### PR TITLE
feat: add quota analysis with multi-tier support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -232,6 +232,12 @@ enum Commands {
         /// Show recent command history
         #[arg(short = 'H', long)]
         history: bool,
+        /// Show monthly quota savings estimate
+        #[arg(short, long)]
+        quota: bool,
+        /// Subscription tier for quota calculation: pro, 5x, 20x
+        #[arg(short, long, default_value = "20x", requires = "quota")]
+        tier: String,
     },
 
     /// Show or create configuration file
@@ -519,8 +525,8 @@ fn main() -> Result<()> {
             }
         }
 
-        Commands::Gain { graph, history } => {
-            gain::run(graph, history, cli.verbose)?;
+        Commands::Gain { graph, history, quota, tier } => {
+            gain::run(graph, history, quota, &tier, cli.verbose)?;
         }
 
         Commands::Config { create } => {


### PR DESCRIPTION
## Summary

Adds `--quota` flag to `rtk gain` command to display estimated monthly quota savings across different Claude subscription tiers (Pro, Max 5x, Max 20x).

This helps users understand the real-world impact of RTK's token optimizations in terms of their subscription usage.

## Changes

- Add `--quota` flag to `rtk gain` command
- Add `--tier <pro|5x|20x>` parameter for subscription tier selection (default: 20x)
- Implement heuristic quota calculation based on ~44K tokens/5h Pro baseline
- Display subscription tier, estimated monthly quota, and % preserved

## Example Output

```bash
$ rtk gain --quota --tier 20x

Monthly Quota Analysis:
────────────────────────────────────────
Subscription tier:        Max 20x ($200/mo)
Estimated monthly quota:  120.0M
Tokens saved (lifetime):  356.7K
Quota preserved:          0.3%

Note: Heuristic estimate based on ~44K tokens/5h (Pro baseline)
      Actual limits use rolling 5-hour windows, not monthly caps.
```

## Quota Estimates

| Tier | Estimated Monthly Quota | Price |
|------|-------------------------|-------|
| Pro | 6.0M tokens | $20/mo |
| Max 5x | 30.0M tokens | $100/mo |
| Max 20x | 120.0M tokens | $200/mo |

**Note**: These are heuristic estimates for user guidance. Claude uses rolling 5-hour usage windows, not fixed monthly token quotas. Estimates based on Pro baseline of ~44K tokens/5h.

## Test Plan

- [x] Build succeeds without warnings
- [x] `rtk gain --quota` uses default tier (20x)
- [x] `rtk gain --quota --tier pro` shows Pro calculations
- [x] `rtk gain --quota --tier 5x` shows 5x calculations  
- [x] Compatible with existing `--graph` and `--history` flags

## Dependencies

None. Uses existing `tracking::Tracker` infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)