### PR TITLE
ci: automate 'latest' tag update on releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,6 +180,32 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  update-latest-tag:
+    name: Update 'latest' tag
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Update latest tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -fa latest -m "Latest stable release (${{ steps.version.outputs.version }})"
+          git push origin latest --force
+
   # TODO: Enable when HOMEBREW_TAP_TOKEN is configured
   # homebrew:
   #   name: Update Homebrew Tap


### PR DESCRIPTION
## Summary
Automates the `latest` tag update after each successful release, eliminating manual tag management.

## Changes
- Added `update-latest-tag` job to `.github/workflows/release.yml`
- Job runs after successful release completion
- Automatically updates `latest` tag to point to new semver tag
- Uses force push to move tag reference

## Benefits
- Install scripts can reliably use `/releases/latest/download/` URLs
- No manual intervention needed for tag updates
- Consistent "current stable" reference across platforms
- Tag annotation includes version info for traceability

## Testing
- Workflow will trigger on next semver tag push (e.g., `v0.3.2`)
- `latest` tag will automatically point to new release

🤖 Generated with Claude Code