### PR TITLE
fix: release pipeline trigger and version-agnostic package URLs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:
@@ -150,12 +149,8 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "version=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-          else
-            # Extract version from Cargo.toml for push to master
-            VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
-            echo "version=v${VERSION}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "release" ]; then
+            echo "version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Flatten artifacts
@@ -163,12 +158,32 @@ jobs:
           mkdir -p release
           find artifacts -type f \( -name "*.tar.gz" -o -name "*.zip" -o -name "*.deb" -o -name "*.rpm" \) -exec cp {} release/ \;
 
+      - name: Create version-agnostic package names
+        run: |
+          cd release
+          for f in *.deb; do
+            [ -f "$f" ] && cp "$f" "rtk_amd64.deb"
+          done
+          for f in *.rpm; do
+            [ -f "$f" ] && cp "$f" "rtk.x86_64.rpm"
+          done
+
       - name: Create checksums
         run: |
           cd release
           sha256sum * > checksums.txt
 
+      - name: Upload Release Assets
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.version }}
+          files: release/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create Release
+        if: github.event_name == 'workflow_dispatch'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ cargo install rtk
 
 ### Debian/Ubuntu
 ```bash
-curl -LO https://github.com/pszymkowiak/rtk/releases/latest/download/rtk_0.3.1-1_amd64.deb
-sudo dpkg -i rtk_0.3.1-1_amd64.deb
+curl -LO https://github.com/pszymkowiak/rtk/releases/latest/download/rtk_amd64.deb
+sudo dpkg -i rtk_amd64.deb
 ```
 
 ### Fedora/RHEL
 ```bash
-curl -LO https://github.com/pszymkowiak/rtk/releases/latest/download/rtk-0.3.1-1.x86_64.rpm
-sudo rpm -i rtk-0.3.1-1.x86_64.rpm
+curl -LO https://github.com/pszymkowiak/rtk/releases/latest/download/rtk.x86_64.rpm
+sudo rpm -i rtk.x86_64.rpm
 ```
 
 ### Manual Download


### PR DESCRIPTION
## Problem

Patrick reported 2 critical issues post-merge PR #23:

1. **v0.5.1 released without binaries**: `release.yml` never triggers because release-please creates tags via GitHub API (no `push` event generated)
2. **Installation URLs 404**: README hardcodes version `0.3.1` in DEB/RPM filenames → `/releases/latest/download/` serves different filenames

## Root Cause Analysis

**Pipeline trigger issue:**
- release-please creates GitHub Releases via API (triggers `release.published` event)
- `release.yml` only listens to `on: push: tags: ['v*']` (doesn't fire for API-created tags)
- Standard pattern with release-please: use `on: release: types: [published]`

**URL issue:**
- DEB/RPM packages include version in filename: `rtk_0.5.0-1_amd64.deb`
- README hardcoded `0.3.1` → breaks on every new release

## Solution

### 1. Fix release.yml trigger
- ✅ Add `on: release: types: [published]` (standard release-please pattern)
- ✅ Remove `on: push: tags: ['v*']` (dead code with release-please)
- ✅ Update version extraction to handle `release` event (`github.event.release.tag_name`)
- ✅ Split release job:
  - Upload assets when triggered by release event (release exists)
  - Create release when triggered by workflow_dispatch (manual)

### 2. Version-agnostic package naming
- ✅ Add workflow step to create version-agnostic copies:
  - `rtk_0.5.0-1_amd64.deb` → `rtk_amd64.deb`
  - `rtk-0.5.0-1.x86_64.rpm` → `rtk.x86_64.rpm`
- ✅ Update README URLs to use stable names

## Impact

- ✅ Future releases auto-trigger binary builds (no manual intervention)
- ✅ Installation URLs work for all releases forever
- ✅ YAML syntax validated

## Test Plan

- [ ] Merge this PR
- [ ] Manually trigger workflow_dispatch for v0.5.1 (to fix missing binaries)
- [ ] Verify binaries upload to v0.5.1 release
- [ ] OR create v0.5.2 with trivial fix → verify auto-trigger works

## Event Flow (After Merge)

```
release-please creates release v0.5.x
  ↓
GitHub fires `release.published` event
  ↓
release.yml triggers automatically
  ↓
Binaries built and uploaded to existing release
  ↓
/releases/latest/download/rtk_amd64.deb works ✓
```

## Files Changed

- `.github/workflows/release.yml`: Fix trigger + add version-agnostic naming
- `README.md`: Update DEB/RPM URLs to use stable filenames

🤖 Generated with [Claude Code](https://claude.com/claude-code)