### PR TITLE
fix: convert rtk ls from reimplementation to native proxy

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -66,20 +66,11 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// List directory contents in ultra-dense, token-optimized format
+    /// List directory contents with token-optimized output (proxy to native ls)
     Ls {
-        /// Directory path
-        #[arg(default_value = ".")]
-        path: PathBuf,
-        /// Max depth
-        #[arg(short, long, default_value = "1")]
-        depth: usize,
-        /// Show hidden files
-        #[arg(short = 'a', long)]
-        all: bool,
-        /// Output format: tree, flat, json
-        #[arg(short, long, default_value = "flat")]
-        format: ls::OutputFormat,
+        /// Arguments passed to ls (supports all native ls flags like -l, -a, -h, -R)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
     },
 
     /// Read file with intelligent filtering
@@ -644,13 +635,8 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Ls {
-            path,
-            depth,
-            all,
-            format,
-        } => {
-            ls::run(&path, depth, all, format, cli.verbose)?;
+        Commands::Ls { args } => {
+            ls::run(&args, cli.verbose)?;
         }
 
         Commands::Read {


### PR DESCRIPTION
## Summary

- Converts `rtk ls` from a WalkBuilder reimplementation to a native `ls` proxy
- Now supports all native ls flags: `-l`, `-a`, `-h`, `-R`, etc.
- Default behavior: `-la` when no args provided
- Token optimization: filters "total X" line from output

## Problem

`rtk ls -al` failed because `-l` was not a recognized flag. The previous implementation reimplemented directory traversal instead of proxying to native ls, which is inconsistent with rtk's philosophy (proxy and filter, don't reimplement).

## Breaking Changes

Removes the following flags:
- `--depth` / `-d`
- `--format` (tree/flat/json)
- `--all` / `-a` (replaced by native `-a`)

These are replaced by native ls flags.

## Test Plan

- [x] `rtk ls -la` works
- [x] `rtk ls -alh` works
- [x] `rtk ls` defaults to `-la`
- [x] `rtk ls -R src/` works (recursive)
- [x] "total X" line is filtered
- [x] Exit code preserved on error
- [x] Unit tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)