### PR TITLE
fix: trigger release build after release-please creates tag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,9 +22,19 @@ jobs:
           release-type: rust
           package-name: rtk
 
+  build-release:
+    name: Build and upload release assets
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}
+    permissions:
+      contents: write
+
   update-latest-tag:
     name: Update 'latest' tag
-    needs: release-please
+    needs: [release-please, build-release]
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Tag to release'
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       tag:
@@ -149,6 +155,8 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "version=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "workflow_call" ]; then
+            echo "version=${{ inputs.tag }}" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" = "release" ]; then
             echo "version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
           fi
@@ -174,7 +182,7 @@ jobs:
           sha256sum * > checksums.txt
 
       - name: Upload Release Assets
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || github.event_name == 'workflow_call'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary

Fixes #27

Tags created by `GITHUB_TOKEN` don't trigger other workflows. This PR makes `release-please.yml` call `release.yml` directly via `workflow_call` after creating a release.

## Changes

### `release.yml`
- Add `workflow_call` trigger with `tag` input
- Handle `workflow_call` in version detection logic
- Upload assets for both `release` and `workflow_call` events

### `release-please.yml`
- Add `build-release` job that calls `release.yml` with the tag
- `update-latest-tag` now waits for build to complete before updating

## Why this approach?

| Approach | Pros | Cons |
|----------|------|------|
| PAT token | Simple | Requires secret management, security risk |
| **workflow_call** ✅ | No secrets, clean, maintainable | Minor changes to both files |
| Merge workflows | Single file | Complex, harder to maintain |

## Flow after this PR

```
push to master
  → release-please creates tag + GitHub Release
  → build-release job calls release.yml
  → binaries built and uploaded to release
  → update-latest-tag updates the 'latest' tag
```

## Test Plan

- [ ] Merge a release PR
- [ ] Verify `release.yml` is triggered via `workflow_call`
- [ ] Verify binaries are uploaded to the GitHub Release
- [ ] Verify `latest` tag is updated after build completes

🤖 Generated with [Claude Code](https://claude.ai/code)