### PR TITLE
Fix install script URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If already installed and `rtk gain` works, **DO NOT reinstall**. Skip to Quick S
 ### Quick Install (Linux/macOS)
 
 ```bash
-curl -fsSL https://github.com/rtk-ai/rtk/blob/master/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
 ```
 
 After installation, **verify you have the correct rtk**:

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # rtk installer - https://github.com/pszymkowiak/rtk
-# Usage: curl -fsSL https://raw.githubusercontent.com/pszymkowiak/rtk/main/install.sh | sh
+# Usage: curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
 
 set -e
 


### PR DESCRIPTION
Fixes the install command to use raw.githubusercontent.com in README and install.sh header.