### PR TITLE
fix(tsc): show every TypeScript error instead of collapsing by code

### DIFF
--- a/src/tsc_cmd.rs
+++ b/src/tsc_cmd.rs
@@ -54,7 +54,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<()> {
     std::process::exit(output.status.code().unwrap_or(1));
 }
 
-/// Filter TypeScript compiler output - group errors by file and error code
+/// Filter TypeScript compiler output - group errors by file, show every error
 fn filter_tsc_output(output: &str) -> String {
     lazy_static::lazy_static! {
         // Pattern: src/file.ts(12,5): error TS2322: Type 'string' is not assignable to type 'number'.
@@ -63,52 +63,64 @@ fn filter_tsc_output(output: &str) -> String {
         ).unwrap();
     }
 
-    #[derive(Debug)]
     struct TsError {
         file: String,
         line: usize,
-        col: usize,
-        _severity: String,
         code: String,
         message: String,
+        context_lines: Vec<String>,
     }
 
     let mut errors: Vec<TsError> = Vec::new();
-    let mut other_lines: Vec<String> = Vec::new();
+    let lines: Vec<&str> = output.lines().collect();
+    let mut i = 0;
 
-    for line in output.lines() {
+    while i < lines.len() {
+        let line = lines[i];
         if let Some(caps) = TSC_ERROR.captures(line) {
-            errors.push(TsError {
+            let mut err = TsError {
                 file: caps[1].to_string(),
                 line: caps[2].parse().unwrap_or(0),
-                col: caps[3].parse().unwrap_or(0),
-                _severity: caps[4].to_string(),
                 code: caps[5].to_string(),
                 message: caps[6].to_string(),
-            });
-        } else if !line.trim().is_empty() {
-            // Keep summary lines and other important info
-            if line.contains("error") || line.contains("warning") || line.contains("Found") {
-                other_lines.push(line.to_string());
+                context_lines: Vec::new(),
+            };
+
+            // Capture continuation lines (indented context from tsc)
+            i += 1;
+            while i < lines.len() {
+                let next = lines[i];
+                if !next.is_empty()
+                    && (next.starts_with("  ") || next.starts_with('\t'))
+                    && !TSC_ERROR.is_match(next)
+                {
+                    err.context_lines.push(next.trim().to_string());
+                    i += 1;
+                } else {
+                    break;
+                }
             }
+
+            errors.push(err);
+        } else {
+            i += 1;
         }
     }
 
     if errors.is_empty() {
-        // No TypeScript errors found
         if output.contains("Found 0 errors") {
             return "✓ TypeScript: No errors found".to_string();
         }
         return "TypeScript compilation completed".to_string();
     }
 
-    // Group errors by file
+    // Group by file
     let mut by_file: HashMap<String, Vec<&TsError>> = HashMap::new();
     for err in &errors {
         by_file.entry(err.file.clone()).or_default().push(err);
     }
 
-    // Group all errors by error code for global summary
+    // Count by error code for summary
     let mut by_code: HashMap<String, usize> = HashMap::new();
     for err in &errors {
         *by_code.entry(err.code.clone()).or_insert(0) += 1;
@@ -122,67 +134,39 @@ fn filter_tsc_output(output: &str) -> String {
     ));
     result.push_str("═══════════════════════════════════════\n");
 
-    // Show top error codes
+    // Top error codes summary (compact, one line)
     let mut code_counts: Vec<_> = by_code.iter().collect();
     code_counts.sort_by(|a, b| b.1.cmp(a.1));
 
     if code_counts.len() > 1 {
-        result.push_str("Top error codes:\n");
-        for (code, count) in code_counts.iter().take(5) {
-            result.push_str(&format!("  {} ({}x)\n", code, count));
-        }
-        result.push('\n');
+        let codes_str: Vec<String> = code_counts
+            .iter()
+            .take(5)
+            .map(|(code, count)| format!("{} ({}x)", code, count))
+            .collect();
+        result.push_str(&format!("Top codes: {}\n\n", codes_str.join(", ")));
     }
 
-    // Show errors grouped by file (limit to top 10 files by error count)
+    // Files sorted by error count (most errors first)
     let mut files_sorted: Vec<_> = by_file.iter().collect();
     files_sorted.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
 
-    for (file, file_errors) in files_sorted.iter().take(10) {
+    // Show every error per file — no limits
+    for (file, file_errors) in &files_sorted {
         result.push_str(&format!("{} ({} errors)\n", file, file_errors.len()));
 
-        // Group errors in this file by error code
-        let mut file_by_code: HashMap<String, Vec<&TsError>> = HashMap::new();
         for err in *file_errors {
-            file_by_code.entry(err.code.clone()).or_default().push(err);
-        }
-
-        // Show grouped by error code
-        let mut file_codes: Vec<_> = file_by_code.iter().collect();
-        file_codes.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
-
-        for (code, code_errors) in file_codes.iter().take(3) {
-            if code_errors.len() == 1 {
-                let err = code_errors[0];
-                result.push_str(&format!(
-                    "  {} ({}:{}): {}\n",
-                    err.code,
-                    err.line,
-                    err.col,
-                    truncate(&err.message, 60)
-                ));
-            } else {
-                result.push_str(&format!(
-                    "  {} ({}x): {}\n",
-                    code,
-                    code_errors.len(),
-                    truncate(&code_errors[0].message, 60)
-                ));
+            result.push_str(&format!(
+                "  L{}: {} {}\n",
+                err.line,
+                err.code,
+                truncate(&err.message, 120)
+            ));
+            for ctx in &err.context_lines {
+                result.push_str(&format!("    {}\n", truncate(ctx, 120)));
             }
         }
-
-        if file_errors.len() > 3 {
-            result.push_str(&format!("  ... +{} more errors\n", file_errors.len() - 3));
-        }
-
         result.push('\n');
-    }
-
-    if by_file.len() > 10 {
-        result.push_str(&format!(
-            "... ({} more files with errors)\n",
-            by_file.len() - 10
-        ));
     }
 
     result.trim().to_string()
@@ -208,6 +192,57 @@ Found 4 errors in 2 files.
         assert!(result.contains("Button.tsx (2 errors)"));
         assert!(result.contains("TS2322"));
         assert!(!result.contains("Found 4 errors")); // Summary line should be replaced
+    }
+
+    #[test]
+    fn test_every_error_message_shown() {
+        let output = "\
+src/api.ts(10,5): error TS2322: Type 'string' is not assignable to type 'number'.
+src/api.ts(20,5): error TS2322: Type 'boolean' is not assignable to type 'string'.
+src/api.ts(30,5): error TS2322: Type 'null' is not assignable to type 'object'.
+";
+        let result = filter_tsc_output(output);
+        // Each error message must be individually visible, not collapsed
+        assert!(result.contains("Type 'string' is not assignable to type 'number'"));
+        assert!(result.contains("Type 'boolean' is not assignable to type 'string'"));
+        assert!(result.contains("Type 'null' is not assignable to type 'object'"));
+        assert!(result.contains("L10:"));
+        assert!(result.contains("L20:"));
+        assert!(result.contains("L30:"));
+    }
+
+    #[test]
+    fn test_continuation_lines_preserved() {
+        let output = "\
+src/app.tsx(10,3): error TS2322: Type '{ children: Element; }' is not assignable to type 'Props'.
+  Property 'children' does not exist on type 'Props'.
+src/app.tsx(20,5): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
+";
+        let result = filter_tsc_output(output);
+        assert!(result.contains("Property 'children' does not exist on type 'Props'"));
+        assert!(result.contains("L10:"));
+        assert!(result.contains("L20:"));
+    }
+
+    #[test]
+    fn test_no_file_limit() {
+        // 15 files with errors — all must appear
+        let mut output = String::new();
+        for i in 1..=15 {
+            output.push_str(&format!(
+                "src/file{}.ts({},1): error TS2322: Error in file {}.\n",
+                i, i, i
+            ));
+        }
+        let result = filter_tsc_output(&output);
+        assert!(result.contains("15 errors in 15 files"));
+        for i in 1..=15 {
+            assert!(
+                result.contains(&format!("file{}.ts", i)),
+                "file{}.ts missing from output",
+                i
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `rtk tsc` grouped errors by error code within files, hiding individual error messages (e.g. 5 TS2322 errors → only first message shown)
- Users had to bypass rtk entirely to see actual TypeScript errors — defeating the tool's purpose
- Now shows every error individually with line number, code, and full message
- Captures tsc continuation/context lines that were previously dropped
- Increases message truncation from 60 → 120 chars
- Removes artificial limits (was: 3 error codes per file, 10 files max)

**Before:**
```
src/api.ts (3 errors)
  TS2322 (3x): Type 'string' is not assignable to typ...
```

**After:**
```
src/api.ts (3 errors)
  L10: TS2322 Type 'string' is not assignable to type 'number'.
  L20: TS2322 Type 'boolean' is not assignable to type 'string'.
  L30: TS2322 Type 'null' is not assignable to type 'object'.
```

## Test plan

- [x] Existing tests pass (5/5)
- [x] New test: every error message shown individually (no collapsing)
- [x] New test: continuation lines preserved
- [x] New test: no file limit (15 files all visible)
- [x] Zero clippy warnings on tsc_cmd
- [ ] Manual: run `rtk tsc` on a project with TypeScript errors and verify all errors visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)