### PR TITLE
fix(git): accept native git flags in add command (including -A)

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -9,7 +9,7 @@ pub enum GitCommand {
     Log,
     Status,
     Show,
-    Add { files: Vec<String> },
+    Add,
     Commit { message: String },
     Push,
     Pull,
@@ -25,7 +25,7 @@ pub fn run(cmd: GitCommand, args: &[String], max_lines: Option<usize>, verbose: 
         GitCommand::Log => run_log(args, max_lines, verbose),
         GitCommand::Status => run_status(args, verbose),
         GitCommand::Show => run_show(args, max_lines, verbose),
-        GitCommand::Add { files } => run_add(&files, verbose),
+        GitCommand::Add => run_add(args, verbose),
         GitCommand::Commit { message } => run_commit(&message, verbose),
         GitCommand::Push => run_push(args, verbose),
         GitCommand::Pull => run_pull(args, verbose),
@@ -578,17 +578,18 @@ fn run_status(args: &[String], verbose: u8) -> Result<()> {
     Ok(())
 }
 
-fn run_add(files: &[String], verbose: u8) -> Result<()> {
+fn run_add(args: &[String], verbose: u8) -> Result<()> {
     let timer = tracking::TimedExecution::start();
 
     let mut cmd = Command::new("git");
     cmd.arg("add");
 
-    if files.is_empty() {
+    // Pass all arguments directly to git (flags like -A, -p, --all, etc.)
+    if args.is_empty() {
         cmd.arg(".");
     } else {
-        for f in files {
-            cmd.arg(f);
+        for arg in args {
+            cmd.arg(arg);
         }
     }
 
@@ -627,8 +628,8 @@ fn run_add(files: &[String], verbose: u8) -> Result<()> {
         println!("{}", compact);
 
         timer.track(
-            &format!("git add {}", files.join(" ")),
-            &format!("rtk git add {}", files.join(" ")),
+            &format!("git add {}", args.join(" ")),
+            &format!("rtk git add {}", args.join(" ")),
             &raw_output,
             &compact,
         );
@@ -642,6 +643,8 @@ fn run_add(files: &[String], verbose: u8) -> Result<()> {
         if !stdout.trim().is_empty() {
             eprintln!("{}", stdout);
         }
+        // Propagate git's exit code
+        std::process::exit(output.status.code().unwrap_or(1));
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -478,9 +478,9 @@ enum GitCommands {
     },
     /// Add files → "ok ✓"
     Add {
-        /// Files to add
-        #[arg(trailing_var_arg = true)]
-        files: Vec<String>,
+        /// Files and flags to add (supports all git add flags like -A, -p, --all, etc)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
     },
     /// Commit → "ok ✓ \<hash\>"
     Commit {
@@ -733,8 +733,8 @@ fn main() -> Result<()> {
             GitCommands::Show { args } => {
                 git::run(git::GitCommand::Show, &args, None, cli.verbose)?;
             }
-            GitCommands::Add { files } => {
-                git::run(git::GitCommand::Add { files }, &[], None, cli.verbose)?;
+            GitCommands::Add { args } => {
+                git::run(git::GitCommand::Add, &args, None, cli.verbose)?;
             }
             GitCommands::Commit { message } => {
                 git::run(git::GitCommand::Commit { message }, &[], None, cli.verbose)?;


### PR DESCRIPTION
## Problem
- `rtk git add -A` failed with "unexpected argument '-A' found"
- Git flags like `-A`, `-p`, `--all` were rejected by Clap parser
- Only filenames could be passed to `git add`

## Solution
- Add `allow_hyphen_values = true` to Add command args (following PR #5 pattern)
- Change Add enum variant from `Add { files }` to `Add` (unified with other git commands)
- Modify `run_add()` to accept args slice and pass all arguments to git
- Add exit code propagation for consistency with other git commands

## Impact
- ✅ All native git add flags now work: `-A`, `-p`, `--all`, `--update`, etc.
- ✅ Maintains RTK compact output format ("ok ✓ 2 files changed, ...")
- ✅ Preserves backward compatibility (no args defaults to ".")

## Testing
- Manual: `rtk git add -A` works correctly
- All existing tests pass (154 passed)
- Smoke tests unchanged (git add not included in test-all.sh)

## Files Changed
- `src/main.rs`: Updated Add command to accept hyphen values
- `src/git.rs`: Simplified Add enum and updated run_add() to handle all args

🤖 Generated with [Claude Code](https://claude.com/claude-code)