### PR TITLE
Fix discover cargo check + wire RtkStatus + enhance init

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,13 +24,18 @@ If `rtk gain` fails, you have the wrong package installed.
 
 ## Development Commands
 
+> **Note**: If rtk is installed, prefer `rtk <cmd>` over raw commands for token-optimized output.
+> All commands work with passthrough support even for subcommands rtk doesn't specifically handle.
+
 ### Build & Run
 ```bash
 # Development build
-cargo build
+cargo build                   # raw
+rtk cargo build               # preferred (token-optimized)
 
 # Release build (optimized)
 cargo build --release
+rtk cargo build --release
 
 # Run directly
 cargo run -- <command>
@@ -42,31 +47,38 @@ cargo install --path .
 ### Testing
 ```bash
 # Run all tests
-cargo test
+cargo test                    # raw
+rtk cargo test                # preferred (token-optimized)
 
 # Run specific test
 cargo test <test_name>
+rtk cargo test <test_name>
 
 # Run tests with output
 cargo test -- --nocapture
+rtk cargo test -- --nocapture
 
 # Run tests in specific module
 cargo test <module_name>::
+rtk cargo test <module_name>::
 ```
 
 ### Linting & Quality
 ```bash
 # Check without building
-cargo check
+cargo check                   # raw
+rtk cargo check               # preferred (token-optimized)
 
 # Format code
-cargo fmt
+cargo fmt                     # passthrough (0% savings, but works)
 
 # Run clippy lints
-cargo clippy
+cargo clippy                  # raw
+rtk cargo clippy              # preferred (token-optimized)
 
 # Check all targets
 cargo clippy --all-targets
+rtk cargo clippy --all-targets
 ```
 
 ### Package Building
@@ -241,7 +253,7 @@ All code follows Red-Green-Refactor. See `.claude/skills/rtk-tdd/` for the full 
 
 ### Pre-commit gate
 ```bash
-cargo fmt --all --check && cargo clippy --all-targets && cargo test
+cargo fmt --all --check && rtk cargo clippy --all-targets && rtk cargo test
 ```
 
 ### Test commands

--- a/src/discover/report.rs
+++ b/src/discover/report.rs
@@ -174,6 +174,12 @@ fn truncate_str(s: &str, max: usize) -> String {
     if s.len() <= max {
         s.to_string()
     } else {
-        format!("{}..", &s[..max.saturating_sub(2)])
+        // UTF-8 safe truncation: collect chars up to max-2, then add ".."
+        let truncated: String = s
+            .char_indices()
+            .take_while(|(i, _)| *i < max.saturating_sub(2))
+            .map(|(_, c)| c)
+            .collect();
+        format!("{}..", truncated)
     }
 }


### PR DESCRIPTION
## Summary

Fixes 3 root causes of RTK adoption issues identified by `rtk discover`:

1. **Discover registry bugs**: `cargo check` missing, `cargo fmt` false positive, `RtkStatus::Passthrough` unwired
2. **Project docs teach raw commands**: CLAUDE.md had no RTK examples
3. **rtk init incomplete**: Old French template missing 17+ commands

**Note**: This PR includes commit `60d2d25` (P0 crashes fix) as a prerequisite.

## Changes

### Discover Registry Fixes
- ✅ Add `cargo check` to pattern (80% savings)
- ✅ Wire `RtkStatus::Passthrough` for `cargo fmt` (0% savings, passthrough mode)
- ✅ Add `status` field to `Classification::Supported` 
- ✅ Fix UTF-8 panic in `truncate_str()` (multi-byte chars)
- ✅ Add coupling tests: prevent PATTERNS/RULES/Commands drift

### Documentation Improvements  
- ✅ CLAUDE.md: dual format (raw + RTK) for all dev commands
- ✅ CLAUDE.md: pre-commit uses RTK (`rtk cargo clippy/test`)
- ✅ ~/.claude/CLAUDE.md: add Cargo section

### RTK Init Rewrite
- ✅ English template with 32+ commands (was 15 in French)
- ✅ Organized by workflow (Build, Test, Git, GitHub, JS/TS, Files, Infra, Network, Meta)
- ✅ Version marker `<!-- rtk-instructions v2 -->` for idempotency
- ✅ Fix idempotency detection (marker vs French text)

## Test Plan

- [x] **229 unit tests pass** (7 new tests added)
- [x] **88 smoke tests pass** (`scripts/test-all.sh`)
- [x] **Clippy clean** 
- [x] **Fmt clean**

## Impact

### Before
- `cargo check` → Unsupported (missed 466 opportunities)
- `cargo fmt` → False positive (0% savings reported as supported)
- `rtk init` → French template, incomplete (15 cmds)

### After  
- `cargo check` → Supported, 80% savings
- `cargo fmt` → Passthrough, 0% savings (correct status)
- `rtk init` → English template, complete (32+ cmds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)