### PR TITLE
fix(ci): fix release artifacts not uploading (#73)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,6 +31,7 @@ jobs:
       tag: ${{ needs.release-please.outputs.tag_name }}
     permissions:
       contents: write
+    secrets: inherit
 
   update-latest-tag:
     name: Update 'latest' tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Release
 
 on:
-  release:
-    types: [published]
   workflow_call:
     inputs:
       tag:
@@ -153,13 +151,11 @@ jobs:
       - name: Get version
         id: version
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" = "workflow_call" ]; then
-            echo "version=${{ inputs.tag }}" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" = "release" ]; then
-            echo "version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          TAG="${{ inputs.tag }}"
+          if [ -z "$TAG" ]; then
+            TAG="${{ github.event.release.tag_name }}"
           fi
+          echo "version=$TAG" >> $GITHUB_OUTPUT
 
       - name: Flatten artifacts
         run: |
@@ -182,23 +178,9 @@ jobs:
           sha256sum * > checksums.txt
 
       - name: Upload Release Assets
-        if: github.event_name == 'release' || github.event_name == 'workflow_call'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.version }}
-          files: release/*
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create Release
-        if: github.event_name == 'workflow_dispatch'
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.version.outputs.version }}
-          name: rtk ${{ steps.version.outputs.version }}
-          draft: false
-          prerelease: false
-          generate_release_notes: true
           files: release/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes #73 — Release workflow runs successfully but uploads **zero artifacts** to GitHub releases. The user had to manually run `workflow_dispatch` to upload assets.

**Root cause:** Three issues in the release pipeline:

1. **Conditional upload steps skipped** — `release.yml` had `if: github.event_name == 'workflow_call'` on upload steps, but `github.event_name` inside a reusable workflow reflects the caller's event (`push`), not `workflow_call`. Both upload steps evaluated to false → skipped.

2. **Missing `secrets: inherit`** — `release-please.yml` didn't pass secrets to the called workflow (present in working rtk-ai/vox pipeline).

3. **Dead trigger** — `on: release: types: [published]` never fires because release-please uses `GITHUB_TOKEN`, and GitHub prevents token-triggered events from triggering other workflows.

**Fix:** Aligned with the working rtk-ai/vox pipeline pattern:
- Removed all `if` conditions on the upload step (always runs)
- Simplified version detection: `inputs.tag` with fallback to `github.event.release.tag_name`
- Removed dead `release: published` trigger
- Added `secrets: inherit` to `release-please.yml`

## Changes
- `.github/workflows/release.yml` — simplified upload logic, removed dead trigger
- `.github/workflows/release-please.yml` — added `secrets: inherit`

## Test plan
- [ ] Merge this PR → release-please creates a new release PR
- [ ] Merge the release PR → verify artifacts appear on the GitHub release
- [ ] Fallback: run `workflow_dispatch` manually to verify it still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)