### PR TITLE
fix: add website URL (rtk-ai.app) across project metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,7 +222,7 @@ jobs:
           cat > rtk.rb << 'FORMULA'
           class Rtk < Formula
             desc "Rust Token Killer - High-performance CLI proxy to minimize LLM token consumption"
-            homepage "https://github.com/rtk-ai/rtk"
+            homepage "https://www.rtk-ai.app"
             version "VERSION_PLACEHOLDER"
             license "MIT"
 
@@ -258,7 +258,7 @@ jobs:
                   # Measure your token savings
                   rtk gain
 
-                Full documentation: https://github.com/rtk-ai/rtk
+                Full documentation: https://www.rtk-ai.app
               EOS
             end
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["Patrick Szymkowiak"]
 description = "Rust Token Killer - High-performance CLI proxy to minimize LLM token consumption"
 license = "MIT"
+homepage = "https://www.rtk-ai.app"
 repository = "https://github.com/rtk-ai/rtk"
 readme = "README.md"
 keywords = ["cli", "llm", "token", "filter", "productivity"]

--- a/Formula/rtk.rb
+++ b/Formula/rtk.rb
@@ -5,7 +5,7 @@
 # To install: brew tap rtk-ai/tap && brew install rtk
 class Rtk < Formula
   desc "High-performance CLI proxy to minimize LLM token consumption"
-  homepage "https://github.com/rtk-ai/rtk"
+  homepage "https://www.rtk-ai.app"
   version "0.1.0"
   license "MIT"
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -317,6 +317,8 @@ cargo install --path . --force
 
 ## Support and Contributing
 
+- **Website**: https://www.rtk-ai.app
+- **Contact**: contact@rtk-ai.app
 - **Troubleshooting**: See [TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) for common issues
 - **GitHub issues**: https://github.com/rtk-ai/rtk/issues
 - **Pull Requests**: https://github.com/rtk-ai/rtk/pulls

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 **High-performance CLI proxy to minimize LLM token consumption.**
 
+[Website](https://www.rtk-ai.app) | [GitHub](https://github.com/rtk-ai/rtk) | [Install](INSTALL.md)
+
 rtk filters and compresses command outputs before they reach your LLM context, saving 60-90% of tokens on common operations.
 
 ## ⚠️ Important: Name Collision Warning
@@ -728,3 +730,9 @@ MIT License - see [LICENSE](LICENSE) for details.
 Contributions welcome! Please open an issue or PR on GitHub.
 
 **For external contributors**: Your PR will undergo automated security review (see [SECURITY.md](SECURITY.md)). This protects RTK's shell execution capabilities against injection attacks and supply chain vulnerabilities.
+
+## Contact
+
+- Website: https://www.rtk-ai.app
+- Email: contact@rtk-ai.app
+- Issues: https://github.com/rtk-ai/rtk/issues


### PR DESCRIPTION
## Summary

Adds the website URL https://www.rtk-ai.app across project metadata. Also serves as a test for the new Homebrew auto-update pipeline (#80).

**Changes:**
- `Cargo.toml`: added `homepage` field
- `README.md`: added website / github / install quick links
- `Formula/rtk.rb`: homepage now points to website instead of GitHub repo
- `release.yml`: updated homepage and docs link in Homebrew formula template

## Test plan
- [ ] Merge → release-please creates release PR
- [ ] Merge release PR → pipeline runs with homebrew auto-update
- [ ] Verify `brew info rtk-ai/tap/rtk` shows new version with rtk-ai.app homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)