### PR TITLE
fix(hook): use POSIX character classes for portable grep matching

### DIFF
--- a/hooks/rtk-rewrite.sh
+++ b/hooks/rtk-rewrite.sh
@@ -34,105 +34,105 @@ esac
 REWRITTEN=""
 
 # --- Git commands ---
-if echo "$FIRST_CMD" | grep -qE '^git\s+status(\s|$)'; then
+if echo "$FIRST_CMD" | grep -qE '^git[[:space:]]+status([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^git status/rtk git status/')
-elif echo "$FIRST_CMD" | grep -qE '^git\s+diff(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^git[[:space:]]+diff([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^git diff/rtk git diff/')
-elif echo "$FIRST_CMD" | grep -qE '^git\s+log(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^git[[:space:]]+log([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^git log/rtk git log/')
-elif echo "$FIRST_CMD" | grep -qE '^git\s+add(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^git[[:space:]]+add([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^git add/rtk git add/')
-elif echo "$FIRST_CMD" | grep -qE '^git\s+commit(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^git[[:space:]]+commit([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^git commit/rtk git commit/')
-elif echo "$FIRST_CMD" | grep -qE '^git\s+push(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^git[[:space:]]+push([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^git push/rtk git push/')
-elif echo "$FIRST_CMD" | grep -qE '^git\s+pull(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^git[[:space:]]+pull([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^git pull/rtk git pull/')
-elif echo "$FIRST_CMD" | grep -qE '^git\s+branch(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^git[[:space:]]+branch([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^git branch/rtk git branch/')
-elif echo "$FIRST_CMD" | grep -qE '^git\s+fetch(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^git[[:space:]]+fetch([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^git fetch/rtk git fetch/')
-elif echo "$FIRST_CMD" | grep -qE '^git\s+stash(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^git[[:space:]]+stash([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^git stash/rtk git stash/')
-elif echo "$FIRST_CMD" | grep -qE '^git\s+show(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^git[[:space:]]+show([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^git show/rtk git show/')
 
 # --- GitHub CLI ---
-elif echo "$FIRST_CMD" | grep -qE '^gh\s+(pr|issue|run)(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^gh[[:space:]]+(pr|issue|run)([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^gh /rtk gh /')
 
 # --- Cargo ---
-elif echo "$FIRST_CMD" | grep -qE '^cargo\s+test(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^cargo[[:space:]]+test([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^cargo test/rtk cargo test/')
-elif echo "$FIRST_CMD" | grep -qE '^cargo\s+build(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^cargo[[:space:]]+build([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^cargo build/rtk cargo build/')
-elif echo "$FIRST_CMD" | grep -qE '^cargo\s+clippy(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^cargo[[:space:]]+clippy([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^cargo clippy/rtk cargo clippy/')
 
 # --- File operations ---
-elif echo "$FIRST_CMD" | grep -qE '^cat\s+'; then
+elif echo "$FIRST_CMD" | grep -qE '^cat[[:space:]]+'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^cat /rtk read /')
-elif echo "$FIRST_CMD" | grep -qE '^(rg|grep)\s+'; then
+elif echo "$FIRST_CMD" | grep -qE '^(rg|grep)[[:space:]]+'; then
   REWRITTEN=$(echo "$CMD" | sed -E 's/^(rg|grep) /rtk grep /')
-elif echo "$FIRST_CMD" | grep -qE '^ls(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^ls([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^ls/rtk ls/')
 
 # --- JS/TS tooling ---
-elif echo "$FIRST_CMD" | grep -qE '^(pnpm\s+)?vitest(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^(pnpm[[:space:]]+)?vitest([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed -E 's/^(pnpm )?vitest/rtk vitest run/')
-elif echo "$FIRST_CMD" | grep -qE '^pnpm\s+test(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^pnpm[[:space:]]+test([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^pnpm test/rtk vitest run/')
-elif echo "$FIRST_CMD" | grep -qE '^pnpm\s+tsc(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^pnpm[[:space:]]+tsc([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^pnpm tsc/rtk tsc/')
-elif echo "$FIRST_CMD" | grep -qE '^(npx\s+)?tsc(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^(npx[[:space:]]+)?tsc([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed -E 's/^(npx )?tsc/rtk tsc/')
-elif echo "$FIRST_CMD" | grep -qE '^pnpm\s+lint(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^pnpm[[:space:]]+lint([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^pnpm lint/rtk lint/')
-elif echo "$FIRST_CMD" | grep -qE '^(npx\s+)?eslint(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^(npx[[:space:]]+)?eslint([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed -E 's/^(npx )?eslint/rtk lint/')
-elif echo "$FIRST_CMD" | grep -qE '^(npx\s+)?prettier(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^(npx[[:space:]]+)?prettier([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed -E 's/^(npx )?prettier/rtk prettier/')
-elif echo "$FIRST_CMD" | grep -qE '^(npx\s+)?playwright(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^(npx[[:space:]]+)?playwright([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed -E 's/^(npx )?playwright/rtk playwright/')
-elif echo "$FIRST_CMD" | grep -qE '^pnpm\s+playwright(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^pnpm[[:space:]]+playwright([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^pnpm playwright/rtk playwright/')
-elif echo "$FIRST_CMD" | grep -qE '^(npx\s+)?prisma(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^(npx[[:space:]]+)?prisma([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed -E 's/^(npx )?prisma/rtk prisma/')
 
 # --- Containers ---
-elif echo "$FIRST_CMD" | grep -qE '^docker\s+(ps|images|logs)(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^docker[[:space:]]+(ps|images|logs)([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^docker /rtk docker /')
-elif echo "$FIRST_CMD" | grep -qE '^kubectl\s+(get|logs)(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^kubectl[[:space:]]+(get|logs)([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^kubectl /rtk kubectl /')
 
 # --- Network ---
-elif echo "$FIRST_CMD" | grep -qE '^curl\s+'; then
+elif echo "$FIRST_CMD" | grep -qE '^curl[[:space:]]+'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^curl /rtk curl /')
 
 # --- pnpm package management ---
-elif echo "$FIRST_CMD" | grep -qE '^pnpm\s+(list|ls|outdated)(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^pnpm[[:space:]]+(list|ls|outdated)([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^pnpm /rtk pnpm /')
 
 # --- Python tooling ---
-elif echo "$FIRST_CMD" | grep -qE '^pytest(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^pytest([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^pytest/rtk pytest/')
-elif echo "$FIRST_CMD" | grep -qE '^python\s+-m\s+pytest(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^python[[:space:]]+-m[[:space:]]+pytest([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^python -m pytest/rtk pytest/')
-elif echo "$FIRST_CMD" | grep -qE '^ruff\s+(check|format)(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^ruff[[:space:]]+(check|format)([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^ruff /rtk ruff /')
-elif echo "$FIRST_CMD" | grep -qE '^pip\s+(list|outdated|install|show)(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^pip[[:space:]]+(list|outdated|install|show)([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^pip /rtk pip /')
-elif echo "$FIRST_CMD" | grep -qE '^uv\s+pip\s+(list|outdated|install|show)(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^uv[[:space:]]+pip[[:space:]]+(list|outdated|install|show)([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^uv pip /rtk pip /')
 
 # --- Go tooling ---
-elif echo "$FIRST_CMD" | grep -qE '^go\s+test(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^go[[:space:]]+test([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^go test/rtk go test/')
-elif echo "$FIRST_CMD" | grep -qE '^go\s+build(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^go[[:space:]]+build([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^go build/rtk go build/')
-elif echo "$FIRST_CMD" | grep -qE '^go\s+vet(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^go[[:space:]]+vet([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^go vet/rtk go vet/')
-elif echo "$FIRST_CMD" | grep -qE '^golangci-lint(\s|$)'; then
+elif echo "$FIRST_CMD" | grep -qE '^golangci-lint([[:space:]]|$)'; then
   REWRITTEN=$(echo "$CMD" | sed 's/^golangci-lint/rtk golangci-lint/')
 fi
 


### PR DESCRIPTION
## Summary
- Replace `\s` with `[[:space:]]` in all 41 `grep -E` patterns in `rtk-rewrite.sh`
- `\s` is a PCRE extension not guaranteed by POSIX ERE, causing intermittent match failures on macOS depending on grep version and locale settings
- This fixes commands like `pytest`, `cargo test`, `git status` etc. silently passing through without rewrite on affected systems

## Test plan
- [x] 47 test cases covering all rewrite rules (git, cargo, docker, kubectl, gh, cat, ls, pytest, ruff, pip, go, vitest, pnpm, etc.)
- [x] Verified no-match cases still correctly pass through
- [x] Verified `rtk`-prefixed commands still skip rewrite
- [x] Tested in isolation on the original hook structure (no other changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)