### PR TITLE
fix: install to ~/.local/bin instead of /usr/local/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ If already installed and `rtk gain` works, **DO NOT reinstall**. Skip to Quick S
 curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
 ```
 
+> **Note**: rtk installs to `~/.local/bin` by default. If this directory is not in your PATH, add it:
+> ```bash
+> echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc  # or ~/.zshrc
+> ```
+
 After installation, **verify you have the correct rtk**:
 ```bash
 rtk gain  # Must show token savings stats (not "command not found")

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ set -e
 
 REPO="rtk-ai/rtk"
 BINARY_NAME="rtk"
-INSTALL_DIR="/usr/local/bin"
+INSTALL_DIR="${RTK_INSTALL_DIR:-$HOME/.local/bin}"
 
 # Colors
 RED='\033[0;31m'
@@ -83,13 +83,8 @@ install() {
     info "Extracting..."
     tar -xzf "$ARCHIVE" -C "$TEMP_DIR"
 
-    # Check if we need sudo
-    if [ -w "$INSTALL_DIR" ]; then
-        mv "${TEMP_DIR}/${BINARY_NAME}" "${INSTALL_DIR}/"
-    else
-        info "Requesting sudo to install to $INSTALL_DIR"
-        sudo mv "${TEMP_DIR}/${BINARY_NAME}" "${INSTALL_DIR}/"
-    fi
+    mkdir -p "$INSTALL_DIR"
+    mv "${TEMP_DIR}/${BINARY_NAME}" "${INSTALL_DIR}/"
 
     chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
 
@@ -104,7 +99,8 @@ verify() {
     if command -v "$BINARY_NAME" >/dev/null 2>&1; then
         info "Verification: $($BINARY_NAME --version)"
     else
-        warn "Binary installed but not in PATH. Add $INSTALL_DIR to your PATH."
+        warn "Binary installed but not in PATH. Add to your shell profile:"
+        warn "  export PATH=\"\$HOME/.local/bin:\$PATH\""
     fi
 }
 


### PR DESCRIPTION
## Summary
- Install to `$HOME/.local/bin` instead of `/usr/local/bin`, removing the need for `sudo` (closes #155)
- Support `RTK_INSTALL_DIR` env var for custom install path
- Add PATH guidance in `verify()` and README for users where `~/.local/bin` isn't in PATH

## Test plan
- [ ] Run `curl ... | sh` on a fresh machine — installs without sudo
- [ ] Verify `RTK_INSTALL_DIR=/custom/path curl ... | sh` respects override
- [ ] Verify PATH warning appears when `~/.local/bin` is not in PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)