### PR TITLE
fix: git branch creation silently swallowed by list mode

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -874,15 +874,31 @@ fn run_branch(args: &[String], verbose: u8) -> Result<()> {
         eprintln!("git branch");
     }
 
-    let mut cmd = Command::new("git");
-    cmd.arg("branch");
-
-    // If user passes flags like -d, -D, -m, pass through directly
+    // Detect write operations: delete, rename, copy
     let has_action_flag = args
         .iter()
         .any(|a| a == "-d" || a == "-D" || a == "-m" || a == "-M" || a == "-c" || a == "-C");
 
-    if has_action_flag {
+    // Detect list-mode flags
+    let has_list_flag = args.iter().any(|a| {
+        a == "-a"
+            || a == "--all"
+            || a == "-r"
+            || a == "--remotes"
+            || a == "--list"
+            || a == "--merged"
+            || a == "--no-merged"
+            || a == "--contains"
+            || a == "--no-contains"
+    });
+
+    // Detect positional arguments (not flags) — indicates branch creation
+    let has_positional_arg = args.iter().any(|a| !a.starts_with('-'));
+
+    // Write operation: action flags, or positional args without list flags (= branch creation)
+    if has_action_flag || (has_positional_arg && !has_list_flag) {
+        let mut cmd = Command::new("git");
+        cmd.arg("branch");
         for arg in args {
             cmd.arg(arg);
         }
@@ -907,19 +923,25 @@ fn run_branch(args: &[String], verbose: u8) -> Result<()> {
         if output.status.success() {
             println!("ok ✓");
         } else {
-            eprintln!("FAILED: git branch");
+            eprintln!("FAILED: git branch {}", args.join(" "));
             if !stderr.trim().is_empty() {
                 eprintln!("{}", stderr);
             }
             if !stdout.trim().is_empty() {
                 eprintln!("{}", stdout);
             }
+            std::process::exit(output.status.code().unwrap_or(1));
         }
         return Ok(());
     }
 
     // List mode: show compact branch list
-    cmd.arg("-a").arg("--no-color");
+    let mut cmd = Command::new("git");
+    cmd.arg("branch");
+    if !has_list_flag {
+        cmd.arg("-a");
+    }
+    cmd.arg("--no-color");
     for arg in args {
         cmd.arg(arg);
     }
@@ -1520,5 +1542,49 @@ no changes added to commit (use "git add" and/or "git commit -a")
         let porcelain = "## main\nA  🎉-party.txt\n M 日本語ファイル.rs\n";
         let result = format_status_output(porcelain);
         assert!(result.contains("📌 main"));
+    }
+
+    /// Regression test: `git branch <name>` must create, not list.
+    /// Before fix, positional args fell into list mode which added `-a`,
+    /// turning creation into a pattern-filtered listing (silent no-op).
+    #[test]
+    #[ignore] // Integration test: requires git repo
+    fn test_branch_creation_not_swallowed() {
+        let branch = "test-rtk-create-branch-regression";
+        // Create branch via run_branch
+        run_branch(&[branch.to_string()], 0).expect("run_branch should succeed");
+        // Verify it exists
+        let output = Command::new("git")
+            .args(["branch", "--list", branch])
+            .output()
+            .expect("git branch --list should work");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains(branch),
+            "Branch '{}' was not created. run_branch silently swallowed the creation.",
+            branch
+        );
+        // Cleanup
+        let _ = Command::new("git").args(["branch", "-d", branch]).output();
+    }
+
+    /// Regression test: `git branch <name> <commit>` must create from commit.
+    #[test]
+    #[ignore] // Integration test: requires git repo
+    fn test_branch_creation_from_commit() {
+        let branch = "test-rtk-create-from-commit";
+        run_branch(&[branch.to_string(), "HEAD".to_string()], 0)
+            .expect("run_branch with start-point should succeed");
+        let output = Command::new("git")
+            .args(["branch", "--list", branch])
+            .output()
+            .expect("git branch --list should work");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains(branch),
+            "Branch '{}' was not created from commit.",
+            branch
+        );
+        let _ = Command::new("git").args(["branch", "-d", branch]).output();
     }
 }


### PR DESCRIPTION
## Summary

- **Bug**: `rtk git branch <name>` silently succeeded but never created the branch. The command fell into the listing code path which injected `-a --no-color`, turning creation into a pattern-filtered listing (empty output, exit 0).
- **Fix**: Detect positional args (branch names) without list-mode flags and route to direct passthrough, so `git branch <name>` and `git branch <name> <start-point>` work correctly.
- **Scope**: Only `src/git.rs` — the `run_branch()` function logic and two new regression integration tests.

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo test --all` — 378 tests pass
- [x] Integration tests (`--ignored`): `test_branch_creation_not_swallowed` and `test_branch_creation_from_commit` both pass
- [x] Manual verification: `rtk git branch test-branch` creates the branch, `git branch --list test-branch` confirms it exists
- [x] Manual verification: duplicate branch creation properly fails with exit 128
- [x] Listing mode (`rtk git branch`, `rtk git branch -a`) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)