### PR TITLE
fix: propagate linter exit code in rtk lint

### DIFF
--- a/src/lint_cmd.rs
+++ b/src/lint_cmd.rs
@@ -190,6 +190,10 @@ pub fn run(args: &[String], verbose: u8) -> Result<()> {
         &filtered,
     );
 
+    if !output.status.success() {
+        std::process::exit(output.status.code().unwrap_or(1));
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- `rtk lint` was always returning exit code 0 regardless of the underlying linter's exit status
- Now propagates the linter's actual exit code using `!output.status.success()` pattern
- Handles both non-zero exit codes (ESLint 1/2, ruff, pylint, mypy) and signal termination (SIGINT/SIGTERM)

## Root Cause

The `run()` function in `lint_cmd.rs` captured the exit code for tee output but never used it to set the process exit status — it always returned `Ok(())` (exit 0).

## Fix

Added 3 lines after tracking, matching the exact pattern used by every other RTK module (git, cargo, playwright, vitest, etc.):

```rust
if !output.status.success() {
    std::process::exit(output.status.code().unwrap_or(1));
}
```

## Why `!status.success()` instead of `exit_code != 0`

Per Rust stdlib docs, `ExitStatus::code()` returns `None` when a process is terminated by signal. `!success()` correctly detects failure in all cases (non-zero exit AND signal termination), while `!= 0` depends on the `unwrap_or` fallback value.

## Test plan

- [x] All 7 existing lint_cmd tests pass (`cargo test lint_cmd`)
- [ ] Manual test: `rtk lint npx eslint <file> --max-warnings=0` returns non-zero exit code
- [ ] Verify: `rtk lint npx eslint <clean-file>` still returns exit code 0

Fixes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)