### PR TITLE
fix: propagate rg exit code in rtk grep for CLI parity

### DIFF
--- a/src/grep_cmd.rs
+++ b/src/grep_cmd.rs
@@ -44,10 +44,18 @@ pub fn run(
         .context("grep/rg failed")?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
+    let exit_code = output.status.code().unwrap_or(1);
 
     let raw_output = stdout.to_string();
 
     if stdout.trim().is_empty() {
+        // Show stderr for errors (bad regex, missing file, etc.)
+        if exit_code == 2 {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if !stderr.trim().is_empty() {
+                eprintln!("{}", stderr.trim());
+            }
+        }
         let msg = format!("🔍 0 for '{}'", pattern);
         println!("{}", msg);
         timer.track(
@@ -56,6 +64,9 @@ pub fn run(
             &raw_output,
             &msg,
         );
+        if exit_code != 0 {
+            std::process::exit(exit_code);
+        }
         return Ok(());
     }
 
@@ -120,6 +131,10 @@ pub fn run(
         &raw_output,
         &rtk_output,
     );
+
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- `rtk grep` returned exit 0 for all failure modes where `rg` returns non-zero
- Now propagates exit codes: 1 (no match), 2 (error — bad regex, missing file)
- Surfaces `rg` stderr on error so users see why it failed

## Before / After

| Scenario | Before | After | `rg` native |
|----------|--------|-------|-------------|
| No match | exit 0 | exit 1 | exit 1 |
| Bad regex (`[`) | exit 0 | exit 2 | exit 2 |
| Missing file | exit 0 | exit 2 | exit 2 |
| Match found | exit 0 | exit 0 | exit 0 |

## Test plan

- [x] `rtk grep "zzz" file` → exit 1 (no match)
- [x] `rtk grep "[" file` → exit 2 + stderr error message
- [x] `rtk grep "alpha" /nonexistent` → exit 2 + stderr error message
- [x] `rtk grep "alpha" file` → exit 0 (match found, unchanged)
- [x] `cargo test grep_cmd` — 8 tests pass
- [x] `cargo test --all` — 412 pass, 0 fail

Fixes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)