### PR TITLE
feat(pnpm): add `rtk pnpm [run] <script>` with smart filter routing

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -228,12 +228,8 @@ fn ensure_hook_installed(hook_path: &Path, verbose: u8) -> Result<bool> {
     // Store SHA-256 hash for runtime integrity verification.
     // Always store (idempotent) to ensure baseline exists even for
     // hooks installed before integrity checks were added.
-    integrity::store_hash(hook_path).with_context(|| {
-        format!(
-            "Failed to store integrity hash for {}",
-            hook_path.display()
-        )
-    })?;
+    integrity::store_hash(hook_path)
+        .with_context(|| format!("Failed to store integrity hash for {}", hook_path.display()))?;
     if verbose > 0 && changed {
         eprintln!("Stored integrity hash for hook");
     }
@@ -1061,7 +1057,8 @@ pub fn show_config() -> Result<()> {
         Ok(integrity::IntegrityStatus::NoBaseline) => {
             println!("⚠️  Integrity: no baseline hash (run: rtk init -g to establish)");
         }
-        Ok(integrity::IntegrityStatus::NotInstalled) | Ok(integrity::IntegrityStatus::OrphanedHash) => {
+        Ok(integrity::IntegrityStatus::NotInstalled)
+        | Ok(integrity::IntegrityStatus::OrphanedHash) => {
             // Don't show integrity line if hook isn't installed
         }
         Err(_) => {

--- a/src/integrity.rs
+++ b/src/integrity.rs
@@ -164,7 +164,10 @@ fn read_stored_hash(path: &Path) -> Result<String> {
     // sha256sum format uses two-space separator: "<hash>  <filename>"
     let parts: Vec<&str> = line.splitn(2, "  ").collect();
     if parts.len() != 2 {
-        anyhow::bail!("Invalid hash format in {} (expected 'hash  filename')", path.display());
+        anyhow::bail!(
+            "Invalid hash format in {} (expected 'hash  filename')",
+            path.display()
+        );
     }
 
     let hash = parts[0];
@@ -250,8 +253,14 @@ pub fn runtime_check() -> Result<()> {
         }
         IntegrityStatus::Tampered { expected, actual } => {
             eprintln!("rtk: hook integrity check FAILED");
-            eprintln!("  Expected hash: {}...", expected.get(..16).unwrap_or(&expected));
-            eprintln!("  Actual hash:   {}...", actual.get(..16).unwrap_or(&actual));
+            eprintln!(
+                "  Expected hash: {}...",
+                expected.get(..16).unwrap_or(&expected)
+            );
+            eprintln!(
+                "  Actual hash:   {}...",
+                actual.get(..16).unwrap_or(&actual)
+            );
             eprintln!();
             eprintln!("  The hook at ~/.claude/hooks/rtk-rewrite.sh has been modified.");
             eprintln!("  This may indicate tampering. RTK will not execute.");
@@ -483,7 +492,10 @@ mod tests {
         .unwrap();
 
         let result = verify_hook_at(&hook);
-        assert!(result.is_err(), "Should reject hash-only format (no filename)");
+        assert!(
+            result.is_err(),
+            "Should reject hash-only format (no filename)"
+        );
     }
 
     #[test]

--- a/src/lint_cmd.rs
+++ b/src/lint_cmd.rs
@@ -408,7 +408,7 @@ fn filter_pylint_json(output: &str) -> String {
 }
 
 /// Filter generic linter output (fallback for non-ESLint linters)
-fn filter_generic_lint(output: &str) -> String {
+pub(crate) fn filter_generic_lint(output: &str) -> String {
     let mut warnings = 0;
     let mut errors = 0;
     let mut issues: Vec<String> = Vec::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1218,16 +1218,18 @@ fn main() -> Result<()> {
                 tsc_cmd::run(&args, cli.verbose)?;
             }
             PnpmCommands::Run { script, args } => {
-                pnpm_cmd::run_script(&script, &args, cli.verbose, cli.skip_env)?;
+                let pkg_scripts = pnpm_cmd::PackageScripts::load();
+                pnpm_cmd::run_script(&script, &args, cli.verbose, cli.skip_env, pkg_scripts)?;
             }
             PnpmCommands::Other(args) => {
                 let first = args.first().and_then(|a| a.to_str()).unwrap_or("");
-                if pnpm_cmd::is_pnpm_script(first) {
+                let pkg_scripts = pnpm_cmd::PackageScripts::load();
+                if pnpm_cmd::is_pnpm_script(first, &pkg_scripts) {
                     let str_args: Vec<String> = args[1..]
                         .iter()
                         .filter_map(|a| a.to_str().map(String::from))
                         .collect();
-                    pnpm_cmd::run_script(first, &str_args, cli.verbose, cli.skip_env)?;
+                    pnpm_cmd::run_script(first, &str_args, cli.verbose, cli.skip_env, pkg_scripts)?;
                 } else {
                     pnpm_cmd::run_passthrough(&args, cli.verbose)?;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -726,6 +726,14 @@ enum PnpmCommands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Run a script with smart routing to specialized filters
+    Run {
+        /// Script name (e.g., test, lint, typecheck)
+        script: String,
+        /// Additional script arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
     /// Passthrough: runs any unsupported pnpm subcommand directly
     #[command(external_subcommand)]
     Other(Vec<OsString>),
@@ -1209,8 +1217,20 @@ fn main() -> Result<()> {
             PnpmCommands::Typecheck { args } => {
                 tsc_cmd::run(&args, cli.verbose)?;
             }
+            PnpmCommands::Run { script, args } => {
+                pnpm_cmd::run_script(&script, &args, cli.verbose, cli.skip_env)?;
+            }
             PnpmCommands::Other(args) => {
-                pnpm_cmd::run_passthrough(&args, cli.verbose)?;
+                let first = args.first().and_then(|a| a.to_str()).unwrap_or("");
+                if pnpm_cmd::is_pnpm_script(first) {
+                    let str_args: Vec<String> = args[1..]
+                        .iter()
+                        .filter_map(|a| a.to_str().map(String::from))
+                        .collect();
+                    pnpm_cmd::run_script(first, &str_args, cli.verbose, cli.skip_env)?;
+                } else {
+                    pnpm_cmd::run_passthrough(&args, cli.verbose)?;
+                }
             }
         },
 
@@ -1990,6 +2010,62 @@ mod tests {
                 "Meta-command {:?} should parse successfully",
                 args
             );
+        }
+    }
+
+    #[test]
+    fn test_pnpm_run_basic() {
+        let cli = Cli::try_parse_from(["rtk", "pnpm", "run", "test"]).unwrap();
+        match cli.command {
+            Commands::Pnpm {
+                command: PnpmCommands::Run { script, args },
+            } => {
+                assert_eq!(script, "test");
+                assert!(args.is_empty());
+            }
+            _ => panic!("Expected Pnpm Run command"),
+        }
+    }
+
+    #[test]
+    fn test_pnpm_run_with_args() {
+        let cli =
+            Cli::try_parse_from(["rtk", "pnpm", "run", "vitest", "--reporter=verbose"]).unwrap();
+        match cli.command {
+            Commands::Pnpm {
+                command: PnpmCommands::Run { script, args },
+            } => {
+                assert_eq!(script, "vitest");
+                assert_eq!(args, vec!["--reporter=verbose"]);
+            }
+            _ => panic!("Expected Pnpm Run command"),
+        }
+    }
+
+    #[test]
+    fn test_pnpm_run_colon_script() {
+        let cli = Cli::try_parse_from(["rtk", "pnpm", "run", "test:e2e"]).unwrap();
+        match cli.command {
+            Commands::Pnpm {
+                command: PnpmCommands::Run { script, args },
+            } => {
+                assert_eq!(script, "test:e2e");
+                assert!(args.is_empty());
+            }
+            _ => panic!("Expected Pnpm Run command"),
+        }
+    }
+
+    #[test]
+    fn test_pnpm_shorthand_falls_to_other() {
+        let cli = Cli::try_parse_from(["rtk", "pnpm", "test"]).unwrap();
+        match cli.command {
+            Commands::Pnpm {
+                command: PnpmCommands::Other(args),
+            } => {
+                assert_eq!(args[0], "test");
+            }
+            _ => panic!("Expected Pnpm Other command"),
         }
     }
 }

--- a/src/pnpm_cmd.rs
+++ b/src/pnpm_cmd.rs
@@ -12,7 +12,7 @@ use crate::parser::{
     DependencyState, FormatMode, OutputParser, ParseResult, TokenFormatter,
 };
 
-/// Native pnpm subcommands that must never be intercepted as scripts (BUG-03).
+/// Native pnpm subcommands that must never be intercepted as scripts.
 /// Sorted alphabetically for binary_search lookup.
 /// Excludes: run, test, start -- those are pnpm script shortcuts that go through smart routing.
 const NATIVE_PNPM_COMMANDS: &[&str] = &[
@@ -68,7 +68,7 @@ lazy_static! {
     // Done in 3.4s
     static ref DONE_MSG: Regex = Regex::new(r"^Done in \d").unwrap();
     // ELIFECYCLE  Command failed with exit code 1.
-    // Matches only ELIFECYCLE, preserves ERR_PNPM messages (BUG-04)
+    // Matches only ELIFECYCLE, preserves ERR_PNPM messages
     static ref ELIFECYCLE_ONLY: Regex = Regex::new(r"(?i)ELIFECYCLE").unwrap();
     // Progress: resolved 123, reused 120, downloaded 3
     static ref PROGRESS: Regex = Regex::new(r"^Progress:").unwrap();
@@ -589,7 +589,7 @@ pub(crate) enum FilterRoute {
     Playwright,
 }
 
-/// Cached package.json scripts (read once per invocation, QUAL-02).
+/// Cached package.json scripts (read once per invocation).
 /// Eliminates redundant fs::read_to_string("package.json") calls in
 /// is_pnpm_script and route_script.
 pub struct PackageScripts {
@@ -640,7 +640,7 @@ impl PackageScripts {
 }
 
 /// Strip pnpm-specific boilerplate from script output.
-/// Returns empty string when all lines are boilerplate (BUG-04: caller decides what to show).
+/// Returns empty string when all lines are boilerplate (caller decides what to show).
 pub(crate) fn filter_pnpm_run_output(output: &str) -> String {
     let mut result = Vec::new();
 
@@ -703,7 +703,7 @@ pub(crate) fn route_script(
 
 /// Check if a name is a known pnpm script (static routing or cached package.json)
 pub fn is_pnpm_script(name: &str, pkg_scripts: &Option<PackageScripts>) -> bool {
-    // Native pnpm commands are never scripts (BUG-03)
+    // Native pnpm commands are never scripts
     if NATIVE_PNPM_COMMANDS.binary_search(&name).is_ok() {
         return false;
     }
@@ -713,7 +713,7 @@ pub fn is_pnpm_script(name: &str, pkg_scripts: &Option<PackageScripts>) -> bool 
         return true;
     }
 
-    // Check cached package.json scripts (QUAL-02)
+    // Check cached package.json scripts
     match pkg_scripts {
         Some(ps) => ps.contains(name),
         None => false,
@@ -721,7 +721,7 @@ pub fn is_pnpm_script(name: &str, pkg_scripts: &Option<PackageScripts>) -> bool 
 }
 
 /// Apply a specialized filter to script output.
-/// Returns Result to allow caller fallback on error (replaces catch_unwind, QUAL-01).
+/// Returns Result to allow caller fallback on error (replaces catch_unwind).
 pub(crate) fn apply_filter(route: FilterRoute, output: &str) -> Result<(String, &'static str)> {
     // Empty/whitespace input is an error -- nothing meaningful to filter
     if output.trim().is_empty() {
@@ -777,8 +777,8 @@ pub(crate) fn apply_filter(route: FilterRoute, output: &str) -> Result<(String, 
 }
 
 /// Execute `pnpm run <script>` with smart routing to specialized filters.
-/// Stream-separated: feeds stdout-only to filters (BUG-01, BUG-02).
-/// Shows stderr on failure, "ok +" only on success with empty stdout (BUG-04).
+/// Stream-separated: feeds stdout-only to filters.
+/// Shows stderr on failure, "ok +" only on success with empty stdout.
 pub fn run_script(
     script: &str,
     args: &[String],
@@ -813,7 +813,7 @@ pub fn run_script(
     // For tee recovery: combined output (stdout+stderr)
     let raw_for_tee = format!("{}\n{}", stdout_str, stderr_str);
 
-    // Stage 1: Strip pnpm boilerplate from STDOUT ONLY (BUG-01, BUG-02 fix)
+    // Stage 1: Strip pnpm boilerplate from STDOUT ONLY
     let stripped = filter_pnpm_run_output(&stdout_str);
 
     if !output.status.success() {
@@ -840,7 +840,7 @@ pub fn run_script(
             String::new()
         };
 
-        // Strip pnpm boilerplate from stderr but preserve ERR_PNPM messages (BUG-04)
+        // Strip pnpm boilerplate from stderr but preserve ERR_PNPM messages
         let stderr_display = strip_pnpm_stderr(&stderr_str);
 
         // Show: filtered stdout (if any) then stderr (if any)
@@ -872,7 +872,7 @@ pub fn run_script(
         std::process::exit(exit_code);
     }
 
-    // SUCCESS PATH: "ok +" only when exit 0 AND stripped stdout is empty (BUG-04)
+    // SUCCESS PATH: "ok +" only when exit 0 AND stripped stdout is empty
     if stripped.is_empty() {
         let display = "ok \u{2713}".to_string();
         println!("{}", display);
@@ -1018,7 +1018,7 @@ mod tests {
 
     #[test]
     fn test_filter_pnpm_run_output_empty() {
-        // BUG-04: filter returns empty string for pure boilerplate (caller decides "ok +")
+        // Filter returns empty string for pure boilerplate (caller decides "ok +")
         let input = "> pkg@1.0.0 test\n$ vitest run\n\nDone in 2.1s\n";
         let result = filter_pnpm_run_output(input);
         assert_eq!(result, "");
@@ -1361,7 +1361,7 @@ Done in 1.2s"#;
 
     #[test]
     fn test_ok_checkmark_guard_skips_routing() {
-        // BUG-04: filter returns empty for boilerplate; run_script adds "ok +" on success
+        // Filter returns empty for boilerplate; run_script adds "ok +" on success
         let raw = "> pkg@1.0.0 test\n$ vitest run\n\nDone in 2s\n";
         let stripped = filter_pnpm_run_output(raw);
         assert_eq!(stripped, "");
@@ -1410,7 +1410,7 @@ Done in 1.2s"#;
 
     #[test]
     fn test_native_commands_not_intercepted() {
-        // These are native pnpm commands -- must never be treated as scripts (BUG-03)
+        // These are native pnpm commands -- must never be treated as scripts
         let no_scripts: Option<PackageScripts> = None;
         assert!(!is_pnpm_script("exec", &no_scripts));
         assert!(!is_pnpm_script("dlx", &no_scripts));
@@ -1519,7 +1519,7 @@ Done in 1.2s"#;
 
     #[test]
     fn test_filter_pnpm_run_output_returns_empty_for_boilerplate() {
-        // BUG-04: filter_pnpm_run_output returns empty string, not "ok +"
+        // filter_pnpm_run_output returns empty string, not "ok +"
         let input = "> pkg@1.0.0 build\n$ tsc\n\nDone in 1s\n";
         let result = filter_pnpm_run_output(input);
         assert!(
@@ -1531,7 +1531,7 @@ Done in 1.2s"#;
 
     #[test]
     fn test_failure_empty_stdout_no_ok_checkmark() {
-        // BUG-04: empty stdout + failure should NOT produce "ok +"
+        // Empty stdout + failure should NOT produce "ok +"
         // Simulate the logic flow in run_script (can't call run_script since it calls exit)
         let stdout = "> pkg@1.0.0 test\n$ vitest run\n";
         let stderr = " ERR_PNPM_NO_PKG_MANIFEST  No package.json found";
@@ -1561,7 +1561,7 @@ Done in 1.2s"#;
         // In run_script success path: println!("ok +") -- verified by logic, not process::exit
     }
 
-    // ─── full pipeline token savings tests (QUAL-05) ─────────────────────
+    // ─── full pipeline token savings tests ─────────────────────
 
     fn count_tokens(text: &str) -> usize {
         text.split_whitespace().count()

--- a/src/pnpm_cmd.rs
+++ b/src/pnpm_cmd.rs
@@ -12,6 +12,20 @@ use crate::parser::{
     DependencyState, FormatMode, OutputParser, ParseResult, TokenFormatter,
 };
 
+// pnpm run output boilerplate patterns
+lazy_static! {
+    // > my-project@1.0.0 test /path/to/project
+    static ref LIFECYCLE_HEADER: Regex = Regex::new(r"^>\s+\S+@\S+\s+").unwrap();
+    // $ vitest run --reporter=json
+    static ref SCRIPT_ECHO: Regex = Regex::new(r"^\$\s+").unwrap();
+    // Done in 3.4s
+    static ref DONE_MSG: Regex = Regex::new(r"^Done in \d").unwrap();
+    // ELIFECYCLE  Command failed with exit code 1.
+    static ref ELIFECYCLE: Regex = Regex::new(r"(?i)ELIFECYCLE|ERR_PNPM").unwrap();
+    // Progress: resolved 123, reused 120, downloaded 3
+    static ref PROGRESS: Regex = Regex::new(r"^Progress:").unwrap();
+}
+
 /// pnpm list JSON output structure
 #[derive(Debug, Deserialize)]
 struct PnpmListOutput {
@@ -529,19 +543,6 @@ pub(crate) enum FilterRoute {
 
 /// Strip pnpm-specific boilerplate from script output
 pub(crate) fn filter_pnpm_run_output(output: &str) -> String {
-    lazy_static! {
-        // > my-project@1.0.0 test /path/to/project
-        static ref LIFECYCLE_HEADER: Regex = Regex::new(r"^>\s+\S+@\S+\s+").unwrap();
-        // $ vitest run --reporter=json
-        static ref SCRIPT_ECHO: Regex = Regex::new(r"^\$\s+").unwrap();
-        // Done in 3.4s
-        static ref DONE_MSG: Regex = Regex::new(r"^Done in \d").unwrap();
-        // ELIFECYCLE  Command failed with exit code 1.
-        static ref ELIFECYCLE: Regex = Regex::new(r"(?i)ELIFECYCLE|ERR_PNPM").unwrap();
-        // Progress: resolved 123, reused 120, downloaded 3
-        static ref PROGRESS: Regex = Regex::new(r"^Progress:").unwrap();
-    }
-
     let mut result = Vec::new();
 
     for line in output.lines() {
@@ -668,7 +669,7 @@ pub(crate) fn apply_filter(route: FilterRoute, output: &str) -> (String, &'stati
         FilterRoute::Tsc => crate::tsc_cmd::filter_tsc_output(output),
         FilterRoute::Lint => crate::lint_cmd::filter_generic_lint(output),
         FilterRoute::Prettier => crate::prettier_cmd::filter_prettier_output(output),
-        FilterRoute::TestRunner => crate::runner::extract_test_summary(output, "npm test"),
+        FilterRoute::TestRunner => crate::runner::extract_test_summary(output, "pnpm test"),
     });
 
     let label = match route {

--- a/src/pnpm_cmd.rs
+++ b/src/pnpm_cmd.rs
@@ -697,11 +697,23 @@ pub fn is_pnpm_script(name: &str) -> bool {
     false
 }
 
-/// Apply a specialized filter to script output
-pub(crate) fn apply_filter(route: FilterRoute, output: &str) -> (String, &'static str) {
-    use crate::parser::{OutputParser, TokenFormatter};
+/// Apply a specialized filter to script output.
+/// Returns Result to allow caller fallback on error (replaces catch_unwind, QUAL-01).
+pub(crate) fn apply_filter(route: FilterRoute, output: &str) -> Result<(String, &'static str)> {
+    // Empty/whitespace input is an error -- nothing meaningful to filter
+    if output.trim().is_empty() {
+        let label = match route {
+            FilterRoute::Vitest => "vitest (via pnpm run)",
+            FilterRoute::Playwright => "playwright (via pnpm run)",
+            FilterRoute::Tsc => "tsc (via pnpm run)",
+            FilterRoute::Lint => "lint (via pnpm run)",
+            FilterRoute::Prettier => "prettier (via pnpm run)",
+            FilterRoute::TestRunner => "test (via pnpm run)",
+        };
+        anyhow::bail!("{} filter received empty input", label);
+    }
 
-    let result = std::panic::catch_unwind(|| match route {
+    let filtered = match route {
         FilterRoute::Vitest => {
             let parse_result = crate::vitest_cmd::VitestParser::parse(output);
             match parse_result {
@@ -722,7 +734,7 @@ pub(crate) fn apply_filter(route: FilterRoute, output: &str) -> (String, &'stati
         FilterRoute::Lint => crate::lint_cmd::filter_generic_lint(output),
         FilterRoute::Prettier => crate::prettier_cmd::filter_prettier_output(output),
         FilterRoute::TestRunner => crate::runner::extract_test_summary(output, "pnpm test"),
-    });
+    };
 
     let label = match route {
         FilterRoute::Vitest => "vitest (via pnpm run)",
@@ -733,10 +745,12 @@ pub(crate) fn apply_filter(route: FilterRoute, output: &str) -> (String, &'stati
         FilterRoute::TestRunner => "test (via pnpm run)",
     };
 
-    match result {
-        Ok(filtered) if !filtered.trim().is_empty() => (filtered, label),
-        _ => (output.to_string(), label),
+    // Empty/whitespace filter output treated as error (triggers fallback)
+    if filtered.trim().is_empty() {
+        anyhow::bail!("{} filter returned empty output", label);
     }
+
+    Ok((filtered, label))
 }
 
 /// Execute `pnpm run <script>` with smart routing to specialized filters
@@ -802,13 +816,20 @@ pub fn run_script(script: &str, args: &[String], verbose: u8, skip_env: bool) ->
 
     // Route to specialized filter
     let filtered = match route_script(script) {
-        Some(route) => {
-            let (result, label) = apply_filter(route, &stripped);
-            if verbose > 0 {
-                eprintln!("Routed to: {}", label);
+        Some(route) => match apply_filter(route, &stripped) {
+            Ok((result, label)) => {
+                if verbose > 0 {
+                    eprintln!("Routed to: {}", label);
+                }
+                result
             }
-            result
-        }
+            Err(e) => {
+                if verbose > 0 {
+                    eprintln!("[RTK:FALLBACK] filter error: {}", e);
+                }
+                stripped.clone()
+            }
+        },
         None => stripped.clone(),
     };
 
@@ -1010,37 +1031,37 @@ Done in 5.2s
 
     #[test]
     fn test_apply_filter_tsc_label() {
-        let (_, label) = apply_filter(FilterRoute::Tsc, "some output");
+        let (_, label) = apply_filter(FilterRoute::Tsc, "some output").unwrap();
         assert_eq!(label, "tsc (via pnpm run)");
     }
 
     #[test]
     fn test_apply_filter_vitest_label() {
-        let (_, label) = apply_filter(FilterRoute::Vitest, "some output");
+        let (_, label) = apply_filter(FilterRoute::Vitest, "some output").unwrap();
         assert_eq!(label, "vitest (via pnpm run)");
     }
 
     #[test]
     fn test_apply_filter_lint_label() {
-        let (_, label) = apply_filter(FilterRoute::Lint, "some output");
+        let (_, label) = apply_filter(FilterRoute::Lint, "some output").unwrap();
         assert_eq!(label, "lint (via pnpm run)");
     }
 
     #[test]
     fn test_apply_filter_prettier_label() {
-        let (_, label) = apply_filter(FilterRoute::Prettier, "some output");
+        let (_, label) = apply_filter(FilterRoute::Prettier, "some output").unwrap();
         assert_eq!(label, "prettier (via pnpm run)");
     }
 
     #[test]
     fn test_apply_filter_test_runner_label() {
-        let (_, label) = apply_filter(FilterRoute::TestRunner, "some output");
+        let (_, label) = apply_filter(FilterRoute::TestRunner, "some output").unwrap();
         assert_eq!(label, "test (via pnpm run)");
     }
 
     #[test]
     fn test_apply_filter_playwright_label() {
-        let (_, label) = apply_filter(FilterRoute::Playwright, "some output");
+        let (_, label) = apply_filter(FilterRoute::Playwright, "some output").unwrap();
         assert_eq!(label, "playwright (via pnpm run)");
     }
 
@@ -1061,7 +1082,7 @@ Done in 1.2s"#;
         let route = route_script("lint");
         assert_eq!(route, Some(FilterRoute::Lint));
 
-        let (filtered, label) = apply_filter(route.unwrap(), &stripped);
+        let (filtered, label) = apply_filter(route.unwrap(), &stripped).unwrap();
         assert_eq!(label, "lint (via pnpm run)");
         assert!(!filtered.is_empty());
     }
@@ -1121,6 +1142,20 @@ Done in 1.2s"#;
             &sorted[..],
             "NATIVE_PNPM_COMMANDS must be sorted alphabetically for binary_search"
         );
+    }
+
+    #[test]
+    fn test_apply_filter_empty_output_returns_error() {
+        // Empty output triggers Err (fallback to stripped output in caller)
+        let result = apply_filter(FilterRoute::Tsc, "");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_apply_filter_whitespace_only_returns_error() {
+        // Whitespace-only output triggers Err
+        let result = apply_filter(FilterRoute::Lint, "   \n\n  ");
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/pnpm_cmd.rs
+++ b/src/pnpm_cmd.rs
@@ -12,6 +12,53 @@ use crate::parser::{
     DependencyState, FormatMode, OutputParser, ParseResult, TokenFormatter,
 };
 
+/// Native pnpm subcommands that must never be intercepted as scripts (BUG-03).
+/// Sorted alphabetically for binary_search lookup.
+/// Excludes: run, test, start -- those are pnpm script shortcuts that go through smart routing.
+const NATIVE_PNPM_COMMANDS: &[&str] = &[
+    "add",
+    "audit",
+    "bin",
+    "cache",
+    "cat-file",
+    "cat-index",
+    "completion",
+    "config",
+    "create",
+    "dedupe",
+    "deploy",
+    "dlx",
+    "doctor",
+    "env",
+    "exec",
+    "fetch",
+    "find-hash",
+    "import",
+    "init",
+    "install",
+    "install-test",
+    "licenses",
+    "link",
+    "list",
+    "outdated",
+    "pack",
+    "patch",
+    "patch-commit",
+    "patch-remove",
+    "prune",
+    "publish",
+    "rebuild",
+    "remove",
+    "root",
+    "self-update",
+    "server",
+    "setup",
+    "store",
+    "unlink",
+    "update",
+    "why",
+];
+
 // pnpm run output boilerplate patterns
 lazy_static! {
     // > my-project@1.0.0 test /path/to/project
@@ -631,6 +678,11 @@ pub(crate) fn detect_tool_from_package_json(script: &str) -> Option<FilterRoute>
 
 /// Check if a name is a known pnpm script (static routing or package.json)
 pub fn is_pnpm_script(name: &str) -> bool {
+    // Native pnpm commands are never scripts (BUG-03)
+    if NATIVE_PNPM_COMMANDS.binary_search(&name).is_ok() {
+        return false;
+    }
+
     if route_script(name).is_some() {
         return true;
     }
@@ -1026,8 +1078,8 @@ Done in 1.2s"#;
     // ─── is_pnpm_script tests ────────────────────────────────────────────
 
     #[test]
-    fn test_is_pnpm_script_static() {
-        assert!(is_pnpm_script("test"));
+    fn test_is_pnpm_script_routed_scripts() {
+        // These are script names that go through smart routing (NOT native commands)
         assert!(is_pnpm_script("lint"));
         assert!(is_pnpm_script("vitest"));
     }
@@ -1035,7 +1087,50 @@ Done in 1.2s"#;
     #[test]
     fn test_is_pnpm_script_unknown() {
         // Not a known script name and no package.json in test env
+        assert!(!is_pnpm_script("my-custom-script"));
+    }
+
+    #[test]
+    fn test_native_commands_not_intercepted() {
+        // These are native pnpm commands -- must never be treated as scripts (BUG-03)
+        assert!(!is_pnpm_script("exec"));
+        assert!(!is_pnpm_script("dlx"));
+        assert!(!is_pnpm_script("audit"));
+        assert!(!is_pnpm_script("create"));
+        assert!(!is_pnpm_script("deploy"));
         assert!(!is_pnpm_script("store"));
-        assert!(!is_pnpm_script("prune"));
+        assert!(!is_pnpm_script("server"));
+        assert!(!is_pnpm_script("patch"));
+        assert!(!is_pnpm_script("env"));
+        assert!(!is_pnpm_script("doctor"));
+        assert!(!is_pnpm_script("why"));
+        assert!(!is_pnpm_script("init"));
+        assert!(!is_pnpm_script("config"));
+        assert!(!is_pnpm_script("setup"));
+        assert!(!is_pnpm_script("bin"));
+        assert!(!is_pnpm_script("self-update"));
+    }
+
+    #[test]
+    fn test_native_commands_sorted() {
+        // binary_search requires sorted array
+        let mut sorted = NATIVE_PNPM_COMMANDS.to_vec();
+        sorted.sort();
+        assert_eq!(
+            NATIVE_PNPM_COMMANDS,
+            &sorted[..],
+            "NATIVE_PNPM_COMMANDS must be sorted alphabetically for binary_search"
+        );
+    }
+
+    #[test]
+    fn test_native_denylist_does_not_block_script_shortcuts() {
+        // run, test, start are NOT in denylist -- they are pnpm script shortcuts
+        // "test" routes via route_script -> FilterRoute::TestRunner
+        assert!(is_pnpm_script("test"));
+        // "start" does not match route_script and no package.json in test env
+        assert!(!is_pnpm_script("start"));
+        // "run" does not match route_script and no package.json in test env
+        assert!(!is_pnpm_script("run"));
     }
 }

--- a/src/pnpm_cmd.rs
+++ b/src/pnpm_cmd.rs
@@ -1472,4 +1472,106 @@ Done in 1.2s"#;
         assert!(stripped.is_empty());
         // In run_script success path: println!("ok +") -- verified by logic, not process::exit
     }
+
+    // ─── full pipeline token savings tests (QUAL-05) ─────────────────────
+
+    fn count_tokens(text: &str) -> usize {
+        text.split_whitespace().count()
+    }
+
+    #[test]
+    fn test_full_pipeline_vitest_savings() {
+        // Realistic pnpm stdout containing vitest --reporter=json output
+        // Pipeline: raw pnpm stdout -> filter_pnpm_run_output (strip) -> apply_filter(Vitest)
+        let fixture = r#"> my-app@1.0.0 test /Users/dev/my-app
+$ vitest run --reporter=json
+
+{"numTotalTestSuites":5,"numPassedTestSuites":4,"numFailedTestSuites":1,"numPendingTestSuites":0,"numTotalTests":25,"numPassedTests":23,"numFailedTests":2,"numPendingTests":0,"startTime":1709312400000,"endTime":1709312405200,"testResults":[{"name":"src/utils.test.ts","assertionResults":[{"fullName":"utils > formats date correctly","status":"passed","failureMessages":[]},{"fullName":"utils > validates email format","status":"passed","failureMessages":[]},{"fullName":"utils > truncates long strings","status":"passed","failureMessages":[]},{"fullName":"utils > handles null input","status":"passed","failureMessages":[]}]},{"name":"src/api.test.ts","assertionResults":[{"fullName":"api > GET /users returns list","status":"passed","failureMessages":[]},{"fullName":"api > POST /users creates user","status":"passed","failureMessages":[]},{"fullName":"api > handles auth error","status":"failed","failureMessages":["Error: expected 200 got 500\n    at Object.<anonymous> (src/api.test.ts:15:5)\n    at Promise.then.completed"]},{"fullName":"api > validates request body","status":"passed","failureMessages":[]}]},{"name":"src/hooks.test.ts","assertionResults":[{"fullName":"hooks > useAuth returns user","status":"passed","failureMessages":[]},{"fullName":"hooks > useAuth handles logout","status":"passed","failureMessages":[]},{"fullName":"hooks > useFetch caches results","status":"passed","failureMessages":[]},{"fullName":"hooks > useFetch retries on error","status":"passed","failureMessages":[]},{"fullName":"hooks > useDebounce delays call","status":"passed","failureMessages":[]}]},{"name":"src/components/Button.test.ts","assertionResults":[{"fullName":"Button > renders with text","status":"passed","failureMessages":[]},{"fullName":"Button > handles click","status":"passed","failureMessages":[]},{"fullName":"Button > applies disabled state","status":"passed","failureMessages":[]},{"fullName":"Button > shows loading spinner","status":"passed","failureMessages":[]}]},{"name":"src/store.test.ts","assertionResults":[{"fullName":"store > initializes with defaults","status":"passed","failureMessages":[]},{"fullName":"store > updates state","status":"passed","failureMessages":[]},{"fullName":"store > handles concurrent updates","status":"failed","failureMessages":["Error: Race condition detected\n    at Object.<anonymous> (src/store.test.ts:42:10)"]},{"fullName":"store > persists to localStorage","status":"passed","failureMessages":[]},{"fullName":"store > clears on logout","status":"passed","failureMessages":[]},{"fullName":"store > subscribes to changes","status":"passed","failureMessages":[]}]}]}
+
+Done in 5.2s
+"#;
+
+        // Stage 1: Strip pnpm boilerplate
+        let stripped = filter_pnpm_run_output(fixture);
+        assert!(
+            !stripped.contains("> my-app@"),
+            "Lifecycle header should be stripped"
+        );
+        assert!(
+            !stripped.contains("Done in"),
+            "Done line should be stripped"
+        );
+        assert!(
+            stripped.contains("numTotalTests"),
+            "JSON payload should survive stripping"
+        );
+
+        // Stage 2: Apply vitest specialized filter
+        let (filtered, label) = apply_filter(FilterRoute::Vitest, &stripped).unwrap();
+        assert_eq!(label, "vitest (via pnpm run)");
+        assert!(
+            filtered.contains("PASS"),
+            "Filtered output should contain PASS summary"
+        );
+
+        // Stage 3: Verify token savings >= 60%
+        let input_tokens = count_tokens(fixture);
+        let output_tokens = count_tokens(&filtered);
+        let savings = 100.0 - (output_tokens as f64 / input_tokens as f64 * 100.0);
+        assert!(
+            savings >= 60.0,
+            "Full pipeline vitest savings: expected >= 60%, got {:.1}% (input={}, output={})",
+            savings,
+            input_tokens,
+            output_tokens
+        );
+    }
+
+    #[test]
+    fn test_full_pipeline_playwright_savings() {
+        // Realistic pnpm stdout containing playwright --reporter=json output
+        // Pipeline: raw pnpm stdout -> filter_pnpm_run_output (strip) -> apply_filter(Playwright)
+        let fixture = r#"> my-app@1.0.0 test:e2e /Users/dev/my-app
+$ playwright test --reporter=json
+
+{"config":{"projects":[{"name":"chromium"}]},"suites":[{"title":"login.spec.ts","file":"tests/login.spec.ts","specs":[{"title":"should login with valid credentials","ok":true,"tests":[{"status":"expected","projectName":"chromium","results":[{"status":"passed","duration":1234,"errors":[]}]}]},{"title":"should reject invalid password","ok":true,"tests":[{"status":"expected","projectName":"chromium","results":[{"status":"passed","duration":567,"errors":[]}]}]},{"title":"should show error for locked account","ok":true,"tests":[{"status":"expected","projectName":"chromium","results":[{"status":"passed","duration":890,"errors":[]}]}]},{"title":"should redirect after login","ok":true,"tests":[{"status":"expected","projectName":"chromium","results":[{"status":"passed","duration":456,"errors":[]}]}]}],"suites":[]},{"title":"dashboard.spec.ts","file":"tests/dashboard.spec.ts","specs":[{"title":"shows metrics overview","ok":true,"tests":[{"status":"expected","projectName":"chromium","results":[{"status":"passed","duration":1100,"errors":[]}]}]},{"title":"filters by date range","ok":true,"tests":[{"status":"expected","projectName":"chromium","results":[{"status":"passed","duration":980,"errors":[]}]}]},{"title":"exports CSV report","ok":true,"tests":[{"status":"expected","projectName":"chromium","results":[{"status":"passed","duration":1500,"errors":[]}]}]}],"suites":[]},{"title":"settings.spec.ts","file":"tests/settings.spec.ts","specs":[{"title":"updates profile name","ok":true,"tests":[{"status":"expected","projectName":"chromium","results":[{"status":"passed","duration":670,"errors":[]}]}]},{"title":"changes password","ok":true,"tests":[{"status":"expected","projectName":"chromium","results":[{"status":"passed","duration":890,"errors":[]}]}]},{"title":"toggles dark mode","ok":true,"tests":[{"status":"expected","projectName":"chromium","results":[{"status":"passed","duration":340,"errors":[]}]}]}],"suites":[]}],"stats":{"expected":10,"unexpected":0,"flaky":0,"skipped":0,"duration":8500}}
+
+Done in 12.3s
+"#;
+
+        // Stage 1: Strip pnpm boilerplate
+        let stripped = filter_pnpm_run_output(fixture);
+        assert!(
+            !stripped.contains("> my-app@"),
+            "Lifecycle header should be stripped"
+        );
+        assert!(
+            !stripped.contains("Done in"),
+            "Done line should be stripped"
+        );
+        assert!(
+            stripped.contains("stats"),
+            "JSON payload should survive stripping"
+        );
+
+        // Stage 2: Apply playwright specialized filter
+        let (filtered, label) = apply_filter(FilterRoute::Playwright, &stripped).unwrap();
+        assert_eq!(label, "playwright (via pnpm run)");
+        assert!(
+            filtered.contains("PASS"),
+            "Filtered output should contain PASS summary"
+        );
+
+        // Stage 3: Verify token savings >= 60%
+        let input_tokens = count_tokens(fixture);
+        let output_tokens = count_tokens(&filtered);
+        let savings = 100.0 - (output_tokens as f64 / input_tokens as f64 * 100.0);
+        assert!(
+            savings >= 60.0,
+            "Full pipeline playwright savings: expected >= 60%, got {:.1}% (input={}, output={})",
+            savings,
+            input_tokens,
+            output_tokens
+        );
+    }
 }

--- a/src/pnpm_cmd.rs
+++ b/src/pnpm_cmd.rs
@@ -588,6 +588,56 @@ pub(crate) enum FilterRoute {
     Playwright,
 }
 
+/// Cached package.json scripts (read once per invocation, QUAL-02).
+/// Eliminates redundant fs::read_to_string("package.json") calls in
+/// is_pnpm_script and route_script.
+pub struct PackageScripts {
+    scripts: HashMap<String, String>, // script_name -> command_string
+}
+
+impl PackageScripts {
+    /// Read package.json from CWD, parse scripts field. Returns None if
+    /// file is missing, unparseable, or has no scripts section.
+    pub fn load() -> Option<Self> {
+        let content = std::fs::read_to_string("package.json").ok()?;
+        let json: serde_json::Value = serde_json::from_str(&content).ok()?;
+        let scripts_obj = json.get("scripts")?.as_object()?;
+        let scripts: HashMap<String, String> = scripts_obj
+            .iter()
+            .filter_map(|(k, v)| Some((k.clone(), v.as_str()?.to_string())))
+            .collect();
+        Some(PackageScripts { scripts })
+    }
+
+    /// Check if a script name exists in the cached scripts map.
+    pub fn contains(&self, name: &str) -> bool {
+        self.scripts.contains_key(name)
+    }
+
+    /// Detect the underlying tool from the script command string.
+    /// Replaces the old detect_tool_from_package_json function.
+    pub fn detect_tool(&self, script: &str) -> Option<FilterRoute> {
+        let command = self.scripts.get(script)?;
+        let cmd_lower = command.to_lowercase();
+
+        if cmd_lower.contains("playwright") {
+            Some(FilterRoute::Playwright)
+        } else if cmd_lower.contains("vitest") {
+            Some(FilterRoute::Vitest)
+        } else if cmd_lower.contains("jest") {
+            Some(FilterRoute::TestRunner)
+        } else if cmd_lower.contains("tsc") || cmd_lower.contains("typescript") {
+            Some(FilterRoute::Tsc)
+        } else if cmd_lower.contains("eslint") || cmd_lower.contains("biome") {
+            Some(FilterRoute::Lint)
+        } else if cmd_lower.contains("prettier") {
+            Some(FilterRoute::Prettier)
+        } else {
+            None
+        }
+    }
+}
+
 /// Strip pnpm-specific boilerplate from script output
 pub(crate) fn filter_pnpm_run_output(output: &str) -> String {
     let mut result = Vec::new();
@@ -622,8 +672,11 @@ pub(crate) fn filter_pnpm_run_output(output: &str) -> String {
     }
 }
 
-/// Route a script name to a specialized filter (static rules + package.json detection)
-pub(crate) fn route_script(script: &str) -> Option<FilterRoute> {
+/// Route a script name to a specialized filter (static rules + cached package.json detection)
+pub(crate) fn route_script(
+    script: &str,
+    pkg_scripts: Option<&PackageScripts>,
+) -> Option<FilterRoute> {
     // Tier 1: Static routing (exact match)
     match script {
         "vitest" => return Some(FilterRoute::Vitest),
@@ -647,54 +700,27 @@ pub(crate) fn route_script(script: &str) -> Option<FilterRoute> {
         }
     }
 
-    // Tier 2: Auto-detect from package.json
-    detect_tool_from_package_json(script)
+    // Tier 2: Auto-detect from cached package.json scripts (QUAL-02)
+    pkg_scripts.and_then(|ps| ps.detect_tool(script))
 }
 
-/// Read package.json scripts[name] and detect the underlying tool
-pub(crate) fn detect_tool_from_package_json(script: &str) -> Option<FilterRoute> {
-    let content = std::fs::read_to_string("package.json").ok()?;
-    let json: serde_json::Value = serde_json::from_str(&content).ok()?;
-    let scripts = json.get("scripts")?.as_object()?;
-    let command = scripts.get(script)?.as_str()?;
-    let cmd_lower = command.to_lowercase();
-
-    if cmd_lower.contains("playwright") {
-        Some(FilterRoute::Playwright)
-    } else if cmd_lower.contains("vitest") {
-        Some(FilterRoute::Vitest)
-    } else if cmd_lower.contains("jest") {
-        Some(FilterRoute::TestRunner)
-    } else if cmd_lower.contains("tsc") || cmd_lower.contains("typescript") {
-        Some(FilterRoute::Tsc)
-    } else if cmd_lower.contains("eslint") || cmd_lower.contains("biome") {
-        Some(FilterRoute::Lint)
-    } else if cmd_lower.contains("prettier") {
-        Some(FilterRoute::Prettier)
-    } else {
-        None
-    }
-}
-
-/// Check if a name is a known pnpm script (static routing or package.json)
-pub fn is_pnpm_script(name: &str) -> bool {
+/// Check if a name is a known pnpm script (static routing or cached package.json)
+pub fn is_pnpm_script(name: &str, pkg_scripts: &Option<PackageScripts>) -> bool {
     // Native pnpm commands are never scripts (BUG-03)
     if NATIVE_PNPM_COMMANDS.binary_search(&name).is_ok() {
         return false;
     }
 
-    if route_script(name).is_some() {
+    // Check static routing first (no I/O)
+    if route_script(name, pkg_scripts.as_ref()).is_some() {
         return true;
     }
-    // Check package.json scripts
-    if let Ok(content) = std::fs::read_to_string("package.json") {
-        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
-            if let Some(scripts) = json.get("scripts").and_then(|s| s.as_object()) {
-                return scripts.contains_key(name);
-            }
-        }
+
+    // Check cached package.json scripts (QUAL-02)
+    match pkg_scripts {
+        Some(ps) => ps.contains(name),
+        None => false,
     }
-    false
 }
 
 /// Apply a specialized filter to script output.
@@ -754,7 +780,13 @@ pub(crate) fn apply_filter(route: FilterRoute, output: &str) -> Result<(String, 
 }
 
 /// Execute `pnpm run <script>` with smart routing to specialized filters
-pub fn run_script(script: &str, args: &[String], verbose: u8, skip_env: bool) -> Result<()> {
+pub fn run_script(
+    script: &str,
+    args: &[String],
+    verbose: u8,
+    skip_env: bool,
+    pkg_scripts: Option<PackageScripts>,
+) -> Result<()> {
     let timer = tracking::TimedExecution::start();
 
     let mut cmd = Command::new("pnpm");
@@ -815,7 +847,7 @@ pub fn run_script(script: &str, args: &[String], verbose: u8, skip_env: bool) ->
     }
 
     // Route to specialized filter
-    let filtered = match route_script(script) {
+    let filtered = match route_script(script, pkg_scripts.as_ref()) {
         Some(route) => match apply_filter(route, &stripped) {
             Ok((result, label)) => {
                 if verbose > 0 {
@@ -982,49 +1014,151 @@ Done in 5.2s
 
     #[test]
     fn test_route_script_exact_matches() {
-        assert_eq!(route_script("vitest"), Some(FilterRoute::Vitest));
-        assert_eq!(route_script("tsc"), Some(FilterRoute::Tsc));
-        assert_eq!(route_script("typecheck"), Some(FilterRoute::Tsc));
-        assert_eq!(route_script("lint"), Some(FilterRoute::Lint));
-        assert_eq!(route_script("prettier"), Some(FilterRoute::Prettier));
-        assert_eq!(route_script("format"), Some(FilterRoute::Prettier));
-        assert_eq!(route_script("test"), Some(FilterRoute::TestRunner));
+        // Static routing works with None pkg_scripts
+        assert_eq!(route_script("vitest", None), Some(FilterRoute::Vitest));
+        assert_eq!(route_script("tsc", None), Some(FilterRoute::Tsc));
+        assert_eq!(route_script("typecheck", None), Some(FilterRoute::Tsc));
+        assert_eq!(route_script("lint", None), Some(FilterRoute::Lint));
+        assert_eq!(route_script("prettier", None), Some(FilterRoute::Prettier));
+        assert_eq!(route_script("format", None), Some(FilterRoute::Prettier));
+        assert_eq!(route_script("test", None), Some(FilterRoute::TestRunner));
     }
 
     #[test]
     fn test_route_script_unknown_returns_none() {
-        // These don't match static rules and no package.json in test env
-        assert_eq!(route_script("build"), None);
-        assert_eq!(route_script("dev"), None);
-        assert_eq!(route_script("start"), None);
+        // These don't match static rules and no PackageScripts provided
+        assert_eq!(route_script("build", None), None);
+        assert_eq!(route_script("dev", None), None);
+        assert_eq!(route_script("start", None), None);
     }
 
     #[test]
     fn test_route_script_prefix_matching() {
-        assert_eq!(route_script("test:unit"), Some(FilterRoute::TestRunner));
         assert_eq!(
-            route_script("test:integration"),
+            route_script("test:unit", None),
             Some(FilterRoute::TestRunner)
         );
-        assert_eq!(route_script("lint:check"), Some(FilterRoute::Lint));
-        assert_eq!(route_script("lint:ci"), Some(FilterRoute::Lint));
+        assert_eq!(
+            route_script("test:integration", None),
+            Some(FilterRoute::TestRunner)
+        );
+        assert_eq!(route_script("lint:check", None), Some(FilterRoute::Lint));
+        assert_eq!(route_script("lint:ci", None), Some(FilterRoute::Lint));
     }
 
     #[test]
     fn test_route_script_prefix_exclusions() {
-        // These are deferred to package.json (no package.json in test → None)
-        assert_eq!(route_script("test:e2e"), None);
-        assert_eq!(route_script("test:playwright"), None);
-        assert_eq!(route_script("test:cypress"), None);
-        assert_eq!(route_script("lint:fix"), None);
+        // These are deferred to package.json (no PackageScripts → None)
+        assert_eq!(route_script("test:e2e", None), None);
+        assert_eq!(route_script("test:playwright", None), None);
+        assert_eq!(route_script("test:cypress", None), None);
+        assert_eq!(route_script("lint:fix", None), None);
     }
 
-    // ─── detect_tool_from_package_json tests ─────────────────────────────
+    // ─── PackageScripts tests ───────────────────────────────────────────
 
     #[test]
-    fn test_detect_missing_script_returns_none() {
-        // No package.json in test CWD → None
-        assert_eq!(detect_tool_from_package_json("nonexistent"), None);
+    fn test_package_scripts_load_returns_none_without_package_json() {
+        // Test CWD has no package.json → load() returns None
+        assert!(PackageScripts::load().is_none());
+    }
+
+    #[test]
+    fn test_package_scripts_contains() {
+        let ps = PackageScripts {
+            scripts: HashMap::from([
+                ("test".to_string(), "vitest run".to_string()),
+                ("lint".to_string(), "eslint .".to_string()),
+            ]),
+        };
+        assert!(ps.contains("test"));
+        assert!(ps.contains("lint"));
+        assert!(!ps.contains("build"));
+        assert!(!ps.contains("nonexistent"));
+    }
+
+    #[test]
+    fn test_package_scripts_detect_tool_vitest() {
+        let ps = PackageScripts {
+            scripts: HashMap::from([("test".to_string(), "vitest run".to_string())]),
+        };
+        assert_eq!(ps.detect_tool("test"), Some(FilterRoute::Vitest));
+    }
+
+    #[test]
+    fn test_package_scripts_detect_tool_playwright() {
+        let ps = PackageScripts {
+            scripts: HashMap::from([("test:e2e".to_string(), "playwright test".to_string())]),
+        };
+        assert_eq!(ps.detect_tool("test:e2e"), Some(FilterRoute::Playwright));
+    }
+
+    #[test]
+    fn test_package_scripts_detect_tool_eslint() {
+        let ps = PackageScripts {
+            scripts: HashMap::from([("lint".to_string(), "eslint .".to_string())]),
+        };
+        assert_eq!(ps.detect_tool("lint"), Some(FilterRoute::Lint));
+    }
+
+    #[test]
+    fn test_package_scripts_detect_tool_tsc() {
+        let ps = PackageScripts {
+            scripts: HashMap::from([("typecheck".to_string(), "tsc --noEmit".to_string())]),
+        };
+        assert_eq!(ps.detect_tool("typecheck"), Some(FilterRoute::Tsc));
+    }
+
+    #[test]
+    fn test_package_scripts_detect_tool_prettier() {
+        let ps = PackageScripts {
+            scripts: HashMap::from([("format".to_string(), "prettier --check .".to_string())]),
+        };
+        assert_eq!(ps.detect_tool("format"), Some(FilterRoute::Prettier));
+    }
+
+    #[test]
+    fn test_package_scripts_detect_tool_jest() {
+        let ps = PackageScripts {
+            scripts: HashMap::from([("test".to_string(), "jest --ci".to_string())]),
+        };
+        assert_eq!(ps.detect_tool("test"), Some(FilterRoute::TestRunner));
+    }
+
+    #[test]
+    fn test_package_scripts_detect_tool_biome() {
+        let ps = PackageScripts {
+            scripts: HashMap::from([("lint".to_string(), "biome check .".to_string())]),
+        };
+        assert_eq!(ps.detect_tool("lint"), Some(FilterRoute::Lint));
+    }
+
+    #[test]
+    fn test_package_scripts_detect_tool_unknown() {
+        let ps = PackageScripts {
+            scripts: HashMap::from([("dev".to_string(), "node server.js".to_string())]),
+        };
+        assert_eq!(ps.detect_tool("dev"), None);
+    }
+
+    #[test]
+    fn test_package_scripts_detect_tool_missing_script() {
+        let ps = PackageScripts {
+            scripts: HashMap::from([("test".to_string(), "vitest run".to_string())]),
+        };
+        assert_eq!(ps.detect_tool("nonexistent"), None);
+    }
+
+    #[test]
+    fn test_route_script_with_package_scripts() {
+        // route_script falls through static matching to cached detect_tool
+        let ps = PackageScripts {
+            scripts: HashMap::from([("test:e2e".to_string(), "playwright test".to_string())]),
+        };
+        assert_eq!(
+            route_script("test:e2e", Some(&ps)),
+            Some(FilterRoute::Playwright)
+        );
     }
 
     // ─── apply_filter tests ──────────────────────────────────────────────
@@ -1079,7 +1213,7 @@ Done in 1.2s"#;
         assert!(!stripped.contains("> app@"));
         assert!(!stripped.contains("Done in"));
 
-        let route = route_script("lint");
+        let route = route_script("lint", None);
         assert_eq!(route, Some(FilterRoute::Lint));
 
         let (filtered, label) = apply_filter(route.unwrap(), &stripped).unwrap();
@@ -1101,35 +1235,55 @@ Done in 1.2s"#;
     #[test]
     fn test_is_pnpm_script_routed_scripts() {
         // These are script names that go through smart routing (NOT native commands)
-        assert!(is_pnpm_script("lint"));
-        assert!(is_pnpm_script("vitest"));
+        let no_scripts: Option<PackageScripts> = None;
+        assert!(is_pnpm_script("lint", &no_scripts));
+        assert!(is_pnpm_script("vitest", &no_scripts));
     }
 
     #[test]
     fn test_is_pnpm_script_unknown() {
-        // Not a known script name and no package.json in test env
-        assert!(!is_pnpm_script("my-custom-script"));
+        // Not a known script name and no PackageScripts
+        let no_scripts: Option<PackageScripts> = None;
+        assert!(!is_pnpm_script("my-custom-script", &no_scripts));
+    }
+
+    #[test]
+    fn test_is_pnpm_script_with_cached_scripts() {
+        // Custom script found via cached PackageScripts
+        let ps = Some(PackageScripts {
+            scripts: HashMap::from([("my-custom".to_string(), "node run.js".to_string())]),
+        });
+        assert!(is_pnpm_script("my-custom", &ps));
+    }
+
+    #[test]
+    fn test_is_pnpm_script_none_scripts_falls_back() {
+        // With None pkg_scripts, only static routing works
+        let no_scripts: Option<PackageScripts> = None;
+        assert!(!is_pnpm_script("my-custom-script", &no_scripts));
+        assert!(is_pnpm_script("lint", &no_scripts)); // static route exists
     }
 
     #[test]
     fn test_native_commands_not_intercepted() {
         // These are native pnpm commands -- must never be treated as scripts (BUG-03)
-        assert!(!is_pnpm_script("exec"));
-        assert!(!is_pnpm_script("dlx"));
-        assert!(!is_pnpm_script("audit"));
-        assert!(!is_pnpm_script("create"));
-        assert!(!is_pnpm_script("deploy"));
-        assert!(!is_pnpm_script("store"));
-        assert!(!is_pnpm_script("server"));
-        assert!(!is_pnpm_script("patch"));
-        assert!(!is_pnpm_script("env"));
-        assert!(!is_pnpm_script("doctor"));
-        assert!(!is_pnpm_script("why"));
-        assert!(!is_pnpm_script("init"));
-        assert!(!is_pnpm_script("config"));
-        assert!(!is_pnpm_script("setup"));
-        assert!(!is_pnpm_script("bin"));
-        assert!(!is_pnpm_script("self-update"));
+        let no_scripts: Option<PackageScripts> = None;
+        assert!(!is_pnpm_script("exec", &no_scripts));
+        assert!(!is_pnpm_script("dlx", &no_scripts));
+        assert!(!is_pnpm_script("audit", &no_scripts));
+        assert!(!is_pnpm_script("create", &no_scripts));
+        assert!(!is_pnpm_script("deploy", &no_scripts));
+        assert!(!is_pnpm_script("store", &no_scripts));
+        assert!(!is_pnpm_script("server", &no_scripts));
+        assert!(!is_pnpm_script("patch", &no_scripts));
+        assert!(!is_pnpm_script("env", &no_scripts));
+        assert!(!is_pnpm_script("doctor", &no_scripts));
+        assert!(!is_pnpm_script("why", &no_scripts));
+        assert!(!is_pnpm_script("init", &no_scripts));
+        assert!(!is_pnpm_script("config", &no_scripts));
+        assert!(!is_pnpm_script("setup", &no_scripts));
+        assert!(!is_pnpm_script("bin", &no_scripts));
+        assert!(!is_pnpm_script("self-update", &no_scripts));
     }
 
     #[test]
@@ -1160,12 +1314,13 @@ Done in 1.2s"#;
 
     #[test]
     fn test_native_denylist_does_not_block_script_shortcuts() {
+        let no_scripts: Option<PackageScripts> = None;
         // run, test, start are NOT in denylist -- they are pnpm script shortcuts
         // "test" routes via route_script -> FilterRoute::TestRunner
-        assert!(is_pnpm_script("test"));
-        // "start" does not match route_script and no package.json in test env
-        assert!(!is_pnpm_script("start"));
-        // "run" does not match route_script and no package.json in test env
-        assert!(!is_pnpm_script("run"));
+        assert!(is_pnpm_script("test", &no_scripts));
+        // "start" does not match route_script and no PackageScripts
+        assert!(!is_pnpm_script("start", &no_scripts));
+        // "run" does not match route_script and no PackageScripts
+        assert!(!is_pnpm_script("run", &no_scripts));
     }
 }

--- a/src/pnpm_cmd.rs
+++ b/src/pnpm_cmd.rs
@@ -690,30 +690,15 @@ pub(crate) fn route_script(
     script: &str,
     pkg_scripts: Option<&PackageScripts>,
 ) -> Option<FilterRoute> {
-    // Tier 1: Static routing (exact match)
+    // Tier 1: Unambiguous script names (tool IS the name)
     match script {
         "vitest" => return Some(FilterRoute::Vitest),
-        "typecheck" | "tsc" => return Some(FilterRoute::Tsc),
-        "prettier" | "format" | "format:check" => return Some(FilterRoute::Prettier),
-        "lint" => return Some(FilterRoute::Lint),
-        "test" => return Some(FilterRoute::TestRunner),
+        "tsc" => return Some(FilterRoute::Tsc),
+        "prettier" => return Some(FilterRoute::Prettier),
         _ => {}
     }
 
-    // Tier 1b: Prefix matching
-    if let Some(suffix) = script.strip_prefix("test:") {
-        match suffix {
-            "e2e" | "playwright" | "cypress" => {} // defer to package.json
-            _ => return Some(FilterRoute::TestRunner),
-        }
-    }
-    if let Some(suffix) = script.strip_prefix("lint:") {
-        if suffix != "fix" {
-            return Some(FilterRoute::Lint);
-        }
-    }
-
-    // Tier 2: Auto-detect from cached package.json scripts (QUAL-02)
+    // Tier 2: Auto-detect from package.json scripts
     pkg_scripts.and_then(|ps| ps.detect_tool(script))
 }
 
@@ -1072,14 +1057,100 @@ Done in 5.2s
 
     #[test]
     fn test_route_script_exact_matches() {
-        // Static routing works with None pkg_scripts
+        // Tier 1: Unambiguous static routing works with None pkg_scripts
         assert_eq!(route_script("vitest", None), Some(FilterRoute::Vitest));
         assert_eq!(route_script("tsc", None), Some(FilterRoute::Tsc));
-        assert_eq!(route_script("typecheck", None), Some(FilterRoute::Tsc));
-        assert_eq!(route_script("lint", None), Some(FilterRoute::Lint));
         assert_eq!(route_script("prettier", None), Some(FilterRoute::Prettier));
-        assert_eq!(route_script("format", None), Some(FilterRoute::Prettier));
-        assert_eq!(route_script("test", None), Some(FilterRoute::TestRunner));
+    }
+
+    #[test]
+    fn test_route_script_typecheck_uses_package_json() {
+        let ps = PackageScripts {
+            scripts: HashMap::from([("typecheck".to_string(), "tsc --noEmit".to_string())]),
+        };
+        assert_eq!(route_script("typecheck", Some(&ps)), Some(FilterRoute::Tsc));
+        // Without package.json, "typecheck" is not routed (could be any tool)
+        assert_eq!(route_script("typecheck", None), None);
+    }
+
+    // ─── Tier 2/3 routing: ambiguous names prefer package.json ──────────
+
+    #[test]
+    fn test_route_script_test_prefers_vitest_from_package_json() {
+        let ps = PackageScripts {
+            scripts: HashMap::from([("test".to_string(), "vitest run".to_string())]),
+        };
+        assert_eq!(route_script("test", Some(&ps)), Some(FilterRoute::Vitest));
+    }
+
+    #[test]
+    fn test_route_script_test_prefers_playwright_from_package_json() {
+        let ps = PackageScripts {
+            scripts: HashMap::from([("test".to_string(), "playwright test".to_string())]),
+        };
+        assert_eq!(
+            route_script("test", Some(&ps)),
+            Some(FilterRoute::Playwright)
+        );
+    }
+
+    #[test]
+    fn test_route_script_test_falls_back_to_test_runner_for_jest() {
+        // jest maps to TestRunner in detect_tool, same as Tier 3 fallback
+        let ps = PackageScripts {
+            scripts: HashMap::from([("test".to_string(), "jest --ci".to_string())]),
+        };
+        assert_eq!(
+            route_script("test", Some(&ps)),
+            Some(FilterRoute::TestRunner)
+        );
+    }
+
+    #[test]
+    fn test_route_script_test_falls_back_without_package_scripts() {
+        // No package.json → no routing (pnpm won't work anyway)
+        assert_eq!(route_script("test", None), None);
+    }
+
+    #[test]
+    fn test_route_script_test_falls_back_when_script_not_in_package_json() {
+        // package.json exists but "test" script is not defined → no routing
+        let ps = PackageScripts {
+            scripts: HashMap::from([("build".to_string(), "tsc && next build".to_string())]),
+        };
+        assert_eq!(route_script("test", Some(&ps)), None);
+    }
+
+    #[test]
+    fn test_route_script_lint_prefers_package_json_detection() {
+        let ps = PackageScripts {
+            scripts: HashMap::from([("lint".to_string(), "biome check .".to_string())]),
+        };
+        // biome maps to Lint in detect_tool — same route but via Tier 2
+        assert_eq!(route_script("lint", Some(&ps)), Some(FilterRoute::Lint));
+    }
+
+    #[test]
+    fn test_route_script_lint_falls_back_without_package_scripts() {
+        // No package.json → no routing (pnpm won't work anyway)
+        assert_eq!(route_script("lint", None), None);
+    }
+
+    #[test]
+    fn test_route_script_format_prefers_package_json_detection() {
+        let ps = PackageScripts {
+            scripts: HashMap::from([("format".to_string(), "prettier --write .".to_string())]),
+        };
+        assert_eq!(
+            route_script("format", Some(&ps)),
+            Some(FilterRoute::Prettier)
+        );
+    }
+
+    #[test]
+    fn test_route_script_format_falls_back_without_package_scripts() {
+        // No package.json → no routing (pnpm won't work anyway)
+        assert_eq!(route_script("format", None), None);
     }
 
     #[test]
@@ -1091,26 +1162,25 @@ Done in 5.2s
     }
 
     #[test]
-    fn test_route_script_prefix_matching() {
+    fn test_route_script_prefix_uses_package_json() {
+        // Prefix scripts route through package.json (no static guessing)
+        let ps = PackageScripts {
+            scripts: HashMap::from([
+                ("test:unit".to_string(), "vitest run".to_string()),
+                ("lint:check".to_string(), "eslint .".to_string()),
+            ]),
+        };
         assert_eq!(
-            route_script("test:unit", None),
-            Some(FilterRoute::TestRunner)
+            route_script("test:unit", Some(&ps)),
+            Some(FilterRoute::Vitest)
         );
         assert_eq!(
-            route_script("test:integration", None),
-            Some(FilterRoute::TestRunner)
+            route_script("lint:check", Some(&ps)),
+            Some(FilterRoute::Lint)
         );
-        assert_eq!(route_script("lint:check", None), Some(FilterRoute::Lint));
-        assert_eq!(route_script("lint:ci", None), Some(FilterRoute::Lint));
-    }
-
-    #[test]
-    fn test_route_script_prefix_exclusions() {
-        // These are deferred to package.json (no PackageScripts → None)
-        assert_eq!(route_script("test:e2e", None), None);
-        assert_eq!(route_script("test:playwright", None), None);
-        assert_eq!(route_script("test:cypress", None), None);
-        assert_eq!(route_script("lint:fix", None), None);
+        // Without package.json, prefix scripts return None
+        assert_eq!(route_script("test:unit", None), None);
+        assert_eq!(route_script("lint:check", None), None);
     }
 
     // ─── PackageScripts tests ───────────────────────────────────────────
@@ -1271,7 +1341,10 @@ Done in 1.2s"#;
         assert!(!stripped.contains("> app@"));
         assert!(!stripped.contains("Done in"));
 
-        let route = route_script("lint", None);
+        let ps = PackageScripts {
+            scripts: HashMap::from([("lint".to_string(), "eslint .".to_string())]),
+        };
+        let route = route_script("lint", Some(&ps));
         assert_eq!(route, Some(FilterRoute::Lint));
 
         let (filtered, label) = apply_filter(route.unwrap(), &stripped).unwrap();
@@ -1292,10 +1365,15 @@ Done in 1.2s"#;
 
     #[test]
     fn test_is_pnpm_script_routed_scripts() {
-        // These are script names that go through smart routing (NOT native commands)
+        // Tier 1 names route without package.json
         let no_scripts: Option<PackageScripts> = None;
-        assert!(is_pnpm_script("lint", &no_scripts));
         assert!(is_pnpm_script("vitest", &no_scripts));
+        // Ambiguous names need package.json
+        assert!(!is_pnpm_script("lint", &no_scripts));
+        let with_scripts = Some(PackageScripts {
+            scripts: HashMap::from([("lint".to_string(), "eslint .".to_string())]),
+        });
+        assert!(is_pnpm_script("lint", &with_scripts));
     }
 
     #[test]
@@ -1316,10 +1394,11 @@ Done in 1.2s"#;
 
     #[test]
     fn test_is_pnpm_script_none_scripts_falls_back() {
-        // With None pkg_scripts, only static routing works
+        // With None pkg_scripts, only Tier 1 static routing works
         let no_scripts: Option<PackageScripts> = None;
         assert!(!is_pnpm_script("my-custom-script", &no_scripts));
-        assert!(is_pnpm_script("lint", &no_scripts)); // static route exists
+        assert!(!is_pnpm_script("lint", &no_scripts)); // needs package.json
+        assert!(is_pnpm_script("vitest", &no_scripts)); // Tier 1
     }
 
     #[test]
@@ -1372,14 +1451,16 @@ Done in 1.2s"#;
 
     #[test]
     fn test_native_denylist_does_not_block_script_shortcuts() {
+        // run, test, start are NOT in denylist -- but need package.json for routing
         let no_scripts: Option<PackageScripts> = None;
-        // run, test, start are NOT in denylist -- they are pnpm script shortcuts
-        // "test" routes via route_script -> FilterRoute::TestRunner
-        assert!(is_pnpm_script("test", &no_scripts));
-        // "start" does not match route_script and no PackageScripts
+        assert!(!is_pnpm_script("test", &no_scripts)); // needs package.json
         assert!(!is_pnpm_script("start", &no_scripts));
-        // "run" does not match route_script and no PackageScripts
         assert!(!is_pnpm_script("run", &no_scripts));
+        // With package.json, "test" routes correctly
+        let with_scripts = Some(PackageScripts {
+            scripts: HashMap::from([("test".to_string(), "vitest run".to_string())]),
+        });
+        assert!(is_pnpm_script("test", &with_scripts));
     }
 
     // ─── strip_pnpm_stderr tests ────────────────────────────────────────

--- a/src/pnpm_cmd.rs
+++ b/src/pnpm_cmd.rs
@@ -69,6 +69,8 @@ lazy_static! {
     static ref DONE_MSG: Regex = Regex::new(r"^Done in \d").unwrap();
     // ELIFECYCLE  Command failed with exit code 1.
     static ref ELIFECYCLE: Regex = Regex::new(r"(?i)ELIFECYCLE|ERR_PNPM").unwrap();
+    // For stderr stripping: only match ELIFECYCLE, preserve ERR_PNPM messages (BUG-04)
+    static ref ELIFECYCLE_ONLY: Regex = Regex::new(r"(?i)ELIFECYCLE").unwrap();
     // Progress: resolved 123, reused 120, downloaded 3
     static ref PROGRESS: Regex = Regex::new(r"^Progress:").unwrap();
 }
@@ -638,7 +640,8 @@ impl PackageScripts {
     }
 }
 
-/// Strip pnpm-specific boilerplate from script output
+/// Strip pnpm-specific boilerplate from script output.
+/// Returns empty string when all lines are boilerplate (BUG-04: caller decides what to show).
 pub(crate) fn filter_pnpm_run_output(output: &str) -> String {
     let mut result = Vec::new();
 
@@ -665,11 +668,21 @@ pub(crate) fn filter_pnpm_run_output(output: &str) -> String {
         result.push(line.to_string());
     }
 
-    if result.is_empty() {
-        "ok ✓".to_string()
-    } else {
-        result.join("\n")
-    }
+    result.join("\n")
+}
+
+/// Strip pnpm boilerplate from stderr for failure display.
+/// Removes ELIFECYCLE and Done lines but preserves ERR_PNPM messages
+/// (those are the actual error messages users need to see).
+pub(crate) fn strip_pnpm_stderr(stderr: &str) -> String {
+    stderr
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim();
+            !trimmed.is_empty() && !ELIFECYCLE_ONLY.is_match(trimmed) && !DONE_MSG.is_match(trimmed)
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Route a script name to a specialized filter (static rules + cached package.json detection)
@@ -779,7 +792,9 @@ pub(crate) fn apply_filter(route: FilterRoute, output: &str) -> Result<(String, 
     Ok((filtered, label))
 }
 
-/// Execute `pnpm run <script>` with smart routing to specialized filters
+/// Execute `pnpm run <script>` with smart routing to specialized filters.
+/// Stream-separated: feeds stdout-only to filters (BUG-01, BUG-02).
+/// Shows stderr on failure, "ok +" only on success with empty stdout (BUG-04).
 pub fn run_script(
     script: &str,
     args: &[String],
@@ -807,41 +822,81 @@ pub fn run_script(
     let output = cmd
         .output()
         .context(format!("Failed to run pnpm run {}", script))?;
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    let raw = format!("{}\n{}", stdout, stderr);
+    let stdout_str = String::from_utf8_lossy(&output.stdout);
+    let stderr_str = String::from_utf8_lossy(&output.stderr);
     let exit_code = output.status.code().unwrap_or(1);
 
-    // On failure: show raw output + tee hint, exit
+    // For tee recovery: combined output (stdout+stderr)
+    let raw_for_tee = format!("{}\n{}", stdout_str, stderr_str);
+
+    // Stage 1: Strip pnpm boilerplate from STDOUT ONLY (BUG-01, BUG-02 fix)
+    let stripped = filter_pnpm_run_output(&stdout_str);
+
     if !output.status.success() {
-        let stripped = filter_pnpm_run_output(&raw);
-        if let Some(hint) =
-            crate::tee::tee_and_hint(&raw, &format!("pnpm-run-{}", script), exit_code)
-        {
-            println!("{}\n{}", stripped, hint);
+        // FAILURE PATH: filter stdout through specialized filter, show stderr
+        let filtered = if !stripped.is_empty() {
+            match route_script(script, pkg_scripts.as_ref()) {
+                Some(route) => match apply_filter(route, &stripped) {
+                    Ok((result, label)) => {
+                        if verbose > 0 {
+                            eprintln!("Routed to: {}", label);
+                        }
+                        result
+                    }
+                    Err(e) => {
+                        if verbose > 0 {
+                            eprintln!("[RTK:FALLBACK] filter error: {}", e);
+                        }
+                        stripped.clone()
+                    }
+                },
+                None => stripped.clone(),
+            }
         } else {
-            println!("{}", stripped);
+            String::new()
+        };
+
+        // Strip pnpm boilerplate from stderr but preserve ERR_PNPM messages (BUG-04)
+        let stderr_display = strip_pnpm_stderr(&stderr_str);
+
+        // Show: filtered stdout (if any) then stderr (if any)
+        let display = [filtered.as_str(), stderr_display.as_str()]
+            .iter()
+            .filter(|s| !s.is_empty())
+            .copied()
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        if let Some(hint) =
+            crate::tee::tee_and_hint(&raw_for_tee, &format!("pnpm-run-{}", script), exit_code)
+        {
+            if display.is_empty() {
+                println!("{}", hint);
+            } else {
+                println!("{}\n{}", display, hint);
+            }
+        } else if !display.is_empty() {
+            println!("{}", display);
         }
+
         timer.track(
             &format!("pnpm run {} {}", script, args.join(" ")),
             &format!("rtk pnpm run {} {}", script, args.join(" ")),
-            &raw,
-            &stripped,
+            &raw_for_tee,
+            &display,
         );
         std::process::exit(exit_code);
     }
 
-    // Strip pnpm boilerplate
-    let stripped = filter_pnpm_run_output(&raw);
-
-    // If all output was boilerplate, just show ok
-    if stripped == "ok ✓" {
-        println!("{}", stripped);
+    // SUCCESS PATH: "ok +" only when exit 0 AND stripped stdout is empty (BUG-04)
+    if stripped.is_empty() {
+        let display = "ok \u{2713}".to_string();
+        println!("{}", display);
         timer.track(
             &format!("pnpm run {} {}", script, args.join(" ")),
             &format!("rtk pnpm run {} {}", script, args.join(" ")),
-            &raw,
-            &stripped,
+            &raw_for_tee,
+            &display,
         );
         return Ok(());
     }
@@ -865,7 +920,9 @@ pub fn run_script(
         None => stripped.clone(),
     };
 
-    if let Some(hint) = crate::tee::tee_and_hint(&raw, &format!("pnpm-run-{}", script), exit_code) {
+    if let Some(hint) =
+        crate::tee::tee_and_hint(&raw_for_tee, &format!("pnpm-run-{}", script), exit_code)
+    {
         println!("{}\n{}", filtered, hint);
     } else {
         println!("{}", filtered);
@@ -874,7 +931,7 @@ pub fn run_script(
     timer.track(
         &format!("pnpm run {} {}", script, args.join(" ")),
         &format!("rtk pnpm run {} {}", script, args.join(" ")),
-        &raw,
+        &raw_for_tee,
         &filtered,
     );
 
@@ -977,9 +1034,10 @@ mod tests {
 
     #[test]
     fn test_filter_pnpm_run_output_empty() {
+        // BUG-04: filter returns empty string for pure boilerplate (caller decides "ok +")
         let input = "> pkg@1.0.0 test\n$ vitest run\n\nDone in 2.1s\n";
         let result = filter_pnpm_run_output(input);
-        assert_eq!(result, "ok ✓");
+        assert_eq!(result, "");
     }
 
     #[test]
@@ -1223,11 +1281,11 @@ Done in 1.2s"#;
 
     #[test]
     fn test_ok_checkmark_guard_skips_routing() {
-        // When all output is boilerplate, we get "ok ✓" and skip routing
+        // BUG-04: filter returns empty for boilerplate; run_script adds "ok +" on success
         let raw = "> pkg@1.0.0 test\n$ vitest run\n\nDone in 2s\n";
         let stripped = filter_pnpm_run_output(raw);
-        assert_eq!(stripped, "ok ✓");
-        // In run_script, this would skip routing
+        assert_eq!(stripped, "");
+        // In run_script: if stripped.is_empty() && success -> println!("ok +")
     }
 
     // ─── is_pnpm_script tests ────────────────────────────────────────────
@@ -1322,5 +1380,96 @@ Done in 1.2s"#;
         assert!(!is_pnpm_script("start", &no_scripts));
         // "run" does not match route_script and no PackageScripts
         assert!(!is_pnpm_script("run", &no_scripts));
+    }
+
+    // ─── strip_pnpm_stderr tests ────────────────────────────────────────
+
+    #[test]
+    fn test_strip_pnpm_stderr_removes_elifecycle() {
+        let stderr = " ELIFECYCLE  Command failed with exit code 1.\nSome real error\nDone in 3s";
+        let result = strip_pnpm_stderr(stderr);
+        assert!(!result.contains("ELIFECYCLE"));
+        assert!(!result.contains("Done in"));
+        assert!(result.contains("Some real error"));
+    }
+
+    #[test]
+    fn test_strip_pnpm_stderr_preserves_err_pnpm() {
+        let stderr =
+            " ERR_PNPM_NO_PKG_MANIFEST  No package.json found\n ELIFECYCLE  Command failed";
+        let result = strip_pnpm_stderr(stderr);
+        assert!(
+            result.contains("ERR_PNPM_NO_PKG_MANIFEST"),
+            "ERR_PNPM messages should be preserved, got: {}",
+            result
+        );
+        assert!(!result.contains("ELIFECYCLE"));
+    }
+
+    #[test]
+    fn test_strip_pnpm_stderr_preserves_non_boilerplate() {
+        let stderr = "Error: Cannot find module 'express'\n    at Module._resolveFilename";
+        let result = strip_pnpm_stderr(stderr);
+        assert!(result.contains("Cannot find module"));
+        assert!(result.contains("_resolveFilename"));
+    }
+
+    #[test]
+    fn test_strip_pnpm_stderr_empty_input() {
+        let result = strip_pnpm_stderr("");
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_strip_pnpm_stderr_only_boilerplate() {
+        let stderr = " ELIFECYCLE  Command failed\n\nDone in 2s\n";
+        let result = strip_pnpm_stderr(stderr);
+        assert_eq!(result, "");
+    }
+
+    // ─── stream separation + failure behavior tests ─────────────────────
+
+    #[test]
+    fn test_filter_pnpm_run_output_returns_empty_for_boilerplate() {
+        // BUG-04: filter_pnpm_run_output returns empty string, not "ok +"
+        let input = "> pkg@1.0.0 build\n$ tsc\n\nDone in 1s\n";
+        let result = filter_pnpm_run_output(input);
+        assert!(
+            result.is_empty(),
+            "Expected empty string for boilerplate, got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_failure_empty_stdout_no_ok_checkmark() {
+        // BUG-04: empty stdout + failure should NOT produce "ok +"
+        // Simulate the logic flow in run_script (can't call run_script since it calls exit)
+        let stdout = "> pkg@1.0.0 test\n$ vitest run\n";
+        let stderr = " ERR_PNPM_NO_PKG_MANIFEST  No package.json found";
+
+        let stripped = filter_pnpm_run_output(stdout);
+        assert!(stripped.is_empty(), "Stripped stdout should be empty");
+
+        // In run_script failure path: when stripped is empty, show stderr
+        let stderr_display = strip_pnpm_stderr(stderr);
+        assert!(
+            stderr_display.contains("ERR_PNPM"),
+            "Stderr should contain the error message"
+        );
+        // The display would be stderr_display, NOT "ok +"
+        assert!(
+            !stderr_display.contains("ok"),
+            "Should never show 'ok' on failure"
+        );
+    }
+
+    #[test]
+    fn test_success_empty_stdout_shows_ok() {
+        // On success with empty stripped stdout, run_script shows "ok +"
+        let stdout = "> pkg@1.0.0 build\n$ tsc --noEmit\n\nDone in 1s\n";
+        let stripped = filter_pnpm_run_output(stdout);
+        assert!(stripped.is_empty());
+        // In run_script success path: println!("ok +") -- verified by logic, not process::exit
     }
 }

--- a/src/pnpm_cmd.rs
+++ b/src/pnpm_cmd.rs
@@ -1,5 +1,7 @@
 use crate::tracking;
 use anyhow::{Context, Result};
+use lazy_static::lazy_static;
+use regex::Regex;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::ffi::OsString;
@@ -512,6 +514,267 @@ pub fn run_passthrough(args: &[OsString], verbose: u8) -> Result<()> {
     Ok(())
 }
 
+// ─── pnpm run <script> support ───────────────────────────────────────────────
+
+/// Filter route for specialized script output processing
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FilterRoute {
+    TestRunner,
+    Vitest,
+    Lint,
+    Tsc,
+    Prettier,
+    Playwright,
+}
+
+/// Strip pnpm-specific boilerplate from script output
+pub(crate) fn filter_pnpm_run_output(output: &str) -> String {
+    lazy_static! {
+        // > my-project@1.0.0 test /path/to/project
+        static ref LIFECYCLE_HEADER: Regex = Regex::new(r"^>\s+\S+@\S+\s+").unwrap();
+        // $ vitest run --reporter=json
+        static ref SCRIPT_ECHO: Regex = Regex::new(r"^\$\s+").unwrap();
+        // Done in 3.4s
+        static ref DONE_MSG: Regex = Regex::new(r"^Done in \d").unwrap();
+        // ELIFECYCLE  Command failed with exit code 1.
+        static ref ELIFECYCLE: Regex = Regex::new(r"(?i)ELIFECYCLE|ERR_PNPM").unwrap();
+        // Progress: resolved 123, reused 120, downloaded 3
+        static ref PROGRESS: Regex = Regex::new(r"^Progress:").unwrap();
+    }
+
+    let mut result = Vec::new();
+
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if LIFECYCLE_HEADER.is_match(trimmed) {
+            continue;
+        }
+        if SCRIPT_ECHO.is_match(trimmed) {
+            continue;
+        }
+        if DONE_MSG.is_match(trimmed) {
+            continue;
+        }
+        if ELIFECYCLE.is_match(trimmed) {
+            continue;
+        }
+        if PROGRESS.is_match(trimmed) {
+            continue;
+        }
+        result.push(line.to_string());
+    }
+
+    if result.is_empty() {
+        "ok ✓".to_string()
+    } else {
+        result.join("\n")
+    }
+}
+
+/// Route a script name to a specialized filter (static rules + package.json detection)
+pub(crate) fn route_script(script: &str) -> Option<FilterRoute> {
+    // Tier 1: Static routing (exact match)
+    match script {
+        "vitest" => return Some(FilterRoute::Vitest),
+        "typecheck" | "tsc" => return Some(FilterRoute::Tsc),
+        "prettier" | "format" | "format:check" => return Some(FilterRoute::Prettier),
+        "lint" => return Some(FilterRoute::Lint),
+        "test" => return Some(FilterRoute::TestRunner),
+        _ => {}
+    }
+
+    // Tier 1b: Prefix matching
+    if let Some(suffix) = script.strip_prefix("test:") {
+        match suffix {
+            "e2e" | "playwright" | "cypress" => {} // defer to package.json
+            _ => return Some(FilterRoute::TestRunner),
+        }
+    }
+    if let Some(suffix) = script.strip_prefix("lint:") {
+        if suffix != "fix" {
+            return Some(FilterRoute::Lint);
+        }
+    }
+
+    // Tier 2: Auto-detect from package.json
+    detect_tool_from_package_json(script)
+}
+
+/// Read package.json scripts[name] and detect the underlying tool
+pub(crate) fn detect_tool_from_package_json(script: &str) -> Option<FilterRoute> {
+    let content = std::fs::read_to_string("package.json").ok()?;
+    let json: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let scripts = json.get("scripts")?.as_object()?;
+    let command = scripts.get(script)?.as_str()?;
+    let cmd_lower = command.to_lowercase();
+
+    if cmd_lower.contains("playwright") {
+        Some(FilterRoute::Playwright)
+    } else if cmd_lower.contains("vitest") {
+        Some(FilterRoute::Vitest)
+    } else if cmd_lower.contains("jest") {
+        Some(FilterRoute::TestRunner)
+    } else if cmd_lower.contains("tsc") || cmd_lower.contains("typescript") {
+        Some(FilterRoute::Tsc)
+    } else if cmd_lower.contains("eslint") || cmd_lower.contains("biome") {
+        Some(FilterRoute::Lint)
+    } else if cmd_lower.contains("prettier") {
+        Some(FilterRoute::Prettier)
+    } else {
+        None
+    }
+}
+
+/// Check if a name is a known pnpm script (static routing or package.json)
+pub fn is_pnpm_script(name: &str) -> bool {
+    if route_script(name).is_some() {
+        return true;
+    }
+    // Check package.json scripts
+    if let Ok(content) = std::fs::read_to_string("package.json") {
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
+            if let Some(scripts) = json.get("scripts").and_then(|s| s.as_object()) {
+                return scripts.contains_key(name);
+            }
+        }
+    }
+    false
+}
+
+/// Apply a specialized filter to script output
+pub(crate) fn apply_filter(route: FilterRoute, output: &str) -> (String, &'static str) {
+    use crate::parser::{OutputParser, TokenFormatter};
+
+    let result = std::panic::catch_unwind(|| match route {
+        FilterRoute::Vitest => {
+            let parse_result = crate::vitest_cmd::VitestParser::parse(output);
+            match parse_result {
+                ParseResult::Full(data) => data.format(FormatMode::Compact),
+                ParseResult::Degraded(data, _) => data.format(FormatMode::Compact),
+                ParseResult::Passthrough(raw) => raw,
+            }
+        }
+        FilterRoute::Playwright => {
+            let parse_result = crate::playwright_cmd::PlaywrightParser::parse(output);
+            match parse_result {
+                ParseResult::Full(data) => data.format(FormatMode::Compact),
+                ParseResult::Degraded(data, _) => data.format(FormatMode::Compact),
+                ParseResult::Passthrough(raw) => raw,
+            }
+        }
+        FilterRoute::Tsc => crate::tsc_cmd::filter_tsc_output(output),
+        FilterRoute::Lint => crate::lint_cmd::filter_generic_lint(output),
+        FilterRoute::Prettier => crate::prettier_cmd::filter_prettier_output(output),
+        FilterRoute::TestRunner => crate::runner::extract_test_summary(output, "npm test"),
+    });
+
+    let label = match route {
+        FilterRoute::Vitest => "vitest (via pnpm run)",
+        FilterRoute::Playwright => "playwright (via pnpm run)",
+        FilterRoute::Tsc => "tsc (via pnpm run)",
+        FilterRoute::Lint => "lint (via pnpm run)",
+        FilterRoute::Prettier => "prettier (via pnpm run)",
+        FilterRoute::TestRunner => "test (via pnpm run)",
+    };
+
+    match result {
+        Ok(filtered) if !filtered.trim().is_empty() => (filtered, label),
+        _ => (output.to_string(), label),
+    }
+}
+
+/// Execute `pnpm run <script>` with smart routing to specialized filters
+pub fn run_script(script: &str, args: &[String], verbose: u8, skip_env: bool) -> Result<()> {
+    let timer = tracking::TimedExecution::start();
+
+    let mut cmd = Command::new("pnpm");
+    cmd.arg("run");
+    cmd.arg(script);
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    if skip_env {
+        cmd.env("SKIP_ENV_VALIDATION", "1");
+    }
+
+    if verbose > 0 {
+        eprintln!("Running: pnpm run {} {}", script, args.join(" "));
+    }
+
+    let output = cmd
+        .output()
+        .context(format!("Failed to run pnpm run {}", script))?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let raw = format!("{}\n{}", stdout, stderr);
+    let exit_code = output.status.code().unwrap_or(1);
+
+    // On failure: show raw output + tee hint, exit
+    if !output.status.success() {
+        let stripped = filter_pnpm_run_output(&raw);
+        if let Some(hint) =
+            crate::tee::tee_and_hint(&raw, &format!("pnpm-run-{}", script), exit_code)
+        {
+            println!("{}\n{}", stripped, hint);
+        } else {
+            println!("{}", stripped);
+        }
+        timer.track(
+            &format!("pnpm run {} {}", script, args.join(" ")),
+            &format!("rtk pnpm run {} {}", script, args.join(" ")),
+            &raw,
+            &stripped,
+        );
+        std::process::exit(exit_code);
+    }
+
+    // Strip pnpm boilerplate
+    let stripped = filter_pnpm_run_output(&raw);
+
+    // If all output was boilerplate, just show ok
+    if stripped == "ok ✓" {
+        println!("{}", stripped);
+        timer.track(
+            &format!("pnpm run {} {}", script, args.join(" ")),
+            &format!("rtk pnpm run {} {}", script, args.join(" ")),
+            &raw,
+            &stripped,
+        );
+        return Ok(());
+    }
+
+    // Route to specialized filter
+    let filtered = match route_script(script) {
+        Some(route) => {
+            let (result, label) = apply_filter(route, &stripped);
+            if verbose > 0 {
+                eprintln!("Routed to: {}", label);
+            }
+            result
+        }
+        None => stripped.clone(),
+    };
+
+    if let Some(hint) = crate::tee::tee_and_hint(&raw, &format!("pnpm-run-{}", script), exit_code) {
+        println!("{}\n{}", filtered, hint);
+    } else {
+        println!("{}", filtered);
+    }
+
+    timer.track(
+        &format!("pnpm run {} {}", script, args.join(" ")),
+        &format!("rtk pnpm run {} {}", script, args.join(" ")),
+        &raw,
+        &filtered,
+    );
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -569,5 +832,209 @@ mod tests {
         // Test that run_passthrough compiles and has correct signature
         let _args: Vec<OsString> = vec![OsString::from("help")];
         // Compile-time verification that the function exists with correct signature
+    }
+
+    // ─── filter_pnpm_run_output tests ────────────────────────────────────
+
+    #[test]
+    fn test_filter_pnpm_run_output_clean() {
+        // Real tool output should be preserved
+        let input = "PASS src/utils.test.ts\nTests: 5 passed, 5 total";
+        let result = filter_pnpm_run_output(input);
+        assert!(result.contains("PASS"));
+        assert!(result.contains("Tests: 5 passed"));
+    }
+
+    #[test]
+    fn test_filter_pnpm_run_output_lifecycle() {
+        let input = "> my-project@1.0.0 test /path/to/project\nPASS tests";
+        let result = filter_pnpm_run_output(input);
+        assert!(!result.contains("> my-project@"));
+        assert!(result.contains("PASS tests"));
+    }
+
+    #[test]
+    fn test_filter_pnpm_run_output_script_echo() {
+        let input = "$ vitest run --reporter=json\nactual output here";
+        let result = filter_pnpm_run_output(input);
+        assert!(!result.contains("$ vitest"));
+        assert!(result.contains("actual output here"));
+    }
+
+    #[test]
+    fn test_filter_pnpm_run_output_done_msg() {
+        let input = "Tests passed\nDone in 3.4s";
+        let result = filter_pnpm_run_output(input);
+        assert!(!result.contains("Done in"));
+        assert!(result.contains("Tests passed"));
+    }
+
+    #[test]
+    fn test_filter_pnpm_run_output_empty() {
+        let input = "> pkg@1.0.0 test\n$ vitest run\n\nDone in 2.1s\n";
+        let result = filter_pnpm_run_output(input);
+        assert_eq!(result, "ok ✓");
+    }
+
+    #[test]
+    fn test_filter_pnpm_run_output_mixed() {
+        let input = r#"> my-project@1.0.0 test
+$ vitest run --reporter=json
+
+{"numTotalTests":10,"numPassedTests":9,"numFailedTests":1,"numPendingTests":0,"testResults":[]}
+
+ ELIFECYCLE  Command failed with exit code 1.
+Done in 5.2s
+"#;
+        let result = filter_pnpm_run_output(input);
+        assert!(!result.contains("> my-project@"));
+        assert!(!result.contains("$ vitest"));
+        assert!(!result.contains("ELIFECYCLE"));
+        assert!(!result.contains("Done in"));
+        assert!(result.contains("numTotalTests"));
+
+        fn count_tokens(text: &str) -> usize {
+            text.split_whitespace().count()
+        }
+        let savings = 100.0 - (count_tokens(&result) as f64 / count_tokens(input) as f64 * 100.0);
+        assert!(
+            savings >= 40.0,
+            "Expected ≥40% savings, got {:.1}%",
+            savings
+        );
+    }
+
+    // ─── route_script tests ──────────────────────────────────────────────
+
+    #[test]
+    fn test_route_script_exact_matches() {
+        assert_eq!(route_script("vitest"), Some(FilterRoute::Vitest));
+        assert_eq!(route_script("tsc"), Some(FilterRoute::Tsc));
+        assert_eq!(route_script("typecheck"), Some(FilterRoute::Tsc));
+        assert_eq!(route_script("lint"), Some(FilterRoute::Lint));
+        assert_eq!(route_script("prettier"), Some(FilterRoute::Prettier));
+        assert_eq!(route_script("format"), Some(FilterRoute::Prettier));
+        assert_eq!(route_script("test"), Some(FilterRoute::TestRunner));
+    }
+
+    #[test]
+    fn test_route_script_unknown_returns_none() {
+        // These don't match static rules and no package.json in test env
+        assert_eq!(route_script("build"), None);
+        assert_eq!(route_script("dev"), None);
+        assert_eq!(route_script("start"), None);
+    }
+
+    #[test]
+    fn test_route_script_prefix_matching() {
+        assert_eq!(route_script("test:unit"), Some(FilterRoute::TestRunner));
+        assert_eq!(
+            route_script("test:integration"),
+            Some(FilterRoute::TestRunner)
+        );
+        assert_eq!(route_script("lint:check"), Some(FilterRoute::Lint));
+        assert_eq!(route_script("lint:ci"), Some(FilterRoute::Lint));
+    }
+
+    #[test]
+    fn test_route_script_prefix_exclusions() {
+        // These are deferred to package.json (no package.json in test → None)
+        assert_eq!(route_script("test:e2e"), None);
+        assert_eq!(route_script("test:playwright"), None);
+        assert_eq!(route_script("test:cypress"), None);
+        assert_eq!(route_script("lint:fix"), None);
+    }
+
+    // ─── detect_tool_from_package_json tests ─────────────────────────────
+
+    #[test]
+    fn test_detect_missing_script_returns_none() {
+        // No package.json in test CWD → None
+        assert_eq!(detect_tool_from_package_json("nonexistent"), None);
+    }
+
+    // ─── apply_filter tests ──────────────────────────────────────────────
+
+    #[test]
+    fn test_apply_filter_tsc_label() {
+        let (_, label) = apply_filter(FilterRoute::Tsc, "some output");
+        assert_eq!(label, "tsc (via pnpm run)");
+    }
+
+    #[test]
+    fn test_apply_filter_vitest_label() {
+        let (_, label) = apply_filter(FilterRoute::Vitest, "some output");
+        assert_eq!(label, "vitest (via pnpm run)");
+    }
+
+    #[test]
+    fn test_apply_filter_lint_label() {
+        let (_, label) = apply_filter(FilterRoute::Lint, "some output");
+        assert_eq!(label, "lint (via pnpm run)");
+    }
+
+    #[test]
+    fn test_apply_filter_prettier_label() {
+        let (_, label) = apply_filter(FilterRoute::Prettier, "some output");
+        assert_eq!(label, "prettier (via pnpm run)");
+    }
+
+    #[test]
+    fn test_apply_filter_test_runner_label() {
+        let (_, label) = apply_filter(FilterRoute::TestRunner, "some output");
+        assert_eq!(label, "test (via pnpm run)");
+    }
+
+    #[test]
+    fn test_apply_filter_playwright_label() {
+        let (_, label) = apply_filter(FilterRoute::Playwright, "some output");
+        assert_eq!(label, "playwright (via pnpm run)");
+    }
+
+    // ─── integration tests ───────────────────────────────────────────────
+
+    #[test]
+    fn test_filter_then_route_integration() {
+        let raw = r#"> app@1.0.0 lint
+$ eslint .
+
+src/file.ts: warning no-unused-vars
+
+Done in 1.2s"#;
+        let stripped = filter_pnpm_run_output(raw);
+        assert!(!stripped.contains("> app@"));
+        assert!(!stripped.contains("Done in"));
+
+        let route = route_script("lint");
+        assert_eq!(route, Some(FilterRoute::Lint));
+
+        let (filtered, label) = apply_filter(route.unwrap(), &stripped);
+        assert_eq!(label, "lint (via pnpm run)");
+        assert!(!filtered.is_empty());
+    }
+
+    #[test]
+    fn test_ok_checkmark_guard_skips_routing() {
+        // When all output is boilerplate, we get "ok ✓" and skip routing
+        let raw = "> pkg@1.0.0 test\n$ vitest run\n\nDone in 2s\n";
+        let stripped = filter_pnpm_run_output(raw);
+        assert_eq!(stripped, "ok ✓");
+        // In run_script, this would skip routing
+    }
+
+    // ─── is_pnpm_script tests ────────────────────────────────────────────
+
+    #[test]
+    fn test_is_pnpm_script_static() {
+        assert!(is_pnpm_script("test"));
+        assert!(is_pnpm_script("lint"));
+        assert!(is_pnpm_script("vitest"));
+    }
+
+    #[test]
+    fn test_is_pnpm_script_unknown() {
+        // Not a known script name and no package.json in test env
+        assert!(!is_pnpm_script("store"));
+        assert!(!is_pnpm_script("prune"));
     }
 }

--- a/src/pnpm_cmd.rs
+++ b/src/pnpm_cmd.rs
@@ -12,53 +12,6 @@ use crate::parser::{
     DependencyState, FormatMode, OutputParser, ParseResult, TokenFormatter,
 };
 
-/// Native pnpm subcommands that must never be intercepted as scripts.
-/// Sorted alphabetically for binary_search lookup.
-/// Excludes: run, test, start -- those are pnpm script shortcuts that go through smart routing.
-const NATIVE_PNPM_COMMANDS: &[&str] = &[
-    "add",
-    "audit",
-    "bin",
-    "cache",
-    "cat-file",
-    "cat-index",
-    "completion",
-    "config",
-    "create",
-    "dedupe",
-    "deploy",
-    "dlx",
-    "doctor",
-    "env",
-    "exec",
-    "fetch",
-    "find-hash",
-    "import",
-    "init",
-    "install",
-    "install-test",
-    "licenses",
-    "link",
-    "list",
-    "outdated",
-    "pack",
-    "patch",
-    "patch-commit",
-    "patch-remove",
-    "prune",
-    "publish",
-    "rebuild",
-    "remove",
-    "root",
-    "self-update",
-    "server",
-    "setup",
-    "store",
-    "unlink",
-    "update",
-    "why",
-];
-
 // pnpm run output boilerplate patterns
 lazy_static! {
     // > my-project@1.0.0 test /path/to/project
@@ -701,19 +654,15 @@ pub(crate) fn route_script(
     pkg_scripts.and_then(|ps| ps.detect_tool(script))
 }
 
-/// Check if a name is a known pnpm script (static routing or cached package.json)
+/// Check if a name is a known pnpm script (static routing or cached package.json).
+/// Default: false (passthrough to pnpm as native command).
 pub fn is_pnpm_script(name: &str, pkg_scripts: &Option<PackageScripts>) -> bool {
-    // Native pnpm commands are never scripts
-    if NATIVE_PNPM_COMMANDS.binary_search(&name).is_ok() {
-        return false;
-    }
-
-    // Check static routing first (no I/O)
+    // Tier 1: Static routes (vitest, tsc, prettier — no I/O)
     if route_script(name, pkg_scripts.as_ref()).is_some() {
         return true;
     }
 
-    // Check cached package.json scripts
+    // Tier 2: Cached package.json scripts
     match pkg_scripts {
         Some(ps) => ps.contains(name),
         None => false,
@@ -1372,7 +1321,7 @@ Done in 1.2s"#;
 
     #[test]
     fn test_is_pnpm_script_routed_scripts() {
-        // Tier 1 names route without package.json
+        // Tier 1 static routes are recognized without package.json
         let no_scripts: Option<PackageScripts> = None;
         assert!(is_pnpm_script("vitest", &no_scripts));
         // Ambiguous names need package.json
@@ -1401,7 +1350,7 @@ Done in 1.2s"#;
 
     #[test]
     fn test_is_pnpm_script_none_scripts_falls_back() {
-        // With None pkg_scripts, only Tier 1 static routing works
+        // Without package.json, only Tier 1 static routes match; everything else defaults to passthrough
         let no_scripts: Option<PackageScripts> = None;
         assert!(!is_pnpm_script("my-custom-script", &no_scripts));
         assert!(!is_pnpm_script("lint", &no_scripts)); // needs package.json
@@ -1409,37 +1358,23 @@ Done in 1.2s"#;
     }
 
     #[test]
-    fn test_native_commands_not_intercepted() {
-        // These are native pnpm commands -- must never be treated as scripts
+    fn test_native_commands_fall_through_without_denylist() {
+        // Native pnpm commands (install, add, exec, dlx) naturally return false
+        // because they're neither static routes nor in package.json.
         let no_scripts: Option<PackageScripts> = None;
+        assert!(!is_pnpm_script("install", &no_scripts));
+        assert!(!is_pnpm_script("add", &no_scripts));
         assert!(!is_pnpm_script("exec", &no_scripts));
         assert!(!is_pnpm_script("dlx", &no_scripts));
-        assert!(!is_pnpm_script("audit", &no_scripts));
-        assert!(!is_pnpm_script("create", &no_scripts));
-        assert!(!is_pnpm_script("deploy", &no_scripts));
-        assert!(!is_pnpm_script("store", &no_scripts));
-        assert!(!is_pnpm_script("server", &no_scripts));
-        assert!(!is_pnpm_script("patch", &no_scripts));
-        assert!(!is_pnpm_script("env", &no_scripts));
-        assert!(!is_pnpm_script("doctor", &no_scripts));
-        assert!(!is_pnpm_script("why", &no_scripts));
-        assert!(!is_pnpm_script("init", &no_scripts));
-        assert!(!is_pnpm_script("config", &no_scripts));
-        assert!(!is_pnpm_script("setup", &no_scripts));
-        assert!(!is_pnpm_script("bin", &no_scripts));
-        assert!(!is_pnpm_script("self-update", &no_scripts));
-    }
 
-    #[test]
-    fn test_native_commands_sorted() {
-        // binary_search requires sorted array
-        let mut sorted = NATIVE_PNPM_COMMANDS.to_vec();
-        sorted.sort();
-        assert_eq!(
-            NATIVE_PNPM_COMMANDS,
-            &sorted[..],
-            "NATIVE_PNPM_COMMANDS must be sorted alphabetically for binary_search"
-        );
+        // Same result with package.json present (native names aren't user scripts)
+        let with_scripts = Some(PackageScripts {
+            scripts: HashMap::from([("dev".to_string(), "next dev".to_string())]),
+        });
+        assert!(!is_pnpm_script("install", &with_scripts));
+        assert!(!is_pnpm_script("add", &with_scripts));
+        assert!(!is_pnpm_script("exec", &with_scripts));
+        assert!(!is_pnpm_script("dlx", &with_scripts));
     }
 
     #[test]
@@ -1454,20 +1389,6 @@ Done in 1.2s"#;
         // Whitespace-only output triggers Err
         let result = apply_filter(FilterRoute::Lint, "   \n\n  ");
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_native_denylist_does_not_block_script_shortcuts() {
-        // run, test, start are NOT in denylist -- but need package.json for routing
-        let no_scripts: Option<PackageScripts> = None;
-        assert!(!is_pnpm_script("test", &no_scripts)); // needs package.json
-        assert!(!is_pnpm_script("start", &no_scripts));
-        assert!(!is_pnpm_script("run", &no_scripts));
-        // With package.json, "test" routes correctly
-        let with_scripts = Some(PackageScripts {
-            scripts: HashMap::from([("test".to_string(), "vitest run".to_string())]),
-        });
-        assert!(is_pnpm_script("test", &with_scripts));
     }
 
     // ─── strip_pnpm_stderr tests ────────────────────────────────────────

--- a/src/pnpm_cmd.rs
+++ b/src/pnpm_cmd.rs
@@ -68,8 +68,7 @@ lazy_static! {
     // Done in 3.4s
     static ref DONE_MSG: Regex = Regex::new(r"^Done in \d").unwrap();
     // ELIFECYCLE  Command failed with exit code 1.
-    static ref ELIFECYCLE: Regex = Regex::new(r"(?i)ELIFECYCLE|ERR_PNPM").unwrap();
-    // For stderr stripping: only match ELIFECYCLE, preserve ERR_PNPM messages (BUG-04)
+    // Matches only ELIFECYCLE, preserves ERR_PNPM messages (BUG-04)
     static ref ELIFECYCLE_ONLY: Regex = Regex::new(r"(?i)ELIFECYCLE").unwrap();
     // Progress: resolved 123, reused 120, downloaded 3
     static ref PROGRESS: Regex = Regex::new(r"^Progress:").unwrap();
@@ -659,7 +658,7 @@ pub(crate) fn filter_pnpm_run_output(output: &str) -> String {
         if DONE_MSG.is_match(trimmed) {
             continue;
         }
-        if ELIFECYCLE.is_match(trimmed) {
+        if ELIFECYCLE_ONLY.is_match(trimmed) {
             continue;
         }
         if PROGRESS.is_match(trimmed) {
@@ -1051,6 +1050,14 @@ Done in 5.2s
             "Expected ≥40% savings, got {:.1}%",
             savings
         );
+    }
+
+    #[test]
+    fn test_filter_pnpm_run_output_preserves_err_pnpm() {
+        let input = " ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND  No package.json (or package.yaml, or package.json5) was found in \"/Users/test\".";
+        let result = filter_pnpm_run_output(input);
+        assert!(result.contains("ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND"));
+        assert!(result.contains("No package.json"));
     }
 
     // ─── route_script tests ──────────────────────────────────────────────

--- a/src/pnpm_cmd.rs
+++ b/src/pnpm_cmd.rs
@@ -542,6 +542,21 @@ pub(crate) enum FilterRoute {
     Playwright,
 }
 
+/// Walk up from CWD to find the nearest package.json (mirrors pnpm resolution).
+fn find_package_json() -> Option<std::path::PathBuf> {
+    let mut dir = std::env::current_dir().ok()?;
+    for _ in 0..10 {
+        let candidate = dir.join("package.json");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        if !dir.pop() {
+            break;
+        }
+    }
+    None
+}
+
 /// Cached package.json scripts (read once per invocation).
 /// Eliminates redundant fs::read_to_string("package.json") calls in
 /// is_pnpm_script and route_script.
@@ -553,7 +568,8 @@ impl PackageScripts {
     /// Read package.json from CWD, parse scripts field. Returns None if
     /// file is missing, unparseable, or has no scripts section.
     pub fn load() -> Option<Self> {
-        let content = std::fs::read_to_string("package.json").ok()?;
+        let path = find_package_json()?;
+        let content = std::fs::read_to_string(path).ok()?;
         let json: serde_json::Value = serde_json::from_str(&content).ok()?;
         let scripts_obj = json.get("scripts")?.as_object()?;
         let scripts: HashMap<String, String> = scripts_obj
@@ -1243,6 +1259,22 @@ Done in 5.2s
             route_script("test:e2e", Some(&ps)),
             Some(FilterRoute::Playwright)
         );
+    }
+
+    #[test]
+    fn test_find_package_json_cwd_first() {
+        // When CWD has a package.json, find_package_json should return it.
+        // This test runs inside the rtk repo root which has a Cargo.toml but
+        // may not have package.json — so we just verify it returns Some/None
+        // consistently with whether the file exists on disk.
+        let result = find_package_json();
+        let cwd_has_pkg = std::path::Path::new("package.json").is_file();
+        if cwd_has_pkg {
+            assert!(result.is_some());
+            assert!(result.unwrap().ends_with("package.json"));
+        } else {
+            // No package.json in any ancestor — None is acceptable
+        }
     }
 
     // ─── apply_filter tests ──────────────────────────────────────────────

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -160,7 +160,7 @@ fn filter_errors(output: &str) -> String {
     result.join("\n")
 }
 
-fn extract_test_summary(output: &str, command: &str) -> String {
+pub(crate) fn extract_test_summary(output: &str, command: &str) -> String {
     let mut result = Vec::new();
     let lines: Vec<&str> = output.lines().collect();
 

--- a/src/tsc_cmd.rs
+++ b/src/tsc_cmd.rs
@@ -60,7 +60,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<()> {
 }
 
 /// Filter TypeScript compiler output - group errors by file, show every error
-fn filter_tsc_output(output: &str) -> String {
+pub(crate) fn filter_tsc_output(output: &str) -> String {
     lazy_static::lazy_static! {
         // Pattern: src/file.ts(12,5): error TS2322: Type 'string' is not assignable to type 'number'.
         static ref TSC_ERROR: Regex = Regex::new(


### PR DESCRIPTION
## Summary                                                                                                     

  - Add `rtk pnpm run <script>` and `rtk pnpm <script>` shorthand with smart routing to specialized filters
  - Strip pnpm boilerplate (lifecycle headers, script echo, "Done in Xs", ELIFECYCLE errors, progress bars)
  - Two-tier script routing: static name matching (test, lint, typecheck, vitest, prettier, format) +
  package.json auto-detection for custom scripts (e.g., `test:e2e` → detects `playwright test` →
  PlaywrightParser)
  - Promote `filter_tsc_output`, `filter_generic_lint`, `extract_test_summary` to `pub(crate)` for cross-module
  reuse

  ## Token Savings

  | Script | Route | Expected Savings |
  |--------|-------|-----------------|
  | `pnpm [run] test` (vitest) | VitestParser | 90%+ |
  | `pnpm [run] typecheck` (tsc) | filter_tsc_output | 80%+ |
  | `pnpm [run] lint` (eslint) | filter_generic_lint | 80%+ |
  | `pnpm [run] prettier --check` | filter_prettier_output | 70%+ |
  | `pnpm [run] test:e2e` (playwright) | PlaywrightParser | 80%+ |
  | `pnpm [run] build` (unrouted) | Boilerplate strip only | 30-50% |

  ## How It Works

  - `rtk pnpm run test` → `PnpmCommands::Run` → `run_script("test")` → boilerplate strip → TestRunner filter
  - `rtk pnpm test` → `PnpmCommands::Other` → `is_pnpm_script("test")` → `run_script("test")`
  - `rtk pnpm test:e2e` → reads `package.json` → detects `playwright test` → PlaywrightParser
  - `rtk pnpm store prune` → `is_pnpm_script("store")` = false → passthrough

  ## Test plan

  - [x] 25 new unit tests (boilerplate filtering, static routing, prefix matching, prefix exclusions,
  apply_filter labels, integration, is_pnpm_script)
  - [x] 4 Clap parsing tests (basic, with args, colon script, shorthand falls to Other)
  - [x] `cargo fmt --all && cargo clippy --all-targets && cargo test --all` — 437 tests pass
  - [x] Manual test with real pnpm project: `rtk pnpm run test`, `rtk pnpm test`, `rtk pnpm run lint`