### PR TITLE
fix(git): propagate exit codes in push/pull/fetch/stash/worktree

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -787,6 +787,7 @@ fn run_push(args: &[String], verbose: u8) -> Result<()> {
         if !stdout.trim().is_empty() {
             eprintln!("{}", stdout);
         }
+        std::process::exit(output.status.code().unwrap_or(1));
     }
 
     Ok(())
@@ -872,6 +873,7 @@ fn run_pull(args: &[String], verbose: u8) -> Result<()> {
         if !stdout.trim().is_empty() {
             eprintln!("{}", stdout);
         }
+        std::process::exit(output.status.code().unwrap_or(1));
     }
 
     Ok(())
@@ -1050,7 +1052,7 @@ fn run_fetch(args: &[String], verbose: u8) -> Result<()> {
         if !stderr.trim().is_empty() {
             eprintln!("{}", stderr);
         }
-        return Ok(());
+        std::process::exit(output.status.code().unwrap_or(1));
     }
 
     // Count new refs from stderr (git fetch outputs to stderr)
@@ -1150,6 +1152,10 @@ fn run_stash(subcommand: Option<&str>, args: &[String], verbose: u8) -> Result<(
                 &combined,
                 &msg,
             );
+
+            if !output.status.success() {
+                std::process::exit(output.status.code().unwrap_or(1));
+            }
         }
         _ => {
             // Default: git stash (push)
@@ -1182,6 +1188,10 @@ fn run_stash(subcommand: Option<&str>, args: &[String], verbose: u8) -> Result<(
             };
 
             timer.track("git stash", "rtk git stash", &combined, &msg);
+
+            if !output.status.success() {
+                std::process::exit(output.status.code().unwrap_or(1));
+            }
         }
     }
 
@@ -1252,6 +1262,7 @@ fn run_worktree(args: &[String], verbose: u8) -> Result<()> {
             if !stderr.trim().is_empty() {
                 eprintln!("{}", stderr);
             }
+            std::process::exit(output.status.code().unwrap_or(1));
         }
         return Ok(());
     }


### PR DESCRIPTION
## Problem

\`rtk git push\`, \`rtk git pull\`, \`rtk git fetch\`, \`rtk git stash\` (pop/apply/drop/push/default), and \`rtk git worktree\` all print a \`FAILED:\` message on error but return exit code **0** to the caller.

This breaks CI/CD pipelines and shell scripts that rely on exit code semantics:

\`\`\`bash
rtk git push || handle_error   # handle_error never called
rtk git pull && deploy         # deploy runs even on pull failure
\`\`\`

## Root cause

The failure branches in these functions print the error but fall through to \`Ok(())\` instead of propagating git's exit code via \`std::process::exit()\`.

## Fix

Add \`std::process::exit(output.status.code().unwrap_or(1))\` in each failure branch, matching the pattern already used correctly in \`run_log\`, \`run_diff\`, \`run_add\`, and \`run_branch\`.

Per the Rust docs, \`status.code()\` returns \`Option<i32>\` — \`None\` when the process was killed by a signal (Unix). The \`.unwrap_or(1)\` fallback handles that case correctly.

## Functions fixed

| Function | Issue |
|----------|-------|
| \`run_push\` | Falls through to \`Ok(())\` on failure |
| \`run_pull\` | Falls through to \`Ok(())\` on failure |
| \`run_fetch\` | Explicit \`return Ok(())\` on failure |
| \`run_stash\` (pop/apply/drop/push) | Falls through to \`Ok(())\` after timer |
| \`run_stash\` (default) | Falls through to \`Ok(())\` after timer |
| \`run_worktree\` | \`return Ok(())\` on both success and failure |

## Testing

All 412 existing tests pass. No new behavior on the success path.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)