### PR TITLE
fix(gh): show fallback note for filtered body; fix api truncation message

### DIFF
--- a/src/gh_cmd.rs
+++ b/src/gh_cmd.rs
@@ -382,6 +382,10 @@ fn view_pr(args: &[String], _verbose: u8, ultra_compact: bool) -> Result<()> {
                     filtered.push_str(&formatted);
                     print!("{}", formatted);
                 }
+            } else {
+                let note = "  (body contained only badges/images/comments)\n";
+                filtered.push_str(note);
+                print!("{}", note);
             }
         }
     }
@@ -678,6 +682,10 @@ fn view_issue(args: &[String], _verbose: u8) -> Result<()> {
                     filtered.push_str(&formatted);
                     print!("{}", formatted);
                 }
+            } else {
+                let note = "  (body contained only badges/images/comments)\n";
+                filtered.push_str(note);
+                print!("{}", note);
             }
         }
     }
@@ -1147,14 +1155,18 @@ fn run_api(args: &[String], _verbose: u8) -> Result<()> {
         }
         Err(_) => {
             // Not JSON, print truncated raw output
+            let all_lines: Vec<&str> = raw.lines().collect();
+            let total = all_lines.len();
             let mut result = String::new();
-            let lines: Vec<&str> = raw.lines().take(20).collect();
-            let joined = lines.join("\n");
-            result.push_str(&joined);
-            print!("{}", joined);
-            if raw.lines().count() > 20 {
-                result.push_str("\n... (truncated)");
-                println!("\n... (truncated)");
+            for line in all_lines.iter().take(20) {
+                result.push_str(line);
+                result.push('\n');
+                println!("{}", line);
+            }
+            if total > 20 {
+                let note = format!("... {} more lines (use gh api for full output)\n", total - 20);
+                result.push_str(&note);
+                print!("{}", note);
             }
             result
         }


### PR DESCRIPTION
## Problems

Two related issues in \`gh_cmd.rs\`, same category as the body-display fix from #214.

### 1. Silent body loss in \`view_pr()\` and \`view_issue()\`

When \`filter_markdown_body()\` removes all content (body contains only badges, images, or HTML comments), the body section is silently skipped — no output, no indication that content existed.

**Example body that disappears completely:**
\`\`\`markdown
<!-- Auto-generated by bot -->
[![CI](https://shields.io/badge.svg)](url)
![screenshot](image.png)
---
\`\`\`

The user sees PR metadata but has no way to know a body was present and filtered.

**Fix:** Show \`(body contained only badges/images/comments)\` so the user is aware.

### 2. Naive \`.take(20)\` with double iteration in \`run_api()\`

The non-JSON fallback in \`run_api()\` used the same naive truncation pattern that #214 fixed for \`view_pr\`:
- Calls \`raw.lines()\` twice (once to take 20, once to count total)
- Shows \`"... (truncated)"\` with no line count

**Fix:** Single pass, message shows exact count: \`"... N more lines (use gh api for full output)"\`, consistent with \`list_prs()\` and the rest of the module.

## Testing

All 412 existing tests pass.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)