### PR TITLE
fix: remove personal preferences from project CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -508,13 +508,11 @@ hyperfine 'target/release/rtk git log -10' --warmup 3
 **ALWAYS confirm working directory before starting any work**:
 
 ```bash
-pwd  # Verify you're in /Users/florianbruniaux/Sites/rtk-ai/rtk
+pwd  # Verify you're in the rtk project root
 git branch  # Verify correct branch (main, feature/*, etc.)
 ```
 
-**Never assume** which project to work in. RTK shares parent directory with other projects (ccboard, cc-economics).
-
-**Context**: Wrong directory detection was a common friction point in multi-repo environments. Always verify before file operations.
+**Never assume** which project to work in. Always verify before file operations.
 
 ## Avoiding Rabbit Holes
 
@@ -545,16 +543,6 @@ When user provides a numbered plan (QW1-QW4, Phase 1-5, sprint tasks, etc.):
 
 **Why**: Plan-driven execution produces better outcomes than ad-hoc implementation. Structured plans help maintain focus and prevent scope creep.
 
-## Language & Communication
-
-- **User communicates in French**: Respond in French unless explicitly writing English content (docs, code comments, READMEs)
-- **"reprend"**: Resume previous task where it was left off
-- **Be direct**: User prefers direct, factual communication (Bold Guy style - cash, bienveillant, énergique)
-
-**Examples**:
-- ✅ "Ça ne va pas marcher parce que X. Voici ce que je ferais : Y."
-- ✅ "Le test échoue car le regex ne capture pas les commits merge. Fix : ajouter `(?:Merge|commit)`."
-- ❌ "Je pense que peut-être nous pourrions éventuellement envisager de..." (trop verbeux, pas direct)
 
 ## Filter Development Checklist
 


### PR DESCRIPTION
## Summary

Project `CLAUDE.md` is loaded for every contributor using Claude Code on this repo. It currently contains personal preferences that get imposed on all forks and contributors:

- **Hardcoded home directory path** (`/Users/florianbruniaux/Sites/rtk-ai/rtk`) — breaks for every other developer
- **Sibling project references** (`ccboard, cc-economics`) — irrelevant to contributors
- **French language/communication style** (`"User communicates in French"`, `"Bold Guy style"`) — forces all contributors into one person's language preference

These belong in the author's personal `~/.claude/CLAUDE.md`, not in the project's committed `CLAUDE.md`.

## Changes

- Replace hardcoded path with generic `# Verify you're in the rtk project root`
- Remove sibling project names from working directory section
- Remove entire "Language & Communication" section

## Test plan

- [x] No code changes — documentation only
- [x] Verified no other personal preferences remain in CLAUDE.md