### PR TITLE
fix: filter docker compose hook rewrites to supported subcommands

### DIFF
--- a/hooks/rtk-rewrite.sh
+++ b/hooks/rtk-rewrite.sh
@@ -129,7 +129,12 @@ elif echo "$MATCH_CMD" | grep -qE '^(npx[[:space:]]+)?prisma([[:space:]]|$)'; th
 # --- Containers (added: docker compose, docker run/build/exec, kubectl describe/apply) ---
 elif echo "$MATCH_CMD" | grep -qE '^docker[[:space:]]'; then
   if echo "$MATCH_CMD" | grep -qE '^docker[[:space:]]+compose([[:space:]]|$)'; then
-    REWRITTEN="${ENV_PREFIX}$(echo "$CMD_BODY" | sed 's/^docker /rtk docker /')"
+    COMPOSE_SUBCMD=$(echo "$MATCH_CMD" | sed -E 's/^docker[[:space:]]+compose[[:space:]]*//')
+    case "$COMPOSE_SUBCMD" in
+      ps|ps\ *|logs|logs\ *|build|build\ *)
+        REWRITTEN="${ENV_PREFIX}$(echo "$CMD_BODY" | sed 's/^docker /rtk docker /')"
+        ;;
+    esac
   else
     DOCKER_SUBCMD=$(echo "$MATCH_CMD" | sed -E \
       -e 's/^docker[[:space:]]+//' \

--- a/hooks/test-rtk-rewrite.sh
+++ b/hooks/test-rtk-rewrite.sh
@@ -145,9 +145,13 @@ test_rewrite "env + npm run" \
   "NODE_ENV=test npm run test:e2e" \
   "NODE_ENV=test rtk npm test:e2e"
 
-test_rewrite "env + docker compose" \
+test_rewrite "env + docker compose (unsupported subcommand, NOT rewritten)" \
   "COMPOSE_PROJECT_NAME=test docker compose up -d" \
-  "COMPOSE_PROJECT_NAME=test rtk docker compose up -d"
+  ""
+
+test_rewrite "env + docker compose logs (supported, rewritten)" \
+  "COMPOSE_PROJECT_NAME=test docker compose logs web" \
+  "COMPOSE_PROJECT_NAME=test rtk docker compose logs web"
 
 echo ""
 
@@ -173,17 +177,29 @@ test_rewrite "npx vue-tsc --noEmit" \
   "npx vue-tsc --noEmit" \
   "rtk tsc --noEmit"
 
-test_rewrite "docker compose up -d" \
+test_rewrite "docker compose up -d (NOT rewritten — unsupported by rtk)" \
   "docker compose up -d" \
-  "rtk docker compose up -d"
+  ""
 
 test_rewrite "docker compose logs postgrest" \
   "docker compose logs postgrest" \
   "rtk docker compose logs postgrest"
 
-test_rewrite "docker compose down" \
+test_rewrite "docker compose ps" \
+  "docker compose ps" \
+  "rtk docker compose ps"
+
+test_rewrite "docker compose build" \
+  "docker compose build" \
+  "rtk docker compose build"
+
+test_rewrite "docker compose down (NOT rewritten — unsupported by rtk)" \
   "docker compose down" \
-  "rtk docker compose down"
+  ""
+
+test_rewrite "docker compose -f file.yml up (NOT rewritten — flag before subcommand)" \
+  "docker compose -f docker-compose.preview.yml --project-name myapp up -d --build" \
+  ""
 
 test_rewrite "docker run --rm postgres" \
   "docker run --rm postgres" \


### PR DESCRIPTION
Fixes #244

The hook was rewriting all `docker compose` commands to `rtk docker compose`, but rtk only supports `ps`, `logs`, and `build` as compose subcommands. Everything else (`up`, `down`, `exec`, `restart`...) and compose-level flags (`-f`, `--project-name`, `--env-file`) caused failures like:

```
error: unexpected argument '-f' found
```

This PR applies the same filtering approach already used by the regular `docker` branch: only rewrite when the subcommand is known to be supported.

### Changes

- `rtk-rewrite.sh`: Extract compose subcommand and match against `ps|logs|build` before rewriting
- `test-rtk-rewrite.sh`: Updated compose tests to expect passthrough for unsupported subcommands, added coverage for `ps`, `build`, `-f` flag, and env var prefix with supported/unsupported subcommands

### Test results

All docker compose tests pass. The 9 pre-existing failures (find, tree, wget, audit) are unrelated.