### PR TITLE
fix(hooks): only rewrite supported docker compose subcommands (fixes #244)

### DIFF
--- a/.claude/hooks/rtk-rewrite.sh
+++ b/.claude/hooks/rtk-rewrite.sh
@@ -158,7 +158,23 @@ elif echo "$MATCH_CMD" | grep -qE '^(npx[[:space:]]+)?prisma([[:space:]]|$)'; th
 
 # --- Containers (added: docker compose, docker run/build/exec, kubectl describe/apply) ---
 elif echo "$MATCH_CMD" | grep -qE '^docker[[:space:]]+compose([[:space:]]|$)'; then
-  REWRITTEN="${ENV_PREFIX}$(echo "$CMD_BODY" | sed 's/^docker /rtk docker /')"
+  # Only rewrite supported compose subcommands (ps, logs, build).
+  # Strip compose-level flags (-f/--file, -p/--project-name, --profile, etc.)
+  # that appear before the subcommand, then check what subcommand remains.
+  COMPOSE_SUBCMD=$(echo "$MATCH_CMD" | sed -E \
+    -e 's/^docker[[:space:]]+compose[[:space:]]*//' \
+    -e 's/(-f|--file)[[:space:]]+[^[:space:]]+[[:space:]]*//g' \
+    -e 's/(-p|--project-name)[[:space:]]+[^[:space:]]+[[:space:]]*//g' \
+    -e 's/--profile[[:space:]]+[^[:space:]]+[[:space:]]*//g' \
+    -e 's/--env-file[[:space:]]+[^[:space:]]+[[:space:]]*//g' \
+    -e 's/--project-directory[[:space:]]+[^[:space:]]+[[:space:]]*//g' \
+    -e 's/--[a-z-]+=[^[:space:]]+[[:space:]]*//g' \
+    -e 's/^[[:space:]]*//')
+  case "$COMPOSE_SUBCMD" in
+    ps|ps\ *|logs|logs\ *|build|build\ *)
+      REWRITTEN="${ENV_PREFIX}$(echo "$CMD_BODY" | sed 's/^docker /rtk docker /')"
+      ;;
+  esac
 elif echo "$MATCH_CMD" | grep -qE '^docker[[:space:]]+(ps|images|logs|run|build|exec)([[:space:]]|$)'; then
   REWRITTEN="${ENV_PREFIX}$(echo "$CMD_BODY" | sed 's/^docker /rtk docker /')"
 elif echo "$MATCH_CMD" | grep -qE '^kubectl[[:space:]]+(get|logs|describe|apply)([[:space:]]|$)'; then

--- a/hooks/rtk-rewrite.sh
+++ b/hooks/rtk-rewrite.sh
@@ -129,7 +129,23 @@ elif echo "$MATCH_CMD" | grep -qE '^(npx[[:space:]]+)?prisma([[:space:]]|$)'; th
 # --- Containers (added: docker compose, docker run/build/exec, kubectl describe/apply) ---
 elif echo "$MATCH_CMD" | grep -qE '^docker[[:space:]]'; then
   if echo "$MATCH_CMD" | grep -qE '^docker[[:space:]]+compose([[:space:]]|$)'; then
-    REWRITTEN="${ENV_PREFIX}$(echo "$CMD_BODY" | sed 's/^docker /rtk docker /')"
+    # Only rewrite supported compose subcommands (ps, logs, build).
+    # Strip compose-level flags (-f/--file, -p/--project-name, --profile, etc.)
+    # that appear before the subcommand, then check what subcommand remains.
+    COMPOSE_SUBCMD=$(echo "$MATCH_CMD" | sed -E \
+      -e 's/^docker[[:space:]]+compose[[:space:]]*//' \
+      -e 's/(-f|--file)[[:space:]]+[^[:space:]]+[[:space:]]*//g' \
+      -e 's/(-p|--project-name)[[:space:]]+[^[:space:]]+[[:space:]]*//g' \
+      -e 's/--profile[[:space:]]+[^[:space:]]+[[:space:]]*//g' \
+      -e 's/--env-file[[:space:]]+[^[:space:]]+[[:space:]]*//g' \
+      -e 's/--project-directory[[:space:]]+[^[:space:]]+[[:space:]]*//g' \
+      -e 's/--[a-z-]+=[^[:space:]]+[[:space:]]*//g' \
+      -e 's/^[[:space:]]*//')
+    case "$COMPOSE_SUBCMD" in
+      ps|ps\ *|logs|logs\ *|build|build\ *)
+        REWRITTEN="${ENV_PREFIX}$(echo "$CMD_BODY" | sed 's/^docker /rtk docker /')"
+        ;;
+    esac
   else
     DOCKER_SUBCMD=$(echo "$MATCH_CMD" | sed -E \
       -e 's/^docker[[:space:]]+//' \

--- a/hooks/test-rtk-rewrite.sh
+++ b/hooks/test-rtk-rewrite.sh
@@ -145,9 +145,13 @@ test_rewrite "env + npm run" \
   "NODE_ENV=test npm run test:e2e" \
   "NODE_ENV=test rtk npm test:e2e"
 
-test_rewrite "env + docker compose" \
+test_rewrite "env + docker compose logs (supported subcommand)" \
+  "COMPOSE_PROJECT_NAME=test docker compose logs" \
+  "COMPOSE_PROJECT_NAME=test rtk docker compose logs"
+
+test_rewrite "env + docker compose up -d (NOT rewritten — unsupported subcommand)" \
   "COMPOSE_PROJECT_NAME=test docker compose up -d" \
-  "COMPOSE_PROJECT_NAME=test rtk docker compose up -d"
+  ""
 
 echo ""
 
@@ -173,17 +177,41 @@ test_rewrite "npx vue-tsc --noEmit" \
   "npx vue-tsc --noEmit" \
   "rtk tsc --noEmit"
 
-test_rewrite "docker compose up -d" \
+test_rewrite "docker compose up -d (NOT rewritten — unsupported subcommand)" \
   "docker compose up -d" \
-  "rtk docker compose up -d"
+  ""
 
 test_rewrite "docker compose logs postgrest" \
   "docker compose logs postgrest" \
   "rtk docker compose logs postgrest"
 
-test_rewrite "docker compose down" \
+test_rewrite "docker compose down (NOT rewritten — unsupported subcommand)" \
   "docker compose down" \
-  "rtk docker compose down"
+  ""
+
+test_rewrite "docker compose ps" \
+  "docker compose ps" \
+  "rtk docker compose ps"
+
+test_rewrite "docker compose build web" \
+  "docker compose build web" \
+  "rtk docker compose build web"
+
+test_rewrite "docker compose -f my-file.yml up -d (NOT rewritten — compose-level flag + unsupported subcommand)" \
+  "docker compose -f my-file.yml up -d --build" \
+  ""
+
+test_rewrite "docker compose -f my-file.yml ps (compose-level flag, supported subcommand)" \
+  "docker compose -f my-file.yml ps" \
+  "rtk docker compose -f my-file.yml ps"
+
+test_rewrite "docker compose exec service cmd (NOT rewritten — unsupported subcommand)" \
+  "docker compose exec app bash" \
+  ""
+
+test_rewrite "docker compose restart (NOT rewritten — unsupported subcommand)" \
+  "docker compose restart" \
+  ""
 
 test_rewrite "docker run --rm postgres" \
   "docker run --rm postgres" \


### PR DESCRIPTION
## Summary

- The rewrite hook was unconditionally rewriting **all** `docker compose` commands to `rtk docker compose`, but RTK only supports `ps`, `logs`, and `build` as compose subcommands
- Unsupported subcommands (`up`, `down`, `exec`, `restart`, etc.) caused clap parse failures because RTK has no handler for them at the flag level
- Compose-level flags like `-f my-file.yml` (before the subcommand) always failed with "unexpected argument" since they're not in RTK's clap schema
- Applied the same subcommand-filtering approach already used for regular `docker` commands: extract the compose subcommand (after stripping compose-level flags), and only rewrite if it's `ps`, `logs`, or `build`; everything else passes through unchanged

Fixes #244. Same family of issue as #236.

## Changes

**`.claude/hooks/rtk-rewrite.sh`** and **`hooks/rtk-rewrite.sh`**: Replace the unconditional `docker compose` rewrite with subcommand-aware filtering:
- Strip compose-level flags: `-f`/`--file`, `-p`/`--project-name`, `--profile`, `--env-file`, `--project-directory`
- Only rewrite `ps`, `logs`, `build` subcommands
- All other subcommands (`up`, `down`, `exec`, `restart`, etc.) are left unchanged

**`hooks/test-rtk-rewrite.sh`**: Updated test expectations to match the new behavior and added new test cases:
- `docker compose up -d` → no rewrite
- `docker compose down` → no rewrite
- `docker compose -f my-file.yml up -d --build` → no rewrite
- `docker compose ps` → rewrites
- `docker compose build web` → rewrites
- `docker compose -f my-file.yml ps` → rewrites (flag stripped, subcommand supported)
- `docker compose exec app bash` → no rewrite
- `docker compose restart` → no rewrite

## Test plan

- [ ] Run `bash hooks/test-rtk-rewrite.sh` (requires `jq` and `rtk` installed)
- [ ] Manually verify: `docker compose -f my-file.yml up -d` no longer gets rewritten by the hook
- [ ] Manually verify: `docker compose ps` still gets rewritten to `rtk docker compose ps`
- [ ] Manually verify: `docker compose logs myservice` still gets rewritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)