### PR TITLE
Fix git show rev:path output formatting and duplication

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -135,7 +135,11 @@ fn run_show(args: &[String], max_lines: Option<usize>, verbose: u8) -> Result<()
         .iter()
         .any(|arg| arg.starts_with("--pretty") || arg.starts_with("--format"));
 
-    if wants_stat_only || wants_format {
+    // `git show rev:path` prints a blob, not a commit diff. In this mode we should
+    // pass through directly to avoid duplicated output from compact-show steps.
+    let wants_blob_show = args.iter().any(|arg| is_blob_show_arg(arg));
+
+    if wants_stat_only || wants_format || wants_blob_show {
         let mut cmd = Command::new("git");
         cmd.arg("show");
         for arg in args {
@@ -148,7 +152,11 @@ fn run_show(args: &[String], max_lines: Option<usize>, verbose: u8) -> Result<()
             std::process::exit(output.status.code().unwrap_or(1));
         }
         let stdout = String::from_utf8_lossy(&output.stdout);
-        println!("{}", stdout.trim());
+        if wants_blob_show {
+            print!("{}", stdout);
+        } else {
+            println!("{}", stdout.trim());
+        }
 
         timer.track(
             &format!("git show {}", args.join(" ")),
@@ -227,6 +235,11 @@ fn run_show(args: &[String], max_lines: Option<usize>, verbose: u8) -> Result<()
     );
 
     Ok(())
+}
+
+fn is_blob_show_arg(arg: &str) -> bool {
+    // Detect `rev:path` style arguments while ignoring flags like `--pretty=format:...`.
+    !arg.starts_with('-') && arg.contains(':')
 }
 
 pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
@@ -1340,6 +1353,15 @@ mod tests {
         let result = compact_diff(diff, 100);
         assert!(result.contains("foo.rs"));
         assert!(result.contains("+"));
+    }
+
+    #[test]
+    fn test_is_blob_show_arg() {
+        assert!(is_blob_show_arg("develop:modules/pairs_backtest.py"));
+        assert!(is_blob_show_arg("HEAD:src/main.rs"));
+        assert!(!is_blob_show_arg("--pretty=format:%h"));
+        assert!(!is_blob_show_arg("--format=short"));
+        assert!(!is_blob_show_arg("HEAD"));
     }
 
     #[test]


### PR DESCRIPTION
**Title:** Fix duplicate and truncated output for `git show rev:path` commands

## Description

**Motivation and Context**
Previously, when using this tool to view the contents of a specific file at a specific revision (e.g., `git show <rev>:<path>`), the tool failed to recognize it as a raw blob request. Instead, it treated the output as a standard commit diff.

This resulted in two critical bugs:
1. **Duplicated Output:** Because the raw file blob was incorrectly passed down to the diff formatting/compacting logic, the file contents were printed multiple times. 
2. **Corrupted File Content:** In the fallback passthrough mode, the output was unconditionally printed using `println!("{}", stdout.trim());`. This stripped all intentional leading/trailing empty lines and forced an unwanted trailing newline.

**Steps to Reproduce the Bug:**
Running a command piped to `grep`, such as:
```bash
rtk git show develop:modules/pairs_backtest.py | grep -n "def _align_arrays"
```
*Expected:* A single line showing the matched function signature.
*Actual:* Duplicate matches returned because the wrapper output the entire file contents twice.

**Changes Proposed**

* **Added `is_blob_show_arg`:** A helper function to detect the `rev:path` syntax (arguments containing `:` and not starting with `-`).
* **Introduced `wants_blob_show` flag:** When a blob request is detected, the command execution routes to a strict passthrough mode.
* **Fixed Output Formatting:** For blob outputs, the code now uses `print!("{}", stdout);` instead of `println!("{}", stdout.trim());`, ensuring the raw file content is preserved exactly as Git outputs it.
* **Added Unit Tests:** Included `test_is_blob_show_arg` to verify the argument parsing logic handles branches, paths, and formatting flags correctly.

**Type of Change**

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Refactoring

**Testing**

* Added unit tests for argument detection (`test_is_blob_show_arg`).
* Manually verified that `rtk git show develop:modules/pairs_backtest.py | grep` now correctly outputs exactly one match, and file trailing newlines are perfectly preserved.
