### PR TITLE
fix: remove remaining personal project reference from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,7 +376,7 @@ pub fn execute_with_filter(cmd: &str, args: &[&str]) -> Result<()> {
   - `rtk prisma`: Prisma CLI without ASCII art (88% reduction)
 - **Shared Infrastructure**: utils.rs module for package manager auto-detection
 - **Features**: Exit code preservation, error grouping, consistent formatting
-- **Testing**: Validated on production T3 Stack project (methode-aristote/app)
+- **Testing**: Validated on a production T3 Stack project
 
 ### Python & Go Support (2026-02-12)
 - **Python Commands**: 3 commands for Python development workflows


### PR DESCRIPTION
## Summary

- Remove `methode-aristote/app` reference from the JS/TS tooling section (line 379)

Follow-up to #242 (merged). That PR removed 3 personal references; this removes the last one that was missed.

## Changes

`CLAUDE.md` line 379: `Validated on production T3 Stack project (methode-aristote/app)` → `Validated on a production T3 Stack project`

🤖 Generated with [Claude Code](https://claude.com/claude-code)