### PR TITLE
ci: replace x86_64-unknown-linux-gnu with musl target for static binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,10 @@ jobs:
             os: macos-latest
             archive: tar.gz
           # Linux
-          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             archive: tar.gz
+            musl: true
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             archive: tar.gz
@@ -62,6 +63,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+
+      - name: Install musl tools
+        if: matrix.musl
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
 
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
@@ -215,7 +222,7 @@ jobs:
           echo "mac_arm=$(grep aarch64-apple-darwin.tar.gz checksums.txt | head -1 | awk '{print $1}')" >> $GITHUB_OUTPUT
           echo "mac_intel=$(grep x86_64-apple-darwin.tar.gz checksums.txt | head -1 | awk '{print $1}')" >> $GITHUB_OUTPUT
           echo "linux_arm=$(grep aarch64-unknown-linux-gnu.tar.gz checksums.txt | head -1 | awk '{print $1}')" >> $GITHUB_OUTPUT
-          echo "linux_intel=$(grep x86_64-unknown-linux-gnu.tar.gz checksums.txt | head -1 | awk '{print $1}')" >> $GITHUB_OUTPUT
+          echo "linux_intel=$(grep x86_64-unknown-linux-musl.tar.gz checksums.txt | head -1 | awk '{print $1}')" >> $GITHUB_OUTPUT
 
       - name: Generate formula
         run: |
@@ -236,7 +243,7 @@ jobs:
               url "https://github.com/rtk-ai/rtk/releases/download/TAG_PLACEHOLDER/rtk-aarch64-unknown-linux-gnu.tar.gz"
               sha256 "SHA_LINUX_ARM_PLACEHOLDER"
             elsif OS.linux? && Hardware::CPU.intel?
-              url "https://github.com/rtk-ai/rtk/releases/download/TAG_PLACEHOLDER/rtk-x86_64-unknown-linux-gnu.tar.gz"
+              url "https://github.com/rtk-ai/rtk/releases/download/TAG_PLACEHOLDER/rtk-x86_64-unknown-linux-musl.tar.gz"
               sha256 "SHA_LINUX_INTEL_PLACEHOLDER"
             end
 

--- a/install.sh
+++ b/install.sh
@@ -57,7 +57,10 @@ get_latest_version() {
 get_target() {
     case "$OS" in
         linux)
-            TARGET="${ARCH}-unknown-linux-gnu"
+            case "$ARCH" in
+                x86_64)  TARGET="x86_64-unknown-linux-musl";;
+                aarch64) TARGET="aarch64-unknown-linux-gnu";;
+            esac
             ;;
         darwin)
             TARGET="${ARCH}-apple-darwin"


### PR DESCRIPTION
The current x86_64-unknown-linux-gnu release binary dynamically links against glibc, which causes failures on systems with an older glibc version:

rtk: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by rtk)

This PR replaces the x86_64-unknown-linux-gnu build target with x86_64-unknown-linux-musl, producing a fully statically-linked binary with no libc dependency.