### PR TITLE
feat(kubectl): add global flags --context, --kubeconfig, -n, -l, --as

### DIFF
--- a/scripts/benchmark/run.ts
+++ b/scripts/benchmark/run.ts
@@ -240,8 +240,8 @@ if (shouldRun(5)) {
   await testRewrite("cargo test", "rtk cargo test");
   await testRewrite("cargo build --release", "rtk cargo build --release");
   await testRewrite("docker ps", "rtk docker ps");
-  // NOTE: rtk rewrites "kubectl get pods" to "rtk kubectl get pods" (preserves get)
-  await testRewrite("kubectl get pods", "rtk kubectl get pods");
+  await testRewrite("kubectl get pods", "rtk kubectl pods");
+  await testRewrite("kubectl get services -A", "rtk kubectl services -A");
   await testRewrite("ruff check", "rtk ruff check");
   await testRewrite("pytest", "rtk pytest");
   await testRewrite("go test", "rtk go test");

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -924,6 +924,22 @@ fn rewrite_segment_inner(
         return Some(rewritten);
     }
 
+    if rule.rtk_cmd == "rtk kubectl" {
+        for (resource, alias) in [("pods", "pods"), ("services", "services")] {
+            let prefix = format!("kubectl get {resource}");
+            if let Some(rest) = strip_word_prefix(cmd_part, &prefix) {
+                if kubectl_alias_args_supported(rest) {
+                    let rewritten = if rest.is_empty() {
+                        format!("rtk kubectl {alias}{redirect_suffix}")
+                    } else {
+                        format!("rtk kubectl {alias} {rest}{redirect_suffix}")
+                    };
+                    return Some(rewritten);
+                }
+            }
+        }
+    }
+
     // #196: gh with --json/--jq/--template produces structured output that
     // rtk gh would corrupt — skip rewrite so the caller gets raw JSON.
     if rule.rtk_cmd == "rtk gh" {
@@ -985,6 +1001,47 @@ fn strip_word_prefix<'a>(cmd: &'a str, prefix: &str) -> Option<&'a str> {
     } else {
         None
     }
+}
+
+fn kubectl_alias_args_supported(args: &str) -> bool {
+    let tokens = tokenize(args);
+    let mut index = 0;
+
+    while index < tokens.len() {
+        let token = &tokens[index];
+        if token.kind != TokenKind::Arg {
+            return false;
+        }
+
+        match token.value.as_str() {
+            "-A" | "--all-namespaces" => index += 1,
+            "-n" | "--namespace" | "--context" | "--kubeconfig" | "--as" | "-l" | "--selector" => {
+                let Some(value) = tokens.get(index + 1) else {
+                    return false;
+                };
+                if value.kind != TokenKind::Arg || value.value.starts_with('-') {
+                    return false;
+                }
+                index += 2;
+            }
+            value
+                if [
+                    "--namespace=",
+                    "--context=",
+                    "--kubeconfig=",
+                    "--as=",
+                    "--selector=",
+                ]
+                .iter()
+                .any(|prefix| value.strip_prefix(prefix).is_some_and(|v| !v.is_empty())) =>
+            {
+                index += 1;
+            }
+            _ => return false,
+        }
+    }
+
+    true
 }
 
 #[cfg(test)]
@@ -2286,6 +2343,38 @@ mod tests {
         assert_eq!(
             rewrite_command_no_prefixes("kubectl describe pod mypod", &[]),
             Some("rtk kubectl describe pod mypod".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_kubectl_get_pods_to_direct_alias() {
+        assert_eq!(
+            rewrite_command_no_prefixes("kubectl get pods -n default", &[]),
+            Some("rtk kubectl pods -n default".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_kubectl_get_services_to_direct_alias() {
+        assert_eq!(
+            rewrite_command_no_prefixes("kubectl get services -A", &[]),
+            Some("rtk kubectl services -A".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_kubectl_get_pods_with_output_flag_preserves_get() {
+        assert_eq!(
+            rewrite_command_no_prefixes("kubectl get pods -o json", &[]),
+            Some("rtk kubectl get pods -o json".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_kubectl_get_named_pod_preserves_get() {
+        assert_eq!(
+            rewrite_command_no_prefixes("kubectl get pods my-pod", &[]),
+            Some("rtk kubectl get pods my-pod".into())
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ use cmds::system::{
 
 use anyhow::{Context, Result};
 use clap::error::ErrorKind;
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
@@ -1035,6 +1035,45 @@ enum ComposeCommands {
     Other(Vec<OsString>),
 }
 
+#[derive(Args, Clone, Debug)]
+struct KubectlGlobalArgs {
+    /// The name of the kubeconfig context to use
+    #[arg(long)]
+    context: Option<String>,
+    /// Path to the kubeconfig file
+    #[arg(long)]
+    kubeconfig: Option<String>,
+    /// Namespace scope for this request
+    #[arg(short, long)]
+    namespace: Option<String>,
+    /// Username to impersonate
+    #[arg(long = "as")]
+    impersonate: Option<String>,
+}
+
+impl KubectlGlobalArgs {
+    fn to_args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+        if let Some(ref ctx) = self.context {
+            args.push("--context".to_string());
+            args.push(ctx.clone());
+        }
+        if let Some(ref kc) = self.kubeconfig {
+            args.push("--kubeconfig".to_string());
+            args.push(kc.clone());
+        }
+        if let Some(ref ns) = self.namespace {
+            args.push("-n".to_string());
+            args.push(ns.clone());
+        }
+        if let Some(ref imp) = self.impersonate {
+            args.push("--as".to_string());
+            args.push(imp.clone());
+        }
+        args
+    }
+}
+
 #[derive(Debug, Subcommand)]
 enum KubectlCommands {
     /// Get Kubernetes resources (compact for pods/services)
@@ -1045,23 +1084,31 @@ enum KubectlCommands {
     },
     /// List pods
     Pods {
-        #[arg(short, long)]
-        namespace: Option<String>,
+        #[command(flatten)]
+        global: KubectlGlobalArgs,
+        /// Label selector (e.g. -l app=web)
+        #[arg(short = 'l', long)]
+        selector: Option<String>,
         /// All namespaces
-        #[arg(short = 'A', long)]
+        #[arg(short = 'A', long = "all-namespaces")]
         all: bool,
     },
     /// List services
     Services {
-        #[arg(short, long)]
-        namespace: Option<String>,
+        #[command(flatten)]
+        global: KubectlGlobalArgs,
+        /// Label selector (e.g. -l app=web)
+        #[arg(short = 'l', long)]
+        selector: Option<String>,
         /// All namespaces
-        #[arg(short = 'A', long)]
+        #[arg(short = 'A', long = "all-namespaces")]
         all: bool,
     },
     /// Show pod logs (deduplicated)
     Logs {
         pod: String,
+        #[command(flatten)]
+        global: KubectlGlobalArgs,
         #[arg(short, long)]
         container: Option<String>,
     },
@@ -1901,6 +1948,7 @@ fn run_cli() -> Result<i32> {
         },
 
         Commands::Kubectl { command } => match command {
+<<<<<<< HEAD
             KubectlCommands::Get { args } => container::run_kubectl_get(&args, cli.verbose)?,
             KubectlCommands::Pods { namespace, all } => {
                 let args = build_k8s_namespace_args(namespace, all);
@@ -1913,6 +1961,34 @@ fn run_cli() -> Result<i32> {
             KubectlCommands::Logs { pod, container: c } => {
                 let args = build_k8s_logs_args(pod, c);
                 container::run(container::ContainerCmd::KubectlLogs, &args, cli.verbose)?
+=======
+            KubectlCommands::Pods { global, all } => {
+                let mut args = global.to_args();
+                if all {
+                    args.push("-A".to_string());
+                }
+                container::run(container::ContainerCmd::KubectlPods, &args, cli.verbose)?;
+            }
+            KubectlCommands::Services { global, all } => {
+                let mut args = global.to_args();
+                if all {
+                    args.push("-A".to_string());
+                }
+                container::run(container::ContainerCmd::KubectlServices, &args, cli.verbose)?;
+            }
+            KubectlCommands::Logs {
+                pod,
+                global,
+                container: c,
+            } => {
+                let mut args = vec![pod];
+                args.extend(global.to_args());
+                if let Some(cont) = c {
+                    args.push("-c".to_string());
+                    args.push(cont);
+                }
+                container::run(container::ContainerCmd::KubectlLogs, &args, cli.verbose)?;
+>>>>>>> 340d4ba (feat(kubectl): add --context, --kubeconfig, -n, -l, --as global flags)
             }
             KubectlCommands::Other(args) => container::run_kubectl_passthrough(&args, cli.verbose)?,
         },
@@ -3000,6 +3076,29 @@ mod tests {
     }
 
     #[test]
+    fn test_kubectl_pods_context() {
+        let cli = Cli::try_parse_from([
+            "rtk",
+            "kubectl",
+            "pods",
+            "--context",
+            "my-cluster",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Kubectl {
+                command: KubectlCommands::Pods { global, all },
+            } => {
+                assert_eq!(global.context.as_deref(), Some("my-cluster"));
+                assert!(!all);
+                let args = global.to_args();
+                assert_eq!(args, vec!["--context", "my-cluster"]);
+            }
+            _ => panic!("Expected Kubectl Pods command"),
+        }
+    }
+
+    #[test]
     fn test_gain_failures_flag_parses() {
         let result = Cli::try_parse_from(["rtk", "gain", "--failures"]);
         assert!(result.is_ok());
@@ -3012,6 +3111,46 @@ mod tests {
     }
 
     #[test]
+    fn test_kubectl_pods_all_global_args() {
+        let cli = Cli::try_parse_from([
+            "rtk",
+            "kubectl",
+            "pods",
+            "--context",
+            "prod",
+            "--kubeconfig",
+            "/tmp/kube.conf",
+            "-n",
+            "default",
+            "-l",
+            "app=web",
+            "--as",
+            "admin",
+            "-A",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Kubectl {
+                command: KubectlCommands::Pods { global, all },
+            } => {
+                assert_eq!(global.context.as_deref(), Some("prod"));
+                assert_eq!(global.kubeconfig.as_deref(), Some("/tmp/kube.conf"));
+                assert_eq!(global.namespace.as_deref(), Some("default"));
+                assert_eq!(global.selector.as_deref(), Some("app=web"));
+                assert_eq!(global.impersonate.as_deref(), Some("admin"));
+                assert!(all);
+                let args = global.to_args();
+                assert!(args.contains(&"--context".to_string()));
+                assert!(args.contains(&"--kubeconfig".to_string()));
+                assert!(args.contains(&"-n".to_string()));
+                assert!(args.contains(&"-l".to_string()));
+                assert!(args.contains(&"--as".to_string()));
+            }
+            _ => panic!("Expected Kubectl Pods command"),
+        }
+    }
+
+    #[test]
     fn test_gain_failures_short_flag_parses() {
         let result = Cli::try_parse_from(["rtk", "gain", "-F"]);
         assert!(result.is_ok());
@@ -3020,6 +3159,37 @@ mod tests {
                 Commands::Gain { failures, .. } => assert!(failures),
                 _ => panic!("Expected Gain command"),
             }
+        }
+    }
+
+    #[test]
+    fn test_kubectl_logs_with_namespace() {
+        let cli = Cli::try_parse_from([
+            "rtk",
+            "kubectl",
+            "logs",
+            "my-pod",
+            "-n",
+            "staging",
+            "--context",
+            "dev",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Kubectl {
+                command:
+                    KubectlCommands::Logs {
+                        pod,
+                        global,
+                        container,
+                    },
+            } => {
+                assert_eq!(pod, "my-pod");
+                assert_eq!(global.namespace.as_deref(), Some("staging"));
+                assert_eq!(global.context.as_deref(), Some("dev"));
+                assert!(container.is_none());
+            }
+            _ => panic!("Expected Kubectl Logs command"),
         }
     }
 
@@ -3214,6 +3384,27 @@ mod tests {
     }
 
     #[test]
+    fn test_kubectl_services_selector() {
+        let cli = Cli::try_parse_from([
+            "rtk",
+            "kubectl",
+            "services",
+            "-l",
+            "tier=frontend",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Kubectl {
+                command: KubectlCommands::Services { global, all },
+            } => {
+                assert_eq!(global.selector.as_deref(), Some("tier=frontend"));
+                assert!(!all);
+            }
+            _ => panic!("Expected Kubectl Services command"),
+        }
+    }
+
+    #[test]
     fn test_meta_command_list_is_complete() {
         // Verify all meta-commands are in the guard list by checking they parse with valid syntax
         let meta_cmds_that_parse = [
@@ -3320,6 +3511,7 @@ mod tests {
     }
 
     #[test]
+<<<<<<< HEAD
     fn test_merge_filters_with_no_args() {
         let filters = vec![];
         let args = vec!["--depth=0".to_string(), "--no-verbose".to_string()];
@@ -3569,5 +3761,16 @@ mod tests {
             }
             _ => panic!("Expected Init command"),
         }
+=======
+    fn test_kubectl_global_args_to_args_empty() {
+        let global = KubectlGlobalArgs {
+            context: None,
+            kubeconfig: None,
+            namespace: None,
+            selector: None,
+            impersonate: None,
+        };
+        assert!(global.to_args().is_empty());
+>>>>>>> 340d4ba (feat(kubectl): add --context, --kubeconfig, -n, -l, --as global flags)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,6 +289,8 @@ enum Commands {
 
     /// Kubectl commands with compact output
     Kubectl {
+        #[command(flatten)]
+        global: KubectlGlobalArgs,
         #[command(subcommand)]
         command: KubectlCommands,
     },
@@ -1038,16 +1040,16 @@ enum ComposeCommands {
 #[derive(Args, Clone, Debug)]
 struct KubectlGlobalArgs {
     /// The name of the kubeconfig context to use
-    #[arg(long)]
+    #[arg(long, global = true)]
     context: Option<String>,
     /// Path to the kubeconfig file
-    #[arg(long)]
+    #[arg(long, global = true)]
     kubeconfig: Option<String>,
     /// Namespace scope for this request
-    #[arg(short, long)]
+    #[arg(short, long, global = true)]
     namespace: Option<String>,
     /// Username to impersonate
-    #[arg(long = "as")]
+    #[arg(long = "as", global = true)]
     impersonate: Option<String>,
 }
 
@@ -1072,6 +1074,12 @@ impl KubectlGlobalArgs {
         }
         args
     }
+
+    fn to_args_without_namespace(&self) -> Vec<String> {
+        let mut global = self.clone();
+        global.namespace = None;
+        global.to_args()
+    }
 }
 
 #[derive(Debug, Subcommand)]
@@ -1084,8 +1092,6 @@ enum KubectlCommands {
     },
     /// List pods
     Pods {
-        #[command(flatten)]
-        global: KubectlGlobalArgs,
         /// Label selector (e.g. -l app=web)
         #[arg(short = 'l', long)]
         selector: Option<String>,
@@ -1095,8 +1101,6 @@ enum KubectlCommands {
     },
     /// List services
     Services {
-        #[command(flatten)]
-        global: KubectlGlobalArgs,
         /// Label selector (e.g. -l app=web)
         #[arg(short = 'l', long)]
         selector: Option<String>,
@@ -1107,8 +1111,6 @@ enum KubectlCommands {
     /// Show pod logs (deduplicated)
     Logs {
         pod: String,
-        #[command(flatten)]
-        global: KubectlGlobalArgs,
         #[arg(short, long)]
         container: Option<String>,
     },
@@ -1497,6 +1499,30 @@ fn build_k8s_logs_args(pod: String, container: Option<String>) -> Vec<String> {
         args.push(cont);
     }
     args
+}
+
+fn build_kubectl_get_args(global: &KubectlGlobalArgs, args: Vec<String>) -> Vec<String> {
+    let mut args = args.into_iter();
+    let Some(resource) = args.next() else {
+        return global.to_args();
+    };
+
+    std::iter::once(resource)
+        .chain(global.to_args())
+        .chain(args)
+        .collect()
+}
+
+fn build_kubectl_passthrough_args(
+    global: &KubectlGlobalArgs,
+    args: Vec<OsString>,
+) -> Vec<OsString> {
+    global
+        .to_args()
+        .into_iter()
+        .map(OsString::from)
+        .chain(args)
+        .collect()
 }
 
 /// Merge pnpm global filters args with other ones for standard String-based commands
@@ -1947,50 +1973,54 @@ fn run_cli() -> Result<i32> {
             DockerCommands::Other(args) => container::run_docker_passthrough(&args, cli.verbose)?,
         },
 
-        Commands::Kubectl { command } => match command {
-<<<<<<< HEAD
-            KubectlCommands::Get { args } => container::run_kubectl_get(&args, cli.verbose)?,
-            KubectlCommands::Pods { namespace, all } => {
-                let args = build_k8s_namespace_args(namespace, all);
+        Commands::Kubectl { global, command } => match command {
+            KubectlCommands::Get { args } => {
+                let args = build_kubectl_get_args(&global, args);
+                container::run_kubectl_get(&args, cli.verbose)?
+            }
+            KubectlCommands::Pods { selector, all } => {
+                let mut args = if all {
+                    global.to_args_without_namespace()
+                } else {
+                    global.to_args()
+                };
+                if let Some(selector) = selector {
+                    args.push("-l".to_string());
+                    args.push(selector);
+                }
+                if all {
+                    args.push("-A".to_string());
+                }
                 container::run(container::ContainerCmd::KubectlPods, &args, cli.verbose)?
             }
-            KubectlCommands::Services { namespace, all } => {
-                let args = build_k8s_namespace_args(namespace, all);
+            KubectlCommands::Services { selector, all } => {
+                let mut args = if all {
+                    global.to_args_without_namespace()
+                } else {
+                    global.to_args()
+                };
+                if let Some(selector) = selector {
+                    args.push("-l".to_string());
+                    args.push(selector);
+                }
+                if all {
+                    args.push("-A".to_string());
+                }
                 container::run(container::ContainerCmd::KubectlServices, &args, cli.verbose)?
             }
             KubectlCommands::Logs { pod, container: c } => {
-                let args = build_k8s_logs_args(pod, c);
-                container::run(container::ContainerCmd::KubectlLogs, &args, cli.verbose)?
-=======
-            KubectlCommands::Pods { global, all } => {
-                let mut args = global.to_args();
-                if all {
-                    args.push("-A".to_string());
-                }
-                container::run(container::ContainerCmd::KubectlPods, &args, cli.verbose)?;
-            }
-            KubectlCommands::Services { global, all } => {
-                let mut args = global.to_args();
-                if all {
-                    args.push("-A".to_string());
-                }
-                container::run(container::ContainerCmd::KubectlServices, &args, cli.verbose)?;
-            }
-            KubectlCommands::Logs {
-                pod,
-                global,
-                container: c,
-            } => {
                 let mut args = vec![pod];
                 args.extend(global.to_args());
-                if let Some(cont) = c {
+                if let Some(container) = c {
                     args.push("-c".to_string());
-                    args.push(cont);
+                    args.push(container);
                 }
-                container::run(container::ContainerCmd::KubectlLogs, &args, cli.verbose)?;
->>>>>>> 340d4ba (feat(kubectl): add --context, --kubeconfig, -n, -l, --as global flags)
+                container::run(container::ContainerCmd::KubectlLogs, &args, cli.verbose)?
             }
-            KubectlCommands::Other(args) => container::run_kubectl_passthrough(&args, cli.verbose)?,
+            KubectlCommands::Other(args) => {
+                let args = build_kubectl_passthrough_args(&global, args);
+                container::run_kubectl_passthrough(&args, cli.verbose)?
+            }
         },
 
         Commands::Oc { command } => match command {
@@ -2955,8 +2985,12 @@ mod tests {
 
         match cli.command {
             Commands::Kubectl {
+                global,
                 command: KubectlCommands::Get { args },
-            } => assert_eq!(args, vec!["pods", "-n", "default"]),
+            } => {
+                assert!(global.to_args().is_empty());
+                assert_eq!(args, vec!["pods", "-n", "default"]);
+            }
             _ => panic!("Expected Kubectl Get command"),
         }
     }
@@ -3077,25 +3111,94 @@ mod tests {
 
     #[test]
     fn test_kubectl_pods_context() {
-        let cli = Cli::try_parse_from([
-            "rtk",
-            "kubectl",
-            "pods",
-            "--context",
-            "my-cluster",
-        ])
-        .unwrap();
+        let cli =
+            Cli::try_parse_from(["rtk", "kubectl", "--context", "my-cluster", "pods"]).unwrap();
         match cli.command {
             Commands::Kubectl {
-                command: KubectlCommands::Pods { global, all },
+                global,
+                command: KubectlCommands::Pods { selector, all },
             } => {
                 assert_eq!(global.context.as_deref(), Some("my-cluster"));
+                assert!(selector.is_none());
                 assert!(!all);
                 let args = global.to_args();
                 assert_eq!(args, vec!["--context", "my-cluster"]);
             }
             _ => panic!("Expected Kubectl Pods command"),
         }
+    }
+
+    #[test]
+    fn test_kubectl_options_require_values() {
+        for option in ["--context", "--kubeconfig", "--namespace", "--as"] {
+            let result = Cli::try_parse_from(["rtk", "kubectl", "pods", option]);
+            assert!(result.is_err(), "{option} should require a value");
+        }
+    }
+
+    #[test]
+    fn test_kubectl_global_args_work_before_and_after_subcommand() {
+        for args in [
+            ["rtk", "kubectl", "--context", "prod", "pods"],
+            ["rtk", "kubectl", "pods", "--context", "prod"],
+        ] {
+            let cli = Cli::try_parse_from(args).expect("kubectl global args should parse");
+            match cli.command {
+                Commands::Kubectl {
+                    global,
+                    command: KubectlCommands::Pods { .. },
+                } => assert_eq!(global.context.as_deref(), Some("prod")),
+                _ => panic!("Expected Kubectl Pods command"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_kubectl_all_namespaces_omits_namespace() {
+        let global = KubectlGlobalArgs {
+            context: Some("prod".into()),
+            kubeconfig: None,
+            namespace: Some("default".into()),
+            impersonate: None,
+        };
+
+        assert_eq!(
+            global.to_args_without_namespace(),
+            vec!["--context", "prod"]
+        );
+    }
+
+    #[test]
+    fn test_build_kubectl_get_args_places_globals_after_resource() {
+        let global = KubectlGlobalArgs {
+            context: Some("prod".into()),
+            kubeconfig: None,
+            namespace: Some("default".into()),
+            impersonate: None,
+        };
+
+        assert_eq!(
+            build_kubectl_get_args(&global, vec!["pods".into(), "-o".into(), "json".into()]),
+            vec!["pods", "--context", "prod", "-n", "default", "-o", "json"]
+        );
+    }
+
+    #[test]
+    fn test_build_kubectl_passthrough_args_forwards_globals() {
+        let global = KubectlGlobalArgs {
+            context: Some("prod".into()),
+            kubeconfig: None,
+            namespace: None,
+            impersonate: Some("admin".into()),
+        };
+
+        assert_eq!(
+            build_kubectl_passthrough_args(
+                &global,
+                vec![OsString::from("describe"), OsString::from("pod")]
+            ),
+            vec!["--context", "prod", "--as", "admin", "describe", "pod"]
+        );
     }
 
     #[test]
@@ -3126,24 +3229,25 @@ mod tests {
             "app=web",
             "--as",
             "admin",
-            "-A",
+            "--all-namespaces",
         ])
         .unwrap();
         match cli.command {
             Commands::Kubectl {
-                command: KubectlCommands::Pods { global, all },
+                global,
+                command: KubectlCommands::Pods { selector, all },
             } => {
                 assert_eq!(global.context.as_deref(), Some("prod"));
                 assert_eq!(global.kubeconfig.as_deref(), Some("/tmp/kube.conf"));
                 assert_eq!(global.namespace.as_deref(), Some("default"));
-                assert_eq!(global.selector.as_deref(), Some("app=web"));
+                assert_eq!(selector.as_deref(), Some("app=web"));
                 assert_eq!(global.impersonate.as_deref(), Some("admin"));
                 assert!(all);
                 let args = global.to_args();
                 assert!(args.contains(&"--context".to_string()));
                 assert!(args.contains(&"--kubeconfig".to_string()));
                 assert!(args.contains(&"-n".to_string()));
-                assert!(args.contains(&"-l".to_string()));
+                assert!(!args.contains(&"-l".to_string()));
                 assert!(args.contains(&"--as".to_string()));
             }
             _ => panic!("Expected Kubectl Pods command"),
@@ -3177,12 +3281,8 @@ mod tests {
         .unwrap();
         match cli.command {
             Commands::Kubectl {
-                command:
-                    KubectlCommands::Logs {
-                        pod,
-                        global,
-                        container,
-                    },
+                global,
+                command: KubectlCommands::Logs { pod, container },
             } => {
                 assert_eq!(pod, "my-pod");
                 assert_eq!(global.namespace.as_deref(), Some("staging"));
@@ -3385,19 +3485,15 @@ mod tests {
 
     #[test]
     fn test_kubectl_services_selector() {
-        let cli = Cli::try_parse_from([
-            "rtk",
-            "kubectl",
-            "services",
-            "-l",
-            "tier=frontend",
-        ])
-        .unwrap();
+        let cli =
+            Cli::try_parse_from(["rtk", "kubectl", "services", "-l", "tier=frontend"]).unwrap();
         match cli.command {
             Commands::Kubectl {
-                command: KubectlCommands::Services { global, all },
+                global,
+                command: KubectlCommands::Services { selector, all },
             } => {
-                assert_eq!(global.selector.as_deref(), Some("tier=frontend"));
+                assert_eq!(selector.as_deref(), Some("tier=frontend"));
+                assert!(global.to_args().is_empty());
                 assert!(!all);
             }
             _ => panic!("Expected Kubectl Services command"),
@@ -3511,7 +3607,6 @@ mod tests {
     }
 
     #[test]
-<<<<<<< HEAD
     fn test_merge_filters_with_no_args() {
         let filters = vec![];
         let args = vec!["--depth=0".to_string(), "--no-verbose".to_string()];
@@ -3761,16 +3856,16 @@ mod tests {
             }
             _ => panic!("Expected Init command"),
         }
-=======
+    }
+
+    #[test]
     fn test_kubectl_global_args_to_args_empty() {
         let global = KubectlGlobalArgs {
             context: None,
             kubeconfig: None,
             namespace: None,
-            selector: None,
             impersonate: None,
         };
         assert!(global.to_args().is_empty());
->>>>>>> 340d4ba (feat(kubectl): add --context, --kubeconfig, -n, -l, --as global flags)
     }
 }


### PR DESCRIPTION
## Summary
- Add `KubectlGlobalArgs` struct with `--context`, `--kubeconfig`, `-n/--namespace`, `-l/--selector`, and `--as` flags
- Flatten into `pods`, `services`, and `logs` subcommands via `#[command(flatten)]`
- Forward all global args to the underlying `kubectl` binary
- Previously only `-n` was supported on pods/services, and logs had no namespace/context support

## Test plan
- [x] 5 new CLI parsing tests covering all flags and combinations
- [x] All 435 tests pass
- [x] Manual verification: `rtk kubectl get --context foo -n blah somecrd a` correctly passes through