### PR TITLE
Replace lazy_static with std::sync::LazyLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,7 +589,6 @@ dependencies = [
  "colored",
  "dirs",
  "ignore",
- "lazy_static",
  "regex",
  "rusqlite",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ anyhow = "1.0"
 ignore = "0.4"
 walkdir = "2"
 regex = "1"
-lazy_static = "1.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 colored = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rtk"
 version = "0.23.0"
 edition = "2021"
+rust-version = "1.80"
 authors = ["Patrick Szymkowiak"]
 description = "Rust Token Killer - High-performance CLI proxy to minimize LLM token consumption"
 license = "MIT"

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1,5 +1,5 @@
-use lazy_static::lazy_static;
 use regex::{Regex, RegexSet};
+use std::sync::LazyLock;
 
 /// A rule mapping a shell command pattern to its RTK equivalent.
 struct RtkRule {
@@ -288,17 +288,20 @@ const IGNORED_PREFIXES: &[&str] = &[
     "case ",
 ];
 
-const IGNORED_EXACT: &[&str] = &["cd", "echo", "true", "false", "wait", "pwd", "bash", "sh", "fi", "done"];
+const IGNORED_EXACT: &[&str] = &[
+    "cd", "echo", "true", "false", "wait", "pwd", "bash", "sh", "fi", "done",
+];
 
-lazy_static! {
-    static ref REGEX_SET: RegexSet = RegexSet::new(PATTERNS).expect("invalid regex patterns");
-    static ref COMPILED: Vec<Regex> = PATTERNS
+static REGEX_SET: LazyLock<RegexSet> =
+    LazyLock::new(|| RegexSet::new(PATTERNS).expect("invalid regex patterns"));
+static COMPILED: LazyLock<Vec<Regex>> = LazyLock::new(|| {
+    PATTERNS
         .iter()
         .map(|p| Regex::new(p).expect("invalid regex"))
-        .collect();
-    static ref ENV_PREFIX: Regex =
-        Regex::new(r"^(?:sudo\s+|env\s+|[A-Z_][A-Z0-9_]*=[^\s]*\s+)+").unwrap();
-}
+        .collect()
+});
+static ENV_PREFIX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(?:sudo\s+|env\s+|[A-Z_][A-Z0-9_]*=[^\s]*\s+)+").unwrap());
 
 /// Classify a single (already-split) command.
 pub fn classify_command(cmd: &str) -> Classification {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,6 +1,6 @@
-use lazy_static::lazy_static;
 use regex::Regex;
 use std::str::FromStr;
+use std::sync::LazyLock;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FilterLevel {
@@ -146,10 +146,8 @@ impl FilterStrategy for NoFilter {
 
 pub struct MinimalFilter;
 
-lazy_static! {
-    static ref MULTIPLE_BLANK_LINES: Regex = Regex::new(r"\n{3,}").unwrap();
-    static ref TRAILING_WHITESPACE: Regex = Regex::new(r"[ \t]+$").unwrap();
-}
+static MULTIPLE_BLANK_LINES: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\n{3,}").unwrap());
+static TRAILING_WHITESPACE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"[ \t]+$").unwrap());
 
 impl FilterStrategy for MinimalFilter {
     fn filter(&self, content: &str, lang: &Language) -> String {
@@ -227,14 +225,14 @@ impl FilterStrategy for MinimalFilter {
 
 pub struct AggressiveFilter;
 
-lazy_static! {
-    static ref IMPORT_PATTERN: Regex =
-        Regex::new(r"^(use |import |from |require\(|#include)").unwrap();
-    static ref FUNC_SIGNATURE: Regex = Regex::new(
-        r"^(pub\s+)?(async\s+)?(fn|def|function|func|class|struct|enum|trait|interface|type)\s+\w+"
+static IMPORT_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(use |import |from |require\(|#include)").unwrap());
+static FUNC_SIGNATURE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"^(pub\s+)?(async\s+)?(fn|def|function|func|class|struct|enum|trait|interface|type)\s+\w+",
     )
-    .unwrap();
-}
+    .unwrap()
+});
 
 impl FilterStrategy for AggressiveFilter {
     fn filter(&self, content: &str, lang: &Language) -> String {

--- a/src/gh_cmd.rs
+++ b/src/gh_cmd.rs
@@ -8,20 +8,19 @@ use crate::json_cmd;
 use crate::tracking;
 use crate::utils::{ok_confirmation, truncate};
 use anyhow::{Context, Result};
-use lazy_static::lazy_static;
 use regex::Regex;
 use serde_json::Value;
 use std::process::Command;
+use std::sync::LazyLock;
 
-lazy_static! {
-    static ref HTML_COMMENT_RE: Regex = Regex::new(r"(?s)<!--.*?-->").unwrap();
-    static ref BADGE_LINE_RE: Regex =
-        Regex::new(r"(?m)^\s*\[!\[[^\]]*\]\([^)]*\)\]\([^)]*\)\s*$").unwrap();
-    static ref IMAGE_ONLY_LINE_RE: Regex = Regex::new(r"(?m)^\s*!\[[^\]]*\]\([^)]*\)\s*$").unwrap();
-    static ref HORIZONTAL_RULE_RE: Regex =
-        Regex::new(r"(?m)^\s*(?:---+|\*\*\*+|___+)\s*$").unwrap();
-    static ref MULTI_BLANK_RE: Regex = Regex::new(r"\n{3,}").unwrap();
-}
+static HTML_COMMENT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?s)<!--.*?-->").unwrap());
+static BADGE_LINE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?m)^\s*\[!\[[^\]]*\]\([^)]*\)\]\([^)]*\)\s*$").unwrap());
+static IMAGE_ONLY_LINE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?m)^\s*!\[[^\]]*\]\([^)]*\)\s*$").unwrap());
+static HORIZONTAL_RULE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?m)^\s*(?:---+|\*\*\*+|___+)\s*$").unwrap());
+static MULTI_BLANK_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\n{3,}").unwrap());
 
 /// Filter markdown body to remove noise while preserving meaningful content.
 /// Removes HTML comments, badge lines, image-only lines, horizontal rules,

--- a/src/go_cmd.rs
+++ b/src/go_cmd.rs
@@ -267,8 +267,7 @@ fn filter_go_test_json(output: &str) -> String {
         // Handle build-output/build-fail events (use ImportPath, no Package)
         match event.action.as_str() {
             "build-output" => {
-                if let (Some(import_path), Some(output_text)) =
-                    (&event.import_path, &event.output)
+                if let (Some(import_path), Some(output_text)) = (&event.import_path, &event.output)
                 {
                     let text = output_text.trim_end().to_string();
                     if !text.is_empty() {

--- a/src/learn/detector.rs
+++ b/src/learn/detector.rs
@@ -1,5 +1,5 @@
-use lazy_static::lazy_static;
 use regex::Regex;
+use std::sync::LazyLock;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ErrorType {
@@ -45,32 +45,41 @@ pub struct CorrectionRule {
     pub example_error: String,
 }
 
-lazy_static! {
-    static ref UNKNOWN_FLAG_RE: Regex = Regex::new(
-        r"(?i)(unexpected argument|unknown (option|flag)|unrecognized (option|flag)|invalid (option|flag))"
-    ).unwrap();
+static UNKNOWN_FLAG_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?i)(unexpected argument|unknown (option|flag)|unrecognized (option|flag)|invalid (option|flag))",
+    )
+    .unwrap()
+});
 
-    static ref CMD_NOT_FOUND_RE: Regex = Regex::new(
-        r"(?i)(command not found|not recognized as an internal|no such file or directory.*command)"
-    ).unwrap();
+static CMD_NOT_FOUND_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?i)(command not found|not recognized as an internal|no such file or directory.*command)",
+    )
+    .unwrap()
+});
 
-    static ref WRONG_PATH_RE: Regex = Regex::new(
-        r"(?i)(no such file or directory|cannot find the path|file not found)"
-    ).unwrap();
+static WRONG_PATH_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)(no such file or directory|cannot find the path|file not found)").unwrap()
+});
 
-    static ref MISSING_ARG_RE: Regex = Regex::new(
-        r"(?i)(requires a value|requires an argument|missing (required )?argument|expected.*argument)"
-    ).unwrap();
+static MISSING_ARG_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?i)(requires a value|requires an argument|missing (required )?argument|expected.*argument)",
+    )
+    .unwrap()
+});
 
-    static ref PERMISSION_DENIED_RE: Regex = Regex::new(
-        r"(?i)(permission denied|access denied|not permitted)"
-    ).unwrap();
+static PERMISSION_DENIED_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)(permission denied|access denied|not permitted)").unwrap());
 
-    // User rejection patterns - NOT actual errors
-    static ref USER_REJECTION_RE: Regex = Regex::new(
-        r"(?i)(user (doesn't want|declined|rejected|cancelled)|operation (cancelled|aborted) by user)"
-    ).unwrap();
-}
+// User rejection patterns - NOT actual errors
+static USER_REJECTION_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?i)(user (doesn't want|declined|rejected|cancelled)|operation (cancelled|aborted) by user)",
+    )
+    .unwrap()
+});
 
 /// Filters out user rejections - requires actual error-indicating content
 pub fn is_command_error(is_error: bool, output: &str) -> bool {

--- a/src/mypy_cmd.rs
+++ b/src/mypy_cmd.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use regex::Regex;
 use std::collections::HashMap;
 use std::process::Command;
+use std::sync::LazyLock;
 
 pub fn run(args: &[String], verbose: u8) -> Result<()> {
     let timer = tracking::TimedExecution::start();
@@ -67,13 +68,11 @@ struct MypyError {
 }
 
 pub fn filter_mypy_output(output: &str) -> String {
-    lazy_static::lazy_static! {
-        // file.py:12: error: Message [error-code]
-        // file.py:12:5: error: Message [error-code]
-        static ref MYPY_DIAG: Regex = Regex::new(
-            r"^(.+?):(\d+)(?::\d+)?: (error|warning|note): (.+?)(?:\s+\[(.+)\])?$"
-        ).unwrap();
-    }
+    // file.py:12: error: Message [error-code]
+    // file.py:12:5: error: Message [error-code]
+    static MYPY_DIAG: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"^(.+?):(\d+)(?::\d+)?: (error|warning|note): (.+?)(?:\s+\[(.+)\])?$").unwrap()
+    });
 
     let lines: Vec<&str> = output.lines().collect();
     let mut errors: Vec<MypyError> = Vec::new();

--- a/src/next_cmd.rs
+++ b/src/next_cmd.rs
@@ -5,6 +5,14 @@ use regex::Regex;
 use std::process::Command;
 use std::sync::LazyLock;
 
+// Bundle size pattern
+static BUNDLE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^[○●◐λ✓]\s+([\w/\-\.]+)\s+(\d+(?:\.\d+)?)\s*(kB|B)\s+(\d+(?:\.\d+)?)\s*(kB|B)")
+        .unwrap()
+});
+static TIME_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(\d+(?:\.\d+)?)\s*(s|ms)").unwrap());
+
 pub fn run(args: &[String], verbose: u8) -> Result<()> {
     let timer = tracking::TimedExecution::start();
 
@@ -57,15 +65,6 @@ pub fn run(args: &[String], verbose: u8) -> Result<()> {
 
 /// Filter Next.js build output - extract routes, bundles, warnings
 fn filter_next_build(output: &str) -> String {
-    // Route line pattern: ○ /dashboard    1.2 kB  132 kB
-    static ROUTE_PATTERN: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"^[○●◐λ✓]\s+(/[^\s]*)\s+(\d+(?:\.\d+)?)\s*(kB|B)").unwrap());
-    // Bundle size pattern
-    static BUNDLE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"^[○●◐λ✓]\s+([\w/\-\.]+)\s+(\d+(?:\.\d+)?)\s*(kB|B)\s+(\d+(?:\.\d+)?)\s*(kB|B)")
-            .unwrap()
-    });
-
     let mut routes_static = 0;
     let mut routes_dynamic = 0;
     let mut routes_total = 0;
@@ -184,9 +183,6 @@ fn filter_next_build(output: &str) -> String {
 
 /// Extract time from build output (e.g., "Compiled in 34.2s")
 fn extract_time(line: &str) -> Option<String> {
-    static TIME_RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"(\d+(?:\.\d+)?)\s*(s|ms)").unwrap());
-
     TIME_RE
         .captures(line)
         .map(|caps| format!("{}{}", &caps[1], &caps[2]))

--- a/src/next_cmd.rs
+++ b/src/next_cmd.rs
@@ -3,6 +3,7 @@ use crate::utils::{strip_ansi, truncate};
 use anyhow::{Context, Result};
 use regex::Regex;
 use std::process::Command;
+use std::sync::LazyLock;
 
 pub fn run(args: &[String], verbose: u8) -> Result<()> {
     let timer = tracking::TimedExecution::start();
@@ -56,17 +57,14 @@ pub fn run(args: &[String], verbose: u8) -> Result<()> {
 
 /// Filter Next.js build output - extract routes, bundles, warnings
 fn filter_next_build(output: &str) -> String {
-    lazy_static::lazy_static! {
-        // Route line pattern: ○ /dashboard    1.2 kB  132 kB
-        static ref ROUTE_PATTERN: Regex = Regex::new(
-            r"^[○●◐λ✓]\s+(/[^\s]*)\s+(\d+(?:\.\d+)?)\s*(kB|B)"
-        ).unwrap();
-
-        // Bundle size pattern
-        static ref BUNDLE_PATTERN: Regex = Regex::new(
-            r"^[○●◐λ✓]\s+([\w/\-\.]+)\s+(\d+(?:\.\d+)?)\s*(kB|B)\s+(\d+(?:\.\d+)?)\s*(kB|B)"
-        ).unwrap();
-    }
+    // Route line pattern: ○ /dashboard    1.2 kB  132 kB
+    static ROUTE_PATTERN: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^[○●◐λ✓]\s+(/[^\s]*)\s+(\d+(?:\.\d+)?)\s*(kB|B)").unwrap());
+    // Bundle size pattern
+    static BUNDLE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"^[○●◐λ✓]\s+([\w/\-\.]+)\s+(\d+(?:\.\d+)?)\s*(kB|B)\s+(\d+(?:\.\d+)?)\s*(kB|B)")
+            .unwrap()
+    });
 
     let mut routes_static = 0;
     let mut routes_dynamic = 0;
@@ -186,9 +184,8 @@ fn filter_next_build(output: &str) -> String {
 
 /// Extract time from build output (e.g., "Compiled in 34.2s")
 fn extract_time(line: &str) -> Option<String> {
-    lazy_static::lazy_static! {
-        static ref TIME_RE: Regex = Regex::new(r"(\d+(?:\.\d+)?)\s*(s|ms)").unwrap();
-    }
+    static TIME_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(\d+(?:\.\d+)?)\s*(s|ms)").unwrap());
 
     TIME_RE
         .captures(line)

--- a/src/playwright_cmd.rs
+++ b/src/playwright_cmd.rs
@@ -3,6 +3,7 @@ use crate::utils::{detect_package_manager, strip_ansi};
 use anyhow::{Context, Result};
 use regex::Regex;
 use serde::Deserialize;
+use std::sync::LazyLock;
 
 use crate::parser::{
     emit_degradation_warning, emit_passthrough_warning, truncate_output, FormatMode, OutputParser,
@@ -150,14 +151,10 @@ fn collect_test_results(
 
 /// Tier 2: Extract test statistics using regex (degraded mode)
 fn extract_playwright_regex(output: &str) -> Option<TestResult> {
-    lazy_static::lazy_static! {
-        static ref SUMMARY_RE: Regex = Regex::new(
-            r"(\d+)\s+(passed|failed|flaky|skipped)"
-        ).unwrap();
-        static ref DURATION_RE: Regex = Regex::new(
-            r"\((\d+(?:\.\d+)?)(ms|s|m)\)"
-        ).unwrap();
-    }
+    static SUMMARY_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(\d+)\s+(passed|failed|flaky|skipped)").unwrap());
+    static DURATION_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\((\d+(?:\.\d+)?)(ms|s|m)\)").unwrap());
 
     let clean_output = strip_ansi(output);
 
@@ -206,11 +203,8 @@ fn extract_playwright_regex(output: &str) -> Option<TestResult> {
 
 /// Extract failures using regex
 fn extract_failures_regex(output: &str) -> Vec<TestFailure> {
-    lazy_static::lazy_static! {
-        static ref TEST_PATTERN: Regex = Regex::new(
-            r"[×✗]\s+.*?›\s+([^›]+\.spec\.[tj]sx?)"
-        ).unwrap();
-    }
+    static TEST_PATTERN: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"[×✗]\s+.*?›\s+([^›]+\.spec\.[tj]sx?)").unwrap());
 
     let mut failures = Vec::new();
 

--- a/src/playwright_cmd.rs
+++ b/src/playwright_cmd.rs
@@ -5,6 +5,13 @@ use regex::Regex;
 use serde::Deserialize;
 use std::sync::LazyLock;
 
+static SUMMARY_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(\d+)\s+(passed|failed|flaky|skipped)").unwrap());
+static DURATION_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\((\d+(?:\.\d+)?)(ms|s|m)\)").unwrap());
+static TEST_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"[×✗]\s+.*?›\s+([^›]+\.spec\.[tj]sx?)").unwrap());
+
 use crate::parser::{
     emit_degradation_warning, emit_passthrough_warning, truncate_output, FormatMode, OutputParser,
     ParseResult, TestFailure, TestResult, TokenFormatter,
@@ -151,11 +158,6 @@ fn collect_test_results(
 
 /// Tier 2: Extract test statistics using regex (degraded mode)
 fn extract_playwright_regex(output: &str) -> Option<TestResult> {
-    static SUMMARY_RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"(\d+)\s+(passed|failed|flaky|skipped)").unwrap());
-    static DURATION_RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"\((\d+(?:\.\d+)?)(ms|s|m)\)").unwrap());
-
     let clean_output = strip_ansi(output);
 
     let mut passed = 0;
@@ -203,9 +205,6 @@ fn extract_playwright_regex(output: &str) -> Option<TestResult> {
 
 /// Extract failures using regex
 fn extract_failures_regex(output: &str) -> Vec<TestFailure> {
-    static TEST_PATTERN: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"[×✗]\s+.*?›\s+([^›]+\.spec\.[tj]sx?)").unwrap());
-
     let mut failures = Vec::new();
 
     for caps in TEST_PATTERN.captures_iter(output) {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -2,6 +2,7 @@ use crate::tracking;
 use anyhow::{Context, Result};
 use regex::Regex;
 use std::process::{Command, Stdio};
+use std::sync::LazyLock;
 
 /// Run a command and filter output to show only errors/warnings
 pub fn run_err(command: &str, verbose: u8) -> Result<()> {
@@ -104,8 +105,8 @@ pub fn run_test(command: &str, verbose: u8) -> Result<()> {
 }
 
 fn filter_errors(output: &str) -> String {
-    lazy_static::lazy_static! {
-        static ref ERROR_PATTERNS: Vec<Regex> = vec![
+    static ERROR_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(|| {
+        vec![
             // Generic errors
             Regex::new(r"(?i)^.*error[\s:\[].*$").unwrap(),
             Regex::new(r"(?i)^.*\berr\b.*$").unwrap(),
@@ -125,8 +126,8 @@ fn filter_errors(output: &str) -> String {
             Regex::new(r"^\s*at .*:\d+:\d+.*$").unwrap(),
             // Go
             Regex::new(r"^.*\.go:\d+:.*$").unwrap(),
-        ];
-    }
+        ]
+    });
 
     let mut result = Vec::new();
     let mut in_error_block = false;

--- a/src/tsc_cmd.rs
+++ b/src/tsc_cmd.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use regex::Regex;
 use std::collections::HashMap;
 use std::process::Command;
+use std::sync::LazyLock;
 
 pub fn run(args: &[String], verbose: u8) -> Result<()> {
     let timer = tracking::TimedExecution::start();
@@ -61,12 +62,10 @@ pub fn run(args: &[String], verbose: u8) -> Result<()> {
 
 /// Filter TypeScript compiler output - group errors by file, show every error
 fn filter_tsc_output(output: &str) -> String {
-    lazy_static::lazy_static! {
-        // Pattern: src/file.ts(12,5): error TS2322: Type 'string' is not assignable to type 'number'.
-        static ref TSC_ERROR: Regex = Regex::new(
-            r"^(.+?)\((\d+),(\d+)\):\s+(error|warning)\s+(TS\d+):\s+(.+)$"
-        ).unwrap();
-    }
+    // Pattern: src/file.ts(12,5): error TS2322: Type 'string' is not assignable to type 'number'.
+    static TSC_ERROR: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"^(.+?)\((\d+),(\d+)\):\s+(error|warning)\s+(TS\d+):\s+(.+)$").unwrap()
+    });
 
     struct TsError {
         file: String,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,6 +8,7 @@
 use anyhow::{Context, Result};
 use regex::Regex;
 use std::process::Command;
+use std::sync::LazyLock;
 
 /// Tronque une chaîne à `max_len` caractères avec "..." si nécessaire.
 ///
@@ -45,9 +46,8 @@ pub fn truncate(s: &str, max_len: usize) -> String {
 /// assert_eq!(strip_ansi(colored), "Error");
 /// ```
 pub fn strip_ansi(text: &str) -> String {
-    lazy_static::lazy_static! {
-        static ref ANSI_RE: Regex = Regex::new(r"\x1b\[[0-9;]*[a-zA-Z]").unwrap();
-    }
+    static ANSI_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\x1b\[[0-9;]*[a-zA-Z]").unwrap());
     ANSI_RE.replace_all(text, "").to_string()
 }
 

--- a/src/vitest_cmd.rs
+++ b/src/vitest_cmd.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use regex::Regex;
 use serde::Deserialize;
+use std::sync::LazyLock;
 
 use crate::parser::{
     emit_degradation_warning, emit_passthrough_warning, extract_json_object, truncate_output,
@@ -119,17 +120,13 @@ fn extract_failures_from_json(json: &VitestJsonOutput) -> Vec<TestFailure> {
 
 /// Tier 2: Extract test statistics using regex (degraded mode)
 fn extract_stats_regex(output: &str) -> Option<TestResult> {
-    lazy_static::lazy_static! {
-        static ref TEST_FILES_RE: Regex = Regex::new(
-            r"Test Files\s+(?:(\d+)\s+failed\s+\|\s+)?(\d+)\s+passed"
-        ).unwrap();
-        static ref TESTS_RE: Regex = Regex::new(
-            r"Tests\s+(?:(\d+)\s+failed\s+\|\s+)?(\d+)\s+passed"
-        ).unwrap();
-        static ref DURATION_RE: Regex = Regex::new(
-            r"Duration\s+([\d.]+)(ms|s)"
-        ).unwrap();
-    }
+    static TEST_FILES_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"Test Files\s+(?:(\d+)\s+failed\s+\|\s+)?(\d+)\s+passed").unwrap()
+    });
+    static TESTS_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"Tests\s+(?:(\d+)\s+failed\s+\|\s+)?(\d+)\s+passed").unwrap());
+    static DURATION_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"Duration\s+([\d.]+)(ms|s)").unwrap());
 
     let clean_output = strip_ansi(output);
 


### PR DESCRIPTION
Replaces all uses of the `lazy_static` crate with `std::sync::LazyLock`, which has been stable since Rust 1.80.

  **Motivation:**                              
  - Removes one external dependency (`lazy_static = "1.4"`)
  - Uses std

  **No behavior change.** LazyLock initializes on first access, exactly like lazy_static. All regex patterns remain identical.
