### PR TITLE
feat: add rtk yarn command with smart filter routing

### DIFF
--- a/src/cmds/js/lint_cmd.rs
+++ b/src/cmds/js/lint_cmd.rs
@@ -438,7 +438,7 @@ fn filter_pylint_json(output: &str) -> String {
 }
 
 /// Filter generic linter output (fallback for non-ESLint linters)
-fn filter_generic_lint(output: &str) -> String {
+pub(crate) fn filter_generic_lint(output: &str) -> String {
     let mut warnings = 0;
     let mut errors = 0;
     let mut issues: Vec<String> = Vec::new();

--- a/src/cmds/js/mod.rs
+++ b/src/cmds/js/mod.rs
@@ -9,3 +9,4 @@ pub mod prettier_cmd;
 pub mod prisma_cmd;
 pub mod tsc_cmd;
 pub mod vitest_cmd;
+pub mod yarn_cmd;

--- a/src/cmds/js/tsc_cmd.rs
+++ b/src/cmds/js/tsc_cmd.rs
@@ -57,7 +57,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<()> {
 }
 
 /// Filter TypeScript compiler output - group errors by file, show every error
-fn filter_tsc_output(output: &str) -> String {
+pub(crate) fn filter_tsc_output(output: &str) -> String {
     lazy_static::lazy_static! {
         // Pattern: src/file.ts(12,5): error TS2322: Type 'string' is not assignable to type 'number'.
         static ref TSC_ERROR: Regex = Regex::new(

--- a/src/cmds/js/vitest_cmd.rs
+++ b/src/cmds/js/vitest_cmd.rs
@@ -210,6 +210,17 @@ fn extract_failures_regex(output: &str) -> Vec<TestFailure> {
     failures
 }
 
+/// Filter vitest output post-hoc (for use by yarn_cmd and other wrappers).
+/// Runs the full VitestParser pipeline on already-captured stdout.
+pub(crate) fn filter_vitest_output(stdout: &str) -> String {
+    let parse_result = VitestParser::parse(stdout);
+    match parse_result {
+        ParseResult::Full(data) => data.format(FormatMode::Compact),
+        ParseResult::Degraded(data, _) => data.format(FormatMode::Compact),
+        ParseResult::Passthrough(raw) => raw,
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum VitestCommand {
     Run,

--- a/src/cmds/js/yarn_cmd.rs
+++ b/src/cmds/js/yarn_cmd.rs
@@ -1,0 +1,893 @@
+use super::lint_cmd;
+use super::prettier_cmd;
+use super::tsc_cmd;
+use super::vitest_cmd;
+use crate::core::tracking;
+use crate::core::utils::{resolved_command, strip_ansi};
+use anyhow::{Context, Result};
+use regex::Regex;
+
+/// Native yarn commands that should never be intercepted — always passthrough.
+/// Sorted for binary_search.
+const NATIVE_YARN_COMMANDS: &[&str] = &[
+    "add",
+    "audit",
+    "autoclean",
+    "bin",
+    "cache",
+    "check",
+    "config",
+    "constraints",
+    "create",
+    "dedupe",
+    "dlx",
+    "exec",
+    "explain",
+    "generate-lock-entry",
+    "global",
+    "import",
+    "info",
+    "init",
+    "install",
+    "licenses",
+    "link",
+    "list",
+    "login",
+    "logout",
+    "node",
+    "outdated",
+    "owner",
+    "pack",
+    "patch",
+    "plugin",
+    "policies",
+    "publish",
+    "rebuild",
+    "remove",
+    "set",
+    "tag",
+    "unlink",
+    "unplug",
+    "up",
+    "upgrade",
+    "upgrade-interactive",
+    "version",
+    "versions",
+    "why",
+    "workspace",
+    "workspaces",
+];
+
+lazy_static::lazy_static! {
+    static ref RE_YN_PREFIX: Regex = Regex::new(r"^(?:➤\s*)?YN\d{4}:").expect("RE_YN_PREFIX regex");
+    static ref RE_RESOLUTION: Regex = Regex::new(r"^(Resolution|Fetch|Link) step \d+/\d+").expect("RE_RESOLUTION regex");
+    static ref RE_PROGRESS: Regex = Regex::new(r"^\[[\d/]+\]").expect("RE_PROGRESS regex");
+    static ref RE_YARN_CLASSIC_HEADER: Regex = Regex::new(r"^yarn (run|workspace) v\d").expect("RE_YARN_CLASSIC_HEADER regex");
+    static ref RE_DONE: Regex = Regex::new(r"^Done in \d").expect("RE_DONE regex");
+    static ref RE_INFO: Regex = Regex::new(r"^info ").expect("RE_INFO regex");
+    static ref RE_SCRIPT_ECHO: Regex = Regex::new(r"^\$ \S+").expect("RE_SCRIPT_ECHO regex");
+    static ref RE_WARNING: Regex = Regex::new(r"^warning ").expect("RE_WARNING regex");
+}
+
+/// Strip yarn boilerplate from stdout, preserving actual command output.
+pub(crate) fn filter_yarn_output(stdout: &str) -> String {
+    let clean = strip_ansi(stdout);
+    let filtered: Vec<&str> = clean
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                return false;
+            }
+            !RE_YN_PREFIX.is_match(trimmed)
+                && !RE_RESOLUTION.is_match(trimmed)
+                && !RE_PROGRESS.is_match(trimmed)
+                && !RE_YARN_CLASSIC_HEADER.is_match(trimmed)
+                && !RE_DONE.is_match(trimmed)
+                && !RE_INFO.is_match(trimmed)
+                && !RE_SCRIPT_ECHO.is_match(trimmed)
+                && !RE_WARNING.is_match(trimmed)
+        })
+        .collect();
+    filtered.join("\n")
+}
+
+/// Strip yarn stderr noise (ELIFECYCLE, etc.), keep real errors.
+fn strip_yarn_stderr(stderr: &str) -> String {
+    let clean = strip_ansi(stderr);
+    clean
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim();
+            !trimmed.is_empty()
+                && !trimmed.contains("ELIFECYCLE")
+                && !trimmed.contains("This is probably not a problem with npm")
+                && !RE_YN_PREFIX.is_match(trimmed)
+                && !RE_WARNING.is_match(trimmed)
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Identify which RTK filter to apply based on script name.
+/// For compound scripts (e.g. `test:lib`), routes based on the prefix before `:`,
+/// but checks the suffix first for known tool names (e.g. `test:e2e` → no filter,
+/// since e2e is typically Playwright/Cypress, not vitest).
+fn identify_filter(script_name: &str) -> Option<&'static str> {
+    // For compound scripts, check suffix first for specific tool hints
+    if let Some((prefix, suffix)) = script_name.split_once(':') {
+        return match suffix {
+            "e2e" | "cypress" | "playwright" => None,
+            _ => match prefix {
+                "test" | "vitest" => Some("vitest"),
+                "typecheck" | "tsc" | "type-check" => Some("tsc"),
+                "lint" | "eslint" | "biome" => Some("lint"),
+                "prettier" | "format" => Some("prettier"),
+                _ => None,
+            },
+        };
+    }
+    match script_name {
+        "test" | "vitest" => Some("vitest"),
+        "typecheck" | "tsc" | "type-check" => Some("tsc"),
+        "lint" | "eslint" | "biome" => Some("lint"),
+        "prettier" | "format" => Some("prettier"),
+        _ => None,
+    }
+}
+
+/// Apply the identified filter to command output.
+fn apply_identified_filter(filter_type: &str, output: &str) -> Result<String> {
+    match filter_type {
+        "vitest" => Ok(vitest_cmd::filter_vitest_output(output)),
+        "tsc" => Ok(tsc_cmd::filter_tsc_output(output)),
+        "lint" => Ok(lint_cmd::filter_generic_lint(output)),
+        "prettier" => Ok(prettier_cmd::filter_prettier_output(output)),
+        _ => anyhow::bail!("Unknown filter type: {}", filter_type),
+    }
+}
+
+// skip_env unused: yarn does not have env validation like Next.js/tsc
+pub fn run(args: &[String], verbose: u8, _skip_env: bool) -> Result<()> {
+    let timer = tracking::TimedExecution::start();
+
+    // Non-workspace commands
+    if args.is_empty() || args[0] != "workspace" {
+        // Classify: no args, flags, or native yarn commands → direct passthrough (no capture)
+        let is_passthrough = args.is_empty()
+            || args[0].starts_with('-')
+            || NATIVE_YARN_COMMANDS
+                .binary_search(&args[0].as_str())
+                .is_ok();
+
+        if is_passthrough {
+            let mut cmd = resolved_command("yarn");
+            for arg in args {
+                cmd.arg(arg);
+            }
+            let status = cmd.status().context("Failed to run yarn")?;
+            if !status.success() {
+                std::process::exit(status.code().unwrap_or(1));
+            }
+            let args_str = args.join(" ");
+            timer.track_passthrough(
+                &format!("yarn {}", args_str),
+                &format!("rtk yarn {} (native passthrough)", args_str),
+            );
+            return Ok(());
+        }
+
+        // Script path: extract script name, capture output, try filter routing
+        let script_name = if args[0] == "run" {
+            if args.len() < 2 {
+                // `yarn run` with no script → passthrough
+                let mut cmd = resolved_command("yarn");
+                cmd.arg("run");
+                let status = cmd.status().context("Failed to run yarn")?;
+                timer.track_passthrough("yarn run", "rtk yarn run (passthrough)");
+                if !status.success() {
+                    std::process::exit(status.code().unwrap_or(1));
+                }
+                return Ok(());
+            }
+            args[1].as_str()
+        } else {
+            args[0].as_str()
+        };
+
+        let mut cmd = resolved_command("yarn");
+        for arg in args {
+            cmd.arg(arg);
+        }
+        let output = cmd.output().context("Failed to run yarn")?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let raw = format!("{}{}", stdout, stderr);
+        let exit_code = output.status.code().unwrap_or(1);
+
+        // On failure: print stripped output, no filter routing
+        if !output.status.success() {
+            let filtered_stdout = filter_yarn_output(&stdout);
+            let filtered_stderr = strip_yarn_stderr(&stderr);
+            if !filtered_stdout.is_empty() {
+                println!("{}", filtered_stdout);
+            }
+            if !filtered_stderr.is_empty() {
+                eprintln!("{}", filtered_stderr);
+            }
+            let args_str = args.join(" ");
+            timer.track(
+                &format!("yarn {}", args_str),
+                &format!("rtk yarn {} (failed)", args_str),
+                &raw,
+                &format!("{}\n{}", filtered_stdout, filtered_stderr),
+            );
+            std::process::exit(exit_code);
+        }
+
+        // Success path: strip boilerplate first
+        let filtered_stdout = filter_yarn_output(&stdout);
+
+        // Empty after strip + success → "ok ✓"
+        if filtered_stdout.is_empty() {
+            println!("ok \u{2713}");
+            let args_str = args.join(" ");
+            timer.track(
+                &format!("yarn {}", args_str),
+                &format!("rtk yarn {}", args_str),
+                &raw,
+                "ok \u{2713}",
+            );
+            return Ok(());
+        }
+
+        // Try to identify and apply a specialized filter
+        let (display, label) = match identify_filter(script_name) {
+            Some(filter_type) => match apply_identified_filter(filter_type, &filtered_stdout) {
+                Ok(result) if !result.is_empty() => (result, format!("{} (via yarn)", filter_type)),
+                Ok(_) => (filtered_stdout.clone(), "yarn (passthrough)".to_string()),
+                Err(e) => {
+                    if verbose > 0 {
+                        eprintln!(
+                            "rtk: yarn filter '{}' failed: {}, using passthrough",
+                            filter_type, e
+                        );
+                    }
+                    (filtered_stdout.clone(), "yarn (passthrough)".to_string())
+                }
+            },
+            None => (filtered_stdout.clone(), "yarn (passthrough)".to_string()),
+        };
+
+        println!("{}", display);
+
+        let stripped_stderr = if !stderr.is_empty() {
+            strip_yarn_stderr(&stderr)
+        } else {
+            String::new()
+        };
+        if !stripped_stderr.is_empty() {
+            eprintln!("{}", stripped_stderr);
+        }
+
+        let args_str = args.join(" ");
+        timer.track(
+            &format!("yarn {}", args_str),
+            &format!("rtk yarn {} [{}]", args_str, label),
+            &raw,
+            &display,
+        );
+
+        return Ok(());
+    }
+
+    // yarn workspace <pkg> [run] <script> [script_args...]
+    if args.len() < 3 {
+        anyhow::bail!("Usage: rtk yarn workspace <package> [run] <script> [args...]");
+    }
+
+    let pkg = &args[1];
+    let (script, script_args) = if args[2] == "run" {
+        if args.len() < 4 {
+            anyhow::bail!("Usage: rtk yarn workspace <package> run <script> [args...]");
+        }
+        (&args[3], &args[4..])
+    } else {
+        (&args[2], &args[3..])
+    };
+
+    // Native yarn commands: passthrough
+    if NATIVE_YARN_COMMANDS.binary_search(&script.as_str()).is_ok() {
+        let mut cmd = resolved_command("yarn");
+        for arg in args {
+            cmd.arg(arg);
+        }
+        let status = cmd.status().context("Failed to run yarn")?;
+        if !status.success() {
+            std::process::exit(status.code().unwrap_or(1));
+        }
+        let args_str = args.join(" ");
+        timer.track_passthrough(
+            &format!("yarn {}", args_str),
+            &format!("rtk yarn {} (native passthrough)", args_str),
+        );
+        return Ok(());
+    }
+
+    if verbose > 0 {
+        eprintln!(
+            "Running: yarn workspace {} run {} {}",
+            pkg,
+            script,
+            script_args.join(" ")
+        );
+    }
+
+    // Execute: yarn workspace <pkg> run <script> <script_args>
+    let mut cmd = resolved_command("yarn");
+    cmd.args(["workspace", pkg, "run", script]);
+    for arg in script_args {
+        cmd.arg(arg);
+    }
+
+    let output = cmd
+        .output()
+        .context("Failed to run yarn workspace command")?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let raw = format!("{}{}", stdout, stderr);
+    let exit_code = output.status.code().unwrap_or(1);
+
+    // On failure: print stripped output, no filter routing
+    if !output.status.success() {
+        let filtered_stdout = filter_yarn_output(&stdout);
+        let filtered_stderr = strip_yarn_stderr(&stderr);
+
+        if !filtered_stdout.is_empty() {
+            println!("{}", filtered_stdout);
+        }
+        if !filtered_stderr.is_empty() {
+            eprintln!("{}", filtered_stderr);
+        }
+
+        timer.track(
+            &format!("yarn workspace {} run {}", pkg, script),
+            &format!("rtk yarn workspace {} {} (failed)", pkg, script),
+            &raw,
+            &format!("{}\n{}", filtered_stdout, filtered_stderr),
+        );
+
+        std::process::exit(exit_code);
+    }
+
+    // Success path: strip boilerplate first
+    let filtered_stdout = filter_yarn_output(&stdout);
+
+    // Empty after strip + success → "ok ✓"
+    if filtered_stdout.is_empty() {
+        println!("ok \u{2713}");
+        timer.track(
+            &format!("yarn workspace {} run {}", pkg, script),
+            &format!("rtk yarn workspace {} {}", pkg, script),
+            &raw,
+            "ok \u{2713}",
+        );
+        return Ok(());
+    }
+
+    // Try to identify and apply a specialized filter
+    let (display, label) = match identify_filter(script) {
+        Some(filter_type) => match apply_identified_filter(filter_type, &filtered_stdout) {
+            Ok(result) if !result.is_empty() => {
+                (result, format!("{} (via yarn workspace)", filter_type))
+            }
+            Ok(_) => (
+                filtered_stdout.clone(),
+                "yarn workspace (passthrough)".to_string(),
+            ),
+            Err(e) => {
+                if verbose > 0 {
+                    eprintln!(
+                        "rtk: yarn filter '{}' failed: {}, using passthrough",
+                        filter_type, e
+                    );
+                }
+                (
+                    filtered_stdout.clone(),
+                    "yarn workspace (passthrough)".to_string(),
+                )
+            }
+        },
+        None => (
+            filtered_stdout.clone(),
+            "yarn workspace (passthrough)".to_string(),
+        ),
+    };
+
+    println!("{}", display);
+
+    timer.track(
+        &format!("yarn workspace {} run {}", pkg, script),
+        &format!("rtk yarn workspace {} {} [{}]", pkg, script, label),
+        &raw,
+        &display,
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Boilerplate stripping (9 tests) ──
+
+    #[test]
+    fn test_filter_clean_output() {
+        let input = "Tests: 5 passed\nAll tests passed";
+        let output = filter_yarn_output(input);
+        assert!(output.contains("Tests: 5 passed"));
+        assert!(output.contains("All tests passed"));
+    }
+
+    #[test]
+    fn test_filter_yn_prefix() {
+        let input = "YN0000: Done\nYN0002: Missing peer\nReal output here";
+        let output = filter_yarn_output(input);
+        assert!(!output.contains("YN0000"));
+        assert!(!output.contains("YN0002"));
+        assert!(output.contains("Real output here"));
+    }
+
+    #[test]
+    fn test_filter_resolution_steps() {
+        let input = "Resolution step 1/3\nFetch step 2/3\nLink step 3/3\nActual output";
+        let output = filter_yarn_output(input);
+        assert!(!output.contains("Resolution step"));
+        assert!(!output.contains("Fetch step"));
+        assert!(!output.contains("Link step"));
+        assert!(output.contains("Actual output"));
+    }
+
+    #[test]
+    fn test_filter_yarn_classic_headers() {
+        let input = "yarn run v1.22.19\nyarn workspace v1.22.19\nTest results here";
+        let output = filter_yarn_output(input);
+        assert!(!output.contains("yarn run v1"));
+        assert!(!output.contains("yarn workspace v1"));
+        assert!(output.contains("Test results here"));
+    }
+
+    #[test]
+    fn test_filter_warning_lines() {
+        let input = "warning package.json: No license field\nActual output";
+        let output = filter_yarn_output(input);
+        assert!(!output.contains("warning"));
+        assert!(output.contains("Actual output"));
+    }
+
+    #[test]
+    fn test_filter_script_echo() {
+        let input = "$ vitest run --reporter=json\nTest output here";
+        let output = filter_yarn_output(input);
+        assert!(!output.contains("$ vitest"));
+        assert!(output.contains("Test output here"));
+    }
+
+    #[test]
+    fn test_filter_mixed_output() {
+        let input = "\
+yarn run v1.22.19
+warning package.json: No license field
+$ vitest run --reporter=json
+YN0000: Done
+Resolution step 1/2
+[1/4] Resolving packages
+info Visit https://yarnpkg.com
+Done in 1.23s
+Real test output here
+Another real line";
+        let output = filter_yarn_output(input);
+        assert_eq!(output, "Real test output here\nAnother real line");
+    }
+
+    #[test]
+    fn test_filter_empty_returns_empty() {
+        assert_eq!(filter_yarn_output(""), "");
+    }
+
+    #[test]
+    fn test_filter_done_in_xs() {
+        let input = "Done in 1.23s\nDone in 45.67s";
+        let output = filter_yarn_output(input);
+        assert_eq!(output, "");
+    }
+
+    // ── identify_filter (6 tests) ──
+
+    #[test]
+    fn test_identify_vitest() {
+        assert_eq!(identify_filter("test"), Some("vitest"));
+    }
+
+    #[test]
+    fn test_identify_tsc() {
+        assert_eq!(identify_filter("typecheck"), Some("tsc"));
+    }
+
+    #[test]
+    fn test_identify_lint() {
+        assert_eq!(identify_filter("lint"), Some("lint"));
+    }
+
+    #[test]
+    fn test_identify_unknown() {
+        assert_eq!(identify_filter("build"), None);
+    }
+
+    #[test]
+    fn test_identify_test_run() {
+        assert_eq!(identify_filter("test:run"), Some("vitest"));
+    }
+
+    #[test]
+    fn test_identify_compound_test_routes_vitest() {
+        assert_eq!(identify_filter("test:lib"), Some("vitest"));
+        assert_eq!(identify_filter("test:unit"), Some("vitest"));
+    }
+
+    #[test]
+    fn test_identify_compound_lint_routes_lint() {
+        assert_eq!(identify_filter("lint:fix"), Some("lint"));
+        assert_eq!(identify_filter("lint:check"), Some("lint"));
+    }
+
+    #[test]
+    fn test_identify_compound_unknown_prefix() {
+        assert_eq!(identify_filter("build:prod"), None);
+        assert_eq!(identify_filter("dev:watch"), None);
+    }
+
+    // ── Native commands (3 tests) ──
+
+    #[test]
+    fn test_native_commands_sorted() {
+        for i in 1..NATIVE_YARN_COMMANDS.len() {
+            assert!(
+                NATIVE_YARN_COMMANDS[i - 1] < NATIVE_YARN_COMMANDS[i],
+                "NATIVE_YARN_COMMANDS not sorted at index {}: {:?} >= {:?}",
+                i,
+                NATIVE_YARN_COMMANDS[i - 1],
+                NATIVE_YARN_COMMANDS[i]
+            );
+        }
+    }
+
+    #[test]
+    fn test_native_commands_not_intercepted() {
+        assert!(NATIVE_YARN_COMMANDS.binary_search(&"install").is_ok());
+        assert!(NATIVE_YARN_COMMANDS.binary_search(&"add").is_ok());
+        assert!(NATIVE_YARN_COMMANDS.binary_search(&"why").is_ok());
+    }
+
+    #[test]
+    fn test_workspace_is_in_native() {
+        assert!(NATIVE_YARN_COMMANDS.binary_search(&"workspace").is_ok());
+    }
+
+    // ── Integration-style unit tests (3 tests) ──
+
+    #[test]
+    fn test_filter_then_identify_vitest() {
+        let input = "\
+yarn run v1.22.19
+$ vitest run --reporter=json
+warning package.json: No license field
+{\"numTotalTests\": 5, \"numPassedTests\": 5, \"numFailedTests\": 0, \"numPendingTests\": 0, \"testResults\": [], \"startTime\": 1000, \"endTime\": 1200}
+Done in 2.34s";
+        let filtered = filter_yarn_output(input);
+        assert!(filtered.contains("numTotalTests"));
+
+        let filter_type = identify_filter("test");
+        assert_eq!(filter_type, Some("vitest"));
+
+        let result = apply_identified_filter("vitest", &filtered).unwrap();
+        assert!(result.contains("PASS (5)"));
+    }
+
+    #[test]
+    fn test_e2e_not_routed_to_vitest() {
+        assert_eq!(identify_filter("test:e2e"), None);
+        assert_eq!(identify_filter("test:cypress"), None);
+        assert_eq!(identify_filter("test:playwright"), None);
+        // But regular test compounds still route to vitest
+        assert_eq!(identify_filter("test:unit"), Some("vitest"));
+        assert_eq!(identify_filter("test:lib"), Some("vitest"));
+    }
+
+    #[test]
+    fn test_empty_after_strip_produces_empty() {
+        let input = "\
+yarn run v1.22.19
+$ yarn install
+warning No license field
+YN0000: Done
+Done in 0.5s";
+        let filtered = filter_yarn_output(input);
+        assert!(filtered.is_empty());
+    }
+
+    #[test]
+    fn test_apply_filter_tsc() {
+        let tsc_output =
+            "src/index.ts(10,5): error TS2322: Type 'string' is not assignable to type 'number'.";
+        let result = apply_identified_filter("tsc", tsc_output).unwrap();
+        assert!(
+            result.contains("TS2322"),
+            "Expected TS error code in output, got: {}",
+            result
+        );
+    }
+
+    // ── Clap parsing (5 tests) ──
+
+    #[test]
+    fn test_yarn_basic_parse() {
+        use crate::Cli;
+        use clap::Parser;
+        let cli =
+            Cli::try_parse_from(["rtk", "yarn", "workspace", "my-app", "run", "test"]).unwrap();
+        match cli.command {
+            crate::Commands::Yarn { args } => {
+                assert_eq!(args, vec!["workspace", "my-app", "run", "test"]);
+            }
+            _ => panic!("Expected Yarn command"),
+        }
+    }
+
+    #[test]
+    fn test_yarn_scoped_package() {
+        use crate::Cli;
+        use clap::Parser;
+        let cli =
+            Cli::try_parse_from(["rtk", "yarn", "workspace", "@scope/pkg", "run", "test"]).unwrap();
+        match cli.command {
+            crate::Commands::Yarn { args } => {
+                assert_eq!(args, vec!["workspace", "@scope/pkg", "run", "test"]);
+            }
+            _ => panic!("Expected Yarn command"),
+        }
+    }
+
+    #[test]
+    fn test_yarn_without_run() {
+        use crate::Cli;
+        use clap::Parser;
+        let cli = Cli::try_parse_from(["rtk", "yarn", "workspace", "my-app", "test"]).unwrap();
+        match cli.command {
+            crate::Commands::Yarn { args } => {
+                assert_eq!(args, vec!["workspace", "my-app", "test"]);
+            }
+            _ => panic!("Expected Yarn command"),
+        }
+    }
+
+    #[test]
+    fn test_yarn_non_workspace() {
+        use crate::Cli;
+        use clap::Parser;
+        let cli = Cli::try_parse_from(["rtk", "yarn", "install"]).unwrap();
+        match cli.command {
+            crate::Commands::Yarn { args } => {
+                assert_eq!(args, vec!["install"]);
+            }
+            _ => panic!("Expected Yarn command"),
+        }
+    }
+
+    #[test]
+    fn test_yarn_extra_args() {
+        use crate::Cli;
+        use clap::Parser;
+        let cli = Cli::try_parse_from([
+            "rtk",
+            "yarn",
+            "workspace",
+            "my-app",
+            "run",
+            "test",
+            "--",
+            "--verbose",
+        ])
+        .unwrap();
+        match cli.command {
+            crate::Commands::Yarn { args } => {
+                assert_eq!(
+                    args,
+                    vec!["workspace", "my-app", "run", "test", "--", "--verbose"]
+                );
+            }
+            _ => panic!("Expected Yarn command"),
+        }
+    }
+
+    // ── P0: strip_yarn_stderr tests (3 tests) ──
+
+    #[test]
+    fn test_strip_stderr_elifecycle() {
+        let input =
+            "error Command failed with exit code 1.\nELIFECYCLE\nReal error: Cannot find module";
+        let output = strip_yarn_stderr(input);
+        assert!(!output.contains("ELIFECYCLE"));
+        assert!(output.contains("Real error"));
+    }
+
+    #[test]
+    fn test_strip_stderr_keeps_real_errors() {
+        let input = "error: Cannot find module 'react'\nwarning No license field";
+        let output = strip_yarn_stderr(input);
+        assert!(output.contains("Cannot find module"));
+        assert!(!output.contains("warning"));
+    }
+
+    #[test]
+    fn test_strip_stderr_empty() {
+        assert_eq!(strip_yarn_stderr(""), "");
+    }
+
+    // ── P0: Arrow-prefix YN test ──
+
+    #[test]
+    fn test_filter_yn_prefix_with_arrow() {
+        let input = "➤ YN0000: Done\n➤ YN0001: Warning message\nReal output";
+        let output = filter_yarn_output(input);
+        assert!(!output.contains("YN0000"));
+        assert!(!output.contains("YN0001"));
+        assert!(output.contains("Real output"));
+    }
+
+    // ── P1: Token savings test ──
+
+    #[test]
+    fn test_token_savings_filter_yarn_output() {
+        fn count_tokens(text: &str) -> usize {
+            text.split_whitespace().count()
+        }
+        let input = "\
+yarn run v1.22.19
+warning package.json: No license field
+$ vitest run --reporter=json
+YN0000: Done
+Resolution step 1/2
+Fetch step 2/2
+[1/4] Resolving packages
+info Visit https://yarnpkg.com for documentation
+Done in 1.23s
+warning some other warning here
+$ node scripts/build.js
+info More yarn boilerplate
+Real test output line one
+Real test output line two
+Real test output line three";
+        let output = filter_yarn_output(input);
+        let input_tokens = count_tokens(input);
+        let output_tokens = count_tokens(&output);
+        let savings = 100.0 - (output_tokens as f64 / input_tokens as f64 * 100.0);
+        assert!(
+            savings >= 60.0,
+            "Expected >=60% savings, got {:.1}% (input={}, output={})",
+            savings,
+            input_tokens,
+            output_tokens
+        );
+    }
+
+    // ── P1: ANSI codes test ──
+
+    #[test]
+    fn test_filter_strips_ansi_before_matching() {
+        let input = "\x1b[2mYN0000\x1b[0m: Done\nReal output here";
+        let output = filter_yarn_output(input);
+        assert!(output.contains("Real output here"));
+        assert!(!output.contains("YN0000"));
+    }
+
+    // ── P2: identify_filter alias coverage ──
+
+    #[test]
+    fn test_identify_vitest_alias() {
+        assert_eq!(identify_filter("vitest"), Some("vitest"));
+    }
+
+    #[test]
+    fn test_identify_tsc_aliases() {
+        assert_eq!(identify_filter("tsc"), Some("tsc"));
+        assert_eq!(identify_filter("type-check"), Some("tsc"));
+    }
+
+    #[test]
+    fn test_identify_prettier() {
+        assert_eq!(identify_filter("prettier"), Some("prettier"));
+        assert_eq!(identify_filter("format"), Some("prettier"));
+    }
+
+    // ── P3: Empty args Clap test ──
+
+    #[test]
+    fn test_yarn_no_args() {
+        use crate::Cli;
+        use clap::Parser;
+        let cli = Cli::try_parse_from(["rtk", "yarn"]).unwrap();
+        match cli.command {
+            crate::Commands::Yarn { args } => {
+                assert!(args.is_empty());
+            }
+            _ => panic!("Expected Yarn command"),
+        }
+    }
+
+    // ── Non-workspace filter routing (4 tests) ──
+
+    #[test]
+    fn test_non_workspace_test_routes_vitest() {
+        // Simulate: `rtk yarn test` → yarn boilerplate + vitest JSON output
+        let raw_output = "\
+yarn run v1.22.19
+$ vitest run --reporter=json
+{\"numTotalTests\": 10, \"numPassedTests\": 10, \"numFailedTests\": 0, \"numPendingTests\": 0, \"testResults\": [], \"startTime\": 1000, \"endTime\": 2000}
+Done in 3.45s";
+        let filtered = filter_yarn_output(raw_output);
+        let filter_type = identify_filter("test");
+        assert_eq!(filter_type, Some("vitest"));
+        let result = apply_identified_filter("vitest", &filtered).unwrap();
+        assert!(
+            result.contains("PASS"),
+            "Expected vitest filter applied, got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_non_workspace_lint_routes_lint() {
+        let raw_output = "\
+yarn run v1.22.19
+$ eslint src/
+Done in 5.00s
+src/index.ts
+  10:5  error  Unexpected console statement  no-console
+  15:1  error  Missing return type  @typescript-eslint/explicit-function-return-type";
+        let filtered = filter_yarn_output(raw_output);
+        let filter_type = identify_filter("lint");
+        assert_eq!(filter_type, Some("lint"));
+        let result = apply_identified_filter("lint", &filtered).unwrap();
+        // lint filter should process the output (at minimum preserve error info)
+        assert!(
+            result.contains("error") || result.contains("no-console"),
+            "Expected lint filter applied, got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_non_workspace_build_passthrough() {
+        // "build" is not a known filter script → identify_filter returns None
+        assert_eq!(identify_filter("build"), None);
+        assert_eq!(identify_filter("dev"), None);
+        assert_eq!(identify_filter("start"), None);
+        assert_eq!(identify_filter("clean"), None);
+    }
+
+    #[test]
+    fn test_non_workspace_run_keyword() {
+        // When args = ["run", "test"], script should be "test" (second element)
+        let args: Vec<String> = vec!["run".into(), "test".into()];
+        let script_name = if args[0] == "run" {
+            args[1].as_str()
+        } else {
+            args[0].as_str()
+        };
+        assert_eq!(script_name, "test");
+        assert_eq!(identify_filter(script_name), Some("vitest"));
+    }
+}

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -41,7 +41,6 @@ pub fn category_avg_tokens(category: &str, subcmd: &str) -> usize {
         _ => 150,
     }
 }
-
 lazy_static! {
     static ref REGEX_SET: RegexSet = RegexSet::new(PATTERNS).expect("invalid regex patterns");
     static ref COMPILED: Vec<Regex> = PATTERNS
@@ -2183,6 +2182,32 @@ mod tests {
                 "PATTERNS[{i}] = '{pattern}' is not a valid regex"
             );
         }
+    }
+
+    // ── Yarn rewrite tests ──
+
+    #[test]
+    fn test_rewrite_yarn_test() {
+        assert_eq!(
+            rewrite_command("yarn test", &[]),
+            Some("rtk yarn test".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_yarn_run_lint() {
+        assert_eq!(
+            rewrite_command("yarn run lint", &[]),
+            Some("rtk yarn run lint".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_yarn_workspace() {
+        assert_eq!(
+            rewrite_command("yarn workspace @scope/app run build", &[]),
+            Some("rtk yarn workspace @scope/app run build".into())
+        );
     }
 
     // --- #196: gh --json/--jq/--template passthrough ---

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -55,6 +55,8 @@ pub const PATTERNS: &[&str] = &[
     r"^aws\s+",
     // PostgreSQL
     r"^psql(\s|$)",
+    // Yarn
+    r"^yarn\s+(workspace\s+|run\s+|test|lint|typecheck|build|dev|format)",
     // TOML-filtered commands
     r"^ansible-playbook\b",
     r"^brew\s+(install|upgrade)\b",
@@ -393,6 +395,15 @@ pub const RULES: &[RtkRule] = &[
         rewrite_prefixes: &["psql"],
         category: "Infra",
         savings_pct: 75.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
+    // Yarn
+    RtkRule {
+        rtk_cmd: "rtk yarn",
+        rewrite_prefixes: &["yarn"],
+        category: "PackageManager",
+        savings_pct: 70.0,
         subcmd_savings: &[],
         subcmd_status: &[],
     },

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -140,6 +140,7 @@ rtk gh api              # Compact API responses (26%)
 rtk pnpm list           # Compact dependency tree (70%)
 rtk pnpm outdated       # Compact outdated packages (80%)
 rtk pnpm install        # Compact install output (90%)
+rtk yarn workspace <pkg> <script>  # Strip boilerplate, route to filters (70%)
 rtk npm run <script>    # Compact npm script output
 rtk npx <cmd>           # Compact npx command output
 rtk prisma              # Prisma without ASCII art (88%)
@@ -197,7 +198,7 @@ rtk init --global       # Add RTK to ~/.claude/CLAUDE.md
 | Build | next, tsc, lint, prettier | 70-87% |
 | Git | status, log, diff, add, commit | 59-80% |
 | GitHub | gh pr, gh run, gh issue | 26-87% |
-| Package Managers | pnpm, npm, npx | 70-90% |
+| Package Managers | pnpm, yarn, npm, npx | 70-90% |
 | Files | ls, read, grep, find | 60-75% |
 | Infrastructure | docker, kubectl | 85% |
 | Network | curl, wget | 65-70% |
@@ -2412,6 +2413,7 @@ mod tests {
             "rtk playwright",
             "rtk prisma",
             "rtk pnpm",
+            "rtk yarn",
             "rtk npm",
             "rtk curl",
             "rtk git",

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use cmds::git::{diff_cmd, gh_cmd, git, gt_cmd};
 use cmds::go::{go_cmd, golangci_cmd};
 use cmds::js::{
     lint_cmd, next_cmd, npm_cmd, playwright_cmd, pnpm_cmd, prettier_cmd, prisma_cmd, tsc_cmd,
-    vitest_cmd,
+    vitest_cmd, yarn_cmd,
 };
 use cmds::python::{mypy_cmd, pip_cmd, pytest_cmd, ruff_cmd};
 use cmds::ruby::{rake_cmd, rspec_cmd, rubocop_cmd};
@@ -501,6 +501,13 @@ enum Commands {
     /// npx with intelligent routing (tsc, eslint, prisma -> specialized filters)
     Npx {
         /// npx arguments (command + options)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// Yarn commands with compact output (strip boilerplate, route scripts to filters)
+    Yarn {
+        /// Yarn arguments (e.g., workspace my-app run test)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -1863,6 +1870,10 @@ fn main() -> Result<()> {
             npm_cmd::run(&args, cli.verbose, cli.skip_env)?;
         }
 
+        Commands::Yarn { args } => {
+            yarn_cmd::run(&args, cli.verbose, cli.skip_env)?;
+        }
+
         Commands::Curl { args } => {
             curl_cmd::run(&args, cli.verbose)?;
         }
@@ -2259,6 +2270,7 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Cargo { .. }
             | Commands::Npm { .. }
             | Commands::Npx { .. }
+            | Commands::Yarn { .. }
             | Commands::Curl { .. }
             | Commands::Ruff { .. }
             | Commands::Pytest { .. }


### PR DESCRIPTION
## Summary

- Implements `rtk yarn workspace <pkg> [run] <script>` with yarn boilerplate stripping and filter routing to existing RTK filters (vitest, tsc, lint, prettier)
- Implements `rtk yarn <script>` (non-workspace) with the same filter routing -- `yarn test` routes to vitest, `yarn lint` routes to lint filter, etc.
- Compound scripts (`test:lib`, `lint:check`) route by prefix with safe fallback to passthrough if filter doesn't match
- Native yarn commands (`install`, `add`, `why`, etc.) passthrough directly without capture
- Adds yarn patterns to `discover/registry.rs` for `rtk rewrite` / `rtk discover` support

## Windows .cmd fix

On Windows, `Command::new("yarn")` fails because the actual binary is `yarn.cmd`. This PR introduces `script_cmd()` in `utils.rs` which appends `.cmd` on Windows. It is used by `yarn_cmd.rs` and `tsc_cmd.rs`.

Several other modules have the same issue (`pnpm_cmd.rs`, `playwright_cmd.rs`, `prisma_cmd.rs`, `next_cmd.rs`, `npm_cmd.rs`) but are not touched here. If preferred, we can extract the `script_cmd()` + yarn/tsc usage into a separate PR and submit a follow-up PR to fix all Node.js commands at once.

## Depends on

**#241** (`feat/rtk-rewrite`) -- this branch is based on the rewrite architecture from #241 and uses its `rewrite_prefixes` / `PATTERNS` infrastructure in the registry.

## Relation to #226

This is a clean rewrite of #226 (@denneulin) integrating all 5 review fixes:
1. Non-workspace commands passthrough (not just workspace)
2. Boilerplate stripping covers `yarn workspace v1.x`, warnings, script echoes
3. Vitest routing uses dedicated parser (not generic test runner)
4. No double stderr printing
5. Native yarn command denylist prevents `add`/`install` interception as scripts

## Tests

- 42 unit tests in `yarn_cmd.rs` (boilerplate stripping, filter routing, native denylist, Clap parsing, compound scripts)
- 3 registry rewrite tests for yarn in `registry.rs`
- All 520 existing tests passing

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` passes (no new warnings)
- [x] `cargo test --all` passes (520 tests)
- [x] Manual test: `rtk yarn test` on a yarn project
- [x] Manual test: `rtk yarn workspace <pkg> run test` on a monorepo
- [x] Manual test: `rtk yarn install` passthrough