### PR TITLE
fix: skip curl JSON schema when larger than original

### DIFF
--- a/src/curl_cmd.rs
+++ b/src/curl_cmd.rs
@@ -55,7 +55,10 @@ fn filter_curl_output(output: &str) -> String {
         && (trimmed.ends_with('}') || trimmed.ends_with(']'))
     {
         if let Ok(schema) = json_cmd::filter_json_string(trimmed, 5) {
-            return schema;
+            // Only use schema if it's actually shorter than the original (saves tokens)
+            if schema.len() < trimmed.len() {
+                return schema;
+            }
         }
     }
 
@@ -85,12 +88,29 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_filter_curl_json() {
-        let output = r#"{"name": "test", "count": 42, "items": [1, 2, 3]}"#;
+    fn test_filter_curl_json_large() {
+        // Large JSON where schema is shorter than original
+        let output = r#"{"name": "test value here", "count": 42, "items": [1, 2, 3], "description": "a longer description value", "active": true, "nested": {"key1": "val1", "key2": "val2"}}"#;
         let result = filter_curl_output(output);
         assert!(result.contains("name"));
         assert!(result.contains("string"));
         assert!(result.contains("int"));
+        assert!(
+            result.len() < output.len(),
+            "Schema should be shorter than original for large JSON"
+        );
+    }
+
+    #[test]
+    fn test_filter_curl_json_small_returns_original() {
+        // Small JSON where schema would be same size or larger
+        let output = r#"{"ok": true}"#;
+        let result = filter_curl_output(output);
+        // Should return original JSON since schema isn't shorter
+        assert!(
+            result.contains("true"),
+            "Small JSON should preserve original values"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds a size guard to `filter_curl_output()` in `curl_cmd.rs`: the JSON-to-schema replacement is only applied when the schema is actually shorter than the original response
- For small JSON payloads like `{"r2Ready": true, "status": "ok"}`, the schema (`{ r2Ready: bool, status: string }`) is the same size or larger, so the original is now returned instead
- Larger JSON responses still get schema replacement as before (the schema is genuinely shorter)

Fixes #297

## Test plan
- [x] Added `test_filter_curl_json_small_returns_original` — verifies small JSON is returned as-is
- [x] Updated `test_filter_curl_json_large` — verifies large JSON still gets schema replacement
- [x] All 516 existing tests pass
- [x] Manual test: `rtk curl https://httpbin.org/get` still returns schema (large response)
- [x] Manual test: small JSON responses preserve original values