### PR TITLE
feat: add OpenCode integration (plugin + setup)

### DIFF
--- a/opencode/README.md
+++ b/opencode/README.md
@@ -1,0 +1,102 @@
+# RTK — OpenCode Integration
+
+Use [RTK (Rust Token Killer)](https://github.com/rtk-ai/rtk) with [OpenCode](https://github.com/sst/opencode) to save 60-90% of tokens on common dev operations.
+
+## How It Works
+
+RTK already supports Claude Code via a `PreToolUse` hook. OpenCode uses a different plugin system — `tool.execute.before` hooks inside `.ts`/`.js` plugin files.
+
+This integration provides:
+
+- **`plugins/rtk-rewrite.ts`** — An OpenCode plugin that intercepts bash tool calls and rewrites them to their rtk equivalents using `rtk rewrite` (the same single-source-of-truth rewrite engine used by the Claude Code hook).
+- **`rtk-awareness.md`** — A slim set of instructions to append to your `AGENTS.md` so the LLM knows about rtk meta-commands (`rtk gain`, `rtk discover`, etc.).
+- **`setup.sh`** — One-command installer that copies the plugin and patches AGENTS.md.
+
+## Quick Start
+
+### Automated
+
+```bash
+# Global install (all OpenCode projects):
+./opencode/setup.sh
+
+# Per-project install:
+./opencode/setup.sh --local
+```
+
+### Manual
+
+1. **Copy the plugin** to your OpenCode plugins directory:
+
+   ```bash
+   # Global
+   mkdir -p ~/.config/opencode/plugins
+   cp opencode/plugins/rtk-rewrite.ts ~/.config/opencode/plugins/
+
+   # Or per-project
+   mkdir -p .opencode/plugins
+   cp opencode/plugins/rtk-rewrite.ts .opencode/plugins/
+   ```
+
+2. **Add RTK awareness to AGENTS.md** (optional but recommended — lets the LLM use meta-commands like `rtk gain`):
+
+   ```bash
+   cat opencode/rtk-awareness.md >> ~/.config/opencode/AGENTS.md
+   # or
+   cat opencode/rtk-awareness.md >> AGENTS.md
+   ```
+
+3. **Restart OpenCode** and run a command — e.g. `git status` — to verify rewriting works.
+
+## Requirements
+
+- [rtk](https://github.com/rtk-ai/rtk) >= 0.23.0 on your PATH
+- [OpenCode](https://github.com/sst/opencode)
+
+The plugin checks for rtk at startup and disables itself gracefully if rtk is missing or too old.
+
+## Commands Rewritten
+
+The plugin delegates to `rtk rewrite`, which is the same registry used by the Claude Code hook. All of these are rewritten transparently:
+
+| Raw Command | Rewritten To |
+|---|---|
+| `git status/diff/log/add/commit/push/pull/...` | `rtk git ...` |
+| `gh pr/issue/run` | `rtk gh ...` |
+| `cargo test/build/clippy` | `rtk cargo ...` |
+| `cat <file>` | `rtk read <file>` |
+| `rg/grep <pattern>` | `rtk grep <pattern>` |
+| `ls` | `rtk ls` |
+| `vitest/pnpm test` | `rtk vitest run` |
+| `tsc/pnpm tsc` | `rtk tsc` |
+| `eslint/pnpm lint` | `rtk lint` |
+| `ruff check/format` | `rtk ruff ...` |
+| `pytest` | `rtk pytest` |
+| `go test/build/vet` | `rtk go ...` |
+| `docker ps/images/logs` | `rtk docker ...` |
+| `kubectl get/logs` | `rtk kubectl ...` |
+| `curl` | `rtk curl` |
+
+Commands already using `rtk`, heredocs (`<<`), and unrecognized commands pass through unchanged.
+
+## Comparison with Claude Code Integration
+
+| Aspect | Claude Code | OpenCode |
+|---|---|---|
+| Hook mechanism | `PreToolUse` shell hook in `settings.json` | `tool.execute.before` TypeScript plugin |
+| Rewrite engine | `rtk rewrite` (Rust binary) | Same `rtk rewrite` binary |
+| Setup command | `rtk init --global` | `./opencode/setup.sh` |
+| Context file | `CLAUDE.md` / `RTK.md` | `AGENTS.md` |
+| Plugin location | `~/.claude/hooks/` | `~/.config/opencode/plugins/` |
+
+## Uninstalling
+
+```bash
+# Global
+rm ~/.config/opencode/plugins/rtk-rewrite.ts
+
+# Per-project
+rm .opencode/plugins/rtk-rewrite.ts
+```
+
+Then manually remove the RTK section from your `AGENTS.md` if desired.

--- a/opencode/plugins/rtk-rewrite.ts
+++ b/opencode/plugins/rtk-rewrite.ts
@@ -1,0 +1,75 @@
+/**
+ * RTK (Rust Token Killer) — OpenCode plugin
+ *
+ * Transparently rewrites bash commands to their rtk equivalents before
+ * execution, saving 60-90% of tokens on common dev operations.
+ *
+ * Requires: rtk >= 0.23.0 installed and on PATH.
+ *
+ * Install:
+ *   cp rtk-rewrite.ts ~/.config/opencode/plugins/
+ *   # or
+ *   cp rtk-rewrite.ts .opencode/plugins/
+ */
+
+import type { Plugin } from "@opencode-ai/plugin"
+
+export const RtkRewritePlugin: Plugin = async ({ $ }) => {
+  // Verify rtk is available at startup
+  const hasRtk = await $`command -v rtk`.quiet().then(
+    () => true,
+    () => false,
+  )
+
+  if (!hasRtk) {
+    console.warn("[rtk] rtk binary not found on PATH — plugin disabled")
+    console.warn("[rtk] Install: cargo install --git https://github.com/rtk-ai/rtk")
+    return {}
+  }
+
+  // Version check: rtk rewrite requires >= 0.23.0
+  const versionOk = await $`rtk --version`
+    .quiet()
+    .text()
+    .then((out) => {
+      const match = out.match(/(\d+)\.(\d+)\.(\d+)/)
+      if (!match) return false
+      const [, major, minor] = match.map(Number)
+      return major > 0 || minor >= 23
+    })
+    .catch(() => false)
+
+  if (!versionOk) {
+    console.warn("[rtk] rtk >= 0.23.0 required for rewrite support — plugin disabled")
+    console.warn("[rtk] Upgrade: cargo install --git https://github.com/rtk-ai/rtk --force")
+    return {}
+  }
+
+  return {
+    "tool.execute.before": async (input, output) => {
+      if (input.tool !== "bash") return
+
+      const cmd: string | undefined = output.args?.command
+      if (!cmd || cmd.trim().length === 0) return
+
+      // Skip commands already using rtk
+      if (cmd.trimStart().startsWith("rtk ")) return
+
+      // Skip heredocs
+      if (cmd.includes("<<")) return
+
+      // Delegate rewrite logic to rtk binary (single source of truth)
+      // rtk rewrite exits 1 when there's no rewrite — we just keep the
+      // original command in that case.
+      const rewritten = await $`rtk rewrite ${cmd}`
+        .quiet()
+        .text()
+        .then((t) => t.trim())
+        .catch(() => null)
+
+      if (!rewritten || rewritten === cmd) return
+
+      output.args.command = rewritten
+    },
+  }
+}

--- a/opencode/rtk-awareness.md
+++ b/opencode/rtk-awareness.md
@@ -1,0 +1,29 @@
+# RTK - Rust Token Killer
+
+**Usage**: Token-optimized CLI proxy (60-90% savings on dev operations)
+
+## Meta Commands (always use rtk directly)
+
+```bash
+rtk gain              # Show token savings analytics
+rtk gain --history    # Show command usage history with savings
+rtk discover          # Analyze session history for missed opportunities
+rtk proxy <cmd>       # Execute raw command without filtering (for debugging)
+```
+
+## Installation Verification
+
+```bash
+rtk --version         # Should show: rtk X.Y.Z
+rtk gain              # Should work (not "command not found")
+which rtk             # Verify correct binary
+```
+
+⚠️ **Name collision**: If `rtk gain` fails, you may have reachingforthejack/rtk (Rust Type Kit) installed instead.
+
+## Plugin-Based Usage
+
+All other commands are automatically rewritten by the OpenCode plugin.
+Example: `git status` → `rtk git status` (transparent, 0 tokens overhead)
+
+Refer to AGENTS.md for full command reference.

--- a/opencode/setup.sh
+++ b/opencode/setup.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# RTK OpenCode integration setup script
+#
+# Usage:
+#   ./setup.sh              # Install globally (~/.config/opencode/)
+#   ./setup.sh --local      # Install into current project (.opencode/)
+#
+# Requires: rtk >= 0.23.0 on PATH
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# ── Flags ──────────────────────────────────────────────────────────
+LOCAL=false
+for arg in "$@"; do
+  case "$arg" in
+    --local) LOCAL=true ;;
+    --help|-h)
+      echo "Usage: $0 [--local]"
+      echo "  --local  Install into .opencode/ in the current directory"
+      echo "  (default) Install globally into ~/.config/opencode/"
+      exit 0
+      ;;
+  esac
+done
+
+# ── Pre-flight ─────────────────────────────────────────────────────
+if ! command -v rtk &>/dev/null; then
+  echo -e "${RED}Error: rtk not found on PATH${NC}"
+  echo "Install: cargo install --git https://github.com/rtk-ai/rtk"
+  exit 1
+fi
+
+RTK_VERSION=$(rtk --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+if [ -n "$RTK_VERSION" ]; then
+  MAJOR=$(echo "$RTK_VERSION" | cut -d. -f1)
+  MINOR=$(echo "$RTK_VERSION" | cut -d. -f2)
+  if [ "$MAJOR" -eq 0 ] && [ "$MINOR" -lt 23 ]; then
+    echo -e "${RED}Error: rtk $RTK_VERSION is too old (need >= 0.23.0)${NC}"
+    echo "Upgrade: cargo install --git https://github.com/rtk-ai/rtk --force"
+    exit 1
+  fi
+fi
+
+# ── Determine target directories ───────────────────────────────────
+if [ "$LOCAL" = true ]; then
+  PLUGIN_DIR=".opencode/plugins"
+  AGENTS_MD="AGENTS.md"
+  SCOPE="project"
+else
+  PLUGIN_DIR="$HOME/.config/opencode/plugins"
+  AGENTS_MD="$HOME/.config/opencode/AGENTS.md"
+  SCOPE="global"
+fi
+
+# ── Install plugin ─────────────────────────────────────────────────
+mkdir -p "$PLUGIN_DIR"
+cp "$SCRIPT_DIR/plugins/rtk-rewrite.ts" "$PLUGIN_DIR/rtk-rewrite.ts"
+echo -e "${GREEN}✅ Plugin installed: $PLUGIN_DIR/rtk-rewrite.ts${NC}"
+
+# ── Patch AGENTS.md with RTK awareness ─────────────────────────────
+RTK_AWARENESS="$SCRIPT_DIR/rtk-awareness.md"
+
+if [ -f "$AGENTS_MD" ]; then
+  if grep -q "RTK - Rust Token Killer" "$AGENTS_MD" 2>/dev/null; then
+    echo -e "${YELLOW}⚠️  AGENTS.md already contains RTK instructions — skipping${NC}"
+  else
+    echo "" >> "$AGENTS_MD"
+    cat "$RTK_AWARENESS" >> "$AGENTS_MD"
+    echo -e "${GREEN}✅ RTK awareness appended to $AGENTS_MD${NC}"
+  fi
+else
+  cp "$RTK_AWARENESS" "$AGENTS_MD"
+  echo -e "${GREEN}✅ Created $AGENTS_MD with RTK instructions${NC}"
+fi
+
+# ── Done ───────────────────────────────────────────────────────────
+echo ""
+echo -e "${GREEN}RTK + OpenCode integration installed (${SCOPE}).${NC}"
+echo ""
+echo "  Next steps:"
+echo "    1. Restart OpenCode"
+echo "    2. Run a command — e.g. git status — and verify rtk is used"
+echo "    3. Check savings: rtk gain"
+echo ""


### PR DESCRIPTION
## Summary

Add support for [OpenCode](https://github.com/sst/opencode) alongside the existing Claude Code integration. RTK's rewrite engine (`rtk rewrite`) is already agent-agnostic — this PR wires it into OpenCode's plugin system.

## What's included

| File | Purpose |
|---|---|
| `opencode/plugins/rtk-rewrite.ts` | `tool.execute.before` hook that calls `rtk rewrite` to transparently rewrite bash commands |
| `opencode/rtk-awareness.md` | Slim RTK instructions for `AGENTS.md` (meta commands, verification) |
| `opencode/setup.sh` | One-command installer — copies plugin + patches AGENTS.md (global or per-project) |
| `opencode/README.md` | Setup guide, command table, comparison with Claude Code flow |

## How it works

OpenCode plugins hook into `tool.execute.before`. When the tool is `bash`, the plugin:

1. Extracts the command string from `output.args.command`
2. Calls `rtk rewrite <cmd>` (same Rust binary / registry used by the Claude Code hook)
3. If a rewrite is returned, replaces the command — otherwise passes through unchanged

Commands already prefixed with `rtk` and heredocs are skipped. The plugin gracefully disables itself if rtk is missing or < 0.23.0.

## Setup

```bash
# Global (all OpenCode projects):
./opencode/setup.sh

# Per-project:
./opencode/setup.sh --local
```

Or manually copy `opencode/plugins/rtk-rewrite.ts` to `~/.config/opencode/plugins/`.

Co-Authored-By: Oz <oz-agent@warp.dev>