### PR TITLE
fix: curl JSON size guard (#297) + exclude_commands config (#243)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -293,7 +293,7 @@ SHARED            utils.rs          Helpers                N/A        ✓
                   tee.rs            Full output recovery   N/A        ✓
 ```
 
-**Total: 55 modules** (37 command modules + 18 infrastructure modules)
+**Total: 56 modules** (38 command modules + 18 infrastructure modules)
 
 ### Module Count Breakdown
 
@@ -1488,4 +1488,4 @@ When implementing a new command, consider:
 
 **Last Updated**: 2026-02-22
 **Architecture Version**: 2.2
-**rtk Version**: 0.24.0
+**rtk Version**: 0.25.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to rtk (Rust Token Killer) will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Features
+
+* **hooks:** `exclude_commands` config — exclude specific commands from auto-rewrite ([#243](https://github.com/rtk-ai/rtk/issues/243))
+
+### Bug Fixes
+
+* **curl:** skip JSON schema replacement when schema is larger than original payload ([#297](https://github.com/rtk-ai/rtk/issues/297))
+
 ## [0.25.0](https://github.com/rtk-ai/rtk/compare/v0.24.0...v0.25.0) (2026-03-05)
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This is a fork with critical fixes for git argument parsing and modern JavaScrip
 
 **Verify correct installation:**
 ```bash
-rtk --version  # Should show "rtk 0.24.0" (or newer)
+rtk --version  # Should show "rtk 0.25.0" (or newer)
 rtk gain       # Should show token savings stats (NOT "command not found")
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ rtk filters and compresses command outputs before they reach your LLM context, s
 
 **How to verify you have the correct rtk:**
 ```bash
-rtk --version   # Should show "rtk 0.24.0"
+rtk --version   # Should show "rtk 0.25.0"
 rtk gain        # Should show token savings stats
 ```
 

--- a/README.md
+++ b/README.md
@@ -455,6 +455,18 @@ database_path = "/path/to/custom.db"
 
 Priority: `RTK_DB_PATH` env var > `config.toml` > default location.
 
+### Excluding Commands from Auto-Rewrite
+
+By default, the hook rewrites all supported commands automatically. To exclude specific commands (e.g., keep raw `curl` output without schema extraction), add to your config:
+
+**Config file** (`~/.config/rtk/config.toml`, macOS: `~/Library/Application Support/rtk/config.toml`):
+```toml
+[hooks]
+exclude_commands = ["curl", "playwright"]
+```
+
+Excluded commands pass through the hook unchanged — no RTK filtering. This survives `rtk init -g` re-runs since the config file is user-owned.
+
 ### Tee: Full Output Recovery
 
 When RTK filters command output, LLM agents lose failure details (stack traces, assertion messages) and may re-run the same command 2-3 times. The **tee** feature saves raw output to a file so the agent can read it without re-executing.

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,16 @@ pub struct Config {
     pub tee: crate::tee::TeeConfig,
     #[serde(default)]
     pub telemetry: TelemetryConfig,
+    #[serde(default)]
+    pub hooks: HooksConfig,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct HooksConfig {
+    /// Commands to exclude from auto-rewrite (e.g. ["curl", "playwright"]).
+    /// Survives `rtk init -g` re-runs since config.toml is user-owned.
+    #[serde(default)]
+    pub exclude_commands: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -142,4 +152,36 @@ pub fn show_config() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hooks_config_deserialize() {
+        let toml = r#"
+[hooks]
+exclude_commands = ["curl", "gh"]
+"#;
+        let config: Config = toml::from_str(toml).expect("valid toml");
+        assert_eq!(config.hooks.exclude_commands, vec!["curl", "gh"]);
+    }
+
+    #[test]
+    fn test_hooks_config_default_empty() {
+        let config = Config::default();
+        assert!(config.hooks.exclude_commands.is_empty());
+    }
+
+    #[test]
+    fn test_config_without_hooks_section_is_valid() {
+        let toml = r#"
+[tracking]
+enabled = true
+history_days = 90
+"#;
+        let config: Config = toml::from_str(toml).expect("valid toml");
+        assert!(config.hooks.exclude_commands.is_empty());
+    }
 }

--- a/src/curl_cmd.rs
+++ b/src/curl_cmd.rs
@@ -55,7 +55,10 @@ fn filter_curl_output(output: &str) -> String {
         && (trimmed.ends_with('}') || trimmed.ends_with(']'))
     {
         if let Ok(schema) = json_cmd::filter_json_string(trimmed, 5) {
-            return schema;
+            // Only use schema if it's actually shorter than the original (#297)
+            if schema.len() <= trimmed.len() {
+                return schema;
+            }
         }
     }
 
@@ -86,7 +89,8 @@ mod tests {
 
     #[test]
     fn test_filter_curl_json() {
-        let output = r#"{"name": "test", "count": 42, "items": [1, 2, 3]}"#;
+        // Large JSON where schema is shorter than original — schema should be returned
+        let output = r#"{"name": "a very long user name here", "count": 42, "items": [1, 2, 3], "description": "a very long description that takes up many characters in the original JSON payload", "status": "active", "url": "https://example.com/api/v1/users/123"}"#;
         let result = filter_curl_output(output);
         assert!(result.contains("name"));
         assert!(result.contains("string"));
@@ -106,6 +110,16 @@ mod tests {
         let result = filter_curl_output(output);
         assert!(result.contains("Hello, World!"));
         assert!(result.contains("plain text"));
+    }
+
+    #[test]
+    fn test_filter_curl_json_small_returns_original() {
+        // Small JSON where schema would be larger than original (issue #297)
+        let output = r#"{"r2Ready":true,"status":"ok"}"#;
+        let result = filter_curl_output(output);
+        // Schema would be "{\n  r2Ready: bool,\n  status: string\n}" which is longer
+        // Should return the original JSON unchanged
+        assert_eq!(result.trim(), output.trim());
     }
 
     #[test]

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -249,7 +249,7 @@ pub fn split_command_chain(cmd: &str) -> Vec<&str> {
 ///
 /// Handles compound commands (`&&`, `||`, `;`) by rewriting each segment independently.
 /// For pipes (`|`), only rewrites the first command (the filter stays raw).
-pub fn rewrite_command(cmd: &str) -> Option<String> {
+pub fn rewrite_command(cmd: &str, excluded: &[String]) -> Option<String> {
     let trimmed = cmd.trim();
     if trimmed.is_empty() {
         return None;
@@ -272,11 +272,11 @@ pub fn rewrite_command(cmd: &str) -> Option<String> {
         return Some(trimmed.to_string());
     }
 
-    rewrite_compound(trimmed)
+    rewrite_compound(trimmed, excluded)
 }
 
 /// Rewrite a compound command (with `&&`, `||`, `;`, `|`) by rewriting each segment.
-fn rewrite_compound(cmd: &str) -> Option<String> {
+fn rewrite_compound(cmd: &str, excluded: &[String]) -> Option<String> {
     let bytes = cmd.as_bytes();
     let len = bytes.len();
     let mut result = String::with_capacity(len + 32);
@@ -301,7 +301,8 @@ fn rewrite_compound(cmd: &str) -> Option<String> {
                 if i + 1 < len && bytes[i + 1] == b'|' {
                     // `||` operator — rewrite left, continue
                     let seg = cmd[seg_start..i].trim();
-                    let rewritten = rewrite_segment(seg).unwrap_or_else(|| seg.to_string());
+                    let rewritten =
+                        rewrite_segment(seg, excluded).unwrap_or_else(|| seg.to_string());
                     if rewritten != seg {
                         any_changed = true;
                     }
@@ -315,7 +316,8 @@ fn rewrite_compound(cmd: &str) -> Option<String> {
                 } else {
                     // `|` pipe — rewrite first segment only, pass through the rest unchanged
                     let seg = cmd[seg_start..i].trim();
-                    let rewritten = rewrite_segment(seg).unwrap_or_else(|| seg.to_string());
+                    let rewritten =
+                        rewrite_segment(seg, excluded).unwrap_or_else(|| seg.to_string());
                     if rewritten != seg {
                         any_changed = true;
                     }
@@ -329,7 +331,7 @@ fn rewrite_compound(cmd: &str) -> Option<String> {
             b'&' if !in_single && !in_double && i + 1 < len && bytes[i + 1] == b'&' => {
                 // `&&` operator — rewrite left, continue
                 let seg = cmd[seg_start..i].trim();
-                let rewritten = rewrite_segment(seg).unwrap_or_else(|| seg.to_string());
+                let rewritten = rewrite_segment(seg, excluded).unwrap_or_else(|| seg.to_string());
                 if rewritten != seg {
                     any_changed = true;
                 }
@@ -344,7 +346,7 @@ fn rewrite_compound(cmd: &str) -> Option<String> {
             b'&' if !in_single && !in_double => {
                 // single `&` background execution operator
                 let seg = cmd[seg_start..i].trim();
-                let rewritten = rewrite_segment(seg).unwrap_or_else(|| seg.to_string());
+                let rewritten = rewrite_segment(seg, excluded).unwrap_or_else(|| seg.to_string());
                 if rewritten != seg {
                     any_changed = true;
                 }
@@ -359,7 +361,7 @@ fn rewrite_compound(cmd: &str) -> Option<String> {
             b';' if !in_single && !in_double => {
                 // `;` separator
                 let seg = cmd[seg_start..i].trim();
-                let rewritten = rewrite_segment(seg).unwrap_or_else(|| seg.to_string());
+                let rewritten = rewrite_segment(seg, excluded).unwrap_or_else(|| seg.to_string());
                 if rewritten != seg {
                     any_changed = true;
                 }
@@ -382,7 +384,7 @@ fn rewrite_compound(cmd: &str) -> Option<String> {
 
     // Last (or only) segment
     let seg = cmd[seg_start..len].trim();
-    let rewritten = rewrite_segment(seg).unwrap_or_else(|| seg.to_string());
+    let rewritten = rewrite_segment(seg, excluded).unwrap_or_else(|| seg.to_string());
     if rewritten != seg {
         any_changed = true;
     }
@@ -424,7 +426,7 @@ fn rewrite_head_numeric(cmd: &str) -> Option<String> {
 /// Rewrite a single (non-compound) command segment.
 /// Returns `Some(rewritten)` if matched (including already-RTK pass-through).
 /// Returns `None` if no match (caller uses original segment).
-fn rewrite_segment(seg: &str) -> Option<String> {
+fn rewrite_segment(seg: &str, excluded: &[String]) -> Option<String> {
     let trimmed = seg.trim();
     if trimmed.is_empty() {
         return None;
@@ -445,7 +447,14 @@ fn rewrite_segment(seg: &str) -> Option<String> {
 
     // Use classify_command for correct ignore/prefix handling
     let rtk_equivalent = match classify_command(trimmed) {
-        Classification::Supported { rtk_equivalent, .. } => rtk_equivalent,
+        Classification::Supported { rtk_equivalent, .. } => {
+            // Check if the base command is excluded from rewriting (#243)
+            let base = trimmed.split_whitespace().next().unwrap_or("");
+            if excluded.iter().any(|e| e == base) {
+                return None;
+            }
+            rtk_equivalent
+        }
         _ => return None,
     };
 
@@ -792,26 +801,32 @@ mod tests {
 
     #[test]
     fn test_rewrite_git_status() {
-        assert_eq!(rewrite_command("git status"), Some("rtk git status".into()));
+        assert_eq!(
+            rewrite_command("git status", &[]),
+            Some("rtk git status".into())
+        );
     }
 
     #[test]
     fn test_rewrite_git_log() {
         assert_eq!(
-            rewrite_command("git log -10"),
+            rewrite_command("git log -10", &[]),
             Some("rtk git log -10".into())
         );
     }
 
     #[test]
     fn test_rewrite_cargo_test() {
-        assert_eq!(rewrite_command("cargo test"), Some("rtk cargo test".into()));
+        assert_eq!(
+            rewrite_command("cargo test", &[]),
+            Some("rtk cargo test".into())
+        );
     }
 
     #[test]
     fn test_rewrite_compound_and() {
         assert_eq!(
-            rewrite_command("git add . && cargo test"),
+            rewrite_command("git add . && cargo test", &[]),
             Some("rtk git add . && rtk cargo test".into())
         );
     }
@@ -819,7 +834,10 @@ mod tests {
     #[test]
     fn test_rewrite_compound_three_segments() {
         assert_eq!(
-            rewrite_command("cargo fmt --all && cargo clippy --all-targets && cargo test"),
+            rewrite_command(
+                "cargo fmt --all && cargo clippy --all-targets && cargo test",
+                &[]
+            ),
             Some("rtk cargo fmt --all && rtk cargo clippy --all-targets && rtk cargo test".into())
         );
     }
@@ -827,7 +845,7 @@ mod tests {
     #[test]
     fn test_rewrite_already_rtk() {
         assert_eq!(
-            rewrite_command("rtk git status"),
+            rewrite_command("rtk git status", &[]),
             Some("rtk git status".into())
         );
     }
@@ -835,7 +853,7 @@ mod tests {
     #[test]
     fn test_rewrite_background_single_amp() {
         assert_eq!(
-            rewrite_command("cargo test & git status"),
+            rewrite_command("cargo test & git status", &[]),
             Some("rtk cargo test & rtk git status".into())
         );
     }
@@ -843,7 +861,7 @@ mod tests {
     #[test]
     fn test_rewrite_background_unsupported_right() {
         assert_eq!(
-            rewrite_command("cargo test & terraform plan"),
+            rewrite_command("cargo test & terraform plan", &[]),
             Some("rtk cargo test & terraform plan".into())
         );
     }
@@ -852,25 +870,25 @@ mod tests {
     fn test_rewrite_background_does_not_affect_double_amp() {
         // `&&` must still work after adding `&` support
         assert_eq!(
-            rewrite_command("cargo test && git status"),
+            rewrite_command("cargo test && git status", &[]),
             Some("rtk cargo test && rtk git status".into())
         );
     }
 
     #[test]
     fn test_rewrite_unsupported_returns_none() {
-        assert_eq!(rewrite_command("terraform plan"), None);
+        assert_eq!(rewrite_command("terraform plan", &[]), None);
     }
 
     #[test]
     fn test_rewrite_ignored_cd() {
-        assert_eq!(rewrite_command("cd /tmp"), None);
+        assert_eq!(rewrite_command("cd /tmp", &[]), None);
     }
 
     #[test]
     fn test_rewrite_with_env_prefix() {
         assert_eq!(
-            rewrite_command("GIT_SSH_COMMAND=ssh git push"),
+            rewrite_command("GIT_SSH_COMMAND=ssh git push", &[]),
             Some("GIT_SSH_COMMAND=ssh rtk git push".into())
         );
     }
@@ -878,7 +896,7 @@ mod tests {
     #[test]
     fn test_rewrite_npx_tsc() {
         assert_eq!(
-            rewrite_command("npx tsc --noEmit"),
+            rewrite_command("npx tsc --noEmit", &[]),
             Some("rtk tsc --noEmit".into())
         );
     }
@@ -886,7 +904,7 @@ mod tests {
     #[test]
     fn test_rewrite_pnpm_tsc() {
         assert_eq!(
-            rewrite_command("pnpm tsc --noEmit"),
+            rewrite_command("pnpm tsc --noEmit", &[]),
             Some("rtk tsc --noEmit".into())
         );
     }
@@ -894,7 +912,7 @@ mod tests {
     #[test]
     fn test_rewrite_cat_file() {
         assert_eq!(
-            rewrite_command("cat src/main.rs"),
+            rewrite_command("cat src/main.rs", &[]),
             Some("rtk read src/main.rs".into())
         );
     }
@@ -902,7 +920,7 @@ mod tests {
     #[test]
     fn test_rewrite_rg_pattern() {
         assert_eq!(
-            rewrite_command("rg \"fn main\""),
+            rewrite_command("rg \"fn main\"", &[]),
             Some("rtk grep \"fn main\"".into())
         );
     }
@@ -910,7 +928,7 @@ mod tests {
     #[test]
     fn test_rewrite_npx_playwright() {
         assert_eq!(
-            rewrite_command("npx playwright test"),
+            rewrite_command("npx playwright test", &[]),
             Some("rtk playwright test".into())
         );
     }
@@ -918,7 +936,7 @@ mod tests {
     #[test]
     fn test_rewrite_next_build() {
         assert_eq!(
-            rewrite_command("next build --turbo"),
+            rewrite_command("next build --turbo", &[]),
             Some("rtk next --turbo".into())
         );
     }
@@ -927,27 +945,27 @@ mod tests {
     fn test_rewrite_pipe_first_only() {
         // After a pipe, the filter command stays raw
         assert_eq!(
-            rewrite_command("git log -10 | grep feat"),
+            rewrite_command("git log -10 | grep feat", &[]),
             Some("rtk git log -10 | grep feat".into())
         );
     }
 
     #[test]
     fn test_rewrite_heredoc_returns_none() {
-        assert_eq!(rewrite_command("cat <<'EOF'\nfoo\nEOF"), None);
+        assert_eq!(rewrite_command("cat <<'EOF'\nfoo\nEOF", &[]), None);
     }
 
     #[test]
     fn test_rewrite_empty_returns_none() {
-        assert_eq!(rewrite_command(""), None);
-        assert_eq!(rewrite_command("   "), None);
+        assert_eq!(rewrite_command("", &[]), None);
+        assert_eq!(rewrite_command("   ", &[]), None);
     }
 
     #[test]
     fn test_rewrite_mixed_compound_partial() {
         // First segment already RTK, second gets rewritten
         assert_eq!(
-            rewrite_command("rtk git add . && cargo test"),
+            rewrite_command("rtk git add . && cargo test", &[]),
             Some("rtk git add . && rtk cargo test".into())
         );
     }
@@ -958,7 +976,7 @@ mod tests {
     fn test_rewrite_head_numeric_flag() {
         // head -20 file → rtk read file --max-lines 20 (not rtk read -20 file)
         assert_eq!(
-            rewrite_command("head -20 src/main.rs"),
+            rewrite_command("head -20 src/main.rs", &[]),
             Some("rtk read src/main.rs --max-lines 20".into())
         );
     }
@@ -966,7 +984,7 @@ mod tests {
     #[test]
     fn test_rewrite_head_lines_long_flag() {
         assert_eq!(
-            rewrite_command("head --lines=50 src/lib.rs"),
+            rewrite_command("head --lines=50 src/lib.rs", &[]),
             Some("rtk read src/lib.rs --max-lines 50".into())
         );
     }
@@ -975,7 +993,7 @@ mod tests {
     fn test_rewrite_head_no_flag_still_rewrites() {
         // plain `head file` → `rtk read file` (no numeric flag)
         assert_eq!(
-            rewrite_command("head src/main.rs"),
+            rewrite_command("head src/main.rs", &[]),
             Some("rtk read src/main.rs".into())
         );
     }
@@ -983,7 +1001,7 @@ mod tests {
     #[test]
     fn test_rewrite_head_other_flag_skipped() {
         // head -c 100 file: unsupported flag, skip rewriting
-        assert_eq!(rewrite_command("head -c 100 src/main.rs"), None);
+        assert_eq!(rewrite_command("head -c 100 src/main.rs", &[]), None);
     }
 
     // --- New registry entries ---
@@ -1089,13 +1107,16 @@ mod tests {
 
     #[test]
     fn test_rewrite_tree() {
-        assert_eq!(rewrite_command("tree src/"), Some("rtk tree src/".into()));
+        assert_eq!(
+            rewrite_command("tree src/", &[]),
+            Some("rtk tree src/".into())
+        );
     }
 
     #[test]
     fn test_rewrite_diff() {
         assert_eq!(
-            rewrite_command("diff file1.txt file2.txt"),
+            rewrite_command("diff file1.txt file2.txt", &[]),
             Some("rtk diff file1.txt file2.txt".into())
         );
     }
@@ -1103,7 +1124,7 @@ mod tests {
     #[test]
     fn test_rewrite_gh_release() {
         assert_eq!(
-            rewrite_command("gh release list"),
+            rewrite_command("gh release list", &[]),
             Some("rtk gh release list".into())
         );
     }
@@ -1111,7 +1132,7 @@ mod tests {
     #[test]
     fn test_rewrite_cargo_install() {
         assert_eq!(
-            rewrite_command("cargo install rtk"),
+            rewrite_command("cargo install rtk", &[]),
             Some("rtk cargo install rtk".into())
         );
     }
@@ -1119,7 +1140,7 @@ mod tests {
     #[test]
     fn test_rewrite_kubectl_describe() {
         assert_eq!(
-            rewrite_command("kubectl describe pod mypod"),
+            rewrite_command("kubectl describe pod mypod", &[]),
             Some("rtk kubectl describe pod mypod".into())
         );
     }
@@ -1127,7 +1148,7 @@ mod tests {
     #[test]
     fn test_rewrite_docker_run() {
         assert_eq!(
-            rewrite_command("docker run --rm ubuntu bash"),
+            rewrite_command("docker run --rm ubuntu bash", &[]),
             Some("rtk docker run --rm ubuntu bash".into())
         );
     }
@@ -1180,13 +1201,16 @@ mod tests {
 
     #[test]
     fn test_rewrite_aws() {
-        assert_eq!(rewrite_command("aws s3 ls"), Some("rtk aws s3 ls".into()));
+        assert_eq!(
+            rewrite_command("aws s3 ls", &[]),
+            Some("rtk aws s3 ls".into())
+        );
     }
 
     #[test]
     fn test_rewrite_aws_ec2() {
         assert_eq!(
-            rewrite_command("aws ec2 describe-instances --region us-east-1"),
+            rewrite_command("aws ec2 describe-instances --region us-east-1", &[]),
             Some("rtk aws ec2 describe-instances --region us-east-1".into())
         );
     }
@@ -1194,7 +1218,7 @@ mod tests {
     #[test]
     fn test_rewrite_psql() {
         assert_eq!(
-            rewrite_command("psql -U postgres -d mydb"),
+            rewrite_command("psql -U postgres -d mydb", &[]),
             Some("rtk psql -U postgres -d mydb".into())
         );
     }
@@ -1270,7 +1294,7 @@ mod tests {
     #[test]
     fn test_rewrite_ruff_check() {
         assert_eq!(
-            rewrite_command("ruff check ."),
+            rewrite_command("ruff check .", &[]),
             Some("rtk ruff check .".into())
         );
     }
@@ -1278,7 +1302,7 @@ mod tests {
     #[test]
     fn test_rewrite_ruff_format() {
         assert_eq!(
-            rewrite_command("ruff format src/"),
+            rewrite_command("ruff format src/", &[]),
             Some("rtk ruff format src/".into())
         );
     }
@@ -1286,7 +1310,7 @@ mod tests {
     #[test]
     fn test_rewrite_pytest() {
         assert_eq!(
-            rewrite_command("pytest tests/"),
+            rewrite_command("pytest tests/", &[]),
             Some("rtk pytest tests/".into())
         );
     }
@@ -1294,27 +1318,33 @@ mod tests {
     #[test]
     fn test_rewrite_python_m_pytest() {
         assert_eq!(
-            rewrite_command("python -m pytest -x tests/"),
+            rewrite_command("python -m pytest -x tests/", &[]),
             Some("rtk pytest -x tests/".into())
         );
     }
 
     #[test]
     fn test_rewrite_pip_list() {
-        assert_eq!(rewrite_command("pip list"), Some("rtk pip list".into()));
+        assert_eq!(
+            rewrite_command("pip list", &[]),
+            Some("rtk pip list".into())
+        );
     }
 
     #[test]
     fn test_rewrite_pip_outdated() {
         assert_eq!(
-            rewrite_command("pip outdated"),
+            rewrite_command("pip outdated", &[]),
             Some("rtk pip outdated".into())
         );
     }
 
     #[test]
     fn test_rewrite_uv_pip_list() {
-        assert_eq!(rewrite_command("uv pip list"), Some("rtk pip list".into()));
+        assert_eq!(
+            rewrite_command("uv pip list", &[]),
+            Some("rtk pip list".into())
+        );
     }
 
     // --- Go tooling ---
@@ -1366,7 +1396,7 @@ mod tests {
     #[test]
     fn test_rewrite_go_test() {
         assert_eq!(
-            rewrite_command("go test ./..."),
+            rewrite_command("go test ./...", &[]),
             Some("rtk go test ./...".into())
         );
     }
@@ -1374,7 +1404,7 @@ mod tests {
     #[test]
     fn test_rewrite_go_build() {
         assert_eq!(
-            rewrite_command("go build ./..."),
+            rewrite_command("go build ./...", &[]),
             Some("rtk go build ./...".into())
         );
     }
@@ -1382,7 +1412,7 @@ mod tests {
     #[test]
     fn test_rewrite_go_vet() {
         assert_eq!(
-            rewrite_command("go vet ./..."),
+            rewrite_command("go vet ./...", &[]),
             Some("rtk go vet ./...".into())
         );
     }
@@ -1390,7 +1420,7 @@ mod tests {
     #[test]
     fn test_rewrite_golangci_lint() {
         assert_eq!(
-            rewrite_command("golangci-lint run ./..."),
+            rewrite_command("golangci-lint run ./...", &[]),
             Some("rtk golangci-lint run ./...".into())
         );
     }
@@ -1410,13 +1440,16 @@ mod tests {
 
     #[test]
     fn test_rewrite_vitest() {
-        assert_eq!(rewrite_command("vitest run"), Some("rtk vitest run".into()));
+        assert_eq!(
+            rewrite_command("vitest run", &[]),
+            Some("rtk vitest run".into())
+        );
     }
 
     #[test]
     fn test_rewrite_pnpm_vitest() {
         assert_eq!(
-            rewrite_command("pnpm vitest run"),
+            rewrite_command("pnpm vitest run", &[]),
             Some("rtk vitest run".into())
         );
     }
@@ -1435,7 +1468,7 @@ mod tests {
     #[test]
     fn test_rewrite_prisma() {
         assert_eq!(
-            rewrite_command("npx prisma migrate dev"),
+            rewrite_command("npx prisma migrate dev", &[]),
             Some("rtk prisma migrate dev".into())
         );
     }
@@ -1443,14 +1476,17 @@ mod tests {
     #[test]
     fn test_rewrite_prettier() {
         assert_eq!(
-            rewrite_command("npx prettier --check src/"),
+            rewrite_command("npx prettier --check src/", &[]),
             Some("rtk prettier --check src/".into())
         );
     }
 
     #[test]
     fn test_rewrite_pnpm_list() {
-        assert_eq!(rewrite_command("pnpm list"), Some("rtk pnpm list".into()));
+        assert_eq!(
+            rewrite_command("pnpm list", &[]),
+            Some("rtk pnpm list".into())
+        );
     }
 
     // --- Compound operator edge cases ---
@@ -1459,7 +1495,7 @@ mod tests {
     fn test_rewrite_compound_or() {
         // `||` fallback: left rewritten, right rewritten
         assert_eq!(
-            rewrite_command("cargo test || cargo build"),
+            rewrite_command("cargo test || cargo build", &[]),
             Some("rtk cargo test || rtk cargo build".into())
         );
     }
@@ -1467,7 +1503,7 @@ mod tests {
     #[test]
     fn test_rewrite_compound_semicolon() {
         assert_eq!(
-            rewrite_command("git status; cargo test"),
+            rewrite_command("git status; cargo test", &[]),
             Some("rtk git status; rtk cargo test".into())
         );
     }
@@ -1476,7 +1512,7 @@ mod tests {
     fn test_rewrite_compound_pipe_raw_filter() {
         // Pipe: rewrite first segment only, pass through rest unchanged
         assert_eq!(
-            rewrite_command("cargo test | grep FAILED"),
+            rewrite_command("cargo test | grep FAILED", &[]),
             Some("rtk cargo test | grep FAILED".into())
         );
     }
@@ -1484,7 +1520,7 @@ mod tests {
     #[test]
     fn test_rewrite_compound_pipe_git_grep() {
         assert_eq!(
-            rewrite_command("git log -10 | grep feat"),
+            rewrite_command("git log -10 | grep feat", &[]),
             Some("rtk git log -10 | grep feat".into())
         );
     }
@@ -1492,7 +1528,10 @@ mod tests {
     #[test]
     fn test_rewrite_compound_four_segments() {
         assert_eq!(
-            rewrite_command("cargo fmt --all && cargo clippy && cargo test && git status"),
+            rewrite_command(
+                "cargo fmt --all && cargo clippy && cargo test && git status",
+                &[]
+            ),
             Some(
                 "rtk cargo fmt --all && rtk cargo clippy && rtk cargo test && rtk git status"
                     .into()
@@ -1504,7 +1543,7 @@ mod tests {
     fn test_rewrite_compound_mixed_supported_unsupported() {
         // unsupported segments stay raw
         assert_eq!(
-            rewrite_command("cargo test && terraform plan"),
+            rewrite_command("cargo test && terraform plan", &[]),
             Some("rtk cargo test && terraform plan".into())
         );
     }
@@ -1512,7 +1551,10 @@ mod tests {
     #[test]
     fn test_rewrite_compound_all_unsupported_returns_none() {
         // No rewrite at all: returns None
-        assert_eq!(rewrite_command("terraform plan && terraform apply"), None);
+        assert_eq!(
+            rewrite_command("terraform plan && terraform apply", &[]),
+            None
+        );
     }
 
     // --- sudo / env prefix + rewrite ---
@@ -1520,7 +1562,7 @@ mod tests {
     #[test]
     fn test_rewrite_sudo_docker() {
         assert_eq!(
-            rewrite_command("sudo docker ps"),
+            rewrite_command("sudo docker ps", &[]),
             Some("sudo rtk docker ps".into())
         );
     }
@@ -1528,7 +1570,7 @@ mod tests {
     #[test]
     fn test_rewrite_env_var_prefix() {
         assert_eq!(
-            rewrite_command("GIT_SSH_COMMAND=ssh git push origin main"),
+            rewrite_command("GIT_SSH_COMMAND=ssh git push origin main", &[]),
             Some("GIT_SSH_COMMAND=ssh rtk git push origin main".into())
         );
     }
@@ -1538,7 +1580,7 @@ mod tests {
     #[test]
     fn test_rewrite_find_with_flags() {
         assert_eq!(
-            rewrite_command("find . -name '*.rs' -type f"),
+            rewrite_command("find . -name '*.rs' -type f", &[]),
             Some("rtk find . -name '*.rs' -type f".into())
         );
     }
@@ -1574,6 +1616,42 @@ mod tests {
                 rule.rtk_cmd
             );
         }
+    }
+
+    // --- exclude_commands (#243) ---
+
+    #[test]
+    fn test_rewrite_excludes_curl() {
+        let excluded = vec!["curl".to_string()];
+        assert_eq!(
+            rewrite_command("curl https://api.example.com/health", &excluded),
+            None
+        );
+    }
+
+    #[test]
+    fn test_rewrite_exclude_does_not_affect_other_commands() {
+        let excluded = vec!["curl".to_string()];
+        assert_eq!(
+            rewrite_command("git status", &excluded),
+            Some("rtk git status".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_empty_excludes_rewrites_curl() {
+        let excluded: Vec<String> = vec![];
+        assert!(rewrite_command("curl https://api.example.com", &excluded).is_some());
+    }
+
+    #[test]
+    fn test_rewrite_compound_partial_exclude() {
+        // curl excluded but git still rewrites
+        let excluded = vec!["curl".to_string()];
+        assert_eq!(
+            rewrite_command("git status && curl https://api.example.com", &excluded),
+            Some("rtk git status && curl https://api.example.com".into())
+        );
     }
 
     // --- Every PATTERN compiles to a valid Regex ---

--- a/src/rewrite_cmd.rs
+++ b/src/rewrite_cmd.rs
@@ -11,7 +11,11 @@ use crate::discover::registry;
 /// [ "$CMD" = "$REWRITTEN" ] && exit 0  # already RTK, skip
 /// ```
 pub fn run(cmd: &str) -> anyhow::Result<()> {
-    match registry::rewrite_command(cmd) {
+    let excluded = crate::config::Config::load()
+        .map(|c| c.hooks.exclude_commands)
+        .unwrap_or_default();
+
+    match registry::rewrite_command(cmd, &excluded) {
         Some(rewritten) => {
             print!("{}", rewritten);
             Ok(())
@@ -28,19 +32,18 @@ mod tests {
 
     #[test]
     fn test_run_supported_command_succeeds() {
-        // We can't easily test exit code here, but we can test the registry directly
-        assert!(registry::rewrite_command("git status").is_some());
+        assert!(registry::rewrite_command("git status", &[]).is_some());
     }
 
     #[test]
     fn test_run_unsupported_returns_none() {
-        assert!(registry::rewrite_command("terraform plan").is_none());
+        assert!(registry::rewrite_command("terraform plan", &[]).is_none());
     }
 
     #[test]
     fn test_run_already_rtk_returns_some() {
         assert_eq!(
-            registry::rewrite_command("rtk git status"),
+            registry::rewrite_command("rtk git status", &[]),
             Some("rtk git status".into())
         );
     }


### PR DESCRIPTION
## Summary

Fixes two related issues with the auto-rewrite hook behavior.

### Bug #297 — `rtk curl` inflates small JSON responses

**Problem**: `rtk curl` was replacing all JSON responses with a type schema, even when the schema was larger than the original payload:
```
# Original: {"r2Ready":true,"status":"ok"}
# RTK output (inflated):
{
  r2Ready: bool,
  status: string
}
```

**Fix**: Size guard in `filter_curl_output()` — schema is only returned when `schema.len() <= original.len()`. Small JSON payloads now pass through unchanged.

Inspired by PR #324 (@rursache).

### Feature #243 — `exclude_commands` config

**Problem**: The auto-rewrite hook intercepted all supported commands unconditionally. No way to opt out of specific rewrites without manually editing the hook (which gets overwritten by `rtk init -g`).

**Fix**: New `[hooks]` section in `config.toml`:
```toml
[hooks]
exclude_commands = ["curl", "playwright"]
```

Excluded commands pass through the hook unchanged. Survives `rtk init -g` re-runs.

## Changes

- `src/curl_cmd.rs` — size guard + updated test fixture
- `src/config.rs` — new `HooksConfig` struct with `exclude_commands`
- `src/rewrite_cmd.rs` — load config, pass excludes to registry
- `src/discover/registry.rs` — thread `excluded` through rewrite chain + new tests

## Test plan

- [x] 617 unit tests pass (`cargo test`)
- [x] 89 smoke tests pass (`bash scripts/test-all.sh`)
- [x] Doc validation passes (`bash scripts/validate-docs.sh`)
- [x] Manual: small JSON `{"status":"ok"}` returns raw, not schema
- [x] Manual: `exclude_commands = ["curl"]` → `rtk rewrite "curl ..."` exits 1
- [x] Manual: excluded curl + non-excluded git in compound command rewrites only git

🤖 Generated with [Claude Code](https://claude.com/claude-code)