### PR TITLE
feat: add Claude Code skills for PR and issue triage

### DIFF
--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -1,0 +1,348 @@
+---
+description: >
+  Issue triage: audit open issues, categorize, detect duplicates, cross-ref PRs, risk assessment, post comments.
+  Args: "all" for deep analysis of all, issue numbers to focus (e.g. "42 57"), "en"/"fr" for language, no arg = audit only in French.
+---
+
+# Issue Triage
+
+## Quand utiliser
+
+| Skill | Usage | Output |
+|-------|-------|--------|
+| `/issue-triage` | Trier, analyser, commenter les issues | Tableaux d'action + deep analysis + commentaires postés |
+| `/repo-recap` | Récap général pour partager avec l'équipe | Résumé Markdown (PRs + issues + releases) |
+
+**Déclencheurs** :
+- Manuellement : `/issue-triage` ou `/issue-triage all` ou `/issue-triage 42 57`
+- Proactivement : quand >10 issues ouvertes sans triage, ou issue stale >30j détectée
+
+---
+
+## Langue
+
+- Vérifier l'argument passé au skill
+- Si `en` ou `english` → tableaux et résumé en anglais
+- Si `fr`, `french`, ou pas d'argument → français (défaut)
+- Note : les commentaires GitHub (Phase 3) restent TOUJOURS en anglais (audience internationale)
+
+---
+
+Workflow en 3 phases : audit automatique → deep analysis opt-in → commentaires avec validation obligatoire.
+
+## Préconditions
+
+```bash
+git rev-parse --is-inside-work-tree
+gh auth status
+```
+
+Si l'un échoue, stop et expliquer ce qui manque.
+
+---
+
+## Phase 1 — Audit (toujours exécutée)
+
+### Data Gathering (commandes en parallèle)
+
+```bash
+# Identité du repo
+gh repo view --json nameWithOwner -q .nameWithOwner
+
+# Issues ouvertes avec métadonnées complètes
+gh issue list --state open --limit 100 \
+  --json number,title,author,createdAt,updatedAt,labels,assignees,body,comments
+
+# PRs ouvertes (pour cross-référence)
+gh pr list --state open --limit 50 --json number,title,body
+
+# Issues fermées récemment (pour détection doublons)
+gh issue list --state closed --limit 20 \
+  --json number,title,labels,closedAt
+
+# Collaborateurs (pour protéger les issues des mainteneurs)
+gh api "repos/{owner}/{repo}/collaborators" --jq '.[].login'
+```
+
+**Fallback collaborateurs** : si `gh api .../collaborators` échoue (403/404) :
+```bash
+gh pr list --state merged --limit 10 --json author --jq '.[].author.login' | sort -u
+```
+Si toujours ambigu, demander à l'utilisateur via `AskUserQuestion`.
+
+**Note** : `author` est un objet `{login: "..."}` — toujours extraire `.author.login`.
+
+### Analyse — 6 dimensions
+
+**1. Catégorisation** (labels existants > inférence titre/body) :
+- **Bug** : mots-clés `crash`, `error`, `fail`, `broken`, `regression`, `wrong`, `unexpected`
+- **Feature** : `add`, `implement`, `support`, `new`, `feat:`
+- **Enhancement** : `improve`, `optimize`, `better`, `enhance`, `refactor`
+- **Question/Support** : `how`, `why`, `help`, `unclear`, `docs`, `documentation`
+- **Duplicate Candidate** : voir dimension 3 ci-dessous
+
+**2. Cross-ref PRs** :
+- Scanner `body` de chaque PR ouverte pour `fixes #N`, `closes #N`, `resolves #N` (case-insensitive, regex)
+- Construire un map : `issue_number -> [PR numbers]`
+- Une issue liée à une PR mergée → recommander fermeture
+
+**3. Détection doublons** :
+- Normaliser les titres : lowercase, strip préfixes (`bug:`, `feat:`, `[bug]`, `[feature]`, etc.)
+- **Jaccard sur mots des titres** : si score > 60% entre deux issues → candidat doublon
+- **Keywords body overlap** > 50% → renforcement du signal
+- Comparer aussi avec issues fermées récentes (20 dernières)
+- Un faux positif peut être confirmé/écarté en Phase 2
+
+**4. Classification risque** :
+- **Rouge** : mots-clés `CVE`, `vulnerability`, `injection`, `auth bypass`, `security`, `exploit`, `unsafe`, `credentials`, `leak`, `RCE`, `XSS`
+- **Jaune** : `breaking change`, `migration`, `deprecation`, `remove API`, `breaking`, `incompatible`
+- **Vert** : tout le reste
+
+**5. Staleness** :
+- >30j sans activité (updatedAt) → **Stale**
+- >90j sans activité → **Very Stale**
+- Calculer depuis la date actuelle
+
+**6. Recommandations d'action** :
+- `Accept & Prioritize` : issue claire, reproducible, dans scope
+- `Label needed` : issue sans label
+- `Comment needed` : info manquante, body insuffisant
+- `Linked to PR` : une PR ouverte référence cette issue
+- `Duplicate candidate` : candidat doublon identifié (préciser avec `#N`)
+- `Close candidate` : stale + aucune activité récente, ou hors scope (jamais si auteur est collaborateur)
+- `PR merged → close` : PR liée est mergée, issue encore ouverte
+
+### Output — 5 tableaux
+
+```
+## Issues ouvertes ({count})
+
+### Critiques (risque rouge)
+| # | Titre | Auteur | Âge | Labels | Action |
+| - | ----- | ------ | --- | ------ | ------ |
+
+### Liées à une PR
+| # | Titre | Auteur | PR(s) liée(s) | Status PR | Action |
+| - | ----- | ------ | ------------- | --------- | ------ |
+
+### Actives
+| # | Titre | Auteur | Catégorie | Âge | Labels | Action |
+| - | ----- | ------ | --------- | --- | ------ | ------ |
+
+### Doublons candidats
+| # | Titre | Doublon de | Similarité | Action |
+| - | ----- | ---------- | ---------- | ------ |
+
+### Stale
+| # | Titre | Auteur | Dernière activité | Action |
+| - | ----- | ------ | ----------------- | ------ |
+
+### Résumé
+- Total : {N} issues ouvertes
+- Critiques : {N} (risque sécurité ou breaking)
+- Liées à PR : {N}
+- Doublons candidats : {N}
+- Stale (>30j) : {N} | Very Stale (>90j) : {N}
+- Sans labels : {N}
+- Quick wins (à fermer ou labeler rapidement) : {liste}
+```
+
+0 issues → afficher `Aucune issue ouverte.` et terminer.
+
+**Note** : `Âge` = jours depuis `createdAt`, format `{N}j`. Si >30j, afficher en **gras**.
+
+### Copie automatique
+
+Après affichage du tableau de triage, copier dans le presse-papier :
+```bash
+pbcopy <<'EOF'
+{tableau de triage complet}
+EOF
+```
+Confirmer : `Tableau copié dans le presse-papier.` (FR) / `Triage table copied to clipboard.` (EN)
+
+---
+
+## Phase 2 — Deep Analysis (opt-in)
+
+### Sélection des issues
+
+**Si argument passé** :
+- `"all"` → toutes les issues ouvertes
+- Numéros (`"42 57"`) → uniquement ces issues
+- Pas d'argument → proposer via `AskUserQuestion`
+
+**Si pas d'argument**, afficher :
+
+```
+question: "Quelles issues voulez-vous analyser en profondeur ?"
+header: "Deep Analysis"
+multiSelect: true
+options:
+  - label: "Toutes ({N} issues)"
+    description: "Analyse approfondie de toutes les issues avec agents en parallèle"
+  - label: "Critiques uniquement"
+    description: "Focus sur les {M} issues à risque rouge/jaune"
+  - label: "Doublons candidats"
+    description: "Confirmer ou écarter les {K} doublons détectés"
+  - label: "Stale uniquement"
+    description: "Décision close/keep sur les {J} issues stale"
+  - label: "Passer"
+    description: "Terminer ici — juste l'audit"
+```
+
+Si "Passer" → fin du workflow.
+
+### Exécution de l'analyse
+
+Pour chaque issue sélectionnée, lancer un agent via **Task tool en parallèle** :
+
+```
+subagent_type: general-purpose
+model: sonnet
+prompt: |
+  Analyze GitHub issue #{num}: "{title}" by @{author}
+
+  **Metadata**: Created {createdAt}, last updated {updatedAt}, labels: {labels}
+
+  **Body**:
+  {body}
+
+  **Existing comments** ({comments_count} total, showing last 5):
+  {last_5_comments}
+
+  **Context**:
+  - Linked PRs: {linked_prs or "none"}
+  - Duplicate candidate of: {duplicate_of or "none"}
+  - Risk classification: {risk_color}
+
+  Analyze this issue and return a structured report:
+  ### Scope Assessment
+  What is this issue actually asking for? Is it clearly defined?
+
+  ### Missing Information
+  What's needed to act on this? (reproduction steps, version, environment, etc.)
+
+  ### Risk & Impact
+  Security risk? Breaking change? Who's affected?
+
+  ### Effort Estimate
+  XS (<1h) / S (1-4h) / M (1-2d) / L (3-5d) / XL (>1 week)
+
+  ### Priority
+  P0 (critical, act now) / P1 (high, this sprint) / P2 (medium, backlog) / P3 (low, someday)
+
+  ### Recommended Action
+  One of: Accept & Prioritize, Request More Info, Mark Duplicate (#N), Close (Stale), Close (Out of Scope), Link to Existing PR
+
+  ### Draft Comment
+  Draft a GitHub comment in English using the appropriate template from templates/issue-comment.md.
+  Be specific, helpful, and constructive.
+```
+
+Si issue a >50 commentaires, résumer les 5 derniers uniquement.
+
+Agréger tous les rapports. Afficher un résumé après toutes les analyses.
+
+---
+
+## Phase 3 — Actions (validation obligatoire)
+
+### Types d'actions possibles
+
+- **Commenter** : `gh issue comment {num} --body-file -`
+- **Labeler** : `gh issue edit {num} --add-label "{label}"` (skip si label déjà présent)
+- **Fermer** : `gh issue close {num} --reason "not planned"` (jamais sans validation)
+
+### Génération des drafts
+
+Pour chaque issue analysée, générer les actions (commentaire + labels + fermeture si applicable) en utilisant `templates/issue-comment.md`.
+
+**Règles** :
+- Langue des commentaires : **anglais** (audience internationale)
+- Ton : professionnel, constructif, factuel
+- Ne jamais re-labeler une issue qui a déjà ce label
+- Ne jamais proposer "close" pour une issue d'un collaborateur
+- Toujours afficher le draft AVANT tout `gh issue comment`
+
+### Affichage et validation
+
+**Afficher TOUS les drafts** au format :
+
+```
+---
+### Draft — Issue #{num}: {title}
+
+**Actions proposées** : {Commentaire | Label: "bug" | Fermeture}
+
+**Commentaire** :
+{commentaire complet}
+
+---
+```
+
+Puis demander validation via `AskUserQuestion` :
+
+```
+question: "Ces actions sont prêtes. Lesquelles voulez-vous exécuter ?"
+header: "Exécuter"
+multiSelect: true
+options:
+  - label: "Toutes ({N} actions)"
+    description: "Commenter + labeler + fermer selon les drafts"
+  - label: "Issue #{x} — {title_truncated}"
+    description: "Exécuter uniquement les actions pour cette issue"
+  - label: "Aucune"
+    description: "Annuler — ne rien faire"
+```
+
+(Générer une option par issue + "Toutes" + "Aucune")
+
+### Exécution
+
+Pour chaque action validée, exécuter dans l'ordre : commenter → labeler → fermer.
+
+```bash
+# Commenter
+gh issue comment {num} --body-file - <<'COMMENT_EOF'
+{commentaire}
+COMMENT_EOF
+
+# Labeler (si applicable)
+gh issue edit {num} --add-label "{label}"
+
+# Fermer (si applicable)
+gh issue close {num} --reason "not planned"
+```
+
+Confirmer chaque action : `Commentaire posté sur issue #{num}: {title}`
+
+Si "Aucune" → `Aucune action exécutée. Workflow terminé.`
+
+---
+
+## Gestion des cas limites
+
+| Situation | Comportement |
+|-----------|--------------|
+| 0 issues ouvertes | `Aucune issue ouverte.` + terminer |
+| Issue sans body | Catégoriser par titre, recommander `Comment needed` |
+| >50 commentaires | Résumer les 5 derniers uniquement |
+| Faux positif doublon | Phase 2 confirme/écarte — ne pas agir sur suspicion seule |
+| Labels déjà présents | Ne pas re-labeler, signaler "label déjà appliqué" |
+| Issue d'un collaborateur | Jamais `close candidate` automatique |
+| Rate limit GitHub API | Réduire `--limit`, notifier l'utilisateur |
+| PR mergée liée à issue ouverte | Recommander fermeture de l'issue |
+| Issue sans activité >90j | Very Stale — proposer fermeture avec message bienveillant |
+| Duplicate confirmed in Phase 2 | Poster commentaire + fermer en faveur de l'issue originale |
+
+---
+
+## Notes
+
+- Toujours dériver owner/repo via `gh repo view`, jamais hardcoder
+- Utiliser `gh` CLI (pas `curl` GitHub API) sauf pour la liste des collaborateurs
+- `updatedAt` peut être null sur certaines issues → traiter comme `createdAt`
+- Ne jamais poster ou fermer sans validation explicite de l'utilisateur dans le chat
+- Les commentaires draftés doivent être visibles AVANT tout `gh issue comment`
+- Similarité Jaccard = |intersection mots| / |union mots| (exclure stop words : a, the, is, in, of, for, to, with, on, at, by)

--- a/.claude/skills/issue-triage/templates/issue-comment.md
+++ b/.claude/skills/issue-triage/templates/issue-comment.md
@@ -1,0 +1,134 @@
+# Issue Comment Templates
+
+Use these templates to generate GitHub issue comments. Select the appropriate template based on the recommended action from Phase 2. Comments are posted in **English** (international audience).
+
+---
+
+## Template 1 — Acknowledgment + Request Info
+
+Use when: issue is valid but missing information to act on it (reproduction steps, version, environment, context).
+
+```markdown
+## Issue Triage
+
+**Category**: {Bug | Feature | Enhancement | Question}
+**Priority**: {P0 | P1 | P2 | P3}
+**Effort estimate**: {XS | S | M | L | XL}
+
+### Assessment
+
+{1-2 sentences: what this issue is about and why it matters. Be direct.}
+
+### Missing Information
+
+To move forward, we need the following:
+
+- {Specific missing info 1 — e.g., "RTK version (`rtk --version` output)"}
+- {Specific missing info 2 — e.g., "Full command used and raw output"}
+- {Specific missing info 3 — e.g., "OS and shell (macOS/Linux, zsh/bash)"}
+
+### Next Steps
+
+{What happens once the info is provided — e.g., "Once confirmed, we'll prioritize this for the next release."}
+
+---
+*Triaged via [rtk](https://github.com/rtk-ai/rtk) `/issue-triage`*
+```
+
+---
+
+## Template 2 — Duplicate
+
+Use when: this issue is a duplicate of an existing open (or recently closed) issue.
+
+```markdown
+## Duplicate Issue
+
+This issue covers the same problem as #{original_number}: **{original_title}**.
+
+### Overlap
+
+{1-2 sentences explaining the overlap — what's identical or nearly identical between the two issues.}
+
+If your situation differs in an important way (different command, different OS, different error message), please reopen and add that context. Otherwise, follow the original issue for updates.
+
+---
+*Triaged via [rtk](https://github.com/rtk-ai/rtk) `/issue-triage`*
+```
+
+---
+
+## Template 3 — Close (Stale)
+
+Use when: issue has had no activity for >90 days and there's been no engagement.
+
+```markdown
+## Closing: No Activity
+
+This issue has been open for {N} days without activity. To keep the backlog actionable, we're closing it.
+
+If this is still relevant:
+- Reopen and add context about your current setup
+- Or reference this issue in a new one if the problem has evolved
+
+Thanks for taking the time to report it.
+
+---
+*Triaged via [rtk](https://github.com/rtk-ai/rtk) `/issue-triage`*
+```
+
+---
+
+## Template 4 — Close (Out of Scope)
+
+Use when: issue requests something that doesn't align with RTK's design goals (e.g., adding async runtime, platform-specific features outside scope, changing core behavior).
+
+```markdown
+## Closing: Out of Scope
+
+After review, this request falls outside RTK's current design goals.
+
+### Rationale
+
+{1-2 sentences explaining why — be specific. Reference design constraints if relevant, e.g., "RTK is intentionally single-threaded with zero async dependencies to maintain <10ms startup time."}
+
+### Alternatives
+
+{If applicable: what the user can do instead. E.g., "For this use case, `rtk proxy <cmd>` gives you raw output while still tracking usage metrics."}
+
+If the use case evolves or the scope changes in a future version, feel free to reopen with updated context.
+
+---
+*Triaged via [rtk](https://github.com/rtk-ai/rtk) `/issue-triage`*
+```
+
+---
+
+## Formatting Rules
+
+**Tone** : Professional, constructive, factual. Help the user move forward. Challenge the issue scope, not the person who filed it.
+
+**Length** : 100-250 words per comment. Long enough to be useful, short enough to respect the reader's time.
+
+**Specificity** : Always name the exact command, file, or behavior in question. Vague comments waste everyone's time.
+
+**No superlatives** : Don't write "great issue", "excellent report", "amazing catch". Just address the substance.
+
+**Priority labels** :
+- P0 — Critical: security vulnerability, data loss, broken core functionality
+- P1 — High: significant bug affecting common workflows, actionable this sprint
+- P2 — Medium: valid issue, queue for backlog
+- P3 — Low: nice-to-have, future consideration
+
+**Effort labels** :
+- XS : <1 hour
+- S : 1-4 hours
+- M : 1-2 days
+- L : 3-5 days
+- XL : >1 week
+
+**RTK-specific context to include when relevant** :
+- Mention `rtk --version` as the first diagnostic step for bug reports
+- Reference the relevant module (`src/git.rs`, `src/vitest_cmd.rs`, etc.) when known
+- Link to the filter development checklist in CLAUDE.md for feature requests that involve new commands
+- Note performance constraints (<10ms startup) when rejecting async/heavy dependency requests

--- a/.claude/skills/pr-triage/SKILL.md
+++ b/.claude/skills/pr-triage/SKILL.md
@@ -1,0 +1,315 @@
+---
+description: >
+  PR triage: audit open PRs, deep review selected ones, draft and post review comments.
+  Args: "all" to review all, PR numbers to focus (e.g. "42 57"), "en"/"fr" for language, no arg = audit only in French.
+---
+
+# PR Triage
+
+## Quand utiliser
+
+| Skill | Usage | Output |
+|-------|-------|--------|
+| `/pr-triage` | Trier, reviewer, commenter les PRs | Tableau d'action + reviews + commentaires postés |
+| `/repo-recap` | Récap général pour partager avec l'équipe | Résumé Markdown (PRs + issues + releases) |
+
+**Déclencheurs** :
+- Manuellement : `/pr-triage` ou `/pr-triage all` ou `/pr-triage 42 57`
+- Proactivement : quand >5 PRs ouvertes sans review, ou PR stale >14j détectée
+
+---
+
+## Langue
+
+- Vérifier l'argument passé au skill
+- Si `en` ou `english` → tableaux et résumé en anglais
+- Si `fr`, `french`, ou pas d'argument → français (défaut)
+- Note : les commentaires GitHub (Phase 3) restent TOUJOURS en anglais (audience internationale)
+
+---
+
+Workflow en 3 phases : audit automatique → deep review opt-in → commentaires avec validation obligatoire.
+
+## Préconditions
+
+```bash
+git rev-parse --is-inside-work-tree
+gh auth status
+```
+
+Si l'un échoue, stop et expliquer ce qui manque.
+
+---
+
+## Phase 1 — Audit (toujours exécutée)
+
+### Data Gathering (commandes en parallèle)
+
+```bash
+# Identité du repo
+gh repo view --json nameWithOwner -q .nameWithOwner
+
+# PRs ouvertes avec métadonnées complètes (ajouter body pour cross-référence issues)
+gh pr list --state open --limit 50 \
+  --json number,title,author,createdAt,updatedAt,additions,deletions,changedFiles,isDraft,mergeable,reviewDecision,statusCheckRollup,body
+
+# Collaborateurs (pour distinguer "nos PRs" des externes)
+gh api "repos/{owner}/{repo}/collaborators" --jq '.[].login'
+```
+
+**Fallback collaborateurs** : si `gh api .../collaborators` échoue (403/404) :
+```bash
+# Extraire les auteurs des 10 derniers PRs mergés
+gh pr list --state merged --limit 10 --json author --jq '.[].author.login' | sort -u
+```
+Si toujours ambigu, demander à l'utilisateur via `AskUserQuestion`.
+
+Pour chaque PR, récupérer reviews existantes ET fichiers modifiés :
+
+```bash
+gh api "repos/{owner}/{repo}/pulls/{num}/reviews" \
+  --jq '[.[] | .user.login + ":" + .state] | join(", ")'
+
+# Fichiers modifiés (nécessaire pour overlap detection)
+gh pr view {num} --json files --jq '[.files[].path] | join(",")'
+```
+
+**Note rate-limiting** : la récupération des fichiers est N appels API (1 par PR). Pour repos avec 20+ PRs, prioriser les PRs candidates à l'overlap (même domaine fonctionnel, même auteur).
+
+**Note** : `author` est un objet `{login: "..."}` — toujours extraire `.author.login`.
+
+### Analyse
+
+**Classification taille** :
+| Label | Additions |
+|-------|-----------|
+| XS | < 50 |
+| S | 50–200 |
+| M | 200–500 |
+| L | 500–1000 |
+| XL | > 1000 |
+
+Format taille : `+{additions}/-{deletions}, {files} files ({label})`
+
+**Détections** :
+- **Overlaps** : comparer les listes de fichiers entre PRs — si >50% de fichiers en commun → cross-reference
+- **Clusters** : auteur avec 3+ PRs ouvertes → suggérer ordre de review (plus petite en premier)
+- **Staleness** : aucune activité depuis >14j → flag "stale"
+- **CI status** : via `statusCheckRollup` → `clean` / `unstable` / `dirty`
+- **Reviews** : approved / changes_requested / aucune
+
+**Liens PR ↔ Issues** :
+- Scanner le `body` de chaque PR pour `fixes #N`, `closes #N`, `resolves #N` (case-insensitive)
+- Si trouvé, afficher dans le tableau : `Fixes #42` dans la colonne Action/Status
+
+**Catégorisation** :
+
+_Nos PRs_ : auteur dans la liste des collaborateurs
+
+_Externes — Prêtes_ : additions ≤ 1000 ET files ≤ 10 ET `mergeable` ≠ `CONFLICTING` ET CI clean/unstable
+
+_Externes — Problématiques_ : un des critères suivants :
+- additions > 1000 OU files > 10
+- OU `mergeable` == `CONFLICTING` (conflit de merge)
+- OU CI dirty (statusCheckRollup contient des échecs)
+- OU overlap avec une autre PR ouverte (>50% fichiers communs)
+
+### Output — Tableau de triage
+
+```
+## PRs ouvertes ({count})
+
+### Nos PRs
+| PR | Titre | Taille | CI | Status |
+| -- | ----- | ------ | -- | ------ |
+
+### Externes — Prêtes pour review
+| PR | Auteur | Titre | Taille | CI | Reviews | Action |
+| -- | ------ | ----- | ------ | -- | ------- | ------ |
+
+### Externes — Problématiques
+| PR | Auteur | Titre | Taille | Problème | Action recommandée |
+| -- | ------ | ----- | ------ | -------- | ------------------ |
+
+### Résumé
+- Quick wins : {PRs XS/S prêtes à merger}
+- Risques : {overlaps, tailles XL, CI dirty}
+- Clusters : {auteurs avec 3+ PRs}
+- Stale : {PRs sans activité >14j}
+- Overlaps : {PRs qui touchent les mêmes fichiers}
+```
+
+0 PRs → afficher `Aucune PR ouverte.` et terminer.
+
+### Copie automatique
+
+Après affichage du tableau de triage, copier dans le presse-papier :
+```bash
+pbcopy <<'EOF'
+{tableau de triage complet}
+EOF
+```
+Confirmer : `Tableau copié dans le presse-papier.` (FR) / `Triage table copied to clipboard.` (EN)
+
+---
+
+## Phase 2 — Deep Review (opt-in)
+
+### Sélection des PRs
+
+**Si argument passé** :
+- `"all"` → toutes les PRs externes
+- Numéros (`"42 57"`) → uniquement ces PRs
+- Pas d'argument → proposer via `AskUserQuestion`
+
+**Si pas d'argument**, afficher :
+
+```
+question: "Quelles PRs voulez-vous reviewer en profondeur ?"
+header: "Deep Review"
+multiSelect: true
+options:
+  - label: "Toutes les externes"
+    description: "Review {N} PRs externes avec agents code-reviewer en parallèle"
+  - label: "Problématiques uniquement"
+    description: "Focus sur les {M} PRs à risque (CI dirty, trop large, overlaps)"
+  - label: "Prêtes uniquement"
+    description: "Review {K} PRs prêtes à merger"
+  - label: "Passer"
+    description: "Terminer ici — juste l'audit"
+```
+
+**Note sur les drafts** :
+- Les PRs en draft sont EXCLUES des options "Toutes les externes" et "Prêtes uniquement"
+- Les PRs en draft sont INCLUSES dans "Problématiques uniquement" (car elles nécessitent attention)
+- Pour reviewer un draft : taper son numéro explicitement (ex: `42`)
+
+Si "Passer" → fin du workflow.
+
+### Exécution des Reviews
+
+Pour chaque PR sélectionnée, lancer un agent `code-reviewer` via **Task tool en parallèle** :
+
+```
+subagent_type: code-reviewer
+model: sonnet
+prompt: |
+  Review PR #{num}: "{title}" by @{author}
+
+  **Metadata**: +{additions}/-{deletions}, {changedFiles} files ({size_label})
+  **CI**: {ci_status} | **Reviews**: {existing_reviews} | **Draft**: {isDraft}
+
+  **PR Body**:
+  {body}
+
+  **Diff**:
+  {gh pr diff {num} output}
+
+  Apply your security-guardian and backend-architect skills for this review.
+  Additionally, apply the RTK-specific checklist:
+  - lazy_static! regex (no inline Regex::new())
+  - anyhow::Result + .context() (no unwrap())
+  - Fallback to raw command on filter failure
+  - Exit code propagation
+  - Token savings ≥60% in tests with real fixtures
+  - No async/tokio dependencies
+
+  Return structured review:
+  ### Critical Issues 🔴
+  ### Important Issues 🟡
+  ### Suggestions 🟢
+  ### What's Good ✅
+
+  Be specific: quote the file:line, explain why it's an issue, suggest the fix.
+```
+
+Récupérer le diff via :
+```bash
+gh pr diff {num}
+gh pr view {num} --json body,title,author -q '{body: .body, title: .title, author: .author.login}'
+```
+
+Agréger tous les rapports. Afficher un résumé après toutes les reviews.
+
+---
+
+## Phase 3 — Commentaires (validation obligatoire)
+
+### Génération des drafts
+
+Pour chaque PR reviewée, générer un commentaire GitHub en utilisant le template `templates/review-comment.md`.
+
+**Règles** :
+- Langue : **anglais** (audience internationale)
+- Ton : professionnel, constructif, factuel
+- Toujours inclure au moins 1 point positif
+- Citer les lignes de code quand pertinent (format `file.rs:42`)
+
+### Affichage et validation
+
+**Afficher TOUS les commentaires draftés** au format :
+
+```
+---
+### Draft — PR #{num}: {title}
+
+{commentaire complet}
+
+---
+```
+
+Puis demander validation via `AskUserQuestion` :
+
+```
+question: "Ces commentaires sont prêts. Lesquels voulez-vous poster ?"
+header: "Poster"
+multiSelect: true
+options:
+  - label: "Tous ({N} commentaires)"
+    description: "Poster sur toutes les PRs reviewées"
+  - label: "PR #{x} — {title_truncated}"
+    description: "Poster uniquement sur cette PR"
+  - label: "Aucun"
+    description: "Annuler — ne rien poster"
+```
+
+(Générer une option par PR + "Tous" + "Aucun")
+
+### Posting
+
+Pour chaque commentaire validé :
+
+```bash
+gh pr comment {num} --body-file - <<'REVIEW_EOF'
+{commentaire}
+REVIEW_EOF
+```
+
+Confirmer chaque post : `✅ Commentaire posté sur PR #{num}: {title}`
+
+Si "Aucun" → `Aucun commentaire posté. Workflow terminé.`
+
+---
+
+## Gestion des cas limites
+
+| Situation | Comportement |
+|-----------|--------------|
+| 0 PRs ouvertes | `Aucune PR ouverte.` + terminer |
+| PR en draft | Indiquer dans tableau, skip pour review sauf si sélectionnée explicitement |
+| CI inconnu | Afficher `?` dans colonne CI |
+| Review agent timeout | Afficher erreur partielle, continuer avec les autres |
+| `gh pr diff` vide | Skip cette PR, notifier l'utilisateur |
+| PR très large (>5000 additions) | Avertir : "Review partielle, diff tronqué" |
+| Collaborateurs API 403/404 | Fallback sur auteurs des 10 derniers PRs mergés |
+
+---
+
+## Notes
+
+- Toujours dériver owner/repo via `gh repo view`, jamais hardcoder
+- Utiliser `gh` CLI (pas `curl` GitHub API) sauf pour la liste des collaborateurs
+- `statusCheckRollup` peut être null → traiter comme `?`
+- `mergeable` peut être `MERGEABLE`, `CONFLICTING`, ou `UNKNOWN` → traiter `UNKNOWN` comme `?`
+- Ne jamais poster sans validation explicite de l'utilisateur dans le chat
+- Les commentaires draftés doivent être visibles AVANT tout `gh pr comment`

--- a/.claude/skills/pr-triage/templates/review-comment.md
+++ b/.claude/skills/pr-triage/templates/review-comment.md
@@ -1,0 +1,71 @@
+# Review Comment Template
+
+Use this template to generate GitHub PR review comments. Fill in each section based on the code-reviewer agent output. Comments are posted in **English** (international audience).
+
+---
+
+## Template
+
+```markdown
+## Review
+
+**Scope**: Security, code quality, performance, test coverage, architecture
+
+### Summary
+
+{1–2 sentences: overall assessment. Be direct — what's the main takeaway?}
+
+### Critical Issues 🔴
+
+{List blocking issues that must be fixed before merge. For each:}
+{- `file.rs:42` — Description of the problem. Why it matters. Suggested fix.}
+
+{If none: "None found."}
+
+### Important Issues 🟡
+
+{List significant issues that should be fixed. For each:}
+{- `file.rs:42` — Description. Why it matters. Suggested fix.}
+
+{If none: "None found."}
+
+### Suggestions 🟢
+
+{List nice-to-haves and minor improvements. For each:}
+{- Description. Context. Optional fix.}
+
+{If none: omit this section.}
+
+### What's Good ✅
+
+{Always include at least 1 positive point. Be specific — what works well and why.}
+{- Description of what's done right.}
+
+---
+*Automated review via [rtk](https://github.com/rtk-ai/rtk) `/pr-triage`*
+```
+
+---
+
+## Formatting Rules
+
+**Citation format** : `file.rs:42` or `` `code snippet` `` for inline references
+
+**Issue severity** :
+- 🔴 Critical : security vulnerability, data loss risk, broken functionality, test missing for new feature
+- 🟡 Important : error handling gap, performance regression, scope creep, missing token savings assertion
+- 🟢 Suggestion : naming, DRY opportunity, documentation, style
+
+**RTK-specific checks to mention if relevant** :
+- `lazy_static!` for regex (not inline `Regex::new()`)
+- `anyhow::Result` + `.context("msg")` (no bare `?`, no `.unwrap()`)
+- Fallback to raw command on filter failure
+- Exit code propagation (`std::process::exit(code)`)
+- Token savings assertion ≥60% in tests
+- Real fixtures (not synthetic test data)
+- No async/tokio dependencies (startup time)
+
+**Tone** : Professional, constructive, factual. Challenge the code, not the person.
+No superlatives ("great", "amazing", "perfect"). No filler ("as mentioned", "it's worth noting").
+
+**Length** : Aim for 200–400 words. Long enough to be useful, short enough to be read.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -293,7 +293,7 @@ SHARED            utils.rs          Helpers                N/A        ✓
                   tee.rs            Full output recovery   N/A        ✓
 ```
 
-**Total: 55 modules** (37 command modules + 18 infrastructure modules)
+**Total: 56 modules** (38 command modules + 18 infrastructure modules)
 
 ### Module Count Breakdown
 
@@ -1488,4 +1488,4 @@ When implementing a new command, consider:
 
 **Last Updated**: 2026-02-22
 **Architecture Version**: 2.2
-**rtk Version**: 0.24.0
+**rtk Version**: 0.25.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This is a fork with critical fixes for git argument parsing and modern JavaScrip
 
 **Verify correct installation:**
 ```bash
-rtk --version  # Should show "rtk 0.24.0" (or newer)
+rtk --version  # Should show "rtk 0.25.0" (or newer)
 rtk gain       # Should show token savings stats (NOT "command not found")
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ rtk filters and compresses command outputs before they reach your LLM context, s
 
 **How to verify you have the correct rtk:**
 ```bash
-rtk --version   # Should show "rtk 0.24.0"
+rtk --version   # Should show "rtk 0.25.0"
 rtk gain        # Should show token savings stats
 ```
 


### PR DESCRIPTION
## Summary

Two Claude Code skills (slash commands) that power structured, repeatable audits directly in a Claude Code session — no more ad-hoc reviews.

### `/pr-triage`
Scans open PRs, runs deep review on selected ones, and posts formatted review comments to GitHub.
- Covers code quality, test coverage, security surface, CLAUDE.md conventions
- Args: `42 57` (specific PRs), `all` (full audit), no arg = audit-only

### `/issue-triage`
Audits open issues, auto-categorizes (bug/feature/doc/question), detects duplicates, cross-references related PRs, and estimates risk/priority.
- Posts structured comments with action queue for maintainers
- Args: `all` (deep analysis), issue numbers to focus, `en`/`fr` for language

### Why this matters

Instead of reading PRs and issues manually before a review session, maintainers invoke a single slash command. The skill handles GitHub CLI calls, formats structured output, and posts comments — keeping everything inside the Claude Code session with full context.

## Test plan

- [x] Skills load correctly in Claude Code (`/pr-triage --help`)
- [x] `gh` CLI integration tested on this repo
- [x] Templates render correctly for both FR and EN output

🤖 Generated with [Claude Code](https://claude.com/claude-code)