### PR TITLE
feat: TOML Part 1 — filter DSL engine + 14 built-in filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ claudedocs
 
 # Vitals provenance data
 .vitals/
+.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ benchmark-report.md
 *.sqlite3
 rtk_tracking.db
 claudedocs
+
+# Vitals provenance data
+.vitals/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -293,7 +293,7 @@ SHARED            utils.rs          Helpers                N/A        ✓
                   tee.rs            Full output recovery   N/A        ✓
 ```
 
-**Total: 59 modules** (38 command modules + 21 infrastructure modules)
+**Total: 60 modules** (38 command modules + 22 infrastructure modules)
 
 ### Module Count Breakdown
 
@@ -1488,4 +1488,4 @@ When implementing a new command, consider:
 
 **Last Updated**: 2026-02-22
 **Architecture Version**: 2.2
-**rtk Version**: 0.27.1
+**rtk Version**: 0.27.2

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -293,12 +293,12 @@ SHARED            utils.rs          Helpers                N/A        ✓
                   tee.rs            Full output recovery   N/A        ✓
 ```
 
-**Total: 57 modules** (38 command modules + 19 infrastructure modules)
+**Total: 59 modules** (38 command modules + 21 infrastructure modules)
 
 ### Module Count Breakdown
 
 - **Command Modules**: 34 (directly exposed to users)
-- **Infrastructure Modules**: 18 (utils, filter, tracking, tee, config, init, gain, etc.)
+- **Infrastructure Modules**: 20 (utils, filter, tracking, tee, config, init, gain, toml_filter, verify_cmd, etc.)
 - **Git Commands**: 7 operations (status, diff, log, add, commit, push, branch/checkout)
 - **JS/TS Tooling**: 8 modules (modern frontend/fullstack development)
 - **Python Tooling**: 3 modules (ruff, pytest, pip)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 * **curl:** skip JSON schema replacement when schema is larger than original payload ([#297](https://github.com/rtk-ai/rtk/issues/297))
+* **toml-dsl:** fix regex overmatch on `tofu-plan/init/validate/fmt` and `mix-format/compile` — add `(\s|$)` word boundary to prevent matching subcommands (e.g. `tofu planet`, `mix formats`) ([#349](https://github.com/rtk-ai/rtk/issues/349))
 
 ## [0.25.0](https://github.com/rtk-ai/rtk/compare/v0.24.0...v0.25.0) (2026-03-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
+* **toml-dsl:** declarative TOML filter engine — add command filters without writing Rust ([#299](https://github.com/rtk-ai/rtk/issues/299))
+  * 8 primitives: `strip_ansi`, `replace`, `match_output`, `strip/keep_lines_matching`, `truncate_lines_at`, `head/tail_lines`, `max_lines`, `on_empty`
+  * lookup chain: `.rtk/filters.toml` (project-local) → built-in filters
+  * `RTK_NO_TOML=1` bypass, `RTK_TOML_DEBUG=1` debug mode
+  * `rtk verify` command with `--require-all` for inline test validation
+  * 14 new built-in filters: `tofu-plan/init/validate/fmt` ([#240](https://github.com/rtk-ai/rtk/issues/240)), `du` ([#284](https://github.com/rtk-ai/rtk/issues/284)), `fail2ban-client` ([#281](https://github.com/rtk-ai/rtk/issues/281)), `iptables` ([#282](https://github.com/rtk-ai/rtk/issues/282)), `mix-format/compile` ([#310](https://github.com/rtk-ai/rtk/issues/310)), `shopify-theme` ([#280](https://github.com/rtk-ai/rtk/issues/280)), `pio-run` ([#231](https://github.com/rtk-ai/rtk/issues/231)), `mvn-build` ([#338](https://github.com/rtk-ai/rtk/issues/338))
 * **hooks:** `exclude_commands` config — exclude specific commands from auto-rewrite ([#243](https://github.com/rtk-ai/rtk/issues/243))
 
 ### Bug Fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This is a fork with critical fixes for git argument parsing and modern JavaScrip
 
 **Verify correct installation:**
 ```bash
-rtk --version  # Should show "rtk 0.27.1" (or newer)
+rtk --version  # Should show "rtk 0.27.2" (or newer)
 rtk gain       # Should show token savings stats (NOT "command not found")
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Download from [releases](https://github.com/rtk-ai/rtk/releases):
 ### Verify Installation
 
 ```bash
-rtk --version   # Should show "rtk 0.27.1"
+rtk --version   # Should show "rtk 0.27.2"
 rtk gain        # Should show token savings stats
 ```
 

--- a/src/builtin_filters.toml
+++ b/src/builtin_filters.toml
@@ -90,7 +90,7 @@ expected = ""
 
 [filters.tofu-plan]
 description = "Compact OpenTofu plan output"
-match_command = "^tofu\\s+plan"
+match_command = "^tofu\\s+plan(\\s|$)"
 strip_ansi = true
 strip_lines_matching = [
   "^Refreshing state",
@@ -104,7 +104,7 @@ on_empty = "tofu plan: no changes detected"
 
 [filters.tofu-init]
 description = "Compact OpenTofu init output"
-match_command = "^tofu\\s+init"
+match_command = "^tofu\\s+init(\\s|$)"
 strip_ansi = true
 strip_lines_matching = [
   "^- Downloading",
@@ -120,7 +120,7 @@ on_empty = "tofu init: ok"
 
 [filters.tofu-validate]
 description = "Compact OpenTofu validate output"
-match_command = "^tofu\\s+validate"
+match_command = "^tofu\\s+validate(\\s|$)"
 strip_ansi = true
 match_output = [
   { pattern = "Success! The configuration is valid", message = "ok (valid)" },
@@ -128,7 +128,7 @@ match_output = [
 
 [filters.tofu-fmt]
 description = "Compact OpenTofu fmt output"
-match_command = "^tofu\\s+fmt"
+match_command = "^tofu\\s+fmt(\\s|$)"
 strip_ansi = true
 on_empty = "tofu fmt: ok (no changes)"
 max_lines = 30
@@ -175,13 +175,13 @@ truncate_lines_at = 120
 
 [filters.mix-format]
 description = "Compact mix format output"
-match_command = "^mix\\s+format"
+match_command = "^mix\\s+format(\\s|$)"
 on_empty = "mix format: ok"
 max_lines = 20
 
 [filters.mix-compile]
 description = "Compact mix compile output"
-match_command = "^mix\\s+compile"
+match_command = "^mix\\s+compile(\\s|$)"
 strip_ansi = true
 strip_lines_matching = [
   "^Compiling \\d+ file",

--- a/src/builtin_filters.toml
+++ b/src/builtin_filters.toml
@@ -1,0 +1,539 @@
+schema_version = 1
+
+[filters.make]
+description = "Compact make output"
+match_command = "^make\\b"
+strip_lines_matching = [
+  "^make\\[\\d+\\]:",
+  "^\\s*$",
+  "^Nothing to be done",
+]
+max_lines = 50
+
+[filters.terraform-plan]
+description = "Compact Terraform plan output"
+match_command = "^terraform\\s+plan"
+strip_ansi = true
+strip_lines_matching = [
+  "^Refreshing state",
+  "^\\s*#.*unchanged",
+  "^\\s*$",
+  "^Acquiring state lock",
+  "^Releasing state lock",
+]
+max_lines = 80
+on_empty = "terraform plan: no changes detected"
+
+[filters.git-checkout]
+description = "Compact git checkout output"
+match_command = "^git\\s+checkout"
+match_output = [
+  { pattern = "(?m)^Switched to", message = "ok" },
+  { pattern = "(?m)^Already on", message = "ok (already on branch)" },
+  { pattern = "(?m)^Updated \\d+", message = "ok (files updated)" },
+]
+
+[filters.git-remote]
+description = "Compact git remote output"
+match_command = "^git\\s+remote"
+strip_lines_matching = ["^\\s*$"]
+max_lines = 10
+
+[filters.git-merge]
+description = "Compact git merge output"
+match_command = "^git\\s+merge"
+match_output = [
+  { pattern = "(?m)^Already up to date", message = "ok (already up to date)" },
+  { pattern = "(?m)^Fast-forward", message = "ok (fast-forward)" },
+  { pattern = "(?m)^Merge made by", message = "ok (merge commit)" },
+]
+
+[filters.cargo-run]
+description = "Compact cargo run output: strip build noise, keep program output"
+match_command = "^cargo\\s+run"
+strip_ansi = true
+strip_lines_matching = [
+  "^\\s*Compiling\\s",
+  "^\\s*Finished\\s",
+  "^\\s*Running\\s`",
+]
+
+# ---------------------------------------------------------------------------
+# Inline tests
+# ---------------------------------------------------------------------------
+
+[[tests.terraform-plan]]
+name = "strips Refreshing state lines and blank lines"
+input = """
+Acquiring state lock. This may take a few moments...
+Refreshing state... [id=vpc-abc]
+Refreshing state... [id=sg-123]
+Releasing state lock. This may take a few moments...
+
+Terraform will perform the following actions:
+
+  # aws_instance.web will be created
+  + resource "aws_instance" "web" {}
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+"""
+expected = "Terraform will perform the following actions:\n  # aws_instance.web will be created\n  + resource \"aws_instance\" \"web\" {}\nPlan: 1 to add, 0 to change, 0 to destroy."
+
+[[tests.terraform-plan]]
+name = "strips noise, preserves non-blank content"
+input = "Refreshing state... [id=vpc-abc]\nNo changes. Your infrastructure matches the configuration."
+expected = "No changes. Your infrastructure matches the configuration."
+
+[[tests.git-remote]]
+name = "passthrough for short output"
+input = "origin"
+expected = "origin"
+
+[[tests.git-remote]]
+name = "strips blank lines"
+input = "origin\n\nupstream"
+expected = "origin\nupstream"
+
+[[tests.make]]
+name = "strips entering/leaving lines"
+input = """
+make[1]: Entering directory '/home/user'
+gcc -O2 foo.c
+make[1]: Leaving directory '/home/user'
+"""
+expected = """
+gcc -O2 foo.c
+"""
+
+[[tests.make]]
+name = "strips blank lines"
+input = """
+gcc -O2 foo.c
+
+gcc -O2 bar.c
+"""
+expected = """
+gcc -O2 foo.c
+gcc -O2 bar.c
+"""
+
+[[tests.make]]
+name = "on_empty when all stripped"
+input = """
+make[1]: Entering directory '/home/user'
+make[1]: Leaving directory '/home/user'
+"""
+expected = ""
+
+[[tests.git-checkout]]
+name = "Switched to branch short-circuits"
+input = "Switched to branch 'main'"
+expected = "ok"
+
+[[tests.git-checkout]]
+name = "Already on short-circuits"
+input = "Already on 'main'"
+expected = "ok (already on branch)"
+
+[[tests.git-checkout]]
+name = "No match passes through"
+input = "error: pathspec 'nope' did not match any file(s) known to git"
+expected = "error: pathspec 'nope' did not match any file(s) known to git"
+
+[[tests.git-merge]]
+name = "Already up to date short-circuits"
+input = "Already up to date."
+expected = "ok (already up to date)"
+
+[[tests.git-merge]]
+name = "Fast-forward short-circuits"
+input = "Updating abc123..def456\nFast-forward\n foo.rs | 2 +-"
+expected = "ok (fast-forward)"
+
+[[tests.cargo-run]]
+name = "strips build noise, keeps program output"
+input = """
+   Compiling myapp v0.1.0
+   Finished dev [unoptimized] target(s) in 1.23s
+    Running `target/debug/myapp`
+Hello, world!
+"""
+expected = """
+Hello, world!
+"""
+
+[[tests.cargo-run]]
+name = "empty program output returns empty"
+input = """
+   Compiling myapp v0.1.0
+   Finished dev [unoptimized] target(s) in 0.5s
+    Running `target/debug/myapp`
+"""
+expected = ""
+
+# ---------------------------------------------------------------------------
+# #240 OpenTofu (mirror of Terraform filters)
+# ---------------------------------------------------------------------------
+
+[filters.tofu-plan]
+description = "Compact OpenTofu plan output"
+match_command = "^tofu\\s+plan"
+strip_ansi = true
+strip_lines_matching = [
+  "^Refreshing state",
+  "^\\s*#.*unchanged",
+  "^\\s*$",
+  "^Acquiring state lock",
+  "^Releasing state lock",
+]
+max_lines = 80
+on_empty = "tofu plan: no changes detected"
+
+[filters.tofu-init]
+description = "Compact OpenTofu init output"
+match_command = "^tofu\\s+init"
+strip_ansi = true
+strip_lines_matching = [
+  "^- Downloading",
+  "^- Installing",
+  "^- Using previously-installed",
+  "^\\s*$",
+  "^Initializing provider",
+  "^Initializing the backend",
+  "^Initializing modules",
+]
+max_lines = 20
+on_empty = "tofu init: ok"
+
+[filters.tofu-validate]
+description = "Compact OpenTofu validate output"
+match_command = "^tofu\\s+validate"
+strip_ansi = true
+match_output = [
+  { pattern = "Success! The configuration is valid", message = "ok (valid)" },
+]
+
+[filters.tofu-fmt]
+description = "Compact OpenTofu fmt output"
+match_command = "^tofu\\s+fmt"
+strip_ansi = true
+on_empty = "tofu fmt: ok (no changes)"
+max_lines = 30
+
+# ---------------------------------------------------------------------------
+# #284 du
+# ---------------------------------------------------------------------------
+
+[filters.du]
+description = "Compact du output"
+match_command = "^du\\b"
+strip_lines_matching = ["^\\s*$"]
+truncate_lines_at = 120
+max_lines = 40
+
+# ---------------------------------------------------------------------------
+# #281 fail2ban-client
+# ---------------------------------------------------------------------------
+
+[filters.fail2ban-client]
+description = "Compact fail2ban-client output"
+match_command = "^fail2ban-client\\b"
+strip_lines_matching = ["^\\s*$"]
+max_lines = 30
+
+# ---------------------------------------------------------------------------
+# #282 iptables
+# ---------------------------------------------------------------------------
+
+[filters.iptables]
+description = "Compact iptables output"
+match_command = "^iptables\\b"
+strip_lines_matching = [
+  "^\\s*$",
+  "^Chain DOCKER",
+  "^Chain BR-",
+]
+max_lines = 50
+truncate_lines_at = 120
+
+# ---------------------------------------------------------------------------
+# #310 Elixir mix
+# ---------------------------------------------------------------------------
+
+[filters.mix-format]
+description = "Compact mix format output"
+match_command = "^mix\\s+format"
+on_empty = "mix format: ok"
+max_lines = 20
+
+[filters.mix-compile]
+description = "Compact mix compile output"
+match_command = "^mix\\s+compile"
+strip_ansi = true
+strip_lines_matching = [
+  "^Compiling \\d+ file",
+  "^\\s*$",
+  "^Generated\\s",
+]
+max_lines = 40
+on_empty = "mix compile: ok"
+
+# ---------------------------------------------------------------------------
+# #280 Shopify theme
+# ---------------------------------------------------------------------------
+
+[filters.shopify-theme]
+description = "Compact shopify theme push/pull output"
+match_command = "^shopify\\s+theme\\s+(push|pull)"
+strip_ansi = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^\\s*Uploading",
+  "^\\s*Downloading",
+]
+tail_lines = 5
+max_lines = 15
+on_empty = "shopify theme: ok"
+
+# ---------------------------------------------------------------------------
+# #231 PlatformIO
+# ---------------------------------------------------------------------------
+
+[filters.pio-run]
+description = "Compact PlatformIO build output"
+match_command = "^pio\\s+run"
+strip_ansi = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^Verbose mode",
+  "^CONFIGURATION:",
+  "^LDF:",
+  "^Library Manager:",
+  "^Compiling\\s",
+  "^Linking\\s",
+  "^Building\\s",
+  "^Checking size",
+]
+max_lines = 30
+on_empty = "pio run: ok"
+
+# ---------------------------------------------------------------------------
+# #338 Maven
+# ---------------------------------------------------------------------------
+
+[filters.mvn-build]
+description = "Compact Maven build output"
+match_command = "^mvn\\s+(compile|package|clean|install)\\b"
+strip_ansi = true
+strip_lines_matching = [
+  "^\\[INFO\\] ---",
+  "^\\[INFO\\] Building\\s",
+  "^\\[INFO\\] Downloading\\s",
+  "^\\[INFO\\] Downloaded\\s",
+  "^\\[INFO\\]\\s*$",
+  "^\\s*$",
+  "^Downloading:",
+  "^Downloaded:",
+  "^Progress",
+]
+max_lines = 50
+on_empty = "mvn: ok"
+
+# ---------------------------------------------------------------------------
+# Inline tests — new filters
+# ---------------------------------------------------------------------------
+
+[[tests.tofu-plan]]
+name = "strips Refreshing state and lock lines"
+input = """
+Acquiring state lock. This may take a few moments...
+Refreshing state... [id=vpc-abc123]
+Refreshing state... [id=sg-def456]
+Releasing state lock. This may take a few moments...
+
+OpenTofu will perform the following actions:
+
+  # aws_instance.web will be created
+  + resource "aws_instance" "web" {}
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+"""
+expected = "OpenTofu will perform the following actions:\n  # aws_instance.web will be created\n  + resource \"aws_instance\" \"web\" {}\nPlan: 1 to add, 0 to change, 0 to destroy."
+
+[[tests.tofu-plan]]
+name = "on_empty when all noise stripped"
+input = "Refreshing state... [id=vpc-abc]\nAcquiring state lock. This may take a few moments...\nReleasing state lock. This may take a few moments..."
+expected = "tofu plan: no changes detected"
+
+[[tests.tofu-init]]
+name = "strips downloading/installing lines"
+input = """
+Initializing the backend...
+Initializing provider plugins...
+- Downloading hashicorp/aws 5.0.0...
+- Installing hashicorp/aws 5.0.0...
+- Using previously-installed hashicorp/random 3.5.1
+
+OpenTofu has been successfully initialized!
+"""
+expected = "OpenTofu has been successfully initialized!"
+
+[[tests.tofu-init]]
+name = "on_empty when all noise stripped"
+input = """
+Initializing the backend...
+Initializing provider plugins...
+- Using previously-installed hashicorp/aws 5.0.0
+
+"""
+expected = "tofu init: ok"
+
+[[tests.tofu-validate]]
+name = "success short-circuits to ok"
+input = "Success! The configuration is valid."
+expected = "ok (valid)"
+
+[[tests.tofu-validate]]
+name = "error passes through unchanged"
+input = "Error: Invalid resource type\n  on main.tf line 3: resource \"aws_instancee\" \"web\""
+expected = "Error: Invalid resource type\n  on main.tf line 3: resource \"aws_instancee\" \"web\""
+
+[[tests.tofu-fmt]]
+name = "empty output returns on_empty message"
+input = ""
+expected = "tofu fmt: ok (no changes)"
+
+[[tests.tofu-fmt]]
+name = "changed files pass through"
+input = "main.tf\nvariables.tf"
+expected = "main.tf\nvariables.tf"
+
+[[tests.du]]
+name = "preserves sizes, strips blank lines"
+input = "4.0K\t./src\n\n8.0K\t./tests\n16K\t."
+expected = "4.0K\t./src\n8.0K\t./tests\n16K\t."
+
+[[tests.du]]
+name = "single line passthrough"
+input = "128K\t."
+expected = "128K\t."
+
+[[tests.fail2ban-client]]
+name = "strips blank lines"
+input = "Status for the jail: sshd\n|- Filter\n|  |- Currently failed: 3\n\n|- Actions\n   `- Total banned: 42"
+expected = "Status for the jail: sshd\n|- Filter\n|  |- Currently failed: 3\n|- Actions\n   `- Total banned: 42"
+
+[[tests.fail2ban-client]]
+name = "single line passthrough"
+input = "Shutdown successful"
+expected = "Shutdown successful"
+
+[[tests.iptables]]
+name = "strips Docker chains, preserves real rules"
+input = """
+Chain INPUT (policy ACCEPT)
+num  target     prot opt source               destination
+1    ACCEPT     all  --  0.0.0.0/0            0.0.0.0/0
+Chain DOCKER (1 references)
+    DOCKER     all  --  0.0.0.0/0            0.0.0.0/0
+Chain BR-abcdef (0 references)
+"""
+expected = "Chain INPUT (policy ACCEPT)\nnum  target     prot opt source               destination\n1    ACCEPT     all  --  0.0.0.0/0            0.0.0.0/0\n    DOCKER     all  --  0.0.0.0/0            0.0.0.0/0"
+
+[[tests.iptables]]
+name = "preserves FORWARD and OUTPUT chains"
+input = "Chain FORWARD (policy DROP)\n1 ACCEPT tcp\nChain OUTPUT (policy ACCEPT)\n1 ACCEPT all"
+expected = "Chain FORWARD (policy DROP)\n1 ACCEPT tcp\nChain OUTPUT (policy ACCEPT)\n1 ACCEPT all"
+
+[[tests.mix-format]]
+name = "empty output returns ok"
+input = ""
+expected = "mix format: ok"
+
+[[tests.mix-format]]
+name = "changed files pass through"
+input = "lib/my_app.ex\ntest/my_app_test.exs"
+expected = "lib/my_app.ex\ntest/my_app_test.exs"
+
+[[tests.mix-compile]]
+name = "strips compile noise, preserves warnings"
+input = """
+Compiling 12 files (.ex)
+Generated my_app app
+
+warning: variable "conn" is unused
+  lib/router.ex:42
+"""
+expected = "warning: variable \"conn\" is unused\n  lib/router.ex:42"
+
+[[tests.mix-compile]]
+name = "on_empty when only noise"
+input = "Compiling 3 files (.ex)\nGenerated my_app app\n"
+expected = "mix compile: ok"
+
+[[tests.shopify-theme]]
+name = "strips upload/download lines, keeps tail"
+input = """
+Uploading assets/app.css
+Uploading assets/app.js
+Uploading templates/index.liquid
+Downloading assets/old.css
+
+Theme 'Development' (id: 12345) pushed to store.example.myshopify.com
+"""
+expected = "Theme 'Development' (id: 12345) pushed to store.example.myshopify.com"
+
+[[tests.shopify-theme]]
+name = "on_empty when all stripped"
+input = "Uploading assets/app.css\nDownloading assets/base.css\n"
+expected = "shopify theme: ok"
+
+[[tests.pio-run]]
+name = "strips build noise, preserves errors"
+input = """
+Verbose mode can be enabled via `-v, --verbose` option
+CONFIGURATION: https://docs.platformio.org/page/boards/espressif32/esp32dev.html
+LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
+Compiling .pio/build/esp32dev/src/main.cpp.o
+Building .pio/build/esp32dev/firmware.elf
+Linking .pio/build/esp32dev/firmware.elf
+Checking size .pio/build/esp32dev/firmware.elf
+src/main.cpp:10:3: error: 'LED_BUILTINN' was not declared
+"""
+expected = "src/main.cpp:10:3: error: 'LED_BUILTINN' was not declared"
+
+[[tests.pio-run]]
+name = "on_empty when clean build with only noise"
+input = """
+Verbose mode can be enabled via `-v, --verbose` option
+Compiling .pio/build/esp32dev/src/main.cpp.o
+Linking .pio/build/esp32dev/firmware.elf
+"""
+expected = "pio run: ok"
+
+[[tests.mvn-build]]
+name = "strips INFO noise, preserves errors and summary"
+input = """
+[INFO] ---
+[INFO] Building myapp 1.0-SNAPSHOT
+[INFO] Downloading org.apache.maven.plugins:maven-compiler-plugin:3.11.0
+[INFO] Downloaded org.apache.maven.plugins:maven-compiler-plugin:3.11.0
+[INFO]
+[ERROR] /src/main/java/Main.java:[10,5] cannot find symbol
+  symbol: method foo()
+[INFO] BUILD FAILURE
+[INFO] Total time: 2.543 s
+"""
+expected = "[ERROR] /src/main/java/Main.java:[10,5] cannot find symbol\n  symbol: method foo()\n[INFO] BUILD FAILURE\n[INFO] Total time: 2.543 s"
+
+[[tests.mvn-build]]
+name = "successful build keeps BUILD SUCCESS line"
+input = """
+[INFO] ---
+[INFO] Building myapp 1.0-SNAPSHOT
+[INFO]
+[INFO] BUILD SUCCESS
+[INFO] Total time: 4.123 s
+[INFO] Finished at: 2024-01-15T10:30:00Z
+"""
+expected = "[INFO] BUILD SUCCESS\n[INFO] Total time: 4.123 s\n[INFO] Finished at: 2024-01-15T10:30:00Z"

--- a/src/builtin_filters.toml
+++ b/src/builtin_filters.toml
@@ -12,7 +12,7 @@ max_lines = 50
 
 [filters.terraform-plan]
 description = "Compact Terraform plan output"
-match_command = "^terraform\\s+plan"
+match_command = "^terraform\\s+plan(\\s|$)"
 strip_ansi = true
 strip_lines_matching = [
   "^Refreshing state",
@@ -24,39 +24,6 @@ strip_lines_matching = [
 max_lines = 80
 on_empty = "terraform plan: no changes detected"
 
-[filters.git-checkout]
-description = "Compact git checkout output"
-match_command = "^git\\s+checkout"
-match_output = [
-  { pattern = "(?m)^Switched to", message = "ok" },
-  { pattern = "(?m)^Already on", message = "ok (already on branch)" },
-  { pattern = "(?m)^Updated \\d+", message = "ok (files updated)" },
-]
-
-[filters.git-remote]
-description = "Compact git remote output"
-match_command = "^git\\s+remote"
-strip_lines_matching = ["^\\s*$"]
-max_lines = 10
-
-[filters.git-merge]
-description = "Compact git merge output"
-match_command = "^git\\s+merge"
-match_output = [
-  { pattern = "(?m)^Already up to date", message = "ok (already up to date)" },
-  { pattern = "(?m)^Fast-forward", message = "ok (fast-forward)" },
-  { pattern = "(?m)^Merge made by", message = "ok (merge commit)" },
-]
-
-[filters.cargo-run]
-description = "Compact cargo run output: strip build noise, keep program output"
-match_command = "^cargo\\s+run"
-strip_ansi = true
-strip_lines_matching = [
-  "^\\s*Compiling\\s",
-  "^\\s*Finished\\s",
-  "^\\s*Running\\s`",
-]
 
 # ---------------------------------------------------------------------------
 # Inline tests
@@ -84,15 +51,6 @@ name = "strips noise, preserves non-blank content"
 input = "Refreshing state... [id=vpc-abc]\nNo changes. Your infrastructure matches the configuration."
 expected = "No changes. Your infrastructure matches the configuration."
 
-[[tests.git-remote]]
-name = "passthrough for short output"
-input = "origin"
-expected = "origin"
-
-[[tests.git-remote]]
-name = "strips blank lines"
-input = "origin\n\nupstream"
-expected = "origin\nupstream"
 
 [[tests.make]]
 name = "strips entering/leaving lines"
@@ -125,51 +83,6 @@ make[1]: Leaving directory '/home/user'
 """
 expected = ""
 
-[[tests.git-checkout]]
-name = "Switched to branch short-circuits"
-input = "Switched to branch 'main'"
-expected = "ok"
-
-[[tests.git-checkout]]
-name = "Already on short-circuits"
-input = "Already on 'main'"
-expected = "ok (already on branch)"
-
-[[tests.git-checkout]]
-name = "No match passes through"
-input = "error: pathspec 'nope' did not match any file(s) known to git"
-expected = "error: pathspec 'nope' did not match any file(s) known to git"
-
-[[tests.git-merge]]
-name = "Already up to date short-circuits"
-input = "Already up to date."
-expected = "ok (already up to date)"
-
-[[tests.git-merge]]
-name = "Fast-forward short-circuits"
-input = "Updating abc123..def456\nFast-forward\n foo.rs | 2 +-"
-expected = "ok (fast-forward)"
-
-[[tests.cargo-run]]
-name = "strips build noise, keeps program output"
-input = """
-   Compiling myapp v0.1.0
-   Finished dev [unoptimized] target(s) in 1.23s
-    Running `target/debug/myapp`
-Hello, world!
-"""
-expected = """
-Hello, world!
-"""
-
-[[tests.cargo-run]]
-name = "empty program output returns empty"
-input = """
-   Compiling myapp v0.1.0
-   Finished dev [unoptimized] target(s) in 0.5s
-    Running `target/debug/myapp`
-"""
-expected = ""
 
 # ---------------------------------------------------------------------------
 # #240 OpenTofu (mirror of Terraform filters)
@@ -247,7 +160,7 @@ max_lines = 30
 
 [filters.iptables]
 description = "Compact iptables output"
-match_command = "^iptables\\b"
+match_command = "^iptables(\\s|$)"
 strip_lines_matching = [
   "^\\s*$",
   "^Chain DOCKER",

--- a/src/builtin_filters.toml
+++ b/src/builtin_filters.toml
@@ -9,6 +9,7 @@ strip_lines_matching = [
   "^Nothing to be done",
 ]
 max_lines = 50
+on_empty = "make: ok"
 
 [filters.terraform-plan]
 description = "Compact Terraform plan output"
@@ -77,11 +78,8 @@ gcc -O2 bar.c
 
 [[tests.make]]
 name = "on_empty when all stripped"
-input = """
-make[1]: Entering directory '/home/user'
-make[1]: Leaving directory '/home/user'
-"""
-expected = ""
+input = "make[1]: Entering directory '/home/user'\nmake[1]: Nothing to be done for 'all'.\nmake[1]: Leaving directory '/home/user'\n"
+expected = "make: ok"
 
 
 # ---------------------------------------------------------------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,10 +48,12 @@ mod runner;
 mod summary;
 mod tee;
 mod telemetry;
+mod toml_filter;
 mod tracking;
 mod tree;
 mod tsc_cmd;
 mod utils;
+mod verify_cmd;
 mod vitest_cmd;
 mod wc_cmd;
 mod wget_cmd;
@@ -550,8 +552,15 @@ enum Commands {
         args: Vec<OsString>,
     },
 
-    /// Verify hook integrity (SHA-256 check)
-    Verify,
+    /// Verify hook integrity and run TOML filter inline tests
+    Verify {
+        /// Run tests only for this filter name
+        #[arg(long)]
+        filter: Option<String>,
+        /// Fail if any filter has no inline tests (CI mode)
+        #[arg(long)]
+        require_all: bool,
+    },
 
     /// Ruff linter/formatter with compact output
     Ruff {
@@ -946,6 +955,7 @@ const RTK_META_COMMANDS: &[&str] = &[
     "proxy",
     "hook-audit",
     "cc-economics",
+    "verify",
 ];
 
 fn run_fallback(parse_error: clap::Error) -> Result<()> {
@@ -968,28 +978,82 @@ fn run_fallback(parse_error: clap::Error) -> Result<()> {
     // Start timer before execution to capture actual command runtime
     let timer = tracking::TimedExecution::start();
 
-    let status = std::process::Command::new(&args[0])
-        .args(&args[1..])
-        .stdin(std::process::Stdio::inherit())
-        .stdout(std::process::Stdio::inherit())
-        .stderr(std::process::Stdio::inherit())
-        .status();
+    // TOML filter lookup — bypass with RTK_NO_TOML=1
+    let toml_match = if std::env::var("RTK_NO_TOML").is_ok() {
+        None
+    } else {
+        toml_filter::find_matching_filter(&raw_command)
+    };
 
-    match status {
-        Ok(s) => {
-            timer.track_passthrough(&raw_command, &format!("rtk fallback: {}", raw_command));
+    if let Some(filter) = toml_match {
+        // TOML match: capture stdout for filtering
+        let result = std::process::Command::new(&args[0])
+            .args(&args[1..])
+            .stdin(std::process::Stdio::inherit())
+            .stdout(std::process::Stdio::piped()) // capture
+            .stderr(std::process::Stdio::inherit()) // stderr always direct
+            .output();
 
-            tracking::record_parse_failure_silent(&raw_command, &error_message, true);
+        match result {
+            Ok(output) => {
+                let stdout_raw = String::from_utf8_lossy(&output.stdout);
 
-            if !s.success() {
-                std::process::exit(s.code().unwrap_or(1));
+                // Tee raw output BEFORE filtering on failure — lets LLM re-read if needed
+                if !output.status.success() {
+                    let _ = tee::tee_and_hint(
+                        &stdout_raw,
+                        &raw_command,
+                        output.status.code().unwrap_or(1),
+                    );
+                }
+
+                let filtered = toml_filter::apply_filter(filter, &stdout_raw);
+                print!("{}", filtered);
+
+                timer.track(
+                    &raw_command,
+                    &format!("rtk:toml {}", raw_command),
+                    &stdout_raw,
+                    &filtered,
+                );
+                tracking::record_parse_failure_silent(&raw_command, &error_message, true);
+
+                if !output.status.success() {
+                    std::process::exit(output.status.code().unwrap_or(1));
+                }
+            }
+            Err(e) => {
+                // Command not found — same behaviour as no-TOML path
+                tracking::record_parse_failure_silent(&raw_command, &error_message, false);
+                eprintln!("[rtk: fallback failed: {}]", e);
+                parse_error.exit();
             }
         }
-        Err(e) => {
-            tracking::record_parse_failure_silent(&raw_command, &error_message, false);
-            // Command not found or other OS error — show Clap's original error
-            eprintln!("[rtk: fallback failed: {}]", e);
-            parse_error.exit();
+    } else {
+        // No TOML match: original passthrough behaviour (Stdio::inherit, streaming)
+        let status = std::process::Command::new(&args[0])
+            .args(&args[1..])
+            .stdin(std::process::Stdio::inherit())
+            .stdout(std::process::Stdio::inherit())
+            .stderr(std::process::Stdio::inherit())
+            .status();
+
+        match status {
+            Ok(s) => {
+                timer.track_passthrough(&raw_command, &format!("rtk fallback: {}", raw_command));
+
+                tracking::record_parse_failure_silent(&raw_command, &error_message, true);
+
+                if !s.success() {
+                    std::process::exit(s.code().unwrap_or(1));
+                }
+            }
+            Err(e) => {
+                tracking::record_parse_failure_silent(&raw_command, &error_message, false);
+                // Command not found or other OS error — show Clap's original error
+                eprintln!("[rtk: fallback failed: {}]", e);
+                parse_error.exit();
+            }
         }
     }
 
@@ -1871,8 +1935,18 @@ fn main() -> Result<()> {
             }
         }
 
-        Commands::Verify => {
-            integrity::run_verify(cli.verbose)?;
+        Commands::Verify {
+            filter,
+            require_all,
+        } => {
+            if filter.is_some() || require_all {
+                // Filter test mode: run TOML inline tests
+                verify_cmd::run(filter, require_all)?;
+            } else {
+                // Default: hook integrity check + TOML filter tests
+                integrity::run_verify(cli.verbose)?;
+                verify_cmd::run(None, false)?;
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -979,10 +979,21 @@ fn run_fallback(parse_error: clap::Error) -> Result<()> {
     let timer = tracking::TimedExecution::start();
 
     // TOML filter lookup — bypass with RTK_NO_TOML=1
+    // Use basename of args[0] so absolute paths (/usr/bin/make) still match "^make\b".
+    let lookup_cmd = {
+        let base = std::path::Path::new(&args[0])
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| args[0].clone());
+        std::iter::once(base.as_str())
+            .chain(args[1..].iter().map(|s| s.as_str()))
+            .collect::<Vec<_>>()
+            .join(" ")
+    };
     let toml_match = if std::env::var("RTK_NO_TOML").ok().as_deref() == Some("1") {
         None
     } else {
-        toml_filter::find_matching_filter(&raw_command)
+        toml_filter::find_matching_filter(&lookup_cmd)
     };
 
     if let Some(filter) = toml_match {
@@ -1000,11 +1011,7 @@ fn run_fallback(parse_error: clap::Error) -> Result<()> {
 
                 // Tee raw output BEFORE filtering on failure — lets LLM re-read if needed
                 let tee_hint = if !output.status.success() {
-                    tee::tee_and_hint(
-                        &stdout_raw,
-                        &raw_command,
-                        output.status.code().unwrap_or(1),
-                    )
+                    tee::tee_and_hint(&stdout_raw, &raw_command, output.status.code().unwrap_or(1))
                 } else {
                     None
                 };
@@ -1030,8 +1037,8 @@ fn run_fallback(parse_error: clap::Error) -> Result<()> {
             Err(e) => {
                 // Command not found — same behaviour as no-TOML path
                 tracking::record_parse_failure_silent(&raw_command, &error_message, false);
-                eprintln!("[rtk: fallback failed: {}]", e);
-                parse_error.exit();
+                eprintln!("[rtk: {}]", e);
+                std::process::exit(127);
             }
         }
     } else {
@@ -1055,9 +1062,9 @@ fn run_fallback(parse_error: clap::Error) -> Result<()> {
             }
             Err(e) => {
                 tracking::record_parse_failure_silent(&raw_command, &error_message, false);
-                // Command not found or other OS error — show Clap's original error
-                eprintln!("[rtk: fallback failed: {}]", e);
-                parse_error.exit();
+                // Command not found or other OS error — single message, no duplicate Clap error
+                eprintln!("[rtk: {}]", e);
+                std::process::exit(127);
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -979,7 +979,7 @@ fn run_fallback(parse_error: clap::Error) -> Result<()> {
     let timer = tracking::TimedExecution::start();
 
     // TOML filter lookup — bypass with RTK_NO_TOML=1
-    let toml_match = if std::env::var("RTK_NO_TOML").is_ok() {
+    let toml_match = if std::env::var("RTK_NO_TOML").ok().as_deref() == Some("1") {
         None
     } else {
         toml_filter::find_matching_filter(&raw_command)
@@ -999,16 +999,21 @@ fn run_fallback(parse_error: clap::Error) -> Result<()> {
                 let stdout_raw = String::from_utf8_lossy(&output.stdout);
 
                 // Tee raw output BEFORE filtering on failure — lets LLM re-read if needed
-                if !output.status.success() {
-                    let _ = tee::tee_and_hint(
+                let tee_hint = if !output.status.success() {
+                    tee::tee_and_hint(
                         &stdout_raw,
                         &raw_command,
                         output.status.code().unwrap_or(1),
-                    );
-                }
+                    )
+                } else {
+                    None
+                };
 
                 let filtered = toml_filter::apply_filter(filter, &stdout_raw);
-                print!("{}", filtered);
+                println!("{}", filtered);
+                if let Some(hint) = tee_hint {
+                    println!("{}", hint);
+                }
 
                 timer.track(
                     &raw_command,
@@ -1939,13 +1944,13 @@ fn main() -> Result<()> {
             filter,
             require_all,
         } => {
-            if filter.is_some() || require_all {
-                // Filter test mode: run TOML inline tests
+            if filter.is_some() {
+                // Filter-specific mode: run only that filter's tests
                 verify_cmd::run(filter, require_all)?;
             } else {
-                // Default: hook integrity check + TOML filter tests
+                // Default or --require-all: always run integrity check first
                 integrity::run_verify(cli.verbose)?;
-                verify_cmd::run(None, false)?;
+                verify_cmd::run(None, require_all)?;
             }
         }
     }

--- a/src/toml_filter.rs
+++ b/src/toml_filter.rs
@@ -1,0 +1,1305 @@
+/// TOML-based filter DSL for RTK.
+///
+/// Provides a declarative pipeline of 8 stages that can be configured
+/// via `.rtk/filters.toml` (project-local) or built-in TOML embedded in the binary.
+///
+/// Lookup priority (first match wins):
+///   1. `.rtk/filters.toml` (PWD — project-local, committable)
+///   2. Built-in TOML (`src/builtin_filters.toml`, embedded at compile time)
+///   3. Passthrough (no match — handled by caller)
+///
+/// Environment variables:
+///   - `RTK_NO_TOML=1`     — bypass TOML engine entirely
+///   - `RTK_TOML_DEBUG=1`  — print which filter matched and line counts to stderr
+///
+/// Pipeline stages (applied in order):
+///   1. strip_ansi           — remove ANSI escape codes
+///   2. replace              — regex substitutions, line-by-line, chainable
+///   3. match_output         — short-circuit: if blob matches a pattern, return message immediately
+///   4. strip/keep_lines     — filter lines by regex
+///   5. truncate_lines_at    — truncate each line to N chars
+///   6. head/tail_lines      — keep first/last N lines
+///   7. max_lines            — absolute line cap
+///   8. on_empty             — message if result is empty
+use lazy_static::lazy_static;
+use regex::{Regex, RegexSet};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+// ---------------------------------------------------------------------------
+// Deserialization types (TOML schema)
+// ---------------------------------------------------------------------------
+
+/// A match-output rule: if `pattern` matches anywhere in the full output blob,
+/// the filter short-circuits and returns `message` immediately.
+/// First matching rule wins; remaining rules are not evaluated.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MatchOutputRule {
+    pattern: String,
+    message: String,
+}
+
+/// A regex substitution applied line-by-line. Rules are chained sequentially:
+/// rule N+1 operates on the output of rule N.
+/// Backreferences (`$1`, `$2`, ...) are supported via the `regex` crate.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReplaceRule {
+    pattern: String,
+    replacement: String,
+}
+
+/// An inline test case attached to a filter in the TOML.
+/// Lives in `[[tests.<filter-name>]]` sections, separate from `[filters.*]`.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TomlFilterTestDef {
+    pub name: String,
+    pub input: String,
+    pub expected: String,
+}
+
+#[derive(Deserialize)]
+struct TomlFilterFile {
+    schema_version: u32,
+    #[serde(default)]
+    filters: BTreeMap<String, TomlFilterDef>,
+    /// Inline tests keyed by filter name. Kept separate from `filters` so that
+    /// `TomlFilterDef` can keep `deny_unknown_fields` without touching test data.
+    #[serde(default)]
+    tests: BTreeMap<String, Vec<TomlFilterTestDef>>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TomlFilterDef {
+    description: Option<String>,
+    match_command: String,
+    #[serde(default)]
+    strip_ansi: bool,
+    /// Regex substitutions, applied line-by-line before match_output (stage 2).
+    #[serde(default)]
+    replace: Vec<ReplaceRule>,
+    /// Short-circuit rules: if the full output blob matches, return the message (stage 3).
+    #[serde(default)]
+    match_output: Vec<MatchOutputRule>,
+    #[serde(default)]
+    strip_lines_matching: Vec<String>,
+    #[serde(default)]
+    keep_lines_matching: Vec<String>,
+    truncate_lines_at: Option<usize>,
+    head_lines: Option<usize>,
+    tail_lines: Option<usize>,
+    max_lines: Option<usize>,
+    on_empty: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Compiled types (post-validation, ready to use)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+struct CompiledMatchOutputRule {
+    pattern: Regex,
+    message: String,
+}
+
+#[derive(Debug)]
+struct CompiledReplaceRule {
+    pattern: Regex,
+    replacement: String,
+}
+
+#[derive(Debug)]
+enum LineFilter {
+    None,
+    Strip(RegexSet),
+    Keep(RegexSet),
+}
+
+/// A filter that has been parsed and compiled — all regexes are ready.
+#[derive(Debug)]
+pub struct CompiledFilter {
+    pub name: String,
+    #[allow(dead_code)]
+    pub description: Option<String>,
+    match_regex: Regex,
+    strip_ansi: bool,
+    replace: Vec<CompiledReplaceRule>,
+    match_output: Vec<CompiledMatchOutputRule>,
+    line_filter: LineFilter,
+    truncate_lines_at: Option<usize>,
+    head_lines: Option<usize>,
+    tail_lines: Option<usize>,
+    pub max_lines: Option<usize>,
+    on_empty: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Results for `rtk verify`
+// ---------------------------------------------------------------------------
+
+/// Outcome of running a single inline test.
+pub struct TestOutcome {
+    pub filter_name: String,
+    pub test_name: String,
+    pub passed: bool,
+    pub actual: String,
+    pub expected: String,
+}
+
+/// Aggregated results from `run_filter_tests`.
+pub struct VerifyResults {
+    /// Individual test outcomes (all filters, or just the requested one).
+    pub outcomes: Vec<TestOutcome>,
+    /// Filter names that have no inline tests (used by `--require-all`).
+    pub filters_without_tests: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+pub struct TomlFilterRegistry {
+    pub filters: Vec<CompiledFilter>,
+}
+
+impl TomlFilterRegistry {
+    /// Load registry from disk + built-in. Emits warnings to stderr on parse
+    /// errors but never panics — bad files are silently ignored.
+    fn load() -> Self {
+        let mut filters = Vec::new();
+
+        // Priority 1: project-local .rtk/filters.toml
+        if let Ok(content) = std::fs::read_to_string(".rtk/filters.toml") {
+            match Self::parse_and_compile(&content, "project") {
+                Ok(f) => filters.extend(f),
+                Err(e) => eprintln!("[rtk] warning: .rtk/filters.toml: {}", e),
+            }
+        }
+
+        // Priority 2: built-in (embedded at compile time)
+        let builtin = include_str!("builtin_filters.toml");
+        match Self::parse_and_compile(builtin, "builtin") {
+            Ok(f) => filters.extend(f),
+            Err(e) => eprintln!("[rtk] warning: builtin filters: {}", e),
+        }
+
+        TomlFilterRegistry { filters }
+    }
+
+    fn parse_and_compile(content: &str, source: &str) -> Result<Vec<CompiledFilter>, String> {
+        let file: TomlFilterFile = toml::from_str(content)
+            .map_err(|e| format!("TOML parse error in {}: {}", source, e))?;
+
+        if file.schema_version != 1 {
+            return Err(format!(
+                "unsupported schema_version {} in {} (expected 1)",
+                file.schema_version, source
+            ));
+        }
+
+        let mut compiled = Vec::new();
+        for (name, def) in file.filters {
+            match compile_filter(name.clone(), def) {
+                Ok(f) => compiled.push(f),
+                Err(e) => eprintln!("[rtk] warning: filter '{}' in {}: {}", name, source, e),
+            }
+        }
+        Ok(compiled)
+    }
+}
+
+fn compile_filter(name: String, def: TomlFilterDef) -> Result<CompiledFilter, String> {
+    // Mutual exclusion: strip and keep cannot both be set
+    if !def.strip_lines_matching.is_empty() && !def.keep_lines_matching.is_empty() {
+        return Err("strip_lines_matching and keep_lines_matching are mutually exclusive".into());
+    }
+
+    let match_regex = Regex::new(&def.match_command)
+        .map_err(|e| format!("invalid match_command regex: {}", e))?;
+
+    let replace = def
+        .replace
+        .into_iter()
+        .map(|r| {
+            let pat = r.pattern.clone();
+            Regex::new(&r.pattern)
+                .map(|pattern| CompiledReplaceRule {
+                    pattern,
+                    replacement: r.replacement,
+                })
+                .map_err(|e| format!("invalid replace pattern '{}': {}", pat, e))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let match_output = def
+        .match_output
+        .into_iter()
+        .map(|r| {
+            let pat = r.pattern.clone();
+            Regex::new(&r.pattern)
+                .map(|pattern| CompiledMatchOutputRule {
+                    pattern,
+                    message: r.message,
+                })
+                .map_err(|e| format!("invalid match_output pattern '{}': {}", pat, e))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let line_filter = if !def.strip_lines_matching.is_empty() {
+        let set = RegexSet::new(&def.strip_lines_matching)
+            .map_err(|e| format!("invalid strip_lines_matching regex: {}", e))?;
+        LineFilter::Strip(set)
+    } else if !def.keep_lines_matching.is_empty() {
+        let set = RegexSet::new(&def.keep_lines_matching)
+            .map_err(|e| format!("invalid keep_lines_matching regex: {}", e))?;
+        LineFilter::Keep(set)
+    } else {
+        LineFilter::None
+    };
+
+    Ok(CompiledFilter {
+        name,
+        description: def.description,
+        match_regex,
+        strip_ansi: def.strip_ansi,
+        replace,
+        match_output,
+        line_filter,
+        truncate_lines_at: def.truncate_lines_at,
+        head_lines: def.head_lines,
+        tail_lines: def.tail_lines,
+        max_lines: def.max_lines,
+        on_empty: def.on_empty,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Singleton (lazy-loaded, one-time cost)
+// ---------------------------------------------------------------------------
+
+lazy_static! {
+    static ref REGISTRY: TomlFilterRegistry = TomlFilterRegistry::load();
+}
+
+// ---------------------------------------------------------------------------
+// Public API — pure functions (testable without global state)
+// ---------------------------------------------------------------------------
+
+/// Find the first matching filter in a slice. O(N) on the number of filters.
+/// Tests should call this directly with a local filter list.
+pub fn find_filter_in<'a>(
+    command: &str,
+    filters: &'a [CompiledFilter],
+) -> Option<&'a CompiledFilter> {
+    filters.iter().find(|f| f.match_regex.is_match(command))
+}
+
+/// Apply a compiled filter pipeline to raw stdout. Pure String -> String.
+///
+/// Pipeline stages (in order):
+///   1. strip_ansi           — remove ANSI escape codes
+///   2. replace              — regex substitutions, line-by-line, chainable
+///   3. match_output         — short-circuit if blob matches a pattern
+///   4. strip/keep_lines     — filter lines by regex
+///   5. truncate_lines_at    — truncate each line to N chars
+///   6. head/tail_lines      — keep first/last N lines
+///   7. max_lines            — absolute line cap
+///   8. on_empty             — message if result is empty
+pub fn apply_filter(filter: &CompiledFilter, stdout: &str) -> String {
+    let mut lines: Vec<String> = stdout.lines().map(String::from).collect();
+
+    // 1. strip_ansi
+    if filter.strip_ansi {
+        lines = lines
+            .into_iter()
+            .map(|l| crate::utils::strip_ansi(&l))
+            .collect();
+    }
+
+    // 2. replace — line-by-line, rules chained sequentially
+    if !filter.replace.is_empty() {
+        lines = lines
+            .into_iter()
+            .map(|mut line| {
+                for rule in &filter.replace {
+                    line = rule
+                        .pattern
+                        .replace_all(&line, rule.replacement.as_str())
+                        .into_owned();
+                }
+                line
+            })
+            .collect();
+    }
+
+    // 3. match_output — short-circuit on full blob match (first rule wins)
+    if !filter.match_output.is_empty() {
+        let blob = lines.join("\n");
+        for rule in &filter.match_output {
+            if rule.pattern.is_match(&blob) {
+                return rule.message.clone();
+            }
+        }
+    }
+
+    // 4. strip OR keep (mutually exclusive)
+    match &filter.line_filter {
+        LineFilter::Strip(set) => lines.retain(|l| !set.is_match(l)),
+        LineFilter::Keep(set) => lines.retain(|l| set.is_match(l)),
+        LineFilter::None => {}
+    }
+
+    // 5. truncate_lines_at — uses utils::truncate (unicode-safe)
+    if let Some(max_chars) = filter.truncate_lines_at {
+        lines = lines
+            .into_iter()
+            .map(|l| crate::utils::truncate(&l, max_chars))
+            .collect();
+    }
+
+    // 6. head + tail
+    let total = lines.len();
+    if let (Some(head), Some(tail)) = (filter.head_lines, filter.tail_lines) {
+        if total > head + tail {
+            let mut result = lines[..head].to_vec();
+            result.push(format!("... ({} lines omitted)", total - head - tail));
+            result.extend_from_slice(&lines[total - tail..]);
+            lines = result;
+        }
+    } else if let Some(head) = filter.head_lines {
+        if total > head {
+            lines.truncate(head);
+            lines.push(format!("... ({} lines omitted)", total - head));
+        }
+    } else if let Some(tail) = filter.tail_lines {
+        if total > tail {
+            let omitted = total - tail;
+            lines = lines[omitted..].to_vec();
+            lines.insert(0, format!("... ({} lines omitted)", omitted));
+        }
+    }
+
+    // 7. max_lines — absolute cap applied after head/tail (includes omit messages)
+    if let Some(max) = filter.max_lines {
+        if lines.len() > max {
+            let truncated = lines.len() - max;
+            lines.truncate(max);
+            lines.push(format!("... ({} lines truncated)", truncated));
+        }
+    }
+
+    // 8. on_empty
+    let result = lines.join("\n");
+    if result.trim().is_empty() {
+        if let Some(ref msg) = filter.on_empty {
+            return msg.clone();
+        }
+    }
+
+    result
+}
+
+// ---------------------------------------------------------------------------
+// rtk verify — inline test execution
+// ---------------------------------------------------------------------------
+
+/// Run inline tests from loaded TOML files (builtin + project-local).
+///
+/// - `filter_name_opt`: if `Some`, only run tests for that filter name.
+/// - Returns `VerifyResults` with all outcomes and filters that have no tests.
+pub fn run_filter_tests(filter_name_opt: Option<&str>) -> VerifyResults {
+    let mut outcomes = Vec::new();
+    let mut all_filter_names: Vec<String> = Vec::new();
+    let mut tested_filter_names: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
+
+    let builtin = include_str!("builtin_filters.toml");
+    collect_test_outcomes(
+        builtin,
+        filter_name_opt,
+        &mut outcomes,
+        &mut all_filter_names,
+        &mut tested_filter_names,
+    );
+
+    if let Ok(content) = std::fs::read_to_string(".rtk/filters.toml") {
+        collect_test_outcomes(
+            &content,
+            filter_name_opt,
+            &mut outcomes,
+            &mut all_filter_names,
+            &mut tested_filter_names,
+        );
+    }
+
+    let filters_without_tests = all_filter_names
+        .into_iter()
+        .filter(|name| {
+            // When a specific filter is requested, only report that one as missing tests
+            filter_name_opt.is_none_or(|f| name == f)
+        })
+        .filter(|name| !tested_filter_names.contains(name))
+        .collect();
+
+    VerifyResults {
+        outcomes,
+        filters_without_tests,
+    }
+}
+
+fn collect_test_outcomes(
+    content: &str,
+    filter_name_opt: Option<&str>,
+    outcomes: &mut Vec<TestOutcome>,
+    all_filter_names: &mut Vec<String>,
+    tested_filter_names: &mut std::collections::HashSet<String>,
+) {
+    let file: TomlFilterFile = match toml::from_str(content) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("[rtk] warning: TOML parse error during verify: {}", e);
+            return;
+        }
+    };
+
+    // Compile all filters and track their names
+    let mut compiled_filters: BTreeMap<String, CompiledFilter> = BTreeMap::new();
+    for (name, def) in file.filters {
+        all_filter_names.push(name.clone());
+        match compile_filter(name.clone(), def) {
+            Ok(f) => {
+                compiled_filters.insert(name, f);
+            }
+            Err(e) => eprintln!("[rtk] warning: filter '{}' compilation error: {}", name, e),
+        }
+    }
+
+    // Run tests
+    for (filter_name, tests) in file.tests {
+        if let Some(name) = filter_name_opt {
+            if filter_name != name {
+                continue;
+            }
+        }
+
+        tested_filter_names.insert(filter_name.clone());
+
+        let compiled = match compiled_filters.get(&filter_name) {
+            Some(f) => f,
+            None => {
+                eprintln!(
+                    "[rtk] warning: [[tests.{}]] references unknown filter",
+                    filter_name
+                );
+                continue;
+            }
+        };
+
+        for test in tests {
+            let actual = apply_filter(compiled, &test.input);
+            // Trim trailing newlines: TOML multiline strings end with a newline
+            let actual_cmp = actual.trim_end_matches('\n').to_string();
+            let expected_cmp = test.expected.trim_end_matches('\n').to_string();
+            outcomes.push(TestOutcome {
+                filter_name: filter_name.clone(),
+                test_name: test.name,
+                passed: actual_cmp == expected_cmp,
+                actual: actual_cmp,
+                expected: expected_cmp,
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Convenience wrapper (uses singleton — for run_fallback)
+// ---------------------------------------------------------------------------
+
+/// Find a matching filter from the global registry. Initialises the registry
+/// lazily on first call. Returns `None` if no filter matches.
+pub fn find_matching_filter(command: &str) -> Option<&'static CompiledFilter> {
+    if std::env::var("RTK_TOML_DEBUG").is_ok() {
+        eprintln!(
+            "[rtk:toml] looking up filter for: {:?} ({} filters loaded)",
+            command,
+            REGISTRY.filters.len()
+        );
+    }
+    let result = find_filter_in(command, &REGISTRY.filters);
+    if std::env::var("RTK_TOML_DEBUG").is_ok() {
+        match result {
+            Some(f) => eprintln!("[rtk:toml] matched filter: '{}'", f.name),
+            None => eprintln!("[rtk:toml] no filter matched — passthrough"),
+        }
+    }
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Helper: build a CompiledFilter from inline TOML for tests.
+    // Never touches the lazy_static registry.
+    fn make_filters(toml: &str) -> Vec<CompiledFilter> {
+        TomlFilterRegistry::parse_and_compile(toml, "test").expect("test TOML should be valid")
+    }
+
+    fn first_filter(toml: &str) -> CompiledFilter {
+        make_filters(toml)
+            .into_iter()
+            .next()
+            .expect("expected at least one filter")
+    }
+
+    // --- Pipeline primitives (existing) ---
+
+    #[test]
+    fn test_strip_ansi_removes_codes() {
+        let f = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+strip_ansi = true
+"#,
+        );
+        let out = apply_filter(&f, "\x1b[31mError\x1b[0m\nnormal");
+        assert_eq!(out, "Error\nnormal");
+    }
+
+    #[test]
+    fn test_strip_lines_matching_basic() {
+        let f = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+strip_lines_matching = ["^noise", "^verbose"]
+"#,
+        );
+        let input = "noise line\nkeep this\nverbose stuff\nalso keep";
+        let out = apply_filter(&f, input);
+        assert_eq!(out, "keep this\nalso keep");
+    }
+
+    #[test]
+    fn test_keep_lines_matching_basic() {
+        let f = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+keep_lines_matching = ["^PASS", "^FAIL"]
+"#,
+        );
+        let input = "PASS test_a\nsome noise\nFAIL test_b\nmore noise";
+        let out = apply_filter(&f, input);
+        assert_eq!(out, "PASS test_a\nFAIL test_b");
+    }
+
+    #[test]
+    fn test_truncate_lines_at_unicode_safe() {
+        let f = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+truncate_lines_at = 5
+"#,
+        );
+        // utils::truncate(s, 5) takes 2 chars + "..." when len > 5
+        // "hello" = 5 chars exactly, stays unchanged
+        // "日本語xyz" = 6 chars, truncated to "日本..." (take 2 + "...")
+        let out = apply_filter(&f, "hello\n日本語xyz");
+        assert_eq!(out, "hello\n日本...");
+    }
+
+    #[test]
+    fn test_head_lines() {
+        let f = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+head_lines = 2
+"#,
+        );
+        let input = "a\nb\nc\nd\ne";
+        let out = apply_filter(&f, input);
+        assert!(out.starts_with("a\nb\n"));
+        assert!(out.contains("3 lines omitted"));
+    }
+
+    #[test]
+    fn test_tail_lines() {
+        let f = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+tail_lines = 2
+"#,
+        );
+        let input = "a\nb\nc\nd\ne";
+        let out = apply_filter(&f, input);
+        assert!(out.contains("3 lines omitted"));
+        assert!(out.ends_with("d\ne"));
+    }
+
+    #[test]
+    fn test_head_and_tail_combined() {
+        let f = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+head_lines = 2
+tail_lines = 2
+"#,
+        );
+        let input = "a\nb\nc\nd\ne\nf";
+        let out = apply_filter(&f, input);
+        assert!(out.starts_with("a\nb\n"));
+        assert!(out.contains("2 lines omitted"));
+        assert!(out.ends_with("e\nf"));
+    }
+
+    #[test]
+    fn test_max_lines_counts_omit_message() {
+        // max_lines applied AFTER head — the "omitted" message counts as a line
+        let f = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+max_lines = 3
+"#,
+        );
+        let input = "a\nb\nc\nd\ne";
+        let out = apply_filter(&f, input);
+        let line_count = out.lines().count();
+        // 3 content lines + 1 truncated message = 4 lines output
+        assert_eq!(line_count, 4);
+        assert!(out.contains("lines truncated"));
+    }
+
+    #[test]
+    fn test_on_empty_when_all_filtered() {
+        let f = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+strip_lines_matching = [".*"]
+on_empty = "nothing left"
+"#,
+        );
+        let out = apply_filter(&f, "line1\nline2");
+        assert_eq!(out, "nothing left");
+    }
+
+    #[test]
+    fn test_on_empty_not_triggered_when_output_remains() {
+        let f = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+keep_lines_matching = ["keep"]
+on_empty = "nothing left"
+"#,
+        );
+        let out = apply_filter(&f, "keep this\nnoise");
+        assert_eq!(out, "keep this");
+    }
+
+    #[test]
+    fn test_full_pipeline_order() {
+        // Verify all 8 stages fire in order on a single input
+        let f = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+strip_ansi = true
+strip_lines_matching = ["^noise"]
+truncate_lines_at = 10
+head_lines = 3
+max_lines = 4
+on_empty = "empty"
+"#,
+        );
+        let input =
+            "\x1b[31mred line\x1b[0m\nnoise skip\nkeep one\nkeep two\nkeep three\nkeep four";
+        let out = apply_filter(&f, input);
+        // After strip_ansi: "red line", strip noise: removed, head 3 from remaining 4 lines
+        assert!(out.contains("red line"));
+        assert!(!out.contains("noise skip"));
+        assert!(out.contains("lines omitted") || out.contains("lines truncated"));
+    }
+
+    // --- Validation ---
+
+    #[test]
+    fn test_mutual_exclusion_strip_keep_errors() {
+        let result = make_filters(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+strip_lines_matching = ["a"]
+keep_lines_matching = ["b"]
+"#,
+        );
+        // The filter should be skipped (warning emitted), resulting in empty list
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_invalid_regex_returns_err() {
+        let result = make_filters(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "["
+"#,
+        );
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_schema_version_mismatch_errors() {
+        let result = TomlFilterRegistry::parse_and_compile(
+            r#"schema_version = 99
+[filters.f]
+match_command = "^cmd"
+"#,
+            "test",
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_unknown_field_typo_errors() {
+        // deny_unknown_fields should catch this
+        let result = TomlFilterRegistry::parse_and_compile(
+            r#"schema_version = 1
+[filters.f]
+match_command = "^cmd"
+strip_ansi_typo = true
+"#,
+            "test",
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_empty_filter_passthrough() {
+        let f = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+"#,
+        );
+        let input = "line1\nline2\nline3";
+        let out = apply_filter(&f, input);
+        assert_eq!(out, input);
+    }
+
+    // --- Registry / find ---
+
+    #[test]
+    fn test_builtin_filters_compile() {
+        // Compile-time safety: panics if builtin_filters.toml is broken
+        let builtin = include_str!("builtin_filters.toml");
+        let result = TomlFilterRegistry::parse_and_compile(builtin, "builtin");
+        assert!(
+            result.is_ok(),
+            "builtin_filters.toml failed to compile: {:?}",
+            result
+        );
+        assert!(!result.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_find_filter_matches_terraform() {
+        let filters = make_filters(
+            r#"
+schema_version = 1
+[filters.terraform-plan]
+match_command = "^terraform\\s+plan"
+strip_ansi = true
+"#,
+        );
+        let found = find_filter_in("terraform plan -out=tfplan", &filters);
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().name, "terraform-plan");
+    }
+
+    #[test]
+    fn test_find_filter_no_match_returns_none() {
+        let filters = make_filters(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^terraform"
+"#,
+        );
+        let found = find_filter_in("kubectl get pods", &filters);
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn test_project_filters_priority_over_builtin() {
+        // Project filter has same name but different max_lines — project wins
+        let project = make_filters(
+            r#"
+schema_version = 1
+[filters.make]
+match_command = "^make\\b"
+max_lines = 999
+"#,
+        );
+        let builtin = make_filters(include_str!("builtin_filters.toml"));
+
+        // Simulate the registry: project first
+        let mut all = project;
+        all.extend(builtin);
+
+        let found = find_filter_in("make all", &all).expect("should match");
+        assert_eq!(found.name, "make");
+        // The first (project) match has max_lines=999
+        assert_eq!(found.max_lines, Some(999));
+    }
+
+    // --- Token savings ---
+
+    #[test]
+    fn test_terraform_savings_above_60pct() {
+        let filters = make_filters(include_str!("builtin_filters.toml"));
+        let filter = find_filter_in("terraform plan", &filters).expect("terraform-plan built-in");
+
+        // Inline fixture: realistic terraform plan with many Refreshing state lines (noise).
+        // Real infra refreshes 30+ resources; the plan section is small.
+        // All Refreshing/lock/blank/unchanged lines are stripped -> >60% savings.
+        let input = concat!(
+            "Acquiring state lock. This may take a few moments...\n",
+            "Refreshing state... [id=vpc-0a1b2c3d]\n",
+            "Refreshing state... [id=subnet-11111111]\n",
+            "Refreshing state... [id=subnet-22222222]\n",
+            "Refreshing state... [id=subnet-33333333]\n",
+            "Refreshing state... [id=subnet-44444444]\n",
+            "Refreshing state... [id=igw-aabbccdd]\n",
+            "Refreshing state... [id=rtb-aabbccdd]\n",
+            "Refreshing state... [id=rtb-11223344]\n",
+            "Refreshing state... [id=sg-00112233]\n",
+            "Refreshing state... [id=sg-44556677]\n",
+            "Refreshing state... [id=sg-88990011]\n",
+            "Refreshing state... [id=nacl-00aabbcc]\n",
+            "Refreshing state... [id=acm-arn:us-east-1:cert/abc]\n",
+            "Refreshing state... [id=Z1234567890ABC]\n",
+            "Refreshing state... [id=alb-arn:my-alb]\n",
+            "Refreshing state... [id=tg-arn:my-tg]\n",
+            "Refreshing state... [id=db-ABCDEFGHIJKLMNO]\n",
+            "Refreshing state... [id=rds-cluster:my-aurora]\n",
+            "Refreshing state... [id=elasticache:my-cluster]\n",
+            "Refreshing state... [id=lambda:my-api-function]\n",
+            "Refreshing state... [id=lambda:my-worker]\n",
+            "Refreshing state... [id=iam-role:my-lambda-role]\n",
+            "Refreshing state... [id=iam-role:my-ecs-role]\n",
+            "Refreshing state... [id=s3:::my-app-assets]\n",
+            "Refreshing state... [id=s3:::my-app-logs]\n",
+            "Refreshing state... [id=cloudfront:ABCDEFGHIJK]\n",
+            "Refreshing state... [id=ssm:/my/app/db-url]\n",
+            "Refreshing state... [id=ssm:/my/app/api-key]\n",
+            "Refreshing state... [id=secretsmanager:my-secret]\n",
+            "Releasing state lock. This may take a few moments...\n",
+            "\n",
+            "Terraform will perform the following actions:\n",
+            "\n",
+            "  # aws_instance.web will be created\n",
+            "  + resource \"aws_instance\" \"web\" {\n",
+            "      + ami           = \"ami-0c55b159cbfafe1f0\"\n",
+            "      + instance_type = \"t3.micro\"\n",
+            "    }\n",
+            "\n",
+            "Plan: 1 to add, 0 to change, 0 to destroy.\n",
+        );
+        let out = apply_filter(filter, input);
+        let input_words = input.split_whitespace().count();
+        let out_words = out.split_whitespace().count();
+        let savings = 100.0 - (out_words as f64 / input_words as f64 * 100.0);
+        assert!(
+            savings >= 60.0,
+            "terraform-plan filter: expected >=60% savings, got {:.1}% (in={} out={})",
+            savings,
+            input_words,
+            out_words
+        );
+    }
+
+    #[test]
+    fn test_make_savings_above_60pct() {
+        let filters = make_filters(include_str!("builtin_filters.toml"));
+        let filter = find_filter_in("make all", &filters).expect("make built-in");
+
+        let input = r#"make[1]: Entering directory '/home/user/project'
+make[2]: Entering directory '/home/user/project/src'
+gcc -O2 -Wall -c foo.c -o foo.o
+
+make[2]: Nothing to be done for 'install'.
+make[3]: Entering directory '/home/user/project/src/lib'
+ar rcs libfoo.a foo.o bar.o baz.o
+make[3]: Leaving directory '/home/user/project/src/lib'
+make[2]: Leaving directory '/home/user/project/src'
+
+make[1]: Leaving directory '/home/user/project'
+gcc -O2 -Wall -c bar.c -o bar.o
+
+gcc -O2 -Wall -c baz.c -o baz.o
+
+make[1]: Entering directory '/home/user/project/test'
+make[2]: Entering directory '/home/user/project/test/unit'
+./run_tests --verbose
+make[2]: Nothing to be done for 'check'.
+make[2]: Leaving directory '/home/user/project/test/unit'
+make[1]: Leaving directory '/home/user/project/test'
+
+ld -o myapp foo.o bar.o baz.o -lfoo
+
+make[1]: Entering directory '/home/user/project/docs'
+doxygen Doxyfile
+make[1]: Leaving directory '/home/user/project/docs'
+"#;
+        let out = apply_filter(filter, input);
+        let input_words = input.split_whitespace().count();
+        let out_words = out.split_whitespace().count();
+        let savings = 100.0 - (out_words as f64 / input_words as f64 * 100.0);
+        assert!(
+            savings >= 60.0,
+            "make filter: expected >=60% savings, got {:.1}% (in={} out={})",
+            savings,
+            input_words,
+            out_words
+        );
+    }
+
+    // --- Edge cases ---
+
+    #[test]
+    fn test_empty_input() {
+        let f = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+strip_lines_matching = [".*"]
+"#,
+        );
+        let out = apply_filter(&f, "");
+        assert_eq!(out, "");
+    }
+
+    #[test]
+    fn test_unicode_preserved() {
+        let f = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+strip_lines_matching = ["^noise"]
+"#,
+        );
+        let out = apply_filter(&f, "日本語テスト\nnoise\n中文内容");
+        assert_eq!(out, "日本語テスト\n中文内容");
+    }
+
+    // --- match_output tests (PR1) ---
+
+    #[test]
+    fn test_match_output_basic_short_circuit() {
+        let f = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+match_output = [
+  { pattern = "Switched to branch", message = "ok" },
+]
+"#,
+        );
+        let out = apply_filter(&f, "Switched to branch 'main'");
+        assert_eq!(out, "ok");
+    }
+
+    #[test]
+    fn test_match_output_second_rule_matches() {
+        let f = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+match_output = [
+  { pattern = "Switched to branch", message = "switched" },
+  { pattern = "Already on", message = "already" },
+]
+"#,
+        );
+        let out = apply_filter(&f, "Already on 'main'");
+        assert_eq!(out, "already");
+    }
+
+    #[test]
+    fn test_match_output_no_match_pipeline_continues() {
+        let f = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+match_output = [
+  { pattern = "Switched to branch", message = "ok" },
+]
+strip_lines_matching = ["^noise"]
+"#,
+        );
+        let out = apply_filter(&f, "noise\nkeep this");
+        // No match_output match, pipeline continues and strips noise
+        assert_eq!(out, "keep this");
+    }
+
+    #[test]
+    fn test_match_output_strip_ansi_before_match() {
+        let f = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+strip_ansi = true
+match_output = [
+  { pattern = "Switched to branch", message = "ok" },
+]
+"#,
+        );
+        // ANSI stripped before match_output check (stage 1 before stage 3)
+        let out = apply_filter(&f, "\x1b[32mSwitched to branch\x1b[0m 'main'");
+        assert_eq!(out, "ok");
+    }
+
+    #[test]
+    fn test_match_output_no_match_then_on_empty() {
+        let f = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+match_output = [
+  { pattern = "Switched", message = "ok" },
+]
+strip_lines_matching = [".*"]
+on_empty = "nothing"
+"#,
+        );
+        // No match_output match; pipeline strips all lines; on_empty fires
+        let out = apply_filter(&f, "foo bar baz");
+        assert_eq!(out, "nothing");
+    }
+
+    #[test]
+    fn test_match_output_invalid_regex_rejected() {
+        let result = make_filters(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+match_output = [
+  { pattern = "[invalid", message = "ok" },
+]
+"#,
+        );
+        assert!(result.is_empty());
+    }
+
+    // --- replace tests (PR1) ---
+
+    #[test]
+    fn test_replace_basic_all_occurrences() {
+        let f = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+replace = [
+  { pattern = "foo", replacement = "bar" },
+]
+"#,
+        );
+        let out = apply_filter(&f, "foo baz foo\nfoo");
+        assert_eq!(out, "bar baz bar\nbar");
+    }
+
+    #[test]
+    fn test_replace_chaining_sequential() {
+        let f = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+replace = [
+  { pattern = "aaa", replacement = "bbb" },
+  { pattern = "bbb", replacement = "ccc" },
+]
+"#,
+        );
+        // Rule 2 operates on the output of rule 1
+        let out = apply_filter(&f, "aaa");
+        assert_eq!(out, "ccc");
+    }
+
+    #[test]
+    fn test_replace_backreferences() {
+        let f = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+replace = [
+  { pattern = "(\\w+):(\\w+)", replacement = "$2:$1" },
+]
+"#,
+        );
+        let out = apply_filter(&f, "hello:world");
+        assert_eq!(out, "world:hello");
+    }
+
+    #[test]
+    fn test_replace_then_strip_interaction() {
+        let f = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+replace = [
+  { pattern = "noise", replacement = "DROPPED" },
+]
+strip_lines_matching = ["^DROPPED"]
+"#,
+        );
+        // replace transforms "noise line" -> "DROPPED line", strip removes it
+        let out = apply_filter(&f, "noise line\nkeep this");
+        assert_eq!(out, "keep this");
+    }
+
+    #[test]
+    fn test_replace_empty_input_noop() {
+        let f = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+replace = [
+  { pattern = "foo", replacement = "bar" },
+]
+"#,
+        );
+        let out = apply_filter(&f, "");
+        assert_eq!(out, "");
+    }
+
+    #[test]
+    fn test_replace_invalid_regex_rejected() {
+        let result = make_filters(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+replace = [
+  { pattern = "[invalid", replacement = "bar" },
+]
+"#,
+        );
+        assert!(result.is_empty());
+    }
+
+    // --- verify (PR2) ---
+
+    #[test]
+    fn test_run_filter_tests_passes_on_correct_expected() {
+        let content = r#"
+schema_version = 1
+
+[filters.make]
+match_command = "^make\\b"
+strip_lines_matching = ["^make\\[\\d+\\]:"]
+
+[[tests.make]]
+name = "strips entering/leaving lines"
+input = """
+make[1]: Entering directory '/home/user'
+gcc -O2 foo.c
+make[1]: Leaving directory '/home/user'
+"""
+expected = """
+gcc -O2 foo.c
+"""
+"#;
+        let mut outcomes = Vec::new();
+        let mut all_names = Vec::new();
+        let mut tested = std::collections::HashSet::new();
+        collect_test_outcomes(content, None, &mut outcomes, &mut all_names, &mut tested);
+        assert_eq!(outcomes.len(), 1);
+        assert!(
+            outcomes[0].passed,
+            "test should pass: {:?}",
+            outcomes[0].actual
+        );
+    }
+
+    #[test]
+    fn test_run_filter_tests_fails_on_wrong_expected() {
+        let content = r#"
+schema_version = 1
+
+[filters.make]
+match_command = "^make\\b"
+strip_lines_matching = ["^make\\[\\d+\\]:"]
+
+[[tests.make]]
+name = "wrong expected"
+input = "make[1]: Entering\ngcc foo.c"
+expected = "wrong output"
+"#;
+        let mut outcomes = Vec::new();
+        let mut all_names = Vec::new();
+        let mut tested = std::collections::HashSet::new();
+        collect_test_outcomes(content, None, &mut outcomes, &mut all_names, &mut tested);
+        assert_eq!(outcomes.len(), 1);
+        assert!(!outcomes[0].passed);
+    }
+
+    #[test]
+    fn test_filters_without_tests_detected() {
+        let content = r#"
+schema_version = 1
+
+[filters.make]
+match_command = "^make\\b"
+"#;
+        let mut outcomes = Vec::new();
+        let mut all_names = Vec::new();
+        let mut tested = std::collections::HashSet::new();
+        collect_test_outcomes(content, None, &mut outcomes, &mut all_names, &mut tested);
+        // No tests defined, but filter exists
+        assert_eq!(outcomes.len(), 0);
+        assert!(all_names.contains(&"make".to_string()));
+        assert!(!tested.contains("make"));
+    }
+}

--- a/src/toml_filter.rs
+++ b/src/toml_filter.rs
@@ -439,7 +439,7 @@ pub fn run_filter_tests(filter_name_opt: Option<&str>) -> VerifyResults {
         .into_iter()
         .filter(|name| {
             // When a specific filter is requested, only report that one as missing tests
-            filter_name_opt.is_none_or(|f| name == f)
+            filter_name_opt.map_or(true, |f| name == f)
         })
         .filter(|name| !tested_filter_names.contains(name))
         .collect();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result};
 use regex::Regex;
 use std::process::Command;
 
-/// Truncates a string to `max_len` characters, appending "..." if needed.
+/// Truncates a string to `max_len` characters, appending `...` if needed.
 ///
 /// # Arguments
 /// * `s` - The string to truncate
@@ -36,7 +36,7 @@ pub fn truncate(s: &str, max_len: usize) -> String {
 /// Strips ANSI escape codes (colors, styles) from a string.
 ///
 /// # Arguments
-/// * `text` - Text potentially containing ANSI codes
+/// * `text` - Text potentially containing ANSI escape codes
 ///
 /// # Examples
 /// ```
@@ -51,7 +51,7 @@ pub fn strip_ansi(text: &str) -> String {
     ANSI_RE.replace_all(text, "").to_string()
 }
 
-/// Execute a command and return cleaned stdout/stderr.
+/// Executes a command and returns cleaned stdout/stderr.
 ///
 /// # Arguments
 /// * `cmd` - Command to execute (e.g. "eslint")
@@ -80,7 +80,7 @@ pub fn execute_command(cmd: &str, args: &[&str]) -> Result<(String, String, i32)
     Ok((stdout, stderr, exit_code))
 }
 
-/// Format a token count with K/M suffixes for readability.
+/// Formats a token count with K/M suffixes for readability.
 ///
 /// # Arguments
 /// * `n` - Token count
@@ -105,7 +105,7 @@ pub fn format_tokens(n: usize) -> String {
     }
 }
 
-/// Format a USD amount with adaptive precision.
+/// Formats a USD amount with adaptive precision.
 ///
 /// # Arguments
 /// * `amount` - Amount in dollars

--- a/src/verify_cmd.rs
+++ b/src/verify_cmd.rs
@@ -1,0 +1,47 @@
+use anyhow::Result;
+
+use crate::toml_filter;
+
+/// Run TOML filter inline tests.
+///
+/// - `filter`: if `Some`, only run tests for that filter name
+/// - `require_all`: fail if any filter has no inline tests
+pub fn run(filter: Option<String>, require_all: bool) -> Result<()> {
+    let results = toml_filter::run_filter_tests(filter.as_deref());
+
+    let total = results.outcomes.len();
+    let passed = results.outcomes.iter().filter(|o| o.passed).count();
+    let failed = total - passed;
+
+    // Print failures with details
+    for outcome in &results.outcomes {
+        if !outcome.passed {
+            eprintln!(
+                "FAIL [{}] {}\n  expected: {:?}\n  actual:   {:?}",
+                outcome.filter_name, outcome.test_name, outcome.expected, outcome.actual
+            );
+        }
+    }
+
+    if total == 0 {
+        println!("No inline tests found.");
+    } else {
+        println!("{}/{} tests passed", passed, total);
+    }
+
+    if require_all && !results.filters_without_tests.is_empty() {
+        for name in &results.filters_without_tests {
+            eprintln!("MISSING tests for filter: {}", name);
+        }
+        anyhow::bail!(
+            "{} filter(s) have no inline tests (use --require-all in CI)",
+            results.filters_without_tests.len()
+        );
+    }
+
+    if failed > 0 {
+        anyhow::bail!("{} test(s) failed", failed);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
> **TOML Part 1** of 3 — establishes the DSL engine. See also [Part 2](#351) and [Part 3](#386).

## What this PR does

Adds a declarative TOML-based filter engine that lets anyone add a new command filter **without writing Rust**. A TOML block in `src/builtin_filters.toml` (or the user's `.rtk/filters.toml`) is enough for commands with stable, predictable output.

This is a foundational change: it lowers the contribution bar for simple filters from ~200 LOC of Rust to a ~10-line TOML block.

---

## Architecture

### New files

| File | Role |
|------|------|
| `src/toml_filter.rs` | Engine: TOML parsing, filter application, `run_fallback()` integration |
| `src/builtin_filters.toml` | Built-in filters (shipped with the binary via `include_str!`) |
| `src/verify_cmd.rs` | `rtk verify` command — runs inline TOML tests, supports `--require-all` |

### How it works

```
 rtk tofu plan
      │
      ▼
 ┌──────────┐    known command    ┌─────────────────┐
 │   Clap   │ ──────────────────► │   Rust module   │
 │  parse   │                     │  (git, cargo…)  │
 └──────────┘                     └─────────────────┘
      │
      │ unknown command (parse error)
      ▼
 ┌──────────────┐
 │ run_fallback │
 └──────┬───────┘
        │
        ├── TOML filter match? ── NO ──► exec raw (passthrough, unchanged)
        │
        │ YES
        ▼
   exec command
   capture stdout
        │
        ▼
   apply filter          ◄── primitives applied in declaration order
   primitives
        │
        ▼
   print filtered
   output + exit code
```

User filters in `.rtk/filters.toml` are loaded at startup and merged with built-ins. **User filters take precedence** over built-ins.

### Filter pipeline

```
 raw stdout
     │
     ▼
 strip_ansi ─────────────────────────────────── (if enabled)
     │
     ▼
 match_output ── pattern match? ──► emit short message, exit early
     │ no match
     ▼
 strip_lines_matching   ──► drop lines matching any regex
 keep_lines_matching    ──► keep only lines matching any regex
     │
     ▼
 replace ────────────────────────────────────── (regex find+replace)
     │
     ▼
 truncate_lines_at ──────────────────────────── (chars per line cap)
     │
     ▼
 head_lines / tail_lines ───────────────────── (first/last N lines)
     │
     ▼
 max_lines ──────────────────────────────────── (total line cap)
     │
     ▼
 on_empty ── output empty? ──► emit fallback message
     │
     ▼
 print to stdout
```

### TOML vs Rust — decision guide

```
 New command to support?
         │
         ▼
  Output is stable &        NO ──────────────────────────────────────┐
  line-oriented?                                                      │
         │ YES                                                        │
         ▼                                                            │
  Filtering = strip noise,  NO → JSON parsing, aggregation,          │
  keep summaries,               state machines, HashMap?             │
  head/tail, truncate?          │                                    │
         │ YES                  ▼                                    ▼
         ▼              Write a Rust module              Write a Rust module
   Add a TOML filter        (_cmd.rs)                       (_cmd.rs)
   in builtin_filters.toml
   or .rtk/filters.toml
```

### Filter primitives (8 total)

| Primitive | Effect |
|-----------|--------|
| `strip_ansi` | Remove ANSI escape sequences |
| `strip_lines_matching` | Drop lines matching any regex in the list |
| `keep_lines_matching` | Keep only lines matching any regex |
| `replace` | Regex find+replace on the full output |
| `match_output` | Short-circuit: if output matches pattern, emit a short message and stop |
| `truncate_lines_at` | Truncate lines longer than N chars |
| `head_lines` / `tail_lines` | Keep first/last N lines |
| `max_lines` | Cap total output lines |
| `on_empty` | Message to emit when filtered output is empty |

---

## 14 new built-in filters

### #240 — OpenTofu (4 filters)

Mirror of the existing `terraform-*` filters, targeting `tofu` CLI.

| Filter | Command | Savings target |
|--------|---------|----------------|
| `tofu-plan` | `tofu plan` | ~80% (strips Refreshing state, lock lines, blanks) |
| `tofu-init` | `tofu init` | ~70% (strips provider download noise) |
| `tofu-validate` | `tofu validate` | short-circuit on `Success!` |
| `tofu-fmt` | `tofu fmt` | `on_empty` for no changes |

### #284 — `du` (1 filter)

Strips blank lines, truncates long paths at 120 chars, caps at 40 lines.

### #281 — `fail2ban-client` (1 filter)

Strips blank lines, caps at 30 lines. Note: no `sudo` prefix — the hook rewrite does not capture `sudo`, so the prefix would be dead code.

### #282 — `iptables` (1 filter)

Defensive regex: strips only Docker-autogenerated chains (`^Chain DOCKER`, `^Chain BR-`). Does not strip the rule lines that follow those chains. Caps at 50 lines, truncates at 120 chars.

### #310 — Elixir `mix` (2 filters)

| Filter | Command | Strategy |
|--------|---------|----------|
| `mix-format` | `mix format` | `on_empty` → `mix format: ok` |
| `mix-compile` | `mix compile` | strips `Compiling N files`, `Generated`, blanks; preserves warnings/errors |

### #280 — Shopify Theme (1 filter)

Strips `Uploading`/`Downloading` lines, keeps last 5 lines (the summary) via `tail_lines`, caps at 15.

### #231 — PlatformIO (1 filter, partial)

`pio run`: strips build noise (CONFIGURATION, LDF, Compiling, Linking, Building, Checking size). Errors and the final memory summary are preserved.

Note: this closes the `pio run` case. Other commands from #231 (`npm test`, `python`, `stty`) remain open.

### #338 — Maven (1 filter, partial)

`mvn compile|package|clean|install`: uses `strip_lines_matching` (not `keep`) to strip `[INFO] ---`, `[INFO] Building`, download lines, and blanks. This preserves stacktraces, plugin warnings, and any unexpected output — only known noise is stripped.

Note: `mvn test` (Surefire state machine) is out of scope for TOML; it requires a Rust module.

---

## Inline test suite

Every filter has at minimum 2 inline tests (realistic fixture + edge case). Run with:

```bash
rtk verify             # 38/38 pass
rtk verify --require-all   # fails if any filter has zero tests
```

Test results at time of this PR: **38/38 passed**.

---

## Issues closed / addressed

### Closed by this PR

| Issue | Status |
|-------|--------|
| **#299** | This PR — TOML filter DSL feature request |
| **#298** | Duplicate of #299 — can be closed |
| **#286** | `rtk` must pass through unrecognized commands — resolved by `run_fallback()` + TOML routing |
| **#240** | OpenTofu support — 4 built-in filters added |
| **#284** | `du` support — filter added |
| **#281** | `fail2ban-client` support — filter added |
| **#282** | `iptables` support — filter added |
| **#310** | `mix format` and `mix compile` — 2 filters added |

### Partially addressed

| Issue | What's covered | What remains |
|-------|----------------|--------------|
| **#231** | `pio run` filter added | `npm test`, `python`, `stty`, other 7 commands from the issue |
| **#280** | `shopify theme push/pull` filter added | Other Shopify subcommands |
| **#338** | `mvn compile/package/clean/install` filter added | `mvn test` (needs Rust state machine for Surefire) |

### Not addressed (documented reasons)

| Issue | Reason |
|-------|--------|
| **#275** `docker exec` | Output is unpredictable — depends on the inner command; no stable format to filter |
| **#283** `stat` | macOS `stat -f` vs Linux format divergence; savings < 60%; low utility |
| **#333** `ssh` | Command dispatch for remote execution needs Rust routing |
| **#271** `jj` | Needs compression-quality filtering (~60-80%); TOML primitives cap at ~10-20% |

---

## PRs with technical coordination needed

Based on the pre-merge impact analysis (`claudedocs/toml-impact-triage-2026-03-05.md`):

### Conflicts (should merge before this PR ideally)

| PR | Author | Zone | Type |
|----|--------|------|------|
| **#306** | @jbgriesner | `lazy_static` → `LazyLock` migration | This PR uses `lazy_static!` in `toml_filter.rs`. If #306 merges first, we switch to `LazyLock` — cleaner result. |
| **#326** | @rursache | `run_fallback()` stderr/`--` separator | This PR also modifies `run_fallback()`. Merging #326 first avoids a painful rebase. |

### Architectural note (no code conflict)

| PR | Author | Note |
|----|--------|------|
| **#268** | @dragonGR | Stream proxy output. TOML captures stdout via `Stdio::piped` for matched commands; streaming behavior for unmatched commands (inherit) is unchanged. No conflict, but related architecturally. |

### PRs NOT affected by this PR

All 7 PRs deep-dived in the impact analysis are **Rust-required** — they use state machines, JSON aggregation, or HashMaps that TOML primitives cannot express:

| PR | Author | Why Rust is needed |
|----|--------|--------------------|
| **#341** | @philbritton | 25 JSON handlers, `serde_json::Value`, metrics aggregation |
| **#308** | @cmolder | `BazelBuildState` / `BazelTestState`, BTreeMap, streaming |
| **#312** | @kherembourg | `test`/`connected`/`deps` subcommands = state machines |
| **#263** | @yonatankarp | `in_failure_block` failure tracking |
| **#288** | @rubixhacker | 6 filters with aggregation + reformatting |
| **#290** | @charlesvien | Regex extraction + summary reformatting |
| **#253** | @TheGlitching | `serde_json` + `HashMap<String, usize>` aggregation |

The ~35 other open PRs (Rust filters, bug fixes, docs, infra, hooks) are unaffected.

---

## Out of scope (documented for follow-up)

- **Hook rewrite coverage (#294)**: The 14 new filters only activate if the hook rewrites the command to `rtk <cmd>`. Adding `tofu`, `du`, `fail2ban-client`, `iptables`, `mix`, `shopify`, `pio`, `mvn` to the hook is a separate PR.
- **`rtk discover` TOML recommendations**: `rtk discover` could suggest TOML filters for unhandled commands — separate issue.
- **CONTRIBUTING.md**: Should document when to use TOML vs Rust — separate PR.

---

## Test plan

```bash
# Quality gates
cargo fmt --all && cargo clippy --all-targets && cargo test --all
# → 656 passed, 0 errors

# Inline tests
cargo build --release
./target/release/rtk verify             # 38/38 passed
./target/release/rtk verify --require-all

# Performance (20 total filters should not impact startup)
/usr/bin/time -p ./target/release/rtk git status  # < 50ms wall
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)