### PR TITLE
feat: warn when installed hook is outdated (#344)

### DIFF
--- a/hooks/rtk-rewrite.sh
+++ b/hooks/rtk-rewrite.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# rtk-hook-version: 2
 # RTK Claude Code hook — rewrites commands to use rtk for token savings.
 # Requires: rtk >= 0.23.0, jq
 #

--- a/src/hook_check.rs
+++ b/src/hook_check.rs
@@ -1,0 +1,88 @@
+use std::path::PathBuf;
+
+const CURRENT_HOOK_VERSION: u8 = 2;
+const WARN_INTERVAL_SECS: u64 = 24 * 3600;
+
+/// Check if the installed hook is outdated, warn once per day.
+pub fn maybe_warn() {
+    // Don't block startup — fail silently on any error
+    let _ = check_and_warn();
+}
+
+fn check_and_warn() -> Option<()> {
+    let hook_path = hook_installed_path()?;
+    let content = std::fs::read_to_string(&hook_path).ok()?;
+
+    let installed_version = parse_hook_version(&content);
+
+    if installed_version >= CURRENT_HOOK_VERSION {
+        return Some(());
+    }
+
+    // Rate limit: warn once per day
+    let marker = warn_marker_path()?;
+    if let Ok(meta) = std::fs::metadata(&marker) {
+        if let Ok(elapsed) = meta.modified().ok()?.elapsed() {
+            if elapsed.as_secs() < WARN_INTERVAL_SECS {
+                return Some(());
+            }
+        }
+    }
+
+    // Touch marker
+    let _ = std::fs::create_dir_all(marker.parent()?);
+    let _ = std::fs::write(&marker, b"");
+
+    eprintln!("[rtk] Hook outdated — run `rtk init -g` to update");
+
+    Some(())
+}
+
+pub fn parse_hook_version(content: &str) -> u8 {
+    for line in content.lines().take(5) {
+        if let Some(rest) = line.strip_prefix("# rtk-hook-version:") {
+            if let Ok(v) = rest.trim().parse::<u8>() {
+                return v;
+            }
+        }
+    }
+    0 // No version tag = version 0 (outdated)
+}
+
+fn hook_installed_path() -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    let path = home.join(".claude").join("hooks").join("rtk-rewrite.sh");
+    if path.exists() {
+        Some(path)
+    } else {
+        None
+    }
+}
+
+fn warn_marker_path() -> Option<PathBuf> {
+    let data_dir = dirs::data_local_dir()?.join("rtk");
+    Some(data_dir.join(".hook_warn_last"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_hook_version_present() {
+        let content = "#!/usr/bin/env bash\n# rtk-hook-version: 2\n# some comment\n";
+        assert_eq!(parse_hook_version(content), 2);
+    }
+
+    #[test]
+    fn test_parse_hook_version_missing() {
+        let content = "#!/usr/bin/env bash\n# old hook without version\n";
+        assert_eq!(parse_hook_version(content), 0);
+    }
+
+    #[test]
+    fn test_parse_hook_version_future() {
+        let content = "#!/usr/bin/env bash\n# rtk-hook-version: 5\n";
+        assert_eq!(parse_hook_version(content), 5);
+    }
+}

--- a/src/init.rs
+++ b/src/init.rs
@@ -1029,6 +1029,7 @@ pub fn show_config() -> Result<()> {
             let has_guards =
                 hook_content.contains("command -v rtk") && hook_content.contains("command -v jq");
             let is_thin_delegator = hook_content.contains("rtk rewrite");
+            let hook_version = crate::hook_check::parse_hook_version(&hook_content);
 
             if !is_executable {
                 println!(
@@ -1045,8 +1046,9 @@ pub fn show_config() -> Result<()> {
                 );
             } else if is_executable && has_guards {
                 println!(
-                    "✅ Hook: {} (thin delegator, up to date)",
-                    hook_path.display()
+                    "✅ Hook: {} (thin delegator, version {})",
+                    hook_path.display(),
+                    hook_version
                 );
             } else {
                 println!("⚠️  Hook: {} (no guards - outdated)", hook_path.display());

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod go_cmd;
 mod golangci_cmd;
 mod grep_cmd;
 mod hook_audit_cmd;
+mod hook_check;
 mod init;
 mod integrity;
 mod json_cmd;
@@ -993,6 +994,9 @@ fn run_fallback(parse_error: clap::Error) -> Result<()> {
 fn main() -> Result<()> {
     // Fire-and-forget telemetry ping (1/day, non-blocking)
     telemetry::maybe_ping();
+
+    // Warn if installed hook is outdated (1/day, non-blocking)
+    hook_check::maybe_warn();
 
     let cli = match Cli::try_parse() {
         Ok(cli) => cli,


### PR DESCRIPTION
## Summary

- Add `# rtk-hook-version: 2` header to the hook file for version tracking
- New `hook_check` module: detects outdated hook at startup, prints warning to stderr (max 1/day via marker file)
- Homebrew caveats updated: remind users to run `rtk init -g` after upgrade

Closes #344

## How it works

1. On every `rtk` invocation, `hook_check::maybe_warn()` reads `~/.claude/hooks/rtk-rewrite.sh`
2. Parses `# rtk-hook-version: N` from the first 5 lines
3. If missing or < current version: prints `[rtk] Hook outdated — run rtk init -g to update`
4. Warning is rate-limited to once per 24h via marker file

## Test plan

- [x] 3 unit tests for version parsing (present, missing, future)
- [x] 620 tests pass
- [x] Manual: old hook (no tag) → warning shown
- [x] Manual: updated hook (version 2) → no warning
- [x] Manual: `rtk init -g` updates hook with version tag