### PR TITLE
fix: RTK_DISABLED ignored, 2>&1 broken, json TOML error (#345, #346, #347)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -293,7 +293,7 @@ SHARED            utils.rs          Helpers                N/A        ✓
                   tee.rs            Full output recovery   N/A        ✓
 ```
 
-**Total: 56 modules** (38 command modules + 18 infrastructure modules)
+**Total: 57 modules** (38 command modules + 19 infrastructure modules)
 
 ### Module Count Breakdown
 
@@ -1488,4 +1488,4 @@ When implementing a new command, consider:
 
 **Last Updated**: 2026-02-22
 **Architecture Version**: 2.2
-**rtk Version**: 0.25.0
+**rtk Version**: 0.26.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This is a fork with critical fixes for git argument parsing and modern JavaScrip
 
 **Verify correct installation:**
 ```bash
-rtk --version  # Should show "rtk 0.25.0" (or newer)
+rtk --version  # Should show "rtk 0.26.0" (or newer)
 rtk gain       # Should show token savings stats (NOT "command not found")
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ rtk filters and compresses command outputs before they reach your LLM context, s
 
 **How to verify you have the correct rtk:**
 ```bash
-rtk --version   # Should show "rtk 0.25.0"
+rtk --version   # Should show "rtk 0.26.0"
 rtk gain        # Should show token savings stats
 ```
 

--- a/hooks/test-rtk-rewrite.sh
+++ b/hooks/test-rtk-rewrite.sh
@@ -239,6 +239,44 @@ test_rewrite "kubectl apply -f deploy.yaml" \
 
 echo ""
 
+# ---- SECTION 3b: RTK_DISABLED and redirect fixes (#345, #346) ----
+echo "--- RTK_DISABLED (#345) ---"
+test_rewrite "RTK_DISABLED=1 git status (no rewrite)" \
+  "RTK_DISABLED=1 git status" \
+  ""
+
+test_rewrite "RTK_DISABLED=1 cargo test (no rewrite)" \
+  "RTK_DISABLED=1 cargo test" \
+  ""
+
+test_rewrite "FOO=1 RTK_DISABLED=1 git status (no rewrite)" \
+  "FOO=1 RTK_DISABLED=1 git status" \
+  ""
+
+echo ""
+echo "--- Redirect operators (#346) ---"
+test_rewrite "cargo test 2>&1 | head" \
+  "cargo test 2>&1 | head" \
+  "rtk cargo test 2>&1 | head"
+
+test_rewrite "cargo test 2>&1" \
+  "cargo test 2>&1" \
+  "rtk cargo test 2>&1"
+
+test_rewrite "cargo test &>/dev/null" \
+  "cargo test &>/dev/null" \
+  "rtk cargo test &>/dev/null"
+
+# Note: the bash hook rewrites only the first command segment (sed-based);
+# full compound rewriting (both sides of &) is handled by `rtk rewrite` (Rust).
+# The critical behavior tested here: `&` after `cargo test` is NOT mistaken for
+# a redirect — the hook still rewrites cargo test, no crash.
+test_rewrite "cargo test & git status (bash hook rewrites first segment only)" \
+  "cargo test & git status" \
+  "rtk cargo test & git status"
+
+echo ""
+
 # ---- SECTION 4: Vitest edge case (fixed double "run" bug) ----
 echo "--- Vitest run dedup ---"
 test_rewrite "vitest (no args)" \

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -344,19 +344,27 @@ fn rewrite_compound(cmd: &str, excluded: &[String]) -> Option<String> {
                 seg_start = i;
             }
             b'&' if !in_single && !in_double => {
-                // single `&` background execution operator
-                let seg = cmd[seg_start..i].trim();
-                let rewritten = rewrite_segment(seg, excluded).unwrap_or_else(|| seg.to_string());
-                if rewritten != seg {
-                    any_changed = true;
-                }
-                result.push_str(&rewritten);
-                result.push_str(" & ");
-                i += 1;
-                while i < len && bytes[i] == b' ' {
+                // #346: redirect detection — 2>&1 / >&2 (> before &) or &>file / &>>file (> after &)
+                let is_redirect =
+                    (i > 0 && bytes[i - 1] == b'>') || (i + 1 < len && bytes[i + 1] == b'>');
+                if is_redirect {
                     i += 1;
+                } else {
+                    // single `&` background execution operator
+                    let seg = cmd[seg_start..i].trim();
+                    let rewritten =
+                        rewrite_segment(seg, excluded).unwrap_or_else(|| seg.to_string());
+                    if rewritten != seg {
+                        any_changed = true;
+                    }
+                    result.push_str(&rewritten);
+                    result.push_str(" & ");
+                    i += 1;
+                    while i < len && bytes[i] == b' ' {
+                        i += 1;
+                    }
+                    seg_start = i;
                 }
-                seg_start = i;
             }
             b';' if !in_single && !in_double => {
                 // `;` separator
@@ -466,6 +474,11 @@ fn rewrite_segment(seg: &str, excluded: &[String]) -> Option<String> {
     let env_prefix_len = trimmed.len() - stripped_cow.len();
     let env_prefix = &trimmed[..env_prefix_len];
     let cmd_clean = stripped_cow.trim();
+
+    // #345: RTK_DISABLED=1 in env prefix → skip rewrite entirely
+    if env_prefix.contains("RTK_DISABLED=") {
+        return None;
+    }
 
     // Try each rewrite prefix (longest first) with word-boundary check
     for &prefix in rule.rewrite_prefixes {
@@ -967,6 +980,89 @@ mod tests {
         assert_eq!(
             rewrite_command("rtk git add . && cargo test", &[]),
             Some("rtk git add . && rtk cargo test".into())
+        );
+    }
+
+    // --- #345: RTK_DISABLED ---
+
+    #[test]
+    fn test_rewrite_rtk_disabled_curl() {
+        assert_eq!(
+            rewrite_command("RTK_DISABLED=1 curl https://example.com", &[]),
+            None
+        );
+    }
+
+    #[test]
+    fn test_rewrite_rtk_disabled_git_status() {
+        assert_eq!(rewrite_command("RTK_DISABLED=1 git status", &[]), None);
+    }
+
+    #[test]
+    fn test_rewrite_rtk_disabled_multi_env() {
+        assert_eq!(
+            rewrite_command("FOO=1 RTK_DISABLED=1 git status", &[]),
+            None
+        );
+    }
+
+    #[test]
+    fn test_rewrite_non_rtk_disabled_env_still_rewrites() {
+        assert_eq!(
+            rewrite_command("SOME_VAR=1 git status", &[]),
+            Some("SOME_VAR=1 rtk git status".into())
+        );
+    }
+
+    // --- #346: 2>&1 and &> redirect detection ---
+
+    #[test]
+    fn test_rewrite_redirect_2_gt_amp_1_with_pipe() {
+        assert_eq!(
+            rewrite_command("cargo test 2>&1 | head", &[]),
+            Some("rtk cargo test 2>&1 | head".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_redirect_2_gt_amp_1_trailing() {
+        assert_eq!(
+            rewrite_command("cargo test 2>&1", &[]),
+            Some("rtk cargo test 2>&1".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_redirect_plain_2_devnull() {
+        // 2>/dev/null has no `&`, never broken — non-regression
+        assert_eq!(
+            rewrite_command("git status 2>/dev/null", &[]),
+            Some("rtk git status 2>/dev/null".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_redirect_2_gt_amp_1_with_and() {
+        assert_eq!(
+            rewrite_command("cargo test 2>&1 && echo done", &[]),
+            Some("rtk cargo test 2>&1 && echo done".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_redirect_amp_gt_devnull() {
+        assert_eq!(
+            rewrite_command("cargo test &>/dev/null", &[]),
+            Some("rtk cargo test &>/dev/null".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_background_amp_non_regression() {
+        // background `&` must still work after redirect fix
+        assert_eq!(
+            rewrite_command("cargo test & git status", &[]),
+            Some("rtk cargo test & rtk git status".into())
         );
     }
 

--- a/src/json_cmd.rs
+++ b/src/json_cmd.rs
@@ -1,12 +1,41 @@
 use crate::tracking;
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use serde_json::Value;
 use std::fs;
 use std::io::{self, Read};
 use std::path::Path;
 
+/// Reject non-JSON files with a clear error before doing any I/O.
+fn validate_json_extension(file: &Path) -> Result<()> {
+    if let Some(ext) = file.extension().and_then(|e| e.to_str()) {
+        let format_name = match ext {
+            "toml" => Some("TOML"),
+            "yaml" | "yml" => Some("YAML"),
+            "xml" => Some("XML"),
+            "csv" => Some("CSV"),
+            "ini" => Some("INI"),
+            "env" => Some("env"),
+            "txt" => Some("plain text"),
+            _ => None,
+        };
+        if let Some(fmt) = format_name {
+            let mut msg = format!(
+                "{} is not a JSON file (detected {}). Use `rtk read` for non-JSON files.",
+                file.display(),
+                fmt
+            );
+            if ext == "toml" && file.file_name().is_some_and(|n| n == "Cargo.toml") {
+                msg.push_str(" Tip: use `rtk deps` for Cargo.toml.");
+            }
+            bail!("{}", msg);
+        }
+    }
+    Ok(())
+}
+
 /// Show JSON structure without values
 pub fn run(file: &Path, max_depth: usize, verbose: u8) -> Result<()> {
+    validate_json_extension(file)?;
     let timer = tracking::TimedExecution::start();
 
     if verbose > 0 {
@@ -146,6 +175,42 @@ fn extract_schema(value: &Value, depth: usize, max_depth: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- #347: validate_json_extension ---
+
+    #[test]
+    fn test_toml_file_rejected() {
+        let err = validate_json_extension(Path::new("config.toml")).unwrap_err();
+        assert!(err.to_string().contains("not a JSON file"));
+        assert!(err.to_string().contains("TOML"));
+    }
+
+    #[test]
+    fn test_cargo_toml_suggests_deps() {
+        let err = validate_json_extension(Path::new("Cargo.toml")).unwrap_err();
+        assert!(err.to_string().contains("rtk deps"));
+    }
+
+    #[test]
+    fn test_yaml_file_rejected() {
+        let err = validate_json_extension(Path::new("config.yaml")).unwrap_err();
+        assert!(err.to_string().contains("YAML"));
+    }
+
+    #[test]
+    fn test_json_file_accepted() {
+        assert!(validate_json_extension(Path::new("data.json")).is_ok());
+    }
+
+    #[test]
+    fn test_unknown_extension_accepted() {
+        assert!(validate_json_extension(Path::new("data.xyz")).is_ok());
+    }
+
+    #[test]
+    fn test_no_extension_accepted() {
+        assert!(validate_json_extension(Path::new("Makefile")).is_ok());
+    }
 
     #[test]
     fn test_extract_schema_simple() {


### PR DESCRIPTION
## Summary

3 bugs reported by @pszymkowiak, all affecting daily usage.

- **#345** — `RTK_DISABLED=1 cmd` was silently rewritten anyway. `rewrite_segment()` now returns `None` when `env_prefix` contains `RTK_DISABLED=`, before any rewriting happens.
- **#346** — `cargo test 2>&1 | head` was corrupted: the byte parser in `rewrite_compound()` saw the `&` in `2>&1` as a background-execution operator. Fixed by checking both `bytes[i-1] == '>'` (catches `2>&1`, `>&2`) and `bytes[i+1] == '>'` (catches `&>/dev/null`, `&>>file`) before falling through to the background `&` arm.
- **#347** — `rtk json Cargo.toml` gave a raw serde parse error. Added `validate_json_extension()` helper that rejects TOML/YAML/XML/CSV/INI/env/txt files with a clear message (`not a JSON file (detected TOML). Use rtk read.`), plus a dedicated tip for `Cargo.toml` pointing to `rtk deps`.

## Files changed

| File | Bug | Change |
|------|-----|--------|
| `src/discover/registry.rs` | #345 | RTK_DISABLED check in `rewrite_segment()` after env prefix extraction |
| `src/discover/registry.rs` | #346 | Redirect detection in `rewrite_compound()` single-`&` arm |
| `src/json_cmd.rs` | #347 | `validate_json_extension()` helper + early call in `run()` |
| `hooks/test-rtk-rewrite.sh` | #345, #346 | Section 3b: 7 new hook integration tests |

## Test plan

- [x] 4 unit tests for #345 (`test_rewrite_rtk_disabled_*`)
- [x] 6 unit tests for #346 (`test_rewrite_redirect_*`)
- [x] 6 unit tests for #347 (`test_toml_file_rejected`, `test_cargo_toml_suggests_deps`, etc.)
- [x] 7 hook integration tests (section 3b in `hooks/test-rtk-rewrite.sh`)
- [x] Full quality gate: `cargo fmt --all --check && cargo clippy --all-targets && cargo test` — 672 tests pass, 0 errors

## Manual verification

```bash
rtk rewrite "RTK_DISABLED=1 git status"   # exit 0, no output (no rewrite)
rtk rewrite "cargo test 2>&1 | head"      # → rtk cargo test 2>&1 | head
rtk rewrite "cargo test &>/dev/null"      # → rtk cargo test &>/dev/null
rtk json Cargo.toml                       # → clear error: not a JSON file (detected TOML)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)