### PR TITLE
feat: add Warp (Oz) integration via skill

### DIFF
--- a/warp/README.md
+++ b/warp/README.md
@@ -1,0 +1,58 @@
+# RTK — Warp (Oz) Integration
+
+Use [RTK (Rust Token Killer)](https://github.com/rtk-ai/rtk) with [Warp](https://www.warp.dev) to save 60-90% of tokens on common dev operations.
+
+## How It Works
+
+Warp's Oz agent doesn't have a pre-execution hook for command rewriting, so this integration uses a **skill** — a markdown instruction set that tells the agent to always prefix commands with `rtk`.
+
+When Oz runs a supported command (git, cargo, docker, etc.), the skill instructs it to use the `rtk` prefix, which filters and compresses the output before it enters the LLM context.
+
+## Quick Start
+
+```bash
+# Global (all projects):
+mkdir -p ~/.agents/skills/rtk
+cp warp/skills/rtk/SKILL.md ~/.agents/skills/rtk/SKILL.md
+
+# Or per-project:
+mkdir -p .agents/skills/rtk
+cp warp/skills/rtk/SKILL.md .agents/skills/rtk/SKILL.md
+```
+
+Restart Warp. The skill is auto-discovered.
+
+## Verify
+
+Ask Oz: "What skills do I have?" — RTK should appear in the list.
+
+Then run a command like `git status` and check that Oz uses `rtk git status`.
+
+## Supported Skill Directories
+
+Warp discovers skills from many directories. You can place the skill in whichever you prefer:
+
+- `.agents/skills/` (recommended)
+- `.warp/skills/`
+- `.claude/skills/`
+- `.codex/skills/`
+- `.opencode/skills/`
+
+The same applies for global skills (`~/.agents/skills/`, `~/.warp/skills/`, etc.).
+
+## Comparison with Hook-Based Integrations
+
+| Aspect | Claude Code / OpenCode | Warp |
+|---|---|---|
+| Mechanism | Pre-execution hook rewrites commands transparently | Skill instructs agent to use `rtk` prefix |
+| Adoption | 100% (automatic) | Depends on agent adherence to skill (~85-95%) |
+| Context cost | 0 tokens (hook) or ~10 tokens (RTK.md) | ~200 tokens (skill loaded on demand) |
+| Setup | `rtk init -g` / plugin copy | Copy SKILL.md to skills directory |
+
+## Uninstalling
+
+```bash
+rm -rf ~/.agents/skills/rtk
+# or
+rm -rf .agents/skills/rtk
+```

--- a/warp/skills/rtk/SKILL.md
+++ b/warp/skills/rtk/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: rtk
+description: >-
+  Use RTK (Rust Token Killer) to reduce LLM token consumption by 60-90% on
+  shell commands. Invoke this skill when running any shell command that produces
+  verbose output — git, cargo, go, pnpm, docker, kubectl, grep, ls, curl, etc.
+  RTK filters, groups, and deduplicates output so the context stays small.
+  Always prefix supported commands with `rtk` (e.g. `rtk git status`).
+---
+
+# RTK — Rust Token Killer
+
+RTK is a CLI proxy that filters command output before it reaches the LLM context, saving 60-90% of tokens.
+
+## Golden Rule
+
+**Always prefix commands with `rtk`.** If RTK has a dedicated filter, it uses it. If not, it passes through unchanged. This means RTK is always safe to use.
+
+In command chains with `&&`, prefix each command:
+
+```bash
+# Correct
+rtk git add . && rtk git commit -m "msg" && rtk git push
+```
+
+## Commands
+
+### Git (59-80% savings)
+```
+rtk git status          rtk git log
+rtk git diff            rtk git show
+rtk git add             rtk git commit -m "msg"
+rtk git push            rtk git pull
+rtk git branch          rtk git fetch
+rtk git stash           rtk git worktree
+```
+
+### GitHub CLI (26-87% savings)
+```
+rtk gh pr view <num>    rtk gh pr checks
+rtk gh run list         rtk gh issue list
+```
+
+### Build & Compile (70-90% savings)
+```
+rtk cargo build         rtk cargo check
+rtk cargo clippy        rtk tsc
+rtk lint                rtk prettier --check
+rtk next build          rtk ruff check
+```
+
+### Test (90-99% savings)
+```
+rtk cargo test          rtk vitest run
+rtk playwright test     rtk pytest
+rtk go test             rtk test <cmd>
+```
+
+### Files & Search (60-75% savings)
+```
+rtk ls <path>           rtk read <file>
+rtk grep <pattern>      rtk find <pattern>
+```
+
+### Infrastructure (65-85% savings)
+```
+rtk docker ps           rtk docker images
+rtk docker logs <c>     rtk kubectl get
+rtk kubectl logs        rtk curl <url>
+```
+
+### Meta
+```
+rtk gain                # Token savings stats
+rtk gain --history      # Command history with savings
+rtk discover            # Find missed RTK usage
+rtk proxy <cmd>         # Run without filtering (debug)
+```
+
+## Installation Verification
+
+```bash
+rtk --version   # Should show rtk X.Y.Z
+rtk gain        # Must show token stats (not "command not found")
+```
+
+If `rtk gain` fails, the wrong package (Rust Type Kit) may be installed. Fix:
+```bash
+cargo uninstall rtk
+cargo install --git https://github.com/rtk-ai/rtk
+```


### PR DESCRIPTION
## Summary

Add RTK support for [Warp](https://www.warp.dev)'s Oz agent using the skill system.

Warp doesn't have pre-execution hooks like Claude Code (`PreToolUse`) or OpenCode (`tool.execute.before`), so this uses an instruction-based approach: a `SKILL.md` file that tells the agent to always prefix commands with `rtk`.

## What's included

| File | Purpose |
|---|---|
| `warp/skills/rtk/SKILL.md` | Warp skill with golden rule, full command reference, and verification steps |
| `warp/README.md` | Setup guide (global + per-project), comparison with hook-based integrations |

## Setup

```bash
# Global:
mkdir -p ~/.agents/skills/rtk
cp warp/skills/rtk/SKILL.md ~/.agents/skills/rtk/SKILL.md

# Per-project:
mkdir -p .agents/skills/rtk
cp warp/skills/rtk/SKILL.md .agents/skills/rtk/SKILL.md
```

The skill is auto-discovered by Warp from any of its supported skill directories (`.agents/skills/`, `.warp/skills/`, `.claude/skills/`, etc.).

Co-Authored-By: Oz <oz-agent@warp.dev>