### PR TITLE
feat: add Codex CLI integration via skill

### DIFF
--- a/codex/README.md
+++ b/codex/README.md
@@ -1,0 +1,50 @@
+# RTK — Codex CLI Integration
+
+Use [RTK (Rust Token Killer)](https://github.com/rtk-ai/rtk) with [OpenAI Codex CLI](https://github.com/openai/codex) to save 60-90% of tokens on common dev operations.
+
+## How It Works
+
+Codex CLI doesn't have a pre-execution hook for command rewriting, so this integration uses a **skill** — a markdown instruction set that tells the agent to always prefix commands with `rtk`.
+
+When Codex runs a supported command (git, cargo, docker, etc.), the skill instructs it to use the `rtk` prefix, which filters and compresses the output before it enters the LLM context.
+
+## Quick Start
+
+```bash
+# Global (all projects):
+mkdir -p ~/.codex/skills/rtk
+cp codex/skills/rtk/SKILL.md ~/.codex/skills/rtk/SKILL.md
+
+# Or per-project:
+mkdir -p .codex/skills/rtk
+cp codex/skills/rtk/SKILL.md .codex/skills/rtk/SKILL.md
+```
+
+## Alternative: AGENTS.md
+
+If you prefer to inject RTK instructions directly into your project rules:
+
+```bash
+cat codex/skills/rtk/SKILL.md >> AGENTS.md
+```
+
+## Verify
+
+After setup, run Codex and ask it to execute `git status`. It should use `rtk git status`. Then check savings:
+
+```bash
+rtk gain
+```
+
+## Requirements
+
+- [rtk](https://github.com/rtk-ai/rtk) >= 0.23.0 on your PATH
+- [Codex CLI](https://github.com/openai/codex)
+
+## Uninstalling
+
+```bash
+rm -rf ~/.codex/skills/rtk
+# or
+rm -rf .codex/skills/rtk
+```

--- a/codex/skills/rtk/SKILL.md
+++ b/codex/skills/rtk/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: rtk
+description: >-
+  Use RTK (Rust Token Killer) to reduce LLM token consumption by 60-90% on
+  shell commands. Invoke this skill when running any shell command that produces
+  verbose output — git, cargo, go, pnpm, docker, kubectl, grep, ls, curl, etc.
+  RTK filters, groups, and deduplicates output so the context stays small.
+  Always prefix supported commands with `rtk` (e.g. `rtk git status`).
+---
+
+# RTK — Rust Token Killer
+
+RTK is a CLI proxy that filters command output before it reaches the LLM context, saving 60-90% of tokens.
+
+## Golden Rule
+
+**Always prefix commands with `rtk`.** If RTK has a dedicated filter, it uses it. If not, it passes through unchanged. This means RTK is always safe to use.
+
+In command chains with `&&`, prefix each command:
+
+```bash
+# Correct
+rtk git add . && rtk git commit -m "msg" && rtk git push
+```
+
+## Commands
+
+### Git (59-80% savings)
+```
+rtk git status          rtk git log
+rtk git diff            rtk git show
+rtk git add             rtk git commit -m "msg"
+rtk git push            rtk git pull
+rtk git branch          rtk git fetch
+rtk git stash           rtk git worktree
+```
+
+### GitHub CLI (26-87% savings)
+```
+rtk gh pr view <num>    rtk gh pr checks
+rtk gh run list         rtk gh issue list
+```
+
+### Build & Compile (70-90% savings)
+```
+rtk cargo build         rtk cargo check
+rtk cargo clippy        rtk tsc
+rtk lint                rtk prettier --check
+rtk next build          rtk ruff check
+```
+
+### Test (90-99% savings)
+```
+rtk cargo test          rtk vitest run
+rtk playwright test     rtk pytest
+rtk go test             rtk test <cmd>
+```
+
+### Files & Search (60-75% savings)
+```
+rtk ls <path>           rtk read <file>
+rtk grep <pattern>      rtk find <pattern>
+```
+
+### Infrastructure (65-85% savings)
+```
+rtk docker ps           rtk docker images
+rtk docker logs <c>     rtk kubectl get
+rtk kubectl logs        rtk curl <url>
+```
+
+### Meta
+```
+rtk gain                # Token savings stats
+rtk gain --history      # Command history with savings
+rtk discover            # Find missed RTK usage
+rtk proxy <cmd>         # Run without filtering (debug)
+```
+
+## Installation Verification
+
+```bash
+rtk --version   # Should show rtk X.Y.Z
+rtk gain        # Must show token stats (not "command not found")
+```
+
+If `rtk gain` fails, the wrong package (Rust Type Kit) may be installed. Fix:
+```bash
+cargo uninstall rtk
+cargo install --git https://github.com/rtk-ai/rtk
+```


### PR DESCRIPTION
## Summary

Add RTK support for [OpenAI Codex CLI](https://github.com/openai/codex) using the skill system.

Codex CLI doesn't have pre-execution hooks like Claude Code (`PreToolUse`) or OpenCode (`tool.execute.before`), so this uses an instruction-based approach: a `SKILL.md` file that tells the agent to always prefix commands with `rtk`.

## What's included

| File | Purpose |
|---|---|
| `codex/skills/rtk/SKILL.md` | Skill with golden rule, full command reference, and verification steps |
| `codex/README.md` | Setup guide (global + per-project + AGENTS.md alternative) |

## Setup

```bash
# Global:
mkdir -p ~/.codex/skills/rtk
cp codex/skills/rtk/SKILL.md ~/.codex/skills/rtk/SKILL.md

# Per-project:
mkdir -p .codex/skills/rtk
cp codex/skills/rtk/SKILL.md .codex/skills/rtk/SKILL.md
```

Co-Authored-By: Oz <oz-agent@warp.dev>