### PR TITLE
fix: support git commit -am, --amend and other flags (#327)

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -10,7 +10,7 @@ pub enum GitCommand {
     Status,
     Show,
     Add,
-    Commit { messages: Vec<String> },
+    Commit,
     Push,
     Pull,
     Branch,
@@ -42,7 +42,7 @@ pub fn run(
         GitCommand::Status => run_status(args, verbose, global_args),
         GitCommand::Show => run_show(args, max_lines, verbose, global_args),
         GitCommand::Add => run_add(args, verbose, global_args),
-        GitCommand::Commit { messages } => run_commit(&messages, verbose, global_args),
+        GitCommand::Commit => run_commit(args, verbose, global_args),
         GitCommand::Push => run_push(args, verbose, global_args),
         GitCommand::Pull => run_pull(args, verbose, global_args),
         GitCommand::Branch => run_branch(args, verbose, global_args),
@@ -703,30 +703,25 @@ fn run_add(args: &[String], verbose: u8, global_args: &[String]) -> Result<()> {
     Ok(())
 }
 
-fn build_commit_command(messages: &[String], global_args: &[String]) -> Command {
+fn build_commit_command(args: &[String], global_args: &[String]) -> Command {
     let mut cmd = git_cmd(global_args);
     cmd.arg("commit");
-    for msg in messages {
-        cmd.args(["-m", msg]);
+    for arg in args {
+        cmd.arg(arg);
     }
     cmd
 }
 
-fn run_commit(messages: &[String], verbose: u8, global_args: &[String]) -> Result<()> {
+fn run_commit(args: &[String], verbose: u8, global_args: &[String]) -> Result<()> {
     let timer = tracking::TimedExecution::start();
 
-    let original_cmd = messages
-        .iter()
-        .map(|m| format!("-m \"{}\"", m))
-        .collect::<Vec<_>>()
-        .join(" ");
-    let original_cmd = format!("git commit {}", original_cmd);
+    let original_cmd = format!("git commit {}", args.join(" "));
 
     if verbose > 0 {
         eprintln!("{}", original_cmd);
     }
 
-    let output = build_commit_command(messages, global_args)
+    let output = build_commit_command(args, global_args)
         .output()
         .context("Failed to run git commit")?;
 
@@ -1721,28 +1716,30 @@ no changes added to commit (use "git add" and/or "git commit -a")
 
     #[test]
     fn test_commit_single_message() {
-        let messages = vec!["fix: typo".to_string()];
-        let cmd = build_commit_command(&messages, &[]);
-        let args: Vec<_> = cmd
+        let args = vec!["-m".to_string(), "fix: typo".to_string()];
+        let cmd = build_commit_command(&args, &[]);
+        let cmd_args: Vec<_> = cmd
             .get_args()
             .map(|a| a.to_string_lossy().to_string())
             .collect();
-        assert_eq!(args, vec!["commit", "-m", "fix: typo"]);
+        assert_eq!(cmd_args, vec!["commit", "-m", "fix: typo"]);
     }
 
     #[test]
     fn test_commit_multiple_messages() {
-        let messages = vec![
+        let args = vec![
+            "-m".to_string(),
             "feat: add multi-paragraph support".to_string(),
+            "-m".to_string(),
             "This allows git commit -m \"title\" -m \"body\".".to_string(),
         ];
-        let cmd = build_commit_command(&messages, &[]);
-        let args: Vec<_> = cmd
+        let cmd = build_commit_command(&args, &[]);
+        let cmd_args: Vec<_> = cmd
             .get_args()
             .map(|a| a.to_string_lossy().to_string())
             .collect();
         assert_eq!(
-            args,
+            cmd_args,
             vec![
                 "commit",
                 "-m",
@@ -1753,29 +1750,30 @@ no changes added to commit (use "git add" and/or "git commit -a")
         );
     }
 
+    // #327: git commit -am "msg" must pass -am through to git
     #[test]
-    fn test_commit_three_messages() {
-        let messages = vec![
-            "title".to_string(),
-            "body".to_string(),
-            "footer: refs #202".to_string(),
-        ];
-        let cmd = build_commit_command(&messages, &[]);
-        let args: Vec<_> = cmd
+    fn test_commit_am_flag() {
+        let args = vec!["-am".to_string(), "quick fix".to_string()];
+        let cmd = build_commit_command(&args, &[]);
+        let cmd_args: Vec<_> = cmd
             .get_args()
             .map(|a| a.to_string_lossy().to_string())
             .collect();
-        assert_eq!(
-            args,
-            vec![
-                "commit",
-                "-m",
-                "title",
-                "-m",
-                "body",
-                "-m",
-                "footer: refs #202"
-            ]
-        );
+        assert_eq!(cmd_args, vec!["commit", "-am", "quick fix"]);
+    }
+
+    #[test]
+    fn test_commit_amend() {
+        let args = vec![
+            "--amend".to_string(),
+            "-m".to_string(),
+            "new msg".to_string(),
+        ];
+        let cmd = build_commit_command(&args, &[]);
+        let cmd_args: Vec<_> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        assert_eq!(cmd_args, vec!["commit", "--amend", "-m", "new msg"]);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -649,9 +649,9 @@ enum GitCommands {
     },
     /// Commit → "ok ✓ \<hash\>"
     Commit {
-        /// Commit message (can be repeated for multi-paragraph)
-        #[arg(short, long)]
-        message: Vec<String>,
+        /// Git commit arguments (supports -a, -m, --amend, --allow-empty, etc)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
     },
     /// Push → "ok ✓ \<branch\>"
     Push {
@@ -1121,10 +1121,10 @@ fn main() -> Result<()> {
                 GitCommands::Add { args } => {
                     git::run(git::GitCommand::Add, &args, None, cli.verbose, &global_args)?;
                 }
-                GitCommands::Commit { message } => {
+                GitCommands::Commit { args } => {
                     git::run(
-                        git::GitCommand::Commit { messages: message },
-                        &[],
+                        git::GitCommand::Commit,
+                        &args,
                         None,
                         cli.verbose,
                         &global_args,
@@ -1817,10 +1817,10 @@ mod tests {
         let cli = Cli::try_parse_from(["rtk", "git", "commit", "-m", "fix: typo"]).unwrap();
         match cli.command {
             Commands::Git {
-                command: GitCommands::Commit { message },
+                command: GitCommands::Commit { args },
                 ..
             } => {
-                assert_eq!(message, vec!["fix: typo"]);
+                assert_eq!(args, vec!["-m", "fix: typo"]);
             }
             _ => panic!("Expected Git Commit command"),
         }
@@ -1840,10 +1840,43 @@ mod tests {
         .unwrap();
         match cli.command {
             Commands::Git {
-                command: GitCommands::Commit { message },
+                command: GitCommands::Commit { args },
                 ..
             } => {
-                assert_eq!(message, vec!["feat: add support", "Body paragraph here."]);
+                assert_eq!(
+                    args,
+                    vec!["-m", "feat: add support", "-m", "Body paragraph here."]
+                );
+            }
+            _ => panic!("Expected Git Commit command"),
+        }
+    }
+
+    // #327: git commit -am "msg" was rejected by Clap
+    #[test]
+    fn test_git_commit_am_flag() {
+        let cli = Cli::try_parse_from(["rtk", "git", "commit", "-am", "quick fix"]).unwrap();
+        match cli.command {
+            Commands::Git {
+                command: GitCommands::Commit { args },
+                ..
+            } => {
+                assert_eq!(args, vec!["-am", "quick fix"]);
+            }
+            _ => panic!("Expected Git Commit command"),
+        }
+    }
+
+    #[test]
+    fn test_git_commit_amend() {
+        let cli =
+            Cli::try_parse_from(["rtk", "git", "commit", "--amend", "-m", "new msg"]).unwrap();
+        match cli.command {
+            Commands::Git {
+                command: GitCommands::Commit { args },
+                ..
+            } => {
+                assert_eq!(args, vec!["--amend", "-m", "new msg"]);
             }
             _ => panic!("Expected Git Commit command"),
         }
@@ -1887,10 +1920,20 @@ mod tests {
         .unwrap();
         match cli.command {
             Commands::Git {
-                command: GitCommands::Commit { message },
+                command: GitCommands::Commit { args },
                 ..
             } => {
-                assert_eq!(message, vec!["title", "body", "footer"]);
+                assert_eq!(
+                    args,
+                    vec![
+                        "--message",
+                        "title",
+                        "--message",
+                        "body",
+                        "--message",
+                        "footer"
+                    ]
+                );
             }
             _ => panic!("Expected Git Commit command"),
         }


### PR DESCRIPTION
## Summary

- `rtk git commit -am "msg"` crashed with `error: unexpected argument '-a' found`
- Root cause: Clap only declared `-m/--message`, rejecting all other git commit flags
- Fix: switch to `trailing_var_arg + allow_hyphen_values` (same pattern as Add, Push, Pull)

## What changed

- `GitCommands::Commit` now takes raw `args: Vec<String>` instead of `message: Vec<String>`
- `build_commit_command` passes args directly to git instead of wrapping with `-m`
- All git commit flags now work: `-a`, `-am`, `--amend`, `--allow-empty`, `--no-edit`, etc.

## Tests

- 4 new tests: `-am`, `--amend`, single message, multiple messages (updated)
- 644 tests pass, 0 failures
- Manual verification: `-am`, `-m`, `--amend --no-edit` all produce correct output

Fixes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)