### PR TITLE
fix: only rewrite docker compose ps/logs/build, skip unsupported (#336)

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1261,6 +1261,50 @@ mod tests {
         );
     }
 
+    // --- #336: docker compose supported subcommands rewritten, unsupported skipped ---
+
+    #[test]
+    fn test_rewrite_docker_compose_ps() {
+        assert_eq!(
+            rewrite_command("docker compose ps", &[]),
+            Some("rtk docker compose ps".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_docker_compose_logs() {
+        assert_eq!(
+            rewrite_command("docker compose logs web", &[]),
+            Some("rtk docker compose logs web".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_docker_compose_build() {
+        assert_eq!(
+            rewrite_command("docker compose build", &[]),
+            Some("rtk docker compose build".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_docker_compose_up_skipped() {
+        assert_eq!(rewrite_command("docker compose up -d", &[]), None);
+    }
+
+    #[test]
+    fn test_rewrite_docker_compose_down_skipped() {
+        assert_eq!(rewrite_command("docker compose down", &[]), None);
+    }
+
+    #[test]
+    fn test_rewrite_docker_compose_config_skipped() {
+        assert_eq!(
+            rewrite_command("docker compose -f foo.yaml config --services", &[]),
+            None
+        );
+    }
+
     // --- AWS / psql (PR #216) ---
 
     #[test]
@@ -1779,10 +1823,7 @@ mod tests {
 
     #[test]
     fn test_rewrite_gh_json_skipped() {
-        assert_eq!(
-            rewrite_command("gh pr list --json number,title", &[]),
-            None
-        );
+        assert_eq!(rewrite_command("gh pr list --json number,title", &[]), None);
     }
 
     #[test]

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -30,7 +30,7 @@ pub const PATTERNS: &[&str] = &[
     r"^(pnpm\s+|npx\s+)?(vitest|jest|test)(\s|$)",
     r"^(npx\s+|pnpm\s+)?playwright",
     r"^(npx\s+|pnpm\s+)?prisma",
-    r"^docker\s+(ps|images|logs|run|exec|build)",
+    r"^docker\s+(ps|images|logs|run|exec|build|compose\s+(ps|logs|build))",
     r"^kubectl\s+(get|logs|describe|apply)",
     r"^tree(\s|$)",
     r"^diff\s+",


### PR DESCRIPTION
## Summary

The rewrite hook was not handling `docker compose` subcommands correctly:
- Supported subcommands (`ps`, `logs`, `build`) were **not** rewritten because the regex only matched `docker ps|images|logs|...` without `compose`
- Unsupported subcommands (`up`, `down`, `config`, `exec`, etc.) were already correctly skipped

**Fix:** Extend the regex pattern to also match `docker compose (ps|logs|build)`.

## Before / After

| Command | Before | After |
|---|---|---|
| `docker compose ps` | not rewritten | `rtk docker compose ps` ✅ |
| `docker compose logs web` | not rewritten | `rtk docker compose logs web` ✅ |
| `docker compose build` | not rewritten | `rtk docker compose build` ✅ |
| `docker compose up -d` | not rewritten | not rewritten ✅ |
| `docker compose down` | not rewritten | not rewritten ✅ |
| `docker ps` | `rtk docker ps` | `rtk docker ps` ✅ (unchanged) |

## Changes

- `src/discover/rules.rs`: Extend regex to cover `docker compose (ps|logs|build)`
- `src/discover/registry.rs`: 6 new tests for supported and unsupported compose subcommands

## Test plan

- [x] `cargo test` — 652 passed, 0 failed
- [x] Manual: `rtk docker compose ps` with real Docker Compose services — works
- [x] Manual: `rtk docker compose logs` — deduplicated output
- [x] Manual: `docker compose up/down` — not rewritten, runs normally

Fixes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)