### PR TITLE
feat: add worktree slash commands for isolated Rust development

### DIFF
--- a/.claude/commands/clean-worktree.md
+++ b/.claude/commands/clean-worktree.md
@@ -1,0 +1,105 @@
+---
+model: haiku
+description: Interactive cleanup of stale worktrees (merged branches, orphaned refs)
+---
+
+# Clean Worktree (Interactive)
+
+Interactive cleanup of worktrees: lists merged/stale branches and asks confirmation before deleting.
+
+**Difference with `/clean-worktrees`**:
+- `/clean-worktree`: Interactive, asks confirmation
+- `/clean-worktrees`: Automatic, no interaction
+
+## Usage
+
+```bash
+/clean-worktree    # Interactive audit + cleanup
+```
+
+## Implementation
+
+Execute this script:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+echo "=== Worktrees Status ==="
+git worktree list
+echo ""
+
+echo "=== Pruning stale references ==="
+git worktree prune
+echo ""
+
+echo "=== Merged branches (safe to delete) ==="
+MERGED_FOUND=false
+CURRENT_DIR="$(pwd)"
+
+while IFS= read -r line; do
+  path=$(echo "$line" | awk '{print $1}')
+  branch=$(echo "$line" | grep -oE '\[.*\]' | tr -d '[]' || true)
+  [ -z "$branch" ] && continue
+  [ "$branch" = "master" ] && continue
+  [ "$branch" = "main" ] && continue
+  [ "$path" = "$CURRENT_DIR" ] && continue
+
+  if git branch --merged master | grep -q "^[* ] ${branch}$" 2>/dev/null; then
+    echo "  - $branch (at $path) - MERGED"
+    MERGED_FOUND=true
+  fi
+done < <(git worktree list)
+
+if [ "$MERGED_FOUND" = false ]; then
+  echo "  (none found)"
+  echo ""
+  echo "=== Disk usage ==="
+  du -sh .worktrees/ 2>/dev/null || echo "No .worktrees directory"
+  exit 0
+fi
+echo ""
+
+echo "=== Clean merged worktrees? [y/N] ==="
+read -r confirm
+if [ "$confirm" = "y" ] || [ "$confirm" = "Y" ]; then
+  while IFS= read -r line; do
+    path=$(echo "$line" | awk '{print $1}')
+    branch=$(echo "$line" | grep -oE '\[.*\]' | tr -d '[]' || true)
+    [ -z "$branch" ] && continue
+    [ "$branch" = "master" ] && continue
+    [ "$branch" = "main" ] && continue
+    [ "$path" = "$CURRENT_DIR" ] && continue
+
+    if git branch --merged master | grep -q "^[* ] ${branch}$" 2>/dev/null; then
+      echo "  Removing $branch..."
+      git worktree remove "$path" 2>/dev/null || rm -rf "$path"
+      git branch -d "$branch" 2>/dev/null || echo "    (branch already deleted)"
+      echo "  Done: $branch"
+    fi
+  done < <(git worktree list)
+  echo ""
+  echo "Cleanup complete."
+else
+  echo "Aborted."
+fi
+
+echo ""
+echo "=== Disk usage ==="
+du -sh .worktrees/ 2>/dev/null || echo "No .worktrees directory"
+```
+
+## Safety
+
+- Never removes `master` or `main` worktrees
+- Only removes branches merged into `master`
+- Asks confirmation before any deletion
+- Cleans both git reference and physical directory
+
+## Manual Force Remove (unmerged branch)
+
+```bash
+git worktree remove --force .worktrees/feature-name
+git branch -D feature/name
+git worktree prune
+```

--- a/.claude/commands/clean-worktrees.md
+++ b/.claude/commands/clean-worktrees.md
@@ -1,0 +1,165 @@
+---
+model: haiku
+description: Clean all merged worktrees automatically (no interaction)
+---
+
+# Clean Worktrees (Automatic)
+
+Automatically remove all worktrees for branches merged into `master`. No interaction required.
+
+**Difference with `/clean-worktree`**:
+- `/clean-worktree`: Interactive, asks confirmation per branch
+- `/clean-worktrees`: Automatic, removes all merged branches at once
+
+## Usage
+
+```bash
+/clean-worktrees              # Remove all merged worktrees
+/clean-worktrees --dry-run    # Preview what would be deleted
+```
+
+## Implementation
+
+Execute this script:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+DRY_RUN=false
+if [[ "${ARGUMENTS:-}" == *"--dry-run"* ]]; then
+  DRY_RUN=true
+fi
+
+echo "Cleaning Worktrees"
+echo "=================="
+echo ""
+
+# Step 1: Prune stale git references
+echo "1. Pruning stale git references..."
+PRUNED=$(git worktree prune -v 2>&1)
+if [ -n "$PRUNED" ]; then
+  echo "$PRUNED"
+  echo "Stale references pruned"
+else
+  echo "No stale references found"
+fi
+echo ""
+
+# Step 2: Find merged worktrees
+echo "2. Finding merged worktrees..."
+MERGED_COUNT=0
+MERGED_BRANCHES=()
+CURRENT_DIR="$(pwd)"
+
+while IFS= read -r line; do
+  path=$(echo "$line" | awk '{print $1}')
+  branch=$(echo "$line" | grep -oE '\[.*\]' | tr -d '[]' || true)
+
+  [ -z "$branch" ] && continue
+  [ "$branch" = "master" ] && continue
+  [ "$branch" = "main" ] && continue
+  [ "$path" = "$CURRENT_DIR" ] && continue
+
+  if git branch --merged master | grep -q "^[* ] ${branch}$" 2>/dev/null; then
+    MERGED_COUNT=$((MERGED_COUNT + 1))
+    MERGED_BRANCHES+=("$branch|$path")
+    echo "  - $branch (merged)"
+  fi
+done < <(git worktree list)
+
+if [ $MERGED_COUNT -eq 0 ]; then
+  echo "No merged worktrees found"
+  echo ""
+  echo "Current worktrees:"
+  git worktree list
+  exit 0
+fi
+
+echo ""
+echo "Found $MERGED_COUNT merged worktree(s)"
+echo ""
+
+if [ "$DRY_RUN" = true ]; then
+  echo "DRY RUN - No changes will be made"
+  echo ""
+  echo "Would delete:"
+  for item in "${MERGED_BRANCHES[@]}"; do
+    branch=$(echo "$item" | cut -d'|' -f1)
+    path=$(echo "$item" | cut -d'|' -f2)
+    echo "  - $branch"
+    echo "    Path: $path"
+  done
+  echo ""
+  echo "Run without --dry-run to actually delete"
+  exit 0
+fi
+
+# Step 3: Remove merged worktrees
+echo "3. Removing merged worktrees..."
+REMOVED_COUNT=0
+
+for item in "${MERGED_BRANCHES[@]}"; do
+  branch=$(echo "$item" | cut -d'|' -f1)
+  path=$(echo "$item" | cut -d'|' -f2)
+
+  echo ""
+  echo "Removing: $branch"
+
+  if git worktree remove "$path" 2>/dev/null; then
+    echo "  Worktree removed"
+  else
+    echo "  Git remove failed, forcing..."
+    rm -rf "$path" 2>/dev/null || true
+    git worktree prune 2>/dev/null || true
+    echo "  Worktree forcefully removed"
+  fi
+
+  if git branch -d "$branch" 2>/dev/null; then
+    echo "  Local branch deleted"
+  else
+    echo "  Local branch already deleted"
+  fi
+
+  if git ls-remote --heads origin "$branch" 2>/dev/null | grep -q "$branch"; then
+    echo "  Remote branch exists: origin/$branch (not auto-deleted)"
+  fi
+
+  REMOVED_COUNT=$((REMOVED_COUNT + 1))
+done
+
+echo ""
+echo "Cleanup complete"
+echo ""
+echo "Summary:"
+echo "  Removed: $REMOVED_COUNT worktree(s)"
+echo ""
+echo "Remaining worktrees:"
+git worktree list
+echo ""
+
+WORKTREES_SIZE=$(du -sh .worktrees/ 2>/dev/null | awk '{print $1}' || echo "N/A")
+echo "Worktrees disk usage: $WORKTREES_SIZE"
+```
+
+## Safety Features
+
+- Only removes branches merged into `master`
+- Skips `master` and `main` (protected)
+- Never removes the current working directory
+- Dry-run mode to preview before deletion
+- Remote branches: reported but not auto-deleted
+
+## When to Use
+
+- After merging PRs: `/clean-worktrees`
+- Weekly maintenance: `/clean-worktrees`
+- Before creating new worktrees: `/clean-worktrees --dry-run` first
+
+## Manual Removal (unmerged branch)
+
+```bash
+git worktree remove --force .worktrees/feature-name
+git branch -D feature/name
+git worktree prune
+```

--- a/.claude/commands/worktree-status.md
+++ b/.claude/commands/worktree-status.md
@@ -1,0 +1,128 @@
+---
+model: haiku
+description: Check background cargo check status for a git worktree
+---
+
+# Worktree Status Check
+
+Check the status of the background `cargo check` started by `/worktree`.
+
+## Usage
+
+```bash
+/worktree-status feature/new-filter
+/worktree-status fix/bug-name
+```
+
+## Implementation
+
+Execute this script with branch name from `$ARGUMENTS`:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+BRANCH_NAME="$ARGUMENTS"
+LOG_FILE="/tmp/worktree-cargocheck-${BRANCH_NAME//\//-}.log"
+
+if [ ! -f "$LOG_FILE" ]; then
+  echo "No cargo check found for branch: $BRANCH_NAME"
+  echo ""
+  echo "Possible reasons:"
+  echo "1. Worktree created with --fast (check skipped)"
+  echo "2. Branch name mismatch (use exact branch name)"
+  echo "3. Check hasn't started yet (wait a few seconds)"
+  echo ""
+  echo "Available logs:"
+  ls -1 /tmp/worktree-cargocheck-*.log 2>/dev/null || echo "  (none)"
+  exit 1
+fi
+
+LOG_CONTENT=$(head -n 500 "$LOG_FILE")
+
+if echo "$LOG_CONTENT" | grep -q "^PASSED"; then
+  TIMESTAMP=$(echo "$LOG_CONTENT" | grep "^PASSED" | sed 's/PASSED at //')
+  echo "cargo check passed"
+  echo "   Completed at: $TIMESTAMP"
+  echo ""
+  echo "Worktree is ready for development!"
+
+elif echo "$LOG_CONTENT" | grep -q "^FAILED"; then
+  TIMESTAMP=$(echo "$LOG_CONTENT" | grep "^FAILED" | sed 's/FAILED at //')
+  echo "cargo check failed"
+  echo "   Completed at: $TIMESTAMP"
+  echo ""
+  echo "Errors:"
+  echo "-------------------------------------"
+  grep -v "^PASSED\|^FAILED\|^cargo check started" "$LOG_FILE" | head -30
+  echo "-------------------------------------"
+  echo ""
+  echo "Full log: cat $LOG_FILE"
+  echo ""
+  echo "You can still work on the worktree - fix errors as you go."
+
+elif echo "$LOG_CONTENT" | grep -q "^cargo check started"; then
+  START_TIME=$(echo "$LOG_CONTENT" | grep "^cargo check started" | sed 's/cargo check started at //')
+  CURRENT_TIME=$(date +%H:%M:%S)
+  echo "cargo check still running..."
+  echo "   Started at: $START_TIME"
+  echo "   Current time: $CURRENT_TIME"
+  echo ""
+  echo "Usually takes 5-30s depending on crate size."
+  echo ""
+  echo "Live progress: tail -f $LOG_FILE"
+
+else
+  echo "Unknown state"
+  echo ""
+  echo "Log content:"
+  cat "$LOG_FILE"
+fi
+```
+
+## Output Examples
+
+### Passed
+```
+cargo check passed
+   Completed at: 14:23:45
+
+Worktree is ready for development!
+```
+
+### Failed
+```
+cargo check failed
+   Completed at: 14:24:12
+
+Errors:
+-------------------------------------
+error[E0308]: mismatched types
+  --> src/git.rs:45:12
+   |
+45 |     let x: i32 = "hello";
+-------------------------------------
+
+Full log: cat /tmp/worktree-cargocheck-feature-new-filter.log
+
+You can still work on the worktree - fix errors as you go.
+```
+
+### Still Running
+```
+cargo check still running...
+   Started at: 14:22:30
+   Current time: 14:22:45
+
+Usually takes 5-30s depending on crate size.
+
+Live progress: tail -f /tmp/worktree-cargocheck-feature-new-filter.log
+```
+
+## Integration
+
+`/worktree` tells you the exact command to check status:
+```
+cargo check running in background...
+Check status: /worktree-status feature/new-filter
+```

--- a/.claude/commands/worktree.md
+++ b/.claude/commands/worktree.md
@@ -1,0 +1,210 @@
+---
+model: haiku
+description: Git Worktree Setup for RTK (Rust project)
+---
+
+# Git Worktree Setup
+
+Create isolated git worktrees with instant feedback and background Rust verification.
+
+**Performance**: ~1s setup + background `cargo check` (non-blocking)
+
+## Usage
+
+```bash
+/worktree feature/new-filter       # Creates worktree + background cargo check
+/worktree fix/typo --fast          # Skip cargo check (instant)
+/worktree feature/big-refactor --check  # Wait for cargo check (blocking)
+```
+
+**Branch naming**: Always use `category/description` with a slash.
+
+- `feature/new-filter` -> branch: `feature/new-filter`, dir: `.worktrees/feature-new-filter`
+- `fix/bug-name` -> branch: `fix/bug-name`, dir: `.worktrees/fix-bug-name`
+
+## Implementation
+
+Execute this **single bash script** with branch name from `$ARGUMENTS`:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
+
+# Resolve main repo root (works from worktree too)
+GIT_COMMON_DIR="$(git rev-parse --git-common-dir 2>/dev/null)"
+if [ -z "$GIT_COMMON_DIR" ]; then
+  echo "Not in a git repository"
+  exit 1
+fi
+REPO_ROOT="$(cd "$GIT_COMMON_DIR/.." && pwd)"
+
+# Parse flags
+RAW_ARGS="$ARGUMENTS"
+BRANCH_NAME="$RAW_ARGS"
+SKIP_CHECK=false
+BLOCKING_CHECK=false
+
+if [[ "$RAW_ARGS" == *"--fast"* ]]; then
+  SKIP_CHECK=true
+  BRANCH_NAME="${BRANCH_NAME// --fast/}"
+fi
+if [[ "$RAW_ARGS" == *"--check"* ]]; then
+  BLOCKING_CHECK=true
+  BRANCH_NAME="${BRANCH_NAME// --check/}"
+fi
+
+# Validate branch name
+if [[ "$BRANCH_NAME" =~ [[:space:]\$\`] ]]; then
+  echo "Invalid branch name (spaces or special characters not allowed)"
+  exit 1
+fi
+if [[ "$BRANCH_NAME" =~ [~^:?*\\\[\]] ]]; then
+  echo "Invalid branch name (git forbidden characters)"
+  exit 1
+fi
+
+# Paths
+WORKTREE_NAME="${BRANCH_NAME//\//-}"
+WORKTREE_DIR="$REPO_ROOT/.worktrees/$WORKTREE_NAME"
+LOG_FILE="/tmp/worktree-cargocheck-${WORKTREE_NAME}.log"
+
+# 1. Check .gitignore (fail-fast)
+if ! grep -qE "^\.worktrees/?$" "$REPO_ROOT/.gitignore" 2>/dev/null; then
+  echo ".worktrees/ not in .gitignore"
+  echo "Run: echo '.worktrees/' >> .gitignore && git add .gitignore && git commit -m 'chore: ignore worktrees'"
+  exit 1
+fi
+
+# 2. Create worktree
+echo "Creating worktree for $BRANCH_NAME..."
+mkdir -p "$REPO_ROOT/.worktrees"
+if ! git worktree add "$WORKTREE_DIR" -b "$BRANCH_NAME" 2>/tmp/worktree-error.log; then
+  echo "Failed to create worktree:"
+  cat /tmp/worktree-error.log
+  exit 1
+fi
+
+# 3. Copy files listed in .worktreeinclude (non-blocking)
+(
+  INCLUDE_FILE="$REPO_ROOT/.worktreeinclude"
+  if [ -f "$INCLUDE_FILE" ]; then
+    while IFS= read -r entry || [ -n "$entry" ]; do
+      [[ "$entry" =~ ^#.*$ || -z "$entry" ]] && continue
+      entry="$(echo "$entry" | xargs)"
+      SRC="$REPO_ROOT/$entry"
+      if [ -e "$SRC" ]; then
+        DEST_DIR="$(dirname "$WORKTREE_DIR/$entry")"
+        mkdir -p "$DEST_DIR"
+        cp -R "$SRC" "$WORKTREE_DIR/$entry"
+      fi
+    done < "$INCLUDE_FILE"
+  else
+    cp "$REPO_ROOT"/.env* "$WORKTREE_DIR/" 2>/dev/null || true
+  fi
+) &
+ENV_PID=$!
+
+# Wait for env copy (with macOS-compatible timeout)
+# gtimeout from coreutils if available, else plain wait
+if command -v gtimeout >/dev/null 2>&1; then
+  gtimeout 10 wait $ENV_PID 2>/dev/null || true
+else
+  wait $ENV_PID 2>/dev/null || true
+fi
+
+# 4. cargo check (background by default, blocking with --check)
+if [ "$SKIP_CHECK" = false ]; then
+  if [ "$BLOCKING_CHECK" = true ]; then
+    echo "Running cargo check..."
+    if (cd "$WORKTREE_DIR" && cargo check 2>&1); then
+      echo "cargo check passed"
+    else
+      echo "cargo check failed (worktree still usable)"
+    fi
+    CHECK_RUNNING=false
+  else
+    # Background
+    (
+      cd "$WORKTREE_DIR"
+      echo "cargo check started at $(date +%H:%M:%S)" > "$LOG_FILE"
+      if cargo check >> "$LOG_FILE" 2>&1; then
+        echo "PASSED at $(date +%H:%M:%S)" >> "$LOG_FILE"
+      else
+        echo "FAILED at $(date +%H:%M:%S)" >> "$LOG_FILE"
+      fi
+    ) &
+    CHECK_RUNNING=true
+  fi
+else
+  CHECK_RUNNING=false
+fi
+
+# 5. Report
+echo ""
+echo "Worktree ready: $WORKTREE_DIR"
+echo "Branch: $BRANCH_NAME"
+
+if [ "$CHECK_RUNNING" = true ]; then
+  echo "cargo check running in background..."
+  echo "Check status: /worktree-status $BRANCH_NAME"
+  echo "Or view log: cat $LOG_FILE"
+elif [ "$SKIP_CHECK" = true ]; then
+  echo "cargo check skipped (--fast)"
+fi
+
+echo ""
+echo "Next steps:"
+echo ""
+echo "If Claude Code is running:"
+echo "   1. /exit"
+echo "   2. cd $WORKTREE_DIR"
+echo "   3. claude"
+echo ""
+echo "If Claude Code is NOT running:"
+echo "   cd $WORKTREE_DIR && claude"
+```
+
+## Flags
+
+### `--fast`
+Skip `cargo check` (instant setup). Use for quick fixes, docs, small changes.
+
+### `--check`
+Run `cargo check` synchronously (blocking). Use when you need to confirm the build is clean before starting.
+
+## Environment Files
+
+Files listed in `.worktreeinclude` are copied automatically. If the file doesn't exist, `.env*` files are copied by default.
+
+Example `.worktreeinclude` for RTK:
+```
+.env
+.env.local
+.claude/settings.local.json
+```
+
+## Cleanup
+
+```bash
+git worktree remove .worktrees/${BRANCH_NAME//\//-}
+git worktree prune
+```
+
+## Troubleshooting
+
+**"worktree already exists"**
+```bash
+git worktree remove .worktrees/feature-name
+```
+
+**"branch already exists"**
+```bash
+git branch -D feature/name
+```
+
+**cargo check log not found**
+```bash
+ls /tmp/worktree-cargocheck-*.log
+```

--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,5 @@ claudedocs
 .vitals/
 .worktrees/
 
-# icm 
+# icm
 .fastembed_cache/


### PR DESCRIPTION
## Summary

Ports 4 worktree management slash commands from MethodeAristote project, adapted for RTK (Rust/cargo instead of pnpm/TypeScript).

**New commands:**

| Command | Description |
|---------|-------------|
| `/worktree <branch>` | Create isolated worktree + background `cargo check` |
| `/worktree-status <branch>` | Check background `cargo check` result |
| `/clean-worktrees` | Auto-remove all merged worktrees (no interaction) |
| `/clean-worktree` | Interactive cleanup with confirmation |

**Key adaptations from source project:**
- `pnpm tsc --noEmit` → `cargo check` (background by default)
- No node_modules symlink step (Rust doesn't need it)
- `develop` branch → `master` branch for merge detection
- macOS-compatible: no `timeout` (uses `gtimeout` fallback)
- Flags: `--fast` (skip check) and `--check` (blocking check)

**Also fixes:** version refs in README, CLAUDE.md, ARCHITECTURE.md (0.26.0 → 0.27.0) — pre-push hook was blocking any push on master.

## Test plan

- [ ] `/worktree feature/test-cmd` — creates `.worktrees/feature-test-cmd`, starts `cargo check` in background
- [ ] `/worktree-status feature/test-cmd` — shows check result
- [ ] `/worktree feature/test-fast --fast` — instant, no cargo check
- [ ] `/clean-worktrees --dry-run` — preview mode, no deletions
- [ ] `/clean-worktree` — interactive, confirms before deleting

🤖 Generated with [Claude Code](https://claude.com/claude-code)