### PR TITLE
docs: fix Linux binary filename in README (gnu → musl)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ cargo install rtk
 
 Download from [rtk-ai/releases](https://github.com/rtk-ai/rtk/releases):
 - macOS: `rtk-x86_64-apple-darwin.tar.gz` / `rtk-aarch64-apple-darwin.tar.gz`
-- Linux: `rtk-x86_64-unknown-linux-gnu.tar.gz` / `rtk-aarch64-unknown-linux-gnu.tar.gz`
+- Linux: `rtk-x86_64-unknown-linux-musl.tar.gz` / `rtk-aarch64-unknown-linux-gnu.tar.gz`
 - Windows: `rtk-x86_64-pc-windows-msvc.zip`
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- README referenced `rtk-x86_64-unknown-linux-gnu.tar.gz` which no longer exists since PR #267 (v0.23.0)
- Updated to `rtk-x86_64-unknown-linux-musl.tar.gz` which is the actual release artifact

Fixes #323