### PR TITLE
fix: reduce gh diff / git diff / gh api truncation (#354)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1488,4 +1488,4 @@ When implementing a new command, consider:
 
 **Last Updated**: 2026-02-22
 **Architecture Version**: 2.2
-**rtk Version**: 0.26.0
+**rtk Version**: 0.27.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This is a fork with critical fixes for git argument parsing and modern JavaScrip
 
 **Verify correct installation:**
 ```bash
-rtk --version  # Should show "rtk 0.26.0" (or newer)
+rtk --version  # Should show "rtk 0.27.1" (or newer)
 rtk gain       # Should show token savings stats (NOT "command not found")
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Download from [releases](https://github.com/rtk-ai/rtk/releases):
 ### Verify Installation
 
 ```bash
-rtk --version   # Should show "rtk 0.27.x"
+rtk --version   # Should show "rtk 0.27.1"
 rtk gain        # Should show token savings stats
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ rtk filters and compresses command outputs before they reach your LLM context, s
 
 **How to verify you have the correct rtk:**
 ```bash
-rtk --version   # Should show "rtk 0.26.0"
+rtk --version   # Should show "rtk 0.27.1"
 rtk gain        # Should show token savings stats
 ```
 

--- a/src/gh_cmd.rs
+++ b/src/gh_cmd.rs
@@ -289,11 +289,10 @@ fn view_pr(args: &[String], _verbose: u8, ultra_compact: bool) -> Result<()> {
         None => return Err(anyhow::anyhow!("PR number required")),
     };
 
-    // If the user provides --json, --jq, or --web, pass through directly.
-    // Our filter forces its own --json fields and would ignore user-requested fields.
-    let extra_args = &args[1..];
-    if should_passthrough_pr_view(extra_args) {
-        return run_passthrough_with_extra("gh", &["pr", "view", pr_number.as_str()], extra_args);
+    // If the user provides --jq or --web, pass through directly.
+    // Note: --json is already handled globally by run() via has_json_flag.
+    if should_passthrough_pr_view(&extra_args) {
+        return run_passthrough_with_extra("gh", &["pr", "view", &pr_number], &extra_args);
     }
 
     let mut cmd = Command::new("gh");

--- a/src/gh_cmd.rs
+++ b/src/gh_cmd.rs
@@ -4,7 +4,6 @@
 //! Focuses on extracting essential information from JSON outputs.
 
 use crate::git;
-use crate::json_cmd;
 use crate::tracking;
 use crate::utils::{ok_confirmation, truncate};
 use anyhow::{Context, Result};
@@ -276,6 +275,12 @@ fn list_prs(args: &[String], _verbose: u8, ultra_compact: bool) -> Result<()> {
     Ok(())
 }
 
+fn should_passthrough_pr_view(extra_args: &[String]) -> bool {
+    extra_args
+        .iter()
+        .any(|a| a == "--json" || a == "--jq" || a == "--web")
+}
+
 fn view_pr(args: &[String], _verbose: u8, ultra_compact: bool) -> Result<()> {
     let timer = tracking::TimedExecution::start();
 
@@ -283,6 +288,13 @@ fn view_pr(args: &[String], _verbose: u8, ultra_compact: bool) -> Result<()> {
         Some(result) => result,
         None => return Err(anyhow::anyhow!("PR number required")),
     };
+
+    // If the user provides --json, --jq, or --web, pass through directly.
+    // Our filter forces its own --json fields and would ignore user-requested fields.
+    let extra_args = &args[1..];
+    if should_passthrough_pr_view(extra_args) {
+        return run_passthrough_with_extra("gh", &["pr", "view", pr_number], extra_args);
+    }
 
     let mut cmd = Command::new("gh");
     cmd.args([
@@ -1092,11 +1104,23 @@ fn pr_merge(args: &[String], _verbose: u8) -> Result<()> {
 }
 
 fn pr_diff(args: &[String], _verbose: u8) -> Result<()> {
+    // --no-compact: pass full diff through (gh CLI doesn't know this flag, strip it)
+    let no_compact = args.iter().any(|a| a == "--no-compact");
+    let gh_args: Vec<String> = args
+        .iter()
+        .filter(|a| *a != "--no-compact")
+        .cloned()
+        .collect();
+
+    if no_compact {
+        return run_passthrough_with_extra("gh", &["pr", "diff"], &gh_args);
+    }
+
     let timer = tracking::TimedExecution::start();
 
     let mut cmd = Command::new("gh");
     cmd.args(["pr", "diff"]);
-    for arg in args {
+    for arg in &gh_args {
         cmd.arg(arg);
     }
 
@@ -1115,7 +1139,7 @@ fn pr_diff(args: &[String], _verbose: u8) -> Result<()> {
         print!("{}", msg);
         msg.to_string()
     } else {
-        let compacted = git::compact_diff(&raw, 100);
+        let compacted = git::compact_diff(&raw, 500);
         println!("{}", compacted);
         compacted
     };
@@ -1179,47 +1203,10 @@ fn pr_action(action: &str, args: &[String], _verbose: u8) -> Result<()> {
 }
 
 fn run_api(args: &[String], _verbose: u8) -> Result<()> {
-    let timer = tracking::TimedExecution::start();
-
-    let mut cmd = Command::new("gh");
-    cmd.arg("api");
-    for arg in args {
-        cmd.arg(arg);
-    }
-
-    let output = cmd.output().context("Failed to run gh api")?;
-    let raw = String::from_utf8_lossy(&output.stdout).to_string();
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        timer.track("gh api", "rtk gh api", &stderr, &stderr);
-        eprintln!("{}", stderr.trim());
-        std::process::exit(output.status.code().unwrap_or(1));
-    }
-
-    // Try to parse as JSON and filter
-    let filtered = match json_cmd::filter_json_string(&raw, 5) {
-        Ok(schema) => {
-            println!("{}", schema);
-            schema
-        }
-        Err(_) => {
-            // Not JSON, print truncated raw output
-            let mut result = String::new();
-            let lines: Vec<&str> = raw.lines().take(20).collect();
-            let joined = lines.join("\n");
-            result.push_str(&joined);
-            print!("{}", joined);
-            if raw.lines().count() > 20 {
-                result.push_str("\n... (truncated)");
-                println!("\n... (truncated)");
-            }
-            result
-        }
-    };
-
-    timer.track("gh api", "rtk gh api", &raw, &filtered);
-    Ok(())
+    // gh api is an explicit/advanced command — the user knows what they asked for.
+    // Converting JSON to a schema destroys all values and forces Claude to re-fetch.
+    // Passthrough preserves the full response and tracks metrics at 0% savings.
+    run_passthrough("gh", "api", args)
 }
 
 /// Pass through a command with base args + extra args, tracking as passthrough.
@@ -1430,6 +1417,36 @@ mod tests {
     #[test]
     fn test_run_view_no_passthrough_other_flags() {
         assert!(!should_passthrough_run_view(&["--web".into()]));
+    }
+
+    // --- should_passthrough_pr_view tests ---
+
+    #[test]
+    fn test_should_passthrough_pr_view_json() {
+        assert!(should_passthrough_pr_view(&[
+            "--json".into(),
+            "body,comments".into()
+        ]));
+    }
+
+    #[test]
+    fn test_should_passthrough_pr_view_jq() {
+        assert!(should_passthrough_pr_view(&["--jq".into(), ".body".into()]));
+    }
+
+    #[test]
+    fn test_should_passthrough_pr_view_web() {
+        assert!(should_passthrough_pr_view(&["--web".into()]));
+    }
+
+    #[test]
+    fn test_should_passthrough_pr_view_default() {
+        assert!(!should_passthrough_pr_view(&[]));
+    }
+
+    #[test]
+    fn test_should_passthrough_pr_view_other_flags() {
+        assert!(!should_passthrough_pr_view(&["--comments".into()]));
     }
 
     // --- filter_markdown_body tests ---

--- a/src/gh_cmd.rs
+++ b/src/gh_cmd.rs
@@ -1120,7 +1120,7 @@ fn pr_diff(args: &[String], _verbose: u8) -> Result<()> {
 
     let mut cmd = Command::new("gh");
     cmd.args(["pr", "diff"]);
-    for arg in &gh_args as &[String] {
+    for arg in gh_args.iter() {
         cmd.arg(arg);
     }
 

--- a/src/gh_cmd.rs
+++ b/src/gh_cmd.rs
@@ -293,7 +293,7 @@ fn view_pr(args: &[String], _verbose: u8, ultra_compact: bool) -> Result<()> {
     // Our filter forces its own --json fields and would ignore user-requested fields.
     let extra_args = &args[1..];
     if should_passthrough_pr_view(extra_args) {
-        return run_passthrough_with_extra("gh", &["pr", "view", pr_number], extra_args);
+        return run_passthrough_with_extra("gh", &["pr", "view", pr_number.as_str()], extra_args);
     }
 
     let mut cmd = Command::new("gh");
@@ -1120,7 +1120,7 @@ fn pr_diff(args: &[String], _verbose: u8) -> Result<()> {
 
     let mut cmd = Command::new("gh");
     cmd.args(["pr", "diff"]);
-    for arg in &gh_args {
+    for arg in &gh_args as &[String] {
         cmd.arg(arg);
     }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -130,7 +130,7 @@ fn run_diff(
     let mut final_output = stat_stdout.to_string();
     if !diff_stdout.is_empty() {
         println!("\n--- Changes ---");
-        let compacted = compact_diff(&diff_stdout, max_lines.unwrap_or(100));
+        let compacted = compact_diff(&diff_stdout, max_lines.unwrap_or(500));
         println!("{}", compacted);
         final_output.push_str("\n--- Changes ---\n");
         final_output.push_str(&compacted);
@@ -250,7 +250,7 @@ fn run_show(
         if verbose > 0 {
             println!("\n--- Changes ---");
         }
-        let compacted = compact_diff(diff_text, max_lines.unwrap_or(100));
+        let compacted = compact_diff(diff_text, max_lines.unwrap_or(500));
         println!("{}", compacted);
         final_output.push_str(&format!("\n{}", compacted));
     }
@@ -277,7 +277,7 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
     let mut removed = 0;
     let mut in_hunk = false;
     let mut hunk_lines = 0;
-    let max_hunk_lines = 10;
+    let max_hunk_lines = 30;
 
     for line in diff.lines() {
         if line.starts_with("diff --git") {
@@ -1447,6 +1447,40 @@ mod tests {
         let result = compact_diff(diff, 100);
         assert!(result.contains("foo.rs"));
         assert!(result.contains("+"));
+    }
+
+    #[test]
+    fn test_compact_diff_increased_hunk_limit() {
+        // Build a hunk with 25 changed lines — should NOT be truncated with limit 30
+        let mut diff =
+            "diff --git a/big.rs b/big.rs\n--- a/big.rs\n+++ b/big.rs\n@@ -1,25 +1,25 @@\n"
+                .to_string();
+        for i in 1..=25 {
+            diff.push_str(&format!("+line{}\n", i));
+        }
+        let result = compact_diff(&diff, 500);
+        assert!(
+            !result.contains("... (truncated)"),
+            "25 lines should not be truncated with max_hunk_lines=30"
+        );
+        assert!(result.contains("+line25"));
+    }
+
+    #[test]
+    fn test_compact_diff_increased_total_limit() {
+        // Build a diff with 150 output result lines across multiple files — should NOT be cut at 100
+        let mut diff = String::new();
+        for f in 1..=5 {
+            diff.push_str(&format!("diff --git a/file{f}.rs b/file{f}.rs\n--- a/file{f}.rs\n+++ b/file{f}.rs\n@@ -1,20 +1,20 @@\n"));
+            for i in 1..=20 {
+                diff.push_str(&format!("+line{f}_{i}\n"));
+            }
+        }
+        let result = compact_diff(&diff, 500);
+        assert!(
+            !result.contains("more changes truncated"),
+            "5 files × 20 lines should not exceed max_lines=500"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

RTK was too aggressively truncating `gh api`, `gh pr diff`, and `git diff` outputs, forcing Claude to re-fetch multiple times and negating token savings. Two root causes:

1. Hardcoded limits too low (100 total lines, 10 lines/hunk)
2. `gh api` was converting JSON to a schema (types without values), destroying all data

## Changes

### `src/git.rs`
- `compact_diff`: `max_hunk_lines` 10 → 30
- `compact_diff`: default `max_lines` 100 → 500 (for `git diff` and `git show`)

### `src/gh_cmd.rs`
- **`gh api`**: replaced JSON→schema transformation with passthrough — `gh api` is an explicit/advanced command, user knows what they asked for
- **`gh pr diff`**: increased limit 100 → 500; added `--no-compact` flag for full passthrough (gh CLI doesn't know this flag, it's stripped before forwarding)
- **`gh pr view`**: passthrough when user provides `--json`, `--jq`, or `--web` (previously forced its own `--json` fields and ignored user-requested fields)

## Testing

- 664 tests pass (`cargo test`)
- 7 new unit tests added (2 in git.rs, 5 in gh_cmd.rs)
- All changes are either limit increases or passthrough patterns (already established in the codebase)

## Verification

```bash
rtk git diff                          # increased limits
rtk git diff --no-compact             # passthrough (existing)
rtk gh pr diff <num>                  # increased limits
rtk gh pr diff <num> --no-compact     # new passthrough
rtk gh api repos/rtk-ai/rtk/pulls    # full JSON, no schema
rtk gh pr view <num> --json body      # passthrough, user fields respected
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)