### PR TITLE
docs: revamp README with logo, badges, and structure cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,71 +1,63 @@
-# rtk - Rust Token Killer
+<p align="center">
+  <img src="https://www.rtk-ai.app/og-image.png" alt="RTK - Rust Token Killer" width="500">
+</p>
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+<p align="center">
+  <strong>High-performance CLI proxy that reduces LLM token consumption by 60-90%</strong>
+</p>
 
-**High-performance CLI proxy to minimize LLM token consumption.**
+<p align="center">
+  <a href="https://github.com/rtk-ai/rtk/actions"><img src="https://github.com/rtk-ai/rtk/workflows/Security%20Check/badge.svg" alt="CI"></a>
+  <a href="https://github.com/rtk-ai/rtk/releases"><img src="https://img.shields.io/github/v/release/rtk-ai/rtk" alt="Release"></a>
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
+  <a href="https://discord.gg/pvHdzAec"><img src="https://img.shields.io/discord/1470188214710046894?label=Discord&logo=discord" alt="Discord"></a>
+  <a href="https://formulae.brew.sh/formula/rtk"><img src="https://img.shields.io/homebrew/v/rtk" alt="Homebrew"></a>
+</p>
 
-[Website](https://www.rtk-ai.app) | [GitHub](https://github.com/rtk-ai/rtk) | [Install](INSTALL.md)
+<p align="center">
+  <a href="https://www.rtk-ai.app">Website</a> &bull;
+  <a href="#installation">Install</a> &bull;
+  <a href="docs/TROUBLESHOOTING.md">Troubleshooting</a> &bull;
+  <a href="ARCHITECTURE.md">Architecture</a> &bull;
+  <a href="https://discord.gg/pvHdzAec">Discord</a>
+</p>
 
-rtk filters and compresses command outputs before they reach your LLM context, saving 60-90% of tokens on common operations.
+<p align="center">
+  <a href="README.md">English</a> &bull;
+  <a href="README_fr.md">Francais</a> &bull;
+  <a href="README_zh.md">中文</a> &bull;
+  <a href="README_ja.md">日本語</a> &bull;
+  <a href="README_ko.md">한국어</a> &bull;
+  <a href="README_es.md">Espanol</a>
+</p>
 
-## ⚠️ Important: Name Collision Warning
+---
 
-**There are TWO different projects named "rtk":**
-
-1. ✅ **This project (Rust Token Killer)** - LLM token optimizer
-   - Repos: `rtk-ai/rtk`
-   - Purpose: Reduce Claude Code token consumption
-
-2. ❌ **reachingforthejack/rtk** - Rust Type Kit (DIFFERENT PROJECT)
-   - Purpose: Query Rust codebase and generate types
-   - **DO NOT install this one if you want token optimization**
-
-**How to verify you have the correct rtk:**
-```bash
-rtk --version   # Should show "rtk 0.26.0"
-rtk gain        # Should show token savings stats
-```
-
-If `rtk gain` doesn't exist, you installed the wrong package. See installation instructions below.
+rtk filters and compresses command outputs before they reach your LLM context. Single Rust binary, zero dependencies, <10ms overhead.
 
 ## Token Savings (30-min Claude Code Session)
 
-Typical session without rtk: **~150,000 tokens**
-With rtk: **~45,000 tokens** → **70% reduction**
-
 | Operation | Frequency | Standard | rtk | Savings |
 |-----------|-----------|----------|-----|---------|
-| `ls` / `tree` | 10× | 2,000 | 400 | -80% |
-| `cat` / `read` | 20× | 40,000 | 12,000 | -70% |
-| `grep` / `rg` | 8× | 16,000 | 3,200 | -80% |
-| `git status` | 10× | 3,000 | 600 | -80% |
-| `git diff` | 5× | 10,000 | 2,500 | -75% |
-| `git log` | 5× | 2,500 | 500 | -80% |
-| `git add/commit/push` | 8× | 1,600 | 120 | -92% |
-| `npm test` / `cargo test` | 5× | 25,000 | 2,500 | -90% |
-| `ruff check` | 3× | 3,000 | 600 | -80% |
-| `pytest` | 4× | 8,000 | 800 | -90% |
-| `go test` | 3× | 6,000 | 600 | -90% |
-| `docker ps` | 3× | 900 | 180 | -80% |
+| `ls` / `tree` | 10x | 2,000 | 400 | -80% |
+| `cat` / `read` | 20x | 40,000 | 12,000 | -70% |
+| `grep` / `rg` | 8x | 16,000 | 3,200 | -80% |
+| `git status` | 10x | 3,000 | 600 | -80% |
+| `git diff` | 5x | 10,000 | 2,500 | -75% |
+| `git log` | 5x | 2,500 | 500 | -80% |
+| `git add/commit/push` | 8x | 1,600 | 120 | -92% |
+| `cargo test` / `npm test` | 5x | 25,000 | 2,500 | -90% |
+| `ruff check` | 3x | 3,000 | 600 | -80% |
+| `pytest` | 4x | 8,000 | 800 | -90% |
+| `go test` | 3x | 6,000 | 600 | -90% |
+| `docker ps` | 3x | 900 | 180 | -80% |
 | **Total** | | **~118,000** | **~23,900** | **-80%** |
 
 > Estimates based on medium-sized TypeScript/Rust projects. Actual savings vary by project size.
 
 ## Installation
 
-### ⚠️ Pre-Installation Check (REQUIRED)
-
-**ALWAYS verify if rtk is already installed before installing:**
-
-```bash
-rtk --version        # Check if installed
-rtk gain             # Verify it's the Token Killer (not Type Kit)
-which rtk            # Check installation path
-```
-
-If already installed and `rtk gain` works, **DO NOT reinstall**. Skip to Quick Start.
-
-### Homebrew (macOS/Linux)
+### Homebrew (recommended)
 
 ```bash
 brew install rtk
@@ -77,63 +69,63 @@ brew install rtk
 curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
 ```
 
-> **Note**: rtk installs to `~/.local/bin` by default. If this directory is not in your PATH, add it:
+> Installs to `~/.local/bin`. Add to PATH if needed:
 > ```bash
 > echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc  # or ~/.zshrc
 > ```
 
-After installation, **verify you have the correct rtk**:
-```bash
-rtk gain  # Must show token savings stats (not "command not found")
-```
-
-### Alternative: Manual Installation
+### Cargo
 
 ```bash
-# From rtk-ai upstream (maintained by pszymkowiak)
 cargo install --git https://github.com/rtk-ai/rtk
-
-# OR if published to crates.io
-cargo install rtk
 ```
 
-⚠️ **WARNING**: `cargo install rtk` from crates.io might install the wrong package (Type Kit instead of Token Killer). Always verify with `rtk gain` after installation.
+### Pre-built Binaries
 
-### Alternative: Pre-built Binaries
-
-Download from [rtk-ai/releases](https://github.com/rtk-ai/rtk/releases):
+Download from [releases](https://github.com/rtk-ai/rtk/releases):
 - macOS: `rtk-x86_64-apple-darwin.tar.gz` / `rtk-aarch64-apple-darwin.tar.gz`
-- Linux: `rtk-x86_64-unknown-linux-gnu.tar.gz` / `rtk-aarch64-unknown-linux-gnu.tar.gz`
+- Linux: `rtk-x86_64-unknown-linux-musl.tar.gz` / `rtk-aarch64-unknown-linux-gnu.tar.gz`
 - Windows: `rtk-x86_64-pc-windows-msvc.zip`
+
+### Verify Installation
+
+```bash
+rtk --version   # Should show "rtk 0.27.x"
+rtk gain        # Should show token savings stats
+```
+
+> **Name collision warning**: Another project named "rtk" (Rust Type Kit) exists on crates.io. If `rtk gain` fails, you have the wrong package. Use `cargo install --git` above instead.
 
 ## Quick Start
 
 ```bash
-# 1. Verify installation
-rtk gain  # Must show token stats, not "command not found"
-
-# 2. Initialize for Claude Code (RECOMMENDED: hook-first mode)
+# 1. Install hook for Claude Code (recommended)
 rtk init --global
-# → Installs hook + creates slim RTK.md (10 lines, 99.5% token savings)
-# → Follow printed instructions to add hook to ~/.claude/settings.json
+# Follow instructions to register in ~/.claude/settings.json
 
-# 3. Test it works
-rtk git status  # Should show ultra-compact output
-rtk init --show # Verify hook is installed and executable
-
-# Alternative modes:
-# rtk init --global --claude-md  # Legacy: full injection (137 lines)
-# rtk init                       # Local project only (./CLAUDE.md)
+# 2. Restart Claude Code, then test
+git status  # Automatically rewritten to rtk git status
 ```
 
-**New in v0.9.5**: Hook-first installation eliminates ~2000 tokens from Claude's context while maintaining full RTK functionality through transparent command rewriting.
+The hook transparently rewrites commands (e.g., `git status` -> `rtk git status`) before execution. Claude never sees the rewrite, it just gets compressed output.
 
-## Global Flags
+## How It Works
 
-```bash
--u, --ultra-compact    # ASCII icons, inline format (extra token savings)
--v, --verbose          # Increase verbosity (-v, -vv, -vvv)
 ```
+  Without rtk:                                    With rtk:
+
+  Claude  --git status-->  shell  -->  git         Claude  --git status-->  RTK  -->  git
+    ^                                   |            ^                      |          |
+    |        ~2,000 tokens (raw)        |            |   ~200 tokens        | filter   |
+    +-----------------------------------+            +------- (filtered) ---+----------+
+```
+
+Four strategies applied per command type:
+
+1. **Smart Filtering** - Removes noise (comments, whitespace, boilerplate)
+2. **Grouping** - Aggregates similar items (files by directory, errors by type)
+3. **Truncation** - Keeps relevant context, cuts redundancy
+4. **Deduplication** - Collapses repeated log lines with counts
 
 ## Commands
 
@@ -145,6 +137,7 @@ rtk read file.rs -l aggressive  # Signatures only (strips bodies)
 rtk smart file.rs               # 2-line heuristic code summary
 rtk find "*.rs" .               # Compact find results
 rtk grep "pattern" .            # Grouped search results
+rtk diff file1 file2            # Condensed diff
 ```
 
 ### Git
@@ -152,95 +145,50 @@ rtk grep "pattern" .            # Grouped search results
 rtk git status                  # Compact status
 rtk git log -n 10               # One-line commits
 rtk git diff                    # Condensed diff
-rtk git add                     # → "ok ✓"
-rtk git commit -m "msg"         # → "ok ✓ abc1234"
-rtk git push                    # → "ok ✓ main"
-rtk git pull                    # → "ok ✓ 3 files +10 -2"
+rtk git add                     # -> "ok"
+rtk git commit -m "msg"         # -> "ok abc1234"
+rtk git push                    # -> "ok main"
+rtk git pull                    # -> "ok 3 files +10 -2"
 ```
 
-### Commands
+### GitHub CLI
 ```bash
-rtk test cargo test             # Show failures only (-90% tokens)
+rtk gh pr list                  # Compact PR listing
+rtk gh pr view 42               # PR details + checks
+rtk gh issue list               # Compact issue listing
+rtk gh run list                 # Workflow run status
+```
+
+### Test Runners
+```bash
+rtk test cargo test             # Show failures only (-90%)
 rtk err npm run build           # Errors/warnings only
-rtk summary <long command>      # Heuristic summary
-rtk log app.log                 # Deduplicated logs
-rtk gh pr list                   # Compact PR listing
-rtk gh pr view 42                # PR details + checks summary
-rtk gh issue list                # Compact issue listing
-rtk gh run list                  # Workflow run status
-rtk wget https://example.com    # Download, strip progress bars
-rtk config                       # Show config (--create to generate)
-rtk ruff check                   # Python linting (JSON, 80% reduction)
-rtk pytest                       # Python tests (failures only, 90% reduction)
-rtk pip list                     # Python packages (auto-detect uv, 70% reduction)
-rtk go test                      # Go tests (NDJSON, 90% reduction)
-rtk golangci-lint run            # Go linting (JSON, 85% reduction)
+rtk vitest run                  # Vitest compact (failures only)
+rtk playwright test             # E2E results (failures only)
+rtk pytest                      # Python tests (-90%)
+rtk go test                     # Go tests (NDJSON, -90%)
+rtk cargo test                  # Cargo tests (-90%)
 ```
 
-### Data & Analytics
+### Build & Lint
 ```bash
-rtk json config.json            # Structure without values
-rtk deps                        # Dependencies summary
-rtk env -f AWS                  # Filtered env vars
-
-# Token Savings Analytics (includes execution time metrics)
-rtk gain                        # Summary stats with total exec time
-rtk gain --graph                # With ASCII graph of last 30 days
-rtk gain --history              # With recent command history (10)
-rtk gain --quota --tier 20x     # Monthly quota analysis (pro/5x/20x)
-
-# Temporal Breakdowns (includes time metrics per period)
-rtk gain --daily                # Day-by-day with avg execution time
-rtk gain --weekly               # Week-by-week breakdown
-rtk gain --monthly              # Month-by-month breakdown
-rtk gain --all                  # All breakdowns combined
-
-# Export Formats (includes total_time_ms and avg_time_ms fields)
-rtk gain --all --format json    # JSON export for APIs/dashboards
-rtk gain --all --format csv     # CSV export for Excel/analysis
+rtk lint                        # ESLint grouped by rule/file
+rtk lint biome                  # Supports other linters
+rtk tsc                         # TypeScript errors grouped by file
+rtk next build                  # Next.js build compact
+rtk prettier --check .          # Files needing formatting
+rtk cargo build                 # Cargo build (-80%)
+rtk cargo clippy                # Cargo clippy (-80%)
+rtk ruff check                  # Python linting (JSON, -80%)
+rtk golangci-lint run           # Go linting (JSON, -85%)
 ```
 
-> 📖 **API Documentation**: For programmatic access to tracking data (Rust library usage, CI/CD integration, custom dashboards), see [docs/tracking.md](docs/tracking.md).
-
-### Discover — Find Missed Savings
-
-Scans your Claude Code session history to find commands where rtk would have saved tokens. Use it to:
-- **Measure what you're missing** — see exactly how many tokens you could save
-- **Identify habits** — find which commands you keep running without rtk
-- **Spot new opportunities** — see unhandled commands that could become rtk features
-
+### Package Managers
 ```bash
-rtk discover                    # Current project, last 30 days
-rtk discover --all              # All Claude Code projects
-rtk discover --all --since 7    # Last 7 days across all projects
-rtk discover -p aristote        # Filter by project name (substring)
-rtk discover --format json      # Machine-readable output
-```
-
-Example output:
-```
-RTK Discover -- Savings Opportunities
-====================================================
-Scanned: 142 sessions (last 30 days), 1786 Bash commands
-Already using RTK: 108 commands (6%)
-
-MISSED SAVINGS -- Commands RTK already handles
-----------------------------------------------------
-Command              Count    RTK Equivalent        Est. Savings
-git log                434    rtk git               ~55.9K tokens
-cargo test             203    rtk cargo             ~49.9K tokens
-ls -la                 107    rtk ls                ~11.8K tokens
-gh pr                   80    rtk gh                ~10.4K tokens
-----------------------------------------------------
-Total: 986 commands -> ~143.9K tokens saveable
-
-TOP UNHANDLED COMMANDS -- open an issue?
-----------------------------------------------------
-Command              Count    Example
-git checkout            84    git checkout feature/my-branch
-cargo run               32    cargo run -- gain --help
-----------------------------------------------------
--> github.com/rtk-ai/rtk/issues
+rtk pnpm list                   # Compact dependency tree
+rtk pip list                    # Python packages (auto-detect uv)
+rtk pip outdated                # Outdated packages
+rtk prisma generate             # Schema generation (no ASCII art)
 ```
 
 ### Containers
@@ -248,623 +196,167 @@ cargo run               32    cargo run -- gain --help
 rtk docker ps                   # Compact container list
 rtk docker images               # Compact image list
 rtk docker logs <container>     # Deduplicated logs
+rtk docker compose ps           # Compose services
 rtk kubectl pods                # Compact pod list
 rtk kubectl logs <pod>          # Deduplicated logs
-rtk kubectl services             # Compact service list
+rtk kubectl services            # Compact service list
 ```
 
-### JavaScript / TypeScript Stack
+### Data & Analytics
 ```bash
-rtk lint                         # ESLint grouped by rule/file
-rtk lint biome                   # Supports other linters too
-rtk tsc                          # TypeScript errors grouped by file
-rtk next build                   # Next.js build compact output
-rtk prettier --check .           # Files needing formatting
-rtk vitest run                   # Test failures only
-rtk playwright test              # E2E results (failures only)
-rtk prisma generate              # Schema generation (no ASCII art)
-rtk prisma migrate dev --name x  # Migration summary
-rtk prisma db-push               # Schema push summary
+rtk json config.json            # Structure without values
+rtk deps                        # Dependencies summary
+rtk env -f AWS                  # Filtered env vars
+rtk log app.log                 # Deduplicated logs
+rtk curl <url>                  # Auto-detect JSON + schema
+rtk wget <url>                  # Download, strip progress bars
+rtk summary <long command>      # Heuristic summary
+rtk proxy <command>             # Raw passthrough + tracking
 ```
 
-### Python & Go Stack
+### Token Savings Analytics
 ```bash
-# Python
-rtk ruff check                   # Ruff linter (JSON, 80% reduction)
-rtk ruff format                  # Ruff formatter (text filter)
-rtk pytest                       # Test failures with state machine parser (90% reduction)
-rtk pip list                     # Package list (auto-detect uv, 70% reduction)
-rtk pip install <package>        # Install with compact output
-rtk pip outdated                 # Outdated packages (85% reduction)
+rtk gain                        # Summary stats
+rtk gain --graph                # ASCII graph (last 30 days)
+rtk gain --history              # Recent command history
+rtk gain --daily                # Day-by-day breakdown
+rtk gain --all --format json    # JSON export for dashboards
 
-# Go
-rtk go test                      # NDJSON streaming parser (90% reduction)
-rtk go build                     # Build errors only (80% reduction)
-rtk go vet                       # Vet issues (75% reduction)
-rtk golangci-lint run            # JSON grouped by rule (85% reduction)
+rtk discover                    # Find missed savings opportunities
+rtk discover --all --since 7    # All projects, last 7 days
+```
+
+## Global Flags
+
+```bash
+-u, --ultra-compact    # ASCII icons, inline format (extra token savings)
+-v, --verbose          # Increase verbosity (-v, -vv, -vvv)
 ```
 
 ## Examples
 
-### Standard vs rtk
-
 **Directory listing:**
 ```
-# ls -la (45 lines, ~800 tokens)
-drwxr-xr-x  15 user  staff    480 Jan 23 10:00 .
-drwxr-xr-x   5 user  staff    160 Jan 23 09:00 ..
--rw-r--r--   1 user  staff   1234 Jan 23 10:00 Cargo.toml
-...
-
-# rtk ls (12 lines, ~150 tokens)
-📁 my-project/
-├── src/ (8 files)
-│   ├── main.rs
-│   └── lib.rs
-├── Cargo.toml
-└── README.md
+# ls -la (45 lines, ~800 tokens)        # rtk ls (12 lines, ~150 tokens)
+drwxr-xr-x  15 user staff 480 ...       my-project/
+-rw-r--r--   1 user staff 1234 ...       +-- src/ (8 files)
+...                                      |   +-- main.rs
+                                         +-- Cargo.toml
 ```
 
 **Git operations:**
 ```
-# git push (15 lines, ~200 tokens)
-Enumerating objects: 5, done.
+# git push (15 lines, ~200 tokens)       # rtk git push (1 line, ~10 tokens)
+Enumerating objects: 5, done.             ok main
 Counting objects: 100% (5/5), done.
 Delta compression using up to 8 threads
 ...
-
-# rtk git push (1 line, ~10 tokens)
-ok ✓ main
 ```
 
 **Test output:**
 ```
-# cargo test (200+ lines on failure)
-running 15 tests
-test utils::test_parse ... ok
-test utils::test_format ... ok
+# cargo test (200+ lines on failure)     # rtk test cargo test (~20 lines)
+running 15 tests                          FAILED: 2/15 tests
+test utils::test_parse ... ok               test_edge_case: assertion failed
+test utils::test_format ... ok              test_overflow: panic at utils.rs:18
 ...
-
-# rtk test cargo test (only failures, ~20 lines)
-FAILED: 2/15 tests
-  ✗ test_edge_case: assertion failed at src/lib.rs:42
-  ✗ test_overflow: panic at src/utils.rs:18
 ```
 
-## How It Works
+## Auto-Rewrite Hook
 
-```
-  Without rtk:
+The most effective way to use rtk. The hook transparently intercepts Bash commands and rewrites them to rtk equivalents before execution.
 
-  ┌──────────┐  git status     ┌──────────┐  git status  ┌──────────┐
-  │  Claude  │ ─────────────── │  shell   │ ──────────── │   git    │
-  │   LLM    │                 │          │              │  (CLI)   │
-  └──────────┘                 └──────────┘              └──────────┘
-        ▲                                                      │
-        │              ~2,000 tokens (raw output)              │
-        └──────────────────────────────────────────────────────┘
+**Result**: 100% rtk adoption across all conversations and subagents, zero token overhead.
 
-  With rtk:
-
-  ┌──────────┐  git status     ┌──────────┐  git status  ┌──────────┐
-  │  Claude  │ ─────────────── │   RTK    │ ──────────── │   git    │
-  │   LLM    │                 │  (proxy) │              │  (CLI)   │
-  └──────────┘                 └──────────┘              └──────────┘
-        ▲                           │  ~2,000 tokens raw       │
-        │                           └──────────────────────────┘
-        │  ~200 tokens (filtered)   filter · group · dedup · truncate
-        └───────────────────────────────────────────────────────
-```
-
-Four strategies applied per command type:
-
-1. **Smart Filtering**: Removes noise (comments, whitespace, boilerplate)
-2. **Grouping**: Aggregates similar items (files by directory, errors by type)
-3. **Truncation**: Keeps relevant context, cuts redundancy
-4. **Deduplication**: Collapses repeated log lines with counts
-
-## Configuration
-
-### Installation Modes
-
-| Command | Scope | Hook | RTK.md | CLAUDE.md | Tokens in Context | Use Case |
-|---------|-------|------|--------|-----------|-------------------|----------|
-| `rtk init -g` | Global | ✅ | ✅ (10 lines) | @RTK.md | ~10 | **Recommended**: All projects, automatic |
-| `rtk init -g --claude-md` | Global | ❌ | ❌ | Full (137 lines) | ~2000 | Legacy compatibility |
-| `rtk init -g --hook-only` | Global | ✅ | ❌ | Nothing | 0 | Minimal setup, hook-only |
-| `rtk init` | Local | ❌ | ❌ | Full (137 lines) | ~2000 | Single project, no hook |
+### Setup
 
 ```bash
-rtk init --show         # Show current configuration
-rtk init -g             # Install hook + RTK.md (recommended)
-rtk init -g --claude-md # Legacy: full injection into CLAUDE.md
-rtk init                # Local project: full injection into ./CLAUDE.md
-```
-
-### Installation Flags
-
-**Settings.json Control**:
-```bash
-rtk init -g                 # Default: prompt to patch [y/N]
-rtk init -g --auto-patch    # Patch settings.json without prompting
-rtk init -g --no-patch      # Skip patching, show manual instructions
-```
-
-**Mode Control**:
-```bash
-rtk init -g --claude-md     # Legacy: full 137-line injection (no hook)
+rtk init -g                 # Install hook + RTK.md (recommended)
+rtk init -g --auto-patch    # Non-interactive (CI/CD)
 rtk init -g --hook-only     # Hook only, no RTK.md
+rtk init --show             # Verify installation
 ```
 
-**Uninstall**:
-```bash
-rtk init -g --uninstall     # Remove all RTK artifacts
-```
-
-**What is settings.json?**
-Claude Code configuration file that registers the RTK hook. The hook transparently rewrites commands (e.g., `git status` → `rtk git status`) before execution. Without this registration, Claude won't use the hook.
-
-**Backup Behavior**:
-RTK creates `~/.claude/settings.json.bak` before making changes. If something breaks, restore with:
-```bash
-cp ~/.claude/settings.json.bak ~/.claude/settings.json
-```
-
-**Migration**: If you previously used `rtk init -g` with the old system (137-line injection), simply re-run `rtk init -g` to automatically migrate to the new hook-first approach.
-
-example of 3 days session:
-```bash
-📊 RTK Token Savings
-════════════════════════════════════════
-
-Total commands:    133
-Input tokens:      30.5K
-Output tokens:     10.7K
-Tokens saved:      25.3K (83.0%)
-
-By Command:
-────────────────────────────────────────
-Command               Count      Saved     Avg%
-rtk git status           41      17.4K    82.9%
-rtk git push             54       3.4K    91.6%
-rtk grep                 15       3.2K    26.5%
-rtk ls                   23       1.4K    37.2%
-
-Daily Savings (last 30 days):
-────────────────────────────────────────
-01-23 │███████████████████                      6.4K
-01-24 │██████████████████                       5.9K
-01-25 │                                         18
-01-26 │████████████████████████████████████████ 13.0K
-```
-
-### Custom Database Path
-
-By default, RTK stores tracking data in `~/.local/share/rtk/history.db`. You can override this:
-
-**Environment variable** (highest priority):
-```bash
-export RTK_DB_PATH="/path/to/custom.db"
-```
-
-**Config file** (`~/.config/rtk/config.toml`):
-```toml
-[tracking]
-database_path = "/path/to/custom.db"
-```
-
-Priority: `RTK_DB_PATH` env var > `config.toml` > default location.
-
-### Excluding Commands from Auto-Rewrite
-
-By default, the hook rewrites all supported commands automatically. To exclude specific commands (e.g., keep raw `curl` output without schema extraction), add to your config:
-
-**Config file** (`~/.config/rtk/config.toml`, macOS: `~/Library/Application Support/rtk/config.toml`):
-```toml
-[hooks]
-exclude_commands = ["curl", "playwright"]
-```
-
-Excluded commands pass through the hook unchanged — no RTK filtering. This survives `rtk init -g` re-runs since the config file is user-owned.
-
-### Tee: Full Output Recovery
-
-When RTK filters command output, LLM agents lose failure details (stack traces, assertion messages) and may re-run the same command 2-3 times. The **tee** feature saves raw output to a file so the agent can read it without re-executing.
-
-**How it works**: On command failure, RTK writes the full unfiltered output to `~/.local/share/rtk/tee/` and prints a one-line hint:
-```
-✓ cargo test: 15 passed (1 suite, 0.01s)
-[full output: ~/.local/share/rtk/tee/1707753600_cargo_test.log]
-```
-
-The agent reads the file instead of re-running the command — saving tokens.
-
-**Default behavior**: Tee only on failures (exit code != 0), skip outputs < 500 chars.
-
-**Config** (`~/.config/rtk/config.toml`):
-```toml
-[tee]
-enabled = true          # default: true
-mode = "failures"       # "failures" (default), "always", or "never"
-max_files = 20          # max files to keep (oldest rotated out)
-max_file_size = 1048576 # 1MB per file max
-# directory = "/custom/path"  # override default location
-```
-
-**Environment overrides**:
-- `RTK_TEE=0` — disable tee entirely
-- `RTK_TEE_DIR=/path` — override output directory
-
-**Supported commands**: cargo (build/test/clippy/check/install/nextest), vitest, pytest, lint (eslint/biome/ruff/pylint/mypy), tsc, go (test/build/vet), err, test.
-
-## Auto-Rewrite Hook (Recommended)
-
-The most effective way to use rtk is with the **auto-rewrite hook** for Claude Code. Instead of relying on CLAUDE.md instructions (which subagents may ignore), this hook transparently intercepts Bash commands and rewrites them to their rtk equivalents before execution.
-
-**Result**: 100% rtk adoption across all conversations and subagents, zero token overhead in Claude's context.
-
-### What Are Hooks?
-
-**For Beginners**:
-Claude Code hooks are scripts that run before/after Claude executes commands. RTK uses a **PreToolUse** hook that intercepts Bash commands and rewrites them (e.g., `git status` → `rtk git status`) before execution. This is **transparent** - Claude never sees the rewrite, it just gets optimized output.
-
-**Why settings.json?**
-Claude Code reads `~/.claude/settings.json` to find registered hooks. Without this file, Claude doesn't know the RTK hook exists. Think of it as the hook registry.
-
-**Is it safe?**
-Yes. RTK creates a backup (`settings.json.bak`) before changes. The hook is read-only (it only modifies command strings, never deletes files or accesses secrets). Review the hook script at `~/.claude/hooks/rtk-rewrite.sh` anytime.
-
-### How It Works
-
-The hook runs as a Claude Code [PreToolUse hook](https://docs.anthropic.com/en/docs/claude-code/hooks). When Claude Code is about to execute a Bash command like `git status`, the hook rewrites it to `rtk git status` before the command reaches the shell. Claude Code never sees the rewrite — it's transparent.
-
-```
-  Claude Code types:  git status
-                           │
-                    ┌──────▼──────────────────────┐
-                    │  ~/.claude/settings.json     │
-                    │  PreToolUse hook registered  │
-                    └──────┬──────────────────────┘
-                           │
-                    ┌──────▼──────────────────────┐
-                    │  rtk-rewrite.sh              │
-                    │  "git status"                │
-                    │    →  "rtk git status"       │  transparent rewrite
-                    └──────┬──────────────────────┘
-                           │
-                    ┌──────▼──────────────────────┐
-                    │  RTK (Rust binary)           │
-                    │  executes real git status    │
-                    │  filters output              │
-                    └──────┬──────────────────────┘
-                           │
-  Claude receives:  "3 modified, 1 untracked ✓"
-                    ↑ not 50 lines of raw git output
-```
-
-### Quick Install (Automated)
-
-```bash
-rtk init -g
-# → Installs hook to ~/.claude/hooks/rtk-rewrite.sh (with executable permissions)
-# → Creates ~/.claude/RTK.md (10 lines, minimal context footprint)
-# → Adds @RTK.md reference to ~/.claude/CLAUDE.md
-# → Prompts: "Patch settings.json? [y/N]"
-# → If yes: creates backup (~/.claude/settings.json.bak), patches file
-
-# Verify installation
-rtk init --show  # Shows hook status, settings.json registration
-```
-
-**Settings.json Patching Options**:
-```bash
-rtk init -g                 # Default: prompts for consent [y/N]
-rtk init -g --auto-patch    # Patch immediately without prompting (CI/CD)
-rtk init -g --no-patch      # Skip patching, print manual JSON snippet
-```
-
-**What is settings.json?**
-Claude Code's configuration file that registers the RTK hook. Without this, Claude won't use the hook. RTK backs up the file before changes (`settings.json.bak`).
-
-**Restart Required**: After installation, restart Claude Code, then test with `git status`.
-
-### Manual Install (Fallback)
-
-If automatic patching fails or you prefer manual control:
-
-```bash
-# 1. Install hook and RTK.md
-rtk init -g --no-patch  # Prints JSON snippet
-
-# 2. Manually edit ~/.claude/settings.json (add the printed snippet)
-
-# 3. Restart Claude Code
-```
-
-**Alternative: Full manual setup**
-
-```bash
-# 1. Copy the hook script
-mkdir -p ~/.claude/hooks
-cp .claude/hooks/rtk-rewrite.sh ~/.claude/hooks/rtk-rewrite.sh
-chmod +x ~/.claude/hooks/rtk-rewrite.sh
-
-# 2. Add to ~/.claude/settings.json under hooks.PreToolUse:
-```
-
-Add this entry to the `PreToolUse` array in `~/.claude/settings.json`:
-
-```json
-{
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/rtk-rewrite.sh"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-### Per-Project Install
-
-The hook is included in this repository at `.claude/hooks/rtk-rewrite.sh`. To use it in another project, copy the hook and add the same settings.json entry using a relative path or project-level `.claude/settings.json`.
+After install, **restart Claude Code**.
 
 ### Commands Rewritten
 
 | Raw Command | Rewritten To |
 |-------------|-------------|
-| `git status/diff/log/add/commit/push/pull/branch/fetch/stash` | `rtk git ...` |
+| `git status/diff/log/add/commit/push/pull` | `rtk git ...` |
 | `gh pr/issue/run` | `rtk gh ...` |
 | `cargo test/build/clippy` | `rtk cargo ...` |
-| `cat <file>` | `rtk read <file>` |
+| `cat/head/tail <file>` | `rtk read <file>` |
 | `rg/grep <pattern>` | `rtk grep <pattern>` |
 | `ls` | `rtk ls` |
-| `vitest/pnpm test` | `rtk vitest run` |
-| `tsc/pnpm tsc` | `rtk tsc` |
-| `eslint/pnpm lint` | `rtk lint` |
+| `vitest/jest` | `rtk vitest run` |
+| `tsc` | `rtk tsc` |
+| `eslint/biome` | `rtk lint` |
 | `prettier` | `rtk prettier` |
 | `playwright` | `rtk playwright` |
 | `prisma` | `rtk prisma` |
 | `ruff check/format` | `rtk ruff ...` |
 | `pytest` | `rtk pytest` |
-| `pip list/install/outdated` | `rtk pip ...` |
+| `pip list/install` | `rtk pip ...` |
 | `go test/build/vet` | `rtk go ...` |
-| `golangci-lint run` | `rtk golangci-lint run` |
+| `golangci-lint` | `rtk golangci-lint` |
 | `docker ps/images/logs` | `rtk docker ...` |
 | `kubectl get/logs` | `rtk kubectl ...` |
 | `curl` | `rtk curl` |
-| `pnpm list/ls/outdated` | `rtk pnpm ...` |
+| `pnpm list/outdated` | `rtk pnpm ...` |
 
 Commands already using `rtk`, heredocs (`<<`), and unrecognized commands pass through unchanged.
 
-### Alternative: Suggest Hook (Non-Intrusive)
+## Configuration
 
-If you prefer Claude Code to **suggest** rtk usage rather than automatically rewriting commands, use the **suggest hook** pattern instead. This emits a system reminder when rtk-compatible commands are detected, without modifying the command execution.
+### Config File
 
-**Comparison**:
+`~/.config/rtk/config.toml` (macOS: `~/Library/Application Support/rtk/config.toml`):
 
-| Aspect | Auto-Rewrite Hook | Suggest Hook |
-|--------|-------------------|--------------|
-| **Strategy** | Intercepts and modifies command before execution | Emits system reminder when rtk-compatible command detected |
-| **Effect** | Claude Code never sees the original command | Claude Code receives hint to use rtk, decides autonomously |
-| **Adoption** | 100% (forced) | ~70-85% (depends on Claude Code's adherence to instructions) |
-| **Use Case** | Production workflows, guaranteed savings | Learning mode, auditing, user preference for explicit control |
-| **Overhead** | Zero (transparent rewrite) | Minimal (reminder message in context) |
+```toml
+[tracking]
+database_path = "/path/to/custom.db"  # default: ~/.local/share/rtk/history.db
 
-**When to use suggest over rewrite**:
-- You want to audit which commands Claude Code chooses to run
-- You're learning rtk patterns and want visibility into the rewrite logic
-- You prefer Claude Code to make explicit decisions rather than transparent rewrites
-- You want to preserve exact command execution for debugging
+[hooks]
+exclude_commands = ["curl", "playwright"]  # skip rewrite for these
 
-#### Suggest Hook Setup
-
-**1. Create the suggest hook script**
-
-```bash
-mkdir -p ~/.claude/hooks
-cp .claude/hooks/rtk-suggest.sh ~/.claude/hooks/rtk-suggest.sh
-chmod +x ~/.claude/hooks/rtk-suggest.sh
+[tee]
+enabled = true          # save raw output on failure (default: true)
+mode = "failures"       # "failures", "always", or "never"
+max_files = 20          # rotation limit
 ```
 
-**2. Add to `~/.claude/settings.json`**
+### Tee: Full Output Recovery
 
-```json
-{
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/rtk-suggest.sh"
-          }
-        ]
-      }
-    ]
-  }
-}
+When a command fails, RTK saves the full unfiltered output so the LLM can read it without re-executing:
+
+```
+FAILED: 2/15 tests
+[full output: ~/.local/share/rtk/tee/1707753600_cargo_test.log]
 ```
 
-The suggest hook detects the same commands as the rewrite hook but outputs a `systemMessage` instead of `updatedInput`, informing Claude Code that an rtk alternative exists.
+### Uninstall
 
-## Uninstalling RTK
-
-**Complete Removal (Global Only)**:
 ```bash
-rtk init -g --uninstall
-
-# Removes:
-#   - ~/.claude/hooks/rtk-rewrite.sh
-#   - ~/.claude/RTK.md
-#   - @RTK.md reference from ~/.claude/CLAUDE.md
-#   - RTK hook entry from ~/.claude/settings.json
-
-# Restart Claude Code after uninstall
-```
-
-**Restore from Backup** (if needed):
-```bash
-cp ~/.claude/settings.json.bak ~/.claude/settings.json
-```
-
-**Local Projects**: Manually remove RTK instructions from `./CLAUDE.md`
-
-**Binary Removal**:
-```bash
-# If installed via cargo
-cargo uninstall rtk
-
-# If installed via package manager
-brew uninstall rtk          # macOS Homebrew
-sudo apt remove rtk         # Debian/Ubuntu
-sudo dnf remove rtk         # Fedora/RHEL
+rtk init -g --uninstall     # Remove hook, RTK.md, settings.json entry
+cargo uninstall rtk          # Remove binary
+brew uninstall rtk           # If installed via Homebrew
 ```
 
 ## Documentation
 
-- **[TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)** - ⚠️ Fix common issues (wrong rtk installed, missing commands, PATH issues)
-- **[INSTALL.md](INSTALL.md)** - Detailed installation guide with verification steps
-- **[AUDIT_GUIDE.md](docs/AUDIT_GUIDE.md)** - Complete guide to token savings analytics, temporal breakdowns, and data export
-- **[CLAUDE.md](CLAUDE.md)** - Claude Code integration instructions and project context
-- **[ARCHITECTURE.md](ARCHITECTURE.md)** - Technical architecture and development guide
-- **[SECURITY.md](SECURITY.md)** - Security policy, vulnerability reporting, and PR review process
+- **[TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)** - Fix common issues
+- **[INSTALL.md](INSTALL.md)** - Detailed installation guide
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** - Technical architecture
+- **[SECURITY.md](SECURITY.md)** - Security policy and PR review process
+- **[AUDIT_GUIDE.md](docs/AUDIT_GUIDE.md)** - Token savings analytics guide
 
-## Troubleshooting
+## Contributing
 
-### Settings.json Patching Failed
+Contributions welcome! Please open an issue or PR on [GitHub](https://github.com/rtk-ai/rtk).
 
-**Problem**: `rtk init -g` fails to patch settings.json
-
-**Solutions**:
-```bash
-# Check if settings.json is valid JSON
-cat ~/.claude/settings.json | python3 -m json.tool
-
-# Use manual patching
-rtk init -g --no-patch  # Prints JSON snippet
-
-# Restore from backup
-cp ~/.claude/settings.json.bak ~/.claude/settings.json
-
-# Check permissions
-ls -la ~/.claude/settings.json
-chmod 644 ~/.claude/settings.json
-```
-
-### Hook Not Working After Install
-
-**Problem**: Commands still not using RTK after `rtk init -g`
-
-**Solutions**:
-```bash
-# Verify hook is registered
-rtk init --show
-
-# Check settings.json manually
-cat ~/.claude/settings.json | grep rtk-rewrite
-
-# Restart Claude Code (critical step!)
-
-# Test with a command
-git status  # Should use rtk automatically
-```
-
-### Uninstall Didn't Remove Everything
-
-**Problem**: RTK traces remain after `rtk init -g --uninstall`
-
-**Manual Cleanup**:
-```bash
-# Remove hook
-rm ~/.claude/hooks/rtk-rewrite.sh
-
-# Remove RTK.md
-rm ~/.claude/RTK.md
-
-# Remove @RTK.md reference
-nano ~/.claude/CLAUDE.md  # Delete @RTK.md line
-
-# Remove from settings.json
-nano ~/.claude/settings.json  # Remove RTK hook entry
-
-# Restore from backup
-cp ~/.claude/settings.json.bak ~/.claude/settings.json
-```
-
-See **[TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)** for more issues and solutions.
-
-## For Maintainers
-
-### Security Review Workflow
-
-RTK implements a comprehensive 3-layer security review process for external PRs:
-
-#### Layer 1: Automated GitHub Action
-Every PR triggers `.github/workflows/security-check.yml`:
-- **Cargo audit**: CVE detection in dependencies
-- **Critical files alert**: Flags modifications to high-risk files (runner.rs, tracking.rs, Cargo.toml, workflows)
-- **Dangerous pattern scanning**: Shell injection, network operations, unsafe code, panic risks
-- **Dependency auditing**: Supply chain verification for new crates
-- **Clippy security lints**: Enforces Rust safety best practices
-
-Results appear in the PR's GitHub Actions summary.
-
-#### Layer 2: Claude Code Skill
-For comprehensive manual review, maintainers with [Claude Code](https://claude.ai/code) can use:
-
-```bash
-/rtk-pr-security <PR_NUMBER>
-```
-
-The skill performs:
-- **Critical files analysis**: Detects modifications to shell execution, validation, or CI/CD files
-- **Dangerous pattern detection**: Identifies shell injection, environment manipulation, exfiltration vectors
-- **Supply chain audit**: Verifies new dependencies on crates.io (downloads, maintainer, license)
-- **Semantic analysis**: Checks intent vs reality, logic bombs, code quality red flags
-- **Structured report generation**: Produces security assessment with risk level and verdict
-
-**Skill installation** (maintainers only):
-```bash
-# The skill is bundled in the rtk-pr-security directory
-# Copy to your Claude skills directory:
-cp -r ~/.claude/skills/rtk-pr-security ~/.claude/skills/
-```
-
-The skill includes:
-- `SKILL.md` - Workflow automation and usage guide
-- `critical-files.md` - RTK-specific file risk tiers with attack scenarios
-- `dangerous-patterns.md` - Regex patterns with exploitation examples
-- `checklist.md` - Manual review template
-
-#### Layer 3: Manual Review
-For PRs touching critical files or adding dependencies:
-- **2 maintainers required** for Cargo.toml, workflows, or Tier 1 files
-- **Isolated testing** recommended for high-risk changes
-- Follow the checklist in SECURITY.md
-
-See **[SECURITY.md](SECURITY.md)** for complete security policy and review guidelines.
+Join the community on [Discord](https://discord.gg/pvHdzAec).
 
 ## License
 
 MIT License - see [LICENSE](LICENSE) for details.
-
-## Contributing
-
-Contributions welcome! Please open an issue or PR on GitHub.
-
-**For external contributors**: Your PR will undergo automated security review (see [SECURITY.md](SECURITY.md)). This protects RTK's shell execution capabilities against injection attacks and supply chain vulnerabilities.
-
-## Contact
-
-- Website: https://www.rtk-ai.app
-- Email: contact@rtk-ai.app
-- Issues: https://github.com/rtk-ai/rtk/issues

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://www.rtk-ai.app/og-image.png" alt="RTK - Rust Token Killer" width="500">
+  <img src="https://avatars.githubusercontent.com/u/258253854?v=4" alt="RTK - Rust Token Killer" width="500">
 </p>
 
 <p align="center">

--- a/README_es.md
+++ b/README_es.md
@@ -1,0 +1,159 @@
+<p align="center">
+  <img src="https://www.rtk-ai.app/og-image.png" alt="RTK - Rust Token Killer" width="500">
+</p>
+
+<p align="center">
+  <strong>Proxy CLI de alto rendimiento que reduce el consumo de tokens LLM en un 60-90%</strong>
+</p>
+
+<p align="center">
+  <a href="https://github.com/rtk-ai/rtk/actions"><img src="https://github.com/rtk-ai/rtk/workflows/Security%20Check/badge.svg" alt="CI"></a>
+  <a href="https://github.com/rtk-ai/rtk/releases"><img src="https://img.shields.io/github/v/release/rtk-ai/rtk" alt="Release"></a>
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
+  <a href="https://discord.gg/pvHdzAec"><img src="https://img.shields.io/discord/1470188214710046894?label=Discord&logo=discord" alt="Discord"></a>
+  <a href="https://formulae.brew.sh/formula/rtk"><img src="https://img.shields.io/homebrew/v/rtk" alt="Homebrew"></a>
+</p>
+
+<p align="center">
+  <a href="https://www.rtk-ai.app">Sitio web</a> &bull;
+  <a href="#instalacion">Instalar</a> &bull;
+  <a href="docs/TROUBLESHOOTING.md">Solucion de problemas</a> &bull;
+  <a href="ARCHITECTURE.md">Arquitectura</a> &bull;
+  <a href="https://discord.gg/pvHdzAec">Discord</a>
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> &bull;
+  <a href="README_fr.md">Francais</a> &bull;
+  <a href="README_zh.md">中文</a> &bull;
+  <a href="README_ja.md">日本語</a> &bull;
+  <a href="README_ko.md">한국어</a> &bull;
+  <a href="README_es.md">Espanol</a>
+</p>
+
+---
+
+rtk filtra y comprime las salidas de comandos antes de que lleguen al contexto de tu LLM. Binario Rust unico, cero dependencias, <10ms de overhead.
+
+## Ahorro de tokens (sesion de 30 min en Claude Code)
+
+| Operacion | Frecuencia | Estandar | rtk | Ahorro |
+|-----------|------------|----------|-----|--------|
+| `ls` / `tree` | 10x | 2,000 | 400 | -80% |
+| `cat` / `read` | 20x | 40,000 | 12,000 | -70% |
+| `grep` / `rg` | 8x | 16,000 | 3,200 | -80% |
+| `git status` | 10x | 3,000 | 600 | -80% |
+| `cargo test` / `npm test` | 5x | 25,000 | 2,500 | -90% |
+| **Total** | | **~118,000** | **~23,900** | **-80%** |
+
+## Instalacion
+
+### Homebrew (recomendado)
+
+```bash
+brew install rtk
+```
+
+### Instalacion rapida (Linux/macOS)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
+```
+
+### Cargo
+
+```bash
+cargo install --git https://github.com/rtk-ai/rtk
+```
+
+### Verificacion
+
+```bash
+rtk --version   # Debe mostrar "rtk 0.27.x"
+rtk gain        # Debe mostrar estadisticas de ahorro
+```
+
+## Inicio rapido
+
+```bash
+# 1. Instalar hook para Claude Code (recomendado)
+rtk init --global
+
+# 2. Reiniciar Claude Code, luego probar
+git status  # Automaticamente reescrito a rtk git status
+```
+
+## Como funciona
+
+```
+  Sin rtk:                                         Con rtk:
+
+  Claude  --git status-->  shell  -->  git          Claude  --git status-->  RTK  -->  git
+    ^                                   |             ^                      |          |
+    |        ~2,000 tokens (crudo)      |             |   ~200 tokens        | filtro   |
+    +-----------------------------------+             +------- (filtrado) ---+----------+
+```
+
+Cuatro estrategias:
+
+1. **Filtrado inteligente** - Elimina ruido (comentarios, espacios, boilerplate)
+2. **Agrupacion** - Agrega elementos similares (archivos por directorio, errores por tipo)
+3. **Truncamiento** - Mantiene contexto relevante, elimina redundancia
+4. **Deduplicacion** - Colapsa lineas de log repetidas con contadores
+
+## Comandos
+
+### Archivos
+```bash
+rtk ls .                        # Arbol de directorios optimizado
+rtk read file.rs                # Lectura inteligente
+rtk find "*.rs" .               # Resultados compactos
+rtk grep "pattern" .            # Busqueda agrupada por archivo
+```
+
+### Git
+```bash
+rtk git status                  # Estado compacto
+rtk git log -n 10               # Commits en una linea
+rtk git diff                    # Diff condensado
+rtk git push                    # -> "ok main"
+```
+
+### Tests
+```bash
+rtk test cargo test             # Solo fallos (-90%)
+rtk vitest run                  # Vitest compacto
+rtk pytest                      # Tests Python (-90%)
+rtk go test                     # Tests Go (-90%)
+```
+
+### Build & Lint
+```bash
+rtk lint                        # ESLint agrupado por regla
+rtk tsc                         # Errores TypeScript agrupados
+rtk cargo build                 # Build Cargo (-80%)
+rtk ruff check                  # Lint Python (-80%)
+```
+
+### Analiticas
+```bash
+rtk gain                        # Estadisticas de ahorro
+rtk gain --graph                # Grafico ASCII (30 dias)
+rtk discover                    # Descubrir ahorros perdidos
+```
+
+## Documentacion
+
+- **[TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)** - Resolver problemas comunes
+- **[INSTALL.md](INSTALL.md)** - Guia de instalacion detallada
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** - Arquitectura tecnica
+
+## Contribuir
+
+Las contribuciones son bienvenidas. Abre un issue o PR en [GitHub](https://github.com/rtk-ai/rtk).
+
+Unete a la comunidad en [Discord](https://discord.gg/pvHdzAec).
+
+## Licencia
+
+Licencia MIT - ver [LICENSE](LICENSE) para detalles.

--- a/README_es.md
+++ b/README_es.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://www.rtk-ai.app/og-image.png" alt="RTK - Rust Token Killer" width="500">
+  <img src="https://avatars.githubusercontent.com/u/258253854?v=4" alt="RTK - Rust Token Killer" width="500">
 </p>
 
 <p align="center">

--- a/README_fr.md
+++ b/README_fr.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://www.rtk-ai.app/og-image.png" alt="RTK - Rust Token Killer" width="500">
+  <img src="https://avatars.githubusercontent.com/u/258253854?v=4" alt="RTK - Rust Token Killer" width="500">
 </p>
 
 <p align="center">

--- a/README_fr.md
+++ b/README_fr.md
@@ -1,0 +1,197 @@
+<p align="center">
+  <img src="https://www.rtk-ai.app/og-image.png" alt="RTK - Rust Token Killer" width="500">
+</p>
+
+<p align="center">
+  <strong>Proxy CLI haute performance qui reduit la consommation de tokens LLM de 60-90%</strong>
+</p>
+
+<p align="center">
+  <a href="https://github.com/rtk-ai/rtk/actions"><img src="https://github.com/rtk-ai/rtk/workflows/Security%20Check/badge.svg" alt="CI"></a>
+  <a href="https://github.com/rtk-ai/rtk/releases"><img src="https://img.shields.io/github/v/release/rtk-ai/rtk" alt="Release"></a>
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
+  <a href="https://discord.gg/pvHdzAec"><img src="https://img.shields.io/discord/1470188214710046894?label=Discord&logo=discord" alt="Discord"></a>
+  <a href="https://formulae.brew.sh/formula/rtk"><img src="https://img.shields.io/homebrew/v/rtk" alt="Homebrew"></a>
+</p>
+
+<p align="center">
+  <a href="https://www.rtk-ai.app">Site web</a> &bull;
+  <a href="#installation">Installer</a> &bull;
+  <a href="docs/TROUBLESHOOTING.md">Depannage</a> &bull;
+  <a href="ARCHITECTURE.md">Architecture</a> &bull;
+  <a href="https://discord.gg/pvHdzAec">Discord</a>
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> &bull;
+  <a href="README_fr.md">Francais</a> &bull;
+  <a href="README_zh.md">中文</a> &bull;
+  <a href="README_ja.md">日本語</a> &bull;
+  <a href="README_ko.md">한국어</a> &bull;
+  <a href="README_es.md">Espanol</a>
+</p>
+
+---
+
+rtk filtre et compresse les sorties de commandes avant qu'elles n'atteignent le contexte de votre LLM. Binaire Rust unique, zero dependance, <10ms d'overhead.
+
+## Economies de tokens (session Claude Code de 30 min)
+
+| Operation | Frequence | Standard | rtk | Economies |
+|-----------|-----------|----------|-----|-----------|
+| `ls` / `tree` | 10x | 2 000 | 400 | -80% |
+| `cat` / `read` | 20x | 40 000 | 12 000 | -70% |
+| `grep` / `rg` | 8x | 16 000 | 3 200 | -80% |
+| `git status` | 10x | 3 000 | 600 | -80% |
+| `git diff` | 5x | 10 000 | 2 500 | -75% |
+| `git log` | 5x | 2 500 | 500 | -80% |
+| `git add/commit/push` | 8x | 1 600 | 120 | -92% |
+| `cargo test` / `npm test` | 5x | 25 000 | 2 500 | -90% |
+| **Total** | | **~118 000** | **~23 900** | **-80%** |
+
+> Estimations basees sur des projets TypeScript/Rust de taille moyenne.
+
+## Installation
+
+### Homebrew (recommande)
+
+```bash
+brew install rtk
+```
+
+### Installation rapide (Linux/macOS)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
+```
+
+### Cargo
+
+```bash
+cargo install --git https://github.com/rtk-ai/rtk
+```
+
+### Verification
+
+```bash
+rtk --version   # Doit afficher "rtk 0.27.x"
+rtk gain        # Doit afficher les statistiques d'economies
+```
+
+> **Attention** : Un autre projet "rtk" (Rust Type Kit) existe sur crates.io. Si `rtk gain` echoue, vous avez le mauvais package.
+
+## Demarrage rapide
+
+```bash
+# 1. Installer le hook pour Claude Code (recommande)
+rtk init --global
+# Suivre les instructions pour enregistrer dans ~/.claude/settings.json
+
+# 2. Redemarrer Claude Code, puis tester
+git status  # Automatiquement reecrit en rtk git status
+```
+
+Le hook reecrit de maniere transparente les commandes (ex: `git status` -> `rtk git status`) avant execution.
+
+## Comment ca marche
+
+```
+  Sans rtk :                                       Avec rtk :
+
+  Claude  --git status-->  shell  -->  git          Claude  --git status-->  RTK  -->  git
+    ^                                   |             ^                      |          |
+    |        ~2 000 tokens (brut)       |             |   ~200 tokens        | filtre   |
+    +-----------------------------------+             +------- (filtre) -----+----------+
+```
+
+Quatre strategies appliquees par type de commande :
+
+1. **Filtrage intelligent** - Supprime le bruit (commentaires, espaces, boilerplate)
+2. **Regroupement** - Agregat d'elements similaires (fichiers par dossier, erreurs par type)
+3. **Troncature** - Conserve le contexte pertinent, coupe la redondance
+4. **Deduplication** - Fusionne les lignes de log repetees avec compteurs
+
+## Commandes
+
+### Fichiers
+```bash
+rtk ls .                        # Arbre de repertoires optimise
+rtk read file.rs                # Lecture intelligente
+rtk read file.rs -l aggressive  # Signatures uniquement
+rtk find "*.rs" .               # Resultats compacts
+rtk grep "pattern" .            # Resultats groupes par fichier
+rtk diff file1 file2            # Diff condense
+```
+
+### Git
+```bash
+rtk git status                  # Status compact
+rtk git log -n 10               # Commits sur une ligne
+rtk git diff                    # Diff condense
+rtk git add                     # -> "ok"
+rtk git commit -m "msg"         # -> "ok abc1234"
+rtk git push                    # -> "ok main"
+```
+
+### Tests
+```bash
+rtk test cargo test             # Echecs uniquement (-90%)
+rtk vitest run                  # Vitest compact
+rtk pytest                      # Tests Python (-90%)
+rtk go test                     # Tests Go (-90%)
+rtk cargo test                  # Tests Cargo (-90%)
+```
+
+### Build & Lint
+```bash
+rtk lint                        # ESLint groupe par regle
+rtk tsc                         # Erreurs TypeScript groupees
+rtk cargo build                 # Build Cargo (-80%)
+rtk cargo clippy                # Clippy (-80%)
+rtk ruff check                  # Linting Python (-80%)
+```
+
+### Conteneurs
+```bash
+rtk docker ps                   # Liste compacte
+rtk docker logs <container>     # Logs dedupliques
+rtk kubectl pods                # Pods compacts
+```
+
+### Analytics
+```bash
+rtk gain                        # Statistiques d'economies
+rtk gain --graph                # Graphique ASCII (30 jours)
+rtk discover                    # Trouver les economies manquees
+```
+
+## Configuration
+
+```toml
+# ~/.config/rtk/config.toml
+[tracking]
+database_path = "/chemin/custom.db"
+
+[hooks]
+exclude_commands = ["curl", "playwright"]
+
+[tee]
+enabled = true
+mode = "failures"
+```
+
+## Documentation
+
+- **[TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)** - Resoudre les problemes courants
+- **[INSTALL.md](INSTALL.md)** - Guide d'installation detaille
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** - Architecture technique
+
+## Contribuer
+
+Les contributions sont les bienvenues ! Ouvrez une issue ou une PR sur [GitHub](https://github.com/rtk-ai/rtk).
+
+Rejoignez la communaute sur [Discord](https://discord.gg/pvHdzAec).
+
+## Licence
+
+Licence MIT - voir [LICENSE](LICENSE) pour les details.

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,0 +1,159 @@
+<p align="center">
+  <img src="https://www.rtk-ai.app/og-image.png" alt="RTK - Rust Token Killer" width="500">
+</p>
+
+<p align="center">
+  <strong>LLM トークン消費を 60-90% 削減する高性能 CLI プロキシ</strong>
+</p>
+
+<p align="center">
+  <a href="https://github.com/rtk-ai/rtk/actions"><img src="https://github.com/rtk-ai/rtk/workflows/Security%20Check/badge.svg" alt="CI"></a>
+  <a href="https://github.com/rtk-ai/rtk/releases"><img src="https://img.shields.io/github/v/release/rtk-ai/rtk" alt="Release"></a>
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
+  <a href="https://discord.gg/pvHdzAec"><img src="https://img.shields.io/discord/1470188214710046894?label=Discord&logo=discord" alt="Discord"></a>
+  <a href="https://formulae.brew.sh/formula/rtk"><img src="https://img.shields.io/homebrew/v/rtk" alt="Homebrew"></a>
+</p>
+
+<p align="center">
+  <a href="https://www.rtk-ai.app">ウェブサイト</a> &bull;
+  <a href="#インストール">インストール</a> &bull;
+  <a href="docs/TROUBLESHOOTING.md">トラブルシューティング</a> &bull;
+  <a href="ARCHITECTURE.md">アーキテクチャ</a> &bull;
+  <a href="https://discord.gg/pvHdzAec">Discord</a>
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> &bull;
+  <a href="README_fr.md">Francais</a> &bull;
+  <a href="README_zh.md">中文</a> &bull;
+  <a href="README_ja.md">日本語</a> &bull;
+  <a href="README_ko.md">한국어</a> &bull;
+  <a href="README_es.md">Espanol</a>
+</p>
+
+---
+
+rtk はコマンド出力を LLM コンテキストに届く前にフィルタリング・圧縮します。単一の Rust バイナリ、依存関係ゼロ、オーバーヘッド 10ms 未満。
+
+## トークン節約（30分の Claude Code セッション）
+
+| 操作 | 頻度 | 標準 | rtk | 節約 |
+|------|------|------|-----|------|
+| `ls` / `tree` | 10x | 2,000 | 400 | -80% |
+| `cat` / `read` | 20x | 40,000 | 12,000 | -70% |
+| `grep` / `rg` | 8x | 16,000 | 3,200 | -80% |
+| `git status` | 10x | 3,000 | 600 | -80% |
+| `cargo test` / `npm test` | 5x | 25,000 | 2,500 | -90% |
+| **合計** | | **~118,000** | **~23,900** | **-80%** |
+
+## インストール
+
+### Homebrew（推奨）
+
+```bash
+brew install rtk
+```
+
+### クイックインストール（Linux/macOS）
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
+```
+
+### Cargo
+
+```bash
+cargo install --git https://github.com/rtk-ai/rtk
+```
+
+### 確認
+
+```bash
+rtk --version   # "rtk 0.27.x" と表示されるはず
+rtk gain        # トークン節約統計が表示されるはず
+```
+
+## クイックスタート
+
+```bash
+# 1. Claude Code 用フックをインストール（推奨）
+rtk init --global
+
+# 2. Claude Code を再起動してテスト
+git status  # 自動的に rtk git status に書き換え
+```
+
+## 仕組み
+
+```
+  rtk なし：                                       rtk あり：
+
+  Claude  --git status-->  shell  -->  git          Claude  --git status-->  RTK  -->  git
+    ^                                   |             ^                      |          |
+    |        ~2,000 tokens（生出力）     |             |   ~200 tokens        | フィルタ |
+    +-----------------------------------+             +------- （圧縮済）----+----------+
+```
+
+4つの戦略：
+
+1. **スマートフィルタリング** - ノイズを除去（コメント、空白、ボイラープレート）
+2. **グルーピング** - 類似項目を集約（ディレクトリ別ファイル、タイプ別エラー）
+3. **トランケーション** - 関連コンテキストを保持、冗長性をカット
+4. **重複排除** - 繰り返しログ行をカウント付きで統合
+
+## コマンド
+
+### ファイル
+```bash
+rtk ls .                        # 最適化されたディレクトリツリー
+rtk read file.rs                # スマートファイル読み取り
+rtk find "*.rs" .               # コンパクトな検索結果
+rtk grep "pattern" .            # ファイル別グループ化検索
+```
+
+### Git
+```bash
+rtk git status                  # コンパクトなステータス
+rtk git log -n 10               # 1行コミット
+rtk git diff                    # 圧縮された diff
+rtk git push                    # -> "ok main"
+```
+
+### テスト
+```bash
+rtk test cargo test             # 失敗のみ表示（-90%）
+rtk vitest run                  # Vitest コンパクト
+rtk pytest                      # Python テスト（-90%）
+rtk go test                     # Go テスト（-90%）
+```
+
+### ビルド & リント
+```bash
+rtk lint                        # ESLint ルール別グループ化
+rtk tsc                         # TypeScript エラーグループ化
+rtk cargo build                 # Cargo ビルド（-80%）
+rtk ruff check                  # Python リント（-80%）
+```
+
+### 分析
+```bash
+rtk gain                        # 節約統計
+rtk gain --graph                # ASCII グラフ（30日間）
+rtk discover                    # 見逃した節約機会を発見
+```
+
+## ドキュメント
+
+- **[TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)** - よくある問題の解決
+- **[INSTALL.md](INSTALL.md)** - 詳細インストールガイド
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** - 技術アーキテクチャ
+
+## コントリビュート
+
+コントリビューション歓迎！[GitHub](https://github.com/rtk-ai/rtk) で issue または PR を作成してください。
+
+[Discord](https://discord.gg/pvHdzAec) コミュニティに参加。
+
+## ライセンス
+
+MIT ライセンス - 詳細は [LICENSE](LICENSE) を参照。

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://www.rtk-ai.app/og-image.png" alt="RTK - Rust Token Killer" width="500">
+  <img src="https://avatars.githubusercontent.com/u/258253854?v=4" alt="RTK - Rust Token Killer" width="500">
 </p>
 
 <p align="center">

--- a/README_ko.md
+++ b/README_ko.md
@@ -1,0 +1,159 @@
+<p align="center">
+  <img src="https://www.rtk-ai.app/og-image.png" alt="RTK - Rust Token Killer" width="500">
+</p>
+
+<p align="center">
+  <strong>LLM 토큰 소비를 60-90% 줄이는 고성능 CLI 프록시</strong>
+</p>
+
+<p align="center">
+  <a href="https://github.com/rtk-ai/rtk/actions"><img src="https://github.com/rtk-ai/rtk/workflows/Security%20Check/badge.svg" alt="CI"></a>
+  <a href="https://github.com/rtk-ai/rtk/releases"><img src="https://img.shields.io/github/v/release/rtk-ai/rtk" alt="Release"></a>
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
+  <a href="https://discord.gg/pvHdzAec"><img src="https://img.shields.io/discord/1470188214710046894?label=Discord&logo=discord" alt="Discord"></a>
+  <a href="https://formulae.brew.sh/formula/rtk"><img src="https://img.shields.io/homebrew/v/rtk" alt="Homebrew"></a>
+</p>
+
+<p align="center">
+  <a href="https://www.rtk-ai.app">웹사이트</a> &bull;
+  <a href="#설치">설치</a> &bull;
+  <a href="docs/TROUBLESHOOTING.md">문제 해결</a> &bull;
+  <a href="ARCHITECTURE.md">아키텍처</a> &bull;
+  <a href="https://discord.gg/pvHdzAec">Discord</a>
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> &bull;
+  <a href="README_fr.md">Francais</a> &bull;
+  <a href="README_zh.md">中文</a> &bull;
+  <a href="README_ja.md">日本語</a> &bull;
+  <a href="README_ko.md">한국어</a> &bull;
+  <a href="README_es.md">Espanol</a>
+</p>
+
+---
+
+rtk는 명령 출력이 LLM 컨텍스트에 도달하기 전에 필터링하고 압축합니다. 단일 Rust 바이너리, 의존성 없음, 10ms 미만의 오버헤드.
+
+## 토큰 절약 (30분 Claude Code 세션)
+
+| 작업 | 빈도 | 표준 | rtk | 절약 |
+|------|------|------|-----|------|
+| `ls` / `tree` | 10x | 2,000 | 400 | -80% |
+| `cat` / `read` | 20x | 40,000 | 12,000 | -70% |
+| `grep` / `rg` | 8x | 16,000 | 3,200 | -80% |
+| `git status` | 10x | 3,000 | 600 | -80% |
+| `cargo test` / `npm test` | 5x | 25,000 | 2,500 | -90% |
+| **합계** | | **~118,000** | **~23,900** | **-80%** |
+
+## 설치
+
+### Homebrew (권장)
+
+```bash
+brew install rtk
+```
+
+### 빠른 설치 (Linux/macOS)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
+```
+
+### Cargo
+
+```bash
+cargo install --git https://github.com/rtk-ai/rtk
+```
+
+### 확인
+
+```bash
+rtk --version   # "rtk 0.27.x" 표시되어야 함
+rtk gain        # 토큰 절약 통계 표시되어야 함
+```
+
+## 빠른 시작
+
+```bash
+# 1. Claude Code용 hook 설치 (권장)
+rtk init --global
+
+# 2. Claude Code 재시작 후 테스트
+git status  # 자동으로 rtk git status로 재작성
+```
+
+## 작동 원리
+
+```
+  rtk 없이:                                        rtk 사용:
+
+  Claude  --git status-->  shell  -->  git          Claude  --git status-->  RTK  -->  git
+    ^                                   |             ^                      |          |
+    |        ~2,000 tokens (원본)        |             |   ~200 tokens        | 필터     |
+    +-----------------------------------+             +------- (필터링) -----+----------+
+```
+
+네 가지 전략:
+
+1. **스마트 필터링** - 노이즈 제거 (주석, 공백, 보일러플레이트)
+2. **그룹화** - 유사 항목 집계 (디렉토리별 파일, 유형별 에러)
+3. **잘라내기** - 관련 컨텍스트 유지, 중복 제거
+4. **중복 제거** - 반복 로그 라인을 카운트와 함께 통합
+
+## 명령어
+
+### 파일
+```bash
+rtk ls .                        # 최적화된 디렉토리 트리
+rtk read file.rs                # 스마트 파일 읽기
+rtk find "*.rs" .               # 컴팩트한 검색 결과
+rtk grep "pattern" .            # 파일별 그룹화 검색
+```
+
+### Git
+```bash
+rtk git status                  # 컴팩트 상태
+rtk git log -n 10               # 한 줄 커밋
+rtk git diff                    # 압축된 diff
+rtk git push                    # -> "ok main"
+```
+
+### 테스트
+```bash
+rtk test cargo test             # 실패만 표시 (-90%)
+rtk vitest run                  # Vitest 컴팩트
+rtk pytest                      # Python 테스트 (-90%)
+rtk go test                     # Go 테스트 (-90%)
+```
+
+### 빌드 & 린트
+```bash
+rtk lint                        # ESLint 규칙별 그룹화
+rtk tsc                         # TypeScript 에러 그룹화
+rtk cargo build                 # Cargo 빌드 (-80%)
+rtk ruff check                  # Python 린트 (-80%)
+```
+
+### 분석
+```bash
+rtk gain                        # 절약 통계
+rtk gain --graph                # ASCII 그래프 (30일)
+rtk discover                    # 놓친 절약 기회 발견
+```
+
+## 문서
+
+- **[TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)** - 일반적인 문제 해결
+- **[INSTALL.md](INSTALL.md)** - 상세 설치 가이드
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** - 기술 아키텍처
+
+## 기여
+
+기여를 환영합니다! [GitHub](https://github.com/rtk-ai/rtk)에서 issue 또는 PR을 생성해 주세요.
+
+[Discord](https://discord.gg/pvHdzAec) 커뮤니티에 참여하세요.
+
+## 라이선스
+
+MIT 라이선스 - 자세한 내용은 [LICENSE](LICENSE)를 참조하세요.

--- a/README_ko.md
+++ b/README_ko.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://www.rtk-ai.app/og-image.png" alt="RTK - Rust Token Killer" width="500">
+  <img src="https://avatars.githubusercontent.com/u/258253854?v=4" alt="RTK - Rust Token Killer" width="500">
 </p>
 
 <p align="center">

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://www.rtk-ai.app/og-image.png" alt="RTK - Rust Token Killer" width="500">
+  <img src="https://avatars.githubusercontent.com/u/258253854?v=4" alt="RTK - Rust Token Killer" width="500">
 </p>
 
 <p align="center">

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,0 +1,167 @@
+<p align="center">
+  <img src="https://www.rtk-ai.app/og-image.png" alt="RTK - Rust Token Killer" width="500">
+</p>
+
+<p align="center">
+  <strong>高性能 CLI 代理，将 LLM token 消耗降低 60-90%</strong>
+</p>
+
+<p align="center">
+  <a href="https://github.com/rtk-ai/rtk/actions"><img src="https://github.com/rtk-ai/rtk/workflows/Security%20Check/badge.svg" alt="CI"></a>
+  <a href="https://github.com/rtk-ai/rtk/releases"><img src="https://img.shields.io/github/v/release/rtk-ai/rtk" alt="Release"></a>
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
+  <a href="https://discord.gg/pvHdzAec"><img src="https://img.shields.io/discord/1470188214710046894?label=Discord&logo=discord" alt="Discord"></a>
+  <a href="https://formulae.brew.sh/formula/rtk"><img src="https://img.shields.io/homebrew/v/rtk" alt="Homebrew"></a>
+</p>
+
+<p align="center">
+  <a href="https://www.rtk-ai.app">官网</a> &bull;
+  <a href="#安装">安装</a> &bull;
+  <a href="docs/TROUBLESHOOTING.md">故障排除</a> &bull;
+  <a href="ARCHITECTURE.md">架构</a> &bull;
+  <a href="https://discord.gg/pvHdzAec">Discord</a>
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> &bull;
+  <a href="README_fr.md">Francais</a> &bull;
+  <a href="README_zh.md">中文</a> &bull;
+  <a href="README_ja.md">日本語</a> &bull;
+  <a href="README_ko.md">한국어</a> &bull;
+  <a href="README_es.md">Espanol</a>
+</p>
+
+---
+
+rtk 在命令输出到达 LLM 上下文之前进行过滤和压缩。单一 Rust 二进制文件，零依赖，<10ms 开销。
+
+## Token 节省（30 分钟 Claude Code 会话）
+
+| 操作 | 频率 | 标准 | rtk | 节省 |
+|------|------|------|-----|------|
+| `ls` / `tree` | 10x | 2,000 | 400 | -80% |
+| `cat` / `read` | 20x | 40,000 | 12,000 | -70% |
+| `grep` / `rg` | 8x | 16,000 | 3,200 | -80% |
+| `git status` | 10x | 3,000 | 600 | -80% |
+| `git diff` | 5x | 10,000 | 2,500 | -75% |
+| `cargo test` / `npm test` | 5x | 25,000 | 2,500 | -90% |
+| **总计** | | **~118,000** | **~23,900** | **-80%** |
+
+## 安装
+
+### Homebrew（推荐）
+
+```bash
+brew install rtk
+```
+
+### 快速安装（Linux/macOS）
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
+```
+
+### Cargo
+
+```bash
+cargo install --git https://github.com/rtk-ai/rtk
+```
+
+### 验证
+
+```bash
+rtk --version   # 应显示 "rtk 0.27.x"
+rtk gain        # 应显示 token 节省统计
+```
+
+## 快速开始
+
+```bash
+# 1. 为 Claude Code 安装 hook（推荐）
+rtk init --global
+
+# 2. 重启 Claude Code，然后测试
+git status  # 自动重写为 rtk git status
+```
+
+## 工作原理
+
+```
+  没有 rtk：                                      使用 rtk：
+
+  Claude  --git status-->  shell  -->  git         Claude  --git status-->  RTK  -->  git
+    ^                                   |            ^                      |          |
+    |        ~2,000 tokens（原始）       |            |   ~200 tokens        | 过滤     |
+    +-----------------------------------+            +------- （已过滤）-----+----------+
+```
+
+四种策略：
+
+1. **智能过滤** - 去除噪音（注释、空白、样板代码）
+2. **分组** - 聚合相似项（按目录分文件，按类型分错误）
+3. **截断** - 保留相关上下文，删除冗余
+4. **去重** - 合并重复日志行并计数
+
+## 命令
+
+### 文件
+```bash
+rtk ls .                        # 优化的目录树
+rtk read file.rs                # 智能文件读取
+rtk find "*.rs" .               # 紧凑的查找结果
+rtk grep "pattern" .            # 按文件分组的搜索结果
+```
+
+### Git
+```bash
+rtk git status                  # 紧凑状态
+rtk git log -n 10               # 单行提交
+rtk git diff                    # 精简 diff
+rtk git push                    # -> "ok main"
+```
+
+### 测试
+```bash
+rtk test cargo test             # 仅显示失败（-90%）
+rtk vitest run                  # Vitest 紧凑输出
+rtk pytest                      # Python 测试（-90%）
+rtk go test                     # Go 测试（-90%）
+```
+
+### 构建 & 检查
+```bash
+rtk lint                        # ESLint 按规则分组
+rtk tsc                         # TypeScript 错误分组
+rtk cargo build                 # Cargo 构建（-80%）
+rtk ruff check                  # Python lint（-80%）
+```
+
+### 容器
+```bash
+rtk docker ps                   # 紧凑容器列表
+rtk docker logs <container>     # 去重日志
+rtk kubectl pods                # 紧凑 Pod 列表
+```
+
+### 分析
+```bash
+rtk gain                        # 节省统计
+rtk gain --graph                # ASCII 图表（30 天）
+rtk discover                    # 发现遗漏的节省机会
+```
+
+## 文档
+
+- **[TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)** - 解决常见问题
+- **[INSTALL.md](INSTALL.md)** - 详细安装指南
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** - 技术架构
+
+## 贡献
+
+欢迎贡献！请在 [GitHub](https://github.com/rtk-ai/rtk) 上提交 issue 或 PR。
+
+加入 [Discord](https://discord.gg/pvHdzAec) 社区。
+
+## 许可证
+
+MIT 许可证 - 详见 [LICENSE](LICENSE)。


### PR DESCRIPTION
## Summary
- Centered org logo + tagline at top
- Badges: CI status, release version, MIT license, Discord, Homebrew
- Language selector with translated READMEs (fr, zh, ja, ko, es)
- Homebrew as primary install method
- Fix Linux binary filename `gnu` -> `musl` (fixes #323)
- Discord invite link added
- Simplified from 871 to ~360 lines — verbose sections moved to dedicated docs

## Changes
- Removed duplicate installation/troubleshooting sections (linked to docs instead)
- Removed maintainer security review section (linked to SECURITY.md)
- Reorganized commands by category (files, git, test, build, containers, analytics)
- Cleaner examples section
- Added 5 translated READMEs (fr, zh, ja, ko, es)

Fixes #323