### PR TITLE
 feat(init): add Codex CLI support via AGENTS.md + RTK.md workflow

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -297,8 +297,8 @@ SHARED            utils.rs          Helpers                N/A        ✓
 
 ### Module Count Breakdown
 
-- **Command Modules**: 34 (directly exposed to users)
-- **Infrastructure Modules**: 20 (utils, filter, tracking, tee, config, init, gain, toml_filter, verify_cmd, etc.)
+- **Command Modules**: 44 (directly exposed to users)
+- **Infrastructure Modules**: 22 (utils, filter, tracking, tee, config, init, gain, toml_filter, verify_cmd, trust, etc.)
 - **Git Commands**: 7 operations (status, diff, log, add, commit, push, branch/checkout)
 - **JS/TS Tooling**: 8 modules (modern frontend/fullstack development)
 - **Python Tooling**: 3 modules (ruff, pytest, pip)

--- a/hooks/rtk-awareness-codex.md
+++ b/hooks/rtk-awareness-codex.md
@@ -1,0 +1,32 @@
+# RTK - Rust Token Killer (Codex CLI)
+
+**Usage**: Token-optimized CLI proxy for shell commands.
+
+## Rule
+
+Always prefix shell commands with `rtk`.
+
+Examples:
+
+```bash
+rtk git status
+rtk cargo test
+rtk npm run build
+rtk pytest -q
+```
+
+## Meta Commands
+
+```bash
+rtk gain            # Token savings analytics
+rtk gain --history  # Recent command savings history
+rtk proxy <cmd>     # Run raw command without filtering
+```
+
+## Verification
+
+```bash
+rtk --version
+rtk gain
+which rtk
+```

--- a/src/init.rs
+++ b/src/init.rs
@@ -14,6 +14,7 @@ const OPENCODE_PLUGIN: &str = include_str!("../hooks/opencode-rtk.ts");
 
 // Embedded slim RTK awareness instructions
 const RTK_SLIM: &str = include_str!("../hooks/rtk-awareness.md");
+const RTK_SLIM_CODEX: &str = include_str!("../hooks/rtk-awareness-codex.md");
 
 /// Template written by `rtk init` when no filters.toml exists yet.
 const FILTERS_TEMPLATE: &str = r#"# Project-local RTK filters — commit this file with your repo.
@@ -206,20 +207,41 @@ pub fn run(
     install_opencode: bool,
     claude_md: bool,
     hook_only: bool,
+    codex: bool,
     patch_mode: PatchMode,
     verbose: u8,
 ) -> Result<()> {
-    if install_opencode && !global {
-        anyhow::bail!("OpenCode plugin is global-only. Use: rtk init -g --opencode");
-    }
-
-    // Mode selection
-    match (install_claude, install_opencode, claude_md, hook_only) {
-        (false, true, _, _) => run_opencode_only_mode(verbose),
-        (true, opencode, true, _) => run_claude_md_mode(global, verbose, opencode),
-        (true, opencode, false, true) => run_hook_only_mode(global, patch_mode, verbose, opencode),
-        (true, opencode, false, false) => run_default_mode(global, patch_mode, verbose, opencode),
-        (false, false, _, _) => {
+    match (
+        codex,
+        install_claude,
+        install_opencode,
+        global,
+        claude_md,
+        hook_only,
+        patch_mode,
+    ) {
+        (true, _, true, _, _, _, _) => anyhow::bail!("--codex cannot be combined with --opencode"),
+        (true, _, _, _, true, _, _) => anyhow::bail!("--codex cannot be combined with --claude-md"),
+        (true, _, _, _, _, true, _) => anyhow::bail!("--codex cannot be combined with --hook-only"),
+        (true, _, _, _, _, _, PatchMode::Auto) => {
+            anyhow::bail!("--codex cannot be combined with --auto-patch")
+        }
+        (true, _, _, _, _, _, PatchMode::Skip) => {
+            anyhow::bail!("--codex cannot be combined with --no-patch")
+        }
+        (true, _, _, _, _, _, PatchMode::Ask) => run_codex_mode(global, verbose),
+        (false, _, true, false, _, _, _) => {
+            anyhow::bail!("OpenCode plugin is global-only. Use: rtk init -g --opencode")
+        }
+        (false, false, true, _, _, _, _) => run_opencode_only_mode(verbose),
+        (false, true, opencode, _, true, _, _) => run_claude_md_mode(global, verbose, opencode),
+        (false, true, opencode, _, false, true, _) => {
+            run_hook_only_mode(global, patch_mode, verbose, opencode)
+        }
+        (false, true, opencode, _, false, false, _) => {
+            run_default_mode(global, patch_mode, verbose, opencode)
+        }
+        (false, false, false, _, _, _, _) => {
             anyhow::bail!("at least one of install_claude or install_opencode must be true")
         }
     }
@@ -458,8 +480,11 @@ fn remove_hook_from_settings(verbose: u8) -> Result<bool> {
     Ok(removed)
 }
 
-/// Full uninstall: remove hook, RTK.md, @RTK.md reference, settings.json entry
-pub fn uninstall(global: bool, gemini: bool, verbose: u8) -> Result<()> {
+/// Full uninstall for Claude, Gemini, or Codex artifacts.
+pub fn uninstall(global: bool, gemini: bool, codex: bool, verbose: u8) -> Result<()> {
+    if codex {
+        return uninstall_codex(global, verbose);
+    }
     if !global {
         anyhow::bail!("Uninstall only works with --global flag. For local projects, manually remove RTK from CLAUDE.md");
     }
@@ -550,6 +575,49 @@ pub fn uninstall(global: bool, gemini: bool, verbose: u8) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn uninstall_codex(global: bool, verbose: u8) -> Result<()> {
+    if !global {
+        anyhow::bail!(
+            "Uninstall only works with --global flag. For local projects, manually remove RTK from AGENTS.md"
+        );
+    }
+
+    let codex_dir = resolve_codex_dir()?;
+    let removed = uninstall_codex_at(&codex_dir, verbose)?;
+
+    if removed.is_empty() {
+        println!("RTK was not installed for Codex CLI (nothing to remove)");
+    } else {
+        println!("RTK uninstalled for Codex CLI:");
+        for item in removed {
+            println!("  - {}", item);
+        }
+    }
+
+    Ok(())
+}
+
+fn uninstall_codex_at(codex_dir: &Path, verbose: u8) -> Result<Vec<String>> {
+    let mut removed = Vec::new();
+
+    let rtk_md_path = codex_dir.join("RTK.md");
+    if rtk_md_path.exists() {
+        fs::remove_file(&rtk_md_path)
+            .with_context(|| format!("Failed to remove RTK.md: {}", rtk_md_path.display()))?;
+        if verbose > 0 {
+            eprintln!("Removed RTK.md: {}", rtk_md_path.display());
+        }
+        removed.push(format!("RTK.md: {}", rtk_md_path.display()));
+    }
+
+    let agents_md_path = codex_dir.join("AGENTS.md");
+    if remove_rtk_reference_from_agents(&agents_md_path, verbose)? {
+        removed.push("AGENTS.md: removed @RTK.md reference".to_string());
+    }
+
+    Ok(removed)
 }
 
 /// Orchestrator: patch settings.json with RTK hook
@@ -1037,6 +1105,51 @@ fn run_claude_md_mode(global: bool, verbose: u8, install_opencode: bool) -> Resu
     Ok(())
 }
 
+/// Codex mode: slim RTK.md + @RTK.md reference in AGENTS.md
+fn run_codex_mode(global: bool, verbose: u8) -> Result<()> {
+    let (agents_md_path, rtk_md_path) = if global {
+        let codex_dir = resolve_codex_dir()?;
+        (codex_dir.join("AGENTS.md"), codex_dir.join("RTK.md"))
+    } else {
+        (PathBuf::from("AGENTS.md"), PathBuf::from("RTK.md"))
+    };
+
+    if global {
+        if let Some(parent) = agents_md_path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "Failed to create Codex config directory: {}",
+                    parent.display()
+                )
+            })?;
+        }
+    }
+
+    write_if_changed(&rtk_md_path, RTK_SLIM_CODEX, "RTK.md", verbose)?;
+    let added_ref = patch_agents_md(&agents_md_path, verbose)?;
+
+    println!("\nRTK configured for Codex CLI.\n");
+    println!("  RTK.md:    {}", rtk_md_path.display());
+    if added_ref {
+        println!("  AGENTS.md: @RTK.md reference added");
+    } else {
+        println!("  AGENTS.md: @RTK.md reference already present");
+    }
+    if global {
+        println!(
+            "\n  Codex global instructions path: {}",
+            agents_md_path.display()
+        );
+    } else {
+        println!(
+            "\n  Codex project instructions path: {}",
+            agents_md_path.display()
+        );
+    }
+
+    Ok(())
+}
+
 // --- upsert_rtk_block: idempotent RTK block management ---
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -1149,6 +1262,83 @@ fn patch_claude_md(path: &Path, verbose: u8) -> Result<bool> {
     Ok(migrated)
 }
 
+/// Patch AGENTS.md: add @RTK.md, migrate old inline block if present
+fn patch_agents_md(path: &Path, verbose: u8) -> Result<bool> {
+    let mut content = if path.exists() {
+        fs::read_to_string(path)
+            .with_context(|| format!("Failed to read AGENTS.md: {}", path.display()))?
+    } else {
+        String::new()
+    };
+
+    let mut migrated = false;
+    if content.contains("<!-- rtk-instructions") {
+        let (new_content, did_migrate) = remove_rtk_block(&content);
+        if did_migrate {
+            content = new_content;
+            migrated = true;
+            if verbose > 0 {
+                eprintln!("Migrated: removed old RTK block from AGENTS.md");
+            }
+        }
+    }
+
+    if content.contains("@RTK.md") {
+        if verbose > 0 {
+            eprintln!("@RTK.md reference already present in AGENTS.md");
+        }
+        if migrated {
+            atomic_write(path, &content)
+                .with_context(|| format!("Failed to write AGENTS.md: {}", path.display()))?;
+        }
+        return Ok(false);
+    }
+
+    let new_content = if content.is_empty() {
+        "@RTK.md\n".to_string()
+    } else {
+        format!("{}\n\n@RTK.md\n", content.trim())
+    };
+
+    atomic_write(path, &new_content)
+        .with_context(|| format!("Failed to write AGENTS.md: {}", path.display()))?;
+    if verbose > 0 {
+        eprintln!("Added @RTK.md reference to AGENTS.md");
+    }
+
+    Ok(true)
+}
+
+fn remove_rtk_reference_from_agents(path: &Path, verbose: u8) -> Result<bool> {
+    if !path.exists() {
+        return Ok(false);
+    }
+
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read AGENTS.md: {}", path.display()))?;
+    if !content.contains("@RTK.md") {
+        return Ok(false);
+    }
+
+    let new_content = content
+        .lines()
+        .filter(|line| !line.trim().starts_with("@RTK.md"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let cleaned = clean_double_blanks(&new_content);
+    atomic_write(path, &cleaned)
+        .with_context(|| format!("Failed to write AGENTS.md: {}", path.display()))?;
+
+    if verbose > 0 {
+        eprintln!(
+            "Removed @RTK.md reference from AGENTS.md: {}",
+            path.display()
+        );
+    }
+
+    Ok(true)
+}
+
 /// Remove old RTK block from CLAUDE.md (migration helper)
 fn remove_rtk_block(content: &str) -> (String, bool) {
     if let (Some(start), Some(end)) = (
@@ -1194,6 +1384,12 @@ fn resolve_claude_dir() -> Result<PathBuf> {
         .context("Cannot determine home directory. Is $HOME set?")
 }
 
+/// Resolve ~/.codex directory with proper home expansion
+fn resolve_codex_dir() -> Result<PathBuf> {
+    dirs::home_dir()
+        .map(|h| h.join(".codex"))
+        .context("Cannot determine home directory. Is $HOME set?")
+}
 /// Resolve OpenCode config directory (~/.config/opencode)
 /// OpenCode uses ~/.config/opencode on all platforms (XDG convention),
 /// NOT the macOS-native ~/Library/Application Support/.
@@ -1245,9 +1441,16 @@ fn remove_opencode_plugin(verbose: u8) -> Result<Vec<PathBuf>> {
 
     Ok(removed)
 }
-
 /// Show current rtk configuration
-pub fn show_config() -> Result<()> {
+pub fn show_config(codex: bool) -> Result<()> {
+    if codex {
+        return show_codex_config();
+    }
+
+    show_claude_config()
+}
+
+fn show_claude_config() -> Result<()> {
     let claude_dir = resolve_claude_dir()?;
     let hook_path = claude_dir.join("hooks").join("rtk-rewrite.sh");
     let rtk_md_path = claude_dir.join("RTK.md");
@@ -1404,7 +1607,64 @@ pub fn show_config() -> Result<()> {
     println!("  rtk init -g --uninstall     # Remove all RTK artifacts");
     println!("  rtk init -g --claude-md     # Legacy: full injection into ~/.claude/CLAUDE.md");
     println!("  rtk init -g --hook-only     # Hook only, no RTK.md");
+    println!("  rtk init --codex            # Configure local AGENTS.md + RTK.md");
+    println!("  rtk init -g --codex         # Configure ~/.codex/AGENTS.md + ~/.codex/RTK.md");
     println!("  rtk init -g --opencode      # OpenCode plugin only");
+
+    Ok(())
+}
+
+fn show_codex_config() -> Result<()> {
+    let codex_dir = resolve_codex_dir()?;
+    let global_agents_md = codex_dir.join("AGENTS.md");
+    let global_rtk_md = codex_dir.join("RTK.md");
+    let local_agents_md = PathBuf::from("AGENTS.md");
+    let local_rtk_md = PathBuf::from("RTK.md");
+
+    println!("rtk Configuration (Codex CLI):\n");
+
+    if global_rtk_md.exists() {
+        println!("[ok] Global RTK.md: {}", global_rtk_md.display());
+    } else {
+        println!("[--] Global RTK.md: not found");
+    }
+
+    if global_agents_md.exists() {
+        let content = fs::read_to_string(&global_agents_md)?;
+        if content.contains("@RTK.md") {
+            println!("[ok] Global AGENTS.md: @RTK.md reference");
+        } else if content.contains("<!-- rtk-instructions") {
+            println!("[!!] Global AGENTS.md: old inline RTK block");
+        } else {
+            println!("[--] Global AGENTS.md: exists but rtk not configured");
+        }
+    } else {
+        println!("[--] Global AGENTS.md: not found");
+    }
+
+    if local_rtk_md.exists() {
+        println!("[ok] Local RTK.md: {}", local_rtk_md.display());
+    } else {
+        println!("[--] Local RTK.md: not found");
+    }
+
+    if local_agents_md.exists() {
+        let content = fs::read_to_string(&local_agents_md)?;
+        if content.contains("@RTK.md") {
+            println!("[ok] Local AGENTS.md: @RTK.md reference");
+        } else if content.contains("<!-- rtk-instructions") {
+            println!("[!!] Local AGENTS.md: old inline RTK block");
+        } else {
+            println!("[--] Local AGENTS.md: exists but rtk not configured");
+        }
+    } else {
+        println!("[--] Local AGENTS.md: not found");
+    }
+
+    println!("\nUsage:");
+    println!("  rtk init --codex              # Configure local AGENTS.md + RTK.md");
+    println!("  rtk init -g --codex           # Configure ~/.codex/AGENTS.md + ~/.codex/RTK.md");
+    println!("  rtk init -g --codex --uninstall  # Remove global Codex RTK artifacts");
 
     Ok(())
 }
@@ -1830,6 +2090,92 @@ More notes
         let content = fs::read_to_string(&claude_md).unwrap();
         let count = content.matches("@RTK.md").count();
         assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_patch_agents_md_adds_reference_once() {
+        let temp = TempDir::new().unwrap();
+        let agents_md = temp.path().join("AGENTS.md");
+
+        fs::write(&agents_md, "# Team rules\n").unwrap();
+        let first_added = patch_agents_md(&agents_md, 0).unwrap();
+        let second_added = patch_agents_md(&agents_md, 0).unwrap();
+
+        assert!(first_added);
+        assert!(!second_added);
+
+        let content = fs::read_to_string(&agents_md).unwrap();
+        assert_eq!(content.matches("@RTK.md").count(), 1);
+    }
+
+    #[test]
+    fn test_codex_mode_rejects_auto_patch() {
+        let err = run(false, false, false, false, false, true, PatchMode::Auto, 0).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "--codex cannot be combined with --auto-patch"
+        );
+    }
+
+    #[test]
+    fn test_codex_mode_rejects_no_patch() {
+        let err = run(false, false, false, false, false, true, PatchMode::Skip, 0).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "--codex cannot be combined with --no-patch"
+        );
+    }
+
+    #[test]
+    fn test_patch_agents_md_creates_missing_file() {
+        let temp = TempDir::new().unwrap();
+        let agents_md = temp.path().join("AGENTS.md");
+
+        let added = patch_agents_md(&agents_md, 0).unwrap();
+
+        assert!(added);
+        let content = fs::read_to_string(&agents_md).unwrap();
+        assert_eq!(content, "@RTK.md\n");
+    }
+
+    #[test]
+    fn test_patch_agents_md_migrates_inline_block() {
+        let temp = TempDir::new().unwrap();
+        let agents_md = temp.path().join("AGENTS.md");
+        fs::write(
+            &agents_md,
+            "# Team rules\n\n<!-- rtk-instructions v2 -->\nold\n<!-- /rtk-instructions -->\n",
+        )
+        .unwrap();
+
+        let added = patch_agents_md(&agents_md, 0).unwrap();
+
+        assert!(added);
+        let content = fs::read_to_string(&agents_md).unwrap();
+        assert!(!content.contains("old"));
+        assert_eq!(content.matches("@RTK.md").count(), 1);
+    }
+
+    #[test]
+    fn test_uninstall_codex_at_is_idempotent() {
+        let temp = TempDir::new().unwrap();
+        let codex_dir = temp.path();
+        let agents_md = codex_dir.join("AGENTS.md");
+        let rtk_md = codex_dir.join("RTK.md");
+
+        fs::write(&agents_md, "# Team rules\n\n@RTK.md\n").unwrap();
+        fs::write(&rtk_md, "codex config").unwrap();
+
+        let removed_first = uninstall_codex_at(codex_dir, 0).unwrap();
+        let removed_second = uninstall_codex_at(codex_dir, 0).unwrap();
+
+        assert_eq!(removed_first.len(), 2);
+        assert!(removed_second.is_empty());
+        assert!(!rtk_md.exists());
+
+        let content = fs::read_to_string(&agents_md).unwrap();
+        assert!(!content.contains("@RTK.md"));
+        assert!(content.contains("# Team rules"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -323,9 +323,9 @@ enum Commands {
         extra_args: Vec<String>,
     },
 
-    /// Initialize rtk instructions in CLAUDE.md
+    /// Initialize rtk instructions for assistant CLI usage
     Init {
-        /// Add to global ~/.claude/CLAUDE.md instead of local
+        /// Add to global assistant config directory instead of local project file
         #[arg(short, long)]
         global: bool,
 
@@ -357,9 +357,13 @@ enum Commands {
         #[arg(long = "no-patch", group = "patch")]
         no_patch: bool,
 
-        /// Remove all RTK artifacts (hook, RTK.md, CLAUDE.md reference, settings.json entry)
+        /// Remove RTK artifacts for the selected assistant mode
         #[arg(long)]
         uninstall: bool,
+
+        /// Target Codex CLI (uses AGENTS.md + RTK.md, no Claude hook patching)
+        #[arg(long)]
+        codex: bool,
     },
 
     /// Download with compact output (strips progress bars)
@@ -1632,11 +1636,12 @@ fn main() -> Result<()> {
             auto_patch,
             no_patch,
             uninstall,
+            codex,
         } => {
             if show {
-                init::show_config()?;
+                init::show_config(codex)?;
             } else if uninstall {
-                init::uninstall(global, gemini, cli.verbose)?;
+                init::uninstall(global, gemini, codex, cli.verbose)?;
             } else if gemini {
                 let patch_mode = if auto_patch {
                     init::PatchMode::Auto
@@ -1663,6 +1668,7 @@ fn main() -> Result<()> {
                     install_opencode,
                     claude_md,
                     hook_only,
+                    codex,
                     patch_mode,
                     cli.verbose,
                 )?;


### PR DESCRIPTION
## Summary

This PR adds minimal, opt-in Codex CLI support to rtk init while preserving the existing Claude default behavior.

## What’s Included

- Added --codex mode to init:
  - `rtk init --codex` (local setup)
  - `rtk init -g --codex` (global setup)
- Added Codex-aware init `--show` and init `--uninstall`
- Added validation for incompatible flag combinations:
  - `--codex` + `--claude-md` => error
  - `--codex` + `--hook-only` => error
- Added idempotent AGENTS.md patching (@RTK.md is not duplicated)
- Added Codex slim instructions file: hooks/rtk-awareness-codex.md
- Refactored init internals for cleaner dispatch and separation:
  - unified mode routing in run(...) via match
  - extracted uninstall_claude(...)
  - extracted show_claude_config(...)

## Behavior

### Codex mode

```
rtk init --codex
# creates/updates:
#   ./RTK.md
#   ./AGENTS.md (ensures @RTK.md exists once)
```

```
rtk init -g --codex
# creates/updates:
#   ~/.codex/RTK.md
#   ~/.codex/AGENTS.md (ensures @RTK.md exists once)
```

```
rtk init --show --codex
rtk init -g --codex --uninstall
```

### Claude mode (unchanged)

If `--codex` is not passed, existing Claude flow remains unchanged.

## Code Scope

- src/main.rs
- src/init.rs
- hooks/rtk-awareness-codex.md

## Validation

Ran:

```
rustfmt --check src/init.rs src/main.rs
cargo test --locked --bin rtk init::tests::
```

Result:

test result: ok. 27 passed; 0 failed

## Out of Scope

- No discover / learn Codex provider integration in this PR.
- No broader cross-command adapter/provider refactor.