### PR TITLE
fix: normalize venv/path-prefixed commands in rewrite hook

### DIFF
--- a/hooks/cursor/rtk-rewrite.sh
+++ b/hooks/cursor/rtk-rewrite.sh
@@ -38,10 +38,31 @@ if [ -z "$CMD" ]; then
   exit 0
 fi
 
+# Normalize path-prefixed commands for matching only.
+# Claude Code often invokes tools via venv or full path, e.g.
+# ".venv/bin/pytest -v" or "/usr/local/bin/ruff check .".
+# Strip the directory prefix from the first word so rtk rewrite
+# can match the bare command name.
+FIRST_WORD="${CMD%% *}"
+BASE_CMD="$(basename "$FIRST_WORD")"
+if [ "$FIRST_WORD" != "$BASE_CMD" ]; then
+  NORM_CMD="${BASE_CMD}${CMD#"$FIRST_WORD"}"
+else
+  NORM_CMD="$CMD"
+fi
+
 # Delegate all rewrite logic to the Rust binary.
 # rtk rewrite exits 1 when there's no rewrite — hook passes through silently.
-REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null) || { echo '{}'; exit 0; }
-
+REWRITTEN=$(rtk rewrite "$NORM_CMD" 2>/dev/null) || { echo '{}'; exit 0; }
+                                                                               
+# If the original command had a path prefix and the rewrite simply           
+# prepended "rtk ", rebuild using the original path so the correct
+# binary (e.g. .venv/bin/pytest) is invoked at runtime.                      
+if [ "$FIRST_WORD" != "$BASE_CMD" ] && [ "$REWRITTEN" = "rtk $NORM_CMD" ];
+then                                                                         
+  REWRITTEN="rtk $CMD"
+fi                                                                           
+             
 # No change — nothing to do.
 if [ "$CMD" = "$REWRITTEN" ]; then
   echo '{}'

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -3087,7 +3087,9 @@ More notes
         assert!(CURSOR_REWRITE_HOOK.contains("command -v rtk"));
         assert!(CURSOR_REWRITE_HOOK.contains("command -v jq"));
         let jq_pos = CURSOR_REWRITE_HOOK.find("command -v jq").unwrap();
-        let rtk_delegate_pos = CURSOR_REWRITE_HOOK.find("rtk rewrite \"$CMD\"").unwrap();
+        let rtk_delegate_pos = CURSOR_REWRITE_HOOK
+            .find("rtk rewrite \"$NORM_CMD\"")
+            .unwrap();
         assert!(
             jq_pos < rtk_delegate_pos,
             "Guards must appear before rtk rewrite delegation"


### PR DESCRIPTION
Commands invoked via venv or full path (e.g., .venv/bin/pytest, /usr/local/bin/ruff) were not matched by the rewrite hook because the patterns only recognize bare command names. Claude Code non-deterministically chooses between bare command names and full venv paths depending on what it has seen in the project (e.g., after discovering a .venv/ directory), so both forms must be handled.

This adds path normalization in the shell hook that strips directory prefixes for matching only, preserving the original path in the rewritten command so the correct binary is executed.

Handles both cases:

Simple prepend: .venv/bin/pytest -v → rtk .venv/bin/pytest -v
Transformation: /usr/bin/cat file → rtk read file