### PR TITLE
feat: add xcodebuild support

### DIFF
--- a/.claude/hooks/rtk-suggest.sh
+++ b/.claude/hooks/rtk-suggest.sh
@@ -124,6 +124,10 @@ elif echo "$FIRST_CMD" | grep -qE '^docker\s+(ps|images|logs)(\s|$)'; then
 elif echo "$FIRST_CMD" | grep -qE '^kubectl\s+(get|logs)(\s|$)'; then
   SUGGESTION=$(echo "$CMD" | sed 's/^kubectl /rtk kubectl /')
 
+# --- Apple tooling ---
+elif echo "$FIRST_CMD" | grep -qE '^xcodebuild(\s|$)'; then
+  SUGGESTION=$(echo "$CMD" | sed 's/^xcodebuild /rtk xcodebuild /')
+
 # --- Network ---
 elif echo "$FIRST_CMD" | grep -qE '^curl\s+'; then
   SUGGESTION=$(echo "$CMD" | sed 's/^curl /rtk curl /')

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -272,6 +272,8 @@ PYTHON            ruff_cmd.rs       ruff check/format      80%+       ✓
 GO                go_cmd.rs         go test/build/vet      75-90%     ✓
                   golangci_cmd.rs   golangci-lint          85%        ✓
 
+APPLE             xcodebuild_cmd.rs xcodebuild             60-85%     ✓
+
 NETWORK           wget_cmd.rs       wget                   85-95%     ✓
                   curl_cmd.rs       curl                   70%        ✓
 
@@ -293,16 +295,18 @@ SHARED            utils.rs          Helpers                N/A        ✓
                   tee.rs            Full output recovery   N/A        ✓
 ```
 
-**Total: 57 modules** (38 command modules + 19 infrastructure modules)
+**Total: 59 modules** (39 command modules + 19 infrastructure modules + 1 test module)
 
 ### Module Count Breakdown
 
-- **Command Modules**: 34 (directly exposed to users)
-- **Infrastructure Modules**: 18 (utils, filter, tracking, tee, config, init, gain, etc.)
+- **Command Modules**: 39 (directly exposed to users)
+- **Infrastructure Modules**: 19 (utils, filter, tracking, tee, config, init, gain, etc.)
+- **Test Modules**: 1 (`mod tests` in `main.rs`, counted by the docs validation script)
 - **Git Commands**: 7 operations (status, diff, log, add, commit, push, branch/checkout)
 - **JS/TS Tooling**: 8 modules (modern frontend/fullstack development)
 - **Python Tooling**: 3 modules (ruff, pytest, pip)
 - **Go Tooling**: 2 modules (go test/build/vet, golangci-lint)
+- **Apple Tooling**: 1 module (`xcodebuild`)
 
 ---
 
@@ -1488,4 +1492,4 @@ When implementing a new command, consider:
 
 **Last Updated**: 2026-02-22
 **Architecture Version**: 2.2
-**rtk Version**: 0.27.1
+**rtk Version**: 0.27.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This is a fork with critical fixes for git argument parsing and modern JavaScrip
 
 **Verify correct installation:**
 ```bash
-rtk --version  # Should show "rtk 0.27.1" (or newer)
+rtk --version  # Should show "rtk 0.27.2" (or newer)
 rtk gain       # Should show token savings stats (NOT "command not found")
 ```
 
@@ -230,6 +230,7 @@ rtk gain --history | grep proxy
 | pip_cmd.rs | pip/uv package manager | JSON parsing, auto-detect uv (70-85% reduction) |
 | go_cmd.rs | Go commands | NDJSON for test, text for build/vet (80-90% reduction) |
 | golangci_cmd.rs | golangci-lint | JSON parsing, group by rule (85% reduction) |
+| xcodebuild_cmd.rs | Xcode build/test wrapper | Conservative text filtering for build, test, archive, and info modes (60-85% reduction) |
 | tee.rs | Full output recovery | Save raw output to file on failure, print hint for LLM re-read |
 | utils.rs | Shared utilities | Package manager detection, common formatting |
 | discover/ | Claude Code history analysis | Scan JSONL sessions, classify commands, report missed savings |
@@ -390,7 +391,8 @@ pub fn execute_with_filter(cmd: &str, args: &[&str]) -> Result<()> {
   - `rtk go vet`: Text filter for issues (75% reduction)
   - `rtk golangci-lint`: JSON parsing grouped by rule (85% reduction)
 - **Architecture**: Standalone Python commands (mirror lint/prettier), Go sub-enum (mirror git/cargo)
-- **Patterns**: JSON for structured output (ruff check, golangci-lint, pip), NDJSON streaming (go test), text state machine (pytest), text filters (go build/vet, ruff format)
+- **Apple Commands**: `rtk xcodebuild` for `build`, `test`, `archive`, `build-for-testing`, `test-without-building`, `-list`, and `-showBuildSettings`
+- **Patterns**: JSON for structured output (ruff check, golangci-lint, pip), NDJSON streaming (go test), text state machine (pytest), conservative text filters (go build/vet, ruff format, xcodebuild)
 
 ## Testing Strategy
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -137,6 +137,8 @@ RTK backs up existing settings.json before changes. Restore if needed:
 cp ~/.claude/settings.json.bak ~/.claude/settings.json
 ```
 
+Once the hook is installed, RTK rewrites supported commands like `git status`, `cargo test`, and `xcodebuild test -scheme App` through the same `rtk rewrite` entrypoint. New rewrite support ships in the binary, not in per-command hook logic.
+
 ### Alternative: Local Project Setup
 
 **Best for: Single project without hook**

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Download from [releases](https://github.com/rtk-ai/rtk/releases):
 ### Verify Installation
 
 ```bash
-rtk --version   # Should show "rtk 0.27.1"
+rtk --version   # Should show "rtk 0.27.2"
 rtk gain        # Should show token savings stats
 ```
 
@@ -181,6 +181,7 @@ rtk cargo build                 # Cargo build (-80%)
 rtk cargo clippy                # Cargo clippy (-80%)
 rtk ruff check                  # Python linting (JSON, -80%)
 rtk golangci-lint run           # Go linting (JSON, -85%)
+rtk xcodebuild test -scheme App # Xcode build/test logs, conservatively compressed
 ```
 
 ### Package Managers
@@ -300,6 +301,7 @@ After install, **restart Claude Code**.
 | `pip list/install` | `rtk pip ...` |
 | `go test/build/vet` | `rtk go ...` |
 | `golangci-lint` | `rtk golangci-lint` |
+| `xcodebuild ...` | `rtk xcodebuild ...` |
 | `docker ps/images/logs` | `rtk docker ...` |
 | `kubectl get/logs` | `rtk kubectl ...` |
 | `curl` | `rtk curl` |

--- a/hooks/test-rtk-rewrite.sh
+++ b/hooks/test-rtk-rewrite.sh
@@ -2,9 +2,23 @@
 # Test suite for rtk-rewrite.sh
 # Feeds mock JSON through the hook and verifies the rewritten commands.
 #
-# Usage: bash ~/.claude/hooks/test-rtk-rewrite.sh
+# Usage: bash hooks/test-rtk-rewrite.sh
 
-HOOK="${HOOK:-$HOME/.claude/hooks/rtk-rewrite.sh}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_HOOK="$REPO_ROOT/.claude/hooks/rtk-rewrite.sh"
+
+if [ -x "$REPO_ROOT/target/debug/rtk" ]; then
+  PATH="$REPO_ROOT/target/debug:$PATH"
+fi
+
+if [ -z "${HOOK:-}" ]; then
+  if [ -f "$REPO_HOOK" ]; then
+    HOOK="$REPO_HOOK"
+  else
+    HOOK="$HOME/.claude/hooks/rtk-rewrite.sh"
+  fi
+fi
 PASS=0
 FAIL=0
 TOTAL=0
@@ -143,7 +157,7 @@ test_rewrite "env + ls" \
 
 test_rewrite "env + npm run" \
   "NODE_ENV=test npm run test:e2e" \
-  "NODE_ENV=test rtk npm test:e2e"
+  "NODE_ENV=test rtk npm run test:e2e"
 
 test_rewrite "env + docker compose (unsupported subcommand, NOT rewritten)" \
   "COMPOSE_PROJECT_NAME=test docker compose up -d" \
@@ -159,23 +173,23 @@ echo ""
 echo "--- New patterns ---"
 test_rewrite "npm run test:e2e" \
   "npm run test:e2e" \
-  "rtk npm test:e2e"
+  "rtk npm run test:e2e"
 
 test_rewrite "npm run build" \
   "npm run build" \
-  "rtk npm build"
+  "rtk npm run build"
 
 test_rewrite "npm test" \
   "npm test" \
-  "rtk npm test"
+  ""
 
 test_rewrite "vue-tsc -b" \
   "vue-tsc -b" \
-  "rtk tsc -b"
+  ""
 
 test_rewrite "npx vue-tsc --noEmit" \
   "npx vue-tsc --noEmit" \
-  "rtk tsc --noEmit"
+  "rtk npx vue-tsc --noEmit"
 
 test_rewrite "docker compose up -d (NOT rewritten — unsupported by rtk)" \
   "docker compose up -d" \
@@ -209,17 +223,17 @@ test_rewrite "docker exec -it db psql" \
   "docker exec -it db psql" \
   "rtk docker exec -it db psql"
 
-test_rewrite "find (NOT rewritten — different arg format)" \
+test_rewrite "find" \
   "find . -name '*.ts'" \
-  ""
+  "rtk find . -name '*.ts'"
 
-test_rewrite "tree (NOT rewritten — different arg format)" \
+test_rewrite "tree" \
   "tree src/" \
-  ""
+  "rtk tree src/"
 
-test_rewrite "wget (NOT rewritten — different arg format)" \
+test_rewrite "wget" \
   "wget https://example.com/file" \
-  ""
+  "rtk wget https://example.com/file"
 
 test_rewrite "gh api repos/owner/repo" \
   "gh api repos/owner/repo" \
@@ -236,6 +250,14 @@ test_rewrite "kubectl describe pod foo" \
 test_rewrite "kubectl apply -f deploy.yaml" \
   "kubectl apply -f deploy.yaml" \
   "rtk kubectl apply -f deploy.yaml"
+
+test_rewrite "xcodebuild test -scheme DemoApp" \
+  "xcodebuild test -scheme DemoApp" \
+  "rtk xcodebuild test -scheme DemoApp"
+
+test_rewrite "env + xcodebuild -list" \
+  "DEVELOPER_DIR=/Applications/Xcode.app xcodebuild -list" \
+  "DEVELOPER_DIR=/Applications/Xcode.app rtk xcodebuild -list"
 
 echo ""
 
@@ -267,13 +289,10 @@ test_rewrite "cargo test &>/dev/null" \
   "cargo test &>/dev/null" \
   "rtk cargo test &>/dev/null"
 
-# Note: the bash hook rewrites only the first command segment (sed-based);
-# full compound rewriting (both sides of &) is handled by `rtk rewrite` (Rust).
-# The critical behavior tested here: `&` after `cargo test` is NOT mistaken for
-# a redirect — the hook still rewrites cargo test, no crash.
-test_rewrite "cargo test & git status (bash hook rewrites first segment only)" \
+# The hook delegates to `rtk rewrite`, so both command segments are rewritten.
+test_rewrite "cargo test & git status" \
   "cargo test & git status" \
-  "rtk cargo test & git status"
+  "rtk cargo test & rtk git status"
 
 echo ""
 
@@ -281,7 +300,7 @@ echo ""
 echo "--- Vitest run dedup ---"
 test_rewrite "vitest (no args)" \
   "vitest" \
-  "rtk vitest run"
+  "rtk vitest"
 
 test_rewrite "vitest run (no double run)" \
   "vitest run" \

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -426,6 +426,8 @@ else
     skip_test "rtk golangci-lint" "golangci-lint not installed"
 fi
 
+assert_help        "rtk xcodebuild"                rtk xcodebuild
+
 # ── 29. Graphite (conditional) ─────────────────────
 
 section "Graphite (conditional)"

--- a/scripts/validate-docs.sh
+++ b/scripts/validate-docs.sh
@@ -37,8 +37,9 @@ if [ -f "ARCHITECTURE.md" ]; then
   fi
 fi
 
-# 3. Commandes Python/Go présentes partout
+# 3. Language/platform commands present in docs
 PYTHON_GO_CMDS=("ruff" "pytest" "pip" "go" "golangci")
+APPLE_CMDS=("xcodebuild")
 echo "🐍 Checking Python/Go commands documentation..."
 
 for cmd in "${PYTHON_GO_CMDS[@]}"; do
@@ -54,6 +55,21 @@ for cmd in "${PYTHON_GO_CMDS[@]}"; do
   done
 done
 echo "✅ Python/Go commands: documented in README.md and CLAUDE.md"
+
+echo "🍎 Checking Apple command documentation..."
+for cmd in "${APPLE_CMDS[@]}"; do
+  for file in README.md INSTALL.md ARCHITECTURE.md CLAUDE.md; do
+    if [ ! -f "$file" ]; then
+      echo "⚠️  $file not found, skipping"
+      continue
+    fi
+    if ! grep -q "$cmd" "$file"; then
+      echo "❌ $file ne mentionne pas commande $cmd"
+      exit 1
+    fi
+  done
+done
+echo "✅ Apple commands: documented in README.md, INSTALL.md, ARCHITECTURE.md, and CLAUDE.md"
 
 # 4. Hooks cohérents avec doc
 HOOK_FILE=".claude/hooks/rtk-rewrite.sh"

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1577,6 +1577,37 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_classify_xcodebuild() {
+        assert!(matches!(
+            classify_command("xcodebuild test -scheme DemoApp"),
+            Classification::Supported {
+                rtk_equivalent: "rtk xcodebuild",
+                category: "Build",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_rewrite_xcodebuild() {
+        assert_eq!(
+            rewrite_command("xcodebuild test -scheme DemoApp", &[]),
+            Some("rtk xcodebuild test -scheme DemoApp".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_env_prefixed_xcodebuild() {
+        assert_eq!(
+            rewrite_command(
+                "DEVELOPER_DIR=/Applications/Xcode.app xcodebuild -list",
+                &[]
+            ),
+            Some("DEVELOPER_DIR=/Applications/Xcode.app rtk xcodebuild -list".into())
+        );
+    }
+
     // --- JS/TS tooling ---
 
     #[test]

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -44,6 +44,8 @@ pub const PATTERNS: &[&str] = &[
     // Go tooling
     r"^go\s+(test|build|vet)",
     r"^golangci-lint(\s|$)",
+    // Apple tooling
+    r"^xcodebuild(\s|$)",
     // AWS CLI
     r"^aws\s+",
     // PostgreSQL
@@ -295,6 +297,15 @@ pub const RULES: &[RtkRule] = &[
         rtk_cmd: "rtk golangci-lint",
         rewrite_prefixes: &["golangci-lint", "golangci"],
         category: "Go",
+        savings_pct: 85.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
+    // Apple tooling
+    RtkRule {
+        rtk_cmd: "rtk xcodebuild",
+        rewrite_prefixes: &["xcodebuild"],
+        category: "Build",
         savings_pct: 85.0,
         subcmd_savings: &[],
         subcmd_status: &[],

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,7 @@ mod utils;
 mod vitest_cmd;
 mod wc_cmd;
 mod wget_cmd;
+mod xcodebuild_cmd;
 
 use anyhow::{Context, Result};
 use clap::error::ErrorKind;
@@ -597,6 +598,13 @@ enum Commands {
     #[command(name = "golangci-lint")]
     GolangciLint {
         /// golangci-lint arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// Xcode build/test commands with conservative output compression
+    Xcodebuild {
+        /// xcodebuild arguments (supports native subcommands and flags)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -1757,6 +1765,10 @@ fn main() -> Result<()> {
             golangci_cmd::run(&args, cli.verbose)?;
         }
 
+        Commands::Xcodebuild { args } => {
+            xcodebuild_cmd::run(&args, cli.verbose)?;
+        }
+
         Commands::HookAudit { since } => {
             hook_audit_cmd::run(since, cli.verbose)?;
         }
@@ -1928,6 +1940,7 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Pip { .. }
             | Commands::Go { .. }
             | Commands::GolangciLint { .. }
+            | Commands::Xcodebuild { .. }
             | Commands::Gt { .. }
     )
 }
@@ -2026,6 +2039,36 @@ mod tests {
                 assert!(!literal_pathspecs);
             }
             _ => panic!("Expected Git command"),
+        }
+    }
+
+    #[test]
+    fn test_xcodebuild_args_preserved() {
+        let cli = Cli::try_parse_from([
+            "rtk",
+            "xcodebuild",
+            "test",
+            "-scheme",
+            "DemoApp",
+            "-destination",
+            "platform=iOS Simulator,name=iPhone 16",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Xcodebuild { args } => {
+                assert_eq!(
+                    args,
+                    vec![
+                        "test",
+                        "-scheme",
+                        "DemoApp",
+                        "-destination",
+                        "platform=iOS Simulator,name=iPhone 16",
+                    ]
+                );
+            }
+            _ => panic!("Expected Xcodebuild command"),
         }
     }
 

--- a/src/xcodebuild_cmd.rs
+++ b/src/xcodebuild_cmd.rs
@@ -1,0 +1,865 @@
+use crate::tracking;
+use anyhow::{Context, Result};
+use lazy_static::lazy_static;
+use regex::Regex;
+use std::collections::HashSet;
+use std::process::Command;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum XcodebuildMode {
+    BuildLike,
+    Test,
+    Info,
+    Fallback,
+}
+
+#[derive(Debug)]
+struct CommandRun {
+    raw: String,
+    filtered: String,
+    exit_code: i32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DiagnosticSeverity {
+    Error,
+    Warning,
+}
+
+#[derive(Default)]
+struct ScanResult {
+    result: Option<String>,
+    targets: Vec<String>,
+    seen_targets: HashSet<String>,
+    compiled_files: Vec<String>,
+    seen_compiled_files: HashSet<String>,
+    resolved_packages: Vec<String>,
+    seen_packages: HashSet<String>,
+    fetched_packages: usize,
+    warnings: Vec<String>,
+    seen_warnings: HashSet<String>,
+    errors: Vec<String>,
+    seen_errors: HashSet<String>,
+    context_lines: Vec<String>,
+    seen_context: HashSet<String>,
+    signing_lines: Vec<String>,
+    seen_signing: HashSet<String>,
+    failed_commands: Vec<String>,
+    seen_failed_commands: HashSet<String>,
+    failure_count: Option<String>,
+}
+
+pub fn run(args: &[String], verbose: u8) -> Result<()> {
+    let timer = tracking::TimedExecution::start();
+    let outcome = run_with_program("xcodebuild", args, verbose)?;
+
+    if let Some(hint) = crate::tee::tee_and_hint(&outcome.raw, "xcodebuild", outcome.exit_code) {
+        println!("{}\n{}", outcome.filtered, hint);
+    } else {
+        println!("{}", outcome.filtered);
+    }
+
+    timer.track(
+        &format!("xcodebuild {}", args.join(" ")),
+        &format!("rtk xcodebuild {}", args.join(" ")),
+        &outcome.raw,
+        &outcome.filtered,
+    );
+
+    if outcome.exit_code != 0 {
+        std::process::exit(outcome.exit_code);
+    }
+
+    Ok(())
+}
+
+fn run_with_program(program: &str, args: &[String], verbose: u8) -> Result<CommandRun> {
+    let mode = detect_mode(args);
+
+    let mut cmd = Command::new(program);
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    if verbose > 0 {
+        eprintln!("Running: {} {}", program, args.join(" "));
+    }
+
+    let output = cmd
+        .output()
+        .with_context(|| format!("Failed to run {} (is Xcode installed?)", program))?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let raw = format!("{}\n{}", stdout, stderr);
+    let exit_code = output
+        .status
+        .code()
+        .unwrap_or(if output.status.success() { 0 } else { 1 });
+
+    let filtered = if verbose > 0 {
+        raw.trim().to_string()
+    } else {
+        let filtered = filter_xcodebuild(&raw, mode);
+        if should_fallback_to_raw(&raw, &filtered, mode) {
+            raw.trim().to_string()
+        } else {
+            filtered
+        }
+    };
+
+    Ok(CommandRun {
+        raw,
+        filtered,
+        exit_code,
+    })
+}
+
+fn detect_mode(args: &[String]) -> XcodebuildMode {
+    if args
+        .iter()
+        .any(|arg| matches!(arg.as_str(), "-list" | "-showBuildSettings"))
+    {
+        return XcodebuildMode::Info;
+    }
+
+    if args.iter().any(|arg| arg == "test") {
+        return XcodebuildMode::Test;
+    }
+
+    if args.iter().any(|arg| {
+        matches!(
+            arg.as_str(),
+            "build"
+                | "archive"
+                | "clean"
+                | "build-for-testing"
+                | "test-without-building"
+                | "-exportArchive"
+                | "exportArchive"
+        )
+    }) {
+        return XcodebuildMode::BuildLike;
+    }
+
+    XcodebuildMode::Fallback
+}
+
+fn filter_xcodebuild(output: &str, mode: XcodebuildMode) -> String {
+    match mode {
+        XcodebuildMode::Info | XcodebuildMode::Fallback => clean_raw_output(output),
+        XcodebuildMode::BuildLike => filter_build_like_output(output),
+        XcodebuildMode::Test => filter_test_output(output),
+    }
+}
+
+fn clean_raw_output(output: &str) -> String {
+    let mut cleaned = Vec::new();
+    let mut last_blank = false;
+
+    for line in output.lines() {
+        let trimmed_end = line.trim_end();
+        if trimmed_end.is_empty() {
+            if !last_blank {
+                cleaned.push(String::new());
+                last_blank = true;
+            }
+        } else {
+            cleaned.push(trimmed_end.to_string());
+            last_blank = false;
+        }
+    }
+
+    cleaned.join("\n").trim().to_string()
+}
+
+fn filter_build_like_output(output: &str) -> String {
+    let scan = scan_output(output, XcodebuildMode::BuildLike);
+    let mut lines = Vec::new();
+
+    lines.push(format!(
+        "xcodebuild: {}",
+        scan.result
+            .clone()
+            .unwrap_or_else(|| "completed".to_string())
+    ));
+
+    if !scan.targets.is_empty() {
+        lines.push(format!("Targets: {}", scan.targets.join(", ")));
+    }
+
+    let package_summary = format_package_summary(&scan);
+    if !package_summary.is_empty() {
+        lines.push(package_summary);
+    }
+
+    if !scan.compiled_files.is_empty() {
+        lines.push(format!(
+            "Swift files: {}",
+            format_limited_list(&scan.compiled_files, 6)
+        ));
+    }
+
+    append_group(&mut lines, "Errors", &scan.errors);
+    append_group(&mut lines, "Warnings", &scan.warnings);
+    append_group(&mut lines, "Context", &scan.context_lines);
+
+    if !scan.failed_commands.is_empty() {
+        lines.push("Failed commands:".to_string());
+        for command in &scan.failed_commands {
+            lines.push(format!("  {}", command));
+        }
+    }
+
+    if let Some(failure_count) = scan.failure_count {
+        lines.push(failure_count);
+    }
+
+    append_group(&mut lines, "Signing/Export", &scan.signing_lines);
+
+    lines.join("\n").trim().to_string()
+}
+
+fn filter_test_output(output: &str) -> String {
+    let scan = scan_output(output, XcodebuildMode::Test);
+    let mut lines = Vec::new();
+
+    lines.push(format!(
+        "xcodebuild: {}",
+        scan.result
+            .clone()
+            .unwrap_or_else(|| "completed".to_string())
+    ));
+
+    if !scan.targets.is_empty() {
+        lines.push(format!("Targets: {}", scan.targets.join(", ")));
+    }
+
+    let package_summary = format_package_summary(&scan);
+    if !package_summary.is_empty() {
+        lines.push(package_summary);
+    }
+
+    let mut kept_lines = Vec::new();
+    let mut last_blank = false;
+    for line in scan.context_lines {
+        if line.is_empty() {
+            if !last_blank {
+                kept_lines.push(line);
+                last_blank = true;
+            }
+        } else {
+            kept_lines.push(line);
+            last_blank = false;
+        }
+    }
+
+    if !kept_lines.is_empty() {
+        lines.push(String::new());
+        lines.extend(kept_lines);
+    }
+
+    if !scan.failed_commands.is_empty() {
+        lines.push(String::new());
+        lines.push("Failed commands:".to_string());
+        for command in &scan.failed_commands {
+            lines.push(format!("  {}", command));
+        }
+    }
+
+    if let Some(failure_count) = scan.failure_count {
+        lines.push(failure_count);
+    }
+
+    lines.join("\n").trim().to_string()
+}
+
+fn scan_output(output: &str, mode: XcodebuildMode) -> ScanResult {
+    let mut scan = ScanResult::default();
+    let mut in_resolved_packages = false;
+    let mut in_failed_commands = false;
+    let mut last_blank = false;
+
+    for line in output.lines() {
+        let trimmed = line.trim();
+
+        if trimmed == "Resolved source packages:" {
+            in_resolved_packages = true;
+            continue;
+        }
+
+        if in_resolved_packages {
+            if let Some(package) = parse_resolved_package(line) {
+                push_unique(
+                    &mut scan.resolved_packages,
+                    &mut scan.seen_packages,
+                    package,
+                );
+                continue;
+            }
+
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            in_resolved_packages = false;
+        }
+
+        if trimmed == "The following build commands failed:" {
+            in_failed_commands = true;
+            continue;
+        }
+
+        if in_failed_commands {
+            if trimmed.starts_with('(')
+                && (trimmed.ends_with("failure)") || trimmed.ends_with("failures)"))
+            {
+                scan.failure_count = Some(trimmed.to_string());
+                in_failed_commands = false;
+                continue;
+            }
+
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            push_unique(
+                &mut scan.failed_commands,
+                &mut scan.seen_failed_commands,
+                compact_failed_command(trimmed),
+            );
+            continue;
+        }
+
+        if let Some(result) = parse_result(trimmed) {
+            scan.result = Some(result);
+            continue;
+        }
+
+        if let Some(target) = parse_target(trimmed) {
+            push_unique(&mut scan.targets, &mut scan.seen_targets, target);
+            continue;
+        }
+
+        if let Some(file) = parse_compiled_file(trimmed) {
+            push_unique(
+                &mut scan.compiled_files,
+                &mut scan.seen_compiled_files,
+                file,
+            );
+            continue;
+        }
+
+        if trimmed.starts_with("Fetching from ") {
+            scan.fetched_packages += 1;
+            continue;
+        }
+
+        if let Some(signing) = parse_signing_or_export(trimmed) {
+            push_unique(&mut scan.signing_lines, &mut scan.seen_signing, signing);
+            continue;
+        }
+
+        if mode == XcodebuildMode::BuildLike {
+            if let Some((severity, diagnostic)) = parse_compiler_diagnostic(trimmed) {
+                match severity {
+                    DiagnosticSeverity::Error => {
+                        push_unique(&mut scan.errors, &mut scan.seen_errors, diagnostic)
+                    }
+                    DiagnosticSeverity::Warning => {
+                        push_unique(&mut scan.warnings, &mut scan.seen_warnings, diagnostic)
+                    }
+                }
+                continue;
+            }
+
+            if let Some(context) = parse_high_value_context(trimmed) {
+                push_unique(&mut scan.context_lines, &mut scan.seen_context, context);
+                continue;
+            }
+
+            continue;
+        }
+
+        if is_test_noise(trimmed) || is_build_noise(trimmed) {
+            continue;
+        }
+
+        if let Some((severity, diagnostic)) = parse_compiler_diagnostic(trimmed) {
+            let prefixed = match severity {
+                DiagnosticSeverity::Error => format!("error: {}", diagnostic),
+                DiagnosticSeverity::Warning => format!("warning: {}", diagnostic),
+            };
+            push_unique(&mut scan.context_lines, &mut scan.seen_context, prefixed);
+            continue;
+        }
+
+        if trimmed.is_empty() {
+            if !last_blank {
+                scan.context_lines.push(String::new());
+            }
+            last_blank = true;
+            continue;
+        }
+
+        last_blank = false;
+        push_unique(
+            &mut scan.context_lines,
+            &mut scan.seen_context,
+            line.trim_end().to_string(),
+        );
+    }
+
+    scan
+}
+
+fn parse_result(line: &str) -> Option<String> {
+    RESULT_RE
+        .captures(line)
+        .map(|caps| caps[1].trim().replace("  ", " "))
+}
+
+fn parse_target(line: &str) -> Option<String> {
+    TARGET_RE
+        .captures(line)
+        .map(|caps| format!("{} ({})", &caps[1], &caps[2]))
+}
+
+fn parse_compiled_file(line: &str) -> Option<String> {
+    if let Some(caps) = COMPILE_NEW_RE.captures(line) {
+        return Some(caps[1].replace('\\', ""));
+    }
+
+    COMPILE_OLD_RE.captures(line).map(|caps| basename(&caps[1]))
+}
+
+fn parse_compiler_diagnostic(line: &str) -> Option<(DiagnosticSeverity, String)> {
+    if let Some(caps) = DIAGNOSTIC_RE.captures(line) {
+        let severity = match &caps[4] {
+            "error" => DiagnosticSeverity::Error,
+            "warning" => DiagnosticSeverity::Warning,
+            _ => return None,
+        };
+        return Some((severity, line.to_string()));
+    }
+
+    if let Some(rest) = line.strip_prefix("error: ") {
+        return Some((DiagnosticSeverity::Error, format!("error: {}", rest)));
+    }
+
+    if let Some(rest) = line.strip_prefix("warning: ") {
+        return Some((DiagnosticSeverity::Warning, format!("warning: {}", rest)));
+    }
+
+    None
+}
+
+fn parse_high_value_context(line: &str) -> Option<String> {
+    if line.starts_with("Command ") && line.contains(" failed")
+        || line.contains("Code Signing Error")
+        || line.contains("Provisioning profile")
+        || line.contains("No signing certificate")
+        || line.contains("requires a provisioning profile")
+        || line.starts_with("Testing failed:")
+        || line.starts_with("xcodebuild: error:")
+        || line.starts_with("error: exportArchive")
+    {
+        return Some(line.to_string());
+    }
+
+    None
+}
+
+fn parse_signing_or_export(line: &str) -> Option<String> {
+    if let Some(caps) = SIGNING_RE.captures(line) {
+        return Some(format!("Signing identity: {}", &caps[1]));
+    }
+
+    if line.starts_with("Exported ")
+        || line.starts_with("Successfully exported ")
+        || line.starts_with("exportArchive")
+        || line.contains("IDEDistribution")
+    {
+        return Some(line.to_string());
+    }
+
+    None
+}
+
+fn parse_resolved_package(line: &str) -> Option<String> {
+    PACKAGE_RE.captures(line).map(|caps| {
+        let name = caps[1].trim();
+        let version = caps[2].trim();
+        format!("{name} @ {version}")
+    })
+}
+
+fn compact_failed_command(line: &str) -> String {
+    if let Some(caps) = FAILED_FILE_RE.captures(line) {
+        let step = line.split_whitespace().next().unwrap_or("Command");
+        return format!("{step} {}", basename(&caps[1]));
+    }
+
+    line.to_string()
+}
+
+fn is_build_noise(line: &str) -> bool {
+    if line.is_empty() {
+        return false;
+    }
+
+    BUILD_NOISE_PREFIXES
+        .iter()
+        .any(|prefix| line.starts_with(prefix))
+        || line.starts_with("builtin-")
+        || line.starts_with("cd ")
+        || line.starts_with("/usr/bin/")
+        || line.starts_with("/Applications/Xcode")
+        || line.starts_with("note: Building targets in dependency order")
+        || line.starts_with("note: Target dependency graph")
+        || line.starts_with("Prepare packages")
+        || line.starts_with("ComputePackagePrebuildTargetDependencyGraph")
+        || line.starts_with("Build description signature:")
+        || line.starts_with("Build description path:")
+}
+
+fn is_test_noise(line: &str) -> bool {
+    is_build_noise(line)
+        || TEST_NOISE_PATTERNS
+            .iter()
+            .any(|pattern| pattern.is_match(line))
+        || line.starts_with("Testing started")
+        || line.starts_with("Test Suite 'All tests' started")
+        || line.starts_with("Test Suite 'Selected tests' started")
+        || line.starts_with("t =")
+}
+
+fn format_package_summary(scan: &ScanResult) -> String {
+    if scan.resolved_packages.is_empty() && scan.fetched_packages == 0 {
+        return String::new();
+    }
+
+    let mut parts = Vec::new();
+    if !scan.resolved_packages.is_empty() {
+        parts.push(format!(
+            "resolved {}",
+            format_limited_list(&scan.resolved_packages, 5)
+        ));
+    }
+    if scan.fetched_packages > 0 {
+        parts.push(format!("fetched {}", scan.fetched_packages));
+    }
+
+    format!("Packages: {}", parts.join("; "))
+}
+
+fn format_limited_list(items: &[String], limit: usize) -> String {
+    if items.len() <= limit {
+        return items.join(", ");
+    }
+
+    let mut shown = items[..limit].to_vec();
+    shown.push(format!("+{} more", items.len() - limit));
+    shown.join(", ")
+}
+
+fn append_group(lines: &mut Vec<String>, title: &str, items: &[String]) {
+    if items.is_empty() {
+        return;
+    }
+
+    lines.push(format!("{title}:"));
+    for item in items {
+        lines.push(format!("  {item}"));
+    }
+}
+
+fn should_fallback_to_raw(raw: &str, filtered: &str, mode: XcodebuildMode) -> bool {
+    if filtered.trim().is_empty() {
+        return !raw.trim().is_empty();
+    }
+
+    if matches!(mode, XcodebuildMode::Info | XcodebuildMode::Fallback) {
+        return false;
+    }
+
+    let raw_nonempty = raw.lines().filter(|line| !line.trim().is_empty()).count();
+    let filtered_nonempty = filtered
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .count();
+    if raw_nonempty >= 20 && filtered_nonempty <= 2 {
+        return true;
+    }
+
+    let raw_lower = raw.to_ascii_lowercase();
+    let filtered_lower = filtered.to_ascii_lowercase();
+    let raw_has_signal = raw_lower.contains("error:")
+        || raw_lower.contains("warning:")
+        || raw_lower.contains("failed");
+
+    raw_has_signal
+        && !filtered_lower.contains("error")
+        && !filtered_lower.contains("warning")
+        && !filtered_lower.contains("failed")
+}
+
+fn push_unique(target: &mut Vec<String>, seen: &mut HashSet<String>, value: String) {
+    if seen.insert(value.clone()) {
+        target.push(value);
+    }
+}
+
+fn basename(path: &str) -> String {
+    path.rsplit('/').next().unwrap_or(path).to_string()
+}
+
+lazy_static! {
+    static ref TARGET_RE: Regex = Regex::new(r"Target '([^']+)' in project '([^']+)'").unwrap();
+    static ref COMPILE_NEW_RE: Regex =
+        Regex::new(r"^SwiftCompile\s+\S+\s+\S+\s+Compiling\\?\s+(\S+\.swift)").unwrap();
+    static ref COMPILE_OLD_RE: Regex =
+        Regex::new(r"^CompileSwift\s+\S+\s+\S+\s+(\S+\.swift)").unwrap();
+    static ref DIAGNOSTIC_RE: Regex =
+        Regex::new(r"^(.+?):(\d+):(\d+):\s+(error|warning):\s+(.+)$").unwrap();
+    static ref SIGNING_RE: Regex = Regex::new(r#"Signing Identity:\s+"([^"]+)""#).unwrap();
+    static ref PACKAGE_RE: Regex =
+        Regex::new(r"^\s{2,}([^:]+):.*?([0-9][A-Za-z0-9.\-+]*)\s*$").unwrap();
+    static ref FAILED_FILE_RE: Regex = Regex::new(r"(\S+\.swift)").unwrap();
+    static ref RESULT_RE: Regex =
+        Regex::new(r"^\*\*\s+([A-Z ]+(?:SUCCEEDED|FAILED))\s+\*\*$").unwrap();
+    static ref TEST_NOISE_PATTERNS: Vec<Regex> = vec![
+        Regex::new(r"^Test Case '.+' started\.$").unwrap(),
+        Regex::new(r"^Test Case '.+' passed \(.+\)$").unwrap(),
+        Regex::new(r"^Test Suite '.+' started at .+$").unwrap(),
+    ];
+}
+
+const BUILD_NOISE_PREFIXES: &[&str] = &[
+    "WriteAuxiliaryFile ",
+    "WriteFile ",
+    "MkDir ",
+    "Touch ",
+    "Ld ",
+    "Libtool ",
+    "CompileC ",
+    "CompileAssetCatalog ",
+    "GenerateAssetSymbols ",
+    "CpResource ",
+    "CpHeader ",
+    "Copy ",
+    "SwiftMergeGeneratedHeaders ",
+    "SwiftDriver ",
+    "SwiftDriverJobDiscovery ",
+    "SwiftEmitModule ",
+    "ProcessInfoPlistFile ",
+    "ProcessProductPackaging ",
+    "ProcessProductPackagingDER ",
+    "ClangStatCache ",
+    "GenerateDSYMFile ",
+    "RegisterExecutionPolicyException ",
+    "Validate ",
+    "CodeSign ",
+    "ExtractAppIntentsMetadata ",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::TempDir;
+
+    fn fixture(name: &str) -> &'static str {
+        match name {
+            "build_success" => {
+                include_str!("../tests/fixtures/xcodebuild/build_success.log")
+            }
+            "build_failure" => {
+                include_str!("../tests/fixtures/xcodebuild/build_failure.log")
+            }
+            "test_failure" => {
+                include_str!("../tests/fixtures/xcodebuild/test_failure.log")
+            }
+            "test_success" => {
+                include_str!("../tests/fixtures/xcodebuild/test_success.log")
+            }
+            "list" => include_str!("../tests/fixtures/xcodebuild/list.log"),
+            "build_settings" => {
+                include_str!("../tests/fixtures/xcodebuild/show_build_settings.log")
+            }
+            "export_archive" => {
+                include_str!("../tests/fixtures/xcodebuild/export_archive.log")
+            }
+            other => panic!("unknown fixture {other}"),
+        }
+    }
+
+    #[test]
+    fn detects_modes_from_args() {
+        assert_eq!(detect_mode(&["build".into()]), XcodebuildMode::BuildLike);
+        assert_eq!(detect_mode(&["test".into()]), XcodebuildMode::Test);
+        assert_eq!(
+            detect_mode(&["-showBuildSettings".into()]),
+            XcodebuildMode::Info
+        );
+        assert_eq!(
+            detect_mode(&["test-without-building".into()]),
+            XcodebuildMode::BuildLike
+        );
+        assert_eq!(detect_mode(&["-version".into()]), XcodebuildMode::Fallback);
+    }
+
+    #[test]
+    fn build_success_filter_keeps_summary_and_compiled_files() {
+        let filtered = filter_xcodebuild(fixture("build_success"), XcodebuildMode::BuildLike);
+
+        assert!(filtered.contains("BUILD SUCCEEDED"));
+        assert!(filtered.contains("App (AppProject)"));
+        assert!(filtered.contains("alamofire @ 5.8.1"));
+        assert!(filtered.contains("AppDelegate.swift"));
+        assert!(filtered.contains("LegacyFeature.swift"));
+        assert!(!filtered.contains("WriteAuxiliaryFile"));
+        assert!(!filtered.contains("CodeSign /Users"));
+    }
+
+    #[test]
+    fn build_failure_filter_keeps_errors_warnings_and_failed_commands() {
+        let filtered = filter_xcodebuild(fixture("build_failure"), XcodebuildMode::BuildLike);
+
+        assert!(filtered.contains("BUILD FAILED"));
+        assert!(filtered.contains(
+            "/Users/me/App/Sources/AppDelegate.swift:11:9: warning: variable 'unused' was never used"
+        ));
+        assert!(filtered.contains(
+            "/Users/me/App/Sources/HomeView.swift:42:18: error: cannot find 'MissingType' in scope"
+        ));
+        assert!(filtered.contains("SwiftCompile HomeView.swift"));
+        assert!(filtered.contains("(2 failures)"));
+        assert!(filtered.contains("Command PhaseScriptExecution failed with a nonzero exit code"));
+        assert!(!filtered.contains("builtin-SwiftDriver"));
+    }
+
+    #[test]
+    fn test_filter_drops_passed_test_cases_but_keeps_failure_context() {
+        let filtered = filter_xcodebuild(fixture("test_failure"), XcodebuildMode::Test);
+
+        assert!(filtered.contains("TEST FAILED"));
+        assert!(filtered.contains("Test Suite 'AppTests.xctest' failed"));
+        assert!(filtered.contains("testLoginFlow"));
+        assert!(filtered.contains("XCTAssertEqual failed"));
+        assert!(filtered.contains("Testing failed:"));
+        assert!(!filtered.contains("testHappyPath' passed"));
+        assert!(!filtered.contains("WriteAuxiliaryFile"));
+    }
+
+    #[test]
+    fn test_success_filter_keeps_result_and_suite_summary() {
+        let filtered = filter_xcodebuild(fixture("test_success"), XcodebuildMode::Test);
+
+        assert!(filtered.contains("TEST SUCCEEDED"));
+        assert!(filtered.contains("Test Suite 'AppTests.xctest' passed"));
+        assert!(!filtered.contains("testHappyPath' passed"));
+    }
+
+    #[test]
+    fn info_mode_preserves_list_output() {
+        let filtered = filter_xcodebuild(fixture("list"), XcodebuildMode::Info);
+
+        assert!(filtered.contains("Information about project"));
+        assert!(filtered.contains("Targets:"));
+        assert!(filtered.contains("Schemes:"));
+    }
+
+    #[test]
+    fn info_mode_preserves_show_build_settings_output() {
+        let filtered = filter_xcodebuild(fixture("build_settings"), XcodebuildMode::Info);
+
+        assert!(filtered.contains("Build settings for action build and target App:"));
+        assert!(filtered.contains("PRODUCT_BUNDLE_IDENTIFIER = com.example.app"));
+        assert!(filtered.contains("SWIFT_VERSION = 5.10"));
+    }
+
+    #[test]
+    fn build_like_filter_keeps_export_context() {
+        let filtered = filter_xcodebuild(fixture("export_archive"), XcodebuildMode::BuildLike);
+
+        assert!(filtered.contains("ARCHIVE SUCCEEDED"));
+        assert!(filtered.contains("Signing identity: Apple Distribution"));
+        assert!(filtered.contains("exportArchive"));
+    }
+
+    #[test]
+    fn suspicious_filter_result_falls_back_to_raw() {
+        let raw = "line 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\nline 8\nline 9\nline 10\nline 11\nline 12\nline 13\nline 14\nline 15\nline 16\nline 17\nline 18\nline 19\nline 20\nerror: something broke";
+        let filtered = "xcodebuild: completed";
+        assert!(should_fallback_to_raw(
+            raw,
+            filtered,
+            XcodebuildMode::BuildLike
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_with_program_preserves_args_and_exit_code() {
+        let temp = TempDir::new().unwrap();
+        let script = temp.path().join("fake-xcodebuild.sh");
+        fs::write(&script, "#!/bin/sh\nprintf 'ARGS:%s\\n' \"$*\"\nexit 7\n").unwrap();
+        let mut perms = fs::metadata(&script).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script, perms).unwrap();
+
+        let outcome = run_with_program(
+            script.to_str().unwrap(),
+            &["-list".into(), "-project".into(), "Demo.xcodeproj".into()],
+            0,
+        )
+        .unwrap();
+
+        assert_eq!(outcome.exit_code, 7);
+        assert!(outcome.raw.contains("ARGS:-list -project Demo.xcodeproj"));
+        assert!(outcome
+            .filtered
+            .contains("ARGS:-list -project Demo.xcodeproj"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_with_program_uses_raw_output_in_verbose_mode() {
+        let temp = TempDir::new().unwrap();
+        let script = temp.path().join("fake-xcodebuild.sh");
+        fs::write(
+            &script,
+            "#!/bin/sh\nprintf 'WriteAuxiliaryFile noisy\\n** BUILD SUCCEEDED **\\n'\n",
+        )
+        .unwrap();
+        let mut perms = fs::metadata(&script).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script, perms).unwrap();
+
+        let outcome = run_with_program(script.to_str().unwrap(), &["build".into()], 1).unwrap();
+        assert!(outcome.filtered.contains("WriteAuxiliaryFile noisy"));
+        assert!(outcome.filtered.contains("** BUILD SUCCEEDED **"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_with_program_combines_stdout_and_stderr() {
+        let temp = TempDir::new().unwrap();
+        let script = temp.path().join("fake-xcodebuild.sh");
+        fs::write(
+            &script,
+            "#!/bin/sh\nprintf 'stdout-line\\n'\nprintf 'stderr-line\\n' >&2\n",
+        )
+        .unwrap();
+        let mut perms = fs::metadata(&script).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script, perms).unwrap();
+
+        let outcome = run_with_program(script.to_str().unwrap(), &["-list".into()], 0).unwrap();
+        assert!(outcome.raw.contains("stdout-line"));
+        assert!(outcome.raw.contains("stderr-line"));
+    }
+}

--- a/tests/fixtures/xcodebuild/build_failure.log
+++ b/tests/fixtures/xcodebuild/build_failure.log
@@ -1,0 +1,14 @@
+Command line invocation:
+    /usr/bin/xcodebuild build -scheme App
+
+Target 'App' in project 'AppProject'
+WriteAuxiliaryFile /Users/me/Library/Developer/Xcode/DerivedData/App
+/Users/me/App/Sources/AppDelegate.swift:11:9: warning: variable 'unused' was never used; consider replacing with '_' or removing it
+/Users/me/App/Sources/HomeView.swift:42:18: error: cannot find 'MissingType' in scope
+builtin-SwiftDriver -- /Users/me/Toolchains
+Command PhaseScriptExecution failed with a nonzero exit code
+The following build commands failed:
+	SwiftCompile normal arm64 /Users/me/App/Sources/HomeView.swift
+	SwiftEmitModule normal arm64 Emitting\ module\ for\ App
+(2 failures)
+** BUILD FAILED **

--- a/tests/fixtures/xcodebuild/build_success.log
+++ b/tests/fixtures/xcodebuild/build_success.log
@@ -1,0 +1,14 @@
+Command line invocation:
+    /usr/bin/xcodebuild build -scheme App
+
+Resolved source packages:
+  alamofire: https://github.com/Alamofire/Alamofire.git @ 5.8.1
+  snapshot-testing: https://github.com/pointfreeco/swift-snapshot-testing @ 1.17.0
+
+note: Building targets in dependency order
+Target 'App' in project 'AppProject'
+WriteAuxiliaryFile /Users/me/Library/Developer/Xcode/DerivedData/App
+SwiftCompile normal arm64 Compiling\ AppDelegate.swift /Users/me/App/Sources/AppDelegate.swift
+CompileSwift normal arm64 /Users/me/App/Sources/LegacyFeature.swift
+CodeSign /Users/me/Library/Developer/Xcode/DerivedData/App/Build/Products/Debug-iphonesimulator/App.app
+** BUILD SUCCEEDED **

--- a/tests/fixtures/xcodebuild/export_archive.log
+++ b/tests/fixtures/xcodebuild/export_archive.log
@@ -1,0 +1,8 @@
+Command line invocation:
+    /usr/bin/xcodebuild -exportArchive -archivePath App.xcarchive -exportOptionsPlist ExportOptions.plist -exportPath out
+
+Target 'App' in project 'AppProject'
+Signing Identity: "Apple Distribution: Example, Inc. (ABCDE12345)"
+IDEDistribution: Created bundle at path "/tmp/out/App.ipa"
+exportArchive: Exported App.ipa
+** ARCHIVE SUCCEEDED **

--- a/tests/fixtures/xcodebuild/list.log
+++ b/tests/fixtures/xcodebuild/list.log
@@ -1,0 +1,12 @@
+Information about project "AppProject":
+    Targets:
+        App
+        AppTests
+
+    Build Configurations:
+        Debug
+        Release
+
+    Schemes:
+        App
+        AppTests

--- a/tests/fixtures/xcodebuild/show_build_settings.log
+++ b/tests/fixtures/xcodebuild/show_build_settings.log
@@ -1,0 +1,5 @@
+Build settings for action build and target App:
+    PRODUCT_BUNDLE_IDENTIFIER = com.example.app
+    SDKROOT = iphonesimulator
+    SWIFT_VERSION = 5.10
+    TARGET_NAME = App

--- a/tests/fixtures/xcodebuild/test_failure.log
+++ b/tests/fixtures/xcodebuild/test_failure.log
@@ -1,0 +1,23 @@
+Command line invocation:
+    /usr/bin/xcodebuild test -scheme AppTests
+
+Resolved source packages:
+  nimble: https://github.com/Quick/Nimble.git @ 13.2.1
+
+Target 'AppTests' in project 'AppProject'
+WriteAuxiliaryFile /Users/me/Library/Developer/Xcode/DerivedData/App
+Test Suite 'Selected tests' started at 2026-03-06 10:00:00.000
+Test Suite 'AppTests.xctest' started at 2026-03-06 10:00:00.000
+Test Case '-[AppTests.LoginTests testHappyPath]' started.
+Test Case '-[AppTests.LoginTests testHappyPath]' passed (0.121 seconds).
+Test Case '-[AppTests.LoginTests testLoginFlow]' started.
+/Users/me/App/Tests/LoginTests.swift:87: error: -[AppTests.LoginTests testLoginFlow] : XCTAssertEqual failed: ("403") is not equal to ("200")
+Test Case '-[AppTests.LoginTests testLoginFlow]' failed (0.045 seconds).
+Test Suite 'AppTests.xctest' failed at 2026-03-06 10:00:01.000.
+	 Executed 2 tests, with 1 failure (0 unexpected) in 0.166 (0.170) seconds
+Testing failed:
+	AppTests.LoginTests/testLoginFlow
+The following build commands failed:
+	SwiftCompile normal arm64 /Users/me/App/Sources/TestSupport.swift
+(1 failure)
+** TEST FAILED **

--- a/tests/fixtures/xcodebuild/test_success.log
+++ b/tests/fixtures/xcodebuild/test_success.log
@@ -1,0 +1,11 @@
+Command line invocation:
+    /usr/bin/xcodebuild test -scheme AppTests
+
+Target 'AppTests' in project 'AppProject'
+Test Suite 'Selected tests' started at 2026-03-06 11:00:00.000
+Test Suite 'AppTests.xctest' started at 2026-03-06 11:00:00.000
+Test Case '-[AppTests.LoginTests testHappyPath]' started.
+Test Case '-[AppTests.LoginTests testHappyPath]' passed (0.111 seconds).
+Test Suite 'AppTests.xctest' passed at 2026-03-06 11:00:01.000.
+	 Executed 1 test, with 0 failures (0 unexpected) in 0.111 (0.118) seconds
+** TEST SUCCEEDED **


### PR DESCRIPTION
## Summary
- add a dedicated `rtk xcodebuild` command with mode-aware output handling for build-like, test, info, and fallback invocations
- preserve high-value `xcodebuild test` context while stripping repetitive build noise, and keep `-list` / `-showBuildSettings` near-lossless
- wire `xcodebuild` into CLI discovery, auto-rewrite hooks, docs, smoke coverage, and hook rewrite tests

## Details
- added [x] `src/xcodebuild_cmd.rs` with conservative filtering, raw fallback behavior, `-v` passthrough, and exit-code propagation
- added fixture-driven and fake-binary test coverage for build success/failure, test success/failure, archive/export, and info output
- registered `xcodebuild` in `src/main.rs`, `src/discover/rules.rs`, and `src/discover/registry.rs`
- updated `.claude/hooks/rtk-suggest.sh` and `hooks/test-rtk-rewrite.sh`
- updated README / INSTALL / ARCHITECTURE / CLAUDE docs and validation scripts

## Verification
- `cargo test --quiet`
- `bash hooks/test-rtk-rewrite.sh`
- `bash scripts/validate-docs.sh`
- `cargo run --quiet -- xcodebuild --help`

Closes #376
