### PR TITLE
feat: add rtk cdk diff/synth/deploy filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "autocfg"
@@ -108,9 +108,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "block-buffer"
@@ -133,15 +133,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -155,9 +155,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -190,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -202,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "colorchoice"
@@ -219,6 +219,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
@@ -324,10 +336,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_home"
-version = "0.1.0"
+name = "encode_unicode"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -365,9 +377,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "flate2"
@@ -417,13 +429,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -493,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.65"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -652,6 +676,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.46.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
+dependencies = [
+ "console",
+ "once_cell",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,9 +701,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -687,16 +723,17 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
+ "bitflags",
  "libc",
 ]
 
@@ -713,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.12.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -731,9 +768,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "miniz_oxide"
@@ -823,12 +860,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -849,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -861,9 +904,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -872,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "ring"
@@ -900,8 +943,10 @@ dependencies = [
  "colored",
  "dirs",
  "flate2",
+ "getrandom 0.4.2",
  "hostname",
  "ignore",
+ "insta",
  "lazy_static",
  "quick-xml",
  "regex",
@@ -933,9 +978,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.4"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags",
  "errno",
@@ -1077,6 +1122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,9 +1153,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1124,12 +1175,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1214,9 +1265,9 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.24"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-xid"
@@ -1318,9 +1369,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1331,9 +1382,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1341,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1354,9 +1405,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
@@ -1415,13 +1466,11 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.1"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a824aeba0fbb27264f815ada4cff43d65b1741b7a4ed7629ff9089148c4a4e0"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
 dependencies = [
- "env_home",
- "rustix",
- "winsafe",
+ "libc",
 ]
 
 [[package]]
@@ -1651,18 +1700,12 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"
@@ -1783,18 +1826,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1863,6 +1906,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ which = "8"
 toml = "0.8"
 
 [dev-dependencies]
+insta = "1"
 
 [profile.release]
 opt-level = 3

--- a/src/cmds/cloud/cdk_cmd.rs
+++ b/src/cmds/cloud/cdk_cmd.rs
@@ -1,0 +1,972 @@
+use crate::core::tracking;
+use crate::core::utils::{resolved_command, strip_ansi, tool_exists, truncate};
+use anyhow::{Context, Result};
+use regex::Regex;
+use std::ffi::OsString;
+use std::io::IsTerminal;
+use std::process::Command;
+
+lazy_static::lazy_static! {
+    /// CloudFormation resource progress lines (both standard and stack-prefixed formats):
+    ///   " 0/12 | 10:30:01 AM | CREATE_IN_PROGRESS ..."
+    ///   "StackName | 0/6 | 17:20:49 | UPDATE_IN_PROGRESS ..."
+    static ref PROGRESS_RE: Regex = Regex::new(
+        r"(\d+/\d+\s*\||\|\s*\d+/\d+\s*\|).*\|\s*(CREATE|UPDATE|DELETE|IMPORT)_(IN_PROGRESS|COMPLETE|FAILED|SKIPPED|COMPLETE_CLEA)"
+    ).unwrap();
+
+    /// Resource type line in synth YAML output (Type: AWS::...)
+    static ref RESOURCE_TYPE_RE: Regex = Regex::new(r"^\s+Type:\s+(AWS::\S+)").unwrap();
+
+    /// Stack name from diff/deploy output header
+    static ref STACK_NAME_RE: Regex = Regex::new(r"^Stack\s+(\S+)").unwrap();
+}
+
+/// Build a Command for the CDK CLI, with npx fallback.
+fn cdk_command() -> Command {
+    if tool_exists("cdk") {
+        resolved_command("cdk")
+    } else {
+        let mut cmd = resolved_command("npx");
+        cmd.arg("cdk");
+        cmd
+    }
+}
+
+pub fn run_diff(args: &[String], verbose: u8) -> Result<()> {
+    let timer = tracking::TimedExecution::start();
+
+    let mut cmd = cdk_command();
+    cmd.arg("diff");
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    if verbose > 0 {
+        eprintln!("Running: cdk diff {}", args.join(" "));
+    }
+
+    let output = cmd
+        .output()
+        .context("Failed to run cdk diff. Is AWS CDK installed?")?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let raw = format!("{}\n{}", stdout, stderr);
+
+    let exit_code = output
+        .status
+        .code()
+        .unwrap_or(if output.status.success() { 0 } else { 1 });
+
+    let filtered = filter_cdk_diff(&strip_ansi(&raw));
+
+    if let Some(hint) = crate::core::tee::tee_and_hint(&raw, "cdk_diff", exit_code) {
+        println!("{}\n{}", filtered, hint);
+    } else {
+        println!("{}", filtered);
+    }
+
+    timer.track(
+        &format!("cdk diff {}", args.join(" ")),
+        &format!("rtk cdk diff {}", args.join(" ")),
+        &raw,
+        &filtered,
+    );
+
+    if !output.status.success() {
+        std::process::exit(exit_code);
+    }
+
+    Ok(())
+}
+
+pub fn run_synth(args: &[String], verbose: u8) -> Result<()> {
+    let timer = tracking::TimedExecution::start();
+
+    let mut cmd = cdk_command();
+    cmd.arg("synth");
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    if verbose > 0 {
+        eprintln!("Running: cdk synth {}", args.join(" "));
+    }
+
+    let output = cmd
+        .output()
+        .context("Failed to run cdk synth. Is AWS CDK installed?")?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let raw = format!("{}\n{}", stdout, stderr);
+
+    let exit_code = output
+        .status
+        .code()
+        .unwrap_or(if output.status.success() { 0 } else { 1 });
+
+    let filtered = filter_cdk_synth(&strip_ansi(&raw));
+
+    if let Some(hint) = crate::core::tee::tee_and_hint(&raw, "cdk_synth", exit_code) {
+        println!("{}\n{}", filtered, hint);
+    } else {
+        println!("{}", filtered);
+    }
+
+    timer.track(
+        &format!("cdk synth {}", args.join(" ")),
+        &format!("rtk cdk synth {}", args.join(" ")),
+        &raw,
+        &filtered,
+    );
+
+    if !output.status.success() {
+        std::process::exit(exit_code);
+    }
+
+    Ok(())
+}
+
+pub fn run_deploy(args: &[String], verbose: u8) -> Result<()> {
+    let timer = tracking::TimedExecution::start();
+
+    let mut cmd = cdk_command();
+    cmd.arg("deploy");
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    if verbose > 0 {
+        eprintln!("Running: cdk deploy {}", args.join(" "));
+    }
+
+    // Use .status() for interactive deploy (approval prompts)
+    // unless we detect non-interactive flags
+    let is_non_interactive = args.iter().enumerate().any(|(i, a)| {
+        a == "--require-approval=never"
+            || (a == "--require-approval" && args.get(i + 1).map(|s| s.as_str()) == Some("never"))
+            || a == "--ci"
+            || a == "-y"
+            || a == "--yes"
+    });
+
+    if !is_non_interactive && std::io::stdout().is_terminal() {
+        // Interactive mode: pass through stdin/stdout for approval prompts
+        let status = cmd
+            .status()
+            .context("Failed to run cdk deploy. Is AWS CDK installed?")?;
+
+        let exit_code = status
+            .code()
+            .unwrap_or(if status.success() { 0 } else { 1 });
+        timer.track_passthrough(
+            &format!("cdk deploy {}", args.join(" ")),
+            &format!("rtk cdk deploy {} (interactive)", args.join(" ")),
+        );
+
+        if !status.success() {
+            std::process::exit(exit_code);
+        }
+
+        return Ok(());
+    }
+
+    // Non-interactive: capture and filter output
+    let output = cmd
+        .output()
+        .context("Failed to run cdk deploy. Is AWS CDK installed?")?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let raw = format!("{}\n{}", stdout, stderr);
+
+    let exit_code = output
+        .status
+        .code()
+        .unwrap_or(if output.status.success() { 0 } else { 1 });
+
+    let filtered = filter_cdk_deploy(&strip_ansi(&raw));
+
+    if let Some(hint) = crate::core::tee::tee_and_hint(&raw, "cdk_deploy", exit_code) {
+        println!("{}\n{}", filtered, hint);
+    } else {
+        println!("{}", filtered);
+    }
+
+    timer.track(
+        &format!("cdk deploy {}", args.join(" ")),
+        &format!("rtk cdk deploy {}", args.join(" ")),
+        &raw,
+        &filtered,
+    );
+
+    if !output.status.success() {
+        std::process::exit(exit_code);
+    }
+
+    Ok(())
+}
+
+pub fn run_other(args: &[OsString], verbose: u8) -> Result<()> {
+    if args.is_empty() {
+        anyhow::bail!("cdk: no subcommand specified");
+    }
+
+    let timer = tracking::TimedExecution::start();
+
+    let subcommand = args[0].to_string_lossy();
+    let mut cmd = cdk_command();
+    cmd.arg(&*subcommand);
+
+    for arg in &args[1..] {
+        cmd.arg(arg);
+    }
+
+    if verbose > 0 {
+        eprintln!("Running: cdk {} ...", subcommand);
+    }
+
+    let status = cmd
+        .status()
+        .with_context(|| format!("Failed to run cdk {}", subcommand))?;
+
+    timer.track_passthrough(
+        &format!("cdk {}", subcommand),
+        &format!("rtk cdk {}", subcommand),
+    );
+
+    if !status.success() {
+        std::process::exit(status.code().unwrap_or(1));
+    }
+
+    Ok(())
+}
+
+// ──────────────────── Filter functions ────────────────────
+
+/// Whitelist check: is this line meaningful diff content?
+fn is_diff_content(trimmed: &str) -> bool {
+    // Stack headers
+    STACK_NAME_RE.is_match(trimmed)
+    // Diff markers — catches ALL diff content including nested subtree
+    // (both proper Unicode and mojibake box-drawing, because [~]/[+]/[-] is always ASCII)
+    || trimmed.contains("[~]") || trimmed.contains("[+]") || trimmed.contains("[-]")
+    || trimmed.contains("[ ]")
+    // Unified diff hunk headers (inside inline diffs)
+    || trimmed.contains("@@ ")
+    // Section headers
+    || trimmed == "Resources"
+    // Status lines
+    || trimmed.contains("no differences") || trimmed.contains("No differences")
+    || trimmed.contains("Number of stacks with differences")
+    // IAM changes (keep if present)
+    || trimmed.starts_with("IAM Statement Changes") || trimmed.starts_with("IAM Policy Changes")
+    || trimmed.starts_with('\u{250c}') || trimmed.starts_with('\u{251c}') || trimmed.starts_with('\u{2514}')
+    || trimmed.starts_with('\u{2502}')
+}
+
+/// Filter cdk diff output: whitelist approach — keep only meaningful lines.
+pub fn filter_cdk_diff(output: &str) -> String {
+    let mut added = 0usize;
+    let mut removed = 0usize;
+    let mut changed = 0usize;
+    let mut lines: Vec<String> = Vec::new();
+
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        if is_diff_content(trimmed) {
+            // Count diff markers at the start of trimmed line
+            if trimmed.starts_with("[+]") {
+                added += 1;
+            } else if trimmed.starts_with("[-]") {
+                removed += 1;
+            } else if trimmed.starts_with("[~]") {
+                changed += 1;
+            }
+            lines.push(truncate(line, 120).to_string());
+        }
+    }
+
+    let mut result = String::new();
+    for line in &lines {
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    result.push_str(&format!(
+        "\nSummary: {} added, {} changed, {} removed",
+        added, changed, removed
+    ));
+
+    result.trim().to_string()
+}
+
+/// Filter cdk synth output: dual-path whitelist.
+/// - No-template path: "Successfully synthesized" message + stack list
+/// - Template path: extract resource type counts from YAML
+pub fn filter_cdk_synth(output: &str) -> String {
+    let mut has_synth_message = false;
+    let mut synth_line = String::new();
+    let mut stack_list_line = String::new();
+    let mut resource_types: Vec<String> = Vec::new();
+
+    for line in output.lines() {
+        let trimmed = line.trim();
+
+        // Detect "Successfully synthesized" line
+        if trimmed.contains("Successfully synthesized") {
+            has_synth_message = true;
+            synth_line = trimmed.to_string();
+            continue;
+        }
+
+        // Detect "Supply a stack id" line (contains stack list)
+        if trimmed.starts_with("Supply a stack id") {
+            stack_list_line = trimmed.to_string();
+            continue;
+        }
+
+        // Collect resource types from YAML template
+        if let Some(caps) = RESOURCE_TYPE_RE.captures(line) {
+            resource_types.push(caps[1].to_string());
+        }
+    }
+
+    let mut result = String::new();
+
+    // No-template path: show synth message + stack list
+    if has_synth_message {
+        result.push_str(&synth_line);
+        result.push('\n');
+        if !stack_list_line.is_empty() {
+            // Extract just the stack names from "Supply a stack id (A, B, C) to display its template."
+            if let Some(start) = stack_list_line.find('(') {
+                if let Some(end) = stack_list_line.rfind(')') {
+                    let stacks = &stack_list_line[start + 1..end];
+                    result.push_str(&format!("Stacks: {}\n", stacks));
+                }
+            }
+        }
+    }
+
+    // Template path: show resource type summary
+    if !resource_types.is_empty() {
+        // Group by resource type
+        let mut type_counts: std::collections::HashMap<&str, usize> =
+            std::collections::HashMap::new();
+        for rt in &resource_types {
+            *type_counts.entry(rt.as_str()).or_insert(0) += 1;
+        }
+
+        let mut sorted_types: Vec<_> = type_counts.into_iter().collect();
+        sorted_types.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+
+        result.push_str(&format!("Resources: {} total\n", resource_types.len()));
+        for (rtype, count) in &sorted_types {
+            let short = rtype.strip_prefix("AWS::").unwrap_or(rtype);
+            if *count > 1 {
+                result.push_str(&format!("  {} x{}\n", short, count));
+            } else {
+                result.push_str(&format!("  {}\n", short));
+            }
+        }
+    }
+
+    // Handle empty output
+    if result.is_empty() {
+        result.push_str("Resources: 0 total");
+    }
+
+    result.trim().to_string()
+}
+
+/// Filter cdk deploy output: whitelist approach — keep only meaningful lines.
+pub fn filter_cdk_deploy(output: &str) -> String {
+    let mut stack_name = String::new();
+    let mut outputs: Vec<String> = Vec::new();
+    let mut errors: Vec<String> = Vec::new();
+    let mut success_line = String::new();
+    let mut deploy_time = String::new();
+    let mut total_time = String::new();
+    let mut in_outputs = false;
+    let mut resource_count = 0usize;
+    let mut failed_count = 0usize;
+    let mut complete_count = 0usize;
+
+    for line in output.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        // Track progress lines for counting (both standard and stack-prefixed)
+        if PROGRESS_RE.is_match(trimmed) {
+            resource_count += 1;
+            if trimmed.contains("_FAILED") {
+                failed_count += 1;
+                errors.push(truncate(trimmed, 150).to_string());
+            } else if trimmed.contains("_COMPLETE") {
+                complete_count += 1;
+            }
+            continue;
+        }
+
+        // Success line: proper Unicode checkmark or mojibake variant
+        if trimmed.contains('\u{2705}') || trimmed.contains("Ô£à") {
+            success_line = trimmed.to_string();
+            // Extract stack name after the emoji
+            let name = trimmed
+                .trim_start_matches('\u{2705}')
+                .trim_start_matches("Ô£à")
+                .trim();
+            if !name.is_empty() {
+                stack_name = name.to_string();
+            }
+            continue;
+        }
+
+        // "deploying..." line
+        if trimmed.contains("deploying...") {
+            stack_name = trimmed.split(':').next().unwrap_or("").trim().to_string();
+            continue;
+        }
+
+        // Deployment time
+        if trimmed.contains("Deployment time:") {
+            deploy_time = trimmed.to_string();
+            continue;
+        }
+        if trimmed.contains("Total time:") {
+            total_time = trimmed.to_string();
+            continue;
+        }
+
+        // Track Outputs section
+        if trimmed == "Outputs:" || trimmed.starts_with("Outputs:") {
+            in_outputs = true;
+            continue;
+        }
+        if trimmed.starts_with("Stack ARN:") {
+            in_outputs = false;
+            continue;
+        }
+
+        if in_outputs {
+            outputs.push(truncate(trimmed, 150).to_string());
+            continue;
+        }
+
+        // Capture deployment error/failure messages (CDK-specific patterns only)
+        if (trimmed.contains("FAILED")
+            || trimmed.contains("ROLLBACK")
+            || trimmed.starts_with("❌")
+            || trimmed.contains("Deployment failed"))
+            && !errors.iter().any(|e| e == trimmed)
+        {
+            errors.push(truncate(trimmed, 150).to_string());
+        }
+    }
+
+    let mut result = String::new();
+
+    if !success_line.is_empty() {
+        result.push_str(&format!("{}\n", success_line));
+    } else if !stack_name.is_empty() {
+        result.push_str(&format!("Stack: {}\n", stack_name));
+    }
+
+    // Resource summary
+    if resource_count > 0 {
+        result.push_str(&format!(
+            "Resources: {}/{} complete",
+            complete_count, resource_count
+        ));
+        if failed_count > 0 {
+            result.push_str(&format!(", {} failed", failed_count));
+        }
+        result.push('\n');
+    }
+
+    // Errors
+    if !errors.is_empty() {
+        result.push_str("\nErrors:\n");
+        for err in &errors {
+            result.push_str(&format!("  {}\n", err));
+        }
+    }
+
+    // Outputs
+    if !outputs.is_empty() {
+        result.push_str("\nOutputs:\n");
+        for out in &outputs {
+            result.push_str(&format!("  {}\n", out));
+        }
+    }
+
+    // Timing
+    if !deploy_time.is_empty() {
+        result.push_str(&format!("\n{}", deploy_time));
+    }
+    if !total_time.is_empty() {
+        result.push_str(&format!("\n{}", total_time));
+    }
+
+    result.trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use insta::assert_snapshot;
+
+    fn count_tokens(text: &str) -> usize {
+        text.split_whitespace().count()
+    }
+
+    // ──────────────── cdk diff — main fixture ────────────────
+
+    #[test]
+    fn test_filter_cdk_diff_basic() {
+        let input = include_str!("../../../tests/fixtures/cdk_diff_raw.txt");
+        let output = filter_cdk_diff(input);
+
+        // Diff content preserved
+        assert!(output.contains("[~]"));
+        assert!(output.contains("Summary:"));
+        // Bundling noise stripped
+        assert!(!output.contains("Bundling asset"));
+        assert!(!output.contains("cdk.out/bundling"));
+        assert!(!output.contains("esbuild"));
+        // NOTICES stripped
+        assert!(!output.contains("NOTICES"));
+        assert!(!output.contains("cdk watch"));
+    }
+
+    #[test]
+    fn test_filter_cdk_diff_multi_stack() {
+        let input = include_str!("../../../tests/fixtures/cdk_diff_raw.txt");
+        let output = filter_cdk_diff(input);
+
+        // Multiple stacks preserved
+        assert!(output.contains("Stack CdkBackendStack/PushNotificationsStack"));
+        assert!(output.contains("Stack CdkBackendStack/WorkflowStack"));
+        assert!(output.contains("Stack CdkBackendStack/BatchWorkflowStack"));
+        assert!(
+            output.contains("Stack CdkBackendStack\n")
+                || output.contains("Stack CdkBackendStack\r")
+        );
+    }
+
+    #[test]
+    fn test_filter_cdk_diff_counts() {
+        let input = include_str!("../../../tests/fixtures/cdk_diff_raw.txt");
+        let output = filter_cdk_diff(input);
+
+        // All changes are [~] in this fixture (10 lambdas with code changes)
+        assert!(output.contains("0 added"));
+        assert!(output.contains("10 changed"));
+        assert!(output.contains("0 removed"));
+    }
+
+    #[test]
+    fn test_filter_cdk_diff_savings() {
+        let input = include_str!("../../../tests/fixtures/cdk_diff_raw.txt");
+        let output = filter_cdk_diff(input);
+
+        let input_tokens = count_tokens(input);
+        let output_tokens = count_tokens(&output);
+        let savings = 100.0 - (output_tokens as f64 / input_tokens as f64 * 100.0);
+
+        assert!(
+            savings >= 60.0,
+            "cdk diff filter: expected >=60% savings, got {:.1}% ({} -> {} tokens)",
+            savings,
+            input_tokens,
+            output_tokens
+        );
+    }
+
+    #[test]
+    fn test_filter_cdk_diff_snapshot() {
+        let input = include_str!("../../../tests/fixtures/cdk_diff_raw.txt");
+        let output = filter_cdk_diff(input);
+        assert_snapshot!(output);
+    }
+
+    // ──────────────── cdk diff — _1 fixture (SampleApp) ────────────────
+
+    #[test]
+    fn test_filter_cdk_diff_1_docker_pip_stripped() {
+        let input = include_str!("../../../tests/fixtures/cdk_diff_raw_1.txt");
+        let output = filter_cdk_diff(input);
+
+        // Docker pull noise stripped
+        assert!(!output.contains("Pulling fs layer"));
+        assert!(!output.contains("Download complete"));
+        assert!(!output.contains("Pull complete"));
+        // pip install noise stripped
+        assert!(!output.contains("Collecting feedparser"));
+        assert!(!output.contains("Downloading"));
+        assert!(!output.contains("Installing collected packages"));
+        // esbuild noise stripped
+        assert!(!output.contains("esbuild"));
+    }
+
+    #[test]
+    fn test_filter_cdk_diff_1_mojibake_kept() {
+        let input = include_str!("../../../tests/fixtures/cdk_diff_raw_1.txt");
+        let output = filter_cdk_diff(input);
+
+        // Mojibake diff content with [~]/[+]/[-] preserved
+        assert!(output.contains("[~]"));
+        assert!(output.contains("[+]"));
+        assert!(output.contains("[-]"));
+        // Stack name preserved
+        assert!(output.contains("Stack SampleApp-RssBatch"));
+    }
+
+    #[test]
+    fn test_filter_cdk_diff_1_savings() {
+        let input = include_str!("../../../tests/fixtures/cdk_diff_raw_1.txt");
+        let output = filter_cdk_diff(input);
+
+        let input_tokens = count_tokens(input);
+        let output_tokens = count_tokens(&output);
+        let savings = 100.0 - (output_tokens as f64 / input_tokens as f64 * 100.0);
+
+        assert!(
+            savings >= 60.0,
+            "cdk diff _1 filter: expected >=60% savings, got {:.1}% ({} -> {} tokens)",
+            savings,
+            input_tokens,
+            output_tokens
+        );
+    }
+
+    #[test]
+    fn test_filter_cdk_diff_1_snapshot() {
+        let input = include_str!("../../../tests/fixtures/cdk_diff_raw_1.txt");
+        let output = filter_cdk_diff(input);
+        assert_snapshot!(output);
+    }
+
+    // ──────────────── cdk diff — edge cases ────────────────
+
+    #[test]
+    fn test_filter_cdk_diff_no_changes() {
+        let input = "Stack MyStack\nThere were no differences";
+        let output = filter_cdk_diff(input);
+
+        assert!(output.contains("no differences"));
+        assert!(output.contains("0 added"));
+    }
+
+    #[test]
+    fn test_filter_cdk_diff_empty() {
+        let output = filter_cdk_diff("");
+        assert!(output.contains("0 added"));
+    }
+
+    #[test]
+    fn test_filter_cdk_diff_iam_synthetic() {
+        let input = r#"Stack MyStack
+Resources
+[~] AWS::IAM::Role MyRole
+IAM Statement Changes
+┌───┬─────────┬────────┬───────────┐
+│   │ Res     │ Effect │ Action    │
+├───┼─────────┼────────┼───────────┤
+│ + │ MyRole  │ Allow  │ s3:Get*   │
+└───┴─────────┴────────┴───────────┘
+[+] AWS::Lambda::Function NewFunc"#;
+
+        let output = filter_cdk_diff(input);
+
+        assert!(output.contains("IAM Statement Changes"));
+        assert!(output.contains("\u{250c}"));
+        assert!(output.contains("\u{2502}"));
+        assert!(output.contains("\u{2514}"));
+        assert!(output.contains("1 added, 1 changed, 0 removed"));
+    }
+
+    // ──────────────── cdk synth — main fixture ────────────────
+
+    #[test]
+    fn test_filter_cdk_synth_basic() {
+        let input = include_str!("../../../tests/fixtures/cdk_synth_raw.txt");
+        let output = filter_cdk_synth(input);
+
+        // No-template path: shows synth success + stack list
+        assert!(output.contains("Successfully synthesized"));
+        assert!(output.contains("Stacks:"));
+        // Bundling stripped
+        assert!(!output.contains("Bundling asset"));
+        assert!(!output.contains("esbuild"));
+        // NOTICES stripped
+        assert!(!output.contains("NOTICES"));
+    }
+
+    #[test]
+    fn test_filter_cdk_synth_stack_list() {
+        let input = include_str!("../../../tests/fixtures/cdk_synth_raw.txt");
+        let output = filter_cdk_synth(input);
+
+        // Stack names extracted
+        assert!(output.contains("CdkBackendStack/PushNotificationsStack"));
+        assert!(output.contains("CdkBackendStack/BatchWorkflowStack"));
+    }
+
+    #[test]
+    fn test_filter_cdk_synth_savings() {
+        let input = include_str!("../../../tests/fixtures/cdk_synth_raw.txt");
+        let output = filter_cdk_synth(input);
+
+        let input_tokens = count_tokens(input);
+        let output_tokens = count_tokens(&output);
+        let savings = 100.0 - (output_tokens as f64 / input_tokens as f64 * 100.0);
+
+        assert!(
+            savings >= 60.0,
+            "cdk synth filter: expected >=60% savings, got {:.1}% ({} -> {} tokens)",
+            savings,
+            input_tokens,
+            output_tokens
+        );
+    }
+
+    #[test]
+    fn test_filter_cdk_synth_snapshot() {
+        let input = include_str!("../../../tests/fixtures/cdk_synth_raw.txt");
+        let output = filter_cdk_synth(input);
+        assert_snapshot!(output);
+    }
+
+    // ──────────────── cdk synth — _1 fixture (template path) ────────────────
+
+    #[test]
+    fn test_filter_cdk_synth_1_yaml_template() {
+        let input = include_str!("../../../tests/fixtures/cdk_synth_raw_1.txt");
+        let output = filter_cdk_synth(input);
+
+        // Template path: resource types extracted
+        assert!(output.contains("Resources:"));
+        assert!(output.contains("IAM::Role"));
+        assert!(output.contains("IAM::Policy"));
+        assert!(output.contains("Lambda::Function"));
+        // Full YAML not present
+        assert!(!output.contains("Properties:"));
+        assert!(!output.contains("BucketName:"));
+    }
+
+    #[test]
+    fn test_filter_cdk_synth_1_savings() {
+        let input = include_str!("../../../tests/fixtures/cdk_synth_raw_1.txt");
+        let output = filter_cdk_synth(input);
+
+        let input_tokens = count_tokens(input);
+        let output_tokens = count_tokens(&output);
+        let savings = 100.0 - (output_tokens as f64 / input_tokens as f64 * 100.0);
+
+        assert!(
+            savings >= 60.0,
+            "cdk synth _1 filter: expected >=60% savings, got {:.1}% ({} -> {} tokens)",
+            savings,
+            input_tokens,
+            output_tokens
+        );
+    }
+
+    #[test]
+    fn test_filter_cdk_synth_1_snapshot() {
+        let input = include_str!("../../../tests/fixtures/cdk_synth_raw_1.txt");
+        let output = filter_cdk_synth(input);
+        assert_snapshot!(output);
+    }
+
+    // ──────────────── cdk synth — edge cases ────────────────
+
+    #[test]
+    fn test_filter_cdk_synth_empty() {
+        let output = filter_cdk_synth("");
+        assert!(output.contains("Resources: 0"));
+    }
+
+    #[test]
+    fn test_filter_cdk_synth_yaml_synthetic() {
+        let input = r#"Resources:
+  MyBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: my-bucket
+  MyFunc:
+    Type: AWS::Lambda::Function
+    Properties:
+      Runtime: nodejs22.x
+  MyTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: my-table
+  MyFunc2:
+    Type: AWS::Lambda::Function
+    Properties:
+      Runtime: python3.14"#;
+
+        let output = filter_cdk_synth(input);
+
+        assert!(output.contains("Resources: 4 total"));
+        assert!(output.contains("Lambda::Function x2"));
+        assert!(output.contains("S3::Bucket"));
+        assert!(output.contains("DynamoDB::Table"));
+        assert!(!output.contains("Properties:"));
+    }
+
+    // ──────────────── cdk deploy — main fixture ────────────────
+
+    #[test]
+    fn test_filter_cdk_deploy_basic() {
+        let input = include_str!("../../../tests/fixtures/cdk_deploy_raw.txt");
+        let output = filter_cdk_deploy(input);
+
+        assert!(output.contains("\u{2705}"));
+        // Per-resource progress stripped
+        assert!(!output.contains("CREATE_IN_PROGRESS"));
+        assert!(!output.contains("10:30:"));
+        // Bundling stripped
+        assert!(!output.contains("Bundling asset"));
+    }
+
+    #[test]
+    fn test_filter_cdk_deploy_outputs_preserved() {
+        let input = include_str!("../../../tests/fixtures/cdk_deploy_raw.txt");
+        let output = filter_cdk_deploy(input);
+
+        assert!(output.contains("Outputs:"));
+        assert!(output.contains("ApiEndpoint"));
+    }
+
+    #[test]
+    fn test_filter_cdk_deploy_resource_summary() {
+        let input = include_str!("../../../tests/fixtures/cdk_deploy_raw.txt");
+        let output = filter_cdk_deploy(input);
+
+        assert!(output.contains("Resources:"));
+        assert!(output.contains("complete"));
+    }
+
+    #[test]
+    fn test_filter_cdk_deploy_savings() {
+        let input = include_str!("../../../tests/fixtures/cdk_deploy_raw.txt");
+        let output = filter_cdk_deploy(input);
+
+        let input_tokens = count_tokens(input);
+        let output_tokens = count_tokens(&output);
+        let savings = 100.0 - (output_tokens as f64 / input_tokens as f64 * 100.0);
+
+        assert!(
+            savings >= 60.0,
+            "cdk deploy filter: expected >=60% savings, got {:.1}% ({} -> {} tokens)",
+            savings,
+            input_tokens,
+            output_tokens
+        );
+    }
+
+    #[test]
+    fn test_filter_cdk_deploy_snapshot() {
+        let input = include_str!("../../../tests/fixtures/cdk_deploy_raw.txt");
+        let output = filter_cdk_deploy(input);
+        assert_snapshot!(output);
+    }
+
+    // ──────────────── cdk deploy — _1 fixture (SampleApp) ────────────────
+
+    #[test]
+    fn test_filter_cdk_deploy_1_basic() {
+        let input = include_str!("../../../tests/fixtures/cdk_deploy_raw_1.txt");
+        let output = filter_cdk_deploy(input);
+
+        // Success detected (mojibake checkmark)
+        assert!(
+            output.contains("SampleApp-RssBatch"),
+            "Should contain stack name. Output:\n{}",
+            output
+        );
+        // Progress stripped
+        assert!(!output.contains("UPDATE_IN_PROGRESS"));
+        assert!(!output.contains("17:20:"));
+    }
+
+    #[test]
+    fn test_filter_cdk_deploy_1_notices_stripped() {
+        let input = include_str!("../../../tests/fixtures/cdk_deploy_raw_1.txt");
+        let output = filter_cdk_deploy(input);
+
+        assert!(!output.contains("NOTICES"));
+        assert!(!output.contains("cdk watch"));
+        assert!(!output.contains("cdk acknowledge"));
+    }
+
+    #[test]
+    fn test_filter_cdk_deploy_1_savings() {
+        let input = include_str!("../../../tests/fixtures/cdk_deploy_raw_1.txt");
+        let output = filter_cdk_deploy(input);
+
+        let input_tokens = count_tokens(input);
+        let output_tokens = count_tokens(&output);
+        let savings = 100.0 - (output_tokens as f64 / input_tokens as f64 * 100.0);
+
+        assert!(
+            savings >= 60.0,
+            "cdk deploy _1 filter: expected >=60% savings, got {:.1}% ({} -> {} tokens)",
+            savings,
+            input_tokens,
+            output_tokens
+        );
+    }
+
+    #[test]
+    fn test_filter_cdk_deploy_1_snapshot() {
+        let input = include_str!("../../../tests/fixtures/cdk_deploy_raw_1.txt");
+        let output = filter_cdk_deploy(input);
+        assert_snapshot!(output);
+    }
+
+    // ──────────────── cdk deploy — edge cases ────────────────
+
+    #[test]
+    fn test_filter_cdk_deploy_empty() {
+        let output = filter_cdk_deploy("");
+        // Should not panic on empty input and produce empty result
+        assert!(
+            output.is_empty(),
+            "Expected empty output, got: {:?}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_filter_cdk_deploy_failure() {
+        let input = r#"InfraStack: deploying... [1/1]
+InfraStack: creating CloudFormation changeset...
+ 0/5 | 10:30:01 AM | CREATE_IN_PROGRESS   | AWS::Lambda::Function | ApiLambda
+ 1/5 | 10:30:10 AM | CREATE_COMPLETE      | AWS::Lambda::Function | ApiLambda
+ 1/5 | 10:30:15 AM | CREATE_FAILED        | AWS::IAM::Policy      | BadPolicy (Resource limit exceeded)
+ 1/5 | 10:30:20 AM | ROLLBACK_IN_PROGRESS | AWS::CloudFormation::Stack | InfraStack
+
+❌ Deployment failed: Error: The stack named InfraStack failed creation"#;
+
+        let output = filter_cdk_deploy(input);
+
+        assert!(
+            output.contains("FAILED")
+                || output.contains("Deployment failed")
+                || output.contains("❌")
+        );
+    }
+}

--- a/src/cmds/cloud/mod.rs
+++ b/src/cmds/cloud/mod.rs
@@ -1,6 +1,7 @@
 //! Cloud and infrastructure tool filters.
 
 pub mod aws_cmd;
+pub mod cdk_cmd;
 pub mod container;
 pub mod curl_cmd;
 pub mod psql_cmd;

--- a/src/cmds/cloud/snapshots/rtk__cmds__cloud__cdk_cmd__tests__filter_cdk_deploy_1_snapshot.snap
+++ b/src/cmds/cloud/snapshots/rtk__cmds__cloud__cdk_cmd__tests__filter_cdk_deploy_1_snapshot.snap
@@ -1,0 +1,9 @@
+---
+source: src/cmds/cloud/cdk_cmd.rs
+expression: output
+---
+Ô£à  SampleApp-RssBatch
+Resources: 4/7 complete
+
+Ô£¿  Deployment time: 42.04s
+Ô£¿  Total time: 43.44s

--- a/src/cmds/cloud/snapshots/rtk__cmds__cloud__cdk_cmd__tests__filter_cdk_deploy_snapshot.snap
+++ b/src/cmds/cloud/snapshots/rtk__cmds__cloud__cdk_cmd__tests__filter_cdk_deploy_snapshot.snap
@@ -1,0 +1,13 @@
+---
+source: src/cmds/cloud/cdk_cmd.rs
+expression: output
+---
+✅  InfraStack
+Resources: 12/24 complete
+
+Outputs:
+  InfraStack.ApiEndpoint = https://abc123.execute-api.us-east-1.amazonaws.com
+  InfraStack.AuthEndpoint = https://def456.execute-api.us-east-1.amazonaws.com
+
+✨  Deployment time: 56.2s
+✨  Total time: 60.43s

--- a/src/cmds/cloud/snapshots/rtk__cmds__cloud__cdk_cmd__tests__filter_cdk_diff_1_snapshot.snap
+++ b/src/cmds/cloud/snapshots/rtk__cmds__cloud__cdk_cmd__tests__filter_cdk_diff_1_snapshot.snap
@@ -1,0 +1,40 @@
+---
+source: src/cmds/cloud/cdk_cmd.rs
+expression: output
+---
+Stack SampleApp-RssBatch
+Resources
+[~] Custom::AWS PopulateFeedTable/Resource PopulateFeedTableFCA8F2DB may be replaced
+ Ôö£ÔöÇ [~] Create (may cause replacement)
+ Ôöé   ÔööÔöÇ [~] .Fn::Join:
+ Ôöé       ÔööÔöÇ @@ -5,6 +5,6 @@
+ Ôöé          [ ]     {
+ Ôöé          [ ]       "Ref": "FeedInitFunctionBDD3CB88"
+ Ôöé          [ ]     },
+ Ôöé          [-]     "\",\"InvocationType\":\"RequestResponse\"},\"physicalResourceId\":{\"id\":\"PopulateFeedTable-...
+ Ôöé          [+]     "\",\"InvocationType\":\"RequestResponse\"},\"physicalResourceId\":{\"id\":\"PopulateFeedTable-...
+ Ôöé          [ ]   ]
+ Ôöé          [ ] ]
+ ÔööÔöÇ [~] Update (may cause replacement)
+     ÔööÔöÇ [~] .Fn::Join:
+         ÔööÔöÇ @@ -5,6 +5,6 @@
+            [ ]     {
+            [ ]       "Ref": "FeedInitFunctionBDD3CB88"
+            [ ]     },
+            [-]     "\",\"InvocationType\":\"RequestResponse\"},\"physicalResourceId\":{\"id\":\"PopulateFeedTable-8b...
+            [+]     "\",\"InvocationType\":\"RequestResponse\"},\"physicalResourceId\":{\"id\":\"PopulateFeedTable-70...
+            [ ]   ]
+            [ ] ]
+[~] AWS::Lambda::Function CollectRSSLambda CollectRSSLambda
+ ÔööÔöÇ [~] Code
+     ÔööÔöÇ [~] .S3Key:
+         Ôö£ÔöÇ [-] 76ce6425ec357997f182cc7370fd6cf0aa8c7c3f7559feca7e9de72232a2008a.zip
+         ÔööÔöÇ [+] e83d32d44b93a5871e77d2b8586d9c5755097bcc11006b0cc914495e2306fcb3.zip
+[~] AWS::Lambda::Function ProcessBatchResultsLambda ProcessBatchResultsLambda
+ ÔööÔöÇ [~] Code
+     ÔööÔöÇ [~] .S3Key:
+         Ôö£ÔöÇ [-] 891f967309fb7f5936e53784f423df3061ecd529ab331eb9ea4d88a52e0d47c8.zip
+         ÔööÔöÇ [+] 3abbe79759e53b9fd31898d57deff1c9ec8792cba0b556bd2da396cd4cdbb651.zip
+Ô£¿  Number of stacks with differences: 1
+
+Summary: 1 added, 3 changed, 1 removed

--- a/src/cmds/cloud/snapshots/rtk__cmds__cloud__cdk_cmd__tests__filter_cdk_diff_snapshot.snap
+++ b/src/cmds/cloud/snapshots/rtk__cmds__cloud__cdk_cmd__tests__filter_cdk_diff_snapshot.snap
@@ -1,0 +1,81 @@
+---
+source: src/cmds/cloud/cdk_cmd.rs
+expression: output
+---
+Stack CdkBackendStack/PushNotificationsStack
+Resources
+[~] AWS::Lambda::Function PushNotificationsStack/PrepareNotificationLambda PrepareNotificationLambda
+ └── [~] Code
+     └── [~] .S3Key:
+         ├── [-] 0afbc113e7c243e1e3ba1a74ecd701b60601672f05b750fde0c1b211822eba4d.zip
+         └── [+] df60cee9d3e19433ea66325e1a662f28d7782e7d966caf067b91bd8f944bd190.zip
+Stack CdkBackendStack/ResetQuotaStack
+Resources
+[~] AWS::Lambda::Function ResetQuotaStack/ResetQuotaLambda ResetQuotaLambda
+ └── [~] Code
+     └── [~] .S3Key:
+         ├── [-] e348fe5ed9a59afa305e345f67e5c0406974ebaed601ef7e566c1bfb2dd7a939.zip
+         └── [+] 59ee62c714aa2a4d71e6208cf58f8c21aa2d13f68068f8a5f509eeee7c081271.zip
+Stack CdkBackendStack/WorkflowStack
+Resources
+[~] AWS::Lambda::Function WorkflowStack/PromptLambda PromptLambda
+ └── [~] Code
+     └── [~] .S3Key:
+         ├── [-] d8c048a306bb272f16c81618d871f8b666143c294e63b4e559d7971306fb84e2.zip
+         └── [+] e4fac3bbe923368939f864a00cececa3cc726719bf29d0a159dd48f2c1b4748a.zip
+[~] AWS::Lambda::Function WorkflowStack/GeminiImageLambda GeminiImageLambda
+ └── [~] Code
+     └── [~] .S3Key:
+         ├── [-] 14d941c93213cc4a54e956d05995bd8a9662e6f9b5421a0a23c41e1873b47a1a.zip
+         └── [+] 337a0a587642ec41c47becbe093c870cc00c3dc4fb48cbffc240a3990780d745.zip
+Stack CdkBackendStack/BatchWorkflowStack
+Resources
+[~] AWS::Lambda::Function BatchWorkflowStack/BatchSubmitLambda BatchSubmitLambda
+ └── [~] Code
+     └── [~] .S3Key:
+         ├── [-] 367bc9d3c12f4637952f83c07d03ff88d66a3536751f69e4ed36f6f67ddd11a2.zip
+         └── [+] 190be3b3e86efe5e694ca15b2d57d89239fed12619a1e868c95eb74f224b6fe8.zip
+[~] AWS::Lambda::Function BatchWorkflowStack/BatchCollectLambda BatchCollectLambda
+ └── [~] Code
+     └── [~] .S3Key:
+         ├── [-] 43bca22ec3d3950f6fdf4da14b62274e81c4f950ce0cf3f005e81c905afc2d62.zip
+         └── [+] 3f815ea087596c6360573f84cbc8d06c3a52f260ebcaa286bf060a68a63478b4.zip
+[~] AWS::Lambda::Function BatchWorkflowStack/BatchPollLambda BatchPollLambda
+ └── [~] Code
+     └── [~] .S3Key:
+         ├── [-] a7bb185ce4d34ff5d1cc5e1e96178c131971bee1e5c154bd4d71e6cc5814a4b3.zip
+         └── [+] 8a715c70416b843a1d8c6c66b50dc9fb3ad2eb301898f03b58ffc91ffe588f27.zip
+Stack CdkBackendStack
+Resources
+[~] AWS::Lambda::Function StatusUpdaterLambda StatusUpdaterLambda
+ ├── [~] Code
+ │   └── [~] .S3Key:
+ │       ├── [-] c93e313789c9867ae227a947e0445cfebf24186350e0cf655cd4d74234562bfb.zip
+ │       └── [+] d0b52efc00aa05e55688631bbda014725bd79249dc2757aceddcc13329468c1c.zip
+ └── [~] Metadata
+     └── [~] .aws:asset:path:
+         ├── [-] asset.c93e313789c9867ae227a947e0445cfebf24186350e0cf655cd4d74234562bfb
+         └── [+] asset.d0b52efc00aa05e55688631bbda014725bd79249dc2757aceddcc13329468c1c
+[~] AWS::Lambda::Function CheckQuotaLambda CheckQuotaLambda
+ ├── [~] Code
+ │   └── [~] .S3Key:
+ │       ├── [-] eab24d4f670d031bde2bb87bed19c5e1545e6e42663f7fe494aa5a49cf4860db.zip
+ │       └── [+] 2a15176866cb9252285027155523375b741faa231209800fd56db54f0750b8d3.zip
+ └── [~] Metadata
+     └── [~] .aws:asset:path:
+         ├── [-] asset.eab24d4f670d031bde2bb87bed19c5e1545e6e42663f7fe494aa5a49cf4860db
+         └── [+] asset.2a15176866cb9252285027155523375b741faa231209800fd56db54f0750b8d3
+[~] AWS::Lambda::Function RefundQuotaLambda RefundQuotaLambda
+ ├── [~] Code
+ │   └── [~] .S3Key:
+ │       ├── [-] 5a0622564bca54b572d895b4f1c76005d8f418fd6254baeed8a299208b97c8d7.zip
+ │       └── [+] 4a81f6a8bbe04ec28d0f7850555961ed5c36218cb30c6878fc4a76af7d350506.zip
+ └── [~] Metadata
+     └── [~] .aws:asset:path:
+         ├── [-] asset.5a0622564bca54b572d895b4f1c76005d8f418fd6254baeed8a299208b97c8d7
+         └── [+] asset.4a81f6a8bbe04ec28d0f7850555961ed5c36218cb30c6878fc4a76af7d350506
+Stack CdkBackendStack-MonitoringStackNestedStackMonitoringStackNestedStackResourceC34BBBCF-1VCCCYW052S0W
+There were no differences
+✨  Number of stacks with differences: 5
+
+Summary: 0 added, 10 changed, 0 removed

--- a/src/cmds/cloud/snapshots/rtk__cmds__cloud__cdk_cmd__tests__filter_cdk_synth_1_snapshot.snap
+++ b/src/cmds/cloud/snapshots/rtk__cmds__cloud__cdk_cmd__tests__filter_cdk_synth_1_snapshot.snap
@@ -1,0 +1,21 @@
+---
+source: src/cmds/cloud/cdk_cmd.rs
+expression: output
+---
+Resources: 44 total
+  IAM::Role x10
+  IAM::Policy x9
+  Lambda::Function x7
+  Logs::LogGroup x6
+  CDK::Metadata
+  DynamoDB::Table
+  Events::Rule
+  Lambda::Permission
+  S3::Bucket
+  S3::BucketPolicy
+  SQS::Queue
+  SQS::QueuePolicy
+  SSM::Parameter
+  SSM::Parameter::Value<String>
+  Scheduler::Schedule
+  StepFunctions::StateMachine

--- a/src/cmds/cloud/snapshots/rtk__cmds__cloud__cdk_cmd__tests__filter_cdk_synth_snapshot.snap
+++ b/src/cmds/cloud/snapshots/rtk__cmds__cloud__cdk_cmd__tests__filter_cdk_synth_snapshot.snap
@@ -1,0 +1,6 @@
+---
+source: src/cmds/cloud/cdk_cmd.rs
+expression: output
+---
+Successfully synthesized to D:\projects\SampleApp\cdk-backend\cdk.out
+Stacks: CdkBackendStack/PushNotificationsStack, CdkBackendStack/ResetQuotaStack, CdkBackendStack/WorkflowStack, CdkBackendStack/BatchWorkflowStack, CdkBackendStack

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -51,6 +51,8 @@ pub const PATTERNS: &[&str] = &[
     r"^(?:bundle\s+exec\s+)?(?:bin/)?(?:rake|rails)\s+test",
     r"^(?:bundle\s+exec\s+)?rspec(?:\s|$)",
     r"^(?:bundle\s+exec\s+)?rubocop(?:\s|$)",
+    // AWS CDK
+    r"^(npx\s+)?cdk\s+(diff|synth|deploy|destroy|bootstrap)",
     // AWS CLI
     r"^aws\s+",
     // PostgreSQL
@@ -376,6 +378,15 @@ pub const RULES: &[RtkRule] = &[
         category: "Build",
         savings_pct: 65.0,
         subcmd_savings: &[],
+        subcmd_status: &[],
+    },
+    // AWS CDK
+    RtkRule {
+        rtk_cmd: "rtk cdk",
+        rewrite_prefixes: &["npx cdk", "cdk"],
+        category: "Infra",
+        savings_pct: 75.0,
+        subcmd_savings: &[("diff", 80.0), ("synth", 80.0), ("deploy", 70.0)],
         subcmd_status: &[],
     },
     // AWS CLI

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -387,7 +387,10 @@ pub const RULES: &[RtkRule] = &[
         category: "Infra",
         savings_pct: 75.0,
         subcmd_savings: &[("diff", 80.0), ("synth", 80.0), ("deploy", 70.0)],
-        subcmd_status: &[],
+        subcmd_status: &[
+            ("destroy", RtkStatus::Passthrough),
+            ("bootstrap", RtkStatus::Passthrough),
+        ],
     },
     // AWS CLI
     RtkRule {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod learn;
 mod parser;
 
 // Re-export command modules for routing
-use cmds::cloud::{aws_cmd, container, curl_cmd, psql_cmd, wget_cmd};
+use cmds::cloud::{aws_cmd, cdk_cmd, container, curl_cmd, psql_cmd, wget_cmd};
 use cmds::dotnet::{binlog, dotnet_cmd, dotnet_format_report, dotnet_trx};
 use cmds::git::{diff_cmd, gh_cmd, git, gt_cmd};
 use cmds::go::{go_cmd, golangci_cmd};
@@ -635,6 +635,12 @@ enum Commands {
         args: Vec<String>,
     },
 
+    /// AWS CDK commands with compact output
+    Cdk {
+        #[command(subcommand)]
+        command: CdkCommands,
+    },
+
     /// Go commands with compact output
     Go {
         #[command(subcommand)]
@@ -1003,6 +1009,31 @@ enum DotnetCommands {
         args: Vec<String>,
     },
     /// Passthrough: runs any unsupported dotnet subcommand directly
+    #[command(external_subcommand)]
+    Other(Vec<OsString>),
+}
+
+#[derive(Subcommand)]
+enum CdkCommands {
+    /// CDK diff with compact output (80% token reduction)
+    Diff {
+        /// Additional cdk diff arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// CDK synth with compact output (80% token reduction)
+    Synth {
+        /// Additional cdk synth arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// CDK deploy with compact output (70% token reduction)
+    Deploy {
+        /// Additional cdk deploy arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Passthrough: runs any unsupported cdk subcommand directly
     #[command(external_subcommand)]
     Other(Vec<OsString>),
 }
@@ -1972,6 +2003,25 @@ fn main() -> Result<()> {
                 "playwright" => {
                     playwright_cmd::run(&args[1..], cli.verbose)?;
                 }
+                "cdk" => {
+                    // Route to cdk_cmd based on subcommand
+                    if args.len() > 1 {
+                        let cdk_rest: Vec<String> = args[2..].to_vec();
+                        match args[1].as_str() {
+                            "diff" => cdk_cmd::run_diff(&cdk_rest, cli.verbose)?,
+                            "synth" | "synthesize" => cdk_cmd::run_synth(&cdk_rest, cli.verbose)?,
+                            "deploy" => cdk_cmd::run_deploy(&cdk_rest, cli.verbose)?,
+                            _ => {
+                                let os_args: Vec<OsString> =
+                                    args[1..].iter().map(OsString::from).collect();
+                                cdk_cmd::run_other(&os_args, cli.verbose)?;
+                            }
+                        }
+                    } else {
+                        let os_args: Vec<OsString> = vec![];
+                        cdk_cmd::run_other(&os_args, cli.verbose)?;
+                    }
+                }
                 _ => {
                     // Generic passthrough with npm boilerplate filter
                     npm_cmd::run(&args, cli.verbose, cli.skip_env)?;
@@ -2006,6 +2056,21 @@ fn main() -> Result<()> {
         Commands::Pip { args } => {
             pip_cmd::run(&args, cli.verbose)?;
         }
+
+        Commands::Cdk { command } => match command {
+            CdkCommands::Diff { args } => {
+                cdk_cmd::run_diff(&args, cli.verbose)?;
+            }
+            CdkCommands::Synth { args } => {
+                cdk_cmd::run_synth(&args, cli.verbose)?;
+            }
+            CdkCommands::Deploy { args } => {
+                cdk_cmd::run_deploy(&args, cli.verbose)?;
+            }
+            CdkCommands::Other(args) => {
+                cdk_cmd::run_other(&args, cli.verbose)?;
+            }
+        },
 
         Commands::Go { command } => match command {
             GoCommands::Test { args } => {
@@ -2266,6 +2331,7 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Rubocop { .. }
             | Commands::Rspec { .. }
             | Commands::Pip { .. }
+            | Commands::Cdk { .. }
             | Commands::Go { .. }
             | Commands::GolangciLint { .. }
             | Commands::Gt { .. }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1022,6 +1022,7 @@ enum CdkCommands {
         args: Vec<String>,
     },
     /// CDK synth with compact output (80% token reduction)
+    #[command(alias = "synthesize")]
     Synth {
         /// Additional cdk synth arguments
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]

--- a/tests/fixtures/cdk_deploy_raw.txt
+++ b/tests/fixtures/cdk_deploy_raw.txt
@@ -1,0 +1,59 @@
+Bundling asset InfraStack/ApiLambda/Code/Stage...
+
+  cdk.out/bundling-temp-abc123/index.js  150.2kb
+
+⚡ Done in 245ms
+Bundling asset InfraStack/AuthLambda/Code/Stage...
+
+  cdk.out/bundling-temp-def456/index.js  89.7kb
+
+⚡ Done in 198ms
+Bundling asset InfraStack/WorkerLambda/Code/Stage...
+
+  cdk.out/bundling-temp-ghi789/index.js  203.4kb
+
+⚡ Done in 312ms
+
+✨  Synthesis time: 4.23s
+
+InfraStack: deploying... [1/1]
+InfraStack: creating CloudFormation changeset...
+ 0/12 | 10:30:01 AM | REVIEW_IN_PROGRESS   | AWS::CloudFormation::Stack | InfraStack User Initiated
+ 0/12 | 10:30:05 AM | CREATE_IN_PROGRESS   | AWS::CloudFormation::Stack | InfraStack User Initiated
+ 0/12 | 10:30:08 AM | CREATE_IN_PROGRESS   | AWS::DynamoDB::Table    | ApiTable (InfraStackApiTableB7E24CF1)
+ 0/12 | 10:30:08 AM | CREATE_IN_PROGRESS   | AWS::IAM::Role          | ApiLambda/ServiceRole (InfraStackApiLambdaServiceRoleABC123)
+ 0/12 | 10:30:08 AM | CREATE_IN_PROGRESS   | AWS::IAM::Role          | AuthLambda/ServiceRole (InfraStackAuthLambdaServiceRoleJKL012)
+ 0/12 | 10:30:08 AM | CREATE_IN_PROGRESS   | AWS::IAM::Role          | WorkerLambda/ServiceRole (InfraStackWorkerLambdaServiceRolePQR678)
+ 0/12 | 10:30:09 AM | CREATE_IN_PROGRESS   | AWS::SNS::Topic         | NotificationTopic (InfraStackNotificationTopicSTU901)
+ 1/12 | 10:30:15 AM | CREATE_COMPLETE      | AWS::SNS::Topic         | NotificationTopic (InfraStackNotificationTopicSTU901)
+ 2/12 | 10:30:20 AM | CREATE_COMPLETE      | AWS::DynamoDB::Table    | ApiTable (InfraStackApiTableB7E24CF1)
+ 3/12 | 10:30:22 AM | CREATE_COMPLETE      | AWS::IAM::Role          | ApiLambda/ServiceRole (InfraStackApiLambdaServiceRoleABC123)
+ 3/12 | 10:30:22 AM | CREATE_IN_PROGRESS   | AWS::IAM::Policy        | ApiLambda/ServiceRole/DefaultPolicy (InfraStackApiLambdaServiceRoleDefaultPolicyDEF456)
+ 4/12 | 10:30:23 AM | CREATE_COMPLETE      | AWS::IAM::Role          | AuthLambda/ServiceRole (InfraStackAuthLambdaServiceRoleJKL012)
+ 4/12 | 10:30:23 AM | CREATE_IN_PROGRESS   | AWS::Lambda::Function   | AuthLambda (InfraStackAuthLambdaGHI789)
+ 5/12 | 10:30:24 AM | CREATE_COMPLETE      | AWS::IAM::Role          | WorkerLambda/ServiceRole (InfraStackWorkerLambdaServiceRolePQR678)
+ 5/12 | 10:30:24 AM | CREATE_IN_PROGRESS   | AWS::Lambda::Function   | WorkerLambda (InfraStackWorkerLambdaMNO345)
+ 6/12 | 10:30:35 AM | CREATE_COMPLETE      | AWS::IAM::Policy        | ApiLambda/ServiceRole/DefaultPolicy (InfraStackApiLambdaServiceRoleDefaultPolicyDEF456)
+ 6/12 | 10:30:35 AM | CREATE_IN_PROGRESS   | AWS::Lambda::Function   | ApiLambda (InfraStackApiLambdaDEF456)
+ 7/12 | 10:30:40 AM | CREATE_COMPLETE      | AWS::Lambda::Function   | AuthLambda (InfraStackAuthLambdaGHI789)
+ 8/12 | 10:30:42 AM | CREATE_COMPLETE      | AWS::Lambda::Function   | WorkerLambda (InfraStackWorkerLambdaMNO345)
+ 9/12 | 10:30:48 AM | CREATE_COMPLETE      | AWS::Lambda::Function   | ApiLambda (InfraStackApiLambdaDEF456)
+ 9/12 | 10:30:48 AM | CREATE_IN_PROGRESS   | AWS::CloudWatch::Alarm  | Alarm (InfraStackAlarmVWX234)
+10/12 | 10:30:52 AM | CREATE_COMPLETE      | AWS::CloudWatch::Alarm  | Alarm (InfraStackAlarmVWX234)
+10/12 | 10:30:52 AM | CREATE_IN_PROGRESS   | AWS::CDK::Metadata      | CDKMetadata/Default (CDKMetadata)
+11/12 | 10:30:55 AM | CREATE_COMPLETE      | AWS::CDK::Metadata      | CDKMetadata/Default (CDKMetadata)
+12/12 | 10:30:57 AM | CREATE_COMPLETE      | AWS::CloudFormation::Stack | InfraStack
+
+ ✅  InfraStack
+
+✨  Deployment time: 56.2s
+
+Outputs:
+InfraStack.ApiEndpoint = https://abc123.execute-api.us-east-1.amazonaws.com
+InfraStack.AuthEndpoint = https://def456.execute-api.us-east-1.amazonaws.com
+
+Stack ARN:
+arn:aws:cloudformation:us-east-1:123456789012:stack/InfraStack/abc-123-def-456
+
+✨  Total time: 60.43s
+

--- a/tests/fixtures/cdk_deploy_raw_1.txt
+++ b/tests/fixtures/cdk_deploy_raw_1.txt
@@ -1,0 +1,88 @@
+﻿yarn run v1.22.22
+node.exe : warning package.json: No license field
+Au caractère C:\nvm4w\nodejs\cdk.ps1:16 : 5
++     & "$basedir/node$exe"  "$basedir/node_modules/aws-cdk/bin/cdk" $a ...
++     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : NotSpecified: (warning package.json: No license field:String) [], RemoteException
+    + FullyQualifiedErrorId : NativeCommandError
+ 
+$ D:\projects\SampleApp\cdk-backend\node_modules\.bin\tsx bin/app.ts
+Bundling asset SampleApp-RssBatch/StoreTaskTokenLambda/Code/Stage...
+warning package.json: No license field
+$ D:\projects\SampleApp\cdk-backend\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workers\store-task-token\handler.ts --target=node22 --platform=node 
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-ae0e8c5f7a86d7d58e8fa87869b0d2862cba7c5ca3fbae914b1c86392227af19-building\index.js --external:@aws-sdk/*
+
+  ...8e8fa87869b0d2862cba7c5ca3fbae914b1c86392227af19-building\index.js  1.9kb
+
+Bundling asset SampleApp-RssBatch/BatchCallbackLambda/Code/Stage...
+warning package.json: No license field
+$ D:\projects\SampleApp\cdk-backend\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workers\batch-callback\handler.ts --target=node22 --platform=node 
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-917e0be5203bd1448bd1b0831ddc5586ad658926a5746a85c9c5b86e72017d6a-building\index.js --external:@aws-sdk/*
+
+  ...8bd1b0831ddc5586ad658926a5746a85c9c5b86e72017d6a-building\index.js  3.4kb
+
+Done in 1.27s.
+
+Ô£¿  Synthesis time: 1.4s
+
+SampleApp-RssBatch: start: Building CollectRSSLambda/Code
+SampleApp-RssBatch: success: Built CollectRSSLambda/Code
+SampleApp-RssBatch: start: Building ProcessBatchResultsLambda/Code
+SampleApp-RssBatch: success: Built ProcessBatchResultsLambda/Code
+SampleApp-RssBatch: start: Building SampleApp-RssBatch Template
+SampleApp-RssBatch: success: Built SampleApp-RssBatch Template
+SampleApp-RssBatch: start: Publishing SampleApp-RssBatch Template (123456789012-us-east-1-0a3e4814)
+SampleApp-RssBatch: start: Publishing CollectRSSLambda/Code (123456789012-us-east-1-20788540)
+SampleApp-RssBatch: start: Publishing ProcessBatchResultsLambda/Code (123456789012-us-east-1-1824a9cc)
+SampleApp-RssBatch: success: Published ProcessBatchResultsLambda/Code (123456789012-us-east-1-1824a9cc)
+SampleApp-RssBatch: success: Published SampleApp-RssBatch Template (123456789012-us-east-1-0a3e4814)
+SampleApp-RssBatch: success: Published CollectRSSLambda/Code (123456789012-us-east-1-20788540)
+SampleApp-RssBatch: deploying... [1/1]
+SampleApp-RssBatch: creating CloudFormation changeset...
+SampleApp-RssBatch | 0/6 | 17:20:49 | UPDATE_IN_PROGRESS   | AWS::CloudFormation::Stack       | SampleApp-RssBatch User Initiated
+SampleApp-RssBatch | 0/6 | 17:20:55 | UPDATE_IN_PROGRESS   | AWS::Lambda::Function            | ProcessBatchResultsLambda 
+SampleApp-RssBatch | 0/6 | 17:20:55 | UPDATE_IN_PROGRESS   | AWS::Lambda::Function            | CollectRSSLambda 
+SampleApp-RssBatch | 1/6 | 17:21:04 | UPDATE_COMPLETE      | AWS::Lambda::Function            | ProcessBatchResultsLambda 
+SampleApp-RssBatch | 2/6 | 17:21:04 | UPDATE_COMPLETE      | AWS::Lambda::Function            | CollectRSSLambda 
+SampleApp-RssBatch | 3/6 | 17:21:06 | UPDATE_COMPLETE_CLEA | AWS::CloudFormation::Stack       | SampleApp-RssBatch 
+SampleApp-RssBatch | 4/6 | 17:21:08 | UPDATE_COMPLETE      | AWS::CloudFormation::Stack       | SampleApp-RssBatch 
+
+ Ô£à  SampleApp-RssBatch
+
+Ô£¿  Deployment time: 42.04s
+
+Stack ARN:
+arn:aws:cloudformation:us-east-1:123456789012:stack/SampleApp-RssBatch/aaa11111-2222-3333-4444-bbbbbbbbbbbb
+
+Ô£¿  Total time: 43.44s
+
+
+NOTICES         (What's this? https://github.com/aws/aws-cdk/wiki/CLI-Notices)
+
+37013	(cli) cdk watch triggers deployment unexpectedly or not at all
+
+	Overview: Do not use 'cdk watch' with this version of the cdk cli.
+	          Upgrade to ^2.1106.0.
+
+	Affected versions: cli: >=2.1103.0 <2.1106.0
+
+	More information at: https://github.com/aws/aws-cdk/issues/37013
+
+
+34892	CDK CLI collects telemetry data on command usage starting at version 2.1100.0 (unless opted out)
+
+	Overview: We do not collect customer content and we anonymize the
+	          telemetry we do collect. See the attached issue for more
+	          information on what data is collected, why, and how to
+	          opt-out. Telemetry will NOT be collected for any CDK CLI
+	          version prior to version 2.1100.0 - regardless of
+	          opt-in/out. You can also view the telemetry we collect by
+	          logging it to a local file, by adding
+	          `--telemetry-file=my/local/file` to any `cdk` command.
+
+	Affected versions: cli: >=2.1100.0 <2.1106.1
+
+	More information at: https://github.com/aws/aws-cdk/issues/34892
+
+
+If you donÔÇÖt want to see a notice anymore, use "cdk acknowledge <id>". For example, "cdk acknowledge 37013".

--- a/tests/fixtures/cdk_diff_raw.txt
+++ b/tests/fixtures/cdk_diff_raw.txt
@@ -1,0 +1,241 @@
+yarn run v1.22.22
+node.exe : warning package.json: No license field
+Au caractère C:\nodejs\cdk.ps1:16 : 5
++     & "$basedir/node$exe"  "$basedir/node_modules/aws-cdk/bin/cdk" $a ...
++     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : NotSpecified: (warning package.json: No license field:String) [], RemoteException
+    + FullyQualifiedErrorId : NativeCommandError
+
+$ D:\projects\SampleApp\node_modules\.bin\tsx bin/cdk-backend.ts
+⚠️  amplify_outputs.json is older than 7 days. Consider running 'npx ampx generate outputs' to refresh.
+Bundling asset CdkBackendStack/StatusUpdaterLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workflow\status-updater.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-67e3ef8bbf7e62fb01b1bd8ae1534e17b15934c0141e0a520af0a4415ca1bce1-building\index.js
+
+  ...b1bd8ae1534e17b15934c0141e0a520af0a4415ca1bce1-building\index.js  5.5mb
+
+Bundling asset CdkBackendStack/CheckQuotaLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workers\check-quota\handler.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-86224dfea4bf525da7a7914649ee2144ba786d3067e4f1ae40eba18800590f67-building\index.js
+
+  ...a7914649ee2144ba786d3067e4f1ae40eba18800590f67-building\index.js  5.5mb
+
+Bundling asset CdkBackendStack/RefundQuotaLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workers\refund-quota\handler.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-5971989bda1ea134e95126556db731245c4030f832be49968233e28dead45b80-building\index.js
+
+  ...5126556db731245c4030f832be49968233e28dead45b80-building\index.js  5.5mb
+
+Bundling asset CdkBackendStack/PreparePayloadLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workflow\prepare-payload\handler.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-2a68b182670678d1fc99204c4165220adde0b6331c3839070d80f062c05416b0-building\index.js
+
+  ...c99204c4165220adde0b6331c3839070d80f062c05416b0-building\index.js  13.4kb
+
+Bundling asset CdkBackendStack/MergeParallelLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workflow\merge-parallel\handler.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-b09a10e4a61270f1e7c91deb77ad433606c44b0e9594aae281ad617983febc71-building\index.js
+
+  ...e7c91deb77ad433606c44b0e9594aae281ad617983febc71-building\index.js  1.7kb
+
+Bundling asset CdkBackendStack/PushNotificationsStack/PrepareNotificationLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\push-notifications\prepare-notification.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-a7c9ce439010b227b9e94a5f5418d473ea1fb7876293ead65fd868c661ea79c6-building\index.js --external:@aws-sdk/client-sqs
+
+  ...9e94a5f5418d473ea1fb7876293ead65fd868c661ea79c6-building\index.js  33.2kb
+
+[WARNING] aws-cdk-lib.aws_iam.GrantOnPrincipalOptions#scope is deprecated.
+  The scope argument is currently unused.
+  This API will be removed in the next major release.
+Bundling asset CdkBackendStack/PushNotificationsStack/SendNotificationLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\push-notifications\send-notification.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-1494d4a7170f0d75ab192bfe4742faf3d386f9b39d5f8962616261b3d37da6e3-building\index.js --external:@aws-sdk/client-dynamodb --external:@aws-sdk/lib-dynamodb --external:@aws-sdk/client-sqs
+
+  ...92bfe4742faf3d386f9b39d5f8962616261b3d37da6e3-building\index.js  1001.9kb
+
+Bundling asset CdkBackendStack/PushNotificationsStack/CheckReceiptsLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\push-notifications\check-receipts.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-2a5213912bf12b508c2f37d70ee916047a8c684a45c0d2d16bc68df1ad010703-building\index.js --external:@aws-sdk/client-dynamodb --external:@aws-sdk/lib-dynamodb
+
+  ...f37d70ee916047a8c684a45c0d2d16bc68df1ad010703-building\index.js  1000.5kb
+
+Bundling asset CdkBackendStack/ResetQuotaStack/ResetQuotaLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\resetQuota\handler.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-3d23ecf5c27d9db8e7646ca291830098217887455c1c12713138fbf652c11b28-building\index.js --external:@aws-sdk/client-ssm
+
+  ...646ca291830098217887455c1c12713138fbf652c11b28-building\index.js  5.5mb
+
+Bundling asset CdkBackendStack/WorkflowStack/PromptLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workers\haiku-prompt\handler.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-1232f49c1bf0a3070f06ca4524ff51f24eea95d57b9aaf809a7e0dadcfa80ecf-building\index.js --external:@aws-sdk/client-bedrock-runtime --loader:.md=text
+
+  ...06ca4524ff51f24eea95d57b9aaf809a7e0dadcfa80ecf-building\index.js  5.2mb
+
+Bundling asset CdkBackendStack/WorkflowStack/GeminiImageLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workers\gemini-image\handler.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-09d802a8fa9b9e882f4233035f93fa8dd65d24aaa5017302414e2ebd3dc084e3-building\index.js --external:@aws-sdk/client-s3 --keep-names
+
+  ...4233035f93fa8dd65d24aaa5017302414e2ebd3dc084e3-building\index.js  5.0mb
+
+WARN AWS_SOLUTIONS_CONSTRUCTS_WARNING:  An override has been provided for the property: dynamoDbStreamParameters[startingPosition]. Default value: 'LATEST'. You provided: 'TRIM_HORIZON'.
+Bundling asset CdkBackendStack/BatchWorkflowStack/BatchSubmitLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workers\batch-submit\handler.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-bcf4fb382ee767437b8991dd33a4d4b5a77445503e679092ddb64943d6a5ba6a-building\index.js --external:@aws-sdk/client-s3 --keep-names
+
+  ...8991dd33a4d4b5a77445503e679092ddb64943d6a5ba6a-building\index.js  5.0mb
+
+Bundling asset CdkBackendStack/BatchWorkflowStack/BatchCollectLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workers\batch-collect\handler.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-48952094757ffe9e7b3f5f9d4ab5a0d58ce720c55cd731eabb3f1da862463cdd-building\index.js --external:@aws-sdk/client-s3 --keep-names
+
+  ...3f5f9d4ab5a0d58ce720c55cd731eabb3f1da862463cdd-building\index.js  4.4mb
+
+Bundling asset CdkBackendStack/BatchWorkflowStack/BatchPollLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workers\batch-poll\handler.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-0289cde6ed040395144ea6ff9be2fb38b35af478a73429dcfeb5bfc1703e170c-building\index.js --external:@aws-sdk/client-sfn --external:@aws-sdk/client-sqs
+
+  ...4ea6ff9be2fb38b35af478a73429dcfeb5bfc1703e170c-building\index.js  6.8mb
+
+WARN AWS_SOLUTIONS_CONSTRUCTS_WARNING:  An override has been provided for the property: dynamoDbStreamParameters[startingPosition]. Default value: 'LATEST'. You provided: 'TRIM_HORIZON'.
+Done in 5.62s.
+start: Building CdkBackendStackPushNotificationsStack714519F7 Template
+success: Built CdkBackendStackPushNotificationsStack714519F7 Template
+start: Publishing CdkBackendStackPushNotificationsStack714519F7 Template (123456789012-us-east-1-818b1815)
+success: Published CdkBackendStackPushNotificationsStack714519F7 Template (123456789012-us-east-1-818b1815)
+Hold on while we create a read-only change set to get a diff with accurate replacement information (use --no-change-set to use a less accurate but faster template-only diff)
+
+Stack CdkBackendStack/PushNotificationsStack
+Resources
+[~] AWS::Lambda::Function PushNotificationsStack/PrepareNotificationLambda PrepareNotificationLambda
+ └── [~] Code
+     └── [~] .S3Key:
+         ├── [-] 0afbc113e7c243e1e3ba1a74ecd701b60601672f05b750fde0c1b211822eba4d.zip
+         └── [+] df60cee9d3e19433ea66325e1a662f28d7782e7d966caf067b91bd8f944bd190.zip
+
+
+start: Building CdkBackendStackResetQuotaStack3FE53801 Template
+success: Built CdkBackendStackResetQuotaStack3FE53801 Template
+start: Publishing CdkBackendStackResetQuotaStack3FE53801 Template (123456789012-us-east-1-2c6b2723)
+success: Published CdkBackendStackResetQuotaStack3FE53801 Template (123456789012-us-east-1-2c6b2723)
+Hold on while we create a read-only change set to get a diff with accurate replacement information (use --no-change-set to use a less accurate but faster template-only diff)
+
+Stack CdkBackendStack/ResetQuotaStack
+Resources
+[~] AWS::Lambda::Function ResetQuotaStack/ResetQuotaLambda ResetQuotaLambda
+ └── [~] Code
+     └── [~] .S3Key:
+         ├── [-] e348fe5ed9a59afa305e345f67e5c0406974ebaed601ef7e566c1bfb2dd7a939.zip
+         └── [+] 59ee62c714aa2a4d71e6208cf58f8c21aa2d13f68068f8a5f509eeee7c081271.zip
+
+
+start: Building CdkBackendStackWorkflowStackBE836EDE Template
+success: Built CdkBackendStackWorkflowStackBE836EDE Template
+start: Publishing CdkBackendStackWorkflowStackBE836EDE Template (123456789012-us-east-1-3dab8de4)
+success: Published CdkBackendStackWorkflowStackBE836EDE Template (123456789012-us-east-1-3dab8de4)
+Hold on while we create a read-only change set to get a diff with accurate replacement information (use --no-change-set to use a less accurate but faster template-only diff)
+
+Stack CdkBackendStack/WorkflowStack
+Resources
+[~] AWS::Lambda::Function WorkflowStack/PromptLambda PromptLambda
+ └── [~] Code
+     └── [~] .S3Key:
+         ├── [-] d8c048a306bb272f16c81618d871f8b666143c294e63b4e559d7971306fb84e2.zip
+         └── [+] e4fac3bbe923368939f864a00cececa3cc726719bf29d0a159dd48f2c1b4748a.zip
+[~] AWS::Lambda::Function WorkflowStack/GeminiImageLambda GeminiImageLambda
+ └── [~] Code
+     └── [~] .S3Key:
+         ├── [-] 14d941c93213cc4a54e956d05995bd8a9662e6f9b5421a0a23c41e1873b47a1a.zip
+         └── [+] 337a0a587642ec41c47becbe093c870cc00c3dc4fb48cbffc240a3990780d745.zip
+
+
+start: Building CdkBackendStackBatchWorkflowStackD157CA9B Template
+success: Built CdkBackendStackBatchWorkflowStackD157CA9B Template
+start: Publishing CdkBackendStackBatchWorkflowStackD157CA9B Template (123456789012-us-east-1-5d952527)
+success: Published CdkBackendStackBatchWorkflowStackD157CA9B Template (123456789012-us-east-1-5d952527)
+Hold on while we create a read-only change set to get a diff with accurate replacement information (use --no-change-set to use a less accurate but faster template-only diff)
+
+Stack CdkBackendStack/BatchWorkflowStack
+Resources
+[~] AWS::Lambda::Function BatchWorkflowStack/BatchSubmitLambda BatchSubmitLambda
+ └── [~] Code
+     └── [~] .S3Key:
+         ├── [-] 367bc9d3c12f4637952f83c07d03ff88d66a3536751f69e4ed36f6f67ddd11a2.zip
+         └── [+] 190be3b3e86efe5e694ca15b2d57d89239fed12619a1e868c95eb74f224b6fe8.zip
+[~] AWS::Lambda::Function BatchWorkflowStack/BatchCollectLambda BatchCollectLambda
+ └── [~] Code
+     └── [~] .S3Key:
+         ├── [-] 43bca22ec3d3950f6fdf4da14b62274e81c4f950ce0cf3f005e81c905afc2d62.zip
+         └── [+] 3f815ea087596c6360573f84cbc8d06c3a52f260ebcaa286bf060a68a63478b4.zip
+[~] AWS::Lambda::Function BatchWorkflowStack/BatchPollLambda BatchPollLambda
+ └── [~] Code
+     └── [~] .S3Key:
+         ├── [-] a7bb185ce4d34ff5d1cc5e1e96178c131971bee1e5c154bd4d71e6cc5814a4b3.zip
+         └── [+] 8a715c70416b843a1d8c6c66b50dc9fb3ad2eb301898f03b58ffc91ffe588f27.zip
+
+
+Stack CdkBackendStack
+Resources
+[~] AWS::Lambda::Function StatusUpdaterLambda StatusUpdaterLambda
+ ├── [~] Code
+ │   └── [~] .S3Key:
+ │       ├── [-] c93e313789c9867ae227a947e0445cfebf24186350e0cf655cd4d74234562bfb.zip
+ │       └── [+] d0b52efc00aa05e55688631bbda014725bd79249dc2757aceddcc13329468c1c.zip
+ └── [~] Metadata
+     └── [~] .aws:asset:path:
+         ├── [-] asset.c93e313789c9867ae227a947e0445cfebf24186350e0cf655cd4d74234562bfb
+         └── [+] asset.d0b52efc00aa05e55688631bbda014725bd79249dc2757aceddcc13329468c1c
+[~] AWS::Lambda::Function CheckQuotaLambda CheckQuotaLambda
+ ├── [~] Code
+ │   └── [~] .S3Key:
+ │       ├── [-] eab24d4f670d031bde2bb87bed19c5e1545e6e42663f7fe494aa5a49cf4860db.zip
+ │       └── [+] 2a15176866cb9252285027155523375b741faa231209800fd56db54f0750b8d3.zip
+ └── [~] Metadata
+     └── [~] .aws:asset:path:
+         ├── [-] asset.eab24d4f670d031bde2bb87bed19c5e1545e6e42663f7fe494aa5a49cf4860db
+         └── [+] asset.2a15176866cb9252285027155523375b741faa231209800fd56db54f0750b8d3
+[~] AWS::Lambda::Function RefundQuotaLambda RefundQuotaLambda
+ ├── [~] Code
+ │   └── [~] .S3Key:
+ │       ├── [-] 5a0622564bca54b572d895b4f1c76005d8f418fd6254baeed8a299208b97c8d7.zip
+ │       └── [+] 4a81f6a8bbe04ec28d0f7850555961ed5c36218cb30c6878fc4a76af7d350506.zip
+ └── [~] Metadata
+     └── [~] .aws:asset:path:
+         ├── [-] asset.5a0622564bca54b572d895b4f1c76005d8f418fd6254baeed8a299208b97c8d7
+         └── [+] asset.4a81f6a8bbe04ec28d0f7850555961ed5c36218cb30c6878fc4a76af7d350506
+
+Stack CdkBackendStack-MonitoringStackNestedStackMonitoringStackNestedStackResourceC34BBBCF-1VCCCYW052S0W
+There were no differences
+
+
+✨  Number of stacks with differences: 5
+
+
+NOTICES         (What's this? https://github.com/aws/aws-cdk/wiki/CLI-Notices)
+
+37013	(cli) cdk watch triggers deployment unexpectedly or not at all
+
+	Overview: Do not use 'cdk watch' with this version of the cdk cli.
+	          Upgrade to ^2.1106.0.
+
+	Affected versions: cli: >=2.1103.0 <2.1106.0
+
+	More information at: https://github.com/aws/aws-cdk/issues/37013
+
+
+34892	CDK CLI collects telemetry data on command usage starting at version 2.1100.0 (unless opted out)
+
+	Overview: We do not collect customer content and we anonymize the
+	          telemetry we do collect. See the attached issue for more
+	          information on what data is collected, why, and how to
+	          opt-out. Telemetry will NOT be collected for any CDK CLI
+	          version prior to version 2.1100.0 - regardless of
+	          opt-in/out. You can also view the telemetry we collect by
+	          logging it to a local file, by adding
+	          `--telemetry-file=my/local/file` to any `cdk` command.
+
+	Affected versions: cli: >=2.1100.0 <2.1106.1
+
+	More information at: https://github.com/aws/aws-cdk/issues/34892
+
+
+If you don't want to see a notice anymore, use "cdk acknowledge <id>". For example, "cdk acknowledge 37013".

--- a/tests/fixtures/cdk_diff_raw_1.txt
+++ b/tests/fixtures/cdk_diff_raw_1.txt
@@ -1,0 +1,221 @@
+﻿yarn run v1.22.22
+node.exe : warning package.json: No license field
+Au caractère C:\nvm4w\nodejs\cdk.ps1:16 : 5
++     & "$basedir/node$exe"  "$basedir/node_modules/aws-cdk/bin/cdk" $a ...
++     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : NotSpecified: (warning package.json: No license field:String) [], RemoteException
+    + FullyQualifiedErrorId : NativeCommandError
+ 
+$ D:\projects\SampleApp\cdk-backend\node_modules\.bin\tsx bin/app.ts
+Bundling asset SampleApp-RssBatch/CollectRSSLambda/Code/Stage...
+Unable to find image 'public.ecr.aws/sam/build-python3.14:latest' locally
+latest: Pulling from sam/build-python3.14
+d46c1d150629: Pulling fs layer
+c120fd0529f1: Pulling fs layer
+b84914748a8d: Pulling fs layer
+edac8acafecf: Pulling fs layer
+160338069757: Pulling fs layer
+0cbecd4ac666: Pulling fs layer
+9dbffe5588e6: Pulling fs layer
+fe41a65ee243: Pulling fs layer
+f92e2ba22480: Pulling fs layer
+d9b29677bc05: Pulling fs layer
+9e07f3746457: Pulling fs layer
+66785e26af30: Pulling fs layer
+0b5238c127b2: Pulling fs layer
+c05b121a2e83: Pulling fs layer
+b2d648c3f80c: Pulling fs layer
+6ea72e7926ea: Pulling fs layer
+fe41a65ee243: Download complete
+d46c1d150629: Download complete
+9e07f3746457: Download complete
+b2d648c3f80c: Download complete
+66785e26af30: Download complete
+9dbffe5588e6: Download complete
+9e07f3746457: Pull complete
+66785e26af30: Pull complete
+160338069757: Download complete
+f92e2ba22480: Download complete
+0b5238c127b2: Download complete
+0b5238c127b2: Pull complete
+0cbecd4ac666: Download complete
+d9b29677bc05: Download complete
+6ea72e7926ea: Download complete
+c120fd0529f1: Download complete
+b84914748a8d: Download complete
+c05b121a2e83: Download complete
+b2d648c3f80c: Pull complete
+c05b121a2e83: Pull complete
+c120fd0529f1: Pull complete
+edac8acafecf: Download complete
+edac8acafecf: Pull complete
+6ea72e7926ea: Pull complete
+fe41a65ee243: Pull complete
+160338069757: Pull complete
+b84914748a8d: Pull complete
+0cbecd4ac666: Pull complete
+9dbffe5588e6: Pull complete
+f92e2ba22480: Pull complete
+d46c1d150629: Pull complete
+d9b29677bc05: Pull complete
+Digest: sha256:4faaa8583bba450565196531bc7cd9a7e3a75a299bf890093e4b0903a6b31743
+Status: Downloaded newer image for public.ecr.aws/sam/build-python3.14:latest
+WARNING: The directory '/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.
+Collecting feedparser (from -r requirements.txt (line 1))
+  Downloading feedparser-6.0.12-py3-none-any.whl.metadata (2.7 kB)
+Collecting beautifulsoup4 (from -r requirements.txt (line 2))
+  Downloading beautifulsoup4-4.14.3-py3-none-any.whl.metadata (3.8 kB)
+Collecting aiohttp (from -r requirements.txt (line 3))
+  Downloading aiohttp-3.13.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl.metadata (8.1 kB)
+Collecting aiohttp-retry (from -r requirements.txt (line 4))
+  Downloading aiohttp_retry-2.9.1-py3-none-any.whl.metadata (8.8 kB)
+Collecting sgmllib3k (from feedparser->-r requirements.txt (line 1))
+  Downloading sgmllib3k-1.0.0.tar.gz (5.8 kB)
+  Installing build dependencies: started
+  Installing build dependencies: finished with status 'done'
+  Getting requirements to build wheel: started
+  Getting requirements to build wheel: finished with status 'done'
+  Preparing metadata (pyproject.toml): started
+  Preparing metadata (pyproject.toml): finished with status 'done'
+Collecting soupsieve>=1.6.1 (from beautifulsoup4->-r requirements.txt (line 2))
+  Downloading soupsieve-2.8.3-py3-none-any.whl.metadata (4.6 kB)
+Collecting typing-extensions>=4.0.0 (from beautifulsoup4->-r requirements.txt (line 2))
+  Downloading typing_extensions-4.15.0-py3-none-any.whl.metadata (3.3 kB)
+Collecting aiohappyeyeballs>=2.5.0 (from aiohttp->-r requirements.txt (line 3))
+  Downloading aiohappyeyeballs-2.6.1-py3-none-any.whl.metadata (5.9 kB)
+Collecting aiosignal>=1.4.0 (from aiohttp->-r requirements.txt (line 3))
+  Downloading aiosignal-1.4.0-py3-none-any.whl.metadata (3.7 kB)
+Collecting attrs>=17.3.0 (from aiohttp->-r requirements.txt (line 3))
+  Downloading attrs-25.4.0-py3-none-any.whl.metadata (10 kB)
+Collecting frozenlist>=1.1.1 (from aiohttp->-r requirements.txt (line 3))
+  Downloading frozenlist-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl.metadata (20 kB)
+Collecting multidict<7.0,>=4.5 (from aiohttp->-r requirements.txt (line 3))
+  Downloading multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl.metadata (5.3 kB)
+Collecting propcache>=0.2.0 (from aiohttp->-r requirements.txt (line 3))
+  Downloading propcache-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl.metadata (13 kB)
+Collecting yarl<2.0,>=1.17.0 (from aiohttp->-r requirements.txt (line 3))
+  Downloading yarl-1.23.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl.metadata (79 kB)
+Collecting idna>=2.0 (from yarl<2.0,>=1.17.0->aiohttp->-r requirements.txt (line 3))
+  Downloading idna-3.11-py3-none-any.whl.metadata (8.4 kB)
+Downloading feedparser-6.0.12-py3-none-any.whl (81 kB)
+Downloading beautifulsoup4-4.14.3-py3-none-any.whl (107 kB)
+Downloading aiohttp-3.13.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl (1.7 MB)
+   ÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöüÔöü 1.7/1.7 MB 14.8 MB/s  0:00:00
+Downloading multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl (252 kB)
+Downloading yarl-1.23.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl (99 kB)
+Downloading aiohttp_retry-2.9.1-py3-none-any.whl (10.0 kB)
+Downloading aiohappyeyeballs-2.6.1-py3-none-any.whl (15 kB)
+Downloading aiosignal-1.4.0-py3-none-any.whl (7.5 kB)
+Downloading attrs-25.4.0-py3-none-any.whl (67 kB)
+Downloading frozenlist-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl (232 kB)
+Downloading idna-3.11-py3-none-any.whl (71 kB)
+Downloading propcache-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl (206 kB)
+Downloading soupsieve-2.8.3-py3-none-any.whl (37 kB)
+Downloading typing_extensions-4.15.0-py3-none-any.whl (44 kB)
+Building wheels for collected packages: sgmllib3k
+  Building wheel for sgmllib3k (pyproject.toml): started
+  Building wheel for sgmllib3k (pyproject.toml): finished with status 'done'
+  Created wheel for sgmllib3k: filename=sgmllib3k-1.0.0-py3-none-any.whl size=6091 sha256=da3751afa962fd77258521b44f25109fd9c5ab41c0487639659b2bd060d3489c
+  Stored in directory: /tmp/pip-ephem-wheel-cache-ougwyiu2/wheels/e3/43/83/0f6e317d0698ac38ee6a5b6e214019c167057916a11bad91ab
+Successfully built sgmllib3k
+Installing collected packages: sgmllib3k, typing-extensions, soupsieve, propcache, multidict, idna, frozenlist, feedparser, attrs, aiohappyeyeballs, yarl, beautifulsoup4, aiosignal, aiohttp, aiohttp-retry
+
+Successfully installed aiohappyeyeballs-2.6.1 aiohttp-3.13.3 aiohttp-retry-2.9.1 aiosignal-1.4.0 attrs-25.4.0 beautifulsoup4-4.14.3 feedparser-6.0.12 frozenlist-1.8.0 idna-3.11 multidict-6.7.1 propcache-0.4.1 sgmllib3k-1.0.0 soupsieve-2.8.3 
+typing-extensions-4.15.0 yarl-1.23.0
+
+[notice] A new release of pip is available: 25.3 -> 26.0.1
+[notice] To update, run: pip install --upgrade pip
+Bundling asset SampleApp-RssBatch/StoreTaskTokenLambda/Code/Stage...
+warning package.json: No license field
+$ D:\projects\SampleApp\cdk-backend\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workers\store-task-token\handler.ts --target=node22 --platform=node 
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-ae0e8c5f7a86d7d58e8fa87869b0d2862cba7c5ca3fbae914b1c86392227af19-building\index.js --external:@aws-sdk/*
+
+  ...8e8fa87869b0d2862cba7c5ca3fbae914b1c86392227af19-building\index.js  1.9kb
+
+Bundling asset SampleApp-RssBatch/BatchCallbackLambda/Code/Stage...
+warning package.json: No license field
+$ D:\projects\SampleApp\cdk-backend\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workers\batch-callback\handler.ts --target=node22 --platform=node 
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-917e0be5203bd1448bd1b0831ddc5586ad658926a5746a85c9c5b86e72017d6a-building\index.js --external:@aws-sdk/*
+
+  ...8bd1b0831ddc5586ad658926a5746a85c9c5b86e72017d6a-building\index.js  3.4kb
+
+Bundling asset SampleApp-RssBatch/ProcessBatchResultsLambda/Code/Stage...
+WARNING: The directory '/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.
+
+[notice] A new release of pip is available: 25.3 -> 26.0.1
+[notice] To update, run: pip install --upgrade pip
+Done in 66.49s.
+start: Building SampleApp-RssBatch Template
+success: Built SampleApp-RssBatch Template
+start: Publishing SampleApp-RssBatch Template (123456789012-us-east-1-5fd8c0e9)
+success: Published SampleApp-RssBatch Template (123456789012-us-east-1-5fd8c0e9)
+Hold on while we create a read-only change set to get a diff with accurate replacement information (use --no-change-set to use a less accurate but faster template-only diff)
+
+Stack SampleApp-RssBatch
+Resources
+[~] Custom::AWS PopulateFeedTable/Resource PopulateFeedTableFCA8F2DB may be replaced
+ Ôö£ÔöÇ [~] Create (may cause replacement)
+ Ôöé   ÔööÔöÇ [~] .Fn::Join:
+ Ôöé       ÔööÔöÇ @@ -5,6 +5,6 @@
+ Ôöé          [ ]     {
+ Ôöé          [ ]       "Ref": "FeedInitFunctionBDD3CB88"
+ Ôöé          [ ]     },
+ Ôöé          [-]     "\",\"InvocationType\":\"RequestResponse\"},\"physicalResourceId\":{\"id\":\"PopulateFeedTable-8b30a5aee38442b2\"}}"
+ Ôöé          [+]     "\",\"InvocationType\":\"RequestResponse\"},\"physicalResourceId\":{\"id\":\"PopulateFeedTable-70f2f13f2165f7de\"}}"
+ Ôöé          [ ]   ]
+ Ôöé          [ ] ]
+ ÔööÔöÇ [~] Update (may cause replacement)
+     ÔööÔöÇ [~] .Fn::Join:
+         ÔööÔöÇ @@ -5,6 +5,6 @@
+            [ ]     {
+            [ ]       "Ref": "FeedInitFunctionBDD3CB88"
+            [ ]     },
+            [-]     "\",\"InvocationType\":\"RequestResponse\"},\"physicalResourceId\":{\"id\":\"PopulateFeedTable-8b30a5aee38442b2\"}}"
+            [+]     "\",\"InvocationType\":\"RequestResponse\"},\"physicalResourceId\":{\"id\":\"PopulateFeedTable-70f2f13f2165f7de\"}}"
+            [ ]   ]
+            [ ] ]
+[~] AWS::Lambda::Function CollectRSSLambda CollectRSSLambda
+ ÔööÔöÇ [~] Code
+     ÔööÔöÇ [~] .S3Key:
+         Ôö£ÔöÇ [-] 76ce6425ec357997f182cc7370fd6cf0aa8c7c3f7559feca7e9de72232a2008a.zip
+         ÔööÔöÇ [+] e83d32d44b93a5871e77d2b8586d9c5755097bcc11006b0cc914495e2306fcb3.zip
+[~] AWS::Lambda::Function ProcessBatchResultsLambda ProcessBatchResultsLambda
+ ÔööÔöÇ [~] Code
+     ÔööÔöÇ [~] .S3Key:
+         Ôö£ÔöÇ [-] 891f967309fb7f5936e53784f423df3061ecd529ab331eb9ea4d88a52e0d47c8.zip
+         ÔööÔöÇ [+] 3abbe79759e53b9fd31898d57deff1c9ec8792cba0b556bd2da396cd4cdbb651.zip
+
+
+
+Ô£¿  Number of stacks with differences: 1
+
+
+NOTICES         (What's this? https://github.com/aws/aws-cdk/wiki/CLI-Notices)
+
+37013	(cli) cdk watch triggers deployment unexpectedly or not at all
+
+	Overview: Do not use 'cdk watch' with this version of the cdk cli.
+	          Upgrade to ^2.1106.0.
+
+	Affected versions: cli: >=2.1103.0 <2.1106.0
+
+	More information at: https://github.com/aws/aws-cdk/issues/37013
+
+
+34892	CDK CLI collects telemetry data on command usage starting at version 2.1100.0 (unless opted out)
+
+	Overview: We do not collect customer content and we anonymize the
+	          telemetry we do collect. See the attached issue for more
+	          information on what data is collected, why, and how to
+	          opt-out. Telemetry will NOT be collected for any CDK CLI
+	          version prior to version 2.1100.0 - regardless of
+	          opt-in/out. You can also view the telemetry we collect by
+	          logging it to a local file, by adding
+	          `--telemetry-file=my/local/file` to any `cdk` command.
+
+	Affected versions: cli: >=2.1100.0 <2.1106.1
+
+	More information at: https://github.com/aws/aws-cdk/issues/34892
+
+
+If you donÔÇÖt want to see a notice anymore, use "cdk acknowledge <id>". For example, "cdk acknowledge 37013".

--- a/tests/fixtures/cdk_synth_raw.txt
+++ b/tests/fixtures/cdk_synth_raw.txt
@@ -1,0 +1,133 @@
+yarn run v1.22.22
+node.exe : warning package.json: No license field
+Au caractère C:\nodejs\cdk.ps1:16 : 5
++     & "$basedir/node$exe"  "$basedir/node_modules/aws-cdk/bin/cdk" $a ...
++     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : NotSpecified: (warning package.json: No license field:String) [], RemoteException
+    + FullyQualifiedErrorId : NativeCommandError
+
+$ D:\projects\SampleApp\node_modules\.bin\tsx bin/cdk-backend.ts
+⚠️  amplify_outputs.json is older than 7 days. Consider running 'npx ampx generate outputs' to refresh.
+Bundling asset CdkBackendStack/StatusUpdaterLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workflow\status-updater.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-67e3ef8bbf7e62fb01b1bd8ae1534e17b15934c0141e0a520af0a4415ca1bce1-building\index.js
+
+  ...b1bd8ae1534e17b15934c0141e0a520af0a4415ca1bce1-building\index.js  5.5mb
+
+Bundling asset CdkBackendStack/CheckQuotaLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workers\check-quota\handler.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-86224dfea4bf525da7a7914649ee2144ba786d3067e4f1ae40eba18800590f67-building\index.js
+
+  ...a7914649ee2144ba786d3067e4f1ae40eba18800590f67-building\index.js  5.5mb
+
+Bundling asset CdkBackendStack/RefundQuotaLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workers\refund-quota\handler.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-5971989bda1ea134e95126556db731245c4030f832be49968233e28dead45b80-building\index.js
+
+  ...5126556db731245c4030f832be49968233e28dead45b80-building\index.js  5.5mb
+
+Bundling asset CdkBackendStack/PreparePayloadLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workflow\prepare-payload\handler.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-2a68b182670678d1fc99204c4165220adde0b6331c3839070d80f062c05416b0-building\index.js
+
+  ...c99204c4165220adde0b6331c3839070d80f062c05416b0-building\index.js  13.4kb
+
+Bundling asset CdkBackendStack/MergeParallelLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workflow\merge-parallel\handler.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-b09a10e4a61270f1e7c91deb77ad433606c44b0e9594aae281ad617983febc71-building\index.js
+
+  ...e7c91deb77ad433606c44b0e9594aae281ad617983febc71-building\index.js  1.7kb
+
+Bundling asset CdkBackendStack/PushNotificationsStack/PrepareNotificationLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\push-notifications\prepare-notification.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-a7c9ce439010b227b9e94a5f5418d473ea1fb7876293ead65fd868c661ea79c6-building\index.js --external:@aws-sdk/client-sqs
+
+  ...9e94a5f5418d473ea1fb7876293ead65fd868c661ea79c6-building\index.js  33.2kb
+
+[WARNING] aws-cdk-lib.aws_iam.GrantOnPrincipalOptions#scope is deprecated.
+  The scope argument is currently unused.
+  This API will be removed in the next major release.
+Bundling asset CdkBackendStack/PushNotificationsStack/SendNotificationLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\push-notifications\send-notification.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-1494d4a7170f0d75ab192bfe4742faf3d386f9b39d5f8962616261b3d37da6e3-building\index.js --external:@aws-sdk/client-dynamodb --external:@aws-sdk/lib-dynamodb --external:@aws-sdk/client-sqs
+
+  ...92bfe4742faf3d386f9b39d5f8962616261b3d37da6e3-building\index.js  1001.9kb
+
+Bundling asset CdkBackendStack/PushNotificationsStack/CheckReceiptsLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\push-notifications\check-receipts.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-2a5213912bf12b508c2f37d70ee916047a8c684a45c0d2d16bc68df1ad010703-building\index.js --external:@aws-sdk/client-dynamodb --external:@aws-sdk/lib-dynamodb
+
+  ...f37d70ee916047a8c684a45c0d2d16bc68df1ad010703-building\index.js  1000.5kb
+
+Bundling asset CdkBackendStack/ResetQuotaStack/ResetQuotaLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\resetQuota\handler.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-3d23ecf5c27d9db8e7646ca291830098217887455c1c12713138fbf652c11b28-building\index.js --external:@aws-sdk/client-ssm
+
+  ...646ca291830098217887455c1c12713138fbf652c11b28-building\index.js  5.5mb
+
+Bundling asset CdkBackendStack/WorkflowStack/PromptLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workers\haiku-prompt\handler.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-1232f49c1bf0a3070f06ca4524ff51f24eea95d57b9aaf809a7e0dadcfa80ecf-building\index.js --external:@aws-sdk/client-bedrock-runtime --loader:.md=text
+
+  ...06ca4524ff51f24eea95d57b9aaf809a7e0dadcfa80ecf-building\index.js  5.2mb
+
+Bundling asset CdkBackendStack/WorkflowStack/GeminiImageLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workers\gemini-image\handler.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-09d802a8fa9b9e882f4233035f93fa8dd65d24aaa5017302414e2ebd3dc084e3-building\index.js --external:@aws-sdk/client-s3 --keep-names
+
+  ...4233035f93fa8dd65d24aaa5017302414e2ebd3dc084e3-building\index.js  5.0mb
+
+WARN AWS_SOLUTIONS_CONSTRUCTS_WARNING:  An override has been provided for the property: dynamoDbStreamParameters[startingPosition]. Default value: 'LATEST'. You provided: 'TRIM_HORIZON'.
+Bundling asset CdkBackendStack/BatchWorkflowStack/BatchSubmitLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workers\batch-submit\handler.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-bcf4fb382ee767437b8991dd33a4d4b5a77445503e679092ddb64943d6a5ba6a-building\index.js --external:@aws-sdk/client-s3 --keep-names
+
+  ...8991dd33a4d4b5a77445503e679092ddb64943d6a5ba6a-building\index.js  5.0mb
+
+Bundling asset CdkBackendStack/BatchWorkflowStack/BatchCollectLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workers\batch-collect\handler.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-48952094757ffe9e7b3f5f9d4ab5a0d58ce720c55cd731eabb3f1da862463cdd-building\index.js --external:@aws-sdk/client-s3 --keep-names
+
+  ...3f5f9d4ab5a0d58ce720c55cd731eabb3f1da862463cdd-building\index.js  4.4mb
+
+Bundling asset CdkBackendStack/BatchWorkflowStack/BatchPollLambda/Code/Stage...
+$ D:\projects\SampleApp\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workers\batch-poll\handler.ts --target=node22 --platform=node
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-0289cde6ed040395144ea6ff9be2fb38b35af478a73429dcfeb5bfc1703e170c-building\index.js --external:@aws-sdk/client-sfn --external:@aws-sdk/client-sqs
+
+  ...4ea6ff9be2fb38b35af478a73429dcfeb5bfc1703e170c-building\index.js  6.8mb
+
+WARN AWS_SOLUTIONS_CONSTRUCTS_WARNING:  An override has been provided for the property: dynamoDbStreamParameters[startingPosition]. Default value: 'LATEST'. You provided: 'TRIM_HORIZON'.
+Done in 5.64s.
+Successfully synthesized to D:\projects\SampleApp\cdk-backend\cdk.out
+Supply a stack id (CdkBackendStack/PushNotificationsStack, CdkBackendStack/ResetQuotaStack, CdkBackendStack/WorkflowStack, CdkBackendStack/BatchWorkflowStack, CdkBackendStack) to display its template.
+4 feature flags are not configured. Run 'cdk flags --unstable=flags' to learn more.
+
+NOTICES         (What's this? https://github.com/aws/aws-cdk/wiki/CLI-Notices)
+
+37013	(cli) cdk watch triggers deployment unexpectedly or not at all
+
+	Overview: Do not use 'cdk watch' with this version of the cdk cli.
+	          Upgrade to ^2.1106.0.
+
+	Affected versions: cli: >=2.1103.0 <2.1106.0
+
+	More information at: https://github.com/aws/aws-cdk/issues/37013
+
+
+34892	CDK CLI collects telemetry data on command usage starting at version 2.1100.0 (unless opted out)
+
+	Overview: We do not collect customer content and we anonymize the
+	          telemetry we do collect. See the attached issue for more
+	          information on what data is collected, why, and how to
+	          opt-out. Telemetry will NOT be collected for any CDK CLI
+	          version prior to version 2.1100.0 - regardless of
+	          opt-in/out. You can also view the telemetry we collect by
+	          logging it to a local file, by adding
+	          `--telemetry-file=my/local/file` to any `cdk` command.
+
+	Affected versions: cli: >=2.1100.0 <2.1106.1
+
+	More information at: https://github.com/aws/aws-cdk/issues/34892
+
+
+If you don't want to see a notice anymore, use "cdk acknowledge <id>". For example, "cdk acknowledge 37013".

--- a/tests/fixtures/cdk_synth_raw_1.txt
+++ b/tests/fixtures/cdk_synth_raw_1.txt
@@ -1,0 +1,1217 @@
+﻿yarn run v1.22.22
+node.exe : warning package.json: No license field
+Au caractère C:\nvm4w\nodejs\cdk.ps1:16 : 5
++     & "$basedir/node$exe"  "$basedir/node_modules/aws-cdk/bin/cdk" $a ...
++     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : NotSpecified: (warning package.json: No license field:String) [], RemoteException
+    + FullyQualifiedErrorId : NativeCommandError
+ 
+$ D:\projects\SampleApp\cdk-backend\node_modules\.bin\tsx bin/app.ts
+Bundling asset SampleApp-RssBatch/StoreTaskTokenLambda/Code/Stage...
+warning package.json: No license field
+$ D:\projects\SampleApp\cdk-backend\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workers\store-task-token\handler.ts --target=node22 --platform=node 
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-ae0e8c5f7a86d7d58e8fa87869b0d2862cba7c5ca3fbae914b1c86392227af19-building\index.js --external:@aws-sdk/*
+
+  ...8e8fa87869b0d2862cba7c5ca3fbae914b1c86392227af19-building\index.js  1.9kb
+
+Bundling asset SampleApp-RssBatch/BatchCallbackLambda/Code/Stage...
+warning package.json: No license field
+$ D:\projects\SampleApp\cdk-backend\node_modules\.bin\esbuild --bundle D:\projects\SampleApp\cdk-backend\lib\workers\batch-callback\handler.ts --target=node22 --platform=node 
+--outfile=D:\projects\SampleApp\cdk-backend\cdk.out\bundling-temp-917e0be5203bd1448bd1b0831ddc5586ad658926a5746a85c9c5b86e72017d6a-building\index.js --external:@aws-sdk/*
+
+  ...8bd1b0831ddc5586ad658926a5746a85c9c5b86e72017d6a-building\index.js  3.4kb
+
+Done in 1.27s.
+Resources:
+  RssBatchBucket7D1FF398:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: sampleapp-rss-batch
+      LifecycleConfiguration:
+        Rules:
+          - ExpirationInDays: 30
+            Status: Enabled
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+        - Key: aws-cdk:auto-delete-objects
+          Value: "true"
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/RssBatchBucket/Resource
+  RssBatchBucketPolicyB32E7B81:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket:
+        Ref: RssBatchBucket7D1FF398
+      PolicyDocument:
+        Statement:
+          - Action:
+              - s3:DeleteObject*
+              - s3:GetBucket*
+              - s3:List*
+              - s3:PutBucketPolicy
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::GetAtt:
+                  - CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092
+                  - Arn
+            Resource:
+              - Fn::GetAtt:
+                  - RssBatchBucket7D1FF398
+                  - Arn
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - RssBatchBucket7D1FF398
+                        - Arn
+                    - /*
+        Version: "2012-10-17"
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/RssBatchBucket/Policy/Resource
+  RssBatchBucketAutoDeleteObjectsCustomResource86370C6A:
+    Type: Custom::S3AutoDeleteObjects
+    Properties:
+      ServiceToken:
+        Fn::GetAtt:
+          - CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F
+          - Arn
+      BucketName:
+        Ref: RssBatchBucket7D1FF398
+    DependsOn:
+      - RssBatchBucketPolicyB32E7B81
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/RssBatchBucket/AutoDeleteObjectsCustomResource/Default
+  CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+      ManagedPolicyArns:
+        - Fn::Sub: arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/Custom::S3AutoDeleteObjectsCustomResourceProvider/Role
+  CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        S3Bucket: cdk-hnb659fds-assets-123456789012-us-east-1
+        S3Key: faa95a81ae7d7373f3e1f242268f904eb748d8d0fdd306e8a6fe515a1905a7d6.zip
+      Timeout: 900
+      MemorySize: 128
+      Handler: index.handler
+      Role:
+        Fn::GetAtt:
+          - CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092
+          - Arn
+      Runtime: nodejs22.x
+      Description:
+        Fn::Join:
+          - ""
+          - - "Lambda function for auto-deleting objects in "
+            - Ref: RssBatchBucket7D1FF398
+            - " S3 bucket."
+    DependsOn:
+      - CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler
+      aws:asset:path: asset.faa95a81ae7d7373f3e1f242268f904eb748d8d0fdd306e8a6fe515a1905a7d6
+      aws:asset:property: Code
+  FeedTable1849209D:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: PK
+          AttributeType: S
+        - AttributeName: SK
+          AttributeType: S
+      BillingMode: PAY_PER_REQUEST
+      KeySchema:
+        - AttributeName: PK
+          KeyType: HASH
+        - AttributeName: SK
+          KeyType: RANGE
+      TableName: sampleapp-feed-table
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/FeedTable/Resource
+  FeedInitFunctionServiceRole3C883FA4:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/FeedInitFunction/ServiceRole/Resource
+  FeedInitFunctionServiceRoleDefaultPolicy7663E5D0:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - dynamodb:BatchWriteItem
+              - dynamodb:DeleteItem
+              - dynamodb:DescribeTable
+              - dynamodb:PutItem
+              - dynamodb:UpdateItem
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - FeedTable1849209D
+                - Arn
+        Version: "2012-10-17"
+      PolicyName: FeedInitFunctionServiceRoleDefaultPolicy7663E5D0
+      Roles:
+        - Ref: FeedInitFunctionServiceRole3C883FA4
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/FeedInitFunction/ServiceRole/DefaultPolicy/Resource
+  FeedInitFunctionBDD3CB88:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile:
+          Fn::Join:
+            - ""
+            - - |-
+                
+                				const { DynamoDBClient, BatchWriteItemCommand } = require('@aws-sdk/client-dynamodb');
+                				const client = new DynamoDBClient();
+                				const batches = {"Batch0":{"RequestItems":{"
+              - Ref: FeedTable1849209D
+              - "\":[{\"PutRequest\":{\"Item\":{\"PK\":{\"S\":\"RSS_FEED\"},\"SK\":{\"S\":\"1\"},\"Name\":{\"S\":\"Sample Feed A\"},\"URL\":{\"S\":\"https://example.com/feed-a.xml\"}}}},{\"PutRequest\":{\"Item\":{\"PK\":{\"S\":\"RSS_FEED\"},\"SK\":{\"S\":\"2\"},\"Name\":{\"S\":\"Sample Feed B\"},\"URL\":{\"S\":\"https://example.com/feed-b.xml\"}}}}]}}};
+
+                \t\t\t\texports.handler = async (event) => {
+
+                \t\t\t\t\tfor (const batchKey of Object.keys(batches)) {
+
+                \t\t\t\t\t\tlet params = batches[batchKey];
+
+                \t\t\t\t\t\tlet attempts = 0;
+
+                \t\t\t\t\t\twhile (Object.keys(params.RequestItems).length > 0 && attempts < 5) {
+
+                \t\t\t\t\t\t\tconst result = await client.send(new BatchWriteItemCommand(params));
+
+                \t\t\t\t\t\t\tconst unprocessed = result.UnprocessedItems || {};
+
+                \t\t\t\t\t\t\tif (Object.keys(unprocessed).length === 0) break;
+
+                \t\t\t\t\t\t\tparams = { RequestItems: unprocessed };
+
+                \t\t\t\t\t\t\tattempts++;
+
+                \t\t\t\t\t\t\tawait new Promise(r => setTimeout(r, 200 * Math.pow(2, attempts)));
+
+                \t\t\t\t\t\t}
+
+                \t\t\t\t\t}
+
+                \t\t\t\t\treturn 'Done';
+
+                \t\t\t\t};
+
+                \t\t\t"
+      Handler: index.handler
+      Role:
+        Fn::GetAtt:
+          - FeedInitFunctionServiceRole3C883FA4
+          - Arn
+      Runtime: nodejs22.x
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+    DependsOn:
+      - FeedInitFunctionServiceRoleDefaultPolicy7663E5D0
+      - FeedInitFunctionServiceRole3C883FA4
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/FeedInitFunction/Resource
+  FeedInitFunctionLogGroup4E4D9755:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName:
+        Fn::Join:
+          - ""
+          - - /aws/lambda/
+            - Ref: FeedInitFunctionBDD3CB88
+      RetentionInDays: 731
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/FeedInitFunction/LogGroup/Resource
+  PopulateFeedTableFCA8F2DB:
+    Type: Custom::AWS
+    Properties:
+      ServiceToken:
+        Fn::GetAtt:
+          - AWS679f53fac002430cb0da5b7982bd22872D164C4C
+          - Arn
+      Create:
+        Fn::Join:
+          - ""
+          - - '{"service":"Lambda","action":"invoke","parameters":{"FunctionName":"'
+            - Ref: FeedInitFunctionBDD3CB88
+            - '","InvocationType":"RequestResponse"},"physicalResourceId":{"id":"PopulateFeedTable-8b30a5aee38442b2"}}'
+      Update:
+        Fn::Join:
+          - ""
+          - - '{"service":"Lambda","action":"invoke","parameters":{"FunctionName":"'
+            - Ref: FeedInitFunctionBDD3CB88
+            - '","InvocationType":"RequestResponse"},"physicalResourceId":{"id":"PopulateFeedTable-8b30a5aee38442b2"}}'
+      InstallLatestAwsSdk: false
+    DependsOn:
+      - PopulateFeedTableCustomResourcePolicy1068CAFF
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/PopulateFeedTable/Resource/Default
+  PopulateFeedTableCustomResourcePolicy1068CAFF:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: lambda:InvokeFunction
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - FeedInitFunctionBDD3CB88
+                - Arn
+        Version: "2012-10-17"
+      PolicyName: PopulateFeedTableCustomResourcePolicy1068CAFF
+      Roles:
+        - Ref: AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/PopulateFeedTable/CustomResourcePolicy/Resource
+  AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/AWS679f53fac002430cb0da5b7982bd2287/ServiceRole/Resource
+  AWS679f53fac002430cb0da5b7982bd22872D164C4C:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        S3Bucket: cdk-hnb659fds-assets-123456789012-us-east-1
+        S3Key: 56f7467bbde8a5efebcf57ae9e460027607099bab9f844669dcf5d800172ee5a.zip
+      Handler: index.handler
+      Role:
+        Fn::GetAtt:
+          - AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2
+          - Arn
+      Runtime: nodejs22.x
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+      Timeout: 120
+    DependsOn:
+      - AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/AWS679f53fac002430cb0da5b7982bd2287/Resource
+      aws:asset:path: asset.56f7467bbde8a5efebcf57ae9e460027607099bab9f844669dcf5d800172ee5a
+      aws:asset:is-bundled: false
+      aws:asset:property: Code
+  AWS679f53fac002430cb0da5b7982bd2287LogGroup449FB7C2:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName:
+        Fn::Join:
+          - ""
+          - - /aws/lambda/
+            - Ref: AWS679f53fac002430cb0da5b7982bd22872D164C4C
+      RetentionInDays: 731
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/AWS679f53fac002430cb0da5b7982bd2287/LogGroup/Resource
+  FeedTableParamFB58D27E:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /sampleapp/tables/FeedTable
+      Tags:
+        ApplicationName: sampleapp
+      Type: String
+      Value:
+        Ref: FeedTable1849209D
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/FeedTableParam/Resource
+  BedrockBatchRole468B3A82:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: bedrock.amazonaws.com
+        Version: "2012-10-17"
+      Description: Role for Bedrock batch inference jobs (RSS enrichment)
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/BedrockBatchRole/Resource
+  BedrockBatchRoleDefaultPolicy14C97418:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - s3:Abort*
+              - s3:DeleteObject*
+              - s3:GetBucket*
+              - s3:GetObject*
+              - s3:List*
+              - s3:PutObject
+              - s3:PutObjectLegalHold
+              - s3:PutObjectRetention
+              - s3:PutObjectTagging
+              - s3:PutObjectVersionTagging
+            Effect: Allow
+            Resource:
+              - Fn::GetAtt:
+                  - RssBatchBucket7D1FF398
+                  - Arn
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - RssBatchBucket7D1FF398
+                        - Arn
+                    - /*
+          - Action: bedrock:InvokeModel
+            Effect: Allow
+            Resource:
+              - arn:aws:bedrock:*::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0
+              - arn:aws:bedrock:us-east-1:*:inference-profile/global.anthropic.claude-haiku-4-5-20251001-v1:0
+              - arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/*
+        Version: "2012-10-17"
+      PolicyName: BedrockBatchRoleDefaultPolicy14C97418
+      Roles:
+        - Ref: BedrockBatchRole468B3A82
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/BedrockBatchRole/DefaultPolicy/Resource
+  CollectRSSLogs:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /aws/lambda/sampleapp-collect-rss
+      RetentionInDays: 30
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/CollectRSSLogs/Resource
+  CollectRSSRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/CollectRSSLambda/ServiceRole/Resource
+  CollectRSSLambdaServiceRoleDefaultPolicy9893EAFF:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - bedrock:CreateModelInvocationJob
+              - xray:PutTelemetryRecords
+              - xray:PutTraceSegments
+            Effect: Allow
+            Resource: "*"
+          - Action:
+              - dynamodb:BatchWriteItem
+              - dynamodb:DeleteItem
+              - dynamodb:DescribeTable
+              - dynamodb:GetItem
+              - dynamodb:PutItem
+              - dynamodb:Query
+              - dynamodb:Scan
+              - dynamodb:UpdateItem
+            Effect: Allow
+            Resource:
+              - arn:aws:dynamodb:us-east-1:123456789012:table/ItemMetadata-abcdefghijklmnopqrstuvwxyz-NONE
+              - arn:aws:dynamodb:us-east-1:123456789012:table/ProcessedItem-abcdefghijklmnopqrstuvwxyz-NONE
+              - arn:aws:dynamodb:us-east-1:123456789012:table/ProcessedItem-abcdefghijklmnopqrstuvwxyz-NONE/index/*
+          - Action:
+              - dynamodb:BatchGetItem
+              - dynamodb:ConditionCheckItem
+              - dynamodb:DescribeTable
+              - dynamodb:GetItem
+              - dynamodb:GetRecords
+              - dynamodb:GetShardIterator
+              - dynamodb:Query
+              - dynamodb:Scan
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - FeedTable1849209D
+                - Arn
+          - Action:
+              - s3:DeleteObject
+              - s3:GetObject
+              - s3:ListBucket
+              - s3:PutObject
+            Effect: Allow
+            Resource:
+              - Fn::Join:
+                  - ""
+                  - - "arn:aws:s3:::"
+                    - Ref: RssBatchBucket7D1FF398
+                    - /*
+              - Fn::Join:
+                  - ""
+                  - - "arn:aws:s3:::"
+                    - Ref: RssBatchBucket7D1FF398
+          - Action: ssm:GetParameter
+            Effect: Allow
+            Resource: arn:aws:ssm:us-east-1:123456789012:parameter/amplify/sampleapp/APP_SECRET_PARAMETER
+          - Action:
+              - bedrock:GetModelInvocationJob
+              - bedrock:TagResource
+            Effect: Allow
+            Resource: arn:aws:bedrock:us-east-1:123456789012:model-invocation-job/*
+          - Action: iam:PassRole
+            Condition:
+              StringEquals:
+                iam:PassedToService: bedrock.amazonaws.com
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - BedrockBatchRole468B3A82
+                - Arn
+        Version: "2012-10-17"
+      PolicyName: CollectRSSLambdaServiceRoleDefaultPolicy9893EAFF
+      Roles:
+        - Ref: CollectRSSRole
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/CollectRSSLambda/ServiceRole/DefaultPolicy/Resource
+  CollectRSSLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Architectures:
+        - arm64
+      Code:
+        S3Bucket: cdk-hnb659fds-assets-123456789012-us-east-1
+        S3Key: e83d32d44b93a5871e77d2b8586d9c5755097bcc11006b0cc914495e2306fcb3.zip
+      Environment:
+        Variables:
+          LOG_LEVEL: WARNING
+          S3_BUCKET:
+            Ref: RssBatchBucket7D1FF398
+          BEDROCK_BATCH_ROLE_ARN:
+            Fn::GetAtt:
+              - BedrockBatchRole468B3A82
+              - Arn
+          DYNAMODB_FEED_TABLE:
+            Ref: FeedTable1849209D
+          DYNAMODB_PROCESSED_TABLE: ProcessedItem-abcdefghijklmnopqrstuvwxyz-NONE
+          DYNAMODB_METADATA_TABLE: ItemMetadata-abcdefghijklmnopqrstuvwxyz-NONE
+          BEDROCK_LLM_ID: arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/sample-profile-id
+          MAX_ARTICLES_PER_FEED: "20"
+      FunctionName: SampleApp-CollectRSS
+      Handler: handler.lambda_handler
+      LoggingConfig:
+        LogGroup:
+          Ref: CollectRSSLogs
+      MemorySize: 256
+      Role:
+        Fn::GetAtt:
+          - CollectRSSRole
+          - Arn
+      Runtime: python3.13
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+      Timeout: 900
+      TracingConfig:
+        Mode: PassThrough
+    DependsOn:
+      - CollectRSSLambdaServiceRoleDefaultPolicy9893EAFF
+      - CollectRSSRole
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/CollectRSSLambda/Resource
+      aws:asset:path: asset.e83d32d44b93a5871e77d2b8586d9c5755097bcc11006b0cc914495e2306fcb3
+      aws:asset:is-bundled: true
+      aws:asset:property: Code
+  StoreTaskTokenLogs:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /aws/lambda/sampleapp-store-task-token
+      RetentionInDays: 30
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/StoreTaskTokenLogs/Resource
+  StoreTaskTokenRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/StoreTaskTokenLambda/ServiceRole/Resource
+  StoreTaskTokenLambdaServiceRoleDefaultPolicy06B5CDD0:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - xray:PutTelemetryRecords
+              - xray:PutTraceSegments
+            Effect: Allow
+            Resource: "*"
+          - Action:
+              - s3:DeleteObject
+              - s3:GetObject
+              - s3:ListBucket
+              - s3:PutObject
+            Effect: Allow
+            Resource:
+              - Fn::Join:
+                  - ""
+                  - - "arn:aws:s3:::"
+                    - Ref: RssBatchBucket7D1FF398
+                    - /*
+              - Fn::Join:
+                  - ""
+                  - - "arn:aws:s3:::"
+                    - Ref: RssBatchBucket7D1FF398
+        Version: "2012-10-17"
+      PolicyName: StoreTaskTokenLambdaServiceRoleDefaultPolicy06B5CDD0
+      Roles:
+        - Ref: StoreTaskTokenRole
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/StoreTaskTokenLambda/ServiceRole/DefaultPolicy/Resource
+  StoreTaskTokenLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Architectures:
+        - arm64
+      Code:
+        S3Bucket: cdk-hnb659fds-assets-123456789012-us-east-1
+        S3Key: eb236f464edf4faf9b21d3086b7ff6d7d297020a00d565772e51fa1a0ac34f61.zip
+      Environment:
+        Variables:
+          LOG_LEVEL: warn
+          S3_BUCKET:
+            Ref: RssBatchBucket7D1FF398
+      FunctionName: SampleApp-StoreTaskToken
+      Handler: index.lambda_handler
+      LoggingConfig:
+        LogGroup:
+          Ref: StoreTaskTokenLogs
+      MemorySize: 128
+      Role:
+        Fn::GetAtt:
+          - StoreTaskTokenRole
+          - Arn
+      Runtime: nodejs22.x
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+      Timeout: 30
+      TracingConfig:
+        Mode: PassThrough
+    DependsOn:
+      - StoreTaskTokenLambdaServiceRoleDefaultPolicy06B5CDD0
+      - StoreTaskTokenRole
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/StoreTaskTokenLambda/Resource
+      aws:asset:path: asset.eb236f464edf4faf9b21d3086b7ff6d7d297020a00d565772e51fa1a0ac34f61
+      aws:asset:is-bundled: true
+      aws:asset:property: Code
+  BatchCallbackLogs:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /aws/lambda/sampleapp-batch-callback
+      RetentionInDays: 30
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/BatchCallbackLogs/Resource
+  BatchCallbackRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/BatchCallbackLambda/ServiceRole/Resource
+  BatchCallbackLambdaServiceRoleDefaultPolicyE128FEC4:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - xray:PutTelemetryRecords
+              - xray:PutTraceSegments
+            Effect: Allow
+            Resource: "*"
+          - Action:
+              - s3:GetObject
+              - s3:ListBucket
+            Effect: Allow
+            Resource:
+              - Fn::Join:
+                  - ""
+                  - - "arn:aws:s3:::"
+                    - Ref: RssBatchBucket7D1FF398
+                    - /*
+              - Fn::Join:
+                  - ""
+                  - - "arn:aws:s3:::"
+                    - Ref: RssBatchBucket7D1FF398
+          - Action: bedrock:GetModelInvocationJob
+            Effect: Allow
+            Resource: arn:aws:bedrock:us-east-1:123456789012:model-invocation-job/*
+          - Action:
+              - states:SendTaskFailure
+              - states:SendTaskSuccess
+            Effect: Allow
+            Resource:
+              Ref: RssBatchStateMachineDA0594EE
+        Version: "2012-10-17"
+      PolicyName: BatchCallbackLambdaServiceRoleDefaultPolicyE128FEC4
+      Roles:
+        - Ref: BatchCallbackRole
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/BatchCallbackLambda/ServiceRole/DefaultPolicy/Resource
+  BatchCallbackLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Architectures:
+        - arm64
+      Code:
+        S3Bucket: cdk-hnb659fds-assets-123456789012-us-east-1
+        S3Key: 1bb6c98818d32bf7b41366eb2f1fabc6fcc8d359061bba4240e935b8a70364b3.zip
+      Environment:
+        Variables:
+          LOG_LEVEL: warn
+          S3_BUCKET:
+            Ref: RssBatchBucket7D1FF398
+      FunctionName: SampleApp-BatchCallback
+      Handler: index.lambda_handler
+      LoggingConfig:
+        LogGroup:
+          Ref: BatchCallbackLogs
+      MemorySize: 128
+      Role:
+        Fn::GetAtt:
+          - BatchCallbackRole
+          - Arn
+      Runtime: nodejs22.x
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+      Timeout: 60
+      TracingConfig:
+        Mode: Active
+    DependsOn:
+      - BatchCallbackLambdaServiceRoleDefaultPolicyE128FEC4
+      - BatchCallbackRole
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/BatchCallbackLambda/Resource
+      aws:asset:path: asset.1bb6c98818d32bf7b41366eb2f1fabc6fcc8d359061bba4240e935b8a70364b3
+      aws:asset:is-bundled: true
+      aws:asset:property: Code
+  ProcessBatchResultsLogs:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /aws/lambda/sampleapp-process-batch-results
+      RetentionInDays: 30
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/ProcessBatchResultsLogs/Resource
+  ProcessBatchResultsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/ProcessBatchResultsLambda/ServiceRole/Resource
+  ProcessBatchResultsLambdaServiceRoleDefaultPolicyBBC5E94E:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - xray:PutTelemetryRecords
+              - xray:PutTraceSegments
+            Effect: Allow
+            Resource: "*"
+          - Action:
+              - dynamodb:BatchWriteItem
+              - dynamodb:DeleteItem
+              - dynamodb:DescribeTable
+              - dynamodb:GetItem
+              - dynamodb:PutItem
+              - dynamodb:Query
+              - dynamodb:Scan
+              - dynamodb:UpdateItem
+            Effect: Allow
+            Resource:
+              - arn:aws:dynamodb:us-east-1:123456789012:table/ItemMetadata-abcdefghijklmnopqrstuvwxyz-NONE
+              - arn:aws:dynamodb:us-east-1:123456789012:table/ItemMetadata-abcdefghijklmnopqrstuvwxyz-NONE/index/*
+              - arn:aws:dynamodb:us-east-1:123456789012:table/ProcessedItem-abcdefghijklmnopqrstuvwxyz-NONE
+              - arn:aws:dynamodb:us-east-1:123456789012:table/ProcessedItem-abcdefghijklmnopqrstuvwxyz-NONE/index/*
+          - Action:
+              - s3:DeleteObject
+              - s3:GetObject
+              - s3:ListBucket
+              - s3:PutObject
+            Effect: Allow
+            Resource:
+              - Fn::Join:
+                  - ""
+                  - - "arn:aws:s3:::"
+                    - Ref: RssBatchBucket7D1FF398
+                    - /*
+              - Fn::Join:
+                  - ""
+                  - - "arn:aws:s3:::"
+                    - Ref: RssBatchBucket7D1FF398
+        Version: "2012-10-17"
+      PolicyName: ProcessBatchResultsLambdaServiceRoleDefaultPolicyBBC5E94E
+      Roles:
+        - Ref: ProcessBatchResultsRole
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/ProcessBatchResultsLambda/ServiceRole/DefaultPolicy/Resource
+  ProcessBatchResultsLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Architectures:
+        - arm64
+      Code:
+        S3Bucket: cdk-hnb659fds-assets-123456789012-us-east-1
+        S3Key: 3abbe79759e53b9fd31898d57deff1c9ec8792cba0b556bd2da396cd4cdbb651.zip
+      Environment:
+        Variables:
+          LOG_LEVEL: WARNING
+          S3_BUCKET:
+            Ref: RssBatchBucket7D1FF398
+          DYNAMODB_PROCESSED_TABLE: ProcessedItem-abcdefghijklmnopqrstuvwxyz-NONE
+          DYNAMODB_METADATA_TABLE: ItemMetadata-abcdefghijklmnopqrstuvwxyz-NONE
+      FunctionName: SampleApp-ProcessBatchResults
+      Handler: handler.lambda_handler
+      LoggingConfig:
+        LogGroup:
+          Ref: ProcessBatchResultsLogs
+      MemorySize: 256
+      Role:
+        Fn::GetAtt:
+          - ProcessBatchResultsRole
+          - Arn
+      Runtime: python3.13
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+      Timeout: 300
+      TracingConfig:
+        Mode: PassThrough
+    DependsOn:
+      - ProcessBatchResultsLambdaServiceRoleDefaultPolicyBBC5E94E
+      - ProcessBatchResultsRole
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/ProcessBatchResultsLambda/Resource
+      aws:asset:path: asset.3abbe79759e53b9fd31898d57deff1c9ec8792cba0b556bd2da396cd4cdbb651
+      aws:asset:is-bundled: true
+      aws:asset:property: Code
+  RssBatchStateMachineRole6443524C:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: states.amazonaws.com
+        Version: "2012-10-17"
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/RssBatchStateMachine/Role/Resource
+  RssBatchStateMachineRoleDefaultPolicy40DEBD3D:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: lambda:InvokeFunction
+            Effect: Allow
+            Resource:
+              - Fn::GetAtt:
+                  - CollectRSSLambda
+                  - Arn
+              - Fn::GetAtt:
+                  - ProcessBatchResultsLambda
+                  - Arn
+              - Fn::GetAtt:
+                  - StoreTaskTokenLambda
+                  - Arn
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - CollectRSSLambda
+                        - Arn
+                    - :*
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - ProcessBatchResultsLambda
+                        - Arn
+                    - :*
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - StoreTaskTokenLambda
+                        - Arn
+                    - :*
+          - Action:
+              - xray:GetSamplingRules
+              - xray:GetSamplingTargets
+              - xray:PutTelemetryRecords
+              - xray:PutTraceSegments
+            Effect: Allow
+            Resource: "*"
+        Version: "2012-10-17"
+      PolicyName: RssBatchStateMachineRoleDefaultPolicy40DEBD3D
+      Roles:
+        - Ref: RssBatchStateMachineRole6443524C
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/RssBatchStateMachine/Role/DefaultPolicy/Resource
+  RssBatchStateMachineDA0594EE:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      DefinitionString:
+        Fn::Join:
+          - ""
+          - - '{"StartAt":"Step-CollectRSS","States":{"Step-CollectRSS":{"Next":"Step-StoreTaskToken","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["Lambda.ServiceException","Lambda.TooManyRequestsException","Lambda.AWSLambdaException"],"IntervalSeconds":2,"MaxAttempts":2,"BackoffRate":2}],"Catch":[{"ErrorEquals":["States.ALL"],"ResultPath":"$.errorInfo","Next":"FormatError-CollectRSS"}],"Type":"Task","ResultPath":"$.stepResults.CollectRSS","ResultSelector":{"output.$":"$.Payload"},"Resource":"arn:'
+            - Ref: AWS::Partition
+            - :states:::lambda:invoke","Parameters":{"FunctionName":"
+            - Fn::GetAtt:
+                - CollectRSSLambda
+                - Arn
+            - '","Payload":{"executionId.$":"$$.Execution.Id","s3Prefix.$":"$.s3Prefix","jobArn.$":"$.jobArn","stepResults.$":"$.stepResults"}}},"Step-StoreTaskToken":{"Next":"Step-ProcessBatchResults","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["Lambda.ServiceException","Lambda.TooManyRequestsException","Lambda.AWSLambdaException"],"IntervalSeconds":2,"MaxAttempts":2,"BackoffRate":2}],"Catch":[{"ErrorEquals":["States.ALL"],"ResultPath":"$.errorInfo","Next":"FormatError-StoreTaskToken"}],"Type":"Task","TimeoutSeconds":172800,"HeartbeatSeconds":86400,"ResultPath":"$.stepResults.StoreTaskToken","ResultSelector":{"output.$":"$"},"Resource":"arn:'
+            - Ref: AWS::Partition
+            - :states:::lambda:invoke.waitForTaskToken","Parameters":{"FunctionName":"
+            - Fn::GetAtt:
+                - StoreTaskTokenLambda
+                - Arn
+            - '","Payload":{"executionId.$":"$$.Execution.Id","s3Prefix.$":"$.stepResults.CollectRSS.output.s3Prefix","jobArn.$":"$.stepResults.CollectRSS.output.jobArn","taskToken.$":"$$.Task.Token","stepResults.$":"$.stepResults"}}},"Step-ProcessBatchResults":{"Next":"WorkflowSucceeded","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["Lambda.ServiceException","Lambda.TooManyRequestsException","Lambda.AWSLambdaException"],"IntervalSeconds":2,"MaxAttempts":2,"BackoffRate":2}],"Catch":[{"ErrorEquals":["States.ALL"],"ResultPath":"$.errorInfo","Next":"FormatError-ProcessBatchResults"}],"Type":"Task","ResultPath":"$.stepResults.ProcessBatchResults","ResultSelector":{"output.$":"$.Payload"},"Resource":"arn:'
+            - Ref: AWS::Partition
+            - :states:::lambda:invoke","Parameters":{"FunctionName":"
+            - Fn::GetAtt:
+                - ProcessBatchResultsLambda
+                - Arn
+            - "\",\"Payload\":{\"executionId.$\":\"$$.Execution.Id\",\"s3Prefix.$\":\"$.s3Prefix\",\"jobArn.$\":\"$.jobArn\",\"stepResults.$\":\"$.stepResults\"}}},\"WorkflowSucceeded\":{\"Type\":\"Succeed\"},\"FormatError-ProcessBatchResults\":{\"Type\":\"Pass\",\"Parameters\":{\"s3Prefix.$\":\"$.s3Prefix\",\"jobArn.$\":\"$.jobArn\",\"stepResults.$\":\"$.stepResults\",\"failedStep\":\"ProcessBatchResults\",\"errorMessage.$\":\"States.Format('Step ProcessBatchResults failed: {}', States.JsonToString($.errorInfo))\",\"errorInfo.$\":\"$.errorInfo\"},\"Next\":\"WorkflowFailed\"},\"WorkflowFailed\":{\"Type\":\"Fail\",\"Error\":\"WorkflowError\",\"Cause\":\"RSS batch workflow step failed\"},\"FormatError-CollectRSS\":{\"Type\":\"Pass\",\"Parameters\":{\"s3Prefix.$\":\"$.s3Prefix\",\"jobArn.$\":\"$.jobArn\",\"stepResults.$\":\"$.stepResults\",\"failedStep\":\"CollectRSS\",\"errorMessage.$\":\"States.Format('Step CollectRSS failed: {}', States.JsonToString($.errorInfo))\",\"errorInfo.$\":\"$.errorInfo\"},\"Next\":\"WorkflowFailed\"},\"FormatError-StoreTaskToken\":{\"Type\":\"Pass\",\"Parameters\":{\"s3Prefix.$\":\"$.s3Prefix\",\"jobArn.$\":\"$.jobArn\",\"stepResults.$\":\"$.stepResults\",\"failedStep\":\"StoreTaskToken\",\"errorMessage.$\":\"States.Format('Step StoreTaskToken failed: {}', States.JsonToString($.errorInfo))\",\"errorInfo.$\":\"$.errorInfo\"},\"Next\":\"WorkflowFailed\"}},\"TimeoutSeconds\":259200}"
+      RoleArn:
+        Fn::GetAtt:
+          - RssBatchStateMachineRole6443524C
+          - Arn
+      StateMachineName: SampleApp-RssBatch
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+      TracingConfiguration:
+        Enabled: true
+    DependsOn:
+      - RssBatchStateMachineRoleDefaultPolicy40DEBD3D
+      - RssBatchStateMachineRole6443524C
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/RssBatchStateMachine/Resource
+  BedrockBatchJobCompletion2F0E167B:
+    Type: AWS::Events::Rule
+    Properties:
+      EventPattern:
+        source:
+          - aws.bedrock
+        detail-type:
+          - Batch Inference Job State Change
+        detail:
+          status:
+            - Completed
+            - Failed
+            - Stopped
+            - Expired
+          batchJobName:
+            - prefix: rss-enrichment-
+      Name: sampleapp-bedrock-batch-completion
+      State: ENABLED
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+      Targets:
+        - Arn:
+            Fn::GetAtt:
+              - BatchCallbackLambda
+              - Arn
+          DeadLetterConfig:
+            Arn:
+              Fn::GetAtt:
+                - BatchCallbackDLQ35932C63
+                - Arn
+          Id: Target0
+          RetryPolicy:
+            MaximumRetryAttempts: 2
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/BedrockBatchJobCompletion/Resource
+  BedrockBatchJobCompletionAllowEventRuleSampleAppRssBatchBatchCallbackLambda7ACB8F3376BECB49:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName:
+        Fn::GetAtt:
+          - BatchCallbackLambda
+          - Arn
+      Principal: events.amazonaws.com
+      SourceArn:
+        Fn::GetAtt:
+          - BedrockBatchJobCompletion2F0E167B
+          - Arn
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/BedrockBatchJobCompletion/AllowEventRuleSampleAppRssBatchBatchCallbackLambda7ACB8F33
+  BatchCallbackDLQ35932C63:
+    Type: AWS::SQS::Queue
+    Properties:
+      MessageRetentionPeriod: 1209600
+      QueueName: sampleapp-batch-callback-dlq
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/BatchCallbackDLQ/Resource
+  BatchCallbackDLQPolicy89F0DCFB:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: sqs:SendMessage
+            Condition:
+              ArnEquals:
+                aws:SourceArn:
+                  Fn::GetAtt:
+                    - BedrockBatchJobCompletion2F0E167B
+                    - Arn
+            Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Resource:
+              Fn::GetAtt:
+                - BatchCallbackDLQ35932C63
+                - Arn
+            Sid: AllowEventRuleSampleAppRssBatchBedrockBatchJobCompletion7817E435
+        Version: "2012-10-17"
+      Queues:
+        - Ref: BatchCallbackDLQ35932C63
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/BatchCallbackDLQ/Policy/Resource
+  SchedulerRole59E73443:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: scheduler.amazonaws.com
+        Version: "2012-10-17"
+      Tags:
+        - Key: ApplicationName
+          Value: sampleapp
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/SchedulerRole/Resource
+  SchedulerRoleDefaultPolicy66F774B8:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: states:StartExecution
+            Effect: Allow
+            Resource:
+              Ref: RssBatchStateMachineDA0594EE
+        Version: "2012-10-17"
+      PolicyName: SchedulerRoleDefaultPolicy66F774B8
+      Roles:
+        - Ref: SchedulerRole59E73443
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/SchedulerRole/DefaultPolicy/Resource
+  DailyRssSchedule:
+    Type: AWS::Scheduler::Schedule
+    Properties:
+      FlexibleTimeWindow:
+        MaximumWindowInMinutes: 30
+        Mode: FLEXIBLE
+      Name: sampleapp-rss-batch-daily
+      ScheduleExpression: cron(22 23 ? * * *)
+      Target:
+        Arn:
+          Ref: RssBatchStateMachineDA0594EE
+        Input: '{"s3Prefix":"","jobArn":"","stepResults":{}}'
+        RetryPolicy:
+          MaximumEventAgeInSeconds: 7200
+          MaximumRetryAttempts: 3
+        RoleArn:
+          Fn::GetAtt:
+            - SchedulerRole59E73443
+            - Arn
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/DailyRssSchedule
+  CDKMetadata:
+    Type: AWS::CDK::Metadata
+    Properties:
+      Analytics: v2:deflate64:H4sIAAAAAAAA/+1ZbW/bNhD+LeXHgNHSZF+Wb07nDsWSTrW9AYNhGDR5kRlTpMsjnXmC/vtA6sVyqnkplhStG8AwJR559zxH8Ugez5PzH8+Ss1fsHk+5WJ0quUiKsWN8Rdk9zgu8SIorz1fgpgVZxIf3LAdySU4IJRZys2EqNUryLbkkAtBZsyWUMO/Mz6DAwW+LO+AOyaWzHihR8hb4lisYeQVILqdFOStpQZgQ111RlNBo5YTMyhl9c6srILQqKqMtqoio26yS142vGEJJxVaz3IhFUkzYQsG0IC6UHUJrZp100uhfYUsuC6J3Irddh8cxKSlBY93hFguplNTZjRGhKh38OU+Ho/lo+OH34XhywHMVgwivpIrlC8GS4q3XPICaFsR67WRrccm0UGDrN14ZOyHBnznkxm7H8u8WnczBeNeMnFGNQJnsF2v8un69rY11vLJZ893T2C80hPHct/kQTBdowNOjdp8Ls3wpHXDnbb9GZxmXOgvuZIiTpTU+W+5D+A/SoDfSGp2Ddn3c689w2G01bb/A4xK+DEe/ME6/Zr7RsdSZAmd0ZwZ6L0UDN87P1Nu1wUdy/uLzjglxA44J5ljNM8ThWb9o54IUbC4RpdEllSxPipGJAZMh+hzEVYx9ays1l2umBpwb345i1SZ0GERGNRaSM80yEDHmySr279VtB7Zu28CbmLQx0UTKdr1wjvHlO62khlbWju9B4Rek8Fw4BCC3ct2pekZ/Rb0P1R02dgRfyWG935v06Af06Am+jP7X5pwXvk/EN+5YgjVaHwoDiKbDxIzinuuBnk+rhRg75iDsCDvnUuzU7RbavpafY+4JAfZWP7f+b7X6+/L7C5rnR1OdlmLYKakyGSbFdX2wmxbtGa891AU1j6sMOSIHugqfF2cHUkbfbu/ovMZdJcWLOUMEh8kgFBQxD8lIK3WWMstycGCnRUjSVc8dixhb/cGUh04msO3V5NLm2gi4w+R9LDqn+v+fDwHt7PZJEh//nltZeC1UFBQE/nJgNVM3RlSZ1Gq/1U0CVr9j4fY1UwnbnA0c3Qg9nlY5o+hg3RDBpHjLpKJhiOnYcw4gaIydN4wvpQ6pJOy8dogLuJU65uCvjNj2MqgBDnVIk4vqZqHdXIaY3bujfQJBDCpdGuU+67ljuMLkOsaad3pjVkBhE1aLpAiXGjGBv3fhEKUpc8GlwblovOU7Vzgm1aS6VthV7O2mh3sKpp+joSXKbBYuUHYUA9aS4kdMig8efMD9MZR9IT4FK43oBN3Yg8b/9o4m9sa9/XqnQUmRLyF8TTYJDq5fSvrGozP5CCpObYoyQqwrH7RJrdlIATZc+NC4iowdy6TOaFfLjPLYa27rSkwG97ivqaRhrUju8IfN+Xny+qfk7NUdSnlaT8xkVJX/ANX2rPdBGwAA
+    Metadata:
+      aws:cdk:path: SampleApp-RssBatch/CDKMetadata/Default
+Parameters:
+  BootstrapVersion:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /cdk-bootstrap/hnb659fds/version
+    Description: Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]
+
+4 feature flags are not configured. Run 'cdk flags --unstable=flags' to learn more.
+
+NOTICES         (What's this? https://github.com/aws/aws-cdk/wiki/CLI-Notices)
+
+37013	(cli) cdk watch triggers deployment unexpectedly or not at all
+
+	Overview: Do not use 'cdk watch' with this version of the cdk cli.
+	          Upgrade to ^2.1106.0.
+
+	Affected versions: cli: >=2.1103.0 <2.1106.0
+
+	More information at: https://github.com/aws/aws-cdk/issues/37013
+
+
+34892	CDK CLI collects telemetry data on command usage starting at version 2.1100.0 (unless opted out)
+
+	Overview: We do not collect customer content and we anonymize the
+	          telemetry we do collect. See the attached issue for more
+	          information on what data is collected, why, and how to
+	          opt-out. Telemetry will NOT be collected for any CDK CLI
+	          version prior to version 2.1100.0 - regardless of
+	          opt-in/out. You can also view the telemetry we collect by
+	          logging it to a local file, by adding
+	          `--telemetry-file=my/local/file` to any `cdk` command.
+
+	Affected versions: cli: >=2.1100.0 <2.1106.1
+
+	More information at: https://github.com/aws/aws-cdk/issues/34892
+
+
+If you donÔÇÖt want to see a notice anymore, use "cdk acknowledge <id>". For example, "cdk acknowledge 37013".


### PR DESCRIPTION
## Context

AWS CDK is an Infrastructure-as-Code framework. Its CLI commands (`cdk diff`, `cdk synth`, `cdk deploy`) produce extremely verbose output: asset bundling logs (esbuild, Docker, pip), CloudFormation progress lines, NOTICES sections, and full YAML templates. A typical `cdk diff` on a project with 13 lambdas generates ~870 tokens of which only ~240 are meaningful.

## What this PR does

Adds `rtk cdk` with 3 specialized filters:

- **`rtk cdk diff`** — Keeps only stack headers, resource diff markers (`[+]`/`[-]`/`[~]`), IAM change tables, and a summary count. Strips all bundling noise, build logs, and NOTICES.
- **`rtk cdk synth`** — Two modes: when no stack is specified, shows the synthesized path + stack list. When a full YAML template is output, extracts a resource type summary (e.g. "Lambda::Function x7, IAM::Role x10").
- **`rtk cdk deploy`** — Strips per-resource CloudFormation progress lines, keeps success/failure status, outputs section, and timing. Handles both standard and stack-prefixed progress formats.

**Design**: whitelist approach — only keep lines matching known meaningful patterns. Everything else is dropped. This is future-proof: any new bundler or tool CDK adds will be automatically filtered without code changes.

Handles Windows/PowerShell mojibake (box-drawing characters rendered as `Ôö£ÔöÇ` instead of `├──`).

## Token savings

| Fixture | Raw | Filtered | Savings |
|---------|-----|----------|---------|
| cdk diff (5 stacks, esbuild bundling) | 870 tok | 240 tok | **72.4%** |
| cdk diff (Docker pull + pip install) | 1049 tok | 133 tok | **87.3%** |
| cdk synth (no-template, stack list) | 483 tok | 10 tok | **97.9%** |
| cdk synth (full 62KB YAML template) | 2446 tok | 23 tok | **99.1%** |
| cdk deploy (stack-prefixed progress) | 396 tok | 13 tok | **96.7%** |

## Depends on

Based on #398 (`fix/windows-cmd-compat`) — `cdk_cmd.rs` uses `script_cmd()` required for Windows where `cdk` is a `.ps1` wrapper. Will rebase onto master once #398 is merged.

## Test plan
- 32 unit tests including 6 insta snapshot tests
- 6 real-world anonymized fixtures (2 projects x 3 commands)
- Token savings verified >= 60% on all fixtures
- `cargo fmt && cargo clippy --all-targets && cargo test --all` — 745 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
