### PR TITLE
Add OpenCode provider support for discover

### DIFF
--- a/src/discover/mod.rs
+++ b/src/discover/mod.rs
@@ -6,10 +6,10 @@ pub mod rules;
 use anyhow::Result;
 use std::collections::HashMap;
 
-use provider::{ClaudeProvider, SessionProvider};
+use provider::{ClaudeProvider, DiscoverProvider, OpenCodeProvider, SessionProvider};
 use registry::{
-    category_avg_tokens, classify_command, has_rtk_disabled_prefix, split_command_chain,
-    strip_disabled_prefix, Classification,
+    category_avg_tokens, classify_command, has_rtk_disabled_prefix, is_rtk_invocation,
+    split_command_chain, strip_disabled_prefix, Classification,
 };
 use report::{DiscoverReport, SupportedEntry, UnsupportedEntry};
 
@@ -37,8 +37,20 @@ pub fn run(
     limit: usize,
     format: &str,
     verbose: u8,
+    provider: DiscoverProvider,
 ) -> Result<()> {
-    let provider = ClaudeProvider;
+    let (session_provider, uses_claude_path_encoding): (Box<dyn SessionProvider>, bool) =
+        match provider {
+            DiscoverProvider::Claude => (Box::new(ClaudeProvider), true),
+            DiscoverProvider::Opencode => (Box::new(OpenCodeProvider::new()?), false),
+            DiscoverProvider::Auto => {
+                if OpenCodeProvider::db_exists() {
+                    (Box::new(OpenCodeProvider::new()?), false)
+                } else {
+                    (Box::new(ClaudeProvider), true)
+                }
+            }
+        };
 
     // Determine project filter
     let project_filter = if all {
@@ -49,11 +61,15 @@ pub fn run(
         // Default: current working directory
         let cwd = std::env::current_dir()?;
         let cwd_str = cwd.to_string_lossy().to_string();
-        let encoded = ClaudeProvider::encode_project_path(&cwd_str);
-        Some(encoded)
+        if uses_claude_path_encoding {
+            Some(ClaudeProvider::encode_project_path(&cwd_str))
+        } else {
+            Some(cwd_str)
+        }
     };
 
-    let sessions = provider.discover_sessions(project_filter.as_deref(), Some(since_days))?;
+    let sessions =
+        session_provider.discover_sessions(project_filter.as_deref(), Some(since_days))?;
 
     if verbose > 0 {
         eprintln!("Scanning {} session files...", sessions.len());
@@ -71,7 +87,7 @@ pub fn run(
     let mut unsupported_map: HashMap<String, UnsupportedBucket> = HashMap::new();
 
     for session_path in &sessions {
-        let extracted = match provider.extract_commands(session_path) {
+        let extracted = match session_provider.extract_commands(session_path) {
             Ok(cmds) => cmds,
             Err(e) => {
                 if verbose > 0 {
@@ -156,8 +172,8 @@ pub fn run(
                         bucket.count += 1;
                     }
                     Classification::Ignored => {
-                        // Check if it starts with "rtk "
-                        if part.trim().starts_with("rtk ") {
+                        // Count direct and path-based RTK invocations as already using RTK.
+                        if is_rtk_invocation(part) {
                             already_rtk += 1;
                         }
                         // Otherwise just skip

--- a/src/discover/provider.rs
+++ b/src/discover/provider.rs
@@ -1,4 +1,8 @@
 use anyhow::{Context, Result};
+use clap::ValueEnum;
+use rusqlite::Connection;
+use serde_json::Value;
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fs;
 use std::io::{BufRead, BufReader};
@@ -33,6 +37,18 @@ pub trait SessionProvider {
 
 pub struct ClaudeProvider;
 
+pub struct OpenCodeProvider {
+    db_path: PathBuf,
+    conn: RefCell<Option<Connection>>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum DiscoverProvider {
+    Auto,
+    Claude,
+    Opencode,
+}
+
 impl ClaudeProvider {
     /// Get the base directory for Claude Code projects.
     fn projects_dir() -> Result<PathBuf> {
@@ -52,6 +68,71 @@ impl ClaudeProvider {
     pub fn encode_project_path(path: &str) -> String {
         path.replace('/', "-")
     }
+}
+
+impl OpenCodeProvider {
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            db_path: Self::resolve_db_path()?,
+            conn: RefCell::new(None),
+        })
+    }
+
+    fn resolve_db_path() -> Result<PathBuf> {
+        if let Ok(path) = std::env::var("OPENCODE_DB_PATH") {
+            let p = PathBuf::from(path);
+            if p.exists() {
+                return Ok(p);
+            }
+        }
+
+        let home = dirs::home_dir().context("could not determine home directory")?;
+        let db = home
+            .join(".local")
+            .join("share")
+            .join("opencode")
+            .join("opencode.db");
+        if !db.exists() {
+            anyhow::bail!(
+                "OpenCode database not found: {}\nSet OPENCODE_DB_PATH to override.",
+                db.display()
+            );
+        }
+        Ok(db)
+    }
+
+    pub fn db_exists() -> bool {
+        Self::resolve_db_path().is_ok()
+    }
+
+    fn parse_session_ref(path: &Path) -> Option<String> {
+        let value = path.to_string_lossy();
+        value
+            .strip_prefix("opencode-session-")
+            .map(|s| s.to_string())
+    }
+
+    fn with_connection<T>(&self, f: impl FnOnce(&Connection) -> Result<T>) -> Result<T> {
+        let mut conn_slot = self.conn.borrow_mut();
+        if conn_slot.is_none() {
+            let conn = Connection::open(&self.db_path).with_context(|| {
+                format!("failed to open OpenCode DB {}", self.db_path.display())
+            })?;
+            *conn_slot = Some(conn);
+        }
+
+        let conn = conn_slot
+            .as_ref()
+            .context("OpenCode DB connection was not initialized")?;
+        f(conn)
+    }
+}
+
+fn escape_like_pattern(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
 }
 
 impl SessionProvider for ClaudeProvider {
@@ -234,6 +315,127 @@ impl SessionProvider for ClaudeProvider {
     }
 }
 
+impl SessionProvider for OpenCodeProvider {
+    fn discover_sessions(
+        &self,
+        project_filter: Option<&str>,
+        since_days: Option<u64>,
+    ) -> Result<Vec<PathBuf>> {
+        let cutoff_ms = since_days.map(|days| {
+            let cutoff = SystemTime::now()
+                .checked_sub(Duration::from_secs(days.saturating_mul(86400)))
+                .unwrap_or(SystemTime::UNIX_EPOCH);
+            cutoff
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .map(|d| d.as_millis() as i64)
+                .unwrap_or(0)
+        });
+        let escaped_project_filter = project_filter.map(escape_like_pattern);
+
+        self.with_connection(|conn| {
+            let mut sessions: Vec<PathBuf> = Vec::new();
+            let mut stmt = conn.prepare(
+                r#"
+                SELECT id
+                FROM session
+                WHERE (?1 IS NULL OR directory LIKE '%' || ?1 || '%' ESCAPE '\')
+                  AND (?2 IS NULL OR time_updated >= ?2)
+                ORDER BY time_updated DESC
+                "#,
+            )?;
+
+            let rows = stmt.query_map(
+                rusqlite::params![escaped_project_filter.as_deref(), cutoff_ms],
+                |row| row.get::<_, String>(0),
+            )?;
+
+            for row in rows {
+                let session_id = row?;
+                sessions.push(PathBuf::from(format!("opencode-session-{session_id}")));
+            }
+
+            Ok(sessions)
+        })
+    }
+
+    fn extract_commands(&self, path: &Path) -> Result<Vec<ExtractedCommand>> {
+        let session_id = Self::parse_session_ref(path).with_context(|| {
+            format!(
+                "invalid OpenCode session reference '{}'; expected opencode-session-<id>",
+                path.display()
+            )
+        })?;
+
+        self.with_connection(|conn| {
+            let mut stmt = conn.prepare(
+                "
+                SELECT data
+                FROM part
+                WHERE session_id = ?1
+                  AND json_extract(data, '$.type') = 'tool'
+                  AND json_extract(data, '$.tool') = 'bash'
+                ORDER BY time_created ASC
+                ",
+            )?;
+
+            let mut commands = Vec::new();
+            let mut sequence_index = 0usize;
+            let rows =
+                stmt.query_map(rusqlite::params![session_id], |row| row.get::<_, String>(0))?;
+
+            for row in rows {
+                let raw = row?;
+                let json: Value = match serde_json::from_str(&raw) {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+
+                let command = json
+                    .pointer("/state/input/command")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .trim()
+                    .to_string();
+                if command.is_empty() {
+                    continue;
+                }
+
+                let output = json
+                    .pointer("/state/output")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+
+                let status = json
+                    .pointer("/state/status")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+
+                let output_content: Option<String> = if output.is_empty() {
+                    None
+                } else {
+                    Some(output.chars().take(1000).collect())
+                };
+
+                commands.push(ExtractedCommand {
+                    command,
+                    output_len: if output.is_empty() {
+                        None
+                    } else {
+                        Some(output.len())
+                    },
+                    session_id: session_id.clone(),
+                    output_content,
+                    is_error: status == "error",
+                    sequence_index,
+                });
+                sequence_index += 1;
+            }
+
+            Ok(commands)
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -334,6 +536,14 @@ mod tests {
         let encoded = ClaudeProvider::encode_project_path("/Users/foo/Sites/rtk");
         assert!(encoded.contains("rtk"));
         assert!(encoded.contains("Sites"));
+    }
+
+    #[test]
+    fn test_escape_like_pattern_escapes_wildcards() {
+        assert_eq!(
+            escape_like_pattern(r"foo%bar_baz\\qux"),
+            r"foo\%bar\_baz\\\\qux"
+        );
     }
 
     #[test]

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1,5 +1,6 @@
 use lazy_static::lazy_static;
 use regex::{Regex, RegexSet};
+use std::path::Path;
 
 use super::rules::{IGNORED_EXACT, IGNORED_PREFIXES, PATTERNS, RULES};
 
@@ -57,6 +58,11 @@ pub fn classify_command(cmd: &str) -> Classification {
         return Classification::Ignored;
     }
 
+    // Ignore script-like snippets captured as a single "command" (multiline, comments).
+    if trimmed.contains('\n') || trimmed.starts_with('#') {
+        return Classification::Ignored;
+    }
+
     // Check ignored
     for exact in IGNORED_EXACT {
         if trimmed == *exact {
@@ -71,8 +77,26 @@ pub fn classify_command(cmd: &str) -> Classification {
 
     // Strip env prefixes (sudo, env VAR=val, VAR=val)
     let stripped = ENV_PREFIX.replace(trimmed, "");
+    let cmd_clean_storage;
     let cmd_clean = stripped.trim();
     if cmd_clean.is_empty() {
+        return Classification::Ignored;
+    }
+
+    // Normalize RTK path invocations to canonical "rtk ..." form.
+    // Examples:
+    //   /home/user/.cargo/bin/rtk git status -> rtk git status
+    //   "/home/user/.cargo/bin/rtk" git status -> rtk git status
+    //   ./rtk git status -> rtk git status
+    let cmd_clean = if let Some(norm) = normalize_rtk_invocation(cmd_clean) {
+        cmd_clean_storage = norm;
+        cmd_clean_storage.as_str()
+    } else {
+        cmd_clean
+    };
+
+    // Already an RTK command (directly or via normalized absolute path)
+    if cmd_clean == "rtk" || cmd_clean.starts_with("rtk ") {
         return Classification::Ignored;
     }
 
@@ -146,6 +170,67 @@ pub fn classify_command(cmd: &str) -> Classification {
             }
         }
     }
+}
+
+/// Returns true when a command is an RTK invocation (direct or path-based),
+/// including env/sudo-prefixed forms.
+pub fn is_rtk_invocation(cmd: &str) -> bool {
+    let trimmed = cmd.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    let stripped = ENV_PREFIX.replace(trimmed, "");
+    let cmd_clean = stripped.trim();
+    if cmd_clean.is_empty() {
+        return false;
+    }
+
+    if cmd_clean == "rtk" || cmd_clean.starts_with("rtk ") {
+        return true;
+    }
+
+    normalize_rtk_invocation(cmd_clean)
+        .map(|norm| norm == "rtk" || norm.starts_with("rtk "))
+        .unwrap_or(false)
+}
+
+fn normalize_rtk_invocation(cmd: &str) -> Option<String> {
+    let mut parts = cmd.splitn(2, char::is_whitespace);
+    let first = parts.next()?.trim();
+    let first = strip_matching_quotes(first);
+
+    let is_rtk = first == "rtk"
+        || first.ends_with("/rtk")
+        || first.ends_with("\\rtk")
+        || Path::new(first)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(|name| name == "rtk")
+            .unwrap_or(false);
+
+    if !is_rtk {
+        return None;
+    }
+
+    let rest = parts.next().map(str::trim_start).unwrap_or("");
+    if rest.is_empty() {
+        Some("rtk".to_string())
+    } else {
+        Some(format!("rtk {rest}"))
+    }
+}
+
+fn strip_matching_quotes(token: &str) -> &str {
+    let bytes = token.as_bytes();
+    if bytes.len() >= 2 {
+        let first = bytes[0];
+        let last = bytes[bytes.len() - 1];
+        if (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'') {
+            return &token[1..token.len() - 1];
+        }
+    }
+    token
 }
 
 /// Extract the base command (first word, or first two if it looks like a subcommand pattern).
@@ -696,6 +781,55 @@ mod tests {
     #[test]
     fn test_classify_rtk_already() {
         assert_eq!(classify_command("rtk git status"), Classification::Ignored);
+    }
+
+    #[test]
+    fn test_is_rtk_invocation_direct() {
+        assert!(is_rtk_invocation("rtk git status"));
+    }
+
+    #[test]
+    fn test_is_rtk_invocation_absolute_path() {
+        assert!(is_rtk_invocation("/home/vadikas/.cargo/bin/rtk git status"));
+    }
+
+    #[test]
+    fn test_is_rtk_invocation_env_prefixed() {
+        assert!(is_rtk_invocation(
+            "FOO=1 /home/vadikas/.cargo/bin/rtk git status"
+        ));
+    }
+
+    #[test]
+    fn test_classify_absolute_rtk_path_ignored() {
+        assert_eq!(
+            classify_command("/home/vadikas/.cargo/bin/rtk git status"),
+            Classification::Ignored
+        );
+    }
+
+    #[test]
+    fn test_classify_quoted_absolute_rtk_path_ignored() {
+        assert_eq!(
+            classify_command("\"/home/vadikas/.cargo/bin/rtk\" git status"),
+            Classification::Ignored
+        );
+    }
+
+    #[test]
+    fn test_classify_env_prefixed_absolute_rtk_path_ignored() {
+        assert_eq!(
+            classify_command("FOO=1 /home/vadikas/.cargo/bin/rtk git status"),
+            Classification::Ignored
+        );
+    }
+
+    #[test]
+    fn test_classify_sudo_absolute_rtk_path_ignored() {
+        assert_eq!(
+            classify_command("sudo /home/vadikas/.cargo/bin/rtk git status"),
+            Classification::Ignored
+        );
     }
 
     #[test]
@@ -1485,7 +1619,7 @@ mod tests {
         );
     }
 
-    // --- AWS / psql (PR #216) ---
+    // --- AWS / SQL clients (PR #216 + sqlite3) ---
 
     #[test]
     fn test_classify_aws() {
@@ -1955,6 +2089,22 @@ mod tests {
         assert_eq!(
             rewrite_command("curl https://api.example.com/health", &excluded),
             None
+        );
+    }
+
+    #[test]
+    fn test_classify_multiline_script_ignored() {
+        assert_eq!(
+            classify_command("# comment\ngit status"),
+            Classification::Ignored
+        );
+    }
+
+    #[test]
+    fn test_classify_single_line_comment_ignored() {
+        assert_eq!(
+            classify_command("# just a comment"),
+            Classification::Ignored
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ mod rewrite_cmd;
 mod ruff_cmd;
 mod runner;
 mod session_cmd;
+mod sqlite3_cmd;
 mod summary;
 mod tee;
 mod telemetry;
@@ -67,6 +68,7 @@ mod wget_cmd;
 use anyhow::{Context, Result};
 use clap::error::ErrorKind;
 use clap::{Parser, Subcommand};
+use discover::provider::DiscoverProvider;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
@@ -199,6 +201,13 @@ enum Commands {
     /// PostgreSQL client with compact output (strip borders, compress tables)
     Psql {
         /// psql arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// SQLite client passthrough with usage tracking
+    Sqlite3 {
+        /// sqlite3 arguments
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -520,8 +529,11 @@ enum Commands {
         args: Vec<String>,
     },
 
-    /// Discover missed RTK savings from Claude Code history
+    /// Discover missed RTK savings from session history
     Discover {
+        /// Session provider: auto, claude, opencode
+        #[arg(long, value_enum, default_value_t = DiscoverProvider::Auto)]
+        provider: DiscoverProvider,
         /// Filter by project path (substring match)
         #[arg(short, long)]
         project: Option<String>,
@@ -1419,6 +1431,10 @@ fn main() -> Result<()> {
             psql_cmd::run(&args, cli.verbose)?;
         }
 
+        Commands::Sqlite3 { args } => {
+            sqlite3_cmd::run(&args, cli.verbose)?;
+        }
+
         Commands::Pnpm { command } => match command {
             PnpmCommands::List { depth, args } => {
                 pnpm_cmd::run(pnpm_cmd::PnpmCommand::List { depth }, &args, cli.verbose)?;
@@ -1799,13 +1815,22 @@ fn main() -> Result<()> {
         }
 
         Commands::Discover {
+            provider,
             project,
             limit,
             all,
             since,
             format,
         } => {
-            discover::run(project.as_deref(), all, since, limit, &format, cli.verbose)?;
+            discover::run(
+                project.as_deref(),
+                all,
+                since,
+                limit,
+                &format,
+                cli.verbose,
+                provider,
+            )?;
         }
 
         Commands::Session {} => {
@@ -2144,6 +2169,8 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Smart { .. }
             | Commands::Git { .. }
             | Commands::Gh { .. }
+            | Commands::Psql { .. }
+            | Commands::Sqlite3 { .. }
             | Commands::Pnpm { .. }
             | Commands::Err { .. }
             | Commands::Test { .. }
@@ -2400,6 +2427,27 @@ mod tests {
                 cmd
             );
         }
+    }
+
+    #[test]
+    fn test_discover_provider_parses_value_enum() {
+        let result = Cli::try_parse_from(["rtk", "discover", "--provider", "opencode"]);
+        assert!(result.is_ok());
+
+        if let Ok(cli) = result {
+            match cli.command {
+                Commands::Discover { provider, .. } => {
+                    assert_eq!(provider, DiscoverProvider::Opencode)
+                }
+                _ => panic!("Expected Discover command"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_discover_provider_rejects_typo() {
+        let result = Cli::try_parse_from(["rtk", "discover", "--provider", "opnecode"]);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/sqlite3_cmd.rs
+++ b/src/sqlite3_cmd.rs
@@ -1,0 +1,51 @@
+//! SQLite3 client wrapper with token-friendly defaults.
+//!
+//! V1 behavior intentionally stays close to native sqlite3:
+//! - pass all args through unchanged
+//! - preserve stdout/stderr and exit codes
+//! - track command usage for RTK analytics
+
+use crate::tracking;
+use anyhow::{Context, Result};
+
+pub fn run(args: &[String], verbose: u8) -> Result<()> {
+    let timer = tracking::TimedExecution::start();
+
+    let mut cmd = std::process::Command::new("sqlite3");
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    if verbose > 0 {
+        eprintln!("Running: sqlite3 {}", args.join(" "));
+    }
+
+    let output = cmd
+        .output()
+        .context("Failed to run sqlite3 (is sqlite3 installed?)")?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let raw = format!("{}{}", stdout, stderr);
+
+    if !stdout.is_empty() {
+        print!("{}", stdout);
+    }
+    if !stderr.is_empty() {
+        eprint!("{}", stderr);
+    }
+
+    let filtered = stdout.to_string();
+    timer.track(
+        &format!("sqlite3 {}", args.join(" ")),
+        &format!("rtk sqlite3 {}", args.join(" ")),
+        &raw,
+        &filtered,
+    );
+
+    if !output.status.success() {
+        std::process::exit(output.status.code().unwrap_or(1));
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a new OpenCode session provider for `rtk discover` that reads command history from `~/.local/share/opencode/opencode.db` (with `OPENCODE_DB_PATH` override)
- add `--provider auto|claude|opencode` to `rtk discover` and make `auto` prefer OpenCode when available
- improve discover signal quality by ignoring multiline/comment script snippets and normalizing absolute RTK binary paths (for example: `/home/user/.cargo/bin/rtk ...`) before classification

## Validation
- `cargo check`
- `cargo test test_classify_ -- --nocapture`
- `cargo run --quiet -- discover --provider opencode --all --since 30 --limit 5 --format text`

## Notes
- this preserves existing Claude behavior while enabling OpenCode-first workflows without requiring Claude session logs
