### PR TITLE
docs: reposition RTK as agent-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@
 
 ---
 
-rtk filters and compresses command outputs before they reach your LLM context. Single Rust binary, 100+ supported commands, <10ms overhead.
+rtk filters and compresses command outputs before they reach your LLM context. Works with any AI coding agent — just prefix commands with `rtk`. 100+ supported commands, single binary, <10ms overhead.
 
-## Token Savings (30-min Claude Code Session)
+## Token Savings (30-min Coding Session)
 
 | Operation | Frequency | Standard | rtk | Savings |
 |-----------|-----------|----------|-----|---------|
@@ -100,31 +100,36 @@ rtk gain        # Should show token savings stats
 
 ## Quick Start
 
+**Use directly with any agent:**
 ```bash
-# 1. Install for your AI tool
+rtk git status              # Compact status (any agent)
+rtk cargo test              # Failures only, -90%
+rtk grep "pattern" .        # Grouped results
+```
+
+**Or auto-rewrite with a hook (commands rewrite transparently):**
+```bash
 rtk init -g                     # Claude Code / Copilot (default)
 rtk init -g --gemini            # Gemini CLI
 rtk init -g --codex             # Codex (OpenAI)
-rtk init -g --agent cursor      # Cursor
+rtk init --agent cursor         # Cursor
 rtk init --agent windsurf       # Windsurf
 rtk init --agent cline          # Cline / Roo Code
 rtk init --agent kilocode       # Kilo Code
 rtk init --agent antigravity    # Google Antigravity
-
-# 2. Restart your AI tool, then test
-git status  # Automatically rewritten to rtk git status
+# Restart your AI tool — `git status` auto-rewrites to `rtk git status`
 ```
 
-The hook transparently rewrites Bash commands (e.g., `git status` -> `rtk git status`) before execution. Claude never sees the rewrite, it just gets compressed output.
+The hook transparently rewrites Bash commands before execution. Your agent never sees the rewrite, it just gets compressed output.
 
-**Important:** the hook only runs on Bash tool calls. Claude Code built-in tools like `Read`, `Grep`, and `Glob` do not pass through the Bash hook, so they are not auto-rewritten. To get RTK's compact output for those workflows, use shell commands (`cat`/`head`/`tail`, `rg`/`grep`, `find`) or call `rtk read`, `rtk grep`, or `rtk find` directly.
+**Note:** hooks only run on Bash tool calls. Built-in tools like `Read`, `Grep`, `Glob` bypass the hook — call `rtk read`, `rtk grep`, `rtk find` directly for those.
 
 ## How It Works
 
 ```
   Without rtk:                                    With rtk:
 
-  Claude  --git status-->  shell  -->  git         Claude  --git status-->  RTK  -->  git
+  Agent  --git status-->  shell  -->  git          Agent  --git status-->  RTK  -->  git
     ^                                   |            ^                      |          |
     |        ~2,000 tokens (raw)        |            |   ~200 tokens        | filter   |
     +-----------------------------------+            +------- (filtered) ---+----------+
@@ -290,9 +295,11 @@ test utils::test_format ... ok              test_overflow: panic at utils.rs:18
 ...
 ```
 
-## Auto-Rewrite Hook
+## Auto-Rewrite Hook (Claude Code)
 
-The most effective way to use rtk. The hook transparently intercepts Bash commands and rewrites them to rtk equivalents before execution.
+RTK works with any agent by prefixing commands with `rtk`. The hook below is specific to Claude Code — it makes the rewrite automatic.
+
+The most effective way to use rtk with Claude Code. The hook transparently intercepts Bash commands and rewrites them to rtk equivalents before execution.
 
 **Result**: 100% rtk adoption across all conversations and subagents, zero token overhead.
 

--- a/README.md
+++ b/README.md
@@ -252,12 +252,17 @@ rtk gain --graph                # ASCII graph (last 30 days)
 rtk gain --history              # Recent command history
 rtk gain --daily                # Day-by-day breakdown
 rtk gain --all --format json    # JSON export for dashboards
-
-rtk discover                    # Find missed savings opportunities
-rtk discover --all --since 7    # All projects, last 7 days
-
-rtk session                     # Show RTK adoption across recent sessions
 ```
+
+_Claude Code only_ (reads `~/.claude/projects/` session files):
+```bash
+rtk discover                    # Find missed savings opportunities in session history
+rtk discover --all --since 7    # All projects, last 7 days
+rtk learn                       # Learn CLI corrections from error history
+rtk cc-economics                # Token cost analysis by Claude Code session
+```
+
+> **Coming soon**: `rtk discover` for Aider, Cline, Goose, and shell history (any agent). Follow [#273](https://github.com/rtk-ai/rtk/issues/273).
 
 ## Global Flags
 

--- a/README_es.md
+++ b/README_es.md
@@ -33,9 +33,9 @@
 
 ---
 
-rtk filtra y comprime las salidas de comandos antes de que lleguen al contexto de tu LLM. Binario Rust unico, cero dependencias, <10ms de overhead.
+rtk filtra y comprime las salidas de comandos antes de que lleguen al contexto de tu LLM. Compatible con cualquier agente de codigo IA — solo prefija los comandos con `rtk`. Binario unico, cero dependencias, <10ms de overhead.
 
-## Ahorro de tokens (sesion de 30 min en Claude Code)
+## Ahorro de tokens (sesion de desarrollo de 30 min)
 
 | Operacion | Frecuencia | Estandar | rtk | Ahorro |
 |-----------|------------|----------|-----|--------|
@@ -75,20 +75,28 @@ rtk gain        # Debe mostrar estadisticas de ahorro
 
 ## Inicio rapido
 
+**Uso directo con cualquier agente:**
 ```bash
-# 1. Instalar hook para Claude Code (recomendado)
-rtk init --global
-
-# 2. Reiniciar Claude Code, luego probar
-git status  # Automaticamente reescrito a rtk git status
+rtk git status              # Estado compacto
+rtk cargo test              # Solo fallos (-90%)
+rtk grep "pattern" .        # Resultados agrupados
 ```
+
+**O reescritura automatica con Claude Code:**
+```bash
+rtk init --global           # Instalar hook
+# Reiniciar Claude Code — los comandos se reescriben automaticamente
+git status                  # → rtk git status (transparente)
+```
+
+RTK es un binario autonomo. El hook de Claude Code reescribe los comandos automaticamente, pero cualquier agente funciona prefijando `rtk`.
 
 ## Como funciona
 
 ```
   Sin rtk:                                         Con rtk:
 
-  Claude  --git status-->  shell  -->  git          Claude  --git status-->  RTK  -->  git
+  Agent  --git status-->  shell  -->  git           Agent  --git status-->  RTK  -->  git
     ^                                   |             ^                      |          |
     |        ~2,000 tokens (crudo)      |             |   ~200 tokens        | filtro   |
     +-----------------------------------+             +------- (filtrado) ---+----------+

--- a/README_es.md
+++ b/README_es.md
@@ -147,8 +147,17 @@ rtk ruff check                  # Lint Python (-80%)
 ```bash
 rtk gain                        # Estadisticas de ahorro
 rtk gain --graph                # Grafico ASCII (30 dias)
-rtk discover                    # Descubrir ahorros perdidos
 ```
+
+_Solo Claude Code_ (lee archivos de sesion de `~/.claude/projects/`):
+```bash
+rtk discover                    # Oportunidades perdidas en el historial de sesiones
+rtk discover --all --since 7    # Todos los proyectos, ultimos 7 dias
+rtk learn                       # Correcciones CLI aprendidas del historial de errores
+rtk cc-economics                # Analisis de costes de tokens por sesion Claude Code
+```
+
+> **Proximamente**: `rtk discover` para Aider, Cline, Goose e historial shell (cualquier agente). Seguir [#273](https://github.com/rtk-ai/rtk/issues/273).
 
 ## Documentacion
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -33,9 +33,9 @@
 
 ---
 
-rtk filtre et compresse les sorties de commandes avant qu'elles n'atteignent le contexte de votre LLM. Binaire Rust unique, zero dependance, <10ms d'overhead.
+rtk filtre et compresse les sorties de commandes avant qu'elles n'atteignent le contexte de votre LLM. Compatible avec tous les agents de code IA — il suffit de prefixer les commandes avec `rtk`. Binaire unique, zero dependance, <10ms d'overhead.
 
-## Economies de tokens (session Claude Code de 30 min)
+## Economies de tokens (session de developpement de 30 min)
 
 | Operation | Frequence | Standard | rtk | Economies |
 |-----------|-----------|----------|-----|-----------|
@@ -82,23 +82,28 @@ rtk gain        # Doit afficher les statistiques d'economies
 
 ## Demarrage rapide
 
+**Utilisation directe avec n'importe quel agent :**
 ```bash
-# 1. Installer le hook pour Claude Code (recommande)
-rtk init --global
-# Suivre les instructions pour enregistrer dans ~/.claude/settings.json
-
-# 2. Redemarrer Claude Code, puis tester
-git status  # Automatiquement reecrit en rtk git status
+rtk git status              # Statut compact
+rtk cargo test              # Echecs uniquement (-90%)
+rtk grep "pattern" .        # Resultats groupes
 ```
 
-Le hook reecrit de maniere transparente les commandes (ex: `git status` -> `rtk git status`) avant execution.
+**Ou reecriture automatique avec Claude Code :**
+```bash
+rtk init --global           # Installer le hook
+# Redemarrer Claude Code — les commandes sont reecrites automatiquement
+git status                  # → rtk git status (transparent)
+```
+
+RTK est un binaire autonome. Le hook Claude Code reecrit les commandes automatiquement, mais n'importe quel agent fonctionne en prefixant `rtk`.
 
 ## Comment ca marche
 
 ```
   Sans rtk :                                       Avec rtk :
 
-  Claude  --git status-->  shell  -->  git          Claude  --git status-->  RTK  -->  git
+  Agent  --git status-->  shell  -->  git           Agent  --git status-->  RTK  -->  git
     ^                                   |             ^                      |          |
     |        ~2 000 tokens (brut)       |             |   ~200 tokens        | filtre   |
     +-----------------------------------+             +------- (filtre) -----+----------+

--- a/README_fr.md
+++ b/README_fr.md
@@ -167,8 +167,17 @@ rtk kubectl pods                # Pods compacts
 ```bash
 rtk gain                        # Statistiques d'economies
 rtk gain --graph                # Graphique ASCII (30 jours)
-rtk discover                    # Trouver les economies manquees
 ```
+
+_Claude Code uniquement_ (lit les fichiers de session `~/.claude/projects/`) :
+```bash
+rtk discover                    # Opportunites d'economies manquees dans l'historique
+rtk discover --all --since 7    # Tous les projets, 7 derniers jours
+rtk learn                       # Corrections CLI depuis l'historique d'erreurs
+rtk cc-economics                # Analyse des couts tokens par session Claude Code
+```
+
+> **Bientot** : `rtk discover` pour Aider, Cline, Goose et l'historique shell (tous agents). Suivre [#273](https://github.com/rtk-ai/rtk/issues/273).
 
 ## Configuration
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -33,9 +33,9 @@
 
 ---
 
-rtk はコマンド出力を LLM コンテキストに届く前にフィルタリング・圧縮します。単一の Rust バイナリ、依存関係ゼロ、オーバーヘッド 10ms 未満。
+rtk はコマンド出力を LLM コンテキストに届く前にフィルタリング・圧縮します。すべての AI コーディングエージェントに対応し、コマンドの前に `rtk` を付けるだけで使えます。単一バイナリ、依存関係ゼロ、オーバーヘッド 10ms 未満。
 
-## トークン節約（30分の Claude Code セッション）
+## トークン節約（30分のコーディングセッション）
 
 | 操作 | 頻度 | 標準 | rtk | 節約 |
 |------|------|------|-----|------|
@@ -75,20 +75,28 @@ rtk gain        # トークン節約統計が表示されるはず
 
 ## クイックスタート
 
+**任意のエージェントで直接使用：**
 ```bash
-# 1. Claude Code 用フックをインストール（推奨）
-rtk init --global
-
-# 2. Claude Code を再起動してテスト
-git status  # 自動的に rtk git status に書き換え
+rtk git status              # コンパクトなステータス
+rtk cargo test              # 失敗のみ (-90%)
+rtk grep "pattern" .        # グループ化された結果
 ```
+
+**または Claude Code で自動書き換え：**
+```bash
+rtk init --global           # フックをインストール
+# Claude Code を再起動 — コマンドが自動的に書き換えられます
+git status                  # → rtk git status（透過的）
+```
+
+RTK はスタンドアロンバイナリです。Claude Code フックはコマンドを自動書き換えしますが、`rtk` をプレフィックスとして付けることで任意のエージェントで動作します。
 
 ## 仕組み
 
 ```
   rtk なし：                                       rtk あり：
 
-  Claude  --git status-->  shell  -->  git          Claude  --git status-->  RTK  -->  git
+  Agent  --git status-->  shell  -->  git           Agent  --git status-->  RTK  -->  git
     ^                                   |             ^                      |          |
     |        ~2,000 tokens（生出力）     |             |   ~200 tokens        | フィルタ |
     +-----------------------------------+             +------- （圧縮済）----+----------+

--- a/README_ja.md
+++ b/README_ja.md
@@ -147,8 +147,17 @@ rtk ruff check                  # Python リント（-80%）
 ```bash
 rtk gain                        # 節約統計
 rtk gain --graph                # ASCII グラフ（30日間）
-rtk discover                    # 見逃した節約機会を発見
 ```
+
+_Claude Code 専用_（`~/.claude/projects/` セッションファイルを読み取ります）：
+```bash
+rtk discover                    # セッション履歴から見逃した節約機会を発見
+rtk discover --all --since 7    # 全プロジェクト、過去7日間
+rtk learn                       # エラー履歴から CLI 修正を学習
+rtk cc-economics                # Claude Code セッション別トークンコスト分析
+```
+
+> **近日公開**：Aider、Cline、Goose、シェル履歴（全エージェント対応）で `rtk discover` をサポート予定。[#273](https://github.com/rtk-ai/rtk/issues/273) をフォロー。
 
 ## ドキュメント
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -33,9 +33,9 @@
 
 ---
 
-rtk는 명령 출력이 LLM 컨텍스트에 도달하기 전에 필터링하고 압축합니다. 단일 Rust 바이너리, 의존성 없음, 10ms 미만의 오버헤드.
+rtk는 명령 출력이 LLM 컨텍스트에 도달하기 전에 필터링하고 압축합니다. 모든 AI 코딩 에이전트와 호환되며, 명령 앞에 `rtk`를 붙이기만 하면 됩니다. 단일 바이너리, 의존성 없음, 10ms 미만의 오버헤드.
 
-## 토큰 절약 (30분 Claude Code 세션)
+## 토큰 절약 (30분 코딩 세션)
 
 | 작업 | 빈도 | 표준 | rtk | 절약 |
 |------|------|------|-----|------|
@@ -75,20 +75,28 @@ rtk gain        # 토큰 절약 통계 표시되어야 함
 
 ## 빠른 시작
 
+**모든 에이전트에서 직접 사용:**
 ```bash
-# 1. Claude Code용 hook 설치 (권장)
-rtk init --global
-
-# 2. Claude Code 재시작 후 테스트
-git status  # 자동으로 rtk git status로 재작성
+rtk git status              # 컴팩트 상태
+rtk cargo test              # 실패만 표시 (-90%)
+rtk grep "pattern" .        # 그룹화된 결과
 ```
+
+**또는 Claude Code로 자동 재작성:**
+```bash
+rtk init --global           # hook 설치
+# Claude Code 재시작 — 명령이 자동으로 재작성됩니다
+git status                  # → rtk git status (투명)
+```
+
+RTK는 독립 실행형 바이너리입니다. Claude Code hook이 명령을 자동으로 재작성하지만, `rtk`를 접두사로 붙이면 어떤 에이전트에서도 작동합니다.
 
 ## 작동 원리
 
 ```
   rtk 없이:                                        rtk 사용:
 
-  Claude  --git status-->  shell  -->  git          Claude  --git status-->  RTK  -->  git
+  Agent  --git status-->  shell  -->  git           Agent  --git status-->  RTK  -->  git
     ^                                   |             ^                      |          |
     |        ~2,000 tokens (원본)        |             |   ~200 tokens        | 필터     |
     +-----------------------------------+             +------- (필터링) -----+----------+

--- a/README_ko.md
+++ b/README_ko.md
@@ -147,8 +147,17 @@ rtk ruff check                  # Python 린트 (-80%)
 ```bash
 rtk gain                        # 절약 통계
 rtk gain --graph                # ASCII 그래프 (30일)
-rtk discover                    # 놓친 절약 기회 발견
 ```
+
+_Claude Code 전용_ (`~/.claude/projects/` 세션 파일 읽기):
+```bash
+rtk discover                    # 세션 기록에서 놓친 절약 기회 발견
+rtk discover --all --since 7    # 모든 프로젝트, 최근 7일
+rtk learn                       # 오류 기록에서 CLI 수정 학습
+rtk cc-economics                # Claude Code 세션별 토큰 비용 분석
+```
+
+> **출시 예정**: Aider, Cline, Goose 및 셸 히스토리(모든 에이전트)에서 `rtk discover` 지원. [#273](https://github.com/rtk-ai/rtk/issues/273) 팔로우.
 
 ## 문서
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -33,9 +33,9 @@
 
 ---
 
-rtk 在命令输出到达 LLM 上下文之前进行过滤和压缩。单一 Rust 二进制文件，零依赖，<10ms 开销。
+rtk 在命令输出到达 LLM 上下文之前进行过滤和压缩。兼容所有 AI 编程代理，只需在命令前加 `rtk`。单一二进制文件，零依赖，<10ms 开销。
 
-## Token 节省（30 分钟 Claude Code 会话）
+## Token 节省（30 分钟编程会话）
 
 | 操作 | 频率 | 标准 | rtk | 节省 |
 |------|------|------|-----|------|
@@ -76,20 +76,28 @@ rtk gain        # 应显示 token 节省统计
 
 ## 快速开始
 
+**直接用于任何代理：**
 ```bash
-# 1. 为 Claude Code 安装 hook（推荐）
-rtk init --global
-
-# 2. 重启 Claude Code，然后测试
-git status  # 自动重写为 rtk git status
+rtk git status              # 紧凑状态
+rtk cargo test              # 仅显示失败 (-90%)
+rtk grep "pattern" .        # 分组结果
 ```
+
+**或使用 Claude Code 自动重写：**
+```bash
+rtk init --global           # 安装 hook
+# 重启 Claude Code — 命令自动重写
+git status                  # → rtk git status（透明）
+```
+
+RTK 是独立的二进制文件。Claude Code hook 可自动重写命令，但任何代理都可以通过添加 `rtk` 前缀来使用。
 
 ## 工作原理
 
 ```
   没有 rtk：                                      使用 rtk：
 
-  Claude  --git status-->  shell  -->  git         Claude  --git status-->  RTK  -->  git
+  Agent  --git status-->  shell  -->  git          Agent  --git status-->  RTK  -->  git
     ^                                   |            ^                      |          |
     |        ~2,000 tokens（原始）       |            |   ~200 tokens        | 过滤     |
     +-----------------------------------+            +------- （已过滤）-----+----------+

--- a/README_zh.md
+++ b/README_zh.md
@@ -155,8 +155,17 @@ rtk kubectl pods                # 紧凑 Pod 列表
 ```bash
 rtk gain                        # 节省统计
 rtk gain --graph                # ASCII 图表（30 天）
-rtk discover                    # 发现遗漏的节省机会
 ```
+
+_仅限 Claude Code_（读取 `~/.claude/projects/` 会话文件）：
+```bash
+rtk discover                    # 发现历史记录中遗漏的节省机会
+rtk discover --all --since 7    # 所有项目，最近 7 天
+rtk learn                       # 从错误历史中学习 CLI 纠正
+rtk cc-economics                # 按 Claude Code 会话分析 token 成本
+```
+
+> **即将推出**：`rtk discover` 支持 Aider、Cline、Goose 及 shell 历史（适用于所有代理）。关注 [#273](https://github.com/rtk-ai/rtk/issues/273)。
 
 ## 文档
 


### PR DESCRIPTION
## Summary

- Intro paragraph: clarifies RTK works with any AI coding agent, not Claude-only
- Token Savings header: "Claude Code Session" → "Coding Session"
- Quick Start: two-path structure — any agent first, Claude Code hook second
- How It Works diagram: "Claude" → "Agent" in ASCII art
- Auto-Rewrite Hook: adds "(Claude Code)" qualifier + agent-agnostic framing
- Applied consistently to all 6 language files (EN, FR, ZH, JA, KO, ES)

Side-fixed: version refs 0.27.1 → 0.27.2, module count 57 → 58 (pre-existing drift caught by pre-push hook).

## Motivation

RTK is agent-agnostic by design but the README implied Claude Code exclusivity. A non-Claude-Code user should understand RTK works for them within 10 seconds. Claude Code remains the highlighted integration (hook advantage preserved), but without false exclusivity claims.

## Test plan

- [ ] Read flow: tagline → intro (agent-agnostic) → token savings → quick start (2 paths) → how it works → commands
- [ ] Grep for "Claude Code" references that imply RTK is Claude-only (none should remain in intro/hero)
- [ ] Verify all 6 language files updated consistently
- [ ] Validate-docs passes (confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)