### PR TITLE
feat(kubectl): support global context and identity flags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ mod wget_cmd;
 
 use anyhow::{Context, Result};
 use clap::error::ErrorKind;
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
@@ -782,20 +782,72 @@ enum ComposeCommands {
     Other(Vec<OsString>),
 }
 
+#[derive(Args, Clone, Debug)]
+struct KubectlGlobalArgs {
+    /// The name of the kubeconfig context to use
+    #[arg(long)]
+    context: Option<String>,
+    /// Path to the kubeconfig file
+    #[arg(long)]
+    kubeconfig: Option<String>,
+    /// Namespace scope for this request
+    #[arg(short, long)]
+    namespace: Option<String>,
+    /// Label selector (e.g. -l app=web)
+    #[arg(short = 'l', long)]
+    selector: Option<String>,
+    /// Username to impersonate
+    #[arg(long = "as")]
+    impersonate: Option<String>,
+}
+
+impl KubectlGlobalArgs {
+    fn to_args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+
+        if let Some(context) = &self.context {
+            args.push("--context".to_string());
+            args.push(context.clone());
+        }
+
+        if let Some(kubeconfig) = &self.kubeconfig {
+            args.push("--kubeconfig".to_string());
+            args.push(kubeconfig.clone());
+        }
+
+        if let Some(namespace) = &self.namespace {
+            args.push("-n".to_string());
+            args.push(namespace.clone());
+        }
+
+        if let Some(selector) = &self.selector {
+            args.push("-l".to_string());
+            args.push(selector.clone());
+        }
+
+        if let Some(impersonate) = &self.impersonate {
+            args.push("--as".to_string());
+            args.push(impersonate.clone());
+        }
+
+        args
+    }
+}
+
 #[derive(Subcommand)]
 enum KubectlCommands {
     /// List pods
     Pods {
-        #[arg(short, long)]
-        namespace: Option<String>,
+        #[command(flatten)]
+        global: KubectlGlobalArgs,
         /// All namespaces
         #[arg(short = 'A', long)]
         all: bool,
     },
     /// List services
     Services {
-        #[arg(short, long)]
-        namespace: Option<String>,
+        #[command(flatten)]
+        global: KubectlGlobalArgs,
         /// All namespaces
         #[arg(short = 'A', long)]
         all: bool,
@@ -803,6 +855,8 @@ enum KubectlCommands {
     /// Show pod logs (deduplicated)
     Logs {
         pod: String,
+        #[command(flatten)]
+        global: KubectlGlobalArgs,
         #[arg(short, long)]
         container: Option<String>,
     },
@@ -1345,28 +1399,27 @@ fn main() -> Result<()> {
         },
 
         Commands::Kubectl { command } => match command {
-            KubectlCommands::Pods { namespace, all } => {
-                let mut args: Vec<String> = Vec::new();
+            KubectlCommands::Pods { global, all } => {
+                let mut args = global.to_args();
                 if all {
                     args.push("-A".to_string());
-                } else if let Some(n) = namespace {
-                    args.push("-n".to_string());
-                    args.push(n);
                 }
                 container::run(container::ContainerCmd::KubectlPods, &args, cli.verbose)?;
             }
-            KubectlCommands::Services { namespace, all } => {
-                let mut args: Vec<String> = Vec::new();
+            KubectlCommands::Services { global, all } => {
+                let mut args = global.to_args();
                 if all {
                     args.push("-A".to_string());
-                } else if let Some(n) = namespace {
-                    args.push("-n".to_string());
-                    args.push(n);
                 }
                 container::run(container::ContainerCmd::KubectlServices, &args, cli.verbose)?;
             }
-            KubectlCommands::Logs { pod, container: c } => {
+            KubectlCommands::Logs {
+                pod,
+                global,
+                container: c,
+            } => {
                 let mut args = vec![pod];
+                args.extend(global.to_args());
                 if let Some(cont) = c {
                     args.push("-c".to_string());
                     args.push(cont);
@@ -2176,5 +2229,85 @@ mod tests {
                 args
             );
         }
+    }
+
+    #[test]
+    fn test_kubectl_pods_global_flags_parse() {
+        let cli = Cli::try_parse_from([
+            "rtk",
+            "kubectl",
+            "pods",
+            "--context",
+            "dev-cluster",
+            "--kubeconfig",
+            "/tmp/kubeconfig",
+            "-n",
+            "default",
+            "-l",
+            "app=web",
+            "--as",
+            "admin",
+            "-A",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Kubectl {
+                command: KubectlCommands::Pods { global, all },
+            } => {
+                assert_eq!(global.context.as_deref(), Some("dev-cluster"));
+                assert_eq!(global.kubeconfig.as_deref(), Some("/tmp/kubeconfig"));
+                assert_eq!(global.namespace.as_deref(), Some("default"));
+                assert_eq!(global.selector.as_deref(), Some("app=web"));
+                assert_eq!(global.impersonate.as_deref(), Some("admin"));
+                assert!(all);
+            }
+            _ => panic!("Expected Kubectl Pods command"),
+        }
+    }
+
+    #[test]
+    fn test_kubectl_services_selector_parse() {
+        let cli =
+            Cli::try_parse_from(["rtk", "kubectl", "services", "-l", "tier=frontend"]).unwrap();
+
+        match cli.command {
+            Commands::Kubectl {
+                command: KubectlCommands::Services { global, all },
+            } => {
+                assert_eq!(global.selector.as_deref(), Some("tier=frontend"));
+                assert!(!all);
+            }
+            _ => panic!("Expected Kubectl Services command"),
+        }
+    }
+
+    #[test]
+    fn test_kubectl_global_args_to_args() {
+        let global = KubectlGlobalArgs {
+            context: Some("ctx-1".to_string()),
+            kubeconfig: Some("/tmp/kubeconfig".to_string()),
+            namespace: Some("default".to_string()),
+            selector: Some("app=api".to_string()),
+            impersonate: Some("admin".to_string()),
+        };
+
+        let args = global.to_args();
+
+        assert_eq!(
+            args,
+            vec![
+                "--context",
+                "ctx-1",
+                "--kubeconfig",
+                "/tmp/kubeconfig",
+                "-n",
+                "default",
+                "-l",
+                "app=api",
+                "--as",
+                "admin",
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add a shared `KubectlGlobalArgs` parser to `kubectl pods`, `kubectl services`, and `kubectl logs`
- forward `--context`, `--kubeconfig`, `-n`, `-l`, and `--as` to underlying kubectl invocations
- add CLI parsing/unit coverage for the new kubectl flag handling

## Why
Using `rtk kubectl` currently drops common kubectl global flags, which breaks context-specific workflows (e.g. `--context`). This keeps filtered commands aligned with normal kubectl ergonomics.

## Validation
- `cargo test test_kubectl -- --nocapture`
- `cargo build --release`
- manual checks:
  - `rtk kubectl pods --context savage-ovh`
  - `rtk kubectl services --context savage-ovh`