### PR TITLE
feat(init): add `--project` and `--local` scope flags

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1050,11 +1050,12 @@ Modules with Exit Code Preservation:
 2. LLM Integration (CLAUDE.md)
    ────────────────────────────
    Locations:
-   • Global: ~/.config/rtk/CLAUDE.md
-   • Local:  ./CLAUDE.md (project-specific)
+   • Global:  ~/.claude/                      (user-wide)
+   • Project: ./.claude/settings.json         (team-shared, committable)
+   • Local:   ./.claude/settings.local.json   (personal, gitignored)
 
    Purpose: Instruct LLM (Claude Code) to use rtk prefix
-   Created by: rtk init [--global]
+   Created by: rtk init [--global | --project | --local]
 
    Template (init.rs:40-60):
    # CLAUDE.md
@@ -1073,11 +1074,13 @@ Modules with Exit Code Preservation:
 │                      rtk init Workflow                                 │
 └────────────────────────────────────────────────────────────────────────┘
 
-$ rtk init [--global]
+$ rtk init [--global | --project | --local]
       ↓
-Check existing CLAUDE.md:
-  • --global? → ~/.config/rtk/CLAUDE.md
-  • else      → ./CLAUDE.md
+Check target location:
+  • --global?  → ~/.claude/
+  • --project? → ./.claude/settings.json       (team-shared, committable)
+  • --local?   → ./.claude/settings.local.json  (personal, gitignored)
+  • (default)  → ./CLAUDE.md
       ↓
       ├─ Exists? → Warn user, ask to overwrite
       └─ Not exists? → Continue

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -77,12 +77,23 @@ rtk gain  # MUST show token savings, not "command not found"
   ├─ YES → rtk init -g              (recommended)
   │         Hook + RTK.md (~10 tokens in context)
   │         Commands auto-rewritten transparently
+  │         Scope: ~/.claude/ (user-wide)
   │
   ├─ YES, minimal → rtk init -g --hook-only
   │         Hook only, nothing added to CLAUDE.md
   │         Zero tokens in context
   │
-  └─ NO, single project → rtk init
+  ├─ NO, team project → rtk init --project
+  │         Hook + RTK.md in ./.claude/
+  │         Patches ./.claude/settings.json (committed to repo)
+  │         Shared with all team members
+  │
+  ├─ NO, personal per-project → rtk init --local
+  │         Hook + RTK.md in ./.claude/
+  │         Patches ./.claude/settings.local.json (gitignored)
+  │         Only affects you, not committed to repo
+  │
+  └─ NO, legacy → rtk init
             Local CLAUDE.md only (137 lines)
             No hook, no global effect
 ```
@@ -137,9 +148,45 @@ RTK backs up existing settings.json before changes. Restore if needed:
 cp ~/.claude/settings.json.bak ~/.claude/settings.json
 ```
 
-### Alternative: Local Project Setup
+### Alternative: Project-Scope Setup (Team-Shared)
 
-**Best for: Single project without hook**
+**Best for: Teams that want RTK active for a specific repo**
+
+```bash
+cd /path/to/your/project
+rtk init --project
+# → Installs hook to ./.claude/hooks/rtk-rewrite.sh
+# → Creates ./.claude/RTK.md
+# → Patches ./.claude/settings.json (committed to repo, shared with team)
+
+rtk init --project --auto-patch    # Patch without prompting
+rtk init --project --no-patch      # Print manual instructions instead
+rtk init --project --hook-only     # Hook only, no RTK.md
+```
+
+**Token savings**: Same as global (~99.5%), scoped to this project only
+
+### Alternative: Local-Scope Setup (Personal, Gitignored)
+
+**Best for: Personal RTK usage in a project without affecting teammates**
+
+```bash
+cd /path/to/your/project
+rtk init --local
+# → Installs hook to ./.claude/hooks/rtk-rewrite.sh
+# → Creates ./.claude/RTK.md
+# → Patches ./.claude/settings.local.json (gitignored, personal only)
+
+rtk init --local --auto-patch      # Patch without prompting
+rtk init --local --no-patch        # Print manual instructions instead
+rtk init --local --hook-only       # Hook only, no RTK.md
+```
+
+**Token savings**: Same as global (~99.5%), personal to you only
+
+### Alternative: Legacy Local Setup
+
+**Best for: Single project without hook (pre-0.22 style)**
 
 ```bash
 cd /path/to/your/project
@@ -147,6 +194,15 @@ rtk init  # Creates ./CLAUDE.md with full RTK instructions (137 lines)
 ```
 
 **Token savings**: Instructions loaded only for this project
+
+### Scope Comparison
+
+| Scope | Flag | Settings file | Shared? | Location |
+|-------|------|---------------|---------|----------|
+| Global | `-g` / `--global` | `~/.claude/settings.json` | User-wide (all projects) | `~/.claude/` |
+| Project | `--project` | `./.claude/settings.json` | Team (committed to repo) | `./.claude/` |
+| Local | `--local` | `./.claude/settings.local.json` | Personal (gitignored) | `./.claude/` |
+| Legacy | _(none)_ | N/A | Project only | `./CLAUDE.md` |
 
 ### Upgrading from Previous Version
 
@@ -240,22 +296,47 @@ rtk vitest run
 
 ## Uninstalling
 
-### Complete Removal (Global Installations Only)
+### Global Uninstall
 
 ```bash
-# Complete removal (global installations only)
 rtk init -g --uninstall
 
 # What gets removed:
 #   - Hook: ~/.claude/hooks/rtk-rewrite.sh
 #   - Context: ~/.claude/RTK.md
 #   - Reference: @RTK.md line from ~/.claude/CLAUDE.md
-#   - Registration: RTK hook entry from settings.json
+#   - Registration: RTK hook entry from ~/.claude/settings.json
 
 # Restart Claude Code after uninstall
 ```
 
-**For Local Projects**: Manually remove RTK block from `./CLAUDE.md`
+### Project-Scope Uninstall
+
+```bash
+cd /path/to/your/project
+rtk init --project --uninstall
+
+# What gets removed:
+#   - Hook: ./.claude/hooks/rtk-rewrite.sh
+#   - Context: ./.claude/RTK.md
+#   - Registration: RTK hook entry from ./.claude/settings.json
+```
+
+### Local-Scope Uninstall
+
+```bash
+cd /path/to/your/project
+rtk init --local --uninstall
+
+# What gets removed:
+#   - Hook: ./.claude/hooks/rtk-rewrite.sh
+#   - Context: ./.claude/RTK.md
+#   - Registration: RTK hook entry from ./.claude/settings.local.json
+```
+
+### Legacy Local Projects
+
+Manually remove the RTK block from `./CLAUDE.md`.
 
 ### Binary Removal
 

--- a/README.md
+++ b/README.md
@@ -100,17 +100,17 @@ rtk gain        # Should show token savings stats
 
 ```bash
 # 1. Install hook for Claude Code (recommended)
-rtk init --global
-# Follow instructions to register in ~/.claude/settings.json
-# Claude Code only by default (use --opencode for OpenCode)
+rtk init --global              # User-wide (~/.claude/settings.json)
+rtk init --project             # Team-shared (.claude/settings.json, committable)
+rtk init --local               # Personal (.claude/settings.local.json, gitignored)
 
 # 2. Restart Claude Code, then test
 git status  # Automatically rewritten to rtk git status
 ```
 
-The hook transparently rewrites Bash commands (e.g., `git status` -> `rtk git status`) before execution. Claude never sees the rewrite, it just gets compressed output.
+Three scopes: **global** applies to all projects for the current user, **project** is shared with your team via version control, and **local** is personal to your machine and gitignored.
 
-**Important:** the hook only runs on Bash tool calls. Claude Code built-in tools like `Read`, `Grep`, and `Glob` do not pass through the Bash hook, so they are not auto-rewritten. To get RTK's compact output for those workflows, use shell commands (`cat`/`head`/`tail`, `rg`/`grep`, `find`) or call `rtk read`, `rtk grep`, or `rtk find` directly.
+The hook transparently rewrites commands (e.g., `git status` -> `rtk git status`) before execution. Claude never sees the rewrite, it just gets compressed output.
 
 ## How It Works
 
@@ -278,8 +278,9 @@ The most effective way to use rtk. The hook transparently intercepts Bash comman
 ### Setup
 
 ```bash
-rtk init -g                 # Install hook + RTK.md (recommended)
-rtk init -g --opencode      # OpenCode plugin (instead of Claude Code)
+rtk init -g                 # Global: hook + RTK.md in ~/.claude/ (recommended)
+rtk init --project          # Project: hook + RTK.md in ./.claude/ (team-shared)
+rtk init --local            # Local: hook + RTK.md in ./.claude/ (personal, gitignored)
 rtk init -g --auto-patch    # Non-interactive (CI/CD)
 rtk init -g --hook-only     # Hook only, no RTK.md
 rtk init --show             # Verify installation
@@ -368,9 +369,11 @@ FAILED: 2/15 tests
 ### Uninstall
 
 ```bash
-rtk init -g --uninstall     # Remove hook, RTK.md, settings.json entry
-cargo uninstall rtk          # Remove binary
-brew uninstall rtk           # If installed via Homebrew
+rtk init -g --uninstall          # Remove global hook, RTK.md, settings.json entry
+rtk init --project --uninstall   # Remove project-scope RTK artifacts
+rtk init --local --uninstall     # Remove local-scope RTK artifacts
+cargo uninstall rtk              # Remove binary
+brew uninstall rtk               # If installed via Homebrew
 ```
 
 ## Documentation

--- a/README_es.md
+++ b/README_es.md
@@ -77,7 +77,9 @@ rtk gain        # Debe mostrar estadisticas de ahorro
 
 ```bash
 # 1. Instalar hook para Claude Code (recomendado)
-rtk init --global
+rtk init --global            # ~/.claude/ (a nivel de usuario)
+rtk init --project           # ./.claude/settings.json (compartido en equipo, committeable)
+rtk init --local             # ./.claude/settings.local.json (personal, gitignored)
 
 # 2. Reiniciar Claude Code, luego probar
 git status  # Automaticamente reescrito a rtk git status

--- a/README_fr.md
+++ b/README_fr.md
@@ -84,8 +84,9 @@ rtk gain        # Doit afficher les statistiques d'economies
 
 ```bash
 # 1. Installer le hook pour Claude Code (recommande)
-rtk init --global
-# Suivre les instructions pour enregistrer dans ~/.claude/settings.json
+rtk init --global            # ~/.claude/ (utilisateur entier)
+rtk init --project           # ./.claude/settings.json (partage en equipe, committable)
+rtk init --local             # ./.claude/settings.local.json (personnel, gitignore)
 
 # 2. Redemarrer Claude Code, puis tester
 git status  # Automatiquement reecrit en rtk git status

--- a/README_ja.md
+++ b/README_ja.md
@@ -77,7 +77,9 @@ rtk gain        # トークン節約統計が表示されるはず
 
 ```bash
 # 1. Claude Code 用フックをインストール（推奨）
-rtk init --global
+rtk init --global            # ~/.claude/（ユーザー全体）
+rtk init --project           # ./.claude/settings.json（チーム共有、コミット可能）
+rtk init --local             # ./.claude/settings.local.json（個人用、gitignore対象）
 
 # 2. Claude Code を再起動してテスト
 git status  # 自動的に rtk git status に書き換え

--- a/README_ko.md
+++ b/README_ko.md
@@ -77,7 +77,9 @@ rtk gain        # 토큰 절약 통계 표시되어야 함
 
 ```bash
 # 1. Claude Code용 hook 설치 (권장)
-rtk init --global
+rtk init --global            # ~/.claude/ (사용자 전체)
+rtk init --project           # ./.claude/settings.json (팀 공유, 커밋 가능)
+rtk init --local             # ./.claude/settings.local.json (개인용, gitignore 대상)
 
 # 2. Claude Code 재시작 후 테스트
 git status  # 자동으로 rtk git status로 재작성

--- a/README_zh.md
+++ b/README_zh.md
@@ -78,7 +78,9 @@ rtk gain        # 应显示 token 节省统计
 
 ```bash
 # 1. 为 Claude Code 安装 hook（推荐）
-rtk init --global
+rtk init --global            # ~/.claude/（用户级别）
+rtk init --project           # ./.claude/settings.json（团队共享，可提交）
+rtk init --local             # ./.claude/settings.local.json（个人使用，gitignore）
 
 # 2. 重启 Claude Code，然后测试
 git status  # 自动重写为 rtk git status

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1213,20 +1213,48 @@ Sortie filtree retournee a Claude (~10 tokens vs ~200)
 ### Installation
 
 ```bash
-rtk init -g                     # Installation recommandee (hook + RTK.md)
+# Portees d'installation
+rtk init --global               # ~/.claude/ (user-wide, recommande)
+rtk init --project              # ./.claude/settings.json (team-shared, committable)
+rtk init --local                # ./.claude/settings.local.json (personal, gitignored)
+
+# Raccourcis
+rtk init -g                     # Equivalent de --global
 rtk init -g --auto-patch        # Non-interactif (CI/CD)
 rtk init -g --hook-only         # Hook seul, sans RTK.md
-rtk init --show                 # Verifier l'installation
-rtk init -g --uninstall         # Desinstaller
+
+# Verification et desinstallation
+rtk init --show                 # Verifier l'installation (toutes les portees)
+rtk init -g --uninstall         # Desinstaller (global)
+rtk init --project --uninstall  # Desinstaller (project)
+rtk init --local --uninstall    # Desinstaller (local)
 ```
 
 ### Fichiers installes
+
+**`--global` (user-wide) :**
 
 | Fichier | Description |
 |---------|-------------|
 | `~/.claude/hooks/rtk-rewrite.sh` | Script hook (delegue a `rtk rewrite`) |
 | `~/.claude/RTK.md` | Instructions minimales pour le LLM |
 | `~/.claude/settings.json` | Enregistrement du hook PreToolUse |
+
+**`--project` (team-shared, committable) :**
+
+| Fichier | Description |
+|---------|-------------|
+| `./.claude/hooks/rtk-rewrite.sh` | Script hook (delegue a `rtk rewrite`) |
+| `./.claude/RTK.md` | Instructions minimales pour le LLM |
+| `./.claude/settings.json` | Enregistrement du hook PreToolUse |
+
+**`--local` (personal, gitignored) :**
+
+| Fichier | Description |
+|---------|-------------|
+| `./.claude/hooks/rtk-rewrite.sh` | Script hook (delegue a `rtk rewrite`) |
+| `./.claude/RTK.md` | Instructions minimales pour le LLM |
+| `./.claude/settings.local.json` | Enregistrement du hook PreToolUse (gitignored) |
 
 ### `rtk rewrite` -- Recriture de commande
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -63,6 +63,14 @@ pub enum PatchResult {
     Skipped,        // --no-patch flag used
 }
 
+/// Installation scope
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Scope {
+    Global,  // ~/.claude/
+    Project, // ./.claude/settings.json (committable)
+    Local,   // ./.claude/settings.local.json (gitignored)
+}
+
 // Legacy full instructions for backward compatibility (--claude-md mode)
 const RTK_INSTRUCTIONS: &str = r##"<!-- rtk-instructions v2 -->
 # RTK (Rust Token Killer) - Token-Optimized Commands
@@ -179,7 +187,9 @@ rtk gain --history      # View command history with savings
 rtk discover            # Analyze Claude Code sessions for missed RTK usage
 rtk proxy <cmd>         # Run command without filtering (for debugging)
 rtk init                # Add RTK instructions to CLAUDE.md
-rtk init --global       # Add RTK to ~/.claude/CLAUDE.md
+rtk init --global       # Add RTK to ~/.claude/ (user scope)
+rtk init --project      # Add RTK to ./.claude/ (team-shared, settings.json)
+rtk init --local        # Add RTK to ./.claude/ (personal, settings.local.json)
 ```
 
 ## Token Savings Overview
@@ -201,38 +211,33 @@ Overall average: **60-90% token reduction** on common development operations.
 
 /// Main entry point for `rtk init`
 pub fn run(
-    global: bool,
-    install_claude: bool,
-    install_opencode: bool,
+    scope: Scope,
     claude_md: bool,
     hook_only: bool,
     patch_mode: PatchMode,
     verbose: u8,
 ) -> Result<()> {
-    if install_opencode && !global {
-        anyhow::bail!("OpenCode plugin is global-only. Use: rtk init -g --opencode");
-    }
-
     // Mode selection
-    match (install_claude, install_opencode, claude_md, hook_only) {
-        (false, true, _, _) => run_opencode_only_mode(verbose),
-        (true, opencode, true, _) => run_claude_md_mode(global, verbose, opencode),
-        (true, opencode, false, true) => run_hook_only_mode(global, patch_mode, verbose, opencode),
-        (true, opencode, false, false) => run_default_mode(global, patch_mode, verbose, opencode),
-        (false, false, _, _) => {
-            anyhow::bail!("at least one of install_claude or install_opencode must be true")
-        }
+    match (claude_md, hook_only) {
+        (true, _) => run_claude_md_mode(scope, verbose),
+        (false, true) => run_hook_only_mode(scope, patch_mode, verbose),
+        (false, false) => run_default_mode(scope, patch_mode, verbose),
     }
 }
 
-/// Prepare hook directory and return paths (hook_dir, hook_path)
-fn prepare_hook_paths() -> Result<(PathBuf, PathBuf)> {
-    let claude_dir = resolve_claude_dir()?;
+/// Prepare hook directory and return paths (hook_dir, hook_path) for a given scope
+fn prepare_hook_paths_scoped(scope: Scope) -> Result<(PathBuf, PathBuf)> {
+    let claude_dir = resolve_dir_for_scope(scope)?;
     let hook_dir = claude_dir.join("hooks");
     fs::create_dir_all(&hook_dir)
         .with_context(|| format!("Failed to create hook directory: {}", hook_dir.display()))?;
     let hook_path = hook_dir.join("rtk-rewrite.sh");
     Ok((hook_dir, hook_path))
+}
+
+/// Prepare hook directory and return paths (hook_dir, hook_path) for global scope
+fn prepare_hook_paths() -> Result<(PathBuf, PathBuf)> {
+    prepare_hook_paths_scoped(Scope::Global)
 }
 
 /// Write hook file if missing or outdated, return true if changed
@@ -414,20 +419,17 @@ fn remove_hook_from_json(root: &mut serde_json::Value) -> bool {
     pre_tool_use_array.len() < original_len
 }
 
-/// Remove RTK hook from settings.json file
+/// Remove RTK hook from a settings file at the given path
 /// Backs up before modification, returns true if hook was found and removed
-fn remove_hook_from_settings(verbose: u8) -> Result<bool> {
-    let claude_dir = resolve_claude_dir()?;
-    let settings_path = claude_dir.join("settings.json");
-
+fn remove_hook_from_settings_at(settings_path: &Path, verbose: u8) -> Result<bool> {
     if !settings_path.exists() {
         if verbose > 0 {
-            eprintln!("settings.json not found, nothing to remove");
+            eprintln!("{} not found, nothing to remove", settings_path.display());
         }
         return Ok(false);
     }
 
-    let content = fs::read_to_string(&settings_path)
+    let content = fs::read_to_string(settings_path)
         .with_context(|| format!("Failed to read {}", settings_path.display()))?;
 
     if content.trim().is_empty() {
@@ -442,29 +444,32 @@ fn remove_hook_from_settings(verbose: u8) -> Result<bool> {
     if removed {
         // Backup original
         let backup_path = settings_path.with_extension("json.bak");
-        fs::copy(&settings_path, &backup_path)
+        fs::copy(settings_path, &backup_path)
             .with_context(|| format!("Failed to backup to {}", backup_path.display()))?;
 
         // Atomic write
         let serialized =
-            serde_json::to_string_pretty(&root).context("Failed to serialize settings.json")?;
-        atomic_write(&settings_path, &serialized)?;
+            serde_json::to_string_pretty(&root).context("Failed to serialize settings")?;
+        atomic_write(settings_path, &serialized)?;
 
         if verbose > 0 {
-            eprintln!("Removed RTK hook from settings.json");
+            eprintln!("Removed RTK hook from {}", settings_path.display());
         }
     }
 
     Ok(removed)
 }
 
-/// Full uninstall: remove hook, RTK.md, @RTK.md reference, settings.json entry
-pub fn uninstall(global: bool, verbose: u8) -> Result<()> {
-    if !global {
-        anyhow::bail!("Uninstall only works with --global flag. For local projects, manually remove RTK from CLAUDE.md");
-    }
-
+/// Remove RTK hook from global settings.json (backward-compatible wrapper)
+fn remove_hook_from_settings(verbose: u8) -> Result<bool> {
     let claude_dir = resolve_claude_dir()?;
+    let settings_path = claude_dir.join("settings.json");
+    remove_hook_from_settings_at(&settings_path, verbose)
+}
+
+/// Full uninstall: remove hook, RTK.md, @RTK.md reference, settings entry
+pub fn uninstall(scope: Scope, verbose: u8) -> Result<()> {
+    let claude_dir = resolve_dir_for_scope(scope)?;
     let mut removed = Vec::new();
 
     // 1. Remove hook file
@@ -489,7 +494,11 @@ pub fn uninstall(global: bool, verbose: u8) -> Result<()> {
     }
 
     // 3. Remove @RTK.md reference from CLAUDE.md
-    let claude_md_path = claude_dir.join("CLAUDE.md");
+    let claude_md_path = if scope == Scope::Global {
+        claude_dir.join("CLAUDE.md")
+    } else {
+        PathBuf::from("CLAUDE.md")
+    };
     if claude_md_path.exists() {
         let content = fs::read_to_string(&claude_md_path)
             .with_context(|| format!("Failed to read CLAUDE.md: {}", claude_md_path.display()))?;
@@ -511,9 +520,13 @@ pub fn uninstall(global: bool, verbose: u8) -> Result<()> {
         }
     }
 
-    // 4. Remove hook entry from settings.json
-    if remove_hook_from_settings(verbose)? {
-        removed.push("settings.json: removed RTK hook entry".to_string());
+    // 4. Remove hook entry from settings file
+    let settings_path = claude_dir.join(settings_filename(scope));
+    if remove_hook_from_settings_at(&settings_path, verbose)? {
+        removed.push(format!(
+            "{}: removed RTK hook entry",
+            settings_filename(scope)
+        ));
     }
 
     // 5. Remove OpenCode plugin
@@ -523,10 +536,18 @@ pub fn uninstall(global: bool, verbose: u8) -> Result<()> {
     }
 
     // Report results
+    let scope_label = match scope {
+        Scope::Global => "global",
+        Scope::Project => "project",
+        Scope::Local => "local",
+    };
     if removed.is_empty() {
-        println!("RTK was not installed (nothing to remove)");
+        println!(
+            "RTK was not installed ({} scope, nothing to remove)",
+            scope_label
+        );
     } else {
-        println!("RTK uninstalled:");
+        println!("RTK uninstalled ({}):", scope_label);
         for item in removed {
             println!("  - {}", item);
         }
@@ -536,21 +557,22 @@ pub fn uninstall(global: bool, verbose: u8) -> Result<()> {
     Ok(())
 }
 
-/// Orchestrator: patch settings.json with RTK hook
+/// Orchestrator: patch settings file with RTK hook (scope-aware)
 /// Handles reading, checking, prompting, merging, backing up, and atomic writing
-fn patch_settings_json(
+fn patch_settings_json_scoped(
     hook_path: &Path,
+    scope: Scope,
     mode: PatchMode,
     verbose: u8,
-    include_opencode: bool,
 ) -> Result<PatchResult> {
-    let claude_dir = resolve_claude_dir()?;
-    let settings_path = claude_dir.join("settings.json");
+    let claude_dir = resolve_dir_for_scope(scope)?;
+    let filename = settings_filename(scope);
+    let settings_path = claude_dir.join(filename);
     let hook_command = hook_path
         .to_str()
         .context("Hook path contains invalid UTF-8")?;
 
-    // Read or create settings.json
+    // Read or create settings file
     let mut root = if settings_path.exists() {
         let content = fs::read_to_string(&settings_path)
             .with_context(|| format!("Failed to read {}", settings_path.display()))?;
@@ -566,9 +588,9 @@ fn patch_settings_json(
     };
 
     // Check idempotency
-    if hook_already_present(&root, &hook_command) {
+    if hook_already_present(&root, hook_command) {
         if verbose > 0 {
-            eprintln!("settings.json: hook already present");
+            eprintln!("{}: hook already present", filename);
         }
         return Ok(PatchResult::AlreadyPresent);
     }
@@ -576,12 +598,12 @@ fn patch_settings_json(
     // Handle mode
     match mode {
         PatchMode::Skip => {
-            print_manual_instructions(hook_path, include_opencode);
+            print_manual_instructions(hook_path, false);
             return Ok(PatchResult::Skipped);
         }
         PatchMode::Ask => {
             if !prompt_user_consent(&settings_path)? {
-                print_manual_instructions(hook_path, include_opencode);
+                print_manual_instructions(hook_path, false);
                 return Ok(PatchResult::Declined);
             }
         }
@@ -591,11 +613,16 @@ fn patch_settings_json(
     }
 
     // Deep-merge hook
-    insert_hook_entry(&mut root, &hook_command);
+    insert_hook_entry(&mut root, hook_command);
 
     // Backup original
     if settings_path.exists() {
-        let backup_path = settings_path.with_extension("json.bak");
+        let backup_ext = if scope == Scope::Local {
+            "local.json.bak"
+        } else {
+            "json.bak"
+        };
+        let backup_path = settings_path.with_extension(backup_ext);
         fs::copy(&settings_path, &backup_path)
             .with_context(|| format!("Failed to backup to {}", backup_path.display()))?;
         if verbose > 0 {
@@ -604,24 +631,27 @@ fn patch_settings_json(
     }
 
     // Atomic write
-    let serialized =
-        serde_json::to_string_pretty(&root).context("Failed to serialize settings.json")?;
+    let serialized = serde_json::to_string_pretty(&root).context("Failed to serialize settings")?;
     atomic_write(&settings_path, &serialized)?;
 
-    println!("\n  settings.json: hook added");
-    if settings_path.with_extension("json.bak").exists() {
-        println!(
-            "  Backup: {}",
-            settings_path.with_extension("json.bak").display()
-        );
-    }
-    if include_opencode {
-        println!("  Restart Claude Code and OpenCode. Test with: git status");
+    println!("\n  {}: hook added", filename);
+    let backup_ext = if scope == Scope::Local {
+        "local.json.bak"
     } else {
-        println!("  Restart Claude Code. Test with: git status");
+        "json.bak"
+    };
+    let backup_path = settings_path.with_extension(backup_ext);
+    if backup_path.exists() {
+        println!("  Backup: {}", backup_path.display());
     }
+    println!("  Restart Claude Code. Test with: git status");
 
     Ok(PatchResult::Patched)
+}
+
+/// Orchestrator: patch settings.json with RTK hook (global scope)
+fn patch_settings_json(hook_path: &Path, mode: PatchMode, verbose: u8) -> Result<PatchResult> {
+    patch_settings_json_scoped(hook_path, Scope::Global, mode, verbose)
 }
 
 /// Clean up consecutive blank lines (collapse 3+ to 2)
@@ -719,98 +749,125 @@ fn hook_already_present(root: &serde_json::Value, hook_command: &str) -> bool {
 
 /// Default mode: hook + slim RTK.md + @RTK.md reference
 #[cfg(not(unix))]
-fn run_default_mode(
-    _global: bool,
-    _patch_mode: PatchMode,
-    _verbose: u8,
-    _install_opencode: bool,
-) -> Result<()> {
+fn run_default_mode(_scope: Scope, _patch_mode: PatchMode, _verbose: u8) -> Result<()> {
     eprintln!("⚠️  Hook-based mode requires Unix (macOS/Linux).");
     eprintln!("    Windows: use --claude-md mode for full injection.");
     eprintln!("    Falling back to --claude-md mode.");
-    run_claude_md_mode(_global, _verbose, _install_opencode)
+    run_claude_md_mode(_scope, _verbose)
 }
 
 #[cfg(unix)]
-fn run_default_mode(
-    global: bool,
-    patch_mode: PatchMode,
-    verbose: u8,
-    install_opencode: bool,
-) -> Result<()> {
-    if !global {
-        // Local init: inject CLAUDE.md + generate project-local filters template
-        run_claude_md_mode(false, verbose, install_opencode)?;
-        generate_project_filters_template(verbose)?;
-        return Ok(());
-    }
+fn run_default_mode(scope: Scope, patch_mode: PatchMode, verbose: u8) -> Result<()> {
+    match scope {
+        Scope::Global => {
+            let claude_dir = resolve_claude_dir()?;
+            let rtk_md_path = claude_dir.join("RTK.md");
+            let claude_md_path = claude_dir.join("CLAUDE.md");
 
-    let claude_dir = resolve_claude_dir()?;
-    let rtk_md_path = claude_dir.join("RTK.md");
-    let claude_md_path = claude_dir.join("CLAUDE.md");
+            // 1. Prepare hook directory and install hook
+            let (_hook_dir, hook_path) = prepare_hook_paths()?;
+            let hook_changed = ensure_hook_installed(&hook_path, verbose)?;
 
-    // 1. Prepare hook directory and install hook
-    let (_hook_dir, hook_path) = prepare_hook_paths()?;
-    let hook_changed = ensure_hook_installed(&hook_path, verbose)?;
+            // 2. Write RTK.md
+            write_if_changed(&rtk_md_path, RTK_SLIM, "RTK.md", verbose)?;
 
-    // 2. Write RTK.md
-    write_if_changed(&rtk_md_path, RTK_SLIM, "RTK.md", verbose)?;
+            // 3. Patch CLAUDE.md (add @RTK.md, migrate if needed)
+            let migrated = patch_claude_md(&claude_md_path, verbose)?;
 
-    let opencode_plugin_path = if install_opencode {
-        let path = prepare_opencode_plugin_path()?;
-        ensure_opencode_plugin_installed(&path, verbose)?;
-        Some(path)
-    } else {
-        None
-    };
-
-    // 3. Patch CLAUDE.md (add @RTK.md, migrate if needed)
-    let migrated = patch_claude_md(&claude_md_path, verbose)?;
-
-    // 4. Print success message
-    let hook_status = if hook_changed {
-        "installed/updated"
-    } else {
-        "already up to date"
-    };
-    println!("\nRTK hook {} (global).\n", hook_status);
-    println!("  Hook:      {}", hook_path.display());
-    println!("  RTK.md:    {} (10 lines)", rtk_md_path.display());
-    if let Some(path) = &opencode_plugin_path {
-        println!("  OpenCode:  {}", path.display());
-    }
-    println!("  CLAUDE.md: @RTK.md reference added");
-
-    if migrated {
-        println!("\n  ✅ Migrated: removed 137-line RTK block from CLAUDE.md");
-        println!("              replaced with @RTK.md (10 lines)");
-    }
-
-    // 5. Patch settings.json
-    let patch_result = patch_settings_json(&hook_path, patch_mode, verbose, install_opencode)?;
-
-    // Report result
-    match patch_result {
-        PatchResult::Patched => {
-            // Already printed by patch_settings_json
-        }
-        PatchResult::AlreadyPresent => {
-            println!("\n  settings.json: hook already present");
-            if install_opencode {
-                println!("  Restart Claude Code and OpenCode. Test with: git status");
+            // 4. Print success message
+            let hook_status = if hook_changed {
+                "installed/updated"
             } else {
-                println!("  Restart Claude Code. Test with: git status");
+                "already up to date"
+            };
+            println!("\nRTK hook {} (global).\n", hook_status);
+            println!("  Hook:      {}", hook_path.display());
+            println!("  RTK.md:    {} (10 lines)", rtk_md_path.display());
+            println!("  CLAUDE.md: @RTK.md reference added");
+
+            if migrated {
+                println!("\n  Migrated: removed 137-line RTK block from CLAUDE.md");
+                println!("              replaced with @RTK.md (10 lines)");
             }
+
+            // 5. Patch settings.json
+            let patch_result = patch_settings_json_scoped(&hook_path, Scope::Global, patch_mode, verbose)?;
+
+            // Report result
+            match patch_result {
+                PatchResult::Patched => {
+                    // Already printed by patch_settings_json
+                }
+                PatchResult::AlreadyPresent => {
+                    println!("\n  settings.json: hook already present");
+                    println!("  Restart Claude Code. Test with: git status");
+                }
+                PatchResult::Declined | PatchResult::Skipped => {
+                    // Manual instructions already printed by patch_settings_json
+                }
+            }
+
+            // 6. Generate user-global filters template (~/.config/rtk/filters.toml)
+            generate_global_filters_template(verbose)?;
+
+            println!(); // Final newline
         }
-        PatchResult::Declined | PatchResult::Skipped => {
-            // Manual instructions already printed by patch_settings_json
+        Scope::Project | Scope::Local => {
+            let claude_dir = resolve_dir_for_scope(scope)?;
+            fs::create_dir_all(&claude_dir)
+                .with_context(|| format!("Failed to create {}", claude_dir.display()))?;
+
+            let rtk_md_path = claude_dir.join("RTK.md");
+            let claude_md_path = PathBuf::from("CLAUDE.md");
+
+            // 1. Install hook
+            let (_hook_dir, hook_path) = prepare_hook_paths_scoped(scope)?;
+            let hook_changed = ensure_hook_installed(&hook_path, verbose)?;
+
+            // 2. Write RTK.md
+            write_if_changed(&rtk_md_path, RTK_SLIM, "RTK.md", verbose)?;
+
+            // 3. Patch CLAUDE.md (add @RTK.md reference)
+            let migrated = patch_claude_md(&claude_md_path, verbose)?;
+
+            // 4. Print success
+            let scope_label = if scope == Scope::Project {
+                "project"
+            } else {
+                "local"
+            };
+            let hook_status = if hook_changed {
+                "installed/updated"
+            } else {
+                "already up to date"
+            };
+            println!("\nRTK hook {} ({}).\n", hook_status, scope_label);
+            println!("  Hook:      {}", hook_path.display());
+            println!("  RTK.md:    {} (10 lines)", rtk_md_path.display());
+            println!("  CLAUDE.md: @RTK.md reference added");
+
+            if migrated {
+                println!("\n  Migrated: removed old RTK block from CLAUDE.md");
+            }
+
+            // 5. Patch settings
+            let patch_result = patch_settings_json_scoped(&hook_path, scope, patch_mode, verbose)?;
+            match patch_result {
+                PatchResult::Patched => {
+                    // Already printed by patch_settings_json_scoped
+                }
+                PatchResult::AlreadyPresent => {
+                    println!("\n  {}: hook already present", settings_filename(scope));
+                    println!("  Restart Claude Code. Test with: git status");
+                }
+                PatchResult::Declined | PatchResult::Skipped => {
+                    // Manual instructions already printed
+                }
+            }
+
+            println!(); // Final newline
         }
     }
-
-    // 6. Generate user-global filters template (~/.config/rtk/filters.toml)
-    generate_global_filters_template(verbose)?;
-
-    println!(); // Final newline
 
     Ok(())
 }
@@ -866,72 +923,53 @@ fn generate_global_filters_template(verbose: u8) -> Result<()> {
 
 /// Hook-only mode: just the hook, no RTK.md
 #[cfg(not(unix))]
-fn run_hook_only_mode(
-    _global: bool,
-    _patch_mode: PatchMode,
-    _verbose: u8,
-    _install_opencode: bool,
-) -> Result<()> {
+fn run_hook_only_mode(_scope: Scope, _patch_mode: PatchMode, _verbose: u8) -> Result<()> {
     anyhow::bail!("Hook install requires Unix (macOS/Linux). Use WSL or --claude-md mode.")
 }
 
 #[cfg(unix)]
-fn run_hook_only_mode(
-    global: bool,
-    patch_mode: PatchMode,
-    verbose: u8,
-    install_opencode: bool,
-) -> Result<()> {
-    if !global {
-        eprintln!("⚠️  Warning: --hook-only only makes sense with --global");
-        eprintln!("    For local projects, use default mode or --claude-md");
-        return Ok(());
-    }
-
-    // Prepare and install hook
-    let (_hook_dir, hook_path) = prepare_hook_paths()?;
+fn run_hook_only_mode(scope: Scope, patch_mode: PatchMode, verbose: u8) -> Result<()> {
+    // Prepare and install hook (scope-aware)
+    let (_hook_dir, hook_path) = if scope == Scope::Global {
+        prepare_hook_paths()?
+    } else {
+        let claude_dir = resolve_dir_for_scope(scope)?;
+        fs::create_dir_all(&claude_dir)
+            .with_context(|| format!("Failed to create {}", claude_dir.display()))?;
+        prepare_hook_paths_scoped(scope)?
+    };
     let hook_changed = ensure_hook_installed(&hook_path, verbose)?;
 
-    let opencode_plugin_path = if install_opencode {
-        let path = prepare_opencode_plugin_path()?;
-        ensure_opencode_plugin_installed(&path, verbose)?;
-        Some(path)
-    } else {
-        None
+    let scope_label = match scope {
+        Scope::Global => "hook-only mode",
+        Scope::Project => "project, hook-only",
+        Scope::Local => "local, hook-only",
     };
-
     let hook_status = if hook_changed {
         "installed/updated"
     } else {
         "already up to date"
     };
-    println!("\nRTK hook {} (hook-only mode).\n", hook_status);
+    println!("\nRTK hook {} ({}).\n", hook_status, scope_label);
     println!("  Hook: {}", hook_path.display());
-    if let Some(path) = &opencode_plugin_path {
-        println!("  OpenCode: {}", path.display());
-    }
     println!(
         "  Note: No RTK.md created. Claude won't know about meta commands (gain, discover, proxy)."
     );
 
-    // Patch settings.json
-    let patch_result = patch_settings_json(&hook_path, patch_mode, verbose, install_opencode)?;
+    // Patch settings (scope-aware)
+    let patch_result = patch_settings_json_scoped(&hook_path, scope, patch_mode, verbose)?;
 
     // Report result
     match patch_result {
         PatchResult::Patched => {
-            // Already printed by patch_settings_json
+            // Already printed by patch_settings_json_scoped
         }
         PatchResult::AlreadyPresent => {
-            println!("\n  settings.json: hook already present");
-            if install_opencode {
-                println!("  Restart Claude Code and OpenCode. Test with: git status");
-            } else {
-                println!("  Restart Claude Code. Test with: git status");
-            }
+            println!("\n  {}: hook already present", settings_filename(scope));
+            println!("  Restart Claude Code. Test with: git status");
         }
         PatchResult::Declined | PatchResult::Skipped => {
-            // Manual instructions already printed by patch_settings_json
+            // Manual instructions already printed
         }
     }
 
@@ -941,14 +979,14 @@ fn run_hook_only_mode(
 }
 
 /// Legacy mode: full 137-line injection into CLAUDE.md
-fn run_claude_md_mode(global: bool, verbose: u8, install_opencode: bool) -> Result<()> {
-    let path = if global {
+fn run_claude_md_mode(scope: Scope, verbose: u8) -> Result<()> {
+    let path = if scope == Scope::Global {
         resolve_claude_dir()?.join("CLAUDE.md")
     } else {
         PathBuf::from("CLAUDE.md")
     };
 
-    if global {
+    if scope == Scope::Global {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
@@ -994,7 +1032,7 @@ fn run_claude_md_mode(global: bool, verbose: u8, install_opencode: bool) -> Resu
                 }
 
                 eprintln!("    Action: Manually remove the incomplete block, then re-run:");
-                if global {
+                if scope == Scope::Global {
                     eprintln!("            rtk init -g --claude-md");
                 } else {
                     eprintln!("            rtk init --claude-md");
@@ -1007,15 +1045,7 @@ fn run_claude_md_mode(global: bool, verbose: u8, install_opencode: bool) -> Resu
         println!("✅ Created {} with rtk instructions", path.display());
     }
 
-    if global {
-        if install_opencode {
-            let opencode_plugin_path = prepare_opencode_plugin_path()?;
-            ensure_opencode_plugin_installed(&opencode_plugin_path, verbose)?;
-            println!(
-                "✅ OpenCode plugin installed: {}",
-                opencode_plugin_path.display()
-            );
-        }
+    if scope == Scope::Global {
         println!("   Claude Code will now use rtk in all sessions");
     } else {
         println!("   Claude Code will use rtk in this project");
@@ -1233,6 +1263,22 @@ fn remove_opencode_plugin(verbose: u8) -> Result<Vec<PathBuf>> {
     Ok(removed)
 }
 
+/// Resolve .claude directory based on scope
+fn resolve_dir_for_scope(scope: Scope) -> Result<PathBuf> {
+    match scope {
+        Scope::Global => resolve_claude_dir(),
+        Scope::Project | Scope::Local => Ok(PathBuf::from(".claude")),
+    }
+}
+
+/// Resolve settings file name based on scope
+fn settings_filename(scope: Scope) -> &'static str {
+    match scope {
+        Scope::Global | Scope::Project => "settings.json",
+        Scope::Local => "settings.local.json",
+    }
+}
+
 /// Show current rtk configuration
 pub fn show_config() -> Result<()> {
     let claude_dir = resolve_claude_dir()?;
@@ -1383,9 +1429,15 @@ pub fn show_config() -> Result<()> {
     println!("\nUsage:");
     println!("  rtk init              # Full injection into local CLAUDE.md");
     println!("  rtk init -g           # Hook + RTK.md + @RTK.md + settings.json (recommended)");
+    println!("  rtk init --project    # Hook + RTK.md in ./.claude/ + settings.json (team-shared)");
+    println!(
+        "  rtk init --local      # Hook + RTK.md in ./.claude/ + settings.local.json (personal)"
+    );
     println!("  rtk init -g --auto-patch    # Same as above but no prompt");
     println!("  rtk init -g --no-patch      # Skip settings.json (manual setup)");
     println!("  rtk init -g --uninstall     # Remove all RTK artifacts");
+    println!("  rtk init --project --uninstall  # Remove project-scope RTK artifacts");
+    println!("  rtk init --local --uninstall    # Remove local-scope RTK artifacts");
     println!("  rtk init -g --claude-md     # Legacy: full injection into ~/.claude/CLAUDE.md");
     println!("  rtk init -g --hook-only     # Hook only, no RTK.md");
     println!("  rtk init -g --opencode      # OpenCode plugin only");
@@ -1855,5 +1907,41 @@ More notes
 
         let removed = remove_hook_from_json(&mut json_content);
         assert!(!removed);
+    }
+
+    // Tests for Scope helpers
+    #[test]
+    fn test_resolve_dir_for_scope_project() {
+        let dir = resolve_dir_for_scope(Scope::Project).unwrap();
+        assert_eq!(dir, PathBuf::from(".claude"));
+    }
+
+    #[test]
+    fn test_resolve_dir_for_scope_local() {
+        let dir = resolve_dir_for_scope(Scope::Local).unwrap();
+        assert_eq!(dir, PathBuf::from(".claude"));
+    }
+
+    #[test]
+    fn test_resolve_dir_for_scope_global() {
+        let dir = resolve_dir_for_scope(Scope::Global).unwrap();
+        // Should be ~/.claude/
+        let expected = dirs::home_dir().unwrap().join(".claude");
+        assert_eq!(dir, expected);
+    }
+
+    #[test]
+    fn test_settings_filename_global() {
+        assert_eq!(settings_filename(Scope::Global), "settings.json");
+    }
+
+    #[test]
+    fn test_settings_filename_project() {
+        assert_eq!(settings_filename(Scope::Project), "settings.json");
+    }
+
+    #[test]
+    fn test_settings_filename_local() {
+        assert_eq!(settings_filename(Scope::Local), "settings.local.json");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -323,9 +323,17 @@ enum Commands {
 
     /// Initialize rtk instructions in CLAUDE.md
     Init {
-        /// Add to global ~/.claude/CLAUDE.md instead of local
-        #[arg(short, long)]
+        /// Add to global ~/.claude/ (user scope)
+        #[arg(short, long, group = "scope")]
         global: bool,
+
+        /// Add to project ./.claude/ with settings.json (team-shared)
+        #[arg(long, group = "scope")]
+        project: bool,
+
+        /// Add to project ./.claude/ with settings.local.json (personal)
+        #[arg(long, group = "scope")]
+        local: bool,
 
         /// Install OpenCode plugin (in addition to Claude Code)
         #[arg(long)]
@@ -1592,6 +1600,8 @@ fn main() -> Result<()> {
 
         Commands::Init {
             global,
+            project,
+            local,
             opencode,
             show,
             claude_md,
@@ -1600,13 +1610,22 @@ fn main() -> Result<()> {
             no_patch,
             uninstall,
         } => {
+            let scope = if global {
+                init::Scope::Global
+            } else if project {
+                init::Scope::Project
+            } else if local {
+                init::Scope::Local
+            } else {
+                init::Scope::Global
+            };
+
             if show {
                 init::show_config()?;
             } else if uninstall {
-                init::uninstall(global, cli.verbose)?;
+                init::uninstall(scope, cli.verbose)?;
             } else {
-                let install_opencode = opencode;
-                let install_claude = !opencode;
+                let _install_opencode = opencode;
 
                 let patch_mode = if auto_patch {
                     init::PatchMode::Auto
@@ -1615,15 +1634,7 @@ fn main() -> Result<()> {
                 } else {
                     init::PatchMode::Ask
                 };
-                init::run(
-                    global,
-                    install_claude,
-                    install_opencode,
-                    claude_md,
-                    hook_only,
-                    patch_mode,
-                    cli.verbose,
-                )?;
+                init::run(scope, claude_md, hook_only, patch_mode, cli.verbose)?;
             }
         }
 


### PR DESCRIPTION
## Summary

  - `--project`: installs to ./.claude/ with settings.json (team-shared)
  - `--local`: installs to ./.claude/ with settings.local.json (personal)
  - Scope-aware uninstall support for all three scopes