### PR TITLE
fix: enrich telemetry with install method and token savings

### DIFF
--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -3,15 +3,18 @@ use crate::tracking;
 use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 
-const TELEMETRY_URL: Option<&str> = option_env!("RTK_TELEMETRY_URL");
+const TELEMETRY_URL: &str = match option_env!("RTK_TELEMETRY_URL") {
+    Some(url) => url,
+    None => "https://telemetry.rtk-ai.app/ping",
+};
 const TELEMETRY_TOKEN: Option<&str> = option_env!("RTK_TELEMETRY_TOKEN");
 const PING_INTERVAL_SECS: u64 = 23 * 3600; // 23 hours
 
 /// Send a telemetry ping if enabled and not already sent today.
 /// Fire-and-forget: errors are silently ignored.
 pub fn maybe_ping() {
-    // No URL compiled in → telemetry disabled
-    if TELEMETRY_URL.is_none() {
+    // Empty URL → telemetry disabled
+    if TELEMETRY_URL.is_empty() {
         return;
     }
 
@@ -47,23 +50,28 @@ pub fn maybe_ping() {
 }
 
 fn send_ping() -> Result<(), Box<dyn std::error::Error>> {
-    let url = TELEMETRY_URL.ok_or("no telemetry URL")?;
+    let url = TELEMETRY_URL;
     let device_hash = generate_device_hash();
     let version = env!("CARGO_PKG_VERSION").to_string();
     let os = std::env::consts::OS.to_string();
     let arch = std::env::consts::ARCH.to_string();
+    let install_method = detect_install_method();
 
     // Get stats from tracking DB
-    let (commands_24h, top_commands, savings_pct) = get_stats();
+    let (commands_24h, top_commands, savings_pct, tokens_saved_24h, tokens_saved_total) =
+        get_stats();
 
     let payload = serde_json::json!({
         "device_hash": device_hash,
         "version": version,
         "os": os,
         "arch": arch,
+        "install_method": install_method,
         "commands_24h": commands_24h,
         "top_commands": top_commands,
         "savings_pct": savings_pct,
+        "tokens_saved_24h": tokens_saved_24h,
+        "tokens_saved_total": tokens_saved_total,
     });
 
     let mut req = ureq::post(url).set("Content-Type", "application/json");
@@ -94,22 +102,58 @@ fn generate_device_hash() -> String {
     format!("{:x}", hasher.finalize())
 }
 
-fn get_stats() -> (i64, Vec<String>, Option<f64>) {
+fn get_stats() -> (i64, Vec<String>, Option<f64>, i64, i64) {
     let tracker = match tracking::Tracker::new() {
         Ok(t) => t,
-        Err(_) => return (0, vec![], None),
+        Err(_) => return (0, vec![], None, 0, 0),
     };
 
+    let since_24h = chrono::Utc::now() - chrono::Duration::hours(24);
+
     // Get 24h command count and top commands from tracking DB
-    let commands_24h = tracker
-        .count_commands_since(chrono::Utc::now() - chrono::Duration::hours(24))
-        .unwrap_or(0);
+    let commands_24h = tracker.count_commands_since(since_24h).unwrap_or(0);
 
     let top_commands = tracker.top_commands(5).unwrap_or_default();
 
     let savings_pct = tracker.overall_savings_pct().ok();
 
-    (commands_24h, top_commands, savings_pct)
+    let tokens_saved_24h = tracker.tokens_saved_24h(since_24h).unwrap_or(0);
+
+    let tokens_saved_total = tracker.total_tokens_saved().unwrap_or(0);
+
+    (
+        commands_24h,
+        top_commands,
+        savings_pct,
+        tokens_saved_24h,
+        tokens_saved_total,
+    )
+}
+
+/// Detect how RTK was installed by inspecting the binary path.
+fn detect_install_method() -> &'static str {
+    let exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(_) => return "unknown",
+    };
+
+    // Resolve symlinks to find the real binary location
+    let real_path = std::fs::canonicalize(&exe)
+        .unwrap_or(exe)
+        .to_string_lossy()
+        .to_string();
+
+    if real_path.contains("/Cellar/rtk/") || real_path.contains("/homebrew/") {
+        "homebrew"
+    } else if real_path.contains("/.cargo/bin/") {
+        "cargo"
+    } else if real_path.contains("/.local/bin/") {
+        "script"
+    } else if real_path.contains("/nix/store/") {
+        "nix"
+    } else {
+        "other"
+    }
 }
 
 fn telemetry_marker_path() -> PathBuf {
@@ -140,5 +184,27 @@ mod tests {
     fn test_marker_path_exists() {
         let path = telemetry_marker_path();
         assert!(path.to_string_lossy().contains("rtk"));
+    }
+
+    #[test]
+    fn test_detect_install_method_returns_known_value() {
+        let method = detect_install_method();
+        assert!(
+            ["homebrew", "cargo", "script", "nix", "other"].contains(&method),
+            "unexpected install method: {}",
+            method
+        );
+    }
+
+    #[test]
+    fn test_get_stats_returns_tuple() {
+        let (cmds, top, pct, saved_24h, saved_total) = get_stats();
+        assert!(cmds >= 0);
+        assert!(top.len() <= 5);
+        assert!(saved_24h >= 0);
+        assert!(saved_total >= 0);
+        if let Some(p) = pct {
+            assert!(p >= 0.0 && p <= 100.0);
+        }
     }
 }

--- a/src/tracking.rs
+++ b/src/tracking.rs
@@ -925,6 +925,27 @@ impl Tracker {
             Ok(0.0)
         }
     }
+
+    /// Get total tokens saved across all tracked commands (for telemetry).
+    pub fn total_tokens_saved(&self) -> Result<i64> {
+        let saved: i64 = self.conn.query_row(
+            "SELECT COALESCE(SUM(saved_tokens), 0) FROM commands",
+            [],
+            |row| row.get(0),
+        )?;
+        Ok(saved)
+    }
+
+    /// Get tokens saved in the last 24 hours (for telemetry).
+    pub fn tokens_saved_24h(&self, since: chrono::DateTime<chrono::Utc>) -> Result<i64> {
+        let ts = since.format("%Y-%m-%dT%H:%M:%S").to_string();
+        let saved: i64 = self.conn.query_row(
+            "SELECT COALESCE(SUM(saved_tokens), 0) FROM commands WHERE timestamp >= ?1",
+            params![ts],
+            |row| row.get(0),
+        )?;
+        Ok(saved)
+    }
 }
 
 fn get_db_path() -> Result<PathBuf> {


### PR DESCRIPTION
## Summary
- Add `install_method` detection (homebrew/cargo/script/nix/other) via binary path inspection
- Add `tokens_saved_24h` and `tokens_saved_total` to telemetry payload
- Add `Tracker::total_tokens_saved()` and `Tracker::tokens_saved_24h()` methods
- Points to new dedicated `rtk-telemetry` service (`telemetry.rtk-ai.app`)

## Backend
The `rtk-telemetry` Cloud Run service is already deployed and accepting enriched payloads. This PR updates the client to send the new fields.

## Test plan
- [x] `cargo test telemetry` — 4/4 tests pass
- [x] Test ping accepted by rtk-telemetry (HTTP 204)
- [x] Stats endpoint shows install_methods + tokens aggregation