### PR TITLE
fix(ci): switch aarch64 Linux build to musl for static linking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,11 @@ jobs:
             os: ubuntu-latest
             archive: tar.gz
             musl: true
-          - target: aarch64-unknown-linux-gnu
+          # aarch64 musl: uses cross tool + Docker image (no host musl-tools needed)
+          - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             archive: tar.gz
-            cross: true
+            use_cross: true
           # Windows
           - target: x86_64-pc-windows-msvc
             os: windows-latest
@@ -57,12 +58,9 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation tools
-        if: matrix.cross
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+      - name: Install cross (cargo cross-compilation tool)
+        if: matrix.use_cross
+        run: cargo install cross --version 0.2.5
 
       - name: Install musl tools
         if: matrix.musl
@@ -70,7 +68,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y musl-tools
 
-      - name: Build
+      - name: Build (cross)
+        if: matrix.use_cross
+        run: cross build --release --target ${{ matrix.target }}
+        env:
+          # Must be set in the runner so Cross.toml can forward them into the
+          # Docker container for option_env!() to bake into the binary at compile time.
+          RTK_TELEMETRY_URL: ${{ vars.RTK_TELEMETRY_URL }}
+          RTK_TELEMETRY_TOKEN: ${{ secrets.RTK_TELEMETRY_TOKEN }}
+
+      - name: Build (cargo)
+        if: "!matrix.use_cross"
         run: cargo build --release --target ${{ matrix.target }}
         env:
           RTK_TELEMETRY_URL: ${{ vars.RTK_TELEMETRY_URL }}
@@ -263,7 +271,7 @@ jobs:
         run: |
           echo "mac_arm=$(grep aarch64-apple-darwin.tar.gz checksums.txt | head -1 | awk '{print $1}')" >> $GITHUB_OUTPUT
           echo "mac_intel=$(grep x86_64-apple-darwin.tar.gz checksums.txt | head -1 | awk '{print $1}')" >> $GITHUB_OUTPUT
-          echo "linux_arm=$(grep aarch64-unknown-linux-gnu.tar.gz checksums.txt | head -1 | awk '{print $1}')" >> $GITHUB_OUTPUT
+          echo "linux_arm=$(grep aarch64-unknown-linux-musl.tar.gz checksums.txt | head -1 | awk '{print $1}')" >> $GITHUB_OUTPUT
           echo "linux_intel=$(grep x86_64-unknown-linux-musl.tar.gz checksums.txt | head -1 | awk '{print $1}')" >> $GITHUB_OUTPUT
 
       - name: Generate formula
@@ -282,7 +290,7 @@ jobs:
               url "https://github.com/rtk-ai/rtk/releases/download/TAG_PLACEHOLDER/rtk-x86_64-apple-darwin.tar.gz"
               sha256 "SHA_MAC_INTEL_PLACEHOLDER"
             elsif OS.linux? && Hardware::CPU.arm?
-              url "https://github.com/rtk-ai/rtk/releases/download/TAG_PLACEHOLDER/rtk-aarch64-unknown-linux-gnu.tar.gz"
+              url "https://github.com/rtk-ai/rtk/releases/download/TAG_PLACEHOLDER/rtk-aarch64-unknown-linux-musl.tar.gz"
               sha256 "SHA_LINUX_ARM_PLACEHOLDER"
             elsif OS.linux? && Hardware::CPU.intel?
               url "https://github.com/rtk-ai/rtk/releases/download/TAG_PLACEHOLDER/rtk-x86_64-unknown-linux-musl.tar.gz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to rtk (Rust Token Killer) will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bug Fixes
+
+* switch aarch64 Linux release binary to musl for static linking, fixing install failures on systems with glibc < 2.39 (e.g. Ubuntu 22.04, devcontainers)
+
 ## [0.27.2](https://github.com/rtk-ai/rtk/compare/v0.27.1...v0.27.2) (2026-03-06)
 
 

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,6 @@
+[build.env]
+# Forward compile-time telemetry vars (used via option_env!()) into the cross Docker container
+passthrough = [
+    "RTK_TELEMETRY_URL",
+    "RTK_TELEMETRY_TOKEN",
+]

--- a/install.sh
+++ b/install.sh
@@ -59,7 +59,7 @@ get_target() {
         linux)
             case "$ARCH" in
                 x86_64)  TARGET="x86_64-unknown-linux-musl";;
-                aarch64) TARGET="aarch64-unknown-linux-gnu";;
+                aarch64) TARGET="aarch64-unknown-linux-musl";;
             esac
             ;;
         darwin)


### PR DESCRIPTION
Fixes install failures on systems with glibc < 2.39 (e.g. Ubuntu 22.04, devcontainers) by building a statically-linked musl binary via the cross tool instead of dynamically linking against glibc.

Mirrors the x86_64 fix from #267.

Fixes #265