### PR TITLE
fix(ls): force LC_ALL=C for predictable parsing

### DIFF
--- a/src/ls.rs
+++ b/src/ls.rs
@@ -52,6 +52,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<()> {
     // Build ls -la + any extra flags the user passed (e.g. -R)
     // Strip -l, -a, -h (we handle all of these ourselves)
     let mut cmd = Command::new("ls");
+    cmd.env("LC_ALL", "C"); // Force standard locale for predictable parsing
     cmd.arg("-la");
     for flag in &flags {
         if flag.starts_with("--") {


### PR DESCRIPTION
On non-English locales (e.g. zh_CN), ls -la output has a different number of columns than the 9 columns assumed by compact_ls. This change forces the C locale to ensure consistent 9-column output for reliable parsing.

e.g. for chinese it's 
```
> ls -lh /etc
总计 1.2M
-rw-r--r-- 1 root root    44  3月 9日 21:44 adjtime
drwxr-xr-x 1 root root    12  3月 9日 21:43 alsa
drwxr-xr-x 1 root root   122  3月10日 10:57 ananicy.d
-rw-r--r-- 1 root root     1 10月13日 00:21 arch-release
-rw-r--r-- 1 root root     0 2025年 4月 1日 arptables.conf
```