### PR TITLE
fix: warn when rtk binary is not in PATH instead of silent exit

### DIFF
--- a/hooks/rtk-rewrite.sh
+++ b/hooks/rtk-rewrite.sh
@@ -13,6 +13,7 @@ if ! command -v jq &>/dev/null; then
 fi
 
 if ! command -v rtk &>/dev/null; then
+  echo "[rtk] WARNING: rtk is not installed or not in PATH. Hook cannot rewrite commands. Install: https://github.com/rtk-ai/rtk#installation" >&2
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

Follow-up to #430 (jq warning) — applies the same pattern to the `rtk` binary check.

Previously the hook exited silently when `rtk` was not in PATH, giving users no indication that the rewrite pipeline was not functioning.

## Context

Raised by @aeppling in PR #462 review: the silent exit pattern affected both `jq` and `rtk` checks.

Closes #430