### PR TITLE
fix: git log --oneline no longer silently truncated to 10

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -352,9 +352,11 @@ fn run_log(
         arg.starts_with("--oneline") || arg.starts_with("--pretty") || arg.starts_with("--format")
     });
 
-    // Check if user provided limit flag
+    // Check if user provided limit flag (-N, -n N, --max-count=N, --max-count N)
     let has_limit_flag = args.iter().any(|arg| {
-        arg.starts_with('-') && arg.chars().nth(1).map_or(false, |c| c.is_ascii_digit())
+        (arg.starts_with('-') && arg.chars().nth(1).map_or(false, |c| c.is_ascii_digit()))
+            || arg == "-n"
+            || arg.starts_with("--max-count")
     });
 
     // Apply RTK defaults only if user didn't specify them
@@ -362,17 +364,22 @@ fn run_log(
         cmd.args(["--pretty=format:%h %s (%ar) <%an>"]);
     }
 
-    let limit = if !has_limit_flag {
+    // Only inject -10 limit when RTK is applying its own format.
+    // When user provides --oneline/--pretty/--format, respect git's default (no limit).
+    let limit = if !has_limit_flag && !has_format_flag {
         cmd.arg("-10");
         10
-    } else {
+    } else if has_limit_flag {
         // Extract limit from args if provided
         args.iter()
             .find(|arg| {
                 arg.starts_with('-') && arg.chars().nth(1).map_or(false, |c| c.is_ascii_digit())
             })
             .and_then(|arg| arg[1..].parse::<usize>().ok())
-            .unwrap_or(10)
+            .unwrap_or(500)
+    } else {
+        // User format, no limit — use a high cap for filter_log_output
+        500
     };
 
     // Only add --no-merges if user didn't explicitly request merge commits


### PR DESCRIPTION
Closes #461

## Summary
- RTK was injecting `-10` on every `git log`, even when the user provided `--oneline` or `--pretty`
- Now only injects `-10` when RTK also applies its own compact format (`--pretty=format:%h %s ...`)
- When user provides `--oneline`/`--pretty`/`--format`, git's default (no limit) is respected
- Also detects `-n` and `--max-count` as user-provided limit flags

## Before/After
| Command | Before | After |
|---------|--------|-------|
| `rtk git log` | 10 lines (RTK format) | 10 lines (RTK format) — unchanged |
| `rtk git log --oneline` | **10 lines** (truncated!) | 278 lines (full log) |
| `rtk git log --oneline -5` | 5 lines | 5 lines — unchanged |
| `rtk git log -n 20` | 20 lines | 20 lines — unchanged |

## Test plan
- [x] `cargo test` — 764 passed, 0 failed
- [x] Manual test: `rtk git log --oneline` shows full log
- [x] Manual test: `rtk git log` still defaults to 10
- [x] Manual test: `rtk git log --oneline -5` respects user limit