### PR TITLE
fix: rtk read no longer corrupts JSON files with glob patterns

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -50,6 +50,7 @@ pub enum Language {
     Java,
     Ruby,
     Shell,
+    Data,
     Unknown,
 }
 
@@ -66,6 +67,9 @@ impl Language {
             "java" => Language::Java,
             "rb" => Language::Ruby,
             "sh" | "bash" | "zsh" => Language::Shell,
+            "json" | "jsonc" | "json5" | "yaml" | "yml" | "toml" | "xml" | "html" | "htm"
+            | "css" | "scss" | "svg" | "md" | "markdown" | "txt" | "csv" | "tsv" | "env"
+            | "ini" | "cfg" | "conf" | "lock" => Language::Data,
             _ => Language::Unknown,
         }
     }
@@ -107,6 +111,13 @@ impl Language {
             },
             Language::Shell => CommentPatterns {
                 line: Some("#"),
+                block_start: None,
+                block_end: None,
+                doc_line: None,
+                doc_block_start: None,
+            },
+            Language::Data => CommentPatterns {
+                line: None,
                 block_start: None,
                 block_end: None,
                 doc_line: None,
@@ -387,6 +398,52 @@ mod tests {
         assert_eq!(Language::from_extension("rs"), Language::Rust);
         assert_eq!(Language::from_extension("py"), Language::Python);
         assert_eq!(Language::from_extension("js"), Language::JavaScript);
+    }
+
+    #[test]
+    fn test_language_detection_data_formats() {
+        assert_eq!(Language::from_extension("json"), Language::Data);
+        assert_eq!(Language::from_extension("yaml"), Language::Data);
+        assert_eq!(Language::from_extension("yml"), Language::Data);
+        assert_eq!(Language::from_extension("toml"), Language::Data);
+        assert_eq!(Language::from_extension("xml"), Language::Data);
+        assert_eq!(Language::from_extension("md"), Language::Data);
+        assert_eq!(Language::from_extension("csv"), Language::Data);
+        assert_eq!(Language::from_extension("lock"), Language::Data);
+    }
+
+    #[test]
+    fn test_data_files_no_comment_stripping() {
+        // Regression test for #464: package.json with `/*` in strings
+        let json = r#"{
+  "workspaces": {
+    "packages": [
+      "packages/*"
+    ]
+  },
+  "scripts": {
+    "build": "bun run --workspaces build"
+  },
+  "lint-staged": {
+    "**/package.json": [
+      "sort-package-json"
+    ]
+  }
+}"#;
+        let filter = MinimalFilter;
+        let result = filter.filter(json, &Language::Data);
+        assert!(
+            result.contains("scripts"),
+            "scripts section must be preserved"
+        );
+        assert!(
+            result.contains("packages/*"),
+            "glob pattern must be preserved"
+        );
+        assert!(
+            result.contains("**/package.json"),
+            "glob pattern must be preserved"
+        );
     }
 
     #[test]

--- a/src/local_llm.rs
+++ b/src/local_llm.rs
@@ -121,6 +121,7 @@ fn lang_display_name(lang: &Language) -> &'static str {
         Language::Java => "Java",
         Language::Ruby => "Ruby",
         Language::Shell => "Shell",
+        Language::Data => "Data",
         Language::Unknown => "Code",
     }
 }


### PR DESCRIPTION
Closes #464

## Summary
- Add `Language::Data` variant for JSON, YAML, TOML, XML, Markdown, CSV, and other data/config formats
- Data files have no comment syntax, so `MinimalFilter` skips comment stripping entirely
- Previously, `"packages/*"` in package.json was treated as a `/*` block comment start, stripping everything until the next `*/` — corrupting the JSON structure

## Root cause
The `Language::Unknown` fallback had `block_start: Some("/*")`, so any file extension not explicitly mapped (including `.json`) would have C-style comment stripping applied. Glob patterns like `packages/*` and `**/package.json` triggered false block comment detection.

## Test plan
- [x] 2 new unit tests: data format detection + JSON with glob patterns preserved
- [x] `cargo test` — 766 passed, 0 failed
- [x] `cargo check` — 0 errors