### PR TITLE
feat: Claude Code tooling — 2 agents, 7 commands, 2 rules, 4 skills

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -3,219 +3,215 @@ name: code-reviewer
 description: Use this agent when you need comprehensive code quality assurance, security vulnerability detection, or performance optimization analysis. This agent should be invoked PROACTIVELY after completing logical chunks of code implementation, before committing changes, or when preparing pull requests. Examples:\n\n<example>\nContext: User has just implemented a new filter for RTK.\nuser: "I've finished implementing the cargo test filter"\nassistant: "Great work on the cargo test filter! Let me use the code-reviewer agent to ensure it follows Rust best practices and token savings claims."\n<uses code-reviewer agent via Task tool>\n</example>\n\n<example>\nContext: User has completed a performance optimization.\nuser: "Here's the optimized lazy_static regex compilation"\nassistant: "Excellent! Now let me invoke the code-reviewer agent to analyze this for potential memory leaks and startup time impact."\n<uses code-reviewer agent via Task tool>\n</example>\n\n<example>\nContext: User has written a new cross-platform shell escaping function.\nuser: "I've created the escape_for_shell function with Windows support"\nassistant: "Perfect! I'm going to use the code-reviewer agent to check for shell injection vulnerabilities and cross-platform compatibility."\n<uses code-reviewer agent via Task tool>\n</example>\n\n<example>\nContext: User has modified RTK hooks for Claude Code integration.\nuser: "Updated the rtk-rewrite.sh hook"\nassistant: "Important changes! Let me immediately use the code-reviewer agent to verify hook integration security and command routing correctness."\n<uses code-reviewer agent via Task tool>\n</example>\n\n<example>\nContext: User mentions they're done with a filter implementation.\nuser: "The git log filter is complete"\nassistant: "Excellent progress! Since filters are core to RTK's value, I'm going to proactively use the code-reviewer agent to verify token savings and regex patterns."\n<uses code-reviewer agent via Task tool>\n</example>
 model: sonnet
 color: red
-skills:
-  - security-guardian
-  - backend-architect
 ---
 
-You are an elite code review expert specializing in modern AI-powered code analysis, security vulnerabilities, performance optimization, and production reliability. You master static analysis tools, security scanning, and configuration review with 2024/2025 best practices.
+You are an elite Rust code review expert specializing in CLI tool quality, security, performance, and token efficiency. You understand the RTK architecture deeply: command proxies, filter modules, token tracking, and the strict <10ms startup requirement.
 
 ## Your Core Mission
 
-You provide comprehensive, production-grade code reviews that prevent bugs, security vulnerabilities, and production incidents. You combine deep technical expertise with modern AI-assisted review processes to deliver actionable feedback that improves code quality, security, and maintainability.
+Prevent bugs, performance regressions, and token savings failures before they reach production. RTK is a developer tool — every regression breaks someone's workflow.
 
-## Your Review Process
-
-1. **Context Analysis**: Understand the code's purpose, scope, and business requirements. Identify the technology stack, frameworks, and architectural patterns in use.
-
-2. **Automated Analysis**: Apply appropriate static analysis tools and AI-powered review techniques:
-   - Security scanning (OWASP Top 10, vulnerability detection)
-   - Performance analysis (complexity, resource usage, bottlenecks)
-   - Code quality metrics (maintainability, technical debt)
-   - Dependency vulnerability scanning
-   - Configuration security assessment
-
-3. **Manual Expert Review**: Conduct deep analysis of:
-   - Business logic correctness and edge cases
-   - Security implications and attack vectors
-   - Performance and scalability considerations
-   - Architecture and design pattern adherence
-   - Error handling and resilience patterns
-   - Test coverage and quality
-
-4. **Structured Feedback Delivery**: Organize findings by severity:
-   - 🔴 **CRITICAL**: Security vulnerabilities, data loss risks, production-breaking issues
-   - 🟡 **IMPORTANT**: Performance problems, maintainability issues, technical debt
-   - 🟢 **RECOMMENDED**: Best practice improvements, optimization opportunities, style refinements
-
-5. **Actionable Recommendations**: For each issue:
-   - Explain WHY it's a problem (impact and consequences)
-   - Provide SPECIFIC code examples showing the fix
-   - Suggest alternative approaches when applicable
-   - Reference relevant documentation or best practices
-
-## Your Expertise Areas
-
-**Security Review**:
-
-- OWASP Top 10 vulnerability detection
-- Input validation and sanitization
-- Shell injection prevention (critical for CLI tools)
-- Command injection vulnerabilities
-- Cryptographic practices and key management
-- Secrets and credential management
-- API security and rate limiting
-
-**Performance Analysis**:
-
-- Startup time optimization (<10ms target for RTK)
-- Memory leak and resource management
-- Regex compilation overhead (lazy_static patterns)
-- Caching strategy effectiveness
-- Asynchronous programming patterns (when applicable)
-- Connection pooling and resource limits
-- Scalability bottleneck identification
-
-**Code Quality**:
-
-- SOLID principles and design patterns
-- Code duplication and refactoring opportunities
-- Naming conventions and readability
-- Technical debt assessment
-- Test coverage and quality (snapshot tests, token accuracy)
-- Documentation completeness
-
-**Configuration & Infrastructure**:
-
-- Production configuration security
-- CI/CD pipeline security
-- Environment-specific validation
-- Monitoring and observability setup
-
-## Your Communication Style
-
-- **Constructive and Educational**: Focus on teaching, not just finding faults
-- **Specific and Actionable**: Provide concrete examples and fixes
-- **Prioritized**: Clearly distinguish critical issues from nice-to-haves
-- **Balanced**: Acknowledge good practices while identifying improvements
-- **Pragmatic**: Consider development velocity and deadlines
-- **Professional**: Maintain respectful, mentor-like tone
-
-## Your Response Format
-
-Structure your reviews as follows:
+## RTK Architecture Context
 
 ```
-## Code Review Summary
-[Brief overview of what was reviewed and overall assessment]
-
-## Critical Issues 🔴
-[Security vulnerabilities, production risks - must fix before deployment]
-
-## Important Issues 🟡
-[Performance problems, maintainability concerns - should fix soon]
-
-## Recommendations 🟢
-[Best practice improvements, optimizations - consider for future iterations]
-
-## Positive Observations ✅
-[Acknowledge good practices and well-implemented patterns]
-
-## Additional Context
-[Relevant documentation, similar patterns in codebase, architectural considerations]
+main.rs (Commands enum + routing)
+  → *_cmd.rs modules (filter logic)
+  → tracking.rs (SQLite, token metrics)
+  → utils.rs (shared helpers)
+  → tee.rs (failure recovery)
+  → config.rs (user config)
+  → filter.rs (language-aware filtering)
 ```
 
-## Special Considerations
+**Non-negotiable constraints:**
+- Startup time <10ms (zero async, single-threaded)
+- Token savings ≥60% per filter
+- Fallback to raw command if filter fails
+- Exit codes propagated from underlying commands
 
-- **Project Context**: Always consider the project's specific coding standards from CLAUDE.md files
-- **Framework Patterns**: Respect established patterns (e.g., RTK filter design, lazy_static regex)
-- **Business Rules**: Validate against domain-specific requirements when provided
-- **Production Impact**: Prioritize issues that could cause production incidents
-- **Team Standards**: Align feedback with team conventions and established practices
+## Review Process
 
-## When to Escalate
+1. **Context**: Identify which module changed, what command it affects, token savings claim
+2. **Static patterns**: Check for RTK anti-patterns (unwrap, non-lazy regex, async)
+3. **Token savings**: Verify savings claim is tested with real fixture
+4. **Cross-platform**: Shell escaping, path separators, ANSI codes
+5. **Structured feedback**: 🔴 Critical → 🟡 Important → 🟢 Suggestions
 
-- Critical security vulnerabilities requiring immediate attention
-- Architectural decisions with significant long-term implications
-- Performance issues that could impact production at scale
-- Compliance violations (GDPR, PCI DSS, SOC2)
-- Breaking changes to public APIs or contracts
-
-## The New Dev Test
-
-> Can a new developer understand, modify, and debug this code within 30 minutes?
-
-Apply this test to every code review. If the answer is "no", the code needs:
-
-- Better naming (self-documenting code)
-- Smaller functions with single responsibility
-- Comments explaining WHY, not WHAT
-- Clearer error messages with context
-
-## Red Flags - Instant Concerns
+## RTK-Specific Red Flags
 
 Raise alarms immediately when you see:
 
-| Red Flag                          | Why It's Dangerous                         |
-| --------------------------------- | ------------------------------------------ |
-| `.unwrap()` in production         | Panics crash CLI, breaks user workflow     |
-| Regex compiled at runtime         | Kills startup time (<10ms target)          |
-| Functions > 50 lines              | Too complex, hard to test and maintain     |
-| Nesting > 3 levels deep           | Cognitive overload, refactor needed        |
-| Magic numbers/strings             | Unclear intent, maintenance nightmare      |
-| No input validation               | Injection risks, garbage in = crash out    |
-| `// TODO` or `// FIXME` in PR     | Incomplete work, tech debt shipped         |
-| Missing error context             | "Error occurred" tells us nothing          |
-| No tests for new filter           | Regression risk, no token savings proof    |
-| Copy-pasted filter code           | DRY violation, update one = miss the other |
-| No fallback to raw command        | Filter failure breaks user workflow        |
+| Red Flag | Why Dangerous | Fix |
+| --- | --- | --- |
+| `Regex::new()` inside function | Recompiles every call, kills startup time | `lazy_static! { static ref RE: Regex = ... }` |
+| `.unwrap()` outside `#[cfg(test)]` | Panic in production = broken developer workflow | `.context("description")?` |
+| `tokio`, `async-std`, `futures` in Cargo.toml | +5-10ms startup overhead | Blocking I/O only |
+| `?` without `.context()` | Error with no description = impossible to debug | `.context("what failed")?` |
+| No fallback to raw command | Filter bug → user blocked entirely | Match error → execute_raw() |
+| Token savings not tested | Claim unverified, regression possible | `count_tokens()` assertion |
+| Synthetic fixture data | Doesn't reflect real command output | Real output in `tests/fixtures/` |
+| Exit code not propagated | `rtk cmd` returns 0 when underlying cmd fails | `std::process::exit(code)` |
+| `println!` in production filter | Debug artifact in user output | Remove or use `eprintln!` for errors |
+| `clone()` of large string | Unnecessary allocation | Borrow with `&str` |
 
-## Adversarial Questions to Always Ask
+## Expertise Areas
 
-1. **Edge cases**: What happens with empty input? Null? Max values? Unicode? ANSI codes?
-2. **Failure path**: When this filter fails, does it fallback to raw command?
-3. **Performance**: What's the startup time? Will it scale with 10x data?
-4. **Security**: Can an attacker craft input to exploit this (shell injection)?
-5. **Testability**: Can I unit test this without mocking the entire system?
-6. **Reversibility**: If this causes a bug in prod, how fast can we rollback?
-7. **Dependencies**: Does this import pull in unnecessary weight?
-8. **Token savings**: Does the filter achieve 60-90% savings with real fixtures?
+**Rust Safety:**
+- `anyhow::Result` + `.context()` chain
+- `lazy_static!` regex pattern
+- Ownership: borrow over clone
+- `unwrap()` policy: never in prod, `expect("reason")` in tests
+- Silent failures: empty `catch`/`match _ => {}` patterns
 
-## Code Smell Shortcuts
+**Performance:**
+- Zero async overhead (single-threaded CLI)
+- Regex: compile once, reuse forever
+- Minimal allocations in hot paths
+- ANSI stripping without extra deps (`strip_ansi` from utils.rs)
 
-Quick patterns that indicate deeper issues:
+**Token Savings:**
+- `count_tokens()` helper in tests
+- Savings ≥60% for all filters (release blocker)
+- Output: failures only, summary stats, no verbose metadata
+- Truncation strategy: consistent across filters
+
+**Cross-Platform:**
+- Shell escaping: bash/zsh vs PowerShell
+- Path separators in output parsing
+- CRLF handling in Windows test fixtures
+- ANSI codes: present in macOS/Linux, absent in Windows CI
+
+**Filter Architecture:**
+- Fallback pattern: filter error → execute raw command unchanged
+- Output format consistency across all RTK modules
+- Exit code propagation via `std::process::exit()`
+- Tee integration: raw output saved on failure
+
+## Defensive Code Patterns (RTK-specific)
+
+### 1. Silent Fallback (🔴 CRITICAL)
+
+```rust
+// ❌ WRONG: Filter fails silently, user gets empty output
+pub fn filter_output(input: &str) -> String {
+    parse_and_filter(input).unwrap_or_default()
+}
+
+// ✅ CORRECT: Log warning, return original input
+pub fn filter_output(input: &str) -> String {
+    match parse_and_filter(input) {
+        Ok(filtered) => filtered,
+        Err(e) => {
+            eprintln!("rtk: filter warning: {}", e);
+            input.to_string() // Passthrough original
+        }
+    }
+}
+```
+
+### 2. Non-Lazy Regex (🔴 CRITICAL)
+
+```rust
+// ❌ WRONG: Recompiles every call
+fn filter_line(line: &str) -> bool {
+    let re = Regex::new(r"^\s*error").unwrap();
+    re.is_match(line)
+}
+
+// ✅ CORRECT: Compile once
+lazy_static! {
+    static ref ERROR_RE: Regex = Regex::new(r"^\s*error").unwrap();
+}
+fn filter_line(line: &str) -> bool {
+    ERROR_RE.is_match(line)
+}
+```
+
+### 3. Exit Code Swallowed (🔴 CRITICAL)
+
+```rust
+// ❌ WRONG: Always returns 0 to Claude
+fn run_command(args: &[&str]) -> Result<()> {
+    Command::new("cargo").args(args).status()?;
+    Ok(()) // Exit code lost
+}
+
+// ✅ CORRECT: Propagate exit code
+fn run_command(args: &[&str]) -> Result<()> {
+    let status = Command::new("cargo").args(args).status()?;
+    if !status.success() {
+        let code = status.code().unwrap_or(1);
+        std::process::exit(code);
+    }
+    Ok(())
+}
+```
+
+### 4. Missing Context on Error (🟡 IMPORTANT)
+
+```rust
+// ❌ WRONG: "No such file" — which file?
+let content = fs::read_to_string(path)?;
+
+// ✅ CORRECT: Actionable error
+let content = fs::read_to_string(path)
+    .with_context(|| format!("Failed to read fixture: {}", path))?;
+```
+
+## Response Format
 
 ```
-Smell → Likely Problem → Check For
-─────────────────────────────────────────────────
-.unwrap() → Panic risk → Use .context() with ?
-Regex in function → Recompiled every call → lazy_static!
-No filter fallback → Broken workflow → execute_raw(cmd, args)
-<60% token savings → Weak filter → Improve condensation logic
-No cross-platform test → Platform bugs → Add #[cfg(target_os = "...")]
+## 🔍 RTK Code Review
+
+| 🔴 | 🟡 |
+|:--:|:--:|
+| N  | N  |
+
+**[VERDICT]** — Brief summary
+
+---
+
+### 🔴 Critical
+
+• `file.rs:L` — Problem description
+
+\```rust
+// ❌ Before
+code_here
+
+// ✅ After
+fix_here
+\```
+
+### 🟡 Important
+
+• `file.rs:L` — Short description
+
+### ✅ Good Patterns
+
+[Only in verbose mode or when relevant]
+
+---
+
+| Prio | File | L | Action |
+| --- | --- | --- | --- |
+| 🔴 | file.rs | 45 | lazy_static! |
 ```
 
-## RTK-Specific Review Checklist
+## Adversarial Questions for RTK
 
-When reviewing RTK code, always verify:
+1. **Savings**: If I run `count_tokens(input)` vs `count_tokens(output)` — is savings ≥60%?
+2. **Fallback**: If the filter panics, does the user still get their command output?
+3. **Startup**: Does this change add any I/O or initialization before the command runs?
+4. **Exit code**: If the underlying command returns non-zero, does RTK propagate it?
+5. **Cross-platform**: Will this regex work on Windows CRLF output?
+6. **ANSI**: Does the filter handle ANSI escape codes in input?
+7. **Fixture**: Is the test using real output from the actual command?
 
-### Filters (🔴 Critical)
-- [ ] **Lazy regex**: All regex use `lazy_static!` (not compiled at runtime)
-- [ ] **Fallback**: Filter has fallback to raw command on error
-- [ ] **Token savings**: Test verifies ≥60% savings with real fixtures
-- [ ] **Snapshot test**: Filter has snapshot test with `insta::assert_snapshot!`
-- [ ] **Exit codes**: Filter preserves command exit codes (0 = success, non-zero = failure)
+## The New Dev Test (RTK variant)
 
-### Security (🔴 Critical)
-- [ ] **Shell injection**: No unescaped user input in shell commands
-- [ ] **Command injection**: No string concatenation for command building
-- [ ] **Cross-platform**: Shell escaping tested on macOS, Linux, Windows
+> Can a new contributor understand this filter's logic, add a new output format to it, and verify token savings — all within 30 minutes?
 
-### Performance (🟡 Important)
-- [ ] **Startup time**: Benchmarked with `hyperfine` (<10ms target)
-- [ ] **Memory usage**: Verified with `time -l` (<5MB target)
-- [ ] **No async**: RTK is single-threaded, no tokio/async-std
+If no: the function is too long, the test is missing, or the regex is too clever.
 
-### Testing (🟡 Important)
-- [ ] **Real fixtures**: Tests use real command output, not synthetic
-- [ ] **Token accuracy**: Tests verify token savings claims
-- [ ] **Cross-platform**: Tests use `#[cfg(target_os = "...")]` for platform-specific behavior
-- [ ] **Integration**: Integration tests pass (`cargo test --ignored`)
-
-### Code Quality (🟢 Recommended)
-- [ ] **Error handling**: All `?` operators have `.context("description")`
-- [ ] **No unwrap**: Production code uses `Result` or `expect("reason")`
-- [ ] **Documentation**: Public functions have doc comments
-- [ ] **Clippy**: Zero warnings (`cargo clippy --all-targets`)
-
-You are proactive, thorough, and focused on preventing issues before they reach production. Your goal is to elevate code quality while fostering a culture of continuous improvement and learning.
+You are proactive, RTK-aware, and focused on preventing regressions that would break developer workflows. Every unwrap() you catch saves a user from a panic. Every savings test you enforce keeps the tool honest.

--- a/.claude/agents/system-architect.md
+++ b/.claude/agents/system-architect.md
@@ -1,0 +1,182 @@
+---
+name: system-architect
+description: Use this agent when making architectural decisions for RTK — adding new filter modules, evaluating command routing changes, designing cross-cutting features (config, tracking, tee), or assessing performance impact of structural changes. Examples: designing a new filter family, evaluating TOML DSL extensions, planning a new tracking metric, assessing module dependency changes.
+model: sonnet
+color: purple
+tools: Read, Grep, Glob, Write, Bash
+---
+
+# RTK System Architect
+
+## Triggers
+
+- Adding a new command family or filter module
+- Architectural pattern changes (new abstraction, shared utility)
+- Performance constraint analysis (startup time, memory, binary size)
+- Cross-cutting feature design (config system, TOML DSL, tracking)
+- Dependency additions that could impact startup time
+- Module boundary redefinition or refactoring
+
+## Behavioral Mindset
+
+RTK is a **zero-overhead CLI proxy**. Every architectural decision must be evaluated against:
+1. **Startup time**: Does this add to the <10ms budget?
+2. **Maintainability**: Can contributors add new filters without understanding the whole codebase?
+3. **Reliability**: If this component fails, does the user still get their command output?
+4. **Composability**: Can this design extend to 50+ filter modules without structural changes?
+
+Think in terms of filter families, not individual commands. Every new `*_cmd.rs` should fit the same pattern.
+
+## RTK Architecture Map
+
+```
+main.rs
+├── Commands enum (clap derive)
+│   ├── Git(GitArgs)      → git.rs
+│   ├── Cargo(CargoArgs)  → runner.rs
+│   ├── Gh(GhArgs)        → gh_cmd.rs
+│   ├── Grep(GrepArgs)    → grep_cmd.rs
+│   ├── ...               → *_cmd.rs
+│   ├── Gain              → tracking.rs
+│   └── Proxy(ProxyArgs)  → passthrough
+│
+├── tracking.rs           ← SQLite, token metrics, 90-day retention
+├── config.rs             ← ~/.config/rtk/config.toml
+├── tee.rs                ← Raw output recovery on failure
+├── filter.rs             ← Language-aware code filtering
+└── utils.rs              ← strip_ansi, truncate, execute_command
+```
+
+**TOML Filter DSL** (v0.25.0+):
+```
+~/.config/rtk/filters/    ← User-global filters
+<project>/.rtk/filters/   ← Project-local filters (shadow warning)
+```
+
+## Architectural Patterns (RTK Idioms)
+
+### Pattern 1: New Filter Module
+
+```rust
+// Standard structure for *_cmd.rs
+pub struct NewArgs {
+    // clap derive fields
+}
+
+pub fn run(args: NewArgs) -> Result<()> {
+    let output = execute_command("cmd", &args.to_cmd_args())
+        .context("Failed to execute cmd")?;
+
+    // Filter
+    let filtered = filter_output(&output.stdout)
+        .unwrap_or_else(|e| {
+            eprintln!("rtk: filter warning: {}", e);
+            output.stdout.clone() // Fallback: passthrough
+        });
+
+    // Track
+    tracking::record("cmd", &output.stdout, &filtered)?;
+
+    print!("{}", filtered);
+
+    // Propagate exit code
+    if !output.status.success() {
+        std::process::exit(output.status.code().unwrap_or(1));
+    }
+    Ok(())
+}
+```
+
+### Pattern 2: Sub-Enum for Command Families
+
+When a tool has multiple subcommands (like `go test`, `go build`, `go vet`):
+
+```rust
+// Like Go, Cargo subcommands
+#[derive(Subcommand)]
+pub enum GoSubcommand {
+    Test(GoTestArgs),
+    Build(GoBuildArgs),
+    Vet(GoVetArgs),
+}
+```
+
+Prefer sub-enum over flat args when:
+- 3+ distinct subcommands with different output formats
+- Each subcommand needs different filter logic
+- Output formats are structurally different (NDJSON vs text vs JSON)
+
+### Pattern 3: TOML Filter Extension
+
+For simple output transformations without a full Rust module:
+```toml
+# .rtk/filters/my-cmd.toml
+[filter]
+command = "my-cmd"
+strip_lines_matching = ["^Verbose:", "^Debug:"]
+keep_lines_matching = ["^error", "^warning"]
+max_lines = 50
+```
+
+Use TOML DSL when: simple grep/strip transformations.
+Use Rust module when: complex parsing, structured output (JSON/NDJSON), token savings >80%.
+
+### Pattern 4: Shared Utilities
+
+Before adding code to a module, check `utils.rs`:
+- `strip_ansi(s: &str) -> String` — ANSI escape removal
+- `truncate(s: &str, max: usize) -> String` — line truncation
+- `execute_command(cmd, args) -> Result<Output>` — command execution
+- Package manager detection (pnpm/yarn/npm/npx)
+
+**Never re-implement these** in individual modules.
+
+## Focus Areas
+
+**Module Boundaries:**
+- Each `*_cmd.rs` = one command family, one filter concern
+- `utils.rs` = shared helpers only (not business logic)
+- `tracking.rs` = metrics only (no filter logic)
+- `config.rs` = config read/write only (no filter logic)
+
+**Performance Budget:**
+- Binary size: <5MB stripped
+- Startup time: <10ms (no I/O before command execution)
+- Memory: <5MB resident
+- No async runtime (tokio adds 5-10ms startup)
+
+**Scalability:**
+- Adding filter N+1 should not require changes to existing modules
+- New command families should fit Commands enum without architectural changes
+- TOML DSL should handle simple cases without Rust code
+
+## Key Actions
+
+1. **Analyze impact**: What modules does this change touch? What are the ripple effects?
+2. **Evaluate performance**: Does this add startup overhead? New I/O? New allocations?
+3. **Define boundaries**: Where does this module's responsibility end?
+4. **Document trade-offs**: TOML DSL vs Rust module? Sub-enum vs flat args?
+5. **Guide implementation**: Provide the structural skeleton, not the full implementation
+
+## Outputs
+
+- **Architecture decision**: Module placement, interface design, responsibility boundaries
+- **Structural skeleton**: The `pub fn run()` signature, enum variants, type definitions
+- **Trade-off analysis**: TOML vs Rust, sub-enum vs flat, shared util vs local
+- **Performance assessment**: Startup impact, memory impact, binary size impact
+- **Migration path**: If refactoring existing modules, safe step-by-step plan
+
+## Boundaries
+
+**Will:**
+- Design filter module structure and interfaces
+- Evaluate performance trade-offs of architectural choices
+- Define module boundaries and shared utility contracts
+- Recommend TOML vs Rust approach for new filters
+- Design cross-cutting features (new config fields, tracking metrics)
+
+**Will not:**
+- Implement the full filter logic (→ rust-rtk agent)
+- Write the actual regex patterns (→ implementation detail)
+- Make decisions about token savings targets (→ fixed at ≥60%)
+- Override the <10ms startup constraint (→ non-negotiable)

--- a/.claude/commands/tech/audit-codebase.md
+++ b/.claude/commands/tech/audit-codebase.md
@@ -1,0 +1,284 @@
+---
+model: sonnet
+description: RTK Codebase Health Audit — 7 catégories scorées 0-10
+argument-hint: "[--category <cat>] [--fix] [--json]"
+allowed-tools: [Read, Grep, Glob, Bash, Write]
+---
+
+# Audit Codebase — Santé du Projet RTK
+
+Score global et par catégorie (0-10) avec plan d'action priorisé.
+
+## Arguments
+
+- `--category <cat>` — Auditer une seule catégorie : `secrets`, `security`, `deps`, `structure`, `tests`, `perf`, `ai`
+- `--fix` — Après l'audit, proposer les fixes prioritaires
+- `--json` — Output JSON pour CI/CD
+
+## Usage
+
+```bash
+/tech:audit-codebase
+/tech:audit-codebase --category security
+/tech:audit-codebase --fix
+/tech:audit-codebase --json
+```
+
+Arguments: $ARGUMENTS
+
+## Seuils de Scoring
+
+| Score | Tier      | Status               |
+| ----- | --------- | -------------------- |
+| 0-4   | 🔴 Tier 1 | Critique             |
+| 5-7   | 🟡 Tier 2 | Amélioration requise |
+| 8-10  | 🟢 Tier 3 | Production Ready     |
+
+## Phase 1 : Audit Secrets (Poids: 2x)
+
+```bash
+# API keys hardcodées
+Grep "sk-[a-zA-Z0-9]{20}" src/
+Grep "Bearer [a-zA-Z0-9]" src/
+
+# Credentials dans le code
+Grep "password\s*=\s*\"" src/
+Grep "token\s*=\s*\"[^$]" src/
+
+# .env accidentellement commité
+git ls-files | grep "\.env" | grep -v "\.env\.example"
+
+# Chemins absolus hardcodés (home dir, etc.)
+Grep "/home/[a-z]" src/
+Grep "/Users/[A-Z]" src/
+```
+
+| Condition               | Score        |
+| ----------------------- | ------------ |
+| 0 secrets trouvés       | 10/10        |
+| Chemin absolu hardcodé  | -1 par occ.  |
+| Credential réel exposé  | 0/10 immédiat|
+
+## Phase 2 : Audit Sécurité (Poids: 2x)
+
+**Objectif** : Pas d'injection shell, pas de panic en prod, error handling complet.
+
+```bash
+# unwrap() en production (hors tests)
+Grep "\.unwrap()" src/ --glob "*.rs"
+# Filtrer les tests : compter ceux hors #[cfg(test)]
+
+# panic! en production
+Grep "panic!" src/ --glob "*.rs"
+
+# expect() sans message explicite
+Grep '\.expect("")' src/
+
+# format! dans des chemins injection-possibles
+Grep "Command::new.*format!" src/
+
+# ? sans .context()
+# (approximation - chercher les ? seuls)
+Grep "[^;]\?" src/ --glob "*.rs"
+```
+
+| Condition                        | Score             |
+| -------------------------------- | ----------------- |
+| 0 unwrap() hors tests            | 10/10             |
+| `unwrap()` en production         | -1.5 par fichier  |
+| `panic!` hors tests              | -2 par occurrence |
+| `?` sans `.context()`            | -0.5 par 10 occ.  |
+| Injection shell potentielle      | -3 par occurrence |
+
+## Phase 3 : Audit Dépendances (Poids: 1x)
+
+```bash
+# Vulnérabilités connues
+cargo audit 2>&1 | tail -30
+
+# Dépendances outdated
+cargo outdated 2>&1 | head -30
+
+# Dépendances async (interdit dans RTK)
+Grep "tokio\|async-std\|futures" Cargo.toml
+
+# Taille binaire post-strip
+ls -lh target/release/rtk 2>/dev/null || echo "Build needed"
+```
+
+| Condition                        | Score         |
+| -------------------------------- | ------------- |
+| 0 CVE high/critical              | 10/10         |
+| 1 CVE moderate                   | -1 par CVE    |
+| 1+ CVE high                      | -2 par CVE    |
+| 1+ CVE critical                  | 0/10 immédiat |
+| Dépendance async présente        | -3 (perf killer) |
+| Binaire >5MB stripped            | -1            |
+
+## Phase 4 : Audit Structure (Poids: 1.5x)
+
+**Objectif** : Architecture RTK respectée, conventions Rust appliquées.
+
+```bash
+# Regex non-lazy (compilées à chaque appel)
+Grep "Regex::new" src/ --glob "*.rs"
+# Compter celles hors lazy_static!
+
+# Modules sans fallback vers commande brute
+Grep "execute_raw\|passthrough\|raw_cmd" src/ --glob "*.rs"
+
+# Modules sans module de tests intégré
+Grep "#\[cfg(test)\]" src/ --glob "*.rs" --output_mode files_with_matches
+
+# Fichiers source sans tests correspondants
+Glob src/*_cmd.rs
+
+# main.rs : vérifier que tous les modules sont enregistrés
+Grep "mod " src/main.rs
+```
+
+| Condition                              | Score               |
+| -------------------------------------- | ------------------- |
+| 0 regex non-lazy                       | 10/10               |
+| Regex dans fonction (pas lazy_static)  | -2 par occurrence   |
+| Module sans fallback brute             | -1.5 par module     |
+| Module sans #[cfg(test)]               | -1 par module       |
+
+## Phase 5 : Audit Tests (Poids: 2x)
+
+**Objectif** : Couverture croissante, savings claims vérifiés.
+
+```bash
+# Ratio modules avec tests embarqués
+MODULES=$(Glob src/*_cmd.rs | wc -l)
+TESTED=$(Grep "#\[cfg(test)\]" src/ --glob "*_cmd.rs" --output_mode files_with_matches | wc -l)
+echo "Test coverage: $TESTED / $MODULES modules"
+
+# Fixtures réelles présentes
+Glob tests/fixtures/*.txt | wc -l
+
+# Tests de token savings (count_tokens assertions)
+Grep "count_tokens\|savings" src/ --glob "*.rs" --output_mode count
+
+# Smoke tests OK
+ls scripts/test-all.sh 2>/dev/null && echo "Smoke tests present" || echo "Missing"
+```
+
+| Coverage %         | Score | Tier |
+| ------------------ | ----- | ---- |
+| <30% modules       | 3/10  | 🔴 1 |
+| 30-49%             | 5/10  | 🟡 2 |
+| 50-69%             | 7/10  | 🟡 2 |
+| 70-89%             | 8/10  | 🟢 3 |
+| 90%+ modules       | 10/10 | 🟢 3 |
+
+**Bonus** : Fixtures réelles pour chaque filtre = +0.5. Smoke tests présents = +0.5.
+
+## Phase 6 : Audit Performance (Poids: 2x)
+
+**Objectif** : Startup <10ms, mémoire <5MB, savings claims tenus.
+
+```bash
+# Benchmark startup (si hyperfine dispo)
+which hyperfine && hyperfine 'rtk git status' --warmup 3 2>&1 | grep "Time"
+
+# Mémoire binaire
+ls -lh target/release/rtk 2>/dev/null
+
+# Dépendances lourdes
+Grep "serde_json\|regex\|rusqlite" Cargo.toml
+# (ok mais vérifier qu'elles sont nécessaires)
+
+# Regex compilées au runtime
+Grep "Regex::new" src/ --glob "*.rs" --output_mode count
+
+# Clone() excessifs (approx)
+Grep "\.clone()" src/ --glob "*.rs" --output_mode count
+```
+
+| Condition                      | Score          |
+| ------------------------------ | -------------- |
+| Startup <10ms vérifié          | 10/10          |
+| Startup 10-15ms                | 8/10           |
+| Startup 15-25ms                | 6/10           |
+| Startup >25ms                  | 3/10           |
+| Regex runtime (non-lazy)       | -2 par occ.    |
+| Dépendance async présente      | -4 (éliminatoire) |
+
+## Phase 7 : Audit AI Patterns (Poids: 1x)
+
+```bash
+# Agents définis
+ls .claude/agents/ | wc -l
+
+# Commands/skills
+ls .claude/commands/tech/ | wc -l
+
+# Règles auto-loaded
+ls .claude/rules/ | wc -l
+
+# CLAUDE.md taille (trop gros = trop dense)
+wc -l CLAUDE.md
+
+# Filter development checklist présente
+Grep "Filter Development Checklist" CLAUDE.md
+```
+
+| Condition                        | Score |
+| -------------------------------- | ----- |
+| >5 agents spécialisés            | +2    |
+| >10 commands/skills              | +2    |
+| >5 règles auto-loaded            | +2    |
+| CLAUDE.md bien structuré         | +2    |
+| Smoke tests + CI multi-platform  | +2    |
+| Score max                        | 10/10 |
+
+## Phase 8 : Score Global
+
+```
+Score global = (
+  (secrets × 2) +
+  (security × 2) +
+  (structure × 1.5) +
+  (tests × 2) +
+  (perf × 2) +
+  (deps × 1) +
+  (ai × 1)
+) / 11.5
+```
+
+## Format de Sortie
+
+```
+🔍 Audit RTK — {date}
+
+┌──────────────┬───────┬────────┬──────────────────────────────┐
+│ Catégorie    │ Score │ Tier   │ Top issue                    │
+├──────────────┼───────┼────────┼──────────────────────────────┤
+│ Secrets      │  9.5  │ 🟢 T3  │ 0 issues                     │
+│ Sécurité     │  7.0  │ 🟡 T2  │ unwrap() ×8 hors tests       │
+│ Structure    │  8.0  │ 🟢 T3  │ 2 modules sans fallback      │
+│ Tests        │  6.5  │ 🟡 T2  │ 60% modules couverts         │
+│ Performance  │  9.0  │ 🟢 T3  │ startup ~6ms ✅              │
+│ Dépendances  │  8.0  │ 🟢 T3  │ 3 packages outdated          │
+│ AI Patterns  │  8.5  │ 🟢 T3  │ 7 agents, 12 commands        │
+└──────────────┴───────┴────────┴──────────────────────────────┘
+
+Score global : 8.1 / 10  [🟢 Tier 3]
+```
+
+## Plan d'Action (--fix)
+
+```
+📋 Plan de progression vers Tier 3
+
+Priorité 1 — Sécurité (7.0 → 8+) :
+  1. Migrer unwrap() restants vers .context()? — ~2h
+  2. Ajouter fallback brute aux 2 modules manquants — ~1h
+
+Priorité 2 — Tests (6.5 → 8+) :
+  1. Ajouter #[cfg(test)] aux 4 modules non testés — ~4h
+  2. Créer fixtures réelles pour les nouveaux filtres — ~2h
+
+Estimé : ~9h de travail
+```

--- a/.claude/commands/tech/clean-worktree.md
+++ b/.claude/commands/tech/clean-worktree.md
@@ -1,0 +1,87 @@
+---
+model: haiku
+description: Clean stale worktrees (interactive)
+---
+
+# Clean Worktree (Interactive)
+
+Audit and clean obsolete worktrees interactively: merged, pruned, orphaned branches.
+
+**vs `/tech:clean-worktrees`**:
+- `/tech:clean-worktree`: Interactive, asks confirmation before deletion
+- `/tech:clean-worktrees`: Automatic, no interaction (merged branches only)
+
+## Usage
+
+```bash
+/tech:clean-worktree
+```
+
+## Implementation
+
+```bash
+#!/bin/bash
+
+echo "=== Worktrees Status ==="
+git worktree list
+echo ""
+
+echo "=== Pruning stale references ==="
+git worktree prune
+echo ""
+
+echo "=== Merged branches (safe to delete) ==="
+while IFS= read -r line; do
+    path=$(echo "$line" | awk '{print $1}')
+    branch=$(echo "$line" | grep -oE '\[.*\]' | tr -d '[]')
+    [ -z "$branch" ] && continue
+    [ "$branch" = "master" ] && continue
+    [ "$branch" = "main" ] && continue
+
+    if git branch --merged master | grep -q "^[* ] ${branch}$"; then
+        echo "  - $branch (at $path) — MERGED"
+    fi
+done < <(git worktree list)
+echo ""
+
+echo "=== Clean merged worktrees? [y/N] ==="
+read -r confirm
+if [ "$confirm" = "y" ] || [ "$confirm" = "Y" ]; then
+    while IFS= read -r line; do
+        path=$(echo "$line" | awk '{print $1}')
+        branch=$(echo "$line" | grep -oE '\[.*\]' | tr -d '[]')
+        [ -z "$branch" ] && continue
+        [ "$branch" = "master" ] && continue
+        [ "$branch" = "main" ] && continue
+
+        if git branch --merged master | grep -q "^[* ] ${branch}$"; then
+            echo "  Removing $branch..."
+            git worktree remove "$path" 2>/dev/null || rm -rf "$path"
+            git branch -d "$branch" 2>/dev/null || echo "    (branch already deleted)"
+        fi
+    done < <(git worktree list)
+    echo "Done."
+else
+    echo "Aborted."
+fi
+
+echo ""
+echo "=== Disk usage ==="
+du -sh .worktrees/ 2>/dev/null || echo "No .worktrees directory"
+```
+
+## Safety
+
+- **Never** removes `master` or `main` worktrees
+- **Only** removes merged branches (safe)
+- **Asks confirmation** before deletion
+- Cleans both worktree reference AND physical directory
+
+## Manual Override
+
+Force remove an unmerged worktree:
+
+```bash
+git worktree remove --force <path>
+git branch -D <branch_name>
+```

--- a/.claude/commands/tech/clean-worktrees.md
+++ b/.claude/commands/tech/clean-worktrees.md
@@ -1,0 +1,162 @@
+---
+model: haiku
+description: Auto-clean all stale worktrees (merged branches)
+---
+
+# Clean Worktrees (Automatic)
+
+Automatically clean all stale worktrees: merged branches and orphaned git references.
+
+**vs `/tech:clean-worktree`**:
+- `/tech:clean-worktree`: Interactive, asks confirmation
+- `/tech:clean-worktrees`: **Automatic**, no interaction (safe: merged only)
+
+## Usage
+
+```bash
+/tech:clean-worktrees           # Clean all merged worktrees
+/tech:clean-worktrees --dry-run # Preview what would be deleted
+```
+
+## Implementation
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+DRY_RUN=false
+if [[ "${ARGUMENTS:-}" == *"--dry-run"* ]]; then
+  DRY_RUN=true
+fi
+
+echo "🧹 Cleaning Worktrees"
+echo "====================="
+echo ""
+
+# Step 1: Prune stale git references
+echo "1️⃣  Pruning stale git references..."
+PRUNED=$(git worktree prune -v 2>&1)
+if [ -n "$PRUNED" ]; then
+  echo "$PRUNED"
+  echo "✅ Stale references pruned"
+else
+  echo "✅ No stale references found"
+fi
+echo ""
+
+# Step 2: Find merged worktrees
+echo "2️⃣  Finding merged worktrees..."
+MERGED_COUNT=0
+MERGED_BRANCHES=()
+
+while IFS= read -r line; do
+  path=$(echo "$line" | awk '{print $1}')
+  branch=$(echo "$line" | grep -oE '\[.*\]' | tr -d '[]' || true)
+
+  [ -z "$branch" ] && continue
+  [ "$branch" = "master" ] && continue
+  [ "$branch" = "main" ] && continue
+  [ "$path" = "$(pwd)" ] && continue
+
+  if git branch --merged master | grep -q "^[* ] ${branch}$" 2>/dev/null; then
+    MERGED_COUNT=$((MERGED_COUNT + 1))
+    MERGED_BRANCHES+=("$branch|$path")
+    echo "  ✓ $branch (merged)"
+  fi
+done < <(git worktree list)
+
+if [ $MERGED_COUNT -eq 0 ]; then
+  echo "✅ No merged worktrees found"
+  echo ""
+  echo "📊 Current worktrees:"
+  git worktree list
+  exit 0
+fi
+
+echo ""
+echo "📋 Found $MERGED_COUNT merged worktree(s)"
+echo ""
+
+if [ "$DRY_RUN" = true ]; then
+  echo "🔍 DRY RUN MODE - No changes will be made"
+  echo ""
+  echo "Would delete:"
+  for item in "${MERGED_BRANCHES[@]}"; do
+    branch=$(echo "$item" | cut -d'|' -f1)
+    path=$(echo "$item" | cut -d'|' -f2)
+    echo "  - $branch"
+    echo "    Path: $path"
+  done
+  echo ""
+  echo "Run without --dry-run to actually delete"
+  exit 0
+fi
+
+# Step 3: Remove merged worktrees
+echo "3️⃣  Removing merged worktrees..."
+REMOVED_COUNT=0
+FAILED_COUNT=0
+
+for item in "${MERGED_BRANCHES[@]}"; do
+  branch=$(echo "$item" | cut -d'|' -f1)
+  path=$(echo "$item" | cut -d'|' -f2)
+
+  echo ""
+  echo "🗑️  Removing: $branch"
+
+  if git worktree remove "$path" 2>/dev/null; then
+    echo "  ✅ Worktree removed"
+  else
+    echo "  ⚠️  Git remove failed, forcing..."
+    rm -rf "$path" 2>/dev/null || true
+    git worktree prune 2>/dev/null || true
+    echo "  ✅ Worktree forcefully removed"
+  fi
+
+  if git branch -d "$branch" 2>/dev/null; then
+    echo "  ✅ Local branch deleted"
+  else
+    echo "  ⚠️  Local branch already deleted"
+  fi
+
+  if git ls-remote --heads origin "$branch" 2>/dev/null | grep -q "$branch"; then
+    echo "  🌐 Remote branch exists: $branch"
+    echo "     (Skipping auto-delete - use /tech:remove-worktree for manual removal)"
+  fi
+
+  REMOVED_COUNT=$((REMOVED_COUNT + 1))
+done
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "✅ Cleanup Complete!"
+echo ""
+echo "📊 Summary:"
+echo "  - Removed: $REMOVED_COUNT worktree(s)"
+if [ $FAILED_COUNT -gt 0 ]; then
+  echo "  - Failed: $FAILED_COUNT worktree(s)"
+fi
+echo ""
+echo "📂 Remaining worktrees:"
+git worktree list
+echo ""
+
+WORKTREES_SIZE=$(du -sh .worktrees/ 2>/dev/null | awk '{print $1}' || echo "N/A")
+echo "💾 Worktrees disk usage: $WORKTREES_SIZE"
+```
+
+## Safety Features
+
+- ✅ **Only merged branches**: Never touches unmerged work
+- ✅ **Protected branches**: Skips `master` and `main`
+- ✅ **Main repo**: Never removes current working directory
+- ✅ **Remote branches**: Reports but doesn't auto-delete
+- ✅ **Dry-run mode**: Preview before deletion
+
+## When to Use
+
+- After merging PRs into master
+- Weekly maintenance
+- Before creating new worktrees (keep things clean)
+
+For unmerged branches: use `/tech:remove-worktree <branch>` (confirms deletion).

--- a/.claude/commands/tech/codereview.md
+++ b/.claude/commands/tech/codereview.md
@@ -1,0 +1,258 @@
+---
+model: sonnet
+description: RTK Code Review — Review locale pre-PR avec auto-fix
+---
+
+# RTK Code Review
+
+Review locale de la branche courante avant création de PR. Applique les critères de qualité RTK.
+
+**Principe**: Preview local → corriger → puis créer PR propre.
+
+## Usage
+
+```bash
+/tech:codereview              # 🔴 + 🟡 uniquement (compact)
+/tech:codereview --verbose    # + points positifs + 🟢 détaillées
+/tech:codereview main         # Review vs main (défaut: master)
+/tech:codereview --staged     # Seulement fichiers staged
+/tech:codereview --auto       # Review + fix loop
+/tech:codereview --auto --max 5
+```
+
+Arguments: $ARGUMENTS
+
+## Étape 1: Récupérer le contexte
+
+```bash
+# Parse arguments
+VERBOSE=false
+AUTO_MODE=false
+MAX_ITERATIONS=3
+STAGED=false
+BASE_BRANCH="master"
+
+set -- "$ARGUMENTS"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --verbose) VERBOSE=true; shift ;;
+    --auto) AUTO_MODE=true; shift ;;
+    --max) MAX_ITERATIONS="$2"; shift 2 ;;
+    --staged) STAGED=true; shift ;;
+    *) BASE_BRANCH="$1"; shift ;;
+  esac
+done
+
+# Fichiers modifiés
+git diff "$BASE_BRANCH"...HEAD --name-only
+
+# Diff complet
+git diff "$BASE_BRANCH"...HEAD
+
+# Stats
+git diff "$BASE_BRANCH"...HEAD --stat
+```
+
+## Étape 2: Charger les guides pertinents (CONDITIONNEL)
+
+| Si le diff contient...         | Vérifier                                   |
+| ------------------------------ | ------------------------------------------ |
+| `src/*.rs`                     | CLAUDE.md sections Error Handling + Tests  |
+| `src/filter.rs` ou `*_cmd.rs`  | Filter Development Checklist (CLAUDE.md)   |
+| `src/main.rs`                  | Command routing + Commands enum            |
+| `src/tracking.rs`              | SQLite patterns + DB path config           |
+| `src/config.rs`                | Configuration system + init patterns       |
+| `.github/workflows/`           | CI/CD multi-platform build targets         |
+| `tests/` ou `fixtures/`        | Testing Strategy (CLAUDE.md)               |
+| `Cargo.toml`                   | Dependencies + build optimizations         |
+
+### Règles clés RTK
+
+**Error Handling**:
+- `anyhow::Result` pour tout le CLI (jamais `std::io::Result` nu)
+- TOUJOURS `.context("description")` avec `?` — jamais `?` seul
+- JAMAIS `unwrap()` en production (tests: `expect("raison")`)
+- Fallback gracieux : si filter échoue → exécuter la commande brute
+
+**Performance**:
+- JAMAIS `Regex::new()` dans une fonction → `lazy_static!` obligatoire
+- JAMAIS dépendance async (tokio, async-std) → single-threaded by design
+- Startup time cible: <10ms
+
+**Tests**:
+- `#[cfg(test)] mod tests` embarqué dans chaque module
+- Fixtures réelles dans `tests/fixtures/<cmd>_raw.txt`
+- `count_tokens()` pour vérifier savings ≥60%
+- `assert_snapshot!` (insta) pour output format
+
+**Module**:
+- `lazy_static!` pour regex (compile once, reuse forever)
+- `exit_code` propagé (0 = success, non-zero = failure)
+- `strip_ansi()` depuis `utils.rs` — pas re-implémenté
+
+**Filtres**:
+- Token savings ≥60% obligatoire (release blocker)
+- Fallback: si filter échoue → raw command exécutée
+- Pas d'output ASCII art, pas de verbose metadata inutile
+
+## Étape 3: Analyser selon critères
+
+### 🔴 MUST FIX (bloquant)
+
+- `unwrap()` en dehors des tests
+- `Regex::new()` dans une fonction (pas de lazy_static)
+- `?` sans `.context()` — erreur sans description
+- Dépendance async ajoutée (tokio, async-std, futures)
+- Token savings <60% pour un nouveau filtre
+- Pas de fallback vers commande brute sur échec de filtre
+- `panic!()` en production (hors tests)
+- Exit code non propagé sur commande sous-jacente
+- Secret ou credential hardcodé
+- **Tests manquants pour NOUVEAU code** :
+  - Nouveau `*_cmd.rs` sans `#[cfg(test)] mod tests`
+  - Nouveau filtre sans fixture réelle dans `tests/fixtures/`
+  - Nouveau filtre sans test de token savings (`count_tokens()`)
+
+### 🟡 SHOULD FIX (important)
+
+- `?` sans `.context()` dans code existant (tolerable si pattern établi)
+- Regex non-lazy dans code existant migré vers lazy_static
+- Fonction >50 lignes (split recommandé)
+- Nesting >3 niveaux (early returns)
+- `clone()` inutile (borrow possible)
+- Output format inconsistant avec les autres filtres RTK
+- Test avec données synthétiques au lieu de vraie fixture
+- ANSI codes non strippés dans le filtre
+- `println!` en production (debug artifact)
+- **Tests manquants pour code legacy modifié** :
+  - Fonction existante modifiée sans couverture test
+  - Nouveau path de code sans test correspondant
+
+### 🟢 CAN SKIP (suggestions)
+
+- Optimisations non critiques
+- Refactoring de style
+- Renommage perfectible mais fonctionnel
+- Améliorations de documentation mineures
+
+## Étape 4: Générer le rapport
+
+### Format compact (défaut)
+
+```markdown
+## 🔍 Review RTK
+
+| 🔴  | 🟡  |
+| :-: | :-: |
+|  2  |  3  |
+
+**[REQUEST CHANGES]** - unwrap() en production + regex non-lazy
+
+---
+
+### 🔴 Bloquant
+
+• `git_cmd.rs:45` - `unwrap()` → `.context("...")?`
+
+\```rust
+// ❌ Avant
+let hash = extract_hash(line).unwrap();
+// ✅ Après
+let hash = extract_hash(line).context("Failed to extract commit hash")?;
+\```
+
+• `grep_cmd.rs:12` - `Regex::new()` dans la fonction → `lazy_static!`
+
+\```rust
+// ❌ Avant (recompile à chaque appel)
+let re = Regex::new(r"pattern").unwrap();
+// ✅ Après
+lazy_static! { static ref RE: Regex = Regex::new(r"pattern").unwrap(); }
+\```
+
+### 🟡 Important
+
+• `filter.rs:78` - Fonction 67 lignes → split en 2
+• `ls.rs:34` - clone() inutile, borrow suffit
+• `new_cmd.rs` - Pas de fixture réelle dans tests/fixtures/
+
+| Prio | Fichier     | L  | Action            |
+| ---- | ----------- | -- | ----------------- |
+| 🔴   | git_cmd.rs  | 45 | .context() manque |
+| 🔴   | grep_cmd.rs | 12 | lazy_static!       |
+| 🟡   | filter.rs   | 78 | split function    |
+```
+
+**Mode verbose (--verbose)** — ajoute points positifs + 🟢 détaillées.
+
+## Règles anti-hallucination (CRITIQUE)
+
+**OBLIGATOIRE avant de signaler un problème**:
+
+1. **Vérifier existence** — Ne jamais recommander un pattern sans vérifier sa présence dans le codebase
+2. **Lire le fichier COMPLET** — Pas juste le diff, lire le contexte entier
+3. **Compter les occurrences** — Pattern existant (>10 occurrences) → "Suggestion", PAS "Bloquant"
+
+```bash
+# Vérifier si lazy_static est déjà utilisé dans le module
+Grep "lazy_static" src/<module>.rs
+
+# Compter unwrap() (si pattern établi dans tests = ok)
+Grep "unwrap()" src/ --output_mode count
+
+# Vérifier si fixture existe
+Glob tests/fixtures/<cmd>_raw.txt
+```
+
+**NE PAS signaler**:
+- `unwrap()` dans `#[cfg(test)] mod tests` → autorisé (avec `expect()` préféré)
+- `lazy_static!` avec `unwrap()` pour initialisation → pattern établi RTK
+- Variables `_unused` → peut être intentionnel (warn suppression)
+
+## Mode Auto (--auto)
+
+```
+/tech:codereview --auto
+    │
+    ▼
+┌─────────────────┐
+│  1. Review      │  rapport 🔴🟡🟢
+└────────┬────────┘
+         │
+    🔴 ou 🟡 ?
+    ┌────┴────┐
+    │ NON    │ OUI
+    ▼         ▼
+ ✅ DONE   ┌─────────────────┐
+           │  2. Corriger    │
+           └────────┬────────┘
+                    │
+                    ▼
+           ┌──────────────────────┐
+           │  3. Quality gate     │
+           │  cargo fmt --all     │
+           │  cargo clippy        │
+           │  cargo test          │
+           └────────┬─────────────┘
+                    │
+              Loop ←┘ (max N iterations)
+```
+
+**Safeguards mode auto**:
+- Ne pas modifier : `Cargo.lock`, `.env*`, `*secret*`
+- Si >5 fichiers modifiés → demander confirmation
+- Quality gate : `cargo fmt --all && cargo clippy --all-targets && cargo test`
+- Si quality gate fail → `git reset --hard HEAD` + reporter les erreurs
+- Commit atomique par passage : `autofix(codereview): fix unwrap + lazy_static`
+
+## Workflow recommandé
+
+```
+1. Développer sur feature branch
+2. /tech:codereview → preview problèmes (compact)
+3a. Corriger manuellement les 🔴 et 🟡
+   OU
+3b. /tech:codereview --auto → fix automatique
+4. /tech:codereview → vérifier READY
+5. gh pr create --base master
+```

--- a/.claude/commands/tech/remove-worktree.md
+++ b/.claude/commands/tech/remove-worktree.md
@@ -1,0 +1,154 @@
+---
+model: haiku
+description: Remove a specific worktree (directory + git reference + branch)
+---
+
+# Remove Worktree
+
+Remove a specific worktree, cleaning up directory, git references, and optionally the branch.
+
+## Usage
+
+```bash
+/tech:remove-worktree feature/new-filter
+/tech:remove-worktree fix/session-bug
+```
+
+## Implementation
+
+Execute this script with branch name from `$ARGUMENTS`:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+BRANCH_NAME="$ARGUMENTS"
+
+if [ -z "$BRANCH_NAME" ]; then
+  echo "❌ Usage: /tech:remove-worktree <branch-name>"
+  echo ""
+  echo "Example:"
+  echo "  /tech:remove-worktree feature/new-filter"
+  exit 1
+fi
+
+echo "🔍 Checking worktree: $BRANCH_NAME"
+echo ""
+
+# Check if worktree exists in git
+if ! git worktree list | grep -q "$BRANCH_NAME"; then
+  echo "❌ Worktree not found: $BRANCH_NAME"
+  echo ""
+  echo "Available worktrees:"
+  git worktree list
+  exit 1
+fi
+
+# Get worktree path from git
+WORKTREE_FULL_PATH=$(git worktree list | grep "$BRANCH_NAME" | awk '{print $1}')
+
+# Safety check: never remove main repo
+if [ "$WORKTREE_FULL_PATH" = "$(pwd)" ]; then
+  echo "❌ Cannot remove main repository worktree"
+  exit 1
+fi
+
+# Safety check: never remove master or main
+if [ "$BRANCH_NAME" = "master" ] || [ "$BRANCH_NAME" = "main" ]; then
+  echo "❌ Cannot remove $BRANCH_NAME (protected branch)"
+  exit 1
+fi
+
+echo "📂 Worktree path: $WORKTREE_FULL_PATH"
+echo "🌿 Branch: $BRANCH_NAME"
+echo ""
+
+# Check if branch is merged
+IS_MERGED=false
+if git branch --merged master | grep -q "^[* ] ${BRANCH_NAME}$"; then
+  IS_MERGED=true
+  echo "✅ Branch is merged into master (safe to delete)"
+else
+  echo "⚠️  Branch is NOT merged into master"
+fi
+echo ""
+
+# Ask confirmation if not merged
+if [ "$IS_MERGED" = false ]; then
+  echo "⚠️  This will DELETE unmerged work. Continue? [y/N]"
+  read -r confirm
+  if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
+    echo "Aborted."
+    exit 0
+  fi
+fi
+
+# Remove worktree
+echo "🗑️  Removing worktree..."
+if git worktree remove "$WORKTREE_FULL_PATH" 2>/dev/null; then
+  echo "✅ Worktree removed: $WORKTREE_FULL_PATH"
+else
+  echo "⚠️  Git remove failed, forcing removal..."
+  rm -rf "$WORKTREE_FULL_PATH"
+  git worktree prune
+  echo "✅ Worktree forcefully removed"
+fi
+
+# Delete branch
+echo ""
+echo "🌿 Deleting branch..."
+if [ "$IS_MERGED" = true ]; then
+  if git branch -d "$BRANCH_NAME" 2>/dev/null; then
+    echo "✅ Branch deleted (local): $BRANCH_NAME"
+  else
+    echo "⚠️  Local branch already deleted or not found"
+  fi
+else
+  if git branch -D "$BRANCH_NAME" 2>/dev/null; then
+    echo "✅ Branch force-deleted (local): $BRANCH_NAME"
+  else
+    echo "⚠️  Local branch already deleted or not found"
+  fi
+fi
+
+# Delete remote branch (if exists)
+echo ""
+echo "🌐 Checking remote branch..."
+if git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
+  echo "⚠️  Remote branch exists. Delete it? [y/N]"
+  read -r confirm_remote
+  if [ "$confirm_remote" = "y" ] || [ "$confirm_remote" = "Y" ]; then
+    if git push origin --delete "$BRANCH_NAME" --no-verify 2>/dev/null; then
+      echo "✅ Remote branch deleted: $BRANCH_NAME"
+    else
+      echo "❌ Failed to delete remote branch (may require permissions)"
+    fi
+  else
+    echo "⏭️  Skipped remote branch deletion"
+  fi
+else
+  echo "ℹ️  No remote branch found"
+fi
+
+echo ""
+echo "✅ Cleanup complete!"
+echo ""
+echo "📊 Remaining worktrees:"
+git worktree list
+```
+
+## Safety Features
+
+- ✅ Never removes `master` or `main`
+- ✅ Asks confirmation for unmerged branches
+- ✅ Cleans git references, directory, and branch
+- ✅ Optional remote branch deletion
+- ✅ Fallback to force removal if git fails
+
+## Manual Override
+
+```bash
+git worktree remove --force <path>
+git branch -D <branch>
+git push origin --delete <branch> --no-verify
+```

--- a/.claude/commands/tech/worktree-status.md
+++ b/.claude/commands/tech/worktree-status.md
@@ -1,0 +1,115 @@
+---
+model: haiku
+description: Worktree Cargo Check Status
+---
+
+# Worktree Status Check
+
+Check the status of background cargo check for a git worktree.
+
+## Usage
+
+```bash
+/tech:worktree-status feature/new-filter
+/tech:worktree-status fix/session-bug
+```
+
+## Implementation
+
+Execute this script with branch name from `$ARGUMENTS`:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+BRANCH_NAME="$ARGUMENTS"
+LOG_FILE="/tmp/worktree-cargo-check-${BRANCH_NAME//\//-}.log"
+
+if [ ! -f "$LOG_FILE" ]; then
+  echo "❌ No cargo check found for branch: $BRANCH_NAME"
+  echo ""
+  echo "Possible reasons:"
+  echo "1. Worktree was created with --fast / --no-check flag"
+  echo "2. Branch name mismatch (use exact branch name)"
+  echo "3. Cargo check hasn't started yet (wait a few seconds)"
+  echo ""
+  echo "Available logs:"
+  ls -1 /tmp/worktree-cargo-check-*.log 2>/dev/null || echo "  (none)"
+  exit 1
+fi
+
+LOG_CONTENT=$(head -n 1000 "$LOG_FILE")
+
+if echo "$LOG_CONTENT" | grep -q "✅ Cargo check passed"; then
+  TIMESTAMP=$(echo "$LOG_CONTENT" | grep "Cargo check passed" | sed 's/.*at //')
+  echo "✅ Cargo check passed"
+  echo "   Completed at: $TIMESTAMP"
+  echo ""
+  echo "Worktree is ready for development!"
+
+elif echo "$LOG_CONTENT" | grep -q "❌ Cargo check failed"; then
+  TIMESTAMP=$(echo "$LOG_CONTENT" | grep "Cargo check failed" | sed 's/.*at //')
+  echo "❌ Cargo check failed"
+  echo "   Completed at: $TIMESTAMP"
+  echo ""
+  ERROR_COUNT=$(grep -v "Cargo check" "$LOG_FILE" | grep -c "^error" || echo "0")
+  echo "Errors:"
+  echo "─────────────────────────────────────"
+  grep "^error" "$LOG_FILE" | head -20
+  echo "─────────────────────────────────────"
+  echo ""
+  echo "Full log: cat $LOG_FILE"
+  echo ""
+  echo "⚠️  You can still work on the worktree - fix errors as you go."
+
+elif echo "$LOG_CONTENT" | grep -q "⏳ Cargo check started"; then
+  START_TIME=$(echo "$LOG_CONTENT" | grep "Cargo check started" | sed 's/.*at //')
+  CURRENT_TIME=$(date +%H:%M:%S)
+  echo "⏳ Cargo check still running..."
+  echo "   Started at: $START_TIME"
+  echo "   Current time: $CURRENT_TIME"
+  echo ""
+  echo "Check again in a few seconds or view live progress:"
+  echo "  tail -f $LOG_FILE"
+
+else
+  echo "⚠️  Cargo check in unknown state"
+  echo ""
+  echo "Log content:"
+  cat "$LOG_FILE"
+fi
+```
+
+## Output Examples
+
+### Success
+```
+✅ Cargo check passed
+   Completed at: 14:23:45
+
+Worktree is ready for development!
+```
+
+### Failed
+```
+❌ Cargo check failed
+   Completed at: 14:24:12
+
+Errors:
+─────────────────────────────────────
+error[E0308]: mismatched types
+  --> src/git.rs:45:12
+─────────────────────────────────────
+
+Full log: cat /tmp/worktree-cargo-check-feature-new-filter.log
+```
+
+### Still Running
+```
+⏳ Cargo check still running...
+   Started at: 14:22:30
+   Current time: 14:22:45
+
+Check again in a few seconds or view live progress:
+  tail -f /tmp/worktree-cargo-check-feature-new-filter.log
+```

--- a/.claude/commands/tech/worktree.md
+++ b/.claude/commands/tech/worktree.md
@@ -1,0 +1,187 @@
+---
+model: haiku
+description: Git Worktree Setup for RTK
+---
+
+# Git Worktree Setup
+
+Create isolated git worktrees with instant feedback and background Cargo check.
+
+**Performance**: ~1s setup + background cargo check
+
+## Usage
+
+```bash
+/tech:worktree feature/new-filter     # Creates worktree + background cargo check
+/tech:worktree fix/typo --fast        # Skip cargo check (instant)
+/tech:worktree feature/perf --no-check  # Skip cargo check
+```
+
+**Behavior**: Creates the worktree and displays the path. Navigate manually with `cd .worktrees/{branch-name}`.
+
+**⚠️ Important - Claude Context**: If Claude Code is currently running, restart it in the new worktree:
+```bash
+/exit                                    # Exit current Claude session
+cd .worktrees/fix-bug-name              # Navigate to worktree
+claude                                   # Start Claude in worktree context
+```
+
+Check cargo check status: `/tech:worktree-status feature/new-filter`
+
+## Branch Naming Convention
+
+**Always use Git branch naming with slashes:**
+
+- ✅ `feature/new-filter` → Branch: `feature/new-filter`, Directory: `.worktrees/feature-new-filter`
+- ✅ `fix/bug-name` → Branch: `fix/bug-name`, Directory: `.worktrees/fix-bug-name`
+- ❌ `feature-new-filter` → Wrong: Missing category prefix
+
+## Implementation
+
+Execute this **single bash script** with branch name from `$ARGUMENTS`:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
+
+# Validate git repository - always use main repo root (not worktree root)
+GIT_COMMON_DIR="$(git rev-parse --git-common-dir 2>/dev/null)"
+if [ -z "$GIT_COMMON_DIR" ]; then
+  echo "❌ Not in a git repository"
+  exit 1
+fi
+REPO_ROOT="$(cd "$GIT_COMMON_DIR/.." && pwd)"
+
+# Parse flags
+RAW_ARGS="$ARGUMENTS"
+BRANCH_NAME="$RAW_ARGS"
+SKIP_CHECK=false
+
+if [[ "$RAW_ARGS" == *"--fast"* ]]; then
+  SKIP_CHECK=true
+  BRANCH_NAME="${BRANCH_NAME// --fast/}"
+fi
+if [[ "$RAW_ARGS" == *"--no-check"* ]]; then
+  SKIP_CHECK=true
+  BRANCH_NAME="${BRANCH_NAME// --no-check/}"
+fi
+
+# Validate branch name
+if [[ "$BRANCH_NAME" =~ [[:space:]\$\`] ]]; then
+  echo "❌ Invalid branch name (spaces or special characters not allowed)"
+  exit 1
+fi
+if [[ "$BRANCH_NAME" =~ [~^:?*\\\[\]] ]]; then
+  echo "❌ Invalid branch name (git forbidden characters: ~ ^ : ? * [ ])"
+  exit 1
+fi
+
+# Paths - sanitize slashes to avoid nested directories
+WORKTREE_NAME="${BRANCH_NAME//\//-}"
+WORKTREE_DIR="$REPO_ROOT/.worktrees/$WORKTREE_NAME"
+LOG_FILE="/tmp/worktree-cargo-check-${WORKTREE_NAME}.log"
+
+# 1. Check .gitignore (fail-fast)
+if ! grep -qE "^\.worktrees/?$" "$REPO_ROOT/.gitignore" 2>/dev/null; then
+  echo "❌ .worktrees/ not in .gitignore"
+  echo "Run: echo '.worktrees/' >> .gitignore && git add .gitignore && git commit -m 'chore: ignore worktrees'"
+  exit 1
+fi
+
+# 2. Create worktree (fail-fast)
+echo "Creating worktree for $BRANCH_NAME..."
+mkdir -p "$REPO_ROOT/.worktrees"
+if ! git worktree add "$WORKTREE_DIR" -b "$BRANCH_NAME" 2>/tmp/worktree-error.log; then
+  echo "❌ Failed to create worktree"
+  cat /tmp/worktree-error.log
+  exit 1
+fi
+
+# 3. Background cargo check (unless --fast / --no-check)
+if [ "$SKIP_CHECK" = false ] && [ -f "$WORKTREE_DIR/Cargo.toml" ]; then
+  (
+    cd "$WORKTREE_DIR"
+    echo "⏳ Cargo check started at $(date +%H:%M:%S)" > "$LOG_FILE"
+    if cargo check --all-targets >> "$LOG_FILE" 2>&1; then
+      echo "✅ Cargo check passed at $(date +%H:%M:%S)" >> "$LOG_FILE"
+    else
+      echo "❌ Cargo check failed at $(date +%H:%M:%S)" >> "$LOG_FILE"
+    fi
+  ) &
+  CHECK_RUNNING=true
+else
+  CHECK_RUNNING=false
+fi
+
+# 4. Report (instant feedback)
+echo ""
+echo "✅ Worktree ready: $WORKTREE_DIR"
+
+if [ "$CHECK_RUNNING" = true ]; then
+  echo "⏳ Cargo check running in background..."
+  echo "📝 Check status: /tech:worktree-status $BRANCH_NAME"
+  echo "📝 Or view log: cat $LOG_FILE"
+elif [ "$SKIP_CHECK" = true ]; then
+  echo "⚡ Cargo check skipped (--fast / --no-check mode)"
+fi
+
+echo ""
+echo "🚀 Next steps:"
+echo ""
+echo "If Claude Code is running:"
+echo "   1. /exit"
+echo "   2. cd $WORKTREE_DIR"
+echo "   3. claude"
+echo ""
+echo "If Claude Code is NOT running:"
+echo "   cd $WORKTREE_DIR && claude"
+echo ""
+echo "✅ Ready to work!"
+```
+
+## Flags
+
+### `--fast` / `--no-check`
+
+Skip cargo check entirely (instant setup).
+
+**Use when**: Quick fixes, documentation, README changes.
+
+```bash
+/tech:worktree fix/typo --fast
+→ ✅ Ready in 1s (no cargo check)
+```
+
+## Status Check
+
+```bash
+/tech:worktree-status feature/new-filter
+→ ✅ Cargo check passed (0 errors)
+→ ❌ Cargo check failed (see log)
+→ ⏳ Still running...
+```
+
+## Cleanup
+
+```bash
+/tech:remove-worktree feature/new-filter
+# Or manually:
+git worktree remove .worktrees/feature-new-filter
+git worktree prune
+```
+
+## Troubleshooting
+
+**"worktree already exists"**
+```bash
+git worktree remove .worktrees/$BRANCH_NAME
+# Then retry
+```
+
+**"branch already exists"**
+```bash
+git branch -D $BRANCH_NAME
+# Then retry
+```

--- a/.claude/rules/rust-patterns.md
+++ b/.claude/rules/rust-patterns.md
@@ -1,0 +1,253 @@
+# Rust Patterns — RTK Development Rules
+
+RTK-specific Rust idioms and constraints. Applied to all code in this repository.
+
+## Non-Negotiable RTK Rules
+
+These override general Rust conventions:
+
+1. **No async** — Zero `tokio`, `async-std`, `futures`. Single-threaded by design. Async adds 5-10ms startup.
+2. **No `unwrap()` in production** — Use `.context("description")?`. Tests: use `expect("reason")`.
+3. **Lazy regex** — `Regex::new()` inside a function recompiles on every call. Always `lazy_static!`.
+4. **Fallback pattern** — If filter fails, execute raw command unchanged. Never block the user.
+5. **Exit code propagation** — `std::process::exit(code)` if underlying command fails.
+
+## Error Handling
+
+### Always context, always anyhow
+
+```rust
+use anyhow::{Context, Result};
+
+// ✅ Correct
+fn read_config(path: &Path) -> Result<Config> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read config: {}", path.display()))?;
+    toml::from_str(&content)
+        .context("Failed to parse config TOML")
+}
+
+// ❌ Wrong — no context
+fn read_config(path: &Path) -> Result<Config> {
+    let content = fs::read_to_string(path)?;
+    Ok(toml::from_str(&content)?)
+}
+
+// ❌ Wrong — panic in production
+fn read_config(path: &Path) -> Config {
+    let content = fs::read_to_string(path).unwrap();
+    toml::from_str(&content).unwrap()
+}
+```
+
+### Fallback pattern (mandatory for all filters)
+
+```rust
+pub fn run(args: MyArgs) -> Result<()> {
+    let output = execute_command("mycmd", &args.to_cmd_args())
+        .context("Failed to execute mycmd")?;
+
+    let filtered = filter_output(&output.stdout)
+        .unwrap_or_else(|e| {
+            eprintln!("rtk: filter warning: {}", e);
+            output.stdout.clone()  // Passthrough on failure
+        });
+
+    tracking::record("mycmd", &output.stdout, &filtered)?;
+    print!("{}", filtered);
+
+    if !output.status.success() {
+        std::process::exit(output.status.code().unwrap_or(1));
+    }
+    Ok(())
+}
+```
+
+## Regex — Always lazy_static
+
+```rust
+use lazy_static::lazy_static;
+use regex::Regex;
+
+lazy_static! {
+    static ref ERROR_RE: Regex = Regex::new(r"^error\[").unwrap();
+    static ref HASH_RE: Regex = Regex::new(r"^[0-9a-f]{7,40}").unwrap();
+}
+
+// ✅ Correct — regex compiled once at first use
+fn is_error_line(line: &str) -> bool {
+    ERROR_RE.is_match(line)
+}
+
+// ❌ Wrong — recompiles every call (kills performance)
+fn is_error_line(line: &str) -> bool {
+    let re = Regex::new(r"^error\[").unwrap();
+    re.is_match(line)
+}
+```
+
+Note: `lazy_static!` with `.unwrap()` for initialization is the **established RTK pattern** — it's acceptable because a bad regex literal is a programming error caught at first use.
+
+## Ownership — Borrow Over Clone
+
+```rust
+// ✅ Prefer borrows in filter functions
+fn filter_lines<'a>(input: &'a str) -> Vec<&'a str> {
+    input.lines()
+        .filter(|line| !line.is_empty())
+        .collect()
+}
+
+// ✅ Clone only when you need to own the data
+fn filter_output(input: &str) -> String {
+    input.lines()
+        .filter(|line| !line.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+// ❌ Unnecessary clone
+fn filter_output(input: &str) -> String {
+    let owned = input.to_string();  // Clone for no reason
+    owned.lines()
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+```
+
+## Iterators Over Loops
+
+```rust
+// ✅ Iterator chain — idiomatic
+let errors: Vec<&str> = output.lines()
+    .filter(|l| l.starts_with("error"))
+    .take(20)
+    .collect();
+
+// ❌ Manual loop — verbose
+let mut errors = Vec::new();
+for line in output.lines() {
+    if line.starts_with("error") {
+        errors.push(line);
+        if errors.len() >= 20 { break; }
+    }
+}
+```
+
+## Struct Patterns
+
+### Builder for complex args
+
+```rust
+// Use Builder when struct has >5 optional fields
+pub struct FilterConfig {
+    max_lines: usize,
+    show_warnings: bool,
+    strip_ansi: bool,
+}
+
+impl FilterConfig {
+    pub fn new() -> Self {
+        Self { max_lines: 100, show_warnings: false, strip_ansi: true }
+    }
+    pub fn max_lines(mut self, n: usize) -> Self { self.max_lines = n; self }
+    pub fn show_warnings(mut self, v: bool) -> Self { self.show_warnings = v; self }
+}
+
+// Usage: FilterConfig::new().max_lines(50).show_warnings(true)
+```
+
+### Newtype for validation
+
+```rust
+// Newtype prevents misuse of raw strings
+pub struct CommandName(String);
+
+impl CommandName {
+    pub fn new(name: &str) -> Result<Self> {
+        if name.contains(';') || name.contains('|') {
+            anyhow::bail!("Invalid command name: contains shell metacharacters");
+        }
+        Ok(Self(name.to_string()))
+    }
+}
+```
+
+## String Handling
+
+```rust
+// String: owned, heap-allocated
+// &str: borrowed slice (prefer in function signatures)
+// &String: almost never — use &str instead
+
+fn process(input: &str) -> String {  // ✅ &str in, String out
+    input.trim().to_uppercase()
+}
+
+fn process(input: &String) -> String {  // ❌ Unnecessary &String
+    input.trim().to_uppercase()
+}
+```
+
+## Match — Exhaustive and Explicit
+
+```rust
+// ✅ Exhaustive match with explicit cases
+match result {
+    Ok(output) => process(output),
+    Err(e) => {
+        eprintln!("rtk: filter warning: {}", e);
+        fallback()
+    }
+}
+
+// ❌ Silent swallow — catastrophic in RTK (user gets no output)
+match result {
+    Ok(output) => process(output),
+    Err(_) => {}
+}
+```
+
+## Module Structure
+
+Every `*_cmd.rs` follows this pattern:
+
+```rust
+// 1. Imports
+use anyhow::{Context, Result};
+use lazy_static::lazy_static;
+use regex::Regex;
+
+// 2. Types (args struct)
+pub struct MyArgs { ... }
+
+// 3. Lazy regexes
+lazy_static! { static ref MY_RE: Regex = ...; }
+
+// 4. Public entry point
+pub fn run(args: MyArgs) -> Result<()> { ... }
+
+// 5. Private filter functions
+fn filter_output(input: &str) -> Result<String> { ... }
+
+// 6. Tests (always present)
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn count_tokens(s: &str) -> usize { s.split_whitespace().count() }
+    // ... snapshot tests, savings tests
+}
+```
+
+## Anti-Patterns (RTK-Specific)
+
+| Pattern | Problem | Fix |
+|---------|---------|-----|
+| `Regex::new()` in function | Recompiles every call | `lazy_static!` |
+| `unwrap()` in production | Panic breaks user workflow | `.context()?` |
+| `tokio::main` or `async fn` | +5-10ms startup | Blocking I/O only |
+| Silent match `Err(_) => {}` | User gets no output | Log warning + fallback |
+| `println!` in filter path | Debug artifact in output | Remove or `eprintln!` |
+| Returning early without exit code | CI/CD thinks command succeeded | `std::process::exit(code)` |
+| `clone()` of large strings | Extra allocation in hot path | Borrow with `&str` |

--- a/.claude/rules/search-strategy.md
+++ b/.claude/rules/search-strategy.md
@@ -1,0 +1,142 @@
+# Search Strategy — RTK Codebase Navigation
+
+Efficient search patterns for RTK's Rust codebase.
+
+## Priority Order
+
+1. **Grep** (exact pattern, fast) → for known symbols/strings
+2. **Glob** (file discovery) → for finding modules by name
+3. **Read** (full file) → only after locating the right file
+4. **Explore agent** (broad research) → last resort for >3 queries
+
+Never use Bash for search (`find`, `grep`, `rg`) — use dedicated tools.
+
+## RTK Module Map
+
+```
+src/
+├── main.rs           ← Commands enum + routing (start here for any command)
+├── git.rs            ← Git operations (log, status, diff)
+├── runner.rs         ← Cargo commands (test, build, clippy, check)
+├── gh_cmd.rs         ← GitHub CLI (pr, run, issue)
+├── grep_cmd.rs       ← Code search output filtering
+├── ls.rs             ← Directory listing
+├── read.rs           ← File reading with filter levels
+├── filter.rs         ← Language-aware code filtering engine
+├── tracking.rs       ← SQLite token metrics
+├── config.rs         ← ~/.config/rtk/config.toml
+├── tee.rs            ← Raw output recovery on failure
+├── utils.rs          ← strip_ansi, truncate, execute_command
+├── init.rs           ← rtk init command
+└── *_cmd.rs          ← All other command modules
+```
+
+## Common Search Patterns
+
+### "Where is command X handled?"
+
+```
+# Step 1: Find the routing
+Grep pattern="Gh\|Cargo\|Git\|Grep" path="src/main.rs" output_mode="content"
+
+# Step 2: Follow to module
+Read file_path="src/gh_cmd.rs"
+```
+
+### "Where is function X defined?"
+
+```
+Grep pattern="fn filter_git_log\|fn run\b" type="rust"
+```
+
+### "All command modules"
+
+```
+Glob pattern="src/*_cmd.rs"
+# Then: src/git.rs, src/runner.rs for non-*_cmd.rs modules
+```
+
+### "Find all lazy_static regex definitions"
+
+```
+Grep pattern="lazy_static!" type="rust" output_mode="content"
+```
+
+### "Find unwrap() outside tests"
+
+```
+Grep pattern="\.unwrap()" type="rust" output_mode="content"
+# Then manually filter out #[cfg(test)] blocks
+```
+
+### "Which modules have tests?"
+
+```
+Grep pattern="#\[cfg\(test\)\]" type="rust" output_mode="files_with_matches"
+```
+
+### "Find token savings assertions"
+
+```
+Grep pattern="count_tokens\|savings" type="rust" output_mode="content"
+```
+
+### "Find test fixtures"
+
+```
+Glob pattern="tests/fixtures/*.txt"
+```
+
+## RTK-Specific Navigation Rules
+
+### Adding a new filter
+
+1. Check `src/main.rs` for Commands enum structure
+2. Check existing `*_cmd.rs` for patterns to follow (e.g., `src/gh_cmd.rs`)
+3. Check `src/utils.rs` for shared helpers before reimplementing
+4. Check `tests/fixtures/` for existing fixture patterns
+
+### Debugging filter output
+
+1. Start with `src/<cmd>_cmd.rs` → find `run()` function
+2. Trace filter function (usually `filter_<cmd>()`)
+3. Check `lazy_static!` regex patterns in same file
+4. Check `src/utils.rs::strip_ansi()` if ANSI codes involved
+
+### Tracking/metrics issues
+
+1. `src/tracking.rs` → `track_command()` function
+2. `src/config.rs` → `tracking.database_path` field
+3. `RTK_DB_PATH` env var overrides config
+
+### Configuration issues
+
+1. `src/config.rs` → `RtkConfig` struct
+2. `src/init.rs` → `rtk init` command
+3. Config file: `~/.config/rtk/config.toml`
+4. Filter files: `~/.config/rtk/filters/` (global) or `.rtk/filters/` (project)
+
+## TOML Filter DSL Navigation
+
+```
+Glob pattern=".rtk/filters/*.toml"         # Project-local filters
+Glob pattern="src/filter_*.rs"             # TOML filter engine
+Grep pattern="FilterRule\|FilterConfig" type="rust"
+```
+
+## Anti-Patterns
+
+❌ **Don't** read all `*_cmd.rs` files to find one function — use Grep first
+❌ **Don't** use Bash `find src -name "*.rs"` — use Glob
+❌ **Don't** read `main.rs` entirely to find a module — Grep for the command name
+❌ **Don't** search `Cargo.toml` for dependencies with Bash — use Grep with `glob="Cargo.toml"`
+
+## Dependency Check
+
+```
+# Check if a crate is already used (before adding)
+Grep pattern="^regex\|^anyhow\|^rusqlite" glob="Cargo.toml" output_mode="content"
+
+# Check if async is creeping in (forbidden)
+Grep pattern="tokio\|async-std\|futures\|async fn" type="rust"
+```

--- a/.claude/skills/code-simplifier/SKILL.md
+++ b/.claude/skills/code-simplifier/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: code-simplifier
+description: Review RTK Rust code for idiomatic simplification. Detects over-engineering, unnecessary allocations, verbose patterns. Applies Rust idioms without changing behavior.
+triggers:
+  - "simplify"
+  - "too verbose"
+  - "over-engineered"
+  - "refactor this"
+  - "make this idiomatic"
+---
+
+# RTK Code Simplifier
+
+Review and simplify Rust code in RTK while respecting the project's constraints.
+
+## Constraints (never simplify away)
+
+- `lazy_static!` regex — cannot be moved inside functions even if "simpler"
+- `.context()` on every `?` — verbose but mandatory
+- Fallback to raw command — never remove even if it looks like dead code
+- Exit code propagation — never simplify to `Ok(())`
+- `#[cfg(test)] mod tests` — never remove test modules
+
+## Simplification Patterns
+
+### 1. Iterator chains over manual loops
+
+```rust
+// ❌ Verbose
+let mut result = Vec::new();
+for line in input.lines() {
+    let trimmed = line.trim();
+    if !trimmed.is_empty() && trimmed.starts_with("error") {
+        result.push(trimmed.to_string());
+    }
+}
+
+// ✅ Idiomatic
+let result: Vec<String> = input.lines()
+    .map(|l| l.trim())
+    .filter(|l| !l.is_empty() && l.starts_with("error"))
+    .map(str::to_string)
+    .collect();
+```
+
+### 2. String building
+
+```rust
+// ❌ Verbose push loop
+let mut out = String::new();
+for (i, line) in lines.iter().enumerate() {
+    out.push_str(line);
+    if i < lines.len() - 1 {
+        out.push('\n');
+    }
+}
+
+// ✅ join
+let out = lines.join("\n");
+```
+
+### 3. Option/Result chaining
+
+```rust
+// ❌ Nested match
+let result = match maybe_value {
+    Some(v) => match transform(v) {
+        Ok(r) => r,
+        Err(_) => default,
+    },
+    None => default,
+};
+
+// ✅ Chained
+let result = maybe_value
+    .and_then(|v| transform(v).ok())
+    .unwrap_or(default);
+```
+
+### 4. Struct destructuring
+
+```rust
+// ❌ Repeated field access
+fn process(args: &MyArgs) -> String {
+    format!("{} {}", args.command, args.subcommand)
+}
+
+// ✅ Destructure
+fn process(&MyArgs { ref command, ref subcommand, .. }: &MyArgs) -> String {
+    format!("{} {}", command, subcommand)
+}
+```
+
+### 5. Early returns over nesting
+
+```rust
+// ❌ Deeply nested
+fn filter(input: &str) -> Option<String> {
+    if !input.is_empty() {
+        if let Some(line) = input.lines().next() {
+            if line.starts_with("error") {
+                return Some(line.to_string());
+            }
+        }
+    }
+    None
+}
+
+// ✅ Early return
+fn filter(input: &str) -> Option<String> {
+    if input.is_empty() { return None; }
+    let line = input.lines().next()?;
+    if !line.starts_with("error") { return None; }
+    Some(line.to_string())
+}
+```
+
+### 6. Avoid redundant clones
+
+```rust
+// ❌ Unnecessary clone
+fn filter_output(input: &str) -> String {
+    let s = input.to_string();  // Pointless clone
+    s.lines().filter(|l| !l.is_empty()).collect::<Vec<_>>().join("\n")
+}
+
+// ✅ Work with &str
+fn filter_output(input: &str) -> String {
+    input.lines().filter(|l| !l.is_empty()).collect::<Vec<_>>().join("\n")
+}
+```
+
+### 7. Use `if let` for single-variant match
+
+```rust
+// ❌ Full match for one variant
+match output {
+    Ok(s) => process(&s),
+    Err(_) => {},
+}
+
+// ✅ if let (but still handle errors in RTK — don't silently drop)
+if let Ok(s) = output {
+    process(&s);
+}
+// Note: in RTK filters, always handle Err with eprintln! + fallback
+```
+
+## RTK-Specific Checks
+
+Run these after simplification:
+
+```bash
+# Verify no regressions
+cargo fmt --all && cargo clippy --all-targets && cargo test
+
+# Verify no new regex in functions
+grep -n "Regex::new" src/<file>.rs
+# All should be inside lazy_static! blocks
+
+# Verify no new unwrap in production
+grep -n "\.unwrap()" src/<file>.rs
+# Should only appear inside #[cfg(test)] blocks
+```
+
+## What NOT to Simplify
+
+- `lazy_static! { static ref RE: Regex = Regex::new(...).unwrap(); }` — the `.unwrap()` here is acceptable, it's init-time
+- `.context("description")?` chains — verbose but required
+- The fallback match arm `Err(e) => { eprintln!(...); raw_output }` — looks redundant but is the safety net
+- `std::process::exit(code)` at end of run() — looks like it could be `Ok(())`but it isn't

--- a/.claude/skills/design-patterns/SKILL.md
+++ b/.claude/skills/design-patterns/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: design-patterns
+description: Rust design patterns for RTK. Newtype, Builder, RAII, Trait Objects, State Machine. Applied to CLI filter modules. Use when designing new modules or refactoring existing ones.
+triggers:
+  - "design pattern"
+  - "how to structure"
+  - "best pattern for"
+  - "refactor to pattern"
+---
+
+# RTK Rust Design Patterns
+
+Patterns that apply to RTK's filter module architecture. Focused on CLI tool patterns, not web/service patterns.
+
+## Pattern 1: Newtype (Type Safety)
+
+Use when: wrapping primitive types to prevent misuse (command names, paths, token counts).
+
+```rust
+// Without Newtype — easy to mix up
+fn track(input_tokens: usize, output_tokens: usize) { ... }
+track(output_tokens, input_tokens);  // Silent bug!
+
+// With Newtype — compile error on swap
+pub struct InputTokens(pub usize);
+pub struct OutputTokens(pub usize);
+fn track(input: InputTokens, output: OutputTokens) { ... }
+track(OutputTokens(100), InputTokens(400));  // Compile error ✅
+```
+
+```rust
+// Practical RTK example: command name validation
+pub struct CommandName(String);
+impl CommandName {
+    pub fn new(s: &str) -> Result<Self> {
+        if s.contains(';') || s.contains('|') || s.contains('`') {
+            anyhow::bail!("Invalid command name: shell metacharacters");
+        }
+        Ok(Self(s.to_string()))
+    }
+    pub fn as_str(&self) -> &str { &self.0 }
+}
+```
+
+## Pattern 2: Builder (Complex Configuration)
+
+Use when: a struct has 4+ optional fields, many with defaults.
+
+```rust
+#[derive(Default)]
+pub struct FilterConfig {
+    max_lines: Option<usize>,
+    strip_ansi: bool,
+    show_warnings: bool,
+    truncate_at: Option<usize>,
+}
+
+impl FilterConfig {
+    pub fn new() -> Self { Self::default() }
+    pub fn max_lines(mut self, n: usize) -> Self { self.max_lines = Some(n); self }
+    pub fn strip_ansi(mut self, v: bool) -> Self { self.strip_ansi = v; self }
+    pub fn show_warnings(mut self, v: bool) -> Self { self.show_warnings = v; self }
+}
+
+// Usage — readable, no positional arg confusion
+let config = FilterConfig::new()
+    .max_lines(50)
+    .strip_ansi(true)
+    .show_warnings(false);
+```
+
+When NOT to use Builder: if the struct has 1-3 fields with obvious meaning. Over-engineering for simple cases.
+
+## Pattern 3: State Machine (Parser/Filter Flows)
+
+Use when: parsing multi-section output (test results, build output) where context changes behavior.
+
+```rust
+// RTK example: pytest output parsing
+#[derive(Debug, PartialEq)]
+enum ParseState {
+    LookingForTests,
+    InTestOutput,
+    InFailureSummary,
+    Done,
+}
+
+fn parse_pytest(input: &str) -> String {
+    let mut state = ParseState::LookingForTests;
+    let mut failures = Vec::new();
+
+    for line in input.lines() {
+        match state {
+            ParseState::LookingForTests => {
+                if line.contains("FAILED") || line.contains("ERROR") {
+                    state = ParseState::InFailureSummary;
+                    failures.push(line);
+                }
+            }
+            ParseState::InFailureSummary => {
+                if line.starts_with("=====") { state = ParseState::Done; }
+                else { failures.push(line); }
+            }
+            ParseState::Done => break,
+            _ => {}
+        }
+    }
+    failures.join("\n")
+}
+```
+
+## Pattern 4: Trait Object (Command Dispatch)
+
+Use when: different command families need the same interface. Avoids massive match arms.
+
+```rust
+// Define a common interface for filters
+pub trait OutputFilter {
+    fn filter(&self, input: &str) -> Result<String>;
+    fn command_name(&self) -> &str;
+}
+
+pub struct GitFilter;
+pub struct CargoFilter;
+
+impl OutputFilter for GitFilter {
+    fn filter(&self, input: &str) -> Result<String> { filter_git(input) }
+    fn command_name(&self) -> &str { "git" }
+}
+
+// RTK currently uses match-based dispatch in main.rs (simpler, no dynamic dispatch overhead)
+// Trait objects are useful if filter registry becomes dynamic (e.g., TOML-loaded plugins)
+```
+
+Note: RTK's current `match` dispatch in `main.rs` is intentional — static dispatch, zero overhead. Only move to trait objects if the match arm count exceeds ~20 commands.
+
+## Pattern 5: RAII (Resource Management)
+
+Use when: managing resources that need cleanup (temp files, SQLite connections).
+
+```rust
+// RTK tee.rs — RAII for temp output files
+pub struct TeeFile {
+    path: PathBuf,
+}
+
+impl TeeFile {
+    pub fn create(content: &str) -> Result<Self> {
+        let path = tee_path()?;
+        fs::write(&path, content)
+            .with_context(|| format!("Failed to write tee file: {}", path.display()))?;
+        Ok(Self { path })
+    }
+
+    pub fn path(&self) -> &Path { &self.path }
+}
+
+// No explicit cleanup needed — file persists intentionally (rotation handled separately)
+// If cleanup were needed: impl Drop { fn drop(&mut self) { let _ = fs::remove_file(&self.path); } }
+```
+
+## Pattern 6: Strategy (Swappable Filter Logic)
+
+Use when: a command has multiple filtering modes (e.g., compact vs. verbose).
+
+```rust
+pub enum FilterMode {
+    Compact,    // Show only failures/errors
+    Summary,    // Show counts + top errors
+    Full,       // Pass through unchanged
+}
+
+pub fn apply_filter(input: &str, mode: FilterMode) -> String {
+    match mode {
+        FilterMode::Compact => filter_compact(input),
+        FilterMode::Summary => filter_summary(input),
+        FilterMode::Full => input.to_string(),
+    }
+}
+```
+
+## Pattern 7: Extension Trait (Add Methods to External Types)
+
+Use when: you need to add methods to types you don't own (like `&str` for RTK-specific parsing).
+
+```rust
+pub trait RtkStrExt {
+    fn is_error_line(&self) -> bool;
+    fn is_warning_line(&self) -> bool;
+    fn token_count(&self) -> usize;
+}
+
+impl RtkStrExt for str {
+    fn is_error_line(&self) -> bool {
+        self.starts_with("error") || self.contains("[E")
+    }
+    fn is_warning_line(&self) -> bool {
+        self.starts_with("warning")
+    }
+    fn token_count(&self) -> usize {
+        self.split_whitespace().count()
+    }
+}
+
+// Usage
+if line.is_error_line() { ... }
+let tokens = output.token_count();
+```
+
+## RTK Pattern Selection Guide
+
+| Situation | Pattern | Avoid |
+|-----------|---------|-------|
+| New `*_cmd.rs` filter module | Standard module pattern (see CLAUDE.md) | Over-abstracting |
+| 4+ optional config fields | Builder | Struct literal |
+| Multi-phase output parsing | State Machine | Nested if/else |
+| Type-safe wrapper around string | Newtype | Raw `String` |
+| Adding methods to `&str` | Extension Trait | Free functions |
+| Resource with cleanup | RAII / Drop | Manual cleanup |
+| Dynamic filter registry | Trait Object | Match sprawl |
+
+## Anti-Patterns in RTK Context
+
+```rust
+// ❌ Generic over-engineering for one command
+pub trait Filterable<T: CommandArgs + Send + Sync + 'static> { ... }
+
+// ✅ Just write the function
+pub fn filter_git_log(input: &str) -> Result<String> { ... }
+
+// ❌ Singleton registry with global state
+static FILTER_REGISTRY: Mutex<HashMap<String, Box<dyn Filter>>> = ...;
+
+// ✅ Match in main.rs — simple, zero overhead, easy to trace
+
+// ❌ Async traits for "future-proofing"
+#[async_trait]
+pub trait Filter { async fn apply(&self, input: &str) -> Result<String>; }
+
+// ✅ Synchronous — RTK is single-threaded by design
+pub trait Filter { fn apply(&self, input: &str) -> Result<String>; }
+```

--- a/.claude/skills/performance/SKILL.md
+++ b/.claude/skills/performance/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: performance
+description: RTK CLI performance analysis and optimization. Startup time (<10ms), binary size (<5MB), regex compilation, memory usage. Use when adding dependencies, changing initialization, or suspecting regressions.
+triggers:
+  - "startup time"
+  - "performance regression"
+  - "too slow"
+  - "benchmark"
+  - "binary size"
+  - "memory usage"
+---
+
+# RTK Performance Analysis
+
+## Hard Targets (Non-Negotiable)
+
+| Metric | Target | Blocker |
+|--------|--------|---------|
+| Startup time | <10ms | Release blocker |
+| Binary size (stripped) | <5MB | Release blocker |
+| Memory (resident) | <5MB | Release blocker |
+| Token savings per filter | ≥60% | Release blocker |
+
+## Benchmark Startup Time
+
+```bash
+# Install hyperfine (once)
+brew install hyperfine
+
+# Baseline (before changes)
+hyperfine 'rtk git status' --warmup 3 --export-json /tmp/before.json
+
+# After changes — rebuild first
+cargo build --release
+
+# Compare against installed
+hyperfine 'target/release/rtk git status' 'rtk git status' --warmup 3
+
+# Target: <10ms mean time
+```
+
+## Check Binary Size
+
+```bash
+# Release build with strip=true (already in Cargo.toml)
+cargo build --release
+ls -lh target/release/rtk
+# Should be <5MB
+
+# If too large — check what's contributing
+cargo bloat --release --crates
+cargo bloat --release -n 20
+# Install: cargo install cargo-bloat
+```
+
+## Memory Usage
+
+```bash
+# macOS
+/usr/bin/time -l target/release/rtk git status 2>&1 | grep "maximum resident"
+# Target: <5,000,000 bytes (5MB)
+
+# Linux
+/usr/bin/time -v target/release/rtk git status 2>&1 | grep "Maximum resident"
+# Target: <5,000 kbytes
+```
+
+## Regex Compilation Audit
+
+Regex compilation on every function call is a common perf killer:
+
+```bash
+# Find all Regex::new calls
+grep -n "Regex::new" src/*.rs
+
+# Verify ALL are inside lazy_static! blocks
+# Any Regex::new outside lazy_static! = performance bug
+```
+
+```rust
+// ❌ Recompiles on every filter_line() call
+fn filter_line(line: &str) -> bool {
+    let re = Regex::new(r"^error").unwrap();  // BAD
+    re.is_match(line)
+}
+
+// ✅ Compiled once at first use
+lazy_static! {
+    static ref ERROR_RE: Regex = Regex::new(r"^error").unwrap();
+}
+fn filter_line(line: &str) -> bool {
+    ERROR_RE.is_match(line)  // GOOD
+}
+```
+
+## Dependency Impact Assessment
+
+Before adding any new crate:
+
+```bash
+# Check startup impact (measure before adding)
+hyperfine 'rtk git status' --warmup 3
+
+# Add dependency to Cargo.toml
+# Rebuild
+cargo build --release
+
+# Measure after
+hyperfine 'target/release/rtk git status' --warmup 3
+
+# If startup increased >1ms — investigate
+# If startup increased >3ms — reject the dependency
+```
+
+### Forbidden dependencies
+
+| Crate | Reason | Alternative |
+|-------|--------|-------------|
+| `tokio` | +5-10ms startup | Blocking `std::process::Command` |
+| `async-std` | +5-10ms startup | Blocking I/O |
+| `rayon` | Thread pool init overhead | Sequential iteration |
+| `reqwest` | Pulls tokio | `ureq` (blocking) if HTTP needed |
+
+### Dependency weight check
+
+```bash
+# After cargo build --release
+cargo build --release --timings
+# Open target/cargo-timings/cargo-timing.html
+# Look for crates with long compile times (correlates with complexity)
+```
+
+## Allocation Profiling
+
+```bash
+# macOS — use Instruments
+instruments -t Allocations target/release/rtk git log -10
+
+# Or use cargo-instruments
+cargo install cargo-instruments
+cargo instruments --release -t Allocations -- git log -10
+```
+
+Common RTK allocation hotspots:
+
+```rust
+// ❌ Allocates new String on every line
+let lines: Vec<String> = input.lines().map(|l| l.to_string()).collect();
+
+// ✅ Borrow slices
+let lines: Vec<&str> = input.lines().collect();
+
+// ❌ Clone large output unnecessarily
+let raw_copy = output.stdout.clone();
+
+// ✅ Use reference until you actually need to own
+let display = &output.stdout;
+```
+
+## Token Savings Measurement
+
+```rust
+// In tests — always verify claims
+fn count_tokens(text: &str) -> usize {
+    text.split_whitespace().count()
+}
+
+#[test]
+fn test_savings_claim() {
+    let input = include_str!("../tests/fixtures/mycmd_raw.txt");
+    let output = filter_output(input).unwrap();
+
+    let input_tokens = count_tokens(input);
+    let output_tokens = count_tokens(&output);
+    let savings = 100.0 * (1.0 - output_tokens as f64 / input_tokens as f64);
+
+    assert!(
+        savings >= 60.0,
+        "Expected ≥60% savings, got {:.1}% ({} → {} tokens)",
+        savings, input_tokens, output_tokens
+    );
+}
+```
+
+## Before/After Regression Check
+
+Template for any performance-sensitive change:
+
+```bash
+# 1. Baseline
+cargo build --release
+hyperfine 'target/release/rtk git status' --warmup 5 --export-json /tmp/before.json
+/usr/bin/time -l target/release/rtk git status 2>&1 | grep "maximum resident"
+ls -lh target/release/rtk
+
+# 2. Make changes
+# ... edit code ...
+
+# 3. Rebuild and compare
+cargo build --release
+hyperfine 'target/release/rtk git status' --warmup 5 --export-json /tmp/after.json
+/usr/bin/time -l target/release/rtk git status 2>&1 | grep "maximum resident"
+ls -lh target/release/rtk
+
+# 4. Compare
+# Startup: jq '.results[0].mean' /tmp/before.json /tmp/after.json
+# If after > before + 1ms: investigate
+# If after > 10ms: regression, do not merge
+```

--- a/.claude/skills/tdd-rust/SKILL.md
+++ b/.claude/skills/tdd-rust/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: tdd-rust
+description: TDD workflow for RTK filter development. Red-Green-Refactor with Rust idioms. Real fixtures, token savings assertions, snapshot tests with insta. Auto-triggers on new filter implementation.
+triggers:
+  - "new filter"
+  - "implement filter"
+  - "add command"
+  - "write tests for"
+  - "test coverage"
+  - "fix failing test"
+---
+
+# RTK TDD Workflow
+
+Enforce Red-Green-Refactor for all RTK filter development.
+
+## The Loop
+
+```
+1. RED   — Write failing test with real fixture
+2. GREEN — Implement minimum code to pass
+3. REFACTOR — Clean up, verify still passing
+4. SAVINGS — Verify ≥60% token reduction
+5. SNAPSHOT — Lock output format with insta
+```
+
+## Step 1: Real Fixture First
+
+Never write synthetic test data. Capture real command output:
+
+```bash
+# Capture real output from the actual command
+git log -20 > tests/fixtures/git_log_raw.txt
+cargo test 2>&1 > tests/fixtures/cargo_test_raw.txt
+cargo clippy 2>&1 > tests/fixtures/cargo_clippy_raw.txt
+gh pr view 42 > tests/fixtures/gh_pr_view_raw.txt
+
+# For commands with ANSI codes — capture as-is
+script -q /dev/null cargo test 2>&1 > tests/fixtures/cargo_test_ansi_raw.txt
+```
+
+Fixture naming: `tests/fixtures/<command>_raw.txt`
+
+## Step 2: Write the Test (Red)
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use insta::assert_snapshot;
+
+    fn count_tokens(s: &str) -> usize {
+        s.split_whitespace().count()
+    }
+
+    // Test 1: Output format (snapshot)
+    #[test]
+    fn test_filter_output_format() {
+        let input = include_str!("../tests/fixtures/mycmd_raw.txt");
+        let output = filter_mycmd(input).expect("filter should not fail");
+        assert_snapshot!(output);
+    }
+
+    // Test 2: Token savings ≥60%
+    #[test]
+    fn test_token_savings() {
+        let input = include_str!("../tests/fixtures/mycmd_raw.txt");
+        let output = filter_mycmd(input).expect("filter should not fail");
+
+        let input_tokens = count_tokens(input);
+        let output_tokens = count_tokens(&output);
+        let savings = 100.0 * (1.0 - output_tokens as f64 / input_tokens as f64);
+
+        assert!(
+            savings >= 60.0,
+            "Expected ≥60% token savings, got {:.1}% ({} → {} tokens)",
+            savings, input_tokens, output_tokens
+        );
+    }
+
+    // Test 3: Edge cases
+    #[test]
+    fn test_empty_input() {
+        let result = filter_mycmd("");
+        assert!(result.is_ok());
+        // Empty input = empty output OR passthrough, never panic
+    }
+
+    #[test]
+    fn test_malformed_input() {
+        let result = filter_mycmd("not valid command output\nrandom text\n");
+        // Must not panic — either filter best-effort or return input unchanged
+        assert!(result.is_ok());
+    }
+}
+```
+
+Run: `cargo test` → should fail (function doesn't exist yet).
+
+## Step 3: Minimum Implementation (Green)
+
+```rust
+// src/mycmd_cmd.rs
+
+use anyhow::{Context, Result};
+use lazy_static::lazy_static;
+use regex::Regex;
+
+lazy_static! {
+    static ref ERROR_RE: Regex = Regex::new(r"^error").unwrap();
+}
+
+pub fn filter_mycmd(input: &str) -> Result<String> {
+    if input.is_empty() {
+        return Ok(String::new());
+    }
+
+    let filtered: Vec<&str> = input.lines()
+        .filter(|line| ERROR_RE.is_match(line))
+        .collect();
+
+    Ok(filtered.join("\n"))
+}
+```
+
+Run: `cargo test` → green.
+
+## Step 4: Accept Snapshot
+
+```bash
+# First run creates the snapshot
+cargo test test_filter_output_format
+
+# Review what was captured
+cargo insta review
+# Press 'a' to accept
+
+# Snapshot saved to src/snapshots/mycmd_cmd__tests__test_filter_output_format.snap
+```
+
+## Step 5: Wire to main.rs (Integration)
+
+```rust
+// src/main.rs
+mod mycmd_cmd;
+
+#[derive(Subcommand)]
+pub enum Commands {
+    // ... existing commands ...
+    Mycmd(MycmdArgs),
+}
+
+// In match:
+Commands::Mycmd(args) => mycmd_cmd::run(args),
+```
+
+```rust
+// src/mycmd_cmd.rs — add run() function
+pub fn run(args: MycmdArgs) -> Result<()> {
+    let output = execute_command("mycmd", &args.to_vec())
+        .context("Failed to execute mycmd")?;
+
+    let filtered = filter_mycmd(&output.stdout)
+        .unwrap_or_else(|e| {
+            eprintln!("rtk: filter warning: {}", e);
+            output.stdout.clone()
+        });
+
+    tracking::record("mycmd", &output.stdout, &filtered)?;
+    print!("{}", filtered);
+
+    if !output.status.success() {
+        std::process::exit(output.status.code().unwrap_or(1));
+    }
+    Ok(())
+}
+```
+
+## Step 6: Quality Gate
+
+```bash
+cargo fmt --all && cargo clippy --all-targets && cargo test
+```
+
+All 3 must pass. Zero clippy warnings.
+
+## Arrange-Act-Assert Pattern
+
+```rust
+#[test]
+fn test_filters_only_errors() {
+    // Arrange
+    let input = "info: starting build\nerror[E0001]: undefined\nwarning: unused\n";
+
+    // Act
+    let output = filter_mycmd(input).expect("should succeed");
+
+    // Assert
+    assert!(output.contains("error[E0001]"), "Should keep error lines");
+    assert!(!output.contains("info:"), "Should drop info lines");
+    assert!(!output.contains("warning:"), "Should drop warning lines");
+}
+```
+
+## RTK-Specific Test Patterns
+
+### Test ANSI stripping
+
+```rust
+#[test]
+fn test_strips_ansi_codes() {
+    let input = "\x1b[32mSuccess\x1b[0m\n\x1b[31merror: failed\x1b[0m\n";
+    let output = filter_mycmd(input).expect("should succeed");
+    assert!(!output.contains("\x1b["), "ANSI codes should be stripped");
+    assert!(output.contains("error: failed"), "Content should be preserved");
+}
+```
+
+### Test fallback behavior
+
+```rust
+#[test]
+fn test_filter_handles_unexpected_format() {
+    // Give it something completely unexpected
+    let input = "completely unexpected\x00binary\xff data";
+    // Should not panic — returns Ok() with either empty or passthrough
+    let result = filter_mycmd(input);
+    assert!(result.is_ok(), "Filter must not panic on unexpected input");
+}
+```
+
+### Test savings at multiple sizes
+
+```rust
+#[test]
+fn test_savings_large_output() {
+    // 1000-line fixture → must still hit ≥60%
+    let large_input: String = (0..1000)
+        .map(|i| format!("info: processing item {}\n", i))
+        .collect();
+    let output = filter_mycmd(&large_input).expect("should succeed");
+
+    let savings = 100.0 * (1.0 - count_tokens(&output) as f64 / count_tokens(&large_input) as f64);
+    assert!(savings >= 60.0, "Large output savings: {:.1}%", savings);
+}
+```
+
+## What "Done" Looks Like
+
+Checklist before moving on:
+
+- [ ] `tests/fixtures/<cmd>_raw.txt` — real command output
+- [ ] `filter_<cmd>()` function returns `Result<String>`
+- [ ] Snapshot test passes and accepted via `cargo insta review`
+- [ ] Token savings test: ≥60% verified
+- [ ] Empty input test: no panic
+- [ ] Malformed input test: no panic
+- [ ] `run()` function with fallback pattern
+- [ ] Registered in `main.rs` Commands enum
+- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test` — all green
+
+## Never Do This
+
+```rust
+// ❌ Synthetic fixture data
+let input = "fake error: something went wrong";  // Not real cargo output
+
+// ❌ Missing savings test
+#[test]
+fn test_filter() {
+    let output = filter_mycmd(input);
+    assert!(!output.is_empty());  // No savings verification
+}
+
+// ❌ unwrap() in production code
+let filtered = filter_mycmd(input).unwrap();  // Panic in prod
+
+// ❌ Regex inside the filter function
+fn filter_mycmd(input: &str) -> Result<String> {
+    let re = Regex::new(r"^error").unwrap();  // Recompiles every call
+    ...
+}
+```

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1488,4 +1488,4 @@ When implementing a new command, consider:
 
 **Last Updated**: 2026-02-22
 **Architecture Version**: 2.2
-**rtk Version**: 0.28.0
+**rtk Version**: 0.28.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This is a fork with critical fixes for git argument parsing and modern JavaScrip
 
 **Verify correct installation:**
 ```bash
-rtk --version  # Should show "rtk 0.28.0" (or newer)
+rtk --version  # Should show "rtk 0.28.2" (or newer)
 rtk gain       # Should show token savings stats (NOT "command not found")
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Download from [releases](https://github.com/rtk-ai/rtk/releases):
 ### Verify Installation
 
 ```bash
-rtk --version   # Should show "rtk 0.28.0"
+rtk --version   # Should show "rtk 0.28.2"
 rtk gain        # Should show token savings stats
 ```
 


### PR DESCRIPTION
## Summary

Port et adaptation de 15 artifacts Claude Code depuis MethodeAristote/ccboard vers RTK. Tout le contexte TypeScript/web a été remplacé par des idiomes Rust, le toolchain cargo, et les contraintes RTK (startup <10ms, savings ≥60%, no async, lazy_static).

## Tableau récap

| Catégorie | Artifact | Description |
|-----------|----------|-------------|
| 🤖 **Agent** | `code-reviewer` (rewrite) | Red flags RTK (Regex::new en fn, unwrap prod, async, no fallback, no savings test), patterns défensifs before/after, 7 questions adversariales |
| 🤖 **Agent** | `system-architect` (new) | Architecture map RTK, patterns filter modules (1-4), guide TOML DSL vs Rust, budget perf (<10ms/<5MB), boundaries modules |
| ⌨️ **Command** | `tech:worktree` | Crée des worktrees git avec `cargo check --all-targets` en background, flags `--fast`/`--no-check` |
| ⌨️ **Command** | `tech:worktree-status` | Vérifie le statut du cargo check background via `/tmp/worktree-cargo-check-{branch}.log` |
| ⌨️ **Command** | `tech:remove-worktree` | Supprime worktree + ref git + branche, protège `master`/`main` |
| ⌨️ **Command** | `tech:clean-worktrees` | Auto-supprime les worktrees sur branches mergées dans master |
| ⌨️ **Command** | `tech:clean-worktree` | Nettoyage interactif avec prompt `y/N` |
| ⌨️ **Command** | `tech:codereview` | Review pre-PR vs `master`, 🔴 checks (unwrap, non-lazy regex, .context(), async deps, savings manquants), mode `--auto` (cargo fmt + clippy + test) |
| ⌨️ **Command** | `tech:audit-codebase` | Audit santé 7 catégories scorées 0-10 : secrets, sécurité, deps (cargo audit), structure, tests, perf, AI patterns |
| 📋 **Rule** | `search-strategy` | Navigation codebase RTK — module map, priorité Grep > Glob > Read > Explore, patterns par cas (filter functions, lazy_static, test coverage, TOML filters) |
| 📋 **Rule** | `rust-patterns` | Non-négociables RTK (no async, lazy_static obligatoire, fallback pattern, exit code propagation) + idiomes Rust (iterators, ownership, error handling, template module) |
| 🛠️ **Skill** | `code-simplifier` | Simplification Rust idiomatique (chains, join, Option chaining, early returns, suppression clones), garde-fous RTK (ne pas toucher lazy_static, .context(), fallback) |
| 🛠️ **Skill** | `performance` | Benchmark startup (hyperfine), binary size (cargo-bloat), memory profiling, audit regex compilation, deps interdits, template before/after regression |
| 🛠️ **Skill** | `design-patterns` | Patterns Rust pour RTK — Newtype, Builder, State Machine (parsers multi-phase), Trait Object, RAII, Extension Trait; guide de sélection + anti-patterns |
| 🛠️ **Skill** | `tdd-rust` | Workflow Red-Green-Refactor complet : capture fixtures réelles, snapshot tests (insta), count_tokens() assertion ≥60%, test fallback, test ANSI stripping, checklist "done" |

## Aucun changement Rust

Ces artifacts sont purement dans `.claude/` — aucun code Rust modifié, aucun risque de régression. Les 3 commits de fix versioning (`README.md`, `CLAUDE.md`, `ARCHITECTURE.md`) mettent à jour des références stale `0.27.2 → 0.28.0` détectées par le hook pre-push.

## Test plan

- [ ] Vérifier que les commandes `/tech:worktree`, `/tech:codereview`, `/tech:audit-codebase` s'affichent dans Claude Code
- [ ] Vérifier que les agents `code-reviewer`, `system-architect` sont disponibles
- [ ] Vérifier que les skills `tdd-rust`, `performance`, `design-patterns`, `code-simplifier` se triggent correctement

🤖 Generated with [Claude Code](https://claude.com/claude-code)