### PR TITLE
fix: test-all.sh aborts when gt is not installed

### DIFF
--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -434,7 +434,7 @@ if command -v gt &>/dev/null; then
     assert_help   "rtk gt"                          rtk gt --help
     assert_ok     "rtk gt log short"                rtk gt log short
 else
-    skip "gt not installed"
+    skip_test "rtk gt" "gt not installed"
 fi
 
 # ── 30. Global flags ────────────────────────────────


### PR DESCRIPTION
## Summary

- Fix `skip` → `skip_test` call in Graphite conditional section (line 437)
- Script was aborting due to `set -euo pipefail` when `gt` is not installed (common case)
- All sections after Graphite (Global flags, CcEconomics, final summary) were never executed

Fixes #500

## Before (script aborts, no summary)
```
── Graphite (conditional) ──
scripts/test-all.sh: line 461: skip: command not found
```

## After (script completes, full summary)
```
── Graphite (conditional) ──
  SKIP  rtk gt (gt not installed)

══════════════════════════════════════
Results: 108 passed, 0 failed, 6 skipped
══════════════════════════════════════
```

## Test plan
- [x] Run `bash scripts/test-all.sh` without `gt` installed — script completes with summary
- [x] Verified on upstream/master: same bug exists (not a regression from our branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)