### PR TITLE
fix: rtk rewrite accepts multiple args without quotes

### DIFF
--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -507,6 +507,37 @@ GOEOF
 fi
 
 # ===================
+# rewrite (verify rewrite works with and without quotes)
+# ===================
+section "rewrite"
+
+# bench_rewrite: verifies rewrite produces expected output (not token comparison)
+bench_rewrite() {
+  local name="$1"
+  local cmd="$2"
+  local expected="$3"
+
+  result=$(eval "$cmd" 2>&1 || true)
+
+  TOTAL_TESTS=$((TOTAL_TESTS + 1))
+
+  if [ "$result" = "$expected" ]; then
+    printf "✅ %-24s │ %-40s │ %s\n" "$name" "$cmd" "$result"
+    GOOD_TESTS=$((GOOD_TESTS + 1))
+  else
+    printf "❌ %-24s │ %-40s │ got: %s (expected: %s)\n" "$name" "$cmd" "$result" "$expected"
+    FAIL_TESTS=$((FAIL_TESTS + 1))
+  fi
+}
+
+bench_rewrite "rewrite quoted"       "$RTK rewrite 'git status'"     "rtk git status"
+bench_rewrite "rewrite unquoted"     "$RTK rewrite git status"       "rtk git status"
+bench_rewrite "rewrite ls -al"       "$RTK rewrite ls -al"           "rtk ls -al"
+bench_rewrite "rewrite npm exec"     "$RTK rewrite npm exec"         "rtk npm exec"
+bench_rewrite "rewrite cargo test"   "$RTK rewrite cargo test"       "rtk cargo test"
+bench_rewrite "rewrite compound"     "$RTK rewrite 'cargo test && git push'" "rtk cargo test && rtk git push"
+
+# ===================
 # Résumé global
 # ===================
 echo ""

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -174,7 +174,7 @@ section "git"
 bench "git status" "git status" "$RTK git status"
 bench "git log -n 10" "git log -10" "$RTK git log -n 10"
 bench "git log -n 5" "git log -5" "$RTK git log -n 5"
-bench "git diff" "git diff HEAD~1 2>/dev/null || echo ''" "$RTK git diff"
+bench "git diff" "git diff HEAD~1 2>/dev/null || echo ''" "$RTK git diff HEAD~1"
 
 # ===================
 # grep
@@ -228,13 +228,21 @@ bench "env --show-all" "env" "$RTK env --show-all"
 # err
 # ===================
 section "err"
-bench "err cargo build" "cargo build 2>&1 || true" "$RTK err cargo build"
+if command -v cargo &>/dev/null; then
+  bench "err cargo build" "cargo build 2>&1 || true" "$RTK err cargo build"
+else
+  echo "⏭️  err cargo build (cargo not in PATH, skipped)"
+fi
 
 # ===================
 # test
 # ===================
 section "test"
-bench "test cargo test" "cargo test 2>&1 || true" "$RTK test cargo test"
+if command -v cargo &>/dev/null; then
+  bench "test cargo test" "cargo test 2>&1 || true" "$RTK test cargo test"
+else
+  echo "⏭️  test cargo test (cargo not in PATH, skipped)"
+fi
 
 # ===================
 # log
@@ -263,17 +271,29 @@ rm -f "$LOG_FILE"
 # summary
 # ===================
 section "summary"
-bench "summary cargo --help" "cargo --help" "$RTK summary cargo --help"
-bench "summary rustc --help" "rustc --help 2>/dev/null || echo 'rustc not found'" "$RTK summary rustc --help"
+if command -v cargo &>/dev/null; then
+  bench "summary cargo --help" "cargo --help" "$RTK summary cargo --help"
+else
+  echo "⏭️  summary cargo --help (cargo not in PATH, skipped)"
+fi
+if command -v rustc &>/dev/null; then
+  bench "summary rustc --help" "rustc --help 2>/dev/null || echo 'rustc not found'" "$RTK summary rustc --help"
+else
+  echo "⏭️  summary rustc --help (rustc not in PATH, skipped)"
+fi
 
 # ===================
 # cargo
 # ===================
 section "cargo"
-bench "cargo build" "cargo build 2>&1 || true" "$RTK cargo build"
-bench "cargo test" "cargo test 2>&1 || true" "$RTK cargo test"
-bench "cargo clippy" "cargo clippy 2>&1 || true" "$RTK cargo clippy"
-bench "cargo check" "cargo check 2>&1 || true" "$RTK cargo check"
+if command -v cargo &>/dev/null; then
+  bench "cargo build" "cargo build 2>&1 || true" "$RTK cargo build"
+  bench "cargo test" "cargo test 2>&1 || true" "$RTK cargo test"
+  bench "cargo clippy" "cargo clippy 2>&1 || true" "$RTK cargo clippy"
+  bench "cargo check" "cargo check 2>&1 || true" "$RTK cargo check"
+else
+  echo "⏭️  cargo build/test/clippy/check (cargo not in PATH, skipped)"
+fi
 
 # ===================
 # diff

--- a/src/main.rs
+++ b/src/main.rs
@@ -627,7 +627,9 @@ enum Commands {
     ///   REWRITTEN=$(rtk rewrite "$CMD") || exit 0
     Rewrite {
         /// Raw command to rewrite (e.g. "git status", "cargo test && git push")
-        cmd: String,
+        /// Accepts multiple args: `rtk rewrite ls -al` is equivalent to `rtk rewrite "ls -al"`
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
     },
 }
 
@@ -1867,7 +1869,8 @@ fn main() -> Result<()> {
             hook_audit_cmd::run(since, cli.verbose)?;
         }
 
-        Commands::Rewrite { cmd } => {
+        Commands::Rewrite { args } => {
+            let cmd = args.join(" ");
             rewrite_cmd::run(&cmd)?;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2346,5 +2346,55 @@ mod tests {
         let result: Vec<String> = shell_split("");
         assert!(result.is_empty());
     }
+
+    #[test]
+    fn test_rewrite_clap_multi_args() {
+        // This is the bug KuSh reported: `rtk rewrite ls -al` failed because
+        // Clap rejected `-al` as an unknown flag. With trailing_var_arg + allow_hyphen_values,
+        // multiple args are accepted and joined into a single command string.
+        let cases = vec![
+            vec!["rtk", "rewrite", "ls", "-al"],
+            vec!["rtk", "rewrite", "git", "status"],
+            vec!["rtk", "rewrite", "npm", "exec"],
+            vec!["rtk", "rewrite", "cargo", "test"],
+            vec!["rtk", "rewrite", "du", "-sh", "."],
+            vec!["rtk", "rewrite", "head", "-50", "file.txt"],
+        ];
+        for args in &cases {
+            let result = Cli::try_parse_from(args.iter());
+            assert!(
+                result.is_ok(),
+                "rtk rewrite {:?} should parse (was failing before trailing_var_arg fix)",
+                &args[2..]
+            );
+            if let Ok(cli) = result {
+                match cli.command {
+                    Commands::Rewrite { ref args } => {
+                        assert!(
+                            args.len() >= 2,
+                            "rewrite args should capture all tokens"
+                        );
+                    }
+                    _ => panic!("expected Rewrite command"),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_rewrite_clap_quoted_single_arg() {
+        // Quoted form: `rtk rewrite "git status"` — single arg containing spaces
+        let result = Cli::try_parse_from(["rtk", "rewrite", "git status"]);
+        assert!(result.is_ok());
+        if let Ok(cli) = result {
+            match cli.command {
+                Commands::Rewrite { ref args } => {
+                    assert_eq!(args.len(), 1);
+                    assert_eq!(args[0], "git status");
+                }
+                _ => panic!("expected Rewrite command"),
+            }
+        }
+    }
 }
 


### PR DESCRIPTION
## Summary

- `rtk rewrite ls -al` now works the same as `rtk rewrite "ls -al"`
- Previously, unquoted args caused `No such file or directory (os error 2)` or `unexpected argument`
- Fix: change `cmd: String` to `args: Vec<String>` with `trailing_var_arg` and join them

Reported by @KuSh on Discord.

## Test plan
- [x] `rtk rewrite ls -al` → `rtk ls -al`
- [x] `rtk rewrite "ls -al"` → still works
- [x] `rtk rewrite npm exec` → `rtk npm exec`
- [x] `rtk rewrite git status` → `rtk git status`
- [x] `rtk rewrite "cargo test && git push"` → compound rewrite works
- [x] 775 tests pass