### PR TITLE
fix: use rtk <cmd> instead of rtk proxy for TOML-filtered commands

### DIFF
--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -352,7 +352,7 @@ pub const RULES: &[RtkRule] = &[
     },
     // TOML-filtered commands
     RtkRule {
-        rtk_cmd: "rtk proxy ansible-playbook",
+        rtk_cmd: "rtk ansible-playbook",
         rewrite_prefixes: &["ansible-playbook"],
         category: "Infra",
         savings_pct: 70.0,
@@ -360,7 +360,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy brew",
+        rtk_cmd: "rtk brew",
         rewrite_prefixes: &["brew"],
         category: "PackageManager",
         savings_pct: 65.0,
@@ -368,7 +368,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy composer",
+        rtk_cmd: "rtk composer",
         rewrite_prefixes: &["composer"],
         category: "PackageManager",
         savings_pct: 65.0,
@@ -376,7 +376,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy df",
+        rtk_cmd: "rtk df",
         rewrite_prefixes: &["df"],
         category: "System",
         savings_pct: 60.0,
@@ -384,7 +384,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy dotnet",
+        rtk_cmd: "rtk dotnet",
         rewrite_prefixes: &["dotnet"],
         category: "Build",
         savings_pct: 70.0,
@@ -392,7 +392,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy du",
+        rtk_cmd: "rtk du",
         rewrite_prefixes: &["du"],
         category: "System",
         savings_pct: 60.0,
@@ -400,7 +400,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy fail2ban-client",
+        rtk_cmd: "rtk fail2ban-client",
         rewrite_prefixes: &["fail2ban-client"],
         category: "Infra",
         savings_pct: 60.0,
@@ -408,7 +408,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy gcloud",
+        rtk_cmd: "rtk gcloud",
         rewrite_prefixes: &["gcloud"],
         category: "Infra",
         savings_pct: 65.0,
@@ -416,7 +416,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy hadolint",
+        rtk_cmd: "rtk hadolint",
         rewrite_prefixes: &["hadolint"],
         category: "Build",
         savings_pct: 65.0,
@@ -424,7 +424,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy helm",
+        rtk_cmd: "rtk helm",
         rewrite_prefixes: &["helm"],
         category: "Infra",
         savings_pct: 65.0,
@@ -432,7 +432,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy iptables",
+        rtk_cmd: "rtk iptables",
         rewrite_prefixes: &["iptables"],
         category: "Infra",
         savings_pct: 60.0,
@@ -440,7 +440,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy make",
+        rtk_cmd: "rtk make",
         rewrite_prefixes: &["make"],
         category: "Build",
         savings_pct: 65.0,
@@ -448,7 +448,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy markdownlint",
+        rtk_cmd: "rtk markdownlint",
         rewrite_prefixes: &["markdownlint"],
         category: "Build",
         savings_pct: 65.0,
@@ -456,7 +456,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy mix",
+        rtk_cmd: "rtk mix",
         rewrite_prefixes: &["mix"],
         category: "Build",
         savings_pct: 65.0,
@@ -464,7 +464,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy mvn",
+        rtk_cmd: "rtk mvn",
         rewrite_prefixes: &["mvn"],
         category: "Build",
         savings_pct: 70.0,
@@ -472,7 +472,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy ping",
+        rtk_cmd: "rtk ping",
         rewrite_prefixes: &["ping"],
         category: "Network",
         savings_pct: 60.0,
@@ -480,7 +480,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy pio",
+        rtk_cmd: "rtk pio",
         rewrite_prefixes: &["pio"],
         category: "Build",
         savings_pct: 65.0,
@@ -488,7 +488,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy poetry",
+        rtk_cmd: "rtk poetry",
         rewrite_prefixes: &["poetry"],
         category: "Python",
         savings_pct: 65.0,
@@ -496,7 +496,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy pre-commit",
+        rtk_cmd: "rtk pre-commit",
         rewrite_prefixes: &["pre-commit"],
         category: "Build",
         savings_pct: 65.0,
@@ -504,7 +504,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy ps",
+        rtk_cmd: "rtk ps",
         rewrite_prefixes: &["ps"],
         category: "System",
         savings_pct: 60.0,
@@ -512,7 +512,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy quarto",
+        rtk_cmd: "rtk quarto",
         rewrite_prefixes: &["quarto"],
         category: "Build",
         savings_pct: 65.0,
@@ -520,7 +520,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy rsync",
+        rtk_cmd: "rtk rsync",
         rewrite_prefixes: &["rsync"],
         category: "Network",
         savings_pct: 65.0,
@@ -528,7 +528,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy shellcheck",
+        rtk_cmd: "rtk shellcheck",
         rewrite_prefixes: &["shellcheck"],
         category: "Build",
         savings_pct: 65.0,
@@ -536,7 +536,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy shopify",
+        rtk_cmd: "rtk shopify",
         rewrite_prefixes: &["shopify"],
         category: "Build",
         savings_pct: 65.0,
@@ -544,7 +544,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy sops",
+        rtk_cmd: "rtk sops",
         rewrite_prefixes: &["sops"],
         category: "Infra",
         savings_pct: 60.0,
@@ -552,7 +552,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy swift",
+        rtk_cmd: "rtk swift",
         rewrite_prefixes: &["swift"],
         category: "Build",
         savings_pct: 65.0,
@@ -560,7 +560,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy systemctl",
+        rtk_cmd: "rtk systemctl",
         rewrite_prefixes: &["systemctl"],
         category: "System",
         savings_pct: 65.0,
@@ -568,7 +568,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy terraform",
+        rtk_cmd: "rtk terraform",
         rewrite_prefixes: &["terraform"],
         category: "Infra",
         savings_pct: 70.0,
@@ -576,7 +576,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy tofu",
+        rtk_cmd: "rtk tofu",
         rewrite_prefixes: &["tofu"],
         category: "Infra",
         savings_pct: 70.0,
@@ -584,7 +584,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy trunk",
+        rtk_cmd: "rtk trunk",
         rewrite_prefixes: &["trunk"],
         category: "Build",
         savings_pct: 65.0,
@@ -592,7 +592,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy uv",
+        rtk_cmd: "rtk uv",
         rewrite_prefixes: &["uv"],
         category: "Python",
         savings_pct: 65.0,
@@ -600,7 +600,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        rtk_cmd: "rtk proxy yamllint",
+        rtk_cmd: "rtk yamllint",
         rewrite_prefixes: &["yamllint"],
         category: "Build",
         savings_pct: 65.0,

--- a/src/npm_cmd.rs
+++ b/src/npm_cmd.rs
@@ -2,6 +2,75 @@ use crate::tracking;
 use anyhow::{Context, Result};
 use std::process::Command;
 
+/// Known npm subcommands that should NOT get "run" injected.
+/// Shared between production code and tests to avoid drift.
+const NPM_SUBCOMMANDS: &[&str] = &[
+    "install",
+    "i",
+    "ci",
+    "uninstall",
+    "remove",
+    "rm",
+    "update",
+    "up",
+    "list",
+    "ls",
+    "outdated",
+    "init",
+    "create",
+    "publish",
+    "pack",
+    "link",
+    "audit",
+    "fund",
+    "exec",
+    "explain",
+    "why",
+    "search",
+    "view",
+    "info",
+    "show",
+    "config",
+    "set",
+    "get",
+    "cache",
+    "prune",
+    "dedupe",
+    "doctor",
+    "help",
+    "version",
+    "prefix",
+    "root",
+    "bin",
+    "bugs",
+    "docs",
+    "home",
+    "repo",
+    "ping",
+    "whoami",
+    "token",
+    "profile",
+    "team",
+    "access",
+    "owner",
+    "deprecate",
+    "dist-tag",
+    "star",
+    "stars",
+    "login",
+    "logout",
+    "adduser",
+    "unpublish",
+    "pkg",
+    "diff",
+    "rebuild",
+    "test",
+    "t",
+    "start",
+    "stop",
+    "restart",
+];
+
 pub fn run(args: &[String], verbose: u8, skip_env: bool) -> Result<()> {
     let timer = tracking::TimedExecution::start();
 
@@ -9,77 +78,10 @@ pub fn run(args: &[String], verbose: u8, skip_env: bool) -> Result<()> {
 
     // Determine if this is "npm run <script>" or another npm subcommand (install, list, etc.)
     // Only inject "run" when args look like a script name, not a known npm subcommand.
-    let npm_subcommands = [
-        "install",
-        "i",
-        "ci",
-        "uninstall",
-        "remove",
-        "rm",
-        "update",
-        "up",
-        "list",
-        "ls",
-        "outdated",
-        "init",
-        "create",
-        "publish",
-        "pack",
-        "link",
-        "audit",
-        "fund",
-        "exec",
-        "explain",
-        "why",
-        "search",
-        "view",
-        "info",
-        "show",
-        "config",
-        "set",
-        "get",
-        "cache",
-        "prune",
-        "dedupe",
-        "doctor",
-        "help",
-        "version",
-        "prefix",
-        "root",
-        "bin",
-        "bugs",
-        "docs",
-        "home",
-        "repo",
-        "ping",
-        "whoami",
-        "token",
-        "profile",
-        "team",
-        "access",
-        "owner",
-        "deprecate",
-        "dist-tag",
-        "star",
-        "stars",
-        "login",
-        "logout",
-        "adduser",
-        "unpublish",
-        "pkg",
-        "diff",
-        "rebuild",
-        "test",
-        "t",
-        "start",
-        "stop",
-        "restart",
-    ];
-
     let first_arg = args.first().map(|s| s.as_str());
     let is_run_explicit = first_arg == Some("run");
     let is_npm_subcommand = first_arg
-        .map(|a| npm_subcommands.contains(&a) || a.starts_with('-'))
+        .map(|a| NPM_SUBCOMMANDS.contains(&a) || a.starts_with('-'))
         .unwrap_or(false);
 
     let effective_args = if is_run_explicit {
@@ -189,88 +191,20 @@ npm notice
 
     #[test]
     fn test_npm_subcommand_routing() {
-        // Test the actual routing logic used in run()
-        let npm_subcommands = [
-            "install",
-            "i",
-            "ci",
-            "uninstall",
-            "remove",
-            "rm",
-            "update",
-            "up",
-            "list",
-            "ls",
-            "outdated",
-            "init",
-            "create",
-            "publish",
-            "pack",
-            "link",
-            "audit",
-            "fund",
-            "exec",
-            "explain",
-            "why",
-            "search",
-            "view",
-            "info",
-            "show",
-            "config",
-            "set",
-            "get",
-            "cache",
-            "prune",
-            "dedupe",
-            "doctor",
-            "help",
-            "version",
-            "prefix",
-            "root",
-            "bin",
-            "bugs",
-            "docs",
-            "home",
-            "repo",
-            "ping",
-            "whoami",
-            "token",
-            "profile",
-            "team",
-            "access",
-            "owner",
-            "deprecate",
-            "dist-tag",
-            "star",
-            "stars",
-            "login",
-            "logout",
-            "adduser",
-            "unpublish",
-            "pkg",
-            "diff",
-            "rebuild",
-            "test",
-            "t",
-            "start",
-            "stop",
-            "restart",
-        ];
-        // Helper: simulate the routing logic from run()
-        fn needs_run_injection(args: &[&str], subcommands: &[&str]) -> bool {
+        // Uses the shared NPM_SUBCOMMANDS constant — no drift between prod and test
+        fn needs_run_injection(args: &[&str]) -> bool {
             let first = args.first().copied();
             let is_run_explicit = first == Some("run");
             let is_subcommand = first
-                .map(|a| subcommands.contains(&a) || a.starts_with('-'))
+                .map(|a| NPM_SUBCOMMANDS.contains(&a) || a.starts_with('-'))
                 .unwrap_or(false);
-            // "run" injection happens when: explicit "run" OR unknown script name
             !is_run_explicit && !is_subcommand
         }
 
         // Known subcommands should NOT get "run" injected
-        for subcmd in &npm_subcommands {
+        for subcmd in NPM_SUBCOMMANDS {
             assert!(
-                !needs_run_injection(&[subcmd], &npm_subcommands),
+                !needs_run_injection(&[subcmd]),
                 "'npm {}' should NOT inject 'run'",
                 subcmd
             );
@@ -279,18 +213,18 @@ npm notice
         // Script names SHOULD get "run" injected
         for script in &["build", "dev", "lint", "typecheck", "deploy"] {
             assert!(
-                needs_run_injection(&[script], &npm_subcommands),
+                needs_run_injection(&[script]),
                 "'npm {}' SHOULD inject 'run'",
                 script
             );
         }
 
         // Flags should NOT get "run" injected
-        assert!(!needs_run_injection(&["--version"], &npm_subcommands));
-        assert!(!needs_run_injection(&["-h"], &npm_subcommands));
+        assert!(!needs_run_injection(&["--version"]));
+        assert!(!needs_run_injection(&["-h"]));
 
         // Explicit "run" should NOT inject another "run"
-        assert!(!needs_run_injection(&["run", "build"], &npm_subcommands));
+        assert!(!needs_run_injection(&["run", "build"]));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replace all 32 `rtk proxy <cmd>` rewrite rules with `rtk <cmd>` so TOML filters actually apply (`proxy` bypasses filters → 0% real savings)
- Extract `NPM_SUBCOMMANDS` to module-level const to prevent test/prod list drift

Reported-by: @FlorianBruniaux in #499

## Test plan
- [x] 144 registry tests pass (rewrite rules validated)
- [x] 3 npm tests pass (shared const works)
- [x] `rtk rewrite make` → `rtk make` (not `rtk proxy make`)

Signed-off-by: Patrick Szymkowiak <patrick.szymkowiak@rtk-ai.app>