### PR TITLE
fix: prevent double -- separator in cargo clippy with -p flags (#496)

### DIFF
--- a/src/cargo_cmd.rs
+++ b/src/cargo_cmd.rs
@@ -40,6 +40,11 @@ fn restore_double_dash_with_raw(args: &[String], raw_args: &[String]) -> Vec<Str
         return args.to_vec();
     }
 
+    // If args already contain `--` (Clap preserved it), no restoration needed
+    if args.iter().any(|a| a == "--") {
+        return args.to_vec();
+    }
+
     // Find `--` in the original command line
     let sep_pos = match raw_args.iter().position(|a| a == "--") {
         Some(pos) => pos,
@@ -1052,6 +1057,42 @@ mod tests {
         ];
         let result = restore_double_dash_with_raw(&args, &raw);
         assert_eq!(result, vec!["--", "-D", "warnings"]);
+    }
+
+    #[test]
+    fn test_restore_double_dash_clippy_with_package_flags() {
+        // rtk cargo clippy -p my-service -p my-crate -- -D warnings
+        // Clap with trailing_var_arg preserves "--" when args precede it
+        // → clap gives ["-p", "my-service", "-p", "my-crate", "--", "-D", "warnings"]
+        let args: Vec<String> = vec![
+            "-p".into(),
+            "my-service".into(),
+            "-p".into(),
+            "my-crate".into(),
+            "--".into(),
+            "-D".into(),
+            "warnings".into(),
+        ];
+        let raw = vec![
+            "rtk".into(),
+            "cargo".into(),
+            "clippy".into(),
+            "-p".into(),
+            "my-service".into(),
+            "-p".into(),
+            "my-crate".into(),
+            "--".into(),
+            "-D".into(),
+            "warnings".into(),
+        ];
+        let result = restore_double_dash_with_raw(&args, &raw);
+        // Should NOT double the "--"
+        assert_eq!(
+            result,
+            vec!["-p", "my-service", "-p", "my-crate", "--", "-D", "warnings"]
+        );
+        // Verify only one "--" exists
+        assert_eq!(result.iter().filter(|a| *a == "--").count(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #496 — `rtk cargo clippy -p my-crate -- -D warnings` fails because `-D` is interpreted as a filename instead of a lint flag.

**Root cause**: `restore_double_dash()` always re-inserts `--`, but Clap with `trailing_var_arg = true` already preserves `--` in parsed args when flags like `-p` precede it. Result: `cargo clippy -p my-crate -- -- -D warnings` (double `--`).

**Fix**: Skip restoration when args already contain `--`.

## Before/After

```bash
# BEFORE: double -- breaks rustc flag parsing
$ rtk -v cargo clippy -p rtk -- -D warnings
Running: cargo clippy -p rtk -- -- -D warnings
# error: multiple input filenames provided (first two filenames are `src/lib.rs` and `-D`)

# AFTER: single -- preserved correctly
$ rtk -v cargo clippy -p rtk -- -D warnings
Running: cargo clippy -p rtk -- -D warnings
# cargo clippy: 54 errors, 0 warnings (correct output, filtered)
```

## Impact

Every Rust project using `cargo clippy -- -D warnings` with `-p` flags (common in workspaces/CI) was broken. The clippy filter gives **80%+ token savings** — this fix restores that for workspace users.

## Test plan

- [x] New test: `test_restore_double_dash_clippy_with_package_flags` — verifies no double `--` when Clap preserves separator
- [x] All 6 `restore_double_dash` tests pass
- [x] Full suite: 765 passed, 0 failed
- [x] Manual verification: `rtk -v cargo clippy -p rtk -- -D warnings` shows single `--`
- [x] `cargo fmt --check && cargo clippy && cargo test` all green

Generated with [Claude Code](https://claude.com/claude-code)