### PR TITLE
ci: PR template + target branch check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+<!-- What does this PR do? Keep it short (1-3 bullet points). -->
+
+-
+
+## Test plan
+<!-- How did you verify this works? -->
+
+- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test`
+- [ ] Manual testing: `rtk <command>` output inspected
+
+> **Important:** All PRs must target the `develop` branch (not `master`).
+> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.

--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -1,0 +1,43 @@
+name: PR Target Branch Check
+
+on:
+  pull_request_target:
+    types: [opened, edited]
+
+jobs:
+  check-target:
+    runs-on: ubuntu-latest
+    # Skip develop→master PRs (maintainer releases)
+    if: >-
+      github.event.pull_request.base.ref == 'master' &&
+      github.event.pull_request.head.ref != 'develop'
+    steps:
+      - name: Add wrong-base label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            // Add label
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              labels: ['wrong-base']
+            });
+
+            // Post comment
+            const body = `👋 Thanks for the PR! It looks like this targets \`master\`, but all PRs should target the **\`develop\`** branch.
+
+            Please update the base branch:
+            1. Click **Edit** at the top right of this PR
+            2. Change the base branch from \`master\` to \`develop\`
+
+            See [CONTRIBUTING.md](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/master/CONTRIBUTING.md) for details.`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: body
+            });


### PR DESCRIPTION
## Summary
- Add PR template reminding contributors to target `develop`
- Add CI workflow that detects PRs targeting `master` (excluding develop→master releases)
- Bot adds `wrong-base` label + posts comment with instructions to change base

Since CONTRIBUTING.md (March 5), ~30 PRs were still merged directly to master. This should fix the problem.

## Test plan
- [x] Label `wrong-base` created (red)
- [x] Workflow uses `pull_request_target` (works on forks)
- [x] Excludes `develop→master` PRs (maintainer releases)