### PR TITLE
docs: correct branch naming example (#474)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ chore/release-pipeline-cleanup
 ```bash
 git checkout develop
 git pull origin develop
-git checkout -b "feat(scope): your-clear-description"
+git checkout -b feat/scope-your-clear-description
 ```
 
 ### 2. Make Your Changes


### PR DESCRIPTION
## Summary
- replace the branch creation example with a slash-based name that git accepts
- keep the branch naming guidance consistent throughout the document

## Testing
- not run (docs only)

Fixes #474