### PR TITLE
feat(ruby): add RSpec and RuboCop support

### DIFF
--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -41,6 +41,9 @@ pub const PATTERNS: &[&str] = &[
     r"^ruff\s+(check|format)",
     r"^(python\s+-m\s+)?pytest(\s|$)",
     r"^(pip3?|uv\s+pip)\s+(list|outdated|install)",
+    // Ruby tooling
+    r"^(bundle\s+exec\s+|bin/)?rspec(\s|$)",
+    r"^(bundle\s+exec\s+)?rubocop(\s|$)",
     // Go tooling
     r"^go\s+(test|build|vet)",
     r"^golangci-lint(\s|$)",
@@ -280,6 +283,23 @@ pub const RULES: &[RtkRule] = &[
         category: "Python",
         savings_pct: 75.0,
         subcmd_savings: &[("list", 75.0), ("outdated", 80.0)],
+        subcmd_status: &[],
+    },
+    // Ruby tooling
+    RtkRule {
+        rtk_cmd: "rtk rspec",
+        rewrite_prefixes: &["bundle exec rspec", "bin/rspec", "rspec"],
+        category: "Ruby",
+        savings_pct: 90.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
+    RtkRule {
+        rtk_cmd: "rtk rubocop",
+        rewrite_prefixes: &["bundle exec rubocop", "rubocop"],
+        category: "Ruby",
+        savings_pct: 70.0,
+        subcmd_savings: &[],
         subcmd_status: &[],
     },
     // Go tooling

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,8 @@ mod psql_cmd;
 mod pytest_cmd;
 mod read;
 mod rewrite_cmd;
+mod rspec_cmd;
+mod rubocop_cmd;
 mod ruff_cmd;
 mod runner;
 mod summary;
@@ -606,6 +608,20 @@ enum Commands {
     #[command(name = "golangci-lint")]
     GolangciLint {
         /// golangci-lint arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// RSpec test runner with compact output
+    Rspec {
+        /// RSpec arguments (e.g., spec/models/user_spec.rb, --tag focus)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// RuboCop linter with compact output
+    Rubocop {
+        /// RuboCop arguments (e.g., app/models/, --only Style)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -1836,6 +1852,14 @@ fn main() -> Result<()> {
             golangci_cmd::run(&args, cli.verbose)?;
         }
 
+        Commands::Rspec { args } => {
+            rspec_cmd::run(&args, cli.verbose)?;
+        }
+
+        Commands::Rubocop { args } => {
+            rubocop_cmd::run(&args, cli.verbose)?;
+        }
+
         Commands::HookAudit { since } => {
             hook_audit_cmd::run(since, cli.verbose)?;
         }
@@ -2017,6 +2041,8 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Pip { .. }
             | Commands::Go { .. }
             | Commands::GolangciLint { .. }
+            | Commands::Rspec { .. }
+            | Commands::Rubocop { .. }
             | Commands::Gt { .. }
     )
 }

--- a/src/rspec_cmd.rs
+++ b/src/rspec_cmd.rs
@@ -1,0 +1,474 @@
+use crate::tracking;
+use crate::utils::truncate;
+use anyhow::{Context, Result};
+use std::process::Command;
+
+#[derive(Debug, PartialEq)]
+enum ParseState {
+    Preamble,
+    Failures,
+    Summary,
+    FailedExamples,
+}
+
+pub fn run(args: &[String], verbose: u8) -> Result<()> {
+    let timer = tracking::TimedExecution::start();
+
+    let (program, base_args) = detect_rspec_command();
+
+    let mut cmd = Command::new(&program);
+    for a in &base_args {
+        cmd.arg(a);
+    }
+    for a in args {
+        cmd.arg(a);
+    }
+
+    if verbose > 0 {
+        eprintln!(
+            "Running: {} {} {}",
+            program,
+            base_args.join(" "),
+            args.join(" ")
+        );
+    }
+
+    let output = cmd
+        .output()
+        .context("Failed to run rspec. Is it installed? Try: gem install rspec")?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let raw = format!("{}\n{}", stdout, stderr);
+
+    let filtered = filter_rspec_output(&raw);
+
+    let exit_code = output
+        .status
+        .code()
+        .unwrap_or(if output.status.success() { 0 } else { 1 });
+
+    if let Some(hint) = crate::tee::tee_and_hint(&raw, "rspec", exit_code) {
+        println!("{}\n{}", filtered, hint);
+    } else {
+        println!("{}", filtered);
+    }
+
+    timer.track(
+        &format!("rspec {}", args.join(" ")),
+        &format!("rtk rspec {}", args.join(" ")),
+        &raw,
+        &filtered,
+    );
+
+    // RSpec exit codes: 0=pass, 1=failure, 2=CLI error
+    if !output.status.success() {
+        std::process::exit(exit_code);
+    }
+
+    Ok(())
+}
+
+/// Detect available rspec command: bundle exec rspec, bin/rspec, or bare rspec
+fn detect_rspec_command() -> (String, Vec<String>) {
+    // Check for bin/rspec first
+    if std::path::Path::new("bin/rspec").exists() {
+        return ("bin/rspec".to_string(), vec![]);
+    }
+
+    // Check if bundle is available
+    if which_command("bundle").is_some() {
+        return (
+            "bundle".to_string(),
+            vec!["exec".to_string(), "rspec".to_string()],
+        );
+    }
+
+    ("rspec".to_string(), vec![])
+}
+
+fn which_command(cmd: &str) -> Option<String> {
+    Command::new("which")
+        .arg(cmd)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Parse RSpec output using a state machine and produce compact output
+pub fn filter_rspec_output(output: &str) -> String {
+    let mut state = ParseState::Preamble;
+    let mut failures: Vec<Vec<String>> = Vec::new();
+    let mut current_failure: Vec<String> = Vec::new();
+    let mut failed_examples: Vec<String> = Vec::new();
+    let mut summary_line = String::new();
+    let mut seed: Option<String> = None;
+    let mut duration: Option<String> = None;
+
+    for line in output.lines() {
+        let trimmed = line.trim();
+
+        // Extract seed anywhere
+        if trimmed.starts_with("Randomized with seed") {
+            if let Some(s) = trimmed.split_whitespace().last() {
+                seed = Some(s.to_string());
+            }
+            continue;
+        }
+
+        // Extract duration from "Finished in X.XX seconds"
+        if trimmed.starts_with("Finished in") {
+            // "Finished in 4.03 seconds (files took 2.13 seconds to load)"
+            let parts: Vec<&str> = trimmed.split_whitespace().collect();
+            if parts.len() >= 3 {
+                duration = Some(format!("{}s", parts[2]));
+            }
+            continue;
+        }
+
+        // State transitions
+        if trimmed == "Failures:" {
+            state = ParseState::Failures;
+            // Save any pending failure
+            if !current_failure.is_empty() {
+                failures.push(current_failure.clone());
+                current_failure.clear();
+            }
+            continue;
+        }
+
+        if trimmed == "Failed examples:" {
+            state = ParseState::FailedExamples;
+            // Save any pending failure
+            if !current_failure.is_empty() {
+                failures.push(current_failure.clone());
+                current_failure.clear();
+            }
+            continue;
+        }
+
+        // Summary line: "N examples, M failures" or "N examples, M failures, P pending"
+        if is_summary_line(trimmed) {
+            summary_line = trimmed.to_string();
+            state = ParseState::Summary;
+            continue;
+        }
+
+        match state {
+            ParseState::Preamble => {
+                // Skip preamble (deprecation warnings, run options, etc.)
+            }
+            ParseState::Failures => {
+                // Detect new failure block: "  1) Description"
+                if is_failure_header(trimmed) {
+                    if !current_failure.is_empty() {
+                        failures.push(current_failure.clone());
+                        current_failure.clear();
+                    }
+                    current_failure.push(trimmed.to_string());
+                } else if !trimmed.is_empty() {
+                    current_failure.push(trimmed.to_string());
+                }
+            }
+            ParseState::Summary => {
+                // Skip lines in summary section
+            }
+            ParseState::FailedExamples => {
+                if trimmed.starts_with("rspec ") {
+                    failed_examples.push(trimmed.to_string());
+                }
+            }
+        }
+    }
+
+    // Save last failure if any
+    if !current_failure.is_empty() {
+        failures.push(current_failure.clone());
+    }
+
+    build_rspec_summary(&summary_line, &failures, &failed_examples, seed, duration)
+}
+
+fn is_summary_line(line: &str) -> bool {
+    // Matches: "42 examples, 0 failures"
+    //          "42 examples, 3 failures, 2 pending"
+    //          "1 example, 1 failure"
+    let has_examples = line.contains("example");
+    let has_failures = line.contains("failure");
+    has_examples && has_failures
+}
+
+fn is_failure_header(line: &str) -> bool {
+    // Matches: "1) Some::Test description"
+    let chars = line.chars();
+    let mut has_digit = false;
+    for c in chars {
+        if c.is_ascii_digit() {
+            has_digit = true;
+        } else if c == ')' && has_digit {
+            return true;
+        } else {
+            break;
+        }
+    }
+    false
+}
+
+fn parse_summary_counts(summary: &str) -> (u32, u32, u32) {
+    let mut examples = 0u32;
+    let mut failures = 0u32;
+    let mut pending = 0u32;
+
+    // "42 examples, 3 failures, 2 pending"
+    // Split by comma and parse each part
+    for part in summary.split(',') {
+        let part = part.trim();
+        let words: Vec<&str> = part.split_whitespace().collect();
+        if words.len() >= 2 {
+            if let Ok(n) = words[0].parse::<u32>() {
+                let label = words[1];
+                if label.starts_with("example") {
+                    examples = n;
+                } else if label.starts_with("failure") {
+                    failures = n;
+                } else if label.starts_with("pending") {
+                    pending = n;
+                }
+            }
+        }
+    }
+
+    (examples, failures, pending)
+}
+
+fn build_rspec_summary(
+    summary_line: &str,
+    failures: &[Vec<String>],
+    failed_examples: &[String],
+    seed: Option<String>,
+    duration: Option<String>,
+) -> String {
+    let (examples, failure_count, pending) = parse_summary_counts(summary_line);
+
+    let seed_str = seed
+        .map(|s| format!(" [seed {}]", s))
+        .unwrap_or_default();
+    let dur_str = duration
+        .map(|d| format!("({})", d))
+        .unwrap_or_default();
+
+    if summary_line.is_empty() {
+        return "RSpec: No output".to_string();
+    }
+
+    if failure_count == 0 {
+        let mut line = format!("✓ RSpec: {} example{}", examples, if examples == 1 { "" } else { "s" });
+        line.push_str(", 0 failures");
+        if pending > 0 {
+            line.push_str(&format!(", {} pending", pending));
+        }
+        if !dur_str.is_empty() {
+            line.push_str(&format!(" {} ", dur_str));
+        }
+        line.push_str(&seed_str);
+        return line;
+    }
+
+    // There are failures
+    let mut result = String::new();
+    result.push_str(&format!(
+        "RSpec: {} example{}, {} failure{}",
+        examples,
+        if examples == 1 { "" } else { "s" },
+        failure_count,
+        if failure_count == 1 { "" } else { "s" }
+    ));
+    if pending > 0 {
+        result.push_str(&format!(", {} pending", pending));
+    }
+    if !dur_str.is_empty() {
+        result.push_str(&format!(" {}", dur_str));
+    }
+    result.push_str(&seed_str);
+    result.push('\n');
+    result.push_str("════════════════════════════════════════\n");
+
+    // Show up to 5 failures
+    let max_failures = 5;
+    for (i, failure_block) in failures.iter().take(max_failures).enumerate() {
+        result.push('\n');
+        let lines = failure_block.as_slice();
+
+        if let Some(header) = lines.first() {
+            result.push_str(&format!("  {}\n", truncate(header, 120)));
+        }
+
+        // Extract key error lines from remaining lines
+        let mut relevant = 0;
+        for line in lines.iter().skip(1) {
+            let lower = line.to_lowercase();
+            let is_relevant = lower.contains("expected")
+                || lower.contains("got:")
+                || lower.contains("failure/error")
+                || lower.contains("error:")
+                || lower.contains("assert")
+                || (line.contains("./spec/") && line.contains(".rb:"))
+                || line.starts_with('#');
+
+            if is_relevant && relevant < 3 {
+                result.push_str(&format!("     {}\n", truncate(line, 120)));
+                relevant += 1;
+            }
+        }
+
+        // Show file location (last line that looks like a spec path)
+        for line in lines.iter().rev() {
+            if line.contains("./spec/") && line.contains(".rb:") {
+                if !result.contains(line) {
+                    result.push_str(&format!("     {}\n", truncate(line, 120)));
+                }
+                break;
+            }
+        }
+
+        let _ = i; // suppress unused warning
+    }
+
+    if failures.len() > max_failures {
+        result.push_str(&format!(
+            "\n  ... +{} more failure{}\n",
+            failures.len() - max_failures,
+            if failures.len() - max_failures == 1 { "" } else { "s" }
+        ));
+    }
+
+    // Show failed examples for re-run
+    if !failed_examples.is_empty() {
+        result.push('\n');
+        result.push_str("Failed examples:\n");
+        for ex in failed_examples {
+            result.push_str(&format!("  {}\n", ex));
+        }
+    }
+
+    result.trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_filter_all_pass() {
+        let input = "Randomized with seed 40426\n\nFinished in 4.03 seconds (files took 2.13 seconds to load)\n1 example, 0 failures\n\nRandomized with seed 40426\n";
+        let result = filter_rspec_output(input);
+        assert!(result.contains("✓ RSpec"), "Expected checkmark, got: {}", result);
+        assert!(result.contains("0 failures"), "got: {}", result);
+        assert!(result.contains("4.03s"), "got: {}", result);
+        assert!(result.contains("40426"), "got: {}", result);
+    }
+
+    #[test]
+    fn test_filter_all_pass_multiple_examples() {
+        let input = "Randomized with seed 12345\n\nFinished in 2.50 seconds\n42 examples, 0 failures\n\nRandomized with seed 12345\n";
+        let result = filter_rspec_output(input);
+        assert!(result.contains("✓ RSpec"), "got: {}", result);
+        assert!(result.contains("42 examples"), "got: {}", result);
+        assert!(result.contains("0 failures"), "got: {}", result);
+    }
+
+    #[test]
+    fn test_filter_with_failures() {
+        let input = r#"Randomized with seed 12345
+
+Failures:
+
+  1) UsersController GET /users returns http success
+     Failure/Error: get :index
+     expected: 200
+          got: 403
+     # ./spec/controllers/users_controller_spec.rb:15
+
+Failed examples:
+
+  rspec ./spec/controllers/users_controller_spec.rb:14
+
+Finished in 4.23 seconds
+5 examples, 1 failure
+
+Randomized with seed 12345
+"#;
+        let result = filter_rspec_output(input);
+        assert!(result.contains("1 failure"), "got: {}", result);
+        assert!(result.contains("Failed examples:"), "got: {}", result);
+        assert!(result.contains("users_controller_spec.rb"), "got: {}", result);
+    }
+
+    #[test]
+    fn test_filter_with_pending() {
+        let input = "Finished in 1.23 seconds\n10 examples, 0 failures, 3 pending\n";
+        let result = filter_rspec_output(input);
+        assert!(result.contains("✓ RSpec"), "got: {}", result);
+        assert!(result.contains("3 pending"), "got: {}", result);
+    }
+
+    #[test]
+    fn test_filter_empty_output() {
+        let result = filter_rspec_output("");
+        assert!(result.contains("No output"), "got: {}", result);
+    }
+
+    #[test]
+    fn test_filter_with_deprecation_warnings() {
+        let input = r#"DEPRECATION WARNING: Some warning here
+Run options: include {:focus=>true}
+
+All examples were skipped -- no :focus tag was set.
+Randomized with seed 99999
+
+Finished in 0.01 seconds
+0 examples, 0 failures
+"#;
+        let result = filter_rspec_output(input);
+        // Should not crash and should show summary
+        assert!(!result.is_empty(), "got empty result");
+    }
+
+    #[test]
+    fn test_is_summary_line() {
+        assert!(is_summary_line("42 examples, 0 failures"));
+        assert!(is_summary_line("1 example, 1 failure"));
+        assert!(is_summary_line("10 examples, 3 failures, 2 pending"));
+        assert!(!is_summary_line("Failures:"));
+        assert!(!is_summary_line("Failed examples:"));
+    }
+
+    #[test]
+    fn test_parse_summary_counts() {
+        assert_eq!(parse_summary_counts("42 examples, 0 failures"), (42, 0, 0));
+        assert_eq!(parse_summary_counts("1 example, 1 failure"), (1, 1, 0));
+        assert_eq!(
+            parse_summary_counts("10 examples, 3 failures, 2 pending"),
+            (10, 3, 2)
+        );
+    }
+
+    #[test]
+    fn test_multiple_failures_truncated() {
+        let mut input = String::from("Failures:\n\n");
+        for i in 1..=7 {
+            input.push_str(&format!(
+                "  {}) Test {} fails\n     expected: true\n          got: false\n\n",
+                i, i
+            ));
+        }
+        input.push_str("Finished in 1.0 seconds\n7 examples, 7 failures\n");
+
+        let result = filter_rspec_output(&input);
+        assert!(result.contains("7 failures"), "got: {}", result);
+        assert!(result.contains("+2 more"), "got: {}", result);
+    }
+}

--- a/src/rubocop_cmd.rs
+++ b/src/rubocop_cmd.rs
@@ -1,0 +1,488 @@
+use crate::tracking;
+use crate::utils::truncate;
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::process::Command;
+
+#[derive(Debug, Deserialize)]
+struct RubocopOutput {
+    files: Vec<RubocopFile>,
+    summary: RubocopSummary,
+}
+
+#[derive(Debug, Deserialize)]
+struct RubocopFile {
+    path: String,
+    offenses: Vec<RubocopOffense>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RubocopOffense {
+    severity: String,
+    message: String,
+    cop_name: String,
+    correctable: bool,
+    location: RubocopLocation,
+}
+
+#[derive(Debug, Deserialize)]
+struct RubocopLocation {
+    start_line: u32,
+    start_column: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct RubocopSummary {
+    offense_count: u32,
+    #[allow(dead_code)]
+    target_file_count: u32,
+    inspected_file_count: u32,
+}
+
+pub fn run(args: &[String], verbose: u8) -> Result<()> {
+    let timer = tracking::TimedExecution::start();
+
+    let (program, base_args) = detect_rubocop_command();
+
+    let mut cmd = Command::new(&program);
+    for a in &base_args {
+        cmd.arg(a);
+    }
+
+    // Inject --format json unless user specified a format
+    let user_specified_format = args
+        .iter()
+        .any(|a| a.starts_with("--format") || a == "-f" || a.starts_with("-f"));
+
+    if !user_specified_format {
+        cmd.args(["--format", "json"]);
+    }
+
+    for a in args {
+        cmd.arg(a);
+    }
+
+    if verbose > 0 {
+        eprintln!(
+            "Running: {} {} --format json {}",
+            program,
+            base_args.join(" "),
+            args.join(" ")
+        );
+    }
+
+    let output = cmd
+        .output()
+        .context("Failed to run rubocop. Is it installed? Try: gem install rubocop")?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let raw = format!("{}\n{}", stdout, stderr);
+
+    let filtered = if !user_specified_format && !stdout.trim().is_empty() {
+        filter_rubocop_json(&stdout)
+    } else {
+        // Fallback: text output (user specified format, or empty stdout)
+        filter_rubocop_text(&raw)
+    };
+
+    let exit_code = output
+        .status
+        .code()
+        .unwrap_or(if output.status.success() { 0 } else { 1 });
+
+    if let Some(hint) = crate::tee::tee_and_hint(&raw, "rubocop", exit_code) {
+        println!("{}\n{}", filtered, hint);
+    } else {
+        println!("{}", filtered);
+    }
+
+    timer.track(
+        &format!("rubocop {}", args.join(" ")),
+        &format!("rtk rubocop {}", args.join(" ")),
+        &raw,
+        &filtered,
+    );
+
+    if !output.status.success() {
+        std::process::exit(exit_code);
+    }
+
+    Ok(())
+}
+
+fn detect_rubocop_command() -> (String, Vec<String>) {
+    // Check for bin/rubocop
+    if std::path::Path::new("bin/rubocop").exists() {
+        return ("bin/rubocop".to_string(), vec![]);
+    }
+
+    // Check if bundle is available
+    if Command::new("which")
+        .arg("bundle")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+    {
+        return (
+            "bundle".to_string(),
+            vec!["exec".to_string(), "rubocop".to_string()],
+        );
+    }
+
+    ("rubocop".to_string(), vec![])
+}
+
+/// Filter RuboCop JSON output — group by cop and file
+pub fn filter_rubocop_json(output: &str) -> String {
+    let parsed: Result<RubocopOutput, _> = serde_json::from_str(output);
+
+    let data = match parsed {
+        Ok(d) => d,
+        Err(e) => {
+            // Fallback to text parser
+            return format!(
+                "RuboCop (JSON parse failed: {})\n{}",
+                e,
+                filter_rubocop_text(output)
+            );
+        }
+    };
+
+    let total_offenses = data.summary.offense_count;
+    let inspected = data.summary.inspected_file_count;
+
+    if total_offenses == 0 {
+        return format!(
+            "✓ RuboCop: {} file{} inspected, no offenses detected",
+            inspected,
+            if inspected == 1 { "" } else { "s" }
+        );
+    }
+
+    // Count correctable offenses
+    let correctable_count: u32 = data
+        .files
+        .iter()
+        .flat_map(|f| &f.offenses)
+        .filter(|o| o.correctable)
+        .count() as u32;
+
+    // Group by cop name
+    let mut by_cop: HashMap<&str, u32> = HashMap::new();
+    for file in &data.files {
+        for offense in &file.offenses {
+            *by_cop.entry(&offense.cop_name).or_insert(0) += 1;
+        }
+    }
+
+    // Sort files by offense count
+    let mut files_with_offenses: Vec<&RubocopFile> =
+        data.files.iter().filter(|f| !f.offenses.is_empty()).collect();
+    files_with_offenses.sort_by(|a, b| b.offenses.len().cmp(&a.offenses.len()));
+
+    // Build output
+    let mut result = String::new();
+    result.push_str(&format!(
+        "RuboCop: {} file{} inspected, {} offense{} detected",
+        inspected,
+        if inspected == 1 { "" } else { "s" },
+        total_offenses,
+        if total_offenses == 1 { "" } else { "s" }
+    ));
+
+    if correctable_count > 0 {
+        result.push_str(&format!(" ({} correctable)", correctable_count));
+    }
+    result.push('\n');
+    result.push_str("════════════════════════════════════════\n");
+
+    // Show top cops
+    let mut cop_counts: Vec<_> = by_cop.iter().collect();
+    cop_counts.sort_by(|a, b| b.1.cmp(a.1));
+
+    if !cop_counts.is_empty() {
+        result.push_str("\nTop cops:\n");
+        for (cop, count) in cop_counts.iter().take(10) {
+            result.push_str(&format!(
+                "  {:<45} {} offense{}\n",
+                cop,
+                count,
+                if **count == 1 { "" } else { "s" }
+            ));
+        }
+    }
+
+    // Show top files with offense details
+    result.push_str("\nTop files:\n");
+    for file in files_with_offenses.iter().take(10) {
+        let count = file.offenses.len();
+        result.push_str(&format!(
+            "  {} ({} offense{})\n",
+            file.path,
+            count,
+            if count == 1 { "" } else { "s" }
+        ));
+
+        // Show up to 3 offenses per file
+        for offense in file.offenses.iter().take(3) {
+            let severity_char = severity_char(&offense.severity);
+            result.push_str(&format!(
+                "    L{:<4}:{:<3} {}: {}: {}\n",
+                offense.location.start_line,
+                offense.location.start_column,
+                severity_char,
+                offense.cop_name,
+                truncate(&offense.message, 80)
+            ));
+        }
+
+        if count > 3 {
+            result.push_str(&format!("    ... +{} more\n", count - 3));
+        }
+    }
+
+    if files_with_offenses.len() > 10 {
+        result.push_str(&format!(
+            "\n... +{} more files\n",
+            files_with_offenses.len() - 10
+        ));
+    }
+
+    if correctable_count > 0 {
+        result.push_str(&format!(
+            "\nHint: rubocop -A to auto-correct {} correctable offense{}\n",
+            correctable_count,
+            if correctable_count == 1 { "" } else { "s" }
+        ));
+    }
+
+    result.trim().to_string()
+}
+
+fn severity_char(severity: &str) -> &str {
+    match severity {
+        "convention" => "C",
+        "warning" => "W",
+        "error" => "E",
+        "fatal" => "F",
+        "refactor" => "R",
+        _ => "?",
+    }
+}
+
+/// Fallback text parser for RuboCop output (when JSON is unavailable)
+pub fn filter_rubocop_text(output: &str) -> String {
+    // Pattern: "path/to/file.rb:line:col: S: CopName: message"
+    let offense_re = regex::Regex::new(
+        r"^(\S+\.\w+):(\d+):(\d+):\s+([CWEFR]):\s+([^:]+):\s+(.+)$"
+    );
+
+    let offense_re = match offense_re {
+        Ok(r) => r,
+        Err(_) => return output.trim().to_string(),
+    };
+
+    let mut offenses: Vec<(String, u32, u32, String, String, String)> = Vec::new();
+
+    for line in output.lines() {
+        if let Some(caps) = offense_re.captures(line) {
+            let path = caps.get(1).map_or("", |m| m.as_str()).to_string();
+            let line_num: u32 = caps.get(2).map_or("0", |m| m.as_str()).parse().unwrap_or(0);
+            let col_num: u32 = caps.get(3).map_or("0", |m| m.as_str()).parse().unwrap_or(0);
+            let severity = caps.get(4).map_or("?", |m| m.as_str()).to_string();
+            let cop = caps.get(5).map_or("", |m| m.as_str()).to_string();
+            let message = caps.get(6).map_or("", |m| m.as_str()).to_string();
+            offenses.push((path, line_num, col_num, severity, cop, message));
+        }
+    }
+
+    // Extract "N files inspected, M offenses" from summary
+    let mut inspected = 0u32;
+    let mut total = 0u32;
+    for line in output.lines() {
+        let l = line.trim();
+        // "8 files inspected, 5 offenses detected"
+        if l.contains("inspected") && l.contains("offense") {
+            let parts: Vec<&str> = l.split(',').collect();
+            for part in &parts {
+                let words: Vec<&str> = part.split_whitespace().collect();
+                for (i, word) in words.iter().enumerate() {
+                    if *word == "inspected" && i > 0 {
+                        inspected = words[i - 1].parse().unwrap_or(0);
+                    }
+                    if word.starts_with("offense") && i > 0 {
+                        total = words[i - 1].parse().unwrap_or(0);
+                    }
+                }
+            }
+        }
+    }
+
+    if total == 0 && offenses.is_empty() {
+        return format!(
+            "✓ RuboCop: {} file{} inspected, no offenses detected",
+            inspected,
+            if inspected == 1 { "" } else { "s" }
+        );
+    }
+
+    // Group by file
+    let mut by_file: HashMap<&str, Vec<_>> = HashMap::new();
+    for offense in &offenses {
+        by_file.entry(&offense.0).or_default().push(offense);
+    }
+
+    let mut files_sorted: Vec<_> = by_file.iter().collect();
+    files_sorted.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+
+    let mut result = String::new();
+    result.push_str(&format!(
+        "RuboCop: {} file{} inspected, {} offense{} detected\n",
+        inspected,
+        if inspected == 1 { "" } else { "s" },
+        total,
+        if total == 1 { "" } else { "s" }
+    ));
+    result.push_str("════════════════════════════════════════\n");
+
+    for (path, file_offenses) in files_sorted.iter().take(10) {
+        result.push_str(&format!(
+            "  {} ({} offense{})\n",
+            path,
+            file_offenses.len(),
+            if file_offenses.len() == 1 { "" } else { "s" }
+        ));
+        for offense in file_offenses.iter().take(3) {
+            result.push_str(&format!(
+                "    L{:<4}:{:<3} {}: {}: {}\n",
+                offense.1,
+                offense.2,
+                offense.3,
+                offense.4,
+                truncate(&offense.5, 80)
+            ));
+        }
+    }
+
+    result.trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_filter_json_no_offenses() {
+        let json = r#"{"files":[],"summary":{"offense_count":0,"target_file_count":8,"inspected_file_count":8}}"#;
+        let result = filter_rubocop_json(json);
+        assert!(result.contains("✓ RuboCop"), "got: {}", result);
+        assert!(result.contains("no offenses"), "got: {}", result);
+        assert!(result.contains("8 files"), "got: {}", result);
+    }
+
+    #[test]
+    fn test_filter_json_with_offenses() {
+        let json = r#"{
+  "files": [
+    {
+      "path": "app/models/user.rb",
+      "offenses": [
+        {
+          "severity": "convention",
+          "message": "Missing frozen string literal comment.",
+          "cop_name": "Style/FrozenStringLiteralComment",
+          "correctable": true,
+          "location": {"start_line": 1, "start_column": 1, "last_line": 1, "last_column": 1, "length": 0}
+        },
+        {
+          "severity": "warning",
+          "message": "Trailing whitespace detected.",
+          "cop_name": "Layout/TrailingWhitespace",
+          "correctable": true,
+          "location": {"start_line": 24, "start_column": 5, "last_line": 24, "last_column": 5, "length": 0}
+        }
+      ]
+    },
+    {
+      "path": "app/services/user_service.rb",
+      "offenses": [
+        {
+          "severity": "convention",
+          "message": "Missing top-level documentation comment",
+          "cop_name": "Style/Documentation",
+          "correctable": false,
+          "location": {"start_line": 8, "start_column": 1, "last_line": 8, "last_column": 1, "length": 0}
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "offense_count": 3,
+    "target_file_count": 5,
+    "inspected_file_count": 5
+  }
+}"#;
+        let result = filter_rubocop_json(json);
+        assert!(result.contains("3 offenses detected"), "got: {}", result);
+        assert!(result.contains("Top cops:"), "got: {}", result);
+        assert!(result.contains("Top files:"), "got: {}", result);
+        assert!(result.contains("user.rb"), "got: {}", result);
+        assert!(result.contains("2 correctable"), "got: {}", result);
+    }
+
+    #[test]
+    fn test_filter_json_correctable_hint() {
+        let json = r#"{
+  "files": [
+    {
+      "path": "app/models/user.rb",
+      "offenses": [
+        {
+          "severity": "convention",
+          "message": "Missing frozen string literal comment.",
+          "cop_name": "Style/FrozenStringLiteralComment",
+          "correctable": true,
+          "location": {"start_line": 1, "start_column": 1, "last_line": 1, "last_column": 1, "length": 0}
+        }
+      ]
+    }
+  ],
+  "summary": {"offense_count": 1, "target_file_count": 1, "inspected_file_count": 1}
+}"#;
+        let result = filter_rubocop_json(json);
+        assert!(result.contains("rubocop -A"), "got: {}", result);
+    }
+
+    #[test]
+    fn test_filter_text_no_offenses() {
+        let text = "8 files inspected, 0 offenses detected\n";
+        let result = filter_rubocop_text(text);
+        assert!(result.contains("✓ RuboCop"), "got: {}", result);
+        assert!(result.contains("no offenses"), "got: {}", result);
+    }
+
+    #[test]
+    fn test_filter_text_with_offenses() {
+        let text = r#"app/models/user.rb:12:3: C: Style/FrozenStringLiteralComment: Missing frozen string literal comment.
+app/models/user.rb:24:5: W: Layout/TrailingWhitespace: Trailing whitespace detected.
+app/services/user_service.rb:8:1: C: Style/Documentation: Missing top-level class documentation comment.
+
+3 files inspected, 3 offenses detected
+"#;
+        let result = filter_rubocop_text(text);
+        assert!(result.contains("offenses detected"), "got: {}", result);
+        assert!(result.contains("user.rb"), "got: {}", result);
+    }
+
+    #[test]
+    fn test_severity_char() {
+        assert_eq!(severity_char("convention"), "C");
+        assert_eq!(severity_char("warning"), "W");
+        assert_eq!(severity_char("error"), "E");
+        assert_eq!(severity_char("fatal"), "F");
+        assert_eq!(severity_char("refactor"), "R");
+        assert_eq!(severity_char("unknown"), "?");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `rtk rspec` — compact RSpec output with state-machine parser: all-pass → single ✓ line; failures → grouped summary with up to 5 blocks (3 relevant lines each) + `Failed examples:` re-run hints
- Adds `rtk rubocop` — auto-injects `--format json` and renders offenses by Top cops / Top files; falls back to regex text parser; shows correctable count + `rubocop -A` hint
- Registers Ruby patterns in `discover/rules.rs` so `rtk rewrite "bundle exec rspec ..."` and `rtk rewrite "bundle exec rubocop ..."` work out of the box
- Both commands auto-detect `bundle exec`, `bin/`, or bare invocation and preserve exit codes for CI/CD

## Motivation

Ruby/Rails is a major ecosystem with no existing RTK coverage. RSpec output is extremely verbose (progress dots, deprecation warnings, seed/timing noise), making it an ideal target for token savings (~90%). RuboCop with `--format json` gives structured data perfect for compact grouping (~70%).

The filter logic is ported from battle-tested Ruby scripts used in production Rails CI.

## Test plan

- [x] `cargo build` — compiles cleanly (zero errors)
- [x] `cargo test` — all 779 tests pass (15 new tests added: 9 rspec, 6 rubocop)
- [x] `cargo clippy` — no warnings in new files
- [x] `rtk rewrite "bundle exec rspec spec/models/user_spec.rb"` → `rtk rspec spec/models/user_spec.rb`
- [x] `rtk rewrite "bin/rspec spec/"` → `rtk rspec spec/`
- [x] `rtk rewrite "bundle exec rubocop app/models/"` → `rtk rubocop app/models/`
- [x] `discover/registry` alignment tests pass (PATTERNS/RULES 1:1 maintained)

🤖 Generated with [Claude Code](https://claude.com/claude-code)