### PR TITLE
feat(helm): add show and template filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ rtk pip outdated                # Outdated packages
 rtk prisma generate             # Schema generation (no ASCII art)
 ```
 
-### Containers
+### Containers & Helm
 ```bash
 rtk docker ps                   # Compact container list
 rtk docker images               # Compact image list
@@ -201,6 +201,9 @@ rtk docker compose ps           # Compose services
 rtk kubectl pods                # Compact pod list
 rtk kubectl logs <pod>          # Deduplicated logs
 rtk kubectl services            # Compact service list
+rtk helm show values <chart>    # Strip commented defaults from chart values
+rtk helm show chart <chart>     # Compact chart metadata
+rtk helm template <r> <chart>   # Reduce Helm boilerplate in rendered manifests
 ```
 
 ### Data & Analytics
@@ -326,6 +329,7 @@ cp hooks/opencode-rtk.ts ~/.config/opencode/plugins/rtk.ts
 | `golangci-lint` | `rtk golangci-lint` |
 | `docker ps/images/logs` | `rtk docker ...` |
 | `kubectl get/logs` | `rtk kubectl ...` |
+| `helm show/template` | `rtk helm ...` |
 | `curl` | `rtk curl` |
 | `pnpm list/outdated` | `rtk pnpm ...` |
 

--- a/src/filters/helm-show-chart.toml
+++ b/src/filters/helm-show-chart.toml
@@ -1,0 +1,28 @@
+[filters.helm-show-chart]
+description = "Compact helm show chart output"
+match_command = "^helm\\s+show\\s+chart\\b"
+strip_ansi = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^#.*$",
+]
+truncate_lines_at = 120
+max_lines = 80
+
+[[tests.helm-show-chart]]
+name = "preserves chart metadata and dependencies"
+input = """
+# Chart metadata
+apiVersion: v2
+name: nginx
+description: NGINX Open Source is a web server that can be also used as a reverse proxy, load balancer, and HTTP cache.
+type: application
+version: 22.4.3
+appVersion: 1.29.4
+
+dependencies:
+  - name: common
+    version: 2.x.x
+    repository: oci://registry-1.docker.io/bitnamicharts
+"""
+expected = "apiVersion: v2\nname: nginx\ndescription: NGINX Open Source is a web server that can be also used as a reverse proxy, load balancer, and HTTP cache.\ntype: application\nversion: 22.4.3\nappVersion: 1.29.4\ndependencies:\n  - name: common\n    version: 2.x.x\n    repository: oci://registry-1.docker.io/bitnamicharts"

--- a/src/filters/helm-show-values.toml
+++ b/src/filters/helm-show-values.toml
@@ -1,0 +1,39 @@
+[filters.helm-show-values]
+description = "Compact helm show values output"
+match_command = "^helm\\s+show\\s+values\\b"
+strip_ansi = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^#.*$",
+]
+truncate_lines_at = 120
+max_lines = 120
+
+[[tests.helm-show-values]]
+name = "strips comments and preserves values structure"
+input = """
+# Copyright Example Corp.
+## @section Global parameters
+## @param image.registry Container registry
+image:
+  registry: docker.io
+  repository: bitnami/nginx
+
+## @param service.type Kubernetes Service type
+service:
+  type: ClusterIP
+  port: 80
+"""
+expected = "image:\n  registry: docker.io\n  repository: bitnami/nginx\nservice:\n  type: ClusterIP\n  port: 80"
+
+[[tests.helm-show-values]]
+name = "keeps uncommented examples and strips comment-only separators"
+input = """
+## Example values
+affinity: {}
+
+extraEnvVars:
+  - name: FOO
+    value: bar
+"""
+expected = "affinity: {}\nextraEnvVars:\n  - name: FOO\n    value: bar"

--- a/src/filters/helm-template.toml
+++ b/src/filters/helm-template.toml
@@ -1,0 +1,61 @@
+[filters.helm-template]
+description = "Compact helm template output"
+match_command = "^helm\\s+template\\b"
+strip_ansi = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^\\s*app\\.kubernetes\\.io/managed-by:\\s*Helm\\s*$",
+  "^\\s*app\\.kubernetes\\.io/version:\\s*.*$",
+  "^\\s*helm\\.sh/chart:\\s*.*$",
+  "^\\s*kubectl\\.kubernetes\\.io/last-applied-configuration:\\s*.*$",
+]
+truncate_lines_at = 120
+max_lines = 120
+
+[[tests.helm-template]]
+name = "strips boilerplate helm labels and last applied annotation"
+input = """
+---
+# Source: nginx/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  labels:
+    app.kubernetes.io/instance: nginx
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/version: 1.29.4
+    helm.sh/chart: nginx-22.4.3
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: {\"apiVersion\":\"v1\"}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+"""
+expected = "---\n# Source: nginx/templates/service.yaml\napiVersion: v1\nkind: Service\nmetadata:\n  name: nginx\n  labels:\n    app.kubernetes.io/instance: nginx\n    app.kubernetes.io/name: nginx\n  annotations:\nspec:\n  type: ClusterIP\n  ports:\n    - name: http\n      port: 80"
+
+[[tests.helm-template]]
+name = "preserves document boundaries across rendered manifests"
+input = """
+---
+# Source: chart/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+data:
+  APP_MODE: production
+
+---
+# Source: chart/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  replicas: 2
+"""
+expected = "---\n# Source: chart/templates/configmap.yaml\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: app-config\ndata:\n  APP_MODE: production\n---\n# Source: chart/templates/deployment.yaml\napiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: app\nspec:\n  replicas: 2"

--- a/src/filters/helm.toml
+++ b/src/filters/helm.toml
@@ -1,5 +1,5 @@
-[filters.helm]
-description = "Compact helm output"
+[filters.helm-z-fallback]
+description = "Compact generic helm output fallback"
 match_command = "^helm\\b"
 strip_ansi = true
 strip_lines_matching = [
@@ -9,7 +9,7 @@ strip_lines_matching = [
 truncate_lines_at = 120
 max_lines = 40
 
-[[tests.helm]]
+[[tests.helm-z-fallback]]
 name = "strips blank lines, preserves release info"
 input = """
 NAME: my-release
@@ -23,7 +23,7 @@ Application is running.
 """
 expected = "NAME: my-release\nLAST DEPLOYED: Mon Jan 15 10:30:00 2024\nNAMESPACE: default\nSTATUS: deployed\nREVISION: 3\nNOTES:\nApplication is running."
 
-[[tests.helm]]
+[[tests.helm-z-fallback]]
 name = "strips glog W-prefix warnings"
 input = "W0115 10:30:00 warning message from internal\nNAME: my-chart\nSTATUS: deployed"
 expected = "NAME: my-chart\nSTATUS: deployed"

--- a/src/init.rs
+++ b/src/init.rs
@@ -164,6 +164,7 @@ rtk docker images       # Compact image list
 rtk docker logs <c>     # Deduplicated logs
 rtk kubectl get         # Compact resource list
 rtk kubectl logs        # Deduplicated pod logs
+rtk helm show values    # Strip commented chart defaults
 ```
 
 ### Network (65-70% savings)
@@ -192,7 +193,7 @@ rtk init --global       # Add RTK to ~/.claude/CLAUDE.md
 | GitHub | gh pr, gh run, gh issue | 26-87% |
 | Package Managers | pnpm, npm, npx | 70-90% |
 | Files | ls, read, grep, find | 60-75% |
-| Infrastructure | docker, kubectl | 85% |
+| Infrastructure | docker, kubectl, helm | 85% |
 | Network | curl, wget | 65-70% |
 
 Overall average: **60-90% token reduction** on common development operations.
@@ -1426,6 +1427,7 @@ mod tests {
             "rtk git",
             "rtk docker",
             "rtk kubectl",
+            "rtk helm",
         ] {
             assert!(
                 RTK_INSTRUCTIONS.contains(cmd),

--- a/src/toml_filter.rs
+++ b/src/toml_filter.rs
@@ -1534,7 +1534,7 @@ match_command = "^make\\b"
             "fail2ban-client",
             "gcloud",
             "hadolint",
-            "helm",
+            "helm-z-fallback",
             "iptables",
             "make",
             "markdownlint",
@@ -1579,8 +1579,8 @@ match_command = "^make\\b"
         let filters = make_filters(BUILTIN_TOML);
         assert_eq!(
             filters.len(),
-            47,
-            "Expected exactly 47 built-in filters, got {}. \
+            50,
+            "Expected exactly 50 built-in filters, got {}. \
              Update this count when adding/removing filters in src/filters/.",
             filters.len()
         );
@@ -1637,11 +1637,11 @@ expected = "output line 1\noutput line 2"
         let combined = format!("{}\n\n{}", BUILTIN_TOML, new_filter);
         let filters = make_filters(&combined);
 
-        // All 47 existing filters still present + 1 new = 48
+        // All 50 existing filters still present + 1 new = 51
         assert_eq!(
             filters.len(),
-            48,
-            "Expected 48 filters after concat (47 built-in + 1 new)"
+            51,
+            "Expected 51 filters after concat (50 built-in + 1 new)"
         );
 
         // New filter is discoverable


### PR DESCRIPTION
## Summary

- add dedicated built-in filters for `helm show values`, `helm show chart`, and `helm template` to cover the high-noise Helm paths requested in #182
- rename the generic Helm fallback filter to `helm-z-fallback` so the command-specific filters win during lookup instead of being shadowed
- document Helm support in `README.md` and `rtk init` guidance, and update built-in filter count assertions

## Test plan

- [x] `cargo fmt --all`
- [x] Added inline TOML tests for `helm-show-values`, `helm-show-chart`, `helm-template`, and `helm-z-fallback`
- [ ] `cargo test` is currently blocked on unrelated `origin/develop` compile failure in `src/cargo_cmd.rs` (`truncate` import missing)
- [ ] `cargo run --quiet -- verify --filter helm-show-values` is blocked by the same unrelated `origin/develop` compile failure

Closes #182