### PR TITLE
fix: remove version check from validate-docs CI (#476)

### DIFF
--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     paths:
       - 'src/**/*.rs'
-      - 'Cargo.toml'
       - '**.md'
       - '.claude/hooks/*.sh'
   push:

--- a/scripts/validate-docs.sh
+++ b/scripts/validate-docs.sh
@@ -3,23 +3,7 @@ set -e
 
 echo "🔍 Validating RTK documentation consistency..."
 
-# 1. Version Cargo.toml == tous les fichiers doc
-CARGO_VERSION=$(grep '^version = ' Cargo.toml | cut -d'"' -f2)
-echo "📦 Cargo.toml version: $CARGO_VERSION"
-
-for file in README.md CLAUDE.md ARCHITECTURE.md; do
-  if [ ! -f "$file" ]; then
-    echo "⚠️  $file not found, skipping"
-    continue
-  fi
-  if ! grep -q "$CARGO_VERSION" "$file"; then
-    echo "❌ $file ne mentionne pas version $CARGO_VERSION"
-    exit 1
-  fi
-done
-echo "✅ Version consistency: all docs mention $CARGO_VERSION"
-
-# 2. Nombre de modules cohérent
+# 1. Nombre de modules cohérent
 MAIN_MODULES=$(grep -c '^mod ' src/main.rs)
 echo "📊 Module count in main.rs: $MAIN_MODULES"
 


### PR DESCRIPTION
## Summary
- Remove the exact version grep from `scripts/validate-docs.sh` that breaks after every release-please bump
- Remove `Cargo.toml` from the workflow trigger paths (no longer relevant)
- Module count, Python/Go commands, and hook coverage checks are preserved

Fixes #476