### PR TITLE
fix: test-all.sh aborts when gt not installed (#500)

### DIFF
--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -434,7 +434,7 @@ if command -v gt &>/dev/null; then
     assert_help   "rtk gt"                          rtk gt --help
     assert_ok     "rtk gt log short"                rtk gt log short
 else
-    skip "gt not installed"
+    skip_test "rtk gt" "gt not installed"
 fi
 
 # ── 30. Global flags ────────────────────────────────


### PR DESCRIPTION
## Summary
- Fix `skip` → `skip_test` call in Graphite section of `test-all.sh`
- Without this fix, `set -euo pipefail` aborts the entire script when `gt` is not installed, skipping all subsequent test sections

One-line fix. Closes #500