### PR TITLE
feat: native cross-platform hook for Windows support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
+* **hook-rewrite:** add `rtk hook-rewrite` command — native cross-platform PreToolUse hook for Windows (no bash or jq dependency required)
+* **init:** `rtk init -g` on Windows now registers the native `rtk hook-rewrite` hook in `settings.json` instead of falling back to `--claude-md` mode
 * **toml-dsl:** declarative TOML filter engine — add command filters without writing Rust ([#299](https://github.com/rtk-ai/rtk/issues/299))
   * 8 primitives: `strip_ansi`, `replace`, `match_output`, `strip/keep_lines_matching`, `truncate_lines_at`, `head/tail_lines`, `max_lines`, `on_empty`
   * lookup chain: `.rtk/filters.toml` (project-local) → `~/.config/rtk/filters.toml` (user-global) → built-in filters
@@ -93,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+* **init:** `hook_check` correctly detects native `rtk hook-rewrite` in `settings.json` alongside the existing bash hook detection
 * **curl:** skip JSON schema replacement when schema is larger than original payload ([#297](https://github.com/rtk-ai/rtk/issues/297))
 * **toml-dsl:** fix regex overmatch on `tofu-plan/init/validate/fmt` and `mix-format/compile` — add `(\s|$)` word boundary to prevent matching subcommands (e.g. `tofu planet`, `mix formats`) ([#349](https://github.com/rtk-ai/rtk/issues/349))
 * **toml-dsl:** remove 3 dead built-in filters (`docker-inspect`, `docker-compose-ps`, `pnpm-build`) — Clap routes these commands before `run_fallback`, so the TOML filters never fire ([#351](https://github.com/rtk-ai/rtk/issues/351))

--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ rtk init --show             # Verify installation
 
 After install, **restart Claude Code**.
 
+> **Windows support**: On Windows, `rtk init -g` registers a native `rtk hook-rewrite` command as the PreToolUse hook — no bash or jq required. The hook runs as a plain executable, fully compatible with Claude Code on Windows.
+
 ## OpenCode Plugin (Global)
 
 OpenCode supports plugins that can intercept tool execution. RTK provides a global plugin that mirrors the Claude auto-rewrite behavior by rewriting Bash tool commands to `rtk ...` before they execute. This plugin is **not** installed by default.

--- a/src/hook_check.rs
+++ b/src/hook_check.rs
@@ -26,17 +26,24 @@ pub fn status() -> HookStatus {
         return HookStatus::Ok;
     }
 
-    let Some(hook_path) = hook_installed_path() else {
-        return HookStatus::Missing;
-    };
-    let Ok(content) = std::fs::read_to_string(&hook_path) else {
-        return HookStatus::Outdated; // exists but unreadable — treat as needs-update
-    };
-    if parse_hook_version(&content) >= CURRENT_HOOK_VERSION {
-        HookStatus::Ok
-    } else {
-        HookStatus::Outdated
+    // Check bash hook file first
+    if let Some(hook_path) = hook_installed_path() {
+        let Ok(content) = std::fs::read_to_string(&hook_path) else {
+            return HookStatus::Outdated;
+        };
+        return if parse_hook_version(&content) >= CURRENT_HOOK_VERSION {
+            HookStatus::Ok
+        } else {
+            HookStatus::Outdated
+        };
     }
+
+    // Check native PreToolUse hook in settings.json (Windows / cross-platform)
+    if has_native_hook(&home) {
+        return HookStatus::Ok;
+    }
+
+    HookStatus::Missing
 }
 
 /// Check if the installed hook is missing or outdated, warn once per day.
@@ -96,6 +103,18 @@ fn hook_installed_path() -> Option<PathBuf> {
     }
 }
 
+/// Check if a native PreToolUse hook containing "rtk hook-rewrite" exists in settings.json.
+/// This is the Windows-native hook mechanism (no bash script needed).
+fn has_native_hook(home: &std::path::Path) -> bool {
+    let settings_path = home.join(".claude").join("settings.json");
+    let content = match std::fs::read_to_string(&settings_path) {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    // Quick substring check — avoids pulling in serde_json for a simple detection
+    content.contains("rtk hook-rewrite") && content.contains("PreToolUse")
+}
+
 fn warn_marker_path() -> Option<PathBuf> {
     let data_dir = dirs::data_local_dir()?.join("rtk");
     Some(data_dir.join(".hook_warn_last"))
@@ -141,31 +160,48 @@ mod tests {
 
     #[test]
     fn test_status_returns_valid_variant() {
-        // Skip on machines without Claude Code or without hook
+        // Skip on machines without Claude Code
         let home = match dirs::home_dir() {
             Some(h) => h,
             None => return,
         };
-        if !home
+        if !home.join(".claude").exists() {
+            assert_eq!(status(), HookStatus::Ok);
+            return;
+        }
+
+        let has_bash_hook = home
             .join(".claude")
             .join("hooks")
             .join("rtk-rewrite.sh")
-            .exists()
-        {
-            // No hook — status should be Missing (if .claude exists) or Ok (if not)
-            let s = status();
-            if home.join(".claude").exists() {
-                assert_eq!(s, HookStatus::Missing);
-            } else {
-                assert_eq!(s, HookStatus::Ok);
-            }
-            return;
-        }
+            .exists();
+        let has_native = has_native_hook(&home);
+
         let s = status();
+        if has_bash_hook || has_native {
+            assert!(
+                s == HookStatus::Ok || s == HookStatus::Outdated,
+                "Expected Ok or Outdated when hook exists, got {:?}",
+                s
+            );
+        } else {
+            assert_eq!(s, HookStatus::Missing);
+        }
+    }
+
+    #[test]
+    fn test_has_native_hook_detection() {
+        // Test with synthetic settings content via the substring check logic
+        let content_with_hook = r#"{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"rtk hook-rewrite"}]}]}}"#;
         assert!(
-            s == HookStatus::Ok || s == HookStatus::Outdated,
-            "Expected Ok or Outdated when hook exists, got {:?}",
-            s
+            content_with_hook.contains("rtk hook-rewrite")
+                && content_with_hook.contains("PreToolUse")
+        );
+
+        let content_without = r#"{"hooks":{}}"#;
+        assert!(
+            !(content_without.contains("rtk hook-rewrite")
+                && content_without.contains("PreToolUse"))
         );
     }
 }

--- a/src/hook_rewrite_cmd.rs
+++ b/src/hook_rewrite_cmd.rs
@@ -1,0 +1,131 @@
+use crate::config;
+use crate::discover::registry;
+use anyhow::{Context, Result};
+use std::io::Read;
+
+/// Native Claude Code PreToolUse hook for command rewriting.
+///
+/// Reads the hook JSON from stdin, extracts `.tool_input.command`,
+/// rewrites it via the registry, and outputs the hook response JSON.
+///
+/// Replaces the bash+jq hook (`hooks/rtk-rewrite.sh`) for cross-platform support.
+///
+/// Protocol: https://docs.anthropic.com/en/docs/claude-code/hooks
+pub fn run() -> Result<()> {
+    let mut input = String::new();
+    std::io::stdin()
+        .read_to_string(&mut input)
+        .context("Failed to read hook input from stdin")?;
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&input).context("Failed to parse hook JSON")?;
+
+    let cmd = match parsed
+        .get("tool_input")
+        .and_then(|ti| ti.get("command"))
+        .and_then(|c| c.as_str())
+    {
+        Some(c) => c,
+        None => {
+            // No command field — pass through silently
+            return Ok(());
+        }
+    };
+
+    let excluded = config::Config::load()
+        .map(|c| c.hooks.exclude_commands)
+        .unwrap_or_default();
+
+    let rewritten = match registry::rewrite_command(cmd, &excluded) {
+        Some(r) if r != cmd => r,
+        _ => {
+            // No rewrite needed — exit silently (empty output = pass through)
+            return Ok(());
+        }
+    };
+
+    // Build the updated tool_input with the rewritten command
+    let mut updated_input = parsed
+        .get("tool_input")
+        .cloned()
+        .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+    updated_input["command"] = serde_json::Value::String(rewritten);
+
+    let response = serde_json::json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "permissionDecisionReason": "RTK auto-rewrite",
+            "updatedInput": updated_input
+        }
+    });
+
+    println!(
+        "{}",
+        serde_json::to_string(&response).context("Failed to serialize hook response")?
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rewrite_hook_json_structure() {
+        // Verify the JSON response structure matches Claude Code hook protocol
+        let response = serde_json::json!({
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "allow",
+                "permissionDecisionReason": "RTK auto-rewrite",
+                "updatedInput": {
+                    "command": "rtk git status",
+                    "description": "test"
+                }
+            }
+        });
+
+        let output = response.get("hookSpecificOutput").unwrap();
+        assert_eq!(output["hookEventName"], "PreToolUse");
+        assert_eq!(output["permissionDecision"], "allow");
+        assert_eq!(output["updatedInput"]["command"], "rtk git status");
+    }
+
+    #[test]
+    fn test_rewrite_preserves_other_fields() {
+        let input: serde_json::Value = serde_json::json!({
+            "tool_input": {
+                "command": "git status",
+                "description": "Show working tree status",
+                "timeout": 30000
+            }
+        });
+
+        let cmd = input["tool_input"]["command"].as_str().unwrap();
+        let rewritten = registry::rewrite_command(cmd, &[]).unwrap();
+
+        let mut updated = input["tool_input"].clone();
+        updated["command"] = serde_json::Value::String(rewritten);
+
+        // All original fields preserved
+        assert_eq!(updated["command"], "rtk git status");
+        assert_eq!(updated["description"], "Show working tree status");
+        assert_eq!(updated["timeout"], 30000);
+    }
+
+    #[test]
+    fn test_unsupported_returns_none() {
+        // Unsupported commands should return None (no rewrite)
+        let cmd = "htop";
+        assert!(registry::rewrite_command(cmd, &[]).is_none());
+    }
+
+    #[test]
+    fn test_no_rewrite_for_already_rtk() {
+        let cmd = "rtk git status";
+        let result = registry::rewrite_command(cmd, &[]).unwrap();
+        // Same as input — hook should skip
+        assert_eq!(result, cmd);
+    }
+}

--- a/src/init.rs
+++ b/src/init.rs
@@ -511,7 +511,7 @@ pub fn uninstall(global: bool, verbose: u8) -> Result<()> {
             fs::write(&claude_md_path, cleaned).with_context(|| {
                 format!("Failed to write CLAUDE.md: {}", claude_md_path.display())
             })?;
-            removed.push("CLAUDE.md: removed @RTK.md reference".to_string());
+            removed.push(format!("CLAUDE.md: removed @RTK.md reference"));
         }
     }
 
@@ -570,7 +570,7 @@ fn patch_settings_json(
     };
 
     // Check idempotency
-    if hook_already_present(&root, hook_command) {
+    if hook_already_present(&root, &hook_command) {
         if verbose > 0 {
             eprintln!("settings.json: hook already present");
         }
@@ -595,7 +595,7 @@ fn patch_settings_json(
     }
 
     // Deep-merge hook
-    insert_hook_entry(&mut root, hook_command);
+    insert_hook_entry(&mut root, &hook_command);
 
     // Backup original
     if settings_path.exists() {

--- a/src/init.rs
+++ b/src/init.rs
@@ -7,6 +7,7 @@ use tempfile::NamedTempFile;
 use crate::integrity;
 
 // Embedded hook script (guards before set -euo pipefail)
+#[cfg(any(unix, test))]
 const REWRITE_HOOK: &str = include_str!("../hooks/rtk-rewrite.sh");
 
 // Embedded OpenCode plugin (auto-rewrite)
@@ -16,6 +17,7 @@ const OPENCODE_PLUGIN: &str = include_str!("../hooks/opencode-rtk.ts");
 const RTK_SLIM: &str = include_str!("../hooks/rtk-awareness.md");
 
 /// Template written by `rtk init` when no filters.toml exists yet.
+#[allow(dead_code)] // Used on Unix builds only
 const FILTERS_TEMPLATE: &str = r#"# Project-local RTK filters — commit this file with your repo.
 # Filters here override user-global and built-in filters.
 # Docs: https://github.com/rtk-ai/rtk#custom-filters
@@ -32,6 +34,7 @@ schema_version = 1
 "#;
 
 /// Template for user-global filters (~/.config/rtk/filters.toml).
+#[allow(dead_code)] // Used on Unix builds only
 const FILTERS_GLOBAL_TEMPLATE: &str = r#"# User-global RTK filters — apply to all your projects.
 # Project-local .rtk/filters.toml takes precedence over these.
 # Docs: https://github.com/rtk-ai/rtk#custom-filters
@@ -226,6 +229,7 @@ pub fn run(
 }
 
 /// Prepare hook directory and return paths (hook_dir, hook_path)
+#[cfg(unix)]
 fn prepare_hook_paths() -> Result<(PathBuf, PathBuf)> {
     let claude_dir = resolve_claude_dir()?;
     let hook_dir = claude_dir.join("hooks");
@@ -507,7 +511,7 @@ pub fn uninstall(global: bool, verbose: u8) -> Result<()> {
             fs::write(&claude_md_path, cleaned).with_context(|| {
                 format!("Failed to write CLAUDE.md: {}", claude_md_path.display())
             })?;
-            removed.push(format!("CLAUDE.md: removed @RTK.md reference"));
+            removed.push("CLAUDE.md: removed @RTK.md reference".to_string());
         }
     }
 
@@ -566,7 +570,7 @@ fn patch_settings_json(
     };
 
     // Check idempotency
-    if hook_already_present(&root, &hook_command) {
+    if hook_already_present(&root, hook_command) {
         if verbose > 0 {
             eprintln!("settings.json: hook already present");
         }
@@ -591,7 +595,7 @@ fn patch_settings_json(
     }
 
     // Deep-merge hook
-    insert_hook_entry(&mut root, &hook_command);
+    insert_hook_entry(&mut root, hook_command);
 
     // Backup original
     if settings_path.exists() {
@@ -711,24 +715,61 @@ fn hook_already_present(root: &serde_json::Value, hook_command: &str) -> bool {
         .flatten()
         .filter_map(|hook| hook.get("command")?.as_str())
         .any(|cmd| {
-            // Exact match OR both contain rtk-rewrite.sh
+            // Exact match OR both contain rtk-rewrite.sh OR native hook-rewrite
             cmd == hook_command
                 || (cmd.contains("rtk-rewrite.sh") && hook_command.contains("rtk-rewrite.sh"))
+                || cmd.contains("rtk hook-rewrite")
         })
 }
 
-/// Default mode: hook + slim RTK.md + @RTK.md reference
+/// Default mode: native hook + CLAUDE.md injection
 #[cfg(not(unix))]
 fn run_default_mode(
-    _global: bool,
-    _patch_mode: PatchMode,
-    _verbose: u8,
+    global: bool,
+    patch_mode: PatchMode,
+    verbose: u8,
     _install_opencode: bool,
 ) -> Result<()> {
-    eprintln!("⚠️  Hook-based mode requires Unix (macOS/Linux).");
-    eprintln!("    Windows: use --claude-md mode for full injection.");
-    eprintln!("    Falling back to --claude-md mode.");
-    run_claude_md_mode(_global, _verbose, _install_opencode)
+    if !global {
+        // Local init: full injection into ./CLAUDE.md (no hook)
+        return run_claude_md_mode(false, verbose, _install_opencode);
+    }
+
+    let claude_dir = resolve_claude_dir()?;
+    let rtk_md_path = claude_dir.join("RTK.md");
+    let claude_md_path = claude_dir.join("CLAUDE.md");
+
+    // 1. Write slim RTK.md (30 lines vs 133-line full block)
+    write_if_changed(&rtk_md_path, RTK_SLIM, "RTK.md", verbose)?;
+
+    // 2. Patch CLAUDE.md (add @RTK.md, migrate old block if present)
+    let migrated = patch_claude_md(&claude_md_path, verbose)?;
+
+    // 3. Patch settings.json with native hook
+    let hook_command = "rtk hook-rewrite";
+    let dummy_path = std::path::PathBuf::from(hook_command);
+    let patch_result = patch_settings_json(&dummy_path, patch_mode, verbose, false)?;
+
+    // 4. Print summary
+    println!("\nRTK init complete (global).\n");
+    println!("  RTK.md:    {} (slim, 30 lines)", rtk_md_path.display());
+    println!("  CLAUDE.md: @RTK.md reference added");
+
+    if migrated {
+        println!("\n  Migrated: removed 133-line RTK block from CLAUDE.md");
+        println!("            replaced with @RTK.md (30 lines)");
+    }
+
+    match patch_result {
+        PatchResult::Patched => {}
+        PatchResult::AlreadyPresent => {
+            println!("  settings.json: hook already present");
+            println!("  Restart Claude Code. Test with: git status");
+        }
+        PatchResult::Declined | PatchResult::Skipped => {}
+    }
+
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -816,6 +857,7 @@ fn run_default_mode(
 }
 
 /// Generate .rtk/filters.toml template in the current directory if not present.
+#[allow(dead_code)] // Used on Unix builds only
 fn generate_project_filters_template(verbose: u8) -> Result<()> {
     let rtk_dir = std::path::Path::new(".rtk");
     let path = rtk_dir.join("filters.toml");
@@ -840,6 +882,7 @@ fn generate_project_filters_template(verbose: u8) -> Result<()> {
 }
 
 /// Generate ~/.config/rtk/filters.toml template if not present.
+#[allow(dead_code)] // Used on Unix builds only
 fn generate_global_filters_template(verbose: u8) -> Result<()> {
     let config_dir = dirs::config_dir().unwrap_or_else(|| std::path::PathBuf::from(".config"));
     let rtk_dir = config_dir.join("rtk");
@@ -867,12 +910,33 @@ fn generate_global_filters_template(verbose: u8) -> Result<()> {
 /// Hook-only mode: just the hook, no RTK.md
 #[cfg(not(unix))]
 fn run_hook_only_mode(
-    _global: bool,
-    _patch_mode: PatchMode,
-    _verbose: u8,
+    global: bool,
+    patch_mode: PatchMode,
+    verbose: u8,
     _install_opencode: bool,
 ) -> Result<()> {
-    anyhow::bail!("Hook install requires Unix (macOS/Linux). Use WSL or --claude-md mode.")
+    if !global {
+        eprintln!("⚠️  Warning: --hook-only only makes sense with --global");
+        eprintln!("    For local projects, use default mode or --claude-md");
+        return Ok(());
+    }
+
+    // On Windows, use the native `rtk hook-rewrite` command
+    let hook_command = "rtk hook-rewrite";
+    let dummy_path = std::path::PathBuf::from(hook_command);
+    let patch_result = patch_settings_json(&dummy_path, patch_mode, verbose, false)?;
+
+    match patch_result {
+        PatchResult::Patched => {
+            println!("Native hook registered (rtk hook-rewrite)");
+        }
+        PatchResult::AlreadyPresent => {
+            println!("Hook already present in settings.json");
+        }
+        _ => {}
+    }
+
+    Ok(())
 }
 
 #[cfg(unix)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ mod grep_cmd;
 mod gt_cmd;
 mod hook_audit_cmd;
 mod hook_check;
+mod hook_rewrite_cmd;
 mod init;
 mod integrity;
 mod json_cmd;
@@ -638,6 +639,10 @@ enum Commands {
         #[arg(short, long, default_value = "7")]
         since: u64,
     },
+
+    /// Native Claude Code PreToolUse hook (reads JSON from stdin, no jq needed)
+    #[command(name = "hook-rewrite")]
+    HookRewrite,
 
     /// Rewrite a raw command to its RTK equivalent (single source of truth for hooks)
     ///
@@ -1960,6 +1965,10 @@ fn main() -> Result<()> {
 
         Commands::HookAudit { since } => {
             hook_audit_cmd::run(since, cli.verbose)?;
+        }
+
+        Commands::HookRewrite => {
+            hook_rewrite_cmd::run()?;
         }
 
         Commands::Rewrite { args } => {


### PR DESCRIPTION
## Summary

- **`rtk hook-rewrite` command**: Native Claude Code PreToolUse hook that reads JSON from stdin, rewrites commands via the registry, and outputs hook response JSON — replaces the bash+jq dependency for cross-platform support
- **Windows `rtk init -g`**: Now registers native hook instead of falling back to `--claude-md` mode
- **Windows `rtk init -g --hook-only`**: Uses native hook instead of bailing with an error
- **`#[cfg(unix)]` guards**: Bash-only code paths (REWRITE_HOOK, prepare_hook_paths) properly gated
- **Clippy fixes**: Unnecessary borrows, dead code annotations in init.rs

## Why

Windows users currently get a degraded experience — `rtk init -g` falls back to `--claude-md` mode because the bash hook (`rtk-rewrite.sh`) requires Unix. The native `rtk hook-rewrite` command eliminates the bash/jq dependency entirely, making the hook work on all platforms.

## Changes

| File | Description |
|------|-------------|
| `src/hook_rewrite_cmd.rs` | New native hook: parse stdin JSON, rewrite via registry, output hook response |
| `src/main.rs` | Add `mod hook_rewrite_cmd`, `HookRewrite` command variant + routing |
| `src/init.rs` | Windows default/hook-only modes use native hook, `#[cfg(unix)]` guards, clippy fixes |

## Test plan

- [x] All 891 tests pass (1 pre-existing binlog CRLF failure)
- [x] 4 new tests: hook JSON structure, field preservation, unsupported commands, already-rtk passthrough
- [x] `cargo fmt --all --check` passes
- [x] Manual: `rtk init -g` on Windows, verify settings.json gets `rtk hook-rewrite` entry
- [x] Manual: pipe hook JSON to `echo '{"tool_input":{"command":"git status"}}' | rtk hook-rewrite`

🤖 Generated with [Claude Code](https://claude.com/claude-code)