### PR TITLE
fix: support git -C <path> in rewrite registry

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -936,6 +936,48 @@ mod tests {
         );
     }
 
+    // --- git -C <path> support (#555) ---
+
+    #[test]
+    fn test_rewrite_git_dash_c_status() {
+        assert_eq!(
+            rewrite_command("git -C /path/to/repo status", &[]),
+            Some("rtk git -C /path/to/repo status".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_git_dash_c_log() {
+        assert_eq!(
+            rewrite_command("git -C /tmp/myrepo log --oneline -5", &[]),
+            Some("rtk git -C /tmp/myrepo log --oneline -5".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_git_dash_c_diff() {
+        assert_eq!(
+            rewrite_command("git -C /home/user/project diff --name-only", &[]),
+            Some("rtk git -C /home/user/project diff --name-only".into())
+        );
+    }
+
+    #[test]
+    fn test_classify_git_dash_c() {
+        let result = classify_command("git -C /tmp status");
+        assert!(
+            matches!(
+                result,
+                Classification::Supported {
+                    rtk_equivalent: "rtk git",
+                    ..
+                }
+            ),
+            "git -C should be classified as supported, got: {:?}",
+            result
+        );
+    }
+
     #[test]
     fn test_rewrite_cargo_test() {
         assert_eq!(

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -13,7 +13,7 @@ pub struct RtkRule {
 
 // Patterns ordered to match RULES indices exactly.
 pub const PATTERNS: &[&str] = &[
-    r"^git\s+(status|log|diff|show|add|commit|push|pull|branch|fetch|stash|worktree)",
+    r"^git\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|push|pull|branch|fetch|stash|worktree)",
     r"^gh\s+(pr|issue|run|repo|api|release)",
     r"^cargo\s+(build|test|clippy|check|fmt|install)",
     r"^pnpm\s+(list|ls|outdated|install)",


### PR DESCRIPTION
## Summary

- Fixes `rtk rewrite` not recognizing `git -C <path> <subcommand>` commands
- Updates regex pattern to accept `-C` and `-c` flags before the git subcommand using a non-capturing group `(?:-[Cc]\s+\S+\s+)*`
- Adds 4 tests: rewrite with `-C` for status/log/diff + classify verification

## Before / After

```bash
# Before (exit 1, no rewrite):
rtk rewrite 'git -C /tmp status'        # → nothing

# After:
rtk rewrite 'git -C /tmp status'        # → rtk git -C /tmp status
rtk rewrite 'git -C /tmp log -5'        # → rtk git -C /tmp log -5
rtk rewrite 'git -C /tmp diff --name-only' # → rtk git -C /tmp diff --name-only
```

## Test plan

- [x] 4 new tests for `git -C` support (rewrite + classify)
- [x] 156 existing registry tests still pass
- [x] `git diff --cached` not broken (non-capturing group preserves subcommand extraction)
- [x] Manual verification with `cargo run -- rewrite`

Closes #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)