### PR TITLE
fix: forward exit codes in err, test, and summary commands

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -293,7 +293,7 @@ SHARED            utils.rs          Helpers                N/A        ✓
                   tee.rs            Full output recovery   N/A        ✓
 ```
 
-**Total: 60 modules** (38 command modules + 22 infrastructure modules)
+**Total: 64 modules** (42 command modules + 22 infrastructure modules)
 
 ### Module Count Breakdown
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -59,6 +59,9 @@ pub fn run_err(command: &str, verbose: u8) -> Result<()> {
         println!("{}", rtk);
     }
     timer.track(command, "rtk run-err", &raw, &rtk);
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
     Ok(())
 }
 
@@ -100,6 +103,9 @@ pub fn run_test(command: &str, verbose: u8) -> Result<()> {
         println!("{}", summary);
     }
     timer.track(command, "rtk run-test", &raw, &summary);
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
     Ok(())
 }
 
@@ -267,5 +273,36 @@ mod tests {
         let filtered = filter_errors(output);
         assert!(filtered.contains("error"));
         assert!(!filtered.contains("info"));
+    }
+
+    #[test]
+    #[ignore]
+    fn test_err_forwards_exit_code_nonzero() {
+        // Requires rtk to be installed on PATH (cargo install --path .)
+        let output = std::process::Command::new("rtk")
+            .args(["err", "sh", "-c", "exit 2"])
+            .output()
+            .expect("failed to run rtk — install with: cargo install --path .");
+        assert_eq!(output.status.code(), Some(2));
+    }
+
+    #[test]
+    #[ignore]
+    fn test_err_forwards_exit_code_zero() {
+        let output = std::process::Command::new("rtk")
+            .args(["err", "sh", "-c", "exit 0"])
+            .output()
+            .expect("failed to run rtk — install with: cargo install --path .");
+        assert_eq!(output.status.code(), Some(0));
+    }
+
+    #[test]
+    #[ignore]
+    fn test_test_forwards_exit_code_nonzero() {
+        let output = std::process::Command::new("rtk")
+            .args(["test", "sh", "-c", "exit 1"])
+            .output()
+            .expect("failed to run rtk — install with: cargo install --path .");
+        assert_eq!(output.status.code(), Some(1));
     }
 }

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -31,9 +31,16 @@ pub fn run(command: &str, verbose: u8) -> Result<()> {
     let stderr = String::from_utf8_lossy(&output.stderr);
     let raw = format!("{}\n{}", stdout, stderr);
 
+    let exit_code = output
+        .status
+        .code()
+        .unwrap_or(if output.status.success() { 0 } else { 1 });
     let summary = summarize_output(&raw, command, output.status.success());
     println!("{}", summary);
     timer.track(command, "rtk summary", &raw, &summary);
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Problem

`rtk err`, `rtk test`, and `rtk summary` always returned exit code 0, even when the wrapped command failed. The exit code was computed but never forwarded.

Reproduction from #557:
```
rtk err zsh -c 'exit 1'  # → exit: 0 (wrong)
rtk test false            # → exit: 0 (wrong)
rtk summary false         # → exit: 0 (wrong)
```

## Root cause

All three commands called `std::process::exit` nowhere after computing `exit_code`. They returned `Ok(())` unconditionally.

## Fix

Added `if exit_code != 0 { std::process::exit(exit_code); }` before returning in `runner::run_err`, `runner::run_test`, and `summary::run`.

## Verification

```
rtk err false       # → exit: 1 ✓
rtk err true        # → exit: 0 ✓
rtk summary false   # → exit: 1 ✓
rtk test false      # → exit: 1 ✓
```

Integration tests added (marked `#[ignore]`, require `rtk` on PATH):
- `test_err_forwards_exit_code_nonzero`
- `test_err_forwards_exit_code_zero`
- `test_test_forwards_exit_code_nonzero`

Closes #557