### PR TITLE
fix: hint when git diff truncated + --no-compact passthrough (#427)

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -76,6 +76,9 @@ fn run_diff(
         let mut cmd = git_cmd(global_args);
         cmd.arg("diff");
         for arg in args {
+            if arg == "--no-compact" {
+                continue; // RTK flag, not a git flag
+            }
             cmd.arg(arg);
         }
 
@@ -279,6 +282,7 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
     let mut in_hunk = false;
     let mut hunk_lines = 0;
     let max_hunk_lines = 30;
+    let mut was_truncated = false;
 
     for line in diff.lines() {
         if line.starts_with("diff --git") {
@@ -287,7 +291,7 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
                 result.push(format!("  +{} -{}", added, removed));
             }
             current_file = line.split(" b/").nth(1).unwrap_or("unknown").to_string();
-            result.push(format!("\n📄 {}", current_file));
+            result.push(format!("\n{}", current_file));
             added = 0;
             removed = 0;
             in_hunk = false;
@@ -321,17 +325,23 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
             if hunk_lines == max_hunk_lines {
                 result.push("  ... (truncated)".to_string());
                 hunk_lines += 1;
+                was_truncated = true;
             }
         }
 
         if result.len() >= max_lines {
             result.push("\n... (more changes truncated)".to_string());
+            was_truncated = true;
             break;
         }
     }
 
     if !current_file.is_empty() && (added > 0 || removed > 0) {
         result.push(format!("  +{} -{}", added, removed));
+    }
+
+    if was_truncated {
+        result.push("[full diff: rtk git diff --no-compact]".to_string());
     }
 
     result.join("\n")


### PR DESCRIPTION
## Summary
- When `compact_diff()` truncates output (>30 lines/hunk or >500 lines total), append a hint: `[full diff: rtk git diff --no-compact]`
- Fix `--no-compact` flag being passed through to git (caused `usage: git diff` error)
- Remove decorative emoji `📄` from compact diff output

## Before
```
  ... (more changes truncated)
```
Claude doesn't know how to get the full diff.

## After
```
  ... (more changes truncated)
[full diff: rtk git diff --no-compact]
```
Claude sees the hint and can run `rtk git diff --no-compact` to get the full output.

## Tested locally
- Large diff (truncated): hint appears at the end ✅
- Small diff (not truncated): no hint ✅
- `rtk git diff --no-compact`: full raw diff, flag stripped before passing to git ✅
- 900 tests pass ✅

Fixes #427