### PR TITLE
fix: rewrite docker-compose (legacy hyphenated CLI) to rtk docker compose

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1443,6 +1443,51 @@ mod tests {
         );
     }
 
+    // --- docker-compose (legacy hyphenated CLI) ---
+
+    #[test]
+    fn test_rewrite_docker_compose_legacy_ps() {
+        assert_eq!(
+            rewrite_command("docker-compose ps", &[]),
+            Some("rtk docker compose ps".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_docker_compose_legacy_logs() {
+        assert_eq!(
+            rewrite_command("docker-compose logs web", &[]),
+            Some("rtk docker compose logs web".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_docker_compose_legacy_logs_no_service() {
+        assert_eq!(
+            rewrite_command("docker-compose logs", &[]),
+            Some("rtk docker compose logs".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_docker_compose_legacy_build() {
+        assert_eq!(
+            rewrite_command("docker-compose build", &[]),
+            Some("rtk docker compose build".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_docker_compose_legacy_up_skipped() {
+        // unsupported subcommand — must not rewrite
+        assert_eq!(rewrite_command("docker-compose up -d", &[]), None);
+    }
+
+    #[test]
+    fn test_rewrite_docker_compose_legacy_down_skipped() {
+        assert_eq!(rewrite_command("docker-compose down", &[]), None);
+    }
+
     // --- AWS / psql (PR #216) ---
 
     #[test]

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -31,6 +31,7 @@ pub const PATTERNS: &[&str] = &[
     r"^(npx\s+|pnpm\s+)?playwright",
     r"^(npx\s+|pnpm\s+)?prisma",
     r"^docker\s+(ps|images|logs|run|exec|build|compose\s+(ps|logs|build))",
+    r"^docker-compose\s+(ps|logs|build)",
     r"^kubectl\s+(get|logs|describe|apply)",
     r"^tree(\s|$)",
     r"^diff\s+",
@@ -237,6 +238,14 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         rtk_cmd: "rtk docker",
         rewrite_prefixes: &["docker"],
+        category: "Infra",
+        savings_pct: 85.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
+    RtkRule {
+        rtk_cmd: "rtk docker compose",
+        rewrite_prefixes: &["docker-compose"],
         category: "Infra",
         savings_pct: 85.0,
         subcmd_savings: &[],


### PR DESCRIPTION
## Problem

Users on the legacy `docker-compose` CLI (hyphenated, v1) get 0% savings — the rewrite registry only handles `docker compose` (space-separated, v2). From `rtk discover` on a real machine, 40+ runs of `docker-compose logs` are fully missed.

## Solution

Add a PATTERN and `RtkRule` for `docker-compose` that maps supported subcommands to `rtk docker compose`:

| Command | Rewrites to |
|---|---|
| `docker-compose ps` | `rtk docker compose ps` |
| `docker-compose logs [service]` | `rtk docker compose logs [service]` |
| `docker-compose build [service]` | `rtk docker compose build [service]` |
| `docker-compose up` | *(not rewritten — passthrough)* |
| `docker-compose down` | *(not rewritten — passthrough)* |

The filter code in `container.rs` already handles all three supported subcommands — this PR only adds the missing rewrite routing.

## Changes

- `src/discover/rules.rs`: new pattern + `RtkRule` for `docker-compose`
- `src/discover/registry.rs`: 6 tests (3 supported, 3 skipped)

## Testing

All 6 new tests cover the supported/skipped split:
```
test_rewrite_docker_compose_legacy_ps         ✓
test_rewrite_docker_compose_legacy_logs       ✓
test_rewrite_docker_compose_legacy_logs_no_service ✓
test_rewrite_docker_compose_legacy_build      ✓
test_rewrite_docker_compose_legacy_up_skipped ✓
test_rewrite_docker_compose_legacy_down_skipped ✓
```

Relates to #578.

🤖 Generated with [Claude Code](https://claude.com/claude-code)