### PR TITLE
fix: resolve clippy warnings in container, git, and init modules

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -60,7 +60,12 @@ fn docker_ps(_verbose: u8) -> Result<()> {
         if parts.len() >= 4 {
             let id = &parts[0][..12.min(parts[0].len())];
             let name = parts[1];
-            let short_image = parts.get(3).unwrap_or(&"").split('/').last().unwrap_or("");
+            let short_image = parts
+                .get(3)
+                .unwrap_or(&"")
+                .split('/')
+                .next_back()
+                .unwrap_or("");
             let ports = compact_ports(parts.get(4).unwrap_or(&""));
             if ports == "-" {
                 rtk.push_str(&format!("  {} {} ({})\n", id, name, short_image));
@@ -508,7 +513,7 @@ fn compact_ports(ports: &str) -> String {
     // Extract just the port numbers
     let port_nums: Vec<&str> = ports
         .split(',')
-        .filter_map(|p| p.split("->").next().and_then(|s| s.split(':').last()))
+        .filter_map(|p| p.split("->").next().and_then(|s| s.split(':').next_back()))
         .collect();
 
     if port_nums.len() <= 3 {

--- a/src/git.rs
+++ b/src/git.rs
@@ -355,7 +355,7 @@ fn run_log(
 
     // Check if user provided limit flag (-N, -n N, --max-count=N, --max-count N)
     let has_limit_flag = args.iter().any(|arg| {
-        (arg.starts_with('-') && arg.chars().nth(1).map_or(false, |c| c.is_ascii_digit()))
+        (arg.starts_with('-') && arg.chars().nth(1).is_some_and(|c| c.is_ascii_digit()))
             || arg == "-n"
             || arg.starts_with("--max-count")
     });
@@ -433,7 +433,7 @@ fn parse_user_limit(args: &[String]) -> Option<usize> {
         // -20 (combined digit form)
         if arg.starts_with('-')
             && arg.len() > 1
-            && arg.chars().nth(1).map_or(false, |c| c.is_ascii_digit())
+            && arg.chars().nth(1).is_some_and(|c| c.is_ascii_digit())
         {
             if let Ok(n) = arg[1..].parse::<usize>() {
                 return Some(n);
@@ -815,7 +815,7 @@ fn run_commit(args: &[String], verbose: u8, global_args: &[String]) -> Result<()
         // Extract commit hash from output like "[main abc1234] message"
         let compact = if let Some(line) = stdout.lines().next() {
             if let Some(hash_start) = line.find(' ') {
-                let hash = line[1..hash_start].split(' ').last().unwrap_or("");
+                let hash = line[1..hash_start].split(' ').next_back().unwrap_or("");
                 if !hash.is_empty() && hash.len() >= 7 {
                     format!("ok ✓ {}", &hash[..7.min(hash.len())])
                 } else {

--- a/src/init.rs
+++ b/src/init.rs
@@ -507,7 +507,7 @@ pub fn uninstall(global: bool, verbose: u8) -> Result<()> {
             fs::write(&claude_md_path, cleaned).with_context(|| {
                 format!("Failed to write CLAUDE.md: {}", claude_md_path.display())
             })?;
-            removed.push(format!("CLAUDE.md: removed @RTK.md reference"));
+            removed.push("CLAUDE.md: removed @RTK.md reference".to_string());
         }
     }
 
@@ -566,7 +566,7 @@ fn patch_settings_json(
     };
 
     // Check idempotency
-    if hook_already_present(&root, &hook_command) {
+    if hook_already_present(&root, hook_command) {
         if verbose > 0 {
             eprintln!("settings.json: hook already present");
         }
@@ -591,7 +591,7 @@ fn patch_settings_json(
     }
 
     // Deep-merge hook
-    insert_hook_entry(&mut root, &hook_command);
+    insert_hook_entry(&mut root, hook_command);
 
     // Backup original
     if settings_path.exists() {


### PR DESCRIPTION
## Summary

- Apply clippy suggestions carved out from feature PRs #551 and #552 to keep those PRs focused on their stated scope
- **container.rs**: `.last()` → `.next_back()` (2 instances)
- **git.rs**: `.map_or(false, ...)` → `.is_some_and(...)` (2 instances), `.last()` → `.next_back()` (1 instance)
- **init.rs**: unnecessary `format!()` → `.to_string()` (1 instance), unnecessary `&` on `&str` parameters (2 instances)

## Test plan

- [x] `cargo clippy --all-targets` passes
- [x] `cargo test` passes (937 passed, 2 pre-existing failures unrelated to these changes)
- [x] No behavioral changes — pure clippy cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)