### PR TITLE
feat(minor): Add json output to the gain command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to rtk (Rust Token Killer) will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Features
+
+* **gain:** add `--json` / `-j` flag as shorthand for `--format json` — `rtk gain --json` outputs a JSON dictionary of all token savings stats
+
 ## [0.28.2](https://github.com/rtk-ai/rtk/compare/v0.28.1...v0.28.2) (2026-03-10)
 
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,8 @@ rtk gain                        # Summary stats
 rtk gain --graph                # ASCII graph (last 30 days)
 rtk gain --history              # Recent command history
 rtk gain --daily                # Day-by-day breakdown
-rtk gain --all --format json    # JSON export for dashboards
+rtk gain --json                 # JSON output (shorthand for --format json)
+rtk gain --all --format json    # JSON export with all breakdowns for dashboards
 
 rtk discover                    # Find missed savings opportunities
 rtk discover --all --since 7    # All projects, last 7 days

--- a/src/gain.rs
+++ b/src/gain.rs
@@ -20,6 +20,7 @@ pub fn run(
     all: bool,
     format: &str,
     failures: bool,
+    json: bool,
     _verbose: u8,
 ) -> Result<()> {
     let tracker = Tracker::new().context("Failed to initialize tracking database")?;
@@ -30,7 +31,8 @@ pub fn run(
     }
 
     // Handle export formats
-    match format {
+    let effective_format = if json { "json" } else { format };
+    match effective_format {
         "json" => {
             return export_json(
                 &tracker,

--- a/src/main.rs
+++ b/src/main.rs
@@ -407,6 +407,9 @@ enum Commands {
         /// Output format: text, json, csv
         #[arg(short, long, default_value = "text")]
         format: String,
+        /// Output as JSON (shorthand for --format json)
+        #[arg(short = 'j', long)]
+        json: bool,
         /// Show parse failure log (commands that fell back to raw execution)
         #[arg(short = 'F', long)]
         failures: bool,
@@ -1650,6 +1653,7 @@ fn main() -> Result<()> {
             monthly,
             all,
             format,
+            json,
             failures,
         } => {
             gain::run(
@@ -1664,6 +1668,7 @@ fn main() -> Result<()> {
                 all,
                 &format,
                 failures,
+                json,
                 cli.verbose,
             )?;
         }
@@ -2361,6 +2366,42 @@ mod tests {
         if let Ok(cli) = result {
             match cli.command {
                 Commands::Gain { failures, .. } => assert!(failures),
+                _ => panic!("Expected Gain command"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_gain_json_flag_parses() {
+        let result = Cli::try_parse_from(["rtk", "gain", "--json"]);
+        assert!(result.is_ok());
+        if let Ok(cli) = result {
+            match cli.command {
+                Commands::Gain { json, .. } => assert!(json),
+                _ => panic!("Expected Gain command"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_gain_json_short_flag_parses() {
+        let result = Cli::try_parse_from(["rtk", "gain", "-j"]);
+        assert!(result.is_ok());
+        if let Ok(cli) = result {
+            match cli.command {
+                Commands::Gain { json, .. } => assert!(json),
+                _ => panic!("Expected Gain command"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_gain_json_default_is_false() {
+        let result = Cli::try_parse_from(["rtk", "gain"]);
+        assert!(result.is_ok());
+        if let Ok(cli) = result {
+            match cli.command {
+                Commands::Gain { json, .. } => assert!(!json),
                 _ => panic!("Expected Gain command"),
             }
         }


### PR DESCRIPTION
We are internally post-processing the token gain information for statistical purposes. Instead of parsing the text output, make rtk return this in json format for easier parsing.