### PR TITLE
fix(pytest): -q mode summary line not detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-* **pytest:** fix `rtk pytest -q` incorrectly reporting "No tests collected" when tests ran ([#565](https://github.com/rtk-ai/rtk/issues/565)) — quiet mode summary line (no `===` wrapper) was not captured by the parser, causing `parse_summary_line("")` to return `(0, 0, 0)` and trigger the wrong message. Also fix false "No tests collected" when only skipped tests exist.
 * **diff:** correct truncation overflow count in condense_unified_diff ([#833](https://github.com/rtk-ai/rtk/pull/833)) ([5399f83](https://github.com/rtk-ai/rtk/commit/5399f83))
 * **git:** replace vague truncation markers with exact counts in log and grep output ([#833](https://github.com/rtk-ai/rtk/pull/833)) ([185fb97](https://github.com/rtk-ai/rtk/commit/185fb97))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+* **pytest:** fix `rtk pytest -q` incorrectly reporting "No tests collected" when tests ran ([#565](https://github.com/rtk-ai/rtk/issues/565)) — quiet mode summary line (no `===` wrapper) was not captured by the parser, causing `parse_summary_line("")` to return `(0, 0, 0)` and trigger the wrong message. Also fix false "No tests collected" when only skipped tests exist.
 * **diff:** correct truncation overflow count in condense_unified_diff ([#833](https://github.com/rtk-ai/rtk/pull/833)) ([5399f83](https://github.com/rtk-ai/rtk/commit/5399f83))
 * **git:** replace vague truncation markers with exact counts in log and grep output ([#833](https://github.com/rtk-ai/rtk/pull/833)) ([185fb97](https://github.com/rtk-ai/rtk/commit/185fb97))
 

--- a/src/cmds/python/pytest_cmd.rs
+++ b/src/cmds/python/pytest_cmd.rs
@@ -111,7 +111,21 @@ fn filter_pytest_output(output: &str) -> String {
             }
             continue;
         } else if trimmed.starts_with("===")
-            && (trimmed.contains("passed") || trimmed.contains("failed"))
+            && (trimmed.contains("passed")
+                || trimmed.contains("failed")
+                || trimmed.contains("skipped"))
+        {
+            summary_line = trimmed.to_string();
+            continue;
+        // quiet mode (-q): bare summary without === wrapper, e.g. "5 failed, 1698 passed, 2 skipped in 108.89s"
+        } else if summary_line.is_empty()
+            && !trimmed.starts_with("===")
+            && !trimmed.starts_with("FAILED")
+            && !trimmed.starts_with("ERROR")
+            && (trimmed.contains(" passed")
+                || trimmed.contains(" failed")
+                || trimmed.contains(" skipped"))
+            && trimmed.contains(" in ")
         {
             summary_line = trimmed.to_string();
             continue;
@@ -172,7 +186,7 @@ fn build_pytest_summary(summary: &str, _test_files: &[String], failures: &[Strin
         return format!("Pytest: {} passed", passed);
     }
 
-    if passed == 0 && failed == 0 {
+    if passed == 0 && failed == 0 && skipped == 0 {
         return "Pytest: No tests collected".to_string();
     }
 
@@ -368,6 +382,54 @@ collected 0 items
         assert_eq!(
             parse_summary_line("=== 3 passed, 1 failed, 2 skipped in 1.0s ==="),
             (3, 1, 2)
+        );
+    }
+
+    #[test]
+    fn test_filter_pytest_quiet_mode_failures() {
+        // In -q mode, the final summary line has NO === wrapper
+        // This was causing "No tests collected" to be reported incorrectly
+        let output = r#"=== test session starts ===
+platform linux -- Python 3.12.11, pytest-8.1.0
+collected 1705 items
+
+.......F.......
+
+=== FAILURES ===
+___ test_something ___
+
+E   AssertionError: expected True
+
+=== short test summary info ===
+FAILED tests/test_foo.py::test_something - AssertionError
+5 failed, 1698 passed, 2 skipped in 108.89s"#;
+
+        let result = filter_pytest_output(output);
+        assert!(
+            !result.contains("No tests collected"),
+            "Should not report 'No tests collected' when tests ran. Got: {}",
+            result
+        );
+        assert!(
+            result.contains("1698") || result.contains("5 failed"),
+            "Should show actual test counts. Got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_filter_pytest_only_skipped() {
+        // If only skipped tests, should NOT say "No tests collected"
+        let output = r#"=== test session starts ===
+collected 3 items
+
+=== 3 skipped in 0.10s ==="#;
+
+        let result = filter_pytest_output(output);
+        assert!(
+            !result.contains("No tests collected"),
+            "Should not say 'No tests collected' when tests were skipped. Got: {}",
+            result
         );
     }
 }


### PR DESCRIPTION
Fixes #565

In quiet mode, pytest emits the final summary without `===` wrappers. The parser only matched `===`-prefixed lines, so the summary was never captured and RTK fell back to the wrong message.