### PR TITLE
fix: align 7 TOML filter tests with on_empty behavior

### DIFF
--- a/src/filters/basedpyright.toml
+++ b/src/filters/basedpyright.toml
@@ -42,6 +42,6 @@ Found 10 source files
 expected = "0 errors, 0 warnings, 0 informations"
 
 [[tests.basedpyright]]
-name = "empty input passes through"
+name = "empty input returns on_empty message"
 input = ""
-expected = ""
+expected = "basedpyright: ok"

--- a/src/filters/biome.toml
+++ b/src/filters/biome.toml
@@ -40,6 +40,6 @@ Checked 42 files in 0.3s
 expected = "biome: ok"
 
 [[tests.biome]]
-name = "empty input passes through"
+name = "empty input returns on_empty message"
 input = ""
-expected = ""
+expected = "biome: ok"

--- a/src/filters/gcc.toml
+++ b/src/filters/gcc.toml
@@ -44,6 +44,6 @@ collect2: error: ld returned 1 exit status
 expected = "/usr/bin/ld: /tmp/main.o: undefined reference to 'missing_func'\ncollect2: error: ld returned 1 exit status"
 
 [[tests.gcc]]
-name = "empty input passes through"
+name = "empty input returns on_empty message"
 input = ""
-expected = ""
+expected = "gcc: ok"

--- a/src/filters/oxlint.toml
+++ b/src/filters/oxlint.toml
@@ -38,6 +38,6 @@ Finished in 5ms on 100 files.
 expected = "oxlint: ok"
 
 [[tests.oxlint]]
-name = "empty input passes through"
+name = "empty input returns on_empty message"
 input = ""
-expected = ""
+expected = "oxlint: ok"

--- a/src/filters/skopeo.toml
+++ b/src/filters/skopeo.toml
@@ -40,6 +40,6 @@ input = """
 expected = "{\n    \"Name\": \"docker.io/library/nginx\",\n    \"Tag\": \"latest\",\n    \"Digest\": \"sha256:abc123\",\n    \"RepoTags\": [\"latest\", \"1.25\"],\n    \"Created\": \"2026-01-01T00:00:00Z\"\n}"
 
 [[tests.skopeo]]
-name = "empty input passes through"
+name = "empty input returns on_empty message"
 input = ""
-expected = ""
+expected = "skopeo: ok"

--- a/src/filters/ty.toml
+++ b/src/filters/ty.toml
@@ -45,6 +45,6 @@ All checks passed!
 expected = "All checks passed!"
 
 [[tests.ty]]
-name = "empty input passes through"
+name = "empty input returns on_empty message"
 input = ""
-expected = ""
+expected = "ty: ok"

--- a/src/filters/xcodebuild.toml
+++ b/src/filters/xcodebuild.toml
@@ -94,6 +94,6 @@ Executed 2 tests, with 1 failure in 0.003 seconds
 expected = "Test Suite 'All tests' started at 2026-03-10 12:00:00\nTest Suite 'AppTests' started at 2026-03-10 12:00:00\nTest Case '-[AppTests testExample]' passed (0.001 seconds).\nTest Case '-[AppTests testFailing]' failed (0.002 seconds).\nTest Suite 'AppTests' passed at 2026-03-10 12:00:01\nExecuted 2 tests, with 1 failure in 0.003 seconds"
 
 [[tests.xcodebuild]]
-name = "empty input passes through"
+name = "empty input returns on_empty message"
 input = ""
-expected = ""
+expected = "xcodebuild: ok"


### PR DESCRIPTION
## The issue

7 filters added in #490 (basedpyright, biome, gcc, oxlint, skopeo, ty,xcodebuild) define `on_empty = "cmd: ok"` but their "empty input passes through" test expected empty string, contradicting the on_empty rule.

## The fix

The TOML engine correctly returns the on_empty message when output is empty. Part 2 filters (trunk-build, tofu-fmt, mix-compile…) already test this correctly. Part 3 copied the on_empty field but wrote the test expectation wrong.

-> update test expectations to match on_empty value, consistent with all other filters that use on_empty.

Before: rtk verify → 104/111 passed, 7 failed
After:  rtk verify → 111/111 passed