### PR TITLE
feat: add Cursor Agent support via --agent flag

### DIFF
--- a/hooks/cursor-rtk-rewrite.sh
+++ b/hooks/cursor-rtk-rewrite.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# rtk-hook-version: 1
+# RTK Cursor Agent hook — rewrites shell commands to use rtk for token savings.
+# Works with both Cursor editor and cursor-cli (they share ~/.cursor/hooks.json).
+# Cursor preToolUse hook format: receives JSON on stdin, returns JSON on stdout.
+# Requires: rtk >= 0.23.0, jq
+#
+# This is a thin delegating hook: all rewrite logic lives in `rtk rewrite`,
+# which is the single source of truth (src/discover/registry.rs).
+# To add or change rewrite rules, edit the Rust registry — not this file.
+
+if ! command -v jq &>/dev/null; then
+  echo "[rtk] WARNING: jq is not installed. Hook cannot rewrite commands. Install jq: https://jqlang.github.io/jq/download/" >&2
+  exit 0
+fi
+
+if ! command -v rtk &>/dev/null; then
+  echo "[rtk] WARNING: rtk is not installed or not in PATH. Hook cannot rewrite commands. Install: https://github.com/rtk-ai/rtk#installation" >&2
+  exit 0
+fi
+
+# Version guard: rtk rewrite was added in 0.23.0.
+RTK_VERSION=$(rtk --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+if [ -n "$RTK_VERSION" ]; then
+  MAJOR=$(echo "$RTK_VERSION" | cut -d. -f1)
+  MINOR=$(echo "$RTK_VERSION" | cut -d. -f2)
+  if [ "$MAJOR" -eq 0 ] && [ "$MINOR" -lt 23 ]; then
+    echo "[rtk] WARNING: rtk $RTK_VERSION is too old (need >= 0.23.0). Upgrade: cargo install rtk" >&2
+    exit 0
+  fi
+fi
+
+INPUT=$(cat)
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [ -z "$CMD" ]; then
+  echo '{}'
+  exit 0
+fi
+
+# Delegate all rewrite logic to the Rust binary.
+# rtk rewrite exits 1 when there's no rewrite — hook passes through silently.
+REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null) || { echo '{}'; exit 0; }
+
+# No change — nothing to do.
+if [ "$CMD" = "$REWRITTEN" ]; then
+  echo '{}'
+  exit 0
+fi
+
+jq -n --arg cmd "$REWRITTEN" '{
+  "permission": "allow",
+  "updated_input": { "command": $cmd }
+}'

--- a/src/discover/provider.rs
+++ b/src/discover/provider.rs
@@ -22,7 +22,11 @@ pub struct ExtractedCommand {
     pub sequence_index: usize,
 }
 
-/// Trait for session providers (Claude Code, future: Cursor, Windsurf).
+/// Trait for session providers (Claude Code, OpenCode, etc.).
+///
+/// Note: Cursor Agent transcripts use a text-only format without structured
+/// tool_use/tool_result blocks, so command extraction is not possible.
+/// Use `rtk gain` to track savings for Cursor sessions instead.
 pub trait SessionProvider {
     fn discover_sessions(
         &self,

--- a/src/discover/report.rs
+++ b/src/discover/report.rs
@@ -165,6 +165,14 @@ pub fn format_text(report: &DiscoverReport, limit: usize, verbose: bool) -> Stri
 
     out.push_str("\n~estimated from tool_result output sizes\n");
 
+    // Cursor note: check if Cursor hooks are installed
+    if let Some(home) = dirs::home_dir() {
+        let cursor_hook = home.join(".cursor").join("hooks").join("rtk-rewrite.sh");
+        if cursor_hook.exists() {
+            out.push_str("\nNote: Cursor sessions are tracked via `rtk gain` (discover scans Claude Code only)\n");
+        }
+    }
+
     if verbose && report.parse_errors > 0 {
         out.push_str(&format!("Parse errors skipped: {}\n", report.parse_errors));
     }

--- a/src/init.rs
+++ b/src/init.rs
@@ -9,6 +9,9 @@ use crate::integrity;
 // Embedded hook script (guards before set -euo pipefail)
 const REWRITE_HOOK: &str = include_str!("../hooks/rtk-rewrite.sh");
 
+// Embedded Cursor hook script (preToolUse format)
+const CURSOR_REWRITE_HOOK: &str = include_str!("../hooks/cursor-rtk-rewrite.sh");
+
 // Embedded OpenCode plugin (auto-rewrite)
 const OPENCODE_PLUGIN: &str = include_str!("../hooks/opencode-rtk.ts");
 
@@ -205,46 +208,67 @@ pub fn run(
     global: bool,
     install_claude: bool,
     install_opencode: bool,
+    install_cursor: bool,
     claude_md: bool,
     hook_only: bool,
     codex: bool,
     patch_mode: PatchMode,
     verbose: u8,
 ) -> Result<()> {
-    match (
-        codex,
-        install_claude,
-        install_opencode,
-        global,
-        claude_md,
-        hook_only,
-        patch_mode,
-    ) {
-        (true, _, true, _, _, _, _) => anyhow::bail!("--codex cannot be combined with --opencode"),
-        (true, _, _, _, true, _, _) => anyhow::bail!("--codex cannot be combined with --claude-md"),
-        (true, _, _, _, _, true, _) => anyhow::bail!("--codex cannot be combined with --hook-only"),
-        (true, _, _, _, _, _, PatchMode::Auto) => {
-            anyhow::bail!("--codex cannot be combined with --auto-patch")
+    // Validation: Codex mode conflicts
+    if codex {
+        if install_opencode {
+            anyhow::bail!("--codex cannot be combined with --opencode");
         }
-        (true, _, _, _, _, _, PatchMode::Skip) => {
-            anyhow::bail!("--codex cannot be combined with --no-patch")
+        if claude_md {
+            anyhow::bail!("--codex cannot be combined with --claude-md");
         }
-        (true, _, _, _, _, _, PatchMode::Ask) => run_codex_mode(global, verbose),
-        (false, _, true, false, _, _, _) => {
-            anyhow::bail!("OpenCode plugin is global-only. Use: rtk init -g --opencode")
+        if hook_only {
+            anyhow::bail!("--codex cannot be combined with --hook-only");
         }
-        (false, false, true, _, _, _, _) => run_opencode_only_mode(verbose),
-        (false, true, opencode, _, true, _, _) => run_claude_md_mode(global, verbose, opencode),
-        (false, true, opencode, _, false, true, _) => {
-            run_hook_only_mode(global, patch_mode, verbose, opencode)
+        if matches!(patch_mode, PatchMode::Auto) {
+            anyhow::bail!("--codex cannot be combined with --auto-patch");
         }
-        (false, true, opencode, _, false, false, _) => {
-            run_default_mode(global, patch_mode, verbose, opencode)
+        if matches!(patch_mode, PatchMode::Skip) {
+            anyhow::bail!("--codex cannot be combined with --no-patch");
         }
-        (false, false, false, _, _, _, _) => {
-            anyhow::bail!("at least one of install_claude or install_opencode must be true")
+        return run_codex_mode(global, verbose);
+    }
+
+    // Validation: Global-only features
+    if install_opencode && !global {
+        anyhow::bail!("OpenCode plugin is global-only. Use: rtk init -g --opencode");
+    }
+
+    if install_cursor && !global {
+        anyhow::bail!("Cursor hooks are global-only. Use: rtk init -g --agent cursor");
+    }
+
+    // Mode selection (Claude Code / OpenCode)
+    match (install_claude, install_opencode, claude_md, hook_only) {
+        (false, true, _, _) => run_opencode_only_mode(verbose)?,
+        (true, opencode, true, _) => run_claude_md_mode(global, verbose, opencode)?,
+        (true, opencode, false, true) => {
+            run_hook_only_mode(global, patch_mode, verbose, opencode)?
+        }
+        (true, opencode, false, false) => {
+            run_default_mode(global, patch_mode, verbose, opencode)?
+        }
+        (false, false, _, _) => {
+            if !install_cursor {
+                anyhow::bail!(
+                    "at least one of install_claude or install_opencode must be true"
+                )
+            }
         }
     }
+
+    // Cursor hooks (additive, installed alongside Claude Code)
+    if install_cursor {
+        install_cursor_hooks(verbose)?;
+    }
+
+    Ok(())
 }
 
 /// Prepare hook directory and return paths (hook_dir, hook_path)
@@ -480,11 +504,30 @@ fn remove_hook_from_settings(verbose: u8) -> Result<bool> {
     Ok(removed)
 }
 
-/// Full uninstall for Claude, Gemini, or Codex artifacts.
-pub fn uninstall(global: bool, gemini: bool, codex: bool, verbose: u8) -> Result<()> {
+/// Full uninstall for Claude, Gemini, Codex, or Cursor artifacts.
+pub fn uninstall(global: bool, gemini: bool, codex: bool, cursor: bool, verbose: u8) -> Result<()> {
     if codex {
         return uninstall_codex(global, verbose);
     }
+
+    if cursor {
+        if !global {
+            anyhow::bail!("Cursor uninstall only works with --global flag");
+        }
+        let cursor_removed = remove_cursor_hooks(verbose)
+            .context("Failed to remove Cursor hooks")?;
+        if !cursor_removed.is_empty() {
+            println!("RTK uninstalled (Cursor):");
+            for item in &cursor_removed {
+                println!("  - {}", item);
+            }
+            println!("\nRestart Cursor to apply changes.");
+        } else {
+            println!("RTK Cursor support was not installed (nothing to remove)");
+        }
+        return Ok(());
+    }
+
     if !global {
         anyhow::bail!("Uninstall only works with --global flag. For local projects, manually remove RTK from CLAUDE.md");
     }
@@ -563,6 +606,10 @@ pub fn uninstall(global: bool, gemini: bool, codex: bool, verbose: u8) -> Result
         removed.push(format!("OpenCode plugin: {}", path.display()));
     }
 
+    // 6. Remove Cursor hooks
+    let cursor_removed = remove_cursor_hooks(verbose)?;
+    removed.extend(cursor_removed);
+
     // Report results
     if removed.is_empty() {
         println!("RTK was not installed (nothing to remove)");
@@ -571,7 +618,7 @@ pub fn uninstall(global: bool, gemini: bool, codex: bool, verbose: u8) -> Result
         for item in removed {
             println!("  - {}", item);
         }
-        println!("\nRestart Claude Code and OpenCode (if used) to apply changes.");
+        println!("\nRestart Claude Code, OpenCode, and Cursor (if used) to apply changes.");
     }
 
     Ok(())
@@ -1441,6 +1488,215 @@ fn remove_opencode_plugin(verbose: u8) -> Result<Vec<PathBuf>> {
 
     Ok(removed)
 }
+
+// ─── Cursor Agent support ─────────────────────────────────────────────
+
+/// Resolve ~/.cursor directory
+fn resolve_cursor_dir() -> Result<PathBuf> {
+    dirs::home_dir()
+        .map(|h| h.join(".cursor"))
+        .context("Cannot determine home directory. Is $HOME set?")
+}
+
+/// Install Cursor hooks: hook script + hooks.json
+fn install_cursor_hooks(verbose: u8) -> Result<()> {
+    let cursor_dir = resolve_cursor_dir()?;
+    let hooks_dir = cursor_dir.join("hooks");
+    fs::create_dir_all(&hooks_dir)
+        .with_context(|| format!("Failed to create Cursor hooks directory: {}", hooks_dir.display()))?;
+
+    // 1. Write hook script
+    let hook_path = hooks_dir.join("rtk-rewrite.sh");
+    let hook_changed = write_if_changed(&hook_path, CURSOR_REWRITE_HOOK, "Cursor hook", verbose)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&hook_path, fs::Permissions::from_mode(0o755))
+            .with_context(|| format!("Failed to set Cursor hook permissions: {}", hook_path.display()))?;
+    }
+
+    // 2. Create or patch hooks.json
+    let hooks_json_path = cursor_dir.join("hooks.json");
+    let patched = patch_cursor_hooks_json(&hooks_json_path, verbose)?;
+
+    // Report
+    let hook_status = if hook_changed { "installed/updated" } else { "already up to date" };
+    println!("\nCursor hook {} (global).\n", hook_status);
+    println!("  Hook:       {}", hook_path.display());
+    println!("  hooks.json: {}", hooks_json_path.display());
+
+    if patched {
+        println!("  hooks.json: RTK preToolUse entry added");
+    } else {
+        println!("  hooks.json: RTK preToolUse entry already present");
+    }
+
+    println!("  Cursor reloads hooks.json automatically. Test with: git status\n");
+
+    Ok(())
+}
+
+/// Patch ~/.cursor/hooks.json to add RTK preToolUse hook.
+/// Returns true if the file was modified.
+fn patch_cursor_hooks_json(path: &Path, verbose: u8) -> Result<bool> {
+    let mut root = if path.exists() {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+        if content.trim().is_empty() {
+            serde_json::json!({ "version": 1 })
+        } else {
+            serde_json::from_str(&content)
+                .with_context(|| format!("Failed to parse {} as JSON", path.display()))?
+        }
+    } else {
+        serde_json::json!({ "version": 1 })
+    };
+
+    // Check idempotency
+    if cursor_hook_already_present(&root) {
+        if verbose > 0 {
+            eprintln!("Cursor hooks.json: RTK hook already present");
+        }
+        return Ok(false);
+    }
+
+    // Insert the RTK preToolUse entry
+    insert_cursor_hook_entry(&mut root);
+
+    // Backup if exists
+    if path.exists() {
+        let backup_path = path.with_extension("json.bak");
+        fs::copy(path, &backup_path)
+            .with_context(|| format!("Failed to backup to {}", backup_path.display()))?;
+        if verbose > 0 {
+            eprintln!("Backup: {}", backup_path.display());
+        }
+    }
+
+    // Atomic write
+    let serialized =
+        serde_json::to_string_pretty(&root).context("Failed to serialize hooks.json")?;
+    atomic_write(path, &serialized)?;
+
+    Ok(true)
+}
+
+/// Check if RTK preToolUse hook is already present in Cursor hooks.json
+fn cursor_hook_already_present(root: &serde_json::Value) -> bool {
+    let hooks = match root.get("hooks").and_then(|h| h.get("preToolUse")).and_then(|p| p.as_array())
+    {
+        Some(arr) => arr,
+        None => return false,
+    };
+
+    hooks.iter().any(|entry| {
+        entry
+            .get("command")
+            .and_then(|c| c.as_str())
+            .map_or(false, |cmd| cmd.contains("rtk-rewrite.sh"))
+    })
+}
+
+/// Insert RTK preToolUse entry into Cursor hooks.json
+fn insert_cursor_hook_entry(root: &mut serde_json::Value) {
+    let root_obj = match root.as_object_mut() {
+        Some(obj) => obj,
+        None => {
+            *root = serde_json::json!({ "version": 1 });
+            root.as_object_mut()
+                .expect("Just created object, must succeed")
+        }
+    };
+
+    // Ensure version key
+    root_obj
+        .entry("version")
+        .or_insert(serde_json::json!(1));
+
+    let hooks = root_obj
+        .entry("hooks")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .expect("hooks must be an object");
+
+    let pre_tool_use = hooks
+        .entry("preToolUse")
+        .or_insert_with(|| serde_json::json!([]))
+        .as_array_mut()
+        .expect("preToolUse must be an array");
+
+    pre_tool_use.push(serde_json::json!({
+        "command": "./hooks/rtk-rewrite.sh",
+        "matcher": "Shell"
+    }));
+}
+
+/// Remove Cursor RTK artifacts: hook script + hooks.json entry
+fn remove_cursor_hooks(verbose: u8) -> Result<Vec<String>> {
+    let cursor_dir = resolve_cursor_dir()?;
+    let mut removed = Vec::new();
+
+    // 1. Remove hook script
+    let hook_path = cursor_dir.join("hooks").join("rtk-rewrite.sh");
+    if hook_path.exists() {
+        fs::remove_file(&hook_path)
+            .with_context(|| format!("Failed to remove Cursor hook: {}", hook_path.display()))?;
+        removed.push(format!("Cursor hook: {}", hook_path.display()));
+    }
+
+    // 2. Remove RTK entry from hooks.json
+    let hooks_json_path = cursor_dir.join("hooks.json");
+    if hooks_json_path.exists() {
+        let content = fs::read_to_string(&hooks_json_path)
+            .with_context(|| format!("Failed to read {}", hooks_json_path.display()))?;
+
+        if !content.trim().is_empty() {
+            if let Ok(mut root) = serde_json::from_str::<serde_json::Value>(&content) {
+                if remove_cursor_hook_from_json(&mut root) {
+                    let backup_path = hooks_json_path.with_extension("json.bak");
+                    fs::copy(&hooks_json_path, &backup_path).ok();
+
+                    let serialized = serde_json::to_string_pretty(&root)
+                        .context("Failed to serialize hooks.json")?;
+                    atomic_write(&hooks_json_path, &serialized)?;
+
+                    removed.push("Cursor hooks.json: removed RTK entry".to_string());
+
+                    if verbose > 0 {
+                        eprintln!("Removed RTK hook from Cursor hooks.json");
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(removed)
+}
+
+/// Remove RTK preToolUse entry from Cursor hooks.json
+/// Returns true if entry was found and removed
+fn remove_cursor_hook_from_json(root: &mut serde_json::Value) -> bool {
+    let pre_tool_use = match root
+        .get_mut("hooks")
+        .and_then(|h| h.get_mut("preToolUse"))
+        .and_then(|p| p.as_array_mut())
+    {
+        Some(arr) => arr,
+        None => return false,
+    };
+
+    let original_len = pre_tool_use.len();
+    pre_tool_use.retain(|entry| {
+        !entry
+            .get("command")
+            .and_then(|c| c.as_str())
+            .map_or(false, |cmd| cmd.contains("rtk-rewrite.sh"))
+    });
+
+    pre_tool_use.len() < original_len
+}
+
 /// Show current rtk configuration
 pub fn show_config(codex: bool) -> Result<()> {
     if codex {
@@ -1599,6 +1855,66 @@ fn show_claude_config() -> Result<()> {
         println!("[--] OpenCode: config dir not found");
     }
 
+    // Check Cursor hooks
+    if let Ok(cursor_dir) = resolve_cursor_dir() {
+        let cursor_hook = cursor_dir.join("hooks").join("rtk-rewrite.sh");
+        let cursor_hooks_json = cursor_dir.join("hooks.json");
+
+        if cursor_hook.exists() {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let meta = fs::metadata(&cursor_hook)?;
+                let is_executable = meta.permissions().mode() & 0o111 != 0;
+                let content = fs::read_to_string(&cursor_hook)?;
+                let is_thin = content.contains("rtk rewrite");
+
+                if !is_executable {
+                    println!(
+                        "⚠️  Cursor hook: {} (NOT executable - run: chmod +x)",
+                        cursor_hook.display()
+                    );
+                } else if is_thin {
+                    println!("✅ Cursor hook: {} (thin delegator)", cursor_hook.display());
+                } else {
+                    println!(
+                        "⚠️  Cursor hook: {} (outdated — missing rtk rewrite delegation)",
+                        cursor_hook.display()
+                    );
+                }
+            }
+
+            #[cfg(not(unix))]
+            {
+                println!("✅ Cursor hook: {} (exists)", cursor_hook.display());
+            }
+        } else {
+            println!("⚪ Cursor hook: not found");
+        }
+
+        if cursor_hooks_json.exists() {
+            let content = fs::read_to_string(&cursor_hooks_json)?;
+            if !content.trim().is_empty() {
+                if let Ok(root) = serde_json::from_str::<serde_json::Value>(&content) {
+                    if cursor_hook_already_present(&root) {
+                        println!("✅ Cursor hooks.json: RTK preToolUse configured");
+                    } else {
+                        println!("⚠️  Cursor hooks.json: exists but RTK not configured");
+                        println!("    Run: rtk init -g --agent cursor");
+                    }
+                } else {
+                    println!("⚠️  Cursor hooks.json: exists but invalid JSON");
+                }
+            } else {
+                println!("⚪ Cursor hooks.json: empty");
+            }
+        } else {
+            println!("⚪ Cursor hooks.json: not found");
+        }
+    } else {
+        println!("⚪ Cursor: home dir not found");
+    }
+
     println!("\nUsage:");
     println!("  rtk init              # Full injection into local CLAUDE.md");
     println!("  rtk init -g           # Hook + RTK.md + @RTK.md + settings.json (recommended)");
@@ -1610,6 +1926,7 @@ fn show_claude_config() -> Result<()> {
     println!("  rtk init --codex            # Configure local AGENTS.md + RTK.md");
     println!("  rtk init -g --codex         # Configure ~/.codex/AGENTS.md + ~/.codex/RTK.md");
     println!("  rtk init -g --opencode      # OpenCode plugin only");
+    println!("  rtk init -g --agent cursor  # Install Cursor Agent hooks");
 
     Ok(())
 }
@@ -2110,7 +2427,7 @@ More notes
 
     #[test]
     fn test_codex_mode_rejects_auto_patch() {
-        let err = run(false, false, false, false, false, true, PatchMode::Auto, 0).unwrap_err();
+        let err = run(false, false, false, false, false, false, true, PatchMode::Auto, 0).unwrap_err();
         assert_eq!(
             err.to_string(),
             "--codex cannot be combined with --auto-patch"
@@ -2119,7 +2436,7 @@ More notes
 
     #[test]
     fn test_codex_mode_rejects_no_patch() {
-        let err = run(false, false, false, false, false, true, PatchMode::Skip, 0).unwrap_err();
+        let err = run(false, false, false, false, false, false, true, PatchMode::Skip, 0).unwrap_err();
         assert_eq!(
             err.to_string(),
             "--codex cannot be combined with --no-patch"
@@ -2428,5 +2745,133 @@ More notes
 
         let removed = remove_hook_from_json(&mut json_content);
         assert!(!removed);
+    }
+
+    // ─── Cursor hooks.json tests ───
+
+    #[test]
+    fn test_cursor_hook_already_present_true() {
+        let json_content = serde_json::json!({
+            "version": 1,
+            "hooks": {
+                "preToolUse": [{
+                    "command": "./hooks/rtk-rewrite.sh",
+                    "matcher": "Shell"
+                }]
+            }
+        });
+        assert!(cursor_hook_already_present(&json_content));
+    }
+
+    #[test]
+    fn test_cursor_hook_already_present_false_empty() {
+        let json_content = serde_json::json!({ "version": 1 });
+        assert!(!cursor_hook_already_present(&json_content));
+    }
+
+    #[test]
+    fn test_cursor_hook_already_present_false_other_hooks() {
+        let json_content = serde_json::json!({
+            "version": 1,
+            "hooks": {
+                "preToolUse": [{
+                    "command": "./hooks/some-other-hook.sh",
+                    "matcher": "Shell"
+                }]
+            }
+        });
+        assert!(!cursor_hook_already_present(&json_content));
+    }
+
+    #[test]
+    fn test_insert_cursor_hook_entry_empty() {
+        let mut json_content = serde_json::json!({ "version": 1 });
+        insert_cursor_hook_entry(&mut json_content);
+
+        let hooks = json_content["hooks"]["preToolUse"].as_array().unwrap();
+        assert_eq!(hooks.len(), 1);
+        assert_eq!(hooks[0]["command"], "./hooks/rtk-rewrite.sh");
+        assert_eq!(hooks[0]["matcher"], "Shell");
+        assert_eq!(json_content["version"], 1);
+    }
+
+    #[test]
+    fn test_insert_cursor_hook_preserves_existing() {
+        let mut json_content = serde_json::json!({
+            "version": 1,
+            "hooks": {
+                "preToolUse": [{
+                    "command": "./hooks/other.sh",
+                    "matcher": "Shell"
+                }],
+                "afterFileEdit": [{
+                    "command": "./hooks/format.sh"
+                }]
+            }
+        });
+
+        insert_cursor_hook_entry(&mut json_content);
+
+        let pre_tool_use = json_content["hooks"]["preToolUse"].as_array().unwrap();
+        assert_eq!(pre_tool_use.len(), 2);
+        assert_eq!(pre_tool_use[0]["command"], "./hooks/other.sh");
+        assert_eq!(pre_tool_use[1]["command"], "./hooks/rtk-rewrite.sh");
+
+        // afterFileEdit should be preserved
+        assert!(json_content["hooks"]["afterFileEdit"].is_array());
+    }
+
+    #[test]
+    fn test_remove_cursor_hook_from_json() {
+        let mut json_content = serde_json::json!({
+            "version": 1,
+            "hooks": {
+                "preToolUse": [
+                    { "command": "./hooks/other.sh", "matcher": "Shell" },
+                    { "command": "./hooks/rtk-rewrite.sh", "matcher": "Shell" }
+                ]
+            }
+        });
+
+        let removed = remove_cursor_hook_from_json(&mut json_content);
+        assert!(removed);
+
+        let hooks = json_content["hooks"]["preToolUse"].as_array().unwrap();
+        assert_eq!(hooks.len(), 1);
+        assert_eq!(hooks[0]["command"], "./hooks/other.sh");
+    }
+
+    #[test]
+    fn test_remove_cursor_hook_not_present() {
+        let mut json_content = serde_json::json!({
+            "version": 1,
+            "hooks": {
+                "preToolUse": [
+                    { "command": "./hooks/other.sh", "matcher": "Shell" }
+                ]
+            }
+        });
+
+        let removed = remove_cursor_hook_from_json(&mut json_content);
+        assert!(!removed);
+    }
+
+    #[test]
+    fn test_cursor_hook_script_has_guards() {
+        assert!(CURSOR_REWRITE_HOOK.contains("command -v rtk"));
+        assert!(CURSOR_REWRITE_HOOK.contains("command -v jq"));
+        let jq_pos = CURSOR_REWRITE_HOOK.find("command -v jq").unwrap();
+        let rtk_delegate_pos = CURSOR_REWRITE_HOOK.find("rtk rewrite \"$CMD\"").unwrap();
+        assert!(
+            jq_pos < rtk_delegate_pos,
+            "Guards must appear before rtk rewrite delegation"
+        );
+    }
+
+    #[test]
+    fn test_cursor_hook_outputs_cursor_format() {
+        assert!(CURSOR_REWRITE_HOOK.contains("\"permission\": \"allow\""));
+        assert!(CURSOR_REWRITE_HOOK.contains("\"updated_input\""));
+        assert!(!CURSOR_REWRITE_HOOK.contains("hookSpecificOutput"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,9 +67,18 @@ mod wget_cmd;
 
 use anyhow::{Context, Result};
 use clap::error::ErrorKind;
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
+
+/// Target agent for hook installation.
+#[derive(Debug, Clone, Copy, PartialEq, ValueEnum)]
+pub enum AgentTarget {
+    /// Claude Code (default)
+    Claude,
+    /// Cursor Agent (editor and CLI)
+    Cursor,
+}
 
 #[derive(Parser)]
 #[command(
@@ -336,6 +345,10 @@ enum Commands {
         /// Initialize for Gemini CLI instead of Claude Code
         #[arg(long)]
         gemini: bool,
+
+        /// Target agent to install hooks for (default: claude)
+        #[arg(long, value_enum)]
+        agent: Option<AgentTarget>,
 
         /// Show current configuration
         #[arg(long)]
@@ -1632,6 +1645,7 @@ fn main() -> Result<()> {
             global,
             opencode,
             gemini,
+            agent,
             show,
             claude_md,
             hook_only,
@@ -1643,7 +1657,8 @@ fn main() -> Result<()> {
             if show {
                 init::show_config(codex)?;
             } else if uninstall {
-                init::uninstall(global, gemini, codex, cli.verbose)?;
+                let cursor = agent.map_or(false, |a| a == AgentTarget::Cursor);
+                init::uninstall(global, gemini, codex, cursor, cli.verbose)?;
             } else if gemini {
                 let patch_mode = if auto_patch {
                     init::PatchMode::Auto
@@ -1656,6 +1671,8 @@ fn main() -> Result<()> {
             } else {
                 let install_opencode = opencode;
                 let install_claude = !opencode;
+                let install_cursor =
+                    agent.map_or(false, |a| a == AgentTarget::Cursor);
 
                 let patch_mode = if auto_patch {
                     init::PatchMode::Auto
@@ -1668,6 +1685,7 @@ fn main() -> Result<()> {
                     global,
                     install_claude,
                     install_opencode,
+                    install_cursor,
                     claude_md,
                     hook_only,
                     codex,


### PR DESCRIPTION
## Summary

Adds Cursor Agent support to RTK via a new `--agent <name>` flag on `rtk init`.

- `rtk init -g --agent cursor` installs a `preToolUse` hook in `~/.cursor/hooks.json` that rewrites shell commands through `rtk rewrite`, using Cursor's JSON format (`{permission, updated_input}`)
- Works with **both Cursor editor and cursor-cli** — they share `~/.cursor/hooks.json`, so a single installation covers both
- `rtk init --show` now reports Cursor hook and hooks.json status alongside existing Claude Code / OpenCode status
- `rtk init -g --uninstall` also removes Cursor artifacts (hook script + hooks.json entry)
- `rtk discover` adds a note when Cursor hooks are detected, directing users to `rtk gain` for Cursor session analytics (Cursor transcripts use a text-only format without structured `tool_use`/`tool_result` blocks, so discover cannot extract commands from them)

### Design decisions

- **`--agent` is an extensible enum** (`claude`, `cursor`), not a boolean flag — ready for future agents (Windsurf, Zed, etc.)
- **Additive behavior**: `--agent cursor` installs Cursor hooks ON TOP of the default Claude Code installation. Without `--agent`, behavior is 100% unchanged.
- **`--opencode` stays separate** for backward compatibility
- **Cursor hook uses `preToolUse`** with `matcher: "Shell"` and returns `updated_input` to rewrite commands — functionally identical to Claude Code's `PreToolUse` but with Cursor's JSON schema

### cursor-cli note

The `preToolUse` hook mechanism is shared between Cursor's editor agent and its CLI agent (`cursor-cli`). Both read hooks from `~/.cursor/hooks.json`, so `rtk init -g --agent cursor` covers both without any additional setup.

### Files changed

| File | Change |
|------|--------|
| `hooks/cursor-rtk-rewrite.sh` | New: Cursor-format hook script (thin delegator to `rtk rewrite`) |
| `src/main.rs` | Add `--agent <name>` flag with `AgentTarget` enum |
| `src/init.rs` | Cursor install/uninstall/show functions, hooks.json patching, unit tests |
| `src/discover/provider.rs` | Doc comment update noting Cursor limitation |
| `src/discover/report.rs` | Cursor note in discover output when hook detected |

## Test plan

- [x] `cargo build` — 0 errors
- [x] `cargo test` — 899 passed, 0 failed
- [x] `rtk init --help` shows `--agent` with `claude` and `cursor` values
- [ ] `rtk init -g --agent cursor --auto-patch` installs hook + patches hooks.json
- [ ] `rtk init --show` reports Cursor hook status
- [ ] `rtk init -g --uninstall` removes Cursor artifacts
- [ ] Cursor agent session with hook active rewrites `git status` → `rtk git status`
- [ ] `rtk gain --history` shows tracked commands from Cursor session