### PR TITLE
fix(golangci): detect major version and use correct output flag for v2

### DIFF
--- a/src/golangci_cmd.rs
+++ b/src/golangci_cmd.rs
@@ -30,18 +30,59 @@ struct GolangciOutput {
     issues: Vec<Issue>,
 }
 
+/// Parse the major version number from `golangci-lint version` output text.
+/// Expected format: "golangci-lint has version 2.11.3 built with ..."
+/// or: "golangci-lint has version v1.64.8 built with ..."
+/// Returns 1 as fallback when parsing fails.
+fn parse_major_version(text: &str) -> u8 {
+    let words: Vec<&str> = text.split_whitespace().collect();
+
+    words
+        .windows(2)
+        .find(|pair| pair[0] == "version")
+        .and_then(|pair| pair[1].trim_start_matches('v').split('.').next())
+        .and_then(|major| major.parse::<u8>().ok())
+        .filter(|&v| v >= 1)
+        .unwrap_or(1)
+}
+
+/// Detect the installed golangci-lint major version by running `golangci-lint version`.
+/// Returns 2 for v2+, 1 for v1 or if detection fails.
+fn detect_major_version() -> u8 {
+    let output = resolved_command("golangci-lint").arg("version").output();
+
+    match output {
+        Ok(o) => {
+            let text = String::from_utf8_lossy(&o.stdout);
+            parse_major_version(&text)
+        }
+        Err(_) => 1,
+    }
+}
+
 pub fn run(args: &[String], verbose: u8) -> Result<()> {
     let timer = tracking::TimedExecution::start();
 
     let mut cmd = resolved_command("golangci-lint");
 
-    // Force JSON output
-    let has_format = args
-        .iter()
-        .any(|a| a == "--out-format" || a.starts_with("--out-format="));
+    let major = detect_major_version();
+
+    // Check if the user already supplied an output format flag
+    let has_format = args.iter().any(|a| {
+        a == "--out-format"
+            || a.starts_with("--out-format=")
+            || a.starts_with("--output.json.")
+            || a.starts_with("--output.text.")
+            || a.starts_with("--output.tab.")
+    });
 
     if !has_format {
-        cmd.arg("run").arg("--out-format=json");
+        cmd.arg("run");
+        if major >= 2 {
+            cmd.arg("--output.json.path=stdout");
+        } else {
+            cmd.arg("--out-format=json");
+        }
     } else {
         cmd.arg("run");
     }
@@ -51,7 +92,12 @@ pub fn run(args: &[String], verbose: u8) -> Result<()> {
     }
 
     if verbose > 0 {
-        eprintln!("Running: golangci-lint run --out-format=json");
+        let flag = if major >= 2 {
+            "--output.json.path=stdout"
+        } else {
+            "--out-format=json"
+        };
+        eprintln!("Running: golangci-lint run {}", flag);
     }
 
     let output = cmd.output().context(
@@ -249,5 +295,66 @@ mod tests {
             "internal/config/loader.go"
         );
         assert_eq!(compact_path("relative/file.go"), "file.go");
+    }
+
+    #[test]
+    fn test_parse_major_version_v2() {
+        let text = "golangci-lint has version 2.11.3 built with go1.26.1 from abc123 on 2026-03-10T10:25:44Z";
+        assert_eq!(parse_major_version(text), 2);
+    }
+
+    #[test]
+    fn test_parse_major_version_v1() {
+        let text = "golangci-lint has version v1.64.8 built with go1.23.0 from def456 on 2025-01-15T08:30:00Z";
+        assert_eq!(parse_major_version(text), 1);
+    }
+
+    #[test]
+    fn test_parse_major_version_empty() {
+        assert_eq!(parse_major_version(""), 1);
+    }
+
+    #[test]
+    fn test_parse_major_version_garbage() {
+        assert_eq!(parse_major_version("not a version string at all"), 1);
+    }
+
+    #[test]
+    fn test_has_format_detection_v1_flag() {
+        let args: Vec<String> = vec!["--out-format=json".into(), "./...".into()];
+        let has_format = args.iter().any(|a| {
+            a == "--out-format"
+                || a.starts_with("--out-format=")
+                || a.starts_with("--output.json.")
+                || a.starts_with("--output.text.")
+                || a.starts_with("--output.tab.")
+        });
+        assert!(has_format);
+    }
+
+    #[test]
+    fn test_has_format_detection_v2_flag() {
+        let args: Vec<String> = vec!["--output.json.path=stdout".into(), "./...".into()];
+        let has_format = args.iter().any(|a| {
+            a == "--out-format"
+                || a.starts_with("--out-format=")
+                || a.starts_with("--output.json.")
+                || a.starts_with("--output.text.")
+                || a.starts_with("--output.tab.")
+        });
+        assert!(has_format);
+    }
+
+    #[test]
+    fn test_has_format_detection_no_flag() {
+        let args: Vec<String> = vec!["./...".into()];
+        let has_format = args.iter().any(|a| {
+            a == "--out-format"
+                || a.starts_with("--out-format=")
+                || a.starts_with("--output.json.")
+                || a.starts_with("--output.text.")
+                || a.starts_with("--output.tab.")
+        });
+        assert!(!has_format);
     }
 }


### PR DESCRIPTION
## Summary

The golangci-lint wrapper injects `--out-format=json` to get structured output, but this flag was removed in golangci-lint v2. The wrapper now detects the installed major version and injects the correct flag.

## What changed

The wrapper runs `golangci-lint version` before the actual lint invocation, parses the major version from the output, and selects the appropriate flag:

- v2+: `--output.json.path=stdout`
- v1: `--out-format=json` (existing behavior)

The user-supplied flag detection was also updated to recognise both v1 and v2 output flags, so the wrapper does not override them.

The version parsing logic is extracted into its own function with unit tests covering v1 output, v2 output, empty input, and garbage input. Three additional tests cover the flag detection for v1 flags, v2 flags, and no flags.

## Related

Closes #596

## References

- [golangci-lint migration guide on `--out-format` removal](https://golangci-lint.run/docs/product/migration-guide/#--out-format)
- [golangci-lint v2 CLI docs for `run` command flags](https://golangci-lint.run/docs/configuration/cli/#run)