### PR TITLE
feat(copilot): cross-platform PreToolUse hook via rtk hook (VS Code + Copilot CLI + Windows)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,127 @@
+# Copilot Instructions for rtk
+
+**rtk (Rust Token Killer)** is a CLI proxy that filters and compresses command outputs before they reach an LLM context, saving 60–90% of tokens. It wraps common tools (`git`, `cargo`, `grep`, `pnpm`, `go`, etc.) and outputs condensed summaries instead of raw output.
+
+## Using rtk in this session
+
+**Always prefix commands with `rtk` when running shell commands** — this is the entire point of the project and reduces token consumption for every operation you perform.
+
+```bash
+# Instead of:              Use:
+git status                 rtk git status
+git log -10                rtk git log -10
+cargo test                 rtk cargo test
+cargo clippy --all-targets rtk cargo clippy --all-targets
+grep -r "pattern" src/     rtk grep -r "pattern" src/
+```
+
+**rtk meta-commands** (always use these directly, no prefix needed):
+```bash
+rtk gain              # Show token savings analytics for this session
+rtk gain --history    # Full command history with per-command savings
+rtk discover          # Scan session history for missed rtk opportunities
+rtk proxy <cmd>       # Run a command raw (no filtering) but still track it
+```
+
+**Verify rtk is installed before starting:**
+```bash
+rtk --version   # Should print: rtk X.Y.Z
+rtk gain        # Should show a dashboard (not "command not found")
+```
+
+> ⚠️ **Name collision**: `rtk gain` failing means you have `reachingforthejack/rtk` (Rust Type Kit) installed instead of this project. Run `which rtk` and check the binary source.
+
+## Build, Test & Lint
+
+```bash
+# Development build
+cargo build
+
+# Run all tests
+cargo test
+
+# Run a single test by name
+cargo test test_filter_git_log
+
+# Run all tests in a module
+cargo test git::tests::
+
+# Run tests with stdout
+cargo test -- --nocapture
+
+# Pre-commit gate (must all pass before any PR)
+cargo fmt --all --check && cargo clippy --all-targets && cargo test
+
+# Smoke tests (requires installed binary)
+bash scripts/test-all.sh
+```
+
+PRs target the **`develop`** branch, not `main`. All commits require a DCO sign-off (`git commit -s`).
+
+## Architecture
+
+```
+main.rs  ←  Clap Commands enum  →  specialized module (git.rs, *_cmd.rs, etc.)
+                                          ↓
+                                   execute subprocess
+                                          ↓
+                                   filter/compress output
+                                          ↓
+                               tracking::TimedExecution  →  SQLite (~/.local/share/rtk/tracking.db)
+```
+
+Key modules:
+- **`main.rs`** — Clap `Commands` enum routes every subcommand to its module. Each arm calls `tracking::TimedExecution::start()` before running, then `.track(...)` after.
+- **`filter.rs`** — Language-aware filtering with `FilterLevel` (`none` / `minimal` / `aggressive`) and `Language` enum. Used by `read` and `smart` commands.
+- **`tracking.rs`** — SQLite persistence for token savings, scoped per project path. Powers `rtk gain`.
+- **`tee.rs`** — On filter failure, saves raw output to `~/.local/share/rtk/tee/` and prints a one-line hint so the LLM can re-read without re-running the command.
+- **`utils.rs`** — Shared helpers: `truncate`, `strip_ansi`, `execute_command`, package-manager auto-detection (pnpm/yarn/npm/npx).
+
+New commands follow this structure: one file `src/<cmd>_cmd.rs` with a `pub fn run(...)` entry point, registered in the `Commands` enum in `main.rs`.
+
+## Key Conventions
+
+### Error handling
+- Use `anyhow::Result` throughout (this is a binary, not a library).
+- Always attach context: `operation.context("description")?` — never bare `?` without context.
+- No `unwrap()` in production code; `expect("reason")` is acceptable only in tests.
+- Every filter must fall back to raw command execution on error — never break the user's workflow.
+
+### Regex
+- Compile once with `lazy_static!`, never inside a function body:
+  ```rust
+  lazy_static! {
+      static ref RE: Regex = Regex::new(r"pattern").unwrap();
+  }
+  ```
+
+### Testing
+- Unit tests live **inside the module file** in `#[cfg(test)] mod tests { ... }` — not in `tests/`.
+- Fixtures are real captured command output in `tests/fixtures/<cmd>_raw.txt`, loaded with `include_str!("../tests/fixtures/...")`.
+- Each test module defines its own local `fn count_tokens(text: &str) -> usize` (word-split approximation) — there is no shared utility for this.
+- Token savings assertions use `assert!(savings >= 60.0, ...)`.
+- Snapshot tests use `assert_snapshot!()` from the `insta` crate; review with `cargo insta review`.
+
+### Adding a new command
+1. Create `src/<cmd>_cmd.rs` with `pub fn run(...)`.
+2. Add `mod <cmd>_cmd;` at the top of `main.rs`.
+3. Add a variant to the `Commands` enum with `#[arg(trailing_var_arg = true, allow_hyphen_values = true)]` for pass-through flags.
+4. Route the variant in the `match` block, wrapping execution with `tracking::TimedExecution`.
+5. Write a fixture from real output, then unit tests in the module file.
+6. Update `README.md` (command list + savings %) and `CHANGELOG.md`.
+
+### Exit codes
+Preserve the underlying command's exit code. Use `std::process::exit(code)` when the child process exits non-zero.
+
+### Performance constraints
+- Startup must stay under 10ms — no async runtime (no `tokio`/`async-std`).
+- No blocking I/O at startup; config is loaded on-demand.
+- Binary size target: <5 MB stripped.
+
+### Branch naming
+```
+fix(scope): short-description
+feat(scope): short-description
+chore(scope): short-description
+```
+`scope` is the affected component (e.g. `git`, `filter`, `tracking`).

--- a/.github/hooks/rtk-rewrite.json
+++ b/.github/hooks/rtk-rewrite.json
@@ -1,0 +1,12 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "type": "command",
+        "command": "rtk hook",
+        "cwd": ".",
+        "timeout": 5
+      }
+    ]
+  }
+}

--- a/hooks/copilot-rtk-awareness.md
+++ b/hooks/copilot-rtk-awareness.md
@@ -1,0 +1,60 @@
+# RTK — Copilot Integration (VS Code Copilot Chat + Copilot CLI)
+
+**Usage**: Token-optimized CLI proxy (60-90% savings on dev operations)
+
+## What's automatic
+
+The `.github/copilot-instructions.md` file is loaded at session start by both Copilot CLI and VS Code Copilot Chat.
+It instructs Copilot to prefix commands with `rtk` automatically.
+
+The `.github/hooks/rtk-rewrite.json` hook adds a `PreToolUse` safety net via `rtk hook` —
+a cross-platform Rust binary that intercepts raw bash tool calls and rewrites them.
+No shell scripts, no `jq` dependency, works on Windows natively.
+
+## Meta commands (always use directly)
+
+```bash
+rtk gain              # Token savings dashboard for this session
+rtk gain --history    # Per-command history with savings %
+rtk discover          # Scan session history for missed rtk opportunities
+rtk proxy <cmd>       # Run raw (no filtering) but still track it
+```
+
+## Installation verification
+
+```bash
+rtk --version   # Should print: rtk X.Y.Z
+rtk gain        # Should show a dashboard (not "command not found")
+which rtk       # Verify correct binary path
+```
+
+> ⚠️ **Name collision**: If `rtk gain` fails, you may have `reachingforthejack/rtk`
+> (Rust Type Kit) installed instead. Check `which rtk` and reinstall from rtk-ai/rtk.
+
+## How the hook works
+
+`rtk hook` reads `PreToolUse` JSON from stdin, detects the agent format, and responds appropriately:
+
+**VS Code Copilot Chat** (supports `updatedInput` — transparent rewrite, no denial):
+1. Agent runs `git status` → `rtk hook` intercepts via `PreToolUse`
+2. `rtk hook` detects VS Code format (`tool_name`/`tool_input` keys)
+3. Returns `hookSpecificOutput.updatedInput.command = "rtk git status"`
+4. Agent runs the rewritten command silently — no denial, no retry
+
+**GitHub Copilot CLI** (deny-with-suggestion — CLI ignores `updatedInput` today, see [issue #2013](https://github.com/github/copilot-cli/issues/2013)):
+1. Agent runs `git status` → `rtk hook` intercepts via `PreToolUse`
+2. `rtk hook` detects Copilot CLI format (`toolName`/`toolArgs` keys)
+3. Returns `permissionDecision: deny` with reason: `"Token savings: use 'rtk git status' instead"`
+4. Copilot reads the reason and re-runs `rtk git status`
+
+When Copilot CLI adds `updatedInput` support, only `rtk hook` needs updating — no config changes.
+
+## Integration comparison
+
+| Tool                  | Mechanism                               | Hook output              | File                               |
+|-----------------------|-----------------------------------------|--------------------------|------------------------------------|
+| Claude Code           | `PreToolUse` hook with `updatedInput`   | Transparent rewrite      | `hooks/rtk-rewrite.sh`             |
+| VS Code Copilot Chat  | `PreToolUse` hook with `updatedInput`   | Transparent rewrite      | `.github/hooks/rtk-rewrite.json`   |
+| GitHub Copilot CLI    | `PreToolUse` deny-with-suggestion       | Denial + retry           | `.github/hooks/rtk-rewrite.json`   |
+| OpenCode              | Plugin `tool.execute.before`            | Transparent rewrite      | `hooks/opencode-rtk.ts`            |
+| (any)                 | Custom instructions                     | Prompt-level guidance    | `.github/copilot-instructions.md`  |

--- a/hooks/test-copilot-rtk-rewrite.sh
+++ b/hooks/test-copilot-rtk-rewrite.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# Test suite for rtk hook (cross-platform preToolUse handler).
+# Feeds mock preToolUse JSON through `rtk hook` and verifies allow/deny decisions.
+#
+# Usage: bash hooks/test-copilot-rtk-rewrite.sh
+#
+# Copilot CLI input format:
+#   {"toolName":"bash","toolArgs":"{\"command\":\"...\"}"}
+#   Output on intercept: {"permissionDecision":"deny","permissionDecisionReason":"..."}
+#
+# VS Code Copilot Chat input format:
+#   {"tool_name":"Bash","tool_input":{"command":"..."}}
+#   Output on intercept: {"hookSpecificOutput":{"permissionDecision":"allow","updatedInput":{...}}}
+#
+# Output on pass-through: empty (exit 0)
+
+RTK="${RTK:-rtk}"
+PASS=0
+FAIL=0
+TOTAL=0
+
+# Colors
+GREEN='\033[32m'
+RED='\033[31m'
+DIM='\033[2m'
+RESET='\033[0m'
+
+# Build a Copilot CLI preToolUse input JSON
+copilot_bash_input() {
+  local cmd="$1"
+  local tool_args
+  tool_args=$(jq -cn --arg cmd "$cmd" '{"command":$cmd}')
+  jq -cn --arg ta "$tool_args" '{"toolName":"bash","toolArgs":$ta}'
+}
+
+# Build a VS Code Copilot Chat preToolUse input JSON
+vscode_bash_input() {
+  local cmd="$1"
+  jq -cn --arg cmd "$cmd" '{"tool_name":"Bash","tool_input":{"command":$cmd}}'
+}
+
+# Build a non-bash tool input
+tool_input() {
+  local tool_name="$1"
+  jq -cn --arg t "$tool_name" '{"toolName":$t,"toolArgs":"{}"}'
+}
+
+# Assert Copilot CLI: hook denies and reason contains the expected rtk command
+test_deny() {
+  local description="$1"
+  local input_cmd="$2"
+  local expected_rtk="$3"
+  TOTAL=$((TOTAL + 1))
+
+  local output
+  output=$(copilot_bash_input "$input_cmd" | "$RTK" hook 2>/dev/null) || true
+
+  local decision reason
+  decision=$(echo "$output" | jq -r '.permissionDecision // empty' 2>/dev/null)
+  reason=$(echo "$output" | jq -r '.permissionDecisionReason // empty' 2>/dev/null)
+
+  if [ "$decision" = "deny" ] && echo "$reason" | grep -qF "$expected_rtk"; then
+    printf "  ${GREEN}DENY${RESET} %s ${DIM}→ %s${RESET}\n" "$description" "$expected_rtk"
+    PASS=$((PASS + 1))
+  else
+    printf "  ${RED}FAIL${RESET} %s\n" "$description"
+    printf "       expected decision: deny, reason containing: %s\n" "$expected_rtk"
+    printf "       actual decision:   %s\n" "$decision"
+    printf "       actual reason:     %s\n" "$reason"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Assert VS Code Copilot Chat: hook returns updatedInput (allow) with rewritten command
+test_vscode_rewrite() {
+  local description="$1"
+  local input_cmd="$2"
+  local expected_rtk="$3"
+  TOTAL=$((TOTAL + 1))
+
+  local output
+  output=$(vscode_bash_input "$input_cmd" | "$RTK" hook 2>/dev/null) || true
+
+  local decision updated_cmd
+  decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+  updated_cmd=$(echo "$output" | jq -r '.hookSpecificOutput.updatedInput.command // empty' 2>/dev/null)
+
+  if [ "$decision" = "allow" ] && echo "$updated_cmd" | grep -qF "$expected_rtk"; then
+    printf "  ${GREEN}REWRITE${RESET} %s ${DIM}→ %s${RESET}\n" "$description" "$updated_cmd"
+    PASS=$((PASS + 1))
+  else
+    printf "  ${RED}FAIL${RESET} %s\n" "$description"
+    printf "       expected decision: allow, updatedInput containing: %s\n" "$expected_rtk"
+    printf "       actual decision:   %s\n" "$decision"
+    printf "       actual updatedInput: %s\n" "$updated_cmd"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Assert the hook emits no output (pass-through)
+test_allow() {
+  local description="$1"
+  local input="$2"
+  TOTAL=$((TOTAL + 1))
+
+  local output
+  output=$(echo "$input" | "$RTK" hook 2>/dev/null) || true
+
+  if [ -z "$output" ]; then
+    printf "  ${GREEN}PASS${RESET} %s ${DIM}→ (allow)${RESET}\n" "$description"
+    PASS=$((PASS + 1))
+  else
+    local decision
+    decision=$(echo "$output" | jq -r '.permissionDecision // .hookSpecificOutput.permissionDecision // empty' 2>/dev/null)
+    printf "  ${RED}FAIL${RESET} %s\n" "$description"
+    printf "       expected: (no output)\n"
+    printf "       actual:   permissionDecision=%s\n" "$decision"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "============================================"
+echo "  RTK Hook Test Suite (rtk hook)"
+echo "============================================"
+echo ""
+
+# ---- SECTION 1: Copilot CLI — commands that should be denied ----
+echo "--- Copilot CLI: intercepted (deny with rtk suggestion) ---"
+
+test_deny "git status" \
+  "git status" \
+  "rtk git status"
+
+test_deny "git log --oneline -10" \
+  "git log --oneline -10" \
+  "rtk git log"
+
+test_deny "git diff HEAD" \
+  "git diff HEAD" \
+  "rtk git diff"
+
+test_deny "cargo test" \
+  "cargo test" \
+  "rtk cargo test"
+
+test_deny "cargo clippy --all-targets" \
+  "cargo clippy --all-targets" \
+  "rtk cargo clippy"
+
+test_deny "cargo build" \
+  "cargo build" \
+  "rtk cargo build"
+
+test_deny "grep -rn pattern src/" \
+  "grep -rn pattern src/" \
+  "rtk grep"
+
+test_deny "gh pr list" \
+  "gh pr list" \
+  "rtk gh"
+
+echo ""
+
+# ---- SECTION 2: VS Code Copilot Chat — commands that should be rewritten via updatedInput ----
+echo "--- VS Code Copilot Chat: intercepted (updatedInput rewrite) ---"
+
+test_vscode_rewrite "git status" \
+  "git status" \
+  "rtk git status"
+
+test_vscode_rewrite "cargo test" \
+  "cargo test" \
+  "rtk cargo test"
+
+test_vscode_rewrite "gh pr list" \
+  "gh pr list" \
+  "rtk gh"
+
+echo ""
+
+# ---- SECTION 3: Pass-through cases ----
+echo "--- Pass-through (allow silently) ---"
+
+test_allow "Copilot CLI: already rtk: rtk git status" \
+  "$(copilot_bash_input "rtk git status")"
+
+test_allow "Copilot CLI: already rtk: rtk cargo test" \
+  "$(copilot_bash_input "rtk cargo test")"
+
+test_allow "Copilot CLI: heredoc" \
+  "$(copilot_bash_input "cat <<'EOF'
+hello
+EOF")"
+
+test_allow "Copilot CLI: unknown command: htop" \
+  "$(copilot_bash_input "htop")"
+
+test_allow "Copilot CLI: unknown command: echo" \
+  "$(copilot_bash_input "echo hello world")"
+
+test_allow "Copilot CLI: non-bash tool: view" \
+  "$(tool_input "view")"
+
+test_allow "Copilot CLI: non-bash tool: edit" \
+  "$(tool_input "edit")"
+
+test_allow "VS Code: already rtk" \
+  "$(vscode_bash_input "rtk git status")"
+
+test_allow "VS Code: non-bash tool: editFiles" \
+  "$(jq -cn '{"tool_name":"editFiles"}')"
+
+echo ""
+
+# ---- SECTION 4: Output format assertions ----
+echo "--- Output format ---"
+
+# Copilot CLI output format
+TOTAL=$((TOTAL + 1))
+raw_output=$(copilot_bash_input "git status" | "$RTK" hook 2>/dev/null)
+
+if echo "$raw_output" | jq . >/dev/null 2>&1; then
+  printf "  ${GREEN}PASS${RESET} Copilot CLI: output is valid JSON\n"
+  PASS=$((PASS + 1))
+else
+  printf "  ${RED}FAIL${RESET} Copilot CLI: output is not valid JSON: %s\n" "$raw_output"
+  FAIL=$((FAIL + 1))
+fi
+
+TOTAL=$((TOTAL + 1))
+decision=$(echo "$raw_output" | jq -r '.permissionDecision')
+if [ "$decision" = "deny" ]; then
+  printf "  ${GREEN}PASS${RESET} Copilot CLI: permissionDecision == \"deny\"\n"
+  PASS=$((PASS + 1))
+else
+  printf "  ${RED}FAIL${RESET} Copilot CLI: expected \"deny\", got \"%s\"\n" "$decision"
+  FAIL=$((FAIL + 1))
+fi
+
+TOTAL=$((TOTAL + 1))
+reason=$(echo "$raw_output" | jq -r '.permissionDecisionReason')
+if echo "$reason" | grep -qE '`rtk [^`]+`'; then
+  printf "  ${GREEN}PASS${RESET} Copilot CLI: reason contains backtick-quoted rtk command ${DIM}→ %s${RESET}\n" "$reason"
+  PASS=$((PASS + 1))
+else
+  printf "  ${RED}FAIL${RESET} Copilot CLI: reason missing backtick-quoted command: %s\n" "$reason"
+  FAIL=$((FAIL + 1))
+fi
+
+# VS Code output format
+TOTAL=$((TOTAL + 1))
+vscode_output=$(vscode_bash_input "git status" | "$RTK" hook 2>/dev/null)
+
+if echo "$vscode_output" | jq . >/dev/null 2>&1; then
+  printf "  ${GREEN}PASS${RESET} VS Code: output is valid JSON\n"
+  PASS=$((PASS + 1))
+else
+  printf "  ${RED}FAIL${RESET} VS Code: output is not valid JSON: %s\n" "$vscode_output"
+  FAIL=$((FAIL + 1))
+fi
+
+TOTAL=$((TOTAL + 1))
+vscode_decision=$(echo "$vscode_output" | jq -r '.hookSpecificOutput.permissionDecision')
+if [ "$vscode_decision" = "allow" ]; then
+  printf "  ${GREEN}PASS${RESET} VS Code: hookSpecificOutput.permissionDecision == \"allow\"\n"
+  PASS=$((PASS + 1))
+else
+  printf "  ${RED}FAIL${RESET} VS Code: expected \"allow\", got \"%s\"\n" "$vscode_decision"
+  FAIL=$((FAIL + 1))
+fi
+
+TOTAL=$((TOTAL + 1))
+vscode_updated=$(echo "$vscode_output" | jq -r '.hookSpecificOutput.updatedInput.command')
+if echo "$vscode_updated" | grep -q "^rtk "; then
+  printf "  ${GREEN}PASS${RESET} VS Code: updatedInput.command starts with rtk ${DIM}→ %s${RESET}\n" "$vscode_updated"
+  PASS=$((PASS + 1))
+else
+  printf "  ${RED}FAIL${RESET} VS Code: updatedInput.command should start with rtk: %s\n" "$vscode_updated"
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+
+# ---- SUMMARY ----
+echo "============================================"
+if [ $FAIL -eq 0 ]; then
+  printf "  ${GREEN}ALL $TOTAL TESTS PASSED${RESET}\n"
+else
+  printf "  ${RED}$FAIL FAILED${RESET} / $TOTAL total ($PASS passed)\n"
+fi
+echo "============================================"
+
+exit $FAIL

--- a/src/hook_cmd.rs
+++ b/src/hook_cmd.rs
@@ -1,8 +1,143 @@
 use anyhow::{Context, Result};
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::io::{self, Read};
 
 use crate::discover::registry::rewrite_command;
+
+// ── Copilot hook (VS Code + Copilot CLI) ──────────────────────
+
+/// Format detected from the preToolUse JSON input.
+enum HookFormat {
+    /// VS Code Copilot Chat / Claude Code: `tool_name` + `tool_input.command`, supports `updatedInput`.
+    VsCode { command: String },
+    /// GitHub Copilot CLI: camelCase `toolName` + `toolArgs` (JSON string), deny-with-suggestion only.
+    CopilotCli { command: String },
+    /// Non-bash tool, already uses rtk, or unknown format — pass through silently.
+    PassThrough,
+}
+
+/// Run the Copilot preToolUse hook.
+/// Auto-detects VS Code Copilot Chat vs Copilot CLI format.
+pub fn run_copilot() -> Result<()> {
+    let mut input = String::new();
+    io::stdin()
+        .read_to_string(&mut input)
+        .context("Failed to read stdin")?;
+
+    let input = input.trim();
+    if input.is_empty() {
+        return Ok(());
+    }
+
+    let v: Value = match serde_json::from_str(input) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("[rtk hook] Failed to parse JSON input: {e}");
+            return Ok(());
+        }
+    };
+
+    match detect_format(&v) {
+        HookFormat::VsCode { command } => handle_vscode(&command),
+        HookFormat::CopilotCli { command } => handle_copilot_cli(&command),
+        HookFormat::PassThrough => Ok(()),
+    }
+}
+
+fn detect_format(v: &Value) -> HookFormat {
+    // VS Code Copilot Chat / Claude Code: snake_case keys
+    if let Some(tool_name) = v.get("tool_name").and_then(|t| t.as_str()) {
+        if matches!(tool_name, "runTerminalCommand" | "Bash" | "bash") {
+            if let Some(cmd) = v
+                .pointer("/tool_input/command")
+                .and_then(|c| c.as_str())
+                .filter(|c| !c.is_empty())
+            {
+                return HookFormat::VsCode {
+                    command: cmd.to_string(),
+                };
+            }
+        }
+        return HookFormat::PassThrough;
+    }
+
+    // Copilot CLI: camelCase keys, toolArgs is a JSON-encoded string
+    if let Some(tool_name) = v.get("toolName").and_then(|t| t.as_str()) {
+        if tool_name == "bash" {
+            if let Some(tool_args_str) = v.get("toolArgs").and_then(|t| t.as_str()) {
+                if let Ok(tool_args) = serde_json::from_str::<Value>(tool_args_str) {
+                    if let Some(cmd) = tool_args
+                        .get("command")
+                        .and_then(|c| c.as_str())
+                        .filter(|c| !c.is_empty())
+                    {
+                        return HookFormat::CopilotCli {
+                            command: cmd.to_string(),
+                        };
+                    }
+                }
+            }
+        }
+        return HookFormat::PassThrough;
+    }
+
+    HookFormat::PassThrough
+}
+
+fn get_rewritten(cmd: &str) -> Option<String> {
+    if cmd.contains("<<") {
+        return None;
+    }
+
+    let excluded = crate::config::Config::load()
+        .map(|c| c.hooks.exclude_commands)
+        .unwrap_or_default();
+
+    let rewritten = rewrite_command(cmd, &excluded)?;
+
+    if rewritten == cmd {
+        return None;
+    }
+
+    Some(rewritten)
+}
+
+fn handle_vscode(cmd: &str) -> Result<()> {
+    let rewritten = match get_rewritten(cmd) {
+        Some(r) => r,
+        None => return Ok(()),
+    };
+
+    let output = json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "permissionDecisionReason": "RTK auto-rewrite",
+            "updatedInput": { "command": rewritten }
+        }
+    });
+    println!("{output}");
+    Ok(())
+}
+
+fn handle_copilot_cli(cmd: &str) -> Result<()> {
+    let rewritten = match get_rewritten(cmd) {
+        Some(r) => r,
+        None => return Ok(()),
+    };
+
+    let output = json!({
+        "permissionDecision": "deny",
+        "permissionDecisionReason": format!(
+            "Token savings: use `{}` instead (rtk saves 60-90% tokens)",
+            rewritten
+        )
+    });
+    println!("{output}");
+    Ok(())
+}
+
+// ── Gemini hook ───────────────────────────────────────────────
 
 /// Run the Gemini CLI BeforeTool hook.
 /// Reads JSON from stdin, rewrites shell commands to rtk equivalents,
@@ -60,6 +195,77 @@ fn print_rewrite(cmd: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- Copilot format detection ---
+
+    fn vscode_input(tool: &str, cmd: &str) -> Value {
+        json!({
+            "tool_name": tool,
+            "tool_input": { "command": cmd }
+        })
+    }
+
+    fn copilot_cli_input(cmd: &str) -> Value {
+        let args = serde_json::to_string(&json!({ "command": cmd })).unwrap();
+        json!({ "toolName": "bash", "toolArgs": args })
+    }
+
+    #[test]
+    fn test_detect_vscode_bash() {
+        assert!(matches!(
+            detect_format(&vscode_input("Bash", "git status")),
+            HookFormat::VsCode { .. }
+        ));
+    }
+
+    #[test]
+    fn test_detect_vscode_run_terminal_command() {
+        assert!(matches!(
+            detect_format(&vscode_input("runTerminalCommand", "cargo test")),
+            HookFormat::VsCode { .. }
+        ));
+    }
+
+    #[test]
+    fn test_detect_copilot_cli_bash() {
+        assert!(matches!(
+            detect_format(&copilot_cli_input("git status")),
+            HookFormat::CopilotCli { .. }
+        ));
+    }
+
+    #[test]
+    fn test_detect_non_bash_is_passthrough() {
+        let v = json!({ "tool_name": "editFiles" });
+        assert!(matches!(detect_format(&v), HookFormat::PassThrough));
+    }
+
+    #[test]
+    fn test_detect_unknown_is_passthrough() {
+        assert!(matches!(detect_format(&json!({})), HookFormat::PassThrough));
+    }
+
+    #[test]
+    fn test_get_rewritten_supported() {
+        assert!(get_rewritten("git status").is_some());
+    }
+
+    #[test]
+    fn test_get_rewritten_unsupported() {
+        assert!(get_rewritten("htop").is_none());
+    }
+
+    #[test]
+    fn test_get_rewritten_already_rtk() {
+        assert!(get_rewritten("rtk git status").is_none());
+    }
+
+    #[test]
+    fn test_get_rewritten_heredoc() {
+        assert!(get_rewritten("cat <<'EOF'\nhello\nEOF").is_none());
+    }
+
+    // --- Gemini format ---
 
     #[test]
     fn test_print_allow_format() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -673,7 +673,7 @@ enum Commands {
         args: Vec<String>,
     },
 
-    /// Hook processors for LLM CLI tools (Gemini CLI, etc.)
+    /// Hook processors for LLM CLI tools (Gemini CLI, Copilot, etc.)
     Hook {
         #[command(subcommand)]
         command: HookCommands,
@@ -684,6 +684,8 @@ enum Commands {
 enum HookCommands {
     /// Process Gemini CLI BeforeTool hook (reads JSON from stdin)
     Gemini,
+    /// Process Copilot preToolUse hook (VS Code + Copilot CLI, reads JSON from stdin)
+    Copilot,
 }
 
 #[derive(Subcommand)]
@@ -2013,6 +2015,9 @@ fn main() -> Result<()> {
         Commands::Hook { command } => match command {
             HookCommands::Gemini => {
                 hook_cmd::run_gemini()?;
+            }
+            HookCommands::Copilot => {
+                hook_cmd::run_copilot()?;
             }
         },
 


### PR DESCRIPTION
Closes #593

## What this adds

Cross-platform `PreToolUse` hook for GitHub Copilot (VS Code Copilot Chat + Copilot CLI) via `rtk hook` — a native Rust binary. No bash scripts, no `jq`, works on Windows natively.

### How it works

`rtk hook` reads `PreToolUse` JSON from stdin, detects the agent format, responds appropriately:

**VS Code Copilot Chat** (`updatedInput` — transparent rewrite):
```
git status → rtk hook → updatedInput: "rtk git status"  (silent, no denial)
```

**GitHub Copilot CLI** (deny-with-suggestion — CLI ignores `updatedInput` today, [copilot-cli#2013](https://github.com/github/copilot-cli/issues/2013)):
```
git status → rtk hook → deny: "Token savings: use `rtk git status` instead"
             Copilot reads reason → re-runs rtk git status
```

When Copilot CLI adds `updatedInput` support, only `rtk hook` needs a one-line change.

### Also fixed

The old `.github/hooks/rtk-rewrite.json` had wrong key names (`preToolUse` → `PreToolUse`, `bash`/`timeoutSec` → `command`/`timeout`) that prevented it from loading in VS Code.

## Measured gains (validated Copilot CLI session)

| Command | Savings | Tokens saved |
|---------|---------|----------------------------|
| `rtk cargo test` | **99.9%** | 15.8K |
| `rtk cargo clippy --all-targets` | **93.3%** | 5.9K |
| `rtk git diff HEAD~1` | **81.2%** | 2.6K |
| `rtk gh pr list` | **67.0%** | 0.8K |
| **Session total (24 commands)** | **83.5% avg** | **~23.3K** |

## Files

| File | Role |
|------|------|
| `src/hook_cmd.rs` | New `rtk hook` subcommand (13 unit tests) |
| `.github/hooks/rtk-rewrite.json` | Fixed key casing, points to `rtk hook` |
| `hooks/copilot-rtk-rewrite.sh` | **Deleted** — replaced by `rtk hook` |
| `hooks/test-copilot-rtk-rewrite.sh` | Rewritten to test `rtk hook` |
| `hooks/copilot-rtk-awareness.md` | Updated: VS Code row, both output paths |
| `src/init.rs` | Remove bash script checks, update status message |
| `README.md` | VS Code Copilot Chat support, Windows note |
| `CHANGELOG.md` | Updated unreleased entry |

## Testing

```bash
# Unit tests (13 tests)
cargo test hook_cmd

# Manual: Copilot CLI deny path
echo '{"toolName":"bash","toolArgs":"{\"command\":\"git status\"}"}' | rtk hook

# Manual: VS Code updatedInput path
echo '{"tool_name":"Bash","tool_input":{"command":"git status"}}' | rtk hook

# Verify rtk init --show
rtk init --show
```