### PR TITLE
feat: add rtk update command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to rtk (Rust Token Killer) will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Features
+
+* add `rtk update` to upgrade Homebrew installs and the default Quick Install path while giving safe manual guidance for other layouts
+
 ## [0.29.0](https://github.com/rtk-ai/rtk/compare/v0.28.2...v0.29.0) (2026-03-12)
 
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -148,7 +148,22 @@ rtk init  # Creates ./CLAUDE.md with full RTK instructions (137 lines)
 
 **Token savings**: Instructions loaded only for this project
 
-### Upgrading from Previous Version
+### Updating the RTK Binary
+
+```bash
+rtk update
+```
+
+`rtk update` uses an update path that matches the installed binary:
+
+- Homebrew installs -> runs `brew upgrade rtk`
+- Default Quick Install path (`~/.local/bin/rtk`) -> installs the latest tagged GitHub release in place
+- Cargo installs -> prints a pinned Cargo command
+- Nix, custom install directories, and other manual layouts -> prints safe manual guidance instead of guessing
+
+If RTK cannot safely determine how it was installed, it prints safe manual guidance instead of guessing.
+
+### Updating from Previous Integration Styles
 
 #### From old 137-line CLAUDE.md injection (pre-0.22)
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ brew install rtk
 ### Quick Install (Linux/macOS)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/master/install.sh | sh
 ```
 
 > Installs to `~/.local/bin`. Add to PATH if needed:
@@ -95,6 +95,16 @@ rtk gain        # Should show token savings stats
 ```
 
 > **Name collision warning**: Another project named "rtk" (Rust Type Kit) exists on crates.io. If `rtk gain` fails, you have the wrong package. Use `cargo install --git` above instead.
+
+### Update
+
+```bash
+rtk update                                              # Homebrew + default Quick Install path
+brew upgrade rtk                                        # Homebrew installs
+cargo install --git https://github.com/rtk-ai/rtk --tag <release-tag> --force
+```
+
+`rtk update` runs Homebrew upgrades automatically and refreshes the default Quick Install location (`~/.local/bin/rtk`) to the latest GitHub release. Cargo installs get a pinned Cargo command, while Nix, custom install directories, and other manual layouts get guidance instead of a guessed auto-update.
 
 ## Quick Start
 

--- a/install.sh
+++ b/install.sh
@@ -45,8 +45,12 @@ detect_arch() {
     esac
 }
 
-# Get latest release version
-get_latest_version() {
+get_version() {
+    if [ -n "$RTK_VERSION" ]; then
+        VERSION="$RTK_VERSION"
+        return
+    fi
+
     VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
     if [ -z "$VERSION" ]; then
         error "Failed to get latest version"
@@ -113,7 +117,7 @@ main() {
     detect_os
     detect_arch
     get_target
-    get_latest_version
+    get_version
     install
     verify
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,7 @@ mod toml_filter;
 mod tracking;
 mod tree;
 mod tsc_cmd;
+mod update_cmd;
 mod utils;
 mod verify_cmd;
 mod vitest_cmd;
@@ -354,6 +355,9 @@ enum Commands {
         #[arg(long)]
         uninstall: bool,
     },
+
+    #[command(about = "Update RTK")]
+    Update,
 
     /// Download with compact output (strips progress bars)
     Wget {
@@ -997,6 +1001,7 @@ const RTK_META_COMMANDS: &[&str] = &[
     "discover",
     "learn",
     "init",
+    "update",
     "config",
     "proxy",
     "hook-audit",
@@ -1621,6 +1626,10 @@ fn main() -> Result<()> {
                     cli.verbose,
                 )?;
             }
+        }
+
+        Commands::Update => {
+            update_cmd::run(cli.verbose)?;
         }
 
         Commands::Wget { url, stdout, args } => {
@@ -2383,6 +2392,7 @@ mod tests {
             vec!["rtk", "discover"],
             vec!["rtk", "learn"],
             vec!["rtk", "init"],
+            vec!["rtk", "update"],
             vec!["rtk", "config"],
             vec!["rtk", "proxy", "echo", "hi"],
             vec!["rtk", "hook-audit"],

--- a/src/update_cmd.rs
+++ b/src/update_cmd.rs
@@ -122,7 +122,10 @@ fn build_script_update_plan(
             install_dir.display()
         ),
         program: "sh".to_string(),
-        args: vec!["-c".to_string(), format!("curl -fsSL {} | sh", INSTALL_SCRIPT_URL)],
+        args: vec![
+            "-c".to_string(),
+            format!("curl -fsSL {} | sh", INSTALL_SCRIPT_URL),
+        ],
         envs: vec![
             ("RTK_VERSION".to_string(), format!("v{}", latest_version)),
             (
@@ -308,11 +311,8 @@ mod tests {
 
     #[test]
     fn test_build_update_plan_for_script_sets_exact_release() {
-        let plan = build_script_update_plan(
-            PathBuf::from("/home/user/.local/bin"),
-            "0.29.0",
-            "0.30.0",
-        );
+        let plan =
+            build_script_update_plan(PathBuf::from("/home/user/.local/bin"), "0.29.0", "0.30.0");
 
         match plan {
             UpdatePlan::Run { envs, .. } => {

--- a/src/update_cmd.rs
+++ b/src/update_cmd.rs
@@ -1,0 +1,350 @@
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+const RELEASE_API_URL: &str = "https://api.github.com/repos/rtk-ai/rtk/releases/latest";
+const INSTALL_SCRIPT_URL: &str = "https://raw.githubusercontent.com/rtk-ai/rtk/master/install.sh";
+const CARGO_INSTALL_REPO: &str = "https://github.com/rtk-ai/rtk";
+
+enum UpdatePlan {
+    Run {
+        message: String,
+        program: String,
+        args: Vec<String>,
+        envs: Vec<(String, String)>,
+    },
+    Manual {
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum UpdateChannel {
+    Homebrew,
+    CargoDefaultBin,
+    ScriptDefaultBin(PathBuf),
+    Nix,
+    Unsupported,
+}
+
+pub fn run(_verbose: u8) -> Result<()> {
+    let current_version = env!("CARGO_PKG_VERSION");
+    let exe_path = current_executable_path()?;
+    let channel = detect_update_channel(&exe_path);
+
+    match build_update_plan(&channel, current_version)? {
+        UpdatePlan::Run {
+            message,
+            program,
+            args,
+            envs,
+        } => {
+            println!("{}", message);
+            execute_update(&program, &args, &envs)?;
+            println!("Update complete. Run `rtk --version` to verify the installed binary.");
+        }
+        UpdatePlan::Manual { message } => {
+            println!("{}", message);
+        }
+    }
+
+    Ok(())
+}
+
+fn build_update_plan(channel: &UpdateChannel, current_version: &str) -> Result<UpdatePlan> {
+    match channel {
+        UpdateChannel::Homebrew => Ok(UpdatePlan::Run {
+            message: "Updating RTK with Homebrew (`brew upgrade rtk`).".to_string(),
+            program: "brew".to_string(),
+            args: vec!["upgrade".to_string(), "rtk".to_string()],
+            envs: Vec::new(),
+        }),
+        UpdateChannel::ScriptDefaultBin(install_dir) => {
+            let latest_version = fetch_latest_version(current_version)?;
+            Ok(build_script_update_plan(
+                install_dir.clone(),
+                current_version,
+                &latest_version,
+            ))
+        }
+        UpdateChannel::CargoDefaultBin => {
+            let latest_version = fetch_latest_version(current_version)?;
+            Ok(build_cargo_update_message(current_version, &latest_version))
+        }
+        UpdateChannel::Nix => Ok(UpdatePlan::Manual {
+            message: "RTK appears to be managed by Nix. Update the package in your flake/profile, then rebuild your environment.".to_string(),
+        }),
+        UpdateChannel::Unsupported => Ok(UpdatePlan::Manual {
+            message: format!(
+                "Automatic update is available for Homebrew installs and the default Quick Install path (`~/.local/bin/rtk`). For this binary layout, reinstall manually with one of:\n\n  brew upgrade rtk\n  cargo install --git {} --tag <release-tag> --force\n  curl -fsSL {} | sh",
+                CARGO_INSTALL_REPO, INSTALL_SCRIPT_URL
+            ),
+        }),
+    }
+}
+
+fn fetch_latest_version(current_version: &str) -> Result<String> {
+    let body = ureq::get(RELEASE_API_URL)
+        .set("User-Agent", &format!("rtk/{}", current_version))
+        .set("Accept", "application/vnd.github+json")
+        .timeout(std::time::Duration::from_secs(10))
+        .call()
+        .context("Failed to query the latest RTK release from GitHub")?
+        .into_string()
+        .context("Failed to read GitHub release metadata")?;
+
+    let json: serde_json::Value =
+        serde_json::from_str(&body).context("Failed to parse GitHub release metadata")?;
+    let tag = json
+        .get("tag_name")
+        .and_then(|value| value.as_str())
+        .context("GitHub release metadata did not include tag_name")?;
+
+    Ok(normalize_version(tag).to_string())
+}
+
+fn build_script_update_plan(
+    install_dir: PathBuf,
+    current_version: &str,
+    latest_version: &str,
+) -> UpdatePlan {
+    if !is_newer_version(latest_version, current_version) {
+        return UpdatePlan::Manual {
+            message: format!("rtk is already up to date (v{}).", current_version),
+        };
+    }
+
+    UpdatePlan::Run {
+        message: format!(
+            "Updating RTK v{} -> v{} in {}.",
+            current_version,
+            latest_version,
+            install_dir.display()
+        ),
+        program: "sh".to_string(),
+        args: vec!["-c".to_string(), format!("curl -fsSL {} | sh", INSTALL_SCRIPT_URL)],
+        envs: vec![
+            ("RTK_VERSION".to_string(), format!("v{}", latest_version)),
+            (
+                "RTK_INSTALL_DIR".to_string(),
+                install_dir.to_string_lossy().to_string(),
+            ),
+        ],
+    }
+}
+
+fn build_cargo_update_message(current_version: &str, latest_version: &str) -> UpdatePlan {
+    if !is_newer_version(latest_version, current_version) {
+        return UpdatePlan::Manual {
+            message: format!("rtk is already up to date (v{}).", current_version),
+        };
+    }
+
+    UpdatePlan::Manual {
+        message: format!(
+            "RTK looks like a default Cargo install. Update it with:\n\n  cargo install --git {} --tag v{} --force",
+            CARGO_INSTALL_REPO, latest_version
+        ),
+    }
+}
+
+fn current_executable_path() -> Result<PathBuf> {
+    let exe = std::env::current_exe().context("Failed to locate the current RTK binary")?;
+    Ok(std::fs::canonicalize(&exe).unwrap_or(exe))
+}
+
+fn detect_update_channel(exe_path: &Path) -> UpdateChannel {
+    let path = exe_path.to_string_lossy();
+
+    if path.contains("/Cellar/rtk/") {
+        return UpdateChannel::Homebrew;
+    }
+
+    if path.contains("/nix/store/") {
+        return UpdateChannel::Nix;
+    }
+
+    if let Some(bin_dir) = default_quick_install_dir() {
+        if exe_path == bin_dir.join(binary_name()) {
+            return UpdateChannel::ScriptDefaultBin(bin_dir);
+        }
+    }
+
+    if is_default_cargo_install(exe_path) {
+        return UpdateChannel::CargoDefaultBin;
+    }
+
+    UpdateChannel::Unsupported
+}
+
+fn is_default_cargo_install(exe_path: &Path) -> bool {
+    default_cargo_bin_dir()
+        .map(|bin_dir| exe_path == bin_dir.join(binary_name()))
+        .unwrap_or(false)
+}
+
+fn default_cargo_bin_dir() -> Option<PathBuf> {
+    if let Some(cargo_home) = std::env::var_os("CARGO_HOME") {
+        return Some(PathBuf::from(cargo_home).join("bin"));
+    }
+
+    home_dir().map(|home| home.join(".cargo").join("bin"))
+}
+
+fn default_quick_install_dir() -> Option<PathBuf> {
+    if cfg!(target_os = "windows") {
+        return None;
+    }
+
+    home_dir().map(|home| home.join(".local").join("bin"))
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+fn binary_name() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "rtk.exe"
+    } else {
+        "rtk"
+    }
+}
+
+fn execute_update(program: &str, args: &[String], envs: &[(String, String)]) -> Result<()> {
+    let mut command = Command::new(program);
+    command
+        .args(args)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+
+    for (key, value) in envs {
+        command.env(key, value);
+    }
+
+    let status = command
+        .status()
+        .with_context(|| format!("Failed to run updater command: {}", program))?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        anyhow::bail!(
+            "Updater command exited with status {}",
+            status
+                .code()
+                .map(|code| code.to_string())
+                .unwrap_or_else(|| "unknown".to_string())
+        )
+    }
+}
+
+fn is_newer_version(latest: &str, current: &str) -> bool {
+    compare_versions(latest, current).is_gt()
+}
+
+fn compare_versions(left: &str, right: &str) -> std::cmp::Ordering {
+    let left = parse_version_parts(left);
+    let right = parse_version_parts(right);
+    let max_len = left.len().max(right.len());
+
+    for idx in 0..max_len {
+        let left_part = left.get(idx).copied().unwrap_or(0);
+        let right_part = right.get(idx).copied().unwrap_or(0);
+
+        match left_part.cmp(&right_part) {
+            std::cmp::Ordering::Equal => continue,
+            ordering => return ordering,
+        }
+    }
+
+    std::cmp::Ordering::Equal
+}
+
+fn parse_version_parts(version: &str) -> Vec<u64> {
+    normalize_version(version)
+        .split('.')
+        .map(|segment| {
+            segment
+                .chars()
+                .take_while(|ch| ch.is_ascii_digit())
+                .collect::<String>()
+        })
+        .filter(|segment| !segment.is_empty())
+        .map(|segment| segment.parse::<u64>().unwrap_or(0))
+        .collect()
+}
+
+fn normalize_version(version: &str) -> &str {
+    version.trim().trim_start_matches('v')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_newer_version_handles_semver() {
+        assert!(is_newer_version("0.29.1", "0.29.0"));
+        assert!(is_newer_version("v0.30.0", "0.29.9"));
+        assert!(!is_newer_version("0.29.0", "0.29.0"));
+        assert!(!is_newer_version("0.28.9", "0.29.0"));
+    }
+
+    #[test]
+    fn test_detect_update_channel_homebrew() {
+        let path = PathBuf::from("/opt/homebrew/Cellar/rtk/0.29.0/bin/rtk");
+        assert_eq!(detect_update_channel(&path), UpdateChannel::Homebrew);
+    }
+
+    #[test]
+    fn test_detect_update_channel_nix() {
+        let path = PathBuf::from("/nix/store/abc123-rtk/bin/rtk");
+        assert_eq!(detect_update_channel(&path), UpdateChannel::Nix);
+    }
+
+    #[test]
+    fn test_build_update_plan_for_script_sets_exact_release() {
+        let plan = build_script_update_plan(
+            PathBuf::from("/home/user/.local/bin"),
+            "0.29.0",
+            "0.30.0",
+        );
+
+        match plan {
+            UpdatePlan::Run { envs, .. } => {
+                assert!(envs.iter().any(|(key, _)| key == "RTK_VERSION"));
+                assert!(envs.iter().any(|(key, value)| {
+                    key == "RTK_INSTALL_DIR" && value == "/home/user/.local/bin"
+                }));
+            }
+            _ => panic!("expected runnable script plan"),
+        }
+    }
+
+    #[test]
+    fn test_build_update_plan_for_unsupported_is_manual() {
+        let plan = build_update_plan(&UpdateChannel::Unsupported, "0.29.0").unwrap();
+        match plan {
+            UpdatePlan::Manual { message } => {
+                assert!(message.contains("brew upgrade rtk"));
+                assert!(message.contains("cargo install --git"));
+            }
+            _ => panic!("expected manual plan"),
+        }
+    }
+
+    #[test]
+    fn test_build_cargo_update_message_uses_exact_tag() {
+        let plan = build_cargo_update_message("0.29.0", "0.30.0");
+        match plan {
+            UpdatePlan::Manual { message } => {
+                assert!(message.contains("--tag v0.30.0 --force"));
+            }
+            _ => panic!("expected manual cargo update command"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `rtk update` subcommand and wire it into the CLI meta-command handling
- update Homebrew installs automatically and pin default Quick Install updates to a tagged release via `install.sh`
- document the supported update paths and add a changelog entry

## Testing
- `sh -n install.sh`
- `. \"$HOME/.cargo/env\" && rtk cargo fmt --all --check`
- `. \"$HOME/.cargo/env\" && rtk cargo clippy --all-targets`
- `. \"$HOME/.cargo/env\" && rtk cargo test`
- `. \"$HOME/.cargo/env\" && cargo run -- update`
- Oracle read-only review of the final implementation