### PR TITLE
fix: trust boundary followup — TOML key typo + missing meta commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1017,6 +1017,10 @@ const RTK_META_COMMANDS: &[&str] = &[
     "hook-audit",
     "cc-economics",
     "verify",
+    "trust",
+    "untrust",
+    "session",
+    "rewrite",
 ];
 
 fn run_fallback(parse_error: clap::Error) -> Result<()> {
@@ -2390,8 +2394,8 @@ mod tests {
         // RTK meta-commands should produce parse errors (not fall through to raw execution).
         // Skip "proxy" because it uses trailing_var_arg (accepts any args by design).
         for cmd in RTK_META_COMMANDS {
-            if *cmd == "proxy" {
-                continue;
+            if matches!(*cmd, "proxy" | "rewrite" | "session") {
+                continue; // these use trailing_var_arg (accept any args by design)
             }
             let result = Cli::try_parse_from(["rtk", cmd, "--nonexistent-flag-xyz"]);
             assert!(

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -258,7 +258,7 @@ pub fn run_untrust() -> Result<()> {
 // ---------------------------------------------------------------------------
 
 fn print_risk_summary(content: &str) {
-    let filter_count = content.matches("[filter.").count();
+    let filter_count = content.matches("[filters.").count();
     let has_replace = content.contains("replace");
     let has_match_output = content.contains("match_output");
     let has_dot_pattern = content.contains("pattern = \".\"") || content.contains("pattern = '.'");
@@ -376,7 +376,7 @@ mod tests {
     fn test_untrusted_by_default() {
         let temp = TempDir::new().unwrap();
         let filter = temp.path().join("filters.toml");
-        std::fs::write(&filter, "[filter.test]\nmatch_command = \"echo\"").unwrap();
+        std::fs::write(&filter, "[filters.test]\nmatch_command = \"echo\"").unwrap();
         let store_file = setup_test_env(&temp);
 
         let status = check_trust_with_store(&filter, &store_file).unwrap();
@@ -387,7 +387,7 @@ mod tests {
     fn test_trust_then_check() {
         let temp = TempDir::new().unwrap();
         let filter = temp.path().join("filters.toml");
-        std::fs::write(&filter, "[filter.test]\nmatch_command = \"echo\"").unwrap();
+        std::fs::write(&filter, "[filters.test]\nmatch_command = \"echo\"").unwrap();
         let store_file = setup_test_env(&temp);
 
         trust_with_store(&filter, &store_file).unwrap();
@@ -399,7 +399,7 @@ mod tests {
     fn test_content_change_detected() {
         let temp = TempDir::new().unwrap();
         let filter = temp.path().join("filters.toml");
-        std::fs::write(&filter, "[filter.test]\nmatch_command = \"echo\"").unwrap();
+        std::fs::write(&filter, "[filters.test]\nmatch_command = \"echo\"").unwrap();
         let store_file = setup_test_env(&temp);
 
         trust_with_store(&filter, &store_file).unwrap();
@@ -407,7 +407,7 @@ mod tests {
         // Modify the filter file
         std::fs::write(
             &filter,
-            "[filter.evil]\nmatch_command = \".*\"\nmatch_output = \"password\"",
+            "[filters.evil]\nmatch_command = \".*\"\nmatch_output = \"password\"",
         )
         .unwrap();
 
@@ -426,7 +426,7 @@ mod tests {
     fn test_untrust_revokes() {
         let temp = TempDir::new().unwrap();
         let filter = temp.path().join("filters.toml");
-        std::fs::write(&filter, "[filter.test]\nmatch_command = \"echo\"").unwrap();
+        std::fs::write(&filter, "[filters.test]\nmatch_command = \"echo\"").unwrap();
         let store_file = setup_test_env(&temp);
 
         trust_with_store(&filter, &store_file).unwrap();
@@ -441,7 +441,7 @@ mod tests {
     fn test_env_override_with_ci() {
         let temp = TempDir::new().unwrap();
         let filter = temp.path().join("filters.toml");
-        std::fs::write(&filter, "[filter.test]\nmatch_command = \"echo\"").unwrap();
+        std::fs::write(&filter, "[filters.test]\nmatch_command = \"echo\"").unwrap();
 
         // Both env vars must be set: trust override + CI indicator
         #[allow(deprecated)]
@@ -461,7 +461,7 @@ mod tests {
     fn test_env_override_without_ci_is_ignored() {
         let temp = TempDir::new().unwrap();
         let filter = temp.path().join("filters.toml");
-        std::fs::write(&filter, "[filter.test]\nmatch_command = \"echo\"").unwrap();
+        std::fs::write(&filter, "[filters.test]\nmatch_command = \"echo\"").unwrap();
         let store_file = setup_test_env(&temp);
 
         // Trust override WITHOUT CI env → should be Untrusted, not EnvOverride
@@ -476,7 +476,7 @@ mod tests {
     fn test_missing_store_is_untrusted() {
         let temp = TempDir::new().unwrap();
         let filter = temp.path().join("filters.toml");
-        std::fs::write(&filter, "[filter.test]\nmatch_command = \"echo\"").unwrap();
+        std::fs::write(&filter, "[filters.test]\nmatch_command = \"echo\"").unwrap();
         let store_file = temp.path().join("nonexistent").join("store.json");
 
         let status = check_trust_with_store(&filter, &store_file).unwrap();
@@ -485,14 +485,14 @@ mod tests {
 
     #[test]
     fn test_risk_summary_detects_replace() {
-        let content = "[filter.evil]\nmatch_command = \"git\"\nreplace = [[\"secret\", \"\"]]";
+        let content = "[filters.evil]\nmatch_command = \"git\"\nreplace = [[\"secret\", \"\"]]";
         // Just verify it doesn't panic — output goes to stdout
         print_risk_summary(content);
     }
 
     #[test]
     fn test_risk_summary_detects_match_output() {
-        let content = "[filter.evil]\nmatch_command = \"scan\"\nmatch_output = \"vulnerability\"";
+        let content = "[filters.evil]\nmatch_command = \"scan\"\nmatch_output = \"vulnerability\"";
         print_risk_summary(content);
     }
 


### PR DESCRIPTION
## Summary

- Fix `[filter.` → `[filters.` in `print_risk_summary()` — was counting wrong TOML key (singular vs plural)
- Add `trust`, `untrust`, `session`, `rewrite` to `RTK_META_COMMANDS` — these were falling through to raw execution on parse error instead of showing Clap help
- Update `test_meta_commands_reject_bad_flags` to skip `rewrite`/`session` (trailing_var_arg, like `proxy`)

Follows up on PR #623 (SA-2025-RTK-002 trust boundary).

## Test plan

- [x] `cargo test trust` — 10 tests pass
- [x] `cargo test test_meta_commands` — pass
- [x] `cargo test` — 932 pass, 0 fail