### PR TITLE
fix(contributing): fix contributing guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to rtk (Rust Token Killer) will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bug Fixes
+
+* fix contributing guildelines ([#628](https://github.com/rtk-ai/rtk/pull/628))
+
 ## [0.29.0](https://github.com/rtk-ai/rtk/compare/v0.28.2...v0.29.0) (2026-03-12)
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,9 +33,9 @@ Every branch **must** follow one of these prefixes to identify the level of chan
 
 | Prefix | Semver Impact | When to Use |
 |--------|---------------|-------------|
-| `fix(scope): ...` | Patch | Bug fixes, corrections, minor adjustments |
-| `feat(scope): ...` | Minor | New features, new filters, new command support |
-| `chore(scope): ...` | Major | Breaking changes, API changes, removed functionality |
+| `fix(scope)/...` | Patch | Bug fixes, corrections, minor adjustments |
+| `feat(scope)/...` | Minor | New features, new filters, new command support |
+| `chore(scope)/...` | Major | Breaking changes, API changes, removed functionality |
 
 The **scope** in parentheses indicates which part of the project is concerned (e.g. `git`, `kubectl`, `filter`, `tracking`, `config`).
 
@@ -43,9 +43,9 @@ The **scope** in parentheses indicates which part of the project is concerned (e
 
 Examples:
 ```
-fix(git): log-filter-drops-merge-commits
-feat(kubectl): add-pod-list-filter
-chore(proxy): remove-deprecated-flags
+fix(git)/log-filter-drops-merge-commits
+feat(kubectl)/add-pod-list-filter
+chore(proxy)/remove-deprecated-flags
 ```
 
 ---
@@ -55,9 +55,9 @@ chore(proxy): remove-deprecated-flags
 ### 1. Create Your Branch
 
 ```bash
-git checkout develop
-git pull origin develop
-git checkout -b "feat(scope): your-clear-description"
+git checkout master
+git pull origin master
+git checkout -b "feat(scope)/your-clear-description"
 ```
 
 ### 2. Make Your Changes
@@ -88,9 +88,9 @@ https://developercertificate.org/
 
 By signing off, you agree to the DCO.
 
-### 5. Merge into `develop`
+### 5. Merge into `master`
 
-Once your work is ready, open a Pull Request targeting the **`develop`** branch.
+Once your work is ready, open a Pull Request targeting the **`master`** branch.
 
 ### 6. Review Process
 
@@ -100,10 +100,10 @@ Once your work is ready, open a Pull Request targeting the **`develop`** branch.
 
 ### 7. Integration & Release
 
-Once merged, your changes are tested on the `develop` branch alongside other features. When the maintainer is satisfied with the state of `develop`, they release to `master` under a specific version.
+Once merged, your changes are tested on the `master` branch alongside other features. When the maintainer is satisfied with the state of `master`, they release to `master` under a specific version.
 
 ```
-your branch --> develop (review + CI + integration testing) --> version branch --> master (versioned release)
+your branch --> master (review + CI + integration testing) --> version branch --> master (versioned release)
 ```
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,8 +55,8 @@ chore(proxy)/remove-deprecated-flags
 ### 1. Create Your Branch
 
 ```bash
-git checkout master
-git pull origin master
+git checkout develop
+git pull origin develop
 git checkout -b "feat(scope)/your-clear-description"
 ```
 
@@ -88,9 +88,9 @@ https://developercertificate.org/
 
 By signing off, you agree to the DCO.
 
-### 5. Merge into `master`
+### 5. Merge into `develop`
 
-Once your work is ready, open a Pull Request targeting the **`master`** branch.
+Once your work is ready, open a Pull Request targeting the **`develop`** branch.
 
 ### 6. Review Process
 
@@ -100,10 +100,10 @@ Once your work is ready, open a Pull Request targeting the **`master`** branch.
 
 ### 7. Integration & Release
 
-Once merged, your changes are tested on the `master` branch alongside other features. When the maintainer is satisfied with the state of `master`, they release to `master` under a specific version.
+Once merged, your changes are tested on the `develop` branch alongside other features. When the maintainer is satisfied with the state of `develop`, they release to `master` under a specific version.
 
 ```
-your branch --> master (review + CI + integration testing) --> version branch --> master (versioned release)
+your branch --> develop (review + CI + integration testing) --> version branch --> master (versioned release)
 ```
 
 ---

--- a/hooks/rtk-rewrite.sh
+++ b/hooks/rtk-rewrite.sh
@@ -19,15 +19,9 @@ fi
 
 # Version guard: rtk rewrite was added in 0.23.0.
 # Older binaries: warn once and exit cleanly (no silent failure).
-RTK_VERSION=$(rtk --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-if [ -n "$RTK_VERSION" ]; then
-  MAJOR=$(echo "$RTK_VERSION" | cut -d. -f1)
-  MINOR=$(echo "$RTK_VERSION" | cut -d. -f2)
-  # Require >= 0.23.0
-  if [ "$MAJOR" -eq 0 ] && [ "$MINOR" -lt 23 ]; then
-    echo "[rtk] WARNING: rtk $RTK_VERSION is too old (need >= 0.23.0). Upgrade: cargo install rtk" >&2
-    exit 0
-  fi
+if ! rtk rewrite --help &>/dev/null; then
+  echo "[rtk] WARNING: rtk is too old (need >= 0.23.0). Upgrade: cargo install rtk" >&2
+  exit 0
 fi
 
 INPUT=$(cat)

--- a/hooks/rtk-rewrite.sh
+++ b/hooks/rtk-rewrite.sh
@@ -24,24 +24,24 @@ if ! rtk rewrite --help &>/dev/null; then
   exit 0
 fi
 
-INPUT=$(cat)
-CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+INPUT="$(cat)"
+CMD="$(echo "$INPUT" | jq -r '.tool_input.command // empty')"
 
-if [ -z "$CMD" ]; then
+if [[ -z "$CMD" ]]; then
   exit 0
 fi
 
 # Delegate all rewrite logic to the Rust binary.
 # rtk rewrite exits 1 when there's no rewrite — hook passes through silently.
-REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null) || exit 0
+REWRITTEN="$(rtk rewrite "$CMD" 2>/dev/null)" || exit 0
 
 # No change — nothing to do.
-if [ "$CMD" = "$REWRITTEN" ]; then
+if [[ "$CMD" == "$REWRITTEN" ]]; then
   exit 0
 fi
 
-ORIGINAL_INPUT=$(echo "$INPUT" | jq -c '.tool_input')
-UPDATED_INPUT=$(echo "$ORIGINAL_INPUT" | jq --arg cmd "$REWRITTEN" '.command = $cmd')
+ORIGINAL_INPUT="$(echo "$INPUT" | jq -c '.tool_input')"
+UPDATED_INPUT="$(echo "$ORIGINAL_INPUT" | jq --arg cmd "$REWRITTEN" '.command = $cmd')"
 
 jq -n \
   --argjson updated "$UPDATED_INPUT" \


### PR DESCRIPTION
This PR fixes some inconsistencies in the CONTRIBUTING.md guidelines.

This addresses 2 points:

- It fixes invalid suggested git branch names, which should rather be something like `feat(scope)/description', otherwise the following error is thrown

```
$ git checkout -b 'feat(contributing): fix-contributing-guidelines'
fatal: 'feat(contributing): fix-contributing-guidelines' is not a valid branch name
hint: See `man git check-ref-format`
hint: Disable this message with "git config set advice.refSyntax false"
```