### PR TITLE
fix: propagate exit codes in git diff/status/commit/branch

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -112,6 +112,21 @@ fn run_diff(
     let output = cmd.output().context("Failed to run git diff")?;
     let stat_stdout = String::from_utf8_lossy(&output.stdout);
 
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.trim().is_empty() {
+            eprint!("{}", stderr);
+        }
+        let raw = stat_stdout.to_string();
+        timer.track(
+            &format!("git diff {}", args.join(" ")),
+            &format!("rtk git diff {}", args.join(" ")),
+            &raw,
+            &raw,
+        );
+        std::process::exit(output.status.code().unwrap_or(1));
+    }
+
     if verbose > 0 {
         eprintln!("Git diff summary:");
     }
@@ -603,7 +618,10 @@ fn format_status_output(porcelain: &str) -> String {
             output.push_str(&format!("   {}\n", f));
         }
         if staged_files.len() > max_files {
-            output.push_str(&format!("   ... +{} more\n", staged_files.len() - max_files));
+            output.push_str(&format!(
+                "   ... +{} more\n",
+                staged_files.len() - max_files
+            ));
         }
     }
 
@@ -613,7 +631,10 @@ fn format_status_output(porcelain: &str) -> String {
             output.push_str(&format!("   {}\n", f));
         }
         if modified_files.len() > max_files {
-            output.push_str(&format!("   ... +{} more\n", modified_files.len() - max_files));
+            output.push_str(&format!(
+                "   ... +{} more\n",
+                modified_files.len() - max_files
+            ));
         }
     }
 
@@ -623,7 +644,10 @@ fn format_status_output(porcelain: &str) -> String {
             output.push_str(&format!("   {}\n", f));
         }
         if untracked_files.len() > max_untracked {
-            output.push_str(&format!("   ... +{} more\n", untracked_files.len() - max_untracked));
+            output.push_str(&format!(
+                "   ... +{} more\n",
+                untracked_files.len() - max_untracked
+            ));
         }
     }
 
@@ -684,6 +708,20 @@ fn run_status(args: &[String], verbose: u8, global_args: &[String]) -> Result<()
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
+
+        if !output.status.success() {
+            if !stderr.trim().is_empty() {
+                eprint!("{}", stderr);
+            }
+            let raw = stdout.to_string();
+            timer.track(
+                &format!("git status {}", args.join(" ")),
+                &format!("rtk git status {}", args.join(" ")),
+                &raw,
+                &raw,
+            );
+            std::process::exit(output.status.code().unwrap_or(1));
+        }
 
         if verbose > 0 || !stderr.is_empty() {
             eprint!("{}", stderr);
@@ -864,13 +902,14 @@ fn run_commit(args: &[String], verbose: u8, global_args: &[String]) -> Result<()
                 "ok (nothing to commit)",
             );
         } else {
-            eprintln!("FAILED: git commit");
             if !stderr.trim().is_empty() {
-                eprintln!("{}", stderr);
+                eprint!("{}", stderr);
             }
             if !stdout.trim().is_empty() {
-                eprintln!("{}", stdout);
+                eprint!("{}", stdout);
             }
+            timer.track(&original_cmd, "rtk git commit", &raw_output, &raw_output);
+            std::process::exit(output.status.code().unwrap_or(1));
         }
     }
 
@@ -1107,6 +1146,20 @@ fn run_branch(args: &[String], verbose: u8, global_args: &[String]) -> Result<()
     let output = cmd.output().context("Failed to run git branch")?;
     let stdout = String::from_utf8_lossy(&output.stdout);
     let raw = stdout.to_string();
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.trim().is_empty() {
+            eprint!("{}", stderr);
+        }
+        timer.track(
+            &format!("git branch {}", args.join(" ")),
+            &format!("rtk git branch {}", args.join(" ")),
+            &raw,
+            &raw,
+        );
+        std::process::exit(output.status.code().unwrap_or(1));
+    }
 
     let filtered = filter_branch_output(&stdout);
     println!("{}", filtered);


### PR DESCRIPTION
## Summary
- Fix 4 P1 bugs where git exit codes were swallowed in `src/git.rs`
- `git diff`: failure silently printed empty stat output
- `git status` (with args): failure was filtered instead of propagated
- `git commit`: failure printed "FAILED" but returned Ok(), breaking pre-commit hooks
- `git branch` (list mode): failure was silently ignored
- All now follow the established pattern: eprint stderr, track raw==raw, process::exit(code)

## Test plan
- [x] `cargo test --all` (934 passed)
- [x] Consistent with exit code pattern used in wget, container, prisma, mypy, golangci modules