### PR TITLE
docs: add sandbox troubleshooting for Claude Code tracking

### DIFF
--- a/docs/tracking.md
+++ b/docs/tracking.md
@@ -561,6 +561,20 @@ sqlite3 ~/.local/share/rtk/tracking.db \
   "ALTER TABLE commands ADD COLUMN exec_time_ms INTEGER DEFAULT 0"
 ```
 
+### No statistics recorded in Claude Code sandbox
+
+When running Claude Code in sandbox mode, RTK commands are blocked by default, which prevents tracking data from being written to the SQLite database. To allow RTK to execute and record statistics, exclude it from the sandbox restrictions in your Claude Code settings:
+
+```json
+{
+  "sandbox": {
+    "excludedCommands": ["rtk:*"]
+  }
+}
+```
+
+This whitelists all RTK commands (`rtk:*`) so they can run normally and persist token savings to the database.
+
 ### Incorrect token counts
 
 Token estimation uses `~4 chars = 1 token`. This is approximate. For precise counts, integrate with your LLM's tokenizer API.


### PR DESCRIPTION
## Summary                                           
                                                                                                                                
- Add a new troubleshooting entry in docs/tracking.md explaining why RTK statistics may not be recorded when Claude Code runs in sandbox mode                                                                                                               
- Document the excludedCommands configuration to whitelist RTK commands                                                       
                                                                                                                                
##  Context                                  
                                                                                                                                
When Claude Code is configured with sandbox mode enabled, all RTK commands are blocked by default. This silently prevents tracking data from being written to the SQLite database, making rtk gain appear empty. This is a common gotcha for new users.
                                                                                                                                
##  Configuration                                     
     
```json                                      
  {
    "sandbox": {
      "excludedCommands": ["rtk:*"]
    }
  }
```

