### PR TITLE
feat: add Nix flake with home-manager module for declarative builds

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -52,6 +52,22 @@ After installation, **verify you have the correct rtk**:
 rtk gain  # Must show token savings stats (not "command not found")
 ```
 
+### Nix
+
+```bash
+# Run directly without installing
+nix run github:rtk-ai/rtk
+
+# Install into a profile
+nix profile install github:rtk-ai/rtk
+
+# Or add to your flake as an input:
+# inputs.rtk.url = "github:rtk-ai/rtk";
+# Then use: rtk.packages.${system}.default
+```
+
+An overlay is also available as `overlays.default`.
+
 ### Alternative: Manual Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -81,6 +81,19 @@ curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/instal
 cargo install --git https://github.com/rtk-ai/rtk
 ```
 
+### Nix
+
+```bash
+# Run directly
+nix run github:rtk-ai/rtk
+
+# Or add to your flake inputs
+# inputs.rtk.url = "github:rtk-ai/rtk";
+# Then use: rtk.packages.${system}.default
+```
+
+An overlay is also available as `overlays.default`.
+
 ### Pre-built Binaries
 
 Download from [releases](https://github.com/rtk-ai/rtk/releases):

--- a/README_es.md
+++ b/README_es.md
@@ -66,6 +66,19 @@ curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/instal
 cargo install --git https://github.com/rtk-ai/rtk
 ```
 
+### Nix
+
+```bash
+# Ejecutar directamente
+nix run github:rtk-ai/rtk
+
+# O agregar como input en tu flake
+# inputs.rtk.url = "github:rtk-ai/rtk";
+# Luego usar: rtk.packages.${system}.default
+```
+
+Tambien hay un overlay disponible como `overlays.default`.
+
 ### Verificacion
 
 ```bash

--- a/README_fr.md
+++ b/README_fr.md
@@ -71,6 +71,19 @@ curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/instal
 cargo install --git https://github.com/rtk-ai/rtk
 ```
 
+### Nix
+
+```bash
+# Executer directement
+nix run github:rtk-ai/rtk
+
+# Ou ajouter comme input dans votre flake
+# inputs.rtk.url = "github:rtk-ai/rtk";
+# Puis utiliser: rtk.packages.${system}.default
+```
+
+Un overlay est egalement disponible via `overlays.default`.
+
 ### Verification
 
 ```bash

--- a/README_ja.md
+++ b/README_ja.md
@@ -66,6 +66,19 @@ curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/instal
 cargo install --git https://github.com/rtk-ai/rtk
 ```
 
+### Nix
+
+```bash
+# 直接実行
+nix run github:rtk-ai/rtk
+
+# またはflakeのinputに追加
+# inputs.rtk.url = "github:rtk-ai/rtk";
+# 使用: rtk.packages.${system}.default
+```
+
+`overlays.default` としてオーバーレイも利用可能です。
+
 ### 確認
 
 ```bash

--- a/README_ko.md
+++ b/README_ko.md
@@ -66,6 +66,19 @@ curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/instal
 cargo install --git https://github.com/rtk-ai/rtk
 ```
 
+### Nix
+
+```bash
+# 직접 실행
+nix run github:rtk-ai/rtk
+
+# 또는 flake input으로 추가
+# inputs.rtk.url = "github:rtk-ai/rtk";
+# 사용: rtk.packages.${system}.default
+```
+
+`overlays.default`로 오버레이도 사용 가능합니다.
+
 ### 확인
 
 ```bash

--- a/README_zh.md
+++ b/README_zh.md
@@ -67,6 +67,19 @@ curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/instal
 cargo install --git https://github.com/rtk-ai/rtk
 ```
 
+### Nix
+
+```bash
+# 直接运行
+nix run github:rtk-ai/rtk
+
+# 或添加为 flake input
+# inputs.rtk.url = "github:rtk-ai/rtk";
+# 使用: rtk.packages.${system}.default
+```
+
+也可通过 `overlays.default` 使用 overlay。
+
 ### 验证
 
 ```bash

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778036283,
+        "narHash": "sha256-62EWg6lI0qyzm7oAx5cAnGkLutvJsRBe0KkEW2JDZCE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ed67bc86e84e51d4a88e73c7fd36006dc876476f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -17,5 +17,7 @@
       overlays.default = final: prev: {
         rtk = final.callPackage ./nix/package.nix {};
       };
+
+      homeManagerModules.default = import ./nix/homeManagerModule.nix self.packages;
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {inherit system;};
+    in {
+      packages.default = pkgs.callPackage ./nix/package.nix {};
+    })
+    // {
+      overlays.default = final: prev: {
+        rtk = final.callPackage ./nix/package.nix {};
+      };
+    };
+}

--- a/nix/homeManagerModule.nix
+++ b/nix/homeManagerModule.nix
@@ -1,0 +1,88 @@
+# Home-manager module for RTK (Rust Token Killer).
+#
+# Usage: import rtk.homeManagerModules.default, then:
+#   programs.rtk = {
+#     enable = true;
+#     claudeCode.enable = true;
+#     opencode.enable = false;
+#   };
+rtkPackages: {
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.programs.rtk;
+  rtkPkg = rtkPackages.${pkgs.stdenv.hostPlatform.system}.default;
+
+  manifest = pkgs.runCommand "rtk-config" {
+    nativeBuildInputs = [rtkPkg pkgs.jq];
+  } ''
+    ${rtkPkg}/bin/rtk init --dry-run --json \
+      ${lib.optionalString cfg.opencode.enable "--opencode"} \
+      ${lib.optionalString (cfg.claudeCode.baseClaude != null) "--base-claude-md ${cfg.claudeCode.baseClaude}"} \
+      ${lib.optionalString (cfg.claudeCode.baseSettings != null) "--base-settings ${cfg.claudeCode.baseSettings}"} \
+      > manifest.json
+
+    count=$(jq '.files | length' manifest.json)
+    for i in $(seq 0 $((count - 1))); do
+      relpath=$(jq -r ".files[$i].path" manifest.json)
+      mode=$(jq -r ".files[$i].mode" manifest.json)
+      mkdir -p "$out/$(dirname "$relpath")"
+      jq -r ".files[$i].content" manifest.json > "$out/$relpath"
+      chmod "$mode" "$out/$relpath"
+    done
+  '';
+in {
+  options.programs.rtk = {
+    enable = lib.mkEnableOption "RTK (Rust Token Killer) token compression";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = rtkPkg;
+      description = "The RTK package to install.";
+    };
+
+    claudeCode = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Configure RTK hooks for Claude Code.";
+      };
+
+      baseClaude = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = "Seed CLAUDE.md content from this file. RTK appends @RTK.md to it.";
+      };
+
+      baseSettings = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = "Seed settings.json from this file. RTK merges the hook entry into it.";
+      };
+    };
+
+    opencode = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Install RTK plugin for OpenCode.";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [cfg.package];
+
+    home.file = lib.mkIf cfg.claudeCode.enable {
+      ".claude/CLAUDE.md".source = "${manifest}/.claude/CLAUDE.md";
+      ".claude/settings.json".source = "${manifest}/.claude/settings.json";
+      ".claude/hooks/rtk-rewrite.sh" = {
+        source = "${manifest}/.claude/hooks/rtk-rewrite.sh";
+        executable = true;
+      };
+      ".claude/RTK.md".source = "${manifest}/.claude/RTK.md";
+    };
+  };
+}

--- a/nix/homeManagerModule.nix
+++ b/nix/homeManagerModule.nix
@@ -29,7 +29,7 @@ rtkPackages: {
       relpath=$(jq -r ".files[$i].path" manifest.json)
       mode=$(jq -r ".files[$i].mode" manifest.json)
       mkdir -p "$out/$(dirname "$relpath")"
-      jq -r ".files[$i].content" manifest.json > "$out/$relpath"
+      jq -j ".files[$i].content" manifest.json > "$out/$relpath"
       chmod "$mode" "$out/$relpath"
     done
   '';

--- a/nix/homeManagerModule.nix
+++ b/nix/homeManagerModule.nix
@@ -78,10 +78,6 @@ in {
     home.file = lib.mkIf cfg.claudeCode.enable {
       ".claude/CLAUDE.md".source = "${manifest}/.claude/CLAUDE.md";
       ".claude/settings.json".source = "${manifest}/.claude/settings.json";
-      ".claude/hooks/rtk-rewrite.sh" = {
-        source = "${manifest}/.claude/hooks/rtk-rewrite.sh";
-        executable = true;
-      };
       ".claude/RTK.md".source = "${manifest}/.claude/RTK.md";
     };
   };

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,18 @@
+{lib, rustPlatform}:
+let
+  cargoToml = builtins.fromTOML (builtins.readFile ../Cargo.toml);
+in
+rustPlatform.buildRustPackage {
+  pname = "rtk";
+  inherit (cargoToml.package) version;
+  src = lib.cleanSource ./..;
+  cargoLock.lockFile = ../Cargo.lock;
+  doCheck = false; # tests require network
+  meta = {
+    description = "High-performance CLI proxy to minimize LLM token consumption";
+    homepage = "https://github.com/rtk-ai/rtk";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    mainProgram = "rtk";
+  };
+}

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -1,6 +1,7 @@
 //! Sets up RTK hooks so AI coding agents automatically route commands through RTK.
 
 use anyhow::{Context, Result};
+use serde::Serialize;
 use std::ffi::OsString;
 use std::fs;
 use std::io::Write;
@@ -70,6 +71,23 @@ const GEMINI_MD: &str = "GEMINI.md";
 
 const RTK_BLOCK_START: &str = "<!-- rtk-instructions";
 const RTK_BLOCK_END: &str = "<!-- /rtk-instructions -->";
+
+/// A single file in the dry-run manifest.
+#[derive(Debug, Clone, Serialize)]
+pub struct FileManifestEntry {
+    /// Path relative to $HOME (no ~/ prefix)
+    pub path: String,
+    /// Final file content after all transforms
+    pub content: String,
+    /// Unix permission mode as octal string (e.g. "755")
+    pub mode: String,
+}
+
+/// Complete dry-run manifest output.
+#[derive(Debug, Clone, Serialize)]
+pub struct FileManifest {
+    pub files: Vec<FileManifestEntry>,
+}
 
 /// Control flow for settings.json patching
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -4178,6 +4196,95 @@ fn uninstall_copilot_global_at(copilot_dir: &Path, ctx: InitContext) -> Result<V
     Ok(removed)
 }
 
+/// Generate a file manifest without writing to disk.
+///
+/// Pure function: all content comes from embedded constants and the provided
+/// seed values. No filesystem I/O is performed.
+///
+/// Used by `--dry-run --json` for declarative config managers (Nix, Ansible, etc.)
+pub fn generate_manifest(
+    install_opencode: bool,
+    base_claude_md: Option<String>,
+    base_settings: Option<String>,
+) -> Result<FileManifest> {
+    let mut files = Vec::new();
+
+    // 1. RTK.md (slim awareness instructions)
+    files.push(FileManifestEntry {
+        path: ".claude/RTK.md".to_string(),
+        content: RTK_SLIM.to_string(),
+        mode: "644".to_string(),
+    });
+
+    // 2. CLAUDE.md — apply same transform as patch_claude_md (pure)
+    let claude_md_content = {
+        let mut content = base_claude_md.unwrap_or_default();
+        if !content.contains(RTK_MD_REF) {
+            content.push_str("\n\n");
+            content.push_str(RTK_MD_REF);
+            content.push('\n');
+        }
+        content
+    };
+
+    files.push(FileManifestEntry {
+        path: ".claude/CLAUDE.md".to_string(),
+        content: claude_md_content,
+        mode: "644".to_string(),
+    });
+
+    // 3. settings.json — wire `rtk hook claude` into PreToolUse (pure)
+    let settings_content = {
+        let base = base_settings.unwrap_or_else(|| "{}".to_string());
+        let mut json: serde_json::Value =
+            serde_json::from_str(&base).context("Failed to parse base settings.json")?;
+
+        if json.get("hooks").is_none() {
+            json["hooks"] = serde_json::json!({});
+        }
+
+        let hooks = json["hooks"].as_object_mut().unwrap();
+        if hooks.get(PRE_TOOL_USE_KEY).is_none() {
+            hooks.insert(
+                PRE_TOOL_USE_KEY.to_string(),
+                serde_json::json!([{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": CLAUDE_HOOK_COMMAND
+                    }]
+                }]),
+            );
+        }
+
+        serde_json::to_string_pretty(&json).context("Failed to serialize settings.json")?
+    };
+
+    files.push(FileManifestEntry {
+        path: ".claude/settings.json".to_string(),
+        content: settings_content,
+        mode: "644".to_string(),
+    });
+
+    // 4. filters.toml (project-local template)
+    files.push(FileManifestEntry {
+        path: ".config/rtk/filters.toml".to_string(),
+        content: FILTERS_TEMPLATE.to_string(),
+        mode: "644".to_string(),
+    });
+
+    // 5. OpenCode plugin (optional)
+    if install_opencode {
+        files.push(FileManifestEntry {
+            path: ".config/opencode/plugins/rtk.ts".to_string(),
+            content: OPENCODE_PLUGIN.to_string(),
+            mode: "644".to_string(),
+        });
+    }
+
+    Ok(FileManifest { files })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -6888,5 +6995,146 @@ mod tests {
             "Hook config must not be written when the upsert aborts: {}",
             hook_path.display()
         );
+    }
+
+    // Tests for generate_manifest()
+
+    #[test]
+    fn test_generate_manifest_default() {
+        let manifest = generate_manifest(false, None, None).unwrap();
+
+        assert_eq!(manifest.files.len(), 4);
+
+        let paths: Vec<&str> = manifest.files.iter().map(|f| f.path.as_str()).collect();
+        assert!(paths.contains(&".claude/RTK.md"));
+        assert!(paths.contains(&".claude/CLAUDE.md"));
+        assert!(paths.contains(&".claude/settings.json"));
+        assert!(paths.contains(&".config/rtk/filters.toml"));
+
+        // CLAUDE.md should contain @RTK.md (empty base)
+        let claude_md = manifest
+            .files
+            .iter()
+            .find(|f| f.path == ".claude/CLAUDE.md")
+            .unwrap();
+        assert!(claude_md.content.contains(RTK_MD_REF));
+
+        // settings.json should wire `rtk hook claude` into PreToolUse
+        let settings = manifest
+            .files
+            .iter()
+            .find(|f| f.path == ".claude/settings.json")
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_str(&settings.content).unwrap();
+        let pre_tool_use = json["hooks"][PRE_TOOL_USE_KEY].as_array().unwrap();
+        assert_eq!(pre_tool_use.len(), 1);
+        assert_eq!(pre_tool_use[0]["matcher"], "Bash");
+        assert_eq!(pre_tool_use[0]["hooks"][0]["command"], CLAUDE_HOOK_COMMAND);
+    }
+
+    #[test]
+    fn test_generate_manifest_with_opencode() {
+        let manifest = generate_manifest(true, None, None).unwrap();
+
+        assert_eq!(manifest.files.len(), 5);
+
+        let paths: Vec<&str> = manifest.files.iter().map(|f| f.path.as_str()).collect();
+        assert!(paths.contains(&".config/opencode/plugins/rtk.ts"));
+
+        let opencode_plugin = manifest
+            .files
+            .iter()
+            .find(|f| f.path == ".config/opencode/plugins/rtk.ts")
+            .unwrap();
+        assert_eq!(opencode_plugin.content, OPENCODE_PLUGIN);
+        assert_eq!(opencode_plugin.mode, "644");
+    }
+
+    #[test]
+    fn test_generate_manifest_with_base_claude() {
+        let base_claude = "# My Project\n\nCustom instructions.".to_string();
+        let manifest = generate_manifest(false, Some(base_claude.clone()), None).unwrap();
+
+        let claude_md = manifest
+            .files
+            .iter()
+            .find(|f| f.path == ".claude/CLAUDE.md")
+            .unwrap();
+
+        // Should preserve base content
+        assert!(claude_md.content.contains("# My Project"));
+        assert!(claude_md.content.contains("Custom instructions."));
+        // Should append @RTK.md reference
+        assert!(claude_md.content.contains(RTK_MD_REF));
+    }
+
+    #[test]
+    fn test_generate_manifest_with_base_settings() {
+        let base_settings = r#"{
+            "tools": {
+                "bash": {
+                    "timeout": 120000
+                }
+            }
+        }"#
+        .to_string();
+        let manifest = generate_manifest(false, None, Some(base_settings)).unwrap();
+
+        let settings = manifest
+            .files
+            .iter()
+            .find(|f| f.path == ".claude/settings.json")
+            .unwrap();
+
+        let json: serde_json::Value = serde_json::from_str(&settings.content).unwrap();
+
+        // Should preserve existing fields
+        assert_eq!(json["tools"]["bash"]["timeout"], 120000);
+        // Should add PreToolUse hook
+        assert!(json["hooks"][PRE_TOOL_USE_KEY].is_array());
+    }
+
+    #[test]
+    fn test_generate_manifest_preserves_existing_hooks() {
+        let base_settings = format!(
+            r#"{{
+                "hooks": {{
+                    "{}": [
+                        {{"matcher": "Bash", "hooks": [{{"type": "command", "command": "./hooks/other.sh"}}]}}
+                    ]
+                }}
+            }}"#,
+            PRE_TOOL_USE_KEY
+        );
+        let manifest = generate_manifest(false, None, Some(base_settings)).unwrap();
+
+        let settings = manifest
+            .files
+            .iter()
+            .find(|f| f.path == ".claude/settings.json")
+            .unwrap();
+
+        let json: serde_json::Value = serde_json::from_str(&settings.content).unwrap();
+
+        // Should preserve existing hook (not add RTK hook again in this pure implementation)
+        let hooks = json["hooks"][PRE_TOOL_USE_KEY].as_array().unwrap();
+        assert_eq!(hooks.len(), 1);
+        assert_eq!(hooks[0]["hooks"][0]["command"], "./hooks/other.sh");
+    }
+
+    #[test]
+    fn test_generate_manifest_claude_md_already_has_ref() {
+        let base_claude = format!("# My Project\n\n{}\n", RTK_MD_REF);
+        let manifest = generate_manifest(false, Some(base_claude.clone()), None).unwrap();
+
+        let claude_md = manifest
+            .files
+            .iter()
+            .find(|f| f.path == ".claude/CLAUDE.md")
+            .unwrap();
+
+        // Should not duplicate @RTK.md reference
+        let ref_count = claude_md.content.matches(RTK_MD_REF).count();
+        assert_eq!(ref_count, 1, "Should have exactly one @RTK.md reference");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -377,6 +377,18 @@ enum Commands {
         /// Preview changes without writing any files (combine with -v to show content)
         #[arg(long = "dry-run", conflicts_with = "show")]
         dry_run: bool,
+
+        /// Emit dry-run manifest as JSON for declarative config managers (requires --dry-run)
+        #[arg(long, requires = "dry_run")]
+        json: bool,
+
+        /// Seed CLAUDE.md content from file (requires --dry-run)
+        #[arg(long = "base-claude-md", requires = "dry_run")]
+        base_claude_md: Option<PathBuf>,
+
+        /// Seed settings.json content from file (requires --dry-run)
+        #[arg(long = "base-settings", requires = "dry_run")]
+        base_settings: Option<PathBuf>,
     },
 
     /// Download with compact output (strips progress bars)
@@ -1887,12 +1899,30 @@ fn run_cli() -> Result<i32> {
             codex,
             copilot,
             dry_run,
+            json,
+            base_claude_md,
+            base_settings,
         } => {
             let ctx = hooks::init::InitContext {
                 verbose: cli.verbose,
                 dry_run,
             };
-            if show {
+            if json {
+                let base_claude = base_claude_md
+                    .map(|p| std::fs::read_to_string(&p))
+                    .transpose()
+                    .context("Failed to read --base-claude-md file")?;
+                let base_set = base_settings
+                    .map(|p| std::fs::read_to_string(&p))
+                    .transpose()
+                    .context("Failed to read --base-settings file")?;
+                let manifest = hooks::init::generate_manifest(opencode, base_claude, base_set)?;
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&manifest)
+                        .context("Failed to serialize manifest")?
+                );
+            } else if show {
                 hooks::init::show_config(codex)?;
             } else if uninstall && copilot {
                 if global {


### PR DESCRIPTION
## Summary

- Add a Nix flake (`flake.nix` + `nix/package.nix`) that builds rtk using `rustPlatform.buildRustPackage`
- Add `--dry-run --json` flag to `rtk init` for declarative config managers (outputs file manifest as JSON)
- Add home-manager module (`nix/homeManagerModule.nix`) for declarative Claude Code hook integration
- Version is read from `Cargo.toml` at eval time — no manual version bumps needed
- Includes an overlay (`overlays.default`) and `homeManagerModules.default` for Nix consumers

## What this enables

```nix
# flake.nix
inputs.rtk.url = "github:rtk-ai/rtk";

# home-manager config
imports = [ inputs.rtk.homeManagerModules.default ];
programs.rtk = {
  enable = true;
  claudeCode = {
    enable = true;
    baseClaude = ./CLAUDE.md.template;   # optional: seed CLAUDE.md
    baseSettings = ./settings.json;       # optional: seed settings.json
  };
};
```

```bash
# Run directly without installing
nix run github:rtk-ai/rtk

# Programmatic config generation (for other package managers)
rtk init --dry-run --json
```

## Design decisions

- **`builtins.fromTOML` for version**: reads `Cargo.toml` at eval time so the package version stays in sync with releases automatically
- **`--dry-run --json`**: outputs the full file manifest as JSON so Nix (or any declarative tool) can extract files at build time without side effects
- **`jq -j` in module**: uses `jq -j` (not `jq -r`) to extract file content without adding a trailing newline, preserving exact content for `rtk verify` integrity checks
- **`doCheck = false`**: tests require network access which is unavailable in the Nix sandbox

## Test plan

- [x] `nix build` succeeds on macOS (aarch64)
- [x] `rtk verify` passes after `darwin-rebuild switch` with home-manager module
- [x] `rtk gain` and hook rewriting work end-to-end
- [x] `nix build` succeeds on Linux (x86_64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)