### PR TITLE
feat(init): add experimental Codex adapter via subprocess-local PATH shims

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -119,6 +119,49 @@ Zero context overhead               Minimal context overhead
 Best for: production                Best for: learning / auditing
 ```
 
+### Codex Adapter Architecture (experimental)
+
+Codex does not currently expose the same documented pre-exec rewrite hook surface that RTK uses for Claude Code and OpenCode. The Codex integration therefore uses an adapter model instead of a host-native hook.
+
+```
+┌────────────────────────────────────────────────────────────────────────┐
+│                      Codex Adapter Execution Path                      │
+└────────────────────────────────────────────────────────────────────────┘
+
+Codex config.toml          Codex subprocess            PATH shim           RTK binary
+      │                           │                       │                    │
+      │ shell_environment_policy  │                       │                    │
+      │ set.PATH=<shim>:<path>    │                       │                    │
+      │ set.RTK_HOST=codex        │                       │                    │
+      │──────────────────────────►│                       │                    │
+      │                           │ exec: git status      │                    │
+      │                           │──────────────────────►│                    │
+      │                           │                       │ argv[0]=git        │
+      │                           │                       │ symlink -> rtk     │
+      │                           │                       │───────────────────►│
+      │                           │                       │                    │ shim mode
+      │                           │                       │                    │ rewrite registry
+      │                           │                       │                    │ or passthrough
+      │                           │◄───────────────────────────────────────────│
+```
+
+Core properties:
+
+1. **Subprocess-local scope**: `rtk init -g --codex` patches `~/.codex/config.toml` so only Codex-started subprocesses see the injected `PATH` and `RTK_HOST=codex`.
+2. **Single binary, multiple entrypoints**: the shim directory contains symlinks such as `git`, `rg`, `python`, and `npx` that all point back to the `rtk` binary. `main.rs` detects `argv[0] != "rtk"` and enters shim mode.
+3. **Single source of truth**: shim mode does not maintain a second rewrite table. It reuses the shared rewrite registry through argv-aware APIs.
+4. **Approval semantics preserved**: Codex still originates commands such as `git status`; the adapter only changes executable resolution through `PATH`, not the command tokens Codex reasons about.
+5. **Recursion guard**: passthrough and rewritten execution paths set `RTK_BYPASS=1` and resolve binaries from a PATH with the shim directory removed.
+
+Codex adapter lifecycle:
+
+- `rtk init -g --codex`: patch config, create shim directory, write install manifest
+- `rtk init --show --codex`: inspect config, shim state, and PATH snapshot freshness
+- `rtk init -g --codex --refresh-path`: refresh the stored PATH snapshot
+- `rtk init -g --codex --uninstall`: remove RTK-managed config entries and shims
+
+This adapter intentionally does **not** rely on AGENTS.md, Skills, or `.rules` for rewriting, and it does **not** change Codex's own model-visible UnifiedExec transcript formatting.
+
 ---
 
 ## Command Lifecycle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to rtk (Rust Token Killer) will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Features
+
+* add experimental Codex adapter via `rtk init -g --codex`, subprocess-local PATH shims, and argv0 dispatch
+
 ## [0.29.0](https://github.com/rtk-ai/rtk/compare/v0.28.2...v0.29.0) (2026-03-12)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * add experimental Codex adapter via `rtk init -g --codex`, subprocess-local PATH shims, and argv0 dispatch
 
+### Bug Fixes
+
+* resolve Codex shim symlinks before re-exec so rewritten commands like `git status` route back through `rtk`
+
 ## [0.29.0](https://github.com/rtk-ai/rtk/compare/v0.28.2...v0.29.0) (2026-03-12)
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,6 +912,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml",
+ "toml_edit",
  "ureq",
  "walkdir",
  "which",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ hostname = "0.4"
 flate2 = "1.0"
 quick-xml = "0.37"
 which = "8"
+toml_edit = "0.22"
 
 [build-dependencies]
 toml = "0.8"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -105,6 +105,7 @@ rtk init -g --no-patch      # Print manual instructions instead
 
 # Verify installation
 rtk init --show  # Check hook is installed and executable
+rtk init --show --codex  # Check Codex adapter status
 ```
 
 **Token savings**: ~99.5% reduction (2000 tokens → 10 tokens in context)
@@ -253,6 +254,28 @@ rtk init -g --uninstall
 #   - Registration: RTK hook entry from settings.json
 
 # Restart Claude Code after uninstall
+
+## Codex Adapter (Experimental)
+
+```bash
+rtk init -g --codex
+
+# What gets created:
+#   - Codex config patch: ~/.codex/config.toml
+#   - RTK shim dir:       platform-specific RTK state dir / codex-shims
+#   - RTK manifest:       platform-specific RTK state dir / codex-adapter.json
+
+# Verify installation
+rtk init --show --codex
+
+# Refresh the PATH snapshot after local PATH changes
+rtk init -g --codex --refresh-path
+
+# Remove the adapter
+rtk init -g --codex --uninstall
+```
+
+The Codex adapter works by injecting `RTK_HOST=codex` and a shim-prefixed `PATH` through Codex's `shell_environment_policy.set`. It only affects subprocesses started by Codex.
 ```
 
 **For Local Projects**: Manually remove RTK block from `./CLAUDE.md`

--- a/README.md
+++ b/README.md
@@ -280,9 +280,11 @@ The most effective way to use rtk. The hook transparently intercepts Bash comman
 ```bash
 rtk init -g                 # Install hook + RTK.md (recommended)
 rtk init -g --opencode      # OpenCode plugin (instead of Claude Code)
+rtk init -g --codex         # Codex adapter via PATH shims (experimental)
 rtk init -g --auto-patch    # Non-interactive (CI/CD)
 rtk init -g --hook-only     # Hook only, no RTK.md
 rtk init --show             # Verify installation
+rtk init --show --codex     # Verify Codex adapter status
 ```
 
 After install, **restart Claude Code**.
@@ -302,6 +304,32 @@ rtk init -g --opencode
 - `~/.config/opencode/plugins/rtk.ts`
 
 **Restart Required**: Restart OpenCode, then test with `git status` in a session.
+
+## Codex Adapter (Experimental)
+
+Codex does not currently expose the same documented pre-exec hook surface that RTK uses for Claude Code and OpenCode. RTK's Codex support is therefore an adapter, not a host-native integration.
+
+**How it works:**
+- patches `~/.codex/config.toml`
+- injects `RTK_HOST=codex` and a Codex-only shim `PATH`
+- installs symlink entrypoints that point back to the `rtk` binary
+- uses RTK's shared rewrite registry in `argv[0]` shim mode
+
+**Install:**
+```bash
+rtk init -g --codex
+rtk init --show --codex
+```
+
+**Refresh after PATH changes:**
+```bash
+rtk init -g --codex --refresh-path
+```
+
+**Notes:**
+- This adapter applies only to Codex-started subprocesses.
+- It does not use AGENTS.md, Skills, or `.rules` for command rewriting.
+- It does not change Codex's own UnifiedExec transcript formatting.
 
 **Manual install (fallback):**
 ```bash
@@ -369,6 +397,7 @@ FAILED: 2/15 tests
 
 ```bash
 rtk init -g --uninstall     # Remove hook, RTK.md, settings.json entry
+rtk init -g --codex --uninstall  # Remove Codex adapter
 cargo uninstall rtk          # Remove binary
 brew uninstall rtk           # If installed via Homebrew
 ```

--- a/src/codex.rs
+++ b/src/codex.rs
@@ -20,7 +20,7 @@ pub fn maybe_run_as_codex_shim(argv0: &OsStr, args: &[OsString]) -> Result<Optio
     if env::var(RTK_HOST_ENV).ok().as_deref() != Some(RTK_HOST_CODEX)
         || env::var(RTK_BYPASS_ENV).ok().as_deref() == Some("1")
         || env::var(RTK_DISABLED_ENV).ok().as_deref() == Some("1")
-        || !registry::entrypoints().contains(invoked_as.as_str())
+        || !registry::codex_entrypoints().contains(invoked_as.as_str())
     {
         return Ok(Some(exec_real_binary(&invoked_as, args)?));
     }
@@ -29,7 +29,7 @@ pub fn maybe_run_as_codex_shim(argv0: &OsStr, args: &[OsString]) -> Result<Optio
         .map(|c| c.hooks.exclude_commands)
         .unwrap_or_default();
 
-    if let Some(rewritten) = registry::rewrite_argv(&invoked_as, args, &excluded) {
+    if let Some(rewritten) = registry::rewrite_codex_argv(&invoked_as, args, &excluded) {
         return Ok(Some(exec_rewritten(&rewritten)?));
     }
 
@@ -121,18 +121,24 @@ mod tests {
     use std::fs;
 
     #[test]
-    fn test_entrypoints_cover_wrapper_binaries() {
-        let entrypoints = registry::entrypoints();
+    fn test_codex_entrypoints_cover_safe_wrapper_binaries() {
+        let entrypoints = registry::codex_entrypoints();
         assert!(entrypoints.contains("python"));
         assert!(entrypoints.contains("python3"));
         assert!(entrypoints.contains("npx"));
         assert!(entrypoints.contains("uv"));
+        assert!(entrypoints.contains("eslint"));
+        assert!(entrypoints.contains("gh"));
+        assert!(!entrypoints.contains("cat"));
+        assert!(!entrypoints.contains("find"));
+        assert!(!entrypoints.contains("rg"));
+        assert!(!entrypoints.contains("pip"));
     }
 
     #[test]
-    fn test_rewrite_git_status_argv() {
+    fn test_rewrite_git_status_argv_in_codex_mode() {
         let args = vec![OsString::from("status")];
-        let rewritten = registry::rewrite_argv("git", &args, &[]).unwrap();
+        let rewritten = registry::rewrite_codex_argv("git", &args, &[]).unwrap();
         let actual: Vec<String> = rewritten
             .into_iter()
             .map(|arg| arg.to_string_lossy().into_owned())
@@ -141,14 +147,14 @@ mod tests {
     }
 
     #[test]
-    fn test_rewrite_python_m_pytest_argv() {
+    fn test_rewrite_python_m_pytest_argv_in_codex_mode() {
         let args = vec![
             OsString::from("-m"),
             OsString::from("pytest"),
             OsString::from("-x"),
             OsString::from("tests/"),
         ];
-        let rewritten = registry::rewrite_argv("python", &args, &[]).unwrap();
+        let rewritten = registry::rewrite_codex_argv("python", &args, &[]).unwrap();
         let actual: Vec<String> = rewritten
             .into_iter()
             .map(|arg| arg.to_string_lossy().into_owned())
@@ -157,14 +163,14 @@ mod tests {
     }
 
     #[test]
-    fn test_rewrite_gh_json_argv_skipped() {
+    fn test_rewrite_gh_json_argv_skipped_in_codex_mode() {
         let args = vec![
             OsString::from("pr"),
             OsString::from("list"),
             OsString::from("--json"),
             OsString::from("number"),
         ];
-        assert!(registry::rewrite_argv("gh", &args, &[]).is_none());
+        assert!(registry::rewrite_codex_argv("gh", &args, &[]).is_none());
     }
 
     #[cfg(unix)]

--- a/src/codex.rs
+++ b/src/codex.rs
@@ -37,14 +37,14 @@ pub fn maybe_run_as_codex_shim(argv0: &OsStr, args: &[OsString]) -> Result<Optio
 }
 
 fn exec_rewritten(argv: &[OsString]) -> Result<i32> {
-    let current_exe = env::current_exe().context("Failed to resolve current rtk binary")?;
+    let current_exe = resolve_current_rtk_binary()?;
     let mut command = Command::new(&current_exe);
     command.args(argv.iter().skip(1)).env(RTK_BYPASS_ENV, "1");
     run_command(command)
 }
 
 fn exec_real_binary(invoked_as: &str, args: &[OsString]) -> Result<i32> {
-    let current_exe = env::current_exe().context("Failed to resolve current rtk binary")?;
+    let current_exe = resolve_current_rtk_binary()?;
     let clean_path = clean_path_without_shims(invoked_as, &current_exe)?;
     let cwd = env::current_dir().context("Failed to resolve current working directory")?;
     let resolved = which::which_in(invoked_as, Some(&clean_path), cwd)
@@ -61,6 +61,15 @@ fn exec_real_binary(invoked_as: &str, args: &[OsString]) -> Result<i32> {
 fn run_command(mut command: Command) -> Result<i32> {
     let status = command.status().context("Failed to spawn child process")?;
     Ok(exit_status_code(status))
+}
+
+fn resolve_current_rtk_binary() -> Result<PathBuf> {
+    let current_exe = env::current_exe().context("Failed to resolve current rtk binary")?;
+    Ok(canonical_binary_path(&current_exe))
+}
+
+fn canonical_binary_path(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
 }
 
 fn clean_path_without_shims(invoked_as: &str, current_exe: &Path) -> Result<OsString> {
@@ -178,6 +187,19 @@ mod tests {
 
         assert!(!parts.contains(&shim_dir));
         assert!(parts.contains(&PathBuf::from("/usr/bin")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_canonical_binary_path_resolves_symlink_target() {
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("rtk");
+        let shim = temp.path().join("git");
+
+        fs::write(&target, "rtk").unwrap();
+        std::os::unix::fs::symlink(&target, &shim).unwrap();
+
+        assert_eq!(canonical_binary_path(&shim), target.canonicalize().unwrap());
     }
 
     mod temp_env {

--- a/src/codex.rs
+++ b/src/codex.rs
@@ -1,0 +1,209 @@
+use anyhow::{Context, Result};
+use std::env;
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::discover::registry;
+
+const RTK_HOST_ENV: &str = "RTK_HOST";
+const RTK_HOST_CODEX: &str = "codex";
+const RTK_BYPASS_ENV: &str = "RTK_BYPASS";
+const RTK_DISABLED_ENV: &str = "RTK_DISABLED";
+
+pub fn maybe_run_as_codex_shim(argv0: &OsStr, args: &[OsString]) -> Result<Option<i32>> {
+    let invoked_as = basename(argv0);
+    if invoked_as == "rtk" {
+        return Ok(None);
+    }
+
+    if env::var(RTK_HOST_ENV).ok().as_deref() != Some(RTK_HOST_CODEX)
+        || env::var(RTK_BYPASS_ENV).ok().as_deref() == Some("1")
+        || env::var(RTK_DISABLED_ENV).ok().as_deref() == Some("1")
+        || !registry::entrypoints().contains(invoked_as.as_str())
+    {
+        return Ok(Some(exec_real_binary(&invoked_as, args)?));
+    }
+
+    let excluded = crate::config::Config::load()
+        .map(|c| c.hooks.exclude_commands)
+        .unwrap_or_default();
+
+    if let Some(rewritten) = registry::rewrite_argv(&invoked_as, args, &excluded) {
+        return Ok(Some(exec_rewritten(&rewritten)?));
+    }
+
+    Ok(Some(exec_real_binary(&invoked_as, args)?))
+}
+
+fn exec_rewritten(argv: &[OsString]) -> Result<i32> {
+    let current_exe = env::current_exe().context("Failed to resolve current rtk binary")?;
+    let mut command = Command::new(&current_exe);
+    command.args(argv.iter().skip(1)).env(RTK_BYPASS_ENV, "1");
+    run_command(command)
+}
+
+fn exec_real_binary(invoked_as: &str, args: &[OsString]) -> Result<i32> {
+    let current_exe = env::current_exe().context("Failed to resolve current rtk binary")?;
+    let clean_path = clean_path_without_shims(invoked_as, &current_exe)?;
+    let cwd = env::current_dir().context("Failed to resolve current working directory")?;
+    let resolved = which::which_in(invoked_as, Some(&clean_path), cwd)
+        .with_context(|| format!("Failed to resolve real binary for {invoked_as}"))?;
+
+    let mut command = Command::new(resolved);
+    command
+        .args(args)
+        .env("PATH", &clean_path)
+        .env(RTK_BYPASS_ENV, "1");
+    run_command(command)
+}
+
+fn run_command(mut command: Command) -> Result<i32> {
+    let status = command.status().context("Failed to spawn child process")?;
+    Ok(exit_status_code(status))
+}
+
+fn clean_path_without_shims(invoked_as: &str, current_exe: &Path) -> Result<OsString> {
+    let original = env::var_os("PATH").unwrap_or_default();
+    let filtered: Vec<PathBuf> = env::split_paths(&original)
+        .filter(|entry| !is_shim_dir(entry, invoked_as, current_exe))
+        .collect();
+    env::join_paths(filtered).context("Failed to rebuild PATH without Codex shim entries")
+}
+
+fn is_shim_dir(dir: &Path, invoked_as: &str, current_exe: &Path) -> bool {
+    let candidate = dir.join(invoked_as);
+    if !candidate.exists() {
+        return false;
+    }
+
+    match (candidate.canonicalize(), current_exe.canonicalize()) {
+        (Ok(candidate), Ok(current_exe)) => candidate == current_exe,
+        _ => false,
+    }
+}
+
+fn basename(path: &OsStr) -> String {
+    Path::new(path)
+        .file_name()
+        .unwrap_or(path)
+        .to_string_lossy()
+        .into_owned()
+}
+
+#[cfg(unix)]
+fn exit_status_code(status: std::process::ExitStatus) -> i32 {
+    use std::os::unix::process::ExitStatusExt;
+
+    status
+        .code()
+        .or_else(|| status.signal().map(|signal| 128 + signal))
+        .unwrap_or(1)
+}
+
+#[cfg(not(unix))]
+fn exit_status_code(status: std::process::ExitStatus) -> i32 {
+    status.code().unwrap_or(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_entrypoints_cover_wrapper_binaries() {
+        let entrypoints = registry::entrypoints();
+        assert!(entrypoints.contains("python"));
+        assert!(entrypoints.contains("python3"));
+        assert!(entrypoints.contains("npx"));
+        assert!(entrypoints.contains("uv"));
+    }
+
+    #[test]
+    fn test_rewrite_git_status_argv() {
+        let args = vec![OsString::from("status")];
+        let rewritten = registry::rewrite_argv("git", &args, &[]).unwrap();
+        let actual: Vec<String> = rewritten
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(actual, vec!["rtk", "git", "status"]);
+    }
+
+    #[test]
+    fn test_rewrite_python_m_pytest_argv() {
+        let args = vec![
+            OsString::from("-m"),
+            OsString::from("pytest"),
+            OsString::from("-x"),
+            OsString::from("tests/"),
+        ];
+        let rewritten = registry::rewrite_argv("python", &args, &[]).unwrap();
+        let actual: Vec<String> = rewritten
+            .into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(actual, vec!["rtk", "pytest", "-x", "tests/"]);
+    }
+
+    #[test]
+    fn test_rewrite_gh_json_argv_skipped() {
+        let args = vec![
+            OsString::from("pr"),
+            OsString::from("list"),
+            OsString::from("--json"),
+            OsString::from("number"),
+        ];
+        assert!(registry::rewrite_argv("gh", &args, &[]).is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_clean_path_without_shims_removes_matching_entry() {
+        let temp = tempfile::tempdir().unwrap();
+        let shim_dir = temp.path().join("shims");
+        fs::create_dir_all(&shim_dir).unwrap();
+
+        let current_exe = env::current_exe().unwrap();
+        std::os::unix::fs::symlink(&current_exe, shim_dir.join("git")).unwrap();
+
+        let original_path =
+            env::join_paths([shim_dir.as_path(), Path::new("/usr/bin"), Path::new("/bin")])
+                .unwrap();
+
+        let _guard = temp_env::with_var("PATH", Some(original_path));
+        let cleaned = clean_path_without_shims("git", &current_exe).unwrap();
+        let parts: Vec<PathBuf> = env::split_paths(&cleaned).collect();
+
+        assert!(!parts.contains(&shim_dir));
+        assert!(parts.contains(&PathBuf::from("/usr/bin")));
+    }
+
+    mod temp_env {
+        use std::ffi::OsString;
+
+        pub struct Guard {
+            key: &'static str,
+            prev: Option<OsString>,
+        }
+
+        impl Drop for Guard {
+            fn drop(&mut self) {
+                match &self.prev {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+
+        pub fn with_var(key: &'static str, value: Option<OsString>) -> Guard {
+            let prev = std::env::var_os(key);
+            match value {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+            Guard { key, prev }
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -124,9 +124,7 @@ impl Default for LimitsConfig {
 
 /// Get limits config. Falls back to defaults if config can't be loaded.
 pub fn limits() -> LimitsConfig {
-    Config::load()
-        .map(|c| c.limits)
-        .unwrap_or_default()
+    Config::load().map(|c| c.limits).unwrap_or_default()
 }
 
 /// Check if telemetry is enabled in config. Returns None if config can't be loaded.

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,8 @@ pub struct Config {
     pub telemetry: TelemetryConfig,
     #[serde(default)]
     pub hooks: HooksConfig,
+    #[serde(default)]
+    pub limits: LimitsConfig,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -92,6 +94,39 @@ impl Default for TelemetryConfig {
     fn default() -> Self {
         Self { enabled: true }
     }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LimitsConfig {
+    /// Max total grep results to show (default: 200)
+    pub grep_max_results: usize,
+    /// Max matches per file in grep output (default: 25)
+    pub grep_max_per_file: usize,
+    /// Max staged/modified files shown in git status (default: 15)
+    pub status_max_files: usize,
+    /// Max untracked files shown in git status (default: 10)
+    pub status_max_untracked: usize,
+    /// Max chars for parser passthrough fallback (default: 2000)
+    pub passthrough_max_chars: usize,
+}
+
+impl Default for LimitsConfig {
+    fn default() -> Self {
+        Self {
+            grep_max_results: 200,
+            grep_max_per_file: 25,
+            status_max_files: 15,
+            status_max_untracked: 10,
+            passthrough_max_chars: 2000,
+        }
+    }
+}
+
+/// Get limits config. Falls back to defaults if config can't be loaded.
+pub fn limits() -> LimitsConfig {
+    Config::load()
+        .map(|c| c.limits)
+        .unwrap_or_default()
 }
 
 /// Check if telemetry is enabled in config. Returns None if config can't be loaded.

--- a/src/container.rs
+++ b/src/container.rs
@@ -183,6 +183,19 @@ fn docker_logs(args: &[String], _verbose: u8) -> Result<()> {
     let stderr = String::from_utf8_lossy(&output.stderr);
     let raw = format!("{}\n{}", stdout, stderr);
 
+    if !output.status.success() {
+        if !stderr.trim().is_empty() {
+            eprint!("{}", stderr);
+        }
+        timer.track(
+            &format!("docker logs {}", container),
+            "rtk docker logs",
+            &raw,
+            &raw,
+        );
+        std::process::exit(output.status.code().unwrap_or(1));
+    }
+
     let analyzed = crate::log_cmd::run_stdin_str(&raw);
     let rtk = format!("🐳 Logs for {}:\n{}", container, analyzed);
     println!("{}", rtk);
@@ -207,6 +220,15 @@ fn kubectl_pods(args: &[String], _verbose: u8) -> Result<()> {
     let output = cmd.output().context("Failed to run kubectl get pods")?;
     let raw = String::from_utf8_lossy(&output.stdout).to_string();
     let mut rtk = String::new();
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.trim().is_empty() {
+            eprint!("{}", stderr);
+        }
+        timer.track("kubectl get pods", "rtk kubectl pods", &raw, &raw);
+        std::process::exit(output.status.code().unwrap_or(1));
+    }
 
     let json: serde_json::Value = match serde_json::from_str(&raw) {
         Ok(v) => v,
@@ -306,6 +328,15 @@ fn kubectl_services(args: &[String], _verbose: u8) -> Result<()> {
     let raw = String::from_utf8_lossy(&output.stdout).to_string();
     let mut rtk = String::new();
 
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.trim().is_empty() {
+            eprint!("{}", stderr);
+        }
+        timer.track("kubectl get svc", "rtk kubectl svc", &raw, &raw);
+        std::process::exit(output.status.code().unwrap_or(1));
+    }
+
     let json: serde_json::Value = match serde_json::from_str(&raw) {
         Ok(v) => v,
         Err(_) => {
@@ -381,6 +412,21 @@ fn kubectl_logs(args: &[String], _verbose: u8) -> Result<()> {
 
     let output = cmd.output().context("Failed to run kubectl logs")?;
     let raw = String::from_utf8_lossy(&output.stdout).to_string();
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.trim().is_empty() {
+            eprint!("{}", stderr);
+        }
+        timer.track(
+            &format!("kubectl logs {}", pod),
+            "rtk kubectl logs",
+            &raw,
+            &raw,
+        );
+        std::process::exit(output.status.code().unwrap_or(1));
+    }
+
     let analyzed = crate::log_cmd::run_stdin_str(&raw);
     let rtk = format!("☸️  Logs for {}:\n{}", pod, analyzed);
     println!("{}", rtk);

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -52,6 +52,21 @@ lazy_static! {
         Regex::new(r"^(?:sudo\s+|env\s+|[A-Z_][A-Z0-9_]*=[^\s]*\s+)+").unwrap();
 }
 
+const CODEX_NEVER_SHIM: &[&str] = &[
+    "cat", "head", "tail", "ls", "find", "rg", "grep", "pip", "pip3",
+];
+const CODEX_GLOBAL_PASSTHROUGH_FLAGS: &[&str] = &["--help", "-h", "--version", "-V"];
+const CODEX_STRUCTURED_OUTPUT_FLAGS: &[&str] = &[
+    "--json",
+    "--jq",
+    "--template",
+    "--output-format",
+    "--format",
+    "--reporter",
+    "--out-format",
+];
+const CODEX_GH_STRUCTURED_OUTPUT_FLAGS: &[&str] = &["--json", "--jq", "--template"];
+
 /// Classify a single (already-split) command.
 pub fn classify_command(cmd: &str) -> Classification {
     let trimmed = cmd.trim();
@@ -325,24 +340,57 @@ pub fn entrypoints() -> BTreeSet<String> {
         .collect()
 }
 
+pub fn codex_entrypoints() -> BTreeSet<String> {
+    entrypoints()
+        .into_iter()
+        .filter(|entrypoint| !is_codex_passthrough_only_entrypoint(entrypoint))
+        .collect()
+}
+
 pub fn rewrite_argv(
     invoked_as: &str,
     args: &[OsString],
     excluded: &[String],
 ) -> Option<Vec<OsString>> {
+    let command = build_argv_command(invoked_as, args);
+    rewrite_argv_from_command(&command, excluded)
+}
+
+pub fn rewrite_codex_argv(
+    invoked_as: &str,
+    args: &[OsString],
+    excluded: &[String],
+) -> Option<Vec<OsString>> {
+    if is_codex_passthrough_only_entrypoint(invoked_as) {
+        return None;
+    }
+
+    let command = build_argv_command(invoked_as, args);
+    if should_passthrough_codex_argv(invoked_as, &command[1..]) {
+        return None;
+    }
+
+    rewrite_argv(invoked_as, args, excluded)
+}
+
+fn build_argv_command(invoked_as: &str, args: &[OsString]) -> Vec<String> {
+    let mut command: Vec<String> = Vec::with_capacity(args.len() + 1);
+    command.push(invoked_as.to_string());
+    command.extend(args.iter().map(|arg| arg.to_string_lossy().into_owned()));
+    command
+}
+
+fn rewrite_argv_from_command(command: &[String], excluded: &[String]) -> Option<Vec<OsString>> {
+    let invoked_as = command.first()?.as_str();
     if excluded.iter().any(|entry| entry == invoked_as) {
         return None;
     }
 
-    let mut command: Vec<String> = Vec::with_capacity(args.len() + 1);
-    command.push(invoked_as.to_string());
-    command.extend(args.iter().map(|arg| arg.to_string_lossy().into_owned()));
-
     if invoked_as == "head" {
-        return rewrite_head_argv(&command);
+        return rewrite_head_argv(command);
     }
     if invoked_as == "tail" {
-        return rewrite_tail_argv(&command);
+        return rewrite_tail_argv(command);
     }
 
     for rule in RULES {
@@ -374,6 +422,43 @@ pub fn rewrite_argv(
     }
 
     None
+}
+
+fn is_codex_passthrough_only_entrypoint(invoked_as: &str) -> bool {
+    CODEX_NEVER_SHIM.contains(&invoked_as)
+}
+
+fn should_passthrough_codex_argv(invoked_as: &str, args: &[String]) -> bool {
+    match invoked_as {
+        "uv" => {
+            is_uv_pip_invocation(args)
+                || has_any_contract_sensitive_flag(args, CODEX_GLOBAL_PASSTHROUGH_FLAGS)
+        }
+        "eslint" | "biome" | "lint" | "golangci-lint" | "golangci" => {
+            has_any_contract_sensitive_flag(args, CODEX_GLOBAL_PASSTHROUGH_FLAGS)
+                || has_any_contract_sensitive_flag(args, CODEX_STRUCTURED_OUTPUT_FLAGS)
+        }
+        "gh" => has_any_contract_sensitive_flag(args, CODEX_GH_STRUCTURED_OUTPUT_FLAGS),
+        _ => false,
+    }
+}
+
+fn is_uv_pip_invocation(args: &[String]) -> bool {
+    args.first().is_some_and(|arg| arg == "pip")
+}
+
+fn has_any_contract_sensitive_flag(args: &[String], flags: &[&str]) -> bool {
+    args.iter()
+        .any(|arg| flags.iter().any(|flag| arg_matches_flag(arg, flag)))
+}
+
+fn arg_matches_flag(arg: &str, flag: &str) -> bool {
+    arg == flag
+        || (arg.starts_with(flag)
+            && arg
+                .as_bytes()
+                .get(flag.len())
+                .is_some_and(|next| *next == b'='))
 }
 
 /// Rewrite a compound command (with `&&`, `||`, `;`, `|`) by rewriting each segment.
@@ -739,6 +824,16 @@ fn strip_word_prefix<'a>(cmd: &'a str, prefix: &str) -> Option<&'a str> {
 mod tests {
     use super::super::report::RtkStatus;
     use super::*;
+
+    fn os_args(args: &[&str]) -> Vec<OsString> {
+        args.iter().map(OsString::from).collect()
+    }
+
+    fn into_strings(argv: Vec<OsString>) -> Vec<String> {
+        argv.into_iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
+    }
 
     #[test]
     fn test_classify_git_status() {
@@ -2198,5 +2293,84 @@ mod tests {
             "cargo test"
         );
         assert_eq!(strip_disabled_prefix("git status"), "git status");
+    }
+
+    #[test]
+    fn test_codex_entrypoints_exclude_passthrough_only_wrappers() {
+        let entrypoints = codex_entrypoints();
+
+        for denied in [
+            "cat", "head", "tail", "ls", "find", "rg", "grep", "pip", "pip3",
+        ] {
+            assert!(
+                !entrypoints.contains(denied),
+                "{denied} should not be installed as a Codex shim"
+            );
+        }
+    }
+
+    #[test]
+    fn test_codex_entrypoints_include_conditionally_safe_wrappers() {
+        let entrypoints = codex_entrypoints();
+
+        for allowed in ["uv", "eslint", "biome", "lint", "golangci-lint", "gh"] {
+            assert!(
+                entrypoints.contains(allowed),
+                "{allowed} should remain installable as a Codex shim"
+            );
+        }
+    }
+
+    #[test]
+    fn test_rewrite_codex_argv_passthrough_cases() {
+        let cases = [
+            ("uv", vec!["pip", "--version"]),
+            ("uv", vec!["pip", "list", "--format=json"]),
+            ("eslint", vec!["--version"]),
+            ("golangci-lint", vec!["--version"]),
+            ("gh", vec!["pr", "list", "--json", "number"]),
+            ("rg", vec!["--files", "src"]),
+            ("find", vec!["src", "-maxdepth", "1", "-type", "f"]),
+            ("cat", vec!["README.md"]),
+            ("pip", vec!["--version"]),
+        ];
+
+        for (invoked_as, args) in cases {
+            assert!(
+                rewrite_codex_argv(invoked_as, &os_args(&args), &[]).is_none(),
+                "{invoked_as} {args:?} should passthrough in Codex mode"
+            );
+        }
+    }
+
+    #[test]
+    fn test_rewrite_codex_argv_rewrite_cases() {
+        let rewritten = rewrite_codex_argv("git", &os_args(&["status"]), &[]).unwrap();
+        assert_eq!(into_strings(rewritten), vec!["rtk", "git", "status"]);
+
+        let rewritten =
+            rewrite_codex_argv("python", &os_args(&["-m", "pytest", "-x"]), &[]).unwrap();
+        assert_eq!(into_strings(rewritten), vec!["rtk", "pytest", "-x"]);
+
+        let rewritten = rewrite_codex_argv("uv", &os_args(&["sync"]), &[]).unwrap();
+        assert_eq!(into_strings(rewritten), vec!["rtk", "uv", "sync"]);
+
+        let rewritten = rewrite_codex_argv("eslint", &os_args(&["src"]), &[]).unwrap();
+        assert_eq!(into_strings(rewritten), vec!["rtk", "lint", "src"]);
+    }
+
+    #[test]
+    fn test_rewrite_codex_argv_passthrough_on_structured_lint_flags() {
+        for args in [
+            vec!["src", "--format=json"],
+            vec!["src", "--reporter", "json"],
+            vec!["src", "--output-format=json"],
+            vec!["src", "--out-format=json"],
+        ] {
+            assert!(
+                rewrite_codex_argv("eslint", &os_args(&args), &[]).is_none(),
+                "eslint {args:?} should passthrough in Codex mode"
+            );
+        }
     }
 }

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1,5 +1,7 @@
 use lazy_static::lazy_static;
 use regex::{Regex, RegexSet};
+use std::collections::BTreeSet;
+use std::ffi::OsString;
 
 use super::rules::{IGNORED_EXACT, IGNORED_PREFIXES, PATTERNS, RULES};
 
@@ -314,6 +316,66 @@ pub fn rewrite_command(cmd: &str, excluded: &[String]) -> Option<String> {
     rewrite_compound(trimmed, excluded)
 }
 
+pub fn entrypoints() -> BTreeSet<String> {
+    RULES
+        .iter()
+        .flat_map(|rule| rule.rewrite_prefixes.iter())
+        .filter_map(|prefix| prefix.split_whitespace().next())
+        .map(str::to_string)
+        .collect()
+}
+
+pub fn rewrite_argv(
+    invoked_as: &str,
+    args: &[OsString],
+    excluded: &[String],
+) -> Option<Vec<OsString>> {
+    if excluded.iter().any(|entry| entry == invoked_as) {
+        return None;
+    }
+
+    let mut command: Vec<String> = Vec::with_capacity(args.len() + 1);
+    command.push(invoked_as.to_string());
+    command.extend(args.iter().map(|arg| arg.to_string_lossy().into_owned()));
+
+    if invoked_as == "head" {
+        return rewrite_head_argv(&command);
+    }
+    if invoked_as == "tail" {
+        return rewrite_tail_argv(&command);
+    }
+
+    for rule in RULES {
+        if rule.rtk_cmd == "rtk gh"
+            && command.iter().skip(1).any(|arg| {
+                arg == "--json"
+                    || arg == "--jq"
+                    || arg == "--template"
+                    || arg.starts_with("--json=")
+                    || arg.starts_with("--jq=")
+                    || arg.starts_with("--template=")
+            })
+        {
+            return None;
+        }
+
+        for &prefix in rule.rewrite_prefixes {
+            let prefix_tokens: Vec<&str> = prefix.split_whitespace().collect();
+            if matches_prefix(&command, &prefix_tokens) {
+                let mut rewritten: Vec<OsString> = rule
+                    .rtk_cmd
+                    .split_whitespace()
+                    .map(OsString::from)
+                    .collect();
+                rewritten.extend(command[prefix_tokens.len()..].iter().map(OsString::from));
+                return Some(rewritten);
+            }
+        }
+    }
+
+    None
+}
+
 /// Rewrite a compound command (with `&&`, `||`, `;`, `|`) by rewriting each segment.
 fn rewrite_compound(cmd: &str, excluded: &[String]) -> Option<String> {
     let bytes = cmd.as_bytes();
@@ -498,6 +560,82 @@ fn rewrite_tail_lines(cmd: &str) -> Option<String> {
 
     // Unknown tail form: skip rewrite to preserve native behavior.
     None
+}
+
+fn rewrite_head_argv(command: &[String]) -> Option<Vec<OsString>> {
+    if command.len() < 3 {
+        return None;
+    }
+
+    let parsed = if let Some(stripped) = command[1].strip_prefix('-') {
+        if stripped.chars().all(|ch| ch.is_ascii_digit()) && command.len() == 3 {
+            Some((stripped, command[2].as_str()))
+        } else {
+            None
+        }
+    } else if let Some(stripped) = command[1].strip_prefix("--lines=") {
+        if stripped.chars().all(|ch| ch.is_ascii_digit()) && command.len() == 3 {
+            Some((stripped, command[2].as_str()))
+        } else {
+            None
+        }
+    } else {
+        None
+    }?;
+
+    Some(vec![
+        OsString::from("rtk"),
+        OsString::from("read"),
+        OsString::from(parsed.1),
+        OsString::from("--max-lines"),
+        OsString::from(parsed.0),
+    ])
+}
+
+fn rewrite_tail_argv(command: &[String]) -> Option<Vec<OsString>> {
+    if command.len() < 3 {
+        return None;
+    }
+
+    let parsed = if let Some(stripped) = command[1].strip_prefix('-') {
+        if stripped.chars().all(|ch| ch.is_ascii_digit()) && command.len() == 3 {
+            Some((stripped, command[2].as_str()))
+        } else {
+            None
+        }
+    } else if command[1] == "-n" && command.len() == 4 {
+        Some((command[2].as_str(), command[3].as_str()))
+    } else if let Some(stripped) = command[1].strip_prefix("--lines=") {
+        if command.len() == 3 {
+            Some((stripped, command[2].as_str()))
+        } else {
+            None
+        }
+    } else if command[1] == "--lines" && command.len() == 4 {
+        Some((command[2].as_str(), command[3].as_str()))
+    } else {
+        None
+    }?;
+
+    if !parsed.0.chars().all(|ch| ch.is_ascii_digit()) {
+        return None;
+    }
+
+    Some(vec![
+        OsString::from("rtk"),
+        OsString::from("read"),
+        OsString::from(parsed.1),
+        OsString::from("--tail-lines"),
+        OsString::from(parsed.0),
+    ])
+}
+
+fn matches_prefix(command: &[String], prefix_tokens: &[&str]) -> bool {
+    command.len() >= prefix_tokens.len()
+        && command
+            .iter()
+            .zip(prefix_tokens.iter())
+            .all(|(left, right)| left == right)
 }
 
 /// Rewrite a single (non-compound) command segment.

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,3 +1,4 @@
+use crate::config;
 use crate::tracking;
 use crate::utils::resolved_command;
 use anyhow::{Context, Result};
@@ -592,33 +593,37 @@ fn format_status_output(porcelain: &str) -> String {
     }
 
     // Build summary
+    let limits = config::limits();
+    let max_files = limits.status_max_files;
+    let max_untracked = limits.status_max_untracked;
+
     if staged > 0 {
         output.push_str(&format!("✅ Staged: {} files\n", staged));
-        for f in staged_files.iter().take(5) {
+        for f in staged_files.iter().take(max_files) {
             output.push_str(&format!("   {}\n", f));
         }
-        if staged_files.len() > 5 {
-            output.push_str(&format!("   ... +{} more\n", staged_files.len() - 5));
+        if staged_files.len() > max_files {
+            output.push_str(&format!("   ... +{} more\n", staged_files.len() - max_files));
         }
     }
 
     if modified > 0 {
         output.push_str(&format!("📝 Modified: {} files\n", modified));
-        for f in modified_files.iter().take(5) {
+        for f in modified_files.iter().take(max_files) {
             output.push_str(&format!("   {}\n", f));
         }
-        if modified_files.len() > 5 {
-            output.push_str(&format!("   ... +{} more\n", modified_files.len() - 5));
+        if modified_files.len() > max_files {
+            output.push_str(&format!("   ... +{} more\n", modified_files.len() - max_files));
         }
     }
 
     if untracked > 0 {
         output.push_str(&format!("❓ Untracked: {} files\n", untracked));
-        for f in untracked_files.iter().take(3) {
+        for f in untracked_files.iter().take(max_untracked) {
             output.push_str(&format!("   {}\n", f));
         }
-        if untracked_files.len() > 3 {
-            output.push_str(&format!("   ... +{} more\n", untracked_files.len() - 3));
+        if untracked_files.len() > max_untracked {
+            output.push_str(&format!("   ... +{} more\n", untracked_files.len() - max_untracked));
         }
     }
 
@@ -1690,23 +1695,48 @@ A  added.rs
 
     #[test]
     fn test_format_status_output_truncation() {
-        // Test that >5 staged files show "... +N more"
-        let porcelain = r#"## main
-M  file1.rs
-M  file2.rs
-M  file3.rs
-M  file4.rs
-M  file5.rs
-M  file6.rs
-M  file7.rs
-"#;
-        let result = format_status_output(porcelain);
-        assert!(result.contains("✅ Staged: 7 files"));
+        // Test that >15 staged files show "... +N more"
+        let mut porcelain = String::from("## main\n");
+        for i in 1..=20 {
+            porcelain.push_str(&format!("M  file{}.rs\n", i));
+        }
+        let result = format_status_output(&porcelain);
+        assert!(result.contains("✅ Staged: 20 files"));
         assert!(result.contains("file1.rs"));
-        assert!(result.contains("file5.rs"));
-        assert!(result.contains("... +2 more"));
-        assert!(!result.contains("file6.rs"));
-        assert!(!result.contains("file7.rs"));
+        assert!(result.contains("file15.rs"));
+        assert!(result.contains("... +5 more"));
+        assert!(!result.contains("file16.rs"));
+        assert!(!result.contains("file20.rs"));
+    }
+
+    #[test]
+    fn test_format_status_modified_truncation() {
+        // Test that >15 modified files show "... +N more"
+        let mut porcelain = String::from("## main\n");
+        for i in 1..=20 {
+            porcelain.push_str(&format!(" M file{}.rs\n", i));
+        }
+        let result = format_status_output(&porcelain);
+        assert!(result.contains("📝 Modified: 20 files"));
+        assert!(result.contains("file1.rs"));
+        assert!(result.contains("file15.rs"));
+        assert!(result.contains("... +5 more"));
+        assert!(!result.contains("file16.rs"));
+    }
+
+    #[test]
+    fn test_format_status_untracked_truncation() {
+        // Test that >10 untracked files show "... +N more"
+        let mut porcelain = String::from("## main\n");
+        for i in 1..=15 {
+            porcelain.push_str(&format!("?? file{}.rs\n", i));
+        }
+        let result = format_status_output(&porcelain);
+        assert!(result.contains("❓ Untracked: 15 files"));
+        assert!(result.contains("file1.rs"));
+        assert!(result.contains("file10.rs"));
+        assert!(result.contains("... +5 more"));
+        assert!(!result.contains("file11.rs"));
     }
 
     #[test]

--- a/src/git.rs
+++ b/src/git.rs
@@ -603,7 +603,10 @@ fn format_status_output(porcelain: &str) -> String {
             output.push_str(&format!("   {}\n", f));
         }
         if staged_files.len() > max_files {
-            output.push_str(&format!("   ... +{} more\n", staged_files.len() - max_files));
+            output.push_str(&format!(
+                "   ... +{} more\n",
+                staged_files.len() - max_files
+            ));
         }
     }
 
@@ -613,7 +616,10 @@ fn format_status_output(porcelain: &str) -> String {
             output.push_str(&format!("   {}\n", f));
         }
         if modified_files.len() > max_files {
-            output.push_str(&format!("   ... +{} more\n", modified_files.len() - max_files));
+            output.push_str(&format!(
+                "   ... +{} more\n",
+                modified_files.len() - max_files
+            ));
         }
     }
 
@@ -623,7 +629,10 @@ fn format_status_output(porcelain: &str) -> String {
             output.push_str(&format!("   {}\n", f));
         }
         if untracked_files.len() > max_untracked {
-            output.push_str(&format!("   ... +{} more\n", untracked_files.len() - max_untracked));
+            output.push_str(&format!(
+                "   ... +{} more\n",
+                untracked_files.len() - max_untracked
+            ));
         }
     }
 

--- a/src/golangci_cmd.rs
+++ b/src/golangci_cmd.rs
@@ -1,3 +1,4 @@
+use crate::config;
 use crate::tracking;
 use crate::utils::{resolved_command, truncate};
 use anyhow::{Context, Result};
@@ -106,7 +107,7 @@ fn filter_golangci_json(output: &str) -> String {
             return format!(
                 "golangci-lint (JSON parse failed: {})\n{}",
                 e,
-                truncate(output, 500)
+                truncate(output, config::limits().passthrough_max_chars)
             );
         }
     };

--- a/src/grep_cmd.rs
+++ b/src/grep_cmd.rs
@@ -77,6 +77,13 @@ pub fn run(
     let mut by_file: HashMap<String, Vec<(usize, String)>> = HashMap::new();
     let mut total = 0;
 
+    // Compile context regex once (instead of per-line in clean_line)
+    let context_re = if context_only {
+        Regex::new(&format!("(?i).{{0,20}}{}.*", regex::escape(pattern))).ok()
+    } else {
+        None
+    };
+
     for line in stdout.lines() {
         let parts: Vec<&str> = line.splitn(3, ':').collect();
 
@@ -91,7 +98,7 @@ pub fn run(
         };
 
         total += 1;
-        let cleaned = clean_line(content, max_line_len, context_only, pattern);
+        let cleaned = clean_line(content, max_line_len, context_re.as_ref(), pattern);
         by_file.entry(file).or_default().push((line_num, cleaned));
     }
 
@@ -143,16 +150,14 @@ pub fn run(
     Ok(())
 }
 
-fn clean_line(line: &str, max_len: usize, context_only: bool, pattern: &str) -> String {
+fn clean_line(line: &str, max_len: usize, context_re: Option<&Regex>, pattern: &str) -> String {
     let trimmed = line.trim();
 
-    if context_only {
-        if let Ok(re) = Regex::new(&format!("(?i).{{0,20}}{}.*", regex::escape(pattern))) {
-            if let Some(m) = re.find(trimmed) {
-                let matched = m.as_str();
-                if matched.len() <= max_len {
-                    return matched.to_string();
-                }
+    if let Some(re) = context_re {
+        if let Some(m) = re.find(trimmed) {
+            let matched = m.as_str();
+            if matched.len() <= max_len {
+                return matched.to_string();
             }
         }
     }
@@ -216,7 +221,7 @@ mod tests {
     #[test]
     fn test_clean_line() {
         let line = "            const result = someFunction();";
-        let cleaned = clean_line(line, 50, false, "result");
+        let cleaned = clean_line(line, 50, None, "result");
         assert!(!cleaned.starts_with(' '));
         assert!(cleaned.len() <= 50);
     }
@@ -240,7 +245,7 @@ mod tests {
     fn test_clean_line_multibyte() {
         // Thai text that exceeds max_len in bytes
         let line = "  สวัสดีครับ นี่คือข้อความที่ยาวมากสำหรับทดสอบ  ";
-        let cleaned = clean_line(line, 20, false, "ครับ");
+        let cleaned = clean_line(line, 20, None, "ครับ");
         // Should not panic
         assert!(!cleaned.is_empty());
     }
@@ -248,7 +253,7 @@ mod tests {
     #[test]
     fn test_clean_line_emoji() {
         let line = "🎉🎊🎈🎁🎂🎄 some text 🎃🎆🎇✨";
-        let cleaned = clean_line(line, 15, false, "text");
+        let cleaned = clean_line(line, 15, None, "text");
         assert!(!cleaned.is_empty());
     }
 

--- a/src/grep_cmd.rs
+++ b/src/grep_cmd.rs
@@ -1,3 +1,4 @@
+use crate::config;
 use crate::tracking;
 use crate::utils::resolved_command;
 use anyhow::{Context, Result};
@@ -117,7 +118,8 @@ pub fn run(
         let file_display = compact_path(file);
         rtk_output.push_str(&format!("📄 {} ({}):\n", file_display, matches.len()));
 
-        for (line_num, content) in matches.iter().take(10) {
+        let per_file = config::limits().grep_max_per_file;
+        for (line_num, content) in matches.iter().take(per_file) {
             rtk_output.push_str(&format!("  {:>4}: {}\n", line_num, content));
             shown += 1;
             if shown >= max_results {
@@ -125,8 +127,8 @@ pub fn run(
             }
         }
 
-        if matches.len() > 10 {
-            rtk_output.push_str(&format!("  +{}\n", matches.len() - 10));
+        if matches.len() > per_file {
+            rtk_output.push_str(&format!("  +{}\n", matches.len() - per_file));
         }
         rtk_output.push('\n');
     }

--- a/src/init.rs
+++ b/src/init.rs
@@ -1582,8 +1582,21 @@ fn load_codex_manifest(path: &Path) -> Result<CodexInstallManifest> {
 fn ensure_codex_shims_installed(shim_dir: &Path, rtk_binary: &Path, verbose: u8) -> Result<()> {
     use std::os::unix::fs::symlink;
 
+    let desired_entrypoints = crate::discover::registry::codex_entrypoints();
     for entrypoint in crate::discover::registry::entrypoints() {
         let link = shim_dir.join(&entrypoint);
+
+        if !desired_entrypoints.contains(&entrypoint) {
+            if link.exists() || link.symlink_metadata().is_ok() {
+                fs::remove_file(&link)
+                    .with_context(|| format!("Failed to remove shim: {}", link.display()))?;
+                if verbose > 0 {
+                    eprintln!("Removed Codex shim: {}", link.display());
+                }
+            }
+            continue;
+        }
+
         if link.exists() || link.symlink_metadata().is_ok() {
             let target = fs::read_link(&link).ok();
             if target.as_deref() == Some(rtk_binary) {
@@ -2330,16 +2343,22 @@ More notes
         let previous_home = std::env::var_os("HOME");
         std::env::set_var("XDG_DATA_HOME", temp.path());
         std::env::set_var("HOME", temp.path());
+        let shim_dir = codex_shim_dir().unwrap();
 
         install_codex_adapter(&codex_dir, &binary, "/usr/bin:/bin", 0).unwrap();
 
         let config = fs::read_to_string(codex_dir.join("config.toml")).unwrap();
         assert!(config.contains("RTK_HOST = \"codex\""));
         assert!(config.contains("PATH = "));
+        assert!(fs::symlink_metadata(shim_dir.join("git")).is_ok());
+        assert!(fs::symlink_metadata(shim_dir.join("uv")).is_ok());
+        assert!(fs::symlink_metadata(shim_dir.join("cat")).is_err());
+        assert!(fs::symlink_metadata(shim_dir.join("find")).is_err());
 
         uninstall_codex_adapter(&codex_dir, 0).unwrap();
         let config_after = fs::read_to_string(codex_dir.join("config.toml")).unwrap();
         assert!(!config_after.contains("RTK_HOST = \"codex\""));
+        assert!(fs::symlink_metadata(shim_dir.join("git")).is_err());
 
         match previous_xdg {
             Some(value) => std::env::set_var("XDG_DATA_HOME", value),
@@ -2349,5 +2368,46 @@ More notes
             Some(value) => std::env::set_var("HOME", value),
             None => std::env::remove_var("HOME"),
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_ensure_codex_shims_installed_removes_passthrough_only_shims() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let shim_dir = temp.path().join("shims");
+        let binary = temp.path().join("rtk");
+        fs::create_dir_all(&shim_dir).unwrap();
+        fs::write(&binary, "rtk").unwrap();
+
+        symlink(&binary, shim_dir.join("cat")).unwrap();
+        ensure_codex_shims_installed(&shim_dir, &binary, 0).unwrap();
+
+        assert!(fs::symlink_metadata(shim_dir.join("git")).is_ok());
+        assert!(fs::symlink_metadata(shim_dir.join("uv")).is_ok());
+        assert!(fs::symlink_metadata(shim_dir.join("cat")).is_err());
+        assert!(fs::symlink_metadata(shim_dir.join("rg")).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_remove_codex_shims_removes_legacy_and_safe_shims() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let shim_dir = temp.path().join("shims");
+        let binary = temp.path().join("rtk");
+        fs::create_dir_all(&shim_dir).unwrap();
+        fs::write(&binary, "rtk").unwrap();
+
+        symlink(&binary, shim_dir.join("cat")).unwrap();
+        symlink(&binary, shim_dir.join("git")).unwrap();
+
+        remove_codex_shims(&shim_dir, 0).unwrap();
+
+        assert!(fs::symlink_metadata(shim_dir.join("cat")).is_err());
+        assert!(fs::symlink_metadata(shim_dir.join("git")).is_err());
+        assert!(!shim_dir.exists());
     }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,8 +1,10 @@
 use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
+use toml_edit::{value, DocumentMut, Item, Table};
 
 use crate::integrity;
 
@@ -14,6 +16,19 @@ const OPENCODE_PLUGIN: &str = include_str!("../hooks/opencode-rtk.ts");
 
 // Embedded slim RTK awareness instructions
 const RTK_SLIM: &str = include_str!("../hooks/rtk-awareness.md");
+const CODEX_HOST: &str = "codex";
+const CODEX_MANIFEST: &str = "codex-adapter.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct CodexInstallManifest {
+    config_path: String,
+    shim_dir: String,
+    injected_path: String,
+    path_snapshot: String,
+    previous_set_path: Option<String>,
+    previous_rtk_host: Option<String>,
+    env_keys: Vec<String>,
+}
 
 /// Template written by `rtk init` when no filters.toml exists yet.
 const FILTERS_TEMPLATE: &str = r#"# Project-local RTK filters — commit this file with your repo.
@@ -223,6 +238,34 @@ pub fn run(
             anyhow::bail!("at least one of install_claude or install_opencode must be true")
         }
     }
+}
+
+pub fn run_codex(global: bool, verbose: u8) -> Result<()> {
+    if !global {
+        anyhow::bail!("Codex adapter is global-only. Use: rtk init -g --codex");
+    }
+    let codex_dir = resolve_codex_dir()?;
+    let current_exe = std::env::current_exe().context("Failed to resolve current rtk binary")?;
+    let path_snapshot = std::env::var("PATH").unwrap_or_default();
+    install_codex_adapter(&codex_dir, &current_exe, &path_snapshot, verbose)
+}
+
+pub fn refresh_codex_path(global: bool, verbose: u8) -> Result<()> {
+    if !global {
+        anyhow::bail!("Codex adapter is global-only. Use: rtk init -g --codex --refresh-path");
+    }
+    let codex_dir = resolve_codex_dir()?;
+    let current_exe = std::env::current_exe().context("Failed to resolve current rtk binary")?;
+    let path_snapshot = std::env::var("PATH").unwrap_or_default();
+    refresh_codex_adapter_path(&codex_dir, &current_exe, &path_snapshot, verbose)
+}
+
+pub fn uninstall_codex(global: bool, verbose: u8) -> Result<()> {
+    if !global {
+        anyhow::bail!("Codex adapter is global-only. Use: rtk init -g --codex --uninstall");
+    }
+    let codex_dir = resolve_codex_dir()?;
+    uninstall_codex_adapter(&codex_dir, verbose)
 }
 
 /// Prepare hook directory and return paths (hook_dir, hook_path)
@@ -637,7 +680,6 @@ fn clean_double_blanks(content: &str) -> String {
         if line.trim().is_empty() {
             // Count consecutive blank lines
             let mut blank_count = 0;
-            let start = i;
             while i < lines.len() && lines[i].trim().is_empty() {
                 blank_count += 1;
                 i += 1;
@@ -1181,6 +1223,31 @@ fn resolve_claude_dir() -> Result<PathBuf> {
         .context("Cannot determine home directory. Is $HOME set?")
 }
 
+fn resolve_codex_dir() -> Result<PathBuf> {
+    if let Some(codex_home) = std::env::var_os("CODEX_HOME") {
+        return Ok(PathBuf::from(codex_home));
+    }
+    dirs::home_dir()
+        .map(|h| h.join(".codex"))
+        .context("Cannot determine home directory. Is $HOME set?")
+}
+
+fn resolve_rtk_state_dir() -> Result<PathBuf> {
+    let base = dirs::data_local_dir()
+        .or_else(dirs::config_dir)
+        .or_else(dirs::home_dir)
+        .context("Cannot determine RTK state directory")?;
+    Ok(base.join("rtk"))
+}
+
+fn codex_manifest_path() -> Result<PathBuf> {
+    Ok(resolve_rtk_state_dir()?.join(CODEX_MANIFEST))
+}
+
+fn codex_shim_dir() -> Result<PathBuf> {
+    Ok(resolve_rtk_state_dir()?.join("codex-shims"))
+}
+
 /// Resolve OpenCode config directory (~/.config/opencode)
 /// OpenCode uses ~/.config/opencode on all platforms (XDG convention),
 /// NOT the macOS-native ~/Library/Application Support/.
@@ -1231,6 +1298,332 @@ fn remove_opencode_plugin(verbose: u8) -> Result<Vec<PathBuf>> {
     }
 
     Ok(removed)
+}
+
+fn install_codex_adapter(
+    codex_dir: &Path,
+    rtk_binary: &Path,
+    path_snapshot: &str,
+    verbose: u8,
+) -> Result<()> {
+    #[cfg(not(unix))]
+    {
+        let _ = (codex_dir, rtk_binary, path_snapshot, verbose);
+        anyhow::bail!("Codex adapter currently requires Unix (macOS/Linux)");
+    }
+
+    #[cfg(unix)]
+    {
+        fs::create_dir_all(codex_dir)
+            .with_context(|| format!("Failed to create Codex home: {}", codex_dir.display()))?;
+
+        let config_path = codex_dir.join("config.toml");
+        let manifest_path = codex_manifest_path()?;
+        let shim_dir = codex_shim_dir()?;
+        fs::create_dir_all(&shim_dir)
+            .with_context(|| format!("Failed to create shim dir: {}", shim_dir.display()))?;
+
+        let mut doc = load_codex_document(&config_path)?;
+        let previous_set_path = get_shell_policy_value(&doc, "PATH");
+        let previous_rtk_host = get_shell_policy_value(&doc, "RTK_HOST");
+        let base_path = previous_set_path
+            .clone()
+            .unwrap_or_else(|| path_snapshot.to_string());
+        let injected_path = build_shimmed_path(&shim_dir, &base_path);
+
+        set_shell_policy_value(&mut doc, "PATH", &injected_path)?;
+        set_shell_policy_value(&mut doc, "RTK_HOST", CODEX_HOST)?;
+
+        atomic_write(&config_path, &doc.to_string())?;
+        ensure_codex_shims_installed(&shim_dir, rtk_binary, verbose)?;
+
+        let manifest = CodexInstallManifest {
+            config_path: config_path.display().to_string(),
+            shim_dir: shim_dir.display().to_string(),
+            injected_path,
+            path_snapshot: path_snapshot.to_string(),
+            previous_set_path,
+            previous_rtk_host,
+            env_keys: vec!["PATH".to_string(), "RTK_HOST".to_string()],
+        };
+        store_codex_manifest(&manifest_path, &manifest)?;
+
+        println!("\nCodex adapter installed (experimental).\n");
+        println!("  Config:  {}", config_path.display());
+        println!("  Shims:   {}", shim_dir.display());
+        println!("  Test in Codex with: git status");
+        Ok(())
+    }
+}
+
+fn refresh_codex_adapter_path(
+    codex_dir: &Path,
+    rtk_binary: &Path,
+    path_snapshot: &str,
+    verbose: u8,
+) -> Result<()> {
+    #[cfg(not(unix))]
+    {
+        let _ = (codex_dir, rtk_binary, path_snapshot, verbose);
+        anyhow::bail!("Codex adapter currently requires Unix (macOS/Linux)");
+    }
+
+    #[cfg(unix)]
+    {
+        let config_path = codex_dir.join("config.toml");
+        let manifest_path = codex_manifest_path()?;
+        let shim_dir = codex_shim_dir()?;
+        fs::create_dir_all(&shim_dir)
+            .with_context(|| format!("Failed to create shim dir: {}", shim_dir.display()))?;
+
+        let mut doc = load_codex_document(&config_path)?;
+        let previous_set_path = get_shell_policy_value(&doc, "PATH");
+        let previous_rtk_host = get_shell_policy_value(&doc, "RTK_HOST");
+        let injected_path = build_shimmed_path(&shim_dir, path_snapshot);
+
+        set_shell_policy_value(&mut doc, "PATH", &injected_path)?;
+        set_shell_policy_value(&mut doc, "RTK_HOST", CODEX_HOST)?;
+
+        atomic_write(&config_path, &doc.to_string())?;
+        ensure_codex_shims_installed(&shim_dir, rtk_binary, verbose)?;
+
+        let manifest = CodexInstallManifest {
+            config_path: config_path.display().to_string(),
+            shim_dir: shim_dir.display().to_string(),
+            injected_path,
+            path_snapshot: path_snapshot.to_string(),
+            previous_set_path,
+            previous_rtk_host,
+            env_keys: vec!["PATH".to_string(), "RTK_HOST".to_string()],
+        };
+        store_codex_manifest(&manifest_path, &manifest)?;
+
+        println!(
+            "\nCodex PATH snapshot refreshed.\n\n  Config:  {}\n  Shims:   {}",
+            config_path.display(),
+            shim_dir.display()
+        );
+        Ok(())
+    }
+}
+
+fn uninstall_codex_adapter(codex_dir: &Path, verbose: u8) -> Result<()> {
+    #[cfg(not(unix))]
+    {
+        let _ = (codex_dir, verbose);
+        anyhow::bail!("Codex adapter currently requires Unix (macOS/Linux)");
+    }
+
+    #[cfg(unix)]
+    {
+        let config_path = codex_dir.join("config.toml");
+        let manifest_path = codex_manifest_path()?;
+        let shim_dir = codex_shim_dir()?;
+
+        if config_path.exists() && manifest_path.exists() {
+            let manifest = load_codex_manifest(&manifest_path)?;
+            let mut doc = load_codex_document(&config_path)?;
+            let current_path = get_shell_policy_value(&doc, "PATH");
+            let current_host = get_shell_policy_value(&doc, "RTK_HOST");
+
+            if current_path.as_deref() == Some(manifest.injected_path.as_str()) {
+                restore_shell_policy_value(
+                    &mut doc,
+                    "PATH",
+                    manifest.previous_set_path.as_deref(),
+                )?;
+            } else if current_path.is_some() {
+                println!("⚠️  PATH changed since install; leaving it unchanged");
+            }
+
+            if current_host.as_deref() == Some(CODEX_HOST) {
+                restore_shell_policy_value(
+                    &mut doc,
+                    "RTK_HOST",
+                    manifest.previous_rtk_host.as_deref(),
+                )?;
+            }
+
+            atomic_write(&config_path, &doc.to_string())?;
+            fs::remove_file(&manifest_path).ok();
+        }
+
+        remove_codex_shims(&shim_dir, verbose)?;
+        println!("\nCodex adapter removed.\n");
+        Ok(())
+    }
+}
+
+fn build_shimmed_path(shim_dir: &Path, base_path: &str) -> String {
+    if base_path.is_empty() {
+        shim_dir.display().to_string()
+    } else {
+        format!("{}:{base_path}", shim_dir.display())
+    }
+}
+
+fn load_codex_document(path: &Path) -> Result<DocumentMut> {
+    if !path.exists() {
+        return Ok(DocumentMut::new());
+    }
+
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read Codex config: {}", path.display()))?;
+    if content.trim().is_empty() {
+        Ok(DocumentMut::new())
+    } else {
+        content
+            .parse::<DocumentMut>()
+            .with_context(|| format!("Failed to parse {}", path.display()))
+    }
+}
+
+fn get_shell_policy_value(doc: &DocumentMut, key: &str) -> Option<String> {
+    let policy = doc.get("shell_environment_policy")?;
+    let set = policy.get("set")?;
+    if let Some(table) = set.as_table() {
+        table.get(key)?.as_str().map(ToOwned::to_owned)
+    } else if let Some(inline) = set.as_inline_table() {
+        inline.get(key)?.as_str().map(ToOwned::to_owned)
+    } else {
+        None
+    }
+}
+
+fn set_shell_policy_value(doc: &mut DocumentMut, key: &str, value_str: &str) -> Result<()> {
+    let policy = doc
+        .entry("shell_environment_policy")
+        .or_insert(Item::Table(Table::new()));
+    if !policy.is_table() {
+        anyhow::bail!("shell_environment_policy must be a table");
+    }
+
+    let policy_table = policy
+        .as_table_mut()
+        .context("shell_environment_policy must be mutable table")?;
+
+    if !policy_table.contains_key("set") {
+        policy_table["set"] = Item::Table(Table::new());
+    } else if policy_table["set"].is_inline_table() {
+        let inline = policy_table["set"]
+            .as_inline_table()
+            .cloned()
+            .context("Failed to read shell_environment_policy.set")?;
+        let mut table = Table::new();
+        for (name, item) in inline.iter() {
+            table[name] = Item::Value(item.clone());
+        }
+        policy_table["set"] = Item::Table(table);
+    } else if !policy_table["set"].is_table() {
+        anyhow::bail!("shell_environment_policy.set must be a table or inline table");
+    }
+
+    let set_table = policy_table["set"]
+        .as_table_mut()
+        .context("shell_environment_policy.set must be mutable table")?;
+    set_table[key] = value(value_str);
+    Ok(())
+}
+
+fn restore_shell_policy_value(
+    doc: &mut DocumentMut,
+    key: &str,
+    value_str: Option<&str>,
+) -> Result<()> {
+    let policy = match doc.get_mut("shell_environment_policy") {
+        Some(item) => item,
+        None => return Ok(()),
+    };
+
+    let set = match policy.get_mut("set") {
+        Some(item) => item,
+        None => return Ok(()),
+    };
+
+    if let Some(table) = set.as_table_mut() {
+        match value_str {
+            Some(v) => {
+                table[key] = value(v);
+            }
+            None => {
+                table.remove(key);
+            }
+        }
+    } else if let Some(inline) = set.as_inline_table_mut() {
+        match value_str {
+            Some(v) => {
+                inline.insert(key, toml_edit::Value::from(v));
+            }
+            None => {
+                inline.remove(key);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn store_codex_manifest(path: &Path, manifest: &CodexInstallManifest) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create manifest dir: {}", parent.display()))?;
+    }
+    let content = serde_json::to_string_pretty(manifest)?;
+    atomic_write(path, &content)
+}
+
+fn load_codex_manifest(path: &Path) -> Result<CodexInstallManifest> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read manifest: {}", path.display()))?;
+    serde_json::from_str(&content).with_context(|| format!("Failed to parse {}", path.display()))
+}
+
+#[cfg(unix)]
+fn ensure_codex_shims_installed(shim_dir: &Path, rtk_binary: &Path, verbose: u8) -> Result<()> {
+    use std::os::unix::fs::symlink;
+
+    for entrypoint in crate::discover::registry::entrypoints() {
+        let link = shim_dir.join(&entrypoint);
+        if link.exists() || link.symlink_metadata().is_ok() {
+            let target = fs::read_link(&link).ok();
+            if target.as_deref() == Some(rtk_binary) {
+                continue;
+            }
+            fs::remove_file(&link)
+                .with_context(|| format!("Failed to replace shim: {}", link.display()))?;
+        }
+        symlink(rtk_binary, &link)
+            .with_context(|| format!("Failed to create shim: {}", link.display()))?;
+        if verbose > 0 {
+            eprintln!("Created Codex shim: {}", link.display());
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn remove_codex_shims(shim_dir: &Path, verbose: u8) -> Result<()> {
+    if !shim_dir.exists() {
+        return Ok(());
+    }
+
+    for entrypoint in crate::discover::registry::entrypoints() {
+        let link = shim_dir.join(&entrypoint);
+        if link.exists() || link.symlink_metadata().is_ok() {
+            fs::remove_file(&link)
+                .with_context(|| format!("Failed to remove shim: {}", link.display()))?;
+            if verbose > 0 {
+                eprintln!("Removed Codex shim: {}", link.display());
+            }
+        }
+    }
+
+    if shim_dir.read_dir()?.next().is_none() {
+        fs::remove_dir(shim_dir).ok();
+    }
+
+    Ok(())
 }
 
 /// Show current rtk configuration
@@ -1389,6 +1782,70 @@ pub fn show_config() -> Result<()> {
     println!("  rtk init -g --claude-md     # Legacy: full injection into ~/.claude/CLAUDE.md");
     println!("  rtk init -g --hook-only     # Hook only, no RTK.md");
     println!("  rtk init -g --opencode      # OpenCode plugin only");
+    println!("  rtk init -g --codex         # Codex adapter via PATH shims");
+    println!("  rtk init --show --codex     # Show Codex adapter status");
+
+    Ok(())
+}
+
+pub fn show_codex_config() -> Result<()> {
+    let codex_dir = resolve_codex_dir()?;
+    let config_path = codex_dir.join("config.toml");
+    let manifest_path = codex_manifest_path()?;
+    let shim_dir = codex_shim_dir()?;
+    let current_path = std::env::var("PATH").unwrap_or_default();
+
+    println!("📋 rtk Codex adapter:\n");
+    println!("  Codex home: {}", codex_dir.display());
+
+    if config_path.exists() {
+        println!("✅ config.toml: {}", config_path.display());
+    } else {
+        println!("⚪ config.toml: not found");
+    }
+
+    let doc = load_codex_document(&config_path)?;
+    let configured_path = get_shell_policy_value(&doc, "PATH");
+    let configured_host = get_shell_policy_value(&doc, "RTK_HOST");
+
+    match configured_host.as_deref() {
+        Some(CODEX_HOST) => println!("✅ RTK_HOST: {}", CODEX_HOST),
+        Some(other) => println!("⚠️  RTK_HOST: {other}"),
+        None => println!("⚪ RTK_HOST: not set"),
+    }
+
+    match &configured_path {
+        Some(path) if path.starts_with(&format!("{}:", shim_dir.display())) => {
+            println!("✅ PATH: shim dir prepended");
+        }
+        Some(_) => println!("⚠️  PATH: present but shim dir not prepended"),
+        None => println!("⚪ PATH: not set in shell_environment_policy"),
+    }
+
+    if shim_dir.exists() {
+        println!("✅ shims: {}", shim_dir.display());
+    } else {
+        println!("⚪ shims: not found");
+    }
+
+    if manifest_path.exists() {
+        let manifest = load_codex_manifest(&manifest_path)?;
+        let stale = manifest.path_snapshot != current_path
+            && configured_path.as_deref() == Some(manifest.injected_path.as_str());
+        println!("✅ manifest: {}", manifest_path.display());
+        if stale {
+            println!("⚠️  PATH snapshot: stale (run: rtk init -g --codex --refresh-path)");
+        } else {
+            println!("✅ PATH snapshot: current");
+        }
+    } else {
+        println!("⚪ manifest: not found");
+    }
+
+    println!("\nUsage:");
+    println!("  rtk init -g --codex                # Install Codex adapter");
+    println!("  rtk init -g --codex --refresh-path # Refresh PATH snapshot");
+    println!("  rtk init -g --codex --uninstall    # Remove Codex adapter");
 
     Ok(())
 }
@@ -1774,10 +2231,6 @@ More notes
         let serialized = serde_json::to_string(&parsed).unwrap();
 
         // Keys should appear in same order
-        let original_keys: Vec<&str> = original.split("\"").filter(|s| s.contains(":")).collect();
-        let serialized_keys: Vec<&str> =
-            serialized.split("\"").filter(|s| s.contains(":")).collect();
-
         // Just check that keys exist (preserve_order doesn't guarantee exact order in nested objects)
         assert!(serialized.contains("\"env\""));
         assert!(serialized.contains("\"permissions\""));
@@ -1855,5 +2308,46 @@ More notes
 
         let removed = remove_hook_from_json(&mut json_content);
         assert!(!removed);
+    }
+
+    #[test]
+    fn test_build_shimmed_path() {
+        let shim_dir = Path::new("/tmp/rtk/codex-shims");
+        assert_eq!(
+            build_shimmed_path(shim_dir, "/usr/bin:/bin"),
+            "/tmp/rtk/codex-shims:/usr/bin:/bin"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_codex_install_round_trip() {
+        let temp = tempfile::tempdir().unwrap();
+        let codex_dir = temp.path().join("codex-home");
+        let binary = temp.path().join("rtk");
+        fs::write(&binary, "rtk").unwrap();
+        let previous_xdg = std::env::var_os("XDG_DATA_HOME");
+        let previous_home = std::env::var_os("HOME");
+        std::env::set_var("XDG_DATA_HOME", temp.path());
+        std::env::set_var("HOME", temp.path());
+
+        install_codex_adapter(&codex_dir, &binary, "/usr/bin:/bin", 0).unwrap();
+
+        let config = fs::read_to_string(codex_dir.join("config.toml")).unwrap();
+        assert!(config.contains("RTK_HOST = \"codex\""));
+        assert!(config.contains("PATH = "));
+
+        uninstall_codex_adapter(&codex_dir, 0).unwrap();
+        let config_after = fs::read_to_string(codex_dir.join("config.toml")).unwrap();
+        assert!(!config_after.contains("RTK_HOST = \"codex\""));
+
+        match previous_xdg {
+            Some(value) => std::env::set_var("XDG_DATA_HOME", value),
+            None => std::env::remove_var("XDG_DATA_HOME"),
+        }
+        match previous_home {
+            Some(value) => std::env::set_var("HOME", value),
+            None => std::env::remove_var("HOME"),
+        }
     }
 }

--- a/src/lint_cmd.rs
+++ b/src/lint_cmd.rs
@@ -1,3 +1,4 @@
+use crate::config;
 use crate::mypy_cmd;
 use crate::ruff_cmd;
 use crate::tracking;
@@ -234,7 +235,7 @@ fn filter_eslint_json(output: &str) -> String {
             return format!(
                 "ESLint output (JSON parse failed: {})\n{}",
                 e,
-                truncate(output, 500)
+                truncate(output, config::limits().passthrough_max_chars)
             );
         }
     };
@@ -326,7 +327,7 @@ fn filter_pylint_json(output: &str) -> String {
             return format!(
                 "Pylint output (JSON parse failed: {})\n{}",
                 e,
-                truncate(output, 500)
+                truncate(output, config::limits().passthrough_max_chars)
             );
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,7 +306,7 @@ enum Commands {
         #[arg(short = 'l', long, default_value = "80")]
         max_len: usize,
         /// Max results to show
-        #[arg(short, long, default_value = "50")]
+        #[arg(short, long, default_value = "200")]
         max: usize,
         /// Show only match context (not full line)
         #[arg(short, long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod binlog;
 mod cargo_cmd;
 mod cc_economics;
 mod ccusage;
+mod codex;
 mod config;
 mod container;
 mod curl_cmd;
@@ -332,6 +333,10 @@ enum Commands {
         #[arg(long)]
         opencode: bool,
 
+        /// Install Codex adapter (global only)
+        #[arg(long)]
+        codex: bool,
+
         /// Show current configuration
         #[arg(long)]
         show: bool,
@@ -355,6 +360,10 @@ enum Commands {
         /// Remove all RTK artifacts (hook, RTK.md, CLAUDE.md reference, settings.json entry)
         #[arg(long)]
         uninstall: bool,
+
+        /// Refresh the Codex PATH snapshot
+        #[arg(long)]
+        refresh_path: bool,
     },
 
     /// Download with compact output (strips progress bars)
@@ -1205,6 +1214,13 @@ fn main() -> Result<()> {
     // Fire-and-forget telemetry ping (1/day, non-blocking)
     telemetry::maybe_ping();
 
+    let mut raw_args = std::env::args_os();
+    let argv0 = raw_args.next().unwrap_or_else(|| OsString::from("rtk"));
+    let passthrough_args: Vec<OsString> = raw_args.collect();
+    if let Some(exit_code) = codex::maybe_run_as_codex_shim(&argv0, &passthrough_args)? {
+        std::process::exit(exit_code);
+    }
+
     let cli = match Cli::try_parse() {
         Ok(cli) => cli,
         Err(e) => {
@@ -1608,17 +1624,40 @@ fn main() -> Result<()> {
         Commands::Init {
             global,
             opencode,
+            codex,
             show,
             claude_md,
             hook_only,
             auto_patch,
             no_patch,
             uninstall,
+            refresh_path,
         } => {
+            if codex && (opencode || claude_md || hook_only || auto_patch || no_patch) {
+                anyhow::bail!(
+                    "--codex cannot be combined with --opencode, --claude-md, --hook-only, --auto-patch, or --no-patch"
+                );
+            }
+
             if show {
-                init::show_config()?;
+                if codex {
+                    init::show_codex_config()?;
+                } else {
+                    init::show_config()?;
+                }
+            } else if refresh_path {
+                if !codex {
+                    anyhow::bail!("--refresh-path is only supported with --codex");
+                }
+                init::refresh_codex_path(global, cli.verbose)?;
             } else if uninstall {
-                init::uninstall(global, cli.verbose)?;
+                if codex {
+                    init::uninstall_codex(global, cli.verbose)?;
+                } else {
+                    init::uninstall(global, cli.verbose)?;
+                }
+            } else if codex {
+                init::run_codex(global, cli.verbose)?;
             } else {
                 let install_opencode = opencode;
                 let install_claude = !opencode;

--- a/src/parser/README.md
+++ b/src/parser/README.md
@@ -70,7 +70,7 @@ impl OutputParser for VitestParser {
                     )
                 } else {
                     // Tier 3: Passthrough
-                    ParseResult::Passthrough(truncate_output(input, 500))
+                    ParseResult::Passthrough(truncate_output(input, 2000))
                 }
             }
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -89,10 +89,16 @@ pub trait OutputParser: Sized {
         let result = Self::parse(input);
         if result.tier() > max_tier {
             // Force degradation to passthrough if exceeds max tier
-            return ParseResult::Passthrough(truncate_output(input, 500));
+            return ParseResult::Passthrough(truncate_passthrough(input));
         }
         result
     }
+}
+
+/// Truncate output using configured passthrough limit
+pub fn truncate_passthrough(output: &str) -> String {
+    let max_chars = crate::config::limits().passthrough_max_chars;
+    truncate_output(output, max_chars)
 }
 
 /// Truncate output to max length with ellipsis

--- a/src/playwright_cmd.rs
+++ b/src/playwright_cmd.rs
@@ -5,8 +5,8 @@ use regex::Regex;
 use serde::Deserialize;
 
 use crate::parser::{
-    emit_degradation_warning, emit_passthrough_warning, truncate_passthrough, FormatMode, OutputParser,
-    ParseResult, TestFailure, TestResult, TokenFormatter,
+    emit_degradation_warning, emit_passthrough_warning, truncate_passthrough, FormatMode,
+    OutputParser, ParseResult, TestFailure, TestResult, TokenFormatter,
 };
 
 /// Matches real Playwright JSON reporter output (suites → specs → tests → results)

--- a/src/playwright_cmd.rs
+++ b/src/playwright_cmd.rs
@@ -5,7 +5,7 @@ use regex::Regex;
 use serde::Deserialize;
 
 use crate::parser::{
-    emit_degradation_warning, emit_passthrough_warning, truncate_output, FormatMode, OutputParser,
+    emit_degradation_warning, emit_passthrough_warning, truncate_passthrough, FormatMode, OutputParser,
     ParseResult, TestFailure, TestResult, TokenFormatter,
 };
 
@@ -110,7 +110,7 @@ impl OutputParser for PlaywrightParser {
                     }
                     None => {
                         // Tier 3: Passthrough
-                        ParseResult::Passthrough(truncate_output(input, 500))
+                        ParseResult::Passthrough(truncate_passthrough(input))
                     }
                 }
             }

--- a/src/pnpm_cmd.rs
+++ b/src/pnpm_cmd.rs
@@ -307,7 +307,8 @@ fn run_list(depth: usize, args: &[String], verbose: u8) -> Result<()> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("pnpm list failed: {}", stderr);
+        eprint!("{}", stderr);
+        std::process::exit(output.status.code().unwrap_or(1));
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -431,7 +432,8 @@ fn run_install(packages: &[String], args: &[String], verbose: u8) -> Result<()> 
     let stderr = String::from_utf8_lossy(&output.stderr);
 
     if !output.status.success() {
-        anyhow::bail!("pnpm install failed: {}", stderr);
+        eprint!("{}", stderr);
+        std::process::exit(output.status.code().unwrap_or(1));
     }
 
     let combined = format!("{}{}", stdout, stderr);

--- a/src/pnpm_cmd.rs
+++ b/src/pnpm_cmd.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::ffi::OsString;
 
 use crate::parser::{
-    emit_degradation_warning, emit_passthrough_warning, truncate_output, Dependency,
+    emit_degradation_warning, emit_passthrough_warning, truncate_passthrough, Dependency,
     DependencyState, FormatMode, OutputParser, ParseResult, TokenFormatter,
 };
 
@@ -75,7 +75,7 @@ impl OutputParser for PnpmListParser {
                     }
                     None => {
                         // Tier 3: Passthrough
-                        ParseResult::Passthrough(truncate_output(input, 500))
+                        ParseResult::Passthrough(truncate_passthrough(input))
                     }
                 }
             }
@@ -202,7 +202,7 @@ impl OutputParser for PnpmOutdatedParser {
                     }
                     None => {
                         // Tier 3: Passthrough
-                        ParseResult::Passthrough(truncate_output(input, 500))
+                        ParseResult::Passthrough(truncate_passthrough(input))
                     }
                 }
             }

--- a/src/ruff_cmd.rs
+++ b/src/ruff_cmd.rs
@@ -1,3 +1,4 @@
+use crate::config;
 use crate::tracking;
 use crate::utils::{resolved_command, truncate};
 use anyhow::{Context, Result};
@@ -121,7 +122,7 @@ pub fn filter_ruff_check_json(output: &str) -> String {
             return format!(
                 "Ruff check (JSON parse failed: {})\n{}",
                 e,
-                truncate(output, 500)
+                truncate(output, config::limits().passthrough_max_chars)
             );
         }
     };

--- a/src/tracking.rs
+++ b/src/tracking.rs
@@ -251,6 +251,12 @@ impl Tracker {
         }
 
         let conn = Connection::open(&db_path)?;
+        // WAL mode + busy_timeout for concurrent access (multiple Claude Code instances).
+        // Non-fatal: NFS/read-only filesystems may not support WAL.
+        let _ = conn.execute_batch(
+            "PRAGMA journal_mode=WAL;
+             PRAGMA busy_timeout=5000;",
+        );
         conn.execute(
             "CREATE TABLE IF NOT EXISTS commands (
                 id INTEGER PRIMARY KEY,

--- a/src/vitest_cmd.rs
+++ b/src/vitest_cmd.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 use serde::Deserialize;
 
 use crate::parser::{
-    emit_degradation_warning, emit_passthrough_warning, extract_json_object, truncate_output,
+    emit_degradation_warning, emit_passthrough_warning, extract_json_object, truncate_passthrough,
     FormatMode, OutputParser, ParseResult, TestFailure, TestResult, TokenFormatter,
 };
 use crate::tracking;
@@ -88,7 +88,7 @@ impl OutputParser for VitestParser {
                     }
                     None => {
                         // Tier 3: Passthrough
-                        ParseResult::Passthrough(truncate_output(input, 500))
+                        ParseResult::Passthrough(truncate_passthrough(input))
                     }
                 }
             }

--- a/src/wget_cmd.rs
+++ b/src/wget_cmd.rs
@@ -41,10 +41,16 @@ pub fn run(url: &str, args: &[String], verbose: u8) -> Result<()> {
         println!("{}", msg);
         timer.track(&format!("wget {}", url), "rtk wget", &raw_output, &msg);
     } else {
-        let error = parse_error(&stderr, &stdout);
-        let msg = format!("⬇️ {} FAILED: {}", compact_url(url), error);
-        println!("{}", msg);
-        timer.track(&format!("wget {}", url), "rtk wget", &raw_output, &msg);
+        if !stderr.trim().is_empty() {
+            eprint!("{}", stderr);
+        }
+        timer.track(
+            &format!("wget {}", url),
+            "rtk wget",
+            &raw_output,
+            &raw_output,
+        );
+        std::process::exit(output.status.code().unwrap_or(1));
     }
 
     Ok(())
@@ -103,10 +109,16 @@ pub fn run_stdout(url: &str, args: &[String], verbose: u8) -> Result<()> {
         );
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        let error = parse_error(&stderr, "");
-        let msg = format!("⬇️ {} FAILED: {}", compact_url(url), error);
-        println!("{}", msg);
-        timer.track(&format!("wget -O - {}", url), "rtk wget -o", &stderr, &msg);
+        if !stderr.trim().is_empty() {
+            eprint!("{}", stderr);
+        }
+        timer.track(
+            &format!("wget -O - {}", url),
+            "rtk wget -o",
+            &stderr,
+            &stderr,
+        );
+        std::process::exit(output.status.code().unwrap_or(1));
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

This PR adds an experimental Codex adapter to RTK.

New user-facing entrypoints:

- `rtk init -g --codex`
- `rtk init -g --codex --uninstall`
- `rtk init --show --codex`
- `rtk init -g --codex --refresh-path`

This is intentionally described as an adapter, not native Codex support.

## Related upstream issue

Related upstream Codex issue:

- `openai/codex#13416` — Add `AGENT=codex` environment variable to `UNIFIED_EXEC_ENV`
- https://github.com/openai/codex/issues/13416

This PR does not depend on that issue being implemented. RTK injects `RTK_HOST=codex` itself so the adapter works with Codex today.

## Motivation

RTK already has transparent execution-layer integration paths for Claude Code and OpenCode.

Codex does not currently expose the same documented pre-exec rewrite seam on the RTK side, so the practical RTK-only path is to adapt Codex using its documented subprocess configuration surface.

This PR does that by:

- patching `~/.codex/config.toml`
- injecting `RTK_HOST=codex`
- prepending a Codex-only RTK shim directory to `PATH`
- routing shim execution back into RTK through `argv[0]`
- reusing the shared rewrite registry instead of maintaining a second command map

## Scope

This PR is intentionally limited to one feature: the Codex adapter lifecycle.

Included:

- Codex install / uninstall / show / refresh-path
- subprocess-local PATH shim adapter
- `argv[0]` shim dispatch in the RTK binary
- shared registry reuse for rewrite decisions
- config patching + manifest persistence
- docs + changelog

Not included:

- AGENTS.md automation
- `.rules` rewriting
- Windows support
- `rtk doctor`
- changes to Codex transcript formatting / UnifiedExec output
- dependency on `AGENT=codex`

## Implementation

### Install lifecycle

`rtk init -g --codex` now:

- resolves `CODEX_HOME` or falls back to `~/.codex`
- patches `config.toml`
- writes:
  - `shell_environment_policy.set.PATH=<shim_dir>:<path_snapshot>`
  - `shell_environment_policy.set.RTK_HOST=codex`
- creates RTK-managed Codex shims
- stores an install manifest for safe uninstall / refresh

`rtk init -g --codex --refresh-path` updates the stored PATH snapshot without changing unrelated Codex config.

`rtk init -g --codex --uninstall` removes RTK-managed Codex shims and restores RTK-managed config entries conservatively.

### Runtime adapter

The RTK binary now supports shim mode:

- if invoked as `rtk`, normal CLI flow runs
- if invoked via a shim name such as `git`, `python`, `rg`, etc., RTK enters Codex shim dispatch mode
- shim mode:
  - checks `RTK_HOST=codex`
  - checks `RTK_BYPASS=1` to avoid recursion
  - checks registry-managed entrypoints
  - reuses the rewrite registry for rewrite / passthrough
  - resolves passthrough binaries from a PATH with the shim dir removed

### Registry reuse

The rewrite registry now exposes:

- `entrypoints()`
- argv-aware rewrite support

This keeps the command mapping single-sourced. The shim installer and shim runtime both depend on the same registry layer.

## Documentation

Updated:

- `README.md`
- `INSTALL.md`
- `ARCHITECTURE.md`
- `CHANGELOG.md`

## Tests

Added / updated tests for:

- Codex config patching
- Codex install / uninstall round trip
- PATH snapshot handling
- shim entrypoint coverage
- argv-aware rewrite for:
  - `git status`
  - `python -m pytest`
  - structured-output skip case for `gh --json`
- recursion-safe PATH cleanup

## Pre-commit gate

Passed:

```bash
cargo fmt --all --check
cargo clippy --all-targets
cargo test
```

### Gate logs

`cargo fmt --all --check`
```text
(exit 0)
```

`cargo clippy --all-targets`
```text
Checking rtk v0.30.0 (/Users/hemuling/tmp/rtk-codex-adapter)
warning: `rtk` (bin "rtk") generated 54 warnings
warning: `rtk` (bin "rtk" test) generated 54 warnings (49 duplicates)
Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.60s
```

`cargo test`
```text
running 944 tests
...
test result: ok. 941 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 6.44s
```

## Manual validation

I also validated the adapter with a real `codex exec` run using an isolated temporary `CODEX_HOME` and fake binaries to make the execution path observable.

### Codex install

Command:

```bash
HOME=/tmp/rtk-codex-smoke.ppWstF/home \
XDG_DATA_HOME=/tmp/rtk-codex-smoke.ppWstF/xdg \
CODEX_HOME=/tmp/rtk-codex-smoke.ppWstF/home/.codex \
PATH=/tmp/rtk-codex-smoke.ppWstF/bin:/usr/bin:/bin \
CARGO_HOME=/Users/hemuling/.cargo \
RUSTUP_HOME=/Users/hemuling/.rustup \
cargo run --quiet -- init -g --codex
```

Observed output:

```text
Codex adapter installed (experimental).

  Config:  /tmp/rtk-codex-smoke.ppWstF/home/.codex/config.toml
  Shims:   /tmp/rtk-codex-smoke.ppWstF/home/Library/Application Support/rtk/codex-shims
  Test in Codex with: git status
```

### Real Codex subprocess validation

Command:

```bash
HOME=/Users/hemuling \
CODEX_HOME=/tmp/rtk-codex-smoke.ppWstF/home/.codex \
codex exec \
  --skip-git-repo-check \
  --dangerously-bypass-approvals-and-sandbox \
  -C /tmp/rtk-codex-smoke.ppWstF/work \
  "Run these exact shell commands and stop after reporting the outputs: git status ; python -m pytest ; node -v"
```

Observed Codex execution log:

```text
exec
/bin/zsh -lc 'git status ; python -m pytest ; node -v' in /tmp/rtk-codex-smoke.ppWstF/work succeeded in 267ms:
fake-git-status
fake-python-pytest
fake-node-version
```

Shim target logs:

`git.log`
```text
RTK_BYPASS=1 ARGS=git status
```

`python.log`
```text
RTK_BYPASS=1 ARGS=pytest
```

`node.log`
```text
RTK_BYPASS= ARGS=-v
```

Interpretation:

- `git status` was intercepted and routed through RTK
- `python -m pytest` was intercepted and rewritten to the RTK pytest path
- `node -v` was not rewritten and passed through normally

## Non-goals / limitations

- This is not native Codex hook support
- This does not rely on AGENTS.md, Skills, or `.rules`
- This does not modify Codex UnifiedExec transcript formatting
- This currently targets Unix-like environments
- If the user's base PATH changes later, they should run:
  - `rtk init -g --codex --refresh-path`
