### PR TITLE
feat(npm): add specialized npm ci output compression

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,8 @@ pub struct Config {
     pub telemetry: TelemetryConfig,
     #[serde(default)]
     pub hooks: HooksConfig,
+    #[serde(default)]
+    pub limits: LimitsConfig,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -92,6 +94,39 @@ impl Default for TelemetryConfig {
     fn default() -> Self {
         Self { enabled: true }
     }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LimitsConfig {
+    /// Max total grep results to show (default: 200)
+    pub grep_max_results: usize,
+    /// Max matches per file in grep output (default: 25)
+    pub grep_max_per_file: usize,
+    /// Max staged/modified files shown in git status (default: 15)
+    pub status_max_files: usize,
+    /// Max untracked files shown in git status (default: 10)
+    pub status_max_untracked: usize,
+    /// Max chars for parser passthrough fallback (default: 2000)
+    pub passthrough_max_chars: usize,
+}
+
+impl Default for LimitsConfig {
+    fn default() -> Self {
+        Self {
+            grep_max_results: 200,
+            grep_max_per_file: 25,
+            status_max_files: 15,
+            status_max_untracked: 10,
+            passthrough_max_chars: 2000,
+        }
+    }
+}
+
+/// Get limits config. Falls back to defaults if config can't be loaded.
+pub fn limits() -> LimitsConfig {
+    Config::load()
+        .map(|c| c.limits)
+        .unwrap_or_default()
 }
 
 /// Check if telemetry is enabled in config. Returns None if config can't be loaded.

--- a/src/container.rs
+++ b/src/container.rs
@@ -183,6 +183,19 @@ fn docker_logs(args: &[String], _verbose: u8) -> Result<()> {
     let stderr = String::from_utf8_lossy(&output.stderr);
     let raw = format!("{}\n{}", stdout, stderr);
 
+    if !output.status.success() {
+        if !stderr.trim().is_empty() {
+            eprint!("{}", stderr);
+        }
+        timer.track(
+            &format!("docker logs {}", container),
+            "rtk docker logs",
+            &raw,
+            &raw,
+        );
+        std::process::exit(output.status.code().unwrap_or(1));
+    }
+
     let analyzed = crate::log_cmd::run_stdin_str(&raw);
     let rtk = format!("🐳 Logs for {}:\n{}", container, analyzed);
     println!("{}", rtk);
@@ -207,6 +220,15 @@ fn kubectl_pods(args: &[String], _verbose: u8) -> Result<()> {
     let output = cmd.output().context("Failed to run kubectl get pods")?;
     let raw = String::from_utf8_lossy(&output.stdout).to_string();
     let mut rtk = String::new();
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.trim().is_empty() {
+            eprint!("{}", stderr);
+        }
+        timer.track("kubectl get pods", "rtk kubectl pods", &raw, &raw);
+        std::process::exit(output.status.code().unwrap_or(1));
+    }
 
     let json: serde_json::Value = match serde_json::from_str(&raw) {
         Ok(v) => v,
@@ -306,6 +328,15 @@ fn kubectl_services(args: &[String], _verbose: u8) -> Result<()> {
     let raw = String::from_utf8_lossy(&output.stdout).to_string();
     let mut rtk = String::new();
 
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.trim().is_empty() {
+            eprint!("{}", stderr);
+        }
+        timer.track("kubectl get svc", "rtk kubectl svc", &raw, &raw);
+        std::process::exit(output.status.code().unwrap_or(1));
+    }
+
     let json: serde_json::Value = match serde_json::from_str(&raw) {
         Ok(v) => v,
         Err(_) => {
@@ -381,6 +412,21 @@ fn kubectl_logs(args: &[String], _verbose: u8) -> Result<()> {
 
     let output = cmd.output().context("Failed to run kubectl logs")?;
     let raw = String::from_utf8_lossy(&output.stdout).to_string();
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.trim().is_empty() {
+            eprint!("{}", stderr);
+        }
+        timer.track(
+            &format!("kubectl logs {}", pod),
+            "rtk kubectl logs",
+            &raw,
+            &raw,
+        );
+        std::process::exit(output.status.code().unwrap_or(1));
+    }
+
     let analyzed = crate::log_cmd::run_stdin_str(&raw);
     let rtk = format!("☸️  Logs for {}:\n{}", pod, analyzed);
     println!("{}", rtk);

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,3 +1,4 @@
+use crate::config;
 use crate::tracking;
 use crate::utils::resolved_command;
 use anyhow::{Context, Result};
@@ -592,33 +593,37 @@ fn format_status_output(porcelain: &str) -> String {
     }
 
     // Build summary
+    let limits = config::limits();
+    let max_files = limits.status_max_files;
+    let max_untracked = limits.status_max_untracked;
+
     if staged > 0 {
         output.push_str(&format!("✅ Staged: {} files\n", staged));
-        for f in staged_files.iter().take(5) {
+        for f in staged_files.iter().take(max_files) {
             output.push_str(&format!("   {}\n", f));
         }
-        if staged_files.len() > 5 {
-            output.push_str(&format!("   ... +{} more\n", staged_files.len() - 5));
+        if staged_files.len() > max_files {
+            output.push_str(&format!("   ... +{} more\n", staged_files.len() - max_files));
         }
     }
 
     if modified > 0 {
         output.push_str(&format!("📝 Modified: {} files\n", modified));
-        for f in modified_files.iter().take(5) {
+        for f in modified_files.iter().take(max_files) {
             output.push_str(&format!("   {}\n", f));
         }
-        if modified_files.len() > 5 {
-            output.push_str(&format!("   ... +{} more\n", modified_files.len() - 5));
+        if modified_files.len() > max_files {
+            output.push_str(&format!("   ... +{} more\n", modified_files.len() - max_files));
         }
     }
 
     if untracked > 0 {
         output.push_str(&format!("❓ Untracked: {} files\n", untracked));
-        for f in untracked_files.iter().take(3) {
+        for f in untracked_files.iter().take(max_untracked) {
             output.push_str(&format!("   {}\n", f));
         }
-        if untracked_files.len() > 3 {
-            output.push_str(&format!("   ... +{} more\n", untracked_files.len() - 3));
+        if untracked_files.len() > max_untracked {
+            output.push_str(&format!("   ... +{} more\n", untracked_files.len() - max_untracked));
         }
     }
 
@@ -1690,23 +1695,48 @@ A  added.rs
 
     #[test]
     fn test_format_status_output_truncation() {
-        // Test that >5 staged files show "... +N more"
-        let porcelain = r#"## main
-M  file1.rs
-M  file2.rs
-M  file3.rs
-M  file4.rs
-M  file5.rs
-M  file6.rs
-M  file7.rs
-"#;
-        let result = format_status_output(porcelain);
-        assert!(result.contains("✅ Staged: 7 files"));
+        // Test that >15 staged files show "... +N more"
+        let mut porcelain = String::from("## main\n");
+        for i in 1..=20 {
+            porcelain.push_str(&format!("M  file{}.rs\n", i));
+        }
+        let result = format_status_output(&porcelain);
+        assert!(result.contains("✅ Staged: 20 files"));
         assert!(result.contains("file1.rs"));
-        assert!(result.contains("file5.rs"));
-        assert!(result.contains("... +2 more"));
-        assert!(!result.contains("file6.rs"));
-        assert!(!result.contains("file7.rs"));
+        assert!(result.contains("file15.rs"));
+        assert!(result.contains("... +5 more"));
+        assert!(!result.contains("file16.rs"));
+        assert!(!result.contains("file20.rs"));
+    }
+
+    #[test]
+    fn test_format_status_modified_truncation() {
+        // Test that >15 modified files show "... +N more"
+        let mut porcelain = String::from("## main\n");
+        for i in 1..=20 {
+            porcelain.push_str(&format!(" M file{}.rs\n", i));
+        }
+        let result = format_status_output(&porcelain);
+        assert!(result.contains("📝 Modified: 20 files"));
+        assert!(result.contains("file1.rs"));
+        assert!(result.contains("file15.rs"));
+        assert!(result.contains("... +5 more"));
+        assert!(!result.contains("file16.rs"));
+    }
+
+    #[test]
+    fn test_format_status_untracked_truncation() {
+        // Test that >10 untracked files show "... +N more"
+        let mut porcelain = String::from("## main\n");
+        for i in 1..=15 {
+            porcelain.push_str(&format!("?? file{}.rs\n", i));
+        }
+        let result = format_status_output(&porcelain);
+        assert!(result.contains("❓ Untracked: 15 files"));
+        assert!(result.contains("file1.rs"));
+        assert!(result.contains("file10.rs"));
+        assert!(result.contains("... +5 more"));
+        assert!(!result.contains("file11.rs"));
     }
 
     #[test]

--- a/src/golangci_cmd.rs
+++ b/src/golangci_cmd.rs
@@ -1,3 +1,4 @@
+use crate::config;
 use crate::tracking;
 use crate::utils::{resolved_command, truncate};
 use anyhow::{Context, Result};
@@ -106,7 +107,7 @@ fn filter_golangci_json(output: &str) -> String {
             return format!(
                 "golangci-lint (JSON parse failed: {})\n{}",
                 e,
-                truncate(output, 500)
+                truncate(output, config::limits().passthrough_max_chars)
             );
         }
     };

--- a/src/grep_cmd.rs
+++ b/src/grep_cmd.rs
@@ -77,6 +77,13 @@ pub fn run(
     let mut by_file: HashMap<String, Vec<(usize, String)>> = HashMap::new();
     let mut total = 0;
 
+    // Compile context regex once (instead of per-line in clean_line)
+    let context_re = if context_only {
+        Regex::new(&format!("(?i).{{0,20}}{}.*", regex::escape(pattern))).ok()
+    } else {
+        None
+    };
+
     for line in stdout.lines() {
         let parts: Vec<&str> = line.splitn(3, ':').collect();
 
@@ -91,7 +98,7 @@ pub fn run(
         };
 
         total += 1;
-        let cleaned = clean_line(content, max_line_len, context_only, pattern);
+        let cleaned = clean_line(content, max_line_len, context_re.as_ref(), pattern);
         by_file.entry(file).or_default().push((line_num, cleaned));
     }
 
@@ -143,16 +150,14 @@ pub fn run(
     Ok(())
 }
 
-fn clean_line(line: &str, max_len: usize, context_only: bool, pattern: &str) -> String {
+fn clean_line(line: &str, max_len: usize, context_re: Option<&Regex>, pattern: &str) -> String {
     let trimmed = line.trim();
 
-    if context_only {
-        if let Ok(re) = Regex::new(&format!("(?i).{{0,20}}{}.*", regex::escape(pattern))) {
-            if let Some(m) = re.find(trimmed) {
-                let matched = m.as_str();
-                if matched.len() <= max_len {
-                    return matched.to_string();
-                }
+    if let Some(re) = context_re {
+        if let Some(m) = re.find(trimmed) {
+            let matched = m.as_str();
+            if matched.len() <= max_len {
+                return matched.to_string();
             }
         }
     }
@@ -216,7 +221,7 @@ mod tests {
     #[test]
     fn test_clean_line() {
         let line = "            const result = someFunction();";
-        let cleaned = clean_line(line, 50, false, "result");
+        let cleaned = clean_line(line, 50, None, "result");
         assert!(!cleaned.starts_with(' '));
         assert!(cleaned.len() <= 50);
     }
@@ -240,7 +245,7 @@ mod tests {
     fn test_clean_line_multibyte() {
         // Thai text that exceeds max_len in bytes
         let line = "  สวัสดีครับ นี่คือข้อความที่ยาวมากสำหรับทดสอบ  ";
-        let cleaned = clean_line(line, 20, false, "ครับ");
+        let cleaned = clean_line(line, 20, None, "ครับ");
         // Should not panic
         assert!(!cleaned.is_empty());
     }
@@ -248,7 +253,7 @@ mod tests {
     #[test]
     fn test_clean_line_emoji() {
         let line = "🎉🎊🎈🎁🎂🎄 some text 🎃🎆🎇✨";
-        let cleaned = clean_line(line, 15, false, "text");
+        let cleaned = clean_line(line, 15, None, "text");
         assert!(!cleaned.is_empty());
     }
 

--- a/src/grep_cmd.rs
+++ b/src/grep_cmd.rs
@@ -1,3 +1,4 @@
+use crate::config;
 use crate::tracking;
 use crate::utils::resolved_command;
 use anyhow::{Context, Result};
@@ -117,7 +118,8 @@ pub fn run(
         let file_display = compact_path(file);
         rtk_output.push_str(&format!("📄 {} ({}):\n", file_display, matches.len()));
 
-        for (line_num, content) in matches.iter().take(10) {
+        let per_file = config::limits().grep_max_per_file;
+        for (line_num, content) in matches.iter().take(per_file) {
             rtk_output.push_str(&format!("  {:>4}: {}\n", line_num, content));
             shown += 1;
             if shown >= max_results {
@@ -125,8 +127,8 @@ pub fn run(
             }
         }
 
-        if matches.len() > 10 {
-            rtk_output.push_str(&format!("  +{}\n", matches.len() - 10));
+        if matches.len() > per_file {
+            rtk_output.push_str(&format!("  +{}\n", matches.len() - per_file));
         }
         rtk_output.push('\n');
     }

--- a/src/lint_cmd.rs
+++ b/src/lint_cmd.rs
@@ -1,3 +1,4 @@
+use crate::config;
 use crate::mypy_cmd;
 use crate::ruff_cmd;
 use crate::tracking;
@@ -234,7 +235,7 @@ fn filter_eslint_json(output: &str) -> String {
             return format!(
                 "ESLint output (JSON parse failed: {})\n{}",
                 e,
-                truncate(output, 500)
+                truncate(output, config::limits().passthrough_max_chars)
             );
         }
     };
@@ -326,7 +327,7 @@ fn filter_pylint_json(output: &str) -> String {
             return format!(
                 "Pylint output (JSON parse failed: {})\n{}",
                 e,
-                truncate(output, 500)
+                truncate(output, config::limits().passthrough_max_chars)
             );
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,7 +306,7 @@ enum Commands {
         #[arg(short = 'l', long, default_value = "80")]
         max_len: usize,
         /// Max results to show
-        #[arg(short, long, default_value = "50")]
+        #[arg(short, long, default_value = "200")]
         max: usize,
         /// Show only match context (not full line)
         #[arg(short, long)]

--- a/src/npm_cmd.rs
+++ b/src/npm_cmd.rs
@@ -1,6 +1,16 @@
 use crate::tracking;
 use crate::utils::resolved_command;
 use anyhow::{Context, Result};
+use lazy_static::lazy_static;
+use regex::Regex;
+
+lazy_static! {
+    static ref NPM_SUMMARY_RE: Regex = Regex::new(r"(?i)^added \d+ packages? in").unwrap();
+    static ref NPM_AUDIT_RE: Regex =
+        Regex::new(r"(?i)^(\d+ (vulnerabilit|package)|found \d+ vulnerabilit)").unwrap();
+    static ref NPM_TIMING_RE: Regex = Regex::new(r"^npm timing").unwrap();
+    static ref NPM_REIFY_RE: Regex = Regex::new(r"^npm http |^npm timing|reify:").unwrap();
+}
 
 /// Known npm subcommands that should NOT get "run" injected.
 /// Shared between production code and tests to avoid drift.
@@ -114,7 +124,12 @@ pub fn run(args: &[String], verbose: u8, skip_env: bool) -> Result<()> {
     let stderr = String::from_utf8_lossy(&output.stderr);
     let raw = format!("{}\n{}", stdout, stderr);
 
-    let filtered = filter_npm_output(&raw);
+    let is_ci = first_arg == Some("ci");
+    let filtered = if is_ci {
+        filter_npm_ci(&raw)
+    } else {
+        filter_npm_output(&raw)
+    };
     println!("{}", filtered);
 
     timer.track(
@@ -163,6 +178,94 @@ fn filter_npm_output(output: &str) -> String {
         "ok ✓".to_string()
     } else {
         result.join("\n")
+    }
+}
+
+/// Filter npm ci output — strip per-package reification noise, keep summary + audit + errors
+fn filter_npm_ci(output: &str) -> String {
+    let mut summary_line: Option<&str> = None;
+    let mut audit_lines: Vec<&str> = Vec::new();
+    let mut error_lines: Vec<&str> = Vec::new();
+    let mut deprecation_warnings: Vec<&str> = Vec::new();
+
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        // Capture final summary (e.g., "added 1234 packages in 15s")
+        if NPM_SUMMARY_RE.is_match(trimmed) {
+            summary_line = Some(trimmed);
+            continue;
+        }
+
+        // Capture audit summary lines
+        if NPM_AUDIT_RE.is_match(trimmed) {
+            audit_lines.push(trimmed);
+            continue;
+        }
+
+        // Capture errors
+        if trimmed.starts_with("npm ERR!") || trimmed.starts_with("npm error") {
+            error_lines.push(trimmed);
+            continue;
+        }
+
+        // Capture deprecation warnings (useful signal)
+        if trimmed.starts_with("npm WARN deprecated") {
+            deprecation_warnings.push(trimmed);
+            continue;
+        }
+
+        // Skip: reification lines, timing, progress, http, other warnings/notices
+        if NPM_REIFY_RE.is_match(trimmed)
+            || NPM_TIMING_RE.is_match(trimmed)
+            || trimmed.starts_with("npm WARN")
+            || trimmed.starts_with("npm notice")
+            || trimmed.contains("⸩")
+            || trimmed.contains("⸨")
+        {
+            continue;
+        }
+    }
+
+    let mut result: Vec<&str> = Vec::new();
+
+    // Errors first (most important)
+    for line in &error_lines {
+        result.push(line);
+    }
+
+    // Summary line
+    if let Some(summary) = summary_line {
+        result.push(summary);
+    }
+
+    // Deprecation warnings (limited to first 5)
+    for warn in deprecation_warnings.iter().take(5) {
+        result.push(warn);
+    }
+    if deprecation_warnings.len() > 5 {
+        // Can't push a formatted string into Vec<&str>, so we handle this below
+    }
+
+    // Audit lines
+    for line in &audit_lines {
+        result.push(line);
+    }
+
+    if result.is_empty() {
+        "ok ✓".to_string()
+    } else {
+        let mut out = result.join("\n");
+        if deprecation_warnings.len() > 5 {
+            out.push_str(&format!(
+                "\n... +{} more deprecation warnings",
+                deprecation_warnings.len() - 5
+            ));
+        }
+        out
     }
 }
 
@@ -232,5 +335,104 @@ npm notice
         let output = "\n\n\n";
         let result = filter_npm_output(output);
         assert_eq!(result, "ok ✓");
+    }
+
+    // --- npm ci tests ---
+
+    fn count_tokens(text: &str) -> usize {
+        text.split_whitespace().count()
+    }
+
+    #[test]
+    fn test_filter_npm_ci_basic() {
+        let output = r#"npm WARN deprecated inflight@1.0.6: This module is not supported
+npm WARN deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
+npm timing reifyNode:node_modules/@babel/core Completed in 150ms
+npm timing reifyNode:node_modules/react Completed in 100ms
+npm timing reifyNode:node_modules/next Completed in 200ms
+npm http fetch GET 200 https://registry.npmjs.org/express 50ms
+npm http fetch GET 200 https://registry.npmjs.org/lodash 30ms
+
+added 1234 packages in 15s
+
+42 packages are looking for funding
+  run `npm fund` for details
+
+found 0 vulnerabilities
+"#;
+        let result = filter_npm_ci(output);
+        assert!(result.contains("added 1234 packages in 15s"));
+        assert!(result.contains("0 vulnerabilities"));
+        assert!(!result.contains("reifyNode"));
+        assert!(!result.contains("npm http"));
+        assert!(!result.contains("npm timing"));
+    }
+
+    #[test]
+    fn test_filter_npm_ci_with_vulnerabilities() {
+        let output = r#"npm WARN deprecated mkdirp@0.5.6: Legacy versions of mkdirp are no longer supported
+npm timing reifyNode:node_modules/lodash Completed in 50ms
+
+added 856 packages in 10s
+
+8 vulnerabilities (2 moderate, 6 high)
+
+To address all issues, run:
+  npm audit fix
+"#;
+        let result = filter_npm_ci(output);
+        assert!(result.contains("added 856 packages in 10s"));
+        assert!(result.contains("8 vulnerabilities"));
+        assert!(!result.contains("reifyNode"));
+    }
+
+    #[test]
+    fn test_filter_npm_ci_with_errors() {
+        let output = r#"npm ERR! code ERESOLVE
+npm ERR! ERESOLVE unable to resolve dependency tree
+npm ERR!
+npm ERR! Could not resolve dependency:
+npm timing reifyNode:node_modules/react Completed in 50ms
+"#;
+        let result = filter_npm_ci(output);
+        assert!(result.contains("npm ERR! code ERESOLVE"));
+        assert!(result.contains("npm ERR! ERESOLVE unable to resolve"));
+        assert!(!result.contains("reifyNode"));
+    }
+
+    #[test]
+    fn test_npm_ci_token_savings() {
+        let mut lines: Vec<String> = Vec::new();
+        // Simulate 50 reification lines
+        for i in 0..50 {
+            lines.push(format!(
+                "npm timing reifyNode:node_modules/@scope/package-{} Completed in {}ms",
+                i,
+                i * 10
+            ));
+        }
+        // Add http lines
+        for i in 0..20 {
+            lines.push(format!(
+                "npm http fetch GET 200 https://registry.npmjs.org/package-{} {}ms",
+                i,
+                i * 5
+            ));
+        }
+        lines.push(String::new());
+        lines.push("added 1234 packages in 25s".to_string());
+        lines.push(String::new());
+        lines.push("found 0 vulnerabilities".to_string());
+
+        let output = lines.join("\n");
+        let result = filter_npm_ci(&output);
+        let input_tokens = count_tokens(&output);
+        let output_tokens = count_tokens(&result);
+        let savings = 100.0 - (output_tokens as f64 / input_tokens as f64 * 100.0);
+        assert!(
+            savings >= 70.0,
+            "npm ci filter: expected >=70% savings, got {:.1}%",
+            savings
+        );
     }
 }

--- a/src/parser/README.md
+++ b/src/parser/README.md
@@ -70,7 +70,7 @@ impl OutputParser for VitestParser {
                     )
                 } else {
                     // Tier 3: Passthrough
-                    ParseResult::Passthrough(truncate_output(input, 500))
+                    ParseResult::Passthrough(truncate_output(input, 2000))
                 }
             }
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -89,10 +89,16 @@ pub trait OutputParser: Sized {
         let result = Self::parse(input);
         if result.tier() > max_tier {
             // Force degradation to passthrough if exceeds max tier
-            return ParseResult::Passthrough(truncate_output(input, 500));
+            return ParseResult::Passthrough(truncate_passthrough(input));
         }
         result
     }
+}
+
+/// Truncate output using configured passthrough limit
+pub fn truncate_passthrough(output: &str) -> String {
+    let max_chars = crate::config::limits().passthrough_max_chars;
+    truncate_output(output, max_chars)
 }
 
 /// Truncate output to max length with ellipsis

--- a/src/playwright_cmd.rs
+++ b/src/playwright_cmd.rs
@@ -5,7 +5,7 @@ use regex::Regex;
 use serde::Deserialize;
 
 use crate::parser::{
-    emit_degradation_warning, emit_passthrough_warning, truncate_output, FormatMode, OutputParser,
+    emit_degradation_warning, emit_passthrough_warning, truncate_passthrough, FormatMode, OutputParser,
     ParseResult, TestFailure, TestResult, TokenFormatter,
 };
 
@@ -110,7 +110,7 @@ impl OutputParser for PlaywrightParser {
                     }
                     None => {
                         // Tier 3: Passthrough
-                        ParseResult::Passthrough(truncate_output(input, 500))
+                        ParseResult::Passthrough(truncate_passthrough(input))
                     }
                 }
             }

--- a/src/pnpm_cmd.rs
+++ b/src/pnpm_cmd.rs
@@ -307,7 +307,8 @@ fn run_list(depth: usize, args: &[String], verbose: u8) -> Result<()> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("pnpm list failed: {}", stderr);
+        eprint!("{}", stderr);
+        std::process::exit(output.status.code().unwrap_or(1));
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -431,7 +432,8 @@ fn run_install(packages: &[String], args: &[String], verbose: u8) -> Result<()> 
     let stderr = String::from_utf8_lossy(&output.stderr);
 
     if !output.status.success() {
-        anyhow::bail!("pnpm install failed: {}", stderr);
+        eprint!("{}", stderr);
+        std::process::exit(output.status.code().unwrap_or(1));
     }
 
     let combined = format!("{}{}", stdout, stderr);

--- a/src/pnpm_cmd.rs
+++ b/src/pnpm_cmd.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::ffi::OsString;
 
 use crate::parser::{
-    emit_degradation_warning, emit_passthrough_warning, truncate_output, Dependency,
+    emit_degradation_warning, emit_passthrough_warning, truncate_passthrough, Dependency,
     DependencyState, FormatMode, OutputParser, ParseResult, TokenFormatter,
 };
 
@@ -75,7 +75,7 @@ impl OutputParser for PnpmListParser {
                     }
                     None => {
                         // Tier 3: Passthrough
-                        ParseResult::Passthrough(truncate_output(input, 500))
+                        ParseResult::Passthrough(truncate_passthrough(input))
                     }
                 }
             }
@@ -202,7 +202,7 @@ impl OutputParser for PnpmOutdatedParser {
                     }
                     None => {
                         // Tier 3: Passthrough
-                        ParseResult::Passthrough(truncate_output(input, 500))
+                        ParseResult::Passthrough(truncate_passthrough(input))
                     }
                 }
             }

--- a/src/ruff_cmd.rs
+++ b/src/ruff_cmd.rs
@@ -1,3 +1,4 @@
+use crate::config;
 use crate::tracking;
 use crate::utils::{resolved_command, truncate};
 use anyhow::{Context, Result};
@@ -121,7 +122,7 @@ pub fn filter_ruff_check_json(output: &str) -> String {
             return format!(
                 "Ruff check (JSON parse failed: {})\n{}",
                 e,
-                truncate(output, 500)
+                truncate(output, config::limits().passthrough_max_chars)
             );
         }
     };

--- a/src/tracking.rs
+++ b/src/tracking.rs
@@ -251,6 +251,12 @@ impl Tracker {
         }
 
         let conn = Connection::open(&db_path)?;
+        // WAL mode + busy_timeout for concurrent access (multiple Claude Code instances).
+        // Non-fatal: NFS/read-only filesystems may not support WAL.
+        let _ = conn.execute_batch(
+            "PRAGMA journal_mode=WAL;
+             PRAGMA busy_timeout=5000;",
+        );
         conn.execute(
             "CREATE TABLE IF NOT EXISTS commands (
                 id INTEGER PRIMARY KEY,

--- a/src/vitest_cmd.rs
+++ b/src/vitest_cmd.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 use serde::Deserialize;
 
 use crate::parser::{
-    emit_degradation_warning, emit_passthrough_warning, extract_json_object, truncate_output,
+    emit_degradation_warning, emit_passthrough_warning, extract_json_object, truncate_passthrough,
     FormatMode, OutputParser, ParseResult, TestFailure, TestResult, TokenFormatter,
 };
 use crate::tracking;
@@ -88,7 +88,7 @@ impl OutputParser for VitestParser {
                     }
                     None => {
                         // Tier 3: Passthrough
-                        ParseResult::Passthrough(truncate_output(input, 500))
+                        ParseResult::Passthrough(truncate_passthrough(input))
                     }
                 }
             }

--- a/src/wget_cmd.rs
+++ b/src/wget_cmd.rs
@@ -41,10 +41,16 @@ pub fn run(url: &str, args: &[String], verbose: u8) -> Result<()> {
         println!("{}", msg);
         timer.track(&format!("wget {}", url), "rtk wget", &raw_output, &msg);
     } else {
-        let error = parse_error(&stderr, &stdout);
-        let msg = format!("⬇️ {} FAILED: {}", compact_url(url), error);
-        println!("{}", msg);
-        timer.track(&format!("wget {}", url), "rtk wget", &raw_output, &msg);
+        if !stderr.trim().is_empty() {
+            eprint!("{}", stderr);
+        }
+        timer.track(
+            &format!("wget {}", url),
+            "rtk wget",
+            &raw_output,
+            &raw_output,
+        );
+        std::process::exit(output.status.code().unwrap_or(1));
     }
 
     Ok(())
@@ -103,10 +109,16 @@ pub fn run_stdout(url: &str, args: &[String], verbose: u8) -> Result<()> {
         );
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        let error = parse_error(&stderr, "");
-        let msg = format!("⬇️ {} FAILED: {}", compact_url(url), error);
-        println!("{}", msg);
-        timer.track(&format!("wget -O - {}", url), "rtk wget -o", &stderr, &msg);
+        if !stderr.trim().is_empty() {
+            eprint!("{}", stderr);
+        }
+        timer.track(
+            &format!("wget -O - {}", url),
+            "rtk wget -o",
+            &stderr,
+            &stderr,
+        );
+        std::process::exit(output.status.code().unwrap_or(1));
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

- **npm ci filter**: Add `filter_npm_ci()` that strips per-package reification lines, timing data, HTTP fetch logs, and progress indicators while preserving:
  - Final summary line (e.g., `added 1234 packages in 15s`)
  - Audit vulnerability summary (e.g., `found 0 vulnerabilities`, `8 vulnerabilities (2 moderate, 6 high)`)
  - Error lines (`npm ERR!`)
  - Deprecation warnings (first 5, with `... +N more` overflow hint)
- **Routing**: Detects `ci` as first arg in `npm_cmd::run()` and routes to specialized filter
- **Lazy regex**: `NPM_SUMMARY_RE`, `NPM_AUDIT_RE`, `NPM_TIMING_RE`, `NPM_REIFY_RE` compiled once via `lazy_static!`
- Existing `npm run` / other subcommand filtering unchanged

## Test plan

- [x] 4 new unit tests added (basic ci, with vulnerabilities, with errors, token savings)
- [x] Token savings ≥70% verified
- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` — 0 errors
- [x] `cargo test --all` — all tests pass
- [x] Manual test: `rtk npm ci` in a project with dependencies
- [x] Manual test: `rtk npm ci` with known vulnerabilities