### PR TITLE
fix(psql): disable help flag for psql to allow native flags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -214,6 +214,7 @@ enum Commands {
     },
 
     /// PostgreSQL client with compact output (strip borders, compress tables)
+    #[command(disable_help_flag = true)]
     Psql {
         /// psql arguments
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]


### PR DESCRIPTION
## Summary
_psql_ flags like `-h`, `-U`, `-d`, `-c` were being interpreted as rtk options instead of being forwarded to psql.

### Problem
When running `rtk psql -h 192.168.106.72 -U dev -d dev -c "\dn"`, rtk's Clap parser consumed `-h` as the automatic help flag and displayed rtk's help text instead of executing the psql command.

### Fix
Added `#[command(disable_help_flag = true)]` to the psql command variant in `main.rs`. This disables Clap's automatic `-h` and `--help` flags so that psql's own flags pass through correctly.

Users can still access psql's native help via `rtk psql --help` (which forwards to `psql --help`).

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test`
- [x] `rtk psql -h` shows psql error (not rtk help)
- [x] `rtk psql --help` still works (shows psql help)
- [x] All existing psql_cmd tests pass

## Related Issues
Fixes #613