### PR TITLE
feat(learn): sanitize sensitive data in output by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to rtk (Rust Token Killer) will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Features
+
+* **learn:** sanitize sensitive data (AWS IDs, account numbers, paths, org names) in `rtk learn` output by default. Disable with `--no-sanitize`. User-defined patterns supported via `[learn].sanitize_patterns` in config.toml. ([#651](https://github.com/rtk-ai/rtk/issues/651))
+
 ## [0.30.1](https://github.com/rtk-ai/rtk/compare/v0.30.0...v0.30.1) (2026-03-18)
 
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,8 @@ pub struct Config {
     pub hooks: HooksConfig,
     #[serde(default)]
     pub limits: LimitsConfig,
+    #[serde(default)]
+    pub learn: LearnConfig,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -120,6 +122,15 @@ impl Default for LimitsConfig {
             passthrough_max_chars: 2000,
         }
     }
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct LearnConfig {
+    /// Extra regex patterns to sanitize from `rtk learn` output.
+    /// Each entry is a regex string. Matches are replaced with `<REDACTED>`.
+    /// These are applied in addition to the built-in sanitization patterns.
+    #[serde(default)]
+    pub sanitize_patterns: Vec<String>,
 }
 
 /// Get limits config. Falls back to defaults if config can't be loaded.

--- a/src/learn/mod.rs
+++ b/src/learn/mod.rs
@@ -4,7 +4,7 @@ pub mod report;
 use crate::discover::provider::{ClaudeProvider, SessionProvider};
 use anyhow::Result;
 use detector::{deduplicate_corrections, find_corrections, CommandExecution};
-use report::{format_console_report, write_rules_file};
+use report::{format_console_report, write_rules_file, Sanitizer};
 
 pub fn run(
     project: Option<String>,
@@ -14,23 +14,21 @@ pub fn run(
     write_rules: bool,
     min_confidence: f64,
     min_occurrences: usize,
+    sanitize: bool,
 ) -> Result<()> {
     let provider = ClaudeProvider;
 
-    // Determine project filter (same logic as discover)
     let project_filter = if all {
         None
     } else if let Some(p) = project {
         Some(p)
     } else {
-        // Default: current working directory
         let cwd = std::env::current_dir()?;
         let cwd_str = cwd.to_string_lossy().to_string();
         let encoded = ClaudeProvider::encode_project_path(&cwd_str);
         Some(encoded)
     };
 
-    // Discover sessions
     let sessions = provider.discover_sessions(project_filter.as_deref(), Some(since))?;
 
     if sessions.is_empty() {
@@ -38,17 +36,15 @@ pub fn run(
         return Ok(());
     }
 
-    // Extract commands from all sessions
     let mut all_commands: Vec<CommandExecution> = Vec::new();
 
     for session_path in &sessions {
         let extracted = match provider.extract_commands(session_path) {
             Ok(cmds) => cmds,
-            Err(_) => continue, // Skip malformed sessions
+            Err(_) => continue,
         };
 
         for ext_cmd in extracted {
-            // Only process commands with output content
             if let Some(output) = ext_cmd.output_content {
                 all_commands.push(CommandExecution {
                     command: ext_cmd.command,
@@ -59,10 +55,6 @@ pub fn run(
         }
     }
 
-    // Sort by sequence index to maintain chronological order
-    // (already sorted by extraction order within each session)
-
-    // Find corrections
     let corrections = find_corrections(&all_commands);
 
     if corrections.is_empty() {
@@ -73,43 +65,41 @@ pub fn run(
         return Ok(());
     }
 
-    // Filter by confidence
     let filtered: Vec<_> = corrections
         .into_iter()
         .filter(|c| c.confidence >= min_confidence)
         .collect();
 
-    // Deduplicate
     let mut rules = deduplicate_corrections(filtered.clone());
-
-    // Filter by occurrences
     rules.retain(|r| r.occurrences >= min_occurrences);
 
-    // Output
+    let sanitizer = Sanitizer::new(sanitize);
+
     match format.as_str() {
         "json" => {
-            // JSON output
             let json = serde_json::json!({
                 "sessions_scanned": sessions.len(),
                 "total_corrections": filtered.len(),
-                "rules": rules.iter().map(|r| serde_json::json!({
-                    "wrong": r.wrong_pattern,
-                    "right": r.right_pattern,
-                    "error_type": r.error_type.as_str(),
-                    "occurrences": r.occurrences,
-                    "base_command": r.base_command,
-                })).collect::<Vec<_>>(),
+                "rules": rules.iter().map(|r| {
+                    serde_json::json!({
+                        "wrong": sanitizer.sanitize(&r.wrong_pattern).as_ref(),
+                        "right": sanitizer.sanitize(&r.right_pattern).as_ref(),
+                        "error_type": r.error_type.as_str(),
+                        "occurrences": r.occurrences,
+                        "base_command": r.base_command,
+                    })
+                }).collect::<Vec<_>>(),
             });
             println!("{}", serde_json::to_string_pretty(&json)?);
         }
         _ => {
-            // Text output
-            let report = format_console_report(&rules, filtered.len(), sessions.len(), since);
+            let report =
+                format_console_report(&rules, filtered.len(), sessions.len(), since, &sanitizer);
             print!("{}", report);
 
             if write_rules && !rules.is_empty() {
                 let rules_path = ".claude/rules/cli-corrections.md";
-                write_rules_file(&rules, rules_path)?;
+                write_rules_file(&rules, rules_path, &sanitizer)?;
                 println!("\nWritten to: {}", rules_path);
             }
         }

--- a/src/learn/report.rs
+++ b/src/learn/report.rs
@@ -1,14 +1,153 @@
 use crate::learn::detector::CorrectionRule;
 use anyhow::Result;
+use lazy_static::lazy_static;
+use regex::Regex;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
+
+// Built-in sanitization patterns, ordered by specificity.
+// AWS resource IDs must run before account IDs to avoid partial hex matches.
+lazy_static! {
+    static ref AWS_RESOURCE_ID_RE: Regex = Regex::new(
+        r"\b(vpc|sg|subnet|vpce|igw|rtb|acl|eni|vol|snap|nat|eipalloc|pcx)-[0-9a-f]{8,17}\b"
+    ).unwrap();
+
+    static ref AWS_INSTANCE_ID_RE: Regex = Regex::new(
+        r"\bi-[0-9a-f]{8,17}\b"
+    ).unwrap();
+
+    static ref ROUTE53_ZONE_ID_RE: Regex = Regex::new(
+        r"\bZ[0-9A-Z]{10,32}\b"
+    ).unwrap();
+
+    // Matches 12-digit account IDs only after `::`, `:`, or `/` delimiters.
+    // Avoids false positives on bare numbers (timestamps, ports, file sizes).
+    static ref AWS_ACCOUNT_ID_RE: Regex = Regex::new(
+        r"(::?|/)\d{12}\b"
+    ).unwrap();
+
+    static ref USER_HOME_PATH_RE: Regex = Regex::new(
+        r"/(Users|home)/[a-zA-Z0-9._-]+/"
+    ).unwrap();
+
+    static ref GITHUB_ORG_REPO_RE: Regex = Regex::new(
+        r"(github\.com/|repos/)([a-zA-Z0-9._-]+)/([a-zA-Z0-9._-]+)"
+    ).unwrap();
+
+    // UUIDs (Databricks account IDs, API keys, correlation IDs, etc.)
+    static ref UUID_RE: Regex = Regex::new(
+        r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b"
+    ).unwrap();
+
+    // --repo org/repo flag (not a URL, so GITHUB_ORG_REPO_RE won't catch it)
+    static ref REPO_FLAG_RE: Regex = Regex::new(
+        r"--repo\s+([a-zA-Z0-9._-]+)/([a-zA-Z0-9._-]+)"
+    ).unwrap();
+}
+
+/// Encapsulates sanitization config: whether enabled + user-defined patterns from config.toml.
+/// Constructed once per `rtk learn` invocation, passed by reference to all output functions.
+pub struct Sanitizer {
+    enabled: bool,
+    user_patterns: Vec<Regex>,
+}
+
+impl Sanitizer {
+    /// Create a sanitizer. When enabled, loads user patterns from config.toml `[learn].sanitize_patterns`.
+    pub fn new(enabled: bool) -> Self {
+        let user_patterns = if enabled {
+            load_user_patterns()
+        } else {
+            Vec::new()
+        };
+        Self {
+            enabled,
+            user_patterns,
+        }
+    }
+
+    /// Sanitize a string by applying built-in and user patterns.
+    /// Returns borrowed input unchanged when disabled or when no patterns match.
+    pub fn sanitize<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        if !self.enabled || input.is_empty() {
+            return Cow::Borrowed(input);
+        }
+
+        // Track whether any pattern matched. Only allocate when something changes.
+        let mut owned: Option<String> = None;
+
+        macro_rules! apply {
+            ($re:expr, $replacement:expr) => {
+                let current = owned.as_deref().unwrap_or(input);
+                let result = $re.replace_all(current, $replacement);
+                if let Cow::Owned(new) = result {
+                    owned = Some(new);
+                }
+            };
+        }
+
+        apply!(AWS_RESOURCE_ID_RE, |caps: &regex::Captures| {
+            let prefix = caps.get(1).map_or("", |m| m.as_str());
+            format!("{}-<ID>", prefix)
+        });
+        apply!(AWS_INSTANCE_ID_RE, "i-<ID>");
+        apply!(ROUTE53_ZONE_ID_RE, "Z<ZONE_ID>");
+        apply!(AWS_ACCOUNT_ID_RE, |caps: &regex::Captures| {
+            let delim = caps.get(1).map_or("", |m| m.as_str());
+            format!("{}<ACCOUNT_ID>", delim)
+        });
+        apply!(USER_HOME_PATH_RE, "~/");
+        apply!(GITHUB_ORG_REPO_RE, |caps: &regex::Captures| {
+            let prefix = caps.get(1).map_or("", |m| m.as_str());
+            format!("{}<org>/<repo>", prefix)
+        });
+        apply!(UUID_RE, "<UUID>");
+        apply!(REPO_FLAG_RE, "--repo <org>/<repo>");
+
+        for re in &self.user_patterns {
+            apply!(re, "<REDACTED>");
+        }
+
+        match owned {
+            Some(s) => Cow::Owned(s),
+            None => Cow::Borrowed(input),
+        }
+    }
+}
+
+/// Load user-defined sanitization patterns from config.
+/// Returns compiled regexes, logging warnings for invalid patterns.
+fn load_user_patterns() -> Vec<Regex> {
+    let config = match crate::config::Config::load() {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+
+    config
+        .learn
+        .sanitize_patterns
+        .iter()
+        .filter_map(|p| match Regex::new(p) {
+            Ok(re) => Some(re),
+            Err(e) => {
+                eprintln!(
+                    "[rtk learn] Warning: invalid sanitize pattern '{}': {}",
+                    p, e
+                );
+                None
+            }
+        })
+        .collect()
+}
 
 pub fn format_console_report(
     rules: &[CorrectionRule],
     total_corrections: usize,
     sessions: usize,
     days: u64,
+    sanitizer: &Sanitizer,
 ) -> String {
     let mut output = String::new();
 
@@ -34,25 +173,24 @@ pub fn format_console_report(
             "     ".to_string()
         };
 
-        output.push_str(&format!(
-            "{}{}  →  {}\n",
-            count_marker, rule.wrong_pattern, rule.right_pattern
-        ));
+        let wrong = sanitizer.sanitize(&rule.wrong_pattern);
+        let right = sanitizer.sanitize(&rule.right_pattern);
 
-        // Show error snippet (first line only)
+        output.push_str(&format!("{}{}  →  {}\n", count_marker, wrong, right));
+
         let error_line = rule.example_error.lines().next().unwrap_or("").trim();
         if !error_line.is_empty() {
-            output.push_str(&format!("     Error: {}\n", error_line));
+            let error_display = sanitizer.sanitize(error_line);
+            output.push_str(&format!("     Error: {}\n", error_display));
         }
     }
 
     output
 }
 
-pub fn write_rules_file(rules: &[CorrectionRule], path: &str) -> Result<()> {
+pub fn write_rules_file(rules: &[CorrectionRule], path: &str, sanitizer: &Sanitizer) -> Result<()> {
     let path_obj = Path::new(path);
 
-    // Create parent directory if it doesn't exist
     if let Some(parent) = path_obj.parent() {
         fs::create_dir_all(parent)?;
     }
@@ -67,7 +205,6 @@ pub fn write_rules_file(rules: &[CorrectionRule], path: &str) -> Result<()> {
         return Ok(());
     }
 
-    // Group by base command
     let mut grouped: HashMap<String, Vec<&CorrectionRule>> = HashMap::new();
     for rule in rules {
         grouped
@@ -76,14 +213,12 @@ pub fn write_rules_file(rules: &[CorrectionRule], path: &str) -> Result<()> {
             .push(rule);
     }
 
-    // Sort base commands alphabetically
     let mut base_commands: Vec<String> = grouped.keys().cloned().collect();
     base_commands.sort();
 
     for base_cmd in base_commands {
         let rules_for_cmd = grouped.get(&base_cmd).unwrap();
 
-        // Capitalize first letter for section header
         let section_header = capitalize_first(&base_cmd);
         content.push_str(&format!("## {}\n", section_header));
 
@@ -94,9 +229,12 @@ pub fn write_rules_file(rules: &[CorrectionRule], path: &str) -> Result<()> {
                 String::new()
             };
 
+            let right = sanitizer.sanitize(&rule.right_pattern);
+            let wrong = sanitizer.sanitize(&rule.wrong_pattern);
+
             content.push_str(&format!(
                 "- Use `{}` not `{}`{}\n",
-                rule.right_pattern, rule.wrong_pattern, occurrence_note
+                right, wrong, occurrence_note
             ));
         }
 
@@ -120,16 +258,277 @@ mod tests {
     use super::*;
     use crate::learn::detector::ErrorType;
 
+    fn enabled_sanitizer() -> Sanitizer {
+        Sanitizer {
+            enabled: true,
+            user_patterns: Vec::new(),
+        }
+    }
+
+    fn disabled_sanitizer() -> Sanitizer {
+        Sanitizer {
+            enabled: false,
+            user_patterns: Vec::new(),
+        }
+    }
+
+    // --- Built-in pattern: AWS resource IDs ---
+
     #[test]
-    fn test_format_console_report_empty() {
-        let report = format_console_report(&[], 0, 0, 30);
+    fn sanitize_redacts_aws_resource_ids() {
+        let s = enabled_sanitizer();
+        assert_eq!(
+            s.sanitize("--vpc-ids vpc-0abc123def456789a").as_ref(),
+            "--vpc-ids vpc-<ID>"
+        );
+        assert_eq!(
+            s.sanitize("--group-id sg-038bad75fae68765e").as_ref(),
+            "--group-id sg-<ID>"
+        );
+        assert_eq!(
+            s.sanitize("vpce-0e5a4b26aac99e9bd subnet-0abc123def456789a")
+                .as_ref(),
+            "vpce-<ID> subnet-<ID>"
+        );
+    }
+
+    #[test]
+    fn sanitize_redacts_ec2_instance_ids() {
+        let s = enabled_sanitizer();
+        assert_eq!(
+            s.sanitize("--instance-ids i-0abc123def456789a").as_ref(),
+            "--instance-ids i-<ID>"
+        );
+    }
+
+    // --- Built-in pattern: Route53 ---
+
+    #[test]
+    fn sanitize_redacts_route53_zone_ids() {
+        let s = enabled_sanitizer();
+        assert_eq!(
+            s.sanitize("--hosted-zone-id Z0247406X6CI60Z1JQ2").as_ref(),
+            "--hosted-zone-id Z<ZONE_ID>"
+        );
+    }
+
+    // --- Built-in pattern: AWS account IDs (context-sensitive) ---
+
+    #[test]
+    fn sanitize_redacts_account_ids_after_delimiters() {
+        let s = enabled_sanitizer();
+        // After `::` in ARNs
+        assert_eq!(
+            s.sanitize("arn:aws:iam::123456789012:role/MyRole").as_ref(),
+            "arn:aws:iam::<ACCOUNT_ID>:role/MyRole"
+        );
+        // After `/` in paths
+        assert_eq!(
+            s.sanitize("accounts/123456789012/settings").as_ref(),
+            "accounts/<ACCOUNT_ID>/settings"
+        );
+    }
+
+    #[test]
+    fn sanitize_ignores_bare_12_digit_numbers() {
+        let s = enabled_sanitizer();
+        assert_eq!(s.sanitize("--port 8443").as_ref(), "--port 8443");
+        assert_eq!(
+            s.sanitize("some_value 123456789012").as_ref(),
+            "some_value 123456789012"
+        );
+    }
+
+    // --- Built-in pattern: user home paths ---
+
+    #[test]
+    fn sanitize_redacts_user_home_paths() {
+        let s = enabled_sanitizer();
+        assert_eq!(
+            s.sanitize("/Users/johndoe/projects/myapp/src/main.rs")
+                .as_ref(),
+            "~/projects/myapp/src/main.rs"
+        );
+        assert_eq!(
+            s.sanitize("/home/deploy/services/api").as_ref(),
+            "~/services/api"
+        );
+    }
+
+    // --- Built-in pattern: GitHub org/repo ---
+
+    #[test]
+    fn sanitize_redacts_github_org_repo_in_urls() {
+        let s = enabled_sanitizer();
+        assert_eq!(
+            s.sanitize("gh api repos/my-company/my-service/pulls")
+                .as_ref(),
+            "gh api repos/<org>/<repo>/pulls"
+        );
+        assert_eq!(
+            s.sanitize("git clone https://github.com/acme-corp/platform.git")
+                .as_ref(),
+            "git clone https://github.com/<org>/<repo>"
+        );
+    }
+
+    // --- Built-in pattern: UUIDs ---
+
+    #[test]
+    fn sanitize_redacts_uuids() {
+        let s = enabled_sanitizer();
+        assert_eq!(
+            s.sanitize("--account-id 292bf5a3-e432-483f-b14d-949b412ea11a")
+                .as_ref(),
+            "--account-id <UUID>"
+        );
+        assert_eq!(
+            s.sanitize("correlation_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+                .as_ref(),
+            "correlation_id=<UUID>"
+        );
+    }
+
+    #[test]
+    fn sanitize_redacts_uuids_in_quotes() {
+        let s = enabled_sanitizer();
+        assert_eq!(
+            s.sanitize(r#"export ID="292bf5a3-e432-483f-b14d-949b412ea11a""#)
+                .as_ref(),
+            r#"export ID="<UUID>""#
+        );
+    }
+
+    #[test]
+    fn sanitize_ignores_short_hex_dashes() {
+        let s = enabled_sanitizer();
+        // Short segments that look like UUID fragments but aren't full UUIDs
+        assert_eq!(s.sanitize("tag-abc-123").as_ref(), "tag-abc-123");
+    }
+
+    // --- Built-in pattern: --repo flag ---
+
+    #[test]
+    fn sanitize_redacts_repo_flag() {
+        let s = enabled_sanitizer();
+        assert_eq!(
+            s.sanitize("gh pr diff 123 --repo my-company/services")
+                .as_ref(),
+            "gh pr diff 123 --repo <org>/<repo>"
+        );
+        assert_eq!(
+            s.sanitize("rtk proxy gh pr diff 5721 --repo acme-corp/platform 2>/dev/null")
+                .as_ref(),
+            "rtk proxy gh pr diff 5721 --repo <org>/<repo> 2>/dev/null"
+        );
+    }
+
+    // --- Safe content / edge cases ---
+
+    #[test]
+    fn sanitize_preserves_commands_without_sensitive_data() {
+        let s = enabled_sanitizer();
+        let safe = "git commit --amend -m 'fix typo'";
+        let result = s.sanitize(safe);
+        assert!(
+            matches!(result, Cow::Borrowed(_)),
+            "no-match should be zero-copy"
+        );
+        assert_eq!(result.as_ref(), safe);
+    }
+
+    #[test]
+    fn sanitize_handles_empty_input() {
+        let s = enabled_sanitizer();
+        assert_eq!(s.sanitize("").as_ref(), "");
+    }
+
+    #[test]
+    fn sanitize_applies_multiple_patterns_in_one_command() {
+        let s = enabled_sanitizer();
+        let input = "aws ec2 describe-security-groups --profile prod --group-ids sg-038bad75fae68765e --query 'SecurityGroups[0]' --output yaml 2>&1";
+        let result = s.sanitize(input);
+        assert!(result.contains("sg-<ID>"), "sg ID not redacted");
+        assert!(!result.contains("038bad75fae68765e"), "raw hex leaked");
+    }
+
+    // --- User-defined patterns ---
+
+    #[test]
+    fn sanitize_applies_user_patterns_from_config() {
+        let s = Sanitizer {
+            enabled: true,
+            user_patterns: vec![
+                Regex::new(r"acme-corp\.1password\.com").unwrap(),
+                Regex::new(r"internal\.example\.co").unwrap(),
+            ],
+        };
+        assert_eq!(
+            s.sanitize("op read 'op://Vault/Item' --account acme-corp.1password.com")
+                .as_ref(),
+            "op read 'op://Vault/Item' --account <REDACTED>"
+        );
+        assert_eq!(
+            s.sanitize("kubectl get nodes -l internal.example.co/id")
+                .as_ref(),
+            "kubectl get nodes -l <REDACTED>/id"
+        );
+    }
+
+    #[test]
+    fn sanitize_user_patterns_combine_with_builtins() {
+        let s = Sanitizer {
+            enabled: true,
+            user_patterns: vec![Regex::new(r"secret-project").unwrap()],
+        };
+        let input = "aws ec2 describe-vpcs --vpc-ids vpc-0abc123def456789a --tag secret-project";
+        let result = s.sanitize(input);
+        assert!(result.contains("vpc-<ID>"), "built-in didn't fire");
+        assert!(result.contains("<REDACTED>"), "user pattern didn't fire");
+        assert!(!result.contains("secret-project"), "user data leaked");
+    }
+
+    #[test]
+    fn sanitize_multiple_user_patterns_chain_correctly() {
+        let s = Sanitizer {
+            enabled: true,
+            user_patterns: vec![
+                Regex::new(r"first-secret").unwrap(),
+                Regex::new(r"second-secret").unwrap(),
+            ],
+        };
+        let input = "cmd --a first-secret --b second-secret";
+        let result = s.sanitize(input);
+        assert!(!result.contains("first-secret"), "first pattern missed");
+        assert!(!result.contains("second-secret"), "second pattern missed");
+        assert_eq!(result.as_ref(), "cmd --a <REDACTED> --b <REDACTED>");
+    }
+
+    // --- Disabled sanitizer ---
+
+    #[test]
+    fn disabled_sanitizer_returns_input_unchanged() {
+        let s = disabled_sanitizer();
+        let input = "aws ec2 describe-vpcs --vpc-ids vpc-0abc123def456789a";
+        // Cow::Borrowed means zero allocation
+        let result = s.sanitize(input);
+        assert!(matches!(result, Cow::Borrowed(_)), "should be zero-copy");
+        assert_eq!(result.as_ref(), input);
+    }
+
+    // --- Console report ---
+
+    #[test]
+    fn format_console_report_shows_header_for_empty_rules() {
+        let s = disabled_sanitizer();
+        let report = format_console_report(&[], 0, 0, 30, &s);
         assert!(report.contains("0 rules"));
-        assert!(report.contains("0 corrections"));
         assert!(report.contains("No CLI corrections detected"));
     }
 
     #[test]
-    fn test_format_console_report_with_rules() {
+    fn format_console_report_includes_counts_and_errors() {
+        let s = disabled_sanitizer();
         let rules = vec![
             CorrectionRule {
                 wrong_pattern: "git commit --ammend".to_string(),
@@ -149,17 +548,36 @@ mod tests {
             },
         ];
 
-        let report = format_console_report(&rules, 4, 10, 30);
+        let report = format_console_report(&rules, 4, 10, 30, &s);
         assert!(report.contains("2 rules"));
         assert!(report.contains("4 corrections"));
         assert!(report.contains("[3x]"));
         assert!(report.contains("--ammend"));
-        assert!(report.contains("--amend"));
         assert!(report.contains("Error: error: unexpected argument"));
     }
 
     #[test]
-    fn test_write_rules_file_markdown() {
+    fn format_console_report_redacts_when_sanitized() {
+        let s = enabled_sanitizer();
+        let rules = vec![CorrectionRule {
+            wrong_pattern: "aws ec2 describe-vpcs --vpc-ids vpc-0abc123def456789a".to_string(),
+            right_pattern: "aws ec2 describe-vpcs --output table".to_string(),
+            error_type: ErrorType::Other("General Error".to_string()),
+            occurrences: 1,
+            base_command: "aws ec2".to_string(),
+            example_error: "error: invalid vpc id".to_string(),
+        }];
+
+        let report = format_console_report(&rules, 1, 1, 30, &s);
+        assert!(report.contains("vpc-<ID>"));
+        assert!(!report.contains("0abc123def456789a"));
+    }
+
+    // --- Markdown rules file ---
+
+    #[test]
+    fn write_rules_file_produces_grouped_markdown() {
+        let s = disabled_sanitizer();
         let rules = vec![CorrectionRule {
             wrong_pattern: "git commit --ammend".to_string(),
             right_pattern: "git commit --amend".to_string(),
@@ -173,12 +591,36 @@ mod tests {
         let path = temp_dir.path().join("cli-corrections.md");
         let path_str = path.to_str().unwrap();
 
-        write_rules_file(&rules, path_str).unwrap();
+        write_rules_file(&rules, path_str, &s).unwrap();
 
         let content = fs::read_to_string(&path).unwrap();
         assert!(content.contains("# CLI Corrections"));
         assert!(content.contains("## Git commit"));
         assert!(content.contains("Use `git commit --amend` not `git commit --ammend`"));
         assert!(content.contains("(seen 3x)"));
+    }
+
+    #[test]
+    fn write_rules_file_redacts_when_sanitized() {
+        let s = enabled_sanitizer();
+        let rules = vec![CorrectionRule {
+            wrong_pattern: "aws ec2 describe-security-groups --group-ids sg-038bad75fae68765e"
+                .to_string(),
+            right_pattern: "aws ec2 describe-security-groups --output table".to_string(),
+            error_type: ErrorType::Other("General Error".to_string()),
+            occurrences: 1,
+            base_command: "aws ec2".to_string(),
+            example_error: "error".to_string(),
+        }];
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("cli-corrections.md");
+        let path_str = path.to_str().unwrap();
+
+        write_rules_file(&rules, path_str, &s).unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("sg-<ID>"));
+        assert!(!content.contains("038bad75fae68765e"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -591,6 +591,9 @@ enum Commands {
         /// Minimum occurrences to include in report
         #[arg(long, default_value = "1")]
         min_occurrences: usize,
+        /// Disable sanitization of sensitive data (IDs, paths, accounts) in output
+        #[arg(long)]
+        no_sanitize: bool,
     },
 
     /// Execute command without filtering but track usage
@@ -1884,6 +1887,7 @@ fn main() -> Result<()> {
             write_rules,
             min_confidence,
             min_occurrences,
+            no_sanitize,
         } => {
             learn::run(
                 project,
@@ -1893,6 +1897,7 @@ fn main() -> Result<()> {
                 write_rules,
                 min_confidence,
                 min_occurrences,
+                !no_sanitize,
             )?;
         }
 


### PR DESCRIPTION
## Summary

`rtk learn --write-rules` outputs raw command pairs that often contain sensitive infrastructure identifiers. These get auto-loaded into Claude Code sessions if the generated rules file is committed.

This PR adds a `Sanitizer` that redacts sensitive patterns from all output formats by default, with user-extensible patterns via `config.toml`.

### Built-in patterns (8)

| Pattern | Replacement | Context guard |
|---------|------------|---------------|
| `vpc-*`, `sg-*`, `subnet-*`, `vpce-*`, + 7 more | `{prefix}-<ID>` | Word boundary + hex `[0-9a-f]{8,17}` |
| `i-*` (EC2 instances) | `i-<ID>` | Separate regex — short prefix needs own match |
| Route53 zone IDs | `Z<ZONE_ID>` | `Z` + `[0-9A-Z]{10,32}` |
| AWS account IDs | `<ACCOUNT_ID>` | Only after `::`, `:`, or `/` — ignores bare numbers |
| `/Users/name/...`, `/home/name/...` | `~/...` | Absolute home paths only |
| `github.com/org/repo`, `repos/org/repo` | `{prefix}<org>/<repo>` | URL and `gh api` path patterns |
| UUIDs | `<UUID>` | Standard 8-4-4-4-12 hex format |
| `--repo org/repo` | `--repo <org>/<repo>` | CLI flag pattern (not caught by URL regex) |

### User-defined patterns via config.toml

```toml
[learn]
sanitize_patterns = [
    "my-company-name",
    "internal\\.example\\.co",
]
```

Compiled as regexes, applied after built-in patterns. Matches replaced with `<REDACTED>`. Invalid patterns warn on stderr and are skipped.

### Flags

Sanitization is **on by default**. `--no-sanitize` restores raw output.

## Design

`Sanitizer` struct constructed once, passed by `&Sanitizer` to all output functions:

- `sanitize()` returns `Cow<str>` — uses `Option<String>` to track whether any pattern matched. Zero allocation when disabled or when no pattern fires.
- Individual named `lazy_static!` regexes match the existing `detector.rs` conventions.
- `apply!` macro eliminates repetition while correctly handling the `Option<String>` → `&str` → `Cow` borrow chain.

## Changes

| File | What |
|------|------|
| `src/learn/report.rs` | `Sanitizer` struct, 8 named regexes, `apply!` macro, updated output functions, 23 tests |
| `src/learn/mod.rs` | Uses `Sanitizer`, sanitizes JSON output (was a gap in original code) |
| `src/config.rs` | `LearnConfig` with `sanitize_patterns: Vec<String>` |
| `src/main.rs` | `--no-sanitize` CLI flag |
| `CHANGELOG.md` | `[Unreleased]` entry |

## Verification

Local (rustc 1.94.0, macOS aarch64):

- `cargo fmt --all --check` — our files clean
- `cargo clippy --all-targets` — no warnings from our code
- `cargo test` — **954 passed, 0 failed, 3 ignored**
- E2E: built binary, ran against 62 real sessions containing AWS IDs, Route53 zones, Databricks UUIDs, GitHub org/repo refs. Verified all 8 pattern types redacted in text output, JSON output, and `--write-rules` file. Verified `--no-sanitize` preserves raw. Verified `Cow::Borrowed` for disabled and no-match paths.

### 23 tests:

| Category | Tests |
|----------|-------|
| AWS resource IDs | `sanitize_redacts_aws_resource_ids`, `sanitize_redacts_ec2_instance_ids` |
| Route53 | `sanitize_redacts_route53_zone_ids` |
| Account IDs | `sanitize_redacts_account_ids_after_delimiters`, `sanitize_ignores_bare_12_digit_numbers` |
| User paths | `sanitize_redacts_user_home_paths` |
| GitHub URLs | `sanitize_redacts_github_org_repo_in_urls` |
| UUIDs | `sanitize_redacts_uuids`, `sanitize_redacts_uuids_in_quotes`, `sanitize_ignores_short_hex_dashes` |
| --repo flag | `sanitize_redacts_repo_flag` |
| Safe content | `sanitize_preserves_commands_without_sensitive_data` (verifies `Cow::Borrowed`), `sanitize_handles_empty_input` |
| Multi-pattern | `sanitize_applies_multiple_patterns_in_one_command` |
| User patterns | `sanitize_applies_user_patterns_from_config`, `sanitize_user_patterns_combine_with_builtins`, `sanitize_multiple_user_patterns_chain_correctly` |
| Disabled | `disabled_sanitizer_returns_input_unchanged` (verifies `Cow::Borrowed`) |
| Console report | `format_console_report_shows_header_for_empty_rules`, `format_console_report_includes_counts_and_errors`, `format_console_report_redacts_when_sanitized` |
| Markdown file | `write_rules_file_produces_grouped_markdown`, `write_rules_file_redacts_when_sanitized` |

Closes #651