### PR TITLE
fix: resolve cargo fmt + 54 clippy warnings blocking CI

### DIFF
--- a/src/cc_economics.rs
+++ b/src/cc_economics.rs
@@ -14,6 +14,7 @@ use crate::utils::{format_cpt, format_tokens, format_usd};
 
 // ── Constants ──
 
+#[allow(dead_code)]
 const BILLION: f64 = 1e9;
 
 // API pricing ratios (verified Feb 2026, consistent across Claude models <=200K context)

--- a/src/ccusage.rs
+++ b/src/ccusage.rs
@@ -112,6 +112,7 @@ fn build_command() -> Option<Command> {
 }
 
 /// Check if ccusage CLI is available (binary or via npx)
+#[allow(dead_code)]
 pub fn is_available() -> bool {
     build_command().is_some()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -124,9 +124,7 @@ impl Default for LimitsConfig {
 
 /// Get limits config. Falls back to defaults if config can't be loaded.
 pub fn limits() -> LimitsConfig {
-    Config::load()
-        .map(|c| c.limits)
-        .unwrap_or_default()
+    Config::load().map(|c| c.limits).unwrap_or_default()
 }
 
 /// Check if telemetry is enabled in config. Returns None if config can't be loaded.

--- a/src/container.rs
+++ b/src/container.rs
@@ -67,7 +67,12 @@ fn docker_ps(_verbose: u8) -> Result<()> {
         if parts.len() >= 4 {
             let id = &parts[0][..12.min(parts[0].len())];
             let name = parts[1];
-            let short_image = parts.get(3).unwrap_or(&"").split('/').last().unwrap_or("");
+            let short_image = parts
+                .get(3)
+                .unwrap_or(&"")
+                .split('/')
+                .next_back()
+                .unwrap_or("");
             let ports = compact_ports(parts.get(4).unwrap_or(&""));
             if ports == "-" {
                 rtk.push_str(&format!("  {} {} ({})\n", id, name, short_image));
@@ -562,7 +567,7 @@ fn compact_ports(ports: &str) -> String {
     // Extract just the port numbers
     let port_nums: Vec<&str> = ports
         .split(',')
-        .filter_map(|p| p.split("->").next().and_then(|s| s.split(':').last()))
+        .filter_map(|p| p.split("->").next().and_then(|s| s.split(':').next_back()))
         .collect();
 
     if port_nums.len() <= 3 {

--- a/src/discover/provider.rs
+++ b/src/discover/provider.rs
@@ -18,6 +18,7 @@ pub struct ExtractedCommand {
     /// Whether the tool_result indicated an error
     pub is_error: bool,
     /// Chronological sequence index within the session
+    #[allow(dead_code)]
     pub sequence_index: usize,
 }
 
@@ -347,7 +348,7 @@ mod tests {
         let cmds = provider.extract_commands(jsonl.path()).unwrap();
         assert_eq!(cmds.len(), 1);
         assert_eq!(cmds[0].command, "git commit --ammend");
-        assert_eq!(cmds[0].is_error, true);
+        assert!(cmds[0].is_error);
         assert!(cmds[0].output_content.is_some());
         assert_eq!(
             cmds[0].output_content.as_ref().unwrap(),
@@ -365,8 +366,8 @@ mod tests {
         let provider = ClaudeProvider;
         let cmds = provider.extract_commands(jsonl.path()).unwrap();
         assert_eq!(cmds.len(), 2);
-        assert_eq!(cmds[0].is_error, false);
-        assert_eq!(cmds[1].is_error, true);
+        assert!(!cmds[0].is_error);
+        assert!(cmds[1].is_error);
     }
 
     #[test]

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -679,12 +679,10 @@ mod tests {
             "tail -f app.log > /dev/null",
         ];
         for cmd in &write_commands {
-            match classify_command(cmd) {
-                Classification::Supported { .. } => {
-                    panic!("{} should NOT be classified as Supported", cmd)
-                }
-                _ => {} // Unsupported or Ignored is fine
+            if let Classification::Supported { .. } = classify_command(cmd) {
+                panic!("{} should NOT be classified as Supported", cmd)
             }
+            // Unsupported or Ignored is fine
         }
     }
 

--- a/src/format_cmd.rs
+++ b/src/format_cmd.rs
@@ -168,7 +168,7 @@ fn filter_black_output(output: &str) -> String {
             // Split by comma to handle both parts
             for part in trimmed.split(',') {
                 let part_lower = part.to_lowercase();
-                let words: Vec<&str> = part.trim().split_whitespace().collect();
+                let words: Vec<&str> = part.split_whitespace().collect();
 
                 if part_lower.contains("would be reformatted") {
                     // Parse "X file(s) would be reformatted"

--- a/src/gain.rs
+++ b/src/gain.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 use std::io::IsTerminal;
 use std::path::PathBuf;
 
+#[allow(clippy::too_many_arguments)]
 pub fn run(
     project: bool, // added: per-project scope flag
     graph: bool,

--- a/src/gh_cmd.rs
+++ b/src/gh_cmd.rs
@@ -193,8 +193,8 @@ fn run_pr(args: &[String], verbose: u8, ultra_compact: bool) -> Result<()> {
         "create" => pr_create(&args[1..], verbose),
         "merge" => pr_merge(&args[1..], verbose),
         "diff" => pr_diff(&args[1..], verbose),
-        "comment" => pr_action("commented", &args, verbose),
-        "edit" => pr_action("edited", &args, verbose),
+        "comment" => pr_action("commented", args, verbose),
+        "edit" => pr_action("edited", args, verbose),
         _ => run_passthrough("gh", "pr", args),
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -356,7 +356,7 @@ fn run_log(
 
     // Check if user provided limit flag (-N, -n N, --max-count=N, --max-count N)
     let has_limit_flag = args.iter().any(|arg| {
-        (arg.starts_with('-') && arg.chars().nth(1).map_or(false, |c| c.is_ascii_digit()))
+        (arg.starts_with('-') && arg.chars().nth(1).is_some_and(|c| c.is_ascii_digit()))
             || arg == "-n"
             || arg.starts_with("--max-count")
     });
@@ -434,7 +434,7 @@ fn parse_user_limit(args: &[String]) -> Option<usize> {
         // -20 (combined digit form)
         if arg.starts_with('-')
             && arg.len() > 1
-            && arg.chars().nth(1).map_or(false, |c| c.is_ascii_digit())
+            && arg.chars().nth(1).is_some_and(|c| c.is_ascii_digit())
         {
             if let Ok(n) = arg[1..].parse::<usize>() {
                 return Some(n);
@@ -603,7 +603,10 @@ fn format_status_output(porcelain: &str) -> String {
             output.push_str(&format!("   {}\n", f));
         }
         if staged_files.len() > max_files {
-            output.push_str(&format!("   ... +{} more\n", staged_files.len() - max_files));
+            output.push_str(&format!(
+                "   ... +{} more\n",
+                staged_files.len() - max_files
+            ));
         }
     }
 
@@ -613,7 +616,10 @@ fn format_status_output(porcelain: &str) -> String {
             output.push_str(&format!("   {}\n", f));
         }
         if modified_files.len() > max_files {
-            output.push_str(&format!("   ... +{} more\n", modified_files.len() - max_files));
+            output.push_str(&format!(
+                "   ... +{} more\n",
+                modified_files.len() - max_files
+            ));
         }
     }
 
@@ -623,7 +629,10 @@ fn format_status_output(porcelain: &str) -> String {
             output.push_str(&format!("   {}\n", f));
         }
         if untracked_files.len() > max_untracked {
-            output.push_str(&format!("   ... +{} more\n", untracked_files.len() - max_untracked));
+            output.push_str(&format!(
+                "   ... +{} more\n",
+                untracked_files.len() - max_untracked
+            ));
         }
     }
 
@@ -838,7 +847,7 @@ fn run_commit(args: &[String], verbose: u8, global_args: &[String]) -> Result<()
         // Extract commit hash from output like "[main abc1234] message"
         let compact = if let Some(line) = stdout.lines().next() {
             if let Some(hash_start) = line.find(' ') {
-                let hash = line[1..hash_start].split(' ').last().unwrap_or("");
+                let hash = line[1..hash_start].split(' ').next_back().unwrap_or("");
                 if !hash.is_empty() && hash.len() >= 7 {
                     format!("ok ✓ {}", &hash[..7.min(hash.len())])
                 } else {

--- a/src/golangci_cmd.rs
+++ b/src/golangci_cmd.rs
@@ -10,8 +10,10 @@ struct Position {
     #[serde(rename = "Filename")]
     filename: String,
     #[serde(rename = "Line")]
+    #[allow(dead_code)]
     line: usize,
     #[serde(rename = "Column")]
+    #[allow(dead_code)]
     column: usize,
 }
 
@@ -20,6 +22,7 @@ struct Issue {
     #[serde(rename = "FromLinter")]
     from_linter: String,
     #[serde(rename = "Text")]
+    #[allow(dead_code)]
     text: String,
     #[serde(rename = "Pos")]
     pos: Position,

--- a/src/grep_cmd.rs
+++ b/src/grep_cmd.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result};
 use regex::Regex;
 use std::collections::HashMap;
 
+#[allow(clippy::too_many_arguments)]
 pub fn run(
     pattern: &str,
     path: &str,

--- a/src/init.rs
+++ b/src/init.rs
@@ -507,7 +507,7 @@ pub fn uninstall(global: bool, verbose: u8) -> Result<()> {
             fs::write(&claude_md_path, cleaned).with_context(|| {
                 format!("Failed to write CLAUDE.md: {}", claude_md_path.display())
             })?;
-            removed.push(format!("CLAUDE.md: removed @RTK.md reference"));
+            removed.push("CLAUDE.md: removed @RTK.md reference".to_string());
         }
     }
 
@@ -566,7 +566,7 @@ fn patch_settings_json(
     };
 
     // Check idempotency
-    if hook_already_present(&root, &hook_command) {
+    if hook_already_present(&root, hook_command) {
         if verbose > 0 {
             eprintln!("settings.json: hook already present");
         }
@@ -591,7 +591,7 @@ fn patch_settings_json(
     }
 
     // Deep-merge hook
-    insert_hook_entry(&mut root, &hook_command);
+    insert_hook_entry(&mut root, hook_command);
 
     // Backup original
     if settings_path.exists() {
@@ -637,7 +637,6 @@ fn clean_double_blanks(content: &str) -> String {
         if line.trim().is_empty() {
             // Count consecutive blank lines
             let mut blank_count = 0;
-            let start = i;
             while i < lines.len() && lines[i].trim().is_empty() {
                 blank_count += 1;
                 i += 1;
@@ -645,9 +644,7 @@ fn clean_double_blanks(content: &str) -> String {
 
             // Keep at most 2 blank lines
             let keep = blank_count.min(2);
-            for _ in 0..keep {
-                result.push("");
-            }
+            result.extend(std::iter::repeat_n("", keep));
         } else {
             result.push(line);
             i += 1;
@@ -1405,7 +1402,6 @@ fn run_opencode_only_mode(verbose: u8) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::Path;
     use tempfile::TempDir;
 
     #[test]
@@ -1774,8 +1770,8 @@ More notes
         let serialized = serde_json::to_string(&parsed).unwrap();
 
         // Keys should appear in same order
-        let original_keys: Vec<&str> = original.split("\"").filter(|s| s.contains(":")).collect();
-        let serialized_keys: Vec<&str> =
+        let _original_keys: Vec<&str> = original.split("\"").filter(|s| s.contains(":")).collect();
+        let _serialized_keys: Vec<&str> =
             serialized.split("\"").filter(|s| s.contains(":")).collect();
 
         // Just check that keys exist (preserve_order doesn't guarantee exact order in nested objects)

--- a/src/learn/detector.rs
+++ b/src/learn/detector.rs
@@ -5,6 +5,7 @@ use regex::Regex;
 pub enum ErrorType {
     UnknownFlag,
     CommandNotFound,
+    #[allow(dead_code)]
     WrongSyntax,
     WrongPath,
     MissingArg,
@@ -229,9 +230,7 @@ pub fn find_corrections(commands: &[CommandExecution]) -> Vec<CorrectionPair> {
         }
 
         // Look ahead for correction within CORRECTION_WINDOW
-        for j in (i + 1)..std::cmp::min(i + 1 + CORRECTION_WINDOW, commands.len()) {
-            let candidate = &commands[j];
-
+        for candidate in commands.iter().skip(i + 1).take(CORRECTION_WINDOW) {
             let similarity = command_similarity(&cmd.command, &candidate.command);
 
             // Must meet minimum similarity

--- a/src/lint_cmd.rs
+++ b/src/lint_cmd.rs
@@ -36,11 +36,13 @@ struct PylintDiagnostic {
     module: String,
     #[allow(dead_code)]
     obj: String,
+    #[allow(dead_code)]
     line: usize,
     #[allow(dead_code)]
     column: usize,
     path: String,
     symbol: String, // rule code like "unused-variable"
+    #[allow(dead_code)]
     message: String,
     #[serde(rename = "message-id")]
     message_id: String, // e.g., "W0612"

--- a/src/log_cmd.rs
+++ b/src/log_cmd.rs
@@ -105,7 +105,7 @@ fn analyze_logs(content: &str) -> String {
     let total_warnings: usize = warn_counts.values().sum();
     let total_info: usize = info_counts.values().sum();
 
-    result.push(format!("📊 Log Summary"));
+    result.push("📊 Log Summary".to_string());
     result.push(format!(
         "   ❌ {} errors ({} unique)",
         total_errors,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1179,11 +1179,11 @@ enum GtCommands {
 fn shell_split(input: &str) -> Vec<String> {
     let mut tokens = Vec::new();
     let mut current = String::new();
-    let mut chars = input.chars().peekable();
+    let chars = input.chars();
     let mut in_single = false;
     let mut in_double = false;
 
-    while let Some(c) = chars.next() {
+    for c in chars {
         match c {
             '\'' if !in_double => in_single = !in_single,
             '"' if !in_single => in_double = !in_double,

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -2,6 +2,7 @@
 use thiserror::Error;
 
 #[derive(Error, Debug)]
+#[allow(dead_code)]
 pub enum ParseError {
     #[error("JSON parse failed at line {line}, column {col}: {msg}")]
     JsonError {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -29,6 +29,7 @@ pub enum ParseResult<T> {
 
 impl<T> ParseResult<T> {
     /// Unwrap the parsed data, panicking on Passthrough
+    #[allow(dead_code)]
     pub fn unwrap(self) -> T {
         match self {
             ParseResult::Full(data) => data,
@@ -38,6 +39,7 @@ impl<T> ParseResult<T> {
     }
 
     /// Get the tier level (1 = Full, 2 = Degraded, 3 = Passthrough)
+    #[allow(dead_code)]
     pub fn tier(&self) -> u8 {
         match self {
             ParseResult::Full(_) => 1,
@@ -47,11 +49,13 @@ impl<T> ParseResult<T> {
     }
 
     /// Check if parsing succeeded (Full or Degraded)
+    #[allow(dead_code)]
     pub fn is_ok(&self) -> bool {
         !matches!(self, ParseResult::Passthrough(_))
     }
 
     /// Map the parsed data while preserving tier
+    #[allow(dead_code)]
     pub fn map<U, F>(self, f: F) -> ParseResult<U>
     where
         F: FnOnce(T) -> U,
@@ -64,6 +68,7 @@ impl<T> ParseResult<T> {
     }
 
     /// Get warnings if Degraded tier
+    #[allow(dead_code)]
     pub fn warnings(&self) -> Vec<String> {
         match self {
             ParseResult::Degraded(_, warnings) => warnings.clone(),
@@ -85,6 +90,7 @@ pub trait OutputParser: Sized {
     fn parse(input: &str) -> ParseResult<Self::Output>;
 
     /// Parse with explicit tier preference (for testing/debugging)
+    #[allow(dead_code)]
     fn parse_with_tier(input: &str, max_tier: u8) -> ParseResult<Self::Output> {
         let result = Self::parse(input);
         if result.tier() > max_tier {

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -23,6 +23,7 @@ pub struct TestFailure {
 
 /// Linting result (eslint, biome, tsc, etc.)
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(dead_code)]
 pub struct LintResult {
     pub total_files: usize,
     pub files_with_issues: usize,
@@ -33,6 +34,7 @@ pub struct LintResult {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(dead_code)]
 pub struct LintIssue {
     pub file_path: String,
     pub line: usize,
@@ -43,6 +45,7 @@ pub struct LintIssue {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[allow(dead_code)]
 pub enum LintSeverity {
     Error,
     Warning,
@@ -68,6 +71,7 @@ pub struct Dependency {
 
 /// Build output (next, webpack, vite, cargo, etc.)
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(dead_code)]
 pub struct BuildOutput {
     pub success: bool,
     pub duration_ms: Option<u64>,
@@ -78,6 +82,7 @@ pub struct BuildOutput {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(dead_code)]
 pub struct BundleInfo {
     pub name: String,
     pub size_bytes: u64,
@@ -85,6 +90,7 @@ pub struct BundleInfo {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(dead_code)]
 pub struct RouteInfo {
     pub path: String,
     pub size_kb: f64,
@@ -93,6 +99,7 @@ pub struct RouteInfo {
 
 /// Git operation result
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(dead_code)]
 pub struct GitResult {
     pub operation: String,
     pub files_changed: usize,
@@ -102,6 +109,7 @@ pub struct GitResult {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(dead_code)]
 pub struct GitCommit {
     pub hash: String,
     pub author: String,
@@ -111,6 +119,7 @@ pub struct GitCommit {
 
 /// Generic command output (for tools without specific types)
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(dead_code)]
 pub struct GenericOutput {
     pub exit_code: i32,
     pub stdout: String,

--- a/src/pip_cmd.rs
+++ b/src/pip_cmd.rs
@@ -216,11 +216,7 @@ fn filter_pip_outdated(output: &str) -> String {
     result.push_str("═══════════════════════════════════════\n");
 
     for (i, pkg) in packages.iter().take(20).enumerate() {
-        let latest = pkg
-            .latest_version
-            .as_ref()
-            .map(|v| v.as_str())
-            .unwrap_or("unknown");
+        let latest = pkg.latest_version.as_deref().unwrap_or("unknown");
         result.push_str(&format!(
             "{}. {} ({} → {})\n",
             i + 1,

--- a/src/playwright_cmd.rs
+++ b/src/playwright_cmd.rs
@@ -5,8 +5,8 @@ use regex::Regex;
 use serde::Deserialize;
 
 use crate::parser::{
-    emit_degradation_warning, emit_passthrough_warning, truncate_passthrough, FormatMode, OutputParser,
-    ParseResult, TestFailure, TestResult, TokenFormatter,
+    emit_degradation_warning, emit_passthrough_warning, truncate_passthrough, FormatMode,
+    OutputParser, ParseResult, TestFailure, TestResult, TokenFormatter,
 };
 
 /// Matches real Playwright JSON reporter output (suites → specs → tests → results)

--- a/src/ruff_cmd.rs
+++ b/src/ruff_cmd.rs
@@ -7,7 +7,9 @@ use std::collections::HashMap;
 
 #[derive(Debug, Deserialize)]
 struct RuffLocation {
+    #[allow(dead_code)]
     row: usize,
+    #[allow(dead_code)]
     column: usize,
 }
 
@@ -20,7 +22,9 @@ struct RuffFix {
 #[derive(Debug, Deserialize)]
 struct RuffDiagnostic {
     code: String,
+    #[allow(dead_code)]
     message: String,
+    #[allow(dead_code)]
     location: RuffLocation,
     #[allow(dead_code)]
     end_location: Option<RuffLocation>,
@@ -238,7 +242,7 @@ pub fn filter_ruff_format(output: &str) -> String {
             for part in parts {
                 let part_lower = part.to_lowercase();
                 if part_lower.contains("left unchanged") {
-                    let words: Vec<&str> = part.trim().split_whitespace().collect();
+                    let words: Vec<&str> = part.split_whitespace().collect();
                     // Look for number before "file" or "files"
                     for (i, word) in words.iter().enumerate() {
                         if (word == &"file" || word == &"files") && i > 0 {

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -96,10 +96,11 @@ fn detect_output_type(output: &str, command: &str) -> OutputType {
         OutputType::JsonOutput
     } else if output.lines().all(|l| {
         l.len() < 200
-            && !l
-                .contains('\t')
-                .then_some(true)
-                .unwrap_or(l.split_whitespace().count() < 10)
+            && if l.contains('\t') {
+                false
+            } else {
+                l.split_whitespace().count() < 10
+            }
     }) {
         OutputType::ListOutput
     } else {

--- a/src/tee.rs
+++ b/src/tee.rs
@@ -182,18 +182,13 @@ pub fn tee_and_hint(raw: &str, command_slug: &str, exit_code: i32) -> Option<Str
 }
 
 /// TeeMode controls when tee writes files.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum TeeMode {
+    #[default]
     Failures,
     Always,
     Never,
-}
-
-impl Default for TeeMode {
-    fn default() -> Self {
-        Self::Failures
-    }
 }
 
 /// Configuration for the tee feature.

--- a/src/toml_filter.rs
+++ b/src/toml_filter.rs
@@ -574,7 +574,7 @@ pub fn run_filter_tests(filter_name_opt: Option<&str>) -> VerifyResults {
         .into_iter()
         .filter(|name| {
             // When a specific filter is requested, only report that one as missing tests
-            filter_name_opt.map_or(true, |f| name == f)
+            filter_name_opt.is_none_or(|f| name == f)
         })
         .filter(|name| !tested_filter_names.contains(name))
         .collect();

--- a/src/tracking.rs
+++ b/src/tracking.rs
@@ -221,6 +221,9 @@ pub struct MonthStats {
     pub avg_time_ms: u64,
 }
 
+/// Type alias for command statistics tuple: (command, count, saved_tokens, avg_savings_pct, avg_time_ms)
+type CommandStats = (String, usize, usize, f64, u64);
+
 impl Tracker {
     /// Create a new tracker instance.
     ///
@@ -494,6 +497,7 @@ impl Tracker {
     ///     summary.total_saved, summary.avg_savings_pct);
     /// # Ok::<(), anyhow::Error>(())
     /// ```
+    #[allow(dead_code)]
     pub fn get_summary(&self) -> Result<GainSummary> {
         self.get_summary_filtered(None) // delegate to filtered variant
     }
@@ -566,7 +570,7 @@ impl Tracker {
     fn get_by_command(
         &self,
         project_path: Option<&str>, // added
-    ) -> Result<Vec<(String, usize, usize, f64, u64)>> {
+    ) -> Result<Vec<CommandStats>> {
         let (project_exact, project_glob) = project_filter_params(project_path); // added
         let mut stmt = self.conn.prepare(
             "SELECT rtk_cmd, COUNT(*), SUM(saved_tokens), AVG(savings_pct), AVG(exec_time_ms)
@@ -857,6 +861,7 @@ impl Tracker {
     /// }
     /// # Ok::<(), anyhow::Error>(())
     /// ```
+    #[allow(dead_code)]
     pub fn get_recent(&self, limit: usize) -> Result<Vec<CommandRecord>> {
         self.get_recent_filtered(limit, None) // delegate to filtered variant
     }
@@ -977,6 +982,7 @@ fn get_db_path() -> Result<PathBuf> {
 pub struct ParseFailureRecord {
     pub timestamp: String,
     pub raw_command: String,
+    #[allow(dead_code)]
     pub error_message: String,
     pub fallback_succeeded: bool,
 }
@@ -1181,6 +1187,7 @@ pub fn args_display(args: &[OsString]) -> String {
 /// timer.track("ls -la", "rtk ls", "input", "output");
 /// ```
 #[deprecated(note = "Use TimedExecution instead")]
+#[allow(dead_code)]
 pub fn track(original_cmd: &str, rtk_cmd: &str, input: &str, output: &str) {
     let input_tokens = estimate_tokens(input);
     let output_tokens = estimate_tokens(output);

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -125,7 +125,7 @@ fn filter_tree_output(raw: &str) -> String {
     }
 
     // Remove trailing empty lines
-    while filtered_lines.last().map_or(false, |l| l.trim().is_empty()) {
+    while filtered_lines.last().is_some_and(|l| l.trim().is_empty()) {
         filtered_lines.pop();
     }
 

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -140,6 +140,7 @@ pub fn check_trust(filter_path: &Path) -> Result<TrustStatus> {
 }
 
 /// Store current SHA-256 hash as trusted (computes hash from file).
+#[allow(dead_code)]
 pub fn trust_filter(filter_path: &Path) -> Result<()> {
     let hash = integrity::compute_hash(filter_path)
         .with_context(|| format!("Failed to hash: {}", filter_path.display()))?;

--- a/src/wc_cmd.rs
+++ b/src/wc_cmd.rs
@@ -167,7 +167,7 @@ fn format_single_line(line: &str, mode: &WcMode) -> String {
         WcMode::Mixed => {
             // Strip file path, keep numbers only
             if parts.len() >= 2 {
-                let last_is_path = parts.last().map_or(false, |p| p.parse::<u64>().is_err());
+                let last_is_path = parts.last().is_some_and(|p| p.parse::<u64>().is_err());
                 if last_is_path {
                     parts[..parts.len() - 1].join(" ")
                 } else {
@@ -202,7 +202,7 @@ fn format_multi_line(lines: &[&str], mode: &WcMode) -> String {
             continue;
         }
 
-        let is_total = parts.last().map_or(false, |p| *p == "total");
+        let is_total = parts.last().is_some_and(|p| *p == "total");
 
         match mode {
             WcMode::Lines | WcMode::Words | WcMode::Bytes | WcMode::Chars => {
@@ -236,7 +236,7 @@ fn format_multi_line(lines: &[&str], mode: &WcMode) -> String {
                     let nums: Vec<&str> = parts[..parts.len() - 1].to_vec();
                     result.push(format!("Σ {}", nums.join(" ")));
                 } else if parts.len() >= 2 {
-                    let last_is_path = parts.last().map_or(false, |p| p.parse::<u64>().is_err());
+                    let last_is_path = parts.last().is_some_and(|p| p.parse::<u64>().is_err());
                     if last_is_path {
                         let name = strip_prefix(parts.last().unwrap_or(&""), &common_prefix);
                         let nums: Vec<&str> = parts[..parts.len() - 1].to_vec();

--- a/src/wget_cmd.rs
+++ b/src/wget_cmd.rs
@@ -218,6 +218,7 @@ fn compact_url(url: &str) -> String {
     }
 }
 
+#[allow(dead_code)]
 fn parse_error(stderr: &str, stdout: &str) -> String {
     // Common wget error patterns
     let combined = format!("{}\n{}", stderr, stdout);


### PR DESCRIPTION
## Summary
- Fix `cargo fmt` diffs in config.rs, git.rs, playwright_cmd.rs that were failing the fmt CI check
- Resolve all 54 clippy warnings across 31 files (dead code annotations, iterator simplifications, assert patterns, unnecessary allocations)
- Unblocks CI for PRs #632, #635, #638 which were cascading-failed (fmt → clippy → test → security all SKIPPED)

## Test plan
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — 0 warnings
- [x] `cargo test --all` — 934 passed, 0 failed