### PR TITLE
fix(pytest): handle xfailed summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -340,6 +340,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 * **cargo clippy:** include actionable error details in compact output instead of summary-only counts ([#602](https://github.com/rtk-ai/rtk/issues/602))
+* **pytest:** report `xfailed` tests separately instead of counting them as failures ([#672](https://github.com/rtk-ai/rtk/issues/672))
 * **curl:** skip JSON schema replacement when schema is larger than original payload ([#297](https://github.com/rtk-ai/rtk/issues/297))
 * **toml-dsl:** fix regex overmatch on `tofu-plan/init/validate/fmt` and `mix-format/compile` — add `(\s|$)` word boundary to prevent matching subcommands (e.g. `tofu planet`, `mix formats`) ([#349](https://github.com/rtk-ai/rtk/issues/349))
 * **toml-dsl:** remove 3 dead built-in filters (`docker-inspect`, `docker-compose-ps`, `pnpm-build`) — Clap routes these commands before `run_fallback`, so the TOML filters never fire ([#351](https://github.com/rtk-ai/rtk/issues/351))

--- a/src/cmds/python/pytest_cmd.rs
+++ b/src/cmds/python/pytest_cmd.rs
@@ -74,23 +74,7 @@ fn filter_pytest_output(output: &str) -> String {
                 current_failure.clear();
             }
             continue;
-        } else if trimmed.starts_with("===")
-            && (trimmed.contains("passed")
-                || trimmed.contains("failed")
-                || trimmed.contains("skipped"))
-        {
-            summary_line = trimmed.to_string();
-            continue;
-        // quiet mode (-q): bare summary without === wrapper, e.g. "5 failed, 1698 passed, 2 skipped in 108.89s"
-        } else if summary_line.is_empty()
-            && !trimmed.starts_with("===")
-            && !trimmed.starts_with("FAILED")
-            && !trimmed.starts_with("ERROR")
-            && (trimmed.contains(" passed")
-                || trimmed.contains(" failed")
-                || trimmed.contains(" skipped"))
-            && trimmed.contains(" in ")
-        {
+        } else if is_pytest_summary_line(trimmed) {
             summary_line = trimmed.to_string();
             continue;
         }
@@ -143,14 +127,23 @@ fn filter_pytest_output(output: &str) -> String {
 }
 
 fn build_pytest_summary(summary: &str, _test_files: &[String], failures: &[String]) -> String {
-    // Parse summary line
-    let (passed, failed, skipped) = parse_summary_line(summary);
+    let (passed, failed, skipped, xfailed) = parse_summary_line(summary);
 
-    if failed == 0 && passed > 0 {
-        return format!("Pytest: {} passed", passed);
+    if failed == 0 && (passed > 0 || skipped > 0 || xfailed > 0) {
+        let mut parts = Vec::new();
+        if passed > 0 {
+            parts.push(format!("{} passed", passed));
+        }
+        if xfailed > 0 {
+            parts.push(format!("{} xfailed", xfailed));
+        }
+        if skipped > 0 {
+            parts.push(format!("{} skipped", skipped));
+        }
+        return format!("Pytest: {}", parts.join(", "));
     }
 
-    if passed == 0 && failed == 0 && skipped == 0 {
+    if passed == 0 && failed == 0 && xfailed == 0 {
         return "Pytest: No tests collected".to_string();
     }
 
@@ -158,6 +151,9 @@ fn build_pytest_summary(summary: &str, _test_files: &[String], failures: &[Strin
     result.push_str(&format!("Pytest: {} passed, {} failed", passed, failed));
     if skipped > 0 {
         result.push_str(&format!(", {} skipped", skipped));
+    }
+    if xfailed > 0 {
+        result.push_str(&format!(", {} xfailed", xfailed));
     }
     result.push('\n');
     result.push_str("═══════════════════════════════════════\n");
@@ -221,10 +217,21 @@ fn build_pytest_summary(summary: &str, _test_files: &[String], failures: &[Strin
     result.trim().to_string()
 }
 
-fn parse_summary_line(summary: &str) -> (usize, usize, usize) {
+fn is_pytest_summary_line(line: &str) -> bool {
+    let normalized = line.trim_matches('=').trim();
+    normalized.contains(" in ")
+        && (normalized.contains("passed")
+            || normalized.contains("failed")
+            || normalized.contains("skipped")
+            || normalized.contains("xfailed")
+            || normalized.contains("no tests ran"))
+}
+
+fn parse_summary_line(summary: &str) -> (usize, usize, usize, usize) {
     let mut passed = 0;
     let mut failed = 0;
     let mut skipped = 0;
+    let mut xfailed = 0;
 
     // Parse lines like "=== 4 passed, 1 failed in 0.50s ==="
     let parts: Vec<&str> = summary.split(',').collect();
@@ -233,24 +240,32 @@ fn parse_summary_line(summary: &str) -> (usize, usize, usize) {
         let words: Vec<&str> = part.split_whitespace().collect();
         for (i, word) in words.iter().enumerate() {
             if i > 0 {
-                if word.contains("passed") {
+                let normalized = word
+                    .trim_matches(|c: char| !c.is_ascii_alphanumeric())
+                    .to_ascii_lowercase();
+
+                if normalized == "passed" {
                     if let Ok(n) = words[i - 1].parse::<usize>() {
                         passed = n;
                     }
-                } else if word.contains("failed") {
+                } else if normalized == "failed" {
                     if let Ok(n) = words[i - 1].parse::<usize>() {
                         failed = n;
                     }
-                } else if word.contains("skipped") {
+                } else if normalized == "skipped" {
                     if let Ok(n) = words[i - 1].parse::<usize>() {
                         skipped = n;
+                    }
+                } else if normalized == "xfailed" {
+                    if let Ok(n) = words[i - 1].parse::<usize>() {
+                        xfailed = n;
                     }
                 }
             }
         }
     }
 
-    (passed, failed, skipped)
+    (passed, failed, skipped, xfailed)
 }
 
 #[cfg(test)]
@@ -270,6 +285,32 @@ tests/test_foo.py .....                                            [100%]
         let result = filter_pytest_output(output);
         assert!(result.contains("Pytest"));
         assert!(result.contains("5 passed"));
+    }
+
+    #[test]
+    fn test_filter_pytest_with_xfailed() {
+        let output = r#"=== test session starts ===
+collected 2 items
+
+tests/test_foo.py .x                                              [100%]
+
+1 passed, 1 xfailed in 0.50s"#;
+
+        let result = filter_pytest_output(output);
+        assert_eq!(result, "Pytest: 1 passed, 1 xfailed");
+    }
+
+    #[test]
+    fn test_filter_pytest_xfailed_only() {
+        let output = r#"=== test session starts ===
+collected 1 item
+
+tests/test_foo.py x                                               [100%]
+
+1 xfailed in 0.50s"#;
+
+        let result = filter_pytest_output(output);
+        assert_eq!(result, "Pytest: 1 xfailed");
     }
 
     #[test]
@@ -338,14 +379,21 @@ collected 0 items
 
     #[test]
     fn test_parse_summary_line() {
-        assert_eq!(parse_summary_line("=== 5 passed in 0.50s ==="), (5, 0, 0));
+        assert_eq!(
+            parse_summary_line("=== 5 passed in 0.50s ==="),
+            (5, 0, 0, 0)
+        );
         assert_eq!(
             parse_summary_line("=== 4 passed, 1 failed in 0.50s ==="),
-            (4, 1, 0)
+            (4, 1, 0, 0)
         );
         assert_eq!(
             parse_summary_line("=== 3 passed, 1 failed, 2 skipped in 1.0s ==="),
-            (3, 1, 2)
+            (3, 1, 2, 0)
+        );
+        assert_eq!(
+            parse_summary_line("=== 3 passed, 2 xfailed, 1 skipped in 1.0s ==="),
+            (3, 0, 1, 2)
         );
     }
 


### PR DESCRIPTION
## Summary
- fix pytest summary parsing so `xfailed` is tracked separately instead of being counted as `failed`
- recognize quiet-mode summary lines like `1 xfailed in 0.01s`, which `rtk pytest` emits because it runs pytest with `-q`
- return compact success summaries for `xfailed`-only and mixed `passed + xfailed` runs
- add regression coverage in `src/pytest_cmd.rs` and note the fix in `CHANGELOG.md`

## Related Issue
Closes #672

## Root Cause / Reproduction
I reproduced this with a minimal pytest suite containing only an `@pytest.mark.xfail` test.

Raw pytest output:
```text
x                                                                        [100%]
1 xfailed in 0.01s
```

Before this change, the parser either:
- matched `xfailed` as `failed` because it used substring checks, or
- missed the summary line entirely in quiet mode because it only looked for `=== ... ===` summaries

That led to incorrect summaries like `1 failed` or `No tests collected`.

## Changes Made
- parse summary tokens by exact normalized outcome name instead of substring matching
- add explicit `xfailed` counting to the pytest summary parser
- detect both classic `=== ... ===` summaries and quiet-mode summaries emitted by `pytest -q`
- keep failure output unchanged while improving success-path summaries

## Files Changed
- `src/pytest_cmd.rs` - fix summary-line detection, parse `xfailed`, add regression tests
- `CHANGELOG.md` - add unreleased bug-fix note for #672

## Testing
- [x] `cargo fmt --all --check`
- [x] `rtk cargo build`
- [x] `rtk cargo clippy --all-targets` (reports 2 pre-existing warnings in untouched files: `src/gh_cmd.rs`, `src/git.rs`)
- [x] `rtk cargo test`
- [x] `rtk cargo test pytest_cmd`
- [x] Manual smoke test with a temporary virtualenv and real `pytest` xfail case using this branch's built binary

## Manual Verification
Using `/Users/stack/Documents/rtk/target/debug/rtk pytest` against a temp suite containing a single xfail test now prints:

```text
✓ Pytest: 1 xfailed
```

instead of misreporting the run.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] No breaking changes introduced

cc @pszymkowiak for review
