### PR TITLE
fix(init): respect CLAUDE_CONFIG_DIR for global paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -340,6 +340,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 * **cargo clippy:** include actionable error details in compact output instead of summary-only counts ([#602](https://github.com/rtk-ai/rtk/issues/602))
+* **init:** respect `CLAUDE_CONFIG_DIR` when resolving global Claude config paths in `rtk init -g` ([#633](https://github.com/rtk-ai/rtk/issues/633))
 * **curl:** skip JSON schema replacement when schema is larger than original payload ([#297](https://github.com/rtk-ai/rtk/issues/297))
 * **toml-dsl:** fix regex overmatch on `tofu-plan/init/validate/fmt` and `mix-format/compile` — add `(\s|$)` word boundary to prevent matching subcommands (e.g. `tofu planet`, `mix formats`) ([#349](https://github.com/rtk-ai/rtk/issues/349))
 * **toml-dsl:** remove 3 dead built-in filters (`docker-inspect`, `docker-compose-ps`, `pnpm-build`) — Clap routes these commands before `run_fallback`, so the TOML filters never fire ([#351](https://github.com/rtk-ai/rtk/issues/351))

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -504,7 +504,11 @@ fn prompt_telemetry_consent() -> Result<()> {
 }
 
 fn print_manual_instructions(hook_path: &Path, include_opencode: bool) {
-    println!("\n  MANUAL STEP: Add this to ~/.claude/settings.json:");
+    let settings_path = resolve_claude_dir()
+        .map(|dir| dir.join("settings.json"))
+        .unwrap_or_else(|_| PathBuf::from("~/.claude/settings.json"));
+
+    println!("\n  MANUAL STEP: Add this to {}:", settings_path.display());
     println!("  {{");
     println!("    \"hooks\": {{ \"PreToolUse\": [{{");
     println!("      \"matcher\": \"Bash\",");
@@ -1718,6 +1722,13 @@ fn resolve_home_subdir(subdir: &str) -> Result<PathBuf> {
 }
 
 fn resolve_claude_dir() -> Result<PathBuf> {
+    if let Some(dir) = std::env::var_os("CLAUDE_CONFIG_DIR") {
+        let path = PathBuf::from(dir);
+        if path.as_os_str().is_empty() {
+            anyhow::bail!("CLAUDE_CONFIG_DIR is set but empty");
+        }
+        return Ok(path);
+    }
     resolve_home_subdir(CLAUDE_DIR)
 }
 
@@ -3395,5 +3406,33 @@ More notes
         assert!(CURSOR_REWRITE_HOOK.contains("\"permission\": \"allow\""));
         assert!(CURSOR_REWRITE_HOOK.contains("\"updated_input\""));
         assert!(!CURSOR_REWRITE_HOOK.contains("hookSpecificOutput"));
+    }
+
+    #[test]
+    fn test_resolve_claude_dir_uses_env_override() {
+        let result = resolve_claude_dir_with(
+            Some(PathBuf::from("/home/test")),
+            Some(std::ffi::OsString::from("/tmp/custom-claude")),
+        )
+        .unwrap();
+        assert_eq!(result, PathBuf::from("/tmp/custom-claude"));
+    }
+
+    #[test]
+    fn test_resolve_claude_dir_falls_back_to_home() {
+        let result = resolve_claude_dir_with(Some(PathBuf::from("/home/test")), None).unwrap();
+        assert_eq!(result, PathBuf::from("/home/test/.claude"));
+    }
+
+    #[test]
+    fn test_resolve_claude_dir_rejects_empty_env_override() {
+        let err = resolve_claude_dir_with(
+            Some(PathBuf::from("/home/test")),
+            Some(std::ffi::OsString::from("")),
+        )
+        .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("CLAUDE_CONFIG_DIR is set but empty"));
     }
 }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -1722,14 +1722,24 @@ fn resolve_home_subdir(subdir: &str) -> Result<PathBuf> {
 }
 
 fn resolve_claude_dir() -> Result<PathBuf> {
-    if let Some(dir) = std::env::var_os("CLAUDE_CONFIG_DIR") {
+    resolve_claude_dir_with(dirs::home_dir(), std::env::var_os("CLAUDE_CONFIG_DIR"))
+}
+
+fn resolve_claude_dir_with(
+    home_dir: Option<PathBuf>,
+    env_override: Option<std::ffi::OsString>,
+) -> Result<PathBuf> {
+    if let Some(dir) = env_override {
         let path = PathBuf::from(dir);
         if path.as_os_str().is_empty() {
             anyhow::bail!("CLAUDE_CONFIG_DIR is set but empty");
         }
         return Ok(path);
     }
-    resolve_home_subdir(CLAUDE_DIR)
+
+    home_dir
+        .map(|h| h.join(CLAUDE_DIR))
+        .context("Cannot determine home directory. Is $HOME set?")
 }
 
 fn resolve_codex_dir() -> Result<PathBuf> {


### PR DESCRIPTION
## Description
`rtk init -g` ignored `CLAUDE_CONFIG_DIR` and always targeted `~/.claude`. This PR makes global Claude path resolution env-aware so installs/patches land in the intended config directory.

## Related Issue
Closes #633

## Changes Made
- updated Claude config resolver to honor `CLAUDE_CONFIG_DIR` when set
- added explicit validation for empty `CLAUDE_CONFIG_DIR`
- updated manual patch instructions to print the resolved `settings.json` path instead of always showing `~/.claude/settings.json`
- added unit tests for env override, home fallback, and empty override rejection
- added changelog entry under Unreleased bug fixes

## Files Changed
- `src/init.rs` - env-aware path resolution and tests
- `CHANGELOG.md` - unreleased bug-fix note for #633

## Testing
- [x] `cargo fmt --all --check`
- [x] `rtk cargo clippy --all-targets` (2 pre-existing warnings in untouched files)
- [x] `rtk cargo test`
- [x] `rtk cargo test init::tests::test_resolve_claude_dir_`

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] No breaking changes introduced

cc @pszymkowiak for review
