### PR TITLE
fix(rewrite): skip unsupported find predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -340,6 +340,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 * **cargo clippy:** include actionable error details in compact output instead of summary-only counts ([#602](https://github.com/rtk-ai/rtk/issues/602))
+* **rewrite:** skip `find` rewrites when unsupported compound predicates/actions are present (`-not`, `-exec`, `-prune`, etc.) ([#664](https://github.com/rtk-ai/rtk/issues/664))
 * **curl:** skip JSON schema replacement when schema is larger than original payload ([#297](https://github.com/rtk-ai/rtk/issues/297))
 * **toml-dsl:** fix regex overmatch on `tofu-plan/init/validate/fmt` and `mix-format/compile` — add `(\s|$)` word boundary to prevent matching subcommands (e.g. `tofu planet`, `mix formats`) ([#349](https://github.com/rtk-ai/rtk/issues/349))
 * **toml-dsl:** remove 3 dead built-in filters (`docker-inspect`, `docker-compose-ps`, `pnpm-build`) — Clap routes these commands before `run_fallback`, so the TOML filters never fire ([#351](https://github.com/rtk-ai/rtk/issues/351))

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -645,6 +645,13 @@ fn rewrite_segment(seg: &str, excluded: &[String]) -> Option<String> {
     let env_prefix = &cmd_part[..env_prefix_len];
     let cmd_clean = stripped_cow.trim();
 
+    // rtk find intentionally does not support compound predicates/actions.
+    // If the command uses unsupported find flags, skip rewriting to preserve
+    // native find behavior and avoid token-wasting error loops.
+    if strip_word_prefix(cmd_clean, "find").is_some() && has_unsupported_find_flags(cmd_clean) {
+        return None;
+    }
+
     // #345: RTK_DISABLED=1 in env prefix → skip rewrite entirely
     // #508: warn on stderr so agents learn to stop overusing it
     if has_rtk_disabled_prefix(cmd_part) {
@@ -692,6 +699,16 @@ fn rewrite_segment(seg: &str, excluded: &[String]) -> Option<String> {
     }
 
     None
+}
+
+fn has_unsupported_find_flags(cmd: &str) -> bool {
+    lazy_static! {
+        static ref UNSUPPORTED_FIND_FLAGS: Regex = Regex::new(
+            r"(^|\s)-(not|exec|execdir|ok|okdir|delete|prune|fls|fprint|fprintf|quit)(\s|$)"
+        )
+        .expect("valid regex");
+    }
+    UNSUPPORTED_FIND_FLAGS.is_match(cmd)
 }
 
 /// Strip a command prefix with word-boundary check.
@@ -2774,6 +2791,23 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_rewrite_find_skips_unsupported_not() {
+        assert_eq!(
+            rewrite_command("find . -name '*.md' -not -path './node_modules/*'", &[]),
+            None
+        );
+    }
+
+    #[test]
+    fn test_rewrite_find_skips_unsupported_exec() {
+        assert_eq!(
+            rewrite_command("find . -name '*.tmp' -exec rm {} \\;", &[]),
+            None
+        );
+    }
+
+    // --- Ensure PATTERNS and RULES stay aligned after modifications ---
     #[test]
     fn test_all_rules_are_complete() {
         for rule in RULES {


### PR DESCRIPTION
## Description
Fix rewrite behavior for `find` commands that use unsupported compound predicates/actions. Instead of rewriting those to `rtk find` (which then errors), we now pass them through as native `find`.

## Related Issue
Closes #664

## Changes Made
- added an unsupported-flag guard in rewrite path for `find`
- skip rewrite when command includes unsupported predicates/actions such as:
  - `-not`, `-exec`, `-execdir`, `-ok`, `-okdir`, `-delete`, `-prune`, `-fls`, `-fprint`, `-fprintf`, `-quit`
- added regression tests for `-not` and `-exec`
- added changelog entry under Unreleased bug fixes

## Files Changed
- `src/discover/registry.rs` - rewrite guard + tests
- `CHANGELOG.md` - unreleased bug-fix note for #664

## Testing
- [x] `cargo fmt --all --check`
- [x] `rtk cargo clippy --all-targets` (2 pre-existing warnings in untouched files)
- [x] `rtk cargo test`
- [x] `rtk cargo test discover::registry::tests::test_rewrite_find_skips_unsupported_not`
- [x] `rtk cargo test discover::registry::tests::test_rewrite_find_skips_unsupported_exec`

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] No breaking changes introduced

cc @pszymkowiak for review
