### PR TITLE
fix(cargo): show clippy error details in compact output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+* **cargo clippy:** include actionable error details in compact output instead of summary-only counts ([#602](https://github.com/rtk-ai/rtk/issues/602))
 * **curl:** skip JSON schema replacement when schema is larger than original payload ([#297](https://github.com/rtk-ai/rtk/issues/297))
 * **toml-dsl:** fix regex overmatch on `tofu-plan/init/validate/fmt` and `mix-format/compile` — add `(\s|$)` word boundary to prevent matching subcommands (e.g. `tofu planet`, `mix formats`) ([#349](https://github.com/rtk-ai/rtk/issues/349))
 * **toml-dsl:** remove 3 dead built-in filters (`docker-inspect`, `docker-compose-ps`, `pnpm-build`) — Clap routes these commands before `run_fallback`, so the TOML filters never fire ([#351](https://github.com/rtk-ai/rtk/issues/351))

--- a/src/cmds/rust/cargo_cmd.rs
+++ b/src/cmds/rust/cargo_cmd.rs
@@ -883,6 +883,7 @@ fn filter_cargo_clippy(output: &str) -> String {
     let mut by_rule: HashMap<String, Vec<String>> = HashMap::new();
     let mut error_count = 0;
     let mut warning_count = 0;
+    let mut error_details: Vec<String> = Vec::new();
 
     // Parse clippy output lines
     // Format: "warning: description\n  --> file:line:col\n  |\n  | code\n"
@@ -915,6 +916,7 @@ fn filter_cargo_clippy(output: &str) -> String {
             let is_error = line.starts_with("error");
             if is_error {
                 error_count += 1;
+                error_details.push(truncate(line.trim(), 160));
             } else {
                 warning_count += 1;
             }
@@ -952,6 +954,17 @@ fn filter_cargo_clippy(output: &str) -> String {
         error_count, warning_count
     ));
     result.push_str("═══════════════════════════════════════\n");
+
+    if !error_details.is_empty() {
+        result.push_str("\nError details:\n");
+        for (idx, detail) in error_details.iter().take(5).enumerate() {
+            result.push_str(&format!("  {}. {}\n", idx + 1, detail));
+        }
+        if error_details.len() > 5 {
+            result.push_str(&format!("  ... +{} more errors\n", error_details.len() - 5));
+        }
+        result.push('\n');
+    }
 
     // Sort rules by frequency
     let mut rule_counts: Vec<_> = by_rule.iter().collect();
@@ -1383,6 +1396,19 @@ warning: `rtk` (bin) generated 2 warnings
         assert!(result.contains("0 errors, 2 warnings"));
         assert!(result.contains("unused_variables"));
         assert!(result.contains("clippy::too_many_arguments"));
+    }
+
+    #[test]
+    fn test_filter_cargo_clippy_includes_error_details() {
+        let output = r#"    Checking rtk v0.5.0
+error: struct literals are not allowed here
+warning: unused variable: `x` [unused_variables]
+    Finished dev [unoptimized + debuginfo] target(s) in 1.53s
+"#;
+        let result = filter_cargo_clippy(output);
+        assert!(result.contains("cargo clippy: 1 errors, 1 warnings"));
+        assert!(result.contains("Error details:"));
+        assert!(result.contains("struct literals are not allowed here"));
     }
 
     #[test]


### PR DESCRIPTION
## Description
`rtk cargo clippy` could collapse output to counts/rules while hiding actionable error text in some failure modes. This PR preserves concise output but always includes concrete error lines.

## Related Issue
Closes #602

## Changes Made
- enhanced clippy filter to collect and show error detail lines in compact output
- added an `Error details` section (up to 5 entries, with overflow summary)
- added regression test to ensure error text is present when clippy reports an error
- added changelog entry under Unreleased bug fixes

## Files Changed
- `src/cargo_cmd.rs` - clippy filter enhancement + regression test
- `CHANGELOG.md` - unreleased bug-fix note for #602

## Testing
- [x] `cargo fmt --all --check`
- [x] `rtk cargo clippy --all-targets` (2 pre-existing warnings in untouched files)
- [x] `rtk cargo test`
- [x] `rtk cargo test cargo_cmd::tests::test_filter_cargo_clippy_includes_error_details`

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] No breaking changes introduced

cc @pszymkowiak for review
