### PR TITLE
fix(cargo): preserve clippy -- separator with cargo flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -340,6 +340,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 * **cargo clippy:** include actionable error details in compact output instead of summary-only counts ([#602](https://github.com/rtk-ai/rtk/issues/602))
+* **cargo clippy:** preserve `--` separator reliably when cargo flags (e.g. `--all-targets`, `--workspace`) are present before clippy args ([#660](https://github.com/rtk-ai/rtk/issues/660))
 * **curl:** skip JSON schema replacement when schema is larger than original payload ([#297](https://github.com/rtk-ai/rtk/issues/297))
 * **toml-dsl:** fix regex overmatch on `tofu-plan/init/validate/fmt` and `mix-format/compile` — add `(\s|$)` word boundary to prevent matching subcommands (e.g. `tofu planet`, `mix formats`) ([#349](https://github.com/rtk-ai/rtk/issues/349))
 * **toml-dsl:** remove 3 dead built-in filters (`docker-inspect`, `docker-compose-ps`, `pnpm-build`) — Clap routes these commands before `run_fallback`, so the TOML filters never fire ([#351](https://github.com/rtk-ai/rtk/issues/351))

--- a/src/cmds/rust/cargo_cmd.rs
+++ b/src/cmds/rust/cargo_cmd.rs
@@ -54,12 +54,14 @@ fn restore_double_dash_with_raw(args: &[String], raw_args: &[String]) -> Vec<Str
         None => return args.to_vec(),
     };
 
-    // Count how many of our parsed args appeared before `--` in the original.
-    // Args before `--` are positional (e.g. test name), args after are flags.
-    let args_before_sep = raw_args[..sep_pos]
-        .iter()
-        .filter(|a| args.contains(a))
-        .count();
+    // Reconstruct the split point by matching args in order against tokens
+    // before `--`. This avoids over-counting when values repeat after `--`.
+    let mut args_before_sep = 0usize;
+    for token in &raw_args[..sep_pos] {
+        if args_before_sep < args.len() && args[args_before_sep] == *token {
+            args_before_sep += 1;
+        }
+    }
 
     let mut result = Vec::with_capacity(args.len() + 1);
     result.extend_from_slice(&args[..args_before_sep]);
@@ -1115,6 +1117,38 @@ mod tests {
         );
         // Verify only one "--" exists
         assert_eq!(result.iter().filter(|a| *a == "--").count(), 1);
+    }
+
+    #[test]
+    fn test_restore_double_dash_clippy_with_all_targets() {
+        let args: Vec<String> = vec!["--all-targets".into(), "-D".into(), "warnings".into()];
+        let raw = vec![
+            "rtk".into(),
+            "cargo".into(),
+            "clippy".into(),
+            "--all-targets".into(),
+            "--".into(),
+            "-D".into(),
+            "warnings".into(),
+        ];
+        let result = restore_double_dash_with_raw(&args, &raw);
+        assert_eq!(result, vec!["--all-targets", "--", "-D", "warnings"]);
+    }
+
+    #[test]
+    fn test_restore_double_dash_clippy_with_workspace() {
+        let args: Vec<String> = vec!["--workspace".into(), "-D".into(), "warnings".into()];
+        let raw = vec![
+            "rtk".into(),
+            "cargo".into(),
+            "clippy".into(),
+            "--workspace".into(),
+            "--".into(),
+            "-D".into(),
+            "warnings".into(),
+        ];
+        let result = restore_double_dash_with_raw(&args, &raw);
+        assert_eq!(result, vec!["--workspace", "--", "-D", "warnings"]);
     }
 
     #[test]


### PR DESCRIPTION
## Description
Fixes `rtk cargo clippy` argument reconstruction when cargo flags are present before `--`.

## Related Issue
Closes #660

## Changes Made
- hardened `--` restoration logic to reconstruct the split point using ordered token matching (instead of broad containment counting)
- kept idempotent behavior when Clap already preserves `--`
- added regression tests for reported failing variants:
  - `--all-targets -- -D warnings`
  - `--workspace -- -D warnings`
- updated changelog under Unreleased bug fixes

## Files Changed
- `src/cargo_cmd.rs`
- `CHANGELOG.md`

## Testing
- [x] `cargo fmt --all --check`
- [x] `rtk cargo clippy --all-targets` (2 pre-existing warnings in untouched files)
- [x] `rtk cargo test`
- [x] `rtk cargo test cargo_cmd::tests::test_restore_double_dash_clippy_with_all_targets`
- [x] `rtk cargo test cargo_cmd::tests::test_restore_double_dash_clippy_with_workspace`

cc @pszymkowiak for review
