### PR TITLE
fix(rewrite): route ollama run through rtk ollama

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+* **rewrite:** route `ollama run` to `rtk ollama run` so the built-in ollama spinner/ANSI filter is applied ([#624](https://github.com/rtk-ai/rtk/issues/624))
 * **curl:** skip JSON schema replacement when schema is larger than original payload ([#297](https://github.com/rtk-ai/rtk/issues/297))
 * **toml-dsl:** fix regex overmatch on `tofu-plan/init/validate/fmt` and `mix-format/compile` — add `(\s|$)` word boundary to prevent matching subcommands (e.g. `tofu planet`, `mix formats`) ([#349](https://github.com/rtk-ai/rtk/issues/349))
 * **toml-dsl:** remove 3 dead built-in filters (`docker-inspect`, `docker-compose-ps`, `pnpm-build`) — Clap routes these commands before `run_fallback`, so the TOML filters never fire ([#351](https://github.com/rtk-ai/rtk/issues/351))

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1980,6 +1980,14 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_rewrite_ollama_run() {
+        assert_eq!(
+            rewrite_command("ollama run phi4:14b \"hello\"", &[]),
+            Some("rtk ollama run phi4:14b \"hello\"".into())
+        );
+    }
+
     // --- Compound operator edge cases ---
 
     #[test]

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -88,6 +88,7 @@ pub const PATTERNS: &[&str] = &[
     r"^trunk\s+build",
     r"^uv\s+(sync|pip\s+install)\b",
     r"^yamllint\b",
+    r"^ollama\s+run\b",
 ];
 
 pub const RULES: &[RtkRule] = &[
@@ -650,6 +651,14 @@ pub const RULES: &[RtkRule] = &[
         rewrite_prefixes: &["yamllint"],
         category: "Build",
         savings_pct: 65.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
+    RtkRule {
+        rtk_cmd: "rtk ollama",
+        rewrite_prefixes: &["ollama"],
+        category: "Data",
+        savings_pct: 80.0,
         subcmd_savings: &[],
         subcmd_status: &[],
     },


### PR DESCRIPTION
## Description
This PR adds rewrite coverage for `ollama run` so it is automatically routed through `rtk ollama` and uses the existing TOML filter.

## Related Issue
Closes #624

## Changes Made
- Added `^ollama\s+run\b` rewrite pattern in discover rules
- Added `ollama -> rtk ollama` rewrite rule entry
- Added regression test for rewrite output in discover registry tests
- Updated changelog unreleased fixes

## Testing
- `cargo fmt --all --check`
- `rtk cargo clippy --all-targets` (only pre-existing warnings outside this change)
- `rtk cargo test`
- `rtk cargo test discover::registry::tests::test_rewrite_ollama_run`
- Manual check: `./target/debug/rtk rewrite "ollama run phi4:14b hello"`

@aeppling please review when you have a chance.
