### PR TITLE
feat: add `rtk clean` command to reset tracking history

### DIFF
--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -1373,7 +1373,75 @@ mod tests {
         assert!(summary.recent.iter().any(|r| r.raw_command == test_cmd));
     }
 
-    // 13. recovery_rate calculation
+    // 13. clear_all on isolated temp DB — deletes all records
+    #[test]
+    fn test_clear_all_deletes_records() {
+        use std::env;
+
+        let tmp = env::temp_dir().join(format!("rtk_test_clean_{}.db", std::process::id()));
+        env::set_var("RTK_DB_PATH", &tmp);
+
+        let tracker = Tracker::new().expect("Failed to create tracker");
+        tracker
+            .record("git status", "rtk git status", 100, 20, 5)
+            .unwrap();
+        tracker
+            .record("git log", "rtk git log", 200, 40, 8)
+            .unwrap();
+
+        let deleted = tracker.clear_all().unwrap();
+        assert_eq!(deleted, 2);
+
+        let recent = tracker.get_recent(10).unwrap();
+        assert!(recent.is_empty());
+
+        env::remove_var("RTK_DB_PATH");
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    // 14. clear_all on empty DB returns 0
+    #[test]
+    fn test_clear_all_empty_db() {
+        use std::env;
+
+        let tmp = env::temp_dir().join(format!("rtk_test_clean_empty_{}.db", std::process::id()));
+        env::set_var("RTK_DB_PATH", &tmp);
+
+        let tracker = Tracker::new().expect("Failed to create tracker");
+        let deleted = tracker.clear_all().unwrap();
+        assert_eq!(deleted, 0);
+
+        env::remove_var("RTK_DB_PATH");
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    // 15. clear_all also clears parse_failures table
+    #[test]
+    fn test_clear_all_clears_parse_failures() {
+        use std::env;
+
+        let tmp = env::temp_dir().join(format!("rtk_test_clean_pf_{}.db", std::process::id()));
+        env::set_var("RTK_DB_PATH", &tmp);
+
+        let tracker = Tracker::new().expect("Failed to create tracker");
+        tracker.record("cmd1", "rtk cmd1", 100, 20, 5).unwrap();
+        tracker
+            .record_parse_failure("bad cmd", "parse error", false)
+            .unwrap();
+
+        tracker.clear_all().unwrap();
+
+        let recent = tracker.get_recent(10).unwrap();
+        assert!(recent.is_empty());
+
+        let pf_summary = tracker.get_parse_failure_summary().unwrap();
+        assert_eq!(pf_summary.total, 0);
+
+        env::remove_var("RTK_DB_PATH");
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    // 16. recovery_rate calculation
     #[test]
     fn test_parse_failure_recovery_rate() {
         let tracker = Tracker::new().expect("Failed to create tracker");

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -398,6 +398,12 @@ impl Tracker {
         Ok(())
     }
 
+    pub fn clear_all(&self) -> Result<usize> {
+        let deleted: usize = self.conn.execute("DELETE FROM commands", [])?;
+        let _ = self.conn.execute("DELETE FROM parse_failures", []);
+        Ok(deleted)
+    }
+
     /// Record a parse failure for analytics.
     pub fn record_parse_failure(
         &self,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1698,11 +1698,13 @@ fn run_cli() -> Result<i32> {
         }
 
         Commands::Clean => {
-            let tracker = tracking::Tracker::new().context("Failed to open tracking database")?;
+            let tracker =
+                core::tracking::Tracker::new().context("Failed to open tracking database")?;
             let deleted = tracker
                 .clear_all()
                 .context("Failed to clear tracking history")?;
             println!("Cleared {} records from tracking history.", deleted);
+            0
         }
 
         Commands::Config { create } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -424,6 +424,9 @@ enum Commands {
         format: String,
     },
 
+    /// Clear all token tracking history (resets rtk gain)
+    Clean,
+
     /// Show or create configuration file
     Config {
         /// Create default config file
@@ -1692,6 +1695,14 @@ fn run_cli() -> Result<i32> {
         } => {
             analytics::cc_economics::run(daily, weekly, monthly, all, &format, cli.verbose)?;
             0
+        }
+
+        Commands::Clean => {
+            let tracker = tracking::Tracker::new().context("Failed to open tracking database")?;
+            let deleted = tracker
+                .clear_all()
+                .context("Failed to clear tracking history")?;
+            println!("Cleared {} records from tracking history.", deleted);
         }
 
         Commands::Config { create } => {


### PR DESCRIPTION
## Summary

- Add `rtk clean` command that clears all token savings records from the SQLite tracking database
- Clears both `commands` and `parse_failures` tables, returns count of deleted records

## Why

There is no way to reset `rtk gain` analytics. When users want to start fresh (e.g. after testing, changing workflow, or benchmarking), they must manually delete the SQLite file. `rtk clean` provides a safe, built-in reset.

## Usage

```
$ rtk clean
Cleared 803 records from tracking history.

$ rtk gain
No tracking data yet.
Run some rtk commands to start tracking savings.
```

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk clean` output inspected, `rtk gain` shows empty after clean

> Replaces #684 (was based on master instead of develop, causing noisy diff).