### PR TITLE
feat: add Cline/Roo Code support via rtk init --agent cline

### DIFF
--- a/hooks/cline-rtk-rules.md
+++ b/hooks/cline-rtk-rules.md
@@ -1,0 +1,32 @@
+# RTK - Rust Token Killer (Cline)
+
+**Usage**: Token-optimized CLI proxy for shell commands.
+
+## Rule
+
+Always prefix shell commands with `rtk` to minimize token consumption.
+
+Examples:
+
+```bash
+rtk git status
+rtk cargo test
+rtk ls src/
+rtk grep "pattern" src/
+rtk find "*.rs" .
+rtk docker ps
+rtk gh pr list
+```
+
+## Meta Commands
+
+```bash
+rtk gain              # Show token savings
+rtk gain --history    # Command history with savings
+rtk discover          # Find missed RTK opportunities
+rtk proxy <cmd>       # Run raw (no filtering, for debugging)
+```
+
+## Why
+
+RTK filters and compresses command output before it reaches the LLM context, saving 60-90% tokens on common operations. Always use `rtk <cmd>` instead of raw commands.

--- a/src/init.rs
+++ b/src/init.rs
@@ -204,12 +204,14 @@ Overall average: **60-90% token reduction** on common development operations.
 "##;
 
 /// Main entry point for `rtk init`
+#[allow(clippy::too_many_arguments)]
 pub fn run(
     global: bool,
     install_claude: bool,
     install_opencode: bool,
     install_cursor: bool,
     install_windsurf: bool,
+    install_cline: bool,
     claude_md: bool,
     hook_only: bool,
     codex: bool,
@@ -252,6 +254,11 @@ pub fn run(
     // Windsurf-only mode
     if install_windsurf {
         return run_windsurf_mode(verbose);
+    }
+
+    // Cline-only mode
+    if install_cline {
+        return run_cline_mode(verbose);
     }
 
     // Mode selection (Claude Code / OpenCode)
@@ -1156,17 +1163,43 @@ fn run_claude_md_mode(global: bool, verbose: u8, install_opencode: bool) -> Resu
     Ok(())
 }
 
-/// Codex mode: slim RTK.md + @RTK.md reference in AGENTS.md
 // ─── Windsurf support ─────────────────────────────────────────
 
 /// Embedded Windsurf RTK rules
 const WINDSURF_RULES: &str = include_str!("../hooks/windsurf-rtk-rules.md");
 
-/// Resolve Windsurf user config directory (~/.codeium/windsurf)
-fn resolve_windsurf_dir() -> Result<PathBuf> {
-    dirs::home_dir()
-        .map(|h| h.join(".codeium").join("windsurf"))
-        .context("Cannot determine home directory")
+/// Embedded Cline RTK rules
+const CLINE_RULES: &str = include_str!("../hooks/cline-rtk-rules.md");
+
+// ─── Cline / Roo Code support ─────────────────────────────────
+
+fn run_cline_mode(verbose: u8) -> Result<()> {
+    // Cline reads .clinerules from the project root (workspace-scoped)
+    let rules_path = PathBuf::from(".clinerules");
+
+    let existing = fs::read_to_string(&rules_path).unwrap_or_default();
+    if existing.contains("RTK") || existing.contains("rtk") {
+        println!("\nRTK already configured for Cline in this project.\n");
+        println!("  Rules: .clinerules (already present)");
+    } else {
+        let new_content = if existing.trim().is_empty() {
+            CLINE_RULES.to_string()
+        } else {
+            format!("{}\n\n{}", existing.trim(), CLINE_RULES)
+        };
+        fs::write(&rules_path, &new_content).context("Failed to write .clinerules")?;
+
+        if verbose > 0 {
+            eprintln!("Wrote .clinerules");
+        }
+
+        println!("\nRTK configured for Cline.\n");
+        println!("  Rules: .clinerules (installed)");
+    }
+    println!("  Cline will now use rtk commands for token savings.");
+    println!("  Test with: git status\n");
+
+    Ok(())
 }
 
 fn run_windsurf_mode(verbose: u8) -> Result<()> {
@@ -1655,7 +1688,7 @@ fn cursor_hook_already_present(root: &serde_json::Value) -> bool {
         entry
             .get("command")
             .and_then(|c| c.as_str())
-            .map_or(false, |cmd| cmd.contains("rtk-rewrite.sh"))
+            .is_some_and(|cmd| cmd.contains("rtk-rewrite.sh"))
     })
 }
 
@@ -1750,7 +1783,7 @@ fn remove_cursor_hook_from_json(root: &mut serde_json::Value) -> bool {
         !entry
             .get("command")
             .and_then(|c| c.as_str())
-            .map_or(false, |cmd| cmd.contains("rtk-rewrite.sh"))
+            .is_some_and(|cmd| cmd.contains("rtk-rewrite.sh"))
     });
 
     pre_tool_use.len() < original_len
@@ -2139,7 +2172,7 @@ fn patch_gemini_settings(
             if arr.iter().any(|h| {
                 h.pointer("/hooks/0/command")
                     .and_then(|v| v.as_str())
-                    .map_or(false, |c| c.contains("rtk"))
+                    .is_some_and(|c| c.contains("rtk"))
             }) {
                 if verbose > 0 {
                     eprintln!("Gemini settings.json already has RTK hook");
@@ -2248,7 +2281,7 @@ fn uninstall_gemini(verbose: u8) -> Result<Vec<String>> {
                 arr.retain(|h| {
                     !h.pointer("/hooks/0/command")
                         .and_then(|v| v.as_str())
-                        .map_or(false, |c| c.contains("rtk"))
+                        .is_some_and(|c| c.contains("rtk"))
                 });
                 if arr.len() < before {
                     let new_content = serde_json::to_string_pretty(&settings)?;
@@ -2494,6 +2527,7 @@ More notes
             false,
             false,
             false,
+            false,
             true,
             PatchMode::Auto,
             0,
@@ -2508,6 +2542,7 @@ More notes
     #[test]
     fn test_codex_mode_rejects_no_patch() {
         let err = run(
+            false,
             false,
             false,
             false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,8 @@ pub enum AgentTarget {
     Cursor,
     /// Windsurf IDE (Cascade)
     Windsurf,
+    /// Cline / Roo Code (VS Code)
+    Cline,
 }
 
 #[derive(Parser)]
@@ -1659,7 +1661,7 @@ fn main() -> Result<()> {
             if show {
                 init::show_config(codex)?;
             } else if uninstall {
-                let cursor = agent.map_or(false, |a| a == AgentTarget::Cursor);
+                let cursor = agent == Some(AgentTarget::Cursor);
                 init::uninstall(global, gemini, codex, cursor, cli.verbose)?;
             } else if gemini {
                 let patch_mode = if auto_patch {
@@ -1673,8 +1675,9 @@ fn main() -> Result<()> {
             } else {
                 let install_opencode = opencode;
                 let install_claude = !opencode;
-                let install_cursor = agent.map_or(false, |a| a == AgentTarget::Cursor);
-                let install_windsurf = agent.map_or(false, |a| a == AgentTarget::Windsurf);
+                let install_cursor = agent == Some(AgentTarget::Cursor);
+                let install_windsurf = agent == Some(AgentTarget::Windsurf);
+                let install_cline = agent == Some(AgentTarget::Cline);
 
                 let patch_mode = if auto_patch {
                     init::PatchMode::Auto
@@ -1689,6 +1692,7 @@ fn main() -> Result<()> {
                     install_opencode,
                     install_cursor,
                     install_windsurf,
+                    install_cline,
                     claude_md,
                     hook_only,
                     codex,


### PR DESCRIPTION
Closes #701

## Summary

Add Cline / Roo Code (VS Code, 3-5M installs) support to RTK.

- `rtk init --agent cline` creates `.clinerules` with RTK instructions
- Cline reads `.clinerules` and prefixes shell commands with `rtk`
- Same rules-based approach as Windsurf (#697) and Codex (#377)

## Test plan

- [x] `cargo check` — compiles clean
- [x] `cargo test --all` — 979 passed
- [x] `rtk init --agent cline` — creates .clinerules correctly