### PR TITLE
feat(gradle): Start implementing Gradle filter module with task-type detection

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -20,6 +20,8 @@ pub struct Config {
     pub hooks: HooksConfig,
     #[serde(default)]
     pub limits: LimitsConfig,
+    #[serde(default)]
+    pub gradle: GradleConfig,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -127,6 +129,35 @@ impl Default for LimitsConfig {
 /// Get limits config. Falls back to defaults if config can't be loaded.
 pub fn limits() -> LimitsConfig {
     Config::load().map(|c| c.limits).unwrap_or_default()
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct GradleConfig {
+    /// Package prefixes treated as "user code" in stack traces (kept, not dropped).
+    #[serde(default)]
+    pub user_packages: Vec<String>,
+    /// Additional regex patterns for lines to drop (applied after built-in global filters).
+    #[serde(default)]
+    pub extra_drop_patterns: Vec<String>,
+    /// Additional package prefixes to treat as framework noise in stack traces.
+    /// Built-in: java.*, kotlin.*, sun.*, javax.*, jdk.*, jakarta.*, *.internal.*
+    #[serde(default = "default_drop_frame_packages")]
+    pub drop_frame_packages: Vec<String>,
+}
+
+pub fn default_drop_frame_packages() -> Vec<String> {
+    vec![
+        "org.gradle".to_string(),
+        "org.junit.platform".to_string(),
+        "org.junit.jupiter.engine".to_string(),
+        "org.springframework".to_string(),
+        "com.google.inject".to_string(),
+        "io.grpc".to_string(),
+        "org.mockito".to_string(),
+        "io.mockk".to_string(),
+        "org.eclipse.jetty".to_string(),
+        "org.assertj.core.internal".to_string(),
+    ]
 }
 
 /// Check if telemetry is enabled in config. Returns None if config can't be loaded.


### PR DESCRIPTION
## Overview

This PR series adds a Rust-native Gradle filter module that replaces the existing `src/filters/gradle.toml` TOML filter (~60% savings) with **85-99% token savings** through task-type detection, stack trace intelligence, and batch processing.

**Tested on Faire's production Gradle monorepo.** Upstreamed from [Faire's fork](https://github.com/Faire/rtk) where it has been in use since January 2026.

## Value over existing `gradle.toml`

The upstream TOML filter does basic noise stripping. This Rust module adds:
- **Task-type detection** (compile, test, detekt, health, proto, deps) with per-type filtering strategies
- **Stack trace intelligence** — keeps user frames + first assertion frame, drops framework noise (configurable via `drop_frame_packages`)
- **Batch processing** — splits multi-task output by `> Task` boundaries, applies per-section filters
- **Path normalization** — converts absolute paths to repo-relative
- **Configurable** — `user_packages`, `extra_drop_patterns`, `drop_frame_packages` via config.toml or `.rtk.toml`

## Token Savings

| Filter | Savings | Strategy |
|--------|---------|----------|
| Global noise | 70-90% | RegexSet (37 patterns), Try-block removal, ANSI stripping |
| Compile | 85%+ | Drop kapt/KSP noise, normalize paths (RegexSet) |
| Test | 90%+ | Drop passing tests, truncate stack traces |
| Detekt | 85%+ | Group violations by rule (RegexSet) |
| Health | 80% | Passthrough (already concise after global) |
| Proto | 75%+ | Drop extraction noise |
| Deps | 40%+ | Truncate dependency tree to depth 0-1 |
| Batch | 95%+ | Per-task routing on multi-task runs |

## Staging PRs (internal review)

Each filter is a separate PR for focused review in [Faire/rtk](https://github.com/Faire/rtk):

| # | PR | Scope | Savings |
|---|-----|-------|---------|
| 3a | [#23](https://github.com/Faire/rtk/pull/23) | GradleConfig struct | — |
| 3b-i | [#33](https://github.com/Faire/rtk/pull/33) | Global noise filters + path normalization + `insta` dep | 70-90% |
| 3b-ii | [#34](https://github.com/Faire/rtk/pull/34) | Command routing + task-type detection | — |
| 3c | [#35](https://github.com/Faire/rtk/pull/35) | Compile filter | 85%+ |
| 3d | [#36](https://github.com/Faire/rtk/pull/36) | Test filter | 90%+ |
| 3e | [#37](https://github.com/Faire/rtk/pull/37) | Detekt filter | 85%+ |
| 3f | [#38](https://github.com/Faire/rtk/pull/38) | Health filter | 80% |
| 3g | [#39](https://github.com/Faire/rtk/pull/39) | Proto filter | 75%+ |
| 3h | [#40](https://github.com/Faire/rtk/pull/40) | Deps filter | 40%+ |
| 3i | [#41](https://github.com/Faire/rtk/pull/41) | Batch processing | 95%+ |
| 3j | [#42](https://github.com/Faire/rtk/pull/42) | Discover rule + retire TOML | — |

## Performance

- All noise pattern matching uses `RegexSet` for single-pass matching (global: 37 patterns, compile: 4, detekt: 3)
- Zero async — single-threaded, no tokio
- All regexes compiled once via `lazy_static!`

## Open Questions

1. **New dev-dependency: `insta` 1.46** for snapshot testing. Is this acceptable? Dev-only (not in release binary). Used for 16 snapshot files validating filter output format.

## Size

~2,800 lines code + 13 fixtures + 16 snapshots (across 10 Rust files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)