### PR TITLE
fix(init): honor OPENCODE_CONFIG_DIR for OpenCode plugin path

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,8 +320,8 @@ rtk init -g --opencode
 ```
 
 **What it creates:**
-- `$OPENCODE_CONFIG_DIR/plugins/rtk.ts` when `OPENCODE_CONFIG_DIR` is set
-- `~/.config/opencode/plugins/rtk.ts` otherwise
+- `$OPENCODE_CONFIG_DIR/plugins/rtk.ts` when `OPENCODE_CONFIG_DIR` is set and non-empty (per `${OPENCODE_CONFIG_DIR:-...}` semantics)
+- `~/.config/opencode/plugins/rtk.ts` when `OPENCODE_CONFIG_DIR` is unset or empty
 
 **Restart Required**: Restart OpenCode, then test with `git status` in a session.
 

--- a/README.md
+++ b/README.md
@@ -320,14 +320,15 @@ rtk init -g --opencode
 ```
 
 **What it creates:**
-- `~/.config/opencode/plugins/rtk.ts`
+- `$OPENCODE_CONFIG_DIR/plugins/rtk.ts` when `OPENCODE_CONFIG_DIR` is set
+- `~/.config/opencode/plugins/rtk.ts` otherwise
 
 **Restart Required**: Restart OpenCode, then test with `git status` in a session.
 
 **Manual install (fallback):**
 ```bash
-mkdir -p ~/.config/opencode/plugins
-cp hooks/opencode-rtk.ts ~/.config/opencode/plugins/rtk.ts
+mkdir -p "${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}/plugins"
+cp hooks/opencode-rtk.ts "${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}/plugins/rtk.ts"
 ```
 
 ### Commands Rewritten

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -187,7 +187,7 @@ rtk init -g --opencode
 
 **3. Verify plugin file exists:**
 ```bash
-ls -la ~/.config/opencode/plugins/rtk.ts
+ls -la "${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}/plugins/rtk.ts"
 ```
 
 **4. Restart OpenCode**

--- a/src/init.rs
+++ b/src/init.rs
@@ -1516,13 +1516,21 @@ fn resolve_codex_dir() -> Result<PathBuf> {
         .map(|h| h.join(".codex"))
         .context("Cannot determine home directory. Is $HOME set?")
 }
-/// Resolve OpenCode config directory (~/.config/opencode)
-/// OpenCode uses ~/.config/opencode on all platforms (XDG convention),
-/// NOT the macOS-native ~/Library/Application Support/.
+/// Resolve OpenCode config directory.
+/// Honors OPENCODE_CONFIG_DIR when set; otherwise falls back to ~/.config/opencode.
 fn resolve_opencode_dir() -> Result<PathBuf> {
+    if let Ok(config_dir) = std::env::var("OPENCODE_CONFIG_DIR") {
+        let trimmed = config_dir.trim();
+        if !trimmed.is_empty() {
+            return Ok(PathBuf::from(trimmed));
+        }
+    }
+
     dirs::home_dir()
         .map(|h| h.join(".config").join("opencode"))
-        .context("Cannot determine home directory. Is $HOME set?")
+        .context(
+            "Cannot determine OpenCode config directory. Is $HOME set or OPENCODE_CONFIG_DIR defined?",
+        )
 }
 
 /// Return OpenCode plugin path: ~/.config/opencode/plugins/rtk.ts
@@ -2305,7 +2313,46 @@ fn uninstall_gemini(verbose: u8) -> Result<Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
+    use std::sync::Mutex;
     use tempfile::TempDir;
+
+    static OPENCODE_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    fn set_env_var(key: &str, value: &str) {
+        // SAFETY: Tests mutate process env under OPENCODE_ENV_LOCK to avoid concurrent access.
+        unsafe { std::env::set_var(key, value) }
+    }
+
+    fn remove_env_var(key: &str) {
+        // SAFETY: Tests mutate process env under OPENCODE_ENV_LOCK to avoid concurrent access.
+        unsafe { std::env::remove_var(key) }
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: Option<&str>) -> Self {
+            let original = std::env::var(key).ok();
+            match value {
+                Some(v) => set_env_var(key, v),
+                None => remove_env_var(key),
+            }
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(value) => set_env_var(self.key, value),
+                None => remove_env_var(self.key),
+            }
+        }
+    }
 
     #[test]
     fn test_init_mentions_all_top_level_commands() {
@@ -2404,6 +2451,49 @@ More content"#;
         assert!(plugin_path.exists());
         fs::remove_file(&plugin_path).unwrap();
         assert!(!plugin_path.exists());
+    }
+
+    #[test]
+    fn test_resolve_opencode_dir_uses_env_override() {
+        let _lock = OPENCODE_ENV_LOCK
+            .lock()
+            .expect("env lock must not be poisoned");
+        let _guard = EnvVarGuard::set("OPENCODE_CONFIG_DIR", Some("/tmp/rtk-opencode-config"));
+
+        let resolved = resolve_opencode_dir().unwrap();
+
+        assert_eq!(resolved, PathBuf::from("/tmp/rtk-opencode-config"));
+    }
+
+    #[test]
+    fn test_resolve_opencode_dir_falls_back_when_env_is_blank() {
+        let _lock = OPENCODE_ENV_LOCK
+            .lock()
+            .expect("env lock must not be poisoned");
+        let _guard = EnvVarGuard::set("OPENCODE_CONFIG_DIR", Some("   \t  "));
+
+        let home = dirs::home_dir().expect("home directory should be available in test");
+        let resolved = resolve_opencode_dir().unwrap();
+
+        assert_eq!(resolved, home.join(".config").join("opencode"));
+    }
+
+    #[test]
+    fn test_prepare_opencode_plugin_path_uses_env_override() {
+        let _lock = OPENCODE_ENV_LOCK
+            .lock()
+            .expect("env lock must not be poisoned");
+        let temp = TempDir::new().unwrap();
+        let custom_dir = temp.path().join("opencode-custom");
+        let _guard = EnvVarGuard::set(
+            "OPENCODE_CONFIG_DIR",
+            Some(custom_dir.to_string_lossy().as_ref()),
+        );
+
+        let plugin_path = prepare_opencode_plugin_path().unwrap();
+
+        assert_eq!(plugin_path, custom_dir.join("plugins").join("rtk.ts"));
+        assert!(plugin_path.parent().unwrap().exists());
     }
 
     #[test]


### PR DESCRIPTION
> This PR was generated using AI on behalf of @cavanaug.

## Summary

- Fix `rtk init -g --opencode` to honor `OPENCODE_CONFIG_DIR` when resolving the OpenCode plugin install directory.
- Preserve existing fallback behavior to `~/.config/opencode` when `OPENCODE_CONFIG_DIR` is unset or blank.
- Add tests covering env override, blank-env fallback, and plugin path preparation using the override.
- Update OpenCode docs/examples to use `${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}`.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets` (2 pre-existing warnings in unrelated files)
- [x] `cargo test` (982 passed)
- [x] `cargo build --release`
- [x] `cargo test test_resolve_opencode_dir_uses_env_override`
- [x] `cargo test test_resolve_opencode_dir_falls_back_when_env_is_blank`
- [x] `cargo test test_prepare_opencode_plugin_path_uses_env_override`
- [x] Manual: verify docs path examples are env-aware