### PR TITLE
fix(golangci-lint): add v2 compatibility with runtime version detection

### DIFF
--- a/src/golangci_cmd.rs
+++ b/src/golangci_cmd.rs
@@ -4,7 +4,6 @@ use crate::utils::{resolved_command, truncate};
 use anyhow::{Context, Result};
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::process::Command;
 
 #[derive(Debug, Deserialize)]
 struct Position {
@@ -62,7 +61,7 @@ fn parse_major_version(version_output: &str) -> u32 {
 /// Run `golangci-lint --version` and return the major version number.
 /// Returns 1 on any failure.
 fn detect_major_version() -> u32 {
-    let output = Command::new("golangci-lint").arg("--version").output();
+    let output = resolved_command("golangci-lint").arg("--version").output();
 
     match output {
         Ok(o) => {
@@ -511,151 +510,7 @@ mod tests {
 
     #[test]
     fn test_golangci_v2_token_savings() {
-        // Simulate a realistic v2 JSON output with multiple issues
-        let raw = r#"{
-  "Issues": [
-    {
-      "FromLinter": "errcheck",
-      "Text": "Error return value of `foo` is not checked",
-      "Severity": "error",
-      "SourceLines": [
-        "    if err := foo(); err != nil {",
-        "        return err",
-        "    }"
-      ],
-      "Pos": {
-        "Filename": "pkg/handler/server.go",
-        "Line": 42,
-        "Column": 5,
-        "Offset": 1024
-      },
-      "Replacement": null,
-      "ExpectNoLint": false,
-      "ExpectedNoLintLinter": ""
-    },
-    {
-      "FromLinter": "errcheck",
-      "Text": "Error return value of `bar` is not checked",
-      "Severity": "error",
-      "SourceLines": [
-        "    bar()",
-        "    return nil",
-        "}"
-      ],
-      "Pos": {
-        "Filename": "pkg/handler/server.go",
-        "Line": 55,
-        "Column": 2,
-        "Offset": 2048
-      },
-      "Replacement": null,
-      "ExpectNoLint": false,
-      "ExpectedNoLintLinter": ""
-    },
-    {
-      "FromLinter": "gosimple",
-      "Text": "S1003: should replace strings.Index with strings.Contains",
-      "Severity": "warning",
-      "SourceLines": [
-        "    if strings.Index(s, sub) >= 0 {",
-        "        return true",
-        "    }"
-      ],
-      "Pos": {
-        "Filename": "pkg/utils/strings.go",
-        "Line": 15,
-        "Column": 2,
-        "Offset": 512
-      },
-      "Replacement": null,
-      "ExpectNoLint": false,
-      "ExpectedNoLintLinter": ""
-    },
-    {
-      "FromLinter": "govet",
-      "Text": "printf: Sprintf format %s has arg of wrong type int",
-      "Severity": "error",
-      "SourceLines": [
-        "    fmt.Sprintf(\"%s\", 42)"
-      ],
-      "Pos": {
-        "Filename": "cmd/main/main.go",
-        "Line": 10,
-        "Column": 3,
-        "Offset": 256
-      },
-      "Replacement": null,
-      "ExpectNoLint": false,
-      "ExpectedNoLintLinter": ""
-    },
-    {
-      "FromLinter": "unused",
-      "Text": "func `unusedHelper` is unused",
-      "Severity": "warning",
-      "SourceLines": [
-        "func unusedHelper() {",
-        "    // implementation",
-        "}"
-      ],
-      "Pos": {
-        "Filename": "internal/helpers.go",
-        "Line": 100,
-        "Column": 1,
-        "Offset": 4096
-      },
-      "Replacement": null,
-      "ExpectNoLint": false,
-      "ExpectedNoLintLinter": ""
-    },
-    {
-      "FromLinter": "errcheck",
-      "Text": "Error return value of `close` is not checked",
-      "Severity": "error",
-      "SourceLines": [
-        "    defer file.Close()"
-      ],
-      "Pos": {
-        "Filename": "pkg/handler/server.go",
-        "Line": 120,
-        "Column": 10,
-        "Offset": 3072
-      },
-      "Replacement": null,
-      "ExpectNoLint": false,
-      "ExpectedNoLintLinter": ""
-    },
-    {
-      "FromLinter": "gosimple",
-      "Text": "S1005: should omit nil check",
-      "Severity": "warning",
-      "SourceLines": [
-        "    if m != nil {",
-        "        for k, v := range m {",
-        "            process(k, v)",
-        "        }",
-        "    }"
-      ],
-      "Pos": {
-        "Filename": "pkg/utils/strings.go",
-        "Line": 45,
-        "Column": 1,
-        "Offset": 1536
-      },
-      "Replacement": null,
-      "ExpectNoLint": false,
-      "ExpectedNoLintLinter": ""
-    }
-  ],
-  "Report": {
-    "Warnings": [],
-    "Linters": [
-      {"Name": "errcheck", "Enabled": true, "EnabledByDefault": true},
-      {"Name": "gosimple", "Enabled": true, "EnabledByDefault": true},
-      {"Name": "govet", "Enabled": true, "EnabledByDefault": true},
-      {"Name": "unused", "Enabled": true, "EnabledByDefault": true}
-    ]
-  }
-}"#;
+        let raw = include_str!("../tests/fixtures/golangci_v2_json.txt");
 
         let filtered = filter_golangci_json(raw, 2);
         let savings = 100.0 - (count_tokens(&filtered) as f64 / count_tokens(raw) as f64 * 100.0);

--- a/tests/fixtures/golangci_v2_json.txt
+++ b/tests/fixtures/golangci_v2_json.txt
@@ -1,0 +1,144 @@
+{
+  "Issues": [
+    {
+      "FromLinter": "errcheck",
+      "Text": "Error return value of `foo` is not checked",
+      "Severity": "error",
+      "SourceLines": [
+        "    if err := foo(); err != nil {",
+        "        return err",
+        "    }"
+      ],
+      "Pos": {
+        "Filename": "pkg/handler/server.go",
+        "Line": 42,
+        "Column": 5,
+        "Offset": 1024
+      },
+      "Replacement": null,
+      "ExpectNoLint": false,
+      "ExpectedNoLintLinter": ""
+    },
+    {
+      "FromLinter": "errcheck",
+      "Text": "Error return value of `bar` is not checked",
+      "Severity": "error",
+      "SourceLines": [
+        "    bar()",
+        "    return nil",
+        "}"
+      ],
+      "Pos": {
+        "Filename": "pkg/handler/server.go",
+        "Line": 55,
+        "Column": 2,
+        "Offset": 2048
+      },
+      "Replacement": null,
+      "ExpectNoLint": false,
+      "ExpectedNoLintLinter": ""
+    },
+    {
+      "FromLinter": "gosimple",
+      "Text": "S1003: should replace strings.Index with strings.Contains",
+      "Severity": "warning",
+      "SourceLines": [
+        "    if strings.Index(s, sub) >= 0 {",
+        "        return true",
+        "    }"
+      ],
+      "Pos": {
+        "Filename": "pkg/utils/strings.go",
+        "Line": 15,
+        "Column": 2,
+        "Offset": 512
+      },
+      "Replacement": null,
+      "ExpectNoLint": false,
+      "ExpectedNoLintLinter": ""
+    },
+    {
+      "FromLinter": "govet",
+      "Text": "printf: Sprintf format %s has arg of wrong type int",
+      "Severity": "error",
+      "SourceLines": [
+        "    fmt.Sprintf(\"%s\", 42)"
+      ],
+      "Pos": {
+        "Filename": "cmd/main/main.go",
+        "Line": 10,
+        "Column": 3,
+        "Offset": 256
+      },
+      "Replacement": null,
+      "ExpectNoLint": false,
+      "ExpectedNoLintLinter": ""
+    },
+    {
+      "FromLinter": "unused",
+      "Text": "func `unusedHelper` is unused",
+      "Severity": "warning",
+      "SourceLines": [
+        "func unusedHelper() {",
+        "    // implementation",
+        "}"
+      ],
+      "Pos": {
+        "Filename": "internal/helpers.go",
+        "Line": 100,
+        "Column": 1,
+        "Offset": 4096
+      },
+      "Replacement": null,
+      "ExpectNoLint": false,
+      "ExpectedNoLintLinter": ""
+    },
+    {
+      "FromLinter": "errcheck",
+      "Text": "Error return value of `close` is not checked",
+      "Severity": "error",
+      "SourceLines": [
+        "    defer file.Close()"
+      ],
+      "Pos": {
+        "Filename": "pkg/handler/server.go",
+        "Line": 120,
+        "Column": 10,
+        "Offset": 3072
+      },
+      "Replacement": null,
+      "ExpectNoLint": false,
+      "ExpectedNoLintLinter": ""
+    },
+    {
+      "FromLinter": "gosimple",
+      "Text": "S1005: should omit nil check",
+      "Severity": "warning",
+      "SourceLines": [
+        "    if m != nil {",
+        "        for k, v := range m {",
+        "            process(k, v)",
+        "        }",
+        "    }"
+      ],
+      "Pos": {
+        "Filename": "pkg/utils/strings.go",
+        "Line": 45,
+        "Column": 1,
+        "Offset": 1536
+      },
+      "Replacement": null,
+      "ExpectNoLint": false,
+      "ExpectedNoLintLinter": ""
+    }
+  ],
+  "Report": {
+    "Warnings": [],
+    "Linters": [
+      {"Name": "errcheck", "Enabled": true, "EnabledByDefault": true},
+      {"Name": "gosimple", "Enabled": true, "EnabledByDefault": true},
+      {"Name": "govet", "Enabled": true, "EnabledByDefault": true},
+      {"Name": "unused", "Enabled": true, "EnabledByDefault": true}
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Detect golangci-lint major version at runtime via `golangci-lint --version`
- Use `--output.json.path stdout` for v2, `--out-format=json` for v1
- Extract JSON from first line only on v2 (v2 appends trailing metadata after the JSON line)
- Deserialise new v2 JSON fields: `SourceLines`, `Severity`, `Offset` (all `#[serde(default)]` for v1 back-compat)
- Show first source line per linter-file group on v2 output (richer context at no extra token cost for v1 users)
- Always forward stderr to caller — previously suppressed unless `--verbose`, silently dropping config errors and missing-linter warnings
- Falls back to v1 behaviour on any version detection failure (safe default)

Closes #721

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk golangci-lint run` output inspected

### New tests added (16 total in module)

- `test_parse_version_v1_format` — parses `"golangci-lint version 1.59.1"`
- `test_parse_version_v2_format` — parses `"golangci-lint has version 2.10.0 built with ..."`
- `test_parse_version_empty_returns_1` — safe fallback on empty string
- `test_parse_version_malformed_returns_1` — safe fallback on unexpected string
- `test_filter_golangci_v2_fields_parse_cleanly` — v2 JSON with `Severity`/`SourceLines`/`Offset` doesn't panic
- `test_filter_v2_shows_source_lines` — v2 shows `→ <source line>` in output
- `test_filter_v1_does_not_show_source_lines` — v1 does not emit source lines
- `test_filter_v2_empty_source_lines_graceful` — degrades cleanly when `SourceLines` is empty
- `test_filter_v2_source_line_truncated_to_80_chars` — ASCII lines capped at 80 chars
- `test_filter_v2_source_line_truncated_non_ascii` — unicode-safe truncation via `char_indices`
- `test_golangci_v2_token_savings` — realistic v2 fixture achieves ≥60% token savings

## Known tradeoff

`golangci-lint --version` is called on every `rtk golangci-lint` invocation to detect the major version. This adds ~5-20ms subprocess overhead. It is the cleanest approach — zero configuration required, works transparently on version upgrades. A future improvement could cache the result (e.g. via `lazy_static` or a short-lived on-disk cache) to eliminate the overhead entirely.