### PR TITLE
feat(init): complete Copilot lifecycle - uninstall, idempotency, show_config

### DIFF
--- a/.github/hooks/rtk-rewrite.json
+++ b/.github/hooks/rtk-rewrite.json
@@ -3,7 +3,7 @@
     "PreToolUse": [
       {
         "type": "command",
-        "command": "rtk hook",
+        "command": "rtk hook copilot",
         "cwd": ".",
         "timeout": 5
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
+* **init:** `rtk init --agent copilot` — one-command setup for GitHub Copilot (VS Code + CLI): installs `.github/copilot-instructions.md` and `.github/hooks/rtk-rewrite.json` PreToolUse hook; idempotent; `--uninstall --agent copilot` removes both
 * **aws:** expand CLI filters from 8 to 25 subcommands — CloudWatch Logs, CloudFormation events, Lambda, IAM, DynamoDB (with type unwrapping), ECS tasks, EC2 security groups, S3API objects, S3 sync/cp, EKS, SQS, Secrets Manager ([#885](https://github.com/rtk-ai/rtk/pull/885))
 * **aws:** add shared runner `run_aws_filtered()` eliminating per-handler boilerplate
 * **tee:** add `force_tee_hint()` — truncated output saves full data to file with recovery hint
+
+### Bug Fixes
+
+* **hook:** `rtk hook copilot` now correctly registered in `RTK_META_COMMANDS` — bare `rtk hook` no longer falls through to passthrough mode (exit 127); `.github/hooks/rtk-rewrite.json` corrected to invoke `rtk hook copilot`
 
 ## [0.34.3](https://github.com/rtk-ai/rtk/compare/v0.34.2...v0.34.3) (2026-04-02)
 
@@ -77,7 +82,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **refacto-codebase:** technical docs & sub folders ([927daef](https://github.com/rtk-ai/rtk/commit/927daef49b8f771d195201d196378e27e0ee8a2b))
 
 ## [0.34.1](https://github.com/rtk-ai/rtk/compare/v0.34.0...v0.34.1) (2026-03-28)
-
 
 ### Bug Fixes
 

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -11,6 +11,7 @@ use super::constants::{
     REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use super::integrity;
+use crate::core::utils;
 
 // Embedded hook script (guards before set -euo pipefail)
 const REWRITE_HOOK: &str = include_str!("../../hooks/claude/rtk-rewrite.sh");
@@ -224,6 +225,7 @@ pub fn run(
     install_cursor: bool,
     install_windsurf: bool,
     install_cline: bool,
+    install_copilot: bool,
     claude_md: bool,
     hook_only: bool,
     codex: bool,
@@ -273,6 +275,15 @@ pub fn run(
         return run_cline_mode(verbose);
     }
 
+    // Copilot-only mode (always project-scoped — ignore -g if passed)
+    if install_copilot {
+        if global {
+            println!("Note: GitHub Copilot integration is always project-scoped (.github/).");
+            println!("      Ignoring -g flag.\n");
+        }
+        return run_copilot_mode(verbose);
+    }
+
     // Mode selection (Claude Code / OpenCode)
     match (install_claude, install_opencode, claude_md, hook_only) {
         (false, true, _, _) => run_opencode_only_mode(verbose)?,
@@ -280,7 +291,7 @@ pub fn run(
         (true, opencode, false, true) => run_hook_only_mode(global, patch_mode, verbose, opencode)?,
         (true, opencode, false, false) => run_default_mode(global, patch_mode, verbose, opencode)?,
         (false, false, _, _) => {
-            if !install_cursor {
+            if !install_cursor && !install_copilot {
                 anyhow::bail!("at least one of install_claude or install_opencode must be true")
             }
         }
@@ -530,9 +541,67 @@ fn remove_hook_from_settings(verbose: u8) -> Result<bool> {
 }
 
 /// Full uninstall for Claude, Gemini, Codex, or Cursor artifacts.
-pub fn uninstall(global: bool, gemini: bool, codex: bool, cursor: bool, verbose: u8) -> Result<()> {
+pub fn uninstall(
+    global: bool,
+    gemini: bool,
+    codex: bool,
+    cursor: bool,
+    copilot: bool,
+    verbose: u8,
+) -> Result<()> {
     if codex {
         return uninstall_codex(global, verbose);
+    }
+
+    if copilot {
+        let instructions_path = PathBuf::from(".github/copilot-instructions.md");
+        let hook_path = PathBuf::from(".github/hooks/rtk-rewrite.json");
+        let mut removed = Vec::new();
+
+        if instructions_path.exists() {
+            let content = fs::read_to_string(&instructions_path).unwrap_or_default();
+            // Strip only the RTK section; preserve any pre-existing user content
+            let stripped = content
+                .replace(&format!("\n\n{}", COPILOT_INSTRUCTIONS), "")
+                .replace(COPILOT_INSTRUCTIONS, "");
+            let stripped = stripped.trim();
+            if stripped.is_empty() {
+                fs::remove_file(&instructions_path)
+                    .with_context(|| format!("Failed to remove {}", instructions_path.display()))?;
+                if verbose > 0 {
+                    eprintln!("Removed {}", instructions_path.display());
+                }
+            } else {
+                fs::write(&instructions_path, format!("{}\n", stripped))
+                    .with_context(|| format!("Failed to update {}", instructions_path.display()))?;
+                if verbose > 0 {
+                    eprintln!(
+                        "Updated {} (RTK section removed)",
+                        instructions_path.display()
+                    );
+                }
+            }
+            removed.push(instructions_path.display().to_string());
+        }
+
+        if hook_path.exists() {
+            fs::remove_file(&hook_path)
+                .with_context(|| format!("Failed to remove {}", hook_path.display()))?;
+            if verbose > 0 {
+                eprintln!("Removed {}", hook_path.display());
+            }
+            removed.push(hook_path.display().to_string());
+        }
+
+        if removed.is_empty() {
+            println!("RTK Copilot support was not installed in this project (nothing to remove)");
+        } else {
+            println!("\nRTK uninstalled (GitHub Copilot):");
+            for item in &removed {
+                println!("  - {}", item);
+            }
+        }
+        return Ok(());
     }
 
     if cursor {
@@ -1321,6 +1390,82 @@ fn run_antigravity_mode_at(base_dir: &Path, verbose: u8) -> Result<()> {
     }
     println!("  Antigravity will now use rtk commands for token savings.");
     println!("  Test with: git status\n");
+
+    Ok(())
+}
+
+/// Embedded GitHub Copilot RTK instructions
+const COPILOT_INSTRUCTIONS: &str = include_str!("../../hooks/copilot/rtk-awareness.md");
+
+/// Embedded VS Code / Copilot CLI hook JSON (single source of truth)
+const COPILOT_HOOK_JSON: &str = include_str!("../../.github/hooks/rtk-rewrite.json");
+
+// ─── GitHub Copilot support ──────────────────────────────────────
+
+fn run_copilot_mode(verbose: u8) -> Result<()> {
+    // GitHub Copilot reads .github/copilot-instructions.md (project-scoped)
+    // and .github/hooks/rtk-rewrite.json (PreToolUse hook for VS Code + Copilot CLI)
+    let github_dir = PathBuf::from(".github");
+    let hooks_dir = github_dir.join("hooks");
+    let instructions_path = github_dir.join("copilot-instructions.md");
+    let hook_path = hooks_dir.join("rtk-rewrite.json");
+
+    // Verify rtk is in PATH (required for the hook to work)
+    if !utils::tool_exists("rtk") {
+        eprintln!("Warning: rtk binary not found in PATH.");
+        eprintln!("  The hook will not work until rtk is installed globally.");
+        eprintln!("  Install: cargo install rtk-ai  (or see README for binary install)");
+    }
+
+    // Check if already fully configured
+    let hook_exists = hook_path.exists();
+    let instructions_exist = instructions_path.exists()
+        && fs::read_to_string(&instructions_path)
+            .unwrap_or_default()
+            .contains("rtk");
+    if hook_exists && instructions_exist {
+        println!("RTK already configured for GitHub Copilot in this project.");
+        println!("  Hook:         {}", hook_path.display());
+        println!("  Instructions: {}", instructions_path.display());
+        return Ok(());
+    }
+
+    fs::create_dir_all(&hooks_dir).context("Failed to create .github/hooks directory")?;
+
+    // 1. Install hook JSON (this is what actually intercepts commands)
+    if hook_exists {
+        if verbose > 0 {
+            println!("  Hook: {} (already present)", hook_path.display());
+        }
+    } else {
+        fs::write(&hook_path, COPILOT_HOOK_JSON)
+            .context("Failed to write .github/hooks/rtk-rewrite.json")?;
+        if verbose > 0 {
+            eprintln!("Wrote {}", hook_path.display());
+        }
+    }
+
+    // 2. Install instructions (soft layer: hints for the LLM)
+    let existing = fs::read_to_string(&instructions_path).unwrap_or_default();
+    if !instructions_exist {
+        let new_content = if existing.trim().is_empty() {
+            COPILOT_INSTRUCTIONS.to_string()
+        } else {
+            format!("{}\n\n{}", existing.trim(), COPILOT_INSTRUCTIONS)
+        };
+        fs::write(&instructions_path, &new_content)
+            .context("Failed to write .github/copilot-instructions.md")?;
+        if verbose > 0 {
+            eprintln!("Wrote {}", instructions_path.display());
+        }
+    }
+
+    println!("\nRTK configured for GitHub Copilot (project-scoped).\n");
+    println!("  Hook config:  {}", hook_path.display());
+    println!("  Instructions: {}", instructions_path.display());
+    println!("\n  VS Code Copilot Chat: transparent rewrite via updatedInput");
+    println!("  Copilot CLI:          deny-with-suggestion (re-runs with rtk prefix)");
+    println!("\n  Restart your IDE or Copilot CLI session to activate.\n");
 
     Ok(())
 }
@@ -2117,6 +2262,42 @@ fn show_claude_config() -> Result<()> {
         println!("[--] Cursor: home dir not found");
     }
 
+    // Check Copilot artifacts (project-scoped in .github/)
+    let copilot_hook = PathBuf::from(".github/hooks/rtk-rewrite.json");
+    let copilot_instructions = PathBuf::from(".github/copilot-instructions.md");
+    if copilot_hook.exists() {
+        let content = fs::read_to_string(&copilot_hook).unwrap_or_default();
+        if content.contains("rtk hook copilot") {
+            println!(
+                "[ok] Copilot hook: {} (rtk hook copilot configured)",
+                copilot_hook.display()
+            );
+        } else {
+            println!(
+                "[warn] Copilot hook: {} (exists but rtk not configured)",
+                copilot_hook.display()
+            );
+        }
+    } else {
+        println!("[--] Copilot hook: not found (run: rtk init --agent copilot)");
+    }
+    if copilot_instructions.exists() {
+        let content = fs::read_to_string(&copilot_instructions).unwrap_or_default();
+        if content.contains("rtk") {
+            println!(
+                "[ok] Copilot instructions: {} (rtk configured)",
+                copilot_instructions.display()
+            );
+        } else {
+            println!(
+                "[--] Copilot instructions: {} (exists but rtk not mentioned)",
+                copilot_instructions.display()
+            );
+        }
+    } else {
+        println!("[--] Copilot instructions: not found (run: rtk init --agent copilot)");
+    }
+
     println!("\nUsage:");
     println!("  rtk init              # Full injection into local CLAUDE.md");
     println!("  rtk init -g           # Hook + RTK.md + @RTK.md + settings.json (recommended)");
@@ -2129,6 +2310,7 @@ fn show_claude_config() -> Result<()> {
     println!("  rtk init -g --codex         # Configure ~/.codex/AGENTS.md + ~/.codex/RTK.md");
     println!("  rtk init -g --opencode      # OpenCode plugin only");
     println!("  rtk init -g --agent cursor  # Install Cursor Agent hooks");
+    println!("  rtk init --agent copilot    # Install GitHub Copilot hook + instructions");
 
     Ok(())
 }
@@ -2408,49 +2590,6 @@ fn uninstall_gemini(verbose: u8) -> Result<Vec<String>> {
     Ok(removed)
 }
 
-// ── Copilot integration ─────────────────────────────────────
-
-const COPILOT_HOOK_JSON: &str = r#"{
-  "hooks": {
-    "PreToolUse": [
-      {
-        "type": "command",
-        "command": "rtk hook copilot",
-        "cwd": ".",
-        "timeout": 5
-      }
-    ]
-  }
-}
-"#;
-
-const COPILOT_INSTRUCTIONS: &str = r#"# RTK — Token-Optimized CLI
-
-**rtk** is a CLI proxy that filters and compresses command outputs, saving 60-90% tokens.
-
-## Rule
-
-Always prefix shell commands with `rtk`:
-
-```bash
-# Instead of:              Use:
-git status                 rtk git status
-git log -10                rtk git log -10
-cargo test                 rtk cargo test
-docker ps                  rtk docker ps
-kubectl get pods           rtk kubectl pods
-```
-
-## Meta commands (use directly)
-
-```bash
-rtk gain              # Token savings dashboard
-rtk gain --history    # Per-command savings history
-rtk discover          # Find missed rtk opportunities
-rtk proxy <cmd>       # Run raw (no filtering) but track usage
-```
-"#;
-
 /// Entry point for `rtk init --copilot`
 pub fn run_copilot(verbose: u8) -> Result<()> {
     // Install in current project's .github/ directory
@@ -2490,7 +2629,11 @@ pub fn run_copilot(verbose: u8) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
     use tempfile::TempDir;
+
+    /// Serialize tests that change the process CWD (global state).
+    static CWD_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_init_mentions_all_top_level_commands() {
@@ -2714,6 +2857,7 @@ More notes
             false,
             false,
             false,
+            false, // install_copilot
             false,
             false,
             true,
@@ -2736,6 +2880,7 @@ More notes
             false,
             false,
             false,
+            false, // install_copilot
             false,
             false,
             true,
@@ -3229,5 +3374,165 @@ More notes
         assert!(CURSOR_REWRITE_HOOK.contains("\"permission\": \"allow\""));
         assert!(CURSOR_REWRITE_HOOK.contains("\"updated_input\""));
         assert!(!CURSOR_REWRITE_HOOK.contains("hookSpecificOutput"));
+    }
+
+    // ─── GitHub Copilot init tests ──────────────────────────────────
+
+    #[test]
+    fn test_run_copilot_mode_installs_both_files() {
+        let _guard = CWD_LOCK.lock().unwrap();
+        let temp = TempDir::new().unwrap();
+        let original_dir = std::env::current_dir().unwrap();
+        std::env::set_current_dir(temp.path()).unwrap();
+
+        run_copilot_mode(0).unwrap();
+
+        let instructions = temp.path().join(".github/copilot-instructions.md");
+        let hook = temp.path().join(".github/hooks/rtk-rewrite.json");
+
+        assert!(
+            instructions.exists(),
+            "copilot-instructions.md should be created"
+        );
+        assert!(
+            hook.exists(),
+            ".github/hooks/rtk-rewrite.json should be created"
+        );
+
+        let hook_content = fs::read_to_string(&hook).unwrap();
+        assert!(
+            hook_content.contains("rtk hook copilot"),
+            "hook JSON must invoke 'rtk hook copilot', got: {}",
+            hook_content
+        );
+
+        let instructions_content = fs::read_to_string(&instructions).unwrap();
+        assert!(
+            instructions_content.contains("RTK") || instructions_content.contains("rtk"),
+            "instructions should mention RTK"
+        );
+
+        std::env::set_current_dir(original_dir).unwrap();
+    }
+
+    #[test]
+    fn test_run_copilot_mode_idempotent() {
+        let _guard = CWD_LOCK.lock().unwrap();
+        let temp = TempDir::new().unwrap();
+        let original_dir = std::env::current_dir().unwrap();
+        std::env::set_current_dir(temp.path()).unwrap();
+
+        run_copilot_mode(0).unwrap();
+        run_copilot_mode(0).unwrap(); // second run should not panic or duplicate
+
+        let instructions = temp.path().join(".github/copilot-instructions.md");
+        let content = fs::read_to_string(&instructions).unwrap();
+        // RTK block should appear exactly once (not duplicated)
+        let count = content.matches("# RTK").count();
+        assert!(
+            count <= 1,
+            "RTK block should not be duplicated, found {} times",
+            count
+        );
+
+        std::env::set_current_dir(original_dir).unwrap();
+    }
+
+    #[test]
+    fn test_uninstall_copilot_removes_both_files() {
+        let _guard = CWD_LOCK.lock().unwrap();
+        let temp = TempDir::new().unwrap();
+        let original_dir = std::env::current_dir().unwrap();
+        std::env::set_current_dir(temp.path()).unwrap();
+
+        run_copilot_mode(0).unwrap();
+
+        let instructions = temp.path().join(".github/copilot-instructions.md");
+        let hook = temp.path().join(".github/hooks/rtk-rewrite.json");
+        assert!(instructions.exists());
+        assert!(hook.exists());
+
+        uninstall(false, false, false, false, true, 0).unwrap();
+
+        assert!(
+            !instructions.exists(),
+            "instructions should be removed on uninstall"
+        );
+        assert!(!hook.exists(), "hook JSON should be removed on uninstall");
+
+        std::env::set_current_dir(original_dir).unwrap();
+    }
+
+    #[test]
+    fn test_uninstall_copilot_preserves_user_content() {
+        let _guard = CWD_LOCK.lock().unwrap();
+        let temp = TempDir::new().unwrap();
+        let original_dir = std::env::current_dir().unwrap();
+        std::env::set_current_dir(temp.path()).unwrap();
+
+        // Create a file with pre-existing user content
+        let github_dir = temp.path().join(".github");
+        fs::create_dir_all(&github_dir).unwrap();
+        let instructions = github_dir.join("copilot-instructions.md");
+        fs::write(
+            &instructions,
+            "# My custom instructions\n\nDo not break me.\n",
+        )
+        .unwrap();
+
+        // Install appends RTK section to existing content
+        run_copilot_mode(0).unwrap();
+        let after_install = fs::read_to_string(&instructions).unwrap();
+        assert!(
+            after_install.contains("My custom instructions"),
+            "install must preserve user content"
+        );
+        assert!(
+            after_install.contains("RTK"),
+            "install must append RTK section"
+        );
+
+        // Uninstall should strip RTK section but keep user content
+        uninstall(false, false, false, false, true, 0).unwrap();
+        assert!(
+            instructions.exists(),
+            "instructions file should remain when user content exists"
+        );
+        let after_uninstall = fs::read_to_string(&instructions).unwrap();
+        assert!(
+            after_uninstall.contains("My custom instructions"),
+            "user content must be preserved after uninstall"
+        );
+        assert!(
+            !after_uninstall.contains("rtk hook copilot"),
+            "RTK section must be removed on uninstall"
+        );
+
+        std::env::set_current_dir(original_dir).unwrap();
+    }
+
+    #[test]
+    fn test_uninstall_copilot_noop_when_not_installed() {
+        let _guard = CWD_LOCK.lock().unwrap();
+        let temp = TempDir::new().unwrap();
+        let original_dir = std::env::current_dir().unwrap();
+        std::env::set_current_dir(temp.path()).unwrap();
+
+        // Should not error even if nothing is installed
+        uninstall(false, false, false, false, true, 0).unwrap();
+
+        std::env::set_current_dir(original_dir).unwrap();
+    }
+
+    #[test]
+    fn test_copilot_hook_json_contains_correct_command() {
+        assert!(
+            COPILOT_HOOK_JSON.contains("rtk hook copilot"),
+            "embedded hook JSON must invoke 'rtk hook copilot'"
+        );
+        assert!(
+            COPILOT_HOOK_JSON.contains("PreToolUse"),
+            "hook JSON must use PreToolUse event"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,8 @@ pub enum AgentTarget {
     Kilocode,
     /// Google Antigravity
     Antigravity,
+    /// GitHub Copilot (VS Code Copilot Chat + Copilot CLI)
+    Copilot,
 }
 
 #[derive(Parser)]
@@ -1046,6 +1048,7 @@ const RTK_META_COMMANDS: &[&str] = &[
     "init",
     "config",
     "proxy",
+    "hook",
     "hook-audit",
     "cc-economics",
     "verify",
@@ -1616,7 +1619,8 @@ fn run_cli() -> Result<i32> {
                 hooks::init::show_config(codex)?;
             } else if uninstall {
                 let cursor = agent == Some(AgentTarget::Cursor);
-                hooks::init::uninstall(global, gemini, codex, cursor, cli.verbose)?;
+                let copilot = agent == Some(AgentTarget::Copilot);
+                hooks::init::uninstall(global, gemini, codex, cursor, copilot, cli.verbose)?;
             } else if gemini {
                 let patch_mode = if auto_patch {
                     hooks::init::PatchMode::Auto
@@ -1646,6 +1650,7 @@ fn run_cli() -> Result<i32> {
                 let install_cursor = agent == Some(AgentTarget::Cursor);
                 let install_windsurf = agent == Some(AgentTarget::Windsurf);
                 let install_cline = agent == Some(AgentTarget::Cline);
+                let install_copilot = agent == Some(AgentTarget::Copilot);
 
                 let patch_mode = if auto_patch {
                     hooks::init::PatchMode::Auto
@@ -1661,6 +1666,7 @@ fn run_cli() -> Result<i32> {
                     install_cursor,
                     install_windsurf,
                     install_cline,
+                    install_copilot,
                     claude_md,
                     hook_only,
                     codex,


### PR DESCRIPTION
## Context

PR #859 (merged) shipped a basic `--copilot` flag from PR #824. This PR completes what was shipped — adding the full agent lifecycle that every other agent in rtk has.

Upstream's current `run_copilot()` installs files and exits. No idempotency. No uninstall. `rtk init --show` is blind to Copilot files. This PR fills all of those gaps.

## What this adds on top of what shipped

| Feature | `--copilot` (upstream, merged) | `--agent copilot` (this PR) |
|---------|-------------------------------|------------------------------|
| Installs `.github/` files | ✅ | ✅ |
| Enum pattern (`--agent copilot`) | ❌ standalone `--copilot: bool` | ✅ consistent with `--agent cline/windsurf/cursor` |
| Idempotency | ❌ always re-runs | ✅ early-return with clear status message |
| PATH check for `rtk` binary | ❌ none | ✅ `utils::tool_exists()` — cross-platform, no false positives on Windows |
| `--uninstall --agent copilot` | ❌ no uninstall path exists | ✅ strips RTK section, preserves pre-existing user content |
| `rtk init --show` Copilot status | ❌ `show_config()` has no Copilot awareness | ✅ `[ok]/[--]` for both `.github/` files |
| Unit tests | 0 | 6 new tests |

## Also fixes #836 / supersedes #837

Issue #836 reports that users who ran `rtk init --copilot` early on got `.github/hooks/rtk-rewrite.json` with `"command": "rtk hook"` (missing subcommand), causing a `parse_failure` entry on every Bash tool call.

- This PR's uninstall path removes the broken file cleanly
- This PR's `show_config()` exposes the Copilot files so users can inspect/verify the state
- PR #837 (also open, targets same bug) adds orphaned hook detection to `--show` and `--uninstall`; this PR's broader lifecycle support already covers that surface

## Changes

| File | Change |
|------|--------|
| `src/main.rs` | `AgentTarget::Copilot` enum variant; `"hook"` added to `RTK_META_COMMANDS`; routing to `run_copilot_mode()` |
| `src/hooks/init.rs` | `run_copilot_mode()` (idempotent install), full uninstall branch (content-safe), `show_config()` checks, 6 unit tests |
| `.github/hooks/rtk-rewrite.json` | `"rtk hook"` → `"rtk hook copilot"` (embedded via `include_str!`, single source of truth) |
| `CHANGELOG.md` | `[Unreleased]` entries |

```bash
# Install (project-scoped, idempotent)
rtk init --agent copilot
# → .github/hooks/rtk-rewrite.json  (PreToolUse hook)
# → .github/copilot-instructions.md (RTK usage rules)

# Uninstall (strips RTK section, preserves pre-existing user content)
rtk init --uninstall --agent copilot

# Check status
rtk init --show
```

## Testing

```
✅ cargo fmt --all
✅ cargo clippy --all-targets (0 warnings)
✅ 1129 tests passed (6 new Copilot tests)
✅ Manual: install → idempotent re-run → uninstall → content preserved — all verified
```
