### PR TITLE
fix(cargo): preserve test compile diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **ruby:** add `ruby_exec()` shared utility for auto-detecting `bundle exec` when Gemfile exists
 * **ruby:** add discover/rewrite rules for rake, rails, rspec, rubocop, and bundle commands
 
+### Bug Fixes
+
+* **cargo:** preserve compile diagnostics when `cargo test` fails before any test suites run
+
 ## [0.30.1](https://github.com/rtk-ai/rtk/compare/v0.30.0...v0.30.1) (2026-03-18)
 
 

--- a/src/cargo_cmd.rs
+++ b/src/cargo_cmd.rs
@@ -850,6 +850,18 @@ fn filter_cargo_test(output: &str) -> String {
     }
 
     if result.trim().is_empty() {
+        let has_compile_errors = output.lines().any(|line| {
+            let trimmed = line.trim_start();
+            trimmed.starts_with("error[") || trimmed.starts_with("error:")
+        });
+
+        if has_compile_errors {
+            let build_filtered = filter_cargo_build(output);
+            if build_filtered.starts_with("cargo build:") {
+                return build_filtered.replacen("cargo build:", "cargo test:", 1);
+            }
+        }
+
         // Fallback: show last meaningful lines
         let meaningful: Vec<&str> = output
             .lines()
@@ -1312,6 +1324,29 @@ test result: MALFORMED LINE WITHOUT PROPER FORMAT
             "Expected fallback format, got: {}",
             result
         );
+    }
+
+    #[test]
+    fn test_filter_cargo_test_compile_error_preserves_error_header() {
+        let output = r#"   Compiling rtk v0.31.0 (/workspace/projects/rtk)
+error[E0425]: cannot find value `missing_symbol` in this scope
+ --> tests/repro_compile_fail.rs:3:13
+  |
+3 |     let _ = missing_symbol;
+  |             ^^^^^^^^^^^^^^ not found in this scope
+
+For more information about this error, try `rustc --explain E0425`.
+error: could not compile `rtk` (test "repro_compile_fail") due to 1 previous error
+"#;
+        let result = filter_cargo_test(output);
+        assert!(result.contains("cargo test: 1 errors, 0 warnings (1 crates)"));
+        assert!(result.contains("error[E0425]"), "got: {}", result);
+        assert!(
+            result.contains("--> tests/repro_compile_fail.rs:3:13"),
+            "got: {}",
+            result
+        );
+        assert!(!result.starts_with('|'), "got: {}", result);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve rustc compile diagnostics when `cargo test` fails before any test suites run
- reuse the existing build diagnostic formatter for compile-error-only `cargo test` output and relabel it from `cargo build:` to `cargo test:`
- add a regression test and update `CHANGELOG.md` for the cargo test compile-diagnostics fix

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Unit test added in `src/cargo_cmd.rs` for compile-failing `cargo test` output
- [x] Manual testing: created a temporary compile-failing test and ran `./target/debug/rtk cargo test --test repro_compile_fail`
- [x] Manual testing: verified filtered output preserved `error[E0425]` and `tests/repro_compile_fail.rs:3:13`
- [x] Manual testing: removed the temporary repro file after verification

Closes #740