### PR TITLE
fix(hook): hook warning repeats on every command on Windows

### DIFF
--- a/src/hook_check.rs
+++ b/src/hook_check.rs
@@ -67,9 +67,11 @@ fn check_and_warn() -> Option<()> {
 
     eprintln!("{}", warning);
 
-    // Touch marker after warning is printed
+    // Touch marker after warning is printed.
+    // Write a non-empty payload — on Windows, writing 0 bytes to an already-empty
+    // file may not update the mtime, which breaks the rate-limiting check.
     let _ = std::fs::create_dir_all(marker.parent()?);
-    let _ = std::fs::write(&marker, b"");
+    let _ = std::fs::write(&marker, b"1");
 
     Some(())
 }


### PR DESCRIPTION
## Summary
- std::fs::write(path, b"") writing 0 bytes to an already-empty marker file does not update the mtime on Windows
- The rate-limiting check uses meta.modified() so the marker always looked stale, causing the "No hook installed" warning to fire on every invocation instead of once per day
- Write a non-empty payload (b"1") so Windows always updates the mtime

## Test plan
- cargo fmt --all && cargo clippy --all-targets && cargo test — 982 tests pass
- Manual testing: rtk <command> output inspected
  - Set marker mtime to 5 days ago → rtk git status — warning shown (expected, marker expired)
  - rtk git status again — warning suppressed (rate-limiting works)
  - rtk tree — warning suppressed (persists across commands)

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
