### PR TITLE
feat(ruby): add rtk tapioca filter for Sorbet RBI generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,6 +282,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **ruby:** add TOML filter for `bundle install/update` — strip `Using` lines (90%+ reduction)
 * **ruby:** add `ruby_exec()` shared utility for auto-detecting `bundle exec` when Gemfile exists
 * **ruby:** add discover/rewrite rules for rake, rails, rspec, rubocop, and bundle commands
+* **ruby:** add Tapioca RBI generator filter — strips Compiling/Compiled/Loading/Fetching progress lines, keeps errors, warnings, and Done summary (~98% reduction for `gems`)
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ rtk go test                     # Go tests (NDJSON, -90%)
 rtk cargo test                  # Cargo tests (-90%)
 rtk rake test                   # Ruby minitest (-90%)
 rtk rspec                       # RSpec tests (JSON, -60%+)
+rtk tapioca gems                # Sorbet RBI generation (-98%)
 rtk err <cmd>                   # Filter errors only from any command
 rtk test <cmd>                  # Generic test wrapper - failures only (-90%)
 ```

--- a/src/cmds/ruby/README.md
+++ b/src/cmds/ruby/README.md
@@ -7,5 +7,6 @@
 - `rake_cmd.rs` filters Minitest output via `rake test` / `rails test`; state machine text parser, failures only (85-90% reduction)
 - `rspec_cmd.rs` uses JSON injection (`--format json`) with text fallback; failures only (60%+ reduction)
 - `rubocop_cmd.rs` uses JSON injection, groups by cop/severity (60%+ reduction)
-- All three modules use `ruby_exec()` from `utils.rs` to auto-detect `bundle exec` when a Gemfile exists
+- `tapioca_cmd.rs` filters Tapioca RBI generator output; strips Compiling/Loading/Fetching progress lines, keeps errors, warnings, and `Done` summary (~98% reduction for `gems`)
+- All four modules use `ruby_exec()` from `utils.rs` to auto-detect `bundle exec` when a Gemfile exists
 - TOML filter `bundle-install.toml` strips `Using` lines from `bundle install`/`update` (90%+ reduction)

--- a/src/cmds/ruby/tapioca_cmd.rs
+++ b/src/cmds/ruby/tapioca_cmd.rs
@@ -1,0 +1,421 @@
+//! Tapioca RBI generator filter.
+//!
+//! Strips verbose compile/fetch progress lines and keeps only errors,
+//! warnings, and the final Done summary line.
+
+use crate::core::tracking;
+use crate::core::utils::{exit_code_from_output, fallback_tail, ruby_exec, strip_ansi};
+use anyhow::{Context, Result};
+use lazy_static::lazy_static;
+use regex::Regex;
+
+lazy_static! {
+    static ref RE_SPRING: Regex = Regex::new(r"(?i)running via spring preloader").unwrap();
+    // Word-boundary match: avoids false positives like `actionable_error.rbi`
+    // `errors?` matches both "error" and "errors" (e.g. "No errors found")
+    static ref RE_ERROR: Regex = Regex::new(r"(?i)\berrors?\b").unwrap();
+    static ref RE_WARNING: Regex = Regex::new(r"(?i)\bwarnings?\b").unwrap();
+    // `gems` summary is "Checking generated RBI files...  Done" — contains but doesn't start with "Done"
+    static ref RE_DONE: Regex = Regex::new(r"\bDone\b").unwrap();
+}
+
+pub fn run(args: &[String], verbose: u8) -> Result<i32> {
+    let timer = tracking::TimedExecution::start();
+
+    let mut cmd = ruby_exec("tapioca");
+    cmd.args(args);
+
+    if verbose > 0 {
+        eprintln!("Running: tapioca {}", args.join(" "));
+    }
+
+    let output = cmd.output().context(
+        "Failed to run tapioca. Is it installed? Try: gem install tapioca or add it to your Gemfile",
+    )?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let raw = format!("{}\n{}", stdout, stderr);
+
+    let exit_code = exit_code_from_output(&output, "tapioca");
+
+    let filtered = if stdout.trim().is_empty() && !output.status.success() {
+        "Tapioca: FAILED (no stdout, see stderr below)".to_string()
+    } else {
+        filter_tapioca(&stdout)
+    };
+
+    if let Some(hint) = crate::core::tee::tee_and_hint(&raw, "tapioca", exit_code) {
+        println!("{}\n{}", filtered, hint);
+    } else {
+        println!("{}", filtered);
+    }
+
+    if !stderr.trim().is_empty() && (!output.status.success() || verbose > 0) {
+        eprintln!("{}", stderr.trim());
+    }
+
+    timer.track(
+        &format!("tapioca {}", args.join(" ")),
+        &format!("rtk tapioca {}", args.join(" ")),
+        &raw,
+        &filtered,
+    );
+
+    Ok(exit_code)
+}
+
+fn filter_tapioca(output: &str) -> String {
+    if output.trim().is_empty() {
+        return "tapioca: no output".to_string();
+    }
+
+    let clean = strip_ansi(output);
+
+    let kept: Vec<&str> = clean
+        .lines()
+        .filter(|line| !RE_SPRING.is_match(line))
+        .filter(|line| {
+            let t = line.trim();
+            if t.is_empty() {
+                return false;
+            }
+            RE_ERROR.is_match(t) || RE_WARNING.is_match(t) || RE_DONE.is_match(t)
+        })
+        .collect();
+
+    if kept.is_empty() {
+        return fallback_tail(&clean, "tapioca", 5);
+    }
+
+    kept.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::utils::count_tokens;
+
+    fn gems_clean_output() -> &'static str {
+        "Removing RBI files of gems that have been removed:\n\
+           Nothing to do.\n\
+         Generating RBI files of gems that are added or updated:\n\
+           Nothing to do.\n\
+         Checking generated RBI files...  Done\n\
+           No errors found\n\
+         All operations performed in working directory.\n\
+         Please review changes and commit them."
+    }
+
+    fn dsl_clean_output() -> &'static str {
+        "Loading DSL extension Tapioca::Dsl::Compilers::ActiveRecordAssociations...\n\
+         Loading DSL extension Tapioca::Dsl::Compilers::ActiveRecordColumns...\n\
+         Compiling User, this may take a few seconds...\n\
+         Compiled User\n\
+         Compiling Post, this may take a few seconds...\n\
+         Compiled Post\n\
+         Done compiling DSL RBI files (2 files in 2.4s)"
+    }
+
+    fn annotations_clean_output() -> &'static str {
+        "Fetching gem RBI annotations from sorbet-typed...\n\
+         Fetching annotations for activesupport (7.0.0)...\n\
+         Fetching annotations for addressable (2.8.0)...\n\
+         Done fetching RBI annotations (2 gems in 1.5s)"
+    }
+
+    fn large_gems_fixture() -> String {
+        let gems = [
+            "activesupport",
+            "addressable",
+            "ast",
+            "aws-sdk-core",
+            "base64",
+            "bcrypt",
+            "bigdecimal",
+            "bootsnap",
+            "bundler",
+            "capybara",
+            "childprocess",
+            "concurrent-ruby",
+            "connection_pool",
+            "crack",
+            "crass",
+            "date",
+            "devise",
+            "digest",
+            "dry-core",
+            "erubi",
+            "factory_bot",
+            "factory_bot_rails",
+            "faker",
+            "ffi",
+            "globalid",
+            "i18n",
+            "io-console",
+            "irb",
+            "json",
+            "launchy",
+            "loofah",
+            "mail",
+            "marcel",
+            "method_source",
+            "mime-types",
+            "minitest",
+            "msgpack",
+            "net-http",
+            "nio4r",
+            "nokogiri",
+            "orm_adapter",
+            "pg",
+            "propshaft",
+            "psych",
+            "public_suffix",
+            "rack",
+            "rack-session",
+            "rack-test",
+            "rails",
+            "railties",
+        ];
+        let mut lines: Vec<String> = gems
+            .iter()
+            .flat_map(|g| {
+                vec![
+                    format!("Compiling {g}, this may take a few seconds..."),
+                    format!("Compiled {g}"),
+                ]
+            })
+            .collect();
+        lines.push("Done compiling RBI files for gems (50 files in 18.3s)".to_string());
+        lines.join("\n")
+    }
+
+    #[test]
+    fn test_filter_clean_gems_run() {
+        let result = filter_tapioca(gems_clean_output());
+        assert!(
+            result.contains("Done"),
+            "Done line should be kept: {result}"
+        );
+        assert!(
+            result.contains("No errors found"),
+            "no-errors line should be kept: {result}"
+        );
+        assert!(
+            !result.contains("Nothing to do"),
+            "noise should be stripped: {result}"
+        );
+        assert!(
+            !result.contains("Please review"),
+            "noise should be stripped: {result}"
+        );
+    }
+
+    #[test]
+    fn test_filter_with_warning() {
+        let input = "Compiling foo, this may take a few seconds...\n\
+                     Compiled foo\n\
+                     Warning: Unresolvable constant 'MyApp::Foo' in sorbet/rbi/gems/foo.rbi\n\
+                     Done compiling RBI files for gems (1 file in 1.2s)";
+        let result = filter_tapioca(input);
+        assert!(
+            result.contains("Warning: Unresolvable constant"),
+            "warning should be kept: {result}"
+        );
+        assert!(
+            result.contains("Done compiling"),
+            "Done line should be kept: {result}"
+        );
+        assert!(
+            !result.contains("Compiling foo"),
+            "progress should be stripped: {result}"
+        );
+        assert!(
+            !result.contains("Compiled foo"),
+            "compiled line should be stripped: {result}"
+        );
+    }
+
+    #[test]
+    fn test_filter_with_error() {
+        let input = "Compiling foo, this may take a few seconds...\n\
+                     Error: Gem 'foo' is not installed\n\
+                     Done compiling RBI files for gems (0 files in 0.1s)";
+        let result = filter_tapioca(input);
+        assert!(
+            result.contains("Error: Gem 'foo'"),
+            "error line should be kept: {result}"
+        );
+        assert!(
+            result.contains("Done compiling"),
+            "Done line should be kept: {result}"
+        );
+    }
+
+    #[test]
+    fn test_filter_dsl_run() {
+        let result = filter_tapioca(dsl_clean_output());
+        assert_eq!(result, "Done compiling DSL RBI files (2 files in 2.4s)");
+        assert!(
+            !result.contains("Loading DSL"),
+            "DSL loading lines should be stripped"
+        );
+        assert!(
+            !result.contains("Compiling User"),
+            "Compiling lines should be stripped"
+        );
+    }
+
+    #[test]
+    fn test_filter_annotations_run() {
+        let result = filter_tapioca(annotations_clean_output());
+        assert_eq!(result, "Done fetching RBI annotations (2 gems in 1.5s)");
+        assert!(
+            !result.contains("Fetching"),
+            "Fetching lines should be stripped"
+        );
+    }
+
+    #[test]
+    fn test_filter_empty_output() {
+        let result = filter_tapioca("");
+        assert_eq!(result, "tapioca: no output");
+    }
+
+    #[test]
+    fn test_filter_no_done_line() {
+        let input = "Compiling foo, this may take a few seconds...\nCompiled foo\n";
+        let result = filter_tapioca(input);
+        assert!(
+            result.contains("Compiled foo"),
+            "fallback should include tail lines: {result}"
+        );
+    }
+
+    #[test]
+    fn test_filter_ansi_done_line() {
+        let input = "\x1b[32mDone compiling RBI files for gems (5 files in 2.1s)\x1b[0m";
+        let result = filter_tapioca(input);
+        assert!(
+            result.contains("Done compiling"),
+            "ANSI-wrapped Done line should be kept after stripping: {result}"
+        );
+    }
+
+    #[test]
+    fn test_filter_spring_preloader() {
+        let input = "Running via Spring preloader in process 12345\n\
+                     Compiling foo, this may take a few seconds...\n\
+                     Compiled foo\n\
+                     Done compiling RBI files for gems (1 file in 1.0s)";
+        let result = filter_tapioca(input);
+        assert!(
+            !result.contains("Spring"),
+            "Spring preloader line should be stripped: {result}"
+        );
+        assert!(
+            result.contains("Done compiling"),
+            "Done line should be kept: {result}"
+        );
+    }
+
+    #[test]
+    fn test_filter_no_false_positive_error_in_filename() {
+        // `actionable_error.rbi` contains "error" as a substring but is not an error
+        let input = "Compiling DSL RBI files...\n\
+                     identical  sorbet/rbi/dsl/active_support/actionable_error.rbi\n\
+                     identical  sorbet/rbi/dsl/active_support/error_reporter.rbi\n\
+                     Done compiling DSL RBI files (2 files in 1.2s)";
+        let result = filter_tapioca(input);
+        assert_eq!(
+            result, "Done compiling DSL RBI files (2 files in 1.2s)",
+            "filenames containing 'error' should not be kept: {result}"
+        );
+    }
+
+    #[test]
+    fn test_token_savings_gems() {
+        let input = large_gems_fixture();
+        let output = filter_tapioca(&input);
+        let input_tokens = count_tokens(&input);
+        let output_tokens = count_tokens(&output);
+        let savings = 100.0 - (output_tokens as f64 / input_tokens as f64 * 100.0);
+        assert!(
+            savings >= 60.0,
+            "Tapioca gems: expected ≥60% savings, got {:.1}% (in={}, out={})",
+            savings,
+            input_tokens,
+            output_tokens
+        );
+    }
+
+    // ── Real fixture tests ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_fixture_gems() {
+        let input = include_str!("../../../tests/fixtures/tapioca_gems_raw.txt");
+        let output = filter_tapioca(input);
+        assert!(
+            output.contains("Done"),
+            "Done line should be kept: {output}"
+        );
+        assert!(
+            output.contains("No errors found"),
+            "no-errors line should be kept: {output}"
+        );
+        assert!(
+            !output.contains("Nothing to do"),
+            "noise should be stripped: {output}"
+        );
+        assert!(
+            !output.contains("Please review"),
+            "noise should be stripped: {output}"
+        );
+    }
+
+    #[test]
+    fn test_fixture_dsl() {
+        let input = include_str!("../../../tests/fixtures/tapioca_dsl_raw.txt");
+        let output = filter_tapioca(input);
+        assert!(
+            output.contains("Done"),
+            "Done line should be kept: {output}"
+        );
+        assert!(
+            output.contains("WARNING:"),
+            "warning should be kept: {output}"
+        );
+        assert!(
+            output.contains("No errors found"),
+            "no-errors line should be kept: {output}"
+        );
+        assert!(
+            !output.contains("identical"),
+            "progress lines should be stripped: {output}"
+        );
+    }
+
+    #[test]
+    fn test_fixture_token_savings_gems() {
+        let input = include_str!("../../../tests/fixtures/tapioca_gems_raw.txt");
+        let output = filter_tapioca(input);
+        let savings = 100.0 - (count_tokens(&output) as f64 / count_tokens(input) as f64 * 100.0);
+        assert!(
+            savings >= 60.0,
+            "gems fixture: expected ≥60% savings, got {:.1}%",
+            savings
+        );
+    }
+
+    #[test]
+    fn test_fixture_token_savings_dsl() {
+        let input = include_str!("../../../tests/fixtures/tapioca_dsl_raw.txt");
+        let output = filter_tapioca(input);
+        let savings = 100.0 - (count_tokens(&output) as f64 / count_tokens(input) as f64 * 100.0);
+        assert!(
+            savings >= 60.0,
+            "dsl fixture: expected ≥60% savings, got {:.1}%",
+            savings
+        );
+    }
+}

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -522,6 +522,16 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
+        pattern: r"^(?:bundle\s+exec\s+)?(?:bin/)?tapioca(?:\s|$)",
+        rtk_cmd: "rtk tapioca",
+        rewrite_prefixes: &["bundle exec tapioca", "bin/tapioca", "tapioca"],
+        category: "Ruby",
+        savings_pct: 98.0,
+        subcmd_savings: &[("gems", 98.0), ("dsl", 95.0), ("annotations", 95.0)],
+        subcmd_status: &[],
+    },
+    // AWS CLI
+    RtkRule {
         pattern: r"^aws\s+",
         rtk_cmd: "rtk aws",
         rewrite_prefixes: &["aws"],

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use cmds::js::{
     vitest_cmd,
 };
 use cmds::python::{mypy_cmd, pip_cmd, pytest_cmd, ruff_cmd};
-use cmds::ruby::{rake_cmd, rspec_cmd, rubocop_cmd};
+use cmds::ruby::{rake_cmd, rspec_cmd, rubocop_cmd, tapioca_cmd};
 use cmds::rust::{cargo_cmd, runner};
 use cmds::system::{
     deps, env_cmd, find_cmd, format_cmd, grep_cmd, json_cmd, local_llm, log_cmd, ls, pipe_cmd,
@@ -689,6 +689,13 @@ enum Commands {
     /// RSpec test runner with compact output (Rails/Ruby)
     Rspec {
         /// RSpec arguments (e.g., spec/models, --tag focus)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// Tapioca RBI generator with compact output (Ruby/Sorbet)
+    Tapioca {
+        /// Tapioca arguments (e.g., gems, dsl, annotations, gem <name>)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -2076,6 +2083,8 @@ fn run_cli() -> Result<i32> {
 
         Commands::Rspec { args } => rspec_cmd::run(&args, cli.verbose)?,
 
+        Commands::Tapioca { args } => tapioca_cmd::run(&args, cli.verbose)?,
+
         Commands::Pip { args } => pip_cmd::run(&args, cli.verbose)?,
 
         Commands::Go { command } => match command {
@@ -2426,6 +2435,7 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Rake { .. }
             | Commands::Rubocop { .. }
             | Commands::Rspec { .. }
+            | Commands::Tapioca { .. }
             | Commands::Pip { .. }
             | Commands::Go { .. }
             | Commands::GolangciLint { .. }

--- a/tests/fixtures/tapioca_dsl_raw.txt
+++ b/tests/fixtures/tapioca_dsl_raw.txt
@@ -1,0 +1,126 @@
+Loading DSL extension classes... Done
+Loading Rails application... Done
+Loading DSL compiler classes... Done
+Compiling DSL RBI files...
+
+WARNING: Multiple constants with the same name: `RuboCop::Cop::EnforceSuperclass`
+Make sure some object is not holding onto these constants during an app reload.
+   identical  sorbet/rbi/dsl/abstract_controller/rendering.rbi
+   identical  sorbet/rbi/dsl/abstract_controller/caching.rbi
+   identical  sorbet/rbi/dsl/abstract_controller/helpers.rbi
+   identical  sorbet/rbi/dsl/abstract_controller/callbacks.rbi
+   identical  sorbet/rbi/dsl/abstract_controller/url_for.rbi
+   identical  sorbet/rbi/dsl/abstract_controller/caching/fragments.rbi
+   identical  sorbet/rbi/dsl/action_cable/channel/periodic_timers.rbi
+   identical  sorbet/rbi/dsl/action_cable/channel/callbacks.rbi
+   identical  sorbet/rbi/dsl/action_cable/connection/identification.rbi
+   identical  sorbet/rbi/dsl/action_cable/connection/callbacks.rbi
+   identical  sorbet/rbi/dsl/action_controller/caching.rbi
+   identical  sorbet/rbi/dsl/action_controller/etag_with_flash.rbi
+   identical  sorbet/rbi/dsl/action_controller/etag_with_template_digest.rbi
+   identical  sorbet/rbi/dsl/action_controller/content_security_policy.rbi
+   identical  sorbet/rbi/dsl/action_controller/conditional_get.rbi
+   identical  sorbet/rbi/dsl/action_controller/form_builder.rbi
+   identical  sorbet/rbi/dsl/action_controller/data_streaming.rbi
+   identical  sorbet/rbi/dsl/action_controller/live.rbi
+   identical  sorbet/rbi/dsl/action_controller/flash.rbi
+   identical  sorbet/rbi/dsl/action_controller/renderers.rbi
+   identical  sorbet/rbi/dsl/action_controller/helpers.rbi
+   identical  sorbet/rbi/dsl/action_controller/params_wrapper.rbi
+   identical  sorbet/rbi/dsl/action_controller/renderers/all.rbi
+   identical  sorbet/rbi/dsl/action_controller/request_forgery_protection.rbi
+   identical  sorbet/rbi/dsl/action_controller/test_case/behavior.rbi
+   identical  sorbet/rbi/dsl/action_controller/rescue.rbi
+   identical  sorbet/rbi/dsl/action_dispatch/assertions.rbi
+   identical  sorbet/rbi/dsl/action_dispatch/integration_test.rbi
+   identical  sorbet/rbi/dsl/action_controller/redirecting.rbi
+   identical  sorbet/rbi/dsl/action_dispatch/routing/route_set/mounted_helpers.rbi
+   identical  sorbet/rbi/dsl/action_view/helpers/form_helper.rbi
+   identical  sorbet/rbi/dsl/action_dispatch/routing/url_for.rbi
+   identical  sorbet/rbi/dsl/action_view/helpers/text_helper.rbi
+   identical  sorbet/rbi/dsl/action_controller/url_for.rbi
+   identical  sorbet/rbi/dsl/action_view/helpers/form_tag_helper.rbi
+   identical  sorbet/rbi/dsl/action_view/rendering.rbi
+   identical  sorbet/rbi/dsl/action_view/helpers.rbi
+   identical  sorbet/rbi/dsl/active_job/callbacks.rbi
+   identical  sorbet/rbi/dsl/action_view/layouts.rbi
+   identical  sorbet/rbi/dsl/active_job/enqueuing.rbi
+   identical  sorbet/rbi/dsl/active_job/exceptions.rbi
+   identical  sorbet/rbi/dsl/active_job/logging.rbi
+   identical  sorbet/rbi/dsl/active_job/execution.rbi
+   identical  sorbet/rbi/dsl/active_job/queue_adapter.rbi
+   identical  sorbet/rbi/dsl/active_job/queue_priority.rbi
+   identical  sorbet/rbi/dsl/active_job/queue_name.rbi
+   identical  sorbet/rbi/dsl/active_job/test_helper/test_queue_adapter.rbi
+   identical  sorbet/rbi/dsl/active_model/attribute_methods.rbi
+   identical  sorbet/rbi/dsl/active_model/api.rbi
+   identical  sorbet/rbi/dsl/active_model/conversion.rbi
+   identical  sorbet/rbi/dsl/active_model/attributes.rbi
+   identical  sorbet/rbi/dsl/active_model/serializers/json.rbi
+   identical  sorbet/rbi/dsl/active_model/dirty.rbi
+   identical  sorbet/rbi/dsl/active_model/attributes/normalization.rbi
+   identical  sorbet/rbi/dsl/active_model/validations/callbacks.rbi
+   identical  sorbet/rbi/dsl/active_model/validations.rbi
+   identical  sorbet/rbi/dsl/active_model/model.rbi
+   identical  sorbet/rbi/dsl/active_record/attribute_methods.rbi
+   identical  sorbet/rbi/dsl/active_record/attribute_methods/serialization.rbi
+   identical  sorbet/rbi/dsl/active_record/attribute_methods/dirty.rbi
+   identical  sorbet/rbi/dsl/active_record/attributes.rbi
+   identical  sorbet/rbi/dsl/active_record/callbacks.rbi
+   identical  sorbet/rbi/dsl/active_record/counter_cache.rbi
+   identical  sorbet/rbi/dsl/active_record/encryption/encryptable_record.rbi
+   identical  sorbet/rbi/dsl/active_record/core.rbi
+   identical  sorbet/rbi/dsl/active_record/attribute_methods/time_zone_conversion.rbi
+   identical  sorbet/rbi/dsl/active_record/locking/optimistic.rbi
+   identical  sorbet/rbi/dsl/active_record/integration.rbi
+   identical  sorbet/rbi/dsl/active_record/nested_attributes.rbi
+   identical  sorbet/rbi/dsl/active_record/readonly_attributes.rbi
+   identical  sorbet/rbi/dsl/active_record/reflection.rbi
+   identical  sorbet/rbi/dsl/active_record/scoping.rbi
+   identical  sorbet/rbi/dsl/active_record/scoping/default.rbi
+   identical  sorbet/rbi/dsl/active_record/model_schema.rbi
+   identical  sorbet/rbi/dsl/active_record/secure_password.rbi
+   identical  sorbet/rbi/dsl/active_record/inheritance.rbi
+   identical  sorbet/rbi/dsl/active_record/signed_id.rbi
+   identical  sorbet/rbi/dsl/active_record/timestamp.rbi
+   identical  sorbet/rbi/dsl/active_record/serialization.rbi
+   identical  sorbet/rbi/dsl/active_record/token_for.rbi
+   identical  sorbet/rbi/dsl/active_support/callbacks.rbi
+   identical  sorbet/rbi/dsl/active_support/actionable_error.rbi
+   identical  sorbet/rbi/dsl/active_support/rescuable.rbi
+   identical  sorbet/rbi/dsl/active_support/testing/file_fixtures.rbi
+   identical  sorbet/rbi/dsl/active_support/environment_inquirer.rbi
+   identical  sorbet/rbi/dsl/application_controller.rbi
+   identical  sorbet/rbi/dsl/app/cleanup_job.rbi
+   identical  sorbet/rbi/dsl/app/scheduled_job.rbi
+   identical  sorbet/rbi/dsl/app/webhook_handler_job.rbi
+   identical  sorbet/rbi/dsl/app/model.rbi
+   identical  sorbet/rbi/dsl/app/user.rbi
+   identical  sorbet/rbi/dsl/good_job/active_job_extensions/concurrency.rbi
+   identical  sorbet/rbi/dsl/good_job/active_job_extensions/labels.rbi
+   identical  sorbet/rbi/dsl/good_job/active_job_extensions/notify_options.rbi
+   identical  sorbet/rbi/dsl/good_job/advisory_lockable.rbi
+   identical  sorbet/rbi/dsl/good_job/application_controller.rbi
+   identical  sorbet/rbi/dsl/good_job/frontends_controller.rbi
+   identical  sorbet/rbi/dsl/good_job/batch_record.rbi
+   identical  sorbet/rbi/dsl/good_job/discrete_execution.rbi
+   identical  sorbet/rbi/dsl/good_job/execution.rbi
+   identical  sorbet/rbi/dsl/good_job/process.rbi
+   identical  sorbet/rbi/dsl/good_job/setting.rbi
+   identical  sorbet/rbi/dsl/good_job/job.rbi
+   identical  sorbet/rbi/dsl/solid_cable/trim_job.rbi
+   identical  sorbet/rbi/dsl/solid_cache/expiry_job.rbi
+   identical  sorbet/rbi/dsl/solid_cable/message.rbi
+   identical  sorbet/rbi/dsl/solid_cache/entry.rbi
+   identical  sorbet/rbi/dsl/time.rbi
+   identical  sorbet/rbi/dsl/turbo/streams/action_broadcast_job.rbi
+   identical  sorbet/rbi/dsl/turbo/streams/broadcast_stream_job.rbi
+   identical  sorbet/rbi/dsl/turbo/streams/broadcast_job.rbi
+
+Done
+
+Checking generated RBI files...  Done
+  No errors found
+
+All operations performed in working directory.
+Please review changes and commit them.

--- a/tests/fixtures/tapioca_gems_raw.txt
+++ b/tests/fixtures/tapioca_gems_raw.txt
@@ -1,0 +1,13 @@
+Removing RBI files of gems that have been removed:
+
+  Nothing to do.
+
+Generating RBI files of gems that are added or updated:
+
+  Nothing to do.
+
+Checking generated RBI files...  Done
+  No errors found
+
+All operations performed in working directory.
+Please review changes and commit them.


### PR DESCRIPTION
## Summary

- Add `rtk tapioca` filter for the Sorbet RBI generator — strips Compiling/Loading/Fetching progress lines, keeps errors, warnings, and `Done` summary (~98% reduction)
- Supports `tapioca gems`, `tapioca gem <name>`, `tapioca dsl`, `tapioca annotations`
- Hook rewriting covers `tapioca`, `bundle exec tapioca`, and `bin/tapioca`

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk tapioca gems` and `rtk tapioca dsl` verified against a production Rails/Sorbet project