### PR TITLE
fix: use /usr/bin/env shebangs for portability across systems

### DIFF
--- a/.claude/hooks/bash/pre-commit-format.sh
+++ b/.claude/hooks/bash/pre-commit-format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Auto-format Rust code before commits
 # Hook: PreToolUse for git commit
 

--- a/.claude/hooks/rtk-rewrite.sh
+++ b/.claude/hooks/rtk-rewrite.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # rtk-hook-version: 3
 # RTK auto-rewrite hook for Claude Code PreToolUse:Bash
 # Transparently rewrites raw commands to their RTK equivalents.

--- a/.claude/hooks/rtk-suggest.sh
+++ b/.claude/hooks/rtk-suggest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # RTK suggest hook for Claude Code PreToolUse:Bash
 # Emits system reminders when rtk-compatible commands are detected.
 # Outputs JSON with systemMessage to inform Claude Code without modifying execution.

--- a/hooks/claude/test-rtk-rewrite.sh
+++ b/hooks/claude/test-rtk-rewrite.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Test suite for rtk-rewrite.sh
 # Feeds mock JSON through the hook and verifies the rewritten commands.
 #

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # rtk installer - https://github.com/rtk-ai/rtk
 # Usage: curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
 

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Use local release build if available, otherwise fall back to installed rtk

--- a/scripts/check-installation.sh
+++ b/scripts/check-installation.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # RTK Installation Verification Script
 # Helps diagnose if you have the correct rtk (Token Killer) installed
 

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Install RTK from a local release build (builds from source, no network download).
 
 set -euo pipefail

--- a/scripts/rtk-economics.sh
+++ b/scripts/rtk-economics.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # rtk-economics.sh
 # Combine ccusage (tokens spent) with rtk (tokens saved) for economic analysis
 

--- a/scripts/update-readme-metrics.sh
+++ b/scripts/update-readme-metrics.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 REPORT="benchmark-report.md"

--- a/scripts/validate-docs.sh
+++ b/scripts/validate-docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 echo "🔍 Validating RTK documentation consistency..."


### PR DESCRIPTION
## Summary
- Currently the scripts don't run on NixOS
- `/usr/bin/env bash` is more portable

## Test plan
It's a tiny change and easy to inspect visually.
