### PR TITLE
fix(npx): use npx (not npm) for unrecognized npx commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1871,8 +1871,22 @@ fn run_cli() -> Result<i32> {
                 "prettier" => prettier_cmd::run(&args[1..], cli.verbose)?,
                 "playwright" => playwright_cmd::run(&args[1..], cli.verbose)?,
                 _ => {
-                    // Generic passthrough with npm boilerplate filter
-                    npm_cmd::run(&args, cli.verbose, cli.skip_env)?
+                    // Passthrough via npx (not npm) — unknown tools need npx directly.
+                    let timer = core::tracking::TimedExecution::start();
+                    let mut cmd = core::utils::resolved_command("npx");
+                    cmd.args(&args);
+                    if cli.skip_env {
+                        cmd.env("SKIP_ENV_VALIDATION", "1");
+                    }
+                    let cmd_label = format!("npx {}", args.join(" "));
+                    let status = cmd.status().with_context(|| {
+                        format!("Failed to run `{cmd_label}`. Is npx on PATH?")
+                    })?;
+                    timer.track_passthrough(
+                        &cmd_label,
+                        &format!("rtk {cmd_label} (passthrough)"),
+                    );
+                    core::utils::exit_code_from_status(&status, &cmd_label)
                 }
             }
         }


### PR DESCRIPTION
## Summary

- The `Commands::Npx` catch-all fallback called `npm_cmd::run()`, which invoked `npm` instead of `npx`
- When npx flags preceded the tool name (e.g. `npx -y -p @playwright/cli playwright-cli list`), routing fell to the catch-all and ran the wrong binary
- Replace with direct npx passthrough matching the existing prisma passthrough pattern

Fixes #713

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test` (1056 passed on develop)
- [x] Manual testing: verified `rtk npx tsc --version` and `rtk npx playwright test` still route to specialized handlers
- [x] Verified existing passthrough pattern consistency (prisma at lines 1933-1946)

> **Note:** Flag-aware routing (`npx -y tsc` → `tsc_cmd`) and rewrite-layer regex updates are follow-up opportunities.