### PR TITLE
fix: include "Finished" line in cargo build/check success output

### DIFF
--- a/src/cmds/rust/cargo_cmd.rs
+++ b/src/cmds/rust/cargo_cmd.rs
@@ -567,6 +567,7 @@ fn filter_cargo_build(output: &str) -> String {
     let mut compiled = 0;
     let mut in_error = false;
     let mut current_error = Vec::new();
+    let mut finished_line: Option<String> = None;
 
     for line in output.lines() {
         if line.trim_start().starts_with("Compiling") || line.trim_start().starts_with("Checking") {
@@ -579,6 +580,7 @@ fn filter_cargo_build(output: &str) -> String {
             continue;
         }
         if line.trim_start().starts_with("Finished") {
+            finished_line = Some(line.trim_start().to_string());
             continue;
         }
 
@@ -625,7 +627,11 @@ fn filter_cargo_build(output: &str) -> String {
     }
 
     if error_count == 0 && warnings == 0 {
-        return format!("cargo build ({} crates compiled)", compiled);
+        return if let Some(finished) = finished_line {
+            format!("cargo build ({} crates compiled)\n{}", compiled, finished)
+        } else {
+            format!("cargo build ({} crates compiled)", compiled)
+        };
     }
 
     let mut result = String::new();


### PR DESCRIPTION
## Summary

Preserves the cargo `Finished ...` line in the filtered success output for `rtk cargo build` and `rtk cargo check`. Previously, success output only showed `cargo build (0 crates compiled)` which was ambiguous - LLMs couldn't tell if the build succeeded or if there were errors.

## Why this matters

Per #759, Claude interpreted `cargo build (0 crates compiled)` as potentially erroneous and tried workarounds (`rtk proxy cargo check`, `RUSTFLAGS="-D warnings" rtk proxy cargo check`), consuming extra tokens. Claude expected to see the `Finished dev profile ...` message as a clear success signal.

## Changes

- `src/cargo_cmd.rs`: In `filter_cargo_build()`, capture the `Finished` line instead of skipping it, and append it to the success summary. The output now looks like:
  ```
  cargo build (5 crates compiled)
  Finished dev [unoptimized + debuginfo] target(s) in 2.53s
  ```

## Testing

All 38 `cargo_cmd` tests pass (`cargo test cargo_cmd`). The change only affects the success path - error/warning output is unchanged.

Fixes #759

This contribution was developed with AI assistance (Claude Code).