### PR TITLE
fix(gh): print 'No Pull Requests' when pr list is empty

### DIFF
--- a/src/gh_cmd.rs
+++ b/src/gh_cmd.rs
@@ -231,6 +231,18 @@ fn list_prs(args: &[String], _verbose: u8, ultra_compact: bool) -> Result<()> {
     let mut filtered = String::new();
 
     if let Some(prs) = json.as_array() {
+        if prs.is_empty() {
+            let msg = if ultra_compact {
+                "No PRs\n"
+            } else {
+                "No Pull Requests\n"
+            };
+            filtered.push_str(msg);
+            print!("{}", msg);
+            timer.track("gh pr list", "rtk gh pr list", &raw, &filtered);
+            return Ok(());
+        }
+
         if ultra_compact {
             filtered.push_str("PRs\n");
             println!("PRs");


### PR DESCRIPTION
## Bug
[#764](https://github.com/rtk-ai/rtk/issues/764) — `rtk gh pr list` on a repo with zero PRs prints the "Pull Requests" header with no entries, giving no indication the list is actually empty.

## Fix
Early-return with `No Pull Requests` (or `No PRs` in ultra-compact mode) when the parsed JSON array is empty.

Follows the same pattern as the existing output: the message is both printed to stdout and tracked in the `filtered` string for telemetry.

## Testing
Tested against a repo with no open PRs:
```
# Before
$ rtk gh pr list --repo <no-prs-repo>
Pull Requests

# After
$ rtk gh pr list --repo <no-prs-repo>
No Pull Requests
```

Happy to address any feedback.

Greetings, saschabuehrle