### PR TITLE
fix: rewrite swift test commands

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1519,6 +1519,27 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_classify_swift_test() {
+        assert!(matches!(
+            classify_command("swift test"),
+            Classification::Supported {
+                rtk_equivalent: "rtk swift",
+                category: "Build",
+                estimated_savings_pct: 90.0,
+                status: RtkStatus::Existing,
+            }
+        ));
+    }
+
+    #[test]
+    fn test_rewrite_swift_test() {
+        assert_eq!(
+            rewrite_command("swift test --parallel", &[]),
+            Some("rtk swift test --parallel".into())
+        );
+    }
+
     // --- #336: docker compose supported subcommands rewritten, unsupported skipped ---
 
     #[test]

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -79,7 +79,7 @@ pub const PATTERNS: &[&str] = &[
     r"^shellcheck\b",
     r"^shopify\s+theme\s+(push|pull)",
     r"^sops\b",
-    r"^swift\s+build\b",
+    r"^swift\s+(build|test)\b",
     r"^systemctl\s+status\b",
     r"^terraform\s+plan",
     r"^tofu\s+(fmt|init|plan|validate)(\s|$)",
@@ -600,7 +600,7 @@ pub const RULES: &[RtkRule] = &[
         rewrite_prefixes: &["swift"],
         category: "Build",
         savings_pct: 65.0,
-        subcmd_savings: &[],
+        subcmd_savings: &[("test", 90.0)],
         subcmd_status: &[],
     },
     RtkRule {


### PR DESCRIPTION
## Summary
- add `swift test` to the hook rewrite registry alongside `swift build`
- route rewritten Swift test commands through `rtk swift`
- add registry coverage for Swift test classification and rewrite behavior

## Test plan
- [x] `cargo test swift_test`
- [x] `cargo test`

Fixes #765

---
Generated by Orbit 🛸
