### PR TITLE
feat: add infra filters for terraform, nix, ansible, and opentofu

### DIFF
--- a/src/cmds/system/nix_cmd.rs
+++ b/src/cmds/system/nix_cmd.rs
@@ -1,0 +1,207 @@
+use crate::core::tracking;
+use crate::core::utils::{resolved_command, strip_ansi};
+use anyhow::{Context, Result};
+
+const MAX_SEARCH_RESULTS: usize = 20;
+const MAX_FALLBACK_LINES: usize = 40;
+
+pub fn run(args: &[String], verbose: u8) -> Result<i32> {
+    let timer = tracking::TimedExecution::start();
+
+    let mut cmd = resolved_command("nix");
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    if verbose > 0 {
+        eprintln!("Running: nix {}", args.join(" "));
+    }
+
+    let output = cmd.output().context("Failed to run nix")?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let raw = format!("{}\n{}", stdout, stderr);
+    let filtered = filter_nix_output(&raw);
+
+    println!("{}", filtered);
+
+    timer.track(
+        &format!("nix {}", args.join(" ")),
+        &format!("rtk nix {}", args.join(" ")),
+        &raw,
+        &filtered,
+    );
+
+    let code = output.status.code().unwrap_or(1);
+    if !output.status.success() {
+        return Ok(code);
+    }
+
+    Ok(0)
+}
+
+fn filter_nix_output(raw: &str) -> String {
+    let clean = strip_ansi(raw);
+    let mut entries: Vec<String> = Vec::new();
+    let mut summaries: Vec<String> = Vec::new();
+    let mut diagnostics: Vec<String> = Vec::new();
+    let mut fallback: Vec<String> = Vec::new();
+
+    let mut pending_entry: Option<String> = None;
+
+    for line in clean.lines() {
+        if line.trim().is_empty() {
+            if let Some(entry) = pending_entry.take() {
+                entries.push(entry);
+            }
+            continue;
+        }
+
+        if let Some(entry) = pending_entry.clone() {
+            if line.starts_with("  ") && !line.trim().starts_with('*') {
+                entries.push(format!("{entry} - {}", line.trim()));
+                pending_entry = None;
+                continue;
+            }
+
+            entries.push(entry);
+            pending_entry = None;
+        }
+
+        let trimmed = line.trim();
+        if trimmed.starts_with("* ") {
+            let after_star = trimmed.trim_start_matches("* ");
+            let normalized = normalize_entry_name(after_star);
+            if is_low_signal_entry(&normalized) {
+                pending_entry = None;
+                continue;
+            }
+            pending_entry = Some(normalized);
+            continue;
+        }
+
+        let lower = trimmed.to_lowercase();
+        if lower.starts_with("error:") || lower.starts_with("warning:") {
+            diagnostics.push(trimmed.to_string());
+            continue;
+        }
+
+        if is_noise_line(trimmed) {
+            continue;
+        }
+
+        if trimmed.starts_with("these ")
+            && (trimmed.contains("will be built")
+                || trimmed.contains("will be fetched")
+                || trimmed.contains("will be downloaded"))
+        {
+            summaries.push(trimmed.to_string());
+            continue;
+        }
+
+        fallback.push(trimmed.to_string());
+    }
+
+    if let Some(entry) = pending_entry.take() {
+        entries.push(entry);
+    }
+
+    if !entries.is_empty() {
+        let shown = entries.len().min(MAX_SEARCH_RESULTS);
+        let mut out = vec![format!(
+            "Nix: {} results (showing {})",
+            entries.len(),
+            shown
+        )];
+        out.extend(entries.into_iter().take(shown));
+        if !diagnostics.is_empty() {
+            out.push(String::new());
+            out.extend(diagnostics);
+        }
+        return out.join("\n");
+    }
+
+    let mut out: Vec<String> = Vec::new();
+    out.extend(summaries);
+    out.extend(diagnostics);
+
+    if out.is_empty() {
+        out.extend(fallback.into_iter().take(MAX_FALLBACK_LINES));
+    }
+
+    if out.is_empty() {
+        "ok nix".to_string()
+    } else {
+        out.join("\n")
+    }
+}
+
+fn is_noise_line(line: &str) -> bool {
+    line.starts_with("evaluating '")
+        || line.starts_with("copying path '")
+        || line.starts_with("copying ")
+        || line.starts_with("downloading ")
+        || line.starts_with("building '")
+        || line.starts_with("unpacking ")
+        || line.starts_with("querying info about ")
+        || line.starts_with("warning: ignoring the client-specified setting")
+}
+
+fn normalize_entry_name(entry: &str) -> String {
+    // nix search entries are often prefixed with: legacyPackages.<arch>.
+    if let Some(rest) = entry.strip_prefix("legacyPackages.") {
+        if let Some(dot_idx) = rest.find('.') {
+            return rest[dot_idx + 1..].to_string();
+        }
+    }
+    entry.to_string()
+}
+
+fn is_low_signal_entry(entry: &str) -> bool {
+    entry.starts_with("tests.") || entry.contains(".tests.")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_filter_nix_search_drops_evaluating_noise() {
+        let raw = r#"
+evaluating 'legacyPackages.x86_64-linux.hello'...
+* legacyPackages.x86_64-linux.hello (2.12.2)
+  Program that produces a familiar, friendly greeting
+evaluating 'legacyPackages.x86_64-linux.hello-wayland'...
+* legacyPackages.x86_64-linux.hello-wayland (0-unstable)
+  Hello world Wayland client
+"#;
+        let filtered = filter_nix_output(raw);
+        assert!(filtered.contains("Nix: 2 results"));
+        assert!(filtered.contains("hello (2.12.2) - Program"));
+        assert!(!filtered.contains("evaluating"));
+    }
+
+    #[test]
+    fn test_filter_nix_keeps_errors() {
+        let raw = r#"
+evaluating 'legacyPackages.x86_64-linux.foo'...
+error: attribute 'foo' missing
+"#;
+        let filtered = filter_nix_output(raw);
+        assert!(filtered.contains("error: attribute 'foo' missing"));
+    }
+
+    #[test]
+    fn test_filter_nix_drops_test_entries_and_normalizes_prefix() {
+        let raw = r#"
+* legacyPackages.x86_64-linux.tests.foo
+  test fixture
+* legacyPackages.x86_64-linux.hello (2.12.2)
+  Program that produces a familiar, friendly greeting
+"#;
+        let filtered = filter_nix_output(raw);
+        assert!(!filtered.contains("tests.foo"));
+        assert!(filtered.contains("hello (2.12.2)"));
+        assert!(!filtered.contains("legacyPackages.x86_64-linux"));
+    }
+}

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -898,6 +898,14 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
+        pattern: r"^nix(\s|$)",
+        rtk_cmd: "rtk nix",
+        rewrite_prefixes: &["nix"],
+        category: "Infra",
+        savings_pct: 70.0,
+        ..RtkRule::DEFAULT
+    },
+    RtkRule {
         pattern: r"^tofu\s+(fmt|init|plan|validate)(\s|$)",
         rtk_cmd: "rtk tofu",
         rewrite_prefixes: &["tofu"],

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -612,6 +612,15 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
+        pattern: r"^nix(\s|$)",
+        rtk_cmd: "rtk nix",
+        rewrite_prefixes: &["nix"],
+        category: "Infra",
+        savings_pct: 70.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
+    RtkRule {
         pattern: r"^tofu\s+(fmt|init|plan|validate)(\s|$)",
         rtk_cmd: "rtk tofu",
         rewrite_prefixes: &["tofu"],

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,8 @@ use cmds::ruby::{rake_cmd, rspec_cmd, rubocop_cmd};
 use cmds::rust::{cargo_cmd, runner};
 use cmds::scala::sbt_cmd;
 use cmds::system::{
-    deps, env_cmd, find_cmd, format_cmd, json_cmd, local_llm, log_cmd, ls, pipe_cmd, read, search,
-    summary, tree, wc_cmd,
+    deps, env_cmd, find_cmd, format_cmd, json_cmd, local_llm, log_cmd, ls, nix_cmd, pipe_cmd, read,
+    search, summary, tree, wc_cmd,
 };
 
 use anyhow::{Context, Result};
@@ -205,6 +205,14 @@ enum Commands {
     #[command(disable_help_flag = true)]
     Psql {
         /// psql arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// Nix package manager with compact output
+    #[command(disable_help_flag = true)]
+    Nix {
+        /// nix arguments
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -1817,6 +1825,8 @@ fn run_cli() -> Result<i32> {
 
         Commands::Psql { args } => psql_cmd::run(&args, cli.verbose)?,
 
+        Commands::Nix { args } => nix_cmd::run(&args, cli.verbose)?,
+
         Commands::Pnpm { filter, command } => {
             // Warns user if filters are used with unsupported subcommands like typecheck
             if let Some(warning) = validate_pnpm_filters(&filter, &command) {
@@ -2767,6 +2777,7 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Cargo { .. }
             | Commands::Npm { .. }
             | Commands::Npx { .. }
+            | Commands::Nix { .. }
             | Commands::Curl { .. }
             | Commands::Ruff { .. }
             | Commands::Pytest { .. }
@@ -3143,6 +3154,7 @@ mod tests {
             "prisma",
             "tsc",
             "next",
+            "nix",
             "lint",
             "prettier",
             "format",

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,8 @@ use cmds::python::{mypy_cmd, pip_cmd, pytest_cmd, ruff_cmd};
 use cmds::ruby::{rake_cmd, rspec_cmd, rubocop_cmd};
 use cmds::rust::{cargo_cmd, runner};
 use cmds::system::{
-    deps, env_cmd, find_cmd, format_cmd, grep_cmd, json_cmd, local_llm, log_cmd, ls, read, summary,
-    tree, wc_cmd,
+    deps, env_cmd, find_cmd, format_cmd, grep_cmd, json_cmd, local_llm, log_cmd, ls, nix_cmd, read,
+    summary, tree, wc_cmd,
 };
 
 use anyhow::{Context, Result};
@@ -173,6 +173,14 @@ enum Commands {
     #[command(disable_help_flag = true)]
     Psql {
         /// psql arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// Nix package manager with compact output
+    #[command(disable_help_flag = true)]
+    Nix {
+        /// nix arguments
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -1426,6 +1434,8 @@ fn run_cli() -> Result<i32> {
 
         Commands::Psql { args } => psql_cmd::run(&args, cli.verbose)?,
 
+        Commands::Nix { args } => nix_cmd::run(&args, cli.verbose)?,
+
         Commands::Pnpm { command } => match command {
             PnpmCommands::List { depth, args } => {
                 pnpm_cmd::run(pnpm_cmd::PnpmCommand::List { depth }, &args, cli.verbose)?
@@ -2194,6 +2204,7 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Cargo { .. }
             | Commands::Npm { .. }
             | Commands::Npx { .. }
+            | Commands::Nix { .. }
             | Commands::Curl { .. }
             | Commands::Ruff { .. }
             | Commands::Pytest { .. }


### PR DESCRIPTION
## Summary
- Add first-class `rtk terraform`, `rtk nix`, and `rtk ansible-playbook` support for compact infra output with gain tracking.
- Add first-class `rtk tofu` support as a Terraform-equivalent command by reusing the Terraform filter pipeline and preserving OpenTofu-specific tracking labels.
- Extend discover rewrite coverage so `terraform`, `nix`, `ansible-playbook`, and `tofu` commands are recognized and rewritten to RTK equivalents.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets`
- [x] `cargo test --all`
- [x] Runtime validation in `nix-shell` with real tools (`terraform`, `opentofu`, `ansible`, `nix`) using raw-vs-rtk comparisons:
  - Terraform plan: **20 -> 3 lines**
  - OpenTofu plan: **20 -> 2 lines**
  - Ansible playbook: **11 -> 4 lines**
  - Nix search: **113383 -> 21 lines**
- [x] Verify gain tracking entries for all commands:
  - `rtk terraform plan -no-color`
  - `rtk tofu plan -no-color`
  - `rtk nix search nixpkgs hello`
  - `rtk ansible-playbook ...`
- [x] Validate discover rewrite behavior:
  - `rtk rewrite "tofu plan -lock=false"`
  - `rtk rewrite "terraform apply -auto-approve"`
  - `rtk rewrite "nix search nixpkgs hello"`
  - `rtk rewrite "ansible-playbook ..."`

## Notes
- Smoke script run (`bash scripts/test-all.sh`) reports known environment-related failures unrelated to this change (`learn/discover` need Claude sessions, and script used an older globally installed `rtk` binary).