### PR TITLE
fix(gh): passthrough --comments flag in issue/pr view

### DIFF
--- a/src/gh_cmd.rs
+++ b/src/gh_cmd.rs
@@ -286,7 +286,13 @@ fn list_prs(args: &[String], _verbose: u8, ultra_compact: bool) -> Result<()> {
 fn should_passthrough_pr_view(extra_args: &[String]) -> bool {
     extra_args
         .iter()
-        .any(|a| a == "--json" || a == "--jq" || a == "--web")
+        .any(|a| a == "--json" || a == "--jq" || a == "--web" || a == "--comments")
+}
+
+fn should_passthrough_issue_view(extra_args: &[String]) -> bool {
+    extra_args
+        .iter()
+        .any(|a| a == "--json" || a == "--jq" || a == "--web" || a == "--comments")
 }
 
 fn view_pr(args: &[String], _verbose: u8, ultra_compact: bool) -> Result<()> {
@@ -679,6 +685,13 @@ fn view_issue(args: &[String], _verbose: u8) -> Result<()> {
         Some(result) => result,
         None => return Err(anyhow::anyhow!("Issue number required")),
     };
+
+    // Passthrough when --comments, --json, --jq, or --web is present.
+    // --comments changes the output to include comments which our JSON
+    // field list doesn't request, causing silent data loss.
+    if should_passthrough_issue_view(&extra_args) {
+        return run_passthrough_with_extra("gh", &["issue", "view", &issue_number], &extra_args);
+    }
 
     let mut cmd = resolved_command("gh");
     cmd.args([
@@ -1488,8 +1501,41 @@ mod tests {
     }
 
     #[test]
-    fn test_should_passthrough_pr_view_other_flags() {
-        assert!(!should_passthrough_pr_view(&["--comments".into()]));
+    fn test_should_passthrough_pr_view_comments() {
+        assert!(should_passthrough_pr_view(&["--comments".into()]));
+    }
+
+    // --- should_passthrough_issue_view tests ---
+
+    #[test]
+    fn test_should_passthrough_issue_view_comments() {
+        assert!(should_passthrough_issue_view(&["--comments".into()]));
+    }
+
+    #[test]
+    fn test_should_passthrough_issue_view_json() {
+        assert!(should_passthrough_issue_view(&[
+            "--json".into(),
+            "body,comments".into()
+        ]));
+    }
+
+    #[test]
+    fn test_should_passthrough_issue_view_jq() {
+        assert!(should_passthrough_issue_view(&[
+            "--jq".into(),
+            ".body".into()
+        ]));
+    }
+
+    #[test]
+    fn test_should_passthrough_issue_view_web() {
+        assert!(should_passthrough_issue_view(&["--web".into()]));
+    }
+
+    #[test]
+    fn test_should_passthrough_issue_view_default() {
+        assert!(!should_passthrough_issue_view(&[]));
     }
 
     // --- filter_markdown_body tests ---


### PR DESCRIPTION
## Summary

- Add `--comments` to passthrough triggers in `should_passthrough_pr_view()`
- Add `should_passthrough_issue_view()` for `view_issue()`, which previously had no passthrough check

## Why this matters

`view_issue()` hardcodes `--json number,title,state,author,body,url` without `comments` (`src/gh_cmd.rs:688-689`). When `--comments` is appended, gh ignores it in `--json` mode and only returns the listed fields. Claude Code sees no comments and reports "no responses" on issues that actually have replies ([#720](https://github.com/rtk-ai/rtk/issues/720)).

`view_pr()` has a passthrough check (`should_passthrough_pr_view`) for `--json`, `--jq`, and `--web` but not `--comments` (line 286-289). Same silent data loss.

@cderv works around both by excluding `gh` from the hook via `config.toml`.

Same class of bug as [#730](https://github.com/rtk-ai/rtk/issues/730) - a filter that doesn't account for a flag silently produces wrong output.

## Changes

`src/gh_cmd.rs`:
- `should_passthrough_pr_view()`: added `--comments` to the trigger list
- Added `should_passthrough_issue_view()` with same triggers (`--comments`, `--json`, `--jq`, `--web`)
- `view_issue()`: added early passthrough check before the hardcoded JSON field list
- 6 new tests for `should_passthrough_issue_view`, 1 updated test for pr_view --comments

## Test plan

- [x] `cargo fmt --all --check && cargo clippy --all-targets && cargo test` (1077 tests pass)
- [x] Updated `test_should_passthrough_pr_view_other_flags` to assert `--comments` triggers passthrough
- [x] 5 new tests for `should_passthrough_issue_view` covering all trigger flags and default case

Fixes #720

This contribution was developed with AI assistance (Claude Code).