### PR TITLE
fix(gh): print 'No Pull Requests' when pr list is empty

### DIFF
--- a/src/cmds/git/gh_cmd.rs
+++ b/src/cmds/git/gh_cmd.rs
@@ -236,6 +236,13 @@ fn format_pr_list(json: &Value, ultra_compact: bool) -> String {
         Some(prs) => prs,
         None => return String::new(),
     };
+    if prs.is_empty() {
+        return if ultra_compact {
+            "No PRs\n".to_string()
+        } else {
+            "No Pull Requests\n".to_string()
+        };
+    }
     let mut out = String::new();
     out.push_str(if ultra_compact {
         "PRs\n"


### PR DESCRIPTION
## Bug
https://github.com/rtk-ai/rtk/issues/764 — `rtk gh pr list` prints an empty header with no feedback when there are zero pull requests.

## Fix
Added early return with a user-friendly message (`No Pull Requests` or `No PRs` in ultra-compact mode) when the parsed JSON array is empty, matching the existing pattern for `rtk gh issue list`.

## Testing
Verified by running `rtk gh pr list` on a repo with no open PRs. Confirmed the message renders correctly in both normal and ultra-compact (`-U`) modes.

Happy to address any feedback.

Greetings, saschabuehrle