### PR TITLE
fix: add telemetry documentation and init notice (#640)

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,28 @@ brew uninstall rtk           # If installed via Homebrew
 - **[SECURITY.md](SECURITY.md)** - Security policy and PR review process
 - **[AUDIT_GUIDE.md](docs/AUDIT_GUIDE.md)** - Token savings analytics guide
 
+## Privacy & Telemetry
+
+RTK collects **anonymous, aggregate usage metrics** once per day to help prioritize development. This is standard practice for open-source CLI tools.
+
+**What is collected:**
+- Device hash (SHA-256 of hostname+username, not reversible)
+- RTK version, OS, architecture
+- Command count (last 24h) and top command names (e.g. "git", "cargo" — no arguments, no file paths)
+- Token savings percentage
+
+**What is NOT collected:** source code, file paths, command arguments, secrets, environment variables, or any personally identifiable information.
+
+**Opt-out** (any of these):
+```bash
+# Environment variable
+export RTK_TELEMETRY_DISABLED=1
+
+# Or in config file (~/.config/rtk/config.toml)
+[telemetry]
+enabled = false
+```
+
 ## Contributing
 
 Contributions welcome! Please open an issue or PR on [GitHub](https://github.com/rtk-ai/rtk).

--- a/src/init.rs
+++ b/src/init.rs
@@ -279,6 +279,11 @@ pub fn run(
         install_cursor_hooks(verbose)?;
     }
 
+    // Telemetry notice (shown once during init)
+    println!();
+    println!("  [info] Anonymous telemetry is enabled (opt-out: RTK_TELEMETRY_DISABLED=1)");
+    println!("  [info] See: https://github.com/rtk-ai/rtk#privacy--telemetry");
+
     Ok(())
 }
 


### PR DESCRIPTION
Addresses H-1 from #640 (security review).

## Changes

- **README.md**: Add "Privacy & Telemetry" section explaining what is collected, what is NOT, and how to opt-out
- **src/init.rs**: Show telemetry notice during `rtk init` so users are informed at install time

## What RTK collects (anonymous, daily, opt-out)

- Device hash (SHA-256, not reversible)
- Version, OS, arch
- Command count + top command names (no arguments, no file paths)
- Token savings %

## What RTK does NOT collect

Source code, file paths, command arguments, secrets, environment variables, PII.

## Opt-out

`RTK_TELEMETRY_DISABLED=1` or `[telemetry] enabled = false` in config.toml.