### PR TITLE
docs: add all 9 AI tool integrations to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,15 @@ rtk gain        # Should show token savings stats
 ## Quick Start
 
 ```bash
-# 1. Install hook for Claude Code (recommended)
-rtk init --global
-# Follow instructions to register in ~/.claude/settings.json
-# Claude Code only by default (use --opencode for OpenCode, --gemini for Gemini CLI)
+# 1. Install for your AI tool
+rtk init -g                     # Claude Code / Copilot (default)
+rtk init -g --gemini            # Gemini CLI
+rtk init -g --codex             # Codex (OpenAI)
+rtk init -g --agent cursor      # Cursor
+rtk init --agent windsurf       # Windsurf
+rtk init --agent cline          # Cline / Roo Code
 
-# 2. Restart Claude Code, then test
+# 2. Restart your AI tool, then test
 git status  # Automatically rewritten to rtk git status
 ```
 
@@ -291,48 +294,95 @@ rtk init --show             # Verify installation
 
 After install, **restart Claude Code**.
 
-## Gemini CLI Support (Global)
+## Supported AI Tools
 
-RTK supports Gemini CLI via a native Rust hook processor. The hook intercepts `run_shell_command` tool calls and rewrites them to `rtk` equivalents using the same rewrite engine as Claude Code.
+RTK supports 9 AI coding tools. Each integration transparently rewrites shell commands to `rtk` equivalents for 60-90% token savings.
 
-**Install Gemini hook:**
+| Tool | Install | Method |
+|------|---------|--------|
+| **Claude Code** | `rtk init -g` | PreToolUse hook (bash) |
+| **GitHub Copilot** | `rtk init -g` | PreToolUse hook (`rtk hook copilot`) |
+| **Cursor** | `rtk init -g --agent cursor` | preToolUse hook (hooks.json) |
+| **Gemini CLI** | `rtk init -g --gemini` | BeforeTool hook (`rtk hook gemini`) |
+| **Codex** | `rtk init -g --codex` | AGENTS.md + RTK.md instructions |
+| **Windsurf** | `rtk init --agent windsurf` | .windsurfrules (project-scoped) |
+| **Cline / Roo Code** | `rtk init --agent cline` | .clinerules (project-scoped) |
+| **OpenCode** | `rtk init -g --opencode` | Plugin TS (tool.execute.before) |
+| **OpenClaw** | `openclaw plugins install ./openclaw` | Plugin TS (before_tool_call) |
+
+### Claude Code (default)
+
 ```bash
-rtk init -g --gemini
+rtk init -g                 # Install hook + RTK.md
+rtk init -g --auto-patch    # Non-interactive (CI/CD)
+rtk init --show             # Verify installation
+rtk init -g --uninstall     # Remove
 ```
 
-**What it creates:**
-- `~/.gemini/hooks/rtk-hook-gemini.sh` (thin wrapper calling `rtk hook gemini`)
-- `~/.gemini/GEMINI.md` (RTK awareness instructions)
-- Patches `~/.gemini/settings.json` with BeforeTool hook
+### GitHub Copilot (VS Code + CLI)
 
-**Uninstall:**
 ```bash
+rtk init -g                 # Same hook as Claude Code
+```
+
+The hook auto-detects Copilot format (VS Code `runTerminalCommand` or CLI `toolName: bash`) and rewrites commands. Works with both Copilot Chat in VS Code and `copilot` CLI.
+
+### Cursor
+
+```bash
+rtk init -g --agent cursor
+```
+
+Creates `~/.cursor/hooks/rtk-rewrite.sh` + patches `~/.cursor/hooks.json` with preToolUse matcher. Works with both Cursor editor and `cursor-agent` CLI.
+
+### Gemini CLI
+
+```bash
+rtk init -g --gemini
 rtk init -g --gemini --uninstall
 ```
 
-**Restart Required**: Restart Gemini CLI, then test with `git status` in a session.
+Creates `~/.gemini/hooks/rtk-hook-gemini.sh` + patches `~/.gemini/settings.json` with BeforeTool hook.
 
-## OpenCode Plugin (Global)
+### Codex (OpenAI)
 
-OpenCode supports plugins that can intercept tool execution. RTK provides a global plugin that mirrors the Claude auto-rewrite behavior by rewriting Bash tool commands to `rtk ...` before they execute. This plugin is **not** installed by default.
+```bash
+rtk init -g --codex
+```
 
-> **Note**: This plugin uses OpenCode's `tool.execute.before` hook. Known limitation: plugin hooks do not intercept subagent tool calls ([upstream issue](https://github.com/sst/opencode/issues/5894)). See [OpenCode plugin docs](https://open-code.ai/en/docs/plugins) for API details.
+Creates `~/.codex/RTK.md` + `~/.codex/AGENTS.md` with `@RTK.md` reference. Codex reads these as global instructions.
 
-**Install OpenCode plugin:**
+### Windsurf
+
+```bash
+rtk init --agent windsurf
+```
+
+Creates `.windsurfrules` in the current project. Cascade reads rules and prefixes commands with `rtk`.
+
+### Cline / Roo Code
+
+```bash
+rtk init --agent cline
+```
+
+Creates `.clinerules` in the current project. Cline reads rules and prefixes commands with `rtk`.
+
+### OpenCode
+
 ```bash
 rtk init -g --opencode
 ```
 
-**What it creates:**
-- `~/.config/opencode/plugins/rtk.ts`
+Creates `~/.config/opencode/plugins/rtk.ts`. Uses `tool.execute.before` hook.
 
-**Restart Required**: Restart OpenCode, then test with `git status` in a session.
+### OpenClaw
 
-**Manual install (fallback):**
 ```bash
-mkdir -p ~/.config/opencode/plugins
-cp hooks/opencode-rtk.ts ~/.config/opencode/plugins/rtk.ts
+openclaw plugins install ./openclaw
 ```
+
+Plugin in `openclaw/` directory. Uses `before_tool_call` hook, delegates to `rtk rewrite`.
 
 ### Commands Rewritten
 


### PR DESCRIPTION
## Summary

Document all 9 supported AI tools in README with install commands.

### Added

- Unified table: Claude Code, Copilot, Cursor, Gemini, Codex, Windsurf, Cline, OpenCode, OpenClaw
- Per-tool setup sections with install commands
- Updated Quick Start with all agent options

### Before

Only Claude Code, Gemini, and OpenCode were documented.

### After

All 9 tools have clear install instructions.