### PR TITLE
fix(golangci-lint): restore run wrapper and preserve global-flag rewrites

### DIFF
--- a/src/cmds/go/golangci_cmd.rs
+++ b/src/cmds/go/golangci_cmd.rs
@@ -191,7 +191,7 @@ fn find_subcommand_index(args: &[String]) -> Option<usize> {
         }
 
         if let Some(flag) = split_flag_name(arg) {
-            if GLOBAL_FLAGS_WITH_VALUE.contains(&flag) {
+            if golangci_flag_takes_separate_value(arg, flag) {
                 i += 1;
             }
         }
@@ -212,6 +212,18 @@ fn split_flag_name(arg: &str) -> Option<&str> {
     }
 
     None
+}
+
+fn golangci_flag_takes_separate_value(arg: &str, flag: &str) -> bool {
+    if !GLOBAL_FLAGS_WITH_VALUE.contains(&flag) {
+        return false;
+    }
+
+    if arg.starts_with("--") && arg.contains('=') {
+        return false;
+    }
+
+    true
 }
 
 fn build_filtered_args(invocation: &RunInvocation, version: u32) -> Vec<String> {
@@ -488,6 +500,28 @@ mod tests {
             classify_invocation(&["-v".into(), "run".into(), "./...".into()]),
             Invocation::FilteredRun(RunInvocation {
                 global_args: vec!["-v".into()],
+                run_args: vec!["./...".into()],
+            })
+        );
+    }
+
+    #[test]
+    fn test_classify_invocation_with_inline_value_flag_uses_filtered_path() {
+        assert_eq!(
+            classify_invocation(&["--color=never".into(), "run".into(), "./...".into()]),
+            Invocation::FilteredRun(RunInvocation {
+                global_args: vec!["--color=never".into()],
+                run_args: vec!["./...".into()],
+            })
+        );
+    }
+
+    #[test]
+    fn test_classify_invocation_with_inline_config_flag_uses_filtered_path() {
+        assert_eq!(
+            classify_invocation(&["--config=foo.yml".into(), "run".into(), "./...".into()]),
+            Invocation::FilteredRun(RunInvocation {
+                global_args: vec!["--config=foo.yml".into()],
                 run_args: vec!["./...".into()],
             })
         );

--- a/src/cmds/go/golangci_cmd.rs
+++ b/src/cmds/go/golangci_cmd.rs
@@ -6,6 +6,42 @@ use crate::core::utils::{resolved_command, truncate};
 use anyhow::Result;
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::ffi::OsString;
+
+const GOLANGCI_SUBCOMMANDS: &[&str] = &[
+    "cache",
+    "completion",
+    "config",
+    "custom",
+    "fmt",
+    "formatters",
+    "help",
+    "linters",
+    "migrate",
+    "run",
+    "version",
+];
+
+const GLOBAL_FLAGS_WITH_VALUE: &[&str] = &[
+    "-c",
+    "--color",
+    "--config",
+    "--cpu-profile-path",
+    "--mem-profile-path",
+    "--trace-path",
+];
+
+#[derive(Debug, PartialEq, Eq)]
+struct RunInvocation {
+    global_args: Vec<String>,
+    run_args: Vec<String>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum Invocation {
+    FilteredRun(RunInvocation),
+    Passthrough,
+}
 
 #[derive(Debug, Deserialize)]
 struct Position {
@@ -81,44 +117,31 @@ pub(crate) fn detect_major_version() -> u32 {
 }
 
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
+    match classify_invocation(args) {
+        Invocation::FilteredRun(invocation) => run_filtered(args, &invocation, verbose),
+        Invocation::Passthrough => run_passthrough(args, verbose),
+    }
+}
+
+fn run_filtered(original_args: &[String], invocation: &RunInvocation, verbose: u8) -> Result<i32> {
     let version = detect_major_version();
 
     let mut cmd = resolved_command("golangci-lint");
-
-    // Force JSON output (only if user hasn't specified it)
-    let has_format = args.iter().any(|a| {
-        a == "--out-format"
-            || a.starts_with("--out-format=")
-            || a == "--output.json.path"
-            || a.starts_with("--output.json.path=")
-    });
-
-    if !has_format {
-        if version >= 2 {
-            cmd.arg("run").arg("--output.json.path").arg("stdout");
-        } else {
-            cmd.arg("run").arg("--out-format=json");
-        }
-    } else {
-        cmd.arg("run");
-    }
-
-    for arg in args {
+    for arg in build_filtered_args(invocation, version) {
         cmd.arg(arg);
     }
 
     if verbose > 0 {
-        if version >= 2 {
-            eprintln!("Running: golangci-lint run --output.json.path stdout");
-        } else {
-            eprintln!("Running: golangci-lint run --out-format=json");
-        }
+        eprintln!(
+            "Running: {}",
+            format_command("golangci-lint", &build_filtered_args(invocation, version))
+        );
     }
 
     let exit_code = runner::run_filtered(
         cmd,
         "golangci-lint",
-        &args.join(" "),
+        &original_args.join(" "),
         |stdout| {
             // v2 outputs JSON on first line + trailing text; v1 outputs just JSON
             let json_output = if version >= 2 {
@@ -134,6 +157,95 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     // golangci-lint: exit 0 = clean, exit 1 = lint issues found (not an error),
     // exit 2+ = config/build error, None = killed by signal (OOM, SIGKILL)
     Ok(if exit_code == 1 { 0 } else { exit_code })
+}
+
+fn run_passthrough(args: &[String], verbose: u8) -> Result<i32> {
+    let os_args: Vec<OsString> = args.iter().map(OsString::from).collect();
+    runner::run_passthrough("golangci-lint", &os_args, verbose)
+}
+
+fn classify_invocation(args: &[String]) -> Invocation {
+    match find_subcommand_index(args) {
+        Some(idx) if args[idx] == "run" => Invocation::FilteredRun(RunInvocation {
+            global_args: args[..idx].to_vec(),
+            run_args: args[idx + 1..].to_vec(),
+        }),
+        _ => Invocation::Passthrough,
+    }
+}
+
+fn find_subcommand_index(args: &[String]) -> Option<usize> {
+    let mut i = 0;
+    while i < args.len() {
+        let arg = args[i].as_str();
+
+        if arg == "--" {
+            return None;
+        }
+
+        if !arg.starts_with('-') {
+            if GOLANGCI_SUBCOMMANDS.contains(&arg) {
+                return Some(i);
+            }
+            return None;
+        }
+
+        if let Some(flag) = split_flag_name(arg) {
+            if GLOBAL_FLAGS_WITH_VALUE.contains(&flag) {
+                i += 1;
+            }
+        }
+
+        i += 1;
+    }
+
+    None
+}
+
+fn split_flag_name(arg: &str) -> Option<&str> {
+    if arg.starts_with("--") {
+        return Some(arg.split_once('=').map(|(flag, _)| flag).unwrap_or(arg));
+    }
+
+    if arg.starts_with('-') {
+        return Some(arg);
+    }
+
+    None
+}
+
+fn build_filtered_args(invocation: &RunInvocation, version: u32) -> Vec<String> {
+    let mut args = invocation.global_args.clone();
+    args.push("run".to_string());
+
+    if !has_output_flag(&invocation.run_args) {
+        if version >= 2 {
+            args.push("--output.json.path".to_string());
+            args.push("stdout".to_string());
+        } else {
+            args.push("--out-format=json".to_string());
+        }
+    }
+
+    args.extend(invocation.run_args.clone());
+    args
+}
+
+fn has_output_flag(args: &[String]) -> bool {
+    args.iter().any(|a| {
+        a == "--out-format"
+            || a.starts_with("--out-format=")
+            || a == "--output.json.path"
+            || a.starts_with("--output.json.path=")
+    })
+}
+
+fn format_command(base: &str, args: &[String]) -> String {
+    if args.is_empty() {
+        base.to_string()
+    } else {
+        format!("{} {}", base, args.join(" "))
+    }
 }
 
 /// Filter golangci-lint JSON output - group by linter and file
@@ -341,6 +453,78 @@ mod tests {
     #[test]
     fn test_parse_version_malformed_returns_1() {
         assert_eq!(parse_major_version("not a version string"), 1);
+    }
+
+    #[test]
+    fn test_classify_invocation_run_uses_filtered_path() {
+        assert_eq!(
+            classify_invocation(&["run".into(), "./...".into()]),
+            Invocation::FilteredRun(RunInvocation {
+                global_args: vec![],
+                run_args: vec!["./...".into()],
+            })
+        );
+    }
+
+    #[test]
+    fn test_classify_invocation_with_global_flag_value_uses_filtered_path() {
+        assert_eq!(
+            classify_invocation(&[
+                "--color".into(),
+                "never".into(),
+                "run".into(),
+                "./...".into(),
+            ]),
+            Invocation::FilteredRun(RunInvocation {
+                global_args: vec!["--color".into(), "never".into()],
+                run_args: vec!["./...".into()],
+            })
+        );
+    }
+
+    #[test]
+    fn test_classify_invocation_with_short_global_flag_uses_filtered_path() {
+        assert_eq!(
+            classify_invocation(&["-v".into(), "run".into(), "./...".into()]),
+            Invocation::FilteredRun(RunInvocation {
+                global_args: vec!["-v".into()],
+                run_args: vec!["./...".into()],
+            })
+        );
+    }
+
+    #[test]
+    fn test_classify_invocation_bare_command_is_passthrough() {
+        assert_eq!(classify_invocation(&[]), Invocation::Passthrough);
+    }
+
+    #[test]
+    fn test_classify_invocation_version_flag_is_passthrough() {
+        assert_eq!(
+            classify_invocation(&["--version".into()]),
+            Invocation::Passthrough
+        );
+    }
+
+    #[test]
+    fn test_classify_invocation_version_subcommand_is_passthrough() {
+        assert_eq!(
+            classify_invocation(&["version".into()]),
+            Invocation::Passthrough
+        );
+    }
+
+    #[test]
+    fn test_build_filtered_args_does_not_duplicate_run() {
+        let invocation = RunInvocation {
+            global_args: vec![],
+            run_args: vec!["./...".into()],
+        };
+
+        assert_eq!(
+            build_filtered_args(&invocation, 2),
+            vec!["run", "--output.json.path", "stdout", "./..."]
+        );
     }
 
     #[test]

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -70,6 +70,21 @@ lazy_static! {
     static ref TAIL_LINES_SPACE: Regex = Regex::new(r"^tail\s+--lines\s+(\d+)\s+(.+)$").unwrap();
 }
 
+const GOLANGCI_GLOBAL_OPT_WITH_VALUE: &[&str] = &[
+    "-c",
+    "--color",
+    "--config",
+    "--cpu-profile-path",
+    "--mem-profile-path",
+    "--trace-path",
+];
+
+#[derive(Debug, Clone, Copy)]
+struct GolangciRunParts<'a> {
+    global_segment: &'a str,
+    run_segment: &'a str,
+}
+
 /// Classify a single (already-split) command.
 pub fn classify_command(cmd: &str) -> Classification {
     let trimmed = cmd.trim();
@@ -100,6 +115,9 @@ pub fn classify_command(cmd: &str) -> Classification {
     let cmd_normalized = strip_absolute_path(cmd_clean);
     // Strip git global options: git -C /tmp status → git status (#163)
     let cmd_normalized = strip_git_global_opts(&cmd_normalized);
+    // Strip golangci-lint global options before `run` so classify/rewrite stays
+    // aligned with the runtime wrapper behavior.
+    let cmd_normalized = strip_golangci_global_opts(&cmd_normalized);
     let cmd_clean = cmd_normalized.as_str();
 
     // Exclude cat/head/tail with redirect operators — these are writes, not reads (#315)
@@ -256,6 +274,93 @@ fn strip_git_global_opts(cmd: &str) -> String {
     let after_git = &cmd[4..]; // skip "git "
     let stripped = GIT_GLOBAL_OPT.replace(after_git, "");
     format!("git {}", stripped.trim())
+}
+
+/// Strip golangci-lint global options before the `run` subcommand.
+/// `golangci-lint --color never run ./...` → `golangci-lint run ./...`
+/// Returns the original string unchanged if this is not a supported compact `run` invocation.
+fn strip_golangci_global_opts(cmd: &str) -> String {
+    match parse_golangci_run_parts(cmd) {
+        Some(parts) => format!("golangci-lint {}", parts.run_segment),
+        None => cmd.to_string(),
+    }
+}
+
+/// Parse supported golangci-lint invocations with optional global flags before `run`.
+fn parse_golangci_run_parts(cmd: &str) -> Option<GolangciRunParts<'_>> {
+    let tokens = split_token_spans(cmd);
+    let first = tokens.first()?;
+    if first.0 != "golangci-lint" && first.0 != "golangci" {
+        return None;
+    }
+
+    let mut i = 1;
+    while i < tokens.len() {
+        let token = tokens[i].0;
+
+        if token == "--" {
+            return None;
+        }
+
+        if !token.starts_with('-') {
+            if token == "run" {
+                let global_segment = if i > 1 {
+                    cmd[tokens[1].1..tokens[i].1].trim()
+                } else {
+                    ""
+                };
+                let run_segment = cmd[tokens[i].1..].trim();
+                return Some(GolangciRunParts {
+                    global_segment,
+                    run_segment,
+                });
+            }
+            return None;
+        }
+
+        if let Some(flag) = split_golangci_flag_name(token) {
+            if GOLANGCI_GLOBAL_OPT_WITH_VALUE.contains(&flag) {
+                i += 1;
+            }
+        }
+
+        i += 1;
+    }
+
+    None
+}
+
+fn split_golangci_flag_name(arg: &str) -> Option<&str> {
+    if arg.starts_with("--") {
+        return Some(arg.split_once('=').map(|(flag, _)| flag).unwrap_or(arg));
+    }
+
+    if arg.starts_with('-') {
+        return Some(arg);
+    }
+
+    None
+}
+
+fn split_token_spans(cmd: &str) -> Vec<(&str, usize, usize)> {
+    let mut tokens = Vec::new();
+    let mut start = None;
+
+    for (idx, ch) in cmd.char_indices() {
+        if ch.is_whitespace() {
+            if let Some(token_start) = start.take() {
+                tokens.push((&cmd[token_start..idx], token_start, idx));
+            }
+        } else if start.is_none() {
+            start = Some(idx);
+        }
+    }
+
+    if let Some(token_start) = start {
+        tokens.push((&cmd[token_start..], token_start, cmd.len()));
+    }
+
+    tokens
 }
 
 /// Normalize absolute binary paths: `/usr/bin/grep -rn foo` → `grep -rn foo` (#485)
@@ -536,6 +641,18 @@ fn rewrite_segment(seg: &str, excluded: &[String]) -> Option<String> {
              Remove RTK_DISABLED=1 to restore token savings."
         );
         return None;
+    }
+
+    if let Some(parts) = parse_golangci_run_parts(cmd_clean) {
+        let rewritten = if parts.global_segment.is_empty() {
+            format!("{}rtk golangci-lint {}", env_prefix, parts.run_segment)
+        } else {
+            format!(
+                "{}rtk golangci-lint {} {}",
+                env_prefix, parts.global_segment, parts.run_segment
+            )
+        };
+        return Some(rewritten);
     }
 
     // #196: gh with --json/--jq/--template produces structured output that
@@ -1884,6 +2001,28 @@ mod tests {
     }
 
     #[test]
+    fn test_classify_golangci_lint_with_flag_before_run() {
+        assert!(matches!(
+            classify_command("golangci-lint -v run ./..."),
+            Classification::Supported {
+                rtk_equivalent: "rtk golangci-lint run",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_classify_golangci_lint_with_value_flag_before_run() {
+        assert!(matches!(
+            classify_command("golangci-lint --color never run ./..."),
+            Classification::Supported {
+                rtk_equivalent: "rtk golangci-lint run",
+                ..
+            }
+        ));
+    }
+
+    #[test]
     fn test_classify_golangci_lint_bare_is_not_compact_wrapper() {
         assert!(!matches!(
             classify_command("golangci-lint"),
@@ -1934,6 +2073,30 @@ mod tests {
         assert_eq!(
             rewrite_command("golangci-lint run ./...", &[]),
             Some("rtk golangci-lint run ./...".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_golangci_lint_with_flag_before_run() {
+        assert_eq!(
+            rewrite_command("golangci-lint -v run ./...", &[]),
+            Some("rtk golangci-lint -v run ./...".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_golangci_lint_with_value_flag_before_run() {
+        assert_eq!(
+            rewrite_command("golangci-lint --color never run ./...", &[]),
+            Some("rtk golangci-lint --color never run ./...".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_env_prefixed_golangci_lint_with_value_flag_before_run() {
+        assert_eq!(
+            rewrite_command("FOO=1 golangci-lint --color never run ./...", &[]),
+            Some("FOO=1 rtk golangci-lint --color never run ./...".into())
         );
     }
 
@@ -2367,6 +2530,23 @@ mod tests {
         assert_eq!(strip_git_global_opts("git --no-pager log"), "git log");
         assert_eq!(strip_git_global_opts("git status"), "git status");
         assert_eq!(strip_git_global_opts("cargo test"), "cargo test");
+    }
+
+    #[test]
+    fn test_strip_golangci_global_opts_helper() {
+        assert_eq!(
+            strip_golangci_global_opts("golangci-lint -v run ./..."),
+            "golangci-lint run ./..."
+        );
+        assert_eq!(
+            strip_golangci_global_opts("golangci-lint --color never run ./..."),
+            "golangci-lint run ./..."
+        );
+        assert_eq!(
+            strip_golangci_global_opts("golangci-lint version"),
+            "golangci-lint version"
+        );
+        assert_eq!(strip_golangci_global_opts("cargo test"), "cargo test");
     }
 
     // --- #wc: wc filter was silently ignored by the hook ---

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -319,7 +319,7 @@ fn parse_golangci_run_parts(cmd: &str) -> Option<GolangciRunParts<'_>> {
         }
 
         if let Some(flag) = split_golangci_flag_name(token) {
-            if GOLANGCI_GLOBAL_OPT_WITH_VALUE.contains(&flag) {
+            if golangci_flag_takes_separate_value(token, flag) {
                 i += 1;
             }
         }
@@ -340,6 +340,18 @@ fn split_golangci_flag_name(arg: &str) -> Option<&str> {
     }
 
     None
+}
+
+fn golangci_flag_takes_separate_value(arg: &str, flag: &str) -> bool {
+    if !GOLANGCI_GLOBAL_OPT_WITH_VALUE.contains(&flag) {
+        return false;
+    }
+
+    if arg.starts_with("--") && arg.contains('=') {
+        return false;
+    }
+
+    true
 }
 
 fn split_token_spans(cmd: &str) -> Vec<(&str, usize, usize)> {
@@ -2023,6 +2035,28 @@ mod tests {
     }
 
     #[test]
+    fn test_classify_golangci_lint_with_inline_value_flag_before_run() {
+        assert!(matches!(
+            classify_command("golangci-lint --color=never run ./..."),
+            Classification::Supported {
+                rtk_equivalent: "rtk golangci-lint run",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_classify_golangci_lint_with_inline_config_flag_before_run() {
+        assert!(matches!(
+            classify_command("golangci-lint --config=foo.yml run ./..."),
+            Classification::Supported {
+                rtk_equivalent: "rtk golangci-lint run",
+                ..
+            }
+        ));
+    }
+
+    #[test]
     fn test_classify_golangci_lint_bare_is_not_compact_wrapper() {
         assert!(!matches!(
             classify_command("golangci-lint"),
@@ -2093,10 +2127,34 @@ mod tests {
     }
 
     #[test]
+    fn test_rewrite_golangci_lint_with_inline_value_flag_before_run() {
+        assert_eq!(
+            rewrite_command("golangci-lint --color=never run ./...", &[]),
+            Some("rtk golangci-lint --color=never run ./...".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_golangci_lint_with_inline_config_flag_before_run() {
+        assert_eq!(
+            rewrite_command("golangci-lint --config=foo.yml run ./...", &[]),
+            Some("rtk golangci-lint --config=foo.yml run ./...".into())
+        );
+    }
+
+    #[test]
     fn test_rewrite_env_prefixed_golangci_lint_with_value_flag_before_run() {
         assert_eq!(
             rewrite_command("FOO=1 golangci-lint --color never run ./...", &[]),
             Some("FOO=1 rtk golangci-lint --color never run ./...".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_env_prefixed_golangci_lint_with_inline_value_flag_before_run() {
+        assert_eq!(
+            rewrite_command("FOO=1 golangci-lint --color=never run ./...", &[]),
+            Some("FOO=1 rtk golangci-lint --color=never run ./...".into())
         );
     }
 
@@ -2540,6 +2598,14 @@ mod tests {
         );
         assert_eq!(
             strip_golangci_global_opts("golangci-lint --color never run ./..."),
+            "golangci-lint run ./..."
+        );
+        assert_eq!(
+            strip_golangci_global_opts("golangci-lint --color=never run ./..."),
+            "golangci-lint run ./..."
+        );
+        assert_eq!(
+            strip_golangci_global_opts("golangci-lint --config=foo.yml run ./..."),
             "golangci-lint run ./..."
         );
         assert_eq!(

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1877,7 +1877,29 @@ mod tests {
         assert!(matches!(
             classify_command("golangci-lint run"),
             Classification::Supported {
-                rtk_equivalent: "rtk golangci-lint",
+                rtk_equivalent: "rtk golangci-lint run",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_classify_golangci_lint_bare_is_not_compact_wrapper() {
+        assert!(!matches!(
+            classify_command("golangci-lint"),
+            Classification::Supported {
+                rtk_equivalent: "rtk golangci-lint run",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_classify_golangci_lint_other_subcommand_is_not_compact_wrapper() {
+        assert!(!matches!(
+            classify_command("golangci-lint version"),
+            Classification::Supported {
+                rtk_equivalent: "rtk golangci-lint run",
                 ..
             }
         ));
@@ -1913,6 +1935,16 @@ mod tests {
             rewrite_command("golangci-lint run ./...", &[]),
             Some("rtk golangci-lint run ./...".into())
         );
+    }
+
+    #[test]
+    fn test_rewrite_bare_golangci_lint_skips_compact_wrapper() {
+        assert_eq!(rewrite_command("golangci-lint", &[]), None);
+    }
+
+    #[test]
+    fn test_rewrite_other_golangci_lint_subcommand_skips_compact_wrapper() {
+        assert_eq!(rewrite_command("golangci-lint version", &[]), None);
     }
 
     // --- JS/TS tooling ---

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -276,9 +276,9 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        pattern: r"^golangci-lint(\s|$)",
-        rtk_cmd: "rtk golangci-lint",
-        rewrite_prefixes: &["golangci-lint", "golangci"],
+        pattern: r"^(?:golangci-lint|golangci)\s+(run)(?:\s|$)",
+        rtk_cmd: "rtk golangci-lint run",
+        rewrite_prefixes: &["golangci-lint run", "golangci run"],
         category: "Go",
         savings_pct: 85.0,
         subcmd_savings: &[],

--- a/src/main.rs
+++ b/src/main.rs
@@ -656,10 +656,10 @@ enum Commands {
         command: GtCommands,
     },
 
-    /// golangci-lint with compact output
+    /// golangci-lint wrapper with compact `run` support and passthrough for other invocations
     #[command(name = "golangci-lint")]
     GolangciLint {
-        /// golangci-lint arguments
+        /// Additional golangci-lint arguments
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },


### PR DESCRIPTION
## Summary

This PR fixes a regression in the `golangci-lint` wrapper and restores consistency between runtime behavior, `discover`/`rewrite`, and the documented compact path.

It includes exactly these 3 commits:
- `fix(golangci-lint): restore run wrapper and align guidance`
- `fix(discover): preserve golangci-lint flags in rewrite`
- `fix(golangci-lint): support inline global flags before run`

## What changed

- restored `rtk golangci-lint` as a single wrapper entrypoint with passthrough for non-`run` invocations
- kept compact filtering only for `rtk golangci-lint run ...`
- fixed `discover` / `rewrite` so global flags before `run` are preserved
- fixed inline `--flag=value` handling in both runtime parsing and rewrite/discovery
- updated guidance/docs so the compact path is consistently advertised as `rtk golangci-lint run ...`

## Validation

Targeted checks passed:
- `rtk cargo test golangci_cmd -- --nocapture`
- `rtk cargo test discover::registry -- --nocapture`
- `rtk cargo run -- rewrite 'golangci-lint --color=never run ./...'`

Local full gate status:
- `rtk cargo fmt --all --check` passed
- `rtk cargo clippy --all-targets` reported one existing warning in `src/rake_cmd.rs`
- `rtk cargo test` in this environment still hits pre-existing tracking DB file failures unrelated to this PR
