### PR TITLE
feat(init): add support for kilocode and antigravity agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ rtk init -g --codex             # Codex (OpenAI)
 rtk init -g --agent cursor      # Cursor
 rtk init --agent windsurf       # Windsurf
 rtk init --agent cline          # Cline / Roo Code
+rtk init --agent kilocode       # Kilo Code
+rtk init --agent antigravity    # Google Antigravity
 
 # 2. Restart your AI tool, then test
 git status  # Automatically rewritten to rtk git status
@@ -308,7 +310,7 @@ After install, **restart Claude Code**.
 
 ## Supported AI Tools
 
-RTK supports 10 AI coding tools. Each integration transparently rewrites shell commands to `rtk` equivalents for 60-90% token savings.
+RTK supports 12 AI coding tools. Each integration transparently rewrites shell commands to `rtk` equivalents for 60-90% token savings.
 
 | Tool | Install | Method |
 |------|---------|--------|
@@ -323,6 +325,8 @@ RTK supports 10 AI coding tools. Each integration transparently rewrites shell c
 | **OpenCode** | `rtk init -g --opencode` | Plugin TS (tool.execute.before) |
 | **OpenClaw** | `openclaw plugins install ./openclaw` | Plugin TS (before_tool_call) |
 | **Mistral Vibe** | Planned ([#800](https://github.com/rtk-ai/rtk/issues/800)) | Blocked on upstream |
+| **Kilo Code** | `rtk init --agent kilocode` | .kilocode/rules/rtk-rules.md (project-scoped) |
+| **Google Antigravity** | `rtk init --agent antigravity` | .agents/rules/antigravity-rtk-rules.md (project-scoped) |
 
 For per-agent setup details, override controls, and graceful degradation, see the [Supported Agents guide](https://www.rtk-ai.app/guide/getting-started/supported-agents).
 

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -1,13 +1,13 @@
 ---
 title: Supported Agents
-description: How to integrate RTK with Claude Code, Cursor, Copilot, Cline, Windsurf, Codex, and OpenCode
+description: How to integrate RTK with Claude Code, Cursor, Copilot, Cline, Windsurf, Codex, OpenCode, Kilo Code, and Antigravity
 sidebar:
   order: 3
 ---
 
 # Supported Agents
 
-RTK supports 10 AI coding agents across 3 integration tiers. Mistral Vibe support is planned.
+RTK supports 12 AI coding agents across 3 integration tiers. Mistral Vibe support is planned.
 
 ## How it works
 
@@ -38,6 +38,8 @@ Agent runs "cargo test"
 | Cline / Roo Code | Rules file (prompt-level) | N/A |
 | Windsurf | Rules file (prompt-level) | N/A |
 | Codex CLI | AGENTS.md instructions | N/A |
+| Kilo Code | Rules file (prompt-level) | N/A |
+| Google Antigravity | Rules file (prompt-level) | N/A |
 | Mistral Vibe | Planned ([#800](https://github.com/rtk-ai/rtk/issues/800)) | Pending upstream |
 
 ## Installation by agent
@@ -110,6 +112,22 @@ rtk init --windsurf    # creates .windsurfrules in current project
 rtk init --codex    # creates AGENTS.md or patches existing one
 ```
 
+### Kilo Code
+
+```bash
+rtk init --agent kilocode    # creates .kilocode/rules/rtk-rules.md in current project
+```
+
+Kilo Code reads `.kilocode/rules/` as custom instructions. RTK adds guidance telling Kilo Code to prefer `rtk <cmd>` over raw commands.
+
+### Google Antigravity
+
+```bash
+rtk init --agent antigravity    # creates .agents/rules/antigravity-rtk-rules.md in current project
+```
+
+Antigravity reads `.agents/rules/` as custom instructions. RTK adds guidance telling Antigravity to prefer `rtk <cmd>` over raw commands.
+
 ### Mistral Vibe (planned)
 
 Support is blocked on upstream `BeforeToolCallback` ([mistral-vibe#531](https://github.com/mistralai/mistral-vibe/issues/531)). Tracked in [#800](https://github.com/rtk-ai/rtk/issues/800).
@@ -122,7 +140,7 @@ Support is blocked on upstream `BeforeToolCallback` ([mistral-vibe#531](https://
 | **Plugin** | TypeScript/JS in agent's plugin system | Transparent — in-place mutation |
 | **Rules file** | Prompt-level instructions | Guidance only — agent is told to prefer `rtk <cmd>` |
 
-Rules file integrations (Cline, Windsurf, Codex) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it.
+Rules file integrations (Cline, Windsurf, Codex, Kilo Code, Antigravity) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it.
 
 ## Graceful degradation
 

--- a/hooks/antigravity/README.md
+++ b/hooks/antigravity/README.md
@@ -1,0 +1,9 @@
+# Google Antigravity Hooks
+
+> Part of [`hooks/`](../README.md) — see also [`src/hooks/`](../../src/hooks/README.md) for installation code
+
+## Specifics
+
+- Prompt-level guidance only (no programmatic hook) -- relies on Antigravity reading custom instructions
+- `rules.md` contains the instruction to prefix all shell commands with `rtk`, usage examples, and meta commands
+- Installed to `.agents/rules/antigravity-rtk-rules.md` (project-local) by `rtk init --agent antigravity`

--- a/hooks/antigravity/rules.md
+++ b/hooks/antigravity/rules.md
@@ -1,0 +1,32 @@
+# RTK - Rust Token Killer (Google Antigravity)
+
+**Usage**: Token-optimized CLI proxy for shell commands.
+
+## Rule
+
+Always prefix shell commands with `rtk` to minimize token consumption.
+
+Examples:
+
+```bash
+rtk git status
+rtk cargo test
+rtk ls src/
+rtk grep "pattern" src/
+rtk find "*.rs" .
+rtk docker ps
+rtk gh pr list
+```
+
+## Meta Commands
+
+```bash
+rtk gain              # Show token savings
+rtk gain --history    # Command history with savings
+rtk discover          # Find missed RTK opportunities
+rtk proxy <cmd>       # Run raw (no filtering, for debugging)
+```
+
+## Why
+
+RTK filters and compresses command output before it reaches the LLM context, saving 60-90% tokens on common operations. Always use `rtk <cmd>` instead of raw commands.

--- a/hooks/kilocode/README.md
+++ b/hooks/kilocode/README.md
@@ -1,0 +1,9 @@
+# Kilo Code Hooks
+
+> Part of [`hooks/`](../README.md) — see also [`src/hooks/`](../../src/hooks/README.md) for installation code
+
+## Specifics
+
+- Prompt-level guidance only (no programmatic hook) -- relies on Kilo Code reading custom instructions
+- `rules.md` contains the instruction to prefix all shell commands with `rtk`, usage examples, and meta commands
+- Installed to `.kilocode/rules/rtk-rules.md` (project-local) by `rtk init --agent kilocode`

--- a/hooks/kilocode/rules.md
+++ b/hooks/kilocode/rules.md
@@ -1,0 +1,32 @@
+# RTK - Rust Token Killer (Kilo Code)
+
+**Usage**: Token-optimized CLI proxy for shell commands.
+
+## Rule
+
+Always prefix shell commands with `rtk` to minimize token consumption.
+
+Examples:
+
+```bash
+rtk git status
+rtk cargo test
+rtk ls src/
+rtk grep "pattern" src/
+rtk find "*.rs" .
+rtk docker ps
+rtk gh pr list
+```
+
+## Meta Commands
+
+```bash
+rtk gain              # Show token savings
+rtk gain --history    # Command history with savings
+rtk discover          # Find missed RTK opportunities
+rtk proxy <cmd>       # Run raw (no filtering, for debugging)
+```
+
+## Why
+
+RTK filters and compresses command output before it reaches the LLM context, saving 60-90% tokens on common operations. Always use `rtk <cmd>` instead of raw commands.

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -1245,6 +1245,86 @@ fn run_windsurf_mode(verbose: u8) -> Result<()> {
     Ok(())
 }
 
+// ─── Kilo Code support ────────────────────────────────────────
+
+const KILOCODE_RULES: &str = include_str!("../../hooks/kilocode/rules.md");
+
+pub fn run_kilocode_mode(verbose: u8) -> Result<()> {
+    run_kilocode_mode_at(&std::env::current_dir()?, verbose)
+}
+
+fn run_kilocode_mode_at(base_dir: &Path, verbose: u8) -> Result<()> {
+    // Kilo Code reads .kilocode/rules/ from the project root (workspace-scoped)
+    let target_dir = base_dir.join(".kilocode/rules");
+    let rules_path = target_dir.join("rtk-rules.md");
+
+    let existing = fs::read_to_string(&rules_path).unwrap_or_default();
+    if existing.contains("RTK") || existing.contains("rtk") {
+        println!("\nRTK already configured for Kilo Code in this project.\n");
+        println!("  Rules: .kilocode/rules/rtk-rules.md (already present)");
+    } else {
+        fs::create_dir_all(&target_dir).context("Failed to create .kilocode/rules directory")?;
+        let new_content = if existing.trim().is_empty() {
+            KILOCODE_RULES.to_string()
+        } else {
+            format!("{}\n\n{}", existing.trim(), KILOCODE_RULES)
+        };
+        fs::write(&rules_path, &new_content)
+            .context("Failed to write .kilocode/rules/rtk-rules.md")?;
+
+        if verbose > 0 {
+            eprintln!("Wrote .kilocode/rules/rtk-rules.md");
+        }
+
+        println!("\nRTK configured for Kilo Code.\n");
+        println!("  Rules: .kilocode/rules/rtk-rules.md (installed)");
+    }
+    println!("  Kilo Code will now use rtk commands for token savings.");
+    println!("  Test with: git status\n");
+
+    Ok(())
+}
+
+// ─── Google Antigravity support ───────────────────────────────
+
+const ANTIGRAVITY_RULES: &str = include_str!("../../hooks/antigravity/rules.md");
+
+pub fn run_antigravity_mode(verbose: u8) -> Result<()> {
+    run_antigravity_mode_at(&std::env::current_dir()?, verbose)
+}
+
+fn run_antigravity_mode_at(base_dir: &Path, verbose: u8) -> Result<()> {
+    // Antigravity reads .agents/rules/ from the project root (workspace-scoped)
+    let target_dir = base_dir.join(".agents/rules");
+    let rules_path = target_dir.join("antigravity-rtk-rules.md");
+
+    let existing = fs::read_to_string(&rules_path).unwrap_or_default();
+    if existing.contains("RTK") || existing.contains("rtk") {
+        println!("\nRTK already configured for Antigravity in this project.\n");
+        println!("  Rules: .agents/rules/antigravity-rtk-rules.md (already present)");
+    } else {
+        fs::create_dir_all(&target_dir).context("Failed to create .agents/rules directory")?;
+        let new_content = if existing.trim().is_empty() {
+            ANTIGRAVITY_RULES.to_string()
+        } else {
+            format!("{}\n\n{}", existing.trim(), ANTIGRAVITY_RULES)
+        };
+        fs::write(&rules_path, &new_content)
+            .context("Failed to write .agents/rules/antigravity-rtk-rules.md")?;
+
+        if verbose > 0 {
+            eprintln!("Wrote .agents/rules/antigravity-rtk-rules.md");
+        }
+
+        println!("\nRTK configured for Google Antigravity.\n");
+        println!("  Rules: .agents/rules/antigravity-rtk-rules.md (installed)");
+    }
+    println!("  Antigravity will now use rtk commands for token savings.");
+    println!("  Test with: git status\n");
+
+    Ok(())
+}
+
 fn run_codex_mode(global: bool, verbose: u8) -> Result<()> {
     let (agents_md_path, rtk_md_path) = if global {
         let codex_dir = resolve_codex_dir()?;
@@ -2667,6 +2747,56 @@ More notes
             err.to_string(),
             "--codex cannot be combined with --no-patch"
         );
+    }
+
+    #[test]
+    fn test_kilocode_mode_creates_rules_file() {
+        let temp = TempDir::new().unwrap();
+        run_kilocode_mode_at(temp.path(), 0).unwrap();
+
+        let rules_path = temp.path().join(".kilocode/rules/rtk-rules.md");
+        assert!(rules_path.exists(), "Rules file should be created");
+        let content = fs::read_to_string(&rules_path).unwrap();
+        assert!(content.contains("RTK"), "Rules file should contain RTK");
+    }
+
+    #[test]
+    fn test_kilocode_mode_is_idempotent() {
+        let temp = TempDir::new().unwrap();
+        run_kilocode_mode_at(temp.path(), 0).unwrap();
+
+        let path = temp.path().join(".kilocode/rules/rtk-rules.md");
+        let first = fs::read_to_string(&path).unwrap();
+
+        // Second run should not overwrite
+        run_kilocode_mode_at(temp.path(), 0).unwrap();
+        let second = fs::read_to_string(&path).unwrap();
+        assert_eq!(first, second, "Idempotent: content should not change");
+    }
+
+    #[test]
+    fn test_antigravity_mode_creates_rules_file() {
+        let temp = TempDir::new().unwrap();
+        run_antigravity_mode_at(temp.path(), 0).unwrap();
+
+        let rules_path = temp.path().join(".agents/rules/antigravity-rtk-rules.md");
+        assert!(rules_path.exists(), "Rules file should be created");
+        let content = fs::read_to_string(&rules_path).unwrap();
+        assert!(content.contains("RTK"), "Rules file should contain RTK");
+    }
+
+    #[test]
+    fn test_antigravity_mode_is_idempotent() {
+        let temp = TempDir::new().unwrap();
+        run_antigravity_mode_at(temp.path(), 0).unwrap();
+
+        let path = temp.path().join(".agents/rules/antigravity-rtk-rules.md");
+        let first = fs::read_to_string(&path).unwrap();
+
+        // Second run should not overwrite
+        run_antigravity_mode_at(temp.path(), 0).unwrap();
+        let second = fs::read_to_string(&path).unwrap();
+        assert_eq!(first, second, "Idempotent: content should not change");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,10 @@ pub enum AgentTarget {
     Windsurf,
     /// Cline / Roo Code (VS Code)
     Cline,
+    /// Kilo Code
+    Kilocode,
+    /// Google Antigravity
+    Antigravity,
 }
 
 #[derive(Parser)]
@@ -1624,6 +1628,18 @@ fn run_cli() -> Result<i32> {
                 hooks::init::run_gemini(global, hook_only, patch_mode, cli.verbose)?;
             } else if copilot {
                 hooks::init::run_copilot(cli.verbose)?;
+            } else if agent == Some(AgentTarget::Kilocode) {
+                if global {
+                    anyhow::bail!("Kilo Code is project-scoped. Use: rtk init --agent kilocode");
+                }
+                hooks::init::run_kilocode_mode(cli.verbose)?;
+            } else if agent == Some(AgentTarget::Antigravity) {
+                if global {
+                    anyhow::bail!(
+                        "Antigravity is project-scoped. Use: rtk init --agent antigravity"
+                    );
+                }
+                hooks::init::run_antigravity_mode(cli.verbose)?;
             } else {
                 let install_opencode = opencode;
                 let install_claude = !opencode;


### PR DESCRIPTION
Add support for generating rules for Kilo Code and Google Antigravity via `rtk init`.

## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

- **Added CLI Flags**: Extended `AgentTarget` to support `--agent kilocode` and `--agent antigravity`.
- **Injected Agent Rules**: Created specific markdown instruction files matching the original token-loss guidelines for both assistants (`.kilocode/rules/rtk-rules.md` and [.agent/rules/antigravity-rtk-rules.md](cci:7://file:///home/juan-blend/Documents/Blend/rtk/rtk-antigravity-kilo/.agent/rules/antigravity-rtk-rules.md:0:0-0:0)).
- **Maintained Code Style**: Kept the new `init::run` console outputs consistent and free of emojis to strictly follow the project's formatting conventions.

## Test plan
<!-- How did you verify this works? -->

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected (Successfully tested `rtk gain`, `rtk git status` locally to ensure the new settings inject and reduce token usage without issues).
