### PR TITLE
fix(cicd): use dev- prefix for pre-release tags

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -68,7 +68,7 @@ jobs:
             fi
           fi
           VERSION="${MAJOR}.${MINOR}.${PATCH}"
-          TAG="v${VERSION}-rc.${{ github.run_number }}"
+          TAG="dev-${VERSION}-rc.${{ github.run_number }}"
 
           echo "Next version: $VERSION (from $LATEST_VERSION)"
           echo "Pre-release tag: $TAG"


### PR DESCRIPTION
## Summary

- Pre-release tags on develop used `v*` prefix (e.g. `v0.33.1-rc.60`) which release-please interpreted as the latest version
- This caused release-please to generate wrong versions like `0.33.2-rc.60` instead of `0.33.1`
- Changed prefix to `dev-` (e.g. `dev-0.34.0-rc.61`) so release-please only sees stable `v*` tags
- Cleaned up: 42 RC releases and tags deleted from GitHub

## Test plan

- [ ] Push to develop triggers pre-release with `dev-` prefix tag
- [ ] Push to master triggers release-please with correct version from `v0.33.0`