### PR TITLE
fix(config): add serde(default) to TeeConfig fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+* **config:** add `serde(default)` to `TeeConfig` fields to prevent silent parse failure when `[tee]` section is partially specified ([#843](https://github.com/rtk-ai/rtk/pull/843)) ([08068447](https://github.com/rtk-ai/rtk/commit/08068447))
 * **diff:** correct truncation overflow count in condense_unified_diff ([#833](https://github.com/rtk-ai/rtk/pull/833)) ([5399f83](https://github.com/rtk-ai/rtk/commit/5399f83))
 * **git:** replace vague truncation markers with exact counts in log and grep output ([#833](https://github.com/rtk-ai/rtk/pull/833)) ([185fb97](https://github.com/rtk-ai/rtk/commit/185fb97))
 

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -72,6 +72,7 @@ emoji = true
 max_width = 120
 
 [tee]
+# All fields are optional — omitting any field uses its default value.
 enabled = true
 mode = "failures"  # failures | always | never
 max_files = 20

--- a/src/core/tee.rs
+++ b/src/core/tee.rs
@@ -194,14 +194,33 @@ pub enum TeeMode {
 }
 
 /// Configuration for the tee feature.
+///
+/// All fields have `serde(default)` so that users can specify a partial `[tee]`
+/// section in config.toml without triggering a parse error for missing fields.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TeeConfig {
+    #[serde(default = "default_enabled")]
     pub enabled: bool,
+    #[serde(default)]
     pub mode: TeeMode,
+    #[serde(default = "default_max_files")]
     pub max_files: usize,
+    #[serde(default = "default_max_file_size")]
     pub max_file_size: usize,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub directory: Option<PathBuf>,
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+fn default_max_files() -> usize {
+    DEFAULT_MAX_FILES
+}
+
+fn default_max_file_size() -> usize {
+    DEFAULT_MAX_FILE_SIZE
 }
 
 impl Default for TeeConfig {
@@ -385,6 +404,34 @@ directory = "/tmp/rtk-tee"
         let deserialized: TeeConfig = toml::from_str(&serialized).unwrap();
         assert_eq!(deserialized.mode, TeeMode::Always);
         assert_eq!(deserialized.max_files, 10);
+    }
+
+    #[test]
+    fn test_tee_config_partial_deserialize() {
+        // Users may specify only some fields in [tee]; missing fields must use defaults.
+        // Before this fix, omitting max_file_size caused the entire config to fail.
+        let toml_str = r#"
+enabled = true
+mode = "failures"
+max_files = 20
+"#;
+        let config: TeeConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.mode, TeeMode::Failures);
+        assert_eq!(config.max_files, 20);
+        assert_eq!(config.max_file_size, DEFAULT_MAX_FILE_SIZE);
+        assert!(config.directory.is_none());
+    }
+
+    #[test]
+    fn test_tee_config_empty_deserialize() {
+        // A completely empty [tee] section should also work with all defaults.
+        let config: TeeConfig = toml::from_str("").unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.mode, TeeMode::Failures);
+        assert_eq!(config.max_files, DEFAULT_MAX_FILES);
+        assert_eq!(config.max_file_size, DEFAULT_MAX_FILE_SIZE);
+        assert!(config.directory.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `TeeConfig` fields lack `#[serde(default)]`, causing the entire `Config` deserialization to fail when users specify a `[tee]` section in `config.toml` but omit some fields (e.g. `max_file_size`)
- Since call sites use `Config::load().map(...).unwrap_or_default()` to silently handle errors, all user settings (including `hooks.exclude_commands`) are silently ignored with no warning
- Add `#[serde(default = "...")]` to every `TeeConfig` field so partial `[tee]` sections deserialize correctly
- Add tests for partial and empty deserialization

## Reproduction

```toml
# ~/.config/rtk/config.toml (Linux) or ~/Library/Application Support/rtk/config.toml (macOS)
[hooks]
exclude_commands = ["curl", "helm"]

[tee]
enabled = true
mode = "failures"
max_files = 20
# max_file_size is omitted — this causes the ENTIRE config to fail silently
```

```bash
$ rtk config
Config: ~/Library/Application Support/rtk/config.toml

Error: TOML parse error at line 35, column 1
   |
35 | [tee]
   | ^^^^^
missing field `max_file_size`
```

When `rtk config` is not called directly, `Config::load()` fails silently and falls back to defaults — all user settings are ignored without any warning.

## Test plan

- [x] `cargo fmt --all --check` — passed
- [x] `cargo clippy --all-targets` — no new warnings
- [x] `cargo test --all` — 1116 passed, 3 ignored
- [x] New `test_tee_config_partial_deserialize` — verifies omitting `max_file_size` does not fail
- [x] New `test_tee_config_empty_deserialize` — verifies a completely empty `[tee]` section uses defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)