### PR TITLE
fix(rewrite): skip cat rewrite when incompatible flags present

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -615,6 +615,16 @@ fn rewrite_segment(seg: &str, excluded: &[String]) -> Option<String> {
         return rewrite_tail_lines(cmd_part).map(|r| format!("{}{}", r, redirect_suffix));
     }
 
+    // Most cat flags (-v, -A, -e, -t, -s, -b, --show-all, etc.) have different
+    // semantics than rtk read or no equivalent at all. Only `-n` (line numbers)
+    // maps correctly to `rtk read -n`. Skip rewrite for any other flag.
+    if cmd_part.starts_with("cat ") {
+        let args = cmd_part["cat ".len()..].trim_start();
+        if args.starts_with('-') && !args.starts_with("-n ") && !args.starts_with("-n\t") {
+            return None;
+        }
+    }
+
     // Use classify_command for correct ignore/prefix handling
     let rtk_equivalent = match classify_command(cmd_part) {
         Classification::Supported { rtk_equivalent, .. } => {
@@ -1162,6 +1172,26 @@ mod tests {
         assert_eq!(
             rewrite_command("cat src/main.rs", &[]),
             Some("rtk read src/main.rs".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_cat_with_incompatible_flags_skipped() {
+        // cat flags with different semantics than rtk read — skip rewrite
+        assert_eq!(rewrite_command("cat -A file.cpp", &[]), None);
+        assert_eq!(rewrite_command("cat -v file.txt", &[]), None);
+        assert_eq!(rewrite_command("cat -e file.txt", &[]), None);
+        assert_eq!(rewrite_command("cat -t file.txt", &[]), None);
+        assert_eq!(rewrite_command("cat -s file.txt", &[]), None);
+        assert_eq!(rewrite_command("cat --show-all file.txt", &[]), None);
+    }
+
+    #[test]
+    fn test_rewrite_cat_with_compatible_flags() {
+        // cat -n (line numbers) maps to rtk read -n — allow rewrite
+        assert_eq!(
+            rewrite_command("cat -n file.txt", &[]),
+            Some("rtk read -n file.txt".into())
         );
     }
 


### PR DESCRIPTION
## Summary

- Skip `cat` → `rtk read` rewrite when cat is invoked with flags that have different semantics than `rtk read` (e.g. `-A`, `-v`, `-e`, `-t`, `-s`, `--show-all`)
- Allow rewrite for `cat -n` since it maps correctly to `rtk read -n` (both mean line numbers)
- Plain `cat file` continues to rewrite to `rtk read file` as before

## Problem

`rtk rewrite` blindly forwards all cat flags to `rtk read`. This causes incorrect behavior because the flags have different semantics:

| Flag | `cat` meaning | `rtk read` meaning |
|------|--------------|-------------------|
| `-n` | Line numbers | Line numbers (compatible) |
| `-v` | Show non-printing chars | Verbosity level (incompatible) |
| `-A` | Show all (non-printing + endings) | Not supported (fails) |
| `-e` | Show non-printing + `$` at EOL | Not supported |
| `-t` | Show non-printing + tabs as `^I` | Not supported |
| `-s` | Squeeze blank lines | Not supported |

For example, `cat -A file.cpp` was rewritten to `rtk read -A file.cpp` which fails with `rtk: Failed to resolve 'read' via PATH`.

## Fix

Early check in `rewrite_segment()`: if the command starts with `cat ` and the first argument starts with `-` (but is not `-n`), return `None` to skip the rewrite. This follows the same pattern used for `head -N` and `tail` special cases.

## Test plan

- [x] New test `test_rewrite_cat_with_incompatible_flags_skipped` — verifies `-A`, `-v`, `-e`, `-t`, `-s`, `--show-all` all return `None`
- [x] New test `test_rewrite_cat_with_compatible_flags` — verifies `cat -n file.txt` rewrites to `rtk read -n file.txt`
- [x] Existing `test_rewrite_cat_file` still passes — plain `cat file` → `rtk read file`
- [x] Full test suite: 1119 passed, 3 ignored