### PR TITLE
fix(runner): propagate exit code from rtk err and rtk test

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -59,6 +59,9 @@ pub fn run_err(command: &str, verbose: u8) -> Result<()> {
         println!("{}", rtk);
     }
     timer.track(command, "rtk run-err", &raw, &rtk);
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
     Ok(())
 }
 
@@ -100,6 +103,9 @@ pub fn run_test(command: &str, verbose: u8) -> Result<()> {
         println!("{}", summary);
     }
     timer.track(command, "rtk run-test", &raw, &summary);
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Fixes #846

  ## Summary

  - `run_err()` and `run_test()` in `src/runner.rs` captured `exit_code` but always returned `Ok(())` — callers
  and the shell always saw exit 0
  - After `timer.track()`, call `std::process::exit(exit_code)` when `exit_code != 0` to propagate the child
  process exit status

  ## Test plan

  - [x] `rtk err false` now returns exit 1 (was 0)
  - [x] `rtk err true` still returns exit 0
  - [x] `rtk test 'cargo test'` propagates test failures
  - [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test`
  - [ ] Rebase on `develop` after #826 refactor

  > **Important:** All PRs must target the `develop` branch (not `master`).