### PR TITLE
fix(hook): rewrite wc commands to rtk wc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+* **wc:** `wc` filter was never invoked by the hook — removed `"wc "` from `IGNORED_PREFIXES` and added registry entry so `wc` commands are rewritten to `rtk wc`
 * **diff:** correct truncation overflow count in condense_unified_diff ([#833](https://github.com/rtk-ai/rtk/pull/833)) ([5399f83](https://github.com/rtk-ai/rtk/commit/5399f83))
 * **git:** replace vague truncation markers with exact counts in log and grep output ([#833](https://github.com/rtk-ai/rtk/pull/833)) ([185fb97](https://github.com/rtk-ai/rtk/commit/185fb97))
 

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -2348,4 +2348,50 @@ mod tests {
         assert_eq!(strip_git_global_opts("git status"), "git status");
         assert_eq!(strip_git_global_opts("cargo test"), "cargo test");
     }
+
+    // --- #wc: wc filter was silently ignored by the hook ---
+
+    #[test]
+    fn test_classify_wc_supported() {
+        // BUG: "wc " was in IGNORED_PREFIXES despite wc_cmd.rs having a full filter.
+        // This test documents the bug: it must FAIL before the fix and PASS after.
+        assert_eq!(
+            classify_command("wc -l src/main.rs"),
+            Classification::Supported {
+                rtk_equivalent: "rtk wc",
+                category: "Files",
+                estimated_savings_pct: 60.0,
+                status: RtkStatus::Existing,
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_wc_multi_file() {
+        assert_eq!(
+            classify_command("wc src/*.rs"),
+            Classification::Supported {
+                rtk_equivalent: "rtk wc",
+                category: "Files",
+                estimated_savings_pct: 60.0,
+                status: RtkStatus::Existing,
+            }
+        );
+    }
+
+    #[test]
+    fn test_rewrite_wc() {
+        assert_eq!(
+            rewrite_command("wc -l src/main.rs", &[]),
+            Some("rtk wc -l src/main.rs".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_wc_multi_file() {
+        assert_eq!(
+            rewrite_command("wc src/*.rs", &[]),
+            Some("rtk wc src/*.rs".into())
+        );
+    }
 }

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -88,6 +88,7 @@ pub const PATTERNS: &[&str] = &[
     r"^trunk\s+build",
     r"^uv\s+(sync|pip\s+install)\b",
     r"^yamllint\b",
+    r"^wc(\s|$)",
 ];
 
 pub const RULES: &[RtkRule] = &[
@@ -653,6 +654,14 @@ pub const RULES: &[RtkRule] = &[
         subcmd_savings: &[],
         subcmd_status: &[],
     },
+    RtkRule {
+        rtk_cmd: "rtk wc",
+        rewrite_prefixes: &["wc"],
+        category: "Files",
+        savings_pct: 60.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
 ];
 
 /// Commands to ignore (shell builtins, trivial, already rtk).
@@ -681,7 +690,6 @@ pub const IGNORED_PREFIXES: &[&str] = &[
     "kill ",
     "set ",
     "unset ",
-    "wc ",
     "sort ",
     "uniq ",
     "tr ",


### PR DESCRIPTION
## Summary

- rewrite `wc` commands through the hook by removing `"wc "` from `IGNORED_PREFIXES`
- add `wc` to the discover/rewrite registry so `wc ...` becomes `rtk wc ...`
- cover the regression with classification and rewrite tests, and document it in the changelog

## Test plan

- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected
- [x] `cargo fmt --all --check`
- [x] `cargo test test_classify_wc_supported -- --nocapture`
- [x] `cargo test test_rewrite_wc -- --nocapture`
- [x] Manual hook test (Copilot VS Code payload): `wc -l src/main.rs` rewrites to `rtk wc -l src/main.rs`
- [x] Manual hook test (Gemini payload): `wc -l src/main.rs` rewrites to `rtk wc -l src/main.rs`
- [x] Manual output check: `wc -l src/main.rs` -> `2643 src/main.rs`, `rtk wc -l src/main.rs` -> `2643`

Clippy currently fails on pre-existing unrelated warnings in `src/gh_cmd.rs` and `src/git.rs` on this branch baseline, so the full `cargo fmt --all && cargo clippy --all-targets && cargo test` box is left unchecked.
