### PR TITLE
feat(discover): track passthrough git/cargo/pnpm subcommands

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -173,10 +173,17 @@ pub fn classify_command(cmd: &str) -> Classification {
             (rule.savings_pct, super::report::RtkStatus::Existing)
         };
 
+        // Passthrough commands have 0% savings (no filtering)
+        let final_savings = if status == super::report::RtkStatus::Passthrough {
+            0.0
+        } else {
+            savings
+        };
+
         Classification::Supported {
             rtk_equivalent: rule.rtk_cmd,
             category: rule.category,
-            estimated_savings_pct: savings,
+            estimated_savings_pct: final_savings,
             status,
         }
     } else {
@@ -919,7 +926,98 @@ mod tests {
             Classification::Supported {
                 rtk_equivalent: "rtk cargo",
                 category: "Cargo",
-                estimated_savings_pct: 80.0,
+                estimated_savings_pct: 0.0,
+                status: RtkStatus::Passthrough,
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_cargo_run_passthrough() {
+        assert_eq!(
+            classify_command("cargo run"),
+            Classification::Supported {
+                rtk_equivalent: "rtk cargo",
+                category: "Cargo",
+                estimated_savings_pct: 0.0,
+                status: RtkStatus::Passthrough,
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_cargo_publish_passthrough() {
+        assert_eq!(
+            classify_command("cargo publish"),
+            Classification::Supported {
+                rtk_equivalent: "rtk cargo",
+                category: "Cargo",
+                estimated_savings_pct: 0.0,
+                status: RtkStatus::Passthrough,
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_git_checkout_passthrough() {
+        assert_eq!(
+            classify_command("git checkout main"),
+            Classification::Supported {
+                rtk_equivalent: "rtk git",
+                category: "Git",
+                estimated_savings_pct: 0.0,
+                status: RtkStatus::Passthrough,
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_git_merge_passthrough() {
+        assert_eq!(
+            classify_command("git merge feature-branch"),
+            Classification::Supported {
+                rtk_equivalent: "rtk git",
+                category: "Git",
+                estimated_savings_pct: 0.0,
+                status: RtkStatus::Passthrough,
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_git_rebase_passthrough() {
+        assert_eq!(
+            classify_command("git rebase origin/main"),
+            Classification::Supported {
+                rtk_equivalent: "rtk git",
+                category: "Git",
+                estimated_savings_pct: 0.0,
+                status: RtkStatus::Passthrough,
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_pnpm_build_passthrough() {
+        assert_eq!(
+            classify_command("pnpm build"),
+            Classification::Supported {
+                rtk_equivalent: "rtk pnpm",
+                category: "PackageManager",
+                estimated_savings_pct: 0.0,
+                status: RtkStatus::Passthrough,
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_pnpm_exec_passthrough() {
+        assert_eq!(
+            classify_command("pnpm exec playwright test"),
+            Classification::Supported {
+                rtk_equivalent: "rtk pnpm",
+                category: "PackageManager",
+                estimated_savings_pct: 0.0,
                 status: RtkStatus::Passthrough,
             }
         );
@@ -940,9 +1038,9 @@ mod tests {
 
     #[test]
     fn test_registry_covers_all_cargo_subcommands() {
-        // Verify that every CargoCommand variant (Build, Test, Clippy, Check, Fmt)
+        // Verify that every CargoCommand variant (Build, Test, Clippy, Check, Fmt, Run, Publish)
         // except Other has a matching pattern in the registry
-        for subcmd in ["build", "test", "clippy", "check", "fmt"] {
+        for subcmd in ["build", "test", "clippy", "check", "fmt", "run", "publish"] {
             let cmd = format!("cargo {subcmd}");
             match classify_command(&cmd) {
                 Classification::Supported { .. } => {}
@@ -956,7 +1054,7 @@ mod tests {
         // Verify that every GitCommand subcommand has a matching pattern
         for subcmd in [
             "status", "log", "diff", "show", "add", "commit", "push", "pull", "branch", "fetch",
-            "stash", "worktree",
+            "stash", "worktree", "checkout", "merge", "rebase",
         ] {
             let cmd = format!("git {subcmd}");
             match classify_command(&cmd) {
@@ -1118,6 +1216,30 @@ mod tests {
         assert_eq!(
             rewrite_command("cargo test", &[]),
             Some("rtk cargo test".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_cargo_publish() {
+        assert_eq!(
+            rewrite_command("cargo publish", &[]),
+            Some("rtk cargo publish".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_git_rebase() {
+        assert_eq!(
+            rewrite_command("git rebase origin/main", &[]),
+            Some("rtk git rebase origin/main".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_pnpm_exec() {
+        assert_eq!(
+            rewrite_command("pnpm exec playwright test", &[]),
+            Some("rtk pnpm exec playwright test".into())
         );
     }
 

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -12,7 +12,7 @@ pub struct RtkRule {
 
 pub const RULES: &[RtkRule] = &[
     RtkRule {
-        pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|push|pull|branch|fetch|stash|worktree)",
+        pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|push|pull|branch|fetch|stash|worktree|checkout|merge|rebase)",
         rtk_cmd: "rtk git",
         rewrite_prefixes: &["git", "yadm"],
         category: "Git",
@@ -23,7 +23,11 @@ pub const RULES: &[RtkRule] = &[
             ("add", 59.0),
             ("commit", 59.0),
         ],
-        subcmd_status: &[],
+        subcmd_status: &[
+            ("checkout", RtkStatus::Passthrough),
+            ("merge", RtkStatus::Passthrough),
+            ("rebase", RtkStatus::Passthrough),
+        ],
     },
     RtkRule {
         pattern: r"^gh\s+(pr|issue|run|repo|api|release)",
@@ -35,22 +39,29 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        pattern: r"^cargo\s+(build|test|clippy|check|fmt|install)",
+        pattern: r"^cargo\s+(build|test|clippy|check|fmt|install|run|publish)",
         rtk_cmd: "rtk cargo",
         rewrite_prefixes: &["cargo"],
         category: "Cargo",
         savings_pct: 80.0,
         subcmd_savings: &[("test", 90.0), ("check", 80.0)],
-        subcmd_status: &[("fmt", RtkStatus::Passthrough)],
+        subcmd_status: &[
+            ("fmt", RtkStatus::Passthrough),
+            ("run", RtkStatus::Passthrough),
+            ("publish", RtkStatus::Passthrough),
+        ],
     },
     RtkRule {
-        pattern: r"^pnpm\s+(list|ls|outdated|install)",
+        pattern: r"^pnpm\s+(list|ls|outdated|install|build|exec)",
         rtk_cmd: "rtk pnpm",
         rewrite_prefixes: &["pnpm"],
         category: "PackageManager",
         savings_pct: 80.0,
         subcmd_savings: &[],
-        subcmd_status: &[],
+        subcmd_status: &[
+            ("build", RtkStatus::Passthrough),
+            ("exec", RtkStatus::Passthrough),
+        ],
     },
     RtkRule {
         pattern: r"^npm\s+(run|exec)",


### PR DESCRIPTION
## Summary

`rtk discover --all` reports `git checkout`, `git merge`, `git rebase`, `pnpm build`, `pnpm exec`, `cargo run`, and `cargo publish` as **TOP UNHANDLED COMMANDS** — even though they already work via passthrough handlers (`GitCommands::Other`, `CargoCommands::Other`, `PnpmCommands::Other`).

The discover regex patterns in `src/discover/rules.rs` didn't include these subcommands, so they appeared unhandled instead of "already tracked, passthrough mode".

## Changes

- `src/discover/rules.rs`: add `checkout|merge|rebase` to git pattern, `run|publish` to cargo pattern, `build|exec` to pnpm pattern. Mark each as `RtkStatus::Passthrough` in `subcmd_status`.
- `src/discover/registry.rs`: update existing coverage tests + 11 new tests (7 classify + 4 rewrite end-to-end).
- `CLAUDE.md`: cherry-pick supported ecosystems line from `feature/help-reorganize` to fix pre-push validation.

## Impact

1277 commands correctly classified in discover output. Zero filtering changes, zero performance impact.

| Subcommands | Occurrences |
|---|---|
| git checkout / merge / rebase | 784 |
| pnpm build / exec | 344 |
| cargo run / publish | 149 |

Closes #888

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets` — 0 errors, 2 pre-existing warnings
- [x] `cargo test --all` — 1134 passed, 3 ignored
- [x] `rtk rewrite "git checkout main"` → `rtk git checkout main` ✓
- [x] `rtk rewrite "cargo run -- verify"` → `rtk cargo run -- verify` ✓
- [x] `rtk rewrite "pnpm build"` → `rtk pnpm build` ✓
- [x] `bash scripts/validate-docs.sh` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)