### PR TITLE
fix(json): rename --schema to --keys-only, closes #621

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,8 +75,6 @@ For the full architecture, component details, and module development patterns, s
 
 Module responsibilities are documented in each folder's `README.md` and each file's `//!` doc header. Browse `src/cmds/*/` to discover available filters.
 
-Supported ecosystems: git/gh/gt, cargo, go/golangci-lint, npm/pnpm/npx, ruff/pytest/pip/mypy, rspec/rubocop/rake, dotnet, playwright/vitest/jest, docker/kubectl/aws.
-
 ### Proxy Mode
 
 **Purpose**: Execute commands without filtering but track usage for metrics.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,8 @@ For the full architecture, component details, and module development patterns, s
 
 Module responsibilities are documented in each folder's `README.md` and each file's `//!` doc header. Browse `src/cmds/*/` to discover available filters.
 
+Supported ecosystems: git/gh/gt, cargo, go/golangci-lint, npm/pnpm/npx, ruff/pytest/pip/mypy, rspec/rubocop/rake, dotnet, playwright/vitest/jest, docker/kubectl/aws.
+
 ### Proxy Mode
 
 **Purpose**: Execute commands without filtering but track usage for metrics.

--- a/src/cmds/system/json_cmd.rs
+++ b/src/cmds/system/json_cmd.rs
@@ -35,7 +35,7 @@ fn validate_json_extension(file: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Show JSON (compact with values, or schema-only with --schema)
+/// Show JSON (compact with values by default, or keys-only with --keys-only)
 pub fn run(file: &Path, max_depth: usize, schema_only: bool, verbose: u8) -> Result<()> {
     validate_json_extension(file)?;
     let timer = tracking::TimedExecution::start();

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,16 +195,16 @@ enum Commands {
         command: Vec<String>,
     },
 
-    /// Show JSON (compact values, or schema-only with --schema)
+    /// Show JSON (compact values by default, or keys-only with --keys-only)
     Json {
         /// JSON file
         file: PathBuf,
         /// Max depth
         #[arg(short, long, default_value = "5")]
         depth: usize,
-        /// Show structure only (strip all values)
+        /// Show keys only (strip all values, show structure)
         #[arg(long)]
-        schema: bool,
+        keys_only: bool,
     },
 
     /// Summarize project dependencies
@@ -1494,12 +1494,12 @@ fn main() -> Result<()> {
         Commands::Json {
             file,
             depth,
-            schema,
+            keys_only,
         } => {
             if file == Path::new("-") {
-                json_cmd::run_stdin(depth, schema, cli.verbose)?;
+                json_cmd::run_stdin(depth, keys_only, cli.verbose)?;
             } else {
-                json_cmd::run(&file, depth, schema, cli.verbose)?;
+                json_cmd::run(&file, depth, keys_only, cli.verbose)?;
             }
         }
 


### PR DESCRIPTION
## Summary

- Renames `rtk json --schema` to `rtk json --keys-only`
- Values are preserved by default (already the behavior) — this makes the opt-in explicit
- Internal `schema_only` parameter name is unchanged (private API)

## Context

Closes #621. The three signal truncation problems in that issue:

1. `git diff` max hunk lines — already raised to 100 on develop (prior commits)
2. `git log` body lines — already at 3 non-empty lines on develop (prior commits)
3. `json` values default — already preserved in `filter_json_compact()` (prior commits), but the opt-in flag was named `--schema` instead of `--keys-only`

This PR addresses item 3: the flag name. `--keys-only` is clearer than `--schema` because it names what the flag *does* (shows only keys) rather than what mode it enables.

## Before / After

```bash
# Before
rtk json config.json --schema  # keys only

# After
rtk json config.json --keys-only  # keys only (same behavior, better name)
rtk json config.json               # values preserved (unchanged default)
```

## Test plan

- [x] 1123 tests pass (`cargo test --all`)
- [x] `cargo clippy --all-targets` — 0 warnings
- [x] `rtk json --help` shows `--keys-only` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)