### PR TITLE
feat(rewrite): consult user TOML filters as fallback

### DIFF
--- a/src/hooks/rewrite_cmd.rs
+++ b/src/hooks/rewrite_cmd.rs
@@ -1,6 +1,7 @@
 //! Translates a raw shell command into its RTK-optimized equivalent.
 
 use super::permissions::{check_command, PermissionVerdict};
+use crate::core::toml_filter;
 use crate::discover::registry;
 use std::io::Write;
 
@@ -42,8 +43,24 @@ pub fn run(cmd: &str) -> anyhow::Result<()> {
             PermissionVerdict::Deny => unreachable!(),
         },
         None => {
-            // No RTK equivalent. Exit 1 = passthrough.
-            // Claude Code independently evaluates its own ask rules on the original cmd.
+            // Fallback: check user TOML filters (project-local and global).
+            if toml_filter::find_matching_filter(cmd).is_some() {
+                let rewritten = format!("rtk {}", cmd);
+                match verdict {
+                    PermissionVerdict::Allow => {
+                        print!("{}", rewritten);
+                        let _ = std::io::stdout().flush();
+                        return Ok(());
+                    }
+                    PermissionVerdict::Ask | PermissionVerdict::Default => {
+                        print!("{}", rewritten);
+                        let _ = std::io::stdout().flush();
+                        std::process::exit(3);
+                    }
+                    PermissionVerdict::Deny => unreachable!(),
+                }
+            }
+            // No RTK equivalent (built-in or TOML). Exit 1 = passthrough.
             std::process::exit(1);
         }
     }
@@ -69,6 +86,28 @@ mod tests {
             registry::rewrite_command("rtk git status", &[]),
             Some("rtk git status".into())
         );
+    }
+
+    #[test]
+    fn test_toml_only_command_has_filter() {
+        // ssh has a built-in TOML filter but no Rust registry entry
+        assert!(registry::rewrite_command("ssh root@host ls", &[]).is_none());
+        assert!(toml_filter::find_matching_filter("ssh root@host ls").is_some());
+    }
+
+    #[test]
+    fn test_no_filter_anywhere() {
+        // htop has neither a Rust registry entry nor a TOML filter
+        assert!(registry::rewrite_command("htop", &[]).is_none());
+        assert!(toml_filter::find_matching_filter("htop").is_none());
+    }
+
+    #[test]
+    fn test_registry_takes_priority_over_toml() {
+        // git has both a Rust registry entry and TOML filters;
+        // registry::rewrite_command returns Some, so the TOML fallback
+        // is never reached in the run() function.
+        assert!(registry::rewrite_command("git status", &[]).is_some());
     }
 
     /// SECURITY: Verify the exit code protocol for permission verdicts.


### PR DESCRIPTION
## Summary

- `rtk rewrite` now checks user TOML filters when no built-in Rust handler matches
- Commands with TOML-only filters (e.g. `ssh`, `jq`, `just`) get rewritten to `rtk <cmd>` so the hook routes them through the TOML filter engine
- Built-in Rust registry retains priority over TOML filters

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test --all` (1131 passed)
- [x] New tests: TOML-only command matched, no filter returns None, registry priority preserved

## What changed

In `src/hooks/rewrite_cmd.rs`, the `None` branch of `registry::rewrite_command()` now calls `toml_filter::find_matching_filter(cmd)` before exiting with code 1. If a TOML filter matches, the command is rewritten as `rtk <cmd>` and printed to stdout with the same permission verdict handling as built-in commands.

Three new unit tests verify:
- `ssh root@host ls` (TOML-only) is matched by `find_matching_filter` but not by `rewrite_command`
- `htop` has neither registry nor TOML match
- `git status` (registry command) is handled by the registry, never reaching the TOML fallback

This contribution was developed with AI assistance (Claude Code).

Fixes #820