### PR TITLE
feat(utils): add package_manager_filtered_exec helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **diff:** correct truncation overflow count in condense_unified_diff ([#833](https://github.com/rtk-ai/rtk/pull/833)) ([5399f83](https://github.com/rtk-ai/rtk/commit/5399f83))
 * **git:** replace vague truncation markers with exact counts in log and grep output ([#833](https://github.com/rtk-ai/rtk/pull/833)) ([185fb97](https://github.com/rtk-ai/rtk/commit/185fb97))
 
+### Features
+
+* **utils:** add `package_manager_filtered_exec()` helper for pnpm workspace execution ([#515](https://github.com/rtk-ai/rtk/issues/515))
+
 ## [0.33.1](https://github.com/rtk-ai/rtk/compare/v0.33.0...v0.33.1) (2026-03-25)
 
 

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -306,6 +306,27 @@ pub fn package_manager_exec(tool: &str) -> Command {
     }
 }
 
+/// Build a Command using `pnpm --filter <workspace> exec -- <tool>`, or
+/// fallback to `package_manager_exec()` when no workspace filter is provided.
+///
+/// When `pnpm_filter` is set, this always uses `pnpm` because workspace
+/// scoping is only supported through pnpm's filter flags.
+#[allow(dead_code)]
+pub fn package_manager_filtered_exec(tool: &str, pnpm_filter: Option<&str>) -> Command {
+    match pnpm_filter {
+        Some(workspace) => {
+            let mut c = resolved_command("pnpm");
+            c.arg("--filter")
+                .arg(workspace)
+                .arg("exec")
+                .arg("--")
+                .arg(tool);
+            c
+        }
+        None => package_manager_exec(tool),
+    }
+}
+
 /// Resolve a binary name to its full path, honoring PATHEXT on Windows.
 ///
 /// On Windows, Node.js tools are installed as `.CMD`/`.BAT`/`.PS1` shims.
@@ -616,6 +637,56 @@ mod tests {
             !tool_exists("nonexistent_binary_xyz_99999"),
             "tool_exists should return false for nonexistent binary"
         );
+    }
+
+    // ===== package_manager_filtered_exec tests (#515) =====
+
+    #[test]
+    fn test_package_manager_filtered_exec_uses_pnpm_when_filter_is_set() {
+        let cmd = package_manager_filtered_exec("prettier", Some("web"));
+        let program = cmd.get_program().to_string_lossy().to_lowercase();
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|arg| arg.to_string_lossy().to_string())
+            .collect();
+
+        assert!(
+            program.contains("pnpm"),
+            "expected pnpm executable, got: {program}"
+        );
+        assert_eq!(args, vec!["--filter", "web", "exec", "--", "prettier"]);
+    }
+
+    #[test]
+    fn test_package_manager_filtered_exec_supports_scoped_workspace() {
+        let cmd = package_manager_filtered_exec("vitest", Some("@scope/pkg"));
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|arg| arg.to_string_lossy().to_string())
+            .collect();
+        assert_eq!(args, vec!["--filter", "@scope/pkg", "exec", "--", "vitest"]);
+    }
+
+    #[test]
+    fn test_package_manager_filtered_exec_none_falls_back_to_package_manager_exec() {
+        let tool = "nonexistent_binary_xyz_99999";
+        let cmd = package_manager_filtered_exec(tool, None);
+
+        let program = cmd.get_program().to_string_lossy().to_lowercase();
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|arg| arg.to_string_lossy().to_string())
+            .collect();
+
+        if program.contains("pnpm") || program.contains("yarn") {
+            assert_eq!(args, vec!["exec", "--", tool]);
+        } else {
+            assert!(
+                program.contains("npx"),
+                "expected npx/pnpm/yarn executable, got: {program}"
+            );
+            assert_eq!(args, vec!["--no-install", "--", tool]);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Description
Adds a utility helper for pnpm workspace-scoped execution so follow-up pnpm filter support can build on a shared command-construction path.

## Related Issue
Closes #515

## Changes Made
- Added `package_manager_filtered_exec(tool, pnpm_filter)` in `src/core/utils.rs`
- Implemented pnpm-filter path: `pnpm --filter <workspace> exec -- <tool>`
- Kept default behavior unchanged by falling back to `package_manager_exec()` when no filter is provided
- Added unit tests for filter mode, scoped workspace values, and fallback behavior
- Updated `CHANGELOG.md` under Unreleased Features

## Files Changed
- `src/core/utils.rs` - new helper + tests
- `CHANGELOG.md` - unreleased feature entry

## Testing
- [x] `rtk cargo fmt --all`
- [x] `rtk cargo clippy --all-targets`
- [x] `rtk cargo test --all`

@pszymkowiak could you please review when convenient?