### PR TITLE
fix: propagate exit code from `rtk err` and `rtk test`

### DIFF
--- a/src/cmds/rust/runner.rs
+++ b/src/cmds/rust/runner.rs
@@ -61,6 +61,11 @@ pub fn run_err(command: &str, verbose: u8) -> Result<()> {
         println!("{}", rtk);
     }
     timer.track(command, "rtk run-err", &raw, &rtk);
+
+    if !output.status.success() {
+        std::process::exit(exit_code);
+    }
+
     Ok(())
 }
 
@@ -102,6 +107,11 @@ pub fn run_test(command: &str, verbose: u8) -> Result<()> {
         println!("{}", summary);
     }
     timer.track(command, "rtk run-test", &raw, &summary);
+
+    if !output.status.success() {
+        std::process::exit(exit_code);
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

`rtk err false` returned exit 0 even though `false` returns 1. The error was
detected and printed, but the process always exited successfully.

Same issue in `run_test`.

## Fix

Both `run_err` and `run_test` now call `std::process::exit(exit_code)` when
the child process fails, consistent with how other RTK subcommands propagate
exit codes.

## Before / After

```bash
# Before
rtk err false; echo $?   # 0
# After
rtk err false; echo $?   # 1
```

Closes #846