### PR TITLE
feat(discover): treat yadm commands like git

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -594,6 +594,40 @@ mod tests {
     }
 
     #[test]
+    fn test_classify_yadm_status() {
+        assert_eq!(
+            classify_command("yadm status"),
+            Classification::Supported {
+                rtk_equivalent: "rtk git",
+                category: "Git",
+                estimated_savings_pct: 70.0,
+                status: RtkStatus::Existing,
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_yadm_diff() {
+        assert_eq!(
+            classify_command("yadm diff"),
+            Classification::Supported {
+                rtk_equivalent: "rtk git",
+                category: "Git",
+                estimated_savings_pct: 80.0,
+                status: RtkStatus::Existing,
+            }
+        );
+    }
+
+    #[test]
+    fn test_rewrite_yadm_status() {
+        assert_eq!(
+            rewrite_command("yadm status", &[]),
+            Some("rtk git status".to_string())
+        );
+    }
+
+    #[test]
     fn test_classify_git_diff_cached() {
         assert_eq!(
             classify_command("git diff --cached"),

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -12,9 +12,9 @@ pub struct RtkRule {
 
 pub const RULES: &[RtkRule] = &[
     RtkRule {
-        pattern: r"^git\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|push|pull|branch|fetch|stash|worktree)",
+        pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|push|pull|branch|fetch|stash|worktree)",
         rtk_cmd: "rtk git",
-        rewrite_prefixes: &["git"],
+        rewrite_prefixes: &["git", "yadm"],
         category: "Git",
         savings_pct: 70.0,
         subcmd_savings: &[


### PR DESCRIPTION
## Problem

yadm (`https://yadm.io`) is a dotfile manager that wraps git. Running
`yadm status`, `yadm diff`, etc. produces the same output as the
equivalent git commands, but rtk doesn't recognize them.

## Fix

Extended the git discovery rule to also match `yadm` prefixes:

- `rules.rs`: pattern now matches `^(?:git|yadm)\s+...`, added `"yadm"` to rewrite prefixes
- 3 new tests: classify yadm status, classify yadm diff, rewrite yadm status

After:
```
yadm status  →  rtk git status  (70% savings)
yadm diff    →  rtk git diff    (80% savings)
```

Closes #567