### PR TITLE
ci: enforce test presence on new/modified filter modules

### DIFF
--- a/scripts/check-test-presence.sh
+++ b/scripts/check-test-presence.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# check-test-presence.sh — CI guard: new/modified *_cmd.rs files must have #[cfg(test)]
+# check-test-presence.sh — CI guard: new functions in *_cmd.rs must have test_<fn> coverage
+#
+# For each *_cmd.rs changed in this PR, parses newly added function signatures from the diff
+# and verifies each non-trivial function has a corresponding fn test_<name>[_variant] in the file.
+#
+# A function is skipped if:
+#   - It starts with test_ or _ (already a test or private helper)
+#   - It's an entry point or trait impl (run, run_*, new, default, fmt, clone, ...)
+#   - Its definition only appears inside the #[cfg(test)] block (test-module helpers)
 #
 # Usage:
 #   bash scripts/check-test-presence.sh [BASE_BRANCH]
@@ -9,20 +17,66 @@ set -euo pipefail
 #
 # BASE_BRANCH defaults to origin/develop
 
-if [ "${1:-}" = "--self-test" ]; then
-    # Self-test: create a tempfile without tests and verify the check catches it
-    TMPFILE="src/cmds/system/_rtk_check_self_test_cmd.rs"
-    echo "pub fn run() {}" > "$TMPFILE"
-    trap 'rm -f "$TMPFILE"' EXIT
+# fn_needs_test FNAME — returns 0 if a test is required, 1 if the function can be skipped.
+fn_needs_test() {
+    local name="$1"
+    case "$name" in
+        # Already a test or underscore-prefixed private helper
+        test_* | _*) return 1 ;;
+        # Entry points
+        run | main) return 1 ;;
+        # Constructors and standard trait methods
+        new | default | clone | fmt | drop | eq | hash | cmp | partial_eq | partial_cmp) return 1 ;;
+        # Prefix patterns: run_*, from_*, into_*, serialize*, deserialize*
+        run_* | from_* | into_* | serialize* | deserialize* | size_hint*) return 1 ;;
+    esac
+    return 0
+}
 
-    if grep -q '#\[cfg(test)\]' "$TMPFILE"; then
-        echo "FAIL: self-test broken (false negative)"
-        exit 1
+# fn_is_outside_test_block FILE FNAME — returns 0 if fn is defined before #[cfg(test)].
+# Functions only inside the test block (e.g. count_tokens helper) are skipped.
+fn_is_outside_test_block() {
+    local file="$1"
+    local fn_name="$2"
+    awk '/^#\[cfg\(test\)\]/{exit} {print}' "$file" \
+        | grep -qE "fn[[:space:]]+${fn_name}[[:space:](<]"
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+    ok=true
+
+    # 1. Validate skip list
+    for name in run run_foo run_passthrough main new default from_str from_utf8 \
+                into_string fmt clone hash eq cmp drop test_foo _helper \
+                serialize deserialize; do
+        if fn_needs_test "$name"; then
+            echo "FAIL: '$name' should be skipped but was not"
+            ok=false
+        fi
+    done
+    for name in filter_output compact_url format_size parse_error mask_value \
+                is_cloud_var extract_filename; do
+        if ! fn_needs_test "$name"; then
+            echo "FAIL: '$name' should require a test but was skipped"
+            ok=false
+        fi
+    done
+
+    # 2. Validate function name extraction from a diff line
+    sample='+    pub fn compact_url(url: &str) -> String {'
+    extracted=$(echo "$sample" | sed -E 's/^.*fn[[:space:]]+([a-z_][a-z0-9_]*).*/\1/')
+    if [ "$extracted" = "compact_url" ]; then
+        echo "  OK  extraction: 'pub fn compact_url(...)' -> '$extracted'"
+    else
+        echo "FAIL: extraction got '$extracted', expected 'compact_url'"
+        ok=false
     fi
-    rm "$TMPFILE"
-    trap - EXIT
-    echo "PASS: --self-test detection works correctly"
-    exit 0
+
+    if $ok; then
+        echo "PASS: --self-test all checks passed"
+        exit 0
+    fi
+    exit 1
 fi
 
 BASE_BRANCH="${1:-origin/develop}"
@@ -37,7 +91,8 @@ if [ -z "$CHANGED_FILES" ]; then
     exit 0
 fi
 
-echo "check-test-presence: checking $(echo "$CHANGED_FILES" | wc -l | tr -d ' ') filter module(s)..."
+FILE_COUNT=$(echo "$CHANGED_FILES" | wc -l | tr -d ' ')
+echo "check-test-presence: scanning $FILE_COUNT filter module(s) for untested functions..."
 echo ""
 
 while IFS= read -r file; do
@@ -45,25 +100,48 @@ while IFS= read -r file; do
         continue
     fi
 
-    if grep -q '#\[cfg(test)\]' "$file"; then
-        echo "  PASS  $file"
-    else
-        echo "  FAIL  $file"
-        echo "        Missing #[cfg(test)] module."
-        echo "        Every *_cmd.rs filter must include inline unit tests."
-        echo "        Reference: src/cmds/cloud/aws_cmd.rs"
-        echo ""
-        EXIT_CODE=1
+    # Extract function names added in this diff.
+    # grep 1: ^\+[^+] keeps added lines (single +), skips +++ header lines.
+    # grep 2: matches fn declarations of any visibility or modifier.
+    ADDED_FNS=$(git diff --unified=0 "$BASE_BRANCH"...HEAD -- "$file" 2>/dev/null \
+        | grep -E '^\+[^+]' \
+        | grep -E 'fn[[:space:]]+[a-z_][a-z0-9_]*[[:space:](<]' \
+        | sed -E 's/^.*fn[[:space:]]+([a-z_][a-z0-9_]*).*/\1/' \
+        | sort -u \
+        || true)
+
+    if [ -z "$ADDED_FNS" ]; then
+        echo "  OK  $file  (no new functions)"
+        continue
     fi
+
+    while IFS= read -r fn_name; do
+        # Skip entry points, trait impls, and existing test names
+        if ! fn_needs_test "$fn_name"; then
+            continue
+        fi
+        # Skip test-module helpers (functions only defined inside #[cfg(test)])
+        if ! fn_is_outside_test_block "$file" "$fn_name"; then
+            continue
+        fi
+        if grep -q "fn test_${fn_name}" "$file"; then
+            echo "  PASS  $file::${fn_name}()"
+        else
+            echo "  FAIL  $file::${fn_name}()"
+            echo "        Expected: fn test_${fn_name}[_variant] in $file"
+            EXIT_CODE=1
+        fi
+    done <<< "$ADDED_FNS"
 done <<< "$CHANGED_FILES"
 
 echo ""
 
 if [ "$EXIT_CODE" -ne 0 ]; then
     echo "check-test-presence: FAILED — add tests before merging."
-    echo "See .claude/rules/cli-testing.md for the testing guide."
+    echo "Convention: fn my_func -> fn test_my_func[_variant]"
+    echo "Reference:  .claude/rules/cli-testing.md"
 else
-    echo "check-test-presence: all filter modules have tests — OK"
+    echo "check-test-presence: all new functions have test coverage — OK"
 fi
 
 exit "$EXIT_CODE"


### PR DESCRIPTION
## Summary

- Add `scripts/check-test-presence.sh`: fails CI if a new or modified `*_cmd.rs` file is missing `#[cfg(test)]`. Uses `--diff-filter=AM` to catch both additions and test deletions on existing files.
- New CI job (`check-test-presence`) runs with no dependencies — pure grep, no Rust toolchain, <10s, parallel to all other jobs.
- Add 17 unit tests to `wget_cmd.rs` (compact_url, format_size, parse_error, extract_filename, truncate_line)
- Add 12 unit tests to `env_cmd.rs` (mask_value, is_lang_var, is_cloud_var, is_tool_var, is_interesting_var, sensitive_patterns)
- Fixes enforcement gap: CONTRIBUTING.md required tests but CI did not check. Now 34/34 `*_cmd.rs` modules have `#[cfg(test)]`.

## Test plan
- [ ] `bash scripts/check-test-presence.sh origin/develop` → exit 0
- [ ] `bash scripts/check-test-presence.sh --self-test` → exit 0
- [ ] `cargo test wget` → 17 passed
- [ ] `cargo test env_cmd` → 12 passed
- [ ] `cargo test --all` → all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)