### PR TITLE
feat(gain): add --watch mode for continuous dashboard refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Features
+
+* **gain:** add `--watch` (`-W`) mode for continuous dashboard refresh with configurable `--interval` (`-n`) in seconds
+
 ### Bug Fixes
 
 * **wc:** `wc` filter was never invoked by the hook — removed `"wc "` from `IGNORED_PREFIXES` and added registry entry so `wc` commands are rewritten to `rtk wc`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +172,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -293,6 +308,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +347,18 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -353,7 +391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -757,6 +795,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,6 +814,21 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -910,6 +975,7 @@ dependencies = [
  "chrono",
  "clap",
  "colored",
+ "ctrlc",
  "dirs",
  "flate2",
  "getrandom 0.4.2",
@@ -953,7 +1019,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1144,7 +1210,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1442,7 +1508,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,7 +391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -989,6 +989,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "terminal_size",
  "toml",
  "ureq",
  "walkdir",
@@ -1019,7 +1020,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1210,7 +1211,17 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1508,7 +1519,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ quick-xml = "0.37"
 which = "8"
 automod = "1"
 ctrlc = "3"
+terminal_size = "0.4"
 
 [build-dependencies]
 toml = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ flate2 = "1.0"
 quick-xml = "0.37"
 which = "8"
 automod = "1"
+ctrlc = "3"
 
 [build-dependencies]
 toml = "0.8"

--- a/src/analytics/gain.rs
+++ b/src/analytics/gain.rs
@@ -4,12 +4,14 @@ use crate::core::display_helpers::{format_duration, print_period_table};
 use crate::core::tracking::{DayStats, MonthStats, Tracker, WeekStats};
 use crate::core::utils::format_tokens;
 use crate::hooks::hook_check;
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use chrono::Local;
 use colored::Colorize;
 use serde::Serialize;
-use std::io::IsTerminal;
+use std::io::{IsTerminal, Write};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 #[allow(clippy::too_many_arguments)]
 pub fn run(
@@ -24,10 +26,151 @@ pub fn run(
     all: bool,
     format: &str,
     failures: bool,
+    watch: bool,
+    interval: u64,
     _verbose: u8,
 ) -> Result<()> {
+    if watch && (format == "json" || format == "csv") {
+        bail!("--watch is not compatible with --format {format} (only text format is supported)");
+    }
+
+    if watch && !std::io::stdout().is_terminal() {
+        bail!("--watch requires an interactive terminal (stdout is not a TTY)");
+    }
+
+    if watch {
+        return run_watch_loop(
+            project, graph, history, quota, tier, daily, weekly, monthly, all, failures, interval,
+        );
+    }
+
+    run_once(
+        project, graph, history, quota, tier, daily, weekly, monthly, all, format, failures,
+    )
+}
+
+/// RAII guard that hides the terminal cursor on creation and restores it on drop (including panic).
+struct CursorGuard;
+
+impl CursorGuard {
+    fn new() -> Self {
+        print!("\x1b[?25l");
+        let _ = std::io::stdout().flush();
+        Self
+    }
+}
+
+impl Drop for CursorGuard {
+    fn drop(&mut self) {
+        let _ = write!(std::io::stdout(), "\x1b[?25h");
+        let _ = std::io::stdout().flush();
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_watch_loop(
+    project: bool,
+    graph: bool,
+    history: bool,
+    quota: bool,
+    tier: &str,
+    daily: bool,
+    weekly: bool,
+    monthly: bool,
+    all: bool,
+    failures: bool,
+    interval: u64,
+) -> Result<()> {
+    let running = Arc::new(AtomicBool::new(true));
+    let r = running.clone();
+
+    ctrlc::set_handler(move || {
+        r.store(false, Ordering::SeqCst);
+    })
+    .context("Failed to set Ctrl+C handler")?;
+
+    // Build the command description for the watch header
+    let mut flag_parts: Vec<String> = vec!["rtk gain".into()];
+    for (on, name) in [
+        (project, "--project"),
+        (graph, "--graph"),
+        (history, "--history"),
+        (quota, "--quota"),
+        (daily, "--daily"),
+        (weekly, "--weekly"),
+        (monthly, "--monthly"),
+        (all, "--all"),
+        (failures, "--failures"),
+    ] {
+        if on {
+            flag_parts.push(name.into());
+        }
+    }
+    if quota && tier != "20x" {
+        flag_parts.push(format!("--tier {tier}"));
+    }
+    if interval != 2 {
+        flag_parts.push(format!("-n {interval}"));
+    }
+    let flags = flag_parts.join(" ");
+
     let tracker = Tracker::new().context("Failed to initialize tracking database")?;
-    let project_scope = resolve_project_scope(project)?; // added: resolve project path
+    let project_scope = resolve_project_scope(project)?;
+    let _cursor_guard = CursorGuard::new();
+
+    while running.load(Ordering::SeqCst) {
+        print!("\x1b[H");
+        let _ = std::io::stdout().flush();
+
+        let now = Local::now().format("%Y-%m-%d %H:%M:%S");
+        println!("Every {}s: {:<40} {}", interval, flags, now);
+        println!();
+
+        // Ignore display errors in watch mode (DB might be temporarily locked)
+        let _ = run_display(
+            &tracker,
+            project_scope.as_deref(),
+            graph,
+            history,
+            quota,
+            tier,
+            daily,
+            weekly,
+            monthly,
+            all,
+            failures,
+        );
+
+        print!("\x1b[J");
+        let _ = std::io::stdout().flush();
+
+        for _ in 0..(interval * 10) {
+            if !running.load(Ordering::SeqCst) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_once(
+    project: bool,
+    graph: bool,
+    history: bool,
+    quota: bool,
+    tier: &str,
+    daily: bool,
+    weekly: bool,
+    monthly: bool,
+    all: bool,
+    format: &str,
+    failures: bool,
+) -> Result<()> {
+    let tracker = Tracker::new().context("Failed to initialize tracking database")?;
+    let project_scope = resolve_project_scope(project)?;
 
     if failures {
         return show_failures(&tracker);
@@ -42,7 +185,7 @@ pub fn run(
                 weekly,
                 monthly,
                 all,
-                project_scope.as_deref(), // added: pass project scope
+                project_scope.as_deref(),
             );
         }
         "csv" => {
@@ -52,14 +195,48 @@ pub fn run(
                 weekly,
                 monthly,
                 all,
-                project_scope.as_deref(), // added: pass project scope
+                project_scope.as_deref(),
             );
         }
-        _ => {} // Continue with text format
+        _ => {}
+    }
+
+    run_display(
+        &tracker,
+        project_scope.as_deref(),
+        graph,
+        history,
+        quota,
+        tier,
+        daily,
+        weekly,
+        monthly,
+        all,
+        failures,
+    )
+}
+
+/// Core display logic, separated to allow Tracker reuse in watch mode.
+#[allow(clippy::too_many_arguments)]
+fn run_display(
+    tracker: &Tracker,
+    project_scope: Option<&str>,
+    graph: bool,
+    history: bool,
+    quota: bool,
+    tier: &str,
+    daily: bool,
+    weekly: bool,
+    monthly: bool,
+    all: bool,
+    failures: bool,
+) -> Result<()> {
+    if failures {
+        return show_failures(tracker);
     }
 
     let summary = tracker
-        .get_summary_filtered(project_scope.as_deref()) // changed: use filtered variant
+        .get_summary_filtered(project_scope)
         .context("Failed to load token savings summary from database")?;
 
     if summary.total_commands == 0 {
@@ -79,7 +256,7 @@ pub fn run(
         println!("{}", styled(title, true));
         println!("{}", "═".repeat(60));
         // added: show project path when scoped
-        if let Some(ref scope) = project_scope {
+        if let Some(scope) = project_scope {
             println!("Scope: {}", shorten_path(scope));
         }
         println!();
@@ -226,7 +403,7 @@ pub fn run(
         }
 
         if history {
-            let recent = tracker.get_recent_filtered(10, project_scope.as_deref())?; // changed: filtered
+            let recent = tracker.get_recent_filtered(10, project_scope)?;
             if !recent.is_empty() {
                 println!("{}", styled("Recent Commands", true)); // added: styled header
                 println!("──────────────────────────────────────────────────────────");
@@ -289,15 +466,15 @@ pub fn run(
 
     // Time breakdown views
     if all || daily {
-        print_daily_full(&tracker, project_scope.as_deref())?; // changed: pass project scope
+        print_daily_full(tracker, project_scope)?;
     }
 
     if all || weekly {
-        print_weekly(&tracker, project_scope.as_deref())?; // changed: pass project scope
+        print_weekly(tracker, project_scope)?;
     }
 
     if all || monthly {
-        print_monthly(&tracker, project_scope.as_deref())?; // changed: pass project scope
+        print_monthly(tracker, project_scope)?;
     }
 
     Ok(())
@@ -724,4 +901,158 @@ fn show_failures(tracker: &Tracker) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    #[derive(Parser)]
+    #[command()]
+    struct TestCli {
+        #[command(subcommand)]
+        command: TestCommands,
+    }
+
+    #[derive(clap::Subcommand)]
+    enum TestCommands {
+        Gain {
+            #[arg(short, long)]
+            project: bool,
+            #[arg(short, long)]
+            graph: bool,
+            #[arg(short = 'H', long)]
+            history: bool,
+            #[arg(short, long)]
+            quota: bool,
+            #[arg(short, long, default_value = "20x", requires = "quota")]
+            tier: String,
+            #[arg(short, long)]
+            daily: bool,
+            #[arg(short, long)]
+            weekly: bool,
+            #[arg(short, long)]
+            monthly: bool,
+            #[arg(short, long)]
+            all: bool,
+            #[arg(short, long, default_value = "text")]
+            format: String,
+            #[arg(short = 'F', long)]
+            failures: bool,
+            #[arg(short = 'W', long)]
+            watch: bool,
+            #[arg(short = 'n', long, default_value = "2", requires = "watch", value_parser = clap::value_parser!(u64).range(1..=3600))]
+            interval: u64,
+        },
+    }
+
+    #[test]
+    fn test_watch_rejects_json_format() {
+        let result = super::run(
+            false, false, false, false, "20x", false, false, false, false, "json", false, true, 2,
+            0,
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("not compatible"),
+            "Expected format incompatibility error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_watch_rejects_csv_format() {
+        let result = super::run(
+            false, false, false, false, "20x", false, false, false, false, "csv", false, true, 2, 0,
+        );
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("not compatible"),
+            "Expected format incompatibility error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_watch_flag_requires_watch_for_interval() {
+        let result = TestCli::try_parse_from(["test", "gain", "--interval", "5"]);
+        assert!(result.is_err(), "--interval without --watch should fail");
+    }
+
+    #[test]
+    fn test_watch_interval_bounds() {
+        let result = TestCli::try_parse_from(["test", "gain", "--watch", "--interval", "0"]);
+        assert!(result.is_err(), "interval=0 should be rejected");
+
+        let result = TestCli::try_parse_from(["test", "gain", "--watch", "--interval", "3601"]);
+        assert!(result.is_err(), "interval=3601 should be rejected");
+
+        let result = TestCli::try_parse_from(["test", "gain", "--watch", "--interval", "1"]);
+        assert!(result.is_ok(), "interval=1 should be accepted");
+
+        let result = TestCli::try_parse_from(["test", "gain", "--watch", "--interval", "3600"]);
+        assert!(result.is_ok(), "interval=3600 should be accepted");
+    }
+
+    #[test]
+    fn test_watch_parses_with_default_interval() {
+        let result = TestCli::try_parse_from(["test", "gain", "--watch"]);
+        assert!(result.is_ok());
+        if let Ok(cli) = result {
+            match cli.command {
+                TestCommands::Gain {
+                    watch, interval, ..
+                } => {
+                    assert!(watch);
+                    assert_eq!(interval, 2, "default interval should be 2s");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_watch_flag_header_reconstruction() {
+        let bool_flags = [
+            (true, "--project"),
+            (true, "--graph"),
+            (false, "--history"),
+            (false, "--quota"),
+            (true, "--daily"),
+            (false, "--weekly"),
+            (false, "--monthly"),
+            (false, "--all"),
+            (false, "--failures"),
+        ];
+        let mut parts: Vec<&str> = vec!["rtk gain"];
+        for (on, name) in &bool_flags {
+            if *on {
+                parts.push(name);
+            }
+        }
+        let flags = parts.join(" ");
+        assert_eq!(flags, "rtk gain --project --graph --daily");
+    }
+
+    #[test]
+    fn test_watch_flag_header_with_non_default_tier_and_interval() {
+        let mut parts: Vec<&str> = vec!["rtk gain"];
+        let bool_flags = [(true, "--quota"), (false, "--daily")];
+        for (on, name) in &bool_flags {
+            if *on {
+                parts.push(name);
+            }
+        }
+        let tier = "pro";
+        let tier_flag = format!("--tier {tier}");
+        if tier != "20x" {
+            parts.push(&tier_flag);
+        }
+        let interval = 5u64;
+        let interval_flag = format!("-n {interval}");
+        if interval != 2 {
+            parts.push(&interval_flag);
+        }
+        let flags = parts.join(" ");
+        assert_eq!(flags, "rtk gain --quota --tier pro -n 5");
+    }
 }

--- a/src/analytics/gain.rs
+++ b/src/analytics/gain.rs
@@ -1,6 +1,8 @@
 //! Shows users how many tokens RTK has saved them over time.
 
-use crate::core::display_helpers::{format_duration, print_period_table};
+use crate::core::display_helpers::{
+    format_duration, print_period_table, start_output_capture, take_output_capture,
+};
 use crate::core::tracking::{DayStats, MonthStats, Tracker, WeekStats};
 use crate::core::utils::format_tokens;
 use crate::hooks::hook_check;
@@ -12,6 +14,13 @@ use std::io::{IsTerminal, Write};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+
+// Shadow `println!` to route through the capture system.
+// When capture is active (watch mode) → buffer; when inactive → regular stdout.
+macro_rules! println {
+    () => { crate::core::display_helpers::captured_println(format_args!("")) };
+    ($($arg:tt)*) => { crate::core::display_helpers::captured_println(format_args!($($arg)*)) };
+}
 
 #[allow(clippy::too_many_arguments)]
 pub fn run(
@@ -49,12 +58,14 @@ pub fn run(
     )
 }
 
-/// RAII guard that hides the terminal cursor on creation and restores it on drop (including panic).
+/// RAII guard that switches to the alternate screen buffer, hides the cursor,
+/// and restores everything on drop (including panic).
 struct CursorGuard;
 
 impl CursorGuard {
     fn new() -> Self {
-        print!("\x1b[?25l");
+        // Alternate screen buffer + hide cursor + disable line wrapping
+        print!("\x1b[?1049h\x1b[?25l\x1b[?7l");
         let _ = std::io::stdout().flush();
         Self
     }
@@ -62,9 +73,17 @@ impl CursorGuard {
 
 impl Drop for CursorGuard {
     fn drop(&mut self) {
-        let _ = write!(std::io::stdout(), "\x1b[?25h");
+        // Re-enable line wrapping + show cursor + leave alternate screen buffer
+        let _ = write!(std::io::stdout(), "\x1b[?7h\x1b[?25h\x1b[?1049l");
         let _ = std::io::stdout().flush();
     }
+}
+
+/// Returns (width, height) of the terminal, with sensible defaults.
+fn terminal_dimensions() -> (usize, usize) {
+    terminal_size::terminal_size()
+        .map(|(w, h)| (w.0 as usize, h.0 as usize))
+        .unwrap_or((80, 24))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -119,14 +138,21 @@ fn run_watch_loop(
     let _cursor_guard = CursorGuard::new();
 
     while running.load(Ordering::SeqCst) {
-        print!("\x1b[H");
-        let _ = std::io::stdout().flush();
+        let (term_w, term_h) = terminal_dimensions();
+
+        // Capture all println! output to a buffer (via the shadow macro).
+        start_output_capture();
 
         let now = Local::now().format("%Y-%m-%d %H:%M:%S");
         println!("Every {}s: {:<40} {}", interval, flags, now);
         println!();
 
-        // Ignore display errors in watch mode (DB might be temporarily locked)
+        // Reserve lines for: watch header(2) + title(1) + sep(1) + blank(1) +
+        // KPIs(6) + blank(1) + section header(1) + table header(3) + table footer(2)
+        // = ~18 lines of overhead before command rows
+        let overhead = 18;
+        let max_cmd_rows = term_h.saturating_sub(overhead).max(3);
+
         let _ = run_display(
             &tracker,
             project_scope.as_deref(),
@@ -139,9 +165,16 @@ fn run_watch_loop(
             monthly,
             all,
             failures,
+            Some(max_cmd_rows),
+            Some(term_w),
         );
 
-        print!("\x1b[J");
+        // Flush the entire frame in a single write: home + content + clear-to-end.
+        // The terminal processes this atomically — no visible blank frame.
+        // \x1b[K (clear to end of line) is already embedded in each line by captured_println.
+        if let Some(content) = take_output_capture() {
+            print!("\x1b[H{}\x1b[J", content);
+        }
         let _ = std::io::stdout().flush();
 
         for _ in 0..(interval * 10) {
@@ -213,6 +246,8 @@ fn run_once(
         monthly,
         all,
         failures,
+        None,
+        None,
     )
 }
 
@@ -230,6 +265,8 @@ fn run_display(
     monthly: bool,
     all: bool,
     failures: bool,
+    max_cmd_rows: Option<usize>,
+    term_width: Option<usize>,
 ) -> Result<()> {
     if failures {
         return show_failures(tracker);
@@ -253,8 +290,9 @@ fn run_display(
         } else {
             "RTK Token Savings (Global Scope)"
         };
+        let sep_width = term_width.unwrap_or(80).min(60);
         println!("{}", styled(title, true));
-        println!("{}", "═".repeat(60));
+        println!("{}", "═".repeat(sep_width));
         // added: show project path when scoped
         if let Some(scope) = project_scope {
             println!("Scope: {}", shorten_path(scope));
@@ -314,9 +352,7 @@ fn run_display(
             // added: styled section header
             println!("{}", styled("By Command", true));
 
-            // added: dynamic column widths for clean alignment
-            let cmd_width = 24usize;
-            let impact_width = 10usize;
+            // Dynamic column widths for clean alignment
             let count_width = summary
                 .by_command
                 .iter()
@@ -338,6 +374,14 @@ fn run_display(
                 .max()
                 .unwrap_or(6)
                 .max(6);
+
+            // Adapt cmd_width and impact_width to fit terminal width
+            // Fixed overhead: "#"(3) + 6×gap(12) + count + saved + "%"(6) + time
+            let fixed_cols = 3 + 12 + count_width + saved_width + 6 + time_width;
+            let available = term_width.unwrap_or(120).saturating_sub(fixed_cols);
+            // Split available space: ~70% command, ~30% impact bar
+            let cmd_width = (available * 7 / 10).clamp(10, 30);
+            let impact_width = available.saturating_sub(cmd_width).clamp(4, 14);
 
             let table_width = 3
                 + 2
@@ -369,9 +413,15 @@ fn run_display(
                 .max()
                 .unwrap_or(1);
 
-            for (idx, (cmd, count, saved, pct, avg_time)) in summary.by_command.iter().enumerate() {
+            let display_rows = max_cmd_rows.unwrap_or(summary.by_command.len());
+            let total_cmds = summary.by_command.len();
+            let visible = display_rows.min(total_cmds);
+
+            for (idx, (cmd, count, saved, pct, avg_time)) in
+                summary.by_command.iter().take(visible).enumerate()
+            {
                 let row_idx = format!("{:>2}.", idx + 1);
-                let cmd_cell = style_command_cell(&truncate_for_column(cmd, cmd_width)); // added: colored command
+                let cmd_cell = style_command_cell(&truncate_for_column(cmd, cmd_width));
                 let count_cell = format!("{:>count_width$}", count, count_width = count_width);
                 let saved_cell = format!(
                     "{:>saved_width$}",
@@ -379,16 +429,22 @@ fn run_display(
                     saved_width = saved_width
                 );
                 let pct_plain = format!("{:>6}", format!("{pct:.1}%"));
-                let pct_cell = colorize_pct_cell(*pct, &pct_plain); // added: color-coded percentage
+                let pct_cell = colorize_pct_cell(*pct, &pct_plain);
                 let time_cell = format!(
                     "{:>time_width$}",
                     format_duration(*avg_time),
                     time_width = time_width
                 );
-                let impact = mini_bar(*saved, max_saved, impact_width); // added: impact bar
+                let impact = mini_bar(*saved, max_saved, impact_width);
                 println!(
                     "{}  {}  {}  {}  {}  {}  {}",
                     row_idx, cmd_cell, count_cell, saved_cell, pct_cell, time_cell, impact
+                );
+            }
+            if visible < total_cmds {
+                println!(
+                    "     ... +{} more (enlarge terminal to see all)",
+                    total_cmds - visible
                 );
             }
             println!("{}", "─".repeat(table_width));

--- a/src/core/display_helpers.rs
+++ b/src/core/display_helpers.rs
@@ -58,6 +58,57 @@ pub trait PeriodStats {
     fn separator_width() -> usize;
 }
 
+// ── Output capture for flicker-free watch mode ──
+//
+// When capture is active, `println!` writes to an in-memory buffer instead of
+// stdout.  The watch loop flushes the whole buffer in a single write, which
+// the terminal processes atomically — no visible blank frame between clear and
+// content.
+//
+// IMPORTANT: `captured_println` is defined BEFORE the `println!` shadow macro
+// so it still calls `std::println!` internally.
+
+use std::cell::RefCell;
+
+thread_local! {
+    static OUTPUT_BUF: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
+/// Activate stdout capture.
+pub fn start_output_capture() {
+    OUTPUT_BUF.with(|buf| {
+        *buf.borrow_mut() = Some(String::with_capacity(4096));
+    });
+}
+
+/// Stop capturing and return the buffered content.
+pub fn take_output_capture() -> Option<String> {
+    OUTPUT_BUF.with(|buf| buf.borrow_mut().take())
+}
+
+/// Write a formatted line to the capture buffer, or stdout if capture is off.
+/// When capturing, each line is terminated with `\x1b[K\n` (clear to end of line)
+/// so the watch loop can render without a separate post-processing pass.
+pub fn captured_println(args: std::fmt::Arguments) {
+    OUTPUT_BUF.with(|buf| {
+        let mut borrow = buf.borrow_mut();
+        if let Some(ref mut s) = *borrow {
+            use std::fmt::Write;
+            let _ = s.write_fmt(args);
+            s.push_str("\x1b[K\n");
+        } else {
+            std::println!("{}", args);
+        }
+    });
+}
+
+// Shadow `println!` for all code below this point in this module.
+// When capture is active → buffer; when inactive → regular stdout.
+macro_rules! println {
+    () => { crate::core::display_helpers::captured_println(format_args!("")) };
+    ($($arg:tt)*) => { crate::core::display_helpers::captured_println(format_args!($($arg)*)) };
+}
+
 /// Generic table printer for any period statistics
 pub fn print_period_table<T: PeriodStats>(data: &[T]) {
     if data.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -403,6 +403,12 @@ enum Commands {
         /// Show parse failure log (commands that fell back to raw execution)
         #[arg(short = 'F', long)]
         failures: bool,
+        /// Continuously refresh the display (like watch(1))
+        #[arg(short = 'W', long)]
+        watch: bool,
+        /// Refresh interval in seconds (requires --watch)
+        #[arg(short = 'n', long, default_value = "2", requires = "watch", value_parser = clap::value_parser!(u64).range(1..=3600))]
+        interval: u64,
     },
 
     /// Claude Code economics: spending (ccusage) vs savings (rtk) analysis
@@ -1665,6 +1671,8 @@ fn run_cli() -> Result<i32> {
             all,
             format,
             failures,
+            watch,
+            interval,
         } => {
             analytics::gain::run(
                 project, // added: pass project flag
@@ -1678,6 +1686,8 @@ fn run_cli() -> Result<i32> {
                 all,
                 &format,
                 failures,
+                watch,
+                interval,
                 cli.verbose,
             )?;
             0


### PR DESCRIPTION
## Summary

- Add `--watch` (`-W`) flag to `rtk gain` for live dashboard monitoring
- Add `--interval` (`-n`) flag for configurable refresh rate (default: 2s, range: 1-3600s)
- Compatible with all existing flags (`--graph`, `--history`, `--project`, `--quota`, etc.)
- Rejects `--watch` with `--format json/csv` and when stdout is not a TTY

## Implementation

- **Alternate screen buffer**: uses `\x1b[?1049h` (like top/htop/vim) — original terminal content restored on exit
- **No line wrapping**: `\x1b[?7l` prevents visual corruption on narrow terminals
- **Flicker-free rendering**: `println!` shadow macro captures all output to an in-memory buffer, then flushes the entire frame in a single `write()` with `\x1b[K` (clear-to-end-of-line) per line — no visible blank frame between refreshes
- **Terminal-aware layout**: `terminal_size` crate detects dimensions at each refresh; table column widths adapt to terminal width, command rows are limited to screen height with `... +N more` overflow indicator
- **CursorGuard RAII**: alternate screen, cursor visibility, and line wrapping are all restored on exit, Ctrl+C, and panic
- **Ctrl+C handling**: `ctrlc` crate + `AtomicBool` with 100ms polling for responsive shutdown
- **Optimized**: `Tracker` (SQLite) created once and reused across refresh cycles
- **New dependencies**: `ctrlc = "3"` (signal handler), `terminal_size = "0.4"` (terminal dimensions)

## Usage

```bash
rtk gain --watch                    # Refresh every 2s (default)
rtk gain --watch --interval 5       # Refresh every 5s
rtk gain -W -n 5 --graph --history  # All flags work together
```

## Test plan

- [x] `cargo fmt --all --check && cargo clippy --all-targets && cargo test` passes
- [x] 7 unit tests added (flag parsing, validation, header reconstruction)
- [x] Manual test: `cargo run -- gain --watch` with concurrent commands
- [x] Manual test: resize terminal during watch — layout adapts dynamically
- [x] Manual test: small terminal (< 80 cols) — no wrapping, no ghosting
- [x] Ctrl+C exits cleanly with cursor and screen buffer restored
- [x] CLA signature (first-time contributor)