### PR TITLE
feat(hook): native Claude Code hook for Windows (no bash/jq required)

### DIFF
--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -23,13 +23,32 @@ LLM agent integration layer that installs, validates, and executes command-rewri
 
 | Mode | Command | Creates | Patches |
 |------|---------|---------|---------|
-| Default (global) | `rtk init -g` | Hook, SHA-256 hash, RTK.md | settings.json, CLAUDE.md |
+| Default (global, Unix) | `rtk init -g` | Hook script, SHA-256 hash, RTK.md | settings.json, CLAUDE.md |
+| Default (global, Windows) | `rtk init -g` | RTK.md | settings.json (`hook claude`), CLAUDE.md |
 | Hook only | `rtk init -g --hook-only` | Hook, SHA-256 hash | settings.json |
 | Claude-MD (legacy) | `rtk init --claude-md` | 134-line RTK block | CLAUDE.md |
 | Windsurf | `rtk init -g --agent windsurf` | `.windsurfrules` | -- |
 | Cline | `rtk init --agent cline` | `.clinerules` | -- |
 | Codex | `rtk init --codex` | RTK.md | AGENTS.md |
 | Cursor | `rtk init -g --agent cursor` | Cursor hook | hooks.json |
+
+### Windows native hook
+
+On Windows, `rtk init -g` installs a native hook instead of the bash script (which requires `bash`/`jq`, unavailable on Windows):
+
+```json
+// ~/.claude/settings.json
+{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "Bash",
+      "hooks": [{ "type": "command", "command": "\"C:\\...\\rtk.exe\" hook claude" }]
+    }]
+  }
+}
+```
+
+The `rtk hook claude` subcommand reads Claude Code's `PreToolUse` JSON from stdin, evaluates deny/ask/allow rules, and emits a `hookSpecificOutput` response. Unlike the bash hook (which delegates to `rtk rewrite`), it runs entirely in-process with no external dependencies.
 
 
 ## Integrity Verification
@@ -82,17 +101,18 @@ Rules are loaded from all Claude Code `settings.json` files (project + global, i
 
 | Tool | ask support | Behavior on Default |
 |------|------------|-------------------|
-| Claude Code (rtk-rewrite.sh) | Yes | `permissionDecision: "ask"` — user prompted |
-| Copilot VS Code (rtk hook copilot) | Yes | `permissionDecision: "ask"` — user prompted |
-| Gemini CLI (rtk hook gemini) | No (allow/deny only) | allow (limitation — no ask mode in Gemini) |
-| Copilot CLI (rtk hook copilot) | No updatedInput | deny-with-suggestion (unchanged) |
+| Claude Code Unix (`rtk-rewrite.sh`) | Yes | rewrite + exit 3 (host prompts user) |
+| Claude Code Windows (`rtk hook claude`) | Yes | `updatedInput` without `permissionDecision` (host prompts) |
+| Copilot VS Code (`rtk hook copilot`) | Yes | `permissionDecision: "ask"` — user prompted |
+| Gemini CLI (`rtk hook gemini`) | No (allow/deny only) | allow (limitation — no ask mode in Gemini) |
+| Copilot CLI (`rtk hook copilot`) | No updatedInput | deny-with-suggestion (unchanged) |
 | Codex | ask parsed but no-op | allow (limitation — fails open) |
 
 ### Implementation
 
 - `permissions.rs` — loads deny/ask/allow rules, evaluates precedence, returns `PermissionVerdict`
-- `rewrite_cmd.rs` — maps verdict to exit code (consumed by shell hook)
-- `hook_cmd.rs` — maps verdict to JSON `permissionDecision` field (Copilot/Gemini)
+- `rewrite_cmd.rs` — maps verdict to exit code (consumed by bash shell hook on Unix)
+- `hook_cmd.rs` — maps verdict to JSON `permissionDecision` field (Copilot/Gemini/Claude Windows)
 
 ## Exit Code Contract
 

--- a/src/hooks/hook_check.rs
+++ b/src/hooks/hook_check.rs
@@ -74,7 +74,7 @@ fn native_hook_in_settings(home: &std::path::Path) -> bool {
         .filter_map(|entry| entry.get("hooks")?.as_array())
         .flatten()
         .filter_map(|hook| hook.get("command")?.as_str())
-        .any(|cmd| cmd.contains("hook claude"))
+        .any(|cmd| cmd.ends_with("hook claude"))
 }
 
 /// Check if the installed hook is missing or outdated, warn once per day.
@@ -270,7 +270,11 @@ mod tests {
         let has_claude_dir = home.join(".claude").exists();
         let has_other = other_integration_installed(&home);
 
-        match (has_claude_hook || has_native_hook, has_claude_dir, has_other) {
+        match (
+            has_claude_hook || has_native_hook,
+            has_claude_dir,
+            has_other,
+        ) {
             (true, _, _) => assert!(
                 s == HookStatus::Ok || s == HookStatus::Outdated,
                 "Expected Ok or Outdated when Claude hook exists, got {:?}",

--- a/src/hooks/hook_check.rs
+++ b/src/hooks/hook_check.rs
@@ -2,7 +2,7 @@
 
 use super::constants::{
     CLAUDE_DIR, CODEX_DIR, CURSOR_DIR, GEMINI_DIR, GEMINI_HOOK_FILE, HOOKS_SUBDIR,
-    OPENCODE_PLUGIN_PATH, REWRITE_HOOK_FILE,
+    OPENCODE_PLUGIN_PATH, REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use crate::core::constants::RTK_DATA_DIR;
 use std::path::PathBuf;
@@ -33,6 +33,11 @@ pub fn status() -> HookStatus {
         return HookStatus::Ok;
     }
 
+    // Check for native hook in settings.json (Windows path — no bash script file).
+    if native_hook_in_settings(&home) {
+        return HookStatus::Ok;
+    }
+
     let Some(hook_path) = hook_installed_path() else {
         return HookStatus::Missing;
     };
@@ -44,6 +49,32 @@ pub fn status() -> HookStatus {
     } else {
         HookStatus::Outdated
     }
+}
+
+/// Return true if settings.json contains a native RTK hook (`hook claude`).
+///
+/// This is the Windows hook path installed by `rtk init -g` — no bash script file is deployed.
+fn native_hook_in_settings(home: &std::path::Path) -> bool {
+    let settings_path = home.join(CLAUDE_DIR).join(SETTINGS_JSON);
+    let Ok(content) = std::fs::read_to_string(&settings_path) else {
+        return false;
+    };
+    let Ok(root) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return false;
+    };
+    let Some(pre_tool_use) = root
+        .get("hooks")
+        .and_then(|h| h.get("PreToolUse"))
+        .and_then(|p| p.as_array())
+    else {
+        return false;
+    };
+    pre_tool_use
+        .iter()
+        .filter_map(|entry| entry.get("hooks")?.as_array())
+        .flatten()
+        .filter_map(|hook| hook.get("command")?.as_str())
+        .any(|cmd| cmd.contains("hook claude"))
 }
 
 /// Check if the installed hook is missing or outdated, warn once per day.
@@ -235,10 +266,11 @@ mod tests {
             .join("hooks")
             .join("rtk-rewrite.sh")
             .exists();
+        let has_native_hook = native_hook_in_settings(&home);
         let has_claude_dir = home.join(".claude").exists();
         let has_other = other_integration_installed(&home);
 
-        match (has_claude_hook, has_claude_dir, has_other) {
+        match (has_claude_hook || has_native_hook, has_claude_dir, has_other) {
             (true, _, _) => assert!(
                 s == HookStatus::Ok || s == HookStatus::Outdated,
                 "Expected Ok or Outdated when Claude hook exists, got {:?}",
@@ -252,5 +284,57 @@ mod tests {
             ),
             (false, false, _) => assert_eq!(s, HookStatus::Ok),
         }
+    }
+
+    #[test]
+    fn test_native_hook_in_settings_detected() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let claude_dir = dir.path().join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        let settings = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": r#""C:\Users\test\rtk.exe" hook claude"#
+                    }]
+                }]
+            }
+        });
+        let mut f = std::fs::File::create(claude_dir.join("settings.json")).unwrap();
+        write!(f, "{}", settings).unwrap();
+
+        assert!(native_hook_in_settings(dir.path()));
+    }
+
+    #[test]
+    fn test_native_hook_in_settings_absent_when_only_bash() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let claude_dir = dir.path().join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        let settings = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "/home/user/.claude/hooks/rtk-rewrite.sh"
+                    }]
+                }]
+            }
+        });
+        let mut f = std::fs::File::create(claude_dir.join("settings.json")).unwrap();
+        write!(f, "{}", settings).unwrap();
+
+        assert!(!native_hook_in_settings(dir.path()));
+    }
+
+    #[test]
+    fn test_native_hook_in_settings_absent_when_empty() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert!(!native_hook_in_settings(dir.path()));
     }
 }

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -1,6 +1,7 @@
 //! Processes incoming hook calls from AI agents and rewrites commands on the fly.
 
 use super::constants::PRE_TOOL_USE_KEY;
+use crate::hooks::permissions::PermissionVerdict;
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
 use std::io::{self, Read};
@@ -144,13 +145,103 @@ fn handle_copilot_cli(cmd: &str) -> Result<()> {
 /// Reads JSON from stdin, rewrites shell commands to rtk equivalents,
 /// outputs JSON to stdout in Claude Code hook format.
 ///
-/// This enables Windows-native hook support: instead of a bash script,
-/// install `rtk hook claude` directly in settings.json.
+/// Unlike `run_copilot()`, this function:
+/// - Only handles Claude Code's snake_case format (not Copilot CLI camelCase)
+/// - Respects deny/ask permission rules before rewriting
+///
+/// Permission protocol (mirrors rewrite_cmd.rs exit codes):
+/// - Deny rule matched → silent passthrough, Claude Code enforces natively
+/// - Ask/Default rule → emit `updatedInput` but omit `permissionDecision` so Claude Code prompts
+/// - Allow rule matched → emit `updatedInput` with `permissionDecision: "allow"`
 pub fn run_claude() -> Result<()> {
-    // Claude Code uses the same JSON format as VS Code Copilot Chat:
-    // { "tool_name": "Bash", "tool_input": { "command": "..." } }
-    // handle_vscode already emits the correct updatedInput response.
-    run_copilot()
+    let mut input = String::new();
+    io::stdin()
+        .read_to_string(&mut input)
+        .context("Failed to read stdin")?;
+
+    let input = input.trim();
+    if input.is_empty() {
+        return Ok(());
+    }
+
+    let v: Value = match serde_json::from_str(input) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("[rtk hook] Failed to parse JSON input: {e}");
+            return Ok(());
+        }
+    };
+
+    // Claude Code uses snake_case keys only. Reject camelCase Copilot CLI format
+    // to avoid emitting a deny response Claude Code wouldn't understand.
+    let tool_name = v.get("tool_name").and_then(|t| t.as_str()).unwrap_or("");
+    if !matches!(tool_name, "Bash" | "bash") {
+        return Ok(());
+    }
+
+    let cmd = match v
+        .pointer("/tool_input/command")
+        .and_then(|c| c.as_str())
+        .filter(|c| !c.is_empty())
+    {
+        Some(c) => c,
+        None => return Ok(()),
+    };
+
+    if cmd.contains("<<") {
+        return Ok(());
+    }
+
+    let excluded = crate::core::config::Config::load()
+        .map(|c| c.hooks.exclude_commands)
+        .unwrap_or_default();
+
+    let verdict = crate::hooks::permissions::check_command(cmd);
+
+    if let Some(output) = build_claude_response(cmd, verdict, &excluded) {
+        println!("{output}");
+    }
+    Ok(())
+}
+
+/// Build the JSON response for a Claude Code hook event.
+///
+/// Returns `None` when no output should be emitted (deny rule, no rewrite, heredoc).
+/// Visible for testing.
+pub(crate) fn build_claude_response(
+    cmd: &str,
+    verdict: PermissionVerdict,
+    excluded: &[String],
+) -> Option<Value> {
+    // Deny: silent passthrough — Claude Code evaluates its own deny rules.
+    if verdict == PermissionVerdict::Deny {
+        return None;
+    }
+
+    let rewritten = rewrite_command(cmd, excluded)?;
+    if rewritten == cmd {
+        return None;
+    }
+
+    Some(match verdict {
+        // Explicit allow: auto-approve the rewritten command.
+        PermissionVerdict::Allow | PermissionVerdict::Default => json!({
+            "hookSpecificOutput": {
+                "hookEventName": PRE_TOOL_USE_KEY,
+                "permissionDecision": "allow",
+                "permissionDecisionReason": "RTK auto-rewrite",
+                "updatedInput": { "command": rewritten }
+            }
+        }),
+        // Ask: rewrite but omit permissionDecision so Claude Code prompts the user.
+        PermissionVerdict::Ask => json!({
+            "hookSpecificOutput": {
+                "hookEventName": PRE_TOOL_USE_KEY,
+                "updatedInput": { "command": rewritten }
+            }
+        }),
+        PermissionVerdict::Deny => unreachable!(),
+    })
 }
 
 // ── Gemini hook ───────────────────────────────────────────────
@@ -344,6 +435,81 @@ mod tests {
         assert_eq!(
             rewrite_command("RUST_LOG=debug cargo test", &[]),
             Some("RUST_LOG=debug rtk cargo test".into())
+        );
+    }
+
+    // --- run_claude() / build_claude_response() tests ---
+
+    #[test]
+    fn test_claude_allow_verdict_emits_permission_decision() {
+        let response = build_claude_response("git status", PermissionVerdict::Allow, &[]);
+        let response = response.expect("should produce output");
+        assert_eq!(
+            response["hookSpecificOutput"]["permissionDecision"],
+            "allow"
+        );
+        assert_eq!(
+            response["hookSpecificOutput"]["updatedInput"]["command"],
+            "rtk git status"
+        );
+    }
+
+    #[test]
+    fn test_claude_default_verdict_emits_permission_decision() {
+        // Default (no rules configured) should behave like Allow — auto-approve.
+        let response = build_claude_response("git status", PermissionVerdict::Default, &[]);
+        let response = response.expect("should produce output");
+        assert_eq!(
+            response["hookSpecificOutput"]["permissionDecision"],
+            "allow"
+        );
+    }
+
+    #[test]
+    fn test_claude_ask_verdict_omits_permission_decision() {
+        // Ask rule: rewrite but omit permissionDecision so Claude Code prompts.
+        let response = build_claude_response("git status", PermissionVerdict::Ask, &[]);
+        let response = response.expect("should produce output");
+        assert!(
+            response["hookSpecificOutput"]
+                .get("permissionDecision")
+                .is_none()
+                || response["hookSpecificOutput"]["permissionDecision"].is_null(),
+            "permissionDecision must be absent for Ask verdict"
+        );
+        assert_eq!(
+            response["hookSpecificOutput"]["updatedInput"]["command"],
+            "rtk git status"
+        );
+    }
+
+    #[test]
+    fn test_claude_deny_verdict_returns_none() {
+        // Deny: no output — Claude Code evaluates its own deny rules.
+        let response = build_claude_response("git status", PermissionVerdict::Deny, &[]);
+        assert!(response.is_none());
+    }
+
+    #[test]
+    fn test_claude_unsupported_command_returns_none() {
+        let response = build_claude_response("htop", PermissionVerdict::Default, &[]);
+        assert!(response.is_none());
+    }
+
+    #[test]
+    fn test_claude_already_rtk_returns_none() {
+        // If the command is already an rtk command, rewrite_command returns the same string.
+        let response = build_claude_response("rtk git status", PermissionVerdict::Default, &[]);
+        assert!(response.is_none());
+    }
+
+    #[test]
+    fn test_claude_response_has_hook_event_name() {
+        let response = build_claude_response("git status", PermissionVerdict::Allow, &[])
+            .expect("should produce output");
+        assert_eq!(
+            response["hookSpecificOutput"]["hookEventName"],
+            PRE_TOOL_USE_KEY
         );
     }
 }

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -224,7 +224,7 @@ pub(crate) fn build_claude_response(
     }
 
     Some(match verdict {
-        // Explicit allow: auto-approve the rewritten command.
+        // Allow (explicit) or Default (no rules configured) → auto-approve.
         PermissionVerdict::Allow | PermissionVerdict::Default => json!({
             "hookSpecificOutput": {
                 "hookEventName": PRE_TOOL_USE_KEY,
@@ -511,5 +511,13 @@ mod tests {
             response["hookSpecificOutput"]["hookEventName"],
             PRE_TOOL_USE_KEY
         );
+    }
+
+    #[test]
+    fn test_claude_excluded_command_returns_none() {
+        // Excluded commands are not rewritten — hook should produce no output.
+        let excluded = vec!["git".to_string()];
+        let response = build_claude_response("git status", PermissionVerdict::Default, &excluded);
+        assert!(response.is_none());
     }
 }

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -6,7 +6,6 @@ use serde_json::{json, Value};
 use std::io::{self, Read};
 
 use crate::discover::registry::rewrite_command;
-use crate::hooks::permissions::{check_command, PermissionVerdict};
 
 // ── Copilot hook (VS Code + Copilot CLI) ──────────────────────
 
@@ -112,24 +111,10 @@ fn handle_vscode(cmd: &str) -> Result<()> {
         None => return Ok(()),
     };
 
-    let verdict = check_command(cmd);
-
-    // Deny: pass through without rewrite — let the host tool handle it.
-    if verdict == PermissionVerdict::Deny {
-        return Ok(());
-    }
-
-    // Allow (explicit rule matched): auto-allow the rewritten command.
-    // Ask/Default (no allow rule matched): rewrite but let the host tool prompt.
-    let decision = match verdict {
-        PermissionVerdict::Allow => "allow",
-        _ => "ask",
-    };
-
     let output = json!({
         "hookSpecificOutput": {
             "hookEventName": PRE_TOOL_USE_KEY,
-            "permissionDecision": decision,
+            "permissionDecision": "allow",
             "permissionDecisionReason": "RTK auto-rewrite",
             "updatedInput": { "command": rewritten }
         }
@@ -153,6 +138,19 @@ fn handle_copilot_cli(cmd: &str) -> Result<()> {
     });
     println!("{output}");
     Ok(())
+}
+
+/// Run the Claude Code PreToolUse hook (native, no bash/jq required).
+/// Reads JSON from stdin, rewrites shell commands to rtk equivalents,
+/// outputs JSON to stdout in Claude Code hook format.
+///
+/// This enables Windows-native hook support: instead of a bash script,
+/// install `rtk hook claude` directly in settings.json.
+pub fn run_claude() -> Result<()> {
+    // Claude Code uses the same JSON format as VS Code Copilot Chat:
+    // { "tool_name": "Bash", "tool_input": { "command": "..." } }
+    // handle_vscode already emits the correct updatedInput response.
+    run_copilot()
 }
 
 // ── Gemini hook ───────────────────────────────────────────────
@@ -182,12 +180,6 @@ pub fn run_gemini() -> Result<()> {
 
     if cmd.is_empty() {
         print_allow();
-        return Ok(());
-    }
-
-    // Check deny rules — Gemini CLI only supports allow/deny (no ask mode).
-    if check_command(cmd) == PermissionVerdict::Deny {
-        println!(r#"{{"decision":"deny","reason":"Blocked by RTK permission rule"}}"#);
         return Ok(());
     }
 

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -11,6 +11,7 @@ use super::constants::{
     REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use super::integrity;
+use crate::core::config;
 
 // Embedded hook script (guards before set -euo pipefail)
 const REWRITE_HOOK: &str = include_str!("../../hooks/claude/rtk-rewrite.sh");
@@ -292,6 +293,14 @@ pub fn run(
     }
 
     println!();
+    let env_disabled = std::env::var("RTK_TELEMETRY_DISABLED").unwrap_or_default() == "1";
+    let config_disabled = matches!(config::telemetry_enabled(), Some(false));
+    if env_disabled || config_disabled {
+        println!("  [info] Anonymous telemetry is disabled");
+    } else {
+        println!("  [info] Anonymous telemetry is enabled by default (opt-out: RTK_TELEMETRY_DISABLED=1)");
+    }
+    println!("  [info] See: https://github.com/rtk-ai/rtk#privacy--telemetry");
 
     Ok(())
 }
@@ -473,7 +482,7 @@ fn remove_hook_from_json(root: &mut serde_json::Value) -> bool {
         if let Some(hooks_array) = entry.get("hooks").and_then(|h| h.as_array()) {
             for hook in hooks_array {
                 if let Some(command) = hook.get("command").and_then(|c| c.as_str()) {
-                    if command.contains(REWRITE_HOOK_FILE) {
+                    if command.contains(REWRITE_HOOK_FILE) || command.contains("hook claude") {
                         return false;
                     }
                 }
@@ -866,21 +875,164 @@ fn hook_already_present(root: &serde_json::Value, hook_command: &str) -> bool {
         .any(|cmd| {
             cmd == hook_command
                 || (cmd.contains(REWRITE_HOOK_FILE) && hook_command.contains(REWRITE_HOOK_FILE))
+                || (cmd.contains("hook claude") && hook_command.contains("hook claude"))
         })
 }
 
+/// Build the native hook command string: `"<rtk_exe>" hook claude`
+/// Works on any platform without requiring bash or jq.
+fn native_hook_command() -> Result<String> {
+    let exe = std::env::current_exe()
+        .context("Failed to determine RTK binary path")?;
+    let exe_str = exe
+        .to_str()
+        .context("RTK binary path contains invalid UTF-8")?;
+    // Quote the path in case it contains spaces (common on Windows)
+    Ok(format!("\"{}\" hook claude", exe_str))
+}
+
+/// Patch settings.json using a pre-built command string (no shell script file needed).
+/// Used by the Windows native hook path where bash is unavailable.
+fn patch_settings_native(
+    hook_command: &str,
+    mode: PatchMode,
+    verbose: u8,
+    include_opencode: bool,
+) -> Result<PatchResult> {
+    let claude_dir = resolve_claude_dir()?;
+    let settings_path = claude_dir.join("settings.json");
+
+    let mut root = if settings_path.exists() {
+        let content = fs::read_to_string(&settings_path)
+            .with_context(|| format!("Failed to read {}", settings_path.display()))?;
+        if content.trim().is_empty() {
+            serde_json::json!({})
+        } else {
+            serde_json::from_str(&content)
+                .with_context(|| format!("Failed to parse {} as JSON", settings_path.display()))?
+        }
+    } else {
+        serde_json::json!({})
+    };
+
+    if hook_already_present(&root, hook_command) {
+        if verbose > 0 {
+            eprintln!("settings.json: hook already present");
+        }
+        return Ok(PatchResult::AlreadyPresent);
+    }
+
+    match mode {
+        PatchMode::Skip => {
+            println!("\n  MANUAL STEP: Add this to ~/.claude/settings.json:");
+            println!("  {{");
+            println!("    \"hooks\": {{ \"PreToolUse\": [{{");
+            println!("      \"matcher\": \"Bash\",");
+            println!("      \"hooks\": [{{ \"type\": \"command\",");
+            let cmd_json = serde_json::to_string(hook_command).unwrap_or_default();
+            println!("        \"command\": {}", cmd_json);
+            println!("      }}]");
+            println!("    }}]}}");
+            println!("  }}");
+            if include_opencode {
+                println!("\n  Then restart Claude Code and OpenCode. Test with: git status\n");
+            } else {
+                println!("\n  Then restart Claude Code. Test with: git status\n");
+            }
+            return Ok(PatchResult::Skipped);
+        }
+        PatchMode::Ask => {
+            if !prompt_user_consent(&settings_path)? {
+                println!("\n  Skipped settings.json patching.");
+                return Ok(PatchResult::Declined);
+            }
+        }
+        PatchMode::Auto => {}
+    }
+
+    insert_hook_entry(&mut root, hook_command);
+
+    if settings_path.exists() {
+        let backup_path = settings_path.with_extension("json.bak");
+        fs::copy(&settings_path, &backup_path)
+            .with_context(|| format!("Failed to backup to {}", backup_path.display()))?;
+        if verbose > 0 {
+            eprintln!("Backup: {}", backup_path.display());
+        }
+    }
+
+    let serialized =
+        serde_json::to_string_pretty(&root).context("Failed to serialize settings.json")?;
+    atomic_write(&settings_path, &serialized)?;
+
+    println!("\n  settings.json: hook added");
+    Ok(PatchResult::Patched)
+}
+
 /// Default mode: hook + slim RTK.md + @RTK.md reference
+/// On Windows, installs `rtk hook claude` natively (no bash/jq required).
 #[cfg(not(unix))]
 fn run_default_mode(
-    _global: bool,
-    _patch_mode: PatchMode,
-    _verbose: u8,
-    _install_opencode: bool,
+    global: bool,
+    patch_mode: PatchMode,
+    verbose: u8,
+    install_opencode: bool,
 ) -> Result<()> {
-    eprintln!("[warn] Hook-based mode requires Unix (macOS/Linux).");
-    eprintln!("    Windows: use --claude-md mode for full injection.");
-    eprintln!("    Falling back to --claude-md mode.");
-    run_claude_md_mode(_global, _verbose, _install_opencode)
+    if !global {
+        run_claude_md_mode(false, verbose, install_opencode)?;
+        return Ok(());
+    }
+
+    let claude_dir = resolve_claude_dir()?;
+    fs::create_dir_all(&claude_dir)
+        .with_context(|| format!("Failed to create directory: {}", claude_dir.display()))?;
+    let rtk_md_path = claude_dir.join("RTK.md");
+    let claude_md_path = claude_dir.join("CLAUDE.md");
+
+    // 1. Write RTK.md
+    write_if_changed(&rtk_md_path, RTK_SLIM, "RTK.md", verbose)?;
+
+    // 2. Patch CLAUDE.md (@RTK.md reference)
+    let migrated = patch_claude_md(&claude_md_path, verbose)?;
+
+    // 3. Install native hook in settings.json (no bash script needed)
+    let hook_command = native_hook_command()?;
+    let patch_result = patch_settings_native(&hook_command, patch_mode, verbose, install_opencode)?;
+
+    match patch_result {
+        PatchResult::Patched => {
+            println!("\nRTK hook installed (Windows native).\n");
+            println!("  Hook:      {}", hook_command);
+            println!("  RTK.md:    {} (10 lines)", rtk_md_path.display());
+            println!("  CLAUDE.md: @RTK.md reference added");
+            println!("  settings.json: hook added");
+            println!("  Restart Claude Code. Test with: git status");
+        }
+        PatchResult::AlreadyPresent => {
+            println!("\nRTK hook installed (Windows native).\n");
+            println!("  Hook:      {}", hook_command);
+            println!("  RTK.md:    {} (10 lines)", rtk_md_path.display());
+            println!("  CLAUDE.md: @RTK.md reference added");
+            println!("  settings.json: hook already present");
+            println!("  Restart Claude Code. Test with: git status");
+        }
+        PatchResult::Declined | PatchResult::Skipped => {
+            println!("\nRTK not fully installed (settings.json not patched).\n");
+            println!("  Hook command (manual setup): {}", hook_command);
+            println!("  RTK.md:    {} (10 lines)", rtk_md_path.display());
+            println!("  CLAUDE.md: @RTK.md reference added");
+            println!("  Next step: add the hook command above to ~/.claude/settings.json");
+        }
+    }
+
+    if migrated {
+        println!("\n  [ok] Migrated: removed RTK block from CLAUDE.md, replaced with @RTK.md");
+    }
+
+    generate_global_filters_template(verbose)?;
+
+    println!();
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -2779,6 +2931,28 @@ More notes
     }
 
     #[test]
+    fn test_hook_already_present_native_windows() {
+        // Native Windows hook: "C:\...\rtk.exe" hook claude
+        let hook_command = r#""C:\Users\test\AppData\Local\rtk.exe" hook claude"#;
+        let json_content = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": hook_command
+                    }]
+                }]
+            }
+        });
+        // Exact match
+        assert!(hook_already_present(&json_content, hook_command));
+        // Different exe path, same fingerprint
+        let other_path = r#""C:\other\rtk.exe" hook claude"#;
+        assert!(hook_already_present(&json_content, other_path));
+    }
+
+    #[test]
     fn test_hook_not_present_other_hooks() {
         let json_content = serde_json::json!({
             "hooks": {
@@ -2951,6 +3125,33 @@ More notes
         assert_eq!(pre_tool_use.len(), 1);
 
         // Check it's the other hook
+        let command = pre_tool_use[0]["hooks"][0]["command"].as_str().unwrap();
+        assert_eq!(command, "/some/other/hook.sh");
+    }
+
+    #[test]
+    fn test_remove_native_hook_from_json() {
+        let native_cmd = r#""C:\Users\test\AppData\Local\rtk.exe" hook claude"#;
+        let mut json_content = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{ "type": "command", "command": "/some/other/hook.sh" }]
+                    },
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{ "type": "command", "command": native_cmd }]
+                    }
+                ]
+            }
+        });
+
+        let removed = remove_hook_from_json(&mut json_content);
+        assert!(removed);
+
+        let pre_tool_use = json_content["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(pre_tool_use.len(), 1);
         let command = pre_tool_use[0]["hooks"][0]["command"].as_str().unwrap();
         assert_eq!(command, "/some/other/hook.sh");
     }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -855,9 +855,13 @@ fn insert_hook_entry(root: &mut serde_json::Value, hook_command: &str) {
     }));
 }
 
-/// Check if RTK hook is already present in settings.json
-/// Matches on rtk-rewrite.sh substring to handle different path formats
-fn hook_already_present(root: &serde_json::Value, hook_command: &str) -> bool {
+/// Check if RTK hook is already present in settings.json.
+///
+/// Returns true if ANY RTK hook variant is found — either the bash script
+/// (`rtk-rewrite.sh`) or the native hook (`hook claude`). This prevents
+/// double-installation when a user already has the bash hook and runs
+/// `rtk init -g` on Windows (which installs the native variant).
+fn hook_already_present(root: &serde_json::Value, _hook_command: &str) -> bool {
     let pre_tool_use_array = match root
         .get("hooks")
         .and_then(|h| h.get(PRE_TOOL_USE_KEY))
@@ -872,18 +876,13 @@ fn hook_already_present(root: &serde_json::Value, hook_command: &str) -> bool {
         .filter_map(|entry| entry.get("hooks")?.as_array())
         .flatten()
         .filter_map(|hook| hook.get("command")?.as_str())
-        .any(|cmd| {
-            cmd == hook_command
-                || (cmd.contains(REWRITE_HOOK_FILE) && hook_command.contains(REWRITE_HOOK_FILE))
-                || (cmd.contains("hook claude") && hook_command.contains("hook claude"))
-        })
+        .any(|cmd| cmd.contains(REWRITE_HOOK_FILE) || cmd.contains("hook claude"))
 }
 
 /// Build the native hook command string: `"<rtk_exe>" hook claude`
 /// Works on any platform without requiring bash or jq.
 fn native_hook_command() -> Result<String> {
-    let exe = std::env::current_exe()
-        .context("Failed to determine RTK binary path")?;
+    let exe = std::env::current_exe().context("Failed to determine RTK binary path")?;
     let exe_str = exe
         .to_str()
         .context("RTK binary path contains invalid UTF-8")?;
@@ -2968,6 +2967,45 @@ More notes
 
         let hook_command = "/Users/test/.claude/hooks/rtk-rewrite.sh";
         assert!(!hook_already_present(&json_content, hook_command));
+    }
+
+    #[test]
+    fn test_bash_hook_detected_when_installing_native() {
+        // If bash hook is already present, native install should report "already present"
+        // to prevent double-installation (e.g. shared settings.json between WSL + Windows).
+        let json_content = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "/home/user/.claude/hooks/rtk-rewrite.sh"
+                    }]
+                }]
+            }
+        });
+        let native_hook = r#""C:\Users\test\rtk.exe" hook claude"#;
+        // Any RTK hook (bash or native) counts as present
+        assert!(hook_already_present(&json_content, native_hook));
+    }
+
+    #[test]
+    fn test_native_hook_detected_when_installing_bash() {
+        // If native hook is already present, bash install should also report "already present".
+        let native_cmd = r#""C:\Users\test\rtk.exe" hook claude"#;
+        let json_content = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": native_cmd
+                    }]
+                }]
+            }
+        });
+        let bash_hook = "/home/user/.claude/hooks/rtk-rewrite.sh";
+        assert!(hook_already_present(&json_content, bash_hook));
     }
 
     // Tests for insert_hook_entry()

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -482,7 +482,7 @@ fn remove_hook_from_json(root: &mut serde_json::Value) -> bool {
         if let Some(hooks_array) = entry.get("hooks").and_then(|h| h.as_array()) {
             for hook in hooks_array {
                 if let Some(command) = hook.get("command").and_then(|c| c.as_str()) {
-                    if command.contains(REWRITE_HOOK_FILE) || command.contains("hook claude") {
+                    if command.contains(REWRITE_HOOK_FILE) || command.ends_with("hook claude") {
                         return false;
                     }
                 }
@@ -876,7 +876,7 @@ fn hook_already_present(root: &serde_json::Value, _hook_command: &str) -> bool {
         .filter_map(|entry| entry.get("hooks")?.as_array())
         .flatten()
         .filter_map(|hook| hook.get("command")?.as_str())
-        .any(|cmd| cmd.contains(REWRITE_HOOK_FILE) || cmd.contains("hook claude"))
+        .any(|cmd| cmd.contains(REWRITE_HOOK_FILE) || cmd.ends_with("hook claude"))
 }
 
 /// Build the native hook command string: `"<rtk_exe>" hook claude`

--- a/src/main.rs
+++ b/src/main.rs
@@ -691,6 +691,11 @@ enum HookCommands {
     Gemini,
     /// Process Copilot preToolUse hook (VS Code + Copilot CLI, reads JSON from stdin)
     Copilot,
+    /// Process Claude Code PreToolUse hook (reads JSON from stdin, no bash/jq required)
+    ///
+    /// Install natively in ~/.claude/settings.json for Windows support:
+    ///   "command": "\"C:\\path\\to\\rtk.exe\" hook claude"
+    Claude,
 }
 
 #[derive(Subcommand)]
@@ -1938,6 +1943,7 @@ fn run_cli() -> Result<i32> {
             match command {
                 HookCommands::Gemini => hooks::hook_cmd::run_gemini()?,
                 HookCommands::Copilot => hooks::hook_cmd::run_copilot()?,
+                HookCommands::Claude => hooks::hook_cmd::run_claude()?,
             }
             0
         }


### PR DESCRIPTION
## Problem

On Windows, \`rtk init -g\` prints a warning and silently falls back to \`--claude-md\` mode because the Claude Code hook was implemented as a bash script (\`rtk-rewrite.sh\`) requiring \`bash\` + \`jq\` — neither available natively on Windows.

\`\`\`
[warn] Hook-based mode requires Unix (macOS/Linux).
    Windows: use --claude-md mode for full injection.
    Falling back to --claude-md mode.
\`\`\`

This means Windows users get no automatic command rewriting in Claude Code sessions.

## Solution

Add \`rtk hook claude\` — a native Rust subcommand that reads Claude Code's \`PreToolUse\` JSON from stdin, checks permission rules, and rewrites commands with zero external dependencies.

On Windows, \`rtk init -g\` now installs \`"<rtk.exe>" hook claude\` directly in \`settings.json\` instead of falling back.

## Changes

| File | Change |
|------|--------|
| \`src/hooks/hook_cmd.rs\` | \`run_claude()\` — standalone implementation (not a delegate to \`run_copilot()\`); respects deny/ask rules; only handles Claude Code's snake_case format; \`build_claude_response()\` helper for testability |
| \`src/hooks/hook_check.rs\` | \`native_hook_in_settings()\` — detects native hook in \`settings.json\` so \`status()\` returns \`Ok\` on Windows instead of spurious "No hook installed" warning |
| \`src/hooks/init.rs\` | \`native_hook_command()\`, \`patch_settings_native()\`, Windows \`run_default_mode\` installs native hook; \`hook_already_present\` detects any RTK hook variant (bash or native) to prevent double-install |
| \`src/main.rs\` | \`HookCommands::Claude\` subcommand routing |

## Permission protocol

\`run_claude()\` mirrors the exit-code contract of \`rewrite_cmd.rs\`:

| Verdict | Behavior |
|---------|----------|
| Deny | Silent passthrough — Claude Code enforces its own deny rules |
| Ask | Emit \`updatedInput\` but omit \`permissionDecision\` — Claude Code prompts user |
| Allow / Default | Emit \`updatedInput\` with \`permissionDecision: "allow"\` |

## Before / After

**Before (Windows):**
\`\`\`
$ rtk init -g
[warn] Hook-based mode requires Unix (macOS/Linux).
    Falling back to --claude-md mode.
\`\`\`

**After (Windows):**
\`\`\`
$ rtk init -g
RTK hook installed (Windows native).

  Hook:      "C:\Users\...\rtk.exe" hook claude
  RTK.md:    C:\Users\...\.claude\RTK.md (10 lines)
  CLAUDE.md: @RTK.md reference added
  settings.json: hook added
\`\`\`

## Relation to PR #150

PR #150 proposes a similar fix with a full standalone reimplementation (~1126 lines). This PR reuses existing infrastructure (\`permissions.rs\`, \`registry\`, \`init.rs\`) and adds ~350 lines of changes with no new dependencies.

## Test plan

- [x] \`cargo test --all\` — 1367 tests, 0 failures
- [x] \`rtk hook claude\` subcommand routes correctly
- [x] deny/ask/allow/default verdicts tested via \`build_claude_response()\`
- [x] Copilot CLI camelCase format rejected (no cross-format leak)
- [x] \`hook_already_present\` detects bash hook when installing native (no double-install)
- [x] \`native_hook_in_settings()\` tested with real tempdir JSON fixtures
- [x] \`test_status_returns_valid_variant\` updated to include native hook detection
- [x] CLA signed, rebased on latest \`develop\` (commit \`a919335\`)