### PR TITLE
fix: fix gh pr status invalid field and forward args correctly

### DIFF
--- a/src/cmds/git/gh_cmd.rs
+++ b/src/cmds/git/gh_cmd.rs
@@ -207,7 +207,7 @@ fn run_pr(args: &[String], verbose: u8, ultra_compact: bool) -> Result<i32> {
         "list" => list_prs(&args[1..], verbose, ultra_compact),
         "view" => view_pr(&args[1..], verbose, ultra_compact),
         "checks" => pr_checks(&args[1..], verbose, ultra_compact),
-        "status" => pr_status(verbose, ultra_compact),
+        "status" => pr_status(&args[1..], verbose, ultra_compact),
         "create" => pr_create(&args[1..], verbose),
         "merge" => pr_merge(&args[1..], verbose),
         "diff" => pr_diff(&args[1..], verbose),
@@ -293,6 +293,19 @@ fn should_passthrough_issue_view(extra_args: &[String]) -> bool {
     extra_args
         .iter()
         .any(|a| a == "--json" || a == "--jq" || a == "--web" || a == "--comments")
+}
+
+fn should_passthrough_pr_status(args: &[String]) -> bool {
+    args.iter().any(|a| {
+        matches!(
+            a.as_str(),
+            "--help" | "-h" | "--web" | "--jq" | "--template"
+        )
+    })
+}
+
+fn pr_status_json_fields() -> &'static str {
+    "number,title,reviewDecision,statusCheckRollup"
 }
 
 fn view_pr(args: &[String], _verbose: u8, ultra_compact: bool) -> Result<i32> {
@@ -457,33 +470,82 @@ fn format_pr_checks(stdout: &str) -> String {
     out
 }
 
-fn pr_status(_verbose: u8, _ultra_compact: bool) -> Result<i32> {
+fn pr_status(args: &[String], _verbose: u8, _ultra_compact: bool) -> Result<i32> {
+    if should_passthrough_pr_status(args) {
+        let mut passthrough_args = Vec::with_capacity(args.len() + 1);
+        passthrough_args.push("status".to_string());
+        passthrough_args.extend(args.iter().cloned());
+        return run_passthrough("gh", "pr", &passthrough_args);
+    }
+
     let mut cmd = resolved_command("gh");
-    cmd.args([
-        "pr",
-        "status",
-        "--json",
-        "currentBranch,createdBy,reviewDecision,statusCheckRollup",
-    ]);
+    cmd.args(["pr", "status", "--json", pr_status_json_fields()]);
+    for arg in args {
+        cmd.arg(arg);
+    }
     run_gh_json(cmd, "pr status", format_pr_status)
 }
 
 fn format_pr_status(json: &Value) -> String {
     let mut out = String::new();
+
+    if !json["currentBranch"].is_null() {
+        let current_branch = format_pr_status_entry(&json["currentBranch"]);
+        if !current_branch.is_empty() {
+            out.push_str("Current Branch\n");
+            out.push_str(&current_branch);
+            out.push('\n');
+        }
+    }
+
     if let Some(created_by) = json["createdBy"].as_array() {
         out.push_str(&format!("Your PRs ({}):\n", created_by.len()));
         for pr in created_by.iter().take(5) {
-            let number = pr["number"].as_i64().unwrap_or(0);
-            let title = pr["title"].as_str().unwrap_or("???");
-            let reviews = pr["reviewDecision"].as_str().unwrap_or("PENDING");
-            out.push_str(&format!(
-                "  #{} {} [{}]\n",
-                number,
-                truncate(title, 50),
-                reviews
-            ));
+            let entry = format_pr_status_entry(pr);
+            if !entry.is_empty() {
+                out.push_str(&entry);
+            }
         }
     }
+    out
+}
+
+fn format_pr_status_entry(pr: &Value) -> String {
+    if pr.is_null() {
+        return String::new();
+    }
+
+    let number = pr["number"].as_i64().unwrap_or(0);
+    let title = pr["title"].as_str().unwrap_or("???");
+    let reviews = pr["reviewDecision"].as_str().unwrap_or("PENDING");
+    let mut out = format!("  #{} {} [{}]", number, truncate(title, 50), reviews);
+
+    if let Some(checks) = pr["statusCheckRollup"].as_array() {
+        let total = checks.len();
+        if total > 0 {
+            let passed = checks
+                .iter()
+                .filter(|c| {
+                    c["conclusion"].as_str() == Some("SUCCESS")
+                        || c["state"].as_str() == Some("SUCCESS")
+                })
+                .count();
+            let failed = checks
+                .iter()
+                .filter(|c| {
+                    c["conclusion"].as_str() == Some("FAILURE")
+                        || c["state"].as_str() == Some("FAILURE")
+                })
+                .count();
+
+            out.push_str(&format!(" checks {}/{}", passed, total));
+            if failed > 0 {
+                out.push_str(&format!(" fail {}", failed));
+            }
+        }
+    }
+
+    out.push('\n');
     out
 }
 
@@ -1118,6 +1180,67 @@ mod tests {
     #[test]
     fn test_should_passthrough_pr_view_comments() {
         assert!(should_passthrough_pr_view(&["--comments".into()]));
+    }
+
+    #[test]
+    fn test_should_passthrough_pr_status_help() {
+        assert!(should_passthrough_pr_status(&["--help".into()]));
+        assert!(should_passthrough_pr_status(&["-h".into()]));
+    }
+
+    #[test]
+    fn test_should_passthrough_pr_status_output_transform_flags() {
+        assert!(should_passthrough_pr_status(&["--web".into()]));
+        assert!(should_passthrough_pr_status(&[
+            "--jq".into(),
+            ".currentBranch".into()
+        ]));
+        assert!(should_passthrough_pr_status(&[
+            "--template".into(),
+            "{{.currentBranch.title}}".into()
+        ]));
+    }
+
+    #[test]
+    fn test_should_passthrough_pr_status_repo_flag_stays_filtered() {
+        assert!(!should_passthrough_pr_status(&[
+            "-R".into(),
+            "owner/repo".into()
+        ]));
+    }
+
+    #[test]
+    fn test_pr_status_json_fields_excludes_current_branch() {
+        let fields = pr_status_json_fields();
+        assert!(!fields.contains("currentBranch"));
+        assert!(fields.contains("number"));
+        assert!(fields.contains("title"));
+        assert!(fields.contains("reviewDecision"));
+        assert!(fields.contains("statusCheckRollup"));
+    }
+
+    #[test]
+    fn test_format_pr_status_includes_current_branch_summary() {
+        let json = serde_json::json!({
+            "currentBranch": {
+                "number": 934,
+                "title": "fix wrappers for standardization and exit codes",
+                "reviewDecision": "CHANGES_REQUESTED",
+                "statusCheckRollup": [
+                    {"conclusion": "SUCCESS"},
+                    {"state": "SUCCESS"},
+                    {"conclusion": "FAILURE"}
+                ]
+            },
+            "createdBy": []
+        });
+
+        let result = format_pr_status(&json);
+        assert!(result.contains("Current Branch"));
+        assert!(result.contains("#934"));
+        assert!(result.contains("CHANGES_REQUESTED"));
+        assert!(result.contains("checks 2/3"));
+        assert!(result.contains("fail 1"));
     }
 
     // --- should_passthrough_issue_view tests ---


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

Fixed the gh pr status wrapper so it no longer requests the invalid currentBranch field in --json. The change also restores forwarding for normal status arguments like -R and passes through output-control options such as --help, --jq, --template, and --web directly to upstream gh.

Closes #960 

## Test plan
<!-- How did you verify this works? -->

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
