### PR TITLE
fix: preserve comments in minimal read filter

### DIFF
--- a/src/core/filter.rs
+++ b/src/core/filter.rs
@@ -163,81 +163,89 @@ pub struct MinimalFilter;
 
 lazy_static! {
     static ref MULTIPLE_BLANK_LINES: Regex = Regex::new(r"\n{3,}").unwrap();
-    static ref TRAILING_WHITESPACE: Regex = Regex::new(r"[ \t]+$").unwrap();
 }
 
 impl FilterStrategy for MinimalFilter {
-    fn filter(&self, content: &str, lang: &Language) -> String {
-        let patterns = lang.comment_patterns();
-        let mut result = String::with_capacity(content.len());
-        let mut in_block_comment = false;
-        let mut in_docstring = false;
-
-        for line in content.lines() {
-            let trimmed = line.trim();
-
-            // Handle block comments
-            if let (Some(start), Some(end)) = (patterns.block_start, patterns.block_end) {
-                if !in_docstring
-                    && trimmed.contains(start)
-                    && !trimmed.starts_with(patterns.doc_block_start.unwrap_or("###"))
-                {
-                    in_block_comment = true;
-                }
-                if in_block_comment {
-                    if trimmed.contains(end) {
-                        in_block_comment = false;
-                    }
-                    continue;
-                }
-            }
-
-            // Handle Python docstrings (keep them in minimal mode)
-            if *lang == Language::Python && trimmed.starts_with("\"\"\"") {
-                in_docstring = !in_docstring;
-                result.push_str(line);
-                result.push('\n');
-                continue;
-            }
-
-            if in_docstring {
-                result.push_str(line);
-                result.push('\n');
-                continue;
-            }
-
-            // Skip single-line comments (but keep doc comments)
-            if let Some(line_comment) = patterns.line {
-                if trimmed.starts_with(line_comment) {
-                    // Keep doc comments
-                    if let Some(doc) = patterns.doc_line {
-                        if trimmed.starts_with(doc) {
-                            result.push_str(line);
-                            result.push('\n');
-                        }
-                    }
-                    continue;
-                }
-            }
-
-            // Skip empty lines at this point, we'll normalize later
-            if trimmed.is_empty() {
-                result.push('\n');
-                continue;
-            }
-
-            result.push_str(line);
-            result.push('\n');
-        }
-
-        // Normalize multiple blank lines to max 2
-        let result = MULTIPLE_BLANK_LINES.replace_all(&result, "\n\n");
-        result.trim().to_string()
+    fn filter(&self, content: &str, _lang: &Language) -> String {
+        lightly_normalize(content)
     }
 
     fn name(&self) -> &'static str {
         "minimal"
     }
+}
+
+fn lightly_normalize(content: &str) -> String {
+    let mut result = String::with_capacity(content.len());
+
+    for line in content.lines() {
+        result.push_str(line.trim_end_matches([' ', '\t']));
+        result.push('\n');
+    }
+
+    let result = MULTIPLE_BLANK_LINES.replace_all(&result, "\n\n");
+    result.trim().to_string()
+}
+
+fn strip_comments_preserving_docs(content: &str, lang: &Language) -> String {
+    let patterns = lang.comment_patterns();
+    let mut result = String::with_capacity(content.len());
+    let mut in_block_comment = false;
+    let mut in_docstring = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        if let (Some(start), Some(end)) = (patterns.block_start, patterns.block_end) {
+            if !in_docstring
+                && trimmed.contains(start)
+                && !trimmed.starts_with(patterns.doc_block_start.unwrap_or("###"))
+            {
+                in_block_comment = true;
+            }
+            if in_block_comment {
+                if trimmed.contains(end) {
+                    in_block_comment = false;
+                }
+                continue;
+            }
+        }
+
+        if *lang == Language::Python && trimmed.starts_with("\"\"\"") {
+            in_docstring = !in_docstring;
+            result.push_str(line);
+            result.push('\n');
+            continue;
+        }
+
+        if in_docstring {
+            result.push_str(line);
+            result.push('\n');
+            continue;
+        }
+
+        if let Some(line_comment) = patterns.line {
+            if trimmed.starts_with(line_comment) {
+                if let Some(doc) = patterns.doc_line {
+                    if trimmed.starts_with(doc) {
+                        result.push_str(line);
+                        result.push('\n');
+                    }
+                }
+                continue;
+            }
+        }
+
+        if trimmed.is_empty() {
+            result.push('\n');
+            continue;
+        }
+
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    lightly_normalize(&result)
 }
 
 pub struct AggressiveFilter;
@@ -258,7 +266,7 @@ impl FilterStrategy for AggressiveFilter {
             return MinimalFilter.filter(content, lang);
         }
 
-        let minimal = MinimalFilter.filter(content, lang);
+        let minimal = strip_comments_preserving_docs(content, lang);
         let mut result = String::with_capacity(minimal.len() / 2);
         let mut brace_depth = 0;
         let mut in_impl_body = false;
@@ -481,14 +489,30 @@ mod tests {
     }
 
     #[test]
-    fn test_minimal_filter_removes_comments() {
+    fn test_minimal_filter_preserves_comments() {
+        let code = r#"
+// This is a comment
+/* block comment */
+fn main() {
+    println!("Hello");
+}
+"#;
+        let filter = MinimalFilter;
+        let result = filter.filter(code, &Language::Rust);
+        assert!(result.contains("// This is a comment"));
+        assert!(result.contains("/* block comment */"));
+        assert!(result.contains("fn main()"));
+    }
+
+    #[test]
+    fn test_aggressive_filter_still_removes_comments() {
         let code = r#"
 // This is a comment
 fn main() {
     println!("Hello");
 }
 "#;
-        let filter = MinimalFilter;
+        let filter = AggressiveFilter;
         let result = filter.filter(code, &Language::Rust);
         assert!(!result.contains("// This is a comment"));
         assert!(result.contains("fn main()"));


### PR DESCRIPTION
## Summary

This change keeps comments visible when `rtk read --level minimal` is used.

- make `MinimalFilter` only normalize trailing whitespace and repeated blank lines
- move comment stripping into a dedicated helper used by `AggressiveFilter`
- add regression tests for both minimal and aggressive behavior

## Why

`minimal` was still dropping source comments, which made `rtk read` less useful when the reader needed inline notes, rationale, or TODO context from the file.

## Verification

- `cargo +stable test test_minimal_filter_preserves_comments -- --nocapture`
- `cargo +stable test test_aggressive_filter_still_removes_comments -- --nocapture`
- `cargo +stable test test_json_no_comment_stripping -- --nocapture`
