### PR TITLE
fix(grep): close subprocess stdin to prevent memory leak (#897)

### DIFF
--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -6,6 +6,7 @@ use crate::core::utils::{exit_code_from_output, resolved_command};
 use anyhow::{Context, Result};
 use regex::Regex;
 use std::collections::HashMap;
+use std::process::Stdio;
 
 #[allow(clippy::too_many_arguments)]
 pub fn run(
@@ -28,7 +29,9 @@ pub fn run(
     let rg_pattern = pattern.replace(r"\|", "|");
 
     let mut rg_cmd = resolved_command("rg");
-    rg_cmd.args(["-n", "--no-heading", &rg_pattern, path]);
+    rg_cmd
+        .args(["-n", "--no-heading", &rg_pattern, path])
+        .stdin(Stdio::null());
 
     if let Some(ft) = file_type {
         rg_cmd.arg("--type").arg(ft);
@@ -47,6 +50,7 @@ pub fn run(
         .or_else(|_| {
             resolved_command("grep")
                 .args(["-rn", pattern, path])
+                .stdin(Stdio::null())
                 .output()
         })
         .context("grep/rg failed")?;


### PR DESCRIPTION
## Summary

- Set `stdin(Stdio::null())` on both `rg` and `grep` fallback subprocess commands
- Prevents grep processes from inheriting the hook's open stdin pipe and blocking indefinitely

## Problem

When RTK runs via Claude Code's PreToolUse hook, grep/rg subprocesses inherit the hook's open stdin pipe. They block waiting for EOF and never terminate, accumulating memory unboundedly. Reported: 8 concurrent grep processes consumed ~514GB (RAM + swap) on a 96GB Mac Studio, triggering a kernel panic.

## Fix

3 lines: import `Stdio` + `.stdin(Stdio::null())` on both `Command` invocations (rg primary + grep fallback).

Fixes #897

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets` — no new warnings
- [x] `cargo test grep` — 11 tests passed