### PR TITLE
fix(gh): pass through gh pr merge instead of canned response (#938)

### DIFF
--- a/src/cmds/git/gh_cmd.rs
+++ b/src/cmds/git/gh_cmd.rs
@@ -785,31 +785,13 @@ fn pr_create(args: &[String], _verbose: u8) -> Result<i32> {
 }
 
 fn pr_merge(args: &[String], _verbose: u8) -> Result<i32> {
-    let pr_num = args
-        .iter()
-        .find(|a| !a.starts_with('-'))
-        .map(|s| s.as_str())
-        .unwrap_or("")
-        .to_string();
-    let mut cmd = resolved_command("gh");
-    cmd.args(["pr", "merge"]);
-    for arg in args {
-        cmd.arg(arg);
-    }
-    runner::run_filtered(
-        cmd,
-        "gh",
-        "pr merge",
-        move |_stdout| {
-            let detail = if !pr_num.is_empty() {
-                format!("#{}", pr_num)
-            } else {
-                String::new()
-            };
-            ok_confirmation("merged", &detail)
-        },
-        RunOptions::stdout_only().early_exit_on_failure(),
-    )
+    // gh pr merge is a destructive action — pass through the real output
+    // so the user (or AI agent) sees exactly what happened.
+    run_passthrough("gh", "pr", &{
+        let mut a = vec!["merge".to_string()];
+        a.extend_from_slice(args);
+        a
+    })
 }
 
 /// Flags that change `gh pr diff` output from unified diff to a different format.


### PR DESCRIPTION
## Summary

- Replace `run_filtered` with `run_passthrough` for `gh pr merge`
- Shows real `gh` output instead of hardcoded "ok merged"

## Problem

`pr_merge()` used `run_filtered` with a filter function that ignored stdout and always returned `ok_confirmation("merged", ...)`. AI agents believed PRs were merged when they weren't — PRs remained OPEN while output said "ok merged".

## Fix

Switch to `run_passthrough` — `gh pr merge` is a destructive action, the user/agent must see real output. `-25/+7` lines.

Fixes #938

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets` — no new warnings
- [x] `cargo test gh_cmd` — 52 tests passed