### PR TITLE
feat: add --reset flag to rtk gain command

### DIFF
--- a/src/analytics/gain.rs
+++ b/src/analytics/gain.rs
@@ -24,10 +24,19 @@ pub fn run(
     all: bool,
     format: &str,
     failures: bool,
+    reset: bool,
     _verbose: u8,
 ) -> Result<()> {
     let tracker = Tracker::new().context("Failed to initialize tracking database")?;
     let project_scope = resolve_project_scope(project)?; // added: resolve project path
+
+    if reset {
+        tracker
+            .reset_all()
+            .context("Failed to reset token savings")?;
+        println!("{}", "Token savings stats reset to zero.".green());
+        return Ok(());
+    }
 
     if failures {
         return show_failures(&tracker);

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -29,7 +29,7 @@
 //!
 //! See [docs/tracking.md](../docs/tracking.md) for full documentation.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection};
 use serde::Serialize;
@@ -395,6 +395,14 @@ impl Tracker {
             "DELETE FROM parse_failures WHERE timestamp < ?1",
             params![cutoff.to_rfc3339()],
         )?;
+        Ok(())
+    }
+
+    /// Delete all tracked commands, resetting savings stats to zero.
+    pub fn reset_all(&self) -> Result<()> {
+        self.conn
+            .execute("DELETE FROM commands", [])
+            .context("Failed to reset tracking data")?;
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -403,6 +403,9 @@ enum Commands {
         /// Show parse failure log (commands that fell back to raw execution)
         #[arg(short = 'F', long)]
         failures: bool,
+        /// Reset all token savings stats to zero
+        #[arg(long)]
+        reset: bool,
     },
 
     /// Claude Code economics: spending (ccusage) vs savings (rtk) analysis
@@ -1665,6 +1668,7 @@ fn run_cli() -> Result<i32> {
             all,
             format,
             failures,
+            reset,
         } => {
             analytics::gain::run(
                 project, // added: pass project flag
@@ -1678,6 +1682,7 @@ fn run_cli() -> Result<i32> {
                 all,
                 &format,
                 failures,
+                reset,
                 cli.verbose,
             )?;
             0


### PR DESCRIPTION
Adds `rtk gain --reset` to clear all token savings stats back to zero. Implements `Tracker::reset_all()` in tracking.rs and wires the flag through the Gain command args and gain::run().

https://claude.ai/code/session_015WXbDdxEU3pXPBtheDkXcd

## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

-

## Test plan
<!-- How did you verify this works? -->

- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
