### PR TITLE
feat(gains): add --reset flag to rtk gain command

### DIFF
--- a/src/analytics/gain.rs
+++ b/src/analytics/gain.rs
@@ -25,12 +25,17 @@ pub fn run(
     format: &str,
     failures: bool,
     reset: bool,
+    yes: bool,
     _verbose: u8,
 ) -> Result<()> {
     let tracker = Tracker::new().context("Failed to initialize tracking database")?;
     let project_scope = resolve_project_scope(project)?; // added: resolve project path
 
     if reset {
+        if !yes && !confirm_reset()? {
+            println!("Aborted.");
+            return Ok(());
+        }
         tracker
             .reset_all()
             .context("Failed to reset token savings")?;
@@ -733,4 +738,27 @@ fn show_failures(tracker: &Tracker) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Prompt the user to confirm a destructive reset operation.
+/// Defaults to No in non-interactive (piped) environments.
+fn confirm_reset() -> Result<bool> {
+    use std::io::{self, BufRead, IsTerminal, Write};
+
+    eprint!("This will permanently delete all tracking data. Continue? [y/N] ");
+    io::stderr().flush().ok();
+
+    if !io::stdin().is_terminal() {
+        eprintln!("(non-interactive mode, defaulting to N)");
+        return Ok(false);
+    }
+
+    let stdin = io::stdin();
+    let mut line = String::new();
+    stdin
+        .lock()
+        .read_line(&mut line)
+        .context("Failed to read confirmation")?;
+
+    Ok(matches!(line.trim().to_lowercase().as_str(), "y" | "yes"))
 }

--- a/src/analytics/gain.rs
+++ b/src/analytics/gain.rs
@@ -24,10 +24,19 @@ pub fn run(
     all: bool,
     format: &str,
     failures: bool,
+    reset: bool,
     _verbose: u8,
 ) -> Result<()> {
     let tracker = Tracker::new().context("Failed to initialize tracking database")?;
     let project_scope = resolve_project_scope(project)?; // added: resolve project path
+
+    if reset {
+        tracker
+            .reset_all()
+            .context("Failed to reset token savings")?;
+        println!("{}", "Token savings stats reset to zero.".green());
+        return Ok(());
+    }
 
     if failures {
         return show_failures(&tracker);

--- a/src/analytics/gain.rs
+++ b/src/analytics/gain.rs
@@ -39,7 +39,7 @@ pub fn run(
         tracker
             .reset_all()
             .context("Failed to reset token savings")?;
-        println!("{}", "Token savings stats reset to zero.".green());
+        println!("{}", styled("Token savings stats reset to zero.", true));
         return Ok(());
     }
 

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -398,11 +398,16 @@ impl Tracker {
         Ok(())
     }
 
-    /// Delete all tracked commands, resetting savings stats to zero.
+    /// Delete all tracked data (commands + parse_failures), resetting all stats to zero.
     pub fn reset_all(&self) -> Result<()> {
         self.conn
-            .execute("DELETE FROM commands", [])
-            .context("Failed to reset tracking data")?;
+            .execute_batch(
+                "BEGIN;
+                 DELETE FROM commands;
+                 DELETE FROM parse_failures;
+                 COMMIT;",
+            )
+            .context("Failed to reset tracking database")?;
         Ok(())
     }
 
@@ -1396,5 +1401,45 @@ mod tests {
         // We can't assert exact rate because other tests may have added records,
         // but we can verify recovery_rate is between 0 and 100
         assert!(summary.recovery_rate >= 0.0 && summary.recovery_rate <= 100.0);
+    }
+
+    #[test]
+    fn test_reset_all_clears_both_tables() {
+        let tracker = Tracker::new().expect("Failed to create tracker");
+        let pid = std::process::id();
+
+        // Insert into commands
+        tracker
+            .record(
+                "git status",
+                &format!("rtk git status reset_test_{}", pid),
+                100,
+                20,
+                50,
+            )
+            .expect("Failed to record command");
+
+        // Insert into parse_failures
+        tracker
+            .record_parse_failure(&format!("bad_cmd_reset_test_{}", pid), "parse error", false)
+            .expect("Failed to record parse failure");
+
+        // Reset everything
+        tracker.reset_all().expect("Failed to reset");
+
+        // Both tables should be empty
+        let summary = tracker.get_summary().expect("Failed to get summary");
+        assert_eq!(
+            summary.total_commands, 0,
+            "commands table should be empty after reset"
+        );
+
+        let failures = tracker
+            .get_parse_failure_summary()
+            .expect("Failed to get failure summary");
+        assert_eq!(
+            failures.total, 0,
+            "parse_failures table should be empty after reset"
+        );
     }
 }

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -29,7 +29,7 @@
 //!
 //! See [docs/tracking.md](../docs/tracking.md) for full documentation.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection};
 use serde::Serialize;
@@ -395,6 +395,14 @@ impl Tracker {
             "DELETE FROM parse_failures WHERE timestamp < ?1",
             params![cutoff.to_rfc3339()],
         )?;
+        Ok(())
+    }
+
+    /// Delete all tracked commands, resetting savings stats to zero.
+    pub fn reset_all(&self) -> Result<()> {
+        self.conn
+            .execute("DELETE FROM commands", [])
+            .context("Failed to reset tracking data")?;
         Ok(())
     }
 

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -326,6 +326,56 @@ impl Tracker {
         Ok(Self { conn })
     }
 
+    /// Create an isolated in-memory tracker for tests.
+    #[cfg(test)]
+    pub fn new_in_memory() -> Result<Self> {
+        let conn = Connection::open_in_memory().context("Failed to open in-memory DB")?;
+        let tracker = Self { conn };
+        tracker.init_schema()?;
+        Ok(tracker)
+    }
+
+    fn init_schema(&self) -> Result<()> {
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS commands (
+                id INTEGER PRIMARY KEY,
+                timestamp TEXT NOT NULL,
+                original_cmd TEXT NOT NULL,
+                rtk_cmd TEXT NOT NULL,
+                input_tokens INTEGER NOT NULL,
+                output_tokens INTEGER NOT NULL,
+                saved_tokens INTEGER NOT NULL,
+                savings_pct REAL NOT NULL,
+                exec_time_ms INTEGER DEFAULT 0,
+                project_path TEXT DEFAULT ''
+            )",
+            [],
+        )?;
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_timestamp ON commands(timestamp)",
+            [],
+        )?;
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_project_path_timestamp ON commands(project_path, timestamp)",
+            [],
+        )?;
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS parse_failures (
+                id INTEGER PRIMARY KEY,
+                timestamp TEXT NOT NULL,
+                raw_command TEXT NOT NULL,
+                error_message TEXT NOT NULL,
+                fallback_succeeded INTEGER NOT NULL DEFAULT 0
+            )",
+            [],
+        )?;
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_pf_timestamp ON parse_failures(timestamp)",
+            [],
+        )?;
+        Ok(())
+    }
+
     /// Record a command execution with token counts and timing.
     ///
     /// Calculates savings metrics and stores the record in the database.
@@ -1405,7 +1455,7 @@ mod tests {
 
     #[test]
     fn test_reset_all_clears_both_tables() {
-        let tracker = Tracker::new().expect("Failed to create tracker");
+        let tracker = Tracker::new_in_memory().expect("Failed to create in-memory tracker");
         let pid = std::process::id();
 
         // Insert into commands

--- a/src/main.rs
+++ b/src/main.rs
@@ -406,6 +406,9 @@ enum Commands {
         /// Reset all token savings stats to zero
         #[arg(long)]
         reset: bool,
+        /// Skip confirmation prompt when resetting
+        #[arg(long, requires = "reset")]
+        yes: bool,
     },
 
     /// Claude Code economics: spending (ccusage) vs savings (rtk) analysis
@@ -1669,6 +1672,7 @@ fn run_cli() -> Result<i32> {
             format,
             failures,
             reset,
+            yes,
         } => {
             analytics::gain::run(
                 project, // added: pass project flag
@@ -1683,6 +1687,7 @@ fn run_cli() -> Result<i32> {
                 &format,
                 failures,
                 reset,
+                yes,
                 cli.verbose,
             )?;
             0

--- a/src/main.rs
+++ b/src/main.rs
@@ -403,6 +403,9 @@ enum Commands {
         /// Show parse failure log (commands that fell back to raw execution)
         #[arg(short = 'F', long)]
         failures: bool,
+        /// Reset all token savings stats to zero
+        #[arg(long)]
+        reset: bool,
     },
 
     /// Claude Code economics: spending (ccusage) vs savings (rtk) analysis
@@ -1665,6 +1668,7 @@ fn run_cli() -> Result<i32> {
             all,
             format,
             failures,
+            reset,
         } => {
             analytics::gain::run(
                 project, // added: pass project flag
@@ -1678,6 +1682,7 @@ fn run_cli() -> Result<i32> {
                 all,
                 &format,
                 failures,
+                reset,
                 cli.verbose,
             )?;
             0


### PR DESCRIPTION
Adds `rtk gain --reset` to clear all token savings stats back to zero. Implements `Tracker::reset_all()` in tracking.rs and wires the flag through the Gain command args and gain::run().

https://claude.ai/code/session_015WXbDdxEU3pXPBtheDkXcd

## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

-

## Test plan
<!-- How did you verify this works? -->

- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
