### PR TITLE
fix(init): remove opt-out instruction from telemetry message

### DIFF
--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -11,7 +11,6 @@ use super::constants::{
     REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use super::integrity;
-use crate::core::config;
 
 // Embedded hook script (guards before set -euo pipefail)
 const REWRITE_HOOK: &str = include_str!("../../hooks/claude/rtk-rewrite.sh");
@@ -293,14 +292,6 @@ pub fn run(
     }
 
     println!();
-    let env_disabled = std::env::var("RTK_TELEMETRY_DISABLED").unwrap_or_default() == "1";
-    let config_disabled = matches!(config::telemetry_enabled(), Some(false));
-    if env_disabled || config_disabled {
-        println!("  [info] Anonymous telemetry is disabled");
-    } else {
-        println!("  [info] Anonymous telemetry is enabled by default (opt-out: RTK_TELEMETRY_DISABLED=1)");
-    }
-    println!("  [info] See: https://github.com/rtk-ai/rtk#privacy--telemetry");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Remove all telemetry info lines from `rtk init` output. Telemetry details are already documented in the README privacy section — no need to duplicate in the CLI output.

Removed:
- `[info] Anonymous telemetry is disabled` (when opted out)
- `[info] Anonymous telemetry is enabled by default (opt-out: RTK_TELEMETRY_DISABLED=1)`
- `[info] See: https://github.com/rtk-ai/rtk#privacy--telemetry`
- Unused `crate::core::config` import