### PR TITLE
fix(pnpm): install don't take a list of packages

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -296,9 +296,9 @@ rtk git push          # → "ok ✓ main"
 
 ### Pnpm (fork only)
 ```bash
-rtk pnpm list         # Dependency tree (-70% tokens)
-rtk pnpm outdated     # Available updates (-80-90%)
-rtk pnpm install pkg  # Silent installation
+rtk pnpm list     # Dependency tree (-70% tokens)
+rtk pnpm outdated # Available updates (-80-90%)
+rtk pnpm install  # Silent installation
 ```
 
 ### Tests

--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -799,7 +799,7 @@ Detecte automatiquement : prettier, black, ruff format, rustfmt. Applique un fil
 |----------|-------------|-----------|
 | `rtk pnpm list [-d N]` | Arbre de dependances compact | ~70% |
 | `rtk pnpm outdated` | Paquets obsoletes : `pkg: old -> new` | ~80% |
-| `rtk pnpm install [pkgs...]` | Filtre les barres de progression | ~60% |
+| `rtk pnpm install` | Filtre les barres de progression | ~60% |
 | `rtk pnpm build` | Delegue au filtre Next.js | ~87% |
 | `rtk pnpm typecheck` | Delegue au filtre tsc | ~83% |
 

--- a/src/cmds/js/pnpm_cmd.rs
+++ b/src/cmds/js/pnpm_cmd.rs
@@ -262,34 +262,18 @@ fn extract_outdated_text(output: &str) -> Option<DependencyState> {
     }
 }
 
-/// Validates npm package name according to official rules
-fn is_valid_package_name(name: &str) -> bool {
-    if name.is_empty() || name.len() > 214 {
-        return false;
-    }
-
-    // No path traversal
-    if name.contains("..") {
-        return false;
-    }
-
-    // Only safe characters
-    name.chars()
-        .all(|c| c.is_alphanumeric() || matches!(c, '@' | '/' | '-' | '_' | '.'))
-}
-
 #[derive(Debug, Clone)]
 pub enum PnpmCommand {
     List { depth: usize },
     Outdated,
-    Install { packages: Vec<String> },
+    Install,
 }
 
 pub fn run(cmd: PnpmCommand, args: &[String], verbose: u8) -> Result<i32> {
     match cmd {
         PnpmCommand::List { depth } => run_list(depth, args, verbose),
         PnpmCommand::Outdated => run_outdated(args, verbose),
-        PnpmCommand::Install { packages } => run_install(&packages, args, verbose),
+        PnpmCommand::Install => run_install(args, verbose),
     }
 }
 
@@ -401,25 +385,11 @@ fn run_outdated(args: &[String], verbose: u8) -> Result<i32> {
     Ok(0)
 }
 
-fn run_install(packages: &[String], args: &[String], verbose: u8) -> Result<i32> {
+fn run_install(args: &[String], verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
-
-    // Validate package names to prevent command injection
-    for pkg in packages {
-        if !is_valid_package_name(pkg) {
-            anyhow::bail!(
-                "Invalid package name: '{}' (contains unsafe characters)",
-                pkg
-            );
-        }
-    }
 
     let mut cmd = resolved_command("pnpm");
     cmd.arg("install");
-
-    for pkg in packages {
-        cmd.arg(pkg);
-    }
 
     for arg in args {
         cmd.arg(arg);
@@ -444,8 +414,8 @@ fn run_install(packages: &[String], args: &[String], verbose: u8) -> Result<i32>
     println!("{}", filtered);
 
     timer.track(
-        &format!("pnpm install {}", packages.join(" ")),
-        &format!("rtk pnpm install {}", packages.join(" ")),
+        &format!("pnpm install"),
+        &format!("rtk pnpm install"),
         &combined,
         &filtered,
     );
@@ -538,14 +508,6 @@ mod tests {
         let data = result.unwrap();
         assert_eq!(data.outdated_count, 1);
         assert_eq!(data.dependencies[0].name, "express");
-    }
-
-    #[test]
-    fn test_package_name_validation() {
-        assert!(is_valid_package_name("lodash"));
-        assert!(is_valid_package_name("@clerk/express"));
-        assert!(!is_valid_package_name("../../../etc/passwd"));
-        assert!(!is_valid_package_name("lodash; rm -rf /"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -801,8 +801,6 @@ enum PnpmCommands {
     },
     /// Install packages (filter progress bars)
     Install {
-        /// Packages to install
-        packages: Vec<String>,
         /// Additional pnpm arguments
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
@@ -1486,8 +1484,8 @@ fn run_cli() -> Result<i32> {
                     &merge_pnpm_args(&filter, &args),
                     cli.verbose,
                 )?,
-                PnpmCommands::Install { packages, args } => pnpm_cmd::run(
-                    pnpm_cmd::PnpmCommand::Install { packages },
+                PnpmCommands::Install { args } => pnpm_cmd::run(
+                    pnpm_cmd::PnpmCommand::Install,
                     &merge_pnpm_args(&filter, &args),
                     cli.verbose,
                 )?,


### PR DESCRIPTION
## Summary
Remove packages handling for pnpm install command.

While testing another PR, I stumbled across this error:
```sh
$ cargo run -- pnpm install -h
thread 'main' (239705) panicked at ~/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap_builder-4.5.60/src/builder/debug_asserts.rs:570:9:
Positional argument `[ARGS]...` *must* have `required(true)` or `last(true)` set because a prior positional argument (`[PACKAGES]...`) has `num_args(1..)`
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
Upon checking [pnpm documentation](https://pnpm.io/11.x/cli/install), it turns out that pnpm install doesn't take a list of packages.

## Test plan
<!-- How did you verify this works? -->

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected
