### PR TITLE
Skip redundant hook warning during rtk init

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1228,8 +1228,11 @@ fn run_cli() -> Result<i32> {
     };
 
     // Warn if installed hook is outdated/missing (1/day, non-blocking).
-    // Skip for Gain — it shows its own inline hook warning.
-    if !matches!(cli.command, Commands::Gain { .. }) {
+    if matches!(cli.command, Commands::Init { .. }) {
+        // Skip for Init — it is about to install/update hooks itself.
+        eprintln!("[rtk] Installing RTK hook");
+    } else if !matches!(cli.command, Commands::Gain { .. }) {
+        // Skip for Gain — it shows its own inline hook warning.
         hooks::hook_check::maybe_warn();
     }
 


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

This fixes https://github.com/rtk-ai/rtk/issues/1011.
- Skip `maybe_warn()` hook check when the command is `Init`, since it's about to install/update hooks itself
- Print `[rtk] Installing RTK hook` instead of the misleading "No hook installed" warning
- Matches existing pattern where `Gain` already skips the check



## Test plan
<!-- How did you verify this works? -->

- [ ] Pre-test: clean up any previous markers first, with `rtk init -g --uninstall` and `rm ~/Library/Application\ Support/rtk/.hook_warn_last`, then rebuild the binary.
- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test`. All pass.
- [ ] Manual testing: `rtk init -g` output inspected. The message now reads "Installing RTK hook" instead of "No hook installed".

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
