### PR TITLE
fix(read): preserve exact head semantics

### DIFF
--- a/docs/contributing/TECHNICAL.md
+++ b/docs/contributing/TECHNICAL.md
@@ -161,7 +161,7 @@ rewrite_segment(seg, excluded)                     [src/discover/registry.rs]
   |  Step 4 — Already RTK → return as-is
   |
   |  Step 5 — Special cases (short-circuit before classification)
-  |  head -N / --lines=N → rewrite_line_range() → "rtk read file --max-lines N"
+  |  head -N / -n N / --lines[= ]N → rewrite_line_range() → "rtk read file --head-lines N"
   |  tail -N / -n N / --lines N → rewrite_line_range() → "rtk read file --tail-lines N"
   |  head/tail with unsupported flag (-c, -f) → None (skip rewrite)
   |  cat with incompatible flag (-A, -v, -e) → None (skip rewrite)

--- a/src/cmds/system/read.rs
+++ b/src/cmds/system/read.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 pub fn run(
     file: &Path,
     level: FilterLevel,
+    head_lines: Option<usize>,
     max_lines: Option<usize>,
     tail_lines: Option<usize>,
     line_numbers: bool,
@@ -63,7 +64,7 @@ pub fn run(
         );
     }
 
-    filtered = apply_line_window(&filtered, max_lines, tail_lines, &lang);
+    filtered = apply_line_window(&filtered, head_lines, max_lines, tail_lines, &lang);
 
     let rtk_output = if line_numbers {
         format_with_line_numbers(&filtered)
@@ -82,6 +83,7 @@ pub fn run(
 
 pub fn run_stdin(
     level: FilterLevel,
+    head_lines: Option<usize>,
     max_lines: Option<usize>,
     tail_lines: Option<usize>,
     line_numbers: bool,
@@ -127,7 +129,7 @@ pub fn run_stdin(
         );
     }
 
-    filtered = apply_line_window(&filtered, max_lines, tail_lines, &lang);
+    filtered = apply_line_window(&filtered, head_lines, max_lines, tail_lines, &lang);
 
     let rtk_output = if line_numbers {
         format_with_line_numbers(&filtered)
@@ -152,10 +154,24 @@ fn format_with_line_numbers(content: &str) -> String {
 
 fn apply_line_window(
     content: &str,
+    head_lines: Option<usize>,
     max_lines: Option<usize>,
     tail_lines: Option<usize>,
     lang: &Language,
 ) -> String {
+    if let Some(head) = head_lines {
+        if head == 0 {
+            return String::new();
+        }
+        let lines: Vec<&str> = content.lines().collect();
+        let end = lines.len().min(head);
+        let mut result = lines[..end].join("\n");
+        if !result.is_empty() && content.ends_with('\n') {
+            result.push('\n');
+        }
+        return result;
+    }
+
     if let Some(tail) = tail_lines {
         if tail == 0 {
             return String::new();
@@ -194,7 +210,7 @@ fn main() {{
         )?;
 
         // Just verify it doesn't panic
-        run(file.path(), FilterLevel::Minimal, None, None, false, 0)?;
+        run(file.path(), FilterLevel::Minimal, None, None, None, false, 0)?;
         Ok(())
     }
 
@@ -208,23 +224,37 @@ fn main() {{
     #[test]
     fn test_apply_line_window_tail_lines() {
         let input = "a\nb\nc\nd\n";
-        let output = apply_line_window(input, None, Some(2), &Language::Unknown);
+        let output = apply_line_window(input, None, None, Some(2), &Language::Unknown);
         assert_eq!(output, "c\nd\n");
     }
 
     #[test]
     fn test_apply_line_window_tail_lines_no_trailing_newline() {
         let input = "a\nb\nc\nd";
-        let output = apply_line_window(input, None, Some(2), &Language::Unknown);
+        let output = apply_line_window(input, None, None, Some(2), &Language::Unknown);
         assert_eq!(output, "c\nd");
     }
 
     #[test]
     fn test_apply_line_window_max_lines_still_works() {
         let input = "a\nb\nc\nd\n";
-        let output = apply_line_window(input, Some(2), None, &Language::Unknown);
+        let output = apply_line_window(input, None, Some(2), None, &Language::Unknown);
         assert!(output.starts_with("a\n"));
         assert!(output.contains("more lines"));
+    }
+
+    #[test]
+    fn test_apply_line_window_head_lines_exact() {
+        let input = "a\nb\nc\nd\n";
+        let output = apply_line_window(input, Some(2), None, None, &Language::Unknown);
+        assert_eq!(output, "a\nb\n");
+    }
+
+    #[test]
+    fn test_apply_line_window_head_lines_no_trailing_newline() {
+        let input = "a\nb\nc\nd";
+        let output = apply_line_window(input, Some(2), None, None, &Language::Unknown);
+        assert_eq!(output, "a\nb");
     }
 
     fn rtk_bin() -> std::path::PathBuf {

--- a/src/discover/README.md
+++ b/src/discover/README.md
@@ -26,7 +26,7 @@ When a hook sends `cargo fmt --all && cargo test 2>&1 | tail -20`:
 **Per-segment rewriting** — Each segment goes through:
 
 1. Strip trailing redirects (`2>&1`, `>/dev/null`) — matched via lexer tokens, set aside, re-appended after rewriting
-2. Short-circuit special cases — `head -20 file` → `rtk read file --max-lines 20`, `tail -n 5 file` → `rtk read file --tail-lines 5`. These can't go through generic prefix replacement because it would produce `rtk read -20 file` (wrong flag position)
+2. Short-circuit special cases — `head -20 file` → `rtk read file --head-lines 20`, `tail -n 5 file` → `rtk read file --tail-lines 5`. These can't go through generic prefix replacement because it would produce `rtk read -20 file` (wrong flag position)
 3. Classify the command — strip env prefixes (`sudo`, `FOO="bar baz"`), normalize paths (`/usr/bin/grep` → `grep`), strip git global opts (`git -C /tmp` → `git`), then match against 60+ regex patterns from `rules.rs`
 4. Apply the rewrite — find the matching rule, replace the command prefix with `rtk <cmd>`, re-prepend the env prefix, re-append the redirect suffix
 

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -66,9 +66,11 @@ lazy_static! {
     // Issue #1362: each capture expects a SINGLE file argument (`\S+$`). Multi-file
     // invocations like `head -3 a b c` fail to match so the segment is passed through
     // to the native `head`/`tail` binary — which already handles multi-file with
-    // `==> name <==` banners that `rtk read --max-lines` cannot reproduce.
+    // `==> name <==` banners that `rtk read --head-lines`/`--tail-lines` cannot reproduce.
     static ref HEAD_N: Regex = Regex::new(r"^head\s+-(\d+)\s+(\S+)$").unwrap();
+    static ref HEAD_N_SPACE: Regex = Regex::new(r"^head\s+-n\s+(\d+)\s+(\S+)$").unwrap();
     static ref HEAD_LINES: Regex = Regex::new(r"^head\s+--lines=(\d+)\s+(\S+)$").unwrap();
+    static ref HEAD_LINES_SPACE: Regex = Regex::new(r"^head\s+--lines\s+(\d+)\s+(\S+)$").unwrap();
     static ref TAIL_N: Regex = Regex::new(r"^tail\s+-(\d+)\s+(\S+)$").unwrap();
     static ref TAIL_N_SPACE: Regex = Regex::new(r"^tail\s+-n\s+(\d+)\s+(\S+)$").unwrap();
     static ref TAIL_LINES_EQ: Regex = Regex::new(r"^tail\s+--lines=(\d+)\s+(\S+)$").unwrap();
@@ -601,15 +603,22 @@ fn rewrite_compound(
 }
 
 fn rewrite_line_range(cmd: &str) -> Option<String> {
-    for re in [&*HEAD_N, &*HEAD_LINES] {
+    for re in [&*HEAD_N, &*HEAD_N_SPACE, &*HEAD_LINES, &*HEAD_LINES_SPACE] {
         if let Some(caps) = re.captures(cmd) {
             let n = caps.get(1)?.as_str();
             let file = caps.get(2)?.as_str();
-            return Some(format!("rtk read {} --max-lines {}", file, n));
+            return Some(format!("rtk read {} --head-lines {}", file, n));
         }
     }
     if cmd.starts_with("head -") {
         return None;
+    }
+    if let Some(file) = cmd.strip_prefix("head ") {
+        let file = file.trim();
+        if file.is_empty() || file.starts_with('-') || file.split_whitespace().count() != 1 {
+            return None;
+        }
+        return Some(format!("rtk read {} --head-lines 10", file));
     }
     for re in [
         &*TAIL_N,
@@ -759,7 +768,7 @@ fn rewrite_segment_inner(
         return Some(trimmed.to_string());
     }
 
-    if cmd_part.starts_with("head -") || cmd_part.starts_with("tail ") {
+    if cmd_part.starts_with("head ") || cmd_part.starts_with("tail ") {
         return rewrite_line_range(cmd_part).map(|r| format!("{}{}", r, redirect_suffix));
     }
 
@@ -1728,10 +1737,10 @@ mod tests {
 
     #[test]
     fn test_rewrite_head_numeric_flag() {
-        // head -20 file → rtk read file --max-lines 20 (not rtk read -20 file)
+        // head -20 file → rtk read file --head-lines 20 (not rtk read -20 file)
         assert_eq!(
             rewrite_command_no_prefixes("head -20 src/main.rs", &[]),
-            Some("rtk read src/main.rs --max-lines 20".into())
+            Some("rtk read src/main.rs --head-lines 20".into())
         );
     }
 
@@ -1739,16 +1748,32 @@ mod tests {
     fn test_rewrite_head_lines_long_flag() {
         assert_eq!(
             rewrite_command_no_prefixes("head --lines=50 src/lib.rs", &[]),
-            Some("rtk read src/lib.rs --max-lines 50".into())
+            Some("rtk read src/lib.rs --head-lines 50".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_head_n_space_flag() {
+        assert_eq!(
+            rewrite_command_no_prefixes("head -n 12 src/lib.rs", &[]),
+            Some("rtk read src/lib.rs --head-lines 12".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_head_lines_space_flag() {
+        assert_eq!(
+            rewrite_command_no_prefixes("head --lines 7 src/lib.rs", &[]),
+            Some("rtk read src/lib.rs --head-lines 7".into())
         );
     }
 
     #[test]
     fn test_rewrite_head_no_flag_still_rewrites() {
-        // plain `head file` → `rtk read file` (no numeric flag)
+        // plain `head file` → exact default `head` width
         assert_eq!(
             rewrite_command_no_prefixes("head src/main.rs", &[]),
-            Some("rtk read src/main.rs".into())
+            Some("rtk read src/main.rs --head-lines 10".into())
         );
     }
 
@@ -1808,9 +1833,9 @@ mod tests {
 
     // --- Issue #1362: head/tail with multiple files falls back to native command ---
     //
-    // `rtk read <file> --max-lines N` only accepts a single positional file path in
+    // `rtk read <file> --head-lines/--tail-lines N` only accepts a single positional file path in
     // a shape that maps cleanly to `head -N`. Rewriting `head -N a b c` to
-    // `rtk read a b c --max-lines N` previously produced a command where `rtk read`
+    // `rtk read a b c --head-lines N` would produce a command where `rtk read`
     // would concatenate the files without the `==> name <==` banners that native
     // `head` emits, so the fix is to skip the rewrite and let the shell run the
     // real `head`/`tail` binary.
@@ -1827,6 +1852,14 @@ mod tests {
     fn test_rewrite_head_lines_long_flag_multi_file_skipped() {
         assert_eq!(
             rewrite_command_no_prefixes("head --lines=50 src/main.rs src/lib.rs", &[]),
+            None
+        );
+    }
+
+    #[test]
+    fn test_rewrite_head_plain_multi_file_skipped() {
+        assert_eq!(
+            rewrite_command_no_prefixes("head src/main.rs src/lib.rs", &[]),
             None
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,11 +99,14 @@ enum Commands {
         /// Filter: none (default, full content), minimal, aggressive
         #[arg(short, long, default_value = "none")]
         level: core::filter::FilterLevel,
+        /// Keep only first N lines exactly (internal head rewrite support)
+        #[arg(long, hide = true, conflicts_with_all = ["max_lines", "tail_lines"])]
+        head_lines: Option<usize>,
         /// Max lines
-        #[arg(short, long, conflicts_with = "tail_lines")]
+        #[arg(short, long, conflicts_with_all = ["head_lines", "tail_lines"])]
         max_lines: Option<usize>,
         /// Keep only last N lines
-        #[arg(long, conflicts_with = "max_lines")]
+        #[arg(long, conflicts_with_all = ["head_lines", "max_lines"])]
         tail_lines: Option<usize>,
         /// Show line numbers
         #[arg(short = 'n', long)]
@@ -1424,6 +1427,7 @@ fn run_cli() -> Result<i32> {
         Commands::Read {
             files,
             level,
+            head_lines,
             max_lines,
             tail_lines,
             line_numbers,
@@ -1437,11 +1441,19 @@ fn run_cli() -> Result<i32> {
                         continue;
                     }
                     stdin_seen = true;
-                    read::run_stdin(level, max_lines, tail_lines, line_numbers, cli.verbose)
+                    read::run_stdin(
+                        level,
+                        head_lines,
+                        max_lines,
+                        tail_lines,
+                        line_numbers,
+                        cli.verbose,
+                    )
                 } else {
                     read::run(
                         file,
                         level,
+                        head_lines,
                         max_lines,
                         tail_lines,
                         line_numbers,


### PR DESCRIPTION
## Summary
- preserve exact `head` semantics in rewrites by routing single-file `head` invocations through an internal `--head-lines` mode instead of `--max-lines`
- rewrite plain `head file` and numeric variants like `head -20`, `head -n 12`, and `head --lines 7` to exact top-line slicing
- keep existing `rtk read --max-lines` summarizing behavior unchanged for direct `rtk read` usage
- keep upstream's multi-file `head`/`tail` guard intact, so native banner semantics remain passthrough
- add focused regression coverage for rewrite routing, multi-file passthrough, and exact head windowing

## Minimal Cases
### `head`
Fixture
```text
line-01
line-02
line-03
line-04
line-05
line-06
line-07
line-08
line-09
line-10
line-11
line-12
```

Raw
```text
line-01
line-02
line-03
line-04
line-05
line-06
line-07
line-08
line-09
line-10
```

Previous RTK
```text
line-01
line-02
line-03
line-04
line-05
line-06
line-07
line-08
line-09
line-10
line-11
line-12
```

This PR
```text
line-01
line-02
line-03
line-04
line-05
line-06
line-07
line-08
line-09
line-10
```

### `head -3`
Fixture
```text
line-01
line-02
line-03
line-04
line-05
```

Raw
```text
line-01
line-02
line-03
```

Previous RTK
```text
line-01
// ... 4 more lines (total: 5)
```

This PR
```text
line-01
line-02
line-03
```

## Testing
- `cargo fmt --all`
- `cargo test test_rewrite_head -- --nocapture`
- `cargo test test_apply_line_window_head_lines -- --nocapture`
- `cargo test --all`
