### PR TITLE
fix(init): clean up data and config directories during uninstall

### DIFF
--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -3079,4 +3079,37 @@ More notes
         assert!(CURSOR_REWRITE_HOOK.contains("\"updated_input\""));
         assert!(!CURSOR_REWRITE_HOOK.contains("hookSpecificOutput"));
     }
+
+    #[test]
+    fn test_clean_data_directory_removes_artifacts() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let data_dir = tmp.path().join("rtk");
+        fs::create_dir_all(data_dir.join("tee")).expect("create tee dir");
+
+        // Create all known artifacts
+        fs::write(data_dir.join("history.db"), b"fake db").expect("write history.db");
+        fs::write(data_dir.join("trusted_filters.json"), b"{}").expect("write trusted_filters");
+        fs::write(data_dir.join(".hook_warn_last"), b"").expect("write hook_warn_last");
+        fs::write(data_dir.join(".telemetry_last_ping"), b"").expect("write telemetry marker");
+        fs::write(data_dir.join(".device_salt"), b"salt").expect("write device_salt");
+        fs::write(data_dir.join("tee").join("output.txt"), b"tee data").expect("write tee file");
+
+        let removed = clean_data_directory_at(&data_dir, 0).expect("clean should succeed");
+
+        assert!(!data_dir.exists(), "data dir should be removed");
+        assert!(!removed.is_empty(), "should report removed items");
+        assert!(
+            removed.iter().any(|s| s.contains("history.db")),
+            "should mention history.db in removed items"
+        );
+    }
+
+    #[test]
+    fn test_clean_data_directory_noop_when_missing() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let data_dir = tmp.path().join("rtk-nonexistent");
+
+        let removed = clean_data_directory_at(&data_dir, 0).expect("clean should succeed");
+        assert!(removed.is_empty(), "nothing to remove");
+    }
 }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -641,7 +641,7 @@ pub fn uninstall(global: bool, gemini: bool, codex: bool, cursor: bool, verbose:
     // 7. Remove RTK data directory (~/.local/share/rtk/)
     if let Some(data_base) = dirs::data_local_dir() {
         let data_dir = data_base.join(RTK_DATA_DIR);
-        let data_removed = clean_data_directory_at(&data_dir, verbose)
+        let data_removed = clean_data_directory_at(&data_dir, verbose, true)
             .context("Failed to clean RTK data directory")?;
         removed.extend(data_removed);
     }
@@ -670,7 +670,7 @@ pub fn uninstall(global: bool, gemini: bool, codex: bool, cursor: bool, verbose:
 
 /// Remove RTK data directory and its contents.
 /// Returns list of removed items for the uninstall report.
-fn clean_data_directory_at(data_dir: &Path, verbose: u8) -> Result<Vec<String>> {
+fn clean_data_directory_at(data_dir: &Path, verbose: u8, interactive: bool) -> Result<Vec<String>> {
     if !data_dir.exists() {
         if verbose > 0 {
             eprintln!("rtk: data dir not found: {}", data_dir.display());
@@ -680,18 +680,42 @@ fn clean_data_directory_at(data_dir: &Path, verbose: u8) -> Result<Vec<String>> 
 
     let mut removed = Vec::new();
 
-    // Always warn about history.db (unconditional - data loss warning per issue #1014)
+    // Prompt before deleting history.db (contains user's token savings data)
     let history_path = data_dir.join(HISTORY_DB);
-    if history_path.exists() {
+    if history_path.exists() && interactive {
+        use std::io::{self, BufRead, IsTerminal};
+
         eprintln!(
-            "Note: removing token savings database ({}). \
-             Run `rtk gain --history` first if you want to export your data.",
+            "\nFound token savings database: {}\n\
+             Run `rtk gain --history` to export before deleting.",
             history_path.display()
         );
+        eprint!("Delete data directory and history? [y/N] ");
+
+        let confirmed = if !io::stdin().is_terminal() {
+            eprintln!("(non-interactive mode, skipping data directory removal)");
+            false
+        } else {
+            let mut line = String::new();
+            io::stdin()
+                .lock()
+                .read_line(&mut line)
+                .context("Failed to read user input")?;
+            let response = line.trim().to_lowercase();
+            response == "y" || response == "yes"
+        };
+
+        if !confirmed {
+            eprintln!("Skipped data directory removal.");
+            return Ok(vec![]);
+        }
+    }
+
+    if history_path.exists() {
         removed.push(format!("Data: history.db ({})", history_path.display()));
     }
 
-    // Report known artifacts for verbose output
+    // Report known artifacts
     let known_artifacts = [
         TRUSTED_FILTERS_JSON,
         ".hook_warn_last",
@@ -3202,7 +3226,7 @@ More notes
         fs::write(data_dir.join(".device_salt"), b"salt").expect("write device_salt");
         fs::write(data_dir.join("tee").join("output.txt"), b"tee data").expect("write tee file");
 
-        let removed = clean_data_directory_at(&data_dir, 0).expect("clean should succeed");
+        let removed = clean_data_directory_at(&data_dir, 0, false).expect("clean should succeed");
 
         assert!(!data_dir.exists(), "data dir should be removed");
         assert!(!removed.is_empty(), "should report removed items");
@@ -3229,7 +3253,7 @@ More notes
         let tmp = tempfile::tempdir().expect("create tempdir");
         let data_dir = tmp.path().join("rtk-nonexistent");
 
-        let removed = clean_data_directory_at(&data_dir, 0).expect("clean should succeed");
+        let removed = clean_data_directory_at(&data_dir, 0, false).expect("clean should succeed");
         assert!(removed.is_empty(), "nothing to remove");
     }
 
@@ -3283,7 +3307,7 @@ More notes
         fs::write(data_dir.join(".device_salt"), b"salt").expect("write");
         fs::write(data_dir.join("tee").join("out.txt"), b"tee").expect("write");
 
-        let removed = clean_data_directory_at(&data_dir, 1).expect("clean");
+        let removed = clean_data_directory_at(&data_dir, 1, false).expect("clean");
 
         // Should report 6 items: history.db, trusted_filters, hook_warn, telemetry, salt, tee/
         assert_eq!(

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -3268,4 +3268,30 @@ More notes
         let removed = clean_config_directory_at(&config_dir, 0).expect("clean should succeed");
         assert!(removed.is_empty(), "nothing to remove");
     }
+
+    #[test]
+    fn test_full_data_cleanup_reports_all_known_artifacts() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let data_dir = tmp.path().join("rtk");
+        fs::create_dir_all(data_dir.join("tee")).expect("create dirs");
+
+        // Populate all known artifacts
+        fs::write(data_dir.join("history.db"), b"data").expect("write");
+        fs::write(data_dir.join("trusted_filters.json"), b"{}").expect("write");
+        fs::write(data_dir.join(".hook_warn_last"), b"").expect("write");
+        fs::write(data_dir.join(".telemetry_last_ping"), b"").expect("write");
+        fs::write(data_dir.join(".device_salt"), b"salt").expect("write");
+        fs::write(data_dir.join("tee").join("out.txt"), b"tee").expect("write");
+
+        let removed = clean_data_directory_at(&data_dir, 1).expect("clean");
+
+        // Should report 6 items: history.db, trusted_filters, hook_warn, telemetry, salt, tee/
+        assert_eq!(
+            removed.len(),
+            6,
+            "expected 6 artifacts reported, got: {:?}",
+            removed
+        );
+        assert!(!data_dir.exists());
+    }
 }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -639,19 +639,24 @@ pub fn uninstall(global: bool, gemini: bool, codex: bool, cursor: bool, verbose:
     removed.extend(cursor_removed);
 
     // 7. Remove RTK data directory (~/.local/share/rtk/)
-    if let Some(data_base) = dirs::data_local_dir() {
-        let data_dir = data_base.join(RTK_DATA_DIR);
-        let data_removed = clean_data_directory_at(&data_dir, verbose, true)
+    let data_dir = dirs::data_local_dir().map(|d| d.join(RTK_DATA_DIR));
+    if let Some(ref data_dir) = data_dir {
+        let data_removed = clean_data_directory_at(data_dir, verbose, true)
             .context("Failed to clean RTK data directory")?;
         removed.extend(data_removed);
     }
 
     // 8. Remove RTK config directory (~/.config/rtk/)
+    // On macOS both dirs resolve to ~/Library/Application Support/rtk/ -
+    // skip if already handled (or skipped) by step 7.
     if let Some(config_base) = dirs::config_dir() {
         let config_dir = config_base.join(RTK_DATA_DIR);
-        let config_removed = clean_config_directory_at(&config_dir, verbose)
-            .context("Failed to clean RTK config directory")?;
-        removed.extend(config_removed);
+        let same_as_data = data_dir.as_ref() == Some(&config_dir);
+        if !same_as_data {
+            let config_removed = clean_config_directory_at(&config_dir, verbose)
+                .context("Failed to clean RTK config directory")?;
+            removed.extend(config_removed);
+        }
     }
 
     // Report results

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -11,7 +11,7 @@ use super::constants::{
     REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use super::integrity;
-use crate::core::constants::RTK_DATA_DIR;
+use crate::core::constants::{HISTORY_DB, RTK_DATA_DIR, TRUSTED_FILTERS_JSON};
 
 // Embedded hook script (guards before set -euo pipefail)
 const REWRITE_HOOK: &str = include_str!("../../hooks/claude/rtk-rewrite.sh");
@@ -664,7 +664,7 @@ fn clean_data_directory_at(data_dir: &Path, verbose: u8) -> Result<Vec<String>> 
     let mut removed = Vec::new();
 
     // Warn about history.db before removal
-    let history_path = data_dir.join("history.db");
+    let history_path = data_dir.join(HISTORY_DB);
     if history_path.exists() {
         eprintln!(
             "Note: removing token savings database ({}). \
@@ -676,7 +676,7 @@ fn clean_data_directory_at(data_dir: &Path, verbose: u8) -> Result<Vec<String>> 
 
     // Report known artifacts for verbose output
     let known_artifacts = [
-        "trusted_filters.json",
+        TRUSTED_FILTERS_JSON,
         ".hook_warn_last",
         ".telemetry_last_ping",
         ".device_salt",
@@ -3158,6 +3158,18 @@ More notes
         assert!(
             removed.iter().any(|s: &String| s.contains("history.db")),
             "should mention history.db in removed items"
+        );
+        assert!(
+            removed.iter().any(|s| s.contains("trusted_filters.json")),
+            "should mention trusted_filters.json"
+        );
+        assert!(
+            removed.iter().any(|s| s.contains(".hook_warn_last")),
+            "should mention .hook_warn_last"
+        );
+        assert!(
+            removed.iter().any(|s| s.contains("tee/")),
+            "should mention tee/"
         );
     }
 

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -638,6 +638,22 @@ pub fn uninstall(global: bool, gemini: bool, codex: bool, cursor: bool, verbose:
     let cursor_removed = remove_cursor_hooks(verbose)?;
     removed.extend(cursor_removed);
 
+    // 7. Remove RTK data directory (~/.local/share/rtk/)
+    if let Some(data_base) = dirs::data_local_dir() {
+        let data_dir = data_base.join(RTK_DATA_DIR);
+        let data_removed = clean_data_directory_at(&data_dir, verbose)
+            .context("Failed to clean RTK data directory")?;
+        removed.extend(data_removed);
+    }
+
+    // 8. Remove RTK config directory (~/.config/rtk/)
+    if let Some(config_base) = dirs::config_dir() {
+        let config_dir = config_base.join(RTK_DATA_DIR);
+        let config_removed = clean_config_directory_at(&config_dir, verbose)
+            .context("Failed to clean RTK config directory")?;
+        removed.extend(config_removed);
+    }
+
     // Report results
     if removed.is_empty() {
         println!("RTK was not installed (nothing to remove)");
@@ -654,7 +670,6 @@ pub fn uninstall(global: bool, gemini: bool, codex: bool, cursor: bool, verbose:
 
 /// Remove RTK data directory and its contents.
 /// Returns list of removed items for the uninstall report.
-#[allow(dead_code)]
 fn clean_data_directory_at(data_dir: &Path, verbose: u8) -> Result<Vec<String>> {
     if !data_dir.exists() {
         if verbose > 0 {
@@ -710,7 +725,6 @@ fn clean_data_directory_at(data_dir: &Path, verbose: u8) -> Result<Vec<String>> 
 
 /// Remove RTK config directory (~/.config/rtk/) and its contents.
 /// Returns list of removed items for the uninstall report.
-#[allow(dead_code)]
 fn clean_config_directory_at(config_dir: &Path, verbose: u8) -> Result<Vec<String>> {
     if !config_dir.exists() {
         if verbose > 0 {

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -11,7 +11,9 @@ use super::constants::{
     REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use super::integrity;
-use crate::core::constants::{CONFIG_TOML, FILTERS_TOML, HISTORY_DB, RTK_DATA_DIR, TRUSTED_FILTERS_JSON};
+use crate::core::constants::{
+    CONFIG_TOML, FILTERS_TOML, HISTORY_DB, RTK_DATA_DIR, TRUSTED_FILTERS_JSON,
+};
 
 // Embedded hook script (guards before set -euo pipefail)
 const REWRITE_HOOK: &str = include_str!("../../hooks/claude/rtk-rewrite.sh");
@@ -701,6 +703,41 @@ fn clean_data_directory_at(data_dir: &Path, verbose: u8) -> Result<Vec<String>> 
     if removed.is_empty() {
         // Directory existed but had no known artifacts - still report removal
         removed.push(format!("Data directory: {}", data_dir.display()));
+    }
+
+    Ok(removed)
+}
+
+/// Remove RTK config directory (~/.config/rtk/) and its contents.
+/// Returns list of removed items for the uninstall report.
+#[allow(dead_code)]
+fn clean_config_directory_at(config_dir: &Path, verbose: u8) -> Result<Vec<String>> {
+    if !config_dir.exists() {
+        if verbose > 0 {
+            eprintln!("rtk: config dir not found: {}", config_dir.display());
+        }
+        return Ok(vec![]);
+    }
+
+    let mut removed = Vec::new();
+
+    let known_files = [CONFIG_TOML, FILTERS_TOML];
+    for name in &known_files {
+        let path = config_dir.join(name);
+        if path.exists() {
+            removed.push(format!("Config: {}", name));
+        }
+    }
+
+    fs::remove_dir_all(config_dir).with_context(|| {
+        format!(
+            "Failed to remove config directory: {}",
+            config_dir.display()
+        )
+    })?;
+
+    if removed.is_empty() {
+        removed.push(format!("Config directory: {}", config_dir.display()));
     }
 
     Ok(removed)
@@ -3188,7 +3225,11 @@ More notes
         let config_dir = tmp.path().join("rtk");
         fs::create_dir_all(&config_dir).expect("create config dir");
 
-        fs::write(config_dir.join("config.toml"), b"[tracking]\nenabled = true").expect("write config");
+        fs::write(
+            config_dir.join("config.toml"),
+            b"[tracking]\nenabled = true",
+        )
+        .expect("write config");
         fs::write(config_dir.join("filters.toml"), b"schema_version = 1").expect("write filters");
 
         let removed = clean_config_directory_at(&config_dir, 0).expect("clean should succeed");

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -11,7 +11,7 @@ use super::constants::{
     REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use super::integrity;
-use crate::core::constants::{HISTORY_DB, RTK_DATA_DIR, TRUSTED_FILTERS_JSON};
+use crate::core::constants::{CONFIG_TOML, FILTERS_TOML, HISTORY_DB, RTK_DATA_DIR, TRUSTED_FILTERS_JSON};
 
 // Embedded hook script (guards before set -euo pipefail)
 const REWRITE_HOOK: &str = include_str!("../../hooks/claude/rtk-rewrite.sh");
@@ -3179,6 +3179,38 @@ More notes
         let data_dir = tmp.path().join("rtk-nonexistent");
 
         let removed = clean_data_directory_at(&data_dir, 0).expect("clean should succeed");
+        assert!(removed.is_empty(), "nothing to remove");
+    }
+
+    #[test]
+    fn test_clean_config_directory_removes_rtk_config() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let config_dir = tmp.path().join("rtk");
+        fs::create_dir_all(&config_dir).expect("create config dir");
+
+        fs::write(config_dir.join("config.toml"), b"[tracking]\nenabled = true").expect("write config");
+        fs::write(config_dir.join("filters.toml"), b"schema_version = 1").expect("write filters");
+
+        let removed = clean_config_directory_at(&config_dir, 0).expect("clean should succeed");
+
+        assert!(!config_dir.exists(), "config dir should be removed");
+        assert!(!removed.is_empty(), "should report removed items");
+        assert!(
+            removed.iter().any(|s| s.contains("config.toml")),
+            "should mention config.toml"
+        );
+        assert!(
+            removed.iter().any(|s| s.contains("filters.toml")),
+            "should mention filters.toml"
+        );
+    }
+
+    #[test]
+    fn test_clean_config_directory_noop_when_missing() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let config_dir = tmp.path().join("rtk-nonexistent");
+
+        let removed = clean_config_directory_at(&config_dir, 0).expect("clean should succeed");
         assert!(removed.is_empty(), "nothing to remove");
     }
 }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -11,6 +11,7 @@ use super::constants::{
     REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use super::integrity;
+use crate::core::constants::RTK_DATA_DIR;
 
 // Embedded hook script (guards before set -euo pipefail)
 const REWRITE_HOOK: &str = include_str!("../../hooks/claude/rtk-rewrite.sh");
@@ -649,6 +650,62 @@ pub fn uninstall(global: bool, gemini: bool, codex: bool, cursor: bool, verbose:
     Ok(())
 }
 
+/// Remove RTK data directory and its contents.
+/// Returns list of removed items for the uninstall report.
+#[allow(dead_code)]
+fn clean_data_directory_at(data_dir: &Path, verbose: u8) -> Result<Vec<String>> {
+    if !data_dir.exists() {
+        if verbose > 0 {
+            eprintln!("rtk: data dir not found: {}", data_dir.display());
+        }
+        return Ok(vec![]);
+    }
+
+    let mut removed = Vec::new();
+
+    // Warn about history.db before removal
+    let history_path = data_dir.join("history.db");
+    if history_path.exists() {
+        eprintln!(
+            "Note: removing token savings database ({}). \
+             Run `rtk gain --history` first if you want to export your data.",
+            history_path.display()
+        );
+        removed.push(format!("Data: history.db ({})", history_path.display()));
+    }
+
+    // Report known artifacts for verbose output
+    let known_artifacts = [
+        "trusted_filters.json",
+        ".hook_warn_last",
+        ".telemetry_last_ping",
+        ".device_salt",
+    ];
+    for name in &known_artifacts {
+        let path = data_dir.join(name);
+        if path.exists() {
+            removed.push(format!("Data: {}", name));
+        }
+    }
+
+    // Report tee directory
+    let tee_dir = data_dir.join("tee");
+    if tee_dir.exists() {
+        removed.push(format!("Data: tee/ ({})", tee_dir.display()));
+    }
+
+    // Remove entire data directory
+    fs::remove_dir_all(data_dir)
+        .with_context(|| format!("Failed to remove data directory: {}", data_dir.display()))?;
+
+    if removed.is_empty() {
+        // Directory existed but had no known artifacts - still report removal
+        removed.push(format!("Data directory: {}", data_dir.display()));
+    }
+
+    Ok(removed)
+}
+
 fn uninstall_codex(global: bool, verbose: u8) -> Result<()> {
     if !global {
         anyhow::bail!(
@@ -994,7 +1051,7 @@ fn generate_project_filters_template(verbose: u8) -> Result<()> {
 /// Generate ~/.config/rtk/filters.toml template if not present.
 fn generate_global_filters_template(verbose: u8) -> Result<()> {
     let config_dir = dirs::config_dir().unwrap_or_else(|| std::path::PathBuf::from(".config"));
-    let rtk_dir = config_dir.join(crate::core::constants::RTK_DATA_DIR);
+    let rtk_dir = config_dir.join(RTK_DATA_DIR);
     let path = rtk_dir.join("filters.toml");
 
     if path.exists() {
@@ -3099,7 +3156,7 @@ More notes
         assert!(!data_dir.exists(), "data dir should be removed");
         assert!(!removed.is_empty(), "should report removed items");
         assert!(
-            removed.iter().any(|s| s.contains("history.db")),
+            removed.iter().any(|s: &String| s.contains("history.db")),
             "should mention history.db in removed items"
         );
     }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -680,7 +680,7 @@ fn clean_data_directory_at(data_dir: &Path, verbose: u8) -> Result<Vec<String>> 
 
     let mut removed = Vec::new();
 
-    // Warn about history.db before removal
+    // Always warn about history.db (unconditional - data loss warning per issue #1014)
     let history_path = data_dir.join(HISTORY_DB);
     if history_path.exists() {
         eprintln!(


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

Fixes #1014.

- `rtk init -g --uninstall` now removes the RTK data directory (`~/.local/share/rtk/` on Linux, `~/Library/Application Support/rtk/` on macOS) - covers history.db, trusted_filters.json, .hook_warn_last, .telemetry_last_ping, .device_salt, and tee/
- Also removes the RTK config directory (`~/.config/rtk/` on Linux) - covers config.toml and filters.toml
- When history.db exists, prompts for confirmation before deleting (with a note to export via `rtk gain --history` first). In non-interactive mode (piped stdin), skips data directory removal entirely to avoid silent data loss.

## Test plan
<!-- How did you verify this works? -->

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`. 1348 tests pass, 0 failures. Clippy warnings are all pre-existing in unrelated files.
- [x] 7 new unit tests cover: data dir cleanup (happy path + noop + full artifact reporting), config dir cleanup (happy path + noop), and an integration test asserting all 6 known data artifacts are individually reported.
- [x] Tests pass `interactive: false` to bypass the stdin prompt; production call site passes `interactive: true`.
- [x] Default calls tested manually.
  - Built source with `cargo build --release`
  - `target/release/rtk init -g` to install, then `target/release/rtk init -g --uninstall`
  - A `[y/N]` prompt appears before deleting history.db. Answering `N` skips data dir removal, answering `y` removes it. Hooks are removed in either case (I felt this was okay given the user explicitly started this `uninstall` command anyhow).
- [x] Tested manually: non-interactive mode (`echo "" | rtk init -g --uninstall`) skips data directory removal with a message.
- [x] Tested manually: a fresh `rtk init -g` after uninstall works cleanly (no leftover state interference).

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.