### PR TITLE
fix(proxy): kill child process on SIGINT/SIGTERM to prevent orphans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,6 +916,7 @@ dependencies = [
  "hostname",
  "ignore",
  "lazy_static",
+ "libc",
  "quick-xml",
  "regex",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ quick-xml = "0.37"
 which = "8"
 automod = "1"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [build-dependencies]
 toml = "0.8"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1951,6 +1951,7 @@ fn run_cli() -> Result<i32> {
         Commands::Proxy { args } => {
             use std::io::{Read, Write};
             use std::process::Stdio;
+            use std::sync::atomic::{AtomicU32, Ordering};
             use std::thread;
 
             if args.is_empty() {
@@ -1986,8 +1987,30 @@ fn run_cli() -> Result<i32> {
                 eprintln!("Proxy mode: {} {}", cmd_name, cmd_args.join(" "));
             }
 
-            // ISSUE #897: ChildGuard kills child on error/panic to prevent
-            // orphan processes that caused a 514GB memory leak + kernel panic.
+            // ISSUE #897: Kill proxy child on SIGINT/SIGTERM to prevent orphan
+            // processes. Drop-based ChildGuard doesn't run on signals with
+            // panic=abort, so we register a signal handler that kills the child
+            // PID stored in this atomic.
+            static PROXY_CHILD_PID: AtomicU32 = AtomicU32::new(0);
+
+            #[cfg(unix)]
+            {
+                unsafe extern "C" fn handle_signal(sig: libc::c_int) {
+                    let pid = PROXY_CHILD_PID.load(Ordering::SeqCst);
+                    if pid != 0 {
+                        libc::kill(pid as libc::pid_t, libc::SIGTERM);
+                        libc::waitpid(pid as libc::pid_t, std::ptr::null_mut(), 0);
+                    }
+                    // Re-raise with default handler so parent sees correct exit status
+                    libc::signal(sig, libc::SIG_DFL);
+                    libc::raise(sig);
+                }
+                unsafe {
+                    libc::signal(libc::SIGINT, handle_signal as libc::sighandler_t);
+                    libc::signal(libc::SIGTERM, handle_signal as libc::sighandler_t);
+                }
+            }
+
             struct ChildGuard(Option<std::process::Child>);
             impl Drop for ChildGuard {
                 fn drop(&mut self) {
@@ -1995,6 +2018,7 @@ fn run_cli() -> Result<i32> {
                         let _ = child.kill();
                         let _ = child.wait();
                     }
+                    PROXY_CHILD_PID.store(0, Ordering::SeqCst);
                 }
             }
 
@@ -2006,6 +2030,11 @@ fn run_cli() -> Result<i32> {
                     .spawn()
                     .context(format!("Failed to execute command: {}", cmd_name))?,
             ));
+
+            // Store child PID for signal handler before anything can fail
+            if let Some(ref inner) = child.0 {
+                PROXY_CHILD_PID.store(inner.id(), Ordering::SeqCst);
+            }
 
             let inner = child.0.as_mut().context("Child process missing")?;
             let stdout_pipe = inner


### PR DESCRIPTION
## Summary
- Register SIGINT/SIGTERM signal handler in proxy mode that kills the child process via its PID stored in an `AtomicU32`
- Fixes orphan processes when `rtk proxy` is killed (by Claude Code, process managers, or manual `kill`)
- Drop-based ChildGuard doesn't run on signals with `panic=abort` (release profile) — this is the actual fix for issue #897
- Uses `libc` (already in dependency tree via `dirs`) for `kill(2)` syscall — zero new downloads

## Reproduction
```bash
# Before: child survives
rtk proxy sleep 300 &; kill $!; sleep 2; pgrep sleep  # orphan alive

# After: child killed
rtk proxy sleep 300 &; kill $!; sleep 2; pgrep sleep  # nothing
```

## Test plan
- [x] `cargo test --all` — 1350 passed, 0 failed
- [x] `cargo clippy --all-targets` — no new warnings
- [x] SIGTERM kills child (verified manually)
- [x] Normal proxy exit still works (`rtk proxy echo hello`)
- [x] Exit code propagation preserved (`rtk proxy false` → exit 1)
- [x] Large output passthrough unaffected (`rtk proxy seq 1 100000`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)