### PR TITLE
fix(json): quote object keys in schema output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+* **json:** quote object keys in extract_schema and compact_json output ([#1015](https://github.com/rtk-ai/rtk/issues/1015))
 * **security:** missing toml pkg ([51f9c88](https://github.com/rtk-ai/rtk/commit/51f9c888b81169309df92f7fa3a6f705d44adcab))
 * **security:** salt device hash for telemetry ([32fdbbb](https://github.com/rtk-ai/rtk/commit/32fdbbbb6923c70d343fab14b4b0ce70424e610f))
 * **security:** set 0600 permissions on salt file ([5eae11d](https://github.com/rtk-ai/rtk/commit/5eae11d16410dc4ff26e97672e5367b14efaab76))

--- a/src/cmds/system/json_cmd.rs
+++ b/src/cmds/system/json_cmd.rs
@@ -158,9 +158,9 @@ fn compact_json(value: &Value, depth: usize, max_depth: usize) -> String {
 
                     if is_simple {
                         let val_str = compact_json(val, 0, max_depth);
-                        lines.push(format!("{}  {}: {}", indent, key, val_str.trim()));
+                        lines.push(format!("{}  \"{}\": {}", indent, key, val_str.trim()));
                     } else {
-                        lines.push(format!("{}  {}:", indent, key));
+                        lines.push(format!("{}  \"{}\":", indent, key));
                         lines.push(compact_json(val, depth + 1, max_depth));
                     }
 
@@ -250,12 +250,12 @@ fn extract_schema(value: &Value, depth: usize, max_depth: usize) -> String {
 
                     if is_simple {
                         if i < keys.len() - 1 {
-                            lines.push(format!("{}  {}: {},", indent, key, val_trimmed));
+                            lines.push(format!("{}  \"{}\": {},", indent, key, val_trimmed));
                         } else {
-                            lines.push(format!("{}  {}: {}", indent, key, val_trimmed));
+                            lines.push(format!("{}  \"{}\": {}", indent, key, val_trimmed));
                         }
                     } else {
-                        lines.push(format!("{}  {}:", indent, key));
+                        lines.push(format!("{}  \"{}\":", indent, key));
                         lines.push(val_schema);
                     }
 


### PR DESCRIPTION
Object keys in `compact_json()` and `extract_schema()` were missing double quotes, producing invalid JSON that breaks `jq`, `python3 json.load()`, etc.

Wraps all key formatting in `"key":` instead of `key:`.

Fixes #1015