### PR TITLE
Add Codex hook installation and guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ rtk init --agent cline          # Cline / Roo Code
 git status  # Automatically rewritten to rtk git status
 ```
 
-The hook transparently rewrites Bash commands (e.g., `git status` -> `rtk git status`) before execution. Claude never sees the rewrite, it just gets compressed output.
+> Codex note: current Codex hooks block + suggest `rtk git status` rather than rewriting in place.
+
+Most supported hook integrations transparently rewrite Bash commands (e.g., `git status` -> `rtk git status`) before execution. Codex currently cannot apply `updatedInput` in hooks yet, so RTK uses a deny-with-suggestion hook there instead.
 
 **Important:** the hook only runs on Bash tool calls. Claude Code built-in tools like `Read`, `Grep`, and `Glob` do not pass through the Bash hook, so they are not auto-rewritten. To get RTK's compact output for those workflows, use shell commands (`cat`/`head`/`tail`, `rg`/`grep`, `find`) or call `rtk read`, `rtk grep`, or `rtk find` directly.
 
@@ -305,7 +307,7 @@ RTK supports 10 AI coding tools. Each integration transparently rewrites shell c
 | **GitHub Copilot CLI** | `rtk init -g --copilot` | PreToolUse deny-with-suggestion (CLI limitation) |
 | **Cursor** | `rtk init -g --agent cursor` | preToolUse hook (hooks.json) |
 | **Gemini CLI** | `rtk init -g --gemini` | BeforeTool hook (`rtk hook gemini`) |
-| **Codex** | `rtk init -g --codex` | AGENTS.md + RTK.md instructions |
+| **Codex** | `rtk init -g --codex` | PreToolUse hook (`rtk hook codex`) + AGENTS.md + RTK.md |
 | **Windsurf** | `rtk init --agent windsurf` | .windsurfrules (project-scoped) |
 | **Cline / Roo Code** | `rtk init --agent cline` | .clinerules (project-scoped) |
 | **OpenCode** | `rtk init -g --opencode` | Plugin TS (tool.execute.before) |
@@ -356,7 +358,9 @@ Creates `~/.gemini/hooks/rtk-hook-gemini.sh` + patches `~/.gemini/settings.json`
 rtk init -g --codex
 ```
 
-Creates `~/.codex/RTK.md` + `~/.codex/AGENTS.md` with `@RTK.md` reference. Codex reads these as global instructions.
+Creates `~/.codex/RTK.md`, `~/.codex/AGENTS.md`, `~/.codex/hooks.json`, and enables `features.codex_hooks = true` in `~/.codex/config.toml`.
+
+Because current Codex hooks do **not** support in-place Bash rewrites yet, RTK installs a `PreToolUse` hook that blocks matching raw commands and tells Codex to retry with the `rtk ...` equivalent.
 
 ### Windsurf
 

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -315,7 +315,7 @@ Start here, then drill down into each README for file-level details.
 | [`cursor/`](../hooks/cursor/README.md) | Cursor IDE | Shell hook, empty JSON response requirement |
 | [`cline/`](../hooks/cline/README.md) | Cline / Roo Code | Rules file (prompt-level, no programmatic hook) |
 | [`windsurf/`](../hooks/windsurf/README.md) | Windsurf / Cascade | Rules file (workspace-scoped) |
-| [`codex/`](../hooks/codex/README.md) | OpenAI Codex CLI | Awareness document, AGENTS.md integration |
+| [`codex/`](../hooks/codex/README.md) | OpenAI Codex CLI | PreToolUse deny-with-suggestion hook + AGENTS.md integration |
 | [`opencode/`](../hooks/opencode/README.md) | OpenCode | TypeScript plugin, zx library, in-place mutation |
 
 ---
@@ -333,7 +333,7 @@ RTK supports the following LLM agents through hook integrations:
 | Gemini CLI | Rust binary | `rtk hook gemini` reads JSON | Yes (`hookSpecificOutput`) |
 | Cline/Roo Code | Rules file | Prompt-level guidance | N/A (prompt) |
 | Windsurf | Rules file | Prompt-level guidance | N/A (prompt) |
-| Codex CLI | Awareness doc | AGENTS.md integration | N/A (prompt) |
+| Codex CLI | Rust binary hook | `rtk hook codex` + AGENTS.md integration | No (deny + suggestion) |
 | OpenCode | TS plugin | `tool.execute.before` event | Yes (in-place mutation) |
 
 > **Details**: [`hooks/README.md`](../hooks/README.md) has the full JSON schemas for each agent. [`src/hooks/README.md`](../src/hooks/README.md) covers installation, integrity verification, and the rewrite command.

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -38,7 +38,7 @@ Each agent subdirectory has its own README with hook-specific details:
 - **[`cursor/`](cursor/README.md)** — Shell hook, Cursor JSON format, empty `{}` response requirement
 - **[`cline/`](cline/README.md)** — Rules file (prompt-level), `.clinerules` project-local installation
 - **[`windsurf/`](windsurf/README.md)** — Rules file (prompt-level), `.windsurfrules` workspace-scoped
-- **[`codex/`](codex/README.md)** — Awareness document, `AGENTS.md` integration, `~/.codex/` location
+- **[`codex/`](codex/README.md)** — Codex hooks.json wiring, `rtk hook codex`, `AGENTS.md` integration
 - **[`opencode/`](opencode/README.md)** — TypeScript plugin, `zx` library, `tool.execute.before` event, in-place mutation
 
 ## Supported Agents
@@ -52,7 +52,7 @@ Each agent subdirectory has its own README with hook-specific details:
 | Gemini CLI | Rust binary (`rtk hook gemini`) | Transparent rewrite | Yes (`hookSpecificOutput`) |
 | Cline / Roo Code | Custom instructions (rules file) | Prompt-level guidance | N/A |
 | Windsurf | Custom instructions (rules file) | Prompt-level guidance | N/A |
-| Codex CLI | AGENTS.md / instructions | Prompt-level guidance | N/A |
+| Codex CLI | Rust binary (`rtk hook codex`) + AGENTS.md | Deny-with-suggestion | No (agent retries) |
 | OpenCode | TypeScript plugin (`tool.execute.before`) | In-place mutation | Yes |
 
 ## JSON Formats by Agent
@@ -216,9 +216,9 @@ New integrations must follow the [Exit Code Contract](#exit-code-contract) and [
 
 | Tier | Mechanism | Maintenance | Examples |
 |------|-----------|-------------|----------|
-| **Full hook** | Shell script or Rust binary, intercepts commands via agent's hook API | High — must track agent API changes | Claude Code, Cursor, Copilot, Gemini |
+| **Full hook** | Shell script or Rust binary, intercepts commands via agent's hook API | High — must track agent API changes | Claude Code, Cursor, Copilot, Gemini, Codex |
 | **Plugin** | TypeScript/JS plugin in agent's plugin system | Medium — agent manages loading | OpenCode |
-| **Rules file** | Prompt-level instructions the agent reads | Low — no code to break | Cline, Windsurf, Codex |
+| **Rules file** | Prompt-level instructions the agent reads | Low — no code to break | Cline, Windsurf |
 
 ### Eligibility
 
@@ -232,4 +232,3 @@ RTK supports AI coding assistants that developers actually use day-to-day. To ad
 ### Maintenance
 
 If an agent's API changes and the hook breaks, the integration should be updated promptly. If the agent becomes unmaintained or the hook can't be fixed, the integration may be deprecated with a release note.
-

--- a/hooks/codex/README.md
+++ b/hooks/codex/README.md
@@ -4,6 +4,16 @@
 
 ## Specifics
 
-- Prompt-level guidance via awareness document -- no programmatic hook
-- `rtk-awareness.md` is injected into `AGENTS.md` with an `@RTK.md` reference
-- Installed to `~/.codex/` by `rtk init --codex`
+- Prompt-level guidance via `rtk-awareness.md`, injected into `AGENTS.md` with an `@RTK.md` reference
+- Programmatic Codex hook via `rtk hook codex`, wired through `hooks.json`
+- `rtk init --codex` also enables `features.codex_hooks = true` in the active Codex `config.toml`
+
+## Behavior
+
+- Codex `PreToolUse` hooks currently **cannot** apply `updatedInput` yet.
+- RTK therefore uses a **deny-with-suggestion** pattern for Codex:
+  - raw command: `git status`
+  - hook response: deny + suggest `rtk git status`
+  - Codex retries with the RTK command and gets filtered output
+
+This differs from Claude Code and Cursor, where RTK can transparently rewrite the Bash command in-place.

--- a/src/cmds/js/next_cmd.rs
+++ b/src/cmds/js/next_cmd.rs
@@ -32,7 +32,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         cmd,
         "next build",
         &args.join(" "),
-        |raw| filter_next_build(raw),
+        filter_next_build,
         runner::RunOptions::default(),
     )
 }

--- a/src/cmds/js/npm_cmd.rs
+++ b/src/cmds/js/npm_cmd.rs
@@ -113,7 +113,7 @@ pub fn run(args: &[String], verbose: u8, skip_env: bool) -> Result<i32> {
         cmd,
         "npm",
         &args.join(" "),
-        |raw| filter_npm_output(raw),
+        filter_npm_output,
         runner::RunOptions::default(),
     )
 }

--- a/src/cmds/js/tsc_cmd.rs
+++ b/src/cmds/js/tsc_cmd.rs
@@ -31,7 +31,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         cmd,
         "tsc",
         &args.join(" "),
-        |raw| filter_tsc_output(raw),
+        filter_tsc_output,
         runner::RunOptions::with_tee("tsc"),
     )
 }

--- a/src/cmds/ruby/rake_cmd.rs
+++ b/src/cmds/ruby/rake_cmd.rs
@@ -15,7 +15,7 @@ use anyhow::Result;
 /// `rails test` which handles single files, multiple files, and line-number
 /// syntax (`file.rb:15`) natively.
 fn select_runner(args: &[String]) -> (&'static str, Vec<String>) {
-    let has_test_subcommand = args.first().map_or(false, |a| a == "test");
+    let has_test_subcommand = args.first().is_some_and(|a| a == "test");
     if !has_test_subcommand {
         return ("rake", args.to_vec());
     }

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -499,8 +499,8 @@ fn rewrite_segment(seg: &str, excluded: &[String]) -> Option<String> {
     // Most cat flags (-v, -A, -e, -t, -s, -b, --show-all, etc.) have different
     // semantics than rtk read or no equivalent at all. Only `-n` (line numbers)
     // maps correctly to `rtk read -n`. Skip rewrite for any other flag.
-    if cmd_part.starts_with("cat ") {
-        let args = cmd_part["cat ".len()..].trim_start();
+    if let Some(stripped) = cmd_part.strip_prefix("cat ") {
+        let args = stripped.trim_start();
         if args.starts_with('-') && !args.starts_with("-n ") && !args.starts_with("-n\t") {
             return None;
         }

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -28,7 +28,7 @@ LLM agent integration layer that installs, validates, and executes command-rewri
 | Claude-MD (legacy) | `rtk init --claude-md` | 134-line RTK block | CLAUDE.md |
 | Windsurf | `rtk init -g --agent windsurf` | `.windsurfrules` | -- |
 | Cline | `rtk init --agent cline` | `.clinerules` | -- |
-| Codex | `rtk init --codex` | RTK.md | AGENTS.md |
+| Codex | `rtk init --codex` | RTK.md, hooks.json, config.toml flag | AGENTS.md |
 | Cursor | `rtk init -g --agent cursor` | Cursor hook | hooks.json |
 
 

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -1,9 +1,11 @@
 pub const REWRITE_HOOK_FILE: &str = "rtk-rewrite.sh";
 pub const GEMINI_HOOK_FILE: &str = "rtk-hook-gemini.sh";
+pub const CODEX_HOOK_COMMAND: &str = "rtk hook codex";
 pub const CLAUDE_DIR: &str = ".claude";
 pub const HOOKS_SUBDIR: &str = "hooks";
 pub const SETTINGS_JSON: &str = "settings.json";
 pub const SETTINGS_LOCAL_JSON: &str = "settings.local.json";
 pub const HOOKS_JSON: &str = "hooks.json";
+pub const CONFIG_TOML: &str = "config.toml";
 pub const PRE_TOOL_USE_KEY: &str = "PreToolUse";
 pub const BEFORE_TOOL_KEY: &str = "BeforeTool";

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -47,6 +47,57 @@ pub fn run_copilot() -> Result<()> {
     }
 }
 
+/// Run the Codex CLI PreToolUse hook.
+///
+/// Codex currently parses `updatedInput` but does not apply it yet, so RTK uses
+/// deny-with-suggestion here instead of transparent rewrite.
+pub fn run_codex() -> Result<()> {
+    let mut input = String::new();
+    io::stdin()
+        .read_to_string(&mut input)
+        .context("Failed to read stdin")?;
+
+    let input = input.trim();
+    if input.is_empty() {
+        return Ok(());
+    }
+
+    let v: Value = match serde_json::from_str(input) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("[rtk hook] Failed to parse JSON input: {e}");
+            return Ok(());
+        }
+    };
+
+    let hook_event_name = v
+        .get("hook_event_name")
+        .and_then(|h| h.as_str())
+        .unwrap_or_default();
+    let tool_name = v.get("tool_name").and_then(|t| t.as_str()).unwrap_or("");
+
+    if hook_event_name != PRE_TOOL_USE_KEY || !matches!(tool_name, "Bash" | "bash") {
+        return Ok(());
+    }
+
+    let cmd = match v
+        .pointer("/tool_input/command")
+        .and_then(|c| c.as_str())
+        .filter(|c| !c.is_empty())
+    {
+        Some(cmd) => cmd,
+        None => return Ok(()),
+    };
+
+    let output = match codex_block_response(cmd) {
+        Some(output) => output,
+        None => return Ok(()),
+    };
+
+    println!("{output}");
+    Ok(())
+}
+
 fn detect_format(v: &Value) -> HookFormat {
     // VS Code Copilot Chat / Claude Code: snake_case keys
     if let Some(tool_name) = v.get("tool_name").and_then(|t| t.as_str()) {
@@ -140,6 +191,20 @@ fn handle_copilot_cli(cmd: &str) -> Result<()> {
     Ok(())
 }
 
+fn codex_block_response(cmd: &str) -> Option<Value> {
+    let rewritten = get_rewritten(cmd)?;
+    Some(json!({
+        "hookSpecificOutput": {
+            "hookEventName": PRE_TOOL_USE_KEY,
+            "permissionDecision": "deny",
+            "permissionDecisionReason": format!(
+                "Token savings: retry with `{}` instead (Codex hooks cannot rewrite Bash commands in-place yet).",
+                rewritten
+            )
+        }
+    }))
+}
+
 // ── Gemini hook ───────────────────────────────────────────────
 
 /// Run the Gemini CLI BeforeTool hook.
@@ -213,6 +278,14 @@ mod tests {
         json!({ "toolName": "bash", "toolArgs": args })
     }
 
+    fn codex_input(event: &str, tool: &str, cmd: &str) -> Value {
+        json!({
+            "hook_event_name": event,
+            "tool_name": tool,
+            "tool_input": { "command": cmd }
+        })
+    }
+
     #[test]
     fn test_detect_vscode_bash() {
         assert!(matches!(
@@ -266,6 +339,33 @@ mod tests {
     #[test]
     fn test_get_rewritten_heredoc() {
         assert!(get_rewritten("cat <<'EOF'\nhello\nEOF").is_none());
+    }
+
+    #[test]
+    fn test_codex_hook_blocks_supported_command_with_suggestion() {
+        let output = codex_block_response("git status").unwrap();
+        assert_eq!(
+            output["hookSpecificOutput"]["hookEventName"],
+            PRE_TOOL_USE_KEY
+        );
+        assert_eq!(output["hookSpecificOutput"]["permissionDecision"], "deny");
+        assert!(output["hookSpecificOutput"]["permissionDecisionReason"]
+            .as_str()
+            .unwrap()
+            .contains("rtk git status"));
+    }
+
+    #[test]
+    fn test_codex_hook_ignores_already_rtk_command() {
+        assert!(codex_block_response("rtk git status").is_none());
+    }
+
+    #[test]
+    fn test_codex_input_shape_matches_pre_tool_use_contract() {
+        let input = codex_input(PRE_TOOL_USE_KEY, "Bash", "git status");
+        assert_eq!(input["hook_event_name"], PRE_TOOL_USE_KEY);
+        assert_eq!(input["tool_name"], "Bash");
+        assert_eq!(input["tool_input"]["command"], "git status");
     }
 
     // --- Gemini format ---

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -7,8 +7,8 @@ use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 
 use super::constants::{
-    BEFORE_TOOL_KEY, CLAUDE_DIR, GEMINI_HOOK_FILE, HOOKS_JSON, HOOKS_SUBDIR, PRE_TOOL_USE_KEY,
-    REWRITE_HOOK_FILE, SETTINGS_JSON,
+    BEFORE_TOOL_KEY, CLAUDE_DIR, CODEX_HOOK_COMMAND, CONFIG_TOML, GEMINI_HOOK_FILE, HOOKS_JSON,
+    HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use super::integrity;
 use crate::core::config;
@@ -420,6 +420,35 @@ fn atomic_write(path: &Path, content: &str) -> Result<()> {
     Ok(())
 }
 
+fn backup_path(path: &Path) -> Result<PathBuf> {
+    let file_name = path
+        .file_name()
+        .context("Cannot create backup: path has no file name")?
+        .to_string_lossy();
+    Ok(path.with_file_name(format!("{file_name}.bak")))
+}
+
+fn backup_file_if_exists(path: &Path, verbose: u8) -> Result<Option<PathBuf>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let backup = backup_path(path)?;
+    fs::copy(path, &backup).with_context(|| {
+        format!(
+            "Failed to back up {} to {}",
+            path.display(),
+            backup.display()
+        )
+    })?;
+
+    if verbose > 0 {
+        eprintln!("Backup: {}", backup.display());
+    }
+
+    Ok(Some(backup))
+}
+
 /// Prompt user for consent to patch settings.json
 /// Prints to stderr (stdout may be piped), reads from stdin
 /// Default is No (capital N)
@@ -698,7 +727,71 @@ fn uninstall_codex_at(codex_dir: &Path, verbose: u8) -> Result<Vec<String>> {
         removed.push("AGENTS.md: removed @RTK.md reference".to_string());
     }
 
+    let hooks_json_path = codex_dir.join(HOOKS_JSON);
+    if remove_codex_hook_from_settings(&hooks_json_path, verbose)? {
+        removed.push("hooks.json: removed RTK PreToolUse hook".to_string());
+    }
+
     Ok(removed)
+}
+
+fn remove_codex_hook_from_settings(path: &Path, verbose: u8) -> Result<bool> {
+    if !path.exists() {
+        return Ok(false);
+    }
+
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+
+    if content.trim().is_empty() {
+        return Ok(false);
+    }
+
+    let mut root: serde_json::Value = serde_json::from_str(&content)
+        .with_context(|| format!("Failed to parse {} as JSON", path.display()))?;
+
+    let removed = remove_codex_hook_from_json(&mut root);
+    if !removed {
+        return Ok(false);
+    }
+
+    backup_file_if_exists(path, verbose)?;
+    let serialized =
+        serde_json::to_string_pretty(&root).context("Failed to serialize Codex hooks.json")?;
+    atomic_write(path, &serialized)?;
+
+    if verbose > 0 {
+        eprintln!("Removed Codex RTK hook from {}", path.display());
+    }
+
+    Ok(true)
+}
+
+fn remove_codex_hook_from_json(root: &mut serde_json::Value) -> bool {
+    let hooks = match root
+        .get_mut("hooks")
+        .and_then(|h| h.get_mut(PRE_TOOL_USE_KEY))
+        .and_then(|p| p.as_array_mut())
+    {
+        Some(hooks) => hooks,
+        None => return false,
+    };
+
+    let original_len = hooks.len();
+    hooks.retain(|entry| {
+        let hook_entries = match entry.get("hooks").and_then(|h| h.as_array()) {
+            Some(hook_entries) => hook_entries,
+            None => return true,
+        };
+
+        !hook_entries.iter().any(|hook| {
+            hook.get("command")
+                .and_then(|c| c.as_str())
+                .is_some_and(|command| command.trim() == CODEX_HOOK_COMMAND)
+        })
+    });
+
+    hooks.len() < original_len
 }
 
 /// Orchestrator: patch settings.json with RTK hook
@@ -1255,26 +1348,31 @@ fn run_windsurf_mode(verbose: u8) -> Result<()> {
 }
 
 fn run_codex_mode(global: bool, verbose: u8) -> Result<()> {
+    let codex_dir = if global {
+        resolve_codex_dir()?
+    } else {
+        resolve_local_codex_dir()
+    };
     let (agents_md_path, rtk_md_path) = if global {
-        let codex_dir = resolve_codex_dir()?;
         (codex_dir.join(AGENTS_MD), codex_dir.join(RTK_MD))
     } else {
         (PathBuf::from(AGENTS_MD), PathBuf::from(RTK_MD))
     };
 
-    if global {
-        if let Some(parent) = agents_md_path.parent() {
-            fs::create_dir_all(parent).with_context(|| {
-                format!(
-                    "Failed to create Codex config directory: {}",
-                    parent.display()
-                )
-            })?;
-        }
-    }
+    fs::create_dir_all(&codex_dir).with_context(|| {
+        format!(
+            "Failed to create Codex config directory: {}",
+            codex_dir.display()
+        )
+    })?;
+
+    let config_path = codex_dir.join(CONFIG_TOML);
+    let hooks_json_path = codex_dir.join(HOOKS_JSON);
 
     write_if_changed(&rtk_md_path, RTK_SLIM_CODEX, RTK_MD, verbose)?;
     let added_ref = patch_agents_md(&agents_md_path, verbose)?;
+    let feature_enabled = ensure_codex_hooks_feature_enabled(&config_path, verbose)?;
+    let hook_added = patch_codex_hooks_json(&hooks_json_path, verbose)?;
 
     println!("\nRTK configured for Codex CLI.\n");
     println!("  RTK.md:    {}", rtk_md_path.display());
@@ -1294,6 +1392,22 @@ fn run_codex_mode(global: bool, verbose: u8) -> Result<()> {
             agents_md_path.display()
         );
     }
+    println!("  hooks.json: {}", hooks_json_path.display());
+    if hook_added {
+        println!("  hooks.json: RTK PreToolUse hook added");
+    } else {
+        println!("  hooks.json: RTK PreToolUse hook already present");
+    }
+    println!("  config.toml: {}", config_path.display());
+    if feature_enabled {
+        println!("  config.toml: enabled features.codex_hooks = true");
+    } else {
+        println!("  config.toml: features.codex_hooks already enabled");
+    }
+    println!(
+        "\n  Note: Codex hooks cannot rewrite Bash commands in-place yet, so RTK blocks matching Bash commands and suggests the `rtk ...` equivalent."
+    );
+    println!("  Restart Codex. Test with: git status\n");
 
     Ok(())
 }
@@ -1539,6 +1653,10 @@ fn resolve_codex_dir() -> Result<PathBuf> {
     resolve_home_subdir(".codex")
 }
 
+fn resolve_local_codex_dir() -> PathBuf {
+    PathBuf::from(".codex")
+}
+
 fn resolve_opencode_dir() -> Result<PathBuf> {
     resolve_home_subdir(".config/opencode")
 }
@@ -1584,6 +1702,172 @@ fn remove_opencode_plugin(verbose: u8) -> Result<Vec<PathBuf>> {
     }
 
     Ok(removed)
+}
+
+fn codex_hooks_enabled(path: &Path) -> Result<bool> {
+    if !path.exists() {
+        return Ok(false);
+    }
+
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    if content.trim().is_empty() {
+        return Ok(false);
+    }
+
+    let root: toml::Value =
+        toml::from_str(&content).with_context(|| format!("Failed to parse {}", path.display()))?;
+
+    Ok(root
+        .get("features")
+        .and_then(|f| f.get("codex_hooks"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false))
+}
+
+fn ensure_codex_hooks_feature_enabled(path: &Path, verbose: u8) -> Result<bool> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create Codex config dir: {}", parent.display()))?;
+    }
+
+    let mut root = if path.exists() {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+
+        if content.trim().is_empty() {
+            toml::Value::Table(toml::map::Map::new())
+        } else {
+            toml::from_str(&content)
+                .with_context(|| format!("Failed to parse {}", path.display()))?
+        }
+    } else {
+        toml::Value::Table(toml::map::Map::new())
+    };
+
+    let root_table = match root.as_table_mut() {
+        Some(table) => table,
+        None => anyhow::bail!("Codex config root must be a TOML table: {}", path.display()),
+    };
+
+    let features = root_table
+        .entry("features")
+        .or_insert_with(|| toml::Value::Table(toml::map::Map::new()));
+    let features_table = match features.as_table_mut() {
+        Some(table) => table,
+        None => anyhow::bail!("Codex [features] must be a TOML table: {}", path.display()),
+    };
+
+    if features_table
+        .get("codex_hooks")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        return Ok(false);
+    }
+
+    features_table.insert("codex_hooks".to_string(), toml::Value::Boolean(true));
+    backup_file_if_exists(path, verbose)?;
+    let serialized = toml::to_string_pretty(&root).context("Failed to serialize Codex config")?;
+    atomic_write(path, &serialized)?;
+
+    if verbose > 0 {
+        eprintln!("Enabled features.codex_hooks in {}", path.display());
+    }
+
+    Ok(true)
+}
+
+fn patch_codex_hooks_json(path: &Path, verbose: u8) -> Result<bool> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create Codex hooks dir: {}", parent.display()))?;
+    }
+
+    let mut root = if path.exists() {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+
+        if content.trim().is_empty() {
+            serde_json::json!({ "hooks": {} })
+        } else {
+            serde_json::from_str(&content)
+                .with_context(|| format!("Failed to parse {} as JSON", path.display()))?
+        }
+    } else {
+        serde_json::json!({ "hooks": {} })
+    };
+
+    if codex_hook_already_present(&root) {
+        if verbose > 0 {
+            eprintln!("Codex hooks.json: RTK hook already present");
+        }
+        return Ok(false);
+    }
+
+    insert_codex_hook_entry(&mut root);
+    backup_file_if_exists(path, verbose)?;
+    let serialized =
+        serde_json::to_string_pretty(&root).context("Failed to serialize Codex hooks.json")?;
+    atomic_write(path, &serialized)?;
+
+    if verbose > 0 {
+        eprintln!("Patched Codex hooks.json: {}", path.display());
+    }
+
+    Ok(true)
+}
+
+fn codex_hook_already_present(root: &serde_json::Value) -> bool {
+    root.get("hooks")
+        .and_then(|h| h.get(PRE_TOOL_USE_KEY))
+        .and_then(|p| p.as_array())
+        .is_some_and(|groups| {
+            groups.iter().any(|entry| {
+                entry
+                    .get("hooks")
+                    .and_then(|h| h.as_array())
+                    .is_some_and(|hooks| {
+                        hooks.iter().any(|hook| {
+                            hook.get("command")
+                                .and_then(|c| c.as_str())
+                                .is_some_and(|command| command.trim() == CODEX_HOOK_COMMAND)
+                        })
+                    })
+            })
+        })
+}
+
+fn insert_codex_hook_entry(root: &mut serde_json::Value) {
+    let root_obj = match root.as_object_mut() {
+        Some(obj) => obj,
+        None => {
+            *root = serde_json::json!({ "hooks": {} });
+            root.as_object_mut()
+                .expect("Just created object, must succeed")
+        }
+    };
+
+    let hooks = root_obj
+        .entry("hooks")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .expect("hooks must be an object");
+
+    let pre_tool_use = hooks
+        .entry(PRE_TOOL_USE_KEY)
+        .or_insert_with(|| serde_json::json!([]))
+        .as_array_mut()
+        .expect("PreToolUse must be an array");
+
+    pre_tool_use.push(serde_json::json!({
+        "matcher": "Bash",
+        "hooks": [{
+            "type": "command",
+            "command": CODEX_HOOK_COMMAND,
+            "statusMessage": "Checking RTK rewrite"
+        }]
+    }));
 }
 
 // ─── Cursor Agent support ─────────────────────────────────────────────
@@ -2033,8 +2317,10 @@ fn show_claude_config() -> Result<()> {
     println!("  rtk init -g --uninstall     # Remove all RTK artifacts");
     println!("  rtk init -g --claude-md     # Legacy: full injection into ~/.claude/CLAUDE.md");
     println!("  rtk init -g --hook-only     # Hook only, no RTK.md");
-    println!("  rtk init --codex            # Configure local AGENTS.md + RTK.md");
-    println!("  rtk init -g --codex         # Configure ~/.codex/AGENTS.md + ~/.codex/RTK.md");
+    println!(
+        "  rtk init --codex            # Configure local AGENTS.md + RTK.md + ./.codex/hooks.json"
+    );
+    println!("  rtk init -g --codex         # Configure ~/.codex/AGENTS.md + ~/.codex/RTK.md + hooks.json");
     println!("  rtk init -g --opencode      # OpenCode plugin only");
     println!("  rtk init -g --agent cursor  # Install Cursor Agent hooks");
 
@@ -2045,8 +2331,13 @@ fn show_codex_config() -> Result<()> {
     let codex_dir = resolve_codex_dir()?;
     let global_agents_md = codex_dir.join(AGENTS_MD);
     let global_rtk_md = codex_dir.join(RTK_MD);
+    let global_hooks_json = codex_dir.join(HOOKS_JSON);
+    let global_config_toml = codex_dir.join(CONFIG_TOML);
+    let local_codex_dir = resolve_local_codex_dir();
     let local_agents_md = PathBuf::from(AGENTS_MD);
     let local_rtk_md = PathBuf::from(RTK_MD);
+    let local_hooks_json = local_codex_dir.join(HOOKS_JSON);
+    let local_config_toml = local_codex_dir.join(CONFIG_TOML);
 
     println!("rtk Configuration (Codex CLI):\n");
 
@@ -2069,6 +2360,26 @@ fn show_codex_config() -> Result<()> {
         println!("[--] Global AGENTS.md: not found");
     }
 
+    if global_hooks_json.exists() {
+        let content = fs::read_to_string(&global_hooks_json)?;
+        let json: serde_json::Value = serde_json::from_str(&content)?;
+        if codex_hook_already_present(&json) {
+            println!("[ok] Global hooks.json: RTK PreToolUse hook");
+        } else {
+            println!("[--] Global hooks.json: exists but RTK hook missing");
+        }
+    } else {
+        println!("[--] Global hooks.json: not found");
+    }
+
+    if codex_hooks_enabled(&global_config_toml)? {
+        println!("[ok] Global config.toml: features.codex_hooks = true");
+    } else if global_config_toml.exists() {
+        println!("[--] Global config.toml: Codex hooks feature disabled");
+    } else {
+        println!("[--] Global config.toml: not found");
+    }
+
     if local_rtk_md.exists() {
         println!("[ok] Local RTK.md: {}", local_rtk_md.display());
     } else {
@@ -2088,10 +2399,31 @@ fn show_codex_config() -> Result<()> {
         println!("[--] Local AGENTS.md: not found");
     }
 
+    if local_hooks_json.exists() {
+        let content = fs::read_to_string(&local_hooks_json)?;
+        let json: serde_json::Value = serde_json::from_str(&content)?;
+        if codex_hook_already_present(&json) {
+            println!("[ok] Local hooks.json: RTK PreToolUse hook");
+        } else {
+            println!("[--] Local hooks.json: exists but RTK hook missing");
+        }
+    } else {
+        println!("[--] Local hooks.json: not found");
+    }
+
+    if codex_hooks_enabled(&local_config_toml)? {
+        println!("[ok] Local config.toml: features.codex_hooks = true");
+    } else if local_config_toml.exists() {
+        println!("[--] Local config.toml: Codex hooks feature disabled");
+    } else {
+        println!("[--] Local config.toml: not found");
+    }
+
     println!("\nUsage:");
-    println!("  rtk init --codex              # Configure local AGENTS.md + RTK.md");
-    println!("  rtk init -g --codex           # Configure ~/.codex/AGENTS.md + ~/.codex/RTK.md");
+    println!("  rtk init --codex              # Configure local AGENTS.md + RTK.md + ./.codex/hooks.json");
+    println!("  rtk init -g --codex           # Configure ~/.codex/AGENTS.md + ~/.codex/RTK.md + hooks.json");
     println!("  rtk init -g --codex --uninstall  # Remove global Codex RTK artifacts");
+    println!("  Note: Codex currently blocks + suggests `rtk ...`; transparent hook rewrites are not supported yet.");
 
     Ok(())
 }
@@ -2658,6 +2990,90 @@ More notes
     }
 
     #[test]
+    fn test_insert_codex_hook_entry_empty() {
+        let mut json_content = serde_json::json!({});
+
+        insert_codex_hook_entry(&mut json_content);
+
+        let pre_tool_use = json_content["hooks"][PRE_TOOL_USE_KEY].as_array().unwrap();
+        assert_eq!(pre_tool_use.len(), 1);
+        assert_eq!(pre_tool_use[0]["matcher"], "Bash");
+        assert_eq!(pre_tool_use[0]["hooks"][0]["command"], CODEX_HOOK_COMMAND);
+    }
+
+    #[test]
+    fn test_insert_codex_hook_preserves_existing() {
+        let mut json_content = serde_json::json!({
+            "hooks": {
+                (PRE_TOOL_USE_KEY): [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "python3 ./other-hook.py"
+                    }]
+                }]
+            }
+        });
+
+        insert_codex_hook_entry(&mut json_content);
+
+        let pre_tool_use = json_content["hooks"][PRE_TOOL_USE_KEY].as_array().unwrap();
+        assert_eq!(pre_tool_use.len(), 2);
+        assert_eq!(
+            pre_tool_use[0]["hooks"][0]["command"],
+            "python3 ./other-hook.py"
+        );
+        assert_eq!(pre_tool_use[1]["hooks"][0]["command"], CODEX_HOOK_COMMAND);
+    }
+
+    #[test]
+    fn test_remove_codex_hook_from_json() {
+        let mut json_content = serde_json::json!({
+            "hooks": {
+                (PRE_TOOL_USE_KEY): [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "python3 ./other-hook.py"
+                        }]
+                    },
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{
+                            "type": "command",
+                            "command": CODEX_HOOK_COMMAND
+                        }]
+                    }
+                ]
+            }
+        });
+
+        let removed = remove_codex_hook_from_json(&mut json_content);
+
+        assert!(removed);
+        let pre_tool_use = json_content["hooks"][PRE_TOOL_USE_KEY].as_array().unwrap();
+        assert_eq!(pre_tool_use.len(), 1);
+        assert_eq!(
+            pre_tool_use[0]["hooks"][0]["command"],
+            "python3 ./other-hook.py"
+        );
+    }
+
+    #[test]
+    fn test_ensure_codex_hooks_feature_enabled_creates_and_is_idempotent() {
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join(CONFIG_TOML);
+
+        let changed_first = ensure_codex_hooks_feature_enabled(&config_path, 0).unwrap();
+        let changed_second = ensure_codex_hooks_feature_enabled(&config_path, 0).unwrap();
+
+        assert!(changed_first);
+        assert!(!changed_second);
+        assert!(codex_hooks_enabled(&config_path).unwrap());
+    }
+
+    #[test]
     fn test_patch_agents_md_creates_missing_file() {
         let temp = TempDir::new().unwrap();
         let agents_md = temp.path().join("AGENTS.md");
@@ -2693,20 +3109,41 @@ More notes
         let codex_dir = temp.path();
         let agents_md = codex_dir.join("AGENTS.md");
         let rtk_md = codex_dir.join("RTK.md");
+        let hooks_json = codex_dir.join(HOOKS_JSON);
 
         fs::write(&agents_md, "# Team rules\n\n@RTK.md\n").unwrap();
         fs::write(&rtk_md, "codex config").unwrap();
+        fs::write(
+            &hooks_json,
+            serde_json::json!({
+                "hooks": {
+                    (PRE_TOOL_USE_KEY): [{
+                        "matcher": "Bash",
+                        "hooks": [{
+                            "type": "command",
+                            "command": CODEX_HOOK_COMMAND
+                        }]
+                    }]
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
 
         let removed_first = uninstall_codex_at(codex_dir, 0).unwrap();
         let removed_second = uninstall_codex_at(codex_dir, 0).unwrap();
 
-        assert_eq!(removed_first.len(), 2);
+        assert_eq!(removed_first.len(), 3);
         assert!(removed_second.is_empty());
         assert!(!rtk_md.exists());
 
         let content = fs::read_to_string(&agents_md).unwrap();
         assert!(!content.contains("@RTK.md"));
         assert!(content.contains("# Team rules"));
+
+        let hooks_content = fs::read_to_string(&hooks_json).unwrap();
+        let hooks_json: serde_json::Value = serde_json::from_str(&hooks_content).unwrap();
+        assert!(!codex_hook_already_present(&hooks_json));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -340,7 +340,7 @@ enum Commands {
         #[arg(long)]
         uninstall: bool,
 
-        /// Target Codex CLI (uses AGENTS.md + RTK.md, no Claude hook patching)
+        /// Target Codex CLI (AGENTS.md + RTK.md + hooks.json for deny-with-suggestion)
         #[arg(long)]
         codex: bool,
 
@@ -668,7 +668,7 @@ enum Commands {
     /// Exits 0 and prints the rewritten command if supported.
     /// Exits 1 with no output if the command has no RTK equivalent.
     ///
-    /// Used by Claude Code, Gemini CLI, and other LLM hooks:
+    /// Used by Claude Code, Gemini CLI, Codex, and other LLM hooks:
     ///   REWRITTEN=$(rtk rewrite "$CMD") || exit 0
     Rewrite {
         /// Raw command to rewrite (e.g. "git status", "cargo test && git push")
@@ -677,7 +677,7 @@ enum Commands {
         args: Vec<String>,
     },
 
-    /// Hook processors for LLM CLI tools (Gemini CLI, Copilot, etc.)
+    /// Hook processors for LLM CLI tools (Gemini CLI, Copilot, Codex, etc.)
     Hook {
         #[command(subcommand)]
         command: HookCommands,
@@ -690,6 +690,8 @@ enum HookCommands {
     Gemini,
     /// Process Copilot preToolUse hook (VS Code + Copilot CLI, reads JSON from stdin)
     Copilot,
+    /// Process Codex CLI PreToolUse hook (reads JSON from stdin)
+    Codex,
 }
 
 #[derive(Subcommand)]
@@ -1919,6 +1921,7 @@ fn run_cli() -> Result<i32> {
             match command {
                 HookCommands::Gemini => hooks::hook_cmd::run_gemini()?,
                 HookCommands::Copilot => hooks::hook_cmd::run_copilot()?,
+                HookCommands::Codex => hooks::hook_cmd::run_codex()?,
             }
             0
         }


### PR DESCRIPTION
## Summary
- add Codex-specific `rtk hook codex` handling and install it via Codex `hooks.json`
- enable `features.codex_hooks = true` during `rtk init --codex`, while preserving AGENTS/RTK guidance
- make Codex hooks point at the exact RTK binary that ran `rtk init --codex`, so the live hook works even when an older `rtk` exists on PATH
- update Codex docs to explain the current deny-with-suggestion behavior and add coverage for install/uninstall helpers

## Why
Codex CLI now exposes hooks, but the current official Codex hooks docs say `updatedInput` is parsed but not supported yet for `PreToolUse`, so it fails open. RTK therefore installs a Codex hook that blocks matching raw Bash commands and tells Codex to retry with the `rtk ...` equivalent.

During live testing I also found a real install bug: a bare `rtk hook codex` could hit an older RTK binary on PATH, causing the hook to silently do nothing. The hook now stores the exact RTK executable path used during install.

Docs reference: https://developers.openai.com/codex/hooks

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all`
- temp-home smoke test for `rtk init -g --codex`, generated `hooks.json` / `config.toml`, `rtk hook codex`, and `codex features list`
- live Codex exec with temporary deny hook: command blocked
- live Codex exec with temporary allow + `updatedInput`: original command still ran
- live Codex exec after reinstall using absolute RTK hook path: real RTK hook blocked `git status` and suggested `rtk git status`

Closes #1003.
