### PR TITLE
feat(rules): add git tag to rewrite rule

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1846,6 +1846,25 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_classify_git_tag_list() {
+        assert!(matches!(
+            classify_command("git tag -l 'v*'"),
+            Classification::Supported {
+                rtk_equivalent: "rtk git",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_rewrite_git_tag_annotated() {
+        assert_eq!(
+            rewrite_command("git tag -a v2.0.0 -m 'release'", &[]),
+            Some("rtk git tag -a v2.0.0 -m 'release'".into())
+        );
+    }
+
     // --- Go tooling ---
 
     #[test]

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1825,6 +1825,27 @@ mod tests {
         );
     }
 
+    // --- git tag ---
+
+    #[test]
+    fn test_classify_git_tag() {
+        assert!(matches!(
+            classify_command("git tag v1.0.0"),
+            Classification::Supported {
+                rtk_equivalent: "rtk git",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_rewrite_git_tag() {
+        assert_eq!(
+            rewrite_command("git tag v1.0.0", &[]),
+            Some("rtk git tag v1.0.0".into())
+        );
+    }
+
     // --- Go tooling ---
 
     #[test]

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -12,7 +12,7 @@ pub struct RtkRule {
 
 pub const RULES: &[RtkRule] = &[
     RtkRule {
-        pattern: r"^git\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|push|pull|branch|fetch|stash|worktree)",
+        pattern: r"^git\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|push|pull|branch|fetch|stash|worktree|tag)",
         rtk_cmd: "rtk git",
         rewrite_prefixes: &["git"],
         category: "Git",


### PR DESCRIPTION
## Summary
- Extend the git rule pattern to include the `tag` subcommand
- `git tag v1.0.0` → `rtk git tag v1.0.0`

## Motivation
`rtk discover` showed 49 unhandled `git tag` commands over 30 days. The existing git command handler already supports passthrough for unlisted subcommands, so only the regex pattern needs updating.

## Changes
| File | Change |
|------|--------|
| `src/discover/rules.rs` | Add `tag` to git pattern alternation |
| `src/discover/registry.rs` | Add `test_classify_git_tag` and `test_rewrite_git_tag` |

## Test plan
- [x] `cargo test git_tag` — 2 new tests pass
- [x] `cargo test` — 1255 passed, 3 ignored, 0 failed
- [x] `rtk rewrite "git tag v1.0.0"` → `rtk git tag v1.0.0`
- [x] Existing git rewrites unchanged (`git status`, `git diff`, etc.)