### PR TITLE
feat(ssh): add ssh command with output truncation

### DIFF
--- a/src/cmds/cloud/ssh_cmd.rs
+++ b/src/cmds/cloud/ssh_cmd.rs
@@ -118,4 +118,55 @@ mod tests {
         let filtered = filter_ssh_output("", "");
         assert_eq!(filtered, "");
     }
+
+    fn count_tokens(text: &str) -> usize {
+        text.split_whitespace().count()
+    }
+
+    #[test]
+    fn test_token_savings_long_output() {
+        // Simulate verbose ssh output (200 lines of systemctl-style output)
+        let input: String = (0..200)
+            .map(|i| format!("    Active: active (running) since Mon; {}d ago", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let filtered = filter_ssh_output(&input, "");
+
+        let input_tokens = count_tokens(&input);
+        let output_tokens = count_tokens(&filtered);
+        let savings = 100.0 - (output_tokens as f64 / input_tokens as f64 * 100.0);
+
+        assert!(
+            savings >= 50.0,
+            "SSH filter: expected ≥50% savings on long output, got {:.1}%",
+            savings
+        );
+    }
+
+    #[test]
+    fn test_truncated_output_format() {
+        let input: String = (0..100)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let filtered = filter_ssh_output(&input, "");
+        // First line preserved
+        assert!(filtered.starts_with("line 0\n"));
+        // Last real line is line 79
+        assert!(filtered.contains("line 79\n"));
+        // Line 80 is NOT in output
+        assert!(!filtered.contains("line 80\n"));
+        // Truncation message at the end
+        assert!(filtered.trim_end().ends_with("... +20 lines truncated"));
+    }
+
+    #[test]
+    fn test_stderr_not_in_filtered_output() {
+        let stdout = "connected to host\ncommand output line 1\ncommand output line 2\n";
+        let stderr = "Warning: Permanently added 'host' to known hosts.\n";
+        let filtered = filter_ssh_output(stdout, stderr);
+        // stderr goes to eprintln, not into the returned filtered string
+        assert!(!filtered.contains("Warning"));
+        assert!(filtered.contains("connected to host"));
+    }
 }

--- a/src/cmds/cloud/ssh_cmd.rs
+++ b/src/cmds/cloud/ssh_cmd.rs
@@ -1,0 +1,121 @@
+//! Runs ssh and compacts output (strips blank lines, caps at 80 lines).
+//!
+//! SSH remote commands can produce verbose output (docker logs, systemctl status,
+//! journal dumps) that wastes tokens when piped back to an LLM. This handler
+//! passes through the command unchanged but truncates the result.
+
+use crate::core::tracking;
+use crate::core::utils::{exit_code_from_output, resolved_command};
+use anyhow::{Context, Result};
+
+const MAX_LINES: usize = 80;
+const MAX_STDERR_LINES: usize = 5;
+
+pub fn run(args: &[String], verbose: u8) -> Result<i32> {
+    let timer = tracking::TimedExecution::start();
+    let mut cmd = resolved_command("ssh");
+
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    if verbose > 0 {
+        eprintln!("Running: ssh {}", args.join(" "));
+    }
+
+    let output = cmd.output().context("Failed to run ssh")?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let raw = format!("{}\n{}", stdout, stderr);
+
+    let filtered = filter_ssh_output(&stdout, &stderr);
+    print!("{}", filtered);
+
+    timer.track(
+        &format!("ssh {}", args.join(" ")),
+        &format!("rtk ssh {}", args.join(" ")),
+        &raw,
+        &filtered,
+    );
+
+    Ok(exit_code_from_output(&output, "ssh"))
+}
+
+fn filter_ssh_output(stdout: &str, stderr: &str) -> String {
+    let mut result = String::new();
+
+    // Drop blank lines to reduce noise, then cap total output
+    let lines: Vec<&str> = stdout
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .collect();
+
+    let truncated = lines.len() > MAX_LINES;
+    for line in lines.iter().take(MAX_LINES) {
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    if truncated {
+        result.push_str(&format!(
+            "... +{} lines truncated\n",
+            lines.len() - MAX_LINES
+        ));
+    }
+
+    // Surface stderr (connection warnings, errors) but cap to avoid noise
+    let stderr_lines: Vec<&str> = stderr
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .collect();
+    if !stderr_lines.is_empty() {
+        for line in stderr_lines.iter().take(MAX_STDERR_LINES) {
+            eprintln!("{}", line);
+        }
+        if stderr_lines.len() > MAX_STDERR_LINES {
+            eprintln!(
+                "... +{} stderr lines truncated",
+                stderr_lines.len() - MAX_STDERR_LINES
+            );
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_filter_truncates_long_output() {
+        let long_output: String = (0..100)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let filtered = filter_ssh_output(&long_output, "");
+        assert!(filtered.contains("... +20 lines truncated"));
+        assert_eq!(filtered.lines().count(), MAX_LINES + 1); // 80 lines + truncation msg
+    }
+
+    #[test]
+    fn test_filter_short_output_unchanged() {
+        let output = "hello\nworld\n";
+        let filtered = filter_ssh_output(output, "");
+        assert_eq!(filtered, "hello\nworld\n");
+        assert!(!filtered.contains("truncated"));
+    }
+
+    #[test]
+    fn test_filter_strips_blank_lines() {
+        let output = "hello\n\n\nworld\n";
+        let filtered = filter_ssh_output(output, "");
+        assert_eq!(filtered, "hello\nworld\n");
+    }
+
+    #[test]
+    fn test_filter_empty_output() {
+        let filtered = filter_ssh_output("", "");
+        assert_eq!(filtered, "");
+    }
+}

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -2076,6 +2076,27 @@ mod tests {
         );
     }
 
+    // --- git tag ---
+
+    #[test]
+    fn test_classify_git_tag() {
+        assert!(matches!(
+            classify_command("git tag v1.0.0"),
+            Classification::Supported {
+                rtk_equivalent: "rtk git",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_rewrite_git_tag() {
+        assert_eq!(
+            rewrite_command("git tag v1.0.0", &[]),
+            Some("rtk git tag v1.0.0".into())
+        );
+    }
+
     // --- Go tooling ---
 
     #[test]

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -860,6 +860,15 @@ pub const RULES: &[RtkRule] = &[
         subcmd_savings: &[],
         subcmd_status: &[],
     },
+    RtkRule {
+        pattern: r"^ssh\s+\S+",
+        rtk_cmd: "rtk ssh",
+        rewrite_prefixes: &["ssh"],
+        category: "Infra",
+        savings_pct: 50.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
 ];
 
 pub const IGNORED_PREFIXES: &[&str] = &[

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod learn;
 mod parser;
 
 // Re-export command modules for routing
-use cmds::cloud::{aws_cmd, container, curl_cmd, psql_cmd, wget_cmd};
+use cmds::cloud::{aws_cmd, container, curl_cmd, psql_cmd, ssh_cmd, wget_cmd};
 use cmds::dotnet::{binlog, dotnet_cmd, dotnet_format_report, dotnet_trx};
 use cmds::git::{diff_cmd, gh_cmd, git, gt_cmd};
 use cmds::go::{go_cmd, golangci_cmd};
@@ -525,6 +525,13 @@ enum Commands {
     /// Curl with auto-JSON detection and schema output
     Curl {
         /// Curl arguments (URL + options)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// SSH with output truncation (strips blank lines, caps at 80 lines)
+    Ssh {
+        /// SSH arguments (host + command)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -1916,6 +1923,8 @@ fn run_cli() -> Result<i32> {
 
         Commands::Curl { args } => curl_cmd::run(&args, cli.verbose)?,
 
+        Commands::Ssh { args } => ssh_cmd::run(&args, cli.verbose)?,
+
         Commands::Discover {
             project,
             limit,
@@ -2374,6 +2383,7 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Npm { .. }
             | Commands::Npx { .. }
             | Commands::Curl { .. }
+            | Commands::Ssh { .. }
             | Commands::Ruff { .. }
             | Commands::Pytest { .. }
             | Commands::Rake { .. }


### PR DESCRIPTION
## Summary
- Add `rtk ssh` command that passes through to ssh and compacts output
- Strips blank lines and caps stdout at 80 lines, stderr at 5 lines
- Add rewrite rule so `ssh host cmd` → `rtk ssh host cmd` via hook

Closes #783
Closes #333

## Motivation
`rtk discover` showed 326 unhandled `ssh` commands over 30 days. SSH remote commands frequently produce verbose output (docker logs, journal dumps, systemctl status) that wastes tokens when piped back to an LLM.

## Changes
| File | Change |
|------|--------|
| `src/cmds/cloud/ssh_cmd.rs` | New: passthrough handler with blank-line stripping and 80-line cap |
| `src/discover/rules.rs` | Add `ssh` rule (pattern `^ssh\s+\S+`, category Infra, 50% est. savings) |
| `src/main.rs` | Add `Ssh` command variant, dispatch, and hook registration |

## Design decisions
- **Passthrough with truncation** rather than parsing: SSH output is unpredictable (could be JSON, logs, status tables) so we just cap lines rather than trying to parse structure
- **80-line stdout cap**: matches the typical useful output length for LLM context; anything beyond is noise
- **5-line stderr cap**: connection warnings and auth messages are useful; full error dumps are not

## Test plan
- [x] `cargo test ssh` — 4 new tests pass (truncation, short output, blank lines, empty)
- [x] `cargo test` — 1257 passed, 3 ignored, 0 failed
- [x] `rtk rewrite "ssh pi@rpi docker ps"` → `rtk ssh pi@rpi docker ps`