### PR TITLE
feat(rewrite): treat uv run as transparent prefix

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -263,18 +263,66 @@ fn strip_git_global_opts(cmd: &str) -> String {
     format!("git {}", stripped.trim())
 }
 
-/// Strip `uv run` transparent prefix: `uv run pytest -v` → `pytest -v`.
+/// Split a `uv run [flags] <inner_cmd>` string into the uv prefix and the inner command.
+/// Returns `Some((prefix, inner))` where `prefix` includes `"uv run "` and any uv-specific
+/// flags (e.g. `"uv run --frozen "`), and `inner` is the real command (e.g. `"pytest -v"`).
+/// Returns `None` if there's no `uv run ` prefix or no inner command after the flags.
+fn split_uv_run(cmd: &str) -> Option<(&str, &str)> {
+    let after_uv_run = cmd.strip_prefix("uv run ")?;
+
+    // Known uv flags that consume the next token as a value
+    const VALUE_FLAGS: &[&str] = &[
+        "--with",
+        "--without",
+        "--python",
+        "-p",
+        "--extra",
+        "--group",
+        "--only-group",
+    ];
+
+    let bytes = after_uv_run.as_bytes();
+    let mut pos = 0;
+
+    loop {
+        // Skip whitespace
+        while pos < bytes.len() && bytes[pos] == b' ' {
+            pos += 1;
+        }
+        if pos >= bytes.len() {
+            return None; // only flags, no inner command
+        }
+        if bytes[pos] != b'-' {
+            break; // found inner command
+        }
+        // Consume flag token
+        let tok_start = pos;
+        while pos < bytes.len() && bytes[pos] != b' ' {
+            pos += 1;
+        }
+        let tok = &after_uv_run[tok_start..pos];
+        // Value-taking flag: also skip the next token
+        if VALUE_FLAGS.contains(&tok) {
+            while pos < bytes.len() && bytes[pos] == b' ' {
+                pos += 1;
+            }
+            while pos < bytes.len() && bytes[pos] != b' ' {
+                pos += 1;
+            }
+        }
+    }
+
+    let prefix_end = "uv run ".len() + pos;
+    Some((&cmd[..prefix_end], &cmd[prefix_end..]))
+}
+
+/// Strip `uv run [flags]` transparent prefix: `uv run --frozen pytest -v` → `pytest -v`.
 /// `uv run` is a virtualenv wrapper — the real command follows it.
 /// Returns a Cow to avoid allocation when no prefix is present.
 fn strip_uv_run_prefix(cmd: &str) -> std::borrow::Cow<'_, str> {
-    if let Some(rest) = cmd.strip_prefix("uv run ") {
-        let inner = rest.trim_start();
-        if inner.is_empty() {
-            return std::borrow::Cow::Borrowed(cmd);
-        }
-        std::borrow::Cow::Owned(inner.to_string())
-    } else {
-        std::borrow::Cow::Borrowed(cmd)
+    match split_uv_run(cmd) {
+        Some((_, inner)) => std::borrow::Cow::Owned(inner.to_string()),
+        None => std::borrow::Cow::Borrowed(cmd),
     }
 }
 
@@ -548,12 +596,11 @@ fn rewrite_segment(seg: &str, excluded: &[String]) -> Option<String> {
     let env_prefix = &cmd_part[..env_prefix_len];
     let after_env = stripped_cow.trim();
 
-    // Strip `uv run` transparent prefix — preserve it so the rewritten command
-    // keeps the virtualenv active: `uv run pytest` → `uv run rtk pytest`
-    let (uv_prefix, cmd_clean) = if let Some(rest) = after_env.strip_prefix("uv run ") {
-        ("uv run ", rest.trim_start())
-    } else {
-        ("", after_env)
+    // Strip `uv run [flags]` transparent prefix — preserve it so the rewritten
+    // command keeps the virtualenv active: `uv run --frozen pytest` → `uv run --frozen rtk pytest`
+    let (uv_prefix, cmd_clean) = match split_uv_run(after_env) {
+        Some((prefix, inner)) => (prefix, inner),
+        None => ("", after_env),
     };
 
     // #345: RTK_DISABLED=1 in env prefix → skip rewrite entirely
@@ -1912,6 +1959,68 @@ mod tests {
         assert_eq!(
             rewrite_command("uv run python -m pytest tests/", &[]),
             Some("uv run rtk pytest tests/".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_uv_run_alone() {
+        // "uv run" with no inner command should not be rewritten
+        assert_eq!(rewrite_command("uv run", &[]), None);
+    }
+
+    #[test]
+    fn test_classify_uv_run_frozen_pytest() {
+        // uv flags like --frozen should be skipped to find the inner command
+        assert!(matches!(
+            classify_command("uv run --frozen pytest tests/"),
+            Classification::Supported {
+                rtk_equivalent: "rtk pytest",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_rewrite_uv_run_frozen_pytest() {
+        assert_eq!(
+            rewrite_command("uv run --frozen pytest tests/", &[]),
+            Some("uv run --frozen rtk pytest tests/".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_uv_run_with_pkg_pytest() {
+        // --with takes a value argument
+        assert_eq!(
+            rewrite_command("uv run --with coverage pytest tests/", &[]),
+            Some("uv run --with coverage rtk pytest tests/".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_env_prefix_uv_run_pytest() {
+        // env prefix + uv run should both be preserved
+        assert_eq!(
+            rewrite_command("PYTHONPATH=. uv run pytest tests/", &[]),
+            Some("PYTHONPATH=. uv run rtk pytest tests/".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_rtk_disabled_uv_run_pytest() {
+        // RTK_DISABLED=1 should suppress rewrite even with uv run
+        assert_eq!(
+            rewrite_command("RTK_DISABLED=1 uv run pytest tests/", &[]),
+            None
+        );
+    }
+
+    #[test]
+    fn test_rewrite_uv_run_pytest_redirect() {
+        // Redirect suffix should be preserved
+        assert_eq!(
+            rewrite_command("uv run pytest tests/ 2>&1", &[]),
+            Some("uv run rtk pytest tests/ 2>&1".into())
         );
     }
 

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -96,6 +96,11 @@ pub fn classify_command(cmd: &str) -> Classification {
         return Classification::Ignored;
     }
 
+    // Strip `uv run` transparent prefix — it's a virtualenv wrapper, not a command.
+    // This lets `uv run pytest ...` classify as Supported(rtk pytest).
+    let cmd_clean = strip_uv_run_prefix(cmd_clean);
+    let cmd_clean = cmd_clean.as_ref();
+
     // Normalize absolute binary paths: /usr/bin/grep → grep (#485)
     let cmd_normalized = strip_absolute_path(cmd_clean);
     // Strip git global options: git -C /tmp status → git status (#163)
@@ -256,6 +261,21 @@ fn strip_git_global_opts(cmd: &str) -> String {
     let after_git = &cmd[4..]; // skip "git "
     let stripped = GIT_GLOBAL_OPT.replace(after_git, "");
     format!("git {}", stripped.trim())
+}
+
+/// Strip `uv run` transparent prefix: `uv run pytest -v` → `pytest -v`.
+/// `uv run` is a virtualenv wrapper — the real command follows it.
+/// Returns a Cow to avoid allocation when no prefix is present.
+fn strip_uv_run_prefix(cmd: &str) -> std::borrow::Cow<'_, str> {
+    if let Some(rest) = cmd.strip_prefix("uv run ") {
+        let inner = rest.trim_start();
+        if inner.is_empty() {
+            return std::borrow::Cow::Borrowed(cmd);
+        }
+        std::borrow::Cow::Owned(inner.to_string())
+    } else {
+        std::borrow::Cow::Borrowed(cmd)
+    }
 }
 
 /// Normalize absolute binary paths: `/usr/bin/grep -rn foo` → `grep -rn foo` (#485)
@@ -526,7 +546,15 @@ fn rewrite_segment(seg: &str, excluded: &[String]) -> Option<String> {
     let stripped_cow = ENV_PREFIX.replace(cmd_part, "");
     let env_prefix_len = cmd_part.len() - stripped_cow.len();
     let env_prefix = &cmd_part[..env_prefix_len];
-    let cmd_clean = stripped_cow.trim();
+    let after_env = stripped_cow.trim();
+
+    // Strip `uv run` transparent prefix — preserve it so the rewritten command
+    // keeps the virtualenv active: `uv run pytest` → `uv run rtk pytest`
+    let (uv_prefix, cmd_clean) = if let Some(rest) = after_env.strip_prefix("uv run ") {
+        ("uv run ", rest.trim_start())
+    } else {
+        ("", after_env)
+    };
 
     // #345: RTK_DISABLED=1 in env prefix → skip rewrite entirely
     // #508: warn on stderr so agents learn to stop overusing it
@@ -554,9 +582,15 @@ fn rewrite_segment(seg: &str, excluded: &[String]) -> Option<String> {
     for &prefix in rule.rewrite_prefixes {
         if let Some(rest) = strip_word_prefix(cmd_clean, prefix) {
             let rewritten = if rest.is_empty() {
-                format!("{}{}{}", env_prefix, rule.rtk_cmd, redirect_suffix)
+                format!(
+                    "{}{}{}{}",
+                    env_prefix, uv_prefix, rule.rtk_cmd, redirect_suffix
+                )
             } else {
-                format!("{}{} {}{}", env_prefix, rule.rtk_cmd, rest, redirect_suffix)
+                format!(
+                    "{}{}{} {}{}",
+                    env_prefix, uv_prefix, rule.rtk_cmd, rest, redirect_suffix
+                )
             };
             return Some(rewritten);
         }
@@ -1822,6 +1856,62 @@ mod tests {
         assert_eq!(
             rewrite_command("uv pip list", &[]),
             Some("rtk pip list".into())
+        );
+    }
+
+    // --- uv run transparent prefix ---
+
+    #[test]
+    fn test_classify_uv_run_pytest() {
+        assert!(matches!(
+            classify_command("uv run pytest tests/ -v"),
+            Classification::Supported {
+                rtk_equivalent: "rtk pytest",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_classify_uv_run_ruff() {
+        assert!(matches!(
+            classify_command("uv run ruff check ."),
+            Classification::Supported {
+                rtk_equivalent: "rtk ruff",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_rewrite_uv_run_pytest() {
+        assert_eq!(
+            rewrite_command("uv run pytest tests/ -v", &[]),
+            Some("uv run rtk pytest tests/ -v".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_uv_run_ruff() {
+        assert_eq!(
+            rewrite_command("uv run ruff check .", &[]),
+            Some("uv run rtk ruff check .".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_uv_run_mypy() {
+        assert_eq!(
+            rewrite_command("uv run mypy --strict src/", &[]),
+            Some("uv run rtk mypy --strict src/".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_uv_run_python_m_pytest() {
+        assert_eq!(
+            rewrite_command("uv run python -m pytest tests/", &[]),
+            Some("uv run rtk pytest tests/".into())
         );
     }
 


### PR DESCRIPTION
## Summary
- Handle `uv run` as a transparent prefix (like `sudo`/`env`) in both `classify_command` and `rewrite_segment`
- The inner command is matched against existing rules; `uv run` is preserved so the virtualenv stays active

```
uv run pytest tests/ -v     → uv run rtk pytest tests/ -v
uv run ruff check .         → uv run rtk ruff check .
uv run python -m pytest     → uv run rtk pytest tests/
uv run mypy --strict src/   → uv run rtk mypy --strict src/
```

## Motivation
`uv run` is the #1 unhandled command in `rtk discover` — 1,062 occurrences over 30 days. Since `uv run` is just a virtualenv wrapper, the real command follows it and can be matched by existing RTK rules.

## Relationship to #176
PR #176 takes a different approach: a first-class `rtk uv` command with subcommand dispatch (`uv run pytest` → `rtk uv run pytest`). This PR is complementary — it treats `uv run` as a transparent prefix so no new command handler is needed. RTK runs inside `uv run` and filters output normally. If #176 lands first, this PR's approach can be superseded.

## Changes
| File | Change |
|------|--------|
| `src/discover/registry.rs` | Add `strip_uv_run_prefix()` in `classify_command`; add `uv_prefix` preservation in `rewrite_segment` format strings |

## Design decisions
- **Cow return type** on `strip_uv_run_prefix` avoids allocation when no prefix is present (majority of commands)
- **Preserving `uv run` in output** ensures the virtualenv is active when RTK invokes the inner tool. Verified: `uv run rtk --version` works since RTK is in global PATH
- **No new command handler** — RTK runs inside `uv run` and captures/filters output normally

## Test plan
- [x] `cargo test uv_run` — 6 new tests pass (classify + rewrite for pytest, ruff, mypy, python -m pytest)
- [x] `cargo test` — 1259 passed, 3 ignored, 0 failed
- [x] Existing `uv pip list` rewrite unchanged (still `rtk pip list`)
- [x] `uv run rtk --version` confirms RTK is accessible inside `uv run`

---
Closes #294 (partial — covers `uv run` prefix stripping)