### PR TITLE
docs: clarify token consumption type in main title description

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <strong>High-performance CLI proxy that reduces LLM token consumption by 60-90%</strong>
+  <strong>High-performance CLI proxy that reduces LLM context token consumption by 60-90%</strong>
 </p>
 
 <p align="center">


### PR DESCRIPTION
The main title in `README.md`: "High-performance CLI proxy that reduces LLM token consumption by 60-90%" can be misleading as it does not specify whether rtk reduces the consumption of input, output, or both, tokens.
I clarified by specifying "[...] LLM *context* token consumption [...]"