### PR TITLE
fix: preserve caller binary path for path-prefixed command rewrites

### DIFF
--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -337,6 +337,18 @@ pub fn resolve_binary(name: &str) -> Result<PathBuf> {
 /// # Returns
 /// A `Command` configured with the resolved binary path.
 pub fn resolved_command(name: &str) -> Command {
+    // Honor RTK_BIN override when the basename matches the requested binary.
+    // This preserves the caller's original binary path (e.g. .venv/bin/pytest)
+    // when the rewrite pipeline normalized it for matching purposes.
+    if let Ok(bin) = std::env::var("RTK_BIN") {
+        let bin_basename = std::path::Path::new(&bin)
+            .file_name()
+            .and_then(|f| f.to_str())
+            .unwrap_or("");
+        if bin_basename == name {
+            return Command::new(&bin); // nosemgrep: dynamic-command-execution
+        }
+    }
     match resolve_binary(name) {
         Ok(path) => Command::new(path),
         Err(e) => {
@@ -359,6 +371,17 @@ pub fn resolved_command(name: &str) -> Command {
 ///
 /// Replaces manual `Command::new("which").arg(tool)` checks that fail on Windows.
 pub fn tool_exists(name: &str) -> bool {
+    // Check RTK_BIN override first: if it points to this binary and the file
+    // exists, the tool is available even if it's not on PATH.
+    if let Ok(bin) = std::env::var("RTK_BIN") {
+        let bin_basename = std::path::Path::new(&bin)
+            .file_name()
+            .and_then(|f| f.to_str())
+            .unwrap_or("");
+        if bin_basename == name && std::path::Path::new(&bin).exists() {
+            return true;
+        }
+    }
     which::which(name).is_ok()
 }
 
@@ -855,5 +878,60 @@ mod tests {
     fn test_count_tokens_multiple_spaces() {
         assert_eq!(count_tokens("hello    world"), 2);
         assert_eq!(count_tokens("  hello   world  "), 2);
+    }
+
+    // ===== RTK_BIN override tests =====
+
+    #[test]
+    fn test_resolved_command_honors_rtk_bin() {
+        // Set RTK_BIN to a known path with matching basename
+        std::env::set_var("RTK_BIN", "/fake/venv/bin/cargo");
+        let cmd = resolved_command("cargo");
+        let program = format!("{:?}", cmd.get_program());
+        assert!(
+            program.contains("/fake/venv/bin/cargo"),
+            "resolved_command should use RTK_BIN when basename matches, got: {}",
+            program
+        );
+        std::env::remove_var("RTK_BIN");
+    }
+
+    #[test]
+    fn test_resolved_command_ignores_rtk_bin_mismatch() {
+        // RTK_BIN basename doesn't match the requested name
+        std::env::set_var("RTK_BIN", "/fake/venv/bin/pytest");
+        let cmd = resolved_command("python");
+        let program = format!("{:?}", cmd.get_program());
+        assert!(
+            !program.contains("pytest"),
+            "resolved_command should ignore RTK_BIN when basename doesn't match, got: {}",
+            program
+        );
+        std::env::remove_var("RTK_BIN");
+    }
+
+    #[test]
+    fn test_tool_exists_honors_rtk_bin() {
+        // Point RTK_BIN at a binary that exists on disk (cargo)
+        let cargo_path = which::which("cargo").expect("cargo must be on PATH for this test");
+        let cargo_str = cargo_path.to_string_lossy().to_string();
+        std::env::set_var("RTK_BIN", &cargo_str);
+        // tool_exists should find it via RTK_BIN even if we ask by basename
+        assert!(
+            tool_exists("cargo"),
+            "tool_exists should return true when RTK_BIN points to an existing file"
+        );
+        std::env::remove_var("RTK_BIN");
+    }
+
+    #[test]
+    fn test_tool_exists_rtk_bin_nonexistent_file() {
+        // RTK_BIN points to a file that doesn't exist, and the tool is not on PATH
+        std::env::set_var("RTK_BIN", "/no/such/path/nonexistent_xyz_99999");
+        assert!(
+            !tool_exists("nonexistent_xyz_99999"),
+            "tool_exists should return false when RTK_BIN file doesn't exist and tool not on PATH"
+        );
+        std::env::remove_var("RTK_BIN");
     }
 }

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -800,9 +800,14 @@ fn rewrite_segment_inner(
     // Use classify_command for correct ignore/prefix handling
     let rtk_equivalent = match classify_command(cmd_part) {
         Classification::Supported { rtk_equivalent, .. } => {
+            // Check excludes against both the raw env-stripped command and the
+            // path-normalized form so user patterns like ["pytest"] still exclude
+            // ".venv/bin/pytest" (#1053). Upstream's anchored regex would
+            // otherwise miss path-prefixed invocations.
             let stripped = ENV_PREFIX.replace(cmd_part, "");
             let cmd_clean = stripped.trim();
-            if is_excluded(cmd_clean, excluded) {
+            let cmd_normalized = strip_absolute_path(cmd_clean);
+            if is_excluded(cmd_clean, excluded) || is_excluded(&cmd_normalized, excluded) {
                 return None;
             }
             rtk_equivalent
@@ -813,7 +818,33 @@ fn rewrite_segment_inner(
     // Find the matching rule (rtk_cmd values are unique across all rules)
     let rule = RULES.iter().find(|r| r.rtk_cmd == rtk_equivalent)?;
 
-    if let Some(parts) = parse_golangci_run_parts(cmd_part) {
+    // Extract env prefix (sudo, env VAR=val, etc.)
+    let stripped_cow = ENV_PREFIX.replace(cmd_part, "");
+    let env_prefix_len = cmd_part.len() - stripped_cow.len();
+    let env_prefix = &cmd_part[..env_prefix_len];
+    let cmd_clean = stripped_cow.trim();
+
+    // Normalize path-prefixed commands for matching: .venv/bin/pytest → pytest
+    // Preserve the original binary path so we can pass it via RTK_BIN.
+    let cmd_normalized = strip_absolute_path(cmd_clean);
+    let original_bin = if cmd_normalized != cmd_clean {
+        let first_word = cmd_clean.split_whitespace().next();
+        first_word
+    } else {
+        None
+    };
+
+    // #345: RTK_DISABLED=1 in env prefix → skip rewrite entirely
+    // #508: warn on stderr so agents learn to stop overusing it
+    if cmd_has_rtk_disabled_prefix(cmd_part) {
+        eprintln!(
+            "[rtk] RTK_DISABLED=1 detected — skipping filter for this command. \
+             Remove RTK_DISABLED=1 to restore token savings."
+        );
+        return None;
+    }
+
+    if let Some(parts) = parse_golangci_run_parts(cmd_clean) {
         let rewritten = if parts.global_segment.is_empty() {
             format!("rtk golangci-lint {}", parts.run_segment)
         } else {
@@ -837,15 +868,31 @@ fn rewrite_segment_inner(
         }
     }
 
-    // Try each rewrite prefix (longest first) with word-boundary check
+    // Try each rewrite prefix (longest first) with word-boundary check.
+    // Use the normalized command (path stripped) for matching.
+    let match_target = if original_bin.is_some() {
+        cmd_normalized.as_str()
+    } else {
+        cmd_clean
+    };
     for &prefix in rule.rewrite_prefixes {
-        if let Some(rest) = strip_word_prefix(cmd_part, prefix) {
-            let rewritten = if rest.is_empty() {
-                format!("{}{}", rule.rtk_cmd, redirect_suffix)
+        if let Some(rest) = strip_word_prefix(match_target, prefix) {
+            let rtk_part = if rest.is_empty() {
+                format!("{}{}{}", env_prefix, rule.rtk_cmd, redirect_suffix)
             } else {
                 format!("{} {}{}", rule.rtk_cmd, rest, redirect_suffix)
             };
-            return Some(rewritten);
+            // When the original command used an explicit binary path,
+            // carry it via RTK_BIN so the handler invokes the correct binary.
+            // Single-quote the value and escape embedded single quotes with
+            // the POSIX '\'' pattern to handle arbitrary paths.
+            return match original_bin {
+                Some(bin) => {
+                    let escaped = bin.replace('\'', "'\\''");
+                    Some(format!("RTK_BIN='{}' {}", escaped, rtk_part))
+                }
+                None => Some(rtk_part),
+            };
         }
     }
 
@@ -3055,7 +3102,7 @@ mod tests {
     fn test_rewrite_gradlew() {
         assert_eq!(
             rewrite_command_no_prefixes("./gradlew assembleDebug", &[]),
-            Some("rtk gradlew assembleDebug".into())
+            Some("RTK_BIN='./gradlew' rtk gradlew assembleDebug".into())
         );
     }
 
@@ -3970,6 +4017,80 @@ mod tests {
         assert_eq!(
             collapse_line_continuations("git diff HEAD~1"),
             std::borrow::Cow::<str>::Borrowed("git diff HEAD~1"),
+        );
+    }
+
+    // --- Path-prefixed command rewriting ---
+
+    #[test]
+    fn test_rewrite_venv_pytest() {
+        assert_eq!(
+            rewrite_command(".venv/bin/pytest -v", &[], &[]),
+            Some("RTK_BIN='.venv/bin/pytest' rtk pytest -v".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_venv_ruff() {
+        assert_eq!(
+            rewrite_command(".venv/bin/ruff check .", &[], &[]),
+            Some("RTK_BIN='.venv/bin/ruff' rtk ruff check .".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_absolute_path_grep() {
+        assert_eq!(
+            rewrite_command("/usr/bin/grep -rn foo", &[], &[]),
+            Some("RTK_BIN='/usr/bin/grep' rtk grep -rn foo".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_node_modules_bin() {
+        // Upstream collapses "vitest run" to "vitest" (run is vitest's default),
+        // so the "run" arg is absorbed by the matching prefix. RTK_BIN is still preserved.
+        assert_eq!(
+            rewrite_command("./node_modules/.bin/vitest run", &[], &[]),
+            Some("RTK_BIN='./node_modules/.bin/vitest' rtk vitest".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_bare_command_no_rtk_bin() {
+        // Bare commands should not include RTK_BIN
+        assert_eq!(
+            rewrite_command("pytest -v", &[], &[]),
+            Some("rtk pytest -v".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_path_prefixed_excluded() {
+        // Exclusions should match against basename, not the full path
+        assert_eq!(
+            rewrite_command(".venv/bin/pytest -v", &["pytest".to_string()], &[]),
+            None
+        );
+    }
+
+    #[test]
+    fn test_rewrite_path_without_spaces_is_quoted() {
+        // RTK_BIN value is single-quoted to survive shell parsing
+        let result = rewrite_command("/opt/tools/bin/git status", &[], &[]);
+        assert_eq!(
+            result,
+            Some("RTK_BIN='/opt/tools/bin/git' rtk git status".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_path_with_embedded_quote_is_escaped() {
+        // Embedded single quotes use the POSIX '\'' escape pattern
+        let result = rewrite_command("/opt/it's/bin/git status", &[], &[]);
+        assert_eq!(
+            result,
+            Some("RTK_BIN='/opt/it'\\''s/bin/git' rtk git status".into())
         );
     }
 }


### PR DESCRIPTION
  rewrite_segment() now normalizes path-prefixed commands (e.g.                
  .venv/bin/pytest, ./node_modules/.bin/vitest) for matching, and carries the  
  original binary path via RTK_BIN so handlers invoke the correct executable   
  instead of re-resolving via PATH.                                            
                                                            
  Also fixes exclude_commands matching to compare against the basename rather  
  than the raw path-prefixed token.
                                                                               
  ## Summary                                                
                                         
  - Normalize path-prefixed commands in rewrite_segment() for matching only,   
  preserving the original executable path via a single-quoted RTK_BIN env var
  in the rewrite output                                                        
  - Teach resolved_command() and tool_exists() to honor RTK_BIN when its
  basename matches the requested binary, so handler branch decisions (e.g.     
  pytest_cmd.rs) use the correct executable
  - Fix exclude_commands to compare against the basename so exclusions work for
   path-prefixed commands                                                      
                                         
  ## Test plan                                                                 
                                                            
  - [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
  - [x] Manual testing: `rtk rewrite '.venv/bin/pytest -v'` outputs
  `RTK_BIN='.venv/bin/pytest' rtk pytest -v`                                   
  - [x] Manual testing: `rtk rewrite 'pytest -v'` outputs `rtk pytest -v` (no
  RTK_BIN)                                                                     
  - [x] Manual testing: `RTK_BIN='.venv/bin/pytest' rtk pytest --version`
  executes the venv binary                                                     
  - [x] 13 new unit tests covering rewrite output, quoting, exclusion matching,
   resolved_command override, and tool_exists override                         

Fixes #1053 