### PR TITLE
feat(init): add Kiro steering integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -384,6 +384,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * **aws:** expand CLI filters from 8 to 25 subcommands — CloudWatch Logs, CloudFormation events, Lambda, IAM, DynamoDB (with type unwrapping), ECS tasks, EC2 security groups, S3API objects, S3 sync/cp, EKS, SQS, Secrets Manager ([#885](https://github.com/rtk-ai/rtk/pull/885))
 * **aws:** add shared runner `run_aws_filtered()` eliminating per-handler boilerplate
+* **init:** add `rtk init --agent kiro` to install RTK guidance into Kiro steering files
 * **tee:** add `force_tee_hint()` — truncated output saves full data to file with recovery hint
 
 ## [0.34.3](https://github.com/rtk-ai/rtk/compare/v0.34.2...v0.34.3) (2026-04-02)

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ rtk init -g                     # Claude Code / Copilot (default)
 rtk init -g --gemini            # Gemini CLI
 rtk init -g --codex             # Codex (OpenAI)
 rtk init -g --agent cursor      # Cursor
+rtk init --agent kiro           # AWS Kiro CLI
 rtk init -g --agent windsurf    # Windsurf
 rtk init --agent cline          # Cline / Roo Code
 rtk init --agent kilocode       # Kilo Code
@@ -381,7 +382,7 @@ rtk init -g
 
 ## Supported AI Tools
 
-RTK supports 15 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents, reducing the bash output the agent reads where the agent supports command interception.
+RTK supports 16 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents, reducing the bash output the agent reads where the agent supports command interception.
 
 | Tool | Install | Method |
 |------|---------|--------|
@@ -391,6 +392,7 @@ RTK supports 15 AI coding tools. Each integration rewrites shell commands to `rt
 | **Cursor** | `rtk init -g --agent cursor` | preToolUse hook (hooks.json) |
 | **Gemini CLI** | `rtk init -g --gemini` | BeforeTool hook |
 | **Codex** | `rtk init -g --codex` | AGENTS.md + RTK.md instructions |
+| **Kiro CLI** | `rtk init --agent kiro` | `.kiro/steering/rtk.md` steering file |
 | **Windsurf** | `rtk init -g --agent windsurf` | .windsurfrules (project-scoped) |
 | **Cline / Roo Code** | `rtk init --agent cline` | .clinerules (project-scoped) |
 | **OpenCode** | `rtk init -g --opencode` | Plugin TS (tool.execute.before) |

--- a/docs/contributing/TECHNICAL.md
+++ b/docs/contributing/TECHNICAL.md
@@ -77,7 +77,7 @@ The user runs `rtk init` to set up hooks for their LLM agent. This:
 3. Patches the agent's settings file (e.g., `settings.json`) to register the hook
 4. Writes RTK awareness instructions (e.g., `RTK.md`) for prompt-level guidance
 
-RTK supports 7 agents, each with its own installation mode. The hook scripts are embedded in the binary and written at install time.
+RTK supports 10 agent integrations, each with its own installation mode. The hook scripts and prompt-level artifacts are embedded in the binary and written at install time.
 
 > **Details**: [`src/hooks/README.md`](../src/hooks/README.md) covers all installation modes, configuration files, and the uninstall flow.
 
@@ -319,6 +319,7 @@ Start here, then drill down into each README for file-level details.
 | [`cline/`](../hooks/cline/README.md) | Cline / Roo Code | Rules file (prompt-level, no programmatic hook) |
 | [`windsurf/`](../hooks/windsurf/README.md) | Windsurf / Cascade | Rules file (workspace-scoped) |
 | [`codex/`](../hooks/codex/README.md) | OpenAI Codex CLI | Awareness document, AGENTS.md integration |
+| [`kiro/`](../hooks/kiro/README.md) | AWS Kiro CLI | Steering file, `.kiro/steering/rtk.md` |
 | [`opencode/`](../hooks/opencode/README.md) | OpenCode | TypeScript plugin, zx library, in-place mutation |
 
 ---
@@ -337,6 +338,7 @@ RTK supports the following LLM agents through hook integrations:
 | Cline/Roo Code | Rules file | Prompt-level guidance | N/A (prompt) |
 | Windsurf | Rules file | Prompt-level guidance | N/A (prompt) |
 | Codex CLI | Awareness doc | AGENTS.md integration | N/A (prompt) |
+| Kiro CLI | Steering file | `.kiro/steering/rtk.md` | N/A (prompt) |
 | OpenCode | TS plugin | `tool.execute.before` event | Yes (in-place mutation) |
 
 > **Details**: [`hooks/README.md`](../hooks/README.md) has the full JSON schemas for each agent. [`src/hooks/README.md`](../src/hooks/README.md) covers installation, integrity verification, and the rewrite command.

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -4,7 +4,7 @@
 
 **Deployed hook artifacts** — the actual files installed on user machines by `rtk init`. These are shell scripts, TypeScript plugins, and rules files that run outside the Rust binary. They are **thin delegates**: parse agent-specific JSON, call `rtk rewrite` as a subprocess, format agent-specific response. Zero filtering logic lives here.
 
-Owns: per-agent hook scripts and configuration files for 9 supported agents (Claude Code, Copilot, Cursor, Cline, Windsurf, Codex, OpenCode, Hermes, Pi).
+Owns: per-agent hook scripts and configuration files for 10 supported agents (Claude Code, Copilot, Cursor, Cline, Windsurf, Codex, Kiro, OpenCode, Hermes, Pi).
 
 Does **not** own: hook installation/uninstallation (that's `src/hooks/init.rs`), the rewrite pattern registry (that's `discover/registry`), or integrity verification (that's `src/hooks/integrity.rs`).
 
@@ -39,6 +39,7 @@ Each agent subdirectory has its own README with hook-specific details:
 - **[`cline/`](cline/README.md)** — Rules file (prompt-level), `.clinerules` project-local installation
 - **[`windsurf/`](windsurf/README.md)** — Rules file (prompt-level), `.windsurfrules` workspace-scoped
 - **[`codex/`](codex/README.md)** — Awareness document, `AGENTS.md` integration, `$CODEX_HOME` or `~/.codex/` location
+- **[`kiro/`](kiro/README.md)** — Steering file, `.kiro/steering/rtk.md`, workspace or global install
 - **[`opencode/`](opencode/README.md)** — TypeScript plugin, `zx` library, `tool.execute.before` event, in-place mutation
 - **[`pi/`](pi/README.md)** — TypeScript extension, `tool_call` event, `isToolCallEventType` guard, in-place mutation, `~/.pi/agent/extensions/`
 - **[`hermes/`](hermes/README.md)** — Python plugin, `pre_tool_call` hook, in-place terminal command mutation
@@ -55,6 +56,7 @@ Each agent subdirectory has its own README with hook-specific details:
 | Cline / Roo Code | Custom instructions (rules file) | Prompt-level guidance | N/A |
 | Windsurf | Custom instructions (rules file) | Prompt-level guidance | N/A |
 | Codex CLI | AGENTS.md / instructions | Prompt-level guidance | N/A |
+| Kiro CLI | Steering file (`.kiro/steering/rtk.md`) | Prompt-level guidance | N/A |
 | OpenCode | TypeScript plugin (`tool.execute.before`) | In-place mutation | Yes |
 | Pi | TypeScript extension (`tool_call` event) | In-place mutation | Yes |
 | Hermes | Python plugin (`pre_tool_call`) | In-place mutation | Yes |
@@ -243,7 +245,7 @@ New integrations must follow the [Exit Code Contract](#exit-code-contract) and [
 |------|-----------|-------------|----------|
 | **Full hook** | Shell script or Rust binary, intercepts commands via agent's hook API | High — must track agent API changes | Claude Code, Cursor, Copilot, Gemini |
 | **Plugin** | TypeScript/JS/Python plugin in agent's plugin system | Medium — agent manages loading | OpenCode, Hermes, Pi |
-| **Rules file** | Prompt-level instructions the agent reads | Low — no code to break | Cline, Windsurf, Codex |
+| **Rules / steering file** | Prompt-level instructions the agent reads | Low — no code to break | Cline, Windsurf, Codex, Kiro |
 
 ### Eligibility
 

--- a/hooks/kiro/README.md
+++ b/hooks/kiro/README.md
@@ -1,0 +1,10 @@
+# Kiro CLI Steering
+
+> Part of [`hooks/`](../README.md) — see also [`src/hooks/`](../../src/hooks/README.md) for installation code
+
+## Specifics
+
+- Prompt-level guidance via a Kiro steering file
+- `rtk-steering.md` is installed as `.kiro/steering/rtk.md`
+- Supports both workspace-local (`rtk init --agent kiro`) and global (`rtk init -g --agent kiro`) installs
+- Uses `inclusion: always` so Kiro loads the RTK guidance in every interaction

--- a/hooks/kiro/rtk-steering.md
+++ b/hooks/kiro/rtk-steering.md
@@ -1,0 +1,36 @@
+---
+inclusion: always
+---
+
+# RTK - Rust Token Killer (Kiro CLI)
+
+**Usage**: Token-optimized CLI proxy for shell commands.
+
+## Rule
+
+Always prefix shell commands with `rtk`.
+
+Examples:
+
+```bash
+rtk git status
+rtk cargo test
+rtk npm run build
+rtk pytest -q
+```
+
+## Meta Commands
+
+```bash
+rtk gain            # Token savings analytics
+rtk gain --history  # Recent command savings history
+rtk proxy <cmd>     # Run raw command without filtering
+```
+
+## Verification
+
+```bash
+rtk --version
+rtk gain
+which rtk
+```

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -6,7 +6,7 @@
 
 The **lifecycle management** layer for LLM agent hooks: install, uninstall, verify integrity, audit usage, and manage trust. This component creates and maintains the hook artifacts that live in `hooks/` (root), but does **not** execute rewrite logic itself — that lives in `discover/registry`.
 
-Owns: `rtk init` installation flows (5 agents via `AgentTarget` enum + 3 special modes: Gemini, Codex, OpenCode), SHA-256 integrity verification, hook version checking, audit log analysis, `rtk rewrite` CLI entry point, and TOML filter trust management.
+Owns: `rtk init` installation flows (6 agents via `AgentTarget` enum + 3 special modes: Gemini, Codex, OpenCode), SHA-256 integrity verification, hook version checking, audit log analysis, `rtk rewrite` CLI entry point, and TOML filter trust management.
 
 Does **not** own: the deployed hook scripts themselves (that's `hooks/`), the rewrite pattern registry (that's `discover/`), or command filtering (that's `cmds/`).
 
@@ -28,6 +28,7 @@ LLM agent integration layer that installs, validates, and executes command-rewri
 | Claude-MD (legacy) | `rtk init --claude-md` | 134-line RTK block | CLAUDE.md |
 | Windsurf | `rtk init -g --agent windsurf` | `.windsurfrules` | -- |
 | Cline | `rtk init --agent cline` | `.clinerules` | -- |
+| Kiro | `rtk init --agent kiro` | `.kiro/steering/rtk.md` | -- |
 | Codex | `rtk init --codex` | RTK.md in `$CODEX_HOME` or `~/.codex` | AGENTS.md |
 | Cursor | `rtk init -g --agent cursor` | Cursor hook | hooks.json |
 | Pi | `rtk init --agent pi` | `.pi/extensions/rtk.ts` | -- |

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -23,6 +23,7 @@ pub const OPENCODE_PLUGIN_FILE: &str = "rtk.ts";
 pub const CURSOR_DIR: &str = ".cursor";
 pub const CODEX_DIR: &str = ".codex";
 pub const GEMINI_DIR: &str = ".gemini";
+pub const KIRO_DIR: &str = ".kiro";
 
 pub const GITHUB_DIR: &str = ".github";
 pub const COPILOT_HOOK_FILE: &str = "rtk-rewrite.json";

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -17,7 +17,7 @@ use super::constants::{
     DROID_EXECUTE_MATCHER, DROID_HOME_ENV, DROID_HOOKS_FILE, DROID_HOOKS_SUBDIR,
     DROID_HOOK_COMMAND, DROID_SETTINGS_FILE, GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR,
     HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON,
-    HOOKS_SUBDIR, PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR,
+    HOOKS_SUBDIR, KIRO_DIR, PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR,
     PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use super::integrity;
@@ -32,6 +32,7 @@ const PI_PLUGIN: &str = include_str!("../../hooks/pi/rtk.ts");
 // Embedded slim RTK awareness instructions
 const RTK_SLIM: &str = include_str!("../../hooks/claude/rtk-awareness.md");
 const RTK_SLIM_CODEX: &str = include_str!("../../hooks/codex/rtk-awareness.md");
+const RTK_SLIM_KIRO: &str = include_str!("../../hooks/kiro/rtk-steering.md");
 
 /// Template written by `rtk init` when no filters.toml exists yet.
 const FILTERS_TEMPLATE: &str = r#"# Project-local RTK filters — commit this file with your repo.
@@ -69,6 +70,8 @@ const CLAUDE_MD: &str = "CLAUDE.md";
 const AGENTS_MD: &str = "AGENTS.md";
 const RTK_MD_REF: &str = "@RTK.md";
 const GEMINI_MD: &str = "GEMINI.md";
+const KIRO_STEERING_SUBDIR: &str = "steering";
+const KIRO_STEERING_FILE: &str = "rtk.md";
 
 const RTK_BLOCK_START: &str = "<!-- rtk-instructions";
 const RTK_BLOCK_END: &str = "<!-- /rtk-instructions -->";
@@ -643,6 +646,7 @@ pub fn uninstall(
     gemini: bool,
     codex: bool,
     cursor: bool,
+    kiro: bool,
     pi: bool,
     ctx: InitContext,
 ) -> Result<()> {
@@ -652,6 +656,11 @@ pub fn uninstall(
         if dry_run {
             print_dry_run_footer();
         }
+        return Ok(());
+    }
+
+    if kiro {
+        uninstall_kiro(global, ctx)?;
         return Ok(());
     }
 
@@ -1629,6 +1638,9 @@ const WINDSURF_RULES: &str = include_str!("../../hooks/windsurf/rules.md");
 /// Embedded Cline RTK rules
 const CLINE_RULES: &str = include_str!("../../hooks/cline/rules.md");
 
+/// Embedded Kiro RTK steering file
+const KIRO_RULES: &str = RTK_SLIM_KIRO;
+
 // ─── Cline / Roo Code support ─────────────────────────────────
 
 fn run_cline_mode(ctx: InitContext) -> Result<()> {
@@ -1716,6 +1728,33 @@ fn run_windsurf_mode(ctx: InitContext) -> Result<()> {
         println!("  Cascade will now use rtk commands for token savings.");
         println!("  Restart Windsurf. Test with: git status\n");
     }
+
+    Ok(())
+}
+
+pub fn run_kiro_mode(global: bool, ctx: InitContext) -> Result<()> {
+    let InitContext { dry_run, .. } = ctx;
+    let steering_path = prepare_kiro_steering_path(global, ctx)?;
+    let changed = ensure_kiro_steering_installed(&steering_path, ctx)?;
+
+    if dry_run {
+        print_dry_run_footer();
+        return Ok(());
+    }
+
+    println!("\nRTK configured for Kiro CLI.\n");
+    println!("  Steering: {}", steering_path.display());
+    if changed {
+        println!("  Mode:     installed/updated");
+    } else {
+        println!("  Mode:     already up to date");
+    }
+    if global {
+        println!("  Scope:    global (~/.kiro/steering)");
+    } else {
+        println!("  Scope:    workspace (./.kiro/steering)");
+    }
+    println!("  Restart Kiro if it is already running. Test with: git status\n");
 
     Ok(())
 }
@@ -2873,6 +2912,10 @@ fn resolve_codex_dir_from(
         .context("Cannot determine Codex config directory. Set $CODEX_HOME or $HOME.")
 }
 
+fn resolve_kiro_dir() -> Result<PathBuf> {
+    resolve_home_subdir(KIRO_DIR)
+}
+
 fn resolve_hermes_home() -> Result<PathBuf> {
     resolve_hermes_home_from_env(dirs::home_dir(), std::env::var_os("HERMES_HOME"))
 }
@@ -3502,6 +3545,80 @@ fn print_pi_result(plugin_path: &Path, installed: bool) {
     println!("Verify: pi -e {} --no-session", plugin_path.display());
 }
 
+fn kiro_steering_path(global: bool) -> Result<PathBuf> {
+    if global {
+        Ok(resolve_kiro_dir()?
+            .join(KIRO_STEERING_SUBDIR)
+            .join(KIRO_STEERING_FILE))
+    } else {
+        Ok(PathBuf::from(KIRO_DIR)
+            .join(KIRO_STEERING_SUBDIR)
+            .join(KIRO_STEERING_FILE))
+    }
+}
+
+fn prepare_kiro_steering_path(global: bool, ctx: InitContext) -> Result<PathBuf> {
+    let InitContext { dry_run, .. } = ctx;
+    let path = kiro_steering_path(global)?;
+    if let Some(parent) = path.parent() {
+        if dry_run {
+            if !parent.exists() {
+                println!(
+                    "[dry-run] would create Kiro steering directory: {}",
+                    parent.display()
+                );
+            }
+        } else {
+            fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "Failed to create Kiro steering directory: {}",
+                    parent.display()
+                )
+            })?;
+        }
+    }
+    Ok(path)
+}
+
+fn ensure_kiro_steering_installed(path: &Path, ctx: InitContext) -> Result<bool> {
+    write_if_changed(path, KIRO_RULES, "Kiro steering", ctx)
+}
+
+fn uninstall_kiro(global: bool, ctx: InitContext) -> Result<()> {
+    let InitContext { verbose, dry_run } = ctx;
+    let steering_path = kiro_steering_path(global)?;
+
+    if steering_path.exists() {
+        if dry_run {
+            println!(
+                "[dry-run] would remove Kiro steering file: {}",
+                steering_path.display()
+            );
+            print_dry_run_footer();
+            return Ok(());
+        }
+
+        fs::remove_file(&steering_path).with_context(|| {
+            format!(
+                "Failed to remove Kiro steering file: {}",
+                steering_path.display()
+            )
+        })?;
+        if verbose > 0 {
+            eprintln!("Removed Kiro steering file: {}", steering_path.display());
+        }
+        println!("RTK uninstalled (Kiro CLI):");
+        println!("  - Steering: {}", steering_path.display());
+        println!("\nRestart Kiro if it is already running.");
+    } else if dry_run {
+        print_dry_run_footer();
+    } else {
+        println!("RTK Kiro support was not installed (nothing to remove)");
+    }
+
+    Ok(())
+}
+
 /// Return OpenCode plugin path: ~/.config/opencode/plugins/rtk.ts
 fn opencode_plugin_path(opencode_dir: &Path) -> PathBuf {
     opencode_dir.join(PLUGIN_SUBDIR).join(OPENCODE_PLUGIN_FILE)
@@ -3868,9 +3985,13 @@ fn remove_cursor_hook_from_json(root: &mut serde_json::Value) -> bool {
 }
 
 /// Show current rtk configuration
-pub fn show_config(codex: bool) -> Result<()> {
+pub fn show_config(codex: bool, kiro: bool) -> Result<()> {
     if codex {
         return show_codex_config();
+    }
+
+    if kiro {
+        return show_kiro_config();
     }
 
     show_claude_config()
@@ -4101,8 +4222,38 @@ fn show_claude_config() -> Result<()> {
     println!("  rtk init -g --hook-only     # Hook only, no RTK.md");
     println!("  rtk init --codex            # Configure local AGENTS.md + RTK.md");
     println!("  rtk init -g --codex         # Configure $CODEX_HOME/AGENTS.md + $CODEX_HOME/RTK.md (or ~/.codex/)");
+    println!("  rtk init --agent kiro       # Configure ./.kiro/steering/rtk.md");
+    println!("  rtk init -g --agent kiro    # Configure ~/.kiro/steering/rtk.md");
     println!("  rtk init -g --opencode      # OpenCode plugin only");
     println!("  rtk init -g --agent cursor  # Install Cursor Agent hooks");
+
+    Ok(())
+}
+
+fn show_kiro_config() -> Result<()> {
+    let global_steering = kiro_steering_path(true)?;
+    let local_steering = kiro_steering_path(false)?;
+
+    println!("rtk Configuration (Kiro CLI):\n");
+
+    if global_steering.exists() {
+        println!("[ok] Global steering: {}", global_steering.display());
+    } else {
+        println!("[--] Global steering: not found");
+    }
+
+    if local_steering.exists() {
+        println!("[ok] Local steering: {}", local_steering.display());
+    } else {
+        println!("[--] Local steering: not found");
+    }
+
+    println!("\nUsage:");
+    println!("  rtk init --agent kiro                  # Configure ./.kiro/steering/rtk.md");
+    println!("  rtk init -g --agent kiro               # Configure ~/.kiro/steering/rtk.md");
+    println!("  rtk init --agent kiro --show           # Show Kiro configuration");
+    println!("  rtk init --agent kiro --uninstall      # Remove local Kiro steering");
+    println!("  rtk init -g --agent kiro --uninstall   # Remove global Kiro steering");
 
     Ok(())
 }
@@ -6152,6 +6303,25 @@ mod tests {
         assert!(content.contains(RTK_BLOCK_START));
     }
 
+    #[test]
+    fn test_kiro_steering_install_and_update() {
+        let temp = TempDir::new().unwrap();
+        let steering_path = temp.path().join("rtk.md");
+
+        let changed =
+            ensure_kiro_steering_installed(&steering_path, InitContext::default()).unwrap();
+        assert!(changed);
+        let content = fs::read_to_string(&steering_path).unwrap();
+        assert_eq!(content, KIRO_RULES);
+
+        fs::write(&steering_path, "old").unwrap();
+        let changed_again =
+            ensure_kiro_steering_installed(&steering_path, InitContext::default()).unwrap();
+        assert!(changed_again);
+        let updated = fs::read_to_string(&steering_path).unwrap();
+        assert_eq!(updated, KIRO_RULES);
+    }
+
     // Tests for hook_already_present()
     #[test]
     fn test_hook_already_present_exact_match() {
@@ -6882,7 +7052,16 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         with_claude_dir_override(&tmp, |claude_dir| {
             run_default_mode(true, PatchMode::Auto, false, InitContext::default()).unwrap();
-            uninstall(true, false, false, false, false, InitContext::default()).unwrap();
+            uninstall(
+                true,
+                false,
+                false,
+                false,
+                false,
+                false,
+                InitContext::default(),
+            )
+            .unwrap();
 
             assert!(!claude_dir.join(RTK_MD).exists(), "RTK.md must be removed");
             let settings_content =
@@ -7010,7 +7189,7 @@ mod tests {
                 dry_run: true,
                 ..Default::default()
             };
-            uninstall(true, false, false, false, false, dry).unwrap();
+            uninstall(true, false, false, false, false, false, dry).unwrap();
 
             // Files must still exist with identical content
             assert!(
@@ -7236,7 +7415,16 @@ mod tests {
             let plugin = pi_dir.join(PI_EXTENSIONS_SUBDIR).join(PI_PLUGIN_FILE);
             assert!(plugin.exists());
 
-            uninstall(true, false, false, false, true, InitContext::default()).unwrap();
+            uninstall(
+                true,
+                false,
+                false,
+                false,
+                false,
+                true,
+                InitContext::default(),
+            )
+            .unwrap();
 
             assert!(!plugin.exists(), "plugin must be removed");
         });
@@ -7250,7 +7438,15 @@ mod tests {
         std::env::set_current_dir(tmp.path()).unwrap();
 
         run_pi_mode(false, InitContext::default()).unwrap();
-        let result = uninstall(false, false, false, false, true, InitContext::default());
+        let result = uninstall(
+            false,
+            false,
+            false,
+            false,
+            false,
+            true,
+            InitContext::default(),
+        );
         std::env::set_current_dir(&cwd).unwrap();
         result.unwrap();
 
@@ -7348,6 +7544,7 @@ mod tests {
                 false,
                 false,
                 false,
+                false,
                 true,
                 InitContext {
                     verbose: 0,
@@ -7382,6 +7579,7 @@ mod tests {
         );
 
         let result = uninstall(
+            false,
             false,
             false,
             false,

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -3598,6 +3598,7 @@ fn uninstall_kiro(global: bool, ctx: InitContext) -> Result<()> {
             return Ok(());
         }
 
+        // nosemgrep: filesystem-deletion -- Kiro uninstall removes only the RTK-managed steering file.
         fs::remove_file(&steering_path).with_context(|| {
             format!(
                 "Failed to remove Kiro steering file: {}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,8 @@ pub enum AgentTarget {
     Claude,
     /// Cursor Agent (editor and CLI)
     Cursor,
+    /// AWS Kiro CLI
+    Kiro,
     /// Windsurf IDE (Cascade)
     Windsurf,
     /// Cline / Roo Code (VS Code)
@@ -1560,7 +1562,8 @@ fn uninstall_init_dispatch<UninstallHermes, UninstallStandard>(
 ) -> Result<()>
 where
     UninstallHermes: FnOnce(hooks::init::InitContext) -> Result<()>,
-    UninstallStandard: FnOnce(bool, bool, bool, bool, bool, hooks::init::InitContext) -> Result<()>,
+    UninstallStandard:
+        FnOnce(bool, bool, bool, bool, bool, bool, hooks::init::InitContext) -> Result<()>,
 {
     if agent == Some(AgentTarget::Hermes) {
         uninstall_hermes(ctx)
@@ -1568,8 +1571,9 @@ where
         hooks::init::uninstall_droid(global, ctx)
     } else {
         let cursor = agent == Some(AgentTarget::Cursor);
+        let kiro = agent == Some(AgentTarget::Kiro);
         let pi = agent == Some(AgentTarget::Pi);
-        uninstall_standard(global, gemini, codex, cursor, pi, ctx)
+        uninstall_standard(global, gemini, codex, cursor, kiro, pi, ctx)
     }
 }
 
@@ -2013,7 +2017,7 @@ fn run_cli() -> Result<i32> {
                 dry_run,
             };
             if show {
-                hooks::init::show_config(codex)?;
+                hooks::init::show_config(codex, agent == Some(AgentTarget::Kiro))?;
             } else if uninstall && copilot {
                 if global {
                     hooks::init::uninstall_copilot_global(ctx)?;
@@ -2047,6 +2051,8 @@ fn run_cli() -> Result<i32> {
                 }
             } else if agent == Some(AgentTarget::Pi) {
                 hooks::init::run_pi_mode(global, ctx)?
+            } else if agent == Some(AgentTarget::Kiro) {
+                hooks::init::run_kiro_mode(global, ctx)?
             } else if agent == Some(AgentTarget::Kilocode) {
                 if global {
                     anyhow::bail!("Kilo Code is project-scoped. Use: rtk init --agent kilocode");
@@ -2991,7 +2997,7 @@ mod tests {
                 assert!(ctx.dry_run);
                 Ok(())
             },
-            |_, _, _, _, _, _| {
+            |_, _, _, _, _, _, _| {
                 standard_called.set(true);
                 Ok(())
             },


### PR DESCRIPTION
## Summary

- add `rtk init --agent kiro` and `rtk init -g --agent kiro` support
- install RTK guidance into `.kiro/steering/rtk.md` with Kiro-specific show/uninstall flows
- document the new Kiro integration across README and contributor docs

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

Related: #845
