### PR TITLE
feat(filters): add poethepoet (poe) task runner support

### DIFF
--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -1613,8 +1613,8 @@ match_command = "^make\\b"
         let filters = make_filters(BUILTIN_TOML);
         assert_eq!(
             filters.len(),
-            58,
-            "Expected exactly 58 built-in filters, got {}. \
+            59,
+            "Expected exactly 59 built-in filters, got {}. \
              Update this count when adding/removing filters in src/filters/.",
             filters.len()
         );
@@ -1671,11 +1671,11 @@ expected = "output line 1\noutput line 2"
         let combined = format!("{}\n\n{}", BUILTIN_TOML, new_filter);
         let filters = make_filters(&combined);
 
-        // All 58 existing filters still present + 1 new = 59
+        // All 59 existing filters still present + 1 new = 60
         assert_eq!(
             filters.len(),
-            59,
-            "Expected 59 filters after concat (58 built-in + 1 new)"
+            60,
+            "Expected 60 filters after concat (59 built-in + 1 new)"
         );
 
         // New filter is discoverable

--- a/src/filters/poe.toml
+++ b/src/filters/poe.toml
@@ -1,0 +1,37 @@
+[filters.poe]
+description = "Compact poethepoet (poe) task runner output — strip Poe header lines, keep command output"
+match_command = "^poe\\b"
+strip_ansi = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^Poe => ",
+  "^Poe the Poet ",
+  "^version \\d",
+  "^USAGE\\b",
+  "^GLOBAL OPTIONS\\b",
+  "^CONFIGURED TASKS\\b",
+  "^Result: Task ",
+]
+truncate_lines_at = 150
+max_lines = 50
+on_empty = "poe: ok"
+
+[[tests.poe]]
+name = "strips Poe header, keeps command output"
+input = "Poe => pytest tests/\n============================= test session starts ==============================\n42 passed in 1.23s"
+expected = "============================= test session starts ==============================\n42 passed in 1.23s"
+
+[[tests.poe]]
+name = "preserves error output"
+input = "Poe => pytest tests/\nFAILED tests/test_foo.py::test_bar - AssertionError\n1 failed, 41 passed"
+expected = "FAILED tests/test_foo.py::test_bar - AssertionError\n1 failed, 41 passed"
+
+[[tests.poe]]
+name = "all stripped → on_empty"
+input = "Poe => echo done\n\nResult: Task succeeded\n"
+expected = "poe: ok"
+
+[[tests.poe]]
+name = "empty input"
+input = ""
+expected = ""


### PR DESCRIPTION
## Summary
- Add `src/filters/poe.toml` filter for the [poethepoet](https://github.com/nat-n/poethepoet) (`poe`) Python task runner
- Strips `Poe => ` echo headers, help banner lines (`Poe the Poet`, `version`, `USAGE`, `GLOBAL OPTIONS`, `CONFIGURED TASKS`), and trailing `Result: Task ...` messages
- Follows the same TOML pattern as `just` / `mise` / `task` from #666
- Bumps built-in filter count assertion 58 → 59 (and the concat-discoverability test 59 → 60)

## Test plan
- [x] `cargo fmt --all --check` — clean
- [x] `cargo test --all` — **1358 passed, 0 failed, 6 ignored**
- [x] `cargo test toml_filter` — 49 passed (including the 4 inline `[[tests.poe]]` cases)
- [x] Inline tests cover: command-output passthrough, error preservation, all-stripped → `on_empty`, empty input

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.