### PR TITLE
fix(security): correct email domain from .dev to .app

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 If you discover a security vulnerability in RTK, please report it to the maintainers privately:
 
-- **Email**: security@rtk-ai.dev (or create a private security advisory on GitHub)
+- **Email**: security@rtk-ai.app (or create a private security advisory on GitHub)
 - **Response time**: We aim to acknowledge reports within 48 hours
 - **Disclosure**: We follow responsible disclosure practices (90-day embargo)
 
@@ -208,7 +208,7 @@ Critical vulnerabilities (remote code execution, data exfiltration) may be fast-
 
 ## Contact
 
-- **Security issues**: security@rtk-ai.dev
+- **Security issues**: security@rtk-ai.app
 - **General questions**: https://github.com/rtk-ai/rtk/discussions
 - **Maintainers**: @FlorianBruniaux (active fork maintainer)
 


### PR DESCRIPTION
## Summary
- Fix bouncing security email: `security@rtk-ai.dev` → `security@rtk-ai.app`
- Both occurrences in SECURITY.md updated (line 7 and line 211)

Fixes #608

## Test plan
- [ ] Verify email works: send test to security@rtk-ai.app