### PR TITLE
fix(hook): cursor hook fails to rewrite commands due to incorrect exit code handling

### DIFF
--- a/hooks/cursor/rtk-rewrite.sh
+++ b/hooks/cursor/rtk-rewrite.sh
@@ -39,8 +39,16 @@ if [ -z "$CMD" ]; then
 fi
 
 # Delegate all rewrite logic to the Rust binary.
-# rtk rewrite exits 1 when there's no rewrite — hook passes through silently.
-REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null) || { echo '{}'; exit 0; }
+# rtk rewrite returns exit 3 on successful rewrite, 0 when no rewrite needed.
+REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null)
+RTK_EXIT=$?
+
+# Exit 0 = no rewrite needed, exit 3 = successfully rewritten
+# Any other exit code indicates an actual error
+if [ "$RTK_EXIT" -ne 0 ] && [ "$RTK_EXIT" -ne 3 ]; then
+  echo '{}'
+  exit 0
+fi
 
 # No change — nothing to do.
 if [ "$CMD" = "$REWRITTEN" ]; then

--- a/hooks/cursor/rtk-rewrite.sh
+++ b/hooks/cursor/rtk-rewrite.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# rtk-hook-version: 1
+# rtk-hook-version: 2
 # RTK Cursor Agent hook — rewrites shell commands to use rtk for token savings.
 # Works with both Cursor editor and cursor-cli (they share ~/.cursor/hooks.json).
 # Cursor preToolUse hook format: receives JSON on stdin, returns JSON on stdout.
@@ -50,11 +50,17 @@ if [ "$RTK_EXIT" -ne 0 ] && [ "$RTK_EXIT" -ne 3 ]; then
   exit 0
 fi
 
-# No change — nothing to do.
-if [ "$CMD" = "$REWRITTEN" ]; then
+# No change — nothing to do (same text, or empty stdout despite exit 0/3).
+if [ -z "$REWRITTEN" ] || [ "$CMD" = "$REWRITTEN" ]; then
   echo '{}'
   exit 0
 fi
+
+# Cursor expects JSON with "permission" and optional "updated_input".
+# rtk rewrite: exit 0 = no rewrite needed; exit 3 = rewritten successfully (RTK uses 3
+# as a success code, unlike typical shell conventions). Either way, when we emit
+# updated_input, Cursor requires "permission": "allow" so the tool runs with the
+# new command (rather than ask/deny/default pass-through).
 
 jq -n --arg cmd "$REWRITTEN" '{
   "permission": "allow",


### PR DESCRIPTION
## Summary

The Cursor agent hook (`~/.cursor/hooks/rtk-rewrite.sh`) fails to rewrite shell commands because it incorrectly handles the exit code from `rtk rewrite`. The hook treats exit code 3 (which indicates a successful rewrite) as a failure condition.

Fixes #1145.

## Bug Description

### Current Behavior (Broken)
All shell commands pass through unchanged - RTK never rewrites them.

### Expected Behavior
Shell commands like `git status`, `ls`, `cat`, etc. should be automatically rewritten to their RTK equivalents.

## Root Cause

In `hooks/cursor/rtk-rewrite.sh` (line 43):

```bash
# Delegate all rewrite logic to the Rust binary.
# rtk rewrite exits 1 when there's no rewrite — hook passes through silently.
REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null) || { echo '{}'; exit 0; }
```

**The problem**: The comment says "exits 1 when there's no rewrite", but `rtk rewrite` actually returns **exit code 3** when it successfully rewrites a command.

The `||` operator treats ANY non-zero exit code as failure, so:
- Exit 0 (no rewrite needed) → OK, hook continues
- Exit 3 (successfully rewritten) → TREATED AS FAILURE, hook exits with `{}`
- Exit 1 (actual error) → TREATED AS FAILURE, hook exits with `{}`

**Result**: Commands are never rewritten because the hook always exits early.

## Evidence

Test showing `rtk rewrite` exit codes:

```bash
# Command that should be rewritten
$ rtk rewrite "git status"
rtk git status
$ echo $?  
3  # ← This is "success", not failure!

# Command with no rewrite needed  
$ rtk rewrite "unknown-command"
unknown-command
$ echo $?
0
```

Hook behavior with current code:
```bash
$ echo '{"tool_input": {"command": "git status"}}' | ~/.cursor/hooks/rtk-rewrite.sh
{}  # ← Always returns empty object, never rewrites
```

## Fix

Replace the incorrect exit code handling:

**Before:**
```bash
REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null) || { echo '{}'; exit 0; }
```

**After:**
```bash
# rtk rewrite returns exit 3 on successful rewrite, 0 when no rewrite needed.
REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null)
RTK_EXIT=$?

# Exit 0 = no rewrite needed, exit 3 = successfully rewritten
# Any other exit code indicates an actual error
if [ "$RTK_EXIT" -ne 0 ] && [ "$RTK_EXIT" -ne 3 ]; then
  echo '{}'
  exit 0
fi
```

## Testing

After applying the fix:

```bash
$ echo '{"tool_input": {"command": "git status"}}' | ~/.cursor/hooks/rtk-rewrite.sh
{
  "permission": "allow",
  "updated_input": {
    "command": "rtk git status"
  }
}
```

Hook now correctly rewrites commands and RTK tracking works:

```bash
$ rtk gain
RTK Token Savings (Global Scope)
════════════════════════════════════════════════════════════

Total commands:    1
Input tokens:      77
Output tokens:     76
Tokens saved:      1 (1.3%)
```

## Impact

**Without this fix:**
- Cursor users get 0% token savings from the auto-rewrite feature
- Hook appears installed but does nothing
- Users must manually prefix commands with `rtk`

**With this fix:**
- 60-90% token savings on shell commands as advertised
- Transparent command rewriting works as designed
- Full RTK adoption for Cursor users

## Follow-up (review feedback)

Incorporating [@CamilleGuillory](https://github.com/CamilleGuillory)'s suggestions on this PR:

- **Empty output guard** — if `rtk rewrite` exits 0 or 3 but prints nothing, the hook returns `{}` and does not emit malformed `updated_input`.
- **`rtk-hook-version: 2`** — bumps the Cursor hook script version so installs and tooling can distinguish this revision from the broken v1 line.
- **Comments before the `jq` block** — documents `rtk rewrite` exit codes (0 vs 3) and why the response uses `"permission": "allow"` for Cursor.

## Acknowledgments

Thanks to [@CamilleGuillory](https://github.com/CamilleGuillory) for the review and for noting the overlap with [#1100](https://github.com/rtk-ai/rtk/pull/1100). The follow-up commit on this branch includes a `Co-authored-by` trailer attributing the review-driven hardening and documentation.

## Checklist

- [x] Fix implemented in `hooks/cursor/rtk-rewrite.sh`
- [x] Tested locally with `rtk rewrite` commands
- [x] Verified hook output format matches Cursor requirements
- [x] Review follow-up: empty-output guard, hook version 2, jq/Cursor comments
- [x] Attribution: `Co-authored-by` for [@CamilleGuillory](https://github.com/CamilleGuillory) on the follow-up commit
