### PR TITLE
fix(read): don't count --max-lines truncation as token savings (#1045)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 * **git:** remove `-u` short alias from `--ultra-compact` to fix `git push -u` upstream tracking ([#1086](https://github.com/rtk-ai/rtk/issues/1086))
+* **read:** stop counting `--max-lines` / `--tail-lines` truncation as token savings ([#1045](https://github.com/rtk-ai/rtk/issues/1045)). Affected users will see lower (and accurate) numbers in `rtk gain` going forward.
 
 ## [0.35.0](https://github.com/rtk-ai/rtk/compare/v0.34.3...v0.35.0) (2026-04-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,6 +243,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 * **git:** remove `-u` short alias from `--ultra-compact` to fix `git push -u` upstream tracking ([#1086](https://github.com/rtk-ai/rtk/issues/1086))
+* **read:** stop counting `--max-lines` / `--tail-lines` truncation as token savings ([#1045](https://github.com/rtk-ai/rtk/issues/1045)). Affected users will see lower (and accurate) numbers in `rtk gain` going forward.
 
 ## [0.35.0](https://github.com/rtk-ai/rtk/compare/v0.34.3...v0.35.0) (2026-04-06)
 

--- a/src/cmds/system/read.rs
+++ b/src/cmds/system/read.rs
@@ -66,22 +66,27 @@ pub fn run(
     // Capture post-filter content before user-requested truncation.
     // --max-lines/--tail-lines is a user choice, not RTK compression — savings
     // are tracked against filtered (not truncated) output to avoid inflation.
-    let filtered_for_tracking = if max_lines.is_some() || tail_lines.is_some() {
-        Some(filtered.clone())
+    // mem::take avoids cloning the entire filtered buffer (can be large).
+    let pre_truncation: Option<String> = if max_lines.is_some() || tail_lines.is_some() {
+        Some(std::mem::take(&mut filtered))
     } else {
         None
     };
-
-    filtered = apply_line_window(&filtered, max_lines, tail_lines, &lang);
+    let windowed = apply_line_window(
+        pre_truncation.as_deref().unwrap_or(&filtered),
+        max_lines,
+        tail_lines,
+        &lang,
+    );
 
     let rtk_output = if line_numbers {
-        format_with_line_numbers(&filtered)
+        format_with_line_numbers(&windowed)
     } else {
-        filtered.clone()
+        windowed
     };
-    println!("{}", rtk_output);
+    print!("{}", rtk_output);
 
-    let tracking_output = filtered_for_tracking.as_deref().unwrap_or(&rtk_output);
+    let tracking_output = pick_tracking_output(pre_truncation.as_deref(), &rtk_output);
     timer.track(
         &format!("cat {}", file.display()),
         "rtk read",
@@ -138,22 +143,26 @@ pub fn run_stdin(
         );
     }
 
-    let filtered_for_tracking = if max_lines.is_some() || tail_lines.is_some() {
-        Some(filtered.clone())
+    let pre_truncation: Option<String> = if max_lines.is_some() || tail_lines.is_some() {
+        Some(std::mem::take(&mut filtered))
     } else {
         None
     };
-
-    filtered = apply_line_window(&filtered, max_lines, tail_lines, &lang);
+    let windowed = apply_line_window(
+        pre_truncation.as_deref().unwrap_or(&filtered),
+        max_lines,
+        tail_lines,
+        &lang,
+    );
 
     let rtk_output = if line_numbers {
-        format_with_line_numbers(&filtered)
+        format_with_line_numbers(&windowed)
     } else {
-        filtered.clone()
+        windowed
     };
     print!("{}", rtk_output);
 
-    let tracking_output = filtered_for_tracking.as_deref().unwrap_or(&rtk_output);
+    let tracking_output = pick_tracking_output(pre_truncation.as_deref(), &rtk_output);
     timer.track("cat - (stdin)", "rtk read -", &content, tracking_output);
     Ok(())
 }
@@ -166,6 +175,17 @@ fn format_with_line_numbers(content: &str) -> String {
         out.push_str(&format!("{:>width$} │ {}\n", i + 1, line, width = width));
     }
     out
+}
+
+/// Selects the tracking baseline for `timer.track()`.
+///
+/// When the user passes `--max-lines` or `--tail-lines`, the truncated output is
+/// not RTK compression — it's user-requested windowing. Tracking against it
+/// would inflate savings by the entire skipped portion (see #1045). In that
+/// case `pre_truncation` holds the post-filter, pre-truncation content and is
+/// returned as the baseline. Otherwise, `rtk_output` itself is the baseline.
+fn pick_tracking_output<'a>(pre_truncation: Option<&'a str>, rtk_output: &'a str) -> &'a str {
+    pre_truncation.unwrap_or(rtk_output)
 }
 
 fn apply_line_window(
@@ -315,29 +335,11 @@ fn main() {{
         );
     }
 
-    // ── Helpers for savings-tracking logic tests ──────────────────────────────
-
-    /// Simulate the filtered_for_tracking / tracking_output logic from run().
-    /// Returns (tracking_output_len, truncated_len, full_filtered_len).
-    fn simulate_tracking(
-        full_content: &str,
-        max_lines: Option<usize>,
-        tail_lines: Option<usize>,
-    ) -> (usize, usize, usize) {
-        let filtered = full_content.to_string();
-        let filtered_for_tracking = if max_lines.is_some() || tail_lines.is_some() {
-            Some(filtered.clone())
-        } else {
-            None
-        };
-        let truncated = apply_line_window(&filtered, max_lines, tail_lines, &Language::Unknown);
-        let tracking_output = filtered_for_tracking
-            .as_deref()
-            .unwrap_or(truncated.as_str());
-        (tracking_output.len(), truncated.len(), filtered.len())
-    }
-
     // ── Regression tests for #1045 ─────────────────────────────────────────
+    //
+    // These exercise the real `pick_tracking_output` + `apply_line_window`
+    // functions used by `run()`, so a regression in the production selection
+    // logic fails them.
 
     /// When --max-lines is active, savings must be calculated against the
     /// pre-truncation (filtered) content, not the truncated output.
@@ -345,20 +347,20 @@ fn main() {{
     /// With this fix   : savings ≈ 0 tokens (no RTK compression happened).
     #[test]
     fn test_max_lines_tracking_uses_pretruncation_content() {
-        let content: String = (0..100).map(|i| format!("line {i}\n")).collect();
-        let (tracking_len, truncated_len, full_len) =
-            simulate_tracking(&content, Some(5), None);
+        let filtered: String = (0..100).map(|i| format!("line {i}\n")).collect();
+        let windowed = apply_line_window(&filtered, Some(5), None, &Language::Unknown);
+        let tracking = pick_tracking_output(Some(&filtered), &windowed);
 
         assert_eq!(
-            tracking_len, full_len,
+            tracking, filtered,
             "tracking_output must equal full filtered content, not the truncated slice"
         );
         assert!(
-            truncated_len < full_len,
+            windowed.len() < filtered.len(),
             "sanity check: truncation must have reduced content"
         );
         assert!(
-            tracking_len > truncated_len,
+            tracking.len() > windowed.len(),
             "tracking_output must be larger than truncated_output to prevent savings inflation"
         );
     }
@@ -366,25 +368,25 @@ fn main() {{
     /// Same invariant for --tail-lines.
     #[test]
     fn test_tail_lines_tracking_uses_pretruncation_content() {
-        let content: String = (0..100).map(|i| format!("line {i}\n")).collect();
-        let (tracking_len, truncated_len, full_len) =
-            simulate_tracking(&content, None, Some(5));
+        let filtered: String = (0..100).map(|i| format!("line {i}\n")).collect();
+        let windowed = apply_line_window(&filtered, None, Some(5), &Language::Unknown);
+        let tracking = pick_tracking_output(Some(&filtered), &windowed);
 
-        assert_eq!(tracking_len, full_len);
-        assert!(truncated_len < full_len);
-        assert!(tracking_len > truncated_len);
+        assert_eq!(tracking, filtered);
+        assert!(windowed.len() < filtered.len());
+        assert!(tracking.len() > windowed.len());
     }
 
     /// Without any truncation flag, tracking_output == rtk_output (no change
     /// in behaviour for the normal code path).
     #[test]
     fn test_no_truncation_tracking_unchanged() {
-        let content: String = (0..10).map(|i| format!("line {i}\n")).collect();
-        let (tracking_len, truncated_len, _full_len) =
-            simulate_tracking(&content, None, None);
+        let filtered: String = (0..10).map(|i| format!("line {i}\n")).collect();
+        let windowed = apply_line_window(&filtered, None, None, &Language::Unknown);
+        let tracking = pick_tracking_output(None, &windowed);
 
         assert_eq!(
-            tracking_len, truncated_len,
+            tracking, windowed,
             "without truncation flags, tracking_output must equal rtk_output"
         );
     }
@@ -396,16 +398,16 @@ fn main() {{
         use crate::core::tracking::estimate_tokens;
 
         // 1000-line file, each line ~20 chars = ~5k tokens input
-        let content: String = (0..1000).map(|i| format!("{:020}\n", i)).collect();
-        let (tracking_len, truncated_len, _) = simulate_tracking(&content, Some(5), None);
+        let filtered: String = (0..1000).map(|i| format!("{:020}\n", i)).collect();
+        let windowed = apply_line_window(&filtered, Some(5), None, &Language::Unknown);
+        let tracking = pick_tracking_output(Some(&filtered), &windowed);
 
-        let input_tokens = estimate_tokens(&content);
+        let input_tokens = estimate_tokens(&filtered);
 
         // Savings reported by the BUGGY version (tracking against truncated output)
-        let buggy_savings = input_tokens as i64 - estimate_tokens(&content[..truncated_len]) as i64;
-
+        let buggy_savings = input_tokens as i64 - estimate_tokens(&windowed) as i64;
         // Savings reported by the FIXED version (tracking against pre-truncation content)
-        let fixed_savings = input_tokens as i64 - estimate_tokens(&content[..tracking_len]) as i64;
+        let fixed_savings = input_tokens as i64 - estimate_tokens(tracking) as i64;
 
         assert!(
             buggy_savings > 1_000,

--- a/src/cmds/system/read.rs
+++ b/src/cmds/system/read.rs
@@ -63,6 +63,15 @@ pub fn run(
         );
     }
 
+    // Capture post-filter content before user-requested truncation.
+    // --max-lines/--tail-lines is a user choice, not RTK compression — savings
+    // are tracked against filtered (not truncated) output to avoid inflation.
+    let filtered_for_tracking = if max_lines.is_some() || tail_lines.is_some() {
+        Some(filtered.clone())
+    } else {
+        None
+    };
+
     filtered = apply_line_window(&filtered, max_lines, tail_lines, &lang);
 
     let rtk_output = if line_numbers {
@@ -70,12 +79,14 @@ pub fn run(
     } else {
         filtered.clone()
     };
-    print!("{}", rtk_output);
+    println!("{}", rtk_output);
+
+    let tracking_output = filtered_for_tracking.as_deref().unwrap_or(&rtk_output);
     timer.track(
         &format!("cat {}", file.display()),
         "rtk read",
         &content,
-        &rtk_output,
+        tracking_output,
     );
     Ok(())
 }
@@ -127,6 +138,12 @@ pub fn run_stdin(
         );
     }
 
+    let filtered_for_tracking = if max_lines.is_some() || tail_lines.is_some() {
+        Some(filtered.clone())
+    } else {
+        None
+    };
+
     filtered = apply_line_window(&filtered, max_lines, tail_lines, &lang);
 
     let rtk_output = if line_numbers {
@@ -136,7 +153,8 @@ pub fn run_stdin(
     };
     print!("{}", rtk_output);
 
-    timer.track("cat - (stdin)", "rtk read -", &content, &rtk_output);
+    let tracking_output = filtered_for_tracking.as_deref().unwrap_or(&rtk_output);
+    timer.track("cat - (stdin)", "rtk read -", &content, tracking_output);
     Ok(())
 }
 
@@ -294,6 +312,108 @@ fn main() {{
             stderr.contains("stdin specified more than once"),
             "should warn about duplicate stdin, got stderr: {}",
             stderr
+        );
+    }
+
+    // ── Helpers for savings-tracking logic tests ──────────────────────────────
+
+    /// Simulate the filtered_for_tracking / tracking_output logic from run().
+    /// Returns (tracking_output_len, truncated_len, full_filtered_len).
+    fn simulate_tracking(
+        full_content: &str,
+        max_lines: Option<usize>,
+        tail_lines: Option<usize>,
+    ) -> (usize, usize, usize) {
+        let filtered = full_content.to_string();
+        let filtered_for_tracking = if max_lines.is_some() || tail_lines.is_some() {
+            Some(filtered.clone())
+        } else {
+            None
+        };
+        let truncated = apply_line_window(&filtered, max_lines, tail_lines, &Language::Unknown);
+        let tracking_output = filtered_for_tracking
+            .as_deref()
+            .unwrap_or(truncated.as_str());
+        (tracking_output.len(), truncated.len(), filtered.len())
+    }
+
+    // ── Regression tests for #1045 ─────────────────────────────────────────
+
+    /// When --max-lines is active, savings must be calculated against the
+    /// pre-truncation (filtered) content, not the truncated output.
+    /// Without this fix: savings ≈ 100k tokens for a 100k-line file.
+    /// With this fix   : savings ≈ 0 tokens (no RTK compression happened).
+    #[test]
+    fn test_max_lines_tracking_uses_pretruncation_content() {
+        let content: String = (0..100).map(|i| format!("line {i}\n")).collect();
+        let (tracking_len, truncated_len, full_len) =
+            simulate_tracking(&content, Some(5), None);
+
+        assert_eq!(
+            tracking_len, full_len,
+            "tracking_output must equal full filtered content, not the truncated slice"
+        );
+        assert!(
+            truncated_len < full_len,
+            "sanity check: truncation must have reduced content"
+        );
+        assert!(
+            tracking_len > truncated_len,
+            "tracking_output must be larger than truncated_output to prevent savings inflation"
+        );
+    }
+
+    /// Same invariant for --tail-lines.
+    #[test]
+    fn test_tail_lines_tracking_uses_pretruncation_content() {
+        let content: String = (0..100).map(|i| format!("line {i}\n")).collect();
+        let (tracking_len, truncated_len, full_len) =
+            simulate_tracking(&content, None, Some(5));
+
+        assert_eq!(tracking_len, full_len);
+        assert!(truncated_len < full_len);
+        assert!(tracking_len > truncated_len);
+    }
+
+    /// Without any truncation flag, tracking_output == rtk_output (no change
+    /// in behaviour for the normal code path).
+    #[test]
+    fn test_no_truncation_tracking_unchanged() {
+        let content: String = (0..10).map(|i| format!("line {i}\n")).collect();
+        let (tracking_len, truncated_len, _full_len) =
+            simulate_tracking(&content, None, None);
+
+        assert_eq!(
+            tracking_len, truncated_len,
+            "without truncation flags, tracking_output must equal rtk_output"
+        );
+    }
+
+    /// Numerical proof: the bug would have reported huge artificial savings;
+    /// the fix reports ≈0 savings (content unchanged by RTK filtering).
+    #[test]
+    fn test_savings_inflation_is_zero_with_fix() {
+        use crate::core::tracking::estimate_tokens;
+
+        // 1000-line file, each line ~20 chars = ~5k tokens input
+        let content: String = (0..1000).map(|i| format!("{:020}\n", i)).collect();
+        let (tracking_len, truncated_len, _) = simulate_tracking(&content, Some(5), None);
+
+        let input_tokens = estimate_tokens(&content);
+
+        // Savings reported by the BUGGY version (tracking against truncated output)
+        let buggy_savings = input_tokens as i64 - estimate_tokens(&content[..truncated_len]) as i64;
+
+        // Savings reported by the FIXED version (tracking against pre-truncation content)
+        let fixed_savings = input_tokens as i64 - estimate_tokens(&content[..tracking_len]) as i64;
+
+        assert!(
+            buggy_savings > 1_000,
+            "bug would report >1k fake token savings, got {buggy_savings}"
+        );
+        assert_eq!(
+            fixed_savings, 0,
+            "fix must report 0 savings when content wasn't actually compressed, got {fixed_savings}"
         );
     }
 }

--- a/src/cmds/system/read.rs
+++ b/src/cmds/system/read.rs
@@ -418,4 +418,77 @@ fn main() {{
             "fix must report 0 savings when content wasn't actually compressed, got {fixed_savings}"
         );
     }
+
+    /// End-to-end regression: drive the real `run()` path, then read what was
+    /// actually persisted to the SQLite tracking DB. Catches the class of
+    /// regression where someone rewires `pick_tracking_output(Some(&windowed), …)`
+    /// — the unit tests above pass `Some(&filtered)` directly so they would not.
+    #[test]
+    fn test_run_does_not_inflate_savings_with_max_lines_e2e() {
+        use rusqlite::Connection;
+        use std::env;
+        use std::sync::Mutex;
+        // Serialize against any other test that mutates RTK_DB_PATH (see
+        // tracking.rs::test_db_path_env_and_default for the same pattern).
+        static ENV_LOCK: Mutex<()> = Mutex::new(());
+        // Don't recover a poisoned guard: poison means a prior test panicked
+        // while RTK_DB_PATH was set, and proceeding here would leak that env
+        // var into our run(). Propagate the original panic instead.
+        let _guard = ENV_LOCK.lock().unwrap();
+
+        let tmpdir = tempfile::tempdir().expect("create tempdir");
+        let db_path = tmpdir.path().join("rtk_e2e.db");
+
+        let mut input = NamedTempFile::with_suffix(".txt").expect("create tempfile");
+        // 1000 plain text lines — `Language::Unknown` filter is identity, so
+        // any reported savings can only come from a tracking-baseline bug.
+        let big: String = (0..1000).map(|i| format!("line {i}\n")).collect();
+        input.write_all(big.as_bytes()).expect("write tempfile");
+        let input_path = input.path().to_path_buf();
+
+        let prev_db = env::var("RTK_DB_PATH").ok();
+        env::set_var("RTK_DB_PATH", &db_path);
+
+        let result = run(
+            &input_path,
+            FilterLevel::Minimal,
+            Some(5), // --max-lines 5: keep 5/1000 lines
+            None,
+            false,
+            0,
+        );
+
+        match prev_db {
+            Some(v) => env::set_var("RTK_DB_PATH", v),
+            None => env::remove_var("RTK_DB_PATH"),
+        }
+        result.expect("run() must succeed");
+
+        // Inspect what `timer.track()` persisted. If `pick_tracking_output`
+        // is wired to the truncated buffer, output_tokens collapses to ~5
+        // lines and saved_tokens explodes — the #1045 regression.
+        let conn = Connection::open(&db_path).expect("open tracking DB");
+        let (input_tokens, output_tokens, saved_tokens): (i64, i64, i64) = conn
+            .query_row(
+                "SELECT input_tokens, output_tokens, saved_tokens
+                 FROM commands ORDER BY id DESC LIMIT 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("at least one row recorded");
+
+        // Filter is identity for plain text → tracking baseline must equal
+        // input. Tolerate small drift from line-numbering / formatting.
+        let drift = (input_tokens - output_tokens).abs();
+        assert!(
+            drift < 50,
+            "Expected near-zero savings on identity filter, got input={input_tokens} \
+             output={output_tokens} saved={saved_tokens} drift={drift}. \
+             A large drift means run() is tracking the truncated buffer (the #1045 bug)."
+        );
+        assert!(
+            saved_tokens.abs() < 50,
+            "saved_tokens must be near-zero when no compression happened, got {saved_tokens}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- `rtk read file --max-lines N` was comparing the full raw file against the truncated output in `timer.track()`, inflating reported savings by the entire skipped portion — 250M+ tokens reported for a single command on large files
- Fix: capture the post-filter, pre-truncation content and use it as the tracking baseline when `--max-lines` or `--tail-lines` is active
- Same fix applied to `run_stdin()`

## Root cause

```rust
// BEFORE — bug
timer.track("cat file", "rtk read", &content, &rtk_output);
//                                   ^^^^^^^^   ^^^^^^^^^^
//                                   11MB file  5 lines → fake 2.8M token "savings"

// AFTER — fix
let tracking_output = filtered_for_tracking.as_deref().unwrap_or(&rtk_output);
timer.track("cat file", "rtk read", &content, tracking_output);
//                                             ^^^^^^^^^^^^^^
//                                             pre-truncation filtered content → real savings only
```

## Test plan

4 new regression tests in `src/cmds/system/read.rs`:

- [x] `test_max_lines_tracking_uses_pretruncation_content` — tracking baseline equals full filtered content, not truncated slice
- [x] `test_tail_lines_tracking_uses_pretruncation_content` — same invariant for `--tail-lines`
- [x] `test_no_truncation_tracking_unchanged` — without truncation flags, behaviour is identical to before
- [x] `test_savings_inflation_is_zero_with_fix` — numerical proof: buggy code reports >1k fake tokens, fix reports 0

```
cargo test: 1347 passed, 0 failed
```

Fixes #1045

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
