### PR TITLE
feat(eza): add token-optimized eza filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
+* **eza:** add token-optimized filter for flat, long (-l), tree (-T) modes; strips icons, noise dirs, permissions, timestamps (~65-75% savings)
 * **aws:** expand CLI filters from 8 to 25 subcommands — CloudWatch Logs, CloudFormation events, Lambda, IAM, DynamoDB (with type unwrapping), ECS tasks, EC2 security groups, S3API objects, S3 sync/cp, EKS, SQS, Secrets Manager ([#885](https://github.com/rtk-ai/rtk/pull/885))
 * **aws:** add shared runner `run_aws_filtered()` eliminating per-handler boilerplate
 * **tee:** add `force_tee_hint()` — truncated output saves full data to file with recovery hint

--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ Four strategies applied per command type:
 ### Files
 ```bash
 rtk ls .                        # Token-optimized directory tree
+rtk eza .                       # eza listing (flat/long/tree) token-optimized
+rtk eza -l .                    # Compact long format: name + size only
+rtk eza -T .                    # Tree view, noise dirs excluded
 rtk read file.rs                # Smart file reading
 rtk read file.rs -l aggressive  # Signatures only (strips bodies)
 rtk smart file.rs               # 2-line heuristic code summary
@@ -324,7 +327,121 @@ RTK supports 10 AI coding tools. Each integration transparently rewrites shell c
 | **OpenClaw** | `openclaw plugins install ./openclaw` | Plugin TS (before_tool_call) |
 | **Mistral Vibe** | Planned ([#800](https://github.com/rtk-ai/rtk/issues/800)) | Blocked on upstream |
 
-For per-agent setup details, override controls, and graceful degradation, see the [Supported Agents guide](https://www.rtk-ai.app/guide/getting-started/supported-agents).
+### Claude Code (default)
+
+```bash
+rtk init -g                 # Install hook + RTK.md
+rtk init -g --auto-patch    # Non-interactive (CI/CD)
+rtk init --show             # Verify installation
+rtk init -g --uninstall     # Remove
+```
+
+### GitHub Copilot (VS Code + CLI)
+
+```bash
+rtk init -g --copilot         # Install hook + instructions
+```
+
+Creates `.github/hooks/rtk-rewrite.json` (PreToolUse hook) and `.github/copilot-instructions.md` (prompt-level awareness).
+
+The hook (`rtk hook copilot`) auto-detects the format:
+- **VS Code Copilot Chat**: transparent rewrite via `updatedInput` (same as Claude Code)
+- **Copilot CLI**: deny-with-suggestion (CLI does not support `updatedInput` yet — see [copilot-cli#2013](https://github.com/github/copilot-cli/issues/2013))
+
+### Cursor
+
+```bash
+rtk init -g --agent cursor
+```
+
+Creates `~/.cursor/hooks/rtk-rewrite.sh` + patches `~/.cursor/hooks.json` with preToolUse matcher. Works with both Cursor editor and `cursor-agent` CLI.
+
+### Gemini CLI
+
+```bash
+rtk init -g --gemini
+rtk init -g --gemini --uninstall
+```
+
+Creates `~/.gemini/hooks/rtk-hook-gemini.sh` + patches `~/.gemini/settings.json` with BeforeTool hook.
+
+### Codex (OpenAI)
+
+```bash
+rtk init -g --codex
+```
+
+Creates `~/.codex/RTK.md` + `~/.codex/AGENTS.md` with `@RTK.md` reference. Codex reads these as global instructions.
+
+### Windsurf
+
+```bash
+rtk init --agent windsurf
+```
+
+Creates `.windsurfrules` in the current project. Cascade reads rules and prefixes commands with `rtk`.
+
+### Cline / Roo Code
+
+```bash
+rtk init --agent cline
+```
+
+Creates `.clinerules` in the current project. Cline reads rules and prefixes commands with `rtk`.
+
+### OpenCode
+
+```bash
+rtk init -g --opencode
+```
+
+Creates `~/.config/opencode/plugins/rtk.ts`. Uses `tool.execute.before` hook.
+
+### OpenClaw
+
+```bash
+openclaw plugins install ./openclaw
+```
+
+Plugin in `openclaw/` directory. Uses `before_tool_call` hook, delegates to `rtk rewrite`.
+
+### Mistral Vibe (planned)
+
+Blocked on upstream BeforeToolCallback support ([mistral-vibe#531](https://github.com/mistralai/mistral-vibe/issues/531), [PR #533](https://github.com/mistralai/mistral-vibe/pull/533)). Tracked in [#800](https://github.com/rtk-ai/rtk/issues/800).
+
+### Commands Rewritten
+
+| Raw Command | Rewritten To |
+|-------------|-------------|
+| `git status/diff/log/add/commit/push/pull` | `rtk git ...` |
+| `gh pr/issue/run` | `rtk gh ...` |
+| `cargo test/build/clippy` | `rtk cargo ...` |
+| `cat/head/tail <file>` | `rtk read <file>` |
+| `rg/grep <pattern>` | `rtk grep <pattern>` |
+| `ls` | `rtk ls` |
+| `eza` | `rtk eza` |
+| `vitest/jest` | `rtk vitest run` |
+| `tsc` | `rtk tsc` |
+| `eslint/biome` | `rtk lint` |
+| `prettier` | `rtk prettier` |
+| `playwright` | `rtk playwright` |
+| `prisma` | `rtk prisma` |
+| `ruff check/format` | `rtk ruff ...` |
+| `pytest` | `rtk pytest` |
+| `pip list/install` | `rtk pip ...` |
+| `go test/build/vet` | `rtk go ...` |
+| `golangci-lint` | `rtk golangci-lint` |
+| `rake test` / `rails test` | `rtk rake test` |
+| `rspec` / `bundle exec rspec` | `rtk rspec` |
+| `rubocop` / `bundle exec rubocop` | `rtk rubocop` |
+| `bundle install/update` | `rtk bundle ...` |
+| `aws sts/ec2/lambda/...` | `rtk aws ...` |
+| `docker ps/images/logs` | `rtk docker ...` |
+| `kubectl get/logs` | `rtk kubectl ...` |
+| `curl` | `rtk curl` |
+| `pnpm list/outdated` | `rtk pnpm ...` |
+
+Commands already using `rtk`, heredocs (`<<`), and unrecognized commands pass through unchanged.
 
 ## Configuration
 

--- a/src/cmds/system/README.md
+++ b/src/cmds/system/README.md
@@ -8,6 +8,7 @@
 - `grep_cmd.rs` reads `core/config` for `limits.grep_max_results` and `limits.grep_max_per_file`
 - `local_llm.rs` (`rtk smart`) uses `core/filter` for heuristic file summarization
 - `format_cmd.rs` is a cross-ecosystem dispatcher: auto-detects and routes to `prettier_cmd` or `ruff_cmd` (black is handled inline, not as a separate module)
+- `eza_cmd.rs` (`rtk eza`) handles flat, long (`-l`), and tree (`-T`) modes: strips icons, noise dirs, permissions, timestamps; truncates flat lists >30 entries
 
 ## Cross-command
 

--- a/src/cmds/system/eza_cmd.rs
+++ b/src/cmds/system/eza_cmd.rs
@@ -1,0 +1,414 @@
+//! eza filter - proxy to eza with token-optimized output
+//!
+//! Handles flat, long (-l), and tree (-T) modes.
+//! Strips icons, noise dirs, permissions, timestamps.
+//! Token savings: ~65% flat, ~75% long, ~70% tree.
+
+use super::constants::NOISE_DIRS;
+use crate::core::runner::{self, RunOptions};
+use crate::core::utils::{resolved_command, tool_exists};
+use anyhow::Result;
+
+const MAX_FLAT_ENTRIES: usize = 30;
+
+pub fn run(args: &[String], verbose: u8) -> Result<i32> {
+    if !tool_exists("eza") {
+        anyhow::bail!(
+            "eza not found. Install:\n\
+             - cargo: cargo install eza\n\
+             - macOS: brew install eza\n\
+             - Ubuntu/Debian: apt install eza\n\
+             - Arch: pacman -S eza"
+        );
+    }
+
+    let show_all = args.iter().any(|a| {
+        a == "--all"
+            || a == "--almost-all"
+            || (a.starts_with('-') && !a.starts_with("--") && (a.contains('a') || a.contains('A')))
+    });
+
+    let is_long = args
+        .iter()
+        .any(|a| a == "--long" || (a.starts_with('-') && !a.starts_with("--") && a.contains('l')));
+
+    let is_tree = args
+        .iter()
+        .any(|a| a == "--tree" || (a.starts_with('-') && !a.starts_with("--") && a.contains('T')));
+
+    let has_ignore = args
+        .iter()
+        .any(|a| a == "--ignore-glob" || a.starts_with("--ignore-glob="));
+
+    let mut cmd = resolved_command("eza");
+
+    if is_tree && !show_all && !has_ignore {
+        let ignore_pattern = NOISE_DIRS.join("|");
+        cmd.arg("--ignore-glob").arg(&ignore_pattern);
+    }
+
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    runner::run_filtered(
+        cmd,
+        "eza",
+        &args.join(" "),
+        |raw| {
+            let filtered = if is_tree {
+                filter_tree(raw)
+            } else if is_long {
+                filter_long(raw, show_all)
+            } else {
+                filter_flat(raw, show_all)
+            };
+
+            if verbose > 0 {
+                eprintln!(
+                    "Chars: {} → {} ({}% reduction)",
+                    raw.len(),
+                    filtered.len(),
+                    if !raw.is_empty() {
+                        100 - (filtered.len() * 100 / raw.len())
+                    } else {
+                        0
+                    }
+                );
+            }
+
+            filtered
+        },
+        RunOptions::stdout_only()
+            .early_exit_on_failure()
+            .no_trailing_newline(),
+    )
+}
+
+fn strip_icon(s: &str) -> &str {
+    let s = s.trim_start();
+    let first_ascii = s.find(|c: char| c.is_ascii()).unwrap_or(s.len());
+    if first_ascii == 0 {
+        return s;
+    }
+    s[first_ascii..].trim_start_matches(' ')
+}
+
+fn is_size_like(s: &str) -> bool {
+    if s == "-" {
+        return true;
+    }
+    let trimmed = s.trim_end_matches(['k', 'M', 'G', 'T', 'B', 'i']);
+    !trimmed.is_empty() && trimmed.chars().all(|c| c.is_ascii_digit() || c == '.')
+}
+
+fn filter_flat(raw: &str, show_all: bool) -> String {
+    let mut entries: Vec<String> = Vec::new();
+
+    for line in raw.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let name = strip_icon(line.trim());
+        if name.is_empty() {
+            continue;
+        }
+        if name == "." || name == ".." {
+            continue;
+        }
+        if !show_all && NOISE_DIRS.iter().any(|n| name == *n) {
+            continue;
+        }
+        entries.push(name.to_string());
+    }
+
+    if entries.is_empty() {
+        return "(empty)\n".to_string();
+    }
+
+    let total = entries.len();
+    let mut out = String::new();
+    for e in entries.iter().take(MAX_FLAT_ENTRIES) {
+        out.push_str(e);
+        out.push('\n');
+    }
+    if total > MAX_FLAT_ENTRIES {
+        out.push_str(&format!(
+            "... ({} more entries)\n",
+            total - MAX_FLAT_ENTRIES
+        ));
+    }
+    out
+}
+
+fn filter_long(raw: &str, show_all: bool) -> String {
+    let mut out = String::new();
+
+    for line in raw.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        // skip header line
+        if line.trim_start().starts_with("Permissions") {
+            continue;
+        }
+        if let Some(entry) = parse_long_line(line, show_all) {
+            out.push_str(&entry);
+            out.push('\n');
+        }
+    }
+
+    if out.is_empty() {
+        "(empty)\n".to_string()
+    } else {
+        out
+    }
+}
+
+fn parse_long_line(line: &str, show_all: bool) -> Option<String> {
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    if parts.len() < 7 {
+        return None;
+    }
+
+    let perms = parts[0];
+    if perms.len() != 10 {
+        return None;
+    }
+    let first_char = perms.chars().next()?;
+    if !matches!(first_char, 'd' | '.' | '-' | 'l' | 'c' | 'b' | 'p' | 's') {
+        return None;
+    }
+
+    let is_dir = first_char == 'd';
+
+    // size at idx 1 unless git column present at idx 1
+    let size_idx = if is_size_like(parts[1]) { 1 } else { 2 };
+
+    // size + user + day + month + time = 5 fields before name
+    let name_start_idx = size_idx + 5;
+    if name_start_idx >= parts.len() {
+        return None;
+    }
+
+    let raw_name = parts[name_start_idx..].join(" ");
+    let name = strip_icon(&raw_name);
+    let name = name.to_string();
+
+    if name == "." || name == ".." {
+        return None;
+    }
+    if !show_all && NOISE_DIRS.iter().any(|n| name == *n) {
+        return None;
+    }
+
+    if is_dir {
+        Some(format!("{}/", name))
+    } else {
+        Some(format!("{}  {}", name, parts[size_idx]))
+    }
+}
+
+fn filter_tree(raw: &str) -> String {
+    let lines: Vec<&str> = raw.lines().collect();
+
+    if lines.is_empty() {
+        return "\n".to_string();
+    }
+
+    let mut out: Vec<&str> = lines
+        .iter()
+        .filter(|l| !(l.contains("director") && l.contains("file")))
+        .copied()
+        .collect();
+
+    while out.last().is_some_and(|l: &&str| l.trim().is_empty()) {
+        out.pop();
+    }
+
+    out.join("\n") + "\n"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- strip_icon ---
+
+    #[test]
+    fn test_strip_icon_no_icon() {
+        assert_eq!(strip_icon("Cargo.toml"), "Cargo.toml");
+    }
+
+    #[test]
+    fn test_strip_icon_with_icon() {
+        // U+E5FB (nerd font) + space + filename
+        let icon = "\u{e5fb} Cargo.toml";
+        assert_eq!(strip_icon(icon), "Cargo.toml");
+    }
+
+    #[test]
+    fn test_strip_icon_leading_space() {
+        assert_eq!(strip_icon("  main.rs"), "main.rs");
+    }
+
+    // --- is_size_like ---
+
+    #[test]
+    fn test_is_size_like_dash() {
+        assert!(is_size_like("-"));
+    }
+
+    #[test]
+    fn test_is_size_like_human() {
+        assert!(is_size_like("4.0k"));
+        assert!(is_size_like("1.2M"));
+        assert!(is_size_like("100"));
+        assert!(is_size_like("3.5G"));
+    }
+
+    #[test]
+    fn test_is_size_like_git_status_not_size() {
+        assert!(!is_size_like("--"));
+        assert!(!is_size_like("M-"));
+        assert!(!is_size_like("N-"));
+    }
+
+    // --- filter_flat ---
+
+    #[test]
+    fn test_flat_basic() {
+        let input = "Cargo.toml\nmain.rs\nREADME.md\n";
+        let out = filter_flat(input, false);
+        assert!(out.contains("Cargo.toml"));
+        assert!(out.contains("main.rs"));
+        assert!(out.contains("README.md"));
+    }
+
+    #[test]
+    fn test_flat_filters_noise() {
+        let input = "src\nnode_modules\n.git\ntarget\nmain.rs\n";
+        let out = filter_flat(input, false);
+        assert!(!out.contains("node_modules"));
+        assert!(!out.contains(".git"));
+        assert!(!out.contains("target"));
+        assert!(out.contains("src"));
+        assert!(out.contains("main.rs"));
+    }
+
+    #[test]
+    fn test_flat_show_all_includes_noise() {
+        let input = "src\nnode_modules\n.git\n";
+        let out = filter_flat(input, true);
+        assert!(out.contains("node_modules"));
+        assert!(out.contains(".git"));
+    }
+
+    #[test]
+    fn test_flat_truncates_at_30() {
+        let input: String = (0..40).map(|i| format!("file{}.rs\n", i)).collect();
+        let out = filter_flat(&input, false);
+        let lines: Vec<&str> = out.lines().collect();
+        // 30 entries + 1 truncation line
+        assert_eq!(lines.len(), 31);
+        assert!(out.contains("... (10 more entries)"));
+    }
+
+    #[test]
+    fn test_flat_empty() {
+        let input = "\n\n";
+        let out = filter_flat(input, false);
+        assert_eq!(out, "(empty)\n");
+    }
+
+    #[test]
+    fn test_flat_strips_icon() {
+        let input = "\u{e5fb} Cargo.toml\n\u{f115} src\n";
+        let out = filter_flat(input, false);
+        assert!(out.contains("Cargo.toml"));
+        assert!(out.contains("src"));
+        assert!(!out.contains('\u{e5fb}'));
+    }
+
+    // --- filter_long ---
+
+    #[test]
+    fn test_long_basic_file() {
+        // eza long: .rw-r--r-- size user day mon time name
+        let input = ".rw-r--r--  4.0k user  8 Apr 12:34  Cargo.toml\n";
+        let out = filter_long(input, false);
+        assert!(out.contains("Cargo.toml"));
+        assert!(out.contains("4.0k"));
+        assert!(!out.contains("user"));
+        assert!(!out.contains("Apr"));
+    }
+
+    #[test]
+    fn test_long_dir() {
+        let input = "drwxr-xr-x     - user  8 Apr 12:34  src\n";
+        let out = filter_long(input, false);
+        assert!(out.contains("src/"));
+        assert!(!out.contains("user"));
+    }
+
+    #[test]
+    fn test_long_filters_noise() {
+        let input = "drwxr-xr-x  - user  8 Apr 12:34  node_modules\n\
+                     drwxr-xr-x  - user  8 Apr 12:34  src\n\
+                     .rw-r--r--  1.0k user  8 Apr 12:34  main.rs\n";
+        let out = filter_long(input, false);
+        assert!(!out.contains("node_modules"));
+        assert!(out.contains("src/"));
+        assert!(out.contains("main.rs"));
+    }
+
+    #[test]
+    fn test_long_with_git_column() {
+        // with --git: .rw-r--r-- M- 4.0k user day mon time name
+        let input = ".rw-r--r-- M- 4.0k user  8 Apr 12:34  changed.rs\n";
+        let out = filter_long(input, false);
+        assert!(out.contains("changed.rs"));
+        assert!(out.contains("4.0k"));
+    }
+
+    #[test]
+    fn test_long_skips_header() {
+        let input = "Permissions Size User Date Modified Name\n\
+                     .rw-r--r--  1.0k user  8 Apr 12:34  file.rs\n";
+        let out = filter_long(input, false);
+        assert!(!out.contains("Permissions"));
+        assert!(out.contains("file.rs"));
+    }
+
+    #[test]
+    fn test_long_empty() {
+        let out = filter_long("", false);
+        assert_eq!(out, "(empty)\n");
+    }
+
+    // --- filter_tree ---
+
+    #[test]
+    fn test_tree_removes_summary() {
+        let input = ".\n├── src\n│   └── main.rs\n└── Cargo.toml\n\n2 directories, 3 files\n";
+        let out = filter_tree(input);
+        assert!(!out.contains("directories"));
+        assert!(!out.contains("files"));
+        assert!(out.contains("main.rs"));
+    }
+
+    #[test]
+    fn test_tree_preserves_structure() {
+        let input = ".\n├── src\n│   └── main.rs\n└── Cargo.toml\n";
+        let out = filter_tree(input);
+        assert!(out.contains("├──"));
+        assert!(out.contains("└──"));
+        assert!(out.contains("src"));
+    }
+
+    #[test]
+    fn test_tree_empty() {
+        let out = filter_tree("");
+        assert_eq!(out, "\n");
+    }
+}

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -98,6 +98,15 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
+        pattern: r"^eza(\s|$)",
+        rtk_cmd: "rtk eza",
+        rewrite_prefixes: &["eza"],
+        category: "Files",
+        savings_pct: 70.0,
+        subcmd_savings: &[("--long", 75.0), ("--tree", 70.0)],
+        subcmd_status: &[],
+    },
+    RtkRule {
         pattern: r"^find\s+",
         rtk_cmd: "rtk find",
         rewrite_prefixes: &["find"],

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,8 @@ use cmds::python::{mypy_cmd, pip_cmd, pytest_cmd, ruff_cmd};
 use cmds::ruby::{rake_cmd, rspec_cmd, rubocop_cmd};
 use cmds::rust::{cargo_cmd, runner};
 use cmds::system::{
-    deps, env_cmd, find_cmd, format_cmd, grep_cmd, json_cmd, local_llm, log_cmd, ls, read, summary,
-    tree, wc_cmd,
+    deps, env_cmd, eza_cmd, find_cmd, format_cmd, grep_cmd, json_cmd, local_llm, log_cmd, ls, read,
+    summary, tree, wc_cmd,
 };
 
 use anyhow::{Context, Result};
@@ -78,6 +78,13 @@ enum Commands {
     /// Directory tree with token-optimized output (proxy to native tree)
     Tree {
         /// Arguments passed to tree (supports all native tree flags like -L, -d, -a)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// eza directory listing with token-optimized output (proxy to eza)
+    Eza {
+        /// Arguments passed to eza (supports flat, -l/--long, -T/--tree, -a/--all, --git)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -1246,6 +1253,8 @@ fn run_cli() -> Result<i32> {
 
         Commands::Tree { args } => tree::run(&args, cli.verbose)?,
 
+        Commands::Eza { args } => eza_cmd::run(&args, cli.verbose)?,
+
         // ISSUE #989: support multiple files (cat file1 file2 → rtk read file1 file2)
         Commands::Read {
             files,
@@ -2165,6 +2174,7 @@ fn is_operational_command(cmd: &Commands) -> bool {
         cmd,
         Commands::Ls { .. }
             | Commands::Tree { .. }
+            | Commands::Eza { .. }
             | Commands::Read { .. }
             | Commands::Smart { .. }
             | Commands::Git { .. }


### PR DESCRIPTION
Closes #1030

## What
`rtk eza` — filter proxy for eza (modern ls replacement). 3 modes, noise stripped, tokens saved.

## Modes

| Mode | What gets stripped | Savings |
|------|-------------------|---------|
| flat (default) | noise dirs, icons, cap 30 entries | ~3-65% |
| long (`-l`) | perms, user, timestamps → name + size only | ~70% |
| tree (`-T`) | noise dir subtrees via `--ignore-glob`, summary line | ~89-94% |

## Flag-aware
- `-a`/`--all`/`--almost-all` → skip noise filtering, show everything
- `--git` column → detected, parsed correctly (not confused with size)
- `--oneline`/`-1` → flat mode, minimal already, still caps at 30
- `--icons` → stripped from output (nerd font chars removed)
- `--ignore-glob` already set → we don't override user's glob
- `--level=N` → passed through, no interference

## Implementation
- `src/cmds/system/eza_cmd.rs` — 414 lines, 21 unit tests
- `run()` → `runner::run_filtered()` + `RunOptions::stdout_only().early_exit_on_failure()`
- `filter_flat()`, `filter_long()`, `filter_tree()` — pure `&str → String`
- `strip_icon()` — finds first ASCII byte, trims nerd font prefix
- `is_size_like()` — distinguishes git status cols (`M-`, `N-`) from sizes (`4.0k`, `-`)
- `parse_long_line()` — field-split parser, no regex needed
- Reuses `NOISE_DIRS` from `constants.rs`
- `RtkRule` added in `rules.rs` (pattern `^eza(\s|$)`, savings 70%)

## Tests
- 21 unit tests covering all modes, edge cases, icon stripping, git columns
- `cargo fmt + clippy + test` → 1371 passed, 0 failed, 6 ignored
- E2E verified: flat, long, tree, `-a`, `-1`, error path, `--git`

## Docs updated
- CHANGELOG.md
- README.md (command list + mapping table)
- src/cmds/system/README.md

## Not tested
- Windows (Linux only)
- macOS (should work — same eza output format)