### PR TITLE
feat(init): add --native-hook for cross-platform hook support (Windows)

### DIFF
--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -1,4 +1,7 @@
 pub const REWRITE_HOOK_FILE: &str = "rtk-rewrite.sh";
+/// Native hook command — uses the compiled rtk binary directly, no bash/jq required.
+/// Works on all platforms including Windows.
+pub const NATIVE_HOOK_COMMAND: &str = "rtk hook copilot";
 pub const GEMINI_HOOK_FILE: &str = "rtk-hook-gemini.sh";
 pub const CLAUDE_DIR: &str = ".claude";
 pub const HOOKS_SUBDIR: &str = "hooks";

--- a/src/hooks/hook_check.rs
+++ b/src/hooks/hook_check.rs
@@ -1,11 +1,13 @@
 //! Detects whether RTK hooks are installed and warns if they are outdated.
 
 use super::constants::{
-    CLAUDE_DIR, CODEX_DIR, CURSOR_DIR, GEMINI_DIR, GEMINI_HOOK_FILE, HOOKS_SUBDIR,
-    OPENCODE_PLUGIN_PATH, REWRITE_HOOK_FILE,
+    CLAUDE_DIR, HOOKS_SUBDIR, NATIVE_HOOK_COMMAND, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE,
+    SETTINGS_JSON,
 };
+#[cfg(test)]
+use super::constants::{CODEX_DIR, CURSOR_DIR, GEMINI_DIR, GEMINI_HOOK_FILE, OPENCODE_PLUGIN_PATH};
 use crate::core::constants::RTK_DATA_DIR;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 const CURRENT_HOOK_VERSION: u8 = 3;
 const WARN_INTERVAL_SECS: u64 = 24 * 3600;
@@ -29,21 +31,61 @@ pub fn status() -> HookStatus {
         Some(h) => h,
         None => return HookStatus::Ok,
     };
-    if !home.join(CLAUDE_DIR).exists() {
+    let claude_dir = home.join(CLAUDE_DIR);
+    if !claude_dir.exists() {
         return HookStatus::Ok;
     }
 
-    let Some(hook_path) = hook_installed_path() else {
-        return HookStatus::Missing;
-    };
-    let Ok(content) = std::fs::read_to_string(&hook_path) else {
-        return HookStatus::Outdated; // exists but unreadable — treat as needs-update
-    };
-    if parse_hook_version(&content) >= CURRENT_HOOK_VERSION {
-        HookStatus::Ok
-    } else {
-        HookStatus::Outdated
+    // Bash hook file (~/.claude/hooks/rtk-rewrite.sh): versioned, may be outdated.
+    if let Some(hook_path) = hook_installed_path() {
+        let Ok(content) = std::fs::read_to_string(&hook_path) else {
+            return HookStatus::Outdated; // exists but unreadable — treat as needs-update
+        };
+        return if parse_hook_version(&content) >= CURRENT_HOOK_VERSION {
+            HookStatus::Ok
+        } else {
+            HookStatus::Outdated
+        };
     }
+
+    // Native hook (command in settings.json): no file on disk, no version.
+    // Either the entry is there or it isn't.
+    if native_hook_installed(&claude_dir) {
+        return HookStatus::Ok;
+    }
+
+    HookStatus::Missing
+}
+
+/// Check whether the native hook command is registered for PreToolUse
+/// in `<claude_dir>/settings.json`. Used as a fallback when no bash hook
+/// file is present on disk (Windows, or users who opted into `--native-hook`).
+pub(crate) fn native_hook_installed(claude_dir: &Path) -> bool {
+    let settings_path = claude_dir.join(SETTINGS_JSON);
+    let Ok(content) = std::fs::read_to_string(&settings_path) else {
+        return false;
+    };
+    let Ok(root) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return false;
+    };
+    root.get("hooks")
+        .and_then(|h| h.get(PRE_TOOL_USE_KEY))
+        .and_then(|p| p.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| entry.get("hooks")?.as_array())
+        .flatten()
+        .filter_map(|hook| hook.get("command")?.as_str())
+        .any(|cmd| cmd == NATIVE_HOOK_COMMAND)
+}
+
+/// Public helper: is the native hook configured for the current user?
+/// Returns false if home dir is unavailable or settings.json is missing/invalid.
+pub fn native_hook_configured() -> bool {
+    let Some(home) = dirs::home_dir() else {
+        return false;
+    };
+    native_hook_installed(&home.join(CLAUDE_DIR))
 }
 
 /// Check if the installed hook is missing or outdated, warn once per day.
@@ -230,27 +272,90 @@ mod tests {
             None => return,
         };
         let s = status();
-        let has_claude_hook = home
-            .join(".claude")
-            .join("hooks")
-            .join("rtk-rewrite.sh")
-            .exists();
-        let has_claude_dir = home.join(".claude").exists();
+        let claude_dir = home.join(".claude");
+        let has_claude_hook = claude_dir.join("hooks").join("rtk-rewrite.sh").exists();
+        let has_claude_dir = claude_dir.exists();
+        let has_native = has_claude_dir && native_hook_installed(&claude_dir);
         let has_other = other_integration_installed(&home);
 
-        match (has_claude_hook, has_claude_dir, has_other) {
-            (true, _, _) => assert!(
+        match (has_claude_hook, has_native, has_claude_dir, has_other) {
+            (true, _, _, _) => assert!(
                 s == HookStatus::Ok || s == HookStatus::Outdated,
-                "Expected Ok or Outdated when Claude hook exists, got {:?}",
+                "Expected Ok or Outdated when bash hook exists, got {:?}",
                 s
             ),
-            (false, true, _) => assert_eq!(
+            (false, true, _, _) => assert_eq!(
+                s,
+                HookStatus::Ok,
+                "Expected Ok when native hook is configured, got {:?}",
+                s
+            ),
+            (false, false, true, _) => assert_eq!(
                 s,
                 HookStatus::Missing,
-                "Expected Missing when .claude/ exists but hook absent, got {:?}",
+                "Expected Missing when .claude/ exists but no hook (bash or native), got {:?}",
                 s
             ),
-            (false, false, _) => assert_eq!(s, HookStatus::Ok),
+            (false, false, false, _) => assert_eq!(s, HookStatus::Ok),
         }
+    }
+
+    #[test]
+    fn test_native_hook_installed_detects_command() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let claude_dir = tmp.path();
+        let settings = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": NATIVE_HOOK_COMMAND}]
+                }]
+            }
+        });
+        std::fs::write(
+            claude_dir.join(SETTINGS_JSON),
+            serde_json::to_string(&settings).unwrap(),
+        )
+        .unwrap();
+        assert!(native_hook_installed(claude_dir));
+    }
+
+    #[test]
+    fn test_native_hook_installed_missing_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(!native_hook_installed(tmp.path()));
+    }
+
+    #[test]
+    fn test_native_hook_installed_unrelated_hook() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let settings = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": "/some/other/tool.sh"}]
+                }]
+            }
+        });
+        std::fs::write(
+            tmp.path().join(SETTINGS_JSON),
+            serde_json::to_string(&settings).unwrap(),
+        )
+        .unwrap();
+        assert!(!native_hook_installed(tmp.path()));
+    }
+
+    #[test]
+    fn test_native_hook_installed_invalid_json() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join(SETTINGS_JSON), "{ not valid json").unwrap();
+        assert!(!native_hook_installed(tmp.path()));
+    }
+
+    #[test]
+    fn test_native_hook_installed_empty_hooks() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join(SETTINGS_JSON), "{}").unwrap();
+        assert!(!native_hook_installed(tmp.path()));
     }
 }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -7,8 +7,8 @@ use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 
 use super::constants::{
-    BEFORE_TOOL_KEY, CLAUDE_DIR, GEMINI_HOOK_FILE, HOOKS_JSON, HOOKS_SUBDIR, PRE_TOOL_USE_KEY,
-    REWRITE_HOOK_FILE, SETTINGS_JSON,
+    BEFORE_TOOL_KEY, CLAUDE_DIR, GEMINI_HOOK_FILE, HOOKS_JSON, HOOKS_SUBDIR, NATIVE_HOOK_COMMAND,
+    PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use super::integrity;
 
@@ -227,6 +227,7 @@ pub fn run(
     claude_md: bool,
     hook_only: bool,
     codex: bool,
+    native_hook: bool,
     patch_mode: PatchMode,
     verbose: u8,
 ) -> Result<()> {
@@ -246,6 +247,9 @@ pub fn run(
         }
         if matches!(patch_mode, PatchMode::Skip) {
             anyhow::bail!("--codex cannot be combined with --no-patch");
+        }
+        if native_hook {
+            anyhow::bail!("--codex cannot be combined with --native-hook");
         }
         return run_codex_mode(global, verbose);
     }
@@ -277,8 +281,12 @@ pub fn run(
     match (install_claude, install_opencode, claude_md, hook_only) {
         (false, true, _, _) => run_opencode_only_mode(verbose)?,
         (true, opencode, true, _) => run_claude_md_mode(global, verbose, opencode)?,
-        (true, opencode, false, true) => run_hook_only_mode(global, patch_mode, verbose, opencode)?,
-        (true, opencode, false, false) => run_default_mode(global, patch_mode, verbose, opencode)?,
+        (true, opencode, false, true) => {
+            run_hook_only_mode(global, patch_mode, verbose, opencode, native_hook)?
+        }
+        (true, opencode, false, false) => {
+            run_default_mode(global, patch_mode, verbose, opencode, native_hook)?
+        }
         (false, false, _, _) => {
             if !install_cursor {
                 anyhow::bail!("at least one of install_claude or install_opencode must be true")
@@ -473,7 +481,7 @@ fn remove_hook_from_json(root: &mut serde_json::Value) -> bool {
         if let Some(hooks_array) = entry.get("hooks").and_then(|h| h.as_array()) {
             for hook in hooks_array {
                 if let Some(command) = hook.get("command").and_then(|c| c.as_str()) {
-                    if command.contains(REWRITE_HOOK_FILE) {
+                    if is_rtk_hook_command(command) {
                         return false;
                     }
                 }
@@ -746,6 +754,12 @@ fn patch_settings_json(
         }
     }
 
+    // Migration: remove other RTK hook variant if present (e.g., switching bash → native)
+    let migrated_hook = replace_other_rtk_hook_in_json(&mut root, hook_command);
+    if migrated_hook && verbose > 0 {
+        eprintln!("settings.json: replacing old RTK hook variant");
+    }
+
     // Deep-merge hook
     insert_hook_entry(&mut root, hook_command);
 
@@ -847,7 +861,7 @@ fn insert_hook_entry(root: &mut serde_json::Value, hook_command: &str) {
 }
 
 /// Check if RTK hook is already present in settings.json
-/// Matches on rtk-rewrite.sh substring to handle different path formats
+/// Matches on rtk-rewrite.sh substring or native hook command
 fn hook_already_present(root: &serde_json::Value, hook_command: &str) -> bool {
     let pre_tool_use_array = match root
         .get("hooks")
@@ -866,21 +880,163 @@ fn hook_already_present(root: &serde_json::Value, hook_command: &str) -> bool {
         .any(|cmd| {
             cmd == hook_command
                 || (cmd.contains(REWRITE_HOOK_FILE) && hook_command.contains(REWRITE_HOOK_FILE))
+                || (cmd == NATIVE_HOOK_COMMAND && hook_command == NATIVE_HOOK_COMMAND)
         })
+}
+
+/// Returns true if the given command string is any form of RTK hook
+/// (bash script path containing "rtk-rewrite.sh" or native "rtk hook copilot").
+fn is_rtk_hook_command(command: &str) -> bool {
+    command.contains(REWRITE_HOOK_FILE) || command == NATIVE_HOOK_COMMAND
+}
+
+/// When switching hook variants (bash → native or native → bash), remove
+/// the OTHER variant from settings.json so Claude Code doesn't run both.
+/// Returns true if an entry was removed.
+fn replace_other_rtk_hook_in_json(root: &mut serde_json::Value, hook_command: &str) -> bool {
+    if !is_rtk_hook_command(hook_command) {
+        return false;
+    }
+
+    let pre_tool_use_array = match root
+        .get_mut("hooks")
+        .and_then(|h| h.get_mut(PRE_TOOL_USE_KEY))
+        .and_then(|p| p.as_array_mut())
+    {
+        Some(arr) => arr,
+        None => return false,
+    };
+
+    let original_len = pre_tool_use_array.len();
+    pre_tool_use_array.retain(|entry| {
+        if let Some(hooks_array) = entry.get("hooks").and_then(|h| h.as_array()) {
+            for hook in hooks_array {
+                if let Some(cmd) = hook.get("command").and_then(|c| c.as_str()) {
+                    // Remove if it's an RTK hook but NOT the same variant we're installing
+                    if is_rtk_hook_command(cmd) && cmd != hook_command {
+                        return false;
+                    }
+                }
+            }
+        }
+        true
+    });
+
+    pre_tool_use_array.len() < original_len
+}
+
+/// Native hook mode: uses `rtk hook copilot` binary directly — no bash, no jq.
+/// Works on all platforms including Windows.
+fn run_native_hook_mode(
+    global: bool,
+    patch_mode: PatchMode,
+    verbose: u8,
+    install_opencode: bool,
+) -> Result<()> {
+    if !global {
+        // Local init: inject CLAUDE.md + generate project-local filters template
+        run_claude_md_mode(false, verbose, install_opencode)?;
+        generate_project_filters_template(verbose)?;
+        return Ok(());
+    }
+
+    let claude_dir = resolve_claude_dir()?;
+    let rtk_md_path = claude_dir.join(RTK_MD);
+    let claude_md_path = claude_dir.join(CLAUDE_MD);
+
+    // 1. Write RTK.md
+    write_if_changed(&rtk_md_path, RTK_SLIM, RTK_MD, verbose)?;
+
+    let opencode_plugin_path = if install_opencode {
+        let path = prepare_opencode_plugin_path()?;
+        ensure_opencode_plugin_installed(&path, verbose)?;
+        Some(path)
+    } else {
+        None
+    };
+
+    // 2. Patch CLAUDE.md (add @RTK.md, migrate if needed)
+    let migrated = patch_claude_md(&claude_md_path, verbose)?;
+
+    // 3. Print success message
+    println!("\nRTK native hook installed (global).\n");
+    println!(
+        "  Hook:      {} (native, cross-platform)",
+        NATIVE_HOOK_COMMAND
+    );
+    println!("  RTK.md:    {} (10 lines)", rtk_md_path.display());
+    if let Some(path) = &opencode_plugin_path {
+        println!("  OpenCode:  {}", path.display());
+    }
+    println!("  CLAUDE.md: @RTK.md reference added");
+
+    if migrated {
+        println!("\n  [ok] Migrated: removed 137-line RTK block from CLAUDE.md");
+        println!("              replaced with @RTK.md (10 lines)");
+    }
+
+    // 4. Patch settings.json with native hook command (no file path needed)
+    let native_path = Path::new(NATIVE_HOOK_COMMAND);
+    let patch_result = patch_settings_json(native_path, patch_mode, verbose, install_opencode)?;
+
+    match patch_result {
+        PatchResult::Patched => {}
+        PatchResult::AlreadyPresent => {
+            println!("\n  settings.json: hook already present");
+            if install_opencode {
+                println!("  Restart Claude Code and OpenCode. Test with: git status");
+            } else {
+                println!("  Restart Claude Code. Test with: git status");
+            }
+        }
+        PatchResult::Declined | PatchResult::Skipped => {}
+    }
+
+    // 5. Generate user-global filters template
+    generate_global_filters_template(verbose)?;
+
+    println!();
+    Ok(())
+}
+
+/// Native hook-only mode: just the hook in settings.json, no RTK.md
+fn run_native_hook_only_mode(global: bool, patch_mode: PatchMode, verbose: u8) -> Result<()> {
+    if !global {
+        eprintln!("[warn] Warning: --hook-only only makes sense with --global");
+        eprintln!("    For local projects, use default mode or --claude-md");
+        return Ok(());
+    }
+
+    println!("\nRTK native hook installed (hook-only mode).\n");
+    println!("  Hook: {} (native, cross-platform)", NATIVE_HOOK_COMMAND);
+    println!(
+        "  Note: No RTK.md created. Claude won't know about meta commands (gain, discover, proxy)."
+    );
+
+    // Patch settings.json with native hook command
+    let native_path = Path::new(NATIVE_HOOK_COMMAND);
+    patch_settings_json(native_path, patch_mode, verbose, false)?;
+
+    Ok(())
 }
 
 /// Default mode: hook + slim RTK.md + @RTK.md reference
 #[cfg(not(unix))]
 fn run_default_mode(
-    _global: bool,
-    _patch_mode: PatchMode,
-    _verbose: u8,
-    _install_opencode: bool,
+    global: bool,
+    patch_mode: PatchMode,
+    verbose: u8,
+    install_opencode: bool,
+    native_hook: bool,
 ) -> Result<()> {
+    if native_hook {
+        return run_native_hook_mode(global, patch_mode, verbose, install_opencode);
+    }
     eprintln!("[warn] Hook-based mode requires Unix (macOS/Linux).");
-    eprintln!("    Windows: use --claude-md mode for full injection.");
+    eprintln!("    Windows: use --native-hook for cross-platform hook support,");
+    eprintln!("    or --claude-md mode for full injection.");
     eprintln!("    Falling back to --claude-md mode.");
-    run_claude_md_mode(_global, _verbose, _install_opencode)
+    run_claude_md_mode(global, verbose, install_opencode)
 }
 
 #[cfg(unix)]
@@ -889,7 +1045,11 @@ fn run_default_mode(
     patch_mode: PatchMode,
     verbose: u8,
     install_opencode: bool,
+    native_hook: bool,
 ) -> Result<()> {
+    if native_hook {
+        return run_native_hook_mode(global, patch_mode, verbose, install_opencode);
+    }
     if !global {
         // Local init: inject CLAUDE.md + generate project-local filters template
         run_claude_md_mode(false, verbose, install_opencode)?;
@@ -1019,12 +1179,19 @@ fn generate_global_filters_template(verbose: u8) -> Result<()> {
 /// Hook-only mode: just the hook, no RTK.md
 #[cfg(not(unix))]
 fn run_hook_only_mode(
-    _global: bool,
-    _patch_mode: PatchMode,
-    _verbose: u8,
+    global: bool,
+    patch_mode: PatchMode,
+    verbose: u8,
     _install_opencode: bool,
+    native_hook: bool,
 ) -> Result<()> {
-    anyhow::bail!("Hook install requires Unix (macOS/Linux). Use WSL or --claude-md mode.")
+    if native_hook {
+        return run_native_hook_only_mode(global, patch_mode, verbose);
+    }
+    anyhow::bail!(
+        "Hook install requires Unix (macOS/Linux). Use --native-hook for cross-platform support, \
+         WSL, or --claude-md mode."
+    )
 }
 
 #[cfg(unix)]
@@ -1033,7 +1200,11 @@ fn run_hook_only_mode(
     patch_mode: PatchMode,
     verbose: u8,
     install_opencode: bool,
+    native_hook: bool,
 ) -> Result<()> {
+    if native_hook {
+        return run_native_hook_only_mode(global, patch_mode, verbose);
+    }
     if !global {
         eprintln!("[warn] Warning: --hook-only only makes sense with --global");
         eprintln!("    For local projects, use default mode or --claude-md");
@@ -1881,7 +2052,28 @@ fn show_claude_config() -> Result<()> {
             println!("[ok] Hook: {} (exists)", hook_path.display());
         }
     } else {
-        println!("[--] Hook: not found");
+        // No bash hook file on disk — check for native hook in settings.json
+        let settings_path = claude_dir.join(SETTINGS_JSON);
+        if settings_path.exists() {
+            if let Ok(content) = fs::read_to_string(&settings_path) {
+                if let Ok(root) = serde_json::from_str::<serde_json::Value>(&content) {
+                    if hook_already_present(&root, NATIVE_HOOK_COMMAND) {
+                        println!(
+                            "[ok] Hook: {} (native, cross-platform)",
+                            NATIVE_HOOK_COMMAND
+                        );
+                    } else {
+                        println!("[--] Hook: not found");
+                    }
+                } else {
+                    println!("[--] Hook: not found");
+                }
+            } else {
+                println!("[--] Hook: not found");
+            }
+        } else {
+            println!("[--] Hook: not found");
+        }
     }
 
     // Check RTK.md
@@ -1945,8 +2137,10 @@ fn show_claude_config() -> Result<()> {
         let content = fs::read_to_string(&settings_path)?;
         if !content.trim().is_empty() {
             if let Ok(root) = serde_json::from_str::<serde_json::Value>(&content) {
-                let hook_command = hook_path.display().to_string();
-                if hook_already_present(&root, &hook_command) {
+                let bash_hook_command = hook_path.display().to_string();
+                if hook_already_present(&root, &bash_hook_command)
+                    || hook_already_present(&root, NATIVE_HOOK_COMMAND)
+                {
                     println!("[ok] settings.json: RTK hook configured");
                 } else {
                     println!("[warn] settings.json: exists but RTK hook not configured");
@@ -2637,6 +2831,7 @@ More notes
             false,
             false,
             true,
+            false,
             PatchMode::Auto,
             0,
         )
@@ -2659,6 +2854,7 @@ More notes
             false,
             false,
             true,
+            false,
             PatchMode::Skip,
             0,
         )
@@ -3099,5 +3295,280 @@ More notes
         assert!(CURSOR_REWRITE_HOOK.contains("\"permission\": \"allow\""));
         assert!(CURSOR_REWRITE_HOOK.contains("\"updated_input\""));
         assert!(!CURSOR_REWRITE_HOOK.contains("hookSpecificOutput"));
+    }
+
+    // ── Native hook tests ─────────────────────────────────────
+
+    #[test]
+    fn test_is_rtk_hook_command() {
+        // Native hook
+        assert!(is_rtk_hook_command("rtk hook copilot"));
+        // Bash hook (various paths)
+        assert!(is_rtk_hook_command(
+            "/Users/test/.claude/hooks/rtk-rewrite.sh"
+        ));
+        assert!(is_rtk_hook_command(
+            "/home/user/.claude/hooks/rtk-rewrite.sh"
+        ));
+        assert!(is_rtk_hook_command("~/.claude/hooks/rtk-rewrite.sh"));
+        // NOT RTK hooks
+        assert!(!is_rtk_hook_command("rtk hook gemini"));
+        assert!(!is_rtk_hook_command("/some/other/hook.sh"));
+        assert!(!is_rtk_hook_command(""));
+        assert!(!is_rtk_hook_command("rtk  hook  copilot")); // extra spaces
+    }
+
+    #[test]
+    fn test_hook_already_present_native_hook() {
+        let json = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": "rtk hook copilot"}]
+                }]
+            }
+        });
+        assert!(hook_already_present(&json, NATIVE_HOOK_COMMAND));
+    }
+
+    #[test]
+    fn test_hook_already_present_native_when_bash_exists() {
+        let json = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": "/home/user/.claude/hooks/rtk-rewrite.sh"}]
+                }]
+            }
+        });
+        // Native hook requested but only bash exists — should NOT match
+        // (allows migration to proceed through patch_settings_json)
+        assert!(!hook_already_present(&json, NATIVE_HOOK_COMMAND));
+    }
+
+    #[test]
+    fn test_hook_already_present_bash_when_native_exists() {
+        let json = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": "rtk hook copilot"}]
+                }]
+            }
+        });
+        // Bash hook requested but only native exists — should NOT match
+        let bash_hook = "/Users/test/.claude/hooks/rtk-rewrite.sh";
+        assert!(!hook_already_present(&json, bash_hook));
+    }
+
+    #[test]
+    fn test_hook_already_present_both_hooks() {
+        let json = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{"type": "command", "command": "/path/to/rtk-rewrite.sh"}]
+                    },
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{"type": "command", "command": "rtk hook copilot"}]
+                    }
+                ]
+            }
+        });
+        assert!(hook_already_present(&json, NATIVE_HOOK_COMMAND));
+        assert!(hook_already_present(&json, "/any/path/rtk-rewrite.sh"));
+    }
+
+    #[test]
+    fn test_hook_already_present_empty_command() {
+        let json = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": "rtk hook copilot"}]
+                }]
+            }
+        });
+        assert!(!hook_already_present(&json, ""));
+    }
+
+    #[test]
+    fn test_hook_already_present_similar_but_different() {
+        let json = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": "rtk hook gemini"}]
+                }]
+            }
+        });
+        // "rtk hook gemini" is NOT an RTK rewrite hook
+        assert!(!hook_already_present(&json, NATIVE_HOOK_COMMAND));
+        assert!(!hook_already_present(&json, "/path/to/rtk-rewrite.sh"));
+    }
+
+    #[test]
+    fn test_remove_native_hook_from_json() {
+        let mut json = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": "rtk hook copilot"}]
+                }]
+            }
+        });
+        let removed = remove_hook_from_json(&mut json);
+        assert!(removed);
+        let arr = json["hooks"]["PreToolUse"].as_array().unwrap();
+        assert!(arr.is_empty());
+    }
+
+    #[test]
+    fn test_remove_native_hook_preserves_other_hooks() {
+        let mut json = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{"type": "command", "command": "/some/other/hook.sh"}]
+                    },
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{"type": "command", "command": "rtk hook copilot"}]
+                    }
+                ]
+            }
+        });
+        let removed = remove_hook_from_json(&mut json);
+        assert!(removed);
+        let arr = json["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["hooks"][0]["command"], "/some/other/hook.sh");
+    }
+
+    #[test]
+    fn test_remove_both_hooks_from_json() {
+        let mut json = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{"type": "command", "command": "/path/to/rtk-rewrite.sh"}]
+                    },
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{"type": "command", "command": "rtk hook copilot"}]
+                    },
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{"type": "command", "command": "/unrelated/hook.sh"}]
+                    }
+                ]
+            }
+        });
+        let removed = remove_hook_from_json(&mut json);
+        assert!(removed);
+        let arr = json["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["hooks"][0]["command"], "/unrelated/hook.sh");
+    }
+
+    #[test]
+    fn test_replace_other_rtk_hook_bash_to_native() {
+        let mut json = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{"type": "command", "command": "/path/to/rtk-rewrite.sh"}]
+                    },
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{"type": "command", "command": "/unrelated/hook.sh"}]
+                    }
+                ]
+            }
+        });
+        let replaced = replace_other_rtk_hook_in_json(&mut json, NATIVE_HOOK_COMMAND);
+        assert!(replaced);
+        let arr = json["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["hooks"][0]["command"], "/unrelated/hook.sh");
+    }
+
+    #[test]
+    fn test_replace_other_rtk_hook_native_to_bash() {
+        let mut json = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": "rtk hook copilot"}]
+                }]
+            }
+        });
+        let replaced =
+            replace_other_rtk_hook_in_json(&mut json, "/home/user/.claude/hooks/rtk-rewrite.sh");
+        assert!(replaced);
+        let arr = json["hooks"]["PreToolUse"].as_array().unwrap();
+        assert!(arr.is_empty());
+    }
+
+    #[test]
+    fn test_replace_other_rtk_hook_no_replacement_when_same_variant() {
+        let mut json = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": "rtk hook copilot"}]
+                }]
+            }
+        });
+        // Installing native when native already exists — should NOT remove it
+        let replaced = replace_other_rtk_hook_in_json(&mut json, NATIVE_HOOK_COMMAND);
+        assert!(!replaced);
+        let arr = json["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+    }
+
+    #[test]
+    fn test_replace_other_rtk_hook_non_rtk_command() {
+        let mut json = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": "rtk hook copilot"}]
+                }]
+            }
+        });
+        // Installing a non-RTK hook should not touch the native hook
+        let replaced = replace_other_rtk_hook_in_json(&mut json, "/some/other/hook.sh");
+        assert!(!replaced);
+        let arr = json["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+    }
+
+    #[test]
+    fn test_codex_mode_rejects_native_hook() {
+        let err = run(
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            false,
+            true,
+            true,
+            PatchMode::Ask,
+            0,
+        )
+        .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "--codex cannot be combined with --native-hook"
+        );
     }
 }

--- a/src/hooks/integrity.rs
+++ b/src/hooks/integrity.rs
@@ -12,7 +12,8 @@
 //!
 //! Reference: SA-2025-RTK-001 (Finding F-01)
 
-use super::constants::{CLAUDE_DIR, HOOKS_SUBDIR, REWRITE_HOOK_FILE};
+use super::constants::{CLAUDE_DIR, HOOKS_SUBDIR, NATIVE_HOOK_COMMAND, REWRITE_HOOK_FILE};
+use super::hook_check;
 use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
 use std::fs;
@@ -226,8 +227,17 @@ pub fn run_verify(verbose: u8) -> Result<()> {
             println!("      Run `rtk init -g` to establish baseline.");
         }
         IntegrityStatus::NotInstalled => {
-            println!("SKIP  RTK hook not installed");
-            println!("      Run `rtk init -g` to install.");
+            // No bash hook on disk — check for the native hook in settings.json.
+            // The native hook is a command string, not a file, so there is no
+            // filesystem baseline to verify against.
+            if hook_check::native_hook_configured() {
+                println!("PASS  native hook configured");
+                println!("      Command: {}", NATIVE_HOOK_COMMAND);
+                println!("      (command lives in settings.json; no file hash to verify)");
+            } else {
+                println!("SKIP  RTK hook not installed");
+                println!("      Run `rtk init -g` to install.");
+            }
         }
         IntegrityStatus::OrphanedHash => {
             eprintln!("WARN  hash file exists but hook is missing");

--- a/src/main.rs
+++ b/src/main.rs
@@ -348,6 +348,11 @@ enum Commands {
         /// Install GitHub Copilot integration (VS Code + CLI)
         #[arg(long)]
         copilot: bool,
+
+        /// Use native cross-platform hook (rtk binary) instead of bash script.
+        /// Required on Windows; opt-in on Unix. No bash or jq dependency.
+        #[arg(long = "native-hook")]
+        native_hook: bool,
     },
 
     /// Download with compact output (strips progress bars)
@@ -1607,6 +1612,7 @@ fn run_cli() -> Result<i32> {
             uninstall,
             codex,
             copilot,
+            native_hook,
         } => {
             if show {
                 hooks::init::show_config(codex)?;
@@ -1648,6 +1654,7 @@ fn run_cli() -> Result<i32> {
                     claude_md,
                     hook_only,
                     codex,
+                    native_hook,
                     patch_mode,
                     cli.verbose,
                 )?;


### PR DESCRIPTION
## Context: Why a New PR Instead of Rebasing #150

PR #150 (`feat/native-hook-rewrite`) added native cross-platform hooks via **8 per-language Rust modules** (`src/hook/git.rs`, `cargo.rs`, `files.rs`, etc. -- 1905 lines across 14 files).

Since then, upstream `develop` has evolved significantly:

1. **PR #241 (`rtk rewrite`)** introduced a **registry-based rewrite system** (`src/discover/registry.rs` + `rules.rs`) that replaced all per-language rewrite logic with centralized regex rules
2. **PR #826/#932** reorganized the codebase from flat `src/` to nested subfolders (`cmds/`, `core/`, `hooks/`, `analytics/`)
3. **`hooks/hook_cmd.rs`** now has native Rust hook processing (`run_copilot()`, `run_gemini()`) that reads JSON from stdin and uses `discover::registry::rewrite_command()`
4. **All P0/P1 bugs** from the #150 review (gh `--json`, git `-C`, cat multi-file, grep flag reorder) were independently fixed in the registry

**Rebasing was not viable**: 9 commits over a massively reorganized repo produced modify/delete conflicts on the first commit. The 8 per-language modules were 100% superseded by the registry.

**This PR takes the clean approach**: fresh branch from `develop`, reusing the existing `rtk hook copilot` command (already in upstream), adding only what was missing -- the `--native-hook` flag in `rtk init` to install it as the hook on all platforms.

**Result**: 3 files, 500 LOC (vs 14 files, 1905 LOC in #150).

**Note**: CLA has been signed as requested in the #150 review.

---

## What This PR Does

Adds `rtk init -g --native-hook` which installs `rtk hook copilot` as the `PreToolUse` hook command instead of the bash script `rtk-rewrite.sh`.

### Why

- **Windows support**: The bash hook requires `bash` + `jq` -- unavailable on Windows. Currently, `rtk init -g` falls back to `--claude-md` mode on Windows (no automatic rewriting). With `--native-hook`, Windows users get the same hook-based token savings as Unix users.
- **Fewer dependencies**: The native hook is the compiled `rtk` binary itself. No `bash`, no `jq`, no shell script on disk.
- **Opt-in on Unix**: Unix users can continue using the battle-tested bash hook by default. `--native-hook` is available for those who prefer the native path.

### Behavior Matrix

| Command | Unix | Windows |
|---------|------|---------|
| `rtk init -g` | Bash hook (unchanged) | Fallback `--claude-md` + message suggesting `--native-hook` |
| `rtk init -g --native-hook` | Native hook `rtk hook copilot` | Native hook `rtk hook copilot` |
| `rtk init -g --hook-only` | Bash hook only | Error + message suggesting `--native-hook` |
| `rtk init -g --hook-only --native-hook` | Native hook only | Native hook only |
| `rtk init --show` | Detects bash OR native hook | Detects bash OR native hook |
| `rtk init -g --uninstall` | Removes bash OR native hook | Removes bash OR native hook |
| `rtk init --codex --native-hook` | Error: incompatible flags | Error: incompatible flags |

---

## Code Changes (3 files, 500 insertions, 19 deletions)

### `src/hooks/constants.rs` (+3 lines)

Added `NATIVE_HOOK_COMMAND` constant:

```rust
/// Native hook command -- uses the compiled rtk binary directly, no bash/jq required.
/// Works on all platforms including Windows.
pub const NATIVE_HOOK_COMMAND: &str = "rtk hook copilot";
```

### `src/main.rs` (+7 lines)

Added `--native-hook` flag to the `Init` command enum and passed it through to `hooks::init::run()`.

### `src/hooks/init.rs` (+490 lines, -19 lines)

#### New functions

| Function | Purpose |
|----------|---------|
| `is_rtk_hook_command(cmd) -> bool` | Single source of truth -- returns true for any RTK hook variant (bash path containing `rtk-rewrite.sh` OR native `rtk hook copilot`) |
| `replace_other_rtk_hook_in_json(root, cmd) -> bool` | Migration helper -- when switching variants (bash to native or native to bash), removes the OTHER variant from `settings.json` to prevent both hooks running |
| `run_native_hook_mode(global, patch_mode, verbose, opencode) -> Result<()>` | Full native install: writes RTK.md, patches CLAUDE.md with @RTK.md, patches settings.json with `"rtk hook copilot"` |
| `run_native_hook_only_mode(global, patch_mode, verbose) -> Result<()>` | Hook-only native install: patches settings.json only, no RTK.md |

#### Bug fixes (5 edge cases found and fixed)

| # | Bug | Impact | Fix |
|---|-----|--------|-----|
| 1 | `remove_hook_from_json()` only checked for `rtk-rewrite.sh` | `rtk init -g --uninstall` would NOT remove the native hook from settings.json | Changed to use `is_rtk_hook_command()` -- now removes both variants |
| 2 | `hook_already_present()` had unconditional `cmd == NATIVE_HOOK_COMMAND` | Asymmetric: prevented migration from bash to native (always returned "already present") | Changed to variant-specific matching: bash matches bash, native matches native |
| 3 | No migration when switching bash/native | Both hooks would coexist in settings.json -- double execution | Added `replace_other_rtk_hook_in_json()` call in `patch_settings_json()` before inserting new entry |
| 4 | `show_claude_config()` only checked bash hook file on disk | `rtk init --show` showed `[--] Hook: not found` when native hook was installed (no file on disk) | Added settings.json lookup for `NATIVE_HOOK_COMMAND` when bash file does not exist |
| 5 | `--codex --native-hook` silently ignored `--native-hook` | User thinks native hook is installed but codex mode ignores it | Added explicit validation: `--codex cannot be combined with --native-hook` |

#### Modified existing functions

| Function | Change |
|----------|--------|
| `run()` | Added `native_hook: bool` parameter, passes to `run_default_mode` and `run_hook_only_mode` |
| `run_default_mode` (Unix) | Early return to `run_native_hook_mode()` when `native_hook` is true |
| `run_default_mode` (Windows) | Same + improved fallback message mentioning `--native-hook` |
| `run_hook_only_mode` (Unix) | Early return to `run_native_hook_only_mode()` when `native_hook` is true |
| `run_hook_only_mode` (Windows) | Same + improved error message |
| `hook_already_present()` | Symmetric variant-specific detection (see fix #2) |
| `remove_hook_from_json()` | Uses `is_rtk_hook_command()` instead of `contains(REWRITE_HOOK_FILE)` (see fix #1) |
| `patch_settings_json()` | Calls `replace_other_rtk_hook_in_json()` before insert (see fix #3) |
| `show_claude_config()` | Detects native hook in settings.json (see fix #4) + checks both variants in settings.json status line |

---

## Tests Added (15 new, 1376 total)

All tests are unit tests in `src/hooks/init.rs` `#[cfg(test)] mod tests`.

### `is_rtk_hook_command` (1 test, 8 assertions)

| Test | Assertions |
|------|------------|
| `test_is_rtk_hook_command` | `"rtk hook copilot"` true, various bash paths true, `"rtk hook gemini"` false, `""` false, `"rtk  hook  copilot"` (extra spaces) false, `"/some/other/hook.sh"` false |

### `hook_already_present` (6 tests)

| Test | Scenario | Expected |
|------|----------|----------|
| `test_hook_already_present_native_hook` | Native in JSON, query native | `true` |
| `test_hook_already_present_native_when_bash_exists` | Bash in JSON, query native | `false` (allows migration) |
| `test_hook_already_present_bash_when_native_exists` | Native in JSON, query bash | `false` (allows migration) |
| `test_hook_already_present_both_hooks` | Both in JSON | `true` for either query |
| `test_hook_already_present_empty_command` | Native in JSON, query `""` | `false` |
| `test_hook_already_present_similar_but_different` | `"rtk hook gemini"` in JSON | `false` for both native and bash queries |

### `remove_hook_from_json` (3 tests)

| Test | Scenario | Verified |
|------|----------|----------|
| `test_remove_native_hook_from_json` | Only native hook | Removed, array empty |
| `test_remove_native_hook_preserves_other_hooks` | Native + unrelated hook | Only native removed |
| `test_remove_both_hooks_from_json` | Bash + native + unrelated | Both RTK hooks removed, unrelated preserved |

### `replace_other_rtk_hook_in_json` (4 tests)

| Test | Scenario | Verified |
|------|----------|----------|
| `test_replace_other_rtk_hook_bash_to_native` | Bash exists, installing native | Bash removed, unrelated preserved |
| `test_replace_other_rtk_hook_native_to_bash` | Native exists, installing bash | Native removed |
| `test_replace_other_rtk_hook_no_replacement_when_same_variant` | Native exists, installing native | No change (idempotent) |
| `test_replace_other_rtk_hook_non_rtk_command` | Native exists, installing unrelated | No change (non-RTK ignored) |

### Validation (1 test)

| Test | Scenario | Expected |
|------|----------|----------|
| `test_codex_mode_rejects_native_hook` | `run(..., codex=true, native_hook=true, ...)` | Error: `"--codex cannot be combined with --native-hook"` |

---

## Quality Gates

| Check | Result |
|-------|--------|
| `cargo fmt --all --check` | Clean |
| `cargo clippy --all-targets` | 0 errors, 0 warnings on changed files (pre-existing warnings in unrelated files only) |
| `cargo test --all` | **1376 passed**, 0 failed, 6 ignored |

## Manual Testing (Windows 11)

| Test | Command | Result |
|------|---------|--------|
| Install native hook | `rtk init -g --native-hook --auto-patch` | Hook installed, settings.json patched |
| Show config | `rtk init --show` | `[ok] Hook: rtk hook copilot (native, cross-platform)` |
| Hook works | `git status` (via AI agent) | Rewrites to `rtk git status`, compact output |
| Windows fallback message | `rtk init -g --auto-patch` (no --native-hook) | Falls back to --claude-md, mentions --native-hook |
| Migration | `rtk init -g --auto-patch` then `rtk init -g --native-hook --auto-patch` | Old 137-line block migrated to @RTK.md, no hook duplication |
| Codex conflict | `rtk init --codex --native-hook` | Error: "--codex cannot be combined with --native-hook" |
| Uninstall | `rtk init -g --uninstall` | Native hook removed from settings.json |
| Post-uninstall | `rtk init --show` | `[--] Hook: not found`, clean state |

## Supersedes

Supersedes #150 -- all unique functionality ported. The per-language hook modules from #150 are no longer needed since the registry-based rewrite system in `develop` handles all command rewriting.
