### PR TITLE
fix(cli): reserve -u for git push

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ rtk session                     # Show RTK adoption across recent sessions
 ## Global Flags
 
 ```bash
--u, --ultra-compact    # ASCII icons, inline format (extra token savings)
+-U, --ultra-compact    # ASCII icons, inline format (extra token savings)
 -v, --verbose          # Increase verbosity (-v, -vv, -vvv)
 ```
 

--- a/docs/contributing/ARCHITECTURE.md
+++ b/docs/contributing/ARCHITECTURE.md
@@ -769,7 +769,7 @@ if verbose > 0 {
 
 ```
 ┌────────────────────────────────────────────────────────────────────────┐
-│                       Ultra-Compact Mode (-u)                          │
+│                       Ultra-Compact Mode (-U)                          │
 └────────────────────────────────────────────────────────────────────────┘
 
 main.rs:51-53
@@ -1028,7 +1028,7 @@ Overhead Sources:
 - **Derive Macros**: Less boilerplate (declarative CLI definition)
 - **Auto-Generated Help**: `--help` generated automatically
 - **Type Safety**: Parse arguments directly into typed structs
-- **Global Flags**: `-v` and `-u` work across all commands
+- **Global Flags**: `-v` and `-U` work across all commands
 
 ---
 
@@ -1052,7 +1052,7 @@ Overhead Sources:
 | **Exit Code Preservation** | Passing through tool's exit code for CI/CD reliability |
 | **Package Manager Detection** | Identifying pnpm/yarn/npm to execute JS/TS tools correctly |
 | **Verbosity Levels** | `-v/-vv/-vvv` for progressively more debug output |
-| **Ultra-Compact** | `-u` flag for maximum compression (ASCII icons, inline format) |
+| **Ultra-Compact** | `-U` flag for maximum compression (ASCII icons, inline format) |
 
 ---
 

--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -53,7 +53,7 @@ Ces drapeaux s'appliquent a **toutes** les sous-commandes :
 | Drapeau | Court | Description |
 |---------|-------|-------------|
 | `--verbose` | `-v` | Augmenter la verbosite (-v, -vv, -vvv). Montre les details de filtrage. |
-| `--ultra-compact` | `-u` | Mode ultra-compact : icones ASCII, format inline. Economies supplementaires. |
+| `--ultra-compact` | `-U` | Mode ultra-compact : icones ASCII, format inline. Economies supplementaires. |
 | `--skip-env` | -- | Definit `SKIP_ENV_VALIDATION=1` pour les processus enfants (Next.js, tsc, lint, prisma). |
 
 **Exemples :**
@@ -61,7 +61,7 @@ Ces drapeaux s'appliquent a **toutes** les sous-commandes :
 ```bash
 rtk -v git status          # Status compact + details de filtrage sur stderr
 rtk -vvv cargo test        # Verbosite maximale (debug)
-rtk -u git log             # Log ultra-compact, icones ASCII
+rtk -U git log             # Log ultra-compact, icones ASCII
 rtk --skip-env next build  # Desactive la validation d'env de Next.js
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ struct Cli {
     verbose: u8,
 
     /// Ultra-compact mode: ASCII icons, inline format (Level 2 optimizations)
-    #[arg(short = 'u', long, global = true)]
+    #[arg(short = 'U', long, global = true)]
     ultra_compact: bool,
 
     /// Set SKIP_ENV_VALIDATION=1 for child processes (Next.js, tsc, lint, prisma)


### PR DESCRIPTION
## Summary
- switch ultra-compact short flag to -U so "-u" can pass through to git push
- update docs to reflect -U for ultra-compact mode

## Test plan
- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] Manual testing: `rtk <command>` output inspected
