### PR TITLE
docs: Windows setup instructions and troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Download from [releases](https://github.com/rtk-ai/rtk/releases):
 - Linux: `rtk-x86_64-unknown-linux-musl.tar.gz` / `rtk-aarch64-unknown-linux-gnu.tar.gz`
 - Windows: `rtk-x86_64-pc-windows-msvc.zip`
 
+> **Windows users**: Extract the zip and place `rtk.exe` somewhere in your PATH (e.g. `C:\Users\<you>\.local\bin`). Run RTK from **Command Prompt**, **PowerShell**, or **Windows Terminal** — do not double-click the `.exe` (it will flash and close). For the best experience, use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) where the full hook system works natively. See [Windows setup](#windows) below for details.
+
 ### Verify Installation
 
 ```bash
@@ -305,6 +307,43 @@ rtk init --show             # Verify installation
 ```
 
 After install, **restart Claude Code**.
+
+## Windows
+
+RTK works on Windows with some limitations. The auto-rewrite hook (`rtk-rewrite.sh`) requires a Unix shell, so on native Windows RTK falls back to **CLAUDE.md injection mode** — your AI assistant receives RTK instructions but commands are not rewritten automatically.
+
+### Recommended: WSL (full support)
+
+For the best experience, use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) (Windows Subsystem for Linux). Inside WSL, RTK works exactly like Linux — full hook support, auto-rewrite, everything:
+
+```bash
+# Inside WSL
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
+rtk init -g
+```
+
+### Native Windows (limited support)
+
+On native Windows (cmd.exe / PowerShell), RTK filters work but the hook does not auto-rewrite commands:
+
+```powershell
+# 1. Download and extract rtk-x86_64-pc-windows-msvc.zip from releases
+# 2. Add rtk.exe to your PATH
+# 3. Initialize (falls back to CLAUDE.md injection)
+rtk init -g
+# 4. Use rtk explicitly
+rtk cargo test
+rtk git status
+```
+
+**Important**: Do not double-click `rtk.exe` — it is a CLI tool that prints usage and exits immediately. Always run it from a terminal (Command Prompt, PowerShell, or Windows Terminal).
+
+| Feature | WSL | Native Windows |
+|---------|-----|----------------|
+| Filters (cargo, git, etc.) | Full | Full |
+| Auto-rewrite hook | Yes | No (CLAUDE.md fallback) |
+| `rtk init -g` | Hook mode | CLAUDE.md mode |
+| `rtk gain` / analytics | Full | Full |
 
 ## Supported AI Tools
 

--- a/docs/guide/getting-started/installation.md
+++ b/docs/guide/getting-started/installation.md
@@ -43,6 +43,16 @@ brew install rtk-ai/tap/rtk
 cargo install rtk
 ```
 
+## Pre-built binaries (Windows, Linux, macOS)
+
+Download from [GitHub releases](https://github.com/rtk-ai/rtk/releases):
+
+- macOS: `rtk-x86_64-apple-darwin.tar.gz` / `rtk-aarch64-apple-darwin.tar.gz`
+- Linux: `rtk-x86_64-unknown-linux-musl.tar.gz` / `rtk-aarch64-unknown-linux-gnu.tar.gz`
+- Windows: `rtk-x86_64-pc-windows-msvc.zip`
+
+**Windows users**: Extract the zip and place `rtk.exe` in a directory on your PATH. Run RTK from Command Prompt, PowerShell, or Windows Terminal — do not double-click the `.exe` (it prints usage and exits immediately). For full hook support, use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) instead.
+
 ## Verify installation
 
 ```bash

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -124,6 +124,16 @@ Support is blocked on upstream `BeforeToolCallback` ([mistral-vibe#531](https://
 
 Rules file integrations (Cline, Windsurf, Codex) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it.
 
+## Windows support
+
+The shell hook (`rtk-rewrite.sh`) requires a Unix shell. On native Windows:
+
+- `rtk init -g` automatically falls back to **CLAUDE.md injection mode** (prompt-level instructions)
+- Filters work normally (`rtk cargo test`, `rtk git status`)
+- Auto-rewrite does not work — the AI assistant is instructed to use RTK but commands are not intercepted
+
+For full hook support on Windows, use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install). Inside WSL, all agents with shell hook integration (Claude Code, Cursor, Gemini) work identically to Linux.
+
 ## Graceful degradation
 
 Hooks never block command execution. If RTK is missing, the hook exits cleanly and the raw command runs unchanged:

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -116,7 +116,7 @@ curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/instal
 rtk init -g    # full hook mode works in WSL
 ```
 
-On native Windows, RTK falls back to CLAUDE.md injection. Your AI assistant gets RTK instructions but won't auto-rewrite commands. You can still use RTK manually: `rtk cargo test`, `rtk git status`, etc.
+On native Windows, RTK falls back to CLAUDE.md injection. Your AI assistant gets RTK instructions but won't auto-rewrite commands. It can still use RTK manually: `rtk cargo test`, `rtk git status`, etc.
 
 ### Node.js tools not found
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -90,7 +90,35 @@ source ~/.zshrc    # or ~/.bashrc
 rtk --version
 ```
 
-## RTK not working on Windows
+## RTK on Windows
+
+### Double-clicking rtk.exe does nothing
+
+**Symptom:** You double-click `rtk.exe`, a terminal flashes and closes instantly.
+
+**Cause:** RTK is a command-line tool. With no arguments, it prints usage and exits. The console window opens and closes before you can read anything.
+
+**Fix:** Open a terminal first, then run RTK from there:
+- Press `Win+R`, type `cmd`, press Enter
+- Or open PowerShell or Windows Terminal
+- Then run: `rtk --version`
+
+### Hook not working (no auto-rewrite)
+
+**Symptom:** `rtk init -g` shows "Falling back to --claude-md mode" on Windows.
+
+**Cause:** The auto-rewrite hook (`rtk-rewrite.sh`) requires a Unix shell. Native Windows doesn't have one.
+
+**Fix:** Use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) for full hook support:
+```bash
+# Inside WSL
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
+rtk init -g    # full hook mode works in WSL
+```
+
+On native Windows, RTK falls back to CLAUDE.md injection. Your AI assistant gets RTK instructions but won't auto-rewrite commands. You can still use RTK manually: `rtk cargo test`, `rtk git status`, etc.
+
+### Node.js tools not found
 
 **Symptom:**
 ```


### PR DESCRIPTION
## Summary
- Add Windows-specific guidance across README, installation, supported-agents, and troubleshooting docs
- Explain that double-clicking `rtk.exe` does nothing (CLI tool, needs a terminal)
- Document WSL (full support) vs native Windows (CLAUDE.md fallback, no auto-rewrite hook)
- Add comparison table WSL vs native Windows features

## Context
Prompted by Discord user report (PedroLyra) — downloaded the Windows zip, double-clicked, terminal flashed and closed. No documentation existed for Windows users.

## Test plan
- [ ] Verify README renders correctly on GitHub (Windows section, anchor link)
- [ ] Verify docs/guide pages render on rtk-ai.app after merge
- [ ] Spot-check that WSL install instructions work

🤖 Generated with [Claude Code](https://claude.com/claude-code)