### PR TITLE
Add glab command support (#1085)

### DIFF
--- a/src/cmds/git/glab_cmd.rs
+++ b/src/cmds/git/glab_cmd.rs
@@ -1,0 +1,14 @@
+//! GitLab CLI (glab) passthrough support.
+//!
+//! This command is intentionally passthrough-only for now. It enables
+//! first-class CLI routing (`rtk glab ...`) and discover rewrite support.
+
+use anyhow::Result;
+use std::ffi::OsString;
+
+/// Run a glab subcommand in passthrough mode.
+pub fn run(subcommand: &str, args: &[String], _verbose: u8) -> Result<i32> {
+    let mut os_args: Vec<OsString> = vec![OsString::from(subcommand)];
+    os_args.extend(args.iter().map(OsString::from));
+    crate::core::runner::run_passthrough("glab", &os_args, 0)
+}

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1555,6 +1555,25 @@ mod tests {
     }
 
     #[test]
+    fn test_classify_glab_mr() {
+        assert!(matches!(
+            classify_command("glab mr list"),
+            Classification::Supported {
+                rtk_equivalent: "rtk glab",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_rewrite_glab_mr() {
+        assert_eq!(
+            rewrite_command("glab mr list", &[]),
+            Some("rtk glab mr list".into())
+        );
+    }
+
+    #[test]
     fn test_rewrite_cargo_install() {
         assert_eq!(
             rewrite_command("cargo install rtk", &[]),

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -35,6 +35,15 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
+        pattern: r"^glab\s+(mr|issue|ci|repo|api|release)",
+        rtk_cmd: "rtk glab",
+        rewrite_prefixes: &["glab"],
+        category: "GitHub",
+        savings_pct: 0.0,
+        subcmd_savings: &[],
+        subcmd_status: &[("mr", RtkStatus::Passthrough)],
+    },
+    RtkRule {
         pattern: r"^cargo\s+(build|test|clippy|check|fmt|install)",
         rtk_cmd: "rtk cargo",
         rewrite_prefixes: &["cargo"],

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ mod parser;
 // Re-export command modules for routing
 use cmds::cloud::{aws_cmd, container, curl_cmd, psql_cmd, wget_cmd};
 use cmds::dotnet::{binlog, dotnet_cmd, dotnet_format_report, dotnet_trx};
-use cmds::git::{diff_cmd, gh_cmd, git, gt_cmd};
+use cmds::git::{diff_cmd, gh_cmd, git, glab_cmd, gt_cmd};
 use cmds::go::{go_cmd, golangci_cmd};
 use cmds::js::{
     lint_cmd, next_cmd, npm_cmd, playwright_cmd, pnpm_cmd, prettier_cmd, prisma_cmd, tsc_cmd,
@@ -154,6 +154,15 @@ enum Commands {
     /// GitHub CLI (gh) commands with token-optimized output
     Gh {
         /// Subcommand: pr, issue, run, repo
+        subcommand: String,
+        /// Additional arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// GitLab CLI (glab) commands passthrough with tracking support
+    Glab {
+        /// Subcommand: mr, issue, ci, repo, etc.
         subcommand: String,
         /// Additional arguments
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
@@ -1422,6 +1431,8 @@ fn run_cli() -> Result<i32> {
             gh_cmd::run(&subcommand, &args, cli.verbose, cli.ultra_compact)?
         }
 
+        Commands::Glab { subcommand, args } => glab_cmd::run(&subcommand, &args, cli.verbose)?,
+
         Commands::Aws { subcommand, args } => aws_cmd::run(&subcommand, &args, cli.verbose)?,
 
         Commands::Psql { args } => psql_cmd::run(&args, cli.verbose)?,
@@ -2169,6 +2180,7 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Smart { .. }
             | Commands::Git { .. }
             | Commands::Gh { .. }
+            | Commands::Glab { .. }
             | Commands::Pnpm { .. }
             | Commands::Err { .. }
             | Commands::Test { .. }
@@ -2343,6 +2355,12 @@ mod tests {
     fn test_try_parse_valid_git_status() {
         let result = Cli::try_parse_from(["rtk", "git", "status"]);
         assert!(result.is_ok(), "git status should parse successfully");
+    }
+
+    #[test]
+    fn test_try_parse_valid_glab_command() {
+        let result = Cli::try_parse_from(["rtk", "glab", "mr", "list"]);
+        assert!(result.is_ok(), "glab mr list should parse successfully");
     }
 
     #[test]


### PR DESCRIPTION
Adds initial glab passthrough support, discover rewrite/classification rules, and tests.

Closes #1085