### PR TITLE
fix(init): allow --hook-only for local project hook installation

### DIFF
--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -297,8 +297,7 @@ pub fn run(
 }
 
 /// Prepare hook directory and return paths (hook_dir, hook_path)
-fn prepare_hook_paths() -> Result<(PathBuf, PathBuf)> {
-    let claude_dir = resolve_claude_dir()?;
+fn prepare_hook_paths(claude_dir: &Path) -> Result<(PathBuf, PathBuf)> {
     let hook_dir = claude_dir.join("hooks");
     fs::create_dir_all(&hook_dir)
         .with_context(|| format!("Failed to create hook directory: {}", hook_dir.display()))?;
@@ -437,8 +436,8 @@ fn prompt_user_consent(settings_path: &Path) -> Result<bool> {
 }
 
 /// Print manual instructions for settings.json patching
-fn print_manual_instructions(hook_path: &Path, include_opencode: bool) {
-    println!("\n  MANUAL STEP: Add this to ~/.claude/settings.json:");
+fn print_manual_instructions(hook_path: &Path, settings_path: &Path, include_opencode: bool) {
+    println!("\n  MANUAL STEP: Add this to {}:", settings_path.display());
     println!("  {{");
     println!("    \"hooks\": {{ \"PreToolUse\": [{{");
     println!("      \"matcher\": \"Bash\",");
@@ -696,11 +695,11 @@ fn uninstall_codex_at(codex_dir: &Path, verbose: u8) -> Result<Vec<String>> {
 /// Handles reading, checking, prompting, merging, backing up, and atomic writing
 fn patch_settings_json(
     hook_path: &Path,
+    claude_dir: &Path,
     mode: PatchMode,
     verbose: u8,
     include_opencode: bool,
 ) -> Result<PatchResult> {
-    let claude_dir = resolve_claude_dir()?;
     let settings_path = claude_dir.join(SETTINGS_JSON);
     let hook_command = hook_path
         .to_str()
@@ -732,12 +731,12 @@ fn patch_settings_json(
     // Handle mode
     match mode {
         PatchMode::Skip => {
-            print_manual_instructions(hook_path, include_opencode);
+            print_manual_instructions(hook_path, &settings_path, include_opencode);
             return Ok(PatchResult::Skipped);
         }
         PatchMode::Ask => {
             if !prompt_user_consent(&settings_path)? {
-                print_manual_instructions(hook_path, include_opencode);
+                print_manual_instructions(hook_path, &settings_path, include_opencode);
                 return Ok(PatchResult::Declined);
             }
         }
@@ -902,7 +901,7 @@ fn run_default_mode(
     let claude_md_path = claude_dir.join(CLAUDE_MD);
 
     // 1. Prepare hook directory and install hook
-    let (_hook_dir, hook_path) = prepare_hook_paths()?;
+    let (_hook_dir, hook_path) = prepare_hook_paths(&claude_dir)?;
     let hook_changed = ensure_hook_installed(&hook_path, verbose)?;
 
     // 2. Write RTK.md
@@ -939,7 +938,13 @@ fn run_default_mode(
     }
 
     // 5. Patch settings.json
-    let patch_result = patch_settings_json(&hook_path, patch_mode, verbose, install_opencode)?;
+    let patch_result = patch_settings_json(
+        &hook_path,
+        &claude_dir,
+        patch_mode,
+        verbose,
+        install_opencode,
+    )?;
 
     // Report result
     match patch_result {
@@ -1034,14 +1039,16 @@ fn run_hook_only_mode(
     verbose: u8,
     install_opencode: bool,
 ) -> Result<()> {
-    if !global {
-        eprintln!("[warn] Warning: --hook-only only makes sense with --global");
-        eprintln!("    For local projects, use default mode or --claude-md");
-        return Ok(());
-    }
+    let claude_dir = if global {
+        resolve_claude_dir()?
+    } else {
+        std::env::current_dir()?.join(".claude")
+    };
+
+    let scope = if global { "global" } else { "project-scoped" };
 
     // Prepare and install hook
-    let (_hook_dir, hook_path) = prepare_hook_paths()?;
+    let (_hook_dir, hook_path) = prepare_hook_paths(&claude_dir)?;
     let hook_changed = ensure_hook_installed(&hook_path, verbose)?;
 
     let opencode_plugin_path = if install_opencode {
@@ -1057,7 +1064,7 @@ fn run_hook_only_mode(
     } else {
         "already up to date"
     };
-    println!("\nRTK hook {} (hook-only mode).\n", hook_status);
+    println!("\nRTK hook {} (hook-only mode, {}).\n", hook_status, scope);
     println!("  Hook: {}", hook_path.display());
     if let Some(path) = &opencode_plugin_path {
         println!("  OpenCode: {}", path.display());
@@ -1067,7 +1074,13 @@ fn run_hook_only_mode(
     );
 
     // Patch settings.json
-    let patch_result = patch_settings_json(&hook_path, patch_mode, verbose, install_opencode)?;
+    let patch_result = patch_settings_json(
+        &hook_path,
+        &claude_dir,
+        patch_mode,
+        verbose,
+        install_opencode,
+    )?;
 
     // Report result
     match patch_result {


### PR DESCRIPTION
## Summary

- `rtk init --hook-only` now works for local (project-scoped) installations, installing the hook to `.claude/hooks/rtk-rewrite.sh` and patching `.claude/settings.json` with the PreToolUse hook entry
- Refactored `prepare_hook_paths`, `patch_settings_json`, and `print_manual_instructions` to accept a `claude_dir` parameter, enabling both global (`~/.claude/`) and local (`.claude/`) hook installation paths
- Previously, `--hook-only` without `--global` printed a warning and exited without doing anything

## Test plan

- [x] `cargo test --all` — 1350 tests pass
- [x] `cargo clippy --all-targets` — no new warnings
- [ ] Manual: run `rtk init --hook-only` in a project directory, verify `.claude/hooks/rtk-rewrite.sh` and `.claude/settings.json` are created correctly
- [ ] Manual: run `rtk init --hook-only` again, verify idempotency (no duplicate hooks)

Closes #1069

🤖 Generated with [Claude Code](https://claude.com/claude-code)