### PR TITLE
feat(dotnet): add discover rules for test, restore, and format

### DIFF
--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -396,12 +396,12 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        pattern: r"^dotnet\s+build\b",
+        pattern: r"^dotnet\s+(build|test|restore|format)\b",
         rtk_cmd: "rtk dotnet",
         rewrite_prefixes: &["dotnet"],
         category: "Build",
         savings_pct: 70.0,
-        subcmd_savings: &[],
+        subcmd_savings: &[("test", 90.0), ("build", 70.0), ("restore", 60.0), ("format", 75.0)],
         subcmd_status: &[],
     },
     RtkRule {


### PR DESCRIPTION
## Summary

- The dotnet discover rule only matched `dotnet build`, so `rtk discover` and savings reports did not account for `dotnet test`, `dotnet restore`, or `dotnet format` — even though filters for all four subcommands already exist in `src/cmds/dotnet/`
- Expand pattern to match `dotnet (build|test|restore|format)`
- Add per-subcommand savings estimates: test 90%, build 70%, format 75%, restore 60%

## Test plan

- [x] `cargo build --release` — compiles without errors
- [x] `cargo test --release` — 1352 passed, 0 failed
- [x] `rtk rewrite "dotnet test"` returns `rtk dotnet test`
- [x] `rtk rewrite "dotnet build"` still works as before