### PR TITLE
fix: augment PATH in hook to fix silent failure on Homebrew installs (#685)

### DIFF
--- a/hooks/claude/rtk-rewrite.sh
+++ b/hooks/claude/rtk-rewrite.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-# rtk-hook-version: 3
+# rtk-hook-version: 4
+# Augment PATH so rtk is found in Claude Code's restricted hook environment.
+# Common locations: Homebrew (Apple Silicon /opt/homebrew/bin, Intel /usr/local/bin)
+# and cargo installs ($HOME/.cargo/bin). Safe to add even if already in PATH.
+export PATH="$HOME/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
 # RTK Claude Code hook — rewrites commands to use rtk for token savings.
 # Requires: rtk >= 0.23.0, jq
 #

--- a/src/hooks/hook_check.rs
+++ b/src/hooks/hook_check.rs
@@ -9,7 +9,7 @@ use super::constants::{CODEX_DIR, CURSOR_DIR, GEMINI_DIR, GEMINI_HOOK_FILE, OPEN
 use crate::core::constants::RTK_DATA_DIR;
 use std::path::PathBuf;
 
-const CURRENT_HOOK_VERSION: u8 = 3;
+const CURRENT_HOOK_VERSION: u8 = 4;
 const WARN_INTERVAL_SECS: u64 = 24 * 3600;
 
 /// Hook status for diagnostics and `rtk gain`.

--- a/src/hooks/hook_check.rs
+++ b/src/hooks/hook_check.rs
@@ -7,7 +7,7 @@ use super::constants::{
 use crate::core::constants::RTK_DATA_DIR;
 use std::path::PathBuf;
 
-const CURRENT_HOOK_VERSION: u8 = 3;
+const CURRENT_HOOK_VERSION: u8 = 4;
 const WARN_INTERVAL_SECS: u64 = 24 * 3600;
 
 /// Hook status for diagnostics and `rtk gain`.

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -2729,6 +2729,32 @@ mod tests {
     }
 
     #[test]
+    fn test_hook_augments_path_before_rtk_check() {
+        // PATH augmentation must exist so that rtk is found in Claude Code's restricted
+        // hook environment (e.g. Homebrew installs at /opt/homebrew/bin are absent otherwise).
+        assert!(
+            REWRITE_HOOK.contains("export PATH="),
+            "Hook must export an augmented PATH"
+        );
+        // The PATH export must appear before the `command -v rtk` guard.
+        let path_export_pos = REWRITE_HOOK.find("export PATH=").unwrap();
+        let rtk_check_pos = REWRITE_HOOK.find("command -v rtk").unwrap();
+        assert!(
+            path_export_pos < rtk_check_pos,
+            "PATH augmentation must precede the `command -v rtk` guard"
+        );
+        // Verify key directories are covered.
+        assert!(
+            REWRITE_HOOK.contains(".cargo/bin"),
+            "cargo install path missing"
+        );
+        assert!(
+            REWRITE_HOOK.contains("/opt/homebrew/bin"),
+            "Homebrew (Apple Silicon) path missing"
+        );
+    }
+
+    #[test]
     fn test_migration_removes_old_block() {
         let input = r#"# My Config
 

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -3983,6 +3983,32 @@ mod tests {
     }
 
     #[test]
+    fn test_hook_augments_path_before_rtk_check() {
+        // PATH augmentation must exist so that rtk is found in Claude Code's restricted
+        // hook environment (e.g. Homebrew installs at /opt/homebrew/bin are absent otherwise).
+        assert!(
+            REWRITE_HOOK.contains("export PATH="),
+            "Hook must export an augmented PATH"
+        );
+        // The PATH export must appear before the `command -v rtk` guard.
+        let path_export_pos = REWRITE_HOOK.find("export PATH=").unwrap();
+        let rtk_check_pos = REWRITE_HOOK.find("command -v rtk").unwrap();
+        assert!(
+            path_export_pos < rtk_check_pos,
+            "PATH augmentation must precede the `command -v rtk` guard"
+        );
+        // Verify key directories are covered.
+        assert!(
+            REWRITE_HOOK.contains(".cargo/bin"),
+            "cargo install path missing"
+        );
+        assert!(
+            REWRITE_HOOK.contains("/opt/homebrew/bin"),
+            "Homebrew (Apple Silicon) path missing"
+        );
+    }
+
+    #[test]
     fn test_migration_removes_old_block() {
         let input = format!(
             "# My Config\n\n{} v2 -->\nOLD RTK STUFF\n{}\n\nMore content",

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -3986,24 +3986,27 @@ mod tests {
     fn test_hook_augments_path_before_rtk_check() {
         // PATH augmentation must exist so that rtk is found in Claude Code's restricted
         // hook environment (e.g. Homebrew installs at /opt/homebrew/bin are absent otherwise).
+        // The inline `REWRITE_HOOK` constant was removed on develop in favor of an
+        // external script — assert the same invariants directly against that file.
+        const REWRITE_HOOK_SCRIPT: &str = include_str!("../../hooks/claude/rtk-rewrite.sh");
         assert!(
-            REWRITE_HOOK.contains("export PATH="),
+            REWRITE_HOOK_SCRIPT.contains("export PATH="),
             "Hook must export an augmented PATH"
         );
         // The PATH export must appear before the `command -v rtk` guard.
-        let path_export_pos = REWRITE_HOOK.find("export PATH=").unwrap();
-        let rtk_check_pos = REWRITE_HOOK.find("command -v rtk").unwrap();
+        let path_export_pos = REWRITE_HOOK_SCRIPT.find("export PATH=").unwrap();
+        let rtk_check_pos = REWRITE_HOOK_SCRIPT.find("command -v rtk").unwrap();
         assert!(
             path_export_pos < rtk_check_pos,
             "PATH augmentation must precede the `command -v rtk` guard"
         );
         // Verify key directories are covered.
         assert!(
-            REWRITE_HOOK.contains(".cargo/bin"),
+            REWRITE_HOOK_SCRIPT.contains(".cargo/bin"),
             "cargo install path missing"
         );
         assert!(
-            REWRITE_HOOK.contains("/opt/homebrew/bin"),
+            REWRITE_HOOK_SCRIPT.contains("/opt/homebrew/bin"),
             "Homebrew (Apple Silicon) path missing"
         );
     }


### PR DESCRIPTION
## Summary

Fixes #685

- Claude Code hooks run with a restricted `PATH` that excludes Homebrew (`/opt/homebrew/bin` on Apple Silicon, `/usr/local/bin` on Intel) and cargo (`~/.cargo/bin`) directories
- `command -v rtk` silently returns non-zero, causing the hook to print a warning and exit — no commands are rewritten, token savings are lost silently
- Fix adds `export PATH="$HOME/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"` at the top of the hook, before the `command -v rtk` guard
- Hook version bumped from 3 → 4; existing installations will be upgraded on the next `rtk init -g`

## Verification

- [x] Baseline tests: 1351 pass, 6 ignored, 0 pre-existing failures
- [x] Post-fix tests: no regressions
- [x] New test: `test_hook_augments_path_before_rtk_check` — asserts PATH export exists and precedes the rtk guard, and that `/opt/homebrew/bin` and `.cargo/bin` are covered
- [x] Review agent: issue alignment verified

## Files changed

| File | Change |
|------|--------|
| `hooks/claude/rtk-rewrite.sh` | Bump version 3→4, add PATH augmentation (6 lines) |
| `src/hooks/hook_check.rs` | Update `CURRENT_HOOK_VERSION` constant to 4 |
| `src/hooks/init.rs` | Add `test_hook_augments_path_before_rtk_check` test |

Generated by Claude Code
Vibe coded by ousamabenyounes

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
