### PR TITLE
fix(find): include dotfiles to match native find behavior

### DIFF
--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -212,7 +212,7 @@ pub fn run(
 
     let mut builder = WalkBuilder::new(path);
     builder
-        .hidden(true) // skip hidden files/dirs
+        .hidden(false) // include dotfiles (match native find behavior)
         .git_ignore(true) // respect .gitignore
         .git_global(true)
         .git_exclude(true);
@@ -423,6 +423,15 @@ mod tests {
         assert!(glob_match("test_*", "test_foo"));
         assert!(glob_match("test_*", "test_"));
         assert!(!glob_match("test_*", "test"));
+    }
+
+    // --- dotfile glob matching (issue #1101) ---
+
+    #[test]
+    fn glob_match_dotfile() {
+        assert!(glob_match(".claude.json", ".claude.json"));
+        assert!(glob_match(".*", ".claude.json"));
+        assert!(glob_match("*.json", ".claude.json"));
     }
 
     // --- dot pattern treated as star ---


### PR DESCRIPTION
## Summary
- Change `WalkBuilder.hidden(true)` to `hidden(false)` so dotfiles like `.claude.json` are found
- Root cause: `ignore` crate's `hidden(true)` skips all dotfiles, diverging from native `find` behavior

Closes #1101

## Test plan
- [x] `cargo test find_cmd` — all 28 tests pass
- [x] Added `glob_match_dotfile` test for dotfile pattern matching