### PR TITLE
fix(gh): don't early exit on failure for "pr checks" 

### DIFF
--- a/src/cmds/git/gh_cmd.rs
+++ b/src/cmds/git/gh_cmd.rs
@@ -418,9 +418,7 @@ fn pr_checks(args: &[String], _verbose: u8, _ultra_compact: bool) -> Result<i32>
         "gh",
         &format!("pr checks {}", pr_number),
         format_pr_checks,
-        RunOptions::stdout_only()
-            .early_exit_on_failure()
-            .no_trailing_newline(),
+        RunOptions::stdout_only().no_trailing_newline(),
     )
 }
 


### PR DESCRIPTION
## Summary

if there are failing checks in the PR, then `gh` will return a status of `1` and `rtk` will refuse to parse the output due to using `early_exit_on_failure`.

remove the use of `early_exit_on_failure` so it can still parse the output.

now if there is an error, we will still get the summarised output with all `0`s, and we'll also pass through the stderr.

example if a repository does not exist:

```
CI Checks Summary:
  [ok] Passed: 0
  [FAIL] Failed: 0
GraphQL: Could not resolve to a Repository with the name 'some-org/some-repo'. (repository)
```

with the error passed through to the output regardless, the error handling downstream by the LLM should still work well.

## Test plan
<!-- How did you verify this works? -->

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
