### PR TITLE
fix(init): enable hook installation on Windows

### DIFF
--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -306,8 +306,14 @@ fn prepare_hook_paths() -> Result<(PathBuf, PathBuf)> {
     Ok((hook_dir, hook_path))
 }
 
-/// Write hook file if missing or outdated, return true if changed
-#[cfg(unix)]
+/// Write hook file if missing or outdated, return true if changed.
+///
+/// Cross-platform: matches the Cursor (`install_cursor_hooks`) and Gemini
+/// (`install_gemini_hook`) hook installers in this file, which already use
+/// a unified body with an inline `#[cfg(unix)]` guard around the chmod call.
+/// On Windows the hook is invoked via `bash /path/to/rtk-rewrite.sh` from
+/// Claude Code's PreToolUse hook entry, so no execute bit is required —
+/// git-bash runs the script directly.
 fn ensure_hook_installed(hook_path: &Path, verbose: u8) -> Result<bool> {
     let changed = if hook_path.exists() {
         let existing = fs::read_to_string(hook_path)
@@ -335,10 +341,13 @@ fn ensure_hook_installed(hook_path: &Path, verbose: u8) -> Result<bool> {
         true
     };
 
-    // Set executable permissions
-    use std::os::unix::fs::PermissionsExt;
-    fs::set_permissions(hook_path, fs::Permissions::from_mode(0o755))
-        .with_context(|| format!("Failed to set hook permissions: {}", hook_path.display()))?;
+    // Set executable permissions (Unix only; Windows invokes via `bash script.sh`)
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(hook_path, fs::Permissions::from_mode(0o755))
+            .with_context(|| format!("Failed to set hook permissions: {}", hook_path.display()))?;
+    }
 
     // Store SHA-256 hash for runtime integrity verification.
     // Always store (idempotent) to ensure baseline exists even for
@@ -869,21 +878,13 @@ fn hook_already_present(root: &serde_json::Value, hook_command: &str) -> bool {
         })
 }
 
-/// Default mode: hook + slim RTK.md + @RTK.md reference
-#[cfg(not(unix))]
-fn run_default_mode(
-    _global: bool,
-    _patch_mode: PatchMode,
-    _verbose: u8,
-    _install_opencode: bool,
-) -> Result<()> {
-    eprintln!("[warn] Hook-based mode requires Unix (macOS/Linux).");
-    eprintln!("    Windows: use --claude-md mode for full injection.");
-    eprintln!("    Falling back to --claude-md mode.");
-    run_claude_md_mode(_global, _verbose, _install_opencode)
-}
-
-#[cfg(unix)]
+/// Default mode: hook + slim RTK.md + @RTK.md reference.
+///
+/// Previously Unix-only (Windows fell back to `--claude-md` mode with a warning),
+/// but the hook installer now compiles on all platforms — the only OS-specific
+/// call (chmod) is guarded inline inside `ensure_hook_installed`. Claude Code's
+/// PreToolUse hook executes `bash /path/to/rtk-rewrite.sh`, which works under
+/// git-bash on Windows without the execute bit.
 fn run_default_mode(
     global: bool,
     patch_mode: PatchMode,
@@ -1016,18 +1017,9 @@ fn generate_global_filters_template(verbose: u8) -> Result<()> {
     Ok(())
 }
 
-/// Hook-only mode: just the hook, no RTK.md
-#[cfg(not(unix))]
-fn run_hook_only_mode(
-    _global: bool,
-    _patch_mode: PatchMode,
-    _verbose: u8,
-    _install_opencode: bool,
-) -> Result<()> {
-    anyhow::bail!("Hook install requires Unix (macOS/Linux). Use WSL or --claude-md mode.")
-}
-
-#[cfg(unix)]
+/// Hook-only mode: just the hook, no RTK.md.
+///
+/// Cross-platform for the same reason as `run_default_mode` — see its doc comment.
 fn run_hook_only_mode(
     global: bool,
     patch_mode: PatchMode,


### PR DESCRIPTION
## Summary

Enable `rtk init -g` hook installation on Windows by removing the `#[cfg(not(unix))]` blockers in `src/hooks/init.rs`, applying the same inline `chmod` guard pattern already used by the Cursor and Gemini installers in this file.

**Net diff: +25 / −33 lines, one file touched.**

## Problem

On Windows, `rtk init -g` currently bails with:

```
[warn] Hook-based mode requires Unix (macOS/Linux).
    Windows: use --claude-md mode for full injection.
    Falling back to --claude-md mode.
```

Related user reports: #682 (persistent "No hook installed" warning, stuck on Windows), #913.

The block is compile-time: `run_default_mode`, `run_hook_only_mode`, and `ensure_hook_installed` are each gated with `#[cfg(unix)]`, and the `#[cfg(not(unix))]` variants either warn-and-fallback or `bail!()`.

## Root cause

Only **one line** actually needs Unix:

```rust
use std::os::unix::fs::PermissionsExt;
fs::set_permissions(hook_path, fs::Permissions::from_mode(0o755))?;
```

`PermissionsExt` is `std::os::unix::fs::PermissionsExt`. Everything else compiles and runs fine on Windows.

The hook script itself (`rtk-rewrite.sh`) is pure `bash + jq`, which Claude Code already executes via git-bash on Windows — no execute bit is required to invoke a script as `bash /path/to/script.sh`.

## Fix

Mirror the pattern already used by `install_cursor_hooks` (line 1622) and the Gemini hook installer (line 2152) in this same file: one unified function body, with only the `chmod` call wrapped in an inline `#[cfg(unix)]` block.

```diff
-#[cfg(unix)]
 fn ensure_hook_installed(hook_path: &Path, verbose: u8) -> Result<bool> {
     // ... write file ...

-    // Set executable permissions
-    use std::os::unix::fs::PermissionsExt;
-    fs::set_permissions(hook_path, fs::Permissions::from_mode(0o755))
-        .with_context(|| format!("Failed to set hook permissions: {}", hook_path.display()))?;
+    // Set executable permissions (Unix only; Windows invokes via `bash script.sh`)
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(hook_path, fs::Permissions::from_mode(0o755))
+            .with_context(|| format!("Failed to set hook permissions: {}", hook_path.display()))?;
+    }
```

The `#[cfg(not(unix))]` warn/bail fallback variants of `run_default_mode` and `run_hook_only_mode` are deleted, and the `#[cfg(unix)]` attribute is removed from the remaining unified bodies. Doc comments are extended to explain the cross-platform rationale for future maintainers.

## Verification

Verified manually on Windows 11 + Claude Code CLI + git-bash by hand-installing the equivalent hook setup (hook script at `~/.claude/hooks/rtk-rewrite.sh` + `PreToolUse` entry in `~/.claude/settings.json`) before writing this PR:

| Check | Result |
|-------|--------|
| `rtk init --show` | `[ok] Hook: ... (exists)` + `[ok] settings.json: RTK hook configured` |
| `git status` (no `rtk` prefix) | Rewritten to `rtk git status`; compressed output (`* master...origin/master`, `~ Modified:`, `? Untracked:`) |
| `ls -la` (no `rtk` prefix) | Rewritten to `rtk ls`, `-la` columns stripped as expected |
| `git log --oneline -3` | Rewritten, compressed output |
| Chain: `pwd && git branch` | Each `&&`-segment rewritten individually |
| `echo "test"` | Pass-through (no rewrite for rtk-unrelated commands) |
| Idempotency: `rtk git status` as input | No-op rewrite, correct output |
| `rtk gain` counter | **1137 → 1234 (+97 commands auto-rewritten via hook)** |
| `[rtk] /!\ No hook installed` warning | Gone from `rtk gain`, `rtk ls`, `rtk init --show` |
| Subagent session (Claude Code `Agent` tool) | **Inherits the hook**, commands transparently rewritten in the child session |
| Existing unrelated `PostToolUse` hook | Intact after settings.json merge |
| Claude Code settings watcher | Reloads immediately after settings.json edit — no session restart required |

Independently verified on multiple Windows 11 machines (team members, rtk v0.35.0 + Claude Code CLI, hand-installed the same hook setup). All reported successful installation, hook fire, and no `No hook installed` warning.

## Scope

- **Touched:** `src/hooks/init.rs` (one file)
- **Not touched:**
  - Tests module (line 2410+) — its `#[cfg(unix)]` blocks are test-only and out of scope
  - Cursor / Gemini installers — already cross-platform, serve as the pattern reference
  - `rtk init --show` Claude hook status display code (line 1839+) — currently uses `#[cfg(unix)]` for `executable` / `is_thin_delegator` checks. Left for a follow-up PR to keep this change minimal; the existing behavior already produces a usable `[ok] Hook: exists` on Windows.

## Related

- Closes #682
- Closes #913

## Draft status

Marked draft pending CI confirmation (Windows/Linux/macOS build matrix). Will flip to ready-for-review once CI is green.