### PR TITLE
fix(ls): show successful entries even when some paths don't exist

### DIFF
--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -96,9 +96,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
             }
             filtered
         },
-        RunOptions::stdout_only()
-            .early_exit_on_failure()
-            .no_trailing_newline(),
+        RunOptions::stdout_only().no_trailing_newline(),
     )
 }
 
@@ -312,6 +310,22 @@ mod tests {
         assert_eq!(human_size(1234), "1.2K");
         assert_eq!(human_size(1_048_576), "1.0M");
         assert_eq!(human_size(2_500_000), "2.4M");
+    }
+
+    #[test]
+    fn test_compact_partial_failure_shows_successful_entries() {
+        // When ls is given multiple paths and some don't exist, ls exits non-zero
+        // but still emits valid entries for the paths that DO exist on stdout.
+        // The filter must show those entries (not suppress them due to non-zero exit).
+        // Error messages go to stderr and are forwarded separately by the runner.
+        let input = "total 8\n\
+                     drwxrwxr-x  2 user  staff  4096 Mar 29 14:19 /home/user/.config/opencode\n\
+                     -rw-rw-r--  1 user  staff   844 Mar 28 23:16 settings.json\n";
+        let (entries, _summary) = compact_ls(input, false);
+        assert!(
+            entries.contains("settings.json"),
+            "successful entries must appear even when some paths failed"
+        );
     }
 
     #[test]

--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -385,7 +385,7 @@ mod tests {
         let input = "total 8\n\
                      drwxrwxr-x  2 user  staff  4096 Mar 29 14:19 /home/user/.config/opencode\n\
                      -rw-rw-r--  1 user  staff   844 Mar 28 23:16 settings.json\n";
-        let (entries, _summary) = compact_ls(input, false);
+        let (entries, _summary, _) = compact_ls(input, false);
         assert!(
             entries.contains("settings.json"),
             "successful entries must appear even when some paths failed"

--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -107,9 +107,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
             }
             filtered
         },
-        RunOptions::stdout_only()
-            .early_exit_on_failure()
-            .no_trailing_newline(),
+        RunOptions::stdout_only().no_trailing_newline(),
     )
 }
 
@@ -376,6 +374,22 @@ mod tests {
         assert_eq!(human_size(1234), "1.2K");
         assert_eq!(human_size(1_048_576), "1.0M");
         assert_eq!(human_size(2_500_000), "2.4M");
+    }
+
+    #[test]
+    fn test_compact_partial_failure_shows_successful_entries() {
+        // When ls is given multiple paths and some don't exist, ls exits non-zero
+        // but still emits valid entries for the paths that DO exist on stdout.
+        // The filter must show those entries (not suppress them due to non-zero exit).
+        // Error messages go to stderr and are forwarded separately by the runner.
+        let input = "total 8\n\
+                     drwxrwxr-x  2 user  staff  4096 Mar 29 14:19 /home/user/.config/opencode\n\
+                     -rw-rw-r--  1 user  staff   844 Mar 28 23:16 settings.json\n";
+        let (entries, _summary) = compact_ls(input, false);
+        assert!(
+            entries.contains("settings.json"),
+            "successful entries must appear even when some paths failed"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Root cause**: `RunOptions::early_exit_on_failure()` in `ls.rs` caused the runner to skip stdout entirely whenever `ls` exited non-zero — which happens any time _any_ argument path doesn't exist
- **Impact**: `rtk ls dir1 missing_path dir2` showed only errors and discarded the `dir1`/`dir2` listings that `ls` had successfully emitted on stdout
- **Fix**: Remove `early_exit_on_failure()` so the stdout filter always runs. Stderr error messages (`ls: cannot access '...'`) continue to be forwarded as before via the `filter_stdout_only` path

## Before / After

**Before:**
```
$ rtk ls -la ~/.config/opencode/plugins ~/.opencode/plugins ~/.config/opencode
/usr/bin/ls: cannot access '~/.opencode/plugins': No such file or directory
# (listings for the 2 existing paths are lost)
```

**After:**
```
$ rtk ls -la ~/.config/opencode/plugins ~/.opencode/plugins ~/.config/opencode
/usr/bin/ls: cannot access '~/.opencode/plugins': No such file or directory
# + compact listings for ~/.config/opencode/plugins and ~/.config/opencode
```

## Test plan
- [x] `test_compact_partial_failure_shows_successful_entries` — verifies filter processes entries from mixed stdout
- [x] All existing `test_compact_*` tests pass
- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test --all` ✅

Fixes #918

🤖 Generated with [Ora Studio](https://studio.oratelecom.net)

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
