### PR TITLE
feat(cicd): enforce cicd sast & package check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "ci"

--- a/.github/workflows/CICD.md
+++ b/.github/workflows/CICD.md
@@ -14,27 +14,29 @@ Trigger: pull_request to develop or master
                           └────────┬─────────┘
                                    │
                           ┌────────▼─────────┐
-                          │     clippy        │
-                          └──┬───┬───┬───┬───┘
-                             │   │   │   │
-              ┌──────────────┘   │   │   └──────────────┐
-              │          ┌───────┘   └───────┐          │
-              ▼          ▼                   ▼          ▼
-     ┌──────────────┐ ┌──────────────┐ ┌───────────┐ ┌──────────┐
-     │ test         │ │Security Scan │ │ benchmark │ │ validate │
-     │ ubuntu       │ │ cargo audit  │ │ >=80%     │ │ ai agent │
-     │ windows      │ │ (advisory)   │ │ savings   │ │ doc      │
-     │ macos        │ │              │ │           │ │          │
-     └──────┬───────┘ └──────┬───────┘ └─────┬─────┘ └────┬─────┘
-            │                │               │             │
-            └────────────────┴───────┬───────┴─────────────┘
-                                     │
-                          ┌──────────▼─────────┐
-                          │  All must pass     │
-                          │  to merge          │
-                          └────────────────────┘
+                          │ clippy            │
+                          │ -D unsafe_code    │
+                          └┬───┬───┬───┬───┬─┘
+                           │   │   │   │   │
+           ┌───────────────┘   │   │   │   └───────────────┐
+           │       ┌───────────┘   │   └──────────┐        │
+           ▼       ▼               ▼              ▼        ▼
+     ┌──────────┐ ┌──────────┐ ┌───────────┐ ┌─────────┐ ┌──────────┐
+     │ test     │ │ security │ │ semgrep   │ │benchmark│ │ doc      │
+     │ ubuntu   │ │ cargo    │ │ AST-aware │ │ >=80%   │ │ review   │
+     │ windows  │ │ audit    │ │ diff-only │ │ savings │ │ ai agent │
+     │ macos    │ │ patterns │ │           │ │         │ │          │
+     └────┬─────┘ └────┬─────┘ └─────┬─────┘ └────┬────┘ └────┬─────┘
+          │            │             │             │            │
+          └────────────┴─────────┬───┴─────────────┴────────────┘
+                                 │
+                      ┌──────────▼─────────┐
+                      │  All must pass     │
+                      │  to merge          │
+                      └────────────────────┘
 
      + DCO check (independent, develop PRs only)
+     + Dependabot (weekly: Cargo deps + GitHub Actions)
 ```
 
 ## Merge to develop — pre-release (cd.yml)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,15 +189,13 @@ jobs:
     name: semgrep security scan
     needs: clippy
     runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: returntocorp/semgrep-action@v1
-        with:
-          config: .semgrep.yml
-        env:
-          SEMGREP_BASELINE_REF: ${{ github.event.pull_request.base.sha }}
+      - run: semgrep scan --config .semgrep.yml --baseline-commit ${{ github.event.pull_request.base.sha }} --error
 
   benchmark:
     name: benchmark

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --all-targets
+      - run: cargo clippy --all-targets -- -D unsafe_code
 
   # ─── Parallel gates (all need code to compile) ───
 
@@ -184,6 +184,20 @@ jobs:
           echo "**For high-risk PRs (critical files modified):**" >> $GITHUB_STEP_SUMMARY
           echo "- Require approval from 2 maintainers" >> $GITHUB_STEP_SUMMARY
           echo "- Test in isolated environment before merge" >> $GITHUB_STEP_SUMMARY
+
+  semgrep:
+    name: semgrep security scan
+    needs: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: returntocorp/semgrep-action@v1
+        with:
+          config: .semgrep.yml
+        env:
+          SEMGREP_BASELINE_REF: ${{ github.event.pull_request.base.sha }}
 
   benchmark:
     name: benchmark

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -1,0 +1,108 @@
+rules:
+  - id: dynamic-command-execution
+    patterns:
+      - pattern: Command::new($ARG)
+      - pattern-not: Command::new("...")
+    message: >
+      Dynamic shell invocation via Command::new($ARG).
+      RTK only executes known CLI tools — use string literals, not variables.
+    languages: [rust]
+    severity: ERROR
+
+  - id: unsafe-block
+    pattern: unsafe { ... }
+    message: >
+      Unsafe block detected. RTK has no legitimate need for unsafe code.
+    languages: [rust]
+    severity: ERROR
+
+  - id: ld-preload-manipulation
+    pattern-either:
+      - pattern: $CMD.env("LD_PRELOAD", ...)
+      - pattern: $CMD.env("LD_LIBRARY_PATH", ...)
+    message: >
+      LD_PRELOAD/LD_LIBRARY_PATH manipulation detected.
+      This can hijack shared library loading — forbidden in RTK.
+    languages: [rust]
+    severity: ERROR
+
+  - id: raw-socket-usage
+    pattern-either:
+      - pattern: TcpStream::$METHOD(...)
+      - pattern: UdpSocket::$METHOD(...)
+      - pattern: TcpListener::$METHOD(...)
+    message: >
+      Raw socket usage detected. RTK is a CLI proxy — it should not
+      open network connections directly. Use ureq in telemetry only.
+    languages: [rust]
+    severity: ERROR
+
+  - id: reqwest-forbidden
+    pattern: reqwest::$METHOD(...)
+    message: >
+      reqwest is forbidden in RTK. The project uses ureq for HTTP
+      (telemetry only). Adding reqwest increases binary size and attack surface.
+    languages: [rust]
+    severity: ERROR
+
+  - id: interpreter-execution
+    pattern-either:
+      - pattern: Command::new("curl")
+      - pattern: Command::new("wget")
+      - pattern: Command::new("python")
+      - pattern: Command::new("python3")
+      - pattern: Command::new("node")
+      - pattern: Command::new("bash")
+      - pattern: Command::new("sh")
+      - pattern: Command::new("perl")
+      - pattern: Command::new("ruby")
+    message: >
+      Direct interpreter/downloader execution detected.
+      RTK proxies user commands — it should never spawn interpreters
+      or download tools on its own.
+    languages: [rust]
+    severity: ERROR
+
+  - id: ureq-outside-telemetry
+    pattern: ureq::$METHOD(...)
+    paths:
+      exclude:
+        - /src/core/telemetry.rs
+    message: >
+      ureq usage outside of src/core/telemetry.rs.
+      HTTP calls are restricted to the telemetry module to prevent data exfiltration.
+    languages: [rust]
+    severity: ERROR
+
+  # ── WARNING rules (non-blocking, flag for review) ──
+
+  - id: path-env-manipulation
+    pattern-either:
+      - pattern: $CMD.env("PATH", ...)
+      - pattern: std::env::set_var("PATH", ...)
+      - pattern: env::set_var("PATH", ...)
+    message: >
+      PATH environment variable manipulation detected.
+      Hijacking PATH can redirect command resolution to attacker-controlled binaries.
+    languages: [rust]
+    severity: WARNING
+
+  - id: sensitive-path-reference
+    pattern-regex: \.(ssh|bashrc|zshrc|bash_profile|profile)|authorized_keys|/etc/passwd|/etc/shadow
+    message: >
+      Reference to sensitive system path detected.
+      RTK filters should not access dotfiles, SSH keys, or system credential files.
+    languages: [rust]
+    severity: WARNING
+
+  - id: filesystem-deletion
+    pattern-either:
+      - pattern: fs::remove_file(...)
+      - pattern: fs::remove_dir_all(...)
+      - pattern: std::fs::remove_file(...)
+      - pattern: std::fs::remove_dir_all(...)
+    message: >
+      File/directory deletion detected. Expected in hooks/init cleanup,
+      surprising in a filter module. Verify intent.
+    languages: [rust]
+    severity: WARNING

--- a/src/main.rs
+++ b/src/main.rs
@@ -2010,6 +2010,7 @@ fn run_cli() -> Result<i32> {
             static PROXY_CHILD_PID: AtomicU32 = AtomicU32::new(0);
 
             #[cfg(unix)]
+            #[allow(unsafe_code)]
             {
                 unsafe extern "C" fn handle_signal(sig: libc::c_int) {
                     let pid = PROXY_CHILD_PID.load(Ordering::SeqCst);
@@ -2017,7 +2018,6 @@ fn run_cli() -> Result<i32> {
                         libc::kill(pid as libc::pid_t, libc::SIGTERM);
                         libc::waitpid(pid as libc::pid_t, std::ptr::null_mut(), 0);
                     }
-                    // Re-raise with default handler so parent sees correct exit status
                     libc::signal(sig, libc::SIG_DFL);
                     libc::raise(sig);
                 }


### PR DESCRIPTION


## Summary
- semgrep for sast check by yml rules
- dependabot for package detection
- update CICD doc
- clippy -D unsafe_code hard fail

## Test plan

- [x] YAML syntax validated (python3 yaml.safe_load) for all 3 files
- [x] Semgrep installed locally and ran against full codebase (10 rules, 0 parse errors)
- [x] Verified 8 ERROR findings on pre-existing code (baseline will filter in CI)
- [x] Verified 15 WARNING findings on pre-existing code (all legitimate)
- [x] Confirmed no false positives on new code (no `.semgrep.yml` or `.github/` files flagged)
- [x] Push branch and verify semgrep job appears in GitHub Actions
- [x] Open PR to develop and confirm `SEMGREP_BASELINE_REF` filters pre-existing findings
-  [ ] Verify Dependabot starts creating PRs after merge (weekly schedule)