### PR TITLE
fix(rules): expand npm rewrite pattern to include install, ci, list, outdated, audit, test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to rtk (Rust Token Killer) will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bug Fixes
+
+* **rules:** expand npm rewrite pattern to include install, ci, list, outdated, audit, test ([#1148](https://github.com/rtk-ai/rtk/issues/1148))
+
 ## [0.34.3](https://github.com/rtk-ai/rtk/compare/v0.34.2...v0.34.3) (2026-04-02)
 
 

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1979,6 +1979,59 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_rewrite_npm_install() {
+        assert_eq!(
+            rewrite_command("npm install express", &[]),
+            Some("rtk npm install express".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_npm_ci() {
+        assert_eq!(rewrite_command("npm ci", &[]), Some("rtk npm ci".into()));
+    }
+
+    #[test]
+    fn test_rewrite_npm_test() {
+        assert_eq!(
+            rewrite_command("npm test", &[]),
+            Some("rtk npm test".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_npm_list() {
+        assert_eq!(
+            rewrite_command("npm list", &[]),
+            Some("rtk npm list".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_npm_outdated() {
+        assert_eq!(
+            rewrite_command("npm outdated", &[]),
+            Some("rtk npm outdated".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_npm_audit() {
+        assert_eq!(
+            rewrite_command("npm audit", &[]),
+            Some("rtk npm audit".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_npm_run_still_works() {
+        assert_eq!(
+            rewrite_command("npm run build", &[]),
+            Some("rtk npm run build".into())
+        );
+    }
+
     // --- Compound operator edge cases ---
 
     #[test]

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -53,7 +53,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        pattern: r"^npm\s+(run|exec)",
+        pattern: r"^npm\s+(run|exec|install|ci|list|ls|outdated|audit|test|i)\b",
         rtk_cmd: "rtk npm",
         rewrite_prefixes: &["npm"],
         category: "PackageManager",


### PR DESCRIPTION
## Summary
- The npm rewrite rule in `rules.rs` only matched `run|exec`, causing `npm install`, `npm ci`, `npm test`, `npm list`, `npm outdated`, and `npm audit` to bypass RTK entirely
- The filter in `npm_cmd.rs` already handles all these subcommands — the rule just didn't route them there
- Expanded pattern: `^npm\s+(run|exec|install|ci|list|ls|outdated|audit|test|i)\b`

## Test plan
- [x] 7 new unit tests in `registry.rs` covering install, ci, test, list, outdated, audit, and run (regression)
- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets` — 0 errors
- [x] `cargo test --all` — 1376 passed

Closes #1148
