### PR TITLE
feat(install): add SHA-256 checksum verification to installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,6 +201,9 @@ jobs:
         run: |
           cd release
           sha256sum * > checksums.txt
+          for f in *.tar.gz *.zip; do
+            [ -f "$f" ] && sha256sum "$f" > "${f}.sha256"
+          done
 
       - name: Upload Release Assets
         uses: softprops/action-gh-release@v2

--- a/install.sh
+++ b/install.sh
@@ -83,6 +83,17 @@ install() {
         error "Failed to download binary"
     fi
 
+    # Download and verify SHA-256 checksum
+    info "Verifying checksum..."
+    if curl -fsSL "${DOWNLOAD_URL}.sha256" -o "${ARCHIVE}.sha256" 2>/dev/null; then
+        if ! (cd "$(dirname "$ARCHIVE")" && sha256sum -c "$(basename "${ARCHIVE}.sha256")"); then
+            error "Checksum verification failed — binary may be corrupted or tampered with"
+        fi
+        info "Checksum verified"
+    else
+        warn "No checksum file found — skipping verification (release $VERSION)"
+    fi
+
     info "Extracting..."
     tar -xzf "$ARCHIVE" -C "$TEMP_DIR"
 


### PR DESCRIPTION
## Summary

Adds SHA-256 checksum verification to the install.sh script to ensure binary integrity during installation.

## Changes

### install.sh
- Downloads and verifies `.sha256` checksum file alongside the binary archive
- Fails with a clear error if checksum verification fails
- Gracefully falls back with a warning if no checksum file is found (for older releases)

### .github/workflows/release.yml
- Generates individual `.sha256` files for each release archive (tar.gz and zip) alongside the existing `checksums.txt`
- These files are automatically uploaded as release assets

## How it works
1. After downloading the binary archive, the installer attempts to fetch the corresponding `.sha256` file from the same release
2. It runs `sha256sum -c` to verify the downloaded archive matches the published checksum
3. If verification fails, installation aborts with an error
4. If no checksum file exists (older releases), a warning is shown and installation continues

Closes #1158