### PR TITLE
feat(ci): add SHA-256 checksums and release verification docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,10 +197,19 @@ jobs:
             [ -f "$f" ] && cp "$f" "rtk.x86_64.rpm"
           done
 
-      - name: Create checksums
+      - name: Generate SHA-256 checksums
         run: |
           cd release
-          sha256sum * > checksums.txt
+          sha256sum * > SHA256SUMS.txt
+          # Keep checksums.txt for backward compatibility (homebrew job)
+          cp SHA256SUMS.txt checksums.txt
+          cat SHA256SUMS.txt
+
+      - name: Generate per-archive checksums
+        run: |
+          for f in release/*.tar.gz release/*.zip; do
+            [ -f "$f" ] && sha256sum "$f" > "${f}.sha256"
+          done
 
       - name: Upload Release Assets
         uses: softprops/action-gh-release@v2

--- a/docs/RELEASE_VERIFY.md
+++ b/docs/RELEASE_VERIFY.md
@@ -1,0 +1,39 @@
+# Verifying Release Binaries
+
+All RTK release artifacts include SHA-256 checksums for integrity verification.
+
+## Manual Verification
+
+1. Download the binary archive and its .sha256 file from the [releases page](https://github.com/rtk-ai/rtk/releases)
+
+2. Verify:
+   ```bash
+   sha256sum -c rtk-x86_64-unknown-linux-musl.tar.gz.sha256
+   ```
+
+3. Or check against SHA256SUMS.txt:
+   ```bash
+   sha256sum -c SHA256SUMS.txt
+   ```
+
+## Verify After Installation
+
+After installing via install.sh, the checksum is automatically verified (since v0.36.0).
+
+## For Maintainers: Setting Up Cosign Signing
+
+1. Generate a cosign keypair:
+   ```bash
+   cosign generate-key-pair
+   ```
+
+2. Add the private key as a GitHub secret: COSIGN_KEY
+
+3. Add to release workflow after checksum generation:
+   ```yaml
+   - name: Sign checksums
+     uses: sigstore/cosign-installer@v3
+     with:
+       cosign-release: v2.2.0
+   - run: echo "$COSIGN_KEY" | cosign sign-blob --key - dist/SHA256SUMS.txt > dist/SHA256SUMS.txt.sig
+   ```


### PR DESCRIPTION
## Summary

Add SHA-256 checksum publication and optional cosign signing support for releases.

## Changes

### .github/workflows/release.yml
- Renamed existing checksum step to `Generate SHA-256 checksums`
- Generates `SHA256SUMS.txt` with checksums for all release artifacts
- Maintains `checksums.txt` for backward compatibility (used by homebrew job)
- Added new `Generate per-archive checksums` step that creates individual `.sha256` files for each tar.gz and zip archive

### docs/RELEASE_VERIFY.md (new)
- Documentation for users to verify release binary integrity
- Instructions for manual verification using `.sha256` files or `SHA256SUMS.txt`
- Guide for maintainers on setting up cosign signing

Closes #1159