### PR TITLE
fix(curl): skip JSON schema conversion for internal/localhost URLs

### DIFF
--- a/src/cmds/cloud/curl_cmd.rs
+++ b/src/cmds/cloud/curl_cmd.rs
@@ -38,7 +38,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     let raw = stdout.to_string();
 
     // Auto-detect JSON and pipe through filter
-    let filtered = filter_curl_output(&stdout);
+    let filtered = filter_curl_output(&stdout, args);
     println!("{}", filtered);
 
     timer.track(
@@ -51,17 +51,20 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     Ok(0)
 }
 
-fn filter_curl_output(output: &str) -> String {
+fn filter_curl_output(output: &str, args: &[String]) -> String {
     let trimmed = output.trim();
 
     // Try JSON detection: starts with { or [
     if (trimmed.starts_with('{') || trimmed.starts_with('['))
         && (trimmed.ends_with('}') || trimmed.ends_with(']'))
     {
-        if let Ok(schema) = json_cmd::filter_json_string(trimmed, 5) {
-            // Only use schema if it's actually shorter than the original (#297)
-            if schema.len() <= trimmed.len() {
-                return schema;
+        // Skip schema conversion for internal/localhost URLs (issues #1152, #1157)
+        if !is_internal_url(args) {
+            if let Ok(schema) = json_cmd::filter_json_string(trimmed, 5) {
+                // Only use schema if it's actually shorter than the original (#297)
+                if schema.len() <= trimmed.len() {
+                    return schema;
+                }
             }
         }
     }
@@ -87,6 +90,17 @@ fn filter_curl_output(output: &str) -> String {
         .join("\n")
 }
 
+fn is_internal_url(args: &[String]) -> bool {
+    args.iter().any(|a| {
+        let lower = a.to_lowercase();
+        lower.starts_with("http://localhost")
+            || lower.starts_with("http://127.0.0.1")
+            || lower.starts_with("http://[::1]")
+            || lower.starts_with("https://localhost")
+            || lower.starts_with("https://127.0.0.1")
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -95,7 +109,7 @@ mod tests {
     fn test_filter_curl_json() {
         // Large JSON where schema is shorter than original — schema should be returned
         let output = r#"{"name": "a very long user name here", "count": 42, "items": [1, 2, 3], "description": "a very long description that takes up many characters in the original JSON payload", "status": "active", "url": "https://example.com/api/v1/users/123"}"#;
-        let result = filter_curl_output(output);
+        let result = filter_curl_output(output, &[]);
         assert!(result.contains("name"));
         assert!(result.contains("string"));
         assert!(result.contains("int"));
@@ -104,14 +118,14 @@ mod tests {
     #[test]
     fn test_filter_curl_json_array() {
         let output = r#"[{"id": 1}, {"id": 2}]"#;
-        let result = filter_curl_output(output);
+        let result = filter_curl_output(output, &[]);
         assert!(result.contains("id"));
     }
 
     #[test]
     fn test_filter_curl_non_json() {
         let output = "Hello, World!\nThis is plain text.";
-        let result = filter_curl_output(output);
+        let result = filter_curl_output(output, &[]);
         assert!(result.contains("Hello, World!"));
         assert!(result.contains("plain text"));
     }
@@ -120,7 +134,7 @@ mod tests {
     fn test_filter_curl_json_small_returns_original() {
         // Small JSON where schema would be larger than original (issue #297)
         let output = r#"{"r2Ready":true,"status":"ok"}"#;
-        let result = filter_curl_output(output);
+        let result = filter_curl_output(output, &[]);
         // Schema would be "{\n  r2Ready: bool,\n  status: string\n}" which is longer
         // Should return the original JSON unchanged
         assert_eq!(result.trim(), output.trim());
@@ -130,9 +144,18 @@ mod tests {
     fn test_filter_curl_long_output() {
         let lines: Vec<String> = (0..50).map(|i| format!("Line {}", i)).collect();
         let output = lines.join("\n");
-        let result = filter_curl_output(&output);
+        let result = filter_curl_output(&output, &[]);
         assert!(result.contains("Line 0"));
         assert!(result.contains("Line 29"));
         assert!(result.contains("more lines"));
+    }
+
+    #[test]
+    fn test_is_internal_url_localhost() {
+        assert!(is_internal_url(&["http://localhost:9222/json/version".to_string()]));
+        assert!(is_internal_url(&["http://127.0.0.1:8080/api".to_string()]));
+        assert!(is_internal_url(&["-s".to_string(), "http://localhost:3000".to_string()]));
+        assert!(!is_internal_url(&["https://api.example.com/data".to_string()]));
+        assert!(!is_internal_url(&["https://github.com".to_string()]));
     }
 }


### PR DESCRIPTION
## Summary

Fixes issues #1152 and #1157: JSON schema conversion was destroying values for internal/localhost URLs.

## Problem

The curl JSON schema filter converts response bodies into type schemas, which destroys the actual values. For internal URLs (localhost, 127.0.0.1, etc.) this is problematic because:
- Chrome DevTools Protocol responses get schema-converted instead of showing actual browser info
- Internal API responses lose their values
- Local development tools get broken output

## Solution

Added `is_internal_url()` helper that detects localhost/127.0.0.1/[::1] URLs. When an internal URL is detected, the JSON schema conversion is skipped, preserving the original JSON values.

## Changes

- Add `is_internal_url()` function to detect internal URLs
- Guard JSON schema conversion behind `!is_internal_url(args)` check
- Update `filter_curl_output` signature to accept args
- Add `test_is_internal_url_localhost` test
- Update existing tests to pass empty args