### PR TITLE
fix(git): allow disabling --no-merges via config

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -1,5 +1,6 @@
 //! Filters git output — log, status, diff, and more — keeping just the essential info.
 
+use crate::core::config;
 use crate::core::stream::{
     self, exec_capture, CaptureResult, FilterMode, LineHandler, LineStreamFilter, StdinMode,
 };
@@ -520,12 +521,15 @@ fn run_log(
         (10, false)
     };
 
-    // Only add --no-merges if user didn't explicitly request merge commits
-    let wants_merges = args
+    // Inject --no-merges unless:
+    //   1. User explicitly passed --merges / --min-parents=2
+    //   2. User explicitly passed --no-merges (avoid duplicate)
+    //   3. User requested an exact count (-n N / --max-count)
+    //   4. Config has [git] no_merges = false (#1113)
+    let has_merge_flag = args
         .iter()
         .any(|arg| arg == "--merges" || arg == "--min-parents=2" || arg == "--no-merges");
-    // Don't add --no-merges if user explicitly requested merges or an exact count (-n N / --max-count)
-    if !wants_merges && !has_limit_flag {
+    if !has_merge_flag && !has_limit_flag && config::git().no_merges {
         cmd.arg("--no-merges");
     }
 

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -21,6 +21,8 @@ pub struct Config {
     pub hooks: HooksConfig,
     #[serde(default)]
     pub limits: LimitsConfig,
+    #[serde(default)]
+    pub git: GitConfig,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -110,6 +112,24 @@ impl Default for FilterConfig {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GitConfig {
+    /// Inject --no-merges into git log output (default: true for backward compat).
+    /// Set to false to include merge commits in git log output.
+    #[serde(default = "default_true")]
+    pub no_merges: bool,
+}
+
+impl Default for GitConfig {
+    fn default() -> Self {
+        Self { no_merges: true }
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct TelemetryConfig {
     pub enabled: bool,
@@ -148,6 +168,11 @@ impl Default for LimitsConfig {
 /// Get limits config. Falls back to defaults if config can't be loaded.
 pub fn limits() -> LimitsConfig {
     Config::load().map(|c| c.limits).unwrap_or_default()
+}
+
+/// Get git config. Falls back to defaults if config can't be loaded.
+pub fn git() -> GitConfig {
+    Config::load().map(|c| c.git).unwrap_or_default()
 }
 
 impl Config {
@@ -295,5 +320,32 @@ consent_date = "2026-04-10T12:00:00Z"
             config.telemetry.consent_date.as_deref(),
             Some("2026-04-10T12:00:00Z")
         );
+    }
+
+    #[test]
+    fn test_git_config_default_no_merges_true() {
+        let config = Config::default();
+        assert!(config.git.no_merges);
+    }
+
+    #[test]
+    fn test_git_config_no_merges_false() {
+        let toml = r#"
+[git]
+no_merges = false
+"#;
+        let config: Config = toml::from_str(toml).expect("valid toml");
+        assert!(!config.git.no_merges);
+    }
+
+    #[test]
+    fn test_git_config_absent_defaults_to_true() {
+        let toml = r#"
+[tracking]
+enabled = true
+history_days = 90
+"#;
+        let config: Config = toml::from_str(toml).expect("valid toml");
+        assert!(config.git.no_merges);
     }
 }


### PR DESCRIPTION
## Summary
- Add `[git] no_merges` config option to `~/.config/rtk/config.toml` (default: `true` for backward compatibility)
- When set to `false`, `rtk git log` no longer injects `--no-merges`, so merge commits appear in the output
- Skip `--no-merges` injection when user explicitly passes `--no-merges` to avoid duplicate flags

## Usage

```toml
# ~/.config/rtk/config.toml
[git]
no_merges = false   # include merge commits in git log
```

## Test plan
- [x] `test_git_config_default_no_merges_true` — default is backward-compatible
- [x] `test_git_config_no_merges_false` — TOML deserialization works
- [x] `test_git_config_absent_defaults_to_true` — missing `[git]` section defaults correctly
- [x] `cargo fmt && cargo clippy --all-targets && cargo test --all` — 1356 tests pass, 0 failures

Closes #1113

🤖 Generated with [Claude Code](https://claude.com/claude-code)