### PR TITLE
fix(git): detect intent-to-add files in rtk git status (#1149)

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -660,7 +660,11 @@ pub(crate) fn format_status_output(porcelain: &str) -> String {
         }
 
         match status.chars().nth(1).unwrap_or(' ') {
-            'M' | 'D' => {
+            // 'A' in working-tree position indicates intent-to-add (`git add -N`):
+            // the path is registered in the index as an empty blob but the actual
+            // content is still unstaged. Git shows it under "Changes not staged",
+            // so we must not treat the repo as clean.
+            'M' | 'D' | 'A' => {
                 modified += 1;
                 modified_files.push(file);
             }
@@ -2000,6 +2004,53 @@ A  added.rs
         assert!(result.contains("modified.rs"));
         assert!(result.contains("? Untracked: 1 files"));
         assert!(result.contains("untracked.txt"));
+    }
+
+    #[test]
+    fn test_format_status_output_intent_to_add() {
+        // `git add -N file` records the path with an empty blob (intent-to-add).
+        // git status --porcelain -b shows it as " A file" (space-A), meaning
+        // nothing is staged vs HEAD but the working-tree entry is new.
+        // RTK must not report "clean — nothing to commit" in this state.
+        let porcelain = "## main\n A new_file.txt\n";
+        let result = format_status_output(porcelain);
+        assert!(
+            !result.contains("clean"),
+            "intent-to-add file should not produce clean message, got: {result}"
+        );
+        assert!(
+            result.contains("new_file.txt"),
+            "intent-to-add file should appear in output, got: {result}"
+        );
+        assert!(
+            result.contains("~ Modified"),
+            "intent-to-add file should appear under Modified section, got: {result}"
+        );
+    }
+
+    #[test]
+    fn test_format_status_output_intent_to_add_multiple() {
+        // Multiple intent-to-add files should all be visible
+        let porcelain = "## feature/wip\n A alpha.rs\n A beta.rs\n";
+        let result = format_status_output(porcelain);
+        assert!(!result.contains("clean"), "got: {result}");
+        assert!(result.contains("alpha.rs"), "got: {result}");
+        assert!(result.contains("beta.rs"), "got: {result}");
+        assert!(result.contains("~ Modified: 2 files"), "got: {result}");
+    }
+
+    #[test]
+    fn test_format_status_output_intent_to_add_with_other_changes() {
+        // Intent-to-add alongside normally staged and untracked files
+        let porcelain = "## main\nA  staged.rs\n A intent.rs\n?? untracked.txt\n";
+        let result = format_status_output(porcelain);
+        assert!(!result.contains("clean"), "got: {result}");
+        assert!(result.contains("+ Staged: 1 files"), "got: {result}");
+        assert!(result.contains("staged.rs"), "got: {result}");
+        assert!(result.contains("~ Modified: 1 files"), "got: {result}");
+        assert!(result.contains("intent.rs"), "got: {result}");
+        assert!(result.contains("? Untracked: 1 files"), "got: {result}");
+        assert!(result.contains("untracked.txt"), "got: {result}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1149

- `git add -N file` (intent-to-add) produces ` A file` in `git status --porcelain -b`
- The 'A' in the **working-tree position** was not matched by the previous `'M' | 'D'` arm
- This caused all intent-to-add files to be invisible, triggering a false "clean — nothing to commit"
- Fix: add `'A'` to the working-tree match so these files appear under `~ Modified`

## Verification

- [x] Baseline tests: 1350 pass, 0 pre-existing failures
- [x] Post-fix tests: 1353 pass, 0 regressions
- [x] New tests: 3 added (`test_format_status_output_intent_to_add*`), all pass
- [x] Review agent: issue alignment verified, single-char change, no scope creep
- [x] Contribution guidelines: branch name `fix/git-status-intent-to-add-1149`, conventional commit

## Files changed

| File | Change |
|------|--------|
| `src/cmds/git/git.rs` | Add `'A'` to working-tree match arm; 3 new tests |

Generated by Ora Studio
Vibe coded by ousamabenyounes

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
