### PR TITLE
fix(git): detect intent-to-add files in status output

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -2161,6 +2161,23 @@ no changes added to commit (use "git add" and/or "git commit -a")
         assert!(result.contains("* main"));
     }
 
+    /// Regression test: files added with `git add -N` (intent-to-add) have
+    /// porcelain status ` A` (space + A). They must not be silently dropped,
+    /// which would cause a false "clean — nothing to commit" result.
+    #[test]
+    fn test_format_status_output_intent_to_add() {
+        let porcelain = "## main\n A new_file.txt\n";
+        let result = format_status_output(porcelain);
+        assert!(
+            !result.contains("clean"),
+            "intent-to-add files should not produce a 'clean' status: {result}"
+        );
+        assert!(
+            result.contains("new_file.txt"),
+            "intent-to-add file should appear in status output: {result}"
+        );
+    }
+
     /// Regression test: --oneline and other user format flags must preserve all commits.
     /// Before fix, filter_log_output split on ---END--- which doesn't exist when
     /// the user specifies their own format, resulting in only 2 commits surviving.

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -635,7 +635,7 @@ fn format_status_output(porcelain: &str) -> String {
         }
 
         match status.chars().nth(1).unwrap_or(' ') {
-            'M' | 'D' => {
+            'M' | 'D' | 'A' => {
                 modified += 1;
                 modified_files.push(file);
             }


### PR DESCRIPTION
## Summary

Fixes #1149 — Files added with `git add -N` (intent-to-add) show as `clean — nothing to commit` in `rtk git status`.

## Root Cause

In `format_status_output()`, git porcelain intent-to-add files have status ` A` (space + A). The worktree column (2nd char) matcher only handled `'M' | 'D'`, missing `'A'`. Since the index column (1st char) is a space, it doesn't match the staged arm either. The file falls through all checks and isn't counted anywhere.

```
git status --porcelain --branch:
## No commits yet on main
 A new_file              ← status ' A', not caught by any arm
```

## Fix

Add `'A'` to the worktree status character match: `'M' | 'D'` → `'M' | 'D' | 'A'`.

## Testing

```bash
mkdir /tmp/t && cd /tmp/t && git init
touch new_file && git add -N new_file
rtk git status  # Before: 'clean — nothing to commit' | After: shows modified file
```