### PR TITLE
fix(discover): expand npm rewrite rule to match install and other subcommands

### DIFF
--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -53,7 +53,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        pattern: r"^npm\s+(run|exec)",
+        pattern: r"^npm\s+(run|exec|install|i|ci|uninstall|remove|rm|update|up|list|ls|outdated|init|create|publish|pack|link|audit|fund|test|t|start|stop|restart)",
         rtk_cmd: "rtk npm",
         rewrite_prefixes: &["npm"],
         category: "PackageManager",


### PR DESCRIPTION
## Summary

Fixes #1148 — npm rewrite rule only matches `run|exec`, causing `npm install`, `npm ci`, `npm test`, etc. to bypass RTK.

## Problem

```rust
// rules.rs L56 — only 2 of 30+ subcommands matched
pattern: r"^npm\s+(run|exec)",
```

`npm_cmd.rs` supports 30+ subcommands via `NPM_SUBCOMMANDS` const and already filters their output (strips progress bars, keeps summaries). The rewrite rule just doesn't route them there.

## Fix

Expand the regex to include the most commonly used npm subcommands that benefit from output filtering:

```rust
pattern: r"^npm\s+(run|exec|install|i|ci|uninstall|remove|rm|update|up|list|ls|outdated|init|create|publish|pack|link|audit|fund|test|t|start|stop|restart)",
```

## Verification

```bash
rtk rewrite "npm install"  # Before: exit 1 (no match) | After: rewrites to `rtk npm install`
```