### PR TITLE
test(rewrite): regression tests for git inside $(…) subshell passthrough

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -3278,4 +3278,38 @@ mod tests {
             Some("rtk git log | head | tail && rtk git status".into())
         );
     }
+
+    /// Regression: commands where `git` appears only inside `$(...)` must NOT be
+    /// rewritten to `git rtk ...` (wrong prefix insertion) or `rtk git ...` (would
+    /// silently change what the subshell runs).  They must pass through unchanged
+    /// so the shell executes the native `git` inside the substitution.
+    ///
+    /// The outer command (echo, cd, VAR=..., for) is what matters for classification;
+    /// the inner git subshell is just a shell expansion that happens at runtime.
+    #[test]
+    fn test_rewrite_git_inside_subshell_passthrough() {
+        // echo/cd/for wrappers — outer command is ignored; inner git stays native
+        assert_eq!(
+            rewrite_command(r#"echo "Branch: $(git rev-parse --abbrev-ref HEAD)""#, &[]),
+            None
+        );
+        assert_eq!(
+            rewrite_command(r#"cd "$(git rev-parse --show-toplevel)""#, &[]),
+            None
+        );
+        assert_eq!(
+            rewrite_command("for f in $(git ls-files); do echo \"$f\"; done", &[]),
+            None
+        );
+        // Variable assignment — whole line has no outer command to rewrite
+        assert_eq!(
+            rewrite_command("BRANCH=$(git branch --show-current)", &[]),
+            None
+        );
+        // Outer git command IS rewritten; inner subshell passes through verbatim
+        assert_eq!(
+            rewrite_command("git log $(git rev-parse HEAD~1)", &[]),
+            Some("rtk git log $(git rev-parse HEAD~1)".into())
+        );
+    }
 }

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -3896,25 +3896,29 @@ mod tests {
     fn test_rewrite_git_inside_subshell_passthrough() {
         // echo/cd/for wrappers — outer command is ignored; inner git stays native
         assert_eq!(
-            rewrite_command(r#"echo "Branch: $(git rev-parse --abbrev-ref HEAD)""#, &[]),
+            rewrite_command(
+                r#"echo "Branch: $(git rev-parse --abbrev-ref HEAD)""#,
+                &[],
+                &[],
+            ),
             None
         );
         assert_eq!(
-            rewrite_command(r#"cd "$(git rev-parse --show-toplevel)""#, &[]),
+            rewrite_command(r#"cd "$(git rev-parse --show-toplevel)""#, &[], &[]),
             None
         );
         assert_eq!(
-            rewrite_command("for f in $(git ls-files); do echo \"$f\"; done", &[]),
+            rewrite_command("for f in $(git ls-files); do echo \"$f\"; done", &[], &[]),
             None
         );
         // Variable assignment — whole line has no outer command to rewrite
         assert_eq!(
-            rewrite_command("BRANCH=$(git branch --show-current)", &[]),
+            rewrite_command("BRANCH=$(git branch --show-current)", &[], &[]),
             None
         );
         // Outer git command IS rewritten; inner subshell passes through verbatim
         assert_eq!(
-            rewrite_command("git log $(git rev-parse HEAD~1)", &[]),
+            rewrite_command("git log $(git rev-parse HEAD~1)", &[], &[]),
             Some("rtk git log $(git rev-parse HEAD~1)".into())
         );
     }

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -3884,4 +3884,38 @@ mod tests {
             Some("rtk git log | head | tail && rtk git status".into())
         );
     }
+
+    /// Regression: commands where `git` appears only inside `$(...)` must NOT be
+    /// rewritten to `git rtk ...` (wrong prefix insertion) or `rtk git ...` (would
+    /// silently change what the subshell runs).  They must pass through unchanged
+    /// so the shell executes the native `git` inside the substitution.
+    ///
+    /// The outer command (echo, cd, VAR=..., for) is what matters for classification;
+    /// the inner git subshell is just a shell expansion that happens at runtime.
+    #[test]
+    fn test_rewrite_git_inside_subshell_passthrough() {
+        // echo/cd/for wrappers — outer command is ignored; inner git stays native
+        assert_eq!(
+            rewrite_command(r#"echo "Branch: $(git rev-parse --abbrev-ref HEAD)""#, &[]),
+            None
+        );
+        assert_eq!(
+            rewrite_command(r#"cd "$(git rev-parse --show-toplevel)""#, &[]),
+            None
+        );
+        assert_eq!(
+            rewrite_command("for f in $(git ls-files); do echo \"$f\"; done", &[]),
+            None
+        );
+        // Variable assignment — whole line has no outer command to rewrite
+        assert_eq!(
+            rewrite_command("BRANCH=$(git branch --show-current)", &[]),
+            None
+        );
+        // Outer git command IS rewritten; inner subshell passes through verbatim
+        assert_eq!(
+            rewrite_command("git log $(git rev-parse HEAD~1)", &[]),
+            Some("rtk git log $(git rev-parse HEAD~1)".into())
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Addresses #1109 — verifies the correct behavior for `git` inside `$(...)` command substitutions.

**Investigation finding**: the `$(git rtk ...)` corruption described in the issue does **not** reproduce with the current codebase. The rewrite logic already correctly passes through all subshell-wrapped git commands:

- `echo "Branch: $(git rev-parse ...)"` → `None` (outer `echo` is ignored)
- `BRANCH=$(git branch --show-current)` → `None` (assignment with no outer command)
- `cd "$(git rev-parse --show-toplevel)"` → `None` (outer `cd` is ignored)
- `for f in $(git ls-files); do ...` → `None` (outer `for` is ignored)
- `git log $(git rev-parse HEAD~1)` → `rtk git log $(git rev-parse HEAD~1)` ✅ (outer git rewritten, inner subshell verbatim)

This PR adds regression tests that lock in this correct behavior, so any future refactoring that accidentally introduces the `git rtk` corruption will be caught immediately.

## Test plan

- [x] `cargo test test_rewrite_git_inside_subshell_passthrough` — passes
- [x] `cargo test --all` — 1351 pass, 0 regressions

🤖 Generated with [Ora Studio](https://studio.oratelecom.net)

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
