### PR TITLE
fix(git): detect intent-to-add files in rtk git status (#1149)

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -1,4 +1,4 @@
-//! Filters git output — log, status, diff, and more — keeping just the essential info.
+﻿//! Filters git output — log, status, diff, and more — keeping just the essential info.
 
 use crate::core::config;
 use crate::core::tracking;
@@ -635,7 +635,7 @@ fn format_status_output(porcelain: &str) -> String {
         }
 
         match status.chars().nth(1).unwrap_or(' ') {
-            'M' | 'D' => {
+            'M' | 'D' | 'A' => {
                 modified += 1;
                 modified_files.push(file);
             }


### PR DESCRIPTION
## Summary

Fixes #1149 鈥?Files added with git add -N (intent-to-add) show as clean 鈥?nothing to commit in tk git status.

## Root Cause

In ormat_status_output(), git porcelain intent-to-add files have status  A (space + A). The worktree column (2nd char) matcher only handled 'M' | 'D', missing 'A'. Since the index column (1st char) is a space, it doesn't match the staged arm either. The file falls through all checks and isn't counted anywhere.

## Fix

Add 'A' to the worktree status character match: 'M' | 'D' 鈫?'M' | 'D' | 'A'.

## Testing

`ash
mkdir /tmp/t && cd /tmp/t && git init
touch new_file && git add -N new_file
rtk git status  # Before: 'clean 鈥?nothing to commit' | After: shows ~ Modified: 1 files
`
