### PR TITLE
fix(security): replace sh -c with direct exec in err, test, summary

### DIFF
--- a/src/cmds/rust/runner.rs
+++ b/src/cmds/rust/runner.rs
@@ -1,32 +1,30 @@
 //! Runs arbitrary commands and captures only stderr or test failures.
 
+use crate::core::utils::resolved_command;
 use crate::core::tracking;
 use anyhow::{Context, Result};
 use regex::Regex;
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 
 /// Run a command and filter output to show only errors/warnings
-pub fn run_err(command: &str, verbose: u8) -> Result<i32> {
+pub fn run_err(parts: &[String], verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
+    let command_label = parts.join(" ");
 
     if verbose > 0 {
-        eprintln!("Running: {}", command);
+        eprintln!("Running: {}", command_label);
     }
 
-    let output = if cfg!(target_os = "windows") {
-        Command::new("cmd")
-            .args(["/C", command])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-    } else {
-        Command::new("sh")
-            .args(["-c", command])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-    }
-    .context("Failed to execute command")?;
+    let (cmd, args) = parts
+        .split_first()
+        .context("run_err: no command provided")?;
+
+    let output = resolved_command(cmd)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .context("Failed to execute command")?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -57,45 +55,42 @@ pub fn run_err(command: &str, verbose: u8) -> Result<i32> {
     } else {
         println!("{}", rtk);
     }
-    timer.track(command, "rtk run-err", &raw, &rtk);
+    timer.track(&command_label, "rtk run-err", &raw, &rtk);
     Ok(exit_code)
 }
 
 /// Run tests and show only failures
-pub fn run_test(command: &str, verbose: u8) -> Result<i32> {
+pub fn run_test(parts: &[String], verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
+    let command_label = parts.join(" ");
 
     if verbose > 0 {
-        eprintln!("Running tests: {}", command);
+        eprintln!("Running tests: {}", command_label);
     }
 
-    let output = if cfg!(target_os = "windows") {
-        Command::new("cmd")
-            .args(["/C", command])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-    } else {
-        Command::new("sh")
-            .args(["-c", command])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-    }
-    .context("Failed to execute test command")?;
+    let (cmd, args) = parts
+        .split_first()
+        .context("run_test: no command provided")?;
+
+    let output = resolved_command(cmd)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .context("Failed to execute test command")?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     let raw = format!("{}\n{}", stdout, stderr);
 
     let exit_code = crate::core::utils::exit_code_from_output(&output, "test");
-    let summary = extract_test_summary(&raw, command);
+    let summary = extract_test_summary(&raw, &command_label);
     if let Some(hint) = crate::core::tee::tee_and_hint(&raw, "test", exit_code) {
         println!("{}\n{}", summary, hint);
     } else {
         println!("{}", summary);
     }
-    timer.track(command, "rtk run-test", &raw, &summary);
+    timer.track(&command_label, "rtk run-test", &raw, &summary);
     Ok(exit_code)
 }
 

--- a/src/cmds/system/summary.rs
+++ b/src/cmds/system/summary.rs
@@ -1,43 +1,40 @@
 //! Runs a command and produces a heuristic summary of its output.
 
 use crate::core::tracking;
-use crate::core::utils::truncate;
+use crate::core::utils::{resolved_command, truncate};
 use anyhow::{Context, Result};
 use regex::Regex;
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 
 /// Run a command and provide a heuristic summary
-pub fn run(command: &str, verbose: u8) -> Result<i32> {
+pub fn run(parts: &[String], verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
+    let command_label = parts.join(" ");
 
     if verbose > 0 {
-        eprintln!("Running and summarizing: {}", command);
+        eprintln!("Running and summarizing: {}", command_label);
     }
 
-    let output = if cfg!(target_os = "windows") {
-        Command::new("cmd")
-            .args(["/C", command])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-    } else {
-        Command::new("sh")
-            .args(["-c", command])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-    }
-    .context("Failed to execute command")?;
+    let (cmd, args) = parts
+        .split_first()
+        .context("summary: no command provided")?;
+
+    let output = resolved_command(cmd)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .context("Failed to execute command")?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     let raw = format!("{}\n{}", stdout, stderr);
 
-    let exit_code = crate::core::utils::exit_code_from_output(&output, command);
+    let exit_code = crate::core::utils::exit_code_from_output(&output, &command_label);
 
-    let summary = summarize_output(&raw, command, output.status.success());
+    let summary = summarize_output(&raw, &command_label, output.status.success());
     println!("{}", summary);
-    timer.track(command, "rtk summary", &raw, &summary);
+    timer.track(&command_label, "rtk summary", &raw, &summary);
     Ok(exit_code)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1448,15 +1448,9 @@ fn run_cli() -> Result<i32> {
             PnpmCommands::Other(args) => pnpm_cmd::run_passthrough(&args, cli.verbose)?,
         },
 
-        Commands::Err { command } => {
-            let cmd = command.join(" ");
-            runner::run_err(&cmd, cli.verbose)?
-        }
+        Commands::Err { command } => runner::run_err(&command, cli.verbose)?,
 
-        Commands::Test { command } => {
-            let cmd = command.join(" ");
-            runner::run_test(&cmd, cli.verbose)?
-        }
+        Commands::Test { command } => runner::run_test(&command, cli.verbose)?,
 
         Commands::Json {
             file,
@@ -1569,10 +1563,7 @@ fn run_cli() -> Result<i32> {
             KubectlCommands::Other(args) => container::run_kubectl_passthrough(&args, cli.verbose)?,
         },
 
-        Commands::Summary { command } => {
-            let cmd = command.join(" ");
-            summary::run(&cmd, cli.verbose)?
-        }
+        Commands::Summary { command } => summary::run(&command, cli.verbose)?,
 
         Commands::Grep {
             pattern,


### PR DESCRIPTION
## Summary

- **Eliminates shell injection** in `rtk err`, `rtk test`, and `rtk summary` by replacing `sh -c` / `cmd /C` with direct `Command::new().args()` execution
- These three commands joined their already-tokenized `Vec<String>` CLI args with spaces and passed the result to `sh -c`, allowing shell metacharacters (`;`, `|`, `&&`, `$()`) to be interpreted
- Every other RTK command module already uses safe `Command::new().args()` — these were the only outliers
- Zero new dependencies; uses the existing `resolved_command()` helper

Closes #640

### Files changed

| File | Change |
|------|--------|
| `src/cmds/rust/runner.rs` | `run_err` and `run_test`: signature `&str` → `&[String]`, replace `sh -c` with `resolved_command().args()` |
| `src/cmds/system/summary.rs` | `run`: same pattern |
| `src/main.rs` | Remove `command.join(" ")` at call sites, pass `&command` directly |

### Why this matters

RTK is designed as a proxy for AI coding agents (Claude Code, Gemini, Copilot). These agents construct `rtk err <cmd>` calls programmatically, potentially influenced by untrusted repository content. Passing args through `sh -c` when they're already tokenized by Clap is an unnecessary risk with zero benefit.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets` — no new warnings
- [x] `cargo test --all` — 1350 tests pass, 0 failures
- [x] Branch is based on latest `master` (8a7106c)

🤖 Generated with [Claude Code](https://claude.com/claude-code)