### PR TITLE
fix(discover): exclude hook-rewritten commands from missed savings (#1055)

### DIFF
--- a/src/discover/mod.rs
+++ b/src/discover/mod.rs
@@ -11,8 +11,8 @@ use std::collections::HashMap;
 
 use provider::{ClaudeProvider, SessionProvider};
 use registry::{
-    category_avg_tokens, classify_command, has_rtk_disabled_prefix, split_command_chain,
-    strip_disabled_prefix, Classification,
+    category_avg_tokens, classify_command, has_rtk_disabled_prefix, rewrite_command,
+    split_command_chain, strip_disabled_prefix, Classification,
 };
 use report::{DiscoverReport, SupportedEntry, UnsupportedEntry};
 
@@ -65,8 +65,17 @@ pub fn run(
         }
     }
 
+    // Detect whether the Claude Code hook is active so we can exclude hook-rewritten
+    // commands from the "missed savings" list — they're already being handled (#1055).
+    let hook_active = matches!(
+        crate::hooks::hook_check::status(),
+        crate::hooks::hook_check::HookStatus::Ok | crate::hooks::hook_check::HookStatus::Outdated
+    );
+
     let mut total_commands: usize = 0;
     let mut already_rtk: usize = 0;
+    let mut hook_rewritten_count: usize = 0;
+    let mut hook_rewritten_tokens: usize = 0;
     let mut parse_errors: usize = 0;
     let mut rtk_disabled_count: usize = 0;
     let mut rtk_disabled_cmds: HashMap<String, usize> = HashMap::new();
@@ -114,6 +123,21 @@ pub fn run(
                         estimated_savings_pct,
                         status,
                     } => {
+                        // If the Claude Code hook is active and would rewrite this command,
+                        // it is already being handled — do not count as a missed saving (#1055).
+                        if hook_active && rewrite_command(part, &[]).is_some() {
+                            let output_tokens = if let Some(len) = ext_cmd.output_len {
+                                len / 4
+                            } else {
+                                let subcmd = extract_subcmd(part);
+                                category_avg_tokens(category, subcmd)
+                            };
+                            hook_rewritten_count += 1;
+                            hook_rewritten_tokens +=
+                                (output_tokens as f64 * estimated_savings_pct / 100.0) as usize;
+                            continue;
+                        }
+
                         let bucket = supported_map.entry(rtk_equivalent).or_insert_with(|| {
                             SupportedBucket {
                                 rtk_equivalent,
@@ -238,6 +262,8 @@ pub fn run(
         sessions_scanned: sessions.len(),
         total_commands,
         already_rtk,
+        hook_rewritten_count,
+        hook_rewritten_tokens,
         since_days,
         supported,
         unsupported,

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -3278,4 +3278,33 @@ mod tests {
             Some("rtk git log | head | tail && rtk git status".into())
         );
     }
+
+    // Regression tests for #1055: supported commands must be rewriteable by the hook.
+    // When the PreToolUse hook is active, `rewrite_command` returning Some means the
+    // command is already handled — the discover report should not count it as missed.
+    #[test]
+    fn test_supported_git_commands_are_rewriteable_by_hook() {
+        let cmds = ["git status", "git log -10", "git diff", "git show HEAD"];
+        for cmd in &cmds {
+            assert!(
+                classify_command(cmd) != Classification::Ignored,
+                "{cmd} should be Supported, not Ignored"
+            );
+            assert!(
+                rewrite_command(cmd, &[]).is_some(),
+                "hook must rewrite '{cmd}' (needed for #1055 hook-aware discover)"
+            );
+        }
+    }
+
+    #[test]
+    fn test_supported_cargo_commands_are_rewriteable_by_hook() {
+        let cmds = ["cargo test", "cargo build", "cargo clippy"];
+        for cmd in &cmds {
+            assert!(
+                rewrite_command(cmd, &[]).is_some(),
+                "hook must rewrite '{cmd}' (needed for #1055 hook-aware discover)"
+            );
+        }
+    }
 }

--- a/src/discover/report.rs
+++ b/src/discover/report.rs
@@ -50,6 +50,10 @@ pub struct DiscoverReport {
     pub sessions_scanned: usize,
     pub total_commands: usize,
     pub already_rtk: usize,
+    /// Commands that the Claude Code PreToolUse hook would rewrite — already handled (#1055).
+    pub hook_rewritten_count: usize,
+    /// Estimated tokens already saved by the hook (not double-counted as missed savings).
+    pub hook_rewritten_tokens: usize,
     pub since_days: u64,
     pub supported: Vec<SupportedEntry>,
     pub unsupported: Vec<UnsupportedEntry>,
@@ -91,6 +95,15 @@ pub fn format_text(report: &DiscoverReport, limit: usize, verbose: bool) -> Stri
             0
         }
     ));
+
+    // Show hook-rewritten commands separately so they don't pollute "missed savings" (#1055).
+    if report.hook_rewritten_count > 0 {
+        out.push_str(&format!(
+            "Hook-handled:      {} commands — already rewritten by Claude Code hook (~{})\n",
+            report.hook_rewritten_count,
+            format_tokens(report.hook_rewritten_tokens),
+        ));
+    }
 
     if report.supported.is_empty() && report.unsupported.is_empty() {
         out.push_str("\nNo missed savings found. RTK usage looks good!\n");
@@ -212,5 +225,55 @@ fn truncate_str(s: &str, max: usize) -> String {
             .map(|(_, c)| c)
             .collect();
         format!("{}..", truncated)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_report() -> DiscoverReport {
+        DiscoverReport {
+            sessions_scanned: 1,
+            total_commands: 100,
+            already_rtk: 10,
+            hook_rewritten_count: 0,
+            hook_rewritten_tokens: 0,
+            since_days: 7,
+            supported: vec![],
+            unsupported: vec![],
+            parse_errors: 0,
+            rtk_disabled_count: 0,
+            rtk_disabled_examples: vec![],
+        }
+    }
+
+    // Regression test for #1055: hook_rewritten_count is shown in report text when non-zero.
+    #[test]
+    fn test_hook_rewritten_count_shown_when_nonzero() {
+        let mut report = empty_report();
+        report.hook_rewritten_count = 42;
+        report.hook_rewritten_tokens = 5000;
+
+        let text = format_text(&report, 20, false);
+        assert!(
+            text.contains("Hook-handled"),
+            "expected 'Hook-handled' line in report: {text}"
+        );
+        assert!(
+            text.contains("42"),
+            "expected hook count 42 in report: {text}"
+        );
+    }
+
+    // When hook count is zero (no hook installed), the line must be absent.
+    #[test]
+    fn test_hook_rewritten_count_hidden_when_zero() {
+        let report = empty_report();
+        let text = format_text(&report, 20, false);
+        assert!(
+            !text.contains("Hook-handled"),
+            "should not show Hook-handled when count is 0: {text}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1055

- When the Ora Studio `PreToolUse` hook is active, `rtk discover` was reporting hook-rewritten commands (e.g. `git diff`, `cargo test`) as "missed savings" — even though the hook was already rewriting them to `rtk git diff`, `rtk cargo test`, etc.
- Root cause: the JSONL session log records the pre-rewrite command; discover saw `git diff` and classified it as `Supported (missed)`.
- Fix: before the scan loop, detect hook status via `hook_check::status()`; when active, test each `Supported` command with `rewrite_command()`. If the hook would rewrite it, count it as `hook_rewritten` (excluded from missed-savings) and show a `Hook-handled: N commands` line in the output.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] 4 new tests: `test_supported_git_commands_are_rewriteable_by_hook`, `test_supported_cargo_commands_are_rewriteable_by_hook`, `test_hook_rewritten_count_shown_when_nonzero`, `test_hook_rewritten_count_hidden_when_zero`
- [x] 1377 pass, 0 regressions (baseline: 1373)
- [x] Manual: `rtk discover` output now shows "Hook-handled: N commands" instead of listing them as missed savings when the hook is installed

## Files changed

| File | Change |
|------|--------|
| `src/discover/mod.rs` | detect hook status; route hook-rewritten commands to new counter |
| `src/discover/report.rs` | add `hook_rewritten_count`/`hook_rewritten_tokens` to `DiscoverReport`; show in text output |
| `src/discover/registry.rs` | 2 regression tests verifying rewriteable-by-hook invariant |
| `CHANGELOG.md` | entry under [Unreleased] |

Generated by Ora Studio
Vibe coded by ousamabenyounes

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
