### PR TITLE
fix(permissions): glob_matches middle-wildcard matches commands with no trailing arguments

### DIFF
--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -253,10 +253,20 @@ fn glob_matches(cmd: &str, pattern: &str) -> bool {
                 return false;
             }
         } else {
-            // Middle segment: find next occurrence
-            match cmd[search_from..].find(*part) {
-                Some(pos) => search_from += pos + part.len(),
-                None => return false,
+            // Middle segment: find next occurrence.
+            // Also accept end-of-string when the segment ends with whitespace — this
+            // handles commands that terminate at the middle token without trailing args,
+            // e.g. "git -C * diff:*" should match bare "git -C /path diff" (#1105).
+            let remaining = &cmd[search_from..];
+            if let Some(pos) = remaining.find(*part) {
+                search_from += pos + part.len();
+            } else {
+                let trimmed = part.trim_end();
+                if !trimmed.is_empty() && remaining.ends_with(trimmed) {
+                    search_from += remaining.len();
+                } else {
+                    return false;
+                }
             }
         }
     }
@@ -436,6 +446,26 @@ mod tests {
     #[test]
     fn test_middle_wildcard_no_match() {
         assert!(!command_matches_pattern("git push develop", "git * main"));
+    }
+
+    // Bug 3: middle wildcard at end-of-command (no trailing args) — #1105
+    #[test]
+    fn test_middle_wildcard_at_end_of_command() {
+        // "git -C * diff:*" should match bare "git -C /path diff" (no trailing flags)
+        assert!(command_matches_pattern(
+            "git -C /path diff",
+            "git -C * diff:*"
+        ));
+        // Must still match when there ARE trailing args
+        assert!(command_matches_pattern(
+            "git -C /path diff --stat",
+            "git -C * diff:*"
+        ));
+        // Must NOT match a different subcommand
+        assert!(!command_matches_pattern(
+            "git -C /path status",
+            "git -C * diff:*"
+        ));
     }
 
     // Bug 3: multiple wildcards


### PR DESCRIPTION
## Summary

- `glob_matches` failed to match commands that terminated at the middle-wildcard token with no trailing arguments
- Example: pattern `git -C * diff:*` matched `git -C /path diff --stat` (has trailing flag) but NOT bare `git -C /path diff`
- Root cause: normalization turns `git -C * diff:*` → `git -C * diff *`, splitting into `["git -C ", " diff ", ""]`. Middle segment `" diff "` has a trailing space; `/path diff` ends with `" diff"` (no trailing space), so `str::find(" diff ")` returns `None` → the command is incorrectly rejected
- Fix: in the middle-segment branch, also check `remaining.ends_with(part.trim_end())` as fallback — this handles commands that end at the middle token with no trailing args

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets` — no new errors
- [x] `cargo test --all` — all 1374 tests pass
- [x] New test: `test_middle_wildcard_at_end_of_command` — covers both positive cases (bare command, command with args) and a negative case

Closes #1105

🤖 Generated with [Ora Studio](https://studio.oratelecom.net)