### PR TITLE
feat: add Tabnine CLI support

### DIFF
--- a/docs/superpowers/specs/2026-04-09-tabnine-cli-support-design.md
+++ b/docs/superpowers/specs/2026-04-09-tabnine-cli-support-design.md
@@ -1,0 +1,206 @@
+# Tabnine CLI support for RTK — Design
+
+**Date**: 2026-04-09
+**Status**: Approved for implementation
+
+## Goal
+
+Add first-class Tabnine CLI integration to RTK alongside the existing Claude Code,
+Gemini CLI, Codex, Copilot, and Cursor integrations. Users should be able to run
+`rtk init -g --tabnine` and get a BeforeTool hook that rewrites shell commands to
+their RTK equivalents, delivering the same 60-90% token savings Tabnine CLI users
+currently don't benefit from.
+
+## Context
+
+[Tabnine CLI](https://docs.tabnine.com/main/getting-started/tabnine-cli) is a fork
+of Gemini CLI. Verified facts (from both the docs and direct inspection of the
+installed binary at `~/.local/bin/tabnine` and bundled source at
+`~/.tabnine/agent/.bundles/<version>/tabnine.mjs`):
+
+- **Binary name**: `tabnine` (installed to `~/.local/bin/tabnine` on Unix)
+- **Global config directory**: `~/.tabnine/agent/`
+- **Settings file**: `~/.tabnine/agent/settings.json`
+- **Context file**: `AGENTS.md` by default, at `~/.tabnine/agent/AGENTS.md`.
+  Configurable via the `contextFileName` setting (string or array of strings).
+  Source proof in the bundle: `rPn="AGENTS.md"` and
+  `URo(t){if(t.contextFileName)... else return["AGENTS.md"]}`.
+- **Hook wire format**: identical to Gemini CLI
+  - Settings shape: `hooks.BeforeTool[]` with `matcher: "run_shell_command"`,
+    each entry containing `hooks: [{type: "command", command: "..."}]`
+  - stdin JSON: `tool_name` + `tool_input.command`
+  - Output: `{"decision":"deny","reason":"..."}` to block,
+    `{"decision":"allow","hookSpecificOutput":{"tool_input":{"command":"..."}}}`
+    to rewrite
+
+Because the hook wire format is byte-identical to Gemini CLI's, RTK's existing
+`run_gemini` hook processor handles Tabnine's input/output correctly as-is. The
+integration work is almost entirely install plumbing.
+
+## Non-goals
+
+- Installing RTK commands/skills into Tabnine's `~/.tabnine/agent/commands/` or
+  `/skills/` directories — out of scope for this change.
+- Supporting Tabnine-specific features (subagents, MCP server config) — RTK does
+  not manage these for any other CLI either.
+- Project-local (non-global) Tabnine install — Gemini is also global-only today;
+  same constraint applies here for symmetry and to match how Tabnine's
+  `~/.tabnine/agent/settings.json` is a user-scoped file.
+- Custom `contextFileName` detection — we install to the default `AGENTS.md`.
+  Users who customized this can add the `@RTK.md` reference manually.
+
+## Design
+
+### User-facing CLI surface
+
+```
+rtk init -g --tabnine               # install (asks before patching settings.json)
+rtk init -g --tabnine --auto-patch  # install without prompt
+rtk init -g --tabnine --no-patch    # install hook + RTK.md, print manual steps
+rtk init -g --tabnine --hook-only   # install hook only, skip AGENTS.md patching
+rtk init -g --tabnine --uninstall   # remove all Tabnine artifacts
+rtk hook tabnine                    # hook processor (stdin JSON → stdout JSON)
+```
+
+Flag is mutually exclusive with `--gemini`, `--codex`, `--copilot` at the same
+level as those existing flags (same switch-style dispatch in `main.rs`).
+
+### Install flow (`run_tabnine`)
+
+Mirrors `run_gemini` exactly, with the target directory changed from
+`~/.gemini/` to `~/.tabnine/agent/` and the context file changed from
+`GEMINI.md` to `AGENTS.md`:
+
+1. Resolve `~/.tabnine/agent/` (fail with a clear error if `$HOME` is unset).
+   Create the directory if missing.
+2. Create `~/.tabnine/agent/hooks/` if missing.
+3. Write `~/.tabnine/agent/hooks/rtk-hook-tabnine.sh` containing
+   `#!/bin/bash\nexec rtk hook tabnine\n`, chmod 0o755 on Unix.
+4. Unless `--hook-only`: write the existing `RTK_SLIM` constant into
+   `~/.tabnine/agent/AGENTS.md` via `write_if_changed`. This is the direct
+   Gemini-equivalent (`write_if_changed(..., RTK_SLIM, GEMINI_MD, ...)` →
+   `write_if_changed(..., RTK_SLIM, AGENTS_MD, ...)`).
+5. Patch `~/.tabnine/agent/settings.json` via the new `patch_tabnine_settings`
+   helper (logic copied from `patch_gemini_settings`, only the directory path
+   differs):
+   - Respect `PatchMode::Ask` / `Auto` / `Skip` consistently with Gemini.
+   - Detect an existing RTK hook entry (command string contains `rtk`) and skip
+     if present.
+   - Atomic write via `tempfile::NamedTempFile::persist`.
+6. Print a success message ending with "Restart Tabnine CLI. Test with: git status".
+
+**Trade-off note:** `write_if_changed` overwrites the target file entirely if
+content differs, so any user-authored content in `~/.tabnine/agent/AGENTS.md`
+will be replaced — including Tabnine's own `## Tabnine Added Memories` section
+if present. This matches how Gemini support currently treats `~/.gemini/GEMINI.md`,
+where the file is considered RTK-owned once `--gemini` has been run. Users who
+want to preserve existing AGENTS.md content should use `--hook-only`.
+
+### Uninstall flow (`uninstall_tabnine`)
+
+Mirrors `uninstall_gemini` line-for-line, with Tabnine paths:
+
+1. Remove `~/.tabnine/agent/hooks/rtk-hook-tabnine.sh` if present.
+2. Remove `~/.tabnine/agent/AGENTS.md` if present. (Gemini-style treats the
+   context file as RTK-owned — same as `uninstall_gemini` removes `GEMINI.md`.)
+3. Remove the RTK hook entry from `~/.tabnine/agent/settings.json` by filtering
+   out entries whose first hook command contains `rtk`, then rewriting the
+   file. Reuses the exact matching logic from `uninstall_gemini`.
+4. Print the removed items list, or "RTK Tabnine support was not installed" if
+   nothing was removed.
+
+### Hook processor (`rtk hook tabnine`)
+
+The existing `run_gemini` handler in `src/hooks/hook_cmd.rs` already produces
+the correct output for Tabnine because the wire format is identical. To keep a
+clean seam for future divergence and clear logs, we add a dedicated
+`HookCommands::Tabnine` variant and a dedicated `run_tabnine()` function, but
+implement it by calling a shared `run_gemini_format_hook()` helper.
+
+Refactor:
+
+```rust
+// src/hooks/hook_cmd.rs
+pub fn run_gemini() -> Result<()> {
+    run_gemini_format_hook()
+}
+
+pub fn run_tabnine() -> Result<()> {
+    run_gemini_format_hook()
+}
+
+fn run_gemini_format_hook() -> Result<()> {
+    // existing body of run_gemini
+}
+```
+
+This is a zero-behavior-change refactor for Gemini. Tests for Gemini continue
+to pass unchanged; new tests verify `run_tabnine` returns equivalent output.
+
+### Code changes
+
+| File | Change |
+|------|--------|
+| `src/hooks/constants.rs` | Add `TABNINE_HOOK_FILE = "rtk-hook-tabnine.sh"` |
+| `src/hooks/hook_check.rs` | Add Tabnine to `other_integration_installed` test helper + `test_other_integration_tabnine` |
+| `src/hooks/init.rs` | Add `resolve_tabnine_agent_dir`, `run_tabnine`, `uninstall_tabnine`, `patch_tabnine_settings`, `TABNINE_HOOK_SCRIPT` const. Wire `--tabnine --uninstall` into `uninstall()` dispatch. |
+| `src/hooks/hook_cmd.rs` | Extract `run_gemini_format_hook()`, add `run_tabnine()`. Add tests for tabnine parity. |
+| `src/main.rs` | Add `tabnine: bool` field to `Commands::Init`, add `HookCommands::Tabnine` variant, add dispatch branches for install + uninstall + hook |
+| `docs/superpowers/specs/2026-04-09-tabnine-cli-support-design.md` | This document |
+
+No new crate dependencies. No changes to `src/cmds/`, filters, or the TOML DSL.
+
+### Testing strategy
+
+Following RTK's established patterns (see `.claude/rules/cli-testing.md`):
+
+1. **Unit tests in `hook_cmd.rs`**:
+   - `run_tabnine` allows non-shell tools (same as Gemini)
+   - `run_tabnine` rewrites `git status` → `rtk git status`
+   - `run_tabnine` denies blocked commands
+   - `run_tabnine` respects `excluded_commands` config
+
+2. **Settings patching test**:
+   - Build a synthetic `settings.json` with existing non-RTK `BeforeTool` hooks,
+     run `patch_tabnine_settings`, assert the new hook is appended without
+     clobbering the existing entry.
+   - Idempotency test: running twice is a no-op.
+
+3. **Uninstall test**:
+   - After install + uninstall, verify no RTK-owned file remains and AGENTS.md
+     preserves non-RTK content.
+
+4. **Manual smoke test** (documented in the PR, not automated):
+   - `cargo install --path .`
+   - `rtk init -g --tabnine --auto-patch`
+   - Inspect `~/.tabnine/agent/settings.json` and
+     `~/.tabnine/agent/hooks/rtk-hook-tabnine.sh`
+   - Launch `tabnine` and issue a shell command via its tool — verify it gets
+     rewritten to the `rtk` equivalent.
+
+### Error handling
+
+- Follow RTK's fallback-on-failure rule: if reading/patching settings.json fails,
+  print a clear warning telling the user how to patch it manually (matching the
+  Gemini pattern at `patch_gemini_settings` when `PatchMode::Skip`).
+- Return `anyhow::Result` with `.context()` on every I/O call, per
+  `.claude/rules/rust-patterns.md`.
+- Never `unwrap()` outside tests.
+
+### Risks & mitigations
+
+- **Risk**: Tabnine CLI may evolve its hook format (it's a fork, not a mirror).
+  **Mitigation**: the dedicated `run_tabnine()` function gives us an isolated
+  seam to add Tabnine-specific handling without touching `run_gemini`.
+- **Risk**: Gemini-style install overwrites any existing
+  `~/.tabnine/agent/AGENTS.md`, including Tabnine's own memory section and any
+  notes authored by other tools that target AGENTS.md.
+  **Mitigation**: (a) the success message clearly states the AGENTS.md path was
+  written, so users know their prior file was replaced; (b) `--hook-only`
+  install is available for users who want to keep full control of AGENTS.md;
+  (c) this behavior exactly matches `--gemini`, so users familiar with that
+  integration will find it consistent.
+- **Risk**: Tabnine users who customized `contextFileName` to something other
+  than `AGENTS.md` won't benefit from the installed file.
+  **Mitigation**: `--hook-only` install works regardless; the printed success
+  message notes the AGENTS.md path so users can adapt manually.

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -1,5 +1,6 @@
 pub const REWRITE_HOOK_FILE: &str = "rtk-rewrite.sh";
 pub const GEMINI_HOOK_FILE: &str = "rtk-hook-gemini.sh";
+pub const TABNINE_HOOK_FILE: &str = "rtk-hook-tabnine.sh";
 pub const CLAUDE_DIR: &str = ".claude";
 pub const HOOKS_SUBDIR: &str = "hooks";
 pub const SETTINGS_JSON: &str = "settings.json";

--- a/src/hooks/hook_check.rs
+++ b/src/hooks/hook_check.rs
@@ -5,7 +5,9 @@ use super::constants::{
     SETTINGS_JSON,
 };
 #[cfg(test)]
-use super::constants::{CODEX_DIR, CURSOR_DIR, GEMINI_DIR, GEMINI_HOOK_FILE, OPENCODE_PLUGIN_PATH};
+use super::constants::{
+    CODEX_DIR, CURSOR_DIR, GEMINI_DIR, GEMINI_HOOK_FILE, OPENCODE_PLUGIN_PATH, TABNINE_HOOK_FILE,
+};
 use crate::core::constants::RTK_DATA_DIR;
 use std::path::PathBuf;
 
@@ -146,6 +148,11 @@ fn other_integration_installed(home: &std::path::Path) -> bool {
         home.join(GEMINI_DIR)
             .join(HOOKS_SUBDIR)
             .join(GEMINI_HOOK_FILE),
+        // Tabnine settings live under ~/.tabnine/agent/
+        home.join(".tabnine")
+            .join("agent")
+            .join(HOOKS_SUBDIR)
+            .join(TABNINE_HOOK_FILE),
     ];
     paths.iter().any(|p| p.exists())
 }
@@ -257,11 +264,26 @@ mod tests {
     }
 
     #[test]
+    fn test_other_integration_tabnine() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp
+            .path()
+            .join(".tabnine")
+            .join("agent")
+            .join(HOOKS_SUBDIR)
+            .join(TABNINE_HOOK_FILE);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"hook").unwrap();
+        assert!(other_integration_installed(tmp.path()));
+    }
+
+    #[test]
     fn test_other_integration_empty_dirs_not_enough() {
         let tmp = tempfile::tempdir().expect("tempdir");
         std::fs::create_dir_all(tmp.path().join(CURSOR_DIR).join(HOOKS_SUBDIR)).unwrap();
         std::fs::create_dir_all(tmp.path().join(CODEX_DIR)).unwrap();
         std::fs::create_dir_all(tmp.path().join(GEMINI_DIR)).unwrap();
+        std::fs::create_dir_all(tmp.path().join(".tabnine").join("agent")).unwrap();
         assert!(!other_integration_installed(tmp.path()));
     }
 

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -171,10 +171,25 @@ fn handle_copilot_cli(cmd: &str) -> Result<()> {
     Ok(())
 }
 
-// ── Gemini hook ───────────────────────────────────────────────
+// ── Gemini / Tabnine hook (shared Gemini CLI wire format) ─────
 
 /// Run the Gemini CLI BeforeTool hook.
 pub fn run_gemini() -> Result<()> {
+    run_gemini_format_hook()
+}
+
+/// Run the Tabnine CLI BeforeTool hook.
+///
+/// Tabnine CLI is a fork of Gemini CLI and uses the identical hook wire format
+/// (stdin `tool_name` + `tool_input.command`, stdout `decision`/`hookSpecificOutput`).
+/// This function exists as a dedicated entry point so logs and future divergence
+/// stay clean.
+pub fn run_tabnine() -> Result<()> {
+    run_gemini_format_hook()
+}
+
+/// Shared implementation for Gemini-format BeforeTool hooks.
+fn run_gemini_format_hook() -> Result<()> {
     let input = read_stdin_limited()?;
 
     let json: Value = serde_json::from_str(&input).context("Failed to parse hook input as JSON")?;
@@ -196,7 +211,7 @@ pub fn run_gemini() -> Result<()> {
         return Ok(());
     }
 
-    // Check deny rules — Gemini CLI only supports allow/deny (no ask mode).
+    // Check deny rules — Gemini/Tabnine CLI only support allow/deny (no ask mode).
     if permissions::check_command(cmd) == PermissionVerdict::Deny {
         let _ = writeln!(
             io::stdout(),
@@ -871,5 +886,30 @@ mod tests {
             get_rewritten("cargo test").is_some(),
             "cargo test should be rewritable when not denied"
         );
+    }
+
+    // --- Tabnine parity (Tabnine CLI is a fork of Gemini CLI, same wire format) ---
+
+    #[test]
+    fn test_tabnine_hook_uses_same_rewriter() {
+        assert_eq!(
+            rewrite_command("git status", &[]),
+            Some("rtk git status".into())
+        );
+        assert_eq!(
+            rewrite_command("cargo test", &[]),
+            Some("rtk cargo test".into())
+        );
+        assert_eq!(
+            rewrite_command("rtk git status", &[]),
+            Some("rtk git status".into())
+        );
+        assert_eq!(rewrite_command("cat <<EOF", &[]), None);
+    }
+
+    #[test]
+    fn test_tabnine_and_gemini_share_format_handler() {
+        let _: fn() -> Result<()> = super::run_gemini;
+        let _: fn() -> Result<()> = super::run_tabnine;
     }
 }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -9,6 +9,7 @@ use tempfile::NamedTempFile;
 use super::constants::{
     BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND,
     GEMINI_HOOK_FILE, HOOKS_JSON, HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
+    TABNINE_HOOK_FILE,
 };
 use super::integrity;
 
@@ -534,8 +535,15 @@ fn remove_hook_from_settings(verbose: u8) -> Result<bool> {
     Ok(removed)
 }
 
-/// Full uninstall for Claude, Gemini, Codex, or Cursor artifacts.
-pub fn uninstall(global: bool, gemini: bool, codex: bool, cursor: bool, verbose: u8) -> Result<()> {
+/// Full uninstall for Claude, Gemini, Tabnine, Codex, or Cursor artifacts.
+pub fn uninstall(
+    global: bool,
+    gemini: bool,
+    tabnine: bool,
+    codex: bool,
+    cursor: bool,
+    verbose: u8,
+) -> Result<()> {
     if codex {
         return uninstall_codex(global, verbose);
     }
@@ -577,6 +585,22 @@ pub fn uninstall(global: bool, gemini: bool, codex: bool, cursor: bool, verbose:
             println!("\nRestart Gemini CLI to apply changes.");
         } else {
             println!("RTK Gemini support was not installed (nothing to remove)");
+        }
+        return Ok(());
+    }
+
+    // Uninstall Tabnine artifacts if --tabnine
+    if tabnine {
+        let tabnine_removed = uninstall_tabnine(verbose)?;
+        removed.extend(tabnine_removed);
+        if !removed.is_empty() {
+            println!("RTK uninstalled (Tabnine):");
+            for item in &removed {
+                println!("  - {}", item);
+            }
+            println!("\nRestart Tabnine CLI to apply changes.");
+        } else {
+            println!("RTK Tabnine support was not installed (nothing to remove)");
         }
         return Ok(());
     }
@@ -2460,6 +2484,229 @@ fn uninstall_gemini(verbose: u8) -> Result<Vec<String>> {
 
     if verbose > 0 && !removed.is_empty() {
         eprintln!("Gemini artifacts removed");
+    }
+
+    Ok(removed)
+}
+
+// ─── Tabnine CLI support ──────────────────────────────────────────
+//
+// Tabnine CLI is a fork of Gemini CLI and uses the identical hook wire
+// format. The install/uninstall flow mirrors the Gemini flow exactly, with
+// two path differences:
+//   - Config dir: ~/.tabnine/agent/ (vs ~/.gemini/)
+//   - Context file: AGENTS.md (vs GEMINI.md) — Tabnine's default
+//     `contextFileName` per its bundled source (`rPn="AGENTS.md"`).
+
+/// Tabnine hook wrapper script — delegates to `rtk hook tabnine`
+const TABNINE_HOOK_SCRIPT: &str = r#"#!/bin/bash
+exec rtk hook tabnine
+"#;
+
+fn resolve_tabnine_agent_dir() -> Result<PathBuf> {
+    resolve_home_subdir(".tabnine/agent")
+}
+
+/// Entry point for `rtk init --tabnine`
+pub fn run_tabnine(
+    global: bool,
+    hook_only: bool,
+    patch_mode: PatchMode,
+    verbose: u8,
+) -> Result<()> {
+    if !global {
+        anyhow::bail!("Tabnine support is global-only. Use: rtk init -g --tabnine");
+    }
+
+    let tabnine_dir = resolve_tabnine_agent_dir()?;
+    fs::create_dir_all(&tabnine_dir).with_context(|| {
+        format!(
+            "Failed to create Tabnine config dir: {}",
+            tabnine_dir.display()
+        )
+    })?;
+
+    // 1. Install hook script
+    let hook_dir = tabnine_dir.join("hooks");
+    fs::create_dir_all(&hook_dir)
+        .with_context(|| format!("Failed to create hook dir: {}", hook_dir.display()))?;
+    let hook_path = hook_dir.join(TABNINE_HOOK_FILE);
+    write_if_changed(&hook_path, TABNINE_HOOK_SCRIPT, "Tabnine hook", verbose)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&hook_path, fs::Permissions::from_mode(0o755))
+            .with_context(|| format!("Failed to set hook permissions: {}", hook_path.display()))?;
+    }
+
+    // 2. Install AGENTS.md (RTK awareness for Tabnine)
+    if !hook_only {
+        let agents_md_path = tabnine_dir.join(AGENTS_MD);
+        // Reuse the same slim RTK awareness content used by the Gemini install.
+        write_if_changed(&agents_md_path, RTK_SLIM, AGENTS_MD, verbose)?;
+    }
+
+    // 3. Patch ~/.tabnine/agent/settings.json
+    patch_tabnine_settings(&tabnine_dir, &hook_path, patch_mode, verbose)?;
+
+    println!("\nTabnine CLI hook installed (global).\n");
+    println!("  Hook: {}", hook_path.display());
+    if !hook_only {
+        println!("  AGENTS.md: {}", tabnine_dir.join(AGENTS_MD).display());
+    }
+    println!("  Restart Tabnine CLI. Test with: git status\n");
+    Ok(())
+}
+
+/// Patch ~/.tabnine/agent/settings.json with the BeforeTool hook
+fn patch_tabnine_settings(
+    tabnine_dir: &Path,
+    hook_path: &Path,
+    patch_mode: PatchMode,
+    verbose: u8,
+) -> Result<()> {
+    let settings_path = tabnine_dir.join(SETTINGS_JSON);
+    let hook_cmd = hook_path.to_string_lossy().to_string();
+
+    // Read or create settings.json
+    let mut settings: serde_json::Value = if settings_path.exists() {
+        let content = fs::read_to_string(&settings_path)
+            .with_context(|| format!("Failed to read {}", settings_path.display()))?;
+        serde_json::from_str(&content).unwrap_or(serde_json::json!({}))
+    } else {
+        serde_json::json!({})
+    };
+
+    let before_tool_pointer = format!("/hooks/{}", BEFORE_TOOL_KEY);
+    if let Some(hooks) = settings.pointer(&before_tool_pointer) {
+        if let Some(arr) = hooks.as_array() {
+            if arr.iter().any(|h| {
+                h.pointer("/hooks/0/command")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|c| c.contains("rtk"))
+            }) {
+                if verbose > 0 {
+                    eprintln!("Tabnine settings.json already has RTK hook");
+                }
+                return Ok(());
+            }
+        }
+    }
+
+    // Ask user before patching
+    if patch_mode == PatchMode::Skip {
+        println!(
+            "\nManual setup needed: add RTK hook to {}\n\
+             See: https://github.com/rtk-ai/rtk#tabnine-cli",
+            settings_path.display()
+        );
+        return Ok(());
+    }
+
+    if patch_mode == PatchMode::Ask {
+        print!("Patch {} with RTK hook? [y/N] ", settings_path.display());
+        std::io::Write::flush(&mut std::io::stdout())?;
+        let mut answer = String::new();
+        std::io::stdin().read_line(&mut answer)?;
+        if !answer.trim().eq_ignore_ascii_case("y") {
+            println!("Skipped. Add hook manually later.");
+            return Ok(());
+        }
+    }
+
+    // Build hook entry matching Tabnine/Gemini CLI format
+    let hook_entry = serde_json::json!({
+        "matcher": "run_shell_command",
+        "hooks": [{
+            "type": "command",
+            "command": hook_cmd
+        }]
+    });
+
+    // Insert into settings
+    let hooks = settings
+        .as_object_mut()
+        .context("settings.json is not an object")?
+        .entry("hooks")
+        .or_insert(serde_json::json!({}));
+
+    let before_tool = hooks
+        .as_object_mut()
+        .context("hooks is not an object")?
+        .entry(BEFORE_TOOL_KEY)
+        .or_insert(serde_json::json!([]));
+
+    before_tool
+        .as_array_mut()
+        .context("BeforeTool is not an array")?
+        .push(hook_entry);
+
+    // Write atomically
+    let content = serde_json::to_string_pretty(&settings)?;
+    let tmp = NamedTempFile::new_in(tabnine_dir)?;
+    fs::write(tmp.path(), &content)?;
+    tmp.persist(&settings_path)
+        .with_context(|| format!("Failed to write {}", settings_path.display()))?;
+
+    if verbose > 0 {
+        eprintln!("Patched {}", settings_path.display());
+    }
+
+    Ok(())
+}
+
+/// Remove Tabnine artifacts during uninstall
+fn uninstall_tabnine(verbose: u8) -> Result<Vec<String>> {
+    let mut removed = Vec::new();
+    let tabnine_dir = match resolve_tabnine_agent_dir() {
+        Ok(d) => d,
+        Err(_) => return Ok(removed),
+    };
+
+    // Remove hook
+    let hook_path = tabnine_dir.join(HOOKS_SUBDIR).join(TABNINE_HOOK_FILE);
+    if hook_path.exists() {
+        fs::remove_file(&hook_path)
+            .with_context(|| format!("Failed to remove {}", hook_path.display()))?;
+        removed.push(format!("Tabnine hook: {}", hook_path.display()));
+    }
+
+    // Remove AGENTS.md (RTK-owned in Gemini-style install)
+    let agents_md = tabnine_dir.join(AGENTS_MD);
+    if agents_md.exists() {
+        fs::remove_file(&agents_md)
+            .with_context(|| format!("Failed to remove {}", agents_md.display()))?;
+        removed.push(format!("AGENTS.md: {}", agents_md.display()));
+    }
+
+    // Remove hook from settings.json
+    let settings_path = tabnine_dir.join(SETTINGS_JSON);
+    if settings_path.exists() {
+        let content = fs::read_to_string(&settings_path)?;
+        if let Ok(mut settings) = serde_json::from_str::<serde_json::Value>(&content) {
+            let bt_pointer = format!("/hooks/{}", BEFORE_TOOL_KEY);
+            if let Some(arr) = settings
+                .pointer_mut(&bt_pointer)
+                .and_then(|v| v.as_array_mut())
+            {
+                let before = arr.len();
+                arr.retain(|h| {
+                    !h.pointer("/hooks/0/command")
+                        .and_then(|v| v.as_str())
+                        .is_some_and(|c| c.contains("rtk"))
+                });
+                if arr.len() < before {
+                    let new_content = serde_json::to_string_pretty(&settings)?;
+                    fs::write(&settings_path, new_content)?;
+                    removed.push("Tabnine settings.json: removed RTK hook entry".to_string());
+                }
+            }
+        }
+    }
+
+    if verbose > 0 && !removed.is_empty() {
+        eprintln!("Tabnine artifacts removed");
     }
 
     Ok(removed)

--- a/src/main.rs
+++ b/src/main.rs
@@ -321,6 +321,10 @@ enum Commands {
         #[arg(long)]
         gemini: bool,
 
+        /// Initialize for Tabnine CLI instead of Claude Code
+        #[arg(long)]
+        tabnine: bool,
+
         /// Target agent to install hooks for (default: claude)
         #[arg(long, value_enum)]
         agent: Option<AgentTarget>,
@@ -712,7 +716,7 @@ enum Commands {
     /// Exits 0 and prints the rewritten command if supported.
     /// Exits 1 with no output if the command has no RTK equivalent.
     ///
-    /// Used by Claude Code, Gemini CLI, and other LLM hooks:
+    /// Used by Claude Code, Gemini CLI, Tabnine CLI, and other LLM hooks:
     ///   REWRITTEN=$(rtk rewrite "$CMD") || exit 0
     Rewrite {
         /// Raw command to rewrite (e.g. "git status", "cargo test && git push")
@@ -721,7 +725,7 @@ enum Commands {
         args: Vec<String>,
     },
 
-    /// Hook processors for LLM CLI tools (Gemini CLI, Copilot, etc.)
+    /// Hook processors for LLM CLI tools (Gemini CLI, Tabnine CLI, Copilot, etc.)
     Hook {
         #[command(subcommand)]
         command: HookCommands,
@@ -736,6 +740,8 @@ enum HookCommands {
     Cursor,
     /// Process Gemini CLI BeforeTool hook (reads JSON from stdin)
     Gemini,
+    /// Process Tabnine CLI BeforeTool hook (reads JSON from stdin)
+    Tabnine,
     /// Process Copilot preToolUse hook (VS Code + Copilot CLI, reads JSON from stdin)
     Copilot,
     /// Check how a command would be rewritten by the hook engine (dry-run)
@@ -1705,6 +1711,7 @@ fn run_cli() -> Result<i32> {
             global,
             opencode,
             gemini,
+            tabnine,
             agent,
             show,
             claude_md,
@@ -1719,7 +1726,7 @@ fn run_cli() -> Result<i32> {
                 hooks::init::show_config(codex)?;
             } else if uninstall {
                 let cursor = agent == Some(AgentTarget::Cursor);
-                hooks::init::uninstall(global, gemini, codex, cursor, cli.verbose)?;
+                hooks::init::uninstall(global, gemini, tabnine, codex, cursor, cli.verbose)?;
             } else if gemini {
                 let patch_mode = if auto_patch {
                     hooks::init::PatchMode::Auto
@@ -1729,6 +1736,15 @@ fn run_cli() -> Result<i32> {
                     hooks::init::PatchMode::Ask
                 };
                 hooks::init::run_gemini(global, hook_only, patch_mode, cli.verbose)?;
+            } else if tabnine {
+                let patch_mode = if auto_patch {
+                    hooks::init::PatchMode::Auto
+                } else if no_patch {
+                    hooks::init::PatchMode::Skip
+                } else {
+                    hooks::init::PatchMode::Ask
+                };
+                hooks::init::run_tabnine(global, hook_only, patch_mode, cli.verbose)?;
             } else if copilot {
                 hooks::init::run_copilot(cli.verbose)?;
             } else if agent == Some(AgentTarget::Kilocode) {
@@ -2067,6 +2083,10 @@ fn run_cli() -> Result<i32> {
             }
             HookCommands::Gemini => {
                 hooks::hook_cmd::run_gemini()?;
+                0
+            }
+            HookCommands::Tabnine => {
+                hooks::hook_cmd::run_tabnine()?;
                 0
             }
             HookCommands::Copilot => {


### PR DESCRIPTION
## Summary

- Add first-class Tabnine CLI integration (`rtk init -g --tabnine` and `rtk hook tabnine`)
- Tabnine CLI is a fork of Gemini CLI with identical BeforeTool hook wire format — reuses the existing Gemini hook processor via a shared `run_gemini_format_hook()` helper
- Installs hook script, AGENTS.md (Tabnine's default context file), and patches `~/.tabnine/agent/settings.json` with the BeforeTool entry
- Full uninstall support via `rtk init -g --tabnine --uninstall`

## Details

- **Config dir**: `~/.tabnine/agent/` (verified from installed Tabnine CLI binary and bundled source)
- **Context file**: `AGENTS.md` — confirmed as Tabnine's default `contextFileName` from `tabnine.mjs` source
- **Hook format**: identical to Gemini (`tool_name` + `tool_input.command` stdin, `decision`/`hookSpecificOutput` stdout)
- Dedicated `HookCommands::Tabnine` variant for clean logs and future divergence seam
- Added Tabnine detection to `other_integration_installed` in `hook_check.rs`

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test --all` — 1353 passed, 0 failed, zero new warnings
- [x] 3 Tabnine-specific unit tests: rewriter parity, format handler signature, integration detection
- [x] Live smoke test: `echo '{"tool_name":"run_shell_command","tool_input":{"command":"git status"}}' | rtk hook tabnine` → correct rewrite JSON
- [x] Manual end-to-end: `rtk init -g --tabnine --auto-patch` → launched Tabnine CLI → shell commands rewritten through RTK
- [x] CLI help shows `--tabnine` flag and `rtk hook tabnine` subcommand