### PR TITLE
fix: expand npm rewrite rule to route install, ci, test, and other subcommands

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -2822,6 +2822,46 @@ mod tests {
             Some("rtk npx svgo".to_string()),
         );
     }
+
+    // --- npm rewrite coverage (issue #1148) ---
+
+    #[test]
+    fn test_rewrite_npm_install() {
+        assert_eq!(
+            rewrite_command("npm install", &[]),
+            Some("rtk npm install".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_npm_install_package() {
+        assert_eq!(
+            rewrite_command("npm install express", &[]),
+            Some("rtk npm install express".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_npm_ci() {
+        assert_eq!(rewrite_command("npm ci", &[]), Some("rtk npm ci".into()));
+    }
+
+    #[test]
+    fn test_rewrite_npm_test() {
+        assert_eq!(
+            rewrite_command("npm test", &[]),
+            Some("rtk npm test".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_npm_run_still_works() {
+        assert_eq!(
+            rewrite_command("npm run build", &[]),
+            Some("rtk npm run build".into())
+        );
+    }
+
     // --- Compound operator edge cases ---
 
     #[test]

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -5626,6 +5626,48 @@ mod tests {
         );
     }
 
+    // --- npm rewrite coverage (rtk-ai/rtk#3671, dup of closed #1148) ---
+
+    #[test]
+    fn test_rewrite_npm_install() {
+        assert_eq!(
+            rewrite_command_no_prefixes("npm install", &[]),
+            Some("rtk npm install".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_npm_install_package() {
+        assert_eq!(
+            rewrite_command_no_prefixes("npm install express", &[]),
+            Some("rtk npm install express".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_npm_ci() {
+        assert_eq!(
+            rewrite_command_no_prefixes("npm ci", &[]),
+            Some("rtk npm ci".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_npm_test() {
+        assert_eq!(
+            rewrite_command_no_prefixes("npm test", &[]),
+            Some("rtk npm test".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_npm_run_still_works() {
+        assert_eq!(
+            rewrite_command_no_prefixes("npm run build", &[]),
+            Some("rtk npm run build".into())
+        );
+    }
+
     // --- Compound operator edge cases ---
 
     #[test]

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -62,7 +62,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        pattern: r"^npm\s+(exec|run|run-script|rum|urn|x)(\s|$)",
+        pattern: r"^npm\s+(audit|ci|exec|i|install|list|ls|outdated|remove|run|run-script|rum|start|t|test|uninstall|update|urn|x)(\s|$)",
         rtk_cmd: "rtk npm",
         rewrite_prefixes: &["npm"],
         category: "PackageManager",

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -107,7 +107,7 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
-        pattern: r"^npm\s+(exec|run|run-script|rum|urn|x)(\s|$)",
+        pattern: r"^npm\s+(audit|ci|exec|i|install|list|ls|outdated|remove|run|run-script|rum|start|t|test|uninstall|update|urn|x)(\s|$)",
         rtk_cmd: "rtk npm",
         rewrite_prefixes: &["npm"],
         category: "PackageManager",


### PR DESCRIPTION
## Summary

Fixes #1148

- The npm rule in `rules.rs` only matched `run|exec`, so `npm install`, `npm ci`, `npm test` etc. bypassed RTK entirely
- The filter in `npm_cmd.rs` already handles all subcommands — this fix routes them there
- Adds: `install`, `i`, `ci`, `uninstall`, `remove`, `update`, `list`, `ls`, `outdated`, `audit`, `test`, `t`, `start`
- Matches pnpm parity (which already routes `list|ls|outdated|install`)

## Intentionally NOT included

- `whoami`, `ping`, `version`, `prefix`, `root`, `bin` — one-line output, no meaningful savings
- `login`, `logout`, `adduser`, `init`, `create` — interactive commands
- `help` — should never be filtered

## Test plan

- [x] 5 new unit tests in `registry.rs` (install, install+package, ci, test, run regression)
- [x] Full test suite: 1355 passed, 0 failed
- [x] Manual smoke test: `rtk rewrite "npm install"` → `rtk npm install` (exit 0)
- [x] Regression: `rtk rewrite "npm run build"` still works
- [x] Negative: `rtk rewrite "npm whoami"` → exit 1 (correctly unmatched)