### PR TITLE
fix(hooks): require all segments to match allow rules (#1213)

### DIFF
--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -34,21 +34,27 @@ pub(crate) fn check_command_with_rules(
 ) -> PermissionVerdict {
     let segments = split_compound_command(cmd);
     let mut any_ask = false;
-    let mut any_allow = false;
+    // Every non-empty segment must independently match an allow rule for the
+    // compound command to receive Allow. See issue #1213: previously a single
+    // matching segment escalated the entire chain to Allow, enabling bypass.
+    let mut all_segments_allowed = true;
+    let mut saw_segment = false;
 
     for segment in &segments {
         let segment = segment.trim();
         if segment.is_empty() {
             continue;
         }
+        saw_segment = true;
 
-        // Deny takes highest priority
+        // Deny takes highest priority — any segment matching Deny blocks the whole chain.
         for pattern in deny_rules {
             if command_matches_pattern(segment, pattern) {
                 return PermissionVerdict::Deny;
             }
         }
 
+        // Ask — if any segment matches an ask rule, the final verdict is Ask.
         if !any_ask {
             for pattern in ask_rules {
                 if command_matches_pattern(segment, pattern) {
@@ -58,20 +64,23 @@ pub(crate) fn check_command_with_rules(
             }
         }
 
-        if !any_allow && !any_ask {
-            for pattern in allow_rules {
-                if command_matches_pattern(segment, pattern) {
-                    any_allow = true;
-                    break;
-                }
+        // Allow — every non-empty segment must match an allow rule independently.
+        // As soon as one segment fails to match, the entire chain loses Allow status.
+        if all_segments_allowed {
+            let matched = allow_rules
+                .iter()
+                .any(|pattern| command_matches_pattern(segment, pattern));
+            if !matched {
+                all_segments_allowed = false;
             }
         }
     }
 
-    // Precedence: Deny > Ask > Allow > Default (ask)
+    // Precedence: Deny > Ask > Allow > Default (ask).
+    // Allow requires (1) at least one segment seen, (2) all segments matched, (3) non-empty rules.
     if any_ask {
         PermissionVerdict::Ask
-    } else if any_allow {
+    } else if saw_segment && all_segments_allowed && !allow_rules.is_empty() {
         PermissionVerdict::Allow
     } else {
         PermissionVerdict::Default
@@ -530,6 +539,122 @@ mod tests {
         assert_eq!(
             check_command_with_rules("cargo build", &[], &[], &allow),
             PermissionVerdict::Default
+        );
+    }
+
+    // --- Regression tests for #1213 ---
+    // Compound command permission escalation: a single allowed segment must NOT
+    // grant Allow to the entire chain. Every non-empty segment must match
+    // independently.
+
+    #[test]
+    fn test_compound_allow_requires_every_segment() {
+        // Reproduces #1213: `git status` is allowed but `git add .` is not.
+        // Previously the chain was escalated to Allow — must now demote to Default.
+        let allow = vec![
+            "git status *".to_string(),
+            "git status".to_string(),
+            "cargo *".to_string(),
+        ];
+
+        // Single allowed command → Allow
+        assert_eq!(
+            check_command_with_rules("git status", &[], &[], &allow),
+            PermissionVerdict::Allow
+        );
+
+        // Single unallowed command → Default
+        assert_eq!(
+            check_command_with_rules("git add .", &[], &[], &allow),
+            PermissionVerdict::Default
+        );
+
+        // BUG #1213: chain with one allowed + one unallowed → must be Default
+        assert_eq!(
+            check_command_with_rules("git status && git add .", &[], &[], &allow),
+            PermissionVerdict::Default,
+            "allowed segment must not escalate unallowed segment"
+        );
+
+        // Three-segment chain with middle unallowed → Default
+        assert_eq!(
+            check_command_with_rules(
+                "cargo test && git add . && git commit -m foo",
+                &[],
+                &[],
+                &allow,
+            ),
+            PermissionVerdict::Default,
+            "middle unallowed segment must demote the whole chain"
+        );
+
+        // Unallowed-then-allowed ordering must also demote
+        assert_eq!(
+            check_command_with_rules("git add . && git status", &[], &[], &allow),
+            PermissionVerdict::Default,
+            "unallowed first segment must demote the chain"
+        );
+    }
+
+    #[test]
+    fn test_compound_allow_all_segments_matched() {
+        // All segments match → Allow (regression: wildcard allow still works)
+        let allow = vec!["git *".to_string(), "cargo *".to_string()];
+
+        assert_eq!(
+            check_command_with_rules("git status && cargo test", &[], &[], &allow),
+            PermissionVerdict::Allow
+        );
+
+        assert_eq!(
+            check_command_with_rules(
+                "git log --oneline && cargo build && git status",
+                &[],
+                &[],
+                &allow
+            ),
+            PermissionVerdict::Allow
+        );
+    }
+
+    #[test]
+    fn test_compound_allow_semicolon_separator() {
+        // `;` separator must be handled identically to `&&`.
+        let allow = vec!["git status".to_string()];
+        assert_eq!(
+            check_command_with_rules("git status; git push", &[], &[], &allow),
+            PermissionVerdict::Default
+        );
+    }
+
+    #[test]
+    fn test_compound_allow_pipe_separator() {
+        // `|` separator must be handled identically to `&&`.
+        let allow = vec!["git log".to_string()];
+        assert_eq!(
+            check_command_with_rules("git log | grep foo", &[], &[], &allow),
+            PermissionVerdict::Default
+        );
+    }
+
+    #[test]
+    fn test_compound_allow_or_separator() {
+        // `||` separator must also split segments.
+        let allow = vec!["cargo build".to_string()];
+        assert_eq!(
+            check_command_with_rules("cargo build || cargo clean", &[], &[], &allow),
+            PermissionVerdict::Default
+        );
+    }
+
+    #[test]
+    fn test_compound_ask_still_wins_over_partial_allow() {
+        // If any segment hits an ask rule, verdict is Ask (ask > allow).
+        let ask = vec!["git push".to_string()];
+        let allow = vec!["git *".to_string()];
+        assert_eq!(
+            check_command_with_rules("git status && git push origin main", &[], &ask, &allow),
+            PermissionVerdict::Ask
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1213 — a compound command permission escalation where a single allowed segment granted auto-allow to the entire chain.

**Before** (broken):
```bash
rtk rewrite "git status"                    # exit 3 (ask) ✓
rtk rewrite "git add ."                     # exit 3 (ask) ✓
rtk rewrite "git status && git add ."       # exit 0 (allow) ❌ BUG
```

**After** (fixed):
```bash
rtk rewrite "git status && git add ."       # exit 3 (ask) ✓
rtk rewrite "cargo test && git add . && git commit -m foo"  # exit 3 (ask) ✓
```

## Root cause

`check_command_with_rules` used an `any_allow` flag that was set by the first matching segment and never unset. Once set, subsequent segments skipped the allow check entirely, escalating the whole chain.

## Fix

Replace `any_allow` with `all_segments_allowed` logic. Every non-empty segment must independently match an allow rule — otherwise the chain demotes to `Default` (ask). Also add:
- `saw_segment` guard to prevent vacuous Allow on empty commands
- `!allow_rules.is_empty()` check in the final verdict

Precedence is unchanged: **Deny > Ask > Allow > Default**.

## Impact

Closes a permission escalation vector: an LLM agent could construct `<allowed_cmd> && <unapproved_cmd>` to bypass user confirmation on the second command.

## Test plan

- [x] 6 new regression tests covering:
  - Reproduction case from #1213 (`git status && git add .`)
  - Three-segment chain with middle unallowed
  - Reversed ordering (unallowed first)
  - All 4 compound separators: `&&`, `||`, `|`, `;`
  - Ask-wins-over-partial-allow precedence
- [x] All 35 permissions tests pass (29 existing + 6 new)
- [x] Full suite: 1377 tests pass, 0 failures
- [x] `cargo fmt` clean

## Related

- #1155 (general hook auto-allow bypass)
- #1105 (glob_matches bug in permissions.rs)