### PR TITLE
fix(grep): accept -r/--recursive flag so grep -rn routes through RTK filter (#880)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -302,6 +302,9 @@ enum Commands {
         /// Show line numbers (always on, accepted for grep/rg compatibility)
         #[arg(short = 'n', long)]
         line_numbers: bool,
+        /// Recursive search (no-op: rg is recursive by default; accepted for grep compatibility)
+        #[arg(short = 'r', long)]
+        recursive: bool,
         /// Extra ripgrep arguments (e.g., -i, -A 3, -w, --glob)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         extra_args: Vec<String>,
@@ -1691,6 +1694,7 @@ fn run_cli() -> Result<i32> {
             context_only,
             file_type,
             line_numbers: _, // no-op: line numbers always enabled in grep_cmd::run
+            recursive: _,    // no-op: rg is recursive by default; -r accepted for grep compat
             extra_args,
         } => grep_cmd::run(
             &pattern,
@@ -2942,5 +2946,67 @@ mod tests {
             cli.ultra_compact,
             "--ultra-compact long form must still enable ultra-compact mode"
         );
+    }
+
+    /// Regression: `grep -rn pattern path` must parse cleanly without falling back.
+    /// Before fix, `-r` was not a recognised flag, causing clap to error and route
+    /// the command through run_fallback, producing "rtk fallback: grep -r..." entries.
+    #[test]
+    fn test_grep_recursive_flag_parses() {
+        // -rn combined (the most common form used by LLMs)
+        let cli = Cli::try_parse_from(["rtk", "grep", "-rn", "pattern", "/some/path"]).unwrap();
+        match cli.command {
+            Commands::Grep {
+                pattern,
+                path,
+                recursive,
+                line_numbers,
+                ..
+            } => {
+                assert_eq!(pattern, "pattern");
+                assert_eq!(path, "/some/path");
+                assert!(recursive, "-r should set recursive=true");
+                assert!(line_numbers, "-n should set line_numbers=true");
+            }
+            _ => panic!("Expected Grep command"),
+        }
+    }
+
+    /// Regression: `grep -r pattern path` (without -n) must also parse cleanly.
+    #[test]
+    fn test_grep_recursive_only_parses() {
+        let cli = Cli::try_parse_from(["rtk", "grep", "-r", "fn main", "."]).unwrap();
+        match cli.command {
+            Commands::Grep {
+                pattern,
+                path,
+                recursive,
+                ..
+            } => {
+                assert_eq!(pattern, "fn main");
+                assert_eq!(path, ".");
+                assert!(recursive);
+            }
+            _ => panic!("Expected Grep command"),
+        }
+    }
+
+    /// Regression: `grep --recursive pattern path` long form must parse cleanly.
+    #[test]
+    fn test_grep_recursive_long_form_parses() {
+        let cli = Cli::try_parse_from(["rtk", "grep", "--recursive", "TODO", "src/"]).unwrap();
+        match cli.command {
+            Commands::Grep {
+                pattern,
+                path,
+                recursive,
+                ..
+            } => {
+                assert_eq!(pattern, "TODO");
+                assert_eq!(path, "src/");
+                assert!(recursive);
+            }
+            _ => panic!("Expected Grep command"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #880

- `grep -rn pattern path` was silently falling back to raw grep because clap rejected the unrecognised `-r` flag, triggering `run_fallback()` and recording each call as `rtk fallback: grep -r...` in `rtk gain` output
- Root cause: the `Grep` command declared `-n`/`--line-numbers` as a compatibility no-op but omitted the equally common `-r`/`--recursive` flag
- Fix: add `-r`/`--recursive` as a recognised no-op flag (rg is recursive by default, same pattern as the existing `-n` no-op); `-r` in `extra_args` is already filtered in `grep_cmd::run` for safety

## Verification

- [x] Baseline tests: 1382 pass, 6 ignored, 0 pre-existing failures
- [x] Post-fix tests: 0 regressions
- [x] New tests: 3 added (all pass): `-rn` combined, `-r` alone, `--recursive` long form
- [x] Binary test: `rtk grep -rn "fn run" src/` now produces compact RTK output instead of raw grep fallback
- [x] CHANGELOG updated
- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test --all` passes

## Files changed

| File | Change |
|------|--------|
| `src/main.rs` | Add `recursive: bool` field with `#[arg(short = 'r', long)]` to `Commands::Grep`; discard in match arm; add 3 regression tests |
| `CHANGELOG.md` | Document fix under `[Unreleased] Bug Fixes` |

Generated by Ora Studio
Vibe coded by ousamabenyounes

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
