### PR TITLE
fix(copilot): upgrade Copilot CLI hook to transparent updatedInput rewrite (v1.0.24+)

### DIFF
--- a/.github/hooks/rtk-rewrite.json
+++ b/.github/hooks/rtk-rewrite.json
@@ -3,7 +3,7 @@
     "PreToolUse": [
       {
         "type": "command",
-        "command": "rtk hook",
+        "command": "rtk hook copilot",
         "cwd": ".",
         "timeout": 5
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to rtk (Rust Token Killer) will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Bug Fixes
+
+* **copilot**: upgrade Copilot CLI hook from deny-with-suggestion to transparent `updatedInput`/`modifiedArgs` rewrite now that Copilot CLI v1.0.24 ships the fix for [copilot-cli#2013](https://github.com/github/copilot-cli/issues/2013); fix broken hook command (`rtk hook` → `rtk hook copilot`) that silently disabled the hook on every invocation (fixes [#1224](https://github.com/rtk-ai/rtk/issues/1224))
+
 ## [0.34.3](https://github.com/rtk-ai/rtk/compare/v0.34.2...v0.34.3) (2026-04-02)
 
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -34,7 +34,7 @@ All rewrite logic lives in the Rust binary (`src/discover/registry.rs`). Hook sc
 Each agent subdirectory has its own README with hook-specific details:
 
 - **[`claude/`](claude/README.md)** — Shell hook, `PreToolUse` JSON format, `settings.json` patching, test script
-- **[`copilot/`](copilot/README.md)** — Rust binary hook, dual format (VS Code Chat vs Copilot CLI), deny-with-suggestion fallback
+- **[`copilot/`](copilot/README.md)** — Rust binary hook, dual format (VS Code Chat vs Copilot CLI), updatedInput rewrite (v1.0.24+)
 - **[`cursor/`](cursor/README.md)** — Shell hook, Cursor JSON format, empty `{}` response requirement
 - **[`cline/`](cline/README.md)** — Rules file (prompt-level), `.clinerules` project-local installation
 - **[`windsurf/`](windsurf/README.md)** — Rules file (prompt-level), `.windsurfrules` workspace-scoped

--- a/hooks/copilot/README.md
+++ b/hooks/copilot/README.md
@@ -7,7 +7,7 @@
 - Uses the `rtk hook copilot` Rust binary (not a shell script) -- no `jq` dependency
 - Auto-detects two input formats: VS Code Copilot Chat (snake_case `tool_name`/`tool_input`) and Copilot CLI (camelCase `toolName`/`toolArgs` with JSON-stringified args)
 - VS Code format: returns `updatedInput` for transparent rewrite
-- Copilot CLI format: returns `permissionDecision: "deny"` with suggestion (Copilot CLI API doesn't support `updatedInput`)
+- Copilot CLI format (v1.0.24+): returns `updatedInput` + `modifiedArgs` with full toolArgs preserved; `permissionDecision: allow` by default (no dialog)
 
 ## Testing
 

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -85,7 +85,7 @@ Rules are loaded from all Claude Code `settings.json` files (project + global, i
 | Claude Code (rtk-rewrite.sh) | Yes | `permissionDecision: "ask"` — user prompted |
 | Copilot VS Code (rtk hook copilot) | Yes | `permissionDecision: "ask"` — user prompted |
 | Gemini CLI (rtk hook gemini) | No (allow/deny only) | allow (limitation — no ask mode in Gemini) |
-| Copilot CLI (rtk hook copilot) | No updatedInput | deny-with-suggestion (unchanged) |
+| Copilot CLI (rtk hook copilot) | Yes (v1.0.24+) | `permissionDecision: "ask"` + `updatedInput`/`modifiedArgs` rewrite |
 | Codex | ask parsed but no-op | allow (limitation — fails open) |
 
 ### Implementation

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -12,10 +12,13 @@ use crate::hooks::permissions::{check_command, PermissionVerdict};
 
 /// Format detected from the preToolUse JSON input.
 enum HookFormat {
-    /// VS Code Copilot Chat / Claude Code: `tool_name` + `tool_input.command`, supports `updatedInput`.
+    /// VS Code Copilot Chat / Claude Code: `tool_name` + `tool_input.command`.
     VsCode { command: String },
-    /// GitHub Copilot CLI: camelCase `toolName` + `toolArgs` (JSON string), deny-with-suggestion only.
-    CopilotCli { command: String },
+    /// GitHub Copilot CLI: camelCase `toolName` + `toolArgs` (JSON-encoded string).
+    /// Supports `updatedInput` / `modifiedArgs` since v1.0.24 (copilot-cli#2013).
+    /// `tool_args` carries the full decoded toolArgs object so we can preserve
+    /// all original fields (e.g. `description`) when building `updatedInput`.
+    CopilotCli { command: String, tool_args: Value },
     /// Non-bash tool, already uses rtk, or unknown format — pass through silently.
     PassThrough,
 }
@@ -43,7 +46,7 @@ pub fn run_copilot() -> Result<()> {
 
     match detect_format(&v) {
         HookFormat::VsCode { command } => handle_vscode(&command),
-        HookFormat::CopilotCli { command } => handle_copilot_cli(&command),
+        HookFormat::CopilotCli { command, tool_args } => handle_copilot_cli(&command, &tool_args),
         HookFormat::PassThrough => Ok(()),
     }
 }
@@ -77,6 +80,7 @@ fn detect_format(v: &Value) -> HookFormat {
                     {
                         return HookFormat::CopilotCli {
                             command: cmd.to_string(),
+                            tool_args,
                         };
                     }
                 }
@@ -138,18 +142,41 @@ fn handle_vscode(cmd: &str) -> Result<()> {
     Ok(())
 }
 
-fn handle_copilot_cli(cmd: &str) -> Result<()> {
+fn handle_copilot_cli(cmd: &str, tool_args: &Value) -> Result<()> {
     let rewritten = match get_rewritten(cmd) {
         Some(r) => r,
         None => return Ok(()),
     };
 
+    let verdict = check_command(cmd);
+
+    // Deny: pass through without rewrite — let the host tool handle it.
+    if verdict == PermissionVerdict::Deny {
+        return Ok(());
+    }
+
+    // Default (no rule matched): auto-allow — just prepending `rtk` to an already-approved cmd.
+    // Only an explicit `ask` rule triggers a prompt.
+    let decision = match verdict {
+        PermissionVerdict::Ask => "ask",
+        _ => "allow",
+    };
+
+    // Preserve all original toolArgs fields (e.g. `description`) — Copilot CLI validates
+    // that the rewritten args contain every field present in the original schema.
+    let mut updated = tool_args.clone();
+    updated["command"] = json!(rewritten);
+
+    // Use the same hookSpecificOutput envelope as the VS Code path.
+    // Include both updatedInput and modifiedArgs for maximum v1.0.24 compatibility.
     let output = json!({
-        "permissionDecision": "deny",
-        "permissionDecisionReason": format!(
-            "Token savings: use `{}` instead (rtk saves 60-90% tokens)",
-            rewritten
-        )
+        "hookSpecificOutput": {
+            "hookEventName": PRE_TOOL_USE_KEY,
+            "permissionDecision": decision,
+            "permissionDecisionReason": "RTK auto-rewrite",
+            "updatedInput": updated,
+            "modifiedArgs": updated
+        }
     });
     println!("{output}");
     Ok(())
@@ -230,7 +257,8 @@ mod tests {
     }
 
     fn copilot_cli_input(cmd: &str) -> Value {
-        let args = serde_json::to_string(&json!({ "command": cmd })).unwrap();
+        let args =
+            serde_json::to_string(&json!({ "command": cmd, "description": "test cmd" })).unwrap();
         json!({ "toolName": "bash", "toolArgs": args })
     }
 
@@ -287,6 +315,65 @@ mod tests {
     #[test]
     fn test_get_rewritten_heredoc() {
         assert!(get_rewritten("cat <<'EOF'\nhello\nEOF").is_none());
+    }
+
+    // --- Copilot CLI output ---
+
+    fn capture_copilot_cli_output(cmd: &str) -> Option<Value> {
+        let tool_args = json!({ "command": cmd, "description": "run cmd" });
+        let rewritten = get_rewritten(cmd)?;
+        let verdict = check_command(cmd);
+        if verdict == PermissionVerdict::Deny {
+            return None;
+        }
+        let decision = match verdict {
+            PermissionVerdict::Ask => "ask",
+            _ => "allow",
+        };
+        let mut updated = tool_args.clone();
+        updated["command"] = json!(rewritten);
+        Some(json!({
+            "hookSpecificOutput": {
+                "hookEventName": PRE_TOOL_USE_KEY,
+                "permissionDecision": decision,
+                "permissionDecisionReason": "RTK auto-rewrite",
+                "updatedInput": updated,
+                "modifiedArgs": updated
+            }
+        }))
+    }
+
+    #[test]
+    fn test_copilot_cli_output_has_updated_input() {
+        let out = capture_copilot_cli_output("git status").unwrap();
+        assert_eq!(
+            out["hookSpecificOutput"]["updatedInput"]["command"],
+            "rtk git status"
+        );
+        assert_eq!(
+            out["hookSpecificOutput"]["modifiedArgs"]["command"],
+            "rtk git status"
+        );
+    }
+
+    #[test]
+    fn test_copilot_cli_output_preserves_tool_args_fields() {
+        let out = capture_copilot_cli_output("git status").unwrap();
+        // description field from original toolArgs must survive in updatedInput
+        assert_eq!(
+            out["hookSpecificOutput"]["updatedInput"]["description"],
+            "run cmd"
+        );
+        assert_eq!(
+            out["hookSpecificOutput"]["modifiedArgs"]["description"],
+            "run cmd"
+        );
+    }
+
+    #[test]
+    fn test_copilot_cli_default_verdict_is_allow() {
+        let out = capture_copilot_cli_output("git status").unwrap();
+        assert_eq!(out["hookSpecificOutput"]["permissionDecision"], "allow");
     }
 
     // --- Gemini format ---

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -2529,8 +2529,8 @@ pub fn run_copilot(verbose: u8) -> Result<()> {
     println!("\nGitHub Copilot integration installed (project-scoped).\n");
     println!("  Hook config:    {}", hook_path.display());
     println!("  Instructions:   {}", instructions_path.display());
-    println!("\n  Works with VS Code Copilot Chat (transparent rewrite)");
-    println!("  and Copilot CLI (deny-with-suggestion).");
+    println!("\n  Works with VS Code Copilot Chat and Copilot CLI v1.0.24+");
+    println!("  (transparent rewrite via updatedInput/modifiedArgs).");
     println!("\n  Restart your IDE or Copilot CLI session to activate.\n");
 
     Ok(())

--- a/src/hooks/rewrite_cmd.rs
+++ b/src/hooks/rewrite_cmd.rs
@@ -14,7 +14,7 @@ use std::io::Write;
 /// | 0    | rewritten| Rewrite allowed — hook may auto-allow the rewritten command. |
 /// | 1    | (none)   | No RTK equivalent — hook passes through unchanged.           |
 /// | 2    | (none)   | Deny rule matched — hook defers to Claude Code native deny.  |
-/// | 3    | rewritten| Ask rule matched — hook rewrites but lets Claude Code prompt.|
+/// | 3    | rewritten| Explicit ask rule matched — hook rewrites but prompts user.  |
 pub fn run(cmd: &str) -> anyhow::Result<()> {
     let excluded = crate::core::config::Config::load()
         .map(|c| c.hooks.exclude_commands)
@@ -34,10 +34,17 @@ pub fn run(cmd: &str) -> anyhow::Result<()> {
                 let _ = std::io::stdout().flush();
                 Ok(())
             }
-            PermissionVerdict::Ask | PermissionVerdict::Default => {
+            // Default (no explicit rule): auto-allow — just prepending `rtk` is safe.
+            // Only explicit ask rules trigger a confirmation prompt.
+            PermissionVerdict::Ask => {
                 print!("{}", rewritten);
                 let _ = std::io::stdout().flush();
                 std::process::exit(3);
+            }
+            PermissionVerdict::Default => {
+                print!("{}", rewritten);
+                let _ = std::io::stdout().flush();
+                Ok(())
             }
             PermissionVerdict::Deny => unreachable!(),
         },


### PR DESCRIPTION
## Summary

Upgrades `rtk hook copilot` from deny-with-suggestion to transparent `updatedInput` rewrite now that Copilot CLI v1.0.24 ships the upstream fix for [copilot-cli#2013](https://github.com/github/copilot-cli/issues/2013).

Closes #1224

## Background

PR #605 predicted this exact change: *"When Copilot CLI adds `updatedInput` support, only `rtk hook` needs a one-line change."*

That day is now. Copilot CLI v1.0.24 (released April 2026) respects `hookSpecificOutput.updatedInput` and `modifiedArgs` in preToolUse responses.

## Changes

### `src/hooks/hook_cmd.rs`
- `handle_copilot_cli()`: replaced deny-with-suggestion with `hookSpecificOutput` envelope — includes both `updatedInput` and `modifiedArgs` for maximum v1.0.24 compatibility
- Preserves **all original toolArgs fields** (e.g. `description`) in `updatedInput` — Copilot CLI validates the rewritten args match the original schema; dropping `description` caused "description: Required" on every rewritten command
- Default verdict: `allow` (no dialog for transparent rewrites — user explicitly installed the hook)
- 3 new tests: output format, toolArgs preservation, default=allow

### `src/hooks/rewrite_cmd.rs`
- `Default` verdict (no explicit rules configured) now exits 0 (auto-allow) instead of 3 (ask prompt)
- Fixes permission dialog appearing on **every** Claude Code rewrite for users with no explicit permission rules

### `.github/hooks/rtk-rewrite.json`
- Fixed `"command": "rtk hook"` → `"rtk hook copilot"` — missing subcommand caused exit code 2 on every invocation, silently disabling the hook for all Copilot CLI users

### `src/hooks/init.rs`
- Success message updated (no longer mentions deny-with-suggestion)

### `src/hooks/README.md` + `hooks/copilot/README.md` + `hooks/README.md`
- Docs updated to reflect `updatedInput` support (v1.0.24+)

### `CHANGELOG.md`
- `[Unreleased]` Bug Fixes entry added

## Before / After

**Before (Copilot CLI):**
```json
{ "permissionDecision": "deny", "permissionDecisionReason": "Token savings: use `rtk git status` instead" }
```
→ User sees denial, must re-run manually.

**After (Copilot CLI v1.0.24+):**
```json
{
  "hookSpecificOutput": {
    "hookEventName": "PreToolUse",
    "permissionDecision": "allow",
    "permissionDecisionReason": "RTK auto-rewrite",
    "updatedInput": { "command": "rtk git status", "description": "check repo" },
    "modifiedArgs": { "command": "rtk git status", "description": "check repo" }
  }
}
```
→ Command silently rewritten, no dialog, no friction, all toolArgs fields preserved.

## Test Results

```
test result: ok. 1382 passed; 0 failed; 6 ignored
```

Manual validation with Copilot CLI v1.0.24:
- Copilot CLI format → transparent rewrite, `permissionDecision: allow` ✅
- `description` field preserved in `updatedInput` ✅
- Already-rtk command → pass through silently ✅
- Non-bash tool → pass through silently ✅
- VS Code format unchanged ✅
- No permission dialog on Claude Code rewrites ✅

## Compatibility

Requires Copilot CLI v1.0.24+. Earlier versions ignored `updatedInput` — same behaviour as the previous deny (no worse). No action needed on user side once they update the CLI.
