### PR TITLE
fix(ccusage): add --yes flag and warn when falling back to npx

### DIFF
--- a/src/analytics/ccusage.rs
+++ b/src/analytics/ccusage.rs
@@ -95,7 +95,9 @@ fn build_command() -> Option<Command> {
     }
 
     // Fallback: try npx
+    eprintln!("[info] ccusage not installed globally, fetching via npx...");
     let npx_check = resolved_command("npx")
+        .arg("--yes")
         .arg("ccusage")
         .arg("--help")
         .stdout(std::process::Stdio::null())
@@ -104,6 +106,7 @@ fn build_command() -> Option<Command> {
 
     if npx_check.map(|s| s.success()).unwrap_or(false) {
         let mut cmd = resolved_command("npx");
+        cmd.arg("--yes");
         cmd.arg("ccusage");
         return Some(cmd);
     }


### PR DESCRIPTION
## Summary

- Fixes silent hang in `rtk cc-economics` when `ccusage` is not installed globally
- `npx` prompts "Ok to proceed? (y)" before installing the package — RTK's subprocess blocks on this forever since it has no interactive stdin
- Adding `--yes` auto-confirms the install
- Added an `[info]` warning to stderr so users know why it may take a moment

## Root Cause

`build_command()` falls back to `npx ccusage` when the binary isn't in PATH. Without `--yes`, npx waits for interactive confirmation that never comes.

Closes #1226