### PR TITLE
feat(hermes): add initial manual plugin support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@ Thumbs.db
 # Test artifacts
 *.cast.bak
 
+# Python
+__pycache__/
+*.pyc
+
 # Benchmark results
 scripts/benchmark/
 benchmark-report.md

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ After install, **restart Claude Code**.
 
 ## Supported AI Tools
 
-RTK supports 12 AI coding tools. Each integration transparently rewrites shell commands to `rtk` equivalents for 60-90% token savings.
+RTK supports a growing set of AI coding tools. Each integration transparently rewrites shell commands to `rtk` equivalents for 60-90% token savings.
 
 | Tool | Install | Method |
 |------|---------|--------|
@@ -323,10 +323,13 @@ RTK supports 12 AI coding tools. Each integration transparently rewrites shell c
 | **Windsurf** | `rtk init --agent windsurf` | .windsurfrules (project-scoped) |
 | **Cline / Roo Code** | `rtk init --agent cline` | .clinerules (project-scoped) |
 | **OpenCode** | `rtk init -g --opencode` | Plugin TS (tool.execute.before) |
+| **Hermes** | Manual install from `hermes/` | Python plugin (`pre_tool_call`) — initial support |
 | **OpenClaw** | `openclaw plugins install ./openclaw` | Plugin TS (before_tool_call) |
 | **Mistral Vibe** | Planned ([#800](https://github.com/rtk-ai/rtk/issues/800)) | Blocked on upstream |
 | **Kilo Code** | `rtk init --agent kilocode` | .kilocode/rules/rtk-rules.md (project-scoped) |
 | **Google Antigravity** | `rtk init --agent antigravity` | .agents/rules/antigravity-rtk-rules.md (project-scoped) |
+
+Hermes support is currently initial/manual: copy the plugin files from `hermes/` into `$HERMES_HOME/plugins/rtk-rewrite/` and restart Hermes. `rtk init` does not install Hermes yet.
 
 For per-agent setup details, override controls, and graceful degradation, see the [Supported Agents guide](https://www.rtk-ai.app/guide/getting-started/supported-agents).
 

--- a/hermes/README.md
+++ b/hermes/README.md
@@ -1,0 +1,124 @@
+# RTK Plugin for Hermes
+
+Initial Hermes support: transparently rewrites shell commands executed via Hermes's `terminal` tool to their RTK equivalents, achieving 60-90% LLM token savings.
+
+This is the Hermes equivalent of the Claude Code hooks in `hooks/claude/rtk-rewrite.sh` and the OpenClaw plugin in `openclaw/`.
+
+## Status
+
+Hermes support is currently **manual/plugin-based**:
+- the plugin files in `hermes/` are ready to use
+- `rtk init` does **not** install Hermes yet
+- if Hermes changes its plugin API, this integration should be updated like any other RTK hook/plugin
+
+## How it works
+
+The plugin registers a `pre_tool_call` hook that intercepts `terminal` tool calls. When the agent runs a command like `git status`, the plugin delegates to `rtk rewrite`, which returns the optimized command (for example `rtk git status`). The compressed output enters the agent's context window, saving tokens.
+
+All rewrite logic lives in RTK itself (`rtk rewrite`). This plugin is a thin delegate — when new filters are added to RTK, the plugin picks them up automatically with zero changes.
+
+```
+Agent runs: terminal(command="cargo test --nocapture")
+  -> Plugin intercepts pre_tool_call hook
+  -> Calls `rtk rewrite "cargo test --nocapture"`
+  -> Mutates args["command"] = "rtk cargo test --nocapture"
+  -> Agent executes the rewritten command
+  -> Filtered output reaches LLM (~90% fewer tokens)
+```
+
+## Installation
+
+### Prerequisites
+
+RTK must be installed and available in `$PATH`:
+
+```bash
+brew install rtk
+# or
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
+```
+
+### Install the plugin manually
+
+Hermes discovers user plugins from `$HERMES_HOME/plugins/`.
+
+- Default Hermes home: `~/.hermes`
+- Profile mode example: `~/.hermes/profiles/zero`
+- Effective plugin target: `$HERMES_HOME/plugins/rtk-rewrite/`
+
+```bash
+PLUGIN_HOME="${HERMES_HOME:-$HOME/.hermes}"
+mkdir -p "$PLUGIN_HOME/plugins/rtk-rewrite"
+cp hermes/__init__.py hermes/plugin.yaml "$PLUGIN_HOME/plugins/rtk-rewrite/"
+```
+
+Then restart Hermes (or the Hermes gateway, if you run one) so the plugin is reloaded.
+
+## Architecture
+
+Hermes uses a Python plugin system with lifecycle hooks. Plugins live in `$HERMES_HOME/plugins/<name>/` and must contain:
+
+- `plugin.yaml` — manifest (name, version, hooks declared)
+- `__init__.py` — module with a `register(ctx)` function
+
+The `register(ctx)` function receives a `PluginContext` that provides:
+- `ctx.register_hook(name, callback)` — subscribe to lifecycle events
+- `ctx.register_tool(...)` — add new tools to the agent
+
+This plugin uses the `pre_tool_call` hook, which fires before every tool execution with `tool_name`, `args` (mutable dict), and `task_id`. Mutating `args["command"]` in-place rewrites the command before the terminal executes it.
+
+## Rewrite behavior
+
+The plugin accepts RTK rewrite exit codes `0` and `3` as successful rewrite paths. Current RTK builds may return exit code `3` while still emitting a valid rewritten command on stdout.
+
+The plugin also skips:
+- commands already starting with `rtk `
+- commands containing `RTK_DISABLED=1`
+- empty or non-string commands
+- non-`terminal` tool calls
+
+## What gets rewritten
+
+Everything that `rtk rewrite` supports (30+ commands). See the [full command list](https://github.com/rtk-ai/rtk#commands).
+
+## What's NOT rewritten
+
+Handled by the plugin and/or `rtk rewrite` guards:
+- commands already using `rtk`
+- commands explicitly disabled with `RTK_DISABLED=1`
+- piped / compound commands according to RTK's compound-command logic
+- heredocs (`<<`)
+- commands without an RTK filter
+
+## Measured savings
+
+| Command | Token savings |
+|---------|--------------|
+| `git log --stat` | 87% |
+| `ls -la` | 78% |
+| `git status` | 66% |
+| `grep` (single file) | 52% |
+| `find -name` | 48% |
+
+## Graceful degradation
+
+The plugin is non-blocking — it never prevents a command from executing:
+
+- RTK binary not found: warning logged, plugin disabled (no hook registered)
+- `rtk rewrite` times out (>2s): command passes through unchanged
+- `rtk rewrite` crashes: command passes through unchanged
+- `rtk rewrite` returns exit code 1 (no equivalent): command passes through unchanged
+- non-terminal tool calls: hook returns immediately (no-op)
+
+## Testing
+
+```bash
+cd /path/to/rtk
+uv run --with pytest python -m pytest hermes/test_rtk_plugin.py -v
+```
+
+Tests cover: binary detection, rewrite logic, hook behavior, edge cases, error handling, and full integration flow.
+
+## License
+
+MIT — same as RTK.

--- a/hermes/__init__.py
+++ b/hermes/__init__.py
@@ -1,0 +1,89 @@
+"""
+RTK Rewrite Plugin for Hermes
+
+Initial Hermes support: transparently rewrites terminal tool commands to RTK equivalents
+before execution, achieving 60-90% LLM token savings.
+
+All rewrite logic lives in `rtk rewrite` (src/discover/registry.rs).
+This plugin is a thin delegate — to add or change rules, edit the
+Rust registry, not this file.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_rtk_available: Optional[bool] = None
+_SUCCESS_REWRITE_EXIT_CODES = {0, 3}
+
+
+def _check_rtk() -> bool:
+    """Check if rtk binary is available in PATH. Result is cached."""
+    global _rtk_available
+    if _rtk_available is not None:
+        return _rtk_available
+    _rtk_available = shutil.which("rtk") is not None
+    return _rtk_available
+
+
+def _should_skip(command: str) -> bool:
+    """Skip commands that should never be re-rewritten."""
+    stripped = command.lstrip()
+    return stripped.startswith("rtk ") or "RTK_DISABLED=1" in command
+
+
+def _try_rewrite(command: str) -> Optional[str]:
+    """Delegate to `rtk rewrite` and return the rewritten command, or None."""
+    if _should_skip(command):
+        return None
+
+    try:
+        result = subprocess.run(
+            ["rtk", "rewrite", command],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        rewritten = result.stdout.strip()
+        if result.returncode in _SUCCESS_REWRITE_EXIT_CODES and rewritten and rewritten != command:
+            return rewritten
+        return None
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None
+
+
+
+def _pre_tool_call(*, tool_name: str, args: dict, task_id: str, **_kwargs) -> None:
+    """pre_tool_call hook: rewrite terminal commands to use RTK.
+
+    Mutates ``args["command"]`` in-place when RTK provides a rewrite.
+    The dict is mutable, so changes propagate to the caller without
+    needing a return value.
+    """
+    if tool_name != "terminal":
+        return
+
+    command = args.get("command")
+    if not isinstance(command, str) or not command.strip():
+        return
+
+    rewritten = _try_rewrite(command)
+    if rewritten:
+        logger.debug("[rtk] %s -> %s", command, rewritten)
+        args["command"] = rewritten
+
+
+
+def register(ctx) -> None:
+    """Entry point called by Hermes plugin system."""
+    if not _check_rtk():
+        logger.warning("[rtk] rtk binary not found in PATH — plugin disabled")
+        return
+
+    ctx.register_hook("pre_tool_call", _pre_tool_call)
+    logger.info("[rtk] Hermes plugin registered")

--- a/hermes/plugin.yaml
+++ b/hermes/plugin.yaml
@@ -1,0 +1,8 @@
+name: rtk-rewrite
+version: "1.0.0"
+description: "Initial Hermes support: rewrite shell commands to RTK equivalents for 60-90% LLM token savings"
+author: rtk-ai
+requires_env: []
+provides_tools: []
+provides_hooks:
+  - pre_tool_call

--- a/hermes/test_rtk_plugin.py
+++ b/hermes/test_rtk_plugin.py
@@ -1,0 +1,325 @@
+"""
+Tests for the RTK Rewrite Plugin for Hermes.
+
+Covers:
+- RTK binary detection (available / not available)
+- Command rewriting via `rtk rewrite`
+- Hermes-specific skip guards
+- Hook registration and invocation
+- Edge cases: non-terminal tools, empty commands, timeouts, errors
+- In-place args mutation
+"""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Import the plugin package (hermes/)
+import hermes as rtk_plugin
+
+
+@pytest.fixture(autouse=True)
+def _reset_rtk_cache():
+    """Reset the cached rtk availability check between tests."""
+    rtk_plugin._rtk_available = None
+    yield
+    rtk_plugin._rtk_available = None
+
+
+# ==========================================================================
+# _check_rtk
+# ==========================================================================
+
+class TestCheckRtk:
+    def test_rtk_found(self):
+        with patch("shutil.which", return_value="/usr/local/bin/rtk"):
+            assert rtk_plugin._check_rtk() is True
+
+    def test_rtk_not_found(self):
+        with patch("shutil.which", return_value=None):
+            assert rtk_plugin._check_rtk() is False
+
+    def test_result_is_cached(self):
+        with patch("shutil.which", return_value="/usr/local/bin/rtk") as mock_which:
+            rtk_plugin._check_rtk()
+            rtk_plugin._check_rtk()
+            mock_which.assert_called_once()
+
+
+# ==========================================================================
+# _should_skip
+# ==========================================================================
+
+class TestShouldSkip:
+    def test_skips_explicit_rtk_command(self):
+        assert rtk_plugin._should_skip("rtk git status") is True
+
+    def test_skips_rtk_disabled_command(self):
+        assert rtk_plugin._should_skip("RTK_DISABLED=1 git status") is True
+
+    def test_does_not_skip_normal_command(self):
+        assert rtk_plugin._should_skip("git status") is False
+
+
+# ==========================================================================
+# _try_rewrite
+# ==========================================================================
+
+class TestTryRewrite:
+    def test_successful_rewrite_exit_code_0(self):
+        fake_result = subprocess.CompletedProcess(
+            args=["rtk", "rewrite", "git status"],
+            returncode=0,
+            stdout="rtk git status\n",
+            stderr="",
+        )
+        with patch("subprocess.run", return_value=fake_result):
+            assert rtk_plugin._try_rewrite("git status") == "rtk git status"
+
+    def test_successful_rewrite_exit_code_3(self):
+        fake_result = subprocess.CompletedProcess(
+            args=["rtk", "rewrite", "git status"],
+            returncode=3,
+            stdout="rtk git status\n",
+            stderr="",
+        )
+        with patch("subprocess.run", return_value=fake_result):
+            assert rtk_plugin._try_rewrite("git status") == "rtk git status"
+
+    def test_no_rewrite_same_command(self):
+        """When rtk rewrite returns the same command, return None."""
+        fake_result = subprocess.CompletedProcess(
+            args=["rtk", "rewrite", "echo hello"],
+            returncode=0,
+            stdout="echo hello\n",
+            stderr="",
+        )
+        with patch("subprocess.run", return_value=fake_result):
+            assert rtk_plugin._try_rewrite("echo hello") is None
+
+    def test_no_rewrite_exit_code_1(self):
+        """Exit code 1 means no RTK equivalent."""
+        fake_result = subprocess.CompletedProcess(
+            args=["rtk", "rewrite", "some_custom_cmd"],
+            returncode=1,
+            stdout="",
+            stderr="",
+        )
+        with patch("subprocess.run", return_value=fake_result):
+            assert rtk_plugin._try_rewrite("some_custom_cmd") is None
+
+    def test_no_rewrite_empty_stdout(self):
+        fake_result = subprocess.CompletedProcess(
+            args=["rtk", "rewrite", "git status"],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+        with patch("subprocess.run", return_value=fake_result):
+            assert rtk_plugin._try_rewrite("git status") is None
+
+    def test_timeout_returns_none(self):
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("rtk", 2)):
+            assert rtk_plugin._try_rewrite("git status") is None
+
+    def test_file_not_found_returns_none(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            assert rtk_plugin._try_rewrite("git status") is None
+
+    def test_os_error_returns_none(self):
+        with patch("subprocess.run", side_effect=OSError("broken")):
+            assert rtk_plugin._try_rewrite("git status") is None
+
+    def test_rewrite_strips_whitespace(self):
+        fake_result = subprocess.CompletedProcess(
+            args=["rtk", "rewrite", "ls -la"],
+            returncode=3,
+            stdout="  rtk ls -la  \n",
+            stderr="",
+        )
+        with patch("subprocess.run", return_value=fake_result):
+            assert rtk_plugin._try_rewrite("ls -la") == "rtk ls -la"
+
+    def test_rewrite_passes_command_as_argument(self):
+        """Verify the command is passed as a separate argument, not shell-expanded."""
+        fake_result = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="")
+        with patch("subprocess.run", return_value=fake_result) as mock_run:
+            rtk_plugin._try_rewrite("git log --oneline -5")
+            mock_run.assert_called_once_with(
+                ["rtk", "rewrite", "git log --oneline -5"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+
+    def test_skip_guard_avoids_subprocess_for_explicit_rtk_command(self):
+        with patch("subprocess.run") as mock_run:
+            assert rtk_plugin._try_rewrite("rtk git status") is None
+            mock_run.assert_not_called()
+
+    def test_skip_guard_avoids_subprocess_for_rtk_disabled_command(self):
+        with patch("subprocess.run") as mock_run:
+            assert rtk_plugin._try_rewrite("RTK_DISABLED=1 git status") is None
+            mock_run.assert_not_called()
+
+
+# ==========================================================================
+# _pre_tool_call hook
+# ==========================================================================
+
+class TestPreToolCall:
+    def test_rewrites_terminal_command(self):
+        """Hook should mutate args in-place when a rewrite is available."""
+        args = {"command": "git status"}
+        with patch.object(rtk_plugin, "_try_rewrite", return_value="rtk git status"):
+            rtk_plugin._pre_tool_call(tool_name="terminal", args=args, task_id="test")
+        assert args["command"] == "rtk git status"
+
+    def test_ignores_non_terminal_tools(self):
+        """Hook should skip tools that aren't 'terminal'."""
+        args = {"command": "git status"}
+        with patch.object(rtk_plugin, "_try_rewrite") as mock_rewrite:
+            rtk_plugin._pre_tool_call(tool_name="web_search", args=args, task_id="test")
+            mock_rewrite.assert_not_called()
+        assert args["command"] == "git status"
+
+    def test_ignores_missing_command(self):
+        """Hook should skip if args has no 'command' key."""
+        args = {"background": True}
+        with patch.object(rtk_plugin, "_try_rewrite") as mock_rewrite:
+            rtk_plugin._pre_tool_call(tool_name="terminal", args=args, task_id="test")
+            mock_rewrite.assert_not_called()
+
+    def test_ignores_non_string_command(self):
+        """Hook should skip if command is not a string."""
+        args = {"command": 123}
+        with patch.object(rtk_plugin, "_try_rewrite") as mock_rewrite:
+            rtk_plugin._pre_tool_call(tool_name="terminal", args=args, task_id="test")
+            mock_rewrite.assert_not_called()
+
+    def test_ignores_empty_command(self):
+        """Hook should skip empty command strings."""
+        args = {"command": "   "}
+        with patch.object(rtk_plugin, "_try_rewrite") as mock_rewrite:
+            rtk_plugin._pre_tool_call(tool_name="terminal", args=args, task_id="test")
+            mock_rewrite.assert_not_called()
+
+    def test_no_mutation_when_no_rewrite(self):
+        """Hook should not modify args when rtk returns None."""
+        args = {"command": "echo hello"}
+        with patch.object(rtk_plugin, "_try_rewrite", return_value=None):
+            rtk_plugin._pre_tool_call(tool_name="terminal", args=args, task_id="test")
+        assert args["command"] == "echo hello"
+
+    def test_preserves_other_args(self):
+        """Hook should only modify 'command', leaving other args untouched."""
+        args = {"command": "git status", "timeout": 30, "workdir": "/tmp"}
+        with patch.object(rtk_plugin, "_try_rewrite", return_value="rtk git status"):
+            rtk_plugin._pre_tool_call(tool_name="terminal", args=args, task_id="test")
+        assert args == {"command": "rtk git status", "timeout": 30, "workdir": "/tmp"}
+
+    def test_handles_extra_kwargs(self):
+        """Hook should accept and ignore extra keyword arguments."""
+        args = {"command": "git status"}
+        with patch.object(rtk_plugin, "_try_rewrite", return_value="rtk git status"):
+            rtk_plugin._pre_tool_call(
+                tool_name="terminal", args=args, task_id="test", unexpected="value"
+            )
+        assert args["command"] == "rtk git status"
+
+
+# ==========================================================================
+# register()
+# ==========================================================================
+
+class TestRegister:
+    def test_registers_hook_when_rtk_available(self):
+        ctx = MagicMock()
+        with patch.object(rtk_plugin, "_check_rtk", return_value=True):
+            rtk_plugin.register(ctx)
+        ctx.register_hook.assert_called_once_with("pre_tool_call", rtk_plugin._pre_tool_call)
+
+    def test_skips_registration_when_rtk_missing(self):
+        ctx = MagicMock()
+        with patch.object(rtk_plugin, "_check_rtk", return_value=False):
+            rtk_plugin.register(ctx)
+        ctx.register_hook.assert_not_called()
+
+    def test_register_does_not_raise_on_missing_rtk(self):
+        """Plugin should degrade gracefully, never crash the agent."""
+        ctx = MagicMock()
+        with patch.object(rtk_plugin, "_check_rtk", return_value=False):
+            rtk_plugin.register(ctx)  # Should not raise
+
+
+# ==========================================================================
+# Integration-style tests (no real rtk binary)
+# ==========================================================================
+
+class TestIntegration:
+    def test_full_flow_rewrite_exit_code_3(self):
+        """Simulate the full flow: register -> hook fires -> command rewritten."""
+        registered_hooks = {}
+
+        class FakeCtx:
+            def register_hook(self, name, callback):
+                registered_hooks[name] = callback
+
+        with patch.object(rtk_plugin, "_check_rtk", return_value=True):
+            rtk_plugin.register(FakeCtx())
+
+        assert "pre_tool_call" in registered_hooks
+
+        args = {"command": "cargo test --nocapture"}
+        fake_result = subprocess.CompletedProcess(
+            args=[],
+            returncode=3,
+            stdout="rtk cargo test --nocapture\n",
+            stderr="",
+        )
+        with patch("subprocess.run", return_value=fake_result):
+            registered_hooks["pre_tool_call"](
+                tool_name="terminal", args=args, task_id="t1"
+            )
+
+        assert args["command"] == "rtk cargo test --nocapture"
+
+    def test_full_flow_no_rewrite(self):
+        """Simulate the full flow when rtk has no rewrite for a command."""
+        registered_hooks = {}
+
+        class FakeCtx:
+            def register_hook(self, name, callback):
+                registered_hooks[name] = callback
+
+        with patch.object(rtk_plugin, "_check_rtk", return_value=True):
+            rtk_plugin.register(FakeCtx())
+
+        args = {"command": "echo hello"}
+        fake_result = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="")
+        with patch("subprocess.run", return_value=fake_result):
+            registered_hooks["pre_tool_call"](
+                tool_name="terminal", args=args, task_id="t1"
+            )
+
+        assert args["command"] == "echo hello"
+
+    def test_full_flow_rtk_crashes(self):
+        """If rtk binary crashes, command should pass through unchanged."""
+        registered_hooks = {}
+
+        class FakeCtx:
+            def register_hook(self, name, callback):
+                registered_hooks[name] = callback
+
+        with patch.object(rtk_plugin, "_check_rtk", return_value=True):
+            rtk_plugin.register(FakeCtx())
+
+        args = {"command": "git status"}
+        with patch("subprocess.run", side_effect=OSError("segfault")):
+            registered_hooks["pre_tool_call"](
+                tool_name="terminal", args=args, task_id="t1"
+            )
+
+        assert args["command"] == "git status"

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -4,7 +4,7 @@
 
 **Deployed hook artifacts** — the actual files installed on user machines by `rtk init`. These are shell scripts, TypeScript plugins, and rules files that run outside the Rust binary. They are **thin delegates**: parse agent-specific JSON, call `rtk rewrite` as a subprocess, format agent-specific response. Zero filtering logic lives here.
 
-Owns: per-agent hook scripts and configuration files for 7 supported agents (Claude Code, Copilot, Cursor, Cline, Windsurf, Codex, OpenCode).
+Owns: per-agent hook scripts and configuration files for supported agents such as Claude Code, Copilot, Cursor, Cline, Windsurf, Codex, OpenCode, and Hermes.
 
 Does **not** own: hook installation/uninstallation (that's `src/hooks/init.rs`), the rewrite pattern registry (that's `discover/registry`), or integrity verification (that's `src/hooks/integrity.rs`).
 
@@ -40,6 +40,7 @@ Each agent subdirectory has its own README with hook-specific details:
 - **[`windsurf/`](windsurf/README.md)** — Rules file (prompt-level), `.windsurfrules` workspace-scoped
 - **[`codex/`](codex/README.md)** — Awareness document, `AGENTS.md` integration, `$CODEX_HOME` or `~/.codex/` location
 - **[`opencode/`](opencode/README.md)** — TypeScript plugin, `zx` library, `tool.execute.before` event, in-place mutation
+- **[`../hermes/`](../hermes/README.md)** — Python plugin, `pre_tool_call` hook, in-place args mutation, manual `$HERMES_HOME/plugins/` installation
 
 ## Supported Agents
 
@@ -54,6 +55,7 @@ Each agent subdirectory has its own README with hook-specific details:
 | Windsurf | Custom instructions (rules file) | Prompt-level guidance | N/A |
 | Codex CLI | AGENTS.md / instructions | Prompt-level guidance | N/A |
 | OpenCode | TypeScript plugin (`tool.execute.before`) | In-place mutation | Yes |
+| Hermes | Python plugin (`pre_tool_call`) | In-place mutation | Yes |
 
 ## JSON Formats by Agent
 
@@ -156,6 +158,18 @@ if (rewritten && rewritten !== command) {
 }
 ```
 
+### Hermes (Python Plugin)
+
+Mutates `args["command"]` in-place via the `pre_tool_call` hook:
+```python
+result = subprocess.run(["rtk", "rewrite", command], capture_output=True, text=True, timeout=2)
+rewritten = result.stdout.strip()
+if result.returncode in (0, 3) and rewritten and rewritten != command:
+    args["command"] = rewritten
+```
+
+Hermes support is currently manual: copy the plugin from `hermes/` into `$HERMES_HOME/plugins/rtk-rewrite/`.
+
 ## Command Rewrite Registry
 
 The registry (`src/discover/registry.rs`) handles command patterns across these categories:
@@ -217,7 +231,7 @@ New integrations must follow the [Exit Code Contract](#exit-code-contract) and [
 | Tier | Mechanism | Maintenance | Examples |
 |------|-----------|-------------|----------|
 | **Full hook** | Shell script or Rust binary, intercepts commands via agent's hook API | High — must track agent API changes | Claude Code, Cursor, Copilot, Gemini |
-| **Plugin** | TypeScript/JS plugin in agent's plugin system | Medium — agent manages loading | OpenCode |
+| **Plugin** | TypeScript/JS/Python plugin in agent's plugin system | Medium — agent manages loading | OpenCode, Hermes |
 | **Rules file** | Prompt-level instructions the agent reads | Low — no code to break | Cline, Windsurf, Codex |
 
 ### Eligibility


### PR DESCRIPTION
## Summary
- add initial Hermes plugin files under `hermes/`
- accept `rtk rewrite` exit code `3` as a valid rewrite path
- skip already-rewritten / `RTK_DISABLED=1` commands
- add README + hooks docs for initial Hermes support and manual install
- add Python tests for rewrite behavior and Hermes-specific guards

## Notes
- this is intentionally based on the latest active branch head rather than the older PR #1006 branch
- Hermes support is manual for now; `rtk init` is not wired up yet
- README now explicitly mentions Hermes initial support

## Test Plan
- `uv run --with pytest python -m pytest hermes/test_rtk_plugin.py -q`
- `python3 -m py_compile hermes/__init__.py hermes/test_rtk_plugin.py`
- manual validation: `rtk rewrite 'git status'` emits `rtk git status` with exit code `3` on current builds
