### PR TITLE
feat(cloud): add xh command support

### DIFF
--- a/src/cmds/cloud/xh_cmd.rs
+++ b/src/cmds/cloud/xh_cmd.rs
@@ -1,0 +1,141 @@
+//! Runs xh (modern curl replacement) and auto-compresses JSON responses.
+//!
+//! xh upstream: https://github.com/ducaale/xh
+
+use crate::core::tracking;
+use crate::core::utils::{exit_code_from_output, resolved_command, truncate};
+use crate::json_cmd;
+use anyhow::{Context, Result};
+
+/// Not using run_filtered: on failure, xh can return HTML error pages (404, 500)
+/// that the JSON schema filter would mangle. The early exit skips filtering entirely.
+pub fn run(args: &[String], verbose: u8) -> Result<i32> {
+    let timer = tracking::TimedExecution::start();
+    let mut cmd = resolved_command("xh");
+    // Body-only + no pretty-print so the filter sees raw payload.
+    // Later flags override, so users can still pass --headers / --pretty=all.
+    cmd.arg("--pretty=none");
+    cmd.arg("--body");
+
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    if verbose > 0 {
+        eprintln!("Running: xh --pretty=none --body {}", args.join(" "));
+    }
+
+    let output = cmd.output().context("Failed to run xh")?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Early exit: don't feed HTTP error bodies (HTML 404 etc.) through JSON schema filter
+    if !output.status.success() {
+        let msg = if stderr.trim().is_empty() {
+            stdout.trim().to_string()
+        } else {
+            stderr.trim().to_string()
+        };
+        eprintln!("FAILED: xh {}", msg);
+        return Ok(exit_code_from_output(&output, "xh"));
+    }
+
+    let raw = stdout.to_string();
+
+    // Auto-detect JSON and pipe through filter
+    let filtered = filter_xh_output(&stdout);
+    println!("{}", filtered);
+
+    timer.track(
+        &format!("xh {}", args.join(" ")),
+        &format!("rtk xh {}", args.join(" ")),
+        &raw,
+        &filtered,
+    );
+
+    Ok(0)
+}
+
+fn filter_xh_output(output: &str) -> String {
+    let trimmed = output.trim();
+
+    // Try JSON detection: starts with { or [
+    if (trimmed.starts_with('{') || trimmed.starts_with('['))
+        && (trimmed.ends_with('}') || trimmed.ends_with(']'))
+    {
+        if let Ok(schema) = json_cmd::filter_json_string(trimmed, 5) {
+            // Only use schema if it's actually shorter than the original (#297)
+            if schema.len() <= trimmed.len() {
+                return schema;
+            }
+        }
+    }
+
+    // Not JSON: truncate long output
+    let lines: Vec<&str> = trimmed.lines().collect();
+    if lines.len() > 30 {
+        let mut result: Vec<&str> = lines[..30].to_vec();
+        result.push("");
+        let msg = format!(
+            "... ({} more lines, {} bytes total)",
+            lines.len() - 30,
+            trimmed.len()
+        );
+        return format!("{}\n{}", result.join("\n"), msg);
+    }
+
+    // Short output: return as-is but truncate long lines
+    lines
+        .iter()
+        .map(|l| truncate(l, 200))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_filter_xh_json() {
+        // Large JSON where schema is shorter than original — schema should be returned
+        let output = r#"{"name": "a very long user name here", "count": 42, "items": [1, 2, 3], "description": "a very long description that takes up many characters in the original JSON payload", "status": "active", "url": "https://example.com/api/v1/users/123"}"#;
+        let result = filter_xh_output(output);
+        assert!(result.contains("name"));
+        assert!(result.contains("string"));
+        assert!(result.contains("int"));
+    }
+
+    #[test]
+    fn test_filter_xh_json_array() {
+        let output = r#"[{"id": 1}, {"id": 2}]"#;
+        let result = filter_xh_output(output);
+        assert!(result.contains("id"));
+    }
+
+    #[test]
+    fn test_filter_xh_non_json() {
+        let output = "Hello, World!\nThis is plain text.";
+        let result = filter_xh_output(output);
+        assert!(result.contains("Hello, World!"));
+        assert!(result.contains("plain text"));
+    }
+
+    #[test]
+    fn test_filter_xh_json_small_returns_original() {
+        // Small JSON where schema would be larger than original (issue #297)
+        let output = r#"{"r2Ready":true,"status":"ok"}"#;
+        let result = filter_xh_output(output);
+        assert_eq!(result.trim(), output.trim());
+    }
+
+    #[test]
+    fn test_filter_xh_long_output() {
+        let lines: Vec<String> = (0..50).map(|i| format!("Line {}", i)).collect();
+        let output = lines.join("\n");
+        let result = filter_xh_output(&output);
+        assert!(result.contains("Line 0"));
+        assert!(result.contains("Line 29"));
+        assert!(result.contains("more lines"));
+    }
+}

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -222,6 +222,15 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
+        pattern: r"^xh\s+",
+        rtk_cmd: "rtk xh",
+        rewrite_prefixes: &["xh"],
+        category: "Network",
+        savings_pct: 70.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
+    RtkRule {
         pattern: r"^wget\s+",
         rtk_cmd: "rtk wget",
         rewrite_prefixes: &["wget"],

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod learn;
 mod parser;
 
 // Re-export command modules for routing
-use cmds::cloud::{aws_cmd, container, curl_cmd, psql_cmd, wget_cmd};
+use cmds::cloud::{aws_cmd, container, curl_cmd, psql_cmd, wget_cmd, xh_cmd};
 use cmds::dotnet::{binlog, dotnet_cmd, dotnet_format_report, dotnet_trx};
 use cmds::git::{diff_cmd, gh_cmd, git, gt_cmd};
 use cmds::go::{go_cmd, golangci_cmd};
@@ -517,6 +517,13 @@ enum Commands {
     /// Curl with auto-JSON detection and schema output
     Curl {
         /// Curl arguments (URL + options)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// xh (modern curl replacement) with auto-JSON detection and schema output
+    Xh {
+        /// xh arguments (URL + options)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -1861,6 +1868,8 @@ fn run_cli() -> Result<i32> {
 
         Commands::Curl { args } => curl_cmd::run(&args, cli.verbose)?,
 
+        Commands::Xh { args } => xh_cmd::run(&args, cli.verbose)?,
+
         Commands::Discover {
             project,
             limit,
@@ -2257,6 +2266,7 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Npm { .. }
             | Commands::Npx { .. }
             | Commands::Curl { .. }
+            | Commands::Xh { .. }
             | Commands::Ruff { .. }
             | Commands::Pytest { .. }
             | Commands::Rake { .. }


### PR DESCRIPTION
## Summary
- Adds `rtk xh` subcommand — a filter wrapping `xh` (modern curl replacement at https://github.com/ducaale/xh).
- Mirrors `curl_cmd`: prepends `--pretty=none --body` so the JSON schema filter sees raw payload; early-exits on non-2xx to avoid mangling HTML error pages.
- Registers an `RtkRule` so the PreToolUse hook auto-rewrites bare `xh ...` → `rtk xh ...` (Network category, ~70% est savings).

## Why
Many users (myself + global CLAUDE.md rules from others) already prefer `xh` over `curl`. Today those invocations bypass RTK entirely — `rtk discover` flags them as top "unhandled commands" on sessions where I counted 22 `xh` calls in one session alone.

## Implementation
- `src/cmds/cloud/xh_cmd.rs` — new, 5 unit tests (JSON schema compression, small-JSON passthrough #297, plain text, line truncation, array)
- `src/main.rs` — import, `Commands::Xh` variant, dispatch, read-only matcher entry
- `src/discover/rules.rs` — new `RtkRule` right after the `curl` rule

## Test plan
- [x] `cargo build` — clean (0 errors)
- [x] `cargo fmt` — clean
- [x] `cargo test` — **1355 passed, 0 failed** (5 new)
- [x] End-to-end: `rtk xh https://r.jina.ai/.../users` — 5729 B → 686 B (88% reduction)
- [x] Error path: non-2xx responses bail to `FAILED: xh …` on stderr, no filter corruption

## Notes
- Flag ordering lets users override: since RTK prepends `--pretty=none --body` and xh honors later flags, `rtk xh --headers <url>` still works.
- No change to existing `curl_cmd` behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)