### PR TITLE
fix(openclaw): fix plugin install — add openclaw.extensions, document --dangerously-force-unsafe-install

### DIFF
--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -35,9 +35,15 @@ openclaw gateway restart
 
 ### Or install via OpenClaw CLI
 
+Run from the **repository root** (not inside the `openclaw/` directory):
+
 ```bash
-openclaw plugins install ./openclaw
+openclaw plugins install ./openclaw --dangerously-force-unsafe-install
 ```
+
+The `--dangerously-force-unsafe-install` flag is required because the plugin
+uses `child_process` to call `rtk rewrite`. This is safe: it only shells out
+to the `rtk` binary you installed in the prerequisite step.
 
 ## Configuration
 

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -25,5 +25,8 @@
   ],
   "peerDependencies": {
     "rtk": ">=0.28.0"
+  },
+  "openclaw": {
+    "extensions": ["./index.ts"]
   }
 }


### PR DESCRIPTION
## Problem

Running `openclaw plugins install ./openclaw` (from the repo root) fails with two errors:

```
package.json missing openclaw.extensions; update the plugin package to include openclaw.extensions
  (for example ["./dist/index.js"])
```

And even after that is fixed, the install is blocked because the plugin uses `child_process`:

```
Plugin "rtk-rewrite" installation blocked: dangerous code patterns detected:
  Shell command execution detected (child_process) (openclaw/index.ts:19)
```

## Fix

**1. Add `openclaw.extensions` to `package.json`**

OpenClaw requires this field to locate the plugin entry point. Since OpenClaw handles TypeScript natively, `./index.ts` works directly — no build step needed.

**2. Update `README.md` install instructions**

- Clarify the command must be run from the **repository root**, not inside `openclaw/`
- Document that `--dangerously-force-unsafe-install` is required (the plugin shells out to `rtk rewrite` via `child_process`)
- Explain why this flag is safe to use

## Verified

```
$ openclaw plugins install ./openclaw --dangerously-force-unsafe-install
WARNING: Plugin "rtk-rewrite" contains dangerous code patterns: Shell command execution detected (child_process)
WARNING: Plugin "rtk-rewrite" installation forced despite dangerous code patterns via --dangerously-force-unsafe-install
Installing to /home/.../.openclaw/extensions/rtk-rewrite…
Installed plugin: rtk-rewrite
Restart the gateway to load plugins.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)