### PR TITLE
fix: dotnet cmd test flakiness

### DIFF
--- a/src/cmds/dotnet/dotnet_trx.rs
+++ b/src/cmds/dotnet/dotnet_trx.rs
@@ -565,9 +565,12 @@ mod tests {
         let trx_old = r#"<?xml version="1.0" encoding="utf-8"?>
 <TestRun><ResultSummary><Counters total="2" executed="2" passed="2" failed="0" /></ResultSummary></TestRun>"#;
         std::fs::write(trx_dir.join("old.trx"), trx_old).expect("write old trx");
-        std::thread::sleep(Duration::from_millis(5));
-        let since = SystemTime::now();
-        std::thread::sleep(Duration::from_millis(5));
+
+        std::thread::sleep(Duration::from_millis(10));
+
+        let since = SystemTime::now()
+            .checked_sub(Duration::from_millis(10))
+            .expect("threshold overflow");
 
         let trx_new = r#"<?xml version="1.0" encoding="utf-8"?>
 <TestRun><ResultSummary><Counters total="3" executed="3" passed="2" failed="1" /></ResultSummary></TestRun>"#;


### PR DESCRIPTION
## Summary
Drastically reduce dotnet_cmd test flakiness.
Before I got 1 error for 4 runs, now 1 for 1000 on my machine.

It's not totally fixed but it reduces it a lot.
Another way would be to use std::fs::set_times on old.trx to set its time in the past, but it requires unstable fs_set_times feature, so I didn't go down that path.

## Test plan
- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] Manual testing: `rtk <command>` output inspected
