### PR TITLE
feat(gain): reset tracking stats with --reset --confirm

### DIFF
--- a/docs/guide/analytics/gain.md
+++ b/docs/guide/analytics/gain.md
@@ -29,6 +29,10 @@ rtk gain --quota -t pro   # quota analysis (pro/5x/20x tiers)
 # Export
 rtk gain --all --format json > savings.json
 rtk gain --all --format csv  > savings.csv
+
+# Reset local statistics (requires explicit confirmation)
+rtk gain --reset --confirm           # same as -y / --yes
+rtk gain --project --reset -y      # current repo only (commands table)
 ```
 
 ## Daily breakdown
@@ -127,9 +131,24 @@ sqlite3 ~/.local/share/rtk/history.db \
 # Backup
 cp ~/.local/share/rtk/history.db ~/backups/rtk-history-$(date +%Y%m%d).db
 
-# Reset
-rm ~/.local/share/rtk/history.db    # recreated on next command
+# Reset (built-in)
+rtk gain --reset --confirm          # deletes all command + parse-failure rows
+rtk gain --project --reset --confirm  # deletes command rows for cwd project only
+
+# Reset (manual — removes entire DB file; recreated on next RTK run)
+rm ~/.local/share/rtk/history.db
 ```
+
+### `rtk gain --reset`
+
+Deletes rows in the local SQLite database. **You must pass `--confirm`, `-y`, or `--yes` together with `--reset`** so the operation cannot run by accident.
+
+| Invocation | Effect |
+|------------|--------|
+| `rtk gain --reset --confirm` | Clears **all** `commands` and **all** `parse_failures`. |
+| `rtk gain --project --reset --confirm` | Clears **only** `commands` whose recorded `project_path` is this directory or a subdirectory. Parse failures are **not** removed (that log is not project-scoped). |
+
+After a reset, the next tracked command recreates aggregates from new data only.
 
 ## Analysis workflows
 

--- a/docs/usage/AUDIT_GUIDE.md
+++ b/docs/usage/AUDIT_GUIDE.md
@@ -317,9 +317,13 @@ sqlite3 ~/.local/share/rtk/history.db .dump > rtk-backup.sql
 sqlite3 ~/.local/share/rtk/history.db \
   "DELETE FROM commands WHERE timestamp < datetime('now', '-90 days')"
 
-# Reset all data
+# Reset via CLI (preferred)
+rtk gain --reset --confirm
+# Project-scoped command history only:
+# rtk gain --project --reset --confirm
+
+# Reset all data (delete DB file; next rtk run recreates it)
 rm ~/.local/share/rtk/history.db
-# Next rtk command will recreate database
 ```
 
 ## Integration Examples

--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -1072,6 +1072,7 @@ rtk gain --monthly              # Ventilation par mois
 rtk gain --all                  # Toutes les ventilations
 rtk gain --quota -t pro         # Estimation d'economies sur le quota mensuel
 rtk gain --failures             # Log des echecs de parsing (commandes en fallback)
+rtk gain --reset --confirm      # Effacer stats locales (-y / --yes)
 rtk gain --format json          # Export JSON (pour dashboards)
 rtk gain --format csv           # Export CSV
 ```

--- a/src/analytics/gain.rs
+++ b/src/analytics/gain.rs
@@ -24,10 +24,39 @@ pub fn run(
     all: bool,
     format: &str,
     failures: bool,
+    reset: bool,
+    confirm: bool,
     _verbose: u8,
 ) -> Result<()> {
     let tracker = Tracker::new().context("Failed to initialize tracking database")?;
     let project_scope = resolve_project_scope(project)?; // added: resolve project path
+
+    if reset {
+        if !confirm {
+            anyhow::bail!(
+                "Refusing to reset tracking data without --confirm (-y).\n\
+                 Examples:\n\
+                   rtk gain --reset --confirm\n\
+                   rtk gain --project --reset --confirm"
+            );
+        }
+        if let Some(ref root) = project_scope {
+            let n = tracker
+                .reset_project_commands(root)
+                .context("Failed to delete project-scoped command rows")?;
+            println!("Deleted {} command row(s) for this project.", n);
+            println!("Note: parse failure rows are global and were not removed.");
+        } else {
+            let (n_cmd, n_pf) = tracker
+                .reset_all()
+                .context("Failed to reset tracking database")?;
+            println!(
+                "Deleted {} command row(s) and {} parse failure row(s).",
+                n_cmd, n_pf
+            );
+        }
+        return Ok(());
+    }
 
     if failures {
         return show_failures(&tracker);

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -398,6 +398,31 @@ impl Tracker {
         Ok(())
     }
 
+    /// Delete all command history and parse-failure rows.
+    ///
+    /// Returns `(commands_deleted, parse_failures_deleted)` as reported by SQLite.
+    pub fn reset_all(&self) -> Result<(usize, usize)> {
+        let commands_deleted = self.conn.execute("DELETE FROM commands", [])?;
+        let failures_deleted = self.conn.execute("DELETE FROM parse_failures", [])?;
+        Ok((commands_deleted, failures_deleted))
+    }
+
+    /// Delete command rows for one project tree (exact `project_path` or subdirectory).
+    ///
+    /// Uses the same path matching rules as [`Tracker::get_summary_filtered`]. The
+    /// `parse_failures` table is not scoped by project and is left unchanged.
+    pub fn reset_project_commands(&self, project_root: &str) -> Result<usize> {
+        let (exact, glob) = project_filter_params(Some(project_root));
+        let (Some(exact), Some(glob)) = (exact, glob) else {
+            anyhow::bail!("internal: project filter params");
+        };
+        let n = self.conn.execute(
+            "DELETE FROM commands WHERE project_path = ?1 OR project_path GLOB ?2",
+            params![exact, glob],
+        )?;
+        Ok(n)
+    }
+
     /// Record a parse failure for analytics.
     pub fn record_parse_failure(
         &self,
@@ -1583,5 +1608,80 @@ mod tests {
         // We can't assert exact rate because other tests may have added records,
         // but we can verify recovery_rate is between 0 and 100
         assert!(summary.recovery_rate >= 0.0 && summary.recovery_rate <= 100.0);
+    }
+
+    // 14. reset_all clears commands and parse_failures (isolated DB)
+    #[test]
+    fn test_reset_all_clears_commands_and_failures() {
+        use std::env;
+
+        let tmp = env::temp_dir().join(format!("rtk_reset_all_{}.db", std::process::id()));
+        let _ = std::fs::remove_file(&tmp);
+        env::set_var("RTK_DB_PATH", &tmp);
+
+        let tracker = Tracker::new().expect("tracker");
+        let pid = std::process::id();
+        tracker
+            .record("oc", &format!("rtk_reset_cmd_{}", pid), 10, 5, 1)
+            .unwrap();
+        tracker
+            .record_parse_failure(&format!("raw_{}", pid), "err", true)
+            .unwrap();
+
+        let (nc, nf) = tracker.reset_all().unwrap();
+        assert!(nc >= 1);
+        assert!(nf >= 1);
+        assert_eq!(tracker.get_summary().unwrap().total_commands, 0);
+        assert_eq!(tracker.get_parse_failure_summary().unwrap().total, 0);
+
+        env::remove_var("RTK_DB_PATH");
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    // 15. reset_project_commands keeps other projects' rows
+    #[test]
+    fn test_reset_project_commands_scoped() {
+        use std::env;
+
+        let tmp = env::temp_dir().join(format!("rtk_reset_proj_{}.db", std::process::id()));
+        let _ = std::fs::remove_file(&tmp);
+        env::set_var("RTK_DB_PATH", &tmp);
+
+        let base = tempfile::tempdir().expect("tempdir");
+        let proj_a = base.path().join("repo_a");
+        let proj_b = base.path().join("repo_b");
+        std::fs::create_dir_all(&proj_a).unwrap();
+        std::fs::create_dir_all(&proj_b).unwrap();
+        let canon_a = proj_a.canonicalize().unwrap();
+        let canon_b = proj_b.canonicalize().unwrap();
+
+        let old_cwd = env::current_dir().unwrap();
+        let tracker = Tracker::new().expect("tracker");
+        env::set_current_dir(&proj_a).unwrap();
+        tracker
+            .record("a1", "rtk_a", 10, 5, 1)
+            .expect("record in a");
+        env::set_current_dir(&proj_b).unwrap();
+        tracker
+            .record("b1", "rtk_b", 10, 5, 1)
+            .expect("record in b");
+
+        let n = tracker
+            .reset_project_commands(&canon_a.to_string_lossy())
+            .unwrap();
+        assert_eq!(n, 1);
+
+        let s_a = tracker
+            .get_summary_filtered(Some(&canon_a.to_string_lossy()))
+            .unwrap();
+        assert_eq!(s_a.total_commands, 0);
+        let s_b = tracker
+            .get_summary_filtered(Some(&canon_b.to_string_lossy()))
+            .unwrap();
+        assert_eq!(s_b.total_commands, 1);
+
+        env::set_current_dir(old_cwd).unwrap();
+        env::remove_var("RTK_DB_PATH");
+        let _ = std::fs::remove_file(&tmp);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -412,6 +412,12 @@ enum Commands {
         /// Show parse failure log (commands that fell back to raw execution)
         #[arg(short = 'F', long)]
         failures: bool,
+        /// Delete tracking rows from the local database (requires --confirm / -y)
+        #[arg(long)]
+        reset: bool,
+        /// Confirm `--reset` (safety guard; same as `-y` / `--yes`)
+        #[arg(long, short = 'y', visible_alias = "yes", requires = "reset")]
+        confirm: bool,
     },
 
     /// Claude Code economics: spending (ccusage) vs savings (rtk) analysis
@@ -1746,6 +1752,8 @@ fn run_cli() -> Result<i32> {
             all,
             format,
             failures,
+            reset,
+            confirm,
         } => {
             analytics::gain::run(
                 project, // added: pass project flag
@@ -1759,6 +1767,8 @@ fn run_cli() -> Result<i32> {
                 all,
                 &format,
                 failures,
+                reset,
+                confirm,
                 cli.verbose,
             )?;
             0
@@ -2473,6 +2483,34 @@ mod tests {
                 _ => panic!("Expected Gain command"),
             }
         }
+    }
+
+    #[test]
+    fn test_gain_reset_confirm_parses() {
+        for args in [
+            vec!["rtk", "gain", "--reset", "--confirm"],
+            vec!["rtk", "gain", "--reset", "-y"],
+            vec!["rtk", "gain", "--reset", "--yes"],
+        ] {
+            let label = format!("{args:?}");
+            let result = Cli::try_parse_from(args);
+            assert!(result.is_ok(), "args {label} should parse");
+            if let Ok(cli) = result {
+                match cli.command {
+                    Commands::Gain { reset, confirm, .. } => {
+                        assert!(reset);
+                        assert!(confirm);
+                    }
+                    _ => panic!("Expected Gain command"),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_gain_confirm_without_reset_rejected() {
+        let result = Cli::try_parse_from(["rtk", "gain", "--confirm"]);
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a safe way to clear local `rtk gain` statistics without deleting the database file manually.

## Usage

- `rtk gain --reset --confirm` (or `-y` / `--yes`) — deletes all rows in `commands` and `parse_failures`.
- `rtk gain --project --reset --confirm` — deletes only `commands` rows for the current working directory (same path rules as `--project` views). Parse failures are global and are not removed in project scope.

`--reset` without confirmation exits with an error message (no data loss).

## Implementation

- `Tracker::reset_all` / `Tracker::reset_project_commands` in `tracking.rs`
- CLI flags on `Gain`: `--reset`, `--confirm` with `requires = "reset"` for `-y`
- Docs: `docs/guide/analytics/gain.md`, `AUDIT_GUIDE.md`, `FEATURES.md`
- Unit tests for SQLite reset and Clap parsing

## Verification

`cargo fmt --all && cargo clippy --all-targets && cargo test --all`