### PR TITLE
feat(discover): unify multi-provider session discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,10 +246,10 @@ rtk gain --history              # Recent command history
 rtk gain --daily                # Day-by-day breakdown
 rtk gain --all --format json    # JSON export for dashboards
 
-rtk discover                    # Find missed savings opportunities
+rtk discover                    # Find missed savings opportunities from session history
 rtk discover --all --since 7    # All projects, last 7 days
 
-rtk session                     # Show RTK adoption across recent sessions
+rtk session                     # Show RTK adoption across recent Claude/OpenCode sessions
 ```
 
 ## Global Flags

--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -1112,7 +1112,7 @@ Top commands:
 
 ### `rtk discover` -- Opportunites manquees
 
-**Objectif :** Analyse l'historique Claude Code pour trouver les commandes qui auraient pu etre optimisees par rtk.
+**Objectif :** Analyse l'historique Claude Code/OpenCode pour trouver les commandes qui auraient pu etre optimisees par rtk.
 
 ```bash
 rtk discover                          # Projet courant, 30 derniers jours
@@ -1136,7 +1136,7 @@ rtk discover --format json            # Export JSON
 
 ### `rtk learn` -- Apprendre des erreurs
 
-**Objectif :** Analyse l'historique d'erreurs CLI de Claude Code pour detecter les corrections recurrentes.
+**Objectif :** Analyse l'historique d'erreurs CLI de Claude Code/OpenCode pour detecter les corrections recurrentes.
 
 ```bash
 rtk learn                             # Projet courant

--- a/hooks/claude/rtk-awareness.md
+++ b/hooks/claude/rtk-awareness.md
@@ -7,7 +7,7 @@
 ```bash
 rtk gain              # Show token savings analytics
 rtk gain --history    # Show command usage history with savings
-rtk discover          # Analyze Claude Code history for missed opportunities
+rtk discover          # Analyze Claude Code/OpenCode history for missed opportunities
 rtk proxy <cmd>       # Execute raw command without filtering (for debugging)
 ```
 

--- a/src/analytics/README.md
+++ b/src/analytics/README.md
@@ -6,7 +6,7 @@
 
 **Read-only dashboards** over the tracking database. Queries token savings, correlates with external spending data, and surfaces adoption metrics. Never modifies the tracking DB.
 
-Owns: `rtk gain` (savings dashboard), `rtk cc-economics` (cost reduction), `rtk session` (adoption analysis), and Claude Code usage data parsing.
+Owns: `rtk gain` (savings dashboard), `rtk cc-economics` (cost reduction), `rtk session` (adoption analysis), and Claude Code/OpenCode/Codex CLI/Copilot CLI usage data parsing.
 
 Does **not** own: recording token savings (that's `core/tracking` called by `cmds/`), or command filtering itself (that's `cmds/`).
 

--- a/src/analytics/session_cmd.rs
+++ b/src/analytics/session_cmd.rs
@@ -1,11 +1,12 @@
 //! Compares RTK-routed vs raw commands in a coding session.
 
 use crate::core::utils::format_tokens;
-use crate::discover::provider::{ClaudeProvider, ExtractedCommand, SessionProvider};
+use crate::discover::provider::{
+    discover_provider_sessions, extract_commands_for_session, supported_providers_display,
+    DiscoveredSession, ExtractedCommand, ProviderId,
+};
 use crate::discover::registry::{classify_command, split_command_chain, Classification};
-use anyhow::{Context, Result};
-use std::fs;
-use std::path::PathBuf;
+use anyhow::Result;
 
 /// A summarized session for display.
 struct SessionSummary {
@@ -56,46 +57,74 @@ fn progress_bar(pct: f64, width: usize) -> String {
     format!("{}{}", "@".repeat(filled), ".".repeat(empty))
 }
 
-pub fn run(_verbose: u8) -> Result<()> {
-    let provider = ClaudeProvider;
-    let sessions = provider
-        .discover_sessions(None, Some(30))
-        .context("Failed to discover Claude Code sessions")?;
+fn session_updated_unix(session: &DiscoveredSession) -> i64 {
+    session.updated_unix
+}
 
-    if sessions.is_empty() {
-        println!("No Claude Code sessions found in the last 30 days.");
-        println!("Make sure Claude Code has been used at least once.");
+fn format_relative_date(unix_ts: i64) -> String {
+    if unix_ts <= 0 {
+        return "?".to_string();
+    }
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64;
+    let delta = (now - unix_ts).max(0) as u64;
+    let days = delta / 86400;
+    if days == 0 {
+        "Today".to_string()
+    } else if days == 1 {
+        "Yesterday".to_string()
+    } else {
+        format!("{}d ago", days)
+    }
+}
+
+pub fn run(_verbose: u8) -> Result<()> {
+    let discovery = discover_provider_sessions(None, Some(30));
+
+    if discovery.available_sources == 0 {
+        anyhow::bail!(
+            "Failed to discover sessions from {}",
+            supported_providers_display()
+        );
+    }
+
+    if discovery.sessions.is_empty() {
+        println!("No sessions found in the last 30 days.");
+        println!(
+            "Make sure {} has been used at least once.",
+            supported_providers_display()
+        );
         return Ok(());
     }
 
-    // Group JSONL files by parent session (ignore subagent files)
-    let mut session_files: Vec<PathBuf> = sessions
+    // Group JSONL files by parent session (ignore Claude subagent files)
+    let mut sessions: Vec<DiscoveredSession> = discovery
+        .sessions
         .into_iter()
-        .filter(|p| {
-            // Skip subagent files — only top-level session JSONL
-            !p.to_string_lossy().contains("subagents")
+        .filter(|session| {
+            !(session.provider == ProviderId::ClaudeCode
+                && session.path.to_string_lossy().contains("subagents"))
         })
         .collect();
 
-    // Sort by mtime desc
-    session_files.sort_by(|a, b| {
-        let ma = fs::metadata(a)
-            .and_then(|m| m.modified())
-            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-        let mb = fs::metadata(b)
-            .and_then(|m| m.modified())
-            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-        mb.cmp(&ma)
+    // Sort by updated time desc for every provider.
+    sessions.sort_by(|a, b| {
+        let ta = session_updated_unix(a);
+        let tb = session_updated_unix(b);
+        tb.cmp(&ta)
     });
 
     // Take top 10
-    session_files.truncate(10);
+    sessions.truncate(10);
 
     let mut summaries: Vec<SessionSummary> = Vec::new();
 
-    for path in &session_files {
-        let cmds = match provider.extract_commands(path) {
-            Ok(c) => c,
+    for session in &sessions {
+        let cmds = match extract_commands_for_session(session) {
+            Ok(commands) => commands,
             Err(_) => continue,
         };
 
@@ -105,33 +134,18 @@ pub fn run(_verbose: u8) -> Result<()> {
 
         let (total_cmds, rtk_cmds, output_tokens) = count_rtk_commands(&cmds);
 
-        // Extract session ID from filename
-        let id = path
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("unknown");
-        let short_id = if id.len() > 8 { &id[..8] } else { id };
+        let id = session.session_id.clone();
+        let short_id = if id.len() > 8 {
+            id[..8].to_string()
+        } else {
+            id
+        };
 
-        // Extract date from mtime
-        let date = fs::metadata(path)
-            .and_then(|m| m.modified())
-            .map(|t| {
-                let elapsed = std::time::SystemTime::now()
-                    .duration_since(t)
-                    .unwrap_or_default();
-                let days = elapsed.as_secs() / 86400;
-                if days == 0 {
-                    "Today".to_string()
-                } else if days == 1 {
-                    "Yesterday".to_string()
-                } else {
-                    format!("{}d ago", days)
-                }
-            })
-            .unwrap_or_else(|_| "?".to_string());
+        let updated_unix = session_updated_unix(session);
+        let date = format_relative_date(updated_unix);
 
         summaries.push(SessionSummary {
-            id: short_id.to_string(),
+            id: short_id,
             date,
             total_cmds,
             rtk_cmds,
@@ -191,7 +205,7 @@ pub fn run(_verbose: u8) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::discover::provider::ExtractedCommand;
+    use crate::discover::provider::{ClaudeProvider, ExtractedCommand, SessionProvider};
     use std::io::Write;
     use tempfile::NamedTempFile;
 

--- a/src/discover/README.md
+++ b/src/discover/README.md
@@ -41,9 +41,9 @@ When a hook sends `cargo fmt --all && cargo test 2>&1 | tail -20`:
 
 ## How History Analysis Works
 
-`rtk discover` reads Claude Code JSONL session files. Each file contains `tool_use`/`tool_result` pairs for every command the LLM ran. The module:
+`rtk discover` reads Claude Code JSONL sessions, OpenCode SQLite sessions, Codex CLI rollout JSONL sessions, and Copilot CLI events JSONL sessions. The module:
 
-1. Extracts commands from the JSONL (via `SessionProvider` trait — currently only Claude Code)
+1. Extracts commands via `SessionProvider` implementations (Claude Code, OpenCode, Codex CLI, Copilot CLI)
 2. Splits compound commands using the same lexer-based tokenization
 3. Classifies each command against the same rules used for live rewriting
 4. Aggregates results: which commands could have been rewritten, estimated token savings, adoption rate

--- a/src/discover/mod.rs
+++ b/src/discover/mod.rs
@@ -9,7 +9,9 @@ pub mod rules;
 use anyhow::Result;
 use std::collections::HashMap;
 
-use provider::{ClaudeProvider, SessionProvider};
+use provider::{
+    discover_provider_sessions, extract_commands_for_session, supported_providers_display,
+};
 use registry::{
     category_avg_tokens, classify_command, has_rtk_disabled_prefix, split_command_chain,
     strip_disabled_prefix, Classification,
@@ -41,8 +43,6 @@ pub fn run(
     format: &str,
     verbose: u8,
 ) -> Result<()> {
-    let provider = ClaudeProvider;
-
     // Determine project filter
     let project_filter = if all {
         None
@@ -51,17 +51,36 @@ pub fn run(
     } else {
         // Default: current working directory
         let cwd = std::env::current_dir()?;
-        let cwd_str = cwd.to_string_lossy().to_string();
-        let encoded = ClaudeProvider::encode_project_path(&cwd_str);
-        Some(encoded)
+        Some(cwd.to_string_lossy().to_string())
     };
 
-    let sessions = provider.discover_sessions(project_filter.as_deref(), Some(since_days))?;
+    let discovery = discover_provider_sessions(project_filter.as_deref(), Some(since_days));
 
     if verbose > 0 {
-        eprintln!("Scanning {} session files...", sessions.len());
-        for s in &sessions {
-            eprintln!("  {}", s.display());
+        for (provider, error) in &discovery.unavailable_sources {
+            eprintln!(
+                "Warning: {} sessions unavailable: {}",
+                provider.display_name(),
+                error
+            );
+        }
+    }
+
+    if discovery.available_sources == 0 {
+        anyhow::bail!(
+            "No session sources available. Use {} at least once, then rerun discover.",
+            supported_providers_display(),
+        );
+    }
+
+    if verbose > 0 {
+        eprintln!("Scanning {} session files...", discovery.sessions.len());
+        for session in &discovery.sessions {
+            eprintln!(
+                "  [{}] {}",
+                session.provider.display_name(),
+                session.path.display()
+            );
         }
     }
 
@@ -73,12 +92,12 @@ pub fn run(
     let mut supported_map: HashMap<&'static str, SupportedBucket> = HashMap::new();
     let mut unsupported_map: HashMap<String, UnsupportedBucket> = HashMap::new();
 
-    for session_path in &sessions {
-        let extracted = match provider.extract_commands(session_path) {
+    for session in &discovery.sessions {
+        let extracted = match extract_commands_for_session(session) {
             Ok(cmds) => cmds,
             Err(e) => {
                 if verbose > 0 {
-                    eprintln!("Warning: skipping {}: {}", session_path.display(), e);
+                    eprintln!("Warning: skipping {}: {}", session.path.display(), e);
                 }
                 parse_errors += 1;
                 continue;
@@ -235,7 +254,7 @@ pub fn run(
     };
 
     let report = DiscoverReport {
-        sessions_scanned: sessions.len(),
+        sessions_scanned: discovery.sessions.len(),
         total_commands,
         already_rtk,
         since_days,

--- a/src/discover/provider.rs
+++ b/src/discover/provider.rs
@@ -1,13 +1,212 @@
-//! Reads Claude Code session logs from disk and streams their command history.
+//! Reads agent session logs and streams their command history.
 
 use crate::hooks::constants::CLAUDE_DIR;
 use anyhow::{Context, Result};
+use chrono::DateTime;
 use std::collections::HashMap;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 use walkdir::WalkDir;
+
+const OPENCODE_DB_RELATIVE_PATH: &str = ".local/share/opencode/opencode.db";
+const OPENCODE_SESSION_PREFIX: &str = "opencode-session:";
+const CODEX_SESSIONS_RELATIVE_PATH: &str = ".codex/sessions";
+const COPILOT_SESSIONS_RELATIVE_PATH: &str = ".copilot/session-state";
+const CODEX_ROLLOUT_PREFIX: &str = "rollout-";
+const COPILOT_EVENTS_FILE: &str = "events.jsonl";
+
+const CODEX_TIMESTAMP_POINTERS: [&str; 3] =
+    ["/timestamp", "/payload/timestamp", "/payload/created_at"];
+const COPILOT_START_TIMESTAMP_POINTERS: [&str; 3] = ["/startTime", "/data/startTime", "/timestamp"];
+const COPILOT_OUTPUT_POINTERS: [&str; 8] = [
+    "/data/output",
+    "/output",
+    "/data/result/content",
+    "/result/content",
+    "/data/result/output",
+    "/result/output",
+    "/data/result",
+    "/result",
+];
+
+const SUPPORTED_PROVIDERS: [ProviderId; 4] = [
+    ProviderId::ClaudeCode,
+    ProviderId::OpenCode,
+    ProviderId::CodexCli,
+    ProviderId::CopilotCli,
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ProviderId {
+    ClaudeCode,
+    OpenCode,
+    CodexCli,
+    CopilotCli,
+}
+
+impl ProviderId {
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            ProviderId::ClaudeCode => "Claude Code",
+            ProviderId::OpenCode => "OpenCode",
+            ProviderId::CodexCli => "Codex CLI",
+            ProviderId::CopilotCli => "Copilot CLI",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DiscoveredSession {
+    pub provider: ProviderId,
+    pub session_id: String,
+    pub path: PathBuf,
+    pub updated_unix: i64,
+}
+
+#[derive(Debug, Default)]
+pub struct ProviderDiscovery {
+    pub sessions: Vec<DiscoveredSession>,
+    pub available_sources: usize,
+    pub unavailable_sources: Vec<(ProviderId, String)>,
+}
+
+pub fn all_provider_ids() -> &'static [ProviderId] {
+    &SUPPORTED_PROVIDERS
+}
+
+pub fn supported_providers_display() -> &'static str {
+    "Claude Code, OpenCode, Codex CLI, Copilot CLI"
+}
+
+pub fn discover_provider_sessions(
+    project_filter: Option<&str>,
+    since_days: Option<u64>,
+) -> ProviderDiscovery {
+    let mut discovery = ProviderDiscovery::default();
+
+    for provider_id in all_provider_ids() {
+        let result = match *provider_id {
+            ProviderId::ClaudeCode => {
+                ClaudeProvider.discover_with_metadata(project_filter, since_days)
+            }
+            ProviderId::OpenCode => {
+                OpenCodeProvider::default().discover_with_metadata(project_filter, since_days)
+            }
+            ProviderId::CodexCli => {
+                CodexProvider.discover_with_metadata(project_filter, since_days)
+            }
+            ProviderId::CopilotCli => {
+                CopilotCliProvider.discover_with_metadata(project_filter, since_days)
+            }
+        };
+
+        match result {
+            Ok(mut sessions) => {
+                discovery.available_sources += 1;
+                discovery.sessions.append(&mut sessions);
+            }
+            Err(error) => {
+                discovery
+                    .unavailable_sources
+                    .push((*provider_id, error.to_string()));
+            }
+        }
+    }
+
+    discovery
+}
+
+pub fn extract_commands_for_session(session: &DiscoveredSession) -> Result<Vec<ExtractedCommand>> {
+    match session.provider {
+        ProviderId::ClaudeCode => ClaudeProvider.extract_commands(&session.path),
+        ProviderId::OpenCode => OpenCodeProvider::default().extract_commands(&session.path),
+        ProviderId::CodexCli => CodexProvider.extract_commands(&session.path),
+        ProviderId::CopilotCli => CopilotCliProvider.extract_commands(&session.path),
+    }
+}
+
+fn cutoff_unix_seconds(since_days: Option<u64>) -> Option<i64> {
+    since_days.map(|days| {
+        let cutoff = SystemTime::now()
+            .checked_sub(Duration::from_secs(days * 86400))
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        cutoff
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64
+    })
+}
+
+fn system_time_to_unix_seconds(time: SystemTime) -> i64 {
+    time.duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+fn file_mtime_unix_seconds(path: &Path) -> i64 {
+    fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .map(system_time_to_unix_seconds)
+        .unwrap_or(0)
+}
+
+fn json_string(value: &serde_json::Value, pointer: &str) -> Option<String> {
+    value
+        .pointer(pointer)
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+}
+
+fn json_unix_timestamp(value: &serde_json::Value, pointer: &str) -> Option<i64> {
+    value.pointer(pointer).and_then(value_to_unix_seconds)
+}
+
+fn json_text(value: &serde_json::Value, pointer: &str) -> Option<String> {
+    value.pointer(pointer).and_then(|v| {
+        if v.is_null() {
+            None
+        } else if let Some(text) = v.as_str() {
+            Some(text.to_string())
+        } else {
+            Some(v.to_string())
+        }
+    })
+}
+
+fn first_json_text(value: &serde_json::Value, pointers: &[&str]) -> Option<String> {
+    pointers
+        .iter()
+        .find_map(|pointer| json_text(value, pointer))
+}
+
+fn first_json_unix_timestamp(value: &serde_json::Value, pointers: &[&str]) -> Option<i64> {
+    pointers
+        .iter()
+        .find_map(|pointer| json_unix_timestamp(value, pointer))
+}
+
+fn value_to_i64(value: &serde_json::Value) -> Option<i64> {
+    if let Some(v) = value.as_i64() {
+        return Some(v);
+    }
+    if let Some(v) = value.as_u64() {
+        return Some(v as i64);
+    }
+    value.as_str().and_then(|s| s.parse::<i64>().ok())
+}
+
+fn value_to_unix_seconds(value: &serde_json::Value) -> Option<i64> {
+    value_to_i64(value)
+        .map(OpenCodeProvider::to_unix_seconds)
+        .or_else(|| {
+            value
+                .as_str()
+                .and_then(|text| DateTime::parse_from_rfc3339(text).ok())
+                .map(|parsed| parsed.timestamp())
+        })
+}
 
 /// A command extracted from a session file.
 #[derive(Debug)]
@@ -41,6 +240,10 @@ pub trait SessionProvider {
 
 pub struct ClaudeProvider;
 
+pub struct CodexProvider;
+
+pub struct CopilotCliProvider;
+
 impl ClaudeProvider {
     /// Get the base directory for Claude Code projects.
     fn projects_dir() -> Result<PathBuf> {
@@ -59,6 +262,132 @@ impl ClaudeProvider {
     /// `/Users/foo/bar` → `-Users-foo-bar`
     pub fn encode_project_path(path: &str) -> String {
         path.replace('/', "-")
+    }
+
+    fn discover_with_metadata(
+        &self,
+        project_filter: Option<&str>,
+        since_days: Option<u64>,
+    ) -> Result<Vec<DiscoveredSession>> {
+        let paths = self.discover_sessions(project_filter, since_days)?;
+        let mut sessions = Vec::with_capacity(paths.len());
+
+        for path in paths {
+            let session_id = path
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .unwrap_or("unknown")
+                .to_string();
+
+            sessions.push(DiscoveredSession {
+                provider: ProviderId::ClaudeCode,
+                session_id,
+                updated_unix: file_mtime_unix_seconds(&path),
+                path,
+            });
+        }
+
+        Ok(sessions)
+    }
+}
+
+#[derive(Default)]
+pub struct OpenCodeProvider {
+    db_path: Option<PathBuf>,
+}
+
+#[derive(Debug)]
+struct OpenCodePartRow {
+    key: String,
+    time_updated: i64,
+    command: String,
+    output: Option<String>,
+    error_output: Option<String>,
+    status: Option<String>,
+}
+
+impl OpenCodeProvider {
+    fn db_path(&self) -> Result<PathBuf> {
+        if let Some(path) = &self.db_path {
+            return Ok(path.clone());
+        }
+
+        let home = dirs::home_dir().context("could not determine home directory")?;
+        let path = home.join(OPENCODE_DB_RELATIVE_PATH);
+
+        if !path.exists() {
+            anyhow::bail!(
+                "OpenCode database not found: {}\nMake sure OpenCode has been used at least once.",
+                path.display()
+            );
+        }
+
+        Ok(path)
+    }
+
+    fn session_path_from_id(id: &str) -> PathBuf {
+        PathBuf::from(format!("{}{}", OPENCODE_SESSION_PREFIX, id))
+    }
+
+    fn session_id_from_path(path: &Path) -> Option<String> {
+        let raw = path.to_string_lossy();
+        raw.strip_prefix(OPENCODE_SESSION_PREFIX)
+            .map(str::to_string)
+    }
+
+    fn to_unix_seconds(ts: i64) -> i64 {
+        if ts > 1_000_000_000_000 {
+            ts / 1000
+        } else {
+            ts
+        }
+    }
+
+    fn discover_with_metadata(
+        &self,
+        project_filter: Option<&str>,
+        since_days: Option<u64>,
+    ) -> Result<Vec<DiscoveredSession>> {
+        let db_path = self.db_path()?;
+        let conn = rusqlite::Connection::open(&db_path)
+            .with_context(|| format!("failed to open {}", db_path.display()))?;
+
+        let cutoff_unix = cutoff_unix_seconds(since_days);
+
+        let mut stmt = conn.prepare("SELECT id, directory, time_updated FROM session")?;
+        let rows = stmt.query_map([], |row| {
+            let id: String = row.get(0)?;
+            let directory: String = row.get(1)?;
+            let time_updated: i64 = row.get(2)?;
+            Ok((id, directory, time_updated))
+        })?;
+
+        let mut sessions = Vec::new();
+        for row in rows {
+            let (id, directory, time_updated) = row?;
+            let updated_unix = OpenCodeProvider::to_unix_seconds(time_updated);
+
+            if let Some(filter) = project_filter {
+                if !directory.contains(filter) {
+                    continue;
+                }
+            }
+
+            if let Some(cutoff) = cutoff_unix {
+                if updated_unix < cutoff {
+                    continue;
+                }
+            }
+
+            sessions.push(DiscoveredSession {
+                provider: ProviderId::OpenCode,
+                session_id: id.clone(),
+                path: OpenCodeProvider::session_path_from_id(&id),
+                updated_unix,
+            });
+        }
+
+        Ok(sessions)
     }
 }
 
@@ -90,7 +419,8 @@ impl SessionProvider for ClaudeProvider {
             // Apply project filter: substring match on directory name
             if let Some(filter) = project_filter {
                 let dir_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-                if !dir_name.contains(filter) {
+                let encoded_filter = ClaudeProvider::encode_project_path(filter);
+                if !dir_name.contains(filter) && !dir_name.contains(&encoded_filter) {
                     continue;
                 }
             }
@@ -242,10 +572,577 @@ impl SessionProvider for ClaudeProvider {
     }
 }
 
+impl CodexProvider {
+    fn sessions_dir() -> Result<PathBuf> {
+        let home = dirs::home_dir().context("could not determine home directory")?;
+        let dir = home.join(CODEX_SESSIONS_RELATIVE_PATH);
+        if !dir.exists() {
+            anyhow::bail!(
+                "Codex CLI sessions directory not found: {}\nMake sure Codex CLI has been used at least once.",
+                dir.display()
+            );
+        }
+        Ok(dir)
+    }
+
+    fn parse_discovery_metadata(path: &Path) -> (Option<String>, Option<i64>) {
+        let file = match fs::File::open(path) {
+            Ok(file) => file,
+            Err(_) => return (None, None),
+        };
+
+        let reader = BufReader::new(file);
+        let mut cwd = None;
+        let mut latest_unix: Option<i64> = None;
+
+        for line in reader.lines().map_while(|line| line.ok()) {
+            let entry: serde_json::Value = match serde_json::from_str(&line) {
+                Ok(value) => value,
+                Err(_) => continue,
+            };
+
+            if entry.get("type").and_then(|t| t.as_str()) == Some("session_meta") && cwd.is_none() {
+                cwd = json_string(&entry, "/payload/cwd");
+            }
+
+            if let Some(unix_ts) = first_json_unix_timestamp(&entry, &CODEX_TIMESTAMP_POINTERS) {
+                latest_unix = Some(latest_unix.map_or(unix_ts, |current| current.max(unix_ts)));
+            }
+        }
+
+        (cwd, latest_unix)
+    }
+
+    fn discover_with_metadata(
+        &self,
+        project_filter: Option<&str>,
+        since_days: Option<u64>,
+    ) -> Result<Vec<DiscoveredSession>> {
+        let sessions_dir = Self::sessions_dir()?;
+        self.discover_in_dir(&sessions_dir, project_filter, since_days)
+    }
+
+    fn discover_in_dir(
+        &self,
+        sessions_dir: &Path,
+        project_filter: Option<&str>,
+        since_days: Option<u64>,
+    ) -> Result<Vec<DiscoveredSession>> {
+        let cutoff_unix = cutoff_unix_seconds(since_days);
+        let mut sessions = Vec::new();
+
+        for entry in WalkDir::new(sessions_dir)
+            .follow_links(false)
+            .into_iter()
+            .filter_map(|entry| entry.ok())
+        {
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+
+            if path.extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
+                continue;
+            }
+
+            let file_name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("");
+            if !file_name.starts_with(CODEX_ROLLOUT_PREFIX) {
+                continue;
+            }
+
+            let (cwd, transcript_unix) = Self::parse_discovery_metadata(path);
+
+            if let Some(filter) = project_filter {
+                if !cwd.as_deref().unwrap_or_default().contains(filter) {
+                    continue;
+                }
+            }
+
+            let mtime_unix = file_mtime_unix_seconds(path);
+            let updated_unix = transcript_unix.unwrap_or(mtime_unix);
+
+            if let Some(cutoff) = cutoff_unix {
+                if updated_unix < cutoff && mtime_unix < cutoff {
+                    continue;
+                }
+            }
+
+            let session_id = path
+                .parent()
+                .and_then(|parent| parent.file_name())
+                .and_then(|name| name.to_str())
+                .unwrap_or("unknown")
+                .to_string();
+
+            sessions.push(DiscoveredSession {
+                provider: ProviderId::CodexCli,
+                session_id,
+                path: path.to_path_buf(),
+                updated_unix,
+            });
+        }
+
+        Ok(sessions)
+    }
+}
+
+impl SessionProvider for CodexProvider {
+    fn discover_sessions(
+        &self,
+        project_filter: Option<&str>,
+        since_days: Option<u64>,
+    ) -> Result<Vec<PathBuf>> {
+        Ok(self
+            .discover_with_metadata(project_filter, since_days)?
+            .into_iter()
+            .map(|session| session.path)
+            .collect())
+    }
+
+    fn extract_commands(&self, path: &Path) -> Result<Vec<ExtractedCommand>> {
+        let file =
+            fs::File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+        let reader = BufReader::new(file);
+
+        let session_id = path
+            .parent()
+            .and_then(|parent| parent.file_name())
+            .and_then(|name| name.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let mut pending_calls: Vec<(String, String, usize)> = Vec::new();
+        let mut call_outputs: HashMap<String, (usize, String, bool)> = HashMap::new();
+        let mut sequence_index = 0usize;
+
+        for line in reader.lines().map_while(|line| line.ok()) {
+            let entry: serde_json::Value = match serde_json::from_str(&line) {
+                Ok(value) => value,
+                Err(_) => continue,
+            };
+
+            if entry.get("type").and_then(|t| t.as_str()) != Some("response_item") {
+                continue;
+            }
+
+            let payload = match entry.get("payload") {
+                Some(payload) => payload,
+                None => continue,
+            };
+
+            match payload.get("type").and_then(|t| t.as_str()) {
+                Some("function_call") => {
+                    if payload.get("name").and_then(|n| n.as_str()) != Some("exec_command") {
+                        continue;
+                    }
+
+                    let call_id = match payload
+                        .get("call_id")
+                        .and_then(|id| id.as_str())
+                        .or_else(|| payload.get("id").and_then(|id| id.as_str()))
+                    {
+                        Some(call_id) => call_id.to_string(),
+                        None => continue,
+                    };
+
+                    let arguments = match payload.get("arguments").and_then(|args| args.as_str()) {
+                        Some(arguments) => arguments,
+                        None => continue,
+                    };
+
+                    let args_json: serde_json::Value = match serde_json::from_str(arguments) {
+                        Ok(args_json) => args_json,
+                        Err(_) => continue,
+                    };
+
+                    let command = match args_json.get("cmd").and_then(|cmd| cmd.as_str()) {
+                        Some(command) => command.to_string(),
+                        None => continue,
+                    };
+
+                    pending_calls.push((call_id, command, sequence_index));
+                    sequence_index += 1;
+                }
+                Some("function_call_output") => {
+                    let call_id = match payload.get("call_id").and_then(|id| id.as_str()) {
+                        Some(call_id) => call_id,
+                        None => continue,
+                    };
+
+                    let output_value = payload
+                        .get("output")
+                        .or_else(|| payload.get("content"))
+                        .cloned()
+                        .unwrap_or(serde_json::Value::Null);
+
+                    let output_content = if let Some(content) = output_value.as_str() {
+                        content.to_string()
+                    } else if output_value.is_null() {
+                        String::new()
+                    } else {
+                        output_value.to_string()
+                    };
+
+                    let is_error = payload
+                        .get("is_error")
+                        .and_then(|flag| flag.as_bool())
+                        .unwrap_or(false)
+                        || payload.get("error").is_some()
+                        || payload.get("status").and_then(|status| status.as_str())
+                            == Some("error");
+
+                    call_outputs.insert(
+                        call_id.to_string(),
+                        (
+                            output_content.len(),
+                            output_content.chars().take(1000).collect(),
+                            is_error,
+                        ),
+                    );
+                }
+                _ => {}
+            }
+        }
+
+        let mut commands = Vec::new();
+        for (call_id, command, sequence_index) in pending_calls {
+            let (output_len, output_content, is_error) = call_outputs
+                .get(&call_id)
+                .map(|(len, content, is_error)| (Some(*len), Some(content.clone()), *is_error))
+                .unwrap_or((None, None, false));
+
+            commands.push(ExtractedCommand {
+                command,
+                output_len,
+                session_id: session_id.clone(),
+                output_content,
+                is_error,
+                sequence_index,
+            });
+        }
+
+        Ok(commands)
+    }
+}
+
+impl CopilotCliProvider {
+    fn sessions_dir() -> Result<PathBuf> {
+        let home = dirs::home_dir().context("could not determine home directory")?;
+        let dir = home.join(COPILOT_SESSIONS_RELATIVE_PATH);
+        if !dir.exists() {
+            anyhow::bail!(
+                "Copilot CLI sessions directory not found: {}\nMake sure Copilot CLI has been used at least once.",
+                dir.display()
+            );
+        }
+        Ok(dir)
+    }
+
+    fn parse_discovery_metadata(path: &Path) -> (Option<String>, Option<i64>) {
+        let file = match fs::File::open(path) {
+            Ok(file) => file,
+            Err(_) => return (None, None),
+        };
+
+        let reader = BufReader::new(file);
+        let mut cwd = None;
+        let mut start_unix = None;
+
+        for line in reader.lines().map_while(|line| line.ok()) {
+            let entry: serde_json::Value = match serde_json::from_str(&line) {
+                Ok(value) => value,
+                Err(_) => continue,
+            };
+
+            if entry.get("type").and_then(|t| t.as_str()) == Some("session.start") {
+                if cwd.is_none() {
+                    cwd = json_string(&entry, "/data/context/cwd");
+                }
+                if start_unix.is_none() {
+                    start_unix =
+                        first_json_unix_timestamp(&entry, &COPILOT_START_TIMESTAMP_POINTERS);
+                }
+            }
+        }
+
+        (cwd, start_unix)
+    }
+
+    fn discover_with_metadata(
+        &self,
+        project_filter: Option<&str>,
+        since_days: Option<u64>,
+    ) -> Result<Vec<DiscoveredSession>> {
+        let sessions_dir = Self::sessions_dir()?;
+        self.discover_in_dir(&sessions_dir, project_filter, since_days)
+    }
+
+    fn discover_in_dir(
+        &self,
+        sessions_dir: &Path,
+        project_filter: Option<&str>,
+        since_days: Option<u64>,
+    ) -> Result<Vec<DiscoveredSession>> {
+        let cutoff_unix = cutoff_unix_seconds(since_days);
+        let mut sessions = Vec::new();
+
+        let entries = fs::read_dir(sessions_dir)
+            .with_context(|| format!("failed to read {}", sessions_dir.display()))?;
+
+        for entry in entries.flatten() {
+            let session_dir = entry.path();
+            if !session_dir.is_dir() {
+                continue;
+            }
+
+            let events_path = session_dir.join(COPILOT_EVENTS_FILE);
+            if !events_path.exists() {
+                continue;
+            }
+
+            let (cwd, start_unix) = Self::parse_discovery_metadata(&events_path);
+
+            if let Some(filter) = project_filter {
+                if !cwd.as_deref().unwrap_or_default().contains(filter) {
+                    continue;
+                }
+            }
+
+            let mtime_unix = file_mtime_unix_seconds(&events_path);
+            let updated_unix = start_unix.unwrap_or(mtime_unix);
+
+            if let Some(cutoff) = cutoff_unix {
+                if updated_unix < cutoff && mtime_unix < cutoff {
+                    continue;
+                }
+            }
+
+            let session_id = session_dir
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("unknown")
+                .to_string();
+
+            sessions.push(DiscoveredSession {
+                provider: ProviderId::CopilotCli,
+                session_id,
+                path: events_path,
+                updated_unix,
+            });
+        }
+
+        Ok(sessions)
+    }
+}
+
+impl SessionProvider for CopilotCliProvider {
+    fn discover_sessions(
+        &self,
+        project_filter: Option<&str>,
+        since_days: Option<u64>,
+    ) -> Result<Vec<PathBuf>> {
+        Ok(self
+            .discover_with_metadata(project_filter, since_days)?
+            .into_iter()
+            .map(|session| session.path)
+            .collect())
+    }
+
+    fn extract_commands(&self, path: &Path) -> Result<Vec<ExtractedCommand>> {
+        let file =
+            fs::File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+        let reader = BufReader::new(file);
+
+        let session_id = path
+            .parent()
+            .and_then(|parent| parent.file_name())
+            .and_then(|name| name.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let mut pending_calls: Vec<(String, String, usize)> = Vec::new();
+        let mut call_results: HashMap<String, (Option<usize>, Option<String>, bool)> =
+            HashMap::new();
+        let mut sequence_index = 0usize;
+
+        for line in reader.lines().map_while(|line| line.ok()) {
+            let entry: serde_json::Value = match serde_json::from_str(&line) {
+                Ok(value) => value,
+                Err(_) => continue,
+            };
+
+            match entry.get("type").and_then(|t| t.as_str()) {
+                Some("tool.execution_start") => {
+                    if json_string(&entry, "/data/toolName").as_deref() != Some("bash") {
+                        continue;
+                    }
+
+                    let command = match json_string(&entry, "/data/arguments/command") {
+                        Some(command) => command,
+                        None => continue,
+                    };
+
+                    let tool_call_id = json_string(&entry, "/data/toolCallId")
+                        .or_else(|| json_string(&entry, "/toolCallId"));
+                    let call_id = match tool_call_id {
+                        Some(call_id) => call_id,
+                        None => continue,
+                    };
+
+                    pending_calls.push((call_id, command, sequence_index));
+                    sequence_index += 1;
+                }
+                Some("tool.execution_complete") => {
+                    let call_id = match json_string(&entry, "/data/toolCallId")
+                        .or_else(|| json_string(&entry, "/toolCallId"))
+                    {
+                        Some(call_id) => call_id,
+                        None => continue,
+                    };
+
+                    let success = entry
+                        .pointer("/data/success")
+                        .and_then(|flag| flag.as_bool())
+                        .or_else(|| entry.pointer("/success").and_then(|flag| flag.as_bool()));
+
+                    let output = first_json_text(&entry, &COPILOT_OUTPUT_POINTERS);
+
+                    let output_len = output.as_ref().map(|content| content.len());
+                    let output_content = output.map(|content| content.chars().take(1000).collect());
+                    let is_error = match success {
+                        Some(success) => !success,
+                        None => {
+                            entry.pointer("/data/error").is_some()
+                                || entry.pointer("/error").is_some()
+                        }
+                    };
+
+                    call_results.insert(call_id, (output_len, output_content, is_error));
+                }
+                _ => {}
+            }
+        }
+
+        let mut commands = Vec::new();
+        for (call_id, command, sequence_index) in pending_calls {
+            let (output_len, output_content, is_error) = call_results
+                .get(&call_id)
+                .cloned()
+                .unwrap_or((None, None, false));
+
+            commands.push(ExtractedCommand {
+                command,
+                output_len,
+                session_id: session_id.clone(),
+                output_content,
+                is_error,
+                sequence_index,
+            });
+        }
+
+        Ok(commands)
+    }
+}
+
+impl SessionProvider for OpenCodeProvider {
+    fn discover_sessions(
+        &self,
+        project_filter: Option<&str>,
+        since_days: Option<u64>,
+    ) -> Result<Vec<PathBuf>> {
+        Ok(self
+            .discover_with_metadata(project_filter, since_days)?
+            .into_iter()
+            .map(|session| session.path)
+            .collect())
+    }
+
+    fn extract_commands(&self, path: &Path) -> Result<Vec<ExtractedCommand>> {
+        let session_id = OpenCodeProvider::session_id_from_path(path)
+            .with_context(|| format!("invalid OpenCode session path: {}", path.display()))?;
+
+        let db_path = self.db_path()?;
+        let conn = rusqlite::Connection::open(&db_path)
+            .with_context(|| format!("failed to open {}", db_path.display()))?;
+
+        let mut stmt = conn.prepare(
+            "SELECT id,
+                    time_updated,
+                    json_extract(data, '$.callID') AS call_id,
+                    json_extract(data, '$.state.input.command') AS command,
+                    json_extract(data, '$.state.output') AS output,
+                    json_extract(data, '$.state.error') AS error_output,
+                    json_extract(data, '$.state.status') AS status
+             FROM part
+             WHERE session_id = ?1
+               AND json_extract(data, '$.type') = 'tool'
+               AND lower(json_extract(data, '$.tool')) IN ('bash', 'shell')
+             ORDER BY time_updated ASC",
+        )?;
+
+        let rows = stmt.query_map([session_id.as_str()], |row| {
+            let id: String = row.get(0)?;
+            let time_updated: i64 = row.get(1)?;
+            let call_id: Option<String> = row.get(2)?;
+            let command: Option<String> = row.get(3)?;
+            let output: Option<String> = row.get(4)?;
+            let error_output: Option<String> = row.get(5)?;
+            let status: Option<String> = row.get(6)?;
+            Ok(OpenCodePartRow {
+                key: call_id.unwrap_or(id),
+                time_updated,
+                command: command.unwrap_or_default(),
+                output,
+                error_output,
+                status,
+            })
+        })?;
+
+        // Keep the latest state per callID (running -> completed/error)
+        let mut by_call: HashMap<String, OpenCodePartRow> = HashMap::new();
+        for row in rows {
+            let parsed = row?;
+            by_call.insert(parsed.key.clone(), parsed);
+        }
+
+        let mut latest_rows: Vec<OpenCodePartRow> = by_call.into_values().collect();
+        latest_rows.sort_by_key(|r| r.time_updated);
+
+        let mut commands = Vec::new();
+        for (sequence_index, row) in latest_rows.into_iter().enumerate() {
+            if row.command.trim().is_empty() {
+                continue;
+            }
+
+            let output = row.output.or(row.error_output);
+            let output_len = output.as_ref().map(|content| content.len());
+            let output_content = output.map(|content| content.chars().take(1000).collect());
+            let is_error = row.status.as_deref() == Some("error");
+
+            commands.push(ExtractedCommand {
+                command: row.command,
+                output_len,
+                session_id: session_id.clone(),
+                output_content,
+                is_error,
+                sequence_index,
+            });
+        }
+
+        Ok(commands)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::{SecondsFormat, Utc};
+    use rusqlite::{params, Connection};
     use std::io::Write;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     fn make_jsonl(lines: &[&str]) -> tempfile::NamedTempFile {
         let mut f = tempfile::NamedTempFile::new().unwrap();
@@ -392,5 +1289,431 @@ mod tests {
         assert_eq!(cmds[0].command, "first");
         assert_eq!(cmds[1].command, "second");
         assert_eq!(cmds[2].command, "third");
+    }
+
+    fn setup_opencode_db() -> (tempfile::TempDir, PathBuf) {
+        let temp = tempfile::tempdir().unwrap();
+        let db_path = temp.path().join("opencode.db");
+        let conn = Connection::open(&db_path).unwrap();
+
+        conn.execute(
+            "CREATE TABLE session (
+                id TEXT PRIMARY KEY,
+                directory TEXT NOT NULL,
+                time_updated INTEGER NOT NULL
+            )",
+            [],
+        )
+        .unwrap();
+
+        conn.execute(
+            "CREATE TABLE part (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                time_updated INTEGER NOT NULL,
+                data TEXT NOT NULL
+            )",
+            [],
+        )
+        .unwrap();
+
+        (temp, db_path)
+    }
+
+    fn now_ms() -> i64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64
+    }
+
+    fn to_rfc3339_millis(ts: i64) -> String {
+        chrono::DateTime::<Utc>::from_timestamp(ts, 0)
+            .unwrap()
+            .to_rfc3339_opts(SecondsFormat::Millis, true)
+    }
+
+    #[test]
+    fn test_opencode_discover_sessions_filters_project_and_since() {
+        let (_temp, db_path) = setup_opencode_db();
+        let conn = Connection::open(&db_path).unwrap();
+        let now = now_ms();
+        let old = now - (40 * 86_400 * 1000);
+
+        conn.execute(
+            "INSERT INTO session (id, directory, time_updated) VALUES (?1, ?2, ?3)",
+            params!["ses_new_match", "/home/user/code/rtk", now],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session (id, directory, time_updated) VALUES (?1, ?2, ?3)",
+            params!["ses_new_other", "/home/user/code/other", now],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session (id, directory, time_updated) VALUES (?1, ?2, ?3)",
+            params!["ses_old_match", "/home/user/code/rtk", old],
+        )
+        .unwrap();
+
+        let provider = OpenCodeProvider {
+            db_path: Some(db_path),
+        };
+        let sessions = provider.discover_sessions(Some("rtk"), Some(30)).unwrap();
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(
+            sessions[0].to_string_lossy(),
+            "opencode-session:ses_new_match"
+        );
+    }
+
+    #[test]
+    fn test_opencode_extract_commands_reads_bash_tools() {
+        let (_temp, db_path) = setup_opencode_db();
+        let conn = Connection::open(&db_path).unwrap();
+
+        conn.execute(
+            "INSERT INTO session (id, directory, time_updated) VALUES (?1, ?2, ?3)",
+            params!["ses_1", "/home/user/code/rtk", now_ms()],
+        )
+        .unwrap();
+
+        let bash_data = r#"{"type":"tool","tool":"bash","callID":"call_1","state":{"status":"completed","input":{"command":"git status"},"output":"clean"}}"#;
+        conn.execute(
+            "INSERT INTO part (id, session_id, time_updated, data) VALUES (?1, ?2, ?3, ?4)",
+            params!["prt_1", "ses_1", now_ms(), bash_data],
+        )
+        .unwrap();
+
+        let read_data = r#"{"type":"tool","tool":"read","callID":"call_2","state":{"status":"completed","input":{"filePath":"/tmp/x"},"output":"abc"}}"#;
+        conn.execute(
+            "INSERT INTO part (id, session_id, time_updated, data) VALUES (?1, ?2, ?3, ?4)",
+            params!["prt_2", "ses_1", now_ms() + 1, read_data],
+        )
+        .unwrap();
+
+        let provider = OpenCodeProvider {
+            db_path: Some(db_path),
+        };
+        let cmds = provider
+            .extract_commands(Path::new("opencode-session:ses_1"))
+            .unwrap();
+
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(cmds[0].command, "git status");
+        assert_eq!(cmds[0].output_len, Some("clean".len()));
+        assert!(!cmds[0].is_error);
+    }
+
+    #[test]
+    fn test_opencode_extract_commands_uses_latest_call_state() {
+        let (_temp, db_path) = setup_opencode_db();
+        let conn = Connection::open(&db_path).unwrap();
+        let t = now_ms();
+
+        conn.execute(
+            "INSERT INTO session (id, directory, time_updated) VALUES (?1, ?2, ?3)",
+            params!["ses_2", "/home/user/code/rtk", t],
+        )
+        .unwrap();
+
+        let running = r#"{"type":"tool","tool":"bash","callID":"call_same","state":{"status":"running","input":{"command":"cargo test"}}}"#;
+        let completed = r#"{"type":"tool","tool":"bash","callID":"call_same","state":{"status":"completed","input":{"command":"cargo test"},"output":"ok"}}"#;
+        let errored = r#"{"type":"tool","tool":"bash","callID":"call_err","state":{"status":"error","input":{"command":"git bad"},"error":"failed"}}"#;
+
+        conn.execute(
+            "INSERT INTO part (id, session_id, time_updated, data) VALUES (?1, ?2, ?3, ?4)",
+            params!["prt_r", "ses_2", t, running],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO part (id, session_id, time_updated, data) VALUES (?1, ?2, ?3, ?4)",
+            params!["prt_c", "ses_2", t + 1, completed],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO part (id, session_id, time_updated, data) VALUES (?1, ?2, ?3, ?4)",
+            params!["prt_e", "ses_2", t + 2, errored],
+        )
+        .unwrap();
+
+        let provider = OpenCodeProvider {
+            db_path: Some(db_path),
+        };
+        let cmds = provider
+            .extract_commands(Path::new("opencode-session:ses_2"))
+            .unwrap();
+
+        assert_eq!(cmds.len(), 2);
+        assert_eq!(cmds[0].command, "cargo test");
+        assert_eq!(cmds[0].output_len, Some(2));
+        assert!(!cmds[0].is_error);
+
+        assert_eq!(cmds[1].command, "git bad");
+        assert_eq!(cmds[1].output_len, Some("failed".len()));
+        assert_eq!(cmds[1].output_content.as_deref(), Some("failed"));
+        assert!(cmds[1].is_error);
+    }
+
+    #[test]
+    fn test_opencode_extract_commands_keeps_latest_row_per_call() {
+        let (_temp, db_path) = setup_opencode_db();
+        let conn = Connection::open(&db_path).unwrap();
+        let t = now_ms();
+
+        conn.execute(
+            "INSERT INTO session (id, directory, time_updated) VALUES (?1, ?2, ?3)",
+            params!["ses_latest", "/home/user/code/rtk", t],
+        )
+        .unwrap();
+
+        let running = r#"{"type":"tool","tool":"bash","callID":"call_1","state":{"status":"running","input":{"command":"npm test"}}}"#;
+        let completed = r#"{"type":"tool","tool":"bash","callID":"call_1","state":{"status":"completed","input":{"command":"npm test"},"output":"pass"}}"#;
+        let overwritten = r#"{"type":"tool","tool":"bash","callID":"call_1","state":{"status":"completed","input":{"command":"npm test"},"output":"pass 2"}}"#;
+
+        conn.execute(
+            "INSERT INTO part (id, session_id, time_updated, data) VALUES (?1, ?2, ?3, ?4)",
+            params!["p1", "ses_latest", t, running],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO part (id, session_id, time_updated, data) VALUES (?1, ?2, ?3, ?4)",
+            params!["p2", "ses_latest", t + 1, completed],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO part (id, session_id, time_updated, data) VALUES (?1, ?2, ?3, ?4)",
+            params!["p3", "ses_latest", t + 2, overwritten],
+        )
+        .unwrap();
+
+        let provider = OpenCodeProvider {
+            db_path: Some(db_path),
+        };
+        let cmds = provider
+            .extract_commands(Path::new("opencode-session:ses_latest"))
+            .unwrap();
+
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(cmds[0].command, "npm test");
+        assert_eq!(cmds[0].output_content.as_deref(), Some("pass 2"));
+    }
+
+    #[test]
+    fn test_opencode_extract_commands_handles_running_without_output() {
+        let (_temp, db_path) = setup_opencode_db();
+        let conn = Connection::open(&db_path).unwrap();
+        let t = now_ms();
+
+        conn.execute(
+            "INSERT INTO session (id, directory, time_updated) VALUES (?1, ?2, ?3)",
+            params!["ses_running", "/home/user/code/rtk", t],
+        )
+        .unwrap();
+
+        let running = r#"{"type":"tool","tool":"bash","callID":"call_1","state":{"status":"running","input":{"command":"cargo test"}}}"#;
+        conn.execute(
+            "INSERT INTO part (id, session_id, time_updated, data) VALUES (?1, ?2, ?3, ?4)",
+            params!["p1", "ses_running", t, running],
+        )
+        .unwrap();
+
+        let provider = OpenCodeProvider {
+            db_path: Some(db_path),
+        };
+        let cmds = provider
+            .extract_commands(Path::new("opencode-session:ses_running"))
+            .unwrap();
+
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(cmds[0].command, "cargo test");
+        assert_eq!(cmds[0].output_len, None);
+        assert_eq!(cmds[0].output_content, None);
+    }
+
+    #[test]
+    fn test_opencode_extract_commands_non_bash_only_is_empty() {
+        let (_temp, db_path) = setup_opencode_db();
+        let conn = Connection::open(&db_path).unwrap();
+        let t = now_ms();
+
+        conn.execute(
+            "INSERT INTO session (id, directory, time_updated) VALUES (?1, ?2, ?3)",
+            params!["ses_nonbash", "/home/user/code/rtk", t],
+        )
+        .unwrap();
+
+        let read_data = r#"{"type":"tool","tool":"read","callID":"call_1","state":{"status":"completed","input":{"filePath":"/tmp/a"},"output":"abc"}}"#;
+        conn.execute(
+            "INSERT INTO part (id, session_id, time_updated, data) VALUES (?1, ?2, ?3, ?4)",
+            params!["p1", "ses_nonbash", t, read_data],
+        )
+        .unwrap();
+
+        let provider = OpenCodeProvider {
+            db_path: Some(db_path),
+        };
+        let cmds = provider
+            .extract_commands(Path::new("opencode-session:ses_nonbash"))
+            .unwrap();
+        assert!(cmds.is_empty());
+    }
+
+    #[test]
+    fn test_opencode_extract_commands_empty_command_session_is_empty() {
+        let (_temp, db_path) = setup_opencode_db();
+        let conn = Connection::open(&db_path).unwrap();
+        let t = now_ms();
+
+        conn.execute(
+            "INSERT INTO session (id, directory, time_updated) VALUES (?1, ?2, ?3)",
+            params!["ses_empty", "/home/user/code/rtk", t],
+        )
+        .unwrap();
+
+        let empty_cmd = r#"{"type":"tool","tool":"bash","callID":"call_1","state":{"status":"completed","input":{"command":""},"output":""}}"#;
+        conn.execute(
+            "INSERT INTO part (id, session_id, time_updated, data) VALUES (?1, ?2, ?3, ?4)",
+            params!["p1", "ses_empty", t, empty_cmd],
+        )
+        .unwrap();
+
+        let provider = OpenCodeProvider {
+            db_path: Some(db_path),
+        };
+        let cmds = provider
+            .extract_commands(Path::new("opencode-session:ses_empty"))
+            .unwrap();
+        assert!(cmds.is_empty());
+    }
+
+    #[test]
+    fn test_codex_extract_commands_exec_command_only() {
+        let jsonl = make_jsonl(&[
+            r#"{"type":"response_item","payload":{"type":"function_call","id":"call_1","name":"exec_command","arguments":"{\"cmd\":\"pnpm test\"}"}}"#,
+            r#"{"type":"response_item","payload":{"type":"function_call","id":"call_2","name":"read_file","arguments":"{\"path\":\"README.md\"}"}}"#,
+            r#"{"type":"response_item","payload":{"type":"function_call_output","call_id":"call_1","output":"ok","is_error":false}}"#,
+            r#"{"type":"response_item","payload":{"type":"function_call_output","call_id":"call_2","output":"ignored"}}"#,
+        ]);
+
+        let provider = CodexProvider;
+        let cmds = provider.extract_commands(jsonl.path()).unwrap();
+
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(cmds[0].command, "pnpm test");
+        assert_eq!(cmds[0].output_content.as_deref(), Some("ok"));
+        assert!(!cmds[0].is_error);
+    }
+
+    #[test]
+    fn test_codex_discover_in_dir_filters_project_and_since() {
+        let temp = tempfile::tempdir().unwrap();
+        let old_session = temp.path().join("old-session");
+        let new_session = temp.path().join("new-session");
+        fs::create_dir_all(&old_session).unwrap();
+        fs::create_dir_all(&new_session).unwrap();
+
+        let old = old_session.join("rollout-old.jsonl");
+        let mut old_file = fs::File::create(&old).unwrap();
+        old_file
+            .write_all(
+                b"{\"type\":\"session_meta\",\"payload\":{\"cwd\":\"/tmp/other\",\"created_at\":\"1970-01-01T00:00:01Z\"}}\n",
+            )
+            .unwrap();
+
+        let now_unix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let new = new_session.join("rollout-new.jsonl");
+        let mut new_file = fs::File::create(&new).unwrap();
+        writeln!(
+            new_file,
+            "{{\"type\":\"session_meta\",\"payload\":{{\"cwd\":\"/tmp/rtk\",\"created_at\":\"{}\"}}}}",
+            to_rfc3339_millis(now_unix)
+        )
+        .unwrap();
+
+        let provider = CodexProvider;
+        let sessions = provider
+            .discover_in_dir(temp.path(), Some("rtk"), Some(30))
+            .unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].provider, ProviderId::CodexCli);
+        assert_eq!(sessions[0].session_id, "new-session");
+    }
+
+    #[test]
+    fn test_copilot_extract_commands_pairs_start_and_complete() {
+        let jsonl = make_jsonl(&[
+            r#"{"type":"tool.execution_start","data":{"toolName":"bash","toolCallId":"tc_1","arguments":{"command":"npm run build"}}}"#,
+            r#"{"type":"tool.execution_start","data":{"toolName":"read","toolCallId":"tc_2","arguments":{"path":"README.md"}}}"#,
+            r#"{"type":"tool.execution_complete","data":{"toolCallId":"tc_1","success":false,"error":{"code":"ERR"},"result":{"content":"failed"}}}"#,
+        ]);
+
+        let provider = CopilotCliProvider;
+        let cmds = provider.extract_commands(jsonl.path()).unwrap();
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(cmds[0].command, "npm run build");
+        assert_eq!(cmds[0].output_content.as_deref(), Some("failed"));
+        assert!(cmds[0].is_error);
+    }
+
+    #[test]
+    fn test_copilot_discover_in_dir_filters_project_and_since() {
+        let temp = tempfile::tempdir().unwrap();
+        let session_a = temp.path().join("session-a");
+        let session_b = temp.path().join("session-b");
+        fs::create_dir_all(&session_a).unwrap();
+        fs::create_dir_all(&session_b).unwrap();
+
+        let events_a = session_a.join("events.jsonl");
+        let mut file_a = fs::File::create(&events_a).unwrap();
+        file_a
+            .write_all(
+                b"{\"type\":\"session.start\",\"data\":{\"context\":{\"cwd\":\"/tmp/other\"},\"startTime\":\"1970-01-01T00:00:01Z\"}}\n",
+            )
+            .unwrap();
+
+        let now_unix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let events_b = session_b.join("events.jsonl");
+        let mut file_b = fs::File::create(&events_b).unwrap();
+        writeln!(
+            file_b,
+            "{{\"type\":\"session.start\",\"data\":{{\"context\":{{\"cwd\":\"/tmp/rtk\"}}}},\"timestamp\":\"{}\"}}",
+            to_rfc3339_millis(now_unix)
+        )
+        .unwrap();
+
+        let provider = CopilotCliProvider;
+        let sessions = provider
+            .discover_in_dir(temp.path(), Some("rtk"), Some(30))
+            .unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].provider, ProviderId::CopilotCli);
+        assert_eq!(sessions[0].session_id, "session-b");
+    }
+
+    #[test]
+    fn test_extract_commands_for_session_dispatches_by_provider() {
+        let jsonl = make_jsonl(&[
+            r#"{"type":"response_item","payload":{"type":"function_call","id":"call_1","name":"exec_command","arguments":"{\"cmd\":\"git status\"}"}}"#,
+            r#"{"type":"response_item","payload":{"type":"function_call_output","call_id":"call_1","output":"clean"}}"#,
+        ]);
+
+        let session = DiscoveredSession {
+            provider: ProviderId::CodexCli,
+            session_id: "abc123".to_string(),
+            path: jsonl.path().to_path_buf(),
+            updated_unix: now_ms() / 1000,
+        };
+
+        let cmds = extract_commands_for_session(&session).unwrap();
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(cmds[0].command, "git status");
     }
 }

--- a/src/discover/report.rs
+++ b/src/discover/report.rs
@@ -175,7 +175,9 @@ pub fn format_text(report: &DiscoverReport, limit: usize, verbose: bool) -> Stri
             .join(HOOKS_SUBDIR)
             .join(REWRITE_HOOK_FILE);
         if cursor_hook.exists() {
-            out.push_str("\nNote: Cursor sessions are tracked via `rtk gain` (discover scans Claude Code only)\n");
+            out.push_str(
+                "\nNote: Cursor sessions are tracked via `rtk gain` (discover scans Claude Code, OpenCode, Codex CLI, and Copilot CLI sessions)\n",
+            );
         }
     }
 

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -192,7 +192,7 @@ rtk wget <url>          # Compact download output (65%)
 ```bash
 rtk gain                # View token savings statistics
 rtk gain --history      # View command history with savings
-rtk discover            # Analyze Claude Code sessions for missed RTK usage
+rtk discover            # Analyze Claude Code/OpenCode/Codex CLI/Copilot CLI sessions for missed RTK usage
 rtk proxy <cmd>         # Run command without filtering (for debugging)
 rtk init                # Add RTK instructions to CLAUDE.md
 rtk init --global       # Add RTK to ~/.claude/CLAUDE.md
@@ -448,7 +448,9 @@ fn print_manual_instructions(hook_path: &Path, include_opencode: bool) {
     println!("    }}]}}");
     println!("  }}");
     if include_opencode {
-        println!("\n  Then restart Claude Code and OpenCode. Test with: git status\n");
+        println!(
+            "\n  Then restart Claude Code, OpenCode, Codex CLI, and Copilot CLI. Test with: git status\n"
+        );
     } else {
         println!("\n  Then restart Claude Code. Test with: git status\n");
     }
@@ -643,7 +645,9 @@ pub fn uninstall(global: bool, gemini: bool, codex: bool, cursor: bool, verbose:
         for item in removed {
             println!("  - {}", item);
         }
-        println!("\nRestart Claude Code, OpenCode, and Cursor (if used) to apply changes.");
+        println!(
+            "\nRestart Claude Code, OpenCode, Codex CLI, Copilot CLI, and Cursor (if used) to apply changes."
+        );
     }
 
     Ok(())
@@ -777,7 +781,9 @@ fn patch_settings_json(
         );
     }
     if include_opencode {
-        println!("  Restart Claude Code and OpenCode. Test with: git status");
+        println!(
+            "  Restart Claude Code, OpenCode, Codex CLI, and Copilot CLI. Test with: git status"
+        );
     } else {
         println!("  Restart Claude Code. Test with: git status");
     }
@@ -954,7 +960,9 @@ fn run_default_mode(
         PatchResult::AlreadyPresent => {
             println!("\n  settings.json: hook already present");
             if install_opencode {
-                println!("  Restart Claude Code and OpenCode. Test with: git status");
+                println!(
+                    "  Restart Claude Code, OpenCode, Codex CLI, and Copilot CLI. Test with: git status"
+                );
             } else {
                 println!("  Restart Claude Code. Test with: git status");
             }
@@ -1082,7 +1090,9 @@ fn run_hook_only_mode(
         PatchResult::AlreadyPresent => {
             println!("\n  settings.json: hook already present");
             if install_opencode {
-                println!("  Restart Claude Code and OpenCode. Test with: git status");
+                println!(
+                    "  Restart Claude Code, OpenCode, Codex CLI, and Copilot CLI. Test with: git status"
+                );
             } else {
                 println!("  Restart Claude Code. Test with: git status");
             }

--- a/src/learn/README.md
+++ b/src/learn/README.md
@@ -4,7 +4,7 @@
 
 ## Purpose
 
-Analyzes Claude Code session history to detect recurring CLI mistakes — commands that fail then get corrected by the agent. Powers the `rtk learn` command, which identifies error patterns (unknown flags, wrong paths, missing args) and can auto-generate `.claude/rules/cli-corrections.md` to prevent them.
+Analyzes Claude Code, OpenCode, Codex CLI, and Copilot CLI session history to detect recurring CLI mistakes — commands that fail then get corrected by the agent. Powers the `rtk learn` command, which identifies error patterns (unknown flags, wrong paths, missing args) and can auto-generate `.claude/rules/cli-corrections.md` to prevent them.
 
 ## Key Types
 
@@ -14,12 +14,12 @@ Analyzes Claude Code session history to detect recurring CLI mistakes — comman
 
 ## Dependencies
 
-- **Uses**: `discover::provider::ClaudeProvider` (session file discovery and command extraction), `lazy_static`/`regex` (error pattern matching), `serde_json` (JSON output)
+- **Uses**: `discover::provider` provider dispatch (session discovery and command extraction), `lazy_static`/`regex` (error pattern matching), `serde_json` (JSON output)
 - **Used by**: `src/main.rs` (routes `rtk learn` command)
 
 ## Detection Algorithm
 
-1. Extract all commands from JSONL sessions via `ClaudeProvider`
+1. Extract all commands from available session providers (Claude Code JSONL + OpenCode SQLite + Codex CLI JSONL + Copilot CLI JSONL)
 2. Scan chronologically for fail-then-succeed pairs (same base command, first has error output, second succeeds)
 3. Classify the error type using regex patterns on the error output
 4. Assign confidence scores based on similarity and error clarity

--- a/src/learn/mod.rs
+++ b/src/learn/mod.rs
@@ -3,7 +3,9 @@
 pub mod detector;
 pub mod report;
 
-use crate::discover::provider::{ClaudeProvider, SessionProvider};
+use crate::discover::provider::{
+    discover_provider_sessions, extract_commands_for_session, supported_providers_display,
+};
 use anyhow::Result;
 use detector::{deduplicate_corrections, find_corrections, CommandExecution};
 use report::{format_console_report, write_rules_file};
@@ -17,8 +19,6 @@ pub fn run(
     min_confidence: f64,
     min_occurrences: usize,
 ) -> Result<()> {
-    let provider = ClaudeProvider;
-
     // Determine project filter (same logic as discover)
     let project_filter = if all {
         None
@@ -27,24 +27,28 @@ pub fn run(
     } else {
         // Default: current working directory
         let cwd = std::env::current_dir()?;
-        let cwd_str = cwd.to_string_lossy().to_string();
-        let encoded = ClaudeProvider::encode_project_path(&cwd_str);
-        Some(encoded)
+        Some(cwd.to_string_lossy().to_string())
     };
 
-    // Discover sessions
-    let sessions = provider.discover_sessions(project_filter.as_deref(), Some(since))?;
+    let discovery = discover_provider_sessions(project_filter.as_deref(), Some(since));
 
-    if sessions.is_empty() {
-        println!("No Claude Code sessions found in the last {} days.", since);
+    if discovery.available_sources == 0 {
+        anyhow::bail!(
+            "No session sources available. Use {} at least once, then rerun learn.",
+            supported_providers_display(),
+        );
+    }
+
+    if discovery.sessions.is_empty() {
+        println!("No sessions found in the last {} days.", since);
         return Ok(());
     }
 
     // Extract commands from all sessions
     let mut all_commands: Vec<CommandExecution> = Vec::new();
 
-    for session_path in &sessions {
-        let extracted = match provider.extract_commands(session_path) {
+    for session in &discovery.sessions {
+        let extracted = match extract_commands_for_session(session) {
             Ok(cmds) => cmds,
             Err(_) => continue, // Skip malformed sessions
         };
@@ -70,7 +74,7 @@ pub fn run(
     if corrections.is_empty() {
         println!(
             "No CLI corrections detected in {} sessions.",
-            sessions.len()
+            discovery.sessions.len()
         );
         return Ok(());
     }
@@ -92,7 +96,7 @@ pub fn run(
         "json" => {
             // JSON output
             let json = serde_json::json!({
-                "sessions_scanned": sessions.len(),
+                "sessions_scanned": discovery.sessions.len(),
                 "total_corrections": filtered.len(),
                 "rules": rules.iter().map(|r| serde_json::json!({
                     "wrong": r.wrong_pattern,
@@ -106,7 +110,8 @@ pub fn run(
         }
         _ => {
             // Text output
-            let report = format_console_report(&rules, filtered.len(), sessions.len(), since);
+            let report =
+                format_console_report(&rules, filtered.len(), discovery.sessions.len(), since);
             print!("{}", report);
 
             if write_rules && !rules.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -521,7 +521,7 @@ enum Commands {
         args: Vec<String>,
     },
 
-    /// Discover missed RTK savings from Claude Code history
+    /// Discover missed RTK savings from Claude Code/OpenCode/Codex CLI/Copilot CLI history
     Discover {
         /// Filter by project path (substring match)
         #[arg(short, long)]
@@ -540,10 +540,10 @@ enum Commands {
         format: String,
     },
 
-    /// Show RTK adoption across Claude Code sessions
+    /// Show RTK adoption across Claude Code/OpenCode/Codex CLI/Copilot CLI sessions
     Session {},
 
-    /// Learn CLI corrections from Claude Code error history
+    /// Learn CLI corrections from Claude Code/OpenCode/Codex CLI/Copilot CLI error history
     Learn {
         /// Filter by project path (substring match)
         #[arg(short, long)]


### PR DESCRIPTION
## Summary
- Add a provider-dispatch discovery pipeline shared by `rtk discover`, `rtk learn`, and `rtk session` so session ingestion is consistent across providers.
- Add Codex CLI and Copilot CLI session discovery/extraction support, including real-world output paths and ISO-8601 timestamp parsing.
- Update reporting/help/docs to reflect multi-provider support and preserve provider metadata in discovery summaries.

## Test plan
- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk session` output inspected