### PR TITLE
fix(git): fix panic on multibyte chars in commit output

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -920,11 +920,16 @@ fn run_commit(args: &[String], verbose: u8, global_args: &[String]) -> Result<i3
 
     if output.status.success() {
         // Extract commit hash from output like "[main abc1234] message"
+        // or "[main (root-commit) abc1234] message" (incl. localized variants)
+        // The hash is always the last whitespace-separated token before ']'.
         let compact = if let Some(line) = stdout.lines().next() {
-            if let Some(hash_start) = line.find(' ') {
-                let hash = line[1..hash_start].split(' ').next_back().unwrap_or("");
+            if let Some(bracket_end) = line.find(']') {
+                let bracket_content = &line[1..bracket_end];
+                let hash = bracket_content.split_whitespace().next_back().unwrap_or("");
                 if !hash.is_empty() && hash.len() >= 7 {
-                    format!("ok {}", &hash[..7.min(hash.len())])
+                    // Git hashes are ASCII; chars().take(7) is safe regardless
+                    let short_hash: String = hash.chars().take(7).collect();
+                    format!("ok {}", short_hash)
                 } else {
                     "ok".to_string()
                 }


### PR DESCRIPTION
git commit on an initial commit under a Chinese locale outputs:
  [master（根提交） fb597ec] Initial commit

The old code found the first space and sliced line[1..hash_start], yielding "master（根提交）" (21 bytes).  hash.len() >= 7 was true, so it tried &hash[..7] — but byte 7 falls inside the 3-byte '（' character, causing a panic.

Two bugs were present:
1. Logic: the code grabbed the token *before* the first space (branch name), not the commit hash.  The hash is always the last whitespace-separated token inside the [...] brackets.
2. Safety: raw byte slicing on a potentially non-ASCII string.

Fix: find ']', extract the bracket content, split_whitespace() and take next_back() to get the hash.  Use chars().take(7) for the short-hash slice so it is always char-boundary-safe.

## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

-

## Test plan
<!-- How did you verify this works? -->

- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
