### PR TITLE
fix(git): fix panic on multibyte chars in commit output

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -941,6 +941,24 @@ fn build_commit_command(args: &[String], global_args: &[String]) -> Command {
     cmd
 }
 
+/// Parse the first line of `git commit` success output and return a compact token.
+/// Handles: `[main abc1234def] message`, `[main (root-commit) abc1234def] msg`,
+/// localized variants, and multibyte branch names.
+fn parse_commit_output(line: &str) -> String {
+    if let Some(bracket_end) = line.find(']') {
+        let bracket_content = &line[1..bracket_end];
+        let hash = bracket_content.split_whitespace().next_back().unwrap_or("");
+        if !hash.is_empty() && hash.len() >= 7 {
+            let short_hash: String = hash.chars().take(7).collect();
+            format!("ok {}", short_hash)
+        } else {
+            "ok".to_string()
+        }
+    } else {
+        "ok".to_string()
+    }
+}
+
 fn run_commit(args: &[String], verbose: u8, global_args: &[String]) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
@@ -964,19 +982,7 @@ fn run_commit(args: &[String], verbose: u8, global_args: &[String]) -> Result<i3
         // or "[main (root-commit) abc1234] message" (incl. localized variants)
         // The hash is always the last whitespace-separated token before ']'.
         let compact = if let Some(line) = stdout.lines().next() {
-            if let Some(bracket_end) = line.find(']') {
-                let bracket_content = &line[1..bracket_end];
-                let hash = bracket_content.split_whitespace().next_back().unwrap_or("");
-                if !hash.is_empty() && hash.len() >= 7 {
-                    // Git hashes are ASCII; chars().take(7) is safe regardless
-                    let short_hash: String = hash.chars().take(7).collect();
-                    format!("ok {}", short_hash)
-                } else {
-                    "ok".to_string()
-                }
-            } else {
-                "ok".to_string()
-            }
+            parse_commit_output(line)
         } else {
             "ok".to_string()
         };
@@ -2276,6 +2282,52 @@ no changes added to commit (use "git add" and/or "git commit -a")
         let porcelain = "## main\nA  🎉-party.txt\n M 日本語ファイル.rs\n";
         let result = format_status_output(porcelain);
         assert!(result.contains("* main"));
+    }
+
+    // --- commit output parsing ---
+
+    #[test]
+    fn test_parse_commit_output_normal() {
+        let line = "[main abc1234def] add feature";
+        assert_eq!(parse_commit_output(line), "ok abc1234");
+    }
+
+    #[test]
+    fn test_parse_commit_output_root_commit() {
+        let line = "[main (root-commit) abc1234def] initial commit";
+        assert_eq!(parse_commit_output(line), "ok abc1234");
+    }
+
+    /// Regression test: multibyte branch name must not panic (was byte-slicing before fix)
+    #[test]
+    fn test_parse_commit_output_multibyte_branch() {
+        let line = "[分支名 abc1234def] 提交消息";
+        assert_eq!(parse_commit_output(line), "ok abc1234");
+    }
+
+    /// Regression test: Thai branch name (3 bytes per char)
+    #[test]
+    fn test_parse_commit_output_thai_branch() {
+        let line = "[สาขา abc1234def] commit message";
+        assert_eq!(parse_commit_output(line), "ok abc1234");
+    }
+
+    #[test]
+    fn test_parse_commit_output_no_bracket() {
+        let line = "some other output";
+        assert_eq!(parse_commit_output(line), "ok");
+    }
+
+    #[test]
+    fn test_parse_commit_output_short_hash() {
+        // Hash shorter than 7 chars — treat as "ok" (no hash shown)
+        let line = "[main abc12] message";
+        assert_eq!(parse_commit_output(line), "ok");
+    }
+
+    #[test]
+    fn test_parse_commit_output_empty() {
+        assert_eq!(parse_commit_output(""), "ok");
     }
 
     /// Regression test: --oneline and other user format flags must preserve all commits.

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -961,11 +961,16 @@ fn run_commit(args: &[String], verbose: u8, global_args: &[String]) -> Result<i3
 
     if output.status.success() {
         // Extract commit hash from output like "[main abc1234] message"
+        // or "[main (root-commit) abc1234] message" (incl. localized variants)
+        // The hash is always the last whitespace-separated token before ']'.
         let compact = if let Some(line) = stdout.lines().next() {
-            if let Some(hash_start) = line.find(' ') {
-                let hash = line[1..hash_start].split(' ').next_back().unwrap_or("");
+            if let Some(bracket_end) = line.find(']') {
+                let bracket_content = &line[1..bracket_end];
+                let hash = bracket_content.split_whitespace().next_back().unwrap_or("");
                 if !hash.is_empty() && hash.len() >= 7 {
-                    format!("ok {}", &hash[..7.min(hash.len())])
+                    // Git hashes are ASCII; chars().take(7) is safe regardless
+                    let short_hash: String = hash.chars().take(7).collect();
+                    format!("ok {}", short_hash)
                 } else {
                     "ok".to_string()
                 }


### PR DESCRIPTION
git commit on an initial commit under a Chinese locale outputs:
  [master（根提交） fb597ec] Initial commit

The old code found the first space and sliced line[1..hash_start], yielding "master（根提交）" (21 bytes).  hash.len() >= 7 was true, so it tried &hash[..7] — but byte 7 falls inside the 3-byte '（' character, causing a panic.

Two bugs were present:
1. Logic: the code grabbed the token *before* the first space (branch name), not the commit hash.  The hash is always the last whitespace-separated token inside the [...] brackets.
2. Safety: raw byte slicing on a potentially non-ASCII string.

Fix: find ']', extract the bracket content, split_whitespace() and take next_back() to get the hash.  Use chars().take(7) for the short-hash slice so it is always char-boundary-safe.

## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

-

## Test plan
<!-- How did you verify this works? -->

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
