### PR TITLE
fix(pytest,grep): harden quiet summary and grep match parsing

### DIFF
--- a/src/cmds/python/pytest_cmd.rs
+++ b/src/cmds/python/pytest_cmd.rs
@@ -12,6 +12,32 @@ enum ParseState {
     Summary,
 }
 
+fn is_summary_line(line: &str) -> bool {
+    let normalized = line.trim().trim_matches('=').trim().to_lowercase();
+    if normalized.is_empty() {
+        return false;
+    }
+
+    if normalized.starts_with("no tests ran") {
+        return true;
+    }
+
+    let Some(first_token) = normalized.split_whitespace().next() else {
+        return false;
+    };
+    if first_token.parse::<usize>().is_err() {
+        return false;
+    }
+
+    normalized.contains(" passed")
+        || normalized.contains(" failed")
+        || normalized.contains(" skipped")
+        || normalized.contains(" xfailed")
+        || normalized.contains(" xpassed")
+        || normalized.contains(" error")
+        || normalized.contains(" errors")
+}
+
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     let mut cmd = if tool_exists("pytest") {
         resolved_command("pytest")
@@ -73,23 +99,7 @@ pub(crate) fn filter_pytest_output(output: &str) -> String {
                 current_failure.clear();
             }
             continue;
-        } else if trimmed.starts_with("===")
-            && (trimmed.contains("passed")
-                || trimmed.contains("failed")
-                || trimmed.contains("skipped"))
-        {
-            summary_line = trimmed.to_string();
-            continue;
-        // quiet mode (-q): bare summary without === wrapper, e.g. "5 failed, 1698 passed, 2 skipped in 108.89s"
-        } else if summary_line.is_empty()
-            && !trimmed.starts_with("===")
-            && !trimmed.starts_with("FAILED")
-            && !trimmed.starts_with("ERROR")
-            && (trimmed.contains(" passed")
-                || trimmed.contains(" failed")
-                || trimmed.contains(" skipped"))
-            && trimmed.contains(" in ")
-        {
+        } else if is_summary_line(trimmed) {
             summary_line = trimmed.to_string();
             continue;
         }
@@ -142,6 +152,10 @@ pub(crate) fn filter_pytest_output(output: &str) -> String {
 }
 
 fn build_pytest_summary(summary: &str, _test_files: &[String], failures: &[String]) -> String {
+    if summary.to_lowercase().contains("no tests ran") {
+        return "Pytest: No tests collected".to_string();
+    }
+
     // Parse summary line
     let (passed, failed, skipped) = parse_summary_line(summary);
 
@@ -272,6 +286,15 @@ tests/test_foo.py .....                                            [100%]
     }
 
     #[test]
+    fn test_filter_pytest_quiet_all_pass() {
+        let output = r#".........................                                                [100%]
+25 passed in 3.92s"#;
+
+        let result = filter_pytest_output(output);
+        assert_eq!(result, "Pytest: 25 passed");
+    }
+
+    #[test]
     fn test_filter_pytest_with_failures() {
         let output = r#"=== test session starts ===
 collected 5 items
@@ -333,6 +356,44 @@ collected 0 items
 
         let result = filter_pytest_output(output);
         assert!(result.contains("No tests collected"));
+    }
+
+    #[test]
+    fn test_filter_pytest_quiet_no_tests() {
+        let output = r#"no tests ran in 0.00s"#;
+
+        let result = filter_pytest_output(output);
+        assert_eq!(result, "Pytest: No tests collected");
+    }
+
+    #[test]
+    fn test_filter_pytest_quiet_failures() {
+        let output = r#"..F..                                                                    [100%]
+
+=================================== FAILURES ===================================
+_______________________________ test_something ________________________________
+
+    def test_something():
+>       assert False
+E       assert False
+
+tests/test_foo.py:10: AssertionError
+
+=========================== short test summary info ============================
+FAILED tests/test_foo.py::test_something - assert False
+4 passed, 1 failed in 0.50s"#;
+
+        let result = filter_pytest_output(output);
+        assert!(result.contains("4 passed, 1 failed"));
+        assert!(result.contains("test_something"));
+    }
+
+    #[test]
+    fn test_is_summary_line_detects_quiet_summary() {
+        assert!(is_summary_line("25 passed in 3.92s"));
+        assert!(is_summary_line("4 passed, 1 failed in 0.50s"));
+        assert!(is_summary_line("no tests ran in 0.00s"));
+        assert!(!is_summary_line("E       AssertionError: expected 5"));
     }
 
     #[test]

--- a/src/cmds/python/pytest_cmd.rs
+++ b/src/cmds/python/pytest_cmd.rs
@@ -12,6 +12,69 @@ enum ParseState {
     Summary,
 }
 
+#[derive(Debug, Default, PartialEq)]
+struct SummaryCounts {
+    passed: usize,
+    failed: usize,
+    errors: usize,
+    skipped: usize,
+    xfailed: usize,
+    xpassed: usize,
+    deselected: usize,
+}
+
+impl SummaryCounts {
+    fn total(&self) -> usize {
+        self.passed
+            + self.failed
+            + self.errors
+            + self.skipped
+            + self.xfailed
+            + self.xpassed
+            + self.deselected
+    }
+
+    fn has_failure_details(&self) -> bool {
+        self.failed > 0 || self.errors > 0
+    }
+
+    fn display_parts(&self) -> Vec<String> {
+        let mut parts = Vec::new();
+
+        if self.passed > 0 {
+            parts.push(format_outcome(self.passed, "passed", "passed"));
+        }
+        if self.failed > 0 {
+            parts.push(format_outcome(self.failed, "failed", "failed"));
+        }
+        if self.errors > 0 {
+            parts.push(format_outcome(self.errors, "error", "errors"));
+        }
+        if self.skipped > 0 {
+            parts.push(format_outcome(self.skipped, "skipped", "skipped"));
+        }
+        if self.xfailed > 0 {
+            parts.push(format_outcome(self.xfailed, "xfailed", "xfailed"));
+        }
+        if self.xpassed > 0 {
+            parts.push(format_outcome(self.xpassed, "xpassed", "xpassed"));
+        }
+        if self.deselected > 0 {
+            parts.push(format_outcome(self.deselected, "deselected", "deselected"));
+        }
+
+        parts
+    }
+}
+
+fn format_outcome(count: usize, singular: &str, plural: &str) -> String {
+    if count == 1 {
+        format!("1 {}", singular)
+    } else {
+        format!("{} {}", count, plural)
+    }
+}
+
 fn is_summary_line(line: &str) -> bool {
     let normalized = line.trim().trim_matches('=').trim().to_lowercase();
     if normalized.is_empty() {
@@ -32,6 +95,7 @@ fn is_summary_line(line: &str) -> bool {
     normalized.contains(" passed")
         || normalized.contains(" failed")
         || normalized.contains(" skipped")
+        || normalized.contains(" deselected")
         || normalized.contains(" xfailed")
         || normalized.contains(" xpassed")
         || normalized.contains(" error")
@@ -156,22 +220,29 @@ fn build_pytest_summary(summary: &str, _test_files: &[String], failures: &[Strin
         return "Pytest: No tests collected".to_string();
     }
 
-    // Parse summary line
-    let (passed, failed, skipped) = parse_summary_line(summary);
+    let counts = parse_summary_line(summary);
 
-    if failed == 0 && passed > 0 {
-        return format!("Pytest: {} passed", passed);
-    }
-
-    if passed == 0 && failed == 0 && skipped == 0 {
+    if counts.total() == 0 {
         return "Pytest: No tests collected".to_string();
     }
 
-    let mut result = String::new();
-    result.push_str(&format!("Pytest: {} passed, {} failed", passed, failed));
-    if skipped > 0 {
-        result.push_str(&format!(", {} skipped", skipped));
+    if counts.failed == 0
+        && counts.errors == 0
+        && counts.skipped == 0
+        && counts.xfailed == 0
+        && counts.xpassed == 0
+        && counts.deselected == 0
+        && counts.passed > 0
+    {
+        return format!("Pytest: {} passed", counts.passed);
     }
+
+    let mut result = format!("Pytest: {}", counts.display_parts().join(", "));
+
+    if !counts.has_failure_details() {
+        return result;
+    }
+
     result.push('\n');
     result.push_str("═══════════════════════════════════════\n");
 
@@ -192,12 +263,19 @@ fn build_pytest_summary(summary: &str, _test_files: &[String], failures: &[Strin
                 // Extract test name between ___
                 let test_name = first_line.trim_matches('_').trim();
                 result.push_str(&format!("{}. [FAIL] {}\n", i + 1, test_name));
-            } else if first_line.starts_with("FAILED") {
-                // Summary format: "FAILED tests/test_foo.py::test_bar - AssertionError"
+            } else if first_line.starts_with("FAILED") || first_line.starts_with("ERROR") {
+                // Summary format: "FAILED/ERROR tests/test_foo.py::test_bar - AssertionError"
                 let parts: Vec<&str> = first_line.split(" - ").collect();
                 if let Some(test_path) = parts.first() {
-                    let test_name = test_path.trim_start_matches("FAILED ");
-                    result.push_str(&format!("{}. [FAIL] {}\n", i + 1, test_name));
+                    let test_name = test_path
+                        .trim_start_matches("FAILED ")
+                        .trim_start_matches("ERROR ");
+                    let status = if first_line.starts_with("ERROR") {
+                        "ERROR"
+                    } else {
+                        "FAIL"
+                    };
+                    result.push_str(&format!("{}. [{}] {}\n", i + 1, status, test_name));
                 }
                 if parts.len() > 1 {
                     result.push_str(&format!("     {}\n", truncate(parts[1], 100)));
@@ -234,36 +312,38 @@ fn build_pytest_summary(summary: &str, _test_files: &[String], failures: &[Strin
     result.trim().to_string()
 }
 
-fn parse_summary_line(summary: &str) -> (usize, usize, usize) {
-    let mut passed = 0;
-    let mut failed = 0;
-    let mut skipped = 0;
+fn parse_summary_line(summary: &str) -> SummaryCounts {
+    let mut counts = SummaryCounts::default();
 
-    // Parse lines like "=== 4 passed, 1 failed in 0.50s ==="
+    // Parse lines like "=== 4 passed, 1 failed in 0.50s ===" or
+    // "1 passed, 1 error, 2 deselected in 0.50s"
     let parts: Vec<&str> = summary.split(',').collect();
 
     for part in parts {
         let words: Vec<&str> = part.split_whitespace().collect();
         for (i, word) in words.iter().enumerate() {
-            if i > 0 {
-                if word.contains("passed") {
-                    if let Ok(n) = words[i - 1].parse::<usize>() {
-                        passed = n;
-                    }
-                } else if word.contains("failed") {
-                    if let Ok(n) = words[i - 1].parse::<usize>() {
-                        failed = n;
-                    }
-                } else if word.contains("skipped") {
-                    if let Ok(n) = words[i - 1].parse::<usize>() {
-                        skipped = n;
-                    }
-                }
+            if i == 0 {
+                continue;
+            }
+
+            let Ok(n) = words[i - 1].parse::<usize>() else {
+                continue;
+            };
+
+            match word.trim_matches(|c: char| c == ',' || c == '=') {
+                "passed" => counts.passed = n,
+                "failed" => counts.failed = n,
+                "error" | "errors" => counts.errors = n,
+                "skipped" => counts.skipped = n,
+                "xfailed" => counts.xfailed = n,
+                "xpassed" => counts.xpassed = n,
+                "deselected" => counts.deselected = n,
+                _ => {}
             }
         }
     }
 
-    (passed, failed, skipped)
+    counts
 }
 
 #[cfg(test)]
@@ -389,23 +469,81 @@ FAILED tests/test_foo.py::test_something - assert False
     }
 
     #[test]
+    fn test_filter_pytest_quiet_error_summary() {
+        let output = r#"E                                                                       [100%]
+
+=========================== short test summary info ============================
+ERROR tests/test_foo.py::test_setup - RuntimeError: boom
+1 error in 0.20s"#;
+
+        let result = filter_pytest_output(output);
+        assert!(result.contains("Pytest: 1 error"));
+        assert!(result.contains("test_setup"));
+        assert!(result.contains("RuntimeError: boom"));
+    }
+
+    #[test]
+    fn test_filter_pytest_quiet_xfailed_summary() {
+        let output = r#".x                                                                      [100%]
+1 passed, 1 xfailed in 0.10s"#;
+
+        let result = filter_pytest_output(output);
+        assert_eq!(result, "Pytest: 1 passed, 1 xfailed");
+    }
+
+    #[test]
+    fn test_filter_pytest_quiet_deselected_summary() {
+        let output = r#"2 deselected in 0.02s"#;
+
+        let result = filter_pytest_output(output);
+        assert_eq!(result, "Pytest: 2 deselected");
+    }
+
+    #[test]
     fn test_is_summary_line_detects_quiet_summary() {
         assert!(is_summary_line("25 passed in 3.92s"));
         assert!(is_summary_line("4 passed, 1 failed in 0.50s"));
         assert!(is_summary_line("no tests ran in 0.00s"));
+        assert!(is_summary_line("2 deselected in 0.02s"));
         assert!(!is_summary_line("E       AssertionError: expected 5"));
     }
 
     #[test]
     fn test_parse_summary_line() {
-        assert_eq!(parse_summary_line("=== 5 passed in 0.50s ==="), (5, 0, 0));
+        assert_eq!(
+            parse_summary_line("=== 5 passed in 0.50s ==="),
+            SummaryCounts {
+                passed: 5,
+                ..Default::default()
+            }
+        );
         assert_eq!(
             parse_summary_line("=== 4 passed, 1 failed in 0.50s ==="),
-            (4, 1, 0)
+            SummaryCounts {
+                passed: 4,
+                failed: 1,
+                ..Default::default()
+            }
         );
         assert_eq!(
             parse_summary_line("=== 3 passed, 1 failed, 2 skipped in 1.0s ==="),
-            (3, 1, 2)
+            SummaryCounts {
+                passed: 3,
+                failed: 1,
+                skipped: 2,
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            parse_summary_line("1 passed, 1 error, 2 deselected, 3 xfailed, 4 xpassed in 1.0s"),
+            SummaryCounts {
+                passed: 1,
+                errors: 1,
+                deselected: 2,
+                xfailed: 3,
+                xpassed: 4,
+                ..Default::default()
+            }
         );
     }
 

--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -7,6 +7,35 @@ use crate::core::utils::resolved_command;
 use anyhow::{Context, Result};
 use regex::Regex;
 use std::collections::HashMap;
+use std::process::Stdio;
+
+fn parse_match_line(line: &str, default_path: &str) -> Option<(String, usize, String)> {
+    let parts: Vec<&str> = line.splitn(3, ':').collect();
+
+    match parts.as_slice() {
+        [line_num, content] => Some((
+            default_path.to_string(),
+            line_num.parse().unwrap_or(0),
+            (*content).to_string(),
+        )),
+        [first, second, third] => {
+            if let Ok(line_num) = first.parse::<usize>() {
+                Some((
+                    default_path.to_string(),
+                    line_num,
+                    format!("{}:{}", second, third),
+                ))
+            } else {
+                Some((
+                    (*first).to_string(),
+                    second.parse().unwrap_or(0),
+                    (*third).to_string(),
+                ))
+            }
+        }
+        _ => None,
+    }
+}
 
 #[allow(clippy::too_many_arguments)]
 pub fn run(
@@ -33,7 +62,9 @@ pub fn run(
     // Without this, rg returns 0 matches for files in .gitignore, causing
     // false negatives that make AI agents draw wrong conclusions.
     // Using --no-ignore-vcs (not --no-ignore) so .ignore/.rgignore are still respected.
-    rg_cmd.args(["-n", "--no-heading", "--no-ignore-vcs", &rg_pattern, path]);
+    rg_cmd
+        .args(["-H", "-n", "--no-heading", "--no-ignore-vcs", &rg_pattern, path])
+        .stdin(Stdio::null());
 
     if let Some(ft) = file_type {
         rg_cmd.arg("--type").arg(ft);
@@ -50,7 +81,9 @@ pub fn run(
     let result = exec_capture(&mut rg_cmd)
         .or_else(|_| {
             let mut grep_cmd = resolved_command("grep");
-            grep_cmd.args(["-rn", pattern, path]);
+            grep_cmd
+                .args(["-H", "-r", "-n", pattern, path])
+                .stdin(Stdio::null());
             exec_capture(&mut grep_cmd)
         })
         .context("grep/rg failed")?;
@@ -89,19 +122,11 @@ pub fn run(
 
     let mut by_file: HashMap<String, Vec<(usize, String)>> = HashMap::new();
     for line in result.stdout.lines() {
-        let parts: Vec<&str> = line.splitn(3, ':').collect();
-
-        let (file, line_num, content) = if parts.len() == 3 {
-            let ln = parts[1].parse().unwrap_or(0);
-            (parts[0].to_string(), ln, parts[2])
-        } else if parts.len() == 2 {
-            let ln = parts[0].parse().unwrap_or(0);
-            (path.to_string(), ln, parts[1])
-        } else {
+        let Some((file, line_num, content)) = parse_match_line(line, path) else {
             continue;
         };
 
-        let cleaned = clean_line(content, max_line_len, context_re.as_ref(), pattern);
+        let cleaned = clean_line(&content, max_line_len, context_re.as_ref(), pattern);
         by_file.entry(file).or_default().push((line_num, cleaned));
     }
 
@@ -231,6 +256,22 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_match_line_with_file_path() {
+        let parsed = parse_match_line("src/main.rs:42:fn main() {", "src/main.rs").unwrap();
+        assert_eq!(parsed.0, "src/main.rs");
+        assert_eq!(parsed.1, 42);
+        assert_eq!(parsed.2, "fn main() {");
+    }
+
+    #[test]
+    fn test_parse_match_line_single_file_without_path() {
+        let parsed = parse_match_line("271:class PluginManager:", "hermes_cli/plugins.py").unwrap();
+        assert_eq!(parsed.0, "hermes_cli/plugins.py");
+        assert_eq!(parsed.1, 271);
+        assert_eq!(parsed.2, "class PluginManager:");
+    }
+
+    #[test]
     fn test_extra_args_accepted() {
         // Test that the function signature accepts extra_args
         // This is a compile-time test - if it compiles, the signature is correct
@@ -299,15 +340,15 @@ mod tests {
     // The -n/--line-numbers clap flag in main.rs is a no-op accepted for compat.
     #[test]
     fn test_rg_always_has_line_numbers() {
-        // grep_cmd::run() always passes "-n" to rg (line 24).
-        // This test documents that -n is built-in, so the clap flag is safe to ignore.
+        // grep_cmd::run() always passes "-H -n" to rg (line 33).
+        // This test documents that -H and -n are accepted, so single-file matches keep filenames.
         let mut cmd = resolved_command("rg");
-        cmd.args(["-n", "--no-heading", "NONEXISTENT_PATTERN_12345", "."]);
-        // If rg is available, it should accept -n without error (exit 1 = no match, not error)
+        cmd.args(["-H", "-n", "--no-heading", "NONEXISTENT_PATTERN_12345", "."]);
+        // If rg is available, it should accept -H/-n without error (exit 1 = no match, not error)
         if let Ok(output) = cmd.output() {
             assert!(
                 output.status.code() == Some(1) || output.status.success(),
-                "rg -n should be accepted"
+                "rg -H -n should be accepted"
             );
         }
         // If rg is not installed, skip gracefully (test still passes)

--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -10,29 +10,24 @@ use std::collections::HashMap;
 use std::process::Stdio;
 
 fn parse_match_line(line: &str, default_path: &str) -> Option<(String, usize, String)> {
-    let parts: Vec<&str> = line.splitn(3, ':').collect();
+    lazy_static::lazy_static! {
+        static ref MATCH_LINE_RE: Regex = Regex::new(r"^(.+):(\d+):(.*)$").unwrap();
+    }
 
+    if let Some(caps) = MATCH_LINE_RE.captures(line) {
+        let file = caps.get(1)?.as_str().to_string();
+        let line_num = caps.get(2)?.as_str().parse().ok()?;
+        let content = caps.get(3)?.as_str().to_string();
+        return Some((file, line_num, content));
+    }
+
+    let parts: Vec<&str> = line.splitn(2, ':').collect();
     match parts.as_slice() {
         [line_num, content] => Some((
             default_path.to_string(),
-            line_num.parse().unwrap_or(0),
+            line_num.parse().ok()?,
             (*content).to_string(),
         )),
-        [first, second, third] => {
-            if let Ok(line_num) = first.parse::<usize>() {
-                Some((
-                    default_path.to_string(),
-                    line_num,
-                    format!("{}:{}", second, third),
-                ))
-            } else {
-                Some((
-                    (*first).to_string(),
-                    second.parse().unwrap_or(0),
-                    (*third).to_string(),
-                ))
-            }
-        }
         _ => None,
     }
 }
@@ -93,10 +88,8 @@ pub fn run(
 
     if result.stdout.trim().is_empty() {
         // Show stderr for errors (bad regex, missing file, etc.)
-        if exit_code == 2 {
-            if !result.stderr.trim().is_empty() {
-                eprintln!("{}", result.stderr.trim());
-            }
+        if exit_code == 2 && !result.stderr.trim().is_empty() {
+            eprintln!("{}", result.stderr.trim());
         }
         let msg = format!("0 matches for '{}'", pattern);
         println!("{}", msg);
@@ -269,6 +262,29 @@ mod tests {
         assert_eq!(parsed.0, "hermes_cli/plugins.py");
         assert_eq!(parsed.1, 271);
         assert_eq!(parsed.2, "class PluginManager:");
+    }
+
+    #[test]
+    fn test_parse_match_line_with_content_colons() {
+        let parsed = parse_match_line(
+            "externalImportShell.class.php:81:        $this->queueProcessModel = ClassRegistry::init('Collections.QueueProcess');",
+            "externalImportShell.class.php",
+        )
+        .unwrap();
+        assert_eq!(parsed.0, "externalImportShell.class.php");
+        assert_eq!(parsed.1, 81);
+        assert_eq!(
+            parsed.2,
+            "        $this->queueProcessModel = ClassRegistry::init('Collections.QueueProcess');"
+        );
+    }
+
+    #[test]
+    fn test_parse_match_line_windows_path() {
+        let parsed = parse_match_line(r"C:\src\file.rs:42:fn main() {}", r"C:\src\file.rs").unwrap();
+        assert_eq!(parsed.0, r"C:\src\file.rs");
+        assert_eq!(parsed.1, 42);
+        assert_eq!(parsed.2, "fn main() {}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- harden pytest quiet-mode summary detection and summary parsing
- surface quiet-mode error/xfailed/xpassed/deselected outcomes correctly
- harden grep match parsing for single-file output, Windows paths, and content containing colons
- keep filenames in rg/grep output with `-H` and fix the output label typo

## Why
While integrating RTK auto-rewrite into Hermes Agent, two parser edge cases showed up:
- `pytest -q` can end with summaries like `25 passed in 3.92s`, `1 error in 0.20s`, or `2 deselected in 0.02s`; the old logic mainly relied on the `=== ... ===` style summary and could fall back to `Pytest: No tests collected`
- single-file grep output can omit the filename, and Windows paths / colon-rich content make naive `split(':')` parsing unsafe

## Changes
### pytest
- add `SummaryCounts` parsing for passed / failed / errors / skipped / xfailed / xpassed / deselected
- detect quiet summaries and `no tests ran` lines via `is_summary_line()`
- preserve failure/error detail rendering in the compact RTK summary

### grep
- add `parse_match_line()` to safely parse `file:line:text` and fallback `line:text`
- force filenames with `-H` for both `rg` and `grep`
- add regression coverage for Windows paths and content containing colons

## Validation
- `cargo test`
- `cargo fmt --all --check`
- `cargo clippy --all-targets`
