### PR TITLE
fix(tracking): rename history.db to tracking.db to match documentation

### DIFF
--- a/src/core/constants.rs
+++ b/src/core/constants.rs
@@ -1,5 +1,7 @@
 pub const RTK_DATA_DIR: &str = "rtk";
-pub const HISTORY_DB: &str = "history.db";
+pub const TRACKING_DB: &str = "tracking.db";
+// Legacy alias for backward compatibility (references to history.db)
+pub const HISTORY_DB: &str = TRACKING_DB;
 pub const CONFIG_TOML: &str = "config.toml";
 pub const FILTERS_TOML: &str = "filters.toml";
 pub const TRUSTED_FILTERS_JSON: &str = "trusted_filters.json";

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -29,7 +29,7 @@
 //!
 //! See [docs/tracking.md](../docs/tracking.md) for full documentation.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection};
 use serde::Serialize;
@@ -61,7 +61,7 @@ fn project_filter_params(project_path: Option<&str>) -> (Option<String>, Option<
     }
 }
 
-use super::constants::{DEFAULT_HISTORY_DAYS, HISTORY_DB, RTK_DATA_DIR};
+use super::constants::{DEFAULT_HISTORY_DAYS, RTK_DATA_DIR, TRACKING_DB};
 
 /// Main tracking interface for recording and querying command history.
 ///
@@ -250,6 +250,21 @@ impl Tracker {
         let db_path = get_db_path()?;
         if let Some(parent) = db_path.parent() {
             std::fs::create_dir_all(parent)?;
+        }
+
+        // Migration: rename history.db to tracking.db if it exists
+        let history_db_path = db_path
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("."))
+            .join("history.db");
+        if !db_path.exists() && history_db_path.exists() {
+            std::fs::rename(&history_db_path, &db_path).with_context(|| {
+                format!(
+                    "Failed to migrate {} to {}",
+                    history_db_path.display(),
+                    db_path.display()
+                )
+            })?;
         }
 
         let conn = Connection::open(&db_path)?;
@@ -1168,7 +1183,7 @@ fn get_db_path() -> Result<PathBuf> {
 
     // Priority 3: Default platform-specific location
     let data_dir = dirs::data_local_dir().unwrap_or_else(|| PathBuf::from("."));
-    Ok(data_dir.join(RTK_DATA_DIR).join(HISTORY_DB))
+    Ok(data_dir.join(RTK_DATA_DIR).join(TRACKING_DB))
 }
 
 /// Individual parse failure record.
@@ -1503,7 +1518,7 @@ mod tests {
         env::remove_var("RTK_DB_PATH");
 
         let db_path = get_db_path().expect("Failed to get db path");
-        assert!(db_path.ends_with("rtk/history.db"));
+        assert!(db_path.ends_with("rtk/tracking.db"));
     }
 
     // 9. project_filter_params uses GLOB pattern with * wildcard // added


### PR DESCRIPTION
## Problem
Naming inconsistency between documentation and code:
- **Documentation says**: `~/.local/share/rtk/tracking.db`
- **Code actually uses**: `~/.local/share/rtk/history.db`

This causes confusion when users look for `tracking.db` but find `history.db` instead.

## Solution
- Add `TRACKING_DB` constant with value `"tracking.db"`
- Keep `HISTORY_DB` as a legacy alias pointing to `TRACKING_DB`
- Auto-migrate existing `history.db` to `tracking.db` on first run
- Update imports and test assertions

## Changes
- `src/core/constants.rs`: Add `TRACKING_DB`, keep `HISTORY_DB` as alias
- `src/core/tracking.rs`: 
  - Import `TRACKING_DB` instead of `HISTORY_DB`
  - Add migration logic in `Tracker::new()`
  - Update `get_db_path()` to use `TRACKING_DB`
  - Update test assertion to expect `tracking.db`

## Testing
All 14 tracking tests pass, including:
- `test_default_db_path`: Now expects `tracking.db`
- Migration logic tested manually with existing `history.db`

## Backward Compatibility
- `HISTORY_DB` constant still works (as alias to `TRACKING_DB`)
- Existing `history.db` files are auto-migrated to `tracking.db`
- No breaking changes to public API

🤖 Generated with [Claude Code](https://claude.com/claude-code)