### PR TITLE
fix(npx): route unknown packages directly via npx, not npm run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+* **npx:** fix `rtk npx <package> --flags` calling `npm run <package>` instead of `npx <package>` for unknown packages like `vue-tsc` ([#1269](https://github.com/rtk-ai/rtk/issues/1269))
 * **git:** remove `-u` short alias from `--ultra-compact` to fix `git push -u` upstream tracking ([#1086](https://github.com/rtk-ai/rtk/issues/1086))
 
 ## [0.35.0](https://github.com/rtk-ai/rtk/compare/v0.34.3...v0.35.0) (2026-04-06)

--- a/src/cmds/js/npm_cmd.rs
+++ b/src/cmds/js/npm_cmd.rs
@@ -4,6 +4,32 @@ use crate::core::runner;
 use crate::core::utils::resolved_command;
 use anyhow::Result;
 
+/// Generic npx passthrough: runs `npx <args>` directly without injecting "run".
+/// Used for unknown npx packages like `vue-tsc`, `taze`, etc.
+pub fn run_npx(args: &[String], verbose: u8, skip_env: bool) -> Result<i32> {
+    let mut cmd = resolved_command("npx");
+
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    if skip_env {
+        cmd.env("SKIP_ENV_VALIDATION", "1");
+    }
+
+    if verbose > 0 {
+        eprintln!("Running: npx {}", args.join(" "));
+    }
+
+    runner::run_filtered(
+        cmd,
+        "npx",
+        &args.join(" "),
+        filter_npm_output,
+        runner::RunOptions::default(),
+    )
+}
+
 /// Known npm subcommands that should NOT get "run" injected.
 /// Shared between production code and tests to avoid drift.
 const NPM_SUBCOMMANDS: &[&str] = &[
@@ -220,4 +246,26 @@ npm notice
         let result = filter_npm_output(output);
         assert_eq!(result, "ok");
     }
+
+    // Regression: https://github.com/rtk-ai/rtk/issues/1269
+    #[test]
+    fn test_npx_vue_tsc_output_passes_through() {
+        let output = r#"src/components/Foo.vue:10:5 - error TS2322: Type 'string' is not assignable to type 'number'.
+
+10     const count: number = "hello"
+       ~~~~~
+
+src/components/Bar.vue:5:3 - error TS2339: Property 'foo' does not exist on type '{}'.
+
+5   this.foo
+    ~~~~
+
+Found 2 errors in 2 files.
+"#;
+        let result = filter_npm_output(output);
+        assert!(result.contains("error TS2322"), "type error must be preserved");
+        assert!(result.contains("error TS2339"), "type error must be preserved");
+        assert!(result.contains("Found 2 errors"), "error summary must be preserved");
+    }
+
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1978,7 +1978,7 @@ fn run_cli() -> Result<i32> {
                 "playwright" => playwright_cmd::run(&args[1..], cli.verbose)?,
                 _ => {
                     // Generic passthrough with npm boilerplate filter
-                    npm_cmd::run(&args, cli.verbose, cli.skip_env)?
+                    npm_cmd::run_npx(&args, cli.verbose, cli.skip_env)?
                 }
             }
         }


### PR DESCRIPTION
## Problem

`rtk npx vue-tsc --noEmit` was calling `npm run vue-tsc --noEmit` instead of `npx vue-tsc --noEmit`, producing `npm error Missing script: "vue-tsc"`.

Root cause: the default `Commands::Npx` handler called `npm_cmd::run()` which injects `run` before any argument not found in `NPM_SUBCOMMANDS`. Since `vue-tsc` is not in that list, it became `npm run vue-tsc`.

Note: `rtk npx vue-tsc --version` appeared to work by accident — npm silently consumes `--version` as its own flag rather than passing it to the script.

## Fix

Add `npm_cmd::run_npx()` that calls `npx <args>` directly without any `run` injection, and use it as the default handler for unknown packages in `Commands::Npx`.

## Testing

```
# Before (system rtk 0.35.0)
$ rtk npx vue-tsc --noEmit
npm error Missing script: "vue-tsc"

# After
$ rtk npx vue-tsc --noEmit
Version 6.0.2
tsc: The TypeScript Compiler - Version 6.0.2
...
```

Fixes #1269