### PR TITLE
fix: force C locale in run_filtered to fix non-English locale parsing

### DIFF
--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -65,6 +65,13 @@ where
 {
     let timer = tracking::TimedExecution::start();
 
+    // Force C locale so that filtered subcommands (ls, git, find, …) emit
+    // English output that matches the existing regexes.  Without this, non-
+    // English locales cause parse failures (e.g. `rtk ls` returns "(empty)").
+    // Intentionally NOT applied to `run_passthrough`, which shows raw output
+    // to the user and should respect their real locale.
+    cmd.env("LC_ALL", "C");
+
     let output = cmd
         .output()
         .with_context(|| format!("Failed to run {}", tool_name))?;


### PR DESCRIPTION
## Summary

Fixes #1276.

`run_filtered` spawns subcommands without overriding the locale, so on non-English systems the output (e.g. localized month names from `ls -la`) does not match the English regexes used by filters. This causes commands like `rtk ls` to report `(empty)` for directories that actually contain files.

## Changes

Added `cmd.env("LC_ALL", "C")` in `run_filtered` (1-line fix) so every filtered subprocess emits C-locale output that the existing regexes can parse correctly.

`run_passthrough` is intentionally left unchanged — it shows output verbatim to the user and should respect their real locale.

## Test plan

- [x] Verified the fix matches the suggested approach in #1276
- [x] Single-line change scoped to `run_filtered` only