### PR TITLE
fix(discover): decimal already_rtk%, weighted savings rate per bucket

### DIFF
--- a/src/discover/mod.rs
+++ b/src/discover/mod.rs
@@ -21,8 +21,13 @@ struct SupportedBucket {
     rtk_equivalent: &'static str,
     category: &'static str,
     count: usize,
+    /// Total estimated tokens *saved* (post-filter). Used for the "Est. Savings" column.
     total_output_tokens: usize,
-    savings_pct: f64,
+    /// Total estimated tokens *before* filtering (raw output). Accumulated alongside
+    /// `total_output_tokens` so the bucket's effective savings rate can be derived as
+    /// `total_output_tokens / total_raw_output_tokens` — a weighted average across
+    /// all sub-commands, regardless of which sub-command was seen first.
+    total_raw_output_tokens: usize,
     // For display: the most common raw command
     command_counts: HashMap<String, usize>,
 }
@@ -120,7 +125,7 @@ pub fn run(
                                 category,
                                 count: 0,
                                 total_output_tokens: 0,
-                                savings_pct: estimated_savings_pct,
+                                total_raw_output_tokens: 0,
                                 command_counts: HashMap::new(),
                             }
                         });
@@ -140,6 +145,9 @@ pub fn run(
                         let savings =
                             (output_tokens as f64 * estimated_savings_pct / 100.0) as usize;
                         bucket.total_output_tokens += savings;
+                        // Accumulate pre-savings tokens so we can compute a weighted effective
+                        // savings rate across all sub-commands in this bucket later.
+                        bucket.total_raw_output_tokens += output_tokens;
 
                         // Track the display name with status
                         let display_name = truncate_command(part);
@@ -196,13 +204,22 @@ pub fn run(
                 })
                 .unwrap_or_else(|| (String::new(), report::RtkStatus::Existing));
 
+            // Derive the effective savings rate from accumulated totals rather than
+            // using the first-seen sub-command's rate. This gives a weighted average
+            // across all sub-commands that fell in this bucket.
+            let effective_savings_pct = if bucket.total_raw_output_tokens > 0 {
+                bucket.total_output_tokens as f64 * 100.0 / bucket.total_raw_output_tokens as f64
+            } else {
+                0.0
+            };
+
             SupportedEntry {
                 command: command_with_status,
                 count: bucket.count,
                 rtk_equivalent: bucket.rtk_equivalent,
                 category: bucket.category,
                 estimated_savings_tokens: bucket.total_output_tokens,
-                estimated_savings_pct: bucket.savings_pct,
+                estimated_savings_pct: effective_savings_pct,
                 rtk_status: status,
             }
         })

--- a/src/discover/report.rs
+++ b/src/discover/report.rs
@@ -83,12 +83,12 @@ pub fn format_text(report: &DiscoverReport, limit: usize, verbose: bool) -> Stri
         report.sessions_scanned, report.since_days, report.total_commands
     ));
     out.push_str(&format!(
-        "Already using RTK: {} commands ({}%)\n",
+        "Already using RTK: {} commands ({:.1}%)\n",
         report.already_rtk,
         if report.total_commands > 0 {
-            report.already_rtk * 100 / report.total_commands
+            report.already_rtk as f64 * 100.0 / report.total_commands as f64
         } else {
-            0
+            0.0
         }
     ));
 
@@ -212,5 +212,59 @@ fn truncate_str(s: &str, max: usize) -> String {
             .map(|(_, c)| c)
             .collect();
         format!("{}..", truncated)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_report(total_commands: usize, already_rtk: usize) -> DiscoverReport {
+        DiscoverReport {
+            sessions_scanned: 1,
+            total_commands,
+            already_rtk,
+            since_days: 30,
+            supported: vec![],
+            unsupported: vec![],
+            parse_errors: 0,
+            rtk_disabled_count: 0,
+            rtk_disabled_examples: vec![],
+        }
+    }
+
+    // B6 regression: integer division truncated small percentages to 0%.
+    // Example: 3/1000 = 0% (old bug), should be "0.3%".
+    #[test]
+    fn test_already_rtk_percent_shows_decimal() {
+        let report = make_report(1000, 3);
+        let output = format_text(&report, 10, false);
+        // "0.3%" must appear; old code would print "0%"
+        assert!(
+            output.contains("0.3%"),
+            "Expected '0.3%' in output but got:\n{}",
+            output
+        );
+        assert!(
+            !output.contains("(0%)"),
+            "Output must not contain '(0%)' — integer division bug still present:\n{}",
+            output
+        );
+    }
+
+    // Edge case: 0/0 must not divide-by-zero.
+    #[test]
+    fn test_already_rtk_percent_zero_total() {
+        let report = make_report(0, 0);
+        let output = format_text(&report, 10, false);
+        assert!(output.contains("0 commands (0.0%)"));
+    }
+
+    // Full percent: 1000/1000 = 100.0%
+    #[test]
+    fn test_already_rtk_percent_full() {
+        let report = make_report(1000, 1000);
+        let output = format_text(&report, 10, false);
+        assert!(output.contains("100.0%"));
     }
 }


### PR DESCRIPTION
## Summary

Two display accuracy fixes in `rtk discover`:

**B6 — Integer division truncated small percentages** (`report.rs:88`)
- `already_rtk * 100 / total_commands` (integer) → `0%` for anything under 1%
- Fix: `already_rtk as f64 * 100.0 / total_commands as f64` with `{:.1}%` format
- 3 regression tests added (0.3%, 0%, 100%)

**B7 — Bucket savings rate was first-write, not weighted** (`mod.rs:123`)
- `SupportedBucket.savings_pct` was set once from the first-seen sub-command and never updated. For buckets containing multiple sub-commands (e.g. `git add` 59% then `git diff` 80% both land in `rtk git`), the displayed `estimated_savings_pct` only reflected the first classification.
- Fix: added `total_raw_output_tokens: usize` to `SupportedBucket`, accumulated alongside existing `total_output_tokens` (savings). At entry construction, `effective_savings_pct = saved / raw * 100` gives a correct weighted average. Exposed in `rtk discover --format json`.

## Test plan

- [ ] `cargo test --all` passes
- [ ] `test_already_rtk_percent_shows_decimal` — 3/1000 → "0.3%"
- [ ] `test_already_rtk_percent_zero_total` — 0/0 → "0.0%"
- [ ] `test_already_rtk_percent_full` — 1000/1000 → "100.0%"
- [ ] `rtk discover --days 90` shows decimal percent in header

🤖 Generated with [Claude Code](https://claude.com/claude-code)