### PR TITLE
fix(git): fix --reverse showing newest commits instead of oldest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 * **git:** remove `-u` short alias from `--ultra-compact` to fix `git push -u` upstream tracking ([#1086](https://github.com/rtk-ai/rtk/issues/1086))
+* **git:** fix `rtk git log --reverse` silently showing newest-N commits reversed instead of oldest-N commits; RTK no longer injects a default `-N` limit when `--reverse` is present, so git emits commits oldest-first and RTK caps to the first 50 ([#1296](https://github.com/rtk-ai/rtk/issues/1296))
 
 ## [0.35.0](https://github.com/rtk-ai/rtk/compare/v0.34.3...v0.35.0) (2026-04-06)
 

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -412,14 +412,18 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
     result.join("\n")
 }
 
-fn run_log(
-    args: &[String],
-    _max_lines: Option<usize>,
-    verbose: u8,
-    global_args: &[String],
-) -> Result<i32> {
-    let timer = tracking::TimedExecution::start();
+/// Parameters resolved from user args for `git log`.
+struct LogParams {
+    limit: usize,
+    user_set_limit: bool,
+    has_format_flag: bool,
+    has_reverse_flag: bool,
+}
 
+/// Build the `git log` Command with RTK defaults applied, and return resolved params.
+/// Extracted for testability: callers can inspect the assembled Command args without
+/// executing git.
+fn build_log_command(args: &[String], global_args: &[String]) -> (Command, LogParams) {
     let mut cmd = git_cmd(global_args);
     cmd.arg("log");
 
@@ -435,6 +439,9 @@ fn run_log(
             || arg.starts_with("--max-count")
     });
 
+    // Check if user requested reverse chronological order
+    let has_reverse_flag = args.iter().any(|arg| arg == "--reverse");
+
     // Apply RTK defaults only if user didn't specify them
     // Use %b (body) to preserve first line of commit body for agent context
     // (BREAKING CHANGE, Closes #xxx, design notes)
@@ -447,6 +454,14 @@ fn run_log(
         // User explicitly passed -N / -n N / --max-count=N → respect their choice
         let n = parse_user_limit(args).unwrap_or(10);
         (n, true)
+    } else if has_reverse_flag {
+        // --reverse without explicit -N: do NOT inject -N into git.
+        // `git log -50 --reverse` picks the 50 most-recent commits then reverses them —
+        // user sees 2025 commits oldest-first instead of historical data from 2022.
+        // Fix: let git stream all commits oldest-first, then RTK caps the output at
+        // the normal limit → user gets the N *oldest* commits (correct).
+        let limit = if has_format_flag { 50 } else { 10 };
+        (limit, false)
     } else if has_format_flag {
         // --oneline / --pretty without -N: user wants compact output, allow more
         cmd.arg("-50");
@@ -470,6 +485,33 @@ fn run_log(
         cmd.arg(arg);
     }
 
+    (
+        cmd,
+        LogParams {
+            limit,
+            user_set_limit,
+            has_format_flag,
+            has_reverse_flag,
+        },
+    )
+}
+
+fn run_log(
+    args: &[String],
+    _max_lines: Option<usize>,
+    verbose: u8,
+    global_args: &[String],
+) -> Result<i32> {
+    let timer = tracking::TimedExecution::start();
+
+    let (mut cmd, params) = build_log_command(args, global_args);
+    let LogParams {
+        limit,
+        user_set_limit,
+        has_format_flag,
+        has_reverse_flag,
+    } = params;
+
     let result = exec_capture(&mut cmd).context("Failed to run git log")?;
 
     if !result.success() {
@@ -483,6 +525,40 @@ fn run_log(
 
     // Post-process: truncate long messages, cap lines only if RTK set the default
     let filtered = filter_log_output(&result.stdout, limit, user_set_limit, has_format_flag);
+
+    // Warn when RTK silently truncated the output so the user knows to pass -N.
+    //
+    // Only meaningful when --reverse is set: that's the only case where RTK did NOT
+    // inject -N into git, so git returned all commits and we can count them.
+    // For all other cases RTK already limited git's output via -N, so we have no
+    // way of knowing how many total commits exist.
+    if !user_set_limit && has_reverse_flag {
+        let (raw_count, shown) = if has_format_flag {
+            // user_format=true: 1 line = 1 commit
+            (result.stdout.lines().count(), filtered.lines().count())
+        } else {
+            // RTK injected ---END--- separators: count blocks in raw output.
+            // In filtered output, each commit starts with a header line (no leading
+            // spaces); body lines are indented with "  ". Count header lines only.
+            let raw_commits = result.stdout
+                .split("---END---")
+                .filter(|s| !s.trim().is_empty())
+                .count();
+            let shown_commits = filtered
+                .lines()
+                .filter(|l| !l.starts_with(' '))
+                .count();
+            (raw_commits, shown_commits)
+        };
+        if raw_count > shown {
+            eprintln!(
+                "rtk: git log truncated to {} of {} commits (use -N or --max-count=N to see more)",
+                shown, raw_count
+            );
+        }
+    }
+
+
     println!("{}", filtered);
 
     timer.track(
@@ -2529,6 +2605,246 @@ no changes added to commit (use "git add" and/or "git commit -a")
             result.contains("+3 lines omitted"),
             "Expected '+3 lines omitted' when 6 body lines truncated to 3, got:\n{}",
             result
+        );
+    }
+
+    // ── Regression tests for #1296: rtk git log --reverse ───────────────────────
+    //
+    // Bug: RTK injected `-50` before `--reverse`, so `git log -50 --reverse`
+    //   picked the 50 most-recent commits then reversed their order — user saw
+    //   2025 data instead of historical commits from 2022.
+    //
+    // Fix: when `--reverse` is present and no explicit `-N` was given, RTK must
+    //   NOT inject a `-N` limit into the git call. Git streams all commits
+    //   oldest-first; RTK's post-processor caps at the normal limit so the user
+    //   receives the N *oldest* commits.
+
+    fn args(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    // ── build_log_command: -N injection decisions ─────────────────────────────
+
+    #[test]
+    fn test_build_log_command_reverse_does_not_inject_n() {
+        // Core regression: --reverse without -N must NOT add a -N arg to git.
+        let (cmd, params) = build_log_command(&args(&["--reverse"]), &[]);
+        let cmd_args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+
+        // No -N, -10, -50 may appear when --reverse is set without explicit limit
+        let has_injected_limit = cmd_args
+            .iter()
+            .any(|a| a == "-10" || a == "-50" || (a.starts_with('-') && a[1..].parse::<usize>().is_ok()));
+        assert!(
+            !has_injected_limit,
+            "--reverse: RTK must not inject a default -N, got args: {:?}",
+            cmd_args
+        );
+        assert!(!params.user_set_limit, "--reverse: user_set_limit must be false");
+        assert_eq!(params.limit, 10, "--reverse plain: default limit must be 10");
+        assert!(params.has_reverse_flag);
+    }
+
+    #[test]
+    fn test_build_log_command_reverse_with_format_does_not_inject_n() {
+        // --reverse + --oneline: still no -N injection, but limit becomes 50
+        let (cmd, params) = build_log_command(&args(&["--oneline", "--reverse"]), &[]);
+        let cmd_args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+
+        let has_injected_limit = cmd_args
+            .iter()
+            .any(|a| a == "-50" || (a.starts_with('-') && a[1..].parse::<usize>().is_ok()));
+        assert!(
+            !has_injected_limit,
+            "--reverse + --oneline: RTK must not inject -N, got args: {:?}",
+            cmd_args
+        );
+        assert_eq!(params.limit, 50, "--reverse + format: default limit must be 50");
+        assert!(!params.user_set_limit);
+    }
+
+    #[test]
+    fn test_build_log_command_reverse_with_explicit_n_respects_user_limit() {
+        // --reverse -20: combined form
+        let (_, params) = build_log_command(&args(&["--reverse", "-20"]), &[]);
+        assert!(params.user_set_limit);
+        assert_eq!(params.limit, 20);
+
+        // --reverse -n 200: two-token form (issue workaround)
+        let (_, params) = build_log_command(&args(&["--reverse", "-n", "200"]), &[]);
+        assert!(params.user_set_limit, "--reverse -n 200: user_set_limit must be true");
+        assert_eq!(params.limit, 200);
+
+        // --reverse --max-count=200: long form
+        let (_, params) = build_log_command(&args(&["--reverse", "--max-count=200"]), &[]);
+        assert!(params.user_set_limit, "--reverse --max-count=200: user_set_limit must be true");
+        assert_eq!(params.limit, 200);
+    }
+
+    #[test]
+    fn test_build_log_command_no_reverse_injects_n() {
+        // Without --reverse, RTK must inject -10 (plain) or -50 (format) as before
+        let (cmd_plain, _) = build_log_command(&args(&[]), &[]);
+        let plain_args: Vec<String> = cmd_plain
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        assert!(
+            plain_args.contains(&"-10".to_string()),
+            "plain mode without flags must inject -10, got: {:?}",
+            plain_args
+        );
+
+        let (cmd_fmt, _) = build_log_command(&args(&["--oneline"]), &[]);
+        let fmt_args: Vec<String> = cmd_fmt
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        assert!(
+            fmt_args.contains(&"-50".to_string()),
+            "--oneline without --reverse must inject -50, got: {:?}",
+            fmt_args
+        );
+    }
+
+    // ── Warning path: truncation notice when --reverse caps output ────────────
+
+    fn make_plain_blocks(n: usize) -> String {
+        (0..n)
+            .map(|i| format!("abc{:04} commit {} (1 day ago) <author>\n\n---END---", i, i))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn make_plain_blocks_with_body(n: usize) -> String {
+        (0..n)
+            .map(|i| {
+                format!(
+                    "abc{:04} commit {} (1 day ago) <author>\nThis is body line one\nThis is body line two\n---END---",
+                    i, i
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    // Mirrors the counting logic in run_log's warning path so tests exercise
+    // the same code path (raw_count from stdout, shown from filter_log_output).
+    fn warning_counts(stdout: &str, limit: usize) -> (usize, usize) {
+        let raw_count = stdout
+            .split("---END---")
+            .filter(|s| !s.trim().is_empty())
+            .count();
+        let filtered = filter_log_output(stdout, limit, false, false);
+        // Mirror run_log's counting: header lines don't start with a space,
+        // body lines are indented with "  ".
+        let shown = filtered.lines().filter(|l| !l.starts_with(' ')).count();
+        (raw_count, shown)
+    }
+
+    #[test]
+    fn test_reverse_truncation_warning_fires_when_over_limit() {
+        // 20 commits, limit=10 → raw_count(20) > shown(10) → warning must fire
+        let stdout = make_plain_blocks(20);
+        let (raw_count, shown) = warning_counts(&stdout, 10);
+        assert!(
+            raw_count > shown,
+            "20 blocks with limit=10: raw_count({}) must exceed shown({})",
+            raw_count, shown
+        );
+    }
+
+    #[test]
+    fn test_reverse_truncation_warning_silent_when_under_limit() {
+        // 5 commits, limit=10 → raw_count(5) ≤ shown(5) → no warning
+        let stdout = make_plain_blocks(5);
+        let (raw_count, shown) = warning_counts(&stdout, 10);
+        assert!(
+            raw_count <= shown,
+            "5 blocks with limit=10: raw_count({}) must not exceed shown({})",
+            raw_count, shown
+        );
+    }
+
+    #[test]
+    fn test_reverse_truncation_warning_silent_at_exact_limit() {
+        // 10 commits, limit=10 → raw_count(10) == shown(10) → no warning (not strictly >)
+        let stdout = make_plain_blocks(10);
+        let (raw_count, shown) = warning_counts(&stdout, 10);
+        assert_eq!(raw_count, shown, "exactly at limit: raw_count must equal shown");
+        assert!(
+            raw_count <= shown,
+            "boundary: warning must not fire when raw_count == shown"
+        );
+    }
+
+    #[test]
+    fn test_reverse_truncation_warning_multiline_commits() {
+        // Regression: commits with body lines must still count as 1 commit each.
+        // Before fix: filtered.lines().count() returned header+body lines (e.g. 30
+        // for 10 commits × 3 lines), so shown > raw_count and warning never fired.
+        let stdout = make_plain_blocks_with_body(20);
+        let (raw_count, shown) = warning_counts(&stdout, 10);
+        assert_eq!(raw_count, 20, "raw_count must be 20 commits");
+        assert_eq!(shown, 10, "shown must be 10 commits (not lines), got {}", shown);
+        assert!(raw_count > shown, "warning must fire: 20 raw > 10 shown");
+    }
+
+    // ── filter_log_output: format path with --reverse data ───────────────────
+
+    #[test]
+    fn test_filter_log_output_reverse_format_path_oldest_first() {
+        // Covers the user_format=true branch of filter_log_output with real
+        // --oneline data already in oldest-first order (git --reverse output).
+        // Fixture has 50 lines; limit=10 → returns first 10 (oldest commits).
+        let input = include_str!("../../../tests/fixtures/git_log_reverse_oneline_raw.txt");
+        let result = filter_log_output(input, 10, false, true);
+
+        assert_eq!(
+            result.lines().count(),
+            10,
+            "--reverse + oneline: must cap at 10 oldest commits, got {}",
+            result.lines().count()
+        );
+        // First hash in fixture is 9c9879c (oldest commit in this repo)
+        assert!(
+            result.lines().next().unwrap().starts_with("9c9879c"),
+            "--reverse + oneline: first line must be oldest commit"
+        );
+    }
+
+    // ── Token savings: real fixture ───────────────────────────────────────────
+
+    fn count_tokens(s: &str) -> usize {
+        s.split_whitespace().count()
+    }
+
+    #[test]
+    fn test_reverse_token_savings_plain_fixture() {
+        // Real output from: git log --reverse --no-merges \
+        //   --pretty=format:"%h %s (%ar) <%an>%n%b%n---END---"
+        // filter_log_output strips trailers (Signed-off-by, Co-authored-by),
+        // caps body to 3 lines, truncates to 80 chars → ≥60% savings.
+        let input = include_str!("../../../tests/fixtures/git_log_reverse_raw.txt");
+        let filtered = filter_log_output(input, 10, false, false);
+
+        let input_tokens = count_tokens(input);
+        let output_tokens = count_tokens(&filtered);
+        let savings = 100.0 - (output_tokens as f64 / input_tokens as f64 * 100.0);
+
+        assert!(
+            savings >= 60.0,
+            "git log --reverse plain: expected ≥60% token savings, got {:.1}% \
+             (input={} tokens, output={} tokens)",
+            savings,
+            input_tokens,
+            output_tokens
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -757,9 +757,12 @@ enum GitCommands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
-    /// One-line commit history
+    /// One-line commit history (default: last 10 commits; use -N or --max-count to override)
     Log {
-        /// Git arguments (supports all git log flags like --oneline, --graph, --all)
+        /// Git arguments (supports all git log flags like --oneline, --graph, --all).
+        /// RTK limits output to 10 commits by default (50 with --oneline/--format).
+        /// Use -N (e.g. -100) or --max-count=N to change the limit.
+        /// With --reverse, no limit is injected so you see the N oldest commits.
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },

--- a/tests/fixtures/git_log_reverse_oneline_raw.txt
+++ b/tests/fixtures/git_log_reverse_oneline_raw.txt
@@ -1,0 +1,50 @@
+9c9879c docs: add interface contract and Phase 0 stubs for docs reorganization
+25438b2 docs(guide): add 11 Phase 1 guide pages — full MVP content
+974db2f docs(phase-4): complete reference, architecture tabs and remaining co...
+a94e949 docs: consolidate to user-facing guide, remove duplicates and legacy ...
+6e55f89 docs: address Adrien's review — structure, missing content, agents
+6938a9d docs: fix broken README links and reduce redundancy, point to docs site
+cea6e20 docs: add Star History and StarMapper to README
+47383e8 fix(security): correct email domain from .dev to .app
+da486bf fix(tee): prevent panic on UTF-8 multi-byte truncation boundary
+c85a387 fix: report package-level failures (timeouts, signals) in go test sum...
+15f666d fix(telemetry): 7 bugs in enrichment — privacy leak, broken meta_usag...
+be5c057 fix(docs): update TELEMETRY.md to match code after review fixes
+d0a3797 feat(init): add native support for Kilo Code and Google Antigravity
+b735068 docs: add Windows setup instructions and troubleshooting
+d442799 fix(init): honor CODEX_HOME for Codex global paths
+fd0c87a Update CLAUDE.md
+f4074f8 fix(clippy): show full error blocks instead of truncated headline
+cce0481 Update troubleshooting.md
+6a5bc84 fix(telemetry): RGPD-compliant, consent gate, erasure, privacy controls
+577c311 fix(curl): skip JSON schema conversion for internal/localhost URLs
+40462c0 fix(hooks): ensure default permission verdict prompts user for confir...
+40c9dbc fix(hooks): require all segments to match allow rules (#1213)
+9979c69 fix(git): re-insert -- separator when clap consumes it from git diff ...
+9722d5e fix(go): prevent double-counting failures when package-level fail cas...
+f68fa00 fix(ccusage): add --yes flag and warn when falling back to npx
+ba235d8 fix(pnpm): list command not working
+d22759b feat(benchmark): add multipass VM integration test suite
+d13c185 fix(benchmark): address review feedback from @FlorianBruniaux
+1fbb6d9 feat(benchmark): add Swift ecosystem tests (6 commands + savings)
+6634712 Update CHANGELOG.md
+87ee81f fix(benchmark): address PR review feedback
+7d99c9e Update CHANGELOG.md
+2e4cc4b fix(telemetry): consent, erasure, auth, docs
+7821e98 fix(telemetry): non-terminal consent, single config load
+8156081 fix(telemetry): clean code
+bab3a53 feat(discover): handle more npm/npx/pnpm/pnpx patterns
+325a42e fix: remove pnpx -> rtk pnpx rule as rtk pnpx command doesn't exist
+f936138 feat(pnpm): handle pnpm build rewrite
+c47edac chore: fix clippy warning
+45938b2 feat(js): distinguish between `jest` and `vitest` and don't rewrite `...
+70610da fix(vitest): rework command to handle differences between vitest and ...
+010596c Revert "feat(pnpm): handle pnpm build rewrite"
+630f0a2 Add liquibase TOML filter
+4f4e4d2 fix(golangci-lint): restore run wrapper and align guidance
+d85303e fix(discover): preserve golangci-lint flags in rewrite
+24f2ada fix(golangci-lint): support inline global flags before run
+dbeeaed fix(find): include hidden files when pattern targets dotfiles (#1101)
+3db8070 fix(permissions): glob_matches middle-wildcard matches commands witho...
+6b76fdb fix(git): remove -u short alias from --ultra-compact to fix git push -u
+0dffefc fix(git): fix --reverse showing newest commits instead of oldest

--- a/tests/fixtures/git_log_reverse_raw.txt
+++ b/tests/fixtures/git_log_reverse_raw.txt
@@ -1,0 +1,50 @@
+9c9879c docs: add interface contract and Phase 0 stubs for docs reorganizatio...
+Creates docs/README.md (interface contract defining 3-tab structure,
+required frontmatter, and conventions) and 4 stub pages with valid
+frontmatter for docs/guide/, docs/reference/, and docs/architecture/.
+These are the prerequisites for the prepare-docs.mjs pipeline (Plan B)
+and for Adrien's Phase 1 content work.
+
+No existing files modified.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+Signed-off-by: Florian BRUNIAUX <florian@bruniaux.com>
+
+---END---
+25438b2 docs(guide): add 11 Phase 1 guide pages — full MVP content (10 дней н...
+Creates the complete user-facing guide for the docs website:
+
+Getting started:
+- quick-start.md: 5-minute walkthrough (init, first commands, rtk gain)
+- supported-agents.md: Claude Code, Cursor, Copilot, Gemini, Cline, Windsurf,
+  Codex, OpenCode — integration tiers, install commands, graceful degradation
+
+Commands (adapted from FEATURES.md, English, --help-first format):
+- git.md: status/log/diff/show/add/commit/push/pull/branch + gh CLI
+- cargo.md: test/nextest/build/check/clippy/install + generic test/err wrappers
+- files.md: ls/read/grep/find/diff/wc/smart with before/after examples
+- javascript.md: vitest/playwright/tsc/eslint/prettier/next/pnpm/npm/npx/prisma
+- python.md: pytest/ruff/mypy/pip/deps
+
+Reference:
+- filters/using-filters.md: 8-stage pipeline, lookup priority, TOML DSL refer...
+  Mermaid diagram (adapted from docs/filter-workflow.md)
+- analytics/gain.md: rtk gain flags, daily/weekly/monthly breakdowns, export
+  formats, token estimation, database management (from docs/AUDIT_GUIDE.md)
+- configuration.md: full config.toml reference, env vars, tee system, telemetry
+- troubleshooting.md: common issues and fixes (from docs/TROUBLESHOOTING.md)
+
+All pages carry valid frontmatter (title, description, sidebar.order).
+No existing files modified.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+Signed-off-by: Florian BRUNIAUX <florian@bruniaux.com>
+
+---END---
+974db2f docs(phase-4): complete reference, architecture tabs and remaining co...
+Guide — 10 new command and analytics pages:
+- commands/go.md: go test (NDJSON), golangci-lint
+- commands/ruby.md: rspec, rubocop, rake
+- commands/dotnet.md: dotnet build/test, binlog, format
+- commands/containers.md: docker ps/images/logs/compose, kubectl pods/service...
+- commands/github-cli.md: gh pr/issue/run, Graphite gt commands


### PR DESCRIPTION
## Summary

- RTK was injecting `-50` into git before `--reverse`, so `git log -50 --reverse` picked the 50 most-recent commits then reversed them — users saw 2025 data instead of historical commits from 2022
- Fix: skip default `-N` injection when `--reverse` is present; git streams all commits oldest-first and RTK caps output at the normal limit (50 with `--format`, 10 plain) → user gets the N *oldest* commits
- Add stderr warning when output is truncated so users know to pass `-N`

Closes #1296

## Test plan

- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] `test_build_log_command_reverse_does_not_inject_n` — regression guard at the actual bug site
- [ ] `test_build_log_command_reverse_with_explicit_n_respects_user_limit` — `-n 200`, `--max-count=200` workarounds from the issue
- [ ] `test_reverse_truncation_warning_multiline_commits` — warning counts commits not lines
- [ ] `test_reverse_token_savings_plain_fixture` — ≥60% savings on real fixture
- [ ] Manual: `rtk git log --reverse` in a repo with 100+ commits shows oldest commits first