### PR TITLE
fix(docs): fix broken links in README files

### DIFF
--- a/README_es.md
+++ b/README_es.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="https://www.rtk-ai.app">Sitio web</a> &bull;
   <a href="#instalacion">Instalar</a> &bull;
-  <a href="docs/TROUBLESHOOTING.md">Solucion de problemas</a> &bull;
+  <a href="docs/guide/resources/troubleshooting.md">Solucion de problemas</a> &bull;
   <a href="docs/contributing/ARCHITECTURE.md">Arquitectura</a> &bull;
   <a href="https://discord.gg/RySmvNF5kF">Discord</a>
 </p>
@@ -146,7 +146,7 @@ rtk discover                    # Descubrir ahorros perdidos
 
 ## Documentacion
 
-- **[TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)** - Resolver problemas comunes
+- **[TROUBLESHOOTING.md](docs/guide/resources/troubleshooting.md)** - Resolver problemas comunes
 - **[INSTALL.md](INSTALL.md)** - Guia de instalacion detallada
 - **[ARCHITECTURE.md](docs/contributing/ARCHITECTURE.md)** - Arquitectura tecnica
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="https://www.rtk-ai.app">Site web</a> &bull;
   <a href="#installation">Installer</a> &bull;
-  <a href="docs/TROUBLESHOOTING.md">Depannage</a> &bull;
+  <a href="docs/guide/resources/troubleshooting.md">Depannage</a> &bull;
   <a href="docs/contributing/ARCHITECTURE.md">Architecture</a> &bull;
   <a href="https://discord.gg/RySmvNF5kF">Discord</a>
 </p>
@@ -183,7 +183,7 @@ mode = "failures"
 
 ## Documentation
 
-- **[TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)** - Resoudre les problemes courants
+- **[TROUBLESHOOTING.md](docs/guide/resources/troubleshooting.md)** - Resoudre les problemes courants
 - **[INSTALL.md](INSTALL.md)** - Guide d'installation detaille
 - **[ARCHITECTURE.md](docs/contributing/ARCHITECTURE.md)** - Architecture technique
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="https://www.rtk-ai.app">ウェブサイト</a> &bull;
   <a href="#インストール">インストール</a> &bull;
-  <a href="docs/TROUBLESHOOTING.md">トラブルシューティング</a> &bull;
+  <a href="docs/guide/resources/troubleshooting.md">トラブルシューティング</a> &bull;
   <a href="docs/contributing/ARCHITECTURE.md">アーキテクチャ</a> &bull;
   <a href="https://discord.gg/RySmvNF5kF">Discord</a>
 </p>
@@ -145,7 +145,7 @@ rtk discover                    # 見逃した節約機会を発見
 
 ## ドキュメント
 
-- **[TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)** - よくある問題の解決
+- **[TROUBLESHOOTING.md](docs/guide/resources/troubleshooting.md)** - よくある問題の解決
 - **[INSTALL.md](INSTALL.md)** - 詳細インストールガイド
 - **[ARCHITECTURE.md](docs/contributing/ARCHITECTURE.md)** - 技術アーキテクチャ
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="https://www.rtk-ai.app">웹사이트</a> &bull;
   <a href="#설치">설치</a> &bull;
-  <a href="docs/TROUBLESHOOTING.md">문제 해결</a> &bull;
+  <a href="docs/guide/resources/troubleshooting.md">문제 해결</a> &bull;
   <a href="docs/contributing/ARCHITECTURE.md">아키텍처</a> &bull;
   <a href="https://discord.gg/RySmvNF5kF">Discord</a>
 </p>
@@ -145,7 +145,7 @@ rtk discover                    # 놓친 절약 기회 발견
 
 ## 문서
 
-- **[TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)** - 일반적인 문제 해결
+- **[TROUBLESHOOTING.md](docs/guide/resources/troubleshooting.md)** - 일반적인 문제 해결
 - **[INSTALL.md](INSTALL.md)** - 상세 설치 가이드
 - **[ARCHITECTURE.md](docs/contributing/ARCHITECTURE.md)** - 기술 아키텍처
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="https://www.rtk-ai.app">官网</a> &bull;
   <a href="#安装">安装</a> &bull;
-  <a href="docs/TROUBLESHOOTING.md">故障排除</a> &bull;
+  <a href="docs/guide/resources/troubleshooting.md">故障排除</a> &bull;
   <a href="docs/contributing/ARCHITECTURE.md">架构</a> &bull;
   <a href="https://discord.gg/RySmvNF5kF">Discord</a>
 </p>
@@ -153,7 +153,7 @@ rtk discover                    # 发现遗漏的节省机会
 
 ## 文档
 
-- **[TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)** - 解决常见问题
+- **[TROUBLESHOOTING.md](docs/guide/resources/troubleshooting.md)** - 解决常见问题
 - **[INSTALL.md](INSTALL.md)** - 详细安装指南
 - **[ARCHITECTURE.md](docs/contributing/ARCHITECTURE.md)** - 技术架构
 


### PR DESCRIPTION
## Summary

Repairs the broken **Troubleshooting** links in the 5 translated READMEs (`es`, `fr`, `ja`, `ko`, `zh`). Each linked to `docs/TROUBLESHOOTING.md`, which no longer exists after the docs were reorganized under `docs/guide/`. Both the header link and the Documentation-list entry now point to the actual file at `docs/guide/resources/troubleshooting.md`, matching the relative-path style already used for the adjacent `docs/contributing/ARCHITECTURE.md` link.

> **Note:** This branch was refreshed onto the current `develop` (it had diverged ~2k commits and conflicted with the docs reorg). The earlier revision targeted `docs/guide/troubleshooting.md`, which does **not** exist; the correct current path is `docs/guide/resources/troubleshooting.md`.

**5 files changed**, 10 insertions, 10 deletions.

## Details

A full broken-relative-link scan of every README against current `develop` found that **only** these links are broken — `README.md` and `README_pt.md` are clean (they reference the docs website rather than relative files).

| File | Fix (×2 occurrences each) |
|------|------|
| `README_es.md` | `docs/TROUBLESHOOTING.md` → `docs/guide/resources/troubleshooting.md` |
| `README_fr.md` | `docs/TROUBLESHOOTING.md` → `docs/guide/resources/troubleshooting.md` |
| `README_ja.md` | `docs/TROUBLESHOOTING.md` → `docs/guide/resources/troubleshooting.md` |
| `README_ko.md` | `docs/TROUBLESHOOTING.md` → `docs/guide/resources/troubleshooting.md` |
| `README_zh.md` | `docs/TROUBLESHOOTING.md` → `docs/guide/resources/troubleshooting.md` |

## Test plan

- [x] Confirmed target `docs/guide/resources/troubleshooting.md` exists on current `develop`
- [x] Scanned all 7 README files for broken relative links — no remaining `docs/TROUBLESHOOTING.md` references
- [x] Verified no other relative links are broken in any README
- [x] CI passing; branch is mergeable (no conflicts)