### PR TITLE
 Simplified `rtk curl` Filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "rtk"
-version = "0.34.3"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "automod",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "rtk"
-version = "0.35.0"
+version = "0.34.3"
 dependencies = [
  "anyhow",
  "automod",

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ rtk json config.json            # Structure without values
 rtk deps                        # Dependencies summary
 rtk env -f AWS                  # Filtered env vars
 rtk log app.log                 # Deduplicated logs
-rtk curl <url>                  # Auto-detect JSON + schema
+rtk curl <url>                  # Truncate + save full output
 rtk wget <url>                  # Download, strip progress bars
 rtk summary <long command>      # Heuristic summary
 rtk proxy <command>             # Raw passthrough + tracking

--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -964,13 +964,13 @@ Les lignes repetees sont fusionnees : `[ERROR] Connection refused (x42)`.
 
 ---
 
-### `rtk curl` -- HTTP avec detection JSON
+### `rtk curl` -- HTTP avec troncature
 
 ```bash
 rtk curl [args...]
 ```
 
-Auto-detecte les reponses JSON et affiche le schema au lieu du contenu complet.
+Tronque les reponses longues et sauvegarde la sortie complete dans un fichier pour recuperation.
 
 ---
 

--- a/src/cmds/cloud/README.md
+++ b/src/cmds/cloud/README.md
@@ -6,6 +6,6 @@
 
 - `aws_cmd.rs` — 25 specialized filters covering STS, S3, EC2, ECS, RDS, CloudFormation, CloudWatch Logs, Lambda, IAM, DynamoDB, EKS, SQS, Secrets Manager. Forces `--output json` for structured parsing, uses `force_tee_hint()` for truncation recovery, strips Lambda secrets. Shared runner `run_aws_filtered()` handles boilerplate for JSON-based filters; text-based filters (S3 ls, S3 sync/cp) have dedicated runners
 - `container.rs` handles both Docker and Kubernetes; `DockerCommands` and `KubectlCommands` sub-enums in `main.rs` route to `container::run()` -- uses passthrough for unknown subcommands
-- `curl_cmd.rs` auto-detects JSON responses and shows schema (structure without values)
+- `curl_cmd.rs` truncates long responses, saves full output to file for recovery
 - `wget_cmd.rs` wraps wget with output filtering
 - `psql_cmd.rs` filters PostgreSQL query output

--- a/src/cmds/cloud/curl_cmd.rs
+++ b/src/cmds/cloud/curl_cmd.rs
@@ -1,9 +1,11 @@
-//! Runs curl and auto-compresses JSON responses.
+//! Runs curl and applies a simple truncation with tee hint if the output is too long.
 
 use crate::core::tee::force_tee_hint;
 use crate::core::tracking;
 use crate::core::{stream::exec_capture, utils::resolved_command};
 use anyhow::{Context, Result};
+
+const MAX_RESPONSE_SIZE: usize = 500;
 
 /// Not using run_filtered: on failure, curl can return HTML error pages (404, 500)
 /// that the JSON schema filter would mangle. The early exit skips filtering entirely.
@@ -56,8 +58,11 @@ fn filter_curl_output(raw: &str) -> FilterResult {
     let trimmed = raw.trim();
     let tee_hint = force_tee_hint(raw, "curl");
 
-    let content = if trimmed.len() >= 500 {
-        let mut end = 500;
+    // If the output is too long and we have a tee hint, truncate the output.
+    let content = if trimmed.len() >= MAX_RESPONSE_SIZE && tee_hint.is_some() {
+        let mut end = MAX_RESPONSE_SIZE;
+        // Ensure we don't cut in the middle of a UTF-8 character.
+        // .len() counts bytes, not chars.
         while !trimmed.is_char_boundary(end) {
             end -= 1;
         }

--- a/src/cmds/cloud/curl_cmd.rs
+++ b/src/cmds/cloud/curl_cmd.rs
@@ -1,9 +1,8 @@
 //! Runs curl and auto-compresses JSON responses.
 
-use crate::core::stream::exec_capture;
+use crate::core::tee::force_tee_hint;
 use crate::core::tracking;
-use crate::core::utils::{resolved_command, truncate};
-use crate::json_cmd;
+use crate::core::{stream::exec_capture, utils::resolved_command};
 use anyhow::{Context, Result};
 
 /// Not using run_filtered: on failure, curl can return HTML error pages (404, 500)
@@ -36,68 +35,43 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
 
     let raw = result.stdout.clone();
 
-    // Auto-detect JSON and pipe through filter
-    let filtered = filter_curl_output(&result.stdout, args);
-    println!("{}", filtered);
+    let result = filter_curl_output(&result.stdout);
+
+    println!("{}", result.content);
+    if let Some(hint) = &result.tee_hint {
+        println!("{}", hint);
+    }
 
     timer.track(
         &format!("curl {}", args.join(" ")),
         &format!("rtk curl {}", args.join(" ")),
         &raw,
-        &filtered,
+        &result.content,
     );
 
     Ok(0)
 }
 
-fn filter_curl_output(output: &str, args: &[String]) -> String {
-    let trimmed = output.trim();
+fn filter_curl_output(raw: &str) -> FilterResult {
+    let trimmed = raw.trim();
+    let tee_hint = force_tee_hint(raw, "curl");
 
-    // Try JSON detection: starts with { or [
-    if (trimmed.starts_with('{') || trimmed.starts_with('['))
-        && (trimmed.ends_with('}') || trimmed.ends_with(']'))
-    {
-        // Skip schema conversion for internal/localhost URLs (issues #1152, #1157)
-        if !is_internal_url(args) {
-            if let Ok(schema) = json_cmd::filter_json_string(trimmed, 5) {
-                // Only use schema if it's actually shorter than the original (#297)
-                if schema.len() <= trimmed.len() {
-                    return schema;
-                }
-            }
+    let content = if trimmed.len() >= 500 {
+        let mut end = 500;
+        while !trimmed.is_char_boundary(end) {
+            end -= 1;
         }
-    }
+        format!("{}... ({} bytes total)", &trimmed[..end], trimmed.len())
+    } else {
+        trimmed.to_string()
+    };
 
-    // Not JSON: truncate long output
-    let lines: Vec<&str> = trimmed.lines().collect();
-    if lines.len() > 30 {
-        let mut result: Vec<&str> = lines[..30].to_vec();
-        result.push("");
-        let msg = format!(
-            "... ({} more lines, {} bytes total)",
-            lines.len() - 30,
-            trimmed.len()
-        );
-        return format!("{}\n{}", result.join("\n"), msg);
-    }
-
-    // Short output: return as-is but truncate long lines
-    lines
-        .iter()
-        .map(|l| truncate(l, 200))
-        .collect::<Vec<_>>()
-        .join("\n")
+    FilterResult { content, tee_hint }
 }
 
-fn is_internal_url(args: &[String]) -> bool {
-    args.iter().any(|a| {
-        let lower = a.to_lowercase();
-        lower.starts_with("http://localhost")
-            || lower.starts_with("http://127.0.0.1")
-            || lower.starts_with("http://[::1]")
-            || lower.starts_with("https://localhost")
-            || lower.starts_with("https://127.0.0.1")
-    })
+struct FilterResult {
+    content: String,
+    tee_hint: Option<String>,
 }
 
 #[cfg(test)]
@@ -105,56 +79,42 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_filter_curl_json() {
-        // Large JSON where schema is shorter than original — schema should be returned
-        let output = r#"{"name": "a very long user name here", "count": 42, "items": [1, 2, 3], "description": "a very long description that takes up many characters in the original JSON payload", "status": "active", "url": "https://example.com/api/v1/users/123"}"#;
-        let result = filter_curl_output(output, &[]);
-        assert!(result.contains("name"));
-        assert!(result.contains("string"));
-        assert!(result.contains("int"));
-    }
-
-    #[test]
-    fn test_filter_curl_json_array() {
-        let output = r#"[{"id": 1}, {"id": 2}]"#;
-        let result = filter_curl_output(output, &[]);
-        assert!(result.contains("id"));
+    fn test_filter_curl_json_small_no_tee_hint() {
+        let output = r#"{"r2Ready":true,"status":"ok"}"#;
+        let result = filter_curl_output(output);
+        assert_eq!(result.content, output);
+        assert!(result.tee_hint.is_none());
     }
 
     #[test]
     fn test_filter_curl_non_json() {
         let output = "Hello, World!\nThis is plain text.";
-        let result = filter_curl_output(output, &[]);
-        assert!(result.contains("Hello, World!"));
-        assert!(result.contains("plain text"));
+        let result = filter_curl_output(output);
+        assert_eq!(result.content, output);
     }
 
     #[test]
-    fn test_filter_curl_json_small_returns_original() {
-        // Small JSON where schema would be larger than original (issue #297)
-        let output = r#"{"r2Ready":true,"status":"ok"}"#;
-        let result = filter_curl_output(output, &[]);
-        // Schema would be "{\n  r2Ready: bool,\n  status: string\n}" which is longer
-        // Should return the original JSON unchanged
-        assert_eq!(result.trim(), output.trim());
+    fn test_filter_curl_long_output_truncated() {
+        let long: String = "x".repeat(1000);
+        let result = filter_curl_output(&long);
+        assert!(result.content.starts_with('x'));
+        assert!(result.content.contains("bytes total"));
+        assert!(result.content.contains("1000"));
+        assert!(result.content.len() < 600);
     }
 
     #[test]
-    fn test_filter_curl_long_output() {
-        let lines: Vec<String> = (0..50).map(|i| format!("Line {}", i)).collect();
-        let output = lines.join("\n");
-        let result = filter_curl_output(&output, &[]);
-        assert!(result.contains("Line 0"));
-        assert!(result.contains("Line 29"));
-        assert!(result.contains("more lines"));
+    fn test_filter_curl_multibyte_boundary() {
+        let content = "a".repeat(499) + "é";
+        let result = filter_curl_output(&content);
+        assert!(result.content.contains("bytes total"));
+        assert!(result.content.len() < 600);
     }
 
     #[test]
-    fn test_is_internal_url_localhost() {
-        assert!(is_internal_url(&["http://localhost:9222/json/version".to_string()]));
-        assert!(is_internal_url(&["http://127.0.0.1:8080/api".to_string()]));
-        assert!(is_internal_url(&["-s".to_string(), "http://localhost:3000".to_string()]));
-        assert!(!is_internal_url(&["https://api.example.com/data".to_string()]));
-        assert!(!is_internal_url(&["https://github.com".to_string()]));
+    fn test_filter_curl_exact_500_bytes() {
+        let content = "a".repeat(500);
+        let result = filter_curl_output(&content);
+        assert!(result.content.contains("bytes total"));
     }
 }


### PR DESCRIPTION
## Summary
Refactored `rtk curl` to use a simple, predictable truncation strategy with tee hints instead of JSON schema conversion. This eliminates edge cases, reduces code complexity by ~36%, and delivers consistent 73-99% token savings across all response types greater than 500 bytes.

## Test plan
I tested against various local and remote endpoints with responses >500 bytess, <500 bytes and  both successful and error responses.

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

### Savings

| Response Type | Original Size | Savings | Behavior |
|--------------|---------------|---------|----------|
| npm registry (express) | 801 KB | **99.9%** | 500B truncated + tee hint |
| GitHub API (releases) | 36 KB | **98.5%** | 500B truncated + tee hint |
| httpbin HTML | 3.7 KB | **86.0%** | 500B truncated + tee hint |
| nginx 404 HTML | 2 KB | **73.8%** | 500B truncated + tee hint |
| httpbin UUID | 53 B | 0% | Below threshold, passed through |
| httpbin 404 (empty) | 0 B | 0% | Empty body, no output, timer not called|

### Tiny JSON — passed through (< 500 bytes)
```bash
$ rtk curl -s https://httpbin.org/ip
{
  "origin": "75.143.98.179"
}
```
### Large API response — truncated + tee hint
```bash
$ rtk curl -s "https://api.github.com/repos/rust-lang/rust/releases?per_page=5"
[
  {
    "url": "https://api.github.com/repos/rust-lang/rust/releases/301852655",
    "assets_url": "https://api.github.com/repos/rust-lang/rust/releases/301852655/assets",
    "upload_url": "https://uploads.github.com/repos/rust-lang/rust/releases/301852655/assets{?name,label}",
    ... (36049 bytes total)
[full output: ~/.local/share/rtk/tee/1776209074_curl.log]
```


> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
