### PR TITLE
fix(ci): add write permissions to pr-target-check workflow

### DIFF
--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, edited]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   check-target:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -464,6 +464,15 @@ export RTK_TELEMETRY_DISABLED=1   # Blocks telemetry regardless of consent
   </picture>
 </a>
 
+## Core team
+
+- **Patrick Szymkowiak** — Founder
+  [GitHub](https://github.com/pszymkowiak) · [LinkedIn](https://www.linkedin.com/in/patrick-szymkowiak/)
+- **Florian Bruniaux** — Core contributor
+  [GitHub](https://github.com/FlorianBruniaux) · [LinkedIn](https://www.linkedin.com/in/florian-bruniaux-43408b83/)
+- **Adrien Eppling** — Core contributor
+  [GitHub](https://github.com/aeppling) · [LinkedIn](https://www.linkedin.com/in/adrien-eppling/)
+
 ## Contributing
 
 Contributions welcome! Please open an issue or PR on [GitHub](https://github.com/rtk-ai/rtk).

--- a/docs/guide/analytics/discover.md
+++ b/docs/guide/analytics/discover.md
@@ -32,7 +32,7 @@ Total missed:           23     ~66,000 tokens
 Run `rtk init --global` to capture these automatically.
 ```
 
-If commands appear in the missed list after installing RTK, it usually means the hook isn't active for that agent. See [Troubleshooting](../troubleshooting.md) — "Agent not using RTK".
+If commands appear in the missed list after installing RTK, it usually means the hook isn't active for that agent. See [Troubleshooting](../resources/troubleshooting.md) — "Agent not using RTK".
 
 ## rtk session — adoption tracking
 

--- a/docs/guide/analytics/gain.md
+++ b/docs/guide/analytics/gain.md
@@ -24,7 +24,8 @@ rtk gain --all            # all breakdowns at once
 # Classic flags
 rtk gain --graph          # ASCII graph, last 30 days
 rtk gain --history        # last 10 commands
-rtk gain --quota -t pro   # quota analysis (pro/5x/20x tiers)
+rtk gain --quota          # monthly quota savings estimate (default tier: 20x)
+rtk gain --quota -t pro   # use pro tier token budget for estimate
 
 # Export
 rtk gain --all --format json > savings.json
@@ -175,6 +176,23 @@ jobs:
       - run: rtk gain --weekly --format json > stats/week-$(date +%Y-%W).json
       - run: git add stats/ && git commit -m "Weekly rtk stats" && git push
 ```
+
+## Quota estimate
+
+`--quota` estimates how many tokens RTK has saved relative to your monthly subscription budget, so you can see the cost impact of those savings.
+
+```bash
+rtk gain --quota          # uses 20x tier by default
+rtk gain --quota -t pro   # Claude Pro plan budget
+rtk gain --quota -t 5x    # 5× usage plan budget
+rtk gain --quota -t 20x   # 20× usage plan budget
+```
+
+The tiers (`pro`, `5x`, `20x`) correspond to Anthropic Claude API subscription levels, each with a different monthly token allocation. RTK uses those allocations as a denominator to express your savings as a percentage of your budget.
+
+:::tip[Find missed savings]
+`rtk gain` shows what RTK saved. To find commands that ran *without* RTK and calculate what you lost, see [rtk discover](./discover.md).
+:::
 
 ## Troubleshooting
 

--- a/docs/guide/getting-started/configuration.md
+++ b/docs/guide/getting-started/configuration.md
@@ -25,7 +25,7 @@ rtk config --create   # create config file with defaults
 [tracking]
 enabled = true              # enable/disable token tracking
 history_days = 90           # retention in days (auto-cleanup)
-database_path = "/custom/path/tracking.db"  # optional override
+database_path = "/custom/path/history.db"   # optional override
 
 [display]
 colors = true               # colored output
@@ -33,6 +33,8 @@ emoji = true                # use emojis in output
 max_width = 120             # maximum output width
 
 [filters]
+# These apply to file-reading commands (ls, find, grep, cat/rtk read).
+# Paths matching these patterns are excluded from output, keeping noise low.
 ignore_dirs = [".git", "node_modules", "target", "__pycache__", ".venv", "vendor"]
 ignore_files = ["*.lock", "*.min.js", "*.min.css"]
 
@@ -43,11 +45,13 @@ max_files = 20              # rotation: keep last N files
 # directory = "/custom/tee/path"  # optional override
 
 [telemetry]
-enabled = true              # anonymous daily ping (opt-out below)
+enabled = true              # anonymous daily ping — see Telemetry & Privacy for full details
 
 [hooks]
 exclude_commands = []       # commands to never auto-rewrite
 ```
+
+For full details on what is collected, opt-out options, and GDPR rights, see [Telemetry & Privacy](../resources/telemetry.md).
 
 ## Environment variables
 

--- a/docs/guide/getting-started/installation.md
+++ b/docs/guide/getting-started/installation.md
@@ -39,8 +39,12 @@ brew install rtk-ai/tap/rtk
 
 ## Cargo
 
+:::caution[Name collision risk]
+`cargo install rtk` may install **Rust Type Kit** instead of Rust Token Killer — two unrelated projects share the same crate name. Use the explicit Git URL to guarantee the correct package:
+:::
+
 ```bash
-cargo install rtk
+cargo install --git https://github.com/rtk-ai/rtk rtk
 ```
 
 ## Pre-built binaries (Windows, Linux, macOS)

--- a/docs/guide/getting-started/quick-start.md
+++ b/docs/guide/getting-started/quick-start.md
@@ -38,7 +38,7 @@ Once the hook is installed, nothing changes in how you work. Your AI assistant r
 
 For example, when Claude Code runs `cargo test`, the hook rewrites it to `rtk cargo test` before it executes. The LLM receives filtered output with only the failures — not 500 lines of passing tests. You never see or type `rtk`.
 
-Supported ecosystems: Git, Cargo/Rust, JavaScript (vitest, tsc, eslint, pnpm, Next.js, Prisma), Python, Go, Ruby, .NET, Docker/Kubernetes, GitHub CLI, and more. See [What RTK Optimizes](../what-rtk-covers.md) for the full list.
+RTK covers all major ecosystems — Git, Cargo/Rust, JavaScript, Python, Go, Ruby, .NET, Docker/Kubernetes, and more. See [What RTK Optimizes](../resources/what-rtk-covers.md) for the full list.
 
 ## Step 3: Check your savings
 
@@ -65,6 +65,6 @@ rtk proxy make install
 
 ## Next steps
 
-- [What RTK Optimizes](../what-rtk-covers.md) — all supported commands and savings by ecosystem
+- [What RTK Optimizes](../resources/what-rtk-covers.md) — all supported commands and savings by ecosystem
 - [Supported agents](./supported-agents.md) — Claude Code, Cursor, Copilot, and more
 - [Configuration](./configuration.md) — customize RTK behavior

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -7,7 +7,7 @@ sidebar:
 
 # Supported Agents
 
-RTK supports 12 AI coding agents across 3 integration tiers. Mistral Vibe support is planned.
+RTK supports all major AI coding agents across 3 integration tiers. Mistral Vibe support is planned.
 
 ## How it works
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -30,13 +30,13 @@ Zero config changes to your workflow. The hook handles everything automatically.
 
 ## What RTK optimizes
 
-60+ commands across 9 ecosystems — Git, Cargo/Rust, JavaScript, Python, Go, Ruby, .NET, Docker/Kubernetes, and more. See [What RTK Optimizes](./what-rtk-covers.md) for the full list with savings percentages.
+Dozens of commands across all major ecosystems — Git, Cargo/Rust, JavaScript, Python, Go, Ruby, .NET, Docker/Kubernetes, and more. See [What RTK Optimizes](./resources/what-rtk-covers.md) for the full list with savings percentages.
 
 ## Get started
 
 1. **[Installation](./getting-started/installation.md)** — Install RTK and verify you have the right package
 2. **[Quick Start](./getting-started/quick-start.md)** — Connect to your AI assistant in 5 minutes
-3. **[Supported Agents](./getting-started/supported-agents.md)** — Claude Code, Cursor, Copilot, Gemini, and 7 more
+3. **[Supported Agents](./getting-started/supported-agents.md)** — Claude Code, Cursor, Copilot, Gemini, and more
 
 ## Measure your savings
 
@@ -46,10 +46,20 @@ rtk gain --daily   # day-by-day breakdown
 rtk gain --weekly  # weekly aggregation
 ```
 
-See [Analytics](./analytics/gain.md) for export formats and analysis workflows.
+See [Token Savings Analytics](./analytics/gain.md) for export formats and analysis workflows.
+
+## Analyze your usage
+
+```bash
+rtk discover       # find commands that ran without RTK (missed savings)
+rtk session        # RTK adoption rate per Claude Code session
+```
+
+See [Discover and Session](./analytics/discover.md) for details.
 
 ## Further reading
 
 - [Configuration](./getting-started/configuration.md) — config.toml, global flags, env vars, tee recovery
-- [Troubleshooting](./troubleshooting.md) — common issues and fixes
+- [Troubleshooting](./resources/troubleshooting.md) — common issues and fixes
+- [Telemetry & Privacy](./resources/telemetry.md) — what RTK collects and how to opt out
 - [ARCHITECTURE.md](https://github.com/rtk-ai/rtk/blob/master/ARCHITECTURE.md) — system design for contributors

--- a/docs/guide/resources/telemetry.md
+++ b/docs/guide/resources/telemetry.md
@@ -1,0 +1,168 @@
+---
+title: Telemetry & Privacy
+description: What RTK collects, how to opt out, and your GDPR rights
+sidebar:
+  order: 3
+---
+
+# Telemetry & Privacy
+
+RTK collects anonymous, aggregate usage metrics once per day to help improve the product. Telemetry is **disabled by default** and requires explicit consent during `rtk init` or `rtk telemetry enable`.
+
+## Data Collector
+
+**Entity**: `RTK AI Labs`
+**Contact**: contact@rtk-ai.app
+
+## Why we collect telemetry
+
+Without telemetry, we have no visibility into:
+
+- Which commands are used most and need the best filters
+- Which filters are underperforming and need improvement
+- Which ecosystems to prioritize for new filter development
+- How much value RTK delivers to users (token savings in $ terms)
+- Whether users stay engaged over time or churn after trying RTK
+
+This data directly drives our roadmap. For example, if telemetry shows that 40% of users run Python commands but only 10% of our filters cover Python, we know where to invest next.
+
+## How it works
+
+1. **Once per day** (23-hour interval), RTK sends a single HTTPS POST to our telemetry endpoint
+2. The ping runs in a **background thread** and never blocks the CLI (2-second timeout)
+3. A marker file prevents duplicate pings within the interval
+4. If the server is unreachable, the ping is silently dropped — no retries, no queue
+
+## What is collected
+
+### Identity (anonymous)
+
+| Field | Example | Purpose |
+|-------|---------|---------|
+| `device_hash` | `a3f8c9...` (64 hex chars) | Count unique installations. SHA-256 of a per-device random salt stored locally (`~/.local/share/rtk/.device_salt`). Not reversible. No hostname or username included. |
+
+### Environment
+
+| Field | Example | Purpose |
+|-------|---------|---------|
+| `version` | `0.34.1` | Track adoption of new versions |
+| `os` | `macos` | Know which platforms to support and test |
+| `arch` | `aarch64` | Prioritize ARM vs x86 builds |
+| `install_method` | `homebrew` | Understand distribution channels (homebrew/cargo/script/nix) |
+
+### Usage volume
+
+| Field | Example | Purpose |
+|-------|---------|---------|
+| `commands_24h` | `142` | Daily activity level |
+| `commands_total` | `32888` | Lifetime usage — segment light vs heavy users |
+| `top_commands` | `["git", "cargo", "ls"]` | Most popular tools (names only, max 5) |
+| `tokens_saved_24h` | `450000` | Daily value delivered |
+| `tokens_saved_total` | `96500000` | Lifetime value delivered |
+| `savings_pct` | `72.5` | Overall effectiveness |
+
+### Quality (filter improvement)
+
+| Field | Example | Purpose |
+|-------|---------|---------|
+| `passthrough_top` | `["git:15", "npm:8"]` | Top 5 commands with 0% savings — these need filters |
+| `parse_failures_24h` | `3` | Filter fragility — high count means filters are breaking |
+| `low_savings_commands` | `["rtk docker ps:25%"]` | Commands averaging <30% savings — filters to improve |
+| `avg_savings_per_command` | `68.5` | Unweighted average (vs global which is volume-biased) |
+
+### Ecosystem distribution
+
+| Field | Example | Purpose |
+|-------|---------|---------|
+| `ecosystem_mix` | `{"git": 45, "cargo": 20, "js": 15}` | Category percentages — where to invest filter development |
+
+### Retention (engagement)
+
+| Field | Example | Purpose |
+|-------|---------|---------|
+| `first_seen_days` | `45` | Installation age in days |
+| `active_days_30d` | `22` | Days with at least 1 command in last 30 days — measures stickiness |
+
+### Economics
+
+| Field | Example | Purpose |
+|-------|---------|---------|
+| `tokens_saved_30d` | `12000000` | 30-day token savings for trend analysis |
+| `estimated_savings_usd_30d` | `36.0` | Estimated dollar value saved (at ~$3/Mtok input pricing, Claude Sonnet) |
+
+### Adoption
+
+| Field | Example | Purpose |
+|-------|---------|---------|
+| `hook_type` | `claude` | Which AI agent hook is installed (claude/gemini/codex/cursor/none) |
+| `custom_toml_filters` | `3` | Number of user-created TOML filter files — DSL adoption |
+
+### Configuration (user maturity)
+
+| Field | Example | Purpose |
+|-------|---------|---------|
+| `has_config_toml` | `true` | Whether user has customized RTK config |
+| `exclude_commands_count` | `2` | Commands excluded from rewriting — high count may indicate frustration |
+| `projects_count` | `5` | Distinct project paths — multi-project = power user |
+
+### Feature adoption
+
+| Field | Example | Purpose |
+|-------|---------|---------|
+| `meta_usage` | `{"gain": 5, "discover": 2}` | Which RTK features are actually used |
+
+## What is NOT collected
+
+- Source code or file contents
+- Full command lines or arguments (only tool names like "git", "cargo")
+- File paths or directory structures
+- Secrets, API keys, or environment variable values
+- Repository names or URLs
+- Personally identifiable information
+- IP addresses (not stored in telemetry pings; stored temporarily in erasure audit log for accountability, anonymized after 6 months)
+
+## Consent
+
+Telemetry requires explicit opt-in consent (GDPR Art. 6, 7). Consent is requested during `rtk init` or via `rtk telemetry enable`. Without consent, no data is sent.
+
+```bash
+rtk telemetry status     # Check current consent state
+rtk telemetry enable     # Give consent (interactive prompt)
+rtk telemetry disable    # Withdraw consent
+rtk telemetry forget     # Withdraw consent + delete local data + request server erasure
+```
+
+Environment variable override (blocks telemetry regardless of consent):
+```bash
+export RTK_TELEMETRY_DISABLED=1
+```
+
+## Retention Policy
+
+- **Server-side**: telemetry records are retained for a maximum of **12 months**, then automatically purged.
+- **Server-side (erasure log)**: IP addresses in the erasure audit log are **anonymized after 6 months** (GDPR — IP is personal data).
+- **Client-side**: the local SQLite database (`~/.local/share/rtk/history.db`) retains data for **90 days** by default (configurable via `tracking.history_days` in `config.toml`). Deleted entirely by `rtk telemetry forget`.
+
+## Your Rights (GDPR)
+
+Under the EU General Data Protection Regulation, you have the right to:
+
+- **Access** your data: `rtk telemetry status` shows your device hash; the telemetry payload is fully documented above.
+- **Rectification**: since data is anonymous and aggregate, rectification is not applicable.
+- **Erasure** (Art. 17): run `rtk telemetry forget` to delete local data and send an erasure request to the server. Alternatively, email contact@rtk-ai.app with your device hash.
+- **Restriction of processing**: `rtk telemetry disable` stops all data collection immediately.
+- **Portability**: the local SQLite database at `~/.local/share/rtk/history.db` contains all locally stored data.
+- **Objection**: `rtk telemetry disable` or `export RTK_TELEMETRY_DISABLED=1`.
+
+## Erasure Procedure
+
+1. Run `rtk telemetry forget` — this disables telemetry, deletes your device salt, ping marker, and local tracking database (`history.db`), then sends an erasure request to the server.
+2. If the server is unreachable, the CLI prints your full device hash and fallback instructions to email contact@rtk-ai.app for manual erasure.
+3. You can also email contact@rtk-ai.app directly to request manual erasure.
+
+## Data Handling
+
+- All communications use HTTPS (TLS)
+- Data is used exclusively for RTK product improvement
+- No data is sold or shared with third parties
+- Aggregate statistics may be published (e.g. "70% of RTK users are on macOS")

--- a/docs/guide/resources/troubleshooting.md
+++ b/docs/guide/resources/troubleshooting.md
@@ -2,7 +2,7 @@
 title: Troubleshooting
 description: Common RTK issues and how to fix them
 sidebar:
-  order: 8
+  order: 2
 ---
 
 # Troubleshooting

--- a/docs/guide/resources/what-rtk-covers.md
+++ b/docs/guide/resources/what-rtk-covers.md
@@ -2,14 +2,14 @@
 title: What RTK Optimizes
 description: Commands and ecosystems automatically optimized by RTK with typical token savings
 sidebar:
-  order: 2
+  order: 1
 ---
 
 # What RTK Optimizes
 
 Once RTK is installed with a hook, these commands are automatically intercepted and filtered. You run them normally — the hook rewrites them transparently before execution.
 
-60+ commands across 9 ecosystems. Typical savings: 60-99%.
+Typical savings: 60-99%.
 
 ## Git
 
@@ -131,17 +131,20 @@ These flags apply to all RTK commands and can push savings even higher:
 
 | Flag | Description |
 |------|-------------|
-| `-u` / `--ultra-compact` | ASCII icons, inline format — extra token reduction on top of normal filtering |
+| `--ultra-compact` | ASCII icons, inline format — extra token reduction on top of normal filtering |
 | `-v` / `--verbose` | Show filtering details on stderr (`-v`, `-vv`, `-vvv` for increasing detail) |
 
 ```bash
 # Ultra-compact: even smaller output
-git log          # → already filtered by RTK
-git log -u       # → ultra-compact variant (if using rtk directly)
+rtk git log --ultra-compact
 
 # Debug: see what RTK is doing
-RTK_DISABLED=0 git status -vvv
+rtk git status -vvv
 ```
+
+:::note
+Use `--ultra-compact` (long form) rather than `-u` when working with Git commands. Git's own `-u` flag means `--set-upstream` and the short form can cause confusion.
+:::
 
 ## Commands that are not rewritten
 

--- a/src/discover/mod.rs
+++ b/src/discover/mod.rs
@@ -21,8 +21,13 @@ struct SupportedBucket {
     rtk_equivalent: &'static str,
     category: &'static str,
     count: usize,
+    /// Total estimated tokens *saved* (post-filter). Used for the "Est. Savings" column.
     total_output_tokens: usize,
-    savings_pct: f64,
+    /// Total estimated tokens *before* filtering (raw output). Accumulated alongside
+    /// `total_output_tokens` so the bucket's effective savings rate can be derived as
+    /// `total_output_tokens / total_raw_output_tokens` — a weighted average across
+    /// all sub-commands, regardless of which sub-command was seen first.
+    total_raw_output_tokens: usize,
     // For display: the most common raw command
     command_counts: HashMap<String, usize>,
 }
@@ -120,7 +125,7 @@ pub fn run(
                                 category,
                                 count: 0,
                                 total_output_tokens: 0,
-                                savings_pct: estimated_savings_pct,
+                                total_raw_output_tokens: 0,
                                 command_counts: HashMap::new(),
                             }
                         });
@@ -140,6 +145,9 @@ pub fn run(
                         let savings =
                             (output_tokens as f64 * estimated_savings_pct / 100.0) as usize;
                         bucket.total_output_tokens += savings;
+                        // Accumulate pre-savings tokens so we can compute a weighted effective
+                        // savings rate across all sub-commands in this bucket later.
+                        bucket.total_raw_output_tokens += output_tokens;
 
                         // Track the display name with status
                         let display_name = truncate_command(part);
@@ -196,13 +204,22 @@ pub fn run(
                 })
                 .unwrap_or_else(|| (String::new(), report::RtkStatus::Existing));
 
+            // Derive the effective savings rate from accumulated totals rather than
+            // using the first-seen sub-command's rate. This gives a weighted average
+            // across all sub-commands that fell in this bucket.
+            let effective_savings_pct = if bucket.total_raw_output_tokens > 0 {
+                bucket.total_output_tokens as f64 * 100.0 / bucket.total_raw_output_tokens as f64
+            } else {
+                0.0
+            };
+
             SupportedEntry {
                 command: command_with_status,
                 count: bucket.count,
                 rtk_equivalent: bucket.rtk_equivalent,
                 category: bucket.category,
                 estimated_savings_tokens: bucket.total_output_tokens,
-                estimated_savings_pct: bucket.savings_pct,
+                estimated_savings_pct: effective_savings_pct,
                 rtk_status: status,
             }
         })

--- a/src/discover/report.rs
+++ b/src/discover/report.rs
@@ -83,12 +83,12 @@ pub fn format_text(report: &DiscoverReport, limit: usize, verbose: bool) -> Stri
         report.sessions_scanned, report.since_days, report.total_commands
     ));
     out.push_str(&format!(
-        "Already using RTK: {} commands ({}%)\n",
+        "Already using RTK: {} commands ({:.1}%)\n",
         report.already_rtk,
         if report.total_commands > 0 {
-            report.already_rtk * 100 / report.total_commands
+            report.already_rtk as f64 * 100.0 / report.total_commands as f64
         } else {
-            0
+            0.0
         }
     ));
 
@@ -212,5 +212,59 @@ fn truncate_str(s: &str, max: usize) -> String {
             .map(|(_, c)| c)
             .collect();
         format!("{}..", truncated)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_report(total_commands: usize, already_rtk: usize) -> DiscoverReport {
+        DiscoverReport {
+            sessions_scanned: 1,
+            total_commands,
+            already_rtk,
+            since_days: 30,
+            supported: vec![],
+            unsupported: vec![],
+            parse_errors: 0,
+            rtk_disabled_count: 0,
+            rtk_disabled_examples: vec![],
+        }
+    }
+
+    // B6 regression: integer division truncated small percentages to 0%.
+    // Example: 3/1000 = 0% (old bug), should be "0.3%".
+    #[test]
+    fn test_already_rtk_percent_shows_decimal() {
+        let report = make_report(1000, 3);
+        let output = format_text(&report, 10, false);
+        // "0.3%" must appear; old code would print "0%"
+        assert!(
+            output.contains("0.3%"),
+            "Expected '0.3%' in output but got:\n{}",
+            output
+        );
+        assert!(
+            !output.contains("(0%)"),
+            "Output must not contain '(0%)' — integer division bug still present:\n{}",
+            output
+        );
+    }
+
+    // Edge case: 0/0 must not divide-by-zero.
+    #[test]
+    fn test_already_rtk_percent_zero_total() {
+        let report = make_report(0, 0);
+        let output = format_text(&report, 10, false);
+        assert!(output.contains("0 commands (0.0%)"));
+    }
+
+    // Full percent: 1000/1000 = 100.0%
+    #[test]
+    fn test_already_rtk_percent_full() {
+        let report = make_report(1000, 1000);
+        let output = format_text(&report, 10, false);
+        assert!(output.contains("100.0%"));
     }
 }


### PR DESCRIPTION
## Summary

- `pull_request_target` doesn't inherit write permissions by default (GitHub security model)
- Workflow was crashing with `403 Resource not accessible by integration` when trying to add the `wrong-base` label and post a comment
- Added explicit `permissions: issues: write / pull-requests: write` at the workflow level

## Root cause

`pull_request_target` runs in the context of the base repo (not the fork), so it *can* have write access — but only if explicitly granted. Without the `permissions` block, the default `GITHUB_TOKEN` is read-only.

Fixes the error seen on PR #1304.