### PR TITLE
fix (copilot): hook syntax for copilot integration

### DIFF
--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -2526,13 +2526,14 @@ fn uninstall_gemini(verbose: u8) -> Result<Vec<String>> {
 // ── Copilot integration ─────────────────────────────────────
 
 const COPILOT_HOOK_JSON: &str = r#"{
+  "version": 1,
   "hooks": {
-    "PreToolUse": [
+    "preToolUse": [
       {
         "type": "command",
-        "command": "rtk hook copilot",
+        "bash": "rtk hook copilot",
         "cwd": ".",
-        "timeout": 5
+        "timeoutSec": 5
       }
     ]
   }


### PR DESCRIPTION
## Summary
- Fix rtk-rewrite.json Copilot hook format generated by rtk init --copilot (is using an outdated syntax)
 - Corrected 4 schema issues: 
     - Added "version": 1
     - Fixed casing PreToolUse → preToolUse
     - Renamed field command → bash
     - Renamed timeout → timeoutSec

## Test plan
- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: hook output inspected using copilot CLI