### PR TITLE
fix: Python single-line docstring and trailing brace on function signature

### DIFF
--- a/src/core/filter.rs
+++ b/src/core/filter.rs
@@ -188,6 +188,15 @@ impl FilterStrategy for MinimalFilter {
 
             // Handle Python docstrings (keep them in minimal mode)
             if *lang == Language::Python && trimmed.starts_with("\"\"\"") {
+                // Single-line docstring: both opens and closes on this line
+                // e.g. """Short docstring."""
+                if trimmed.ends_with("\"\"\"") {
+                    // Single-line docstring — don't toggle, just keep the line
+                    result.push_str(line);
+                    result.push('\n');
+                    continue;
+                }
+                // Multi-line docstring start or end — toggle the flag
                 in_docstring = !in_docstring;
                 result.push_str(line);
                 result.push('\n');
@@ -265,10 +274,14 @@ impl FilterStrategy for AggressiveFilter {
 
             // Always keep function/struct/class signatures
             if FUNC_SIGNATURE.is_match(trimmed) {
+                // Count braces on the signature line (e.g. "fn foo() {")
+                // before continuing, so a trailing '{' is reflected in brace_depth
+                let sig_open = trimmed.matches('{').count() as i32;
+                let sig_close = trimmed.matches('}').count() as i32;
                 result.push_str(line);
                 result.push('\n');
                 in_impl_body = true;
-                brace_depth = 0;
+                brace_depth = sig_open - sig_close;
                 continue;
             }
 
@@ -467,6 +480,33 @@ mod tests {
     }
 
     #[test]
+    fn test_aggressive_filter_trailing_brace_on_signature() {
+        // When a function signature has trailing '{' on the same line,
+        // brace_depth must be counted before continuing, so the function body
+        // is correctly identified as implementation.
+        let input = r#"fn compute(x: i32) -> i32 {
+    let result = x * 2;
+    let extra = result + 1;
+    extra
+}
+"#;
+        let filter = AggressiveFilter;
+        let result = filter.filter(input, &Language::Rust);
+        assert!(
+            !result.contains("let result = x * 2;"),
+            "let binding inside function body should be filtered out"
+        );
+        assert!(
+            !result.contains("let extra = result + 1;"),
+            "let binding inside function body should be filtered out"
+        );
+        assert!(
+            result.contains("fn compute(x: i32) -> i32 {"),
+            "function signature with trailing brace should be kept"
+        );
+    }
+
+    #[test]
     fn test_minimal_filter_removes_comments() {
         let code = r#"
 // This is a comment
@@ -478,6 +518,33 @@ fn main() {
         let result = filter.filter(code, &Language::Rust);
         assert!(!result.contains("// This is a comment"));
         assert!(result.contains("fn main()"));
+    }
+
+    #[test]
+    fn test_minimal_python_single_line_docstring() {
+        // Single-line docstrings like """Short docstring.""" should not
+        // toggle in_docstring — the closing """ is on the same line.
+        let input = r#"def foo():
+    """Short docstring."""
+    # this comment should be stripped
+    x = 1
+    # another comment to strip
+    return x
+"#;
+        let filter = MinimalFilter;
+        let result = filter.filter(input, &Language::Python);
+        assert!(
+            !result.contains("# this comment should be stripped"),
+            "comment after single-line docstring should be stripped"
+        );
+        assert!(
+            !result.contains("# another comment to strip"),
+            "subsequent comment should also be stripped"
+        );
+        assert!(
+            result.contains("\"\"\"Short docstring.\"\"\""),
+            "single-line docstring should be preserved"
+        );
     }
 
     // --- truncation accuracy ---


### PR DESCRIPTION
## Description

Fix two bugs in `src/core/filter.rs`:

### 1. MinimalFilter: Python single-line docstrings

Single-line docstrings like `\`\`\`"Short docstring."\`\`\`` now correctly keep `in_docstring=false`. Previously, the opening `\`\`\`` toggled the flag to `true` and the line was emitted via `continue`, so the closing `\`\`\`` on the same line was never processed. Every subsequent line was treated as inside a docstring, suppressing comment stripping.

**Root cause:** The Python docstring branch unconditionally toggled `in_docstring` on any line starting with `\`\`\``, without checking if the same line also closed the docstring.

**Fix:** Check if the line both starts and ends with `\`\`\`` — if so, it is a single-line docstring and we skip the toggle.

### 2. AggressiveFilter: Trailing `{` on function signature

Function signatures with trailing `{` on the same line (e.g. `fn compute(x: i32) -> i32 {`) now correctly count the brace before `continue`. Previously, the `FUNC_SIGNATURE` branch called `continue` before brace counting ran, leaving `brace_depth=0`. This caused the first body line to set `in_impl_body=false`, letting `let` bindings leak through the "Keep type definitions" branch.

**Root cause:** The signature branch reset `brace_depth = 0` and called `continue` before the brace-counting code, so a trailing `{` on the signature line was never accounted for.

**Fix:** Count opening and closing braces on the signature line before `continue`, so `brace_depth` reflects any trailing `{`.

## Tests

Both fixes include regression tests:
- `test_minimal_python_single_line_docstring`
- `test_aggressive_filter_trailing_brace_on_signature`

## Related Issues

- Fixes #1322
- Fixes #1323