### PR TITLE
fix(ls): LC_ALL=C + fallback to raw on unrecognized locale

### DIFF
--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -77,10 +77,10 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
 
             // If no lines were parsed (e.g., unrecognized locale), fall back to raw output.
             // This is safer than returning "(empty)" for a non-empty directory.
-            let has_content = raw
+            let has_real_content = raw
                 .lines()
-                .any(|l| !l.starts_with("total ") && !l.is_empty());
-            if parsed_count == 0 && has_content {
+                .any(|l| !l.starts_with("total ") && !l.is_empty() && !is_dotdir(l));
+            if parsed_count == 0 && has_real_content {
                 return raw.to_string();
             }
 
@@ -334,6 +334,17 @@ mod tests {
         let input = "total 8\n\
                      drwxr-xr-x  2 user user  4096  1月  1 12:00 .\n\
                      drwxr-xr-x 16 user user 20480  1月  1 12:00 ..\n";
+        let (entries, summary, parsed_count) = compact_ls(input, false);
+        assert_eq!(parsed_count, 0);
+        assert_eq!(entries, "(empty)\n");
+        assert!(summary.is_empty());
+    }
+
+    #[test]
+    fn test_compact_empty_english_locale() {
+        let input = "total 0\n\
+                     drwxr-xr-x  2 lumin  wheel  64 Apr 23 00:37 .\n\
+                     drwxr-xr-x 16 root  wheel 164576 Apr 23 00:37 ..\n";
         let (entries, summary, parsed_count) = compact_ls(input, false);
         assert_eq!(parsed_count, 0);
         assert_eq!(entries, "(empty)\n");

--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -187,7 +187,6 @@ fn compact_ls(raw: &str, show_all: bool) -> (String, String, usize) {
     let mut lines_seen: usize = 0;
     let mut parsed_count: usize = 0;
     let mut dotdirs: usize = 0;
-    let mut parse_failed: usize = 0;
 
     for line in raw.lines() {
         if line.starts_with("total ") || line.is_empty() {
@@ -198,8 +197,6 @@ fn compact_ls(raw: &str, show_all: bool) -> (String, String, usize) {
         let Some((file_type, size, name)) = parse_ls_line(line) else {
             if is_dotdir(line) {
                 dotdirs += 1;
-            } else {
-                parse_failed += 1;
             }
             continue;
         };

--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -35,6 +35,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         .collect();
 
     let mut cmd = resolved_command("ls");
+    cmd.env("LC_ALL", "C");
     cmd.arg("-la");
     for flag in &flags {
         if flag.starts_with("--") {
@@ -72,7 +73,16 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         "ls",
         &format!("-la {}", target_display),
         |raw| {
-            let (entries, summary) = compact_ls(raw, show_all);
+            let (entries, summary, parsed_count) = compact_ls(raw, show_all);
+
+            // If no lines were parsed (e.g., unrecognized locale), fall back to raw output.
+            // This is safer than returning "(empty)" for a non-empty directory.
+            let has_content = raw
+                .lines()
+                .any(|l| !l.starts_with("total ") && !l.is_empty());
+            if parsed_count == 0 && has_content {
+                return raw.to_string();
+            }
 
             // Only show summary in interactive mode (not when piped)
             let is_tty = std::io::stdout().is_terminal();
@@ -150,22 +160,28 @@ fn parse_ls_line(line: &str) -> Option<(char, u64, String)> {
 /// Parse ls -la output into compact format:
 ///   name/  (dirs)
 ///   name  size  (files)
-/// Returns (entries, summary) so caller can suppress summary when piped.
-fn compact_ls(raw: &str, show_all: bool) -> (String, String) {
+/// Returns (entries, summary, parsed_count) so caller can suppress summary when piped.
+/// parsed_count tracks how many non-header lines were successfully parsed.
+/// If parsed_count == 0 but raw had content, caller should fall back to raw output.
+fn compact_ls(raw: &str, show_all: bool) -> (String, String, usize) {
     use std::collections::HashMap;
 
     let mut dirs: Vec<String> = Vec::new();
     let mut files: Vec<(String, String)> = Vec::new(); // (name, size)
     let mut by_ext: HashMap<String, usize> = HashMap::new();
+    let mut lines_seen: usize = 0;
+    let mut parsed_count: usize = 0;
 
     for line in raw.lines() {
         if line.starts_with("total ") || line.is_empty() {
             continue;
         }
+        lines_seen += 1;
 
         let Some((file_type, size, name)) = parse_ls_line(line) else {
             continue;
         };
+        parsed_count += 1;
 
         // Skip . and ..
         if name == "." || name == ".." {
@@ -191,7 +207,10 @@ fn compact_ls(raw: &str, show_all: bool) -> (String, String) {
     }
 
     if dirs.is_empty() && files.is_empty() {
-        return ("(empty)\n".to_string(), String::new());
+        if lines_seen > 0 && parsed_count == 0 {
+            return (String::new(), String::new(), 0);
+        }
+        return ("(empty)\n".to_string(), String::new(), 0);
     }
 
     let mut entries = String::new();
@@ -229,7 +248,7 @@ fn compact_ls(raw: &str, show_all: bool) -> (String, String) {
     }
     summary.push('\n');
 
-    (entries, summary)
+    (entries, summary, parsed_count)
 }
 
 #[cfg(test)]
@@ -244,7 +263,7 @@ mod tests {
                      drwxr-xr-x  2 user  staff    64 Jan  1 12:00 src\n\
                      -rw-r--r--  1 user  staff  1234 Jan  1 12:00 Cargo.toml\n\
                      -rw-r--r--  1 user  staff  5678 Jan  1 12:00 README.md\n";
-        let (entries, _summary) = compact_ls(input, false);
+        let (entries, _summary, _) = compact_ls(input, false);
         assert!(entries.contains("src/"));
         assert!(entries.contains("Cargo.toml"));
         assert!(entries.contains("README.md"));
@@ -265,7 +284,7 @@ mod tests {
                      drwxr-xr-x  2 user  staff  64 Jan  1 12:00 target\n\
                      drwxr-xr-x  2 user  staff  64 Jan  1 12:00 src\n\
                      -rw-r--r--  1 user  staff  100 Jan  1 12:00 main.rs\n";
-        let (entries, _summary) = compact_ls(input, false);
+        let (entries, _summary, _) = compact_ls(input, false);
         assert!(!entries.contains("node_modules"));
         assert!(!entries.contains(".git"));
         assert!(!entries.contains("target"));
@@ -278,7 +297,7 @@ mod tests {
         let input = "total 8\n\
                      drwxr-xr-x  2 user  staff  64 Jan  1 12:00 .git\n\
                      drwxr-xr-x  2 user  staff  64 Jan  1 12:00 src\n";
-        let (entries, _summary) = compact_ls(input, true);
+        let (entries, _summary, _) = compact_ls(input, true);
         assert!(entries.contains(".git/"));
         assert!(entries.contains("src/"));
     }
@@ -286,7 +305,7 @@ mod tests {
     #[test]
     fn test_compact_empty() {
         let input = "total 0\n";
-        let (entries, summary) = compact_ls(input, false);
+        let (entries, summary, _) = compact_ls(input, false);
         assert_eq!(entries, "(empty)\n");
         assert!(summary.is_empty());
     }
@@ -298,7 +317,7 @@ mod tests {
                      -rw-r--r--  1 user  staff  1234 Jan  1 12:00 main.rs\n\
                      -rw-r--r--  1 user  staff  5678 Jan  1 12:00 lib.rs\n\
                      -rw-r--r--  1 user  staff   100 Jan  1 12:00 Cargo.toml\n";
-        let (_entries, summary) = compact_ls(input, false);
+        let (_entries, summary, _) = compact_ls(input, false);
         assert!(summary.contains("Summary: 3 files, 1 dirs"));
         assert!(summary.contains(".rs"));
         assert!(summary.contains(".toml"));
@@ -318,7 +337,7 @@ mod tests {
     fn test_compact_handles_filenames_with_spaces() {
         let input = "total 8\n\
                      -rw-r--r--  1 user  staff  1234 Jan  1 12:00 my file.txt\n";
-        let (entries, _summary) = compact_ls(input, false);
+        let (entries, _summary, _) = compact_ls(input, false);
         assert!(entries.contains("my file.txt"));
     }
 
@@ -326,7 +345,7 @@ mod tests {
     fn test_compact_symlinks() {
         let input = "total 8\n\
                      lrwxr-xr-x  1 user  staff  10 Jan  1 12:00 link -> target\n";
-        let (entries, _summary) = compact_ls(input, false);
+        let (entries, _summary, _) = compact_ls(input, false);
         assert!(entries.contains("link -> target"));
     }
 
@@ -336,7 +355,7 @@ mod tests {
         let input = "total 48\n\
                      drwxr-xr-x  2 user  staff    64 Jan  1 12:00 src\n\
                      -rw-r--r--  1 user  staff  1234 Jan  1 12:00 main.rs\n";
-        let (entries, summary) = compact_ls(input, false);
+        let (entries, summary, _) = compact_ls(input, false);
         assert!(
             !entries.contains("Summary:"),
             "entries must not contain summary"
@@ -355,7 +374,7 @@ mod tests {
                      drwxr-xr-x  2 user  staff    64 Jan  1 12:00 src\n\
                      -rw-r--r--  1 user  staff  1234 Jan  1 12:00 main.rs\n\
                      -rw-r--r--  1 user  staff  5678 Jan  1 12:00 lib.rs\n";
-        let (entries, _summary) = compact_ls(input, false);
+        let (entries, _summary, _) = compact_ls(input, false);
         let line_count = entries.lines().count();
         assert_eq!(
             line_count, 3,
@@ -370,7 +389,7 @@ mod tests {
         let input = "total 8\n\
                      -rw-r--r--  1 fjeanne utilisa. du domaine    0 Mar 31 16:18 empty.txt\n\
                      -rw-r--r--  1 fjeanne utilisa. du domaine 1234 Mar 31 16:18 data.json\n";
-        let (entries, _summary) = compact_ls(input, false);
+        let (entries, _summary, _) = compact_ls(input, false);
         assert!(
             entries.contains("empty.txt"),
             "should contain 'empty.txt', got: {entries}"
@@ -398,23 +417,18 @@ mod tests {
         // Some systems show year instead of time for old files
         let input = "total 8\n\
                      -rw-r--r--  1 user staff  5678 Dec 25  2024 archive.tar\n";
-        let (entries, _summary) = compact_ls(input, false);
+        let (entries, _summary, _) = compact_ls(input, false);
         assert!(
             entries.contains("archive.tar"),
             "should contain filename, got: {entries}"
         );
-        assert!(
-            entries.contains("5.5K"),
-            "should show 5.5K, got: {entries}"
-        );
+        assert!(entries.contains("5.5K"), "should show 5.5K, got: {entries}");
     }
 
     #[test]
     fn test_parse_ls_line_basic() {
-        let (ft, size, name) = parse_ls_line(
-            "-rw-r--r--  1 user staff 1234 Jan  1 12:00 file.txt",
-        )
-        .unwrap();
+        let (ft, size, name) =
+            parse_ls_line("-rw-r--r--  1 user staff 1234 Jan  1 12:00 file.txt").unwrap();
         assert_eq!(ft, '-');
         assert_eq!(size, 1234);
         assert_eq!(name, "file.txt");
@@ -422,10 +436,9 @@ mod tests {
 
     #[test]
     fn test_parse_ls_line_multiline_group() {
-        let (ft, size, name) = parse_ls_line(
-            "-rw-r--r--  1 fjeanne utilisa. du domaine 0 Mar 31 16:18 empty.txt",
-        )
-        .unwrap();
+        let (ft, size, name) =
+            parse_ls_line("-rw-r--r--  1 fjeanne utilisa. du domaine 0 Mar 31 16:18 empty.txt")
+                .unwrap();
         assert_eq!(ft, '-');
         assert_eq!(size, 0);
         assert_eq!(name, "empty.txt");
@@ -433,10 +446,9 @@ mod tests {
 
     #[test]
     fn test_parse_ls_line_dir_with_space_in_group() {
-        let (ft, size, name) = parse_ls_line(
-            "drwxr-xr-x  2 fjeanne utilisa. du domaine 64 Mar 31 16:18 my dir",
-        )
-        .unwrap();
+        let (ft, size, name) =
+            parse_ls_line("drwxr-xr-x  2 fjeanne utilisa. du domaine 64 Mar 31 16:18 my dir")
+                .unwrap();
         assert_eq!(ft, 'd');
         assert_eq!(size, 64);
         assert_eq!(name, "my dir");
@@ -444,10 +456,8 @@ mod tests {
 
     #[test]
     fn test_parse_ls_line_symlink() {
-        let (ft, size, name) = parse_ls_line(
-            "lrwxr-xr-x  1 user staff 10 Jan  1 12:00 link -> target",
-        )
-        .unwrap();
+        let (ft, size, name) =
+            parse_ls_line("lrwxr-xr-x  1 user staff 10 Jan  1 12:00 link -> target").unwrap();
         assert_eq!(ft, 'l');
         assert_eq!(size, 10);
         assert_eq!(name, "link -> target");
@@ -460,12 +470,21 @@ mod tests {
 
     #[test]
     fn test_parse_ls_line_year_format() {
-        let (ft, size, name) = parse_ls_line(
-            "-rw-r--r--  1 user staff 5678 Dec 25  2024 old.tar.gz",
-        )
-        .unwrap();
+        let (ft, size, name) =
+            parse_ls_line("-rw-r--r--  1 user staff 5678 Dec 25  2024 old.tar.gz").unwrap();
         assert_eq!(ft, '-');
         assert_eq!(size, 5678);
         assert_eq!(name, "old.tar.gz");
+    }
+
+    #[test]
+    fn test_compact_chinese_locale_fallback() {
+        let input = "total 8\n\
+                      drwxr-xr-x  2 user staff  64  1月  1 12:00 src\n\
+                      -rw-r--r--  1 user staff 1234  1月  1 12:00 main.rs\n";
+        let (entries, summary, parsed_count) = compact_ls(input, false);
+        assert_eq!(parsed_count, 0);
+        assert!(entries.is_empty());
+        assert!(summary.is_empty());
     }
 }

--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -131,6 +131,11 @@ fn human_size(bytes: u64) -> String {
 /// filename (everything after the date). This handles owner/group names that
 /// contain spaces, which break the old fixed-column approach.
 fn parse_ls_line(line: &str) -> Option<(char, u64, String)> {
+    // Skip . and .. entries before date parsing (works for non-English locales too)
+    if is_dotdir(line) {
+        return None;
+    }
+
     let date_match = LS_DATE_RE.find(line)?;
     let name = line[date_match.end()..].to_string();
 
@@ -157,6 +162,16 @@ fn parse_ls_line(line: &str) -> Option<(char, u64, String)> {
     Some((file_type, size, name))
 }
 
+/// Returns true if the line represents a . or .. directory entry.
+///
+/// POSIX.1-2017 (IEEE Std 1003.1) specifies that each directory contains
+/// entries for "." (the directory itself) and ".." (its parent). These entries
+/// always appear in `ls -la` output and are skipped during parsing since they
+/// carry no meaningful content for token reduction.
+fn is_dotdir(line: &str) -> bool {
+    line.trim().ends_with('.') || line.trim().ends_with("..")
+}
+
 /// Parse ls -la output into compact format:
 ///   name/  (dirs)
 ///   name  size  (files)
@@ -171,6 +186,8 @@ fn compact_ls(raw: &str, show_all: bool) -> (String, String, usize) {
     let mut by_ext: HashMap<String, usize> = HashMap::new();
     let mut lines_seen: usize = 0;
     let mut parsed_count: usize = 0;
+    let mut dotdirs: usize = 0;
+    let mut parse_failed: usize = 0;
 
     for line in raw.lines() {
         if line.starts_with("total ") || line.is_empty() {
@@ -179,14 +196,14 @@ fn compact_ls(raw: &str, show_all: bool) -> (String, String, usize) {
         lines_seen += 1;
 
         let Some((file_type, size, name)) = parse_ls_line(line) else {
+            if is_dotdir(line) {
+                dotdirs += 1;
+            } else {
+                parse_failed += 1;
+            }
             continue;
         };
         parsed_count += 1;
-
-        // Skip . and ..
-        if name == "." || name == ".." {
-            continue;
-        }
 
         // Filter noise dirs unless -a
         if !show_all && NOISE_DIRS.iter().any(|noise| name == *noise) {
@@ -208,6 +225,11 @@ fn compact_ls(raw: &str, show_all: bool) -> (String, String, usize) {
 
     if dirs.is_empty() && files.is_empty() {
         if lines_seen > 0 && parsed_count == 0 {
+            if dotdirs == lines_seen {
+                // Only . and .. entries (empty directory)
+                return ("(empty)\n".to_string(), String::new(), 0);
+            }
+            // Real content that couldn't be parsed (e.g., non-English locale)
             return (String::new(), String::new(), 0);
         }
         return ("(empty)\n".to_string(), String::new(), 0);
@@ -306,6 +328,17 @@ mod tests {
     fn test_compact_empty() {
         let input = "total 0\n";
         let (entries, summary, _) = compact_ls(input, false);
+        assert_eq!(entries, "(empty)\n");
+        assert!(summary.is_empty());
+    }
+
+    #[test]
+    fn test_compact_empty_chinese_locale() {
+        let input = "total 8\n\
+                     drwxr-xr-x  2 user user  4096  1月  1 12:00 .\n\
+                     drwxr-xr-x 16 user user 20480  1月  1 12:00 ..\n";
+        let (entries, summary, parsed_count) = compact_ls(input, false);
+        assert_eq!(parsed_count, 0);
         assert_eq!(entries, "(empty)\n");
         assert!(summary.is_empty());
     }


### PR DESCRIPTION
## Summary

Fixes `rtk ls` returning empty output for non-English locales (zh_CN, ja, ko, etc.).

### Root Cause
The `LS_DATE_RE` regex hardcodes English month names (`Jan|Feb|Mar|...`). When `ls -la` runs under a non-English locale, it outputs native month names (e.g., `1月`, `1月`), causing the regex to match nothing → `parse_ls_line` returns `None` for every line → `(empty)` output.

### Changes

1. **`LC_ALL=C`**: Force English output for `ls` regardless of system locale (`src/cmds/system/ls.rs:38`)
2. **Fallback to raw**: When zero lines are parsed but the directory is non-empty, return the original `ls` output instead of `(empty)` (`src/cmds/system/ls.rs:79-84`)
3. **Unit test**: `test_compact_chinese_locale_fallback` verifies the fallback path

### Behavior

| Scenario | Before | After |
|----------|--------|-------|
| English locale | ✅ Works | ✅ Works |
| Non-English locale (e.g. zh_CN) | ❌ `(empty)` | ✅ Raw `ls -la` output |
| Empty directory | ✅ `(empty)` | ✅ `(empty)` |

No token savings for non-English locale users, but no silent data loss — the LLM still sees the full directory listing.

Closes #1276