### PR TITLE
feat(hooks): support CLAUDE_CONFIG_DIR environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Features
+
+* **hooks:** support `CLAUDE_CONFIG_DIR` environment variable for custom Claude Code config directory
+
 ### Bug Fixes
 
 * **git:** remove `-u` short alias from `--ultra-compact` to fix `git push -u` upstream tracking ([#1086](https://github.com/rtk-ai/rtk/issues/1086))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "rtk"
-version = "0.35.0"
+version = "0.34.3"
 dependencies = [
  "anyhow",
  "automod",

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -39,6 +39,8 @@ Each agent subdirectory has its own README with hook-specific details:
 - **[`cline/`](cline/README.md)** — Rules file (prompt-level), `.clinerules` project-local installation
 - **[`windsurf/`](windsurf/README.md)** — Rules file (prompt-level), `.windsurfrules` workspace-scoped
 - **[`codex/`](codex/README.md)** — Awareness document, `AGENTS.md` integration, `$CODEX_HOME` or `~/.codex/` location
+
+**Config directory overrides**: RTK honors `CLAUDE_CONFIG_DIR` (for Claude Code) and `CODEX_HOME` (for Codex CLI) environment variables. When set, all hook paths use the overridden directory instead of the default.
 - **[`opencode/`](opencode/README.md)** — TypeScript plugin, `zx` library, `tool.execute.before` event, in-place mutation
 
 ## Supported Agents

--- a/src/core/telemetry.rs
+++ b/src/core/telemetry.rs
@@ -3,6 +3,7 @@
 use super::constants::RTK_DATA_DIR;
 use crate::core::config;
 use crate::core::tracking;
+use crate::hooks::claude_path::resolve_claude_dir;
 use sha2::{Digest, Sha256};
 use std::fmt::Write as FmtWrite;
 use std::io::Write as IoWrite;
@@ -353,10 +354,21 @@ fn detect_hook_type() -> String {
         None => return "unknown".to_string(),
     };
 
-    // Check in order of popularity
+    // Check Claude hooks (respects CLAUDE_CONFIG_DIR)
+    if let Ok(claude_dir) = resolve_claude_dir() {
+        let claude_checks = [
+            claude_dir.join("hooks/rtk-rewrite.sh"),
+            claude_dir.join("hooks/rtk-rewrite.json"),
+        ];
+        for path in &claude_checks {
+            if path.exists() {
+                return "claude".to_string();
+            }
+        }
+    }
+
+    // Check other agent hooks
     let checks = [
-        (home.join(".claude/hooks/rtk-rewrite.sh"), "claude"),
-        (home.join(".claude/hooks/rtk-rewrite.json"), "claude"),
         (home.join(".gemini/hooks/rtk-hook.sh"), "gemini"),
         (home.join(".codex/AGENTS.md"), "codex"),
         (home.join(".cursor/hooks/rtk-rewrite.json"), "cursor"),
@@ -368,7 +380,7 @@ fn detect_hook_type() -> String {
         }
     }
 
-    // Check project-level hooks
+    // Check project-level hooks (always .claude/ relative to project root)
     if let Ok(cwd) = std::env::current_dir() {
         if cwd.join(".claude/hooks/rtk-rewrite.sh").exists() {
             return "claude".to_string();

--- a/src/discover/provider.rs
+++ b/src/discover/provider.rs
@@ -1,6 +1,6 @@
 //! Reads Claude Code session logs from disk and streams their command history.
 
-use crate::hooks::constants::CLAUDE_DIR;
+use crate::hooks::claude_path::resolve_claude_dir;
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::fs;
@@ -44,8 +44,7 @@ pub struct ClaudeProvider;
 impl ClaudeProvider {
     /// Get the base directory for Claude Code projects.
     fn projects_dir() -> Result<PathBuf> {
-        let home = dirs::home_dir().context("could not determine home directory")?;
-        let dir = home.join(CLAUDE_DIR).join("projects");
+        let dir = resolve_claude_dir()?.join("projects");
         if !dir.exists() {
             anyhow::bail!(
                 "Claude Code projects directory not found: {}\nMake sure Claude Code has been used at least once.",

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -29,6 +29,17 @@ LLM agent integration layer that installs, validates, and executes command-rewri
 | Windsurf | `rtk init -g --agent windsurf` | `.windsurfrules` | -- |
 | Cline | `rtk init --agent cline` | `.clinerules` | -- |
 | Codex | `rtk init --codex` | RTK.md in `$CODEX_HOME` or `~/.codex` | AGENTS.md |
+
+### Environment Variable Overrides
+
+RTK honors the same config directory environment variables used by the AI tools themselves:
+
+| Variable | Tool | Default | Effect |
+|----------|------|---------|--------|
+| `CLAUDE_CONFIG_DIR` | Claude Code | `~/.claude` | All Claude hook paths use this dir instead |
+| `CODEX_HOME` | Codex CLI | `~/.codex` | All Codex hook paths use this dir instead |
+
+When set, all operations (install, verify, permissions, session discovery) use the overridden path. When unset or empty, the default is used. This is handled by `claude_path::resolve_claude_dir()` and the corresponding codex resolver.
 | Cursor | `rtk init -g --agent cursor` | Cursor hook | hooks.json |
 
 

--- a/src/hooks/claude_path.rs
+++ b/src/hooks/claude_path.rs
@@ -1,0 +1,118 @@
+//! Shared Claude Code config directory resolution.
+//!
+//! Honors the `CLAUDE_CONFIG_DIR` environment variable, falling back to
+//! `$HOME/.claude` when unset or empty.  This mirrors the existing
+//! `CODEX_HOME` support for Codex CLI.
+
+use super::constants::CLAUDE_DIR;
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+
+/// Resolve the Claude Code config directory.
+///
+/// Priority: `$CLAUDE_CONFIG_DIR` env var → `$HOME/.claude`.
+pub(crate) fn resolve_claude_dir() -> Result<PathBuf> {
+    resolve_claude_dir_from(
+        std::env::var_os("CLAUDE_CONFIG_DIR").map(PathBuf::from),
+        dirs::home_dir(),
+    )
+}
+
+/// Testable inner resolver (no env var side-effects).
+pub(crate) fn resolve_claude_dir_from(
+    claude_config_dir: Option<PathBuf>,
+    home_dir: Option<PathBuf>,
+) -> Result<PathBuf> {
+    if let Some(path) = claude_config_dir.filter(|p| !p.as_os_str().is_empty()) {
+        return Ok(path);
+    }
+
+    home_dir
+        .map(|home| home.join(CLAUDE_DIR))
+        .context("Cannot determine Claude config directory. Set $CLAUDE_CONFIG_DIR or $HOME.")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_prefers_env_var_over_home() {
+        let custom = PathBuf::from("/custom/claude");
+        let home = PathBuf::from("/home/user");
+        let result = resolve_claude_dir_from(Some(custom.clone()), Some(home)).unwrap();
+        assert_eq!(result, custom);
+    }
+
+    #[test]
+    fn test_empty_env_var_falls_back_to_home() {
+        let home = PathBuf::from("/home/user");
+        let result = resolve_claude_dir_from(Some(PathBuf::new()), Some(home.clone())).unwrap();
+        assert_eq!(result, home.join(".claude"));
+    }
+
+    #[test]
+    fn test_none_env_var_falls_back_to_home() {
+        let home = PathBuf::from("/home/user");
+        let result = resolve_claude_dir_from(None, Some(home.clone())).unwrap();
+        assert_eq!(result, home.join(".claude"));
+    }
+
+    #[test]
+    fn test_both_none_returns_error() {
+        assert!(resolve_claude_dir_from(None, None).is_err());
+    }
+
+    #[test]
+    fn test_path_with_spaces() {
+        let custom = PathBuf::from("/Users/John Doe/.my claude");
+        let home = PathBuf::from("/home/user");
+        let result = resolve_claude_dir_from(Some(custom.clone()), Some(home)).unwrap();
+        assert_eq!(result, custom);
+    }
+
+    #[test]
+    fn test_relative_path_preserved_as_is() {
+        let relative = PathBuf::from("./configs/.claude");
+        let home = PathBuf::from("/home/user");
+        let result = resolve_claude_dir_from(Some(relative.clone()), Some(home)).unwrap();
+        assert_eq!(result, relative);
+    }
+
+    #[test]
+    fn test_env_var_takes_priority_even_when_home_missing() {
+        let custom = PathBuf::from("/custom/claude");
+        let result = resolve_claude_dir_from(Some(custom.clone()), None).unwrap();
+        assert_eq!(result, custom);
+    }
+}
+
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_resolve_with_real_tempdir() {
+        let temp = TempDir::new().unwrap();
+        let claude_dir = temp.path().join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+        let result = resolve_claude_dir_from(Some(claude_dir.clone()), None).unwrap();
+        assert_eq!(result, claude_dir);
+        assert!(result.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_resolve_with_symlink() {
+        let temp = TempDir::new().unwrap();
+        let real_dir = temp.path().join("real-claude");
+        let symlink = temp.path().join("symlink-claude");
+        fs::create_dir_all(&real_dir).unwrap();
+        std::os::unix::fs::symlink(&real_dir, &symlink).unwrap();
+        let result = resolve_claude_dir_from(Some(symlink.clone()), None).unwrap();
+        assert_eq!(result, symlink);
+    }
+}

--- a/src/hooks/hook_check.rs
+++ b/src/hooks/hook_check.rs
@@ -1,8 +1,8 @@
 //! Detects whether RTK hooks are installed and warns if they are outdated.
 
+use super::claude_path::resolve_claude_dir;
 use super::constants::{
-    CLAUDE_DIR, CLAUDE_HOOK_COMMAND, HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE,
-    SETTINGS_JSON,
+    CLAUDE_HOOK_COMMAND, HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 #[cfg(test)]
 use super::constants::{CODEX_DIR, CURSOR_DIR, GEMINI_DIR, GEMINI_HOOK_FILE, OPENCODE_PLUGIN_PATH};
@@ -27,11 +27,10 @@ pub enum HookStatus {
 /// Returns `Ok` if no Claude Code is detected (not applicable).
 pub fn status() -> HookStatus {
     // Don't warn users who don't have Claude Code installed
-    let home = match dirs::home_dir() {
-        Some(h) => h,
-        None => return HookStatus::Ok,
+    let claude_dir = match resolve_claude_dir() {
+        Ok(d) => d,
+        Err(_) => return HookStatus::Ok,
     };
-    let claude_dir = home.join(CLAUDE_DIR);
     if !claude_dir.exists() {
         return HookStatus::Ok;
     }
@@ -151,9 +150,8 @@ fn other_integration_installed(home: &std::path::Path) -> bool {
 }
 
 fn hook_installed_path() -> Option<PathBuf> {
-    let home = dirs::home_dir()?;
-    let path = home
-        .join(CLAUDE_DIR)
+    let path = resolve_claude_dir()
+        .ok()?
         .join(HOOKS_SUBDIR)
         .join(REWRITE_HOOK_FILE);
     if path.exists() {

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -6,9 +6,10 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 
+use super::claude_path::resolve_claude_dir;
 use super::constants::{
-    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND,
-    GEMINI_HOOK_FILE, HOOKS_JSON, HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
+    BEFORE_TOOL_KEY, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND, GEMINI_HOOK_FILE,
+    HOOKS_JSON, HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use super::integrity;
 
@@ -967,11 +968,8 @@ fn run_default_mode(
 /// Migrate old hook script to new binary command.
 /// Deletes `~/.claude/hooks/rtk-rewrite.sh` and `.rtk-hook.sha256` if present.
 fn migrate_old_hook_script(verbose: u8) {
-    if let Some(home) = dirs::home_dir() {
-        let old_hook = home
-            .join(CLAUDE_DIR)
-            .join(HOOKS_SUBDIR)
-            .join(REWRITE_HOOK_FILE);
+    if let Ok(claude_dir) = resolve_claude_dir() {
+        let old_hook = claude_dir.join(HOOKS_SUBDIR).join(REWRITE_HOOK_FILE);
         if old_hook.exists() {
             if let Err(e) = std::fs::remove_file(&old_hook) {
                 if verbose > 0 {
@@ -982,15 +980,16 @@ fn migrate_old_hook_script(verbose: u8) {
             }
         }
         // Remove legacy hash file
-        let hash_file = home
-            .join(CLAUDE_DIR)
-            .join(HOOKS_SUBDIR)
-            .join(".rtk-hook.sha256");
+        let hash_file = claude_dir.join(HOOKS_SUBDIR).join(".rtk-hook.sha256");
         if hash_file.exists() {
             let _ = std::fs::remove_file(&hash_file);
         }
         // Remove Cursor legacy hook
-        let cursor_hook = home.join(".cursor").join("hooks").join(REWRITE_HOOK_FILE);
+        let cursor_hook = dirs::home_dir()
+            .unwrap_or_default()
+            .join(".cursor")
+            .join("hooks")
+            .join(REWRITE_HOOK_FILE);
         if cursor_hook.exists() {
             let _ = std::fs::remove_file(&cursor_hook);
         }
@@ -1669,10 +1668,6 @@ fn resolve_home_subdir(subdir: &str) -> Result<PathBuf> {
     dirs::home_dir()
         .map(|h| h.join(subdir))
         .context("Cannot determine home directory. Is $HOME set?")
-}
-
-fn resolve_claude_dir() -> Result<PathBuf> {
-    resolve_home_subdir(CLAUDE_DIR)
 }
 
 fn resolve_codex_dir() -> Result<PathBuf> {

--- a/src/hooks/integrity.rs
+++ b/src/hooks/integrity.rs
@@ -12,7 +12,8 @@
 //!
 //! Reference: SA-2025-RTK-001 (Finding F-01)
 
-use super::constants::{CLAUDE_DIR, HOOKS_SUBDIR, REWRITE_HOOK_FILE};
+use super::claude_path::resolve_claude_dir;
+use super::constants::{HOOKS_SUBDIR, REWRITE_HOOK_FILE};
 use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
 use std::fs;
@@ -183,13 +184,9 @@ fn read_stored_hash(path: &Path) -> Result<String> {
 
 /// Resolve the default hook path (~/.claude/hooks/rtk-rewrite.sh)
 pub fn resolve_hook_path() -> Result<PathBuf> {
-    dirs::home_dir()
-        .map(|h| {
-            h.join(CLAUDE_DIR)
-                .join(HOOKS_SUBDIR)
-                .join(REWRITE_HOOK_FILE)
-        })
-        .context("Cannot determine home directory. Is $HOME set?")
+    Ok(resolve_claude_dir()?
+        .join(HOOKS_SUBDIR)
+        .join(REWRITE_HOOK_FILE))
 }
 
 /// Run integrity check and print results (for `rtk verify` subcommand)
@@ -205,8 +202,7 @@ pub fn run_verify(verbose: u8) -> Result<()> {
     // If no legacy script exists, check for native binary command registration
     if !hook_path.exists() && !hash_file.exists() {
         // Check if the native binary command is registered in settings.json
-        let home = dirs::home_dir().context("Cannot determine home directory")?;
-        let settings_path = home.join(CLAUDE_DIR).join("settings.json");
+        let settings_path = resolve_claude_dir()?.join("settings.json");
         if settings_path.exists() {
             let content = fs::read_to_string(&settings_path).unwrap_or_default();
             if content.contains("rtk hook claude") {

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1,5 +1,6 @@
 //! Hook installation and lifecycle management for AI coding agents.
 
+pub(crate) mod claude_path;
 pub mod constants;
 pub mod hook_audit_cmd;
 pub mod hook_check;

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -1,3 +1,4 @@
+use super::claude_path::resolve_claude_dir;
 use super::constants::{CLAUDE_DIR, SETTINGS_JSON, SETTINGS_LOCAL_JSON};
 use crate::core::stream::exec_capture;
 use crate::discover::lexer::split_on_operators;
@@ -150,9 +151,9 @@ fn get_settings_paths() -> Vec<PathBuf> {
         paths.push(root.join(CLAUDE_DIR).join(SETTINGS_JSON));
         paths.push(root.join(CLAUDE_DIR).join(SETTINGS_LOCAL_JSON));
     }
-    if let Some(home) = dirs::home_dir() {
-        paths.push(home.join(CLAUDE_DIR).join(SETTINGS_JSON));
-        paths.push(home.join(CLAUDE_DIR).join(SETTINGS_LOCAL_JSON));
+    if let Ok(claude_dir) = resolve_claude_dir() {
+        paths.push(claude_dir.join(SETTINGS_JSON));
+        paths.push(claude_dir.join(SETTINGS_LOCAL_JSON));
     }
 
     paths


### PR DESCRIPTION
## Summary

RTK already honors `CODEX_HOME` for Codex CLI — this adds the same support
for Claude Code's official `CLAUDE_CONFIG_DIR` environment variable
([docs](https://code.claude.com/docs/en/env-vars)).

When `CLAUDE_CONFIG_DIR` is set, RTK uses it instead of `~/.claude` for
hook installation, permission lookup, session discovery, integrity checks,
and telemetry detection. Falls back to `~/.claude` when unset or empty —
no behavior change for existing users.

## Changes

- Extract shared `claude_path` module with `resolve_claude_dir()` (matches `resolve_codex_dir()` pattern)
- Update all hardcoded `home.join(CLAUDE_DIR)` callers across 7 files:
  `init.rs`, `permissions.rs`, `provider.rs`, `hook_check.rs`, `integrity.rs`, `telemetry.rs`
- Add 9 unit + integration tests (preference, fallback, empty, spaces, relative, symlink)
- Update `src/hooks/README.md`, `hooks/README.md`, and `CHANGELOG.md`

## Testing

- `cargo fmt --all --check && cargo clippy --all-targets && cargo test` — all 1593 tests pass
- Manual smoke test: `CLAUDE_CONFIG_DIR=/tmp/test rtk init -g` installs hooks to custom dir