### PR TITLE
feat(js): add bun and bunx to command rewrite rules

### DIFF
--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -260,13 +260,14 @@ pub fn count_tokens(text: &str) -> usize {
 }
 
 /// Detect the package manager used in the current directory.
-/// Returns "pnpm", "yarn", or "npm" based on lockfile presence.
+/// Returns "pnpm", "yarn", "bun", or "npm" based on lockfile presence.
 ///
 /// # Examples
 /// ```no_run
 /// use rtk::utils::detect_package_manager;
 /// let pm = detect_package_manager();
-/// // Returns "pnpm" if pnpm-lock.yaml exists, "yarn" if yarn.lock, else "npm"
+/// // Returns "pnpm" if pnpm-lock.yaml exists, "yarn" if yarn.lock,
+/// // "bun" if bun.lockb exists, else "npm"
 /// ```
 #[allow(dead_code)]
 pub fn detect_package_manager() -> &'static str {
@@ -274,6 +275,10 @@ pub fn detect_package_manager() -> &'static str {
         "pnpm"
     } else if std::path::Path::new("yarn.lock").exists() {
         "yarn"
+    } else if std::path::Path::new("bun.lockb").exists()
+        || std::path::Path::new("bun.lock").exists()
+    {
+        "bun"
     } else {
         "npm"
     }
@@ -295,6 +300,11 @@ pub fn package_manager_exec(tool: &str) -> Command {
             "yarn" => {
                 let mut c = resolved_command("yarn");
                 c.arg("exec").arg("--").arg(tool);
+                c
+            }
+            "bun" => {
+                let mut c = resolved_command("bunx");
+                c.arg(tool);
                 c
             }
             _ => {
@@ -497,7 +507,7 @@ mod tests {
         // In the test environment (rtk repo), there's no JS lockfile
         // so it should default to "npm"
         let pm = detect_package_manager();
-        assert!(["pnpm", "yarn", "npm"].contains(&pm));
+        assert!(["pnpm", "yarn", "bun", "npm"].contains(&pm));
     }
 
     #[test]

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1040,6 +1040,14 @@ mod tests {
     }
 
     #[test]
+    fn test_rewrite_bunx_tsc() {
+        assert_eq!(
+            rewrite_command("bunx tsc --noEmit", &[]),
+            Some("rtk tsc --noEmit".into())
+        );
+    }
+
+    #[test]
     fn test_rewrite_cat_file() {
         assert_eq!(
             rewrite_command("cat src/main.rs", &[]),
@@ -1891,6 +1899,30 @@ mod tests {
     fn test_rewrite_pnpm_vitest() {
         assert_eq!(
             rewrite_command("pnpm vitest run", &[]),
+            Some("rtk vitest run".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_bun_test() {
+        assert_eq!(
+            rewrite_command("bun test", &[]),
+            Some("rtk vitest".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_bun_test_with_path() {
+        assert_eq!(
+            rewrite_command("bun test src/", &[]),
+            Some("rtk vitest src/".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_bunx_vitest() {
+        assert_eq!(
+            rewrite_command("bunx vitest run", &[]),
             Some("rtk vitest run".into())
         );
     }

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -107,9 +107,9 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        pattern: r"^(npx\s+|pnpm\s+)?tsc(\s|$)",
+        pattern: r"^(npx\s+|pnpm\s+|bunx\s+)?tsc(\s|$)",
         rtk_cmd: "rtk tsc",
-        rewrite_prefixes: &["pnpm tsc", "npx tsc", "tsc"],
+        rewrite_prefixes: &["pnpm tsc", "npx tsc", "bunx tsc", "tsc"],
         category: "Build",
         savings_pct: 83.0,
         subcmd_savings: &[],
@@ -150,9 +150,9 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        pattern: r"^(pnpm\s+|npx\s+)?(vitest|jest|test)(\s|$)",
+        pattern: r"^(pnpm\s+|npx\s+|bunx\s+)?(vitest|jest|test)(\s|$)|^bun\s+test(\s|$)",
         rtk_cmd: "rtk vitest",
-        rewrite_prefixes: &["pnpm vitest", "npx vitest", "vitest", "jest"],
+        rewrite_prefixes: &["pnpm vitest", "npx vitest", "bunx vitest", "vitest", "jest", "bun test"],
         category: "Tests",
         savings_pct: 99.0,
         subcmd_savings: &[],


### PR DESCRIPTION
Fixes #1316

Bun projects use `bun test`, `bunx tsc`, and `bunx vitest` in place of the npm/pnpm/npx equivalents. None of these were matched by the rewrite registry, so they passed through unfiltered.

Three changes:

**rules.rs** — extend two existing patterns:
- tsc: `^(npx|pnpm|bunx)?tsc` so `bunx tsc --noEmit` → `rtk tsc --noEmit`
- vitest: add `bunx` prefix variant and a dedicated `^bun test` alternative so `bun test src/` → `rtk vitest src/`

**utils.rs** — teach `detect_package_manager()` to recognise `bun.lockb` / `bun.lock` and return `"bun"`, then route `package_manager_exec()` to `bunx` when the lockfile says bun. This matches the pattern already in place for pnpm / yarn.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test` — 1228 passed, 0 failed (4 new tests)
- New tests: `test_rewrite_bunx_tsc`, `test_rewrite_bun_test`, `test_rewrite_bun_test_with_path`, `test_rewrite_bunx_vitest`