### PR TITLE
fix(cursor): handle rtk rewrite exit code 3 — rewrites were silently discarded

### DIFF
--- a/hooks/cursor/rtk-rewrite.sh
+++ b/hooks/cursor/rtk-rewrite.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# rtk-hook-version: 1
+# rtk-hook-version: 2
 # RTK Cursor Agent hook — rewrites shell commands to use rtk for token savings.
 # Works with both Cursor editor and cursor-cli (they share ~/.cursor/hooks.json).
 # Cursor preToolUse hook format: receives JSON on stdin, returns JSON on stdout.
@@ -8,6 +8,12 @@
 # This is a thin delegating hook: all rewrite logic lives in `rtk rewrite`,
 # which is the single source of truth (src/discover/registry.rs).
 # To add or change rewrite rules, edit the Rust registry — not this file.
+#
+# Exit code protocol for `rtk rewrite`:
+#   0 + stdout  Rewrite found, no deny/ask rule matched → auto-allow
+#   1           No RTK equivalent → pass through unchanged
+#   2           Deny rule matched → pass through
+#   3 + stdout  Ask rule matched → rewrite (Cursor has no ask model, so auto-allow)
 
 if ! command -v jq &>/dev/null; then
   echo "[rtk] WARNING: jq is not installed. Hook cannot rewrite commands. Install jq: https://jqlang.github.io/jq/download/" >&2
@@ -20,14 +26,21 @@ if ! command -v rtk &>/dev/null; then
 fi
 
 # Version guard: rtk rewrite was added in 0.23.0.
-RTK_VERSION=$(rtk --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-if [ -n "$RTK_VERSION" ]; then
-  MAJOR=$(echo "$RTK_VERSION" | cut -d. -f1)
-  MINOR=$(echo "$RTK_VERSION" | cut -d. -f2)
-  if [ "$MAJOR" -eq 0 ] && [ "$MINOR" -lt 23 ]; then
-    echo "[rtk] WARNING: rtk $RTK_VERSION is too old (need >= 0.23.0). Upgrade: cargo install rtk" >&2
-    exit 0
+# Cache the version check to avoid spawning `rtk --version` on every hook call.
+CACHE_DIR=${XDG_CACHE_HOME:-$HOME/.cache}
+CACHE_FILE="$CACHE_DIR/rtk-cursor-hook-version-ok"
+if [ ! -f "$CACHE_FILE" ]; then
+  RTK_VERSION=$(rtk --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+  if [ -n "$RTK_VERSION" ]; then
+    MAJOR=$(echo "$RTK_VERSION" | cut -d. -f1)
+    MINOR=$(echo "$RTK_VERSION" | cut -d. -f2)
+    if [ "$MAJOR" -eq 0 ] && [ "$MINOR" -lt 23 ]; then
+      echo "[rtk] WARNING: rtk $RTK_VERSION is too old (need >= 0.23.0). Upgrade: cargo install rtk" >&2
+      exit 0
+    fi
   fi
+  mkdir -p "$CACHE_DIR" 2>/dev/null
+  touch "$CACHE_FILE" 2>/dev/null
 fi
 
 INPUT=$(cat)
@@ -39,14 +52,23 @@ if [ -z "$CMD" ]; then
 fi
 
 # Delegate all rewrite logic to the Rust binary.
-# rtk rewrite exits 1 when there's no rewrite — hook passes through silently.
-REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null) || { echo '{}'; exit 0; }
+# Exit code contract: 0 = rewrite (allow), 1 = no match, 2 = deny, 3 = rewrite (ask).
+# Cursor has no ask/deny model, so both 0 and 3 produce an auto-allow rewrite.
+REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null)
+RC=$?
 
-# No change — nothing to do.
-if [ "$CMD" = "$REWRITTEN" ]; then
-  echo '{}'
-  exit 0
-fi
+case $RC in
+  0|3)
+    if [ "$CMD" = "$REWRITTEN" ]; then
+      echo '{}'
+      exit 0
+    fi
+    ;;
+  *)
+    echo '{}'
+    exit 0
+    ;;
+esac
 
 jq -n --arg cmd "$REWRITTEN" '{
   "permission": "allow",


### PR DESCRIPTION
## Summary

The Cursor hook (`hooks/cursor/rtk-rewrite.sh`) used a blanket `||` to catch `rtk rewrite` failures, which treated **all** non-zero exit codes as "no rewrite." Since `rtk rewrite` returns exit code **3** for ask-rule rewrites — the most common code path in practice — the hook silently discarded every rewrite and always output `{}`.

**Result:** RTK Cursor integration was completely non-functional. Zero commands were rewritten; `rtk gain` showed no tracking data.

## Changes

- **Replace `||` with `case` statement** matching the documented exit code contract:
  | Exit Code | Meaning | Hook Action |
  |-----------|---------|-------------|
  | 0 | Rewrite found (allow) | Apply rewrite |
  | 1 | No RTK equivalent | Pass through (`{}`) |
  | 2 | Deny rule matched | Pass through (`{}`) |
  | 3 | Ask rule matched | Apply rewrite (Cursor has no ask model) |

- **Bump hook version** from 1 → 2 so `rtk init` detects stale hooks and prompts users to upgrade
- **Add version-check caching** (like Claude hook v3) to avoid spawning `rtk --version` on every hook invocation
- **Document exit code protocol** in the script header for maintainability

## Root Cause

The v1 hook was written before exit code 3 was introduced in the `rtk rewrite` contract. When the Claude Code hook was upgraded to v3 with proper `case` handling, the Cursor hook was never updated.

```bash
# Before (broken) — || catches exit 3, discards rewrite
REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null) || { echo '{}'; exit 0; }

# After (fixed) — case statement respects exit code contract
REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null)
RC=$?
case $RC in
  0|3) ... apply rewrite ... ;;
  *)   echo '{}'; exit 0 ;;
esac
```

## Test plan

- [x] All 1446 existing tests pass (`cargo test --all`)
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets` clean (no new warnings)
- [ ] Manual verification: `echo '{"tool_name":"Shell","tool_input":{"command":"git status"}}' | bash hooks/cursor/rtk-rewrite.sh` returns rewrite JSON instead of `{}`
- [ ] Verify `rtk init -g --agent cursor` detects v1 hooks as outdated and upgrades to v2

## Impact

Affects **all Cursor users** running rtk >= 0.23.0 (when the exit code contract changed). After this fix, `rtk gain` will show token savings from Cursor sessions.

Made with [Cursor](https://cursor.com)