### PR TITLE
Fix/windows ls native

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,11 +251,6 @@ dependencies = [
 [[package]]
 name = "crc32fast"
 version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "crossbeam-deque"
@@ -333,6 +328,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "env_home"
@@ -900,6 +901,7 @@ dependencies = [
  "clap",
  "colored",
  "dirs",
+ "dunce",
  "flate2",
  "getrandom 0.4.2",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ libc = "0.2"
 toml = "0.8"
 
 [dev-dependencies]
+tempfile = "3"
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ flate2 = "1.0"
 quick-xml = "0.37"
 which = "8"
 automod = "1"
+dunce = "1.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -66,3 +67,5 @@ assets = [
 assets = [
     { source = "target/release/rtk", dest = "/usr/bin/rtk", mode = "755" },
 ]
+
+

--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -81,8 +81,8 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         "ls",
         &format!("-la {}", target_display),
         |raw| {
-            let (dirs, files) = compact_ls(raw, show_all);
-            let (entries, summary) = synthesize_output(dirs, files);
+            let result = compact_ls(raw, show_all);
+            let (entries, summary) = synthesize_output(result);
 
             // Only show summary in interactive mode (not when piped)
             let is_tty = std::io::stdout().is_terminal();

--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -1,7 +1,7 @@
 //! Filters directory listings into a compact tree format.
 
 use super::constants::NOISE_DIRS;
-pub use super::ls_format::{synthesize_output, LsRecord};
+pub use super::ls_format::{synthesize_output, LsRecord, LsRecordType};
 pub use super::ls_unix::parse_ls_line;
 use crate::core::runner::{self, RunOptions};
 use crate::core::utils::{resolved_command, tool_exists};
@@ -64,7 +64,21 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     #[cfg(windows)]
     {
         if !tool_exists("ls") {
-            return super::ls_win::run_native(paths, show_all,flags);
+            let timer = crate::core::tracking::TimedExecution::start();
+
+            let (exit_code, output) = super::ls_win::run_native(paths.clone(), show_all, flags.clone())?;
+            print!("{}", output);
+
+            let raw_estimate = estimate_raw_dir_output();
+
+            timer.track(
+                "dir /s",
+                "rtk ls (native win)",
+                &raw_estimate,
+                &output,
+            );
+
+            return Ok(exit_code);
         }
     }
 
@@ -120,8 +134,14 @@ pub fn get_extension(name: &str) -> String {
     }
 }
 
+#[cfg(windows)]
+fn estimate_raw_dir_output() -> String {
+    // Provide a dummy implementation to satisfy tracking
+    String::new()
+}
+
 /// Parse ls -la output into compact records.
-pub fn compact_ls(raw: &str, show_all: bool) -> (Vec<LsRecord>, Vec<LsRecord>) {
+pub fn compact_ls(raw: &str, show_all: bool) -> Vec<LsRecord> {
     let mut records = Vec::new();
 
     for line in raw.lines() {
@@ -129,7 +149,7 @@ pub fn compact_ls(raw: &str, show_all: bool) -> (Vec<LsRecord>, Vec<LsRecord>) {
             continue;
         }
 
-        let Some((file_type, size, name)) = parse_ls_line(line) else {
+        let Some((file_type_ch, size, name)) = parse_ls_line(line) else {
             continue;
         };
 
@@ -142,20 +162,22 @@ pub fn compact_ls(raw: &str, show_all: bool) -> (Vec<LsRecord>, Vec<LsRecord>) {
         if !show_all && NOISE_DIRS.iter().any(|noise| name == *noise) {
             continue;
         }
-
+        let file_type = match file_type_ch {
+            'd' => LsRecordType::DIRECTORY,
+            'l' => LsRecordType::SYMBOLINK,
+            'f' | '-' => LsRecordType::FILE,
+            _ => LsRecordType::UNKNOWN,
+        };
         records.push(LsRecord {
             extension: get_extension(&name),
-            is_dir: file_type == 'd',
+            file_type,
             size,
             name,
-            timestamp:None
+            timestamp: None,
         });
     }
 
-    let (dirs, files): (Vec<LsRecord>, Vec<LsRecord>) = records
-        .into_iter() 
-        .partition(|r| r.is_dir);
-    (dirs, files)
+    records
 }
 
 #[cfg(test)]

--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -64,7 +64,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     #[cfg(windows)]
     {
         if !tool_exists("ls") {
-            return super::ls_win::run_native(paths, show_all);
+            return super::ls_win::run_native(paths, show_all,flags);
         }
     }
 
@@ -81,8 +81,8 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         "ls",
         &format!("-la {}", target_display),
         |raw| {
-            let records = compact_ls(raw, show_all);
-            let (entries, summary) = synthesize_output(records);
+            let (dirs, files) = compact_ls(raw, show_all);
+            let (entries, summary) = synthesize_output(dirs, files);
 
             // Only show summary in interactive mode (not when piped)
             let is_tty = std::io::stdout().is_terminal();
@@ -121,7 +121,7 @@ pub fn get_extension(name: &str) -> String {
 }
 
 /// Parse ls -la output into compact records.
-pub fn compact_ls(raw: &str, show_all: bool) -> Vec<LsRecord> {
+pub fn compact_ls(raw: &str, show_all: bool) -> (Vec<LsRecord>, Vec<LsRecord>) {
     let mut records = Vec::new();
 
     for line in raw.lines() {
@@ -151,7 +151,10 @@ pub fn compact_ls(raw: &str, show_all: bool) -> Vec<LsRecord> {
         });
     }
 
-    records
+    let (dirs, files): (Vec<LsRecord>, Vec<LsRecord>) = records
+        .into_iter() 
+        .partition(|r| r.is_dir);
+    (dirs, files)
 }
 
 #[cfg(test)]

--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -148,6 +148,7 @@ pub fn compact_ls(raw: &str, show_all: bool) -> (Vec<LsRecord>, Vec<LsRecord>) {
             is_dir: file_type == 'd',
             size,
             name,
+            timestamp:None
         });
     }
 

--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::io::IsTerminal;
+use std::process::Command;
 
 lazy_static! {
     /// Matches the date+time portion in `ls -la` output, which serves as a
@@ -17,35 +18,30 @@ lazy_static! {
     )
     .unwrap();
 }
-
-pub fn run(args: &[String], verbose: u8) -> Result<i32> {
+pub fn parser(args: &[String]) -> (Vec<String>, Vec<String>, bool) {
     let show_all = args
         .iter()
         .any(|a| (a.starts_with('-') && !a.starts_with("--") && a.contains('a')) || a == "--all");
 
-    let flags: Vec<&str> = args
+    let flags: Vec<String> = args
         .iter()
         .filter(|a| a.starts_with('-'))
-        .map(|s| s.as_str())
+        .cloned()
         .collect();
-    let paths: Vec<&str> = args
+    let paths: Vec<String> = args
         .iter()
         .filter(|a| !a.starts_with('-'))
-        .map(|s| s.as_str())
+        .cloned()
         .collect();
+    (paths, flags, show_all)
+}
 
-    #[cfg(windows)]
-    {
-        if !tool_exists("ls") {
-            return super::ls_win::run_native(&paths, show_all);
-        }
-    }
-
+pub fn cmd_builder(paths: &[String], flags: &[String], _show_all: bool) -> Command {
     let mut cmd = resolved_command("ls");
     cmd.arg("-la");
-    for flag in &flags {
+    for flag in flags {
         if flag.starts_with("--") {
-            if *flag != "--all" {
+            if flag != "--all" {
                 cmd.arg(flag);
             }
         } else {
@@ -63,10 +59,25 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     if paths.is_empty() {
         cmd.arg(".");
     } else {
-        for p in &paths {
+        for p in paths {
             cmd.arg(p);
         }
     }
+
+    cmd
+}
+
+pub fn run(args: &[String], verbose: u8) -> Result<i32> {
+    let (paths, flags, show_all) = parser(args);
+
+    #[cfg(windows)]
+    {
+        if !tool_exists("ls") {
+            return super::ls_win::run_native(paths, show_all);
+        }
+    }
+
+    let cmd = cmd_builder(&paths, &flags, show_all);
 
     let target_display = if paths.is_empty() {
         ".".to_string()

--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -1,7 +1,7 @@
 //! Filters directory listings into a compact tree format.
 
 use super::constants::NOISE_DIRS;
-pub use super::ls_format::{human_size, synthesize_output, LsRecord};
+pub use super::ls_format::{synthesize_output, LsRecord};
 pub use super::ls_unix::parse_ls_line;
 use crate::core::runner::{self, RunOptions};
 use crate::core::utils::{resolved_command, tool_exists};
@@ -157,6 +157,7 @@ pub fn compact_ls(raw: &str, show_all: bool) -> Vec<LsRecord> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cmds::system::ls_format::human_size;
 
     #[test]
     fn test_compact_basic() {
@@ -336,18 +337,13 @@ mod tests {
             entries.contains("archive.tar"),
             "should contain filename, got: {entries}"
         );
-        assert!(
-            entries.contains("5.5K"),
-            "should show 5.5K, got: {entries}"
-        );
+        assert!(entries.contains("5.5K"), "should show 5.5K, got: {entries}");
     }
 
     #[test]
     fn test_parse_ls_line_basic() {
-        let (ft, size, name) = parse_ls_line(
-            "-rw-r--r--  1 user staff 1234 Jan  1 12:00 file.txt",
-        )
-        .unwrap();
+        let (ft, size, name) =
+            parse_ls_line("-rw-r--r--  1 user staff 1234 Jan  1 12:00 file.txt").unwrap();
         assert_eq!(ft, '-');
         assert_eq!(size, 1234);
         assert_eq!(name, "file.txt");
@@ -355,10 +351,9 @@ mod tests {
 
     #[test]
     fn test_parse_ls_line_multiline_group() {
-        let (ft, size, name) = parse_ls_line(
-            "-rw-r--r--  1 fjeanne utilisa. du domaine 0 Mar 31 16:18 empty.txt",
-        )
-        .unwrap();
+        let (ft, size, name) =
+            parse_ls_line("-rw-r--r--  1 fjeanne utilisa. du domaine 0 Mar 31 16:18 empty.txt")
+                .unwrap();
         assert_eq!(ft, '-');
         assert_eq!(size, 0);
         assert_eq!(name, "empty.txt");
@@ -366,10 +361,9 @@ mod tests {
 
     #[test]
     fn test_parse_ls_line_dir_with_space_in_group() {
-        let (ft, size, name) = parse_ls_line(
-            "drwxr-xr-x  2 fjeanne utilisa. du domaine 64 Mar 31 16:18 my dir",
-        )
-        .unwrap();
+        let (ft, size, name) =
+            parse_ls_line("drwxr-xr-x  2 fjeanne utilisa. du domaine 64 Mar 31 16:18 my dir")
+                .unwrap();
         assert_eq!(ft, 'd');
         assert_eq!(size, 64);
         assert_eq!(name, "my dir");
@@ -377,10 +371,8 @@ mod tests {
 
     #[test]
     fn test_parse_ls_line_symlink() {
-        let (ft, size, name) = parse_ls_line(
-            "lrwxr-xr-x  1 user staff 10 Jan  1 12:00 link -> target",
-        )
-        .unwrap();
+        let (ft, size, name) =
+            parse_ls_line("lrwxr-xr-x  1 user staff 10 Jan  1 12:00 link -> target").unwrap();
         assert_eq!(ft, 'l');
         assert_eq!(size, 10);
         assert_eq!(name, "link -> target");
@@ -393,10 +385,8 @@ mod tests {
 
     #[test]
     fn test_parse_ls_line_year_format() {
-        let (ft, size, name) = parse_ls_line(
-            "-rw-r--r--  1 user staff 5678 Dec 25  2024 old.tar.gz",
-        )
-        .unwrap();
+        let (ft, size, name) =
+            parse_ls_line("-rw-r--r--  1 user staff 5678 Dec 25  2024 old.tar.gz").unwrap();
         assert_eq!(ft, '-');
         assert_eq!(size, 5678);
         assert_eq!(name, "old.tar.gz");

--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -8,11 +8,6 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use std::io::IsTerminal;
 
-#[cfg(windows)]
-use std::collections::HashMap;
-#[cfg(windows)]
-use std::path::Path;
-
 lazy_static! {
     /// Matches the date+time portion in `ls -la` output, which serves as a
     /// stable anchor regardless of owner/group column width.
@@ -42,7 +37,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     #[cfg(windows)]
     {
         if !tool_exists("ls") {
-            return run_native_windows(&paths, show_all, verbose);
+            return super::ls_win::run_native(&paths, show_all);
         }
     }
 
@@ -480,136 +475,4 @@ mod tests {
         assert_eq!(size, 5678);
         assert_eq!(name, "old.tar.gz");
     }
-}
-
-/// Native Windows fallback when `ls` is missing.
-/// Bypasses Unix-style parsing and uses `std::fs` directly.
-#[cfg(windows)]
-fn run_native_windows(paths: &[&str], show_all: bool, _verbose: u8) -> Result<i32> {
-    let timer = crate::core::tracking::TimedExecution::start();
-    let mut dirs = Vec::new();
-    let mut files = Vec::new();
-    let mut by_ext = HashMap::new();
-
-    let targets = if paths.is_empty() {
-        vec!["."]
-    } else {
-        paths.to_vec()
-    };
-
-    for path_str in &targets {
-        let path = Path::new(path_str);
-        if !path.exists() {
-            eprintln!("rtk: {}: No such file or directory", path_str);
-            continue;
-        }
-
-        if path.is_dir() {
-            match std::fs::read_dir(path) {
-                Ok(entries) => {
-                    for entry in entries.flatten() {
-                        let name = entry.file_name().to_string_lossy().to_string();
-
-                        // Skip . and ..
-                        if name == "." || name == ".." {
-                            continue;
-                        }
-
-                        // Filter noise dirs unless -a
-                        if !show_all && NOISE_DIRS.iter().any(|noise| name == *noise) {
-                            continue;
-                        }
-
-                        // Also filter hidden files (starting with .) on Windows if not show_all
-                        if !show_all && name.starts_with('.') {
-                            continue;
-                        }
-
-                        if let Ok(metadata) = entry.metadata() {
-                            if metadata.is_dir() {
-                                dirs.push(name);
-                            } else {
-                                let ext = if let Some(pos) = name.rfind('.') {
-                                    name[pos..].to_string()
-                                } else {
-                                    "no ext".to_string()
-                                };
-                                *by_ext.entry(ext).or_insert(0) += 1;
-                                files.push((name, human_size(metadata.len())));
-                            }
-                        }
-                    }
-                }
-                Err(e) => {
-                    eprintln!("rtk: {}: {}", path_str, e);
-                }
-            }
-        } else {
-            // Single file target
-            if let Ok(metadata) = path.metadata() {
-                let name = path
-                    .file_name()
-                    .unwrap_or_default()
-                    .to_string_lossy()
-                    .to_string();
-                files.push((name, human_size(metadata.len())));
-            }
-        }
-    }
-
-    // Sort for stable output
-    dirs.sort();
-    files.sort_by(|a, b| a.0.cmp(&b.0));
-
-    let mut entries = String::new();
-    for d in &dirs {
-        entries.push_str(d);
-        entries.push_str("/\n");
-    }
-    for (name, size) in &files {
-        entries.push_str(name);
-        entries.push_str("  ");
-        entries.push_str(size);
-        entries.push('\n');
-    }
-
-    if dirs.is_empty() && files.is_empty() {
-        entries = "(empty)\n".to_string();
-    }
-
-    // Only show summary in interactive mode
-    let is_tty = std::io::stdout().is_terminal();
-    let filtered = if is_tty {
-        let mut summary = format!("\nSummary: {} files, {} dirs", files.len(), dirs.len());
-        if !by_ext.is_empty() {
-            let mut ext_counts: Vec<_> = by_ext.iter().collect();
-            ext_counts.sort_by(|a, b| b.1.cmp(a.1));
-            let ext_parts: Vec<String> = ext_counts
-                .iter()
-                .take(5)
-                .map(|(ext, count)| format!("{} {}", count, ext))
-                .collect();
-            summary.push_str(" (");
-            summary.push_str(&ext_parts.join(", "));
-            if ext_counts.len() > 5 {
-                summary.push_str(&format!(", +{} more", ext_counts.len() - 5));
-            }
-            summary.push(')');
-        }
-        summary.push('\n');
-        format!("{}{}", entries, summary)
-    } else {
-        entries
-    };
-
-    print!("{}", filtered);
-
-    timer.track(
-        &format!("ls (native) {}", targets.join(" ")),
-        &format!("rtk ls {}", targets.join(" ")),
-        "", // No raw output for native
-        &filtered,
-    );
-
-    Ok(0)
 }

--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -2,11 +2,16 @@
 
 use super::constants::NOISE_DIRS;
 use crate::core::runner::{self, RunOptions};
-use crate::core::utils::resolved_command;
+use crate::core::utils::{resolved_command, tool_exists};
 use anyhow::Result;
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::io::IsTerminal;
+
+#[cfg(windows)]
+use std::collections::HashMap;
+#[cfg(windows)]
+use std::path::Path;
 
 lazy_static! {
     /// Matches the date+time portion in `ls -la` output, which serves as a
@@ -33,6 +38,13 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         .filter(|a| !a.starts_with('-'))
         .map(|s| s.as_str())
         .collect();
+
+    #[cfg(windows)]
+    {
+        if !tool_exists("ls") {
+            return run_native_windows(&paths, show_all, verbose);
+        }
+    }
 
     let mut cmd = resolved_command("ls");
     cmd.arg("-la");
@@ -468,4 +480,136 @@ mod tests {
         assert_eq!(size, 5678);
         assert_eq!(name, "old.tar.gz");
     }
+}
+
+/// Native Windows fallback when `ls` is missing.
+/// Bypasses Unix-style parsing and uses `std::fs` directly.
+#[cfg(windows)]
+fn run_native_windows(paths: &[&str], show_all: bool, _verbose: u8) -> Result<i32> {
+    let timer = crate::core::tracking::TimedExecution::start();
+    let mut dirs = Vec::new();
+    let mut files = Vec::new();
+    let mut by_ext = HashMap::new();
+
+    let targets = if paths.is_empty() {
+        vec!["."]
+    } else {
+        paths.to_vec()
+    };
+
+    for path_str in &targets {
+        let path = Path::new(path_str);
+        if !path.exists() {
+            eprintln!("rtk: {}: No such file or directory", path_str);
+            continue;
+        }
+
+        if path.is_dir() {
+            match std::fs::read_dir(path) {
+                Ok(entries) => {
+                    for entry in entries.flatten() {
+                        let name = entry.file_name().to_string_lossy().to_string();
+
+                        // Skip . and ..
+                        if name == "." || name == ".." {
+                            continue;
+                        }
+
+                        // Filter noise dirs unless -a
+                        if !show_all && NOISE_DIRS.iter().any(|noise| name == *noise) {
+                            continue;
+                        }
+
+                        // Also filter hidden files (starting with .) on Windows if not show_all
+                        if !show_all && name.starts_with('.') {
+                            continue;
+                        }
+
+                        if let Ok(metadata) = entry.metadata() {
+                            if metadata.is_dir() {
+                                dirs.push(name);
+                            } else {
+                                let ext = if let Some(pos) = name.rfind('.') {
+                                    name[pos..].to_string()
+                                } else {
+                                    "no ext".to_string()
+                                };
+                                *by_ext.entry(ext).or_insert(0) += 1;
+                                files.push((name, human_size(metadata.len())));
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!("rtk: {}: {}", path_str, e);
+                }
+            }
+        } else {
+            // Single file target
+            if let Ok(metadata) = path.metadata() {
+                let name = path
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string();
+                files.push((name, human_size(metadata.len())));
+            }
+        }
+    }
+
+    // Sort for stable output
+    dirs.sort();
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut entries = String::new();
+    for d in &dirs {
+        entries.push_str(d);
+        entries.push_str("/\n");
+    }
+    for (name, size) in &files {
+        entries.push_str(name);
+        entries.push_str("  ");
+        entries.push_str(size);
+        entries.push('\n');
+    }
+
+    if dirs.is_empty() && files.is_empty() {
+        entries = "(empty)\n".to_string();
+    }
+
+    // Only show summary in interactive mode
+    let is_tty = std::io::stdout().is_terminal();
+    let filtered = if is_tty {
+        let mut summary = format!("\nSummary: {} files, {} dirs", files.len(), dirs.len());
+        if !by_ext.is_empty() {
+            let mut ext_counts: Vec<_> = by_ext.iter().collect();
+            ext_counts.sort_by(|a, b| b.1.cmp(a.1));
+            let ext_parts: Vec<String> = ext_counts
+                .iter()
+                .take(5)
+                .map(|(ext, count)| format!("{} {}", count, ext))
+                .collect();
+            summary.push_str(" (");
+            summary.push_str(&ext_parts.join(", "));
+            if ext_counts.len() > 5 {
+                summary.push_str(&format!(", +{} more", ext_counts.len() - 5));
+            }
+            summary.push(')');
+        }
+        summary.push('\n');
+        format!("{}{}", entries, summary)
+    } else {
+        entries
+    };
+
+    print!("{}", filtered);
+
+    timer.track(
+        &format!("ls (native) {}", targets.join(" ")),
+        &format!("rtk ls {}", targets.join(" ")),
+        "", // No raw output for native
+        &filtered,
+    );
+
+    Ok(0)
 }

--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -1,13 +1,30 @@
 //! Filters directory listings into a compact tree format.
 
-use super::constants::NOISE_DIRS;
-pub use super::ls_format::{synthesize_output, LsRecord, LsRecordType};
-pub use super::ls_unix::parse_ls_line;
+use super::ls_format::synthesize_output;
+use super::ls_unix::compact_ls;
 use crate::core::runner::{self, RunOptions};
 use crate::core::utils::{resolved_command, tool_exists};
 use anyhow::Result;
 use std::io::IsTerminal;
 use std::process::Command;
+
+/// Represents a single directory entry for token-optimized listing.
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+pub enum LsRecordType {
+    FILE,
+    DIRECTORY,
+    SYMBOLINK,
+    UNKNOWN,
+}
+
+pub struct LsRecord {
+    pub name: String,
+    pub file_type: LsRecordType,
+    pub size: u64,
+    pub extension: String,
+    pub timestamp: Option<u64>,
+}
+
 
 pub fn parser(args: &[String]) -> (Vec<String>, Vec<String>, bool) {
     let show_all = args
@@ -66,13 +83,11 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         if !tool_exists("ls") {
             let timer = crate::core::tracking::TimedExecution::start();
 
-            let (exit_code, output) = super::ls_win::run_native(paths.clone(), show_all, flags.clone())?;
+            let (exit_code, output, raw_estimate) = super::ls_win::run_native(paths.clone(), show_all, flags.clone())?;
             print!("{}", output);
 
-            let raw_estimate = estimate_raw_dir_output();
-
             timer.track(
-                "dir /s",
+                "ls -la",
                 "rtk ls (native win)",
                 &raw_estimate,
                 &output,
@@ -134,287 +149,3 @@ pub fn get_extension(name: &str) -> String {
     }
 }
 
-#[cfg(windows)]
-fn estimate_raw_dir_output() -> String {
-    // Provide a dummy implementation to satisfy tracking
-    String::new()
-}
-
-/// Parse ls -la output into compact records.
-pub fn compact_ls(raw: &str, show_all: bool) -> Vec<LsRecord> {
-    let mut records = Vec::new();
-
-    for line in raw.lines() {
-        if line.starts_with("total ") || line.is_empty() {
-            continue;
-        }
-
-        let Some((file_type_ch, size, name)) = parse_ls_line(line) else {
-            continue;
-        };
-
-        // Skip . and ..
-        if name == "." || name == ".." {
-            continue;
-        }
-
-        // Filter noise dirs unless -a
-        if !show_all && NOISE_DIRS.iter().any(|noise| name == *noise) {
-            continue;
-        }
-        let file_type = match file_type_ch {
-            'd' => LsRecordType::DIRECTORY,
-            'l' => LsRecordType::SYMBOLINK,
-            'f' | '-' => LsRecordType::FILE,
-            _ => LsRecordType::UNKNOWN,
-        };
-        records.push(LsRecord {
-            extension: get_extension(&name),
-            file_type,
-            size,
-            name,
-            timestamp: None,
-        });
-    }
-
-    records
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::cmds::system::ls_format::human_size;
-
-    #[test]
-    fn test_compact_basic() {
-        let input = "total 48\n\
-                     drwxr-xr-x  2 user  staff    64 Jan  1 12:00 .\n\
-                     drwxr-xr-x  2 user  staff    64 Jan  1 12:00 ..\n\
-                     drwxr-xr-x  2 user  staff    64 Jan  1 12:00 src\n\
-                     -rw-r--r--  1 user  staff  1234 Jan  1 12:00 Cargo.toml\n\
-                     -rw-r--r--  1 user  staff  5678 Jan  1 12:00 README.md\n";
-        let records = compact_ls(input, false);
-        let (entries, _summary) = synthesize_output(records);
-        assert!(entries.contains("src/"));
-        assert!(entries.contains("Cargo.toml"));
-        assert!(entries.contains("README.md"));
-        assert!(entries.contains("1.2K")); // 1234 bytes
-        assert!(entries.contains("5.5K")); // 5678 bytes
-        assert!(!entries.contains("drwx")); // no permissions
-        assert!(!entries.contains("staff")); // no group
-        assert!(!entries.contains("total")); // no total
-        assert!(!entries.contains("\n.\n")); // no . entry
-        assert!(!entries.contains("\n..\n")); // no .. entry
-    }
-
-    #[test]
-    fn test_compact_filters_noise() {
-        let input = "total 8\n\
-                     drwxr-xr-x  2 user  staff  64 Jan  1 12:00 node_modules\n\
-                     drwxr-xr-x  2 user  staff  64 Jan  1 12:00 .git\n\
-                     drwxr-xr-x  2 user  staff  64 Jan  1 12:00 target\n\
-                     drwxr-xr-x  2 user  staff  64 Jan  1 12:00 src\n\
-                     -rw-r--r--  1 user  staff  100 Jan  1 12:00 main.rs\n";
-        let records = compact_ls(input, false);
-        let (entries, _summary) = synthesize_output(records);
-        assert!(!entries.contains("node_modules"));
-        assert!(!entries.contains(".git"));
-        assert!(!entries.contains("target"));
-        assert!(entries.contains("src/"));
-        assert!(entries.contains("main.rs"));
-    }
-
-    #[test]
-    fn test_compact_show_all() {
-        let input = "total 8\n\
-                     drwxr-xr-x  2 user  staff  64 Jan  1 12:00 .git\n\
-                     drwxr-xr-x  2 user  staff  64 Jan  1 12:00 src\n";
-        let records = compact_ls(input, true);
-        let (entries, _summary) = synthesize_output(records);
-        assert!(entries.contains(".git/"));
-        assert!(entries.contains("src/"));
-    }
-
-    #[test]
-    fn test_compact_empty() {
-        let input = "total 0\n";
-        let records = compact_ls(input, false);
-        let (entries, summary) = synthesize_output(records);
-        assert_eq!(entries, "(empty)\n");
-        assert!(summary.is_empty());
-    }
-
-    #[test]
-    fn test_compact_summary() {
-        let input = "total 48\n\
-                     drwxr-xr-x  2 user  staff    64 Jan  1 12:00 src\n\
-                     -rw-r--r--  1 user  staff  1234 Jan  1 12:00 main.rs\n\
-                     -rw-r--r--  1 user  staff  5678 Jan  1 12:00 lib.rs\n\
-                     -rw-r--r--  1 user  staff   100 Jan  1 12:00 Cargo.toml\n";
-        let records = compact_ls(input, false);
-        let (_entries, summary) = synthesize_output(records);
-        assert!(summary.contains("Summary: 3 files, 1 dirs"));
-        assert!(summary.contains(".rs"));
-        assert!(summary.contains(".toml"));
-    }
-
-    #[test]
-    fn test_human_size() {
-        assert_eq!(human_size(0), "0B");
-        assert_eq!(human_size(500), "500B");
-        assert_eq!(human_size(1024), "1.0K");
-        assert_eq!(human_size(1234), "1.2K");
-        assert_eq!(human_size(1_048_576), "1.0M");
-        assert_eq!(human_size(2_500_000), "2.4M");
-    }
-
-    #[test]
-    fn test_compact_handles_filenames_with_spaces() {
-        let input = "total 8\n\
-                     -rw-r--r--  1 user  staff  1234 Jan  1 12:00 my file.txt\n";
-        let records = compact_ls(input, false);
-        let (entries, _summary) = synthesize_output(records);
-        assert!(entries.contains("my file.txt"));
-    }
-
-    #[test]
-    fn test_compact_symlinks() {
-        let input = "total 8\n\
-                     lrwxr-xr-x  1 user  staff  10 Jan  1 12:00 link -> target\n";
-        let records = compact_ls(input, false);
-        let (entries, _summary) = synthesize_output(records);
-        assert!(entries.contains("link -> target"));
-    }
-
-    #[test]
-    fn test_entries_no_summary() {
-        // Entries should never contain the summary line
-        let input = "total 48\n\
-                     drwxr-xr-x  2 user  staff    64 Jan  1 12:00 src\n\
-                     -rw-r--r--  1 user  staff  1234 Jan  1 12:00 main.rs\n";
-        let records = compact_ls(input, false);
-        let (entries, summary) = synthesize_output(records);
-        assert!(
-            !entries.contains("Summary:"),
-            "entries must not contain summary"
-        );
-        assert!(
-            summary.contains("Summary:"),
-            "summary must contain the icon"
-        );
-    }
-
-    #[test]
-    fn test_pipe_line_count() {
-        // Simulates: rtk ls | wc -l
-        // Entries should have exactly 1 line per file/dir, no extra blank or summary
-        let input = "total 48\n\
-                     drwxr-xr-x  2 user  staff    64 Jan  1 12:00 src\n\
-                     -rw-r--r--  1 user  staff  1234 Jan  1 12:00 main.rs\n\
-                     -rw-r--r--  1 user  staff  5678 Jan  1 12:00 lib.rs\n";
-        let records = compact_ls(input, false);
-        let (entries, _summary) = synthesize_output(records);
-        let line_count = entries.lines().count();
-        assert_eq!(
-            line_count, 3,
-            "pipe should see exactly 3 lines (1 dir + 2 files), got {}",
-            line_count
-        );
-    }
-
-    // Regression test for #948: owner/group with spaces breaks fixed-column parsing
-    #[test]
-    fn test_compact_multiline_group() {
-        let input = "total 8\n\
-                     -rw-r--r--  1 fjeanne utilisa. du domaine    0 Mar 31 16:18 empty.txt\n\
-                     -rw-r--r--  1 fjeanne utilisa. du domaine 1234 Mar 31 16:18 data.json\n";
-        let records = compact_ls(input, false);
-        let (entries, _summary) = synthesize_output(records);
-        assert!(
-            entries.contains("empty.txt"),
-            "should contain 'empty.txt', got: {entries}"
-        );
-        assert!(
-            entries.contains("data.json"),
-            "should contain 'data.json', got: {entries}"
-        );
-        assert!(
-            !entries.contains("16:18"),
-            "time should not leak into filename, got: {entries}"
-        );
-        assert!(
-            entries.contains("0B"),
-            "empty.txt should show 0B, got: {entries}"
-        );
-        assert!(
-            entries.contains("1.2K"),
-            "data.json should show 1.2K (1234 bytes), got: {entries}"
-        );
-    }
-
-    #[test]
-    fn test_compact_year_format_date() {
-        // Some systems show year instead of time for old files
-        let input = "total 8\n\
-                     -rw-r--r--  1 user staff  5678 Dec 25  2024 archive.tar\n";
-        let records = compact_ls(input, false);
-        let (entries, _summary) = synthesize_output(records);
-        assert!(
-            entries.contains("archive.tar"),
-            "should contain filename, got: {entries}"
-        );
-        assert!(entries.contains("5.5K"), "should show 5.5K, got: {entries}");
-    }
-
-    #[test]
-    fn test_parse_ls_line_basic() {
-        let (ft, size, name) =
-            parse_ls_line("-rw-r--r--  1 user staff 1234 Jan  1 12:00 file.txt").unwrap();
-        assert_eq!(ft, '-');
-        assert_eq!(size, 1234);
-        assert_eq!(name, "file.txt");
-    }
-
-    #[test]
-    fn test_parse_ls_line_multiline_group() {
-        let (ft, size, name) =
-            parse_ls_line("-rw-r--r--  1 fjeanne utilisa. du domaine 0 Mar 31 16:18 empty.txt")
-                .unwrap();
-        assert_eq!(ft, '-');
-        assert_eq!(size, 0);
-        assert_eq!(name, "empty.txt");
-    }
-
-    #[test]
-    fn test_parse_ls_line_dir_with_space_in_group() {
-        let (ft, size, name) =
-            parse_ls_line("drwxr-xr-x  2 fjeanne utilisa. du domaine 64 Mar 31 16:18 my dir")
-                .unwrap();
-        assert_eq!(ft, 'd');
-        assert_eq!(size, 64);
-        assert_eq!(name, "my dir");
-    }
-
-    #[test]
-    fn test_parse_ls_line_symlink() {
-        let (ft, size, name) =
-            parse_ls_line("lrwxr-xr-x  1 user staff 10 Jan  1 12:00 link -> target").unwrap();
-        assert_eq!(ft, 'l');
-        assert_eq!(size, 10);
-        assert_eq!(name, "link -> target");
-    }
-
-    #[test]
-    fn test_parse_ls_line_returns_none_for_total() {
-        assert!(parse_ls_line("total 48").is_none());
-    }
-
-    #[test]
-    fn test_parse_ls_line_year_format() {
-        let (ft, size, name) =
-            parse_ls_line("-rw-r--r--  1 user staff 5678 Dec 25  2024 old.tar.gz").unwrap();
-        assert_eq!(ft, '-');
-        assert_eq!(size, 5678);
-        assert_eq!(name, "old.tar.gz");
-    }
-}

--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -1,23 +1,14 @@
 //! Filters directory listings into a compact tree format.
 
 use super::constants::NOISE_DIRS;
+pub use super::ls_format::{human_size, synthesize_output, LsRecord};
+pub use super::ls_unix::parse_ls_line;
 use crate::core::runner::{self, RunOptions};
 use crate::core::utils::{resolved_command, tool_exists};
 use anyhow::Result;
-use lazy_static::lazy_static;
-use regex::Regex;
 use std::io::IsTerminal;
 use std::process::Command;
 
-lazy_static! {
-    /// Matches the date+time portion in `ls -la` output, which serves as a
-    /// stable anchor regardless of owner/group column width.
-    /// E.g.: " Mar 31 16:18 " or " Dec 25  2024 "
-    static ref LS_DATE_RE: Regex = Regex::new(
-        r"\s+(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}\s+(?:\d{4}|\d{2}:\d{2})\s+"
-    )
-    .unwrap();
-}
 pub fn parser(args: &[String]) -> (Vec<String>, Vec<String>, bool) {
     let show_all = args
         .iter()
@@ -90,7 +81,8 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         "ls",
         &format!("-la {}", target_display),
         |raw| {
-            let (entries, summary) = compact_ls(raw, show_all);
+            let records = compact_ls(raw, show_all);
+            let (entries, summary) = synthesize_output(records);
 
             // Only show summary in interactive mode (not when piped)
             let is_tty = std::io::stdout().is_terminal();
@@ -120,61 +112,17 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     )
 }
 
-/// Format bytes into human-readable size
-fn human_size(bytes: u64) -> String {
-    if bytes >= 1_048_576 {
-        format!("{:.1}M", bytes as f64 / 1_048_576.0)
-    } else if bytes >= 1024 {
-        format!("{:.1}K", bytes as f64 / 1024.0)
+pub fn get_extension(name: &str) -> String {
+    if let Some(pos) = name.rfind('.') {
+        name[pos..].to_string()
     } else {
-        format!("{}B", bytes)
+        "no ext".to_string()
     }
 }
 
-/// Parse a single `ls -la` line, returning `(file_type_char, size, name)`.
-///
-/// Uses the date field as a stable anchor — the date format in `ls -la` is
-/// always three tokens (`Mon DD HH:MM` or `Mon DD  YYYY`), so we locate it
-/// with a regex, then extract size (rightmost number before the date) and
-/// filename (everything after the date). This handles owner/group names that
-/// contain spaces, which break the old fixed-column approach.
-fn parse_ls_line(line: &str) -> Option<(char, u64, String)> {
-    let date_match = LS_DATE_RE.find(line)?;
-    let name = line[date_match.end()..].to_string();
-
-    let before_date = &line[..date_match.start()];
-    let before_parts: Vec<&str> = before_date.split_whitespace().collect();
-    if before_parts.len() < 4 {
-        return None;
-    }
-
-    let perms = before_parts[0];
-    let file_type = perms.chars().next()?;
-
-    // Size is the rightmost parseable number before the date.
-    // nlinks is also numeric but appears earlier; scanning from the end
-    // guarantees we hit the size field first.
-    let mut size: u64 = 0;
-    for part in before_parts.iter().rev() {
-        if let Ok(s) = part.parse::<u64>() {
-            size = s;
-            break;
-        }
-    }
-
-    Some((file_type, size, name))
-}
-
-/// Parse ls -la output into compact format:
-///   name/  (dirs)
-///   name  size  (files)
-/// Returns (entries, summary) so caller can suppress summary when piped.
-fn compact_ls(raw: &str, show_all: bool) -> (String, String) {
-    use std::collections::HashMap;
-
-    let mut dirs: Vec<String> = Vec::new();
-    let mut files: Vec<(String, String)> = Vec::new(); // (name, size)
-    let mut by_ext: HashMap<String, usize> = HashMap::new();
+/// Parse ls -la output into compact records.
+pub fn compact_ls(raw: &str, show_all: bool) -> Vec<LsRecord> {
+    let mut records = Vec::new();
 
     for line in raw.lines() {
         if line.starts_with("total ") || line.is_empty() {
@@ -195,59 +143,15 @@ fn compact_ls(raw: &str, show_all: bool) -> (String, String) {
             continue;
         }
 
-        if file_type == 'd' {
-            dirs.push(name);
-        } else if file_type == '-' || file_type == 'l' {
-            let ext = if let Some(pos) = name.rfind('.') {
-                name[pos..].to_string()
-            } else {
-                "no ext".to_string()
-            };
-            *by_ext.entry(ext).or_insert(0) += 1;
-            files.push((name, human_size(size)));
-        }
+        records.push(LsRecord {
+            extension: get_extension(&name),
+            is_dir: file_type == 'd',
+            size,
+            name,
+        });
     }
 
-    if dirs.is_empty() && files.is_empty() {
-        return ("(empty)\n".to_string(), String::new());
-    }
-
-    let mut entries = String::new();
-
-    // Dirs first, compact
-    for d in &dirs {
-        entries.push_str(d);
-        entries.push_str("/\n");
-    }
-
-    // Files with size
-    for (name, size) in &files {
-        entries.push_str(name);
-        entries.push_str("  ");
-        entries.push_str(size);
-        entries.push('\n');
-    }
-
-    // Summary line (separate so caller can suppress when piped)
-    let mut summary = format!("\nSummary: {} files, {} dirs", files.len(), dirs.len());
-    if !by_ext.is_empty() {
-        let mut ext_counts: Vec<_> = by_ext.iter().collect();
-        ext_counts.sort_by(|a, b| b.1.cmp(a.1));
-        let ext_parts: Vec<String> = ext_counts
-            .iter()
-            .take(5)
-            .map(|(ext, count)| format!("{} {}", count, ext))
-            .collect();
-        summary.push_str(" (");
-        summary.push_str(&ext_parts.join(", "));
-        if ext_counts.len() > 5 {
-            summary.push_str(&format!(", +{} more", ext_counts.len() - 5));
-        }
-        summary.push(')');
-    }
-    summary.push('\n');
-
-    (entries, summary)
+    records
 }
 
 #[cfg(test)]
@@ -262,7 +166,8 @@ mod tests {
                      drwxr-xr-x  2 user  staff    64 Jan  1 12:00 src\n\
                      -rw-r--r--  1 user  staff  1234 Jan  1 12:00 Cargo.toml\n\
                      -rw-r--r--  1 user  staff  5678 Jan  1 12:00 README.md\n";
-        let (entries, _summary) = compact_ls(input, false);
+        let records = compact_ls(input, false);
+        let (entries, _summary) = synthesize_output(records);
         assert!(entries.contains("src/"));
         assert!(entries.contains("Cargo.toml"));
         assert!(entries.contains("README.md"));
@@ -283,7 +188,8 @@ mod tests {
                      drwxr-xr-x  2 user  staff  64 Jan  1 12:00 target\n\
                      drwxr-xr-x  2 user  staff  64 Jan  1 12:00 src\n\
                      -rw-r--r--  1 user  staff  100 Jan  1 12:00 main.rs\n";
-        let (entries, _summary) = compact_ls(input, false);
+        let records = compact_ls(input, false);
+        let (entries, _summary) = synthesize_output(records);
         assert!(!entries.contains("node_modules"));
         assert!(!entries.contains(".git"));
         assert!(!entries.contains("target"));
@@ -296,7 +202,8 @@ mod tests {
         let input = "total 8\n\
                      drwxr-xr-x  2 user  staff  64 Jan  1 12:00 .git\n\
                      drwxr-xr-x  2 user  staff  64 Jan  1 12:00 src\n";
-        let (entries, _summary) = compact_ls(input, true);
+        let records = compact_ls(input, true);
+        let (entries, _summary) = synthesize_output(records);
         assert!(entries.contains(".git/"));
         assert!(entries.contains("src/"));
     }
@@ -304,7 +211,8 @@ mod tests {
     #[test]
     fn test_compact_empty() {
         let input = "total 0\n";
-        let (entries, summary) = compact_ls(input, false);
+        let records = compact_ls(input, false);
+        let (entries, summary) = synthesize_output(records);
         assert_eq!(entries, "(empty)\n");
         assert!(summary.is_empty());
     }
@@ -316,7 +224,8 @@ mod tests {
                      -rw-r--r--  1 user  staff  1234 Jan  1 12:00 main.rs\n\
                      -rw-r--r--  1 user  staff  5678 Jan  1 12:00 lib.rs\n\
                      -rw-r--r--  1 user  staff   100 Jan  1 12:00 Cargo.toml\n";
-        let (_entries, summary) = compact_ls(input, false);
+        let records = compact_ls(input, false);
+        let (_entries, summary) = synthesize_output(records);
         assert!(summary.contains("Summary: 3 files, 1 dirs"));
         assert!(summary.contains(".rs"));
         assert!(summary.contains(".toml"));
@@ -336,7 +245,8 @@ mod tests {
     fn test_compact_handles_filenames_with_spaces() {
         let input = "total 8\n\
                      -rw-r--r--  1 user  staff  1234 Jan  1 12:00 my file.txt\n";
-        let (entries, _summary) = compact_ls(input, false);
+        let records = compact_ls(input, false);
+        let (entries, _summary) = synthesize_output(records);
         assert!(entries.contains("my file.txt"));
     }
 
@@ -344,7 +254,8 @@ mod tests {
     fn test_compact_symlinks() {
         let input = "total 8\n\
                      lrwxr-xr-x  1 user  staff  10 Jan  1 12:00 link -> target\n";
-        let (entries, _summary) = compact_ls(input, false);
+        let records = compact_ls(input, false);
+        let (entries, _summary) = synthesize_output(records);
         assert!(entries.contains("link -> target"));
     }
 
@@ -354,7 +265,8 @@ mod tests {
         let input = "total 48\n\
                      drwxr-xr-x  2 user  staff    64 Jan  1 12:00 src\n\
                      -rw-r--r--  1 user  staff  1234 Jan  1 12:00 main.rs\n";
-        let (entries, summary) = compact_ls(input, false);
+        let records = compact_ls(input, false);
+        let (entries, summary) = synthesize_output(records);
         assert!(
             !entries.contains("Summary:"),
             "entries must not contain summary"
@@ -373,7 +285,8 @@ mod tests {
                      drwxr-xr-x  2 user  staff    64 Jan  1 12:00 src\n\
                      -rw-r--r--  1 user  staff  1234 Jan  1 12:00 main.rs\n\
                      -rw-r--r--  1 user  staff  5678 Jan  1 12:00 lib.rs\n";
-        let (entries, _summary) = compact_ls(input, false);
+        let records = compact_ls(input, false);
+        let (entries, _summary) = synthesize_output(records);
         let line_count = entries.lines().count();
         assert_eq!(
             line_count, 3,
@@ -388,7 +301,8 @@ mod tests {
         let input = "total 8\n\
                      -rw-r--r--  1 fjeanne utilisa. du domaine    0 Mar 31 16:18 empty.txt\n\
                      -rw-r--r--  1 fjeanne utilisa. du domaine 1234 Mar 31 16:18 data.json\n";
-        let (entries, _summary) = compact_ls(input, false);
+        let records = compact_ls(input, false);
+        let (entries, _summary) = synthesize_output(records);
         assert!(
             entries.contains("empty.txt"),
             "should contain 'empty.txt', got: {entries}"
@@ -416,7 +330,8 @@ mod tests {
         // Some systems show year instead of time for old files
         let input = "total 8\n\
                      -rw-r--r--  1 user staff  5678 Dec 25  2024 archive.tar\n";
-        let (entries, _summary) = compact_ls(input, false);
+        let records = compact_ls(input, false);
+        let (entries, _summary) = synthesize_output(records);
         assert!(
             entries.contains("archive.tar"),
             "should contain filename, got: {entries}"

--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -17,19 +17,39 @@ pub enum LsRecordType {
     UNKNOWN,
 }
 
+#[derive(Debug, Clone)]
 pub struct LsRecord {
     pub name: String,
     pub file_type: LsRecordType,
     pub size: u64,
     pub extension: String,
     pub timestamp: Option<u64>,
+    pub octal_permissions: Option<String>,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct FormatOptions {
+    pub show_all: bool,
+    pub show_long: bool,
+    pub sort_by_time: bool,
+    pub reverse: bool,
+}
 
-pub fn parser(args: &[String]) -> (Vec<String>, Vec<String>, bool) {
+pub fn parser(args: &[String]) -> (Vec<String>, Vec<String>, FormatOptions) {
     let show_all = args
         .iter()
         .any(|a| (a.starts_with('-') && !a.starts_with("--") && a.contains('a')) || a == "--all");
+
+    let show_long = args.iter().any(|f| {
+        f == "-l"
+            || f == "-g"
+            || f == "-n"
+            || f == "-o"
+            || f == "--full-time"
+            || f == "--format=long"
+            || f == "--format=verbose"
+            || (f.starts_with('-') && !f.starts_with("--") && (f.chars().skip(1).any(|c| c == 'l' || c == 'g' || c == 'n' || c == 'o')))
+    });
 
     let flags: Vec<String> = args
         .iter()
@@ -41,8 +61,13 @@ pub fn parser(args: &[String]) -> (Vec<String>, Vec<String>, bool) {
         .filter(|a| !a.starts_with('-'))
         .cloned()
         .collect();
-    (paths, flags, show_all)
+
+    let sort_by_time = flags.iter().any(|f| f.starts_with('-') && !f.starts_with("--") && f.contains('t'));
+    let reverse = flags.iter().any(|f| f.starts_with('-') && !f.starts_with("--") && f.contains('r'));
+
+    (paths, flags, FormatOptions { show_all, show_long, sort_by_time, reverse })
 }
+
 
 pub fn cmd_builder(paths: &[String], flags: &[String], _show_all: bool) -> Command {
     let mut cmd = resolved_command("ls");
@@ -76,14 +101,14 @@ pub fn cmd_builder(paths: &[String], flags: &[String], _show_all: bool) -> Comma
 }
 
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
-    let (paths, flags, show_all) = parser(args);
+    let (paths, flags, options) = parser(args);
 
     #[cfg(windows)]
     {
         if !tool_exists("ls") {
             let timer = crate::core::tracking::TimedExecution::start();
 
-            let (exit_code, output, raw_estimate) = super::ls_win::run_native(paths.clone(), show_all, flags.clone())?;
+            let (exit_code, output, raw_estimate) = super::ls_win::run_native(paths.clone(), options.clone(), flags.clone())?;
             print!("{}", output);
 
             timer.track(
@@ -97,7 +122,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         }
     }
 
-    let cmd = cmd_builder(&paths, &flags, show_all);
+    let cmd = cmd_builder(&paths, &flags, options.show_all);
 
     let target_display = if paths.is_empty() {
         ".".to_string()
@@ -110,8 +135,8 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         "ls",
         &format!("-la {}", target_display),
         |raw| {
-            let result = compact_ls(raw, show_all);
-            let (entries, summary) = synthesize_output(result);
+            let result = compact_ls(raw, &options);
+            let (entries, summary) = synthesize_output(result, &options);
 
             // Only show summary in interactive mode (not when piped)
             let is_tty = std::io::stdout().is_terminal();
@@ -148,4 +173,5 @@ pub fn get_extension(name: &str) -> String {
         "no ext".to_string()
     }
 }
+
 

--- a/src/cmds/system/ls_format.rs
+++ b/src/cmds/system/ls_format.rs
@@ -6,7 +6,7 @@ pub struct LsRecord {
     pub is_dir: bool,
     pub size: u64,
     pub extension: String,
-    pub timestamp : Option(u64)
+    pub timestamp: Option<u64>,
 }
 
 /// Format bytes into human-readable size

--- a/src/cmds/system/ls_format.rs
+++ b/src/cmds/system/ls_format.rs
@@ -6,7 +6,7 @@ pub struct LsRecord {
     pub is_dir: bool,
     pub size: u64,
     pub extension: String,
-    pub timestamp : u64
+    pub timestamp : Option(u64)
 }
 
 /// Format bytes into human-readable size

--- a/src/cmds/system/ls_format.rs
+++ b/src/cmds/system/ls_format.rs
@@ -1,9 +1,16 @@
 use std::collections::HashMap;
 
 /// Represents a single directory entry for token-optimized listing.
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+pub enum LsRecordType{
+    FILE,
+    DIRECTORY,
+    SYMBOLINK,
+    UNKNOWN,
+}
 pub struct LsRecord {
     pub name: String,
-    pub is_dir: bool,
+    pub file_type: LsRecordType,
     pub size: u64,
     pub extension: String,
     pub timestamp: Option<u64>,
@@ -21,34 +28,58 @@ pub fn human_size(bytes: u64) -> String {
 }
 
 /// Synthesizes the compact, token-optimized string from a list of records.
-pub fn synthesize_output(dir_and_files: (Vec<LsRecord>, Vec<LsRecord>)) -> (String, String) {
-    let (mut dirs, mut files) = dir_and_files;
-    if dirs.is_empty() && files.is_empty() {
+pub fn synthesize_output(mut records: Vec<LsRecord>) -> (String, String) {
+    if records.is_empty() {
         return ("(empty)\n".to_string(), String::new());
     }
 
     let mut by_ext = HashMap::new();
 
-    for file in &files {
-        *by_ext.entry(file.extension.clone()).or_insert(0) += 1;
-    }
-
     // Sort to ensure stable output order
     #[cfg(not(target_os = "windows"))]{
-        dirs.sort_by(|a, b| a.name.cmp(&b.name));
-        files.sort_by(|a, b| a.name.cmp(&b.name));  
+        records.sort_by(|a, b| a.name.cmp(&b.name));
+    }
+
+    let mut dirs_out = String::new();
+    let mut files_out = String::new();
+    let mut symlinks_out = String::new();
+
+    let mut dir_count = 0;
+    let mut file_count = 0;
+    let mut sym_count = 0;
+
+    for r in &records {
+        match r.file_type {
+            LsRecordType::DIRECTORY => {
+                dirs_out.push_str(&format!("{}/\n", r.name));
+                dir_count += 1;
+            }
+            LsRecordType::SYMBOLINK => {
+                symlinks_out.push_str(&format!("{}  {}\n", r.name, human_size(r.size)));
+                sym_count += 1;
+            }
+            _ => {
+                if r.file_type == LsRecordType::FILE {
+                    *by_ext.entry(r.extension.clone()).or_insert(0) += 1;
+                }
+                files_out.push_str(&format!("{}  {}\n", r.name, human_size(r.size)));
+                file_count += 1;
+            }
+        }
     }
 
     let mut entries = String::new();
-    for d in &dirs {
-        entries.push_str(&format!("{}/\n", d.name));
-    }
-    for f in &files {
-        entries.push_str(&format!("{}  {}\n", f.name, human_size(f.size)));
-    }
+    entries.push_str(&dirs_out);
+    entries.push_str(&symlinks_out);
+    entries.push_str(&files_out);
 
     // Summary line (separate so caller can suppress when piped)
-    let mut summary = format!("\nSummary: {} files, {} dirs", files.len(), dirs.len());
+    let mut summary = if sym_count > 0 {
+        format!("\nSummary: {} files, {} dirs, {} symlinks", file_count, dir_count, sym_count)
+    } else {
+        format!("\nSummary: {} files, {} dirs", file_count, dir_count)
+    };
+
     if !by_ext.is_empty() {
         let mut ext_counts: Vec<_> = by_ext.iter().collect();
         ext_counts.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));

--- a/src/cmds/system/ls_format.rs
+++ b/src/cmds/system/ls_format.rs
@@ -1,0 +1,68 @@
+use std::collections::HashMap;
+
+/// Represents a single directory entry for token-optimized listing.
+pub struct LsRecord {
+    pub name: String,
+    pub is_dir: bool,
+    pub size: u64,
+    pub extension: String,
+}
+
+/// Format bytes into human-readable size
+pub fn human_size(bytes: u64) -> String {
+    if bytes >= 1_048_576 {
+        format!("{:.1}M", bytes as f64 / 1_048_576.0)
+    } else if bytes >= 1024 {
+        format!("{:.1}K", bytes as f64 / 1024.0)
+    } else {
+        format!("{}B", bytes)
+    }
+}
+
+/// Synthesizes the compact, token-optimized string from a list of records.
+pub fn synthesize_output(records: Vec<LsRecord>) -> (String, String) {
+    if records.is_empty() {
+        return ("(empty)\n".to_string(), String::new());
+    }
+
+    let mut dirs: Vec<&LsRecord> = records.iter().filter(|r| r.is_dir).collect();
+    let mut files: Vec<&LsRecord> = records.iter().filter(|r| !r.is_dir).collect();
+    let mut by_ext = HashMap::new();
+
+    for file in &files {
+        *by_ext.entry(file.extension.clone()).or_insert(0) += 1;
+    }
+
+    // Sort to ensure stable output order
+    dirs.sort_by(|a, b| a.name.cmp(&b.name));
+    files.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let mut entries = String::new();
+    for d in &dirs {
+        entries.push_str(&format!("{}/\n", d.name));
+    }
+    for f in &files {
+        entries.push_str(&format!("{}  {}\n", f.name, human_size(f.size)));
+    }
+
+    // Summary line (separate so caller can suppress when piped)
+    let mut summary = format!("\nSummary: {} files, {} dirs", files.len(), dirs.len());
+    if !by_ext.is_empty() {
+        let mut ext_counts: Vec<_> = by_ext.iter().collect();
+        ext_counts.sort_by(|a, b| b.1.cmp(a.1));
+        let ext_parts: Vec<String> = ext_counts
+            .iter()
+            .take(5)
+            .map(|(ext, count)| format!("{} {}", count, ext))
+            .collect();
+        summary.push_str(" (");
+        summary.push_str(&ext_parts.join(", "));
+        if ext_counts.len() > 5 {
+            summary.push_str(&format!(", +{} more", ext_counts.len() - 5));
+        }
+        summary.push(')');
+    }
+    summary.push('\n');
+
+    (entries, summary)
+}

--- a/src/cmds/system/ls_format.rs
+++ b/src/cmds/system/ls_format.rs
@@ -21,7 +21,8 @@ pub fn human_size(bytes: u64) -> String {
 }
 
 /// Synthesizes the compact, token-optimized string from a list of records.
-pub fn synthesize_output(mut dirs: Vec<LsRecord>, mut files: Vec<LsRecord>) -> (String, String) {
+pub fn synthesize_output(dir_and_files: (Vec<LsRecord>, Vec<LsRecord>)) -> (String, String) {
+    let (mut dirs, mut files) = dir_and_files;
     if dirs.is_empty() && files.is_empty() {
         return ("(empty)\n".to_string(), String::new());
     }
@@ -33,8 +34,10 @@ pub fn synthesize_output(mut dirs: Vec<LsRecord>, mut files: Vec<LsRecord>) -> (
     }
 
     // Sort to ensure stable output order
-    dirs.sort_by(|a, b| a.name.cmp(&b.name));
-    files.sort_by(|a, b| a.name.cmp(&b.name));
+    #[cfg(not(target_os = "windows"))]{
+        dirs.sort_by(|a, b| a.name.cmp(&b.name));
+        files.sort_by(|a, b| a.name.cmp(&b.name));  
+    }
 
     let mut entries = String::new();
     for d in &dirs {

--- a/src/cmds/system/ls_format.rs
+++ b/src/cmds/system/ls_format.rs
@@ -49,7 +49,7 @@ pub fn synthesize_output(records: Vec<LsRecord>) -> (String, String) {
     let mut summary = format!("\nSummary: {} files, {} dirs", files.len(), dirs.len());
     if !by_ext.is_empty() {
         let mut ext_counts: Vec<_> = by_ext.iter().collect();
-        ext_counts.sort_by(|a, b| b.1.cmp(a.1));
+        ext_counts.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
         let ext_parts: Vec<String> = ext_counts
             .iter()
             .take(5)

--- a/src/cmds/system/ls_format.rs
+++ b/src/cmds/system/ls_format.rs
@@ -14,6 +14,7 @@ pub fn human_size(bytes: u64) -> String {
 }
 
 /// Synthesizes the compact, token-optimized string from a list of records.
+// todo : I would add the flags in the synthesize output procedure.
 #[allow(unused_mut)]
 pub fn synthesize_output(mut records: Vec<LsRecord>) -> (String, String) {
     if records.is_empty() {

--- a/src/cmds/system/ls_format.rs
+++ b/src/cmds/system/ls_format.rs
@@ -1,20 +1,6 @@
 use std::collections::HashMap;
 
-/// Represents a single directory entry for token-optimized listing.
-#[derive(PartialEq, Eq, Debug, Clone, Copy)]
-pub enum LsRecordType{
-    FILE,
-    DIRECTORY,
-    SYMBOLINK,
-    UNKNOWN,
-}
-pub struct LsRecord {
-    pub name: String,
-    pub file_type: LsRecordType,
-    pub size: u64,
-    pub extension: String,
-    pub timestamp: Option<u64>,
-}
+use super::ls::{LsRecord, LsRecordType};
 
 /// Format bytes into human-readable size
 pub fn human_size(bytes: u64) -> String {
@@ -28,6 +14,7 @@ pub fn human_size(bytes: u64) -> String {
 }
 
 /// Synthesizes the compact, token-optimized string from a list of records.
+#[allow(unused_mut)]
 pub fn synthesize_output(mut records: Vec<LsRecord>) -> (String, String) {
     if records.is_empty() {
         return ("(empty)\n".to_string(), String::new());
@@ -98,4 +85,19 @@ pub fn synthesize_output(mut records: Vec<LsRecord>) -> (String, String) {
     summary.push('\n');
 
     (entries, summary)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_human_size() {
+        assert_eq!(human_size(0), "0B");
+        assert_eq!(human_size(500), "500B");
+        assert_eq!(human_size(1024), "1.0K");
+        assert_eq!(human_size(1234), "1.2K");
+        assert_eq!(human_size(1_048_576), "1.0M");
+        assert_eq!(human_size(2_500_000), "2.4M");
+    }
 }

--- a/src/cmds/system/ls_format.rs
+++ b/src/cmds/system/ls_format.rs
@@ -6,6 +6,7 @@ pub struct LsRecord {
     pub is_dir: bool,
     pub size: u64,
     pub extension: String,
+    pub timestamp : u64
 }
 
 /// Format bytes into human-readable size
@@ -20,13 +21,11 @@ pub fn human_size(bytes: u64) -> String {
 }
 
 /// Synthesizes the compact, token-optimized string from a list of records.
-pub fn synthesize_output(records: Vec<LsRecord>) -> (String, String) {
-    if records.is_empty() {
+pub fn synthesize_output(mut dirs: Vec<LsRecord>, mut files: Vec<LsRecord>) -> (String, String) {
+    if dirs.is_empty() && files.is_empty() {
         return ("(empty)\n".to_string(), String::new());
     }
 
-    let mut dirs: Vec<&LsRecord> = records.iter().filter(|r| r.is_dir).collect();
-    let mut files: Vec<&LsRecord> = records.iter().filter(|r| !r.is_dir).collect();
     let mut by_ext = HashMap::new();
 
     for file in &files {

--- a/src/cmds/system/ls_format.rs
+++ b/src/cmds/system/ls_format.rs
@@ -22,11 +22,9 @@ pub fn synthesize_output(mut records: Vec<LsRecord>, options: &FormatOptions) ->
 
     let mut by_ext = HashMap::new();
 
-    // Sort to ensure stable output order on Unix if no custom sorting is requested
-    #[cfg(not(target_os = "windows"))]{
-        if !options.sort_by_time && !options.reverse {
-            records.sort_by(|a, b| a.name.cmp(&b.name));
-        }
+    // Sort to ensure stable output order if no custom sorting is requested
+    if !options.sort_by_time && !options.reverse {
+        records.sort_by(|a, b| a.name.cmp(&b.name));
     }
 
     let mut dirs_out = String::new();
@@ -54,14 +52,14 @@ pub fn synthesize_output(mut records: Vec<LsRecord>, options: &FormatOptions) ->
                 dir_count += 1;
             }
             LsRecordType::SYMBOLINK => {
-                symlinks_out.push_str(&format!("{}{}{}  {}\n", perms_prefix, r.name, if r.name.contains(" -> ") { "" } else { "" }, human_size(r.size)));
+                symlinks_out.push_str(&format!("{}{}  {}\n", perms_prefix, r.name, human_size(r.size)));
                 sym_count += 1;
             }
             _ => {
                 if r.file_type == LsRecordType::FILE {
                     *by_ext.entry(r.extension.clone()).or_insert(0) += 1;
                 }
-                files_out.push_str(&format!("{}{}{}  {}\n", perms_prefix, r.name, if r.name.contains(" -> ") { "" } else { "" }, human_size(r.size)));
+                files_out.push_str(&format!("{}{}  {}\n", perms_prefix, r.name, human_size(r.size)));
                 file_count += 1;
             }
         }
@@ -112,5 +110,50 @@ mod tests {
         assert_eq!(human_size(1_048_576), "1.0M");
         assert_eq!(human_size(2_500_000), "2.4M");
     }
+
+    #[test]
+    fn test_token_savings_assertion() {
+        use crate::cmds::system::ls_win::generate_mock_raw_output;
+
+        let mut records = Vec::new();
+        for i in 0..8 {
+            records.push(LsRecord {
+                name: format!("module_file_{}.rs", i),
+                file_type: LsRecordType::FILE,
+                size: 1024 * (i + 1),
+                extension: "rs".to_string(),
+                timestamp: Some(1000 + i),
+                octal_permissions: Some("644".to_string()),
+            });
+        }
+        for i in 0..4 {
+            records.push(LsRecord {
+                name: format!("sub_dir_{}", i),
+                file_type: LsRecordType::DIRECTORY,
+                size: 4096,
+                extension: "".to_string(),
+                timestamp: Some(2000 + i),
+                octal_permissions: Some("755".to_string()),
+            });
+        }
+
+        let raw = generate_mock_raw_output(&records);
+        let options = FormatOptions::default();
+        let (entries, summary) = synthesize_output(records, &options);
+        let cooked = format!("{}{}", entries, summary);
+
+        assert!(!raw.is_empty());
+        assert!(!cooked.is_empty());
+        let savings = 100 - (cooked.len() * 100 / raw.len());
+        assert!(
+            savings >= 60,
+            "Expected >= 60% token savings, got {}% (raw len: {}, cooked len: {})",
+            savings,
+            raw.len(),
+            cooked.len()
+        );
+    }
 }
+
+
 

--- a/src/cmds/system/ls_format.rs
+++ b/src/cmds/system/ls_format.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use super::ls::{LsRecord, LsRecordType};
+use super::ls::{LsRecord, LsRecordType, FormatOptions};
 
 /// Format bytes into human-readable size
 pub fn human_size(bytes: u64) -> String {
@@ -14,18 +14,19 @@ pub fn human_size(bytes: u64) -> String {
 }
 
 /// Synthesizes the compact, token-optimized string from a list of records.
-// todo : I would add the flags in the synthesize output procedure.
 #[allow(unused_mut)]
-pub fn synthesize_output(mut records: Vec<LsRecord>) -> (String, String) {
+pub fn synthesize_output(mut records: Vec<LsRecord>, options: &FormatOptions) -> (String, String) {
     if records.is_empty() {
         return ("(empty)\n".to_string(), String::new());
     }
 
     let mut by_ext = HashMap::new();
 
-    // Sort to ensure stable output order
+    // Sort to ensure stable output order on Unix if no custom sorting is requested
     #[cfg(not(target_os = "windows"))]{
-        records.sort_by(|a, b| a.name.cmp(&b.name));
+        if !options.sort_by_time && !options.reverse {
+            records.sort_by(|a, b| a.name.cmp(&b.name));
+        }
     }
 
     let mut dirs_out = String::new();
@@ -37,20 +38,30 @@ pub fn synthesize_output(mut records: Vec<LsRecord>) -> (String, String) {
     let mut sym_count = 0;
 
     for r in &records {
+        let perms_prefix = if options.show_long {
+            if let Some(oct) = &r.octal_permissions {
+                format!("{}  ", oct)
+            } else {
+                "".to_string()
+            }
+        } else {
+            "".to_string()
+        };
+
         match r.file_type {
             LsRecordType::DIRECTORY => {
-                dirs_out.push_str(&format!("{}/\n", r.name));
+                dirs_out.push_str(&format!("{}{}/\n", perms_prefix, r.name));
                 dir_count += 1;
             }
             LsRecordType::SYMBOLINK => {
-                symlinks_out.push_str(&format!("{}  {}\n", r.name, human_size(r.size)));
+                symlinks_out.push_str(&format!("{}{}{}  {}\n", perms_prefix, r.name, if r.name.contains(" -> ") { "" } else { "" }, human_size(r.size)));
                 sym_count += 1;
             }
             _ => {
                 if r.file_type == LsRecordType::FILE {
                     *by_ext.entry(r.extension.clone()).or_insert(0) += 1;
                 }
-                files_out.push_str(&format!("{}  {}\n", r.name, human_size(r.size)));
+                files_out.push_str(&format!("{}{}{}  {}\n", perms_prefix, r.name, if r.name.contains(" -> ") { "" } else { "" }, human_size(r.size)));
                 file_count += 1;
             }
         }
@@ -102,3 +113,4 @@ mod tests {
         assert_eq!(human_size(2_500_000), "2.4M");
     }
 }
+

--- a/src/cmds/system/ls_unix.rs
+++ b/src/cmds/system/ls_unix.rs
@@ -1,0 +1,46 @@
+use lazy_static::lazy_static;
+use regex::Regex;
+
+lazy_static! {
+    /// Matches the date+time portion in `ls -la` output, which serves as a
+    /// stable anchor regardless of owner/group column width.
+    /// E.g.: " Mar 31 16:18 " or " Dec 25  2024 "
+    pub static ref LS_DATE_RE: Regex = Regex::new(
+        r"\s+(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}\s+(?:\d{4}|\d{2}:\d{2})\s+"
+    )
+    .unwrap();
+}
+
+/// Parse a single `ls -la` line, returning `(file_type_char, size, name)`.
+///
+/// Uses the date field as a stable anchor — the date format in `ls -la` is
+/// always three tokens (`Mon DD HH:MM` or `Mon DD  YYYY`), so we locate it
+/// with a regex, then extract size (rightmost number before the date) and
+/// filename (everything after the date). This handles owner/group names that
+/// contain spaces, which break the old fixed-column approach.
+pub fn parse_ls_line(line: &str) -> Option<(char, u64, String)> {
+    let date_match = LS_DATE_RE.find(line)?;
+    let name = line[date_match.end()..].to_string();
+
+    let before_date = &line[..date_match.start()];
+    let before_parts: Vec<&str> = before_date.split_whitespace().collect();
+    if before_parts.len() < 4 {
+        return None;
+    }
+
+    let perms = before_parts[0];
+    let file_type = perms.chars().next()?;
+
+    // Size is the rightmost parseable number before the date.
+    // nlinks is also numeric but appears earlier; scanning from the end
+    // guarantees we hit the size field first.
+    let mut size: u64 = 0;
+    for part in before_parts.iter().rev() {
+        if let Ok(s) = part.parse::<u64>() {
+            size = s;
+            break;
+        }
+    }
+
+    Some((file_type, size, name))
+}

--- a/src/cmds/system/ls_unix.rs
+++ b/src/cmds/system/ls_unix.rs
@@ -1,5 +1,7 @@
 use lazy_static::lazy_static;
 use regex::Regex;
+use super::constants::NOISE_DIRS;
+use super::ls::{get_extension, LsRecord, LsRecordType};
 
 lazy_static! {
     /// Matches the date+time portion in `ls -la` output, which serves as a
@@ -43,4 +45,268 @@ pub fn parse_ls_line(line: &str) -> Option<(char, u64, String)> {
     }
 
     Some((file_type, size, name))
+}
+
+/// Parse ls -la output into compact records.
+pub fn compact_ls(raw: &str, show_all: bool) -> Vec<LsRecord> {
+    let mut records = Vec::new();
+
+    for line in raw.lines() {
+        if line.starts_with("total ") || line.is_empty() {
+            continue;
+        }
+
+        let Some((file_type_ch, size, name)) = parse_ls_line(line) else {
+            continue;
+        };
+
+        // Skip . and ..
+        if name == "." || name == ".." {
+            continue;
+        }
+
+        // Filter noise dirs unless -a
+        if !show_all && NOISE_DIRS.iter().any(|noise| name == *noise) {
+            continue;
+        }
+        let file_type = match file_type_ch {
+            'd' => LsRecordType::DIRECTORY,
+            'l' => LsRecordType::SYMBOLINK,
+            'f' | '-' => LsRecordType::FILE,
+            _ => LsRecordType::UNKNOWN,
+        };
+        records.push(LsRecord {
+            extension: get_extension(&name),
+            file_type,
+            size,
+            name,
+            timestamp: None,
+        });
+    }
+
+    records
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cmds::system::ls_format::synthesize_output;
+
+    #[test]
+    fn test_compact_basic() {
+        let input = "total 48\n\
+                     drwxr-xr-x  2 user  staff    64 Jan  1 12:00 .\n\
+                     drwxr-xr-x  2 user  staff    64 Jan  1 12:00 ..\n\
+                     drwxr-xr-x  2 user  staff    64 Jan  1 12:00 src\n\
+                     -rw-r--r--  1 user  staff  1234 Jan  1 12:00 Cargo.toml\n\
+                     -rw-r--r--  1 user  staff  5678 Jan  1 12:00 README.md\n";
+        let records = compact_ls(input, false);
+        let (entries, _summary) = synthesize_output(records);
+        assert!(entries.contains("src/"));
+        assert!(entries.contains("Cargo.toml"));
+        assert!(entries.contains("README.md"));
+        assert!(entries.contains("1.2K")); // 1234 bytes
+        assert!(entries.contains("5.5K")); // 5678 bytes
+        assert!(!entries.contains("drwx")); // no permissions
+        assert!(!entries.contains("staff")); // no group
+        assert!(!entries.contains("total")); // no total
+        assert!(!entries.contains("\n.\n")); // no . entry
+        assert!(!entries.contains("\n..\n")); // no .. entry
+    }
+
+    #[test]
+    fn test_compact_filters_noise() {
+        let input = "total 8\n\
+                     drwxr-xr-x  2 user  staff  64 Jan  1 12:00 node_modules\n\
+                     drwxr-xr-x  2 user  staff  64 Jan  1 12:00 .git\n\
+                     drwxr-xr-x  2 user  staff  64 Jan  1 12:00 target\n\
+                     drwxr-xr-x  2 user  staff  64 Jan  1 12:00 src\n\
+                     -rw-r--r--  1 user  staff  100 Jan  1 12:00 main.rs\n";
+        let records = compact_ls(input, false);
+        let (entries, _summary) = synthesize_output(records);
+        assert!(!entries.contains("node_modules"));
+        assert!(!entries.contains(".git"));
+        assert!(!entries.contains("target"));
+        assert!(entries.contains("src/"));
+        assert!(entries.contains("main.rs"));
+    }
+
+    #[test]
+    fn test_compact_show_all() {
+        let input = "total 8\n\
+                     drwxr-xr-x  2 user  staff  64 Jan  1 12:00 .git\n\
+                     drwxr-xr-x  2 user  staff  64 Jan  1 12:00 src\n";
+        let records = compact_ls(input, true);
+        let (entries, _summary) = synthesize_output(records);
+        assert!(entries.contains(".git/"));
+        assert!(entries.contains("src/"));
+    }
+
+    #[test]
+    fn test_compact_empty() {
+        let input = "total 0\n";
+        let records = compact_ls(input, false);
+        let (entries, summary) = synthesize_output(records);
+        assert_eq!(entries, "(empty)\n");
+        assert!(summary.is_empty());
+    }
+
+    #[test]
+    fn test_compact_summary() {
+        let input = "total 48\n\
+                     drwxr-xr-x  2 user  staff    64 Jan  1 12:00 src\n\
+                     -rw-r--r--  1 user  staff  1234 Jan  1 12:00 main.rs\n\
+                     -rw-r--r--  1 user  staff  5678 Jan  1 12:00 lib.rs\n\
+                     -rw-r--r--  1 user  staff   100 Jan  1 12:00 Cargo.toml\n";
+        let records = compact_ls(input, false);
+        let (_entries, summary) = synthesize_output(records);
+        assert!(summary.contains("Summary: 3 files, 1 dirs"));
+        assert!(summary.contains(".rs"));
+        assert!(summary.contains(".toml"));
+    }
+
+    #[test]
+    fn test_compact_handles_filenames_with_spaces() {
+        let input = "total 8\n\
+                     -rw-r--r--  1 user  staff  1234 Jan  1 12:00 my file.txt\n";
+        let records = compact_ls(input, false);
+        let (entries, _summary) = synthesize_output(records);
+        assert!(entries.contains("my file.txt"));
+    }
+
+    #[test]
+    fn test_compact_symlinks() {
+        let input = "total 8\n\
+                     lrwxr-xr-x  1 user  staff  10 Jan  1 12:00 link -> target\n";
+        let records = compact_ls(input, false);
+        let (entries, _summary) = synthesize_output(records);
+        assert!(entries.contains("link -> target"));
+    }
+
+    #[test]
+    fn test_entries_no_summary() {
+        let input = "total 48\n\
+                     drwxr-xr-x  2 user  staff    64 Jan  1 12:00 src\n\
+                     -rw-r--r--  1 user  staff  1234 Jan  1 12:00 main.rs\n";
+        let records = compact_ls(input, false);
+        let (entries, summary) = synthesize_output(records);
+        assert!(
+            !entries.contains("Summary:"),
+            "entries must not contain summary"
+        );
+        assert!(
+            summary.contains("Summary:"),
+            "summary must contain the icon"
+        );
+    }
+
+    #[test]
+    fn test_pipe_line_count() {
+        let input = "total 48\n\
+                     drwxr-xr-x  2 user  staff    64 Jan  1 12:00 src\n\
+                     -rw-r--r--  1 user  staff  1234 Jan  1 12:00 main.rs\n\
+                     -rw-r--r--  1 user  staff  5678 Jan  1 12:00 lib.rs\n";
+        let records = compact_ls(input, false);
+        let (entries, _summary) = synthesize_output(records);
+        let line_count = entries.lines().count();
+        assert_eq!(
+            line_count, 3,
+            "pipe should see exactly 3 lines (1 dir + 2 files), got {}",
+            line_count
+        );
+    }
+
+    #[test]
+    fn test_compact_multiline_group() {
+        let input = "total 8\n\
+                     -rw-r--r--  1 fjeanne utilisa. du domaine    0 Mar 31 16:18 empty.txt\n\
+                     -rw-r--r--  1 fjeanne utilisa. du domaine 1234 Mar 31 16:18 data.json\n";
+        let records = compact_ls(input, false);
+        let (entries, _summary) = synthesize_output(records);
+        assert!(
+            entries.contains("empty.txt"),
+            "should contain 'empty.txt', got: {entries}"
+        );
+        assert!(
+            entries.contains("data.json"),
+            "should contain 'data.json', got: {entries}"
+        );
+        assert!(
+            !entries.contains("16:18"),
+            "time should not leak into filename, got: {entries}"
+        );
+        assert!(
+            entries.contains("0B"),
+            "empty.txt should show 0B, got: {entries}"
+        );
+        assert!(
+            entries.contains("1.2K"),
+            "data.json should show 1.2K (1234 bytes), got: {entries}"
+        );
+    }
+
+    #[test]
+    fn test_compact_year_format_date() {
+        let input = "total 8\n\
+                     -rw-r--r--  1 user staff  5678 Dec 25  2024 archive.tar\n";
+        let records = compact_ls(input, false);
+        let (entries, _summary) = synthesize_output(records);
+        assert!(
+            entries.contains("archive.tar"),
+            "should contain filename, got: {entries}"
+        );
+        assert!(entries.contains("5.5K"), "should show 5.5K, got: {entries}");
+    }
+
+    #[test]
+    fn test_parse_ls_line_basic() {
+        let (ft, size, name) =
+            parse_ls_line("-rw-r--r--  1 user staff 1234 Jan  1 12:00 file.txt").unwrap();
+        assert_eq!(ft, '-');
+        assert_eq!(size, 1234);
+        assert_eq!(name, "file.txt");
+    }
+
+    #[test]
+    fn test_parse_ls_line_multiline_group() {
+        let (ft, size, name) =
+            parse_ls_line("-rw-r--r--  1 fjeanne utilisa. du domaine 0 Mar 31 16:18 empty.txt")
+                .unwrap();
+        assert_eq!(ft, '-');
+        assert_eq!(size, 0);
+        assert_eq!(name, "empty.txt");
+    }
+
+    #[test]
+    fn test_parse_ls_line_dir_with_space_in_group() {
+        let (ft, size, name) =
+            parse_ls_line("drwxr-xr-x  2 fjeanne utilisa. du domaine 64 Mar 31 16:18 my dir")
+                .unwrap();
+        assert_eq!(ft, 'd');
+        assert_eq!(size, 64);
+        assert_eq!(name, "my dir");
+    }
+
+    #[test]
+    fn test_parse_ls_line_symlink() {
+        let (ft, size, name) =
+            parse_ls_line("lrwxr-xr-x  1 user staff 10 Jan  1 12:00 link -> target").unwrap();
+        assert_eq!(ft, 'l');
+        assert_eq!(size, 10);
+        assert_eq!(name, "link -> target");
+    }
+
+    #[test]
+    fn test_parse_ls_line_returns_none_for_total() {
+        assert!(parse_ls_line("total 48").is_none());
+    }
+
+    #[test]
+    fn test_parse_ls_line_year_format() {
+        let (ft, size, name) =
+            parse_ls_line("-rw-r--r--  1 user staff 5678 Dec 25  2024 old.tar.gz").unwrap();
+        assert_eq!(ft, '-');
+        assert_eq!(size, 5678);
+        assert_eq!(name, "old.tar.gz");
+    }
 }

--- a/src/cmds/system/ls_unix.rs
+++ b/src/cmds/system/ls_unix.rs
@@ -1,7 +1,7 @@
 use lazy_static::lazy_static;
 use regex::Regex;
 use super::constants::NOISE_DIRS;
-use super::ls::{get_extension, LsRecord, LsRecordType};
+use super::ls::{get_extension, LsRecord, LsRecordType, FormatOptions};
 
 lazy_static! {
     /// Matches the date+time portion in `ls -la` output, which serves as a
@@ -13,14 +13,54 @@ lazy_static! {
     .unwrap();
 }
 
-/// Parse a single `ls -la` line, returning `(file_type_char, size, name)`.
+/// Helper to convert a Unix permissions string (e.g. "rwxr-xr-x") to octal.
+pub fn unix_perms_to_octal(perms: &str) -> String {
+    let chars: Vec<char> = perms.chars().collect();
+    if chars.len() < 9 {
+        return "000".to_string();
+    }
+
+    let mut modes = [0u32; 3];
+    for i in 0..3 {
+        let r = chars[i * 3] == 'r';
+        let w = chars[i * 3 + 1] == 'w';
+        let x_char = chars[i * 3 + 2];
+        let x = x_char == 'x' || x_char == 's' || x_char == 't';
+
+        let mut val = 0;
+        if r { val += 4; }
+        if w { val += 2; }
+        if x { val += 1; }
+        modes[i] = val;
+    }
+
+    // Special bits
+    let mut special = 0;
+    if chars[2] == 's' || chars[2] == 'S' {
+        special += 4;
+    }
+    if chars[5] == 's' || chars[5] == 'S' {
+        special += 2;
+    }
+    if chars[8] == 't' || chars[8] == 'T' {
+        special += 1;
+    }
+
+    if special > 0 {
+        format!("{}{}{}{}", special, modes[0], modes[1], modes[2])
+    } else {
+        format!("{}{}{}", modes[0], modes[1], modes[2])
+    }
+}
+
+/// Parse a single `ls -la` line, returning `(file_type_char, size, name, perms_part)`.
 ///
 /// Uses the date field as a stable anchor — the date format in `ls -la` is
 /// always three tokens (`Mon DD HH:MM` or `Mon DD  YYYY`), so we locate it
 /// with a regex, then extract size (rightmost number before the date) and
 /// filename (everything after the date). This handles owner/group names that
 /// contain spaces, which break the old fixed-column approach.
-pub fn parse_ls_line(line: &str) -> Option<(char, u64, String)> {
+pub fn parse_ls_line(line: &str) -> Option<(char, u64, String, String)> {
     let date_match = LS_DATE_RE.find(line)?;
     let name = line[date_match.end()..].to_string();
 
@@ -32,6 +72,11 @@ pub fn parse_ls_line(line: &str) -> Option<(char, u64, String)> {
 
     let perms = before_parts[0];
     let file_type = perms.chars().next()?;
+    let perms_part = if perms.len() > 1 {
+        perms[1..].to_string()
+    } else {
+        "".to_string()
+    };
 
     // Size is the rightmost parseable number before the date.
     // nlinks is also numeric but appears earlier; scanning from the end
@@ -44,11 +89,11 @@ pub fn parse_ls_line(line: &str) -> Option<(char, u64, String)> {
         }
     }
 
-    Some((file_type, size, name))
+    Some((file_type, size, name, perms_part))
 }
 
 /// Parse ls -la output into compact records.
-pub fn compact_ls(raw: &str, show_all: bool) -> Vec<LsRecord> {
+pub fn compact_ls(raw: &str, options: &FormatOptions) -> Vec<LsRecord> {
     let mut records = Vec::new();
 
     for line in raw.lines() {
@@ -56,7 +101,7 @@ pub fn compact_ls(raw: &str, show_all: bool) -> Vec<LsRecord> {
             continue;
         }
 
-        let Some((file_type_ch, size, name)) = parse_ls_line(line) else {
+        let Some((file_type_ch, size, name, perms_part)) = parse_ls_line(line) else {
             continue;
         };
 
@@ -66,7 +111,7 @@ pub fn compact_ls(raw: &str, show_all: bool) -> Vec<LsRecord> {
         }
 
         // Filter noise dirs unless -a
-        if !show_all && NOISE_DIRS.iter().any(|noise| name == *noise) {
+        if !options.show_all && NOISE_DIRS.iter().any(|noise| name == *noise) {
             continue;
         }
         let file_type = match file_type_ch {
@@ -75,12 +120,20 @@ pub fn compact_ls(raw: &str, show_all: bool) -> Vec<LsRecord> {
             'f' | '-' => LsRecordType::FILE,
             _ => LsRecordType::UNKNOWN,
         };
+
+        let octal_permissions = if options.show_long {
+            Some(unix_perms_to_octal(&perms_part))
+        } else {
+            None
+        };
+
         records.push(LsRecord {
             extension: get_extension(&name),
             file_type,
             size,
             name,
             timestamp: None,
+            octal_permissions,
         });
     }
 
@@ -100,8 +153,9 @@ mod tests {
                      drwxr-xr-x  2 user  staff    64 Jan  1 12:00 src\n\
                      -rw-r--r--  1 user  staff  1234 Jan  1 12:00 Cargo.toml\n\
                      -rw-r--r--  1 user  staff  5678 Jan  1 12:00 README.md\n";
-        let records = compact_ls(input, false);
-        let (entries, _summary) = synthesize_output(records);
+        let options = FormatOptions { show_all: false, show_long: false, sort_by_time: false, reverse: false };
+        let records = compact_ls(input, &options);
+        let (entries, _summary) = synthesize_output(records, &options);
         assert!(entries.contains("src/"));
         assert!(entries.contains("Cargo.toml"));
         assert!(entries.contains("README.md"));
@@ -115,6 +169,18 @@ mod tests {
     }
 
     #[test]
+    fn test_compact_show_long() {
+        let input = "total 48\n\
+                     drwxr-xr-x  2 user  staff    64 Jan  1 12:00 src\n\
+                     -rw-r--r--  1 user  staff  1234 Jan  1 12:00 Cargo.toml\n";
+        let options = FormatOptions { show_all: false, show_long: true, sort_by_time: false, reverse: false };
+        let records = compact_ls(input, &options);
+        let (entries, _summary) = synthesize_output(records, &options);
+        assert!(entries.contains("755  src/"));
+        assert!(entries.contains("644  Cargo.toml  1.2K"));
+    }
+
+    #[test]
     fn test_compact_filters_noise() {
         let input = "total 8\n\
                      drwxr-xr-x  2 user  staff  64 Jan  1 12:00 node_modules\n\
@@ -122,8 +188,9 @@ mod tests {
                      drwxr-xr-x  2 user  staff  64 Jan  1 12:00 target\n\
                      drwxr-xr-x  2 user  staff  64 Jan  1 12:00 src\n\
                      -rw-r--r--  1 user  staff  100 Jan  1 12:00 main.rs\n";
-        let records = compact_ls(input, false);
-        let (entries, _summary) = synthesize_output(records);
+        let options = FormatOptions { show_all: false, show_long: false, sort_by_time: false, reverse: false };
+        let records = compact_ls(input, &options);
+        let (entries, _summary) = synthesize_output(records, &options);
         assert!(!entries.contains("node_modules"));
         assert!(!entries.contains(".git"));
         assert!(!entries.contains("target"));
@@ -136,8 +203,9 @@ mod tests {
         let input = "total 8\n\
                      drwxr-xr-x  2 user  staff  64 Jan  1 12:00 .git\n\
                      drwxr-xr-x  2 user  staff  64 Jan  1 12:00 src\n";
-        let records = compact_ls(input, true);
-        let (entries, _summary) = synthesize_output(records);
+        let options = FormatOptions { show_all: true, show_long: false, sort_by_time: false, reverse: false };
+        let records = compact_ls(input, &options);
+        let (entries, _summary) = synthesize_output(records, &options);
         assert!(entries.contains(".git/"));
         assert!(entries.contains("src/"));
     }
@@ -145,8 +213,9 @@ mod tests {
     #[test]
     fn test_compact_empty() {
         let input = "total 0\n";
-        let records = compact_ls(input, false);
-        let (entries, summary) = synthesize_output(records);
+        let options = FormatOptions { show_all: false, show_long: false, sort_by_time: false, reverse: false };
+        let records = compact_ls(input, &options);
+        let (entries, summary) = synthesize_output(records, &options);
         assert_eq!(entries, "(empty)\n");
         assert!(summary.is_empty());
     }
@@ -158,8 +227,9 @@ mod tests {
                      -rw-r--r--  1 user  staff  1234 Jan  1 12:00 main.rs\n\
                      -rw-r--r--  1 user  staff  5678 Jan  1 12:00 lib.rs\n\
                      -rw-r--r--  1 user  staff   100 Jan  1 12:00 Cargo.toml\n";
-        let records = compact_ls(input, false);
-        let (_entries, summary) = synthesize_output(records);
+        let options = FormatOptions { show_all: false, show_long: false, sort_by_time: false, reverse: false };
+        let records = compact_ls(input, &options);
+        let (_entries, summary) = synthesize_output(records, &options);
         assert!(summary.contains("Summary: 3 files, 1 dirs"));
         assert!(summary.contains(".rs"));
         assert!(summary.contains(".toml"));
@@ -169,8 +239,9 @@ mod tests {
     fn test_compact_handles_filenames_with_spaces() {
         let input = "total 8\n\
                      -rw-r--r--  1 user  staff  1234 Jan  1 12:00 my file.txt\n";
-        let records = compact_ls(input, false);
-        let (entries, _summary) = synthesize_output(records);
+        let options = FormatOptions { show_all: false, show_long: false, sort_by_time: false, reverse: false };
+        let records = compact_ls(input, &options);
+        let (entries, _summary) = synthesize_output(records, &options);
         assert!(entries.contains("my file.txt"));
     }
 
@@ -178,8 +249,9 @@ mod tests {
     fn test_compact_symlinks() {
         let input = "total 8\n\
                      lrwxr-xr-x  1 user  staff  10 Jan  1 12:00 link -> target\n";
-        let records = compact_ls(input, false);
-        let (entries, _summary) = synthesize_output(records);
+        let options = FormatOptions { show_all: false, show_long: false, sort_by_time: false, reverse: false };
+        let records = compact_ls(input, &options);
+        let (entries, _summary) = synthesize_output(records, &options);
         assert!(entries.contains("link -> target"));
     }
 
@@ -188,8 +260,9 @@ mod tests {
         let input = "total 48\n\
                      drwxr-xr-x  2 user  staff    64 Jan  1 12:00 src\n\
                      -rw-r--r--  1 user  staff  1234 Jan  1 12:00 main.rs\n";
-        let records = compact_ls(input, false);
-        let (entries, summary) = synthesize_output(records);
+        let options = FormatOptions { show_all: false, show_long: false, sort_by_time: false, reverse: false };
+        let records = compact_ls(input, &options);
+        let (entries, summary) = synthesize_output(records, &options);
         assert!(
             !entries.contains("Summary:"),
             "entries must not contain summary"
@@ -206,8 +279,9 @@ mod tests {
                      drwxr-xr-x  2 user  staff    64 Jan  1 12:00 src\n\
                      -rw-r--r--  1 user  staff  1234 Jan  1 12:00 main.rs\n\
                      -rw-r--r--  1 user  staff  5678 Jan  1 12:00 lib.rs\n";
-        let records = compact_ls(input, false);
-        let (entries, _summary) = synthesize_output(records);
+        let options = FormatOptions { show_all: false, show_long: false, sort_by_time: false, reverse: false };
+        let records = compact_ls(input, &options);
+        let (entries, _summary) = synthesize_output(records, &options);
         let line_count = entries.lines().count();
         assert_eq!(
             line_count, 3,
@@ -221,8 +295,9 @@ mod tests {
         let input = "total 8\n\
                      -rw-r--r--  1 fjeanne utilisa. du domaine    0 Mar 31 16:18 empty.txt\n\
                      -rw-r--r--  1 fjeanne utilisa. du domaine 1234 Mar 31 16:18 data.json\n";
-        let records = compact_ls(input, false);
-        let (entries, _summary) = synthesize_output(records);
+        let options = FormatOptions { show_all: false, show_long: false, sort_by_time: false, reverse: false };
+        let records = compact_ls(input, &options);
+        let (entries, _summary) = synthesize_output(records, &options);
         assert!(
             entries.contains("empty.txt"),
             "should contain 'empty.txt', got: {entries}"
@@ -249,8 +324,9 @@ mod tests {
     fn test_compact_year_format_date() {
         let input = "total 8\n\
                      -rw-r--r--  1 user staff  5678 Dec 25  2024 archive.tar\n";
-        let records = compact_ls(input, false);
-        let (entries, _summary) = synthesize_output(records);
+        let options = FormatOptions { show_all: false, show_long: false, sort_by_time: false, reverse: false };
+        let records = compact_ls(input, &options);
+        let (entries, _summary) = synthesize_output(records, &options);
         assert!(
             entries.contains("archive.tar"),
             "should contain filename, got: {entries}"
@@ -260,40 +336,44 @@ mod tests {
 
     #[test]
     fn test_parse_ls_line_basic() {
-        let (ft, size, name) =
+        let (ft, size, name, perms) =
             parse_ls_line("-rw-r--r--  1 user staff 1234 Jan  1 12:00 file.txt").unwrap();
         assert_eq!(ft, '-');
         assert_eq!(size, 1234);
         assert_eq!(name, "file.txt");
+        assert_eq!(perms, "rw-r--r--");
     }
 
     #[test]
     fn test_parse_ls_line_multiline_group() {
-        let (ft, size, name) =
+        let (ft, size, name, perms) =
             parse_ls_line("-rw-r--r--  1 fjeanne utilisa. du domaine 0 Mar 31 16:18 empty.txt")
                 .unwrap();
         assert_eq!(ft, '-');
         assert_eq!(size, 0);
         assert_eq!(name, "empty.txt");
+        assert_eq!(perms, "rw-r--r--");
     }
 
     #[test]
     fn test_parse_ls_line_dir_with_space_in_group() {
-        let (ft, size, name) =
+        let (ft, size, name, perms) =
             parse_ls_line("drwxr-xr-x  2 fjeanne utilisa. du domaine 64 Mar 31 16:18 my dir")
                 .unwrap();
         assert_eq!(ft, 'd');
         assert_eq!(size, 64);
         assert_eq!(name, "my dir");
+        assert_eq!(perms, "rwxr-xr-x");
     }
 
     #[test]
     fn test_parse_ls_line_symlink() {
-        let (ft, size, name) =
+        let (ft, size, name, perms) =
             parse_ls_line("lrwxr-xr-x  1 user staff 10 Jan  1 12:00 link -> target").unwrap();
         assert_eq!(ft, 'l');
         assert_eq!(size, 10);
         assert_eq!(name, "link -> target");
+        assert_eq!(perms, "rwxr-xr-x");
     }
 
     #[test]
@@ -303,10 +383,11 @@ mod tests {
 
     #[test]
     fn test_parse_ls_line_year_format() {
-        let (ft, size, name) =
+        let (ft, size, name, perms) =
             parse_ls_line("-rw-r--r--  1 user staff 5678 Dec 25  2024 old.tar.gz").unwrap();
         assert_eq!(ft, '-');
         assert_eq!(size, 5678);
         assert_eq!(name, "old.tar.gz");
+        assert_eq!(perms, "rw-r--r--");
     }
 }

--- a/src/cmds/system/ls_win.rs
+++ b/src/cmds/system/ls_win.rs
@@ -1,14 +1,18 @@
+use crate::cmds::system::ls_format::LsRecordType;
 use super::constants::NOISE_DIRS;
 use super::ls::{self, LsRecord};
+
 use anyhow::Result;
-use colored::Colorize; // 顯式引入 Trait
+use colored::Colorize; 
 use std::collections::HashSet;
 use std::io::IsTerminal;
 use std::path::Path;
 use std::time::UNIX_EPOCH;
 
+
 /// Fetches file information from the filesystem using native Rust std::fs.
-pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<(Vec<LsRecord>, Vec<LsRecord>)> {
+/// refactor required
+pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<Vec<LsRecord>> {
     let mut records = Vec::new();
     let targets: Vec<String> = if paths.is_empty() {
         vec![".".to_string()]
@@ -23,8 +27,17 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<(Vec<LsRecord>,
             continue;
         }
 
-        if path.is_dir() {
-            for entry in std::fs::read_dir(path)?.flatten() {
+        let metadata = match std::fs::symlink_metadata(path) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+
+        if metadata.is_dir() {
+            for entry_res in std::fs::read_dir(path)? {
+                let entry = match entry_res {
+                    Ok(e) => e,
+                    Err(_) => continue,
+                };
                 let name = entry.file_name().to_string_lossy().to_string();
 
                 if name == "." || name == ".." {
@@ -35,30 +48,49 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<(Vec<LsRecord>,
                     continue;
                 }
 
-                if let Ok(metadata) = entry.metadata() {
-                    let timestamp = Some(
-                        metadata
-                            .modified()
+                if let Ok(file_type) = entry.file_type() {
+                    let ls_file_type = if file_type.is_symlink() {
+                        LsRecordType::SYMBOLINK
+                    } else if file_type.is_dir() {
+                        LsRecordType::DIRECTORY
+                    } else {
+                        LsRecordType::FILE
+                    };
+
+                    let meta = entry.metadata().or_else(|_| std::fs::symlink_metadata(entry.path())).ok();
+                    let (size, timestamp) = if let Some(m) = meta {
+                        let ts = m.modified()
                             .ok()
                             .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
                             .map(|d| d.as_secs() as u64)
-                            .unwrap_or(0),
-                    );
+                            .unwrap_or(0);
+                        (m.len(), Some(ts))
+                    } else {
+                        (0, None)
+                    };
+
                     records.push(LsRecord {
                         extension: ls::get_extension(&name),
-                        is_dir: metadata.is_dir(),
-                        size: metadata.len(),
+                        file_type: ls_file_type,
+                        size,
                         name,
                         timestamp,
                     });
                 }
             }
-        } else if let Ok(metadata) = path.metadata() {
+        } else {
             let name = path
                 .file_name()
                 .unwrap_or_default()
                 .to_string_lossy()
                 .to_string();
+                
+            let ls_file_type = if metadata.is_symlink() {
+                LsRecordType::SYMBOLINK
+            } else {
+                LsRecordType::FILE
+            };
+
             let timestamp = Some(
                 metadata
                     .modified()
@@ -69,15 +101,14 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<(Vec<LsRecord>,
             );
             records.push(LsRecord {
                 extension: ls::get_extension(&name),
-                is_dir: false,
+                file_type: ls_file_type,
                 size: metadata.len(),
                 name,
                 timestamp,
             });
         }
     }
-    let (dirs, files): (Vec<LsRecord>, Vec<LsRecord>) = records.into_iter().partition(|r| r.is_dir);
-    Ok((dirs, files))
+    Ok(records)
 }
 fn warn_unsupported_flags(flags: &[String]) {
     let allowed_flags = ["-t", "-r", "-rt", "-tr"];
@@ -100,9 +131,8 @@ fn warn_unsupported_flags(flags: &[String]) {
     }
 }
 
-pub fn run_native(paths: Vec<String>, show_all: bool, flags: Vec<String>) -> Result<i32> {
+pub fn run_native(paths: Vec<String>, show_all: bool, flags: Vec<String>) -> Result<(i32, String)> {
     warn_unsupported_flags(&flags);
-    let timer = crate::core::tracking::TimedExecution::start();
 
     let active_flags: HashSet<char> = flags
         .iter()
@@ -113,26 +143,24 @@ pub fn run_native(paths: Vec<String>, show_all: bool, flags: Vec<String>) -> Res
     let is_r = active_flags.contains(&'r');
     let is_t = active_flags.contains(&'t');
 
-    let (mut dirs, mut files) = fetch_entries(&paths, show_all)?;
+    let mut records = fetch_entries(&paths, show_all)?;
 
     let sort_fn = if is_t {
-        // 按時間倒序 (新到舊)
+        //
         |a: &LsRecord, b: &LsRecord| b.timestamp.unwrap_or(0).cmp(&a.timestamp.unwrap_or(0))
     } else {
-        // 按名稱正序
+        //
         |a: &LsRecord, b: &LsRecord| a.name.cmp(&b.name)
     };
 
-    dirs.sort_by(sort_fn);
-    files.sort_by(sort_fn);
+    records.sort_by(sort_fn);
 
-    // 3. 反轉邏輯
+    // 
     if is_r {
-        dirs.reverse();
-        files.reverse();
+        records.reverse();
     }
 
-    let (entries, summary) = ls::synthesize_output((dirs, files));
+    let (entries, summary) = ls::synthesize_output(records);
     let is_tty = std::io::stdout().is_terminal();
     let output = if is_tty {
         format!("{}{}", entries, summary)
@@ -140,14 +168,5 @@ pub fn run_native(paths: Vec<String>, show_all: bool, flags: Vec<String>) -> Res
         entries
     };
 
-    print!("{}", output);
-
-    timer.track(
-        &format!("ls (native) {}", paths.join(" ")),
-        &format!("rtk ls {}", paths.join(" ")),
-        "",
-        &output,
-    );
-
-    Ok(0)
+    Ok((0, output))
 }

--- a/src/cmds/system/ls_win.rs
+++ b/src/cmds/system/ls_win.rs
@@ -306,5 +306,146 @@ mod tests {
         assert!(summary.contains(".rs"));
         assert!(summary.contains(".toml"));
     }
+        #[test]
+    fn test_estimate_raw_dir_output() {
+        let records = vec![
+            LsRecord {
+                name: "file.txt".to_string(),
+                file_type: LsRecordType::FILE,
+                size: 100,
+                timestamp: Some(1000),
+                extension: "txt".to_string(),
+            },
+            LsRecord {
+                name: "dir".to_string(),
+                file_type: LsRecordType::DIRECTORY,
+                size: 0,
+                timestamp: Some(2000),
+                extension: "".to_string(),
+            },
+        ];
+        let estimate = estimate_raw_dir_output(&records);
+        // Calculation: 
+        // Base = 8 ("total 0\n")
+        // file.txt length (8) + 45 = 53
+        // dir length (3) + 45 = 48
+        // 8 + 53 + 48 = 109 spaces
+        assert_eq!(estimate.len(), 109);
+        assert_eq!(estimate, " ".repeat(109));
+    }
+
+    #[test]
+    fn test_fetch_entries_single_file() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path();
+
+        let file_path = dir_path.join("single.txt");
+        File::create(&file_path).unwrap();
+
+        // Testing the `} else {` branch of fetch_entries
+        let records = fetch_entries(&[file_path.to_string_lossy().into_owned()], false).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].name, "single.txt");
+        assert_eq!(records[0].file_type, LsRecordType::FILE);
+    }
+
+    #[test]
+    fn test_run_native_sorting() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path();
+
+        // Create files in specific order but with non-alphabetical names.
+        // We add slight sleeps to guarantee different OS file modification times.
+        File::create(dir_path.join("c.txt")).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(1050));
+        
+        File::create(dir_path.join("a.txt")).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(1050));
+        
+        File::create(dir_path.join("b.txt")).unwrap();
+
+        let path_str = dir_path.to_string_lossy().into_owned();
+
+        // 1. Default (alphabetical: a.txt -> b.txt -> c.txt)
+        let (_, output_default, _) = run_native(vec![path_str.clone()], false, vec![]).unwrap();
+        let pos_a = output_default.find("a.txt").unwrap();
+        let pos_b = output_default.find("b.txt").unwrap();
+        let pos_c = output_default.find("c.txt").unwrap();
+        assert!(pos_a < pos_b && pos_b < pos_c, "Default sort should be alphabetical");
+
+        // 2. Reverse alphabetical (-r: c.txt -> b.txt -> a.txt)
+        let (_, output_rev, _) = run_native(vec![path_str.clone()], false, vec!["-r".to_string()]).unwrap();
+        let pos_a_r = output_rev.find("a.txt").unwrap();
+        let pos_b_r = output_rev.find("b.txt").unwrap();
+        let pos_c_r = output_rev.find("c.txt").unwrap();
+        assert!(pos_c_r < pos_b_r && pos_b_r < pos_a_r, "Reverse sort (-r) should be reverse alphabetical");
+
+        // 3. Time sort (-t: newest first -> b.txt -> a.txt -> c.txt)
+        let (_, output_time, _) = run_native(vec![path_str.clone()], false, vec!["-t".to_string()]).unwrap();
+        let pos_a_t = output_time.find("a.txt").unwrap();
+        let pos_b_t = output_time.find("b.txt").unwrap();
+        let pos_c_t = output_time.find("c.txt").unwrap();
+        assert!(pos_b_t < pos_a_t && pos_a_t < pos_c_t, "Time sort (-t) should be newest first");
+
+        // 4. Reverse time sort (-rt: oldest first -> c.txt -> a.txt -> b.txt)
+        let (_, output_rev_time, _) = run_native(vec![path_str.clone()], false, vec!["-rt".to_string()]).unwrap();
+        let pos_a_rt = output_rev_time.find("a.txt").unwrap();
+        let pos_b_rt = output_rev_time.find("b.txt").unwrap();
+        let pos_c_rt = output_rev_time.find("c.txt").unwrap();
+        assert!(pos_c_rt < pos_a_rt && pos_a_rt < pos_b_rt, "Reverse time sort (-rt) should be oldest first");
+    }
+
+    #[test]
+    fn test_run_native_total_combo() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path();
+
+        // Create Directory
+        fs::create_dir(dir_path.join("folder_b")).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        // Create File
+        let file_path = dir_path.join("file_a.txt");
+        File::create(&file_path).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        // Create Symlink
+        let link_path = dir_path.join("symlink_c");
+        #[cfg(windows)]
+        let symlink_result = std::os::windows::fs::symlink_file(&file_path, &link_path);
+        #[cfg(not(windows))]
+        let symlink_result = std::os::unix::fs::symlink(&file_path, &link_path);
+
+        if let Err(e) = symlink_result {
+            eprintln!("Skipping symlink creation in combo test due to privileges: {:?}", e);
+        }
+
+        let path_str = dir_path.to_string_lossy().into_owned();
+
+        // Run holistic function with -rt flags and show_all = true
+        let (exit_code, output, estimate) = run_native(
+            vec![path_str], 
+            true, 
+            vec!["-rt".to_string()]
+        ).unwrap();
+
+        assert_eq!(exit_code, 0);
+        assert!(!estimate.is_empty(), "Token estimate string should be generated");
+        
+        // Assert output contains all elements
+        assert!(output.contains("folder_b/"));
+        assert!(output.contains("file_a.txt"));
+        
+        if dir_path.join("symlink_c").exists() {
+            assert!(output.contains("symlink_c"));
+        }
+        
+        // Because synthesize_output explicitly formats into sections (Dirs -> Symlinks -> Files)
+        // the sorting flags only apply to the items *within* those sections. 
+        // We assert the summary appears at the bottom.
+        assert!(output.contains("Summary: "));
+    }
+
+
 }
 

--- a/src/cmds/system/ls_win.rs
+++ b/src/cmds/system/ls_win.rs
@@ -85,8 +85,8 @@ pub fn run_native( paths: Vec<String>, show_all: bool ,  flags:Vec<String>) -> R
         files.reverse();
     }
     if flags.contains(&"-t".to_string()) {
-        dirs.sort_by(|a, b| b.size.cmp(&a.size));
-        files.sort_by(|a, b| b.size.cmp(&a.size));
+        dirs.sort_by(|a, b| b.timestamp.unwrap_or(0).cmp(&a.timestamp.unwrap_or(0)));      
+        files.sort_by(|a, b| b.timestamp.unwrap_or(0).cmp(&a.timestamp.unwrap_or(0)));
     }
     if !flags.is_empty() && flags.iter().all(|f| f != "-t" && f != "-r"){
         eprintln!("{}","rtk ls: native Windows path ignores flags: {flags:?}".bold().yellow())

--- a/src/cmds/system/ls_win.rs
+++ b/src/cmds/system/ls_win.rs
@@ -60,6 +60,7 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<Vec<LsRecord>> 
 
 /// Entry point called by ls::run on Windows.
 pub fn run_native(paths: Vec<String>, show_all: bool) -> Result<i32> {
+    eprintln!("⚠️ Warning: ls on Windows is not fully supported yet. some flag may not work as expected. the program use system call to fetch file information.");
     let timer = crate::core::tracking::TimedExecution::start();
     
     let records = fetch_entries(&paths, show_all)?;

--- a/src/cmds/system/ls_win.rs
+++ b/src/cmds/system/ls_win.rs
@@ -77,7 +77,6 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<(Vec<LsRecord>,
 
 /// Entry point called by ls::run on Windows.
 pub fn run_native( paths: Vec<String>, show_all: bool ,  flags:Vec<String>) -> Result<i32> {
-    eprintln!("{}","⚠️ Warning: ls on Windows is not fully supported yet. some flag may not work as expected. the program use system call to fetch file information.".yellow().bold());
     let timer = crate::core::tracking::TimedExecution::start();
     
     let (mut dirs, mut files) = fetch_entries(&paths, show_all)?;
@@ -88,6 +87,9 @@ pub fn run_native( paths: Vec<String>, show_all: bool ,  flags:Vec<String>) -> R
     if flags.contains(&"-t".to_string()) {
         dirs.sort_by(|a, b| b.size.cmp(&a.size));
         files.sort_by(|a, b| b.size.cmp(&a.size));
+    }
+    if !flags.is_empty() && flags.iter().all(|f| f != "-t" && f != "-r"){
+        eprintln!("{}","rtk ls: native Windows path ignores flags: {flags:?}".bold().yellow())
     }
     let (entries, summary) = ls::synthesize_output(dirs,files);
 

--- a/src/cmds/system/ls_win.rs
+++ b/src/cmds/system/ls_win.rs
@@ -1,0 +1,155 @@
+use super::constants::NOISE_DIRS;
+use anyhow::Result;
+use std::collections::HashMap;
+use std::io::IsTerminal;
+use std::path::Path;
+
+/// Represents a single directory entry for token-optimized listing.
+pub struct LsRecord {
+    pub name: String,
+    pub is_dir: bool,
+    pub size: u64,
+    pub extension: String,
+}
+
+/// Fetches file information from the filesystem using native Rust std::fs.
+pub fn fetch_entries(paths: &[&str], show_all: bool) -> Result<Vec<LsRecord>> {
+    let mut records = Vec::new();
+    let targets = if paths.is_empty() {
+        vec!["."]
+    } else {
+        paths.to_vec()
+    };
+
+    for path_str in &targets {
+        let path = Path::new(path_str);
+        if !path.exists() {
+            eprintln!("rtk: {}: No such file or directory", path_str);
+            continue;
+        }
+
+        if path.is_dir() {
+            for entry in std::fs::read_dir(path)?.flatten() {
+                let name = entry.file_name().to_string_lossy().to_string();
+
+                if name == "." || name == ".." {
+                    continue;
+                }
+
+                if !show_all && (name.starts_with('.') || NOISE_DIRS.iter().any(|noise| name == *noise)) {
+                    continue;
+                }
+
+                if let Ok(metadata) = entry.metadata() {
+                    records.push(LsRecord {
+                        extension: get_extension(&name),
+                        is_dir: metadata.is_dir(),
+                        size: metadata.len(),
+                        name,
+                    });
+                }
+            }
+        } else if let Ok(metadata) = path.metadata() {
+            let name = path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+            records.push(LsRecord {
+                extension: get_extension(&name),
+                is_dir: false,
+                size: metadata.len(),
+                name,
+            });
+        }
+    }
+    Ok(records)
+}
+
+/// Synthesizes the compact, token-optimized string from a list of records.
+pub fn synthesize_output(records: Vec<LsRecord>) -> (String, String) {
+    if records.is_empty() {
+        return ("(empty)\n".to_string(), String::new());
+    }
+
+    let mut dirs: Vec<&LsRecord> = records.iter().filter(|r| r.is_dir).collect();
+    let mut files: Vec<&LsRecord> = records.iter().filter(|r| !r.is_dir).collect();
+    let mut by_ext = HashMap::new();
+
+    for file in &files {
+        *by_ext.entry(file.extension.clone()).or_insert(0) += 1;
+    }
+
+    dirs.sort_by(|a, b| a.name.cmp(&b.name));
+    files.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let mut entries = String::new();
+    for d in &dirs {
+        entries.push_str(&format!("{}/\n", d.name));
+    }
+    for f in &files {
+        entries.push_str(&format!("{}  {}\n", f.name, human_size(f.size)));
+    }
+
+    let mut summary = format!("\nSummary: {} files, {} dirs", files.len(), dirs.len());
+    if !by_ext.is_empty() {
+        let mut ext_counts: Vec<_> = by_ext.iter().collect();
+        ext_counts.sort_by(|a, b| b.1.cmp(a.1));
+        let ext_parts: Vec<String> = ext_counts
+            .iter()
+            .take(5)
+            .map(|(ext, count)| format!("{} {}", count, ext))
+            .collect();
+        summary.push_str(&format!(" ({})", ext_parts.join(", ")));
+        if ext_counts.len() > 5 {
+            summary.push_str(&format!(", +{} more", ext_counts.len() - 5));
+        }
+    }
+    summary.push('\n');
+
+    (entries, summary)
+}
+
+/// Entry point called by ls::run on Windows.
+pub fn run_native(paths: &[&str], show_all: bool) -> Result<i32> {
+    let timer = crate::core::tracking::TimedExecution::start();
+    
+    let records = fetch_entries(paths, show_all)?;
+    let (entries, summary) = synthesize_output(records);
+
+    let is_tty = std::io::stdout().is_terminal();
+    let output = if is_tty {
+        format!("{}{}", entries, summary)
+    } else {
+        entries
+    };
+
+    print!("{}", output);
+
+    timer.track(
+        &format!("ls (native) {}", paths.join(" ")),
+        &format!("rtk ls {}", paths.join(" ")),
+        "", 
+        &output,
+    );
+
+    Ok(0)
+}
+
+fn get_extension(name: &str) -> String {
+    if let Some(pos) = name.rfind('.') {
+        name[pos..].to_string()
+    } else {
+        "no ext".to_string()
+    }
+}
+
+fn human_size(bytes: u64) -> String {
+    if bytes >= 1_048_576 {
+        format!("{:.1}M", bytes as f64 / 1_048_576.0)
+    } else if bytes >= 1024 {
+        format!("{:.1}K", bytes as f64 / 1024.0)
+    } else {
+        format!("{}B", bytes)
+    }
+}

--- a/src/cmds/system/ls_win.rs
+++ b/src/cmds/system/ls_win.rs
@@ -13,10 +13,10 @@ pub struct LsRecord {
 }
 
 /// Fetches file information from the filesystem using native Rust std::fs.
-pub fn fetch_entries(paths: &[&str], show_all: bool) -> Result<Vec<LsRecord>> {
+pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<Vec<LsRecord>> {
     let mut records = Vec::new();
-    let targets = if paths.is_empty() {
-        vec!["."]
+    let targets: Vec<String> = if paths.is_empty() {
+        vec![".".to_string()]
     } else {
         paths.to_vec()
     };
@@ -113,10 +113,10 @@ pub fn synthesize_output(records: Vec<LsRecord>) -> (String, String) {
 }
 
 /// Entry point called by ls::run on Windows.
-pub fn run_native(paths: &[&str], show_all: bool) -> Result<i32> {
+pub fn run_native(paths: Vec<String>, show_all: bool) -> Result<i32> {
     let timer = crate::core::tracking::TimedExecution::start();
     
-    let records = fetch_entries(paths, show_all)?;
+    let records = fetch_entries(&paths, show_all)?;
     let (entries, summary) = synthesize_output(records);
 
     let is_tty = std::io::stdout().is_terminal();

--- a/src/cmds/system/ls_win.rs
+++ b/src/cmds/system/ls_win.rs
@@ -6,7 +6,7 @@ use super::constants::NOISE_DIRS;
 use colored::Colorize; // 顯式引入 Trait
 
 /// Fetches file information from the filesystem using native Rust std::fs.
-pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<Vec<LsRecord>> {
+pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<(Vec<LsRecord>, Vec<LsRecord>)> {
     let mut records = Vec::new();
     let targets: Vec<String> = if paths.is_empty() {
         vec![".".to_string()]
@@ -34,11 +34,17 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<Vec<LsRecord>> 
                 }
 
                 if let Ok(metadata) = entry.metadata() {
+                    let timestamp = metadata.modified()
+                                            .ok()
+                                            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                                            .map(|d| d.as_secs() as i64)
+                                            .unwrap_or(0);
                     records.push(LsRecord {
                         extension: ls::get_extension(&name),
                         is_dir: metadata.is_dir(),
                         size: metadata.len(),
                         name,
+                        
                     });
                 }
             }
@@ -56,16 +62,27 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<Vec<LsRecord>> 
             });
         }
     }
-    Ok(records)
+    let (dirs, files): (Vec<LsRecord>, Vec<LsRecord>) = records
+        .into_iter() 
+        .partition(|r| r.is_dir);
+    Ok((dirs, files))
 }
 
 /// Entry point called by ls::run on Windows.
-pub fn run_native(paths: Vec<String>, show_all: bool) -> Result<i32> {
+pub fn run_native( paths: Vec<String>, show_all: bool ,  flags:Vec<String>) -> Result<i32> {
     eprintln!("{}","⚠️ Warning: ls on Windows is not fully supported yet. some flag may not work as expected. the program use system call to fetch file information.".yellow().bold());
     let timer = crate::core::tracking::TimedExecution::start();
     
-    let records = fetch_entries(&paths, show_all)?;
-    let (entries, summary) = ls::synthesize_output(records);
+    let (mut dirs, mut files) = fetch_entries(&paths, show_all)?;
+    if flags.contains(&"-r".to_string()) {
+        dirs.reverse();
+        files.reverse();
+    }
+    if flags.contains(&"-t".to_string()) {
+        dirs.sort_by(|a, b| b.size.cmp(&a.size));
+        files.sort_by(|a, b| b.size.cmp(&a.size));
+    }
+    let (entries, summary) = ls::synthesize_output(dirs,files);
 
     let is_tty = std::io::stdout().is_terminal();
     let output = if is_tty {

--- a/src/cmds/system/ls_win.rs
+++ b/src/cmds/system/ls_win.rs
@@ -1,16 +1,8 @@
-use super::constants::NOISE_DIRS;
+use super::ls::{self, LsRecord};
 use anyhow::Result;
-use std::collections::HashMap;
 use std::io::IsTerminal;
 use std::path::Path;
-
-/// Represents a single directory entry for token-optimized listing.
-pub struct LsRecord {
-    pub name: String,
-    pub is_dir: bool,
-    pub size: u64,
-    pub extension: String,
-}
+use super::constants::NOISE_DIRS;
 
 /// Fetches file information from the filesystem using native Rust std::fs.
 pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<Vec<LsRecord>> {
@@ -42,7 +34,7 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<Vec<LsRecord>> 
 
                 if let Ok(metadata) = entry.metadata() {
                     records.push(LsRecord {
-                        extension: get_extension(&name),
+                        extension: ls::get_extension(&name),
                         is_dir: metadata.is_dir(),
                         size: metadata.len(),
                         name,
@@ -56,7 +48,7 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<Vec<LsRecord>> 
                 .to_string_lossy()
                 .to_string();
             records.push(LsRecord {
-                extension: get_extension(&name),
+                extension: ls::get_extension(&name),
                 is_dir: false,
                 size: metadata.len(),
                 name,
@@ -66,58 +58,12 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<Vec<LsRecord>> 
     Ok(records)
 }
 
-/// Synthesizes the compact, token-optimized string from a list of records.
-pub fn synthesize_output(records: Vec<LsRecord>) -> (String, String) {
-    if records.is_empty() {
-        return ("(empty)\n".to_string(), String::new());
-    }
-
-    let mut dirs: Vec<&LsRecord> = records.iter().filter(|r| r.is_dir).collect();
-    let mut files: Vec<&LsRecord> = records.iter().filter(|r| !r.is_dir).collect();
-    let mut by_ext = HashMap::new();
-
-    for file in &files {
-        *by_ext.entry(file.extension.clone()).or_insert(0) += 1;
-    }
-
-    dirs.sort_by(|a, b| a.name.cmp(&b.name));
-    files.sort_by(|a, b| a.name.cmp(&b.name));
-
-    let mut entries = String::new();
-    for d in &dirs {
-        entries.push_str(&format!("{}/\n", d.name));
-    }
-    for f in &files {
-        entries.push_str(&format!("{}  {}\n", f.name, human_size(f.size)));
-    }
-
-    let mut summary = format!("\nSummary: {} files, {} dirs", files.len(), dirs.len());
-    if !by_ext.is_empty() {
-        let mut ext_counts: Vec<_> = by_ext.iter().collect();
-        ext_counts.sort_by(|a, b| b.1.cmp(a.1));
-        let ext_parts: Vec<String> = ext_counts
-            .iter()
-            .take(5)
-            .map(|(ext, count)| format!("{} {}", count, ext))
-            .collect();
-        summary.push_str(" (");
-        summary.push_str(&ext_parts.join(", "));
-        if ext_counts.len() > 5 {
-            summary.push_str(&format!(", +{} more", ext_counts.len() - 5));
-        }
-        summary.push(')');
-    }
-    summary.push('\n');
-
-    (entries, summary)
-}
-
 /// Entry point called by ls::run on Windows.
 pub fn run_native(paths: Vec<String>, show_all: bool) -> Result<i32> {
     let timer = crate::core::tracking::TimedExecution::start();
     
     let records = fetch_entries(&paths, show_all)?;
-    let (entries, summary) = synthesize_output(records);
+    let (entries, summary) = ls::synthesize_output(records);
 
     let is_tty = std::io::stdout().is_terminal();
     let output = if is_tty {
@@ -136,22 +82,4 @@ pub fn run_native(paths: Vec<String>, show_all: bool) -> Result<i32> {
     );
 
     Ok(0)
-}
-
-fn get_extension(name: &str) -> String {
-    if let Some(pos) = name.rfind('.') {
-        name[pos..].to_string()
-    } else {
-        "no ext".to_string()
-    }
-}
-
-fn human_size(bytes: u64) -> String {
-    if bytes >= 1_048_576 {
-        format!("{:.1}M", bytes as f64 / 1_048_576.0)
-    } else if bytes >= 1024 {
-        format!("{:.1}K", bytes as f64 / 1024.0)
-    } else {
-        format!("{}B", bytes)
-    }
 }

--- a/src/cmds/system/ls_win.rs
+++ b/src/cmds/system/ls_win.rs
@@ -1,6 +1,5 @@
-use crate::cmds::system::ls_format::LsRecordType;
 use super::constants::NOISE_DIRS;
-use super::ls::{self, LsRecord};
+use super::ls::{self, LsRecord, LsRecordType};
 
 use anyhow::Result;
 use colored::Colorize; 
@@ -9,6 +8,14 @@ use std::io::IsTerminal;
 use std::path::Path;
 use std::time::UNIX_EPOCH;
 
+pub fn estimate_raw_dir_output(records: &[LsRecord]) -> String {
+    let mut chars = 8; // "total 0\n"
+    for r in records {
+        // Heuristic: ~50 chars of fixed `ls -la` metadata overhead + filename length
+        chars += 45 + r.name.len();
+    }
+    " ".repeat(chars)
+}
 
 /// Fetches file information from the filesystem using native Rust std::fs.
 /// refactor required
@@ -131,7 +138,7 @@ fn warn_unsupported_flags(flags: &[String]) {
     }
 }
 
-pub fn run_native(paths: Vec<String>, show_all: bool, flags: Vec<String>) -> Result<(i32, String)> {
+pub fn run_native(paths: Vec<String>, show_all: bool, flags: Vec<String>) -> Result<(i32, String, String)> {
     warn_unsupported_flags(&flags);
 
     let active_flags: HashSet<char> = flags
@@ -160,7 +167,9 @@ pub fn run_native(paths: Vec<String>, show_all: bool, flags: Vec<String>) -> Res
         records.reverse();
     }
 
-    let (entries, summary) = ls::synthesize_output(records);
+    let raw_estimate = estimate_raw_dir_output(&records);
+
+    let (entries, summary) = super::ls_format::synthesize_output(records);
     let is_tty = std::io::stdout().is_terminal();
     let output = if is_tty {
         format!("{}{}", entries, summary)
@@ -168,5 +177,134 @@ pub fn run_native(paths: Vec<String>, show_all: bool, flags: Vec<String>) -> Res
         entries
     };
 
-    Ok((0, output))
+    Ok((0, output, raw_estimate))
 }
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+    use std::fs::{self, File};
+    use crate::cmds::system::ls_format::synthesize_output;
+
+    #[test]
+    fn test_fetch_entries_basic() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path();
+
+        fs::create_dir(dir_path.join("src")).unwrap();
+        File::create(dir_path.join("Cargo.toml")).unwrap();
+        File::create(dir_path.join("README.md")).unwrap();
+
+        let records = fetch_entries(&[dir_path.to_string_lossy().into_owned()], false).unwrap();
+        let (entries, _summary) = synthesize_output(records);
+
+        assert!(entries.contains("src/"));
+        assert!(entries.contains("Cargo.toml"));
+        assert!(entries.contains("README.md"));
+        assert!(!entries.contains("total"));
+    }
+
+    #[test]
+    fn test_fetch_entries_filters_noise() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path();
+
+        fs::create_dir(dir_path.join("node_modules")).unwrap();
+        fs::create_dir(dir_path.join(".git")).unwrap();
+        fs::create_dir(dir_path.join("target")).unwrap();
+        fs::create_dir(dir_path.join("src")).unwrap();
+        File::create(dir_path.join("main.rs")).unwrap();
+
+        let records = fetch_entries(&[dir_path.to_string_lossy().into_owned()], false).unwrap();
+        let (entries, _summary) = synthesize_output(records);
+
+        assert!(!entries.contains("node_modules"));
+        assert!(!entries.contains(".git"));
+        assert!(!entries.contains("target"));
+        assert!(entries.contains("src/"));
+        assert!(entries.contains("main.rs"));
+    }
+
+    #[test]
+    fn test_fetch_entries_show_all() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path();
+
+        fs::create_dir(dir_path.join(".git")).unwrap();
+        fs::create_dir(dir_path.join("src")).unwrap();
+
+        let records = fetch_entries(&[dir_path.to_string_lossy().into_owned()], true).unwrap();
+        let (entries, _summary) = synthesize_output(records);
+
+        assert!(entries.contains(".git/"));
+        assert!(entries.contains("src/"));
+    }
+
+    #[test]
+    fn test_fetch_entries_empty() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path();
+
+        let records = fetch_entries(&[dir_path.to_string_lossy().into_owned()], false).unwrap();
+        let (entries, summary) = synthesize_output(records);
+
+        assert_eq!(entries, "(empty)\n");
+        assert!(summary.is_empty());
+    }
+
+    #[test]
+    fn test_fetch_entries_symlinks() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path();
+
+        let target_path = dir_path.join("target.txt");
+        File::create(&target_path).unwrap();
+
+        let link_path = dir_path.join("link.txt");
+        
+        // Handling symlinks specifically on windows 
+        #[cfg(windows)]
+        let symlink_result = std::os::windows::fs::symlink_file(&target_path, &link_path);
+        
+        #[cfg(not(windows))]
+        let symlink_result = std::os::unix::fs::symlink(&target_path, &link_path);
+
+        if let Err(e) = symlink_result {
+            // Ignore error if symlink creation failed due to lack of administrative privileges on Windows
+            eprintln!("Failed to create symlink: {:?}", e);
+            return;
+        }
+
+        let records = fetch_entries(&[dir_path.to_string_lossy().into_owned()], false).unwrap();
+        let (entries, _summary) = synthesize_output(records);
+
+        // NOTE: This assertion will FAIL with your current code, as fetch_entries 
+        // does not append " -> target.txt" to the file name. 
+        assert!(
+            entries.contains("link.txt -> target.txt") || entries.contains(&format!("link.txt -> {}", target_path.to_string_lossy())),
+            "Symlink output does not include target, got entries:\n{}", 
+            entries
+        );
+    }
+
+    #[test]
+    fn test_fetch_entries_summary() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path();
+
+        fs::create_dir(dir_path.join("src")).unwrap();
+        File::create(dir_path.join("main.rs")).unwrap();
+        File::create(dir_path.join("lib.rs")).unwrap();
+        File::create(dir_path.join("Cargo.toml")).unwrap();
+
+        let records = fetch_entries(&[dir_path.to_string_lossy().into_owned()], false).unwrap();
+        let (_entries, summary) = synthesize_output(records);
+
+        assert!(summary.contains("Summary: 3 files, 1 dirs"));
+        assert!(summary.contains(".rs"));
+        assert!(summary.contains(".toml"));
+    }
+}
+

--- a/src/cmds/system/ls_win.rs
+++ b/src/cmds/system/ls_win.rs
@@ -4,6 +4,7 @@ use std::io::IsTerminal;
 use std::path::Path;
 use super::constants::NOISE_DIRS;
 use colored::Colorize; // 顯式引入 Trait
+use std::time::UNIX_EPOCH;
 
 /// Fetches file information from the filesystem using native Rust std::fs.
 pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<(Vec<LsRecord>, Vec<LsRecord>)> {
@@ -37,14 +38,14 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<(Vec<LsRecord>,
                     let timestamp = metadata.modified()
                                             .ok()
                                             .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-                                            .map(|d| d.as_secs() as i64)
+                                            .map(|d| d.as_secs() as u64)
                                             .unwrap_or(0);
                     records.push(LsRecord {
                         extension: ls::get_extension(&name),
                         is_dir: metadata.is_dir(),
                         size: metadata.len(),
                         name,
-                        
+                        timestamp
                     });
                 }
             }
@@ -54,11 +55,17 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<(Vec<LsRecord>,
                 .unwrap_or_default()
                 .to_string_lossy()
                 .to_string();
+            let timestamp = metadata.modified()
+                                    .ok()
+                                    .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                                    .map(|d| d.as_secs() as u64)
+                                    .unwrap_or(0);
             records.push(LsRecord {
                 extension: ls::get_extension(&name),
                 is_dir: false,
                 size: metadata.len(),
                 name,
+                timestamp
             });
         }
     }

--- a/src/cmds/system/ls_win.rs
+++ b/src/cmds/system/ls_win.rs
@@ -1,9 +1,10 @@
+use super::constants::NOISE_DIRS;
 use super::ls::{self, LsRecord};
 use anyhow::Result;
+use colored::Colorize; // 顯式引入 Trait
+use std::collections::HashSet;
 use std::io::IsTerminal;
 use std::path::Path;
-use super::constants::NOISE_DIRS;
-use colored::Colorize; // 顯式引入 Trait
 use std::time::UNIX_EPOCH;
 
 /// Fetches file information from the filesystem using native Rust std::fs.
@@ -35,17 +36,20 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<(Vec<LsRecord>,
                 }
 
                 if let Ok(metadata) = entry.metadata() {
-                    let timestamp = Some(metadata.modified()
-                                            .ok()
-                                            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-                                            .map(|d| d.as_secs() as u64)
-                                            .unwrap_or(0));
+                    let timestamp = Some(
+                        metadata
+                            .modified()
+                            .ok()
+                            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                            .map(|d| d.as_secs() as u64)
+                            .unwrap_or(0),
+                    );
                     records.push(LsRecord {
                         extension: ls::get_extension(&name),
                         is_dir: metadata.is_dir(),
                         size: metadata.len(),
                         name,
-                        timestamp
+                        timestamp,
                     });
                 }
             }
@@ -55,44 +59,80 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<(Vec<LsRecord>,
                 .unwrap_or_default()
                 .to_string_lossy()
                 .to_string();
-            let timestamp = Some(metadata.modified()
-                                    .ok()
-                                    .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
-                                    .map(|d| d.as_secs() as u64)
-                                    .unwrap_or(0));
+            let timestamp = Some(
+                metadata
+                    .modified()
+                    .ok()
+                    .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                    .map(|d| d.as_secs() as u64)
+                    .unwrap_or(0),
+            );
             records.push(LsRecord {
                 extension: ls::get_extension(&name),
                 is_dir: false,
                 size: metadata.len(),
                 name,
-                timestamp
+                timestamp,
             });
         }
     }
-    let (dirs, files): (Vec<LsRecord>, Vec<LsRecord>) = records
-        .into_iter() 
-        .partition(|r| r.is_dir);
+    let (dirs, files): (Vec<LsRecord>, Vec<LsRecord>) = records.into_iter().partition(|r| r.is_dir);
     Ok((dirs, files))
 }
+fn warn_unsupported_flags(flags: &[String]) {
+    let allowed_flags = ["-t", "-r", "-rt", "-tr"];
 
-/// Entry point called by ls::run on Windows.
-pub fn run_native( paths: Vec<String>, show_all: bool ,  flags:Vec<String>) -> Result<i32> {
+    let unsupported_flags: Vec<&String> = flags
+        .iter()
+        .filter(|f| !allowed_flags.contains(&f.as_str()))
+        .collect();
+
+    if !unsupported_flags.is_empty() {
+        eprintln!(
+            "{}",
+            format!(
+                "rtk ls: native Windows path ignores flags: {:?}",
+                unsupported_flags
+            )
+            .bold()
+            .yellow()
+        );
+    }
+}
+
+pub fn run_native(paths: Vec<String>, show_all: bool, flags: Vec<String>) -> Result<i32> {
+    warn_unsupported_flags(&flags);
     let timer = crate::core::tracking::TimedExecution::start();
-    
+
+    let active_flags: HashSet<char> = flags
+        .iter()
+        .filter(|f| f.starts_with('-') && !f.starts_with("--"))
+        .flat_map(|f| f.chars().skip(1)) // 跳過 '-'
+        .collect();
+
+    let is_r = active_flags.contains(&'r');
+    let is_t = active_flags.contains(&'t');
+
     let (mut dirs, mut files) = fetch_entries(&paths, show_all)?;
-    if flags.contains(&"-r".to_string()) {
+
+    let sort_fn = if is_t {
+        // 按時間倒序 (新到舊)
+        |a: &LsRecord, b: &LsRecord| b.timestamp.unwrap_or(0).cmp(&a.timestamp.unwrap_or(0))
+    } else {
+        // 按名稱正序
+        |a: &LsRecord, b: &LsRecord| a.name.cmp(&b.name)
+    };
+
+    dirs.sort_by(sort_fn);
+    files.sort_by(sort_fn);
+
+    // 3. 反轉邏輯
+    if is_r {
         dirs.reverse();
         files.reverse();
     }
-    if flags.contains(&"-t".to_string()) {
-        dirs.sort_by(|a, b| b.timestamp.unwrap_or(0).cmp(&a.timestamp.unwrap_or(0)));      
-        files.sort_by(|a, b| b.timestamp.unwrap_or(0).cmp(&a.timestamp.unwrap_or(0)));
-    }
-    if !flags.is_empty() && flags.iter().all(|f| f != "-t" && f != "-r"){
-        eprintln!("{}","rtk ls: native Windows path ignores flags: {flags:?}".bold().yellow())
-    }
-    let (entries, summary) = ls::synthesize_output(dirs,files);
 
+    let (entries, summary) = ls::synthesize_output((dirs, files));
     let is_tty = std::io::stdout().is_terminal();
     let output = if is_tty {
         format!("{}{}", entries, summary)
@@ -105,7 +145,7 @@ pub fn run_native( paths: Vec<String>, show_all: bool ,  flags:Vec<String>) -> R
     timer.track(
         &format!("ls (native) {}", paths.join(" ")),
         &format!("rtk ls {}", paths.join(" ")),
-        "", 
+        "",
         &output,
     );
 

--- a/src/cmds/system/ls_win.rs
+++ b/src/cmds/system/ls_win.rs
@@ -45,7 +45,7 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<Vec<LsRecord>> 
                     Ok(e) => e,
                     Err(_) => continue,
                 };
-                let name = entry.file_name().to_string_lossy().to_string();
+                let mut name = entry.file_name().to_string_lossy().to_string();
 
                 if name == "." || name == ".." {
                     continue;
@@ -57,6 +57,9 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<Vec<LsRecord>> 
 
                 if let Ok(file_type) = entry.file_type() {
                     let ls_file_type = if file_type.is_symlink() {
+                        if let Ok(target) = std::fs::read_link(entry.path()) {
+                            name = format!("{} -> {}", name, target.to_string_lossy());
+                        }
                         LsRecordType::SYMBOLINK
                     } else if file_type.is_dir() {
                         LsRecordType::DIRECTORY
@@ -86,13 +89,16 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<Vec<LsRecord>> 
                 }
             }
         } else {
-            let name = path
+            let mut name = path
                 .file_name()
                 .unwrap_or_default()
                 .to_string_lossy()
                 .to_string();
                 
             let ls_file_type = if metadata.is_symlink() {
+                if let Ok(target) = std::fs::read_link(path) {
+                    name = format!("{} -> {}", name, target.to_string_lossy());
+                }
                 LsRecordType::SYMBOLINK
             } else {
                 LsRecordType::FILE

--- a/src/cmds/system/ls_win.rs
+++ b/src/cmds/system/ls_win.rs
@@ -36,7 +36,7 @@ pub fn fetch_entries(paths: &[&str], show_all: bool) -> Result<Vec<LsRecord>> {
                     continue;
                 }
 
-                if !show_all && (name.starts_with('.') || NOISE_DIRS.iter().any(|noise| name == *noise)) {
+                if !show_all && NOISE_DIRS.iter().any(|noise| name == *noise) {
                     continue;
                 }
 
@@ -100,10 +100,12 @@ pub fn synthesize_output(records: Vec<LsRecord>) -> (String, String) {
             .take(5)
             .map(|(ext, count)| format!("{} {}", count, ext))
             .collect();
-        summary.push_str(&format!(" ({})", ext_parts.join(", ")));
+        summary.push_str(" (");
+        summary.push_str(&ext_parts.join(", "));
         if ext_counts.len() > 5 {
             summary.push_str(&format!(", +{} more", ext_counts.len() - 5));
         }
+        summary.push(')');
     }
     summary.push('\n');
 

--- a/src/cmds/system/ls_win.rs
+++ b/src/cmds/system/ls_win.rs
@@ -35,11 +35,11 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<(Vec<LsRecord>,
                 }
 
                 if let Ok(metadata) = entry.metadata() {
-                    let timestamp = metadata.modified()
+                    let timestamp = Some(metadata.modified()
                                             .ok()
                                             .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
                                             .map(|d| d.as_secs() as u64)
-                                            .unwrap_or(0);
+                                            .unwrap_or(0));
                     records.push(LsRecord {
                         extension: ls::get_extension(&name),
                         is_dir: metadata.is_dir(),
@@ -55,11 +55,11 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<(Vec<LsRecord>,
                 .unwrap_or_default()
                 .to_string_lossy()
                 .to_string();
-            let timestamp = metadata.modified()
+            let timestamp = Some(metadata.modified()
                                     .ok()
                                     .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
                                     .map(|d| d.as_secs() as u64)
-                                    .unwrap_or(0);
+                                    .unwrap_or(0));
             records.push(LsRecord {
                 extension: ls::get_extension(&name),
                 is_dir: false,

--- a/src/cmds/system/ls_win.rs
+++ b/src/cmds/system/ls_win.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 use std::io::IsTerminal;
 use std::path::Path;
 use super::constants::NOISE_DIRS;
+use colored::Colorize; // 顯式引入 Trait
 
 /// Fetches file information from the filesystem using native Rust std::fs.
 pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<Vec<LsRecord>> {
@@ -60,7 +61,7 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<Vec<LsRecord>> 
 
 /// Entry point called by ls::run on Windows.
 pub fn run_native(paths: Vec<String>, show_all: bool) -> Result<i32> {
-    eprintln!("⚠️ Warning: ls on Windows is not fully supported yet. some flag may not work as expected. the program use system call to fetch file information.");
+    eprintln!("{}","⚠️ Warning: ls on Windows is not fully supported yet. some flag may not work as expected. the program use system call to fetch file information.".yellow().bold());
     let timer = crate::core::tracking::TimedExecution::start();
     
     let records = fetch_entries(&paths, show_all)?;

--- a/src/cmds/system/ls_win.rs
+++ b/src/cmds/system/ls_win.rs
@@ -7,14 +7,6 @@ use std::io::IsTerminal;
 use std::path::Path;
 use std::time::UNIX_EPOCH;
 
-pub fn estimate_raw_dir_output(records: &[LsRecord]) -> String {
-    let mut chars = 8; // "total 0\n"
-    for r in records {
-        // Heuristic: ~50 chars of fixed `ls -la` metadata overhead + filename length
-        chars += 45 + r.name.len();
-    }
-    " ".repeat(chars)
-}
 
 pub fn generate_mock_raw_output(records: &[LsRecord]) -> String {
     let mut out = String::new();
@@ -381,31 +373,6 @@ mod tests {
     }
 
     #[test]
-    fn test_estimate_raw_dir_output() {
-        let records = vec![
-            LsRecord {
-                name: "file.txt".to_string(),
-                file_type: LsRecordType::FILE,
-                size: 100,
-                timestamp: Some(1000),
-                extension: "txt".to_string(),
-                octal_permissions: Some("644".to_string()),
-            },
-            LsRecord {
-                name: "dir".to_string(),
-                file_type: LsRecordType::DIRECTORY,
-                size: 0,
-                timestamp: Some(2000),
-                extension: "".to_string(),
-                octal_permissions: Some("755".to_string()),
-            },
-        ];
-        let estimate = estimate_raw_dir_output(&records);
-        assert_eq!(estimate.len(), 109);
-        assert_eq!(estimate, " ".repeat(109));
-    }
-
-    #[test]
     fn test_fetch_entries_single_file() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path();
@@ -493,8 +460,8 @@ mod tests {
 
         let options = FormatOptions { show_all: true, show_long: false, sort_by_time: true, reverse: true };
         let (exit_code, output, estimate) = run_native(
-            vec![path_str], 
-            options, 
+            vec![path_str.clone()], 
+            options.clone(), 
             vec!["-rt".to_string()]
         ).unwrap();
 
@@ -507,7 +474,11 @@ mod tests {
         if dir_path.join("symlink_c").exists() {
             assert!(output.contains("symlink_c"));
         }
-        
-        assert!(output.contains("Summary: "));
+
+        let records = fetch_entries(&[path_str], true).unwrap();
+        let (_entries, summary) = synthesize_output(records, &options);
+        assert!(summary.contains("Summary: "));
     }
 }
+
+

--- a/src/cmds/system/ls_win.rs
+++ b/src/cmds/system/ls_win.rs
@@ -1,9 +1,8 @@
 use super::constants::NOISE_DIRS;
-use super::ls::{self, LsRecord, LsRecordType};
+use super::ls::{self, LsRecord, LsRecordType, FormatOptions};
 
 use anyhow::Result;
 use colored::Colorize; 
-use std::collections::HashSet;
 use std::io::IsTerminal;
 use std::path::Path;
 use std::time::UNIX_EPOCH;
@@ -17,8 +16,55 @@ pub fn estimate_raw_dir_output(records: &[LsRecord]) -> String {
     " ".repeat(chars)
 }
 
+pub fn generate_mock_raw_output(records: &[LsRecord]) -> String {
+    let mut out = String::new();
+    let total_blocks = records.iter().map(|r| (r.size + 4095) / 4096 * 4).sum::<u64>();
+    out.push_str(&format!("total {}\n", total_blocks));
+
+    for r in records {
+        let type_char = match r.file_type {
+            LsRecordType::DIRECTORY => 'd',
+            LsRecordType::SYMBOLINK => 'l',
+            _ => '-',
+        };
+        let perms = match &r.octal_permissions {
+            Some(oct) => {
+                let mut p = String::new();
+                for c in oct.chars() {
+                    let val = c.to_digit(8).unwrap_or(0);
+                    p.push(if val & 4 != 0 { 'r' } else { '-' });
+                    p.push(if val & 2 != 0 { 'w' } else { '-' });
+                    p.push(if val & 1 != 0 { 'x' } else { '-' });
+                }
+                p
+            }
+            None => "rwxr-xr-x".to_string(),
+        };
+
+        out.push_str(&format!(
+            "{}{} 1 user staff {} Jan 1 12:00 {}\n",
+            type_char, perms, r.size, r.name
+        ));
+    }
+    out
+}
+
+fn is_file_hidden(name: &str, metadata: &std::fs::Metadata) -> bool {
+    if name.starts_with('.') {
+        return true;
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        (metadata.file_attributes() & 0x2) != 0
+    }
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
 /// Fetches file information from the filesystem using native Rust std::fs.
-/// refactor required
 pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<Vec<LsRecord>> {
     let mut records = Vec::new();
     let targets: Vec<String> = if paths.is_empty() {
@@ -40,7 +86,12 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<Vec<LsRecord>> 
         };
 
         if metadata.is_dir() {
-            for entry_res in std::fs::read_dir(path)? {
+            let resolved_path = match dunce::canonicalize(path) {
+                Ok(p) => p,
+                Err(_) => path.to_path_buf(),
+            };
+
+            for entry_res in std::fs::read_dir(&resolved_path)? {
                 let entry = match entry_res {
                     Ok(e) => e,
                     Err(_) => continue,
@@ -51,8 +102,11 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<Vec<LsRecord>> 
                     continue;
                 }
 
-                if !show_all && NOISE_DIRS.iter().any(|noise| name == *noise) {
-                    continue;
+                let meta = entry.metadata().or_else(|_| std::fs::symlink_metadata(entry.path())).ok();
+                if let Some(ref m) = meta {
+                    if !show_all && (is_file_hidden(&name, m) || NOISE_DIRS.iter().any(|noise| name == *noise)) {
+                        continue;
+                    }
                 }
 
                 if let Ok(file_type) = entry.file_type() {
@@ -67,17 +121,22 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<Vec<LsRecord>> 
                         LsRecordType::FILE
                     };
 
-                    let meta = entry.metadata().or_else(|_| std::fs::symlink_metadata(entry.path())).ok();
-                    let (size, timestamp) = if let Some(m) = meta {
+                    let (size, timestamp, is_readonly) = if let Some(ref m) = meta {
                         let ts = m.modified()
                             .ok()
                             .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
                             .map(|d| d.as_secs() as u64)
                             .unwrap_or(0);
-                        (m.len(), Some(ts))
+                        (m.len(), Some(ts), m.permissions().readonly())
                     } else {
-                        (0, None)
+                        (0, None, false)
                     };
+
+                    let octal_permissions = if is_readonly {
+                        if ls_file_type == LsRecordType::DIRECTORY { "555" } else { "444" }
+                    } else {
+                        if ls_file_type == LsRecordType::DIRECTORY { "755" } else { "644" }
+                    }.to_string();
 
                     records.push(LsRecord {
                         extension: ls::get_extension(&name),
@@ -85,6 +144,7 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<Vec<LsRecord>> 
                         size,
                         name,
                         timestamp,
+                        octal_permissions: Some(octal_permissions),
                     });
                 }
             }
@@ -112,31 +172,48 @@ pub fn fetch_entries(paths: &[String], show_all: bool) -> Result<Vec<LsRecord>> 
                     .map(|d| d.as_secs() as u64)
                     .unwrap_or(0),
             );
+
+            let is_readonly = metadata.permissions().readonly();
+            let octal_permissions = if is_readonly {
+                if ls_file_type == LsRecordType::DIRECTORY { "555" } else { "444" }
+            } else {
+                if ls_file_type == LsRecordType::DIRECTORY { "755" } else { "644" }
+            }.to_string();
+
             records.push(LsRecord {
                 extension: ls::get_extension(&name),
                 file_type: ls_file_type,
                 size: metadata.len(),
                 name,
                 timestamp,
+                octal_permissions: Some(octal_permissions),
             });
         }
     }
     Ok(records)
 }
+
 fn warn_unsupported_flags(flags: &[String]) {
-    let allowed_flags = ["-t", "-r", "-rt", "-tr"];
+    let mut unsupported = Vec::new();
+    for f in flags {
+        if f.starts_with("--") {
+            if f != "--all" && f != "--full-time" && f != "--format=long" && f != "--format=verbose" {
+                unsupported.push(f.clone());
+            }
+        } else if f.starts_with('-') && f != "-" {
+            let bad_chars: String = f.chars().skip(1).filter(|c| *c != 'a' && *c != 'l' && *c != 't' && *c != 'r' && *c != 'h').collect();
+            if !bad_chars.is_empty() {
+                unsupported.push(f.clone());
+            }
+        }
+    }
 
-    let unsupported_flags: Vec<&String> = flags
-        .iter()
-        .filter(|f| !allowed_flags.contains(&f.as_str()))
-        .collect();
-
-    if !unsupported_flags.is_empty() {
+    if !unsupported.is_empty() {
         eprintln!(
             "{}",
             format!(
                 "rtk ls: native Windows path ignores flags: {:?}",
-                unsupported_flags
+                unsupported
             )
             .bold()
             .yellow()
@@ -144,38 +221,26 @@ fn warn_unsupported_flags(flags: &[String]) {
     }
 }
 
-pub fn run_native(paths: Vec<String>, show_all: bool, flags: Vec<String>) -> Result<(i32, String, String)> {
+pub fn run_native(paths: Vec<String>, options: FormatOptions, flags: Vec<String>) -> Result<(i32, String, String)> {
     warn_unsupported_flags(&flags);
 
-    let active_flags: HashSet<char> = flags
-        .iter()
-        .filter(|f| f.starts_with('-') && !f.starts_with("--"))
-        .flat_map(|f| f.chars().skip(1)) // 跳過 '-'
-        .collect();
+    let mut records = fetch_entries(&paths, options.show_all)?;
 
-    let is_r = active_flags.contains(&'r');
-    let is_t = active_flags.contains(&'t');
-
-    let mut records = fetch_entries(&paths, show_all)?;
-
-    let sort_fn = if is_t {
-        //
+    let sort_fn = if options.sort_by_time {
         |a: &LsRecord, b: &LsRecord| b.timestamp.unwrap_or(0).cmp(&a.timestamp.unwrap_or(0))
     } else {
-        //
         |a: &LsRecord, b: &LsRecord| a.name.cmp(&b.name)
     };
 
     records.sort_by(sort_fn);
 
-    // 
-    if is_r {
+    if options.reverse {
         records.reverse();
     }
 
-    let raw_estimate = estimate_raw_dir_output(&records);
+    let raw_estimate = generate_mock_raw_output(&records);
 
-    let (entries, summary) = super::ls_format::synthesize_output(records);
+    let (entries, summary) = super::ls_format::synthesize_output(records, &options);
     let is_tty = std::io::stdout().is_terminal();
     let output = if is_tty {
         format!("{}{}", entries, summary)
@@ -204,7 +269,8 @@ mod tests {
         File::create(dir_path.join("README.md")).unwrap();
 
         let records = fetch_entries(&[dir_path.to_string_lossy().into_owned()], false).unwrap();
-        let (entries, _summary) = synthesize_output(records);
+        let options = FormatOptions::default();
+        let (entries, _summary) = synthesize_output(records, &options);
 
         assert!(entries.contains("src/"));
         assert!(entries.contains("Cargo.toml"));
@@ -224,7 +290,8 @@ mod tests {
         File::create(dir_path.join("main.rs")).unwrap();
 
         let records = fetch_entries(&[dir_path.to_string_lossy().into_owned()], false).unwrap();
-        let (entries, _summary) = synthesize_output(records);
+        let options = FormatOptions::default();
+        let (entries, _summary) = synthesize_output(records, &options);
 
         assert!(!entries.contains("node_modules"));
         assert!(!entries.contains(".git"));
@@ -242,7 +309,8 @@ mod tests {
         fs::create_dir(dir_path.join("src")).unwrap();
 
         let records = fetch_entries(&[dir_path.to_string_lossy().into_owned()], true).unwrap();
-        let (entries, _summary) = synthesize_output(records);
+        let options = FormatOptions { show_all: true, show_long: false, sort_by_time: false, reverse: false };
+        let (entries, _summary) = synthesize_output(records, &options);
 
         assert!(entries.contains(".git/"));
         assert!(entries.contains("src/"));
@@ -254,7 +322,8 @@ mod tests {
         let dir_path = dir.path();
 
         let records = fetch_entries(&[dir_path.to_string_lossy().into_owned()], false).unwrap();
-        let (entries, summary) = synthesize_output(records);
+        let options = FormatOptions::default();
+        let (entries, summary) = synthesize_output(records, &options);
 
         assert_eq!(entries, "(empty)\n");
         assert!(summary.is_empty());
@@ -270,7 +339,6 @@ mod tests {
 
         let link_path = dir_path.join("link.txt");
         
-        // Handling symlinks specifically on windows 
         #[cfg(windows)]
         let symlink_result = std::os::windows::fs::symlink_file(&target_path, &link_path);
         
@@ -278,16 +346,14 @@ mod tests {
         let symlink_result = std::os::unix::fs::symlink(&target_path, &link_path);
 
         if let Err(e) = symlink_result {
-            // Ignore error if symlink creation failed due to lack of administrative privileges on Windows
             eprintln!("Failed to create symlink: {:?}", e);
             return;
         }
 
         let records = fetch_entries(&[dir_path.to_string_lossy().into_owned()], false).unwrap();
-        let (entries, _summary) = synthesize_output(records);
+        let options = FormatOptions::default();
+        let (entries, _summary) = synthesize_output(records, &options);
 
-        // NOTE: This assertion will FAIL with your current code, as fetch_entries 
-        // does not append " -> target.txt" to the file name. 
         assert!(
             entries.contains("link.txt -> target.txt") || entries.contains(&format!("link.txt -> {}", target_path.to_string_lossy())),
             "Symlink output does not include target, got entries:\n{}", 
@@ -306,13 +372,15 @@ mod tests {
         File::create(dir_path.join("Cargo.toml")).unwrap();
 
         let records = fetch_entries(&[dir_path.to_string_lossy().into_owned()], false).unwrap();
-        let (_entries, summary) = synthesize_output(records);
+        let options = FormatOptions::default();
+        let (_entries, summary) = synthesize_output(records, &options);
 
         assert!(summary.contains("Summary: 3 files, 1 dirs"));
         assert!(summary.contains(".rs"));
         assert!(summary.contains(".toml"));
     }
-        #[test]
+
+    #[test]
     fn test_estimate_raw_dir_output() {
         let records = vec![
             LsRecord {
@@ -321,6 +389,7 @@ mod tests {
                 size: 100,
                 timestamp: Some(1000),
                 extension: "txt".to_string(),
+                octal_permissions: Some("644".to_string()),
             },
             LsRecord {
                 name: "dir".to_string(),
@@ -328,14 +397,10 @@ mod tests {
                 size: 0,
                 timestamp: Some(2000),
                 extension: "".to_string(),
+                octal_permissions: Some("755".to_string()),
             },
         ];
         let estimate = estimate_raw_dir_output(&records);
-        // Calculation: 
-        // Base = 8 ("total 0\n")
-        // file.txt length (8) + 45 = 53
-        // dir length (3) + 45 = 48
-        // 8 + 53 + 48 = 109 spaces
         assert_eq!(estimate.len(), 109);
         assert_eq!(estimate, " ".repeat(109));
     }
@@ -348,7 +413,6 @@ mod tests {
         let file_path = dir_path.join("single.txt");
         File::create(&file_path).unwrap();
 
-        // Testing the `} else {` branch of fetch_entries
         let records = fetch_entries(&[file_path.to_string_lossy().into_owned()], false).unwrap();
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].name, "single.txt");
@@ -360,8 +424,6 @@ mod tests {
         let dir = tempdir().unwrap();
         let dir_path = dir.path();
 
-        // Create files in specific order but with non-alphabetical names.
-        // We add slight sleeps to guarantee different OS file modification times.
         File::create(dir_path.join("c.txt")).unwrap();
         std::thread::sleep(std::time::Duration::from_millis(1050));
         
@@ -373,28 +435,32 @@ mod tests {
         let path_str = dir_path.to_string_lossy().into_owned();
 
         // 1. Default (alphabetical: a.txt -> b.txt -> c.txt)
-        let (_, output_default, _) = run_native(vec![path_str.clone()], false, vec![]).unwrap();
+        let options_default = FormatOptions::default();
+        let (_, output_default, _) = run_native(vec![path_str.clone()], options_default, vec![]).unwrap();
         let pos_a = output_default.find("a.txt").unwrap();
         let pos_b = output_default.find("b.txt").unwrap();
         let pos_c = output_default.find("c.txt").unwrap();
         assert!(pos_a < pos_b && pos_b < pos_c, "Default sort should be alphabetical");
 
         // 2. Reverse alphabetical (-r: c.txt -> b.txt -> a.txt)
-        let (_, output_rev, _) = run_native(vec![path_str.clone()], false, vec!["-r".to_string()]).unwrap();
+        let options_rev = FormatOptions { show_all: false, show_long: false, sort_by_time: false, reverse: true };
+        let (_, output_rev, _) = run_native(vec![path_str.clone()], options_rev, vec!["-r".to_string()]).unwrap();
         let pos_a_r = output_rev.find("a.txt").unwrap();
         let pos_b_r = output_rev.find("b.txt").unwrap();
         let pos_c_r = output_rev.find("c.txt").unwrap();
         assert!(pos_c_r < pos_b_r && pos_b_r < pos_a_r, "Reverse sort (-r) should be reverse alphabetical");
 
         // 3. Time sort (-t: newest first -> b.txt -> a.txt -> c.txt)
-        let (_, output_time, _) = run_native(vec![path_str.clone()], false, vec!["-t".to_string()]).unwrap();
+        let options_time = FormatOptions { show_all: false, show_long: false, sort_by_time: true, reverse: false };
+        let (_, output_time, _) = run_native(vec![path_str.clone()], options_time, vec!["-t".to_string()]).unwrap();
         let pos_a_t = output_time.find("a.txt").unwrap();
         let pos_b_t = output_time.find("b.txt").unwrap();
         let pos_c_t = output_time.find("c.txt").unwrap();
         assert!(pos_b_t < pos_a_t && pos_a_t < pos_c_t, "Time sort (-t) should be newest first");
 
         // 4. Reverse time sort (-rt: oldest first -> c.txt -> a.txt -> b.txt)
-        let (_, output_rev_time, _) = run_native(vec![path_str.clone()], false, vec!["-rt".to_string()]).unwrap();
+        let options_rev_time = FormatOptions { show_all: false, show_long: false, sort_by_time: true, reverse: true };
+        let (_, output_rev_time, _) = run_native(vec![path_str.clone()], options_rev_time, vec!["-rt".to_string()]).unwrap();
         let pos_a_rt = output_rev_time.find("a.txt").unwrap();
         let pos_b_rt = output_rev_time.find("b.txt").unwrap();
         let pos_c_rt = output_rev_time.find("c.txt").unwrap();
@@ -406,16 +472,13 @@ mod tests {
         let dir = tempdir().unwrap();
         let dir_path = dir.path();
 
-        // Create Directory
         fs::create_dir(dir_path.join("folder_b")).unwrap();
         std::thread::sleep(std::time::Duration::from_millis(50));
 
-        // Create File
         let file_path = dir_path.join("file_a.txt");
         File::create(&file_path).unwrap();
         std::thread::sleep(std::time::Duration::from_millis(50));
 
-        // Create Symlink
         let link_path = dir_path.join("symlink_c");
         #[cfg(windows)]
         let symlink_result = std::os::windows::fs::symlink_file(&file_path, &link_path);
@@ -428,17 +491,16 @@ mod tests {
 
         let path_str = dir_path.to_string_lossy().into_owned();
 
-        // Run holistic function with -rt flags and show_all = true
+        let options = FormatOptions { show_all: true, show_long: false, sort_by_time: true, reverse: true };
         let (exit_code, output, estimate) = run_native(
             vec![path_str], 
-            true, 
+            options, 
             vec!["-rt".to_string()]
         ).unwrap();
 
         assert_eq!(exit_code, 0);
         assert!(!estimate.is_empty(), "Token estimate string should be generated");
         
-        // Assert output contains all elements
         assert!(output.contains("folder_b/"));
         assert!(output.contains("file_a.txt"));
         
@@ -446,12 +508,6 @@ mod tests {
             assert!(output.contains("symlink_c"));
         }
         
-        // Because synthesize_output explicitly formats into sections (Dirs -> Symlinks -> Files)
-        // the sorting flags only apply to the items *within* those sections. 
-        // We assert the summary appears at the bottom.
         assert!(output.contains("Summary: "));
     }
-
-
 }
-


### PR DESCRIPTION
# Feat: Native Windows `ls` Fallback with SRP-based Refactor

## Summary
This PR implements a native Rust fallback for the `ls` command on Windows environments and refactors the underlying logic to adhere to the Single Responsibility Principle (SRP).

## Technical Rationale
### 1. Windows Native Support
Windows lacks a native `ls` binary. To ensure `rtk` remains functional across all environments without external dependencies, this PR introduces a native implementation leveraging `std::fs`. This ensures the core directory listing functionality is available out-of-the-box on Windows.

### 2. SRP Refactor & Modular Architecture
The implementation has been decoupled into a dedicated `ls_win` module to improve maintainability and testability. The logic is now partitioned into discrete units:
- **`fetch_entries`**: Responsible for filesystem traversal and metadata retrieval.
- **`synthesize_output`**: A pure transformation layer that handles sorting, extension aggregation, and output formatting.
- **`run_native`**: The entry-point orchestrator managing timing and terminal I/O.
- **`LsRecord` Struct**: Serves as the data contract between the filesystem and the synthesizer.

### 3. Platform Consistency & Fixes
- **Filter Alignment**: Standardized the Windows filtering logic to match Unix behavior. Generic dot-file hiding has been replaced with targeted `NOISE_DIRS` filtering, ensuring high-signal files (like `.cargo-lock`) remain visible while maintaining LLM-friendly output.
- **Summary Synthesis Fix**: Corrected a formatting regression in the extension summary where the closing parenthesis was prematurely appended when truncating the extension list.

## Verification
- [ ] Validated native `ls` execution on Windows (fallback triggers when binary is missing).
- [ ] Verified output consistency between Windows and Linux platforms (filtering and formatting).
### test log  

for windows platform
```
> .\target\release\rtk.exe ls
.claude/
.github/
.rtk/
Formula/
docs/
hooks/
openclaw/
scripts/
src/
tests/
.gitignore  553B
.release-please-manifest.json  23B
CHANGELOG.md  74.2K
CLAUDE.md  7.4K
CONTRIBUTING.md  12.6K
Cargo.lock  48.8K
Cargo.toml  1.7K
DISCLAIMER.md  2.2K
INSTALL.md  11.4K
LICENSE  10.7K
README.md  20.5K
README_es.md  5.4K
README_fr.md  6.7K
README_ja.md  5.8K
README_ko.md  5.4K
README_zh.md  5.3K
SECURITY.md  7.6K
build.rs  2.4K
install.sh  2.9K
release-please-config.json  191B

Summary: 20 files, 10 dirs (12 .md, 2 .json, 1 .lock, 1 no ext, 1 .sh, +3 more)

```
for ubuntu platform
```
$ ./target/release/rtk ls
.claude/
.github/
.rtk/
Formula/
docs/
hooks/
openclaw/
scripts/
src/
tests/
.gitignore  553B
.release-please-manifest.json  23B
CHANGELOG.md  74.2K
CLAUDE.md  7.4K
CONTRIBUTING.md  12.6K
Cargo.lock  48.8K
Cargo.toml  1.7K
DISCLAIMER.md  2.2K
INSTALL.md  11.4K
LICENSE  10.7K
README.md  20.5K
README_es.md  5.4K
README_fr.md  6.7K
README_ja.md  5.8K
README_ko.md  5.4K
README_zh.md  5.3K
SECURITY.md  7.6K
build.rs  2.4K
install.sh  2.9K
release-please-config.json  191B

Summary: 20 files, 10 dirs (12 .md, 2 .json, 1 .gitignore, 1 .toml, 1 .lock, +3 more)
```
