### PR TITLE
fix(hook): prevent flag injection in rtk-rewrite hooks (#1350)

### DIFF
--- a/hooks/claude/rtk-rewrite.sh
+++ b/hooks/claude/rtk-rewrite.sh
@@ -52,7 +52,10 @@ if [ -z "$CMD" ]; then
 fi
 
 # Delegate all rewrite + permission logic to the Rust binary.
-REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null)
+# The `--` terminator is REQUIRED: without it, a command like "--help" or "-h"
+# would be interpreted by clap as a flag to `rtk rewrite`, causing the help text
+# to be emitted as the rewritten command and fed back to the agent (issue #1350).
+REWRITTEN=$(rtk rewrite -- "$CMD" 2>/dev/null)
 EXIT_CODE=$?
 
 case $EXIT_CODE in

--- a/hooks/claude/test-rtk-rewrite.sh
+++ b/hooks/claude/test-rtk-rewrite.sh
@@ -327,6 +327,34 @@ test_rewrite "node (no pattern)" \
 
 echo ""
 
+# ---- SECTION 5b: Flag injection safety (#1350) ----
+# Without the `--` terminator before "$CMD", an input like "--help" would be
+# interpreted by clap as a flag to `rtk rewrite`, causing the help text to be
+# emitted as the "rewritten" command and shell-executed by the agent.
+# Each of these inputs must produce NO rewrite.
+echo "--- Flag injection safety (#1350) ---"
+test_rewrite "flag injection: --help must not trigger clap help" \
+  "--help" \
+  ""
+
+test_rewrite "flag injection: -h must not trigger clap short help" \
+  "-h" \
+  ""
+
+test_rewrite "flag injection: --version must not trigger clap version" \
+  "--version" \
+  ""
+
+test_rewrite "flag injection: -V must not trigger clap short version" \
+  "-V" \
+  ""
+
+test_rewrite "flag injection: lone -- must not crash the hook" \
+  "--" \
+  ""
+
+echo ""
+
 # ---- SECTION 6: Audit logging ----
 echo "--- Audit logging (RTK_HOOK_AUDIT=1) ---"
 

--- a/hooks/cursor/rtk-rewrite.sh
+++ b/hooks/cursor/rtk-rewrite.sh
@@ -40,7 +40,10 @@ fi
 
 # Delegate all rewrite logic to the Rust binary.
 # rtk rewrite exits 1 when there's no rewrite — hook passes through silently.
-REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null) || { echo '{}'; exit 0; }
+# The `--` terminator is REQUIRED: without it, a command like "--help" or "-h"
+# would be interpreted by clap as a flag to `rtk rewrite`, causing the help text
+# to be emitted as the rewritten command and fed back to the agent (issue #1350).
+REWRITTEN=$(rtk rewrite -- "$CMD" 2>/dev/null) || { echo '{}'; exit 0; }
 
 # No change — nothing to do.
 if [ "$CMD" = "$REWRITTEN" ]; then

--- a/src/main.rs
+++ b/src/main.rs
@@ -2782,6 +2782,38 @@ mod tests {
         }
     }
 
+    /// SECURITY: Hooks call `rtk rewrite -- "$CMD"` to prevent flag injection.
+    /// Without the `--` terminator, a command like "--help" or "-h" would be
+    /// interpreted by clap as a flag to the `rewrite` subcommand — clap would
+    /// print help text and exit 0, the hook would then feed that help text
+    /// back to the agent as the rewritten command, which is shell-executed.
+    /// See issue #1350. This test asserts that `--` causes hyphen-prefixed
+    /// inputs to be captured as positional args rather than triggering clap's
+    /// built-in help/version paths.
+    #[test]
+    fn test_rewrite_clap_double_dash_blocks_flag_injection() {
+        let injection_inputs = ["--help", "-h", "--version", "-V"];
+        for injected in injection_inputs {
+            let result = Cli::try_parse_from(["rtk", "rewrite", "--", injected]);
+            assert!(
+                result.is_ok(),
+                "`rtk rewrite -- {injected:?}` must parse without triggering clap"
+            );
+            if let Ok(cli) = result {
+                match cli.command {
+                    Commands::Rewrite { ref args } => {
+                        assert_eq!(
+                            args,
+                            &vec![injected.to_string()],
+                            "{injected:?} must be captured as a positional arg, not a flag"
+                        );
+                    }
+                    _ => panic!("expected Rewrite command"),
+                }
+            }
+        }
+    }
+
     #[test]
     fn test_merge_filters_with_no_args() {
         let filters = vec![];


### PR DESCRIPTION
## Summary

Fixes #1350.

- Add `--` end-of-options terminator before `"$CMD"` in `hooks/claude/rtk-rewrite.sh:55` and `hooks/cursor/rtk-rewrite.sh:43` (same bug in both hooks).
- An LLM-generated command starting with `-`/`--` (e.g. `--help`) would otherwise be intercepted by clap as a flag to `rtk rewrite`, causing the help text to be emitted as the "rewritten" command and fed back to the agent for shell execution.
- Adding `--` makes clap treat `$CMD` as a positional argument, closing the injection path.

## Test plan

- [x] `cargo fmt --all --check && cargo clippy --all-targets && cargo test` — 1591 passed, 6 ignored (baseline was 1590 pass, +1 from new test)
- [x] New Rust CLI parser test `test_rewrite_clap_double_dash_blocks_flag_injection` covers `--help`, `-h`, `--version`, `-V`
- [x] New bash regression tests in `hooks/claude/test-rtk-rewrite.sh` (5 flag-injection cases, all pass against the patched hook)
- [x] Manual verification: `rtk rewrite "--help"` emits help text (bug), `rtk rewrite -- "--help"` emits nothing with exit 1 (fix)

## Files changed

| File | Change |
|------|--------|
| `hooks/claude/rtk-rewrite.sh` | Add `--` before `"$CMD"` + comment explaining why |
| `hooks/cursor/rtk-rewrite.sh` | Same fix for the Cursor hook (identical bug) |
| `hooks/claude/test-rtk-rewrite.sh` | 5 new bash tests under "Flag injection safety (#1350)" |
| `src/main.rs` | 1 new `#[test]` verifying clap + `--` behavior for `Commands::Rewrite` |

## Notes

- Pre-existing bash hook test failures (7 audit-logging + 1 compound-command) are unrelated and reproduce on `develop` without this PR.
- No CHANGELOG.md edits — release-please manages it.

Generated by Claude Code

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
