### PR TITLE
fix: head/tail multi-file rewrite falls back to native command (#1362)

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -62,12 +62,16 @@ lazy_static! {
     // --git-dir <dir>, --work-tree <dir>, and flag-only options (#163)
     static ref GIT_GLOBAL_OPT: Regex =
         Regex::new(r"^(?:(?:-C\s+\S+|-c\s+\S+|--git-dir(?:=\S+|\s+\S+)|--work-tree(?:=\S+|\s+\S+)|--no-pager|--no-optional-locks|--bare|--literal-pathspecs)\s+)+").unwrap();
-    static ref HEAD_N: Regex = Regex::new(r"^head\s+-(\d+)\s+(.+)$").unwrap();
-    static ref HEAD_LINES: Regex = Regex::new(r"^head\s+--lines=(\d+)\s+(.+)$").unwrap();
-    static ref TAIL_N: Regex = Regex::new(r"^tail\s+-(\d+)\s+(.+)$").unwrap();
-    static ref TAIL_N_SPACE: Regex = Regex::new(r"^tail\s+-n\s+(\d+)\s+(.+)$").unwrap();
-    static ref TAIL_LINES_EQ: Regex = Regex::new(r"^tail\s+--lines=(\d+)\s+(.+)$").unwrap();
-    static ref TAIL_LINES_SPACE: Regex = Regex::new(r"^tail\s+--lines\s+(\d+)\s+(.+)$").unwrap();
+    // Issue #1362: each capture expects a SINGLE file argument (`\S+$`). Multi-file
+    // invocations like `head -3 a b c` fail to match so the segment is passed through
+    // to the native `head`/`tail` binary — which already handles multi-file with
+    // `==> name <==` banners that `rtk read --max-lines` cannot reproduce.
+    static ref HEAD_N: Regex = Regex::new(r"^head\s+-(\d+)\s+(\S+)$").unwrap();
+    static ref HEAD_LINES: Regex = Regex::new(r"^head\s+--lines=(\d+)\s+(\S+)$").unwrap();
+    static ref TAIL_N: Regex = Regex::new(r"^tail\s+-(\d+)\s+(\S+)$").unwrap();
+    static ref TAIL_N_SPACE: Regex = Regex::new(r"^tail\s+-n\s+(\d+)\s+(\S+)$").unwrap();
+    static ref TAIL_LINES_EQ: Regex = Regex::new(r"^tail\s+--lines=(\d+)\s+(\S+)$").unwrap();
+    static ref TAIL_LINES_SPACE: Regex = Regex::new(r"^tail\s+--lines\s+(\d+)\s+(\S+)$").unwrap();
 }
 
 const GOLANGCI_GLOBAL_OPT_WITH_VALUE: &[&str] = &[
@@ -1666,6 +1670,48 @@ mod tests {
     #[test]
     fn test_rewrite_tail_plain_file_skipped() {
         assert_eq!(rewrite_command("tail src/main.rs", &[]), None);
+    }
+
+    // --- Issue #1362: head/tail with multiple files falls back to native command ---
+    //
+    // `rtk read <file> --max-lines N` only accepts a single positional file path in
+    // a shape that maps cleanly to `head -N`. Rewriting `head -N a b c` to
+    // `rtk read a b c --max-lines N` previously produced a command where `rtk read`
+    // would concatenate the files without the `==> name <==` banners that native
+    // `head` emits, so the fix is to skip the rewrite and let the shell run the
+    // real `head`/`tail` binary.
+
+    #[test]
+    fn test_rewrite_head_numeric_flag_multi_file_skipped() {
+        assert_eq!(rewrite_command("head -3 /tmp/a /tmp/b /tmp/c", &[]), None);
+    }
+
+    #[test]
+    fn test_rewrite_head_lines_long_flag_multi_file_skipped() {
+        assert_eq!(
+            rewrite_command("head --lines=50 src/main.rs src/lib.rs", &[]),
+            None
+        );
+    }
+
+    #[test]
+    fn test_rewrite_tail_numeric_flag_multi_file_skipped() {
+        assert_eq!(rewrite_command("tail -20 a.log b.log", &[]), None);
+    }
+
+    #[test]
+    fn test_rewrite_tail_n_space_flag_multi_file_skipped() {
+        assert_eq!(rewrite_command("tail -n 12 a.log b.log c.log", &[]), None);
+    }
+
+    #[test]
+    fn test_rewrite_tail_lines_eq_multi_file_skipped() {
+        assert_eq!(rewrite_command("tail --lines=7 a.log b.log", &[]), None);
+    }
+
+    #[test]
+    fn test_rewrite_tail_lines_space_multi_file_skipped() {
+        assert_eq!(rewrite_command("tail --lines 7 a.log b.log", &[]), None);
     }
 
     // --- New registry entries ---


### PR DESCRIPTION
## Summary

- Tightens the `head`/`tail` regexes in `src/discover/registry.rs` so that each one only matches a **single** file argument (`\S+$` instead of `(.+)$`).
- When >1 file is passed, `rewrite_line_range` now returns `None` and the shell runs the native `head` / `tail` binary, which already emits the `==> name <==` banners that `rtk read --max-lines` cannot reproduce.
- Closes #1362 — same class as the `cat` multi-file fallback in #989.

Before: `head -3 /tmp/a /tmp/b /tmp/c` was rewritten to `rtk read /tmp/a /tmp/b /tmp/c --max-lines 3`, silently mis-handled and occasionally falling through to the system `read` builtin on macOS.
After: the same command is not rewritten; native `head` runs unchanged with correct multi-file banners.

## Test plan

- [x] `cargo fmt --all --check && cargo clippy --all-targets && cargo test` — 1596 pass / 0 fail / 6 ignored (6 new tests added, no clippy warnings introduced in `src/discover/registry.rs`).
- [x] Manual: `rtk rewrite "head -3 /tmp/a /tmp/b /tmp/c"` now exits 1 (no rewrite); single-file form still rewrites to `rtk read /tmp/a --max-lines 3` as before.
- [x] Regression: `head -20 src/main.rs`, `tail -n 12 src/lib.rs`, `tail --lines=7 src/lib.rs`, `head --lines=50 src/lib.rs` all still rewrite correctly.

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
