### PR TITLE
fix(hooks): skip hook-installed warning on Windows

### DIFF
--- a/src/hooks/hook_check.rs
+++ b/src/hooks/hook_check.rs
@@ -26,6 +26,11 @@ pub enum HookStatus {
 /// Return the current hook status without printing anything.
 /// Returns `Ok` if no Claude Code is detected (not applicable).
 pub fn status() -> HookStatus {
+    // Hooks are Unix-only; on Windows, users run `rtk init --claude-md` instead.
+    // Showing a "No hook installed" warning they can't resolve is not helpful.
+    #[cfg(windows)]
+    return HookStatus::Ok;
+
     // Don't warn users who don't have Claude Code installed
     let home = match dirs::home_dir() {
         Some(h) => h,
@@ -263,6 +268,14 @@ mod tests {
         std::fs::create_dir_all(tmp.path().join(CODEX_DIR)).unwrap();
         std::fs::create_dir_all(tmp.path().join(GEMINI_DIR)).unwrap();
         assert!(!other_integration_installed(tmp.path()));
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_status_always_ok_on_windows() {
+        // Hooks are not supported on Windows; status() must never trigger the
+        // "No hook installed" warning path, even when .claude exists.
+        assert_eq!(status(), HookStatus::Ok);
     }
 
     #[test]


### PR DESCRIPTION
Hooks require Unix; Windows users fall back to `--claude-md` mode after running `rtk init -g`. Since there is no way to install a hook on Windows, the "No hook installed" warning shows on every command with no way to suppress it.

The fix is a single `#[cfg(windows)]` guard in `status()` that returns `HookStatus::Ok` unconditionally. No env var, no config key — the platform already tells us hooks aren't applicable.

Added a `#[cfg(windows)]` test to document the invariant. All existing tests pass.

Closes #1373