### PR TITLE
fix(discover): normalize venv/absolute paths with binary preservation (#1053)

### DIFF
--- a/src/cmds/python/mypy_cmd.rs
+++ b/src/cmds/python/mypy_cmd.rs
@@ -1,19 +1,21 @@
 //! Filters mypy type-checking output, grouping errors by file.
 
 use crate::core::runner;
-use crate::core::utils::{resolved_command, strip_ansi, tool_exists, truncate};
+use crate::core::utils::{override_command, resolved_command, strip_ansi, tool_exists, truncate};
 use anyhow::Result;
 use regex::Regex;
 use std::collections::HashMap;
 
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
-    let mut cmd = if tool_exists("mypy") {
-        resolved_command("mypy")
-    } else {
-        let mut c = resolved_command("python3");
-        c.arg("-m").arg("mypy");
-        c
-    };
+    let mut cmd = override_command("mypy").unwrap_or_else(|| {
+        if tool_exists("mypy") {
+            resolved_command("mypy")
+        } else {
+            let mut c = resolved_command("python3");
+            c.arg("-m").arg("mypy");
+            c
+        }
+    });
 
     for arg in args {
         cmd.arg(arg);

--- a/src/cmds/python/pip_cmd.rs
+++ b/src/cmds/python/pip_cmd.rs
@@ -17,8 +17,12 @@ struct Package {
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
-    // Auto-detect uv vs pip
-    let use_uv = tool_exists("uv");
+    // Honor explicit binary path from rewrite engine (#1053), otherwise auto-detect
+    let has_bin_override = std::env::var("RTK_BIN_PATH")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .is_some();
+    let use_uv = !has_bin_override && tool_exists("uv");
     let base_cmd = if use_uv { "uv" } else { "pip" };
 
     if verbose > 0 && use_uv {
@@ -51,8 +55,17 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     Ok(exit_code)
 }
 
+fn pip_resolved(base_cmd: &str) -> std::process::Command {
+    if let Ok(bin) = std::env::var("RTK_BIN_PATH") {
+        if !bin.is_empty() {
+            return std::process::Command::new(bin);
+        }
+    }
+    resolved_command(base_cmd)
+}
+
 fn run_list(base_cmd: &str, args: &[String], verbose: u8) -> Result<(String, String, i32)> {
-    let mut cmd = resolved_command(base_cmd);
+    let mut cmd = pip_resolved(base_cmd);
 
     if base_cmd == "uv" {
         cmd.arg("pip");
@@ -80,7 +93,7 @@ fn run_list(base_cmd: &str, args: &[String], verbose: u8) -> Result<(String, Str
 }
 
 fn run_outdated(base_cmd: &str, args: &[String], verbose: u8) -> Result<(String, String, i32)> {
-    let mut cmd = resolved_command(base_cmd);
+    let mut cmd = pip_resolved(base_cmd);
 
     if base_cmd == "uv" {
         cmd.arg("pip");
@@ -108,7 +121,7 @@ fn run_outdated(base_cmd: &str, args: &[String], verbose: u8) -> Result<(String,
 }
 
 fn run_passthrough(base_cmd: &str, args: &[String], verbose: u8) -> Result<(String, String, i32)> {
-    let mut cmd = resolved_command(base_cmd);
+    let mut cmd = pip_resolved(base_cmd);
 
     if base_cmd == "uv" {
         cmd.arg("pip");

--- a/src/cmds/python/pytest_cmd.rs
+++ b/src/cmds/python/pytest_cmd.rs
@@ -1,7 +1,7 @@
 //! Filters pytest output to show only failures and the summary line.
 
 use crate::core::runner;
-use crate::core::utils::{resolved_command, tool_exists, truncate};
+use crate::core::utils::{override_command, resolved_command, tool_exists, truncate};
 use anyhow::Result;
 
 #[derive(Debug, PartialEq)]
@@ -13,13 +13,15 @@ enum ParseState {
 }
 
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
-    let mut cmd = if tool_exists("pytest") {
-        resolved_command("pytest")
-    } else {
-        let mut c = resolved_command("python");
-        c.arg("-m").arg("pytest");
-        c
-    };
+    let mut cmd = override_command("pytest").unwrap_or_else(|| {
+        if tool_exists("pytest") {
+            resolved_command("pytest")
+        } else {
+            let mut c = resolved_command("python");
+            c.arg("-m").arg("pytest");
+            c
+        }
+    });
 
     let has_tb_flag = args.iter().any(|a| a.starts_with("--tb"));
     let has_quiet_flag = args.iter().any(|a| a == "-q" || a == "--quiet");

--- a/src/cmds/python/ruff_cmd.rs
+++ b/src/cmds/python/ruff_cmd.rs
@@ -2,7 +2,7 @@
 
 use crate::core::config;
 use crate::core::runner;
-use crate::core::utils::{resolved_command, truncate};
+use crate::core::utils::{override_command, resolved_command, truncate};
 use anyhow::Result;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -41,7 +41,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
 
     let is_format = args.iter().any(|a| a == "format");
 
-    let mut cmd = resolved_command("ruff");
+    let mut cmd = override_command("ruff").unwrap_or_else(|| resolved_command("ruff"));
 
     if is_check {
         if !args.contains(&"--output-format".to_string()) {

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -368,6 +368,33 @@ pub fn tool_exists(name: &str) -> bool {
     which::which(name).is_ok()
 }
 
+/// Build a `Command` honoring the `RTK_BIN_PATH` env var set by the rewrite
+/// engine when a path-prefixed command (e.g. `.venv/bin/pytest`) was normalized.
+///
+/// If `RTK_BIN_PATH` is set and its basename starts with "python", the command
+/// is constructed as `<bin> -m <tool_name>` (module invocation). Otherwise the
+/// binary is invoked directly.
+///
+/// Returns `None` when `RTK_BIN_PATH` is unset or empty, so callers fall back
+/// to their normal resolution logic.
+pub fn override_command(tool_name: &str) -> Option<Command> {
+    let bin_path = std::env::var("RTK_BIN_PATH").ok()?;
+    if bin_path.is_empty() {
+        return None;
+    }
+    let basename = std::path::Path::new(&bin_path)
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or("");
+    if basename.starts_with("python") {
+        let mut cmd = Command::new(&bin_path);
+        cmd.arg("-m").arg(tool_name);
+        Some(cmd)
+    } else {
+        Some(Command::new(&bin_path))
+    }
+}
+
 /// Extract short name from AWS ARN.
 /// Example: `arn:aws:ecs:region:acct:service/cluster/name` -> `name`
 /// For simple ARNs like `arn:aws:iam::123:user/alice`, returns `alice`.

--- a/src/discover/README.md
+++ b/src/discover/README.md
@@ -28,7 +28,7 @@ When a hook sends `cargo fmt --all && cargo test 2>&1 | tail -20`:
 1. Strip trailing redirects (`2>&1`, `>/dev/null`) — matched via lexer tokens, set aside, re-appended after rewriting
 2. Short-circuit special cases — `head -20 file` → `rtk read file --max-lines 20`, `tail -n 5 file` → `rtk read file --tail-lines 5`. These can't go through generic prefix replacement because it would produce `rtk read -20 file` (wrong flag position)
 3. Classify the command — strip env prefixes (`sudo`, `FOO="bar baz"`), normalize paths (`/usr/bin/grep` → `grep`), strip git global opts (`git -C /tmp` → `git`), then match against 60+ regex patterns from `rules.rs`
-4. Apply the rewrite — find the matching rule, replace the command prefix with `rtk <cmd>`, re-prepend the env prefix, re-append the redirect suffix
+4. Apply the rewrite — find the matching rule, normalize paths (`.venv/bin/python` → `python`), replace the command prefix with `rtk <cmd>`, re-prepend the env prefix, re-append the redirect suffix
 
 **Guards along the way:**
 - `RTK_DISABLED=1` in the env prefix → skip rewrite

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -664,7 +664,17 @@ fn rewrite_segment_inner(seg: &str, excluded: &[String], depth: usize) -> Option
     let stripped_cow = ENV_PREFIX.replace(cmd_part, "");
     let env_prefix_len = cmd_part.len() - stripped_cow.len();
     let env_prefix = &cmd_part[..env_prefix_len];
-    let cmd_clean = stripped_cow.trim();
+    let cmd_clean_raw = stripped_cow.trim();
+    let cmd_normalized = strip_absolute_path(cmd_clean_raw);
+    let original_bin = if cmd_normalized.as_str() != cmd_clean_raw {
+        cmd_clean_raw
+            .split_whitespace()
+            .next()
+            .map(|s| s.to_string())
+    } else {
+        None
+    };
+    let cmd_clean = cmd_normalized.as_str();
 
     // #345: RTK_DISABLED=1 in env prefix → skip rewrite entirely
     // #508: warn on stderr so agents learn to stop overusing it
@@ -676,13 +686,22 @@ fn rewrite_segment_inner(seg: &str, excluded: &[String], depth: usize) -> Option
         return None;
     }
 
+    // #1053: preserve original binary path so handlers use the correct executable
+    let bin_env = match &original_bin {
+        Some(bin) => format!("RTK_BIN_PATH={} ", bin),
+        None => String::new(),
+    };
+
     if let Some(parts) = parse_golangci_run_parts(cmd_clean) {
         let rewritten = if parts.global_segment.is_empty() {
-            format!("{}rtk golangci-lint {}", env_prefix, parts.run_segment)
+            format!(
+                "{}{}rtk golangci-lint {}",
+                env_prefix, bin_env, parts.run_segment
+            )
         } else {
             format!(
-                "{}rtk golangci-lint {} {}",
-                env_prefix, parts.global_segment, parts.run_segment
+                "{}{}rtk golangci-lint {} {}",
+                env_prefix, bin_env, parts.global_segment, parts.run_segment
             )
         };
         return Some(rewritten);
@@ -704,9 +723,15 @@ fn rewrite_segment_inner(seg: &str, excluded: &[String], depth: usize) -> Option
     for &prefix in rule.rewrite_prefixes {
         if let Some(rest) = strip_word_prefix(cmd_clean, prefix) {
             let rewritten = if rest.is_empty() {
-                format!("{}{}{}", env_prefix, rule.rtk_cmd, redirect_suffix)
+                format!(
+                    "{}{}{}{}",
+                    env_prefix, bin_env, rule.rtk_cmd, redirect_suffix
+                )
             } else {
-                format!("{}{} {}{}", env_prefix, rule.rtk_cmd, rest, redirect_suffix)
+                format!(
+                    "{}{}{} {}{}",
+                    env_prefix, bin_env, rule.rtk_cmd, rest, redirect_suffix
+                )
             };
             return Some(rewritten);
         }
@@ -3276,6 +3301,151 @@ mod tests {
         assert_eq!(
             rewrite_command("git log | head | tail && git status", &[]),
             Some("rtk git log | head | tail && rtk git status".into())
+        );
+    }
+
+    // --- Absolute/venv path rewrite ---
+
+    #[test]
+    fn test_rewrite_venv_python_pytest() {
+        assert_eq!(
+            rewrite_command(".venv/bin/python -m pytest tests/", &[]),
+            Some("RTK_BIN_PATH=.venv/bin/python rtk pytest tests/".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_venv_python3_pytest() {
+        assert_eq!(
+            rewrite_command(".venv/bin/python3 -m pytest -x tests/", &[]),
+            Some("RTK_BIN_PATH=.venv/bin/python3 rtk pytest -x tests/".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_venv_pytest_direct() {
+        assert_eq!(
+            rewrite_command(".venv/bin/pytest tests/", &[]),
+            Some("RTK_BIN_PATH=.venv/bin/pytest rtk pytest tests/".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_venv_ruff_check() {
+        assert_eq!(
+            rewrite_command(".venv/bin/ruff check .", &[]),
+            Some("RTK_BIN_PATH=.venv/bin/ruff rtk ruff check .".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_venv_mypy() {
+        assert_eq!(
+            rewrite_command(".venv/bin/python -m mypy src/", &[]),
+            Some("RTK_BIN_PATH=.venv/bin/python rtk mypy src/".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_venv_pip_install() {
+        assert_eq!(
+            rewrite_command(".venv/bin/pip install flask", &[]),
+            Some("RTK_BIN_PATH=.venv/bin/pip rtk pip install flask".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_absolute_path_grep() {
+        assert_eq!(
+            rewrite_command("/usr/bin/grep -rn pattern src/", &[]),
+            Some("RTK_BIN_PATH=/usr/bin/grep rtk grep -rn pattern src/".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_absolute_path_git() {
+        assert_eq!(
+            rewrite_command("/usr/local/bin/git status", &[]),
+            Some("RTK_BIN_PATH=/usr/local/bin/git rtk git status".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_absolute_path_ls() {
+        assert_eq!(
+            rewrite_command("/bin/ls -la", &[]),
+            Some("RTK_BIN_PATH=/bin/ls rtk ls -la".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_venv_in_compound() {
+        assert_eq!(
+            rewrite_command(".venv/bin/python -m pytest tests/ && git status", &[]),
+            Some("RTK_BIN_PATH=.venv/bin/python rtk pytest tests/ && rtk git status".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_venv_with_env_prefix() {
+        assert_eq!(
+            rewrite_command(
+                "PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest tests/",
+                &[]
+            ),
+            Some(
+                "PYTHONDONTWRITEBYTECODE=1 RTK_BIN_PATH=.venv/bin/python rtk pytest tests/".into()
+            )
+        );
+    }
+
+    #[test]
+    fn test_rewrite_deep_venv_path() {
+        assert_eq!(
+            rewrite_command("/tmp/vt-venv/bin/python -m pytest tests/", &[]),
+            Some("RTK_BIN_PATH=/tmp/vt-venv/bin/python rtk pytest tests/".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_named_venv_path() {
+        assert_eq!(
+            rewrite_command("venv/bin/python3 -m pytest tests/", &[]),
+            Some("RTK_BIN_PATH=venv/bin/python3 rtk pytest tests/".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_bare_command_no_bin_path() {
+        assert_eq!(
+            rewrite_command("pytest tests/", &[]),
+            Some("rtk pytest tests/".into())
+        );
+    }
+
+    #[test]
+    fn test_classify_venv_python_pytest() {
+        assert_eq!(
+            classify_command(".venv/bin/python -m pytest tests/"),
+            Classification::Supported {
+                rtk_equivalent: "rtk pytest",
+                category: "Python",
+                estimated_savings_pct: 90.0,
+                status: RtkStatus::Existing,
+            }
+        );
+    }
+
+    #[test]
+    fn test_strip_absolute_path_venv() {
+        assert_eq!(
+            strip_absolute_path(".venv/bin/python -m pytest tests/"),
+            "python -m pytest tests/"
+        );
+        assert_eq!(strip_absolute_path("venv/bin/ruff check ."), "ruff check .");
+        assert_eq!(
+            strip_absolute_path("/tmp/vt-venv/bin/python3 -m mypy src/"),
+            "python3 -m mypy src/"
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes the path-prefixed command rewrite issue described in #1053 and #1206.

The naive approach (strip `.venv/bin/` prefix and emit bare `rtk pytest`) changes execution semantics: handlers call `resolved_command("pytest")` which resolves via PATH, not the original venv binary. When the venv isn't activated, this executes the wrong binary or fails.

This PR implements the **three-part fix** from #1053:

1. **Normalize for matching only** — `strip_absolute_path()` in `rewrite_segment_inner()` normalizes path-prefixed commands to find the matching registry rule, but doesn't discard the original path
2. **Preserve original binary via `RTK_BIN_PATH`** — when a path prefix is stripped, the rewritten command includes `RTK_BIN_PATH=<original_bin>` as an env var prefix (e.g. `RTK_BIN_PATH=.venv/bin/python rtk pytest tests/`)
3. **Handlers honor the override** — `override_command()` in `utils.rs` checks `RTK_BIN_PATH`; if the basename starts with "python", it uses `-m <tool>` module invocation, otherwise direct execution. All Python handlers (pytest, ruff, mypy, pip) use this before falling back to PATH resolution.

## Paths handled

| Input | Rewritten |
|-------|-----------|
| `.venv/bin/pytest tests/` | `RTK_BIN_PATH=.venv/bin/pytest rtk pytest tests/` |
| `.venv/bin/python -m pytest tests/` | `RTK_BIN_PATH=.venv/bin/python rtk pytest tests/` |
| `/usr/bin/grep -rn pattern src/` | `RTK_BIN_PATH=/usr/bin/grep rtk grep -rn pattern src/` |
| `pytest tests/` (no path) | `rtk pytest tests/` (no RTK_BIN_PATH) |

## Test plan

- [x] All 1606 existing tests pass
- [x] New test: bare commands produce no `RTK_BIN_PATH`
- [x] Updated tests: venv paths emit correct `RTK_BIN_PATH` values
- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test --all` clean

Closes #1053
Refs #1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)