### PR TITLE
Fix #1071

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -232,16 +232,23 @@ fn run_show(
         for arg in args {
             cmd.arg(arg);
         }
+        // https://github.com/rtk-ai/rtk/issues/1071
+        // git show <rev>:<path> cannot be filtered when blob is binary -> passthrough
+        // git show <rev> is still incorrectly filtered when it corresponds to a binary blob
+        if wants_blob_show {
+            let status = cmd.status().context("Failed to run git show")?;
+            timer.track_passthrough(
+                &format!("git show {}", args.join(" ")),
+                &format!("rtk git show {} (passthrough)", args.join(" ")),
+            );
+            return Ok(exit_code_from_status(&status, "git show"));
+        }
         let result = exec_capture(&mut cmd).context("Failed to run git show")?;
         if !result.success() {
             eprintln!("{}", result.stderr);
             return Ok(result.exit_code);
         }
-        if wants_blob_show {
-            print!("{}", result.stdout);
-        } else {
-            println!("{}", result.stdout.trim());
-        }
+        println!("{}", result.stdout.trim());
 
         timer.track(
             &format!("git show {}", args.join(" ")),


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->
- Fix #1071 
- it only fixes `rtk git show <rev>:<path>`
- `rtk git show <rev>` without the `:` where `<rev>` corresponds to a binary blob still produces incorrect filtered content

## Test plan
<!-- How did you verify this works? -->

- [x] Manual testing: `rtk <command>` output inspected

```
rtk on  fix-1071 is 📦 v0.34.3 via 🦀 v1.92.0 
❯ git show ca7fbeb:test.bin | md5sum
3df17d08f5e181ff83982d9334a58579  -

rtk on  fix-1071 is 📦 v0.34.3 via 🦀 v1.92.0 
❯ ./target/debug/rtk git show ca7fbeb:test.bin | md5sum
3df17d08f5e181ff83982d9334a58579  -
```

AI Use disclosure:

- I used AI to analyze the code and write the fix
- I reviewed the code and tested the fix manually
- I also used AI to do additional code review
- This PR was written manually without the use of AI

I ran `cargo fmt --all && cargo clippy --all-targets && cargo test` on my commit