### PR TITLE
fix(openclaw): preserve rewrite stdout on exit 3

### DIFF
--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -24,6 +24,29 @@ function checkRtk(): boolean {
   return rtkAvailable;
 }
 
+function getRewriteExitStatus(error: unknown): number | null {
+  if (!error || typeof error !== "object" || !("status" in error)) {
+    return null;
+  }
+
+  const status = error.status;
+  return typeof status === "number" ? status : null;
+}
+
+function getRewriteStdout(error: unknown): string {
+  if (!error || typeof error !== "object" || !("stdout" in error)) {
+    return "";
+  }
+
+  const stdout = error.stdout;
+
+  if (typeof stdout === "string") {
+    return stdout.trim();
+  }
+
+  return Buffer.isBuffer(stdout) ? stdout.toString("utf-8").trim() : "";
+}
+
 function tryRewrite(command: string): string | null {
   try {
     const result = execSync(`rtk rewrite ${JSON.stringify(command)}`, {
@@ -31,8 +54,11 @@ function tryRewrite(command: string): string | null {
       timeout: 2000,
     }).trim();
     return result && result !== command ? result : null;
-  } catch {
-    return null;
+  } catch (error) {
+    const stdout = getRewriteStdout(error);
+    return getRewriteExitStatus(error) === 3 && stdout && stdout !== command
+      ? stdout
+      : null;
   }
 }
 


### PR DESCRIPTION
## Summary
- preserve `rtk rewrite` stdout when the child process exits with status `3`
- fix the OpenClaw plugin path where `execSync(...)` throws and the rewrite is discarded
- closes #1388

## Why this change
The current OpenClaw plugin drops rewritten stdout if `rtk rewrite` exits with status `3`.

That matters because RTKs hook-side rewrite contract uses exit `3` as the "rewritten + ask" path in `src/hooks/rewrite_cmd.rs`. The current `execSync(...)` path throws on that non-zero exit and the plugin returns `null`, so the rewrite is lost.

This PR makes the plugin preserve rewritten stdout on exit `3` instead of treating it as unrecoverable.

## Validation
- Ran: `bun --eval 'await import("./openclaw/index.ts")'`
- Ran: `cargo fmt --all --check`
- Ran: `cargo clippy --all-targets`
- Ran: `cargo test`
- Result: `1592 passed; 0 failed; 6 ignored`
- Not re-confirmed locally before opening this PR: manual verification in an environment where `rtk rewrite` emits rewritten stdout with exit `3`

## Notes
I am intentionally framing this as a correctness fix against the current exit-code contract.

The direct protocol evidence for exit `3` lives in `src/hooks/rewrite_cmd.rs`.
