### PR TITLE
fix(ls): force C locale so non-English month names don't break parsing

### DIFF
--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -35,6 +35,11 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         .collect();
 
     let mut cmd = resolved_command("ls");
+    // Force C locale so month names match LS_DATE_RE, which is English-only.
+    // Without this, non-English locales (e.g. LC_TIME=pt_BR.UTF-8 → "abr"/"mar")
+    // cause every line to fail the regex, and compact_ls returns "(empty)"
+    // even for non-empty directories.
+    cmd.env("LC_ALL", "C");
     cmd.arg("-la");
     for flag in &flags {
         if flag.starts_with("--") {


### PR DESCRIPTION
## Summary

`rtk ls` returns `(empty)` for any non-empty directory when the user's locale prints non-English month abbreviations (e.g. `LC_TIME=pt_BR.UTF-8` → `abr`, `mar`, `out`).

`LS_DATE_RE` in `src/cmds/system/ls.rs` is English-only and case-sensitive:

```rust
r"\s+(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}\s+(?:\d{4}|\d{2}:\d{2})\s+"
```

When `ls -la` prints a Portuguese/French/etc. month, the regex doesn't match, `parse_ls_line` returns `None` for every line, and `compact_ls` falls through to the `(empty)` sentinel at line 194 — silently hiding every file and directory.

## Repro

```
$ echo $LC_TIME
pt_BR.UTF-8

$ /usr/bin/ls -la ~/.local/bin/ | head -3
total 330912
drwxr-xr-x 1 gabriel gabriel      2592 abr 18 18:59 .
-rwxr-xr-x 1 gabriel gabriel        99 jan 13 16:25 agent

$ rtk -vvv ls ~/.local/bin/
Chars: 9773 → 8 (100% reduction)
(empty)
```

A 100% reduction on a directory with 140+ entries is a strong hint the filter is eating real data.

## Fix

Set `LC_ALL=C` on the spawned `ls` process, forcing English month names regardless of the user's locale. Smallest possible change, localized to where the locale-dependent parsing happens.

```rust
cmd.env("LC_ALL", "C");
```

This keeps the existing regex/parser contract intact (it already assumes a stable English format) and doesn't touch any other command path.

## After

```
$ rtk ls ~/.local/bin/ | head -3
agent  99B
aider -> /home/gabriel/.local/share/uv/tools/aider-chat/bin/aider  56B
alphashape  185B
```

Scope check: `grep -rn "Jan|Feb|Mar" src/` confirms `ls.rs` is the only runtime path with locale-dependent date parsing. `tree` / `find` / other proxies don't hit this.

## Test plan

- [x] Manual repro under `LC_TIME=pt_BR.UTF-8` before fix — reproduces `(empty)`
- [x] Manual verification after fix — `rtk ls` lists the directory correctly
- [x] `cargo build --release` clean
- [x] Existing `ls` tests unaffected (they feed the parser directly and are locale-independent)