### PR TITLE
fix(hooks): windows use 'rtk hook claude' no fallback

### DIFF
--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -3643,4 +3643,145 @@ More notes
         assert_eq!(arr.len(), 1);
         assert_eq!(arr[0]["command"].as_str().unwrap(), CURSOR_HOOK_COMMAND);
     }
+
+    use std::sync::Mutex;
+    static HOME_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_home_override<F: FnOnce()>(tmp: &TempDir, f: F) {
+        let _guard = HOME_LOCK.lock().unwrap();
+        fs::create_dir_all(tmp.path().join(CLAUDE_DIR)).unwrap();
+
+        let orig_home = std::env::var_os("HOME");
+        let orig_profile = std::env::var_os("USERPROFILE");
+        std::env::set_var("HOME", tmp.path());
+        std::env::set_var("USERPROFILE", tmp.path());
+        f();
+        match orig_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        match orig_profile {
+            Some(v) => std::env::set_var("USERPROFILE", v),
+            None => std::env::remove_var("USERPROFILE"),
+        }
+    }
+
+    #[test]
+    fn test_global_default_mode_creates_artifacts() {
+        let tmp = TempDir::new().unwrap();
+        with_home_override(&tmp, || {
+            run_default_mode(true, PatchMode::Auto, 0, false).unwrap();
+
+            let claude_dir = tmp.path().join(CLAUDE_DIR);
+            assert!(claude_dir.join(RTK_MD).exists(), "RTK.md must be created");
+            assert!(
+                claude_dir.join(CLAUDE_MD).exists(),
+                "CLAUDE.md must be created"
+            );
+
+            let settings = claude_dir.join(SETTINGS_JSON);
+            assert!(settings.exists(), "settings.json must be created");
+            let content = fs::read_to_string(&settings).unwrap();
+            assert!(
+                content.contains(CLAUDE_HOOK_COMMAND),
+                "settings.json must contain hook command"
+            );
+        });
+    }
+
+    #[test]
+    fn test_global_uninstall_removes_artifacts() {
+        let tmp = TempDir::new().unwrap();
+        with_home_override(&tmp, || {
+            run_default_mode(true, PatchMode::Auto, 0, false).unwrap();
+            uninstall(true, false, false, false, 0).unwrap();
+
+            let claude_dir = tmp.path().join(CLAUDE_DIR);
+            assert!(!claude_dir.join(RTK_MD).exists(), "RTK.md must be removed");
+            let settings_content =
+                fs::read_to_string(claude_dir.join(SETTINGS_JSON)).unwrap_or_default();
+            assert!(
+                !settings_content.contains(CLAUDE_HOOK_COMMAND),
+                "hook entry must be removed from settings.json"
+            );
+        });
+    }
+
+    #[test]
+    fn test_global_default_mode_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        with_home_override(&tmp, || {
+            run_default_mode(true, PatchMode::Auto, 0, false).unwrap();
+            run_default_mode(true, PatchMode::Auto, 0, false).unwrap();
+
+            let settings =
+                fs::read_to_string(tmp.path().join(CLAUDE_DIR).join(SETTINGS_JSON)).unwrap();
+            let count = settings.matches(CLAUDE_HOOK_COMMAND).count();
+            assert_eq!(count, 1, "hook command must appear exactly once");
+        });
+    }
+
+    #[test]
+    fn test_upgrade_from_claude_md_to_hook_mode() {
+        let tmp = TempDir::new().unwrap();
+        with_home_override(&tmp, || {
+            // Simulate old --claude-md installation
+            run_claude_md_mode(true, 0, false).unwrap();
+            let claude_dir = tmp.path().join(CLAUDE_DIR);
+            let claude_md_content = fs::read_to_string(claude_dir.join(CLAUDE_MD)).unwrap();
+            assert!(
+                claude_md_content.contains("<!-- rtk-instructions"),
+                "pre-condition: old block must exist"
+            );
+
+            // Upgrade to hook mode
+            run_default_mode(true, PatchMode::Auto, 0, false).unwrap();
+
+            assert!(claude_dir.join(RTK_MD).exists(), "RTK.md must be created");
+            let settings = fs::read_to_string(claude_dir.join(SETTINGS_JSON)).unwrap();
+            assert!(
+                settings.contains(CLAUDE_HOOK_COMMAND),
+                "hook must be in settings.json after upgrade"
+            );
+        });
+    }
+
+    #[test]
+    fn test_local_init_no_hook() {
+        let tmp = TempDir::new().unwrap();
+        let cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        let result = run_default_mode(false, PatchMode::Auto, 0, false);
+        std::env::set_current_dir(&cwd).unwrap();
+
+        result.unwrap();
+        assert!(
+            tmp.path().join(CLAUDE_MD).exists(),
+            "local CLAUDE.md must be created"
+        );
+        assert!(
+            !tmp.path().join(SETTINGS_JSON).exists(),
+            "settings.json must not be created for local init"
+        );
+    }
+
+    #[test]
+    fn test_global_hook_only_mode_creates_settings() {
+        let tmp = TempDir::new().unwrap();
+        with_home_override(&tmp, || {
+            run_hook_only_mode(true, PatchMode::Auto, 0, false).unwrap();
+
+            let claude_dir = tmp.path().join(CLAUDE_DIR);
+            assert!(
+                !claude_dir.join(RTK_MD).exists(),
+                "RTK.md must NOT be created in hook-only mode"
+            );
+            let settings = fs::read_to_string(claude_dir.join(SETTINGS_JSON)).unwrap();
+            assert!(
+                settings.contains(CLAUDE_HOOK_COMMAND),
+                "settings.json must contain hook command"
+            );
+        });
+    }
 }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -1727,6 +1727,9 @@ fn resolve_home_subdir(subdir: &str) -> Result<PathBuf> {
 }
 
 fn resolve_claude_dir() -> Result<PathBuf> {
+    if let Ok(dir) = std::env::var("RTK_CLAUDE_DIR") {
+        return Ok(PathBuf::from(dir));
+    }
     resolve_home_subdir(CLAUDE_DIR)
 }
 
@@ -3645,34 +3648,28 @@ More notes
     }
 
     use std::sync::Mutex;
-    static HOME_LOCK: Mutex<()> = Mutex::new(());
+    static CLAUDE_DIR_LOCK: Mutex<()> = Mutex::new(());
 
-    fn with_home_override<F: FnOnce()>(tmp: &TempDir, f: F) {
-        let _guard = HOME_LOCK.lock().unwrap();
-        fs::create_dir_all(tmp.path().join(CLAUDE_DIR)).unwrap();
+    fn with_claude_dir_override<F: FnOnce(&Path)>(tmp: &TempDir, f: F) {
+        let _guard = CLAUDE_DIR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let claude_dir = tmp.path().join(CLAUDE_DIR);
+        fs::create_dir_all(&claude_dir).unwrap();
 
-        let orig_home = std::env::var_os("HOME");
-        let orig_profile = std::env::var_os("USERPROFILE");
-        std::env::set_var("HOME", tmp.path());
-        std::env::set_var("USERPROFILE", tmp.path());
-        f();
-        match orig_home {
-            Some(v) => std::env::set_var("HOME", v),
-            None => std::env::remove_var("HOME"),
-        }
-        match orig_profile {
-            Some(v) => std::env::set_var("USERPROFILE", v),
-            None => std::env::remove_var("USERPROFILE"),
+        let orig = std::env::var_os("RTK_CLAUDE_DIR");
+        std::env::set_var("RTK_CLAUDE_DIR", &claude_dir);
+        f(&claude_dir);
+        match orig {
+            Some(v) => std::env::set_var("RTK_CLAUDE_DIR", v),
+            None => std::env::remove_var("RTK_CLAUDE_DIR"),
         }
     }
 
     #[test]
     fn test_global_default_mode_creates_artifacts() {
         let tmp = TempDir::new().unwrap();
-        with_home_override(&tmp, || {
+        with_claude_dir_override(&tmp, |claude_dir| {
             run_default_mode(true, PatchMode::Auto, 0, false).unwrap();
 
-            let claude_dir = tmp.path().join(CLAUDE_DIR);
             assert!(claude_dir.join(RTK_MD).exists(), "RTK.md must be created");
             assert!(
                 claude_dir.join(CLAUDE_MD).exists(),
@@ -3692,11 +3689,10 @@ More notes
     #[test]
     fn test_global_uninstall_removes_artifacts() {
         let tmp = TempDir::new().unwrap();
-        with_home_override(&tmp, || {
+        with_claude_dir_override(&tmp, |claude_dir| {
             run_default_mode(true, PatchMode::Auto, 0, false).unwrap();
             uninstall(true, false, false, false, 0).unwrap();
 
-            let claude_dir = tmp.path().join(CLAUDE_DIR);
             assert!(!claude_dir.join(RTK_MD).exists(), "RTK.md must be removed");
             let settings_content =
                 fs::read_to_string(claude_dir.join(SETTINGS_JSON)).unwrap_or_default();
@@ -3710,12 +3706,11 @@ More notes
     #[test]
     fn test_global_default_mode_idempotent() {
         let tmp = TempDir::new().unwrap();
-        with_home_override(&tmp, || {
+        with_claude_dir_override(&tmp, |claude_dir| {
             run_default_mode(true, PatchMode::Auto, 0, false).unwrap();
             run_default_mode(true, PatchMode::Auto, 0, false).unwrap();
 
-            let settings =
-                fs::read_to_string(tmp.path().join(CLAUDE_DIR).join(SETTINGS_JSON)).unwrap();
+            let settings = fs::read_to_string(claude_dir.join(SETTINGS_JSON)).unwrap();
             let count = settings.matches(CLAUDE_HOOK_COMMAND).count();
             assert_eq!(count, 1, "hook command must appear exactly once");
         });
@@ -3724,17 +3719,14 @@ More notes
     #[test]
     fn test_upgrade_from_claude_md_to_hook_mode() {
         let tmp = TempDir::new().unwrap();
-        with_home_override(&tmp, || {
-            // Simulate old --claude-md installation
+        with_claude_dir_override(&tmp, |claude_dir| {
             run_claude_md_mode(true, 0, false).unwrap();
-            let claude_dir = tmp.path().join(CLAUDE_DIR);
             let claude_md_content = fs::read_to_string(claude_dir.join(CLAUDE_MD)).unwrap();
             assert!(
                 claude_md_content.contains("<!-- rtk-instructions"),
                 "pre-condition: old block must exist"
             );
 
-            // Upgrade to hook mode
             run_default_mode(true, PatchMode::Auto, 0, false).unwrap();
 
             assert!(claude_dir.join(RTK_MD).exists(), "RTK.md must be created");
@@ -3769,10 +3761,9 @@ More notes
     #[test]
     fn test_global_hook_only_mode_creates_settings() {
         let tmp = TempDir::new().unwrap();
-        with_home_override(&tmp, || {
+        with_claude_dir_override(&tmp, |claude_dir| {
             run_hook_only_mode(true, PatchMode::Auto, 0, false).unwrap();
 
-            let claude_dir = tmp.path().join(CLAUDE_DIR);
             assert!(
                 !claude_dir.join(RTK_MD).exists(),
                 "RTK.md must NOT be created in hook-only mode"

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -872,20 +872,6 @@ fn hook_already_present(root: &serde_json::Value, hook_command: &str) -> bool {
 }
 
 /// Default mode: hook + slim RTK.md + @RTK.md reference
-#[cfg(not(unix))]
-fn run_default_mode(
-    _global: bool,
-    _patch_mode: PatchMode,
-    _verbose: u8,
-    _install_opencode: bool,
-) -> Result<()> {
-    eprintln!("[warn] Hook-based mode requires Unix (macOS/Linux).");
-    eprintln!("    Windows: use --claude-md mode for full injection.");
-    eprintln!("    Falling back to --claude-md mode.");
-    run_claude_md_mode(_global, _verbose, _install_opencode)
-}
-
-#[cfg(unix)]
 fn run_default_mode(
     global: bool,
     patch_mode: PatchMode,
@@ -1127,17 +1113,6 @@ fn generate_global_filters_template(verbose: u8) -> Result<()> {
 }
 
 /// Hook-only mode: just the hook, no RTK.md
-#[cfg(not(unix))]
-fn run_hook_only_mode(
-    _global: bool,
-    _patch_mode: PatchMode,
-    _verbose: u8,
-    _install_opencode: bool,
-) -> Result<()> {
-    anyhow::bail!("Hook install requires Unix (macOS/Linux). Use WSL or --claude-md mode.")
-}
-
-#[cfg(unix)]
 fn run_hook_only_mode(
     global: bool,
     patch_mode: PatchMode,


### PR DESCRIPTION
Removing old guards, windows can now just use the binary hook engine from 0.37

Related issues:
- Fixes #502 : rtk init --global falls back to --claude-md on Windows
- Fixes #1353 : Feature request: hook-based mode on Windows
- Partially addresses #330 : Add hooks support for Windows
- Partially addresses #913 :  Persistent "No hook installed" warning on Windows
- Partially addresses #1373 : Suppress "No hook installed" warning on Windows
- Partially addresses #682 : Config to suppress hook warning
- Related to #1248 : Windows PowerShell compatibility gaps

Supersedes community PRs:
- #1123 fix(init): enable hook installation on Windows
- #1027 fix(init): enable hook-based mode on Windows
- #809 feat: enable hook-based mode on Windows
- #452 feat: add Windows hook support for rtk init --global
- #551 feat: native cross-platform hook for Windows support
- #150 feat(hook): native cross-platform hook-rewrite command
- #1063 Feat/windows hooks

## Summary

init claude with binary hook for Windows support

## Test plan

Test 1: rtk init -g: Shows Command: rtk hook claude, no Unix warning
Test 2: rtk init -g --hook-only: Shows RTK hook registered (hook-only mode), no Unix error
Test 3: rtk init --show: No crash, shows [ok] Hook: rtk hook claude
Test 4: rtk init -g --uninstall: RTK.md removed, hook removed from settings.json
Test 5: rtk init -g twice: Second run says hook already present, hook count = 1
Test 6: Upgrade from --claude-md: Shows Migrated, replaces full block with @RTK.md
Test 7: rtk hook claude binary: Returns JSON, no crash
Test 8: rtk init (local): Creates local CLAUDE.md only, no hook installed