### PR TITLE
test(init): cover CODEX_HOME in Codex global init

### DIFF
--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -2672,6 +2672,19 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    static CODEX_HOME_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn with_codex_home<F: FnOnce()>(codex_home: &Path, f: F) {
+        let _guard = CODEX_HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let original = std::env::var_os("CODEX_HOME");
+        std::env::set_var("CODEX_HOME", codex_home);
+        f();
+        match original {
+            Some(value) => std::env::set_var("CODEX_HOME", value),
+            None => std::env::remove_var("CODEX_HOME"),
+        }
+    }
+
     #[test]
     fn test_init_mentions_all_top_level_commands() {
         for cmd in [
@@ -3017,6 +3030,27 @@ More notes
         assert_eq!(preferred, codex_home);
         assert_eq!(empty_falls_back, home_dir.join(".codex"));
         assert_eq!(missing_falls_back, home_dir.join(".codex"));
+    }
+
+    #[test]
+    fn test_run_codex_mode_global_respects_codex_home_env() {
+        let temp = TempDir::new().unwrap();
+        let codex_dir = temp.path().join(".config/codex");
+
+        with_codex_home(&codex_dir, || {
+            run_codex_mode(true, 0).unwrap();
+        });
+
+        let agents_md = codex_dir.join(AGENTS_MD);
+        let rtk_md = codex_dir.join(RTK_MD);
+
+        assert!(agents_md.exists());
+        assert!(rtk_md.exists());
+        assert_eq!(
+            fs::read_to_string(&agents_md).unwrap(),
+            format!("{}\n", codex_rtk_md_ref(&codex_dir))
+        );
+        assert_eq!(fs::read_to_string(&rtk_md).unwrap(), RTK_SLIM_CODEX);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a regression test that exercises `run_codex_mode(true, ...)` with `CODEX_HOME` set in the process environment
- serialize `CODEX_HOME` mutation inside the test module to keep env-based tests isolated
- verify both `AGENTS.md` and `RTK.md` are written into the configured Codex home

## Context

Refs #1400.

I investigated the report in `#1400` and could not reproduce it on either:

- the current source tree
- the shipped `v0.37.1` release binary downloaded from GitHub releases

In both cases, `rtk init -g --codex` wrote `AGENTS.md` and `RTK.md` into `CODEX_HOME` (including the exact `~/.config/codex` shape from the issue body), not `~/.codex`.

This PR does not change runtime behavior. It adds direct coverage around the public env-driven code path so future regressions in the `CODEX_HOME` handling are caught by tests instead of being inferred only through the helper-level unit test.

## Testing

- `cargo test codex_home -- --nocapture`
- manual smoke test with the released `v0.37.1` binary:
  - `HOME=<tmp> CODEX_HOME=<tmp>/.config/codex rtk init -g --codex`
  - `HOME=<tmp> CODEX_HOME=<tmp>/.config/codex rtk init --show --codex`
  - `HOME=<tmp> CODEX_HOME=<tmp>/.config/codex rtk init -g --codex --uninstall`
