### PR TITLE
fix: rewrite bunx prisma to rtk prisma

### DIFF
--- a/hooks/claude/test-rtk-rewrite.sh
+++ b/hooks/claude/test-rtk-rewrite.sh
@@ -117,6 +117,10 @@ test_rewrite "npx prisma migrate" \
   "npx prisma migrate" \
   "rtk prisma migrate"
 
+test_rewrite "bunx prisma migrate" \
+  "bunx prisma migrate" \
+  "rtk prisma migrate"
+
 test_rewrite "rtk git status" \
   "rtk git status" \
   "rtk git status"

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -2584,6 +2584,7 @@ mod tests {
     #[test]
     fn test_classify_prisma() {
         let commands = vec![
+            "bunx prisma",
             "npm exec prisma",
             "npm rum prisma",
             "npm run prisma",
@@ -2618,6 +2619,7 @@ mod tests {
     #[test]
     fn test_rewrite_prisma() {
         let commands = vec![
+            "bunx prisma",
             "npm exec prisma",
             "npm rum prisma",
             "npm run prisma",

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -338,9 +338,10 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?prisma",
+        pattern: r"^((bunx|p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?prisma",
         rtk_cmd: "rtk prisma",
         rewrite_prefixes: &[
+            "bunx prisma",
             "npm exec prisma",
             "npm prisma",
             "npm rum prisma",


### PR DESCRIPTION
## Summary
- add `bunx prisma` to the Prisma rewrite rule in the registry
- cover the new prefix in the Rust classify/rewrite tests
- add a Claude hook regression case for `bunx prisma migrate`

## Testing
- `/Users/sasha/.rustup/toolchains/stable-x86_64-apple-darwin/bin/cargo test prisma -- --nocapture`
- `printf ... | PATH=target/debug:$PATH bash hooks/claude/rtk-rewrite.sh | jq -r .hookSpecificOutput.updatedInput.command` → `rtk prisma migrate`

Closes #1401