### PR TITLE
docs: clarify Codex rewrite behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ rtk gain        # Should show token savings stats
 # 1. Install for your AI tool
 rtk init -g                     # Claude Code / Copilot (default)
 rtk init -g --gemini            # Gemini CLI
-rtk init -g --codex             # Codex (OpenAI)
+rtk init -g --codex             # Codex (OpenAI, instruction mode)
 rtk init -g --agent cursor      # Cursor
 rtk init --agent windsurf       # Windsurf
 rtk init --agent cline          # Cline / Roo Code
@@ -112,7 +112,8 @@ rtk init --agent kilocode       # Kilo Code
 rtk init --agent antigravity    # Google Antigravity
 
 # 2. Restart your AI tool, then test
-git status  # Automatically rewritten to rtk git status
+git status      # Hook-based integrations: automatically rewritten to rtk git status
+rtk git status  # Codex: use explicitly, or rely on AGENTS.md / RTK.md instructions
 ```
 
 The hook transparently rewrites Bash commands (e.g., `git status` -> `rtk git status`) before execution. Claude never sees the rewrite, it just gets compressed output.
@@ -350,7 +351,7 @@ rtk git status
 
 ## Supported AI Tools
 
-RTK supports 12 AI coding tools. Each integration transparently rewrites shell commands to `rtk` equivalents for 60-90% token savings.
+RTK supports 12 AI coding tools. Hook-based integrations transparently rewrite shell commands to `rtk` equivalents for 60-90% token savings; instruction-based integrations guide the agent to use `rtk` explicitly.
 
 | Tool | Install | Method |
 |------|---------|--------|


### PR DESCRIPTION
## Summary
Clarify that Codex uses AGENTS.md / RTK.md instruction mode rather than transparent hook-based rewrite.

## What changed
- mark 
RTK configured for Codex CLI.

  RTK.md:    /Users/davidcai/.codex/RTK.md
  AGENTS.md: @/Users/davidcai/.codex/RTK.md reference already present

  Codex global instructions path: /Users/davidcai/.codex/AGENTS.md as instruction mode in Quick Start
- split the Quick Start test snippet between hook-based integrations and Codex
- narrow the Supported AI Tools intro so it does not imply transparent rewrite for instruction-based integrations

## Why
The README currently says On branch codex/clarify-codex-rewrite-docs
Your branch is up to date with 'origin/codex/clarify-codex-rewrite-docs'.

nothing to commit, working tree clean is automatically rewritten right after listing 
RTK configured for Codex CLI.

  RTK.md:    /Users/davidcai/.codex/RTK.md
  AGENTS.md: @/Users/davidcai/.codex/RTK.md reference already present

  Codex global instructions path: /Users/davidcai/.codex/AGENTS.md, while the Supported AI Tools table correctly says Codex uses .

This keeps the docs internally consistent and matches observed Codex behavior without changing any product claims for hook-based integrations.