### PR TITLE
fix(install): resolve version via redirect to avoid GitHub API rate limits

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -46,10 +46,25 @@ detect_arch() {
 }
 
 # Get latest release version
+# Primary: parse the 302 redirect on /releases/latest (no API call, no rate limit).
+# Fallback: the GitHub REST API (subject to 60 req/hour anonymous limit).
 get_latest_version() {
-    VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+    # Try the web redirect first — does not count against the API rate limit.
+    VERSION=$(curl -sI "https://github.com/${REPO}/releases/latest" \
+        | grep -i '^location:' \
+        | sed -E 's|.*/tag/([^[:space:]]+).*|\1|' \
+        | tr -d '\r')
+
+    # Fallback to the REST API if the redirect didn't yield a tag.
     if [ -z "$VERSION" ]; then
-        error "Failed to get latest version"
+        warn "Redirect lookup failed, falling back to GitHub API..."
+        VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+            | grep '"tag_name":' \
+            | sed -E 's/.*"([^"]+)".*/\1/')
+    fi
+
+    if [ -z "$VERSION" ]; then
+        error "Failed to get latest version (GitHub API may be rate-limited; set RTK_VERSION=vX.Y.Z to pin)"
     fi
 }
 
@@ -113,7 +128,12 @@ main() {
     detect_os
     detect_arch
     get_target
-    get_latest_version
+    if [ -n "$RTK_VERSION" ]; then
+        VERSION="$RTK_VERSION"
+        info "Using pinned version from RTK_VERSION: $VERSION"
+    else
+        get_latest_version
+    fi
     install
     verify
 


### PR DESCRIPTION
## Summary

- `install.sh` fails with `Failed to get latest version` when the GitHub REST API returns 403 (anonymous rate limit of 60 req/hour, easily hit from shared NATs, CI, or corporate networks).
- Switch the primary lookup to the `https://github.com/<repo>/releases/latest` 302 redirect, whose `Location` header contains the tag — **no API quota consumed**.
- Keep the REST API call as a fallback for defense in depth.
- Add an `RTK_VERSION` env var as an escape hatch to pin a specific version (the error message now points users to it).

## Problem

```sh
# Before
VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
  | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
```

When unauthenticated requests exceed 60/hour (GitHub's documented rate limit for anonymous API access), the API returns HTTP 403. With `curl -f`, that produces an empty pipeline result, and the installer bails with `Failed to get latest version`. Users sharing an outbound IP (CI, NAT, coworking spaces) can trivially exhaust the quota for everyone behind that IP.

## Fix

Primary: parse the 302 redirect from `github.com/<repo>/releases/latest`. This doesn't hit the API at all and has no documented rate limit.

```sh
VERSION=$(curl -sI "https://github.com/${REPO}/releases/latest" \
    | grep -i '^location:' \
    | sed -E 's|.*/tag/([^[:space:]]+).*|\1|' \
    | tr -d '\r')
```

Fallback: if the redirect parsing yields nothing (unexpected GitHub change, network oddity), fall back to the original API call with a warning.

Escape hatch: `RTK_VERSION=v0.37.1 curl -fsSL ... | sh` lets users pin a version and skip both lookups entirely.

## Verification

- POSIX syntax check: `sh -n install.sh` ✅
- Redirect lookup tested against `rtk-ai/rtk`:
  ```
  $ curl -sI https://github.com/rtk-ai/rtk/releases/latest | grep -i '^location:'
  location: https://github.com/rtk-ai/rtk/releases/tag/v0.37.1
  ```
- Resolved version: `v0.37.1` ✅
- Fallback path preserved (still parses the API JSON the same way).
- `RTK_VERSION` override path tested by setting the env var and short-circuiting `get_latest_version`.

## Test plan

- [x] `curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/master/install.sh | sh` installs successfully on macOS
- [x] Same on Linux (bash, `/bin/sh` = dash)
- [x] `RTK_VERSION=v0.37.0 curl -fsSL ... | sh` installs v0.37.0 specifically

## Related

- No existing open issue or PR covers this (#450 was a different problem — missing binaries on the `latest` tag, fixed in v0.28.0).
- Security-adjacent issues on the installer (#1158, #1159, #1250) are separate concerns and unaffected by this change.