### PR TITLE
fix: suppress hook warning during rtk init and verify

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1331,8 +1331,11 @@ fn run_cli() -> Result<i32> {
     };
 
     // Warn if installed hook is outdated/missing (1/day, non-blocking).
-    // Skip for Gain — it shows its own inline hook warning.
-    if !matches!(cli.command, Commands::Gain { .. }) {
+    // Skip for Gain (shows its own inline warning), Init/Verify (manage the hook themselves).
+    if !matches!(
+        cli.command,
+        Commands::Gain { .. } | Commands::Init { .. } | Commands::Verify { .. }
+    ) {
         hooks::hook_check::maybe_warn();
     }
 


### PR DESCRIPTION
Fixes #1011

## Problem

Running `rtk init -g` printed a spurious warning:

```
[rtk] /!\ No hook installed — run `rtk init -g` for automatic token savings
```

This happened because `maybe_warn()` fired before the init completed.

## Fix

Skip `maybe_warn()` for `Init` and `Verify` commands — they manage the hook themselves and don't need the reminder.

```rust
if !matches!(
    cli.command,
    Commands::Gain { .. } | Commands::Init { .. } | Commands::Verify { .. }
) {
    hooks::hook_check::maybe_warn();
}
```

## Test plan

- [ ] `rtk init -g` no longer shows the hook warning
- [ ] `rtk verify` no longer shows the hook warning  
- [ ] Other commands (e.g. `rtk git status`) still show the warning when hook is missing
- [ ] `cargo test --all` passes (1606 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
