### PR TITLE
fix(hook_check): treat non-Claude integrations as installed

### DIFF
--- a/src/hooks/hook_check.rs
+++ b/src/hooks/hook_check.rs
@@ -4,7 +4,6 @@ use super::constants::{
     CLAUDE_DIR, CLAUDE_HOOK_COMMAND, HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE,
     SETTINGS_JSON,
 };
-#[cfg(test)]
 use super::constants::{CODEX_DIR, CURSOR_DIR, GEMINI_DIR, GEMINI_HOOK_FILE, OPENCODE_PLUGIN_PATH};
 use crate::core::constants::RTK_DATA_DIR;
 use std::path::PathBuf;
@@ -31,6 +30,13 @@ pub fn status() -> HookStatus {
         Some(h) => h,
         None => return HookStatus::Ok,
     };
+    status_for_home(&home)
+}
+
+fn status_for_home(home: &std::path::Path) -> HookStatus {
+    if other_integration_installed(&home) {
+        return HookStatus::Ok;
+    }
     let claude_dir = home.join(CLAUDE_DIR);
     if !claude_dir.exists() {
         return HookStatus::Ok;
@@ -135,7 +141,6 @@ pub fn parse_hook_version(content: &str) -> u8 {
     0 // No version tag = version 0 (outdated)
 }
 
-#[cfg(test)]
 fn other_integration_installed(home: &std::path::Path) -> bool {
     let paths = [
         home.join(OPENCODE_PLUGIN_PATH),
@@ -263,6 +268,22 @@ mod tests {
         std::fs::create_dir_all(tmp.path().join(CODEX_DIR)).unwrap();
         std::fs::create_dir_all(tmp.path().join(GEMINI_DIR)).unwrap();
         assert!(!other_integration_installed(tmp.path()));
+    }
+
+    #[test]
+    fn test_status_ok_when_codex_installed_without_claude() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join(CODEX_DIR).join("AGENTS.md");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"agents").unwrap();
+        assert_eq!(status_for_home(tmp.path()), HookStatus::Ok);
+    }
+
+    #[test]
+    fn test_status_missing_when_claude_present_without_hook() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(tmp.path().join(CLAUDE_DIR)).unwrap();
+        assert_eq!(status_for_home(tmp.path()), HookStatus::Missing);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- treat Codex, Cursor, Gemini, and OpenCode installations as valid RTK integrations in hook_check::status()
- stop emitting the No hook installed warning when RTK is already configured for one of those integrations
- add regression coverage for the non-Claude integration path

## Fix

- move the status logic into status_for_home() so the hook check can be tested without depending on the caller's real home directory
- run other_integration_installed() before the Claude-specific hook checks
- keep the existing Claude hook behavior unchanged when no other integration is present
- this is complementary to #1376 and #1083: it handles environments where RTK is already installed for a different integration instead of suppressing the warning based on platform

Related: #1373

## Test

- [x] cargo fmt --all
- [x] cargo test hooks::hook_check::tests::test_status_ok_when_codex_installed_without_claude -- --exact
- [x] cargo test hooks::hook_check::tests::test_status_missing_when_claude_present_without_hook -- --exact
- [ ] cargo test still hits existing core::stream Windows command-spawn failures (program not found), unrelated to this file