### PR TITLE
chore(cargo): set rust-version = "1.91" (MSRV)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rtk"
 version = "0.34.3"
 edition = "2021"
+rust-version = "1.91"
 authors = ["Patrick Szymkowiak"]
 description = "Rust Token Killer - High-performance CLI proxy to minimize LLM token consumption"
 license = "MIT"


### PR DESCRIPTION
The codebase uses `str::floor_char_boundary()` (in `src/cmds/system/pipe_cmd.rs`), which was stabilized in Rust 1.91.0. Without a declared MSRV, building with an older toolchain produces a confusing `E0658: use of unstable library feature` error instead of a clear version requirement.

Adding `rust-version = "1.91"` to `[package]` lets cargo produce an actionable message upfront:

```
error: package `rtk v0.37.x` cannot be built because it requires rustc 1.91 or newer
```

This matters for distribution packagers (Arch AUR, Nix, Homebrew) and CI environments where the system Rust may lag behind the stable channel.

Closes #1402