### PR TITLE
fix(openclaw): add installer metadata for rtk plugin package

### DIFF
--- a/openclaw/dist/index.js
+++ b/openclaw/dist/index.js
@@ -1,0 +1,68 @@
+/**
+ * RTK Rewrite Plugin for OpenClaw
+ * Runtime JS entry used by OpenClaw plugin installer via package.json#openclaw.extensions.
+ */
+
+import { execSync } from "node:child_process";
+
+let rtkAvailable = null;
+
+function checkRtk() {
+  if (rtkAvailable !== null) return rtkAvailable;
+  try {
+    execSync("which rtk", { stdio: "ignore" });
+    rtkAvailable = true;
+  } catch {
+    rtkAvailable = false;
+  }
+  return rtkAvailable;
+}
+
+function tryRewrite(command) {
+  try {
+    const result = execSync(`rtk rewrite ${JSON.stringify(command)}`, {
+      encoding: "utf-8",
+      timeout: 2000,
+    }).trim();
+    return result && result !== command ? result : null;
+  } catch {
+    return null;
+  }
+}
+
+export default function register(api) {
+  const pluginConfig = api.config ?? {};
+  const enabled = pluginConfig.enabled !== false;
+  const verbose = pluginConfig.verbose === true;
+
+  if (!enabled) return;
+
+  if (!checkRtk()) {
+    console.warn("[rtk] rtk binary not found in PATH - plugin disabled");
+    return;
+  }
+
+  api.on(
+    "before_tool_call",
+    (event) => {
+      if (event.toolName !== "exec") return;
+
+      const command = event.params?.command;
+      if (typeof command !== "string") return;
+
+      const rewritten = tryRewrite(command);
+      if (!rewritten) return;
+
+      if (verbose) {
+        console.log(`[rtk] ${command} -> ${rewritten}`);
+      }
+
+      return { params: { ...event.params, command: rewritten } };
+    },
+    { priority: 10 }
+  );
+
+  if (verbose) {
+    console.log("[rtk] OpenClaw plugin registered");
+  }
+}

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -2,7 +2,11 @@
   "name": "@rtk-ai/rtk-rewrite",
   "version": "1.0.0",
   "description": "RTK plugin for OpenClaw — rewrites shell commands for 60-90% LLM token savings",
-  "main": "index.ts",
+  "type": "module",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -18,7 +22,13 @@
     "llm",
     "cli-proxy"
   ],
+  "openclaw": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
   "files": [
+    "dist",
     "index.ts",
     "openclaw.plugin.json",
     "README.md"


### PR DESCRIPTION
## Summary
- add OpenClaw installer metadata to `openclaw/package.json` via `openclaw.extensions`
- set runtime entry to `./dist/index.js` and export it
- include `dist` in published files
- add `openclaw/dist/index.js` runtime JS entry for installer-based loading

## Why
`openclaw plugins install ./openclaw` currently fails with:
- missing `openclaw.extensions`
- fallback hook-pack validation also fails

This patch makes installer-based plugin installation work as documented.

## Validation
- local install succeeds with:
  `openclaw plugins install --dangerously-force-unsafe-install /tmp/rtk-openclaw-plugin/openclaw`
- plugin is discoverable and has install provenance in `openclaw plugins inspect rtk-rewrite`
