### PR TITLE
fix(grep): adjust the command to fall through if the output would already be as small as possible

### DIFF
--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -215,11 +215,11 @@ rtk grep <pattern> [chemin] [options]
 |--------|-------|--------|-------------|
 | `--max-len` | `-l` | 80 | Longueur maximale de ligne |
 | `--max` | `-m` | 50 | Nombre maximum de resultats |
-| `--context-only` | `-c` | non | Afficher uniquement le contexte du match |
+| `--context-only` |  | non | Afficher uniquement le contexte du match (pas de raccourci, `-c` est reserve a `grep --count`) |
 | `--file-type` | `-t` | tous | Filtrer par type (ts, py, rust, etc.) |
 | `--line-numbers` | `-n` | oui | Numeros de ligne (toujours actif) |
 
-Les arguments supplementaires sont transmis a `rg` (ripgrep).
+Les arguments supplementaires sont transmis a `rg` (ripgrep). Les flags qui changent le format de sortie (`-c`, `-l`, `-L`, `-o`, `-Z`) passent directement a `rg`/`grep` sans filtrage RTK.
 
 **Economies :** ~80%
 

--- a/src/cmds/system/README.md
+++ b/src/cmds/system/README.md
@@ -5,7 +5,7 @@
 ## Specifics
 
 - `read.rs` uses `core/filter` for language-aware code stripping (FilterLevel: none/minimal/aggressive)
-- `grep_cmd.rs` reads `core/config` for `limits.grep_max_results` and `limits.grep_max_per_file`
+- `grep_cmd.rs` reads `core/config` for `limits.grep_max_results` and `limits.grep_max_per_file`. Format-altering flags (`-c`, `-l`, `-L`, `-o`, `-Z`) bypass RTK filtering and run raw.
 - `local_llm.rs` (`rtk smart`) uses `core/filter` for heuristic file summarization
 - `format_cmd.rs` is a cross-ecosystem dispatcher: auto-detects and routes to `prettier_cmd` or `ruff_cmd` (black is handled inline, not as a separate module)
 

--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -46,20 +46,39 @@ pub fn run(
     let result = exec_capture(&mut rg_cmd)
         .or_else(|_| {
             let mut grep_cmd = resolved_command("grep");
-            grep_cmd.args(["-rn", pattern, path]);
+            //When we fall back to grep,include all args, not just -rn.
+            grep_cmd.args(["-rn", pattern, path]).args(extra_args);
             exec_capture(&mut grep_cmd)
         })
         .context("grep/rg failed")?;
+
+    // Passthrough output flags that produce output that is already small.
+    if has_format_flag(extra_args) {
+        print!("{}", result.stdout);
+        if !result.stderr.is_empty() {
+            eprint!("{}", result.stderr.trim());
+        }
+
+        let args_display = if extra_args.is_empty() {
+            format!("'{}' {}", pattern, path)
+        } else {
+            format!("{} '{}' {}", extra_args.join(" "), pattern, path)
+        };
+
+        timer.track_passthrough(
+            &format!("grep {}", args_display),
+            &format!("rtk grep {} (passthrough)", args_display),
+        );
+        return Ok(result.exit_code);
+    }
 
     let exit_code = result.exit_code;
     let raw_output = result.stdout.clone();
 
     if result.stdout.trim().is_empty() {
         // Show stderr for errors (bad regex, missing file, etc.)
-        if exit_code == 2 {
-            if !result.stderr.trim().is_empty() {
-                eprintln!("{}", result.stderr.trim());
-            }
+        if exit_code == 2 && !result.stderr.trim().is_empty() {
+            eprintln!("{}", result.stderr.trim());
         }
         let msg = format!("0 matches for '{}'", pattern);
         println!("{}", msg);
@@ -143,6 +162,23 @@ pub fn run(
     );
 
     Ok(exit_code)
+}
+
+fn has_format_flag(extra_args: &[String]) -> bool {
+    extra_args.iter().any(|arg| {
+        matches!(
+            arg.as_str(),
+            "-c" | "--count"
+                | "-l"
+                | "--files-with-matches"
+                | "-L"
+                | "--files-without-match"
+                | "-o"
+                | "--only-matching"
+                | "-Z"
+                | "--null"
+        )
+    })
 }
 
 fn clean_line(line: &str, max_len: usize, context_re: Option<&Regex>, pattern: &str) -> String {
@@ -291,6 +327,48 @@ mod tests {
             wrong_overflow, overflow,
             "capping before subtraction gives wrong overflow"
         );
+    }
+
+    // --- format flag detection ---
+
+    #[test]
+    fn test_format_flag_detects_count() {
+        assert!(has_format_flag(&["-c".to_string()]));
+        assert!(has_format_flag(&["--count".to_string()]));
+    }
+
+    #[test]
+    fn test_format_flag_detects_files_with_matches() {
+        assert!(has_format_flag(&["-l".to_string()]));
+        assert!(has_format_flag(&["--files-with-matches".to_string()]));
+    }
+
+    #[test]
+    fn test_format_flag_detects_files_without_match() {
+        assert!(has_format_flag(&["-L".to_string()]));
+        assert!(has_format_flag(&["--files-without-match".to_string()]));
+    }
+
+    #[test]
+    fn test_format_flag_detects_only_matching() {
+        assert!(has_format_flag(&["-o".to_string()]));
+        assert!(has_format_flag(&["--only-matching".to_string()]));
+    }
+
+    #[test]
+    fn test_format_flag_detects_null() {
+        assert!(has_format_flag(&["-Z".to_string()]));
+        assert!(has_format_flag(&["--null".to_string()]));
+    }
+
+    #[test]
+    fn test_format_flag_ignores_normal_flags() {
+        assert!(!has_format_flag(&[
+            "-i".to_string(),
+            "-w".to_string(),
+            "-A".to_string(),
+            "3".to_string(),
+        ]));
     }
 
     // Verify line numbers are always enabled in rg invocation (grep_cmd.rs:24).

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -157,7 +157,7 @@ rtk prisma              # Prisma without ASCII art (88%)
 ```bash
 rtk ls <path>           # Tree format, compact (65%)
 rtk read <file>         # Code reading with filtering (60%)
-rtk grep <pattern>      # Search grouped by file (75%)
+rtk grep <pattern>      # Search grouped by file (75%). Format flags (-c, -l, -L, -o, -Z) run raw.
 rtk find <pattern>      # Find grouped by directory (70%)
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -309,7 +309,7 @@ enum Commands {
         #[arg(short, long, default_value = "200")]
         max: usize,
         /// Show only match context (not full line)
-        #[arg(short, long)]
+        #[arg(long)]
         context_only: bool,
         /// Filter by file type (e.g., ts, py, rust)
         #[arg(short = 't', long)]


### PR DESCRIPTION
## Summary
Fix `rtk grep` compatibility with standard grep format flags (`-c`, `-l`, `-L`, `-o`, `-Z`). These flags change output shape so fundamentally that RTK's grouped formatter produced garbage or ignored the flag entirely.

### Root Cause
- Issue: #1452 
- `rtk grep` hardcoded `-n --no-heading` into `rg` regardless of user flags.
- The output parser assumed `file:line:content` format, so `-c` output (`file:count`) was misinterpreted.
- Clap's `context_only: bool` had `#[arg(short, long)]`, which captured `-c` before it reached `extra_args`.

## Test plan

**All tests pass:**
```bash
$ rtk cargo test --all
cargo test: 1680 passed, 6 ignored
```

**Format flags now produce raw output:**

| Flag | Command | Output |
|------|---------|--------|
| `-c` | `rtk grep -c "fn run" src/cmds/system/grep_cmd.rs` | `1` |
| `-l` | `rtk grep -l "fn run" src/cmds/system/grep_cmd.rs` | `src/cmds/system/grep_cmd.rs` |
| `-L` | `rtk grep -L "nonexistent" src/cmds/system/grep_cmd.rs` | `src/cmds/system/grep_cmd.rs` |
| `-o` | `rtk grep -o "fn" src/cmds/system/grep_cmd.rs` | `fn\nfn\nfn...` |

**Normal path unchanged:**
```bash
$ rtk grep "fn run" src/cmds/system/grep_cmd.rs
1 matches in 1F:

[file] src/cmds/system/grep_cmd.rs (1):
    12: pub fn run(
```

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
