### PR TITLE
feat: add Kiro CLI agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ rtk init --agent windsurf       # Windsurf
 rtk init --agent cline          # Cline / Roo Code
 rtk init --agent kilocode       # Kilo Code
 rtk init --agent antigravity    # Google Antigravity
+rtk init -g --agent kiro        # Kiro CLI
 
 # 2. Restart your AI tool, then test
 git status  # Automatically rewritten to rtk git status
@@ -367,6 +368,7 @@ RTK supports 12 AI coding tools. Each integration transparently rewrites shell c
 | **Mistral Vibe** | Planned ([#800](https://github.com/rtk-ai/rtk/issues/800)) | Blocked on upstream |
 | **Kilo Code** | `rtk init --agent kilocode` | .kilocode/rules/rtk-rules.md (project-scoped) |
 | **Google Antigravity** | `rtk init --agent antigravity` | .agents/rules/antigravity-rtk-rules.md (project-scoped) |
+| **Kiro CLI** | `rtk init -g --agent kiro` | ~/.kiro/steering/rtk-rules.md (global) or .kiro/steering/rtk-rules.md (project-scoped) |
 
 For per-agent setup details, override controls, and graceful degradation, see the [Supported Agents guide](https://www.rtk-ai.app/guide/getting-started/supported-agents).
 

--- a/hooks/kiro/README.md
+++ b/hooks/kiro/README.md
@@ -1,0 +1,11 @@
+# Kiro CLI Hooks
+
+> Part of [`hooks/`](../README.md) — see also [`src/hooks/`](../../src/hooks/README.md) for installation code
+
+## Specifics
+
+- Prompt-level guidance only (no programmatic hook) — relies on Kiro CLI reading steering files
+- `rules.md` contains the instruction to prefix all shell commands with `rtk`, usage examples, and meta commands
+- Installed to `~/.kiro/steering/rtk-rules.md` (global) by `rtk init -g --agent kiro`
+- Installed to `.kiro/steering/rtk-rules.md` (project-local) by `rtk init --agent kiro`
+- Kiro CLI automatically loads all `.md` files from `~/.kiro/steering/` into every conversation context

--- a/hooks/kiro/rules.md
+++ b/hooks/kiro/rules.md
@@ -1,0 +1,32 @@
+# RTK - Rust Token Killer (Kiro CLI)
+
+**Usage**: Token-optimized CLI proxy for shell commands.
+
+## Rule
+
+Always prefix shell commands with `rtk` to minimize token consumption.
+
+Examples:
+
+```bash
+rtk git status
+rtk cargo test
+rtk ls src/
+rtk grep "pattern" src/
+rtk find "*.rs" .
+rtk docker ps
+rtk gh pr list
+```
+
+## Meta Commands
+
+```bash
+rtk gain              # Show token savings
+rtk gain --history    # Command history with savings
+rtk discover          # Find missed RTK opportunities
+rtk proxy <cmd>       # Run raw (no filtering, for debugging)
+```
+
+## Why
+
+RTK filters and compresses command output before it reaches the LLM context, saving 60-90% tokens on common operations. Always use `rtk <cmd>` instead of raw commands.

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -1405,6 +1405,56 @@ fn run_antigravity_mode_at(base_dir: &Path, verbose: u8) -> Result<()> {
     Ok(())
 }
 
+// ─── Kiro CLI support ─────────────────────────────────────────
+
+const KIRO_RULES: &str = include_str!("../../hooks/kiro/rules.md");
+
+pub fn run_kiro_mode(global: bool, verbose: u8) -> Result<()> {
+    run_kiro_mode_at(global, verbose)
+}
+
+fn run_kiro_mode_at(global: bool, verbose: u8) -> Result<()> {
+    // Kiro CLI reads steering files from:
+    //   Global: ~/.kiro/steering/*.md (loaded into every conversation)
+    //   Local:  .kiro/steering/*.md   (project-scoped)
+    let (target_dir, rules_path, scope_label) = if global {
+        let home = dirs::home_dir().context("Cannot determine home directory")?;
+        let dir = home.join(".kiro").join("steering");
+        let path = dir.join("rtk-rules.md");
+        (dir, path, "global (~/.kiro/steering/rtk-rules.md)")
+    } else {
+        let dir = PathBuf::from(".kiro").join("steering");
+        let path = dir.join("rtk-rules.md");
+        (dir, path, "project (.kiro/steering/rtk-rules.md)")
+    };
+
+    let existing = fs::read_to_string(&rules_path).unwrap_or_default();
+    if existing.contains("RTK") || existing.contains("rtk") {
+        println!("\nRTK already configured for Kiro CLI ({scope_label}).\n");
+        println!("  Rules: {scope_label} (already present)");
+    } else {
+        fs::create_dir_all(&target_dir).context("Failed to create Kiro steering directory")?;
+        let new_content = if existing.trim().is_empty() {
+            KIRO_RULES.to_string()
+        } else {
+            format!("{}\n\n{}", existing.trim(), KIRO_RULES)
+        };
+        fs::write(&rules_path, &new_content)
+            .context("Failed to write Kiro steering rules")?;
+
+        if verbose > 0 {
+            eprintln!("Wrote {}", rules_path.display());
+        }
+
+        println!("\nRTK configured for Kiro CLI.\n");
+        println!("  Rules: {scope_label} (installed)");
+    }
+    println!("  Kiro CLI will now use rtk commands for token savings.");
+    println!("  Restart Kiro CLI. Test with: git status\n");
+
+    Ok(())
+}
+
 fn run_codex_mode(global: bool, verbose: u8) -> Result<()> {
     let (agents_md_path, rtk_md_path) = if global {
         let codex_dir = resolve_codex_dir()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,8 @@ pub enum AgentTarget {
     Kilocode,
     /// Google Antigravity
     Antigravity,
+    /// Kiro CLI
+    Kiro,
 }
 
 #[derive(Parser)]
@@ -1785,6 +1787,8 @@ fn run_cli() -> Result<i32> {
                     );
                 }
                 hooks::init::run_antigravity_mode(cli.verbose)?;
+            } else if agent == Some(AgentTarget::Kiro) {
+                hooks::init::run_kiro_mode(global, cli.verbose)?;
             } else {
                 let install_opencode = opencode;
                 let install_claude = !opencode;


### PR DESCRIPTION
## Summary

- Add Kiro CLI as a supported AI coding agent
- Kiro CLI reads steering files from `~/.kiro/steering/` (global) and `.kiro/steering/` (project-local), so RTK installs `rtk-rules.md` into those directories
- Supports both `rtk init -g --agent kiro` (global) and `rtk init --agent kiro` (project-scoped)

## Changes

| File | What |
|------|------|
| `hooks/kiro/rules.md` | Steering rules (same pattern as Cline/Windsurf/Kilocode) |
| `hooks/kiro/README.md` | Hook documentation |
| `src/main.rs` | Add `Kiro` variant to `AgentTarget` enum + routing |
| `src/hooks/init.rs` | `run_kiro_mode()` — global and project-local installation |
| `README.md` | Add Kiro CLI to Quick Start + Supported AI Tools table |

## Usage

bash
rtk init -g --agent kiro     # Global: ~/.kiro/steering/rtk-rules.md
rtk init --agent kiro        # Project: .kiro/steering/rtk-rules.md

## Test plan

- [x] `cargo build` — compiles cleanly (no new warnings)
- [x] `cargo test init` — 72 tests passed, 0 failed
- [x] Manual testing: `rtk init -g --agent kiro` installs rules correctly
- [x] Manual testing: `rtk init --agent kiro` installs project-local rules
- [x] Idempotent: running twice does not duplicate content
- [x] `rtk init --agent kiro --help` shows `kiro: Kiro CLI`