### PR TITLE
fix(discover): encode '.' as '-' in project path slug

### DIFF
--- a/src/discover/provider.rs
+++ b/src/discover/provider.rs
@@ -57,8 +57,9 @@ impl ClaudeProvider {
 
     /// Encode a filesystem path to Claude Code's directory name format.
     /// `/Users/foo/bar` → `-Users-foo-bar`
+    /// `/Users/first.last/bar` → `-Users-first-last-bar`
     pub fn encode_project_path(path: &str) -> String {
-        path.replace('/', "-")
+        path.replace(['/', '.'], "-")
     }
 }
 
@@ -334,6 +335,26 @@ mod tests {
         assert_eq!(
             ClaudeProvider::encode_project_path("/Users/foo/bar/"),
             "-Users-foo-bar-"
+        );
+    }
+
+    #[test]
+    fn test_encode_project_path_dot_in_username() {
+        // Claude Code replaces both '/' and '.' with '-'.
+        // A cwd like /Users/first.last must produce the same slug as
+        // Claude's projects directory (-Users-first-last), otherwise
+        // `rtk discover` finds zero sessions for that project.
+        assert_eq!(
+            ClaudeProvider::encode_project_path("/Users/first.last/my-project"),
+            "-Users-first-last-my-project"
+        );
+    }
+
+    #[test]
+    fn test_encode_project_path_multiple_dots() {
+        assert_eq!(
+            ClaudeProvider::encode_project_path("/Users/a.b.c/proj"),
+            "-Users-a-b-c-proj"
         );
     }
 

--- a/src/discover/provider.rs
+++ b/src/discover/provider.rs
@@ -56,10 +56,24 @@ impl ClaudeProvider {
     }
 
     /// Encode a filesystem path to Claude Code's directory name format.
-    /// `/Users/foo/bar` → `-Users-foo-bar`
-    /// `/Users/first.last/bar` → `-Users-first-last-bar`
+    ///
+    /// Claude Code replaces `/`, `.`, `_`, `\`, and any non-ASCII character
+    /// with `-` when computing the project directory slug under `~/.claude/projects/`.
+    ///
+    /// `/Users/foo/bar`          → `-Users-foo-bar`
+    /// `/Users/first.last/bar`   → `-Users-first-last-bar`
+    /// `/home/chris/2_project`   → `-home-chris-2-project`
+    /// `C:\Users\foo\bar`        → `C:-Users-foo-bar`
     pub fn encode_project_path(path: &str) -> String {
-        path.replace(['/', '.'], "-")
+        path.chars()
+            .map(|c| {
+                if c == '/' || c == '.' || c == '_' || c == '\\' || !c.is_ascii() {
+                    '-'
+                } else {
+                    c
+                }
+            })
+            .collect()
     }
 }
 
@@ -355,6 +369,34 @@ mod tests {
         assert_eq!(
             ClaudeProvider::encode_project_path("/Users/a.b.c/proj"),
             "-Users-a-b-c-proj"
+        );
+    }
+
+    #[test]
+    fn test_encode_project_path_underscore() {
+        // Claude Code also replaces '_' with '-' (https://github.com/anthropics/claude-code/issues/24067)
+        assert_eq!(
+            ClaudeProvider::encode_project_path("/home/chris/2_project-files/proj"),
+            "-home-chris-2-project-files-proj"
+        );
+    }
+
+    #[test]
+    fn test_encode_project_path_non_ascii() {
+        // Non-ASCII characters are each replaced with '-' (https://github.com/anthropics/claude-code/issues/40946)
+        // '/home/user/' + '外' + '主' + '/app' -> '-home-user' + '-' + '-' + '-' + '-' + 'app'
+        assert_eq!(
+            ClaudeProvider::encode_project_path("/home/user/\u{5916}\u{4e3b}/app"),
+            "-home-user----app"
+        );
+    }
+
+    #[test]
+    fn test_encode_project_path_windows() {
+        // Windows backslashes are also replaced with '-'
+        assert_eq!(
+            ClaudeProvider::encode_project_path(r"C:\Users\foo\bar"),
+            "C:-Users-foo-bar"
         );
     }
 

--- a/src/discover/provider.rs
+++ b/src/discover/provider.rs
@@ -65,9 +65,11 @@ impl ClaudeProvider {
     /// `/home/chris/2_project`   → `-home-chris-2-project`
     /// `C:\Users\foo\bar`        → `C:-Users-foo-bar`
     pub fn encode_project_path(path: &str) -> String {
+        const SANITIZED_CHARS: &[char] = &['/', '.', '_', '\\'];
+
         path.chars()
             .map(|c| {
-                if c == '/' || c == '.' || c == '_' || c == '\\' || !c.is_ascii() {
+                if !c.is_ascii() || SANITIZED_CHARS.contains(&c) {
                     '-'
                 } else {
                     c


### PR DESCRIPTION
Claude Code replaces both `/` and `.` with `-` when computing a project directory name from the working directory path. `rtk` only replaced `/`, so for users with a dot in their path (e.g. `/Users/first.last`) the computed slug didn't match Claude's directory name and `rtk discover` returned zero sessions.

The fix is a one-character change in `encode_project_path`: replace `['/', '.']` instead of just `'/'`.

Two tests added to cover the dot case and multiple consecutive dots.

Closes #1457