### PR TITLE
fix(config): parse partial sub-config sections

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -32,6 +32,7 @@ pub struct HooksConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(default)]
 pub struct TrackingConfig {
     pub enabled: bool,
     pub history_days: u32,
@@ -50,6 +51,7 @@ impl Default for TrackingConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(default)]
 pub struct DisplayConfig {
     pub colors: bool,
     pub emoji: bool,
@@ -67,6 +69,7 @@ impl Default for DisplayConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(default)]
 pub struct FilterConfig {
     pub ignore_dirs: Vec<String>,
     pub ignore_files: Vec<String>,
@@ -89,6 +92,7 @@ impl Default for FilterConfig {
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(default)]
 pub struct TelemetryConfig {
     pub enabled: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -98,6 +102,7 @@ pub struct TelemetryConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(default)]
 pub struct LimitsConfig {
     /// Max total grep results to show (default: 200)
     pub grep_max_results: usize,
@@ -247,5 +252,87 @@ consent_date = "2026-04-10T12:00:00Z"
             config.telemetry.consent_date.as_deref(),
             Some("2026-04-10T12:00:00Z")
         );
+    }
+
+    #[test]
+    fn test_partial_tracking_section_uses_defaults() {
+        // Only `enabled` is set; history_days and database_path fall
+        // back to TrackingConfig::default().
+        let toml = r#"
+[tracking]
+enabled = false
+"#;
+        let config: Config = toml::from_str(toml).expect("valid toml");
+        assert!(!config.tracking.enabled);
+        assert_eq!(config.tracking.history_days, DEFAULT_HISTORY_DAYS as u32);
+        assert!(config.tracking.database_path.is_none());
+    }
+
+    #[test]
+    fn test_partial_display_section_uses_defaults() {
+        let toml = r#"
+[display]
+max_width = 200
+"#;
+        let config: Config = toml::from_str(toml).expect("valid toml");
+        assert_eq!(config.display.max_width, 200);
+        assert!(config.display.colors);
+        assert!(config.display.emoji);
+    }
+
+    #[test]
+    fn test_partial_filters_section_uses_defaults() {
+        let toml = r#"
+[filters]
+ignore_dirs = ["dist"]
+"#;
+        let config: Config = toml::from_str(toml).expect("valid toml");
+        assert_eq!(config.filters.ignore_dirs, vec!["dist"]);
+        // Missing ignore_files falls back to the full default list.
+        assert!(config.filters.ignore_files.contains(&"*.lock".to_string()));
+    }
+
+    #[test]
+    fn test_partial_telemetry_section_uses_defaults() {
+        // Previously, omitting `enabled` made the whole section fail to parse.
+        let toml = r#"
+[telemetry]
+consent_given = false
+"#;
+        let config: Config = toml::from_str(toml).expect("valid toml");
+        assert!(!config.telemetry.enabled);
+        assert_eq!(config.telemetry.consent_given, Some(false));
+    }
+
+    #[test]
+    fn test_partial_limits_section_uses_defaults() {
+        let toml = r#"
+[limits]
+grep_max_results = 500
+"#;
+        let config: Config = toml::from_str(toml).expect("valid toml");
+        assert_eq!(config.limits.grep_max_results, 500);
+        assert_eq!(config.limits.grep_max_per_file, 25);
+        assert_eq!(config.limits.status_max_files, 15);
+        assert_eq!(config.limits.status_max_untracked, 10);
+        assert_eq!(config.limits.passthrough_max_chars, 2000);
+    }
+
+    #[test]
+    fn test_full_limits_section_roundtrip() {
+        let toml = r#"
+[limits]
+grep_max_results = 500
+grep_max_per_file = 50
+status_max_files = 25
+status_max_untracked = 15
+passthrough_max_chars = 4000
+"#;
+        let config: Config = toml::from_str(toml).expect("valid toml");
+        assert_eq!(config.limits.grep_max_results, 500);
+        assert_eq!(config.limits.grep_max_per_file, 50);
+        assert_eq!(config.limits.status_max_files, 25);
+        assert_eq!(config.limits.status_max_untracked, 15);
+        assert_eq!(config.limits.passthrough_max_chars, 4000);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1482.

- Five sub-config structs (`TrackingConfig`, `DisplayConfig`, `FilterConfig`, `TelemetryConfig` and `LimitsConfig`) don't have `#[serde(default)]`, so any partial TOML section fails to parse with `missing field`. `Config::load` returns the error, helpers like `config::limits` call `.unwrap_or_default()`, and the user's explicit overrides are silently replaced by the full default config.
- Add struct-level `#[serde(default)]` to each of the five structs. Every one of them already implements `Default` with the correct domain values, so the attribute delegates to what's already there. No logic changes, no duplicated defaults, backward compatible with fully specified configs.

## Test plan

- [x] `cargo fmt --all --check && cargo clippy --all-targets && cargo test`: 1684 passed, 0 failed.
- [x] Six new tests in `src/core/config.rs::tests`:
  - `test_partial_tracking_section_uses_defaults`
  - `test_partial_display_section_uses_defaults`
  - `test_partial_filters_section_uses_defaults`
  - `test_partial_telemetry_section_uses_defaults`
  - `test_partial_limits_section_uses_defaults`
  - `test_full_limits_section_roundtrip` (regression guard for fully specified sections)

## Files Changed

| File | Change |
|------|--------|
| `src/core/config.rs` | Add struct-level `#[serde(default)]` to five sub-config structs; add six parsing tests. |

## Related

- Previously reported in #1134, which was closed as user confusion about `[telemetry]` vs `[tracking]`. The reporter's second example (partial config) was the real bug but never got addressed.
- Previously attempted in #1135, which the author self-closed for branching off `master` instead of `develop`. This PR is a clean resubmission against `develop`.

---
*Co-Authored-By AI (Claude Opus 4.7) via [Pi](https://github.com/badlogic/pi-mono)*
