### PR TITLE
fix(git): passthrough `git branch -v`/`-vv`/`--verbose` in list mode (#1499)

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -1163,6 +1163,17 @@ fn run_branch(args: &[String], verbose: u8, global_args: &[String]) -> Result<i3
     // Detect positional arguments (not flags) — indicates branch creation
     let has_positional_arg = args.iter().any(|a| !a.starts_with('-'));
 
+    // Detect verbose-list intent: the user asked for commit hashes,
+    // `[origin/...]` upstream markers, and subjects. There are two ways
+    // that intent reaches us: either a `-v`/`-vv`/`--verbose` survived
+    // in `args` (trailing position, e.g. `rtk git branch --list -v`), or
+    // rtk's global `--verbose` flag consumed it before the subcommand
+    // was parsed (leading position, e.g. `rtk git branch -vv`). Either
+    // source means the compact `filter_branch_output` would defeat the
+    // flag, so we skip the filter and forward git's output as-is.
+    let verbose_in_args = is_verbose_branch_list(args);
+    let has_verbose_intent = verbose_in_args || verbose > 0;
+
     // --show-current: passthrough with raw stdout (not "ok")
     if has_show_flag {
         let mut cmd = git_cmd(global_args);
@@ -1238,6 +1249,14 @@ fn run_branch(args: &[String], verbose: u8, global_args: &[String]) -> Result<i3
         cmd.arg("-a");
     }
     cmd.arg("--no-color");
+    // If rtk's global `--verbose` swallowed the user's `-v`/`-vv`, forward
+    // the equivalent flag to git. Without this the user's intent never
+    // reaches the child process. `args` is checked first so explicit
+    // `--verbose` / `-v` in args wins and avoids duplicating the flag.
+    if !verbose_in_args && verbose > 0 {
+        let count = verbose.min(2);
+        cmd.arg(format!("-{}", "v".repeat(count as usize)));
+    }
     for arg in args {
         cmd.arg(arg);
     }
@@ -1257,7 +1276,13 @@ fn run_branch(args: &[String], verbose: u8, global_args: &[String]) -> Result<i3
         return Ok(result.exit_code);
     }
 
-    let filtered = filter_branch_output(&result.stdout);
+    let filtered = if has_verbose_intent {
+        // Passthrough: the user asked for verbose format. Trim the
+        // trailing newline so println! doesn't double it.
+        result.stdout.trim_end().to_string()
+    } else {
+        filter_branch_output(&result.stdout)
+    };
     println!("{}", filtered);
 
     timer.track(
@@ -1268,6 +1293,33 @@ fn run_branch(args: &[String], verbose: u8, global_args: &[String]) -> Result<i3
     );
 
     Ok(0)
+}
+
+/// Returns true when `git branch` args request verbose list output
+/// (`-v`, `-vv`, or `--verbose`). Short-flag groups like `-va` and
+/// `-av` are recognized so combined forms pass through too. Long
+/// flags whose name happens to contain `v` (e.g. `--vim`,
+/// `--verify-signatures`) are not matched, and a positional branch
+/// name containing `v` never looks like a short-flag group because
+/// the leading `-` is required.
+fn is_verbose_branch_list(args: &[String]) -> bool {
+    args.iter().any(|a| {
+        if a == "--verbose" {
+            return true;
+        }
+        if let Some(rest) = a.strip_prefix('-') {
+            // Short-flag group: single leading `-`, non-empty tail,
+            // all ASCII letters. Reject `--foo` (starts with `-`)
+            // and bare `-` (empty tail) up front.
+            if !rest.starts_with('-')
+                && !rest.is_empty()
+                && rest.chars().all(|c| c.is_ascii_alphabetic())
+            {
+                return rest.contains('v');
+            }
+        }
+        false
+    })
 }
 
 fn filter_branch_output(output: &str) -> String {
@@ -1900,6 +1952,71 @@ mod tests {
         assert!(result.contains("* main"));
         assert!(result.contains("develop"));
         assert!(!result.contains("remote-only"));
+    }
+
+    // Regression tests for issue #1499: `rtk git branch -vv` stripped
+    // commit hashes, `[origin/...]` upstream markers, and commit subjects
+    // because list mode always ran `filter_branch_output`. The helper
+    // must recognize the canonical spellings, combined short-flag groups,
+    // and reject look-alikes (long flags containing `v`, positional
+    // branch names that happen to contain `v`).
+
+    #[test]
+    fn test_is_verbose_branch_list_canonical_flags() {
+        assert!(is_verbose_branch_list(&["-v".to_string()]));
+        assert!(is_verbose_branch_list(&["-vv".to_string()]));
+        assert!(is_verbose_branch_list(&["--verbose".to_string()]));
+    }
+
+    #[test]
+    fn test_is_verbose_branch_list_combined_with_list_flags() {
+        assert!(is_verbose_branch_list(&[
+            "--list".to_string(),
+            "-v".to_string()
+        ]));
+        assert!(is_verbose_branch_list(&[
+            "-a".to_string(),
+            "-vv".to_string()
+        ]));
+        assert!(is_verbose_branch_list(&[
+            "-vv".to_string(),
+            "--all".to_string()
+        ]));
+    }
+
+    #[test]
+    fn test_is_verbose_branch_list_combined_short_flag_group() {
+        // git accepts combined short-flag groups; `-va` is equivalent
+        // to `-v -a`. Recognize any group that contains `v`.
+        assert!(is_verbose_branch_list(&["-va".to_string()]));
+        assert!(is_verbose_branch_list(&["-av".to_string()]));
+        assert!(is_verbose_branch_list(&["-avv".to_string()]));
+    }
+
+    #[test]
+    fn test_is_verbose_branch_list_no_verbose() {
+        assert!(!is_verbose_branch_list(&[]));
+        assert!(!is_verbose_branch_list(&["-a".to_string()]));
+        assert!(!is_verbose_branch_list(&["--all".to_string()]));
+        assert!(!is_verbose_branch_list(&[
+            "--list".to_string(),
+            "-a".to_string()
+        ]));
+    }
+
+    #[test]
+    fn test_is_verbose_branch_list_does_not_match_long_flags_with_v() {
+        // Long flags whose name contains `v` must not be treated as `-v`.
+        assert!(!is_verbose_branch_list(&["--vim".to_string()]));
+        assert!(!is_verbose_branch_list(&["--verify-signatures".to_string()]));
+    }
+
+    #[test]
+    fn test_is_verbose_branch_list_does_not_match_positional_containing_v() {
+        // A positional branch name lacks the leading `-`, so it can
+        // never look like a short-flag group.
+        assert!(!is_verbose_branch_list(&["vee".to_string()]));
+        assert!(!is_verbose_branch_list(&["feature/v2".to_string()]));
     }
 
     #[test]


### PR DESCRIPTION
Closes #1499.

## Cause

`run_branch` list mode always runs `filter_branch_output`, which compresses `git branch -a`-shaped output into a compact `* current` + locals + `remote-only` block. When the user asks for `-v`/`-vv`/`--verbose`, the filter still ran, stripping the commit hash, `[origin/...]` upstream marker, and subject that `-v` exists to show. From git's point of view the flag had no effect.

The `-v` flag reaches `run_branch` through two different paths depending on position:

1. **trailing position** (`rtk git branch --list -v`): clap's `trailing_var_arg = true` on `Branch { args }` captures `-v` inside `args`.
2. **leading position** (`rtk git branch -vv`): rtk's own `-v` / `--verbose` is declared `global = true` on `Cli`, so clap consumes the `-vv` before the subcommand is parsed. `args` arrives empty and `cli.verbose == 2`.

The original fix I wrote only covered case 1, but the repro in #1499 is case 2, so I had to add the second branch. A small debug build in `/tmp` confirmed the split:

```
$ rtk git branch -vv          → args=[], verbose=2
$ rtk git branch --verbose    → args=[], verbose=1
$ rtk git branch -a -v        → args=["-a","-v"], verbose=0
```

## Fix

`is_verbose_branch_list(args)` recognizes `--verbose` and short-flag groups (so `-v`, `-vv`, `-va`, `-av`, `-avv` all match) while rejecting look-alikes such as `--vim`, `--verify-signatures`, and positional branch names containing `v`. For the case-2 path we inject `-v<N>` before forwarding to `git` so the child process actually sees the flag. Either signal flips `has_verbose_intent`, which bypasses `filter_branch_output` and forwards git's raw output unchanged.

Trade-off: `rtk -v git branch` (rtk-verbose-as-trace) now also forwards `-v` to git and shows verbose branch info. I think this is an improvement; the prior behavior (trace line plus compact list) was an accidental product of the clap collision, and the new behavior matches what anyone typing `-v` near `git branch` actually wants.

## Before / after

Against a small test repo with one local tracking `origin/main` (gone) and one local tracking `origin/feature-1` (gone):

```
$ target/release/rtk-master git branch -vv
git branch
* main
  feature-1

$ target/release/rtk-fix git branch -vv
git branch
  feature-1 7b78477 [origin/feature-1: gone] feature work
* main      8c70500 [origin/main: gone] init

$ RTK_DISABLED=1 git branch -vv
  feature-1 7b78477 [origin/feature-1: gone] feature work
* main      8c70500 [origin/main: gone] init
```

Negative path verified: `rtk git branch` and `rtk git branch -a` still produce the compact filter output.

## Tests

Six new unit tests for `is_verbose_branch_list` covering canonical spellings, combined short-flag groups, no-verbose cases, long flags containing `v`, and positional names containing `v`:

```
test cmds::git::git::tests::test_is_verbose_branch_list_canonical_flags ... ok
test cmds::git::git::tests::test_is_verbose_branch_list_combined_with_list_flags ... ok
test cmds::git::git::tests::test_is_verbose_branch_list_combined_short_flag_group ... ok
test cmds::git::git::tests::test_is_verbose_branch_list_no_verbose ... ok
test cmds::git::git::tests::test_is_verbose_branch_list_does_not_match_long_flags_with_v ... ok
test cmds::git::git::tests::test_is_verbose_branch_list_does_not_match_positional_containing_v ... ok
```

Full suite: `cargo test --bin rtk` → **1612 passed, 6 ignored, 0 failed** on `rust:1.95`. `cargo fmt --all -- --check` clean. `cargo clippy --bin rtk` introduces zero new issues vs master.

## Scope

Only `run_branch` list mode. `--show-current`, write-path (`-d` / `-D` / `-m` / `-M` / rename / upstream edit), and branch creation are untouched. The compact `filter_branch_output` is unchanged so the 80%+ savings on bare `git branch -a` stay intact.