### PR TITLE
fix(ls): preserve .env in default output

### DIFF
--- a/src/cmds/system/constants.rs
+++ b/src/cmds/system/constants.rs
@@ -15,7 +15,6 @@ pub const NOISE_DIRS: &[&str] = &[
     ".venv",
     "venv",
     "env",
-    ".env",
     "coverage",
     ".nyc_output",
     ".DS_Store",

--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -274,6 +274,24 @@ mod tests {
     }
 
     #[test]
+    fn test_compact_preserves_dotenv() {
+        // .env files MUST be visible by default. Hiding them silently caused
+        // agents to assume the project was unconfigured and overwrite the file
+        // with template defaults — destroying production secrets.
+        // See discussion: r/ClaudeCode "Token Optimizers...Silently Dangerous".
+        let input = "total 8\n\
+                     -rw-r--r--  1 user  staff  64 Jan  1 12:00 .env\n\
+                     -rw-r--r--  1 user  staff  64 Jan  1 12:00 .env.local\n\
+                     -rw-r--r--  1 user  staff  64 Jan  1 12:00 .env.example\n\
+                     -rw-r--r--  1 user  staff  100 Jan  1 12:00 main.rs\n";
+        let (entries, _summary) = compact_ls(input, false);
+        assert!(entries.contains(".env"), "default ls must show .env");
+        assert!(entries.contains(".env.local"));
+        assert!(entries.contains(".env.example"));
+        assert!(entries.contains("main.rs"));
+    }
+
+    #[test]
     fn test_compact_show_all() {
         let input = "total 8\n\
                      drwxr-xr-x  2 user  staff  64 Jan  1 12:00 .git\n\


### PR DESCRIPTION
## Problem

`.env` is listed in `NOISE_DIRS` (`src/cmds/system/constants.rs`), so `rtk ls` silently drops it unless the agent passes `-a`. This creates a data-loss hazard:

1. Agent runs `rtk ls` to scan a project's setup state.
2. Output shows `.env.example` but no `.env`.
3. Agent concludes the project isn't configured and writes a fresh `.env` from the template.
4. Real production secrets (DB passwords, API keys) are clobbered.

A user reproduced this directly:

```
$ touch .env
$ rtk ls
.claude/
demo-agents/
README.md  2.6K
notes.md  19.0K
slides.md  31.1K
Summary: 3 files, 2 dirs (3 .md)
```

`.env` is gone from the output. The agent has no way to know it exists.

## Why this matters

`.env` is **configuration the agent must reason about**, not a build artifact like `node_modules/`, `.git/`, or `target/`. The other entries in `NOISE_DIRS` are regenerable; `.env` typically is not.

CONTRIBUTING.md's *Correctness VS Token Savings* principle applies directly:

> When in doubt, preserve correctness.

A few tokens for one filename are cheap. Restoring rotated production credentials is not.

## Fix

Remove `.env` from `NOISE_DIRS`. Sibling entries `.env.local`, `.env.production`, `.env.example` were never matched (the filter uses exact equality), so behavior for those is unchanged — they were already visible. This change only restores `.env` itself.

## Test

Adds `test_compact_preserves_dotenv` covering `.env`, `.env.local`, and `.env.example` to lock in the expected behavior.

```
running 19 tests
test result: ok. 19 passed; 0 failed
```

## Scope

Intentionally narrow. Does not touch:
- `env`, `.venv`, `venv` (Python virtualenv directories — those are regenerable)
- The broader question of whether *any* dotfile filtering belongs in `ls` (see #810)
- `RTK_DISABLED` / `--raw` discussions (#1167, #1171)

Just `.env`. One line in constants, one regression test.