### PR TITLE
feat(telemetry): respect DO_NOT_TRACK opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,7 @@ rtk telemetry forget     # Withdraw consent + delete all local data + request se
 **Override via environment:**
 ```bash
 export RTK_TELEMETRY_DISABLED=1   # Blocks telemetry regardless of consent
+export DO_NOT_TRACK=true          # Standard opt-out convention; 1 also works
 ```
 
 ## Star History

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -130,6 +130,8 @@ rtk telemetry forget     # Withdraw consent + delete local data + request server
 Environment variable override (blocks telemetry regardless of consent):
 ```bash
 export RTK_TELEMETRY_DISABLED=1
+# Standard "do not track" convention is also respected:
+export DO_NOT_TRACK=1             # accepts 1 or true (case-insensitive)
 ```
 
 ## Retention Policy
@@ -147,7 +149,7 @@ Under the EU General Data Protection Regulation, you have the right to:
 - **Erasure** (Art. 17): run `rtk telemetry forget` to delete local data and send an erasure request to the server. Alternatively, email contact@rtk-ai.app with your device hash.
 - **Restriction of processing**: `rtk telemetry disable` stops all data collection immediately.
 - **Portability**: the local SQLite database at `~/.local/share/rtk/tracking.db` contains all locally stored data.
-- **Objection**: `rtk telemetry disable` or `export RTK_TELEMETRY_DISABLED=1`.
+- **Objection**: `rtk telemetry disable`, `export RTK_TELEMETRY_DISABLED=1`, or `export DO_NOT_TRACK=true`.
 
 ## Erasure Procedure
 

--- a/docs/guide/getting-started/configuration.md
+++ b/docs/guide/getting-started/configuration.md
@@ -60,6 +60,7 @@ For full details on what is collected, opt-out options, and GDPR rights, see [Te
 | `RTK_DISABLED=1` | Disable RTK for a single command (`RTK_DISABLED=1 git status`) |
 | `RTK_TEE_DIR` | Override the tee directory |
 | `RTK_TELEMETRY_DISABLED=1` | Disable telemetry |
+| `DO_NOT_TRACK=true` | Disable telemetry using the standard opt-out convention (`1` also works) |
 | `RTK_HOOK_AUDIT=1` | Enable hook audit logging |
 | `SKIP_ENV_VALIDATION=1` | Skip env validation (useful with Next.js) |
 

--- a/docs/guide/resources/telemetry.md
+++ b/docs/guide/resources/telemetry.md
@@ -135,6 +135,8 @@ rtk telemetry forget     # Withdraw consent + delete local data + request server
 Environment variable override (blocks telemetry regardless of consent):
 ```bash
 export RTK_TELEMETRY_DISABLED=1
+# Standard "do not track" convention is also respected:
+export DO_NOT_TRACK=1             # accepts 1 or true (case-insensitive)
 ```
 
 ## Retention Policy
@@ -152,7 +154,7 @@ Under the EU General Data Protection Regulation, you have the right to:
 - **Erasure** (Art. 17): run `rtk telemetry forget` to delete local data and send an erasure request to the server. Alternatively, email contact@rtk-ai.app with your device hash.
 - **Restriction of processing**: `rtk telemetry disable` stops all data collection immediately.
 - **Portability**: the local SQLite database at `~/.local/share/rtk/history.db` contains all locally stored data.
-- **Objection**: `rtk telemetry disable` or `export RTK_TELEMETRY_DISABLED=1`.
+- **Objection**: `rtk telemetry disable`, `export RTK_TELEMETRY_DISABLED=1`, or `export DO_NOT_TRACK=true`.
 
 ## Erasure Procedure
 

--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -1338,6 +1338,7 @@ exclude_commands = []       # Commandes a exclure de la recriture automatique
 |----------|-------------|
 | `RTK_TEE_DIR` | Surcharge le repertoire tee |
 | `RTK_TELEMETRY_DISABLED=1` | Desactiver la telemetrie |
+| `DO_NOT_TRACK=true` | Desactiver la telemetrie via la convention standard (`1` fonctionne aussi) |
 | `RTK_HOOK_AUDIT=1` | Activer l'audit du hook |
 | `SKIP_ENV_VALIDATION=1` | Desactiver la validation d'env (Next.js, etc.) |
 
@@ -1392,6 +1393,7 @@ rtk telemetry forget     # Retirer + supprimer donnees locales + demande d'effac
 **Desactiver via variable d'environnement :**
 ```bash
 export RTK_TELEMETRY_DISABLED=1
+export DO_NOT_TRACK=true  # ou DO_NOT_TRACK=1
 ```
 
 Aucune donnee personnelle, aucun contenu de commande, aucun chemin de fichier n'est transmis. Conservation serveur : 12 mois max. Details : [docs/TELEMETRY.md](../TELEMETRY.md)

--- a/docs/usage/TRACKING.md
+++ b/docs/usage/TRACKING.md
@@ -539,7 +539,7 @@ let _ = conn.execute(
 ## Security & Privacy
 
 - **Local storage only**: Tracking database never leaves the machine
-- **Telemetry requires consent**: RTK can send a daily anonymous usage ping (version, OS, command counts, token savings). Disabled by default, requires explicit consent via `rtk init` or `rtk telemetry enable`. Manage with `rtk telemetry status/disable/forget`. Override: `RTK_TELEMETRY_DISABLED=1`
+- **Telemetry requires consent**: RTK can send a daily anonymous usage ping (version, OS, command counts, token savings). Disabled by default, requires explicit consent via `rtk init` or `rtk telemetry enable`. Manage with `rtk telemetry status/disable/forget`. Override: `RTK_TELEMETRY_DISABLED=1` or `DO_NOT_TRACK=true`/`1`
 - **User control**: Users can delete `~/.local/share/rtk/tracking.db` anytime
 - **90-day retention**: Old data automatically purged
 

--- a/src/core/telemetry.rs
+++ b/src/core/telemetry.rs
@@ -14,6 +14,48 @@ static CACHED_SALT: OnceLock<String> = OnceLock::new();
 const TELEMETRY_URL: Option<&str> = option_env!("RTK_TELEMETRY_URL");
 const TELEMETRY_TOKEN: Option<&str> = option_env!("RTK_TELEMETRY_TOKEN");
 const PING_INTERVAL_SECS: u64 = 23 * 3600; // 23 hours
+const RTK_TELEMETRY_DISABLED_ENV: &str = "RTK_TELEMETRY_DISABLED";
+const DO_NOT_TRACK_ENV: &str = "DO_NOT_TRACK";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TelemetryEnvOverride {
+    RtkTelemetryDisabled,
+    DoNotTrack,
+}
+
+impl TelemetryEnvOverride {
+    pub(crate) fn status_message(self) -> &'static str {
+        match self {
+            Self::RtkTelemetryDisabled => "RTK_TELEMETRY_DISABLED (blocked)",
+            Self::DoNotTrack => "DO_NOT_TRACK (blocked)",
+        }
+    }
+}
+
+pub(crate) fn telemetry_env_override() -> Option<TelemetryEnvOverride> {
+    telemetry_env_override_from_values(
+        std::env::var(RTK_TELEMETRY_DISABLED_ENV).ok().as_deref(),
+        std::env::var(DO_NOT_TRACK_ENV).ok().as_deref(),
+    )
+}
+
+fn telemetry_env_override_from_values(
+    rtk_disabled: Option<&str>,
+    do_not_track: Option<&str>,
+) -> Option<TelemetryEnvOverride> {
+    if rtk_disabled == Some("1") {
+        return Some(TelemetryEnvOverride::RtkTelemetryDisabled);
+    }
+    if do_not_track.is_some_and(is_truthy_env) {
+        return Some(TelemetryEnvOverride::DoNotTrack);
+    }
+    None
+}
+
+fn is_truthy_env(value: &str) -> bool {
+    let v = value.trim();
+    v == "1" || v.eq_ignore_ascii_case("true")
+}
 
 /// Send a telemetry ping if enabled and not already sent today.
 /// Fire-and-forget: errors are silently ignored.
@@ -24,7 +66,7 @@ pub fn maybe_ping() {
     }
 
     // Check opt-out: env var
-    if std::env::var("RTK_TELEMETRY_DISABLED").unwrap_or_default() == "1" {
+    if telemetry_env_override().is_some() {
         return;
     }
 
@@ -490,6 +532,55 @@ mod tests {
     fn test_marker_path_exists() {
         let path = telemetry_marker_path();
         assert!(path.to_string_lossy().contains("rtk"));
+    }
+
+    #[test]
+    fn test_telemetry_env_override_baseline() {
+        assert_eq!(telemetry_env_override_from_values(None, None), None);
+        assert_eq!(telemetry_env_override_from_values(Some(""), Some("")), None);
+    }
+
+    #[test]
+    fn test_telemetry_env_override_honors_rtk_specific_opt_out() {
+        assert_eq!(
+            telemetry_env_override_from_values(Some("1"), None),
+            Some(TelemetryEnvOverride::RtkTelemetryDisabled)
+        );
+
+        for value in ["0", "true", "TRUE", "false", "yes", "no", "", " 1 "] {
+            assert_eq!(
+                telemetry_env_override_from_values(Some(value), None),
+                None,
+                "RTK_TELEMETRY_DISABLED={value:?} should not block telemetry"
+            );
+        }
+    }
+
+    #[test]
+    fn test_telemetry_env_override_honors_do_not_track() {
+        for value in ["true", "TRUE", "TrUe", "1", " true "] {
+            assert_eq!(
+                telemetry_env_override_from_values(None, Some(value)),
+                Some(TelemetryEnvOverride::DoNotTrack),
+                "DO_NOT_TRACK={value:?} should block telemetry"
+            );
+        }
+
+        for value in ["false", "0", "yes", "no", ""] {
+            assert_eq!(
+                telemetry_env_override_from_values(None, Some(value)),
+                None,
+                "DO_NOT_TRACK={value:?} should not block telemetry"
+            );
+        }
+    }
+
+    #[test]
+    fn test_telemetry_env_override_prefers_rtk_specific_opt_out() {
+        assert_eq!(
+            telemetry_env_override_from_values(Some("1"), Some("true")),
+            Some(TelemetryEnvOverride::RtkTelemetryDisabled)
+        );
     }
 
     #[test]

--- a/src/core/telemetry_cmd.rs
+++ b/src/core/telemetry_cmd.rs
@@ -33,7 +33,7 @@ fn run_status() -> Result<()> {
         "no"
     };
 
-    let env_override = std::env::var("RTK_TELEMETRY_DISABLED").unwrap_or_default() == "1";
+    let env_override = super::telemetry::telemetry_env_override();
 
     println!("Telemetry status:");
     println!("  consent:       {}", consent_str);
@@ -41,8 +41,8 @@ fn run_status() -> Result<()> {
         println!("  consent date:  {}", date);
     }
     println!("  enabled:       {}", enabled_str);
-    if env_override {
-        println!("  env override:  RTK_TELEMETRY_DISABLED=1 (blocked)");
+    if let Some(env_override) = env_override {
+        println!("  env override:  {}", env_override.status_message());
     }
 
     let salt_path = super::telemetry::salt_file_path();


### PR DESCRIPTION
## Summary

- Honor the standard `DO_NOT_TRACK` environment variable as a telemetry opt-out.
- Keep the existing `RTK_TELEMETRY_DISABLED=1` behavior unchanged.
- Show the active env override in `rtk telemetry status` and document the new opt-out in telemetry docs.

Fixes #1514

## Behavior

Telemetry is now blocked when either of these environment variables is set:

```bash
RTK_TELEMETRY_DISABLED=1
DO_NOT_TRACK=true  # also accepts DO_NOT_TRACK=1
```

`DO_NOT_TRACK=true` is case-insensitive and trims surrounding whitespace. Non-truthy values such as `false`, `0`, `yes`, `no`, and empty strings do not block telemetry.

## Test plan

- [x] `rtk cargo +1.92.0 fmt --all -- --check`
- [x] `rtk cargo +1.92.0 clippy --all-targets` (passes with pre-existing warnings in unrelated files)
- [x] `rtk cargo +1.92.0 test telemetry_env_override`
- [x] `rtk git diff --check`
- [x] Manual: `DO_NOT_TRACK=1 rtk cargo +1.92.0 run --quiet -- telemetry status` reports `env override:  DO_NOT_TRACK (blocked)`
- [x] Manual: `RTK_TELEMETRY_DISABLED=true rtk cargo +1.92.0 run --quiet -- telemetry status` does not report an env override, preserving the existing exact `=1` RTK-specific behavior

## Full suite note

`rtk cargo +1.92.0 test` was run, but the full suite fails in unrelated existing areas:

- `cmds::cloud::curl_cmd::tests::{test_filter_curl_long_output_truncated,test_filter_curl_multibyte_boundary,test_filter_curl_exact_500_bytes}` fail because the result no longer contains `bytes total`.
- Six `core::tracking` tests fail with `unable to open database file` while creating the tracker.

The new telemetry env override tests pass independently.