### PR TITLE
fix(npx): execute unknown targets via npx, not npm (#1495)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2058,8 +2058,22 @@ fn run_cli() -> Result<i32> {
                 "prettier" => prettier_cmd::run(&args[1..], cli.verbose)?,
                 "playwright" => playwright_cmd::run(&args[1..], cli.verbose)?,
                 _ => {
-                    // Generic passthrough with npm boilerplate filter
-                    npm_cmd::run(&args, cli.verbose, cli.skip_env)?
+                    // Generic npx passthrough — execute via `npx` (binary lookup),
+                    // NOT `npm` (script lookup). Routing through `npm_cmd::run` would
+                    // turn `npx oxlint` into `npm run oxlint`, breaking any binary
+                    // without a matching package.json script entry. See issue #1495.
+                    let timer = core::tracking::TimedExecution::start();
+                    let mut cmd = core::utils::resolved_command("npx");
+                    for arg in &args {
+                        cmd.arg(arg);
+                    }
+                    let status = cmd.status().context("Failed to run npx")?;
+                    let args_str = args.join(" ");
+                    timer.track_passthrough(
+                        &format!("npx {}", args_str),
+                        &format!("rtk npx {} (passthrough)", args_str),
+                    );
+                    core::utils::exit_code_from_status(&status, "npx")
                 }
             }
         }
@@ -2595,6 +2609,25 @@ mod tests {
                 ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
             )),
             Ok(_) => panic!("Expected parse error for unknown subcommand"),
+        }
+    }
+
+    /// Regression test for #1495 — `npx oxlint` was being routed through `npm_cmd::run`
+    /// in the Commands::Npx fallback, which executes `npm` (with `run` injection) and
+    /// produced "Missing script: oxlint" for any binary not declared in package.json.
+    /// Verify that the args still parse cleanly into Commands::Npx so the dispatcher
+    /// reaches the npx-passthrough fallback (binary lookup, not script lookup).
+    #[test]
+    fn test_try_parse_npx_oxlint_routes_to_npx_command() {
+        let result = Cli::try_parse_from(["rtk", "npx", "oxlint", "--fix", "src/"]);
+        assert!(result.is_ok(), "npx oxlint should parse successfully");
+        if let Ok(cli) = result {
+            match cli.command {
+                Commands::Npx { args } => {
+                    assert_eq!(args, vec!["oxlint", "--fix", "src/"]);
+                }
+                _ => panic!("Expected Commands::Npx, got {:?}", cli.command),
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

`rtk npx <unknown_binary>` (e.g. `npx oxlint`) failed with `npm ERR! Missing script: \"<binary>\"` instead of running the binary.

## Root cause

`src/main.rs` Commands::Npx fallback called `npm_cmd::run(&args, ...)`. `npm_cmd::run` invokes `npm` and (when args don't match a known npm subcommand) injects `run`, turning `rtk npx oxlint` into `npm run oxlint`. Any binary not declared as a `package.json` script broke.

## Fix

Replace the `npm_cmd::run` fallback with a proper `npx` passthrough — the same pattern already used a few lines above for `npx prisma <unknown>`:

```rust
let timer = core::tracking::TimedExecution::start();
let mut cmd = core::utils::resolved_command(\"npx\");
for arg in &args { cmd.arg(arg); }
let status = cmd.status().context(\"Failed to run npx\")?;
let args_str = args.join(\" \");
timer.track_passthrough(
    &format!(\"npx {}\", args_str),
    &format!(\"rtk npx {} (passthrough)\", args_str),
);
core::utils::exit_code_from_status(&status, \"npx\")
```

This restores correct binary-lookup semantics (npx) instead of script-lookup (npm), keeps tracking visible in `rtk gain --history`, and propagates the child exit code.

## Test plan

- [x] Added regression test \`test_try_parse_npx_oxlint_routes_to_npx_command\` confirming the dispatcher entrypoint stays correct.
- [x] \`cargo test --all\` → 1682 passed, 0 failed.
- [x] \`cargo fmt --all\` clean.
- [x] Manually verified post-fix: \`rtk npx oxlint --version\` → \`Version: 1.61.0\` (npx auto-installed and ran the binary). Pre-fix it produced \`npm ERR! Missing script: \"oxlint\"\`.
- [x] No behavior change for specialized targets (\`npx tsc\`, \`npx eslint\`, \`npx prisma\`, \`npx next\`, \`npx prettier\`, \`npx playwright\`) — only the catch-all fallback changed.

Closes #1495