### PR TITLE
fix(grep): honor -c count flag (#1452)

### DIFF
--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -15,6 +15,7 @@ pub fn run(
     max_line_len: usize,
     max_results: usize,
     context_only: bool,
+    count: bool,
     file_type: Option<&str>,
     extra_args: &[String],
     verbose: u8,
@@ -23,6 +24,14 @@ pub fn run(
 
     if verbose > 0 {
         eprintln!("grep: '{}' in {}", pattern, path);
+    }
+
+    // #1452: --count short-circuit. Plain `grep -c` returns the bare integer
+    // for a single file (or `path:N` per file when scanning a directory or
+    // multiple files). RTK aggregation/truncation would obscure that integer,
+    // so we bypass the formatter entirely.
+    if count {
+        return run_count(pattern, path, file_type, extra_args, &timer);
     }
 
     // Fix: convert BRE alternation \| → | for rg (which uses PCRE-style regex)
@@ -181,6 +190,88 @@ fn has_format_flag(extra_args: &[String]) -> bool {
                 | "--null"
         )
     })
+}
+
+/// `grep -c` / `rg --count` short-circuit. Mirrors plain `grep -c` semantics:
+///
+/// - Single regular file → the bare integer count (one line, no `path:` prefix).
+/// - Directory or multi-file → `path:count` per file (rg's native `--count` format).
+///
+/// Tracking still records the command but the output is forwarded verbatim so
+/// scripts that capture the count (e.g. `n=$(rtk grep -c pat file)`) keep working.
+fn run_count(
+    pattern: &str,
+    path: &str,
+    file_type: Option<&str>,
+    extra_args: &[String],
+    timer: &tracking::TimedExecution,
+) -> Result<i32> {
+    let rg_pattern = pattern.replace(r"\|", "|");
+
+    let mut rg_cmd = resolved_command("rg");
+    rg_cmd.args(["--count", "--no-heading", "--no-ignore-vcs", &rg_pattern, path]);
+    if let Some(ft) = file_type {
+        rg_cmd.arg("--type").arg(ft);
+    }
+    for arg in extra_args {
+        if arg == "-r" || arg == "--recursive" || arg == "-c" || arg == "--count" {
+            continue;
+        }
+        rg_cmd.arg(arg);
+    }
+
+    let is_single_file = std::path::Path::new(path).is_file();
+
+    let result = exec_capture(&mut rg_cmd)
+        .or_else(|_| {
+            // GNU grep fallback. Recurse for directory paths so `grep -c` doesn't
+            // fail with "Is a directory". `grep -c` on a missing match exits 1 with "0".
+            let mut grep_cmd = resolved_command("grep");
+            if !is_single_file {
+                grep_cmd.arg("-r");
+            }
+            grep_cmd.arg("-c");
+            for arg in extra_args {
+                if arg == "-r" || arg == "--recursive" || arg == "-c" || arg == "--count" {
+                    continue;
+                }
+                grep_cmd.arg(arg);
+            }
+            grep_cmd.args([pattern, path]);
+            exec_capture(&mut grep_cmd)
+        })
+        .context("grep/rg failed")?;
+
+    let raw = result.stdout.clone();
+
+    let formatted = if is_single_file {
+        // rg `--count` emits "path:N"; GNU `grep -c` already emits "N".
+        // Either way, emit just the trailing integer to match `grep -c` semantics.
+        let last_line = raw.lines().last().unwrap_or("");
+        let n = last_line.rsplit(':').next().unwrap_or(last_line).trim();
+        if n.is_empty() {
+            "0".to_string()
+        } else {
+            n.to_string()
+        }
+    } else {
+        // Directory / multi-file: keep "path:N" lines (rg's native format).
+        // Trim trailing newline; we'll re-add a single newline below.
+        raw.trim_end().to_string()
+    };
+
+    println!("{}", formatted);
+    timer.track(
+        &format!("grep -c '{}' {}", pattern, path),
+        "rtk grep --count",
+        &raw,
+        &formatted,
+    );
+
+    // grep/rg exit codes: 0 = match, 1 = no match, 2 = error.
+    // For `--count` semantics we still propagate these so scripts can branch
+    // on `if rtk grep -c pat file >/dev/null; then ...; fi`.
+    Ok(result.exit_code)
 }
 
 fn clean_line(line: &str, max_len: usize, context_re: Option<&Regex>, pattern: &str) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,6 +318,11 @@ enum Commands {
         /// Show line numbers (always on, accepted for grep/rg compatibility)
         #[arg(short = 'n', long)]
         line_numbers: bool,
+        /// Count matching lines (grep/rg -c). The literal `-c` token collides
+        /// with the `context_only` short alias, so `preprocess_argv` rewrites
+        /// `-c` to `--count` after the `grep` subcommand (issue #1452).
+        #[arg(long = "count")]
+        count: bool,
         /// Extra ripgrep arguments (e.g., -i, -A 3, -w, --glob)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         extra_args: Vec<String>,
@@ -1344,11 +1349,48 @@ fn main() {
     std::process::exit(code);
 }
 
+/// Pre-clap argv rewrites for subcommands whose native flags collide with
+/// rtk's reserved short aliases. Today this only affects `rtk grep`, where
+/// `-c` would be eaten by `context_only`'s short alias (issue #1452). The
+/// literal `-c` token is rewritten to `--count` so the count semantics
+/// reach the Grep handler intact. Other subcommands keep their argv unchanged.
+fn preprocess_argv(argv: Vec<OsString>) -> Vec<OsString> {
+    let mut iter = argv.into_iter();
+    let prog = match iter.next() {
+        Some(p) => p,
+        None => return Vec::new(),
+    };
+    let mut out: Vec<OsString> = Vec::with_capacity(8);
+    out.push(prog);
+
+    let subcmd = match iter.next() {
+        Some(s) => s,
+        None => return out,
+    };
+    let is_grep = subcmd.to_str() == Some("grep");
+    out.push(subcmd);
+
+    if !is_grep {
+        out.extend(iter);
+        return out;
+    }
+
+    for arg in iter {
+        let translated = match arg.to_str() {
+            Some("-c") => OsString::from("--count"),
+            _ => arg,
+        };
+        out.push(translated);
+    }
+    out
+}
+
 fn run_cli() -> Result<i32> {
     // Fire-and-forget telemetry ping (1/day, non-blocking)
     core::telemetry::maybe_ping();
 
-    let cli = match Cli::try_parse() {
+    let argv: Vec<OsString> = std::env::args_os().collect();
+    let cli = match Cli::try_parse_from(preprocess_argv(argv)) {
         Ok(cli) => cli,
         Err(e) => {
             if matches!(e.kind(), ErrorKind::DisplayHelp | ErrorKind::DisplayVersion) {
@@ -1738,6 +1780,7 @@ fn run_cli() -> Result<i32> {
             context_only,
             file_type,
             line_numbers: _, // no-op: line numbers always enabled in grep_cmd::run
+            count,
             extra_args,
         } => grep_cmd::run(
             &pattern,
@@ -1745,6 +1788,7 @@ fn run_cli() -> Result<i32> {
             max_len,
             max,
             context_only,
+            count,
             file_type.as_deref(),
             &extra_args,
             cli.verbose,
@@ -3039,5 +3083,48 @@ mod tests {
             }
             _ => panic!("Expected Commands::Npx for unknown tool"),
         }
+    }
+
+    // Regression for #1452: `rtk grep -c PATTERN PATH` must parse with `count`
+    // set, not be eaten by the `context_only` short alias. preprocess_argv
+    // rewrites `-c` to `--count` after the `grep` subcommand.
+    #[test]
+    fn test_preprocess_argv_grep_dash_c_rewritten() {
+        let argv: Vec<OsString> = ["rtk", "grep", "-c", "TODO", "src/"]
+            .iter()
+            .map(OsString::from)
+            .collect();
+        let rewritten = preprocess_argv(argv);
+        let as_str: Vec<&str> = rewritten.iter().filter_map(|s| s.to_str()).collect();
+        assert_eq!(as_str, vec!["rtk", "grep", "--count", "TODO", "src/"]);
+
+        let cli = Cli::try_parse_from(&rewritten).unwrap();
+        match cli.command {
+            Commands::Grep {
+                count,
+                context_only,
+                pattern,
+                path,
+                ..
+            } => {
+                assert!(count, "count flag must be set");
+                assert!(!context_only, "context_only must NOT be set");
+                assert_eq!(pattern, "TODO");
+                assert_eq!(path, "src/");
+            }
+            _ => panic!("Expected Grep command"),
+        }
+    }
+
+    // preprocess_argv must NOT touch `-c` for non-grep subcommands.
+    #[test]
+    fn test_preprocess_argv_non_grep_dash_c_untouched() {
+        let argv: Vec<OsString> = ["rtk", "git", "-c", "user.name=Foo", "log"]
+            .iter()
+            .map(OsString::from)
+            .collect();
+        let rewritten = preprocess_argv(argv);
+        let as_str: Vec<&str> = rewritten.iter().filter_map(|s| s.to_str()).collect();
+        assert_eq!(as_str, vec!["rtk", "git", "-c", "user.name=Foo", "log"]);
     }
 }


### PR DESCRIPTION
## Problem (#1452)

`rtk grep -c PATTERN PATH` ignored the `-c` flag and returned the regular match summary + context lines instead of a line count. Plain `grep -c` and `rg --count` emit a single integer (or `path:N` per file) — the existing rtk behaviour broke any script doing `n=$(rtk grep -c …)`.

## Root cause

The Grep subcommand has `context_only: bool` whose short alias is `-c`. Clap consumed the bare `-c` token before the new `count` flag could be parsed, silently flipping `context_only` on and dropping the pattern positional.

## Fix

1. **New `--count` flag on `Grep`** (`src/main.rs`) routed to a dedicated `run_count` path in `grep_cmd.rs`.
2. **`run_count` helper** invokes `rg --count` (with a GNU `grep -c` fallback) and mirrors plain `grep -c` semantics: bare integer for a single regular file, `path:N` per file for directory / multi-file. Tracking still records the command.
3. **`preprocess_argv` argv rewrite** (`src/main.rs`) translates the literal `-c` token into `--count` only when the `grep` subcommand is in play. Other subcommands (e.g. `git -c user.name=…`) are untouched. This is the minimal escape hatch for the short-alias collision; no other rtk subcommand currently needs it.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test --all` — 1683 passed, 0 failed
- [x] New regression tests in `src/main.rs`:
  - `test_preprocess_argv_grep_dash_c_rewritten` — `rtk grep -c TODO src/` parses with `count=true`, `context_only=false`
  - `test_preprocess_argv_non_grep_dash_c_untouched` — `rtk git -c user.name=Foo log` is left alone
- [x] Smoke test against release binary:
  - `rtk grep -c foo /tmp/t.txt` → `3` (matches plain `grep -c`)
  - `rtk grep -c TODO src/cmds/system/` → `path:N` per file (matches `grep -rc`)

Closes #1452

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Vibe Coded by Ousama Ben Younes_
_Developed With Ora Studio (Claude Code)_
