### PR TITLE
chore: Fix clippy warnings

### DIFF
--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -1,8 +1,10 @@
 use anyhow::{Context, Result};
-use regex::Regex;
 use std::io::{self, BufRead, BufReader, BufWriter, Write};
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
+
+#[cfg(test)]
+use regex::Regex;
 
 pub trait StreamFilter {
     fn feed_line(&mut self, line: &str) -> Option<String>;
@@ -83,7 +85,7 @@ impl<H: BlockHandler> StreamFilter for BlockStreamFilter<H> {
     }
 }
 
-#[allow(dead_code)] // available for command modules; currently used in tests only
+#[cfg(test)] // available for command modules; currently used in tests only
 pub struct RegexBlockFilter {
     start_re: Regex,
     skip_prefixes: Vec<String>,
@@ -91,6 +93,7 @@ pub struct RegexBlockFilter {
     block_count: usize,
 }
 
+#[cfg(test)]
 impl RegexBlockFilter {
     pub fn new(tool_name: &str, start_pattern: &str) -> Self {
         Self {
@@ -103,13 +106,11 @@ impl RegexBlockFilter {
         }
     }
 
-    #[allow(dead_code)]
     pub fn skip_prefix(mut self, prefix: &str) -> Self {
         self.skip_prefixes.push(prefix.to_string());
         self
     }
 
-    #[allow(dead_code)]
     pub fn skip_prefixes(mut self, prefixes: &[&str]) -> Self {
         self.skip_prefixes
             .extend(prefixes.iter().map(|s| s.to_string()));
@@ -117,6 +118,7 @@ impl RegexBlockFilter {
     }
 }
 
+#[cfg(test)]
 impl BlockHandler for RegexBlockFilter {
     fn should_skip(&mut self, line: &str) -> bool {
         self.skip_prefixes.iter().any(|p| line.starts_with(p))
@@ -152,30 +154,9 @@ pub trait StdinFilter: Send {
     fn flush(&mut self) -> String;
 }
 
-#[allow(dead_code)] // test utility: wraps closures as StreamFilter
-pub struct LineFilter<F: FnMut(&str) -> Option<String>> {
-    f: F,
-}
-
-#[allow(dead_code)]
-impl<F: FnMut(&str) -> Option<String>> LineFilter<F> {
-    pub fn new(f: F) -> Self {
-        Self { f }
-    }
-}
-
-impl<F: FnMut(&str) -> Option<String>> StreamFilter for LineFilter<F> {
-    fn feed_line(&mut self, line: &str) -> Option<String> {
-        (self.f)(line)
-    }
-
-    fn flush(&mut self) -> String {
-        String::new()
-    }
-}
-
 pub enum FilterMode<'a> {
     Streaming(Box<dyn StreamFilter + 'a>),
+    #[allow(dead_code)]
     Buffered(Box<dyn Fn(&str) -> String + 'a>),
     CaptureOnly,
     Passthrough,
@@ -197,7 +178,7 @@ pub struct StreamResult {
 }
 
 impl StreamResult {
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn success(&self) -> bool {
         self.exit_code == 0
     }
@@ -344,7 +325,7 @@ pub fn run_streaming(
                 };
                 if is_stderr {
                     if !capped_err {
-                        if raw_stderr.len() + line.len() + 1 <= RAW_CAP {
+                        if raw_stderr.len() + line.len() < RAW_CAP {
                             raw_stderr.push_str(&line);
                             raw_stderr.push('\n');
                         } else {
@@ -353,7 +334,7 @@ pub fn run_streaming(
                         }
                     }
                 } else if !capped_out {
-                    if raw_stdout.len() + line.len() + 1 <= RAW_CAP {
+                    if raw_stdout.len() + line.len() < RAW_CAP {
                         raw_stdout.push_str(&line);
                         raw_stdout.push('\n');
                     } else {
@@ -394,7 +375,7 @@ pub fn run_streaming(
             let mut raw_err = String::new();
             let mut capped = false;
             for line in BufReader::new(stderr).lines().map_while(Result::ok) {
-                if raw_err.len() + line.len() + 1 <= RAW_CAP {
+                if raw_err.len() + line.len() < RAW_CAP {
                     raw_err.push_str(&line);
                     raw_err.push('\n');
                 } else if !capped {
@@ -413,7 +394,7 @@ pub fn run_streaming(
                 FilterMode::Streaming(_) => unreachable!("handled by is_streaming branch"),
                 FilterMode::Buffered(filter_fn) => {
                     for line in BufReader::new(stdout).lines().map_while(Result::ok) {
-                        if raw_stdout.len() + line.len() + 1 <= RAW_CAP {
+                        if raw_stdout.len() + line.len() < RAW_CAP {
                             raw_stdout.push_str(&line);
                             raw_stdout.push('\n');
                         } else if !capped_out {
@@ -438,7 +419,7 @@ pub fn run_streaming(
                 }
                 FilterMode::CaptureOnly => {
                     for line in BufReader::new(stdout).lines().map_while(Result::ok) {
-                        if raw_stdout.len() + line.len() + 1 <= RAW_CAP {
+                        if raw_stdout.len() + line.len() < RAW_CAP {
                             raw_stdout.push_str(&line);
                             raw_stdout.push('\n');
                         } else if !capped_out {
@@ -521,6 +502,26 @@ pub fn exec_capture(cmd: &mut Command) -> Result<CaptureResult> {
 pub(crate) mod tests {
     use super::*;
     use std::process::Command;
+
+    struct LineFilter<F: FnMut(&str) -> Option<String>> {
+        f: F,
+    }
+
+    impl<F: FnMut(&str) -> Option<String>> LineFilter<F> {
+        pub fn new(f: F) -> Self {
+            Self { f }
+        }
+    }
+
+    impl<F: FnMut(&str) -> Option<String>> StreamFilter for LineFilter<F> {
+        fn feed_line(&mut self, line: &str) -> Option<String> {
+            (self.f)(line)
+        }
+
+        fn flush(&mut self) -> String {
+            String::new()
+        }
+    }
 
     #[test]
     fn test_exit_code_zero() {

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -335,6 +335,7 @@ impl Tracker {
         Ok(tracker)
     }
 
+    #[cfg(test)]
     fn init_schema(&self) -> Result<()> {
         self.conn.execute(
             "CREATE TABLE IF NOT EXISTS commands (

--- a/src/discover/lexer.rs
+++ b/src/discover/lexer.rs
@@ -306,6 +306,7 @@ pub fn split_on_operators(cmd: &str, stop_at_pipe: bool) -> Vec<&str> {
     results
 }
 
+#[cfg(test)]
 pub fn strip_quotes(s: &str) -> String {
     let chars: Vec<char> = s.chars().collect();
     if chars.len() >= 2

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -660,10 +660,8 @@ fn rewrite_segment_inner(seg: &str, excluded: &[ExcludePattern], depth: usize) -
             if rest.is_empty() {
                 return None;
             }
-            return match rewrite_segment_inner(rest, excluded, depth + 1) {
-                Some(rewritten) => Some(format!("{} {}", prefix, rewritten)),
-                None => None,
-            };
+            return rewrite_segment_inner(rest, excluded, depth + 1)
+                .map(|rewritten| format!("{} {}", prefix, rewritten));
         }
     }
 

--- a/src/discover/report.rs
+++ b/src/discover/report.rs
@@ -1,6 +1,6 @@
 //! Data types for reporting which commands RTK can and cannot optimize.
 
-use crate::hooks::constants::{HOOKS_SUBDIR, REWRITE_HOOK_FILE};
+use crate::hooks::constants::{CURSOR_DIR, HOOKS_SUBDIR, REWRITE_HOOK_FILE};
 use serde::Serialize;
 
 /// RTK support status for a command.
@@ -171,7 +171,7 @@ pub fn format_text(report: &DiscoverReport, limit: usize, verbose: bool) -> Stri
     // Cursor note: check if Cursor hooks are installed
     if let Some(home) = dirs::home_dir() {
         let cursor_hook = home
-            .join(".cursor")
+            .join(CURSOR_DIR)
             .join(HOOKS_SUBDIR)
             .join(REWRITE_HOOK_FILE);
         if cursor_hook.exists() {

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -13,7 +13,11 @@ pub const CLAUDE_HOOK_COMMAND: &str = "rtk hook claude";
 /// Native Rust hook command for Cursor (replaces rtk-rewrite.sh).
 pub const CURSOR_HOOK_COMMAND: &str = "rtk hook cursor";
 
-pub const OPENCODE_PLUGIN_PATH: &str = ".config/opencode/plugins/rtk.ts";
+pub const CONFIG_DIR: &str = ".config";
+pub const OPENCODE_SUBDIR: &str = "opencode";
+pub const PLUGIN_SUBDIR: &str = "plugins";
+pub const OPENCODE_PLUGIN_FILE: &str = "rtk.ts";
+
 pub const CURSOR_DIR: &str = ".cursor";
 pub const CODEX_DIR: &str = ".codex";
 pub const GEMINI_DIR: &str = ".gemini";

--- a/src/hooks/hook_check.rs
+++ b/src/hooks/hook_check.rs
@@ -4,8 +4,6 @@ use super::constants::{
     CLAUDE_DIR, CLAUDE_HOOK_COMMAND, HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE,
     SETTINGS_JSON,
 };
-#[cfg(test)]
-use super::constants::{CODEX_DIR, CURSOR_DIR, GEMINI_DIR, GEMINI_HOOK_FILE, OPENCODE_PLUGIN_PATH};
 use crate::core::constants::RTK_DATA_DIR;
 use std::path::PathBuf;
 
@@ -135,21 +133,6 @@ pub fn parse_hook_version(content: &str) -> u8 {
     0 // No version tag = version 0 (outdated)
 }
 
-#[cfg(test)]
-fn other_integration_installed(home: &std::path::Path) -> bool {
-    let paths = [
-        home.join(OPENCODE_PLUGIN_PATH),
-        home.join(CURSOR_DIR)
-            .join(HOOKS_SUBDIR)
-            .join(REWRITE_HOOK_FILE),
-        home.join(CODEX_DIR).join("AGENTS.md"),
-        home.join(GEMINI_DIR)
-            .join(HOOKS_SUBDIR)
-            .join(GEMINI_HOOK_FILE),
-    ];
-    paths.iter().any(|p| p.exists())
-}
-
 fn hook_installed_path() -> Option<PathBuf> {
     let home = dirs::home_dir()?;
     let path = home
@@ -171,6 +154,27 @@ fn warn_marker_path() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::hooks::constants::{
+        CODEX_DIR, CONFIG_DIR, CURSOR_DIR, GEMINI_DIR, GEMINI_HOOK_FILE, OPENCODE_PLUGIN_FILE,
+        OPENCODE_SUBDIR, PLUGIN_SUBDIR,
+    };
+
+    fn other_integration_installed(home: &std::path::Path) -> bool {
+        let paths = [
+            home.join(CONFIG_DIR)
+                .join(OPENCODE_SUBDIR)
+                .join(PLUGIN_SUBDIR)
+                .join(OPENCODE_PLUGIN_FILE),
+            home.join(CURSOR_DIR)
+                .join(HOOKS_SUBDIR)
+                .join(REWRITE_HOOK_FILE),
+            home.join(CODEX_DIR).join("AGENTS.md"),
+            home.join(GEMINI_DIR)
+                .join(HOOKS_SUBDIR)
+                .join(GEMINI_HOOK_FILE),
+        ];
+        paths.iter().any(|p| p.exists())
+    }
 
     #[test]
     fn test_parse_hook_version_present() {
@@ -215,7 +219,12 @@ mod tests {
     #[test]
     fn test_other_integration_opencode() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let path = tmp.path().join(OPENCODE_PLUGIN_PATH);
+        let path = tmp
+            .path()
+            .join(CONFIG_DIR)
+            .join(OPENCODE_SUBDIR)
+            .join(PLUGIN_SUBDIR)
+            .join(OPENCODE_PLUGIN_FILE);
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::fs::write(&path, b"plugin").unwrap();
         assert!(other_integration_installed(tmp.path()));

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -6,6 +6,10 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 
+use crate::hooks::constants::{
+    CONFIG_DIR, CURSOR_DIR, GEMINI_DIR, OPENCODE_PLUGIN_FILE, OPENCODE_SUBDIR, PLUGIN_SUBDIR,
+};
+
 use super::constants::{
     BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND,
     GEMINI_HOOK_FILE, HOOKS_JSON, HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
@@ -986,7 +990,7 @@ fn migrate_old_hook_script(verbose: u8) {
             let _ = std::fs::remove_file(&hash_file);
         }
         // Remove Cursor legacy hook
-        let cursor_hook = home.join(".cursor").join("hooks").join(REWRITE_HOOK_FILE);
+        let cursor_hook = home.join(CURSOR_DIR).join("hooks").join(REWRITE_HOOK_FILE);
         if cursor_hook.exists() {
             let _ = std::fs::remove_file(&cursor_hook);
         }
@@ -1758,12 +1762,12 @@ fn codex_rtk_md_ref(codex_dir: &Path) -> String {
 }
 
 fn resolve_opencode_dir() -> Result<PathBuf> {
-    resolve_home_subdir(".config/opencode")
+    resolve_home_subdir(CONFIG_DIR).map(|p| p.join(OPENCODE_SUBDIR))
 }
 
 /// Return OpenCode plugin path: ~/.config/opencode/plugins/rtk.ts
 fn opencode_plugin_path(opencode_dir: &Path) -> PathBuf {
-    opencode_dir.join("plugins").join("rtk.ts")
+    opencode_dir.join(PLUGIN_SUBDIR).join(OPENCODE_PLUGIN_FILE)
 }
 
 /// Prepare OpenCode plugin directory and return install path
@@ -1807,7 +1811,7 @@ fn remove_opencode_plugin(verbose: u8) -> Result<Vec<PathBuf>> {
 // ─── Cursor Agent support ─────────────────────────────────────────────
 
 fn resolve_cursor_dir() -> Result<PathBuf> {
-    resolve_home_subdir(".cursor")
+    resolve_home_subdir(CURSOR_DIR)
 }
 
 /// Install Cursor hooks: register binary command in hooks.json
@@ -2381,7 +2385,7 @@ exec rtk hook gemini
 "#;
 
 fn resolve_gemini_dir() -> Result<PathBuf> {
-    resolve_home_subdir(".gemini")
+    resolve_home_subdir(GEMINI_DIR)
 }
 
 /// Entry point for `rtk init --gemini`

--- a/src/main.rs
+++ b/src/main.rs
@@ -2227,9 +2227,16 @@ fn run_cli() -> Result<i32> {
                     libc::signal(sig, libc::SIG_DFL);
                     libc::raise(sig);
                 }
+                // nosemgrep: unsafe-block
                 unsafe {
-                    libc::signal(libc::SIGINT, handle_signal as libc::sighandler_t);
-                    libc::signal(libc::SIGTERM, handle_signal as libc::sighandler_t);
+                    libc::signal(
+                        libc::SIGINT,
+                        handle_signal as *const () as libc::sighandler_t,
+                    );
+                    libc::signal(
+                        libc::SIGTERM,
+                        handle_signal as *const () as libc::sighandler_t,
+                    );
                 }
             }
 


### PR DESCRIPTION
## Summary

- **Path Centralization:** Hardcoded directory and file paths across all hook logic () are replaced with dedicated, exported constants in . This prevents magic strings and simplifies maintenance when system directories change.
- **Code Cleanup:** Move all code only used by tests behind cfg(test) attribute
- **Refactoring:** Apply Clippy fixes and address remaining warnings

## Test plan
- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] Manual testing: `rtk <command>` output inspected
