### PR TITLE
fix(init): uninstall Codex artifacts in global cleanup

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -245,12 +245,14 @@ rtk vitest
 ```bash
 # Complete removal (global installations only)
 rtk init -g --uninstall
+rtk init -g --codex --uninstall    # Codex-only cleanup
+rtk init -g --gemini --uninstall   # Gemini-only cleanup
 
 # What gets removed:
-#   - Hook: ~/.claude/hooks/rtk-rewrite.sh
-#   - Context: ~/.claude/RTK.md
-#   - Reference: @RTK.md line from ~/.claude/CLAUDE.md
-#   - Registration: RTK hook entry from settings.json
+#   - Claude Code: hook, RTK.md, CLAUDE.md reference, settings.json entry
+#   - Codex CLI: global RTK.md + AGENTS.md reference
+#   - Gemini CLI: hook, GEMINI.md, settings.json entry
+#   - OpenCode / Cursor: global plugin or hook registrations
 
 # Restart Claude Code after uninstall
 ```

--- a/README.md
+++ b/README.md
@@ -395,7 +395,9 @@ For the full config reference (all sections, env vars, per-project filters), see
 ### Uninstall
 
 ```bash
-rtk init -g --uninstall     # Remove hook, RTK.md, settings.json entry
+rtk init -g --uninstall     # Remove all global RTK artifacts
+rtk init -g --codex --uninstall  # Remove only global Codex RTK artifacts
+rtk init -g --gemini --uninstall # Remove only global Gemini RTK artifacts
 cargo uninstall rtk          # Remove binary
 brew uninstall rtk           # If installed via Homebrew
 ```

--- a/docs/guide/getting-started/installation.md
+++ b/docs/guide/getting-started/installation.md
@@ -89,7 +89,9 @@ rtk init --global
 ## Uninstall
 
 ```bash
-rtk init -g --uninstall    # remove hook, RTK.md, and settings.json entry
+rtk init -g --uninstall    # remove all global RTK artifacts
+rtk init -g --codex --uninstall  # remove only global Codex RTK artifacts
+rtk init -g --gemini --uninstall # remove only global Gemini RTK artifacts
 cargo uninstall rtk         # remove binary (if installed via Cargo)
 brew uninstall rtk          # remove binary (if installed via Homebrew)
 ```

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -110,6 +110,8 @@ rtk init --windsurf    # creates .windsurfrules in current project
 
 ```bash
 rtk init --codex    # creates AGENTS.md or patches existing one
+rtk init -g --codex    # installs global Codex instructions in $CODEX_HOME or ~/.codex
+rtk init -g --codex --uninstall    # removes only global Codex RTK artifacts
 ```
 
 ### Kilo Code

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -558,20 +558,11 @@ pub fn uninstall(global: bool, gemini: bool, codex: bool, cursor: bool, verbose:
         return Ok(());
     }
 
-    if !global {
-        anyhow::bail!("Uninstall only works with --global flag. For local projects, manually remove RTK from CLAUDE.md");
-    }
-
-    let claude_dir = resolve_claude_dir()?;
-    let mut removed = Vec::new();
-
-    // Also uninstall Gemini artifacts if --gemini or always (clean everything)
     if gemini {
         let gemini_removed = uninstall_gemini(verbose)?;
-        removed.extend(gemini_removed);
-        if !removed.is_empty() {
+        if !gemini_removed.is_empty() {
             println!("RTK uninstalled (Gemini):");
-            for item in &removed {
+            for item in &gemini_removed {
                 println!("  - {}", item);
             }
             println!("\nRestart Gemini CLI to apply changes.");
@@ -580,6 +571,19 @@ pub fn uninstall(global: bool, gemini: bool, codex: bool, cursor: bool, verbose:
         }
         return Ok(());
     }
+
+    if !global {
+        anyhow::bail!("Uninstall only works with --global flag. For local projects, manually remove RTK from CLAUDE.md");
+    }
+
+    let claude_dir = resolve_claude_dir()?;
+    let mut removed = Vec::new();
+
+    // `rtk init -g --uninstall` is the catch-all global cleanup path.
+    // Keep `--gemini --uninstall` as a targeted Gemini-only uninstall above,
+    // but also remove Gemini artifacts here so global uninstall matches the
+    // user-facing "remove all global RTK artifacts" guidance.
+    removed.extend(uninstall_gemini(verbose)?);
 
     // 1. Remove legacy hook file (if exists from old installation)
     let hook_path = claude_dir.join(HOOKS_SUBDIR).join(REWRITE_HOOK_FILE);
@@ -636,7 +640,13 @@ pub fn uninstall(global: bool, gemini: bool, codex: bool, cursor: bool, verbose:
         removed.push(format!("OpenCode plugin: {}", path.display()));
     }
 
-    // 6. Remove Cursor hooks
+    // 6. Remove Codex global instructions, if any.
+    if let Ok(codex_dir) = resolve_codex_dir() {
+        let codex_removed = uninstall_codex_at(&codex_dir, verbose)?;
+        removed.extend(codex_removed.into_iter().map(|item| format!("Codex {}", item)));
+    }
+
+    // 7. Remove Cursor hooks
     let cursor_removed = remove_cursor_hooks(verbose)?;
     removed.extend(cursor_removed);
 
@@ -648,7 +658,9 @@ pub fn uninstall(global: bool, gemini: bool, codex: bool, cursor: bool, verbose:
         for item in removed {
             println!("  - {}", item);
         }
-        println!("\nRestart Claude Code, OpenCode, and Cursor (if used) to apply changes.");
+        println!(
+            "\nRestart Claude Code, Codex CLI, Gemini CLI, OpenCode, and Cursor (if used) to apply changes."
+        );
     }
 
     Ok(())
@@ -2297,11 +2309,13 @@ fn show_claude_config() -> Result<()> {
     println!("  rtk init -g           # Hook + RTK.md + @RTK.md + settings.json (recommended)");
     println!("  rtk init -g --auto-patch    # Same as above but no prompt");
     println!("  rtk init -g --no-patch      # Skip settings.json (manual setup)");
-    println!("  rtk init -g --uninstall     # Remove all RTK artifacts");
+    println!("  rtk init -g --uninstall     # Remove all global RTK artifacts");
     println!("  rtk init -g --claude-md     # Legacy: full injection into ~/.claude/CLAUDE.md");
     println!("  rtk init -g --hook-only     # Hook only, no RTK.md");
     println!("  rtk init --codex            # Configure local AGENTS.md + RTK.md");
     println!("  rtk init -g --codex         # Configure $CODEX_HOME/AGENTS.md + $CODEX_HOME/RTK.md (or ~/.codex/)");
+    println!("  rtk init -g --codex --uninstall  # Remove only global Codex RTK artifacts");
+    println!("  rtk init -g --gemini --uninstall # Remove only global Gemini RTK artifacts");
     println!("  rtk init -g --opencode      # OpenCode plugin only");
     println!("  rtk init -g --agent cursor  # Install Cursor Agent hooks");
 
@@ -2357,9 +2371,10 @@ fn show_codex_config() -> Result<()> {
     }
 
     println!("\nUsage:");
+    println!("  rtk init -g --uninstall         # Remove all global RTK artifacts");
     println!("  rtk init --codex              # Configure local AGENTS.md + RTK.md");
     println!("  rtk init -g --codex           # Configure $CODEX_HOME/AGENTS.md + $CODEX_HOME/RTK.md (or ~/.codex/)");
-    println!("  rtk init -g --codex --uninstall  # Remove global Codex RTK artifacts");
+    println!("  rtk init -g --codex --uninstall  # Remove only global Codex RTK artifacts");
 
     Ok(())
 }
@@ -3648,10 +3663,10 @@ More notes
     }
 
     use std::sync::Mutex;
-    static CLAUDE_DIR_LOCK: Mutex<()> = Mutex::new(());
+    static ENV_OVERRIDE_LOCK: Mutex<()> = Mutex::new(());
 
     fn with_claude_dir_override<F: FnOnce(&Path)>(tmp: &TempDir, f: F) {
-        let _guard = CLAUDE_DIR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = ENV_OVERRIDE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let claude_dir = tmp.path().join(CLAUDE_DIR);
         fs::create_dir_all(&claude_dir).unwrap();
 
@@ -3661,6 +3676,28 @@ More notes
         match orig {
             Some(v) => std::env::set_var("RTK_CLAUDE_DIR", v),
             None => std::env::remove_var("RTK_CLAUDE_DIR"),
+        }
+    }
+
+    fn with_claude_and_codex_dir_overrides<F: FnOnce(&Path, &Path)>(tmp: &TempDir, f: F) {
+        let _guard = ENV_OVERRIDE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let claude_dir = tmp.path().join(CLAUDE_DIR);
+        let codex_dir = tmp.path().join(CODEX_DIR);
+        fs::create_dir_all(&claude_dir).unwrap();
+        fs::create_dir_all(&codex_dir).unwrap();
+
+        let orig_claude = std::env::var_os("RTK_CLAUDE_DIR");
+        let orig_codex = std::env::var_os("CODEX_HOME");
+        std::env::set_var("RTK_CLAUDE_DIR", &claude_dir);
+        std::env::set_var("CODEX_HOME", &codex_dir);
+        f(&claude_dir, &codex_dir);
+        match orig_claude {
+            Some(v) => std::env::set_var("RTK_CLAUDE_DIR", v),
+            None => std::env::remove_var("RTK_CLAUDE_DIR"),
+        }
+        match orig_codex {
+            Some(v) => std::env::set_var("CODEX_HOME", v),
+            None => std::env::remove_var("CODEX_HOME"),
         }
     }
 
@@ -3699,6 +3736,35 @@ More notes
             assert!(
                 !settings_content.contains(CLAUDE_HOOK_COMMAND),
                 "hook entry must be removed from settings.json"
+            );
+        });
+    }
+
+    #[test]
+    fn test_global_uninstall_removes_codex_artifacts_too() {
+        let tmp = TempDir::new().unwrap();
+        with_claude_and_codex_dir_overrides(&tmp, |claude_dir, codex_dir| {
+            run_default_mode(true, PatchMode::Auto, 0, false).unwrap();
+            run_codex_mode(true, 0).unwrap();
+
+            let codex_ref = codex_rtk_md_ref(codex_dir);
+            let agents_md = codex_dir.join(AGENTS_MD);
+            let codex_rtk_md = codex_dir.join(RTK_MD);
+
+            assert!(codex_rtk_md.exists(), "Codex RTK.md must be created");
+            assert!(
+                fs::read_to_string(&agents_md).unwrap().contains(&codex_ref),
+                "Codex AGENTS.md must reference RTK.md"
+            );
+
+            uninstall(true, false, false, false, 0).unwrap();
+
+            assert!(!claude_dir.join(RTK_MD).exists(), "Claude RTK.md must be removed");
+            assert!(!codex_rtk_md.exists(), "Codex RTK.md must be removed");
+            let agents_content = fs::read_to_string(&agents_md).unwrap_or_default();
+            assert!(
+                !agents_content.contains(&codex_ref),
+                "Codex AGENTS.md reference must be removed"
             );
         });
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -345,7 +345,7 @@ enum Commands {
         #[arg(long = "no-patch", group = "patch")]
         no_patch: bool,
 
-        /// Remove RTK artifacts for the selected assistant mode
+        /// Remove RTK artifacts for the selected assistant mode, or all global installs when no mode flag is provided
         #[arg(long)]
         uninstall: bool,
 


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

- Make `rtk init -g --uninstall` clean up global Codex and Gemini artifacts in addition to the existing global RTK uninstall flow.
- Add a regression test covering global Codex uninstall behavior and keep targeted `--codex --uninstall` / `--gemini --uninstall` paths intact.
- Clarify CLI/help text and installation docs so uninstall behavior matches what the command actually does.

## Test plan
<!-- How did you verify this works? -->

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
  - `test result: ok. 1607 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 0.97s`
- [x] `cargo test uninstall -- --nocapture`
- [x] Manual CLI smoke test: global Codex install + `rtk init -g --uninstall` with temp `RTK_CLAUDE_DIR` / `CODEX_HOME`, verified `RTK.md` and the `AGENTS.md` reference were removed
- [x] Manual CLI smoke test: global Gemini install + `rtk init -g --uninstall` with temp `HOME`, verified `.gemini/GEMINI.md` and `.gemini/hooks/rtk-gemini.sh` were removed

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
