### PR TITLE
feat: infer pnpm bare scripts through run

### DIFF
--- a/src/cmds/js/pnpm_cmd.rs
+++ b/src/cmds/js/pnpm_cmd.rs
@@ -63,12 +63,36 @@ const PNPM_SUBCOMMANDS: &[&str] = &[
     "workspace",
 ];
 
+fn split_pnpm_global_args(args: &[OsString]) -> (&[OsString], &[OsString]) {
+    let split_at = args
+        .iter()
+        .take_while(|arg| {
+            arg.to_str()
+                .map(|arg| arg.starts_with("--filter="))
+                .unwrap_or(false)
+        })
+        .count();
+
+    args.split_at(split_at)
+}
+
 fn needs_run_injection(args: &[OsString]) -> bool {
-    let Some(first) = args.first().and_then(|arg| arg.to_str()) else {
+    let (_, command_args) = split_pnpm_global_args(args);
+    let Some(first) = command_args.first().and_then(|arg| arg.to_str()) else {
         return false;
     };
 
     !first.starts_with('-') && !PNPM_SUBCOMMANDS.contains(&first)
+}
+
+fn pnpm_run_args(args: &[OsString]) -> Vec<OsString> {
+    let (global_args, script_args) = split_pnpm_global_args(args);
+    global_args
+        .iter()
+        .cloned()
+        .chain(std::iter::once(OsString::from("run")))
+        .chain(script_args.iter().cloned())
+        .collect()
 }
 
 fn filter_pnpm_script_output(output: &str) -> String {
@@ -580,19 +604,19 @@ pub fn run_other(args: &[OsString], verbose: u8) -> Result<i32> {
         return run_passthrough(args, verbose);
     }
 
+    let run_args = pnpm_run_args(args);
     let mut cmd = resolved_command("pnpm");
-    cmd.arg("run");
-    cmd.args(args);
+    cmd.args(&run_args);
 
-    let args_display = tracking::args_display(args);
+    let args_display = tracking::args_display(&run_args);
     if verbose > 0 {
-        eprintln!("Running: pnpm run {}", args_display);
+        eprintln!("Running: pnpm {}", args_display);
     }
 
     runner::run_filtered(
         cmd,
         "pnpm",
-        &format!("run {}", args_display),
+        &args_display,
         filter_pnpm_script_output,
         runner::RunOptions::default(),
     )
@@ -624,6 +648,15 @@ mod tests {
             );
         }
 
+        assert!(needs_run_injection(&[
+            OsString::from("--filter=@app/web"),
+            OsString::from("build")
+        ]));
+        assert!(!needs_run_injection(&[
+            OsString::from("--filter=@app/web"),
+            OsString::from("install")
+        ]));
+
         for script in [
             "build",
             "dev",
@@ -644,6 +677,27 @@ mod tests {
                 script
             );
         }
+    }
+
+    #[test]
+    fn test_pnpm_run_args_preserve_global_filters() {
+        let args = [
+            OsString::from("--filter=@app/web"),
+            OsString::from("l2"),
+            OsString::from("--"),
+            OsString::from("--human"),
+        ];
+        let run_args = pnpm_run_args(&args);
+        assert_eq!(
+            run_args,
+            vec![
+                OsString::from("--filter=@app/web"),
+                OsString::from("run"),
+                OsString::from("l2"),
+                OsString::from("--"),
+                OsString::from("--human"),
+            ]
+        );
     }
 
     #[test]

--- a/src/cmds/js/pnpm_cmd.rs
+++ b/src/cmds/js/pnpm_cmd.rs
@@ -1,5 +1,6 @@
 //! Filters pnpm output — dependency trees, install logs, outdated packages.
 
+use crate::core::runner;
 use crate::core::stream::exec_capture;
 use crate::core::tracking;
 use crate::core::utils::resolved_command;
@@ -12,6 +13,87 @@ use crate::parser::{
     emit_degradation_warning, emit_passthrough_warning, truncate_passthrough, Dependency,
     DependencyState, FormatMode, OutputParser, ParseResult, TokenFormatter,
 };
+
+const PNPM_SUBCOMMANDS: &[&str] = &[
+    "add",
+    "approve-builds",
+    "audit",
+    "bin",
+    "catalog",
+    "config",
+    "create",
+    "dedupe",
+    "deploy",
+    "dlx",
+    "env",
+    "exec",
+    "explain",
+    "fetch",
+    "help",
+    "i",
+    "import",
+    "init",
+    "install",
+    "licenses",
+    "link",
+    "list",
+    "ln",
+    "ls",
+    "outdated",
+    "pack",
+    "patch",
+    "patch-commit",
+    "patch-remove",
+    "prune",
+    "publish",
+    "rebuild",
+    "remove",
+    "root",
+    "run",
+    "run-script",
+    "self-update",
+    "setup",
+    "store",
+    "test",
+    "unlink",
+    "uninstall",
+    "update",
+    "up",
+    "why",
+    "workspace",
+];
+
+fn needs_run_injection(args: &[OsString]) -> bool {
+    let Some(first) = args.first().and_then(|arg| arg.to_str()) else {
+        return false;
+    };
+
+    !first.starts_with('-') && !PNPM_SUBCOMMANDS.contains(&first)
+}
+
+fn filter_pnpm_script_output(output: &str) -> String {
+    let mut result = Vec::new();
+
+    for line in output.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        if trimmed.starts_with('>') && (trimmed.contains('@') || trimmed[1..].trim_start().contains(' ')) {
+            continue;
+        }
+
+        result.push(line.to_string());
+    }
+
+    if result.is_empty() {
+        "ok".to_string()
+    } else {
+        result.join("\n")
+    }
+}
 
 /// pnpm list JSON output structure
 #[derive(Debug, Deserialize)]
@@ -493,6 +575,29 @@ fn filter_pnpm_install(output: &str) -> String {
     }
 }
 
+pub fn run_other(args: &[OsString], verbose: u8) -> Result<i32> {
+    if !needs_run_injection(args) {
+        return run_passthrough(args, verbose);
+    }
+
+    let mut cmd = resolved_command("pnpm");
+    cmd.arg("run");
+    cmd.args(args);
+
+    let args_display = tracking::args_display(args);
+    if verbose > 0 {
+        eprintln!("Running: pnpm run {}", args_display);
+    }
+
+    runner::run_filtered(
+        cmd,
+        "pnpm",
+        &format!("run {}", args_display),
+        filter_pnpm_script_output,
+        runner::RunOptions::default(),
+    )
+}
+
 pub fn run_passthrough(args: &[OsString], verbose: u8) -> Result<i32> {
     crate::core::runner::run_passthrough("pnpm", args, verbose)
 }
@@ -500,6 +605,67 @@ pub fn run_passthrough(args: &[OsString], verbose: u8) -> Result<i32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_pnpm_subcommand_routing() {
+        for subcmd in PNPM_SUBCOMMANDS {
+            assert!(
+                !needs_run_injection(&[OsString::from(subcmd)]),
+                "'pnpm {}' should NOT inject 'run'",
+                subcmd
+            );
+        }
+
+        for flag in ["--version", "-v", "--help"] {
+            assert!(
+                !needs_run_injection(&[OsString::from(flag)]),
+                "'pnpm {}' should NOT inject 'run'",
+                flag
+            );
+        }
+
+        for script in [
+            "build",
+            "dev",
+            "lint",
+            "typecheck",
+            "test:coverage",
+            "test:changed-surface:run",
+            "l1",
+            "l2",
+            "l3",
+            "smoke",
+            "comp",
+            "surface:run",
+        ] {
+            assert!(
+                needs_run_injection(&[OsString::from(script)]),
+                "'pnpm {}' SHOULD inject 'run'",
+                script
+            );
+        }
+    }
+
+    #[test]
+    fn test_filter_pnpm_script_output() {
+        let output = r#"
+> my-project@0.1.0 build /repo
+> next build
+
+▲ Next.js 16.1.6
+✓ Compiled successfully in 47s
+"#;
+        let result = filter_pnpm_script_output(output);
+        assert!(!result.contains("> my-project@"));
+        assert!(!result.contains("> next build"));
+        assert!(result.contains("Compiled successfully"));
+    }
+
+    #[test]
+    fn test_filter_pnpm_script_output_empty() {
+        let result = filter_pnpm_script_output("\n\n");
+        assert_eq!(result, "ok");
+    }
 
     #[test]
     fn test_pnpm_list_parser_json() {

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -2771,19 +2771,22 @@ mod tests {
     #[test]
     fn test_rewrite_pnpm_command() {
         let commands = vec![
-            "exec",
-            "i",
-            "install",
-            "list",
-            "ls",
-            "outdated",
-            "run",
-            "run-script",
+            ("exec", "rtk pnpm exec"),
+            ("i", "rtk pnpm i"),
+            ("install", "rtk pnpm install"),
+            ("list", "rtk pnpm list"),
+            ("ls", "rtk pnpm ls"),
+            ("outdated", "rtk pnpm outdated"),
+            ("run", "rtk pnpm run"),
+            ("run-script", "rtk pnpm run-script"),
+            ("build", "rtk pnpm build"),
+            ("test:coverage", "rtk pnpm test:coverage"),
+            ("l2 -- --human", "rtk pnpm l2 -- --human"),
         ];
-        for command in commands {
+        for (command, expected) in commands {
             assert_eq!(
                 rewrite_command(format!("pnpm {command}").as_str(), &[]),
-                Some(format!("rtk pnpm {command}")),
+                Some(expected.to_string()),
                 "Failed for command: pnpm {}",
                 command
             );
@@ -2812,6 +2815,14 @@ mod tests {
         assert_eq!(
             rewrite_command("npm exec vitest", &[]),
             Some("rtk vitest".to_string()),
+        );
+    }
+
+    #[test]
+    fn test_rewrite_compound_pnpm_and_git() {
+        assert_eq!(
+            rewrite_command("pnpm build && git status", &[]),
+            Some("rtk pnpm build && rtk git status".into())
         );
     }
 

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -53,7 +53,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[("fmt", RtkStatus::Passthrough)],
     },
     RtkRule {
-        pattern: r"^pnpm\s+(exec|i|install|list|ls|outdated|run|run-script)",
+        pattern: r"^pnpm\s+",
         rtk_cmd: "rtk pnpm",
         rewrite_prefixes: &["pnpm"],
         category: "PackageManager",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1303,6 +1303,13 @@ fn merge_pnpm_args_os(filters: &[String], args: &[OsString]) -> Vec<OsString> {
         .collect()
 }
 
+fn normalize_hook_check_command(command: &[String]) -> String {
+    match command {
+        [shell, inner] if matches!(shell.as_str(), "bash" | "sh" | "zsh") => inner.clone(),
+        _ => command.join(" "),
+    }
+}
+
 /// Validate that pnpm filters are only used in the global context, not before subcommands like tsc.
 fn validate_pnpm_filters(filters: &[String], command: &PnpmCommands) -> Option<String> {
     // Check if this is a Build or Typecheck command with filters
@@ -1592,7 +1599,7 @@ fn run_cli() -> Result<i32> {
                 )?,
                 PnpmCommands::Typecheck { args } => tsc_cmd::run(&args, cli.verbose)?,
                 PnpmCommands::Other(args) => {
-                    pnpm_cmd::run_passthrough(&merge_pnpm_args_os(&filter, &args), cli.verbose)?
+                    pnpm_cmd::run_other(&merge_pnpm_args_os(&filter, &args), cli.verbose)?
                 }
             }
         }
@@ -2118,7 +2125,7 @@ fn run_cli() -> Result<i32> {
             }
             HookCommands::Check { agent: _, command } => {
                 use crate::discover::registry::rewrite_command;
-                let raw = command.join(" ");
+                let raw = normalize_hook_check_command(&command);
                 let excluded = crate::core::config::Config::load()
                     .map(|c| c.hooks.exclude_commands)
                     .unwrap_or_default();
@@ -2716,6 +2723,22 @@ mod tests {
             }
             _ => panic!("Expected Hook Check command"),
         }
+    }
+
+    #[test]
+    fn test_normalize_hook_check_command_shell_wrapper() {
+        assert_eq!(
+            normalize_hook_check_command(&["bash".into(), "pnpm build".into()]),
+            "pnpm build"
+        );
+        assert_eq!(
+            normalize_hook_check_command(&["sh".into(), "git status".into()]),
+            "git status"
+        );
+        assert_eq!(
+            normalize_hook_check_command(&["pnpm".into(), "build".into()]),
+            "pnpm build"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- make `rtk pnpm <script>` infer `pnpm run <script>` for bare script names while keeping specialized pnpm commands unchanged
- preserve pnpm global filters before the injected `run` subcommand for workspace-filtered scripts
- broaden pnpm discover rewrite coverage and add regression tests for script classification, output filtering, rewrite, hook check, and filtered script arg ordering

## Test plan
- [x] `rtk cargo test --manifest-path /root/TAO/Tools/rtk/Cargo.toml test_pnpm_subcommand_routing`
- [x] `rtk cargo test --manifest-path /root/TAO/Tools/rtk/Cargo.toml test_pnpm_run_args_preserve_global_filters`
- [x] `rtk cargo test --manifest-path /root/TAO/Tools/rtk/Cargo.toml test_filter_pnpm_script_output`
- [x] `rtk cargo test --manifest-path /root/TAO/Tools/rtk/Cargo.toml test_rewrite_pnpm_command`
- [x] `rtk cargo test --manifest-path /root/TAO/Tools/rtk/Cargo.toml test_rewrite_compound_pnpm_and_git`
- [x] `rtk cargo test --manifest-path /root/TAO/Tools/rtk/Cargo.toml test_normalize_hook_check_command_shell_wrapper`
- [x] `rtk cargo build --manifest-path /root/TAO/Tools/rtk/Cargo.toml`
- [x] `rtk cargo clippy --manifest-path /root/TAO/Tools/rtk/Cargo.toml --all-targets`
- [x] `rtk cargo test --manifest-path /root/TAO/Tools/rtk/Cargo.toml --all`
- [x] `rtk cargo run --manifest-path /root/TAO/Tools/rtk/Cargo.toml -- rewrite pnpm build`
- [x] `rtk cargo run --manifest-path /root/TAO/Tools/rtk/Cargo.toml -- rewrite pnpm test:coverage`
- [x] `rtk cargo run --manifest-path /root/TAO/Tools/rtk/Cargo.toml -- hook check bash \"pnpm build\"`
- [x] `/root/TAO/Tools/rtk/target/debug/rtk pnpm build` from `/root/TAO/Projects/MyRemotely/web-app`
- [x] `/root/TAO/Tools/rtk/target/debug/rtk -v pnpm --filter @app/web build` confirms native shape `pnpm --filter=@app/web run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)