### PR TITLE
fix(config): add #[serde(default)] to partial config sections

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -32,6 +32,7 @@ pub struct HooksConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(default)]
 pub struct TrackingConfig {
     pub enabled: bool,
     pub history_days: u32,
@@ -50,6 +51,7 @@ impl Default for TrackingConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(default)]
 pub struct DisplayConfig {
     pub colors: bool,
     pub emoji: bool,
@@ -67,6 +69,7 @@ impl Default for DisplayConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(default)]
 pub struct FilterConfig {
     pub ignore_dirs: Vec<String>,
     pub ignore_files: Vec<String>,
@@ -89,6 +92,7 @@ impl Default for FilterConfig {
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(default)]
 pub struct TelemetryConfig {
     pub enabled: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -98,6 +102,7 @@ pub struct TelemetryConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(default)]
 pub struct LimitsConfig {
     /// Max total grep results to show (default: 200)
     pub grep_max_results: usize,


### PR DESCRIPTION
## Summary

Partial TOML config sections like `[limits]` now parse correctly when only some fields are specified.

**Root cause**: Without `#[serde(default)]`, missing fields in a TOML section cause `toml::from_str` to return a `missing field` error. This bubbles up to `Config::load()`, which silently falls back to full defaults — discarding every user-specified override.

**Fix**: Added `#[serde(default)]` to five sub-config structs: `TrackingConfig`, `DisplayConfig`, `FilterConfig`, `TelemetryConfig`, `LimitsConfig`. Each already implements `Default` with correct values, so serde now falls back to those defaults for any missing fields.

Fixes: rtk-ai/rtk#1482

## Test Plan

- [x] `cargo test config` — 14 tests pass
- [ ] Manual: `[limits]` with only `grep_max_results = 500` applies correctly