### PR TITLE
fix(git): clarify stash push no-op output

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -1463,7 +1463,7 @@ fn run_stash(
             let combined = result.combined();
 
             let msg = if result.success() {
-                let msg = format!("ok stash {}", sub);
+                let msg = stash_success_message(sub, &result.stdout);
                 println!("{}", msg);
                 msg
             } else {
@@ -1555,6 +1555,14 @@ fn run_stash(
     }
 
     Ok(0)
+}
+
+fn stash_success_message(sub: &str, stdout: &str) -> String {
+    if sub == "push" && stdout.contains("No local changes") {
+        "ok (nothing to stash)".to_string()
+    } else {
+        format!("ok stash {}", sub)
+    }
 }
 
 fn filter_stash_list(output: &str) -> String {
@@ -2011,6 +2019,13 @@ mod tests {
         let result = filter_stash_list(output);
         assert!(result.contains("stash@{0}: abc1234 fix login"));
         assert!(result.contains("stash@{1}: def5678 wip"));
+    }
+
+    #[test]
+    fn test_stash_push_noop_success_message() {
+        let output = "No local changes to save\n";
+        let result = stash_success_message("push", output);
+        assert_eq!(result, "ok (nothing to stash)");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- make explicit `rtk git stash push` report `ok (nothing to stash)` when git reports no local changes
- keep existing non-zero exit propagation for failing stash subcommands unchanged
- add a regression unit test for the no-op stash push message

Closes #1535

## Test plan

- [x] `cargo test test_stash_push_noop_success_message -- --nocapture`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D unsafe_code`
- [x] `cargo test --all`
- [x] `bash scripts/check-test-presence.sh origin/develop`
- [x] Manual testing: in a clean temp git repo, `rtk git stash push` now returns rc=0 with `ok (nothing to stash)`; `rtk git stash pop/apply/drop` still return rc=1 with `FAILED: git stash <sub>`.

Note: on the current `develop` branch, the non-zero exit status handling for failed `pop/apply/drop/push` was already present. This PR fixes the remaining ambiguous success output for explicit `stash push` when there is nothing to stash.
