### PR TITLE
feat(kimi): add Kimi CLI integration with deny-with-suggestion hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "rtk"
-version = "0.36.0"
+version = "0.34.3"
 dependencies = [
  "anyhow",
  "automod",

--- a/hooks/kimi/README.md
+++ b/hooks/kimi/README.md
@@ -1,0 +1,28 @@
+# Kimi CLI Hooks
+
+> Part of [`hooks/`](../README.md) — see also [`src/hooks/`](../../src/hooks/README.md) for installation code
+
+## Specifics
+
+- Uses the `rtk hook kimi` Rust binary (no `jq` dependency)
+- Kimi CLI's PreToolUse hook is **deny-only** — it cannot rewrite the command
+  via `updatedInput`. RTK responds with `permissionDecision: "deny"` and a
+  suggestion in `permissionDecisionReason`. Kimi feeds the reason back to the
+  LLM, which retries with the suggested `rtk <cmd>` form.
+- Configuration lives in `~/.kimi/config.toml` as a `[[hooks]]` block
+  (kimi-cli is global-config-based).
+- Rules live in `~/.kimi/rtk-rules.md` — reference them from your KIMI.md or
+  system prompt so the model uses `rtk` proactively.
+
+## Install
+
+```bash
+rtk init -g --agent kimi
+```
+
+## Test
+
+```bash
+echo '{"tool_name":"Shell","tool_input":{"command":"git status"}}' | rtk hook kimi
+# {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Use `rtk git status` instead — RTK saves 60-90% tokens"}}
+```

--- a/hooks/kimi/rules.md
+++ b/hooks/kimi/rules.md
@@ -1,0 +1,34 @@
+# RTK - Rust Token Killer (Kimi CLI)
+
+**Usage**: Token-optimized CLI proxy for shell commands.
+
+## Rule
+
+Always prefix shell commands with `rtk` to minimize token consumption.
+
+Examples:
+
+```bash
+rtk git status
+rtk cargo test
+rtk ls src/
+rtk grep "pattern" src/
+rtk find "*.rs" .
+rtk docker ps
+rtk gh pr list
+```
+
+## Meta Commands
+
+```bash
+rtk gain              # Show token savings
+rtk gain --history    # Command history with savings
+rtk discover          # Find missed RTK opportunities
+rtk proxy <cmd>       # Run raw (no filtering, for debugging)
+```
+
+## Why
+
+RTK filters and compresses command output before it reaches the LLM context, saving 60-90% tokens on common operations. Always use `rtk <cmd>` instead of raw commands.
+
+A `PreToolUse` hook is installed: if you submit a shell command without the `rtk` prefix, it will be denied with a suggestion to retry using `rtk <cmd>`.

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -506,6 +506,69 @@ fn run_cursor_inner_with_rules(
     }
 }
 
+// ── Kimi CLI hook ─────────────────────────────────────────────
+
+/// Run the Kimi CLI PreToolUse hook.
+///
+/// Kimi's hook protocol is deny-only — we cannot rewrite the command via
+/// `updatedInput`. Instead, when an unprefixed command would be rewritten by
+/// the engine, we emit `permissionDecision: "deny"` with a reason instructing
+/// the LLM to retry with the `rtk`-prefixed form. Kimi feeds the reason back
+/// into the model context so it self-corrects.
+pub fn run_kimi() -> Result<()> {
+    let input = read_stdin_limited()?;
+    let _ = writeln!(io::stdout(), "{}", run_kimi_inner(input.trim()));
+    Ok(())
+}
+
+fn run_kimi_inner(input: &str) -> String {
+    if input.is_empty() {
+        return "{}".to_string();
+    }
+
+    let v: Value = match serde_json::from_str(input) {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = writeln!(io::stderr(), "[rtk hook] Failed to parse JSON input: {e}");
+            return "{}".to_string();
+        }
+    };
+
+    // Kimi sends `tool_name = "Shell"` for shell commands. Anything else: passthrough.
+    let tool_name = v.get("tool_name").and_then(|t| t.as_str()).unwrap_or("");
+    if !matches!(tool_name, "Shell" | "Bash" | "bash" | "shell") {
+        return "{}".to_string();
+    }
+
+    let cmd = match v
+        .pointer("/tool_input/command")
+        .and_then(|c| c.as_str())
+        .filter(|c| !c.is_empty())
+    {
+        Some(c) => c,
+        None => return "{}".to_string(),
+    };
+
+    let rewritten = match get_rewritten(cmd) {
+        Some(r) => r,
+        None => return "{}".to_string(),
+    };
+
+    audit_log("rewrite", cmd, &rewritten);
+
+    json!({
+        "hookSpecificOutput": {
+            "hookEventName": PRE_TOOL_USE_KEY,
+            "permissionDecision": "deny",
+            "permissionDecisionReason": format!(
+                "Use `{}` instead — RTK saves 60-90% tokens",
+                rewritten
+            )
+        }
+    })
+    .to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -904,5 +967,83 @@ mod tests {
             get_rewritten("cargo test").is_some(),
             "cargo test should be rewritable when not denied"
         );
+    }
+
+    // --- Kimi CLI hook ---
+
+    fn kimi_input(tool: &str, cmd: &str) -> String {
+        json!({
+            "session_id": "test",
+            "cwd": "/tmp",
+            "hook_event_name": "PreToolUse",
+            "tool_name": tool,
+            "tool_input": { "command": cmd },
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn test_kimi_rewrite_emits_deny_with_suggestion() {
+        let out = run_kimi_inner(&kimi_input("Shell", "git status"));
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(
+            v["hookSpecificOutput"]["permissionDecision"], "deny",
+            "got: {out}"
+        );
+        assert_eq!(
+            v["hookSpecificOutput"]["hookEventName"], "PreToolUse",
+            "got: {out}"
+        );
+        let reason = v["hookSpecificOutput"]["permissionDecisionReason"]
+            .as_str()
+            .unwrap();
+        assert!(reason.contains("rtk git status"), "reason: {reason}");
+    }
+
+    #[test]
+    fn test_kimi_already_rtk_passes_through() {
+        let out = run_kimi_inner(&kimi_input("Shell", "rtk git status"));
+        assert_eq!(out, "{}");
+    }
+
+    #[test]
+    fn test_kimi_unknown_command_passes_through() {
+        let out = run_kimi_inner(&kimi_input("Shell", "htop"));
+        assert_eq!(out, "{}");
+    }
+
+    #[test]
+    fn test_kimi_non_shell_tool_passes_through() {
+        let out = run_kimi_inner(&kimi_input("ReadFile", "git status"));
+        assert_eq!(out, "{}");
+    }
+
+    #[test]
+    fn test_kimi_bash_alias_works() {
+        let out = run_kimi_inner(&kimi_input("Bash", "git status"));
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["hookSpecificOutput"]["permissionDecision"], "deny");
+    }
+
+    #[test]
+    fn test_kimi_invalid_json_returns_empty() {
+        assert_eq!(run_kimi_inner("not json at all"), "{}");
+    }
+
+    #[test]
+    fn test_kimi_empty_input_returns_empty() {
+        assert_eq!(run_kimi_inner(""), "{}");
+    }
+
+    #[test]
+    fn test_kimi_missing_command_passes_through() {
+        let out = run_kimi_inner(r#"{"tool_name":"Shell","tool_input":{}}"#);
+        assert_eq!(out, "{}");
+    }
+
+    #[test]
+    fn test_kimi_heredoc_passes_through() {
+        let out = run_kimi_inner(&kimi_input("Shell", "cat <<'EOF'\nhi\nEOF"));
+        assert_eq!(out, "{}");
     }
 }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -356,6 +356,265 @@ fn atomic_write(path: &Path, content: &str) -> Result<()> {
     Ok(())
 }
 
+// ─── Surgical JSON / TOML patching helpers ────────────────────
+
+/// Find the byte bounds of a JSON array that follows a specific key.
+fn find_json_array_bounds(text: &str, key: &str) -> Option<(usize, usize)> {
+    let key_pattern = format!("\"{}\"", key);
+    let key_pos = text.find(&key_pattern)?;
+    let rest = &text[key_pos..];
+    let bracket_offset = rest.find('[')?;
+    let array_start = key_pos + bracket_offset;
+
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut escape = false;
+
+    for (i, c) in text[array_start..].chars().enumerate() {
+        if escape {
+            escape = false;
+            continue;
+        }
+        if c == '\\' {
+            escape = true;
+            continue;
+        }
+        if c == '"' {
+            in_string = !in_string;
+            continue;
+        }
+        if in_string {
+            continue;
+        }
+        match c {
+            '[' => depth += 1,
+            ']' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some((array_start, array_start + i + 1));
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Find all top-level object elements within a JSON array range.
+fn find_json_array_object_elements(
+    text: &str,
+    array_start: usize,
+    array_end: usize,
+) -> Vec<(usize, usize)> {
+    let mut elements = Vec::new();
+    let mut brace_depth = 0usize;
+    let mut in_string = false;
+    let mut escape = false;
+    let mut current_start: Option<usize> = None;
+
+    for (i, c) in text[array_start + 1..array_end].chars().enumerate() {
+        let global_idx = array_start + 1 + i;
+        if escape {
+            escape = false;
+            continue;
+        }
+        if c == '\\' {
+            escape = true;
+            continue;
+        }
+        if c == '"' {
+            in_string = !in_string;
+            continue;
+        }
+        if in_string {
+            continue;
+        }
+        match c {
+            '{' => {
+                if brace_depth == 0 {
+                    current_start = Some(global_idx);
+                }
+                brace_depth += 1;
+            }
+            '}' => {
+                brace_depth -= 1;
+                if brace_depth == 0 {
+                    if let Some(start) = current_start {
+                        elements.push((start, global_idx + 1));
+                        current_start = None;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    elements
+}
+
+/// Find the byte index just after the root object's closing `}`.
+fn find_root_object_end(text: &str) -> Option<usize> {
+    let trimmed = text.trim_start();
+    let offset = text.len() - trimmed.len();
+    if !trimmed.starts_with('{') {
+        return None;
+    }
+
+    let mut depth = 0usize;
+    let mut in_string = false;
+    let mut escape = false;
+
+    for (i, c) in text[offset..].chars().enumerate() {
+        if escape {
+            escape = false;
+            continue;
+        }
+        if c == '\\' {
+            escape = true;
+            continue;
+        }
+        if c == '"' {
+            in_string = !in_string;
+            continue;
+        }
+        if in_string {
+            continue;
+        }
+        match c {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(offset + i + 1);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Infer the indentation string used for elements inside a JSON array.
+fn infer_array_indent(text: &str, array_start: usize) -> String {
+    if let Some(first_brace) = text[array_start + 1..].find('{') {
+        let brace_pos = array_start + 1 + first_brace;
+        let line_start = text[..brace_pos].rfind('\n').map(|i| i + 1).unwrap_or(0);
+        let indent_len = text[line_start..brace_pos]
+            .chars()
+            .take_while(|c| c.is_whitespace())
+            .count();
+        " ".repeat(indent_len)
+    } else {
+        "  ".to_string()
+    }
+}
+
+/// Append a pretty-printed JSON object to an array in the original text.
+fn append_to_json_array(original: &str, array_bounds: (usize, usize), new_entry: &str) -> String {
+    let (array_start, array_end) = array_bounds;
+    let indent = infer_array_indent(original, array_start);
+    let inner = &original[array_start + 1..array_end - 1];
+
+    let indented_entry = new_entry
+        .lines()
+        .map(|l| format!("{}{}", indent, l))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    if inner.trim().is_empty() {
+        format!(
+            "{}\n{}\n{}",
+            &original[..array_start + 1],
+            indented_entry,
+            &original[array_end - 1..]
+        )
+    } else {
+        let before_bracket = array_end - 1;
+        let inner_trimmed = inner.trim_end();
+        let separator = if inner_trimmed.ends_with(',') {
+            format!("\n{}", indent)
+        } else {
+            format!(",\n{}", indent)
+        };
+        format!(
+            "{}{}{}{}\n{}",
+            &original[..before_bracket],
+            separator,
+            indented_entry,
+            &original[before_bracket..before_bracket + 1],
+            &original[before_bracket + 1..]
+        )
+    }
+}
+
+/// Find all `[[hooks]]` blocks in TOML text.
+/// Returns vector of (start_line, end_line) for each block.
+fn find_toml_hooks_blocks(text: &str) -> Vec<(usize, usize)> {
+    let mut blocks = Vec::new();
+    let mut in_hooks_block = false;
+    let mut block_start = 0usize;
+
+    let lines: Vec<(usize, &str)> = text
+        .lines()
+        .enumerate()
+        .scan(0usize, |pos, (_idx, line)| {
+            let start = *pos;
+            *pos += line.len() + 1; // +1 for newline
+            Some((start, line))
+        })
+        .collect();
+
+    for i in 0..lines.len() {
+        let (start, line) = lines[i];
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("[[") && trimmed.ends_with("]]") {
+            if in_hooks_block {
+                blocks.push((block_start, start));
+            }
+            if trimmed == "[[hooks]]" {
+                in_hooks_block = true;
+                block_start = start;
+            } else {
+                in_hooks_block = false;
+            }
+        }
+    }
+
+    if in_hooks_block {
+        blocks.push((block_start, text.len()));
+    }
+
+    blocks
+}
+
+/// Build the intended Kimi hook table as a toml::Value.
+fn intended_kimi_hook() -> toml::Value {
+    let mut hook_table = toml::map::Map::new();
+    hook_table.insert(
+        "event".to_string(),
+        toml::Value::String("PreToolUse".to_string()),
+    );
+    hook_table.insert(
+        "matcher".to_string(),
+        toml::Value::String("Shell".to_string()),
+    );
+    hook_table.insert(
+        "command".to_string(),
+        toml::Value::String(KIMI_HOOK_COMMAND.to_string()),
+    );
+    hook_table.insert("timeout".to_string(), toml::Value::Integer(10));
+    toml::Value::Table(hook_table)
+}
+
+/// Serialize a single hook table as a `[[hooks]]` TOML block.
+fn hook_to_toml_block(hook: &toml::Value) -> String {
+    let mut wrapper = toml::map::Map::new();
+    wrapper.insert("hooks".to_string(), toml::Value::Array(vec![hook.clone()]));
+    toml::to_string_pretty(&toml::Value::Table(wrapper))
+        .unwrap()
+        .trim_start()
+        .to_string()
+}
+
 /// Prompt user for consent to patch settings.json
 /// Prints to stderr (stdout may be piped), reads from stdin
 /// Default is No (capital N)
@@ -702,6 +961,113 @@ fn uninstall_codex_at(codex_dir: &Path, verbose: u8) -> Result<Vec<String>> {
     Ok(removed)
 }
 
+/// Check if the exact RTK hook entry is already present in parsed settings.json.
+fn is_exact_claude_hook_present(root: &serde_json::Value, hook_command: &str) -> bool {
+    let pre_tool_use_array = match root
+        .get("hooks")
+        .and_then(|h| h.get(PRE_TOOL_USE_KEY))
+        .and_then(|p| p.as_array())
+    {
+        Some(arr) => arr,
+        None => return false,
+    };
+
+    pre_tool_use_array.iter().any(|entry| {
+        entry.get("matcher") == Some(&serde_json::json!("Bash"))
+            && entry
+                .get("hooks")
+                .and_then(|h| h.as_array())
+                .map(|hooks| {
+                    hooks.iter().any(|h| {
+                        h.get("type") == Some(&serde_json::json!("command"))
+                            && h.get("command") == Some(&serde_json::json!(hook_command))
+                    })
+                })
+                .unwrap_or(false)
+    })
+}
+
+/// Surgically patch Claude settings.json text.
+/// Returns `None` if the exact hook is already present.
+fn patch_claude_settings_text(original: &str, hook_command: &str) -> Result<Option<String>> {
+    let parsed: serde_json::Value =
+        serde_json::from_str(original).with_context(|| "Failed to parse settings.json")?;
+
+    if is_exact_claude_hook_present(&parsed, hook_command) {
+        return Ok(None);
+    }
+
+    let intended_entry = serde_json::json!({
+        "matcher": "Bash",
+        "hooks": [{
+            "type": "command",
+            "command": hook_command
+        }]
+    });
+    let intended_text = serde_json::to_string_pretty(&intended_entry)?;
+
+    // No hooks/PreToolUse section → append to root object
+    if parsed
+        .get("hooks")
+        .and_then(|h| h.get(PRE_TOOL_USE_KEY))
+        .is_none()
+    {
+        let root_end = find_root_object_end(original)
+            .context("Could not find root object end in settings.json")?;
+        let before_close = root_end - 1;
+        let has_content = original[..before_close].trim().len() > 1;
+        let separator = if has_content { ",\n" } else { "\n" };
+        let mut result = String::with_capacity(original.len() + 256);
+        result.push_str(&original[..before_close]);
+        result.push_str(separator);
+        result.push_str("  \"hooks\": {\n");
+        result.push_str("    \"PreToolUse\": [\n");
+        for line in intended_text.lines() {
+            result.push_str("      ");
+            result.push_str(line);
+            result.push('\n');
+        }
+        result.push_str("    ]\n");
+        result.push_str("  }\n");
+        result.push_str(&original[before_close..]);
+        return Ok(Some(result));
+    }
+
+    let array_bounds = find_json_array_bounds(original, PRE_TOOL_USE_KEY)
+        .context("Could not find PreToolUse array in settings.json")?;
+
+    let elements = find_json_array_object_elements(original, array_bounds.0, array_bounds.1);
+
+    for (start, end) in elements {
+        let element_text = &original[start..end];
+        if element_text.contains(REWRITE_HOOK_FILE) || element_text.contains(hook_command) {
+            let indent = infer_array_indent(original, array_bounds.0);
+            let indented = intended_text
+                .lines()
+                .map(|l| {
+                    if l.trim().is_empty() {
+                        l.to_string()
+                    } else {
+                        format!("{}{}", indent, l)
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            let mut result = String::with_capacity(original.len() + indented.len());
+            result.push_str(&original[..start]);
+            result.push_str(&indented);
+            result.push_str(&original[end..]);
+            return Ok(Some(result));
+        }
+    }
+
+    Ok(Some(append_to_json_array(
+        original,
+        array_bounds,
+        &intended_text,
+    )))
+}
+
 /// Orchestrator: patch settings.json with RTK hook (binary command variant)
 /// Handles reading, checking, prompting, merging, backing up, and atomic writing
 fn patch_settings_json_command(
@@ -714,22 +1080,23 @@ fn patch_settings_json_command(
     let settings_path = claude_dir.join(SETTINGS_JSON);
 
     // Read or create settings.json
-    let mut root = if settings_path.exists() {
+    let (original_content, parsed) = if settings_path.exists() {
         let content = fs::read_to_string(&settings_path)
             .with_context(|| format!("Failed to read {}", settings_path.display()))?;
 
         if content.trim().is_empty() {
-            serde_json::json!({})
+            (content, serde_json::json!({}))
         } else {
-            serde_json::from_str(&content)
-                .with_context(|| format!("Failed to parse {} as JSON", settings_path.display()))?
+            let root = serde_json::from_str(&content)
+                .with_context(|| format!("Failed to parse {} as JSON", settings_path.display()))?;
+            (content, root)
         }
     } else {
-        serde_json::json!({})
+        (String::new(), serde_json::json!({}))
     };
 
-    // Check idempotency
-    if hook_already_present(&root, hook_command) {
+    // Check idempotency using parsed value
+    if is_exact_claude_hook_present(&parsed, hook_command) {
         if verbose > 0 {
             eprintln!("settings.json: hook already present");
         }
@@ -753,7 +1120,15 @@ fn patch_settings_json_command(
         }
     }
 
-    insert_hook_entry(&mut root, hook_command)?;
+    // Build new content
+    let new_content = if original_content.trim().is_empty() {
+        let mut root = serde_json::json!({});
+        insert_hook_entry(&mut root, hook_command)?;
+        serde_json::to_string_pretty(&root).context("Failed to serialize settings.json")?
+    } else {
+        patch_claude_settings_text(&original_content, hook_command)?
+            .context("Failed to patch settings.json")?
+    };
 
     // Backup original
     if settings_path.exists() {
@@ -766,9 +1141,7 @@ fn patch_settings_json_command(
     }
 
     // Atomic write
-    let serialized =
-        serde_json::to_string_pretty(&root).context("Failed to serialize settings.json")?;
-    atomic_write(&settings_path, &serialized)?;
+    atomic_write(&settings_path, &new_content)?;
 
     println!("\n  settings.json: hook added");
     if settings_path.with_extension("json.bak").exists() {
@@ -1405,6 +1778,138 @@ fn run_antigravity_mode_at(base_dir: &Path, verbose: u8) -> Result<()> {
     Ok(())
 }
 
+// ─── Kimi CLI support ─────────────────────────────────────────
+
+const KIMI_RULES: &str = include_str!("../../hooks/kimi/rules.md");
+const KIMI_HOOK_COMMAND: &str = "rtk hook kimi";
+
+/// Parse the existing kimi config.toml and ensure the RTK hook is present
+/// in the `hooks` array, preserving any existing hooks. Returns the
+/// unchanged string if the hook is already installed.
+fn patch_kimi_config(existing: &str) -> Result<String> {
+    // ── Strategy: never parse & re-serialize the whole document.
+    // We do targeted string surgery so comments, ordering and formatting
+    // survive untouched.
+
+    let intended = hook_to_toml_block(&intended_kimi_hook());
+
+    // 1. Empty file → just write the hook block
+    if existing.trim().is_empty() {
+        return Ok(intended);
+    }
+
+    // 2. Already installed (command appears anywhere)?
+    if existing.lines().any(|l| l.contains(KIMI_HOOK_COMMAND)) {
+        return Ok(existing.to_string());
+    }
+
+    // 3. File already uses [[hooks]] blocks → append after the last one
+    let blocks = find_toml_hooks_blocks(existing);
+    if !blocks.is_empty() {
+        let (_start, end) = blocks.last().unwrap();
+        let mut result = String::with_capacity(existing.len() + 256);
+        result.push_str(&existing[..*end]);
+        // Ensure blank line before new block
+        if !result.ends_with('\n') {
+            result.push('\n');
+        }
+        result.push('\n');
+        result.push_str(&intended);
+        result.push_str(&existing[*end..]);
+        return Ok(result);
+    }
+
+    // 4. Inline array: hooks = []  or  hooks = [{...}]
+    //    Strip the inline line, then append [[hooks]] blocks.
+    let mut result = String::with_capacity(existing.len() + 256);
+    let mut hooks_line_found = false;
+    let mut inline_value: Option<String> = None;
+
+    for line in existing.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("hooks") && trimmed.contains('=') && !hooks_line_found {
+            hooks_line_found = true;
+            // Capture everything after '=' so we can parse existing entries
+            if let Some(eq) = trimmed.find('=') {
+                inline_value = Some(trimmed[eq + 1..].trim().to_string());
+            }
+            continue;
+        }
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    // If the inline array had entries, convert them to [[hooks]] blocks.
+    // An empty "[]" yields nothing.
+    if let Some(val) = inline_value {
+        if val != "[]" {
+            // Wrap the raw array text in a dummy key so toml can parse it
+            let wrapped = format!("dummy = {}", val);
+            if let Ok(doc) = toml::from_str::<toml::Value>(&wrapped) {
+                if let Some(arr) = doc.get("dummy").and_then(|v| v.as_array()) {
+                    for entry in arr {
+                        result.push_str(&hook_to_toml_block(entry));
+                    }
+                }
+            }
+        }
+    }
+
+    // Ensure blank line before new block
+    if !result.ends_with('\n') {
+        result.push('\n');
+    }
+    if !result.ends_with("\n\n") {
+        result.push('\n');
+    }
+    result.push_str(&intended);
+    Ok(result)
+}
+
+pub fn run_kimi(verbose: u8) -> Result<()> {
+    let home = dirs::home_dir().context("Cannot resolve home directory")?;
+    run_kimi_at(&home.join(".kimi"), verbose)
+}
+
+fn run_kimi_at(kimi_dir: &Path, verbose: u8) -> Result<()> {
+    fs::create_dir_all(kimi_dir)
+        .with_context(|| format!("Failed to create {}", kimi_dir.display()))?;
+
+    // 1. Rules file
+    let rules_path = kimi_dir.join("rtk-rules.md");
+    write_if_changed(&rules_path, KIMI_RULES, "Kimi RTK rules", verbose)?;
+
+    // 2. Patch config.toml — append [[hooks]] block if not already present
+    let config_path = kimi_dir.join("config.toml");
+    let existing = fs::read_to_string(&config_path).unwrap_or_default();
+
+    let new_content = patch_kimi_config(&existing)
+        .with_context(|| format!("Failed to patch {}", config_path.display()))?;
+
+    if new_content == existing {
+        if verbose > 0 {
+            eprintln!("Kimi hook already in {}", config_path.display());
+        }
+        println!("\nRTK already configured for Kimi CLI.\n");
+        println!("  Config: {}", config_path.display());
+    } else {
+        atomic_write(&config_path, &new_content)
+            .with_context(|| format!("Failed to write {}", config_path.display()))?;
+
+        if verbose > 0 {
+            eprintln!("Patched {}", config_path.display());
+        }
+
+        println!("\nRTK configured for Kimi CLI.\n");
+        println!("  Config: {} (patched)", config_path.display());
+    }
+    println!("  Rules:  {}", rules_path.display());
+    println!("  Add the rules file to your Kimi system prompt or agent config.");
+    println!("  Restart your kimi-cli session to activate.\n");
+
+    Ok(())
+}
+
 fn run_codex_mode(global: bool, verbose: u8) -> Result<()> {
     let (agents_md_path, rtk_md_path) = if global {
         let codex_dir = resolve_codex_dir()?;
@@ -1855,29 +2360,132 @@ fn install_cursor_hooks(verbose: u8) -> Result<()> {
 
 /// Patch ~/.cursor/hooks.json to add RTK preToolUse hook.
 /// Returns true if the file was modified.
+/// Check if the exact Cursor RTK hook entry is already present.
+fn is_exact_cursor_hook_present(root: &serde_json::Value) -> bool {
+    let hooks = match root
+        .get("hooks")
+        .and_then(|h| h.get("preToolUse"))
+        .and_then(|p| p.as_array())
+    {
+        Some(arr) => arr,
+        None => return false,
+    };
+
+    hooks.iter().any(|entry| {
+        entry.get("command") == Some(&serde_json::json!(CURSOR_HOOK_COMMAND))
+            && entry.get("matcher") == Some(&serde_json::json!("Shell"))
+    })
+}
+
+/// Surgically patch Cursor hooks.json text.
+/// Returns `None` if the exact hook is already present.
+fn patch_cursor_hooks_text(original: &str) -> Result<Option<String>> {
+    let parsed: serde_json::Value =
+        serde_json::from_str(original).with_context(|| "Failed to parse Cursor hooks.json")?;
+
+    if is_exact_cursor_hook_present(&parsed) {
+        return Ok(None);
+    }
+
+    let intended_entry = serde_json::json!({
+        "command": CURSOR_HOOK_COMMAND,
+        "matcher": "Shell"
+    });
+    let intended_text = serde_json::to_string_pretty(&intended_entry)?;
+
+    // No hooks.preToolUse section → append to root object
+    if parsed
+        .get("hooks")
+        .and_then(|h| h.get("preToolUse"))
+        .is_none()
+    {
+        let root_end = find_root_object_end(original)
+            .context("Could not find root object end in hooks.json")?;
+        let before_close = root_end - 1;
+        let has_content = original[..before_close].trim().len() > 1;
+        let separator = if has_content { ",\n" } else { "\n" };
+        let mut result = String::with_capacity(original.len() + 256);
+        result.push_str(&original[..before_close]);
+        result.push_str(separator);
+        result.push_str("  \"hooks\": {\n");
+        result.push_str("    \"preToolUse\": [\n");
+        for line in intended_text.lines() {
+            result.push_str("      ");
+            result.push_str(line);
+            result.push('\n');
+        }
+        result.push_str("    ]\n");
+        result.push_str("  }\n");
+        result.push_str(&original[before_close..]);
+        return Ok(Some(result));
+    }
+
+    let array_bounds = find_json_array_bounds(original, "preToolUse")
+        .context("Could not find preToolUse array in hooks.json")?;
+
+    let elements = find_json_array_object_elements(original, array_bounds.0, array_bounds.1);
+
+    for (start, end) in elements {
+        let element_text = &original[start..end];
+        if element_text.contains(REWRITE_HOOK_FILE) || element_text.contains(CURSOR_HOOK_COMMAND) {
+            let indent = infer_array_indent(original, array_bounds.0);
+            let indented = intended_text
+                .lines()
+                .map(|l| {
+                    if l.trim().is_empty() {
+                        l.to_string()
+                    } else {
+                        format!("{}{}", indent, l)
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            let mut result = String::with_capacity(original.len() + indented.len());
+            result.push_str(&original[..start]);
+            result.push_str(&indented);
+            result.push_str(&original[end..]);
+            return Ok(Some(result));
+        }
+    }
+
+    Ok(Some(append_to_json_array(
+        original,
+        array_bounds,
+        &intended_text,
+    )))
+}
+
 fn patch_cursor_hooks_json(path: &Path, verbose: u8) -> Result<bool> {
-    let mut root = if path.exists() {
+    let (original_content, parsed) = if path.exists() {
         let content = fs::read_to_string(path)
             .with_context(|| format!("Failed to read {}", path.display()))?;
         if content.trim().is_empty() {
-            serde_json::json!({ "version": 1 })
+            (content, serde_json::json!({ "version": 1 }))
         } else {
-            serde_json::from_str(&content)
-                .with_context(|| format!("Failed to parse {} as JSON", path.display()))?
+            let root = serde_json::from_str(&content)
+                .with_context(|| format!("Failed to parse {} as JSON", path.display()))?;
+            (content, root)
         }
     } else {
-        serde_json::json!({ "version": 1 })
+        (String::new(), serde_json::json!({ "version": 1 }))
     };
 
     // Check idempotency
-    if cursor_hook_already_present(&root) {
+    if is_exact_cursor_hook_present(&parsed) {
         if verbose > 0 {
             eprintln!("Cursor hooks.json: RTK hook already present");
         }
         return Ok(false);
     }
 
-    insert_cursor_hook_entry(&mut root)?;
+    // Build new content
+    let new_content = if original_content.trim().is_empty() {
+        let mut root = serde_json::json!({ "version": 1 });
+        insert_cursor_hook_entry(&mut root)?;
+        serde_json::to_string_pretty(&root).context("Failed to serialize hooks.json")?
+    } else {
+        patch_cursor_hooks_text(&original_content)?.context("Failed to patch hooks.json")?
+    };
 
     // Backup if exists
     if path.exists() {
@@ -1890,9 +2498,7 @@ fn patch_cursor_hooks_json(path: &Path, verbose: u8) -> Result<bool> {
     }
 
     // Atomic write
-    let serialized =
-        serde_json::to_string_pretty(&root).context("Failed to serialize hooks.json")?;
-    atomic_write(path, &serialized)?;
+    atomic_write(path, &new_content)?;
 
     Ok(true)
 }
@@ -2436,6 +3042,113 @@ pub fn run_gemini(global: bool, hook_only: bool, patch_mode: PatchMode, verbose:
 }
 
 /// Patch ~/.gemini/settings.json with the BeforeTool hook
+/// Check if the exact Gemini RTK hook entry is already present.
+fn is_exact_gemini_hook_present(root: &serde_json::Value, hook_cmd: &str) -> bool {
+    let hooks = match root
+        .get("hooks")
+        .and_then(|h| h.get(BEFORE_TOOL_KEY))
+        .and_then(|p| p.as_array())
+    {
+        Some(arr) => arr,
+        None => return false,
+    };
+
+    hooks.iter().any(|entry| {
+        entry.get("matcher") == Some(&serde_json::json!("run_shell_command"))
+            && entry
+                .get("hooks")
+                .and_then(|h| h.as_array())
+                .map(|inner| {
+                    inner.iter().any(|h| {
+                        h.get("type") == Some(&serde_json::json!("command"))
+                            && h.get("command") == Some(&serde_json::json!(hook_cmd))
+                    })
+                })
+                .unwrap_or(false)
+    })
+}
+
+/// Surgically patch Gemini settings.json text.
+/// Returns `None` if the exact hook is already present.
+fn patch_gemini_settings_text(original: &str, hook_cmd: &str) -> Result<Option<String>> {
+    let parsed: serde_json::Value =
+        serde_json::from_str(original).with_context(|| "Failed to parse Gemini settings.json")?;
+
+    if is_exact_gemini_hook_present(&parsed, hook_cmd) {
+        return Ok(None);
+    }
+
+    let intended_entry = serde_json::json!({
+        "matcher": "run_shell_command",
+        "hooks": [{
+            "type": "command",
+            "command": hook_cmd
+        }]
+    });
+    let intended_text = serde_json::to_string_pretty(&intended_entry)?;
+
+    // No hooks.BeforeTool section → append to root object
+    if parsed
+        .get("hooks")
+        .and_then(|h| h.get(BEFORE_TOOL_KEY))
+        .is_none()
+    {
+        let root_end = find_root_object_end(original)
+            .context("Could not find root object end in Gemini settings.json")?;
+        let before_close = root_end - 1;
+        let has_content = original[..before_close].trim().len() > 1;
+        let separator = if has_content { ",\n" } else { "\n" };
+        let mut result = String::with_capacity(original.len() + 256);
+        result.push_str(&original[..before_close]);
+        result.push_str(separator);
+        result.push_str("  \"hooks\": {\n");
+        result.push_str("    \"BeforeTool\": [\n");
+        for line in intended_text.lines() {
+            result.push_str("      ");
+            result.push_str(line);
+            result.push('\n');
+        }
+        result.push_str("    ]\n");
+        result.push_str("  }\n");
+        result.push_str(&original[before_close..]);
+        return Ok(Some(result));
+    }
+
+    let array_bounds = find_json_array_bounds(original, BEFORE_TOOL_KEY)
+        .context("Could not find BeforeTool array in Gemini settings.json")?;
+
+    let elements = find_json_array_object_elements(original, array_bounds.0, array_bounds.1);
+
+    for (start, end) in elements {
+        let element_text = &original[start..end];
+        if element_text.contains("rtk") {
+            let indent = infer_array_indent(original, array_bounds.0);
+            let indented = intended_text
+                .lines()
+                .map(|l| {
+                    if l.trim().is_empty() {
+                        l.to_string()
+                    } else {
+                        format!("{}{}", indent, l)
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            let mut result = String::with_capacity(original.len() + indented.len());
+            result.push_str(&original[..start]);
+            result.push_str(&indented);
+            result.push_str(&original[end..]);
+            return Ok(Some(result));
+        }
+    }
+
+    Ok(Some(append_to_json_array(
+        original,
+        array_bounds,
+        &intended_text,
+    )))
+}
+
 fn patch_gemini_settings(
     gemini_dir: &Path,
     hook_path: &Path,
@@ -2446,28 +3159,21 @@ fn patch_gemini_settings(
     let hook_cmd = hook_path.to_string_lossy().to_string();
 
     // Read or create settings.json
-    let mut settings: serde_json::Value = if settings_path.exists() {
+    let (original_content, parsed) = if settings_path.exists() {
         let content = fs::read_to_string(&settings_path)
             .with_context(|| format!("Failed to read {}", settings_path.display()))?;
-        serde_json::from_str(&content).unwrap_or(serde_json::json!({}))
+        let root = serde_json::from_str(&content).unwrap_or(serde_json::json!({}));
+        (content, root)
     } else {
-        serde_json::json!({})
+        (String::new(), serde_json::json!({}))
     };
 
-    let before_tool_pointer = format!("/hooks/{}", BEFORE_TOOL_KEY);
-    if let Some(hooks) = settings.pointer(&before_tool_pointer) {
-        if let Some(arr) = hooks.as_array() {
-            if arr.iter().any(|h| {
-                h.pointer("/hooks/0/command")
-                    .and_then(|v| v.as_str())
-                    .is_some_and(|c| c.contains("rtk"))
-            }) {
-                if verbose > 0 {
-                    eprintln!("Gemini settings.json already has RTK hook");
-                }
-                return Ok(());
-            }
+    // Check exact idempotency
+    if is_exact_gemini_hook_present(&parsed, &hook_cmd) {
+        if verbose > 0 {
+            eprintln!("Gemini settings.json already has RTK hook");
         }
+        return Ok(());
     }
 
     // Ask user before patching
@@ -2491,37 +3197,35 @@ fn patch_gemini_settings(
         }
     }
 
-    // Build hook entry matching Gemini CLI format
-    let hook_entry = serde_json::json!({
-        "matcher": "run_shell_command",
-        "hooks": [{
-            "type": "command",
-            "command": hook_cmd
-        }]
-    });
-
-    // Insert into settings
-    let hooks = settings
-        .as_object_mut()
-        .context("settings.json is not an object")?
-        .entry("hooks")
-        .or_insert(serde_json::json!({}));
-
-    let before_tool = hooks
-        .as_object_mut()
-        .context("hooks is not an object")?
-        .entry(BEFORE_TOOL_KEY)
-        .or_insert(serde_json::json!([]));
-
-    before_tool
-        .as_array_mut()
-        .context("BeforeTool is not an array")?
-        .push(hook_entry);
+    // Build new content
+    let new_content = if original_content.trim().is_empty() {
+        let mut root = serde_json::json!({});
+        let hooks = root
+            .as_object_mut()
+            .unwrap()
+            .entry("hooks")
+            .or_insert(serde_json::json!({}));
+        let before_tool = hooks
+            .as_object_mut()
+            .unwrap()
+            .entry(BEFORE_TOOL_KEY)
+            .or_insert(serde_json::json!([]));
+        before_tool.as_array_mut().unwrap().push(serde_json::json!({
+            "matcher": "run_shell_command",
+            "hooks": [{
+                "type": "command",
+                "command": hook_cmd
+            }]
+        }));
+        serde_json::to_string_pretty(&root).context("Failed to serialize Gemini settings.json")?
+    } else {
+        patch_gemini_settings_text(&original_content, &hook_cmd)?
+            .context("Failed to patch Gemini settings.json")?
+    };
 
     // Write atomically
-    let content = serde_json::to_string_pretty(&settings)?;
     let tmp = NamedTempFile::new_in(gemini_dir)?;
-    fs::write(tmp.path(), &content)?;
+    fs::write(tmp.path(), &new_content)?;
     tmp.persist(&settings_path)
         .with_context(|| format!("Failed to write {}", settings_path.display()))?;
 
@@ -2955,6 +3659,210 @@ More notes
         run_antigravity_mode_at(temp.path(), 0).unwrap();
         let second = fs::read_to_string(&path).unwrap();
         assert_eq!(first, second, "Idempotent: content should not change");
+    }
+
+    #[test]
+    fn test_kimi_init_creates_config_and_rules() {
+        let temp = TempDir::new().unwrap();
+        run_kimi_at(temp.path(), 0).unwrap();
+
+        let rules = temp.path().join("rtk-rules.md");
+        let config = temp.path().join("config.toml");
+        assert!(rules.exists(), "rules file missing");
+        assert!(config.exists(), "config.toml missing");
+
+        let cfg = fs::read_to_string(&config).unwrap();
+        assert!(cfg.contains("[[hooks]]"), "missing [[hooks]] block");
+        assert!(cfg.contains("rtk hook kimi"), "missing rtk hook command");
+        assert!(cfg.contains("PreToolUse"), "missing event");
+    }
+
+    #[test]
+    fn test_kimi_init_is_idempotent() {
+        let temp = TempDir::new().unwrap();
+        run_kimi_at(temp.path(), 0).unwrap();
+        run_kimi_at(temp.path(), 0).unwrap();
+
+        let cfg = fs::read_to_string(temp.path().join("config.toml")).unwrap();
+        assert_eq!(
+            cfg.matches("rtk hook kimi").count(),
+            1,
+            "hook block duplicated on rerun"
+        );
+    }
+
+    #[test]
+    fn test_kimi_init_preserves_existing_config() {
+        let temp = TempDir::new().unwrap();
+        let cfg_path = temp.path().join("config.toml");
+        fs::create_dir_all(temp.path()).unwrap();
+        fs::write(&cfg_path, "model = \"k1\"\n[ui]\ntheme = \"dark\"\n").unwrap();
+
+        run_kimi_at(temp.path(), 0).unwrap();
+
+        let cfg = fs::read_to_string(&cfg_path).unwrap();
+        assert!(cfg.contains("model = \"k1\""), "lost model line");
+        assert!(cfg.contains("theme = \"dark\""), "lost theme line");
+        assert!(cfg.contains("rtk hook kimi"), "missing hook block");
+    }
+
+    #[test]
+    fn test_kimi_init_replaces_inline_hooks_array() {
+        let temp = TempDir::new().unwrap();
+        let cfg_path = temp.path().join("config.toml");
+        fs::create_dir_all(temp.path()).unwrap();
+        fs::write(&cfg_path, "model = \"k1\"\nhooks = []\n").unwrap();
+
+        run_kimi_at(temp.path(), 0).unwrap();
+
+        let cfg = fs::read_to_string(&cfg_path).unwrap();
+        assert!(cfg.contains("model = \"k1\""), "lost model line");
+        assert!(
+            !cfg.contains("hooks = []"),
+            "inline hooks array should be removed"
+        );
+        assert!(cfg.contains("[[hooks]]"), "missing [[hooks]] block");
+        assert!(cfg.contains("rtk hook kimi"), "missing rtk hook command");
+
+        // Must be valid TOML
+        let _: toml::Value = toml::from_str(&cfg).expect("resulting config is not valid TOML");
+    }
+
+    #[test]
+    fn test_kimi_init_preserves_existing_hooks() {
+        let temp = TempDir::new().unwrap();
+        let cfg_path = temp.path().join("config.toml");
+        fs::create_dir_all(temp.path()).unwrap();
+        fs::write(
+            &cfg_path,
+            "model = \"k1\"\nhooks = [{event = \"PreToolUse\", matcher = \"Shell\", command = \"existing-hook\", timeout = 5}]\n",
+        )
+        .unwrap();
+
+        run_kimi_at(temp.path(), 0).unwrap();
+
+        let cfg = fs::read_to_string(&cfg_path).unwrap();
+        assert!(cfg.contains("model = \"k1\""), "lost model line");
+        assert!(
+            !cfg.contains("hooks = ["),
+            "inline hooks array should be converted"
+        );
+        assert!(cfg.contains("existing-hook"), "lost existing hook command");
+        assert!(cfg.contains("rtk hook kimi"), "missing rtk hook command");
+
+        // Parse and verify both hooks are present
+        let doc: toml::Value = toml::from_str(&cfg).expect("resulting config is not valid TOML");
+        let hooks = doc
+            .get("hooks")
+            .and_then(|v| v.as_array())
+            .expect("hooks should be an array");
+        assert_eq!(hooks.len(), 2, "should have exactly 2 hooks");
+        assert!(
+            hooks
+                .iter()
+                .any(|h| { h.get("command").and_then(|c| c.as_str()) == Some("existing-hook") }),
+            "existing hook missing"
+        );
+        assert!(
+            hooks
+                .iter()
+                .any(|h| { h.get("command").and_then(|c| c.as_str()) == Some("rtk hook kimi") }),
+            "rtk hook missing"
+        );
+    }
+
+    #[test]
+    fn test_kimi_init_preserves_full_user_config() {
+        // Regression test for the real ~/.kimi/config.toml format
+        let input = r#"default_model = "kimi-code/kimi-for-coding"
+default_thinking = true
+default_yolo = false
+skip_yolo_prompt_injection = false
+default_plan_mode = false
+default_editor = ""
+theme = "dark"
+show_thinking_stream = true
+hooks = []
+merge_all_available_skills = true
+extra_skill_dirs = []
+telemetry = true
+
+[models."kimi-code/kimi-for-coding"]
+provider = "managed:kimi-code"
+model = "kimi-for-coding"
+max_context_size = 262144
+capabilities = ["thinking", "image_in", "video_in"]
+display_name = "Kimi-k2.6"
+
+[providers."managed:kimi-code"]
+type = "kimi"
+base_url = "https://api.kimi.com/coding/v1"
+api_key = ""
+
+[providers."managed:kimi-code".oauth]
+storage = "file"
+key = "oauth/kimi-code"
+
+[loop_control]
+max_steps_per_turn = 500
+max_retries_per_step = 3
+max_ralph_iterations = 0
+reserved_context_size = 50000
+compaction_trigger_ratio = 0.85
+
+[background]
+max_running_tasks = 4
+read_max_bytes = 30000
+notification_tail_lines = 20
+notification_tail_chars = 3000
+wait_poll_interval_ms = 500
+worker_heartbeat_interval_ms = 5000
+worker_stale_after_ms = 15000
+kill_grace_period_ms = 2000
+keep_alive_on_exit = false
+agent_task_timeout_s = 900
+print_wait_ceiling_s = 3600
+
+[notifications]
+claim_stale_after_ms = 15000
+
+[services.moonshot_search]
+base_url = "https://api.kimi.com/coding/v1/search"
+api_key = ""
+
+[services.moonshot_search.oauth]
+storage = "file"
+key = "oauth/kimi-code"
+
+[services.moonshot_fetch]
+base_url = "https://api.kimi.com/coding/v1/fetch"
+api_key = ""
+
+[services.moonshot_fetch.oauth]
+storage = "file"
+key = "oauth/kimi-code"
+
+[mcp.client]
+tool_call_timeout_ms = 60000
+"#;
+        assert!(find_toml_hooks_blocks(input).is_empty());
+
+        let output = patch_kimi_config(input).unwrap();
+        assert!(output.contains("default_model"), "lost default_model");
+        assert!(output.contains("mcp.client"), "lost mcp.client table");
+        assert!(output.contains("moonshot_search"), "lost moonshot_search");
+        assert!(
+            output.contains("tool_call_timeout_ms"),
+            "lost tool_call_timeout_ms"
+        );
+        assert!(output.contains("rtk hook kimi"), "missing rtk hook");
+        assert!(
+            !output.contains("hooks = []"),
+            "inline hooks array should be removed"
+        );
+
+        // Must be valid TOML
+        let _: toml::Value = toml::from_str(&output).expect("output is not valid TOML");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,8 @@ pub enum AgentTarget {
     Kilocode,
     /// Google Antigravity
     Antigravity,
+    /// Kimi CLI
+    Kimi,
 }
 
 #[derive(Parser)]
@@ -759,6 +761,8 @@ enum HookCommands {
     Gemini,
     /// Process Copilot preToolUse hook (VS Code + Copilot CLI, reads JSON from stdin)
     Copilot,
+    /// Process Kimi CLI PreToolUse hook (deny-with-suggestion, reads JSON from stdin)
+    Kimi,
     /// Check how a command would be rewritten by the hook engine (dry-run)
     Check {
         /// Target agent
@@ -1785,6 +1789,11 @@ fn run_cli() -> Result<i32> {
                     );
                 }
                 hooks::init::run_antigravity_mode(cli.verbose)?;
+            } else if agent == Some(AgentTarget::Kimi) {
+                if !global {
+                    anyhow::bail!("Kimi CLI is global-only. Use: rtk init -g --agent kimi");
+                }
+                hooks::init::run_kimi(cli.verbose)?;
             } else {
                 let install_opencode = opencode;
                 let install_claude = !opencode;
@@ -2114,6 +2123,10 @@ fn run_cli() -> Result<i32> {
             }
             HookCommands::Copilot => {
                 hooks::hook_cmd::run_copilot()?;
+                0
+            }
+            HookCommands::Kimi => {
+                hooks::hook_cmd::run_kimi()?;
                 0
             }
             HookCommands::Check { agent: _, command } => {


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

Adds `rtk init -g --agent kimi` to configure Kimi CLI:
- Patches ~/.kimi/config.toml with a PreToolUse [[hooks]] block pointing to `rtk hook kimi`
- Writes ~/.kimi/rtk-rules.md and prompts user to add to system prompt

Adds `rtk hook kimi` PreToolUse handler: since Kimi's hook protocol is deny-only (no updatedInput support), the hook emits permissionDecision=deny with a reason instructing the LLM to retry with the rtk-prefixed form. Handles tool_name Shell/Bash; passes through non-shell tools and already- optimized commands. 12 unit tests across hook_cmd and init.

* https://www.kimi.com/code/docs/en/kimi-code-cli/customization/hooks.html#supported-hook-events


## Test plan
<!-- How did you verify this works? -->

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

### Manual testing

#### Installation

```
[kimi-cli-support][~/repos/rtk]$ target/release/rtk init -g --agent kimi                    

RTK configured for Kimi CLI.

  Config: /Users/shwoop/.kimi/config.toml (patched)
  Rules:  /Users/shwoop/.kimi/rtk-rules.md
  Add the rules file to your Kimi system prompt or agent config.
  Restart your kimi-cli session to activate.

[kimi-cli-support]*[~/repos/rtk]$ diff -a ~/.kimibackup ~/.kimi          
diff --color -a /Users/shwoop/.kimibackup/config.toml /Users/shwoop/.kimi/config.toml
9d8
< hooks = []
70a70,75
> 
> [[hooks]]
> command = "rtk hook kimi"
> event = "PreToolUse"
> matcher = "Shell"
> timeout = 10
Only in /Users/shwoop/.kimi: config.toml.before-rtk
Common subdirectories: /Users/shwoop/.kimibackup/credentials and /Users/shwoop/.kimi/credentials
Common subdirectories: /Users/shwoop/.kimibackup/logs and /Users/shwoop/.kimi/logs
Common subdirectories: /Users/shwoop/.kimibackup/plans and /Users/shwoop/.kimi/plans
Only in /Users/shwoop/.kimi: rtk-rules.md
Common subdirectories: /Users/shwoop/.kimibackup/sessions and /Users/shwoop/.kimi/sessions
Common subdirectories: /Users/shwoop/.kimibackup/telemetry and /Users/shwoop/.kimi/telemetry
Common subdirectories: /Users/shwoop/.kimibackup/user-history and /Users/shwoop/.kimi/user-history
```

#### Hook functionality

```
[kimi-cli-support][~/repos/rtk]$ cat <<EOF | target/release/rtk hook kimi
pipe heredoc> {
  "session_id": "abc123",
  "cwd": "/path/to/project",
  "hook_event_name": "PreToolUse",
  "tool_name": "Shell",
  "tool_input": {"command": "go test ./..."}
}
pipe heredoc> EOF
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Use `rtk go test ./...` instead — RTK saves 60-90% tokens"}}
```

```
[kimi-cli-support][~/repos/rtk]$ cat <<EOF | target/release/rtk hook kimi
pipe heredoc> {
  "session_id": "abc123",
  "cwd": "/path/to/project",
  "hook_event_name": "PreToolUse",
  "tool_name": "Shell",
  "tool_input": {"command": "rtk go test ./..."}
}
pipe heredoc> EOF
{}
```

#### Truncated output being processed in kimi-cli

```
[kimi-cli-support]*[~/repos/rtk]$ kimi
╭────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                            │
│   ▐█▛█▛█▌  Welcome to Kimi Code CLI!                                                                       │
│   ▐█████▌  Send /help for help information.                                                                │
│                                                                                                            │
│  Directory: ~/repos/rtk                                                                                    │
│  Session: 364d4230-641f-45e7-bc30-03d52cf7385a                                                             │
│  Model: Kimi-k2.6                                                                                          │
│                                                                                                            │
│  Tip: Spot a bug or have feedback? Type /feedback right in this session — every report makes Kimi better.  │
│                                                                                                            │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
✨ Are there any errors in `cargo test`?
• The user wants to know if there are any errors in cargo test. I should run the tests and report the results.
• Used Shell (cargo test 2>&1)
• The output was truncated. I need to see the end of the test output to know if there were any failures. Let me run the tests again but capture just the summary at the end.
• Used Shell (cargo test 2>&1 | tail -30)
• The tests all passed. There are no errors - 1696 passed, 0 failed, 6 ignored. There are 2 compiler warnings about direct function item casts, but those are just warnings, not errors. I should report this clearly to the user.
• No errors. cargo test results:
  • 1696 passed
  • 0 failed
  • 6 ignored

  There are 2 compiler warnings (not test failures) about direct function item casts into integers in src/main.rs:2244-2245, which cargo suggests fixing with an intermediate *const () cast.
```

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.

