### PR TITLE
feat(hooks): add Codex deny-retry hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ rtk init --agent kilocode       # Kilo Code
 rtk init --agent antigravity    # Google Antigravity
 
 # 2. Restart your AI tool, then test
-git status  # Automatically rewritten to rtk git status
+git status  # Automatically rewritten or, for Codex, blocked with an RTK retry suggestion
 ```
 
-The hook transparently rewrites Bash commands (e.g., `git status` -> `rtk git status`) before execution. Claude never sees the rewrite, it just gets compressed output.
+Most hooks transparently rewrite Bash commands (e.g., `git status` -> `rtk git status`) before execution. Codex currently cannot apply hook-provided `updatedInput`, so RTK uses a deny-with-suggestion hook there: Codex sees `Rerun that as: rtk git status` and retries with the compact command.
 
 **Important:** the hook only runs on Bash tool calls. Claude Code built-in tools like `Read`, `Grep`, and `Glob` do not pass through the Bash hook, so they are not auto-rewritten. To get RTK's compact output for those workflows, use shell commands (`cat`/`head`/`tail`, `rg`/`grep`, `find`) or call `rtk read`, `rtk grep`, or `rtk find` directly.
 
@@ -350,7 +350,7 @@ rtk git status
 
 ## Supported AI Tools
 
-RTK supports 12 AI coding tools. Each integration transparently rewrites shell commands to `rtk` equivalents for 60-90% token savings.
+RTK supports 12 AI coding tools. Most integrations transparently rewrite shell commands to `rtk` equivalents for 60-90% token savings; Codex uses deny-with-suggestion until its hook API supports in-place command updates.
 
 | Tool | Install | Method |
 |------|---------|--------|
@@ -359,7 +359,7 @@ RTK supports 12 AI coding tools. Each integration transparently rewrites shell c
 | **GitHub Copilot CLI** | `rtk init -g --copilot` | PreToolUse deny-with-suggestion (CLI limitation) |
 | **Cursor** | `rtk init -g --agent cursor` | preToolUse hook (hooks.json) |
 | **Gemini CLI** | `rtk init -g --gemini` | BeforeTool hook |
-| **Codex** | `rtk init -g --codex` | AGENTS.md + RTK.md instructions |
+| **Codex** | `rtk init -g --codex` | PreToolUse hook (`rtk hook codex`) + AGENTS.md + RTK.md |
 | **Windsurf** | `rtk init --agent windsurf` | .windsurfrules (project-scoped) |
 | **Cline / Roo Code** | `rtk init --agent cline` | .clinerules (project-scoped) |
 | **OpenCode** | `rtk init -g --opencode` | Plugin TS (tool.execute.before) |

--- a/docs/contributing/TECHNICAL.md
+++ b/docs/contributing/TECHNICAL.md
@@ -315,7 +315,7 @@ Start here, then drill down into each README for file-level details.
 | [`cursor/`](../hooks/cursor/README.md) | Cursor IDE | Shell hook, empty JSON response requirement |
 | [`cline/`](../hooks/cline/README.md) | Cline / Roo Code | Rules file (prompt-level, no programmatic hook) |
 | [`windsurf/`](../hooks/windsurf/README.md) | Windsurf / Cascade | Rules file (workspace-scoped) |
-| [`codex/`](../hooks/codex/README.md) | OpenAI Codex CLI | Awareness document, AGENTS.md integration |
+| [`codex/`](../hooks/codex/README.md) | OpenAI Codex CLI | PreToolUse deny-with-suggestion hook + AGENTS.md integration |
 | [`opencode/`](../hooks/opencode/README.md) | OpenCode | TypeScript plugin, zx library, in-place mutation |
 
 ---
@@ -333,7 +333,7 @@ RTK supports the following LLM agents through hook integrations:
 | Gemini CLI | Rust binary | `rtk hook gemini` reads JSON | Yes (`hookSpecificOutput`) |
 | Cline/Roo Code | Rules file | Prompt-level guidance | N/A (prompt) |
 | Windsurf | Rules file | Prompt-level guidance | N/A (prompt) |
-| Codex CLI | Awareness doc | AGENTS.md integration | N/A (prompt) |
+| Codex CLI | Rust binary hook | `rtk hook codex` + AGENTS.md integration | No (deny + suggestion) |
 | OpenCode | TS plugin | `tool.execute.before` event | Yes (in-place mutation) |
 
 > **Details**: [`hooks/README.md`](../hooks/README.md) has the full JSON schemas for each agent. [`src/hooks/README.md`](../src/hooks/README.md) covers installation, integrity verification, and the rewrite command.

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -12,7 +12,7 @@ Relationship to `src/hooks/`: that component **creates** these files; this direc
 
 ## Purpose
 
-LLM agent integrations that intercept CLI commands and route them through RTK for token optimization. Each hook transparently rewrites raw commands (e.g., `git status`) to their RTK equivalents (e.g., `rtk git status`), delivering 60-90% token savings without requiring the agent or user to change their workflow.
+LLM agent integrations that intercept CLI commands and route them through RTK for token optimization. Most hooks transparently rewrite raw commands (e.g., `git status`) to their RTK equivalents (e.g., `rtk git status`), delivering 60-90% token savings without requiring the agent or user to change their workflow. Codex currently uses deny-with-suggestion because its PreToolUse hook cannot apply `updatedInput` in-place yet.
 
 ## How It Works
 
@@ -38,7 +38,7 @@ Each agent subdirectory has its own README with hook-specific details:
 - **[`cursor/`](cursor/README.md)** — Shell hook, Cursor JSON format, empty `{}` response requirement
 - **[`cline/`](cline/README.md)** — Rules file (prompt-level), `.clinerules` project-local installation
 - **[`windsurf/`](windsurf/README.md)** — Rules file (prompt-level), `.windsurfrules` workspace-scoped
-- **[`codex/`](codex/README.md)** — Awareness document, `AGENTS.md` integration, `$CODEX_HOME` or `~/.codex/` location
+- **[`codex/`](codex/README.md)** — Codex hooks.json wiring, `rtk hook codex`, `AGENTS.md` integration
 - **[`opencode/`](opencode/README.md)** — TypeScript plugin, `zx` library, `tool.execute.before` event, in-place mutation
 
 ## Supported Agents
@@ -52,7 +52,7 @@ Each agent subdirectory has its own README with hook-specific details:
 | Gemini CLI | Rust binary (`rtk hook gemini`) | Transparent rewrite | Yes (`hookSpecificOutput`) |
 | Cline / Roo Code | Custom instructions (rules file) | Prompt-level guidance | N/A |
 | Windsurf | Custom instructions (rules file) | Prompt-level guidance | N/A |
-| Codex CLI | AGENTS.md / instructions | Prompt-level guidance | N/A |
+| Codex CLI | Rust binary (`rtk hook codex`) + AGENTS.md | Deny-with-suggestion | No (agent retries) |
 | OpenCode | TypeScript plugin (`tool.execute.before`) | In-place mutation | Yes |
 
 ## JSON Formats by Agent
@@ -216,9 +216,9 @@ New integrations must follow the [Exit Code Contract](#exit-code-contract) and [
 
 | Tier | Mechanism | Maintenance | Examples |
 |------|-----------|-------------|----------|
-| **Full hook** | Shell script or Rust binary, intercepts commands via agent's hook API | High — must track agent API changes | Claude Code, Cursor, Copilot, Gemini |
+| **Full hook** | Shell script or Rust binary, intercepts commands via agent's hook API | High — must track agent API changes | Claude Code, Cursor, Copilot, Gemini, Codex |
 | **Plugin** | TypeScript/JS plugin in agent's plugin system | Medium — agent manages loading | OpenCode |
-| **Rules file** | Prompt-level instructions the agent reads | Low — no code to break | Cline, Windsurf, Codex |
+| **Rules file** | Prompt-level instructions the agent reads | Low — no code to break | Cline, Windsurf |
 
 ### Eligibility
 
@@ -232,4 +232,3 @@ RTK supports AI coding assistants that developers actually use day-to-day. To ad
 ### Maintenance
 
 If an agent's API changes and the hook breaks, the integration should be updated promptly. If the agent becomes unmaintained or the hook can't be fixed, the integration may be deprecated with a release note.
-

--- a/hooks/codex/README.md
+++ b/hooks/codex/README.md
@@ -7,7 +7,8 @@
 - Prompt-level guidance via `rtk-awareness.md`, injected into `AGENTS.md` with an `@RTK.md` reference
 - Programmatic Codex hook via `rtk hook codex`, wired through `hooks.json`
 - `rtk init --codex` also enables `features.codex_hooks = true` in the active Codex `config.toml`
-- Installed to `$CODEX_HOME` when set, otherwise `~/.codex/`, by `rtk init --codex`
+- `rtk init --codex` writes Codex hook files to the local `./.codex/` directory
+- `rtk init -g --codex` writes to `$CODEX_HOME` when set, otherwise `~/.codex/`
 
 ## Behavior
 

--- a/hooks/codex/README.md
+++ b/hooks/codex/README.md
@@ -4,6 +4,17 @@
 
 ## Specifics
 
-- Prompt-level guidance via awareness document -- no programmatic hook
-- `rtk-awareness.md` is injected into `AGENTS.md` with an `@RTK.md` reference
+- Prompt-level guidance via `rtk-awareness.md`, injected into `AGENTS.md` with an `@RTK.md` reference
+- Programmatic Codex hook via `rtk hook codex`, wired through `hooks.json`
+- `rtk init --codex` also enables `features.codex_hooks = true` in the active Codex `config.toml`
 - Installed to `$CODEX_HOME` when set, otherwise `~/.codex/`, by `rtk init --codex`
+
+## Behavior
+
+- Codex `PreToolUse` hooks currently cannot apply `updatedInput` yet.
+- RTK therefore uses a deny-with-suggestion pattern for Codex:
+  - raw command: `git status`
+  - hook response: deny + `Rerun that as: rtk git status`
+  - Codex retries with the RTK command and gets filtered output
+
+This differs from Claude Code and Cursor, where RTK can transparently rewrite the Bash command in-place.

--- a/hooks/codex/rtk-awareness.md
+++ b/hooks/codex/rtk-awareness.md
@@ -1,71 +1,49 @@
 # RTK - Rust Token Killer (Codex CLI)
 
-RTK is a token-optimized CLI proxy for shell commands. Use it deliberately:
-save context on noisy output without hiding exact details needed for the task.
+**Usage**: Token-optimized CLI proxy for noisy shell commands.
 
-## Decision Policy
+## Rule
 
-Use RTK when the shell command is likely to emit noisy or large output and the
-filtered output still preserves the signal needed for implementation,
-debugging, or verification.
-
-Do not blindly prefix every command with `rtk`. In particular, do not rewrite
-shell builtins such as `test -d`, `[`/`]`, `printf`, `pwd`, or tiny probes.
-
-## Prefer RTK For
+Use `rtk` when filtered output preserves the signal you need. Do not blindly
+prefix tiny probes, shell builtins, or commands where exact output matters.
 
 ```bash
 rtk git status
 rtk git diff
 rtk git show
 rtk gh pr view <num>
-rtk gh run view <id>
 rtk grep <pattern> <path>
-rtk find <path> -name <pattern>
 rtk read <file>
 rtk cargo test
 rtk pytest
 rtk vitest run
-rtk playwright test
-rtk tsc
-rtk lint
-rtk docker logs <container>
-rtk kubectl logs <pod>
-rtk curl <url>
 ```
 
-For noisy repo scripts that RTK cannot rewrite directly, use generic wrappers:
+For noisy repo scripts, use generic wrappers:
 
 ```bash
 rtk test bun run test
 rtk err bun run typecheck
-rtk err bun run lint
 rtk err bun run build
-rtk err bun run validate:local:agent
 ```
 
-## Use Raw Commands For
+## Raw Commands
 
-- Exact file snippets or exact formatting where every line/character matters.
-- Machine-readable JSON that will be piped into `jq`, saved, or consumed later.
-- Small probes such as `pwd`, `command -v`, `printf`, `date`, or `test -d`.
-- Interactive or long-running commands such as dev servers and watchers.
-- Secret/env inspection, binary/media output, or user-requested raw/full output.
+Use raw commands for exact file snippets, JSON consumed by another command,
+small probes like `pwd`/`printf`/`test -d`, interactive servers, secrets,
+binary output, or user-requested full output.
 
-## Hook Behavior
+## Codex Hook
 
-Codex hooks cannot rewrite Bash input in place yet. If a raw command is blocked
-with `Rerun that as: ...`, rerun the exact suggested `rtk ...` command unless it
-conflicts with explicit user instructions or a safety rule.
+Codex hooks cannot rewrite Bash input in place yet. If blocked with
+`Rerun that as: ...`, run the suggested command.
 
-## Escape Hatches
+## Meta Commands
 
 ```bash
-rtk proxy <cmd>       # track invocation but bypass filtering
-RTK_DISABLED=1 <cmd>  # skip hook rewrite for one command
-rtk gain              # token savings analytics
-rtk gain --history    # recent command savings history
-rtk hook-audit        # hook rewrite metrics when RTK_HOOK_AUDIT=1 is enabled
+rtk gain             # Token savings analytics
+rtk gain --history   # Recent command savings history
+rtk proxy <cmd>      # Track invocation but bypass filtering
 rtk --version
 which rtk
 ```

--- a/hooks/codex/rtk-awareness.md
+++ b/hooks/codex/rtk-awareness.md
@@ -1,32 +1,71 @@
 # RTK - Rust Token Killer (Codex CLI)
 
-**Usage**: Token-optimized CLI proxy for shell commands.
+RTK is a token-optimized CLI proxy for shell commands. Use it deliberately:
+save context on noisy output without hiding exact details needed for the task.
 
-## Rule
+## Decision Policy
 
-Always prefix shell commands with `rtk`.
+Use RTK when the shell command is likely to emit noisy or large output and the
+filtered output still preserves the signal needed for implementation,
+debugging, or verification.
 
-Examples:
+Do not blindly prefix every command with `rtk`. In particular, do not rewrite
+shell builtins such as `test -d`, `[`/`]`, `printf`, `pwd`, or tiny probes.
+
+## Prefer RTK For
 
 ```bash
 rtk git status
+rtk git diff
+rtk git show
+rtk gh pr view <num>
+rtk gh run view <id>
+rtk grep <pattern> <path>
+rtk find <path> -name <pattern>
+rtk read <file>
 rtk cargo test
-rtk npm run build
-rtk pytest -q
+rtk pytest
+rtk vitest run
+rtk playwright test
+rtk tsc
+rtk lint
+rtk docker logs <container>
+rtk kubectl logs <pod>
+rtk curl <url>
 ```
 
-## Meta Commands
+For noisy repo scripts that RTK cannot rewrite directly, use generic wrappers:
 
 ```bash
-rtk gain            # Token savings analytics
-rtk gain --history  # Recent command savings history
-rtk proxy <cmd>     # Run raw command without filtering
+rtk test bun run test
+rtk err bun run typecheck
+rtk err bun run lint
+rtk err bun run build
+rtk err bun run validate:local:agent
 ```
 
-## Verification
+## Use Raw Commands For
+
+- Exact file snippets or exact formatting where every line/character matters.
+- Machine-readable JSON that will be piped into `jq`, saved, or consumed later.
+- Small probes such as `pwd`, `command -v`, `printf`, `date`, or `test -d`.
+- Interactive or long-running commands such as dev servers and watchers.
+- Secret/env inspection, binary/media output, or user-requested raw/full output.
+
+## Hook Behavior
+
+Codex hooks cannot rewrite Bash input in place yet. If a raw command is blocked
+with `Rerun that as: ...`, rerun the exact suggested `rtk ...` command unless it
+conflicts with explicit user instructions or a safety rule.
+
+## Escape Hatches
 
 ```bash
+rtk proxy <cmd>       # track invocation but bypass filtering
+RTK_DISABLED=1 <cmd>  # skip hook rewrite for one command
+rtk gain              # token savings analytics
+rtk gain --history    # recent command savings history
+rtk hook-audit        # hook rewrite metrics when RTK_HOOK_AUDIT=1 is enabled
 rtk --version
-rtk gain
 which rtk
 ```

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -28,7 +28,7 @@ LLM agent integration layer that installs, validates, and executes command-rewri
 | Claude-MD (legacy) | `rtk init --claude-md` | 134-line RTK block | CLAUDE.md |
 | Windsurf | `rtk init -g --agent windsurf` | `.windsurfrules` | -- |
 | Cline | `rtk init --agent cline` | `.clinerules` | -- |
-| Codex | `rtk init --codex` | RTK.md in `$CODEX_HOME` or `~/.codex` | AGENTS.md |
+| Codex | `rtk init --codex` | RTK.md + hooks.json + config.toml in `$CODEX_HOME` or `~/.codex` | AGENTS.md |
 | Cursor | `rtk init -g --agent cursor` | Cursor hook | hooks.json |
 
 
@@ -86,13 +86,13 @@ Rules are loaded from all Claude Code `settings.json` files (project + global, i
 | Copilot VS Code (rtk hook copilot) | Yes | `permissionDecision: "ask"` — user prompted |
 | Gemini CLI (rtk hook gemini) | No (allow/deny only) | allow (limitation — no ask mode in Gemini) |
 | Copilot CLI (rtk hook copilot) | No updatedInput | deny-with-suggestion (unchanged) |
-| Codex | ask parsed but no-op | allow (limitation — fails open) |
+| Codex | No in-place `updatedInput` | deny-with-suggestion |
 
 ### Implementation
 
 - `permissions.rs` — loads deny/ask/allow rules, evaluates precedence, returns `PermissionVerdict`
 - `rewrite_cmd.rs` — maps verdict to exit code (consumed by shell hook)
-- `hook_cmd.rs` — maps verdict to JSON `permissionDecision` field (Copilot/Gemini)
+- `hook_cmd.rs` — maps verdict to JSON `permissionDecision` field (Copilot/Gemini/Codex)
 
 ## Exit Code Contract
 

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -5,6 +5,7 @@ pub const HOOKS_SUBDIR: &str = "hooks";
 pub const SETTINGS_JSON: &str = "settings.json";
 pub const SETTINGS_LOCAL_JSON: &str = "settings.local.json";
 pub const HOOKS_JSON: &str = "hooks.json";
+pub const CONFIG_TOML: &str = "config.toml";
 pub const PRE_TOOL_USE_KEY: &str = "PreToolUse";
 pub const BEFORE_TOOL_KEY: &str = "BeforeTool";
 

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -62,6 +62,54 @@ pub fn run_copilot() -> Result<()> {
     }
 }
 
+/// Run the Codex CLI PreToolUse hook.
+///
+/// Codex currently parses `updatedInput` but does not apply it yet, so RTK uses
+/// deny-with-suggestion here instead of transparent rewrite.
+pub fn run_codex() -> Result<()> {
+    let input = read_stdin_limited()?;
+
+    let input = input.trim();
+    if input.is_empty() {
+        return Ok(());
+    }
+
+    let v: Value = match serde_json::from_str(input) {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = writeln!(io::stderr(), "[rtk hook] Failed to parse JSON input: {e}");
+            return Ok(());
+        }
+    };
+
+    let hook_event_name = v
+        .get("hook_event_name")
+        .and_then(|h| h.as_str())
+        .unwrap_or_default();
+    let tool_name = v.get("tool_name").and_then(|t| t.as_str()).unwrap_or("");
+
+    if hook_event_name != PRE_TOOL_USE_KEY || !matches!(tool_name, "Bash" | "bash") {
+        return Ok(());
+    }
+
+    let cmd = match v
+        .pointer("/tool_input/command")
+        .and_then(|c| c.as_str())
+        .filter(|c| !c.is_empty())
+    {
+        Some(cmd) => cmd,
+        None => return Ok(()),
+    };
+
+    let output = match codex_block_response(cmd) {
+        Some(output) => output,
+        None => return Ok(()),
+    };
+
+    let _ = writeln!(io::stdout(), "{output}");
+    Ok(())
+}
+
 fn detect_format(v: &Value) -> HookFormat {
     // VS Code Copilot Chat / Claude Code: snake_case keys
     if let Some(tool_name) = v.get("tool_name").and_then(|t| t.as_str()) {
@@ -175,6 +223,17 @@ fn handle_copilot_cli(cmd: &str) -> Result<()> {
     });
     let _ = writeln!(io::stdout(), "{output}");
     Ok(())
+}
+
+fn codex_block_response(cmd: &str) -> Option<Value> {
+    let rewritten = get_rewritten(cmd)?;
+    Some(json!({
+        "hookSpecificOutput": {
+            "hookEventName": PRE_TOOL_USE_KEY,
+            "permissionDecision": "deny",
+            "permissionDecisionReason": format!("Rerun that as: {}", rewritten)
+        }
+    }))
 }
 
 // ── Gemini hook ───────────────────────────────────────────────
@@ -524,6 +583,14 @@ mod tests {
         json!({ "toolName": "bash", "toolArgs": args })
     }
 
+    fn codex_input(event: &str, tool: &str, cmd: &str) -> Value {
+        json!({
+            "hook_event_name": event,
+            "tool_name": tool,
+            "tool_input": { "command": cmd }
+        })
+    }
+
     #[test]
     fn test_detect_vscode_bash() {
         assert!(matches!(
@@ -577,6 +644,33 @@ mod tests {
     #[test]
     fn test_get_rewritten_heredoc() {
         assert!(get_rewritten("cat <<'EOF'\nhello\nEOF").is_none());
+    }
+
+    #[test]
+    fn test_codex_hook_blocks_supported_command_with_suggestion() {
+        let output = codex_block_response("git status").unwrap();
+        assert_eq!(
+            output["hookSpecificOutput"]["hookEventName"],
+            PRE_TOOL_USE_KEY
+        );
+        assert_eq!(output["hookSpecificOutput"]["permissionDecision"], "deny");
+        assert_eq!(
+            output["hookSpecificOutput"]["permissionDecisionReason"],
+            "Rerun that as: rtk git status"
+        );
+    }
+
+    #[test]
+    fn test_codex_hook_ignores_already_rtk_command() {
+        assert!(codex_block_response("rtk git status").is_none());
+    }
+
+    #[test]
+    fn test_codex_input_shape_matches_pre_tool_use_contract() {
+        let input = codex_input(PRE_TOOL_USE_KEY, "Bash", "git status");
+        assert_eq!(input["hook_event_name"], PRE_TOOL_USE_KEY);
+        assert_eq!(input["tool_name"], "Bash");
+        assert_eq!(input["tool_input"]["command"], "git status");
     }
 
     // --- Gemini format ---

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -226,7 +226,18 @@ fn handle_copilot_cli(cmd: &str) -> Result<()> {
 }
 
 fn codex_block_response(cmd: &str) -> Option<Value> {
+    codex_block_response_with_verdict(cmd, permissions::check_command(cmd))
+}
+
+fn codex_block_response_with_verdict(cmd: &str, verdict: PermissionVerdict) -> Option<Value> {
+    if verdict == PermissionVerdict::Deny {
+        audit_log("deny", cmd, "");
+        return None;
+    }
+
     let rewritten = get_rewritten(cmd)?;
+    audit_log("rewrite", cmd, &rewritten);
+
     Some(json!({
         "hookSpecificOutput": {
             "hookEventName": PRE_TOOL_USE_KEY,
@@ -663,6 +674,11 @@ mod tests {
     #[test]
     fn test_codex_hook_ignores_already_rtk_command() {
         assert!(codex_block_response("rtk git status").is_none());
+    }
+
+    #[test]
+    fn test_codex_hook_respects_deny_verdict() {
+        assert!(codex_block_response_with_verdict("git status", PermissionVerdict::Deny).is_none());
     }
 
     #[test]

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -55,6 +55,8 @@ const CLAUDE_MD: &str = "CLAUDE.md";
 const AGENTS_MD: &str = "AGENTS.md";
 const RTK_MD_REF: &str = "@RTK.md";
 const GEMINI_MD: &str = "GEMINI.md";
+const CODEX_RTK_POLICY_START: &str = "<!-- rtk-codex-policy v1 -->";
+const CODEX_RTK_POLICY_END: &str = "<!-- /rtk-codex-policy -->";
 
 /// Control flow for settings.json patching
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -1627,7 +1629,7 @@ fn run_codex_mode_with_paths(
     };
 
     write_if_changed(&rtk_md_path, RTK_SLIM_CODEX, RTK_MD, verbose)?;
-    let added_ref = patch_agents_md(&agents_md_path, &rtk_md_ref, verbose)?;
+    let added_ref = patch_codex_agents_md(&agents_md_path, &rtk_md_ref, verbose)?;
     let config_path = codex_dir.join(CONFIG_TOML);
     let hooks_json_path = codex_dir.join(HOOKS_JSON);
     let feature_enabled = ensure_codex_hooks_feature_enabled(&config_path, verbose)?;
@@ -1636,9 +1638,9 @@ fn run_codex_mode_with_paths(
     println!("\nRTK configured for Codex CLI.\n");
     println!("  RTK.md:    {}", rtk_md_path.display());
     if added_ref {
-        println!("  AGENTS.md: {} reference added", rtk_md_ref);
+        println!("  AGENTS.md: inline RTK policy added");
     } else {
-        println!("  AGENTS.md: {} reference already present", rtk_md_ref);
+        println!("  AGENTS.md: inline RTK policy already present");
     }
     if global {
         println!(
@@ -1783,8 +1785,23 @@ fn patch_claude_md(path: &Path, verbose: u8) -> Result<bool> {
     Ok(migrated)
 }
 
-/// Patch AGENTS.md: add @RTK.md (or absolute path), migrate old inline block if present
-fn patch_agents_md(path: &Path, rtk_md_ref: &str, verbose: u8) -> Result<bool> {
+fn codex_agents_policy(rtk_md_ref: &str) -> String {
+    format!(
+        r#"{CODEX_RTK_POLICY_START}
+## RTK Shell Output Policy
+- Use `rtk` for shell commands likely to produce noisy or large output when the filtered output still preserves the signal needed for the task.
+- Prefer RTK for: `git status/log/diff/show`, `gh pr/issue/run/api`, `rg`/`grep`, `find`, `ls`, `tree`, `cat`/`head`/`tail` when reading broad files, `cargo`, `pytest`, `vitest`, `jest`, `playwright`, `tsc`, lint/typecheck/build/test scripts, Docker/Kubernetes/AWS logs or listings, and HTTP/API responses.
+- For repo scripts that RTK cannot rewrite directly, use generic wrappers: `rtk test <command>` for tests and `rtk err <command>` for typecheck/lint/build/validate commands.
+- Do not blindly prefix every shell command with `rtk`. Use raw commands when exact output is required, including exact file snippets, machine-readable JSON consumed by later commands, small probes like `pwd` or `printf`, interactive or long-running dev servers, secret/env inspection, binary/media output, or when the user asks for raw/full output.
+- If the Codex hook blocks a command and says `Rerun that as: ...`, rerun the exact suggested `rtk ...` command unless it conflicts with explicit user instructions or a safety rule.
+- Use `rtk proxy <command>` only when RTK invocation/tracking is useful but filtering must be bypassed. Use `rtk gain` or `rtk hook-audit` when diagnosing RTK adoption.
+- Expanded RTK reference: {rtk_md_ref}.
+{CODEX_RTK_POLICY_END}"#
+    )
+}
+
+/// Patch Codex AGENTS.md with inline policy plus RTK.md reference.
+fn patch_codex_agents_md(path: &Path, rtk_md_ref: &str, verbose: u8) -> Result<bool> {
     let mut content = if path.exists() {
         fs::read_to_string(path)
             .with_context(|| format!("Failed to read AGENTS.md: {}", path.display()))?
@@ -1792,54 +1809,60 @@ fn patch_agents_md(path: &Path, rtk_md_ref: &str, verbose: u8) -> Result<bool> {
         String::new()
     };
 
-    let mut migrated = false;
+    let mut changed = false;
     if content.contains("<!-- rtk-instructions") {
         let (new_content, did_migrate) = remove_rtk_block(&content);
         if did_migrate {
             content = new_content;
-            migrated = true;
+            changed = true;
             if verbose > 0 {
                 eprintln!("Migrated: removed old RTK block from AGENTS.md");
             }
         }
     }
 
-    // ISSUE #892: Check for both relative and absolute @RTK.md references
-    if content.contains(RTK_MD_REF) || content.contains(rtk_md_ref) {
-        if verbose > 0 {
-            eprintln!("{} reference already present in AGENTS.md", rtk_md_ref);
-        }
-        // ISSUE #892: Migrate old relative @RTK.md to absolute path if needed
-        if rtk_md_ref != RTK_MD_REF && content.contains(RTK_MD_REF) && !content.contains(rtk_md_ref)
-        {
-            content = content.replace(RTK_MD_REF, rtk_md_ref);
-            atomic_write(path, &content)
-                .with_context(|| format!("Failed to write AGENTS.md: {}", path.display()))?;
-            if verbose > 0 {
-                eprintln!("Migrated {} to {}", RTK_MD_REF, rtk_md_ref);
-            }
-            return Ok(true);
-        }
-        if migrated {
+    let policy = codex_agents_policy(rtk_md_ref);
+    if content.contains(&policy) && !has_rtk_reference(&content, &[RTK_MD_REF, rtk_md_ref]) {
+        if changed {
             atomic_write(path, &content)
                 .with_context(|| format!("Failed to write AGENTS.md: {}", path.display()))?;
         }
-        return Ok(false);
+        return Ok(changed);
     }
 
-    let new_content = if content.is_empty() {
-        format!("{}\n", rtk_md_ref)
+    let (without_policy, removed_policy) =
+        remove_between_markers(&content, CODEX_RTK_POLICY_START, CODEX_RTK_POLICY_END);
+    if removed_policy {
+        content = without_policy;
+        changed = true;
+    }
+
+    let mut lines = content
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim();
+            trimmed != RTK_MD_REF && trimmed != rtk_md_ref
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    lines = clean_double_blanks(&lines);
+
+    let new_content = if lines.trim().is_empty() {
+        format!("{}\n", policy)
     } else {
-        format!("{}\n\n{}\n", content.trim(), rtk_md_ref)
+        format!("{}\n\n{}\n", lines.trim(), policy)
     };
 
-    atomic_write(path, &new_content)
-        .with_context(|| format!("Failed to write AGENTS.md: {}", path.display()))?;
-    if verbose > 0 {
-        eprintln!("Added {} reference to AGENTS.md", rtk_md_ref);
+    if new_content != content {
+        changed = true;
+        atomic_write(path, &new_content)
+            .with_context(|| format!("Failed to write AGENTS.md: {}", path.display()))?;
+        if verbose > 0 {
+            eprintln!("Added inline RTK policy to AGENTS.md");
+        }
     }
 
-    Ok(true)
+    Ok(changed)
 }
 
 fn has_rtk_reference(content: &str, refs: &[&str]) -> bool {
@@ -1849,14 +1872,42 @@ fn has_rtk_reference(content: &str, refs: &[&str]) -> bool {
         .any(|line| refs.contains(&line))
 }
 
+fn has_codex_rtk_policy(content: &str) -> bool {
+    content.contains(CODEX_RTK_POLICY_START) && content.contains(CODEX_RTK_POLICY_END)
+}
+
+fn remove_between_markers(content: &str, start_marker: &str, end_marker: &str) -> (String, bool) {
+    if let (Some(start), Some(end)) = (content.find(start_marker), content.find(end_marker)) {
+        let end_pos = end + end_marker.len();
+        let before = content[..start].trim_end();
+        let after = content[end_pos..].trim_start();
+        let result = if before.is_empty() {
+            after.to_string()
+        } else if after.is_empty() {
+            before.to_string()
+        } else {
+            format!("{}\n\n{}", before, after)
+        };
+        (result, true)
+    } else {
+        (content.to_string(), false)
+    }
+}
+
 fn remove_rtk_reference_from_agents(path: &Path, refs: &[&str], verbose: u8) -> Result<bool> {
     if !path.exists() {
         return Ok(false);
     }
 
-    let content = fs::read_to_string(path)
+    let mut content = fs::read_to_string(path)
         .with_context(|| format!("Failed to read AGENTS.md: {}", path.display()))?;
-    if !has_rtk_reference(&content, refs) {
+    let (without_policy, removed_policy) =
+        remove_between_markers(&content, CODEX_RTK_POLICY_START, CODEX_RTK_POLICY_END);
+    if removed_policy {
+        content = without_policy;
+    }
+
+    if !removed_policy && !has_rtk_reference(&content, refs) {
         return Ok(false);
     }
 
@@ -2788,7 +2839,9 @@ fn show_codex_config() -> Result<()> {
 
     if global_agents_md.exists() {
         let content = fs::read_to_string(&global_agents_md)?;
-        if has_rtk_reference(&content, &[RTK_MD_REF, global_rtk_md_ref.as_str()]) {
+        if has_codex_rtk_policy(&content) {
+            println!("[ok] Global AGENTS.md: inline RTK policy");
+        } else if has_rtk_reference(&content, &[RTK_MD_REF, global_rtk_md_ref.as_str()]) {
             println!("[ok] Global AGENTS.md: RTK.md reference");
         } else if content.contains("<!-- rtk-instructions") {
             println!("[!!] Global AGENTS.md: old inline RTK block");
@@ -2817,7 +2870,9 @@ fn show_codex_config() -> Result<()> {
 
     if local_agents_md.exists() {
         let content = fs::read_to_string(&local_agents_md)?;
-        if has_rtk_reference(&content, &[RTK_MD_REF]) {
+        if has_codex_rtk_policy(&content) {
+            println!("[ok] Local AGENTS.md: inline RTK policy");
+        } else if has_rtk_reference(&content, &[RTK_MD_REF]) {
             println!("[ok] Local AGENTS.md: @RTK.md reference");
         } else if content.contains("<!-- rtk-instructions") {
             println!("[!!] Local AGENTS.md: old inline RTK block");
@@ -3333,22 +3388,6 @@ More notes
     }
 
     #[test]
-    fn test_patch_agents_md_adds_reference_once() {
-        let temp = TempDir::new().unwrap();
-        let agents_md = temp.path().join("AGENTS.md");
-
-        fs::write(&agents_md, "# Team rules\n").unwrap();
-        let first_added = patch_agents_md(&agents_md, RTK_MD_REF, 0).unwrap();
-        let second_added = patch_agents_md(&agents_md, RTK_MD_REF, 0).unwrap();
-
-        assert!(first_added);
-        assert!(!second_added);
-
-        let content = fs::read_to_string(&agents_md).unwrap();
-        assert_eq!(content.matches("@RTK.md").count(), 1);
-    }
-
-    #[test]
     fn test_codex_mode_rejects_auto_patch() {
         let err = run(
             false,
@@ -3636,37 +3675,7 @@ codex_hooks = true
     }
 
     #[test]
-    fn test_patch_agents_md_creates_missing_file() {
-        let temp = TempDir::new().unwrap();
-        let agents_md = temp.path().join("AGENTS.md");
-
-        let added = patch_agents_md(&agents_md, RTK_MD_REF, 0).unwrap();
-
-        assert!(added);
-        let content = fs::read_to_string(&agents_md).unwrap();
-        assert_eq!(content, "@RTK.md\n");
-    }
-
-    #[test]
-    fn test_patch_agents_md_migrates_inline_block() {
-        let temp = TempDir::new().unwrap();
-        let agents_md = temp.path().join("AGENTS.md");
-        fs::write(
-            &agents_md,
-            "# Team rules\n\n<!-- rtk-instructions v2 -->\nold\n<!-- /rtk-instructions -->\n",
-        )
-        .unwrap();
-
-        let added = patch_agents_md(&agents_md, RTK_MD_REF, 0).unwrap();
-
-        assert!(added);
-        let content = fs::read_to_string(&agents_md).unwrap();
-        assert!(!content.contains("old"));
-        assert_eq!(content.matches("@RTK.md").count(), 1);
-    }
-
-    #[test]
-    fn test_run_codex_mode_global_writes_absolute_reference_to_codex_dir() {
+    fn test_run_codex_mode_global_writes_inline_policy_with_absolute_reference() {
         let temp = TempDir::new().unwrap();
         let agents_md = temp.path().join("AGENTS.md");
         let rtk_md = temp.path().join("RTK.md");
@@ -3676,10 +3685,38 @@ codex_hooks = true
 
         assert!(rtk_md.exists());
         assert_eq!(fs::read_to_string(&rtk_md).unwrap(), RTK_SLIM_CODEX);
-        assert_eq!(
-            fs::read_to_string(&agents_md).unwrap(),
-            format!("{}\n", codex_rtk_md_ref(temp.path()))
-        );
+        let agents_content = fs::read_to_string(&agents_md).unwrap();
+        assert!(has_codex_rtk_policy(&agents_content));
+        assert!(agents_content.contains(&codex_rtk_md_ref(temp.path())));
+        assert!(!has_rtk_reference(
+            &agents_content,
+            &[RTK_MD_REF, codex_rtk_md_ref(temp.path()).as_str()]
+        ));
+    }
+
+    #[test]
+    fn test_patch_codex_agents_md_replaces_legacy_reference_idempotently() {
+        let temp = TempDir::new().unwrap();
+        let agents_md = temp.path().join("AGENTS.md");
+        let absolute_ref = codex_rtk_md_ref(temp.path());
+
+        fs::write(&agents_md, format!("# Team rules\n\n{}\n", RTK_MD_REF)).unwrap();
+
+        let first_added = patch_codex_agents_md(&agents_md, &absolute_ref, 0).unwrap();
+        let second_added = patch_codex_agents_md(&agents_md, &absolute_ref, 0).unwrap();
+
+        assert!(first_added);
+        assert!(!second_added);
+
+        let content = fs::read_to_string(&agents_md).unwrap();
+        assert!(content.contains("# Team rules"));
+        assert!(has_codex_rtk_policy(&content));
+        assert!(content.contains(&absolute_ref));
+        assert_eq!(content.matches(CODEX_RTK_POLICY_START).count(), 1);
+        assert!(!has_rtk_reference(
+            &content,
+            &[RTK_MD_REF, absolute_ref.as_str()]
+        ));
     }
 
     #[test]
@@ -3736,6 +3773,7 @@ codex_hooks = true
 
         let content = fs::read_to_string(&agents_md).unwrap();
         assert!(!content.contains("@RTK.md"));
+        assert!(!has_codex_rtk_policy(&content));
         assert!(content.contains("# Team rules"));
 
         let hooks_content = fs::read_to_string(&hooks_json).unwrap();
@@ -3763,6 +3801,31 @@ codex_hooks = true
         assert_eq!(removed.len(), 2);
         let content = fs::read_to_string(&agents_md).unwrap();
         assert!(!content.contains(&absolute_ref));
+        assert!(!has_codex_rtk_policy(&content));
+        assert!(content.contains("# Team rules"));
+    }
+
+    #[test]
+    fn test_uninstall_codex_at_removes_inline_policy() {
+        let temp = TempDir::new().unwrap();
+        let codex_dir = temp.path();
+        let agents_md = codex_dir.join("AGENTS.md");
+        let rtk_md = codex_dir.join("RTK.md");
+        let absolute_ref = codex_rtk_md_ref(codex_dir);
+
+        fs::write(
+            &agents_md,
+            format!("# Team rules\n\n{}\n", codex_agents_policy(&absolute_ref)),
+        )
+        .unwrap();
+        fs::write(&rtk_md, "codex config").unwrap();
+
+        let removed = uninstall_codex_at(codex_dir, 0).unwrap();
+
+        assert_eq!(removed.len(), 2);
+        let content = fs::read_to_string(&agents_md).unwrap();
+        assert!(!content.contains(&absolute_ref));
+        assert!(!has_codex_rtk_policy(&content));
         assert!(content.contains("# Team rules"));
     }
 

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -1789,12 +1789,12 @@ fn codex_agents_policy(rtk_md_ref: &str) -> String {
     format!(
         r#"{CODEX_RTK_POLICY_START}
 ## RTK Shell Output Policy
-- Use `rtk` for shell commands likely to produce noisy or large output when the filtered output still preserves the signal needed for the task.
-- Prefer RTK for: `git status/log/diff/show`, `gh pr/issue/run/api`, `rg`/`grep`, `find`, `ls`, `tree`, `cat`/`head`/`tail` when reading broad files, `cargo`, `pytest`, `vitest`, `jest`, `playwright`, `tsc`, lint/typecheck/build/test scripts, Docker/Kubernetes/AWS logs or listings, and HTTP/API responses.
-- For repo scripts that RTK cannot rewrite directly, use generic wrappers: `rtk test <command>` for tests and `rtk err <command>` for typecheck/lint/build/validate commands.
-- Do not blindly prefix every shell command with `rtk`. Use raw commands when exact output is required, including exact file snippets, machine-readable JSON consumed by later commands, small probes like `pwd` or `printf`, interactive or long-running dev servers, secret/env inspection, binary/media output, or when the user asks for raw/full output.
-- If the Codex hook blocks a command and says `Rerun that as: ...`, rerun the exact suggested `rtk ...` command unless it conflicts with explicit user instructions or a safety rule.
-- Use `rtk proxy <command>` only when RTK invocation/tracking is useful but filtering must be bypassed. Use `rtk gain` or `rtk hook-audit` when diagnosing RTK adoption.
+- Use `rtk` for noisy shell commands when filtered output preserves the signal needed.
+- Prefer RTK for Git/GitHub status, diffs, searches, broad file reads, tests, builds, typechecks, linters, logs, and API responses.
+- For repo scripts, use `rtk test <command>` for tests and `rtk err <command>` for typecheck/lint/build commands.
+- Use raw commands for exact snippets, JSON consumed by another command, tiny probes like `pwd`/`printf`/`test -d`, interactive servers, secrets, binary output, or user-requested full output.
+- If the Codex hook blocks a command with `Rerun that as: ...`, run the suggested command.
+- Use `rtk proxy <command>` when tracking is useful but filtering must be bypassed.
 - Expanded RTK reference: {rtk_md_ref}.
 {CODEX_RTK_POLICY_END}"#
     )

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -743,6 +743,11 @@ fn uninstall_codex_at(codex_dir: &Path, verbose: u8) -> Result<Vec<String>> {
         removed.push("hooks.json: removed RTK PreToolUse hook".to_string());
     }
 
+    let config_toml_path = codex_dir.join(CONFIG_TOML);
+    if remove_codex_hook_flag_from_config(&config_toml_path, verbose)? {
+        removed.push("config.toml: removed features.codex_hooks".to_string());
+    }
+
     Ok(removed)
 }
 
@@ -788,21 +793,92 @@ fn remove_codex_hook_from_json(root: &mut serde_json::Value) -> bool {
         None => return false,
     };
 
-    let original_len = hooks.len();
-    hooks.retain(|entry| {
-        let hook_entries = match entry.get("hooks").and_then(|h| h.as_array()) {
+    let mut removed = false;
+
+    for entry in hooks.iter_mut() {
+        let hook_entries = match entry.get_mut("hooks").and_then(|h| h.as_array_mut()) {
             Some(hook_entries) => hook_entries,
-            None => return true,
+            None => continue,
         };
 
-        !hook_entries.iter().any(|hook| {
-            hook.get("command")
+        let original_len = hook_entries.len();
+        hook_entries.retain(|hook| {
+            !hook
+                .get("command")
                 .and_then(|c| c.as_str())
                 .is_some_and(is_codex_hook_command)
-        })
+        });
+
+        if hook_entries.len() < original_len {
+            removed = true;
+        }
+    }
+
+    hooks.retain(|entry| {
+        entry
+            .get("hooks")
+            .and_then(|h| h.as_array())
+            .is_none_or(|hook_entries| !hook_entries.is_empty())
     });
 
-    hooks.len() < original_len
+    removed
+}
+
+fn remove_codex_hook_flag_from_config(path: &Path, verbose: u8) -> Result<bool> {
+    if !path.exists() {
+        return Ok(false);
+    }
+
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+
+    if content.trim().is_empty() {
+        return Ok(false);
+    }
+
+    let mut root: toml::Value = toml::from_str(&content)
+        .with_context(|| format!("Failed to parse {} as TOML", path.display()))?;
+
+    let removed = remove_codex_hook_flag_from_toml(&mut root);
+    if !removed {
+        return Ok(false);
+    }
+
+    backup_file_if_exists(path, verbose)?;
+    let serialized =
+        toml::to_string_pretty(&root).context("Failed to serialize Codex config.toml")?;
+    atomic_write(path, &serialized)?;
+
+    if verbose > 0 {
+        eprintln!("Removed Codex hook flag from {}", path.display());
+    }
+
+    Ok(true)
+}
+
+fn remove_codex_hook_flag_from_toml(root: &mut toml::Value) -> bool {
+    let Some(root_table) = root.as_table_mut() else {
+        return false;
+    };
+
+    let Some(features_value) = root_table.get_mut("features") else {
+        return false;
+    };
+
+    let Some(features_table) = features_value.as_table_mut() else {
+        return false;
+    };
+
+    let removed = features_table.remove("codex_hooks").is_some();
+    if !removed {
+        return false;
+    }
+
+    if features_table.is_empty() {
+        root_table.remove("features");
+    }
+
+    true
 }
 
 /// Orchestrator: patch settings.json with RTK hook (binary command variant)
@@ -2113,6 +2189,33 @@ fn codex_hook_already_present(root: &serde_json::Value) -> bool {
         })
 }
 
+fn print_codex_hooks_status(scope: &str, path: &Path) {
+    if !path.exists() {
+        println!("[--] {scope} hooks.json: not found");
+        return;
+    }
+
+    match fs::read_to_string(path) {
+        Ok(content) => match serde_json::from_str::<serde_json::Value>(&content) {
+            Ok(json) => {
+                if codex_hook_already_present(&json) {
+                    println!("[ok] {scope} hooks.json: RTK PreToolUse hook");
+                } else {
+                    println!("[--] {scope} hooks.json: exists but RTK hook missing");
+                }
+            }
+            Err(err) => {
+                println!(
+                    "[!!] {scope} hooks.json: invalid JSON ({err}); treating as not configured"
+                );
+            }
+        },
+        Err(err) => {
+            println!("[!!] {scope} hooks.json: could not read ({err}); treating as not configured");
+        }
+    }
+}
+
 fn normalize_codex_hooks_root(root: &mut serde_json::Value) {
     if !root.is_object() {
         *root = serde_json::json!({ "hooks": {} });
@@ -2696,17 +2799,7 @@ fn show_codex_config() -> Result<()> {
         println!("[--] Global AGENTS.md: not found");
     }
 
-    if global_hooks_json.exists() {
-        let content = fs::read_to_string(&global_hooks_json)?;
-        let json: serde_json::Value = serde_json::from_str(&content)?;
-        if codex_hook_already_present(&json) {
-            println!("[ok] Global hooks.json: RTK PreToolUse hook");
-        } else {
-            println!("[--] Global hooks.json: exists but RTK hook missing");
-        }
-    } else {
-        println!("[--] Global hooks.json: not found");
-    }
+    print_codex_hooks_status("Global", &global_hooks_json);
 
     if codex_hooks_enabled(&global_config_toml)? {
         println!("[ok] Global config.toml: features.codex_hooks = true");
@@ -2735,17 +2828,7 @@ fn show_codex_config() -> Result<()> {
         println!("[--] Local AGENTS.md: not found");
     }
 
-    if local_hooks_json.exists() {
-        let content = fs::read_to_string(&local_hooks_json)?;
-        let json: serde_json::Value = serde_json::from_str(&content)?;
-        if codex_hook_already_present(&json) {
-            println!("[ok] Local hooks.json: RTK PreToolUse hook");
-        } else {
-            println!("[--] Local hooks.json: exists but RTK hook missing");
-        }
-    } else {
-        println!("[--] Local hooks.json: not found");
-    }
+    print_codex_hooks_status("Local", &local_hooks_json);
 
     if codex_hooks_enabled(&local_config_toml)? {
         println!("[ok] Local config.toml: features.codex_hooks = true");
@@ -3452,6 +3535,86 @@ More notes
     }
 
     #[test]
+    fn test_remove_codex_hook_from_json_preserves_sibling_hooks() {
+        let mut json_content = serde_json::json!({
+            "hooks": {
+                (PRE_TOOL_USE_KEY): [{
+                    "matcher": "Bash",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "python3 ./other-hook.py"
+                        },
+                        {
+                            "type": "command",
+                            "command": "rtk hook codex"
+                        }
+                    ]
+                }]
+            }
+        });
+
+        let removed = remove_codex_hook_from_json(&mut json_content);
+
+        assert!(removed);
+        let pre_tool_use = json_content["hooks"][PRE_TOOL_USE_KEY].as_array().unwrap();
+        assert_eq!(pre_tool_use.len(), 1);
+        let hooks = pre_tool_use[0]["hooks"].as_array().unwrap();
+        assert_eq!(hooks.len(), 1);
+        assert_eq!(hooks[0]["command"], "python3 ./other-hook.py");
+    }
+
+    #[test]
+    fn test_remove_codex_hook_flag_from_toml() {
+        let mut config: toml::Value = r#"
+[features]
+codex_hooks = true
+other_feature = true
+"#
+        .parse()
+        .unwrap();
+
+        assert!(remove_codex_hook_flag_from_toml(&mut config));
+        assert!(!codex_hooks_enabled_value(&config));
+        assert_eq!(
+            config
+                .get("features")
+                .and_then(|features| features.get("other_feature"))
+                .and_then(|value| value.as_bool()),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn test_remove_codex_hook_flag_removes_empty_features_table() {
+        let mut config: toml::Value = r#"
+[features]
+codex_hooks = true
+"#
+        .parse()
+        .unwrap();
+
+        assert!(remove_codex_hook_flag_from_toml(&mut config));
+        assert!(config.get("features").is_none());
+    }
+
+    fn codex_hooks_enabled_value(root: &toml::Value) -> bool {
+        root.get("features")
+            .and_then(|features| features.get("codex_hooks"))
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false)
+    }
+
+    #[test]
+    fn test_print_codex_hooks_status_handles_invalid_json() {
+        let temp = TempDir::new().unwrap();
+        let hooks_json = temp.path().join(HOOKS_JSON);
+        fs::write(&hooks_json, "{not-json").unwrap();
+
+        print_codex_hooks_status("Test", &hooks_json);
+    }
+
+    #[test]
     fn test_ensure_codex_hooks_feature_enabled_creates_and_is_idempotent() {
         let temp = TempDir::new().unwrap();
         let config_path = temp.path().join(CONFIG_TOML);
@@ -3542,6 +3705,7 @@ More notes
         let agents_md = codex_dir.join("AGENTS.md");
         let rtk_md = codex_dir.join("RTK.md");
         let hooks_json = codex_dir.join(HOOKS_JSON);
+        let config_toml = codex_dir.join(CONFIG_TOML);
 
         fs::write(&agents_md, "# Team rules\n\n@RTK.md\n").unwrap();
         fs::write(&rtk_md, "codex config").unwrap();
@@ -3561,11 +3725,12 @@ More notes
             .to_string(),
         )
         .unwrap();
+        fs::write(&config_toml, "[features]\ncodex_hooks = true\n").unwrap();
 
         let removed_first = uninstall_codex_at(codex_dir, 0).unwrap();
         let removed_second = uninstall_codex_at(codex_dir, 0).unwrap();
 
-        assert_eq!(removed_first.len(), 3);
+        assert_eq!(removed_first.len(), 4);
         assert!(removed_second.is_empty());
         assert!(!rtk_md.exists());
 
@@ -3576,6 +3741,10 @@ More notes
         let hooks_content = fs::read_to_string(&hooks_json).unwrap();
         let hooks_json: serde_json::Value = serde_json::from_str(&hooks_content).unwrap();
         assert!(!codex_hook_already_present(&hooks_json));
+
+        let config_content = fs::read_to_string(&config_toml).unwrap();
+        let config: toml::Value = toml::from_str(&config_content).unwrap();
+        assert!(!codex_hooks_enabled_value(&config));
     }
 
     #[test]

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 
 use super::constants::{
-    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND,
+    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CONFIG_TOML, CURSOR_HOOK_COMMAND,
     GEMINI_HOOK_FILE, HOOKS_JSON, HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use super::integrity;
@@ -356,6 +356,45 @@ fn atomic_write(path: &Path, content: &str) -> Result<()> {
     Ok(())
 }
 
+fn backup_path(path: &Path) -> Result<PathBuf> {
+    let file_name = path
+        .file_name()
+        .context("Cannot create backup: path has no file name")?
+        .to_string_lossy();
+    Ok(path.with_file_name(format!("{file_name}.bak")))
+}
+
+fn backup_file_if_exists(path: &Path, verbose: u8) -> Result<Option<PathBuf>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let backup = backup_path(path)?;
+    fs::copy(path, &backup).with_context(|| {
+        format!(
+            "Failed to back up {} to {}",
+            path.display(),
+            backup.display()
+        )
+    })?;
+
+    if verbose > 0 {
+        eprintln!("Backup: {}", backup.display());
+    }
+
+    Ok(Some(backup))
+}
+
+fn is_codex_hook_command(command: &str) -> bool {
+    let trimmed = command.trim();
+    trimmed == "rtk hook codex"
+        || trimmed == "~/.local/bin/rtk hook codex"
+        || trimmed.ends_with("/rtk hook codex")
+        || trimmed.ends_with("\\rtk hook codex")
+        || trimmed.ends_with("/rtk' hook codex")
+        || trimmed.ends_with("\\rtk' hook codex")
+}
+
 /// Prompt user for consent to patch settings.json
 /// Prints to stderr (stdout may be piped), reads from stdin
 /// Default is No (capital N)
@@ -699,7 +738,71 @@ fn uninstall_codex_at(codex_dir: &Path, verbose: u8) -> Result<Vec<String>> {
         removed.push("AGENTS.md: removed @RTK.md reference".to_string());
     }
 
+    let hooks_json_path = codex_dir.join(HOOKS_JSON);
+    if remove_codex_hook_from_settings(&hooks_json_path, verbose)? {
+        removed.push("hooks.json: removed RTK PreToolUse hook".to_string());
+    }
+
     Ok(removed)
+}
+
+fn remove_codex_hook_from_settings(path: &Path, verbose: u8) -> Result<bool> {
+    if !path.exists() {
+        return Ok(false);
+    }
+
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+
+    if content.trim().is_empty() {
+        return Ok(false);
+    }
+
+    let mut root: serde_json::Value = serde_json::from_str(&content)
+        .with_context(|| format!("Failed to parse {} as JSON", path.display()))?;
+
+    let removed = remove_codex_hook_from_json(&mut root);
+    if !removed {
+        return Ok(false);
+    }
+
+    backup_file_if_exists(path, verbose)?;
+    let serialized =
+        serde_json::to_string_pretty(&root).context("Failed to serialize Codex hooks.json")?;
+    atomic_write(path, &serialized)?;
+
+    if verbose > 0 {
+        eprintln!("Removed Codex RTK hook from {}", path.display());
+    }
+
+    Ok(true)
+}
+
+fn remove_codex_hook_from_json(root: &mut serde_json::Value) -> bool {
+    let hooks = match root
+        .get_mut("hooks")
+        .and_then(|h| h.get_mut(PRE_TOOL_USE_KEY))
+        .and_then(|p| p.as_array_mut())
+    {
+        Some(hooks) => hooks,
+        None => return false,
+    };
+
+    let original_len = hooks.len();
+    hooks.retain(|entry| {
+        let hook_entries = match entry.get("hooks").and_then(|h| h.as_array()) {
+            Some(hook_entries) => hook_entries,
+            None => return true,
+        };
+
+        !hook_entries.iter().any(|hook| {
+            hook.get("command")
+                .and_then(|c| c.as_str())
+                .is_some_and(is_codex_hook_command)
+        })
+    });
+
+    hooks.len() < original_len
 }
 
 /// Orchestrator: patch settings.json with RTK hook (binary command variant)
@@ -1406,32 +1509,33 @@ fn run_antigravity_mode_at(base_dir: &Path, verbose: u8) -> Result<()> {
 }
 
 fn run_codex_mode(global: bool, verbose: u8) -> Result<()> {
+    let codex_dir = if global {
+        resolve_codex_dir()?
+    } else {
+        resolve_local_codex_dir()
+    };
     let (agents_md_path, rtk_md_path) = if global {
-        let codex_dir = resolve_codex_dir()?;
         (codex_dir.join(AGENTS_MD), codex_dir.join(RTK_MD))
     } else {
         (PathBuf::from(AGENTS_MD), PathBuf::from(RTK_MD))
     };
 
-    run_codex_mode_with_paths(agents_md_path, rtk_md_path, global, verbose)
+    run_codex_mode_with_paths(agents_md_path, rtk_md_path, codex_dir, global, verbose)
 }
 
 fn run_codex_mode_with_paths(
     agents_md_path: PathBuf,
     rtk_md_path: PathBuf,
+    codex_dir: PathBuf,
     global: bool,
     verbose: u8,
 ) -> Result<()> {
-    if global {
-        if let Some(parent) = agents_md_path.parent() {
-            fs::create_dir_all(parent).with_context(|| {
-                format!(
-                    "Failed to create Codex config directory: {}",
-                    parent.display()
-                )
-            })?;
-        }
-    }
+    fs::create_dir_all(&codex_dir).with_context(|| {
+        format!(
+            "Failed to create Codex config directory: {}",
+            codex_dir.display()
+        )
+    })?;
 
     // ISSUE #892: In global mode, use absolute path so @RTK.md resolves
     // from any CWD (worktrees, nested projects). Codex resolves @ references
@@ -1448,6 +1552,10 @@ fn run_codex_mode_with_paths(
 
     write_if_changed(&rtk_md_path, RTK_SLIM_CODEX, RTK_MD, verbose)?;
     let added_ref = patch_agents_md(&agents_md_path, &rtk_md_ref, verbose)?;
+    let config_path = codex_dir.join(CONFIG_TOML);
+    let hooks_json_path = codex_dir.join(HOOKS_JSON);
+    let feature_enabled = ensure_codex_hooks_feature_enabled(&config_path, verbose)?;
+    let hook_added = patch_codex_hooks_json(&hooks_json_path, verbose)?;
 
     println!("\nRTK configured for Codex CLI.\n");
     println!("  RTK.md:    {}", rtk_md_path.display());
@@ -1467,6 +1575,22 @@ fn run_codex_mode_with_paths(
             agents_md_path.display()
         );
     }
+    println!("  hooks.json: {}", hooks_json_path.display());
+    if hook_added {
+        println!("  hooks.json: RTK PreToolUse hook added");
+    } else {
+        println!("  hooks.json: RTK PreToolUse hook already present");
+    }
+    println!("  config.toml: {}", config_path.display());
+    if feature_enabled {
+        println!("  config.toml: enabled features.codex_hooks = true");
+    } else {
+        println!("  config.toml: features.codex_hooks already enabled");
+    }
+    println!(
+        "\n  Note: Codex hooks cannot rewrite Bash commands in-place yet, so RTK blocks matching Bash commands and suggests the `rtk ...` equivalent."
+    );
+    println!("  Restart Codex. Test with: git status\n");
 
     Ok(())
 }
@@ -1753,6 +1877,10 @@ fn resolve_codex_dir_from(
         .context("Cannot determine Codex config directory. Set $CODEX_HOME or $HOME.")
 }
 
+fn resolve_local_codex_dir() -> PathBuf {
+    PathBuf::from(CODEX_DIR)
+}
+
 fn codex_rtk_md_ref(codex_dir: &Path) -> String {
     format!("@{}", codex_dir.join(RTK_MD).display())
 }
@@ -1802,6 +1930,230 @@ fn remove_opencode_plugin(verbose: u8) -> Result<Vec<PathBuf>> {
     }
 
     Ok(removed)
+}
+
+fn codex_hooks_enabled(path: &Path) -> Result<bool> {
+    if !path.exists() {
+        return Ok(false);
+    }
+
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    if content.trim().is_empty() {
+        return Ok(false);
+    }
+
+    let root: toml::Value =
+        toml::from_str(&content).with_context(|| format!("Failed to parse {}", path.display()))?;
+
+    Ok(root
+        .get("features")
+        .and_then(|f| f.get("codex_hooks"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false))
+}
+
+fn ensure_codex_hooks_feature_enabled(path: &Path, verbose: u8) -> Result<bool> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create Codex config dir: {}", parent.display()))?;
+    }
+
+    let mut root = if path.exists() {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+
+        if content.trim().is_empty() {
+            toml::Value::Table(toml::map::Map::new())
+        } else {
+            toml::from_str(&content)
+                .with_context(|| format!("Failed to parse {}", path.display()))?
+        }
+    } else {
+        toml::Value::Table(toml::map::Map::new())
+    };
+
+    let root_table = match root.as_table_mut() {
+        Some(table) => table,
+        None => anyhow::bail!("Codex config root must be a TOML table: {}", path.display()),
+    };
+
+    let features = root_table
+        .entry("features")
+        .or_insert_with(|| toml::Value::Table(toml::map::Map::new()));
+    let features_table = match features.as_table_mut() {
+        Some(table) => table,
+        None => anyhow::bail!("Codex [features] must be a TOML table: {}", path.display()),
+    };
+
+    if features_table
+        .get("codex_hooks")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        return Ok(false);
+    }
+
+    features_table.insert("codex_hooks".to_string(), toml::Value::Boolean(true));
+    backup_file_if_exists(path, verbose)?;
+    let serialized = toml::to_string_pretty(&root).context("Failed to serialize Codex config")?;
+    atomic_write(path, &serialized)?;
+
+    if verbose > 0 {
+        eprintln!("Enabled features.codex_hooks in {}", path.display());
+    }
+
+    Ok(true)
+}
+
+fn patch_codex_hooks_json(path: &Path, verbose: u8) -> Result<bool> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create Codex hooks dir: {}", parent.display()))?;
+    }
+
+    let mut root = if path.exists() {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+
+        if content.trim().is_empty() {
+            serde_json::json!({ "hooks": {} })
+        } else {
+            serde_json::from_str(&content)
+                .with_context(|| format!("Failed to parse {} as JSON", path.display()))?
+        }
+    } else {
+        serde_json::json!({ "hooks": {} })
+    };
+
+    let changed = upsert_codex_hook_entry(&mut root, "rtk hook codex");
+    if !changed {
+        if verbose > 0 {
+            eprintln!("Codex hooks.json: RTK hook already present");
+        }
+        return Ok(false);
+    }
+    backup_file_if_exists(path, verbose)?;
+    let serialized =
+        serde_json::to_string_pretty(&root).context("Failed to serialize Codex hooks.json")?;
+    atomic_write(path, &serialized)?;
+
+    if verbose > 0 {
+        eprintln!("Patched Codex hooks.json: {}", path.display());
+    }
+
+    Ok(true)
+}
+
+fn upsert_codex_hook_entry(root: &mut serde_json::Value, command: &str) -> bool {
+    normalize_codex_hooks_root(root);
+
+    if update_existing_codex_hook_command(root, command) {
+        return true;
+    }
+    if codex_hook_already_present(root) {
+        return false;
+    }
+
+    insert_codex_hook_entry(root, command);
+    true
+}
+
+fn update_existing_codex_hook_command(root: &mut serde_json::Value, command: &str) -> bool {
+    let Some(pre_tool_use) = root
+        .get_mut("hooks")
+        .and_then(|h| h.get_mut(PRE_TOOL_USE_KEY))
+        .and_then(|p| p.as_array_mut())
+    else {
+        return false;
+    };
+
+    let mut changed = false;
+    for entry in pre_tool_use.iter_mut() {
+        let Some(hooks_array) = entry.get_mut("hooks").and_then(|h| h.as_array_mut()) else {
+            continue;
+        };
+
+        for hook in hooks_array.iter_mut() {
+            let Some(existing) = hook.get("command").and_then(|c| c.as_str()) else {
+                continue;
+            };
+
+            if is_codex_hook_command(existing) && existing != command {
+                if let Some(obj) = hook.as_object_mut() {
+                    obj.insert("command".to_string(), serde_json::json!(command));
+                    obj.entry("statusMessage".to_string())
+                        .or_insert_with(|| serde_json::json!("Checking RTK rewrite"));
+                    changed = true;
+                }
+            }
+        }
+    }
+
+    changed
+}
+
+fn codex_hook_already_present(root: &serde_json::Value) -> bool {
+    root.get("hooks")
+        .and_then(|h| h.get(PRE_TOOL_USE_KEY))
+        .and_then(|p| p.as_array())
+        .is_some_and(|groups| {
+            groups.iter().any(|entry| {
+                entry
+                    .get("hooks")
+                    .and_then(|h| h.as_array())
+                    .is_some_and(|hooks| {
+                        hooks.iter().any(|hook| {
+                            hook.get("command")
+                                .and_then(|c| c.as_str())
+                                .is_some_and(is_codex_hook_command)
+                        })
+                    })
+            })
+        })
+}
+
+fn normalize_codex_hooks_root(root: &mut serde_json::Value) {
+    if !root.is_object() {
+        *root = serde_json::json!({ "hooks": {} });
+        return;
+    }
+
+    let root_obj = root
+        .as_object_mut()
+        .expect("root was checked as object above");
+    if !root_obj.get("hooks").is_some_and(|hooks| hooks.is_object()) {
+        root_obj.insert("hooks".to_string(), serde_json::json!({}));
+    }
+
+    let hooks = root_obj
+        .get_mut("hooks")
+        .and_then(|hooks| hooks.as_object_mut())
+        .expect("hooks was normalized as object");
+    if !hooks
+        .get(PRE_TOOL_USE_KEY)
+        .is_some_and(|pre_tool_use| pre_tool_use.is_array())
+    {
+        hooks.insert(PRE_TOOL_USE_KEY.to_string(), serde_json::json!([]));
+    }
+}
+
+fn insert_codex_hook_entry(root: &mut serde_json::Value, command: &str) {
+    normalize_codex_hooks_root(root);
+    let pre_tool_use = root
+        .get_mut("hooks")
+        .and_then(|h| h.get_mut(PRE_TOOL_USE_KEY))
+        .and_then(|p| p.as_array_mut())
+        .expect("PreToolUse was normalized as an array");
+
+    pre_tool_use.push(serde_json::json!({
+        "matcher": "Bash",
+        "hooks": [{
+            "type": "command",
+            "command": command,
+            "statusMessage": "Checking RTK rewrite"
+        }]
+    }));
 }
 
 // ─── Cursor Agent support ─────────────────────────────────────────────
@@ -2300,8 +2652,10 @@ fn show_claude_config() -> Result<()> {
     println!("  rtk init -g --uninstall     # Remove all RTK artifacts");
     println!("  rtk init -g --claude-md     # Legacy: full injection into ~/.claude/CLAUDE.md");
     println!("  rtk init -g --hook-only     # Hook only, no RTK.md");
-    println!("  rtk init --codex            # Configure local AGENTS.md + RTK.md");
-    println!("  rtk init -g --codex         # Configure $CODEX_HOME/AGENTS.md + $CODEX_HOME/RTK.md (or ~/.codex/)");
+    println!(
+        "  rtk init --codex            # Configure local AGENTS.md + RTK.md + ./.codex/hooks.json"
+    );
+    println!("  rtk init -g --codex         # Configure $CODEX_HOME/AGENTS.md + $CODEX_HOME/RTK.md + hooks.json");
     println!("  rtk init -g --opencode      # OpenCode plugin only");
     println!("  rtk init -g --agent cursor  # Install Cursor Agent hooks");
 
@@ -2312,9 +2666,14 @@ fn show_codex_config() -> Result<()> {
     let codex_dir = resolve_codex_dir()?;
     let global_agents_md = codex_dir.join(AGENTS_MD);
     let global_rtk_md = codex_dir.join(RTK_MD);
+    let global_hooks_json = codex_dir.join(HOOKS_JSON);
+    let global_config_toml = codex_dir.join(CONFIG_TOML);
     let global_rtk_md_ref = codex_rtk_md_ref(&codex_dir);
+    let local_codex_dir = resolve_local_codex_dir();
     let local_agents_md = PathBuf::from(AGENTS_MD);
     let local_rtk_md = PathBuf::from(RTK_MD);
+    let local_hooks_json = local_codex_dir.join(HOOKS_JSON);
+    let local_config_toml = local_codex_dir.join(CONFIG_TOML);
 
     println!("rtk Configuration (Codex CLI):\n");
 
@@ -2337,6 +2696,26 @@ fn show_codex_config() -> Result<()> {
         println!("[--] Global AGENTS.md: not found");
     }
 
+    if global_hooks_json.exists() {
+        let content = fs::read_to_string(&global_hooks_json)?;
+        let json: serde_json::Value = serde_json::from_str(&content)?;
+        if codex_hook_already_present(&json) {
+            println!("[ok] Global hooks.json: RTK PreToolUse hook");
+        } else {
+            println!("[--] Global hooks.json: exists but RTK hook missing");
+        }
+    } else {
+        println!("[--] Global hooks.json: not found");
+    }
+
+    if codex_hooks_enabled(&global_config_toml)? {
+        println!("[ok] Global config.toml: features.codex_hooks = true");
+    } else if global_config_toml.exists() {
+        println!("[--] Global config.toml: Codex hooks feature disabled");
+    } else {
+        println!("[--] Global config.toml: not found");
+    }
+
     if local_rtk_md.exists() {
         println!("[ok] Local RTK.md: {}", local_rtk_md.display());
     } else {
@@ -2356,10 +2735,33 @@ fn show_codex_config() -> Result<()> {
         println!("[--] Local AGENTS.md: not found");
     }
 
+    if local_hooks_json.exists() {
+        let content = fs::read_to_string(&local_hooks_json)?;
+        let json: serde_json::Value = serde_json::from_str(&content)?;
+        if codex_hook_already_present(&json) {
+            println!("[ok] Local hooks.json: RTK PreToolUse hook");
+        } else {
+            println!("[--] Local hooks.json: exists but RTK hook missing");
+        }
+    } else {
+        println!("[--] Local hooks.json: not found");
+    }
+
+    if codex_hooks_enabled(&local_config_toml)? {
+        println!("[ok] Local config.toml: features.codex_hooks = true");
+    } else if local_config_toml.exists() {
+        println!("[--] Local config.toml: Codex hooks feature disabled");
+    } else {
+        println!("[--] Local config.toml: not found");
+    }
+
     println!("\nUsage:");
-    println!("  rtk init --codex              # Configure local AGENTS.md + RTK.md");
-    println!("  rtk init -g --codex           # Configure $CODEX_HOME/AGENTS.md + $CODEX_HOME/RTK.md (or ~/.codex/)");
+    println!("  rtk init --codex              # Configure local AGENTS.md + RTK.md + ./.codex/hooks.json");
+    println!("  rtk init -g --codex           # Configure $CODEX_HOME/AGENTS.md + $CODEX_HOME/RTK.md + hooks.json");
     println!("  rtk init -g --codex --uninstall  # Remove global Codex RTK artifacts");
+    println!(
+        "  Note: Codex currently blocks + suggests `rtk ...`; transparent hook rewrites are not supported yet."
+    );
 
     Ok(())
 }
@@ -2958,6 +3360,119 @@ More notes
     }
 
     #[test]
+    fn test_insert_codex_hook_entry_empty() {
+        let mut json_content = serde_json::json!({});
+
+        insert_codex_hook_entry(&mut json_content, "rtk hook codex");
+
+        let pre_tool_use = json_content["hooks"][PRE_TOOL_USE_KEY].as_array().unwrap();
+        assert_eq!(pre_tool_use.len(), 1);
+        assert_eq!(pre_tool_use[0]["matcher"], "Bash");
+        assert_eq!(pre_tool_use[0]["hooks"][0]["command"], "rtk hook codex");
+    }
+
+    #[test]
+    fn test_insert_codex_hook_preserves_existing() {
+        let mut json_content = serde_json::json!({
+            "hooks": {
+                (PRE_TOOL_USE_KEY): [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "python3 ./other-hook.py"
+                    }]
+                }]
+            }
+        });
+
+        insert_codex_hook_entry(&mut json_content, "rtk hook codex");
+
+        let pre_tool_use = json_content["hooks"][PRE_TOOL_USE_KEY].as_array().unwrap();
+        assert_eq!(pre_tool_use.len(), 2);
+        assert_eq!(
+            pre_tool_use[0]["hooks"][0]["command"],
+            "python3 ./other-hook.py"
+        );
+        assert_eq!(pre_tool_use[1]["hooks"][0]["command"], "rtk hook codex");
+    }
+
+    #[test]
+    fn test_upsert_codex_hook_entry_updates_stale_command() {
+        let mut json_content = serde_json::json!({
+            "hooks": {
+                (PRE_TOOL_USE_KEY): [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "'/tmp/rtk' hook codex"
+                    }]
+                }]
+            }
+        });
+
+        let changed = upsert_codex_hook_entry(&mut json_content, "rtk hook codex");
+
+        assert!(changed);
+        let pre_tool_use = json_content["hooks"][PRE_TOOL_USE_KEY].as_array().unwrap();
+        assert_eq!(pre_tool_use[0]["hooks"][0]["command"], "rtk hook codex");
+    }
+
+    #[test]
+    fn test_remove_codex_hook_from_json() {
+        let mut json_content = serde_json::json!({
+            "hooks": {
+                (PRE_TOOL_USE_KEY): [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "python3 ./other-hook.py"
+                        }]
+                    },
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "rtk hook codex"
+                        }]
+                    }
+                ]
+            }
+        });
+
+        let removed = remove_codex_hook_from_json(&mut json_content);
+
+        assert!(removed);
+        let pre_tool_use = json_content["hooks"][PRE_TOOL_USE_KEY].as_array().unwrap();
+        assert_eq!(pre_tool_use.len(), 1);
+        assert_eq!(
+            pre_tool_use[0]["hooks"][0]["command"],
+            "python3 ./other-hook.py"
+        );
+    }
+
+    #[test]
+    fn test_ensure_codex_hooks_feature_enabled_creates_and_is_idempotent() {
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join(CONFIG_TOML);
+
+        let changed_first = ensure_codex_hooks_feature_enabled(&config_path, 0).unwrap();
+        let changed_second = ensure_codex_hooks_feature_enabled(&config_path, 0).unwrap();
+
+        assert!(changed_first);
+        assert!(!changed_second);
+        assert!(codex_hooks_enabled(&config_path).unwrap());
+    }
+
+    #[test]
+    fn test_is_codex_hook_command_matches_bare_and_absolute_forms() {
+        assert!(is_codex_hook_command("rtk hook codex"));
+        assert!(is_codex_hook_command("~/.local/bin/rtk hook codex"));
+        assert!(is_codex_hook_command("'/tmp/build dir/rtk' hook codex"));
+        assert!(!is_codex_hook_command("python3 ./hook.py"));
+    }
+
+    #[test]
     fn test_patch_agents_md_creates_missing_file() {
         let temp = TempDir::new().unwrap();
         let agents_md = temp.path().join("AGENTS.md");
@@ -2992,8 +3507,9 @@ More notes
         let temp = TempDir::new().unwrap();
         let agents_md = temp.path().join("AGENTS.md");
         let rtk_md = temp.path().join("RTK.md");
+        let codex_dir = temp.path().join(".codex");
 
-        run_codex_mode_with_paths(agents_md.clone(), rtk_md.clone(), true, 0).unwrap();
+        run_codex_mode_with_paths(agents_md.clone(), rtk_md.clone(), codex_dir, true, 0).unwrap();
 
         assert!(rtk_md.exists());
         assert_eq!(fs::read_to_string(&rtk_md).unwrap(), RTK_SLIM_CODEX);
@@ -3025,20 +3541,41 @@ More notes
         let codex_dir = temp.path();
         let agents_md = codex_dir.join("AGENTS.md");
         let rtk_md = codex_dir.join("RTK.md");
+        let hooks_json = codex_dir.join(HOOKS_JSON);
 
         fs::write(&agents_md, "# Team rules\n\n@RTK.md\n").unwrap();
         fs::write(&rtk_md, "codex config").unwrap();
+        fs::write(
+            &hooks_json,
+            serde_json::json!({
+                "hooks": {
+                    (PRE_TOOL_USE_KEY): [{
+                        "matcher": "Bash",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "rtk hook codex"
+                        }]
+                    }]
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
 
         let removed_first = uninstall_codex_at(codex_dir, 0).unwrap();
         let removed_second = uninstall_codex_at(codex_dir, 0).unwrap();
 
-        assert_eq!(removed_first.len(), 2);
+        assert_eq!(removed_first.len(), 3);
         assert!(removed_second.is_empty());
         assert!(!rtk_md.exists());
 
         let content = fs::read_to_string(&agents_md).unwrap();
         assert!(!content.contains("@RTK.md"));
         assert!(content.contains("# Team rules"));
+
+        let hooks_content = fs::read_to_string(&hooks_json).unwrap();
+        let hooks_json: serde_json::Value = serde_json::from_str(&hooks_content).unwrap();
+        assert!(!codex_hook_already_present(&hooks_json));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -364,7 +364,7 @@ enum Commands {
         #[arg(long)]
         uninstall: bool,
 
-        /// Target Codex CLI (uses AGENTS.md + RTK.md, no Claude hook patching)
+        /// Target Codex CLI (AGENTS.md + RTK.md + hooks.json deny-with-suggestion)
         #[arg(long)]
         codex: bool,
 
@@ -733,7 +733,7 @@ enum Commands {
     /// Exits 0 and prints the rewritten command if supported.
     /// Exits 1 with no output if the command has no RTK equivalent.
     ///
-    /// Used by Claude Code, Gemini CLI, and other LLM hooks:
+    /// Used by Claude Code, Gemini CLI, Codex, and other LLM hooks:
     ///   REWRITTEN=$(rtk rewrite "$CMD") || exit 0
     Rewrite {
         /// Raw command to rewrite (e.g. "git status", "cargo test && git push")
@@ -742,7 +742,7 @@ enum Commands {
         args: Vec<String>,
     },
 
-    /// Hook processors for LLM CLI tools (Gemini CLI, Copilot, etc.)
+    /// Hook processors for LLM CLI tools (Gemini CLI, Copilot, Codex, etc.)
     Hook {
         #[command(subcommand)]
         command: HookCommands,
@@ -759,6 +759,8 @@ enum HookCommands {
     Gemini,
     /// Process Copilot preToolUse hook (VS Code + Copilot CLI, reads JSON from stdin)
     Copilot,
+    /// Process Codex CLI PreToolUse hook (reads JSON from stdin)
+    Codex,
     /// Check how a command would be rewritten by the hook engine (dry-run)
     Check {
         /// Target agent
@@ -2114,6 +2116,10 @@ fn run_cli() -> Result<i32> {
             }
             HookCommands::Copilot => {
                 hooks::hook_cmd::run_copilot()?;
+                0
+            }
+            HookCommands::Codex => {
+                hooks::hook_cmd::run_codex()?;
                 0
             }
             HookCommands::Check { agent: _, command } => {


### PR DESCRIPTION
## Summary

Adds official Codex CLI hook support for RTK.

- adds `rtk hook codex` for Codex `PreToolUse` JSON
- updates `rtk init --codex` to write `hooks.json` and enable `[features].codex_hooks = true`
- keeps AGENTS.md + RTK.md awareness guidance
- adds uninstall/show support for Codex hooks/config state
- documents why Codex uses deny-with-suggestion instead of transparent `updatedInput`

Closes #1003.

## Codex hook behavior

Codex currently parses `updatedInput` in `PreToolUse` hook output but does not apply it in practice. This PR uses the working path instead:

```text
git status --short
=> denied with: Rerun that as: rtk git status --short
=> Codex retries: rtk git status --short
```

The installed `hooks.json` command is portable:

```json
{
  "hooks": {
    "PreToolUse": [
      {
        "matcher": "Bash",
        "hooks": [
          {
            "type": "command",
            "command": "rtk hook codex",
            "statusMessage": "Checking RTK rewrite"
          }
        ]
      }
    ]
  }
}
```

## Validation

- `cargo fmt --all`
- `cargo test codex -- --nocapture`
- `cargo test --all`
- `cargo clippy --all-targets`
- temp-home smoke test: `HOME=$(mktemp -d) ./target/debug/rtk init -g --codex`
- direct hook smoke: raw `git status` returns Codex deny payload with `Rerun that as: rtk git status`
- direct hook smoke: already-RTK command emits no output
- live Codex smoke: nested Codex blocked `git status --short`, surfaced `Rerun that as: rtk git status --short`, then reran the RTK command

## Notes

`cargo clippy --all-targets -- -D warnings` is not the current CI command and fails on existing baseline warnings unrelated to this change. The repository CI command, `cargo clippy --all-targets`, passes.
