### PR TITLE
fix(grep): parse single-file output containing colons

### DIFF
--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -34,14 +34,14 @@ pub fn run(
     // false negatives that make AI agents draw wrong conclusions.
     // Using --no-ignore-vcs (not --no-ignore) so .ignore/.rgignore are still respected.
     //
-    // --with-filename: force rg to always include the filename, even for
-    // single-file invocations. Without it, rg emits `<line>:<content>` for a
-    // single file, and the parser cannot tell `<line>:<content>` from
-    // `<file>:<line>:<content>` when content itself contains ':' (issue #1436).
+    // -H: force rg to always include the filename, even for single-file searches.
+    // --null: separate file from line:content with a NUL byte so the parser is
+    // unambiguous even when the filename or content contains `:digits:`
+    // patterns (issue #1436).
     rg_cmd.args([
-        "-n",
+        "-nH",
         "--no-heading",
-        "--with-filename",
+        "--null",
         "--no-ignore-vcs",
         &rg_pattern,
         path,
@@ -62,9 +62,10 @@ pub fn run(
     let result = exec_capture(&mut rg_cmd)
         .or_else(|_| {
             let mut grep_cmd = resolved_command("grep");
-            // -H: always emit the filename so the parser sees a uniform
-            // file:line:content shape (parity with rg's --with-filename).
-            grep_cmd.args(["-rnH", pattern, path]).args(extra_args);
+            // -H: always emit the filename; -Z: NUL-separate filename from
+            // line:content so the parser can disambiguate even for filenames
+            // or content containing `:digits:` (parity with rg's --null).
+            grep_cmd.args(["-rnHZ", pattern, path]).args(extra_args);
             exec_capture(&mut grep_cmd)
         })
         .context("grep/rg failed")?;
@@ -170,27 +171,26 @@ pub fn run(
     Ok(exit_code)
 }
 
-/// Parses a single rg/grep match line of the form `file:line_number:content`.
+/// Parses a single rg/grep match line of the form `file\0line_number:content`.
 ///
-/// Always returns three colon-separated fields when the underlying command was
-/// invoked with `--with-filename` (rg) or `-H` (grep). Uses a greedy regex on
-/// the path so:
-///   - content with `::` (e.g. `ClassRegistry::init(...)`) does not split into
-///     a phantom file bucket (issue #1436);
-///   - paths with embedded `:` (Windows drive letters like `C:\foo\file.php`)
-///     parse correctly — the LAST `:digits:` before content is the boundary.
+/// Requires the underlying command to be invoked with `--null` (rg) or `-Z`
+/// (grep) so the filename is NUL-separated from `line:content`. NUL cannot
+/// appear in file paths, so the parser is unambiguous regardless of:
+///   - content with `:` or `::` (e.g. `ClassRegistry::init(...)`, issue #1436);
+///   - paths with embedded `:` (Windows drive letters, weird filenames like
+///     `badly_named:52:file.txt`).
 ///
 /// Returns `None` for lines that do not match the expected shape (e.g. rg
 /// `-A`/`-B` context lines that use `-` as separator).
 fn parse_match_line(line: &str) -> Option<(String, usize, &str)> {
     lazy_static::lazy_static! {
-        static ref MATCH_LINE_RE: Regex = Regex::new(r"^(.+):(\d+):(.*)$").unwrap();
+        static ref MATCH_LINE_RE: Regex = Regex::new(r"^([^\x00]+)\x00(\d+):(.*)$").unwrap();
     }
-    let caps = MATCH_LINE_RE.captures(line)?;
-    let file = caps.get(1)?.as_str().to_string();
-    let line_num: usize = caps.get(2)?.as_str().parse().ok()?;
-    let content_start = caps.get(3)?.start();
-    Some((file, line_num, &line[content_start..]))
+    MATCH_LINE_RE.captures(line).and_then(|caps| {
+        let (_, [file, line_num, content]) = caps.extract();
+        let line_num: usize = line_num.parse().ok()?;
+        Some((file.to_string(), line_num, content))
+    })
 }
 
 fn has_format_flag(extra_args: &[String]) -> bool {
@@ -419,10 +419,11 @@ mod tests {
     }
 
     // --- issue #1436: parse_match_line robustness ---
+    // Input shape is `file\0line:content` (rg --null / grep -Z).
 
     #[test]
     fn test_parse_match_line_simple() {
-        let line = "file.php:10:use Foo\\Bar;";
+        let line = "file.php\x0010:use Foo\\Bar;";
         let (file, line_num, content) = parse_match_line(line).unwrap();
         assert_eq!(file, "file.php");
         assert_eq!(line_num, 10);
@@ -430,12 +431,11 @@ mod tests {
     }
 
     // Issue #1436 reproducer: content with `::` must not split into a phantom
-    // file bucket. Before the fix, rg's single-file output `81:        $this->...
-    // ClassRegistry::init('...')` was parsed into 3 colon-fields, producing
-    // file="81", line=0, content=":init('...')".
+    // file bucket. With NUL separation between file and line:content, content
+    // colons are irrelevant to the parser.
     #[test]
     fn test_parse_match_line_content_with_double_colon() {
-        let line = "externalImportShell.class.php:81:        $this->queueProcessModel = ClassRegistry::init('Collections.QueueProcess');";
+        let line = "externalImportShell.class.php\x0081:        $this->queueProcessModel = ClassRegistry::init('Collections.QueueProcess');";
         let (file, line_num, content) = parse_match_line(line).unwrap();
         assert_eq!(file, "externalImportShell.class.php");
         assert_eq!(line_num, 81);
@@ -446,29 +446,53 @@ mod tests {
     }
 
     // Windows abs-path safety: drive letter + backslashes must not break the
-    // parser. Greedy regex on path picks the LAST `:digits:` boundary.
+    // parser. The NUL separator makes the file portion unambiguous.
     #[test]
     fn test_parse_match_line_windows_path() {
-        let line = r"C:\src\file.rs:42:fn main() {}";
+        let line = "C:\\src\\file.rs\x0042:fn main() {}";
         let (file, line_num, content) = parse_match_line(line).unwrap();
         assert_eq!(file, r"C:\src\file.rs");
         assert_eq!(line_num, 42);
         assert_eq!(content, "fn main() {}");
     }
 
+    // Filenames containing `:digits:` (which would fool a greedy `:` parser)
+    // must still parse correctly under NUL separation.
+    #[test]
+    fn test_parse_match_line_filename_with_colons() {
+        let line = "badly_named:52:file.txt\x001:xxx";
+        let (file, line_num, content) = parse_match_line(line).unwrap();
+        assert_eq!(file, "badly_named:52:file.txt");
+        assert_eq!(line_num, 1);
+        assert_eq!(content, "xxx");
+    }
+
+    // Content that itself contains `:digits:` (e.g. log lines, port numbers,
+    // line-number-like substrings) must not confuse the parser.
+    #[test]
+    fn test_parse_match_line_content_with_digit_colons() {
+        let line = "log.txt\x007:debug: counter is :42: now";
+        let (file, line_num, content) = parse_match_line(line).unwrap();
+        assert_eq!(file, "log.txt");
+        assert_eq!(line_num, 7);
+        assert_eq!(content, "debug: counter is :42: now");
+    }
+
     #[test]
     fn test_parse_match_line_malformed_returns_none() {
-        // Single token, no colons (e.g. an rg context line written with `-`)
+        // No NUL separator (e.g. rg/grep invoked without --null/-Z, or a
+        // context line written with `-`).
+        assert!(parse_match_line("file.rs:1:content").is_none());
         assert!(parse_match_line("not a match line").is_none());
-        // Missing line number
-        assert!(parse_match_line("file.rs:fn foo()").is_none());
+        // Missing line number after NUL
+        assert!(parse_match_line("file.rs\x00fn foo()").is_none());
         // Empty
         assert!(parse_match_line("").is_none());
     }
 
     #[test]
     fn test_parse_match_line_empty_content() {
-        let line = "file.rs:7:";
+        let line = "file.rs\x007:";
         let (file, line_num, content) = parse_match_line(line).unwrap();
         assert_eq!(file, "file.rs");
         assert_eq!(line_num, 7);

--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -33,19 +33,10 @@ pub fn run(
     // Without this, rg returns 0 matches for files in .gitignore, causing
     // false negatives that make AI agents draw wrong conclusions.
     // Using --no-ignore-vcs (not --no-ignore) so .ignore/.rgignore are still respected.
-    //
-    // -H: force rg to always include the filename, even for single-file searches.
-    // --null: separate file from line:content with a NUL byte so the parser is
-    // unambiguous even when the filename or content contains `:digits:`
-    // patterns (issue #1436).
-    rg_cmd.args([
-        "-nH",
-        "--no-heading",
-        "--null",
-        "--no-ignore-vcs",
-        &rg_pattern,
-        path,
-    ]);
+    // -H: always emit the filename.
+    // -0: NUL-separate filename. Allows the parser to disambiguate filenames or
+    // content containing `:digits:` patterns (issue #1436).
+    rg_cmd.args(["-nH0", "--no-heading", "--no-ignore-vcs", &rg_pattern, path]);
 
     if let Some(ft) = file_type {
         rg_cmd.arg("--type").arg(ft);
@@ -62,9 +53,7 @@ pub fn run(
     let result = exec_capture(&mut rg_cmd)
         .or_else(|_| {
             let mut grep_cmd = resolved_command("grep");
-            // -H: always emit the filename; -Z: NUL-separate filename from
-            // line:content so the parser can disambiguate even for filenames
-            // or content containing `:digits:` (parity with rg's --null).
+            // When we fall back to grep, include all args, not just -rnHZ.
             grep_cmd.args(["-rnHZ", pattern, path]).args(extra_args);
             exec_capture(&mut grep_cmd)
         })
@@ -173,9 +162,9 @@ pub fn run(
 
 /// Parses a single rg/grep match line of the form `file\0line_number:content`.
 ///
-/// Requires the underlying command to be invoked with `--null` (rg) or `-Z`
-/// (grep) so the filename is NUL-separated from `line:content`. NUL cannot
-/// appear in file paths, so the parser is unambiguous regardless of:
+/// Requires the underlying command to be invoked with `-0` (rg) or `-Z` (grep)
+/// so the filename is NUL-separated from `line:content`. NUL cannot appear in
+/// file paths, so the parser is unambiguous regardless of:
 ///   - content with `:` or `::` (e.g. `ClassRegistry::init(...)`, issue #1436);
 ///   - paths with embedded `:` (Windows drive letters, weird filenames like
 ///     `badly_named:52:file.txt`).

--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -33,7 +33,19 @@ pub fn run(
     // Without this, rg returns 0 matches for files in .gitignore, causing
     // false negatives that make AI agents draw wrong conclusions.
     // Using --no-ignore-vcs (not --no-ignore) so .ignore/.rgignore are still respected.
-    rg_cmd.args(["-n", "--no-heading", "--no-ignore-vcs", &rg_pattern, path]);
+    //
+    // --with-filename: force rg to always include the filename, even for
+    // single-file invocations. Without it, rg emits `<line>:<content>` for a
+    // single file, and the parser cannot tell `<line>:<content>` from
+    // `<file>:<line>:<content>` when content itself contains ':' (issue #1436).
+    rg_cmd.args([
+        "-n",
+        "--no-heading",
+        "--with-filename",
+        "--no-ignore-vcs",
+        &rg_pattern,
+        path,
+    ]);
 
     if let Some(ft) = file_type {
         rg_cmd.arg("--type").arg(ft);
@@ -50,8 +62,9 @@ pub fn run(
     let result = exec_capture(&mut rg_cmd)
         .or_else(|_| {
             let mut grep_cmd = resolved_command("grep");
-            //When we fall back to grep,include all args, not just -rn.
-            grep_cmd.args(["-rn", pattern, path]).args(extra_args);
+            // -H: always emit the filename so the parser sees a uniform
+            // file:line:content shape (parity with rg's --with-filename).
+            grep_cmd.args(["-rnH", pattern, path]).args(extra_args);
             exec_capture(&mut grep_cmd)
         })
         .context("grep/rg failed")?;
@@ -108,18 +121,9 @@ pub fn run(
 
     let mut by_file: HashMap<String, Vec<(usize, String)>> = HashMap::new();
     for line in result.stdout.lines() {
-        let parts: Vec<&str> = line.splitn(3, ':').collect();
-
-        let (file, line_num, content) = if parts.len() == 3 {
-            let ln = parts[1].parse().unwrap_or(0);
-            (parts[0].to_string(), ln, parts[2])
-        } else if parts.len() == 2 {
-            let ln = parts[0].parse().unwrap_or(0);
-            (path.to_string(), ln, parts[1])
-        } else {
+        let Some((file, line_num, content)) = parse_match_line(line) else {
             continue;
         };
-
         let cleaned = clean_line(content, max_line_len, context_re.as_ref(), pattern);
         by_file.entry(file).or_default().push((line_num, cleaned));
     }
@@ -164,6 +168,29 @@ pub fn run(
     );
 
     Ok(exit_code)
+}
+
+/// Parses a single rg/grep match line of the form `file:line_number:content`.
+///
+/// Always returns three colon-separated fields when the underlying command was
+/// invoked with `--with-filename` (rg) or `-H` (grep). Uses a greedy regex on
+/// the path so:
+///   - content with `::` (e.g. `ClassRegistry::init(...)`) does not split into
+///     a phantom file bucket (issue #1436);
+///   - paths with embedded `:` (Windows drive letters like `C:\foo\file.php`)
+///     parse correctly — the LAST `:digits:` before content is the boundary.
+///
+/// Returns `None` for lines that do not match the expected shape (e.g. rg
+/// `-A`/`-B` context lines that use `-` as separator).
+fn parse_match_line(line: &str) -> Option<(String, usize, &str)> {
+    lazy_static::lazy_static! {
+        static ref MATCH_LINE_RE: Regex = Regex::new(r"^(.+):(\d+):(.*)$").unwrap();
+    }
+    let caps = MATCH_LINE_RE.captures(line)?;
+    let file = caps.get(1)?.as_str().to_string();
+    let line_num: usize = caps.get(2)?.as_str().parse().ok()?;
+    let content_start = caps.get(3)?.start();
+    Some((file, line_num, &line[content_start..]))
 }
 
 fn has_format_flag(extra_args: &[String]) -> bool {
@@ -389,6 +416,63 @@ mod tests {
             );
         }
         // If rg is not installed, skip gracefully (test still passes)
+    }
+
+    // --- issue #1436: parse_match_line robustness ---
+
+    #[test]
+    fn test_parse_match_line_simple() {
+        let line = "file.php:10:use Foo\\Bar;";
+        let (file, line_num, content) = parse_match_line(line).unwrap();
+        assert_eq!(file, "file.php");
+        assert_eq!(line_num, 10);
+        assert_eq!(content, "use Foo\\Bar;");
+    }
+
+    // Issue #1436 reproducer: content with `::` must not split into a phantom
+    // file bucket. Before the fix, rg's single-file output `81:        $this->...
+    // ClassRegistry::init('...')` was parsed into 3 colon-fields, producing
+    // file="81", line=0, content=":init('...')".
+    #[test]
+    fn test_parse_match_line_content_with_double_colon() {
+        let line = "externalImportShell.class.php:81:        $this->queueProcessModel = ClassRegistry::init('Collections.QueueProcess');";
+        let (file, line_num, content) = parse_match_line(line).unwrap();
+        assert_eq!(file, "externalImportShell.class.php");
+        assert_eq!(line_num, 81);
+        assert_eq!(
+            content,
+            "        $this->queueProcessModel = ClassRegistry::init('Collections.QueueProcess');"
+        );
+    }
+
+    // Windows abs-path safety: drive letter + backslashes must not break the
+    // parser. Greedy regex on path picks the LAST `:digits:` boundary.
+    #[test]
+    fn test_parse_match_line_windows_path() {
+        let line = r"C:\src\file.rs:42:fn main() {}";
+        let (file, line_num, content) = parse_match_line(line).unwrap();
+        assert_eq!(file, r"C:\src\file.rs");
+        assert_eq!(line_num, 42);
+        assert_eq!(content, "fn main() {}");
+    }
+
+    #[test]
+    fn test_parse_match_line_malformed_returns_none() {
+        // Single token, no colons (e.g. an rg context line written with `-`)
+        assert!(parse_match_line("not a match line").is_none());
+        // Missing line number
+        assert!(parse_match_line("file.rs:fn foo()").is_none());
+        // Empty
+        assert!(parse_match_line("").is_none());
+    }
+
+    #[test]
+    fn test_parse_match_line_empty_content() {
+        let line = "file.rs:7:";
+        let (file, line_num, content) = parse_match_line(line).unwrap();
+        assert_eq!(file, "file.rs");
+        assert_eq!(line_num, 7);
+        assert_eq!(content, "");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fix `rtk grep` synthesizing a phantom `[file] N` bucket when a single-file match contained `:` (e.g. `ClassRegistry::init(...)`); ripgrep emits `<line>:<content>` for single-file searches and the parser used `splitn(3, ':')` length to disambiguate, which broke whenever content also had `:`.
- Force `--with-filename` on rg (`-H` on the grep fallback) so output is always `file:line:content`, and replace the inline parser with a regex-based `parse_match_line` that also handles paths with embedded `:` (Windows drive letters like `C:\...`).
- Scoped to the parser/rendering portion of #1436. The BRE→regex match-set behavior (e.g. `delete()` matching every `delete`) is a separate concern and ships in a follow-up PR (now also pushed).

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test --bin rtk` — 1692 passed, 0 failed
- [x] 5 new unit tests on `parse_match_line`: simple, content-with-`::` (#1436 reproducer), Windows drive path, malformed line, empty content
- [x] Manual end-to-end: synthetic PHP file with the issue's exact pattern + a `ClassRegistry::init('...')` line; rtk output now matches plain `grep -nH` line-for-line, no phantom bucket
- [x] CI green on `develop`

Closes the parser/rendering portion of #1436.

### Related work

[PR #1273](https://github.com/rtk-ai/rtk/pull/1273) by @siubing05 (open since 2026-04-13) addresses the same parser issue alongside a pytest summary fix. Their approach uses `splitn(3, ':')` with a 2-format fallback that tolerates missing `-H`. This PR uses a regex parser (`^(.+):(\d+):(.*)$`) that additionally handles paths with embedded `:` (Windows drive letters). Either approach fixes the Linux/macOS reproducer in #1436 — happy to defer or fold a Windows-path test into #1273 if maintainers prefer that path.

### Notes for reviewers

- **`-H` is load-bearing, not noise.** Without it, GNU grep's single-file output drops the filename, the new regex parser can't extract three fields, and every match gets silently dropped (rendering shows `N matches in 0 files`). It's an input flag for grep, rtk re-formats its own output, so user-facing token cost is zero. Verified empirically (with-`-H` vs without-`-H` build).
- **Greedy regex on path is intentional.** `^(.+):(\d+):(.*)$` picks the LAST `:digits:` boundary, which correctly handles `C:\path\file.rs:42:content`. A pathological filename containing `:digits:` would mis-split; that edge is documented in the parser's doc comment.