### PR TITLE
fix(json): use char boundary when truncating long string values

### DIFF
--- a/src/cmds/system/json_cmd.rs
+++ b/src/cmds/system/json_cmd.rs
@@ -330,11 +330,8 @@ mod tests {
         assert!(schema.contains("(3)"));
     }
 
-    #[test]
-    fn test_compact_long_multibyte_string_does_not_panic() {
-        let payload = "日本語テスト".repeat(85); // well above the 80-byte threshold
+    fn assert_value_truncated(payload: &str) {
         let json = format!(r#"{{"key": "{}"}}"#, payload);
-
         let output = filter_json_compact(&json, 5)
             .expect("filter_json_compact must not error on valid JSON");
 
@@ -343,12 +340,25 @@ mod tests {
             output.contains("..."),
             "long string should be truncated, got: {output}"
         );
-        for line in output.lines() {
-            assert!(
-                line.chars().count() <= 80,
-                "output line exceeds 80 chars ({} chars): {line}",
-                line.chars().count()
-            );
-        }
+
+        let value = output
+            .split('"')
+            .nth(1)
+            .expect("output should contain a quoted string value");
+        assert!(
+            value.len() <= 80,
+            "truncated value is {} bytes: {value}",
+            value.len()
+        );
+    }
+
+    #[test]
+    fn test_compact_truncates_pure_multibyte_string() {
+        assert_value_truncated(&"日本語テスト".repeat(85));
+    }
+
+    #[test]
+    fn test_compact_truncates_mixed_ascii_multibyte_string() {
+        assert_value_truncated(&("a".repeat(76) + &"日本語".repeat(5)));
     }
 }

--- a/src/cmds/system/json_cmd.rs
+++ b/src/cmds/system/json_cmd.rs
@@ -332,7 +332,7 @@ mod tests {
 
     #[test]
     fn test_compact_long_multibyte_string_does_not_panic() {
-        let payload = "a".repeat(76) + &"日本語".repeat(5);
+        let payload = "日本語テスト".repeat(85); // well above the 80-byte threshold
         let json = format!(r#"{{"key": "{}"}}"#, payload);
 
         let output = filter_json_compact(&json, 5)
@@ -343,5 +343,12 @@ mod tests {
             output.contains("..."),
             "long string should be truncated, got: {output}"
         );
+        for line in output.lines() {
+            assert!(
+                line.chars().count() <= 80,
+                "output line exceeds 80 chars ({} chars): {line}",
+                line.chars().count()
+            );
+        }
     }
 }

--- a/src/cmds/system/json_cmd.rs
+++ b/src/cmds/system/json_cmd.rs
@@ -106,7 +106,8 @@ fn compact_json(value: &Value, depth: usize, max_depth: usize) -> String {
         Value::Number(n) => format!("{}{}", indent, n),
         Value::String(s) => {
             if s.len() > 80 {
-                format!("{}\"{}...\"", indent, &s[..77])
+                let end = s.floor_char_boundary(77);
+                format!("{}\"{}...\"", indent, &s[..end])
             } else {
                 format!("{}\"{}\"", indent, s)
             }
@@ -327,5 +328,20 @@ mod tests {
         let schema = extract_schema(&json, 0, 5);
         assert!(schema.contains("items"));
         assert!(schema.contains("(3)"));
+    }
+
+    #[test]
+    fn test_compact_long_multibyte_string_does_not_panic() {
+        let payload = "a".repeat(76) + &"日本語".repeat(5);
+        let json = format!(r#"{{"key": "{}"}}"#, payload);
+
+        let output = filter_json_compact(&json, 5)
+            .expect("filter_json_compact must not error on valid JSON");
+
+        assert!(output.contains("key"));
+        assert!(
+            output.contains("..."),
+            "long string should be truncated, got: {output}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Fix UTF-8 panic in `rtk json` when a multi-byte char crosses byte 77 of a string value (e.g. JSON containing Japanese, Cyrillic, accented Latin, or emoji).
- `compact_json` now rounds the truncation index down to the nearest valid char boundary with `str::floor_char_boundary`, matching the existing pattern in `pipe_cmd::auto_detect_filter`.
- Add regression test covering the multi-byte boundary case.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

  ```sh
  python3 -c 'import json; print(json.dumps({"key": "a"*76 + "日本語"*5}, ensure_ascii=False))' \
    | ./target/release/rtk json -
Before: panicked at `src/cmds/system/json_cmd.rs:109`: `end byte index 77 is not a char boundary; it is inside '日'`
After: pretty-printed compact JSON with the value truncated to "aaaa…aaaa...".