### PR TITLE
fix(pytest): avoid rendering each failure twice

### DIFF
--- a/src/cmds/python/pytest_cmd.rs
+++ b/src/cmds/python/pytest_cmd.rs
@@ -124,8 +124,13 @@ pub(crate) fn filter_pytest_output(output: &str) -> String {
                 }
             }
             ParseState::Summary => {
-                // FAILED test lines
-                if trimmed.starts_with("FAILED") || trimmed.starts_with("ERROR") {
+                // FAILED/ERROR lines from `=== short test summary info ===` are a
+                // recap of failures already captured in the `=== FAILURES ===`
+                // section. Only collect them when FAILURES section was empty
+                // (e.g. user passed --tb=no) — otherwise every failure renders twice.
+                if failures.is_empty()
+                    && (trimmed.starts_with("FAILED") || trimmed.starts_with("ERROR"))
+                {
                     failures.push(trimmed.to_string());
                 }
             }
@@ -378,6 +383,39 @@ FAILED tests/test_foo.py::test_something - AssertionError
             "Should show actual test counts. Got: {}",
             result
         );
+    }
+
+    #[test]
+    fn test_filter_pytest_no_duplicate_failures() {
+        // pytest prints each failure twice — once in `=== FAILURES ===` (with
+        // traceback) and once in `=== short test summary info ===` (one-liner).
+        // We must collect each failure only once.
+        let output = r#"=== test session starts ===
+collected 10 items
+
+tests/test_sample.py F                                              [100%]
+
+=== FAILURES ===
+___ TestSample.test_case ___
+
+    def test_case(self):
+>       assert False
+E       assert False
+
+tests/test_sample.py:8: AssertionError
+
+=== short test summary info ===
+FAILED tests/test_sample.py::TestSample::test_case - assert False
+=== 9 passed, 1 failed in 1.50s ==="#;
+
+        let result = filter_pytest_output(output);
+        let occurrences = result.matches("test_case").count();
+        assert_eq!(
+            occurrences, 1,
+            "Expected exactly one mention of test_case, got {}. Output:\n{}",
+            occurrences, result
+        );
+        assert!(result.contains("[FAIL]"), "Output: {}", result);
     }
 
     #[test]

--- a/src/cmds/python/pytest_cmd.rs
+++ b/src/cmds/python/pytest_cmd.rs
@@ -54,6 +54,7 @@ pub(crate) fn filter_pytest_output(output: &str) -> String {
     let mut failures: Vec<String> = Vec::new();
     let mut current_failure: Vec<String> = Vec::new();
     let mut summary_line = String::new();
+    let mut had_failures_section = false;
 
     for line in output.lines() {
         let trimmed = line.trim();
@@ -64,6 +65,7 @@ pub(crate) fn filter_pytest_output(output: &str) -> String {
             continue;
         } else if trimmed.starts_with("===") && trimmed.contains("FAILURES") {
             state = ParseState::Failures;
+            had_failures_section = true;
             continue;
         } else if trimmed.starts_with("===") && trimmed.contains("short test summary") {
             state = ParseState::Summary;
@@ -126,9 +128,10 @@ pub(crate) fn filter_pytest_output(output: &str) -> String {
             ParseState::Summary => {
                 // FAILED/ERROR lines from `=== short test summary info ===` are a
                 // recap of failures already captured in the `=== FAILURES ===`
-                // section. Only collect them when FAILURES section was empty
-                // (e.g. user passed --tb=no) — otherwise every failure renders twice.
-                if failures.is_empty()
+                // section. Skip them entirely when we saw a FAILURES section
+                // (otherwise every failure renders twice); use them as the only
+                // source of failures when FAILURES section is absent (--tb=no).
+                if !had_failures_section
                     && (trimmed.starts_with("FAILED") || trimmed.starts_with("ERROR"))
                 {
                     failures.push(trimmed.to_string());
@@ -416,6 +419,39 @@ FAILED tests/test_sample.py::TestSample::test_case - assert False
             occurrences, result
         );
         assert!(result.contains("[FAIL]"), "Output: {}", result);
+    }
+
+    #[test]
+    fn test_filter_pytest_tb_no_collects_all_failures() {
+        // With --tb=no there's no FAILURES section, only summary recap. All
+        // FAILED lines from the summary should still be captured.
+        let output = r#"=== test session starts ===
+collected 5 items
+
+tests/test_sample.py FFF..                                          [100%]
+
+=== short test summary info ===
+FAILED tests/test_sample.py::test_one - assert False
+FAILED tests/test_sample.py::test_two - assert False
+FAILED tests/test_sample.py::test_three - assert False
+=== 3 failed, 2 passed in 1.50s ==="#;
+
+        let result = filter_pytest_output(output);
+        assert!(
+            result.contains("test_one"),
+            "Missing test_one. Output:\n{}",
+            result
+        );
+        assert!(
+            result.contains("test_two"),
+            "Missing test_two. Output:\n{}",
+            result
+        );
+        assert!(
+            result.contains("test_three"),
+            "Missing test_three. Output:\n{}",
+            result
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- The pytest filter collected failures from both `=== FAILURES ===` and `=== short test summary info ===`, so every failed test rendered twice in the output (once with traceback, once as a one-line recap).
- Now we only fall back to the summary recap when the FAILURES section was empty (e.g. user passed `--tb=no`), eliminating the duplication.
- Added a regression test asserting each failure appears only once.

### Before
```
Pytest: 818 passed, 1 failed
═══════════════════════════════════════

Failures:
1. [FAIL] TestSample.test_case
     tests/test_sample.py:8: in test_case
     assert False
     E   assert False

2. [FAIL] tests/test_sample.py::TestSample::test_case
     assert False
```

### After
```
Pytest: 818 passed, 1 failed
═══════════════════════════════════════

Failures:
1. [FAIL] TestSample.test_case
     >       assert False
     E       assert False
     tests/test_sample.py:8: AssertionError
```

## Test plan
- [x] `cargo test --bin rtk pytest` — all 15 pytest tests pass, including the new `test_filter_pytest_no_duplicate_failures`
- [x] `cargo test --all` — 1607/1607 pass
- [x] `cargo fmt --all` clean
- [x] Existing tests covering `--tb=no`-style output (no FAILURES section, summary-only failures) still parse correctly via `failures.is_empty()` fallback