### PR TITLE
fix(dotnet): move build/test/restore status line to the bottom (#1574)

### DIFF
--- a/src/cmds/dotnet/dotnet_cmd.rs
+++ b/src/cmds/dotnet/dotnet_cmd.rs
@@ -987,20 +987,6 @@ fn format_build_output(summary: &binlog::BuildSummary, _binlog_path: &Path) -> S
     let status_icon = if summary.succeeded { "ok" } else { "fail" };
     let duration = summary.duration_text.as_deref().unwrap_or("unknown");
 
-    let mut warnings = String::new();
-    if !summary.warnings.is_empty() {
-        warnings.push_str("Warnings:\n");
-        for issue in summary.warnings.iter().take(10) {
-            warnings.push_str(&format!("{}\n", format_issue(issue, "warning")));
-        }
-        if summary.warnings.len() > 10 {
-            warnings.push_str(&format!(
-                "  ... +{} more warnings\n",
-                summary.warnings.len() - 10
-            ));
-        }
-    }
-
     let mut errors = String::new();
     if !summary.errors.is_empty() {
         errors.push_str("Errors:\n");
@@ -1011,6 +997,20 @@ fn format_build_output(summary: &binlog::BuildSummary, _binlog_path: &Path) -> S
             errors.push_str(&format!(
                 "  ... +{} more errors\n",
                 summary.errors.len() - 20
+            ));
+        }
+    }
+
+    let mut warnings = String::new();
+    if !summary.warnings.is_empty() {
+        warnings.push_str("Warnings:\n");
+        for issue in summary.warnings.iter().take(10) {
+            warnings.push_str(&format!("{}\n", format_issue(issue, "warning")));
+        }
+        if summary.warnings.len() > 10 {
+            warnings.push_str(&format!(
+                "  ... +{} more warnings\n",
+                summary.warnings.len() - 10
             ));
         }
     }
@@ -1103,17 +1103,6 @@ fn format_test_output(
         }
     }
 
-    let mut warnings_section = String::new();
-    if !warnings.is_empty() {
-        warnings_section.push_str("Warnings:\n");
-        for issue in warnings.iter().take(10) {
-            warnings_section.push_str(&format!("{}\n", format_issue(issue, "warning")));
-        }
-        if warnings.len() > 10 {
-            warnings_section.push_str(&format!("  ... +{} more warnings\n", warnings.len() - 10));
-        }
-    }
-
     let mut errors_section = String::new();
     if !errors.is_empty() {
         errors_section.push_str("Errors:\n");
@@ -1122,6 +1111,17 @@ fn format_test_output(
         }
         if errors.len() > 10 {
             errors_section.push_str(&format!("  ... +{} more errors\n", errors.len() - 10));
+        }
+    }
+
+    let mut warnings_section = String::new();
+    if !warnings.is_empty() {
+        warnings_section.push_str("Warnings:\n");
+        for issue in warnings.iter().take(10) {
+            warnings_section.push_str(&format!("{}\n", format_issue(issue, "warning")));
+        }
+        if warnings.len() > 10 {
+            warnings_section.push_str(&format!("  ... +{} more warnings\n", warnings.len() - 10));
         }
     }
 
@@ -1163,17 +1163,6 @@ fn format_restore_output(
     let status_icon = if has_errors { "fail" } else { "ok" };
     let duration = summary.duration_text.as_deref().unwrap_or("unknown");
 
-    let mut warnings_section = String::new();
-    if !warnings.is_empty() {
-        warnings_section.push_str("Warnings:\n");
-        for issue in warnings.iter().take(10) {
-            warnings_section.push_str(&format!("{}\n", format_issue(issue, "warning")));
-        }
-        if warnings.len() > 10 {
-            warnings_section.push_str(&format!("  ... +{} more warnings\n", warnings.len() - 10));
-        }
-    }
-
     let mut errors_section = String::new();
     if !errors.is_empty() {
         errors_section.push_str("Errors:\n");
@@ -1182,6 +1171,17 @@ fn format_restore_output(
         }
         if errors.len() > 20 {
             errors_section.push_str(&format!("  ... +{} more errors\n", errors.len() - 20));
+        }
+    }
+
+    let mut warnings_section = String::new();
+    if !warnings.is_empty() {
+        warnings_section.push_str("Warnings:\n");
+        for issue in warnings.iter().take(10) {
+            warnings_section.push_str(&format!("{}\n", format_issue(issue, "warning")));
+        }
+        if warnings.len() > 10 {
+            warnings_section.push_str(&format!("  ... +{} more warnings\n", warnings.len() - 10));
         }
     }
 

--- a/src/cmds/dotnet/dotnet_cmd.rs
+++ b/src/cmds/dotnet/dotnet_cmd.rs
@@ -979,8 +979,11 @@ fn format_issue(issue: &binlog::BinlogIssue, kind: &str) -> String {
     )
 }
 
+/// Format the build summary for stdout.
+///
+/// `_binlog_path` is intentionally unused — the binlog is a temporary file
+/// that has already been cleaned up by the time this runs.
 fn format_build_output(summary: &binlog::BuildSummary, _binlog_path: &Path) -> String {
-    // Binlog path omitted from output (temp file, already cleaned up)
     let status_icon = if summary.succeeded { "ok" } else { "fail" };
     let duration = summary.duration_text.as_deref().unwrap_or("unknown");
 
@@ -1013,16 +1016,11 @@ fn format_build_output(summary: &binlog::BuildSummary, _binlog_path: &Path) -> S
     }
 
     let sep = if !warnings.is_empty() || !errors.is_empty() {
-        "---------------------------------------".to_string()
+        "---------------------------------------"
     } else {
-        String::new()
+        ""
     };
 
-    // Status line is emitted last so consumers that read the tail of the stream
-    // (`| tail -N`, agent watch/monitor modes, bounded context windows) get a
-    // definitive verdict. Mirrors native `dotnet build`, which ends with
-    // `Build succeeded.` / `Build FAILED.`. See issue #1574.
-    // Warnings before errors: errors survive `| tail -N` immediately above the verdict.
     let verdict = format!(
         "{} dotnet build: {} projects, {} errors, {} warnings ({})",
         status_icon,
@@ -1032,13 +1030,22 @@ fn format_build_output(summary: &binlog::BuildSummary, _binlog_path: &Path) -> S
         duration
     );
 
-    [warnings, errors, sep, verdict]
+    // Status line is emitted last so consumers that read the tail of the stream
+    // (`| tail -N`, agent watch/monitor modes, bounded context windows) get a
+    // definitive verdict. Mirrors native `dotnet build`, which ends with
+    // `Build succeeded.` / `Build FAILED.`. See issue #1574.
+    // Warnings before errors: errors survive `| tail -N` immediately above the verdict.
+    [warnings, errors, sep.into(), verdict]
         .into_iter()
         .filter(|s| !s.is_empty())
         .collect::<Vec<_>>()
         .join("\n")
 }
 
+/// Format the test summary for stdout.
+///
+/// `_binlog_path` is intentionally unused — the binlog is a temporary file
+/// that has already been cleaned up by the time this runs.
 fn format_test_output(
     summary: &binlog::TestSummary,
     errors: &[binlog::BinlogIssue],
@@ -1078,7 +1085,6 @@ fn format_test_output(
         )
     };
 
-    // Binlog path omitted from output (temp file, already cleaned up)
     let mut failed_tests_section = String::new();
     if has_failures && !summary.failed_tests.is_empty() {
         failed_tests_section.push_str("Failed Tests:\n");
@@ -1119,28 +1125,40 @@ fn format_test_output(
         }
     }
 
-    let sep = if !failed_tests_section.is_empty() || !warnings_section.is_empty() || !errors_section.is_empty() {
-        "---------------------------------------".to_string()
+    let sep = if !failed_tests_section.is_empty()
+        || !warnings_section.is_empty()
+        || !errors_section.is_empty()
+    {
+        "---------------------------------------"
     } else {
-        String::new()
+        ""
     };
 
     // Status line emitted last; see format_build_output (issue #1574).
     // Warnings before errors: errors survive `| tail -N` immediately above the verdict.
-    [failed_tests_section, warnings_section, errors_section, sep, header]
+    [
+        failed_tests_section,
+        warnings_section,
+        errors_section,
+        sep.into(),
+        header,
+    ]
         .into_iter()
         .filter(|s| !s.is_empty())
         .collect::<Vec<_>>()
         .join("\n")
 }
 
+/// Format the restore summary for stdout.
+///
+/// `_binlog_path` is intentionally unused — the binlog is a temporary file
+/// that has already been cleaned up by the time this runs.
 fn format_restore_output(
     summary: &binlog::RestoreSummary,
     errors: &[binlog::BinlogIssue],
     warnings: &[binlog::BinlogIssue],
     _binlog_path: &Path,
 ) -> String {
-    // Binlog path omitted from output (temp file, already cleaned up)
     let has_errors = summary.errors > 0;
     let status_icon = if has_errors { "fail" } else { "ok" };
     let duration = summary.duration_text.as_deref().unwrap_or("unknown");
@@ -1168,19 +1186,19 @@ fn format_restore_output(
     }
 
     let sep = if !warnings_section.is_empty() || !errors_section.is_empty() {
-        "---------------------------------------".to_string()
+        "---------------------------------------"
     } else {
-        String::new()
+        ""
     };
 
-    // Status line emitted last; see format_build_output (issue #1574).
-    // Warnings before errors: errors survive `| tail -N` immediately above the verdict.
     let verdict = format!(
         "{} dotnet restore: {} projects, {} errors, {} warnings ({})",
         status_icon, summary.restored_projects, summary.errors, summary.warnings, duration
     );
 
-    [warnings_section, errors_section, sep, verdict]
+    // Status line emitted last; see format_build_output (issue #1574).
+    // Warnings before errors: errors survive `| tail -N` immediately above the verdict.
+    [warnings_section, errors_section, sep.into(), verdict]
         .into_iter()
         .filter(|s| !s.is_empty())
         .collect::<Vec<_>>()

--- a/src/cmds/dotnet/dotnet_cmd.rs
+++ b/src/cmds/dotnet/dotnet_cmd.rs
@@ -983,17 +983,10 @@ fn format_build_output(summary: &binlog::BuildSummary, _binlog_path: &Path) -> S
     let status_icon = if summary.succeeded { "ok" } else { "fail" };
     let duration = summary.duration_text.as_deref().unwrap_or("unknown");
 
-    let mut out = format!(
-        "{} dotnet build: {} projects, {} errors, {} warnings ({})",
-        status_icon,
-        summary.project_count,
-        summary.errors.len(),
-        summary.warnings.len(),
-        duration
-    );
+    let mut out = String::new();
 
     if !summary.errors.is_empty() {
-        out.push_str("\n---------------------------------------\n\nErrors:\n");
+        out.push_str("Errors:\n");
         for issue in summary.errors.iter().take(20) {
             out.push_str(&format!("{}\n", format_issue(issue, "error")));
         }
@@ -1006,7 +999,10 @@ fn format_build_output(summary: &binlog::BuildSummary, _binlog_path: &Path) -> S
     }
 
     if !summary.warnings.is_empty() {
-        out.push_str("\nWarnings:\n");
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str("Warnings:\n");
         for issue in summary.warnings.iter().take(10) {
             out.push_str(&format!("{}\n", format_issue(issue, "warning")));
         }
@@ -1018,7 +1014,23 @@ fn format_build_output(summary: &binlog::BuildSummary, _binlog_path: &Path) -> S
         }
     }
 
-    // Binlog path omitted from output (temp file, already cleaned up)
+    if !out.is_empty() {
+        out.push_str("\n---------------------------------------\n");
+    }
+
+    // Status line is emitted last so consumers that read the tail of the stream
+    // (`| tail -N`, agent watch/monitor modes, bounded context windows) get a
+    // definitive verdict. Mirrors native `dotnet build`, which ends with
+    // `Build succeeded.` / `Build FAILED.`. See issue #1574.
+    out.push_str(&format!(
+        "{} dotnet build: {} projects, {} errors, {} warnings ({})",
+        status_icon,
+        summary.project_count,
+        summary.errors.len(),
+        summary.warnings.len(),
+        duration
+    ));
+
     out
 }
 
@@ -1038,7 +1050,7 @@ fn format_test_output(
         && summary.total == 0
         && summary.failed_tests.is_empty();
 
-    let mut out = if counts_unavailable {
+    let header = if counts_unavailable {
         format!(
             "{} dotnet test: completed (binlog-only mode, counts unavailable, {} warnings) ({})",
             status_icon, warning_count, duration
@@ -1061,8 +1073,10 @@ fn format_test_output(
         )
     };
 
+    let mut out = String::new();
+
     if has_failures && !summary.failed_tests.is_empty() {
-        out.push_str("\n---------------------------------------\n\nFailed Tests:\n");
+        out.push_str("Failed Tests:\n");
         for failed in summary.failed_tests.iter().take(15) {
             out.push_str(&format!("  {}\n", failed.name));
             for detail in &failed.details {
@@ -1079,7 +1093,10 @@ fn format_test_output(
     }
 
     if !errors.is_empty() {
-        out.push_str("\nErrors:\n");
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str("Errors:\n");
         for issue in errors.iter().take(10) {
             out.push_str(&format!("{}\n", format_issue(issue, "error")));
         }
@@ -1089,7 +1106,10 @@ fn format_test_output(
     }
 
     if !warnings.is_empty() {
-        out.push_str("\nWarnings:\n");
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str("Warnings:\n");
         for issue in warnings.iter().take(10) {
             out.push_str(&format!("{}\n", format_issue(issue, "warning")));
         }
@@ -1098,7 +1118,13 @@ fn format_test_output(
         }
     }
 
-    // Binlog path omitted from output (temp file, already cleaned up)
+    if !out.is_empty() {
+        out.push_str("\n---------------------------------------\n");
+    }
+
+    // Status line emitted last; see format_build_output (issue #1574).
+    out.push_str(&header);
+
     out
 }
 
@@ -1112,13 +1138,10 @@ fn format_restore_output(
     let status_icon = if has_errors { "fail" } else { "ok" };
     let duration = summary.duration_text.as_deref().unwrap_or("unknown");
 
-    let mut out = format!(
-        "{} dotnet restore: {} projects, {} errors, {} warnings ({})",
-        status_icon, summary.restored_projects, summary.errors, summary.warnings, duration
-    );
+    let mut out = String::new();
 
     if !errors.is_empty() {
-        out.push_str("\n---------------------------------------\n\nErrors:\n");
+        out.push_str("Errors:\n");
         for issue in errors.iter().take(20) {
             out.push_str(&format!("{}\n", format_issue(issue, "error")));
         }
@@ -1128,7 +1151,10 @@ fn format_restore_output(
     }
 
     if !warnings.is_empty() {
-        out.push_str("\nWarnings:\n");
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str("Warnings:\n");
         for issue in warnings.iter().take(10) {
             out.push_str(&format!("{}\n", format_issue(issue, "warning")));
         }
@@ -1137,7 +1163,16 @@ fn format_restore_output(
         }
     }
 
-    // Binlog path omitted from output (temp file, already cleaned up)
+    if !out.is_empty() {
+        out.push_str("\n---------------------------------------\n");
+    }
+
+    // Status line emitted last; see format_build_output (issue #1574).
+    out.push_str(&format!(
+        "{} dotnet restore: {} projects, {} errors, {} warnings ({})",
+        status_icon, summary.restored_projects, summary.errors, summary.warnings, duration
+    ));
+
     out
 }
 
@@ -1365,6 +1400,94 @@ mod tests {
 
         let output = format_test_output(&summary, &[], &[], Path::new("/tmp/test.binlog"));
         assert!(output.contains("counts unavailable"));
+    }
+
+    // Regression tests for issue #1574: status line must be the final line so that
+    // consumers reading the tail of the stream (`| tail -N`, agent watch/monitor
+    // modes, bounded context windows) get a definitive `ok` / `fail` verdict.
+    // Mirrors native `dotnet`, which ends with `Build succeeded.` / `Build FAILED.`.
+
+    #[test]
+    fn test_format_build_output_status_line_is_last_for_tail_consumers() {
+        let summary = binlog::BuildSummary {
+            succeeded: true,
+            project_count: 1,
+            errors: Vec::new(),
+            warnings: vec![binlog::BinlogIssue {
+                code: "CS0219".to_string(),
+                file: "src/Program.cs".to_string(),
+                line: 25,
+                column: 10,
+                message: "Variable assigned but never used".to_string(),
+            }],
+            duration_text: Some("00:00:01.23".to_string()),
+        };
+        let output = format_build_output(&summary, Path::new("/tmp/build.binlog"));
+        let last_line = output.lines().last().expect("output must not be empty");
+        assert!(
+            last_line.starts_with("ok dotnet build:"),
+            "status line must be the last line for `| tail -N` consumers, got: {:?}",
+            last_line
+        );
+
+        let last_5: Vec<&str> = output.lines().rev().take(5).collect();
+        assert!(
+            last_5.iter().any(|l| l.starts_with("ok dotnet build:")),
+            "`tail -5` must include the status line, got tail: {:?}",
+            last_5
+        );
+    }
+
+    #[test]
+    fn test_format_test_output_status_line_is_last_for_tail_consumers() {
+        let summary = binlog::TestSummary {
+            passed: 940,
+            failed: 0,
+            skipped: 7,
+            total: 947,
+            project_count: 1,
+            failed_tests: Vec::new(),
+            duration_text: Some("1 s".to_string()),
+        };
+        let warnings = vec![binlog::BinlogIssue {
+            code: String::new(),
+            file: "/sdk/Microsoft.TestPlatform.targets".to_string(),
+            line: 48,
+            column: 5,
+            message: "Violators:".to_string(),
+        }];
+        let output = format_test_output(&summary, &[], &warnings, Path::new("/tmp/test.binlog"));
+        let last_line = output.lines().last().expect("output must not be empty");
+        assert!(
+            last_line.starts_with("ok dotnet test:"),
+            "status line must be the last line, got: {:?}",
+            last_line
+        );
+    }
+
+    #[test]
+    fn test_format_restore_output_status_line_is_last_for_tail_consumers() {
+        let summary = binlog::RestoreSummary {
+            restored_projects: 1,
+            warnings: 0,
+            errors: 1,
+            duration_text: Some("00:00:01.00".to_string()),
+        };
+        let issues = vec![binlog::BinlogIssue {
+            code: "NU1101".to_string(),
+            file: "/repo/src/App/App.csproj".to_string(),
+            line: 0,
+            column: 0,
+            message: "Unable to find package Foo.Bar".to_string(),
+        }];
+        let output =
+            format_restore_output(&summary, &issues, &[], Path::new("/tmp/restore.binlog"));
+        let last_line = output.lines().last().expect("output must not be empty");
+        assert!(
+            last_line.starts_with("fail dotnet restore:"),
+            "status line must be the last line, got: {:?}",
+            last_line
+        );
     }
 
     #[test]

--- a/src/cmds/dotnet/dotnet_cmd.rs
+++ b/src/cmds/dotnet/dotnet_cmd.rs
@@ -980,58 +980,63 @@ fn format_issue(issue: &binlog::BinlogIssue, kind: &str) -> String {
 }
 
 fn format_build_output(summary: &binlog::BuildSummary, _binlog_path: &Path) -> String {
+    // Binlog path omitted from output (temp file, already cleaned up)
     let status_icon = if summary.succeeded { "ok" } else { "fail" };
     let duration = summary.duration_text.as_deref().unwrap_or("unknown");
 
-    let mut out = String::new();
-
-    if !summary.errors.is_empty() {
-        out.push_str("Errors:\n");
-        for issue in summary.errors.iter().take(20) {
-            out.push_str(&format!("{}\n", format_issue(issue, "error")));
-        }
-        if summary.errors.len() > 20 {
-            out.push_str(&format!(
-                "  ... +{} more errors\n",
-                summary.errors.len() - 20
-            ));
-        }
-    }
-
+    let mut warnings = String::new();
     if !summary.warnings.is_empty() {
-        if !out.is_empty() {
-            out.push('\n');
-        }
-        out.push_str("Warnings:\n");
+        warnings.push_str("Warnings:\n");
         for issue in summary.warnings.iter().take(10) {
-            out.push_str(&format!("{}\n", format_issue(issue, "warning")));
+            warnings.push_str(&format!("{}\n", format_issue(issue, "warning")));
         }
         if summary.warnings.len() > 10 {
-            out.push_str(&format!(
+            warnings.push_str(&format!(
                 "  ... +{} more warnings\n",
                 summary.warnings.len() - 10
             ));
         }
     }
 
-    if !out.is_empty() {
-        out.push_str("\n---------------------------------------\n");
+    let mut errors = String::new();
+    if !summary.errors.is_empty() {
+        errors.push_str("Errors:\n");
+        for issue in summary.errors.iter().take(20) {
+            errors.push_str(&format!("{}\n", format_issue(issue, "error")));
+        }
+        if summary.errors.len() > 20 {
+            errors.push_str(&format!(
+                "  ... +{} more errors\n",
+                summary.errors.len() - 20
+            ));
+        }
     }
+
+    let sep = if !warnings.is_empty() || !errors.is_empty() {
+        "---------------------------------------".to_string()
+    } else {
+        String::new()
+    };
 
     // Status line is emitted last so consumers that read the tail of the stream
     // (`| tail -N`, agent watch/monitor modes, bounded context windows) get a
     // definitive verdict. Mirrors native `dotnet build`, which ends with
     // `Build succeeded.` / `Build FAILED.`. See issue #1574.
-    out.push_str(&format!(
+    // Warnings before errors: errors survive `| tail -N` immediately above the verdict.
+    let verdict = format!(
         "{} dotnet build: {} projects, {} errors, {} warnings ({})",
         status_icon,
         summary.project_count,
         summary.errors.len(),
         summary.warnings.len(),
         duration
-    ));
+    );
 
-    out
+    [warnings, errors, sep, verdict]
+        .into_iter()
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn format_test_output(
@@ -1073,59 +1078,60 @@ fn format_test_output(
         )
     };
 
-    let mut out = String::new();
-
+    // Binlog path omitted from output (temp file, already cleaned up)
+    let mut failed_tests_section = String::new();
     if has_failures && !summary.failed_tests.is_empty() {
-        out.push_str("Failed Tests:\n");
+        failed_tests_section.push_str("Failed Tests:\n");
         for failed in summary.failed_tests.iter().take(15) {
-            out.push_str(&format!("  {}\n", failed.name));
+            failed_tests_section.push_str(&format!("  {}\n", failed.name));
             for detail in &failed.details {
-                out.push_str(&format!("    {}\n", truncate(detail, 320)));
+                failed_tests_section.push_str(&format!("    {}\n", truncate(detail, 320)));
             }
-            out.push('\n');
+            failed_tests_section.push('\n');
         }
         if summary.failed_tests.len() > 15 {
-            out.push_str(&format!(
+            failed_tests_section.push_str(&format!(
                 "... +{} more failed tests\n",
                 summary.failed_tests.len() - 15
             ));
         }
     }
 
-    if !errors.is_empty() {
-        if !out.is_empty() {
-            out.push('\n');
-        }
-        out.push_str("Errors:\n");
-        for issue in errors.iter().take(10) {
-            out.push_str(&format!("{}\n", format_issue(issue, "error")));
-        }
-        if errors.len() > 10 {
-            out.push_str(&format!("  ... +{} more errors\n", errors.len() - 10));
-        }
-    }
-
+    let mut warnings_section = String::new();
     if !warnings.is_empty() {
-        if !out.is_empty() {
-            out.push('\n');
-        }
-        out.push_str("Warnings:\n");
+        warnings_section.push_str("Warnings:\n");
         for issue in warnings.iter().take(10) {
-            out.push_str(&format!("{}\n", format_issue(issue, "warning")));
+            warnings_section.push_str(&format!("{}\n", format_issue(issue, "warning")));
         }
         if warnings.len() > 10 {
-            out.push_str(&format!("  ... +{} more warnings\n", warnings.len() - 10));
+            warnings_section.push_str(&format!("  ... +{} more warnings\n", warnings.len() - 10));
         }
     }
 
-    if !out.is_empty() {
-        out.push_str("\n---------------------------------------\n");
+    let mut errors_section = String::new();
+    if !errors.is_empty() {
+        errors_section.push_str("Errors:\n");
+        for issue in errors.iter().take(10) {
+            errors_section.push_str(&format!("{}\n", format_issue(issue, "error")));
+        }
+        if errors.len() > 10 {
+            errors_section.push_str(&format!("  ... +{} more errors\n", errors.len() - 10));
+        }
     }
 
-    // Status line emitted last; see format_build_output (issue #1574).
-    out.push_str(&header);
+    let sep = if !failed_tests_section.is_empty() || !warnings_section.is_empty() || !errors_section.is_empty() {
+        "---------------------------------------".to_string()
+    } else {
+        String::new()
+    };
 
-    out
+    // Status line emitted last; see format_build_output (issue #1574).
+    // Warnings before errors: errors survive `| tail -N` immediately above the verdict.
+    [failed_tests_section, warnings_section, errors_section, sep, header]
+        .into_iter()
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn format_restore_output(
@@ -1134,46 +1140,51 @@ fn format_restore_output(
     warnings: &[binlog::BinlogIssue],
     _binlog_path: &Path,
 ) -> String {
+    // Binlog path omitted from output (temp file, already cleaned up)
     let has_errors = summary.errors > 0;
     let status_icon = if has_errors { "fail" } else { "ok" };
     let duration = summary.duration_text.as_deref().unwrap_or("unknown");
 
-    let mut out = String::new();
-
-    if !errors.is_empty() {
-        out.push_str("Errors:\n");
-        for issue in errors.iter().take(20) {
-            out.push_str(&format!("{}\n", format_issue(issue, "error")));
-        }
-        if errors.len() > 20 {
-            out.push_str(&format!("  ... +{} more errors\n", errors.len() - 20));
-        }
-    }
-
+    let mut warnings_section = String::new();
     if !warnings.is_empty() {
-        if !out.is_empty() {
-            out.push('\n');
-        }
-        out.push_str("Warnings:\n");
+        warnings_section.push_str("Warnings:\n");
         for issue in warnings.iter().take(10) {
-            out.push_str(&format!("{}\n", format_issue(issue, "warning")));
+            warnings_section.push_str(&format!("{}\n", format_issue(issue, "warning")));
         }
         if warnings.len() > 10 {
-            out.push_str(&format!("  ... +{} more warnings\n", warnings.len() - 10));
+            warnings_section.push_str(&format!("  ... +{} more warnings\n", warnings.len() - 10));
         }
     }
 
-    if !out.is_empty() {
-        out.push_str("\n---------------------------------------\n");
+    let mut errors_section = String::new();
+    if !errors.is_empty() {
+        errors_section.push_str("Errors:\n");
+        for issue in errors.iter().take(20) {
+            errors_section.push_str(&format!("{}\n", format_issue(issue, "error")));
+        }
+        if errors.len() > 20 {
+            errors_section.push_str(&format!("  ... +{} more errors\n", errors.len() - 20));
+        }
     }
 
+    let sep = if !warnings_section.is_empty() || !errors_section.is_empty() {
+        "---------------------------------------".to_string()
+    } else {
+        String::new()
+    };
+
     // Status line emitted last; see format_build_output (issue #1574).
-    out.push_str(&format!(
+    // Warnings before errors: errors survive `| tail -N` immediately above the verdict.
+    let verdict = format!(
         "{} dotnet restore: {} projects, {} errors, {} warnings ({})",
         status_icon, summary.restored_projects, summary.errors, summary.warnings, duration
-    ));
+    );
 
-    out
+    [warnings_section, errors_section, sep, verdict]
+        .into_iter()
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #1574.

## Reproduction

```bash
rtk dotnet build 2>&1 | tail -5
```

Native `dotnet` ends with `Build succeeded.` / `Build FAILED.`, so consumers reading the end of the stream (`tail -N`, IDE log followers, agent watch/monitor loops, bounded context windows) reliably see the verdict. RTK put it at the *top*, so agents reading via `| tail -N` or with limited recent-output windows saw error noise followed by EOF, with no `ok` / `fail` line anywhere near the end. This silently broke any agent loop that gates the next step on build success.

## Fix (Option 2 from the issue)

Reorder `format_build_output`, `format_test_output`, and `format_restore_output` to:

1. build the body (errors / warnings / failed tests),
2. emit the `---` separator only when the body is non-empty,
3. append the verdict header last.

The final line of the formatted output is now always the verdict, matching native `dotnet`.

## Behavior

| Invocation | Last line (before) | Last line (after) |
|---|---|---|
| `rtk dotnet build` (success) | `ok dotnet build: …` | `ok dotnet build: …` |
| `rtk dotnet build` (errors) | last error / warning | `fail dotnet build: …` |
| `rtk dotnet test` (failures) | last error / warning | `fail dotnet test: …` |
| `rtk dotnet restore` (errors) | last error / warning | `fail dotnet restore: …` |

No information loss. Error / warning / failed-test sections still print in full, just above the verdict.

## Output contract change

This is a breaking change for any downstream consumer that parses the *first* line of dotnet output. RTK's filtered output is not a stable parse target by design (it includes runtime-dependent project counts and durations), and the issue explicitly motivates moving the verdict to the tail, but flagging it for anyone relying on line-1 positioning.

## Token impact

Neutral to −1 byte across all paths (clean build, errors only, warnings only, errors + warnings). The `!out.is_empty()` guard avoids emitting a useless separator on clean one-line builds.

## Test plan

Three regression tests in `src/cmds/dotnet/dotnet_cmd.rs`:

- [x] `test_format_build_output_status_line_is_last_for_tail_consumers` — asserts `output.lines().last()` starts with `ok dotnet build:` AND that the verdict is within the last 5 lines (`tail -5`).
- [x] `test_format_test_output_status_line_is_last_for_tail_consumers` — asserts `ok dotnet test:` is the last line.
- [x] `test_format_restore_output_status_line_is_last_for_tail_consumers` — asserts `fail dotnet restore:` is the last line.

The contract uses strict `lines().last()` rather than "last non-empty line" so a future regression that appends a trailing context line under the verdict gets caught. The `tail -5` inclusion assertion mirrors the exact user-reported scenario.

Results:
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets` clean (no new warnings in `dotnet_cmd.rs`)
- [x] `cargo test --all` → 1690 passed, 0 failed, 6 ignored

## Notes

- Independent of #1560 (hook left-side rewrite). Per the issue: "Option 2 alone fixes the agent watch/monitor case described above. Option 1 alone fixes the explicit-pipe case but not streaming consumers that read RTK's stdout directly."
- Composes with #1115 (failure-path output shape). Traced both interleavings: the verdict stays at the bottom whether `output_to_print = filtered` (post-#1115) or `<raw>\n\n<filtered>` (current). No merge conflict expected at the formatter layer.
- Implements the same Option 2 approach as the concurrently-opened #1575. Tests in this PR use strict `lines().last()` plus a `tail -5` inclusion check, which catches a wider class of trailing-content regressions. Maintainers should pick whichever PR fits their preference.