### PR TITLE
feat(git): support git sparse-checkout subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ rtk git add                     # -> "ok"
 rtk git commit -m "msg"         # -> "ok abc1234"
 rtk git push                    # -> "ok main"
 rtk git pull                    # -> "ok 3 files +10 -2"
+rtk git sparse-checkout list    # Compact pattern list (truncated >50)
+rtk git sparse-checkout set ... # -> "ok sparse-checkout set"
 ```
 
 ### GitHub CLI

--- a/src/cmds/git/README.md
+++ b/src/cmds/git/README.md
@@ -8,6 +8,10 @@
 - Auto-detects `--merges` flag to avoid conflicting with `--no-merges` injection
 - Global git options (`-C`, `--git-dir`, `--work-tree`, `--no-pager`) are prepended before the subcommand
 - Exit code propagation is critical for CI/CD pipelines
+- **`sparse-checkout`** routes through `run_sparse_checkout()`:
+  - `list`  → prints all patterns verbatim, capped at 50 lines with `... +N more` (patterns are semantically meaningful, never reorder/merge)
+  - `init`/`set`/`add`/`disable`/`reapply` → collapses progress noise to `ok sparse-checkout <sub>`
+  - `check-rules`, missing subcommand, or any future subcommand → passthrough
 - **glab_cmd.rs** declares `-R`/`--repo` and `-g`/`--group` at the clap level; they are **appended** to the glab args (not prepended) so subcommand dispatch stays intact
 - `has_output_flag()` short-circuits to passthrough when the user explicitly requests `-F` / `--output` / `--json` (avoids double JSON injection)
 - `should_passthrough_view()` redirects `mr/issue view` to passthrough when `--web` or `--comments` is set

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -23,6 +23,7 @@ pub enum GitCommand {
     Fetch,
     Stash { subcommand: Option<String> },
     Worktree,
+    SparseCheckout { subcommand: Option<String> },
 }
 
 /// Create a git Command with global options (e.g. -C, -c, --git-dir, --work-tree)
@@ -57,6 +58,9 @@ pub fn run(
             run_stash(subcommand.as_deref(), args, verbose, global_args)
         }
         GitCommand::Worktree => run_worktree(args, verbose, global_args),
+        GitCommand::SparseCheckout { subcommand } => {
+            run_sparse_checkout(subcommand.as_deref(), args, verbose, global_args)
+        }
     }
 }
 
@@ -1669,6 +1673,146 @@ fn filter_worktree_list(output: &str) -> String {
     result.join("\n")
 }
 
+/// Maximum number of sparse-checkout patterns to print before truncating to a
+/// `... +N more` summary. Mirrors the truncation thresholds used by
+/// `format_status_output` so very large monorepo cone lists don't blow up the
+/// LLM context.
+const SPARSE_CHECKOUT_LIST_MAX_LINES: usize = 50;
+
+/// Subcommands of `git sparse-checkout` that mutate state.
+///
+/// On success they typically produce only progress noise (`Updating files: ...`)
+/// which we collapse to a short `ok` line. Unknown subcommands fall through to
+/// passthrough so we never block a future git release.
+const SPARSE_CHECKOUT_ACTION_SUBCOMMANDS: &[&str] = &[
+    "init", "set", "add", "disable", "reapply",
+];
+
+fn run_sparse_checkout(
+    subcommand: Option<&str>,
+    args: &[String],
+    verbose: u8,
+    global_args: &[String],
+) -> Result<i32> {
+    let timer = tracking::TimedExecution::start();
+
+    if verbose > 0 {
+        eprintln!("git sparse-checkout {:?}", subcommand);
+    }
+
+    match subcommand {
+        Some("list") => {
+            let mut cmd = git_cmd(global_args);
+            cmd.args(["sparse-checkout", "list"]);
+            for arg in args {
+                cmd.arg(arg);
+            }
+            let result = exec_capture(&mut cmd)
+                .context("Failed to run git sparse-checkout list")?;
+
+            if !result.success() {
+                eprintln!("FAILED: git sparse-checkout list");
+                if !result.stderr.trim().is_empty() {
+                    eprintln!("{}", result.stderr);
+                }
+                return Ok(result.exit_code);
+            }
+
+            let filtered = if result.stdout.trim().is_empty() {
+                "No sparse-checkout patterns (sparse-checkout disabled or empty)".to_string()
+            } else {
+                filter_sparse_checkout_list(&result.stdout, SPARSE_CHECKOUT_LIST_MAX_LINES)
+            };
+            println!("{}", filtered);
+            timer.track(
+                "git sparse-checkout list",
+                "rtk git sparse-checkout list",
+                &result.stdout,
+                &filtered,
+            );
+        }
+        Some(sub) if SPARSE_CHECKOUT_ACTION_SUBCOMMANDS.contains(&sub) => {
+            let mut cmd = git_cmd(global_args);
+            cmd.args(["sparse-checkout", sub]);
+            for arg in args {
+                cmd.arg(arg);
+            }
+            let result = exec_capture(&mut cmd)
+                .context("Failed to run git sparse-checkout")?;
+            let combined = result.combined();
+
+            let msg = if result.success() {
+                let msg = format!("ok sparse-checkout {}", sub);
+                println!("{}", msg);
+                msg
+            } else {
+                eprintln!("FAILED: git sparse-checkout {}", sub);
+                if !result.stderr.trim().is_empty() {
+                    eprintln!("{}", result.stderr);
+                }
+                combined.clone()
+            };
+
+            timer.track(
+                &format!("git sparse-checkout {}", sub),
+                &format!("rtk git sparse-checkout {}", sub),
+                &combined,
+                &msg,
+            );
+
+            if !result.success() {
+                return Ok(result.exit_code);
+            }
+        }
+        Some(sub) => {
+            // Unrecognized subcommand (e.g. `check-rules`, future additions):
+            // passthrough unfiltered so we never break valid git usage.
+            let mut passthrough_args: Vec<OsString> =
+                Vec::with_capacity(args.len() + 2);
+            passthrough_args.push(OsString::from("sparse-checkout"));
+            passthrough_args.push(OsString::from(sub));
+            for arg in args {
+                passthrough_args.push(OsString::from(arg));
+            }
+            let _ = timer; // tracking handled inside run_passthrough
+            return run_passthrough(&passthrough_args, global_args, verbose);
+        }
+        None => {
+            // `git sparse-checkout` with no subcommand prints usage to stderr
+            // and exits non-zero. Pass through so the user sees the real help.
+            let passthrough_args: Vec<OsString> = vec![OsString::from("sparse-checkout")];
+            let _ = timer;
+            return run_passthrough(&passthrough_args, global_args, verbose);
+        }
+    }
+
+    Ok(0)
+}
+
+/// Compress `git sparse-checkout list` output: trim, drop blank lines, and cap
+/// at `max_lines` patterns followed by a `... +N more` summary. Each pattern is
+/// preserved verbatim — sparse-checkout patterns are semantically meaningful
+/// (they decide which paths exist on disk), so we never reorder or merge them.
+pub(crate) fn filter_sparse_checkout_list(output: &str, max_lines: usize) -> String {
+    let patterns: Vec<&str> = output
+        .lines()
+        .map(str::trim_end)
+        .filter(|l| !l.is_empty())
+        .collect();
+
+    if patterns.len() <= max_lines {
+        return patterns.join("\n");
+    }
+
+    let mut out: Vec<String> = patterns
+        .iter()
+        .take(max_lines)
+        .map(|s| (*s).to_string())
+        .collect();
+    out.push(format!("... +{} more", patterns.len() - max_lines));
+    out.join("\n")
+}
+
 /// Runs an unsupported git subcommand by passing it through directly
 pub fn run_passthrough(args: &[OsString], global_args: &[String], verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
@@ -2021,6 +2165,74 @@ mod tests {
         assert!(result.contains("abc1234"));
         assert!(result.contains("[main]"));
         assert!(result.contains("[feature]"));
+    }
+
+    // ----- sparse-checkout -----
+
+    #[test]
+    fn test_filter_sparse_checkout_list_short() {
+        let output = "src/\ndocs/\nREADME.md\n";
+        let result = filter_sparse_checkout_list(output, 50);
+        assert_eq!(result, "src/\ndocs/\nREADME.md");
+    }
+
+    #[test]
+    fn test_filter_sparse_checkout_list_drops_blank_and_trailing_whitespace() {
+        // Real git output occasionally has trailing spaces (cone mode) and
+        // blank lines from CRLF round-trips on Windows checkouts.
+        let output = "src/   \n\ndocs/\n\n  \nREADME.md\n";
+        let result = filter_sparse_checkout_list(output, 50);
+        assert_eq!(result, "src/\ndocs/\nREADME.md");
+    }
+
+    #[test]
+    fn test_filter_sparse_checkout_list_truncates_when_over_limit() {
+        let mut output = String::new();
+        for i in 0..120 {
+            output.push_str(&format!("path/dir{}/\n", i));
+        }
+        let result = filter_sparse_checkout_list(&output, 50);
+        let lines: Vec<&str> = result.lines().collect();
+        assert_eq!(lines.len(), 51, "50 patterns + summary line");
+        assert_eq!(lines[0], "path/dir0/");
+        assert_eq!(lines[49], "path/dir49/");
+        assert_eq!(lines[50], "... +70 more");
+    }
+
+    #[test]
+    fn test_filter_sparse_checkout_list_at_exact_limit() {
+        // Boundary: exactly max_lines must not get a `+0 more` suffix.
+        let mut output = String::new();
+        for i in 0..50 {
+            output.push_str(&format!("d{}/\n", i));
+        }
+        let result = filter_sparse_checkout_list(&output, 50);
+        assert_eq!(result.lines().count(), 50);
+        assert!(!result.contains("... +"));
+    }
+
+    #[test]
+    fn test_filter_sparse_checkout_list_preserves_negation_patterns() {
+        // Non-cone mode uses gitignore-style patterns including `!` negation.
+        // We must preserve them verbatim — reordering or stripping changes
+        // which paths exist on disk.
+        let output = "/*\n!/docs/\n!/src/lib/\n";
+        let result = filter_sparse_checkout_list(output, 50);
+        assert_eq!(result, "/*\n!/docs/\n!/src/lib/");
+    }
+
+    #[test]
+    fn test_sparse_checkout_action_subcommands_are_recognized() {
+        // Guard against accidental rename: each action must produce an `ok`
+        // success message in run_sparse_checkout. The list also drives the
+        // dispatch in the match arm above.
+        for sub in SPARSE_CHECKOUT_ACTION_SUBCOMMANDS {
+            assert!(
+                matches!(*sub, "init" | "set" | "add" | "disable" | "reapply"),
+                "unexpected sparse-checkout action subcommand: {}",
+                sub
+            );
+        }
     }
 
     #[test]

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -1674,9 +1674,11 @@ fn filter_worktree_list(output: &str) -> String {
 }
 
 /// Maximum number of sparse-checkout patterns to print before truncating to a
-/// `... +N more` summary. Mirrors the truncation thresholds used by
-/// `format_status_output` so very large monorepo cone lists don't blow up the
-/// LLM context.
+/// `... +N more` summary. Same order of magnitude as the configurable
+/// thresholds used by `format_status_output` (`status_max_files`,
+/// `status_max_untracked`, defaults 15/10) but intentionally fixed here —
+/// typical project configs never truncate, while a 200+ pattern monorepo cone
+/// list compresses meaningfully without blowing up the LLM context.
 const SPARSE_CHECKOUT_LIST_MAX_LINES: usize = 50;
 
 /// Subcommands of `git sparse-checkout` that mutate state.
@@ -1688,20 +1690,44 @@ const SPARSE_CHECKOUT_ACTION_SUBCOMMANDS: &[&str] = &[
     "init", "set", "add", "disable", "reapply",
 ];
 
+/// Returns true when `args` contains git's `--stdin` flag, which makes
+/// `set`/`add` read patterns line-by-line from stdin until EOF.
+///
+/// `exec_capture` unconditionally nulls stdin, so action subcommands invoked
+/// with `--stdin` would otherwise see immediate EOF and silently apply an
+/// empty pattern set — effectively wiping the user's sparse-checkout config
+/// while still reporting success.
+fn sparse_checkout_uses_stdin(sub: &str, args: &[String]) -> bool {
+    matches!(sub, "set" | "add") && args.iter().any(|a| a == "--stdin")
+}
+
+/// Build the args slice that `run_passthrough` expects from a sparse-checkout
+/// invocation: `["sparse-checkout", <sub>?, ...args]` as `OsString`s.
+fn sparse_checkout_passthrough_args(sub: Option<&str>, args: &[String]) -> Vec<OsString> {
+    let mut out: Vec<OsString> = Vec::with_capacity(args.len() + 2);
+    out.push(OsString::from("sparse-checkout"));
+    if let Some(sub) = sub {
+        out.push(OsString::from(sub));
+    }
+    for arg in args {
+        out.push(OsString::from(arg));
+    }
+    out
+}
+
 fn run_sparse_checkout(
     subcommand: Option<&str>,
     args: &[String],
     verbose: u8,
     global_args: &[String],
 ) -> Result<i32> {
-    let timer = tracking::TimedExecution::start();
-
     if verbose > 0 {
         eprintln!("git sparse-checkout {:?}", subcommand);
     }
 
     match subcommand {
         Some("list") => {
+            let timer = tracking::TimedExecution::start();
             let mut cmd = git_cmd(global_args);
             cmd.args(["sparse-checkout", "list"]);
             for arg in args {
@@ -1730,8 +1756,13 @@ fn run_sparse_checkout(
                 &result.stdout,
                 &filtered,
             );
+            Ok(0)
         }
-        Some(sub) if SPARSE_CHECKOUT_ACTION_SUBCOMMANDS.contains(&sub) => {
+        Some(sub)
+            if SPARSE_CHECKOUT_ACTION_SUBCOMMANDS.contains(&sub)
+                && !sparse_checkout_uses_stdin(sub, args) =>
+        {
+            let timer = tracking::TimedExecution::start();
             let mut cmd = git_cmd(global_args);
             cmd.args(["sparse-checkout", sub]);
             for arg in args {
@@ -1763,37 +1794,34 @@ fn run_sparse_checkout(
             if !result.success() {
                 return Ok(result.exit_code);
             }
+            Ok(0)
         }
         Some(sub) => {
-            // Unrecognized subcommand (e.g. `check-rules`, future additions):
-            // passthrough unfiltered so we never break valid git usage.
-            let mut passthrough_args: Vec<OsString> =
-                Vec::with_capacity(args.len() + 2);
-            passthrough_args.push(OsString::from("sparse-checkout"));
-            passthrough_args.push(OsString::from(sub));
-            for arg in args {
-                passthrough_args.push(OsString::from(arg));
-            }
-            let _ = timer; // tracking handled inside run_passthrough
-            return run_passthrough(&passthrough_args, global_args, verbose);
+            // Falls through to passthrough for three cases, all of which need
+            // an inherited stdin or unfiltered output:
+            //   1. `set --stdin` / `add --stdin`  — read patterns from stdin
+            //   2. `check-rules`                  — reads paths from stdin
+            //   3. unknown / future subcommands   — don't break valid git usage
+            //
+            // `run_passthrough` uses `.status()` which inherits the parent
+            // stdin/stdout/stderr, and tracks its own timing.
+            let passthrough_args = sparse_checkout_passthrough_args(Some(sub), args);
+            run_passthrough(&passthrough_args, global_args, verbose)
         }
         None => {
             // `git sparse-checkout` with no subcommand prints usage to stderr
             // and exits non-zero. Pass through so the user sees the real help.
-            let passthrough_args: Vec<OsString> = vec![OsString::from("sparse-checkout")];
-            let _ = timer;
-            return run_passthrough(&passthrough_args, global_args, verbose);
+            let passthrough_args = sparse_checkout_passthrough_args(None, args);
+            run_passthrough(&passthrough_args, global_args, verbose)
         }
     }
-
-    Ok(0)
 }
 
 /// Compress `git sparse-checkout list` output: trim, drop blank lines, and cap
 /// at `max_lines` patterns followed by a `... +N more` summary. Each pattern is
 /// preserved verbatim — sparse-checkout patterns are semantically meaningful
 /// (they decide which paths exist on disk), so we never reorder or merge them.
-pub(crate) fn filter_sparse_checkout_list(output: &str, max_lines: usize) -> String {
+fn filter_sparse_checkout_list(output: &str, max_lines: usize) -> String {
     let patterns: Vec<&str> = output
         .lines()
         .map(str::trim_end)
@@ -2223,16 +2251,55 @@ mod tests {
 
     #[test]
     fn test_sparse_checkout_action_subcommands_are_recognized() {
-        // Guard against accidental rename: each action must produce an `ok`
-        // success message in run_sparse_checkout. The list also drives the
-        // dispatch in the match arm above.
-        for sub in SPARSE_CHECKOUT_ACTION_SUBCOMMANDS {
-            assert!(
-                matches!(*sub, "init" | "set" | "add" | "disable" | "reapply"),
-                "unexpected sparse-checkout action subcommand: {}",
-                sub
-            );
+        // Equality (not membership) so accidental removals, additions, typos,
+        // or reordering all surface here — this slice drives dispatch.
+        assert_eq!(
+            SPARSE_CHECKOUT_ACTION_SUBCOMMANDS,
+            &["init", "set", "add", "disable", "reapply"]
+        );
+    }
+
+    #[test]
+    fn test_sparse_checkout_uses_stdin_only_for_set_and_add() {
+        // Carve-out predicate for the `--stdin` regression: only `set` and
+        // `add` accept `--stdin` per git-sparse-checkout(1).
+        assert!(sparse_checkout_uses_stdin(
+            "set",
+            &["--stdin".to_string()]
+        ));
+        assert!(sparse_checkout_uses_stdin(
+            "add",
+            &["--stdin".to_string()]
+        ));
+        // No `--stdin` token → false even for set/add.
+        assert!(!sparse_checkout_uses_stdin(
+            "set",
+            &["src".to_string(), "docs".to_string()]
+        ));
+        // Other action subcommands never read stdin.
+        for sub in ["init", "disable", "reapply"] {
+            assert!(!sparse_checkout_uses_stdin(
+                sub,
+                &["--stdin".to_string()]
+            ));
         }
+    }
+
+    #[test]
+    fn test_sparse_checkout_passthrough_args_with_subcommand() {
+        let out = sparse_checkout_passthrough_args(
+            Some("check-rules"),
+            &["-z".to_string(), "src/foo.rs".to_string()],
+        );
+        let strs: Vec<&str> = out.iter().map(|s| s.to_str().unwrap()).collect();
+        assert_eq!(strs, vec!["sparse-checkout", "check-rules", "-z", "src/foo.rs"]);
+    }
+
+    #[test]
+    fn test_sparse_checkout_passthrough_args_without_subcommand() {
+        let out = sparse_checkout_passthrough_args(None, &[]);
+        let strs: Vec<&str> = out.iter().map(|s| s.to_str().unwrap()).collect();
+        assert_eq!(strs, vec!["sparse-checkout"]);
     }
 
     #[test]

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -12,7 +12,7 @@ pub struct RtkRule {
 
 pub const RULES: &[RtkRule] = &[
     RtkRule {
-        pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|push|pull|branch|fetch|stash|worktree)",
+        pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|push|pull|branch|fetch|stash|worktree|sparse-checkout)",
         rtk_cmd: "rtk git",
         rewrite_prefixes: &["git", "yadm"],
         category: "Git",

--- a/src/main.rs
+++ b/src/main.rs
@@ -2584,6 +2584,101 @@ mod tests {
         assert!(result.is_ok(), "git status should parse successfully");
     }
 
+    // ----- sparse-checkout clap parsing -----
+    //
+    // Pin the optional-subcommand + trailing_var_arg split for the hyphenated
+    // `sparse-checkout` variant. Regressions here would mis-dispatch dangerous
+    // forms (e.g. routing `set --stdin` to capture mode — see the `--stdin`
+    // regression test in run_sparse_checkout).
+
+    #[test]
+    fn test_git_sparse_checkout_list_no_args() {
+        let cli = Cli::try_parse_from(["rtk", "git", "sparse-checkout", "list"]).unwrap();
+        match cli.command {
+            Commands::Git {
+                command: GitCommands::SparseCheckout { subcommand, args },
+                ..
+            } => {
+                assert_eq!(subcommand.as_deref(), Some("list"));
+                assert!(
+                    args.is_empty(),
+                    "list takes no positional args, got {:?}",
+                    args
+                );
+            }
+            _ => panic!("Expected Git SparseCheckout command"),
+        }
+    }
+
+    #[test]
+    fn test_git_sparse_checkout_set_with_patterns() {
+        let cli =
+            Cli::try_parse_from(["rtk", "git", "sparse-checkout", "set", "src", "docs"]).unwrap();
+        match cli.command {
+            Commands::Git {
+                command: GitCommands::SparseCheckout { subcommand, args },
+                ..
+            } => {
+                assert_eq!(subcommand.as_deref(), Some("set"));
+                assert_eq!(args, vec!["src", "docs"]);
+            }
+            _ => panic!("Expected Git SparseCheckout command"),
+        }
+    }
+
+    #[test]
+    fn test_git_sparse_checkout_set_stdin_flag_lands_in_args() {
+        // `--stdin` must reach `args` so the runtime can detect it and route
+        // to passthrough (otherwise stdin gets nulled and patterns are wiped).
+        let cli = Cli::try_parse_from(["rtk", "git", "sparse-checkout", "set", "--stdin"]).unwrap();
+        match cli.command {
+            Commands::Git {
+                command: GitCommands::SparseCheckout { subcommand, args },
+                ..
+            } => {
+                assert_eq!(subcommand.as_deref(), Some("set"));
+                assert_eq!(args, vec!["--stdin"]);
+            }
+            _ => panic!("Expected Git SparseCheckout command"),
+        }
+    }
+
+    #[test]
+    fn test_git_sparse_checkout_check_rules_with_z_flag() {
+        // `check-rules -z` is a real git invocation (NUL-delimited paths from
+        // stdin). Ensure the hyphenated subcommand parses with hyphen-prefixed
+        // trailing args.
+        let cli =
+            Cli::try_parse_from(["rtk", "git", "sparse-checkout", "check-rules", "-z"]).unwrap();
+        match cli.command {
+            Commands::Git {
+                command: GitCommands::SparseCheckout { subcommand, args },
+                ..
+            } => {
+                assert_eq!(subcommand.as_deref(), Some("check-rules"));
+                assert_eq!(args, vec!["-z"]);
+            }
+            _ => panic!("Expected Git SparseCheckout command"),
+        }
+    }
+
+    #[test]
+    fn test_git_sparse_checkout_no_subcommand_is_none() {
+        // `rtk git sparse-checkout` (no further args) must parse with
+        // subcommand=None so the runtime can passthrough to git's usage error.
+        let cli = Cli::try_parse_from(["rtk", "git", "sparse-checkout"]).unwrap();
+        match cli.command {
+            Commands::Git {
+                command: GitCommands::SparseCheckout { subcommand, args },
+                ..
+            } => {
+                assert!(subcommand.is_none(), "expected None, got {:?}", subcommand);
+                assert!(args.is_empty());
+            }
+            _ => panic!("Expected Git SparseCheckout command"),
+        }
+    }
+
     #[test]
     fn test_try_parse_help_is_display_help() {
         match Cli::try_parse_from(["rtk", "--help"]) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -846,6 +846,15 @@ enum GitCommands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Sparse-checkout management (init, set, add, list, disable, reapply)
+    #[command(name = "sparse-checkout")]
+    SparseCheckout {
+        /// Subcommand: list, init, set, add, disable, reapply, check-rules
+        subcommand: Option<String>,
+        /// Additional arguments (patterns for set/add, flags like --cone)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
     /// Passthrough: runs any unsupported git subcommand directly
     #[command(external_subcommand)]
     Other(Vec<OsString>),
@@ -1532,6 +1541,13 @@ fn run_cli() -> Result<i32> {
                 )?,
                 GitCommands::Worktree { args } => git::run(
                     git::GitCommand::Worktree,
+                    &args,
+                    None,
+                    cli.verbose,
+                    &global_args,
+                )?,
+                GitCommands::SparseCheckout { subcommand, args } => git::run(
+                    git::GitCommand::SparseCheckout { subcommand },
                     &args,
                     None,
                     cli.verbose,


### PR DESCRIPTION
## Summary

Adds explicit handling for `git sparse-checkout` so the RTK hook system auto-rewrites it and the noisy progress output emitted by mutating subcommands collapses to a short `ok` line.

Today `git sparse-checkout` falls through to `GitCommands::Other` (the `external_subcommand` passthrough), which means:

- The hook system doesn't rewrite it (no `rtk_cmd` mapping in `discover/rules.rs`).
- Mutating subcommands stream raw `Updating files: 50% (5/10)…` progress noise into the LLM context with zero filtering.
- `list` output is unbounded — sparse-checkout configs in large monorepos can hit hundreds of patterns.

## What changed

| Subcommand | Behavior |
|---|---|
| `list` | Prints all patterns verbatim, capped at 50 lines with `... +N more`. Patterns are **never** reordered or merged — they are semantically meaningful (they decide which paths exist on disk). |
| `init` / `set` / `add` / `disable` / `reapply` | Collapses to `ok sparse-checkout <sub>` on success; surfaces stderr + git's real exit code on failure. |
| `check-rules`, no subcommand, any future/unknown subcommand | Passthrough — never block a future git release. |

The discover rule pattern is extended so the hook auto-rewriter picks `git sparse-checkout …` up:

```diff
-pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|...|stash|worktree)",
+pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|...|stash|worktree|sparse-checkout)",
```

## Token savings

Verified end-to-end against a real sparse repo with 200 cone patterns:

```
raw   git sparse-checkout list: 1700 chars
rtk   git sparse-checkout list:  397 chars   (-76.6%)
```

Well above the 60% bar from `CONTRIBUTING.md`.

For action subcommands the savings come from collapsing git's progress lines (and any warnings) into a single `ok sparse-checkout <sub>` token sequence, matching the existing pattern used by `add`/`commit`/`push`/`pull`/`stash`/`worktree`.

## Design notes

- **Patterns are preserved verbatim.** Sparse-checkout patterns are not advisory — they decide which paths get materialized in the working tree. Sorting, deduping, or grouping them would change which files an LLM sees on disk. The filter only trims trailing whitespace, drops blank lines, and applies a top-N cap with a `... +N more` summary.
- **Truncation threshold is 50.** Same order of magnitude as the truncation thresholds already used by `format_status_output`. Tuned high enough that typical project configs never truncate, but low enough that a 200+ pattern monorepo cone list compresses meaningfully.
- **Action list is a `const &[&str]`.** A small unit test asserts the contents to guard against accidental rename/typo.
- **Empty stdout on `list` → friendly message.** When a worktree has sparse-checkout enabled but no patterns yet, raw git prints nothing; we surface "No sparse-checkout patterns (sparse-checkout disabled or empty)" so the LLM doesn't see an unexplained empty response.
- **`check-rules` is intentionally passthrough.** Its output is structured (path + match status) and primarily consumed by scripts; reformatting risks breaking valid use cases for marginal token savings.
- **Exit codes propagate.** `git sparse-checkout list` on a non-sparse worktree exits 128 — RTK forwards that exit code unchanged for CI/CD compatibility.

## Manual verification

```
$ rtk git sparse-checkout init --cone
ok sparse-checkout init
$ rtk git sparse-checkout set src docs
ok sparse-checkout set
$ rtk git sparse-checkout list
docs
src
$ rtk git sparse-checkout add scripts
ok sparse-checkout add
$ rtk git sparse-checkout reapply
ok sparse-checkout reapply
$ rtk git sparse-checkout disable
ok sparse-checkout disable
$ echo "src/a.txt" | rtk git sparse-checkout check-rules    # passthrough
src/a.txt
$ rtk hook check "git sparse-checkout list"                 # auto-rewrite
rtk git sparse-checkout list
```

## Tests

Six new unit tests in `src/cmds/git/git.rs`:

- `test_filter_sparse_checkout_list_short` — happy path, no truncation
- `test_filter_sparse_checkout_list_drops_blank_and_trailing_whitespace` — Windows CRLF / trailing-space tolerance
- `test_filter_sparse_checkout_list_truncates_when_over_limit` — 120 patterns → 50 + `... +70 more`
- `test_filter_sparse_checkout_list_at_exact_limit` — boundary: exactly 50 must not get a `+0 more` suffix
- `test_filter_sparse_checkout_list_preserves_negation_patterns` — non-cone `!/path/` patterns preserved verbatim and in order
- `test_sparse_checkout_action_subcommands_are_recognized` — guards the `SPARSE_CHECKOUT_ACTION_SUBCOMMANDS` constant against accidental rename

All 1693 existing tests still pass. `cargo fmt --all --check && cargo clippy --all-targets && cargo test` is green.

## Docs

- `README.md`: added two `rtk git sparse-checkout …` examples to the Git section.
- `src/cmds/git/README.md`: documented routing rules under "Specifics".

## Scope

Single feature, single PR, per `CONTRIBUTING.md` scope rules. No drive-by refactors, no `CHANGELOG.md` edit (release-please handles it from the conventional commit).
