### PR TITLE
fix(curl): emit valid JSON envelope when truncating large responses

### DIFF
--- a/src/cmds/cloud/curl_cmd.rs
+++ b/src/cmds/cloud/curl_cmd.rs
@@ -58,20 +58,51 @@ fn filter_curl_output(raw: &str) -> FilterResult {
     let trimmed = raw.trim();
     let tee_hint = force_tee_hint(raw, "curl");
 
-    // If the output is too long and we have a tee hint, truncate the output.
-    let content = if trimmed.len() >= MAX_RESPONSE_SIZE && tee_hint.is_some() {
-        let mut end = MAX_RESPONSE_SIZE;
-        // Ensure we don't cut in the middle of a UTF-8 character.
-        // .len() counts bytes, not chars.
-        while !trimmed.is_char_boundary(end) {
-            end -= 1;
-        }
-        format!("{}... ({} bytes total)", &trimmed[..end], trimmed.len())
-    } else {
-        trimmed.to_string()
-    };
+    if trimmed.len() < MAX_RESPONSE_SIZE || tee_hint.is_none() {
+        return FilterResult {
+            content: trimmed.to_string(),
+            tee_hint,
+        };
+    }
 
+    let total_bytes = trimmed.len();
+
+    // For JSON-shaped responses, mid-stream truncation produces invalid JSON
+    // that downstream agents can't parse. Emit a parseable envelope instead and
+    // fold the tee path into it so the caller doesn't print a separate trailer.
+    if is_json_shape(trimmed) {
+        let tee_log = tee_hint
+            .as_deref()
+            .and_then(|h| h.strip_prefix("[full output: "))
+            .and_then(|h| h.strip_suffix(']'))
+            .unwrap_or("");
+        let envelope = serde_json::json!({
+            "_rtk": {
+                "truncated": true,
+                "total_bytes": total_bytes,
+                "tee_log": tee_log,
+            }
+        })
+        .to_string();
+        return FilterResult {
+            content: envelope,
+            tee_hint: None,
+        };
+    }
+
+    // Non-JSON: keep the existing prefix-with-byte-count truncation.
+    let mut end = MAX_RESPONSE_SIZE;
+    // Ensure we don't cut in the middle of a UTF-8 character.
+    // .len() counts bytes, not chars.
+    while !trimmed.is_char_boundary(end) {
+        end -= 1;
+    }
+    let content = format!("{}... ({} bytes total)", &trimmed[..end], total_bytes);
     FilterResult { content, tee_hint }
+}
+
+fn is_json_shape(s: &str) -> bool {
+    matches!(s.as_bytes().first(), Some(b'{' | b'['))
 }
 
 struct FilterResult {
@@ -121,5 +152,48 @@ mod tests {
         let content = "a".repeat(500);
         let result = filter_curl_output(&content);
         assert!(result.content.contains("bytes total"));
+    }
+
+    #[test]
+    fn test_filter_curl_large_json_object_emits_valid_envelope() {
+        // Build a JSON object well past MAX_RESPONSE_SIZE so the truncation
+        // branch fires. With the prior implementation the result would be a
+        // mid-string slice ending in "... (N bytes total)" which is not
+        // parseable as JSON.
+        let payload = "x".repeat(600);
+        let json = format!(r#"{{"data":"{}"}}"#, payload);
+        let result = filter_curl_output(&json);
+
+        // Output must be valid JSON and identifiably an rtk envelope.
+        let parsed: serde_json::Value = serde_json::from_str(&result.content)
+            .expect("envelope must be valid JSON for downstream agents to parse");
+        let rtk = parsed
+            .get("_rtk")
+            .expect("envelope carries _rtk metadata key");
+        assert_eq!(rtk.get("truncated"), Some(&serde_json::Value::Bool(true)));
+        assert_eq!(
+            rtk.get("total_bytes")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap(),
+            json.len() as u64
+        );
+        assert!(rtk.get("tee_log").and_then(|v| v.as_str()).is_some());
+
+        // Envelope already carries the tee path; suppress the separate trailer
+        // line so callers print one valid JSON document and nothing else.
+        assert!(result.tee_hint.is_none());
+    }
+
+    #[test]
+    fn test_filter_curl_large_json_array_emits_valid_envelope() {
+        let item = r#"{"id":1,"name":"placeholder-name-with-padding"}"#;
+        let array = format!("[{}]", vec![item; 20].join(","));
+        assert!(array.len() >= 500);
+        let result = filter_curl_output(&array);
+
+        let parsed: serde_json::Value = serde_json::from_str(&result.content)
+            .expect("array-shaped responses also need a parseable envelope");
+        assert!(parsed.get("_rtk").is_some());
+        assert!(result.tee_hint.is_none());
     }
 }


### PR DESCRIPTION
Closes #1536.

Today, on any curl response above 500 bytes the truncation produces
output like:

```
{"items":[{"id":1,"name":"alpha"},{"id":2,"name"... (1234 bytes total)
[full output: ~/.local/share/rtk/curl-...log]
```

That is no longer valid JSON. Anything piping rtk through `jq`, parsing
structured tool output, or feeding the response back to an LLM hits a
parse error on every response above the threshold. Reproducer in #1536
(`rtk curl https://jsonplaceholder.typicode.com/users` → `jq` fails).

## Approach

I considered three options and went with the smallest one that fits the
existing design:

- **A — passthrough (PR #1016):** drop truncation entirely for JSON. This
  regresses the token-savings intent of the simplified filter that landed
  in #1310, and makes large responses expensive again for the LLM caller.
- **B — JSON envelope (this PR):** when the response is JSON-shaped and
  above the threshold, replace the body with a small envelope:
  ```json
  {"_rtk":{"truncated":true,"total_bytes":1234,"tee_log":"~/path"}}
  ```
  Downstream agents can parse it, branch on `_rtk.truncated`, and read
  the full body from the tee log. Keeps the token-saving guarantee.
- **C — config flag:** adds surface area for a behavior that should
  always be correct.

The envelope path also folds the tee log into the JSON object and sets
`tee_hint = None`, so callers print exactly one valid JSON document and
not a separate `[full output: ...]` trailer line.

Non-JSON responses keep the existing prefix-with-byte-count format. The
shape detection is a one-byte check (`{` or `[`); responses curl produces
that aren't actually JSON but happen to start with those bytes are
extremely rare and will surface as a parse error on `_rtk` lookup, which
is at worst the same outcome as today.

## Verification

Stash-bisect against this branch's two new tests:

Without the fix (existing implementation, new tests applied):
```
test test_filter_curl_large_json_object_emits_valid_envelope ... FAILED
test test_filter_curl_large_json_array_emits_valid_envelope  ... FAILED
  panicked: 'envelope must be valid JSON for downstream agents to parse:
  Error("EOF while parsing a string", line: 1, column: 521)'
```

With the fix:
```
test result: ok. 7 passed; 0 failed; 0 ignored
```

The four pre-existing tests (`test_filter_curl_json_small_no_tee_hint`,
`test_filter_curl_non_json`, `test_filter_curl_long_output_truncated`,
`test_filter_curl_multibyte_boundary`, `test_filter_curl_exact_500_bytes`)
all still pass — non-JSON truncation behavior is unchanged.