### PR TITLE
fix, add correct copilot init cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,11 @@ rtk gain        # Should show token savings stats
 
 ```bash
 # 1. Install for your AI tool
-rtk init -g                     # Claude Code / Copilot (default)
+rtk init -g                     # Claude Code (default)
 rtk init -g --gemini            # Gemini CLI
 rtk init -g --codex             # Codex (OpenAI)
 rtk init -g --agent cursor      # Cursor
+rtk init -g --copilot           # Copilot
 rtk init --agent windsurf       # Windsurf
 rtk init --agent cline          # Cline / Roo Code
 rtk init --agent kilocode       # Kilo Code


### PR DESCRIPTION


## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->
`rtk init -g` initializes Claude Code.
If the user doesn't have Claude Code installed, it will fail because the `~/.claude` folder is not found.

-

## Test plan
<!-- How did you verify this works? -->

- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
