### PR TITLE
feat(hook): add Kiro CLI agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ rtk init --agent windsurf       # Windsurf
 rtk init --agent cline          # Cline / Roo Code
 rtk init --agent kilocode       # Kilo Code
 rtk init --agent antigravity    # Google Antigravity
+rtk init -g --agent kiro-cli    # Kiro CLI
 
 # 2. Restart your AI tool, then test
 git status  # Automatically rewritten to rtk git status
@@ -350,7 +351,7 @@ rtk git status
 
 ## Supported AI Tools
 
-RTK supports 12 AI coding tools. Each integration transparently rewrites shell commands to `rtk` equivalents for 60-90% token savings.
+RTK supports 13 AI coding tools. Each integration transparently rewrites shell commands to `rtk` equivalents for 60-90% token savings.
 
 | Tool | Install | Method |
 |------|---------|--------|
@@ -367,6 +368,7 @@ RTK supports 12 AI coding tools. Each integration transparently rewrites shell c
 | **Mistral Vibe** | Planned ([#800](https://github.com/rtk-ai/rtk/issues/800)) | Blocked on upstream |
 | **Kilo Code** | `rtk init --agent kilocode` | .kilocode/rules/rtk-rules.md (project-scoped) |
 | **Google Antigravity** | `rtk init --agent antigravity` | .agents/rules/antigravity-rtk-rules.md (project-scoped) |
+| **Kiro CLI** | `rtk init -g --agent kiro-cli` | Steering + preToolUse deny-with-suggestion hook |
 
 For per-agent setup details, override controls, and graceful degradation, see the [Supported Agents guide](https://www.rtk-ai.app/guide/getting-started/supported-agents).
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -40,6 +40,7 @@ Each agent subdirectory has its own README with hook-specific details:
 - **[`windsurf/`](windsurf/README.md)** — Rules file (prompt-level), `.windsurfrules` workspace-scoped
 - **[`codex/`](codex/README.md)** — Awareness document, `AGENTS.md` integration, `$CODEX_HOME` or `~/.codex/` location
 - **[`opencode/`](opencode/README.md)** — TypeScript plugin, `zx` library, `tool.execute.before` event, in-place mutation
+- **[`kiro/`](kiro/README.md)** — Steering file + agent config with `preToolUse` deny-with-suggestion hook, `~/.kiro/` location
 
 ## Supported Agents
 
@@ -54,6 +55,7 @@ Each agent subdirectory has its own README with hook-specific details:
 | Windsurf | Custom instructions (rules file) | Prompt-level guidance | N/A |
 | Codex CLI | AGENTS.md / instructions | Prompt-level guidance | N/A |
 | OpenCode | TypeScript plugin (`tool.execute.before`) | In-place mutation | Yes |
+| Kiro CLI | Steering + Rust binary (`rtk hook kiro`) | Deny-with-suggestion | No (agent retries) |
 
 ## JSON Formats by Agent
 
@@ -155,6 +157,21 @@ if (rewritten && rewritten !== command) {
   (args as Record<string, unknown>).command = rewritten
 }
 ```
+
+### Kiro CLI (Rust Binary)
+
+**Input** (stdin):
+```json
+{
+  "hook_event_name": "preToolUse",
+  "tool_name": "shell",
+  "tool_input": { "command": "git status" }
+}
+```
+
+**Output** (deny-with-suggestion — no `updatedInput` support):
+- Exit 0: Allow (command already uses rtk, or no RTK equivalent)
+- Exit 2 + stderr: `Command should use rtk for token savings. Use: rtk git status`
 
 ## Command Rewrite Registry
 

--- a/hooks/kiro/README.md
+++ b/hooks/kiro/README.md
@@ -1,0 +1,13 @@
+# Kiro CLI Hooks
+
+> Part of [`hooks/`](../README.md) — see also [`src/hooks/`](../../src/hooks/README.md) for installation code
+
+## Specifics
+
+- Two-layer integration: steering file (prompt-level) + `preToolUse` hook (deny-with-suggestion enforcement)
+- `rules.md` contains the instruction to prefix all shell commands with `rtk`, usage examples, and meta commands
+- Installed to `~/.kiro/steering/rtk-rules.md` (global) by `rtk init -g --agent kiro-cli`
+- Installed to `.kiro/steering/rtk-rules.md` (project-local) by `rtk init --agent kiro-cli`
+- Agent config with `preToolUse` hook installed to `~/.kiro/agents/rtk-hook.json` (global) or `.kiro/agents/rtk-hook.json` (project)
+- Hook matches `execute_bash` and `shell` tools, runs `rtk hook kiro` to deny-with-suggestion for rewritable commands
+- Kiro CLI automatically loads all `.md` files from `~/.kiro/steering/` into every conversation context

--- a/hooks/kiro/rules.md
+++ b/hooks/kiro/rules.md
@@ -1,0 +1,32 @@
+# RTK - Rust Token Killer (Kiro CLI)
+
+**Usage**: Token-optimized CLI proxy for shell commands.
+
+## Rule
+
+Always prefix shell commands with `rtk` to minimize token consumption.
+
+Examples:
+
+```bash
+rtk git status
+rtk cargo test
+rtk ls src/
+rtk grep "pattern" src/
+rtk find "*.rs" .
+rtk docker ps
+rtk gh pr list
+```
+
+## Meta Commands
+
+```bash
+rtk gain              # Show token savings
+rtk gain --history    # Command history with savings
+rtk discover          # Find missed RTK opportunities
+rtk proxy <cmd>       # Run raw (no filtering, for debugging)
+```
+
+## Why
+
+RTK filters and compresses command output before it reaches the LLM context, saving 60-90% tokens on common operations. Always use `rtk <cmd>` instead of raw commands.

--- a/src/core/telemetry.rs
+++ b/src/core/telemetry.rs
@@ -360,6 +360,7 @@ fn detect_hook_type() -> String {
         (home.join(".gemini/hooks/rtk-hook.sh"), "gemini"),
         (home.join(".codex/AGENTS.md"), "codex"),
         (home.join(".cursor/hooks/rtk-rewrite.json"), "cursor"),
+        (home.join(".kiro/steering/rtk-rules.md"), "kiro"),
     ];
 
     for (path, name) in &checks {
@@ -571,7 +572,7 @@ mod tests {
         assert!(stats.low_savings_commands.len() <= 5);
         assert!((0.0..=100.0).contains(&stats.avg_savings_per_command));
         assert!(
-            ["claude", "gemini", "codex", "cursor", "none", "unknown"]
+            ["claude", "gemini", "codex", "cursor", "kiro", "none", "unknown"]
                 .iter()
                 .any(|&h| stats.hook_type.starts_with(h)),
             "Unexpected hook type: {}",
@@ -583,7 +584,8 @@ mod tests {
     fn test_detect_hook_type_returns_known() {
         let ht = detect_hook_type();
         assert!(
-            ["claude", "gemini", "codex", "cursor", "none", "unknown"].contains(&ht.as_str()),
+            ["claude", "gemini", "codex", "cursor", "kiro", "none", "unknown"]
+                .contains(&ht.as_str()),
             "Unexpected hook type: {}",
             ht
         );

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -30,6 +30,7 @@ LLM agent integration layer that installs, validates, and executes command-rewri
 | Cline | `rtk init --agent cline` | `.clinerules` | -- |
 | Codex | `rtk init --codex` | RTK.md in `$CODEX_HOME` or `~/.codex` | AGENTS.md |
 | Cursor | `rtk init -g --agent cursor` | Cursor hook | hooks.json |
+| Kiro CLI | `rtk init -g --agent kiro-cli` | Steering + agent config | -- |
 
 
 ## Integrity Verification
@@ -87,6 +88,7 @@ Rules are loaded from all Claude Code `settings.json` files (project + global, i
 | Gemini CLI (rtk hook gemini) | No (allow/deny only) | allow (limitation — no ask mode in Gemini) |
 | Copilot CLI (rtk hook copilot) | No updatedInput | deny-with-suggestion (unchanged) |
 | Codex | ask parsed but no-op | allow (limitation — fails open) |
+| Kiro CLI (rtk hook kiro) | No updatedInput | deny-with-suggestion (agent retries) |
 
 ### Implementation
 

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -17,3 +17,4 @@ pub const OPENCODE_PLUGIN_PATH: &str = ".config/opencode/plugins/rtk.ts";
 pub const CURSOR_DIR: &str = ".cursor";
 pub const CODEX_DIR: &str = ".codex";
 pub const GEMINI_DIR: &str = ".gemini";
+pub const KIRO_DIR: &str = ".kiro";

--- a/src/hooks/hook_check.rs
+++ b/src/hooks/hook_check.rs
@@ -5,7 +5,9 @@ use super::constants::{
     SETTINGS_JSON,
 };
 #[cfg(test)]
-use super::constants::{CODEX_DIR, CURSOR_DIR, GEMINI_DIR, GEMINI_HOOK_FILE, OPENCODE_PLUGIN_PATH};
+use super::constants::{
+    CODEX_DIR, CURSOR_DIR, GEMINI_DIR, GEMINI_HOOK_FILE, KIRO_DIR, OPENCODE_PLUGIN_PATH,
+};
 use crate::core::constants::RTK_DATA_DIR;
 use std::path::PathBuf;
 
@@ -146,6 +148,7 @@ fn other_integration_installed(home: &std::path::Path) -> bool {
         home.join(GEMINI_DIR)
             .join(HOOKS_SUBDIR)
             .join(GEMINI_HOOK_FILE),
+        home.join(KIRO_DIR).join("steering").join("rtk-rules.md"),
     ];
     paths.iter().any(|p| p.exists())
 }
@@ -253,6 +256,19 @@ mod tests {
             .join(GEMINI_HOOK_FILE);
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::fs::write(&path, b"hook").unwrap();
+        assert!(other_integration_installed(tmp.path()));
+    }
+
+    #[test]
+    fn test_other_integration_kiro() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp
+            .path()
+            .join(KIRO_DIR)
+            .join("steering")
+            .join("rtk-rules.md");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"rules").unwrap();
         assert!(other_integration_installed(tmp.path()));
     }
 

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -506,6 +506,101 @@ fn run_cursor_inner_with_rules(
     }
 }
 
+// ── Kiro CLI hook ──────────────────────────────────────────────
+
+/// Run the Kiro CLI preToolUse hook.
+/// Deny-with-suggestion: blocks rewritable commands (exit 2 + stderr) so the LLM retries with `rtk`.
+pub fn run_kiro() -> Result<()> {
+    let input = read_stdin_limited()?;
+
+    let input = input.trim();
+    if input.is_empty() {
+        return Ok(());
+    }
+
+    let v: Value = match serde_json::from_str(input) {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+
+    let tool_name = v.get("tool_name").and_then(|t| t.as_str()).unwrap_or("");
+    if !matches!(tool_name, "execute_bash" | "shell") {
+        return Ok(());
+    }
+
+    let cmd = match v
+        .pointer("/tool_input/command")
+        .and_then(|c| c.as_str())
+        .filter(|c| !c.is_empty())
+    {
+        Some(c) => c,
+        None => return Ok(()),
+    };
+
+    if cmd.starts_with("rtk ") || cmd == "rtk" {
+        return Ok(());
+    }
+
+    if permissions::check_command(cmd) == PermissionVerdict::Deny {
+        audit_log("deny", cmd, "");
+        return Ok(());
+    }
+
+    match get_rewritten(cmd) {
+        Some(ref rewritten) => {
+            audit_log("rewrite", cmd, rewritten);
+            let _ = writeln!(
+                io::stderr(),
+                "Command should use rtk for token savings. Use: {}",
+                rewritten
+            );
+            std::process::exit(2);
+        }
+        None => {
+            audit_log("skip:no_match", cmd, "");
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+fn run_kiro_inner(input: &str) -> (Option<String>, bool) {
+    let v: Value = match serde_json::from_str(input) {
+        Ok(v) => v,
+        Err(_) => return (None, false),
+    };
+
+    let tool_name = v.get("tool_name").and_then(|t| t.as_str()).unwrap_or("");
+    if !matches!(tool_name, "execute_bash" | "shell") {
+        return (None, false);
+    }
+
+    let cmd = match v
+        .pointer("/tool_input/command")
+        .and_then(|c| c.as_str())
+        .filter(|c| !c.is_empty())
+    {
+        Some(c) => c,
+        None => return (None, false),
+    };
+
+    if cmd.starts_with("rtk ") || cmd == "rtk" {
+        return (None, false);
+    }
+
+    match get_rewritten(cmd) {
+        Some(rewritten) => {
+            let msg = format!(
+                "Command should use rtk for token savings. Use: {}",
+                rewritten
+            );
+            (Some(msg), true)
+        }
+        None => (None, false),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -904,5 +999,65 @@ mod tests {
             get_rewritten("cargo test").is_some(),
             "cargo test should be rewritable when not denied"
         );
+    }
+
+    // --- Kiro CLI hook ---
+
+    fn kiro_input(tool: &str, cmd: &str) -> String {
+        serde_json::json!({
+            "hook_event_name": "preToolUse",
+            "tool_name": tool,
+            "tool_input": { "command": cmd }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn test_kiro_rewritable_command_blocked() {
+        let (msg, blocked) = run_kiro_inner(&kiro_input("shell", "git status"));
+        assert!(blocked, "rewritable command should be blocked");
+        assert!(msg.unwrap().contains("rtk git status"));
+    }
+
+    #[test]
+    fn test_kiro_already_rtk_passthrough() {
+        let (msg, blocked) = run_kiro_inner(&kiro_input("shell", "rtk git status"));
+        assert!(!blocked);
+        assert!(msg.is_none());
+    }
+
+    #[test]
+    fn test_kiro_non_rewritable_allowed() {
+        let (msg, blocked) = run_kiro_inner(&kiro_input("shell", "echo hello"));
+        assert!(!blocked);
+        assert!(msg.is_none());
+    }
+
+    #[test]
+    fn test_kiro_empty_command_passthrough() {
+        let (msg, blocked) = run_kiro_inner(&kiro_input("shell", ""));
+        assert!(!blocked);
+        assert!(msg.is_none());
+    }
+
+    #[test]
+    fn test_kiro_non_bash_tool_passthrough() {
+        let (msg, blocked) = run_kiro_inner(&kiro_input("fs_read", "git status"));
+        assert!(!blocked);
+        assert!(msg.is_none());
+    }
+
+    #[test]
+    fn test_kiro_malformed_json_passthrough() {
+        let (msg, blocked) = run_kiro_inner("not json at all");
+        assert!(!blocked);
+        assert!(msg.is_none());
+    }
+
+    #[test]
+    fn test_kiro_execute_bash_tool_also_works() {
+        let (msg, blocked) = run_kiro_inner(&kiro_input("execute_bash", "cargo test"));
+        assert!(blocked, "execute_bash should also be intercepted");
+        assert!(msg.unwrap().contains("rtk cargo test"));
     }
 }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -1405,6 +1405,69 @@ fn run_antigravity_mode_at(base_dir: &Path, verbose: u8) -> Result<()> {
     Ok(())
 }
 
+// ─── Kiro CLI support ───────────────────────────────────────────
+
+const KIRO_RULES: &str = include_str!("../../hooks/kiro/rules.md");
+
+pub fn run_kiro_mode(global: bool, verbose: u8) -> Result<()> {
+    let base = if global {
+        dirs::home_dir().context("Cannot determine home directory")?
+    } else {
+        std::env::current_dir().context("Cannot determine current directory")?
+    };
+    run_kiro_mode_at(&base, verbose)
+}
+
+fn run_kiro_mode_at(base_dir: &Path, verbose: u8) -> Result<()> {
+    let kiro_dir = base_dir.join(".kiro");
+
+    // 1. Install steering file
+    let steering_dir = kiro_dir.join("steering");
+    fs::create_dir_all(&steering_dir).context("Failed to create .kiro/steering directory")?;
+    let rules_path = steering_dir.join("rtk-rules.md");
+    write_if_changed(&rules_path, KIRO_RULES, "Kiro CLI steering rules", verbose)?;
+
+    // 2. Install agent config with preToolUse hook
+    let agents_dir = kiro_dir.join("agents");
+    fs::create_dir_all(&agents_dir).context("Failed to create .kiro/agents directory")?;
+    let agent_config = serde_json::json!({
+        "name": "rtk-hook",
+        "description": "RTK token savings hook — blocks non-rtk commands with suggestions",
+        "hooks": {
+            "preToolUse": [
+                {
+                    "matcher": "execute_bash",
+                    "command": "rtk hook kiro"
+                },
+                {
+                    "matcher": "shell",
+                    "command": "rtk hook kiro"
+                }
+            ]
+        }
+    });
+    let agent_path = agents_dir.join("rtk-hook.json");
+    let agent_content = serde_json::to_string_pretty(&agent_config).unwrap();
+    write_if_changed(
+        &agent_path,
+        &agent_content,
+        "Kiro CLI agent config",
+        verbose,
+    )?;
+
+    let scope = if base_dir == dirs::home_dir().unwrap_or_default() {
+        "global"
+    } else {
+        "project"
+    };
+    println!("\nKiro CLI RTK integration installed ({scope}).\n");
+    println!("  Steering: {}", rules_path.display());
+    println!("  Agent config: {}", agent_path.display());
+    println!("  Restart Kiro CLI. Test with: git status\n");
+
+    Ok(())
+}
+
 fn run_codex_mode(global: bool, verbose: u8) -> Result<()> {
     let (agents_md_path, rtk_md_path) = if global {
         let codex_dir = resolve_codex_dir()?;
@@ -2955,6 +3018,50 @@ More notes
         run_antigravity_mode_at(temp.path(), 0).unwrap();
         let second = fs::read_to_string(&path).unwrap();
         assert_eq!(first, second, "Idempotent: content should not change");
+    }
+
+    #[test]
+    fn test_kiro_mode_creates_steering_file() {
+        let temp = TempDir::new().unwrap();
+        run_kiro_mode_at(temp.path(), 0).unwrap();
+
+        let rules_path = temp.path().join(".kiro/steering/rtk-rules.md");
+        assert!(rules_path.exists(), "Steering file should be created");
+        let content = fs::read_to_string(&rules_path).unwrap();
+        assert!(content.contains("RTK"), "Steering file should contain RTK");
+    }
+
+    #[test]
+    fn test_kiro_mode_creates_agent_config() {
+        let temp = TempDir::new().unwrap();
+        run_kiro_mode_at(temp.path(), 0).unwrap();
+
+        let agent_path = temp.path().join(".kiro/agents/rtk-hook.json");
+        assert!(agent_path.exists(), "Agent config should be created");
+        let content = fs::read_to_string(&agent_path).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(v["name"], "rtk-hook");
+        assert!(v["hooks"]["preToolUse"].is_array());
+    }
+
+    #[test]
+    fn test_kiro_mode_is_idempotent() {
+        let temp = TempDir::new().unwrap();
+        run_kiro_mode_at(temp.path(), 0).unwrap();
+
+        let rules = temp.path().join(".kiro/steering/rtk-rules.md");
+        let agent = temp.path().join(".kiro/agents/rtk-hook.json");
+        let first_rules = fs::read_to_string(&rules).unwrap();
+        let first_agent = fs::read_to_string(&agent).unwrap();
+
+        run_kiro_mode_at(temp.path(), 0).unwrap();
+        let second_rules = fs::read_to_string(&rules).unwrap();
+        let second_agent = fs::read_to_string(&agent).unwrap();
+        assert_eq!(first_rules, second_rules, "Idempotent: steering unchanged");
+        assert_eq!(
+            first_agent, second_agent,
+            "Idempotent: agent config unchanged"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,8 @@ pub enum AgentTarget {
     Kilocode,
     /// Google Antigravity
     Antigravity,
+    /// Kiro CLI
+    KiroCli,
 }
 
 #[derive(Parser)]
@@ -759,6 +761,8 @@ enum HookCommands {
     Gemini,
     /// Process Copilot preToolUse hook (VS Code + Copilot CLI, reads JSON from stdin)
     Copilot,
+    /// Process Kiro CLI preToolUse hook (reads JSON from stdin)
+    Kiro,
     /// Check how a command would be rewritten by the hook engine (dry-run)
     Check {
         /// Target agent
@@ -1785,6 +1789,8 @@ fn run_cli() -> Result<i32> {
                     );
                 }
                 hooks::init::run_antigravity_mode(cli.verbose)?;
+            } else if agent == Some(AgentTarget::KiroCli) {
+                hooks::init::run_kiro_mode(global, cli.verbose)?;
             } else {
                 let install_opencode = opencode;
                 let install_claude = !opencode;
@@ -2114,6 +2120,10 @@ fn run_cli() -> Result<i32> {
             }
             HookCommands::Copilot => {
                 hooks::hook_cmd::run_copilot()?;
+                0
+            }
+            HookCommands::Kiro => {
+                hooks::hook_cmd::run_kiro()?;
                 0
             }
             HookCommands::Check { agent: _, command } => {


### PR DESCRIPTION
## Summary

Two-layer integration for Kiro CLI: steering file for prompt-level guidance + preToolUse hook for deny-with-suggestion enforcement.

## Changes

- Add `KiroCli` variant to `AgentTarget` enum (`rtk init --agent kiro-cli`)
- Add `run_kiro()` hook processor using deny-with-suggestion pattern (exit 2 + stderr for rewritable commands, exit 0 otherwise)
- Add `run_kiro_mode()` installer for both global (`-g`) and project scope
- Install steering to `~/.kiro/steering/rtk-rules.md`
- Install agent config to `~/.kiro/agents/rtk-hook.json` with preToolUse hooks matching `execute_bash` and `shell` tools
- Add Kiro to `detect_hook_type()` telemetry and `hook_check`
- Add `kiro` to telemetry test allowed hook types

## Testing

- 11 new tests (7 hook processor + 3 init + 1 hook_check)
- `cargo fmt --all --check` ✅
- `cargo clippy --all-targets` ✅ (0 new warnings)
- `cargo test` ✅ (1617 passed, 0 failed)
- Manual: verified `rtk hook kiro` intercepts and suggests correctly