### PR TITLE
fix(go): report failure when build produces unrecognized error output

### DIFF
--- a/src/cmds/go/go_cmd.rs
+++ b/src/cmds/go/go_cmd.rs
@@ -572,6 +572,23 @@ pub(crate) fn filter_go_build(output: &str) -> String {
     }
 
     if errors.is_empty() {
+        let has_unrecognized_output = output.lines().any(|l| {
+            let t = l.trim();
+            if t.is_empty() || t.starts_with('#') {
+                return false;
+            }
+            let lower = t.to_lowercase();
+            if lower.starts_with("go: downloading ")
+                || lower.starts_with("go: finding ")
+                || lower.starts_with("go: extracting ")
+            {
+                return false;
+            }
+            true
+        });
+        if has_unrecognized_output {
+            return format!("Go build: Failed\n{}", output.trim());
+        }
         return "Go build: Success".to_string();
     }
 
@@ -972,6 +989,22 @@ go: cannot load module missing listed in go.work file: open missing/go.mod: no s
         assert!(result.contains("go.mod file not found in current directory or any parent directory"));
         assert!(result.contains("no Go files in /tmp/example"));
         assert!(result.contains("go: cannot load module missing listed in go.work file"));
+    }
+
+    #[test]
+    fn test_filter_go_build_unrecognized_error_not_swallowed() {
+        let output = "stat /some/path/cmd/orator: directory not found\n";
+        let result = filter_go_build(output);
+        assert!(
+            result.contains("Failed"),
+            "Should report failure, got: {}",
+            result
+        );
+        assert!(
+            result.contains("directory not found"),
+            "Should preserve raw error, got: {}",
+            result
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `filter_go_build()` now reports "Go build: Failed" with raw output preserved when `go build` produces unrecognized non-empty output that doesn't match any known error or progress pattern
- Previously, unrecognized errors were silently dropped and the filter reported "Go build: Success" despite exit code 1

## Problem

`filter_go_build()` determined success purely by scanning for known error patterns. When `go build` failed with an error that didn't match any pattern (e.g. `stat ...: directory not found` for an invalid package path), the filter swallowed the error and reported success.

A successful `go build` produces no output (or only `go: downloading ...` progress lines). Any other unrecognized output indicates an error the filter doesn't understand — it should be passed through, not hidden.

## Changes

- `src/cmds/go/go_cmd.rs`: When `errors.is_empty()`, check if output contains unrecognized non-empty lines (excluding download/progress/header lines). If so, report "Go build: Failed" with the raw output.
- Added test `test_filter_go_build_unrecognized_error_not_swallowed`

## Test plan

- [x] `cargo test test_filter_go_build` — all 7 tests pass
- [x] `rtk go build -o /tmp/test ./cmd/nonexistent` → "Go build: Failed" + actual error
- [x] `rtk go build -o /tmp/test .` (valid path) → "Go build: Success"
- [x] Download-only output still reports success (existing test)

Fixes #1599