### PR TITLE
feat(discover): wire xcodebuild into rewriter registry (#1551)

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1933,6 +1933,34 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_classify_xcodebuild() {
+        assert!(matches!(
+            classify_command("xcodebuild build -project Foo.xcodeproj"),
+            Classification::Supported {
+                rtk_equivalent: "rtk xcodebuild",
+                category: "Build",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_rewrite_xcodebuild() {
+        assert_eq!(
+            rewrite_command("xcodebuild build -project Foo.xcodeproj", &[]),
+            Some("rtk xcodebuild build -project Foo.xcodeproj".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_xcodebuild_test() {
+        assert_eq!(
+            rewrite_command("xcodebuild test -scheme MyApp -destination 'platform=iOS Simulator,name=iPhone 15'", &[]),
+            Some("rtk xcodebuild test -scheme MyApp -destination 'platform=iOS Simulator,name=iPhone 15'".into())
+        );
+    }
+
     // --- #336: docker compose supported subcommands rewritten, unsupported skipped ---
 
     #[test]

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -789,6 +789,15 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
+        pattern: r"^xcodebuild\b",
+        rtk_cmd: "rtk xcodebuild",
+        rewrite_prefixes: &["xcodebuild"],
+        category: "Build",
+        savings_pct: 85.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
+    RtkRule {
         pattern: r"^systemctl\s+status\b",
         rtk_cmd: "rtk systemctl",
         rewrite_prefixes: &["systemctl"],


### PR DESCRIPTION
The xcodebuild TOML filter has existed since v0.30.0 but the rewriter registry had no matching entry. `rtk rewrite "xcodebuild build -project Foo.xcodeproj"` exits 1 (no RTK equivalent), so Claude Code hooks never route xcodebuild through the filter and `rtk discover` shows xcodebuild invocations as missed savings even when the filter is active.

The fix is a single registry rule: pattern `^xcodebuild\b`, rtk_cmd `rtk xcodebuild`, category Build, 85% savings (consistent with other build tools that eliminate verbose compiler noise). This wires the existing filter into the rewriter the same way swift, systemctl, yamllint, etc. are wired.

Closes #1551