### PR TITLE
feat(hermes): add Hermes Agent support via rtk init --agent hermes

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,13 @@ rtk init --agent windsurf       # Windsurf
 rtk init --agent cline          # Cline / Roo Code
 rtk init --agent kilocode       # Kilo Code
 rtk init --agent antigravity    # Google Antigravity
+rtk init --agent hermes         # Hermes
 
 # 2. Restart your AI tool, then test
 git status  # Automatically rewritten to rtk git status
 ```
 
-The hook transparently rewrites Bash commands (e.g., `git status` -> `rtk git status`) before execution. Claude never sees the rewrite, it just gets compressed output.
+Hook-based agents rewrite Bash commands (e.g., `git status` -> `rtk git status`) before execution. Plugin-based agents, including Hermes, use their plugin API to rewrite commands before execution. The agent receives compact output without needing to call `rtk` explicitly.
 
 **Important:** the hook only runs on Bash tool calls. Claude Code built-in tools like `Read`, `Grep`, and `Glob` do not pass through the Bash hook, so they are not auto-rewritten. To get RTK's compact output for those workflows, use shell commands (`cat`/`head`/`tail`, `rg`/`grep`, `find`) or call `rtk read`, `rtk grep`, or `rtk find` directly.
 
@@ -350,7 +351,7 @@ rtk git status
 
 ## Supported AI Tools
 
-RTK supports 12 AI coding tools. Each integration transparently rewrites shell commands to `rtk` equivalents for 60-90% token savings.
+RTK supports 13 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents for 60-90% token savings where the agent supports command interception.
 
 | Tool | Install | Method |
 |------|---------|--------|
@@ -364,6 +365,7 @@ RTK supports 12 AI coding tools. Each integration transparently rewrites shell c
 | **Cline / Roo Code** | `rtk init --agent cline` | .clinerules (project-scoped) |
 | **OpenCode** | `rtk init -g --opencode` | Plugin TS (tool.execute.before) |
 | **OpenClaw** | `openclaw plugins install ./openclaw` | Plugin TS (before_tool_call) |
+| **Hermes** | `rtk init --agent hermes` | Python plugin (terminal command mutation via `rtk rewrite`) |
 | **Mistral Vibe** | Planned ([#800](https://github.com/rtk-ai/rtk/issues/800)) | Blocked on upstream |
 | **Kilo Code** | `rtk init --agent kilocode` | .kilocode/rules/rtk-rules.md (project-scoped) |
 | **Google Antigravity** | `rtk init --agent antigravity` | .agents/rules/antigravity-rtk-rules.md (project-scoped) |

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -1,6 +1,6 @@
 ---
 title: Supported Agents
-description: How to integrate RTK with Claude Code, Cursor, Copilot, Cline, Windsurf, Codex, OpenCode, Kilo Code, and Antigravity
+description: How to integrate RTK with Claude Code, Cursor, Copilot, Cline, Windsurf, Codex, OpenCode, Hermes, Kilo Code, and Antigravity
 sidebar:
   order: 3
 ---
@@ -35,6 +35,7 @@ Agent runs "cargo test"
 | Gemini CLI | Rust binary (`BeforeTool`) | Yes |
 | OpenCode | TypeScript plugin (`tool.execute.before`) | Yes |
 | OpenClaw | TypeScript plugin (`before_tool_call`) | Yes |
+| Hermes | Python plugin (`terminal` command mutation) | Yes |
 | Cline / Roo Code | Rules file (prompt-level) | N/A |
 | Windsurf | Rules file (prompt-level) | N/A |
 | Codex CLI | AGENTS.md instructions | N/A |
@@ -92,6 +93,16 @@ openclaw plugins install ./openclaw
 
 Plugin in the `openclaw/` directory. Uses the `before_tool_call` hook, delegates to `rtk rewrite`.
 
+### Hermes
+
+```bash
+rtk init --agent hermes
+```
+
+Creates `~/.hermes/plugins/rtk-rewrite/` and enables it through `plugins.enabled` in the Hermes config. Hermes loads Python plugins, so the plugin entrypoint is Python, but it is only a thin adapter. It mutates the Hermes `terminal` tool `command` before execution and delegates all rewrite decisions to Rust through `rtk rewrite`.
+
+The plugin fails open. If `rtk` is missing, `rtk rewrite` errors, the tool is not `terminal`, the payload has no string `command`, or the plugin raises an exception, Hermes runs the original command unchanged. The same `rtk rewrite` limitations apply: already-prefixed `rtk` commands, compound shell commands, heredocs, and commands without filters are not rewritten.
+
 ### Cline / Roo Code
 
 ```bash
@@ -137,7 +148,7 @@ Support is blocked on upstream `BeforeToolCallback` ([mistral-vibe#531](https://
 | Tier | Mechanism | How rewrites work |
 |------|-----------|------------------|
 | **Full hook** | Shell script or Rust binary, intercepts via agent API | Transparent — agent never sees the raw command |
-| **Plugin** | TypeScript/JS in agent's plugin system | Transparent — in-place mutation |
+| **Plugin** | TypeScript, JavaScript, or Python in agent's plugin system | Transparent, in-place mutation when the agent allows it |
 | **Rules file** | Prompt-level instructions | Guidance only — agent is told to prefer `rtk <cmd>` |
 
 Rules file integrations (Cline, Windsurf, Codex, Kilo Code, Antigravity) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it.

--- a/hermes/README.md
+++ b/hermes/README.md
@@ -1,0 +1,33 @@
+# RTK Plugin for Hermes
+
+Rewrites Hermes `terminal` tool commands to RTK equivalents before execution, so Hermes receives compact command output without changing your workflow.
+
+## Installation
+
+```bash
+rtk init --agent hermes
+```
+
+The installer writes the plugin to `~/.hermes/plugins/rtk-rewrite/` and enables it through `plugins.enabled` in the Hermes config.
+
+## How it works
+
+Hermes loads plugins from Python, so the plugin entrypoint is Python. The Python code is only a thin Hermes adapter. It reads the Hermes terminal tool payload, calls `rtk rewrite` for the actual command decision, then mutates the terminal tool `command` before Hermes executes it.
+
+All rewrite rules stay in Rust inside `rtk rewrite`. When RTK adds or changes command rewrite behavior, the Hermes plugin picks up that behavior by delegating to the RTK binary.
+
+## Fail-open behavior
+
+The plugin does not block command execution. If anything goes wrong, Hermes runs the original command unchanged.
+
+- `rtk` is missing from `PATH`
+- `rtk rewrite` exits with an error
+- Hermes sends a non-terminal tool call
+- The tool payload has no string `command`
+- The plugin raises an unexpected exception
+
+## Limitations
+
+- Only Hermes `terminal` tool calls are rewritten.
+- Commands skipped by `rtk rewrite` stay unchanged, including commands already prefixed with `rtk`, compound shell commands, heredocs, and commands without an RTK filter.
+- Shell hooks are not used for Hermes command rewriting. The integration depends on Hermes loading Python plugins and passing a mutable terminal tool payload.

--- a/hermes/rtk-rewrite/__init__.py
+++ b/hermes/rtk-rewrite/__init__.py
@@ -1,0 +1,43 @@
+"""Hermes plugin adapter for RTK command rewriting.
+
+All rewrite logic lives in RTK's Rust ``rtk rewrite`` command; this module
+only bridges Hermes ``pre_tool_call`` payloads to that command and fails open.
+"""
+
+import subprocess
+
+
+ACCEPTED_REWRITE_RETURN_CODES = {0, 3}
+
+
+def register(ctx):
+    """Register the Hermes pre-tool callback."""
+    ctx.register_hook("pre_tool_call", _pre_tool_call)
+
+
+def _pre_tool_call(tool_name=None, args=None, **_kwargs):
+    """Rewrite mutable Hermes terminal command args when RTK provides a change."""
+    try:
+        if tool_name != "terminal" or not isinstance(args, dict):
+            return
+
+        command = args.get("command")
+        if not isinstance(command, str) or not command.strip():
+            return
+
+        result = subprocess.run(
+            ["rtk", "rewrite", command],
+            shell=False,
+            timeout=2,
+            capture_output=True,
+            text=True,
+        )
+
+        if result.returncode not in ACCEPTED_REWRITE_RETURN_CODES:
+            return
+
+        rewritten = result.stdout.strip()
+        if rewritten and rewritten != command:
+            args["command"] = rewritten
+    except Exception:
+        return

--- a/hermes/rtk-rewrite/plugin.yaml
+++ b/hermes/rtk-rewrite/plugin.yaml
@@ -1,0 +1,8 @@
+name: rtk-rewrite
+version: "0.1.0"
+description: Rewrite Hermes terminal commands through RTK before execution.
+author: RTK Contributors
+hooks:
+  - pre_tool_call
+provides_hooks:
+  - pre_tool_call

--- a/hermes/tests/test_rtk_rewrite_plugin.py
+++ b/hermes/tests/test_rtk_rewrite_plugin.py
@@ -1,0 +1,238 @@
+import importlib.util
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+PLUGIN_PATH = Path(__file__).resolve().parents[1] / "rtk-rewrite" / "__init__.py"
+
+
+class FakeContext:
+    def __init__(self):
+        self.hooks = {}
+
+    def register_hook(self, hook_name, callback):
+        self.hooks[hook_name] = callback
+
+
+class FakeCompletedProcess:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def load_plugin_module(path=PLUGIN_PATH, module_name="rtk_rewrite_plugin"):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load Hermes plugin from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_fake_rtk(bin_dir):
+    fake_rtk = bin_dir / "rtk"
+    fake_rtk.write_text(
+        "\n".join(
+            [
+                f"#!{sys.executable}",
+                "import sys",
+                "if sys.argv[1:] == ['rewrite', 'git status']:",
+                "    print('rtk git status')",
+                "    raise SystemExit(0)",
+                "print('unexpected rtk args:', sys.argv[1:], file=sys.stderr)",
+                "raise SystemExit(1)",
+                "",
+            ]
+        )
+    )
+    fake_rtk.chmod(fake_rtk.stat().st_mode | stat.S_IXUSR)
+    return fake_rtk
+
+
+class RtkRewritePluginTest(unittest.TestCase):
+    def load_callback(self):
+        module = load_plugin_module()
+        ctx = FakeContext()
+
+        module.register(ctx)
+
+        self.assertIn("pre_tool_call", ctx.hooks)
+        return module, ctx.hooks["pre_tool_call"]
+
+    def test_rewrite_success_mutates_same_terminal_args_dict(self):
+        module, callback = self.load_callback()
+        args = {"command": "git status"}
+
+        with mock.patch.object(
+            module.subprocess,
+            "run",
+            return_value=FakeCompletedProcess(stdout="rtk git status\n"),
+        ):
+            callback(tool_name="terminal", args=args)
+
+        self.assertEqual({"command": "rtk git status"}, args)
+
+    def test_rewrite_returncode_three_mutates_same_terminal_args_dict(self):
+        module, callback = self.load_callback()
+        args = {"command": "git status"}
+
+        with mock.patch.object(
+            module.subprocess,
+            "run",
+            return_value=FakeCompletedProcess(returncode=3, stdout="rtk git status\n"),
+        ):
+            callback(tool_name="terminal", args=args)
+
+        self.assertEqual({"command": "rtk git status"}, args)
+
+    def test_file_not_found_preserves_original_command(self):
+        module, callback = self.load_callback()
+        args = {"command": "git status"}
+
+        with mock.patch.object(module.subprocess, "run", side_effect=FileNotFoundError):
+            callback(tool_name="terminal", args=args)
+
+        self.assertEqual({"command": "git status"}, args)
+
+    def test_non_accepted_returncodes_preserve_original_command(self):
+        for returncode in (1, 2, 4):
+            with self.subTest(returncode=returncode):
+                module, callback = self.load_callback()
+                args = {"command": "git status"}
+
+                with mock.patch.object(
+                    module.subprocess,
+                    "run",
+                    return_value=FakeCompletedProcess(
+                        returncode=returncode,
+                        stdout="rtk git status\n",
+                    ),
+                ):
+                    callback(tool_name="terminal", args=args)
+
+                self.assertEqual({"command": "git status"}, args)
+
+    def test_non_terminal_tool_is_noop(self):
+        module, callback = self.load_callback()
+        args = {"command": "git status"}
+
+        with mock.patch.object(module.subprocess, "run") as run:
+            callback(tool_name="read_file", args=args)
+
+        run.assert_not_called()
+        self.assertEqual({"command": "git status"}, args)
+
+    def test_missing_command_is_noop(self):
+        module, callback = self.load_callback()
+        args = {}
+
+        with mock.patch.object(module.subprocess, "run") as run:
+            callback(tool_name="terminal", args=args)
+
+        run.assert_not_called()
+        self.assertEqual({}, args)
+
+    def test_non_string_command_is_noop(self):
+        module, callback = self.load_callback()
+        args = {"command": ["git", "status"]}
+
+        with mock.patch.object(module.subprocess, "run") as run:
+            callback(tool_name="terminal", args=args)
+
+        run.assert_not_called()
+        self.assertEqual({"command": ["git", "status"]}, args)
+
+    def test_empty_command_strings_are_noop(self):
+        for command in ("", "   ", "\t\n"):
+            with self.subTest(command=command):
+                module, callback = self.load_callback()
+                args = {"command": command}
+
+                with mock.patch.object(module.subprocess, "run") as run:
+                    callback(tool_name="terminal", args=args)
+
+                run.assert_not_called()
+                self.assertEqual({"command": command}, args)
+
+    def test_empty_or_unchanged_rewrite_output_preserves_original_command(self):
+        for stdout in ("", "\n", "git status\n"):
+            with self.subTest(stdout=stdout):
+                module, callback = self.load_callback()
+                args = {"command": "git status"}
+
+                with mock.patch.object(
+                    module.subprocess,
+                    "run",
+                    return_value=FakeCompletedProcess(stdout=stdout),
+                ):
+                    callback(tool_name="terminal", args=args)
+
+                self.assertEqual({"command": "git status"}, args)
+
+
+class InstalledRtkRewritePluginTest(unittest.TestCase):
+    @unittest.skipUnless(shutil.which("cargo"), "cargo is required for installed flow")
+    def test_cargo_init_installs_importable_plugin_that_rewrites_with_fake_rtk(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        real_home = Path(os.path.expanduser("~"))
+
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as bin_dir:
+            home_path = Path(home)
+            fake_bin = Path(bin_dir)
+            write_fake_rtk(fake_bin)
+
+            env = os.environ.copy()
+            env["HOME"] = str(home_path)
+            env["PATH"] = str(fake_bin) + os.pathsep + env.get("PATH", "")
+            env["RTK_TELEMETRY_DISABLED"] = "1"
+            env["CARGO_TERM_COLOR"] = "never"
+            env.setdefault("RUSTUP_TOOLCHAIN", "stable")
+            if "RUSTUP_HOME" not in env and (real_home / ".rustup").exists():
+                env["RUSTUP_HOME"] = str(real_home / ".rustup")
+            if "CARGO_HOME" not in env and (real_home / ".cargo").exists():
+                env["CARGO_HOME"] = str(real_home / ".cargo")
+            env.pop("RTK_CLAUDE_DIR", None)
+
+            result = subprocess.run(
+                ["cargo", "run", "--quiet", "--", "init", "--agent", "hermes"],
+                cwd=repo_root,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+
+            self.assertEqual(
+                0,
+                result.returncode,
+                msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+            )
+
+            plugin_dir = home_path / ".hermes" / "plugins" / "rtk-rewrite"
+            init_path = plugin_dir / "__init__.py"
+            manifest_path = plugin_dir / "plugin.yaml"
+            self.assertTrue(init_path.exists(), "installed plugin __init__.py must exist")
+            self.assertTrue(manifest_path.exists(), "installed plugin.yaml must exist")
+
+            module = load_plugin_module(init_path, "installed_rtk_rewrite_plugin")
+            ctx = FakeContext()
+            module.register(ctx)
+            callback = ctx.hooks["pre_tool_call"]
+
+            args = {"command": "git status"}
+            with mock.patch.dict(os.environ, {"PATH": env["PATH"]}):
+                callback(tool_name="terminal", args=args)
+
+            self.assertEqual({"command": "rtk git status"}, args)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -1405,6 +1405,236 @@ fn run_antigravity_mode_at(base_dir: &Path, verbose: u8) -> Result<()> {
     Ok(())
 }
 
+// ─── Hermes support ────────────────────────────────────────────
+
+const HERMES_PLUGIN_INIT: &str = include_str!("../../hermes/rtk-rewrite/__init__.py");
+const HERMES_PLUGIN_YAML: &str = include_str!("../../hermes/rtk-rewrite/plugin.yaml");
+const HERMES_PLUGIN_NAME: &str = "rtk-rewrite";
+
+pub fn run_hermes_mode(verbose: u8) -> Result<()> {
+    let hermes_home = resolve_home_subdir(".hermes")?;
+    run_hermes_mode_at(&hermes_home, verbose)
+}
+
+fn run_hermes_mode_at(hermes_home: &Path, verbose: u8) -> Result<()> {
+    let plugin_dir = hermes_home.join("plugins").join(HERMES_PLUGIN_NAME);
+    fs::create_dir_all(&plugin_dir).with_context(|| {
+        format!(
+            "Failed to create Hermes plugin directory: {}",
+            plugin_dir.display()
+        )
+    })?;
+
+    let init_path = plugin_dir.join("__init__.py");
+    let manifest_path = plugin_dir.join("plugin.yaml");
+    write_if_changed(&init_path, HERMES_PLUGIN_INIT, "Hermes plugin", verbose)?;
+    write_if_changed(
+        &manifest_path,
+        HERMES_PLUGIN_YAML,
+        "Hermes plugin manifest",
+        verbose,
+    )?;
+
+    let config_path = hermes_home.join("config.yaml");
+    let existing_config = if config_path.exists() {
+        fs::read_to_string(&config_path)
+            .with_context(|| format!("Failed to read Hermes config: {}", config_path.display()))?
+    } else {
+        String::new()
+    };
+    let patched_config = patch_hermes_config(&existing_config);
+    write_if_changed(&config_path, &patched_config, "Hermes config", verbose)?;
+
+    println!("\nRTK configured for Hermes.\n");
+    println!("  Plugin: {}", plugin_dir.display());
+    println!("  Config: {}", config_path.display());
+    println!("  Hermes will now rewrite terminal commands through rtk.");
+    println!("  Restart Hermes. Test with: git status\n");
+
+    Ok(())
+}
+
+fn patch_hermes_config(existing: &str) -> String {
+    if existing.trim().is_empty() {
+        return hermes_plugins_block();
+    }
+
+    let mut lines = split_yaml_lines(existing);
+    let Some(plugins_idx) = find_yaml_key_line(&lines, "plugins", 0, None) else {
+        return append_hermes_plugins_block(existing);
+    };
+
+    let plugins_indent = yaml_indent(&lines[plugins_idx]);
+    let plugins_end = yaml_block_end(&lines, plugins_idx, plugins_indent);
+    let Some(enabled_idx) = find_yaml_key_line(
+        &lines,
+        "enabled",
+        plugins_idx + 1,
+        Some((plugins_end, plugins_indent)),
+    ) else {
+        let enabled_block = format!(
+            "{}enabled:\n{}  - {}\n",
+            " ".repeat(plugins_indent + 2),
+            " ".repeat(plugins_indent + 2),
+            HERMES_PLUGIN_NAME
+        );
+        lines.insert(plugins_end, enabled_block);
+        return lines.concat();
+    };
+
+    if yaml_line_without_ending(&lines[enabled_idx]).contains('[') {
+        patch_inline_hermes_enabled(&mut lines, enabled_idx);
+        return lines.concat();
+    }
+
+    patch_block_hermes_enabled(&mut lines, enabled_idx);
+    lines.concat()
+}
+
+fn split_yaml_lines(input: &str) -> Vec<String> {
+    if input.is_empty() {
+        Vec::new()
+    } else {
+        input.split_inclusive('\n').map(str::to_string).collect()
+    }
+}
+
+fn hermes_plugins_block() -> String {
+    format!("plugins:\n  enabled:\n    - {}\n", HERMES_PLUGIN_NAME)
+}
+
+fn append_hermes_plugins_block(existing: &str) -> String {
+    let mut patched = existing.to_string();
+    if !patched.ends_with('\n') {
+        patched.push('\n');
+    }
+    patched.push_str(&hermes_plugins_block());
+    patched
+}
+
+fn find_yaml_key_line(
+    lines: &[String],
+    key: &str,
+    start: usize,
+    block: Option<(usize, usize)>,
+) -> Option<usize> {
+    let end = block.map_or(lines.len(), |(end, _)| end);
+    let min_indent = block.map(|(_, indent)| indent);
+
+    lines[start..end]
+        .iter()
+        .enumerate()
+        .find_map(|(offset, line)| {
+            let raw = yaml_line_without_ending(line);
+            let trimmed = raw.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                return None;
+            }
+
+            if min_indent.is_some_and(|indent| yaml_indent(line) <= indent) {
+                return None;
+            }
+
+            let is_key = trimmed == format!("{key}:") || trimmed.starts_with(&format!("{key}:"));
+            is_key.then_some(start + offset)
+        })
+}
+
+fn yaml_block_end(lines: &[String], start: usize, parent_indent: usize) -> usize {
+    lines[start + 1..]
+        .iter()
+        .enumerate()
+        .find_map(|(offset, line)| {
+            let raw = yaml_line_without_ending(line);
+            let trimmed = raw.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                return None;
+            }
+
+            (yaml_indent(line) <= parent_indent).then_some(start + 1 + offset)
+        })
+        .unwrap_or(lines.len())
+}
+
+fn patch_inline_hermes_enabled(lines: &mut [String], enabled_idx: usize) {
+    let raw = yaml_line_without_ending(&lines[enabled_idx]);
+    let indent = yaml_indent(&lines[enabled_idx]);
+    let values = raw
+        .split_once(':')
+        .map(|(_, value)| value.trim())
+        .unwrap_or_default();
+    let items = values
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .map(|value| {
+            value
+                .split(',')
+                .filter_map(normalized_yaml_scalar)
+                .filter(|item| item != HERMES_PLUGIN_NAME)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let mut replacement = format!("{}enabled:\n", " ".repeat(indent));
+    for item in items {
+        replacement.push_str(&format!("{}- {}\n", " ".repeat(indent + 2), item));
+    }
+    replacement.push_str(&format!(
+        "{}- {}\n",
+        " ".repeat(indent + 2),
+        HERMES_PLUGIN_NAME
+    ));
+    lines[enabled_idx] = replacement;
+}
+
+fn patch_block_hermes_enabled(lines: &mut Vec<String>, enabled_idx: usize) {
+    let enabled_indent = yaml_indent(&lines[enabled_idx]);
+    let enabled_end = yaml_block_end(lines, enabled_idx, enabled_indent);
+    let rtk_entry = format!(
+        "{}- {}\n",
+        " ".repeat(enabled_indent + 2),
+        HERMES_PLUGIN_NAME
+    );
+
+    let mut patched = Vec::with_capacity(lines.len() + 1);
+    patched.extend_from_slice(&lines[..=enabled_idx]);
+    patched.extend(
+        lines[enabled_idx + 1..enabled_end]
+            .iter()
+            .filter(|line| !is_yaml_list_item_named(line, HERMES_PLUGIN_NAME))
+            .cloned(),
+    );
+    patched.push(rtk_entry);
+    patched.extend_from_slice(&lines[enabled_end..]);
+    *lines = patched;
+}
+
+fn yaml_line_without_ending(line: &str) -> &str {
+    line.trim_end_matches(['\r', '\n'])
+}
+
+fn yaml_indent(line: &str) -> usize {
+    yaml_line_without_ending(line)
+        .chars()
+        .take_while(|ch| ch.is_whitespace())
+        .count()
+}
+
+fn is_yaml_list_item_named(line: &str, expected: &str) -> bool {
+    let trimmed = yaml_line_without_ending(line).trim();
+    let Some(item) = trimmed.strip_prefix("- ") else {
+        return false;
+    };
+
+    normalized_yaml_scalar(item).is_some_and(|item| item == expected)
+}
+
+fn normalized_yaml_scalar(value: &str) -> Option<String> {
+    let without_comment = value.split_once('#').map_or(value, |(item, _)| item);
+    let trimmed = without_comment.trim().trim_matches(['\'', '"']);
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
 fn run_codex_mode(global: bool, verbose: u8) -> Result<()> {
     let (agents_md_path, rtk_md_path) = if global {
         let codex_dir = resolve_codex_dir()?;
@@ -2955,6 +3185,78 @@ More notes
         run_antigravity_mode_at(temp.path(), 0).unwrap();
         let second = fs::read_to_string(&path).unwrap();
         assert_eq!(first, second, "Idempotent: content should not change");
+    }
+
+    #[test]
+    fn test_hermes_mode_creates_plugin_files() {
+        let temp = TempDir::new().unwrap();
+        run_hermes_mode_at(temp.path(), 0).unwrap();
+
+        let plugin_dir = temp.path().join("plugins/rtk-rewrite");
+        let init_path = plugin_dir.join("__init__.py");
+        let manifest_path = plugin_dir.join("plugin.yaml");
+        let config_path = temp.path().join("config.yaml");
+
+        assert!(init_path.exists(), "Python plugin should be created");
+        assert!(manifest_path.exists(), "Plugin manifest should be created");
+        assert_eq!(
+            fs::read_to_string(&init_path).unwrap(),
+            include_str!("../../hermes/rtk-rewrite/__init__.py")
+        );
+        assert_eq!(
+            fs::read_to_string(&manifest_path).unwrap(),
+            include_str!("../../hermes/rtk-rewrite/plugin.yaml")
+        );
+
+        let config = fs::read_to_string(&config_path).unwrap();
+        assert!(config.contains("plugins:\n"));
+        assert!(config.contains("  enabled:\n"));
+        assert_eq!(config.matches("rtk-rewrite").count(), 1);
+    }
+
+    #[test]
+    fn test_hermes_mode_preserves_config_and_is_idempotent() {
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join("config.yaml");
+        fs::write(
+            &config_path,
+            "theme: dark\nplugins:\n  enabled:\n    - existing-plugin\n  search_path: ./plugins\nother: true\n",
+        )
+        .unwrap();
+
+        run_hermes_mode_at(temp.path(), 0).unwrap();
+        let first = fs::read_to_string(&config_path).unwrap();
+        run_hermes_mode_at(temp.path(), 0).unwrap();
+        let second = fs::read_to_string(&config_path).unwrap();
+
+        assert_eq!(first, second, "Hermes config patch should be idempotent");
+        assert!(first.contains("theme: dark\n"));
+        assert!(first.contains("    - existing-plugin\n"));
+        assert!(first.contains("  search_path: ./plugins\n"));
+        assert!(first.contains("other: true\n"));
+        assert_eq!(first.matches("rtk-rewrite").count(), 1);
+    }
+
+    #[test]
+    fn test_hermes_config_patch_adds_missing_enabled_list() {
+        let existing = "theme: dark\nplugins:\n  search_path: ./plugins\nother: true\n";
+        let patched = patch_hermes_config(existing);
+
+        assert!(patched.contains("theme: dark\n"));
+        assert!(patched.contains("plugins:\n"));
+        assert!(patched.contains("  search_path: ./plugins\n"));
+        assert!(patched.contains("  enabled:\n    - rtk-rewrite\n"));
+        assert!(patched.contains("other: true\n"));
+        assert_eq!(patched.matches("rtk-rewrite").count(), 1);
+    }
+
+    #[test]
+    fn test_hermes_config_patch_removes_duplicate_rtk_rewrite() {
+        let existing = "plugins:\n  enabled:\n    - rtk-rewrite\n    - other\n    - rtk-rewrite\n";
+        let patched = patch_hermes_config(existing);
+
+        assert!(patched.contains("    - other\n"));
+        assert_eq!(patched.matches("rtk-rewrite").count(), 1);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,8 @@ pub enum AgentTarget {
     Kilocode,
     /// Google Antigravity
     Antigravity,
+    /// Hermes CLI
+    Hermes,
 }
 
 #[derive(Parser)]
@@ -1785,6 +1787,8 @@ fn run_cli() -> Result<i32> {
                     );
                 }
                 hooks::init::run_antigravity_mode(cli.verbose)?;
+            } else if agent == Some(AgentTarget::Hermes) {
+                hooks::init::run_hermes_mode(cli.verbose)?;
             } else {
                 let install_opencode = opencode;
                 let install_claude = !opencode;
@@ -2566,6 +2570,17 @@ mod tests {
     fn test_try_parse_valid_git_status() {
         let result = Cli::try_parse_from(["rtk", "git", "status"]);
         assert!(result.is_ok(), "git status should parse successfully");
+    }
+
+    #[test]
+    fn test_try_parse_init_agent_hermes() {
+        let cli = Cli::try_parse_from(["rtk", "init", "--agent", "hermes"]).unwrap();
+        match cli.command {
+            Commands::Init { agent, .. } => {
+                assert_eq!(agent, Some(AgentTarget::Hermes));
+            }
+            _ => panic!("Expected Init command"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add first-class RTK support for Hermes Agent through `rtk init --agent hermes`.

- Install a Hermes Python plugin that rewrites `terminal` tool commands to RTK equivalents before execution.
- Keep rewrite decisions centralized in Rust by delegating to `rtk rewrite`, so Hermes gets the same command coverage and safety behavior as other RTK integrations.

## Behavior

- `rtk init --agent hermes` installs the plugin under `~/.hermes/plugins/rtk-rewrite/` and enables it in `~/.hermes/config.yaml`.
- The plugin handles Hermes `pre_tool_call` events, mutates the terminal `command` in place when RTK returns a rewrite, and fails open if RTK is unavailable or no rewrite applies.
- Hermes permission checks still run against the final command before execution.

## Files Changed

| File | Description |
|------|-------------|
| `src/hooks/init.rs` | Add `hermes` agent init handler (plugin install + config) |
| `src/main.rs` | Wire `Agent::Hermes` into CLI |
| `hermes/rtk-rewrite/` | Python plugin (rewrite logic) |
| `hermes/tests/` | Unit tests |
| `hermes/README.md` | Plugin docs |
| `README.md`, `docs/` | Add Hermes to supported agents list |

## Verification

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test --all`
- [x] `python3 -m unittest discover -s hermes -p '*test*.py'`
- [x] Local install smoke test: `rtk init --agent hermes` → verified `git status` rewrites to `rtk git status`

Supersedes #1559 (clean branch from develop).