### PR TITLE
fix(git): distinguish stash push no-op from successful stash (#1535)

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -1463,9 +1463,19 @@ fn run_stash(
             let combined = result.combined();
 
             let msg = if result.success() {
-                let msg = format!("ok stash {}", sub);
-                println!("{}", msg);
-                msg
+                // `git stash push` exits 0 even when no stash entry is created
+                // (e.g. clean tree, or pathspecs that match nothing). The generic
+                // "ok stash push" message hid that case and led to lost WIP in
+                // #1535 — surface it explicitly instead.
+                if sub == "push" && stash_push_is_noop(&combined) {
+                    let msg = "noop stash push (no local changes)".to_string();
+                    println!("{}", msg);
+                    msg
+                } else {
+                    let msg = format!("ok stash {}", sub);
+                    println!("{}", msg);
+                    msg
+                }
             } else {
                 eprintln!("FAILED: git stash {}", sub);
                 if !result.stderr.trim().is_empty() {
@@ -1555,6 +1565,13 @@ fn run_stash(
     }
 
     Ok(0)
+}
+
+/// Detect the "git stash push" no-op case where git exits 0 but did not
+/// actually create a stash entry. Covers both an entirely clean tree and
+/// pathspec-restricted invocations whose pathspecs matched nothing.
+fn stash_push_is_noop(combined: &str) -> bool {
+    combined.contains("No local changes to save")
 }
 
 fn filter_stash_list(output: &str) -> String {
@@ -2002,6 +2019,25 @@ mod tests {
             main_count,
             result
         );
+    }
+
+    #[test]
+    fn test_stash_push_is_noop_detects_no_local_changes() {
+        // Real `git stash push` output on a clean tree: stdout-only, exit 0.
+        assert!(stash_push_is_noop("No local changes to save\n"));
+        // Same message can appear when restricted by a pathspec that matched nothing.
+        assert!(stash_push_is_noop(
+            "error: pathspec 'missing.txt' did not match any file(s) known to git\nNo local changes to save\n"
+        ));
+    }
+
+    #[test]
+    fn test_stash_push_is_noop_negative_for_real_stash() {
+        // A successful stash creation does not contain the no-op marker.
+        assert!(!stash_push_is_noop(
+            "Saved working directory and index state WIP on main: abc1234 fix login\n"
+        ));
+        assert!(!stash_push_is_noop(""));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`git stash push` exits 0 even when **no stash entry is created** — for example on a clean tree, or when pathspec-restricted invocations match nothing. rtk's generic `ok stash push` collapsed that no-op into the same message it prints for a real stash, which led to lost WIP in the report at #1535 (the user assumed work had been preserved that wasn't).

This change keeps the success-case wire format users rely on, but adds a distinct `noop stash push (no local changes)` line for the no-op case so callers and AI agents can tell whether anything was actually stashed.

## Repro before

```
$ cd /clean/repo
$ rtk -vv git stash push -m "test"
git stash Some("push")
ok stash push      # ← misleading — nothing was stashed
$ echo \$?
0
```

## After

```
$ rtk -vv git stash push -m "test"
git stash Some("push")
noop stash push (no local changes)
$ echo \$?
0
```

A real change still produces the existing `ok stash push` message; the failure path (bad pathspec with real changes elsewhere) still produces `FAILED: git stash push` with a non-zero exit code.

## Notes on Repro 1 (exit 0 on bad pathspec)

The reporter's first repro (exit 0 when the underlying git fails) does not reproduce on current master — `result.exit_code` already propagates correctly through the `pop`/`apply`/`drop`/`push` arm of `run_stash`. I verified this against rtk@master with `git stash push DOES_NOT_EXIST.txt` on a tree with real changes elsewhere: rtk now exits 1 and prints `FAILED: git stash push`. So this PR focuses on Repro 2, which is still present.

## Scope

Only the `Some("pop") | Some("apply") | Some("drop") | Some("push")` arm in `run_stash` is touched. The `None` arm (default `git stash`) already detects "No local changes" separately, and the unrecognized-subcommand and `list`/`show` arms have no equivalent no-op semantics.

## Test plan

- [x] New unit tests cover `stash_push_is_noop` against real `git stash push` output (clean tree, and pathspec-only no-op).
- [x] Manual verification on a local repo:
  - clean tree: prints `noop stash push (no local changes)`, exit 0
  - bad pathspec with real changes elsewhere: prints `FAILED: git stash push`, exit 1
  - real change: prints `ok stash push`, exit 0
- [x] \`cargo fmt --all && cargo clippy --all-targets && cargo test --all\` passes (1689 tests, 0 new warnings).

Closes #1535