### PR TITLE
fix(rewrite): leave pipe groups raw end-to-end (#1560)

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -462,8 +462,8 @@ fn collapse_line_continuations(s: &str) -> std::borrow::Cow<'_, str> {
 /// Returns `None` if the command is unsupported or ignored (hook should pass through).
 ///
 /// Handles compound commands (`&&`, `||`, `;`) by rewriting each segment independently.
-/// For pipes (`|`), only rewrites the left-hand command (pipe targets stay raw),
-/// but continues rewriting segments after subsequent `&&`/`||`/`;` operators.
+/// For pipes (`|`), leaves the whole pipe group raw, but continues rewriting
+/// segments after subsequent `&&`/`||`/`;` operators.
 /// Also strips user-configured transparent wrapper prefixes
 /// (`[hooks].transparent_prefixes` in `config.toml`) before routing.
 ///
@@ -557,21 +557,15 @@ fn rewrite_compound(
                 }
             }
             TokenKind::Pipe => {
+                // Never rewrite the left-hand side of a pipe (#1560). RTK
+                // filters reformat output (compress, group, drop columns) and
+                // can silently break downstream consumers like grep, awk, jq,
+                // wc — see the `ps aux | grep python | grep -v grep` repro,
+                // and the older find/fd carve-outs that motivated #439. The
+                // safest behavior across the whole filter set is to leave
+                // every pipe group raw end-to-end.
                 let seg = cmd[seg_start..tok.offset].trim();
-                let is_pipe_incompatible = seg.starts_with("find ")
-                    || seg == "find"
-                    || seg.starts_with("fd ")
-                    || seg == "fd";
-                let rewritten = if is_pipe_incompatible {
-                    seg.to_string()
-                } else {
-                    rewrite_segment(seg, excluded, transparent_prefixes)
-                        .unwrap_or_else(|| seg.to_string())
-                };
-                if rewritten != seg {
-                    any_changed = true;
-                }
-                result.push_str(&rewritten);
+                result.push_str(seg);
 
                 let pipe_group_end = tokens.iter().find(|t| {
                     t.offset > tok.offset
@@ -1488,18 +1482,26 @@ mod tests {
     }
 
     #[test]
-    fn test_rewrite_pipe_first_only() {
-        // After a pipe, the filter command stays raw
+    fn test_rewrite_pipe_left_side_stays_raw() {
+        // RTK filters reformat output and can silently break downstream pipe
+        // consumers like grep, awk, jq (#1560: `rtk ps aux | grep python`
+        // returns nothing because rtk reformats `ps`). Leaving the entire pipe
+        // group raw is the safe default across the whole filter set.
         assert_eq!(
             rewrite_command_no_prefixes("git log -10 | grep feat", &[]),
-            Some("rtk git log -10 | grep feat".into())
+            None
         );
+        assert_eq!(
+            rewrite_command_no_prefixes("ps aux | grep python | grep -v grep", &[]),
+            None
+        );
+        assert_eq!(rewrite_command_no_prefixes("ls -la | head", &[]), None);
     }
 
     #[test]
     fn test_rewrite_find_pipe_skipped() {
-        // find in a pipe should NOT be rewritten — rtk find output format
-        // is incompatible with pipe consumers like xargs (#439)
+        // find in a pipe stays raw — same reasoning as #1560 above; this case
+        // (#439) was the original carve-out that motivated the rule.
         assert_eq!(
             rewrite_command_no_prefixes("find . -name '*.rs' | xargs grep 'fn run'", &[]),
             None
@@ -1511,6 +1513,16 @@ mod tests {
         assert_eq!(
             rewrite_command_no_prefixes("find src -type f | wc -l", &[]),
             None
+        );
+    }
+
+    #[test]
+    fn test_rewrite_pipe_in_compound_keeps_pipe_group_raw_only() {
+        // `cmd1 && piped_group && cmd2` rewrites the non-piped segments but
+        // leaves the entire pipe group end-to-end raw.
+        assert_eq!(
+            rewrite_command_no_prefixes("git status && ps aux | grep python && cargo test", &[]),
+            Some("rtk git status && ps aux | grep python && rtk cargo test".into()),
         );
     }
 
@@ -1679,9 +1691,11 @@ mod tests {
 
     #[test]
     fn test_rewrite_redirect_2_gt_amp_1_with_pipe() {
+        // #1560: pipe LHS stays raw (rtk filters reformat output and break
+        // downstream consumers like grep/head/awk).
         assert_eq!(
             rewrite_command_no_prefixes("cargo test 2>&1 | head", &[]),
-            Some("rtk cargo test 2>&1 | head".into())
+            None
         );
     }
 
@@ -3302,18 +3316,19 @@ mod tests {
 
     #[test]
     fn test_rewrite_compound_pipe_raw_filter() {
-        // Pipe: rewrite first segment only, pass through rest unchanged
+        // #1560: pipe groups stay raw end-to-end.
         assert_eq!(
             rewrite_command_no_prefixes("cargo test | grep FAILED", &[]),
-            Some("rtk cargo test | grep FAILED".into())
+            None
         );
     }
 
     #[test]
     fn test_rewrite_compound_pipe_git_grep() {
+        // #1560: pipe groups stay raw end-to-end.
         assert_eq!(
             rewrite_command_no_prefixes("git log -10 | grep feat", &[]),
-            Some("rtk git log -10 | grep feat".into())
+            None
         );
     }
 
@@ -4043,11 +4058,14 @@ mod tests {
 
     // --- Pipe + operator rewrite ---
 
+    // #1560: pipe groups stay raw end-to-end. Non-piped segments around a
+    // pipe group are still rewritten when the operator separates them.
+
     #[test]
     fn test_rewrite_pipe_then_and() {
         assert_eq!(
             rewrite_command_no_prefixes("git log | head -5 && git stash", &[]),
-            Some("rtk git log | head -5 && rtk git stash".into())
+            Some("git log | head -5 && rtk git stash".into())
         );
     }
 
@@ -4055,7 +4073,7 @@ mod tests {
     fn test_rewrite_pipe_then_semicolon() {
         assert_eq!(
             rewrite_command_no_prefixes("cargo test | head; git status", &[]),
-            Some("rtk cargo test | head; rtk git status".into())
+            Some("cargo test | head; rtk git status".into())
         );
     }
 
@@ -4063,7 +4081,7 @@ mod tests {
     fn test_rewrite_pipe_then_or() {
         assert_eq!(
             rewrite_command_no_prefixes("cargo test | grep FAIL || git stash", &[]),
-            Some("rtk cargo test | grep FAIL || rtk git stash".into())
+            Some("cargo test | grep FAIL || rtk git stash".into())
         );
     }
 
@@ -4074,7 +4092,7 @@ mod tests {
                 "RUST_BACKTRACE=1 cargo test 2>&1 | grep FAILED && git stash",
                 &[]
             ),
-            Some("RUST_BACKTRACE=1 rtk cargo test 2>&1 | grep FAILED && rtk git stash".into())
+            Some("RUST_BACKTRACE=1 cargo test 2>&1 | grep FAILED && rtk git stash".into())
         );
     }
 
@@ -4082,7 +4100,7 @@ mod tests {
     fn test_rewrite_and_then_pipe() {
         assert_eq!(
             rewrite_command_no_prefixes("git status && cargo test | grep FAIL", &[]),
-            Some("rtk git status && rtk cargo test | grep FAIL".into())
+            Some("rtk git status && cargo test | grep FAIL".into())
         );
     }
 
@@ -4090,7 +4108,7 @@ mod tests {
     fn test_rewrite_multi_pipe_then_and() {
         assert_eq!(
             rewrite_command_no_prefixes("git log | head | tail && git status", &[]),
-            Some("rtk git log | head | tail && rtk git status".into())
+            Some("git log | head | tail && rtk git status".into())
         );
     }
 


### PR DESCRIPTION
## Summary

\`rewrite_compound\` only treated \`find\`/\`fd\` as pipe-incompatible (#439) and rewrote every other LHS. RTK filters reformat output — compress, group, drop columns — and silently break downstream pipe consumers. The reported case is

\`\`\`
ps aux | grep python | grep -v grep
\`\`\`

which used to be rewritten to

\`\`\`
rtk ps aux | grep python | grep -v grep
\`\`\`

and returns nothing because \`rtk ps aux\` restructures the output before \`grep\` sees it.

This change generalizes the pipe-incompatible rule: when a segment is followed by a pipe, the entire pipe group stays raw end-to-end. Non-piped segments around a pipe group (separated by \`&&\` / \`||\` / \`;\`) are still rewritten as before, so chained workflows keep their token savings.

## Behavior

Before:
\`\`\`
\$ rtk rewrite 'ps aux | grep python | grep -v grep'
rtk ps aux | grep python | grep -v grep
\$ echo \$?
3
\`\`\`

After:
\`\`\`
\$ rtk rewrite 'ps aux | grep python | grep -v grep'
\$ echo \$?
1   # no rtk equivalent — hook passes through unchanged
\`\`\`

Hook (\`rtk hook claude\`) for the same command produces no \`updatedInput\` after this PR, so Claude Code runs the command verbatim.

Compound commands still rewrite their non-piped halves:
\`\`\`
git status && cargo test | grep FAIL
  → rtk git status && cargo test | grep FAIL    # pipe group raw, &&-segment rewritten
\`\`\`

## Notes

- Several existing tests (\`test_rewrite_pipe_first_only\`, \`test_rewrite_compound_pipe_*\`, \`test_rewrite_*_pipe_*\`, \`test_rewrite_redirect_2_gt_amp_1_with_pipe\`) codified the old \"LHS gets rewritten\" behavior. They are updated to reflect the new safe-by-default rule, with comments pointing back to #1560 and the existing #439 carve-out.
- The find/fd carve-out is no longer special-cased — it falls out of the universal rule.
- New test \`test_rewrite_pipe_in_compound_keeps_pipe_group_raw_only\` pins down the compound-with-pipe semantics.

## Test plan

- [x] All updated and new pipe-related tests pass.
- [x] \`cargo fmt --all && cargo test --all\` passes (1688 tests).
- [x] Manual verification:
  - \`rtk rewrite 'ps aux | grep python | grep -v grep'\` → exit 1, no rewrite
  - \`rtk hook claude\` for same command → no \`updatedInput\` in JSON
  - \`rtk rewrite 'cargo test'\` (no pipe) → \`rtk cargo test\` exit 3 (still works)

Closes #1560