### PR TITLE
fix(filters): remove max_lines cap from helm filter that truncates template output

### DIFF
--- a/src/filters/helm.toml
+++ b/src/filters/helm.toml
@@ -7,7 +7,6 @@ strip_lines_matching = [
   "^W\\d{4}",
 ]
 truncate_lines_at = 120
-max_lines = 40
 
 [[tests.helm]]
 name = "strips blank lines, preserves release info"
@@ -27,3 +26,78 @@ expected = "NAME: my-release\nLAST DEPLOYED: Mon Jan 15 10:30:00 2024\nNAMESPACE
 name = "strips glog W-prefix warnings"
 input = "W0115 10:30:00 warning message from internal\nNAME: my-chart\nSTATUS: deployed"
 expected = "NAME: my-chart\nSTATUS: deployed"
+
+[[tests.helm]]
+name = "helm template output is not truncated"
+input = """
+# Source: my-chart/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-ns
+---
+# Source: my-chart/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+---
+# Source: my-chart/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-cm
+---
+# Source: my-chart/templates/pvc.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: my-pvc
+---
+# Source: my-chart/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-svc
+---
+# Source: my-chart/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deploy
+"""
+expected = """# Source: my-chart/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-ns
+---
+# Source: my-chart/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+---
+# Source: my-chart/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-cm
+---
+# Source: my-chart/templates/pvc.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: my-pvc
+---
+# Source: my-chart/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-svc
+---
+# Source: my-chart/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deploy"""


### PR DESCRIPTION
## Summary

Fixes #1626 — `rtk helm template` silently truncates output to ~40 lines, dropping remaining Kubernetes manifests.

## Root Cause

The helm filter in `src/filters/helm.toml` had `max_lines = 40`. This caps ALL helm output at 40 lines. For short commands like `helm status` this is fine, but `helm template` produces hundreds of lines of YAML manifests that get silently truncated — no warning, no error, exit code 0.

## Fix

Remove `max_lines = 40`. The filter retains its other output hygiene settings:
- `strip_ansi = true` — removes ANSI escape codes
- `strip_lines_matching` — removes blank lines and glog warnings  
- `truncate_lines_at = 120` — truncates individual long lines

These are sufficient. The `max_lines` cap is too aggressive for commands with legitimately long output.

## Testing

Added regression test `"helm template output is not truncated"` that verifies multi-document YAML output (6 Kubernetes manifests) is preserved in full.

All 1687 tests pass. `cargo fmt` and `cargo clippy` clean.

## Impact

Without this fix, CI/CD pipelines that pipe `rtk helm template` output to `kubectl apply` would apply an **incomplete** set of manifests — silently dropping deployments, PVCs, secrets, etc.
