### PR TITLE
fix(hooks/claude): omit permissionDecision under bypassPermissions

### DIFF
--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -339,6 +339,33 @@ enum PayloadAction {
     Ignore,
 }
 
+/// Detect Claude Code's `bypassPermissions` mode from the PreToolUse hook input.
+///
+/// The hook input JSON includes `permission_mode` carrying the active mode
+/// (`default`, `acceptEdits`, `plan`, `bypassPermissions`). Returns `false`
+/// when the field is absent or unrecognized — matches Claude Code's
+/// least-privilege default for unknown payloads.
+fn is_bypass_mode(v: &Value) -> bool {
+    v.get("permission_mode")
+        .and_then(|m| m.as_str())
+        .map(|m| m == "bypassPermissions")
+        .unwrap_or(false)
+}
+
+/// Decide whether to emit `permissionDecision: "allow"` in the Claude hook output.
+///
+/// Auto-allow is an optimization for `default` mode: it pre-approves the
+/// rewritten command so allow-listed users don't re-prompt for the new form.
+///
+/// Under `bypassPermissions`, Claude Code drops `updatedInput` whenever
+/// `permissionDecision` is present in the same `hookSpecificOutput` envelope —
+/// the original command then runs raw and the rewrite silently fails. Since
+/// bypass mode skips prompts already, the auto-allow has nothing to optimize,
+/// so omitting it costs nothing and restores the rewrite path.
+fn should_emit_allow_decision(allow: bool, bypass_mode: bool) -> bool {
+    allow && !bypass_mode
+}
+
 fn process_claude_payload(v: &Value) -> PayloadAction {
     let cmd = match v
         .pointer("/tool_input/command")
@@ -380,7 +407,7 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
         "updatedInput": updated_input
     });
 
-    if allow {
+    if should_emit_allow_decision(allow, is_bypass_mode(v)) {
         hook_output
             .as_object_mut()
             .unwrap()
@@ -949,6 +976,43 @@ mod tests {
     fn test_claude_fd_dup_redirect_still_rewritten() {
         // `2>&1` is attestable — the rewrite proceeds as normal.
         assert!(run_claude_inner(&claude_input("git status 2>&1")).is_some());
+    }
+
+    #[test]
+    fn test_is_bypass_mode_recognizes_bypass_permissions() {
+        let v: Value = serde_json::from_str(
+            r#"{"permission_mode":"bypassPermissions","tool_input":{"command":"git status"}}"#,
+        )
+        .unwrap();
+        assert!(is_bypass_mode(&v));
+    }
+
+    #[test]
+    fn test_is_bypass_mode_treats_other_modes_as_non_bypass() {
+        for mode in ["default", "acceptEdits", "plan", "unknown_future_mode"] {
+            let v: Value = serde_json::from_str(&format!(
+                r#"{{"permission_mode":"{mode}","tool_input":{{"command":"git status"}}}}"#
+            ))
+            .unwrap();
+            assert!(!is_bypass_mode(&v), "{mode} should not count as bypass");
+        }
+    }
+
+    #[test]
+    fn test_is_bypass_mode_absent_field_defaults_to_false() {
+        let v: Value = serde_json::from_str(r#"{"tool_input":{"command":"git status"}}"#).unwrap();
+        assert!(!is_bypass_mode(&v));
+    }
+
+    #[test]
+    fn test_should_emit_allow_decision_truth_table() {
+        // allow + default → emit (the auto-allow optimization)
+        assert!(should_emit_allow_decision(true, false));
+        // allow + bypass → omit (would silently kill updatedInput)
+        assert!(!should_emit_allow_decision(true, true));
+        // non-allow → omit regardless of mode
+        assert!(!should_emit_allow_decision(false, false));
+        assert!(!should_emit_allow_decision(false, true));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Under Claude Code's `bypassPermissions` mode (a.k.a. `--dangerously-skip-permissions`), rtk's PreToolUse hook fires correctly but its rewrites silently never land. The cause is undocumented Claude Code behavior: when `hookSpecificOutput` contains both `updatedInput` and `permissionDecision: "allow"`, Claude Code drops `updatedInput` under bypass. For users with curated permission allow-lists (where `verdict == Allow` is the common case), most rtk rewrites silently fail under bypass.

This patch detects bypass mode from the hook input's `permission_mode` field and omits `permissionDecision` accordingly. Default mode keeps the auto-allow optimization, which does real work there by skipping the re-prompt for the rewritten command.

## Reproducer

`~/.claude/settings.json`:
```json
{
  "permissions": {
    "defaultMode": "bypassPermissions",
    "allow": ["Bash(git status:*)"]
  },
  "hooks": {
    "PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "rtk hook claude"}]}]
  }
}
```

Have an agent invoke an atomic `git status`.

- **Before:** raw 104-byte output (`On branch master / ... / nothing to commit`).
- **After:** rtk's compressed ~50-byte form (`* master...origin/master / clean — nothing to commit`).

Direct hook test:
```bash
echo '{"tool_name":"Bash","permission_mode":"bypassPermissions","tool_input":{"command":"git status"}}' \
  | rtk hook claude | jq .
# After patch: omits permissionDecision; updatedInput.command = "rtk git status".

echo '{"tool_name":"Bash","permission_mode":"default","tool_input":{"command":"git status"}}' \
  | rtk hook claude | jq .
# After patch: includes permissionDecision: "allow" (auto-allow optimization preserved).
```

## What changed

`src/hooks/hook_cmd.rs`:
- `is_bypass_mode(v: &Value) -> bool`: parses `permission_mode` from hook input. Anything other than `"bypassPermissions"` (including absent or unknown values) maps to non-bypass.
- `should_emit_allow_decision(verdict: &PermissionVerdict, bypass_mode: bool) -> bool`: pure helper.
- `process_claude_payload` routes through both.

## Tests

4 new unit tests covering: bypass-mode recognition, non-bypass modes (`default`, `acceptEdits`, `plan`, unknown future), absent field, and the full Allow × bypass / non-Allow × bypass truth table.

`cargo test -- hooks::hook_cmd` passes; `cargo fmt --check` clean; no new clippy warnings.

## Compatibility

- Default mode: unchanged.
- Legacy clients without `permission_mode`: unchanged (defaults to non-bypass).
- Other agent paths (Cursor, Copilot, Gemini): unchanged. The patch only touches `process_claude_payload`.

## How this was discovered

I bisected the hook output fields. With an audit-logging wrapper, I confirmed the hook *is* invoked under bypass; stripping `permissionDecision` from rtk's output made rewrites land. This patch is the in-binary equivalent of that bisection.

Anthropic's hook docs define `permissionDecision` and `updatedInput` as separate fields without specifying their interaction under bypass. A parallel docs issue against Anthropic would help.
