### PR TITLE
feat(cicd): target develop branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "cargo"
+    target-branch: "develop"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -9,9 +10,10 @@ updates:
     open-pull-requests-limit: 5
 
   - package-ecosystem: "github-actions"
+    target-branch: "develop"
     directory: "/"
     schedule:
       interval: "weekly"
     labels:
       - "dependencies"
-      - "ci"
+      - "area:ci"


### PR DESCRIPTION
## Summary
- Make dependabot target develop branch for PRs
- Also use existing `area:ci` label instead of missing one
