### PR TITLE
fix: use blob/master instead of blob/main in telemetry URLs

### DIFF
--- a/src/core/telemetry_cmd.rs
+++ b/src/core/telemetry_cmd.rs
@@ -55,7 +55,7 @@ fn run_status() -> Result<()> {
 
     println!();
     println!("Data controller: RTK AI Labs, contact@rtk-ai.app");
-    println!("Details: https://github.com/rtk-ai/rtk/blob/main/docs/TELEMETRY.md");
+    println!("Details: https://github.com/rtk-ai/rtk/blob/master/docs/TELEMETRY.md");
 
     Ok(())
 }
@@ -73,7 +73,7 @@ fn run_enable() -> Result<()> {
     eprintln!();
     eprintln!("  What:    command names (not arguments), token savings, OS, version");
     eprintln!("  Who:     RTK AI Labs, contact@rtk-ai.app");
-    eprintln!("  Details: https://github.com/rtk-ai/rtk/blob/main/docs/TELEMETRY.md");
+    eprintln!("  Details: https://github.com/rtk-ai/rtk/blob/master/docs/TELEMETRY.md");
     eprintln!();
     eprint!("Enable anonymous telemetry? [y/N] ");
 

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -414,7 +414,7 @@ fn prompt_telemetry_consent() -> Result<()> {
     eprintln!("  Who:     RTK AI Labs, contact@rtk-ai.app");
     eprintln!("  Rights:  disable anytime with `rtk telemetry disable`,");
     eprintln!("           request erasure with `rtk telemetry forget`");
-    eprintln!("  Details: https://github.com/rtk-ai/rtk/blob/main/docs/TELEMETRY.md");
+    eprintln!("  Details: https://github.com/rtk-ai/rtk/blob/master/docs/TELEMETRY.md");
     eprintln!();
     eprint!("Enable anonymous telemetry? [y/N] ");
 


### PR DESCRIPTION
## Summary

Fixes the broken telemetry details URL shown during `rtk init -g`.

The installer prints:
```
Details: https://github.com/rtk-ai/rtk/blob/main/docs/TELEMETRY.md
```

Since the repo's default branch is `master`, this URL 404s. This PR changes all three occurrences to use `blob/master`.

## Changes

- `src/core/telemetry_cmd.rs` (2 lines)
- `src/hooks/init.rs` (1 line)

Closes #1665