### PR TITLE
refactor(json): Single-line output with truncation hints

### DIFF
--- a/src/cmds/cloud/aws_cmd.rs
+++ b/src/cmds/cloud/aws_cmd.rs
@@ -256,7 +256,7 @@ fn run_generic(subcommand: &str, args: &[String], verbose: u8, full_sub: &str) -
         return Ok(crate::core::utils::exit_code_from_output(&output, "aws"));
     }
 
-    let filtered = match json_cmd::filter_json_string(&raw, JSON_COMPRESS_DEPTH) {
+    let filtered = match json_cmd::filter_json_schema(&raw, JSON_COMPRESS_DEPTH) {
         Ok(schema) => {
             println!("{}", schema);
             schema

--- a/src/cmds/system/json_cmd.rs
+++ b/src/cmds/system/json_cmd.rs
@@ -6,6 +6,7 @@ use serde_json::Value;
 use std::fs;
 use std::io::{self, Read};
 use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Reject non-JSON files with a clear error before doing any I/O.
 fn validate_json_extension(file: &Path) -> Result<()> {
@@ -47,12 +48,21 @@ pub fn run(file: &Path, max_depth: usize, schema_only: bool, verbose: u8) -> Res
     let content = fs::read_to_string(file)
         .with_context(|| format!("Failed to read file: {}", file.display()))?;
 
-    let output = if schema_only {
-        filter_json_string(&content, max_depth)?
+    let (output, truncated) = if schema_only {
+        filter_json_schema(&content, max_depth).map(|s| (s, false))?
     } else {
         filter_json_compact(&content, max_depth)?
     };
+
     println!("{}", output);
+
+    if truncated {
+        let value: Value = serde_json::from_str(&content).context("Failed to parse JSON")?;
+        if let Some(hint) = write_json_hint(&value, file) {
+            println!("{}", hint);
+        }
+    }
+
     timer.track(
         &format!("cat {}", file.display()),
         "rtk json",
@@ -76,102 +86,90 @@ pub fn run_stdin(max_depth: usize, schema_only: bool, verbose: u8) -> Result<()>
         .read_to_string(&mut content)
         .context("Failed to read from stdin")?;
 
-    let output = if schema_only {
-        filter_json_string(&content, max_depth)?
+    let (output, truncated) = if schema_only {
+        filter_json_schema(&content, max_depth).map(|s| (s, false))?
     } else {
         filter_json_compact(&content, max_depth)?
     };
+
     println!("{}", output);
+
+    if truncated {
+        let value: Value = serde_json::from_str(&content).context("Failed to parse JSON")?;
+        if let Some(hint) = write_json_hint(&value, Path::new("stdin")) {
+            println!("{}", hint);
+        }
+    }
+
     timer.track("cat - (stdin)", "rtk json -", &content, &output);
     Ok(())
 }
 
 /// Parse a JSON string and return compact representation with values preserved.
 /// Long strings are truncated, arrays are summarized.
-pub fn filter_json_compact(json_str: &str, max_depth: usize) -> Result<String> {
+pub fn filter_json_compact(json_str: &str, max_depth: usize) -> Result<(String, bool)> {
     let value: Value = serde_json::from_str(json_str).context("Failed to parse JSON")?;
-    Ok(compact_json(&value, 0, max_depth))
+    let mut truncated = false;
+    let output = compact_json(&value, 0, max_depth, &mut truncated);
+    Ok((output, truncated))
 }
 
-fn compact_json(value: &Value, depth: usize, max_depth: usize) -> String {
-    let indent = "  ".repeat(depth);
+const STRING_CHARS_LIMIT: usize = 80;
 
+/// Compact JSON output - single-line with truncation tracking.
+fn compact_json(value: &Value, depth: usize, max_depth: usize, truncated: &mut bool) -> String {
     if depth > max_depth {
-        return format!("{}...", indent);
+        *truncated = true;
+        return "…".to_string();
     }
 
     match value {
-        Value::Null => format!("{}null", indent),
-        Value::Bool(b) => format!("{}{}", indent, b),
-        Value::Number(n) => format!("{}{}", indent, n),
+        Value::Null => "null".to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
         Value::String(s) => {
-            if s.len() > 80 {
-                let end = s.floor_char_boundary(77);
-                format!("{}\"{}...\"", indent, &s[..end])
+            if s.chars().count() > STRING_CHARS_LIMIT {
+                *truncated = true;
+                let truncated_str: String = s.chars().take(STRING_CHARS_LIMIT - 1).collect();
+                format!(r#""{}…""#, truncated_str)
             } else {
-                format!("{}\"{}\"", indent, s)
+                format!(r#""{}""#, s)
             }
         }
         Value::Array(arr) => {
             if arr.is_empty() {
-                format!("{}[]", indent)
+                "[]".to_string()
             } else if arr.len() > 5 {
-                let first = compact_json(&arr[0], depth + 1, max_depth);
-                format!("{}[{}, ... +{} more]", indent, first.trim(), arr.len() - 1)
+                *truncated = true;
+                let first = compact_json(&arr[0], depth + 1, max_depth, truncated);
+                format!("[{}, … +{} more]", first, arr.len() - 1)
             } else {
                 let items: Vec<String> = arr
                     .iter()
-                    .map(|v| compact_json(v, depth + 1, max_depth))
+                    .map(|v| compact_json(v, depth + 1, max_depth, truncated))
                     .collect();
-                let all_simple = arr.iter().all(|v| {
-                    matches!(
-                        v,
-                        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_)
-                    )
-                });
-                if all_simple {
-                    let inline: Vec<&str> = items.iter().map(|s| s.trim()).collect();
-                    format!("{}[{}]", indent, inline.join(", "))
-                } else {
-                    let mut lines = vec![format!("{}[", indent)];
-                    for item in &items {
-                        lines.push(format!("{},", item));
-                    }
-                    lines.push(format!("{}]", indent));
-                    lines.join("\n")
-                }
+                format!("[{}]", items.join(","))
             }
         }
         Value::Object(map) => {
             if map.is_empty() {
-                format!("{}{{}}", indent)
+                "{}".to_string()
             } else {
-                let mut lines = vec![format!("{}{{", indent)];
                 let mut keys: Vec<_> = map.keys().collect();
                 keys.sort();
 
+                let mut parts = Vec::new();
                 for (i, key) in keys.iter().enumerate() {
-                    let val = &map[*key];
-                    let is_simple = matches!(
-                        val,
-                        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_)
-                    );
-
-                    if is_simple {
-                        let val_str = compact_json(val, 0, max_depth);
-                        lines.push(format!("{}  {}: {}", indent, key, val_str.trim()));
-                    } else {
-                        lines.push(format!("{}  {}:", indent, key));
-                        lines.push(compact_json(val, depth + 1, max_depth));
-                    }
-
                     if i >= 20 {
-                        lines.push(format!("{}  ... +{} more keys", indent, keys.len() - i - 1));
+                        *truncated = true;
+                        parts.push(format!("… +{} more keys", keys.len() - i));
                         break;
                     }
+                    let val = &map[*key];
+                    let val_str = compact_json(val, depth + 1, max_depth, truncated);
+                    parts.push(format!(r#""{}":{}"#, key, val_str));
                 }
-                lines.push(format!("{}}}", indent));
-                lines.join("\n")
+                format!("{{{}}}", parts.join(","))
             }
         }
     }
@@ -179,97 +177,135 @@ fn compact_json(value: &Value, depth: usize, max_depth: usize) -> String {
 
 /// Parse a JSON string and return its schema representation (types only, no values).
 /// Useful for piping JSON from other commands (e.g., `gh api`, `curl`).
-pub fn filter_json_string(json_str: &str, max_depth: usize) -> Result<String> {
+pub fn filter_json_schema(json_str: &str, max_depth: usize) -> Result<String> {
     let value: Value = serde_json::from_str(json_str).context("Failed to parse JSON")?;
     Ok(extract_schema(&value, 0, max_depth))
 }
 
+/// Schema extraction - single-line output with char-based truncation.
 fn extract_schema(value: &Value, depth: usize, max_depth: usize) -> String {
-    let indent = "  ".repeat(depth);
-
     if depth > max_depth {
-        return format!("{}...", indent);
+        return "…".to_string();
     }
 
     match value {
-        Value::Null => format!("{}null", indent),
-        Value::Bool(_) => format!("{}bool", indent),
+        Value::Null => "null".to_string(),
+        Value::Bool(_) => "bool".to_string(),
         Value::Number(n) => {
             if n.is_i64() {
-                format!("{}int", indent)
+                "int".to_string()
             } else {
-                format!("{}float", indent)
+                "float".to_string()
             }
         }
         Value::String(s) => {
-            if s.len() > 50 {
-                format!("{}string[{}]", indent, s.len())
+            if s.chars().count() > 50 {
+                format!("string[{}]", s.chars().count())
             } else if s.is_empty() {
-                format!("{}string", indent)
+                "string".to_string()
+            } else if s.starts_with("http") {
+                "url".to_string()
+            } else if s.contains('-') && s.len() == 10 {
+                "date?".to_string()
             } else {
-                // Check if it looks like a URL, date, etc.
-                if s.starts_with("http") {
-                    format!("{}url", indent)
-                } else if s.contains('-') && s.len() == 10 {
-                    format!("{}date?", indent)
-                } else {
-                    format!("{}string", indent)
-                }
+                "string".to_string()
             }
         }
         Value::Array(arr) => {
             if arr.is_empty() {
-                format!("{}[]", indent)
+                "[]".to_string()
             } else {
                 let first_schema = extract_schema(&arr[0], depth + 1, max_depth);
-                let trimmed = first_schema.trim();
                 if arr.len() == 1 {
-                    format!("{}[\n{}\n{}]", indent, first_schema, indent)
+                    format!("[{}]", first_schema)
                 } else {
-                    format!("{}[{}] ({})", indent, trimmed, arr.len())
+                    format!("[{}] ({})", first_schema, arr.len())
                 }
             }
         }
         Value::Object(map) => {
             if map.is_empty() {
-                format!("{}{{}}", indent)
+                "{}".to_string()
             } else {
-                let mut lines = vec![format!("{}{{", indent)];
                 let mut keys: Vec<_> = map.keys().collect();
                 keys.sort();
 
+                let mut parts = Vec::new();
                 for (i, key) in keys.iter().enumerate() {
-                    let val = &map[*key];
-                    let val_schema = extract_schema(val, depth + 1, max_depth);
-                    let val_trimmed = val_schema.trim();
-
-                    // Inline simple types
-                    let is_simple = matches!(
-                        val,
-                        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_)
-                    );
-
-                    if is_simple {
-                        if i < keys.len() - 1 {
-                            lines.push(format!("{}  {}: {},", indent, key, val_trimmed));
-                        } else {
-                            lines.push(format!("{}  {}: {}", indent, key, val_trimmed));
-                        }
-                    } else {
-                        lines.push(format!("{}  {}:", indent, key));
-                        lines.push(val_schema);
-                    }
-
-                    // Limit keys shown
                     if i >= 15 {
-                        lines.push(format!("{}  ... +{} more keys", indent, keys.len() - i - 1));
+                        parts.push(format!("… +{} more keys", keys.len() - i));
                         break;
                     }
+                    let val = &map[*key];
+                    let val_schema = extract_schema(val, depth + 1, max_depth);
+                    parts.push(format!(r#""{}":{}"#, key, val_schema));
                 }
-                lines.push(format!("{}}}", indent));
-                lines.join("\n")
+                format!("{{{}}}", parts.join(","))
             }
         }
+    }
+}
+
+/// Write full compact JSON to a file and return a hint string.
+fn write_json_hint(value: &Value, file: &Path) -> Option<String> {
+    let full_output = serde_json::to_string(value).ok()?;
+
+    let json_dir = dirs::data_local_dir()?.join("rtk").join("json");
+    std::fs::create_dir_all(&json_dir).ok()?;
+
+    let epoch = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
+    let file_slug = file.file_name().and_then(|n| n.to_str()).unwrap_or("stdin");
+    let sanitized: String = file_slug
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .take(40)
+        .collect();
+    let filename = format!("{}_{}.json", epoch, sanitized);
+    let filepath = json_dir.join(filename);
+
+    std::fs::write(&filepath, &full_output).ok()?;
+
+    cleanup_old_json_files(&json_dir);
+
+    let hint = if let Some(home) = dirs::home_dir() {
+        if let Ok(relative) = filepath.strip_prefix(&home) {
+            format!("[full output: ~/{}]", relative.display())
+        } else {
+            format!("[full output: {}]", filepath.display())
+        }
+    } else {
+        format!("[full output: {}]", filepath.display())
+    };
+
+    Some(hint)
+}
+
+/// Clean up old JSON full compact files, keeping only the last 20.
+fn cleanup_old_json_files(json_dir: &std::path::Path) {
+    let mut entries: Vec<_> = std::fs::read_dir(json_dir)
+        .ok()
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
+        .filter(|e| e.file_name().to_string_lossy().contains(".json"))
+        .collect();
+
+    if entries.len() <= 20 {
+        return;
+    }
+
+    entries.sort_by_key(|e| e.file_name());
+
+    let to_remove = entries.len() - 20;
+    for entry in entries.iter().take(to_remove) {
+        let _ = std::fs::remove_file(entry.path());
     }
 }
 
@@ -314,42 +350,116 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_schema_simple() {
-        let json: Value = serde_json::from_str(r#"{"name": "test", "count": 42}"#).unwrap();
+    fn test_filter_json_compact_single_line() {
+        let (output, truncated) = filter_json_compact(
+            r#"{
+              "name": "test",
+              "count": 42
+            }"#,
+            5,
+        )
+        .unwrap();
+        assert!(output.lines().count() == 1);
+        assert!(output.contains("\"name\":\"test\""));
+        assert!(output.contains("\"count\":42"));
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn test_filter_json_compact_string_limit() {
+        let long_string = "a".repeat(STRING_CHARS_LIMIT);
+        let json = format!(r#"{{"name": "{}"}}"#, long_string);
+        let (output, truncated) = filter_json_compact(&json, 5).unwrap();
+        assert!(!output.contains('…'));
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn test_filter_json_compact_string_truncation() {
+        let long_string = "a".repeat(STRING_CHARS_LIMIT + 20);
+        let json = format!(r#"{{"name": "{}"}}"#, long_string);
+        let (output, truncated) = filter_json_compact(&json, 5).unwrap();
+        assert!(output.contains('…'));
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_filter_json_compact_depth_truncation() {
+        let json = r#"{"a": {"b": {"c": 1}}}"#;
+        let (output, truncated) = filter_json_compact(json, 1).unwrap();
+        assert!(output.contains('…'));
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_filter_json_compact_array_truncation() {
+        let json = r#"{"items": [1, 2, 3, 4, 5, 6]}"#;
+        let (output, truncated) = filter_json_compact(json, 5).unwrap();
+        assert!(output.contains("… +5 more"));
+        assert!(truncated);
+    }
+
+    #[test]
+    fn test_extract_schema_single_line() {
+        let json: Value = serde_json::from_str(
+            r#"{
+                "name": "test",
+                "count": 42
+            }"#,
+        )
+        .unwrap();
         let schema = extract_schema(&json, 0, 5);
-        assert!(schema.contains("name"));
-        assert!(schema.contains("string"));
-        assert!(schema.contains("int"));
+        assert!(schema.lines().count() == 1);
+        assert!(schema.contains("\"name\":string"));
+        assert!(schema.contains("\"count\":int"));
     }
 
     #[test]
     fn test_extract_schema_array() {
         let json: Value = serde_json::from_str(r#"{"items": [1, 2, 3]}"#).unwrap();
         let schema = extract_schema(&json, 0, 5);
-        assert!(schema.contains("items"));
-        assert!(schema.contains("(3)"));
+        assert!(schema.lines().count() == 1);
+        assert!(schema.contains("[int] (3)"));
+    }
+
+    #[test]
+    fn test_extract_schema_utf8_truncation() {
+        let long_string = "a".repeat(100);
+        let json = format!(r#"{{"name": "{}"}}"#, long_string);
+        let value: Value = serde_json::from_str(&json).unwrap();
+        let schema = extract_schema(&value, 0, 5);
+        assert!(schema.contains("string[100]"));
     }
 
     fn assert_value_truncated(payload: &str) {
-        let json = format!(r#"{{"key": "{}"}}"#, payload);
-        let output = filter_json_compact(&json, 5)
+        let json = format!(r#"{{"key":"{}"}}"#, payload);
+        let (output, truncated) = filter_json_compact(&json, 5)
             .expect("filter_json_compact must not error on valid JSON");
 
-        assert!(output.contains("key"));
-        assert!(
-            output.contains("..."),
-            "long string should be truncated, got: {output}"
-        );
+        let value: Value = serde_json::from_str(output.as_str()).expect("Failed to parse JSON");
+        let s = value
+            .get("key")
+            .and_then(|val| val.as_str())
+            .expect("Output JSON should contain 'key' as a string");
 
-        let value = output
-            .split('"')
-            .nth(1)
-            .expect("output should contain a quoted string value");
         assert!(
-            value.len() <= 80,
-            "truncated value is {} bytes: {value}",
-            value.len()
+            truncated,
+            "Expected truncation for payload of length {}, got: {}",
+            payload.len(),
+            output
         );
+        assert!(
+            s.chars().count() == STRING_CHARS_LIMIT,
+            "Truncated string should be {} chars, got {}: {}",
+            STRING_CHARS_LIMIT,
+            s.chars().count(),
+            s
+        );
+        assert!(
+            s.ends_with("…"),
+            "Truncated string should end with '…', got: {}",
+            s
+        )
     }
 
     #[test]

--- a/src/cmds/system/json_cmd.rs
+++ b/src/cmds/system/json_cmd.rs
@@ -1,12 +1,12 @@
 //! Inspects JSON structure without showing values, saving tokens on large payloads.
 
+use crate::core::content_hint::save_output_and_hint;
 use crate::core::tracking;
 use anyhow::{bail, Context, Result};
 use serde_json::Value;
 use std::fs;
 use std::io::{self, Read};
 use std::path::Path;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Reject non-JSON files with a clear error before doing any I/O.
 fn validate_json_extension(file: &Path) -> Result<()> {
@@ -58,8 +58,10 @@ pub fn run(file: &Path, max_depth: usize, schema_only: bool, verbose: u8) -> Res
 
     if truncated {
         let value: Value = serde_json::from_str(&content).context("Failed to parse JSON")?;
-        if let Some(hint) = write_json_hint(&value, file) {
-            println!("{}", hint);
+        if let Ok(full_json) = serde_json::to_string(&value) {
+            if let Some(hint) = save_output_and_hint(&full_json, "json", ".json") {
+                println!("{}", hint);
+            }
         }
     }
 
@@ -96,8 +98,10 @@ pub fn run_stdin(max_depth: usize, schema_only: bool, verbose: u8) -> Result<()>
 
     if truncated {
         let value: Value = serde_json::from_str(&content).context("Failed to parse JSON")?;
-        if let Some(hint) = write_json_hint(&value, Path::new("stdin")) {
-            println!("{}", hint);
+        if let Ok(full_json) = serde_json::to_string(&value) {
+            if let Some(hint) = save_output_and_hint(&full_json, "json", ".json") {
+                println!("{}", hint);
+            }
         }
     }
 
@@ -243,69 +247,6 @@ fn extract_schema(value: &Value, depth: usize, max_depth: usize) -> String {
                 format!("{{{}}}", parts.join(","))
             }
         }
-    }
-}
-
-/// Write full compact JSON to a file and return a hint string.
-fn write_json_hint(value: &Value, file: &Path) -> Option<String> {
-    let full_output = serde_json::to_string(value).ok()?;
-
-    let json_dir = dirs::data_local_dir()?.join("rtk").join("json");
-    std::fs::create_dir_all(&json_dir).ok()?;
-
-    let epoch = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
-    let file_slug = file.file_name().and_then(|n| n.to_str()).unwrap_or("stdin");
-    let sanitized: String = file_slug
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .take(40)
-        .collect();
-    let filename = format!("{}_{}.json", epoch, sanitized);
-    let filepath = json_dir.join(filename);
-
-    std::fs::write(&filepath, &full_output).ok()?;
-
-    cleanup_old_json_files(&json_dir);
-
-    let hint = if let Some(home) = dirs::home_dir() {
-        if let Ok(relative) = filepath.strip_prefix(&home) {
-            format!("[full output: ~/{}]", relative.display())
-        } else {
-            format!("[full output: {}]", filepath.display())
-        }
-    } else {
-        format!("[full output: {}]", filepath.display())
-    };
-
-    Some(hint)
-}
-
-/// Clean up old JSON full compact files, keeping only the last 20.
-fn cleanup_old_json_files(json_dir: &std::path::Path) {
-    let mut entries: Vec<_> = std::fs::read_dir(json_dir)
-        .ok()
-        .into_iter()
-        .flatten()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
-        .filter(|e| e.file_name().to_string_lossy().contains(".json"))
-        .collect();
-
-    if entries.len() <= 20 {
-        return;
-    }
-
-    entries.sort_by_key(|e| e.file_name());
-
-    let to_remove = entries.len() - 20;
-    for entry in entries.iter().take(to_remove) {
-        let _ = std::fs::remove_file(entry.path());
     }
 }
 

--- a/src/core/content_hint.rs
+++ b/src/core/content_hint.rs
@@ -9,9 +9,6 @@ use super::constants::RTK_DATA_DIR;
 use crate::core::config::Config;
 use std::path::PathBuf;
 
-/// Minimum output size to save (smaller outputs don't need recovery)
-pub const MIN_CONTENT_SIZE: usize = 500;
-
 /// Default max files to keep
 pub const DEFAULT_MAX_FILES: usize = 20;
 
@@ -161,16 +158,22 @@ fn hints_disabled() -> bool {
     false
 }
 
+/// Check if hints should be generated.
+/// Returns false if env disabled or content too small.
+pub fn should_hint(content: &str) -> bool {
+    if hints_disabled() {
+        return false;
+    }
+    if content.is_empty() {
+        return false;
+    }
+    true
+}
+
 /// Save content to file and return the file path.
-/// The caller is responsible for checking conditions (size, etc.).
 /// Returns None if save fails or hints are disabled.
 pub fn save_output(content: &str, slug: &str, ext: &str) -> Option<PathBuf> {
-    // Check env override (disable)
-    if hints_disabled() {
-        return None;
-    }
-
-    if content.is_empty() {
+    if !should_hint(content) {
         return None;
     }
 
@@ -200,62 +203,6 @@ pub fn save_output(content: &str, slug: &str, ext: &str) -> Option<PathBuf> {
 /// Returns None if save fails or hints are disabled.
 pub fn save_output_and_hint(content: &str, slug: &str, ext: &str) -> Option<String> {
     let path = save_output(content, slug, ext)?;
-    Some(format_hint(&path))
-}
-
-/// Save content to file only if exit_code != 0.
-/// Convenience for "save on failure" pattern.
-/// Returns None if save fails, skipped, or exit_code == 0.
-pub fn save_output_on_failure(
-    content: &str,
-    slug: &str,
-    ext: &str,
-    exit_code: i32,
-) -> Option<String> {
-    // Check env override (disable)
-    if hints_disabled() {
-        return None;
-    }
-
-    // Only save on failure
-    if exit_code == 0 {
-        return None;
-    }
-
-    let config = Config::load().ok()?;
-
-    // Check config
-    if !config.tee.enabled {
-        return None;
-    }
-
-    match config.tee.mode {
-        super::tee::TeeMode::Never => return None,
-        super::tee::TeeMode::Always => {}
-        super::tee::TeeMode::Failures => {
-            // Already checked exit_code != 0 above
-        }
-    }
-
-    // Skip if output too small
-    if content.len() < MIN_CONTENT_SIZE {
-        return None;
-    }
-
-    let hint_dir = get_hint_dir(&config)?;
-    let hint_dir = std::fs::create_dir_all(&hint_dir)
-        .ok()
-        .and(Some(hint_dir))?;
-
-    let path = write_content_file(
-        content,
-        slug,
-        &hint_dir,
-        ext,
-        config.tee.max_file_size,
-        config.tee.max_files,
-    )?;
-
     Some(format_hint(&path))
 }
 
@@ -304,6 +251,26 @@ mod tests {
             let filename = format!("{:010}_{}.json", 1000000 + i, "test");
             assert!(!dir.join(&filename).exists());
         }
+    }
+
+    #[test]
+    fn test_should_hint_respects_env_disable() {
+        std::env::set_var("RTK_HINTS", "0");
+        assert!(!should_hint("test"));
+        std::env::remove_var("RTK_HINTS");
+
+        std::env::set_var("RTK_TEE", "0");
+        assert!(!should_hint("test"));
+        std::env::remove_var("RTK_TEE");
+
+        // Verify env is cleared
+        assert!(should_hint("test"));
+    }
+
+    #[test]
+    fn test_should_hint_respects_empty() {
+        assert!(!should_hint("")); // Empty
+        assert!(should_hint("test")); // Not empty
     }
 
     #[test]

--- a/src/core/content_hint.rs
+++ b/src/core/content_hint.rs
@@ -1,0 +1,308 @@
+//! Content hint system - generic output saving with hint recovery.
+//! Replaces and extends the former tee.rs functionality.
+//!
+//! This module provides a generic way to save content to disk and optionally
+//! return a hint string that can be displayed to the user.
+//! Used by: JSON truncation, command output recovery, etc.
+
+use super::constants::RTK_DATA_DIR;
+use crate::core::config::Config;
+use std::path::PathBuf;
+
+/// Minimum output size to save (smaller outputs don't need recovery)
+pub const MIN_CONTENT_SIZE: usize = 500;
+
+/// Default max files to keep
+pub const DEFAULT_MAX_FILES: usize = 20;
+
+/// Default max file size (1MB)
+pub const DEFAULT_MAX_FILE_SIZE: usize = 1_048_576;
+
+/// Sanitize a command slug for use in filenames.
+/// Replaces non-alphanumeric chars (except underscore/hyphen) with underscore,
+/// truncates at 40 chars.
+pub fn sanitize_slug(slug: &str) -> String {
+    let sanitized: String = slug
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if sanitized.len() > 40 {
+        sanitized[..40].to_string()
+    } else {
+        sanitized
+    }
+}
+
+/// Get the tee/hint directory, respecting config and env overrides.
+pub fn get_hint_dir(config: &Config) -> Option<PathBuf> {
+    // Env var override
+    if let Ok(dir) = std::env::var("RTK_TEE_DIR") {
+        return Some(PathBuf::from(dir));
+    }
+
+    // Config override
+    if let Some(ref dir) = config.tee.directory {
+        return Some(dir.clone());
+    }
+
+    // Default: ~/.local/share/rtk/tee/
+    dirs::data_local_dir().map(|d| d.join(RTK_DATA_DIR).join("tee"))
+}
+
+/// Rotate old files: keep only the last `max_files`, delete oldest.
+/// Filters by extension (e.g., ".log", ".json").
+fn cleanup_old_files(dir: &std::path::Path, ext: &str, max_files: usize) {
+    let ext_str = ext.trim_start_matches('.').to_string();
+    let mut entries: Vec<_> = std::fs::read_dir(dir)
+        .ok()
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.path()
+                .extension()
+                .is_some_and(|ext| ext.to_string_lossy() == ext_str)
+        })
+        .collect();
+
+    if entries.len() <= max_files {
+        return;
+    }
+
+    // Sort by filename (which starts with epoch timestamp = chronological)
+    entries.sort_by_key(|e| e.file_name());
+
+    let to_remove = entries.len() - max_files;
+    for entry in entries.iter().take(to_remove) {
+        let _ = std::fs::remove_file(entry.path());
+    }
+}
+
+/// Write content to a file in the given directory.
+/// Returns file path on success.
+/// - `content`: the content to save
+/// - `slug`: identifier for the file (e.g., "json", "cargo_test")
+/// - `ext`: extension including dot (e.g., ".json", ".log")
+/// - `max_file_size`: maximum size before truncation
+/// - `max_files`: maximum number of files to keep
+fn write_content_file(
+    content: &str,
+    slug: &str,
+    dir: &std::path::Path,
+    ext: &str,
+    max_file_size: usize,
+    max_files: usize,
+) -> Option<PathBuf> {
+    std::fs::create_dir_all(dir).ok()?;
+
+    let sanitized_slug = sanitize_slug(slug);
+    let epoch = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_secs();
+    let filename = format!("{}_{}{}", epoch, sanitized_slug, ext);
+    let filepath = dir.join(filename);
+
+    // Truncate at max_file_size (find a safe UTF-8 char boundary)
+    let content_to_write = if content.len() > max_file_size {
+        let boundary = content
+            .char_indices()
+            .take_while(|(i, _)| *i < max_file_size)
+            .last()
+            .map(|(i, c)| i + c.len_utf8())
+            .unwrap_or(0);
+        format!(
+            "{}\n\n--- truncated at {} bytes ---",
+            &content[..boundary],
+            max_file_size
+        )
+    } else {
+        content.to_string()
+    };
+
+    std::fs::write(&filepath, content_to_write).ok()?;
+
+    // Rotate old files (filter by extension)
+    cleanup_old_files(dir, ext, max_files);
+
+    Some(filepath)
+}
+
+pub fn display_path(path: &std::path::Path) -> String {
+    if let Some(home) = dirs::home_dir() {
+        if let Ok(relative) = path.strip_prefix(&home) {
+            return format!("~/{}", relative.display());
+        }
+    }
+    path.display().to_string()
+}
+
+pub fn format_hint(path: &std::path::Path) -> String {
+    format!("[full output: {}]", display_path(path))
+}
+
+/// Check if hints are disabled via environment variable.
+/// Supports both RTK_TEE=0 (backward compat) and RTK_HINTS=0.
+fn hints_disabled() -> bool {
+    // Check RTK_TEE=0 (backward compatibility)
+    if std::env::var("RTK_TEE").ok().as_deref() == Some("0") {
+        return true;
+    }
+    // Check RTK_HINTS=0 (new, more general)
+    if std::env::var("RTK_HINTS").ok().as_deref() == Some("0") {
+        return true;
+    }
+    false
+}
+
+/// Save content to file and return the file path.
+/// The caller is responsible for checking conditions (size, etc.).
+/// Returns None if save fails or hints are disabled.
+pub fn save_output(content: &str, slug: &str, ext: &str) -> Option<PathBuf> {
+    // Check env override (disable)
+    if hints_disabled() {
+        return None;
+    }
+
+    if content.is_empty() {
+        return None;
+    }
+
+    let config = Config::load().ok()?;
+
+    if !config.tee.enabled {
+        return None;
+    }
+
+    let hint_dir = get_hint_dir(&config)?;
+    let hint_dir = std::fs::create_dir_all(&hint_dir)
+        .ok()
+        .and(Some(hint_dir))?;
+
+    write_content_file(
+        content,
+        slug,
+        &hint_dir,
+        ext,
+        config.tee.max_file_size,
+        config.tee.max_files,
+    )
+}
+
+/// Save content to file and return the hint string.
+/// Convenience wrapper combining save_output + format_hint.
+/// Returns None if save fails or hints are disabled.
+pub fn save_output_and_hint(content: &str, slug: &str, ext: &str) -> Option<String> {
+    let path = save_output(content, slug, ext)?;
+    Some(format_hint(&path))
+}
+
+/// Save content to file only if exit_code != 0.
+/// Convenience for "save on failure" pattern.
+/// Returns None if save fails, skipped, or exit_code == 0.
+pub fn save_output_on_failure(
+    content: &str,
+    slug: &str,
+    ext: &str,
+    exit_code: i32,
+) -> Option<String> {
+    // Check env override (disable)
+    if hints_disabled() {
+        return None;
+    }
+
+    // Only save on failure
+    if exit_code == 0 {
+        return None;
+    }
+
+    let config = Config::load().ok()?;
+
+    // Check config
+    if !config.tee.enabled {
+        return None;
+    }
+
+    match config.tee.mode {
+        super::tee::TeeMode::Never => return None,
+        super::tee::TeeMode::Always => {}
+        super::tee::TeeMode::Failures => {
+            // Already checked exit_code != 0 above
+        }
+    }
+
+    // Skip if output too small
+    if content.len() < MIN_CONTENT_SIZE {
+        return None;
+    }
+
+    let hint_dir = get_hint_dir(&config)?;
+    let hint_dir = std::fs::create_dir_all(&hint_dir)
+        .ok()
+        .and(Some(hint_dir))?;
+
+    let path = write_content_file(
+        content,
+        slug,
+        &hint_dir,
+        ext,
+        config.tee.max_file_size,
+        config.tee.max_files,
+    )?;
+
+    Some(format_hint(&path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_sanitize_slug() {
+        assert_eq!(sanitize_slug("cargo_test"), "cargo_test");
+        assert_eq!(sanitize_slug("cargo test"), "cargo_test");
+        assert_eq!(sanitize_slug("cargo-test"), "cargo-test");
+        assert_eq!(sanitize_slug("go/test/./pkg"), "go_test___pkg");
+        let long = "a".repeat(50);
+        assert_eq!(sanitize_slug(&long).len(), 40);
+    }
+
+    #[test]
+    fn test_format_hint() {
+        let path = PathBuf::from("/tmp/rtk/tee/1234567890_json.json");
+        let hint = format_hint(&path);
+        assert!(hint.starts_with("[full output: "));
+        assert!(hint.ends_with(']'));
+        assert!(hint.contains("1234567890_json.json"));
+    }
+
+    #[test]
+    fn test_cleanup_old_files_by_extension() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dir = tmpdir.path();
+
+        // Create 25 .json files
+        for i in 0..25 {
+            let filename = format!("{:010}_{}.json", 1000000 + i, "test");
+            fs::write(dir.join(&filename), "content").unwrap();
+        }
+
+        cleanup_old_files(dir, ".json", 20);
+
+        let remaining: Vec<_> = fs::read_dir(dir).unwrap().filter_map(|e| e.ok()).collect();
+        assert_eq!(remaining.len(), 20);
+
+        // Oldest 5 should be removed
+        for i in 0..5 {
+            let filename = format!("{:010}_{}.json", 1000000 + i, "test");
+            assert!(!dir.join(&filename).exists());
+        }
+    }
+}

--- a/src/core/content_hint.rs
+++ b/src/core/content_hint.rs
@@ -305,4 +305,80 @@ mod tests {
             assert!(!dir.join(&filename).exists());
         }
     }
+
+    #[test]
+    fn test_write_content_file_creates_file() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let content = "error: test failed\n".repeat(50);
+
+        let result = write_content_file(
+            &content,
+            "cargo_test",
+            tmpdir.path(),
+            ".log",
+            DEFAULT_MAX_FILE_SIZE,
+            20,
+        );
+        assert!(result.is_some());
+
+        let path = result.unwrap();
+        assert!(path.exists());
+        let written = fs::read_to_string(&path).unwrap();
+        assert!(written.contains("error: test failed"));
+    }
+
+    #[test]
+    fn test_write_content_file_truncation() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let big_output = "x".repeat(2000);
+        // Set max_file_size to 1000 bytes
+        let result = write_content_file(&big_output, "test", tmpdir.path(), ".log", 1000, 20);
+        assert!(result.is_some());
+
+        let path = result.unwrap();
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("--- truncated at 1000 bytes ---"));
+        assert!(content.len() < 2000);
+    }
+
+    #[test]
+    fn test_write_content_file_truncation_utf8_boundary() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        // Create a string where the truncation point falls inside a multi-byte char.
+        // Japanese chars are 3 bytes each in UTF-8.
+        // 332 chars * 3 bytes = 996 bytes, then one more = 999 bytes.
+        // With max_file_size=998, the cut falls mid-character.
+        let japanese = "\u{6F22}".repeat(333); // 999 bytes of 3-byte chars
+        assert_eq!(japanese.len(), 999);
+
+        // Truncate at 998 — falls in the middle of the 333rd character
+        let result = write_content_file(&japanese, "test_utf8", tmpdir.path(), ".log", 998, 20);
+        assert!(result.is_some());
+
+        let path = result.unwrap();
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("--- truncated at 998 bytes ---"));
+        // Should contain 332 full characters (996 bytes), not panic
+        assert!(content.starts_with(&"\u{6F22}".repeat(332)));
+    }
+
+    #[test]
+    fn test_write_content_file_truncation_emoji() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        // Emoji are 4 bytes each in UTF-8
+        let emojis = "\u{1F600}".repeat(100); // 400 bytes
+        assert_eq!(emojis.len(), 400);
+
+        // Truncate at 201 — falls mid-emoji (4-byte boundary is at 200, 204)
+        let result = write_content_file(&emojis, "test_emoji", tmpdir.path(), ".log", 201, 20);
+        assert!(result.is_some());
+
+        let path = result.unwrap();
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("--- truncated at 201 bytes ---"));
+        // The emoji portion should be exactly 200 bytes (50 emojis),
+        // rounded down from 201 to the nearest char boundary
+        let target = "\u{1F600}".repeat(50);
+        assert!(content.starts_with(&target));
+    }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod config;
 pub mod constants;
+pub mod content_hint;
 pub mod display_helpers;
 pub mod filter;
 pub mod runner;

--- a/src/core/tee.rs
+++ b/src/core/tee.rs
@@ -1,224 +1,19 @@
 //! Raw output recovery -- saves unfiltered output to disk on command failure.
+//! This module is kept for backward compatibility.
+//! New code should use content_hint module instead.
 
-use super::constants::RTK_DATA_DIR;
-use crate::core::config::Config;
+use crate::core::content_hint as ch;
 use std::path::PathBuf;
-
-/// Minimum output size to tee (smaller outputs don't need recovery)
-const MIN_TEE_SIZE: usize = 500;
-
-/// Default max files to keep in tee directory
-const DEFAULT_MAX_FILES: usize = 20;
-
-/// Default max file size (1MB)
-const DEFAULT_MAX_FILE_SIZE: usize = 1_048_576;
-
-/// Sanitize a command slug for use in filenames.
-/// Replaces non-alphanumeric chars (except underscore/hyphen) with underscore,
-/// truncates at 40 chars.
-fn sanitize_slug(slug: &str) -> String {
-    let sanitized: String = slug
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect();
-    if sanitized.len() > 40 {
-        sanitized[..40].to_string()
-    } else {
-        sanitized
-    }
-}
-
-/// Get the tee directory, respecting config and env overrides.
-fn get_tee_dir(config: &Config) -> Option<PathBuf> {
-    // Env var override
-    if let Ok(dir) = std::env::var("RTK_TEE_DIR") {
-        return Some(PathBuf::from(dir));
-    }
-
-    // Config override
-    if let Some(ref dir) = config.tee.directory {
-        return Some(dir.clone());
-    }
-
-    // Default: ~/.local/share/rtk/tee/
-    dirs::data_local_dir().map(|d| d.join(RTK_DATA_DIR).join("tee"))
-}
-
-/// Rotate old tee files: keep only the last `max_files`, delete oldest.
-fn cleanup_old_files(dir: &std::path::Path, max_files: usize) {
-    let mut entries: Vec<_> = std::fs::read_dir(dir)
-        .ok()
-        .into_iter()
-        .flatten()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().is_some_and(|ext| ext == "log"))
-        .collect();
-
-    if entries.len() <= max_files {
-        return;
-    }
-
-    // Sort by filename (which starts with epoch timestamp = chronological)
-    entries.sort_by_key(|e| e.file_name());
-
-    let to_remove = entries.len() - max_files;
-    for entry in entries.iter().take(to_remove) {
-        let _ = std::fs::remove_file(entry.path());
-    }
-}
-
-/// Check if tee should be skipped based on config, mode, exit code, and size.
-/// Returns None if should skip, Some(tee_dir) if should proceed.
-fn should_tee(
-    config: &TeeConfig,
-    raw_len: usize,
-    exit_code: i32,
-    tee_dir: Option<PathBuf>,
-) -> Option<PathBuf> {
-    if !config.enabled {
-        return None;
-    }
-
-    match config.mode {
-        TeeMode::Never => return None,
-        TeeMode::Failures => {
-            if exit_code == 0 {
-                return None;
-            }
-        }
-        TeeMode::Always => {}
-    }
-
-    if raw_len < MIN_TEE_SIZE {
-        return None;
-    }
-
-    tee_dir
-}
-
-/// Write raw output to a tee file in the given directory.
-/// Returns file path on success.
-fn write_tee_file(
-    raw: &str,
-    command_slug: &str,
-    tee_dir: &std::path::Path,
-    max_file_size: usize,
-    max_files: usize,
-) -> Option<PathBuf> {
-    std::fs::create_dir_all(tee_dir).ok()?;
-
-    let slug = sanitize_slug(command_slug);
-    let epoch = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .ok()?
-        .as_secs();
-    let filename = format!("{}_{}.log", epoch, slug);
-    let filepath = tee_dir.join(filename);
-
-    // Truncate at max_file_size (find a safe UTF-8 char boundary)
-    let content = if raw.len() > max_file_size {
-        let boundary = raw
-            .char_indices()
-            .take_while(|(i, _)| *i < max_file_size)
-            .last()
-            .map(|(i, c)| i + c.len_utf8())
-            .unwrap_or(0);
-        format!(
-            "{}\n\n--- truncated at {} bytes ---",
-            &raw[..boundary],
-            max_file_size
-        )
-    } else {
-        raw.to_string()
-    };
-
-    std::fs::write(&filepath, content).ok()?;
-
-    // Rotate old files
-    cleanup_old_files(tee_dir, max_files);
-
-    Some(filepath)
-}
-
-/// Write raw output to tee file if conditions are met.
-/// Returns file path on success, None if skipped/failed.
-pub fn tee_raw(raw: &str, command_slug: &str, exit_code: i32) -> Option<PathBuf> {
-    // Check RTK_TEE=0 env override (disable)
-    if std::env::var("RTK_TEE").ok().as_deref() == Some("0") {
-        return None;
-    }
-
-    let config = Config::load().ok()?;
-    let tee_dir = get_tee_dir(&config)?;
-
-    let tee_dir = should_tee(&config.tee, raw.len(), exit_code, Some(tee_dir))?;
-
-    write_tee_file(
-        raw,
-        command_slug,
-        &tee_dir,
-        config.tee.max_file_size,
-        config.tee.max_files,
-    )
-}
-
-fn display_path(path: &std::path::Path) -> String {
-    if let Some(home) = dirs::home_dir() {
-        if let Ok(relative) = path.strip_prefix(&home) {
-            return format!("~/{}", relative.display());
-        }
-    }
-    path.display().to_string()
-}
-
-fn format_hint(path: &std::path::Path) -> String {
-    format!("[full output: {}]", display_path(path))
-}
 
 /// Convenience: tee + format hint in one call.
 /// Returns hint string if file was written, None if skipped.
 pub fn tee_and_hint(raw: &str, command_slug: &str, exit_code: i32) -> Option<String> {
-    let path = tee_raw(raw, command_slug, exit_code)?;
-    Some(format_hint(&path))
-}
-
-fn force_tee_path(content: &str, command_slug: &str) -> Option<PathBuf> {
-    if std::env::var("RTK_TEE").ok().as_deref() == Some("0") {
-        return None;
-    }
-
-    if content.is_empty() {
-        return None;
-    }
-
-    let config = Config::load().ok()?;
-
-    if !config.tee.enabled {
-        return None;
-    }
-
-    let tee_dir = get_tee_dir(&config)?;
-    let tee_dir = std::fs::create_dir_all(&tee_dir).ok().and(Some(tee_dir))?;
-
-    write_tee_file(
-        content,
-        command_slug,
-        &tee_dir,
-        config.tee.max_file_size,
-        config.tee.max_files,
-    )
+    ch::save_output_on_failure(raw, command_slug, ".log", exit_code)
 }
 
 /// Returns `[full output: ~/path]`, or None if tee is disabled/skipped.
 pub fn force_tee_hint(raw: &str, command_slug: &str) -> Option<String> {
-    let path = force_tee_path(raw, command_slug)?;
-    Some(format_hint(&path))
+    ch::save_output_and_hint(raw, command_slug, ".log")
 }
 
 /// Returns `[see remaining: tail -n +{line_offset} ~/path]`, or None if tee is disabled/skipped.
@@ -227,11 +22,11 @@ pub fn force_tee_tail_hint(
     command_slug: &str,
     line_offset: usize,
 ) -> Option<String> {
-    let path = force_tee_path(content, command_slug)?;
+    let path = ch::save_output(content, command_slug, ".log")?;
     Some(format!(
         "[see remaining: tail -n +{} {}]",
         line_offset,
-        display_path(&path)
+        ch::display_path(&path)
     ))
 }
 
@@ -261,8 +56,8 @@ impl Default for TeeConfig {
         Self {
             enabled: true,
             mode: TeeMode::default(),
-            max_files: DEFAULT_MAX_FILES,
-            max_file_size: DEFAULT_MAX_FILE_SIZE,
+            max_files: ch::DEFAULT_MAX_FILES,
+            max_file_size: ch::DEFAULT_MAX_FILE_SIZE,
             directory: None,
         }
     }
@@ -271,181 +66,6 @@ impl Default for TeeConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
-
-    #[test]
-    fn test_sanitize_slug() {
-        assert_eq!(sanitize_slug("cargo_test"), "cargo_test");
-        assert_eq!(sanitize_slug("cargo test"), "cargo_test");
-        assert_eq!(sanitize_slug("cargo-test"), "cargo-test");
-        assert_eq!(sanitize_slug("go/test/./pkg"), "go_test___pkg");
-        // Truncate at 40
-        let long = "a".repeat(50);
-        assert_eq!(sanitize_slug(&long).len(), 40);
-    }
-
-    #[test]
-    fn test_should_tee_disabled() {
-        let config = TeeConfig {
-            enabled: false,
-            ..TeeConfig::default()
-        };
-        let dir = PathBuf::from("/tmp/tee");
-        assert!(should_tee(&config, 1000, 1, Some(dir)).is_none());
-    }
-
-    #[test]
-    fn test_should_tee_never_mode() {
-        let config = TeeConfig {
-            mode: TeeMode::Never,
-            ..TeeConfig::default()
-        };
-        let dir = PathBuf::from("/tmp/tee");
-        assert!(should_tee(&config, 1000, 1, Some(dir)).is_none());
-    }
-
-    #[test]
-    fn test_should_tee_skip_small_output() {
-        let config = TeeConfig::default();
-        let dir = PathBuf::from("/tmp/tee");
-        // Below MIN_TEE_SIZE (500)
-        assert!(should_tee(&config, 100, 1, Some(dir)).is_none());
-    }
-
-    #[test]
-    fn test_should_tee_skip_success_in_failures_mode() {
-        let config = TeeConfig::default(); // mode = Failures
-        let dir = PathBuf::from("/tmp/tee");
-        assert!(should_tee(&config, 1000, 0, Some(dir)).is_none());
-    }
-
-    #[test]
-    fn test_should_tee_proceed_on_failure() {
-        let config = TeeConfig::default(); // mode = Failures
-        let dir = PathBuf::from("/tmp/tee");
-        assert!(should_tee(&config, 1000, 1, Some(dir)).is_some());
-    }
-
-    #[test]
-    fn test_should_tee_always_mode_success() {
-        let config = TeeConfig {
-            mode: TeeMode::Always,
-            ..TeeConfig::default()
-        };
-        let dir = PathBuf::from("/tmp/tee");
-        assert!(should_tee(&config, 1000, 0, Some(dir)).is_some());
-    }
-
-    #[test]
-    fn test_write_tee_file_creates_file() {
-        let tmpdir = tempfile::tempdir().unwrap();
-        let content = "error: test failed\n".repeat(50);
-        let result = write_tee_file(
-            &content,
-            "cargo_test",
-            tmpdir.path(),
-            DEFAULT_MAX_FILE_SIZE,
-            20,
-        );
-        assert!(result.is_some());
-
-        let path = result.unwrap();
-        assert!(path.exists());
-        let written = fs::read_to_string(&path).unwrap();
-        assert!(written.contains("error: test failed"));
-    }
-
-    #[test]
-    fn test_write_tee_file_truncation() {
-        let tmpdir = tempfile::tempdir().unwrap();
-        let big_output = "x".repeat(2000);
-        // Set max_file_size to 1000 bytes
-        let result = write_tee_file(&big_output, "test", tmpdir.path(), 1000, 20);
-        assert!(result.is_some());
-
-        let path = result.unwrap();
-        let content = fs::read_to_string(&path).unwrap();
-        assert!(content.contains("--- truncated at 1000 bytes ---"));
-        assert!(content.len() < 2000);
-    }
-
-    #[test]
-    fn test_write_tee_file_truncation_utf8_boundary() {
-        let tmpdir = tempfile::tempdir().unwrap();
-        // Create a string where the truncation point falls inside a multi-byte char.
-        // Japanese chars are 3 bytes each in UTF-8.
-        // 332 chars * 3 bytes = 996 bytes, then one more = 999 bytes.
-        // With max_file_size=998, the cut falls mid-character.
-        let japanese = "\u{6F22}".repeat(333); // 999 bytes of 3-byte chars
-        assert_eq!(japanese.len(), 999);
-
-        // Truncate at 998 — falls in the middle of the 333rd character
-        let result = write_tee_file(&japanese, "test_utf8", tmpdir.path(), 998, 20);
-        assert!(result.is_some());
-
-        let path = result.unwrap();
-        let content = fs::read_to_string(&path).unwrap();
-        assert!(content.contains("--- truncated at 998 bytes ---"));
-        // Should contain 332 full characters (996 bytes), not panic
-        assert!(content.starts_with(&"\u{6F22}".repeat(332)));
-    }
-
-    #[test]
-    fn test_write_tee_file_truncation_emoji() {
-        let tmpdir = tempfile::tempdir().unwrap();
-        // Emoji are 4 bytes each in UTF-8
-        let emojis = "\u{1F600}".repeat(100); // 400 bytes
-        assert_eq!(emojis.len(), 400);
-
-        // Truncate at 201 — falls mid-emoji (4-byte boundary is at 200, 204)
-        let result = write_tee_file(&emojis, "test_emoji", tmpdir.path(), 201, 20);
-        assert!(result.is_some());
-
-        let path = result.unwrap();
-        let content = fs::read_to_string(&path).unwrap();
-        assert!(content.contains("--- truncated at 201 bytes ---"));
-        // The emoji portion should be exactly 200 bytes (50 emojis),
-        // rounded down from 201 to the nearest char boundary
-        let target = "\u{1F600}".repeat(50);
-        assert!(content.starts_with(&target));
-    }
-
-    #[test]
-    fn test_cleanup_old_files() {
-        let tmpdir = tempfile::tempdir().unwrap();
-        let dir = tmpdir.path();
-
-        // Create 25 .log files
-        for i in 0..25 {
-            let filename = format!("{:010}_{}.log", 1000000 + i, "test");
-            fs::write(dir.join(&filename), "content").unwrap();
-        }
-
-        cleanup_old_files(dir, 20);
-
-        let remaining: Vec<_> = fs::read_dir(dir).unwrap().filter_map(|e| e.ok()).collect();
-        assert_eq!(remaining.len(), 20);
-
-        // Oldest 5 should be removed
-        for i in 0..5 {
-            let filename = format!("{:010}_{}.log", 1000000 + i, "test");
-            assert!(!dir.join(&filename).exists());
-        }
-        // Newest 20 should remain
-        for i in 5..25 {
-            let filename = format!("{:010}_{}.log", 1000000 + i, "test");
-            assert!(dir.join(&filename).exists());
-        }
-    }
-
-    #[test]
-    fn test_format_hint() {
-        let path = PathBuf::from("/tmp/rtk/tee/123_cargo_test.log");
-        let hint = format_hint(&path);
-        assert!(hint.starts_with("[full output: "));
-        assert!(hint.ends_with(']'));
-        assert!(hint.contains("123_cargo_test.log"));
-    }
 
     #[test]
     fn test_tee_config_default() {
@@ -518,7 +138,7 @@ directory = "/tmp/rtk-tee"
     #[test]
     fn test_force_tee_tail_hint_format() {
         let path = std::path::PathBuf::from("/tmp/rtk/tee/123_docker_images.log");
-        let display = display_path(&path);
+        let display = ch::display_path(&path);
         let hint = format!("[see remaining: tail -n +{} {}]", 22, display);
         assert!(hint.starts_with("[see remaining: tail -n +22 "));
         assert!(hint.ends_with(']'));

--- a/src/core/tee.rs
+++ b/src/core/tee.rs
@@ -2,13 +2,36 @@
 //! This module is kept for backward compatibility.
 //! New code should use content_hint module instead.
 
+use crate::core::config::Config;
 use crate::core::content_hint as ch;
 use std::path::PathBuf;
 
+/// Check if tee should be performed based on config and conditions.
+/// Returns true if tee should proceed.
+fn should_tee(config: &TeeConfig, exit_code: i32) -> bool {
+    if !config.enabled {
+        return false;
+    }
+
+    match config.mode {
+        TeeMode::Never => false,
+        TeeMode::Always => true,
+        TeeMode::Failures => exit_code != 0,
+    }
+}
+
 /// Convenience: tee + format hint in one call.
+/// Respects TeeMode (Always/Failures/Never).
 /// Returns hint string if file was written, None if skipped.
 pub fn tee_and_hint(raw: &str, command_slug: &str, exit_code: i32) -> Option<String> {
-    ch::save_output_on_failure(raw, command_slug, ".log", exit_code)
+    let config = Config::load().ok()?;
+
+    if !should_tee(&config.tee, exit_code) {
+        return None;
+    }
+
+    let path = ch::save_output(raw, command_slug, ".log")?;
+    Some(ch::format_hint(&path))
 }
 
 /// Returns `[full output: ~/path]`, or None if tee is disabled/skipped.
@@ -66,6 +89,48 @@ impl Default for TeeConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_should_tee_disabled() {
+        let config = TeeConfig {
+            enabled: false,
+            ..TeeConfig::default()
+        };
+        assert!(!should_tee(&config, 0));
+        assert!(!should_tee(&config, 1));
+    }
+
+    #[test]
+    fn test_should_tee_never_mode() {
+        let config = TeeConfig {
+            mode: TeeMode::Never,
+            ..TeeConfig::default()
+        };
+        assert!(!should_tee(&config, 0));
+        assert!(!should_tee(&config, 1));
+    }
+
+    #[test]
+    fn test_should_tee_failures_mode_success() {
+        let config = TeeConfig::default(); // mode = Failures
+        assert!(!should_tee(&config, 0));
+    }
+
+    #[test]
+    fn test_should_tee_failures_mode_failure() {
+        let config = TeeConfig::default(); // mode = Failures
+        assert!(should_tee(&config, 1));
+    }
+
+    #[test]
+    fn test_should_tee_always_mode() {
+        let config = TeeConfig {
+            mode: TeeMode::Always,
+            ..TeeConfig::default()
+        };
+        assert!(should_tee(&config, 0));
+        assert!(should_tee(&config, 1));
+    }
 
     #[test]
     fn test_tee_config_default() {


### PR DESCRIPTION
## Summary
- Consolidate json_cmd output to single-line format and add user-facing truncation feedback.
- Also fixes UTF-8 correctness by using char-based truncation instead of byte boundaries.

## Test plan
- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `target/debug/rtk json openclaw/package.json` output inspected
