### PR TITLE
fix(grep): support --pcre2 flag

### DIFF
--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -16,6 +16,7 @@ pub fn run(
     max_results: usize,
     context_only: bool,
     file_type: Option<&str>,
+    pcre2: bool,
     extra_args: &[String],
     verbose: u8,
 ) -> Result<i32> {
@@ -39,11 +40,7 @@ pub fn run(
         rg_cmd.arg("--type").arg(ft);
     }
 
-    for arg in extra_args {
-        // Fix: skip grep-ism -r flag (rg is recursive by default; rg -r means --replace)
-        if arg == "-r" || arg == "--recursive" {
-            continue;
-        }
+    for arg in rg_extra_args(extra_args, pcre2) {
         rg_cmd.arg(arg);
     }
 
@@ -183,6 +180,23 @@ fn has_format_flag(extra_args: &[String]) -> bool {
     })
 }
 
+fn rg_extra_args(extra_args: &[String], pcre2: bool) -> Vec<String> {
+    let mut args = Vec::with_capacity(extra_args.len() + usize::from(pcre2));
+    if pcre2 {
+        args.push("--pcre2".to_string());
+    }
+
+    for arg in extra_args {
+        // Fix: skip grep-ism -r flag (rg is recursive by default; rg -r means --replace)
+        if arg == "-r" || arg == "--recursive" {
+            continue;
+        }
+        args.push(arg.clone());
+    }
+
+    args
+}
+
 fn clean_line(line: &str, max_len: usize, context_re: Option<&Regex>, pattern: &str) -> String {
     let trimmed = line.trim();
 
@@ -302,12 +316,16 @@ mod tests {
     #[test]
     fn test_recursive_flag_stripped() {
         let extra_args: Vec<String> = vec!["-r".to_string(), "-i".to_string()];
-        let filtered: Vec<&String> = extra_args
-            .iter()
-            .filter(|a| *a != "-r" && *a != "--recursive")
-            .collect();
-        assert_eq!(filtered.len(), 1);
-        assert_eq!(filtered[0], "-i");
+        assert_eq!(rg_extra_args(&extra_args, false), vec!["-i"]);
+    }
+
+    #[test]
+    fn test_pcre2_flag_is_forwarded_to_rg() {
+        let extra_args: Vec<String> = vec!["-i".to_string(), "--glob".to_string(), "*.rs".to_string()];
+        assert_eq!(
+            rg_extra_args(&extra_args, true),
+            vec!["--pcre2", "-i", "--glob", "*.rs"]
+        );
     }
 
     // --- truncation accuracy ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -314,6 +314,9 @@ enum Commands {
         /// Filter by file type (e.g., ts, py, rust)
         #[arg(short = 't', long)]
         file_type: Option<String>,
+        /// Use PCRE2 regex syntax (ripgrep compatibility)
+        #[arg(long)]
+        pcre2: bool,
         /// Show line numbers (always on, accepted for grep/rg compatibility)
         #[arg(short = 'n', long)]
         line_numbers: bool,
@@ -1730,6 +1733,7 @@ fn run_cli() -> Result<i32> {
             max,
             context_only,
             file_type,
+            pcre2,
             line_numbers: _, // no-op: line numbers always enabled in grep_cmd::run
             extra_args,
         } => grep_cmd::run(
@@ -1739,6 +1743,7 @@ fn run_cli() -> Result<i32> {
             max,
             context_only,
             file_type.as_deref(),
+            pcre2,
             &extra_args,
             cli.verbose,
         )?,
@@ -2633,6 +2638,29 @@ mod tests {
                 Commands::Gain { failures, .. } => assert!(failures),
                 _ => panic!("Expected Gain command"),
             }
+        }
+    }
+
+    #[test]
+    fn test_grep_pcre2_before_pattern_parses() {
+        let cli =
+            Cli::try_parse_from(["rtk", "grep", "-n", "--pcre2", "e2e-tests(?!-v2)"]).unwrap();
+        match cli.command {
+            Commands::Grep {
+                pattern,
+                path,
+                line_numbers,
+                pcre2,
+                extra_args,
+                ..
+            } => {
+                assert_eq!(pattern, "e2e-tests(?!-v2)");
+                assert_eq!(path, ".");
+                assert!(line_numbers);
+                assert!(pcre2);
+                assert!(extra_args.is_empty());
+            }
+            _ => panic!("Expected Grep command"),
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #1651 by teaching `rtk grep` to parse `--pcre2` before the pattern and forward it to ripgrep instead of falling through to system `grep`.

The existing grep compatibility handling for `-r`/`--recursive` is preserved.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test pcre2`
- `cargo test grep_cmd`
- `cargo test test_grep_pcre2_before_pattern_parses`
- `cargo clippy --all-targets`
- `cargo test` (`1689 passed, 6 ignored`)
- Manual smoke with `rg 15.1.0 features:+pcre2`
