### PR TITLE
fix: pre-extraction path traversal check in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -99,6 +99,9 @@ install() {
     fi
 
     info "Extracting..."
+    if tar -tf "$ARCHIVE" | grep -qE '\.\./|\./|\.\.$'; then
+        error "Blocked: path traversal attempt detected in archive"
+    fi
     tar -xzf "$ARCHIVE" -C "$TEMP_DIR"
 
     mkdir -p "$INSTALL_DIR"


### PR DESCRIPTION
## Summary

Fixes #1250.

## The vulnerability

The installer had no path traversal protection. A malicious mirror or compromised download could serve a tar archive containing `../../etc/cron.d/malware` and overwrite arbitrary filesystem paths.

## The fix

Use `tar -tf` to list archive contents **before** extraction. Block and exit if any entry contains path traversal patterns (`../`, `/./`, `..`):

```bash
if tar -tf "$ARCHIVE" | grep -qE '\.\./|\./|\.\.$'; then
  error "Blocked: path traversal attempt detected in archive"
fi
```

This is a single pre-extraction check with no architectural changes.

## References

- CWE-22: Path Traversal
- Reported via upstream security audit