### PR TITLE
fix(ls): force LC_TIME=C for locale-independent date parsing

### DIFF
--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -36,6 +36,9 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
 
     let mut cmd = resolved_command("ls");
     cmd.arg("-la");
+    // Force English date format so LS_DATE_RE can parse the output reliably,
+    // regardless of the user's locale/LC_TIME setting.
+    cmd.env("LC_TIME", "C");
     for flag in &flags {
         if flag.starts_with("--") {
             if *flag != "--all" {


### PR DESCRIPTION
The LS_DATE_RE regex expects English month names (Jan, Feb, etc.), but ls -la output uses numeric months (5, 6, etc.) when the user's locale sets LC_TIME to a non-English language.

This causes parse_ls_line() to fail on every line, making rtk ls always return '(empty)' on such systems (e.g. Chinese locale).

Fix by setting LC_TIME=C before executing ls, ensuring the date format is always 'May  3 12:23' regardless of system locale.

Fixes #(issue number if known)

## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

- Force `LC_TIME=C` in the `ls` command environment so that `ls -la` output always uses English month names, matching the `LS_DATE_RE` regex in `parse_ls_line()`
- Fixes `rtk ls` returning `(empty)` on systems with non-English locales (e.g. `zh_CN.UTF-8`)
-

## Test plan
<!-- How did you verify this works? -->
  - [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
  - [x] `LC_TIME=zh_CN.UTF-8 rtk ls` should now show files instead  of `(empty)`
  - [x] `rtk ls` with default English locale still works correctly
  - [x] Manual testing: `rtk ls` output inspected on both English and Chinese locale

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
