### PR TITLE
feat(skills): improve triage skills scalability for large repos

### DIFF
--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -2,7 +2,8 @@
 name: issue-triage
 description: >
   Issue triage: audit open issues, categorize, detect duplicates, cross-ref PRs, risk assessment, post comments.
-  Args: "all" for deep analysis of all, issue numbers to focus (e.g. "42 57"), "en"/"fr" for language, no arg = audit only in French.
+  Args: "all" for deep analysis of all, issue numbers to focus (e.g. "42 57"), "en"/"fr" for language,
+  "--focus recent" (default, last 60d), "--focus critical", "--focus stale", "--all" (everything).
 allowed-tools:
   - Bash
   - Read
@@ -35,6 +36,19 @@ tags: [triage, issues, github, categorize, duplicates, risk]
 
 ---
 
+## Modes de filtrage (argument `--focus`)
+
+| Mode | Comportement | Quand utiliser |
+|------|-------------|----------------|
+| `--focus recent` | Issues updatedAt < 60j (défaut si >200 issues) | Triage hebdomadaire normal |
+| `--focus critical` | Risque rouge + jaune uniquement | Avant sprint, incidents |
+| `--focus stale` | Aucune activité >30j | Nettoyage backlog |
+| `--all` | Toutes les issues ouvertes, paginé | Audit exhaustif mensuel |
+
+**Seuil automatique** : si le repo a >200 issues ouvertes, appliquer `--focus recent` par défaut et prévenir l'utilisateur : "400+ issues détectées — mode `--focus recent` activé (60 derniers jours). Passer `--all` pour tout voir."
+
+---
+
 Workflow en 3 phases : audit automatique → deep analysis opt-in → commentaires avec validation obligatoire.
 
 ## Préconditions
@@ -50,18 +64,20 @@ Si l'un échoue, stop et expliquer ce qui manque.
 
 ## Phase 1 — Audit (toujours exécutée)
 
-### Data Gathering (commandes en parallèle)
+### Data Gathering — deux passes
+
+**Passe 1 : métadonnées uniquement (rapide, sans body/comments)**
 
 ```bash
 # Identité du repo
 gh repo view --json nameWithOwner -q .nameWithOwner
 
-# Issues ouvertes avec métadonnées complètes
-gh issue list --state open --limit 100 \
-  --json number,title,author,createdAt,updatedAt,labels,assignees,body,comments
+# Issues ouvertes — métadonnées sans body ni comments (léger)
+gh issue list --state open --limit 500 \
+  --json number,title,author,createdAt,updatedAt,labels,assignees
 
-# PRs ouvertes (pour cross-référence)
-gh pr list --state open --limit 50 --json number,title,body
+# PRs ouvertes pour cross-référence (body nécessaire pour fixes #N)
+gh pr list --state open --limit 500 --json number,title,body
 
 # Issues fermées récemment (pour détection doublons)
 gh issue list --state closed --limit 20 \
@@ -76,6 +92,17 @@ gh api "repos/{owner}/{repo}/collaborators" --jq '.[].login'
 gh pr list --state merged --limit 10 --json author --jq '.[].author.login' | sort -u
 ```
 Si toujours ambigu, demander à l'utilisateur via `AskUserQuestion`.
+
+**Passe 2 : bodies (seulement pour les issues dans le scope)**
+
+Après application du filtre `--focus`, fetcher les bodies uniquement pour les issues retenues :
+
+```bash
+gh issue view {num} --json body,comments \
+  --jq '{body: .body, comments: (.comments[-5:] | map(.body))}'
+```
+
+Si issue a >50 commentaires, fetcher uniquement les 5 derniers.
 
 **Note** : `author` est un objet `{login: "..."}` — toujours extraire `.author.login`.
 
@@ -93,12 +120,21 @@ Si toujours ambigu, demander à l'utilisateur via `AskUserQuestion`.
 - Construire un map : `issue_number -> [PR numbers]`
 - Une issue liée à une PR mergée → recommander fermeture
 
-**3. Détection doublons** :
-- Normaliser les titres : lowercase, strip préfixes (`bug:`, `feat:`, `[bug]`, `[feature]`, etc.)
-- **Jaccard sur mots des titres** : si score > 60% entre deux issues → candidat doublon
-- **Keywords body overlap** > 50% → renforcement du signal
-- Comparer aussi avec issues fermées récentes (20 dernières)
-- Un faux positif peut être confirmé/écarté en Phase 2
+**3. Détection doublons — pré-filtrage obligatoire**
+
+Ne pas faire Jaccard brut sur toutes les paires (O(N²) = 160K comparaisons à 400 issues). Utiliser cette séquence :
+
+**Étape 3a — pré-filtre par n-grams** :
+- Extraire les mots-clés de chaque titre (lowercase, strip préfixes `bug:`, `feat:`, `[bug]`, etc., exclure stop words : a, the, is, in, of, for, to, with, on, at, by, and, or, not, it, this)
+- Grouper les issues qui partagent au moins 2 mots-clés communs → candidats Jaccard
+- Comparer aussi contre les 20 dernières issues fermées
+
+**Étape 3b — Jaccard sur candidats seulement** :
+- Jaccard = |intersection mots| / |union mots|
+- Score > 60% → candidat doublon confirmé
+- Score 40–60% + body overlap > 50% → candidat doublon faible (signaler mais ne pas clore sans Phase 2)
+
+Cette approche ramène les comparaisons de ~160K à ~2–5K.
 
 **4. Classification risque** :
 - **Rouge** : mots-clés `CVE`, `vulnerability`, `injection`, `auth bypass`, `security`, `exploit`, `unsafe`, `credentials`, `leak`, `RCE`, `XSS`
@@ -121,8 +157,10 @@ Si toujours ambigu, demander à l'utilisateur via `AskUserQuestion`.
 
 ### Output — 5 tableaux
 
+Si le scope dépasse 100 issues après filtrage, afficher les 50 les plus récentes par catégorie et indiquer "... et N autres (passer `--all` pour voir toutes)".
+
 ```
-## Issues ouvertes ({count})
+## Issues ouvertes ({total} total, {scope} dans le scope {mode})
 
 ### Critiques (risque rouge)
 | # | Titre | Auteur | Âge | Labels | Action |
@@ -145,7 +183,7 @@ Si toujours ambigu, demander à l'utilisateur via `AskUserQuestion`.
 | - | ----- | ------ | ----------------- | ------ |
 
 ### Résumé
-- Total : {N} issues ouvertes
+- Total : {N} issues ouvertes ({scope} dans le scope)
 - Critiques : {N} (risque sécurité ou breaking)
 - Liées à PR : {N}
 - Doublons candidats : {N}
@@ -162,7 +200,6 @@ Si toujours ambigu, demander à l'utilisateur via `AskUserQuestion`.
 
 Après affichage du tableau de triage, copier dans le presse-papier :
 ```bash
-# Cross-platform clipboard
 clip() {
   if command -v pbcopy &>/dev/null; then pbcopy
   elif command -v xclip &>/dev/null; then xclip -selection clipboard
@@ -184,7 +221,7 @@ Confirmer : `Tableau copié dans le presse-papier.` (FR) / `Triage table copied 
 ### Sélection des issues
 
 **Si argument passé** :
-- `"all"` → toutes les issues ouvertes
+- `"all"` → toutes les issues du scope actif (pas les 400 brutes)
 - Numéros (`"42 57"`) → uniquement ces issues
 - Pas d'argument → proposer via `AskUserQuestion`
 
@@ -195,8 +232,8 @@ question: "Quelles issues voulez-vous analyser en profondeur ?"
 header: "Deep Analysis"
 multiSelect: true
 options:
-  - label: "Toutes ({N} issues)"
-    description: "Analyse approfondie de toutes les issues avec agents en parallèle"
+  - label: "Toutes ({N} dans le scope)"
+    description: "Analyse approfondie — max 20 agents simultanés, batches si nécessaire"
   - label: "Critiques uniquement"
     description: "Focus sur les {M} issues à risque rouge/jaune"
   - label: "Doublons candidats"
@@ -209,9 +246,11 @@ options:
 
 Si "Passer" → fin du workflow.
 
+**Plafond agents** : lancer au maximum 20 agents en parallèle. Si la sélection dépasse 20 issues, traiter en batches de 20 et afficher la progression entre chaque batch.
+
 ### Exécution de l'analyse
 
-Pour chaque issue sélectionnée, lancer un agent via **Task tool en parallèle** :
+Pour chaque issue sélectionnée, lancer un agent via **Task tool en parallèle** (max 20 simultanés) :
 
 ```
 subagent_type: general-purpose
@@ -255,8 +294,6 @@ prompt: |
   Draft a GitHub comment in English using the appropriate template from templates/issue-comment.md.
   Be specific, helpful, and constructive.
 ```
-
-Si issue a >50 commentaires, résumer les 5 derniers uniquement.
 
 Agréger tous les rapports. Afficher un résumé après toutes les analyses.
 
@@ -342,15 +379,18 @@ Si "Aucune" → `Aucune action exécutée. Workflow terminé.`
 | Situation | Comportement |
 |-----------|--------------|
 | 0 issues ouvertes | `Aucune issue ouverte.` + terminer |
+| >200 issues ouvertes | Activer `--focus recent` auto, prévenir l'utilisateur |
 | Issue sans body | Catégoriser par titre, recommander `Comment needed` |
-| >50 commentaires | Résumer les 5 derniers uniquement |
+| >50 commentaires | Fetcher uniquement les 5 derniers |
+| Jaccard candidats >500 paires | Limiter à top 50 paires par score, signaler |
 | Faux positif doublon | Phase 2 confirme/écarte — ne pas agir sur suspicion seule |
 | Labels déjà présents | Ne pas re-labeler, signaler "label déjà appliqué" |
 | Issue d'un collaborateur | Jamais `close candidate` automatique |
-| Rate limit GitHub API | Réduire `--limit`, notifier l'utilisateur |
+| Rate limit GitHub API | Ralentir fetch bodies (pause 1s entre appels), notifier |
 | PR mergée liée à issue ouverte | Recommander fermeture de l'issue |
 | Issue sans activité >90j | Very Stale — proposer fermeture avec message bienveillant |
 | Duplicate confirmed in Phase 2 | Poster commentaire + fermer en faveur de l'issue originale |
+| Sélection deep analysis >20 issues | Traiter en batches de 20, afficher progression |
 
 ---
 
@@ -361,4 +401,5 @@ Si "Aucune" → `Aucune action exécutée. Workflow terminé.`
 - `updatedAt` peut être null sur certaines issues → traiter comme `createdAt`
 - Ne jamais poster ou fermer sans validation explicite de l'utilisateur dans le chat
 - Les commentaires draftés doivent être visibles AVANT tout `gh issue comment`
-- Similarité Jaccard = |intersection mots| / |union mots| (exclure stop words : a, the, is, in, of, for, to, with, on, at, by)
+- Jaccard = |intersection mots| / |union mots| (exclure stop words : a, the, is, in, of, for, to, with, on, at, by, and, or, not, it, this)
+- `--limit 500` couvre les backlogs jusqu'à 500 items ; au-delà utiliser `gh api` avec pagination curseur

--- a/.claude/skills/pr-triage/SKILL.md
+++ b/.claude/skills/pr-triage/SKILL.md
@@ -2,7 +2,8 @@
 name: pr-triage
 description: >
   PR triage: audit open PRs, deep review selected ones, draft and post review comments.
-  Args: "all" to review all, PR numbers to focus (e.g. "42 57"), "en"/"fr" for language, no arg = audit only in French.
+  Args: "all" to review all, PR numbers to focus (e.g. "42 57"), "en"/"fr" for language,
+  "--focus recent" (default, last 60d), "--focus critical" (bugs/security), "--all" (everything).
 allowed-tools:
   - Bash
   - Read
@@ -36,6 +37,19 @@ tags: [triage, pr, github, review, code-review, rtk]
 
 ---
 
+## Modes de filtrage (argument `--focus`)
+
+| Mode | Comportement | Quand utiliser |
+|------|-------------|----------------|
+| `--focus recent` | PRs updatedAt < 60j (défaut si >200 PRs) | Triage hebdomadaire normal |
+| `--focus critical` | CI dirty + CONFLICTING + overlaps détectés | Sprint urgent, avant merge |
+| `--focus stale` | Aucune activité >14j | Nettoyage backlog |
+| `--all` | Toutes les PRs ouvertes, paginé | Audit exhaustif mensuel |
+
+**Seuil automatique** : si le repo a >200 PRs ouvertes, appliquer `--focus recent` par défaut et prévenir l'utilisateur : "400+ PRs détectées — mode `--focus recent` activé (60 derniers jours). Passer `--all` pour tout voir."
+
+---
+
 Workflow en 3 phases : audit automatique → deep review opt-in → commentaires avec validation obligatoire.
 
 ## Préconditions
@@ -51,15 +65,17 @@ Si l'un échoue, stop et expliquer ce qui manque.
 
 ## Phase 1 — Audit (toujours exécutée)
 
-### Data Gathering (commandes en parallèle)
+### Data Gathering — deux passes
+
+**Passe 1 : métadonnées uniquement (rapide, sans body)**
 
 ```bash
 # Identité du repo
 gh repo view --json nameWithOwner -q .nameWithOwner
 
-# PRs ouvertes avec métadonnées complètes (ajouter body pour cross-référence issues)
-gh pr list --state open --limit 50 \
-  --json number,title,author,createdAt,updatedAt,additions,deletions,changedFiles,isDraft,mergeable,reviewDecision,statusCheckRollup,body
+# PRs ouvertes — métadonnées sans body (léger)
+gh pr list --state open --limit 500 \
+  --json number,title,author,createdAt,updatedAt,additions,deletions,changedFiles,isDraft,mergeable,reviewDecision,statusCheckRollup
 
 # Collaborateurs (pour distinguer "nos PRs" des externes)
 gh api "repos/{owner}/{repo}/collaborators" --jq '.[].login'
@@ -67,22 +83,35 @@ gh api "repos/{owner}/{repo}/collaborators" --jq '.[].login'
 
 **Fallback collaborateurs** : si `gh api .../collaborators` échoue (403/404) :
 ```bash
-# Extraire les auteurs des 10 derniers PRs mergés
 gh pr list --state merged --limit 10 --json author --jq '.[].author.login' | sort -u
 ```
 Si toujours ambigu, demander à l'utilisateur via `AskUserQuestion`.
 
-Pour chaque PR, récupérer reviews existantes ET fichiers modifiés :
+**Passe 2 : bodies + reviews (seulement pour les PRs dans le scope)**
+
+Après application du filtre `--focus`, fetcher uniquement les PRs retenues :
 
 ```bash
+# Body (pour cross-ref issues fixes #N)
+gh pr view {num} --json body --jq '.body'
+
+# Reviews existantes
 gh api "repos/{owner}/{repo}/pulls/{num}/reviews" \
   --jq '[.[] | .user.login + ":" + .state] | join(", ")'
+```
 
-# Fichiers modifiés (nécessaire pour overlap detection)
+**Fichiers modifiés (overlap detection — échantillon ciblé)**
+
+Ne fetcher les fichiers QUE pour les PRs répondant à TOUS ces critères :
+- `updatedAt` < 30 jours
+- additions < 1000 (skip les XL stales)
+- Pas en draft depuis >14j
+
+```bash
 gh pr view {num} --json files --jq '[.files[].path] | join(",")'
 ```
 
-**Note rate-limiting** : la récupération des fichiers est N appels API (1 par PR). Pour repos avec 20+ PRs, prioriser les PRs candidates à l'overlap (même domaine fonctionnel, même auteur).
+**Limite API** : si les PRs dans le scope dépassent 50 après filtrage, désactiver l'overlap detection et signaler : "Overlap detection désactivée (>50 PRs dans le scope). Passer des numéros explicites pour l'activer."
 
 **Note** : `author` est un objet `{login: "..."}` — toujours extraire `.author.login`.
 
@@ -100,7 +129,7 @@ gh pr view {num} --json files --jq '[.files[].path] | join(",")'
 Format taille : `+{additions}/-{deletions}, {files} files ({label})`
 
 **Détections** :
-- **Overlaps** : comparer les listes de fichiers entre PRs — si >50% de fichiers en commun → cross-reference
+- **Overlaps** : comparer les listes de fichiers entre PRs — si >50% de fichiers en commun → cross-reference (seulement sur l'échantillon ciblé, voir ci-dessus)
 - **Clusters** : auteur avec 3+ PRs ouvertes → suggérer ordre de review (plus petite en premier)
 - **Staleness** : aucune activité depuis >14j → flag "stale"
 - **CI status** : via `statusCheckRollup` → `clean` / `unstable` / `dirty`
@@ -124,8 +153,10 @@ _Externes — Problématiques_ : un des critères suivants :
 
 ### Output — Tableau de triage
 
+Si le scope dépasse 100 PRs après filtrage, afficher les 50 les plus récentes par catégorie et indiquer "... et N autres (passer `--all` pour voir toutes)".
+
 ```
-## PRs ouvertes ({count})
+## PRs ouvertes ({total} total, {scope} dans le scope {mode})
 
 ### Nos PRs
 | PR | Titre | Taille | CI | Status |
@@ -145,6 +176,7 @@ _Externes — Problématiques_ : un des critères suivants :
 - Clusters : {auteurs avec 3+ PRs}
 - Stale : {PRs sans activité >14j}
 - Overlaps : {PRs qui touchent les mêmes fichiers}
+- Hors scope (filtre actif) : {N PRs non affichées}
 ```
 
 0 PRs → afficher `Aucune PR ouverte.` et terminer.
@@ -153,7 +185,6 @@ _Externes — Problématiques_ : un des critères suivants :
 
 Après affichage du tableau de triage, copier dans le presse-papier :
 ```bash
-# Cross-platform clipboard
 clip() {
   if command -v pbcopy &>/dev/null; then pbcopy
   elif command -v xclip &>/dev/null; then xclip -selection clipboard
@@ -175,7 +206,7 @@ Confirmer : `Tableau copié dans le presse-papier.` (FR) / `Triage table copied 
 ### Sélection des PRs
 
 **Si argument passé** :
-- `"all"` → toutes les PRs externes
+- `"all"` → toutes les PRs externes du scope actif (pas les 400 brutes)
 - Numéros (`"42 57"`) → uniquement ces PRs
 - Pas d'argument → proposer via `AskUserQuestion`
 
@@ -186,8 +217,8 @@ question: "Quelles PRs voulez-vous reviewer en profondeur ?"
 header: "Deep Review"
 multiSelect: true
 options:
-  - label: "Toutes les externes"
-    description: "Review {N} PRs externes avec agents code-reviewer en parallèle"
+  - label: "Toutes les externes ({N} dans le scope)"
+    description: "Review avec agents code-reviewer en parallèle — max 15 agents simultanés"
   - label: "Problématiques uniquement"
     description: "Focus sur les {M} PRs à risque (CI dirty, trop large, overlaps)"
   - label: "Prêtes uniquement"
@@ -198,14 +229,16 @@ options:
 
 **Note sur les drafts** :
 - Les PRs en draft sont EXCLUES des options "Toutes les externes" et "Prêtes uniquement"
-- Les PRs en draft sont INCLUSES dans "Problématiques uniquement" (car elles nécessitent attention)
+- Les PRs en draft sont INCLUSES dans "Problématiques uniquement"
 - Pour reviewer un draft : taper son numéro explicitement (ex: `42`)
+
+**Plafond agents** : lancer au maximum 15 agents en parallèle. Si la sélection dépasse 15 PRs, traiter en batches de 15 et afficher la progression entre chaque batch.
 
 Si "Passer" → fin du workflow.
 
 ### Exécution des Reviews
 
-Pour chaque PR sélectionnée, lancer un agent `code-reviewer` via **Task tool en parallèle** :
+Pour chaque PR sélectionnée, lancer un agent `code-reviewer` via **Task tool en parallèle** (max 15 simultanés) :
 
 ```
 subagent_type: code-reviewer
@@ -302,7 +335,7 @@ gh pr comment {num} --body-file - <<'REVIEW_EOF'
 REVIEW_EOF
 ```
 
-Confirmer chaque post : `✅ Commentaire posté sur PR #{num}: {title}`
+Confirmer chaque post : `Commentaire posté sur PR #{num}: {title}`
 
 Si "Aucun" → `Aucun commentaire posté. Workflow terminé.`
 
@@ -313,12 +346,15 @@ Si "Aucun" → `Aucun commentaire posté. Workflow terminé.`
 | Situation | Comportement |
 |-----------|--------------|
 | 0 PRs ouvertes | `Aucune PR ouverte.` + terminer |
+| >200 PRs ouvertes | Activer `--focus recent` auto, prévenir l'utilisateur |
 | PR en draft | Indiquer dans tableau, skip pour review sauf si sélectionnée explicitement |
 | CI inconnu | Afficher `?` dans colonne CI |
 | Review agent timeout | Afficher erreur partielle, continuer avec les autres |
 | `gh pr diff` vide | Skip cette PR, notifier l'utilisateur |
 | PR très large (>5000 additions) | Avertir : "Review partielle, diff tronqué" |
 | Collaborateurs API 403/404 | Fallback sur auteurs des 10 derniers PRs mergés |
+| >50 PRs dans scope pour overlap | Désactiver overlap detection, signaler |
+| Sélection deep review >15 PRs | Traiter en batches de 15, afficher progression |
 
 ---
 
@@ -330,3 +366,4 @@ Si "Aucun" → `Aucun commentaire posté. Workflow terminé.`
 - `mergeable` peut être `MERGEABLE`, `CONFLICTING`, ou `UNKNOWN` → traiter `UNKNOWN` comme `?`
 - Ne jamais poster sans validation explicite de l'utilisateur dans le chat
 - Les commentaires draftés doivent être visibles AVANT tout `gh pr comment`
+- `--limit 500` couvre les backlogs jusqu'à 500 PRs ; au-delà utiliser `gh api` avec pagination curseur

--- a/.claude/skills/rtk-triage/SKILL.md
+++ b/.claude/skills/rtk-triage/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Triage complet RTK : exécute issue-triage + pr-triage en parallèle,
   puis croise les données pour détecter doubles couvertures, trous sécurité,
   P0 sans PR, et conflits internes. Sauvegarde dans claudedocs/RTK-YYYY-MM-DD.md.
-  Args: "en"/"fr" pour la langue (défaut: fr), "save" pour forcer la sauvegarde.
+  Args: "en"/"fr" pour la langue (défaut: fr), "--focus recent/critical/stale/all", "save" pour forcer la sauvegarde.
 allowed-tools:
   - Bash
   - Write
@@ -28,6 +28,19 @@ Orchestrateur de triage RTK. Fusionne issue-triage + pr-triage et produit une an
 
 ---
 
+## Modes de filtrage
+
+| Mode | Issues | PRs | Quand utiliser |
+|------|--------|-----|----------------|
+| `--focus recent` (défaut si >200) | updatedAt < 60j | updatedAt < 60j | Triage hebdomadaire |
+| `--focus critical` | risque rouge + jaune | CI dirty + CONFLICTING | Avant sprint urgent |
+| `--focus stale` | >30j sans activité | >14j sans activité | Nettoyage backlog |
+| `--all` | Toutes, paginé | Toutes, paginé | Audit mensuel exhaustif |
+
+**Seuil automatique** : si >200 issues OU >200 PRs détectées, activer `--focus recent` et prévenir l'utilisateur avant de continuer.
+
+---
+
 ## Workflow en 4 phases
 
 ### Phase 0 — Préconditions
@@ -35,22 +48,23 @@ Orchestrateur de triage RTK. Fusionne issue-triage + pr-triage et produit une an
 ```bash
 git rev-parse --is-inside-work-tree
 gh auth status
+date +%Y-%m-%d
 ```
 
-Vérifier que la date actuelle est connue (utiliser `date +%Y-%m-%d`).
+Si >200 issues ou >200 PRs, annoncer : "Repo à fort volume ({N} PRs, {M} issues). Mode `--focus recent` actif. Passer `--all` pour un audit exhaustif (plus lent)."
 
 ---
 
 ### Phase 1 — Data gathering (parallèle)
 
-Lancer les deux collectes simultanément :
+Lancer les deux collectes simultanément. Utiliser une approche deux passes (métadonnées d'abord, bodies ensuite sur le scope filtré).
 
-**Issues** :
+**Issues — Passe 1 (métadonnées)**:
 ```bash
 gh repo view --json nameWithOwner -q .nameWithOwner
 
-gh issue list --state open --limit 150 \
-  --json number,title,author,createdAt,updatedAt,labels,assignees,body
+gh issue list --state open --limit 500 \
+  --json number,title,author,createdAt,updatedAt,labels,assignees
 
 gh issue list --state closed --limit 20 \
   --json number,title,labels,closedAt
@@ -58,46 +72,68 @@ gh issue list --state closed --limit 20 \
 gh api "repos/{owner}/{repo}/collaborators" --jq '.[].login'
 ```
 
-**PRs** :
+**Issues — Passe 2 (bodies sur le scope filtré uniquement)**:
 ```bash
-# Fetcher toutes les PRs ouvertes — paginer si nécessaire (gh limite à 200 par appel)
-gh pr list --state open --limit 200 \
+# Pour chaque issue dans le scope :
+gh issue view {num} --json body --jq '.body'
+```
+
+**PRs — Passe 1 (métadonnées)**:
+```bash
+gh pr list --state open --limit 500 \
   --json number,title,author,createdAt,updatedAt,additions,deletions,changedFiles,isDraft,mergeable,reviewDecision,statusCheckRollup,body
+```
 
-# Si le repo a >200 PRs ouvertes, relancer avec --search pour paginer :
-# gh pr list --state open --limit 200 --search "is:pr is:open sort:updated-desc" ...
+**PRs — Passe 2 (fichiers modifiés — échantillon ciblé)**:
 
-# Pour chaque PR, récupérer les fichiers modifiés (nécessaire pour overlap detection)
-# Prioriser les PRs candidates (même domaine, même auteur)
+Ne fetcher les fichiers QUE pour les PRs répondant à TOUS ces critères :
+- `updatedAt` < 30 jours
+- additions < 1000
+- Pas en draft depuis >14j
+
+```bash
 gh pr view {num} --json files --jq '[.files[].path] | join(",")'
+```
+
+Si les PRs candidates dépassent 50, désactiver l'overlap detection et signaler.
+
+**Pagination si >400 items** : utiliser `gh api` avec curseur :
+```bash
+# Issues au-delà de 400
+gh api "repos/{owner}/{repo}/issues?state=open&per_page=100&page=2" \
+  --jq '[.[] | {number: .number, title: .title, updatedAt: .updated_at}]'
+# Répéter page=3, page=4... jusqu'à réponse vide
 ```
 
 ---
 
 ### Phase 2 — Triage individuel
 
-Exécuter les analyses de `/issue-triage` et `/pr-triage` séparément (même logique que les skills individuels) pour produire :
+Appliquer la logique de `/issue-triage` et `/pr-triage` sur le scope filtré (pas les 400 brutes).
 
 **Issues** :
 - Catégorisation (Bug/Feature/Enhancement/Question/Duplicate)
 - Risque (Rouge/Jaune/Vert)
-- Staleness (>30j)
+- Staleness (>30j / >90j)
 - Map `issue_number → [PR numbers]` via scan `fixes #N`, `closes #N`, `resolves #N`
+- Détection doublons : pré-filtre n-grams → Jaccard sur candidats seulement (cap 5K comparaisons max)
 
 **PRs** :
 - Taille (XS/S/M/L/XL)
 - CI status (clean/dirty)
 - Nos PRs vs externes
-- Overlaps (>50% fichiers communs entre 2 PRs)
+- Overlaps (>50% fichiers communs — sur l'échantillon ciblé uniquement)
 - Clusters (auteur avec 3+ PRs)
 
 Afficher les tableaux standards de chaque skill (voir SKILL.md de issue-triage et pr-triage pour le format exact).
+
+Si le scope dépasse 100 items par catégorie, afficher les 50 les plus récents + "... et N autres".
 
 ---
 
 ### Phase 3 — Analyse croisée (cœur de ce skill)
 
-C'est ici que ce skill apporte de la valeur au-delà des deux skills individuels.
+**Fenêtre d'analyse** : pour limiter la combinatoire, travailler sur les 100 issues et 100 PRs les plus récemment actives du scope. Signaler si des items sont exclus : "Analyse croisée sur les 100 issues × 100 PRs les plus actives. {N} items exclus de la fenêtre."
 
 #### 3.1 Double couverture — 2 PRs pour 1 issue
 
@@ -115,7 +151,7 @@ Règle de verdict :
 
 #### 3.2 Trous de couverture sécurité
 
-Pour chaque issue rouge (#640-type security review) :
+Pour chaque issue rouge (security review) dans la fenêtre :
 - Lister les sous-findings mentionnés dans le body
 - Croiser avec les PRs existantes (mots-clés dans titre/body)
 - Identifier les findings sans PR
@@ -145,8 +181,7 @@ Chercher un pattern commun (ex: "cap hardcodé", "exit code perdu") — si 3+ bu
 #### 3.4 Nos PRs dirty — causes probables
 
 Pour chaque PR interne avec CI dirty ou CONFLICTING :
-- Vérifier si un autre PR touche les mêmes fichiers
-- Vérifier si un merge récent sur develop peut expliquer le conflit
+- Vérifier si une autre PR touche les mêmes fichiers (overlap)
 - Recommander : rebase, fermeture, ou attente
 
 Format :
@@ -171,6 +206,8 @@ Puis afficher le résumé chiffré :
 ```
 ## Résumé chiffré — YYYY-MM-DD
 
+Scope : {N} PRs, {M} issues ({mode} actif)
+
 | Catégorie | Count |
 |-----------|-------|
 | PRs prêtes à merger (nos) | N |
@@ -180,18 +217,16 @@ Puis afficher le résumé chiffré :
 | Security findings sans PR | N |
 | Nos PRs dirty à rebaser | N |
 | PRs à fermer (recommandé) | N |
+| Items hors fenêtre d'analyse | N |
 ```
 
 #### Sauvegarder dans claudedocs
-
-```bash
-date +%Y-%m-%d  # Pour construire le nom de fichier
-```
 
 Sauvegarder dans `claudedocs/RTK-YYYY-MM-DD.md` avec :
 - Les tableaux de triage issues + PRs (Phase 2)
 - L'analyse croisée complète (Phase 3)
 - Le résumé chiffré
+- Le mode utilisé (`--focus recent` / `--all` / etc.)
 
 Confirmer : `Sauvegardé dans claudedocs/RTK-YYYY-MM-DD.md`
 
@@ -202,7 +237,7 @@ Confirmer : `Sauvegardé dans claudedocs/RTK-YYYY-MM-DD.md`
 ```markdown
 # RTK Triage — YYYY-MM-DD
 
-Croisement issues × PRs. {N} PRs ouvertes, {N} issues ouvertes.
+Scope : {N} PRs, {M} issues. Mode : {--focus recent / --all}.
 
 ---
 
@@ -238,7 +273,9 @@ Croisement issues × PRs. {N} PRs ouvertes, {N} issues ouvertes.
 ## Règles
 
 - Langue : argument `en`/`fr`. Défaut : `fr`. Les commentaires GitHub restent toujours en anglais.
-- Ne jamais poster de commentaires GitHub sans validation utilisateur (AskUserQuestion).
-- Si >200 issues ou >200 PRs : prévenir l'utilisateur et paginer (relancer avec `--search` ou `gh api` avec pagination).
-- L'analyse croisée (Phase 3) est toujours exécutée — c'est la valeur ajoutée de ce skill.
+- Ne jamais poster de commentaires GitHub sans validation utilisateur.
+- Si >200 issues ou >200 PRs : activer `--focus recent` automatiquement, prévenir l'utilisateur.
+- L'analyse croisée (Phase 3) est toujours exécutée sur la fenêtre d'analyse.
 - Le fichier claudedocs est sauvegardé automatiquement sauf si l'utilisateur dit "no save".
+- `--limit 500` couvre jusqu'à 500 items. Au-delà : pagination `gh api` page par page.
+- La fenêtre d'analyse croisée est plafonnée à 100 issues × 100 PRs pour éviter la combinatoire.


### PR DESCRIPTION
## Summary

- Add `--focus` modes (recent/critical/stale/all) with auto-activation above 200 items — prevents token explosion on large repos
- Two-pass data gathering: metadata first, bodies only for scoped items (faster, cheaper)
- Cap parallel agents: 20 for issue-triage, 15 for pr-triage, with batching above the limit
- Duplicate detection rewrite: n-gram pre-filter cuts Jaccard comparisons from ~160K to ~2-5K on a 400-issue repo
- Overlap detection capped to a targeted sample (updatedAt <30d, additions <1000, not stale draft)
- Pagination support via `gh api` cursor for repos beyond 400 items
- Cross-analysis window in rtk-triage capped at 100 issues x 100 PRs to avoid combinatorial explosion

## Test plan

- [ ] Run `/issue-triage` on a repo with >200 open issues, verify `--focus recent` activates automatically
- [ ] Run `/pr-triage --focus critical` and confirm only CI-dirty + CONFLICTING PRs appear
- [ ] Run `/rtk-triage --all` and verify pagination kicks in beyond 400 items
- [ ] Confirm agent batching works when selecting >20 issues for deep analysis
- [ ] Verify duplicate detection still catches obvious dupes with n-gram pre-filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)