### PR TITLE
enforce LC_ALL=C for ls, fix #1715

### DIFF
--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -35,6 +35,10 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         .collect();
 
     let mut cmd = resolved_command("ls");
+    // Force C locale so month names are in English (Jan-Dec),
+    // which the date regex expects. Non-English locales produce
+    // localized month names that break parsing.
+    cmd.env("LC_ALL", "C");
     cmd.arg("-la");
     for flag in &flags {
         if flag.starts_with("--") {


### PR DESCRIPTION
enforce LC_ALL=C for ls, fix https://github.com/rtk-ai/rtk/issues/1715

## RTK `ls` Locale Bug — Root Cause Analysis

### Symptom

- `ls` shows normal directory output
- `rtk ls` returns `(empty)` even when the directory contains files

### Root Cause

RTK's `ls` parser relies on a **date regex** that only matches **English month names** (`@src/cmds/system/ls.rs:15-18`):

```rust
static ref LS_DATE_RE: Regex = Regex::new(
    r"\s+(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}\s+(?:\d{4}|\d{2}:\d{2})\s+"
).unwrap();
```

This regex is used in `parse_ls_line()` (`@ls.rs:124`) to anchor the line and extract the filename:

```rust
fn parse_ls_line(line: &str) -> Option<(char, u64, String)> {
    let date_match = LS_DATE_RE.find(line)?;  // Returns None for non-English months
    let name = line[date_match.end()..].to_string();
    // ...
}
```

When the system locale is **non-English** (e.g., Chinese `zh_CN.UTF-8`), `ls -la` outputs localized month names:

```
# English locale (C)
-rw-r--r-- 1 user staff 1234 May  5 12:00 file.txt

# Chinese locale (zh_CN.UTF-8)
-rw-r--r-- 1 user staff 1234  5月  5 12:00 file.txt
```

The regex fails to match `5月` (or any non-English month), so `parse_ls_line()` returns `None` for **every line**. All lines are skipped by `continue` in `compact_ls()` (`@ls.rs:166`). With zero directories and zero files parsed, the function falls into the empty case (`@ls.rs:193-195`):

```rust
if dirs.is_empty() && files.is_empty() {
    return ("(empty)\n".to_string(), String::new());
}
```
