### PR TITLE
fix(kubectl): compact get pods and services aliases

### DIFF
--- a/src/cmds/cloud/container.rs
+++ b/src/cmds/cloud/container.rs
@@ -612,6 +612,45 @@ pub fn run_compose_passthrough(args: &[OsString], verbose: u8) -> Result<i32> {
     crate::core::runner::run_passthrough("docker", &combined, verbose)
 }
 
+pub fn run_kubectl_get(args: &[String], verbose: u8) -> Result<i32> {
+    match kubectl_get_target(args) {
+        Some(("pods", rest)) => run(ContainerCmd::KubectlPods, rest, verbose),
+        Some(("services", rest)) => run(ContainerCmd::KubectlServices, rest, verbose),
+        _ => run_kubectl_get_passthrough(args, verbose),
+    }
+}
+
+fn kubectl_get_target(args: &[String]) -> Option<(&'static str, &[String])> {
+    let resource = args.first()?.as_str();
+    let rest = &args[1..];
+    if kubectl_get_requests_raw_output(rest) {
+        return None;
+    }
+
+    match resource {
+        "po" | "pod" | "pods" => Some(("pods", rest)),
+        "svc" | "service" | "services" => Some(("services", rest)),
+        _ => None,
+    }
+}
+
+fn kubectl_get_requests_raw_output(args: &[String]) -> bool {
+    args.iter().any(|arg| {
+        matches!(
+            arg.as_str(),
+            "-o" | "--output" | "-w" | "--watch" | "--show-labels" | "--show-kind"
+        ) || arg.starts_with("-o")
+            || arg.starts_with("--output=")
+    })
+}
+
+fn run_kubectl_get_passthrough(args: &[String], verbose: u8) -> Result<i32> {
+    let passthrough_args: Vec<OsString> = std::iter::once(OsString::from("get"))
+        .chain(args.iter().map(|arg| OsString::from(arg.as_str())))
+        .collect();
+    run_kubectl_passthrough(&passthrough_args, verbose)
+}
+
 pub fn run_kubectl_passthrough(args: &[OsString], verbose: u8) -> Result<i32> {
     crate::core::runner::run_passthrough("kubectl", args, verbose)
 }
@@ -751,5 +790,55 @@ api-1  | Connected to database";
     fn test_compact_ports_many() {
         let result = compact_ports("0.0.0.0:80->80/tcp, 0.0.0.0:443->443/tcp, 0.0.0.0:8080->8080/tcp, 0.0.0.0:9090->9090/tcp");
         assert!(result.contains("..."), "should truncate for >3 ports");
+    }
+
+    #[test]
+    fn test_kubectl_get_target_pods_aliases() {
+        for resource in ["po", "pod", "pods"] {
+            let args = vec![resource.to_string(), "-n".to_string(), "default".to_string()];
+
+            assert_eq!(
+                kubectl_get_target(&args),
+                Some(("pods", &args[1..])),
+                "failed for {resource}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_kubectl_get_target_services_aliases() {
+        for resource in ["svc", "service", "services"] {
+            let args = vec![resource.to_string(), "-A".to_string()];
+
+            assert_eq!(
+                kubectl_get_target(&args),
+                Some(("services", &args[1..])),
+                "failed for {resource}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_kubectl_get_target_unsupported_resource() {
+        let args = vec!["deployments".to_string()];
+
+        assert_eq!(kubectl_get_target(&args), None);
+    }
+
+    #[test]
+    fn test_kubectl_get_target_respects_output_flags() {
+        for output_flag in ["-o", "-owide", "--output", "--output=json"] {
+            let args = vec![
+                "pods".to_string(),
+                output_flag.to_string(),
+                "wide".to_string(),
+            ];
+
+            assert_eq!(
+                kubectl_get_target(&args),
+                None,
+                "should pass through {output_flag}"
+            );
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -942,6 +942,12 @@ enum ComposeCommands {
 
 #[derive(Debug, Subcommand)]
 enum KubectlCommands {
+    /// Get Kubernetes resources (compact for pods/services)
+    Get {
+        /// kubectl get arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
     /// List pods
     Pods {
         #[arg(short, long)]
@@ -1724,6 +1730,7 @@ fn run_cli() -> Result<i32> {
         },
 
         Commands::Kubectl { command } => match command {
+            KubectlCommands::Get { args } => container::run_kubectl_get(&args, cli.verbose)?,
             KubectlCommands::Pods { namespace, all } => {
                 let mut args: Vec<String> = Vec::new();
                 if all {
@@ -2637,6 +2644,18 @@ mod tests {
                 assert_eq!(agent, Some(AgentTarget::Hermes));
             }
             _ => panic!("Expected Init command"),
+        }
+    }
+
+    #[test]
+    fn test_try_parse_kubectl_get_alias() {
+        let cli = Cli::try_parse_from(["rtk", "kubectl", "get", "pods", "-n", "default"]).unwrap();
+
+        match cli.command {
+            Commands::Kubectl {
+                command: KubectlCommands::Get { args },
+            } => assert_eq!(args, vec!["pods", "-n", "default"]),
+            _ => panic!("Expected Kubectl Get command"),
         }
     }
 


### PR DESCRIPTION
## Summary
- Route `rtk kubectl get pods` / `get services` aliases through the existing compact pod and service filters.
- Preserve raw kubectl passthrough for unsupported resources and explicit output/detail/watch flags such as `-o name` or `--watch`.
- Add unit coverage for the new `get` parser path and kubectl resource alias routing.

## Context
RTK's hook already rewrites `kubectl get pods` to `rtk kubectl get pods`, but that form currently falls through to raw kubectl output instead of using the compact pod/service filters. This made `rtk gain` show little or no savings for kubectl-heavy sessions, even though kubectl is listed as a supported infrastructure command.

This PR keeps the existing rewrite shape and makes `rtk kubectl get pods` / `get services` use the same compact filters as `rtk kubectl pods` / `services`. Explicit output/detail flags like `-o name` still pass through raw kubectl output.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D unsafe_code`
- [x] `cargo test --all`
- [x] Manual testing: `./target/debug/rtk kubectl get pods`, `./target/debug/rtk kubectl get svc`, `./target/debug/rtk kubectl get pods -o name`

Made with [Cursor](https://cursor.com)