### PR TITLE
fix(terraform): preserve long plan and HCL data output

### DIFF
--- a/src/core/filter.rs
+++ b/src/core/filter.rs
@@ -69,9 +69,8 @@ impl Language {
             "rb" => Language::Ruby,
             "sh" | "bash" | "zsh" => Language::Shell,
             "json" | "jsonc" | "json5" | "yaml" | "yml" | "toml" | "xml" | "csv" | "tsv"
-            | "graphql" | "gql" | "sql" | "md" | "markdown" | "txt" | "env" | "lock" => {
-                Language::Data
-            }
+            | "graphql" | "gql" | "sql" | "md" | "markdown" | "txt" | "env" | "lock" | "tf"
+            | "tfvars" | "hcl" => Language::Data,
             _ => Language::Unknown,
         }
     }
@@ -320,10 +319,23 @@ pub fn get_filter(level: FilterLevel) -> Box<dyn FilterStrategy> {
     }
 }
 
-pub fn smart_truncate(content: &str, max_lines: usize, _lang: &Language) -> String {
+pub fn smart_truncate(content: &str, max_lines: usize, lang: &Language) -> String {
     let lines: Vec<&str> = content.lines().collect();
     if lines.len() <= max_lines {
         return content.to_string();
+    }
+
+    if max_lines == 0 {
+        return format!("[{} more lines]", lines.len());
+    }
+
+    if *lang == Language::Data {
+        let mut result = lines[..max_lines]
+            .iter()
+            .map(|line| (*line).to_string())
+            .collect::<Vec<_>>();
+        result.push(format!("[{} more lines]", lines.len() - max_lines));
+        return result.join("\n");
     }
 
     let mut result = Vec::with_capacity(max_lines + 1);
@@ -395,6 +407,9 @@ mod tests {
         assert_eq!(Language::from_extension("csv"), Language::Data);
         assert_eq!(Language::from_extension("md"), Language::Data);
         assert_eq!(Language::from_extension("lock"), Language::Data);
+        assert_eq!(Language::from_extension("tf"), Language::Data);
+        assert_eq!(Language::from_extension("tfvars"), Language::Data);
+        assert_eq!(Language::from_extension("hcl"), Language::Data);
     }
 
     #[test]
@@ -531,6 +546,23 @@ fn main() {
         assert!(output.contains("[9 more lines]"));
         // Only the first line is kept (plain-text, no important signatures)
         assert!(output.starts_with("line1\n"));
+    }
+
+    #[test]
+    fn test_smart_truncate_data_keeps_contiguous_prefix() {
+        let input = (0..10)
+            .map(|i| format!("resource line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let output = smart_truncate(&input, 5, &Language::Data);
+
+        assert!(
+            output.contains("resource line 4"),
+            "data truncation should keep the requested prefix:\n{output}"
+        );
+        assert!(!output.contains("resource line 5"));
+        assert!(output.contains("[5 more lines]"));
     }
 
     #[test]

--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -1093,6 +1093,34 @@ max_lines = 999
     }
 
     #[test]
+    fn test_terraform_plan_preserves_long_useful_output() {
+        let filters = make_filters(BUILTIN_TOML);
+        let filter = find_filter_in("terraform plan", &filters).expect("terraform-plan built-in");
+
+        let mut input = String::from(
+            "Acquiring state lock. This may take a few moments...\n\
+             Refreshing state... [id=vpc-0a1b2c3d]\n\
+             Terraform will perform the following actions:\n",
+        );
+        for i in 0..90 {
+            input.push_str(&format!("      + attribute_{i:02} = \"value_{i:02}\"\n"));
+        }
+        input.push_str(
+            "Plan: 1 to add, 0 to change, 0 to destroy.\n\
+             Releasing state lock. This may take a few moments...\n",
+        );
+
+        let out = apply_filter(filter, &input);
+
+        assert!(
+            !out.contains("lines truncated"),
+            "terraform plan should not truncate useful plan content:\n{out}"
+        );
+        assert!(out.contains("attribute_89"));
+        assert!(out.contains("Plan: 1 to add, 0 to change, 0 to destroy."));
+    }
+
+    #[test]
     fn test_make_savings_above_60pct() {
         let filters = make_filters(BUILTIN_TOML);
         let filter = find_filter_in("make all", &filters).expect("make built-in");

--- a/src/filters/terraform-plan.toml
+++ b/src/filters/terraform-plan.toml
@@ -9,7 +9,6 @@ strip_lines_matching = [
   "^Acquiring state lock",
   "^Releasing state lock",
 ]
-max_lines = 80
 on_empty = "terraform plan: no changes detected"
 
 [[tests.terraform-plan]]


### PR DESCRIPTION
## Summary
- Remove the built-in `terraform plan` max-lines cap so long useful plan output is preserved.
- Treat `.tf`, `.tfvars`, and `.hcl` files as data formats.
- Keep data-file truncation as a contiguous prefix instead of applying code-oriented smart selection.

## Why
RTK could hide useful Terraform plan blocks after filtering because the TOML filter capped retained output at 80 lines. HCL/Terraform files could also be treated as unknown code, which made `rtk read --max-lines` skip lines in the middle of structured configuration.

## Validation
- `cargo fmt --all --check`
- `cargo clippy --all-targets`
- `cargo test`

Note: `cargo clippy --all-targets` completes successfully on `develop`; it reports pre-existing warnings in `src/cmds/js/pnpm_cmd.rs`, left out of this PR to keep the scope focused.