### PR TITLE
feat(discover): route git rev-parse through rtk for analytics tracking

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1025,7 +1025,7 @@ mod tests {
         // Verify that every GitCommand subcommand has a matching pattern
         for subcmd in [
             "status", "log", "diff", "show", "add", "commit", "push", "pull", "branch", "fetch",
-            "stash", "worktree",
+            "stash", "worktree", "rev-parse",
         ] {
             let cmd = format!("git {subcmd}");
             match classify_command(&cmd) {
@@ -1033,6 +1033,28 @@ mod tests {
                 other => panic!("git {subcmd} should be Supported, got {other:?}"),
             }
         }
+    }
+
+    #[test]
+    fn test_classify_git_rev_parse() {
+        // rev-parse is a passthrough subcommand (#1729): no filtering, just routes
+        // through `rtk git` so usage is tracked in `rtk gain` analytics.
+        for args in [
+            "git rev-parse HEAD",
+            "git rev-parse --show-toplevel",
+            "git rev-parse --abbrev-ref HEAD",
+        ] {
+            match classify_command(args) {
+                Classification::Supported { rtk_equivalent, .. } => {
+                    assert_eq!(rtk_equivalent, "rtk git");
+                }
+                other => panic!("{args} should be Supported, got {other:?}"),
+            }
+        }
+        assert_eq!(
+            rewrite_command("git rev-parse --show-toplevel", &[]),
+            Some("rtk git rev-parse --show-toplevel".into())
+        );
     }
 
     #[test]

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -12,7 +12,7 @@ pub struct RtkRule {
 
 pub const RULES: &[RtkRule] = &[
     RtkRule {
-        pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|push|pull|branch|fetch|stash|worktree)",
+        pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|push|pull|branch|fetch|stash|worktree|rev-parse)",
         rtk_cmd: "rtk git",
         rewrite_prefixes: &["git", "yadm"],
         category: "Git",


### PR DESCRIPTION
Closes #1729

## Summary

Add `rev-parse` to the `rtk git` subcommand alternation in `src/discover/rules.rs` so invocations like `git rev-parse HEAD`, `git rev-parse --show-toplevel`, and `git rev-parse --abbrev-ref HEAD` are classified as `Supported` and rewritten to `rtk git rev-parse ...`.

## Why

Per #1729: 67 invocations of `git rev-parse` in 30 days don't show up in `rtk gain` analytics because the auto-rewrite hook didn't recognize the subcommand. Output is already minimal (one line) so no filtering is needed this is hygiene/tracking only, keeping behavior consistent with the rest of the `git *` family.

## Implementation

- `src/discover/rules.rs`: add `rev-parse` to the alternation group of the existing git rule
- `src/discover/registry.rs`: extend `test_registry_covers_all_git_subcommands` to cover `rev-parse`, plus a new `test_classify_git_rev_parse` exercising the three forms from the issue and asserting the rewrite

The existing `GitCommands::Other` external_subcommand variant in `main.rs` already handles execution as passthrough, so no dispatch change in `src/cmds/git/git.rs` is needed.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --bin rtk` — 1730 passed, 0 failed
- [x] new test `test_classify_git_rev_parse` passes