### PR TITLE
docs: align telemetry disclaimer with opt-in policy

### DIFF
--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -22,7 +22,7 @@ This software interacts with your development environment, file system, and exte
 
 ## Telemetry
 
-This software collects anonymous, aggregate usage metrics by default and can be disabled at any time. No personally identifiable information, source code, file paths, command arguments, or secrets are collected. See the README for full details and opt-out instructions.
+This software can collect anonymous, aggregate usage metrics only after explicit opt-in consent. Telemetry is disabled by default and can be disabled at any time. No personally identifiable information, source code, file paths, command arguments, or secrets are collected. See the README and docs/TELEMETRY.md for full details and consent management instructions.
 
 ---
 


### PR DESCRIPTION
## Summary
- Aligns DISCLAIMER.md with README and docs/TELEMETRY.md telemetry language.
- Clarifies telemetry is disabled by default and requires explicit opt-in consent.
- Points readers to docs/TELEMETRY.md for consent management details.

## Context
README.md and docs/TELEMETRY.md both state telemetry is disabled by default and requires explicit opt-in. DISCLAIMER.md still said metrics are collected by default, which creates a privacy-documentation conflict.

## Test Plan
- [x] Documentation-only change
- [x] `git diff --check`