### PR TITLE
Fix link to user guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ brew uninstall rtk           # If installed via Homebrew
 
 ## Documentation
 
-- **[rtk-ai.app/guide](https://www.rtk-ai.app/guide)** — full user guide (installation, supported agents, what gets optimized, analytics, configuration, troubleshooting)
+- **[rtk-ai.app/guide](https://www.rtk-ai.app)** — full user guide (installation, supported agents, what gets optimized, analytics, configuration, troubleshooting)
 - **[INSTALL.md](INSTALL.md)** — detailed installation reference
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — system design and technical decisions
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** — contribution guide


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

- /guide is 404

## Test plan
<!-- How did you verify this works? -->

- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
