### PR TITLE
Update telemetry documentation link to use 'master' branch

### DIFF
--- a/src/core/telemetry_cmd.rs
+++ b/src/core/telemetry_cmd.rs
@@ -55,7 +55,7 @@ fn run_status() -> Result<()> {
 
     println!();
     println!("Data controller: RTK AI Labs, contact@rtk-ai.app");
-    println!("Details: https://github.com/rtk-ai/rtk/blob/main/docs/TELEMETRY.md");
+    println!("Details: https://github.com/rtk-ai/rtk/blob/master/docs/TELEMETRY.md");
 
     Ok(())
 }
@@ -73,7 +73,7 @@ fn run_enable() -> Result<()> {
     eprintln!();
     eprintln!("  What:    command names (not arguments), token savings, OS, version");
     eprintln!("  Who:     RTK AI Labs, contact@rtk-ai.app");
-    eprintln!("  Details: https://github.com/rtk-ai/rtk/blob/main/docs/TELEMETRY.md");
+    eprintln!("  Details: https://github.com/rtk-ai/rtk/blob/master/docs/TELEMETRY.md");
     eprintln!();
     eprint!("Enable anonymous telemetry? [y/N] ");
 

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -421,7 +421,7 @@ fn prompt_telemetry_consent() -> Result<()> {
     eprintln!("  Who:     RTK AI Labs, contact@rtk-ai.app");
     eprintln!("  Rights:  disable anytime with `rtk telemetry disable`,");
     eprintln!("           request erasure with `rtk telemetry forget`");
-    eprintln!("  Details: https://github.com/rtk-ai/rtk/blob/main/docs/TELEMETRY.md");
+    eprintln!("  Details: https://github.com/rtk-ai/rtk/blob/master/docs/TELEMETRY.md");
     eprintln!();
     eprint!("Enable anonymous telemetry? [y/N] ");
 


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->
* fix: update telemetry documentation link to use 'master' branch

<img width="491" height="155" alt="image" src="https://github.com/user-attachments/assets/b4f3c17e-b2e2-4a3c-bbd1-5c5b18a2bc23" />

https://github.com/rtk-ai/rtk/blob/main/docs/TELEMETRY.md
->
https://github.com/rtk-ai/rtk/blob/master/docs/TELEMETRY.md

## Test plan
<!-- How did you verify this works? -->

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected
<img width="538" height="188" alt="image" src="https://github.com/user-attachments/assets/2d1fe13b-92d6-4928-af99-0289c815e23f" />

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
