### PR TITLE
feat(update): add verified self-update command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,6 +375,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,7 +708,10 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
+ "bitflags",
  "libc",
+ "plain",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -785,6 +799,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -835,6 +855,15 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "redox_users"
@@ -892,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "rtk"
-version = "0.36.0"
+version = "0.34.3"
 dependencies = [
  "anyhow",
  "automod",
@@ -911,6 +940,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tar",
  "tempfile",
  "toml",
  "ureq",
@@ -1121,6 +1151,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -1758,6 +1799,16 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ flate2 = "1.0"
 quick-xml = "0.37"
 which = "8"
 automod = "1"
+tar = "0.4"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -67,6 +67,41 @@ rtk gain  # MUST show token savings, not "command not found"
 
 ⚠️ **WARNING**: `cargo install rtk` from crates.io might install the wrong package. Always verify with `rtk gain`.
 
+## Updating RTK
+
+Check for a newer release:
+
+```bash
+rtk update --check
+```
+
+Update a direct release install:
+
+```bash
+rtk update
+```
+
+Install a specific release tag:
+
+```bash
+rtk update --tag v0.39.0
+```
+
+`rtk update` downloads the matching GitHub release archive, verifies it against `checksums.txt`, rejects unsafe archive paths, and replaces the current binary atomically.
+
+Package-manager installs remain owned by their package manager. If RTK detects one of these installs, it prints the correct command instead of replacing the binary:
+
+```bash
+brew upgrade rtk
+cargo install --git https://github.com/rtk-ai/rtk --force
+```
+
+For binaries built from this repository, update with:
+
+```bash
+cargo install --path . --force
+```
+
 ## Project Initialization
 
 ### Which mode to choose?

--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ rtk gain        # Should show token savings stats
 
 > **Name collision warning**: Another project named "rtk" (Rust Type Kit) exists on crates.io. If `rtk gain` fails, you have the wrong package. Use `cargo install --git` above instead.
 
+### Update RTK
+
+```bash
+rtk update          # Update direct release installs
+rtk update --check  # Check whether a newer release is available
+```
+
+`rtk update` verifies release checksums before replacing the current binary. Homebrew, Cargo, and source-build installs stay managed by their installer; RTK prints the matching upgrade command instead of overwriting those installations.
+
 ## Quick Start
 
 ```bash
@@ -167,6 +176,13 @@ rtk gh pr list                  # Compact PR listing
 rtk gh pr view 42               # PR details + checks
 rtk gh issue list               # Compact issue listing
 rtk gh run list                 # Workflow run status
+```
+
+### RTK
+```bash
+rtk update                      # Verified self-update for direct installs
+rtk update --check              # Check for a newer release
+rtk update --tag v0.39.0        # Install a specific release tag
 ```
 
 ### Test Runners

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -11,4 +11,5 @@ pub mod telemetry;
 pub mod telemetry_cmd;
 pub mod toml_filter;
 pub mod tracking;
+pub mod update;
 pub mod utils;

--- a/src/core/update.rs
+++ b/src/core/update.rs
@@ -1,0 +1,668 @@
+use anyhow::{anyhow, bail, Context, Result};
+use flate2::read::GzDecoder;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::ffi::OsStr;
+use std::io::{self, Cursor, Read, Write};
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+const REPO: &str = "rtk-ai/rtk";
+const GITHUB_API: &str = "https://api.github.com";
+const GITHUB_WEB: &str = "https://github.com";
+
+#[derive(Debug, Clone)]
+pub struct UpdateOptions {
+    pub check: bool,
+    pub tag: Option<String>,
+    pub force: bool,
+    pub yes: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct Release {
+    tag_name: String,
+    assets: Vec<ReleaseAsset>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReleaseAsset {
+    name: String,
+    browser_download_url: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InstallKind {
+    Homebrew,
+    Cargo,
+    SourceBuild,
+    Direct,
+}
+
+pub fn run(opts: UpdateOptions) -> Result<i32> {
+    let current_version = env!("CARGO_PKG_VERSION");
+    let release = fetch_release(opts.tag.as_deref())?;
+    let latest_version = release.tag_name.trim_start_matches('v');
+    let newer = is_newer_version(latest_version, current_version);
+    let target_differs = latest_version != current_version;
+    let should_update = opts.force
+        || if opts.tag.is_some() {
+            target_differs
+        } else {
+            newer
+        };
+
+    if !should_update {
+        println!("rtk already latest {}", current_version);
+        return Ok(0);
+    }
+
+    if newer {
+        println!(
+            "rtk update available {} -> {}",
+            current_version, latest_version
+        );
+    } else {
+        println!(
+            "rtk update target {} -> {}",
+            current_version, latest_version
+        );
+    }
+    if opts.check {
+        return Ok(0);
+    }
+
+    let current_exe = std::env::current_exe().context("Could not resolve current rtk binary")?;
+    match detect_install_kind(&current_exe) {
+        InstallKind::Homebrew => {
+            println!("rtk managed by Homebrew. Run: brew upgrade rtk");
+            return Ok(0);
+        }
+        InstallKind::Cargo => {
+            println!(
+                "rtk managed by Cargo. Run: cargo install --git https://github.com/rtk-ai/rtk --force"
+            );
+            return Ok(0);
+        }
+        InstallKind::SourceBuild => {
+            println!(
+                "rtk running from source build. Run: cargo install --path . --force or cargo install --git https://github.com/rtk-ai/rtk --force"
+            );
+            return Ok(0);
+        }
+        InstallKind::Direct => {}
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let asset = select_asset(std::env::consts::OS, std::env::consts::ARCH, &release)
+            .context("No release asset for this platform")?;
+        let checksum_asset = release
+            .assets
+            .iter()
+            .find(|asset| asset.name == "checksums.txt")
+            .context("Release missing checksums.txt")?;
+        let archive = download(&asset.browser_download_url)?;
+        let checksums = String::from_utf8(download(&checksum_asset.browser_download_url)?)
+            .context("checksums.txt is not UTF-8")?;
+        verify_checksum(&archive, &asset.name, &checksums)?;
+        println!(
+            "rtk downloaded and verified {}. Windows self-replace not supported; replace {} manually from release zip.",
+            asset.name,
+            current_exe.display()
+        );
+        return Ok(0);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        if !opts.yes && !confirm_update(current_version, latest_version, &current_exe)? {
+            println!("rtk update cancelled");
+            return Ok(1);
+        }
+
+        let asset = select_asset(std::env::consts::OS, std::env::consts::ARCH, &release)
+            .context("No release asset for this platform")?;
+        let checksum_asset = release
+            .assets
+            .iter()
+            .find(|asset| asset.name == "checksums.txt")
+            .context("Release missing checksums.txt")?;
+
+        let archive = download(&asset.browser_download_url)?;
+        let checksums = String::from_utf8(download(&checksum_asset.browser_download_url)?)
+            .context("checksums.txt is not UTF-8")?;
+        verify_checksum(&archive, &asset.name, &checksums)?;
+
+        let binary = extract_rtk_from_tar_gz(&archive)?;
+        replace_binary(&current_exe, &binary)?;
+        println!("rtk updated {} -> {}", current_version, latest_version);
+        Ok(0)
+    }
+}
+
+fn fetch_release(tag: Option<&str>) -> Result<Release> {
+    match tag {
+        Some(tag) => fetch_release_from_api(Some(tag)),
+        None => match fetch_latest_tag_from_redirect() {
+            Ok(tag) => Ok(release_from_known_assets(&tag)),
+            Err(_) => fetch_release_from_api(None),
+        },
+    }
+}
+
+fn fetch_latest_tag_from_redirect() -> Result<String> {
+    let url = format!("{}/{}/releases/latest", GITHUB_WEB, REPO);
+    let response = ureq::head(&url)
+        .set("User-Agent", concat!("rtk/", env!("CARGO_PKG_VERSION")))
+        .call()
+        .map_err(|e| anyhow!("Failed to resolve latest release redirect: {}", e))?;
+    parse_tag_from_release_url(response.get_url()).context("Latest release redirect had no tag")
+}
+
+fn parse_tag_from_release_url(url: &str) -> Option<String> {
+    url.split("/releases/tag/")
+        .nth(1)
+        .and_then(|tail| tail.split(['?', '#']).next())
+        .filter(|tag| !tag.trim().is_empty())
+        .map(|tag| tag.trim().to_string())
+}
+
+fn fetch_release_from_api(tag: Option<&str>) -> Result<Release> {
+    let path = match tag {
+        Some(tag) => format!("/repos/{}/releases/tags/{}", REPO, tag),
+        None => format!("/repos/{}/releases/latest", REPO),
+    };
+    let url = format!("{}{}", GITHUB_API, path);
+    let body = ureq::get(&url)
+        .set("User-Agent", concat!("rtk/", env!("CARGO_PKG_VERSION")))
+        .call()
+        .map_err(|e| anyhow!("Failed to fetch release metadata: {}", e))?
+        .into_string()
+        .context("Failed to read release metadata")?;
+    serde_json::from_str(&body).context("Failed to parse release metadata")
+}
+
+fn release_from_known_assets(tag: &str) -> Release {
+    const ASSETS: &[&str] = &[
+        "checksums.txt",
+        "rtk-aarch64-apple-darwin.tar.gz",
+        "rtk-aarch64-unknown-linux-gnu.tar.gz",
+        "rtk-x86_64-apple-darwin.tar.gz",
+        "rtk-x86_64-pc-windows-msvc.zip",
+        "rtk-x86_64-unknown-linux-musl.tar.gz",
+    ];
+    Release {
+        tag_name: tag.to_string(),
+        assets: ASSETS
+            .iter()
+            .map(|name| ReleaseAsset {
+                name: (*name).to_string(),
+                browser_download_url: format!(
+                    "{}/{}/releases/download/{}/{}",
+                    GITHUB_WEB, REPO, tag, name
+                ),
+            })
+            .collect(),
+    }
+}
+
+fn download(url: &str) -> Result<Vec<u8>> {
+    let mut reader = ureq::get(url)
+        .set("User-Agent", concat!("rtk/", env!("CARGO_PKG_VERSION")))
+        .call()
+        .map_err(|e| anyhow!("Failed to download {}: {}", url, e))?
+        .into_reader();
+    let mut bytes = Vec::new();
+    reader
+        .read_to_end(&mut bytes)
+        .with_context(|| format!("Failed to read {}", url))?;
+    Ok(bytes)
+}
+
+#[cfg(not(target_os = "windows"))]
+fn confirm_update(current: &str, latest: &str, path: &Path) -> Result<bool> {
+    print!(
+        "Update rtk {} -> {} at {}? [y/N] ",
+        current,
+        latest,
+        path.display()
+    );
+    io::stdout().flush().ok();
+
+    let mut input = String::new();
+    io::stdin()
+        .read_line(&mut input)
+        .context("Failed to read confirmation")?;
+    let answer = input.trim().to_ascii_lowercase();
+    Ok(answer == "y" || answer == "yes")
+}
+
+fn select_asset<'a>(os: &str, arch: &str, release: &'a Release) -> Option<&'a ReleaseAsset> {
+    let target = target_asset_name(os, arch)?;
+    release.assets.iter().find(|asset| asset.name == target)
+}
+
+fn target_asset_name(os: &str, arch: &str) -> Option<&'static str> {
+    match (os, arch) {
+        ("linux", "x86_64") => Some("rtk-x86_64-unknown-linux-musl.tar.gz"),
+        ("linux", "aarch64") => Some("rtk-aarch64-unknown-linux-gnu.tar.gz"),
+        ("macos", "x86_64") => Some("rtk-x86_64-apple-darwin.tar.gz"),
+        ("macos", "aarch64") => Some("rtk-aarch64-apple-darwin.tar.gz"),
+        ("windows", "x86_64") => Some("rtk-x86_64-pc-windows-msvc.zip"),
+        _ => None,
+    }
+}
+
+fn verify_checksum(bytes: &[u8], asset_name: &str, checksums: &str) -> Result<()> {
+    let expected = parse_checksum(checksums, asset_name)
+        .with_context(|| format!("checksums.txt missing {}", asset_name))?;
+    let actual = sha256_hex(bytes);
+    if actual != expected {
+        bail!(
+            "Checksum mismatch for {}: expected {}, got {}",
+            asset_name,
+            expected,
+            actual
+        );
+    }
+    Ok(())
+}
+
+fn parse_checksum(checksums: &str, asset_name: &str) -> Option<String> {
+    checksums.lines().find_map(|line| {
+        let mut parts = line.split_whitespace();
+        let hash = parts.next()?;
+        let name = parts.next()?;
+        if name == asset_name && hash.len() == 64 && hash.chars().all(|c| c.is_ascii_hexdigit()) {
+            Some(hash.to_ascii_lowercase())
+        } else {
+            None
+        }
+    })
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+#[cfg(not(target_os = "windows"))]
+fn extract_rtk_from_tar_gz(archive: &[u8]) -> Result<Vec<u8>> {
+    let decoder = GzDecoder::new(Cursor::new(archive));
+    let mut tar = tar::Archive::new(decoder);
+    let mut found = None;
+
+    for entry in tar.entries().context("Failed to read release archive")? {
+        let mut entry = entry.context("Failed to read archive entry")?;
+        let path = entry.path().context("Failed to read archive entry path")?;
+        validate_archive_entry(&path, entry.header().entry_type())?;
+
+        let mut bytes = Vec::new();
+        entry
+            .read_to_end(&mut bytes)
+            .context("Failed to extract rtk binary")?;
+        found = Some(bytes);
+    }
+
+    found.context("Release archive did not contain rtk binary")
+}
+
+fn validate_archive_entry(path: &Path, entry_type: tar::EntryType) -> Result<()> {
+    validate_archive_path(path)?;
+    if !entry_type.is_file() {
+        bail!("Blocked non-file archive entry: {}", path.display());
+    }
+    Ok(())
+}
+
+fn validate_archive_path(path: &Path) -> Result<()> {
+    if path.components().count() != 1 {
+        bail!("Blocked unsafe archive path: {}", path.display());
+    }
+    for component in path.components() {
+        match component {
+            Component::Normal(name) if name == OsStr::new("rtk") => {}
+            _ => bail!("Blocked unsafe archive path: {}", path.display()),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "windows"))]
+fn replace_binary(current_exe: &Path, binary: &[u8]) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let parent = current_exe
+        .parent()
+        .context("Current binary has no parent directory")?;
+    let mut temp = tempfile::NamedTempFile::new_in(parent)
+        .with_context(|| format!("Failed to create temp file in {}", parent.display()))?;
+    temp.write_all(binary)
+        .context("Failed to write new rtk binary")?;
+    temp.as_file_mut()
+        .sync_all()
+        .context("Failed to sync new rtk binary")?;
+
+    let mut perms = temp.as_file().metadata()?.permissions();
+    perms.set_mode(0o755);
+    temp.as_file()
+        .set_permissions(perms)
+        .context("Failed to set executable permissions")?;
+
+    temp.persist(current_exe).map_err(|e| {
+        anyhow!(
+            "Failed to install new binary at {}: {}",
+            current_exe.display(),
+            e.error
+        )
+    })?;
+    Ok(())
+}
+
+fn detect_install_kind(path: &Path) -> InstallKind {
+    let homebrew_paths = homebrew_paths();
+    detect_install_kind_with_paths(path, &homebrew_paths, cargo_home().as_deref())
+}
+
+fn detect_install_kind_with_paths(
+    path: &Path,
+    homebrew_paths: &[PathBuf],
+    cargo_home: Option<&Path>,
+) -> InstallKind {
+    if is_homebrew_path(path, homebrew_paths) {
+        return InstallKind::Homebrew;
+    }
+    if is_source_build(path) {
+        return InstallKind::SourceBuild;
+    }
+    if is_cargo_path(path, cargo_home) {
+        return InstallKind::Cargo;
+    }
+    InstallKind::Direct
+}
+
+fn homebrew_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    for args in [["--prefix", "rtk"], ["--cellar", "rtk"]] {
+        if let Some(path) = run_brew_path(&args) {
+            paths.push(path);
+        }
+    }
+    paths
+}
+
+fn run_brew_path(args: &[&str]) -> Option<PathBuf> {
+    let output = Command::new("brew").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if path.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(path))
+    }
+}
+
+fn is_homebrew_path(path: &Path, homebrew_paths: &[PathBuf]) -> bool {
+    let normalized_path = normalize_path(path);
+    homebrew_paths.iter().any(|brew_path| {
+        let normalized_brew = normalize_path(brew_path);
+        normalized_path.starts_with(&normalized_brew)
+    }) || has_cellar_rtk_components(path)
+}
+
+fn has_cellar_rtk_components(path: &Path) -> bool {
+    let components: Vec<_> = path
+        .components()
+        .filter_map(|component| match component {
+            Component::Normal(name) => Some(name),
+            _ => None,
+        })
+        .collect();
+    components
+        .windows(2)
+        .any(|pair| pair[0] == OsStr::new("Cellar") && pair[1] == OsStr::new("rtk"))
+}
+
+fn is_cargo_path(path: &Path, cargo_home: Option<&Path>) -> bool {
+    let Some(cargo_home) = cargo_home else {
+        return false;
+    };
+    normalize_path(path).starts_with(normalize_path(&cargo_home.join("bin")))
+}
+
+fn cargo_home() -> Option<PathBuf> {
+    std::env::var_os("CARGO_HOME")
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(".cargo")))
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn is_source_build(path: &Path) -> bool {
+    let mut saw_target = false;
+    for component in path.components() {
+        let Component::Normal(name) = component else {
+            continue;
+        };
+        if saw_target && (name == OsStr::new("debug") || name == OsStr::new("release")) {
+            return true;
+        }
+        saw_target = name == OsStr::new("target");
+    }
+    false
+}
+
+fn is_newer_version(candidate: &str, current: &str) -> bool {
+    parse_version(candidate) > parse_version(current)
+}
+
+fn parse_version(version: &str) -> Vec<u64> {
+    version
+        .trim_start_matches('v')
+        .split(|c: char| !(c.is_ascii_digit()))
+        .filter(|part| !part.is_empty())
+        .take(3)
+        .map(|part| part.parse().unwrap_or(0))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(not(target_os = "windows"))]
+    fn tar_gz_entry(path: &str, entry_type: tar::EntryType, data: &[u8]) -> Vec<u8> {
+        let mut tar_bytes = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut tar_bytes);
+            let mut header = tar::Header::new_gnu();
+            header.set_entry_type(entry_type);
+            header.set_size(data.len() as u64);
+            header.set_mode(0o755);
+            header.set_cksum();
+            builder.append_data(&mut header, path, data).unwrap();
+            builder.finish().unwrap();
+        }
+
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder.write_all(&tar_bytes).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    fn tar_gz_with_rewritten_path(from: &str, to: &str, data: &[u8]) -> Vec<u8> {
+        let archive = tar_gz_entry(from, tar::EntryType::file(), data);
+        let mut decoder = GzDecoder::new(Cursor::new(archive));
+        let mut tar_bytes = Vec::new();
+        decoder.read_to_end(&mut tar_bytes).unwrap();
+
+        tar_bytes[0..100].fill(0);
+        tar_bytes[0..to.len()].copy_from_slice(to.as_bytes());
+        tar_bytes[148..156].fill(b' ');
+        let checksum: u32 = tar_bytes[0..512].iter().map(|byte| *byte as u32).sum();
+        let checksum_text = format!("{:06o}\0 ", checksum);
+        tar_bytes[148..156].copy_from_slice(checksum_text.as_bytes());
+
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder.write_all(&tar_bytes).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    #[test]
+    fn update_version_compare_handles_v_prefix() {
+        assert!(is_newer_version("v0.39.0", "0.38.9"));
+        assert!(is_newer_version("0.40.0", "0.39.9"));
+        assert!(!is_newer_version("v0.39.0", "0.39.0"));
+        assert!(!is_newer_version("v0.38.9", "0.39.0"));
+    }
+
+    #[test]
+    fn update_parses_latest_tag_from_redirect_url() {
+        assert_eq!(
+            parse_tag_from_release_url("https://github.com/rtk-ai/rtk/releases/tag/v0.39.0"),
+            Some("v0.39.0".to_string())
+        );
+        assert_eq!(
+            parse_tag_from_release_url("https://github.com/rtk-ai/rtk/releases"),
+            None
+        );
+    }
+
+    #[test]
+    fn update_known_release_assets_match_platforms() {
+        let release = release_from_known_assets("v0.39.0");
+        assert_eq!(release.tag_name, "v0.39.0");
+        assert!(select_asset("linux", "x86_64", &release).is_some());
+        assert!(release
+            .assets
+            .iter()
+            .any(|asset| asset.name == "checksums.txt"));
+    }
+
+    #[test]
+    fn update_selects_platform_assets() {
+        assert_eq!(
+            target_asset_name("linux", "x86_64"),
+            Some("rtk-x86_64-unknown-linux-musl.tar.gz")
+        );
+        assert_eq!(
+            target_asset_name("macos", "aarch64"),
+            Some("rtk-aarch64-apple-darwin.tar.gz")
+        );
+        assert_eq!(
+            target_asset_name("windows", "x86_64"),
+            Some("rtk-x86_64-pc-windows-msvc.zip")
+        );
+        assert_eq!(target_asset_name("freebsd", "x86_64"), None);
+    }
+
+    #[test]
+    fn update_parses_checksums() {
+        let checksums = "abc  other\n0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef  rtk-x86_64-unknown-linux-musl.tar.gz\n";
+        assert_eq!(
+            parse_checksum(checksums, "rtk-x86_64-unknown-linux-musl.tar.gz"),
+            Some("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string())
+        );
+        assert_eq!(parse_checksum(checksums, "missing.tar.gz"), None);
+    }
+
+    #[test]
+    fn update_verifies_checksum() {
+        let bytes = b"hello";
+        let hash = sha256_hex(bytes);
+        let checksums = format!("{}  rtk-test.tar.gz\n", hash);
+        assert!(verify_checksum(bytes, "rtk-test.tar.gz", &checksums).is_ok());
+        assert!(verify_checksum(b"bye", "rtk-test.tar.gz", &checksums).is_err());
+    }
+
+    #[test]
+    fn update_rejects_unsafe_archive_paths() {
+        assert!(validate_archive_path(Path::new("rtk")).is_ok());
+        assert!(validate_archive_path(Path::new("../rtk")).is_err());
+        assert!(validate_archive_path(Path::new("dir/rtk")).is_err());
+        assert!(validate_archive_path(Path::new("/tmp/rtk")).is_err());
+        assert!(validate_archive_path(Path::new("other")).is_err());
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn update_extracts_valid_tar_gz() {
+        let archive = tar_gz_entry("rtk", tar::EntryType::file(), b"new-binary");
+        assert_eq!(extract_rtk_from_tar_gz(&archive).unwrap(), b"new-binary");
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn update_rejects_tar_gz_path_traversal() {
+        let archive = tar_gz_with_rewritten_path("aaa", "../rtk", b"bad");
+        assert!(extract_rtk_from_tar_gz(&archive).is_err());
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn update_rejects_tar_gz_symlink() {
+        let archive = tar_gz_entry("rtk", tar::EntryType::symlink(), b"target");
+        assert!(extract_rtk_from_tar_gz(&archive).is_err());
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn update_replaces_binary_atomically() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("rtk");
+        std::fs::write(&path, b"old").unwrap();
+        replace_binary(&path, b"new").unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"new");
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_ne!(mode & 0o111, 0);
+    }
+
+    #[test]
+    fn update_detects_install_kinds_from_paths() {
+        let brew_roots = vec![
+            PathBuf::from("/opt/homebrew/opt/rtk"),
+            PathBuf::from("/opt/homebrew/Cellar/rtk"),
+        ];
+        assert_eq!(
+            detect_install_kind_with_paths(
+                Path::new("/opt/homebrew/Cellar/rtk/0.39.0/bin/rtk"),
+                &brew_roots,
+                Some(Path::new("/home/me/.cargo"))
+            ),
+            InstallKind::Homebrew
+        );
+        assert_eq!(
+            detect_install_kind_with_paths(
+                Path::new("/home/me/.cargo/bin/rtk"),
+                &[],
+                Some(Path::new("/home/me/.cargo"))
+            ),
+            InstallKind::Cargo
+        );
+        assert_eq!(
+            detect_install_kind_with_paths(
+                Path::new("/repo/target/debug/rtk"),
+                &[],
+                Some(Path::new("/home/me/.cargo"))
+            ),
+            InstallKind::SourceBuild
+        );
+        assert_eq!(
+            detect_install_kind_with_paths(
+                Path::new("/home/me/.local/bin/rtk"),
+                &[],
+                Some(Path::new("/home/me/.cargo"))
+            ),
+            InstallKind::Direct
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -604,6 +604,22 @@ enum Commands {
         min_occurrences: usize,
     },
 
+    /// Update rtk to the latest GitHub release
+    Update {
+        /// Only check whether an update is available
+        #[arg(long)]
+        check: bool,
+        /// Install a specific release tag (e.g. v0.39.0)
+        #[arg(long)]
+        tag: Option<String>,
+        /// Reinstall even when current version matches target
+        #[arg(long)]
+        force: bool,
+        /// Skip confirmation prompt for direct binary replacement
+        #[arg(long)]
+        yes: bool,
+    },
+
     /// Execute a shell command via sh -c (raw, no filtering or tracking)
     Run {
         /// Command string to execute (use -c for shell-like invocation)
@@ -1120,6 +1136,7 @@ const RTK_META_COMMANDS: &[&str] = &[
     "untrust",
     "session",
     "rewrite",
+    "update",
 ];
 
 fn run_fallback(parse_error: clap::Error) -> Result<i32> {
@@ -2011,6 +2028,18 @@ fn run_cli() -> Result<i32> {
             0
         }
 
+        Commands::Update {
+            check,
+            tag,
+            force,
+            yes,
+        } => core::update::run(core::update::UpdateOptions {
+            check,
+            tag,
+            force,
+            yes,
+        })?,
+
         Commands::Npx { args } => {
             if args.is_empty() {
                 anyhow::bail!("npx requires a command argument");
@@ -2678,6 +2707,28 @@ mod tests {
                 assert!(args.is_empty());
             }
             _ => panic!("Expected Run command"),
+        }
+    }
+
+    #[test]
+    fn test_update_command_parses() {
+        let cli = Cli::try_parse_from([
+            "rtk", "update", "--check", "--tag", "v0.39.0", "--force", "--yes",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Update {
+                check,
+                tag,
+                force,
+                yes,
+            } => {
+                assert!(check);
+                assert_eq!(tag, Some("v0.39.0".to_string()));
+                assert!(force);
+                assert!(yes);
+            }
+            _ => panic!("Expected Update command"),
         }
     }
 


### PR DESCRIPTION
## Summary

Adds `rtk update`.

For direct binary installs, RTK now updates itself from GitHub Releases:

- `rtk update` installs the latest release
- `rtk update --check` checks without changing anything
- `rtk update --tag v0.39.0` installs a specific tag
- `rtk update --force` reinstalls even when versions match
- `rtk update --yes` skips the confirmation prompt

The updater verifies `checksums.txt`, rejects unsafe archive entries, and replaces the current binary through a temp file in the same directory.

Managed installs stay managed. If RTK detects Homebrew, Cargo, or a source-tree binary, it prints the right upgrade command instead of overwriting files it should not own.

## Why

Users keep asking for this. See #1763 and #995.

Today the answer is basically "reinstall it yourself". That works, but it is not much of an answer after you have shipped a CLI people use every day.

This keeps the boring path boring:

```bash
rtk update
```

No shell installer pipeline. No guessing which file to replace. No writing over Homebrew or Cargo installs.

## Related Work

Related to #614.

That PR adds an update command too. Main difference: this implementation keeps direct binary updates inside Rust and verifies the release artifact before replacing the executable.

Homebrew and Cargo remain package-manager paths here. I think that boundary matters. I have debugged enough broken self-updaters to prefer boring ownership rules.

## Docs

Updated:

- `README.md`
- `INSTALL.md`

`CHANGELOG.md` is not edited manually because release-please owns it.

## Testing

```bash
cargo fmt --all --check
cargo clippy --all-targets
cargo test
```

`cargo clippy --all-targets` exits successfully. It still reports existing warnings outside this change.
