### PR TITLE
refactor(warn): replace #[cfg] with cfg! macro to fix unused variable warning

### DIFF
--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -343,19 +343,13 @@ pub fn resolved_command(name: &str) -> Command {
             // On Windows, resolution failure likely means a .CMD/.BAT wrapper
             // wasn't found — always warn so users have a signal.
             // On Unix, this is less common; only log in debug builds.
-            #[cfg(target_os = "windows")]
-            eprintln!(
-                "rtk: Failed to resolve '{}' via PATH, falling back to direct exec: {}",
-                name, e
-            );
-            #[cfg(not(target_os = "windows"))]
-            {
-                #[cfg(debug_assertions)]
+            if cfg!(any(target_os = "windows", debug_assertions)) {
                 eprintln!(
                     "rtk: Failed to resolve '{}' via PATH, falling back to direct exec: {}",
                     name, e
                 );
             }
+
             Command::new(name)
         }
     }


### PR DESCRIPTION
## Summary

Resolve unused variable warning in utils.rs by replacing the `#[cfg]` with `cfg!` macro and refactoring the code to make it more elegant.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected
