### PR TITLE
fix: handle single-line Python docstrings in MinimalFilter (fixes #1322)

### DIFF
--- a/src/core/filter.rs
+++ b/src/core/filter.rs
@@ -188,6 +188,17 @@ impl FilterStrategy for MinimalFilter {
 
             // Handle Python docstrings (keep them in minimal mode)
             if *lang == Language::Python && trimmed.starts_with("\"\"\"") {
+                // Check for single-line docstring: opens and closes on the same line.
+                // e.g. """Short docstring.""" — skip the toggle since the docstring
+                // is fully contained on one line.
+                let rest = &trimmed[3..];
+                if rest.contains("\"\"\"") {
+                    // Single-line docstring: emit the line but don't toggle
+                    in_docstring = false;
+                    result.push_str(line);
+                    result.push('\n');
+                    continue;
+                }
                 in_docstring = !in_docstring;
                 result.push_str(line);
                 result.push('\n');
@@ -468,6 +479,35 @@ fn main() {
         let result = filter.filter(code, &Language::Rust);
         assert!(!result.contains("// This is a comment"));
         assert!(result.contains("fn main()"));
+    }
+
+    #[test]
+    fn test_minimal_filter_single_line_docstring() {
+        // Regression test for #1322: single-line Python docstrings like
+        // """Short docstring.""" should not leave in_docstring=true,
+        // which would suppress comment stripping on subsequent lines.
+        let code = r#"def foo():
+    """Short docstring."""
+    # this comment should be stripped
+    x = 1
+    # another comment to strip
+    return x
+"#;
+        let filter = MinimalFilter;
+        let result = filter.filter(code, &Language::Python);
+        assert!(
+            !result.contains("# this comment should be stripped"),
+            "comment after single-line docstring should be stripped"
+        );
+        assert!(
+            !result.contains("# another comment to strip"),
+            "second comment after single-line docstring should be stripped"
+        );
+        // Docstring itself should be preserved
+        assert!(
+            result.contains("\"\"\"Short docstring.\"\"\""),
+            "single-line docstring should be kept"
+        );
     }
 
     // --- truncation accuracy ---


### PR DESCRIPTION
Fixes #1322.

## Problem

When a Python line both opens and closes a docstring on the same line (e.g. `"""Short docstring."""`), `MinimalFilter` was toggling `in_docstring` to `true` on the opening `"""` and calling `continue`, so the closing `"""` on the same line was never processed. Every subsequent line was treated as inside a docstring, suppressing comment stripping.

## Fix

Before toggling `in_docstring`, check if the same line also contains a closing `"""` after the opening ones. If so, it's a single-line docstring — emit the line without toggling the flag.

## Changes

- `src/core/filter.rs`: Add same-line closing `"""` check before toggling `in_docstring` in the Python docstring handler
- Added regression test `test_minimal_filter_single_line_docstring`

## Testing

- New regression test passes
- Full test suite: **1817 passed, 0 failed, 6 ignored**

---
*This contribution was AI-assisted.*