### PR TITLE
feat(filters): add xmllint compact output filter

### DIFF
--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -1602,6 +1602,7 @@ match_command = "^make\\b"
             "tofu-validate",
             "trunk-build",
             "uv-sync",
+            "xmllint",
             "yamllint",
         ];
 
@@ -1621,8 +1622,8 @@ match_command = "^make\\b"
         let filters = make_filters(BUILTIN_TOML);
         assert_eq!(
             filters.len(),
-            59,
-            "Expected exactly 59 built-in filters, got {}. \
+            60,
+            "Expected exactly 60 built-in filters, got {}. \
              Update this count when adding/removing filters in src/filters/.",
             filters.len()
         );
@@ -1679,11 +1680,11 @@ expected = "output line 1\noutput line 2"
         let combined = format!("{}\n\n{}", BUILTIN_TOML, new_filter);
         let filters = make_filters(&combined);
 
-        // All 59 existing filters still present + 1 new = 60
+        // All 60 existing filters still present + 1 new = 61
         assert_eq!(
             filters.len(),
-            60,
-            "Expected 60 filters after concat (59 built-in + 1 new)"
+            61,
+            "Expected 61 filters after concat (60 built-in + 1 new)"
         );
 
         // New filter is discoverable

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -2649,6 +2649,26 @@ mod tests {
     }
 
     #[test]
+    fn test_classify_xmllint() {
+        assert!(matches!(
+            classify_command("xmllint --noout config.xml"),
+            Classification::Supported {
+                rtk_equivalent: "rtk xmllint",
+                category: "Build",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_rewrite_xmllint() {
+        assert_eq!(
+            rewrite_command_no_prefixes("xmllint --noout config.xml", &[]),
+            Some("rtk xmllint --noout config.xml".into())
+        );
+    }
+
+    #[test]
     fn test_classify_jest() {
         let commands = vec![
             "jest run",

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -852,6 +852,15 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
+        pattern: r"^xmllint\b",
+        rtk_cmd: "rtk xmllint",
+        rewrite_prefixes: &["xmllint"],
+        category: "Build",
+        savings_pct: 65.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
+    RtkRule {
         pattern: r"^wc(\s|$)",
         rtk_cmd: "rtk wc",
         rewrite_prefixes: &["wc"],

--- a/src/filters/xmllint.toml
+++ b/src/filters/xmllint.toml
@@ -1,0 +1,36 @@
+[filters.xmllint]
+description = "Compact xmllint output — strip blank lines and parser boilerplate, keep diagnostics"
+match_command = "^xmllint\\b"
+strip_ansi = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^Document\\s+.*\\s+does not validate$",
+]
+max_lines = 50
+truncate_lines_at = 200
+on_empty = "xmllint: ok"
+
+[[tests.xmllint]]
+name = "keeps parser diagnostics and strips blank lines"
+input = """
+bad.xml:3: parser error : Opening and ending tag mismatch: item line 2 and root
+</root>
+       ^
+
+bad.xml:4: parser error : Premature end of data in tag root line 1
+
+"""
+expected = "bad.xml:3: parser error : Opening and ending tag mismatch: item line 2 and root\n</root>\n       ^\nbad.xml:4: parser error : Premature end of data in tag root line 1"
+
+[[tests.xmllint]]
+name = "empty successful output shows ok"
+input = ""
+expected = "xmllint: ok"
+
+[[tests.xmllint]]
+name = "validation boilerplate stripped"
+input = """
+Document bad.xml does not validate
+bad.xml:7: element root: validity error : Element root content does not follow the DTD
+"""
+expected = "bad.xml:7: element root: validity error : Element root content does not follow the DTD"


### PR DESCRIPTION
## Summary
- add a built-in TOML filter for xmllint diagnostics
- add discover classification/rewrite for xmllint commands
- update built-in filter discovery/count tests

## Why
`rtk discover --all --since 7` showed `xmllint` as a repeated unhandled command in local usage, after the higher-value items already covered by existing PRs. This keeps the change narrow and data-driven.

## Testing
- `cargo fmt -- --check`
- `cargo test core::toml_filter::tests`
- `cargo test discover::registry::tests`
- `cargo run -- hook check "xmllint --noout config.xml"`
- `cargo test`