### PR TITLE
feat(filters): add node --check syntax filter

### DIFF
--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -1583,6 +1583,7 @@ match_command = "^make\\b"
             "mix-compile",
             "mix-format",
             "mvn-build",
+            "node-check",
             "ping",
             "pio-run",
             "poetry-install",
@@ -1621,8 +1622,8 @@ match_command = "^make\\b"
         let filters = make_filters(BUILTIN_TOML);
         assert_eq!(
             filters.len(),
-            59,
-            "Expected exactly 59 built-in filters, got {}. \
+            60,
+            "Expected exactly 60 built-in filters, got {}. \
              Update this count when adding/removing filters in src/filters/.",
             filters.len()
         );
@@ -1679,11 +1680,11 @@ expected = "output line 1\noutput line 2"
         let combined = format!("{}\n\n{}", BUILTIN_TOML, new_filter);
         let filters = make_filters(&combined);
 
-        // All 59 existing filters still present + 1 new = 60
+        // All 60 existing filters still present + 1 new = 61
         assert_eq!(
             filters.len(),
-            60,
-            "Expected 60 filters after concat (59 built-in + 1 new)"
+            61,
+            "Expected 61 filters after concat (60 built-in + 1 new)"
         );
 
         // New filter is discoverable

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1456,6 +1456,26 @@ mod tests {
     }
 
     #[test]
+    fn test_classify_node_check() {
+        assert!(matches!(
+            classify_command("node --check src/app.js"),
+            Classification::Supported {
+                rtk_equivalent: "rtk node --check",
+                category: "JS",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_rewrite_node_check() {
+        assert_eq!(
+            rewrite_command_no_prefixes("node --check src/app.js", &[]),
+            Some("rtk node --check src/app.js".into())
+        );
+    }
+
+    #[test]
     fn test_rewrite_pipe_first_only() {
         // After a pipe, the filter command stays raw
         assert_eq!(

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -242,6 +242,15 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
+        pattern: r"^node\s+--check\b",
+        rtk_cmd: "rtk node --check",
+        rewrite_prefixes: &["node --check"],
+        category: "JS",
+        savings_pct: 65.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
+    RtkRule {
         pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?jest(\s+run)?(\s|$)",
         rtk_cmd: "rtk jest",
         rewrite_prefixes: &[

--- a/src/filters/node-check.toml
+++ b/src/filters/node-check.toml
@@ -1,0 +1,33 @@
+[filters.node-check]
+description = "Compact node --check syntax diagnostics"
+match_command = "^node\\s+--check\\b"
+filter_stderr = true
+strip_ansi = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^\\s+at\\s+.*$",
+  "^Node\\.js\\s+v\\d+\\.\\d+\\.\\d+$",
+]
+max_lines = 50
+truncate_lines_at = 200
+on_empty = "node --check: ok"
+
+[[tests.node-check]]
+name = "keeps syntax diagnostic and strips stack"
+input = """
+bad.js:1
+const =
+      ^
+
+SyntaxError: Unexpected token '='
+    at wrapSafe (node:internal/modules/cjs/loader:1638:18)
+    at checkSyntax (node:internal/main/check_syntax:78:3)
+
+Node.js v22.19.0
+"""
+expected = "bad.js:1\nconst =\n      ^\nSyntaxError: Unexpected token '='"
+
+[[tests.node-check]]
+name = "empty successful output shows ok"
+input = ""
+expected = "node --check: ok"


### PR DESCRIPTION
## Summary
- add a built-in TOML filter for `node --check` syntax diagnostics
- include stderr in filtering so syntax errors are compacted
- add discover classification/rewrite to `rtk node --check ...`

## Why
`rtk discover --all --since 7` showed repeated unhandled `node` usage. This PR covers the safe syntax-checking case while leaving executable snippets like `node -e` ignored.

## Testing
- `cargo fmt -- --check`
- `cargo test core::toml_filter::tests`
- `cargo test discover::registry::tests`
- `cargo run -- hook check "node --check src/app.js"`
- `cargo run -- node --check /private/tmp/rtk-node-check-good.js`
- `cargo run -- node --check /private/tmp/rtk-node-check-bad.js` (expected exit 1, compact diagnostic)
- `cargo test`