### PR TITLE
fix(hooks): add timeout to Claude and Gemini hook entries

### DIFF
--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -904,7 +904,8 @@ fn insert_hook_entry(root: &mut serde_json::Value, hook_command: &str) -> Result
         "matcher": "Bash",
         "hooks": [{
             "type": "command",
-            "command": hook_command
+            "command": hook_command,
+            "timeout": 10
         }]
     }));
     Ok(())
@@ -2561,7 +2562,8 @@ fn patch_gemini_settings(
         "matcher": "run_shell_command",
         "hooks": [{
             "type": "command",
-            "command": hook_cmd
+            "command": hook_cmd,
+            "timeout": 10
         }]
     });
 
@@ -3264,6 +3266,9 @@ mod tests {
 
         let command = pre_tool_use[0]["hooks"][0]["command"].as_str().unwrap();
         assert_eq!(command, hook_command);
+
+        let timeout = pre_tool_use[0]["hooks"][0]["timeout"].as_u64().unwrap();
+        assert_eq!(timeout, 10);
     }
 
     #[test]
@@ -3313,6 +3318,29 @@ mod tests {
 
         // And add hooks
         assert!(json_content.get("hooks").is_some());
+    }
+
+    #[test]
+    fn test_patch_gemini_settings_sets_timeout() {
+        let temp = TempDir::new().unwrap();
+        let hook_path = temp.path().join("rtk-gemini.sh");
+        fs::write(&hook_path, "#!/bin/sh\nrtk hook gemini").unwrap();
+
+        patch_gemini_settings(temp.path(), &hook_path, PatchMode::Auto, 0).unwrap();
+
+        let settings_path = temp.path().join(SETTINGS_JSON);
+        let content = fs::read_to_string(&settings_path).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+        let before_tool = json["hooks"][BEFORE_TOOL_KEY].as_array().unwrap();
+        assert_eq!(before_tool.len(), 1);
+
+        let hook = &before_tool[0]["hooks"][0];
+        assert_eq!(hook["timeout"].as_u64().unwrap(), 10);
+        assert_eq!(
+            hook["command"].as_str().unwrap(),
+            hook_path.to_str().unwrap()
+        );
     }
 
     // Tests for atomic_write()


### PR DESCRIPTION
## Summary
### Problem                                                                                                                                               
                                               
  If RTK hangs during a hook call, Claude stalls indefinitely — there is no timeout to bail out. The Copilot hook already had `"timeout": 5`, but the      
  Claude Code and Gemini CLI hooks were missing it entirely.
                                                                                                                                                           
  Fixes rtk-ai/rtk#218.                                                                                                                                    
  ## Changes                                                                                                                                             
                                                                                                                                                           
  - Added `"timeout": 10` to the Claude Code `PreToolUse` hook written by `rtk init`
  - Added `"timeout": 10` to the Gemini CLI `BeforeTool` hook written by `rtk init`                                                                        

copilot timeout still 5s 

## Test plan

Added two tests asserting timeout is 10s: one for the Claude Code hook (in-memory JSON), one for the Gemini hook (file write via TempDir)             

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

