### PR TITLE
feat(hooks): detect Cursor 3.x hook registration in ~/.cursor/hooks.json

### DIFF
--- a/src/hooks/hook_check.rs
+++ b/src/hooks/hook_check.rs
@@ -1,11 +1,11 @@
 //! Detects whether RTK hooks are installed and warns if they are outdated.
 
 use super::constants::{
-    CLAUDE_DIR, CLAUDE_HOOK_COMMAND, HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE,
-    SETTINGS_JSON,
+    CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CURSOR_DIR, CURSOR_HOOK_COMMAND, HOOKS_JSON, HOOKS_SUBDIR,
+    PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use crate::core::constants::RTK_DATA_DIR;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 const CURRENT_HOOK_VERSION: u8 = 3;
 const WARN_INTERVAL_SECS: u64 = 24 * 3600;
@@ -24,11 +24,20 @@ pub enum HookStatus {
 /// Return the current hook status without printing anything.
 /// Returns `Ok` if no Claude Code is detected (not applicable).
 pub fn status() -> HookStatus {
-    // Don't warn users who don't have Claude Code installed
     let home = match dirs::home_dir() {
         Some(h) => h,
         None => return HookStatus::Ok,
     };
+
+    // Cursor 3.x users register the hook in `~/.cursor/hooks.json` directly
+    // (no `.claude/` directory required). If that file references `rtk hook
+    // cursor` (directly or via a wrapper script that invokes rtk), treat the
+    // hook as installed and skip the legacy Claude detection path.
+    if cursor_3x_hook_registered(&home) {
+        return HookStatus::Ok;
+    }
+
+    // Don't warn users who don't have Claude Code installed
     let claude_dir = home.join(CLAUDE_DIR);
     if !claude_dir.exists() {
         return HookStatus::Ok;
@@ -57,6 +66,53 @@ pub fn status() -> HookStatus {
     } else {
         HookStatus::Outdated
     }
+}
+
+/// Check whether `~/.cursor/hooks.json` registers an rtk-aware hook (Cursor 3.x format).
+///
+/// Cursor 3.x adopts a project-style hook config at `~/.cursor/hooks.json` with
+/// a top-level `version: 1` and a `hooks` map keyed by hook event names
+/// (`preToolUse`, `beforeShellExecution`, etc.). Each entry has a `command`
+/// string that Cursor invokes with the tool input piped on stdin. This is a
+/// distinct surface from `~/.claude/settings.json`, so users who configure
+/// Cursor 3.x correctly were still seeing the "No hook installed" warning.
+///
+/// Returns true if the file exists, is valid JSON, and any hook entry under
+/// `preToolUse` or `beforeShellExecution` has a `command` that either invokes
+/// `rtk hook cursor` directly or references the `rtk` binary through a
+/// platform-specific wrapper (PowerShell/bash/batch). The wrapper case covers
+/// users on Windows + Cursor where the `permission: "ask"` quirk requires a
+/// thin shim returning `permission: "allow"` (see rtk-ai/rtk#1718).
+fn cursor_3x_hook_registered(home: &Path) -> bool {
+    let cursor_hooks = home.join(CURSOR_DIR).join(HOOKS_JSON);
+    let Ok(content) = std::fs::read_to_string(&cursor_hooks) else {
+        return false;
+    };
+    let root: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    let hooks = match root.get("hooks") {
+        Some(h) => h,
+        None => return false,
+    };
+    // Inspect the hook arrays Cursor uses for command interception.
+    for key in &["preToolUse", "beforeShellExecution"] {
+        if let Some(arr) = hooks.get(key).and_then(|v| v.as_array()) {
+            let any_rtk = arr
+                .iter()
+                .filter_map(|entry| entry.get("command")?.as_str())
+                .any(|cmd| {
+                    cmd == CURSOR_HOOK_COMMAND
+                        || cmd.contains(CURSOR_HOOK_COMMAND)
+                        || cmd.contains("rtk")
+                });
+            if any_rtk {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 /// Check if the native binary command is registered in settings.json
@@ -293,5 +349,108 @@ mod tests {
             "Expected valid HookStatus variant, got {:?}",
             s
         );
+    }
+
+    // --- Cursor 3.x hook detection ---
+
+    fn write_cursor_hooks_json(home: &std::path::Path, contents: &str) {
+        let dir = home.join(CURSOR_DIR);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(HOOKS_JSON), contents).unwrap();
+    }
+
+    #[test]
+    fn test_cursor_3x_hook_registered_native_command() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_cursor_hooks_json(
+            tmp.path(),
+            r#"{
+                "version": 1,
+                "hooks": {
+                    "preToolUse": [
+                        { "command": "rtk hook cursor", "matcher": "Shell" }
+                    ]
+                }
+            }"#,
+        );
+        assert!(cursor_3x_hook_registered(tmp.path()));
+    }
+
+    #[test]
+    fn test_cursor_3x_hook_registered_wrapper_script() {
+        // Users on Windows + Cursor sometimes need a thin wrapper around
+        // `rtk hook cursor` until rtk-ai/rtk#1718 (BOM strip + permission:"allow"
+        // + continue:true) is merged. Detection should still recognize that
+        // wrapper as an rtk-aware hook so the warning is suppressed.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_cursor_hooks_json(
+            tmp.path(),
+            r#"{
+                "version": 1,
+                "hooks": {
+                    "preToolUse": [
+                        {
+                            "command": "powershell.exe -File C:/Users/foo/.cursor/hooks/rtk-cursor-allow.ps1",
+                            "matcher": "Shell"
+                        }
+                    ]
+                }
+            }"#,
+        );
+        assert!(cursor_3x_hook_registered(tmp.path()));
+    }
+
+    #[test]
+    fn test_cursor_3x_hook_registered_before_shell_execution() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_cursor_hooks_json(
+            tmp.path(),
+            r#"{
+                "version": 1,
+                "hooks": {
+                    "beforeShellExecution": [
+                        { "command": "rtk hook cursor" }
+                    ]
+                }
+            }"#,
+        );
+        assert!(cursor_3x_hook_registered(tmp.path()));
+    }
+
+    #[test]
+    fn test_cursor_3x_hook_not_registered_no_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert!(!cursor_3x_hook_registered(tmp.path()));
+    }
+
+    #[test]
+    fn test_cursor_3x_hook_not_registered_unrelated_command() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_cursor_hooks_json(
+            tmp.path(),
+            r#"{
+                "version": 1,
+                "hooks": {
+                    "preToolUse": [
+                        { "command": "./scripts/audit.sh" }
+                    ]
+                }
+            }"#,
+        );
+        assert!(!cursor_3x_hook_registered(tmp.path()));
+    }
+
+    #[test]
+    fn test_cursor_3x_hook_not_registered_invalid_json() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_cursor_hooks_json(tmp.path(), "{ this is not json");
+        assert!(!cursor_3x_hook_registered(tmp.path()));
+    }
+
+    #[test]
+    fn test_cursor_3x_hook_not_registered_empty_hooks() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_cursor_hooks_json(tmp.path(), r#"{ "version": 1, "hooks": {} }"#);
+        assert!(!cursor_3x_hook_registered(tmp.path()));
     }
 }


### PR DESCRIPTION
## Summary

Adds detection of Cursor 3.x hook registration so users who configure rtk via `~/.cursor/hooks.json` (instead of `~/.claude/settings.json`) no longer see the `[rtk] /!\ No hook installed — run rtk init -g` warning every time they run `rtk git status`, `rtk gain`, etc.

## Why

Cursor 3.x introduced its own hook config surface (separate from Claude Code's `settings.json`):

```json
// ~/.cursor/hooks.json
{
  "version": 1,
  "hooks": {
    "preToolUse": [
      { "command": "rtk hook cursor", "matcher": "Shell" }
    ]
  }
}
```

Cursor loads this file directly and pipes the hook payload to the configured `command`. From the user's perspective the hook is "installed" — they ran the equivalent of `rtk init -g --agent cursor`, the file exists, the hook gets invoked, and rewrites work end-to-end.

But `hook_check::status()` only inspects `~/.claude/settings.json` and the legacy `~/.claude/hooks/rtk-rewrite.sh`. So Cursor-only users (no `.claude/` directory at all, or `.claude/` exists but without rtk hook entries) get the warning on every command — even though their setup is correct.

## What this PR changes

- New helper `cursor_3x_hook_registered(home: &Path) -> bool` in `src/hooks/hook_check.rs`. It reads `~/.cursor/hooks.json`, parses the JSON, and returns `true` if any entry under `hooks.preToolUse` or `hooks.beforeShellExecution` has a `command` that:
  - Equals `rtk hook cursor` (the constant `CURSOR_HOOK_COMMAND`), OR
  - Contains `rtk hook cursor` as a substring (covers wrapper invocations like `bash -c "rtk hook cursor"`), OR
  - Contains `rtk` (covers thin wrapper scripts that invoke the rtk binary, e.g. `powershell.exe -File ~/.cursor/hooks/rtk-cursor-allow.ps1` on Windows).
- `status()` calls the new helper *first*, before the existing Claude path. If the Cursor 3.x hook is registered, `HookStatus::Ok` is returned and the warning is suppressed regardless of whether `~/.claude/` exists.
- Graceful degradation: missing file, invalid JSON, or empty `hooks` object → returns `false` (falls through to the existing Claude detection).

## Why the wrapper substring match

Some Windows + Cursor users currently need a small PowerShell shim around `rtk hook cursor` because Cursor 3.x silently ignores `permission: "ask"` and Cursor on Windows ships hook stdin with leading UTF-8 BOMs. That issue is being addressed in #1718 — once it lands, the wrapper goes away and users go back to the native `rtk hook cursor` command directly. Until then, recognizing the wrapper as an rtk-aware hook avoids a confusing UX where the warning fires even though token savings are happening.

## Test plan

- [x] 7 new unit tests in `src/hooks/hook_check.rs::tests`:
  - `test_cursor_3x_hook_registered_native_command` — `rtk hook cursor` directly
  - `test_cursor_3x_hook_registered_wrapper_script` — PowerShell wrapper invoking rtk
  - `test_cursor_3x_hook_registered_before_shell_execution` — alternate hook key
  - `test_cursor_3x_hook_not_registered_no_file` — missing `hooks.json`
  - `test_cursor_3x_hook_not_registered_unrelated_command` — non-rtk command
  - `test_cursor_3x_hook_not_registered_invalid_json` — malformed JSON
  - `test_cursor_3x_hook_not_registered_empty_hooks` — `hooks: {}` empty
- [x] Local Windows reproduction:
  - With `~/.cursor/hooks.json` registering `rtk hook cursor` and **no** `~/.claude/` directory → `rtk gain` runs without the "No hook installed" warning.
  - Same setup but with `~/.claude/` present (no rtk entries) → still no warning (Cursor detection wins).
  - `~/.cursor/hooks.json` missing → falls through to existing behavior.

## Related issues

- **Refs #1463** — "Cursor agents doesn't use RTK on Ubuntu 24.04.4 LTS". The reporter says the hook is registered (`rtk init -g --agent cursor` ran) but the warning still fires. This PR addresses the post-installation visibility gap on the Cursor 3.x file format. Worth retesting on Linux with this branch.
- **Refs #1718** — "fix(hooks): make Cursor preToolUse rewrites work and stay visible". The wrapper-substring branch in this PR exists specifically because users hitting #1718 currently use a wrapper shim; once #1718 lands, the wrapper goes away and only the native `rtk hook cursor` match path is exercised. The two PRs are independent and can land in any order.

## Notes for reviewers

- **Scope.** The fix is intentionally `~/.cursor/hooks.json`-only. Project-level `<workspace>/.cursor/hooks.json` is also a Cursor 3.x surface but I left it alone here — would prefer to do it as a follow-up if maintainers want, since it requires resolving the workspace cwd at the moment `status()` is called, which is non-trivial in the existing code.
- **Substring match permissiveness.** The `cmd.contains("rtk")` branch is intentionally permissive to handle wrapper scripts whose path may not contain the literal `rtk hook cursor` substring (e.g. `~/.cursor/hooks/my-rtk-shim.ps1`). False positives here only suppress the warning — they don't change rewrite behavior. If maintainers prefer a stricter match (e.g. only the exact `rtk hook cursor` substring), happy to tighten it.
- **No breaking change.** Existing Claude Code detection path is untouched. Users with `~/.claude/settings.json` registering `rtk hook claude` still see `HookStatus::Ok` exactly as before.
