### PR TITLE
fix(hooks): make Cursor preToolUse rewrites work and stay visible (rebase of #1718)

### DIFF
--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -399,11 +399,25 @@ fn run_claude_inner(input: &str) -> Option<String> {
 
 // ── Cursor native hook ─────────────────────────────────────────
 
+/// Strip leading UTF-8 BOM(s) from a string.
+///
+/// Cursor on Windows ships hook payloads with one or two leading UTF-8 BOMs
+/// (`EF BB BF`). `serde_json::from_str` rejects them, so the hook silently
+/// no-ops on every Shell command unless we strip them first. The loop covers
+/// the observed double-BOM case and is defensive against future N-BOM cases.
+fn strip_utf8_boms(s: &str) -> &str {
+    let mut out = s;
+    while let Some(rest) = out.strip_prefix('\u{FEFF}') {
+        out = rest;
+    }
+    out
+}
+
 /// Run the Cursor Agent hook natively.
 pub fn run_cursor() -> Result<()> {
     let input = read_stdin_limited()?;
 
-    let input = input.trim();
+    let input = strip_utf8_boms(input.trim());
     if input.is_empty() {
         let _ = writeln!(io::stdout(), "{{}}");
         return Ok(());
@@ -444,15 +458,19 @@ pub fn run_cursor() -> Result<()> {
         }
     };
 
-    let decision = match verdict {
-        PermissionVerdict::Allow => "allow",
-        _ => "ask",
-    };
-
+    // Cursor 3.x preToolUse only enforces "allow"/"deny"; "ask" is silently
+    // ignored and the original command runs without the rewrite. Always return
+    // "allow" for rewrites so the updated_input takes effect. Deny verdicts
+    // are short-circuited above so we never lose security boundaries here.
+    //
+    // The `continue: true` key mirrors the shape of other Cursor hooks
+    // (`afterShellExecution`, `beforeSubmitPrompt`, `stop`, ...) so the panel
+    // renders the JSON instead of collapsing to "Output: {}".
     audit_log("rewrite", &cmd, &rewritten);
 
     let output = json!({
-        "permission": decision,
+        "continue": true,
+        "permission": "allow",
         "updated_input": { "command": rewritten }
     });
     let _ = writeln!(io::stdout(), "{output}");
@@ -471,6 +489,7 @@ fn run_cursor_inner_with_rules(
     ask_rules: &[String],
     allow_rules: &[String],
 ) -> String {
+    let input = strip_utf8_boms(input.trim());
     let v: Value = match serde_json::from_str(input) {
         Ok(v) => v,
         Err(_) => return "{}".to_string(),
@@ -492,12 +511,9 @@ fn run_cursor_inner_with_rules(
 
     match get_rewritten(&cmd) {
         Some(rewritten) => {
-            let decision = match verdict {
-                PermissionVerdict::Allow => "allow",
-                _ => "ask",
-            };
             let output = json!({
-                "permission": decision,
+                "continue": true,
+                "permission": "allow",
                 "updated_input": { "command": rewritten }
             });
             output.to_string()
@@ -777,8 +793,10 @@ mod tests {
     fn test_cursor_rewrite_flat_format() {
         let result = run_cursor_inner(&cursor_input("git status"));
         let v: Value = serde_json::from_str(&result).unwrap();
-        // Default permission (no explicit allow rule) → "ask"
-        assert_eq!(v["permission"], "ask");
+        // Cursor 3.x preToolUse silently ignores "ask" — rewrites must always
+        // be returned with permission: "allow" or the updated_input is dropped.
+        assert_eq!(v["permission"], "allow");
+        assert_eq!(v["continue"], true);
         assert_eq!(v["updated_input"]["command"], "rtk git status");
         assert!(v.get("hookSpecificOutput").is_none());
     }
@@ -812,7 +830,37 @@ mod tests {
         let result = run_cursor_inner(&cursor_input("cargo test"));
         let v: Value = serde_json::from_str(&result).unwrap();
         assert!(v.get("hookSpecificOutput").is_none());
-        assert_eq!(v["permission"], "ask");
+        assert_eq!(v["permission"], "allow");
+        assert_eq!(v["continue"], true);
+    }
+
+    #[test]
+    fn test_cursor_strips_single_utf8_bom() {
+        let input_with_bom = format!("\u{FEFF}{}", cursor_input("git status"));
+        let result = run_cursor_inner(&input_with_bom);
+        let v: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(v["permission"], "allow");
+        assert_eq!(v["continue"], true);
+        assert_eq!(v["updated_input"]["command"], "rtk git status");
+    }
+
+    #[test]
+    fn test_cursor_strips_double_utf8_bom() {
+        // Cursor on Windows sometimes ships TWO leading BOMs back-to-back.
+        let input_with_double_bom = format!("\u{FEFF}\u{FEFF}{}", cursor_input("git status"));
+        let result = run_cursor_inner(&input_with_double_bom);
+        let v: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(v["permission"], "allow");
+        assert_eq!(v["updated_input"]["command"], "rtk git status");
+    }
+
+    #[test]
+    fn test_strip_utf8_boms_helper() {
+        assert_eq!(strip_utf8_boms("hello"), "hello");
+        assert_eq!(strip_utf8_boms("\u{FEFF}hello"), "hello");
+        assert_eq!(strip_utf8_boms("\u{FEFF}\u{FEFF}hello"), "hello");
+        assert_eq!(strip_utf8_boms("\u{FEFF}\u{FEFF}\u{FEFF}{}"), "{}");
+        assert_eq!(strip_utf8_boms(""), "");
     }
 
     // --- Audit logging ---


### PR DESCRIPTION
## Summary

Rebases #1718 ("fix(hooks): make Cursor preToolUse rewrites work and stay visible") onto current `develop` so the fix is consumable by users on `rtk 0.39.x` while the original PR catches up. **Credit goes to @kamilkaczmareksolutions for the original investigation and patch** — this PR exists only because I needed the fix on `develop` HEAD and the original branch is based on an older commit. Happy to close this in favor of #1718 the moment that one merges.

## What's broken (recap of #1718)

On Windows + Cursor, `rtk hook cursor` silently no-ops on **every** Shell command. The Cursor panel shows `Output: {}`, which looks like the hook fired correctly — it didn't. The rewrite path is never reached.

| Before this PR | After this PR |
| --- | --- |
| `preToolUse` panel | `Output: {}` for every Shell call | full JSON: `continue`, `permission`, `updated_input` |
| Command Cursor actually ran | original (e.g. raw `git status`) | rewritten (`rtk git status`) |
| `rtk gain --history` | no entries from Cursor | rewrites with 30–94% token reduction |
| User signal | "looks like the hook fires but does nothing" | rewrite is visible, output is smaller |

The confusion is that `Output: {}` is **also** the legitimate response when RTK intentionally skips a command (`htop`, `kill`, already-`rtk`-prefixed). So users had no signal that the hook was actually broken — it looked indistinguishable from "RTK chose not to rewrite this one".

## Three fixes, bundled (same as #1718)

### 1. `permission: "ask"` is silently ignored by Cursor

Cursor `preToolUse` only enforces `"allow"` / `"deny"`. Returning `"ask"` with `updated_input` causes Cursor to drop the rewrite and run the original command. Always return `"allow"` for rewrites. Deny verdicts still take precedence and are short-circuited above.

### 2. Panel collapses to `Output: {}` without `continue: true`

Every other Cursor hook (`afterShellExecution`, `beforeSubmitPrompt`, `stop`, ...) returns `{ "continue": true, ... }` and renders the JSON correctly. The flat `{ permission, updated_input }` payload was technically valid but the Cursor UI didn't surface it. Mirroring the working shape makes the rewrite visible.

### 3. Cursor stdin on Windows is BOM-prefixed

Cursor on Windows ships hook payloads with **one or two leading UTF-8 BOMs** (`EF BB BF [EF BB BF]`). `serde_json::from_str` rejects them, so `run_cursor` falls into the "no command" branch and returns `{}` — silently, on every single hook call. **This is the actual root cause of "RTK silently does nothing in Cursor".** Fixes #1 and #2 above are correctness/UX gaps that only become visible once parsing succeeds.

```rust
fn strip_utf8_boms(s: &str) -> &str {
    let mut out = s;
    while let Some(rest) = out.strip_prefix('\u{FEFF}') {
        out = rest;
    }
    out
}
```

The loop is defensive: covers the observed double-BOM case and any future N-BOM variant without code changes.

## Why a separate PR instead of just commenting on #1718

I need the fix on `develop` HEAD today on Windows + Cursor 3.3.27 + `rtk 0.39.0`. The original PR's branch is based on a commit ~6 months back, so it doesn't apply cleanly without a rebase, and the upstream tree has moved on. Rather than blocking on the original author's availability to rebase, this PR:

1. Cherry-picks the same three fixes onto current `develop`.
2. Keeps the helper function (`strip_utf8_boms`) named and shaped identically to make the diff against #1718 obvious (same author intent, just a different base).
3. Adds two extra tests (single + double BOM as separate cases, plus a unit test on the helper) since this PR's diff context allows it.

If the maintainers prefer to land #1718 directly (e.g. after rebasing the original branch), I'll happily close this one. The credit for the design and investigation belongs to @kamilkaczmareksolutions.

## Test plan

- [x] Existing `test_cursor_rewrite_flat_format` updated to assert `permission: "allow"` + `continue: true` (was `"ask"`).
- [x] Existing `test_cursor_no_hook_specific_output` updated similarly.
- [x] New `test_cursor_strips_single_utf8_bom` — one leading BOM → still parses + rewrites.
- [x] New `test_cursor_strips_double_utf8_bom` — two leading BOMs (real-world case on Windows) → still parses + rewrites.
- [x] New `test_strip_utf8_boms_helper` — unit test covering 0/1/2/3 BOMs and empty input.
- [x] Existing passthrough tests (`htop`, heredoc, already-rtk) unchanged — their `{}` responses are still correct.
- [x] **End-to-end on Windows 11 + Cursor 3.3.27 + `rtk 0.39.0`-rebased**: panel renders the rewrite payload (no more `Output: {}`); `rtk git status` produces compact output; `rtk gain --history` confirms rewrites land with token reduction.

## Related issues

- **#1718** — original PR by @kamilkaczmareksolutions. Same fix, older base. Close this in favor of #1718 once it rebases.
- **#1272** — "Cursor hook: rtk rewrite success exit code causes rewrites to be dropped". Linux-focused report; this PR addresses the Windows variant of the same family.
- **#1463** — "Cursor agents doesn't use RTK on Ubuntu 24.04.4 LTS". Same external symptom; if Linux Cursor also prepends BOM, this PR likely closes it too. Worth retesting on the rebased branch.
- **#1806** (companion) — adds Cursor 3.x hook detection in `~/.cursor/hooks.json` so the "No hook installed" warning stops firing for users who configure rtk via Cursor's native hooks file. Independent of this PR; can land in any order.

## Notes for reviewers

- **No new dependencies, no API changes** — only `run_cursor()` body + 4 unit tests + 1 helper function (private to the module).
- **Cursor-side bug.** Sending double UTF-8 BOM on stdin is its own bug worth reporting upstream to Cursor. RTK should be robust to it regardless.
- **BOM strip is intentionally Cursor-only.** Same scope decision as #1718 — I did not observe the same BOM behavior on Claude/Copilot/Gemini stdin during local debugging. Happy to widen to a shared helper across all hook handlers in a follow-up if maintainers prefer.
