### PR TITLE
feat(git): add `rtk git grep` filter

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -31,6 +31,7 @@ pub enum GitCommand {
     Fetch,
     Stash { subcommand: Option<String> },
     Worktree,
+    Grep,
 }
 
 /// Create a git Command with global options (e.g. -C, -c, --git-dir, --work-tree)
@@ -106,6 +107,7 @@ pub fn run(
             run_stash(subcommand.as_deref(), args, verbose, global_args)
         }
         GitCommand::Worktree => run_worktree(args, verbose, global_args),
+        GitCommand::Grep => run_grep(args, max_lines, verbose, global_args),
     }
 }
 
@@ -2045,6 +2047,144 @@ fn filter_worktree_list(output: &str) -> String {
     result.join("\n")
 }
 
+/// Format flags that produce already-compact output (counts, filenames-only).
+/// Match what `rtk grep` passes through, plus git-specific `--name-only`.
+fn git_grep_has_format_flag(args: &[String]) -> bool {
+    args.iter().any(|arg| {
+        // Long forms match exactly; short forms may be bundled (e.g. `-ln`), so
+        // scan each letter of a single-dash cluster — `-c -l -L -o -z` all yield
+        // output that is already compact or shape-sensitive, so we passthrough.
+        match arg.as_str() {
+            "--count" | "--files-with-matches" | "--name-only" | "--files-without-match"
+            | "--only-matching" | "--null" => true,
+            s if s.starts_with("--") => false,
+            s if s.starts_with('-') && s.len() > 1 => {
+                s[1..].chars().any(|c| matches!(c, 'c' | 'l' | 'L' | 'o' | 'z'))
+            }
+            _ => false,
+        }
+    })
+}
+
+/// Whether the user already requested the line-number / filename-prefix toggles
+/// we'd otherwise inject.
+fn git_grep_has_no_filename(args: &[String]) -> bool {
+    args.iter().any(|a| a == "-h" || a == "--no-filename")
+}
+
+fn git_grep_has_line_number(args: &[String]) -> bool {
+    args.iter().any(|a| {
+        a == "--line-number" || (a.starts_with('-') && !a.starts_with("--") && a.contains('n'))
+    })
+}
+
+fn run_grep(
+    args: &[String],
+    _max_lines: Option<usize>,
+    verbose: u8,
+    global_args: &[String],
+) -> Result<i32> {
+    let timer = tracking::TimedExecution::start();
+
+    // Passthrough for format flags whose output is already compact (counts,
+    // filenames-only, NUL-delimited). Matches `rtk grep`'s policy.
+    if git_grep_has_format_flag(args) {
+        let mut cmd = git_cmd(global_args);
+        cmd.arg("grep");
+        for arg in args {
+            cmd.arg(arg);
+        }
+        let result = exec_capture(&mut cmd).context("Failed to run git grep")?;
+        print!("{}", result.stdout);
+        if !result.stderr.is_empty() {
+            eprint!("{}", result.stderr.trim());
+        }
+        let args_display = args.join(" ");
+        timer.track_passthrough(
+            &format!("git grep {}", args_display),
+            &format!("rtk git grep {} (passthrough)", args_display),
+        );
+        return Ok(result.exit_code);
+    }
+
+    // -h / --no-filename strips the filename prefix, breaking the per-file
+    // grouping the filter relies on. Honor the user's intent and passthrough.
+    if git_grep_has_no_filename(args) {
+        let mut cmd = git_cmd(global_args);
+        cmd.arg("grep");
+        for arg in args {
+            cmd.arg(arg);
+        }
+        let result = exec_capture(&mut cmd).context("Failed to run git grep")?;
+        print!("{}", result.stdout);
+        if !result.stderr.is_empty() {
+            eprint!("{}", result.stderr.trim());
+        }
+        let args_display = args.join(" ");
+        timer.track_passthrough(
+            &format!("git grep {}", args_display),
+            &format!("rtk git grep {} (passthrough)", args_display),
+        );
+        return Ok(result.exit_code);
+    }
+
+    let mut cmd = git_cmd(global_args);
+    cmd.arg("grep");
+    if !git_grep_has_line_number(args) {
+        cmd.arg("-n");
+    }
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    let result = exec_capture(&mut cmd).context("Failed to run git grep")?;
+
+    if verbose > 0 {
+        eprintln!("git grep executed");
+    }
+
+    let raw_output = result.stdout.clone();
+
+    if result.stdout.trim().is_empty() {
+        // Empty stdout is either a genuine no-match (exit 1) or a real error
+        // (exit >= 2: bad object, not-a-repo, ambiguous arg, transient odb read).
+        // git grep prints nothing on a no-match, so neither do we: a synthetic
+        // "0 matches" exceeds the raw command and, on an error exit, masks the
+        // failure as a false negative (cf. `rtk grep`, which surfaces exit >= 2).
+        if result.exit_code >= 2 && !result.stderr.trim().is_empty() {
+            eprintln!("{}", result.stderr.trim());
+        }
+        let args_display = args.join(" ");
+        timer.track(
+            &format!("git grep {}", args_display),
+            "rtk git grep",
+            &raw_output,
+            "",
+        );
+        return Ok(result.exit_code);
+    }
+
+    // Reuse the same grouped-by-file formatter that `rtk grep` uses; git grep
+    // emits the same `path:lineno:content` shape.
+    let formatter = crate::cmds::system::pipe_cmd::resolve_filter("grep")
+        .expect("grep filter must exist");
+    let formatted = formatter(&raw_output);
+    print!("{}", formatted);
+    if !result.stderr.is_empty() {
+        eprint!("{}", result.stderr.trim());
+    }
+
+    let args_display = args.join(" ");
+    timer.track(
+        &format!("git grep {}", args_display),
+        "rtk git grep",
+        &raw_output,
+        &formatted,
+    );
+
+    Ok(result.exit_code)
+}
+
 /// Runs an unsupported git subcommand by passing it through directly
 pub fn run_passthrough(args: &[OsString], global_args: &[String], verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
@@ -3321,5 +3461,66 @@ To https://github.com/foo/bar.git
             input_tokens,
             output_tokens
         );
+    }
+
+    #[test]
+    fn test_git_grep_format_flag_detection() {
+        for flag in [
+            "-c",
+            "--count",
+            "-l",
+            "--files-with-matches",
+            "--name-only",
+            "-L",
+            "--files-without-match",
+            "-o",
+            "--only-matching",
+            "-z",
+            "--null",
+        ] {
+            assert!(
+                git_grep_has_format_flag(&[flag.to_string()]),
+                "{} should be detected as a format flag",
+                flag
+            );
+        }
+        assert!(!git_grep_has_format_flag(&["-i".to_string()]));
+        assert!(!git_grep_has_format_flag(&["-n".to_string()]));
+    }
+
+    #[test]
+    fn test_git_grep_no_filename_detection() {
+        assert!(git_grep_has_no_filename(&["-h".to_string()]));
+        assert!(git_grep_has_no_filename(&["--no-filename".to_string()]));
+        assert!(!git_grep_has_no_filename(&["-H".to_string()]));
+        assert!(!git_grep_has_no_filename(&["-n".to_string()]));
+    }
+
+    #[test]
+    fn test_git_grep_line_number_detection() {
+        assert!(git_grep_has_line_number(&["-n".to_string()]));
+        assert!(git_grep_has_line_number(&["--line-number".to_string()]));
+        assert!(!git_grep_has_line_number(&["-l".to_string()]));
+        assert!(!git_grep_has_line_number(&["-N".to_string()]));
+    }
+
+    #[test]
+    fn test_git_grep_bundled_short_flags() {
+        // Short flags may be bundled: `-ln` is `-l` plus `-n`. Matching whole
+        // args exactly misses these and silently drops the passthrough.
+        assert!(git_grep_has_format_flag(&["-ln".to_string()]));
+        assert!(git_grep_has_format_flag(&["-nl".to_string()]));
+        assert!(git_grep_has_format_flag(&["-inc".to_string()]));
+        assert!(git_grep_has_line_number(&["-ln".to_string()]));
+        assert!(git_grep_has_line_number(&["-in".to_string()]));
+
+        // A long flag whose name happens to contain a format letter must not
+        // match: `--ignore-case` contains both 'c' and 'n'.
+        assert!(!git_grep_has_format_flag(&["--ignore-case".to_string()]));
+        assert!(!git_grep_has_line_number(&["--ignore-case".to_string()]));
+
+        // A bare dash is not a flag cluster.
+        assert!(!git_grep_has_format_flag(&["-".to_string()]));
+        assert!(!git_grep_has_line_number(&["-".to_string()]));
     }
 }

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -24,6 +24,7 @@ pub enum GitCommand {
     Fetch,
     Stash { subcommand: Option<String> },
     Worktree,
+    Grep,
 }
 
 /// Create a git Command with global options (e.g. -C, -c, --git-dir, --work-tree)
@@ -98,6 +99,7 @@ pub fn run(
             run_stash(subcommand.as_deref(), args, verbose, global_args)
         }
         GitCommand::Worktree => run_worktree(args, verbose, global_args),
+        GitCommand::Grep => run_grep(args, max_lines, verbose, global_args),
     }
 }
 
@@ -1761,6 +1763,141 @@ fn filter_worktree_list(output: &str) -> String {
     result.join("\n")
 }
 
+/// Format flags that produce already-compact output (counts, filenames-only).
+/// Match what `rtk grep` passes through, plus git-specific `--name-only`.
+fn git_grep_has_format_flag(args: &[String]) -> bool {
+    args.iter().any(|arg| {
+        matches!(
+            arg.as_str(),
+            "-c" | "--count"
+                | "-l"
+                | "--files-with-matches"
+                | "--name-only"
+                | "-L"
+                | "--files-without-match"
+                | "-o"
+                | "--only-matching"
+                | "-z"
+                | "--null"
+        )
+    })
+}
+
+/// Whether the user already requested the line-number / filename-prefix toggles
+/// we'd otherwise inject.
+fn git_grep_has_no_filename(args: &[String]) -> bool {
+    args.iter().any(|a| a == "-h" || a == "--no-filename")
+}
+
+fn git_grep_has_line_number(args: &[String]) -> bool {
+    args.iter().any(|a| a == "-n" || a == "--line-number")
+}
+
+fn run_grep(
+    args: &[String],
+    _max_lines: Option<usize>,
+    verbose: u8,
+    global_args: &[String],
+) -> Result<i32> {
+    let timer = tracking::TimedExecution::start();
+
+    // Passthrough for format flags whose output is already compact (counts,
+    // filenames-only, NUL-delimited). Matches `rtk grep`'s policy.
+    if git_grep_has_format_flag(args) {
+        let mut cmd = git_cmd(global_args);
+        cmd.arg("grep");
+        for arg in args {
+            cmd.arg(arg);
+        }
+        let result = exec_capture(&mut cmd).context("Failed to run git grep")?;
+        print!("{}", result.stdout);
+        if !result.stderr.is_empty() {
+            eprint!("{}", result.stderr.trim());
+        }
+        let args_display = args.join(" ");
+        timer.track_passthrough(
+            &format!("git grep {}", args_display),
+            &format!("rtk git grep {} (passthrough)", args_display),
+        );
+        return Ok(result.exit_code);
+    }
+
+    // -h / --no-filename strips the filename prefix, breaking the per-file
+    // grouping the filter relies on. Honor the user's intent and passthrough.
+    if git_grep_has_no_filename(args) {
+        let mut cmd = git_cmd(global_args);
+        cmd.arg("grep");
+        for arg in args {
+            cmd.arg(arg);
+        }
+        let result = exec_capture(&mut cmd).context("Failed to run git grep")?;
+        print!("{}", result.stdout);
+        if !result.stderr.is_empty() {
+            eprint!("{}", result.stderr.trim());
+        }
+        let args_display = args.join(" ");
+        timer.track_passthrough(
+            &format!("git grep {}", args_display),
+            &format!("rtk git grep {} (passthrough)", args_display),
+        );
+        return Ok(result.exit_code);
+    }
+
+    let mut cmd = git_cmd(global_args);
+    cmd.arg("grep");
+    if !git_grep_has_line_number(args) {
+        cmd.arg("-n");
+    }
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    let result = exec_capture(&mut cmd).context("Failed to run git grep")?;
+
+    if verbose > 0 {
+        eprintln!("git grep executed");
+    }
+
+    let raw_output = result.stdout.clone();
+
+    if result.stdout.trim().is_empty() {
+        // Surface stderr for usage errors (bad regex, not-a-repo, ambiguous arg).
+        if result.exit_code != 0 && result.exit_code != 1 && !result.stderr.trim().is_empty() {
+            eprintln!("{}", result.stderr.trim());
+        }
+        let msg = "0 matches".to_string();
+        println!("{}", msg);
+        let args_display = args.join(" ");
+        timer.track(
+            &format!("git grep {}", args_display),
+            "rtk git grep",
+            &raw_output,
+            &msg,
+        );
+        return Ok(result.exit_code);
+    }
+
+    // Reuse the same grouped-by-file formatter that `rtk grep` uses; git grep
+    // emits the same `path:lineno:content` shape.
+    let formatter = crate::cmds::system::pipe_cmd::resolve_filter("grep")
+        .expect("grep filter must exist");
+    let formatted = formatter(&raw_output);
+    print!("{}", formatted);
+    if !result.stderr.is_empty() {
+        eprint!("{}", result.stderr.trim());
+    }
+
+    let args_display = args.join(" ");
+    timer.track(
+        &format!("git grep {}", args_display),
+        "rtk git grep",
+        &raw_output,
+        &formatted,
+    );
+
+    Ok(result.exit_code)
+}
+
 /// Runs an unsupported git subcommand by passing it through directly
 pub fn run_passthrough(args: &[OsString], global_args: &[String], verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
@@ -2898,5 +3035,46 @@ To https://github.com/foo/bar.git
             input_tokens,
             output_tokens
         );
+    }
+
+    #[test]
+    fn test_git_grep_format_flag_detection() {
+        for flag in [
+            "-c",
+            "--count",
+            "-l",
+            "--files-with-matches",
+            "--name-only",
+            "-L",
+            "--files-without-match",
+            "-o",
+            "--only-matching",
+            "-z",
+            "--null",
+        ] {
+            assert!(
+                git_grep_has_format_flag(&[flag.to_string()]),
+                "{} should be detected as a format flag",
+                flag
+            );
+        }
+        assert!(!git_grep_has_format_flag(&["-i".to_string()]));
+        assert!(!git_grep_has_format_flag(&["-n".to_string()]));
+    }
+
+    #[test]
+    fn test_git_grep_no_filename_detection() {
+        assert!(git_grep_has_no_filename(&["-h".to_string()]));
+        assert!(git_grep_has_no_filename(&["--no-filename".to_string()]));
+        assert!(!git_grep_has_no_filename(&["-H".to_string()]));
+        assert!(!git_grep_has_no_filename(&["-n".to_string()]));
+    }
+
+    #[test]
+    fn test_git_grep_line_number_detection() {
+        assert!(git_grep_has_line_number(&["-n".to_string()]));
+        assert!(git_grep_has_line_number(&["--line-number".to_string()]));
+        assert!(!git_grep_has_line_number(&["-l".to_string()]));
+        assert!(!git_grep_has_line_number(&["-N".to_string()]));
     }
 }

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1238,7 +1238,7 @@ mod tests {
         // Verify that every GitCommand subcommand has a matching pattern
         for subcmd in [
             "status", "log", "diff", "show", "add", "commit", "push", "pull", "branch", "fetch",
-            "stash", "worktree",
+            "stash", "worktree", "grep",
         ] {
             let cmd = format!("git {subcmd}");
             match classify_command(&cmd) {
@@ -1246,6 +1246,26 @@ mod tests {
                 other => panic!("git {subcmd} should be Supported, got {other:?}"),
             }
         }
+    }
+
+    #[test]
+    fn test_classify_git_grep() {
+        match classify_command("git grep -n foo src/") {
+            Classification::Supported { rtk_equivalent, .. } => {
+                assert_eq!(rtk_equivalent, "rtk git");
+            }
+            other => panic!("git grep should be Supported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_rewrite_git_grep() {
+        let rewritten = rewrite_command("git grep -n foo src/", &[], &[]);
+        assert_eq!(
+            rewritten,
+            Some("rtk git grep -n foo src/".to_string()),
+            "git grep should rewrite to rtk git grep"
+        );
     }
 
     #[test]

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1094,7 +1094,7 @@ mod tests {
         // Verify that every GitCommand subcommand has a matching pattern
         for subcmd in [
             "status", "log", "diff", "show", "add", "commit", "push", "pull", "branch", "fetch",
-            "stash", "worktree",
+            "stash", "worktree", "grep",
         ] {
             let cmd = format!("git {subcmd}");
             match classify_command(&cmd) {
@@ -1102,6 +1102,26 @@ mod tests {
                 other => panic!("git {subcmd} should be Supported, got {other:?}"),
             }
         }
+    }
+
+    #[test]
+    fn test_classify_git_grep() {
+        match classify_command("git grep -n foo src/") {
+            Classification::Supported { rtk_equivalent, .. } => {
+                assert_eq!(rtk_equivalent, "rtk git");
+            }
+            other => panic!("git grep should be Supported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_rewrite_git_grep() {
+        let rewritten = rewrite_command("git grep -n foo src/", &[], &[]);
+        assert_eq!(
+            rewritten,
+            Some("rtk git grep -n foo src/".to_string()),
+            "git grep should rewrite to rtk git grep"
+        );
     }
 
     #[test]

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -12,7 +12,7 @@ pub struct RtkRule {
 
 pub const RULES: &[RtkRule] = &[
     RtkRule {
-        pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|checkout|push|pull|branch|fetch|stash|worktree)",
+        pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|checkout|push|pull|branch|fetch|stash|worktree|grep)",
         rtk_cmd: "rtk git",
         rewrite_prefixes: &["git", "yadm"],
         category: "Git",
@@ -22,6 +22,7 @@ pub const RULES: &[RtkRule] = &[
             ("show", 80.0),
             ("add", 59.0),
             ("commit", 59.0),
+            ("grep", 75.0),
         ],
         subcmd_status: &[],
     },

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -12,7 +12,7 @@ pub struct RtkRule {
 
 pub const RULES: &[RtkRule] = &[
     RtkRule {
-        pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|push|pull|branch|fetch|stash|worktree)",
+        pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|push|pull|branch|fetch|stash|worktree|grep)",
         rtk_cmd: "rtk git",
         rewrite_prefixes: &["git", "yadm"],
         category: "Git",
@@ -22,6 +22,7 @@ pub const RULES: &[RtkRule] = &[
             ("show", 80.0),
             ("add", 59.0),
             ("commit", 59.0),
+            ("grep", 75.0),
         ],
         subcmd_status: &[],
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -950,6 +950,15 @@ enum GitCommands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Search tracked files: matches grouped by file (-c, -l, -L, -z, -o, --name-only run raw)
+    #[command(disable_help_flag = true)]
+    Grep {
+        /// Git grep arguments (pattern, paths, and any git grep flags).
+        /// `-h` and `--help` reach git grep so its native flags work; use
+        /// `rtk git --help` to read this description.
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
     /// Passthrough: runs any unsupported git subcommand directly
     #[command(external_subcommand)]
     Other(Vec<OsString>),
@@ -1741,6 +1750,13 @@ fn run_cli() -> Result<i32> {
                 )?,
                 GitCommands::Worktree { args } => git::run(
                     git::GitCommand::Worktree,
+                    &args,
+                    None,
+                    cli.verbose,
+                    &global_args,
+                )?,
+                GitCommands::Grep { args } => git::run(
+                    git::GitCommand::Grep,
                     &args,
                     None,
                     cli.verbose,

--- a/src/main.rs
+++ b/src/main.rs
@@ -861,6 +861,15 @@ enum GitCommands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Search tracked files: matches grouped by file (-c, -l, -L, -z, -o, --name-only run raw)
+    #[command(disable_help_flag = true)]
+    Grep {
+        /// Git grep arguments (pattern, paths, and any git grep flags).
+        /// `-h` and `--help` reach git grep so its native flags work; use
+        /// `rtk git --help` to read this description.
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
     /// Passthrough: runs any unsupported git subcommand directly
     #[command(external_subcommand)]
     Other(Vec<OsString>),
@@ -1575,6 +1584,13 @@ fn run_cli() -> Result<i32> {
                 )?,
                 GitCommands::Worktree { args } => git::run(
                     git::GitCommand::Worktree,
+                    &args,
+                    None,
+                    cli.verbose,
+                    &global_args,
+                )?,
+                GitCommands::Grep { args } => git::run(
+                    git::GitCommand::Grep,
                     &args,
                     None,
                     cli.verbose,


### PR DESCRIPTION
## Summary
Adds `rtk git grep` as a thin filter over `git grep`, grouping matches by file using the same `path:lineno:content` formatter that backs `rtk grep`. Format flags whose output is already compact (`-c`, `-l`, `-L`, `-z`, `-o`, `--name-only`) and `-h`/`--no-filename` pass through raw.

## Why
`git grep` was the most-frequent unhandled `git ` subcommand in `rtk discover` runs on this box (~77/week), and its output shape (`path:lineno:content`) is identical to `grep -rn`, which `rtk grep` already compresses by ~75%.

## Empty output emits nothing, and that's deliberate

An earlier revision of this branch printed a synthetic `0 matches` to **stdout** whenever `git grep` returned empty stdout. That's wrong two ways:

1. Real `git grep` prints nothing on a no-match, so the synthetic line makes the filter's output *larger* than the raw command.
2. Empty stdout also happens on a real error (exit >= 2: bad object, not-a-repo, ambiguous arg, a transient odb read on a freshly-fetched SHA). The error text goes to stderr, but `0 matches` still went to stdout, so anything reading stdout concludes "none found" and never sees the failure. In a blast-radius audit that silently understates the result, which is the dangerous direction: an absence is exactly the answer that ends an investigation.

This is the same false-negative class that `d727db3` (#2461) fixed for `rtk grep`; it was never applied to the git-grep path. Now: nothing on stdout for empty output, and on exit >= 2 the underlying stderr is surfaced. The exit code is propagated unchanged either way.

## Bundled short flags

`git_grep_has_format_flag` and `git_grep_has_line_number` matched whole args exactly, so a bundled cluster like `-ln` bypassed the passthrough that `-l` alone triggers. Both now scan each letter of a single-dash cluster, while long forms still match exactly (so `--ignore-case` isn't caught by its `c` or `n`). Covered by `test_git_grep_bundled_short_flags`.

## What changed
- `src/discover/rules.rs` -- extend the git subcommand pattern with `grep`, declare 75% subcmd savings.
- `src/cmds/git/git.rs` -- add `GitCommand::Grep` + `run_grep`, defer post-processing to `pipe_cmd::resolve_filter("grep")`.
- `src/main.rs` -- `GitCommands::Grep` clap variant + dispatch arm. `disable_help_flag` so `git grep -h` reaches git grep instead of clap.
- `src/discover/registry.rs` -- cover `git grep` in the registry-coverage test, plus `classify_command` and `rewrite_command` regression tests.

## Test plan
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --bin rtk git` passes (326 passed, 0 failed)
- [x] Smoke tests on a Rust workspace: matches grouped by file, `-l`/`-c` passthrough preserves raw form, `-h` reaches git grep
- [x] No-match prints nothing and exits 1; a bad object surfaces git's stderr and propagates its exit code
- [x] Hook-side rewrite verified in a fresh Claude Code session: raw `git grep -n <pattern>` returns rtk's `N matches in MF:` form; `rtk session` shows the new subcommand counted toward adoption
- [x] Rebased onto current `develop`; previously conflicting, now mergeable
