### PR TITLE
feat(git): add `rtk git ls-tree` and `rtk git ls-files` passthrough

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -31,6 +31,8 @@ pub enum GitCommand {
     Fetch,
     Stash { subcommand: Option<String> },
     Worktree,
+    LsTree,
+    LsFiles,
 }
 
 /// Create a git Command with global options (e.g. -C, -c, --git-dir, --work-tree)
@@ -106,6 +108,8 @@ pub fn run(
             run_stash(subcommand.as_deref(), args, verbose, global_args)
         }
         GitCommand::Worktree => run_worktree(args, verbose, global_args),
+        GitCommand::LsTree => run_ls_tree(args, verbose, global_args),
+        GitCommand::LsFiles => run_ls_files(args, verbose, global_args),
     }
 }
 
@@ -2043,6 +2047,55 @@ fn filter_worktree_list(output: &str) -> String {
         }
     }
     result.join("\n")
+}
+
+/// `git ls-tree` and `git ls-files` are script-facing: consumers (xargs,
+/// while-read loops, awk pipelines) require one full path per line. Any
+/// reshape -- even a "summary" -- breaks them, so rtk runs the command with
+/// inherited stdio and only records telemetry. It never touches the output.
+fn run_ls_tree(args: &[String], verbose: u8, global_args: &[String]) -> Result<i32> {
+    let timer = tracking::TimedExecution::start();
+
+    if verbose > 0 {
+        eprintln!("git ls-tree passthrough: {:?}", args);
+    }
+
+    let status = git_cmd(global_args)
+        .arg("ls-tree")
+        .args(args)
+        .status()
+        .context("Failed to run git ls-tree")?;
+
+    let args_display = args.join(" ");
+    timer.track_passthrough(
+        &format!("git ls-tree {}", args_display),
+        &format!("rtk git ls-tree {} (passthrough)", args_display),
+    );
+
+    Ok(exit_code_from_status(&status, "git ls-tree"))
+}
+
+/// See `run_ls_tree`: same script-facing contract, same raw passthrough.
+fn run_ls_files(args: &[String], verbose: u8, global_args: &[String]) -> Result<i32> {
+    let timer = tracking::TimedExecution::start();
+
+    if verbose > 0 {
+        eprintln!("git ls-files passthrough: {:?}", args);
+    }
+
+    let status = git_cmd(global_args)
+        .arg("ls-files")
+        .args(args)
+        .status()
+        .context("Failed to run git ls-files")?;
+
+    let args_display = args.join(" ");
+    timer.track_passthrough(
+        &format!("git ls-files {}", args_display),
+        &format!("rtk git ls-files {} (passthrough)", args_display),
+    );
+
+    Ok(exit_code_from_status(&status, "git ls-files"))
 }
 
 /// Runs an unsupported git subcommand by passing it through directly

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -24,6 +24,8 @@ pub enum GitCommand {
     Fetch,
     Stash { subcommand: Option<String> },
     Worktree,
+    LsTree,
+    LsFiles,
 }
 
 /// Create a git Command with global options (e.g. -C, -c, --git-dir, --work-tree)
@@ -98,6 +100,8 @@ pub fn run(
             run_stash(subcommand.as_deref(), args, verbose, global_args)
         }
         GitCommand::Worktree => run_worktree(args, verbose, global_args),
+        GitCommand::LsTree => run_ls_tree(args, verbose, global_args),
+        GitCommand::LsFiles => run_ls_files(args, verbose, global_args),
     }
 }
 
@@ -1761,6 +1765,192 @@ fn filter_worktree_list(output: &str) -> String {
     result.join("\n")
 }
 
+/// Flags whose presence makes `git ls-tree` output incompatible with the
+/// path-per-line shape `find_wrapper` expects.
+fn ls_tree_breaks_format(args: &[String]) -> bool {
+    args.iter().any(|a| {
+        matches!(
+            a.as_str(),
+            "-z" | "-l" | "--long" | "--object-only" | "--abbrev"
+        ) || a.starts_with("--abbrev=")
+    })
+}
+
+/// Flags whose presence makes `git ls-files` output incompatible with the
+/// path-per-line shape `find_wrapper` expects.
+fn ls_files_breaks_format(args: &[String]) -> bool {
+    args.iter().any(|a| {
+        matches!(
+            a.as_str(),
+            "-z"
+                | "-s"
+                | "--stage"
+                | "-t"
+                | "-v"
+                | "-c"
+                | "-d"
+                | "-m"
+                | "-u"
+                | "--debug"
+                | "--eol"
+        )
+    })
+}
+
+/// Extract the path portion of a `git ls-tree` line.
+///
+/// Default format: `<mode> SP <type> SP <hash> TAB <path>`. With `--name-only`
+/// the line is just the path. Returns the original line if neither shape matches.
+fn ls_tree_extract_path(line: &str) -> &str {
+    if let Some(tab_pos) = line.find('\t') {
+        &line[tab_pos + 1..]
+    } else {
+        line
+    }
+}
+
+fn run_ls_tree(args: &[String], verbose: u8, global_args: &[String]) -> Result<i32> {
+    let timer = tracking::TimedExecution::start();
+
+    let mut cmd = git_cmd(global_args);
+    cmd.arg("ls-tree");
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    let result = exec_capture(&mut cmd).context("Failed to run git ls-tree")?;
+
+    if verbose > 0 {
+        eprintln!("git ls-tree executed");
+    }
+
+    if !result.success() {
+        if !result.stderr.trim().is_empty() {
+            eprintln!("{}", result.stderr.trim());
+        }
+        if !result.stdout.is_empty() {
+            print!("{}", result.stdout);
+        }
+        return Ok(result.exit_code);
+    }
+
+    let raw_output = result.stdout.clone();
+
+    // Format-breaking flags: emit raw output unchanged.
+    if ls_tree_breaks_format(args) {
+        print!("{}", raw_output);
+        let args_display = args.join(" ");
+        timer.track_passthrough(
+            &format!("git ls-tree {}", args_display),
+            &format!("rtk git ls-tree {} (passthrough)", args_display),
+        );
+        return Ok(result.exit_code);
+    }
+
+    if raw_output.trim().is_empty() {
+        let msg = "(empty tree)".to_string();
+        println!("{}", msg);
+        let args_display = args.join(" ");
+        timer.track(
+            &format!("git ls-tree {}", args_display),
+            "rtk git ls-tree",
+            &raw_output,
+            &msg,
+        );
+        return Ok(result.exit_code);
+    }
+
+    // Strip the mode/type/hash prefix from each line so the formatter sees a
+    // flat path list. Empty lines are dropped.
+    let paths: String = raw_output
+        .lines()
+        .map(ls_tree_extract_path)
+        .filter(|p| !p.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let formatter = crate::cmds::system::pipe_cmd::resolve_filter("find")
+        .expect("find filter must exist");
+    let formatted = formatter(&paths);
+    print!("{}", formatted);
+
+    let args_display = args.join(" ");
+    timer.track(
+        &format!("git ls-tree {}", args_display),
+        "rtk git ls-tree",
+        &raw_output,
+        &formatted,
+    );
+
+    Ok(result.exit_code)
+}
+
+fn run_ls_files(args: &[String], verbose: u8, global_args: &[String]) -> Result<i32> {
+    let timer = tracking::TimedExecution::start();
+
+    let mut cmd = git_cmd(global_args);
+    cmd.arg("ls-files");
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    let result = exec_capture(&mut cmd).context("Failed to run git ls-files")?;
+
+    if verbose > 0 {
+        eprintln!("git ls-files executed");
+    }
+
+    if !result.success() {
+        if !result.stderr.trim().is_empty() {
+            eprintln!("{}", result.stderr.trim());
+        }
+        if !result.stdout.is_empty() {
+            print!("{}", result.stdout);
+        }
+        return Ok(result.exit_code);
+    }
+
+    let raw_output = result.stdout.clone();
+
+    if ls_files_breaks_format(args) {
+        print!("{}", raw_output);
+        let args_display = args.join(" ");
+        timer.track_passthrough(
+            &format!("git ls-files {}", args_display),
+            &format!("rtk git ls-files {} (passthrough)", args_display),
+        );
+        return Ok(result.exit_code);
+    }
+
+    if raw_output.trim().is_empty() {
+        let msg = "(no tracked files)".to_string();
+        println!("{}", msg);
+        let args_display = args.join(" ");
+        timer.track(
+            &format!("git ls-files {}", args_display),
+            "rtk git ls-files",
+            &raw_output,
+            &msg,
+        );
+        return Ok(result.exit_code);
+    }
+
+    let formatter = crate::cmds::system::pipe_cmd::resolve_filter("find")
+        .expect("find filter must exist");
+    let formatted = formatter(&raw_output);
+    print!("{}", formatted);
+
+    let args_display = args.join(" ");
+    timer.track(
+        &format!("git ls-files {}", args_display),
+        "rtk git ls-files",
+        &raw_output,
+        &formatted,
+    );
+
+    Ok(result.exit_code)
+}
+
 /// Runs an unsupported git subcommand by passing it through directly
 pub fn run_passthrough(args: &[OsString], global_args: &[String], verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
@@ -2898,5 +3088,81 @@ To https://github.com/foo/bar.git
             input_tokens,
             output_tokens
         );
+    }
+
+    #[test]
+    fn test_ls_tree_extract_path_default_format() {
+        let line = "100644 blob abc123def4567890\tsrc/main.rs";
+        assert_eq!(ls_tree_extract_path(line), "src/main.rs");
+    }
+
+    #[test]
+    fn test_ls_tree_extract_path_name_only() {
+        let line = "src/main.rs";
+        assert_eq!(ls_tree_extract_path(line), "src/main.rs");
+    }
+
+    #[test]
+    fn test_ls_tree_extract_path_with_subtree() {
+        let line = "040000 tree def456\tsrc/lib";
+        assert_eq!(ls_tree_extract_path(line), "src/lib");
+    }
+
+    #[test]
+    fn test_ls_tree_breaks_format_z() {
+        assert!(ls_tree_breaks_format(&["-z".to_string()]));
+    }
+
+    #[test]
+    fn test_ls_tree_breaks_format_long() {
+        assert!(ls_tree_breaks_format(&["-l".to_string()]));
+        assert!(ls_tree_breaks_format(&["--long".to_string()]));
+    }
+
+    #[test]
+    fn test_ls_tree_breaks_format_object_only() {
+        assert!(ls_tree_breaks_format(&["--object-only".to_string()]));
+    }
+
+    #[test]
+    fn test_ls_tree_breaks_format_abbrev() {
+        assert!(ls_tree_breaks_format(&["--abbrev".to_string()]));
+        assert!(ls_tree_breaks_format(&["--abbrev=8".to_string()]));
+    }
+
+    #[test]
+    fn test_ls_tree_no_break_for_recursive() {
+        // -r is recursive listing — same shape, just more lines.
+        assert!(!ls_tree_breaks_format(&["-r".to_string()]));
+    }
+
+    #[test]
+    fn test_ls_files_breaks_format_stage() {
+        assert!(ls_files_breaks_format(&["-s".to_string()]));
+        assert!(ls_files_breaks_format(&["--stage".to_string()]));
+    }
+
+    #[test]
+    fn test_ls_files_breaks_format_z() {
+        assert!(ls_files_breaks_format(&["-z".to_string()]));
+    }
+
+    #[test]
+    fn test_ls_files_breaks_format_status_tags() {
+        // -t prepends a status letter (H/S/M/...) to each path.
+        assert!(ls_files_breaks_format(&["-t".to_string()]));
+        assert!(ls_files_breaks_format(&["-v".to_string()]));
+    }
+
+    #[test]
+    fn test_ls_files_breaks_format_debug() {
+        assert!(ls_files_breaks_format(&["--debug".to_string()]));
+    }
+
+    #[test]
+    fn test_ls_files_no_break_for_pathspec() {
+        // Bare path arguments should not flip to passthrough.
+        assert!(!ls_files_breaks_format(&["src/".to_string()]));
+        assert!(!ls_files_breaks_format(&["--".to_string(), "src/".to_string()]));
     }
 }

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1238,7 +1238,7 @@ mod tests {
         // Verify that every GitCommand subcommand has a matching pattern
         for subcmd in [
             "status", "log", "diff", "show", "add", "commit", "push", "pull", "branch", "fetch",
-            "stash", "worktree",
+            "stash", "worktree", "ls-tree", "ls-files",
         ] {
             let cmd = format!("git {subcmd}");
             match classify_command(&cmd) {
@@ -1246,6 +1246,41 @@ mod tests {
                 other => panic!("git {subcmd} should be Supported, got {other:?}"),
             }
         }
+    }
+
+    #[test]
+    fn test_classify_git_ls_tree() {
+        match classify_command("git ls-tree -r HEAD") {
+            Classification::Supported { rtk_equivalent, .. } => {
+                assert_eq!(rtk_equivalent, "rtk git");
+            }
+            other => panic!("git ls-tree should be Supported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_classify_git_ls_files() {
+        match classify_command("git ls-files src/") {
+            Classification::Supported { rtk_equivalent, .. } => {
+                assert_eq!(rtk_equivalent, "rtk git");
+            }
+            other => panic!("git ls-files should be Supported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_rewrite_git_ls_tree() {
+        let rewritten = rewrite_command("git ls-tree -r HEAD", &[], &[]);
+        assert_eq!(rewritten, Some("rtk git ls-tree -r HEAD".to_string()));
+    }
+
+    #[test]
+    fn test_rewrite_git_ls_files() {
+        let rewritten = rewrite_command("git ls-files AGENTS.md CLAUDE.md", &[], &[]);
+        assert_eq!(
+            rewritten,
+            Some("rtk git ls-files AGENTS.md CLAUDE.md".to_string())
+        );
     }
 
     #[test]

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1094,7 +1094,7 @@ mod tests {
         // Verify that every GitCommand subcommand has a matching pattern
         for subcmd in [
             "status", "log", "diff", "show", "add", "commit", "push", "pull", "branch", "fetch",
-            "stash", "worktree",
+            "stash", "worktree", "ls-tree", "ls-files",
         ] {
             let cmd = format!("git {subcmd}");
             match classify_command(&cmd) {
@@ -1102,6 +1102,41 @@ mod tests {
                 other => panic!("git {subcmd} should be Supported, got {other:?}"),
             }
         }
+    }
+
+    #[test]
+    fn test_classify_git_ls_tree() {
+        match classify_command("git ls-tree -r HEAD") {
+            Classification::Supported { rtk_equivalent, .. } => {
+                assert_eq!(rtk_equivalent, "rtk git");
+            }
+            other => panic!("git ls-tree should be Supported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_classify_git_ls_files() {
+        match classify_command("git ls-files src/") {
+            Classification::Supported { rtk_equivalent, .. } => {
+                assert_eq!(rtk_equivalent, "rtk git");
+            }
+            other => panic!("git ls-files should be Supported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_rewrite_git_ls_tree() {
+        let rewritten = rewrite_command("git ls-tree -r HEAD", &[], &[]);
+        assert_eq!(rewritten, Some("rtk git ls-tree -r HEAD".to_string()));
+    }
+
+    #[test]
+    fn test_rewrite_git_ls_files() {
+        let rewritten = rewrite_command("git ls-files AGENTS.md CLAUDE.md", &[], &[]);
+        assert_eq!(
+            rewritten,
+            Some("rtk git ls-files AGENTS.md CLAUDE.md".to_string())
+        );
     }
 
     #[test]

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -12,7 +12,7 @@ pub struct RtkRule {
 
 pub const RULES: &[RtkRule] = &[
     RtkRule {
-        pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|checkout|push|pull|branch|fetch|stash|worktree)",
+        pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|checkout|push|pull|branch|fetch|stash|worktree|ls-tree|ls-files)",
         rtk_cmd: "rtk git",
         rewrite_prefixes: &["git", "yadm"],
         category: "Git",
@@ -22,6 +22,11 @@ pub const RULES: &[RtkRule] = &[
             ("show", 80.0),
             ("add", 59.0),
             ("commit", 59.0),
+            // Passthrough: output is script-facing (one path per line), so rtk
+            // reshapes nothing and saves nothing. A non-zero figure here would
+            // make `rtk discover` overstate the value of wrapping them.
+            ("ls-tree", 0.0),
+            ("ls-files", 0.0),
         ],
         subcmd_status: &[],
     },

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -12,7 +12,7 @@ pub struct RtkRule {
 
 pub const RULES: &[RtkRule] = &[
     RtkRule {
-        pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|push|pull|branch|fetch|stash|worktree)",
+        pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|push|pull|branch|fetch|stash|worktree|ls-tree|ls-files)",
         rtk_cmd: "rtk git",
         rewrite_prefixes: &["git", "yadm"],
         category: "Git",
@@ -22,6 +22,8 @@ pub const RULES: &[RtkRule] = &[
             ("show", 80.0),
             ("add", 59.0),
             ("commit", 59.0),
+            ("ls-tree", 65.0),
+            ("ls-files", 65.0),
         ],
         subcmd_status: &[],
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -950,6 +950,18 @@ enum GitCommands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// List tree entries: paths grouped by directory (-z, -l, --object-only run raw)
+    LsTree {
+        /// Git ls-tree arguments (tree-ish, paths, flags)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// List tracked files: paths grouped by directory (-z, -s, -t, --debug run raw)
+    LsFiles {
+        /// Git ls-files arguments (paths, flags)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
     /// Passthrough: runs any unsupported git subcommand directly
     #[command(external_subcommand)]
     Other(Vec<OsString>),
@@ -1741,6 +1753,20 @@ fn run_cli() -> Result<i32> {
                 )?,
                 GitCommands::Worktree { args } => git::run(
                     git::GitCommand::Worktree,
+                    &args,
+                    None,
+                    cli.verbose,
+                    &global_args,
+                )?,
+                GitCommands::LsTree { args } => git::run(
+                    git::GitCommand::LsTree,
+                    &args,
+                    None,
+                    cli.verbose,
+                    &global_args,
+                )?,
+                GitCommands::LsFiles { args } => git::run(
+                    git::GitCommand::LsFiles,
                     &args,
                     None,
                     cli.verbose,

--- a/src/main.rs
+++ b/src/main.rs
@@ -861,6 +861,18 @@ enum GitCommands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// List tree entries: paths grouped by directory (-z, -l, --object-only run raw)
+    LsTree {
+        /// Git ls-tree arguments (tree-ish, paths, flags)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// List tracked files: paths grouped by directory (-z, -s, -t, --debug run raw)
+    LsFiles {
+        /// Git ls-files arguments (paths, flags)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
     /// Passthrough: runs any unsupported git subcommand directly
     #[command(external_subcommand)]
     Other(Vec<OsString>),
@@ -1575,6 +1587,20 @@ fn run_cli() -> Result<i32> {
                 )?,
                 GitCommands::Worktree { args } => git::run(
                     git::GitCommand::Worktree,
+                    &args,
+                    None,
+                    cli.verbose,
+                    &global_args,
+                )?,
+                GitCommands::LsTree { args } => git::run(
+                    git::GitCommand::LsTree,
+                    &args,
+                    None,
+                    cli.verbose,
+                    &global_args,
+                )?,
+                GitCommands::LsFiles { args } => git::run(
+                    git::GitCommand::LsFiles,
                     &args,
                     None,
                     cli.verbose,


### PR DESCRIPTION
## Summary

Adds `rtk git ls-tree` and `rtk git ls-files` as **raw passthrough with telemetry**. rtk runs the command with inherited stdio and records the invocation. It doesn't touch the output.

## Why passthrough and not a filter

Both commands are script-facing. Their default output is one full path per line, and it's consumed by `xargs`, `while read` loops, and `awk` pipelines. Any reshape breaks those consumers, including a "summary".

An earlier revision of this branch fed both through `pipe_cmd::find_wrapper` to group paths by directory. That's exactly the reshape above. It strips the directory prefix from each row and truncates to 20 dirs x 10 files, so `git ls-files` returned bare basenames and every `[ -f "$f" ]` check downstream failed silently. It also makes `ls-tree -r --name-only <sha> | grep -c <name>` return a confident, wrong `0` for a file that exists, because grep then searches the summary rather than the path list. Grouping a path list is a data-loss bug, not a filter.

So this PR deliberately saves no tokens, and `subcmd_savings` declares 0% for both rather than the 65% an earlier revision claimed. A non-zero figure would make `rtk discover` overstate the value of wrapping them.

## What's the point, then

Coverage rather than compression:

- Claiming the subcommands keeps a formatter from being added later by someone reasonably assuming a path list is safe to group.
- `gain` and `discover` get to see the usage.

If you'd rather rtk not claim commands it can't compress, closing this is a reasonable call. I'd argue the explicit passthrough is worth it as a guard, but the savings case for it is zero and I don't want to pretend otherwise.

## What changed

- `src/discover/rules.rs` - extend the git subcommand pattern with `ls-tree` and `ls-files`; declare 0% savings for both.
- `src/cmds/git/git.rs` - `GitCommand::LsTree` / `LsFiles` with `run_ls_tree` / `run_ls_files` as raw passthrough.
- `src/main.rs` - clap variants + dispatch.
- `src/discover/registry.rs` - registry-coverage test, plus `classify_command` / `rewrite_command` regression tests.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --bin rtk` passes (2437 passed; the 2 `unattestable_passthrough` failures are ambient-config dependent and reproduce on unmodified `develop` on this machine, since `check_command` reads the real `~/.claude/settings.json`)
- [x] Rebased onto current `develop`; previously conflicting, now mergeable
