### PR TITLE
chore(args): introduce a more generic solution for restoring double dashes in args

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -1,5 +1,6 @@
 //! Filters git output — log, status, diff, and more — keeping just the essential info.
 
+use crate::core::args_utils;
 use crate::core::stream::{
     self, exec_capture, CaptureResult, FilterMode, LineHandler, LineStreamFilter, StdinMode,
 };
@@ -102,65 +103,6 @@ pub fn run(
     }
 }
 
-/// Re-insert `--` before the first path-like argument when clap has consumed it.
-///
-/// clap's `trailing_var_arg = true` silently drops `--` when it appears as the
-/// first positional argument (before any other positional).  This means:
-///   `rtk git diff -- file` → args = ["file"]   (clap ate `--`)
-///   `rtk git diff HEAD -- file` → args = ["HEAD", "--", "file"]  (preserved)
-///
-/// Without the `--` separator git may treat an unambiguous path as a revision and
-/// emit "fatal: ambiguous argument".  We re-insert `--` before the first path-like
-/// argument; see `normalize_diff_args_impl` for the detection rules.
-fn normalize_diff_args(args: &[String]) -> Vec<String> {
-    normalize_diff_args_impl(args, |p| std::path::Path::new(p).exists())
-}
-
-/// Testable core of `normalize_diff_args` — accepts an injectable filesystem existence checker.
-///
-/// The path-detection logic is:
-/// 1. Explicit path prefixes (`.`, `~`) → always a path, no filesystem check needed.
-/// 2. Contains path separator (`/`, `\`) → use `path_exists` to distinguish branch names
-///    (e.g. `feature/auth`) from real paths (e.g. `src/main.rs`).
-/// 3. Bare word with no separator → never a path (avoids injecting `--` when a file
-///    happens to share a name with a branch or ref, e.g. a file named `main`).
-fn normalize_diff_args_impl<F>(args: &[String], path_exists: F) -> Vec<String>
-where
-    F: Fn(&str) -> bool,
-{
-    // Already has `--` — nothing to do
-    if args.iter().any(|a| a == "--") {
-        return args.to_vec();
-    }
-    let path_start = args.iter().position(|arg| {
-        if arg.starts_with('-') {
-            return false;
-        }
-        // Explicit path prefixes — always treat as path regardless of existence
-        if arg.starts_with('.') || arg.starts_with('~') {
-            return true;
-        }
-        // Contains path separator — use filesystem check to distinguish
-        // branch names (feature/auth) from real paths (src/main.rs)
-        if arg.contains('/') || arg.contains('\\') {
-            return path_exists(arg);
-        }
-        // Bare word (no separator, no special prefix) — never inject `--`
-        // This avoids misidentifying a ref/branch as a path even if a same-named
-        // file happens to exist on disk.
-        false
-    });
-    match path_start {
-        Some(idx) => {
-            let mut out = args[..idx].to_vec();
-            out.push("--".to_string());
-            out.extend_from_slice(&args[idx..]);
-            out
-        }
-        None => args.to_vec(),
-    }
-}
-
 fn run_diff(
     args: &[String],
     max_lines: Option<usize>,
@@ -170,7 +112,7 @@ fn run_diff(
     let timer = tracking::TimedExecution::start();
 
     // Re-insert `--` when clap's trailing_var_arg consumed it (issue #1215)
-    let args = &normalize_diff_args(args);
+    let args = &args_utils::restore_double_dash(args);
 
     // Check if user wants stat output
     let wants_stat = args
@@ -1910,8 +1852,14 @@ mod tests {
         assert!(uses_compact_status_path(&["-b".to_string()]));
         assert!(uses_compact_status_path(&["--branch".to_string()]));
         assert!(uses_compact_status_path(&["-sb".to_string()]));
-        assert!(uses_compact_status_path(&["-s".to_string(), "-b".to_string()]));
-        assert!(uses_compact_status_path(&["--short".to_string(), "--branch".to_string()]));
+        assert!(uses_compact_status_path(&[
+            "-s".to_string(),
+            "-b".to_string()
+        ]));
+        assert!(uses_compact_status_path(&[
+            "--short".to_string(),
+            "--branch".to_string()
+        ]));
         assert!(!uses_compact_status_path(&["-s".to_string()]));
         assert!(!uses_compact_status_path(&["--short".to_string()]));
         assert!(!uses_compact_status_path(&["--porcelain".to_string()]));
@@ -1998,134 +1946,6 @@ mod tests {
         assert!(
             !result.contains("more changes truncated"),
             "5 files × 20 lines should not exceed max_lines=500"
-        );
-    }
-
-    // ----- normalize_diff_args (issue #1215 + branch-name fix #1431) -----
-    //
-    // Tests use normalize_diff_args_impl with a mock path-existence checker so
-    // they don't depend on the real filesystem.
-
-    fn exists_mock<'a>(existing: &'a [&'a str]) -> impl Fn(&str) -> bool + 'a {
-        move |p| existing.contains(&p)
-    }
-
-    /// Baseline: `--` already present → no-op, args unchanged.
-    #[test]
-    fn test_normalize_diff_args_noop_when_separator_present() {
-        let args = vec![
-            "HEAD".to_string(),
-            "--".to_string(),
-            "src/main.rs".to_string(),
-        ];
-        assert_eq!(normalize_diff_args_impl(&args, exists_mock(&[])), args);
-    }
-
-    /// Core regression (issue #1215): clap ate `--` before a real file path.
-    /// When the path exists on disk, `--` must be re-inserted.
-    #[test]
-    fn test_normalize_diff_args_reinserts_separator_before_existing_path() {
-        let args = vec!["apps/client/frontend/src/MyComponent.tsx".to_string()];
-        let normalized = normalize_diff_args_impl(
-            &args,
-            exists_mock(&["apps/client/frontend/src/MyComponent.tsx"]),
-        );
-        assert_eq!(
-            normalized,
-            vec![
-                "--".to_string(),
-                "apps/client/frontend/src/MyComponent.tsx".to_string()
-            ],
-            "-- must be injected before an existing path"
-        );
-    }
-
-    /// Ref before path: ["HEAD", "src/foo.rs"] where src/foo.rs exists → inject after HEAD.
-    #[test]
-    fn test_normalize_diff_args_reinserts_separator_after_ref() {
-        let args = vec!["HEAD".to_string(), "src/foo.rs".to_string()];
-        let normalized = normalize_diff_args_impl(&args, exists_mock(&["src/foo.rs"]));
-        assert_eq!(
-            normalized,
-            vec![
-                "HEAD".to_string(),
-                "--".to_string(),
-                "src/foo.rs".to_string()
-            ]
-        );
-    }
-
-    /// Flags before path: ["--cached", "src/foo.rs"] where src/foo.rs exists.
-    #[test]
-    fn test_normalize_diff_args_reinserts_separator_after_flag() {
-        let args = vec!["--cached".to_string(), "src/foo.rs".to_string()];
-        let normalized = normalize_diff_args_impl(&args, exists_mock(&["src/foo.rs"]));
-        assert_eq!(
-            normalized,
-            vec![
-                "--cached".to_string(),
-                "--".to_string(),
-                "src/foo.rs".to_string()
-            ]
-        );
-    }
-
-    /// Pure flags (no paths) → no injection.
-    #[test]
-    fn test_normalize_diff_args_no_injection_for_pure_flags() {
-        let args = vec!["--stat".to_string(), "--cached".to_string()];
-        assert_eq!(normalize_diff_args_impl(&args, exists_mock(&[])), args);
-    }
-
-    /// Dotfile that exists on disk → inject `--`.
-    #[test]
-    fn test_normalize_diff_args_dotfile_is_path() {
-        let args = vec![".gitignore".to_string()];
-        let normalized = normalize_diff_args_impl(&args, exists_mock(&[".gitignore"]));
-        assert_eq!(normalized, vec!["--".to_string(), ".gitignore".to_string()]);
-    }
-
-    /// A bare ref (HEAD) that doesn't exist as a file → no injection.
-    #[test]
-    fn test_normalize_diff_args_no_injection_for_bare_ref() {
-        let args = vec!["HEAD".to_string()];
-        assert_eq!(normalize_diff_args_impl(&args, exists_mock(&[])), args);
-    }
-
-    /// Branch name with `/` that does NOT exist as a file → no injection.
-    /// Regression for issue #1431: `rtk git diff feature/user-auth` must not inject `--`.
-    #[test]
-    fn test_normalize_diff_args_no_injection_for_branch_with_slash() {
-        let args = vec!["feature/user-auth".to_string()];
-        assert_eq!(
-            normalize_diff_args_impl(&args, exists_mock(&[])),
-            args,
-            "branch names containing '/' must not trigger -- injection"
-        );
-    }
-
-    /// Range syntax with `/` → no injection.
-    /// Regression: `rtk git diff main...feature/user-auth` produced no output.
-    #[test]
-    fn test_normalize_diff_args_no_injection_for_range_with_slash() {
-        let args = vec!["main...feature/user-auth".to_string()];
-        assert_eq!(
-            normalize_diff_args_impl(&args, exists_mock(&[])),
-            args,
-            "revision ranges like main...feature/user-auth must not trigger -- injection"
-        );
-    }
-
-    /// Bare word that happens to exist as a file on disk → still no injection.
-    /// A file named "main" must not cause `--` to be injected when the user
-    /// intends `rtk git diff main` as a branch comparison.
-    #[test]
-    fn test_normalize_diff_args_no_injection_for_bare_word_even_if_file_exists() {
-        let args = vec!["main".to_string()];
-        assert_eq!(
-            normalize_diff_args_impl(&args, exists_mock(&["main"])),
-            args,
-            "bare words must never trigger -- injection even when a same-named file exists"
         );
     }
 

--- a/src/cmds/rust/cargo_cmd.rs
+++ b/src/cmds/rust/cargo_cmd.rs
@@ -1,5 +1,6 @@
 //! Filters cargo output — build errors, test results, clippy warnings.
 
+use crate::core::args_utils;
 use crate::core::runner;
 use crate::core::stream::{BlockHandler, BlockStreamFilter, StreamFilter};
 use crate::core::truncate::{CAP_ERRORS, CAP_LIST, CAP_WARNINGS};
@@ -29,45 +30,6 @@ pub fn run(cmd: CargoCommand, args: &[String], verbose: u8) -> Result<i32> {
         CargoCommand::Install => run_install(args, verbose),
         CargoCommand::Nextest => run_nextest(args, verbose),
     }
-}
-
-/// Reconstruct args with `--` separator preserved from the original command line.
-/// Clap strips `--` from parsed args, but cargo subcommands need it to separate
-/// their own flags from test runner flags (e.g. `cargo test -- --nocapture`).
-fn restore_double_dash(args: &[String]) -> Vec<String> {
-    let raw_args: Vec<String> = std::env::args().collect();
-    restore_double_dash_with_raw(args, &raw_args)
-}
-
-/// Testable version that takes raw_args explicitly.
-fn restore_double_dash_with_raw(args: &[String], raw_args: &[String]) -> Vec<String> {
-    if args.is_empty() {
-        return args.to_vec();
-    }
-
-    // If args already contain `--` (Clap preserved it), no restoration needed
-    if args.iter().any(|a| a == "--") {
-        return args.to_vec();
-    }
-
-    // Find `--` in the original command line
-    let sep_pos = match raw_args.iter().position(|a| a == "--") {
-        Some(pos) => pos,
-        None => return args.to_vec(),
-    };
-
-    // Count how many of our parsed args appeared before `--` in the original.
-    // Args before `--` are positional (e.g. test name), args after are flags.
-    let args_before_sep = raw_args[..sep_pos]
-        .iter()
-        .filter(|a| args.contains(a))
-        .count();
-
-    let mut result = Vec::with_capacity(args.len() + 1);
-    result.extend_from_slice(&args[..args_before_sep]);
-    result.push("--".to_string());
-    result.extend_from_slice(&args[args_before_sep..]);
-    result
 }
 
 // --- Stream handlers ---
@@ -291,7 +253,7 @@ where
     let mut cmd = resolved_command("cargo");
     cmd.arg(subcommand);
 
-    let restored_args = restore_double_dash(args);
+    let restored_args = args_utils::restore_double_dash(args);
     for arg in &restored_args {
         cmd.arg(arg);
     }
@@ -318,7 +280,7 @@ fn run_cargo_streamed(
     let mut cmd = resolved_command("cargo");
     cmd.arg(subcommand);
 
-    let restored_args = restore_double_dash(args);
+    let restored_args = args_utils::restore_double_dash(args);
     for arg in &restored_args {
         cmd.arg(arg);
     }
@@ -1275,6 +1237,7 @@ pub fn run_passthrough(args: &[OsString], verbose: u8) -> Result<i32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::args_utils::restore_double_dash_with_raw;
 
     #[test]
     fn test_restore_double_dash_with_separator() {

--- a/src/core/args_utils.rs
+++ b/src/core/args_utils.rs
@@ -1,0 +1,240 @@
+//! Utility functions for argument handling, particularly for restoring "--" escape
+//! arguments that clap consumes during parsing.
+
+/// Restores "--" escape arguments that clap consumed.
+/// Handles:
+/// - Single/multiple "--" swallowed by clap (restores each at its original position)
+/// - "--" already present in parsed (no change)
+/// - No "--" in original command (no injection)
+/// - Args appearing before/after "--" in original (preserves order)
+/// - Interleaved "--" and args (preserves relative positions, e.g., "-- arg1 -- arg2")
+/// - Duplicate args on both sides of "--"
+///
+/// Returns parsed_args unchanged if raw has same or fewer "--" than parsed
+/// (meaning clap didn't consume any, or preserved them).
+pub fn restore_double_dash(parsed_args: &[String]) -> Vec<String> {
+    let raw_args: Vec<String> = std::env::args().collect();
+    restore_double_dash_with_raw(parsed_args, &raw_args)
+}
+
+/// Testable version that takes raw_args explicitly.
+pub fn restore_double_dash_with_raw(parsed_args: &[String], raw_args: &[String]) -> Vec<String> {
+    let raw_dash_count = raw_args.iter().filter(|a| a.as_str() == "--").count();
+    let parsed_dash_count = parsed_args.iter().filter(|a| a.as_str() == "--").count();
+
+    if raw_dash_count <= parsed_dash_count {
+        return parsed_args.to_vec();
+    }
+
+    // Find all positions of "--" in raw_args (skip index 0 = "rtk")
+    let mut dash_positions: Vec<usize> = Vec::new();
+    for (i, arg) in raw_args.iter().enumerate().skip(1) {
+        if arg == "--" {
+            dash_positions.push(i);
+        }
+    }
+
+    if dash_positions.is_empty() {
+        return parsed_args.to_vec();
+    }
+
+    // Build result by inserting "--" at correct positions relative to parsed args
+    let mut result = Vec::new();
+    let mut raw_idx = 1; // start after "rtk"
+    let mut dash_idx = 0;
+
+    while raw_idx < raw_args.len() {
+        // Check if current position is a "--" that was swallowed
+        if dash_idx < dash_positions.len() && raw_idx == dash_positions[dash_idx] {
+            result.push("--".to_string());
+            dash_idx += 1;
+        } else if parsed_args.contains(&raw_args[raw_idx]) {
+            // This arg is in parsed_args, add it
+            result.push(raw_args[raw_idx].clone());
+        }
+        raw_idx += 1;
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn restore_with_raw(parsed: &[&str], raw: &[&str]) -> Vec<String> {
+        let parsed: Vec<String> = parsed.iter().map(|s| s.to_string()).collect();
+        let raw: Vec<String> = raw.iter().map(|s| s.to_string()).collect();
+        restore_double_dash_with_raw(parsed.as_slice(), raw.as_slice())
+    }
+
+    // ============ Single "--" swallowed ============
+
+    #[test]
+    fn test_single_dash_swallowed() {
+        // rtk git diff -- file → clap gave ["file"], restore "--"
+        let raw = vec!["rtk", "git", "diff", "--", "file"];
+        let parsed = vec!["file"];
+        assert_eq!(restore_with_raw(&parsed, &raw), vec!["--", "file"]);
+    }
+
+    #[test]
+    fn test_args_before_dash() {
+        // rtk cargo test name -- --nocapture → args before "--" stay before
+        let raw = vec!["rtk", "cargo", "test", "name", "--", "--nocapture"];
+        let parsed = vec!["name", "--nocapture"];
+        assert_eq!(
+            restore_with_raw(&parsed, &raw),
+            vec!["name", "--", "--nocapture"]
+        );
+    }
+
+    // ============ Multiple "--" swallowed ============
+
+    #[test]
+    fn test_multiple_dashes_all_swallowed() {
+        // rtk git diff -- -- -- → all 3 "--" swallowed, consecutive in output
+        let raw = vec!["rtk", "git", "diff", "--", "--", "--"];
+        let parsed: Vec<&str> = vec![];
+        assert_eq!(restore_with_raw(&parsed, &raw), vec!["--", "--", "--"]);
+    }
+
+    #[test]
+    fn test_dashes_with_args_between() {
+        // rtk git diff -- arg1 -- arg2 → both "--" consumed, preserve positions
+        let raw = vec!["rtk", "git", "diff", "--", "arg1", "--", "arg2"];
+        let parsed = vec!["arg1", "arg2"];
+        // Result: each "--" inserted at its original position relative to args
+        assert_eq!(
+            restore_with_raw(&parsed, &raw),
+            vec!["--", "arg1", "--", "arg2"]
+        );
+    }
+
+    #[test]
+    fn test_multiple_dashes_some_preserved() {
+        // rtk git diff -- -- → 2 in raw, 1 preserved in parsed
+        let raw = vec!["rtk", "git", "diff", "--", "--"];
+        let parsed = vec!["--"];
+        assert_eq!(restore_with_raw(&parsed, &raw), vec!["--", "--"]);
+    }
+
+    #[test]
+    fn test_compound_command_with_dashes() {
+        // Multiple segments with "--" → restore all
+        let raw = vec!["rtk", "cmd1", "--", "arg1", "&&", "cmd2", "--", "file"];
+        let parsed = vec!["file"];
+        assert_eq!(restore_with_raw(&parsed, &raw), vec!["--", "--", "file"]);
+    }
+
+    // ============ "--" already present (no change needed) ============
+
+    #[test]
+    fn test_dash_already_preserved() {
+        // rtk cargo clippy -p pkg -- -D warnings → clap kept "--"
+        let raw = vec![
+            "rtk", "cargo", "clippy", "-p", "pkg", "--", "-D", "warnings",
+        ];
+        let parsed = vec!["-p", "pkg", "--", "-D", "warnings"];
+        assert_eq!(
+            restore_with_raw(&parsed, &raw),
+            vec!["-p", "pkg", "--", "-D", "warnings"]
+        );
+    }
+
+    #[test]
+    fn test_trailing_dash_preserved() {
+        // rtk git diff file -- → trailing "--" preserved
+        let raw = vec!["rtk", "git", "diff", "file", "--"];
+        let parsed = vec!["file", "--"];
+        assert_eq!(restore_with_raw(&parsed, &raw), vec!["file", "--"]);
+    }
+
+    // ============ No "--" in original (no injection) ============
+
+    #[test]
+    fn test_no_dash_in_original() {
+        // Various cases: branch with /, range, bare word, flags only
+        // All should return args unchanged (no injection)
+        let cases = vec![
+            (
+                vec!["rtk", "git", "diff", "feature/auth"],
+                vec!["feature/auth"],
+            ),
+            (
+                vec!["rtk", "git", "diff", "main...feature"],
+                vec!["main...feature"],
+            ),
+            (vec!["rtk", "git", "diff", "main"], vec!["main"]),
+            (
+                vec!["rtk", "git", "diff", "--stat", "--cached"],
+                vec!["--stat", "--cached"],
+            ),
+        ];
+        for (raw, parsed) in cases {
+            assert_eq!(restore_with_raw(&parsed, &raw), parsed);
+        }
+    }
+
+    // ============ Edge cases ============
+
+    #[test]
+    fn test_duplicate_args_both_sides() {
+        // -p pkg1 -p pkg2 -- -p pkg3 → restore after last -p
+        let raw = vec![
+            "rtk", "cargo", "clippy", "-p", "p1", "-p", "p2", "--", "-p", "p3",
+        ];
+        let parsed = vec!["-p", "p1", "-p", "p2", "-p", "p3"];
+        assert_eq!(
+            restore_with_raw(&parsed, &raw),
+            vec!["-p", "p1", "-p", "p2", "--", "-p", "p3"]
+        );
+    }
+
+    #[test]
+    fn test_empty_args() {
+        let raw = vec!["rtk", "cargo", "test"];
+        let parsed: Vec<&str> = vec![];
+        assert_eq!(restore_with_raw(&parsed, &raw), Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_cargo_clippy_missing_dash() {
+        // No "--" in original → no injection
+        let raw = vec!["rtk", "cargo", "clippy", "-D", "warnings"];
+        let parsed = vec!["-D", "warnings"];
+        assert_eq!(restore_with_raw(&parsed, &raw), vec!["-D", "warnings"]);
+    }
+
+    // ============ Git diff specific cases ============
+
+    #[test]
+    fn test_git_diff_ref_before_path() {
+        // rtk git diff HEAD -- file
+        let raw = vec!["rtk", "git", "diff", "HEAD", "--", "file"];
+        let parsed = vec!["HEAD", "file"];
+        assert_eq!(restore_with_raw(&parsed, &raw), vec!["HEAD", "--", "file"]);
+    }
+
+    #[test]
+    fn test_git_diff_flags_before_path() {
+        // rtk git diff --cached -- file
+        let raw = vec!["rtk", "git", "diff", "--cached", "--", "file"];
+        let parsed = vec!["--cached", "file"];
+        assert_eq!(
+            restore_with_raw(&parsed, &raw),
+            vec!["--cached", "--", "file"]
+        );
+    }
+
+    #[test]
+    fn test_git_diff_multiple_files() {
+        // Original issue: multiple files caused "fatal: bad revision"
+        let raw = vec!["rtk", "git", "diff", "--", "file1", "file2", "file3"];
+        let parsed = vec!["file1", "file2", "file3"];
+        assert_eq!(
+            restore_with_raw(&parsed, &raw),
+            vec!["--", "file1", "file2", "file3"]
+        );
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,5 +1,6 @@
 //! Building blocks shared across all RTK modules.
 
+pub mod args_utils;
 pub mod config;
 pub mod constants;
 pub mod display_helpers;


### PR DESCRIPTION
## Summary
- Introduce a shared, generic solution to restore double dashed into args
- Replace custom solutions in cargo and git commands with that solution

Fixes #1669

## Test plan
- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk git diff -- "src/core/args_utils.rs"` output inspected
