### PR TITLE
feat(pipe): add dotnet-test pipe filter

### DIFF
--- a/src/cmds/dotnet/dotnet_cmd.rs
+++ b/src/cmds/dotnet/dotnet_cmd.rs
@@ -1141,6 +1141,31 @@ fn format_test_output(
     .join("\n")
 }
 
+/// Pipe-mode filter for `dotnet test` stdout (`rtk pipe --filter dotnet-test`).
+///
+/// Used when test output is captured externally (e.g. WSL invoking the Windows
+/// `dotnet` via `cmd.exe`) and rtk's `dotnet test` wrapper can't be invoked
+/// directly. Parses the same regexes as the wrapper but without a binlog,
+/// infers success from the parsed counts, and renders the standard
+/// `format_test_output` summary.
+pub(crate) fn filter_dotnet_test_text(input: &str) -> String {
+    let test_summary = binlog::parse_test_from_text(input);
+    let build_summary = binlog::parse_build_from_text(input);
+
+    let command_success = test_summary.failed == 0
+        && test_summary.failed_tests.is_empty()
+        && build_summary.errors.is_empty();
+
+    let summary = normalize_test_summary(test_summary, command_success);
+    let dummy_binlog_path = PathBuf::new();
+    format_test_output(
+        &summary,
+        &build_summary.errors,
+        &build_summary.warnings,
+        &dummy_binlog_path,
+    )
+}
+
 /// Format the restore summary for stdout.
 ///
 /// `_binlog_path` is intentionally unused — the binlog is a temporary file
@@ -2447,5 +2472,52 @@ mod tests {
         cleanup_temp_file(&missing_file);
 
         assert!(!missing_file.exists());
+    }
+
+    #[test]
+    fn test_filter_dotnet_test_text_passing_run() {
+        // Real-world dotnet test stdout (success case, single project)
+        let input = "  Joko.NINA.Plugins.HocusFocus.Tests -> /repo/bin/Debug/Tests.dll\n\
+                     Test run for /repo/bin/Debug/Tests.dll (.NETCoreApp,Version=v8.0)\n\
+                     A total of 1 test files matched the specified pattern.\n\
+                     \n\
+                     Passed!  - Failed:     0, Passed:   672, Skipped:     0, Total:   672, \
+                     Duration: 2 s - Tests.dll (net8.0)\n";
+
+        let output = filter_dotnet_test_text(input);
+        assert!(output.starts_with("ok"), "verdict should be 'ok': {}", output);
+        assert!(output.contains("672 tests passed"), "out={}", output);
+        // Filter must compress: real input is ~300+ bytes, output should be much smaller
+        assert!(output.len() < input.len(), "filter should shrink output");
+    }
+
+    #[test]
+    fn test_filter_dotnet_test_text_failing_run() {
+        let input = "Test run for /repo/bin/Debug/Tests.dll (.NETCoreApp,Version=v8.0)\n\
+                     Failed MyTests.ShouldFail [10 ms]\n\
+                     Error Message:\n\
+                       Expected: 5\n\
+                       But was:  4\n\
+                     Stack Trace:\n\
+                        at MyTests.ShouldFail() in /repo/MyTests.cs:line 42\n\
+                     \n\
+                     Failed!  - Failed:     1, Passed:   670, Skipped:     0, Total:   671, \
+                     Duration: 2 s - Tests.dll (net8.0)\n";
+
+        let output = filter_dotnet_test_text(input);
+        assert!(
+            output.starts_with("fail") || output.contains("\nfail "),
+            "verdict should be 'fail': {}",
+            output
+        );
+        assert!(output.contains("MyTests.ShouldFail"), "out={}", output);
+        assert!(output.contains("1 failed"), "out={}", output);
+    }
+
+    #[test]
+    fn test_filter_dotnet_test_text_empty_input_is_safe() {
+        let output = filter_dotnet_test_text("");
+        // Empty input should not panic; produces a degenerate "binlog-only" header.
+        assert!(!output.is_empty());
     }
 }

--- a/src/cmds/system/pipe_cmd.rs
+++ b/src/cmds/system/pipe_cmd.rs
@@ -20,6 +20,7 @@ pub fn resolve_filter(name: &str) -> Option<fn(&str) -> String> {
         "ruff-check" => Some(crate::cmds::python::ruff_cmd::filter_ruff_check_json),
         "ruff-format" => Some(crate::cmds::python::ruff_cmd::filter_ruff_format),
         "prettier" => Some(crate::cmds::js::prettier_cmd::filter_prettier_output),
+        "dotnet-test" => Some(crate::cmds::dotnet::dotnet_cmd::filter_dotnet_test_text),
         _ => None,
     }
 }
@@ -169,6 +170,15 @@ pub fn auto_detect_filter(input: &str) -> fn(&str) -> String {
         return vitest_wrapper;
     }
 
+    // dotnet test: "Test run for <path>" appears once per project, and the
+    // verdict line "Passed!  -" / "Failed!  -" is unique to the dotnet CLI.
+    if first_1k.contains("Test run for ")
+        || first_1k.contains("Passed!  - ")
+        || first_1k.contains("Failed!  - ")
+    {
+        return crate::cmds::dotnet::dotnet_cmd::filter_dotnet_test_text;
+    }
+
     // find/fd: all non-empty lines look like file paths, minimum 3 lines
     let path_like_lines: usize = first_1k
         .lines()
@@ -220,7 +230,7 @@ pub fn run(filter_name: Option<&str>, passthrough: bool) -> Result<()> {
             anyhow::anyhow!(
                 "Unknown filter '{}'. Available: cargo-test, pytest, go-test, go-build, \
                  tsc, vitest, grep, rg, find, fd, git-log, git-diff, git-status, \
-                 mypy, ruff-check, ruff-format, prettier",
+                 mypy, ruff-check, ruff-format, prettier, dotnet-test",
                 name
             )
         })?,
@@ -530,5 +540,62 @@ mod tests {
         let f = auto_detect_filter(input);
         let out = f(input);
         assert!(!out.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_filter_dotnet_test() {
+        assert!(resolve_filter("dotnet-test").is_some());
+    }
+
+    #[test]
+    fn test_auto_detect_dotnet_test_passed() {
+        let input = "Test run for /repo/bin/Debug/Tests.dll (.NETCoreApp,Version=v8.0)\n\
+                     A total of 1 test files matched the specified pattern.\n\
+                     \n\
+                     Passed!  - Failed:     0, Passed:   672, Skipped:     0, Total:   672, \
+                     Duration: 2 s - Tests.dll (net8.0)\n";
+        let f = auto_detect_filter(input);
+        let out = f(input);
+        assert!(out.contains("dotnet test"), "out={}", out);
+        assert!(out.contains("672"), "out={}", out);
+    }
+
+    #[test]
+    fn test_dotnet_test_pipe_filter_compresses_real_output() {
+        // Mirrors a real WSL-via-cmd.exe `dotnet test` run: ~50 lines of MSBuild
+        // file-copy noise followed by the one summary line that actually matters.
+        let mut input = String::from(
+            "  Determining projects to restore...\n\
+             Microsoft (R) Build Engine version 17.8.3+195e7f5a3 for .NET\n\
+             Copyright (C) Microsoft Corporation. All rights reserved.\n\n",
+        );
+        for i in 0..40 {
+            input.push_str(&format!(
+                "  /repo/bin/Debug/net8.0/Dep{}.dll\n  1 File(s) copied\n",
+                i
+            ));
+        }
+        input.push_str(
+            "  Joko.NINA.Plugins.HocusFocus.Tests -> /repo/bin/Debug/Tests.dll\n\
+             Test run for /repo/bin/Debug/Tests.dll (.NETCoreApp,Version=v8.0)\n\
+             A total of 1 test files matched the specified pattern.\n\
+             \n\
+             Passed!  - Failed:     0, Passed:   672, Skipped:     0, Total:   672, \
+             Duration: 2 s - Tests.dll (net8.0)\n",
+        );
+
+        let f = resolve_filter("dotnet-test").expect("dotnet-test filter must exist");
+        let output = f(&input);
+
+        assert!(output.contains("672 tests passed"), "out={}", output);
+        // Filter target: ≥60% savings on realistic dotnet test output.
+        let savings = 100.0 - (output.len() as f64 / input.len() as f64 * 100.0);
+        assert!(
+            savings >= 60.0,
+            "dotnet-test filter: expected ≥60% savings, got {:.1}% (in={}, out={})",
+            savings,
+            input.len(),
+            output.len()
+        );
     }
 }


### PR DESCRIPTION
## Summary

Add a `dotnet-test` filter to `rtk pipe`, mirroring the existing `cargo-test` / `pytest` / `go-test` filters.

This unblocks setups where the rtk `dotnet test` wrapper can't be invoked directly — notably WSL development where the Windows toolchain must be run via `cmd.exe /c "dotnet test ..."`. In that flow the rtk hook rewrite never fires (the outer command is `cmd.exe`, not `dotnet`), so until now `dotnet test` output landed in the LLM context completely unfiltered.

## What changed

- New `pub(crate) fn filter_dotnet_test_text` in `src/cmds/dotnet/dotnet_cmd.rs` that:
  - parses test counts via existing `binlog::parse_test_from_text`
  - parses build issues via existing `binlog::parse_build_from_text`
  - infers success from parsed counts (pipe mode has no exit code)
  - renders through the same `format_test_output` as the wrapper, so output is indistinguishable from `rtk dotnet test`
- Registered `dotnet-test` in `pipe_cmd::resolve_filter` and updated the unknown-filter error message
- Added auto-detection on stdin containing `Test run for `, `Passed!  - `, or `Failed!  - `
- 6 new unit tests, including a savings-floor assertion (≥60% on realistic input)

## Validation

Real-world WSL `dotnet test` run (672 tests, 1 project, 10 NU1701 package-restore warnings):

| | bytes |
|---|---|
| raw | 9,107 |
| filtered | 3,361 |
| **saved** | **63%** |

Verdict line preserved verbatim: `ok dotnet test: 672 tests passed, 10 warnings in 10 projects (2 s)`. All 10 legitimate package warnings surfaced; per-DLL "1 File(s) copied" noise stripped.

Quality gate:
- [x] `cargo build` — clean
- [x] `cargo clippy --all-targets` — no issues
- [x] `cargo test --all` — 1831 passed, 0 failed (6 new tests)

## Test plan

- [ ] `echo "Test run for ... Passed!  - Failed:     0, Passed:     5, Skipped:     0, Total:     5, Duration: 1 s" | rtk pipe --filter dotnet-test` → compact `ok` summary
- [ ] Same input via `rtk pipe` (no flag) → auto-detects and routes to the dotnet-test filter
- [ ] Failure-path input (`Failed!  - Failed:     1, ...` plus a `Failed TestName` block) → `fail` verdict + failed-test name surfaced

## Notes for reviewers

- Output format reuses `format_test_output` deliberately — keeps the wrapper and pipe outputs identical so downstream tooling/agent behavior doesn't diverge.
- Did not add `dotnet-build` / `dotnet-restore` pipe filters in the same PR to keep scope focused. They would follow the same shape (`parse_build_from_text` + `format_build_output`, `parse_restore_from_text` + `format_restore_output`) — happy to add as a follow-up if maintainers want.
- Cargo.lock had an unrelated pending change in the working tree (0.36.0 → 0.34.3 sync); reverted before committing so this PR is source-only.
