### PR TITLE
fix(parser/formatter): show every failure name in compact mode (#1813)

### DIFF
--- a/src/parser/formatter.rs
+++ b/src/parser/formatter.rs
@@ -45,19 +45,41 @@ pub trait TokenFormatter {
 
 impl TokenFormatter for TestResult {
     fn format_compact(&self) -> String {
+        // Top-N failures keep their full error message (numbered, indented). Anything
+        // beyond N collapses to a one-liner showing the test name and, when known,
+        // the source file — the original `take(5) + "+N more failures"` truncation
+        // hid every remaining failure name from the agent, which forced a re-read of
+        // the tee log to find the failing files (see rtk-ai/rtk#1813).
+        const DETAILED_FAILURES: usize = 5;
+
         let mut lines = vec![format!("PASS ({}) FAIL ({})", self.passed, self.failed)];
 
         if !self.failures.is_empty() {
             lines.push(String::new());
-            for (idx, failure) in self.failures.iter().enumerate().take(5) {
+            for (idx, failure) in self.failures.iter().enumerate().take(DETAILED_FAILURES) {
                 lines.push(format!("{}. {}", idx + 1, failure.test_name));
                 for line in failure.error_message.lines() {
                     lines.push(format!("   {}", line));
                 }
             }
 
-            if self.failures.len() > 5 {
-                lines.push(format!("\n... +{} more failures", self.failures.len() - 5));
+            if self.failures.len() > DETAILED_FAILURES {
+                lines.push(String::new());
+                lines.push(format!(
+                    "Remaining {} failures:",
+                    self.failures.len() - DETAILED_FAILURES,
+                ));
+                for (idx, failure) in self.failures.iter().enumerate().skip(DETAILED_FAILURES) {
+                    // `file_path` is set on the JSON happy-path (vitest/playwright Tier 1)
+                    // but empty in regex-fallback Tier 2 — emit the bracket suffix only
+                    // when populated so the line does not render as `1. name []`.
+                    let path_hint = if failure.file_path.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" [{}]", failure.file_path)
+                    };
+                    lines.push(format!("{}. {}{}", idx + 1, failure.test_name, path_hint,));
+                }
             }
         }
 
@@ -254,6 +276,153 @@ mod tests {
         assert!(
             output.contains("Timeout exceeded"),
             "Single-line error must appear\nGot:\n{output}"
+        );
+    }
+
+    // Regression for rtk-ai/rtk#1813: when a test run has more than 5 failures the
+    // first 5 keep their full error detail, and every remaining failure must still
+    // be visible by name (plus file path when known) so the agent can locate every
+    // failing file without re-reading the tee log.
+    #[test]
+    fn test_compact_lists_remaining_failures_with_file_path() {
+        let failures: Vec<TestFailure> = (1..=7)
+            .map(|i| TestFailure {
+                test_name: format!("test number {i}"),
+                file_path: format!("tests/spec_{i}.test.ts"),
+                error_message: format!("AssertionError: test {i} failed"),
+                stack_trace: None,
+            })
+            .collect();
+        let result = make_result(40, failures);
+
+        let output = result.format_compact();
+
+        // Top 5 keep full detail (numbering + error message line).
+        for i in 1..=5 {
+            assert!(
+                output.contains(&format!("{i}. test number {i}")),
+                "detailed entry {i} missing\nGot:\n{output}"
+            );
+            assert!(
+                output.contains(&format!("AssertionError: test {i} failed")),
+                "error for detailed entry {i} missing\nGot:\n{output}"
+            );
+        }
+        // Remaining failures must be listed by name with file_path bracketed.
+        assert!(
+            output.contains("Remaining 2 failures:"),
+            "overflow section missing\nGot:\n{output}"
+        );
+        for i in 6..=7 {
+            assert!(
+                output.contains(&format!("{i}. test number {i} [tests/spec_{i}.test.ts]")),
+                "overflow entry {i} missing or malformed\nGot:\n{output}"
+            );
+        }
+        // The legacy "+N more failures" line must not appear — it was the bug.
+        assert!(
+            !output.contains("more failures"),
+            "legacy '+N more failures' truncation leaked\nGot:\n{output}"
+        );
+    }
+
+    // Tier-2 (regex fallback) leaves file_path empty for every failure; the
+    // overflow line must render as `N. test_name` with no dangling `[]` suffix.
+    #[test]
+    fn test_compact_lists_remaining_failures_without_file_path() {
+        let failures: Vec<TestFailure> = (1..=8)
+            .map(|i| TestFailure {
+                test_name: format!("orphan test {i}"),
+                file_path: String::new(),
+                error_message: format!("err {i}"),
+                stack_trace: None,
+            })
+            .collect();
+        let result = make_result(0, failures);
+
+        let output = result.format_compact();
+
+        // Overflow entries omit the bracket when file_path is empty.
+        for i in 6..=8 {
+            assert!(
+                output.contains(&format!("{i}. orphan test {i}\n"))
+                    || output.ends_with(&format!("{i}. orphan test {i}"))
+                    || output.contains(&format!("{i}. orphan test {i}\nTime:")),
+                "overflow entry {i} should be 'N. name' with no trailing brackets\nGot:\n{output}"
+            );
+            assert!(
+                !output.contains(&format!("{i}. orphan test {i} []")),
+                "empty file_path must not render as '[]'\nGot:\n{output}"
+            );
+        }
+    }
+
+    // Boundary: exactly 5 failures must not emit the "Remaining" section.
+    #[test]
+    fn test_compact_no_remaining_section_at_five_failure_boundary() {
+        let failures: Vec<TestFailure> = (1..=5)
+            .map(|i| make_failure(&format!("test {i}"), &format!("err {i}")))
+            .collect();
+        let result = make_result(10, failures);
+
+        let output = result.format_compact();
+
+        assert!(
+            !output.contains("Remaining"),
+            "no overflow section expected at boundary of 5\nGot:\n{output}"
+        );
+        assert!(
+            !output.contains("more failures"),
+            "legacy overflow line must not appear at boundary\nGot:\n{output}"
+        );
+    }
+
+    // The core promise of rtk-ai/rtk#1813: every failure name must be visible
+    // in the compact output regardless of count. With 49 failures the first 5
+    // stay detailed and the other 44 appear as one-liners with their file paths.
+    #[test]
+    fn test_compact_keeps_every_failure_name_visible_on_large_set() {
+        let failures: Vec<TestFailure> = (1..=49)
+            .map(|i| TestFailure {
+                test_name: format!(
+                    "src/agents/agent-validation.test.ts > agent rejects malformed payload variant {i}"
+                ),
+                file_path: format!("src/agents/agent-validation-{i}.test.ts"),
+                error_message: format!("AssertionError: expected 403 to be 201 (case {i})"),
+                stack_trace: None,
+            })
+            .collect();
+        let result = make_result(664, failures);
+
+        let compact = result.format_compact();
+
+        // Header + overflow announcement are present.
+        assert!(compact.starts_with("PASS (664) FAIL (49)"));
+        assert!(compact.contains("Remaining 44 failures:"));
+
+        // Every variant 1..=49 is named in the output.
+        for i in 1..=49 {
+            assert!(
+                compact.contains(&format!("variant {i}")),
+                "failure {i} must be visible in compact output (issue #1813)"
+            );
+        }
+        // Overflow entries 6..=49 must carry their file_path bracket.
+        for i in 6..=49 {
+            assert!(
+                compact.contains(&format!("[src/agents/agent-validation-{i}.test.ts]")),
+                "overflow entry {i} should include its file_path bracket"
+            );
+        }
+        // Compact still comes out structurally smaller than the verbose dump
+        // even with every name preserved — the per-failure stack-trace preview
+        // verbose adds keeps it the larger of the two modes.
+        let verbose = result.format_verbose();
+        assert!(
+            compact.len() < verbose.len(),
+            "compact ({} chars) must stay smaller than verbose ({} chars)",
+            compact.len(),
+            verbose.len(),
         );
     }
 }


### PR DESCRIPTION
Closes #1813.

## Problem

`TestResult::format_compact()` truncates to the first 5 failures and
replaces the rest with `... +N more failures`. On a real-world vitest
run with 49 failures, 44 test names — and the files they belong to —
disappear from the agent's context. The agent then has to re-read the
tee log (whose path has spaces and contains raw JSON) to find which
tests failed, which is exactly the round-trip overhead RTK is supposed
to remove.

The truncation lives on `TestResult`, so it affects every test-runner
consumer of `TokenFormatter::format(Compact)`. Today that's
`vitest_cmd`, `playwright_cmd`, and the `pnpm_cmd` vitest wrapper.

## Before / after on 49 failures

Before:
```
PASS (664) FAIL (49)

1. test_a
   AssertionError: expected 403 to be 201
2. test_b
   ...

... +44 more failures
```

After:
```
PASS (664) FAIL (49)

1. test_a
   AssertionError: expected 403 to be 201
... (5 detailed entries unchanged) ...

Remaining 44 failures:
6. test_f [src/agents/agent-validation-6.test.ts]
7. test_g [src/agents/agent-validation-7.test.ts]
...
49. test_xyz [src/users/user-flow-49.test.ts]
```

## Design

- First 5 failures keep the full multi-line `error_message` exactly as
  before.
- 6+ render on one line as `N. test_name [file_path]`.
- `file_path` is rendered only when non-empty so the regex-fallback
  Tier 2 path in `vitest_cmd` does not produce `N. name []` with
  dangling brackets.
- The boundary case of exactly 5 failures still emits no overflow
  section, matching the previous behavior.
- `format_verbose` and `format_ultra` are untouched.

## Preserved invariants

- `PASS (X) FAIL (Y)` summary header.
- Full multi-line `error_message` for the top 5 (the Playwright
  diff / call-log invariant the existing
  `test_compact_shows_full_error_message` test already enforces).
- `Time: Xms` footer when `duration_ms` is set.
- No failure section when `failures.is_empty()`.
- Compact stays structurally smaller than verbose, even with every
  remaining name preserved.

## Tests

Four regression tests added next to the existing ones in
`src/parser/formatter.rs`:

- `test_compact_lists_remaining_failures_with_file_path` — top-5
  detail preserved, overflow rendered as `N. name [path]`, no leftover
  `+N more failures` text.
- `test_compact_lists_remaining_failures_without_file_path` — empty
  `file_path` (Tier 2) produces `N. name` with no dangling brackets.
- `test_compact_no_remaining_section_at_five_failure_boundary` —
  exactly 5 failures emits neither the new `Remaining` section nor
  the legacy line.
- `test_compact_keeps_every_failure_name_visible_on_large_set` —
  realistic 49-failure shape, every variant 1..49 is named, every
  variant 6..49 carries its `file_path` bracket, compact stays smaller
  than verbose.

The existing four compact tests (full-error-message preservation,
summary-line conciseness, all-pass one-liner, single-line error
trailing-noise) still pass unchanged.

## Validation

```
cargo fmt --all && cargo clippy --all-targets -- -D warnings && cargo test --all
# 1829 passed, 6 ignored
```