### PR TITLE
fix(ls): remove .env from NOISE_DIRS to prevent silent credential overwrite

### DIFF
--- a/src/cmds/system/constants.rs
+++ b/src/cmds/system/constants.rs
@@ -15,7 +15,7 @@ pub const NOISE_DIRS: &[&str] = &[
     ".venv",
     "venv",
     "env",
-    ".env",
+    // NOTE: .env is intentionally absent — it is a file containing secrets and must never be hidden
     "coverage",
     ".nyc_output",
     ".DS_Store",


### PR DESCRIPTION
## Problem

\`.env\` was listed in \`NOISE_DIRS\`, causing \`rtk ls\` to silently hide \`.env\` files from directory listings. Only the canonical dotenv file was affected — \`.env.production\`, \`.env.staging\`, \`.env.example\` remained visible.

**Silent failure mode for AI agents**:
1. Agent runs \`rtk ls\` to assess a project
2. Does not see any \`.env\` file
3. Generates a new \`.env\` from project docs and placeholder values
4. The existing \`.env\` — containing production secrets — is **overwritten**
5. Agent confirms "success". Credentials are gone.

## Root Cause

\`NOISE_DIRS\` is intended to suppress build artifact and tool **directories** (\`node_modules\`, \`.git\`, \`target\`, etc.). A \`.env\` file is neither a directory nor a build artifact — it must always be visible.

Note: \`env\`, \`.venv\`, and \`venv\` (Python virtualenv directories) remain in the list.

## Fix

Remove \`.env\` from \`NOISE_DIRS\`. One line change.

---

> Identified via adversarial testing: https://www.reddit.com/r/ClaudeCode/comments/1spiy8t/