### PR TITLE
fix(docs): repair broken links across README, docs, and templates

### DIFF
--- a/.claude/agents/technical-writer.md
+++ b/.claude/agents/technical-writer.md
@@ -141,9 +141,7 @@ rtk --version
 
 **Binary Download** (faster):
 ```bash
-curl -sSL https://github.com/rtk-ai/rtk/releases/download/v0.16.0/rtk-linux-x86_64 -o rtk
-chmod +x rtk
-sudo mv rtk /usr/local/bin/
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
 rtk --version
 ```
 

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -187,9 +187,9 @@ gh release view v0.17.0
 
 ### 3. Installation Verification
 ```bash
-# Test installation from release
-curl -sSL https://github.com/rtk-ai/rtk/releases/download/v0.17.0/rtk-macos-latest -o rtk
-chmod +x rtk
+# Test installation from release (replace VERSION + ARCH as needed)
+curl -sSL https://github.com/rtk-ai/rtk/releases/download/v0.17.0/rtk-aarch64-apple-darwin.tar.gz -o rtk.tar.gz
+tar xzf rtk.tar.gz
 ./rtk --version
 # Should show v0.17.0
 ```

--- a/.rtk/filters.toml
+++ b/.rtk/filters.toml
@@ -1,6 +1,6 @@
 # Project-local RTK filters — commit this file with your repo.
 # Filters here override user-global and built-in filters.
-# Docs: https://github.com/rtk-ai/rtk#custom-filters
+# Docs: https://github.com/rtk-ai/rtk/blob/HEAD/src/filters/README.md
 schema_version = 1
 
 # Example: suppress build noise from a custom tool

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="https://www.rtk-ai.app">Website</a> &bull;
   <a href="#installation">Install</a> &bull;
-  <a href="https://www.rtk-ai.app/guide/troubleshooting">Troubleshooting</a> &bull;
+  <a href="https://www.rtk-ai.app/docs/resources/troubleshooting/">Troubleshooting</a> &bull;
   <a href="docs/contributing/ARCHITECTURE.md">Architecture</a> &bull;
   <a href="https://discord.gg/RySmvNF5kF">Discord</a>
 </p>
@@ -370,7 +370,7 @@ RTK supports 13 AI coding tools. Each integration rewrites shell commands to `rt
 | **Kilo Code** | `rtk init --agent kilocode` | .kilocode/rules/rtk-rules.md (project-scoped) |
 | **Google Antigravity** | `rtk init --agent antigravity` | .agents/rules/antigravity-rtk-rules.md (project-scoped) |
 
-For per-agent setup details, override controls, and graceful degradation, see the [Supported Agents guide](https://www.rtk-ai.app/guide/getting-started/supported-agents). The Hermes plugin source and tests live in `hooks/hermes/`; installed Hermes runtime files still live under `~/.hermes/plugins/rtk-rewrite/`.
+For per-agent setup details, override controls, and graceful degradation, see the [Supported Agents guide](https://www.rtk-ai.app/docs/getting-started/supported-agents/). The Hermes plugin source and tests live in `hooks/hermes/`; installed Hermes runtime files still live under `~/.hermes/plugins/rtk-rewrite/`.
 
 ## Configuration
 
@@ -392,7 +392,7 @@ FAILED: 2/15 tests
 [full output: ~/.local/share/rtk/tee/1707753600_cargo_test.log]
 ```
 
-For the full config reference (all sections, env vars, per-project filters), see the [Configuration guide](https://www.rtk-ai.app/guide/getting-started/configuration).
+For the full config reference (all sections, env vars, per-project filters), see the [Configuration guide](https://www.rtk-ai.app/docs/getting-started/configuration/).
 
 ### Uninstall
 
@@ -404,7 +404,7 @@ brew uninstall rtk           # If installed via Homebrew
 
 ## Documentation
 
-- **[rtk-ai.app/guide](https://www.rtk-ai.app/guide)** — full user guide (installation, supported agents, what gets optimized, analytics, configuration, troubleshooting)
+- **[rtk-ai.app/docs](https://www.rtk-ai.app/docs/)** — full user guide (installation, supported agents, what gets optimized, analytics, configuration, troubleshooting)
 - **[INSTALL.md](INSTALL.md)** — detailed installation reference
 - **[ARCHITECTURE.md](docs/contributing/ARCHITECTURE.md)** — system design and technical decisions
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** — contribution guide

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -62,4 +62,4 @@ See [Discover and Session](./analytics/discover.md) for details.
 - [Configuration](./getting-started/configuration.md) — config.toml, global flags, env vars, tee recovery
 - [Troubleshooting](./resources/troubleshooting.md) — common issues and fixes
 - [Telemetry & Privacy](./resources/telemetry.md) — what RTK collects and how to opt out
-- [ARCHITECTURE.md](https://github.com/rtk-ai/rtk/blob/master/ARCHITECTURE.md) — system design for contributors
+- [ARCHITECTURE.md](https://github.com/rtk-ai/rtk/blob/HEAD/docs/contributing/ARCHITECTURE.md) — system design for contributors

--- a/scripts/check-installation.sh
+++ b/scripts/check-installation.sh
@@ -24,7 +24,7 @@ else
     echo -e "   ${RED}❌ RTK is NOT installed${NC}"
     echo ""
     echo "   Install with:"
-    echo "   curl -fsSL https://github.com/rtk-ai/rtk/blob/master/install.sh| sh"
+    echo "   curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh"
     exit 1
 fi
 echo ""
@@ -45,7 +45,7 @@ else
     echo ""
     echo "   You installed the wrong package. Fix it with:"
     echo "   cargo uninstall rtk"
-    echo "   curl -fsSL https://github.com/rtk-ai/rtk/blob/master/install.sh | sh"
+    echo "   curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh"
     CORRECT_RTK=false
 fi
 echo ""
@@ -142,7 +142,7 @@ if [ ${#MISSING_FEATURES[@]} -gt 0 ]; then
     echo ""
     echo "To get all features, install the fork:"
     echo "  cargo uninstall rtk"
-    echo "  curl -fsSL https://github.com/rtk-ai/rtk/blob/master/install.sh | sh"
+    echo "  curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh"
     echo "  cd rtk && git checkout feat/all-features"
     echo "  cargo install --path . --force"
 else

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -29,7 +29,7 @@ const RTK_SLIM_CODEX: &str = include_str!("../../hooks/codex/rtk-awareness.md");
 /// Template written by `rtk init` when no filters.toml exists yet.
 const FILTERS_TEMPLATE: &str = r#"# Project-local RTK filters — commit this file with your repo.
 # Filters here override user-global and built-in filters.
-# Docs: https://github.com/rtk-ai/rtk#custom-filters
+# Docs: https://github.com/rtk-ai/rtk/blob/HEAD/src/filters/README.md
 schema_version = 1
 
 # Example: suppress build noise from a custom tool
@@ -45,7 +45,7 @@ schema_version = 1
 /// Template for user-global filters (~/.config/rtk/filters.toml).
 const FILTERS_GLOBAL_TEMPLATE: &str = r#"# User-global RTK filters — apply to all your projects.
 # Project-local .rtk/filters.toml takes precedence over these.
-# Docs: https://github.com/rtk-ai/rtk#custom-filters
+# Docs: https://github.com/rtk-ai/rtk/blob/HEAD/src/filters/README.md
 schema_version = 1
 
 # Example: suppress noise from a tool you use everywhere


### PR DESCRIPTION
## TL;DR

Audit of every URL in the repo found **9 broken links** across 7 files plus 2 README links that worked only via redirect. All fixed; doc-only changes; pre-commit gate clean (`fmt` + `clippy` + `1869 tests passed`).

## Summary

All URLs below are clickable in the preview — click both **Before** and **After** to verify yourself.

### 🔴 Group 1 — Broken (404 or wrong content)

**README.md — supported-agents docs**

- ❌ Before · **404** · https://www.rtk-ai.app/guide/getting-started/supported-agents
- ✅ After  · **200** · https://www.rtk-ai.app/docs/getting-started/supported-agents/

**README.md — configuration docs**

- ❌ Before · **404** · https://www.rtk-ai.app/guide/getting-started/configuration
- ✅ After  · **200** · https://www.rtk-ai.app/docs/getting-started/configuration/

**`src/hooks/init.rs` (×2) and `.rtk/filters.toml` — filter template header**

- ❌ Before · **page 200, anchor dead** · https://github.com/rtk-ai/rtk#custom-filters (no `## Custom Filters` heading exists in the README)
- ✅ After  · **200** · https://github.com/rtk-ai/rtk/blob/HEAD/src/filters/README.md

**`docs/guide/index.md` — ARCHITECTURE.md link**

- ❌ Before · **404** · https://github.com/rtk-ai/rtk/blob/master/ARCHITECTURE.md (file actually lives at `docs/contributing/ARCHITECTURE.md`)
- ✅ After  · **200** · https://github.com/rtk-ai/rtk/blob/HEAD/docs/contributing/ARCHITECTURE.md

**`scripts/check-installation.sh` (×3) — install one-liner**

- ❌ Before · **200 but `text/html`** · https://github.com/rtk-ai/rtk/blob/master/install.sh (GitHub's HTML wrapper page, not the script — fails when piped to `sh`)
- ✅ After  · **200 `text/plain`** · https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh

**`.claude/agents/technical-writer.md` — Linux binary install snippet**

- ❌ Before · **404** · https://github.com/rtk-ai/rtk/releases/download/v0.16.0/rtk-linux-x86_64 (asset name never existed; releases ship `.tar.gz` tarballs)
- ✅ After  · replaced with the official `install.sh` one-liner

**`.claude/skills/ship/SKILL.md` — release verification snippet**

- ❌ Before · **404** · https://github.com/rtk-ai/rtk/releases/download/v0.17.0/rtk-macos-latest (asset name never existed)
- ✅ After  · **200** · https://github.com/rtk-ai/rtk/releases/download/v0.17.0/rtk-aarch64-apple-darwin.tar.gz

### 🟢 Group 2 — Worked via redirect, now canonical

**README.md — troubleshooting link**

- 🔁 Before · **301 → /docs/resources/troubleshooting/** · https://www.rtk-ai.app/guide/troubleshooting
- ✅ After  · **200 direct** · https://www.rtk-ai.app/docs/resources/troubleshooting/

**README.md — docs landing link**

- 🔁 Before · **301 → /docs/** · https://www.rtk-ai.app/guide
- ✅ After  · **200 direct** · https://www.rtk-ai.app/docs/

---

Doc-only changes — no runtime behavior altered. The only Rust file touched is `src/hooks/init.rs`, and only the URL inside two `const &str` template comments (the headers written by `rtk init` into a new `.rtk/filters.toml` or `~/.config/rtk/filters.toml`).


## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --all-targets` — 0 warnings
- [x] `cargo test` — **1869 passed**, 0 failed, 6 ignored
- [x] HTTP status verified for every URL via `curl -sS -L -o /dev/null -w '%{http_code}' --max-time 12 <url>`
- [x] Content-type verified for `install.sh` (`text/html` vs `text/plain`) to confirm `/blob/` vs `raw.githubusercontent.com` distinction
- [x] All ✅ After URLs return **200** (or **200 direct** for the canonical/redirect cases)
- [x] All ❌ Before URLs return **404** (or wrong content-type for `install.sh`)
- [ ] ~~Manual `rtk <command>` output inspection~~ — N/A, no filter logic changed

### Pre-commit gate raw output

```text
$ cargo fmt --all --check
(clean)

$ cargo clippy --all-targets
Finished `dev` profile [unoptimized + debuginfo] target(s) in 24.34s
(0 warnings)

$ cargo test
test result: ok. 1869 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out
