### PR TITLE
feat(hook): add Devin agent integration

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -41,6 +41,7 @@ Each agent subdirectory has its own README with hook-specific details:
 - **[`codex/`](codex/README.md)** — Awareness document, `AGENTS.md` integration, `$CODEX_HOME` or `~/.codex/` location
 - **[`opencode/`](opencode/README.md)** — TypeScript plugin, `zx` library, `tool.execute.before` event, in-place mutation
 - **[`hermes/`](hermes/README.md)** — Python plugin, `pre_tool_call` hook, in-place terminal command mutation
+- **[`devin/`](devin/README.md)** — Shell hook, `PreToolUse` JSON format (Claude-compatible), uses `rtk hook claude` command
 
 ## Supported Agents
 
@@ -56,6 +57,7 @@ Each agent subdirectory has its own README with hook-specific details:
 | Codex CLI | AGENTS.md / instructions | Prompt-level guidance | N/A |
 | OpenCode | TypeScript plugin (`tool.execute.before`) | In-place mutation | Yes |
 | Hermes | Python plugin (`pre_tool_call`) | In-place mutation | Yes |
+| Devin for Terminal | Shell hook (`PreToolUse`) | Transparent rewrite | Yes (`updatedInput`) |
 
 ## JSON Formats by Agent
 
@@ -80,6 +82,14 @@ Each agent subdirectory has its own README with hook-specific details:
   }
 }
 ```
+
+### Devin for Terminal (Shell Hook)
+
+**Input**: Same as Claude Code.
+
+**Output**: Same as Claude Code format (with `updatedInput`).
+
+Devin hooks are fully compatible with Claude Code hooks and use the same JSON format.
 
 ### Cursor (Shell Hook)
 

--- a/hooks/devin/README.md
+++ b/hooks/devin/README.md
@@ -1,0 +1,33 @@
+# Devin Hooks
+
+> Part of [`hooks/`](../README.md) — see also [`src/hooks/`](../../src/hooks/README.md) for installation code
+
+## Specifics
+
+- Devin hooks are fully compatible with Claude Code hooks and use the same JSON format
+- Shell-based `PreToolUse` hook -- requires `jq` for JSON parsing
+- Returns `updatedInput` JSON for transparent command rewrite (agent doesn't know RTK is involved)
+- Exits silently (exit 0) on any failure: jq missing, rtk missing, rtk too old (< 0.23.0), no match
+- Version guard checks `rtk --version` against minimum 0.23.0
+- Uses the standard `rtk hook claude` command (Devin and Claude Code share the same hook protocol)
+
+## Installation
+
+```bash
+rtk init --agent devin
+```
+
+This installs the hook in `~/.config/devin/config.json` using the Claude-compatible format.
+
+## Testing
+
+```bash
+# Run the full test suite (60+ assertions)
+bash hooks/devin/test-rtk-rewrite.sh
+
+# Test against a specific hook path
+HOOK=/path/to/rtk-rewrite.sh bash hooks/devin/test-rtk-rewrite.sh
+
+# Enable audit logging during testing
+RTK_HOOK_AUDIT=1 RTK_AUDIT_DIR=/tmp bash hooks/devin/test-rtk-rewrite.sh
+```

--- a/hooks/devin/rtk-rewrite.sh
+++ b/hooks/devin/rtk-rewrite.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# rtk-hook-version: 3
+# RTK Devin hook — rewrites commands to use rtk for token savings.
+# Requires: rtk >= 0.23.0, jq
+#
+# This is a thin delegating hook: all rewrite logic lives in `rtk rewrite`,
+# which is the single source of truth (src/discover/registry.rs).
+# To add or change rewrite rules, edit the Rust registry — not this file.
+#
+# Exit code protocol for `rtk rewrite`:
+#   0 + stdout  Rewrite found, no deny/ask rule matched → auto-allow
+#   1           No RTK equivalent → pass through unchanged
+#   2           Deny rule matched → pass through (Devin native deny handles it)
+#   3 + stdout  Ask rule matched → rewrite but let Devin prompt the user
+
+if ! command -v jq &>/dev/null; then
+  echo "[rtk] WARNING: jq is not installed. Hook cannot rewrite commands. Install jq: https://jqlang.github.io/jq/download/" >&2
+  exit 0
+fi
+
+if ! command -v rtk &>/dev/null; then
+  echo "[rtk] WARNING: rtk is not installed or not in PATH. Hook cannot rewrite commands. Install: https://github.com/rtk-ai/rtk#installation" >&2
+  exit 0
+fi
+
+# Version guard: rtk rewrite was added in 0.23.0.
+# Older binaries: warn once and exit cleanly (no silent failure).
+# Cache the version check to avoid spawning multiple processes on every hook call.
+CACHE_DIR=${XDG_CACHE_HOME:-$HOME/.cache}
+CACHE_FILE="$CACHE_DIR/rtk-hook-version-ok"
+if [ ! -f "$CACHE_FILE" ]; then
+  RTK_VERSION_RAW=$(rtk --version 2>/dev/null)
+  RTK_VERSION=${RTK_VERSION_RAW#rtk }
+  RTK_VERSION=${RTK_VERSION%% *}
+  if [ -n "$RTK_VERSION" ]; then
+    IFS=. read -r MAJOR MINOR PATCH <<<"$RTK_VERSION"
+    # Require >= 0.23.0
+    if [ "$MAJOR" -eq 0 ] && [ "$MINOR" -lt 23 ]; then
+      echo "[rtk] WARNING: rtk $RTK_VERSION is too old (need >= 0.23.0). Upgrade: cargo install rtk" >&2
+      exit 0
+    fi
+  fi
+  mkdir -p "$CACHE_DIR" 2>/dev/null
+  touch "$CACHE_FILE" 2>/dev/null
+fi
+
+INPUT=$(cat)
+CMD=$(jq -r '.tool_input.command // empty' <<<"$INPUT")
+
+if [ -z "$CMD" ]; then
+  exit 0
+fi
+
+# Delegate all rewrite + permission logic to the Rust binary.
+REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null)
+EXIT_CODE=$?
+
+case $EXIT_CODE in
+  0)
+    # Rewrite found, no permission rules matched — safe to auto-allow.
+    # If the output is identical, the command was already using RTK.
+    [ "$CMD" = "$REWRITTEN" ] && exit 0
+    ;;
+  1)
+    # No RTK equivalent — pass through unchanged.
+    exit 0
+    ;;
+  2)
+    # Deny rule matched — let Devin's native deny rule handle it.
+    exit 0
+    ;;
+  3)
+    # Ask rule matched — rewrite the command but do NOT auto-allow so that
+    # Devin prompts the user for confirmation.
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+if [ "$EXIT_CODE" -eq 3 ]; then
+  # Ask: rewrite the command, omit permissionDecision so Devin prompts.
+  jq -c --arg cmd "$REWRITTEN" \
+    '.tool_input.command = $cmd | {
+      "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "updatedInput": .tool_input
+      }
+    }' <<<"$INPUT"
+else
+  # Allow: rewrite the command and auto-allow.
+  jq -c --arg cmd "$REWRITTEN" \
+    '.tool_input.command = $cmd | {
+      "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "allow",
+        "permissionDecisionReason": "RTK auto-rewrite",
+        "updatedInput": .tool_input
+      }
+    }' <<<"$INPUT"
+fi

--- a/hooks/devin/test-rtk-rewrite.sh
+++ b/hooks/devin/test-rtk-rewrite.sh
@@ -1,0 +1,434 @@
+#!/usr/bin/env bash
+# Test suite for rtk-rewrite.sh
+# Feeds mock JSON through the hook and verifies the rewritten commands.
+#
+# Usage: bash ~/.claude/hooks/test-rtk-rewrite.sh
+
+HOOK="${HOOK:-$HOME/.devin/hooks/rtk-rewrite.sh}"
+PASS=0
+FAIL=0
+TOTAL=0
+
+# Colors
+GREEN='\033[32m'
+RED='\033[31m'
+DIM='\033[2m'
+RESET='\033[0m'
+
+test_rewrite() {
+  local description="$1"
+  local input_cmd="$2"
+  local expected_cmd="$3"  # empty string = expect no rewrite
+  TOTAL=$((TOTAL + 1))
+
+  local input_json
+  input_json=$(jq -n --arg cmd "$input_cmd" '{"tool_name":"Bash","tool_input":{"command":$cmd}}')
+  local output
+  output=$(echo "$input_json" | bash "$HOOK" 2>/dev/null) || true
+
+  if [ -z "$expected_cmd" ]; then
+    # Expect no rewrite (hook exits 0 with no output)
+    if [ -z "$output" ]; then
+      printf "  ${GREEN}PASS${RESET} %s ${DIM}→ (no rewrite)${RESET}\n" "$description"
+      PASS=$((PASS + 1))
+    else
+      local actual
+      actual=$(echo "$output" | jq -r '.hookSpecificOutput.updatedInput.command // empty')
+      printf "  ${RED}FAIL${RESET} %s\n" "$description"
+      printf "       expected: (no rewrite)\n"
+      printf "       actual:   %s\n" "$actual"
+      FAIL=$((FAIL + 1))
+    fi
+  else
+    local actual
+    actual=$(echo "$output" | jq -r '.hookSpecificOutput.updatedInput.command // empty' 2>/dev/null)
+    if [ "$actual" = "$expected_cmd" ]; then
+      printf "  ${GREEN}PASS${RESET} %s ${DIM}→ %s${RESET}\n" "$description" "$actual"
+      PASS=$((PASS + 1))
+    else
+      printf "  ${RED}FAIL${RESET} %s\n" "$description"
+      printf "       expected: %s\n" "$expected_cmd"
+      printf "       actual:   %s\n" "$actual"
+      FAIL=$((FAIL + 1))
+    fi
+  fi
+}
+
+echo "============================================"
+echo "  RTK Rewrite Hook Test Suite"
+echo "============================================"
+echo ""
+
+# ---- SECTION 1: Existing patterns (regression tests) ----
+echo "--- Existing patterns (regression) ---"
+test_rewrite "git status" \
+  "git status" \
+  "rtk git status"
+
+test_rewrite "git log --oneline -10" \
+  "git log --oneline -10" \
+  "rtk git log --oneline -10"
+
+test_rewrite "git diff HEAD" \
+  "git diff HEAD" \
+  "rtk git diff HEAD"
+
+test_rewrite "git show abc123" \
+  "git show abc123" \
+  "rtk git show abc123"
+
+test_rewrite "git add ." \
+  "git add ." \
+  "rtk git add ."
+
+test_rewrite "gh pr list" \
+  "gh pr list" \
+  "rtk gh pr list"
+
+test_rewrite "npx playwright test" \
+  "npx playwright test" \
+  "rtk playwright test"
+
+test_rewrite "ls -la" \
+  "ls -la" \
+  "rtk ls -la"
+
+test_rewrite "curl -s https://example.com" \
+  "curl -s https://example.com" \
+  "rtk curl -s https://example.com"
+
+test_rewrite "cat package.json" \
+  "cat package.json" \
+  "rtk read package.json"
+
+test_rewrite "grep -rn pattern src/" \
+  "grep -rn pattern src/" \
+  "rtk grep -rn pattern src/"
+
+test_rewrite "rg pattern src/" \
+  "rg pattern src/" \
+  "rtk grep pattern src/"
+
+test_rewrite "cargo test" \
+  "cargo test" \
+  "rtk cargo test"
+
+test_rewrite "npx prisma migrate" \
+  "npx prisma migrate" \
+  "rtk prisma migrate"
+
+test_rewrite "rtk git status" \
+  "rtk git status" \
+  "rtk git status"
+
+echo ""
+
+# ---- SECTION 2: Env var prefix handling (THE BIG FIX) ----
+echo "--- Env var prefix handling (new) ---"
+test_rewrite "env + playwright" \
+  "TEST_SESSION_ID=2 npx playwright test --config=foo" \
+  "TEST_SESSION_ID=2 rtk playwright test --config=foo"
+
+test_rewrite "env + git status" \
+  "GIT_PAGER=cat git status" \
+  "GIT_PAGER=cat rtk git status"
+
+test_rewrite "env + git log" \
+  "GIT_PAGER=cat git log --oneline -10" \
+  "GIT_PAGER=cat rtk git log --oneline -10"
+
+test_rewrite "multi env + vitest" \
+  "NODE_ENV=test CI=1 npx vitest" \
+  "NODE_ENV=test CI=1 rtk vitest"
+
+test_rewrite "env + ls" \
+  "LANG=C ls -la" \
+  "LANG=C rtk ls -la"
+
+test_rewrite "env + npm run" \
+  "NODE_ENV=test npm run test:e2e" \
+  "NODE_ENV=test rtk npm run test:e2e"
+
+test_rewrite "env + docker compose (unsupported subcommand, NOT rewritten)" \
+  "COMPOSE_PROJECT_NAME=test docker compose up -d" \
+  ""
+
+test_rewrite "env + docker compose logs (supported, rewritten)" \
+  "COMPOSE_PROJECT_NAME=test docker compose logs web" \
+  "COMPOSE_PROJECT_NAME=test rtk docker compose logs web"
+
+echo ""
+
+# ---- SECTION 3: New patterns ----
+echo "--- New patterns ---"
+test_rewrite "npm run test:e2e" \
+  "npm run test:e2e" \
+  "rtk npm run test:e2e"
+
+test_rewrite "npm run build" \
+  "npm run build" \
+  "rtk npm run build"
+
+test_rewrite "npm jest run" \
+  "npm jest run" \
+  "rtk jest"
+
+test_rewrite "docker compose up -d (NOT rewritten — unsupported by rtk)" \
+  "docker compose up -d" \
+  ""
+
+test_rewrite "docker compose logs postgrest" \
+  "docker compose logs postgrest" \
+  "rtk docker compose logs postgrest"
+
+test_rewrite "docker compose ps" \
+  "docker compose ps" \
+  "rtk docker compose ps"
+
+test_rewrite "docker compose build" \
+  "docker compose build" \
+  "rtk docker compose build"
+
+test_rewrite "docker compose down (NOT rewritten — unsupported by rtk)" \
+  "docker compose down" \
+  ""
+
+test_rewrite "docker compose -f file.yml up (NOT rewritten — flag before subcommand)" \
+  "docker compose -f docker-compose.preview.yml --project-name myapp up -d --build" \
+  ""
+
+test_rewrite "docker run --rm postgres" \
+  "docker run --rm postgres" \
+  "rtk docker run --rm postgres"
+
+test_rewrite "docker exec -it db psql" \
+  "docker exec -it db psql" \
+  "rtk docker exec -it db psql"
+
+test_rewrite "find . -name '*.ts'" \
+  "find . -name '*.ts'" \
+  "rtk find . -name '*.ts'"
+
+test_rewrite "tree src/" \
+  "tree src/" \
+  "rtk tree src/"
+
+test_rewrite "wget https://example.com/file" \
+  "wget https://example.com/file" \
+  "rtk wget https://example.com/file"
+
+test_rewrite "gh api repos/owner/repo" \
+  "gh api repos/owner/repo" \
+  "rtk gh api repos/owner/repo"
+
+test_rewrite "gh release list" \
+  "gh release list" \
+  "rtk gh release list"
+
+test_rewrite "kubectl describe pod foo" \
+  "kubectl describe pod foo" \
+  "rtk kubectl describe pod foo"
+
+test_rewrite "kubectl apply -f deploy.yaml" \
+  "kubectl apply -f deploy.yaml" \
+  "rtk kubectl apply -f deploy.yaml"
+
+echo ""
+
+# ---- SECTION 3b: RTK_DISABLED and redirect fixes (#345, #346) ----
+echo "--- RTK_DISABLED (#345) ---"
+test_rewrite "RTK_DISABLED=1 git status (no rewrite)" \
+  "RTK_DISABLED=1 git status" \
+  ""
+
+test_rewrite "RTK_DISABLED=1 cargo test (no rewrite)" \
+  "RTK_DISABLED=1 cargo test" \
+  ""
+
+test_rewrite "FOO=1 RTK_DISABLED=1 git status (no rewrite)" \
+  "FOO=1 RTK_DISABLED=1 git status" \
+  ""
+
+echo ""
+echo "--- Redirect operators (#346) ---"
+test_rewrite "cargo test 2>&1 | head" \
+  "cargo test 2>&1 | head" \
+  "rtk cargo test 2>&1 | head"
+
+test_rewrite "cargo test 2>&1" \
+  "cargo test 2>&1" \
+  "rtk cargo test 2>&1"
+
+test_rewrite "cargo test &>/dev/null" \
+  "cargo test &>/dev/null" \
+  "rtk cargo test &>/dev/null"
+
+# Note: the bash hook rewrites only the first command segment (sed-based);
+# full compound rewriting (both sides of &) is handled by `rtk rewrite` (Rust).
+# The critical behavior tested here: `&` after `cargo test` is NOT mistaken for
+# a redirect — the hook still rewrites cargo test, no crash.
+test_rewrite "cargo test & git status (bash hook rewrites first segment only)" \
+  "cargo test & git status" \
+  "rtk cargo test & git status"
+
+echo ""
+
+# ---- SECTION 4: Vitest edge case (fixed double "run" bug) ----
+echo "--- Vitest run dedup ---"
+test_rewrite "vitest (no args)" \
+  "vitest" \
+  "rtk vitest"
+
+test_rewrite "vitest run (no run)" \
+  "vitest run" \
+  "rtk vitest"
+
+test_rewrite "vitest --reporter" \
+  "vitest --reporter=verbose" \
+  "rtk vitest --reporter=verbose"
+
+test_rewrite "npx vitest" \
+  "npx vitest" \
+  "rtk vitest"
+
+test_rewrite "pnpm vitest --coverage" \
+  "pnpm vitest --coverage" \
+  "rtk vitest --coverage"
+
+echo ""
+
+# ---- SECTION 5: Should NOT rewrite ----
+echo "--- Should NOT rewrite ---"
+test_rewrite "heredoc" \
+  "cat <<'EOF'
+hello
+EOF" \
+  ""
+
+test_rewrite "echo (no pattern)" \
+  "echo hello world" \
+  ""
+
+test_rewrite "cd (no pattern)" \
+  "cd /tmp" \
+  ""
+
+test_rewrite "mkdir (no pattern)" \
+  "mkdir -p foo/bar" \
+  ""
+
+test_rewrite "python3 (no pattern)" \
+  "python3 script.py" \
+  ""
+
+test_rewrite "node (no pattern)" \
+  "node -e 'console.log(1)'" \
+  ""
+
+echo ""
+
+# ---- SECTION 6: Audit logging ----
+echo "--- Audit logging (RTK_HOOK_AUDIT=1) ---"
+
+AUDIT_TMPDIR=$(mktemp -d)
+trap "rm -rf $AUDIT_TMPDIR" EXIT
+
+test_audit_log() {
+  local description="$1"
+  local input_cmd="$2"
+  local expected_action="$3"
+  TOTAL=$((TOTAL + 1))
+
+  # Clean log
+  rm -f "$AUDIT_TMPDIR/hook-audit.log"
+
+  local input_json
+  input_json=$(jq -n --arg cmd "$input_cmd" '{"tool_name":"Bash","tool_input":{"command":$cmd}}')
+  echo "$input_json" | RTK_HOOK_AUDIT=1 RTK_AUDIT_DIR="$AUDIT_TMPDIR" bash "$HOOK" 2>/dev/null || true
+
+  if [ ! -f "$AUDIT_TMPDIR/hook-audit.log" ]; then
+    printf "  ${RED}FAIL${RESET} %s (no log file created)\n" "$description"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  local log_line
+  log_line=$(head -1 "$AUDIT_TMPDIR/hook-audit.log")
+  local actual_action
+  actual_action=$(echo "$log_line" | cut -d'|' -f2 | tr -d ' ')
+
+  if [ "$actual_action" = "$expected_action" ]; then
+    printf "  ${GREEN}PASS${RESET} %s ${DIM}→ %s${RESET}\n" "$description" "$actual_action"
+    PASS=$((PASS + 1))
+  else
+    printf "  ${RED}FAIL${RESET} %s\n" "$description"
+    printf "       expected action: %s\n" "$expected_action"
+    printf "       actual action:   %s\n" "$actual_action"
+    printf "       log line:        %s\n" "$log_line"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+test_audit_log "audit: rewrite git status" \
+  "git status" \
+  "rewrite"
+
+test_audit_log "audit: skip already_rtk" \
+  "rtk git status" \
+  "skip:already_rtk"
+
+test_audit_log "audit: skip heredoc" \
+  "cat <<'EOF'
+hello
+EOF" \
+  "skip:heredoc"
+
+test_audit_log "audit: skip no_match" \
+  "echo hello world" \
+  "skip:no_match"
+
+test_audit_log "audit: rewrite cargo test" \
+  "cargo test" \
+  "rewrite"
+
+# Test log format (4 pipe-separated fields)
+rm -f "$AUDIT_TMPDIR/hook-audit.log"
+input_json=$(jq -n --arg cmd "git status" '{"tool_name":"Bash","tool_input":{"command":$cmd}}')
+echo "$input_json" | RTK_HOOK_AUDIT=1 RTK_AUDIT_DIR="$AUDIT_TMPDIR" bash "$HOOK" 2>/dev/null || true
+TOTAL=$((TOTAL + 1))
+log_line=$(cat "$AUDIT_TMPDIR/hook-audit.log" 2>/dev/null || echo "")
+field_count=$(echo "$log_line" | awk -F' \\| ' '{print NF}')
+if [ "$field_count" = "4" ]; then
+  printf "  ${GREEN}PASS${RESET} audit: log format has 4 fields ${DIM}→ %s${RESET}\n" "$log_line"
+  PASS=$((PASS + 1))
+else
+  printf "  ${RED}FAIL${RESET} audit: log format (expected 4 fields, got %s)\n" "$field_count"
+  printf "       log line: %s\n" "$log_line"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test no log when RTK_HOOK_AUDIT is unset
+rm -f "$AUDIT_TMPDIR/hook-audit.log"
+input_json=$(jq -n --arg cmd "git status" '{"tool_name":"Bash","tool_input":{"command":$cmd}}')
+echo "$input_json" | RTK_AUDIT_DIR="$AUDIT_TMPDIR" bash "$HOOK" 2>/dev/null || true
+TOTAL=$((TOTAL + 1))
+if [ ! -f "$AUDIT_TMPDIR/hook-audit.log" ]; then
+  printf "  ${GREEN}PASS${RESET} audit: no log when RTK_HOOK_AUDIT unset\n"
+  PASS=$((PASS + 1))
+else
+  printf "  ${RED}FAIL${RESET} audit: log created when RTK_HOOK_AUDIT unset\n"
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+
+# ---- SUMMARY ----
+echo "============================================"
+if [ $FAIL -eq 0 ]; then
+  printf "  ${GREEN}ALL $TOTAL TESTS PASSED${RESET}\n"
+else
+  printf "  ${RED}$FAIL FAILED${RESET} / $TOTAL total ($PASS passed)\n"
+fi
+echo "============================================"
+
+exit $FAIL

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -31,6 +31,7 @@ LLM agent integration layer that installs, validates, and executes command-rewri
 | Codex | `rtk init --codex` | RTK.md in `$CODEX_HOME` or `~/.codex` | AGENTS.md |
 | Cursor | `rtk init -g --agent cursor` | Cursor hook | hooks.json |
 | Hermes | `rtk init --agent hermes` | Python plugin in `~/.hermes/plugins/rtk-rewrite/` | `config.yaml` `plugins.enabled` |
+| Devin | `rtk init --agent devin` | Hook in `~/.config/devin/config.json` | `config.json` (uses Claude-compatible format) |
 
 
 ## Integrity Verification

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -1,6 +1,7 @@
 pub const REWRITE_HOOK_FILE: &str = "rtk-rewrite.sh";
 pub const GEMINI_HOOK_FILE: &str = "rtk-hook-gemini.sh";
 pub const CLAUDE_DIR: &str = ".claude";
+pub const DEVIN_DIR: &str = ".config/devin";
 pub const HOOKS_SUBDIR: &str = "hooks";
 pub const SETTINGS_JSON: &str = "settings.json";
 pub const SETTINGS_LOCAL_JSON: &str = "settings.local.json";

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -12,7 +12,7 @@ use crate::hooks::constants::{
 };
 
 use super::constants::{
-    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND,
+    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND, DEVIN_DIR,
     GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_INIT_FILE,
     HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON, HOOKS_SUBDIR, PRE_TOOL_USE_KEY,
     REWRITE_HOOK_FILE, SETTINGS_JSON,
@@ -2773,6 +2773,228 @@ fn remove_opencode_plugin(ctx: InitContext) -> Result<Vec<PathBuf>> {
     }
 
     Ok(removed)
+}
+
+// ─── Devin for Terminal support ───────────────────────────────────────
+
+pub fn run_devin_mode(ctx: InitContext) -> Result<()> {
+    run_devin_mode_at(ctx)
+}
+
+fn resolve_devin_dir() -> Result<PathBuf> {
+    resolve_home_subdir(DEVIN_DIR)
+}
+
+fn run_devin_mode_at(ctx: InitContext) -> Result<()> {
+    let InitContext { dry_run, .. } = ctx;
+    let devin_dir = resolve_devin_dir()?;
+
+    // Create .devin directory if it doesn't exist
+    if !dry_run {
+        fs::create_dir_all(&devin_dir).with_context(|| {
+            format!("Failed to create Devin directory: {}", devin_dir.display())
+        })?;
+    }
+
+    // Patch config.json with hook (Devin uses same format as Claude Code)
+    let patch_result = patch_devin_config(CLAUDE_HOOK_COMMAND, PatchMode::Auto, ctx)?;
+
+    if dry_run {
+        print_dry_run_footer();
+    } else {
+        println!("\nRTK configured for Devin for Terminal.\n");
+        match patch_result {
+            PatchResult::Patched => {
+                println!("  config.json: hook registered");
+            }
+            PatchResult::AlreadyPresent => {
+                println!("  config.json: hook already present");
+            }
+            PatchResult::Declined | PatchResult::Skipped => {
+                println!("  config.json: manual configuration required");
+            }
+            PatchResult::WouldPatch => {}
+        }
+        println!("\n  Restart Devin. Test with: git status\n");
+    }
+
+    Ok(())
+}
+
+pub fn uninstall_devin(ctx: InitContext) -> Result<()> {
+    let InitContext { dry_run, .. } = ctx;
+    let devin_dir = resolve_devin_dir()?;
+    let removed = uninstall_devin_at(&devin_dir, ctx)?;
+
+    if removed.is_empty() {
+        println!("RTK Devin support was not installed (nothing to remove)");
+    } else {
+        let header = if dry_run {
+            "[dry-run] would uninstall RTK for Devin:"
+        } else {
+            "RTK uninstalled for Devin:"
+        };
+        println!("{}", header);
+        for item in removed {
+            println!("  - {}", item);
+        }
+    }
+
+    if dry_run {
+        print_dry_run_footer();
+    }
+
+    Ok(())
+}
+
+fn uninstall_devin_at(devin_dir: &Path, ctx: InitContext) -> Result<Vec<String>> {
+    let InitContext { dry_run, .. } = ctx;
+    let mut removed = Vec::new();
+
+    let config_path = devin_dir.join("config.json");
+    if config_path.exists() {
+        let unpatched = unpatch_devin_config(&config_path, ctx)?;
+        if unpatched {
+            removed.push("config.json: removed RTK hook".to_string());
+        }
+    }
+
+    if dry_run {
+        print_dry_run_footer();
+    }
+
+    Ok(removed)
+}
+
+fn patch_devin_config(
+    hook_command: &str,
+    _mode: PatchMode,
+    ctx: InitContext,
+) -> Result<PatchResult> {
+    let InitContext { verbose, dry_run } = ctx;
+    let devin_dir = resolve_devin_dir()?;
+    let config_path = devin_dir.join("config.json");
+
+    // Read or create config.json
+    let mut root = if config_path.exists() {
+        let content = fs::read_to_string(&config_path)
+            .with_context(|| format!("Failed to read {}", config_path.display()))?;
+
+        if content.trim().is_empty() {
+            serde_json::json!({})
+        } else {
+            serde_json::from_str(&content)
+                .with_context(|| format!("Failed to parse {} as JSON", config_path.display()))?
+        }
+    } else {
+        serde_json::json!({})
+    };
+
+    // Check if hook is already present
+    if devin_hook_already_present(&root, hook_command) {
+        if verbose > 0 {
+            eprintln!("  Devin hook already present in config.json");
+        }
+        return Ok(PatchResult::AlreadyPresent);
+    }
+
+    // Add the hook using the standard insert_hook_entry function for correct structure
+    insert_hook_entry(&mut root, hook_command)?;
+
+    // Write the updated config
+    if dry_run {
+        println!(
+            "[dry-run] would update Devin config: {}",
+            config_path.display()
+        );
+        return Ok(PatchResult::WouldPatch);
+    }
+
+    let content =
+        serde_json::to_string_pretty(&root).with_context(|| "Failed to serialize config.json")?;
+
+    atomic_write(&config_path, &content)
+        .with_context(|| format!("Failed to write {}", config_path.display()))?;
+
+    if verbose > 0 {
+        eprintln!("  Updated Devin config: {}", config_path.display());
+    }
+
+    Ok(PatchResult::Patched)
+}
+
+fn devin_hook_already_present(root: &serde_json::Value, hook_command: &str) -> bool {
+    let pre_tool_use_array = match root
+        .get("hooks")
+        .and_then(|h| h.get(PRE_TOOL_USE_KEY))
+        .and_then(|p| p.as_array())
+    {
+        Some(arr) => arr,
+        None => return false,
+    };
+
+    pre_tool_use_array
+        .iter()
+        .filter_map(|entry| entry.get("hooks")?.as_array())
+        .flatten()
+        .filter_map(|hook| hook.get("command")?.as_str())
+        .any(|cmd| cmd == hook_command || cmd.contains(REWRITE_HOOK_FILE))
+}
+
+fn unpatch_devin_config(config_path: &Path, ctx: InitContext) -> Result<bool> {
+    let InitContext { verbose, dry_run } = ctx;
+
+    let content = fs::read_to_string(config_path)
+        .with_context(|| format!("Failed to read {}", config_path.display()))?;
+
+    let mut root: serde_json::Value = serde_json::from_str(&content)
+        .with_context(|| format!("Failed to parse {} as JSON", config_path.display()))?;
+
+    let pre_tool_use = match root
+        .get_mut("hooks")
+        .and_then(|h| h.get_mut(PRE_TOOL_USE_KEY))
+        .and_then(|p| p.as_array_mut())
+    {
+        Some(arr) => arr,
+        None => return Ok(false),
+    };
+
+    let original_len = pre_tool_use.len();
+    pre_tool_use.retain(|entry| {
+        // Check the nested hooks array for RTK commands
+        if let Some(hooks_array) = entry.get("hooks").and_then(|h| h.as_array()) {
+            !hooks_array.iter().any(|hook| {
+                let cmd = hook.get("command").and_then(|c| c.as_str()).unwrap_or("");
+                cmd.contains("rtk") || cmd.contains(REWRITE_HOOK_FILE)
+            })
+        } else {
+            true
+        }
+    });
+
+    if pre_tool_use.len() == original_len {
+        return Ok(false);
+    }
+
+    if dry_run {
+        println!(
+            "[dry-run] would update Devin config: {}",
+            config_path.display()
+        );
+        return Ok(true);
+    }
+
+    let content =
+        serde_json::to_string_pretty(&root).with_context(|| "Failed to serialize config.json")?;
+
+    atomic_write(config_path, &content)
+        .with_context(|| format!("Failed to write {}", config_path.display()))?;
+
+    if verbose > 0 {
+        eprintln!("  Updated Devin config: {}", config_path.display());
+    }
+
+    Ok(true)
 }
 
 // ─── Cursor Agent support ─────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,8 @@ pub enum AgentTarget {
     Antigravity,
     /// Hermes CLI
     Hermes,
+    /// Devin for Terminal
+    Devin,
 }
 
 #[derive(Parser)]
@@ -1365,6 +1367,8 @@ where
 {
     if agent == Some(AgentTarget::Hermes) {
         uninstall_hermes(ctx)
+    } else if agent == Some(AgentTarget::Devin) {
+        hooks::init::uninstall_devin(ctx)
     } else {
         let cursor = agent == Some(AgentTarget::Cursor);
         uninstall_standard(global, gemini, codex, cursor, ctx)
@@ -1833,6 +1837,8 @@ fn run_cli() -> Result<i32> {
                 hooks::init::run_antigravity_mode(ctx)?;
             } else if agent == Some(AgentTarget::Hermes) {
                 hooks::init::run_hermes_mode(ctx)?;
+            } else if agent == Some(AgentTarget::Devin) {
+                hooks::init::run_devin_mode(ctx)?;
             } else {
                 let install_opencode = opencode;
                 let install_claude = !opencode;


### PR DESCRIPTION
Devin for Terminal uses Claude-compatible hook format, so this integration reuses the existing Claude Code hook command and JSON protocol. Installation patches ~/.devin/config.json with the RTK hook entry, enabling automatic command rewriting for Devin users without workflow changes.

## Summary
- Added Devin to `AgentTarget` enum in main.rs
- Created `hooks/devin/` directory with hook script (rtk-rewrite.sh) and tests
- Added `run_devin_mode()` and `uninstall_devin()` functions in src/hooks/init.rs
- Added `DEVIN_DIR` constant to src/hooks/constants.rs
- Updated hooks/README.md and src/hooks/README.md to document Devin support
- Installation creates ~/.devin/config.json with RTK hook entry using Claude-compatible format

## Test plan
- [X] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [X] Manual testing: `rtk init --agent devin` - verified config.json created with correct hook entry
- [X] Manual testing: `rtk init --agent devin --uninstall` - verified hook removal
- [X] Manual testing: Verified ~/.devin/config.json structure matches expected JSON format
