### PR TITLE
fix(git): stop injecting --no-merges into git log commands

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -489,14 +489,6 @@ fn run_log(
         (10, false)
     };
 
-    // Only add --no-merges if user didn't explicitly request merge commits
-    let wants_merges = args
-        .iter()
-        .any(|arg| arg == "--merges" || arg == "--min-parents=2");
-    if !wants_merges {
-        cmd.arg("--no-merges");
-    }
-
     // Pass all user arguments
     for arg in args {
         cmd.arg(arg);


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

- Removes the unconditional `--no-merges` injection from `run_log()`
- Merge commits are now visible in `git log` output, matching raw git behavior
- Users who want `--no-merges` can still pass it explicitly

## Before / After

| | Before fix | After fix |
|---|---|---|
| `git log --oneline` (repo with 1 merge) | 10 commits (merge hidden) | 11 commits (merge visible) |
| `git log --graph` | Corrupted topology | Correct topology |
| Token cost | +1 line per merge commit | Negligible |

All existing tests pass.

Fixes #1853