### PR TITLE
fix(docker): forward --tail flag in compose logs

### DIFF
--- a/src/cmds/cloud/container.rs
+++ b/src/cmds/cloud/container.rs
@@ -561,9 +561,10 @@ pub fn run_compose_ps(verbose: u8) -> Result<i32> {
     Ok(0)
 }
 
-pub fn run_compose_logs(service: Option<&str>, verbose: u8) -> Result<i32> {
+pub fn run_compose_logs(service: Option<&str>, tail: u32, verbose: u8) -> Result<i32> {
     let mut cmd = resolved_command("docker");
-    cmd.args(["compose", "logs", "--tail", "100"]);
+    let tail_str = tail.to_string();
+    cmd.args(["compose", "logs", "--tail", &tail_str]);
     if let Some(svc) = service {
         cmd.arg(svc);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -926,6 +926,9 @@ enum ComposeCommands {
     Logs {
         /// Optional service name
         service: Option<String>,
+        /// Number of log lines to fetch
+        #[arg(long, default_value_t = 100)]
+        tail: u32,
     },
     /// Build compose services (summary)
     Build {
@@ -1707,8 +1710,8 @@ fn run_cli() -> Result<i32> {
             }
             DockerCommands::Compose { command: compose } => match compose {
                 ComposeCommands::Ps => container::run_compose_ps(cli.verbose)?,
-                ComposeCommands::Logs { service } => {
-                    container::run_compose_logs(service.as_deref(), cli.verbose)?
+                ComposeCommands::Logs { service, tail } => {
+                    container::run_compose_logs(service.as_deref(), tail, cli.verbose)?
                 }
                 ComposeCommands::Build { service } => {
                     container::run_compose_build(service.as_deref(), cli.verbose)?


### PR DESCRIPTION
## Problem

`rtk docker compose logs --tail=20 web` falls through to the passthrough handler because clap had no `--tail` field on the `Logs` subcommand → 0% token savings. Additionally, `run_compose_logs` always fetched 100 lines regardless of user input.

## Solution

- Add `#[arg(long, default_value_t = 100)] tail: u32` to `ComposeCommands::Logs`
- Thread the value through to the docker invocation
- Default unchanged (100 lines), so bare `rtk docker compose logs` behaves as before

## Origin

Ports the core fix from #580 (by @slice-mihird), retargeted onto current `develop` layout (`src/cmds/cloud/container.rs`). The original PR bundled several unrelated changes and was based on pre-#826 src/ layout, making rebase non-trivial — this PR carries only the `--tail` fix.

Credit preserved via `Co-authored-by`.

Relates to #578. Will close #580 once merged.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo test --all` (1870 passed)
- [ ] Manual: `rtk docker compose logs --tail=20 <svc>` shows filtered output for 20 lines