### PR TITLE
feat: add support for rovodev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "rtk"
-version = "0.36.0"
+version = "0.34.3"
 dependencies = [
  "anyhow",
  "automod",

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ rtk git status
 
 ## Supported AI Tools
 
-RTK supports 13 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents for 60-90% token savings where the agent supports command interception.
+RTK supports 14 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents for 60-90% token savings where the agent supports command interception.
 
 | Tool | Install | Method |
 |------|---------|--------|
@@ -361,6 +361,7 @@ RTK supports 13 AI coding tools. Each integration rewrites shell commands to `rt
 | **Cursor** | `rtk init -g --agent cursor` | preToolUse hook (hooks.json) |
 | **Gemini CLI** | `rtk init -g --gemini` | BeforeTool hook |
 | **Codex** | `rtk init -g --codex` | AGENTS.md + RTK.md instructions |
+| **Rovo Dev** | `rtk init --agent rovodev` | AGENTS.md memory file (inlined) |
 | **Windsurf** | `rtk init --agent windsurf` | .windsurfrules (project-scoped) |
 | **Cline / Roo Code** | `rtk init --agent cline` | .clinerules (project-scoped) |
 | **OpenCode** | `rtk init -g --opencode` | Plugin TS (tool.execute.before) |

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -54,6 +54,7 @@ Each agent subdirectory has its own README with hook-specific details:
 | Cline / Roo Code | Custom instructions (rules file) | Prompt-level guidance | N/A |
 | Windsurf | Custom instructions (rules file) | Prompt-level guidance | N/A |
 | Codex CLI | AGENTS.md / instructions | Prompt-level guidance | N/A |
+| Rovo Dev | AGENTS.md / memory file | Prompt-level guidance | N/A |
 | OpenCode | TypeScript plugin (`tool.execute.before`) | In-place mutation | Yes |
 | Hermes | Python plugin (`pre_tool_call`) | In-place mutation | Yes |
 
@@ -157,6 +158,33 @@ if (rewritten && rewritten !== command) {
   (args as Record<string, unknown>).command = rewritten
 }
 ```
+
+### Rovo Dev (AGENTS.md Memory File)
+
+Rovo Dev reads `AGENTS.md` at session start (project scope) and
+`~/.rovodev/AGENTS.md` (user/global scope). RTK inlines its instructions
+directly into `AGENTS.md` between `<!-- rtk-instructions -->` markers
+(Rovo Dev does not auto-expand `@file` references inside memory files).
+The block is idempotent — re-running `rtk init` updates it in place.
+
+**Install (project scope)**:
+```bash
+rtk init --agent rovodev
+```
+
+**Install (global scope — applies to all `acli rovodev` sessions)**:
+```bash
+rtk init -g --agent rovodev
+```
+
+**Uninstall**:
+```bash
+rtk init --agent rovodev --uninstall      # local
+rtk init -g --agent rovodev --uninstall   # global
+```
+
+No programmatic hook is used; prompt-level guidance is the most reliable
+and transparent integration available with Rovo Dev today.
 
 ### Hermes (Python Plugin)
 

--- a/hooks/rovodev/README.md
+++ b/hooks/rovodev/README.md
@@ -1,0 +1,43 @@
+# Rovo Dev Hooks
+
+> Part of [`hooks/`](../README.md) — see also [`src/hooks/`](../../src/hooks/README.md) for installation code
+
+## Specifics
+
+- Prompt-level guidance via memory file (`AGENTS.md`) -- Rovo Dev natively
+  reads `AGENTS.md` for project memory and `~/.rovodev/AGENTS.md` for
+  user-global memory.
+- `rtk-awareness.md` is **inlined** into `AGENTS.md` between
+  `<!-- rtk-instructions -->` markers (Rovo Dev does not auto-expand `@file`
+  references inside memory files, so the content must be embedded directly).
+- Project-scope install (default): writes the RTK block into `./AGENTS.md`.
+- Global install (`-g`): writes the RTK block into `~/.rovodev/AGENTS.md`
+  so RTK awareness applies to every `acli rovodev` session for the user.
+- Installed by `rtk init --agent rovodev` (project) or
+  `rtk init -g --agent rovodev` (global).
+- The block is idempotent — re-running `rtk init --agent rovodev` updates
+  the block in place if the awareness content has changed.
+
+## Why a memory file (and not a programmatic hook)?
+
+Rovo Dev does support event hooks (configured via the `/hooks` slash
+command), but its native `PreToolUse`-equivalent does not yet expose
+`updatedInput` for shell commands the way Claude Code does. The most
+reliable, transparent integration today is therefore prompt-level guidance
+via `AGENTS.md`, which Rovo Dev always loads at session start.
+
+## Testing
+
+```bash
+# Project-scope
+rtk init --agent rovodev
+grep rtk-instructions AGENTS.md
+
+# Global-scope
+rtk init -g --agent rovodev
+grep rtk-instructions ~/.rovodev/AGENTS.md
+
+# Uninstall (removes only the RTK block; preserves any other content)
+rtk init --agent rovodev --uninstall      # local
+rtk init -g --agent rovodev --uninstall   # global
+```

--- a/hooks/rovodev/rtk-awareness.md
+++ b/hooks/rovodev/rtk-awareness.md
@@ -1,0 +1,36 @@
+<!-- rtk-instructions -->
+## RTK — Token-Optimized Shell Commands
+
+Always prefix shell commands with `rtk` to reduce token consumption (60-90% savings on common dev operations).
+
+```bash
+rtk git status        # rtk git log -10        rtk git diff
+rtk cargo test        # rtk cargo build        rtk cargo clippy
+rtk npm run build     # rtk pnpm install       rtk pytest -q
+rtk grep "pat" src/   # rtk ls src/            rtk find . -name "*.rs"
+rtk docker ps         # rtk kubectl get pods   rtk gh pr list
+```
+
+Even in command chains, prefix every command:
+
+```bash
+rtk git add . && rtk git commit -m "msg" && rtk git push
+```
+
+### Meta commands
+
+```bash
+rtk gain              # Token savings dashboard
+rtk gain --history    # Per-command savings history
+rtk proxy <cmd>       # Run raw command without filtering (debug)
+```
+
+### Verify install
+
+```bash
+rtk --version         # Should print: rtk X.Y.Z
+rtk gain              # Should show dashboard (not "command not found")
+```
+
+> If `rtk gain` fails, you may have `reachingforthejack/rtk` (Rust Type Kit) installed instead. Reinstall from `rtk-ai/rtk`.
+<!-- /rtk-instructions -->

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -26,3 +26,5 @@ pub const HERMES_PLUGINS_SUBDIR: &str = "plugins";
 pub const HERMES_PLUGIN_NAME: &str = "rtk-rewrite";
 pub const HERMES_PLUGIN_INIT_FILE: &str = "__init__.py";
 pub const HERMES_PLUGIN_MANIFEST_FILE: &str = "plugin.yaml";
+
+pub const ROVODEV_DIR: &str = ".rovodev";

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -15,7 +15,7 @@ use super::constants::{
     BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND,
     GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_INIT_FILE,
     HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON, HOOKS_SUBDIR, PRE_TOOL_USE_KEY,
-    REWRITE_HOOK_FILE, SETTINGS_JSON,
+    REWRITE_HOOK_FILE, ROVODEV_DIR, SETTINGS_JSON,
 };
 use super::integrity;
 
@@ -25,6 +25,7 @@ const OPENCODE_PLUGIN: &str = include_str!("../../hooks/opencode/rtk.ts");
 // Embedded slim RTK awareness instructions
 const RTK_SLIM: &str = include_str!("../../hooks/claude/rtk-awareness.md");
 const RTK_SLIM_CODEX: &str = include_str!("../../hooks/codex/rtk-awareness.md");
+const RTK_SLIM_ROVODEV: &str = include_str!("../../hooks/rovodev/rtk-awareness.md");
 
 /// Template written by `rtk init` when no filters.toml exists yet.
 const FILTERS_TEMPLATE: &str = r#"# Project-local RTK filters — commit this file with your repo.
@@ -2284,6 +2285,140 @@ fn normalized_yaml_scalar(value: &str) -> Option<String> {
     (!trimmed.is_empty()).then(|| trimmed.to_string())
 }
 
+// ─── Rovo Dev support ─────────────────────────────────────────
+
+pub fn run_rovodev_mode(global: bool, ctx: InitContext) -> Result<()> {
+    let agents_md_path = if global {
+        resolve_rovodev_dir()?.join(AGENTS_MD)
+    } else {
+        PathBuf::from(AGENTS_MD)
+    };
+
+    run_rovodev_mode_with_paths(agents_md_path, global, ctx)
+}
+
+fn run_rovodev_mode_with_paths(
+    agents_md_path: PathBuf,
+    global: bool,
+    ctx: InitContext,
+) -> Result<()> {
+    let InitContext { verbose, dry_run } = ctx;
+    if global && !dry_run {
+        if let Some(parent) = agents_md_path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "Failed to create Rovo Dev config directory: {}",
+                    parent.display()
+                )
+            })?;
+        }
+    }
+
+    // Rovo Dev does not auto-expand @file references inside AGENTS.md, so we
+    // inline the RTK awareness directly between markers (the same approach
+    // used by the legacy --claude-md mode and Kilo Code / Antigravity rules).
+    let existing = if agents_md_path.exists() {
+        fs::read_to_string(&agents_md_path)
+            .with_context(|| format!("Failed to read AGENTS.md: {}", agents_md_path.display()))?
+    } else {
+        String::new()
+    };
+
+    let (new_content, action) = upsert_rtk_block(&existing, RTK_SLIM_ROVODEV);
+    let action_str = match action {
+        RtkBlockUpsert::Added => "added",
+        RtkBlockUpsert::Updated => "updated",
+        RtkBlockUpsert::Unchanged => "already up to date",
+        RtkBlockUpsert::Malformed => {
+            anyhow::bail!(
+                "AGENTS.md at {} contains an unterminated RTK block (opening marker without closing). \
+                Please fix manually before re-running.",
+                agents_md_path.display()
+            );
+        }
+    };
+
+    if action != RtkBlockUpsert::Unchanged {
+        if dry_run {
+            println!(
+                "[dry-run] would {} RTK block in {}",
+                action_str,
+                agents_md_path.display()
+            );
+            if verbose > 0 {
+                println!("[dry-run] content:\n{}", new_content);
+            }
+        } else {
+            atomic_write(&agents_md_path, &new_content).with_context(|| {
+                format!("Failed to write AGENTS.md: {}", agents_md_path.display())
+            })?;
+        }
+    }
+
+    if !dry_run {
+        println!("\nRTK configured for Rovo Dev.\n");
+        println!("  AGENTS.md: {} ({})", agents_md_path.display(), action_str);
+        if global {
+            println!("  Applies to all `acli rovodev` sessions for this user.");
+        } else {
+            println!("  Commit AGENTS.md to share RTK awareness with your team.");
+        }
+    }
+
+    Ok(())
+}
+
+pub fn uninstall_rovodev(global: bool, ctx: InitContext) -> Result<()> {
+    let InitContext { dry_run, .. } = ctx;
+    let agents_md_path = if global {
+        resolve_rovodev_dir()?.join(AGENTS_MD)
+    } else {
+        PathBuf::from(AGENTS_MD)
+    };
+    let mut removed = Vec::new();
+
+    if agents_md_path.exists() {
+        let content = fs::read_to_string(&agents_md_path)
+            .with_context(|| format!("Failed to read AGENTS.md: {}", agents_md_path.display()))?;
+
+        if content.contains(RTK_BLOCK_START) {
+            let (cleaned, did_remove) = remove_rtk_block(&content);
+            if did_remove {
+                if dry_run {
+                    println!(
+                        "[dry-run] would remove RTK block from {}",
+                        agents_md_path.display()
+                    );
+                } else {
+                    atomic_write(&agents_md_path, &cleaned).with_context(|| {
+                        format!("Failed to write AGENTS.md: {}", agents_md_path.display())
+                    })?;
+                }
+                removed.push(format!(
+                    "AGENTS.md: removed RTK block ({})",
+                    agents_md_path.display()
+                ));
+            }
+        }
+    }
+
+    if removed.is_empty() {
+        println!("RTK was not installed for Rovo Dev (nothing to remove)");
+    } else {
+        let header = if dry_run {
+            "[dry-run] would uninstall RTK for Rovo Dev:"
+        } else {
+            "RTK uninstalled for Rovo Dev:"
+        };
+        println!("{}", header);
+        for item in removed {
+            println!("  - {}", item);
+        }
+    }
+
+    Ok(())
+}
+
 fn run_codex_mode(global: bool, ctx: InitContext) -> Result<()> {
     let (agents_md_path, rtk_md_path) = if global {
         let codex_dir = resolve_codex_dir()?;
@@ -2699,6 +2834,13 @@ fn resolve_codex_dir_from(
 
 fn resolve_hermes_home() -> Result<PathBuf> {
     resolve_hermes_home_from_env(dirs::home_dir(), std::env::var_os("HERMES_HOME"))
+}
+
+fn resolve_rovodev_dir() -> Result<PathBuf> {
+    if let Ok(dir) = std::env::var("RTK_ROVODEV_DIR") {
+        return Ok(PathBuf::from(dir));
+    }
+    resolve_home_subdir(ROVODEV_DIR)
 }
 
 fn resolve_hermes_home_from_env(

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,8 @@ pub enum AgentTarget {
     Antigravity,
     /// Hermes CLI
     Hermes,
+    /// Rovo Dev
+    Rovodev,
 }
 
 #[derive(Parser)]
@@ -1353,21 +1355,25 @@ fn main() {
     std::process::exit(code);
 }
 
-fn uninstall_init_dispatch<UninstallHermes, UninstallStandard>(
+fn uninstall_init_dispatch<UninstallHermes, UninstallRovodev, UninstallStandard>(
     agent: Option<AgentTarget>,
     global: bool,
     gemini: bool,
     codex: bool,
     ctx: hooks::init::InitContext,
     uninstall_hermes: UninstallHermes,
+    uninstall_rovodev: UninstallRovodev,
     uninstall_standard: UninstallStandard,
 ) -> Result<()>
 where
     UninstallHermes: FnOnce(hooks::init::InitContext) -> Result<()>,
+    UninstallRovodev: FnOnce(bool, hooks::init::InitContext) -> Result<()>,
     UninstallStandard: FnOnce(bool, bool, bool, bool, hooks::init::InitContext) -> Result<()>,
 {
     if agent == Some(AgentTarget::Hermes) {
         uninstall_hermes(ctx)
+    } else if agent == Some(AgentTarget::Rovodev) {
+        uninstall_rovodev(global, ctx)
     } else {
         let cursor = agent == Some(AgentTarget::Cursor);
         uninstall_standard(global, gemini, codex, cursor, ctx)
@@ -1809,6 +1815,7 @@ fn run_cli() -> Result<i32> {
                     codex,
                     ctx,
                     hooks::init::uninstall_hermes,
+                    hooks::init::uninstall_rovodev,
                     hooks::init::uninstall,
                 )?;
             } else if gemini {
@@ -1836,6 +1843,8 @@ fn run_cli() -> Result<i32> {
                 hooks::init::run_antigravity_mode(ctx)?;
             } else if agent == Some(AgentTarget::Hermes) {
                 hooks::init::run_hermes_mode(ctx)?;
+            } else if agent == Some(AgentTarget::Rovodev) {
+                hooks::init::run_rovodev_mode(global, ctx)?;
             } else {
                 let install_opencode = opencode;
                 let install_claude = !opencode;
@@ -2675,6 +2684,9 @@ mod tests {
                 assert!(ctx.dry_run);
                 Ok(())
             },
+            |_, _| {
+                panic!("rovodev uninstall should not be called for Hermes");
+            },
             |_, _, _, _, _| {
                 standard_called.set(true);
                 Ok(())
@@ -2683,6 +2695,74 @@ mod tests {
 
         assert!(result.is_ok());
         assert!(hermes_called.get());
+        assert!(!standard_called.get());
+    }
+
+    #[test]
+    fn test_try_parse_init_agent_rovodev() {
+        let cli = Cli::try_parse_from(["rtk", "init", "--agent", "rovodev"]).unwrap();
+        match cli.command {
+            Commands::Init { agent, .. } => {
+                assert_eq!(agent, Some(AgentTarget::Rovodev));
+            }
+            _ => panic!("Expected Init command"),
+        }
+    }
+
+    #[test]
+    fn test_try_parse_init_agent_rovodev_global_uninstall() {
+        let cli = Cli::try_parse_from(["rtk", "init", "-g", "--agent", "rovodev", "--uninstall"])
+            .unwrap();
+        match cli.command {
+            Commands::Init {
+                agent,
+                uninstall,
+                global,
+                ..
+            } => {
+                assert_eq!(agent, Some(AgentTarget::Rovodev));
+                assert!(uninstall);
+                assert!(global);
+            }
+            _ => panic!("Expected Init command"),
+        }
+    }
+
+    #[test]
+    fn test_init_uninstall_dispatch_routes_rovodev_to_rovodev_cleanup() {
+        let rovodev_called = Cell::new(false);
+        let hermes_called = Cell::new(false);
+        let standard_called = Cell::new(false);
+        let ctx = hooks::init::InitContext {
+            verbose: 0,
+            dry_run: true,
+        };
+
+        let result = uninstall_init_dispatch(
+            Some(AgentTarget::Rovodev),
+            true,
+            false,
+            false,
+            ctx,
+            |_| {
+                hermes_called.set(true);
+                Ok(())
+            },
+            |global, ctx| {
+                rovodev_called.set(true);
+                assert!(global);
+                assert!(ctx.dry_run);
+                Ok(())
+            },
+            |_, _, _, _, _| {
+                standard_called.set(true);
+                Ok(())
+            },
+        );
+
+        assert!(result.is_ok());
+        assert!(rovodev_called.get());
+        assert!(!hermes_called.get());
         assert!(!standard_called.get());
     }
 


### PR DESCRIPTION
# Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

- Adds **Rovo Dev** as a first-class agent target, installable via `rtk init --agent rovodev` (project) or `rtk init -g --agent rovodev` (global).
- Inlines the RTK awareness content directly into `AGENTS.md` between `<!-- rtk-instructions -->` markers, using the existing `upsert_rtk_block` / `remove_rtk_block` helpers (Rovo Dev does not auto-expand `@file` references inside memory files, so the Codex-style `@RTK.md` indirection wouldn't work). Re-running `rtk init` is idempotent; uninstall removes only the RTK block and preserves any other user content.
- Bumps the supported-tools count from 13 → 14 in the README and adds a Rovo Dev section to `hooks/README.md` and `hooks/rovodev/README.md`.

# Test plan
<!-- How did you verify this works? -->

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`  
      (1873 tests pass, including 3 new tests: `test_try_parse_init_agent_rovodev`, `test_try_parse_init_agent_rovodev_global_uninstall`, `test_init_uninstall_dispatch_routes_rovodev_to_rovodev_cleanup` — the last asserts the `--global` flag is forwarded to `uninstall_rovodev`).
- [x] Manual testing:
  - `rtk init --agent rovodev` → writes `<!-- rtk-instructions -->` block into `./AGENTS.md`.
  - Re-running → reports `(already up to date)` (idempotent).
  - Adding user content (e.g. `# My Project ...`) below the block, then `rtk init --agent rovodev --uninstall` → removes only the RTK block, preserves user content.
  - Global install/uninstall (`-g`) writes to / removes from `~/.rovodev/AGENTS.md`.
- [x] Verified `acli rovodev run` loads the inline block from `AGENTS.md` and the agent prefixes shell commands with `rtk` as instructed.

## Files changed
- `src/main.rs` — new `AgentTarget::Rovodev` variant, install/uninstall dispatch wiring, 3 new tests
- `src/hooks/init.rs` — `run_rovodev_mode` (inline block via `upsert_rtk_block`) + `uninstall_rovodev(global, ctx)` (preserves user content via `remove_rtk_block`)
- `src/hooks/constants.rs` — `ROVODEV_DIR` constant (`.rovodev`)
- `hooks/rovodev/{README.md,rtk-awareness.md}` — embedded awareness doc (wrapped in `<!-- rtk-instructions -->` markers) and per-agent README
- `README.md`, `hooks/README.md` — supported-tools table and integration docs

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.