### PR TITLE
fix(discover): guard dbg/gdbg debugger commands from rewrite hook

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -738,6 +738,12 @@ fn rewrite_segment_inner(
         }
     }
 
+    // Debugger prefixes must never be stripped even if listed in transparent_prefixes
+    // (#1387: dbg stack / gdbg break main.py:27 were being mangled).
+    if trimmed.starts_with("dbg ") || trimmed.starts_with("gdbg ") {
+        return None;
+    }
+
     // User-configured wrapper prefixes (e.g. `docker exec mycontainer`). Same
     // strip-recurse-reprepend contract as the builtin list above.
     for prefix in transparent_prefixes {
@@ -3883,5 +3889,24 @@ mod tests {
             rewrite_command_no_prefixes("git log | head | tail && git status", &[]),
             Some("rtk git log | head | tail && rtk git status".into())
         );
+    }
+
+    // #1387: dbg/gdbg debugger commands must never be rewritten, even when
+    // listed in transparent_prefixes — the guard fires before the prefix loop.
+    #[test]
+    fn test_dbg_commands_pass_through() {
+        assert_eq!(rewrite_command_no_prefixes("dbg stack", &[]), None);
+        assert_eq!(
+            rewrite_command_no_prefixes("dbg p distance_miles", &[]),
+            None
+        );
+        assert_eq!(rewrite_command_no_prefixes("dbg where", &[]), None);
+        assert_eq!(
+            rewrite_command_no_prefixes("gdbg break main.py:27", &[]),
+            None
+        );
+        // Guard holds even when dbg is a configured transparent_prefix
+        let prefixes = vec!["dbg".to_string()];
+        assert_eq!(super::rewrite_command("dbg stack", &[], &prefixes), None);
     }
 }

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -928,6 +928,8 @@ pub const IGNORED_PREFIXES: &[&str] = &[
     "while ",
     "if ",
     "case ",
+    "dbg ",
+    "gdbg ",
 ];
 
 pub const IGNORED_EXACT: &[&str] = &[


### PR DESCRIPTION
## Problem

`dbg stack`, `dbg p variable`, `dbg where`, and `gdbg break main.py:27` were at risk of being mangled by the hook rewrite system. If a user added `dbg` to `transparent_prefixes` in their config, the prefix would be stripped **before** `IGNORED_PREFIXES` is checked — causing the subcommand to be routed or dropped incorrectly.

Root cause: `rewrite_segment_inner()` processes `transparent_prefixes` after `SHELL_PREFIX_BUILTINS` but before the `IGNORED_PREFIXES` check returns `None`. A user-configured `dbg` transparent prefix bypasses the ignore guard.

## Fix

Two-layer defense:

1. **`IGNORED_PREFIXES`** (rules.rs): Add `"dbg "` and `"gdbg "` to the prefix ignore list — covers the standard path.

2. **Early-return guard** (registry.rs): Add an explicit `if trimmed.starts_with("dbg ") || trimmed.starts_with("gdbg ")` guard inside `rewrite_segment_inner()` that fires **before** the `transparent_prefixes` loop — closes the ordering gap.

## Changes

| File | Action |
|------|--------|
| `src/discover/rules.rs` | Add `"dbg "` and `"gdbg "` to `IGNORED_PREFIXES` |
| `src/discover/registry.rs` | Early-return guard before `transparent_prefixes` loop + new test |

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — zero warnings
- [x] `cargo test --all` — 1871 passed, 6 ignored
- [x] `test_dbg_commands_pass_through` — covers bare commands and transparent_prefix edge case

## Closes

Closes #1387