### PR TITLE
fix(discover): classify universal-passthrough git subcommands as supported

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -4,6 +4,7 @@ use lazy_static::lazy_static;
 use regex::{Regex, RegexSet};
 
 use super::lexer::{split_on_operators, tokenize, TokenKind};
+use super::report::RtkStatus;
 use super::rules::{IGNORED_EXACT, IGNORED_PREFIXES, RULES};
 
 /// Result of classifying a command.
@@ -160,7 +161,7 @@ pub fn classify_command(cmd: &str) -> Classification {
                     .iter()
                     .find(|(s, _)| *s == subcmd)
                     .map(|(_, st)| *st)
-                    .unwrap_or(super::report::RtkStatus::Existing);
+                    .unwrap_or(RtkStatus::Existing);
 
                 // Check if this subcommand has custom savings
                 let savings = rule
@@ -172,10 +173,10 @@ pub fn classify_command(cmd: &str) -> Classification {
 
                 (savings, status)
             } else {
-                (rule.savings_pct, super::report::RtkStatus::Existing)
+                (rule.savings_pct, RtkStatus::Existing)
             }
         } else {
-            (rule.savings_pct, super::report::RtkStatus::Existing)
+            (rule.savings_pct, RtkStatus::Existing)
         };
 
         Classification::Supported {
@@ -185,6 +186,16 @@ pub fn classify_command(cmd: &str) -> Classification {
             status,
         }
     } else {
+        // Universal-passthrough parents: `rtk git <anything>` (and yadm) works
+        // via the per-parent `run_passthrough` path even when the specific
+        // subcommand has no dedicated filter. Don't flag these as unhandled
+        // (see #1897). The rewrite path picks the existing git rule via
+        // `rtk_equivalent == "rtk git"` and the per-rule `rewrite_prefixes`
+        // handles the actual rewrite.
+        if let Some(class) = passthrough_parent_classification(cmd_clean) {
+            return class;
+        }
+
         // Extract base command for unsupported
         let base = extract_base_command(cmd_clean);
         if base.is_empty() {
@@ -195,6 +206,28 @@ pub fn classify_command(cmd: &str) -> Classification {
             }
         }
     }
+}
+
+/// Returns a `Supported` classification with `RtkStatus::Passthrough` if the
+/// command's parent has a `run_passthrough` handler that covers any subcommand
+/// (e.g. `rtk git <anything>` for git and yadm). Used to keep `rtk discover`
+/// from flagging genuinely-supported commands like `git checkout`, `git clone`,
+/// `git remote` as unhandled. See #1897.
+fn passthrough_parent_classification(cmd: &str) -> Option<Classification> {
+    let first = cmd.split_whitespace().next()?;
+    let (rtk_equivalent, category) = match first {
+        "git" | "yadm" => ("rtk git", "Git"),
+        _ => return None,
+    };
+    Some(Classification::Supported {
+        rtk_equivalent,
+        category,
+        // Passthrough does no output filtering, so no per-command token savings.
+        // Tracking still has value via `rtk gain`, but reporting 0 keeps the
+        // savings totals honest.
+        estimated_savings_pct: 0.0,
+        status: RtkStatus::Passthrough,
+    })
 }
 
 /// Extract the base command (first word, or first two if it looks like a subcommand pattern).
@@ -996,6 +1029,84 @@ mod tests {
             }
             other => panic!("expected Unsupported, got {:?}", other),
         }
+    }
+
+    // --- #1897: git passthrough subcommands ---
+
+    #[test]
+    fn test_classify_git_checkout_passthrough() {
+        // Regression test for https://github.com/rtk-ai/rtk/issues/1897:
+        // `git checkout` was being classified Unsupported because it isn't in the
+        // git rule's explicit subcommand list, even though `rtk git checkout`
+        // already works via the git run_passthrough handler. The discover report
+        // would then flag it as "TOP UNHANDLED" and prompt users to "open an
+        // issue?", causing noise and false bug reports.
+        assert_eq!(
+            classify_command("git checkout -b my-branch"),
+            Classification::Supported {
+                rtk_equivalent: "rtk git",
+                category: "Git",
+                estimated_savings_pct: 0.0,
+                status: RtkStatus::Passthrough,
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_git_clone_passthrough() {
+        assert_eq!(
+            classify_command("git clone --depth=1 https://github.com/foo/bar"),
+            Classification::Supported {
+                rtk_equivalent: "rtk git",
+                category: "Git",
+                estimated_savings_pct: 0.0,
+                status: RtkStatus::Passthrough,
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_git_remote_passthrough() {
+        assert_eq!(
+            classify_command("git remote add fork https://github.com/foo/bar"),
+            Classification::Supported {
+                rtk_equivalent: "rtk git",
+                category: "Git",
+                estimated_savings_pct: 0.0,
+                status: RtkStatus::Passthrough,
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_yadm_checkout_passthrough() {
+        // yadm shares the universal git rewrite path (rewrite_prefixes = ["git", "yadm"]).
+        assert_eq!(
+            classify_command("yadm checkout -b my-branch"),
+            Classification::Supported {
+                rtk_equivalent: "rtk git",
+                category: "Git",
+                estimated_savings_pct: 0.0,
+                status: RtkStatus::Passthrough,
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_git_status_still_uses_dedicated_filter() {
+        // Sentinel: the new passthrough fallback must NOT shadow the existing
+        // dedicated-filter rule for `git status` and friends. The matches.last()
+        // logic picks the more specific (later) match, so the existing 70%-savings
+        // Existing-status classification must still win.
+        assert_eq!(
+            classify_command("git status"),
+            Classification::Supported {
+                rtk_equivalent: "rtk git",
+                category: "Git",
+                estimated_savings_pct: 70.0,
+                status: RtkStatus::Existing,
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`rtk discover` was flagging `git checkout`, `git clone`, `git remote` and other unhandled-by-name git subcommands in its `TOP UNHANDLED COMMANDS -- open an issue?` section, even though `rtk git <anything>` already works via the universal `run_passthrough` handler in `src/cmds/git/git.rs`. The report would prompt users (and AI assistants following RTK instructions) to file unnecessary "add git X support" issues, or worse, to conclude `rtk git checkout` does not work and to keep using bare `git checkout` without the proxy.

## Root cause

The git rule in `src/discover/rules.rs` enumerates only the subcommands with dedicated filters:

```rust
pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|push|pull|branch|fetch|stash|worktree)"
```

Anything else (`checkout`, `clone`, `remote`, `fetch-pack`, `cat-file`, ...) falls through `classify_command` to `Classification::Unsupported`, which populates the `unsupported` bucket that the report renders under `TOP UNHANDLED COMMANDS`.

## Fix

Add `passthrough_parent_classification` to `classify_command` as a fallback before the existing `Unsupported` return. For commands whose parent has a `run_passthrough` handler (`git`, `yadm`), classify as `Supported { rtk_status: Passthrough }` so the report shows them under `MISSED SAVINGS` with status `passthrough` instead of `TOP UNHANDLED`. `estimated_savings_pct: 0.0` keeps the savings totals honest (no filter-based compression on the passthrough path).

The fallback runs only after the existing rule-matching fails, so:

- Known git subcommands (`git status`, `git diff`, ...) keep their dedicated-filter classification with `status: Existing` and the per-subcommand `savings_pct` (70%, 80%, etc).
- Yadm continues to share git's rewrite path (already configured via `rewrite_prefixes: ["git", "yadm"]` on the existing rule).

## Test plan

5 regression tests added to `mod tests` in `src/discover/registry.rs`:

- `test_classify_git_checkout_passthrough` (the issue's example: `git checkout -b my-branch`)
- `test_classify_git_clone_passthrough`
- `test_classify_git_remote_passthrough`
- `test_classify_yadm_checkout_passthrough` (yadm parity)
- `test_classify_git_status_still_uses_dedicated_filter` (sentinel that the new fallback does not shadow the existing rule for known subcommands, since `matches.last()` picks the more specific later match)

All checks pass:

- [x] `cargo test`: 1875 passed, 0 failed, 6 ignored.
- [x] `cargo fmt --check`: clean.
- [x] `cargo clippy --all-targets -- -D warnings`: clean.

## Scope

Git/yadm only, matching the issue. Other universal-proxy parents (`cargo`, `pnpm`, `go`, `gh`, `glab`, `dotnet`, `pip`) also have `run_passthrough` handlers; the same fix could extend to those once the maintainer signals the direction is right.

Fixes #1897.
