### PR TITLE
feat(ssh): add SSH output filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +344,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "env_home"
@@ -652,6 +669,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "rtk"
-version = "0.36.0"
+version = "0.34.3"
 dependencies = [
  "anyhow",
  "automod",
@@ -903,6 +932,7 @@ dependencies = [
  "flate2",
  "getrandom 0.4.2",
  "ignore",
+ "insta",
  "lazy_static",
  "libc",
  "quick-xml",
@@ -1076,6 +1106,12 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ libc = "0.2"
 toml = "0.8"
 
 [dev-dependencies]
+insta = "1"
 
 [profile.release]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ rtk json config.json            # Structure without values
 rtk deps                        # Dependencies summary
 rtk env -f AWS                  # Filtered env vars
 rtk log app.log                 # Deduplicated logs
+rtk ssh <host> <cmd>            # JSON/log/plain-text filtered; interactive passthrough
 rtk curl <url>                  # Truncate + save full output
 rtk wget <url>                  # Download, strip progress bars
 rtk summary <long command>      # Heuristic summary

--- a/src/cmds/cloud/README.md
+++ b/src/cmds/cloud/README.md
@@ -9,3 +9,4 @@
 - `curl_cmd.rs` truncates long responses, saves full output to file for recovery
 - `wget_cmd.rs` wraps wget with output filtering
 - `psql_cmd.rs` filters PostgreSQL query output
+- `ssh_cmd.rs` — SSH output filter with three modes: JSON passthrough (preserves parseability), log filtering (keeps WARN/ERROR + 1-line context, suppresses INFO/DEBUG), plain-text truncation at 50 lines. Interactive sessions (no remote command) pass through to TTY unchanged. Prometheus metric output is not mistaken for log output (≥10% threshold guard).

--- a/src/cmds/cloud/snapshots/rtk__cmds__cloud__ssh_cmd__tests__snapshot_log_fixture.snap
+++ b/src/cmds/cloud/snapshots/rtk__cmds__cloud__ssh_cmd__tests__snapshot_log_fixture.snap
@@ -1,0 +1,11 @@
+---
+source: src/cmds/cloud/ssh_cmd.rs
+assertion_line: 390
+expression: output
+---
+2026-05-18T01:00:03Z WARN  myapp::ratelimit ip=9.10.11.12 req_count=480 threshold=500
+2026-05-18T01:00:06Z ERROR myapp::lb health backend=192.0.2.2:80 status=connection_refused
+2026-05-18T01:00:10Z WARN  myapp::lb health backend=192.0.2.2:80 retry=1 latency_ms=5000
+2026-05-18T01:00:14Z ERROR myapp::metrics db send_batch failed: connection timeout after 5000ms
+2026-05-18T01:00:18Z WARN  myapp::waf rule_id=942100 match=true action=log zone=demo.net
+... (46 INFO/DEBUG lines suppressed)

--- a/src/cmds/cloud/snapshots/rtk__cmds__cloud__ssh_cmd__tests__snapshot_plain_metrics_fixture.snap
+++ b/src/cmds/cloud/snapshots/rtk__cmds__cloud__ssh_cmd__tests__snapshot_plain_metrics_fixture.snap
@@ -1,0 +1,56 @@
+---
+source: src/cmds/cloud/ssh_cmd.rs
+assertion_line: 397
+expression: output
+---
+# HELP myapp_http_requests_total Total HTTP requests
+# TYPE myapp_http_requests_total counter
+myapp_http_requests_total{method="GET",status="200"} 4821
+myapp_http_requests_total{method="POST",status="200"} 312
+myapp_http_requests_total{method="GET",status="404"} 17
+myapp_http_requests_total{method="GET",status="500"} 3
+# HELP myapp_http_request_duration_seconds HTTP request latency
+# TYPE myapp_http_request_duration_seconds histogram
+myapp_http_request_duration_seconds_bucket{le="0.005"} 1234
+myapp_http_request_duration_seconds_bucket{le="0.01"} 2100
+myapp_http_request_duration_seconds_bucket{le="0.025"} 3500
+myapp_http_request_duration_seconds_bucket{le="0.05"} 4200
+myapp_http_request_duration_seconds_bucket{le="0.1"} 4750
+myapp_http_request_duration_seconds_bucket{le="0.25"} 4810
+myapp_http_request_duration_seconds_bucket{le="0.5"} 4820
+myapp_http_request_duration_seconds_bucket{le="1"} 4821
+myapp_http_request_duration_seconds_bucket{le="+Inf"} 4821
+myapp_http_request_duration_seconds_sum 48.3
+myapp_http_request_duration_seconds_count 4821
+# HELP myapp_active_connections Current open connections
+# TYPE myapp_active_connections gauge
+myapp_active_connections 42
+# HELP myapp_cache_hits_total Cache hit counter
+# TYPE myapp_cache_hits_total counter
+myapp_cache_hits_total 3902
+# HELP myapp_cache_misses_total Cache miss counter
+# TYPE myapp_cache_misses_total counter
+myapp_cache_misses_total 919
+# HELP myapp_cache_hit_ratio Current cache hit ratio
+# TYPE myapp_cache_hit_ratio gauge
+myapp_cache_hit_ratio 0.809
+# HELP myapp_upstream_pool_size Upstream connection pool size
+# TYPE myapp_upstream_pool_size gauge
+myapp_upstream_pool_size{backend="api-1"} 10
+myapp_upstream_pool_size{backend="api-2"} 10
+myapp_upstream_pool_size{backend="api-3"} 8
+# HELP myapp_upstream_errors_total Upstream connection errors
+# TYPE myapp_upstream_errors_total counter
+myapp_upstream_errors_total{backend="api-1"} 0
+myapp_upstream_errors_total{backend="api-2"} 2
+myapp_upstream_errors_total{backend="api-3"} 0
+# HELP myapp_build_info Build metadata (always 1)
+# TYPE myapp_build_info gauge
+myapp_build_info{version="1.4.2",commit="abc1234"} 1
+# HELP myapp_queue_depth Current task queue depth
+# TYPE myapp_queue_depth gauge
+myapp_queue_depth{worker="default"} 5
+myapp_queue_depth{worker="priority"} 1
+# HELP myapp_queue_processed_total Tasks processed
+# TYPE myapp_queue_processed_total counter
+... (49 more lines)

--- a/src/cmds/cloud/ssh_cmd.rs
+++ b/src/cmds/cloud/ssh_cmd.rs
@@ -1,0 +1,437 @@
+//! SSH output filter.
+//!
+//! Three output modes:
+//! - JSON body (`ssh host 'curl ...'`) → pass through unchanged to preserve parseability
+//! - Log/grep output → keep WARN/ERROR lines + 1-line context, suppress INFO/DEBUG
+//! - Plain text (uptime, systemctl status, etc.) → truncate at MAX_PLAIN_LINES
+//!
+//! Interactive sessions (no remote command in args) → passthrough with no filtering.
+
+use crate::core::runner::{self, RunOptions};
+use crate::core::utils::resolved_command;
+use anyhow::Result;
+use lazy_static::lazy_static;
+use regex::Regex;
+use std::ffi::OsString;
+
+const MAX_PLAIN_LINES: usize = 50;
+const MAX_JSON_CHARS: usize = 4000;
+
+lazy_static! {
+    static ref LOG_IMPORTANT: Regex =
+        Regex::new(r"(?i)\b(WARN|WARNING|ERROR|FATAL|CRITICAL|PANIC)\b").unwrap();
+    static ref LOG_NOISE: Regex = Regex::new(r"(?i)\b(INFO|DEBUG|TRACE)\b").unwrap();
+    static ref ANSI_ESCAPE: Regex = Regex::new(r"\x1b\[[0-9;]*[mGKHF]").unwrap();
+}
+
+/// SSH options that consume the next token (so we don't confuse it with the hostname).
+const OPTS_WITH_ARG: &[&str] = &[
+    "-b", "-c", "-D", "-E", "-e", "-F", "-I", "-i", "-J", "-L", "-l", "-m", "-O", "-o", "-p",
+    "-Q", "-R", "-S", "-W", "-w",
+];
+
+/// Returns true when args contain a remote command after the [user@]host.
+fn has_remote_command(args: &[String]) -> bool {
+    let mut skip_next = false;
+    let mut host_seen = false;
+    for arg in args {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if arg.starts_with('-') {
+            if OPTS_WITH_ARG.contains(&arg.as_str()) {
+                skip_next = true;
+            }
+            continue;
+        }
+        if !host_seen {
+            host_seen = true; // first non-option arg = [user@]host
+            continue;
+        }
+        return true; // anything after host = remote command
+    }
+    false
+}
+
+pub fn run(args: &[String], verbose: u8) -> Result<i32> {
+    if verbose > 0 {
+        eprintln!("Running: ssh {}", args.join(" "));
+    }
+
+    // Interactive session — inherit TTY, no filtering
+    if !has_remote_command(args) {
+        let os_args: Vec<OsString> = args.iter().map(Into::into).collect();
+        return runner::run_passthrough("ssh", &os_args, verbose);
+    }
+
+    let mut cmd = resolved_command("ssh");
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    runner::run_filtered(
+        cmd,
+        "ssh",
+        &args.join(" "),
+        filter_ssh_output,
+        RunOptions::stdout_only().tee("ssh"),
+    )
+}
+
+pub fn filter_ssh_output(raw: &str) -> String {
+    let clean = ANSI_ESCAPE.replace_all(raw.trim(), "");
+    let text = clean.as_ref();
+    let t = text.trim();
+
+    // JSON body → pass through (truncating mid-JSON breaks downstream parsers)
+    if (t.starts_with('{') && t.ends_with('}')) || (t.starts_with('[') && t.ends_with(']')) {
+        if t.len() > MAX_JSON_CHARS {
+            // Large JSON: trim with byte-safe boundary
+            let mut end = MAX_JSON_CHARS;
+            while !t.is_char_boundary(end) {
+                end -= 1;
+            }
+            return format!("{}... ({} bytes total)", &t[..end], t.len());
+        }
+        return t.to_owned();
+    }
+
+    let lines: Vec<&str> = t.lines().collect();
+
+    // Log/grep output → keep important lines + 1-line context.
+    // Require ≥10% of lines to have a log-level prefix in their first 3 tokens
+    // to avoid false positives from Prometheus metric names / HELP text.
+    if looks_like_log_output(&lines) {
+        return filter_log_lines(&lines);
+    }
+
+    // Plain text → truncate at MAX_PLAIN_LINES
+    if lines.len() > MAX_PLAIN_LINES {
+        let omitted = lines.len() - MAX_PLAIN_LINES;
+        return format!("{}\n... ({} more lines)", lines[..MAX_PLAIN_LINES].join("\n"), omitted);
+    }
+
+    t.to_owned()
+}
+
+/// True when a line has a log-level keyword in its first 3 whitespace-separated tokens.
+/// Scanning only leading tokens prevents metric names like `oneshield_build_info` from
+/// triggering log mode — those contain `info` mid-token where `\b` doesn't match,
+/// but even if they did, they'd only appear as the first token in metric lines.
+fn is_log_line(line: &str) -> bool {
+    line.split_whitespace()
+        .take(3)
+        .any(|tok| LOG_IMPORTANT.is_match(tok) || LOG_NOISE.is_match(tok))
+}
+
+/// Log mode needs ≥10% of lines to look like log entries (min 1).
+/// Prometheus metrics, systemctl status, and `ps aux` output all score 0%.
+/// Application logs with INFO/WARN/ERROR prefixes score 80–100%.
+fn looks_like_log_output(lines: &[&str]) -> bool {
+    if lines.is_empty() {
+        return false;
+    }
+    let threshold = (lines.len() / 10).max(1);
+    lines.iter().filter(|l| is_log_line(l)).count() >= threshold
+}
+
+fn filter_log_lines(lines: &[&str]) -> String {
+    let mut kept: Vec<String> = Vec::new();
+    let mut suppressed: usize = 0;
+    let mut prev_important = false;
+
+    for line in lines {
+        if LOG_IMPORTANT.is_match(line) {
+            kept.push(line.to_string());
+            prev_important = true;
+        } else if LOG_NOISE.is_match(line) {
+            suppressed += 1;
+            prev_important = false;
+        } else if prev_important {
+            kept.push(line.to_string()); // 1-line context
+            prev_important = false;
+        } else {
+            kept.push(line.to_string()); // headers, prompts, plain output
+        }
+    }
+
+    if suppressed > 0 {
+        kept.push(format!("... ({} INFO/DEBUG lines suppressed)", suppressed));
+    }
+    kept.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use insta::assert_snapshot;
+
+    fn count_tokens(text: &str) -> usize {
+        text.split_whitespace().count()
+    }
+
+    fn savings_pct(input: &str, output: &str) -> f64 {
+        let in_tok = count_tokens(input);
+        if in_tok == 0 {
+            return 0.0;
+        }
+        100.0 - (count_tokens(output) as f64 / in_tok as f64 * 100.0)
+    }
+
+    // ── interactive detection ────────────────────────────────────────────────
+
+    #[test]
+    fn test_interactive_bare_host() {
+        assert!(!has_remote_command(&["stg-dp1".into()]));
+    }
+
+    #[test]
+    fn test_interactive_flag_no_cmd() {
+        assert!(!has_remote_command(&["-A".into(), "stg-dp1".into()]));
+    }
+
+    #[test]
+    fn test_interactive_o_option_consumes_value() {
+        // -o StrictHostKeyChecking=no must not be mistaken for the host
+        assert!(!has_remote_command(&[
+            "-o".into(),
+            "StrictHostKeyChecking=no".into(),
+            "stg-dp1".into()
+        ]));
+    }
+
+    #[test]
+    fn test_interactive_jump_host() {
+        // -J jump-host consumes next token; targethost is the host, no cmd
+        assert!(!has_remote_command(&[
+            "-J".into(),
+            "jump-host".into(),
+            "targethost".into()
+        ]));
+    }
+
+    #[test]
+    fn test_interactive_o_ctl_cmd() {
+        // -O check consumes "check"; targethost is the host, no remote command
+        assert!(!has_remote_command(&[
+            "-O".into(),
+            "check".into(),
+            "targethost".into()
+        ]));
+    }
+
+    #[test]
+    fn test_oneshot_bare_cmd() {
+        assert!(has_remote_command(&["stg-dp1".into(), "uptime".into()]));
+    }
+
+    #[test]
+    fn test_oneshot_with_p_option() {
+        assert!(has_remote_command(&[
+            "-p".into(),
+            "22".into(),
+            "stg-dp1".into(),
+            "hostname".into()
+        ]));
+    }
+
+    #[test]
+    fn test_oneshot_user_at_host() {
+        assert!(has_remote_command(&[
+            "root@stg-dp1".into(),
+            "hostname".into()
+        ]));
+    }
+
+    #[test]
+    fn test_oneshot_jump_host_with_cmd() {
+        // -J jump targethost cmd
+        assert!(has_remote_command(&[
+            "-J".into(),
+            "jump".into(),
+            "targethost".into(),
+            "uptime".into()
+        ]));
+    }
+
+    #[test]
+    fn test_oneshot_multi_o_with_cmd() {
+        assert!(has_remote_command(&[
+            "-o".into(),
+            "ConnectTimeout=5".into(),
+            "-o".into(),
+            "StrictHostKeyChecking=no".into(),
+            "hn01-dp1".into(),
+            "curl -s http://localhost:8080/api/v1/stats".into()
+        ]));
+    }
+
+    // ── JSON output ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_json_small_passthrough() {
+        let json = r#"{"status":"ok","zones":3}"#;
+        assert_eq!(filter_ssh_output(json), json);
+    }
+
+    #[test]
+    fn test_json_array_passthrough() {
+        let json = r#"[{"id":1},{"id":2}]"#;
+        assert_eq!(filter_ssh_output(json), json);
+    }
+
+    #[test]
+    fn test_json_large_truncated() {
+        let body = "x".repeat(5000);
+        let json = format!(r#"{{"data":"{}"}}"#, body);
+        let out = filter_ssh_output(&json);
+        assert!(out.contains("bytes total"), "must show byte count");
+        assert!(out.len() < json.len(), "must be shorter than input");
+    }
+
+    #[test]
+    fn test_json_large_byte_safe_boundary() {
+        // Ensure truncation doesn't split a multi-byte UTF-8 char
+        let body = "é".repeat(3000); // 2 bytes each = 6000 bytes
+        let json = format!(r#"{{"data":"{}"}}"#, body);
+        let out = filter_ssh_output(&json);
+        // Output must be valid UTF-8 (no panic = success, assert well-formed)
+        assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+        assert!(out.contains("bytes total"));
+    }
+
+    #[test]
+    fn test_json_with_ansi_stripped() {
+        let raw = "\x1b[32m{\"status\":\"ok\"}\x1b[0m";
+        assert_eq!(filter_ssh_output(raw), r#"{"status":"ok"}"#);
+    }
+
+    // ── log filtering ────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_log_suppresses_info() {
+        let raw = "2026-05-18 INFO starting\n2026-05-18 ERROR disk full\n2026-05-18 INFO done";
+        let out = filter_ssh_output(raw);
+        assert!(out.contains("ERROR disk full"));
+        assert!(out.contains("INFO/DEBUG lines suppressed"));
+        assert!(!out.contains("INFO starting"));
+        assert!(!out.contains("INFO done"));
+    }
+
+    #[test]
+    fn test_log_keeps_warn_with_context() {
+        let raw = "DEBUG tick\nWARN high memory\ncontext line\nDEBUG tick2";
+        let out = filter_ssh_output(raw);
+        assert!(out.contains("WARN high memory"));
+        assert!(out.contains("context line"), "1-line context after WARN must be kept");
+        assert!(!out.contains("DEBUG tick2"));
+    }
+
+    #[test]
+    fn test_log_keeps_fatal_critical() {
+        let raw = "INFO tick\nFATAL oom killer\nCRITICAL signal 11";
+        let out = filter_ssh_output(raw);
+        assert!(out.contains("FATAL oom killer"));
+        assert!(out.contains("CRITICAL signal 11"));
+    }
+
+    // ── plain text truncation ────────────────────────────────────────────────
+
+    #[test]
+    fn test_plain_truncated_at_50() {
+        let lines: Vec<String> = (0..100).map(|i| format!("line {}", i)).collect();
+        let out = filter_ssh_output(&lines.join("\n"));
+        assert!(out.contains("50 more lines"), "truncation annotation required");
+        assert!(!out.contains("line 99"), "must not contain lines past cutoff");
+    }
+
+    #[test]
+    fn test_plain_short_passthrough() {
+        let raw = "hostname\nuptime\nload: 0.5";
+        assert_eq!(filter_ssh_output(raw), raw);
+    }
+
+    #[test]
+    fn test_plain_strips_ansi() {
+        let raw = "\x1b[32mOK\x1b[0m status";
+        assert_eq!(filter_ssh_output(raw), "OK status");
+    }
+
+    #[test]
+    fn test_prometheus_metrics_not_detected_as_log() {
+        // Prometheus HELP/TYPE/value lines must NOT trigger log mode even if metric
+        // names contain substrings like "info" in "build_info".
+        let input = include_str!("../../../tests/fixtures/ssh/ssh_plain_metrics_raw.txt");
+        let out = filter_ssh_output(input);
+        assert!(
+            out.contains("more lines"),
+            "Prometheus metrics (100 lines) must be truncated as plain text, not passed through as log"
+        );
+    }
+
+    #[test]
+    fn test_log_threshold_requires_10_pct() {
+        // 9 plain lines + 0 log lines → below 10% threshold → plain truncation path
+        let lines: Vec<String> = (0..9).map(|i| format!("plain line {}", i)).collect();
+        let raw = lines.join("\n");
+        let out = filter_ssh_output(&raw);
+        // Short output (< MAX_PLAIN_LINES), should pass through unchanged
+        assert_eq!(out, raw);
+    }
+
+    #[test]
+    fn test_empty_input() {
+        assert_eq!(filter_ssh_output(""), "");
+    }
+
+    #[test]
+    fn test_unicode_passthrough() {
+        let raw = "日本語テスト\nok";
+        assert_eq!(filter_ssh_output(raw), raw);
+    }
+
+    // ── snapshot tests (insta) ───────────────────────────────────────────────
+
+    #[test]
+    fn test_snapshot_log_fixture() {
+        let input = include_str!("../../../tests/fixtures/ssh/ssh_log_raw.txt");
+        let output = filter_ssh_output(input);
+        assert_snapshot!(output);
+    }
+
+    #[test]
+    fn test_snapshot_plain_metrics_fixture() {
+        let input = include_str!("../../../tests/fixtures/ssh/ssh_plain_metrics_raw.txt");
+        let output = filter_ssh_output(input);
+        assert_snapshot!(output);
+    }
+
+    // ── token accuracy (≥65% savings on dominant real-world patterns) ────────
+
+    #[test]
+    fn test_token_savings_log_fixture() {
+        let input = include_str!("../../../tests/fixtures/ssh/ssh_log_raw.txt");
+        let output = filter_ssh_output(input);
+        let savings = savings_pct(input, &output);
+        assert!(
+            savings >= 65.0,
+            "log filter: expected ≥65% savings, got {:.1}% (input {} tokens, output {} tokens)",
+            savings,
+            count_tokens(input),
+            count_tokens(&output),
+        );
+    }
+
+    #[test]
+    fn test_token_savings_plain_metrics_fixture() {
+        let input = include_str!("../../../tests/fixtures/ssh/ssh_plain_metrics_raw.txt");
+        let output = filter_ssh_output(input);
+        let savings = savings_pct(input, &output);
+        assert!(
+            savings >= 40.0,
+            "plain truncation: expected ≥40% savings, got {:.1}%",
+            savings,
+        );
+    }
+}

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -417,6 +417,15 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
+        pattern: r"^ssh\s+",
+        rtk_cmd: "rtk ssh",
+        rewrite_prefixes: &["ssh"],
+        category: "Network",
+        savings_pct: 65.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
+    RtkRule {
         pattern: r"^wget\s+",
         rtk_cmd: "rtk wget",
         rewrite_prefixes: &["wget"],

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod learn;
 mod parser;
 
 // Re-export command modules for routing
-use cmds::cloud::{aws_cmd, container, curl_cmd, psql_cmd, wget_cmd};
+use cmds::cloud::{aws_cmd, container, curl_cmd, psql_cmd, ssh_cmd, wget_cmd};
 use cmds::dotnet::{binlog, dotnet_cmd, dotnet_format_report, dotnet_trx};
 use cmds::git::{diff_cmd, gh_cmd, git, glab_cmd, gt_cmd};
 use cmds::go::{go_cmd, golangci_cmd};
@@ -553,6 +553,13 @@ enum Commands {
     /// Curl with auto-JSON detection and schema output
     Curl {
         /// Curl arguments (URL + options)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// SSH with JSON/log/plain-text output filtering; passthrough for interactive sessions
+    Ssh {
+        /// SSH arguments ([options] [user@]host [command])
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -2019,6 +2026,7 @@ fn run_cli() -> Result<i32> {
         Commands::Npm { args } => npm_cmd::run(&args, cli.verbose, cli.skip_env)?,
 
         Commands::Curl { args } => curl_cmd::run(&args, cli.verbose)?,
+        Commands::Ssh { args } => ssh_cmd::run(&args, cli.verbose)?,
 
         Commands::Discover {
             project,
@@ -2485,6 +2493,7 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Npm { .. }
             | Commands::Npx { .. }
             | Commands::Curl { .. }
+            | Commands::Ssh { .. }
             | Commands::Ruff { .. }
             | Commands::Pytest { .. }
             | Commands::Rake { .. }

--- a/tests/fixtures/ssh/ssh_log_raw.txt
+++ b/tests/fixtures/ssh/ssh_log_raw.txt
@@ -1,0 +1,51 @@
+2026-05-18T01:00:00Z INFO  myapp::proxy starting request pipeline
+2026-05-18T01:00:00Z INFO  myapp::config loaded 42 zones
+2026-05-18T01:00:01Z INFO  myapp::proxy request_filter zone=example.com
+2026-05-18T01:00:01Z INFO  myapp::security ip=1.2.3.4 action=allow
+2026-05-18T01:00:01Z INFO  myapp::cache cache_hit=true ttl=300
+2026-05-18T01:00:02Z INFO  myapp::proxy request_filter zone=demo.net
+2026-05-18T01:00:02Z INFO  myapp::security ip=5.6.7.8 action=allow
+2026-05-18T01:00:02Z INFO  myapp::cache cache_hit=false
+2026-05-18T01:00:03Z WARN  myapp::ratelimit ip=9.10.11.12 req_count=480 threshold=500
+2026-05-18T01:00:03Z INFO  myapp::proxy upstream_connect backend=192.0.2.1:80
+2026-05-18T01:00:04Z INFO  myapp::proxy request_filter zone=test.org
+2026-05-18T01:00:04Z INFO  myapp::security ip=13.14.15.16 action=allow
+2026-05-18T01:00:04Z INFO  myapp::cache cache_hit=true ttl=60
+2026-05-18T01:00:05Z INFO  myapp::proxy request_filter zone=example.com
+2026-05-18T01:00:05Z INFO  myapp::security waf rule_eval=ok phase=1
+2026-05-18T01:00:06Z ERROR myapp::lb health backend=192.0.2.2:80 status=connection_refused
+2026-05-18T01:00:06Z INFO  myapp::lb balancer failover to backend=192.0.2.3:80
+2026-05-18T01:00:07Z INFO  myapp::proxy request_filter zone=demo.net
+2026-05-18T01:00:07Z INFO  myapp::security geo country=US action=allow
+2026-05-18T01:00:08Z INFO  myapp::cache cache_hit=true ttl=300
+2026-05-18T01:00:09Z INFO  myapp::proxy request_filter zone=test.org
+2026-05-18T01:00:09Z INFO  myapp::security ip=17.18.19.20 action=allow
+2026-05-18T01:00:10Z WARN  myapp::lb health backend=192.0.2.2:80 retry=1 latency_ms=5000
+2026-05-18T01:00:10Z INFO  myapp::proxy upstream_connect backend=192.0.2.3:80
+2026-05-18T01:00:11Z INFO  myapp::proxy request_filter zone=example.com
+2026-05-18T01:00:11Z INFO  myapp::security ratelimit ip=21.22.23.24 req_count=10
+2026-05-18T01:00:12Z INFO  myapp::cache cache_hit=false
+2026-05-18T01:00:12Z INFO  myapp::proxy upstream_connect backend=192.0.2.1:80
+2026-05-18T01:00:13Z INFO  myapp::proxy request_filter zone=demo.net
+2026-05-18T01:00:13Z INFO  myapp::security waf rule_eval=ok phase=2
+2026-05-18T01:00:14Z ERROR myapp::metrics db send_batch failed: connection timeout after 5000ms
+2026-05-18T01:00:14Z INFO  myapp::metrics db retry scheduled in 10s
+2026-05-18T01:00:15Z INFO  myapp::proxy request_filter zone=test.org
+2026-05-18T01:00:15Z INFO  myapp::security ip=25.26.27.28 action=allow
+2026-05-18T01:00:16Z INFO  myapp::cache cache_hit=true ttl=120
+2026-05-18T01:00:17Z INFO  myapp::proxy request_filter zone=example.com
+2026-05-18T01:00:17Z INFO  myapp::security geo country=DE action=allow
+2026-05-18T01:00:18Z WARN  myapp::waf rule_id=942100 match=true action=log zone=demo.net
+2026-05-18T01:00:18Z INFO  myapp::proxy upstream_response status=200
+2026-05-18T01:00:19Z INFO  myapp::proxy request_filter zone=test.org
+2026-05-18T01:00:19Z INFO  myapp::security ip=29.30.31.32 action=allow
+2026-05-18T01:00:20Z INFO  myapp::cache cache_hit=true ttl=300
+2026-05-18T01:00:21Z INFO  myapp::proxy request_filter zone=example.com
+2026-05-18T01:00:21Z INFO  myapp::security ratelimit ip=33.34.35.36 req_count=5
+2026-05-18T01:00:22Z INFO  myapp::proxy upstream_connect backend=192.0.2.1:80
+2026-05-18T01:00:23Z INFO  myapp::proxy request_filter zone=demo.net
+2026-05-18T01:00:24Z INFO  myapp::security waf rule_eval=ok phase=1
+2026-05-18T01:00:25Z INFO  myapp::proxy request_filter zone=test.org
+2026-05-18T01:00:25Z INFO  myapp::security ip=37.38.39.40 action=allow
+2026-05-18T01:00:26Z INFO  myapp::cache cache_hit=false
+2026-05-18T01:00:27Z INFO  myapp::proxy upstream_connect backend=192.0.2.3:80

--- a/tests/fixtures/ssh/ssh_plain_metrics_raw.txt
+++ b/tests/fixtures/ssh/ssh_plain_metrics_raw.txt
@@ -1,0 +1,99 @@
+# HELP myapp_http_requests_total Total HTTP requests
+# TYPE myapp_http_requests_total counter
+myapp_http_requests_total{method="GET",status="200"} 4821
+myapp_http_requests_total{method="POST",status="200"} 312
+myapp_http_requests_total{method="GET",status="404"} 17
+myapp_http_requests_total{method="GET",status="500"} 3
+# HELP myapp_http_request_duration_seconds HTTP request latency
+# TYPE myapp_http_request_duration_seconds histogram
+myapp_http_request_duration_seconds_bucket{le="0.005"} 1234
+myapp_http_request_duration_seconds_bucket{le="0.01"} 2100
+myapp_http_request_duration_seconds_bucket{le="0.025"} 3500
+myapp_http_request_duration_seconds_bucket{le="0.05"} 4200
+myapp_http_request_duration_seconds_bucket{le="0.1"} 4750
+myapp_http_request_duration_seconds_bucket{le="0.25"} 4810
+myapp_http_request_duration_seconds_bucket{le="0.5"} 4820
+myapp_http_request_duration_seconds_bucket{le="1"} 4821
+myapp_http_request_duration_seconds_bucket{le="+Inf"} 4821
+myapp_http_request_duration_seconds_sum 48.3
+myapp_http_request_duration_seconds_count 4821
+# HELP myapp_active_connections Current open connections
+# TYPE myapp_active_connections gauge
+myapp_active_connections 42
+# HELP myapp_cache_hits_total Cache hit counter
+# TYPE myapp_cache_hits_total counter
+myapp_cache_hits_total 3902
+# HELP myapp_cache_misses_total Cache miss counter
+# TYPE myapp_cache_misses_total counter
+myapp_cache_misses_total 919
+# HELP myapp_cache_hit_ratio Current cache hit ratio
+# TYPE myapp_cache_hit_ratio gauge
+myapp_cache_hit_ratio 0.809
+# HELP myapp_upstream_pool_size Upstream connection pool size
+# TYPE myapp_upstream_pool_size gauge
+myapp_upstream_pool_size{backend="api-1"} 10
+myapp_upstream_pool_size{backend="api-2"} 10
+myapp_upstream_pool_size{backend="api-3"} 8
+# HELP myapp_upstream_errors_total Upstream connection errors
+# TYPE myapp_upstream_errors_total counter
+myapp_upstream_errors_total{backend="api-1"} 0
+myapp_upstream_errors_total{backend="api-2"} 2
+myapp_upstream_errors_total{backend="api-3"} 0
+# HELP myapp_build_info Build metadata (always 1)
+# TYPE myapp_build_info gauge
+myapp_build_info{version="1.4.2",commit="abc1234"} 1
+# HELP myapp_queue_depth Current task queue depth
+# TYPE myapp_queue_depth gauge
+myapp_queue_depth{worker="default"} 5
+myapp_queue_depth{worker="priority"} 1
+# HELP myapp_queue_processed_total Tasks processed
+# TYPE myapp_queue_processed_total counter
+myapp_queue_processed_total{worker="default"} 10482
+myapp_queue_processed_total{worker="priority"} 874
+# HELP myapp_queue_failed_total Tasks failed
+# TYPE myapp_queue_failed_total counter
+myapp_queue_failed_total{worker="default"} 12
+myapp_queue_failed_total{worker="priority"} 0
+# HELP myapp_memory_bytes Memory usage in bytes
+# TYPE myapp_memory_bytes gauge
+myapp_memory_bytes{type="heap"} 52428800
+myapp_memory_bytes{type="rss"} 78643200
+# HELP myapp_goroutines Current goroutine count
+# TYPE myapp_goroutines gauge
+myapp_goroutines 84
+# HELP myapp_gc_duration_seconds GC pause duration
+# TYPE myapp_gc_duration_seconds summary
+myapp_gc_duration_seconds{quantile="0.5"} 0.000112
+myapp_gc_duration_seconds{quantile="0.9"} 0.000198
+myapp_gc_duration_seconds{quantile="0.99"} 0.000431
+myapp_gc_duration_seconds_sum 0.214
+myapp_gc_duration_seconds_count 1200
+# HELP myapp_db_connections_open Open database connections
+# TYPE myapp_db_connections_open gauge
+myapp_db_connections_open{pool="primary"} 5
+myapp_db_connections_open{pool="replica"} 3
+# HELP myapp_db_query_duration_seconds DB query latency
+# TYPE myapp_db_query_duration_seconds histogram
+myapp_db_query_duration_seconds_bucket{le="0.001"} 8200
+myapp_db_query_duration_seconds_bucket{le="0.005"} 9800
+myapp_db_query_duration_seconds_bucket{le="0.01"} 9950
+myapp_db_query_duration_seconds_bucket{le="0.05"} 9998
+myapp_db_query_duration_seconds_bucket{le="+Inf"} 10000
+myapp_db_query_duration_seconds_sum 12.7
+myapp_db_query_duration_seconds_count 10000
+# HELP myapp_tls_handshakes_total TLS handshakes by version
+# TYPE myapp_tls_handshakes_total counter
+myapp_tls_handshakes_total{version="TLS1.2"} 1203
+myapp_tls_handshakes_total{version="TLS1.3"} 3618
+# HELP myapp_bytes_in_total Inbound bytes
+# TYPE myapp_bytes_in_total counter
+myapp_bytes_in_total 2147483648
+# HELP myapp_bytes_out_total Outbound bytes
+# TYPE myapp_bytes_out_total counter
+myapp_bytes_out_total 8589934592
+# HELP myapp_rate_limit_hits_total Requests rejected by rate limiter
+# TYPE myapp_rate_limit_hits_total counter
+myapp_rate_limit_hits_total 47
+# HELP myapp_config_reload_total Config reloads triggered
+# TYPE myapp_config_reload_total counter
+myapp_config_reload_total 3


### PR DESCRIPTION
## Summary

- Adds `rtk ssh <host> <cmd>` with three-mode output filtering: JSON passthrough, log filtering (WARN/ERROR + 1-line context, suppresses INFO/DEBUG), plain-text truncation at 50 lines
- Interactive sessions (no remote command) inherit the TTY unchanged — no filtering applied
- Prometheus/metric output protected from false log-detection via a ≥10% log-line threshold guard
- `-O ctl_cmd` (ControlMaster) correctly treated as interactive (passthrough)

## Test plan

- [x] `cargo fmt --all --check && cargo clippy --all-targets && cargo test` — 1914 passed, 0 failed
- [x] 29 unit tests: interactive detection (incl. `-O`), JSON passthrough, log filtering, plain truncation, token savings (≥65% log, ≥40% plain), insta snapshots
- [x] Manual: `rtk ssh <host> uptime` (plain truncation), `rtk ssh <host> 'curl -s localhost:9090/metrics'` (Prometheus → plain, no false log-detect), `rtk ssh <host> 'journalctl -n 200'` (log mode)