### PR TITLE
fix(gradlew): collapse consecutive blank lines in build filter output

### DIFF
--- a/src/cmds/jvm/gradlew_cmd.rs
+++ b/src/cmds/jvm/gradlew_cmd.rs
@@ -100,15 +100,29 @@ fn new_gradle_command(args: &[String]) -> Command {
 }
 
 /// `StreamFilter` for build mode: keeps lines for which `filter_build_line` returns true.
-struct BuildLineFilter;
+///
+/// Collapses runs of consecutive blank lines in the emitted output to a single
+/// blank. `filter_build_line` intentionally preserves blanks as section
+/// separators, but on real kotlin/JVM builds this preserves hundreds of blanks
+/// between groups of `w:` compiler warnings — overwhelming the signal.
+/// Tracking `last_emitted_was_blank` keeps the separator intent while killing
+/// the pathological case.
+#[derive(Default)]
+struct BuildLineFilter {
+    last_emitted_was_blank: bool,
+}
 
 impl StreamFilter for BuildLineFilter {
     fn feed_line(&mut self, line: &str) -> Option<String> {
-        if filter_build_line(line) {
-            Some(format!("{}\n", line))
-        } else {
-            None
+        if !filter_build_line(line) {
+            return None; // dropped — state unchanged
         }
+        let is_blank = line.trim().is_empty();
+        if is_blank && self.last_emitted_was_blank {
+            return None; // collapse consecutive blanks
+        }
+        self.last_emitted_was_blank = is_blank;
+        Some(format!("{}\n", line))
     }
 
     fn flush(&mut self) -> String {
@@ -135,7 +149,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
             cmd,
             tool,
             &args_display,
-            Box::new(BuildLineFilter),
+            Box::new(BuildLineFilter::default()),
             RunOptions::with_tee("gradlew_build"),
         ),
         GradlewTask::Test => runner::run_filtered(
@@ -736,6 +750,58 @@ Publishing build scan...
 https://gradle.com/s/abc123"#;
         let filtered: Vec<&str> = input.lines().filter(|l| filter_build_line(l)).collect();
         assert!(filtered.iter().any(|l| l.contains("gradle.com/s/")));
+    }
+
+    /// Feed an input stream to `BuildLineFilter` line-by-line and return the
+    /// concatenated emitted output (matches what the streaming runner does).
+    fn run_build_filter(input: &str) -> String {
+        use crate::core::stream::StreamFilter;
+        let mut f = BuildLineFilter::default();
+        let mut out = String::new();
+        for line in input.lines() {
+            if let Some(emitted) = f.feed_line(line) {
+                out.push_str(&emitted);
+            }
+        }
+        out.push_str(&f.flush());
+        out
+    }
+
+    #[test]
+    fn test_build_filter_collapses_consecutive_blanks() {
+        // Three back-to-back kotlin warnings each followed by blanks should
+        // produce one blank between warnings, not the full run.
+        let input = "w: warning1\n\n\n\nw: warning2\n\n\n\nw: warning3\n";
+        let out = run_build_filter(input);
+        assert_eq!(out, "w: warning1\n\nw: warning2\n\nw: warning3\n");
+    }
+
+    #[test]
+    fn test_build_filter_preserves_single_blank_separator() {
+        // Single blanks between kept lines are preserved (section separators).
+        let input = "w: warning1\n\nw: warning2\n";
+        let out = run_build_filter(input);
+        assert_eq!(out, "w: warning1\n\nw: warning2\n");
+    }
+
+    #[test]
+    fn test_build_filter_collapse_survives_dropped_lines_between_blanks() {
+        // If a non-kept line is sandwiched between blanks, the surviving
+        // blanks are still consecutive in the output and should collapse.
+        let input = "w: warn\n\n> Task :foo:compile\n\nBUILD SUCCESSFUL in 1s\n";
+        let out = run_build_filter(input);
+        // `> Task :…` is dropped (TASK_LINE strip), so the blank before and
+        // the two blanks after become a run of 3 in the emitted stream — must
+        // collapse to one.
+        assert_eq!(out, "w: warn\n\nBUILD SUCCESSFUL in 1s\n");
+    }
+
+    #[test]
+    fn test_build_filter_leading_blanks_collapsed() {
+        // A run of blanks at the start of the stream collapses to one blank.
+        let input = "\n\n\nBUILD SUCCESSFUL in 1s\n";
+        let out = run_build_filter(input);
+        assert_eq!(out, "\nBUILD SUCCESSFUL in 1s\n");
     }
 
     // ── TEST FILTER ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `BuildLineFilter::feed_line` was stateless: every line `filter_build_line` accepted got emitted as-is, including blanks intentionally kept as section separators.
- On real kotlin/JVM builds — which emit groups of `w:` warnings separated by blank lines — this produced multi-screen runs of blank lines between groups of warnings, drowning the actual signal.
- Make `BuildLineFilter` stateful with `last_emitted_was_blank: bool`. Single-blank separators are preserved; runs of 2+ collapse to one. Non-blank lines unaffected.

**Note on the "fix" framing**: BPE tokenizers fully collapse whitespace runs, so this patch saves ~0 tokens. The win is human readability (tee files, debug sessions, scrollback). Filed as `fix` because it removes pathological output noise that hides the actual build signal.

## Test plan

- [x] `cargo fmt --all --check && cargo clippy --all-targets -- -D warnings && cargo test` — all pass
- [x] Four new tests use byte-exact `assert_eq!` via a `run_build_filter` helper:
  - `test_build_filter_collapses_consecutive_blanks` — runs of `\n\n\n\n` collapse to `\n\n`
  - `test_build_filter_preserves_single_blank_separator` — single `\n\n` survives
  - `test_build_filter_collapse_survives_dropped_lines_between_blanks` — `> Task :…` stripped between blanks still collapses (regression for the "state only tracks emitted lines" decision)
  - `test_build_filter_leading_blanks_collapsed` — initial run of blanks collapses to one

> Targets `develop` per CONTRIBUTING.md. Independent of #1939 (same file, unrelated bug).