### PR TITLE
fix(rewrite): broaden npm AND pnpm rule patterns to cover all subcommands

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -991,6 +991,66 @@ mod tests {
         }
     }
 
+    /// Same regression as `npm`, but for `pnpm`: the rewriter rule was
+    /// `^pnpm\s+(exec|i|install|list|ls|outdated|run|run-script)` which
+    /// missed `pnpm test`, `pnpm add`, `pnpm update`, `pnpm dlx`, etc.
+    /// In monorepo / Next.js workflows this is reportedly the dominant
+    /// missed volume (issue #1950 comment: 1296 `pnpm test` vs 180
+    /// `npm test` over 30d).
+    #[test]
+    fn test_classify_pnpm_subcommands() {
+        let supported_pnpm_invocations = [
+            "pnpm test",
+            "pnpm t",
+            "pnpm start",
+            "pnpm dev",
+            "pnpm build",
+            "pnpm install",
+            "pnpm i",
+            "pnpm i react@18",
+            "pnpm add lodash",
+            "pnpm add -D vitest",
+            "pnpm update",
+            "pnpm up",
+            "pnpm remove react",
+            "pnpm rm react",
+            "pnpm audit",
+            "pnpm publish",
+            "pnpm pack",
+            "pnpm outdated",
+            "pnpm list",
+            "pnpm ls --depth=0",
+            "pnpm exec eslint",
+            "pnpm run build",
+            "pnpm run-script build",
+            "pnpm dlx create-next-app",
+            "pnpm --version",
+        ];
+        for cmd in &supported_pnpm_invocations {
+            match classify_command(cmd) {
+                Classification::Supported {
+                    rtk_equivalent: "rtk pnpm",
+                    ..
+                } => {}
+                other => panic!(
+                    "'{}' should classify as Supported(rtk pnpm), got {:?}",
+                    cmd, other
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn test_classify_bare_pnpm_is_supported() {
+        match classify_command("pnpm") {
+            Classification::Supported {
+                rtk_equivalent: "rtk pnpm",
+                ..
+            } => {}
+            other => panic!("bare 'pnpm' should classify as Supported, got {:?}", other),
+        }
+    }
+
     #[test]
     fn test_classify_cat_file() {
         assert_eq!(

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -938,6 +938,59 @@ mod tests {
         );
     }
 
+    /// Regression: the `npm` rewriter rule should cover ALL npm subcommands,
+    /// not just `exec|run|run-script|rum|urn|x`. The handler in
+    /// `cmds/js/npm_cmd.rs` already dispatches every subcommand internally
+    /// via its NPM_SUBCOMMANDS list — the regex previously prevented the
+    /// hook from triggering for the most common ones (`npm test`, `npm
+    /// install`, `npm ci`).
+    #[test]
+    fn test_classify_npm_subcommands() {
+        let supported_npm_invocations = [
+            "npm test",
+            "npm t",
+            "npm start",
+            "npm install",
+            "npm i",
+            "npm i react@18",
+            "npm ci",
+            "npm audit",
+            "npm audit fix",
+            "npm run build",
+            "npm run-script build",
+            "npm exec eslint",
+            "npm publish",
+            "npm pack",
+            "npm outdated",
+            "npm ls --depth=0",
+            "npm view react",
+            "npm --version",
+        ];
+        for cmd in &supported_npm_invocations {
+            match classify_command(cmd) {
+                Classification::Supported {
+                    rtk_equivalent: "rtk npm",
+                    ..
+                } => {}
+                other => panic!(
+                    "'{}' should classify as Supported(rtk npm), got {:?}",
+                    cmd, other
+                ),
+            }
+        }
+    }
+
+    #[test]
+    fn test_classify_bare_npm_is_supported() {
+        match classify_command("npm") {
+            Classification::Supported {
+                rtk_equivalent: "rtk npm",
+                ..
+            } => {}
+            other => panic!("bare 'npm' should classify as Supported, got {:?}", other),
+        }
+    }
+
     #[test]
     fn test_classify_cat_file() {
         assert_eq!(

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -62,7 +62,12 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        pattern: r"^npm\s+(exec|run|run-script|rum|urn|x)(\s|$)",
+        // Match any `npm <subcommand>`. The `npm_cmd::run` handler dispatches
+        // internally based on its NPM_SUBCOMMANDS list, so the regex doesn't
+        // need to enumerate them. Previously this rule only matched `exec|
+        // run|run-script|rum|urn|x`, leaving `npm test`, `npm install`,
+        // `npm ci`, `npm i`, `npm audit`, etc. as unrouted by the hook.
+        pattern: r"^npm(\s+|$)",
         rtk_cmd: "rtk npm",
         rewrite_prefixes: &["npm"],
         category: "PackageManager",

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -53,7 +53,16 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[("fmt", RtkStatus::Passthrough)],
     },
     RtkRule {
-        pattern: r"^pnpm\s+(exec|i|install|list|ls|outdated|run|run-script)",
+        // Match any `pnpm <subcommand>`. The `PnpmCommands::Other(args)` arm in
+        // `main.rs` dispatches every non-specialised subcommand to
+        // `pnpm_cmd::run_passthrough`, so the regex doesn't need to enumerate
+        // them. Previously this rule only matched `exec|i|install|list|ls|
+        // outdated|run|run-script`, leaving `pnpm test`, `pnpm add`,
+        // `pnpm update`, `pnpm dlx`, etc. unrouted by the hook. In monorepo
+        // / Next.js workflows `pnpm test` alone can dominate the unhandled
+        // volume — see issue #1950 (comment by @iwaki-syogo with 1296
+        // `pnpm test` invocations vs 180 `npm test` over 30d).
+        pattern: r"^pnpm(\s+|$)",
         rtk_cmd: "rtk pnpm",
         rewrite_prefixes: &["pnpm"],
         category: "PackageManager",


### PR DESCRIPTION
Closes #1950 (the package-manager rewrite-pattern half; `node` handler is a separate PR).

## Problem

Both `npm` and `pnpm` rewriter rules in `src/discover/rules.rs` enumerated only a narrow subset of subcommands and missed the most common ones:

```rust
// npm — was missing test, install, ci, audit, i, …
pattern: r"^npm\s+(exec|run|run-script|rum|urn|x)(\s|$)"

// pnpm — was missing test, add, update, dlx, …
pattern: r"^pnpm\s+(exec|i|install|list|ls|outdated|run|run-script)"
```

So `npm test`, `npm install`, `npm ci`, `pnpm test`, `pnpm add`, `pnpm update`, `pnpm dlx` etc. fell through the hook and reached the agent's context as raw output — even though `npm_cmd::run` and `PnpmCommands::Other(args) → pnpm_cmd::run_passthrough` already handle every subcommand downstream.

Real-world impact (issue #1950 + comment from @iwaki-syogo):

- My session: ~35 unrouted `npm` / `npm test` over 24h.
- @iwaki-syogo's 30-day data on macOS: **1,296 `pnpm test`** vs **180 `npm test`** — so in monorepo / Next.js workflows pnpm is by far the dominant missed volume.

## Fix

```rust
// npm
pattern: r"^npm(\s+|$)"

// pnpm
pattern: r"^pnpm(\s+|$)"
```

The handlers downstream were the right place to dispatch all along — the regex was the bottleneck. No handler changes needed.

## Tests

Added `test_classify_npm_subcommands`, `test_classify_bare_npm_is_supported`, `test_classify_pnpm_subcommands`, `test_classify_bare_pnpm_is_supported`. Together they cover: `test` / `t` / `start` / `dev` / `build` / `install` / `i` / `i react@18` / `ci` / `add` / `add -D vitest` / `update` / `up` / `remove` / `rm` / `audit` / `audit fix` / `publish` / `pack` / `outdated` / `list` / `ls` / `view` / `exec` / `run` / `run-script` / `dlx` / `--version` + bare `npm` / bare `pnpm`. Previously-handled forms (`run`, `exec`, `run-script`) are kept in the same lists.

I couldn't run `cargo test` locally (`ring` build fails without gcc on my Windows-GNU toolchain), but `cargo fmt -- --check` passes on all modified files. Counting on Linux CI to validate.
