### PR TITLE
feat: add CodeBuddy Code support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ rtk init --agent kimi           # Kimi AI
 rtk init -g --agent pi          # Pi
 rtk init --agent hermes         # Hermes
 rtk init -g --agent droid       # Factory Droid
+rtk init -g --agent codebuddy   # CodeBuddy
 
 # 2. Restart your AI tool, then test
 git status  # Automatically rewritten to rtk git status
@@ -381,7 +382,7 @@ rtk init -g
 
 ## Supported AI Tools
 
-RTK supports 16 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents, reducing the bash output the agent reads where the agent supports command interception.
+RTK supports 17 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents, reducing the bash output the agent reads where the agent supports command interception.
 
 | Tool | Install | Method |
 |------|---------|--------|
@@ -402,6 +403,7 @@ RTK supports 16 AI coding tools. Each integration rewrites shell commands to `rt
 | **Google Antigravity** | `rtk init --agent antigravity` | .agents/rules/antigravity-rtk-rules.md (project-scoped) |
 | **Kimi AI** | `rtk init --agent kimi` | AGENTS.md (project-scoped) |
 | **Factory Droid** | `rtk init -g --agent droid` (or per-project) | PreToolUse hook in `~/.factory/hooks.json` (matcher `Execute`) |
+| **CodeBuddy** | `rtk init -g --agent codebuddy` | PreToolUse hook (bash) + CODEBUDDY.md |
 
 For per-agent setup details, override controls, and graceful degradation, see the [Supported Agents guide](https://www.rtk-ai.app/guide/getting-started/supported-agents). The Hermes plugin source and tests live in `hooks/hermes/`; installed Hermes runtime files still live under `~/.hermes/plugins/rtk-rewrite/`.
 

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -1,6 +1,6 @@
 ---
 title: Supported Agents
-description: How to integrate RTK with Claude Code, Cursor, Copilot, Cline, Windsurf, Codex, OpenCode, Hermes, Kilo Code, Antigravity, Factory Droid, and Mistral Vibe
+description: How to integrate RTK with Claude Code, Cursor, Copilot, Cline, Windsurf, Codex, OpenCode, Hermes, Kilo Code, Antigravity, Factory Droid, Mistral Vibe, and CodeBuddy
 sidebar:
   order: 3
 ---
@@ -44,6 +44,7 @@ Agent runs "cargo test"
 | Kilo Code | Rules file (prompt-level) | N/A |
 | Google Antigravity | Rules file (prompt-level) | N/A |
 | Mistral Vibe | Rust binary (`pre_tool`) | Yes |
+| CodeBuddy | Rust binary (`PreToolUse`) | Yes |
 
 ## Installation by agent
 
@@ -220,6 +221,20 @@ rtk init -g --agent vibe --uninstall
 
 Strips only RTK's `[[hooks]]` block and the `~/.vibe/prompts/rtk.md` file. Any other user-declared hooks in `hooks.toml` are preserved byte-for-byte. `hooks.toml` is removed only when the RTK entry was the sole content.
 
+### CodeBuddy
+
+```bash
+rtk init -g --agent codebuddy    # installs hook + patches ~/.codebuddy/settings.json
+```
+
+CodeBuddy uses the same `PreToolUse` hook mechanism as Claude Code. The hook transparently rewrites Bash commands before execution. A `CODEBUDDY.md` file with RTK awareness instructions is also installed to `~/.codebuddy/CODEBUDDY.md`.
+
+Uninstall:
+
+```bash
+rtk init --uninstall -g --agent codebuddy
+```
+
 ## Integration tiers explained
 
 | Tier | Mechanism | How rewrites work |
@@ -228,7 +243,7 @@ Strips only RTK's `[[hooks]]` block and the `~/.vibe/prompts/rtk.md` file. Any o
 | **Plugin** | TypeScript, JavaScript, or Python in agent's plugin system | Transparent, in-place mutation when the agent allows it |
 | **Rules file** | Prompt-level instructions | Guidance only — agent is told to prefer `rtk <cmd>` |
 
-Rules file integrations (Cline, Windsurf, Codex, Kilo Code, Antigravity) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it. Plugin integrations (OpenCode, Pi) use in-place mutation via the agent's TypeScript extension API.
+Rules file integrations (Cline, Windsurf, Codex, Kilo Code, Antigravity) rely on the model following instructions. Full hook integrations (Claude Code, CodeBuddy, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it. Plugin integrations (OpenCode, Pi) use in-place mutation via the agent's TypeScript extension API.
 
 ## Windows support
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -4,7 +4,7 @@
 
 **Deployed hook artifacts** — the actual files installed on user machines by `rtk init`. These are shell scripts, TypeScript plugins, and rules files that run outside the Rust binary. They are **thin delegates**: parse agent-specific JSON, call `rtk rewrite` as a subprocess, format agent-specific response. Zero filtering logic lives here.
 
-Owns: per-agent hook scripts and configuration files for 10 supported agents (Claude Code, Copilot, Cursor, Cline, Windsurf, Codex, OpenCode, Hermes, Pi, Mistral Vibe).
+Owns: per-agent hook scripts and configuration files for 11 supported agents (Claude Code, Copilot, Cursor, Cline, Windsurf, Codex, OpenCode, Hermes, Pi, Mistral Vibe, CodeBuddy).
 
 Does **not** own: hook installation/uninstallation (that's `src/hooks/init.rs`), the rewrite pattern registry (that's `discover/registry`), or integrity verification (that's `src/hooks/integrity.rs`).
 
@@ -43,6 +43,7 @@ Each agent subdirectory has its own README with hook-specific details:
 - **[`pi/`](pi/README.md)** — TypeScript extension, `tool_call` event, `isToolCallEventType` guard, in-place mutation, `~/.pi/agent/extensions/`
 - **[`hermes/`](hermes/README.md)** — Python plugin, `pre_tool_call` hook, in-place terminal command mutation
 - **[`vibe/`](vibe/README.md)** — Rust binary hook (`rtk hook vibe`), `pre_tool` entry in `~/.vibe/hooks.toml`, `hook_specific_output.tool_input` rewrite plus `system_message` for UI visibility
+- **[`codebuddy/`](codebuddy/README.md)** — Rust binary hook (`rtk hook codebuddy`), same `PreToolUse` protocol as Claude Code with `"continue": true` and `"permissionDecision"` added
 
 ## Supported Agents
 
@@ -60,6 +61,7 @@ Each agent subdirectory has its own README with hook-specific details:
 | Pi | TypeScript extension (`tool_call` event) | In-place mutation | Yes |
 | Hermes | Python plugin (`pre_tool_call`) | In-place mutation | Yes |
 | Mistral Vibe | Rust binary (`rtk hook vibe`) | Transparent rewrite | Yes (`hook_specific_output.tool_input`) |
+| CodeBuddy | Rust binary (`rtk hook codebuddy`) | Transparent rewrite | Yes (`updatedInput`) |
 
 ## JSON Formats by Agent
 
@@ -185,6 +187,27 @@ Returns `{}` when no rewrite (Cursor requires JSON for all paths).
 
 **No rewrite**: exit 0 with empty stdout (Vibe's contract for "no opinion" from a `pre_tool` hook).
 
+### CodeBuddy (Rust Binary)
+
+**Input**: Same as Claude Code (`tool_name: "Bash"`, `tool_input.command`).
+
+**Output** (when rewritten):
+
+```json
+{
+  "continue": true,
+  "permissionDecision": "allow",
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "allow",
+    "permissionDecisionReason": "RTK auto-rewrite",
+    "updatedInput": { "command": "rtk git status" }
+  }
+}
+```
+
+Differs from Claude Code: requires top-level `"continue": true` and `"permissionDecision"` (`"allow"`, `"ask"`, or `"deny"`).
+
 ### OpenCode (TypeScript Plugin)
 
 Mutates `args.command` in-place via the zx library:
@@ -269,7 +292,7 @@ New integrations must follow the [Exit Code Contract](#exit-code-contract) and [
 
 | Tier | Mechanism | Maintenance | Examples |
 |------|-----------|-------------|----------|
-| **Full hook** | Shell script or Rust binary, intercepts commands via agent's hook API | High — must track agent API changes | Claude Code, Cursor, Copilot, Gemini |
+| **Full hook** | Shell script or Rust binary, intercepts commands via agent's hook API | High — must track agent API changes | Claude Code, Cursor, Copilot, Gemini, CodeBuddy |
 | **Plugin** | TypeScript/JS/Python plugin in agent's plugin system | Medium — agent manages loading | OpenCode, Hermes, Pi |
 | **Rules file** | Prompt-level instructions the agent reads | Low — no code to break | Cline, Windsurf, Codex |
 

--- a/hooks/codebuddy/README.md
+++ b/hooks/codebuddy/README.md
@@ -1,0 +1,15 @@
+# CodeBuddy Code Hooks
+
+> Part of [`hooks/`](../README.md) — see also [`src/hooks/`](../../src/hooks/README.md) for installation code
+
+## Specifics
+
+- Uses the `rtk hook codebuddy` Rust binary — no `jq` dependency
+- Same `PreToolUse` JSON protocol as Claude Code (`tool_name` + `tool_input.command`), with two differences: requires top-level `"continue": true` and a `"permissionDecision"` field (`"allow"`, `"ask"`, or `"deny"`)
+- Emits `updatedInput` (not `modifiedInput` — CodeBuddy upstream has converged on `updatedInput`)
+- `CODEBUDDY.md` is generated at install time from the shared `hooks/claude/rtk-awareness.md` template (no per-agent copy shipped in this directory)
+- Installed globally via `rtk init -g --agent codebuddy`; there is no project-scoped variant
+
+## Notes
+
+- CodeBuddy is an independent product, not a Claude Code fork. The `PreToolUse` JSON shape is the only shared contract; if either agent evolves its schema, RTK tracks them independently

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -91,6 +91,7 @@ Rules are loaded from all Claude Code `settings.json` files (project + global, i
 | Copilot CLI (rtk hook copilot) | No updatedInput | deny-with-suggestion (unchanged) |
 | Codex | ask parsed but no-op | allow (limitation — fails open) |
 | Mistral Vibe (rtk hook vibe) | No native ask surface | passthrough — Vibe's own approval prompt fires on the rewritten command |
+| CodeBuddy (rtk hook codebuddy) | Yes | `permissionDecision: "ask"` — user prompted |
 
 ### Implementation
 

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -16,6 +16,10 @@ pub const CURSOR_HOOK_COMMAND: &str = "rtk hook cursor";
 pub const DROID_HOOK_COMMAND: &str = "rtk hook droid";
 /// Native Rust hook command for Mistral Vibe.
 pub const VIBE_HOOK_COMMAND: &str = "rtk hook vibe";
+/// Native Rust hook command for CodeBuddy (replaces rtk-rewrite.sh).
+pub const CODEBUDDY_HOOK_COMMAND: &str = "rtk hook codebuddy";
+/// CodeBuddy PreToolUse matcher: CLI mode (Bash) and IDE mode (execute_command).
+pub const CODEBUDDY_MATCHER: &str = "Bash|execute_command";
 
 pub const CONFIG_DIR: &str = ".config";
 pub const OPENCODE_SUBDIR: &str = "opencode";
@@ -67,3 +71,4 @@ pub const VIBE_PROMPTS_SUBDIR: &str = "prompts";
 pub const VIBE_PROMPT_FILE: &str = "rtk.md";
 pub const VIBE_HOOK_NAME: &str = "rtk-rewrite";
 pub const VIBE_BASH_MATCH: &str = "bash";
+pub const CODEBUDDY_DIR: &str = ".codebuddy";

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -598,13 +598,7 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
         HookDecision::AskRewrite(r) => (r, false),
     };
 
-    let updated_input = {
-        let mut ti = v.get("tool_input").cloned().unwrap_or_else(|| json!({}));
-        if let Some(obj) = ti.as_object_mut() {
-            obj.insert("command".into(), Value::String(rewritten.clone()));
-        }
-        ti
-    };
+    let updated_input = build_updated_input(v, rewritten.clone());
 
     let mut hook_output = json!({
         "hookEventName": PRE_TOOL_USE_KEY,
@@ -624,6 +618,17 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
         rewritten,
         output: json!({ "hookSpecificOutput": hook_output }),
     }
+}
+
+/// Build an `updatedInput` object by cloning the original `tool_input`
+/// and overriding the `command` field. Preserves sibling fields like
+/// `timeout` and `description` that may be present in the hook payload.
+fn build_updated_input(v: &Value, rewritten: String) -> Value {
+    let mut ti = v.get("tool_input").cloned().unwrap_or_else(|| json!({}));
+    if let Some(obj) = ti.as_object_mut() {
+        obj.insert("command".into(), Value::String(rewritten));
+    }
+    ti
 }
 
 /// Run the Claude Code PreToolUse hook natively.
@@ -668,6 +673,97 @@ fn run_claude_inner(input: &str) -> Option<String> {
         PayloadAction::Rewrite { output, .. } => Some(output.to_string()),
         _ => None,
     }
+}
+
+// ── CodeBuddy native hook ─────────────────────────────────
+//
+// CodeBuddy (Tencent Cloud AI code editor) uses a hook protocol compatible
+// with Claude Code's specification, with these differences in the output JSON:
+// 1. Requires top-level `"continue": true`
+// 2. Reads `"updatedInput"` (CodeBuddy's older IDE builds used `modifiedInput`;
+//    upstream has converged on `updatedInput`, so RTK emits `updatedInput`)
+// 3. Mirrors RTK's verdict: AllowRewrite -> `"allow"`, AskRewrite -> `"ask"`.
+//    Earlier IDE builds ignored the rewritten input when `permissionDecision`
+//    was `"ask"` (an upstream Bug fixed in a later release), so RTK briefly
+//    collapsed both to `"allow"`. With the fix in place the distinction is
+//    honored again.
+
+/// Run the CodeBuddy PreToolUse hook natively.
+pub fn run_codebuddy() -> Result<()> {
+    let input = read_stdin_limited()?;
+
+    let input = input.trim();
+    if input.is_empty() {
+        return Ok(());
+    }
+
+    let v: Value = match serde_json::from_str(input) {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = writeln!(io::stderr(), "[rtk hook] Failed to parse JSON input: {e}");
+            return Ok(());
+        }
+    };
+
+    let cmd = match v
+        .pointer("/tool_input/command")
+        .and_then(|c| c.as_str())
+        .filter(|c| !c.is_empty())
+    {
+        Some(c) => c.to_string(),
+        None => return Ok(()),
+    };
+
+    // Use CodeBuddy's own permission settings, not Claude's.
+    let decision = decide_hook_action(&cmd, permissions::Host::CodeBuddy);
+
+    if let Some(response) = codebuddy_response_from_decision(&v, &cmd, decision) {
+        let _ = writeln!(io::stdout(), "{response}");
+    }
+    Ok(())
+}
+
+/// Build the CodeBuddy `PreToolUse` hook response for a verdict, mirroring RTK's
+/// own ask/allow distinction. `Deny`/`AllowRewrite`/`AskRewrite` return a
+/// response; `Defer` returns `None` (no output, command untouched).
+///
+/// CodeBuddy differs from Claude Code by requiring top-level `"continue": true`.
+/// It reads the same `updatedInput` field as Claude Code (CodeBuddy's older IDE
+/// builds used `modifiedInput`, but upstream has converged on `updatedInput`, so
+/// RTK emits `updatedInput` for both). Earlier IDE builds ignored the rewritten
+/// input when `permissionDecision` was `"ask"` — an upstream Bug fixed in a
+/// later release — so RTK briefly collapsed both rewrites to `"allow"`. With the
+/// fix in place the ask/allow distinction is honored again.
+fn codebuddy_response_from_decision(v: &Value, cmd: &str, decision: HookDecision) -> Option<Value> {
+    let (permission, reason, rewritten) = match decision {
+        HookDecision::Defer => return None,
+        HookDecision::Deny => {
+            audit_log("deny", cmd, "");
+            ("deny", "Blocked by RTK permission rule", None)
+        }
+        HookDecision::AllowRewrite(r) => {
+            audit_log("rewrite", cmd, &r);
+            ("allow", "RTK auto-rewrite", Some(r))
+        }
+        HookDecision::AskRewrite(r) => {
+            audit_log("ask", cmd, &r);
+            ("ask", "RTK auto-rewrite", Some(r))
+        }
+    };
+
+    let mut hook_output = json!({
+        "hookEventName": PRE_TOOL_USE_KEY,
+        "permissionDecision": permission,
+        "permissionDecisionReason": reason,
+    });
+    if let Some(rewritten) = rewritten {
+        hook_output["updatedInput"] = build_updated_input(v, rewritten);
+    }
+    Some(json!({
+        "continue": true,
+        "permissionDecision": permission,
+        "hookSpecificOutput": hook_output,
+    }))
 }
 
 // ── Cursor native hook ─────────────────────────────────────────
@@ -833,13 +929,7 @@ fn droid_response_from_decision(v: &Value, cmd: &str, decision: HookDecision) ->
 
     audit_log("rewrite", cmd, &rewritten);
 
-    let updated_input = {
-        let mut ti = v.get("tool_input").cloned().unwrap_or_else(|| json!({}));
-        if let Some(obj) = ti.as_object_mut() {
-            obj.insert("command".into(), Value::String(rewritten));
-        }
-        ti
-    };
+    let updated_input = build_updated_input(v, rewritten);
 
     Some(json!({
         "hookSpecificOutput": {
@@ -1563,6 +1653,66 @@ mod tests {
         // `continue: true` keeps the Cursor preToolUse panel from collapsing
         // to `Output: {}`; without it the rewrite is invisible to users.
         assert_eq!(v["continue"], true);
+    }
+
+    // ── CodeBuddy hook ──────────────────────────────────────────
+
+    fn codebuddy_payload(cmd: &str) -> Value {
+        json!({ "tool_name": "Bash", "tool_input": { "command": cmd } })
+    }
+
+    #[test]
+    fn test_codebuddy_allow_rewrite_sets_allow_with_updated_input() {
+        let v = codebuddy_payload("git status");
+        let r = codebuddy_response_from_decision(
+            &v,
+            "git status",
+            HookDecision::AllowRewrite("rtk git status".into()),
+        )
+        .unwrap();
+        assert_eq!(r["continue"], true);
+        assert_eq!(r["permissionDecision"], "allow");
+        assert_eq!(r["hookSpecificOutput"]["permissionDecision"], "allow");
+        assert_eq!(
+            r["hookSpecificOutput"]["updatedInput"]["command"],
+            "rtk git status"
+        );
+    }
+
+    #[test]
+    fn test_codebuddy_ask_rewrite_sets_ask_with_updated_input() {
+        let v = codebuddy_payload("git status");
+        let r = codebuddy_response_from_decision(
+            &v,
+            "git status",
+            HookDecision::AskRewrite("rtk git status".into()),
+        )
+        .unwrap();
+        assert_eq!(r["continue"], true);
+        assert_eq!(r["permissionDecision"], "ask");
+        assert_eq!(r["hookSpecificOutput"]["permissionDecision"], "ask");
+        assert_eq!(
+            r["hookSpecificOutput"]["updatedInput"]["command"],
+            "rtk git status"
+        );
+    }
+
+    #[test]
+    fn test_codebuddy_deny_omits_updated_input() {
+        let v = codebuddy_payload("git status");
+        let r = codebuddy_response_from_decision(&v, "git status", HookDecision::Deny).unwrap();
+        assert_eq!(r["permissionDecision"], "deny");
+        assert_eq!(
+            r["hookSpecificOutput"]["permissionDecisionReason"],
+            "Blocked by RTK permission rule"
+        );
+        assert!(r["hookSpecificOutput"].get("updatedInput").is_none());
+    }
+
+    #[test]
+    fn test_codebuddy_defer_returns_none() {
+        let v = codebuddy_payload("git status");
+        assert!(codebuddy_response_from_decision(&v, "git status", HookDecision::Defer).is_none());
     }
 
     #[test]

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -705,11 +705,7 @@ pub fn run_codebuddy() -> Result<()> {
         }
     };
 
-    let cmd = match v
-        .pointer("/tool_input/command")
-        .and_then(|c| c.as_str())
-        .filter(|c| !c.is_empty())
-    {
+    let cmd = match codebuddy_execute_command(&v) {
         Some(c) => c.to_string(),
         None => return Ok(()),
     };
@@ -721,6 +717,22 @@ pub fn run_codebuddy() -> Result<()> {
         let _ = writeln!(io::stdout(), "{response}");
     }
     Ok(())
+}
+
+/// Extract the shell command when the payload targets CodeBuddy's shell tool.
+///
+/// CodeBuddy uses `Bash` in CLI mode and `execute_command` in IDE mode (the
+/// installed matcher is `Bash|execute_command`). Tolerate a missing `tool_name`
+/// defensively, mirroring `droid_execute_command`.
+fn codebuddy_execute_command(v: &Value) -> Option<&str> {
+    let tool_name = v.get("tool_name").and_then(|t| t.as_str()).unwrap_or("");
+    if !matches!(tool_name, "Bash" | "execute_command" | "") {
+        return None;
+    }
+
+    v.pointer("/tool_input/command")
+        .and_then(|c| c.as_str())
+        .filter(|c| !c.is_empty())
 }
 
 /// Build the CodeBuddy `PreToolUse` hook response for a verdict, mirroring RTK's

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -2599,8 +2599,14 @@ fn write_rtk_block(
     Ok(action)
 }
 
-/// Patch CLAUDE.md: add @RTK.md, migrate if old block exists
+/// Patch an agent markdown file: add @RTK.md, migrate if old block exists
 fn patch_claude_md(path: &Path, ctx: InitContext) -> Result<bool> {
+    patch_md_with_ref(path, CLAUDE_MD, ctx)
+}
+
+/// Patch an agent markdown file (e.g. CLAUDE.md, CODEBUDDY.md): add @RTK.md,
+/// migrate if old block exists. `md_name` is used only for log/dry-run output.
+fn patch_md_with_ref(path: &Path, md_name: &str, ctx: InitContext) -> Result<bool> {
     let InitContext { verbose, dry_run } = ctx;
     let mut content = if path.exists() {
         fs::read_to_string(path)?
@@ -2617,7 +2623,7 @@ fn patch_claude_md(path: &Path, ctx: InitContext) -> Result<bool> {
             content = new_content;
             migrated = true;
             if verbose > 0 {
-                eprintln!("Migrated: removed old RTK block from CLAUDE.md");
+                eprintln!("Migrated: removed old RTK block from {}", md_name);
             }
         }
     }
@@ -2625,12 +2631,13 @@ fn patch_claude_md(path: &Path, ctx: InitContext) -> Result<bool> {
     // Check if @RTK.md already present
     if content.contains(RTK_MD_REF) {
         if verbose > 0 {
-            eprintln!("@RTK.md reference already present in CLAUDE.md");
+            eprintln!("@RTK.md reference already present in {}", md_name);
         }
         if migrated {
             if dry_run {
                 println!(
-                    "[dry-run] would migrate old RTK block in CLAUDE.md: {}",
+                    "[dry-run] would migrate old RTK block in {}: {}",
+                    md_name,
                     path.display()
                 );
             } else {
@@ -2649,7 +2656,8 @@ fn patch_claude_md(path: &Path, ctx: InitContext) -> Result<bool> {
 
     if dry_run {
         println!(
-            "[dry-run] would add @RTK.md reference to CLAUDE.md: {}",
+            "[dry-run] would add @RTK.md reference to {}: {}",
+            md_name,
             path.display()
         );
         if verbose > 0 {
@@ -2659,7 +2667,7 @@ fn patch_claude_md(path: &Path, ctx: InitContext) -> Result<bool> {
         fs::write(path, new_content)?;
 
         if verbose > 0 {
-            eprintln!("Added @RTK.md reference to CLAUDE.md");
+            eprintln!("Added @RTK.md reference to {}", md_name);
         }
     }
 
@@ -5235,7 +5243,7 @@ pub fn run_codebuddy_mode(
     // 2. Patch CODEBUDDY.md (add @RTK.md reference, migrate old blocks)
     if !hook_only {
         let codebuddy_md_path = codebuddy_dir.join(CODEBUDDY_MD);
-        patch_claude_md(&codebuddy_md_path, ctx)?;
+        patch_md_with_ref(&codebuddy_md_path, CODEBUDDY_MD, ctx)?;
     }
 
     // 3. Patch ~/.codebuddy/settings.json with the PreToolUse hook
@@ -5267,8 +5275,9 @@ pub fn run_codebuddy_mode(
             PatchResult::Declined | PatchResult::Skipped => {
                 println!(
                     "\n  To add manually, patch ~/.codebuddy/settings.json:\n  \
-                     {{\"hooks\": {{\"PreToolUse\": [{{\"matcher\": \"Bash|execute_command\", \"hooks\": \
-                     [{{\"type\": \"command\", \"command\": \"rtk hook codebuddy\"}}]}}]}}}}"
+                     {{\"hooks\": {{\"PreToolUse\": [{{\"matcher\": \"{}\", \"hooks\": \
+                     [{{\"type\": \"command\", \"command\": \"{}\"}}]}}]}}}}",
+                    CODEBUDDY_MATCHER, CODEBUDDY_HOOK_COMMAND
                 );
             }
         }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -8,18 +8,20 @@ use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 
 use crate::hooks::constants::{
-    CONFIG_DIR, COPILOT_HOME_ENV, COPILOT_HOOK_FILE, COPILOT_INSTRUCTIONS_FILE, COPILOT_USER_DIR,
-    CURSOR_DIR, GEMINI_DIR, GITHUB_DIR, OPENCODE_PLUGIN_FILE, OPENCODE_SUBDIR, PLUGIN_SUBDIR,
+    CODEBUDDY_DIR, CONFIG_DIR, COPILOT_HOME_ENV, COPILOT_HOOK_FILE, COPILOT_INSTRUCTIONS_FILE,
+    COPILOT_USER_DIR, CURSOR_DIR, GEMINI_DIR, GITHUB_DIR, OPENCODE_PLUGIN_FILE, OPENCODE_SUBDIR,
+    PLUGIN_SUBDIR,
 };
 
 use super::constants::{
-    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND, DROID_DIR,
-    DROID_EXECUTE_MATCHER, DROID_HOME_ENV, DROID_HOOKS_FILE, DROID_HOOKS_SUBDIR,
-    DROID_HOOK_COMMAND, DROID_SETTINGS_FILE, GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR,
-    HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON,
-    HOOKS_SUBDIR, PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR,
-    PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON, VIBE_BASH_MATCH, VIBE_DIR,
-    VIBE_HOOKS_FILE, VIBE_HOOK_COMMAND, VIBE_HOOK_NAME, VIBE_PROMPTS_SUBDIR, VIBE_PROMPT_FILE,
+    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEBUDDY_HOOK_COMMAND, CODEBUDDY_MATCHER,
+    CODEX_DIR, CURSOR_HOOK_COMMAND, DROID_DIR, DROID_EXECUTE_MATCHER, DROID_HOME_ENV,
+    DROID_HOOKS_FILE, DROID_HOOKS_SUBDIR, DROID_HOOK_COMMAND, DROID_SETTINGS_FILE,
+    GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_INIT_FILE,
+    HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON, HOOKS_SUBDIR,
+    PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR, PI_PLUGIN_FILE,
+    PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON, VIBE_BASH_MATCH, VIBE_DIR, VIBE_HOOKS_FILE,
+    VIBE_HOOK_COMMAND, VIBE_HOOK_NAME, VIBE_PROMPTS_SUBDIR, VIBE_PROMPT_FILE,
 };
 use super::integrity;
 use super::is_claude_hook_command;
@@ -33,6 +35,16 @@ const PI_PLUGIN: &str = include_str!("../../hooks/pi/rtk.ts");
 // Embedded slim RTK awareness instructions
 const RTK_SLIM: &str = include_str!("../../hooks/claude/rtk-awareness.md");
 const RTK_SLIM_CODEX: &str = include_str!("../../hooks/codex/rtk-awareness.md");
+
+/// Build agent-specific slim RTK awareness markdown from the shared Claude
+/// template. Only the agent display name and the trailing markdown-filename
+/// reference differ between agents that reuse this format (e.g. CodeBuddy).
+/// Agents with a distinct format (Codex) ship their own `rtk-awareness.md`.
+fn rtk_awareness_for_agent(agent_name: &str, md_filename: &str) -> String {
+    RTK_SLIM
+        .replace("Claude Code", agent_name)
+        .replace("CLAUDE.md", md_filename)
+}
 
 /// Template written by `rtk init` when no filters.toml exists yet.
 const FILTERS_TEMPLATE: &str = r#"# Project-local RTK filters — commit this file with your repo.
@@ -80,6 +92,17 @@ pub enum PatchMode {
     Ask,  // Default: prompt user [y/N]
     Auto, // --auto-patch: no prompt
     Skip, // --no-patch: manual instructions
+}
+
+/// Resolve the patch mode from the CLI flags shared by every agent path.
+pub fn patch_mode_from_flags(auto_patch: bool, no_patch: bool) -> PatchMode {
+    if auto_patch {
+        PatchMode::Auto
+    } else if no_patch {
+        PatchMode::Skip
+    } else {
+        PatchMode::Ask
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
@@ -548,7 +571,9 @@ fn print_manual_instructions(hook_command: &str, include_opencode: bool) {
     }
 }
 
-fn remove_hook_from_json(root: &mut serde_json::Value) -> bool {
+/// Remove hook entries from parsed settings.json that match the given
+/// command or the legacy `rtk-rewrite.sh` script path.
+fn remove_matching_hooks_from_json(root: &mut serde_json::Value, hook_command: &str) -> bool {
     let hooks = match root
         .get_mut("hooks")
         .and_then(|h| h.get_mut(PRE_TOOL_USE_KEY))
@@ -567,8 +592,16 @@ fn remove_hook_from_json(root: &mut serde_json::Value) -> bool {
         if let Some(hooks_array) = entry.get("hooks").and_then(|h| h.as_array()) {
             for hook in hooks_array {
                 if let Some(command) = hook.get("command").and_then(|c| c.as_str()) {
-                    // Match both legacy script path and new binary command
-                    if command.contains(REWRITE_HOOK_FILE) || is_claude_hook_command(command) {
+                    // Match legacy script path, exact hook command, or (Claude path
+                    // only) absolute-path variants of `rtk hook claude`. The
+                    // absolute-path branch is gated on `hook_command ==
+                    // CLAUDE_HOOK_COMMAND`, so non-Claude agents (e.g. CodeBuddy,
+                    // which passes `rtk hook codebuddy`) match only their own exact
+                    // command and never inherit Claude's path-resolution logic.
+                    if command.contains(REWRITE_HOOK_FILE)
+                        || command == hook_command
+                        || (hook_command == CLAUDE_HOOK_COMMAND && is_claude_hook_command(command))
+                    {
                         return false;
                     }
                 }
@@ -580,12 +613,16 @@ fn remove_hook_from_json(root: &mut serde_json::Value) -> bool {
     pre_tool_use_array.len() < original_len
 }
 
-/// Remove RTK hook from settings.json file
-/// Backs up before modification, returns true if hook was found and removed
-fn remove_hook_from_settings(ctx: InitContext) -> Result<bool> {
+/// Remove RTK hook entries from a settings.json file at the given path.
+/// Matches a hook command equal to `hook_command` or containing
+/// `REWRITE_HOOK_FILE` (legacy script path).
+/// Backs up before modification, returns true if hook was found and removed.
+fn remove_hooks_from_settings_at(
+    settings_path: &Path,
+    hook_command: &str,
+    ctx: InitContext,
+) -> Result<bool> {
     let InitContext { verbose, dry_run } = ctx;
-    let claude_dir = resolve_claude_dir()?;
-    let settings_path = claude_dir.join(SETTINGS_JSON);
 
     if !settings_path.exists() {
         if verbose > 0 {
@@ -594,7 +631,7 @@ fn remove_hook_from_settings(ctx: InitContext) -> Result<bool> {
         return Ok(false);
     }
 
-    let content = fs::read_to_string(&settings_path)
+    let content = fs::read_to_string(settings_path)
         .with_context(|| format!("Failed to read {}", settings_path.display()))?;
 
     if content.trim().is_empty() {
@@ -604,7 +641,7 @@ fn remove_hook_from_settings(ctx: InitContext) -> Result<bool> {
     let mut root: serde_json::Value = serde_json::from_str(&content)
         .with_context(|| format!("Failed to parse {} as JSON", settings_path.display()))?;
 
-    let removed = remove_hook_from_json(&mut root);
+    let removed = remove_matching_hooks_from_json(&mut root, hook_command);
 
     if removed {
         if dry_run {
@@ -622,20 +659,27 @@ fn remove_hook_from_settings(ctx: InitContext) -> Result<bool> {
 
         // Backup original
         let backup_path = settings_path.with_extension("json.bak");
-        fs::copy(&settings_path, &backup_path)
+        fs::copy(settings_path, &backup_path)
             .with_context(|| format!("Failed to backup to {}", backup_path.display()))?;
 
         // Atomic write
         let serialized =
             serde_json::to_string_pretty(&root).context("Failed to serialize settings.json")?;
-        atomic_write(&settings_path, &serialized)?;
+        atomic_write(settings_path, &serialized)?;
 
         if verbose > 0 {
-            eprintln!("Removed RTK hook from settings.json");
+            eprintln!("Removed RTK hook from {}", settings_path.display());
         }
     }
 
     Ok(removed)
+}
+
+/// Remove RTK hook from Claude's settings.json (backward-compatible wrapper).
+fn remove_hook_from_settings(ctx: InitContext) -> Result<bool> {
+    let claude_dir = resolve_claude_dir()?;
+    let settings_path = claude_dir.join(SETTINGS_JSON);
+    remove_hooks_from_settings_at(&settings_path, CLAUDE_HOOK_COMMAND, ctx)
 }
 
 /// Full uninstall for Claude, Gemini, Codex, Cursor, or Pi artifacts.
@@ -647,7 +691,10 @@ pub fn uninstall(
     pi: bool,
     ctx: InitContext,
 ) -> Result<()> {
-    let InitContext { verbose, dry_run } = ctx;
+    let InitContext {
+        verbose: _,
+        dry_run,
+    } = ctx;
     if codex {
         uninstall_codex(global, ctx)?;
         if dry_run {
@@ -761,68 +808,12 @@ pub fn uninstall(
 
     // 3. Remove @RTK.md reference from CLAUDE.md
     let claude_md_path = claude_dir.join(CLAUDE_MD);
-    if claude_md_path.exists() {
-        let content = fs::read_to_string(&claude_md_path)
-            .with_context(|| format!("Failed to read CLAUDE.md: {}", claude_md_path.display()))?;
-
-        let mut claude_md_changed = false;
-        let mut working_content = content.clone();
-
-        if working_content.contains(RTK_MD_REF) {
-            let new_content = working_content
-                .lines()
-                .filter(|line| !line.trim().starts_with(RTK_MD_REF))
-                .collect::<Vec<_>>()
-                .join("\n");
-
-            working_content = clean_double_blanks(&new_content);
-            claude_md_changed = true;
-            removed.push("CLAUDE.md: removed @RTK.md reference".to_string());
-        }
-
-        if working_content.contains(RTK_BLOCK_START) {
-            let (cleaned, did_remove) = remove_rtk_block(&working_content);
-            if did_remove {
-                working_content = cleaned;
-                claude_md_changed = true;
-                removed.push("CLAUDE.md: removed rtk-instructions block".to_string());
-            }
-        }
-
-        if claude_md_changed {
-            let trimmed = working_content.trim();
-            if trimmed.is_empty() {
-                if dry_run {
-                    println!(
-                        "[dry-run] would remove CLAUDE.md (empty after cleanup): {}",
-                        claude_md_path.display()
-                    );
-                } else {
-                    // nosemgrep: filesystem-deletion
-                    fs::remove_file(&claude_md_path).with_context(|| {
-                        format!(
-                            "Failed to remove empty CLAUDE.md: {}",
-                            claude_md_path.display()
-                        )
-                    })?;
-                }
-                removed.retain(|r| !r.starts_with("CLAUDE.md:"));
-                removed.push("CLAUDE.md: removed (was empty after cleanup)".to_string());
-            } else if dry_run {
-                println!(
-                    "[dry-run] would update CLAUDE.md: {}",
-                    claude_md_path.display()
-                );
-                if verbose > 0 {
-                    println!("[dry-run] content:\n{}", working_content);
-                }
-            } else {
-                fs::write(&claude_md_path, &working_content).with_context(|| {
-                    format!("Failed to write CLAUDE.md: {}", claude_md_path.display())
-                })?;
-            }
-        }
-    }
+    removed.extend(remove_rtk_refs_from_md(
+        &claude_md_path,
+        CLAUDE_MD,
+        &[RTK_MD_REF],
+        ctx,
+    )?);
 
     // 4. Remove hook entry from settings.json
     if remove_hook_from_settings(ctx)? {
@@ -958,15 +949,54 @@ fn patch_settings_json_command(
     include_opencode: bool,
     ctx: InitContext,
 ) -> Result<PatchResult> {
-    let InitContext { verbose, dry_run } = ctx;
     let claude_dir = resolve_claude_dir()?;
     let settings_path = claude_dir.join(SETTINGS_JSON);
+
+    let result = patch_settings_json_at(&claude_dir, hook_command, "Bash", mode, ctx)?;
+
+    // Claude Code shows manual instructions when the user skips or declines
+    // (so the user can still wire the hook by hand if they want).
+    if matches!(result, PatchResult::Skipped | PatchResult::Declined) {
+        print_manual_instructions(hook_command, include_opencode);
+    }
+
+    // Claude-specific success output (backup hint + restart notice)
+    if result == PatchResult::Patched {
+        if settings_path.with_extension("json.bak").exists() {
+            println!(
+                "  Backup: {}",
+                settings_path.with_extension("json.bak").display()
+            );
+        }
+        if include_opencode {
+            println!("  Restart Claude Code and OpenCode. Test with: git status");
+        } else {
+            println!("  Restart Claude Code. Test with: git status");
+        }
+    }
+
+    Ok(result)
+}
+
+/// Patch settings.json in the given agent config directory with the RTK PreToolUse hook.
+///
+/// `patch_settings_json_command` (Claude) is a thin wrapper that adds Claude-specific
+/// manual-instruction output and restart notices around this core helper. Other agents
+/// (e.g. CodeBuddy's `~/.codebuddy/`) call this directly with their own dir.
+fn patch_settings_json_at(
+    agent_dir: &Path,
+    hook_command: &str,
+    matcher: &str,
+    mode: PatchMode,
+    ctx: InitContext,
+) -> Result<PatchResult> {
+    let InitContext { verbose, dry_run } = ctx;
+    let settings_path = agent_dir.join(SETTINGS_JSON);
 
     // Read or create settings.json
     let mut root = if settings_path.exists() {
         let content = fs::read_to_string(&settings_path)
             .with_context(|| format!("Failed to read {}", settings_path.display()))?;
-
         if content.trim().is_empty() {
             serde_json::json!({})
         } else {
@@ -985,30 +1015,24 @@ fn patch_settings_json_command(
         return Ok(PatchResult::AlreadyPresent);
     }
 
-    // Handle mode
     match mode {
         PatchMode::Skip => {
-            print_manual_instructions(hook_command, include_opencode);
             return Ok(PatchResult::Skipped);
         }
         PatchMode::Ask => {
-            // Skip the interactive prompt in dry-run: we must not mutate state or block on stdin.
             if dry_run {
                 println!(
                     "[dry-run] would prompt before patching {}",
                     settings_path.display()
                 );
             } else if !prompt_user_consent(&settings_path)? {
-                print_manual_instructions(hook_command, include_opencode);
                 return Ok(PatchResult::Declined);
             }
         }
-        PatchMode::Auto => {
-            // Proceed without prompting
-        }
+        PatchMode::Auto => {}
     }
 
-    insert_hook_entry(&mut root, hook_command)?;
+    insert_hook_entry(&mut root, hook_command, matcher)?;
 
     let serialized =
         serde_json::to_string_pretty(&root).context("Failed to serialize settings.json")?;
@@ -1036,19 +1060,7 @@ fn patch_settings_json_command(
 
     // Atomic write
     atomic_write(&settings_path, &serialized)?;
-
     println!("\n  settings.json: hook added");
-    if settings_path.with_extension("json.bak").exists() {
-        println!(
-            "  Backup: {}",
-            settings_path.with_extension("json.bak").display()
-        );
-    }
-    if include_opencode {
-        println!("  Restart Claude Code and OpenCode. Test with: git status");
-    } else {
-        println!("  Restart Claude Code. Test with: git status");
-    }
 
     Ok(PatchResult::Patched)
 }
@@ -1085,7 +1097,11 @@ fn clean_double_blanks(content: &str) -> String {
 
 /// Deep-merge RTK hook entry into settings.json
 /// Creates hooks.PreToolUse structure if missing, preserves existing hooks
-fn insert_hook_entry(root: &mut serde_json::Value, hook_command: &str) -> Result<()> {
+fn insert_hook_entry(
+    root: &mut serde_json::Value,
+    hook_command: &str,
+    matcher: &str,
+) -> Result<()> {
     let root_obj = match root.as_object_mut() {
         Some(obj) => obj,
         None => {
@@ -1107,7 +1123,7 @@ fn insert_hook_entry(root: &mut serde_json::Value, hook_command: &str) -> Result
         .context("PreToolUse value is not an array")?;
 
     pre_tool_use.push(serde_json::json!({
-        "matcher": "Bash",
+        "matcher": matcher,
         "hooks": [{
             "type": "command",
             "command": hook_command
@@ -1134,7 +1150,9 @@ fn hook_already_present(root: &serde_json::Value, hook_command: &str) -> bool {
         .flatten()
         .filter_map(|hook| hook.get("command")?.as_str())
         .any(|cmd| {
-            cmd == hook_command || is_claude_hook_command(cmd) || cmd.contains(REWRITE_HOOK_FILE)
+            cmd == hook_command
+                || cmd.contains(REWRITE_HOOK_FILE)
+                || (hook_command == CLAUDE_HOOK_COMMAND && is_claude_hook_command(cmd))
         })
 }
 
@@ -2823,6 +2841,87 @@ fn remove_rtk_block(content: &str) -> (String, bool) {
     } else {
         (content.to_string(), false)
     }
+}
+
+/// Remove RTK references (`@RTK.md` and `<!-- rtk-instructions ... -->` block)
+/// from an agent markdown file (e.g. CLAUDE.md, CODEBUDDY.md).
+///
+/// Returns a list of human-readable removal descriptions (empty if nothing
+/// was found). Handles dry-run, empty-file deletion, and atomic writes.
+fn remove_rtk_refs_from_md(
+    path: &Path,
+    md_name: &str,
+    refs: &[&str],
+    ctx: InitContext,
+) -> Result<Vec<String>> {
+    let InitContext { dry_run, verbose } = ctx;
+    let mut removed = Vec::new();
+
+    if !path.exists() {
+        return Ok(removed);
+    }
+
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read {}: {}", md_name, path.display()))?;
+
+    let mut working_content = content.clone();
+    let mut changed = false;
+
+    if has_rtk_reference(&working_content, refs) {
+        let new_content = working_content
+            .lines()
+            .filter(|line| {
+                let trimmed = line.trim();
+                !refs.contains(&trimmed)
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        working_content = clean_double_blanks(&new_content);
+        changed = true;
+        removed.push(format!("{}: removed @RTK.md reference", md_name));
+    }
+
+    if working_content.contains(RTK_BLOCK_START) {
+        let (cleaned, did_remove) = remove_rtk_block(&working_content);
+        if did_remove {
+            working_content = cleaned;
+            changed = true;
+            removed.push(format!("{}: removed rtk-instructions block", md_name));
+        }
+    }
+
+    if changed {
+        let trimmed = working_content.trim();
+        if trimmed.is_empty() {
+            if dry_run {
+                println!(
+                    "[dry-run] would remove {} (empty after cleanup): {}",
+                    md_name,
+                    path.display()
+                );
+            } else {
+                // nosemgrep: filesystem-deletion
+                fs::remove_file(path).with_context(|| {
+                    format!("Failed to remove empty {}: {}", md_name, path.display())
+                })?;
+            }
+            removed.retain(|r| !r.starts_with(md_name));
+            removed.push(format!("{}: removed (was empty after cleanup)", md_name));
+        } else if dry_run {
+            println!("[dry-run] would update {}: {}", md_name, path.display());
+            if verbose > 0 {
+                println!("[dry-run] content:\n{}", working_content);
+            }
+        } else {
+            atomic_write(path, &working_content)
+                .with_context(|| format!("Failed to write {}: {}", md_name, path.display()))?;
+            if verbose > 0 {
+                eprintln!("Updated {}: {}", md_name, path.display());
+            }
+        }
+    }
+
+    Ok(removed)
 }
 
 fn resolve_home_subdir(subdir: &str) -> Result<PathBuf> {
@@ -5096,6 +5195,169 @@ fn uninstall_copilot_global_at(copilot_dir: &Path, ctx: InitContext) -> Result<V
     Ok(removed)
 }
 
+// ── CodeBuddy integration ──────────────────────────────
+
+const CODEBUDDY_MD: &str = "CODEBUDDY.md";
+
+fn resolve_codebuddy_dir() -> Result<PathBuf> {
+    resolve_home_subdir(CODEBUDDY_DIR)
+}
+
+/// Entry point for `rtk init -g --agent codebuddy`
+pub fn run_codebuddy_mode(
+    global: bool,
+    hook_only: bool,
+    patch_mode: PatchMode,
+    ctx: InitContext,
+) -> Result<()> {
+    let InitContext { dry_run, .. } = ctx;
+    if !global {
+        anyhow::bail!("CodeBuddy support is global-only. Use: rtk init -g --agent codebuddy");
+    }
+
+    let codebuddy_dir = resolve_codebuddy_dir()?;
+    if !dry_run {
+        fs::create_dir_all(&codebuddy_dir).with_context(|| {
+            format!(
+                "Failed to create CodeBuddy config dir: {}",
+                codebuddy_dir.display()
+            )
+        })?;
+    }
+
+    // 1. Write RTK.md (slim awareness, customized for CodeBuddy)
+    if !hook_only {
+        let rtk_md_path = codebuddy_dir.join(RTK_MD);
+        let rtk_md = rtk_awareness_for_agent("CodeBuddy", CODEBUDDY_MD);
+        write_if_changed(&rtk_md_path, &rtk_md, RTK_MD, ctx)?;
+    }
+
+    // 2. Patch CODEBUDDY.md (add @RTK.md reference, migrate old blocks)
+    if !hook_only {
+        let codebuddy_md_path = codebuddy_dir.join(CODEBUDDY_MD);
+        patch_claude_md(&codebuddy_md_path, ctx)?;
+    }
+
+    // 3. Patch ~/.codebuddy/settings.json with the PreToolUse hook
+    let result = patch_settings_json_at(
+        &codebuddy_dir,
+        CODEBUDDY_HOOK_COMMAND,
+        CODEBUDDY_MATCHER,
+        patch_mode,
+        ctx,
+    )?;
+
+    if dry_run {
+        print_dry_run_footer();
+    } else {
+        println!("\nCodeBuddy hook installed (global).\n");
+        if !hook_only {
+            println!("  RTK.md:       {}", codebuddy_dir.join(RTK_MD).display());
+            println!(
+                "  CODEBUDDY.md: {}",
+                codebuddy_dir.join(CODEBUDDY_MD).display()
+            );
+        }
+        match result {
+            PatchResult::Patched | PatchResult::WouldPatch => {}
+            PatchResult::AlreadyPresent => {
+                println!("  settings.json: hook already present");
+                println!("  Restart CodeBuddy. Test with: git status\n");
+            }
+            PatchResult::Declined | PatchResult::Skipped => {
+                println!(
+                    "\n  To add manually, patch ~/.codebuddy/settings.json:\n  \
+                     {{\"hooks\": {{\"PreToolUse\": [{{\"matcher\": \"Bash|execute_command\", \"hooks\": \
+                     [{{\"type\": \"command\", \"command\": \"rtk hook codebuddy\"}}]}}]}}}}"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Remove CodeBuddy artifacts under the given config dir.
+///
+/// Pure filesystem logic, separated from CLI output so it can be unit-tested.
+/// Returns the list of human-readable removal descriptions (empty if nothing
+/// was found). Does not print anything except dry-run notices.
+fn uninstall_codebuddy_at(codebuddy_dir: &Path, ctx: InitContext) -> Result<Vec<String>> {
+    let InitContext {
+        dry_run,
+        verbose: _,
+    } = ctx;
+    let mut removed = Vec::new();
+
+    // Remove RTK.md
+    let rtk_md_path = codebuddy_dir.join(RTK_MD);
+    if rtk_md_path.exists() {
+        if dry_run {
+            println!("[dry-run] would remove RTK.md: {}", rtk_md_path.display());
+        } else {
+            // nosemgrep: filesystem-deletion
+            fs::remove_file(&rtk_md_path)
+                .with_context(|| format!("Failed to remove RTK.md: {}", rtk_md_path.display()))?;
+        }
+        removed.push(format!("RTK.md: {}", rtk_md_path.display()));
+    }
+
+    // Remove @RTK.md reference from CODEBUDDY.md
+    let codebuddy_md_path = codebuddy_dir.join(CODEBUDDY_MD);
+    removed.extend(remove_rtk_refs_from_md(
+        &codebuddy_md_path,
+        CODEBUDDY_MD,
+        &[RTK_MD_REF],
+        ctx,
+    )?);
+
+    // Remove RTK hook from settings.json
+    let settings_path = codebuddy_dir.join(SETTINGS_JSON);
+    if settings_path.exists()
+        && remove_hooks_from_settings_at(&settings_path, CODEBUDDY_HOOK_COMMAND, ctx)?
+    {
+        removed.push(format!(
+            "settings.json: removed RTK hook entry ({})",
+            settings_path.display()
+        ));
+    }
+
+    Ok(removed)
+}
+
+/// Remove CodeBuddy artifacts during uninstall.
+pub fn uninstall_codebuddy(global: bool, ctx: InitContext) -> Result<()> {
+    let InitContext { dry_run, .. } = ctx;
+    if !global {
+        anyhow::bail!("CodeBuddy uninstall only works with --global flag");
+    }
+
+    let codebuddy_dir = resolve_codebuddy_dir()?;
+    let removed = uninstall_codebuddy_at(&codebuddy_dir, ctx)?;
+
+    if removed.is_empty() {
+        println!("RTK CodeBuddy support was not installed (nothing to remove)");
+    } else {
+        let header = if dry_run {
+            "[dry-run] would uninstall RTK (CodeBuddy):"
+        } else {
+            "RTK uninstalled (CodeBuddy):"
+        };
+        println!("{}", header);
+        for item in &removed {
+            println!("  - {}", item);
+        }
+        if !dry_run {
+            println!("\nRestart CodeBuddy to apply changes.");
+        }
+    }
+
+    if dry_run {
+        print_dry_run_footer();
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -6595,7 +6857,7 @@ mod tests {
         let mut json_content = serde_json::json!({});
         let hook_command = "/Users/test/.claude/hooks/rtk-rewrite.sh";
 
-        insert_hook_entry(&mut json_content, hook_command).unwrap();
+        insert_hook_entry(&mut json_content, hook_command, "Bash").unwrap();
 
         // Should create full structure
         assert!(json_content.get("hooks").is_some());
@@ -6627,7 +6889,7 @@ mod tests {
         });
 
         let hook_command = "/Users/test/.claude/hooks/rtk-rewrite.sh";
-        insert_hook_entry(&mut json_content, hook_command).unwrap();
+        insert_hook_entry(&mut json_content, hook_command, "Bash").unwrap();
 
         let pre_tool_use = json_content["hooks"]["PreToolUse"].as_array().unwrap();
         assert_eq!(pre_tool_use.len(), 2); // Should have both hooks
@@ -6650,7 +6912,7 @@ mod tests {
         });
 
         let hook_command = "/Users/test/.claude/hooks/rtk-rewrite.sh";
-        insert_hook_entry(&mut json_content, hook_command).unwrap();
+        insert_hook_entry(&mut json_content, hook_command, "Bash").unwrap();
 
         // Should preserve all other keys
         assert_eq!(json_content["env"]["PATH"], "/custom/path");
@@ -6754,7 +7016,7 @@ mod tests {
         assert_eq!(clean_double_blanks(input), input); // No change
     }
 
-    // Tests for remove_hook_from_settings()
+    // Tests for remove_hooks_from_settings_at() / remove_matching_hooks_from_json()
     #[test]
     fn test_remove_hook_from_json() {
         let mut json_content = serde_json::json!({
@@ -6778,7 +7040,7 @@ mod tests {
             }
         });
 
-        let removed = remove_hook_from_json(&mut json_content);
+        let removed = remove_matching_hooks_from_json(&mut json_content, CLAUDE_HOOK_COMMAND);
         assert!(removed);
 
         // Should have only one hook left
@@ -6813,7 +7075,7 @@ mod tests {
             }
         });
 
-        let removed = remove_hook_from_json(&mut json_content);
+        let removed = remove_matching_hooks_from_json(&mut json_content, CLAUDE_HOOK_COMMAND);
         assert!(removed);
 
         let pre_tool_use = json_content["hooks"]["PreToolUse"].as_array().unwrap();
@@ -6847,7 +7109,7 @@ mod tests {
             }
         });
 
-        let removed = remove_hook_from_json(&mut json_content);
+        let removed = remove_matching_hooks_from_json(&mut json_content, CLAUDE_HOOK_COMMAND);
         assert!(removed);
 
         let pre_tool_use = json_content["hooks"]["PreToolUse"].as_array().unwrap();
@@ -6872,7 +7134,7 @@ mod tests {
             }
         });
 
-        let removed = remove_hook_from_json(&mut json_content);
+        let removed = remove_matching_hooks_from_json(&mut json_content, CLAUDE_HOOK_COMMAND);
         assert!(!removed);
     }
 
@@ -8383,5 +8645,79 @@ mod tests {
         uninstall_vibe_at(&vibe_dir, InitContext::default()).unwrap();
 
         assert!(!vibe_dir.join(VIBE_HOOKS_FILE).exists());
+    }
+
+    // ── uninstall_codebuddy_at ───────────────────────────────────
+
+    #[test]
+    fn test_uninstall_codebuddy_at_removes_md_and_hook() {
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path();
+
+        // Write RTK.md (will be removed)
+        fs::write(dir.join(RTK_MD), "rtk awareness").unwrap();
+        // Write CODEBUDDY.md with @RTK.md reference (reference will be removed, file kept if has other content)
+        fs::write(dir.join(CODEBUDDY_MD), "my rules\n\n@RTK.md\n").unwrap();
+        let settings = dir.join(SETTINGS_JSON);
+        fs::write(
+            &settings,
+            serde_json::json!({
+                "hooks": {
+                    "PreToolUse": [
+                        {"matcher": "Bash", "hooks": [{"type": "command", "command": CODEBUDDY_HOOK_COMMAND}]}
+                    ]
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let removed = uninstall_codebuddy_at(dir, InitContext::default()).unwrap();
+
+        assert_eq!(removed.len(), 3);
+        assert!(!dir.join(RTK_MD).exists());
+        // CODEBUDDY.md still exists but @RTK.md reference was removed
+        assert!(dir.join(CODEBUDDY_MD).exists());
+        let codebuddy_md_content = fs::read_to_string(dir.join(CODEBUDDY_MD)).unwrap();
+        assert!(!codebuddy_md_content.contains(RTK_MD_REF));
+        assert!(codebuddy_md_content.contains("my rules"));
+        let settings_content = fs::read_to_string(&settings).unwrap();
+        assert!(!settings_content.contains(CODEBUDDY_HOOK_COMMAND));
+    }
+
+    #[test]
+    fn test_uninstall_codebuddy_at_idempotent_when_nothing_installed() {
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path();
+
+        let removed = uninstall_codebuddy_at(dir, InitContext::default()).unwrap();
+
+        assert!(removed.is_empty());
+    }
+
+    #[test]
+    fn test_uninstall_codebuddy_at_preserves_third_party_hooks() {
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path();
+
+        let settings = dir.join(SETTINGS_JSON);
+        fs::write(
+            &settings,
+            serde_json::json!({
+                "hooks": {
+                    "PreToolUse": [
+                        {"matcher": "Bash", "hooks": [{"type": "command", "command": "other-agent-hook"}]}
+                    ]
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let removed = uninstall_codebuddy_at(dir, InitContext::default()).unwrap();
+
+        assert!(removed.is_empty());
+        let content = fs::read_to_string(&settings).unwrap();
+        assert!(content.contains("other-agent-hook"));
     }
 }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -2875,12 +2875,14 @@ fn remove_rtk_refs_from_md(
     let mut working_content = content.clone();
     let mut changed = false;
 
-    if has_rtk_reference(&working_content, refs) {
+    // Substring check (not exact line match) so a reference line carrying a
+    // trailing comment (e.g. `@RTK.md — see below`) still triggers cleanup.
+    if refs.iter().any(|r| working_content.contains(r)) {
         let new_content = working_content
             .lines()
             .filter(|line| {
                 let trimmed = line.trim();
-                !refs.contains(&trimmed)
+                !refs.iter().any(|r| trimmed.starts_with(r))
             })
             .collect::<Vec<_>>()
             .join("\n");
@@ -8692,6 +8694,56 @@ mod tests {
         assert!(codebuddy_md_content.contains("my rules"));
         let settings_content = fs::read_to_string(&settings).unwrap();
         assert!(!settings_content.contains(CODEBUDDY_HOOK_COMMAND));
+    }
+
+    // ── remove_rtk_refs_from_md ─────────────────────────────────
+
+    #[test]
+    fn test_remove_rtk_refs_from_md_strips_trailing_comment_reference() {
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path();
+
+        // Only a reference line carrying a trailing comment — the exact-match
+        // regression left this behind, and it must be stripped (issue flagged
+        // by maintainer review).
+        let md = dir.join(CLAUDE_MD);
+        fs::write(
+            &md,
+            "my rules\n\n@RTK.md — see this for token-saving instructions\n",
+        )
+        .unwrap();
+
+        let removed =
+            remove_rtk_refs_from_md(&md, CLAUDE_MD, &[RTK_MD_REF], InitContext::default()).unwrap();
+
+        assert_eq!(
+            removed,
+            vec!["CLAUDE.md: removed @RTK.md reference".to_string()]
+        );
+        let content = fs::read_to_string(&md).unwrap();
+        assert!(!content.contains(RTK_MD_REF));
+        assert!(content.contains("my rules"));
+    }
+
+    #[test]
+    fn test_remove_rtk_refs_from_md_strips_mixed_reference_lines() {
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path();
+
+        // A plain reference plus one with trailing text: both must go.
+        let md = dir.join(CLAUDE_MD);
+        fs::write(&md, "my rules\n\n@RTK.md\n@RTK.md — token notes\n").unwrap();
+
+        let removed =
+            remove_rtk_refs_from_md(&md, CLAUDE_MD, &[RTK_MD_REF], InitContext::default()).unwrap();
+
+        assert_eq!(
+            removed,
+            vec!["CLAUDE.md: removed @RTK.md reference".to_string()]
+        );
+        let content = fs::read_to_string(&md).unwrap();
+        assert!(!content.contains(RTK_MD_REF));
+        assert!(content.contains("my rules"));
     }
 
     #[test]

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -1,6 +1,6 @@
 use super::constants::{
-    CLAUDE_DIR, CURSOR_DIR, DROID_DIR, DROID_HOME_ENV, DROID_SETTINGS_FILE, GEMINI_DIR,
-    SETTINGS_JSON, SETTINGS_LOCAL_JSON,
+    CLAUDE_DIR, CODEBUDDY_DIR, CURSOR_DIR, DROID_DIR, DROID_HOME_ENV, DROID_SETTINGS_FILE,
+    GEMINI_DIR, SETTINGS_JSON, SETTINGS_LOCAL_JSON,
 };
 use crate::core::stream::exec_capture;
 use crate::discover::lexer::split_for_permissions;
@@ -37,6 +37,7 @@ pub enum Host {
     Gemini,
     Droid,
     Vibe,
+    CodeBuddy,
 }
 
 pub fn check_command_for(cmd: &str, host: Host) -> PermissionVerdict {
@@ -46,6 +47,7 @@ pub fn check_command_for(cmd: &str, host: Host) -> PermissionVerdict {
         Host::Gemini => load_gemini_rules(),
         Host::Droid => load_droid_rules(),
         Host::Vibe => (Vec::new(), Vec::new(), Vec::new()),
+        Host::CodeBuddy => load_codebuddy_rules(),
     };
     check_command_with_rules(cmd, &deny_rules, &ask_rules, &allow_rules)
 }
@@ -178,13 +180,62 @@ fn append_bash_rules(rules_value: Option<&Value>, target: &mut Vec<String>) {
 fn get_settings_paths() -> Vec<PathBuf> {
     let mut paths = Vec::new();
 
-    if let Some(root) = find_project_root() {
+    if let Some(root) = find_project_root(CLAUDE_DIR) {
         paths.push(root.join(CLAUDE_DIR).join(SETTINGS_JSON));
         paths.push(root.join(CLAUDE_DIR).join(SETTINGS_LOCAL_JSON));
     }
     if let Some(home) = dirs::home_dir() {
         paths.push(home.join(CLAUDE_DIR).join(SETTINGS_JSON));
         paths.push(home.join(CLAUDE_DIR).join(SETTINGS_LOCAL_JSON));
+    }
+
+    paths
+}
+
+/// Load deny, ask, and allow Bash rules from CodeBuddy settings files.
+///
+/// CodeBuddy uses the same `Bash(pattern)` syntax as Claude Code,
+/// stored under `permissions.deny` / `permissions.ask` / `permissions.allow`
+/// in `.codebuddy/settings.json` and `.codebuddy/settings.local.json`.
+fn load_codebuddy_rules() -> (Vec<String>, Vec<String>, Vec<String>) {
+    let mut deny_rules = Vec::new();
+    let mut ask_rules = Vec::new();
+    let mut allow_rules = Vec::new();
+
+    for path in get_codebuddy_settings_paths() {
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(json) = serde_json::from_str::<Value>(&content) else {
+            eprintln!(
+                "[rtk] warning: failed to parse permissions from {}",
+                path.display()
+            );
+            continue;
+        };
+        let Some(permissions) = json.get("permissions") else {
+            continue;
+        };
+
+        append_bash_rules(permissions.get("deny"), &mut deny_rules);
+        append_bash_rules(permissions.get("ask"), &mut ask_rules);
+        append_bash_rules(permissions.get("allow"), &mut allow_rules);
+    }
+
+    (deny_rules, ask_rules, allow_rules)
+}
+
+/// Return the ordered list of CodeBuddy settings file paths to check.
+fn get_codebuddy_settings_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    if let Some(root) = find_project_root(CODEBUDDY_DIR) {
+        paths.push(root.join(CODEBUDDY_DIR).join(SETTINGS_JSON));
+        paths.push(root.join(CODEBUDDY_DIR).join(SETTINGS_LOCAL_JSON));
+    }
+    if let Some(home) = dirs::home_dir() {
+        paths.push(home.join(CODEBUDDY_DIR).join(SETTINGS_JSON));
+        paths.push(home.join(CODEBUDDY_DIR).join(SETTINGS_LOCAL_JSON));
     }
 
     paths
@@ -258,7 +309,7 @@ fn gemini_settings() -> Option<Value> {
             })
             .unwrap_or(false);
     if trusted {
-        if let Some(root) = find_project_root() {
+        if let Some(root) = find_project_root(GEMINI_DIR) {
             if let Some(v) = read_json(&root.join(GEMINI_DIR).join(SETTINGS_JSON)) {
                 return Some(v);
             }
@@ -290,7 +341,7 @@ fn droid_settings_scopes() -> Vec<Value> {
     {
         dirs_to_read.push(home.join(DROID_DIR));
     }
-    if let Some(root) = find_project_root() {
+    if let Some(root) = find_project_root(DROID_DIR) {
         dirs_to_read.push(root.join(DROID_DIR));
     }
 
@@ -336,14 +387,19 @@ pub(crate) fn droid_rules_from_settings(
     (deny, Vec::new(), Vec::new())
 }
 
-/// Locate the project root by walking up from CWD looking for `.claude/`.
+/// Locate the project root by walking up from CWD looking for `agent_dir`.
+///
+/// Only the caller's own agent config dir is considered, so a sibling agent's
+/// dir (e.g. `.codebuddy/` in a subdir) never steals the root from another
+/// host (e.g. Claude's `.claude/` at the repo root) — each host's deny/ask
+/// rules keep applying independently.
 ///
 /// Falls back to `git rev-parse --show-toplevel` if not found via directory walk.
-fn find_project_root() -> Option<PathBuf> {
-    // Fast path: walk up CWD looking for .claude/ — no subprocess needed.
+fn find_project_root(agent_dir: &str) -> Option<PathBuf> {
+    // Fast path: walk up CWD looking for the agent's config dir — no subprocess needed.
     let mut dir = std::env::current_dir().ok()?;
     loop {
-        if dir.join(CLAUDE_DIR).exists() {
+        if dir.join(agent_dir).exists() {
             return Some(dir);
         }
         if !dir.pop() {

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -133,31 +133,7 @@ pub(crate) fn check_command_with_rules(
 ///
 /// Missing files and malformed JSON are silently skipped.
 fn load_permission_rules() -> (Vec<String>, Vec<String>, Vec<String>) {
-    let mut deny_rules = Vec::new();
-    let mut ask_rules = Vec::new();
-    let mut allow_rules = Vec::new();
-
-    for path in get_settings_paths() {
-        let Ok(content) = std::fs::read_to_string(&path) else {
-            continue;
-        };
-        let Ok(json) = serde_json::from_str::<Value>(&content) else {
-            eprintln!(
-                "[rtk] warning: failed to parse permissions from {}",
-                path.display()
-            );
-            continue;
-        };
-        let Some(permissions) = json.get("permissions") else {
-            continue;
-        };
-
-        append_bash_rules(permissions.get("deny"), &mut deny_rules);
-        append_bash_rules(permissions.get("ask"), &mut ask_rules);
-        append_bash_rules(permissions.get("allow"), &mut allow_rules);
-    }
-
-    (deny_rules, ask_rules, allow_rules)
+    load_rules_from_paths(&get_settings_paths())
 }
 
 /// Extract Bash-scoped patterns from a JSON array and append them to `target`.
@@ -198,12 +174,22 @@ fn get_settings_paths() -> Vec<PathBuf> {
 /// stored under `permissions.deny` / `permissions.ask` / `permissions.allow`
 /// in `.codebuddy/settings.json` and `.codebuddy/settings.local.json`.
 fn load_codebuddy_rules() -> (Vec<String>, Vec<String>, Vec<String>) {
+    load_rules_from_paths(&get_codebuddy_settings_paths())
+}
+
+/// Load deny, ask, and allow Bash rules from an ordered list of settings files.
+///
+/// Shared by Claude (`load_permission_rules`) and CodeBuddy
+/// (`load_codebuddy_rules`), which differ only in which settings paths they
+/// resolve. Missing files and malformed JSON are silently skipped; later files
+/// are merged with earlier ones (all rules accumulate).
+fn load_rules_from_paths(paths: &[PathBuf]) -> (Vec<String>, Vec<String>, Vec<String>) {
     let mut deny_rules = Vec::new();
     let mut ask_rules = Vec::new();
     let mut allow_rules = Vec::new();
 
-    for path in get_codebuddy_settings_paths() {
-        let Ok(content) = std::fs::read_to_string(&path) else {
+    for path in paths {
+        let Ok(content) = std::fs::read_to_string(path) else {
             continue;
         };
         let Ok(json) = serde_json::from_str::<Value>(&content) else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,8 @@ pub enum AgentTarget {
     Droid,
     /// Mistral Vibe CLI
     Vibe,
+    /// CodeBuddy
+    Codebuddy,
 }
 
 #[derive(Parser)]
@@ -870,6 +872,8 @@ enum HookCommands {
     Droid,
     /// Process Mistral Vibe CLI pre_tool hook (reads JSON from stdin)
     Vibe,
+    /// Process CodeBuddy PreToolUse hook (reads JSON from stdin)
+    Codebuddy,
     /// Check how a command would be rewritten by the hook engine (dry-run)
     Check {
         /// Target agent
@@ -1572,6 +1576,8 @@ where
         hooks::init::uninstall_droid(global, ctx)
     } else if agent == Some(AgentTarget::Vibe) {
         hooks::init::uninstall_vibe(ctx)
+    } else if agent == Some(AgentTarget::Codebuddy) {
+        hooks::init::uninstall_codebuddy(global, ctx)
     } else {
         let cursor = agent == Some(AgentTarget::Cursor);
         let pi = agent == Some(AgentTarget::Pi);
@@ -2037,13 +2043,7 @@ fn run_cli() -> Result<i32> {
                     hooks::init::uninstall,
                 )?;
             } else if gemini {
-                let patch_mode = if auto_patch {
-                    hooks::init::PatchMode::Auto
-                } else if no_patch {
-                    hooks::init::PatchMode::Skip
-                } else {
-                    hooks::init::PatchMode::Ask
-                };
+                let patch_mode = hooks::init::patch_mode_from_flags(auto_patch, no_patch);
                 hooks::init::run_gemini(global, hook_only, patch_mode, ctx)?;
             } else if copilot {
                 if global {
@@ -2083,6 +2083,9 @@ fn run_cli() -> Result<i32> {
                     hooks::init::PatchMode::Ask
                 };
                 hooks::init::run_vibe_mode(global, hook_only, patch_mode, ctx)?;
+            } else if agent == Some(AgentTarget::Codebuddy) {
+                let patch_mode = hooks::init::patch_mode_from_flags(auto_patch, no_patch);
+                hooks::init::run_codebuddy_mode(global, hook_only, patch_mode, ctx)?;
             } else {
                 let install_opencode = opencode;
                 let install_claude = !opencode;
@@ -2090,13 +2093,7 @@ fn run_cli() -> Result<i32> {
                 let install_windsurf = agent == Some(AgentTarget::Windsurf);
                 let install_cline = agent == Some(AgentTarget::Cline);
 
-                let patch_mode = if auto_patch {
-                    hooks::init::PatchMode::Auto
-                } else if no_patch {
-                    hooks::init::PatchMode::Skip
-                } else {
-                    hooks::init::PatchMode::Ask
-                };
+                let patch_mode = hooks::init::patch_mode_from_flags(auto_patch, no_patch);
                 hooks::init::run(
                     global,
                     install_claude,
@@ -2455,6 +2452,10 @@ fn run_cli() -> Result<i32> {
             }
             HookCommands::Vibe => {
                 hooks::hook_cmd::run_vibe()?;
+                0
+            }
+            HookCommands::Codebuddy => {
+                hooks::hook_cmd::run_codebuddy()?;
                 0
             }
             HookCommands::Check { agent: _, command } => {


### PR DESCRIPTION
Closes https://github.com/rtk-ai/rtk/issues/1966

## Summary

Adds first-class support for [CodeBuddy Code](https://cnb.cool/codebuddy/codebuddy-code), a Claude-powered AI coding assistant whose config lives in `.codebuddy/`.

CodeBuddy Code uses the same `PreToolUse` hook JSON protocol as Claude Code, so the hook implementation delegates directly to the existing `process_claude_payload` logic.

## Changes

### New commands

- `rtk hook codebuddy` — PreToolUse hook processor (reads JSON from stdin, rewrites `tool_input.command`)
- `rtk init -g --agent codebuddy` — installs hook into `~/.codebuddy/settings.json` and writes `~/.codebuddy/CODEBUDDY.md`
- `rtk init -g --agent codebuddy --uninstall` — removes all RTK artifacts

### Files changed

| File | Change |
|------|--------|
| `src/hooks/constants.rs` | Add `CODEBUDDY_DIR` (`.codebuddy`) and `CODEBUDDY_HOOK_COMMAND` constants |
| `src/hooks/hook_cmd.rs` | Add `run_codebuddy()` — delegates to `process_claude_payload` |
| `src/hooks/init.rs` | Add `run_codebuddy_mode()`, `uninstall_codebuddy()`, and `patch_settings_json_at()` helper |
| `src/main.rs` | Add `AgentTarget::Codebuddy`, `HookCommands::Codebuddy`, dispatch logic |
| `hooks/codebuddy/rtk-awareness.md` | RTK awareness instructions embedded into `~/.codebuddy/CODEBUDDY.md` |
| `hooks/codebuddy/README.md` | Integration documentation |

### Design notes

- **Zero new protocol code**: CodeBuddy Code uses the identical `PreToolUse` + `tool_input.command` JSON format as Claude Code, so `run_codebuddy()` simply calls `process_claude_payload()`.
- **`patch_settings_json_at()`**: Extracted a new helper that patches `settings.json` in an arbitrary directory (instead of hardcoding the Claude config dir). This makes it easy to add future agents with similar config layouts.
- **Global-only**: Like Gemini and Cursor, CodeBuddy hooks are installed globally (`~/.codebuddy/`).

## Testing

```bash
# Hook rewrite works correctly
echo '{"tool_name":"Bash","tool_input":{"command":"git status"}}' | rtk hook codebuddy
# Output: {"hookSpecificOutput":{"hookEventName":"PreToolUse","updatedInput":{"command":"rtk git status"}}}

# Dry-run init
rtk init -g --agent codebuddy --dry-run -v

# All 1901 existing tests pass
cargo test
```