### PR TITLE
fix(ccusage): accept period field emitted by ccusage ≥19.0 for all granularities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "rtk"
-version = "0.36.0"
+version = "0.34.3"
 dependencies = [
  "anyhow",
  "automod",

--- a/src/analytics/ccusage.rs
+++ b/src/analytics/ccusage.rs
@@ -77,7 +77,8 @@ struct MonthlyResponse {
 
 #[derive(Debug, Deserialize)]
 struct MonthlyEntry {
-    month: String,
+    #[serde(rename = "period", alias = "month")]
+    period: String,
     #[serde(flatten)]
     metrics: CcusageMetrics,
 }
@@ -198,7 +199,7 @@ fn parse_json(json: &str, granularity: Granularity) -> Result<Vec<CcusagePeriod>
                 .monthly
                 .into_iter()
                 .map(|e| CcusagePeriod {
-                    key: e.month,
+                    key: e.period,
                     metrics: e.metrics,
                 })
                 .collect())
@@ -212,6 +213,36 @@ mod tests {
 
     #[test]
     fn test_parse_monthly_valid() {
+        // ccusage ≥19.0 emits `period` instead of `month`
+        let json = r#"{
+            "monthly": [
+                {
+                    "period": "2026-01",
+                    "agent": "all",
+                    "modelsUsed": ["claude-haiku-4-5-20251001"],
+                    "inputTokens": 1000,
+                    "outputTokens": 500,
+                    "cacheCreationTokens": 100,
+                    "cacheReadTokens": 200,
+                    "totalTokens": 1800,
+                    "totalCost": 12.34,
+                    "metadata": {"agents": ["claude"]}
+                }
+            ]
+        }"#;
+
+        let result = parse_json(json, Granularity::Monthly);
+        assert!(result.is_ok());
+        let periods = result.unwrap();
+        assert_eq!(periods.len(), 1);
+        assert_eq!(periods[0].key, "2026-01");
+        assert_eq!(periods[0].metrics.input_tokens, 1000);
+        assert_eq!(periods[0].metrics.total_cost, 12.34);
+    }
+
+    #[test]
+    fn test_parse_monthly_legacy_month_field() {
+        // backward compat: ccusage <19.0 used `month` — alias keeps it working
         let json = r#"{
             "monthly": [
                 {
@@ -231,8 +262,6 @@ mod tests {
         let periods = result.unwrap();
         assert_eq!(periods.len(), 1);
         assert_eq!(periods[0].key, "2026-01");
-        assert_eq!(periods[0].metrics.input_tokens, 1000);
-        assert_eq!(periods[0].metrics.total_cost, 12.34);
     }
 
     #[test]

--- a/src/analytics/ccusage.rs
+++ b/src/analytics/ccusage.rs
@@ -7,6 +7,7 @@
 use crate::core::stream::exec_capture;
 use crate::core::utils::{resolved_command, tool_exists};
 use anyhow::{Context, Result};
+use chrono::{Duration, Local};
 use serde::Deserialize;
 use std::process::Command;
 
@@ -53,7 +54,8 @@ struct DailyResponse {
 
 #[derive(Debug, Deserialize)]
 struct DailyEntry {
-    date: String,
+    #[serde(rename = "period", alias = "date")]
+    period: String,
     #[serde(flatten)]
     metrics: CcusageMetrics,
 }
@@ -65,7 +67,8 @@ struct WeeklyResponse {
 
 #[derive(Debug, Deserialize)]
 struct WeeklyEntry {
-    week: String, // ISO week start (Monday)
+    #[serde(rename = "period", alias = "week")]
+    period: String, // ISO week start (Monday)
     #[serde(flatten)]
     metrics: CcusageMetrics,
 }
@@ -136,10 +139,11 @@ pub fn fetch(granularity: Granularity) -> Result<Option<Vec<CcusagePeriod>>> {
         Granularity::Monthly => "monthly",
     };
 
-    cmd.arg(subcommand)
-        .arg("--json")
-        .arg("--since")
-        .arg("20250101"); // 90 days back approx
+    let since = (Local::now() - Duration::days(90))
+        .format("%Y%m%d")
+        .to_string();
+
+    cmd.arg(subcommand).arg("--json").arg("--since").arg(&since);
 
     let result = match exec_capture(&mut cmd) {
         Err(e) => {
@@ -175,7 +179,7 @@ fn parse_json(json: &str, granularity: Granularity) -> Result<Vec<CcusagePeriod>
                 .daily
                 .into_iter()
                 .map(|e| CcusagePeriod {
-                    key: e.date,
+                    key: e.period,
                     metrics: e.metrics,
                 })
                 .collect())
@@ -187,7 +191,7 @@ fn parse_json(json: &str, granularity: Granularity) -> Result<Vec<CcusagePeriod>
                 .weekly
                 .into_iter()
                 .map(|e| CcusagePeriod {
-                    key: e.week,
+                    key: e.period,
                     metrics: e.metrics,
                 })
                 .collect())
@@ -266,6 +270,31 @@ mod tests {
 
     #[test]
     fn test_parse_daily_valid() {
+        // ccusage ≥19.0 emits `period` instead of `date`
+        let json = r#"{
+            "daily": [
+                {
+                    "period": "2026-01-30",
+                    "inputTokens": 100,
+                    "outputTokens": 50,
+                    "cacheCreationTokens": 0,
+                    "cacheReadTokens": 0,
+                    "totalTokens": 150,
+                    "totalCost": 0.15
+                }
+            ]
+        }"#;
+
+        let result = parse_json(json, Granularity::Daily);
+        assert!(result.is_ok());
+        let periods = result.unwrap();
+        assert_eq!(periods.len(), 1);
+        assert_eq!(periods[0].key, "2026-01-30");
+    }
+
+    #[test]
+    fn test_parse_daily_legacy_date_field() {
+        // backward compat: ccusage <19.0 used `date` — alias keeps it working
         let json = r#"{
             "daily": [
                 {
@@ -289,6 +318,31 @@ mod tests {
 
     #[test]
     fn test_parse_weekly_valid() {
+        // ccusage ≥19.0 emits `period` instead of `week`
+        let json = r#"{
+            "weekly": [
+                {
+                    "period": "2026-01-20",
+                    "inputTokens": 500,
+                    "outputTokens": 250,
+                    "cacheCreationTokens": 50,
+                    "cacheReadTokens": 100,
+                    "totalTokens": 900,
+                    "totalCost": 5.67
+                }
+            ]
+        }"#;
+
+        let result = parse_json(json, Granularity::Weekly);
+        assert!(result.is_ok());
+        let periods = result.unwrap();
+        assert_eq!(periods.len(), 1);
+        assert_eq!(periods[0].key, "2026-01-20");
+    }
+
+    #[test]
+    fn test_parse_weekly_legacy_week_field() {
+        // backward compat: ccusage <19.0 used `week` — alias keeps it working
         let json = r#"{
             "weekly": [
                 {

--- a/src/cmds/system/json_cmd.rs
+++ b/src/cmds/system/json_cmd.rs
@@ -106,7 +106,10 @@ fn compact_json(value: &Value, depth: usize, max_depth: usize) -> String {
         Value::Number(n) => format!("{}{}", indent, n),
         Value::String(s) => {
             if s.len() > 80 {
-                let end = s.floor_char_boundary(77);
+                let end = (0..=77_usize)
+                    .rev()
+                    .find(|&i| s.is_char_boundary(i))
+                    .unwrap_or(0);
                 format!("{}\"{}...\"", indent, &s[..end])
             } else {
                 format!("{}\"{}\"", indent, s)

--- a/src/cmds/system/pipe_cmd.rs
+++ b/src/cmds/system/pipe_cmd.rs
@@ -137,7 +137,7 @@ fn find_wrapper(input: &str) -> String {
 pub fn auto_detect_filter(input: &str) -> fn(&str) -> String {
     let end = input.len().min(1024);
     // Avoid panic: byte 1024 may fall inside a multi-byte UTF-8 char
-    let end = input.floor_char_boundary(end);
+    let end = (0..=end).rev().find(|&i| input.is_char_boundary(i)).unwrap_or(0);
     let first_1k = &input[..end];
 
     if first_1k.contains("test result:") && first_1k.contains("passed;") {

--- a/src/core/constants.rs
+++ b/src/core/constants.rs
@@ -1,6 +1,7 @@
 pub const RTK_DATA_DIR: &str = "rtk";
 pub const HISTORY_DB: &str = "history.db";
 pub const CONFIG_TOML: &str = "config.toml";
+#[allow(dead_code)]
 pub const FILTERS_TOML: &str = "filters.toml";
 pub const TRUSTED_FILTERS_JSON: &str = "trusted_filters.json";
 pub const DEFAULT_HISTORY_DAYS: i64 = 90;

--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -185,6 +185,7 @@ pub struct TomlFilterRegistry {
 impl TomlFilterRegistry {
     /// Load registry from disk + built-in. Emits warnings to stderr on parse
     /// errors but never panics — bad files are silently ignored.
+    #[allow(dead_code)]
     fn load() -> Self {
         let mut filters = Vec::new();
 


### PR DESCRIPTION
## Problem

ccusage ≥19.0 unified all three granularities to emit `"period"` as the period identifier key, replacing the previous per-granularity field names:

| Granularity | Old field | New field |
|---|---|---|
| Daily | `"date"` | `"period"` |
| Weekly | `"week"` | `"period"` |
| Monthly | `"month"` | `"period"` |

This caused `rtk gain` (and any command that fetches ccusage data) to fail with:

```
Failed to fetch ccusage daily data: Failed to parse ccusage JSON output:
Invalid JSON structure for daily data: missing field `date` at line 30 column 5
```

## Changes

- **`DailyEntry`**: rename `date` → `period` with `alias = "date"` for backward compat
- **`WeeklyEntry`**: rename `week` → `period` with `alias = "week"` for backward compat
- **`MonthlyEntry`**: already fixed in earlier commit (rename `month` → `period`)
- **Rolling `--since`**: replace hardcoded `--since 20250101` with a dynamic rolling 90-day window so the fetch range stays current without manual updates
- **`floor_char_boundary` compile fix**: replace with `is_char_boundary` iterator in `json_cmd.rs` and `pipe_cmd.rs` (was causing build failures in some toolchain configs)
- **Tests**: updated daily/weekly tests to use `period`, added legacy-alias tests confirming old field names still deserialize correctly

## Backward compatibility

All three entries use `#[serde(rename = "period", alias = "<old>")]` so both old and new ccusage versions parse correctly.