### PR TITLE
fix(golangci-lint): accept null source lines

### DIFF
--- a/src/cmds/go/golangci_cmd.rs
+++ b/src/cmds/go/golangci_cmd.rs
@@ -5,7 +5,7 @@ use crate::core::runner;
 use crate::core::stream::exec_capture;
 use crate::core::utils::{resolved_command, truncate};
 use anyhow::Result;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
 use std::ffi::OsString;
 
@@ -68,7 +68,11 @@ struct Issue {
     text: String,
     #[serde(rename = "Pos")]
     pos: Position,
-    #[serde(rename = "SourceLines", default)]
+    #[serde(
+        rename = "SourceLines",
+        default,
+        deserialize_with = "deserialize_source_lines"
+    )]
     source_lines: Vec<String>,
     #[serde(rename = "Severity", default)]
     #[allow(dead_code)]
@@ -79,6 +83,13 @@ struct Issue {
 struct GolangciOutput {
     #[serde(rename = "Issues")]
     issues: Vec<Issue>,
+}
+
+fn deserialize_source_lines<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(Option::<Vec<String>>::deserialize(deserializer)?.unwrap_or_default())
 }
 
 /// Parse major version number from `golangci-lint --version` output.
@@ -636,6 +647,30 @@ mod tests {
         assert!(
             !result.contains("→"),
             "no source line to show, should degrade gracefully"
+        );
+    }
+
+    #[test]
+    fn test_filter_v2_null_source_lines_graceful() {
+        let output = r#"{
+  "Issues": [
+    {
+      "FromLinter": "errcheck",
+      "Text": "Error return value not checked",
+      "Severity": "",
+      "SourceLines": null,
+      "Pos": {"Filename": "main.go", "Line": 42, "Column": 5, "Offset": 0}
+    }
+  ]
+}"#;
+        let result = filter_golangci_json(output, 2);
+        assert!(result.contains("golangci-lint: 1 issues in 1 files"));
+        assert!(result.contains("errcheck"));
+        assert!(result.contains("main.go"));
+        assert!(!result.contains("JSON parse failed"));
+        assert!(
+            !result.contains("→"),
+            "null source lines should degrade gracefully"
         );
     }
 


### PR DESCRIPTION
## Summary
- Treat golangci-lint v2 `SourceLines: null` as an empty source line list while preserving the existing compact output.
- Add a regression test so null source lines no longer fall back to raw JSON parse output.

## Problem
Closes #1958.

golangci-lint v2 can emit `SourceLines: null` when source text is unavailable. RTK currently deserializes `SourceLines` into `Vec<String>` with only `#[serde(default)]`, which handles missing fields but not explicit `null`. That causes JSON parsing to fail and prints the raw JSON instead of RTK's summarized lint report.

## Duplicate check
- Searched open PRs for `SourceLines` + `null` + `golangci-lint`; found no existing fix.
- Checked prior v2 compatibility PR #722; it handled the v2 field shape but not explicit null source lines.

## Validation
- `cargo fmt --all --check`
- `cargo test --bin rtk -- cmds::go::golangci_cmd::tests::test_filter_v2_null_source_lines_graceful`
- `cargo test --bin rtk -- cmds::go::golangci_cmd`
- `git diff --check`