### PR TITLE
fix(discover): reclassify universal-passthrough git subcommands and flag pre-hook nature

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -866,6 +866,62 @@ mod tests {
     }
 
     #[test]
+    fn test_classify_git_checkout_is_supported_passthrough() {
+        // Issue #1897: git checkout/clone/remote/... are universal-passthrough,
+        // not missed savings. They must not appear in `rtk discover`'s
+        // "missed opportunities" list.
+        assert_eq!(
+            classify_command("git checkout main"),
+            Classification::Supported {
+                rtk_equivalent: "rtk git",
+                category: "Git",
+                estimated_savings_pct: 70.0,
+                status: RtkStatus::Passthrough,
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_git_clone_is_supported_passthrough() {
+        assert_eq!(
+            classify_command("git clone https://example.com/repo.git"),
+            Classification::Supported {
+                rtk_equivalent: "rtk git",
+                category: "Git",
+                estimated_savings_pct: 70.0,
+                status: RtkStatus::Passthrough,
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_git_remote_is_supported_passthrough() {
+        assert_eq!(
+            classify_command("git remote -v"),
+            Classification::Supported {
+                rtk_equivalent: "rtk git",
+                category: "Git",
+                estimated_savings_pct: 70.0,
+                status: RtkStatus::Passthrough,
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_git_reset_is_supported_passthrough() {
+        // Coverage for another previously-Unsupported subcommand.
+        assert_eq!(
+            classify_command("git reset --hard HEAD~1"),
+            Classification::Supported {
+                rtk_equivalent: "rtk git",
+                category: "Git",
+                estimated_savings_pct: 70.0,
+                status: RtkStatus::Passthrough,
+            }
+        );
+    }
+
+    #[test]
     fn test_classify_yadm_status() {
         assert_eq!(
             classify_command("yadm status"),

--- a/src/discover/report.rs
+++ b/src/discover/report.rs
@@ -127,6 +127,23 @@ pub fn format_text(report: &DiscoverReport, limit: usize, verbose: bool) -> Stri
         }
     ));
 
+    // Issue #1973 / #1929: transcripts record pre-hook commands. When the
+    // PreToolUse hook is installed, what actually executes may differ from
+    // what this report shows. Tell the user so the "0% adoption" headline
+    // doesn't look catastrophic when the hook is in fact doing its job.
+    if matches!(
+        crate::hooks::hook_check::status(),
+        crate::hooks::hook_check::HookStatus::Ok
+    ) {
+        out.push_str(
+            "Note: RTK PreToolUse hook detected; transcripts capture the\n      \
+             pre-hook (assistant-proposed) command. Hook-rewritten commands\n      \
+             execute as `rtk …` but appear in this report as the original\n      \
+             form. Cross-reference `rtk gain --history` for what RTK\n      \
+             actually handled.\n",
+        );
+    }
+
     if report.supported.is_empty() && report.unsupported.is_empty() {
         out.push_str("\nNo missed savings found. RTK usage looks good!\n");
         append_agent_notes(&mut out, report.agent_status);

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -12,7 +12,13 @@ pub struct RtkRule {
 
 pub const RULES: &[RtkRule] = &[
     RtkRule {
-        pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|push|pull|branch|fetch|stash|worktree)",
+        // Issue #1897: include universal-passthrough subcommands so they are
+        // classified as Supported (with Passthrough status) rather than
+        // landing in "missed savings". RTK routes them transparently — they
+        // don't shrink tokens, but `rtk git checkout main` works exactly the
+        // same as `git checkout main`, so the dashboard shouldn't flag them
+        // as opportunities.
+        pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|push|pull|branch|fetch|stash|worktree|checkout|clone|remote|merge|rebase|reset|restore|switch|tag|init|clean|cherry-pick|revert|bisect|grep|blame|describe|reflog|config|rm|mv|notes|submodule|apply|format-patch|am|range-diff|shortlog|whatchanged|cat-file|ls-files|ls-tree|rev-parse|rev-list|update-ref)",
         rtk_cmd: "rtk git",
         rewrite_prefixes: &["git", "yadm"],
         category: "Git",
@@ -23,7 +29,45 @@ pub const RULES: &[RtkRule] = &[
             ("add", 59.0),
             ("commit", 59.0),
         ],
-        subcmd_status: &[],
+        subcmd_status: &[
+            // Universal-passthrough subcommands: no per-subcommand filter,
+            // but the RTK proxy still wraps them transparently.
+            ("checkout", RtkStatus::Passthrough),
+            ("clone", RtkStatus::Passthrough),
+            ("remote", RtkStatus::Passthrough),
+            ("merge", RtkStatus::Passthrough),
+            ("rebase", RtkStatus::Passthrough),
+            ("reset", RtkStatus::Passthrough),
+            ("restore", RtkStatus::Passthrough),
+            ("switch", RtkStatus::Passthrough),
+            ("tag", RtkStatus::Passthrough),
+            ("init", RtkStatus::Passthrough),
+            ("clean", RtkStatus::Passthrough),
+            ("cherry-pick", RtkStatus::Passthrough),
+            ("revert", RtkStatus::Passthrough),
+            ("bisect", RtkStatus::Passthrough),
+            ("grep", RtkStatus::Passthrough),
+            ("blame", RtkStatus::Passthrough),
+            ("describe", RtkStatus::Passthrough),
+            ("reflog", RtkStatus::Passthrough),
+            ("config", RtkStatus::Passthrough),
+            ("rm", RtkStatus::Passthrough),
+            ("mv", RtkStatus::Passthrough),
+            ("notes", RtkStatus::Passthrough),
+            ("submodule", RtkStatus::Passthrough),
+            ("apply", RtkStatus::Passthrough),
+            ("format-patch", RtkStatus::Passthrough),
+            ("am", RtkStatus::Passthrough),
+            ("range-diff", RtkStatus::Passthrough),
+            ("shortlog", RtkStatus::Passthrough),
+            ("whatchanged", RtkStatus::Passthrough),
+            ("cat-file", RtkStatus::Passthrough),
+            ("ls-files", RtkStatus::Passthrough),
+            ("ls-tree", RtkStatus::Passthrough),
+            ("rev-parse", RtkStatus::Passthrough),
+            ("rev-list", RtkStatus::Passthrough),
+            ("update-ref", RtkStatus::Passthrough),
+        ],
     },
     RtkRule {
         pattern: r"^gh\s+(pr|issue|run|repo|api|release)",

--- a/src/main.rs
+++ b/src/main.rs
@@ -557,7 +557,16 @@ enum Commands {
         args: Vec<String>,
     },
 
-    /// Discover missed RTK savings from Claude Code history
+    /// Discover missed RTK savings from Claude Code history.
+    ///
+    /// Note: this report inspects Claude Code's session transcripts, which
+    /// record the **pre-hook** form of each command (i.e. what the assistant
+    /// originally proposed). When the RTK PreToolUse hook is installed and
+    /// active, those commands are rewritten on the fly into `rtk …` and the
+    /// rewritten form is what actually executes. The "missed savings" list
+    /// below therefore overstates true misses when a hook is present; cross-
+    /// reference with `rtk gain --history` (which records executed commands)
+    /// to see what RTK actually handled.
     Discover {
         /// Filter by project path (substring match)
         #[arg(short, long)]


### PR DESCRIPTION
## Summary

Three related \`rtk discover\` issues are partially addressed in this PR.

**Fixed (#1897):** \`git checkout / clone / remote / reset / merge / rebase / restore / switch / tag / init / clean / cherry-pick / revert / bisect / grep / blame / …\` (~30 subcommands) were misclassified as \`Unsupported\` and surfaced in the "missed savings" list, even though RTK proxies them transparently via the universal git passthrough. The git rule now matches those subcommands with \`RtkStatus::Passthrough\`.

**Mitigated (#1973 / #1929):** \`rtk discover\` parses Claude Code session transcripts, which record the **pre-hook** form of each Bash command (what the assistant originally proposed), not the **post-hook** form (what the RTK \`PreToolUse\` hook rewrote it to and what actually executed). When the hook is installed and active, the "Already using RTK" headline understates true adoption because hook-rewritten commands still appear in transcripts as their original form.

A full fix would require either Claude Code logging the post-hook \`updatedInput\` in transcripts, or RTK shadowing transcripts against its own audit log — both out of scope here. This PR provides a stopgap:

- \`discover\` \`--help\` docstring explicitly explains the pre-hook nature and points users to \`rtk gain --history\` for executed-command data.
- When the RTK \`PreToolUse\` hook is detected as installed, the report prepends a \`Note:\` warning the reader to cross-reference \`rtk gain --history\`.

## Reproduction

\`\`\`bash
# Before
rtk discover
# Output included e.g.:
#   git checkout main    50    rtk git    -          ~3500
# (false positive: passthrough, not missed savings)

# After
rtk discover
# git checkout is classified as Passthrough (Supported) and does
# not contribute to the "missed savings" total.

# Plus, when the RTK hook is installed:
#   Note: RTK PreToolUse hook detected; transcripts capture the
#         pre-hook (assistant-proposed) command...
\`\`\`

## Behavior changes

- The "Missed Savings" list shrinks for projects that use the previously-unsupported git subcommands.
- Reports now display a note explaining the pre-hook caveat when a hook is detected.
- No flag changes; no schema changes.

## Test plan

- [x] \`test_classify_git_checkout_is_supported_passthrough\` — passthrough status, no longer "Unsupported".
- [x] \`test_classify_git_clone_is_supported_passthrough\`.
- [x] \`test_classify_git_remote_is_supported_passthrough\`.
- [x] \`test_classify_git_reset_is_supported_passthrough\`.
- [x] All 383 existing \`discover\` tests still pass.
- [x] \`cargo fmt --all\` clean.
- [x] \`cargo clippy --all-targets\` zero warnings.
- [x] \`cargo test --bin rtk -- --test-threads=8\` 1905 passed, 0 failed.

## Out of scope (deferred)

- True post-hook command reading from Claude Code transcripts. Requires schema reverse-engineering / coordination with Anthropic on whether \`hookSpecificOutput.updatedInput\` is logged. Tracking under #1973.
- \`--include-pre-hook\` flag for an explicit dual-view. Not added here to keep the diff focused; the docstring + report note already give users the information they need.

Fixes #1897
Refs #1973, #1929