### PR TITLE
fix(cmds/ruby): accept version-only JSON from rubocop/rspec --version

### DIFF
--- a/src/cmds/ruby/rspec_cmd.rs
+++ b/src/cmds/ruby/rspec_cmd.rs
@@ -158,6 +158,13 @@ fn filter_rspec_output(output: &str) -> String {
         return "RSpec: No output".to_string();
     }
 
+    // `rspec --version` emits minimal JSON like `{"version":"3.13.2"}` which
+    // does not match the run-report struct. Detect and surface it cleanly
+    // instead of warning about a missing `examples` field.
+    if let Some(line) = try_version_only_json(output) {
+        return line;
+    }
+
     // Try parsing as JSON first (happy path when --format json is injected)
     if let Ok(rspec) = serde_json::from_str::<RspecOutput>(output) {
         return build_rspec_summary(&rspec);
@@ -176,6 +183,35 @@ fn filter_rspec_output(output: &str) -> String {
     }
 
     filter_rspec_text(&stripped)
+}
+
+/// Detect the minimal JSON shape emitted by `rspec --version`.
+///
+/// Recognizes `{"version":"..."}` with no run-report fields (`examples`,
+/// `summary`, `summary_line`) and returns a clean `rspec <version>` line.
+/// Returns `None` for any other input so the caller can fall through to the
+/// standard report parser.
+fn try_version_only_json(output: &str) -> Option<String> {
+    let trimmed = output.trim();
+    if !trimmed.starts_with('{') || !trimmed.ends_with('}') {
+        return None;
+    }
+
+    let value: serde_json::Value = serde_json::from_str(trimmed).ok()?;
+    let obj = value.as_object()?;
+
+    let version = obj.get("version")?.as_str()?;
+
+    // Bail if any run-report key is present — that means it's a real report
+    // that happens to include `version`, not a `--version` query.
+    if obj.contains_key("examples")
+        || obj.contains_key("summary")
+        || obj.contains_key("summary_line")
+    {
+        return None;
+    }
+
+    Some(format!("rspec {}", version))
 }
 
 fn build_rspec_summary(rspec: &RspecOutput) -> String {
@@ -971,6 +1007,61 @@ rspec ./spec/models/user_spec.rb:5 # User is valid
             "should have RSpec prefix: {}",
             result
         );
+    }
+
+    // ── --version JSON handling (Issue 1946) ────────────────────────────────
+
+    #[test]
+    fn test_filter_rspec_version_only_json_clean() {
+        // `rspec --version` emits `{"version":"3.13.2"}` — must produce a
+        // clean line containing the version, with no JSON-parse warning text.
+        let input = r#"{"version":"3.13.2"}"#;
+        let result = filter_rspec_output(input);
+        assert!(
+            result.contains("3.13.2"),
+            "should contain version string: {}",
+            result
+        );
+        assert!(
+            !result.contains("JSON parse"),
+            "should not mention JSON parse error: {}",
+            result
+        );
+        assert!(
+            !result.contains("not recognized"),
+            "should not emit fallback warning marker: {}",
+            result
+        );
+        assert_eq!(result, "rspec 3.13.2");
+    }
+
+    #[test]
+    fn test_filter_rspec_version_only_json_with_whitespace() {
+        // Trailing newline / surrounding whitespace still detected as version-only.
+        let input = "\n  {\"version\":\"3.12.0\"}\n";
+        let result = filter_rspec_output(input);
+        assert_eq!(result, "rspec 3.12.0");
+    }
+
+    #[test]
+    fn test_filter_rspec_version_only_does_not_swallow_real_report() {
+        // A full report that also includes `version` must still go through the
+        // run-report parser (regression guard).
+        let result = filter_rspec_output(all_pass_json());
+        assert!(
+            result.starts_with("✓ RSpec:"),
+            "real report must still be parsed: {}",
+            result
+        );
+        assert!(result.contains("2 passed"));
+    }
+
+    #[test]
+    fn test_try_version_only_json_rspec_rejects_non_object() {
+        assert!(try_version_only_json("\"3.13.2\"").is_none());
+        assert!(try_version_only_json("[]").is_none());
+        assert!(try_version_only_json("not json").is_none());
+        assert!(try_version_only_json("").is_none());
     }
 
     // ── Format flag detection tests (from PR #534) ───────────────────────

--- a/src/cmds/ruby/rubocop_cmd.rs
+++ b/src/cmds/ruby/rubocop_cmd.rs
@@ -88,6 +88,32 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
 
 // ── JSON filtering ───────────────────────────────────────────────────────────
 
+/// Detect the minimal JSON shape emitted by `rubocop --version`.
+///
+/// Recognizes `{"version":"..."}` with no lint-report fields (`files`,
+/// `summary`, `metadata`) and returns a clean `rubocop <version>` line.
+/// Returns `None` for any other input so the caller can fall through to the
+/// standard report parser.
+fn try_version_only_json(output: &str) -> Option<String> {
+    let trimmed = output.trim();
+    if !trimmed.starts_with('{') || !trimmed.ends_with('}') {
+        return None;
+    }
+
+    let value: serde_json::Value = serde_json::from_str(trimmed).ok()?;
+    let obj = value.as_object()?;
+
+    let version = obj.get("version")?.as_str()?;
+
+    // Bail if any lint-report key is present — that means it's a real report
+    // that happens to include `version`, not a `--version` query.
+    if obj.contains_key("files") || obj.contains_key("summary") || obj.contains_key("metadata") {
+        return None;
+    }
+
+    Some(format!("rubocop {}", version))
+}
+
 /// Rank severity for ordering: lower = more severe.
 fn severity_rank(severity: &str) -> u8 {
     match severity {
@@ -101,6 +127,13 @@ fn severity_rank(severity: &str) -> u8 {
 fn filter_rubocop_json(output: &str) -> String {
     if output.trim().is_empty() {
         return "RuboCop: No output".to_string();
+    }
+
+    // `rubocop --version` emits minimal JSON like `{"version":"1.86.2"}` which
+    // does not match the lint-report struct. Detect and surface it cleanly
+    // instead of warning about a missing `files` field.
+    if let Some(line) = try_version_only_json(output) {
+        return line;
     }
 
     let parsed: Result<RubocopOutput, _> = serde_json::from_str(output);
@@ -610,6 +643,56 @@ mod tests {
         let input = "\x1b[33mWarning: something\x1b[0m\n{\"broken\": true}";
         let result = filter_rubocop_json(input);
         assert!(!result.is_empty(), "should not panic on ANSI-prefixed JSON");
+    }
+
+    // ── --version JSON handling (Issue 1946) ────────────────────────────────
+
+    #[test]
+    fn test_filter_rubocop_version_only_json_clean() {
+        // `rubocop --version` emits `{"version":"1.86.2"}` — must produce a
+        // clean line containing the version, with no JSON-parse warning text.
+        let input = r#"{"version":"1.86.2"}"#;
+        let result = filter_rubocop_json(input);
+        assert!(
+            result.contains("1.86.2"),
+            "should contain version string: {}",
+            result
+        );
+        assert!(
+            !result.contains("JSON parse"),
+            "should not mention JSON parse error: {}",
+            result
+        );
+        assert!(
+            !result.contains("not recognized"),
+            "should not emit fallback warning marker: {}",
+            result
+        );
+        assert_eq!(result, "rubocop 1.86.2");
+    }
+
+    #[test]
+    fn test_filter_rubocop_version_only_json_with_whitespace() {
+        // Trailing newline / surrounding whitespace still detected as version-only.
+        let input = "\n  {\"version\":\"2.0.0\"}\n";
+        let result = filter_rubocop_json(input);
+        assert_eq!(result, "rubocop 2.0.0");
+    }
+
+    #[test]
+    fn test_filter_rubocop_version_only_does_not_swallow_real_report() {
+        // A real report that happens to include `version` must still go through
+        // the full struct parser (regression guard).
+        let result = filter_rubocop_json(no_offenses_json());
+        assert_eq!(result, "ok ✓ rubocop (15 files)");
+    }
+
+    #[test]
+    fn test_try_version_only_json_rejects_non_object() {
+        assert!(try_version_only_json("\"1.86.2\"").is_none());
+        assert!(try_version_only_json("[]").is_none());
+        assert!(try_version_only_json("not json").is_none());
+        assert!(try_version_only_json("").is_none());
     }
 
     // ── 10-file cap test (Issue 12) ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #1946. `rtk rubocop --version` and `rtk rspec --version` were polluting
stdout with two redundant warnings:

```
[rtk] rubocop: JSON parse failed (missing field `files` at line 1 column 20)
[rtk] rubocop (JSON parse error): output format not recognized, showing last 5 lines
{"version":"1.86.2"}
```

This PR detects the minimal `{"version":"..."}` JSON shape emitted by
`--version` queries before attempting the full lint/test report parse and
surfaces it as a clean `rubocop 1.86.2` / `rspec 3.13.2` line.

## Root cause

Both modules inject `--format json` to get structured output. When the user
runs `--version`, the tool emits `{"version":"..."}` instead of a full report.
The strongly-typed struct (`RubocopOutput { files, summary }` /
`RspecOutput { examples, summary }`) rejects it, the JSON parse error is
logged, and `fallback_tail` adds a second "output format not recognized"
warning before printing the raw line.

## Fix

In `filter_rubocop_json` and `filter_rspec_output`, run a lightweight
detector first:

- Parse as `serde_json::Value`.
- Verify it's an object with a string `version` key.
- Bail out if any report-specific key is present (`files`/`summary`/`metadata`
  for rubocop, `examples`/`summary`/`summary_line` for rspec) — that means
  it's a real report, not a `--version` query.
- Otherwise return `<tool> <version>` cleanly with no warnings.

Real reports that happen to carry a `version` field (which RSpec's JSON
formatter does) still flow through the existing report parser; covered by
regression tests.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets` (zero warnings)
- [x] `cargo test --bin rtk` — 1909 passed, 0 failed
- [x] New tests (8 total, 4 per module):
  - `test_filter_rubocop_version_only_json_clean`
  - `test_filter_rubocop_version_only_json_with_whitespace`
  - `test_filter_rubocop_version_only_does_not_swallow_real_report`
  - `test_try_version_only_json_rejects_non_object`
  - `test_filter_rspec_version_only_json_clean`
  - `test_filter_rspec_version_only_json_with_whitespace`
  - `test_filter_rspec_version_only_does_not_swallow_real_report`
  - `test_try_version_only_json_rspec_rejects_non_object`

## Files changed

- `src/cmds/ruby/rubocop_cmd.rs` — add `try_version_only_json()`, call it before report parse, add 4 tests
- `src/cmds/ruby/rspec_cmd.rs` — same shape, 4 tests

Fixes #1946