### PR TITLE
fix(cmds/go): surface failure context inline instead of hiding in tee file

### DIFF
--- a/src/cmds/go/go_cmd.rs
+++ b/src/cmds/go/go_cmd.rs
@@ -486,8 +486,16 @@ pub(crate) fn filter_go_test_json(output: &str) -> String {
         for (test, outputs) in &pkg_result.failed_tests {
             result.push_str(&format!("  [FAIL] {}\n", test));
 
+            // Trace-mode (panic/fatal) needs wider lines for full stack frame
+            // paths -- truncating to 100 chars would chop the file the user
+            // actually wrote. Assertion-mode keeps the original 100-char cap.
+            let trace_mode = outputs
+                .iter()
+                .any(|line| is_go_trace_marker(line.trim()));
+            let line_cap = if trace_mode { 160 } else { 100 };
+
             for line in select_go_test_failure_lines(outputs) {
-                result.push_str(&format!("     {}\n", truncate(&line, 100)));
+                result.push_str(&format!("     {}\n", truncate(&line, line_cap)));
             }
         }
     }
@@ -495,7 +503,96 @@ pub(crate) fn filter_go_test_json(output: &str) -> String {
     result.trim().to_string()
 }
 
+/// Maximum lines of trace context to keep per failed test in panic/fatal mode.
+/// Big enough to show the user-code frames of a Go stack trace, small enough
+/// that the tee file remains the authoritative recovery point.
+const GO_TEST_TRACE_MAX_LINES: usize = 50;
+
+/// Maximum lines kept for plain assertion failures (no panic/fatal/goroutine).
+const GO_TEST_ASSERT_MAX_LINES: usize = 8;
+
+fn is_go_trace_marker(line: &str) -> bool {
+    let lower = line.to_lowercase();
+    lower.starts_with("panic:")
+        || lower.starts_with("fatal error:")
+        || lower.starts_with("goroutine ")
+        || (lower.starts_with("--- fail:")) // explicit subtest failure header
+}
+
+fn is_go_test_skippable_header(line: &str) -> bool {
+    line.starts_with("=== RUN")
+        || line.starts_with("=== PAUSE")
+        || line.starts_with("=== CONT")
+        || line.starts_with("=== NAME")
+        || line.starts_with("--- PASS")
+}
+
 fn select_go_test_failure_lines(outputs: &[String]) -> Vec<String> {
+    // Step 1: detect whether any output line is a panic / fatal / goroutine
+    // header. If so we switch into "trace mode" and preserve the contiguous
+    // block verbatim — losing user-code stack frames defeats the point of
+    // having any diagnostic at all (see issue #1882).
+    let trace_mode = outputs
+        .iter()
+        .any(|line| is_go_trace_marker(line.trim()));
+
+    if trace_mode {
+        return collect_trace_lines(outputs);
+    }
+
+    collect_assertion_lines(outputs)
+}
+
+/// Trace mode: keep contiguous diagnostic lines (panic message + goroutine +
+/// stack frames) up to GO_TEST_TRACE_MAX_LINES. Skips only purely cosmetic
+/// `=== RUN` / `--- PASS` headers and blank lines, so file:line frames and
+/// function-name lines are all preserved together.
+fn collect_trace_lines(outputs: &[String]) -> Vec<String> {
+    let mut relevant: Vec<String> = Vec::new();
+    let mut started = false;
+    let mut truncated = false;
+
+    for line in outputs {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if is_go_test_skippable_header(trimmed) {
+            continue;
+        }
+
+        // Don't start emitting until we see a meaningful line (skip any pre-`--- FAIL:` noise).
+        if !started {
+            started = true;
+        }
+
+        if relevant.len() >= GO_TEST_TRACE_MAX_LINES {
+            truncated = true;
+            break;
+        }
+        relevant.push(trimmed.to_string());
+    }
+
+    if truncated {
+        let remaining = outputs
+            .iter()
+            .filter(|l| {
+                let t = l.trim();
+                !t.is_empty() && !is_go_test_skippable_header(t)
+            })
+            .count()
+            .saturating_sub(relevant.len());
+        if remaining > 0 {
+            relevant.push(format!("… +{} more trace lines (see tee file)", remaining));
+        }
+    }
+
+    relevant
+}
+
+/// Assertion mode (no panic/fatal): keep file:line locations, their follow-up
+/// context lines, and any obvious error / mismatch lines, up to a small cap.
+fn collect_assertion_lines(outputs: &[String]) -> Vec<String> {
     let mut relevant = Vec::new();
     let mut keep_next_context_line = false;
 
@@ -521,7 +618,7 @@ fn select_go_test_failure_lines(outputs: &[String]) -> Vec<String> {
             keep_next_context_line = false;
         }
 
-        if relevant.len() >= 5 {
+        if relevant.len() >= GO_TEST_ASSERT_MAX_LINES {
             break;
         }
     }
@@ -746,6 +843,10 @@ fn compact_package_name(package: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn count_tokens(s: &str) -> usize {
+        s.split_whitespace().count()
+    }
 
     #[test]
     fn test_filter_go_test_all_pass() {
@@ -1048,6 +1149,145 @@ pattern ./...: directory prefix . does not contain modules listed in go.work or 
         assert!(result.contains("Go build: failed (exit 1)"));
         assert!(result.contains(output));
         assert!(!result.contains("Success"));
+    }
+
+    #[test]
+    fn test_filter_go_test_panic_preserves_full_trace() {
+        // Regression test for issue #1882: a panic in a Go test should surface
+        // its message and user-code stack frames inline, not just a one-line summary.
+        let input = include_str!("../../../tests/fixtures/go_test_panic_json.txt");
+        let result = filter_go_test_json(input);
+
+        // Panic message must appear verbatim.
+        assert!(
+            result.contains("panic: runtime error: index out of range [3] with length 2"),
+            "panic message must be inline, got:\n{}",
+            result
+        );
+
+        // User code frame (the actual bug site) must be preserved.
+        assert!(
+            result.contains("classifier_test.go:58"),
+            "user-code stack frame must be preserved, got:\n{}",
+            result
+        );
+        assert!(
+            result.contains("model.go:142"),
+            "panic origin frame must be preserved, got:\n{}",
+            result
+        );
+
+        // At least one goroutine header should appear so the LLM sees this is a panic trace.
+        assert!(
+            result.contains("goroutine 17 [running]:"),
+            "goroutine header must be preserved, got:\n{}",
+            result
+        );
+
+        // Summary must still be accurate.
+        assert!(
+            result.starts_with("Go test: 3 passed, 1 failed, 1 skipped in 2 packages"),
+            "Expected summary header, got:\n{}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_filter_go_test_panic_caps_stack_trace_size() {
+        // Even on a panic, we must not unconditionally dump everything --
+        // each failure's trace is capped (~50 lines) so it stays diagnostic
+        // without blowing past tee territory.
+        let input = include_str!("../../../tests/fixtures/go_test_panic_json.txt");
+        let result = filter_go_test_json(input);
+        let body_lines = result.lines().count();
+        assert!(
+            body_lines <= 80,
+            "Filtered output should be capped (≤80 lines), got {} lines:\n{}",
+            body_lines,
+            result
+        );
+    }
+
+    #[test]
+    fn test_filter_go_test_panic_still_saves_meaningful_bytes() {
+        // Failures legitimately inflate output but RTK should still strip the
+        // verbose NDJSON envelope. Bytes are the right metric here because the
+        // raw stream packs long JSON keys (e.g. `"Package":"github.com/..."`)
+        // into single whitespace tokens, which deflates a token-based ratio.
+        let input = include_str!("../../../tests/fixtures/go_test_panic_json.txt");
+        let result = filter_go_test_json(input);
+        let raw_bytes = input.len();
+        let filtered_bytes = result.len();
+        let savings = 100.0 - (filtered_bytes as f64 / raw_bytes as f64 * 100.0);
+        assert!(
+            savings >= 60.0,
+            "Expected ≥60% byte savings on failing fixture, got {:.1}% ({}->{} bytes)",
+            savings,
+            raw_bytes,
+            filtered_bytes
+        );
+    }
+
+    #[test]
+    fn test_filter_go_test_all_pass_remains_compact() {
+        // Passing-only output must stay tiny (≥60% token savings, the RTK promise).
+        let input = include_str!("../../../tests/fixtures/go_test_pass_json.txt");
+        let result = filter_go_test_json(input);
+
+        // Must summarize, not dump per-test lines.
+        assert!(
+            result.starts_with("Go test: 336 passed in 2 packages"),
+            "Passing summary mismatch, got: {}",
+            result
+        );
+
+        let raw_tokens = count_tokens(input);
+        let filtered_tokens = count_tokens(&result);
+        let savings = 100.0 - (filtered_tokens as f64 / raw_tokens as f64 * 100.0);
+        assert!(
+            savings >= 60.0,
+            "Expected ≥60% savings on passing fixture, got {:.1}% ({}->{} tokens)",
+            savings,
+            raw_tokens,
+            filtered_tokens
+        );
+    }
+
+    #[test]
+    fn test_filter_go_test_panic_shape() {
+        // Output shape check: header line + classifier block, with the panic
+        // body sandwiched between the test header and a fallback tee hint.
+        let input = include_str!("../../../tests/fixtures/go_test_panic_json.txt");
+        let result = filter_go_test_json(input);
+
+        // The classifier block must contain the failing test name.
+        assert!(
+            result.contains("[FAIL] TestClassify"),
+            "Failing test name must appear, got:\n{}",
+            result
+        );
+
+        // The panic trace must include at least one /usr/local/go/ stack frame
+        // (the runtime context the LLM needs to recognize this is a Go panic).
+        assert!(
+            result.contains("/usr/local/go/"),
+            "Runtime stack frame must be preserved, got:\n{}",
+            result
+        );
+
+        // Skipped tests should still be counted.
+        assert!(
+            result.contains("1 skipped"),
+            "Skipped count must remain, got:\n{}",
+            result
+        );
+
+        // Passing-only package must NOT have per-test details printed.
+        assert!(
+            !result.contains("TestDecode"),
+            "Passing-only package must not list tests, got:\n{}",
+            result
+        );
     }
 
     #[test]

--- a/tests/fixtures/go_test_panic_json.txt
+++ b/tests/fixtures/go_test_panic_json.txt
@@ -1,0 +1,46 @@
+{"Time":"2025-01-15T10:00:00.000Z","Action":"start","Package":"github.com/tphakala/birdnet-go/internal/classifier"}
+{"Time":"2025-01-15T10:00:00.100Z","Action":"run","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestLoadModel"}
+{"Time":"2025-01-15T10:00:00.110Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestLoadModel","Output":"=== RUN   TestLoadModel\n"}
+{"Time":"2025-01-15T10:00:00.120Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestLoadModel","Output":"--- PASS: TestLoadModel (0.01s)\n"}
+{"Time":"2025-01-15T10:00:00.130Z","Action":"pass","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestLoadModel","Elapsed":0.01}
+{"Time":"2025-01-15T10:00:00.140Z","Action":"run","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestClassify"}
+{"Time":"2025-01-15T10:00:00.150Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestClassify","Output":"=== RUN   TestClassify\n"}
+{"Time":"2025-01-15T10:00:00.160Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestClassify","Output":"--- FAIL: TestClassify (0.02s)\n"}
+{"Time":"2025-01-15T10:00:00.165Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestClassify","Output":"panic: runtime error: index out of range [3] with length 2 [recovered]\n"}
+{"Time":"2025-01-15T10:00:00.166Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestClassify","Output":"\tpanic: runtime error: index out of range [3] with length 2\n"}
+{"Time":"2025-01-15T10:00:00.167Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestClassify","Output":"\n"}
+{"Time":"2025-01-15T10:00:00.168Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestClassify","Output":"goroutine 17 [running]:\n"}
+{"Time":"2025-01-15T10:00:00.169Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestClassify","Output":"testing.tRunner.func1.2({0x10a3ce0, 0xc000018090})\n"}
+{"Time":"2025-01-15T10:00:00.170Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestClassify","Output":"\t/usr/local/go/src/testing/testing.go:1545 +0x238\n"}
+{"Time":"2025-01-15T10:00:00.171Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestClassify","Output":"testing.tRunner.func1()\n"}
+{"Time":"2025-01-15T10:00:00.172Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestClassify","Output":"\t/usr/local/go/src/testing/testing.go:1548 +0x397\n"}
+{"Time":"2025-01-15T10:00:00.173Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestClassify","Output":"panic({0x10a3ce0?, 0xc000018090?})\n"}
+{"Time":"2025-01-15T10:00:00.174Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestClassify","Output":"\t/usr/local/go/src/runtime/panic.go:914 +0x21f\n"}
+{"Time":"2025-01-15T10:00:00.175Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestClassify","Output":"github.com/tphakala/birdnet-go/internal/classifier.(*Model).Predict(0xc00009e000, {0xc0001ba000, 0x2, 0x2})\n"}
+{"Time":"2025-01-15T10:00:00.176Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestClassify","Output":"\t/home/runner/work/birdnet-go/internal/classifier/model.go:142 +0x1a4\n"}
+{"Time":"2025-01-15T10:00:00.177Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestClassify","Output":"github.com/tphakala/birdnet-go/internal/classifier.TestClassify(0xc0001b6680)\n"}
+{"Time":"2025-01-15T10:00:00.178Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestClassify","Output":"\t/home/runner/work/birdnet-go/internal/classifier/classifier_test.go:58 +0xf8\n"}
+{"Time":"2025-01-15T10:00:00.179Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestClassify","Output":"testing.tRunner(0xc0001b6680, 0x10c5c50)\n"}
+{"Time":"2025-01-15T10:00:00.180Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestClassify","Output":"\t/usr/local/go/src/testing/testing.go:1595 +0xe8\n"}
+{"Time":"2025-01-15T10:00:00.181Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestClassify","Output":"created by testing.(*T).Run in goroutine 1\n"}
+{"Time":"2025-01-15T10:00:00.182Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestClassify","Output":"\t/usr/local/go/src/testing/testing.go:1648 +0x35f\n"}
+{"Time":"2025-01-15T10:00:00.183Z","Action":"fail","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestClassify","Elapsed":0.02}
+{"Time":"2025-01-15T10:00:00.190Z","Action":"run","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestSkippedFeature"}
+{"Time":"2025-01-15T10:00:00.191Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestSkippedFeature","Output":"=== RUN   TestSkippedFeature\n"}
+{"Time":"2025-01-15T10:00:00.192Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestSkippedFeature","Output":"    classifier_test.go:90: requires GPU\n"}
+{"Time":"2025-01-15T10:00:00.193Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestSkippedFeature","Output":"--- SKIP: TestSkippedFeature (0.00s)\n"}
+{"Time":"2025-01-15T10:00:00.194Z","Action":"skip","Package":"github.com/tphakala/birdnet-go/internal/classifier","Test":"TestSkippedFeature","Elapsed":0.0}
+{"Time":"2025-01-15T10:00:00.200Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Output":"FAIL\n"}
+{"Time":"2025-01-15T10:00:00.201Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/classifier","Output":"FAIL\tgithub.com/tphakala/birdnet-go/internal/classifier\t0.924s\n"}
+{"Time":"2025-01-15T10:00:00.202Z","Action":"fail","Package":"github.com/tphakala/birdnet-go/internal/classifier","Elapsed":0.924}
+{"Time":"2025-01-15T10:00:00.210Z","Action":"run","Package":"github.com/tphakala/birdnet-go/internal/audio","Test":"TestDecode"}
+{"Time":"2025-01-15T10:00:00.211Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/audio","Test":"TestDecode","Output":"=== RUN   TestDecode\n"}
+{"Time":"2025-01-15T10:00:00.212Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/audio","Test":"TestDecode","Output":"--- PASS: TestDecode (0.01s)\n"}
+{"Time":"2025-01-15T10:00:00.213Z","Action":"pass","Package":"github.com/tphakala/birdnet-go/internal/audio","Test":"TestDecode","Elapsed":0.01}
+{"Time":"2025-01-15T10:00:00.214Z","Action":"run","Package":"github.com/tphakala/birdnet-go/internal/audio","Test":"TestEncode"}
+{"Time":"2025-01-15T10:00:00.215Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/audio","Test":"TestEncode","Output":"=== RUN   TestEncode\n"}
+{"Time":"2025-01-15T10:00:00.216Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/audio","Test":"TestEncode","Output":"--- PASS: TestEncode (0.01s)\n"}
+{"Time":"2025-01-15T10:00:00.217Z","Action":"pass","Package":"github.com/tphakala/birdnet-go/internal/audio","Test":"TestEncode","Elapsed":0.01}
+{"Time":"2025-01-15T10:00:00.218Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/audio","Output":"PASS\n"}
+{"Time":"2025-01-15T10:00:00.219Z","Action":"output","Package":"github.com/tphakala/birdnet-go/internal/audio","Output":"ok\tgithub.com/tphakala/birdnet-go/internal/audio\t0.123s\n"}
+{"Time":"2025-01-15T10:00:00.220Z","Action":"pass","Package":"github.com/tphakala/birdnet-go/internal/audio","Elapsed":0.123}

--- a/tests/fixtures/go_test_pass_json.txt
+++ b/tests/fixtures/go_test_pass_json.txt
@@ -1,0 +1,1352 @@
+{"Time": "2025-01-15T10:00:00Z", "Action": "start", "Package": "github.com/tphakala/birdnet-go/internal/audio"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature000"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature000", "Output": "=== RUN   TestFeature000\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature000", "Output": "--- PASS: TestFeature000 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature000", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature001"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature001", "Output": "=== RUN   TestFeature001\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature001", "Output": "--- PASS: TestFeature001 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature001", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature002"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature002", "Output": "=== RUN   TestFeature002\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature002", "Output": "--- PASS: TestFeature002 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature002", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature003"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature003", "Output": "=== RUN   TestFeature003\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature003", "Output": "--- PASS: TestFeature003 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature003", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature004"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature004", "Output": "=== RUN   TestFeature004\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature004", "Output": "--- PASS: TestFeature004 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature004", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature005"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature005", "Output": "=== RUN   TestFeature005\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature005", "Output": "--- PASS: TestFeature005 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature005", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature006"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature006", "Output": "=== RUN   TestFeature006\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature006", "Output": "--- PASS: TestFeature006 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature006", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature007"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature007", "Output": "=== RUN   TestFeature007\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature007", "Output": "--- PASS: TestFeature007 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature007", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature008"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature008", "Output": "=== RUN   TestFeature008\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature008", "Output": "--- PASS: TestFeature008 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature008", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature009"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature009", "Output": "=== RUN   TestFeature009\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature009", "Output": "--- PASS: TestFeature009 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature009", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature010"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature010", "Output": "=== RUN   TestFeature010\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature010", "Output": "--- PASS: TestFeature010 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature010", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature011"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature011", "Output": "=== RUN   TestFeature011\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature011", "Output": "--- PASS: TestFeature011 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature011", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature012"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature012", "Output": "=== RUN   TestFeature012\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature012", "Output": "--- PASS: TestFeature012 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature012", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature013"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature013", "Output": "=== RUN   TestFeature013\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature013", "Output": "--- PASS: TestFeature013 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature013", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature014"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature014", "Output": "=== RUN   TestFeature014\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature014", "Output": "--- PASS: TestFeature014 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature014", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature015"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature015", "Output": "=== RUN   TestFeature015\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature015", "Output": "--- PASS: TestFeature015 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature015", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature016"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature016", "Output": "=== RUN   TestFeature016\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature016", "Output": "--- PASS: TestFeature016 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature016", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature017"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature017", "Output": "=== RUN   TestFeature017\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature017", "Output": "--- PASS: TestFeature017 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature017", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature018"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature018", "Output": "=== RUN   TestFeature018\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature018", "Output": "--- PASS: TestFeature018 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature018", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature019"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature019", "Output": "=== RUN   TestFeature019\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature019", "Output": "--- PASS: TestFeature019 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature019", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature020"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature020", "Output": "=== RUN   TestFeature020\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature020", "Output": "--- PASS: TestFeature020 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature020", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature021"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature021", "Output": "=== RUN   TestFeature021\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature021", "Output": "--- PASS: TestFeature021 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature021", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature022"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature022", "Output": "=== RUN   TestFeature022\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature022", "Output": "--- PASS: TestFeature022 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature022", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature023"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature023", "Output": "=== RUN   TestFeature023\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature023", "Output": "--- PASS: TestFeature023 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature023", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature024"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature024", "Output": "=== RUN   TestFeature024\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature024", "Output": "--- PASS: TestFeature024 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature024", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature025"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature025", "Output": "=== RUN   TestFeature025\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature025", "Output": "--- PASS: TestFeature025 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature025", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature026"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature026", "Output": "=== RUN   TestFeature026\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature026", "Output": "--- PASS: TestFeature026 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature026", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature027"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature027", "Output": "=== RUN   TestFeature027\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature027", "Output": "--- PASS: TestFeature027 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature027", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature028"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature028", "Output": "=== RUN   TestFeature028\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature028", "Output": "--- PASS: TestFeature028 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature028", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature029"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature029", "Output": "=== RUN   TestFeature029\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature029", "Output": "--- PASS: TestFeature029 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature029", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature030"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature030", "Output": "=== RUN   TestFeature030\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature030", "Output": "--- PASS: TestFeature030 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature030", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature031"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature031", "Output": "=== RUN   TestFeature031\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature031", "Output": "--- PASS: TestFeature031 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature031", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature032"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature032", "Output": "=== RUN   TestFeature032\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature032", "Output": "--- PASS: TestFeature032 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature032", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature033"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature033", "Output": "=== RUN   TestFeature033\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature033", "Output": "--- PASS: TestFeature033 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature033", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature034"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature034", "Output": "=== RUN   TestFeature034\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature034", "Output": "--- PASS: TestFeature034 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature034", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature035"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature035", "Output": "=== RUN   TestFeature035\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature035", "Output": "--- PASS: TestFeature035 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature035", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature036"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature036", "Output": "=== RUN   TestFeature036\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature036", "Output": "--- PASS: TestFeature036 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature036", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature037"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature037", "Output": "=== RUN   TestFeature037\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature037", "Output": "--- PASS: TestFeature037 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature037", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature038"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature038", "Output": "=== RUN   TestFeature038\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature038", "Output": "--- PASS: TestFeature038 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature038", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature039"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature039", "Output": "=== RUN   TestFeature039\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature039", "Output": "--- PASS: TestFeature039 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature039", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature040"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature040", "Output": "=== RUN   TestFeature040\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature040", "Output": "--- PASS: TestFeature040 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature040", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature041"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature041", "Output": "=== RUN   TestFeature041\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature041", "Output": "--- PASS: TestFeature041 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature041", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature042"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature042", "Output": "=== RUN   TestFeature042\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature042", "Output": "--- PASS: TestFeature042 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature042", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature043"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature043", "Output": "=== RUN   TestFeature043\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature043", "Output": "--- PASS: TestFeature043 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature043", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature044"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature044", "Output": "=== RUN   TestFeature044\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature044", "Output": "--- PASS: TestFeature044 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature044", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature045"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature045", "Output": "=== RUN   TestFeature045\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature045", "Output": "--- PASS: TestFeature045 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature045", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature046"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature046", "Output": "=== RUN   TestFeature046\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature046", "Output": "--- PASS: TestFeature046 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature046", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature047"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature047", "Output": "=== RUN   TestFeature047\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature047", "Output": "--- PASS: TestFeature047 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature047", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature048"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature048", "Output": "=== RUN   TestFeature048\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature048", "Output": "--- PASS: TestFeature048 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature048", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature049"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature049", "Output": "=== RUN   TestFeature049\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature049", "Output": "--- PASS: TestFeature049 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature049", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature050"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature050", "Output": "=== RUN   TestFeature050\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature050", "Output": "--- PASS: TestFeature050 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature050", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature051"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature051", "Output": "=== RUN   TestFeature051\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature051", "Output": "--- PASS: TestFeature051 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature051", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature052"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature052", "Output": "=== RUN   TestFeature052\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature052", "Output": "--- PASS: TestFeature052 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature052", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature053"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature053", "Output": "=== RUN   TestFeature053\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature053", "Output": "--- PASS: TestFeature053 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature053", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature054"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature054", "Output": "=== RUN   TestFeature054\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature054", "Output": "--- PASS: TestFeature054 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature054", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature055"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature055", "Output": "=== RUN   TestFeature055\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature055", "Output": "--- PASS: TestFeature055 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature055", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature056"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature056", "Output": "=== RUN   TestFeature056\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature056", "Output": "--- PASS: TestFeature056 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature056", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature057"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature057", "Output": "=== RUN   TestFeature057\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature057", "Output": "--- PASS: TestFeature057 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature057", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature058"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature058", "Output": "=== RUN   TestFeature058\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature058", "Output": "--- PASS: TestFeature058 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature058", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature059"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature059", "Output": "=== RUN   TestFeature059\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature059", "Output": "--- PASS: TestFeature059 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature059", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature060"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature060", "Output": "=== RUN   TestFeature060\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature060", "Output": "--- PASS: TestFeature060 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature060", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature061"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature061", "Output": "=== RUN   TestFeature061\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature061", "Output": "--- PASS: TestFeature061 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature061", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature062"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature062", "Output": "=== RUN   TestFeature062\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature062", "Output": "--- PASS: TestFeature062 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature062", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature063"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature063", "Output": "=== RUN   TestFeature063\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature063", "Output": "--- PASS: TestFeature063 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature063", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature064"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature064", "Output": "=== RUN   TestFeature064\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature064", "Output": "--- PASS: TestFeature064 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature064", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature065"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature065", "Output": "=== RUN   TestFeature065\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature065", "Output": "--- PASS: TestFeature065 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature065", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature066"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature066", "Output": "=== RUN   TestFeature066\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature066", "Output": "--- PASS: TestFeature066 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature066", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature067"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature067", "Output": "=== RUN   TestFeature067\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature067", "Output": "--- PASS: TestFeature067 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature067", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature068"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature068", "Output": "=== RUN   TestFeature068\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature068", "Output": "--- PASS: TestFeature068 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature068", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature069"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature069", "Output": "=== RUN   TestFeature069\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature069", "Output": "--- PASS: TestFeature069 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature069", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature070"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature070", "Output": "=== RUN   TestFeature070\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature070", "Output": "--- PASS: TestFeature070 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature070", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature071"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature071", "Output": "=== RUN   TestFeature071\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature071", "Output": "--- PASS: TestFeature071 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature071", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature072"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature072", "Output": "=== RUN   TestFeature072\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature072", "Output": "--- PASS: TestFeature072 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature072", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature073"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature073", "Output": "=== RUN   TestFeature073\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature073", "Output": "--- PASS: TestFeature073 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature073", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature074"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature074", "Output": "=== RUN   TestFeature074\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature074", "Output": "--- PASS: TestFeature074 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature074", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature075"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature075", "Output": "=== RUN   TestFeature075\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature075", "Output": "--- PASS: TestFeature075 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature075", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature076"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature076", "Output": "=== RUN   TestFeature076\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature076", "Output": "--- PASS: TestFeature076 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature076", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature077"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature077", "Output": "=== RUN   TestFeature077\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature077", "Output": "--- PASS: TestFeature077 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature077", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature078"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature078", "Output": "=== RUN   TestFeature078\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature078", "Output": "--- PASS: TestFeature078 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature078", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature079"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature079", "Output": "=== RUN   TestFeature079\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature079", "Output": "--- PASS: TestFeature079 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature079", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature080"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature080", "Output": "=== RUN   TestFeature080\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature080", "Output": "--- PASS: TestFeature080 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature080", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature081"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature081", "Output": "=== RUN   TestFeature081\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature081", "Output": "--- PASS: TestFeature081 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature081", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature082"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature082", "Output": "=== RUN   TestFeature082\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature082", "Output": "--- PASS: TestFeature082 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature082", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature083"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature083", "Output": "=== RUN   TestFeature083\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature083", "Output": "--- PASS: TestFeature083 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature083", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature084"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature084", "Output": "=== RUN   TestFeature084\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature084", "Output": "--- PASS: TestFeature084 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature084", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature085"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature085", "Output": "=== RUN   TestFeature085\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature085", "Output": "--- PASS: TestFeature085 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature085", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature086"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature086", "Output": "=== RUN   TestFeature086\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature086", "Output": "--- PASS: TestFeature086 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature086", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature087"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature087", "Output": "=== RUN   TestFeature087\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature087", "Output": "--- PASS: TestFeature087 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature087", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature088"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature088", "Output": "=== RUN   TestFeature088\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature088", "Output": "--- PASS: TestFeature088 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature088", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature089"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature089", "Output": "=== RUN   TestFeature089\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature089", "Output": "--- PASS: TestFeature089 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature089", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature090"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature090", "Output": "=== RUN   TestFeature090\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature090", "Output": "--- PASS: TestFeature090 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature090", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature091"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature091", "Output": "=== RUN   TestFeature091\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature091", "Output": "--- PASS: TestFeature091 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature091", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature092"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature092", "Output": "=== RUN   TestFeature092\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature092", "Output": "--- PASS: TestFeature092 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature092", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature093"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature093", "Output": "=== RUN   TestFeature093\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature093", "Output": "--- PASS: TestFeature093 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature093", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature094"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature094", "Output": "=== RUN   TestFeature094\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature094", "Output": "--- PASS: TestFeature094 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature094", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature095"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature095", "Output": "=== RUN   TestFeature095\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature095", "Output": "--- PASS: TestFeature095 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature095", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature096"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature096", "Output": "=== RUN   TestFeature096\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature096", "Output": "--- PASS: TestFeature096 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature096", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature097"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature097", "Output": "=== RUN   TestFeature097\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature097", "Output": "--- PASS: TestFeature097 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature097", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature098"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature098", "Output": "=== RUN   TestFeature098\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature098", "Output": "--- PASS: TestFeature098 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature098", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature099"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature099", "Output": "=== RUN   TestFeature099\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature099", "Output": "--- PASS: TestFeature099 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature099", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature100"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature100", "Output": "=== RUN   TestFeature100\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature100", "Output": "--- PASS: TestFeature100 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature100", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature101"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature101", "Output": "=== RUN   TestFeature101\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature101", "Output": "--- PASS: TestFeature101 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature101", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature102"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature102", "Output": "=== RUN   TestFeature102\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature102", "Output": "--- PASS: TestFeature102 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature102", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature103"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature103", "Output": "=== RUN   TestFeature103\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature103", "Output": "--- PASS: TestFeature103 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature103", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature104"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature104", "Output": "=== RUN   TestFeature104\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature104", "Output": "--- PASS: TestFeature104 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature104", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature105"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature105", "Output": "=== RUN   TestFeature105\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature105", "Output": "--- PASS: TestFeature105 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature105", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature106"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature106", "Output": "=== RUN   TestFeature106\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature106", "Output": "--- PASS: TestFeature106 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature106", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature107"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature107", "Output": "=== RUN   TestFeature107\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature107", "Output": "--- PASS: TestFeature107 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature107", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature108"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature108", "Output": "=== RUN   TestFeature108\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature108", "Output": "--- PASS: TestFeature108 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature108", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature109"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature109", "Output": "=== RUN   TestFeature109\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature109", "Output": "--- PASS: TestFeature109 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature109", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature110"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature110", "Output": "=== RUN   TestFeature110\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature110", "Output": "--- PASS: TestFeature110 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature110", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature111"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature111", "Output": "=== RUN   TestFeature111\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature111", "Output": "--- PASS: TestFeature111 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature111", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature112"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature112", "Output": "=== RUN   TestFeature112\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature112", "Output": "--- PASS: TestFeature112 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature112", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature113"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature113", "Output": "=== RUN   TestFeature113\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature113", "Output": "--- PASS: TestFeature113 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature113", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature114"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature114", "Output": "=== RUN   TestFeature114\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature114", "Output": "--- PASS: TestFeature114 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature114", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature115"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature115", "Output": "=== RUN   TestFeature115\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature115", "Output": "--- PASS: TestFeature115 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature115", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature116"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature116", "Output": "=== RUN   TestFeature116\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature116", "Output": "--- PASS: TestFeature116 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature116", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature117"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature117", "Output": "=== RUN   TestFeature117\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature117", "Output": "--- PASS: TestFeature117 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature117", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature118"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature118", "Output": "=== RUN   TestFeature118\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature118", "Output": "--- PASS: TestFeature118 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature118", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature119"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature119", "Output": "=== RUN   TestFeature119\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature119", "Output": "--- PASS: TestFeature119 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature119", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature120"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature120", "Output": "=== RUN   TestFeature120\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature120", "Output": "--- PASS: TestFeature120 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature120", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature121"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature121", "Output": "=== RUN   TestFeature121\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature121", "Output": "--- PASS: TestFeature121 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature121", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature122"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature122", "Output": "=== RUN   TestFeature122\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature122", "Output": "--- PASS: TestFeature122 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature122", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature123"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature123", "Output": "=== RUN   TestFeature123\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature123", "Output": "--- PASS: TestFeature123 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature123", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature124"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature124", "Output": "=== RUN   TestFeature124\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature124", "Output": "--- PASS: TestFeature124 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature124", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature125"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature125", "Output": "=== RUN   TestFeature125\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature125", "Output": "--- PASS: TestFeature125 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature125", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature126"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature126", "Output": "=== RUN   TestFeature126\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature126", "Output": "--- PASS: TestFeature126 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature126", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature127"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature127", "Output": "=== RUN   TestFeature127\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature127", "Output": "--- PASS: TestFeature127 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature127", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature128"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature128", "Output": "=== RUN   TestFeature128\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature128", "Output": "--- PASS: TestFeature128 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature128", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature129"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature129", "Output": "=== RUN   TestFeature129\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature129", "Output": "--- PASS: TestFeature129 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature129", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature130"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature130", "Output": "=== RUN   TestFeature130\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature130", "Output": "--- PASS: TestFeature130 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature130", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature131"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature131", "Output": "=== RUN   TestFeature131\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature131", "Output": "--- PASS: TestFeature131 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature131", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature132"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature132", "Output": "=== RUN   TestFeature132\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature132", "Output": "--- PASS: TestFeature132 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature132", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature133"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature133", "Output": "=== RUN   TestFeature133\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature133", "Output": "--- PASS: TestFeature133 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature133", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature134"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature134", "Output": "=== RUN   TestFeature134\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature134", "Output": "--- PASS: TestFeature134 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature134", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature135"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature135", "Output": "=== RUN   TestFeature135\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature135", "Output": "--- PASS: TestFeature135 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature135", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature136"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature136", "Output": "=== RUN   TestFeature136\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature136", "Output": "--- PASS: TestFeature136 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature136", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature137"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature137", "Output": "=== RUN   TestFeature137\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature137", "Output": "--- PASS: TestFeature137 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature137", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature138"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature138", "Output": "=== RUN   TestFeature138\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature138", "Output": "--- PASS: TestFeature138 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature138", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature139"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature139", "Output": "=== RUN   TestFeature139\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature139", "Output": "--- PASS: TestFeature139 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature139", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature140"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature140", "Output": "=== RUN   TestFeature140\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature140", "Output": "--- PASS: TestFeature140 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature140", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature141"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature141", "Output": "=== RUN   TestFeature141\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature141", "Output": "--- PASS: TestFeature141 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature141", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature142"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature142", "Output": "=== RUN   TestFeature142\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature142", "Output": "--- PASS: TestFeature142 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature142", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature143"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature143", "Output": "=== RUN   TestFeature143\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature143", "Output": "--- PASS: TestFeature143 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature143", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature144"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature144", "Output": "=== RUN   TestFeature144\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature144", "Output": "--- PASS: TestFeature144 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature144", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature145"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature145", "Output": "=== RUN   TestFeature145\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature145", "Output": "--- PASS: TestFeature145 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature145", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature146"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature146", "Output": "=== RUN   TestFeature146\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature146", "Output": "--- PASS: TestFeature146 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature146", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature147"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature147", "Output": "=== RUN   TestFeature147\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature147", "Output": "--- PASS: TestFeature147 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature147", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature148"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature148", "Output": "=== RUN   TestFeature148\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature148", "Output": "--- PASS: TestFeature148 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature148", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature149"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature149", "Output": "=== RUN   TestFeature149\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature149", "Output": "--- PASS: TestFeature149 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature149", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature150"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature150", "Output": "=== RUN   TestFeature150\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature150", "Output": "--- PASS: TestFeature150 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature150", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature151"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature151", "Output": "=== RUN   TestFeature151\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature151", "Output": "--- PASS: TestFeature151 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature151", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature152"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature152", "Output": "=== RUN   TestFeature152\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature152", "Output": "--- PASS: TestFeature152 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature152", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature153"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature153", "Output": "=== RUN   TestFeature153\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature153", "Output": "--- PASS: TestFeature153 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature153", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature154"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature154", "Output": "=== RUN   TestFeature154\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature154", "Output": "--- PASS: TestFeature154 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature154", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature155"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature155", "Output": "=== RUN   TestFeature155\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature155", "Output": "--- PASS: TestFeature155 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature155", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature156"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature156", "Output": "=== RUN   TestFeature156\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature156", "Output": "--- PASS: TestFeature156 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature156", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature157"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature157", "Output": "=== RUN   TestFeature157\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature157", "Output": "--- PASS: TestFeature157 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature157", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature158"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature158", "Output": "=== RUN   TestFeature158\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature158", "Output": "--- PASS: TestFeature158 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature158", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature159"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature159", "Output": "=== RUN   TestFeature159\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature159", "Output": "--- PASS: TestFeature159 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature159", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature160"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature160", "Output": "=== RUN   TestFeature160\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature160", "Output": "--- PASS: TestFeature160 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature160", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature161"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature161", "Output": "=== RUN   TestFeature161\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature161", "Output": "--- PASS: TestFeature161 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature161", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature162"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature162", "Output": "=== RUN   TestFeature162\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature162", "Output": "--- PASS: TestFeature162 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature162", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature163"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature163", "Output": "=== RUN   TestFeature163\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature163", "Output": "--- PASS: TestFeature163 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature163", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature164"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature164", "Output": "=== RUN   TestFeature164\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature164", "Output": "--- PASS: TestFeature164 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature164", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature165"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature165", "Output": "=== RUN   TestFeature165\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature165", "Output": "--- PASS: TestFeature165 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature165", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature166"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature166", "Output": "=== RUN   TestFeature166\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature166", "Output": "--- PASS: TestFeature166 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature166", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature167"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature167", "Output": "=== RUN   TestFeature167\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature167", "Output": "--- PASS: TestFeature167 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Test": "TestFeature167", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Output": "PASS\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Output": "ok\tgithub.com/tphakala/birdnet-go/internal/audio\t0.456s\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/audio", "Elapsed": 0.456}
+{"Time": "2025-01-15T10:00:00Z", "Action": "start", "Package": "github.com/tphakala/birdnet-go/internal/classifier"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature000"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature000", "Output": "=== RUN   TestFeature000\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature000", "Output": "--- PASS: TestFeature000 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature000", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature001"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature001", "Output": "=== RUN   TestFeature001\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature001", "Output": "--- PASS: TestFeature001 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature001", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature002"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature002", "Output": "=== RUN   TestFeature002\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature002", "Output": "--- PASS: TestFeature002 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature002", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature003"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature003", "Output": "=== RUN   TestFeature003\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature003", "Output": "--- PASS: TestFeature003 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature003", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature004"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature004", "Output": "=== RUN   TestFeature004\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature004", "Output": "--- PASS: TestFeature004 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature004", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature005"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature005", "Output": "=== RUN   TestFeature005\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature005", "Output": "--- PASS: TestFeature005 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature005", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature006"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature006", "Output": "=== RUN   TestFeature006\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature006", "Output": "--- PASS: TestFeature006 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature006", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature007"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature007", "Output": "=== RUN   TestFeature007\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature007", "Output": "--- PASS: TestFeature007 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature007", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature008"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature008", "Output": "=== RUN   TestFeature008\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature008", "Output": "--- PASS: TestFeature008 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature008", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature009"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature009", "Output": "=== RUN   TestFeature009\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature009", "Output": "--- PASS: TestFeature009 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature009", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature010"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature010", "Output": "=== RUN   TestFeature010\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature010", "Output": "--- PASS: TestFeature010 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature010", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature011"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature011", "Output": "=== RUN   TestFeature011\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature011", "Output": "--- PASS: TestFeature011 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature011", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature012"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature012", "Output": "=== RUN   TestFeature012\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature012", "Output": "--- PASS: TestFeature012 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature012", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature013"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature013", "Output": "=== RUN   TestFeature013\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature013", "Output": "--- PASS: TestFeature013 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature013", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature014"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature014", "Output": "=== RUN   TestFeature014\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature014", "Output": "--- PASS: TestFeature014 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature014", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature015"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature015", "Output": "=== RUN   TestFeature015\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature015", "Output": "--- PASS: TestFeature015 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature015", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature016"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature016", "Output": "=== RUN   TestFeature016\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature016", "Output": "--- PASS: TestFeature016 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature016", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature017"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature017", "Output": "=== RUN   TestFeature017\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature017", "Output": "--- PASS: TestFeature017 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature017", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature018"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature018", "Output": "=== RUN   TestFeature018\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature018", "Output": "--- PASS: TestFeature018 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature018", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature019"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature019", "Output": "=== RUN   TestFeature019\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature019", "Output": "--- PASS: TestFeature019 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature019", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature020"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature020", "Output": "=== RUN   TestFeature020\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature020", "Output": "--- PASS: TestFeature020 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature020", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature021"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature021", "Output": "=== RUN   TestFeature021\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature021", "Output": "--- PASS: TestFeature021 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature021", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature022"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature022", "Output": "=== RUN   TestFeature022\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature022", "Output": "--- PASS: TestFeature022 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature022", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature023"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature023", "Output": "=== RUN   TestFeature023\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature023", "Output": "--- PASS: TestFeature023 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature023", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature024"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature024", "Output": "=== RUN   TestFeature024\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature024", "Output": "--- PASS: TestFeature024 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature024", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature025"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature025", "Output": "=== RUN   TestFeature025\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature025", "Output": "--- PASS: TestFeature025 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature025", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature026"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature026", "Output": "=== RUN   TestFeature026\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature026", "Output": "--- PASS: TestFeature026 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature026", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature027"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature027", "Output": "=== RUN   TestFeature027\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature027", "Output": "--- PASS: TestFeature027 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature027", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature028"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature028", "Output": "=== RUN   TestFeature028\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature028", "Output": "--- PASS: TestFeature028 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature028", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature029"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature029", "Output": "=== RUN   TestFeature029\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature029", "Output": "--- PASS: TestFeature029 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature029", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature030"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature030", "Output": "=== RUN   TestFeature030\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature030", "Output": "--- PASS: TestFeature030 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature030", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature031"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature031", "Output": "=== RUN   TestFeature031\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature031", "Output": "--- PASS: TestFeature031 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature031", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature032"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature032", "Output": "=== RUN   TestFeature032\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature032", "Output": "--- PASS: TestFeature032 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature032", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature033"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature033", "Output": "=== RUN   TestFeature033\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature033", "Output": "--- PASS: TestFeature033 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature033", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature034"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature034", "Output": "=== RUN   TestFeature034\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature034", "Output": "--- PASS: TestFeature034 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature034", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature035"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature035", "Output": "=== RUN   TestFeature035\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature035", "Output": "--- PASS: TestFeature035 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature035", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature036"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature036", "Output": "=== RUN   TestFeature036\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature036", "Output": "--- PASS: TestFeature036 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature036", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature037"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature037", "Output": "=== RUN   TestFeature037\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature037", "Output": "--- PASS: TestFeature037 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature037", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature038"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature038", "Output": "=== RUN   TestFeature038\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature038", "Output": "--- PASS: TestFeature038 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature038", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature039"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature039", "Output": "=== RUN   TestFeature039\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature039", "Output": "--- PASS: TestFeature039 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature039", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature040"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature040", "Output": "=== RUN   TestFeature040\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature040", "Output": "--- PASS: TestFeature040 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature040", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature041"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature041", "Output": "=== RUN   TestFeature041\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature041", "Output": "--- PASS: TestFeature041 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature041", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature042"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature042", "Output": "=== RUN   TestFeature042\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature042", "Output": "--- PASS: TestFeature042 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature042", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature043"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature043", "Output": "=== RUN   TestFeature043\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature043", "Output": "--- PASS: TestFeature043 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature043", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature044"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature044", "Output": "=== RUN   TestFeature044\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature044", "Output": "--- PASS: TestFeature044 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature044", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature045"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature045", "Output": "=== RUN   TestFeature045\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature045", "Output": "--- PASS: TestFeature045 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature045", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature046"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature046", "Output": "=== RUN   TestFeature046\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature046", "Output": "--- PASS: TestFeature046 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature046", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature047"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature047", "Output": "=== RUN   TestFeature047\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature047", "Output": "--- PASS: TestFeature047 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature047", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature048"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature048", "Output": "=== RUN   TestFeature048\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature048", "Output": "--- PASS: TestFeature048 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature048", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature049"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature049", "Output": "=== RUN   TestFeature049\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature049", "Output": "--- PASS: TestFeature049 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature049", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature050"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature050", "Output": "=== RUN   TestFeature050\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature050", "Output": "--- PASS: TestFeature050 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature050", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature051"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature051", "Output": "=== RUN   TestFeature051\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature051", "Output": "--- PASS: TestFeature051 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature051", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature052"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature052", "Output": "=== RUN   TestFeature052\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature052", "Output": "--- PASS: TestFeature052 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature052", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature053"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature053", "Output": "=== RUN   TestFeature053\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature053", "Output": "--- PASS: TestFeature053 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature053", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature054"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature054", "Output": "=== RUN   TestFeature054\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature054", "Output": "--- PASS: TestFeature054 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature054", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature055"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature055", "Output": "=== RUN   TestFeature055\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature055", "Output": "--- PASS: TestFeature055 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature055", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature056"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature056", "Output": "=== RUN   TestFeature056\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature056", "Output": "--- PASS: TestFeature056 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature056", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature057"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature057", "Output": "=== RUN   TestFeature057\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature057", "Output": "--- PASS: TestFeature057 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature057", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature058"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature058", "Output": "=== RUN   TestFeature058\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature058", "Output": "--- PASS: TestFeature058 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature058", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature059"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature059", "Output": "=== RUN   TestFeature059\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature059", "Output": "--- PASS: TestFeature059 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature059", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature060"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature060", "Output": "=== RUN   TestFeature060\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature060", "Output": "--- PASS: TestFeature060 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature060", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature061"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature061", "Output": "=== RUN   TestFeature061\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature061", "Output": "--- PASS: TestFeature061 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature061", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature062"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature062", "Output": "=== RUN   TestFeature062\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature062", "Output": "--- PASS: TestFeature062 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature062", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature063"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature063", "Output": "=== RUN   TestFeature063\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature063", "Output": "--- PASS: TestFeature063 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature063", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature064"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature064", "Output": "=== RUN   TestFeature064\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature064", "Output": "--- PASS: TestFeature064 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature064", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature065"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature065", "Output": "=== RUN   TestFeature065\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature065", "Output": "--- PASS: TestFeature065 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature065", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature066"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature066", "Output": "=== RUN   TestFeature066\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature066", "Output": "--- PASS: TestFeature066 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature066", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature067"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature067", "Output": "=== RUN   TestFeature067\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature067", "Output": "--- PASS: TestFeature067 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature067", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature068"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature068", "Output": "=== RUN   TestFeature068\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature068", "Output": "--- PASS: TestFeature068 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature068", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature069"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature069", "Output": "=== RUN   TestFeature069\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature069", "Output": "--- PASS: TestFeature069 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature069", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature070"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature070", "Output": "=== RUN   TestFeature070\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature070", "Output": "--- PASS: TestFeature070 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature070", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature071"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature071", "Output": "=== RUN   TestFeature071\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature071", "Output": "--- PASS: TestFeature071 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature071", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature072"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature072", "Output": "=== RUN   TestFeature072\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature072", "Output": "--- PASS: TestFeature072 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature072", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature073"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature073", "Output": "=== RUN   TestFeature073\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature073", "Output": "--- PASS: TestFeature073 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature073", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature074"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature074", "Output": "=== RUN   TestFeature074\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature074", "Output": "--- PASS: TestFeature074 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature074", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature075"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature075", "Output": "=== RUN   TestFeature075\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature075", "Output": "--- PASS: TestFeature075 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature075", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature076"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature076", "Output": "=== RUN   TestFeature076\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature076", "Output": "--- PASS: TestFeature076 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature076", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature077"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature077", "Output": "=== RUN   TestFeature077\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature077", "Output": "--- PASS: TestFeature077 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature077", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature078"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature078", "Output": "=== RUN   TestFeature078\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature078", "Output": "--- PASS: TestFeature078 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature078", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature079"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature079", "Output": "=== RUN   TestFeature079\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature079", "Output": "--- PASS: TestFeature079 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature079", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature080"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature080", "Output": "=== RUN   TestFeature080\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature080", "Output": "--- PASS: TestFeature080 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature080", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature081"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature081", "Output": "=== RUN   TestFeature081\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature081", "Output": "--- PASS: TestFeature081 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature081", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature082"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature082", "Output": "=== RUN   TestFeature082\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature082", "Output": "--- PASS: TestFeature082 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature082", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature083"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature083", "Output": "=== RUN   TestFeature083\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature083", "Output": "--- PASS: TestFeature083 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature083", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature084"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature084", "Output": "=== RUN   TestFeature084\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature084", "Output": "--- PASS: TestFeature084 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature084", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature085"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature085", "Output": "=== RUN   TestFeature085\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature085", "Output": "--- PASS: TestFeature085 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature085", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature086"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature086", "Output": "=== RUN   TestFeature086\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature086", "Output": "--- PASS: TestFeature086 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature086", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature087"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature087", "Output": "=== RUN   TestFeature087\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature087", "Output": "--- PASS: TestFeature087 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature087", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature088"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature088", "Output": "=== RUN   TestFeature088\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature088", "Output": "--- PASS: TestFeature088 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature088", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature089"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature089", "Output": "=== RUN   TestFeature089\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature089", "Output": "--- PASS: TestFeature089 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature089", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature090"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature090", "Output": "=== RUN   TestFeature090\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature090", "Output": "--- PASS: TestFeature090 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature090", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature091"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature091", "Output": "=== RUN   TestFeature091\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature091", "Output": "--- PASS: TestFeature091 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature091", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature092"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature092", "Output": "=== RUN   TestFeature092\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature092", "Output": "--- PASS: TestFeature092 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature092", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature093"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature093", "Output": "=== RUN   TestFeature093\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature093", "Output": "--- PASS: TestFeature093 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature093", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature094"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature094", "Output": "=== RUN   TestFeature094\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature094", "Output": "--- PASS: TestFeature094 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature094", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature095"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature095", "Output": "=== RUN   TestFeature095\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature095", "Output": "--- PASS: TestFeature095 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature095", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature096"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature096", "Output": "=== RUN   TestFeature096\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature096", "Output": "--- PASS: TestFeature096 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature096", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature097"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature097", "Output": "=== RUN   TestFeature097\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature097", "Output": "--- PASS: TestFeature097 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature097", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature098"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature098", "Output": "=== RUN   TestFeature098\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature098", "Output": "--- PASS: TestFeature098 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature098", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature099"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature099", "Output": "=== RUN   TestFeature099\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature099", "Output": "--- PASS: TestFeature099 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature099", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature100"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature100", "Output": "=== RUN   TestFeature100\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature100", "Output": "--- PASS: TestFeature100 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature100", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature101"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature101", "Output": "=== RUN   TestFeature101\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature101", "Output": "--- PASS: TestFeature101 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature101", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature102"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature102", "Output": "=== RUN   TestFeature102\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature102", "Output": "--- PASS: TestFeature102 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature102", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature103"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature103", "Output": "=== RUN   TestFeature103\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature103", "Output": "--- PASS: TestFeature103 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature103", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature104"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature104", "Output": "=== RUN   TestFeature104\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature104", "Output": "--- PASS: TestFeature104 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature104", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature105"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature105", "Output": "=== RUN   TestFeature105\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature105", "Output": "--- PASS: TestFeature105 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature105", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature106"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature106", "Output": "=== RUN   TestFeature106\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature106", "Output": "--- PASS: TestFeature106 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature106", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature107"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature107", "Output": "=== RUN   TestFeature107\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature107", "Output": "--- PASS: TestFeature107 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature107", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature108"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature108", "Output": "=== RUN   TestFeature108\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature108", "Output": "--- PASS: TestFeature108 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature108", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature109"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature109", "Output": "=== RUN   TestFeature109\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature109", "Output": "--- PASS: TestFeature109 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature109", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature110"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature110", "Output": "=== RUN   TestFeature110\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature110", "Output": "--- PASS: TestFeature110 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature110", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature111"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature111", "Output": "=== RUN   TestFeature111\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature111", "Output": "--- PASS: TestFeature111 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature111", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature112"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature112", "Output": "=== RUN   TestFeature112\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature112", "Output": "--- PASS: TestFeature112 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature112", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature113"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature113", "Output": "=== RUN   TestFeature113\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature113", "Output": "--- PASS: TestFeature113 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature113", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature114"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature114", "Output": "=== RUN   TestFeature114\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature114", "Output": "--- PASS: TestFeature114 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature114", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature115"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature115", "Output": "=== RUN   TestFeature115\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature115", "Output": "--- PASS: TestFeature115 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature115", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature116"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature116", "Output": "=== RUN   TestFeature116\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature116", "Output": "--- PASS: TestFeature116 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature116", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature117"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature117", "Output": "=== RUN   TestFeature117\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature117", "Output": "--- PASS: TestFeature117 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature117", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature118"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature118", "Output": "=== RUN   TestFeature118\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature118", "Output": "--- PASS: TestFeature118 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature118", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature119"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature119", "Output": "=== RUN   TestFeature119\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature119", "Output": "--- PASS: TestFeature119 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature119", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature120"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature120", "Output": "=== RUN   TestFeature120\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature120", "Output": "--- PASS: TestFeature120 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature120", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature121"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature121", "Output": "=== RUN   TestFeature121\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature121", "Output": "--- PASS: TestFeature121 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature121", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature122"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature122", "Output": "=== RUN   TestFeature122\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature122", "Output": "--- PASS: TestFeature122 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature122", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature123"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature123", "Output": "=== RUN   TestFeature123\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature123", "Output": "--- PASS: TestFeature123 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature123", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature124"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature124", "Output": "=== RUN   TestFeature124\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature124", "Output": "--- PASS: TestFeature124 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature124", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature125"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature125", "Output": "=== RUN   TestFeature125\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature125", "Output": "--- PASS: TestFeature125 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature125", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature126"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature126", "Output": "=== RUN   TestFeature126\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature126", "Output": "--- PASS: TestFeature126 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature126", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature127"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature127", "Output": "=== RUN   TestFeature127\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature127", "Output": "--- PASS: TestFeature127 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature127", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature128"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature128", "Output": "=== RUN   TestFeature128\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature128", "Output": "--- PASS: TestFeature128 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature128", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature129"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature129", "Output": "=== RUN   TestFeature129\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature129", "Output": "--- PASS: TestFeature129 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature129", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature130"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature130", "Output": "=== RUN   TestFeature130\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature130", "Output": "--- PASS: TestFeature130 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature130", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature131"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature131", "Output": "=== RUN   TestFeature131\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature131", "Output": "--- PASS: TestFeature131 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature131", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature132"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature132", "Output": "=== RUN   TestFeature132\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature132", "Output": "--- PASS: TestFeature132 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature132", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature133"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature133", "Output": "=== RUN   TestFeature133\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature133", "Output": "--- PASS: TestFeature133 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature133", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature134"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature134", "Output": "=== RUN   TestFeature134\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature134", "Output": "--- PASS: TestFeature134 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature134", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature135"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature135", "Output": "=== RUN   TestFeature135\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature135", "Output": "--- PASS: TestFeature135 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature135", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature136"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature136", "Output": "=== RUN   TestFeature136\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature136", "Output": "--- PASS: TestFeature136 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature136", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature137"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature137", "Output": "=== RUN   TestFeature137\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature137", "Output": "--- PASS: TestFeature137 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature137", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature138"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature138", "Output": "=== RUN   TestFeature138\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature138", "Output": "--- PASS: TestFeature138 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature138", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature139"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature139", "Output": "=== RUN   TestFeature139\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature139", "Output": "--- PASS: TestFeature139 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature139", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature140"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature140", "Output": "=== RUN   TestFeature140\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature140", "Output": "--- PASS: TestFeature140 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature140", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature141"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature141", "Output": "=== RUN   TestFeature141\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature141", "Output": "--- PASS: TestFeature141 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature141", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature142"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature142", "Output": "=== RUN   TestFeature142\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature142", "Output": "--- PASS: TestFeature142 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature142", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature143"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature143", "Output": "=== RUN   TestFeature143\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature143", "Output": "--- PASS: TestFeature143 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature143", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature144"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature144", "Output": "=== RUN   TestFeature144\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature144", "Output": "--- PASS: TestFeature144 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature144", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature145"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature145", "Output": "=== RUN   TestFeature145\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature145", "Output": "--- PASS: TestFeature145 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature145", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature146"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature146", "Output": "=== RUN   TestFeature146\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature146", "Output": "--- PASS: TestFeature146 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature146", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature147"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature147", "Output": "=== RUN   TestFeature147\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature147", "Output": "--- PASS: TestFeature147 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature147", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature148"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature148", "Output": "=== RUN   TestFeature148\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature148", "Output": "--- PASS: TestFeature148 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature148", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature149"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature149", "Output": "=== RUN   TestFeature149\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature149", "Output": "--- PASS: TestFeature149 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature149", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature150"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature150", "Output": "=== RUN   TestFeature150\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature150", "Output": "--- PASS: TestFeature150 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature150", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature151"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature151", "Output": "=== RUN   TestFeature151\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature151", "Output": "--- PASS: TestFeature151 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature151", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature152"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature152", "Output": "=== RUN   TestFeature152\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature152", "Output": "--- PASS: TestFeature152 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature152", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature153"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature153", "Output": "=== RUN   TestFeature153\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature153", "Output": "--- PASS: TestFeature153 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature153", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature154"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature154", "Output": "=== RUN   TestFeature154\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature154", "Output": "--- PASS: TestFeature154 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature154", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature155"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature155", "Output": "=== RUN   TestFeature155\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature155", "Output": "--- PASS: TestFeature155 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature155", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature156"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature156", "Output": "=== RUN   TestFeature156\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature156", "Output": "--- PASS: TestFeature156 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature156", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature157"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature157", "Output": "=== RUN   TestFeature157\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature157", "Output": "--- PASS: TestFeature157 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature157", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature158"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature158", "Output": "=== RUN   TestFeature158\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature158", "Output": "--- PASS: TestFeature158 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature158", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature159"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature159", "Output": "=== RUN   TestFeature159\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature159", "Output": "--- PASS: TestFeature159 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature159", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature160"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature160", "Output": "=== RUN   TestFeature160\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature160", "Output": "--- PASS: TestFeature160 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature160", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature161"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature161", "Output": "=== RUN   TestFeature161\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature161", "Output": "--- PASS: TestFeature161 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature161", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature162"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature162", "Output": "=== RUN   TestFeature162\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature162", "Output": "--- PASS: TestFeature162 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature162", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature163"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature163", "Output": "=== RUN   TestFeature163\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature163", "Output": "--- PASS: TestFeature163 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature163", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature164"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature164", "Output": "=== RUN   TestFeature164\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature164", "Output": "--- PASS: TestFeature164 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature164", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature165"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature165", "Output": "=== RUN   TestFeature165\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature165", "Output": "--- PASS: TestFeature165 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature165", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature166"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature166", "Output": "=== RUN   TestFeature166\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature166", "Output": "--- PASS: TestFeature166 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature166", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "run", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature167"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature167", "Output": "=== RUN   TestFeature167\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature167", "Output": "--- PASS: TestFeature167 (0.00s)\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Test": "TestFeature167", "Elapsed": 0.001}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Output": "PASS\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "output", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Output": "ok\tgithub.com/tphakala/birdnet-go/internal/classifier\t0.456s\n"}
+{"Time": "2025-01-15T10:00:00Z", "Action": "pass", "Package": "github.com/tphakala/birdnet-go/internal/classifier", "Elapsed": 0.456}


### PR DESCRIPTION
## Summary

Fixes #1882. `rtk go test` was hiding the actual failure context behind a tee file path on any non-trivial failure (panic, timeout, fatal error). The summary plus a `[full output: ...]` link is fine for a human at a terminal, but it forces LLMs to make a second tool call just to learn what broke — defeating the inline-diagnostic premise. This patch keeps the existing tee fallback but inlines the panic message and user-code stack frames directly, capped so the output never balloons.

## Reproduction

A test that panics produced (before this PR):

```
Go test: 336 passed, 1 failed, 1 skipped in 2 packages
═══════════════════════════════════════

classifier (1 passed, 1 failed)
  [FAIL] TestClassify
     panic: runtime error: index out of range [3] with length 2 [recovered]
     panic: runtime error: index out of range [3] with length 2
     /usr/local/go/src/testing/testing.go:1545 +0x238
     testing.tRunner.func1()
     /usr/local/go/src/testing/testing.go:1548 +0x397
```

The `classifier_test.go:58` line (the actual bug site) and the `model.go:142` panic origin were silently dropped. The user has to open the tee file to see them.

## Root cause

`select_go_test_failure_lines` was a one-pass loop with a hard 5-line cap and two heuristics: `is_go_test_location_line` (matches `.go:<digit>`) and `is_go_test_failure_line` (matches `panic:`, `error:`, `expected`, `got`, etc.). A Go panic stack frame looks like:

```
github.com/x/y/z.(*Model).Predict(...)
	/home/runner/.../classifier/model.go:142 +0x1a4
```

The function-name row has no `.go:` and matches none of the failure keywords, so it's discarded. After 5 lines the loop exits, and the runtime-side frames win the cap because they appear first in the trace. The user-code frames the developer actually needs are never emitted.

## Fix

Detect when the captured output for a failed test contains a panic / fatal-error / goroutine header. If so, switch to a contiguous "trace mode":

- preserve every non-cosmetic line verbatim (drop only `=== RUN` / `=== PAUSE` / `=== CONT` / `=== NAME` / `--- PASS` and blank lines)
- cap at 50 lines per failure, appending `… +N more trace lines (see tee file)` when the cap fires
- widen per-line truncation from 100 → 160 chars (long CI paths fit)

Plain assertion failures still go through the old heuristic path, but with the per-failure cap bumped from 5 → 8 lines so an immediate follow-up context line after a `file:line` header isn't dropped.

## Behavior after this PR

```
Go test: 336 passed, 1 failed, 1 skipped in 2 packages
═══════════════════════════════════════

classifier (1 passed, 1 failed)
  [FAIL] TestClassify
     --- FAIL: TestClassify (0.02s)
     panic: runtime error: index out of range [3] with length 2 [recovered]
     panic: runtime error: index out of range [3] with length 2
     goroutine 17 [running]:
     testing.tRunner.func1.2({0x10a3ce0, 0xc000018090})
     /usr/local/go/src/testing/testing.go:1545 +0x238
     ...
     github.com/tphakala/birdnet-go/internal/classifier.(*Model).Predict(...)
     /home/runner/work/birdnet-go/internal/classifier/model.go:142 +0x1a4
     github.com/tphakala/birdnet-go/internal/classifier.TestClassify(0xc0001b6680)
     /home/runner/work/birdnet-go/internal/classifier/classifier_test.go:58 +0xf8
     ...
[full output: ~/.local/share/rtk/tee/...go_test.log]
```

The tee hint stays — full unfiltered NDJSON remains one path away if a developer wants it. Passing-only output is unchanged (still a one-line summary).

## Tradeoff

Failed tests with panics produce a larger inline section than before. On the synthetic panic fixture, RTK now emits 1267 bytes of filtered output vs. 502 bytes pre-fix — but the raw NDJSON is 8095 bytes, so we're still cutting ~84% of bytes. The cap of 50 trace lines guarantees no single failure can blow past tee territory.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets` zero warnings
- [x] `cargo test --bin rtk -- --test-threads=8` — 1906 passed, 0 failed, 6 ignored
- [x] New fixture `tests/fixtures/go_test_panic_json.txt` (panic + stack trace, 2 packages, 1 skipped)
- [x] New fixture `tests/fixtures/go_test_pass_json.txt` (336 passing tests, 2 packages, regression guard)
- [x] `test_filter_go_test_panic_preserves_full_trace` — asserts panic msg, `goroutine 17 [running]:`, `classifier_test.go:58`, `model.go:142` all inline
- [x] `test_filter_go_test_panic_caps_stack_trace_size` — output ≤ 80 lines
- [x] `test_filter_go_test_panic_still_saves_meaningful_bytes` — ≥ 60% byte savings even with panic trace
- [x] `test_filter_go_test_all_pass_remains_compact` — 336-pass case stays summary-only, ≥ 60% token savings
- [x] All pre-existing go_cmd tests still pass (timeout/build-fail/double-count regression cases)

Fixes #1882