### PR TITLE
feat(tracking): honour tracking.enabled and redact sensitive args

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -59,6 +59,16 @@ pub struct TrackingConfig {
     pub history_days: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database_path: Option<PathBuf>,
+    /// Replace stored project paths with `<basename>#<8-hex-sha256>` so the
+    /// tracking DB does not pin a user's private filesystem layout. Defaults
+    /// to `true`; set to `false` to keep raw paths for `rtk gain --by-project`
+    /// scripts that depend on prefix matching.
+    #[serde(default = "default_true")]
+    pub hash_project_paths: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 impl Default for TrackingConfig {
@@ -67,6 +77,7 @@ impl Default for TrackingConfig {
             enabled: true,
             history_days: DEFAULT_HISTORY_DAYS as u32,
             database_path: None,
+            hash_project_paths: true,
         }
     }
 }
@@ -183,6 +194,12 @@ impl Config {
 }
 
 fn get_config_path() -> Result<PathBuf> {
+    // Priority 1: explicit override (mirrors RTK_DB_PATH for `Tracker`).
+    // Mostly used by tests to keep `Config::load()` deterministic without
+    // touching the real `$HOME`.
+    if let Ok(custom) = std::env::var("RTK_CONFIG_PATH") {
+        return Ok(PathBuf::from(custom));
+    }
     let config_dir = dirs::config_dir().unwrap_or_else(|| PathBuf::from("."));
     Ok(config_dir.join(RTK_DATA_DIR).join(CONFIG_TOML))
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod constants;
 pub mod display_helpers;
 pub mod filter;
+pub mod redact;
 pub mod runner;
 pub mod stream;
 pub mod tee;

--- a/src/core/redact.rs
+++ b/src/core/redact.rs
@@ -1,0 +1,286 @@
+//! Shared credential/PII redactor used by tracking and tee.
+//!
+//! `redact_command` scrubs known credential shapes from a command line
+//! (URL userinfo, Bearer / Authorization headers, `--token=`/`--password=`/etc,
+//! inline `FOO_TOKEN=…` assignments, and well-known credential prefixes such
+//! as `ghp_`, `sk-`, `AKIA…`). `redact_project_path` reduces a filesystem
+//! path to `<basename>#<8-hex-sha256>` so the tracking DB does not pin a
+//! user's private layout.
+//!
+//! All regex are `lazy_static!`-cached and the public functions perform a
+//! single pass per call — they run on the `Tracker::record` hot path.
+//!
+//! This module is shared with the upcoming tee content redactor (see the
+//! security & privacy design doc) — `redact_project_path` and the regex
+//! helpers are deliberately `pub(crate)` so PR 3 can consume them without
+//! duplicating the patterns.
+
+use lazy_static::lazy_static;
+use regex::Regex;
+use sha2::{Digest, Sha256};
+use std::path::Path;
+
+lazy_static! {
+    /// `https://user:secret@host/repo` → keep host/path, mask user + secret.
+    /// Restricted to URL contexts (after `://`) so we do not chew through
+    /// arbitrary `user:pass` substrings.
+    static ref URL_USERINFO_RE: Regex =
+        Regex::new(r"(?P<scheme>[a-zA-Z][a-zA-Z0-9+.-]*://)(?P<user>[^/@\s:]+):(?P<pass>[^@\s]+)@")
+            .expect("URL_USERINFO_RE");
+
+    /// `Authorization: Bearer abc123` / `bearer abc123` style.
+    /// We match the keyword and replace the trailing token with `****`.
+    static ref BEARER_RE: Regex = Regex::new(
+        r#"(?i)(?P<lead>(?:authorization\s*[:=]\s*)?(?:bearer|basic|token))[ \t]+(?P<val>[^\s"']+)"#
+    )
+    .expect("BEARER_RE");
+
+    /// `--token=secret` / `--token secret` / `-p=secret`.
+    /// Covers `token`, `password`, `passwd`, `pwd`, `api-key`, `apikey`,
+    /// `secret`, `auth`, `access-token`, `refresh-token`.
+    static ref FLAG_VALUE_RE: Regex = Regex::new(
+        r#"(?ix)
+        (?P<flag>--(?:token|password|passwd|pwd|api[_-]?key|secret|auth|access[_-]?token|refresh[_-]?token))
+        (?P<sep>=|\s+)
+        (?P<val>[^\s"']+)
+        "#
+    )
+    .expect("FLAG_VALUE_RE");
+
+    /// Inline env-style `FOO_TOKEN=value` assignment.
+    /// Restricted to a known-allowlist of credential-shaped variable names so
+    /// we do not mangle benign `LANG=en_US.UTF-8`-style assignments.
+    static ref INLINE_ENV_RE: Regex = Regex::new(
+        r"(?x)
+        \b
+        (?P<name>
+            AWS_SECRET_ACCESS_KEY
+            | AWS_SESSION_TOKEN
+            | AWS_ACCESS_KEY_ID
+            | GH_TOKEN
+            | GITHUB_TOKEN
+            | GH_ENTERPRISE_TOKEN
+            | GITLAB_TOKEN
+            | OPENAI_API_KEY
+            | ANTHROPIC_API_KEY
+            | NPM_TOKEN
+            | HF_TOKEN
+            | HUGGING_FACE_HUB_TOKEN
+            | SLACK_TOKEN
+            | SLACK_BOT_TOKEN
+            | SLACK_APP_TOKEN
+            | DOCKER_PASSWORD
+            | DOCKERHUB_PASSWORD
+            | CI_JOB_TOKEN
+            | CARGO_REGISTRY_TOKEN
+            | RUBYGEMS_API_KEY
+            | PYPI_TOKEN
+            | DATABASE_URL
+            | PGPASSWORD
+        )
+        =
+        (?P<val>\S+)
+        "
+    )
+    .expect("INLINE_ENV_RE");
+
+    /// "Looks like a credential" heuristic — well-known prefixes.
+    /// `ghp_…`, `gho_…`, `ghu_…`, `ghs_…`, `github_pat_…`,
+    /// `sk-…` / `sk_live_…` / `sk_test_…`, `xoxb-…` / `xoxp-…`,
+    /// `AKIA…` (AWS access key id), `ASIA…` (AWS STS), `glpat-…` (GitLab).
+    static ref CREDENTIAL_PREFIX_RE: Regex = Regex::new(
+        r"(?x)
+        \b
+        (?:
+            ghp_ | gho_ | ghu_ | ghs_ | github_pat_
+            | sk-live_ | sk_live_ | sk_test_ | sk-
+            | xoxb- | xoxp- | xoxa- | xoxs-
+            | glpat-
+            | AKIA | ASIA
+        )
+        [A-Za-z0-9_\-]{16,}
+        \b
+        "
+    )
+    .expect("CREDENTIAL_PREFIX_RE");
+
+    /// Project-path output shape used by `redact_project_path`.
+    static ref BASENAME_SAFE_RE: Regex =
+        Regex::new(r"[^A-Za-z0-9_.-]").expect("BASENAME_SAFE_RE");
+}
+
+/// Scrub credential-shaped substrings from a command line.
+///
+/// Runs a single, deterministic pass through the lazy-cached regex bundle.
+/// The function is idempotent — running it twice produces the same string,
+/// because every replacement collapses to `****` (which matches none of the
+/// patterns).
+pub(crate) fn redact_command(s: &str) -> String {
+    if s.is_empty() {
+        return String::new();
+    }
+
+    // 1. URL userinfo: scheme://user:pass@host → scheme://****:****@host
+    let s = URL_USERINFO_RE.replace_all(s, "$scheme****:****@");
+
+    // 2. Bearer / Basic / Token header values
+    let s = BEARER_RE.replace_all(&s, "$lead ****");
+
+    // 3. Flag/value pairs (--token=…, --password …)
+    let s = FLAG_VALUE_RE.replace_all(&s, "$flag$sep****");
+
+    // 4. Well-known inline env assignments (GH_TOKEN=…)
+    let s = INLINE_ENV_RE.replace_all(&s, "$name=****");
+
+    // 5. Credential prefix heuristic (ghp_…, sk-…, AKIA…) — last so the
+    //    other rules get first crack at structured values.
+    let s = CREDENTIAL_PREFIX_RE.replace_all(&s, "****");
+
+    s.into_owned()
+}
+
+/// Reduce a project path to `<basename>#<8-hex-sha256>`.
+///
+/// Used by the tracking DB so `rtk gain --by-project` can still distinguish
+/// projects without storing `/Users/<corporate-username>/Clients/Acme/…`.
+/// Empty / unrecognised paths short-circuit to `""` so the existing
+/// `project_path != ''` filter in `projects_count()` keeps working.
+///
+/// The output shape is `<sanitised-basename>#<8-hex>` which always satisfies
+/// `^[A-Za-z0-9_.-]+#[0-9a-f]{8}$`.
+pub(crate) fn redact_project_path(s: &str) -> String {
+    if s.is_empty() {
+        return String::new();
+    }
+
+    // Already-redacted paths (basename#deadbeef) are idempotent — let them
+    // round-trip unchanged so the one-shot migration is safe to re-run.
+    if is_already_hashed(s) {
+        return s.to_string();
+    }
+
+    let basename = Path::new(s)
+        .file_name()
+        .map(|os| os.to_string_lossy().to_string())
+        .unwrap_or_else(|| "root".to_string());
+
+    let basename_safe = BASENAME_SAFE_RE.replace_all(&basename, "_");
+    let basename_safe = if basename_safe.is_empty() {
+        "root".to_string()
+    } else {
+        basename_safe.into_owned()
+    };
+
+    let mut hasher = Sha256::new();
+    hasher.update(s.as_bytes());
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(8);
+    for byte in digest.iter().take(4) {
+        use std::fmt::Write as _;
+        let _ = write!(&mut hex, "{:02x}", byte);
+    }
+
+    format!("{}#{}", basename_safe, hex)
+}
+
+fn is_already_hashed(s: &str) -> bool {
+    let Some((base, hash)) = s.rsplit_once('#') else {
+        return false;
+    };
+    if hash.len() != 8 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+        return false;
+    }
+    !base.is_empty()
+        && base
+            .chars()
+            .all(|c| matches!(c, 'A'..='Z' | 'a'..='z' | '0'..='9' | '_' | '.' | '-'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_redact_url_userinfo() {
+        let input = "git push https://alice:s3cret@github.com/acme/repo.git main";
+        let got = redact_command(input);
+        assert!(
+            got.contains("https://****:****@github.com/acme/repo.git"),
+            "got: {got}"
+        );
+        assert!(!got.contains("alice"));
+        assert!(!got.contains("s3cret"));
+    }
+
+    #[test]
+    fn test_redact_bearer_header() {
+        let input = r#"curl -H "Authorization: Bearer abc123XYZdef456" https://api.example.com"#;
+        let got = redact_command(input);
+        assert!(got.contains("Bearer ****"), "got: {got}");
+        assert!(!got.contains("abc123XYZdef456"));
+    }
+
+    #[test]
+    fn test_redact_flag_value_pairs() {
+        let input =
+            "tool --token=abc123 --password xyz789 --api-key=key1 --secret xyzS --auth=A1B2C3";
+        let got = redact_command(input);
+        // Each flag's value masked
+        assert!(got.contains("--token=****"), "got: {got}");
+        assert!(got.contains("--password ****"), "got: {got}");
+        assert!(got.contains("--api-key=****"), "got: {got}");
+        assert!(got.contains("--secret ****"), "got: {got}");
+        assert!(got.contains("--auth=****"), "got: {got}");
+        // No leaked literals
+        for needle in ["abc123", "xyz789", "key1", "xyzS", "A1B2C3"] {
+            assert!(!got.contains(needle), "needle {needle} leaked: {got}");
+        }
+    }
+
+    #[test]
+    fn test_redact_inline_env() {
+        let input = "GH_TOKEN=ghp_ZZZZZZZZZZZZZZZZZZZZ git push origin main";
+        let got = redact_command(input);
+        assert!(got.contains("GH_TOKEN=****"), "got: {got}");
+        assert!(!got.contains("ghp_ZZZZZZZZZZZZZZZZZZZZ"));
+    }
+
+    #[test]
+    fn test_redact_credential_heuristic() {
+        // Synthetic fixtures: chosen so GitHub's secret-scanner does not
+        // (correctly) reject the commit. Each starts with a credential-prefix
+        // RTK recognises and is followed by 16+ chars that match the regex.
+        let inputs_and_haystacks = [
+            // ghp_<20 ZZ…> — not a real PAT, but matches our prefix regex.
+            "echo ghp_ZZZZZZZZZZZZZZZZZZZZ",
+            "echo sk-ZZZZZZZZZZZZZZZZZZZZ",
+            "echo AKIAZZZZZZZZZZZZZZZZ",
+            "echo xoxb-ZZZZZZZZZZ-ZZZZZZZZZZZZZZ",
+        ];
+        let prefixes = ["ghp_ZZZZ", "sk-ZZZZ", "AKIAZZZZ", "xoxb-ZZZZ"];
+        for input in inputs_and_haystacks {
+            let got = redact_command(input);
+            assert!(got.contains("****"), "want **** in: {got} (input {input})");
+            let prefix_leaked = prefixes
+                .iter()
+                .any(|p| input.contains(p) && got.contains(p));
+            assert!(!prefix_leaked, "prefix leaked: {got}");
+        }
+    }
+
+    #[test]
+    fn test_redact_idempotent() {
+        let inputs = [
+            "git push https://alice:s3cret@github.com/acme/repo.git",
+            "curl -H 'Authorization: Bearer abc' https://x",
+            "tool --token=xyz --password=k",
+            "GH_TOKEN=ghp_ZZZZZZZZZZZZZZZZZZZZ git push",
+            "echo ghp_ZZZZZZZZZZZZZZZZZZZZ",
+        ];
+        for input in inputs {
+            let once = redact_command(input);
+            let twice = redact_command(&once);
+            assert_eq!(once, twice, "non-idempotent for input: {input}");
+        }
+    }
+}

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -29,6 +29,7 @@
 //!
 //! See [docs/tracking.md](../docs/tracking.md) for full documentation.
 
+use super::redact::{redact_command, redact_project_path};
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection};
@@ -36,6 +37,45 @@ use serde::Serialize;
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::time::Instant;
+
+/// SQLite `PRAGMA user_version` value that signals the credential-redaction
+/// migration has been applied. Bumped from the previous baseline of 0/1 to 2.
+const USER_VERSION_REDACTED: i32 = 2;
+
+/// Re-canonicalise a project path against the config-driven hashing toggle.
+/// Centralised here so `Tracker::record` and the one-shot migration share a
+/// single decision point.
+fn canonical_project_path(raw: &str, hash_enabled: bool) -> String {
+    if hash_enabled {
+        redact_project_path(raw)
+    } else {
+        raw.to_string()
+    }
+}
+
+/// Decide whether `Tracker::record` / `Tracker::record_parse_failure` should
+/// touch the DB this invocation.
+///
+/// Honours the long-documented-but-previously-unenforced `tracking.enabled`
+/// flag and adds a one-shot `RTK_TRACK=0` escape hatch mirroring the existing
+/// `RTK_TEE=0` pattern. Fails open: a missing/corrupt config never disables
+/// tracking on its own.
+fn tracking_enabled() -> bool {
+    if std::env::var("RTK_TRACK").ok().as_deref() == Some("0") {
+        return false;
+    }
+    crate::core::config::Config::load()
+        .map(|c| c.tracking.enabled)
+        .unwrap_or(true)
+}
+
+/// Whether `redact_project_path` should be applied. Defaults to true so new
+/// rows are private by default.
+fn hash_project_paths_enabled() -> bool {
+    crate::core::config::Config::load()
+        .map(|c| c.tracking.hash_project_paths)
+        .unwrap_or(true)
+}
 
 // ── Project path helpers ── // added: project-scoped tracking support
 
@@ -323,7 +363,105 @@ impl Tracker {
             [],
         )?;
 
-        Ok(Self { conn })
+        let tracker = Self { conn };
+        // One-shot redaction migration. Logs (and swallows) errors so a
+        // half-broken DB never blocks `rtk gain` from opening.
+        if let Err(e) = tracker.maybe_run_redaction_migration() {
+            eprintln!("rtk: tracking redaction migration skipped: {}", e);
+        }
+        Ok(tracker)
+    }
+
+    /// Redact `original_cmd` and `project_path` for rows newer than 90 days.
+    ///
+    /// Gated by `PRAGMA user_version` so it runs at most once per binary
+    /// version. The migration is a pure-Rust read-modify-write loop; we do
+    /// not register a SQLite UDF.
+    fn maybe_run_redaction_migration(&self) -> Result<()> {
+        let current: i32 = self
+            .conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .unwrap_or(0);
+        if current >= USER_VERSION_REDACTED {
+            return Ok(());
+        }
+
+        let cutoff = Utc::now() - chrono::Duration::days(DEFAULT_HISTORY_DAYS);
+        let hash_paths = hash_project_paths_enabled();
+
+        // Collect candidate rows first so we don't hold a statement open
+        // while issuing UPDATEs on the same connection.
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, original_cmd, project_path
+                 FROM commands
+                 WHERE timestamp >= ?1",
+            )
+            .context("Failed to prepare migration SELECT")?;
+        let rows: Vec<(i64, String, String)> = stmt
+            .query_map(params![cutoff.to_rfc3339()], |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            })
+            .context("Failed to query commands for migration")?
+            .collect::<Result<Vec<_>, _>>()
+            .context("Failed to collect migration rows")?;
+        drop(stmt);
+
+        for (id, cmd, project_path) in rows {
+            let cmd_redacted = redact_command(&cmd);
+            let path_redacted = canonical_project_path(&project_path, hash_paths);
+            if cmd_redacted == cmd && path_redacted == project_path {
+                continue;
+            }
+            self.conn
+                .execute(
+                    "UPDATE commands
+                     SET original_cmd = ?1, project_path = ?2
+                     WHERE id = ?3",
+                    params![cmd_redacted, path_redacted, id],
+                )
+                .context("Failed to update redacted row")?;
+        }
+
+        // Parse failures table — same treatment for `raw_command`.
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, raw_command FROM parse_failures
+                 WHERE timestamp >= ?1",
+            )
+            .context("Failed to prepare migration SELECT (parse_failures)")?;
+        let pf_rows: Vec<(i64, String)> = stmt
+            .query_map(params![cutoff.to_rfc3339()], |row| {
+                Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+            })
+            .context("Failed to query parse_failures for migration")?
+            .collect::<Result<Vec<_>, _>>()
+            .context("Failed to collect parse_failures rows")?;
+        drop(stmt);
+        for (id, raw_cmd) in pf_rows {
+            let redacted = redact_command(&raw_cmd);
+            if redacted == raw_cmd {
+                continue;
+            }
+            self.conn
+                .execute(
+                    "UPDATE parse_failures SET raw_command = ?1 WHERE id = ?2",
+                    params![redacted, id],
+                )
+                .context("Failed to update redacted parse_failure row")?;
+        }
+
+        // PRAGMA user_version takes a literal int, not a bound param.
+        self.conn
+            .execute_batch(&format!("PRAGMA user_version = {}", USER_VERSION_REDACTED))
+            .context("Failed to bump user_version after migration")?;
+        Ok(())
     }
 
     /// Create an isolated in-memory tracker for tests.
@@ -333,6 +471,14 @@ impl Tracker {
         let tracker = Self { conn };
         tracker.init_schema()?;
         Ok(tracker)
+    }
+
+    /// Run the credential-redaction migration on an in-memory tracker.
+    /// Exposed for the dedicated migration test; production callers go
+    /// through `Tracker::new()`.
+    #[cfg(test)]
+    pub fn run_redaction_migration_for_tests(&self) -> Result<()> {
+        self.maybe_run_redaction_migration()
     }
 
     #[cfg(test)]
@@ -407,6 +553,10 @@ impl Tracker {
         output_tokens: usize,
         exec_time_ms: u64,
     ) -> Result<()> {
+        if !tracking_enabled() {
+            return Ok(()); // silent no-op when [tracking] enabled = false / RTK_TRACK=0
+        }
+
         let saved = input_tokens.saturating_sub(output_tokens);
         let pct = if input_tokens > 0 {
             (saved as f64 / input_tokens as f64) * 100.0
@@ -414,14 +564,21 @@ impl Tracker {
             0.0
         };
 
-        let project_path = current_project_path_string(); // added: record cwd
+        // Scrub credential-shaped substrings before binding to SQL. The
+        // ecosystem aggregation paths (top_commands, categorize_command,
+        // top_passthrough) only look at the first whitespace-delimited
+        // token, which the redactor never touches.
+        let original_cmd_redacted = redact_command(original_cmd);
+
+        let raw_project_path = current_project_path_string(); // added: record cwd
+        let project_path = canonical_project_path(&raw_project_path, hash_project_paths_enabled());
 
         self.conn.execute(
             "INSERT INTO commands (timestamp, original_cmd, rtk_cmd, project_path, input_tokens, output_tokens, saved_tokens, savings_pct, exec_time_ms)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)", // added: project_path
             params![
                 Utc::now().to_rfc3339(),
-                original_cmd,
+                original_cmd_redacted,
                 rtk_cmd,
                 project_path, // added
                 input_tokens as i64,
@@ -469,12 +626,16 @@ impl Tracker {
         error_message: &str,
         fallback_succeeded: bool,
     ) -> Result<()> {
+        if !tracking_enabled() {
+            return Ok(()); // gated by the same flag as Tracker::record
+        }
+        let raw_command_redacted = redact_command(raw_command);
         self.conn.execute(
             "INSERT INTO parse_failures (timestamp, raw_command, error_message, fallback_succeeded)
              VALUES (?1, ?2, ?3, ?4)",
             params![
                 Utc::now().to_rfc3339(),
-                raw_command,
+                raw_command_redacted,
                 error_message,
                 fallback_succeeded as i32,
             ],
@@ -1684,6 +1845,366 @@ mod tests {
         assert_eq!(
             failures.total, 0,
             "parse_failures table should be empty after reset"
+        );
+    }
+
+    // ── Finding 2 + 3 redaction & gating tests ──
+    //
+    // All tests below set `HOME` / `XDG_CONFIG_HOME` to a per-test temp dir so
+    // `Config::load()` falls back to defaults (tracking.enabled = true,
+    // hash_project_paths = true). They serialise via `tracking_env_lock` to
+    // avoid env-var races, mirroring `test_db_path_env_and_default`.
+
+    use std::sync::Mutex;
+    static TRACKING_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct ScopedEnv {
+        keys: Vec<(&'static str, Option<OsString>)>,
+    }
+
+    impl ScopedEnv {
+        fn new(overrides: &[(&'static str, Option<&str>)]) -> Self {
+            let mut saved = Vec::with_capacity(overrides.len());
+            for (key, val) in overrides {
+                saved.push((*key, std::env::var_os(key)));
+                match val {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+            Self { keys: saved }
+        }
+    }
+
+    impl Drop for ScopedEnv {
+        fn drop(&mut self) {
+            for (key, prev) in &self.keys {
+                match prev {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+
+    /// Write a config file at `<tmp>/config.toml` and return the path.
+    fn write_config(tmp: &std::path::Path, toml: &str) -> std::path::PathBuf {
+        let p = tmp.join("config.toml");
+        std::fs::write(&p, toml).expect("write config.toml");
+        p
+    }
+
+    /// Build an env-override list that points `Config::load()` at a per-test
+    /// config file via `RTK_CONFIG_PATH`. Avoids mutating `HOME` so we don't
+    /// race against other tests that call `Tracker::new()`.
+    fn make_isolated_config_env(
+        cfg_path: &std::path::Path,
+    ) -> Vec<(&'static str, Option<&'static str>)> {
+        let p: &'static str = Box::leak(
+            cfg_path
+                .to_str()
+                .expect("temp path utf8")
+                .to_string()
+                .into_boxed_str(),
+        );
+        vec![
+            ("RTK_CONFIG_PATH", Some(p)),
+            // Make sure no stray RTK_TRACK from the host leaks in.
+            ("RTK_TRACK", None),
+        ]
+    }
+
+    // ── Finding 2: redact_command tests ──
+
+    #[test]
+    fn test_redact_command_url_userinfo() {
+        let input = "git push https://x:y@host/repo";
+        let got = redact_command(input);
+        assert!(got.contains("https://****:****@host/repo"), "got: {got}");
+        assert!(!got.contains("x:y@"));
+    }
+
+    #[test]
+    fn test_redact_command_bearer() {
+        let input = r#"curl -H "Authorization: Bearer abc123" https://api"#;
+        let got = redact_command(input);
+        assert!(got.contains("Bearer ****"), "got: {got}");
+        assert!(!got.contains("abc123"));
+    }
+
+    #[test]
+    fn test_redact_command_flags() {
+        let cases = [
+            ("tool --token=abc", "--token=****"),
+            ("tool --password xyz", "--password ****"),
+            ("tool --api-key=k", "--api-key=****"),
+        ];
+        for (input, needle) in cases {
+            let got = redact_command(input);
+            assert!(got.contains(needle), "input={input} got={got}");
+            assert!(!got.contains("abc") || !input.contains("abc=abc"));
+        }
+    }
+
+    #[test]
+    fn test_redact_command_inline_env() {
+        let input = "GH_TOKEN=ghp_abc git push";
+        let got = redact_command(input);
+        assert!(got.contains("GH_TOKEN=****"), "got: {got}");
+        assert!(!got.contains("ghp_abc"));
+    }
+
+    #[test]
+    fn test_redact_command_credential_heuristic() {
+        // Synthetic fixtures (all Z-suffixed) — not real credentials, but
+        // they trip the RTK prefix regex without flagging GitHub's
+        // secret-scanner.
+        let cases = [
+            ("echo ghp_ZZZZZZZZZZZZZZZZZZZZ", "ghp_"),
+            ("echo sk-ZZZZZZZZZZZZZZZZZZZZ", "sk-"),
+            ("echo AKIAZZZZZZZZZZZZZZZZ", "AKIA"),
+        ];
+        for (input, prefix) in cases {
+            let got = redact_command(input);
+            assert!(got.contains("****"), "input={input} got={got}");
+            let original_tail = input.split_whitespace().last().expect("token");
+            assert!(
+                !got.contains(original_tail),
+                "original token {original_tail} (prefix {prefix}) leaked: {got}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_redact_command_idempotent() {
+        let inputs = [
+            "git push https://alice:s3cret@github.com/acme/repo.git",
+            "curl --token=abc -H 'Authorization: Bearer xyz' https://api",
+            "GH_TOKEN=ghp_ZZZZZZZZZZZZZZZZZZZZ git push",
+        ];
+        for input in inputs {
+            let once = redact_command(input);
+            let twice = redact_command(&once);
+            assert_eq!(once, twice, "non-idempotent: {input}");
+        }
+    }
+
+    #[test]
+    fn test_redact_project_path_shape() {
+        let cases = [
+            "/Users/alice/Projects/rtk",
+            "/home/bob/work/secret-project",
+            "C:\\Users\\carol\\code\\rtk",
+            "/", // edge case
+        ];
+        let shape = regex::Regex::new(r"^[A-Za-z0-9_.-]+#[0-9a-f]{8}$").expect("shape regex");
+        for path in cases {
+            let got = redact_project_path(path);
+            assert!(shape.is_match(&got), "shape mismatch for {path}: got {got}");
+        }
+        // Empty path stays empty (so existing `project_path != ''` filter
+        // keeps treating it as "no project recorded").
+        assert_eq!(redact_project_path(""), "");
+    }
+
+    #[test]
+    fn test_migration_redacts_existing_rows() {
+        let tracker = Tracker::new_in_memory().expect("in-memory tracker");
+
+        // Insert a pre-migration row directly (bypassing record's redactor).
+        // Token below is a synthetic Z-suffixed fixture (not a real PAT).
+        let original =
+            "git push https://alice:s3cret@example.com/repo --token=ghp_ZZZZZZZZZZZZZZZZZZZZ";
+        tracker
+            .conn
+            .execute(
+                "INSERT INTO commands
+                 (timestamp, original_cmd, rtk_cmd, project_path,
+                  input_tokens, output_tokens, saved_tokens, savings_pct, exec_time_ms)
+                 VALUES (?1, ?2, 'rtk git push', '/Users/test/proj', 100, 20, 80, 80.0, 5)",
+                params![Utc::now().to_rfc3339(), original],
+            )
+            .expect("seed pre-migration row");
+        // Pre-condition: token visible.
+        let row: String = tracker
+            .conn
+            .query_row("SELECT original_cmd FROM commands LIMIT 1", [], |r| {
+                r.get(0)
+            })
+            .expect("read seeded row");
+        assert!(row.contains("ghp_ZZZZZZZZZZZZZZZZZZZZ"), "seed: {row}");
+
+        // Reset user_version so the migration runs.
+        tracker
+            .conn
+            .execute_batch("PRAGMA user_version = 0")
+            .expect("reset user_version");
+        tracker
+            .run_redaction_migration_for_tests()
+            .expect("run migration");
+
+        let row: String = tracker
+            .conn
+            .query_row("SELECT original_cmd FROM commands LIMIT 1", [], |r| {
+                r.get(0)
+            })
+            .expect("read migrated row");
+        assert!(
+            !row.contains("ghp_ZZZZZZZZZZZZZZZZZZZZ"),
+            "token leaked post-migration: {row}"
+        );
+        assert!(!row.contains("alice"), "user leaked post-migration: {row}");
+        assert!(!row.contains("s3cret"), "pw leaked post-migration: {row}");
+
+        // user_version bumped → second run is a no-op (does not re-rewrite).
+        let path_before: String = tracker
+            .conn
+            .query_row("SELECT project_path FROM commands LIMIT 1", [], |r| {
+                r.get(0)
+            })
+            .expect("read project_path");
+        tracker
+            .run_redaction_migration_for_tests()
+            .expect("second migration");
+        let path_after: String = tracker
+            .conn
+            .query_row("SELECT project_path FROM commands LIMIT 1", [], |r| {
+                r.get(0)
+            })
+            .expect("read project_path again");
+        assert_eq!(path_before, path_after, "migration not idempotent");
+    }
+
+    // ── Finding 3: tracking_enabled gate tests ──
+
+    #[test]
+    fn test_tracking_disabled_via_config_skips_insert() {
+        let _guard = TRACKING_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg = write_config(
+            tmp.path(),
+            "[tracking]\nenabled = false\nhistory_days = 90\n",
+        );
+        let overrides = make_isolated_config_env(&cfg);
+        let _env = ScopedEnv::new(&overrides);
+
+        let tracker = Tracker::new_in_memory().expect("tracker");
+        let before: i64 = tracker
+            .conn
+            .query_row("SELECT COUNT(*) FROM commands", [], |r| r.get(0))
+            .expect("count");
+        tracker
+            .record("git status", "rtk git status", 100, 20, 5)
+            .expect("record");
+        let after: i64 = tracker
+            .conn
+            .query_row("SELECT COUNT(*) FROM commands", [], |r| r.get(0))
+            .expect("count");
+        assert_eq!(
+            before, after,
+            "tracking.enabled = false must skip the INSERT"
+        );
+    }
+
+    #[test]
+    fn test_tracking_disabled_via_env_skips_insert() {
+        let _guard = TRACKING_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // No config file written — rely on the env var override.
+        let cfg = tmp.path().join("nonexistent-config.toml");
+        let mut overrides = make_isolated_config_env(&cfg);
+        for slot in overrides.iter_mut() {
+            if slot.0 == "RTK_TRACK" {
+                slot.1 = Some("0");
+            }
+        }
+        let _env = ScopedEnv::new(&overrides);
+
+        let tracker = Tracker::new_in_memory().expect("tracker");
+        tracker
+            .record("git status", "rtk git status", 100, 20, 5)
+            .expect("record");
+        let after: i64 = tracker
+            .conn
+            .query_row("SELECT COUNT(*) FROM commands", [], |r| r.get(0))
+            .expect("count");
+        assert_eq!(after, 0, "RTK_TRACK=0 must skip the INSERT");
+    }
+
+    #[test]
+    fn test_tracking_enabled_default_records() {
+        let _guard = TRACKING_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg = tmp.path().join("missing-config.toml"); // file does not exist → defaults
+        let overrides = make_isolated_config_env(&cfg);
+        let _env = ScopedEnv::new(&overrides);
+
+        let tracker = Tracker::new_in_memory().expect("tracker");
+        tracker
+            .record("git status", "rtk git status", 100, 20, 5)
+            .expect("record");
+        let after: i64 = tracker
+            .conn
+            .query_row("SELECT COUNT(*) FROM commands", [], |r| r.get(0))
+            .expect("count");
+        assert_eq!(after, 1, "default config must record");
+    }
+
+    #[test]
+    fn test_tracking_disabled_still_lets_reset_run() {
+        let _guard = TRACKING_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // Step 1: seed a row while tracking is enabled (no config file yet).
+        let cfg_path = tmp.path().join("config.toml");
+        let overrides = make_isolated_config_env(&cfg_path);
+        let _env = ScopedEnv::new(&overrides);
+
+        let tracker = Tracker::new_in_memory().expect("tracker");
+        tracker
+            .record("git status", "rtk git status", 100, 20, 5)
+            .expect("seed record");
+
+        // Step 2: write the disabling config in place.
+        std::fs::write(
+            &cfg_path,
+            "[tracking]\nenabled = false\nhistory_days = 90\n",
+        )
+        .expect("write config");
+
+        // Records are now no-ops, but reset_all must still drain the table.
+        tracker
+            .record("git diff", "rtk git diff", 50, 10, 5)
+            .expect("noop record");
+        tracker.reset_all().expect("reset");
+        let after: i64 = tracker
+            .conn
+            .query_row("SELECT COUNT(*) FROM commands", [], |r| r.get(0))
+            .expect("count");
+        assert_eq!(after, 0, "reset_all must work even when disabled");
+    }
+
+    #[test]
+    fn test_parse_failure_also_gated() {
+        let _guard = TRACKING_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg = write_config(
+            tmp.path(),
+            "[tracking]\nenabled = false\nhistory_days = 90\n",
+        );
+        let overrides = make_isolated_config_env(&cfg);
+        let _env = ScopedEnv::new(&overrides);
+
+        let tracker = Tracker::new_in_memory().expect("tracker");
+        tracker
+            .record_parse_failure("bad cmd", "boom", false)
+            .expect("noop pf");
+        let after: i64 = tracker
+            .conn
+            .query_row("SELECT COUNT(*) FROM parse_failures", [], |r| r.get(0))
+            .expect("count");
+        assert_eq!(
+            after, 0,
+            "record_parse_failure must respect tracking.enabled"
         );
     }
 }


### PR DESCRIPTION
## Summary

This is the second of three security PRs landing the [RTK security &
privacy remediation design](https://github.com/rtk-ai/rtk/issues/1875).
It closes Findings 2 + 3, which share the same call site
(`Tracker::record` in `src/core/tracking.rs:402-437`).

- **Finding 2 (DB stores secrets):** original_cmd and project_path are
  now scrubbed before INSERT via a new `src/core/redact.rs` module
  (shared with the upcoming tee redaction PR). Project paths default to
  `<basename>#<8-hex-sha256>`, gated by a new
  `tracking.hash_project_paths` field (default `true`, forward-compat
  via `#[serde(default)]`).
- **Finding 3 (`tracking.enabled` is dead code):**
  `Tracker::record` and `Tracker::record_parse_failure` now early-return
  `Ok(())` when the flag is `false`. A new `RTK_TRACK=0` env var mirrors
  the existing `RTK_TEE=0` one-shot opt-out.

A one-shot migration runs on `Tracker::new()` to rewrite rows from the
last 90 days. It is gated by `PRAGMA user_version` so it runs once per
binary version.

## Reproduction

### Finding 2

```bash
# Before this PR:
rtk git push https://alice:s3cr3t@github.com/acme/repo.git --token=ghp_ZZZZZ...
sqlite3 ~/.local/share/rtk/history.db \
  'SELECT original_cmd FROM commands ORDER BY timestamp DESC LIMIT 1;'
# → git push https://alice:s3cr3t@github.com/acme/repo.git --token=ghp_ZZZZZ...
#   (secret stored verbatim for 90 days; visible to anyone with read-home)
```

### Finding 3

```toml
# ~/.config/rtk/config.toml (or platform equivalent)
[tracking]
enabled = false
```

```bash
# Before this PR:
rtk git status
rtk gain --history | tail -5
# → row still appears — the flag was parsed but never read.
```

## Root cause

### Finding 2

`Tracker::record` bound `original_cmd` and `current_project_path_string()`
straight into a SQLite `INSERT`. The DB is reached from 200+ call sites
via `TimedExecution::start()`, so the fix had to live inside
`Tracker::record` itself, not at the call sites.

### Finding 3

`grep -rn tracking\.enabled src/` showed zero matches outside `config.rs`.
The field was parsed, defaulted to `true`, and never read. Both
`Tracker::new()` and `Tracker::record(…)` proceeded unconditionally.

## Fix approach

1. **New `src/core/redact.rs` (`pub(crate)`)** — single-pass, lazy_static
   regex bundle:
   - URL userinfo (`https://user:pass@host` → `https://****:****@host`)
   - `Authorization: Bearer …` / `Basic …` / `Token …`
   - `--token=…`, `--password …`, `--api-key=…`, `--secret …`,
     `--auth=…`, `--access-token …`, `--refresh-token …`
   - Inline env assignments from a 22-name allowlist
     (`AWS_SECRET_ACCESS_KEY`, `GH_TOKEN`, `OPENAI_API_KEY`, …)
   - Credential-prefix heuristic (`ghp_`, `gho_`, `sk-`, `sk_live_`,
     `xoxb-`, `AKIA`, `ASIA`, `glpat-`, …)
   - `redact_project_path` returns `<basename>#<8-hex-sha256>`;
     empty paths stay empty so the existing `project_path != ''` filter
     in `projects_count()` keeps working; already-hashed paths pass
     through unchanged (idempotent).
2. **Gate `Tracker::record` and `Tracker::record_parse_failure`** on a
   shared `tracking_enabled()` helper. `RTK_TRACK=0` short-circuits
   without touching disk; otherwise `Config::load()` decides; on
   missing/corrupt config we fall open (`unwrap_or(true)`).
3. **One-shot migration in `Tracker::new()`** — reads rows newer than
   90 days, redacts in-Rust, `UPDATE`s by id, bumps
   `PRAGMA user_version` from 0/1 to 2. Errors are logged to stderr but
   never block tracker creation (`rtk gain` keeps working on
   half-broken DBs).
4. **`TrackingConfig::hash_project_paths`** (default `true`,
   `#[serde(default = "default_true")]`) so configs predating this PR
   still parse.
5. **`RTK_CONFIG_PATH`** override added to `Config::get_config_path()`.
   This is a pure test/CI/container convenience that mirrors the
   existing `RTK_DB_PATH` pattern — required because `dirs::config_dir()`
   resolves via `$HOME/Library/Application Support` on macOS, and our
   gating tests cannot safely mutate `HOME` while other parallel tests
   are calling `Tracker::new()`.

## Behavior changes

- **DB rows are lossy from now on.** `--token=ghp_abc` becomes
  `--token=****`. Ecosystem aggregation (`top_commands`,
  `categorize_command`, `top_passthrough`) only looks at the first
  whitespace-delimited token, so headline `rtk gain` output is
  unchanged.
- **`--by-project` filters by hash now.** Same semantics (one row per
  project), shorter DB row.
- **`tracking.enabled = false` is now honoured.** No-op INSERT; reads
  are still allowed so `rtk gain` keeps showing past stats.
- **`RTK_TRACK=0`** one-shot env opt-out.
- **`RTK_CONFIG_PATH`** explicit config override.

No DB schema change, no public Rust API change, no CLI flag removal.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --bin rtk -- --test-threads=8` — **1920 passed, 0 failed, 6 ignored**
- [x] 19 new tests:
  - `src/core/redact.rs`: 6 (URL userinfo, Bearer, flag-value, inline env,
    credential heuristic, idempotent).
  - `src/core/tracking.rs`: 8 Finding 2 tests + 5 Finding 3 tests, all
    serialised via a per-module `TRACKING_ENV_LOCK` mutex.
- [x] Migration test seeds a pre-redaction row directly, resets
  `PRAGMA user_version = 0`, runs the migration, verifies token /
  user / password gone and second-run is a no-op.
- [x] Release-build perf sanity: `target/release/rtk --version` runs in
  <10ms on warm cache (rtk itself), `rtk gh --version` ~50ms (dominated
  by `gh` startup, not rtk overhead).

## Refs

- #1875 (Findings 2, 3)
- Design doc: `docs/superpowers/specs/2026-05-20-rtk-security-privacy-design.md` (local only — not pushed)
- Companion PR 3 (forthcoming): reuses `src/core/redact.rs` for tee-file content scrubbing.