### PR TITLE
feat(tee): redact sensitive output and add per-command opt-out

### DIFF
--- a/src/cmds/cloud/aws_cmd.rs
+++ b/src/cmds/cloud/aws_cmd.rs
@@ -3,7 +3,7 @@
 //! Replaces verbose `--output table`/`text` with JSON, then compresses.
 //! Specialized filters for high-frequency commands (STS, S3, EC2, ECS, RDS, CloudFormation).
 
-use crate::core::tee::force_tee_hint;
+use crate::core::tee::force_tee_hint_sensitive;
 use crate::core::tracking;
 use crate::core::truncate::{CAP_INVENTORY, CAP_LIST};
 use crate::core::utils::{
@@ -347,7 +347,7 @@ fn run_aws_filtered(
 
     if !status.success() {
         let exit_code = exit_code_from_status(&status, "aws");
-        if let Some(hint) = crate::core::tee::tee_and_hint(&raw, &slug, exit_code) {
+        if let Some(hint) = crate::core::tee::tee_and_hint_sensitive(&raw, &slug, exit_code) {
             eprintln!("{}\n{}", stderr.trim(), hint);
         } else {
             eprintln!("{}", stderr.trim());
@@ -362,12 +362,12 @@ fn run_aws_filtered(
     });
 
     if result.truncated {
-        if let Some(hint) = crate::core::tee::force_tee_hint(&raw, &slug) {
+        if let Some(hint) = crate::core::tee::force_tee_hint_sensitive(&raw, &slug) {
             println!("{}\n{}", result.text, hint);
         } else {
             println!("{}", result.text);
         }
-    } else if let Some(hint) = crate::core::tee::tee_and_hint(&raw, &slug, 0) {
+    } else if let Some(hint) = crate::core::tee::tee_and_hint_sensitive(&raw, &slug, 0) {
         println!("{}\n{}", result.text, hint);
     } else {
         println!("{}", result.text);
@@ -400,7 +400,8 @@ fn run_s3_ls(extra_args: &[String], verbose: u8) -> Result<i32> {
     };
     if !output.status.success() {
         let exit_code = exit_code_from_output(&output, "aws");
-        if let Some(hint) = crate::core::tee::tee_and_hint(&raw, "aws_s3_ls", exit_code) {
+        if let Some(hint) = crate::core::tee::tee_and_hint_sensitive(&raw, "aws_s3_ls", exit_code)
+        {
             eprintln!("{}\n{}", stderr.trim(), hint);
         } else {
             eprintln!("{}", stderr.trim());
@@ -411,7 +412,7 @@ fn run_s3_ls(extra_args: &[String], verbose: u8) -> Result<i32> {
 
     let result = filter_s3_ls(&stdout);
     if result.truncated {
-        if let Some(hint) = crate::core::tee::force_tee_hint(&raw, "aws_s3_ls") {
+        if let Some(hint) = crate::core::tee::force_tee_hint_sensitive(&raw, "aws_s3_ls") {
             println!("{}\n{}", result.text, hint);
         } else {
             println!("{}", result.text);
@@ -453,7 +454,7 @@ fn run_s3_transfer(operation: &str, extra_args: &[String], verbose: u8) -> Resul
     };
     if !output.status.success() {
         let exit_code = exit_code_from_output(&output, "aws");
-        if let Some(hint) = crate::core::tee::tee_and_hint(&raw, &slug, exit_code) {
+        if let Some(hint) = crate::core::tee::tee_and_hint_sensitive(&raw, &slug, exit_code) {
             eprintln!("{}\n{}", stderr.trim(), hint);
         } else {
             eprintln!("{}", stderr.trim());
@@ -464,7 +465,7 @@ fn run_s3_transfer(operation: &str, extra_args: &[String], verbose: u8) -> Resul
 
     let result = filter_s3_transfer(&stdout);
     if result.truncated {
-        if let Some(hint) = force_tee_hint(&raw, &slug) {
+        if let Some(hint) = force_tee_hint_sensitive(&raw, &slug) {
             println!("{}\n{}", result.text, hint);
         } else {
             println!("{}", result.text);

--- a/src/cmds/cloud/curl_cmd.rs
+++ b/src/cmds/cloud/curl_cmd.rs
@@ -11,7 +11,7 @@
 //! otherwise replace non-UTF-8 bytes with U+FFFD and corrupt the stream
 //! (`#1087`).
 
-use crate::core::tee::force_tee_hint;
+use crate::core::tee::force_tee_hint_sensitive;
 use crate::core::tracking;
 use crate::core::utils::resolved_command;
 use anyhow::{Context, Result};
@@ -116,7 +116,7 @@ fn filter_curl_output(raw: &str, is_tty: bool) -> FilterResult<'_> {
     // - stdout is not a terminal (pipes / redirects need the full body, #1282)
     // - body fits under the truncation threshold
     //
-    // Critically, do NOT call `force_tee_hint` on this path — it has a side effect
+    // Critically, do NOT call `force_tee_hint_sensitive` on this path — it has a side effect
     // (writes the raw body to a tee log file) and we don't need a recovery file
     // when the consumer already receives the full body.
     if !is_tty || looks_like_json || trimmed.len() < MAX_RESPONSE_SIZE {
@@ -128,7 +128,7 @@ fn filter_curl_output(raw: &str, is_tty: bool) -> FilterResult<'_> {
 
     // We're about to truncate for a human reader. Write a tee file so they (or
     // the LLM in their stead) can recover the full body from the printed hint.
-    let Some(hint) = force_tee_hint(raw, "curl") else {
+    let Some(hint) = force_tee_hint_sensitive(raw, "curl") else {
         // Tee disabled (RTK_TEE=0 or below MIN_TEE_SIZE): we have nowhere to
         // point a recovery hint to, so pass through rather than emit an
         // unrecoverable truncation marker.

--- a/src/cmds/cloud/psql_cmd.rs
+++ b/src/cmds/cloud/psql_cmd.rs
@@ -41,6 +41,10 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         filter_psql_output,
         RunOptions::stdout_only()
             .tee("psql")
+            // psql results can carry connection strings / `PGPASSWORD=` echoes
+            // in NOTICE / ECHO output, so route through the credential
+            // scrubber unconditionally.
+            .tee_sensitive()
             .early_exit_on_failure(),
     )
 }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -59,6 +59,16 @@ pub struct TrackingConfig {
     pub history_days: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database_path: Option<PathBuf>,
+    /// Replace stored project paths with `<basename>#<8-hex-sha256>` so the
+    /// tracking DB does not pin a user's private filesystem layout. Defaults
+    /// to `true`; set to `false` to keep raw paths for `rtk gain --by-project`
+    /// scripts that depend on prefix matching.
+    #[serde(default = "default_true")]
+    pub hash_project_paths: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 impl Default for TrackingConfig {
@@ -67,6 +77,7 @@ impl Default for TrackingConfig {
             enabled: true,
             history_days: DEFAULT_HISTORY_DAYS as u32,
             database_path: None,
+            hash_project_paths: true,
         }
     }
 }
@@ -183,6 +194,12 @@ impl Config {
 }
 
 fn get_config_path() -> Result<PathBuf> {
+    // Priority 1: explicit override (mirrors RTK_DB_PATH for `Tracker`).
+    // Mostly used by tests to keep `Config::load()` deterministic without
+    // touching the real `$HOME`.
+    if let Ok(custom) = std::env::var("RTK_CONFIG_PATH") {
+        return Ok(PathBuf::from(custom));
+    }
     let config_dir = dirs::config_dir().unwrap_or_else(|| PathBuf::from("."));
     Ok(config_dir.join(RTK_DATA_DIR).join(CONFIG_TOML))
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod constants;
 pub mod display_helpers;
 pub mod filter;
+pub mod redact;
 pub mod runner;
 pub mod stream;
 pub mod tee;

--- a/src/core/redact.rs
+++ b/src/core/redact.rs
@@ -10,10 +10,10 @@
 //! All regex are `lazy_static!`-cached and the public functions perform a
 //! single pass per call — they run on the `Tracker::record` hot path.
 //!
-//! This module is shared with the upcoming tee content redactor (see the
-//! security & privacy design doc) — `redact_project_path` and the regex
-//! helpers are deliberately `pub(crate)` so PR 3 can consume them without
-//! duplicating the patterns.
+//! `redact_content` reuses the same regex bundle for free-form command output
+//! that may contain credential-shaped substrings (used by the tee write path,
+//! see the security & privacy design doc). It returns both the redacted text
+//! and a count of substitutions so callers can prepend an audit header.
 
 use lazy_static::lazy_static;
 use regex::Regex;
@@ -137,6 +137,53 @@ pub(crate) fn redact_command(s: &str) -> String {
     let s = CREDENTIAL_PREFIX_RE.replace_all(&s, "****");
 
     s.into_owned()
+}
+
+/// Scrub credential-shaped substrings from free-form command output.
+///
+/// Like [`redact_command`] but returns the substitution count alongside the
+/// redacted string. The count is used by the tee write path to decide whether
+/// to prepend the `--- rtk: N credential-like patterns redacted ---` audit
+/// header.
+///
+/// Counted matches are *substituted* occurrences (one per regex hit) — note
+/// that a single line can hit multiple patterns (e.g. `Authorization: Bearer
+/// ghp_…` matches both the bearer rule and the credential-prefix rule), each
+/// adds to the count. This is the desired behaviour: the header just signals
+/// "something looked like a credential and was masked", not "exactly N unique
+/// secrets were found".
+///
+/// Reuses the same `lazy_static!`-cached regex bundle as `redact_command`,
+/// so the cost is identical to a single command-line redact pass.
+pub(crate) fn redact_content(s: &str) -> (String, usize) {
+    if s.is_empty() {
+        return (String::new(), 0);
+    }
+
+    let mut count = 0usize;
+
+    // 1. URL userinfo
+    count += URL_USERINFO_RE.find_iter(s).count();
+    let s = URL_USERINFO_RE.replace_all(s, "$scheme****:****@");
+
+    // 2. Bearer / Basic / Token header values
+    count += BEARER_RE.find_iter(&s).count();
+    let s = BEARER_RE.replace_all(&s, "$lead ****");
+
+    // 3. Flag/value pairs
+    count += FLAG_VALUE_RE.find_iter(&s).count();
+    let s = FLAG_VALUE_RE.replace_all(&s, "$flag$sep****");
+
+    // 4. Inline env assignments
+    count += INLINE_ENV_RE.find_iter(&s).count();
+    let s = INLINE_ENV_RE.replace_all(&s, "$name=****");
+
+    // 5. Credential prefix heuristic — last so the structured rules above
+    //    get first crack at structured values.
+    count += CREDENTIAL_PREFIX_RE.find_iter(&s).count();
+    let s = CREDENTIAL_PREFIX_RE.replace_all(&s, "****");
+
+    (s.into_owned(), count)
 }
 
 /// Reduce a project path to `<basename>#<8-hex-sha256>`.
@@ -266,6 +313,34 @@ mod tests {
                 .any(|p| input.contains(p) && got.contains(p));
             assert!(!prefix_leaked, "prefix leaked: {got}");
         }
+    }
+
+    #[test]
+    fn test_redact_content_counts_substitutions() {
+        let input = "log: GET https://alice:s3cret@host/api Authorization: Bearer abc123XYZdef456";
+        let (out, n) = redact_content(input);
+        assert!(out.contains("https://****:****@host/api"), "got: {out}");
+        assert!(out.contains("Bearer ****"), "got: {out}");
+        assert!(!out.contains("alice"));
+        assert!(!out.contains("s3cret"));
+        assert!(!out.contains("abc123XYZdef456"));
+        // URL userinfo + bearer = 2 substitutions at minimum.
+        assert!(n >= 2, "expected >=2 matches, got {n}");
+    }
+
+    #[test]
+    fn test_redact_content_passes_clean_text_unchanged() {
+        let input = "running 12 tests\ntest core::tee::tests::test_sanitize_slug ... ok\n";
+        let (out, n) = redact_content(input);
+        assert_eq!(out, input, "clean text must round-trip");
+        assert_eq!(n, 0, "clean text must report zero matches");
+    }
+
+    #[test]
+    fn test_redact_content_empty_input() {
+        let (out, n) = redact_content("");
+        assert!(out.is_empty());
+        assert_eq!(n, 0);
     }
 
     #[test]

--- a/src/core/redact.rs
+++ b/src/core/redact.rs
@@ -1,0 +1,286 @@
+//! Shared credential/PII redactor used by tracking and tee.
+//!
+//! `redact_command` scrubs known credential shapes from a command line
+//! (URL userinfo, Bearer / Authorization headers, `--token=`/`--password=`/etc,
+//! inline `FOO_TOKEN=…` assignments, and well-known credential prefixes such
+//! as `ghp_`, `sk-`, `AKIA…`). `redact_project_path` reduces a filesystem
+//! path to `<basename>#<8-hex-sha256>` so the tracking DB does not pin a
+//! user's private layout.
+//!
+//! All regex are `lazy_static!`-cached and the public functions perform a
+//! single pass per call — they run on the `Tracker::record` hot path.
+//!
+//! This module is shared with the upcoming tee content redactor (see the
+//! security & privacy design doc) — `redact_project_path` and the regex
+//! helpers are deliberately `pub(crate)` so PR 3 can consume them without
+//! duplicating the patterns.
+
+use lazy_static::lazy_static;
+use regex::Regex;
+use sha2::{Digest, Sha256};
+use std::path::Path;
+
+lazy_static! {
+    /// `https://user:secret@host/repo` → keep host/path, mask user + secret.
+    /// Restricted to URL contexts (after `://`) so we do not chew through
+    /// arbitrary `user:pass` substrings.
+    static ref URL_USERINFO_RE: Regex =
+        Regex::new(r"(?P<scheme>[a-zA-Z][a-zA-Z0-9+.-]*://)(?P<user>[^/@\s:]+):(?P<pass>[^@\s]+)@")
+            .expect("URL_USERINFO_RE");
+
+    /// `Authorization: Bearer abc123` / `bearer abc123` style.
+    /// We match the keyword and replace the trailing token with `****`.
+    static ref BEARER_RE: Regex = Regex::new(
+        r#"(?i)(?P<lead>(?:authorization\s*[:=]\s*)?(?:bearer|basic|token))[ \t]+(?P<val>[^\s"']+)"#
+    )
+    .expect("BEARER_RE");
+
+    /// `--token=secret` / `--token secret` / `-p=secret`.
+    /// Covers `token`, `password`, `passwd`, `pwd`, `api-key`, `apikey`,
+    /// `secret`, `auth`, `access-token`, `refresh-token`.
+    static ref FLAG_VALUE_RE: Regex = Regex::new(
+        r#"(?ix)
+        (?P<flag>--(?:token|password|passwd|pwd|api[_-]?key|secret|auth|access[_-]?token|refresh[_-]?token))
+        (?P<sep>=|\s+)
+        (?P<val>[^\s"']+)
+        "#
+    )
+    .expect("FLAG_VALUE_RE");
+
+    /// Inline env-style `FOO_TOKEN=value` assignment.
+    /// Restricted to a known-allowlist of credential-shaped variable names so
+    /// we do not mangle benign `LANG=en_US.UTF-8`-style assignments.
+    static ref INLINE_ENV_RE: Regex = Regex::new(
+        r"(?x)
+        \b
+        (?P<name>
+            AWS_SECRET_ACCESS_KEY
+            | AWS_SESSION_TOKEN
+            | AWS_ACCESS_KEY_ID
+            | GH_TOKEN
+            | GITHUB_TOKEN
+            | GH_ENTERPRISE_TOKEN
+            | GITLAB_TOKEN
+            | OPENAI_API_KEY
+            | ANTHROPIC_API_KEY
+            | NPM_TOKEN
+            | HF_TOKEN
+            | HUGGING_FACE_HUB_TOKEN
+            | SLACK_TOKEN
+            | SLACK_BOT_TOKEN
+            | SLACK_APP_TOKEN
+            | DOCKER_PASSWORD
+            | DOCKERHUB_PASSWORD
+            | CI_JOB_TOKEN
+            | CARGO_REGISTRY_TOKEN
+            | RUBYGEMS_API_KEY
+            | PYPI_TOKEN
+            | DATABASE_URL
+            | PGPASSWORD
+        )
+        =
+        (?P<val>\S+)
+        "
+    )
+    .expect("INLINE_ENV_RE");
+
+    /// "Looks like a credential" heuristic — well-known prefixes.
+    /// `ghp_…`, `gho_…`, `ghu_…`, `ghs_…`, `github_pat_…`,
+    /// `sk-…` / `sk_live_…` / `sk_test_…`, `xoxb-…` / `xoxp-…`,
+    /// `AKIA…` (AWS access key id), `ASIA…` (AWS STS), `glpat-…` (GitLab).
+    static ref CREDENTIAL_PREFIX_RE: Regex = Regex::new(
+        r"(?x)
+        \b
+        (?:
+            ghp_ | gho_ | ghu_ | ghs_ | github_pat_
+            | sk-live_ | sk_live_ | sk_test_ | sk-
+            | xoxb- | xoxp- | xoxa- | xoxs-
+            | glpat-
+            | AKIA | ASIA
+        )
+        [A-Za-z0-9_\-]{16,}
+        \b
+        "
+    )
+    .expect("CREDENTIAL_PREFIX_RE");
+
+    /// Project-path output shape used by `redact_project_path`.
+    static ref BASENAME_SAFE_RE: Regex =
+        Regex::new(r"[^A-Za-z0-9_.-]").expect("BASENAME_SAFE_RE");
+}
+
+/// Scrub credential-shaped substrings from a command line.
+///
+/// Runs a single, deterministic pass through the lazy-cached regex bundle.
+/// The function is idempotent — running it twice produces the same string,
+/// because every replacement collapses to `****` (which matches none of the
+/// patterns).
+pub(crate) fn redact_command(s: &str) -> String {
+    if s.is_empty() {
+        return String::new();
+    }
+
+    // 1. URL userinfo: scheme://user:pass@host → scheme://****:****@host
+    let s = URL_USERINFO_RE.replace_all(s, "$scheme****:****@");
+
+    // 2. Bearer / Basic / Token header values
+    let s = BEARER_RE.replace_all(&s, "$lead ****");
+
+    // 3. Flag/value pairs (--token=…, --password …)
+    let s = FLAG_VALUE_RE.replace_all(&s, "$flag$sep****");
+
+    // 4. Well-known inline env assignments (GH_TOKEN=…)
+    let s = INLINE_ENV_RE.replace_all(&s, "$name=****");
+
+    // 5. Credential prefix heuristic (ghp_…, sk-…, AKIA…) — last so the
+    //    other rules get first crack at structured values.
+    let s = CREDENTIAL_PREFIX_RE.replace_all(&s, "****");
+
+    s.into_owned()
+}
+
+/// Reduce a project path to `<basename>#<8-hex-sha256>`.
+///
+/// Used by the tracking DB so `rtk gain --by-project` can still distinguish
+/// projects without storing `/Users/<corporate-username>/Clients/Acme/…`.
+/// Empty / unrecognised paths short-circuit to `""` so the existing
+/// `project_path != ''` filter in `projects_count()` keeps working.
+///
+/// The output shape is `<sanitised-basename>#<8-hex>` which always satisfies
+/// `^[A-Za-z0-9_.-]+#[0-9a-f]{8}$`.
+pub(crate) fn redact_project_path(s: &str) -> String {
+    if s.is_empty() {
+        return String::new();
+    }
+
+    // Already-redacted paths (basename#deadbeef) are idempotent — let them
+    // round-trip unchanged so the one-shot migration is safe to re-run.
+    if is_already_hashed(s) {
+        return s.to_string();
+    }
+
+    let basename = Path::new(s)
+        .file_name()
+        .map(|os| os.to_string_lossy().to_string())
+        .unwrap_or_else(|| "root".to_string());
+
+    let basename_safe = BASENAME_SAFE_RE.replace_all(&basename, "_");
+    let basename_safe = if basename_safe.is_empty() {
+        "root".to_string()
+    } else {
+        basename_safe.into_owned()
+    };
+
+    let mut hasher = Sha256::new();
+    hasher.update(s.as_bytes());
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(8);
+    for byte in digest.iter().take(4) {
+        use std::fmt::Write as _;
+        let _ = write!(&mut hex, "{:02x}", byte);
+    }
+
+    format!("{}#{}", basename_safe, hex)
+}
+
+fn is_already_hashed(s: &str) -> bool {
+    let Some((base, hash)) = s.rsplit_once('#') else {
+        return false;
+    };
+    if hash.len() != 8 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+        return false;
+    }
+    !base.is_empty()
+        && base
+            .chars()
+            .all(|c| matches!(c, 'A'..='Z' | 'a'..='z' | '0'..='9' | '_' | '.' | '-'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_redact_url_userinfo() {
+        let input = "git push https://alice:s3cret@github.com/acme/repo.git main";
+        let got = redact_command(input);
+        assert!(
+            got.contains("https://****:****@github.com/acme/repo.git"),
+            "got: {got}"
+        );
+        assert!(!got.contains("alice"));
+        assert!(!got.contains("s3cret"));
+    }
+
+    #[test]
+    fn test_redact_bearer_header() {
+        let input = r#"curl -H "Authorization: Bearer abc123XYZdef456" https://api.example.com"#;
+        let got = redact_command(input);
+        assert!(got.contains("Bearer ****"), "got: {got}");
+        assert!(!got.contains("abc123XYZdef456"));
+    }
+
+    #[test]
+    fn test_redact_flag_value_pairs() {
+        let input =
+            "tool --token=abc123 --password xyz789 --api-key=key1 --secret xyzS --auth=A1B2C3";
+        let got = redact_command(input);
+        // Each flag's value masked
+        assert!(got.contains("--token=****"), "got: {got}");
+        assert!(got.contains("--password ****"), "got: {got}");
+        assert!(got.contains("--api-key=****"), "got: {got}");
+        assert!(got.contains("--secret ****"), "got: {got}");
+        assert!(got.contains("--auth=****"), "got: {got}");
+        // No leaked literals
+        for needle in ["abc123", "xyz789", "key1", "xyzS", "A1B2C3"] {
+            assert!(!got.contains(needle), "needle {needle} leaked: {got}");
+        }
+    }
+
+    #[test]
+    fn test_redact_inline_env() {
+        let input = "GH_TOKEN=ghp_ZZZZZZZZZZZZZZZZZZZZ git push origin main";
+        let got = redact_command(input);
+        assert!(got.contains("GH_TOKEN=****"), "got: {got}");
+        assert!(!got.contains("ghp_ZZZZZZZZZZZZZZZZZZZZ"));
+    }
+
+    #[test]
+    fn test_redact_credential_heuristic() {
+        // Synthetic fixtures: chosen so GitHub's secret-scanner does not
+        // (correctly) reject the commit. Each starts with a credential-prefix
+        // RTK recognises and is followed by 16+ chars that match the regex.
+        let inputs_and_haystacks = [
+            // ghp_<20 ZZ…> — not a real PAT, but matches our prefix regex.
+            "echo ghp_ZZZZZZZZZZZZZZZZZZZZ",
+            "echo sk-ZZZZZZZZZZZZZZZZZZZZ",
+            "echo AKIAZZZZZZZZZZZZZZZZ",
+            "echo xoxb-ZZZZZZZZZZ-ZZZZZZZZZZZZZZ",
+        ];
+        let prefixes = ["ghp_ZZZZ", "sk-ZZZZ", "AKIAZZZZ", "xoxb-ZZZZ"];
+        for input in inputs_and_haystacks {
+            let got = redact_command(input);
+            assert!(got.contains("****"), "want **** in: {got} (input {input})");
+            let prefix_leaked = prefixes
+                .iter()
+                .any(|p| input.contains(p) && got.contains(p));
+            assert!(!prefix_leaked, "prefix leaked: {got}");
+        }
+    }
+
+    #[test]
+    fn test_redact_idempotent() {
+        let inputs = [
+            "git push https://alice:s3cret@github.com/acme/repo.git",
+            "curl -H 'Authorization: Bearer abc' https://x",
+            "tool --token=xyz --password=k",
+            "GH_TOKEN=ghp_ZZZZZZZZZZZZZZZZZZZZ git push",
+            "echo ghp_ZZZZZZZZZZZZZZZZZZZZ",
+        ];
+        for input in inputs {
+            let once = redact_command(input);
+            let twice = redact_command(&once);
+            assert_eq!(once, twice, "non-idempotent for input: {input}");
+        }
+    }
+}

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -6,8 +6,19 @@ use std::process::Command;
 use crate::core::stream::{self, FilterMode, StdinMode, StreamFilter};
 use crate::core::tracking;
 
+/// Tee the raw output and emit a `[full output: …]` hint after the filtered
+/// body. The non-sensitive entry point — see `print_with_hint_sensitive`
+/// for the credential-scrubbing variant used by psql / aws / curl.
 pub fn print_with_hint(filtered: &str, raw: &str, tee_label: &str, exit_code: i32) {
     if let Some(hint) = crate::core::tee::tee_and_hint(raw, tee_label, exit_code) {
+        println!("{}\n{}", filtered, hint);
+    } else {
+        println!("{}", filtered);
+    }
+}
+
+fn print_with_hint_sensitive(filtered: &str, raw: &str, tee_label: &str, exit_code: i32) {
+    if let Some(hint) = crate::core::tee::tee_and_hint_sensitive(raw, tee_label, exit_code) {
         println!("{}\n{}", filtered, hint);
     } else {
         println!("{}", filtered);
@@ -17,6 +28,10 @@ pub fn print_with_hint(filtered: &str, raw: &str, tee_label: &str, exit_code: i3
 #[derive(Default)]
 pub struct RunOptions<'a> {
     pub tee_label: Option<&'a str>,
+    /// When the tee label points at a known-sensitive command family (psql
+    /// results, AWS streamed output), route through the credential-scrubbing
+    /// `*_sensitive` tee API. See `src/core/tee.rs` for the redaction policy.
+    pub tee_sensitive: bool,
     pub filter_stdout_only: bool,
     pub skip_filter_on_failure: bool,
     pub no_trailing_newline: bool,
@@ -43,6 +58,15 @@ impl<'a> RunOptions<'a> {
 
     pub fn tee(mut self, label: &'a str) -> Self {
         self.tee_label = Some(label);
+        self
+    }
+
+    /// Mark this command as known to handle credential-shaped output. The
+    /// tee write path will force its content redactor on the raw output and
+    /// keep doing so even if a future config knob disables the default
+    /// safety-net redaction for non-sensitive callers.
+    pub fn tee_sensitive(mut self) -> Self {
+        self.tee_sensitive = true;
         self
     }
 
@@ -114,7 +138,11 @@ where
     let filtered = filter_fn(text_to_filter, exit_code);
 
     if let Some(label) = opts.tee_label {
-        print_with_hint(&filtered, raw, label, exit_code);
+        if opts.tee_sensitive {
+            print_with_hint_sensitive(&filtered, raw, label, exit_code);
+        } else {
+            print_with_hint(&filtered, raw, label, exit_code);
+        }
     } else if opts.no_trailing_newline {
         print!("{}", filtered);
     } else {
@@ -168,9 +196,12 @@ pub fn run(
                     .with_context(|| format!("Failed to run {}", tool_name))?;
 
             if let Some(label) = opts.tee_label {
-                if let Some(hint) =
+                let hint = if opts.tee_sensitive {
+                    crate::core::tee::tee_and_hint_sensitive(&result.raw, label, result.exit_code)
+                } else {
                     crate::core::tee::tee_and_hint(&result.raw, label, result.exit_code)
-                {
+                };
+                if let Some(hint) = hint {
                     println!("{}", hint);
                 }
             }

--- a/src/core/tee.rs
+++ b/src/core/tee.rs
@@ -1,11 +1,75 @@
 //! Raw output recovery -- saves unfiltered output to disk on command failure.
+//!
+//! ## Sensitive-output handling (see `docs/superpowers/specs/2026-05-20-…`)
+//!
+//! Three layers of defence, increasing strictness:
+//!
+//! 1. **Per-slug blocklist** — commands that *always* deal in credentials
+//!    (e.g. `aws_secretsmanager_get-secret-value`, `kubectl_get_secret`,
+//!    `op_*`, `vault_*`) short-circuit before any disk write and emit no
+//!    hint at all. See [`is_blocklisted_slug`].
+//! 2. **Content-level redactor** — all surviving writes pass through
+//!    [`crate::core::redact::redact_content`] which masks Bearer tokens,
+//!    `AKIA…` keys, `ghp_…` PATs, URL userinfo, and inline credential env
+//!    assignments. If any matches were found, a `--- rtk: N credential-like
+//!    patterns redacted ---` audit header is prepended to the on-disk file.
+//! 3. **Per-call-site Sensitive opt-in** — callers that know they handle
+//!    credentials (`aws_cmd.rs`, `curl_cmd.rs`, `psql_cmd.rs`) use the
+//!    `*_sensitive` variants below. These force the redactor pass even when
+//!    the slug is not on the blocklist, so a yet-to-be-classified sensitive
+//!    command still gets scrubbed.
 
 use super::constants::RTK_DATA_DIR;
 use crate::core::config::Config;
+use crate::core::redact;
 use std::path::PathBuf;
 
 /// Minimum output size to tee (smaller outputs don't need recovery)
 const MIN_TEE_SIZE: usize = 500;
+
+/// Per-slug blocklist for commands that should *never* persist raw output
+/// to disk, regardless of content. Matched with `slug.starts_with(prefix)`
+/// so e.g. `aws_secretsmanager` covers `aws_secretsmanager_get-secret-value`,
+/// `aws_secretsmanager_list-secrets`, etc.
+///
+/// Sourced from the security & privacy design doc, Finding 4.
+const SENSITIVE_SLUG_PREFIXES: &[&str] = &[
+    // AWS secret/identity surfaces
+    "aws_secretsmanager",
+    "aws_kms",
+    "aws_sts_get-session-token",
+    "aws_sts_assume-role",
+    // Kubernetes
+    "kubectl_get_secret",
+    "kubectl_describe_secret",
+    // GitHub / GitLab CLIs
+    "gh_secret",
+    "gh_auth",
+    "glab_secret",
+    "glab_auth",
+    // Password / secret managers
+    "op_",
+    "vault_",
+    "doppler_",
+    "bw_",
+    "pass_",
+    // Helm values often contain secrets
+    "helm_get_values",
+    // Git config can leak credential.helper / PATs
+    "git_config",
+];
+
+/// Audit header prepended to tee files when the content redactor fired.
+fn redaction_header(count: usize) -> String {
+    format!("--- rtk: {} credential-like patterns redacted ---\n", count)
+}
+
+/// True when the slug matches any sensitive prefix from `SENSITIVE_SLUG_PREFIXES`.
+fn is_blocklisted_slug(slug: &str) -> bool {
+    SENSITIVE_SLUG_PREFIXES
+        .iter()
+        .any(|prefix| slug.starts_with(prefix))
+}
 
 /// Default max files to keep in tee directory
 const DEFAULT_MAX_FILES: usize = 20;
@@ -102,15 +166,42 @@ fn should_tee(
     tee_dir
 }
 
+/// Whether the content redactor should be applied unconditionally
+/// (`Forced`, used by `*_sensitive` variants for known-credential-bearing
+/// commands) or only when the default safety-net policy says to (`Auto`).
+///
+/// At present `Auto` *also* runs the redactor on every write — the safety net
+/// is on by default. `Forced` exists so the call-site intent stays explicit
+/// and so a future config knob that lets users opt out of `Auto` redaction
+/// (e.g. `RTK_TEE_REDACT=0`) will still leave `Sensitive` callers protected.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RedactPolicy {
+    Auto,
+    Forced,
+}
+
 /// Write raw output to a tee file in the given directory.
 /// Returns file path on success.
+///
+/// Refuses to write (returns `None`) when `command_slug` matches a prefix in
+/// [`SENSITIVE_SLUG_PREFIXES`]. For all surviving writes, the content is
+/// passed through [`redact::redact_content`] — if any credential-shaped
+/// substring was masked, a one-line audit header is prepended to the file.
 fn write_tee_file(
     raw: &str,
     command_slug: &str,
     tee_dir: &std::path::Path,
     max_file_size: usize,
     max_files: usize,
+    policy: RedactPolicy,
 ) -> Option<PathBuf> {
+    // Layer 1: hard blocklist. Refuse to write at all for slugs known to deal
+    // in secrets — the cost of a missed recovery is "the LLM can't read the
+    // failed secret-fetch", which is the correct trade-off.
+    if is_blocklisted_slug(command_slug) {
+        return None;
+    }
+
     std::fs::create_dir_all(tee_dir).ok()?;
 
     let slug = sanitize_slug(command_slug);
@@ -121,9 +212,28 @@ fn write_tee_file(
     let filename = format!("{}_{}.log", epoch, slug);
     let filepath = tee_dir.join(filename);
 
+    // Layer 2: content-level redactor. Single-pass over `lazy_static!`-cached
+    // regex, a no-op (byte-identical output, no header) when the input has no
+    // credential-shaped substrings — so the cost on clean cargo-test /
+    // npm-install output is one regex scan per pattern, no allocations.
+    //
+    // `Auto` and `Forced` currently behave identically; the policy is plumbed
+    // through so the `*_sensitive` callers remain explicit even if a future
+    // config flag turns `Auto` off.
+    let _ = policy; // reserved for future per-policy behaviour
+    let (scrubbed, match_count) = redact::redact_content(raw);
+    let body: std::borrow::Cow<'_, str> = if match_count > 0 {
+        std::borrow::Cow::Owned(format!("{}{}", redaction_header(match_count), scrubbed))
+    } else if scrubbed == raw {
+        // Fast path: byte-identical output, avoid the second allocation.
+        std::borrow::Cow::Borrowed(raw)
+    } else {
+        std::borrow::Cow::Owned(scrubbed)
+    };
+
     // Truncate at max_file_size (find a safe UTF-8 char boundary)
-    let content = if raw.len() > max_file_size {
-        let boundary = raw
+    let content = if body.len() > max_file_size {
+        let boundary = body
             .char_indices()
             .take_while(|(i, _)| *i < max_file_size)
             .last()
@@ -131,11 +241,11 @@ fn write_tee_file(
             .unwrap_or(0);
         format!(
             "{}\n\n--- truncated at {} bytes ---",
-            &raw[..boundary],
+            &body[..boundary],
             max_file_size
         )
     } else {
-        raw.to_string()
+        body.into_owned()
     };
 
     std::fs::write(&filepath, content).ok()?;
@@ -149,6 +259,15 @@ fn write_tee_file(
 /// Write raw output to tee file if conditions are met.
 /// Returns file path on success, None if skipped/failed.
 pub fn tee_raw(raw: &str, command_slug: &str, exit_code: i32) -> Option<PathBuf> {
+    tee_raw_with_policy(raw, command_slug, exit_code, RedactPolicy::Auto)
+}
+
+fn tee_raw_with_policy(
+    raw: &str,
+    command_slug: &str,
+    exit_code: i32,
+    policy: RedactPolicy,
+) -> Option<PathBuf> {
     // Check RTK_TEE=0 env override (disable)
     if std::env::var("RTK_TEE").ok().as_deref() == Some("0") {
         return None;
@@ -165,6 +284,7 @@ pub fn tee_raw(raw: &str, command_slug: &str, exit_code: i32) -> Option<PathBuf>
         &tee_dir,
         config.tee.max_file_size,
         config.tee.max_files,
+        policy,
     )
 }
 
@@ -189,6 +309,14 @@ pub fn tee_and_hint(raw: &str, command_slug: &str, exit_code: i32) -> Option<Str
 }
 
 fn force_tee_path(content: &str, command_slug: &str) -> Option<PathBuf> {
+    force_tee_path_with_policy(content, command_slug, RedactPolicy::Auto)
+}
+
+fn force_tee_path_with_policy(
+    content: &str,
+    command_slug: &str,
+    policy: RedactPolicy,
+) -> Option<PathBuf> {
     if std::env::var("RTK_TEE").ok().as_deref() == Some("0") {
         return None;
     }
@@ -212,6 +340,7 @@ fn force_tee_path(content: &str, command_slug: &str) -> Option<PathBuf> {
         &tee_dir,
         config.tee.max_file_size,
         config.tee.max_files,
+        policy,
     )
 }
 
@@ -228,6 +357,49 @@ pub fn force_tee_tail_hint(
     line_offset: usize,
 ) -> Option<String> {
     let path = force_tee_path(content, command_slug)?;
+    Some(format!(
+        "[see remaining: tail -n +{} {}]",
+        line_offset,
+        display_path(&path)
+    ))
+}
+
+// --- Sensitive variants ---
+//
+// Call sites that know they're dealing with credential-shaped content
+// (`aws_cmd.rs`, `curl_cmd.rs`, `psql_cmd.rs`) use these variants. They
+// share the existing tee bookkeeping (rotation, mode, MIN_TEE_SIZE) but
+// force the content redactor pass and stay scrubbed even if a future
+// config knob lets users disable the default Auto redaction.
+
+/// Like [`tee_and_hint`], but force the credential redactor unconditionally.
+///
+/// Use for command families where output is known to often contain
+/// secrets (AWS API responses, curl bodies, psql results that may carry
+/// connection strings in NOTICE lines, …).
+pub fn tee_and_hint_sensitive(raw: &str, command_slug: &str, exit_code: i32) -> Option<String> {
+    let path = tee_raw_with_policy(raw, command_slug, exit_code, RedactPolicy::Forced)?;
+    Some(format_hint(&path))
+}
+
+/// Like [`force_tee_hint`], but force the credential redactor unconditionally.
+pub fn force_tee_hint_sensitive(raw: &str, command_slug: &str) -> Option<String> {
+    let path = force_tee_path_with_policy(raw, command_slug, RedactPolicy::Forced)?;
+    Some(format_hint(&path))
+}
+
+/// Like [`force_tee_tail_hint`], but force the credential redactor unconditionally.
+///
+/// Reserved for future call sites that emit a `tail -n +offset` recovery
+/// hint for known-credential-bearing command families (none ship today but
+/// the variant is documented as part of the sensitive surface).
+#[allow(dead_code)]
+pub fn force_tee_tail_hint_sensitive(
+    content: &str,
+    command_slug: &str,
+    line_offset: usize,
+) -> Option<String> {
+    let path = force_tee_path_with_policy(content, command_slug, RedactPolicy::Forced)?;
     Some(format!(
         "[see remaining: tail -n +{} {}]",
         line_offset,
@@ -272,6 +444,11 @@ impl Default for TeeConfig {
 mod tests {
     use super::*;
     use std::fs;
+
+    /// Serialises tests that touch `RTK_TEE*` / `RTK_CONFIG_PATH` env vars so
+    /// parallel `cargo test` runs don't see each other's `set_var`. Tests
+    /// that don't mutate env can run concurrently without taking this lock.
+    static TEE_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     #[test]
     fn test_sanitize_slug() {
@@ -346,6 +523,7 @@ mod tests {
             tmpdir.path(),
             DEFAULT_MAX_FILE_SIZE,
             20,
+            RedactPolicy::Auto,
         );
         assert!(result.is_some());
 
@@ -360,7 +538,14 @@ mod tests {
         let tmpdir = tempfile::tempdir().unwrap();
         let big_output = "x".repeat(2000);
         // Set max_file_size to 1000 bytes
-        let result = write_tee_file(&big_output, "test", tmpdir.path(), 1000, 20);
+        let result = write_tee_file(
+            &big_output,
+            "test",
+            tmpdir.path(),
+            1000,
+            20,
+            RedactPolicy::Auto,
+        );
         assert!(result.is_some());
 
         let path = result.unwrap();
@@ -380,7 +565,14 @@ mod tests {
         assert_eq!(japanese.len(), 999);
 
         // Truncate at 998 — falls in the middle of the 333rd character
-        let result = write_tee_file(&japanese, "test_utf8", tmpdir.path(), 998, 20);
+        let result = write_tee_file(
+            &japanese,
+            "test_utf8",
+            tmpdir.path(),
+            998,
+            20,
+            RedactPolicy::Auto,
+        );
         assert!(result.is_some());
 
         let path = result.unwrap();
@@ -398,7 +590,14 @@ mod tests {
         assert_eq!(emojis.len(), 400);
 
         // Truncate at 201 — falls mid-emoji (4-byte boundary is at 200, 204)
-        let result = write_tee_file(&emojis, "test_emoji", tmpdir.path(), 201, 20);
+        let result = write_tee_file(
+            &emojis,
+            "test_emoji",
+            tmpdir.path(),
+            201,
+            20,
+            RedactPolicy::Auto,
+        );
         assert!(result.is_some());
 
         let path = result.unwrap();
@@ -501,7 +700,9 @@ directory = "/tmp/rtk-tee"
 
     #[test]
     fn test_force_tee_hint_respects_env_disable() {
-        // When RTK_TEE=0, force_tee_hint should return None
+        // When RTK_TEE=0, force_tee_hint should return None.
+        // Serialise via TEE_ENV_LOCK so we don't race other env-touching tests.
+        let _guard = TEE_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         std::env::set_var("RTK_TEE", "0");
         let large_output = "x".repeat(1000);
         let hint = force_tee_hint(&large_output, "test_cmd");
@@ -523,5 +724,265 @@ directory = "/tmp/rtk-tee"
         assert!(hint.starts_with("[see remaining: tail -n +22 "));
         assert!(hint.ends_with(']'));
         assert!(hint.contains("123_docker_images.log"));
+    }
+
+    // --- Sensitive output handling (Finding 4) ---
+    //
+    // The slug-blocklist tests stay below `write_tee_file` so they don't
+    // touch the user's real `~/.config/rtk/` or `~/.local/share/rtk/`.
+    // The high-level `*_sensitive` tests set `RTK_TEE_DIR` to a tempdir
+    // and `RTK_CONFIG_PATH` to a non-existent path so `Config::load()`
+    // returns the default config without reading the user's file. They
+    // serialise via the module-level `TEE_ENV_LOCK` above to keep
+    // concurrent `cargo test` runs deterministic.
+
+    #[test]
+    fn test_blocklisted_slug_skips_write() {
+        let tmpdir = tempfile::tempdir().expect("tempdir");
+        let content = "AWS secret payload that must never hit disk\n".repeat(20);
+        let result = write_tee_file(
+            &content,
+            "aws_secretsmanager_get-secret-value",
+            tmpdir.path(),
+            DEFAULT_MAX_FILE_SIZE,
+            20,
+            RedactPolicy::Auto,
+        );
+        assert!(result.is_none(), "blocklisted slug must refuse to write");
+
+        // And no file should have been created in the tempdir.
+        let count = fs::read_dir(tmpdir.path())
+            .expect("read tempdir")
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|x| x == "log"))
+            .count();
+        assert_eq!(count, 0, "no .log file may exist for blocklisted slug");
+    }
+
+    #[test]
+    fn test_redactor_masks_bearer_in_content() {
+        let tmpdir = tempfile::tempdir().expect("tempdir");
+        let content = format!(
+            "{}\nFailed request — Authorization: Bearer abc123XYZdef456GHIjkl\n{}",
+            "noise line ".repeat(30),
+            "more noise ".repeat(30),
+        );
+        let result = write_tee_file(
+            &content,
+            "cargo_test",
+            tmpdir.path(),
+            DEFAULT_MAX_FILE_SIZE,
+            20,
+            RedactPolicy::Auto,
+        );
+        let path = result.expect("write_tee_file should succeed");
+        let written = fs::read_to_string(&path).expect("read written file");
+
+        assert!(
+            written.contains("Bearer ****"),
+            "Bearer token must be masked: {}",
+            written
+        );
+        assert!(
+            !written.contains("abc123XYZdef456GHIjkl"),
+            "raw bearer token must not survive: {}",
+            written
+        );
+        assert!(
+            written.starts_with("--- rtk: 1 credential-like patterns redacted ---\n"),
+            "audit header must be prepended: {}",
+            &written[..written.len().min(120)],
+        );
+    }
+
+    #[test]
+    fn test_redactor_passes_through_clean_content() {
+        let tmpdir = tempfile::tempdir().expect("tempdir");
+        let content = "running 12 tests\n".repeat(60); // > MIN_TEE_SIZE
+        let result = write_tee_file(
+            &content,
+            "cargo_test",
+            tmpdir.path(),
+            DEFAULT_MAX_FILE_SIZE,
+            20,
+            RedactPolicy::Auto,
+        );
+        let path = result.expect("write_tee_file should succeed");
+        let written = fs::read_to_string(&path).expect("read written file");
+
+        assert_eq!(
+            written, content,
+            "clean content must be byte-identical (no header, no mutation)"
+        );
+        assert!(
+            !written.contains("--- rtk:"),
+            "no audit header for clean content"
+        );
+    }
+
+    #[test]
+    fn test_redactor_masks_aws_keys() {
+        let tmpdir = tempfile::tempdir().expect("tempdir");
+        // Synthetic, scanner-safe AWS-style key (Z-suffixed) — matches
+        // RTK's CREDENTIAL_PREFIX_RE without being a real AWS access key.
+        let content = format!(
+            "Failed deploy:\nAccessKeyId: AKIAZZZZZZZZZZZZZZZZ\n{}",
+            "trailing noise ".repeat(40),
+        );
+        let result = write_tee_file(
+            &content,
+            "docker_inspect",
+            tmpdir.path(),
+            DEFAULT_MAX_FILE_SIZE,
+            20,
+            RedactPolicy::Auto,
+        );
+        let path = result.expect("write_tee_file should succeed");
+        let written = fs::read_to_string(&path).expect("read written file");
+
+        assert!(
+            !written.contains("AKIAZZZZZZZZZZZZZZZZ"),
+            "AKIA-prefixed key must be masked: {}",
+            written
+        );
+        assert!(
+            written.contains("****"),
+            "redactor must leave its **** marker: {}",
+            written
+        );
+        assert!(
+            written.starts_with("--- rtk: 1 credential-like patterns redacted ---\n"),
+            "audit header must be prepended: {}",
+            &written[..written.len().min(120)],
+        );
+    }
+
+    #[test]
+    fn test_tee_and_hint_sensitive_always_redacts() {
+        let _guard = TEE_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+        let tmpdir = tempfile::tempdir().expect("tempdir");
+        // Point Config::load() at a non-existent path so it returns
+        // Config::default() (tee enabled, mode = Failures).
+        let fake_config = tmpdir.path().join("no-such-config.toml");
+        std::env::set_var("RTK_CONFIG_PATH", &fake_config);
+        std::env::set_var("RTK_TEE_DIR", tmpdir.path());
+        std::env::remove_var("RTK_TEE");
+
+        // Non-blocklisted slug, exit_code != 0 (so default Failures mode tees).
+        let content = format!(
+            "request failed:\nAuthorization: Bearer abc123XYZdef456GHIjkl\n{}",
+            "padding ".repeat(80),
+        );
+        let hint = tee_and_hint_sensitive(&content, "cargo_test", 1);
+
+        // Restore env before any assertion can fail the test.
+        std::env::remove_var("RTK_CONFIG_PATH");
+        std::env::remove_var("RTK_TEE_DIR");
+
+        let hint = hint.expect("sensitive tee should write for non-blocklisted slug");
+        assert!(hint.starts_with("[full output: "), "hint shape: {hint}");
+
+        // Find the file inside the tempdir and assert it's scrubbed.
+        let entry = fs::read_dir(tmpdir.path())
+            .expect("read tempdir")
+            .filter_map(|e| e.ok())
+            .find(|e| e.path().extension().is_some_and(|x| x == "log"))
+            .expect("tee file must exist");
+        let written = fs::read_to_string(entry.path()).expect("read tee file");
+
+        assert!(
+            written.contains("Bearer ****"),
+            "sensitive variant must redact Bearer: {}",
+            written
+        );
+        assert!(
+            !written.contains("abc123XYZdef456GHIjkl"),
+            "raw bearer must not survive: {}",
+            written
+        );
+        assert!(
+            written.starts_with("--- rtk: "),
+            "audit header must be prepended: {}",
+            &written[..written.len().min(120)],
+        );
+    }
+
+    #[test]
+    fn test_aws_sts_get_session_token_does_not_persist_to_disk() {
+        let _guard = TEE_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+        let tmpdir = tempfile::tempdir().expect("tempdir");
+        let fake_config = tmpdir.path().join("no-such-config.toml");
+        std::env::set_var("RTK_CONFIG_PATH", &fake_config);
+        std::env::set_var("RTK_TEE_DIR", tmpdir.path());
+        std::env::remove_var("RTK_TEE");
+
+        // Slug matches `aws_sts_get-session-token` prefix → blocklisted.
+        let content = format!(
+            "{{\"Credentials\":{{\"AccessKeyId\":\"AKIAZZZZZZZZZZZZZZZZ\",\"SecretAccessKey\":\"xyz\"}}}}\n{}",
+            "padding ".repeat(80),
+        );
+        let hint = tee_and_hint_sensitive(&content, "aws_sts_get-session-token", 1);
+
+        std::env::remove_var("RTK_CONFIG_PATH");
+        std::env::remove_var("RTK_TEE_DIR");
+
+        assert!(
+            hint.is_none(),
+            "blocklisted slug must not emit a tee hint: {:?}",
+            hint
+        );
+        let log_count = fs::read_dir(tmpdir.path())
+            .expect("read tempdir")
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|x| x == "log"))
+            .count();
+        assert_eq!(
+            log_count, 0,
+            "blocklisted slug must not persist any .log file"
+        );
+    }
+
+    #[test]
+    fn test_is_blocklisted_slug_examples() {
+        // Positive: all the slugs from the design doc Finding 4.
+        for slug in [
+            "aws_secretsmanager_get-secret-value",
+            "aws_kms_decrypt",
+            "aws_sts_get-session-token",
+            "aws_sts_assume-role",
+            "kubectl_get_secret_my-secret",
+            "kubectl_describe_secret_my-secret",
+            "gh_secret_set",
+            "gh_auth_status",
+            "glab_secret_list",
+            "glab_auth_login",
+            "op_item_get",
+            "vault_kv_get",
+            "doppler_secrets",
+            "bw_get_password",
+            "pass_show",
+            "helm_get_values_release",
+            "git_config_user.email",
+        ] {
+            assert!(is_blocklisted_slug(slug), "slug {slug} must be blocklisted");
+        }
+        // Negative: ordinary slugs must not be blocked.
+        for slug in [
+            "cargo_test",
+            "cargo_build",
+            "npm_install",
+            "docker_ps",
+            "kubectl_get_pods",
+            "git_log",
+            "git_status",
+            "gh_pr_view",
+        ] {
+            assert!(
+                !is_blocklisted_slug(slug),
+                "slug {slug} must NOT be blocklisted"
+            );
+        }
     }
 }

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -29,6 +29,7 @@
 //!
 //! See [docs/tracking.md](../docs/tracking.md) for full documentation.
 
+use super::redact::{redact_command, redact_project_path};
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection};
@@ -36,6 +37,45 @@ use serde::Serialize;
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::time::Instant;
+
+/// SQLite `PRAGMA user_version` value that signals the credential-redaction
+/// migration has been applied. Bumped from the previous baseline of 0/1 to 2.
+const USER_VERSION_REDACTED: i32 = 2;
+
+/// Re-canonicalise a project path against the config-driven hashing toggle.
+/// Centralised here so `Tracker::record` and the one-shot migration share a
+/// single decision point.
+fn canonical_project_path(raw: &str, hash_enabled: bool) -> String {
+    if hash_enabled {
+        redact_project_path(raw)
+    } else {
+        raw.to_string()
+    }
+}
+
+/// Decide whether `Tracker::record` / `Tracker::record_parse_failure` should
+/// touch the DB this invocation.
+///
+/// Honours the long-documented-but-previously-unenforced `tracking.enabled`
+/// flag and adds a one-shot `RTK_TRACK=0` escape hatch mirroring the existing
+/// `RTK_TEE=0` pattern. Fails open: a missing/corrupt config never disables
+/// tracking on its own.
+fn tracking_enabled() -> bool {
+    if std::env::var("RTK_TRACK").ok().as_deref() == Some("0") {
+        return false;
+    }
+    crate::core::config::Config::load()
+        .map(|c| c.tracking.enabled)
+        .unwrap_or(true)
+}
+
+/// Whether `redact_project_path` should be applied. Defaults to true so new
+/// rows are private by default.
+fn hash_project_paths_enabled() -> bool {
+    crate::core::config::Config::load()
+        .map(|c| c.tracking.hash_project_paths)
+        .unwrap_or(true)
+}
 
 // ── Project path helpers ── // added: project-scoped tracking support
 
@@ -323,7 +363,105 @@ impl Tracker {
             [],
         )?;
 
-        Ok(Self { conn })
+        let tracker = Self { conn };
+        // One-shot redaction migration. Logs (and swallows) errors so a
+        // half-broken DB never blocks `rtk gain` from opening.
+        if let Err(e) = tracker.maybe_run_redaction_migration() {
+            eprintln!("rtk: tracking redaction migration skipped: {}", e);
+        }
+        Ok(tracker)
+    }
+
+    /// Redact `original_cmd` and `project_path` for rows newer than 90 days.
+    ///
+    /// Gated by `PRAGMA user_version` so it runs at most once per binary
+    /// version. The migration is a pure-Rust read-modify-write loop; we do
+    /// not register a SQLite UDF.
+    fn maybe_run_redaction_migration(&self) -> Result<()> {
+        let current: i32 = self
+            .conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .unwrap_or(0);
+        if current >= USER_VERSION_REDACTED {
+            return Ok(());
+        }
+
+        let cutoff = Utc::now() - chrono::Duration::days(DEFAULT_HISTORY_DAYS);
+        let hash_paths = hash_project_paths_enabled();
+
+        // Collect candidate rows first so we don't hold a statement open
+        // while issuing UPDATEs on the same connection.
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, original_cmd, project_path
+                 FROM commands
+                 WHERE timestamp >= ?1",
+            )
+            .context("Failed to prepare migration SELECT")?;
+        let rows: Vec<(i64, String, String)> = stmt
+            .query_map(params![cutoff.to_rfc3339()], |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            })
+            .context("Failed to query commands for migration")?
+            .collect::<Result<Vec<_>, _>>()
+            .context("Failed to collect migration rows")?;
+        drop(stmt);
+
+        for (id, cmd, project_path) in rows {
+            let cmd_redacted = redact_command(&cmd);
+            let path_redacted = canonical_project_path(&project_path, hash_paths);
+            if cmd_redacted == cmd && path_redacted == project_path {
+                continue;
+            }
+            self.conn
+                .execute(
+                    "UPDATE commands
+                     SET original_cmd = ?1, project_path = ?2
+                     WHERE id = ?3",
+                    params![cmd_redacted, path_redacted, id],
+                )
+                .context("Failed to update redacted row")?;
+        }
+
+        // Parse failures table — same treatment for `raw_command`.
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, raw_command FROM parse_failures
+                 WHERE timestamp >= ?1",
+            )
+            .context("Failed to prepare migration SELECT (parse_failures)")?;
+        let pf_rows: Vec<(i64, String)> = stmt
+            .query_map(params![cutoff.to_rfc3339()], |row| {
+                Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+            })
+            .context("Failed to query parse_failures for migration")?
+            .collect::<Result<Vec<_>, _>>()
+            .context("Failed to collect parse_failures rows")?;
+        drop(stmt);
+        for (id, raw_cmd) in pf_rows {
+            let redacted = redact_command(&raw_cmd);
+            if redacted == raw_cmd {
+                continue;
+            }
+            self.conn
+                .execute(
+                    "UPDATE parse_failures SET raw_command = ?1 WHERE id = ?2",
+                    params![redacted, id],
+                )
+                .context("Failed to update redacted parse_failure row")?;
+        }
+
+        // PRAGMA user_version takes a literal int, not a bound param.
+        self.conn
+            .execute_batch(&format!("PRAGMA user_version = {}", USER_VERSION_REDACTED))
+            .context("Failed to bump user_version after migration")?;
+        Ok(())
     }
 
     /// Create an isolated in-memory tracker for tests.
@@ -333,6 +471,14 @@ impl Tracker {
         let tracker = Self { conn };
         tracker.init_schema()?;
         Ok(tracker)
+    }
+
+    /// Run the credential-redaction migration on an in-memory tracker.
+    /// Exposed for the dedicated migration test; production callers go
+    /// through `Tracker::new()`.
+    #[cfg(test)]
+    pub fn run_redaction_migration_for_tests(&self) -> Result<()> {
+        self.maybe_run_redaction_migration()
     }
 
     #[cfg(test)]
@@ -407,6 +553,10 @@ impl Tracker {
         output_tokens: usize,
         exec_time_ms: u64,
     ) -> Result<()> {
+        if !tracking_enabled() {
+            return Ok(()); // silent no-op when [tracking] enabled = false / RTK_TRACK=0
+        }
+
         let saved = input_tokens.saturating_sub(output_tokens);
         let pct = if input_tokens > 0 {
             (saved as f64 / input_tokens as f64) * 100.0
@@ -414,14 +564,21 @@ impl Tracker {
             0.0
         };
 
-        let project_path = current_project_path_string(); // added: record cwd
+        // Scrub credential-shaped substrings before binding to SQL. The
+        // ecosystem aggregation paths (top_commands, categorize_command,
+        // top_passthrough) only look at the first whitespace-delimited
+        // token, which the redactor never touches.
+        let original_cmd_redacted = redact_command(original_cmd);
+
+        let raw_project_path = current_project_path_string(); // added: record cwd
+        let project_path = canonical_project_path(&raw_project_path, hash_project_paths_enabled());
 
         self.conn.execute(
             "INSERT INTO commands (timestamp, original_cmd, rtk_cmd, project_path, input_tokens, output_tokens, saved_tokens, savings_pct, exec_time_ms)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)", // added: project_path
             params![
                 Utc::now().to_rfc3339(),
-                original_cmd,
+                original_cmd_redacted,
                 rtk_cmd,
                 project_path, // added
                 input_tokens as i64,
@@ -469,12 +626,16 @@ impl Tracker {
         error_message: &str,
         fallback_succeeded: bool,
     ) -> Result<()> {
+        if !tracking_enabled() {
+            return Ok(()); // gated by the same flag as Tracker::record
+        }
+        let raw_command_redacted = redact_command(raw_command);
         self.conn.execute(
             "INSERT INTO parse_failures (timestamp, raw_command, error_message, fallback_succeeded)
              VALUES (?1, ?2, ?3, ?4)",
             params![
                 Utc::now().to_rfc3339(),
-                raw_command,
+                raw_command_redacted,
                 error_message,
                 fallback_succeeded as i32,
             ],
@@ -1684,6 +1845,366 @@ mod tests {
         assert_eq!(
             failures.total, 0,
             "parse_failures table should be empty after reset"
+        );
+    }
+
+    // ── Finding 2 + 3 redaction & gating tests ──
+    //
+    // All tests below set `HOME` / `XDG_CONFIG_HOME` to a per-test temp dir so
+    // `Config::load()` falls back to defaults (tracking.enabled = true,
+    // hash_project_paths = true). They serialise via `tracking_env_lock` to
+    // avoid env-var races, mirroring `test_db_path_env_and_default`.
+
+    use std::sync::Mutex;
+    static TRACKING_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct ScopedEnv {
+        keys: Vec<(&'static str, Option<OsString>)>,
+    }
+
+    impl ScopedEnv {
+        fn new(overrides: &[(&'static str, Option<&str>)]) -> Self {
+            let mut saved = Vec::with_capacity(overrides.len());
+            for (key, val) in overrides {
+                saved.push((*key, std::env::var_os(key)));
+                match val {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+            Self { keys: saved }
+        }
+    }
+
+    impl Drop for ScopedEnv {
+        fn drop(&mut self) {
+            for (key, prev) in &self.keys {
+                match prev {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+
+    /// Write a config file at `<tmp>/config.toml` and return the path.
+    fn write_config(tmp: &std::path::Path, toml: &str) -> std::path::PathBuf {
+        let p = tmp.join("config.toml");
+        std::fs::write(&p, toml).expect("write config.toml");
+        p
+    }
+
+    /// Build an env-override list that points `Config::load()` at a per-test
+    /// config file via `RTK_CONFIG_PATH`. Avoids mutating `HOME` so we don't
+    /// race against other tests that call `Tracker::new()`.
+    fn make_isolated_config_env(
+        cfg_path: &std::path::Path,
+    ) -> Vec<(&'static str, Option<&'static str>)> {
+        let p: &'static str = Box::leak(
+            cfg_path
+                .to_str()
+                .expect("temp path utf8")
+                .to_string()
+                .into_boxed_str(),
+        );
+        vec![
+            ("RTK_CONFIG_PATH", Some(p)),
+            // Make sure no stray RTK_TRACK from the host leaks in.
+            ("RTK_TRACK", None),
+        ]
+    }
+
+    // ── Finding 2: redact_command tests ──
+
+    #[test]
+    fn test_redact_command_url_userinfo() {
+        let input = "git push https://x:y@host/repo";
+        let got = redact_command(input);
+        assert!(got.contains("https://****:****@host/repo"), "got: {got}");
+        assert!(!got.contains("x:y@"));
+    }
+
+    #[test]
+    fn test_redact_command_bearer() {
+        let input = r#"curl -H "Authorization: Bearer abc123" https://api"#;
+        let got = redact_command(input);
+        assert!(got.contains("Bearer ****"), "got: {got}");
+        assert!(!got.contains("abc123"));
+    }
+
+    #[test]
+    fn test_redact_command_flags() {
+        let cases = [
+            ("tool --token=abc", "--token=****"),
+            ("tool --password xyz", "--password ****"),
+            ("tool --api-key=k", "--api-key=****"),
+        ];
+        for (input, needle) in cases {
+            let got = redact_command(input);
+            assert!(got.contains(needle), "input={input} got={got}");
+            assert!(!got.contains("abc") || !input.contains("abc=abc"));
+        }
+    }
+
+    #[test]
+    fn test_redact_command_inline_env() {
+        let input = "GH_TOKEN=ghp_abc git push";
+        let got = redact_command(input);
+        assert!(got.contains("GH_TOKEN=****"), "got: {got}");
+        assert!(!got.contains("ghp_abc"));
+    }
+
+    #[test]
+    fn test_redact_command_credential_heuristic() {
+        // Synthetic fixtures (all Z-suffixed) — not real credentials, but
+        // they trip the RTK prefix regex without flagging GitHub's
+        // secret-scanner.
+        let cases = [
+            ("echo ghp_ZZZZZZZZZZZZZZZZZZZZ", "ghp_"),
+            ("echo sk-ZZZZZZZZZZZZZZZZZZZZ", "sk-"),
+            ("echo AKIAZZZZZZZZZZZZZZZZ", "AKIA"),
+        ];
+        for (input, prefix) in cases {
+            let got = redact_command(input);
+            assert!(got.contains("****"), "input={input} got={got}");
+            let original_tail = input.split_whitespace().last().expect("token");
+            assert!(
+                !got.contains(original_tail),
+                "original token {original_tail} (prefix {prefix}) leaked: {got}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_redact_command_idempotent() {
+        let inputs = [
+            "git push https://alice:s3cret@github.com/acme/repo.git",
+            "curl --token=abc -H 'Authorization: Bearer xyz' https://api",
+            "GH_TOKEN=ghp_ZZZZZZZZZZZZZZZZZZZZ git push",
+        ];
+        for input in inputs {
+            let once = redact_command(input);
+            let twice = redact_command(&once);
+            assert_eq!(once, twice, "non-idempotent: {input}");
+        }
+    }
+
+    #[test]
+    fn test_redact_project_path_shape() {
+        let cases = [
+            "/Users/alice/Projects/rtk",
+            "/home/bob/work/secret-project",
+            "C:\\Users\\carol\\code\\rtk",
+            "/", // edge case
+        ];
+        let shape = regex::Regex::new(r"^[A-Za-z0-9_.-]+#[0-9a-f]{8}$").expect("shape regex");
+        for path in cases {
+            let got = redact_project_path(path);
+            assert!(shape.is_match(&got), "shape mismatch for {path}: got {got}");
+        }
+        // Empty path stays empty (so existing `project_path != ''` filter
+        // keeps treating it as "no project recorded").
+        assert_eq!(redact_project_path(""), "");
+    }
+
+    #[test]
+    fn test_migration_redacts_existing_rows() {
+        let tracker = Tracker::new_in_memory().expect("in-memory tracker");
+
+        // Insert a pre-migration row directly (bypassing record's redactor).
+        // Token below is a synthetic Z-suffixed fixture (not a real PAT).
+        let original =
+            "git push https://alice:s3cret@example.com/repo --token=ghp_ZZZZZZZZZZZZZZZZZZZZ";
+        tracker
+            .conn
+            .execute(
+                "INSERT INTO commands
+                 (timestamp, original_cmd, rtk_cmd, project_path,
+                  input_tokens, output_tokens, saved_tokens, savings_pct, exec_time_ms)
+                 VALUES (?1, ?2, 'rtk git push', '/Users/test/proj', 100, 20, 80, 80.0, 5)",
+                params![Utc::now().to_rfc3339(), original],
+            )
+            .expect("seed pre-migration row");
+        // Pre-condition: token visible.
+        let row: String = tracker
+            .conn
+            .query_row("SELECT original_cmd FROM commands LIMIT 1", [], |r| {
+                r.get(0)
+            })
+            .expect("read seeded row");
+        assert!(row.contains("ghp_ZZZZZZZZZZZZZZZZZZZZ"), "seed: {row}");
+
+        // Reset user_version so the migration runs.
+        tracker
+            .conn
+            .execute_batch("PRAGMA user_version = 0")
+            .expect("reset user_version");
+        tracker
+            .run_redaction_migration_for_tests()
+            .expect("run migration");
+
+        let row: String = tracker
+            .conn
+            .query_row("SELECT original_cmd FROM commands LIMIT 1", [], |r| {
+                r.get(0)
+            })
+            .expect("read migrated row");
+        assert!(
+            !row.contains("ghp_ZZZZZZZZZZZZZZZZZZZZ"),
+            "token leaked post-migration: {row}"
+        );
+        assert!(!row.contains("alice"), "user leaked post-migration: {row}");
+        assert!(!row.contains("s3cret"), "pw leaked post-migration: {row}");
+
+        // user_version bumped → second run is a no-op (does not re-rewrite).
+        let path_before: String = tracker
+            .conn
+            .query_row("SELECT project_path FROM commands LIMIT 1", [], |r| {
+                r.get(0)
+            })
+            .expect("read project_path");
+        tracker
+            .run_redaction_migration_for_tests()
+            .expect("second migration");
+        let path_after: String = tracker
+            .conn
+            .query_row("SELECT project_path FROM commands LIMIT 1", [], |r| {
+                r.get(0)
+            })
+            .expect("read project_path again");
+        assert_eq!(path_before, path_after, "migration not idempotent");
+    }
+
+    // ── Finding 3: tracking_enabled gate tests ──
+
+    #[test]
+    fn test_tracking_disabled_via_config_skips_insert() {
+        let _guard = TRACKING_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg = write_config(
+            tmp.path(),
+            "[tracking]\nenabled = false\nhistory_days = 90\n",
+        );
+        let overrides = make_isolated_config_env(&cfg);
+        let _env = ScopedEnv::new(&overrides);
+
+        let tracker = Tracker::new_in_memory().expect("tracker");
+        let before: i64 = tracker
+            .conn
+            .query_row("SELECT COUNT(*) FROM commands", [], |r| r.get(0))
+            .expect("count");
+        tracker
+            .record("git status", "rtk git status", 100, 20, 5)
+            .expect("record");
+        let after: i64 = tracker
+            .conn
+            .query_row("SELECT COUNT(*) FROM commands", [], |r| r.get(0))
+            .expect("count");
+        assert_eq!(
+            before, after,
+            "tracking.enabled = false must skip the INSERT"
+        );
+    }
+
+    #[test]
+    fn test_tracking_disabled_via_env_skips_insert() {
+        let _guard = TRACKING_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // No config file written — rely on the env var override.
+        let cfg = tmp.path().join("nonexistent-config.toml");
+        let mut overrides = make_isolated_config_env(&cfg);
+        for slot in overrides.iter_mut() {
+            if slot.0 == "RTK_TRACK" {
+                slot.1 = Some("0");
+            }
+        }
+        let _env = ScopedEnv::new(&overrides);
+
+        let tracker = Tracker::new_in_memory().expect("tracker");
+        tracker
+            .record("git status", "rtk git status", 100, 20, 5)
+            .expect("record");
+        let after: i64 = tracker
+            .conn
+            .query_row("SELECT COUNT(*) FROM commands", [], |r| r.get(0))
+            .expect("count");
+        assert_eq!(after, 0, "RTK_TRACK=0 must skip the INSERT");
+    }
+
+    #[test]
+    fn test_tracking_enabled_default_records() {
+        let _guard = TRACKING_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg = tmp.path().join("missing-config.toml"); // file does not exist → defaults
+        let overrides = make_isolated_config_env(&cfg);
+        let _env = ScopedEnv::new(&overrides);
+
+        let tracker = Tracker::new_in_memory().expect("tracker");
+        tracker
+            .record("git status", "rtk git status", 100, 20, 5)
+            .expect("record");
+        let after: i64 = tracker
+            .conn
+            .query_row("SELECT COUNT(*) FROM commands", [], |r| r.get(0))
+            .expect("count");
+        assert_eq!(after, 1, "default config must record");
+    }
+
+    #[test]
+    fn test_tracking_disabled_still_lets_reset_run() {
+        let _guard = TRACKING_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // Step 1: seed a row while tracking is enabled (no config file yet).
+        let cfg_path = tmp.path().join("config.toml");
+        let overrides = make_isolated_config_env(&cfg_path);
+        let _env = ScopedEnv::new(&overrides);
+
+        let tracker = Tracker::new_in_memory().expect("tracker");
+        tracker
+            .record("git status", "rtk git status", 100, 20, 5)
+            .expect("seed record");
+
+        // Step 2: write the disabling config in place.
+        std::fs::write(
+            &cfg_path,
+            "[tracking]\nenabled = false\nhistory_days = 90\n",
+        )
+        .expect("write config");
+
+        // Records are now no-ops, but reset_all must still drain the table.
+        tracker
+            .record("git diff", "rtk git diff", 50, 10, 5)
+            .expect("noop record");
+        tracker.reset_all().expect("reset");
+        let after: i64 = tracker
+            .conn
+            .query_row("SELECT COUNT(*) FROM commands", [], |r| r.get(0))
+            .expect("count");
+        assert_eq!(after, 0, "reset_all must work even when disabled");
+    }
+
+    #[test]
+    fn test_parse_failure_also_gated() {
+        let _guard = TRACKING_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg = write_config(
+            tmp.path(),
+            "[tracking]\nenabled = false\nhistory_days = 90\n",
+        );
+        let overrides = make_isolated_config_env(&cfg);
+        let _env = ScopedEnv::new(&overrides);
+
+        let tracker = Tracker::new_in_memory().expect("tracker");
+        tracker
+            .record_parse_failure("bad cmd", "boom", false)
+            .expect("noop pf");
+        let after: i64 = tracker
+            .conn
+            .query_row("SELECT COUNT(*) FROM parse_failures", [], |r| r.get(0))
+            .expect("count");
+        assert_eq!(
+            after, 0,
+            "record_parse_failure must respect tracking.enabled"
         );
     }
 }


### PR DESCRIPTION
## ⚠️ Stacked PR
This PR is stacked on #1987 (security PR 2/3 — `feat/tracking-redaction-and-gating`). Merge #1987 first; this PR's diff will then become its own delta against develop.

## Summary

Final PR in the 3-part RTK security batch (Refs #1875, Finding 4). Three layers of defence over the tee subsystem so that `~/.local/share/rtk/tee/<epoch>_<slug>.log` files never become a verbatim, LLM-pointed-at copy of `aws secretsmanager get-secret-value` / `kubectl get secret -o yaml` / `op item get` output.

### Why

The tee subsystem writes raw, unfiltered command output to disk on failure (default `mode = Failures`) and then emits a `[full output: ~/path]` hint into the LLM-visible stdout — so the agent will frequently `Read` the file back into context. For sensitive command families this turns a single failed secret-fetch into a persistent on-disk leak *and* re-injects the credential into the model on the next turn.

### What ships

**1. Per-slug blocklist** (`src/core/tee.rs::SENSITIVE_SLUG_PREFIXES`)

Slugs are matched with `starts_with(prefix)`. When a slug matches, `write_tee_file` returns `None` before any disk I/O and the `[full output: …]` hint is suppressed.

Initial prefixes (per design doc):

- `aws_secretsmanager*`, `aws_kms*`, `aws_sts_get-session-token`, `aws_sts_assume-role`
- `kubectl_get_secret*`, `kubectl_describe_secret*`
- `gh_secret*`, `gh_auth*`, `glab_secret*`, `glab_auth*`
- `op_*` (1Password), `vault_*`, `doppler_*`, `bw_*` (Bitwarden), `pass_*`
- `helm_get_values*`, `git_config*`

**2. Content-level redactor** (uses `redact_content` extracted into `src/core/redact.rs` from PR #1987)

Every tee write — blocklisted or not — passes through `redact::redact_content`, which reuses the PR-11 `lazy_static!`-cached regex bundle (URL userinfo, Bearer / Authorization headers, `--token=` / `--password=` flags, `GH_TOKEN=` / `AWS_SECRET_ACCESS_KEY=` inline env, and the `ghp_…` / `sk-…` / `AKIA…` credential-prefix heuristic). On hit, a one-line audit header is prepended:

```
--- rtk: N credential-like patterns redacted ---
<scrubbed body>
```

The redactor is single-pass over already-cached regex (no allocations on clean input), so the cost on the cargo-test / npm-install hot path is one regex scan per pattern with a byte-identical fast-path return.

**3. Per-call-site `Sensitive` opt-in**

New public API in `tee.rs`:

- `tee_and_hint_sensitive(raw, slug, exit_code)`
- `force_tee_hint_sensitive(raw, slug)`
- `force_tee_tail_hint_sensitive(content, slug, offset)` (reserved for future, marked `#[allow(dead_code)]`)

A new `RunOptions::tee_sensitive()` chain method on `src/core/runner.rs` lets shared-runner callers (psql) opt in without re-implementing the tee plumbing.

**Migrated call sites** (grep-confirmed in this PR's worktree):

| File | Line | Old → New |
| --- | --- | --- |
| `src/cmds/cloud/aws_cmd.rs` | 6 | `force_tee_hint` import → `force_tee_hint_sensitive` |
| `src/cmds/cloud/aws_cmd.rs` | 349 | `tee_and_hint` → `tee_and_hint_sensitive` |
| `src/cmds/cloud/aws_cmd.rs` | 364 | `force_tee_hint` → `force_tee_hint_sensitive` |
| `src/cmds/cloud/aws_cmd.rs` | 369 | `tee_and_hint` → `tee_and_hint_sensitive` |
| `src/cmds/cloud/aws_cmd.rs` | 402 | `tee_and_hint` → `tee_and_hint_sensitive` (s3_ls failure) |
| `src/cmds/cloud/aws_cmd.rs` | 414 | `force_tee_hint` → `force_tee_hint_sensitive` (s3_ls truncated) |
| `src/cmds/cloud/aws_cmd.rs` | 456 | `tee_and_hint` → `tee_and_hint_sensitive` (s3 transfer) |
| `src/cmds/cloud/aws_cmd.rs` | 467 | `force_tee_hint` → `force_tee_hint_sensitive` (s3 transfer truncated) |
| `src/cmds/cloud/curl_cmd.rs` | 9, 91 | `force_tee_hint` → `force_tee_hint_sensitive` |
| `src/cmds/cloud/psql_cmd.rs` | 42 | `.tee("psql")` → `.tee("psql").tee_sensitive()` |

(The design doc listed 6 AWS lines but a grep over the post-PR10 worktree turned up 7 — `aws_cmd.rs:467` in `run_s3_transfer` was a new addition since the doc was written. Migrated all of them.)

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets` — zero warnings
- [x] `cargo test --bin rtk -- --test-threads=1` → **1930 passed, 0 failed**
- [x] Single-thread + 8-thread runs both stable. (Existing `test_force_tee_hint_respects_env_disable` was made race-safe by sharing a new `TEE_ENV_LOCK` with the env-touching tests added here.)
- [x] Released a follow-up audit grep — no remaining `force_tee_hint(` / `tee_and_hint(` in `src/cmds/cloud/`; runner-mediated `.tee_sensitive()` toggle covers psql.

### Tests added (10)

In `src/core/tee.rs::tests`:
- `test_blocklisted_slug_skips_write` — slug `aws_secretsmanager_get-secret-value`, write returns `None`, no `.log` file appears in the tempdir.
- `test_redactor_masks_bearer_in_content` — `Authorization: Bearer abc…` → `Bearer ****` + `--- rtk: 1 credential-like patterns redacted ---` header.
- `test_redactor_passes_through_clean_content` — clean cargo-test fixture round-trips byte-identical, no header.
- `test_redactor_masks_aws_keys` — synthetic `AKIAZZZZZZZZZZZZZZZZ` (scanner-safe Z-suffix per PR-11 convention) gets masked.
- `test_tee_and_hint_sensitive_always_redacts` — non-blocklisted slug (`cargo_test`) still gets scrubbed when called via the sensitive variant.
- `test_aws_sts_get_session_token_does_not_persist_to_disk` — sensitive variant + blocklisted slug → no file, no hint.
- `test_is_blocklisted_slug_examples` — round-trip coverage of every prefix in `SENSITIVE_SLUG_PREFIXES`, plus negative cases.

In `src/core/redact.rs::tests`:
- `test_redact_content_counts_substitutions` — combined URL+Bearer hit reports `n >= 2` matches.
- `test_redact_content_passes_clean_text_unchanged` — clean text round-trips, count = 0.
- `test_redact_content_empty_input` — empty input → empty output, count = 0.

### Backward compatibility

- The current "recover huge cargo-test failure from the LLM" workflow is unchanged because (a) cargo / test / build slugs are not on the blocklist and (b) the regex redactor is a no-op (byte-identical fast-path) on output that has no credential-shaped substrings.
- Hint format unchanged — `[full output: …]` still appears when the file is written. The model just reads back a file with `****` where credentials used to be.
- `tee.enabled = false` and `RTK_TEE=0` continue to work as before.

### Out of scope (deferred)

- Encrypting the tee directory at rest.
- A `rtk privacy` meta-command (`rtk privacy purge`, etc.).
- PII detection beyond the credential-prefix heuristic.
- A `RTK_TEE_REDACT=0` env knob to disable Layer 2 (kept as future-extension hook via the `RedactPolicy` enum).

Refs #1875 (Finding 4)