### PR TITLE
docs(readme): fix license references to match LICENSE (Apache-2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/rtk-ai/rtk/actions"><img src="https://github.com/rtk-ai/rtk/workflows/Security%20Check/badge.svg" alt="CI"></a>
   <a href="https://github.com/rtk-ai/rtk/releases"><img src="https://img.shields.io/github/v/release/rtk-ai/rtk" alt="Release"></a>
-  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
+  <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0"></a>
   <a href="https://discord.gg/RySmvNF5kF"><img src="https://img.shields.io/discord/1470188214710046894?label=Discord&logo=discord" alt="Discord"></a>
   <a href="https://formulae.brew.sh/formula/rtk"><img src="https://img.shields.io/homebrew/v/rtk" alt="Homebrew"></a>
 </p>
@@ -483,7 +483,7 @@ Join the community on [Discord](https://discord.gg/RySmvNF5kF).
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) for details.
+Apache License 2.0 - see [LICENSE](LICENSE) for details.
 
 ## Disclaimer
 


### PR DESCRIPTION
## Summary

The README badge and footer claimed MIT, but the `LICENSE` file is **Apache License 2.0**. This PR updates the README so both references match the authoritative `LICENSE` file.

- `README.md:12` — shields.io badge updated from MIT (yellow) to Apache 2.0 (blue), link updated to `opensource.org/licenses/Apache-2.0`
- `README.md:486` — footer updated from "MIT License" to "Apache License 2.0"

No code changes; LICENSE file is unchanged.

Closes #1996

## Test plan

- [x] `git diff` shows only the two intended line changes in `README.md`
- [ ] GitHub renders the new Apache-2.0 badge on the repo page after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>