### PR TITLE
chore(cargo): declare MSRV via rust-version = "1.91"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rtk"
 version = "0.34.3"
 edition = "2021"
+rust-version = "1.91"
 authors = ["Patrick Szymkowiak"]
 description = "Rust Token Killer - High-performance CLI proxy to minimize LLM token consumption"
 license = "MIT"


### PR DESCRIPTION
## Summary

\`rtk\` already uses \`str::floor_char_boundary()\` (\`src/cmds/system/pipe_cmd.rs:140\`), stabilized in Rust 1.91.0, but \`Cargo.toml\` doesn't declare the MSRV. Distribution packagers on older toolchains see a confusing \`use of unstable library feature\` rustc error instead of a clear cargo-level MSRV diagnostic.

## Reproduction

\`\`\`bash
# Without this PR, on Rust 1.88.0:
$ cargo check
error[E0658]: use of unstable library feature \`round_char_boundary\`
 --> src/cmds/system/pipe_cmd.rs:140:21
\`\`\`

## Fix

Add \`rust-version = "1.91"\` to the \`[package]\` table.

\`\`\`toml
[package]
name = "rtk"
version = "0.34.3"
edition = "2021"
rust-version = "1.91"   # ← added
\`\`\`

## After

\`\`\`bash
$ cargo +1.88 check
error: rustc 1.88.0 is not supported by the following packages:
  rtk@0.34.3 requires rustc 1.91
\`\`\`

Cargo gives the right diagnostic at the \`[package]\`-validation step, before \`rustc\` ever runs.

## Test plan

- [x] \`cargo +1.93 fmt --all -- --check\` clean.
- [x] \`cargo +1.93 clippy --all-targets\` zero warnings.
- [x] \`cargo +1.93 test --bin rtk -- --test-threads=8\` → 1909 passed.
- [x] \`cargo +1.88 check\` reproduces the friendly MSRV error (intended behaviour).

## Notes

@DavidReque expressed interest a month ago but no PR materialized — happy to defer if they'd prefer to push their own; otherwise this lands the minimal one-line change so packagers stop hitting the unhelpful rustc message.

Fixes #1402