### PR TITLE
fix(discover): register ssh in the rewrite rule table so hook routes it

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1011,6 +1011,67 @@ mod tests {
         );
     }
 
+    // --- #1654: ssh classify + rewrite roundtrip ---
+
+    #[test]
+    fn test_classify_ssh_with_remote_command() {
+        // Hook path must classify ssh-with-args as Supported so `rtk rewrite`
+        // returns the prefixed form instead of bailing with exit 1.
+        match classify_command("ssh user@host uptime") {
+            Classification::Supported {
+                rtk_equivalent,
+                category,
+                ..
+            } => {
+                assert_eq!(rtk_equivalent, "rtk ssh");
+                assert_eq!(category, "Network");
+            }
+            other => panic!("expected Supported, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_rewrite_ssh_shapes() {
+        // Spot-check the four shapes from #1654's reproduction script.
+        let cases = [
+            ("ssh root@host uptime", "rtk ssh root@host uptime"),
+            ("ssh user@example.test ls", "rtk ssh user@example.test ls"),
+            (
+                "ssh -o ConnectTimeout=5 host echo OK",
+                "rtk ssh -o ConnectTimeout=5 host echo OK",
+            ),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(
+                rewrite_command_no_prefixes(input, &[]),
+                Some(expected.into()),
+                "rewrite for {:?} should be Some({:?})",
+                input,
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn test_rewrite_ssh_with_host_only() {
+        // `ssh host` (no remote command, just login) is the fourth shape
+        // from #1654's reproduction script. It still needs to flow through
+        // the filter — even login banners benefit from `strip_lines_matching`
+        // in `src/filters/ssh.toml`.
+        assert_eq!(
+            rewrite_command_no_prefixes("ssh host", &[]),
+            Some("rtk ssh host".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_bare_ssh_not_rewritten() {
+        // `ssh` with no arguments at all is left alone (the regex requires
+        // `\s+` after `ssh`); without an argv it would just print usage to
+        // stderr and there's nothing to filter.
+        assert_eq!(rewrite_command_no_prefixes("ssh", &[]), None);
+    }
+
     #[test]
     fn test_classify_sudo_stripped() {
         assert_eq!(

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -425,6 +425,22 @@ pub const RULES: &[RtkRule] = &[
         subcmd_savings: &[],
         subcmd_status: &[],
     },
+    // #1654: ssh has a TOML filter (`src/filters/ssh.toml`) that passes
+    // `rtk verify --filter ssh` but the hook rewrite path never reached it
+    // because the registry didn't list a matching rule. Adding the rule lets
+    // `ssh user@host cmd` flow through `rtk rewrite` → `rtk ssh user@host cmd`
+    // → main.rs's TOML-filter dispatch. Interactive `ssh host` (no remote
+    // command, banners only) is intentionally not rewritten — `\s+` requires
+    // at least one argument, mirroring wget/curl above.
+    RtkRule {
+        pattern: r"^ssh\s+",
+        rtk_cmd: "rtk ssh",
+        rewrite_prefixes: &["ssh"],
+        category: "Network",
+        savings_pct: 65.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
     RtkRule {
         pattern: r"^(python3?\s+-m\s+)?mypy(\s|$)",
         rtk_cmd: "rtk mypy",


### PR DESCRIPTION
## Summary

\`rtk verify --filter ssh\` reports 3/3 passing because the TOML filter at \`src/filters/ssh.toml\` is valid, but \`rtk rewrite "ssh …"\` exits 1 for every shape — the Claude Code hook's rewrite path therefore never produces \`rtk ssh …\` and the ssh filter is effectively dark in production, even though verify passes.

Reporter (#1654) saw ssh as the #1 unhandled command in 30 days of \`rtk discover\`, with ~50K–100K tokens/month of savings missed on a single user.

## Root cause

\`registry::rewrite_command\` → \`rewrite_segment_inner\` looks the base command up in \`RULES\` (\`src/discover/rules.rs\`). \`RULES\` is the source of truth for the hook rewrite path, but it did not list ssh. \`rtk verify\` consults the TOML filter registry; \`rtk rewrite\` consults the hard-coded RULES table — so a TOML-only filter with no RULES entry passes verify yet is invisible to the hook.

This split is the same shape as the historical \`ps\` / \`ansible-playbook\` setup that the reporter mentions still working — those have RULES entries; ssh did not.

## Fix

Add one \`RtkRule\` for ssh next to curl/wget (same \`Network\` category, same \`^cmd\\s+\` pattern shape). Once \`rtk rewrite\` produces \`rtk ssh …\`, main.rs's TOML-filter dispatch picks up \`src/filters/ssh.toml\` unchanged — no other code paths needed.

\`\`\`rust
RtkRule {
    pattern: r"^ssh\\s+",
    rtk_cmd: "rtk ssh",
    rewrite_prefixes: &["ssh"],
    category: "Network",
    savings_pct: 65.0,
    ...
}
\`\`\`

## Behaviour

| Input | After |
|---|---|
| \`ssh user@host uptime\` | \`rtk ssh user@host uptime\` (Allow + filter) |
| \`ssh -o ConnectTimeout=5 host echo OK\` | \`rtk ssh -o ConnectTimeout=5 host echo OK\` |
| \`ssh host\` (login only) | \`rtk ssh host\` (banners still filtered by \`strip_lines_matching\`) |
| bare \`ssh\` (no args) | unchanged (\`\\s+\` guard, nothing to filter) |

\`GIT_SSH_COMMAND="ssh -o …" git push\` continues to env-strip → \`rtk git push\` exactly as today; covered by existing \`test_classify_env_prefix_stripped\`.

## Test plan

- [x] \`test_classify_ssh_with_remote_command\` — Supported / Network classification, locks the rule-order invariant.
- [x] \`test_rewrite_ssh_shapes\` — three reproduction shapes from the issue verbatim.
- [x] \`test_rewrite_ssh_with_host_only\` — the no-remote-command shape from the repro.
- [x] \`test_rewrite_bare_ssh_not_rewritten\` — guards the \`\\s+\` boundary so a future loosened pattern doesn't start rewriting argv-less \`ssh\`.
- [x] \`cargo fmt --all\` clean.
- [x] \`cargo clippy --all-targets\` zero warnings.
- [x] \`cargo test --bin rtk -- --test-threads=8\` → **1913 passed** (was 1909).

## Notes

- \`src/filters/ssh.toml\` itself is unchanged; this PR only fills the RULES gap that kept the hook from ever reaching it.
- Token savings for an ssh command depend heavily on remote output, but \`ssh.toml\` strips connection banners + caps at \`max_lines = 200\`; \`savings_pct: 65\` follows wget's neighbour entry as a conservative estimate.
- \`rtk verify --filter ssh\` continues to pass (filter logic untouched).

Fixes #1654