### PR TITLE
feat(discover): rewrite bunx prisma → rtk prisma

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -2851,6 +2851,7 @@ mod tests {
             "npx prisma",
             "pnpm prisma",
             "pnpx prisma",
+            "bunx prisma",
             "prisma",
         ];
         for command in commands {
@@ -2885,6 +2886,7 @@ mod tests {
             "npx prisma",
             "pnpm prisma",
             "pnpx prisma",
+            "bunx prisma",
             "prisma",
         ];
         for command in commands {
@@ -2893,6 +2895,34 @@ mod tests {
                 Some("rtk prisma migrate dev".into()),
                 "Failed for command: {}",
                 command
+            );
+        }
+    }
+
+    #[test]
+    fn test_rewrite_bunx_prisma_subcommands() {
+        // #1401: exercise the full Prisma surface that the reporter said hits
+        // unfiltered with bun. The classify_command/rewrite tests above already
+        // cover `migrate dev` for every runner; this nails down each subcommand
+        // shape verbatim so a future regex tweak doesn't silently drop one.
+        let cases = [
+            ("bunx prisma migrate dev", "rtk prisma migrate dev"),
+            (
+                "bunx prisma migrate dev --name add_col",
+                "rtk prisma migrate dev --name add_col",
+            ),
+            ("bunx prisma migrate deploy", "rtk prisma migrate deploy"),
+            ("bunx prisma migrate status", "rtk prisma migrate status"),
+            ("bunx prisma generate", "rtk prisma generate"),
+            ("bunx prisma db seed", "rtk prisma db seed"),
+            ("bunx prisma studio", "rtk prisma studio"),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(
+                rewrite_command_no_prefixes(input, &[]),
+                Some(expected.into()),
+                "Failed for input: {}",
+                input
             );
         }
     }

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -346,10 +346,15 @@ pub const RULES: &[RtkRule] = &[
         subcmd_savings: &[],
         subcmd_status: &[],
     },
+    // #1401: Bun is now the primary JS runtime on a growing share of Prisma
+    // projects. `bunx prisma <sub>` is semantically equivalent to
+    // `npx prisma <sub>` (same CLI, same output format), so it routes through
+    // the same `rtk prisma` filter — no new output-handling logic required.
     RtkRule {
-        pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?prisma",
+        pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx|bunx)\s+)?prisma",
         rtk_cmd: "rtk prisma",
         rewrite_prefixes: &[
+            "bunx prisma",
             "npm exec prisma",
             "npm prisma",
             "npm rum prisma",


### PR DESCRIPTION
## Summary

Bun is the primary JS runtime on a growing share of Prisma projects. \`bunx prisma <sub>\` is semantically equivalent to \`npx prisma <sub>\` — same CLI, same output format, same subcommands — but the hook didn't recognise it, so the reporter's 45 monthly \`bunx prisma\` invocations (#1401) were flowing through the Bash hook completely unfiltered.

## Fix

One \`RtkRule\` change in \`src/discover/rules.rs\`:

\`\`\`diff
-    pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?prisma",
+    pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx|bunx)\s+)?prisma",
     rtk_cmd: "rtk prisma",
     rewrite_prefixes: &[
+        "bunx prisma",
         "npm exec prisma",
         …
     ],
\`\`\`

No new output-filtering logic — the entire Bun-Prisma stack goes through the same \`src/cmds/js/prisma_cmd.rs\` handler as npx/pnpm/npm; only the rewrite recognition was missing.

## Behaviour

| Input | After |
|---|---|
| \`bunx prisma migrate dev\` | \`rtk prisma migrate dev\` |
| \`bunx prisma migrate dev --name add_col\` | \`rtk prisma migrate dev --name add_col\` |
| \`bunx prisma migrate deploy\` | \`rtk prisma migrate deploy\` |
| \`bunx prisma migrate status\` | \`rtk prisma migrate status\` |
| \`bunx prisma generate\` | \`rtk prisma generate\` |
| \`bunx prisma db seed\` | \`rtk prisma db seed\` |
| \`bunx prisma studio\` | \`rtk prisma studio\` |

\`npx prisma\` / \`pnpm prisma\` / \`pnpm dlx prisma\` continue to work exactly as before — same rule, just one more alternation branch.

## Scope notes

- This PR is intentionally narrow: it only adds \`bunx\` to the **existing** Prisma rule. Other \`bun\` runner forms (\`bun x\`, \`bun run\`, bare \`bun prisma\`) are *not* covered here; if usage data shows they matter we can extend the alternation in a follow-up.
- Other RTK-handled binaries that ship as \`bunx <tool>\` (vitest, playwright, tsc, prettier, biome, jest, eslint…) are out of scope. The reporter only flagged Prisma — happy to do a sweep in a separate PR if maintainers want broad bun adoption.

## Test plan

- [x] \`test_classify_prisma\` and \`test_rewrite_prisma\` extended with \`bunx prisma\` (locks the invariant fence per runner).
- [x] New \`test_rewrite_bunx_prisma_subcommands\` covers the six subcommand shapes the reporter named.
- [x] \`cargo fmt --all\` clean.
- [x] \`cargo clippy --all-targets\` zero warnings.
- [x] \`cargo test --bin rtk -- --test-threads=8\` → **1910 passed**.

Fixes #1401