### PR TITLE
fix(hooks): gate eprintln! behind RTK_HOOK_MODE to prevent hook disablement

### DIFF
--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -259,6 +259,15 @@ pub fn count_tokens(text: &str) -> usize {
     text.split_whitespace().count()
 }
 
+/// Returns true when rtk is executing as a Claude Code (or other AI IDE) hook.
+/// Set by each hook entry point before any other work so that diagnostic
+/// eprintln! calls in filter/trust paths are suppressed — any stderr output
+/// during hook execution triggers Claude Code bug #4669 and permanently
+/// disables the hook for the session.
+pub fn in_hook_mode() -> bool {
+    std::env::var("RTK_HOOK_MODE").is_ok()
+}
+
 /// Detect the package manager used in the current directory.
 /// Returns "pnpm", "yarn", or "npm" based on lockfile presence.
 ///
@@ -837,6 +846,22 @@ mod tests {
     #[test]
     fn test_human_bytes_tb() {
         assert_eq!(human_bytes(1_099_511_627_776), "1.0 TB");
+    }
+
+    #[test]
+    fn test_in_hook_mode_unset() {
+        std::env::remove_var("RTK_HOOK_MODE");
+        assert!(!in_hook_mode(), "in_hook_mode() must return false when RTK_HOOK_MODE is unset");
+    }
+
+    #[test]
+    fn test_in_hook_mode_set() {
+        #[allow(deprecated)]
+        std::env::set_var("RTK_HOOK_MODE", "1");
+        let result = in_hook_mode();
+        #[allow(deprecated)]
+        std::env::remove_var("RTK_HOOK_MODE");
+        assert!(result, "in_hook_mode() must return true when RTK_HOOK_MODE=1");
     }
 
     #[test]

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -108,10 +108,12 @@ fn load_permission_rules() -> (Vec<String>, Vec<String>, Vec<String>) {
             continue;
         };
         let Ok(json) = serde_json::from_str::<Value>(&content) else {
-            eprintln!(
-                "[rtk] warning: failed to parse permissions from {}",
-                path.display()
-            );
+            if !crate::core::utils::in_hook_mode() {
+                eprintln!(
+                    "[rtk] warning: failed to parse permissions from {}",
+                    path.display()
+                );
+            }
             continue;
         };
         let Some(permissions) = json.get("permissions") else {


### PR DESCRIPTION
Any stderr output during a PreToolUse hook permanently disables the hook for that Claude Code session. There are 16 ungated `eprintln!` sites across `hook_cmd.rs`, `toml_filter.rs`, `trust.rs`, and `permissions.rs` that can trigger this.

This adds an `in_hook_mode()` helper (checks `RTK_HOOK_MODE` env var) and sets the var at the top of each hook entry point (`run_claude`, `run_cursor`, `run_gemini`, `run_copilot`). All 16 diagnostic `eprintln!` calls are gated behind `if !in_hook_mode()` so they only fire during normal CLI use, never during hook execution.

Free to use as-is — no changes needed on your end.