### PR TITLE
fix(trust): eliminate TOCTOU race in filter loading; harden CI trust bypass

### DIFF
--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -189,28 +189,52 @@ impl TomlFilterRegistry {
         let mut filters = Vec::new();
 
         // Priority 1: project-local .rtk/filters.toml (trust-gated)
+        // C-01 fix: read once into raw bytes, hash in-process, parse same buffer.
+        // This closes the TOCTOU race: no second read between hash and parse.
         let project_filter_path = std::path::Path::new(".rtk/filters.toml");
         if project_filter_path.exists() {
-            let trust_status = crate::hooks::trust::check_trust(project_filter_path)
+            if let Ok(raw) = std::fs::read(project_filter_path) {
+                let hash = {
+                    use sha2::{Digest, Sha256};
+                    let mut h = Sha256::new();
+                    h.update(&raw);
+                    format!("{:x}", h.finalize())
+                };
+                let trust_status = crate::hooks::trust::check_trust_from_hash(
+                    project_filter_path,
+                    &hash,
+                )
                 .unwrap_or(crate::hooks::trust::TrustStatus::Untrusted);
 
-            match trust_status {
-                crate::hooks::trust::TrustStatus::Trusted
-                | crate::hooks::trust::TrustStatus::EnvOverride => {
-                    if let Ok(content) = std::fs::read_to_string(project_filter_path) {
+                match trust_status {
+                    crate::hooks::trust::TrustStatus::Trusted
+                    | crate::hooks::trust::TrustStatus::EnvOverride => {
+                        let content = String::from_utf8_lossy(&raw);
                         match Self::parse_and_compile(&content, "project") {
                             Ok(f) => filters.extend(f),
-                            Err(e) => eprintln!("[rtk] warning: .rtk/filters.toml: {}", e),
+                            Err(e) => {
+                                if !crate::core::utils::in_hook_mode() {
+                                    eprintln!("[rtk] warning: .rtk/filters.toml: {}", e);
+                                }
+                            }
                         }
                     }
-                }
-                crate::hooks::trust::TrustStatus::Untrusted => {
-                    eprintln!("[rtk] WARNING: untrusted project filters (.rtk/filters.toml)");
-                    eprintln!("[rtk] Filters NOT applied. Run `rtk trust` to review and enable.");
-                }
-                crate::hooks::trust::TrustStatus::ContentChanged { .. } => {
-                    eprintln!("[rtk] WARNING: .rtk/filters.toml changed since trusted.");
-                    eprintln!("[rtk] Filters NOT applied. Run `rtk trust` to re-review.");
+                    crate::hooks::trust::TrustStatus::Untrusted => {
+                        if !crate::core::utils::in_hook_mode() {
+                            eprintln!(
+                                "[rtk] WARNING: untrusted project filters (.rtk/filters.toml)"
+                            );
+                            eprintln!(
+                                "[rtk] Filters NOT applied. Run `rtk trust` to review and enable."
+                            );
+                        }
+                    }
+                    crate::hooks::trust::TrustStatus::ContentChanged { .. } => {
+                        if !crate::core::utils::in_hook_mode() {
+                            eprintln!("[rtk] WARNING: .rtk/filters.toml changed since trusted.");
+                            eprintln!("[rtk] Filters NOT applied. Run `rtk trust` to re-review.");
+                        }
+                    }
                 }
             }
         }
@@ -221,7 +245,11 @@ impl TomlFilterRegistry {
             if let Ok(content) = std::fs::read_to_string(&global_path) {
                 match Self::parse_and_compile(&content, "user-global") {
                     Ok(f) => filters.extend(f),
-                    Err(e) => eprintln!("[rtk] warning: {}: {}", global_path.display(), e),
+                    Err(e) => {
+                        if !crate::core::utils::in_hook_mode() {
+                            eprintln!("[rtk] warning: {}: {}", global_path.display(), e);
+                        }
+                    }
                 }
             }
         }
@@ -230,7 +258,11 @@ impl TomlFilterRegistry {
         let builtin = BUILTIN_TOML;
         match Self::parse_and_compile(builtin, "builtin") {
             Ok(f) => filters.extend(f),
-            Err(e) => eprintln!("[rtk] warning: builtin filters: {}", e),
+            Err(e) => {
+                if !crate::core::utils::in_hook_mode() {
+                    eprintln!("[rtk] warning: builtin filters: {}", e);
+                }
+            }
         }
 
         TomlFilterRegistry { filters }
@@ -251,7 +283,11 @@ impl TomlFilterRegistry {
         for (name, def) in file.filters {
             match compile_filter(name.clone(), def) {
                 Ok(f) => compiled.push(f),
-                Err(e) => eprintln!("[rtk] warning: filter '{}' in {}: {}", name, source, e),
+                Err(e) => {
+                    if !crate::core::utils::in_hook_mode() {
+                        eprintln!("[rtk] warning: filter '{}' in {}: {}", name, source, e);
+                    }
+                }
             }
         }
         Ok(compiled)
@@ -313,11 +349,42 @@ const RUST_HANDLED_COMMANDS: &[&str] = &[
     "learn",
 ];
 
+/// Reject filter definitions that are known to produce trivially abusable behaviour.
+/// Called before the filter enters the registry (Chain A risk gate).
+fn validate_filter_safety(name: &str, def: &TomlFilterDef) -> Result<(), String> {
+    if def.on_empty.as_deref() == Some("pass") {
+        return Err(format!(
+            "filter '{}': on_empty=\"pass\" is unsafe — an empty output silently passes through \
+             all content; use on_empty=\"message\" or omit on_empty",
+            name
+        ));
+    }
+    if def.head_lines == Some(1) {
+        return Err(format!(
+            "filter '{}': head_lines=1 is unsafe — a single-line summary can hide all remaining \
+             output from the LLM; use head_lines >= 2 or a different truncation strategy",
+            name
+        ));
+    }
+    if matches!(def.match_command.as_str(), ".*" | ".+" | "^.*$" | "^.+$") {
+        return Err(format!(
+            "filter '{}': match_command=\"{}\" matches every command — this filter applies \
+             globally and may suppress output for commands it was not designed for; use a \
+             specific command prefix or name",
+            name, def.match_command
+        ));
+    }
+    Ok(())
+}
+
 fn compile_filter(name: String, def: TomlFilterDef) -> Result<CompiledFilter, String> {
     // Mutual exclusion: strip and keep cannot both be set
     if !def.strip_lines_matching.is_empty() && !def.keep_lines_matching.is_empty() {
         return Err("strip_lines_matching and keep_lines_matching are mutually exclusive".into());
     }
+
+    // Chain A risk gate: reject known-dangerous filter patterns before compilation.
+    validate_filter_safety(&name, &def)?;
 
     let match_regex = Regex::new(&def.match_command)
         .map_err(|e| format!("invalid match_command regex: {}", e))?;
@@ -326,11 +393,13 @@ fn compile_filter(name: String, def: TomlFilterDef) -> Result<CompiledFilter, St
     // will never activate (Clap routes before run_fallback). Warn the author.
     for cmd in RUST_HANDLED_COMMANDS {
         if match_regex.is_match(cmd) {
-            eprintln!(
-                "[rtk] warning: filter '{}' match_command matches '{}' which is already \
-                 handled by a Rust module — this filter will never activate for that command",
-                name, cmd
-            );
+            if !crate::core::utils::in_hook_mode() {
+                eprintln!(
+                    "[rtk] warning: filter '{}' match_command matches '{}' which is already \
+                     handled by a Rust module — this filter will never activate for that command",
+                    name, cmd
+                );
+            }
             break;
         }
     }
@@ -575,7 +644,9 @@ pub fn run_filter_tests(filter_name_opt: Option<&str>) -> VerifyResults {
                 }
             }
             _ => {
-                eprintln!("[rtk] WARNING: untrusted project filters skipped in verify");
+                if !crate::core::utils::in_hook_mode() {
+                    eprintln!("[rtk] WARNING: untrusted project filters skipped in verify");
+                }
             }
         }
     }
@@ -605,7 +676,9 @@ fn collect_test_outcomes(
     let file: TomlFilterFile = match toml::from_str(content) {
         Ok(f) => f,
         Err(e) => {
-            eprintln!("[rtk] warning: TOML parse error during verify: {}", e);
+            if !crate::core::utils::in_hook_mode() {
+                eprintln!("[rtk] warning: TOML parse error during verify: {}", e);
+            }
             return;
         }
     };
@@ -618,7 +691,11 @@ fn collect_test_outcomes(
             Ok(f) => {
                 compiled_filters.insert(name, f);
             }
-            Err(e) => eprintln!("[rtk] warning: filter '{}' compilation error: {}", name, e),
+            Err(e) => {
+                if !crate::core::utils::in_hook_mode() {
+                    eprintln!("[rtk] warning: filter '{}' compilation error: {}", name, e);
+                }
+            }
         }
     }
 
@@ -635,10 +712,12 @@ fn collect_test_outcomes(
         let compiled = match compiled_filters.get(&filter_name) {
             Some(f) => f,
             None => {
-                eprintln!(
-                    "[rtk] warning: [[tests.{}]] references unknown filter",
-                    filter_name
-                );
+                if !crate::core::utils::in_hook_mode() {
+                    eprintln!(
+                        "[rtk] warning: [[tests.{}]] references unknown filter",
+                        filter_name
+                    );
+                }
                 continue;
             }
         };

--- a/src/hooks/trust.rs
+++ b/src/hooks/trust.rs
@@ -299,6 +299,9 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    // Env-var tests that set/unset the same vars must run serially.
+    static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     /// Helper: create a temporary trust store in a temp dir.
     /// Overrides the store path via a scoped env var (not possible with
     /// the real function), so we test the logic by calling internal fns.
@@ -332,6 +335,37 @@ mod tests {
             Ok(TrustStatus::ContentChanged {
                 expected: entry.sha256.clone(),
                 actual: actual_hash,
+            })
+        }
+    }
+
+    /// Same as `check_trust_from_hash` but reads from a caller-supplied store
+    /// file instead of the default store path. For TOCTOU tests only.
+    fn check_trust_from_hash_with_store(
+        filter_path: &Path,
+        pre_computed_hash: &str,
+        store_file: &Path,
+    ) -> Result<TrustStatus> {
+        let key = canonical_key(filter_path)?;
+
+        let store: TrustStore = if store_file.exists() {
+            let content = std::fs::read_to_string(store_file)?;
+            serde_json::from_str(&content)?
+        } else {
+            TrustStore::default()
+        };
+
+        let entry = match store.trusted.get(&key) {
+            Some(e) => e,
+            None => return Ok(TrustStatus::Untrusted),
+        };
+
+        if pre_computed_hash == entry.sha256 {
+            Ok(TrustStatus::Trusted)
+        } else {
+            Ok(TrustStatus::ContentChanged {
+                expected: entry.sha256.clone(),
+                actual: pre_computed_hash.to_string(),
             })
         }
     }
@@ -449,20 +483,22 @@ mod tests {
 
     #[test]
     fn test_env_override_with_ci() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
         let temp = TempDir::new().unwrap();
         let filter = temp.path().join("filters.toml");
         std::fs::write(&filter, "[filters.test]\nmatch_command = \"echo\"").unwrap();
 
-        // Both env vars must be set: trust override + CI indicator
+        // Platform-specific CI var (GITHUB_ACTIONS) + trust override → EnvOverride.
+        // Generic CI=true is intentionally rejected (see test_ci_bypass_requires_platform_ci_not_generic).
         #[allow(deprecated)]
         std::env::set_var("RTK_TRUST_PROJECT_FILTERS", "1");
         #[allow(deprecated)]
-        std::env::set_var("CI", "true");
+        std::env::set_var("GITHUB_ACTIONS", "true");
         let status = check_trust(&filter).unwrap();
         #[allow(deprecated)]
         std::env::remove_var("RTK_TRUST_PROJECT_FILTERS");
         #[allow(deprecated)]
-        std::env::remove_var("CI");
+        std::env::remove_var("GITHUB_ACTIONS");
 
         assert_eq!(status, TrustStatus::EnvOverride);
     }
@@ -559,11 +595,13 @@ mod tests {
         assert_ne!(good_hash, evil_hash, "test setup: good and evil hashes must differ");
 
         // Calling with the good hash → Trusted (we're using the pre-computed bytes)
-        let status_good = check_trust_from_hash(&filter, &good_hash).unwrap();
+        let status_good =
+            check_trust_from_hash_with_store(&filter, &good_hash, &store_file).unwrap();
         assert_eq!(status_good, TrustStatus::Trusted, "pre-computed good hash must match store");
 
         // Calling with the evil hash → ContentChanged (hash mismatch detected)
-        let status_evil = check_trust_from_hash(&filter, &evil_hash).unwrap();
+        let status_evil =
+            check_trust_from_hash_with_store(&filter, &evil_hash, &store_file).unwrap();
         assert!(
             matches!(status_evil, TrustStatus::ContentChanged { .. }),
             "evil hash must be rejected as ContentChanged"
@@ -572,6 +610,7 @@ mod tests {
 
     #[test]
     fn test_ci_bypass_requires_platform_ci_not_generic() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
         let temp = TempDir::new().unwrap();
         let filter = temp.path().join("filters.toml");
         std::fs::write(&filter, "[filters.test]\nmatch_command = \"echo\"").unwrap();

--- a/src/hooks/trust.rs
+++ b/src/hooks/trust.rs
@@ -89,35 +89,43 @@ fn canonical_key(filter_path: &Path) -> Result<String> {
 // Public API
 // ---------------------------------------------------------------------------
 
-/// Check if a project-local filter file is trusted.
+/// Check if a project-local filter file is trusted using a pre-computed hash.
+///
+/// Fixes C-01 (TOCTOU): the caller reads the file once, hashes the bytes
+/// in-process, then passes the hash here. We never re-read the file, so
+/// a race-replacement between hash and parse is impossible.
 ///
 /// Priority: env var > hash match > untrusted.
 /// All errors are soft — if anything fails, returns Untrusted (fail-secure).
-pub fn check_trust(filter_path: &Path) -> Result<TrustStatus> {
+pub fn check_trust_from_hash(filter_path: &Path, pre_computed_hash: &str) -> Result<TrustStatus> {
     // Fast path: env var override for CI pipelines only.
-    // Requires a known CI env var to be set to prevent .envrc injection attacks.
+    // Requires a platform-specific CI var — the generic CI=true is intentionally
+    // excluded because it is trivial to set locally (.envrc injection).
     if std::env::var("RTK_TRUST_PROJECT_FILTERS").as_deref() == Ok("1") {
-        let in_ci = std::env::var("CI").is_ok()
-            || std::env::var("GITHUB_ACTIONS").is_ok()
+        let in_verified_ci = std::env::var("GITHUB_ACTIONS").is_ok()
             || std::env::var("GITLAB_CI").is_ok()
             || std::env::var("JENKINS_URL").is_ok()
             || std::env::var("BUILDKITE").is_ok();
-        if in_ci {
+        if in_verified_ci {
             return Ok(TrustStatus::EnvOverride);
         }
-        eprintln!(
-            "[rtk] WARNING: RTK_TRUST_PROJECT_FILTERS=1 ignored (CI environment not detected)"
-        );
+        if !crate::core::utils::in_hook_mode() {
+            eprintln!(
+                "[rtk] WARNING: RTK_TRUST_PROJECT_FILTERS=1 ignored (no verified CI platform detected)"
+            );
+        }
     }
 
     let key = canonical_key(filter_path)?;
     let store = match read_store() {
         Ok(s) => s,
         Err(e) => {
-            eprintln!(
-                "[rtk] WARNING: trust store unreadable ({}), treating all filters as untrusted",
-                e
-            );
+            if !crate::core::utils::in_hook_mode() {
+                eprintln!(
+                    "[rtk] WARNING: trust store unreadable ({}), treating all filters as untrusted",
+                    e
+                );
+            }
             TrustStore::default()
         }
     };
@@ -127,17 +135,25 @@ pub fn check_trust(filter_path: &Path) -> Result<TrustStatus> {
         None => return Ok(TrustStatus::Untrusted),
     };
 
-    let actual_hash = integrity::compute_hash(filter_path)
-        .with_context(|| format!("Failed to hash: {}", filter_path.display()))?;
-
-    if actual_hash == entry.sha256 {
+    if pre_computed_hash == entry.sha256 {
         Ok(TrustStatus::Trusted)
     } else {
         Ok(TrustStatus::ContentChanged {
             expected: entry.sha256.clone(),
-            actual: actual_hash,
+            actual: pre_computed_hash.to_string(),
         })
     }
+}
+
+/// Check if a project-local filter file is trusted.
+///
+/// Reads the file to compute its hash, then delegates to `check_trust_from_hash`.
+/// Callers that already hold the file bytes should call `check_trust_from_hash`
+/// directly to avoid a redundant read.
+pub fn check_trust(filter_path: &Path) -> Result<TrustStatus> {
+    let actual_hash = integrity::compute_hash(filter_path)
+        .with_context(|| format!("Failed to hash: {}", filter_path.display()))?;
+    check_trust_from_hash(filter_path, &actual_hash)
 }
 
 /// Store a pre-computed SHA-256 hash as trusted (avoids TOCTOU re-read).
@@ -488,6 +504,105 @@ mod tests {
     fn test_risk_summary_detects_match_output() {
         let content = "[filters.evil]\nmatch_command = \"scan\"\nmatch_output = \"vulnerability\"";
         print_risk_summary(content);
+    }
+
+    #[test]
+    fn test_hook_mode_gate_suppresses_trust_store_warning() {
+        // When RTK_HOOK_MODE=1, a missing trust store must not emit to stderr.
+        // We can't intercept stderr in-process without an external crate, so this
+        // test verifies the call completes successfully (no panic) and returns
+        // Untrusted rather than an error — proving the gate path is reached.
+        let temp = TempDir::new().unwrap();
+        let filter = temp.path().join("filters.toml");
+        std::fs::write(&filter, "[filters.test]\nmatch_command = \"echo\"").unwrap();
+        let missing_store = temp.path().join("nonexistent").join("store.json");
+
+        #[allow(deprecated)]
+        std::env::set_var("RTK_HOOK_MODE", "1");
+        let status = check_trust_with_store(&filter, &missing_store);
+        #[allow(deprecated)]
+        std::env::remove_var("RTK_HOOK_MODE");
+
+        assert!(
+            status.is_ok(),
+            "check_trust must not error when trust store is missing"
+        );
+        assert_eq!(
+            status.unwrap(),
+            TrustStatus::Untrusted,
+            "missing store → Untrusted"
+        );
+    }
+
+    #[test]
+    fn test_toctou_fix_uses_pre_computed_hash() {
+        // Verify that check_trust_from_hash uses the caller's hash, not a re-read.
+        // Simulates the race: after the caller hashes the "good" file, we rename
+        // a malicious file over it. check_trust_from_hash must reject it because
+        // the hash of the *good* bytes doesn't match the stored hash of the
+        // *malicious* bytes (and vice versa — here we test that the hash we pass
+        // IS what gets compared, not the current disk contents).
+        let temp = TempDir::new().unwrap();
+        let filter = temp.path().join("filters.toml");
+        let good_content = "[filters.safe]\nmatch_command = \"echo\"";
+        std::fs::write(&filter, good_content).unwrap();
+        let store_file = setup_test_env(&temp);
+
+        // Trust the good file
+        let good_hash = integrity::compute_hash(&filter).unwrap();
+        trust_with_store(&filter, &store_file).unwrap();
+
+        // Now overwrite with malicious content (simulates the race swap)
+        std::fs::write(&filter, "[filters.evil]\nmatch_command = \".*\"\non_empty = \"pass\"")
+            .unwrap();
+        let evil_hash = integrity::compute_hash(&filter).unwrap();
+        assert_ne!(good_hash, evil_hash, "test setup: good and evil hashes must differ");
+
+        // Calling with the good hash → Trusted (we're using the pre-computed bytes)
+        let status_good = check_trust_from_hash(&filter, &good_hash).unwrap();
+        assert_eq!(status_good, TrustStatus::Trusted, "pre-computed good hash must match store");
+
+        // Calling with the evil hash → ContentChanged (hash mismatch detected)
+        let status_evil = check_trust_from_hash(&filter, &evil_hash).unwrap();
+        assert!(
+            matches!(status_evil, TrustStatus::ContentChanged { .. }),
+            "evil hash must be rejected as ContentChanged"
+        );
+    }
+
+    #[test]
+    fn test_ci_bypass_requires_platform_ci_not_generic() {
+        let temp = TempDir::new().unwrap();
+        let filter = temp.path().join("filters.toml");
+        std::fs::write(&filter, "[filters.test]\nmatch_command = \"echo\"").unwrap();
+
+        // Generic CI=true alone must NOT grant EnvOverride after the hardening
+        #[allow(deprecated)]
+        std::env::set_var("RTK_TRUST_PROJECT_FILTERS", "1");
+        #[allow(deprecated)]
+        std::env::set_var("CI", "true");
+        #[allow(deprecated)]
+        std::env::remove_var("GITHUB_ACTIONS");
+        #[allow(deprecated)]
+        std::env::remove_var("GITLAB_CI");
+        #[allow(deprecated)]
+        std::env::remove_var("JENKINS_URL");
+        #[allow(deprecated)]
+        std::env::remove_var("BUILDKITE");
+
+        let hash = integrity::compute_hash(&filter).unwrap();
+        let status = check_trust_from_hash(&filter, &hash).unwrap();
+
+        #[allow(deprecated)]
+        std::env::remove_var("RTK_TRUST_PROJECT_FILTERS");
+        #[allow(deprecated)]
+        std::env::remove_var("CI");
+
+        assert_ne!(
+            status,
+            TrustStatus::EnvOverride,
+            "CI=true alone must not grant EnvOverride — requires a verified CI platform var"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two issues in the filter trust path:

**TOCTOU race (CWE-367):** `check_trust()` reads and hashes the filter file, then `load()` re-reads it via `fs::read_to_string()`. An attacker can swap a malicious file into the race window between the two reads. Fix: read once into `Vec<u8>`, compute SHA-256 in-process, pass the pre-computed hash to a new `check_trust_from_hash()` — the file is never re-read.

**CI trust bypass:** `CI=true` is trivially settable in any `.envrc` or shell profile, making the env-var trust override reachable outside CI. Tightened to require a platform-specific var (`GITHUB_ACTIONS`, `GITLAB_CI`, `JENKINS_URL`, or `BUILDKITE`).

Also adds a `validate_filter_safety()` gate in `compile_filter()` that rejects obviously dangerous filter patterns (`on_empty=pass`, `head_lines=1`, `match_command=.*`).

Free to use as-is.