### PR TITLE
Add Trae.ai agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ rtk init -g --agent cursor      # Cursor
 rtk init --agent windsurf       # Windsurf
 rtk init --agent cline          # Cline / Roo Code
 rtk init --agent kilocode       # Kilo Code
+rtk init --agent trae           # Trae.ai
 rtk init --agent antigravity    # Google Antigravity
 rtk init --agent hermes         # Hermes
 
@@ -351,7 +352,7 @@ rtk git status
 
 ## Supported AI Tools
 
-RTK supports 13 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents for 60-90% token savings where the agent supports command interception.
+RTK supports 14 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents for 60-90% token savings where the agent supports command interception.
 
 | Tool | Install | Method |
 |------|---------|--------|
@@ -368,6 +369,7 @@ RTK supports 13 AI coding tools. Each integration rewrites shell commands to `rt
 | **Hermes** | `rtk init --agent hermes` | Python plugin adapter (terminal command mutation via `rtk rewrite`) |
 | **Mistral Vibe** | Planned ([#800](https://github.com/rtk-ai/rtk/issues/800)) | Blocked on upstream |
 | **Kilo Code** | `rtk init --agent kilocode` | .kilocode/rules/rtk-rules.md (project-scoped) |
+| **Trae.ai** | `rtk init --agent trae` | .trae/rules/rtk-rules.md (project-scoped) |
 | **Google Antigravity** | `rtk init --agent antigravity` | .agents/rules/antigravity-rtk-rules.md (project-scoped) |
 
 For per-agent setup details, override controls, and graceful degradation, see the [Supported Agents guide](https://www.rtk-ai.app/guide/getting-started/supported-agents). The Hermes plugin source and tests live in `hooks/hermes/`; installed Hermes runtime files still live under `~/.hermes/plugins/rtk-rewrite/`.

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -153,6 +153,14 @@ rtk init --agent kilocode    # creates .kilocode/rules/rtk-rules.md in current p
 
 Kilo Code reads `.kilocode/rules/` as custom instructions. RTK adds guidance telling Kilo Code to prefer `rtk <cmd>` over raw commands.
 
+### Trae.ai
+
+```bash
+rtk init --agent trae    # creates .trae/rules/rtk-rules.md in current project
+```
+
+Trae.ai reads `.trae/rules/` as project-scoped rules. RTK adds guidance telling Trae.ai to prefer `rtk <cmd>` over raw commands.
+
 ### Google Antigravity
 
 ```bash
@@ -173,7 +181,7 @@ Support is blocked on upstream `BeforeToolCallback` ([mistral-vibe#531](https://
 | **Plugin** | TypeScript, JavaScript, or Python in agent's plugin system | Transparent, in-place mutation when the agent allows it |
 | **Rules file** | Prompt-level instructions | Guidance only — agent is told to prefer `rtk <cmd>` |
 
-Rules file integrations (Cline, Windsurf, Codex, Kilo Code, Antigravity) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it. Plugin integrations (OpenCode, Pi) use in-place mutation via the agent's TypeScript extension API.
+Rules file integrations (Cline, Windsurf, Codex, Kilo Code, Trae.ai, Antigravity) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it. Plugin integrations (OpenCode, Pi) use in-place mutation via the agent's TypeScript extension API.
 
 ## Windows support
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -4,7 +4,7 @@
 
 **Deployed hook artifacts** — the actual files installed on user machines by `rtk init`. These are shell scripts, TypeScript plugins, and rules files that run outside the Rust binary. They are **thin delegates**: parse agent-specific JSON, call `rtk rewrite` as a subprocess, format agent-specific response. Zero filtering logic lives here.
 
-Owns: per-agent hook scripts and configuration files for 9 supported agents (Claude Code, Copilot, Cursor, Cline, Windsurf, Codex, OpenCode, Hermes, Pi).
+Owns: per-agent hook scripts and configuration files for supported agents (Claude Code, Copilot, Cursor, Cline, Windsurf, Codex, OpenCode, Hermes, Pi, Kilo Code, Trae.ai, Antigravity).
 
 Does **not** own: hook installation/uninstallation (that's `src/hooks/init.rs`), the rewrite pattern registry (that's `discover/registry`), or integrity verification (that's `src/hooks/integrity.rs`).
 
@@ -42,6 +42,9 @@ Each agent subdirectory has its own README with hook-specific details:
 - **[`opencode/`](opencode/README.md)** — TypeScript plugin, `zx` library, `tool.execute.before` event, in-place mutation
 - **[`pi/`](pi/README.md)** — TypeScript extension, `tool_call` event, `isToolCallEventType` guard, in-place mutation, `~/.pi/agent/extensions/`
 - **[`hermes/`](hermes/README.md)** — Python plugin, `pre_tool_call` hook, in-place terminal command mutation
+- **[`kilocode/`](kilocode/README.md)** — Rules file (prompt-level), `.kilocode/rules/rtk-rules.md` project-local installation
+- **[`trae/`](trae/README.md)** — Rules file (prompt-level), `.trae/rules/rtk-rules.md` project-local installation
+- **[`antigravity/`](antigravity/README.md)** — Rules file (prompt-level), `.agents/rules/antigravity-rtk-rules.md` project-local installation
 
 ## Supported Agents
 
@@ -55,6 +58,9 @@ Each agent subdirectory has its own README with hook-specific details:
 | Cline / Roo Code | Custom instructions (rules file) | Prompt-level guidance | N/A |
 | Windsurf | Custom instructions (rules file) | Prompt-level guidance | N/A |
 | Codex CLI | AGENTS.md / instructions | Prompt-level guidance | N/A |
+| Kilo Code | Custom instructions (rules file) | Prompt-level guidance | N/A |
+| Trae.ai | Custom instructions (rules file) | Prompt-level guidance | N/A |
+| Google Antigravity | Custom instructions (rules file) | Prompt-level guidance | N/A |
 | OpenCode | TypeScript plugin (`tool.execute.before`) | In-place mutation | Yes |
 | Pi | TypeScript extension (`tool_call` event) | In-place mutation | Yes |
 | Hermes | Python plugin (`pre_tool_call`) | In-place mutation | Yes |

--- a/hooks/trae/README.md
+++ b/hooks/trae/README.md
@@ -1,0 +1,9 @@
+# Trae.ai Hooks
+
+> Part of [`hooks/`](../README.md) -- see also [`src/hooks/`](../../src/hooks/README.md) for installation code
+
+## Specifics
+
+- Prompt-level guidance only (no programmatic hook) -- relies on Trae.ai reading project rules
+- `rules.md` contains the instruction to prefix all shell commands with `rtk`, usage examples, and meta commands
+- Installed to `.trae/rules/rtk-rules.md` (project-local) by `rtk init --agent trae`

--- a/hooks/trae/rules.md
+++ b/hooks/trae/rules.md
@@ -1,0 +1,32 @@
+# RTK - Rust Token Killer (Trae.ai)
+
+**Usage**: Token-optimized CLI proxy for shell commands.
+
+## Rule
+
+Always prefix shell commands with `rtk` to minimize token consumption.
+
+Examples:
+
+```bash
+rtk git status
+rtk cargo test
+rtk ls src/
+rtk grep "pattern" src/
+rtk find "*.rs" .
+rtk docker ps
+rtk gh pr list
+```
+
+## Meta Commands
+
+```bash
+rtk gain              # Show token savings
+rtk gain --history    # Command history with savings
+rtk discover          # Find missed RTK opportunities
+rtk proxy <cmd>       # Run raw (no filtering, for debugging)
+```
+
+## Why
+
+RTK filters and compresses command output before it reaches the LLM context, saving 60-90% tokens on common operations. Always use `rtk <cmd>` instead of raw commands.

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -32,6 +32,9 @@ LLM agent integration layer that installs, validates, and executes command-rewri
 | Cursor | `rtk init -g --agent cursor` | Cursor hook | hooks.json |
 | Pi | `rtk init --agent pi` | `.pi/extensions/rtk.ts` | -- |
 | Hermes | `rtk init --agent hermes` | Python plugin in `~/.hermes/plugins/rtk-rewrite/` | `config.yaml` `plugins.enabled` |
+| Kilo Code | `rtk init --agent kilocode` | `.kilocode/rules/rtk-rules.md` | -- |
+| Trae.ai | `rtk init --agent trae` | `.trae/rules/rtk-rules.md` | -- |
+| Google Antigravity | `rtk init --agent antigravity` | `.agents/rules/antigravity-rtk-rules.md` | -- |
 
 
 ## Integrity Verification

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -1688,6 +1688,63 @@ fn run_kilocode_mode_at(base_dir: &Path, ctx: InitContext) -> Result<()> {
     Ok(())
 }
 
+// ─── Trae.ai support ─────────────────────────────────────────
+
+const TRAE_RULES: &str = include_str!("../../hooks/trae/rules.md");
+
+pub fn run_trae_mode(ctx: InitContext) -> Result<()> {
+    run_trae_mode_at(&std::env::current_dir()?, ctx)
+}
+
+fn run_trae_mode_at(base_dir: &Path, ctx: InitContext) -> Result<()> {
+    let InitContext { verbose, dry_run } = ctx;
+    // Trae.ai reads .trae/rules/ from the project root (workspace-scoped)
+    let target_dir = base_dir.join(".trae/rules");
+    let rules_path = target_dir.join("rtk-rules.md");
+
+    let existing = fs::read_to_string(&rules_path).unwrap_or_default();
+    if existing.contains("RTK") || existing.contains("rtk") {
+        if !dry_run {
+            println!("\nRTK already configured for Trae.ai in this project.\n");
+            println!("  Rules: .trae/rules/rtk-rules.md (already present)");
+        }
+    } else {
+        let new_content = if existing.trim().is_empty() {
+            TRAE_RULES.to_string()
+        } else {
+            format!("{}\n\n{}", existing.trim(), TRAE_RULES)
+        };
+        if dry_run {
+            println!(
+                "[dry-run] would write {}: (and create parent dir if missing)",
+                rules_path.display()
+            );
+            if verbose > 0 {
+                println!("[dry-run] content:\n{}", new_content);
+            }
+        } else {
+            fs::create_dir_all(&target_dir).context("Failed to create .trae/rules directory")?;
+            fs::write(&rules_path, &new_content)
+                .context("Failed to write .trae/rules/rtk-rules.md")?;
+
+            if verbose > 0 {
+                eprintln!("Wrote .trae/rules/rtk-rules.md");
+            }
+
+            println!("\nRTK configured for Trae.ai.\n");
+            println!("  Rules: .trae/rules/rtk-rules.md (installed)");
+        }
+    }
+    if dry_run {
+        print_dry_run_footer();
+    } else {
+        println!("  Trae.ai will now use rtk commands for token savings.");
+        println!("  Test with: git status\n");
+    }
+
+    Ok(())
+}
+
 // ─── Google Antigravity support ───────────────────────────────
 
 const ANTIGRAVITY_RULES: &str = include_str!("../../hooks/antigravity/rules.md");
@@ -4199,6 +4256,31 @@ mod tests {
 
         // Second run should not overwrite
         run_kilocode_mode_at(temp.path(), InitContext::default()).unwrap();
+        let second = fs::read_to_string(&path).unwrap();
+        assert_eq!(first, second, "Idempotent: content should not change");
+    }
+
+    #[test]
+    fn test_trae_mode_creates_rules_file() {
+        let temp = TempDir::new().unwrap();
+        run_trae_mode_at(temp.path(), InitContext::default()).unwrap();
+
+        let rules_path = temp.path().join(".trae/rules/rtk-rules.md");
+        assert!(rules_path.exists(), "Rules file should be created");
+        let content = fs::read_to_string(&rules_path).unwrap();
+        assert!(content.contains("RTK"), "Rules file should contain RTK");
+    }
+
+    #[test]
+    fn test_trae_mode_is_idempotent() {
+        let temp = TempDir::new().unwrap();
+        run_trae_mode_at(temp.path(), InitContext::default()).unwrap();
+
+        let path = temp.path().join(".trae/rules/rtk-rules.md");
+        let first = fs::read_to_string(&path).unwrap();
+
+        // Second run should not overwrite
+        run_trae_mode_at(temp.path(), InitContext::default()).unwrap();
         let second = fs::read_to_string(&path).unwrap();
         assert_eq!(first, second, "Idempotent: content should not change");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,8 @@ pub enum AgentTarget {
     Cline,
     /// Kilo Code
     Kilocode,
+    /// Trae.ai IDE
+    Trae,
     /// Google Antigravity
     Antigravity,
     /// Pi coding agent
@@ -1849,6 +1851,11 @@ fn run_cli() -> Result<i32> {
                     anyhow::bail!("Kilo Code is project-scoped. Use: rtk init --agent kilocode");
                 }
                 hooks::init::run_kilocode_mode(ctx)?;
+            } else if agent == Some(AgentTarget::Trae) {
+                if global {
+                    anyhow::bail!("Trae.ai is project-scoped. Use: rtk init --agent trae");
+                }
+                hooks::init::run_trae_mode(ctx)?;
             } else if agent == Some(AgentTarget::Antigravity) {
                 if global {
                     anyhow::bail!(
@@ -2657,6 +2664,17 @@ mod tests {
         match cli.command {
             Commands::Init { agent, .. } => {
                 assert_eq!(agent, Some(AgentTarget::Hermes));
+            }
+            _ => panic!("Expected Init command"),
+        }
+    }
+
+    #[test]
+    fn test_try_parse_init_agent_trae() {
+        let cli = Cli::try_parse_from(["rtk", "init", "--agent", "trae"]).unwrap();
+        match cli.command {
+            Commands::Init { agent, .. } => {
+                assert_eq!(agent, Some(AgentTarget::Trae));
             }
             _ => panic!("Expected Init command"),
         }


### PR DESCRIPTION
Closes #1676.

Adds Trae.ai as a project-scoped rules-file integration via `rtk init --agent trae`, installing RTK guidance at `.trae/rules/rtk-rules.md`.

Also updates the supported-agent documentation and adds tests for CLI parsing, rules-file creation, and idempotency.

Verification:
- `git diff --check`
- Could not run Rust tests locally because `cargo` and `rustfmt` are not installed in this shell.