### PR TITLE
feat(hooks): add CodeBuddy integration

### DIFF
--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -1,6 +1,7 @@
 pub const REWRITE_HOOK_FILE: &str = "rtk-rewrite.sh";
 pub const GEMINI_HOOK_FILE: &str = "rtk-hook-gemini.sh";
 pub const CLAUDE_DIR: &str = ".claude";
+pub const CODEBUDDY_DIR: &str = ".codebuddy";
 pub const HOOKS_SUBDIR: &str = "hooks";
 pub const SETTINGS_JSON: &str = "settings.json";
 pub const SETTINGS_LOCAL_JSON: &str = "settings.local.json";
@@ -12,6 +13,8 @@ pub const BEFORE_TOOL_KEY: &str = "BeforeTool";
 pub const CLAUDE_HOOK_COMMAND: &str = "rtk hook claude";
 /// Native Rust hook command for Cursor (replaces rtk-rewrite.sh).
 pub const CURSOR_HOOK_COMMAND: &str = "rtk hook cursor";
+/// Native Rust hook command for CodeBuddy Code.
+pub const CODEBUDDY_HOOK_COMMAND: &str = "rtk hook codebuddy";
 
 pub const CONFIG_DIR: &str = ".config";
 pub const OPENCODE_SUBDIR: &str = "opencode";
@@ -21,3 +24,9 @@ pub const OPENCODE_PLUGIN_FILE: &str = "rtk.ts";
 pub const CURSOR_DIR: &str = ".cursor";
 pub const CODEX_DIR: &str = ".codex";
 pub const GEMINI_DIR: &str = ".gemini";
+
+pub const CODEBUDDY_PLUGIN_NAME: &str = "rtk";
+pub const CODEBUDDY_PLUGIN_MARKETPLACE: &str = "codebuddy-plugins-official";
+pub const CODEBUDDY_PLUGIN_ENABLED_KEY: &str = "rtk@codebuddy-plugins-official";
+pub const CODEBUDDY_PLUGIN_MANIFEST_DIR: &str = ".codebuddy-plugin";
+pub const CODEBUDDY_PLUGIN_MANIFEST_FILE: &str = "plugin.json";

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -297,7 +297,17 @@ enum PayloadAction {
     Ignore,
 }
 
-fn process_claude_payload(v: &Value) -> PayloadAction {
+#[derive(Clone, Copy)]
+enum PermissionMode {
+    Claude,
+    NoPermissionCheck,
+}
+
+fn process_claude_payload(
+    v: &Value,
+    permission_mode: PermissionMode,
+    include_modified_input: bool,
+) -> PayloadAction {
     let cmd = match v
         .pointer("/tool_input/command")
         .and_then(|c| c.as_str())
@@ -307,7 +317,10 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
         None => return PayloadAction::Ignore,
     };
 
-    let verdict = permissions::check_command(cmd);
+    let verdict = match permission_mode {
+        PermissionMode::Claude => permissions::check_command(cmd),
+        PermissionMode::NoPermissionCheck => PermissionVerdict::Default,
+    };
     if verdict == PermissionVerdict::Deny {
         return PayloadAction::Skip {
             reason: "skip:deny_rule",
@@ -336,8 +349,15 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
     let mut hook_output = json!({
         "hookEventName": PRE_TOOL_USE_KEY,
         "permissionDecisionReason": "RTK auto-rewrite",
-        "updatedInput": updated_input
+        "updatedInput": updated_input.clone()
     });
+
+    if include_modified_input {
+        hook_output
+            .as_object_mut()
+            .unwrap()
+            .insert("modifiedInput".into(), updated_input);
+    }
 
     if verdict == PermissionVerdict::Allow {
         hook_output
@@ -355,6 +375,19 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
 
 /// Run the Claude Code PreToolUse hook natively.
 pub fn run_claude() -> Result<()> {
+    run_claude_compatible_hook("claude", PermissionMode::Claude, false)
+}
+
+/// Run the CodeBuddy Code PreToolUse hook natively.
+pub fn run_codebuddy() -> Result<()> {
+    run_claude_compatible_hook("codebuddy", PermissionMode::NoPermissionCheck, true)
+}
+
+fn run_claude_compatible_hook(
+    adapter: &str,
+    permission_mode: PermissionMode,
+    include_modified_input: bool,
+) -> Result<()> {
     let input = read_stdin_limited()?;
 
     let input = input.trim();
@@ -365,12 +398,15 @@ pub fn run_claude() -> Result<()> {
     let v: Value = match serde_json::from_str(input) {
         Ok(v) => v,
         Err(e) => {
-            let _ = writeln!(io::stderr(), "[rtk hook] Failed to parse JSON input: {e}");
+            let _ = writeln!(
+                io::stderr(),
+                "[rtk hook {adapter}] Failed to parse JSON input: {e}"
+            );
             return Ok(());
         }
     };
 
-    match process_claude_payload(&v) {
+    match process_claude_payload(&v, permission_mode, include_modified_input) {
         PayloadAction::Rewrite {
             cmd,
             rewritten,
@@ -390,8 +426,22 @@ pub fn run_claude() -> Result<()> {
 
 #[cfg(test)]
 fn run_claude_inner(input: &str) -> Option<String> {
+    run_claude_compatible_inner(input, PermissionMode::Claude, false)
+}
+
+#[cfg(test)]
+fn run_codebuddy_inner(input: &str) -> Option<String> {
+    run_claude_compatible_inner(input, PermissionMode::NoPermissionCheck, true)
+}
+
+#[cfg(test)]
+fn run_claude_compatible_inner(
+    input: &str,
+    permission_mode: PermissionMode,
+    include_modified_input: bool,
+) -> Option<String> {
     let v: Value = serde_json::from_str(input).ok()?;
-    match process_claude_payload(&v) {
+    match process_claude_payload(&v, permission_mode, include_modified_input) {
         PayloadAction::Rewrite { output, .. } => Some(output.to_string()),
         _ => None,
     }
@@ -754,6 +804,84 @@ mod tests {
     fn test_claude_no_tool_input_passthrough() {
         let input = json!({ "tool_name": "Bash" }).to_string();
         assert!(run_claude_inner(&input).is_none());
+    }
+
+    // --- CodeBuddy handler ---
+
+    fn codebuddy_input(cmd: &str) -> String {
+        json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": { "command": cmd }
+        })
+        .to_string()
+    }
+
+    fn codebuddy_input_with_fields(cmd: &str, timeout: u64, description: &str) -> String {
+        json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": cmd,
+                "timeout": timeout,
+                "description": description,
+                "extra": { "keep": true }
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn test_codebuddy_rewrite_git_status() {
+        let result = run_codebuddy_inner(&codebuddy_input("git status")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let cmd = v
+            .pointer("/hookSpecificOutput/updatedInput/command")
+            .and_then(|c| c.as_str())
+            .unwrap();
+        assert_eq!(cmd, "rtk git status");
+    }
+
+    #[test]
+    fn test_codebuddy_rewrite_preserves_tool_input_fields() {
+        let input = codebuddy_input_with_fields("git status", 30000, "Check repo status");
+        let result = run_codebuddy_inner(&input).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let updated = &v["hookSpecificOutput"]["updatedInput"];
+        assert_eq!(updated["command"], "rtk git status");
+        assert_eq!(updated["timeout"], 30000);
+        assert_eq!(updated["description"], "Check repo status");
+        assert_eq!(updated["extra"]["keep"], true);
+    }
+
+    #[test]
+    fn test_codebuddy_modified_input_matches_updated_input() {
+        let result = run_codebuddy_inner(&codebuddy_input("git status")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let hook = &v["hookSpecificOutput"];
+        assert_eq!(hook["modifiedInput"], hook["updatedInput"]);
+    }
+
+    #[test]
+    fn test_claude_output_does_not_include_codebuddy_modified_input() {
+        let result = run_claude_inner(&claude_input("git status")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        assert!(v["hookSpecificOutput"].get("modifiedInput").is_none());
+    }
+
+    #[test]
+    fn test_codebuddy_unsupported_command_passthrough() {
+        assert!(run_codebuddy_inner(&codebuddy_input("htop")).is_none());
+    }
+
+    #[test]
+    fn test_codebuddy_heredoc_passthrough() {
+        assert!(run_codebuddy_inner(&codebuddy_input("cat <<EOF\nhello\nEOF")).is_none());
+    }
+
+    #[test]
+    fn test_codebuddy_already_rtk_passthrough() {
+        assert!(run_codebuddy_inner(&codebuddy_input("rtk git status")).is_none());
     }
 
     // --- Cursor handler ---

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -11,7 +11,9 @@ use crate::hooks::constants::{
 };
 
 use super::constants::{
-    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND,
+    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEBUDDY_DIR, CODEBUDDY_HOOK_COMMAND,
+    CODEBUDDY_PLUGIN_ENABLED_KEY, CODEBUDDY_PLUGIN_MANIFEST_DIR, CODEBUDDY_PLUGIN_MANIFEST_FILE,
+    CODEBUDDY_PLUGIN_MARKETPLACE, CODEBUDDY_PLUGIN_NAME, CODEX_DIR, CURSOR_HOOK_COMMAND,
     GEMINI_HOOK_FILE, HOOKS_JSON, HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use super::integrity;
@@ -845,6 +847,243 @@ fn patch_settings_json_command(
     }
 
     Ok(PatchResult::Patched)
+}
+
+/// Initialize CodeBuddy Code settings with the native RTK Bash hook.
+pub fn run_codebuddy(global: bool, verbose: u8) -> Result<()> {
+    let settings_path = resolve_codebuddy_settings_path(global)?;
+
+    let patch_result = patch_codebuddy_settings_json(&settings_path, verbose)?;
+    if patch_result == PatchResult::AlreadyPresent {
+        println!("\n  settings.json: CodeBuddy hook already present");
+    }
+
+    let plugin_dir = if global {
+        let plugin_dir = codebuddy_plugin_dir()?;
+        let plugin_result = install_codebuddy_plugin_at(&plugin_dir, verbose)?;
+        enable_codebuddy_plugin(&settings_path, verbose)?;
+
+        if plugin_result == PatchResult::AlreadyPresent {
+            println!("  plugin: RTK CodeBuddy plugin already installed");
+        }
+
+        Some(plugin_dir)
+    } else {
+        None
+    };
+
+    println!("  CodeBuddy settings: {}", settings_path.display());
+    if let Some(plugin_dir) = plugin_dir {
+        println!("  CodeBuddy plugin:   {}", plugin_dir.display());
+    }
+    println!("  Command: {}", CODEBUDDY_HOOK_COMMAND);
+    if global {
+        println!("  Restart CodeBuddy Code (CLI or App). Test with: git status\n");
+    } else {
+        println!("  Restart CodeBuddy Code CLI. For App/IDE plugin setup, run: rtk init -g --codebuddy\n");
+    }
+
+    Ok(())
+}
+
+fn resolve_codebuddy_settings_path(global: bool) -> Result<PathBuf> {
+    let cwd = std::env::current_dir().context("Failed to determine current working directory")?;
+    codebuddy_settings_path_from(global, dirs::home_dir(), &cwd)
+}
+
+fn codebuddy_settings_path_from(
+    global: bool,
+    home_dir: Option<PathBuf>,
+    cwd: &Path,
+) -> Result<PathBuf> {
+    let codebuddy_dir = if global {
+        home_dir
+            .map(|home| home.join(CODEBUDDY_DIR))
+            .context("Cannot determine home directory. Is $HOME set?")?
+    } else {
+        cwd.join(CODEBUDDY_DIR)
+    };
+
+    Ok(codebuddy_dir.join(SETTINGS_JSON))
+}
+
+fn codebuddy_plugin_dir() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("Cannot determine home directory. Is $HOME set?")?;
+    Ok(home
+        .join(CODEBUDDY_DIR)
+        .join("plugins")
+        .join("marketplaces")
+        .join(CODEBUDDY_PLUGIN_MARKETPLACE)
+        .join("plugins")
+        .join(CODEBUDDY_PLUGIN_NAME))
+}
+
+fn install_codebuddy_plugin_at(plugin_dir: &Path, verbose: u8) -> Result<PatchResult> {
+    let manifest_dir = plugin_dir.join(CODEBUDDY_PLUGIN_MANIFEST_DIR);
+    let manifest_path = manifest_dir.join(CODEBUDDY_PLUGIN_MANIFEST_FILE);
+    let hooks_dir = plugin_dir.join(HOOKS_SUBDIR);
+    let hooks_path = hooks_dir.join(HOOKS_JSON);
+
+    fs::create_dir_all(&manifest_dir).with_context(|| {
+        format!(
+            "Failed to create CodeBuddy plugin manifest directory: {}",
+            manifest_dir.display()
+        )
+    })?;
+    fs::create_dir_all(&hooks_dir).with_context(|| {
+        format!(
+            "Failed to create CodeBuddy plugin hooks directory: {}",
+            hooks_dir.display()
+        )
+    })?;
+
+    let plugin_json = serde_json::json!({
+        "name": CODEBUDDY_PLUGIN_NAME,
+        "version": env!("CARGO_PKG_VERSION"),
+        "description": "Token saver: rewrites Bash commands through RTK to reduce token usage",
+        "author": {
+            "name": "rtk-ai"
+        },
+        "homepage": "https://github.com/rtk-ai/rtk",
+        "license": "Apache-2.0",
+        "hooks": "./hooks/hooks.json"
+    });
+    let plugin_json_str =
+        serde_json::to_string_pretty(&plugin_json).context("Failed to serialize plugin.json")?;
+    let manifest_changed = write_if_changed(
+        &manifest_path,
+        &plugin_json_str,
+        "CodeBuddy plugin manifest",
+        verbose,
+    )?;
+
+    let hooks_json = serde_json::json!({
+        "hooks": {
+            "PreToolUse": [{
+                "matcher": "Bash",
+                "hooks": [{
+                    "type": "command",
+                    "command": CODEBUDDY_HOOK_COMMAND,
+                    "timeout": 60
+                }]
+            }]
+        }
+    });
+    let hooks_json_str =
+        serde_json::to_string_pretty(&hooks_json).context("Failed to serialize hooks.json")?;
+    let hooks_changed = write_if_changed(
+        &hooks_path,
+        &hooks_json_str,
+        "CodeBuddy plugin hooks",
+        verbose,
+    )?;
+
+    if manifest_changed || hooks_changed {
+        Ok(PatchResult::Patched)
+    } else {
+        Ok(PatchResult::AlreadyPresent)
+    }
+}
+
+fn enable_codebuddy_plugin(settings_path: &Path, verbose: u8) -> Result<PatchResult> {
+    let mut root = read_json_object_or_empty(settings_path)?;
+    let root_obj = root
+        .as_object_mut()
+        .expect("read_json_object_or_empty object");
+    let enabled_plugins = root_obj
+        .entry("enabledPlugins")
+        .or_insert_with(|| serde_json::json!({}));
+
+    if !enabled_plugins.is_object() {
+        *enabled_plugins = serde_json::json!({});
+    }
+
+    let plugins_obj = enabled_plugins
+        .as_object_mut()
+        .context("enabledPlugins value is not an object")?;
+    let already_enabled = plugins_obj
+        .get(CODEBUDDY_PLUGIN_ENABLED_KEY)
+        .and_then(|v| v.as_bool())
+        == Some(true);
+
+    plugins_obj.insert(
+        CODEBUDDY_PLUGIN_ENABLED_KEY.to_string(),
+        serde_json::json!(true),
+    );
+
+    if let Some(parent) = settings_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+    }
+
+    let serialized =
+        serde_json::to_string_pretty(&root).context("Failed to serialize CodeBuddy settings")?;
+    atomic_write(settings_path, &serialized)?;
+
+    if already_enabled {
+        if verbose > 0 {
+            eprintln!("CodeBuddy plugin already enabled");
+        }
+        Ok(PatchResult::AlreadyPresent)
+    } else {
+        Ok(PatchResult::Patched)
+    }
+}
+
+fn patch_codebuddy_settings_json(path: &Path, verbose: u8) -> Result<PatchResult> {
+    let mut root = read_json_object_or_empty(path)?;
+
+    if exact_command_hook_already_present(&root, CODEBUDDY_HOOK_COMMAND) {
+        if verbose > 0 {
+            eprintln!("CodeBuddy settings.json: hook already present");
+        }
+        return Ok(PatchResult::AlreadyPresent);
+    }
+
+    insert_hook_entry(&mut root, CODEBUDDY_HOOK_COMMAND)?;
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+    }
+
+    let serialized = serde_json::to_string_pretty(&root)
+        .context("Failed to serialize CodeBuddy settings.json")?;
+    atomic_write(path, &serialized)?;
+
+    println!("\n  settings.json: CodeBuddy hook added");
+    Ok(PatchResult::Patched)
+}
+
+fn read_json_object_or_empty(path: &Path) -> Result<serde_json::Value> {
+    if !path.exists() {
+        return Ok(serde_json::json!({}));
+    }
+
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    if content.trim().is_empty() {
+        return Ok(serde_json::json!({}));
+    }
+
+    let mut root: serde_json::Value = serde_json::from_str(&content)
+        .with_context(|| format!("Failed to parse {} as JSON", path.display()))?;
+    if !root.is_object() {
+        root = serde_json::json!({});
+    }
+    Ok(root)
+}
+
+fn exact_command_hook_already_present(root: &serde_json::Value, hook_command: &str) -> bool {
+    root.get("hooks")
+        .and_then(|h| h.get(PRE_TOOL_USE_KEY))
+        .and_then(|p| p.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| entry.get("hooks")?.as_array())
+        .flatten()
+        .filter_map(|hook| hook.get("command")?.as_str())
+        .any(|cmd| cmd == hook_command)
 }
 
 /// Clean up consecutive blank lines (collapse 3+ to 2)
@@ -3595,6 +3834,118 @@ mod tests {
 
         let removed = remove_cursor_hook_from_json(&mut json_content);
         assert!(!removed);
+    }
+
+    #[test]
+    fn test_codebuddy_settings_path_project_and_global() {
+        let temp = TempDir::new().unwrap();
+        let home = temp.path().join("home");
+        let project = temp.path().join("project");
+
+        assert_eq!(
+            codebuddy_settings_path_from(false, Some(home.clone()), &project).unwrap(),
+            project.join(CODEBUDDY_DIR).join(SETTINGS_JSON)
+        );
+        assert_eq!(
+            codebuddy_settings_path_from(true, Some(home.clone()), &project).unwrap(),
+            home.join(CODEBUDDY_DIR).join(SETTINGS_JSON)
+        );
+    }
+
+    #[test]
+    fn test_patch_codebuddy_settings_json_preserves_existing_fields() {
+        let temp = TempDir::new().unwrap();
+        let settings = temp.path().join(CODEBUDDY_DIR).join(SETTINGS_JSON);
+        fs::create_dir_all(settings.parent().unwrap()).unwrap();
+        fs::write(
+            &settings,
+            serde_json::to_string_pretty(&serde_json::json!({
+                "model": "preserve-me"
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let result = patch_codebuddy_settings_json(&settings, 0).unwrap();
+        assert_eq!(result, PatchResult::Patched);
+
+        let root: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&settings).unwrap()).unwrap();
+        assert_eq!(root["model"], "preserve-me");
+        assert_eq!(root["hooks"][PRE_TOOL_USE_KEY][0]["matcher"], "Bash");
+        assert_eq!(
+            root["hooks"][PRE_TOOL_USE_KEY][0]["hooks"][0]["command"],
+            CODEBUDDY_HOOK_COMMAND
+        );
+
+        let result = patch_codebuddy_settings_json(&settings, 0).unwrap();
+        assert_eq!(result, PatchResult::AlreadyPresent);
+    }
+
+    #[test]
+    fn test_codebuddy_plugin_install_writes_manifest_and_hooks() {
+        let temp = TempDir::new().unwrap();
+        let plugin_dir = temp.path().join(CODEBUDDY_PLUGIN_NAME);
+
+        let result = install_codebuddy_plugin_at(&plugin_dir, 0).unwrap();
+        assert_eq!(result, PatchResult::Patched);
+
+        let manifest_path = plugin_dir
+            .join(CODEBUDDY_PLUGIN_MANIFEST_DIR)
+            .join(CODEBUDDY_PLUGIN_MANIFEST_FILE);
+        let hooks_path = plugin_dir.join(HOOKS_SUBDIR).join(HOOKS_JSON);
+
+        let manifest: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&manifest_path).unwrap()).unwrap();
+        assert_eq!(manifest["name"], CODEBUDDY_PLUGIN_NAME);
+        assert_eq!(manifest["version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(manifest["homepage"], "https://github.com/rtk-ai/rtk");
+        assert_eq!(manifest["license"], "Apache-2.0");
+        assert_eq!(manifest["hooks"], "./hooks/hooks.json");
+
+        let hooks: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&hooks_path).unwrap()).unwrap();
+        assert_eq!(hooks["hooks"][PRE_TOOL_USE_KEY][0]["matcher"], "Bash");
+        assert_eq!(
+            hooks["hooks"][PRE_TOOL_USE_KEY][0]["hooks"][0]["command"],
+            CODEBUDDY_HOOK_COMMAND
+        );
+        assert_eq!(
+            hooks["hooks"][PRE_TOOL_USE_KEY][0]["hooks"][0]["timeout"],
+            60
+        );
+
+        let result = install_codebuddy_plugin_at(&plugin_dir, 0).unwrap();
+        assert_eq!(result, PatchResult::AlreadyPresent);
+    }
+
+    #[test]
+    fn test_codebuddy_plugin_enable_preserves_settings() {
+        let temp = TempDir::new().unwrap();
+        let settings = temp.path().join(CODEBUDDY_DIR).join(SETTINGS_JSON);
+        fs::create_dir_all(settings.parent().unwrap()).unwrap();
+        fs::write(
+            &settings,
+            serde_json::to_string_pretty(&serde_json::json!({
+                "enabledPlugins": {
+                    "docx@codebuddy-plugins-official": true
+                },
+                "model": "preserve-me"
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        enable_codebuddy_plugin(&settings, 0).unwrap();
+        let root: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&settings).unwrap()).unwrap();
+
+        assert_eq!(root["model"], "preserve-me");
+        assert_eq!(
+            root["enabledPlugins"]["docx@codebuddy-plugins-official"],
+            true
+        );
+        assert_eq!(root["enabledPlugins"][CODEBUDDY_PLUGIN_ENABLED_KEY], true);
     }
 
     // ─── Legacy migration tests ──────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -371,6 +371,10 @@ enum Commands {
         /// Install GitHub Copilot integration (VS Code + CLI)
         #[arg(long)]
         copilot: bool,
+
+        /// Initialize CodeBuddy Code settings hooks
+        #[arg(long)]
+        codebuddy: bool,
     },
 
     /// Download with compact output (strips progress bars)
@@ -759,6 +763,9 @@ enum HookCommands {
     Gemini,
     /// Process Copilot preToolUse hook (VS Code + Copilot CLI, reads JSON from stdin)
     Copilot,
+    /// Process CodeBuddy Code PreToolUse hook (reads JSON from stdin)
+    #[command(name = "codebuddy")]
+    CodeBuddy,
     /// Check how a command would be rewritten by the hook engine (dry-run)
     Check {
         /// Target agent
@@ -1754,6 +1761,7 @@ fn run_cli() -> Result<i32> {
             uninstall,
             codex,
             copilot,
+            codebuddy,
         } => {
             if show {
                 hooks::init::show_config(codex)?;
@@ -1771,6 +1779,8 @@ fn run_cli() -> Result<i32> {
                 hooks::init::run_gemini(global, hook_only, patch_mode, cli.verbose)?;
             } else if copilot {
                 hooks::init::run_copilot(cli.verbose)?;
+            } else if codebuddy {
+                hooks::init::run_codebuddy(global, cli.verbose)?;
             } else if agent == Some(AgentTarget::Kilocode) {
                 if global {
                     anyhow::bail!("Kilo Code is project-scoped. Use: rtk init --agent kilocode");
@@ -2112,6 +2122,10 @@ fn run_cli() -> Result<i32> {
             }
             HookCommands::Copilot => {
                 hooks::hook_cmd::run_copilot()?;
+                0
+            }
+            HookCommands::CodeBuddy => {
+                hooks::hook_cmd::run_codebuddy()?;
                 0
             }
             HookCommands::Check { agent: _, command } => {
@@ -2689,6 +2703,45 @@ mod tests {
             cli.command,
             Commands::Hook {
                 command: HookCommands::Claude
+            }
+        ));
+    }
+
+    #[test]
+    fn test_try_parse_init_codebuddy() {
+        let cli = Cli::try_parse_from(["rtk", "init", "--codebuddy"]).unwrap();
+        match cli.command {
+            Commands::Init {
+                codebuddy, global, ..
+            } => {
+                assert!(codebuddy);
+                assert!(!global);
+            }
+            _ => panic!("Expected Init command"),
+        }
+    }
+
+    #[test]
+    fn test_try_parse_init_global_codebuddy() {
+        let cli = Cli::try_parse_from(["rtk", "init", "-g", "--codebuddy"]).unwrap();
+        match cli.command {
+            Commands::Init {
+                codebuddy, global, ..
+            } => {
+                assert!(codebuddy);
+                assert!(global);
+            }
+            _ => panic!("Expected Init command"),
+        }
+    }
+
+    #[test]
+    fn test_hook_codebuddy_parses() {
+        let cli = Cli::try_parse_from(["rtk", "hook", "codebuddy"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Hook {
+                command: HookCommands::CodeBuddy
             }
         ));
     }


### PR DESCRIPTION
## Summary

- Adds first-class CodeBuddy hook support through `rtk init --codebuddy` and `rtk hook codebuddy`.
- Installs and enables a global CodeBuddy plugin for App/IDE usage while preserving existing settings.

## Why

CodeBuddy can use Claude-compatible `PreToolUse` hooks, but RTK did not have a native setup path or hook adapter for its settings and plugin layout.

## Changes

- Adds CodeBuddy CLI parsing and hook dispatch.
- Adds a CodeBuddy-compatible hook adapter that preserves tool input fields and returns both `updatedInput` and `modifiedInput`.
- Writes `.codebuddy/settings.json` or `~/.codebuddy/settings.json`, and installs the global CodeBuddy plugin under the CodeBuddy marketplace directory.
- Adds focused tests for parsing, settings patching, plugin files, and hook rewrite behavior.

## Review Guide

Start with `src/main.rs` for the new CLI and hook entry points, then review `src/hooks/hook_cmd.rs` for the CodeBuddy JSON response shape. Check `src/hooks/init.rs` for settings and plugin writes. `src/hooks/constants.rs` only contains the new CodeBuddy constants.

## Verification

- `rtk cargo test codebuddy`
- `rtk cargo fmt --all --check`
- `rtk cargo clippy --all-targets` (exited successfully; existing warnings remain in unrelated dotnet/go/js filter files)
- `rtk cargo test --all` (`1753 passed, 6 ignored`)

## Risk

Risk level: Low

Potential impact: Incorrect CodeBuddy settings could make the integration fail to rewrite commands, but the change is opt-in through `rtk init --codebuddy`.

Rollback plan: Revert this PR to remove the CodeBuddy CLI path, hook adapter, and settings/plugin writer.
