### PR TITLE
feat(codebuddy): add CodeBuddy Code agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,15 @@ rtk init --agent windsurf       # Windsurf
 rtk init --agent cline          # Cline / Roo Code
 rtk init --agent kilocode       # Kilo Code
 rtk init --agent antigravity    # Google Antigravity
+rtk init --agent codebuddy      # CodeBuddy Code CLI
+rtk init -g --agent codebuddy   # CodeBuddy Code CLI + App/IDE plugin
 rtk init --agent hermes         # Hermes
 
 # 2. Restart your AI tool, then test
 git status  # Automatically rewritten to rtk git status
 ```
 
-Hook-based agents rewrite Bash commands (e.g., `git status` -> `rtk git status`) before execution. Plugin-based agents, including Hermes, use their plugin API to rewrite commands before execution. The agent receives compact output without needing to call `rtk` explicitly.
+Hook-based agents rewrite Bash commands (e.g., `git status` -> `rtk git status`) before execution. Plugin-based agents, including Hermes and CodeBuddy App/IDE, use their plugin API to rewrite commands before execution. The agent receives compact output without needing to call `rtk` explicitly.
 
 **Important:** the hook only runs on Bash tool calls. Claude Code built-in tools like `Read`, `Grep`, and `Glob` do not pass through the Bash hook, so they are not auto-rewritten. To get RTK's compact output for those workflows, use shell commands (`cat`/`head`/`tail`, `rg`/`grep`, `find`) or call `rtk read`, `rtk grep`, or `rtk find` directly.
 
@@ -351,7 +353,7 @@ rtk git status
 
 ## Supported AI Tools
 
-RTK supports 13 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents for 60-90% token savings where the agent supports command interception.
+RTK supports multiple AI coding tools. Each integration rewrites shell commands to `rtk` equivalents for 60-90% token savings where the agent supports command interception.
 
 | Tool | Install | Method |
 |------|---------|--------|
@@ -369,6 +371,7 @@ RTK supports 13 AI coding tools. Each integration rewrites shell commands to `rt
 | **Mistral Vibe** | Planned ([#800](https://github.com/rtk-ai/rtk/issues/800)) | Blocked on upstream |
 | **Kilo Code** | `rtk init --agent kilocode` | .kilocode/rules/rtk-rules.md (project-scoped) |
 | **Google Antigravity** | `rtk init --agent antigravity` | .agents/rules/antigravity-rtk-rules.md (project-scoped) |
+| **CodeBuddy Code** | `rtk init --agent codebuddy` / `rtk init -g --agent codebuddy` | PreToolUse hook; global install also enables App/IDE marketplace plugin |
 
 For per-agent setup details, override controls, and graceful degradation, see the [Supported Agents guide](https://www.rtk-ai.app/guide/getting-started/supported-agents). The Hermes plugin source and tests live in `hooks/hermes/`; installed Hermes runtime files still live under `~/.hermes/plugins/rtk-rewrite/`.
 

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -1,6 +1,6 @@
 ---
 title: Supported Agents
-description: How to integrate RTK with Claude Code, Cursor, Copilot, Cline, Windsurf, Codex, OpenCode, Hermes, Kilo Code, and Antigravity
+description: How to integrate RTK with Claude Code, Cursor, Copilot, CodeBuddy Code, Cline, Windsurf, Codex, OpenCode, Hermes, Kilo Code, and Antigravity
 sidebar:
   order: 3
 ---
@@ -33,6 +33,7 @@ Agent runs "cargo test"
 | GitHub Copilot CLI | Shell hook (deny-with-suggestion) | No (agent retries) |
 | Cursor | Shell hook (`preToolUse`) | Yes |
 | Gemini CLI | Rust binary (`BeforeTool`) | Yes |
+| CodeBuddy Code | Shell hook (`PreToolUse`) + App/IDE marketplace plugin | Yes |
 | OpenCode | TypeScript plugin (`tool.execute.before`) | Yes |
 | OpenClaw | TypeScript plugin (`before_tool_call`) | Yes |
 | Pi | TypeScript extension (`tool_call` event) | Yes |
@@ -77,6 +78,27 @@ rtk init --global --copilot
 ```bash
 rtk init --global --gemini
 ```
+
+### CodeBuddy Code
+
+```bash
+# Project-local CLI hook
+rtk init --agent codebuddy
+
+# Global CLI hook + App/IDE marketplace plugin
+rtk init -g --agent codebuddy
+```
+
+The project-local install writes `.codebuddy/settings.json` with a `PreToolUse` hook that delegates Bash commands to `rtk hook codebuddy`. The global install writes `~/.codebuddy/settings.json`, installs the RTK plugin under `~/.codebuddy/plugins/marketplaces/codebuddy-plugins-official/plugins/rtk/`, and enables `rtk@codebuddy-plugins-official` in `enabledPlugins` so the CodeBuddy App/IDE path is active too.
+
+Uninstall:
+
+```bash
+rtk init --uninstall --agent codebuddy
+rtk init --uninstall -g --agent codebuddy
+```
+
+Uninstall removes the CodeBuddy hook entries, the global RTK plugin directory, and the plugin enable flag. It also cleans up legacy `rtk-tx` CodeBuddy hook and plugin entries when present.
 
 ### OpenCode
 
@@ -173,7 +195,7 @@ Support is blocked on upstream `BeforeToolCallback` ([mistral-vibe#531](https://
 | **Plugin** | TypeScript, JavaScript, or Python in agent's plugin system | Transparent, in-place mutation when the agent allows it |
 | **Rules file** | Prompt-level instructions | Guidance only — agent is told to prefer `rtk <cmd>` |
 
-Rules file integrations (Cline, Windsurf, Codex, Kilo Code, Antigravity) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it. Plugin integrations (OpenCode, Pi) use in-place mutation via the agent's TypeScript extension API.
+Rules file integrations (Cline, Windsurf, Codex, Kilo Code, Antigravity) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini, CodeBuddy Code CLI) are guaranteed because the command is rewritten before the agent sees it. Plugin integrations (CodeBuddy App/IDE, OpenCode, Pi) use in-place mutation through the agent's plugin or extension API.
 
 ## Windows support
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -4,7 +4,7 @@
 
 **Deployed hook artifacts** — the actual files installed on user machines by `rtk init`. These are shell scripts, TypeScript plugins, and rules files that run outside the Rust binary. They are **thin delegates**: parse agent-specific JSON, call `rtk rewrite` as a subprocess, format agent-specific response. Zero filtering logic lives here.
 
-Owns: per-agent hook scripts and configuration files for 9 supported agents (Claude Code, Copilot, Cursor, Cline, Windsurf, Codex, OpenCode, Hermes, Pi).
+Owns: per-agent hook scripts and configuration files for supported agents (Claude Code, CodeBuddy Code, Copilot, Cursor, Cline, Windsurf, Codex, OpenCode, Hermes, Pi).
 
 Does **not** own: hook installation/uninstallation (that's `src/hooks/init.rs`), the rewrite pattern registry (that's `discover/registry`), or integrity verification (that's `src/hooks/integrity.rs`).
 
@@ -48,6 +48,7 @@ Each agent subdirectory has its own README with hook-specific details:
 | Agent | Mechanism | Hook Type | Can Modify Command? |
 |-------|-----------|-----------|---------------------|
 | Claude Code | Shell hook (`PreToolUse`) | Transparent rewrite | Yes (`updatedInput`) |
+| CodeBuddy Code | Rust binary (`rtk hook codebuddy`) | Transparent rewrite | Yes (`updatedInput`, `modifiedInput`) |
 | VS Code Copilot Chat | Rust binary (`rtk hook copilot`) | Transparent rewrite | Yes (`updatedInput`) |
 | GitHub Copilot CLI | Rust binary (`rtk hook copilot`) | Deny-with-suggestion | No (agent retries) |
 | Cursor | Shell hook (`preToolUse`) | Transparent rewrite | Yes (`updated_input`) |
@@ -81,6 +82,29 @@ Each agent subdirectory has its own README with hook-specific details:
     "permissionDecision": "allow",
     "permissionDecisionReason": "RTK auto-rewrite",
     "updatedInput": { "command": "rtk git status" }
+  }
+}
+```
+
+### CodeBuddy Code (Rust Binary)
+
+CodeBuddy uses a Claude-compatible `PreToolUse` payload and RTK responds with both `updatedInput` and `modifiedInput` for compatibility with CodeBuddy's CLI and App/IDE plugin paths. Project installs write `.codebuddy/settings.json`; global installs also write and enable the CodeBuddy marketplace plugin under `~/.codebuddy/plugins/marketplaces/codebuddy-plugins-official/plugins/rtk/`.
+
+**Command**:
+
+```bash
+rtk hook codebuddy
+```
+
+**Output** (stdout, when rewritten):
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecisionReason": "RTK auto-rewrite",
+    "updatedInput": { "command": "rtk git status" },
+    "modifiedInput": { "command": "rtk git status" }
   }
 }
 ```

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -6,7 +6,7 @@
 
 The **lifecycle management** layer for LLM agent hooks: install, uninstall, verify integrity, audit usage, and manage trust. This component creates and maintains the hook artifacts that live in `hooks/` (root), but does **not** execute rewrite logic itself — that lives in `discover/registry`.
 
-Owns: `rtk init` installation flows (5 agents via `AgentTarget` enum + 3 special modes: Gemini, Codex, OpenCode), SHA-256 integrity verification, hook version checking, audit log analysis, `rtk rewrite` CLI entry point, and TOML filter trust management.
+Owns: `rtk init` installation flows (6 agents via `AgentTarget` enum + 3 special modes: Gemini, Codex, OpenCode), SHA-256 integrity verification, hook version checking, audit log analysis, `rtk rewrite` CLI entry point, and TOML filter trust management.
 
 Does **not** own: the deployed hook scripts themselves (that's `hooks/`), the rewrite pattern registry (that's `discover/`), or command filtering (that's `cmds/`).
 
@@ -31,6 +31,8 @@ LLM agent integration layer that installs, validates, and executes command-rewri
 | Codex | `rtk init --codex` | RTK.md in `$CODEX_HOME` or `~/.codex` | AGENTS.md |
 | Cursor | `rtk init -g --agent cursor` | Cursor hook | hooks.json |
 | Pi | `rtk init --agent pi` | `.pi/extensions/rtk.ts` | -- |
+| CodeBuddy project | `rtk init --agent codebuddy` | `.codebuddy/settings.json` | `hooks.PreToolUse` |
+| CodeBuddy global | `rtk init -g --agent codebuddy` | `~/.codebuddy/settings.json`, marketplace plugin | `hooks.PreToolUse`, `enabledPlugins` |
 | Hermes | `rtk init --agent hermes` | Python plugin in `~/.hermes/plugins/rtk-rewrite/` | `config.yaml` `plugins.enabled` |
 
 
@@ -89,6 +91,7 @@ Rules are loaded from all Claude Code `settings.json` files (project + global, i
 | Gemini CLI (rtk hook gemini) | No (allow/deny only) | allow (limitation — no ask mode in Gemini) |
 | Copilot CLI (rtk hook copilot) | No updatedInput | deny-with-suggestion (unchanged) |
 | Codex | ask parsed but no-op | allow (limitation — fails open) |
+| CodeBuddy Code (rtk hook codebuddy) | Host-managed hook approval | rewrite with `updatedInput` + `modifiedInput`; Claude permission files are not consulted |
 
 ### Implementation
 

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -12,6 +12,8 @@ pub const BEFORE_TOOL_KEY: &str = "BeforeTool";
 pub const CLAUDE_HOOK_COMMAND: &str = "rtk hook claude";
 /// Native Rust hook command for Cursor (replaces rtk-rewrite.sh).
 pub const CURSOR_HOOK_COMMAND: &str = "rtk hook cursor";
+/// Native Rust hook command for CodeBuddy Code.
+pub const CODEBUDDY_HOOK_COMMAND: &str = "rtk hook codebuddy";
 
 pub const CONFIG_DIR: &str = ".config";
 pub const OPENCODE_SUBDIR: &str = "opencode";
@@ -21,6 +23,12 @@ pub const OPENCODE_PLUGIN_FILE: &str = "rtk.ts";
 pub const CURSOR_DIR: &str = ".cursor";
 pub const CODEX_DIR: &str = ".codex";
 pub const GEMINI_DIR: &str = ".gemini";
+pub const CODEBUDDY_DIR: &str = ".codebuddy";
+pub const CODEBUDDY_PLUGIN_NAME: &str = "rtk";
+pub const CODEBUDDY_PLUGIN_MARKETPLACE: &str = "codebuddy-plugins-official";
+pub const CODEBUDDY_PLUGIN_ENABLED_KEY: &str = "rtk@codebuddy-plugins-official";
+pub const CODEBUDDY_PLUGIN_MANIFEST_DIR: &str = ".codebuddy-plugin";
+pub const CODEBUDDY_PLUGIN_MANIFEST_FILE: &str = "plugin.json";
 
 pub const PI_DIR: &str = ".pi/agent";
 pub const PI_LOCAL_DIR: &str = ".pi";

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -297,7 +297,17 @@ enum PayloadAction {
     Ignore,
 }
 
-fn process_claude_payload(v: &Value) -> PayloadAction {
+#[derive(Clone, Copy)]
+enum PermissionMode {
+    Claude,
+    NoPermissionCheck,
+}
+
+fn process_claude_payload(
+    v: &Value,
+    permission_mode: PermissionMode,
+    include_modified_input: bool,
+) -> PayloadAction {
     let cmd = match v
         .pointer("/tool_input/command")
         .and_then(|c| c.as_str())
@@ -307,7 +317,10 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
         None => return PayloadAction::Ignore,
     };
 
-    let verdict = permissions::check_command(cmd);
+    let verdict = match permission_mode {
+        PermissionMode::Claude => permissions::check_command(cmd),
+        PermissionMode::NoPermissionCheck => PermissionVerdict::Default,
+    };
     if verdict == PermissionVerdict::Deny {
         return PayloadAction::Skip {
             reason: "skip:deny_rule",
@@ -336,8 +349,15 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
     let mut hook_output = json!({
         "hookEventName": PRE_TOOL_USE_KEY,
         "permissionDecisionReason": "RTK auto-rewrite",
-        "updatedInput": updated_input
+        "updatedInput": updated_input.clone()
     });
+
+    if include_modified_input {
+        hook_output
+            .as_object_mut()
+            .unwrap()
+            .insert("modifiedInput".into(), updated_input);
+    }
 
     if verdict == PermissionVerdict::Allow {
         hook_output
@@ -355,6 +375,19 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
 
 /// Run the Claude Code PreToolUse hook natively.
 pub fn run_claude() -> Result<()> {
+    run_claude_compatible_hook("claude", PermissionMode::Claude, false)
+}
+
+/// Run the CodeBuddy Code PreToolUse hook natively.
+pub fn run_codebuddy() -> Result<()> {
+    run_claude_compatible_hook("codebuddy", PermissionMode::NoPermissionCheck, true)
+}
+
+fn run_claude_compatible_hook(
+    adapter: &str,
+    permission_mode: PermissionMode,
+    include_modified_input: bool,
+) -> Result<()> {
     let input = read_stdin_limited()?;
 
     let input = input.trim();
@@ -365,12 +398,15 @@ pub fn run_claude() -> Result<()> {
     let v: Value = match serde_json::from_str(input) {
         Ok(v) => v,
         Err(e) => {
-            let _ = writeln!(io::stderr(), "[rtk hook] Failed to parse JSON input: {e}");
+            let _ = writeln!(
+                io::stderr(),
+                "[rtk hook {adapter}] Failed to parse JSON input: {e}"
+            );
             return Ok(());
         }
     };
 
-    match process_claude_payload(&v) {
+    match process_claude_payload(&v, permission_mode, include_modified_input) {
         PayloadAction::Rewrite {
             cmd,
             rewritten,
@@ -391,7 +427,16 @@ pub fn run_claude() -> Result<()> {
 #[cfg(test)]
 fn run_claude_inner(input: &str) -> Option<String> {
     let v: Value = serde_json::from_str(input).ok()?;
-    match process_claude_payload(&v) {
+    match process_claude_payload(&v, PermissionMode::Claude, false) {
+        PayloadAction::Rewrite { output, .. } => Some(output.to_string()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+fn run_codebuddy_inner(input: &str) -> Option<String> {
+    let v: Value = serde_json::from_str(input).ok()?;
+    match process_claude_payload(&v, PermissionMode::NoPermissionCheck, true) {
         PayloadAction::Rewrite { output, .. } => Some(output.to_string()),
         _ => None,
     }
@@ -778,6 +823,99 @@ mod tests {
     fn test_claude_no_tool_input_passthrough() {
         let input = json!({ "tool_name": "Bash" }).to_string();
         assert!(run_claude_inner(&input).is_none());
+    }
+
+    // --- CodeBuddy handler ---
+
+    fn codebuddy_input(cmd: &str) -> String {
+        json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": { "command": cmd }
+        })
+        .to_string()
+    }
+
+    fn codebuddy_input_with_fields(cmd: &str, timeout: u64, description: &str) -> String {
+        json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": cmd,
+                "timeout": timeout,
+                "description": description,
+                "extra": { "keep": true }
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn test_codebuddy_rewrite_git_status() {
+        let result = run_codebuddy_inner(&codebuddy_input("git status")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let cmd = v
+            .pointer("/hookSpecificOutput/updatedInput/command")
+            .and_then(|c| c.as_str())
+            .unwrap();
+        assert_eq!(cmd, "rtk git status");
+    }
+
+    #[test]
+    fn test_codebuddy_rewrite_preserves_tool_input_fields() {
+        let input = codebuddy_input_with_fields("git status", 30000, "Check repo status");
+        let result = run_codebuddy_inner(&input).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let updated = &v["hookSpecificOutput"]["updatedInput"];
+        assert_eq!(updated["command"], "rtk git status");
+        assert_eq!(updated["timeout"], 30000);
+        assert_eq!(updated["description"], "Check repo status");
+        assert_eq!(updated["extra"]["keep"], true);
+    }
+
+    #[test]
+    fn test_codebuddy_modified_input_matches_updated_input() {
+        let result = run_codebuddy_inner(&codebuddy_input("git status")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let hook = &v["hookSpecificOutput"];
+        assert_eq!(hook["modifiedInput"], hook["updatedInput"]);
+    }
+
+    #[test]
+    fn test_claude_output_does_not_include_codebuddy_modified_input() {
+        let result = run_claude_inner(&claude_input("git status")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        assert!(v["hookSpecificOutput"].get("modifiedInput").is_none());
+    }
+
+    #[test]
+    fn test_codebuddy_output_uses_host_managed_permissions() {
+        let result = run_codebuddy_inner(&codebuddy_input("git status")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let hook = &v["hookSpecificOutput"];
+        assert_eq!(hook["updatedInput"]["command"], "rtk git status");
+        assert!(hook.get("permissionDecision").is_none());
+        assert_eq!(hook["permissionDecisionReason"], "RTK auto-rewrite");
+    }
+
+    #[test]
+    fn test_codebuddy_malformed_json_passthrough() {
+        assert!(run_codebuddy_inner("not valid json {{{").is_none());
+    }
+
+    #[test]
+    fn test_codebuddy_unsupported_command_passthrough() {
+        assert!(run_codebuddy_inner(&codebuddy_input("htop")).is_none());
+    }
+
+    #[test]
+    fn test_codebuddy_heredoc_passthrough() {
+        assert!(run_codebuddy_inner(&codebuddy_input("cat <<EOF\nhello\nEOF")).is_none());
+    }
+
+    #[test]
+    fn test_codebuddy_already_rtk_passthrough() {
+        assert!(run_codebuddy_inner(&codebuddy_input("rtk git status")).is_none());
     }
 
     // --- Cursor handler ---

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -8,15 +8,17 @@ use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 
 use crate::hooks::constants::{
+    CODEBUDDY_DIR, CODEBUDDY_PLUGIN_ENABLED_KEY, CODEBUDDY_PLUGIN_MANIFEST_DIR,
+    CODEBUDDY_PLUGIN_MANIFEST_FILE, CODEBUDDY_PLUGIN_MARKETPLACE, CODEBUDDY_PLUGIN_NAME,
     CONFIG_DIR, CURSOR_DIR, GEMINI_DIR, OPENCODE_PLUGIN_FILE, OPENCODE_SUBDIR, PLUGIN_SUBDIR,
 };
 
 use super::constants::{
-    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND,
-    GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_INIT_FILE,
-    HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON, HOOKS_SUBDIR,
-    PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR, PI_PLUGIN_FILE,
-    PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
+    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEBUDDY_HOOK_COMMAND, CODEX_DIR,
+    CURSOR_HOOK_COMMAND, GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR,
+    HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON,
+    HOOKS_SUBDIR, PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR,
+    PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use super::integrity;
 
@@ -1052,6 +1054,14 @@ fn clean_double_blanks(content: &str) -> String {
 /// Deep-merge RTK hook entry into settings.json
 /// Creates hooks.PreToolUse structure if missing, preserves existing hooks
 fn insert_hook_entry(root: &mut serde_json::Value, hook_command: &str) -> Result<()> {
+    insert_hook_entry_with_matcher(root, hook_command, "Bash")
+}
+
+fn insert_hook_entry_with_matcher(
+    root: &mut serde_json::Value,
+    hook_command: &str,
+    matcher: &str,
+) -> Result<()> {
     let root_obj = match root.as_object_mut() {
         Some(obj) => obj,
         None => {
@@ -1073,7 +1083,7 @@ fn insert_hook_entry(root: &mut serde_json::Value, hook_command: &str) -> Result
         .context("PreToolUse value is not an array")?;
 
     pre_tool_use.push(serde_json::json!({
-        "matcher": "Bash",
+        "matcher": matcher,
         "hooks": [{
             "type": "command",
             "command": hook_command
@@ -1102,6 +1112,622 @@ fn hook_already_present(root: &serde_json::Value, hook_command: &str) -> bool {
         .any(|cmd| {
             cmd == hook_command || cmd == CLAUDE_HOOK_COMMAND || cmd.contains(REWRITE_HOOK_FILE)
         })
+}
+
+const LEGACY_CODEBUDDY_HOOK_COMMAND: &str = "rtk-tx hook codebuddy";
+const LEGACY_CODEBUDDY_PLUGIN_NAME: &str = "rtk-tx";
+const LEGACY_CODEBUDDY_PLUGIN_ENABLED_KEY: &str = "rtk-tx@codebuddy-plugins-official";
+
+/// Initialize CodeBuddy settings and global App/IDE plugin artifacts.
+pub fn run_codebuddy(global: bool, patch_mode: PatchMode, ctx: InitContext) -> Result<()> {
+    let settings_path = resolve_codebuddy_settings_path(global)?;
+    let patch_result = patch_codebuddy_settings_json_with_mode(&settings_path, patch_mode, ctx)?;
+    let manual_settings_required =
+        matches!(patch_result, PatchResult::Declined | PatchResult::Skipped);
+
+    let plugin_dir = if global {
+        let codebuddy_dir = settings_path
+            .parent()
+            .context("CodeBuddy settings path has no parent directory")?;
+        let plugin_dir = codebuddy_plugin_dir(codebuddy_dir);
+        let plugin_result = install_codebuddy_plugin_at(&plugin_dir, ctx)?;
+        let enable_result = match patch_result {
+            PatchResult::Declined | PatchResult::Skipped => PatchResult::Skipped,
+            PatchResult::Patched | PatchResult::AlreadyPresent | PatchResult::WouldPatch => {
+                enable_codebuddy_plugin(&settings_path, ctx)?
+            }
+        };
+        match plugin_result {
+            PatchResult::Patched => println!("  plugin: CodeBuddy App/IDE plugin installed"),
+            PatchResult::AlreadyPresent => {
+                println!("  plugin: CodeBuddy App/IDE plugin already installed")
+            }
+            PatchResult::WouldPatch | PatchResult::Declined | PatchResult::Skipped => {}
+        }
+        match enable_result {
+            PatchResult::Patched => println!(
+                "  settings.json: plugin {} enabled",
+                CODEBUDDY_PLUGIN_ENABLED_KEY
+            ),
+            PatchResult::AlreadyPresent => println!(
+                "  settings.json: plugin {} already enabled",
+                CODEBUDDY_PLUGIN_ENABLED_KEY
+            ),
+            PatchResult::WouldPatch | PatchResult::Declined | PatchResult::Skipped => {}
+        }
+        Some(plugin_dir)
+    } else {
+        None
+    };
+
+    match patch_result {
+        PatchResult::Patched => println!("\n  settings.json: CodeBuddy hook added"),
+        PatchResult::AlreadyPresent => {
+            println!("\n  settings.json: CodeBuddy hook already present")
+        }
+        PatchResult::Skipped | PatchResult::Declined | PatchResult::WouldPatch => {}
+    }
+
+    if manual_settings_required {
+        print_codebuddy_manual_instructions(&settings_path, global);
+        return Ok(());
+    }
+
+    println!("  CodeBuddy settings: {}", settings_path.display());
+    if let Some(plugin_dir) = plugin_dir {
+        println!("  CodeBuddy plugin:   {}", plugin_dir.display());
+        if ctx.dry_run {
+            print_dry_run_footer();
+            return Ok(());
+        }
+        println!("  Restart CodeBuddy Code (CLI or App). Test with: git status\n");
+    } else {
+        if ctx.dry_run {
+            print_dry_run_footer();
+            return Ok(());
+        }
+        println!(
+            "  Restart CodeBuddy Code CLI. For App/IDE plugin setup, run: rtk init -g --agent codebuddy\n"
+        );
+    }
+
+    Ok(())
+}
+
+/// Remove CodeBuddy settings hooks and global App/IDE plugin artifacts.
+pub fn uninstall_codebuddy(global: bool, ctx: InitContext) -> Result<()> {
+    let settings_path = resolve_codebuddy_settings_path(global)?;
+    let plugin_dirs = if global {
+        let codebuddy_dir = settings_path
+            .parent()
+            .context("CodeBuddy settings path has no parent directory")?;
+        vec![
+            codebuddy_plugin_dir(codebuddy_dir),
+            codebuddy_plugin_dir_with_name(codebuddy_dir, LEGACY_CODEBUDDY_PLUGIN_NAME),
+        ]
+    } else {
+        Vec::new()
+    };
+
+    let removed = uninstall_codebuddy_at(&settings_path, &plugin_dirs, ctx)?;
+    if !removed.is_empty() {
+        let header = if ctx.dry_run {
+            "[dry-run] would uninstall RTK (CodeBuddy):"
+        } else {
+            "RTK uninstalled (CodeBuddy):"
+        };
+        println!("{}", header);
+        for item in &removed {
+            println!("  - {}", item);
+        }
+        if !ctx.dry_run {
+            println!("\nRestart CodeBuddy Code to apply changes.");
+        }
+    } else {
+        println!("RTK CodeBuddy support was not installed (nothing to remove)");
+    }
+
+    if ctx.dry_run {
+        print_dry_run_footer();
+    }
+
+    Ok(())
+}
+
+fn resolve_codebuddy_settings_path(global: bool) -> Result<PathBuf> {
+    let cwd = std::env::current_dir().context("Failed to determine current working directory")?;
+    codebuddy_settings_path_from(global, dirs::home_dir(), &cwd)
+}
+
+fn codebuddy_settings_path_from(
+    global: bool,
+    home_dir: Option<PathBuf>,
+    cwd: &Path,
+) -> Result<PathBuf> {
+    let codebuddy_dir = if global {
+        home_dir
+            .map(|home| home.join(CODEBUDDY_DIR))
+            .context("Cannot determine home directory. Is $HOME set?")?
+    } else {
+        cwd.join(CODEBUDDY_DIR)
+    };
+
+    Ok(codebuddy_dir.join(SETTINGS_JSON))
+}
+
+fn codebuddy_plugin_dir(codebuddy_dir: &Path) -> PathBuf {
+    codebuddy_plugin_dir_with_name(codebuddy_dir, CODEBUDDY_PLUGIN_NAME)
+}
+
+fn codebuddy_plugin_dir_with_name(codebuddy_dir: &Path, plugin_name: &str) -> PathBuf {
+    codebuddy_dir
+        .join(PLUGIN_SUBDIR)
+        .join("marketplaces")
+        .join(CODEBUDDY_PLUGIN_MARKETPLACE)
+        .join(PLUGIN_SUBDIR)
+        .join(plugin_name)
+}
+
+fn codebuddy_manual_settings_json(enable_plugin: bool) -> String {
+    let mut root = serde_json::json!({
+        "hooks": {
+            PRE_TOOL_USE_KEY: [{
+                "matcher": "Bash",
+                "hooks": [{
+                    "type": "command",
+                    "command": CODEBUDDY_HOOK_COMMAND
+                }]
+            }]
+        }
+    });
+
+    if enable_plugin {
+        root["enabledPlugins"] = serde_json::json!({
+            CODEBUDDY_PLUGIN_ENABLED_KEY: true
+        });
+    }
+
+    serde_json::to_string_pretty(&root).expect("CodeBuddy manual settings JSON is serializable")
+}
+
+fn print_codebuddy_manual_instructions(settings_path: &Path, enable_plugin: bool) {
+    println!("\n  MANUAL STEP: Add this to {}:", settings_path.display());
+    for line in codebuddy_manual_settings_json(enable_plugin).lines() {
+        println!("  {line}");
+    }
+    if enable_plugin {
+        println!(
+            "\n  The CodeBuddy App/IDE plugin files are installed, but settings.json was not patched."
+        );
+        println!("  Add the hook and enabledPlugins entry above, then restart CodeBuddy Code.");
+        println!("  Test with: git status\n");
+    } else {
+        println!("\n  Then restart CodeBuddy Code CLI. Test with: git status\n");
+    }
+}
+
+#[cfg(test)]
+fn patch_codebuddy_settings_json(path: &Path, ctx: InitContext) -> Result<PatchResult> {
+    patch_codebuddy_settings_json_with_mode(path, PatchMode::Auto, ctx)
+}
+
+fn patch_codebuddy_settings_json_with_mode(
+    path: &Path,
+    mode: PatchMode,
+    ctx: InitContext,
+) -> Result<PatchResult> {
+    let mut root = read_settings_json_or_empty(path)?;
+
+    let already_present = exact_command_hook_already_present(&root, CODEBUDDY_HOOK_COMMAND);
+    let removed_legacy = remove_exact_command_hooks(&mut root, LEGACY_CODEBUDDY_HOOK_COMMAND);
+    let deduped = dedupe_exact_command_hooks(&mut root, CODEBUDDY_HOOK_COMMAND);
+
+    if already_present && !deduped && !removed_legacy {
+        if ctx.verbose > 0 {
+            eprintln!("CodeBuddy settings.json: hook already present");
+        }
+        return Ok(PatchResult::AlreadyPresent);
+    }
+
+    match mode {
+        PatchMode::Skip => return Ok(PatchResult::Skipped),
+        PatchMode::Ask => {
+            if ctx.dry_run {
+                println!("[dry-run] would prompt before patching {}", path.display());
+            } else if !prompt_user_consent(path)? {
+                return Ok(PatchResult::Declined);
+            }
+        }
+        PatchMode::Auto => {}
+    }
+
+    if !already_present {
+        insert_hook_entry_with_matcher(&mut root, CODEBUDDY_HOOK_COMMAND, "Bash")?;
+    }
+
+    let serialized = serde_json::to_string_pretty(&root)
+        .context("Failed to serialize CodeBuddy settings.json")?;
+
+    if ctx.dry_run {
+        println!(
+            "[dry-run] would patch CodeBuddy settings: {}",
+            path.display()
+        );
+        if ctx.verbose > 0 {
+            println!("[dry-run] content:\n{}", serialized);
+        }
+        return Ok(PatchResult::WouldPatch);
+    }
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+    }
+    atomic_write(path, &serialized)?;
+
+    Ok(PatchResult::Patched)
+}
+
+fn install_codebuddy_plugin_at(plugin_dir: &Path, ctx: InitContext) -> Result<PatchResult> {
+    let manifest_dir = plugin_dir.join(CODEBUDDY_PLUGIN_MANIFEST_DIR);
+    let manifest_path = manifest_dir.join(CODEBUDDY_PLUGIN_MANIFEST_FILE);
+    let hooks_dir = plugin_dir.join(HOOKS_SUBDIR);
+    let hooks_path = hooks_dir.join(HOOKS_JSON);
+
+    if !ctx.dry_run {
+        fs::create_dir_all(&manifest_dir).with_context(|| {
+            format!(
+                "Failed to create CodeBuddy plugin manifest directory: {}",
+                manifest_dir.display()
+            )
+        })?;
+        fs::create_dir_all(&hooks_dir).with_context(|| {
+            format!(
+                "Failed to create CodeBuddy plugin hooks directory: {}",
+                hooks_dir.display()
+            )
+        })?;
+    }
+
+    let plugin_json = serde_json::json!({
+        "name": CODEBUDDY_PLUGIN_NAME,
+        "version": env!("CARGO_PKG_VERSION"),
+        "description": "Token saver: rewrites Bash commands through RTK to reduce token usage",
+        "author": {
+            "name": "RTK Contributors",
+            "email": "contact@rtk-ai.app"
+        },
+        "homepage": "https://github.com/rtk-ai/rtk",
+        "license": "Apache-2.0",
+        "hooks": "./hooks/hooks.json"
+    });
+    let plugin_json_str =
+        serde_json::to_string_pretty(&plugin_json).context("Failed to serialize plugin.json")?;
+    let manifest_changed = write_if_changed(
+        &manifest_path,
+        &plugin_json_str,
+        "CodeBuddy plugin manifest",
+        ctx,
+    )?;
+
+    let hooks_json = serde_json::json!({
+        "description": "RTK PreToolUse hook - rewrites Bash commands to save tokens",
+        "hooks": {
+            PRE_TOOL_USE_KEY: [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": CODEBUDDY_HOOK_COMMAND,
+                            "timeout": 60
+                        }
+                    ]
+                }
+            ]
+        }
+    });
+    let hooks_json_str =
+        serde_json::to_string_pretty(&hooks_json).context("Failed to serialize hooks.json")?;
+    let hooks_changed =
+        write_if_changed(&hooks_path, &hooks_json_str, "CodeBuddy plugin hooks", ctx)?;
+
+    if ctx.dry_run && (manifest_changed || hooks_changed) {
+        Ok(PatchResult::WouldPatch)
+    } else if manifest_changed || hooks_changed {
+        Ok(PatchResult::Patched)
+    } else {
+        Ok(PatchResult::AlreadyPresent)
+    }
+}
+
+fn enable_codebuddy_plugin(settings_path: &Path, ctx: InitContext) -> Result<PatchResult> {
+    let mut root = read_settings_json_or_empty(settings_path)?;
+
+    let already_enabled = root
+        .get("enabledPlugins")
+        .and_then(|ep| ep.get(CODEBUDDY_PLUGIN_ENABLED_KEY))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let removed_legacy = remove_enabled_plugin_key(&mut root, LEGACY_CODEBUDDY_PLUGIN_ENABLED_KEY);
+
+    if already_enabled && !removed_legacy {
+        if ctx.verbose > 0 {
+            eprintln!(
+                "CodeBuddy plugin {} already enabled",
+                CODEBUDDY_PLUGIN_ENABLED_KEY
+            );
+        }
+        return Ok(PatchResult::AlreadyPresent);
+    }
+
+    if !already_enabled {
+        let enabled = root
+            .as_object_mut()
+            .context("settings.json root is not an object")?
+            .entry("enabledPlugins")
+            .or_insert_with(|| serde_json::json!({}))
+            .as_object_mut()
+            .context("enabledPlugins is not an object")?;
+
+        enabled.insert(
+            CODEBUDDY_PLUGIN_ENABLED_KEY.to_string(),
+            serde_json::Value::Bool(true),
+        );
+    }
+
+    let serialized =
+        serde_json::to_string_pretty(&root).context("Failed to serialize settings.json")?;
+
+    if ctx.dry_run {
+        println!(
+            "[dry-run] would enable CodeBuddy plugin in settings.json: {}",
+            settings_path.display()
+        );
+        if ctx.verbose > 0 {
+            println!("[dry-run] content:\n{}", serialized);
+        }
+        return Ok(PatchResult::WouldPatch);
+    }
+
+    if let Some(parent) = settings_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+    }
+    atomic_write(settings_path, &serialized)?;
+
+    Ok(PatchResult::Patched)
+}
+
+fn uninstall_codebuddy_at(
+    settings_path: &Path,
+    plugin_dirs: &[PathBuf],
+    ctx: InitContext,
+) -> Result<Vec<String>> {
+    let mut removed = Vec::new();
+
+    if settings_path.exists() {
+        let mut root = read_settings_json_or_empty(settings_path)?;
+        let removed_hook = remove_exact_command_hooks(&mut root, CODEBUDDY_HOOK_COMMAND)
+            | remove_exact_command_hooks(&mut root, LEGACY_CODEBUDDY_HOOK_COMMAND);
+        let removed_enabled_plugin =
+            remove_enabled_plugin_key(&mut root, CODEBUDDY_PLUGIN_ENABLED_KEY)
+                | remove_enabled_plugin_key(&mut root, LEGACY_CODEBUDDY_PLUGIN_ENABLED_KEY);
+        let pruned_empty_sections = prune_empty_codebuddy_settings_sections(&mut root);
+
+        if removed_hook || removed_enabled_plugin || pruned_empty_sections {
+            let serialized = serde_json::to_string_pretty(&root)
+                .context("Failed to serialize CodeBuddy settings.json")?;
+            if ctx.dry_run {
+                println!(
+                    "[dry-run] would update CodeBuddy settings: {}",
+                    settings_path.display()
+                );
+                if ctx.verbose > 0 {
+                    println!("[dry-run] content:\n{}", serialized);
+                }
+            } else {
+                atomic_write(settings_path, &serialized)?;
+            }
+
+            if removed_hook {
+                removed.push("CodeBuddy settings.json: removed RTK hook entry".to_string());
+            }
+            if removed_enabled_plugin {
+                removed.push(format!(
+                    "CodeBuddy settings.json: disabled {}",
+                    CODEBUDDY_PLUGIN_ENABLED_KEY
+                ));
+            }
+            if pruned_empty_sections && !removed_hook && !removed_enabled_plugin {
+                removed.push("CodeBuddy settings.json: pruned empty RTK sections".to_string());
+            }
+        }
+    }
+
+    for plugin_dir in plugin_dirs {
+        if plugin_dir.exists() {
+            if ctx.dry_run {
+                println!(
+                    "[dry-run] would remove CodeBuddy plugin directory: {}",
+                    plugin_dir.display()
+                );
+            } else {
+                // nosemgrep: filesystem-deletion -- uninstall intentionally removes only RTK's CodeBuddy plugin directory.
+                fs::remove_dir_all(plugin_dir).with_context(|| {
+                    format!(
+                        "Failed to remove CodeBuddy plugin directory: {}",
+                        plugin_dir.display()
+                    )
+                })?;
+            }
+            removed.push(format!("CodeBuddy plugin: {}", plugin_dir.display()));
+        }
+    }
+
+    Ok(removed)
+}
+
+fn read_settings_json_or_empty(path: &Path) -> Result<serde_json::Value> {
+    if !path.exists() {
+        return Ok(serde_json::json!({}));
+    }
+
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    if content.trim().is_empty() {
+        return Ok(serde_json::json!({}));
+    }
+
+    serde_json::from_str(&content)
+        .with_context(|| format!("Failed to parse {} as JSON", path.display()))
+}
+
+fn exact_command_hook_already_present(root: &serde_json::Value, hook_command: &str) -> bool {
+    root.get("hooks")
+        .and_then(|h| h.get(PRE_TOOL_USE_KEY))
+        .and_then(|p| p.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| entry.get("hooks")?.as_array())
+        .flatten()
+        .filter_map(|hook| hook.get("command")?.as_str())
+        .any(|cmd| cmd == hook_command)
+}
+
+fn remove_exact_command_hooks(root: &mut serde_json::Value, hook_command: &str) -> bool {
+    let pre_tool_use_array = match root
+        .get_mut("hooks")
+        .and_then(|h| h.get_mut(PRE_TOOL_USE_KEY))
+        .and_then(|p| p.as_array_mut())
+    {
+        Some(arr) => arr,
+        None => return false,
+    };
+
+    let mut changed = false;
+    let mut index = 0;
+    while index < pre_tool_use_array.len() {
+        let Some(hooks_array) = pre_tool_use_array[index]
+            .get_mut("hooks")
+            .and_then(|h| h.as_array_mut())
+        else {
+            index += 1;
+            continue;
+        };
+        let before = hooks_array.len();
+        hooks_array
+            .retain(|hook| hook.get("command").and_then(|c| c.as_str()) != Some(hook_command));
+        let removed_from_entry = hooks_array.len() != before;
+        changed |= removed_from_entry;
+        if removed_from_entry && hooks_array.is_empty() {
+            pre_tool_use_array.remove(index);
+            continue;
+        }
+        index += 1;
+    }
+
+    changed
+}
+
+fn remove_enabled_plugin_key(root: &mut serde_json::Value, key: &str) -> bool {
+    root.get_mut("enabledPlugins")
+        .and_then(|v| v.as_object_mut())
+        .and_then(|plugins| plugins.remove(key))
+        .is_some()
+}
+
+fn prune_empty_codebuddy_settings_sections(root: &mut serde_json::Value) -> bool {
+    let Some(root_obj) = root.as_object_mut() else {
+        return false;
+    };
+
+    let mut changed = false;
+    if root_obj
+        .get("enabledPlugins")
+        .and_then(|v| v.as_object())
+        .is_some_and(|plugins| plugins.is_empty())
+    {
+        root_obj.remove("enabledPlugins");
+        changed = true;
+    }
+
+    if let Some(hooks_obj) = root_obj.get_mut("hooks").and_then(|v| v.as_object_mut()) {
+        if let Some(pre_tool_use) = hooks_obj
+            .get_mut(PRE_TOOL_USE_KEY)
+            .and_then(|v| v.as_array_mut())
+        {
+            let before = pre_tool_use.len();
+            pre_tool_use.retain(|entry| {
+                entry
+                    .get("hooks")
+                    .and_then(|v| v.as_array())
+                    .is_none_or(|hooks| !hooks.is_empty())
+            });
+            changed |= pre_tool_use.len() != before;
+        }
+
+        if hooks_obj
+            .get(PRE_TOOL_USE_KEY)
+            .and_then(|v| v.as_array())
+            .is_some_and(|hooks| hooks.is_empty())
+        {
+            hooks_obj.remove(PRE_TOOL_USE_KEY);
+            changed = true;
+        }
+    }
+
+    if root_obj
+        .get("hooks")
+        .and_then(|v| v.as_object())
+        .is_some_and(|hooks| hooks.is_empty())
+    {
+        root_obj.remove("hooks");
+        changed = true;
+    }
+
+    changed
+}
+
+fn dedupe_exact_command_hooks(root: &mut serde_json::Value, hook_command: &str) -> bool {
+    let pre_tool_use_array = match root
+        .get_mut("hooks")
+        .and_then(|h| h.get_mut(PRE_TOOL_USE_KEY))
+        .and_then(|p| p.as_array_mut())
+    {
+        Some(arr) => arr,
+        None => return false,
+    };
+
+    let mut seen = false;
+    let mut changed = false;
+
+    for entry in pre_tool_use_array {
+        let Some(hooks_array) = entry.get_mut("hooks").and_then(|h| h.as_array_mut()) else {
+            continue;
+        };
+
+        hooks_array.retain(|hook| {
+            let is_match = hook
+                .get("command")
+                .and_then(|c| c.as_str())
+                .is_some_and(|cmd| cmd == hook_command);
+
+            if !is_match {
+                return true;
+            }
+
+            if seen {
+                changed = true;
+                false
+            } else {
+                seen = true;
+                true
+            }
+        });
+    }
+
+    changed
 }
 
 /// Default mode: hook + slim RTK.md + @RTK.md reference
@@ -4030,6 +4656,492 @@ mod tests {
         assert!(plugin_path.exists());
         fs::remove_file(&plugin_path).unwrap();
         assert!(!plugin_path.exists());
+    }
+
+    fn count_exact_command_hooks(root: &serde_json::Value, hook_command: &str) -> usize {
+        root.get("hooks")
+            .and_then(|h| h.get(PRE_TOOL_USE_KEY))
+            .and_then(|p| p.as_array())
+            .into_iter()
+            .flatten()
+            .filter_map(|entry| entry.get("hooks")?.as_array())
+            .flatten()
+            .filter_map(|hook| hook.get("command")?.as_str())
+            .filter(|cmd| *cmd == hook_command)
+            .count()
+    }
+
+    #[test]
+    fn test_codebuddy_settings_path_project_and_global() {
+        let project = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+
+        let project_path =
+            codebuddy_settings_path_from(false, Some(home.path().to_path_buf()), project.path())
+                .unwrap();
+        assert_eq!(
+            project_path,
+            project.path().join(CODEBUDDY_DIR).join(SETTINGS_JSON)
+        );
+
+        let global_path =
+            codebuddy_settings_path_from(true, Some(home.path().to_path_buf()), project.path())
+                .unwrap();
+        assert_eq!(
+            global_path,
+            home.path().join(CODEBUDDY_DIR).join(SETTINGS_JSON)
+        );
+    }
+
+    #[test]
+    fn test_codebuddy_patch_creates_settings_only_and_preserves_local_settings() {
+        let temp = TempDir::new().unwrap();
+        let codebuddy_dir = temp.path().join(CODEBUDDY_DIR);
+        fs::create_dir_all(&codebuddy_dir).unwrap();
+
+        let settings = codebuddy_dir.join(SETTINGS_JSON);
+        let local_settings = codebuddy_dir.join(crate::hooks::constants::SETTINGS_LOCAL_JSON);
+        let local_original = r#"{"doNotTouch": true}"#;
+        fs::write(&local_settings, local_original).unwrap();
+
+        patch_codebuddy_settings_json(&settings, InitContext::default()).unwrap();
+
+        assert!(settings.exists());
+        assert_eq!(fs::read_to_string(&local_settings).unwrap(), local_original);
+        assert!(!temp.path().join(CLAUDE_DIR).join(SETTINGS_JSON).exists());
+        assert!(!temp.path().join(CLAUDE_MD).exists());
+        assert!(!temp.path().join(RTK_MD).exists());
+
+        let root: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&settings).unwrap()).unwrap();
+        let entry = &root["hooks"][PRE_TOOL_USE_KEY][0];
+        assert_eq!(entry["matcher"], "Bash");
+        assert_eq!(entry["hooks"][0]["type"], "command");
+        assert_eq!(entry["hooks"][0]["command"], CODEBUDDY_HOOK_COMMAND);
+    }
+
+    #[test]
+    fn test_codebuddy_patch_preserves_settings_and_uses_bash_matcher() {
+        let temp = TempDir::new().unwrap();
+        let settings = temp.path().join(CODEBUDDY_DIR).join(SETTINGS_JSON);
+        fs::create_dir_all(settings.parent().unwrap()).unwrap();
+        fs::write(
+            &settings,
+            serde_json::to_string_pretty(&serde_json::json!({
+                "model": "preserve-me",
+                "hooks": {
+                    "PostToolUse": [{
+                        "matcher": "Write",
+                        "hooks": [{"type": "command", "command": "after"}]
+                    }]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        patch_codebuddy_settings_json(&settings, InitContext::default()).unwrap();
+
+        let root: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&settings).unwrap()).unwrap();
+        assert_eq!(root["model"], "preserve-me");
+        assert_eq!(
+            root["hooks"]["PostToolUse"][0]["hooks"][0]["command"],
+            "after"
+        );
+        let entry = &root["hooks"][PRE_TOOL_USE_KEY][0];
+        assert_eq!(entry["matcher"], "Bash");
+        assert_eq!(entry["hooks"][0]["type"], "command");
+        assert_eq!(entry["hooks"][0]["command"], CODEBUDDY_HOOK_COMMAND);
+    }
+
+    #[test]
+    fn test_codebuddy_patch_idempotent() {
+        let temp = TempDir::new().unwrap();
+        let settings = temp.path().join(CODEBUDDY_DIR).join(SETTINGS_JSON);
+
+        patch_codebuddy_settings_json(&settings, InitContext::default()).unwrap();
+        patch_codebuddy_settings_json(&settings, InitContext::default()).unwrap();
+
+        let root: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&settings).unwrap()).unwrap();
+        assert_eq!(count_exact_command_hooks(&root, CODEBUDDY_HOOK_COMMAND), 1);
+    }
+
+    #[test]
+    fn test_codebuddy_patch_migrates_legacy_rtk_tx_hook() {
+        let temp = TempDir::new().unwrap();
+        let settings = temp.path().join(CODEBUDDY_DIR).join(SETTINGS_JSON);
+        fs::create_dir_all(settings.parent().unwrap()).unwrap();
+        fs::write(
+            &settings,
+            serde_json::to_string_pretty(&serde_json::json!({
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [{"type": "command", "command": LEGACY_CODEBUDDY_HOOK_COMMAND}]
+                        }
+                    ]
+                },
+                "model": "preserve-me"
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        patch_codebuddy_settings_json(&settings, InitContext::default()).unwrap();
+
+        let root: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&settings).unwrap()).unwrap();
+        assert_eq!(root["model"], "preserve-me");
+        assert_eq!(
+            count_exact_command_hooks(&root, LEGACY_CODEBUDDY_HOOK_COMMAND),
+            0
+        );
+        assert_eq!(count_exact_command_hooks(&root, CODEBUDDY_HOOK_COMMAND), 1);
+    }
+
+    #[test]
+    fn test_codebuddy_patch_existing_settings_does_not_create_backup() {
+        let temp = TempDir::new().unwrap();
+        let settings = temp.path().join(CODEBUDDY_DIR).join(SETTINGS_JSON);
+        fs::create_dir_all(settings.parent().unwrap()).unwrap();
+        fs::write(&settings, r#"{"env":{"KEEP":"yes"}}"#).unwrap();
+
+        patch_codebuddy_settings_json(&settings, InitContext::default()).unwrap();
+
+        assert!(settings.exists());
+        assert!(
+            !settings.with_extension("json.bak").exists(),
+            "CodeBuddy init must not create settings.json.bak"
+        );
+        let root: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&settings).unwrap()).unwrap();
+        assert_eq!(root["env"]["KEEP"], "yes");
+        assert_eq!(count_exact_command_hooks(&root, CODEBUDDY_HOOK_COMMAND), 1);
+    }
+
+    #[test]
+    fn test_codebuddy_patch_malformed_json_preserves_original_bytes() {
+        let temp = TempDir::new().unwrap();
+        let settings = temp.path().join(CODEBUDDY_DIR).join(SETTINGS_JSON);
+        fs::create_dir_all(settings.parent().unwrap()).unwrap();
+        let original = b"{ malformed json\n";
+        fs::write(&settings, original).unwrap();
+
+        let err = patch_codebuddy_settings_json(&settings, InitContext::default()).unwrap_err();
+        assert!(err.to_string().contains("Failed to parse"));
+        assert_eq!(fs::read(&settings).unwrap(), original);
+    }
+
+    #[test]
+    fn test_codebuddy_patch_dedupes_codebuddy_only() {
+        let temp = TempDir::new().unwrap();
+        let settings = temp.path().join(CODEBUDDY_DIR).join(SETTINGS_JSON);
+        fs::create_dir_all(settings.parent().unwrap()).unwrap();
+        fs::write(
+            &settings,
+            serde_json::to_string_pretty(&serde_json::json!({
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [{"type": "command", "command": CODEBUDDY_HOOK_COMMAND}]
+                        },
+                        {
+                            "matcher": "Bash",
+                            "hooks": [{"type": "command", "command": CODEBUDDY_HOOK_COMMAND}]
+                        },
+                        {
+                            "matcher": "Bash",
+                            "hooks": [{"type": "command", "command": CLAUDE_HOOK_COMMAND}]
+                        },
+                        {
+                            "matcher": "Bash",
+                            "hooks": [{"type": "command", "command": "/tmp/rtk-rewrite.sh"}]
+                        }
+                    ]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        patch_codebuddy_settings_json(&settings, InitContext::default()).unwrap();
+
+        let root: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&settings).unwrap()).unwrap();
+        assert_eq!(count_exact_command_hooks(&root, CODEBUDDY_HOOK_COMMAND), 1);
+        assert_eq!(count_exact_command_hooks(&root, CLAUDE_HOOK_COMMAND), 1);
+        assert_eq!(count_exact_command_hooks(&root, "/tmp/rtk-rewrite.sh"), 1);
+    }
+
+    #[test]
+    fn test_codebuddy_patch_no_patch_writes_nothing() {
+        let temp = TempDir::new().unwrap();
+        let settings = temp.path().join(CODEBUDDY_DIR).join(SETTINGS_JSON);
+
+        let result = patch_codebuddy_settings_json_with_mode(
+            &settings,
+            PatchMode::Skip,
+            InitContext::default(),
+        )
+        .unwrap();
+
+        assert_eq!(result, PatchResult::Skipped);
+        assert!(!settings.exists());
+    }
+
+    #[test]
+    fn test_codebuddy_patch_ask_dry_run_writes_nothing() {
+        let temp = TempDir::new().unwrap();
+        let settings = temp.path().join(CODEBUDDY_DIR).join(SETTINGS_JSON);
+        let ctx = InitContext {
+            dry_run: true,
+            ..InitContext::default()
+        };
+
+        let result =
+            patch_codebuddy_settings_json_with_mode(&settings, PatchMode::Ask, ctx).unwrap();
+
+        assert_eq!(result, PatchResult::WouldPatch);
+        assert!(!settings.exists());
+    }
+
+    #[test]
+    fn test_codebuddy_plugin_install_writes_manifest_and_hooks() {
+        let temp = TempDir::new().unwrap();
+        let plugin_dir = temp.path().join(CODEBUDDY_PLUGIN_NAME);
+
+        let result = install_codebuddy_plugin_at(&plugin_dir, InitContext::default()).unwrap();
+        assert_eq!(result, PatchResult::Patched);
+
+        let manifest_path = plugin_dir
+            .join(CODEBUDDY_PLUGIN_MANIFEST_DIR)
+            .join(CODEBUDDY_PLUGIN_MANIFEST_FILE);
+        let hooks_path = plugin_dir.join(HOOKS_SUBDIR).join(HOOKS_JSON);
+
+        let manifest: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&manifest_path).unwrap()).unwrap();
+        assert_eq!(manifest["name"], CODEBUDDY_PLUGIN_NAME);
+        assert_eq!(manifest["version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(manifest["homepage"], "https://github.com/rtk-ai/rtk");
+        assert_eq!(manifest["license"], "Apache-2.0");
+        assert_eq!(manifest["hooks"], "./hooks/hooks.json");
+
+        let hooks: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&hooks_path).unwrap()).unwrap();
+        assert_eq!(hooks["hooks"][PRE_TOOL_USE_KEY][0]["matcher"], "Bash");
+        assert_eq!(
+            hooks["hooks"][PRE_TOOL_USE_KEY][0]["hooks"][0]["command"],
+            CODEBUDDY_HOOK_COMMAND
+        );
+        assert_eq!(
+            hooks["hooks"][PRE_TOOL_USE_KEY][0]["hooks"][0]["timeout"],
+            60
+        );
+
+        let result = install_codebuddy_plugin_at(&plugin_dir, InitContext::default()).unwrap();
+        assert_eq!(result, PatchResult::AlreadyPresent);
+    }
+
+    #[test]
+    fn test_codebuddy_plugin_enable_preserves_settings() {
+        let temp = TempDir::new().unwrap();
+        let settings = temp.path().join(CODEBUDDY_DIR).join(SETTINGS_JSON);
+        fs::create_dir_all(settings.parent().unwrap()).unwrap();
+        fs::write(
+            &settings,
+            serde_json::to_string_pretty(&serde_json::json!({
+                "enabledPlugins": {
+                    "docx@codebuddy-plugins-official": true
+                },
+                "model": "preserve-me"
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let result = enable_codebuddy_plugin(&settings, InitContext::default()).unwrap();
+        assert_eq!(result, PatchResult::Patched);
+
+        let root: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&settings).unwrap()).unwrap();
+        assert_eq!(root["model"], "preserve-me");
+        assert_eq!(
+            root["enabledPlugins"]["docx@codebuddy-plugins-official"],
+            true
+        );
+        assert_eq!(root["enabledPlugins"][CODEBUDDY_PLUGIN_ENABLED_KEY], true);
+    }
+
+    #[test]
+    fn test_codebuddy_plugin_enable_migrates_legacy_rtk_tx_plugin_key() {
+        let temp = TempDir::new().unwrap();
+        let settings = temp.path().join(CODEBUDDY_DIR).join(SETTINGS_JSON);
+        fs::create_dir_all(settings.parent().unwrap()).unwrap();
+        fs::write(
+            &settings,
+            serde_json::to_string_pretty(&serde_json::json!({
+                "enabledPlugins": {
+                    LEGACY_CODEBUDDY_PLUGIN_ENABLED_KEY: true,
+                    "docx@codebuddy-plugins-official": true
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let result = enable_codebuddy_plugin(&settings, InitContext::default()).unwrap();
+        assert_eq!(result, PatchResult::Patched);
+
+        let root: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&settings).unwrap()).unwrap();
+        assert!(root["enabledPlugins"]
+            .get(LEGACY_CODEBUDDY_PLUGIN_ENABLED_KEY)
+            .is_none());
+        assert_eq!(root["enabledPlugins"][CODEBUDDY_PLUGIN_ENABLED_KEY], true);
+        assert_eq!(
+            root["enabledPlugins"]["docx@codebuddy-plugins-official"],
+            true
+        );
+    }
+
+    #[test]
+    fn test_codebuddy_manual_settings_json_includes_plugin_enable_for_global() {
+        let manual = codebuddy_manual_settings_json(true);
+        let root: serde_json::Value = serde_json::from_str(&manual).unwrap();
+
+        assert_eq!(
+            root["hooks"][PRE_TOOL_USE_KEY][0]["hooks"][0]["command"],
+            CODEBUDDY_HOOK_COMMAND
+        );
+        assert_eq!(root["enabledPlugins"][CODEBUDDY_PLUGIN_ENABLED_KEY], true);
+    }
+
+    #[test]
+    fn test_codebuddy_manual_settings_json_omits_plugin_enable_for_project() {
+        let manual = codebuddy_manual_settings_json(false);
+        let root: serde_json::Value = serde_json::from_str(&manual).unwrap();
+
+        assert_eq!(
+            root["hooks"][PRE_TOOL_USE_KEY][0]["hooks"][0]["command"],
+            CODEBUDDY_HOOK_COMMAND
+        );
+        assert!(root.get("enabledPlugins").is_none());
+    }
+
+    #[test]
+    fn test_codebuddy_uninstall_removes_hook_plugin_and_enabled_plugin() {
+        let temp = TempDir::new().unwrap();
+        let settings = temp.path().join(CODEBUDDY_DIR).join(SETTINGS_JSON);
+        let plugin_dir = temp.path().join("plugins").join(CODEBUDDY_PLUGIN_NAME);
+        let legacy_plugin_dir = temp
+            .path()
+            .join("plugins")
+            .join(LEGACY_CODEBUDDY_PLUGIN_NAME);
+        fs::create_dir_all(settings.parent().unwrap()).unwrap();
+        fs::create_dir_all(&plugin_dir).unwrap();
+        fs::create_dir_all(&legacy_plugin_dir).unwrap();
+        fs::write(plugin_dir.join("marker"), "plugin").unwrap();
+        fs::write(legacy_plugin_dir.join("marker"), "legacy plugin").unwrap();
+        fs::write(
+            &settings,
+            serde_json::to_string_pretty(&serde_json::json!({
+                "enabledPlugins": {
+                    CODEBUDDY_PLUGIN_ENABLED_KEY: true,
+                    LEGACY_CODEBUDDY_PLUGIN_ENABLED_KEY: true,
+                    "docx@codebuddy-plugins-official": true
+                },
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [{"type": "command", "command": CODEBUDDY_HOOK_COMMAND}]
+                        },
+                        {
+                            "matcher": "Bash",
+                            "hooks": [{"type": "command", "command": LEGACY_CODEBUDDY_HOOK_COMMAND}]
+                        },
+                        {
+                            "matcher": "Bash",
+                            "hooks": [{"type": "command", "command": "other-tool hook"}]
+                        }
+                    ]
+                },
+                "model": "preserve-me"
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let removed = uninstall_codebuddy_at(
+            &settings,
+            &[plugin_dir.clone(), legacy_plugin_dir.clone()],
+            InitContext::default(),
+        )
+        .unwrap();
+
+        assert_eq!(removed.len(), 4);
+        assert!(!plugin_dir.exists());
+        assert!(!legacy_plugin_dir.exists());
+        let root: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&settings).unwrap()).unwrap();
+        assert_eq!(root["model"], "preserve-me");
+        assert_eq!(
+            root["enabledPlugins"]["docx@codebuddy-plugins-official"],
+            true
+        );
+        assert!(root["enabledPlugins"]
+            .get(CODEBUDDY_PLUGIN_ENABLED_KEY)
+            .is_none());
+        assert!(root["enabledPlugins"]
+            .get(LEGACY_CODEBUDDY_PLUGIN_ENABLED_KEY)
+            .is_none());
+        assert_eq!(count_exact_command_hooks(&root, CODEBUDDY_HOOK_COMMAND), 0);
+        assert_eq!(
+            count_exact_command_hooks(&root, LEGACY_CODEBUDDY_HOOK_COMMAND),
+            0
+        );
+        assert_eq!(count_exact_command_hooks(&root, "other-tool hook"), 1);
+    }
+
+    #[test]
+    fn test_codebuddy_uninstall_prunes_empty_settings_sections() {
+        let temp = TempDir::new().unwrap();
+        let settings = temp.path().join(CODEBUDDY_DIR).join(SETTINGS_JSON);
+        fs::create_dir_all(settings.parent().unwrap()).unwrap();
+        fs::write(
+            &settings,
+            serde_json::to_string_pretty(&serde_json::json!({
+                "enabledPlugins": {
+                    CODEBUDDY_PLUGIN_ENABLED_KEY: true
+                },
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": []
+                        },
+                        {
+                            "matcher": "Bash",
+                            "hooks": [{"type": "command", "command": CODEBUDDY_HOOK_COMMAND}]
+                        }
+                    ]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let removed = uninstall_codebuddy_at(&settings, &[], InitContext::default()).unwrap();
+        assert_eq!(removed.len(), 2);
+
+        let root: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&settings).unwrap()).unwrap();
+        assert!(root.get("hooks").is_none());
+        assert!(root.get("enabledPlugins").is_none());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,8 @@ pub enum AgentTarget {
     Antigravity,
     /// Pi coding agent
     Pi,
+    /// CodeBuddy Code (CLI and App/IDE plugin)
+    Codebuddy,
     /// Hermes CLI
     Hermes,
 }
@@ -775,6 +777,8 @@ enum HookCommands {
     Gemini,
     /// Process Copilot preToolUse hook (VS Code + Copilot CLI, reads JSON from stdin)
     Copilot,
+    /// Process CodeBuddy PreToolUse hook (reads JSON from stdin)
+    Codebuddy,
     /// Check how a command would be rewritten by the hook engine (dry-run)
     Check {
         /// Target agent
@@ -1366,25 +1370,33 @@ fn main() {
     std::process::exit(code);
 }
 
-fn uninstall_init_dispatch<UninstallHermes, UninstallStandard>(
+struct UninstallDispatchHandlers<UninstallHermes, UninstallCodebuddy, UninstallStandard> {
+    hermes: UninstallHermes,
+    codebuddy: UninstallCodebuddy,
+    standard: UninstallStandard,
+}
+
+fn uninstall_init_dispatch<UninstallHermes, UninstallCodebuddy, UninstallStandard>(
     agent: Option<AgentTarget>,
     global: bool,
     gemini: bool,
     codex: bool,
     ctx: hooks::init::InitContext,
-    uninstall_hermes: UninstallHermes,
-    uninstall_standard: UninstallStandard,
+    handlers: UninstallDispatchHandlers<UninstallHermes, UninstallCodebuddy, UninstallStandard>,
 ) -> Result<()>
 where
     UninstallHermes: FnOnce(hooks::init::InitContext) -> Result<()>,
+    UninstallCodebuddy: FnOnce(bool, hooks::init::InitContext) -> Result<()>,
     UninstallStandard: FnOnce(bool, bool, bool, bool, bool, hooks::init::InitContext) -> Result<()>,
 {
     if agent == Some(AgentTarget::Hermes) {
-        uninstall_hermes(ctx)
+        (handlers.hermes)(ctx)
+    } else if agent == Some(AgentTarget::Codebuddy) {
+        (handlers.codebuddy)(global, ctx)
     } else {
         let cursor = agent == Some(AgentTarget::Cursor);
         let pi = agent == Some(AgentTarget::Pi);
-        uninstall_standard(global, gemini, codex, cursor, pi, ctx)
+        (handlers.standard)(global, gemini, codex, cursor, pi, ctx)
     }
 }
 
@@ -1828,8 +1840,11 @@ fn run_cli() -> Result<i32> {
                     gemini,
                     codex,
                     ctx,
-                    hooks::init::uninstall_hermes,
-                    hooks::init::uninstall,
+                    UninstallDispatchHandlers {
+                        hermes: hooks::init::uninstall_hermes,
+                        codebuddy: hooks::init::uninstall_codebuddy,
+                        standard: hooks::init::uninstall,
+                    },
                 )?;
             } else if gemini {
                 let patch_mode = if auto_patch {
@@ -1842,6 +1857,15 @@ fn run_cli() -> Result<i32> {
                 hooks::init::run_gemini(global, hook_only, patch_mode, ctx)?;
             } else if copilot {
                 hooks::init::run_copilot(ctx)?;
+            } else if agent == Some(AgentTarget::Codebuddy) {
+                let patch_mode = if auto_patch {
+                    hooks::init::PatchMode::Auto
+                } else if no_patch {
+                    hooks::init::PatchMode::Skip
+                } else {
+                    hooks::init::PatchMode::Ask
+                };
+                hooks::init::run_codebuddy(global, patch_mode, ctx)?;
             } else if agent == Some(AgentTarget::Pi) {
                 hooks::init::run_pi_mode(global, ctx)?
             } else if agent == Some(AgentTarget::Kilocode) {
@@ -2189,6 +2213,10 @@ fn run_cli() -> Result<i32> {
             }
             HookCommands::Copilot => {
                 hooks::hook_cmd::run_copilot()?;
+                0
+            }
+            HookCommands::Codebuddy => {
+                hooks::hook_cmd::run_codebuddy()?;
                 0
             }
             HookCommands::Check { agent: _, command } => {
@@ -2663,6 +2691,17 @@ mod tests {
     }
 
     #[test]
+    fn test_try_parse_init_agent_codebuddy() {
+        let cli = Cli::try_parse_from(["rtk", "init", "--agent", "codebuddy"]).unwrap();
+        match cli.command {
+            Commands::Init { agent, .. } => {
+                assert_eq!(agent, Some(AgentTarget::Codebuddy));
+            }
+            _ => panic!("Expected Init command"),
+        }
+    }
+
+    #[test]
     fn test_try_parse_kubectl_get_alias() {
         let cli = Cli::try_parse_from(["rtk", "kubectl", "get", "pods", "-n", "default"]).unwrap();
 
@@ -2689,8 +2728,24 @@ mod tests {
     }
 
     #[test]
+    fn test_try_parse_init_agent_codebuddy_uninstall() {
+        let cli =
+            Cli::try_parse_from(["rtk", "init", "--agent", "codebuddy", "--uninstall"]).unwrap();
+        match cli.command {
+            Commands::Init {
+                agent, uninstall, ..
+            } => {
+                assert_eq!(agent, Some(AgentTarget::Codebuddy));
+                assert!(uninstall);
+            }
+            _ => panic!("Expected Init command"),
+        }
+    }
+
+    #[test]
     fn test_init_uninstall_dispatch_routes_hermes_to_hermes_cleanup() {
         let hermes_called = Cell::new(false);
+        let codebuddy_called = Cell::new(false);
         let standard_called = Cell::new(false);
         let ctx = hooks::init::InitContext {
             verbose: 2,
@@ -2703,20 +2758,68 @@ mod tests {
             false,
             false,
             ctx,
-            |ctx| {
-                hermes_called.set(true);
-                assert_eq!(ctx.verbose, 2);
-                assert!(ctx.dry_run);
-                Ok(())
-            },
-            |_, _, _, _, _, _| {
-                standard_called.set(true);
-                Ok(())
+            UninstallDispatchHandlers {
+                hermes: |ctx: hooks::init::InitContext| {
+                    hermes_called.set(true);
+                    assert_eq!(ctx.verbose, 2);
+                    assert!(ctx.dry_run);
+                    Ok(())
+                },
+                codebuddy: |_: bool, _: hooks::init::InitContext| {
+                    codebuddy_called.set(true);
+                    Ok(())
+                },
+                standard: |_, _, _, _, _, _| {
+                    standard_called.set(true);
+                    Ok(())
+                },
             },
         );
 
         assert!(result.is_ok());
         assert!(hermes_called.get());
+        assert!(!codebuddy_called.get());
+        assert!(!standard_called.get());
+    }
+
+    #[test]
+    fn test_init_uninstall_dispatch_routes_codebuddy_to_codebuddy_cleanup() {
+        let hermes_called = Cell::new(false);
+        let codebuddy_called = Cell::new(false);
+        let standard_called = Cell::new(false);
+        let ctx = hooks::init::InitContext {
+            verbose: 1,
+            dry_run: true,
+        };
+
+        let result = uninstall_init_dispatch(
+            Some(AgentTarget::Codebuddy),
+            true,
+            false,
+            false,
+            ctx,
+            UninstallDispatchHandlers {
+                hermes: |_: hooks::init::InitContext| {
+                    hermes_called.set(true);
+                    Ok(())
+                },
+                codebuddy: |global: bool, ctx: hooks::init::InitContext| {
+                    codebuddy_called.set(true);
+                    assert!(global);
+                    assert_eq!(ctx.verbose, 1);
+                    assert!(ctx.dry_run);
+                    Ok(())
+                },
+                standard: |_, _, _, _, _, _| {
+                    standard_called.set(true);
+                    Ok(())
+                },
+            },
+        );
+
+        assert!(result.is_ok());
+        assert!(!hermes_called.get());
+        assert!(codebuddy_called.get());
         assert!(!standard_called.get());
     }
 
@@ -2836,6 +2939,17 @@ mod tests {
             cli.command,
             Commands::Hook {
                 command: HookCommands::Claude
+            }
+        ));
+    }
+
+    #[test]
+    fn test_hook_codebuddy_parses() {
+        let cli = Cli::try_parse_from(["rtk", "hook", "codebuddy"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Hook {
+                command: HookCommands::Codebuddy
             }
         ));
     }


### PR DESCRIPTION
## Summary

- Adds first-class CodeBuddy Code support via `rtk hook codebuddy` and `rtk init --agent codebuddy`.
- Supports both project-local `.codebuddy/settings.json` hooks and the global CodeBuddy App/IDE marketplace plugin path.
- Adds clean install/uninstall behavior with docs and tests.

## Why

This is an expanded implementation for #1966. It covers the CLI/settings hook path plus the CodeBuddy App/IDE plugin install path, including `enabledPlugins` handling. Related PR #1967 covers a smaller global settings integration; this PR is intended as the complete CodeBuddy agent support surface.

## Changes

- Adds CodeBuddy CLI dispatch for `rtk hook codebuddy`, `rtk init --agent codebuddy`, and uninstall handling.
- Reuses the Claude-compatible `PreToolUse` command rewriting flow while leaving permission approval to the CodeBuddy host.
- Adds project/global settings patching, dry-run/manual patch output, plugin manifest and hook generation, idempotent install behavior, and uninstall cleanup.
- Updates README, hook documentation, and the supported agents guide for CodeBuddy.

## Review Guide

Start with `src/hooks/init.rs` for install, plugin, and uninstall behavior. Then check `src/hooks/hook_cmd.rs` for the hook protocol output and `src/main.rs` for CLI dispatch. The docs changes mirror the new user-facing commands and can be reviewed after the behavior.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo test codebuddy`
- [x] `cargo test --all`
- [x] `cargo clippy --all-targets`
- [x] Manual temporary-HOME install/uninstall check for `rtk init -g --agent codebuddy`, including plugin files, `enabledPlugins`, idempotent reinstall, and cleanup of generated config.

## Risk

Risk level: Medium.

Potential impact is localized to CodeBuddy config generation and CodeBuddy hook output. Existing agent integrations and telemetry paths are not changed.

Rollback plan: revert this commit.

## Linked Issues

Closes #1966

Related: #1967
