### PR TITLE
feat(init): add PowerShell hook for Claude Code on Windows

### DIFF
--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -500,12 +500,20 @@ fn prompt_telemetry_consent() -> Result<()> {
 fn print_manual_instructions(hook_command: &str, include_opencode: bool) {
     println!("\n  MANUAL STEP: Add this to ~/.claude/settings.json:");
     println!("  {{");
-    println!("    \"hooks\": {{ \"PreToolUse\": [{{");
-    println!("      \"matcher\": \"Bash\",");
-    println!("      \"hooks\": [{{ \"type\": \"command\",");
-    println!("        \"command\": \"{}\"", hook_command);
-    println!("      }}]");
-    println!("    }}]}}");
+    println!("    \"hooks\": {{ \"PreToolUse\": [");
+    println!("      {{");
+    println!("        \"matcher\": \"Bash\",");
+    println!("        \"hooks\": [{{ \"type\": \"command\",");
+    println!("          \"command\": \"{}\"", hook_command);
+    println!("        }}]");
+    println!("      }},");
+    println!("      {{");
+    println!("        \"matcher\": \"PowerShell\",");
+    println!("        \"hooks\": [{{ \"type\": \"command\",");
+    println!("          \"command\": \"{}\"", hook_command);
+    println!("        }}]");
+    println!("      }}");
+    println!("    ]}}");
     println!("  }}");
     if include_opencode {
         println!("\n  Then restart Claude Code and OpenCode. Test with: git status\n");
@@ -1074,6 +1082,13 @@ fn insert_hook_entry(root: &mut serde_json::Value, hook_command: &str) -> Result
 
     pre_tool_use.push(serde_json::json!({
         "matcher": "Bash",
+        "hooks": [{
+            "type": "command",
+            "command": hook_command
+        }]
+    }));
+    pre_tool_use.push(serde_json::json!({
+        "matcher": "PowerShell",
         "hooks": [{
             "type": "command",
             "command": hook_command
@@ -5064,10 +5079,17 @@ mod tests {
             .is_some());
 
         let pre_tool_use = json_content["hooks"]["PreToolUse"].as_array().unwrap();
-        assert_eq!(pre_tool_use.len(), 1);
+        assert_eq!(pre_tool_use.len(), 2);
 
-        let command = pre_tool_use[0]["hooks"][0]["command"].as_str().unwrap();
-        assert_eq!(command, hook_command);
+        let bash_matcher = pre_tool_use[0]["matcher"].as_str().unwrap();
+        assert_eq!(bash_matcher, "Bash");
+        let bash_command = pre_tool_use[0]["hooks"][0]["command"].as_str().unwrap();
+        assert_eq!(bash_command, hook_command);
+
+        let ps_matcher = pre_tool_use[1]["matcher"].as_str().unwrap();
+        assert_eq!(ps_matcher, "PowerShell");
+        let ps_command = pre_tool_use[1]["hooks"][0]["command"].as_str().unwrap();
+        assert_eq!(ps_command, hook_command);
     }
 
     #[test]
@@ -5088,15 +5110,23 @@ mod tests {
         insert_hook_entry(&mut json_content, hook_command).unwrap();
 
         let pre_tool_use = json_content["hooks"]["PreToolUse"].as_array().unwrap();
-        assert_eq!(pre_tool_use.len(), 2); // Should have both hooks
+        assert_eq!(pre_tool_use.len(), 3); // Should have existing + Bash + PowerShell
 
         // Check first hook is preserved
         let first_command = pre_tool_use[0]["hooks"][0]["command"].as_str().unwrap();
         assert_eq!(first_command, "/some/other/hook.sh");
 
-        // Check second hook is RTK
+        // Check Bash RTK hook
+        let bash_matcher = pre_tool_use[1]["matcher"].as_str().unwrap();
+        assert_eq!(bash_matcher, "Bash");
         let second_command = pre_tool_use[1]["hooks"][0]["command"].as_str().unwrap();
         assert_eq!(second_command, hook_command);
+
+        // Check PowerShell RTK hook
+        let ps_matcher = pre_tool_use[2]["matcher"].as_str().unwrap();
+        assert_eq!(ps_matcher, "PowerShell");
+        let third_command = pre_tool_use[2]["hooks"][0]["command"].as_str().unwrap();
+        assert_eq!(third_command, hook_command);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

On Windows, Claude Code routes most shell invocations through its **PowerShell** tool rather than the **Bash** tool. The existing `rtk init -g` only registers a `PreToolUse` hook with `"matcher": "Bash"`, so Windows users get **zero automatic rewriting** for the majority of their shell calls.

## Solution

Register **both** matchers when patching `settings.json`:

```json
{ "matcher": "Bash",       "hooks": [{ "type": "command", "command": "rtk hook claude" }] }
{ "matcher": "PowerShell", "hooks": [{ "type": "command", "command": "rtk hook claude" }] }
```

The `rtk hook claude` handler already reads the tool-input JSON from stdin and pattern-matches on the `command` field — it doesn't inspect `tool_name` — so no changes to the hook runtime are required.

### Verified locally

```powershell
# Simulates the JSON Claude Code sends for a PowerShell tool call
echo '{"tool_name":"PowerShell","tool_input":{"command":"git status"}}' | rtk hook claude
# → {"hookSpecificOutput":{"updatedInput":{"command":"rtk git status"},"permissionDecision":"allow",...}}
```

Commands that RTK doesn't recognise (e.g. `Get-Process`) pass through with exit 0 and no output — unchanged behaviour.

## Changes

- **`insert_hook_entry()`** — pushes a second entry with `"matcher": "PowerShell"` after the existing `"Bash"` one
- **`print_manual_instructions()`** — shows both matchers in the manual-step output so users who decline auto-patch know to add both
- **Tests** — updated `test_insert_hook_entry_empty_root` and `test_insert_hook_entry_preserves_existing` to assert the new array lengths and verify both matchers are present

## Impact

- macOS / Linux: no behaviour change (both matchers are registered but Claude Code only fires the Bash one)
- Windows (native): full automatic rewriting now works for PowerShell tool calls
- Uninstall (`--uninstall`): `remove_hook_from_json` matches on command value, not matcher — both entries are removed correctly with no changes needed