### PR TITLE
fix: remove yadm from git rewrite rules

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -869,12 +869,7 @@ mod tests {
     fn test_classify_yadm_status() {
         assert_eq!(
             classify_command("yadm status"),
-            Classification::Supported {
-                rtk_equivalent: "rtk git",
-                category: "Git",
-                estimated_savings_pct: 70.0,
-                status: RtkStatus::Existing,
-            }
+            Classification::Unsupported
         );
     }
 
@@ -882,12 +877,7 @@ mod tests {
     fn test_classify_yadm_diff() {
         assert_eq!(
             classify_command("yadm diff"),
-            Classification::Supported {
-                rtk_equivalent: "rtk git",
-                category: "Git",
-                estimated_savings_pct: 80.0,
-                status: RtkStatus::Existing,
-            }
+            Classification::Unsupported
         );
     }
 
@@ -895,7 +885,7 @@ mod tests {
     fn test_rewrite_yadm_status() {
         assert_eq!(
             rewrite_command_no_prefixes("yadm status", &[]),
-            Some("rtk git status".to_string())
+            None
         );
     }
 

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -12,9 +12,9 @@ pub struct RtkRule {
 
 pub const RULES: &[RtkRule] = &[
     RtkRule {
-        pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|push|pull|branch|fetch|stash|worktree)",
+        pattern: r"^git\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|push|pull|branch|fetch|stash|worktree)",
         rtk_cmd: "rtk git",
-        rewrite_prefixes: &["git", "yadm"],
+        rewrite_prefixes: &["git"],
         category: "Git",
         savings_pct: 70.0,
         subcmd_savings: &[


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Problem

`rtk rewrite "yadm status"` outputs `rtk git status`, which fails because `yadm` is **not** a git alias.

[yadm](https://yadm.io/) is a dotfile manager that wraps git with a separate bare repository (`~/.local/share/yadm/repo.git`) and `--work-tree=$HOME`). Running `rtk git status` in an arbitrary CWD fails with "Not a git repository" since there's no `.git` in the working directory — yadm manages this transparently.

## Fix

- Remove `yadm` from the regex pattern in the first git rule (`rules.rs`)
- Remove `"yadm"` from `rewrite_prefixes`
- Update tests to expect `Classification::Unsupported` and `None` for yadm commands

The existing `src/filters/yadm.toml` (output filtering) is preserved — it only applies when users explicitly pipe yadm output through rtk.

Closes #2077
