### PR TITLE
feat: Rust filter for pre-commit/prek -- compact hook output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ For the full architecture, component details, and module development patterns, s
 
 Module responsibilities are documented in each folder's `README.md` and each file's `//!` doc header. Browse `src/cmds/*/` to discover available filters.
 
-Supported ecosystems: git/gh/gt, cargo, go/golangci-lint, npm/pnpm/npx, ruff/pytest/pip/mypy, rspec/rubocop/rake, dotnet, playwright/vitest/jest, docker/kubectl/aws.
+Supported ecosystems: git/gh/gt, cargo, go/golangci-lint, npm/pnpm/npx, ruff/pytest/pip/mypy/pre-commit/prek, rspec/rubocop/rake, dotnet, playwright/vitest/jest, docker/kubectl/aws.
 
 ### Proxy Mode
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ rtk prettier --check .          # Files needing formatting
 rtk cargo build                 # Cargo build (-80%)
 rtk cargo clippy                # Cargo clippy (-80%)
 rtk ruff check                  # Python linting (JSON, -80%)
+rtk pre-commit                  # Hook output compacted (no dots, -65%)
+rtk prek                        # Same as pre-commit (-65%)
 rtk golangci-lint run           # Go linting (JSON, -85%)
 rtk rubocop                     # Ruby linting (JSON, -60%+)
 ```

--- a/docs/guide/resources/what-rtk-covers.md
+++ b/docs/guide/resources/what-rtk-covers.md
@@ -69,6 +69,7 @@ Typical savings: 60-99%.
 | `ruff check` | 75% | Violations grouped by file |
 | `mypy` | 75% | Type errors grouped by file |
 | `pip install` | 70% | Installed packages only, progress stripped |
+| `pre-commit run` / `prek run` | 65% | Dots removed, compact hook status, errors in full |
 
 ## Go
 

--- a/src/cmds/README.md
+++ b/src/cmds/README.md
@@ -28,7 +28,7 @@ Each subdirectory has its own README with file descriptions, parsing strategies,
 - **[`git/`](git/README.md)** — git, gh, gt, diff — `trailing_var_arg` parsing, gh markdown filtering, gt passthrough
 - **[`rust/`](rust/README.md)** — cargo, runner (err/test) — Cargo sub-enum routing, runner dual-mode
 - **[`js/`](js/README.md)** — npm, pnpm, vitest, lint, tsc, next, prettier, playwright, prisma — Package manager auto-detection, lint routing, cross-deps with python
-- **[`python/`](python/README.md)** — ruff, pytest, mypy, pip — JSON check vs text format, state machine parsing, uv auto-detection
+- **[`python/`](python/README.md)** — ruff, pytest, mypy, pip, pre-commit, prek — JSON check vs text format, state machine parsing, uv auto-detection, hook output compacting
 - **[`go/`](go/README.md)** — go test/build/vet, golangci-lint — NDJSON streaming, Go sub-enum pattern
 - **[`dotnet/`](dotnet/README.md)** — dotnet, binlog, trx, format_report — DotnetCommands sub-enum, internal helper modules
 - **[`cloud/`](cloud/README.md)** — aws, docker/kubectl, curl, wget, psql — Docker/Kubectl sub-enums, JSON forced output

--- a/src/cmds/python/README.md
+++ b/src/cmds/python/README.md
@@ -7,6 +7,7 @@
 - `pytest_cmd.rs` uses a state machine text parser (no JSON available from pytest)
 - `ruff_cmd.rs` uses JSON for check mode (`--output-format=json`) and text filtering for format mode
 - `pip_cmd.rs` auto-detects `uv` as a pip alternative and routes accordingly
+- `pre_commit_cmd.rs` filters pre-commit/prek output: removes `...` separators, uses `[Status]` brackets, shows hook-id + full error on failures
 - `python -m pytest` and `python3 -m mypy` are rewritten by the hook registry to `rtk pytest` / `rtk mypy`
 
 ## Cross-command

--- a/src/cmds/python/pre_commit_cmd.rs
+++ b/src/cmds/python/pre_commit_cmd.rs
@@ -192,4 +192,38 @@ file.py:2:3: import not sorted";
         let result = filter_pre_commit_output(output);
         assert_eq!(result, "pre-commit checks completed");
     }
+
+    #[test]
+    fn test_real_all_pass_output() {
+        let output = "\
+Trim trailing whitespace.................................................Passed
+fix end of files.........................................................Passed
+check yaml...............................................................Passed
+check toml...............................................................Passed
+check json...............................................................Passed
+check for added large files..............................................Passed
+check for merge conflicts................................................Passed
+debug statements (python)................................................Passed
+detect private key.......................................................Passed
+mixed line ending........................................................Passed
+ruff (lint + fix)........................................................Passed
+ruff (format)............................................................Passed
+pyrefly (type check).....................................................Passed";
+        let result = filter_pre_commit_output(output);
+        let expected = "\
+Trim trailing whitespace Passed
+fix end of files Passed
+check yaml Passed
+check toml Passed
+check json Passed
+check for added large files Passed
+check for merge conflicts Passed
+debug statements (python) Passed
+detect private key Passed
+mixed line ending Passed
+ruff (lint + fix) Passed
+ruff (format) Passed
+pyrefly (type check) Passed";
+        assert_eq!(result, expected);
+    }
 }

--- a/src/cmds/python/pre_commit_cmd.rs
+++ b/src/cmds/python/pre_commit_cmd.rs
@@ -1,6 +1,3 @@
-//! Filters pre-commit output, removing dots between hook names and status.
-//! Success/skipped hooks show one line; failures show hook-id + full error.
-
 use crate::core::runner;
 use crate::core::utils::resolved_command;
 use anyhow::Result;
@@ -22,7 +19,6 @@ fn run_with_tool(tool: &str, args: &[String], verbose: u8) -> Result<i32> {
         eprintln!("Running: {} {}", tool, display);
     }
 
-    // Only apply the hook filter for `run` subcommand (install, autoupdate, etc. passthrough)
     if args.first().map(|a| a == "run").unwrap_or(false) {
         let mut cmd = resolved_command(tool);
         for arg in args {

--- a/src/cmds/python/pre_commit_cmd.rs
+++ b/src/cmds/python/pre_commit_cmd.rs
@@ -8,22 +8,30 @@ use anyhow::Result;
 const HOOK_STATUSES: [&str; 4] = ["Passed", "Failed", "Skipped", "Ignored"];
 
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
-    let mut cmd = resolved_command("pre-commit");
+    run_with_tool("pre-commit", args, verbose)
+}
+
+pub fn run_prek(args: &[String], verbose: u8) -> Result<i32> {
+    run_with_tool("prek", args, verbose)
+}
+
+fn run_with_tool(tool: &str, args: &[String], verbose: u8) -> Result<i32> {
+    let mut cmd = resolved_command(tool);
 
     for arg in args {
         cmd.arg(arg);
     }
 
     if verbose > 0 {
-        eprintln!("Running: pre-commit {}", args.join(" "));
+        eprintln!("Running: {} {}", tool, args.join(" "));
     }
 
     runner::run_filtered(
         cmd,
-        "pre-commit",
+        tool,
         &args.join(" "),
         filter_pre_commit_output,
-        runner::RunOptions::stdout_only().tee("pre-commit"),
+        runner::RunOptions::stdout_only().tee(tool),
     )
 }
 

--- a/src/cmds/python/pre_commit_cmd.rs
+++ b/src/cmds/python/pre_commit_cmd.rs
@@ -5,35 +5,28 @@ use anyhow::Result;
 const HOOK_STATUSES: [&str; 4] = ["Passed", "Failed", "Skipped", "Ignored"];
 
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
-    run_with_tool("pre-commit", args, verbose)
-}
-
-pub fn run_prek(args: &[String], verbose: u8) -> Result<i32> {
-    run_with_tool("prek", args, verbose)
-}
-
-fn run_with_tool(tool: &str, args: &[String], verbose: u8) -> Result<i32> {
     let display = args.join(" ");
 
     if verbose > 0 {
-        eprintln!("Running: {} {}", tool, display);
+        eprintln!("Running: pre-commit {}", display);
     }
 
     if args.first().map(|a| a == "run").unwrap_or(false) {
-        let mut cmd = resolved_command(tool);
+        let mut cmd = resolved_command("pre-commit");
         for arg in args {
             cmd.arg(arg);
         }
         runner::run_filtered(
             cmd,
-            tool,
+            "pre-commit",
             &display,
             filter_pre_commit_output,
-            runner::RunOptions::stdout_only().tee(tool),
+            runner::RunOptions::stdout_only().tee("pre-commit"),
         )
     } else {
-        let os_args: Vec<std::ffi::OsString> = args.iter().map(std::ffi::OsString::from).collect();
-        runner::run_passthrough(tool, &os_args, verbose)
+        let os_args: Vec<std::ffi::OsString> =
+            args.iter().map(std::ffi::OsString::from).collect();
+        runner::run_passthrough("pre-commit", &os_args, verbose)
     }
 }
 

--- a/src/cmds/python/pre_commit_cmd.rs
+++ b/src/cmds/python/pre_commit_cmd.rs
@@ -240,4 +240,58 @@ ruff (format) Skipped
 pyrefly (type check) Skipped";
         assert_eq!(result, expected);
     }
+
+    #[test]
+    fn test_mixed_output_with_hook_modifications() {
+        let output = "\
+trim trailing whitespace.................................................Failed
+- hook id: trailing-whitespace
+- exit code: 1
+- files were modified by this hook
+
+Fixing CLAUDE.md
+
+fix end of files.........................................................Passed
+check yaml...........................................(no files to check)Skipped
+check toml...........................................(no files to check)Skipped
+check json...........................................(no files to check)Skipped
+check for added large files..............................................Passed
+check for merge conflicts................................................Passed
+debug statements (python)................................................Passed
+detect private key.......................................................Passed
+mixed line ending........................................................Passed
+ruff (lint + fix)........................................................Failed
+- hook id: ruff
+- files were modified by this hook
+
+Found 1 error (1 fixed, 0 remaining).
+
+ruff (format)............................................................Failed
+- hook id: ruff-format
+- files were modified by this hook ";
+        let result = filter_pre_commit_output(output);
+        let expected = "\
+trailing-whitespace Failed
+- files were modified by this hook
+
+Fixing CLAUDE.md
+
+fix end of files Passed
+check yaml Skipped
+check toml Skipped
+check json Skipped
+check for added large files Passed
+check for merge conflicts Passed
+debug statements (python) Passed
+detect private key Passed
+mixed line ending Passed
+ruff Failed
+- files were modified by this hook
+
+Found 1 error (1 fixed, 0 remaining).
+
+ruff-format Failed
+- files were modified by this hook ";
+        assert_eq!(result, expected);
+    }
 }

--- a/src/cmds/python/pre_commit_cmd.rs
+++ b/src/cmds/python/pre_commit_cmd.rs
@@ -75,7 +75,7 @@ pub(crate) fn filter_pre_commit_output(output: &str) -> String {
                     }
 
                     let id = hook_id.unwrap_or(name);
-                    let mut failure = format!("{} Failed", id);
+                    let mut failure = format!("{} [Failed]", id);
                     if !linter_output.is_empty() {
                         failure.push('\n');
                         failure.push_str(&linter_output.join("\n"));
@@ -83,7 +83,7 @@ pub(crate) fn filter_pre_commit_output(output: &str) -> String {
                     result.push(failure);
                 }
                 _ => {
-                    result.push(format!("{} {}", name, status));
+                    result.push(format!("{} [{}]", name, status));
                 }
             }
         } else {
@@ -119,7 +119,7 @@ Fix End of Files.........................................................Passed"
         let result = filter_pre_commit_output(output);
         assert_eq!(
             result,
-            "Trim Trailing Whitespace Passed\nFix End of Files Passed"
+            "Trim Trailing Whitespace [Passed]\nFix End of Files [Passed]"
         );
     }
 
@@ -135,7 +135,7 @@ Fix End of Files.........................................................Passed"
         let result = filter_pre_commit_output(output);
         assert_eq!(
             result,
-            "Trim Trailing Whitespace Passed\ncheck-yaml Failed\n.yaml-lint:13:1: expected a mapping\nFix End of Files Passed"
+            "Trim Trailing Whitespace [Passed]\ncheck-yaml [Failed]\n.yaml-lint:13:1: expected a mapping\nFix End of Files [Passed]"
         );
     }
 
@@ -147,7 +147,7 @@ Fix End of Files.........................................................Passed"
 isort....................................................................Passed
 black....................................................................Passed";
         let result = filter_pre_commit_output(output);
-        assert_eq!(result, "isort Passed\nblack Passed");
+        assert_eq!(result, "isort [Passed]\nblack [Passed]");
     }
 
     #[test]
@@ -157,7 +157,7 @@ Check Yaml...............................................................Failed
 - hook id: check-yaml
 - exit code: 1";
         let result = filter_pre_commit_output(output);
-        assert_eq!(result, "check-yaml Failed");
+        assert_eq!(result, "check-yaml [Failed]");
     }
 
     #[test]
@@ -165,7 +165,7 @@ Check Yaml...............................................................Failed
         let output =
             "check-ast................................................................Skipped";
         let result = filter_pre_commit_output(output);
-        assert_eq!(result, "check-ast Skipped");
+        assert_eq!(result, "check-ast [Skipped]");
     }
 
     #[test]
@@ -182,7 +182,7 @@ file.py:2:3: import not sorted";
         let result = filter_pre_commit_output(output);
         assert_eq!(
             result,
-            "black Failed\nfile.py:1:1: black would reformat\nisort Failed\nfile.py:2:3: import not sorted"
+            "black [Failed]\nfile.py:1:1: black would reformat\nisort [Failed]\nfile.py:2:3: import not sorted"
         );
     }
 
@@ -211,19 +211,19 @@ ruff (format)............................................................Passed
 pyrefly (type check).....................................................Passed";
         let result = filter_pre_commit_output(output);
         let expected = "\
-Trim trailing whitespace Passed
-fix end of files Passed
-check yaml Passed
-check toml Passed
-check json Passed
-check for added large files Passed
-check for merge conflicts Passed
-debug statements (python) Passed
-detect private key Passed
-mixed line ending Passed
-ruff (lint + fix) Passed
-ruff (format) Passed
-pyrefly (type check) Passed";
+Trim trailing whitespace [Passed]
+fix end of files [Passed]
+check yaml [Passed]
+check toml [Passed]
+check json [Passed]
+check for added large files [Passed]
+check for merge conflicts [Passed]
+debug statements (python) [Passed]
+detect private key [Passed]
+mixed line ending [Passed]
+ruff (lint + fix) [Passed]
+ruff (format) [Passed]
+pyrefly (type check) [Passed]";
         assert_eq!(result, expected);
     }
 
@@ -235,9 +235,9 @@ ruff (format)........................................(no files to check)Skipped
 pyrefly (type check).................................(no files to check)Skipped";
         let result = filter_pre_commit_output(output);
         let expected = "\
-ruff (lint + fix) Skipped
-ruff (format) Skipped
-pyrefly (type check) Skipped";
+ruff (lint + fix) [Skipped]
+ruff (format) [Skipped]
+pyrefly (type check) [Skipped]";
         assert_eq!(result, expected);
     }
 
@@ -271,26 +271,26 @@ ruff (format)............................................................Failed
 - files were modified by this hook ";
         let result = filter_pre_commit_output(output);
         let expected = "\
-trailing-whitespace Failed
+trailing-whitespace [Failed]
 - files were modified by this hook
 
 Fixing CLAUDE.md
 
-fix end of files Passed
-check yaml Skipped
-check toml Skipped
-check json Skipped
-check for added large files Passed
-check for merge conflicts Passed
-debug statements (python) Passed
-detect private key Passed
-mixed line ending Passed
-ruff Failed
+fix end of files [Passed]
+check yaml [Skipped]
+check toml [Skipped]
+check json [Skipped]
+check for added large files [Passed]
+check for merge conflicts [Passed]
+debug statements (python) [Passed]
+detect private key [Passed]
+mixed line ending [Passed]
+ruff [Failed]
 - files were modified by this hook
 
 Found 1 error (1 fixed, 0 remaining).
 
-ruff-format Failed
+ruff-format [Failed]
 - files were modified by this hook ";
         assert_eq!(result, expected);
     }

--- a/src/cmds/python/pre_commit_cmd.rs
+++ b/src/cmds/python/pre_commit_cmd.rs
@@ -96,12 +96,12 @@ pub(crate) fn filter_pre_commit_output(output: &str) -> String {
 }
 
 fn parse_hook_line(line: &str) -> Option<(&str, &str)> {
+    let dot_pos = line.find("...")?;
+    let name = line[..dot_pos].trim_end();
+    let tail = line[dot_pos..].trim_start_matches('.');
     for status in &HOOK_STATUSES {
-        if let Some(rest) = line.strip_suffix(status) {
-            let trimmed = rest.trim_end_matches('.');
-            if trimmed.len() < rest.len() {
-                return Some((trimmed.trim_end(), *status));
-            }
+        if tail.ends_with(status) {
+            return Some((name, *status));
         }
     }
     None
@@ -224,6 +224,20 @@ mixed line ending Passed
 ruff (lint + fix) Passed
 ruff (format) Passed
 pyrefly (type check) Passed";
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_skipped_with_reason() {
+        let output = "\
+ruff (lint + fix)....................................(no files to check)Skipped
+ruff (format)........................................(no files to check)Skipped
+pyrefly (type check).................................(no files to check)Skipped";
+        let result = filter_pre_commit_output(output);
+        let expected = "\
+ruff (lint + fix) Skipped
+ruff (format) Skipped
+pyrefly (type check) Skipped";
         assert_eq!(result, expected);
     }
 }

--- a/src/cmds/python/pre_commit_cmd.rs
+++ b/src/cmds/python/pre_commit_cmd.rs
@@ -16,23 +16,29 @@ pub fn run_prek(args: &[String], verbose: u8) -> Result<i32> {
 }
 
 fn run_with_tool(tool: &str, args: &[String], verbose: u8) -> Result<i32> {
-    let mut cmd = resolved_command(tool);
-
-    for arg in args {
-        cmd.arg(arg);
-    }
+    let display = args.join(" ");
 
     if verbose > 0 {
-        eprintln!("Running: {} {}", tool, args.join(" "));
+        eprintln!("Running: {} {}", tool, display);
     }
 
-    runner::run_filtered(
-        cmd,
-        tool,
-        &args.join(" "),
-        filter_pre_commit_output,
-        runner::RunOptions::stdout_only().tee(tool),
-    )
+    // Only apply the hook filter for `run` subcommand (install, autoupdate, etc. passthrough)
+    if args.first().map(|a| a == "run").unwrap_or(false) {
+        let mut cmd = resolved_command(tool);
+        for arg in args {
+            cmd.arg(arg);
+        }
+        runner::run_filtered(
+            cmd,
+            tool,
+            &display,
+            filter_pre_commit_output,
+            runner::RunOptions::stdout_only().tee(tool),
+        )
+    } else {
+        let os_args: Vec<std::ffi::OsString> = args.iter().map(std::ffi::OsString::from).collect();
+        runner::run_passthrough(tool, &os_args, verbose)
+    }
 }
 
 pub(crate) fn filter_pre_commit_output(output: &str) -> String {

--- a/src/cmds/python/pre_commit_cmd.rs
+++ b/src/cmds/python/pre_commit_cmd.rs
@@ -1,0 +1,187 @@
+//! Filters pre-commit output, removing dots between hook names and status.
+//! Success/skipped hooks show one line; failures show hook-id + full error.
+
+use crate::core::runner;
+use crate::core::utils::resolved_command;
+use anyhow::Result;
+
+const HOOK_STATUSES: [&str; 4] = ["Passed", "Failed", "Skipped", "Ignored"];
+
+pub fn run(args: &[String], verbose: u8) -> Result<i32> {
+    let mut cmd = resolved_command("pre-commit");
+
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    if verbose > 0 {
+        eprintln!("Running: pre-commit {}", args.join(" "));
+    }
+
+    runner::run_filtered(
+        cmd,
+        "pre-commit",
+        &args.join(" "),
+        filter_pre_commit_output,
+        runner::RunOptions::stdout_only().tee("pre-commit"),
+    )
+}
+
+pub(crate) fn filter_pre_commit_output(output: &str) -> String {
+    let mut result: Vec<String> = Vec::new();
+    let lines: Vec<&str> = output.lines().collect();
+    let mut i = 0;
+
+    while i < lines.len() {
+        let line = lines[i];
+
+        if line.starts_with("[INFO]") || line.trim().is_empty() {
+            i += 1;
+            continue;
+        }
+
+        if let Some((name, status)) = parse_hook_line(line) {
+            i += 1;
+            match status {
+                "Failed" => {
+                    let mut hook_id = None;
+                    while i < lines.len() {
+                        let next = lines[i].trim();
+                        if next.starts_with("- hook id:") {
+                            hook_id = Some(next.trim_start_matches("- hook id:").trim());
+                            i += 1;
+                        } else if next.starts_with("- exit code:") || next.is_empty() {
+                            i += 1;
+                        } else {
+                            break;
+                        }
+                    }
+
+                    let mut linter_output: Vec<&str> = Vec::new();
+                    while i < lines.len() {
+                        if parse_hook_line(lines[i]).is_some() || lines[i].starts_with("[INFO]") {
+                            break;
+                        }
+                        linter_output.push(lines[i]);
+                        i += 1;
+                    }
+
+                    let id = hook_id.unwrap_or(name);
+                    let mut failure = format!("{} Failed", id);
+                    if !linter_output.is_empty() {
+                        failure.push('\n');
+                        failure.push_str(&linter_output.join("\n"));
+                    }
+                    result.push(failure);
+                }
+                _ => {
+                    result.push(format!("{} {}", name, status));
+                }
+            }
+        } else {
+            result.push(line.to_string());
+            i += 1;
+        }
+    }
+
+    result.join("\n")
+}
+
+fn parse_hook_line(line: &str) -> Option<(&str, &str)> {
+    for status in &HOOK_STATUSES {
+        if let Some(rest) = line.strip_suffix(status) {
+            let trimmed = rest.trim_end_matches('.');
+            if trimmed.len() < rest.len() {
+                return Some((trimmed.trim_end(), *status));
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_all_pass() {
+        let output = "\
+Trim Trailing Whitespace.................................................Passed
+Fix End of Files.........................................................Passed";
+        let result = filter_pre_commit_output(output);
+        assert_eq!(
+            result,
+            "Trim Trailing Whitespace Passed\nFix End of Files Passed"
+        );
+    }
+
+    #[test]
+    fn test_mixed_passed_and_failed() {
+        let output = "\
+Trim Trailing Whitespace.................................................Passed
+Check Yaml...............................................................Failed
+- hook id: check-yaml
+- exit code: 1
+.yaml-lint:13:1: expected a mapping
+Fix End of Files.........................................................Passed";
+        let result = filter_pre_commit_output(output);
+        assert_eq!(
+            result,
+            "Trim Trailing Whitespace Passed\ncheck-yaml Failed\n.yaml-lint:13:1: expected a mapping\nFix End of Files Passed"
+        );
+    }
+
+    #[test]
+    fn test_info_lines_stripped() {
+        let output = "\
+[INFO] Installing environment for https://github.com/psf/black.
+[INFO] Once installed this environment will be reused.
+isort....................................................................Passed
+black....................................................................Passed";
+        let result = filter_pre_commit_output(output);
+        assert_eq!(result, "isort Passed\nblack Passed");
+    }
+
+    #[test]
+    fn test_failed_no_linter_output() {
+        let output = "\
+Check Yaml...............................................................Failed
+- hook id: check-yaml
+- exit code: 1";
+        let result = filter_pre_commit_output(output);
+        assert_eq!(result, "check-yaml Failed");
+    }
+
+    #[test]
+    fn test_skipped_hook() {
+        let output =
+            "check-ast................................................................Skipped";
+        let result = filter_pre_commit_output(output);
+        assert_eq!(result, "check-ast Skipped");
+    }
+
+    #[test]
+    fn test_multiple_failures() {
+        let output = "\
+black....................................................................Failed
+- hook id: black
+- exit code: 1
+file.py:1:1: black would reformat
+isort....................................................................Failed
+- hook id: isort
+- exit code: 1
+file.py:2:3: import not sorted";
+        let result = filter_pre_commit_output(output);
+        assert_eq!(
+            result,
+            "black Failed\nfile.py:1:1: black would reformat\nisort Failed\nfile.py:2:3: import not sorted"
+        );
+    }
+
+    #[test]
+    fn test_passthrough_non_hook_lines() {
+        let output = "pre-commit checks completed";
+        let result = filter_pre_commit_output(output);
+        assert_eq!(result, "pre-commit checks completed");
+    }
+}

--- a/src/cmds/python/prek_cmd.rs
+++ b/src/cmds/python/prek_cmd.rs
@@ -1,0 +1,71 @@
+use crate::core::runner;
+use crate::core::utils::resolved_command;
+use anyhow::Result;
+
+pub fn run(args: &[String], verbose: u8) -> Result<i32> {
+    let display = args.join(" ");
+
+    if verbose > 0 {
+        eprintln!("Running: prek {}", display);
+    }
+
+    if args.first().map(|a| a == "run").unwrap_or(false) {
+        let mut cmd = resolved_command("prek");
+        for arg in args {
+            cmd.arg(arg);
+        }
+        runner::run_filtered(
+            cmd,
+            "prek",
+            &display,
+            super::pre_commit_cmd::filter_pre_commit_output,
+            runner::RunOptions::stdout_only().tee("prek"),
+        )
+    } else {
+        let os_args: Vec<std::ffi::OsString> =
+            args.iter().map(std::ffi::OsString::from).collect();
+        runner::run_passthrough("prek", &os_args, verbose)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    fn filter(output: &str) -> String {
+        super::super::pre_commit_cmd::filter_pre_commit_output(output)
+    }
+
+    #[test]
+    fn test_prek_filter_all_pass() {
+        let output = "\
+Trim trailing whitespace.................................................Passed
+fix end of files.........................................................Passed";
+        assert_eq!(
+            filter(output),
+            "Trim trailing whitespace [Passed]\nfix end of files [Passed]"
+        );
+    }
+
+    #[test]
+    fn test_prek_filter_failed_with_hook_id() {
+        let output = "\
+Check Yaml...............................................................Failed
+- hook id: check-yaml
+- exit code: 1
+.yaml-lint:13:1: expected a mapping";
+        assert_eq!(
+            filter(output),
+            "check-yaml [Failed]\n.yaml-lint:13:1: expected a mapping"
+        );
+    }
+
+    #[test]
+    fn test_prek_filter_skipped_with_reason() {
+        let output = "\
+ruff (lint + fix)....................................(no files to check)Skipped
+ruff (format)........................................(no files to check)Skipped";
+        assert_eq!(
+            filter(output),
+            "ruff (lint + fix) [Skipped]\nruff (format) [Skipped]"
+        );
+    }
+}

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -735,6 +735,15 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
+        pattern: r"^prek\b",
+        rtk_cmd: "rtk prek",
+        rewrite_prefixes: &["prek"],
+        category: "Build",
+        savings_pct: 65.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
+    RtkRule {
         pattern: r"^ps(\s|$)",
         rtk_cmd: "rtk ps",
         rewrite_prefixes: &["ps"],

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -735,10 +735,10 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        pattern: r"^prek\b",
+        pattern: r"^(python[0-9.]*\s+-m\s+)?prek(\s|$)",
         rtk_cmd: "rtk prek",
-        rewrite_prefixes: &["prek"],
-        category: "Build",
+        rewrite_prefixes: &["python3 -m prek", "python -m prek", "prek"],
+        category: "Python",
         savings_pct: 65.0,
         subcmd_savings: &[],
         subcmd_status: &[],

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use cmds::js::{
     vitest_cmd,
 };
 use cmds::jvm::gradlew_cmd;
-use cmds::python::{mypy_cmd, pip_cmd, pytest_cmd, ruff_cmd};
+use cmds::python::{mypy_cmd, pip_cmd, pre_commit_cmd, pytest_cmd, ruff_cmd};
 use cmds::ruby::{rake_cmd, rspec_cmd, rubocop_cmd};
 use cmds::rust::{cargo_cmd, runner};
 use cmds::system::{
@@ -704,6 +704,13 @@ enum Commands {
     /// Pip package manager with compact output (auto-detects uv)
     Pip {
         /// Pip arguments (e.g., list, outdated, install)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// Pre-commit hook runner with compact output (removes `...` separators)
+    PreCommit {
+        /// Pre-commit arguments (run, install, autoupdate, etc.)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -2148,6 +2155,8 @@ fn run_cli() -> Result<i32> {
 
         Commands::Pip { args } => pip_cmd::run(&args, cli.verbose)?,
 
+        Commands::PreCommit { args } => pre_commit_cmd::run(&args, cli.verbose)?,
+
         Commands::Go { command } => match command {
             GoCommands::Test { args } => go_cmd::run_test(&args, cli.verbose)?,
             GoCommands::Build { args } => go_cmd::run_build(&args, cli.verbose)?,
@@ -2506,6 +2515,7 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Rubocop { .. }
             | Commands::Rspec { .. }
             | Commands::Pip { .. }
+            | Commands::PreCommit { .. }
             | Commands::Go { .. }
             | Commands::GolangciLint { .. }
             | Commands::Gt { .. }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use cmds::js::{
     vitest_cmd,
 };
 use cmds::jvm::gradlew_cmd;
-use cmds::python::{mypy_cmd, pip_cmd, pre_commit_cmd, pytest_cmd, ruff_cmd};
+use cmds::python::{mypy_cmd, pip_cmd, pre_commit_cmd, prek_cmd, pytest_cmd, ruff_cmd};
 use cmds::ruby::{rake_cmd, rspec_cmd, rubocop_cmd};
 use cmds::rust::{cargo_cmd, runner};
 use cmds::system::{
@@ -2164,7 +2164,7 @@ fn run_cli() -> Result<i32> {
 
         Commands::PreCommit { args } => pre_commit_cmd::run(&args, cli.verbose)?,
 
-        Commands::Prek { args } => pre_commit_cmd::run_prek(&args, cli.verbose)?,
+        Commands::Prek { args } => prek_cmd::run(&args, cli.verbose)?,
 
         Commands::Go { command } => match command {
             GoCommands::Test { args } => go_cmd::run_test(&args, cli.verbose)?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -715,6 +715,13 @@ enum Commands {
         args: Vec<String>,
     },
 
+    /// Prek hook runner (pre-commit equivalent) with the same filter
+    Prek {
+        /// Prek arguments (run, install, autoupdate, etc.)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
     /// Go commands with compact output
     Go {
         #[command(subcommand)]
@@ -2157,6 +2164,8 @@ fn run_cli() -> Result<i32> {
 
         Commands::PreCommit { args } => pre_commit_cmd::run(&args, cli.verbose)?,
 
+        Commands::Prek { args } => pre_commit_cmd::run_prek(&args, cli.verbose)?,
+
         Commands::Go { command } => match command {
             GoCommands::Test { args } => go_cmd::run_test(&args, cli.verbose)?,
             GoCommands::Build { args } => go_cmd::run_build(&args, cli.verbose)?,
@@ -2516,6 +2525,7 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Rspec { .. }
             | Commands::Pip { .. }
             | Commands::PreCommit { .. }
+            | Commands::Prek { .. }
             | Commands::Go { .. }
             | Commands::GolangciLint { .. }
             | Commands::Gt { .. }


### PR DESCRIPTION
## Summary

Creates a Rust filter module for pre-commit / prek that transforms hook output:
- Removes ... dot separators between hook name and status
- Wraps status in [brackets]: Trim Trailing Whitespace [Passed]
- Failed hooks show hook-id [Failed] + full linter error output
- Strips [INFO] installation noise and empty lines
- Only applies to run subcommand; install, autoupdate, etc. passthrough
- Also adds prek support with the same filter

## Test plan

- [x] cargo fmt --all && cargo clippy --all-targets && cargo test - 1938 passed, clippy clean
- [x] 10 unit tests covering all-pass, mixed pass/fail, skipped with reason, hook modifications, INFO stripping, multiple failures, real-world 13-hook output