### PR TITLE
fix(init): preserve settings.json symlink during atomic write

### DIFF
--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -384,31 +384,15 @@ fn write_if_changed(path: &Path, content: &str, name: &str, ctx: InitContext) ->
 
 /// Resolve the final write target: if `path` is a symlink, follow it so
 /// the atomic rename lands on the real file and the symlink is preserved.
-fn resolve_atomic_target(path: &Path) -> Result<PathBuf> {
-    if let Ok(meta) = fs::symlink_metadata(path) {
-        if meta.file_type().is_symlink() {
-            let link_target = fs::read_link(path)
-                .with_context(|| format!("Failed to read symlink target: {}", path.display()))?;
-            if link_target.is_absolute() {
-                return Ok(link_target);
-            }
-            let parent = path.parent().with_context(|| {
-                format!(
-                    "Cannot resolve relative symlink for {}: no parent directory",
-                    path.display()
-                )
-            })?;
-            return Ok(parent.join(link_target));
-        }
-    }
-    Ok(path.to_path_buf())
+fn resolve_atomic_target(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 /// Atomic write using tempfile + rename
 /// Prevents corruption on crash/interrupt
 /// Follows symlinks so the link itself is preserved.
 fn atomic_write(path: &Path, content: &str) -> Result<()> {
-    let target = resolve_atomic_target(path)?;
+    let target = resolve_atomic_target(path);
     let parent = target.parent().with_context(|| {
         format!(
             "Cannot write to {}: path has no parent directory",

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -382,13 +382,37 @@ fn write_if_changed(path: &Path, content: &str, name: &str, ctx: InitContext) ->
     }
 }
 
+/// Resolve the final write target: if `path` is a symlink, follow it so
+/// the atomic rename lands on the real file and the symlink is preserved.
+fn resolve_atomic_target(path: &Path) -> Result<PathBuf> {
+    if let Ok(meta) = fs::symlink_metadata(path) {
+        if meta.file_type().is_symlink() {
+            let link_target = fs::read_link(path)
+                .with_context(|| format!("Failed to read symlink target: {}", path.display()))?;
+            if link_target.is_absolute() {
+                return Ok(link_target);
+            }
+            let parent = path.parent().with_context(|| {
+                format!(
+                    "Cannot resolve relative symlink for {}: no parent directory",
+                    path.display()
+                )
+            })?;
+            return Ok(parent.join(link_target));
+        }
+    }
+    Ok(path.to_path_buf())
+}
+
 /// Atomic write using tempfile + rename
 /// Prevents corruption on crash/interrupt
+/// Follows symlinks so the link itself is preserved.
 fn atomic_write(path: &Path, content: &str) -> Result<()> {
-    let parent = path.parent().with_context(|| {
+    let target = resolve_atomic_target(path)?;
+    let parent = target.parent().with_context(|| {
         format!(
             "Cannot write to {}: path has no parent directory",
-            path.display()
+            target.display()
         )
     })?;
 
@@ -402,10 +426,10 @@ fn atomic_write(path: &Path, content: &str) -> Result<()> {
         .with_context(|| format!("Failed to write {} bytes to temp file", content.len()))?;
 
     // Atomic rename
-    temp_file.persist(path).with_context(|| {
+    temp_file.persist(&target).with_context(|| {
         format!(
             "Failed to atomically replace {} (disk full?)",
-            path.display()
+            target.display()
         )
     })?;
 
@@ -5131,6 +5155,48 @@ mod tests {
         assert!(file_path.exists());
         let written = fs::read_to_string(&file_path).unwrap();
         assert_eq!(written, content);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_atomic_write_preserves_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let target_path = temp.path().join("real-settings.json");
+        let link_path = temp.path().join("settings.json");
+
+        fs::write(&target_path, "{}").expect("seed target file");
+        symlink(&target_path, &link_path).expect("create symlink");
+
+        atomic_write(&link_path, "{\"hooks\":{}}").unwrap();
+
+        let meta = fs::symlink_metadata(&link_path).unwrap();
+        assert!(meta.file_type().is_symlink(), "symlink must survive");
+        let written = fs::read_to_string(&target_path).unwrap();
+        assert_eq!(written, "{\"hooks\":{}}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_atomic_write_preserves_relative_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let subdir = temp.path().join("real");
+        fs::create_dir(&subdir).unwrap();
+        let target_path = subdir.join("settings.json");
+        let link_path = temp.path().join("settings.json");
+
+        fs::write(&target_path, "{}").expect("seed target file");
+        symlink(Path::new("real/settings.json"), &link_path).expect("create relative symlink");
+
+        atomic_write(&link_path, "{\"patched\":true}").unwrap();
+
+        let meta = fs::symlink_metadata(&link_path).unwrap();
+        assert!(meta.file_type().is_symlink(), "symlink must survive");
+        let written = fs::read_to_string(&target_path).unwrap();
+        assert_eq!(written, "{\"patched\":true}");
     }
 
     // Test for preserve_order round-trip


### PR DESCRIPTION
## Summary

- `atomic_write()` replaced symlinked `settings.json` with a regular file, breaking setups that symlink config files (e.g. dotfile managers, multi-machine sync)
- Now resolves symlink targets before the tempfile+rename so the link itself is preserved

Closes #653

Supersedes #675 — rebased on current develop. The portable hook path change from #675 is no longer needed since the codebase moved from shell scripts to `rtk hook claude` binary command.

## Changes Made

- Added `resolve_atomic_target()` that detects symlinks and resolves to their target (absolute or relative)
- Updated `atomic_write()` to write through to the resolved target
- Added 2 unix-specific tests for absolute and relative symlink preservation

## Testing

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets` — no warnings
- [x] `cargo test --all` — 1942 passed, 6 ignored
- [x] Specific tests: `cargo test init::tests::test_atomic_write`
- [x] Verified both fixes merge cleanly together (1947 tests pass combined)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No breaking changes introduced
- [x] Tests added for new functionality

