### PR TITLE
fix(ci): publish linux aarch64 musl binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,8 @@ jobs:
             os: ubuntu-latest
             archive: tar.gz
             musl: true
-          - target: aarch64-unknown-linux-gnu
+          # Use cross for aarch64 musl so the Linux ARM binary is statically linked.
+          - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             archive: tar.gz
             cross: true
@@ -66,12 +67,9 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation tools
+      - name: Install cross
         if: matrix.cross
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+        run: cargo install cross --version 0.2.5 --locked
 
       - name: Install musl tools
         if: matrix.musl
@@ -79,7 +77,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y musl-tools
 
-      - name: Build
+      - name: Build (cross)
+        if: matrix.cross
+        run: cross build --release --target ${{ matrix.target }}
+        env:
+          RTK_TELEMETRY_URL: ${{ vars.RTK_TELEMETRY_URL }}
+          RTK_TELEMETRY_TOKEN: ${{ secrets.RTK_TELEMETRY_TOKEN }}
+
+      - name: Build (cargo)
+        if: ${{ ! matrix.cross }}
         run: cargo build --release --target ${{ matrix.target }}
         env:
           RTK_TELEMETRY_URL: ${{ vars.RTK_TELEMETRY_URL }}
@@ -281,7 +287,7 @@ jobs:
         run: |
           echo "mac_arm=$(grep aarch64-apple-darwin.tar.gz checksums.txt | head -1 | awk '{print $1}')" >> $GITHUB_OUTPUT
           echo "mac_intel=$(grep x86_64-apple-darwin.tar.gz checksums.txt | head -1 | awk '{print $1}')" >> $GITHUB_OUTPUT
-          echo "linux_arm=$(grep aarch64-unknown-linux-gnu.tar.gz checksums.txt | head -1 | awk '{print $1}')" >> $GITHUB_OUTPUT
+          echo "linux_arm=$(grep aarch64-unknown-linux-musl.tar.gz checksums.txt | head -1 | awk '{print $1}')" >> $GITHUB_OUTPUT
           echo "linux_intel=$(grep x86_64-unknown-linux-musl.tar.gz checksums.txt | head -1 | awk '{print $1}')" >> $GITHUB_OUTPUT
 
       - name: Generate formula
@@ -300,7 +306,7 @@ jobs:
               url "https://github.com/rtk-ai/rtk/releases/download/TAG_PLACEHOLDER/rtk-x86_64-apple-darwin.tar.gz"
               sha256 "SHA_MAC_INTEL_PLACEHOLDER"
             elsif OS.linux? && Hardware::CPU.arm?
-              url "https://github.com/rtk-ai/rtk/releases/download/TAG_PLACEHOLDER/rtk-aarch64-unknown-linux-gnu.tar.gz"
+              url "https://github.com/rtk-ai/rtk/releases/download/TAG_PLACEHOLDER/rtk-aarch64-unknown-linux-musl.tar.gz"
               sha256 "SHA_LINUX_ARM_PLACEHOLDER"
             elsif OS.linux? && Hardware::CPU.intel?
               url "https://github.com/rtk-ai/rtk/releases/download/TAG_PLACEHOLDER/rtk-x86_64-unknown-linux-musl.tar.gz"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,6 @@
+[build.env]
+# Forward compile-time telemetry vars used by option_env!() into cross containers.
+passthrough = [
+    "RTK_TELEMETRY_URL",
+    "RTK_TELEMETRY_TOKEN",
+]

--- a/Formula/rtk.rb
+++ b/Formula/rtk.rb
@@ -23,12 +23,12 @@ class Rtk < Formula
 
   on_linux do
     on_intel do
-      url "https://github.com/rtk-ai/rtk/releases/download/v#{version}/rtk-x86_64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/rtk-ai/rtk/releases/download/v#{version}/rtk-x86_64-unknown-linux-musl.tar.gz"
       sha256 "PLACEHOLDER_SHA256_LINUX_INTEL"
     end
 
     on_arm do
-      url "https://github.com/rtk-ai/rtk/releases/download/v#{version}/rtk-aarch64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/rtk-ai/rtk/releases/download/v#{version}/rtk-aarch64-unknown-linux-musl.tar.gz"
       sha256 "PLACEHOLDER_SHA256_LINUX_ARM"
     end
   end

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ cargo install --git https://github.com/rtk-ai/rtk
 
 Download from [releases](https://github.com/rtk-ai/rtk/releases):
 - macOS: `rtk-x86_64-apple-darwin.tar.gz` / `rtk-aarch64-apple-darwin.tar.gz`
-- Linux: `rtk-x86_64-unknown-linux-musl.tar.gz` / `rtk-aarch64-unknown-linux-gnu.tar.gz`
+- Linux: `rtk-x86_64-unknown-linux-musl.tar.gz` / `rtk-aarch64-unknown-linux-musl.tar.gz`
 - Windows: `rtk-x86_64-pc-windows-msvc.zip`
 
 > **Windows users**: Extract the zip and place `rtk.exe` somewhere in your PATH (e.g. `C:\Users\<you>\.local\bin`). Run RTK from **Command Prompt**, **PowerShell**, or **Windows Terminal** — do not double-click the `.exe` (it will flash and close). For the best experience, use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) where the full hook system works natively. See [Windows setup](#windows) below for details.

--- a/docs/guide/getting-started/installation.md
+++ b/docs/guide/getting-started/installation.md
@@ -52,7 +52,7 @@ cargo install --git https://github.com/rtk-ai/rtk rtk
 Download from [GitHub releases](https://github.com/rtk-ai/rtk/releases):
 
 - macOS: `rtk-x86_64-apple-darwin.tar.gz` / `rtk-aarch64-apple-darwin.tar.gz`
-- Linux: `rtk-x86_64-unknown-linux-musl.tar.gz` / `rtk-aarch64-unknown-linux-gnu.tar.gz`
+- Linux: `rtk-x86_64-unknown-linux-musl.tar.gz` / `rtk-aarch64-unknown-linux-musl.tar.gz`
 - Windows: `rtk-x86_64-pc-windows-msvc.zip`
 
 **Windows users**: Extract the zip and place `rtk.exe` in a directory on your PATH. Run RTK from Command Prompt, PowerShell, or Windows Terminal — do not double-click the `.exe` (it prints usage and exits immediately). For full hook support, use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) instead.

--- a/install.sh
+++ b/install.sh
@@ -74,7 +74,7 @@ get_target() {
         linux)
             case "$ARCH" in
                 x86_64)  TARGET="x86_64-unknown-linux-musl";;
-                aarch64) TARGET="aarch64-unknown-linux-gnu";;
+                aarch64) TARGET="aarch64-unknown-linux-musl";;
             esac
             ;;
         darwin)


### PR DESCRIPTION
## Summary

Hello there! This fixes the Linux aarch64 binary distribution by publishing a musl build instead of the glibc-linked GNU build.

This resolves the aarch64 side of https://github.com/rtk-ai/rtk/issues/265, where release binaries can fail on systems with older glibc, such as Ubuntu 22.04-based dev containers. The x86_64 Linux artifact already moved to musl in https://github.com/rtk-ai/rtk/pull/267; this applies the same approach to aarch64 Linux.

This also picks up the intent from https://github.com/rtk-ai/rtk/pull/459, which was closed prematurely by its author. The changes are as follows:

- Build `aarch64-unknown-linux-musl` in the release workflow using `cross`
- Add `Cross.toml` env passthrough for compile-time telemetry vars
- Update installer target detection to download the musl Linux ARM artifact
- Update Homebrew formula generation, checked-in formula, and docs to reference the musl artifact

## Test plan

- [x] `rg "unknown-linux-gnu" -n` returns no matches
- [x] Parsed `.github/workflows/release.yml` with [PyYAML](https://pypi.org/project/PyYAML/)
- [x] Parsed `Cross.toml` with [tomllib](https://docs.python.org/3/library/tomllib.html) from Python's standard library
- [x] `git diff --check`
- [x] `cargo check`
- [ ] Release workflow validation: confirm `rtk-aarch64-unknown-linux-musl.tar.gz` is uploaded and included in `checksums.txt`

I didn't want to make too many changes in order to ease review but in future I think it would be desirable to build each artifact on PRs. I'd recommend splitting `.github/workflows/release.yml` into two parts:

- reusable build/package workflow: builds targets and uploads artifacts
- release workflow: downloads those artifacts, publishes release assets, etc.

Then PR CI can call only the build/package part, while release/CD calls both build/package and publish.