### PR TITLE
feat(agy): Google Antigravity CLI hook integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,11 @@ rtk init -g                     # Claude Code / Copilot (default)
 rtk init -g --gemini            # Gemini CLI
 rtk init -g --codex             # Codex (OpenAI)
 rtk init -g --agent cursor      # Cursor
+rtk init -g --agent agy         # Google Antigravity CLI (agy)
 rtk init --agent windsurf       # Windsurf
 rtk init --agent cline          # Cline / Roo Code
 rtk init --agent kilocode       # Kilo Code
-rtk init --agent antigravity    # Google Antigravity
+rtk init --agent antigravity    # Google Antigravity IDE (rules-based)
 rtk init --agent hermes         # Hermes
 
 # 2. Restart your AI tool, then test
@@ -351,7 +352,7 @@ rtk git status
 
 ## Supported AI Tools
 
-RTK supports 13 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents for 60-90% token savings where the agent supports command interception.
+RTK supports 14 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents for 60-90% token savings where the agent supports command interception.
 
 | Tool | Install | Method |
 |------|---------|--------|
@@ -360,6 +361,7 @@ RTK supports 13 AI coding tools. Each integration rewrites shell commands to `rt
 | **GitHub Copilot CLI** | `rtk init -g --copilot` | PreToolUse deny-with-suggestion (CLI limitation) |
 | **Cursor** | `rtk init -g --agent cursor` | preToolUse hook (hooks.json) |
 | **Gemini CLI** | `rtk init -g --gemini` | BeforeTool hook |
+| **Google Antigravity CLI (`agy`)** | `rtk init -g --agent agy` | PreToolUse hook — deny-with-reason (global) |
 | **Codex** | `rtk init -g --codex` | AGENTS.md + RTK.md instructions |
 | **Windsurf** | `rtk init --agent windsurf` | .windsurfrules (project-scoped) |
 | **Cline / Roo Code** | `rtk init --agent cline` | .clinerules (project-scoped) |
@@ -368,7 +370,7 @@ RTK supports 13 AI coding tools. Each integration rewrites shell commands to `rt
 | **Hermes** | `rtk init --agent hermes` | Python plugin adapter (terminal command mutation via `rtk rewrite`) |
 | **Mistral Vibe** | Planned ([#800](https://github.com/rtk-ai/rtk/issues/800)) | Blocked on upstream |
 | **Kilo Code** | `rtk init --agent kilocode` | .kilocode/rules/rtk-rules.md (project-scoped) |
-| **Google Antigravity** | `rtk init --agent antigravity` | .agents/rules/antigravity-rtk-rules.md (project-scoped) |
+| **Google Antigravity IDE** | `rtk init --agent antigravity` | .agents/rules/antigravity-rtk-rules.md (project-scoped) |
 
 For per-agent setup details, override controls, and graceful degradation, see the [Supported Agents guide](https://www.rtk-ai.app/guide/getting-started/supported-agents). The Hermes plugin source and tests live in `hooks/hermes/`; installed Hermes runtime files still live under `~/.hermes/plugins/rtk-rewrite/`.
 

--- a/hooks/antigravity/README.md
+++ b/hooks/antigravity/README.md
@@ -10,45 +10,44 @@ RTK supports two separate Google Antigravity integrations:
 
 The `agy` CLI (successor to Gemini CLI) supports a JSON hook protocol.  RTK registers as a `PreToolUse` hook that rewrites shell commands before execution.
 
-**Install (global):**
+**Install (global only):**
 ```bash
 rtk init -g --agent agy
 ```
 
-**Install (project-local):**
-```bash
-rtk init --agent agy
-```
+agy CLI hook support is **global-only** — there is no project-local install. The hook runner is registered system-wide so it intercepts all agy sessions.
 
-**Hook location:**
-- Global: `~/.agents/hooks.json`
-- Project: `.agents/hooks.json`
+**Files written:**
+- `~/.gemini/config/hooks.json` — registers the `PreToolUse` hook
+- `~/.gemini/antigravity-cli/settings.json` — grants `command(rtk)` permission
 
-**Hook entry written:**
+**Hook entry written to `~/.gemini/config/hooks.json`:**
 ```json
 {
-  "hooks": {
+  "rtk-antigravity": {
+    "enabled": true,
     "PreToolUse": [
       {
-        "type": "command",
-        "command": "rtk hook antigravity",
-        "toolNameMatcher": "^(run_command|Bash)$"
+        "toolNameMatcher": "^(run_command|Bash|bash)$",
+        "hooks": [{"type": "command", "command": "/path/to/rtk hook antigravity"}]
       }
     ]
   }
 }
 ```
 
-**JSON protocol:**
+**Hook protocol:**
+
+agy sends a JSON payload to stdin; the hook replies to stdout.
 
 Input (`run_command` tool):
 ```json
 {"toolCall": {"name": "run_command", "args": {"CommandLine": "git status"}}}
 ```
 
-Output (rewritten):
+Output — deny with replacement name (model retries with `rtk git status`, auto-approved via `command(rtk)` allow entry):
 ```json
-{"decision": "allow", "toolCall": {"args": {"CommandLine": "rtk git status"}}}
+{"denyReason": "RTK: use 'rtk git status' instead of 'git status' (60-90% token savings)"}
 ```
 
 Input (`Bash` tool):
@@ -56,17 +55,13 @@ Input (`Bash` tool):
 {"toolCall": {"name": "Bash", "args": {"command": "cargo test"}}}
 ```
 
-Output (rewritten):
-```json
-{"decision": "allow", "toolCall": {"args": {"command": "rtk cargo test"}}}
-```
+Non-shell tools and commands already prefixed with `rtk` receive `{"allowTool": true}` and pass through unchanged.
 
-No output is produced for non-shell tools or commands that don't match any RTK filter — the tool runs unchanged.
+> **Note:** agy's `overwrite` field in `PreToolHookResult` is silently ignored regardless of `toolPermission` mode. RTK uses the deny-and-retry pattern as a workaround until `overwrite` is implemented by agy.
 
 **Uninstall:**
 ```bash
-rtk init --uninstall --agent agy          # project-local
-rtk init -g --uninstall --agent agy       # global
+rtk init -g --uninstall --agent agy
 ```
 
 ### 2. Antigravity IDE — Prompt-Level Guidance

--- a/hooks/antigravity/README.md
+++ b/hooks/antigravity/README.md
@@ -2,8 +2,90 @@
 
 > Part of [`hooks/`](../README.md) — see also [`src/hooks/`](../../src/hooks/README.md) for installation code
 
-## Specifics
+## Supported Modes
 
-- Prompt-level guidance only (no programmatic hook) -- relies on Antigravity reading custom instructions
-- `rules.md` contains the instruction to prefix all shell commands with `rtk`, usage examples, and meta commands
-- Installed to `.agents/rules/antigravity-rtk-rules.md` (project-local) by `rtk init --agent antigravity`
+RTK supports two separate Google Antigravity integrations:
+
+### 1. Antigravity CLI (`agy`) — Programmatic Hook
+
+The `agy` CLI (successor to Gemini CLI) supports a JSON hook protocol.  RTK registers as a `PreToolUse` hook that rewrites shell commands before execution.
+
+**Install (global):**
+```bash
+rtk init -g --agent agy
+```
+
+**Install (project-local):**
+```bash
+rtk init --agent agy
+```
+
+**Hook location:**
+- Global: `~/.agents/hooks.json`
+- Project: `.agents/hooks.json`
+
+**Hook entry written:**
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "type": "command",
+        "command": "rtk hook antigravity",
+        "toolNameMatcher": "^(run_command|Bash)$"
+      }
+    ]
+  }
+}
+```
+
+**JSON protocol:**
+
+Input (`run_command` tool):
+```json
+{"toolCall": {"name": "run_command", "args": {"CommandLine": "git status"}}}
+```
+
+Output (rewritten):
+```json
+{"decision": "allow", "toolCall": {"args": {"CommandLine": "rtk git status"}}}
+```
+
+Input (`Bash` tool):
+```json
+{"toolCall": {"name": "Bash", "args": {"command": "cargo test"}}}
+```
+
+Output (rewritten):
+```json
+{"decision": "allow", "toolCall": {"args": {"command": "rtk cargo test"}}}
+```
+
+No output is produced for non-shell tools or commands that don't match any RTK filter — the tool runs unchanged.
+
+**Uninstall:**
+```bash
+rtk init --uninstall --agent agy          # project-local
+rtk init -g --uninstall --agent agy       # global
+```
+
+### 2. Antigravity IDE — Prompt-Level Guidance
+
+The Antigravity IDE (formerly "Antigravity") reads project rules files.  RTK installs its awareness instructions as a rules file.
+
+**Install (project-local only):**
+```bash
+rtk init --agent antigravity
+```
+
+- Installs `.agents/rules/antigravity-rtk-rules.md` in the project root
+- Instructs Antigravity to prefix shell commands with `rtk`
+- No programmatic hook — relies on the model following the rules
+
+## Gemini CLI (Legacy)
+
+The Gemini CLI is still supported but is now considered **legacy**.  New users should use `agy`.
+
+```bash
+rtk init -g --gemini    # Gemini CLI (legacy)
+```

--- a/src/cmds/system/json_cmd.rs
+++ b/src/cmds/system/json_cmd.rs
@@ -106,7 +106,8 @@ fn compact_json(value: &Value, depth: usize, max_depth: usize) -> String {
         Value::Number(n) => format!("{}{}", indent, n),
         Value::String(s) => {
             if s.len() > 80 {
-                let end = s.floor_char_boundary(77);
+                let mut end = 77.min(s.len());
+                while !s.is_char_boundary(end) { end -= 1; }
                 format!("{}\"{}...\"", indent, &s[..end])
             } else {
                 format!("{}\"{}\"", indent, s)

--- a/src/cmds/system/pipe_cmd.rs
+++ b/src/cmds/system/pipe_cmd.rs
@@ -140,9 +140,9 @@ fn find_wrapper(input: &str) -> String {
 }
 
 pub fn auto_detect_filter(input: &str) -> fn(&str) -> String {
-    let end = input.len().min(1024);
+    let mut end = input.len().min(1024);
     // Avoid panic: byte 1024 may fall inside a multi-byte UTF-8 char
-    let end = input.floor_char_boundary(end);
+    while !input.is_char_boundary(end) { end -= 1; }
     let first_1k = &input[..end];
 
     if first_1k.contains("test result:") && first_1k.contains("passed;") {

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -21,6 +21,14 @@ pub const OPENCODE_PLUGIN_FILE: &str = "rtk.ts";
 pub const CURSOR_DIR: &str = ".cursor";
 pub const CODEX_DIR: &str = ".codex";
 pub const GEMINI_DIR: &str = ".gemini";
+
+pub const ANTIGRAVITY_DIR: &str = ".agents";
+
+/// Native Rust hook command for Google Antigravity CLI (agy).
+pub const ANTIGRAVITY_HOOK_COMMAND: &str = "rtk hook antigravity";
+/// Regex matcher covering both Antigravity shell-execution tool names.
+pub const ANTIGRAVITY_TOOL_MATCHER: &str = "^(run_command|Bash)$";
+
 pub const HERMES_DIR: &str = ".hermes";
 pub const HERMES_PLUGINS_SUBDIR: &str = "plugins";
 pub const HERMES_PLUGIN_NAME: &str = "rtk-rewrite";

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -25,8 +25,6 @@ pub const GEMINI_DIR: &str = ".gemini";
 #[allow(dead_code)]
 pub const ANTIGRAVITY_DIR: &str = ".agents";
 
-/// Native Rust hook command for Google Antigravity CLI (agy).
-pub const ANTIGRAVITY_HOOK_COMMAND: &str = "rtk hook antigravity";
 /// Config subdirectory for the Antigravity CLI (agy) under ~/.gemini/
 pub const AGY_CLI_SUBDIR: &str = "antigravity-cli";
 

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -26,6 +26,7 @@ pub const GEMINI_DIR: &str = ".gemini";
 pub const ANTIGRAVITY_DIR: &str = ".agents";
 
 /// Config subdirectory for the Antigravity CLI (agy) under ~/.gemini/
+#[allow(dead_code)]
 pub const AGY_CLI_SUBDIR: &str = "antigravity-cli";
 
 pub const HERMES_DIR: &str = ".hermes";

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -22,12 +22,13 @@ pub const CURSOR_DIR: &str = ".cursor";
 pub const CODEX_DIR: &str = ".codex";
 pub const GEMINI_DIR: &str = ".gemini";
 
+#[allow(dead_code)]
 pub const ANTIGRAVITY_DIR: &str = ".agents";
 
 /// Native Rust hook command for Google Antigravity CLI (agy).
 pub const ANTIGRAVITY_HOOK_COMMAND: &str = "rtk hook antigravity";
-/// Regex matcher covering both Antigravity shell-execution tool names.
-pub const ANTIGRAVITY_TOOL_MATCHER: &str = "^(run_command|Bash)$";
+/// Config subdirectory for the Antigravity CLI (agy) under ~/.gemini/
+pub const AGY_CLI_SUBDIR: &str = "antigravity-cli";
 
 pub const HERMES_DIR: &str = ".hermes";
 pub const HERMES_PLUGINS_SUBDIR: &str = "plugins";

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -26,7 +26,6 @@ pub const GEMINI_DIR: &str = ".gemini";
 pub const ANTIGRAVITY_DIR: &str = ".agents";
 
 /// Config subdirectory for the Antigravity CLI (agy) under ~/.gemini/
-#[allow(dead_code)]
 pub const AGY_CLI_SUBDIR: &str = "antigravity-cli";
 
 pub const HERMES_DIR: &str = ".hermes";

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -637,8 +637,10 @@ fn process_agy_simple(v: &Value, tool_name: &str) -> PayloadAction {
         }
     };
 
-    // agy PreToolHookResult: use "overwrite" to replace the tool call.
+    // agy PreToolHookResult: allowTool must be true to permit execution;
+    // overwrite replaces the tool call with the rewritten command.
     let output = json!({
+        "allowTool": true,
         "overwrite": {
             "name": tool_name,
             "args": { field: rewritten.clone() }
@@ -706,10 +708,12 @@ fn process_agy_rich(v: &Value, tool_name: &str) -> PayloadAction {
         args
     };
 
-    // agy PreToolHookResult: use "overwrite" (HookToolCall) to replace the call.
+    // agy PreToolHookResult: allowTool must be true to permit execution;
+    // overwrite replaces the tool call with the rewritten command.
     // Mirror the tool name and all args so extra fields (Cwd, WaitMsBeforeAsync, …)
     // are preserved.
     let output = json!({
+        "allowTool": true,
         "overwrite": {
             "name": tool_name,
             "args": updated_args
@@ -728,13 +732,13 @@ fn process_agy_rich(v: &Value, tool_name: &str) -> PayloadAction {
 /// Reads a JSON payload from stdin, rewrites shell commands through RTK,
 /// and outputs the result as a PreToolHookResult protojson.
 ///
-/// IMPORTANT: agy interprets empty stdout as "deny" — always output at
-/// least `{}` (allow, no modification) so non-shell tools are not blocked.
+/// IMPORTANT: agy's PreToolHookResult.allow_tool defaults to false (deny).
+/// Every response must include `{"allowTool": true}` to permit the tool.
+/// `{}` is NOT an allow — it's an implicit deny.
 pub fn run_antigravity() -> Result<()> {
     let input = read_stdin_limited()?;
     let input = input.trim();
     if input.is_empty() {
-        // No payload — nothing to process, nothing to allow.
         return Ok(());
     }
 
@@ -742,8 +746,8 @@ pub fn run_antigravity() -> Result<()> {
         Ok(v) => v,
         Err(e) => {
             let _ = writeln!(io::stderr(), "[rtk hook] Failed to parse JSON input: {e}");
-            // Still output allow so a parse error doesn't block the tool.
-            let _ = writeln!(io::stdout(), "{{}}");
+            // Parse error — allow the tool so the user isn't blocked.
+            let _ = writeln!(io::stdout(), r#"{{"allowTool":true}}"#);
             return Ok(());
         }
     };
@@ -759,12 +763,12 @@ pub fn run_antigravity() -> Result<()> {
         }
         PayloadAction::Skip { reason, cmd } => {
             audit_log(reason, &cmd, "");
-            // No rewrite needed — allow unchanged.
-            let _ = writeln!(io::stdout(), "{{}}");
+            // No rewrite needed — allow the original tool call unchanged.
+            let _ = writeln!(io::stdout(), r#"{{"allowTool":true}}"#);
         }
         PayloadAction::Ignore => {
             // Non-shell tool — allow unchanged.
-            let _ = writeln!(io::stdout(), "{{}}");
+            let _ = writeln!(io::stdout(), r#"{{"allowTool":true}}"#);
         }
     }
 
@@ -1260,6 +1264,7 @@ mod tests {
     fn test_agy_simple_bash_rewrite() {
         let out = run_antigravity_inner(&agy_simple_bash("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["allowTool"], true);
         assert_eq!(v["overwrite"]["name"], "Bash");
         assert_eq!(v["overwrite"]["args"]["command"], "rtk git status");
     }
@@ -1268,6 +1273,7 @@ mod tests {
     fn test_agy_simple_run_command_rewrite() {
         let out = run_antigravity_inner(&agy_simple_run_command("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["allowTool"], true);
         assert_eq!(v["overwrite"]["name"], "run_command");
         assert_eq!(v["overwrite"]["args"]["CommandLine"], "rtk git status");
     }
@@ -1298,6 +1304,7 @@ mod tests {
     fn test_agy_rich_run_command_rewrite() {
         let out = run_antigravity_inner(&agy_rich_run_command("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["allowTool"], true);
         assert_eq!(v["overwrite"]["name"], "run_command");
         assert_eq!(v["overwrite"]["args"]["CommandLine"], "rtk git status");
     }
@@ -1306,6 +1313,7 @@ mod tests {
     fn test_agy_rich_bash_rewrite() {
         let out = run_antigravity_inner(&agy_rich_bash("cargo test")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["allowTool"], true);
         assert_eq!(v["overwrite"]["name"], "Bash");
         assert_eq!(v["overwrite"]["args"]["command"], "rtk cargo test");
     }
@@ -1321,6 +1329,7 @@ mod tests {
         .to_string();
         let out = run_antigravity_inner(&input).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["allowTool"], true);
         assert_eq!(v["overwrite"]["name"], "run_command");
         assert_eq!(v["overwrite"]["args"]["Cwd"], "/tmp");
         assert_eq!(v["overwrite"]["args"]["WaitMsBeforeAsync"], 2000);

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -637,10 +637,9 @@ fn process_agy_simple(v: &Value, tool_name: &str) -> PayloadAction {
         }
     };
 
-    // agy PreToolHookResult: allowTool must be true to permit execution;
-    // overwrite replaces the tool call with the rewritten command.
+    // agy PreToolHookResult: "overwrite" replaces the tool call and implicitly
+    // allows it. Do NOT include "allowTool" — it overrides the overwrite.
     let output = json!({
-        "allowTool": true,
         "overwrite": {
             "name": tool_name,
             "args": { field: rewritten.clone() }
@@ -708,12 +707,11 @@ fn process_agy_rich(v: &Value, tool_name: &str) -> PayloadAction {
         args
     };
 
-    // agy PreToolHookResult: allowTool must be true to permit execution;
-    // overwrite replaces the tool call with the rewritten command.
+    // agy PreToolHookResult: "overwrite" replaces the tool call and implicitly
+    // allows it. Do NOT include "allowTool" — it overrides the overwrite.
     // Mirror the tool name and all args so extra fields (Cwd, WaitMsBeforeAsync, …)
     // are preserved.
     let output = json!({
-        "allowTool": true,
         "overwrite": {
             "name": tool_name,
             "args": updated_args
@@ -1264,7 +1262,10 @@ mod tests {
     fn test_agy_simple_bash_rewrite() {
         let out = run_antigravity_inner(&agy_simple_bash("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(v["allowTool"], true);
+        assert!(
+            v.get("allowTool").is_none(),
+            "allowTool must not appear alongside overwrite"
+        );
         assert_eq!(v["overwrite"]["name"], "Bash");
         assert_eq!(v["overwrite"]["args"]["command"], "rtk git status");
     }
@@ -1273,7 +1274,10 @@ mod tests {
     fn test_agy_simple_run_command_rewrite() {
         let out = run_antigravity_inner(&agy_simple_run_command("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(v["allowTool"], true);
+        assert!(
+            v.get("allowTool").is_none(),
+            "allowTool must not appear alongside overwrite"
+        );
         assert_eq!(v["overwrite"]["name"], "run_command");
         assert_eq!(v["overwrite"]["args"]["CommandLine"], "rtk git status");
     }
@@ -1304,7 +1308,10 @@ mod tests {
     fn test_agy_rich_run_command_rewrite() {
         let out = run_antigravity_inner(&agy_rich_run_command("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(v["allowTool"], true);
+        assert!(
+            v.get("allowTool").is_none(),
+            "allowTool must not appear alongside overwrite"
+        );
         assert_eq!(v["overwrite"]["name"], "run_command");
         assert_eq!(v["overwrite"]["args"]["CommandLine"], "rtk git status");
     }
@@ -1313,7 +1320,10 @@ mod tests {
     fn test_agy_rich_bash_rewrite() {
         let out = run_antigravity_inner(&agy_rich_bash("cargo test")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(v["allowTool"], true);
+        assert!(
+            v.get("allowTool").is_none(),
+            "allowTool must not appear alongside overwrite"
+        );
         assert_eq!(v["overwrite"]["name"], "Bash");
         assert_eq!(v["overwrite"]["args"]["command"], "rtk cargo test");
     }
@@ -1329,7 +1339,10 @@ mod tests {
         .to_string();
         let out = run_antigravity_inner(&input).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(v["allowTool"], true);
+        assert!(
+            v.get("allowTool").is_none(),
+            "allowTool must not appear alongside overwrite"
+        );
         assert_eq!(v["overwrite"]["name"], "run_command");
         assert_eq!(v["overwrite"]["args"]["Cwd"], "/tmp");
         assert_eq!(v["overwrite"]["args"]["WaitMsBeforeAsync"], 2000);

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -185,6 +185,17 @@ pub fn run_gemini() -> Result<()> {
 
     let json: Value = serde_json::from_str(&input).context("Failed to parse hook input as JSON")?;
 
+    // agy (Antigravity CLI) sends a rich format: toolCall.args.CommandLine.
+    // Gemini CLI sends the simple format: tool_name + tool_input.command.
+    if let Some(cmd) = json
+        .pointer("/toolCall/args/CommandLine")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+    {
+        return handle_gemini_rich(&json, cmd);
+    }
+
+    // Simple Gemini CLI format.
     let tool_name = json.get("tool_name").and_then(|v| v.as_str()).unwrap_or("");
 
     if tool_name != "run_shell_command" {
@@ -219,6 +230,42 @@ pub fn run_gemini() -> Result<()> {
         Some(ref rewritten) => {
             audit_log("rewrite", cmd, rewritten);
             print_rewrite(rewritten);
+        }
+        None => print_allow(),
+    }
+
+    Ok(())
+}
+
+/// Handle agy's rich payload format (toolCall.args.CommandLine).
+/// Preserves all extra args (Cwd, WaitMsBeforeAsync, etc.) and returns a toolCall.args response.
+fn handle_gemini_rich(json: &Value, cmd: &str) -> Result<()> {
+    if permissions::check_command(cmd) == PermissionVerdict::Deny {
+        let _ = writeln!(
+            io::stdout(),
+            r#"{{"decision":"deny","reason":"Blocked by RTK permission rule"}}"#
+        );
+        return Ok(());
+    }
+
+    let (excluded, transparent_prefixes) = crate::core::config::Config::load()
+        .map(|c| (c.hooks.exclude_commands, c.hooks.transparent_prefixes))
+        .unwrap_or_default();
+
+    match rewrite_command(cmd, &excluded, &transparent_prefixes) {
+        Some(ref rewritten) => {
+            audit_log("rewrite", cmd, rewritten);
+            let mut updated_args = json
+                .pointer("/toolCall/args")
+                .and_then(|v| v.as_object())
+                .cloned()
+                .unwrap_or_default();
+            updated_args.insert("CommandLine".to_string(), Value::String(rewritten.clone()));
+            let output = json!({
+                "decision": "allow",
+                "toolCall": {"args": updated_args}
+            });
+            let _ = writeln!(io::stdout(), "{}", output);
         }
         None => print_allow(),
     }

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -597,15 +597,19 @@ fn process_antigravity_payload(v: &Value) -> PayloadAction {
 }
 
 fn process_agy_simple(v: &Value, tool_name: &str) -> PayloadAction {
-    let cmd = match tool_name {
-        "run_command" => v
-            .pointer("/tool_input/CommandLine")
-            .and_then(|c| c.as_str())
-            .unwrap_or(""),
-        "Bash" | "bash" => v
-            .pointer("/tool_input/command")
-            .and_then(|c| c.as_str())
-            .unwrap_or(""),
+    let (cmd, arg_key) = match tool_name {
+        "run_command" => (
+            v.pointer("/tool_input/CommandLine")
+                .and_then(|c| c.as_str())
+                .unwrap_or(""),
+            "CommandLine",
+        ),
+        "Bash" | "bash" => (
+            v.pointer("/tool_input/command")
+                .and_then(|c| c.as_str())
+                .unwrap_or(""),
+            "command",
+        ),
         _ => return PayloadAction::Ignore,
     };
 
@@ -631,16 +635,11 @@ fn process_agy_simple(v: &Value, tool_name: &str) -> PayloadAction {
         }
     };
 
-    // agy deny-with-reason: deny the original command and tell the model the
-    // exact replacement. The model retries with the rtk-prefixed command, which
-    // hits the Allow list (command(rtk)) and bypasses the request-review gate.
-    // The overwrite mechanism is broken under toolPermission=request-review —
-    // the review fires on the original binary, not the overwritten one.
     let output = json!({
-        "denyReason": format!(
-            "RTK: use '{}' instead of '{}' (60-90% token savings — see GEMINI.md)",
-            rewritten, cmd
-        )
+        "overwrite": {
+            "name": tool_name,
+            "args": { arg_key: rewritten }
+        }
     });
 
     PayloadAction::Rewrite {
@@ -651,15 +650,19 @@ fn process_agy_simple(v: &Value, tool_name: &str) -> PayloadAction {
 }
 
 fn process_agy_rich(v: &Value, tool_name: &str) -> PayloadAction {
-    let cmd = match tool_name {
-        "run_command" => v
-            .pointer("/toolCall/args/CommandLine")
-            .and_then(|c| c.as_str())
-            .unwrap_or(""),
-        "Bash" | "bash" => v
-            .pointer("/toolCall/args/command")
-            .and_then(|c| c.as_str())
-            .unwrap_or(""),
+    let (cmd, arg_key) = match tool_name {
+        "run_command" => (
+            v.pointer("/toolCall/args/CommandLine")
+                .and_then(|c| c.as_str())
+                .unwrap_or(""),
+            "CommandLine",
+        ),
+        "Bash" | "bash" => (
+            v.pointer("/toolCall/args/command")
+                .and_then(|c| c.as_str())
+                .unwrap_or(""),
+            "command",
+        ),
         _ => return PayloadAction::Ignore,
     };
 
@@ -685,14 +688,21 @@ fn process_agy_rich(v: &Value, tool_name: &str) -> PayloadAction {
         }
     };
 
-    // agy deny-with-reason: deny the original command and tell the model the
-    // exact replacement. The model retries with the rtk-prefixed command, which
-    // hits the Allow list (command(rtk)) and bypasses the request-review gate.
+    // Preserve extra metadata fields (Cwd, WaitMsBeforeAsync, etc.) from the
+    // original args; only replace the command string itself.
+    let mut updated_args = v
+        .pointer("/toolCall/args")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+    if let Some(obj) = updated_args.as_object_mut() {
+        obj.insert(arg_key.to_string(), Value::String(rewritten.clone()));
+    }
+
     let output = json!({
-        "denyReason": format!(
-            "RTK: use '{}' instead of '{}' (60-90% token savings — see GEMINI.md)",
-            rewritten, cmd
-        )
+        "overwrite": {
+            "name": tool_name,
+            "args": updated_args
+        }
     });
 
     PayloadAction::Rewrite {
@@ -706,12 +716,11 @@ fn process_agy_rich(v: &Value, tool_name: &str) -> PayloadAction {
 ///
 /// Reads a JSON payload from stdin and outputs a PreToolHookResult protojson.
 ///
-/// Strategy: deny commands that need rewriting with a `denyReason` that names
-/// the rtk-prefixed replacement. The model retries with the exact replacement,
-/// which agy allows immediately because `command(rtk)` is in the Allow list
-/// (bypassing the `toolPermission=request-review` gate). The `overwrite` field
-/// was abandoned because under request-review, the review fires on the original
-/// binary — the model never sees the overwritten command.
+/// Strategy: rewrite the command in-place using the `overwrite` field
+/// (PreToolHookResult.overwrite). Under `toolPermission=always-proceed` this
+/// is transparent — no ⚠ warning, no extra LLM call. Under `request-review`
+/// the review fires on the original binary so RTK is bypassed for that turn,
+/// but the user is not blocked.
 pub fn run_antigravity() -> Result<()> {
     let input = read_stdin_limited()?;
     let input = input.trim();
@@ -1257,33 +1266,20 @@ mod tests {
     fn test_agy_simple_bash_rewrite() {
         let out = run_antigravity_inner(&agy_simple_bash("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        // deny-with-reason: no overwrite, no allowTool — just denyReason
-        assert!(
-            v.get("overwrite").is_none(),
-            "must not use overwrite (broken under request-review)"
-        );
-        assert!(v.get("allowTool").is_none());
-        let reason = v["denyReason"].as_str().unwrap();
-        assert!(
-            reason.contains("rtk git status"),
-            "deny reason must name the replacement: {reason}"
-        );
+        assert!(v.get("denyReason").is_none(), "must use overwrite, not denyReason");
+        let ow = &v["overwrite"];
+        assert_eq!(ow["name"].as_str().unwrap(), "Bash");
+        assert_eq!(ow["args"]["command"].as_str().unwrap(), "rtk git status");
     }
 
     #[test]
     fn test_agy_simple_run_command_rewrite() {
         let out = run_antigravity_inner(&agy_simple_run_command("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        assert!(
-            v.get("overwrite").is_none(),
-            "must not use overwrite (broken under request-review)"
-        );
-        assert!(v.get("allowTool").is_none());
-        let reason = v["denyReason"].as_str().unwrap();
-        assert!(
-            reason.contains("rtk git status"),
-            "deny reason must name the replacement: {reason}"
-        );
+        assert!(v.get("denyReason").is_none(), "must use overwrite, not denyReason");
+        let ow = &v["overwrite"];
+        assert_eq!(ow["name"].as_str().unwrap(), "run_command");
+        assert_eq!(ow["args"]["CommandLine"].as_str().unwrap(), "rtk git status");
     }
 
     #[test]
@@ -1312,38 +1308,24 @@ mod tests {
     fn test_agy_rich_run_command_rewrite() {
         let out = run_antigravity_inner(&agy_rich_run_command("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        assert!(
-            v.get("overwrite").is_none(),
-            "must not use overwrite (broken under request-review)"
-        );
-        assert!(v.get("allowTool").is_none());
-        let reason = v["denyReason"].as_str().unwrap();
-        assert!(
-            reason.contains("rtk git status"),
-            "deny reason must name the replacement: {reason}"
-        );
+        assert!(v.get("denyReason").is_none(), "must use overwrite, not denyReason");
+        let ow = &v["overwrite"];
+        assert_eq!(ow["name"].as_str().unwrap(), "run_command");
+        assert_eq!(ow["args"]["CommandLine"].as_str().unwrap(), "rtk git status");
     }
 
     #[test]
     fn test_agy_rich_bash_rewrite() {
         let out = run_antigravity_inner(&agy_rich_bash("cargo test")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        assert!(
-            v.get("overwrite").is_none(),
-            "must not use overwrite (broken under request-review)"
-        );
-        assert!(v.get("allowTool").is_none());
-        let reason = v["denyReason"].as_str().unwrap();
-        assert!(
-            reason.contains("rtk cargo test"),
-            "deny reason must name the replacement: {reason}"
-        );
+        assert!(v.get("denyReason").is_none(), "must use overwrite, not denyReason");
+        let ow = &v["overwrite"];
+        assert_eq!(ow["name"].as_str().unwrap(), "Bash");
+        assert_eq!(ow["args"]["command"].as_str().unwrap(), "rtk cargo test");
     }
 
     #[test]
-    fn test_agy_rich_deny_reason_names_replacement() {
-        // Extra args are no longer in the response (deny has no args to preserve),
-        // but the deny reason must still name the correct rewritten command.
+    fn test_agy_rich_overwrite_preserves_extra_args() {
         let input = json!({
             "toolCall": {
                 "name": "run_command",
@@ -1353,9 +1335,11 @@ mod tests {
         .to_string();
         let out = run_antigravity_inner(&input).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        assert!(v.get("overwrite").is_none());
-        let reason = v["denyReason"].as_str().unwrap();
-        assert!(reason.contains("rtk git status"), "deny reason: {reason}");
+        assert!(v.get("denyReason").is_none());
+        let ow = &v["overwrite"];
+        assert_eq!(ow["args"]["CommandLine"].as_str().unwrap(), "rtk git status");
+        assert_eq!(ow["args"]["Cwd"].as_str().unwrap(), "/tmp");
+        assert_eq!(ow["args"]["WaitMsBeforeAsync"].as_i64().unwrap(), 2000);
     }
 
     #[test]

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -524,14 +524,87 @@ fn run_cursor_inner_with_rules(
 }
 
 // ── Google Antigravity (agy) hook ─────────────────────────────
+//
+// agy sends two distinct payload shapes depending on context:
+//
+// Simple (older/Bash tool):
+//   {"tool_name": "Bash",         "tool_input": {"command": "git status"}}
+//   {"tool_name": "run_command",  "tool_input": {"CommandLine": "git status"}}
+//
+// Rich (newer/run_command tool — includes metadata fields):
+//   {"toolCall": {"name": "run_command", "args": {"CommandLine": "git status", "Cwd": "..."}}, ...}
+//   {"toolCall": {"name": "Bash",        "args": {"command": "git status", ...}}, ...}
 
 fn process_antigravity_payload(v: &Value) -> PayloadAction {
-    let tool_name = v
-        .pointer("/toolCall/name")
-        .and_then(|t| t.as_str())
-        .unwrap_or("");
+    // Simple format: uses top-level "tool_name" key (same as Gemini CLI).
+    if let Some(tool_name) = v.get("tool_name").and_then(|t| t.as_str()) {
+        return process_agy_simple(v, tool_name);
+    }
 
-    // Map tool name → command field name.  Non-shell tools are ignored.
+    // Rich format: command buried inside toolCall.{name,args}.
+    if let Some(tool_name) = v.pointer("/toolCall/name").and_then(|t| t.as_str()) {
+        return process_agy_rich(v, tool_name);
+    }
+
+    PayloadAction::Ignore
+}
+
+fn process_agy_simple(v: &Value, tool_name: &str) -> PayloadAction {
+    let (cmd, field) = match tool_name {
+        "run_command" => {
+            let c = v
+                .pointer("/tool_input/CommandLine")
+                .and_then(|c| c.as_str())
+                .unwrap_or("");
+            (c, "CommandLine")
+        }
+        "Bash" | "bash" => {
+            let c = v
+                .pointer("/tool_input/command")
+                .and_then(|c| c.as_str())
+                .unwrap_or("");
+            (c, "command")
+        }
+        _ => return PayloadAction::Ignore,
+    };
+
+    if cmd.is_empty() {
+        return PayloadAction::Ignore;
+    }
+
+    let verdict = permissions::check_command(cmd);
+    if verdict == PermissionVerdict::Deny {
+        return PayloadAction::Skip {
+            reason: "skip:deny_rule",
+            cmd: cmd.to_string(),
+        };
+    }
+
+    let rewritten = match get_rewritten(cmd) {
+        Some(r) => r,
+        None => {
+            return PayloadAction::Skip {
+                reason: "skip:no_match",
+                cmd: cmd.to_string(),
+            }
+        }
+    };
+
+    let output = json!({
+        "decision": "allow",
+        "hookSpecificOutput": {
+            "tool_input": { field: rewritten.clone() }
+        }
+    });
+
+    PayloadAction::Rewrite {
+        cmd: cmd.to_string(),
+        rewritten,
+        output,
+    }
+}
+
+fn process_agy_rich(v: &Value, tool_name: &str) -> PayloadAction {
     let (cmd, field) = match tool_name {
         "run_command" => {
             let c = v
@@ -572,8 +645,8 @@ fn process_antigravity_payload(v: &Value) -> PayloadAction {
         }
     };
 
-    // Mirror the full args object from the request, updating only the
-    // command field so extra fields like `Cwd` are preserved unchanged.
+    // Mirror the full args object so extra fields (Cwd, WaitMsBeforeAsync, …)
+    // are preserved unchanged in the rewritten call.
     let updated_args = {
         let mut args = v
             .pointer("/toolCall/args")
@@ -1113,77 +1186,104 @@ mod tests {
         );
     }
 
-    // --- Antigravity (agy) hook ---
+    // --- Antigravity (agy) — simple format (tool_name / tool_input) ---
 
-    fn agy_input_run_command(cmd: &str) -> String {
-        json!({
-            "toolCall": {
-                "name": "run_command",
-                "args": { "CommandLine": cmd }
-            }
-        })
-        .to_string()
+    fn agy_simple_bash(cmd: &str) -> String {
+        json!({"tool_name": "Bash", "tool_input": {"command": cmd}}).to_string()
     }
 
-    fn agy_input_bash(cmd: &str) -> String {
-        json!({
-            "toolCall": {
-                "name": "Bash",
-                "args": { "command": cmd }
-            }
-        })
-        .to_string()
+    fn agy_simple_run_command(cmd: &str) -> String {
+        json!({"tool_name": "run_command", "tool_input": {"CommandLine": cmd}}).to_string()
     }
 
     #[test]
-    fn test_agy_run_command_rewrite() {
-        let out = run_antigravity_inner(&agy_input_run_command("git status")).unwrap();
+    fn test_agy_simple_bash_rewrite() {
+        let out = run_antigravity_inner(&agy_simple_bash("git status")).unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["decision"], "allow");
+        assert_eq!(
+            v["hookSpecificOutput"]["tool_input"]["command"],
+            "rtk git status"
+        );
+    }
+
+    #[test]
+    fn test_agy_simple_run_command_rewrite() {
+        let out = run_antigravity_inner(&agy_simple_run_command("git status")).unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["decision"], "allow");
+        assert_eq!(
+            v["hookSpecificOutput"]["tool_input"]["CommandLine"],
+            "rtk git status"
+        );
+    }
+
+    #[test]
+    fn test_agy_simple_unsupported_returns_none() {
+        assert!(run_antigravity_inner(&agy_simple_bash("htop")).is_none());
+    }
+
+    #[test]
+    fn test_agy_simple_non_shell_returns_none() {
+        assert!(
+            run_antigravity_inner(&json!({"tool_name": "ListPermissions"}).to_string()).is_none()
+        );
+    }
+
+    // --- Antigravity (agy) — rich format (toolCall / args) ---
+
+    fn agy_rich_run_command(cmd: &str) -> String {
+        json!({"toolCall": {"name": "run_command", "args": {"CommandLine": cmd}}}).to_string()
+    }
+
+    fn agy_rich_bash(cmd: &str) -> String {
+        json!({"toolCall": {"name": "Bash", "args": {"command": cmd}}}).to_string()
+    }
+
+    #[test]
+    fn test_agy_rich_run_command_rewrite() {
+        let out = run_antigravity_inner(&agy_rich_run_command("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["decision"], "allow");
         assert_eq!(v["toolCall"]["args"]["CommandLine"], "rtk git status");
     }
 
     #[test]
-    fn test_agy_bash_rewrite() {
-        let out = run_antigravity_inner(&agy_input_bash("cargo test")).unwrap();
+    fn test_agy_rich_bash_rewrite() {
+        let out = run_antigravity_inner(&agy_rich_bash("cargo test")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["decision"], "allow");
         assert_eq!(v["toolCall"]["args"]["command"], "rtk cargo test");
     }
 
     #[test]
-    fn test_agy_non_shell_tool_returns_none() {
-        let input = json!({
-            "toolCall": { "name": "ListPermissions", "args": {} }
-        })
-        .to_string();
-        assert!(run_antigravity_inner(&input).is_none());
-    }
-
-    #[test]
-    fn test_agy_already_rtk_returns_none() {
-        assert!(run_antigravity_inner(&agy_input_run_command("rtk git status")).is_none());
-    }
-
-    #[test]
-    fn test_agy_unsupported_command_returns_none() {
-        assert!(run_antigravity_inner(&agy_input_run_command("htop")).is_none());
-    }
-
-    #[test]
-    fn test_agy_extra_args_preserved() {
-        // Extra fields in toolCall.args (e.g. Cwd) must survive the rewrite
+    fn test_agy_rich_extra_args_preserved() {
         let input = json!({
             "toolCall": {
                 "name": "run_command",
-                "args": { "CommandLine": "git status", "Cwd": "/tmp" }
+                "args": {"CommandLine": "git status", "Cwd": "/tmp", "WaitMsBeforeAsync": 2000}
             }
         })
         .to_string();
         let out = run_antigravity_inner(&input).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
         assert_eq!(v["toolCall"]["args"]["Cwd"], "/tmp");
+        assert_eq!(v["toolCall"]["args"]["WaitMsBeforeAsync"], 2000);
         assert_eq!(v["toolCall"]["args"]["CommandLine"], "rtk git status");
+    }
+
+    #[test]
+    fn test_agy_rich_non_shell_returns_none() {
+        assert!(run_antigravity_inner(
+            &json!({"toolCall": {"name": "ListPermissions", "args": {}}}).to_string()
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn test_agy_already_rtk_returns_none() {
+        assert!(run_antigravity_inner(&agy_simple_bash("rtk git status")).is_none());
+        assert!(run_antigravity_inner(&agy_rich_run_command("rtk git status")).is_none());
     }
 
     #[test]

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -764,6 +764,7 @@ pub fn run_antigravity() -> Result<()> {
         let _ = (|| -> Option<()> {
             let dir = dirs::home_dir()?.join(".local").join("share").join("rtk");
             let mut f = std::fs::OpenOptions::new()
+                .create(true)
                 .append(true)
                 .open(dir.join("agy-hook-debug.log"))
                 .ok()?;
@@ -1266,18 +1267,30 @@ mod tests {
     fn test_agy_simple_bash_rewrite() {
         let out = run_antigravity_inner(&agy_simple_bash("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        assert!(v.get("overwrite").is_none(), "overwrite is silently ignored by agy");
+        assert!(
+            v.get("overwrite").is_none(),
+            "overwrite is silently ignored by agy"
+        );
         let reason = v["denyReason"].as_str().unwrap();
-        assert!(reason.contains("rtk git status"), "deny reason must name the replacement: {reason}");
+        assert!(
+            reason.contains("rtk git status"),
+            "deny reason must name the replacement: {reason}"
+        );
     }
 
     #[test]
     fn test_agy_simple_run_command_rewrite() {
         let out = run_antigravity_inner(&agy_simple_run_command("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        assert!(v.get("overwrite").is_none(), "overwrite is silently ignored by agy");
+        assert!(
+            v.get("overwrite").is_none(),
+            "overwrite is silently ignored by agy"
+        );
         let reason = v["denyReason"].as_str().unwrap();
-        assert!(reason.contains("rtk git status"), "deny reason must name the replacement: {reason}");
+        assert!(
+            reason.contains("rtk git status"),
+            "deny reason must name the replacement: {reason}"
+        );
     }
 
     #[test]
@@ -1306,7 +1319,10 @@ mod tests {
     fn test_agy_rich_run_command_rewrite() {
         let out = run_antigravity_inner(&agy_rich_run_command("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        assert!(v.get("overwrite").is_none(), "overwrite is silently ignored by agy");
+        assert!(
+            v.get("overwrite").is_none(),
+            "overwrite is silently ignored by agy"
+        );
         let reason = v["denyReason"].as_str().unwrap();
         assert!(reason.contains("rtk git status"), "deny reason: {reason}");
     }
@@ -1315,7 +1331,10 @@ mod tests {
     fn test_agy_rich_bash_rewrite() {
         let out = run_antigravity_inner(&agy_rich_bash("cargo test")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        assert!(v.get("overwrite").is_none(), "overwrite is silently ignored by agy");
+        assert!(
+            v.get("overwrite").is_none(),
+            "overwrite is silently ignored by agy"
+        );
         let reason = v["denyReason"].as_str().unwrap();
         assert!(reason.contains("rtk cargo test"), "deny reason: {reason}");
     }

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -597,21 +597,15 @@ fn process_antigravity_payload(v: &Value) -> PayloadAction {
 }
 
 fn process_agy_simple(v: &Value, tool_name: &str) -> PayloadAction {
-    let (cmd, field) = match tool_name {
-        "run_command" => {
-            let c = v
-                .pointer("/tool_input/CommandLine")
-                .and_then(|c| c.as_str())
-                .unwrap_or("");
-            (c, "CommandLine")
-        }
-        "Bash" | "bash" => {
-            let c = v
-                .pointer("/tool_input/command")
-                .and_then(|c| c.as_str())
-                .unwrap_or("");
-            (c, "command")
-        }
+    let cmd = match tool_name {
+        "run_command" => v
+            .pointer("/tool_input/CommandLine")
+            .and_then(|c| c.as_str())
+            .unwrap_or(""),
+        "Bash" | "bash" => v
+            .pointer("/tool_input/command")
+            .and_then(|c| c.as_str())
+            .unwrap_or(""),
         _ => return PayloadAction::Ignore,
     };
 
@@ -637,13 +631,16 @@ fn process_agy_simple(v: &Value, tool_name: &str) -> PayloadAction {
         }
     };
 
-    // agy PreToolHookResult: "overwrite" replaces the tool call and implicitly
-    // allows it. Do NOT include "allowTool" — it overrides the overwrite.
+    // agy deny-with-reason: deny the original command and tell the model the
+    // exact replacement. The model retries with the rtk-prefixed command, which
+    // hits the Allow list (command(rtk)) and bypasses the request-review gate.
+    // The overwrite mechanism is broken under toolPermission=request-review —
+    // the review fires on the original binary, not the overwritten one.
     let output = json!({
-        "overwrite": {
-            "name": tool_name,
-            "args": { field: rewritten.clone() }
-        }
+        "denyReason": format!(
+            "RTK: use '{}' instead of '{}' (60-90% token savings — see CLAUDE.md)",
+            rewritten, cmd
+        )
     });
 
     PayloadAction::Rewrite {
@@ -654,21 +651,15 @@ fn process_agy_simple(v: &Value, tool_name: &str) -> PayloadAction {
 }
 
 fn process_agy_rich(v: &Value, tool_name: &str) -> PayloadAction {
-    let (cmd, field) = match tool_name {
-        "run_command" => {
-            let c = v
-                .pointer("/toolCall/args/CommandLine")
-                .and_then(|c| c.as_str())
-                .unwrap_or("");
-            (c, "CommandLine")
-        }
-        "Bash" | "bash" => {
-            let c = v
-                .pointer("/toolCall/args/command")
-                .and_then(|c| c.as_str())
-                .unwrap_or("");
-            (c, "command")
-        }
+    let cmd = match tool_name {
+        "run_command" => v
+            .pointer("/toolCall/args/CommandLine")
+            .and_then(|c| c.as_str())
+            .unwrap_or(""),
+        "Bash" | "bash" => v
+            .pointer("/toolCall/args/command")
+            .and_then(|c| c.as_str())
+            .unwrap_or(""),
         _ => return PayloadAction::Ignore,
     };
 
@@ -694,28 +685,14 @@ fn process_agy_rich(v: &Value, tool_name: &str) -> PayloadAction {
         }
     };
 
-    // Mirror the full args object so extra fields (Cwd, WaitMsBeforeAsync, …)
-    // are preserved unchanged in the rewritten call.
-    let updated_args = {
-        let mut args = v
-            .pointer("/toolCall/args")
-            .cloned()
-            .unwrap_or_else(|| json!({}));
-        if let Some(obj) = args.as_object_mut() {
-            obj.insert(field.to_string(), Value::String(rewritten.clone()));
-        }
-        args
-    };
-
-    // agy PreToolHookResult: "overwrite" replaces the tool call and implicitly
-    // allows it. Do NOT include "allowTool" — it overrides the overwrite.
-    // Mirror the tool name and all args so extra fields (Cwd, WaitMsBeforeAsync, …)
-    // are preserved.
+    // agy deny-with-reason: deny the original command and tell the model the
+    // exact replacement. The model retries with the rtk-prefixed command, which
+    // hits the Allow list (command(rtk)) and bypasses the request-review gate.
     let output = json!({
-        "overwrite": {
-            "name": tool_name,
-            "args": updated_args
-        }
+        "denyReason": format!(
+            "RTK: use '{}' instead of '{}' (60-90% token savings — see CLAUDE.md)",
+            rewritten, cmd
+        )
     });
 
     PayloadAction::Rewrite {
@@ -727,12 +704,14 @@ fn process_agy_rich(v: &Value, tool_name: &str) -> PayloadAction {
 
 /// Run the Google Antigravity (agy) CLI PreToolUse hook.
 ///
-/// Reads a JSON payload from stdin, rewrites shell commands through RTK,
-/// and outputs the result as a PreToolHookResult protojson.
+/// Reads a JSON payload from stdin and outputs a PreToolHookResult protojson.
 ///
-/// IMPORTANT: agy's PreToolHookResult.allow_tool defaults to false (deny).
-/// Every response must include `{"allowTool": true}` to permit the tool.
-/// `{}` is NOT an allow — it's an implicit deny.
+/// Strategy: deny commands that need rewriting with a `denyReason` that names
+/// the rtk-prefixed replacement. The model retries with the exact replacement,
+/// which agy allows immediately because `command(rtk)` is in the Allow list
+/// (bypassing the `toolPermission=request-review` gate). The `overwrite` field
+/// was abandoned because under request-review, the review fires on the original
+/// binary — the model never sees the overwritten command.
 pub fn run_antigravity() -> Result<()> {
     let input = read_stdin_limited()?;
     let input = input.trim();
@@ -1278,12 +1257,17 @@ mod tests {
     fn test_agy_simple_bash_rewrite() {
         let out = run_antigravity_inner(&agy_simple_bash("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
+        // deny-with-reason: no overwrite, no allowTool — just denyReason
         assert!(
-            v.get("allowTool").is_none(),
-            "allowTool must not appear alongside overwrite"
+            v.get("overwrite").is_none(),
+            "must not use overwrite (broken under request-review)"
         );
-        assert_eq!(v["overwrite"]["name"], "Bash");
-        assert_eq!(v["overwrite"]["args"]["command"], "rtk git status");
+        assert!(v.get("allowTool").is_none());
+        let reason = v["denyReason"].as_str().unwrap();
+        assert!(
+            reason.contains("rtk git status"),
+            "deny reason must name the replacement: {reason}"
+        );
     }
 
     #[test]
@@ -1291,11 +1275,15 @@ mod tests {
         let out = run_antigravity_inner(&agy_simple_run_command("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
         assert!(
-            v.get("allowTool").is_none(),
-            "allowTool must not appear alongside overwrite"
+            v.get("overwrite").is_none(),
+            "must not use overwrite (broken under request-review)"
         );
-        assert_eq!(v["overwrite"]["name"], "run_command");
-        assert_eq!(v["overwrite"]["args"]["CommandLine"], "rtk git status");
+        assert!(v.get("allowTool").is_none());
+        let reason = v["denyReason"].as_str().unwrap();
+        assert!(
+            reason.contains("rtk git status"),
+            "deny reason must name the replacement: {reason}"
+        );
     }
 
     #[test]
@@ -1325,11 +1313,15 @@ mod tests {
         let out = run_antigravity_inner(&agy_rich_run_command("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
         assert!(
-            v.get("allowTool").is_none(),
-            "allowTool must not appear alongside overwrite"
+            v.get("overwrite").is_none(),
+            "must not use overwrite (broken under request-review)"
         );
-        assert_eq!(v["overwrite"]["name"], "run_command");
-        assert_eq!(v["overwrite"]["args"]["CommandLine"], "rtk git status");
+        assert!(v.get("allowTool").is_none());
+        let reason = v["denyReason"].as_str().unwrap();
+        assert!(
+            reason.contains("rtk git status"),
+            "deny reason must name the replacement: {reason}"
+        );
     }
 
     #[test]
@@ -1337,15 +1329,21 @@ mod tests {
         let out = run_antigravity_inner(&agy_rich_bash("cargo test")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
         assert!(
-            v.get("allowTool").is_none(),
-            "allowTool must not appear alongside overwrite"
+            v.get("overwrite").is_none(),
+            "must not use overwrite (broken under request-review)"
         );
-        assert_eq!(v["overwrite"]["name"], "Bash");
-        assert_eq!(v["overwrite"]["args"]["command"], "rtk cargo test");
+        assert!(v.get("allowTool").is_none());
+        let reason = v["denyReason"].as_str().unwrap();
+        assert!(
+            reason.contains("rtk cargo test"),
+            "deny reason must name the replacement: {reason}"
+        );
     }
 
     #[test]
-    fn test_agy_rich_extra_args_preserved() {
+    fn test_agy_rich_deny_reason_names_replacement() {
+        // Extra args are no longer in the response (deny has no args to preserve),
+        // but the deny reason must still name the correct rewritten command.
         let input = json!({
             "toolCall": {
                 "name": "run_command",
@@ -1355,14 +1353,9 @@ mod tests {
         .to_string();
         let out = run_antigravity_inner(&input).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        assert!(
-            v.get("allowTool").is_none(),
-            "allowTool must not appear alongside overwrite"
-        );
-        assert_eq!(v["overwrite"]["name"], "run_command");
-        assert_eq!(v["overwrite"]["args"]["Cwd"], "/tmp");
-        assert_eq!(v["overwrite"]["args"]["WaitMsBeforeAsync"], 2000);
-        assert_eq!(v["overwrite"]["args"]["CommandLine"], "rtk git status");
+        assert!(v.get("overwrite").is_none());
+        let reason = v["denyReason"].as_str().unwrap();
+        assert!(reason.contains("rtk git status"), "deny reason: {reason}");
     }
 
     #[test]

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -637,10 +637,11 @@ fn process_agy_simple(v: &Value, tool_name: &str) -> PayloadAction {
         }
     };
 
+    // agy PreToolHookResult: use "overwrite" to replace the tool call.
     let output = json!({
-        "decision": "allow",
-        "hookSpecificOutput": {
-            "tool_input": { field: rewritten.clone() }
+        "overwrite": {
+            "name": tool_name,
+            "args": { field: rewritten.clone() }
         }
     });
 
@@ -705,9 +706,14 @@ fn process_agy_rich(v: &Value, tool_name: &str) -> PayloadAction {
         args
     };
 
+    // agy PreToolHookResult: use "overwrite" (HookToolCall) to replace the call.
+    // Mirror the tool name and all args so extra fields (Cwd, WaitMsBeforeAsync, …)
+    // are preserved.
     let output = json!({
-        "decision": "allow",
-        "toolCall": { "args": updated_args }
+        "overwrite": {
+            "name": tool_name,
+            "args": updated_args
+        }
     });
 
     PayloadAction::Rewrite {
@@ -1247,22 +1253,16 @@ mod tests {
     fn test_agy_simple_bash_rewrite() {
         let out = run_antigravity_inner(&agy_simple_bash("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(v["decision"], "allow");
-        assert_eq!(
-            v["hookSpecificOutput"]["tool_input"]["command"],
-            "rtk git status"
-        );
+        assert_eq!(v["overwrite"]["name"], "Bash");
+        assert_eq!(v["overwrite"]["args"]["command"], "rtk git status");
     }
 
     #[test]
     fn test_agy_simple_run_command_rewrite() {
         let out = run_antigravity_inner(&agy_simple_run_command("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(v["decision"], "allow");
-        assert_eq!(
-            v["hookSpecificOutput"]["tool_input"]["CommandLine"],
-            "rtk git status"
-        );
+        assert_eq!(v["overwrite"]["name"], "run_command");
+        assert_eq!(v["overwrite"]["args"]["CommandLine"], "rtk git status");
     }
 
     #[test]
@@ -1291,16 +1291,16 @@ mod tests {
     fn test_agy_rich_run_command_rewrite() {
         let out = run_antigravity_inner(&agy_rich_run_command("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(v["decision"], "allow");
-        assert_eq!(v["toolCall"]["args"]["CommandLine"], "rtk git status");
+        assert_eq!(v["overwrite"]["name"], "run_command");
+        assert_eq!(v["overwrite"]["args"]["CommandLine"], "rtk git status");
     }
 
     #[test]
     fn test_agy_rich_bash_rewrite() {
         let out = run_antigravity_inner(&agy_rich_bash("cargo test")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(v["decision"], "allow");
-        assert_eq!(v["toolCall"]["args"]["command"], "rtk cargo test");
+        assert_eq!(v["overwrite"]["name"], "Bash");
+        assert_eq!(v["overwrite"]["args"]["command"], "rtk cargo test");
     }
 
     #[test]
@@ -1314,9 +1314,10 @@ mod tests {
         .to_string();
         let out = run_antigravity_inner(&input).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        assert_eq!(v["toolCall"]["args"]["Cwd"], "/tmp");
-        assert_eq!(v["toolCall"]["args"]["WaitMsBeforeAsync"], 2000);
-        assert_eq!(v["toolCall"]["args"]["CommandLine"], "rtk git status");
+        assert_eq!(v["overwrite"]["name"], "run_command");
+        assert_eq!(v["overwrite"]["args"]["Cwd"], "/tmp");
+        assert_eq!(v["overwrite"]["args"]["WaitMsBeforeAsync"], 2000);
+        assert_eq!(v["overwrite"]["args"]["CommandLine"], "rtk git status");
     }
 
     #[test]

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -740,6 +740,22 @@ pub fn run_antigravity() -> Result<()> {
         return Ok(());
     }
 
+    // RTK_HOOK_DEBUG=1 — dump raw stdin to ~/.local/share/rtk/agy-hook-debug.log
+    if std::env::var("RTK_HOOK_DEBUG").as_deref() == Ok("1") {
+        let _ = (|| -> Option<()> {
+            let dir = dirs::home_dir()?.join(".local").join("share").join("rtk");
+            std::fs::create_dir_all(&dir).ok()?;
+            let mut f = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(dir.join("agy-hook-debug.log"))
+                .ok()?;
+            let ts = chrono::Local::now().format("%Y-%m-%dT%H:%M:%S");
+            let _ = writeln!(f, "--- {} ---\n{}\n", ts, input);
+            Some(())
+        })();
+    }
+
     let v: Value = match serde_json::from_str(input) {
         Ok(v) => v,
         Err(e) => {

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -726,12 +726,15 @@ fn process_agy_rich(v: &Value, tool_name: &str) -> PayloadAction {
 /// Run the Google Antigravity (agy) CLI PreToolUse hook.
 ///
 /// Reads a JSON payload from stdin, rewrites shell commands through RTK,
-/// and outputs the modified tool call.  Non-shell tools and commands that
-/// don't match any RTK filter produce no output so the tool runs unchanged.
+/// and outputs the result as a PreToolHookResult protojson.
+///
+/// IMPORTANT: agy interprets empty stdout as "deny" — always output at
+/// least `{}` (allow, no modification) so non-shell tools are not blocked.
 pub fn run_antigravity() -> Result<()> {
     let input = read_stdin_limited()?;
     let input = input.trim();
     if input.is_empty() {
+        // No payload — nothing to process, nothing to allow.
         return Ok(());
     }
 
@@ -739,6 +742,8 @@ pub fn run_antigravity() -> Result<()> {
         Ok(v) => v,
         Err(e) => {
             let _ = writeln!(io::stderr(), "[rtk hook] Failed to parse JSON input: {e}");
+            // Still output allow so a parse error doesn't block the tool.
+            let _ = writeln!(io::stdout(), "{{}}");
             return Ok(());
         }
     };
@@ -754,10 +759,12 @@ pub fn run_antigravity() -> Result<()> {
         }
         PayloadAction::Skip { reason, cmd } => {
             audit_log(reason, &cmd, "");
-            // No stdout output — the Antigravity CLI runs the tool unchanged.
+            // No rewrite needed — allow unchanged.
+            let _ = writeln!(io::stdout(), "{{}}");
         }
         PayloadAction::Ignore => {
-            // Non-shell tool — no output, let it pass through natively.
+            // Non-shell tool — allow unchanged.
+            let _ = writeln!(io::stdout(), "{{}}");
         }
     }
 

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -638,7 +638,7 @@ fn process_agy_simple(v: &Value, tool_name: &str) -> PayloadAction {
     // the review fires on the original binary, not the overwritten one.
     let output = json!({
         "denyReason": format!(
-            "RTK: use '{}' instead of '{}' (60-90% token savings — see CLAUDE.md)",
+            "RTK: use '{}' instead of '{}' (60-90% token savings — see GEMINI.md)",
             rewritten, cmd
         )
     });
@@ -690,7 +690,7 @@ fn process_agy_rich(v: &Value, tool_name: &str) -> PayloadAction {
     // hits the Allow list (command(rtk)) and bypasses the request-review gate.
     let output = json!({
         "denyReason": format!(
-            "RTK: use '{}' instead of '{}' (60-90% token savings — see CLAUDE.md)",
+            "RTK: use '{}' instead of '{}' (60-90% token savings — see GEMINI.md)",
             rewritten, cmd
         )
     });

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -636,6 +636,7 @@ fn process_agy_simple(v: &Value, tool_name: &str) -> PayloadAction {
     };
 
     let output = json!({
+        "allowTool": true,
         "overwrite": {
             "name": tool_name,
             "args": { arg_key: rewritten }
@@ -699,6 +700,7 @@ fn process_agy_rich(v: &Value, tool_name: &str) -> PayloadAction {
     }
 
     let output = json!({
+        "allowTool": true,
         "overwrite": {
             "name": tool_name,
             "args": updated_args
@@ -1267,6 +1269,7 @@ mod tests {
         let out = run_antigravity_inner(&agy_simple_bash("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
         assert!(v.get("denyReason").is_none(), "must use overwrite, not denyReason");
+        assert_eq!(v["allowTool"], true, "allowTool must be true to permit the rewrite");
         let ow = &v["overwrite"];
         assert_eq!(ow["name"].as_str().unwrap(), "Bash");
         assert_eq!(ow["args"]["command"].as_str().unwrap(), "rtk git status");
@@ -1277,6 +1280,7 @@ mod tests {
         let out = run_antigravity_inner(&agy_simple_run_command("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
         assert!(v.get("denyReason").is_none(), "must use overwrite, not denyReason");
+        assert_eq!(v["allowTool"], true, "allowTool must be true to permit the rewrite");
         let ow = &v["overwrite"];
         assert_eq!(ow["name"].as_str().unwrap(), "run_command");
         assert_eq!(ow["args"]["CommandLine"].as_str().unwrap(), "rtk git status");
@@ -1309,6 +1313,7 @@ mod tests {
         let out = run_antigravity_inner(&agy_rich_run_command("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
         assert!(v.get("denyReason").is_none(), "must use overwrite, not denyReason");
+        assert_eq!(v["allowTool"], true);
         let ow = &v["overwrite"];
         assert_eq!(ow["name"].as_str().unwrap(), "run_command");
         assert_eq!(ow["args"]["CommandLine"].as_str().unwrap(), "rtk git status");
@@ -1319,6 +1324,7 @@ mod tests {
         let out = run_antigravity_inner(&agy_rich_bash("cargo test")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
         assert!(v.get("denyReason").is_none(), "must use overwrite, not denyReason");
+        assert_eq!(v["allowTool"], true);
         let ow = &v["overwrite"];
         assert_eq!(ow["name"].as_str().unwrap(), "Bash");
         assert_eq!(ow["args"]["command"].as_str().unwrap(), "rtk cargo test");

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -523,6 +523,130 @@ fn run_cursor_inner_with_rules(
     }
 }
 
+// ── Google Antigravity (agy) hook ─────────────────────────────
+
+fn process_antigravity_payload(v: &Value) -> PayloadAction {
+    let tool_name = v
+        .pointer("/toolCall/name")
+        .and_then(|t| t.as_str())
+        .unwrap_or("");
+
+    // Map tool name → command field name.  Non-shell tools are ignored.
+    let (cmd, field) = match tool_name {
+        "run_command" => {
+            let c = v
+                .pointer("/toolCall/args/CommandLine")
+                .and_then(|c| c.as_str())
+                .unwrap_or("");
+            (c, "CommandLine")
+        }
+        "Bash" | "bash" => {
+            let c = v
+                .pointer("/toolCall/args/command")
+                .and_then(|c| c.as_str())
+                .unwrap_or("");
+            (c, "command")
+        }
+        _ => return PayloadAction::Ignore,
+    };
+
+    if cmd.is_empty() {
+        return PayloadAction::Ignore;
+    }
+
+    let verdict = permissions::check_command(cmd);
+    if verdict == PermissionVerdict::Deny {
+        return PayloadAction::Skip {
+            reason: "skip:deny_rule",
+            cmd: cmd.to_string(),
+        };
+    }
+
+    let rewritten = match get_rewritten(cmd) {
+        Some(r) => r,
+        None => {
+            return PayloadAction::Skip {
+                reason: "skip:no_match",
+                cmd: cmd.to_string(),
+            }
+        }
+    };
+
+    // Mirror the full args object from the request, updating only the
+    // command field so extra fields like `Cwd` are preserved unchanged.
+    let updated_args = {
+        let mut args = v
+            .pointer("/toolCall/args")
+            .cloned()
+            .unwrap_or_else(|| json!({}));
+        if let Some(obj) = args.as_object_mut() {
+            obj.insert(field.to_string(), Value::String(rewritten.clone()));
+        }
+        args
+    };
+
+    let output = json!({
+        "decision": "allow",
+        "toolCall": { "args": updated_args }
+    });
+
+    PayloadAction::Rewrite {
+        cmd: cmd.to_string(),
+        rewritten,
+        output,
+    }
+}
+
+/// Run the Google Antigravity (agy) CLI PreToolUse hook.
+///
+/// Reads a JSON payload from stdin, rewrites shell commands through RTK,
+/// and outputs the modified tool call.  Non-shell tools and commands that
+/// don't match any RTK filter produce no output so the tool runs unchanged.
+pub fn run_antigravity() -> Result<()> {
+    let input = read_stdin_limited()?;
+    let input = input.trim();
+    if input.is_empty() {
+        return Ok(());
+    }
+
+    let v: Value = match serde_json::from_str(input) {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = writeln!(io::stderr(), "[rtk hook] Failed to parse JSON input: {e}");
+            return Ok(());
+        }
+    };
+
+    match process_antigravity_payload(&v) {
+        PayloadAction::Rewrite {
+            cmd,
+            rewritten,
+            output,
+        } => {
+            audit_log("rewrite", &cmd, &rewritten);
+            let _ = writeln!(io::stdout(), "{output}");
+        }
+        PayloadAction::Skip { reason, cmd } => {
+            audit_log(reason, &cmd, "");
+            // No stdout output — the Antigravity CLI runs the tool unchanged.
+        }
+        PayloadAction::Ignore => {
+            // Non-shell tool — no output, let it pass through natively.
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+fn run_antigravity_inner(input: &str) -> Option<String> {
+    let v: Value = serde_json::from_str(input).ok()?;
+    match process_antigravity_payload(&v) {
+        PayloadAction::Rewrite { output, .. } => Some(output.to_string()),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -987,5 +1111,88 @@ mod tests {
             get_rewritten("cargo test").is_some(),
             "cargo test should be rewritable when not denied"
         );
+    }
+
+    // --- Antigravity (agy) hook ---
+
+    fn agy_input_run_command(cmd: &str) -> String {
+        json!({
+            "toolCall": {
+                "name": "run_command",
+                "args": { "CommandLine": cmd }
+            }
+        })
+        .to_string()
+    }
+
+    fn agy_input_bash(cmd: &str) -> String {
+        json!({
+            "toolCall": {
+                "name": "Bash",
+                "args": { "command": cmd }
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn test_agy_run_command_rewrite() {
+        let out = run_antigravity_inner(&agy_input_run_command("git status")).unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["decision"], "allow");
+        assert_eq!(v["toolCall"]["args"]["CommandLine"], "rtk git status");
+    }
+
+    #[test]
+    fn test_agy_bash_rewrite() {
+        let out = run_antigravity_inner(&agy_input_bash("cargo test")).unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["decision"], "allow");
+        assert_eq!(v["toolCall"]["args"]["command"], "rtk cargo test");
+    }
+
+    #[test]
+    fn test_agy_non_shell_tool_returns_none() {
+        let input = json!({
+            "toolCall": { "name": "ListPermissions", "args": {} }
+        })
+        .to_string();
+        assert!(run_antigravity_inner(&input).is_none());
+    }
+
+    #[test]
+    fn test_agy_already_rtk_returns_none() {
+        assert!(run_antigravity_inner(&agy_input_run_command("rtk git status")).is_none());
+    }
+
+    #[test]
+    fn test_agy_unsupported_command_returns_none() {
+        assert!(run_antigravity_inner(&agy_input_run_command("htop")).is_none());
+    }
+
+    #[test]
+    fn test_agy_extra_args_preserved() {
+        // Extra fields in toolCall.args (e.g. Cwd) must survive the rewrite
+        let input = json!({
+            "toolCall": {
+                "name": "run_command",
+                "args": { "CommandLine": "git status", "Cwd": "/tmp" }
+            }
+        })
+        .to_string();
+        let out = run_antigravity_inner(&input).unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["toolCall"]["args"]["Cwd"], "/tmp");
+        assert_eq!(v["toolCall"]["args"]["CommandLine"], "rtk git status");
+    }
+
+    #[test]
+    fn test_agy_empty_input_returns_none() {
+        assert!(run_antigravity_inner("").is_none());
+    }
+
+    #[test]
+    fn test_agy_invalid_json_returns_none() {
+        assert!(run_antigravity_inner("not json").is_none());
     }
 }

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -597,19 +597,15 @@ fn process_antigravity_payload(v: &Value) -> PayloadAction {
 }
 
 fn process_agy_simple(v: &Value, tool_name: &str) -> PayloadAction {
-    let (cmd, arg_key) = match tool_name {
-        "run_command" => (
-            v.pointer("/tool_input/CommandLine")
-                .and_then(|c| c.as_str())
-                .unwrap_or(""),
-            "CommandLine",
-        ),
-        "Bash" | "bash" => (
-            v.pointer("/tool_input/command")
-                .and_then(|c| c.as_str())
-                .unwrap_or(""),
-            "command",
-        ),
+    let cmd = match tool_name {
+        "run_command" => v
+            .pointer("/tool_input/CommandLine")
+            .and_then(|c| c.as_str())
+            .unwrap_or(""),
+        "Bash" | "bash" => v
+            .pointer("/tool_input/command")
+            .and_then(|c| c.as_str())
+            .unwrap_or(""),
         _ => return PayloadAction::Ignore,
     };
 
@@ -635,12 +631,14 @@ fn process_agy_simple(v: &Value, tool_name: &str) -> PayloadAction {
         }
     };
 
+    // agy's `overwrite` field in PreToolHookResult is silently ignored (confirmed
+    // via RTK_HOOK_DEBUG: correct payload sent, original command executed anyway).
+    // denyReason is the only hook mechanism agy actually implements.
     let output = json!({
-        "allowTool": true,
-        "overwrite": {
-            "name": tool_name,
-            "args": { arg_key: rewritten }
-        }
+        "denyReason": format!(
+            "RTK: use '{}' instead of '{}' (60-90% token savings)",
+            rewritten, cmd
+        )
     });
 
     PayloadAction::Rewrite {
@@ -651,19 +649,15 @@ fn process_agy_simple(v: &Value, tool_name: &str) -> PayloadAction {
 }
 
 fn process_agy_rich(v: &Value, tool_name: &str) -> PayloadAction {
-    let (cmd, arg_key) = match tool_name {
-        "run_command" => (
-            v.pointer("/toolCall/args/CommandLine")
-                .and_then(|c| c.as_str())
-                .unwrap_or(""),
-            "CommandLine",
-        ),
-        "Bash" | "bash" => (
-            v.pointer("/toolCall/args/command")
-                .and_then(|c| c.as_str())
-                .unwrap_or(""),
-            "command",
-        ),
+    let cmd = match tool_name {
+        "run_command" => v
+            .pointer("/toolCall/args/CommandLine")
+            .and_then(|c| c.as_str())
+            .unwrap_or(""),
+        "Bash" | "bash" => v
+            .pointer("/toolCall/args/command")
+            .and_then(|c| c.as_str())
+            .unwrap_or(""),
         _ => return PayloadAction::Ignore,
     };
 
@@ -689,22 +683,12 @@ fn process_agy_rich(v: &Value, tool_name: &str) -> PayloadAction {
         }
     };
 
-    // Preserve extra metadata fields (Cwd, WaitMsBeforeAsync, etc.) from the
-    // original args; only replace the command string itself.
-    let mut updated_args = v
-        .pointer("/toolCall/args")
-        .cloned()
-        .unwrap_or_else(|| json!({}));
-    if let Some(obj) = updated_args.as_object_mut() {
-        obj.insert(arg_key.to_string(), Value::String(rewritten.clone()));
-    }
-
+    // agy's `overwrite` field is silently ignored — only denyReason works.
     let output = json!({
-        "allowTool": true,
-        "overwrite": {
-            "name": tool_name,
-            "args": updated_args
-        }
+        "denyReason": format!(
+            "RTK: use '{}' instead of '{}' (60-90% token savings)",
+            rewritten, cmd
+        )
     });
 
     PayloadAction::Rewrite {
@@ -718,11 +702,13 @@ fn process_agy_rich(v: &Value, tool_name: &str) -> PayloadAction {
 ///
 /// Reads a JSON payload from stdin and outputs a PreToolHookResult protojson.
 ///
-/// Strategy: rewrite the command in-place using the `overwrite` field
-/// (PreToolHookResult.overwrite). Under `toolPermission=always-proceed` this
-/// is transparent — no ⚠ warning, no extra LLM call. Under `request-review`
-/// the review fires on the original binary so RTK is bypassed for that turn,
-/// but the user is not blocked.
+/// Strategy: deny commands that need rewriting with a `denyReason` naming the
+/// rtk-prefixed replacement. The model retries with that command, which agy
+/// auto-approves via `command(rtk)` in the allow list.
+///
+/// NOTE: The `overwrite` field in PreToolHookResult is silently ignored by agy
+/// regardless of permission mode — confirmed via debug logging. Only
+/// `allowTool` and `denyReason` are honored.
 pub fn run_antigravity() -> Result<()> {
     let input = read_stdin_limited()?;
     let input = input.trim();
@@ -756,25 +742,37 @@ pub fn run_antigravity() -> Result<()> {
         }
     };
 
-    match process_antigravity_payload(&v) {
+    let debug = std::env::var("RTK_HOOK_DEBUG").as_deref() == Ok("1");
+
+    let response = match process_antigravity_payload(&v) {
         PayloadAction::Rewrite {
             cmd,
             rewritten,
             output,
         } => {
             audit_log("rewrite", &cmd, &rewritten);
-            let _ = writeln!(io::stdout(), "{output}");
+            output.to_string()
         }
         PayloadAction::Skip { reason, cmd } => {
             audit_log(reason, &cmd, "");
-            // No rewrite needed — allow the original tool call unchanged.
-            let _ = writeln!(io::stdout(), r#"{{"allowTool":true}}"#);
+            r#"{"allowTool":true}"#.to_string()
         }
-        PayloadAction::Ignore => {
-            // Non-shell tool — allow unchanged.
-            let _ = writeln!(io::stdout(), r#"{{"allowTool":true}}"#);
-        }
+        PayloadAction::Ignore => r#"{"allowTool":true}"#.to_string(),
+    };
+
+    if debug {
+        let _ = (|| -> Option<()> {
+            let dir = dirs::home_dir()?.join(".local").join("share").join("rtk");
+            let mut f = std::fs::OpenOptions::new()
+                .append(true)
+                .open(dir.join("agy-hook-debug.log"))
+                .ok()?;
+            let _ = writeln!(f, ">>> {}\n", response);
+            Some(())
+        })();
     }
+
+    let _ = writeln!(io::stdout(), "{response}");
 
     Ok(())
 }
@@ -1268,22 +1266,18 @@ mod tests {
     fn test_agy_simple_bash_rewrite() {
         let out = run_antigravity_inner(&agy_simple_bash("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        assert!(v.get("denyReason").is_none(), "must use overwrite, not denyReason");
-        assert_eq!(v["allowTool"], true, "allowTool must be true to permit the rewrite");
-        let ow = &v["overwrite"];
-        assert_eq!(ow["name"].as_str().unwrap(), "Bash");
-        assert_eq!(ow["args"]["command"].as_str().unwrap(), "rtk git status");
+        assert!(v.get("overwrite").is_none(), "overwrite is silently ignored by agy");
+        let reason = v["denyReason"].as_str().unwrap();
+        assert!(reason.contains("rtk git status"), "deny reason must name the replacement: {reason}");
     }
 
     #[test]
     fn test_agy_simple_run_command_rewrite() {
         let out = run_antigravity_inner(&agy_simple_run_command("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        assert!(v.get("denyReason").is_none(), "must use overwrite, not denyReason");
-        assert_eq!(v["allowTool"], true, "allowTool must be true to permit the rewrite");
-        let ow = &v["overwrite"];
-        assert_eq!(ow["name"].as_str().unwrap(), "run_command");
-        assert_eq!(ow["args"]["CommandLine"].as_str().unwrap(), "rtk git status");
+        assert!(v.get("overwrite").is_none(), "overwrite is silently ignored by agy");
+        let reason = v["denyReason"].as_str().unwrap();
+        assert!(reason.contains("rtk git status"), "deny reason must name the replacement: {reason}");
     }
 
     #[test]
@@ -1312,26 +1306,22 @@ mod tests {
     fn test_agy_rich_run_command_rewrite() {
         let out = run_antigravity_inner(&agy_rich_run_command("git status")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        assert!(v.get("denyReason").is_none(), "must use overwrite, not denyReason");
-        assert_eq!(v["allowTool"], true);
-        let ow = &v["overwrite"];
-        assert_eq!(ow["name"].as_str().unwrap(), "run_command");
-        assert_eq!(ow["args"]["CommandLine"].as_str().unwrap(), "rtk git status");
+        assert!(v.get("overwrite").is_none(), "overwrite is silently ignored by agy");
+        let reason = v["denyReason"].as_str().unwrap();
+        assert!(reason.contains("rtk git status"), "deny reason: {reason}");
     }
 
     #[test]
     fn test_agy_rich_bash_rewrite() {
         let out = run_antigravity_inner(&agy_rich_bash("cargo test")).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        assert!(v.get("denyReason").is_none(), "must use overwrite, not denyReason");
-        assert_eq!(v["allowTool"], true);
-        let ow = &v["overwrite"];
-        assert_eq!(ow["name"].as_str().unwrap(), "Bash");
-        assert_eq!(ow["args"]["command"].as_str().unwrap(), "rtk cargo test");
+        assert!(v.get("overwrite").is_none(), "overwrite is silently ignored by agy");
+        let reason = v["denyReason"].as_str().unwrap();
+        assert!(reason.contains("rtk cargo test"), "deny reason: {reason}");
     }
 
     #[test]
-    fn test_agy_rich_overwrite_preserves_extra_args() {
+    fn test_agy_rich_deny_reason_names_replacement() {
         let input = json!({
             "toolCall": {
                 "name": "run_command",
@@ -1341,11 +1331,9 @@ mod tests {
         .to_string();
         let out = run_antigravity_inner(&input).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
-        assert!(v.get("denyReason").is_none());
-        let ow = &v["overwrite"];
-        assert_eq!(ow["args"]["CommandLine"].as_str().unwrap(), "rtk git status");
-        assert_eq!(ow["args"]["Cwd"].as_str().unwrap(), "/tmp");
-        assert_eq!(ow["args"]["WaitMsBeforeAsync"].as_i64().unwrap(), 2000);
+        assert!(v.get("overwrite").is_none());
+        let reason = v["denyReason"].as_str().unwrap();
+        assert!(reason.contains("rtk git status"), "deny reason: {reason}");
     }
 
     #[test]

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -8,8 +8,8 @@ use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 
 use crate::hooks::constants::{
-    CONFIG_DIR, CURSOR_DIR, GEMINI_DIR, HOOKS_JSON, OPENCODE_PLUGIN_FILE, OPENCODE_SUBDIR,
-    PLUGIN_SUBDIR,
+    AGY_CLI_SUBDIR, CONFIG_DIR, CURSOR_DIR, GEMINI_DIR, HOOKS_JSON, OPENCODE_PLUGIN_FILE,
+    OPENCODE_SUBDIR, PLUGIN_SUBDIR,
 };
 
 use super::constants::{
@@ -1755,12 +1755,14 @@ fn run_antigravity_mode_at(base_dir: &Path, ctx: InitContext) -> Result<()> {
 const AGY_HOOK_NAME: &str = "rtk-antigravity";
 /// Subdirectory of ~/.gemini that holds agy's hooks.json.
 const AGY_CONFIG_SUBDIR: &str = "config";
+/// Permission token added to agy's settings.json so rewritten commands can run.
+const AGY_RTK_PERMISSION: &str = "command(rtk)";
 
 /// Entry point for `rtk init --agent agy` (global-only).
 ///
 /// Writes the RTK hook entry into `~/.gemini/config/hooks.json`.
 pub fn run_agy_cli_mode(global: bool, ctx: InitContext) -> Result<()> {
-    let InitContext { dry_run, .. } = ctx;
+    let InitContext { dry_run, verbose } = ctx;
 
     if !global {
         anyhow::bail!("agy CLI support is global-only. Use: rtk init -g --agent agy");
@@ -1784,6 +1786,10 @@ pub fn run_agy_cli_mode(global: bool, ctx: InitContext) -> Result<()> {
 
     let patched = patch_agy_hooks_json(&hooks_path, ctx, &hook_command)?;
 
+    // Also grant command(rtk) permission so the rewritten commands are auto-allowed.
+    let settings_path = resolve_agy_settings_path()?;
+    let permission_granted = grant_agy_rtk_permission(&settings_path, dry_run, verbose)?;
+
     if dry_run {
         print_dry_run_footer();
     } else {
@@ -1792,7 +1798,10 @@ pub fn run_agy_cli_mode(global: bool, ctx: InitContext) -> Result<()> {
         } else {
             println!("\nGoogle Antigravity CLI (agy) hook already present (global).\n");
         }
-        println!("  hooks.json: {}", hooks_path.display());
+        println!("  hooks.json:   {}", hooks_path.display());
+        if permission_granted {
+            println!("  settings.json: added command(rtk) to allow list");
+        }
         println!("  Restart agy. Test with: git status\n");
     }
 
@@ -1802,6 +1811,124 @@ pub fn run_agy_cli_mode(global: bool, ctx: InitContext) -> Result<()> {
 fn resolve_agy_config_dir() -> Result<PathBuf> {
     let gemini_dir = resolve_home_subdir(GEMINI_DIR)?;
     Ok(gemini_dir.join(AGY_CONFIG_SUBDIR))
+}
+
+fn resolve_agy_settings_path() -> Result<PathBuf> {
+    let gemini_dir = resolve_home_subdir(GEMINI_DIR)?;
+    Ok(gemini_dir.join(AGY_CLI_SUBDIR).join(SETTINGS_JSON))
+}
+
+/// Add `command(rtk)` to `permissions.allow` in agy's settings.json.
+/// Returns true if the file was modified.
+fn grant_agy_rtk_permission(path: &Path, dry_run: bool, verbose: u8) -> Result<bool> {
+    let mut settings: serde_json::Value = if path.exists() {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+        serde_json::from_str(&content).unwrap_or(serde_json::json!({}))
+    } else {
+        serde_json::json!({})
+    };
+
+    let already = settings
+        .pointer("/permissions/allow")
+        .and_then(|v| v.as_array())
+        .is_some_and(|arr| arr.iter().any(|v| v.as_str() == Some(AGY_RTK_PERMISSION)));
+
+    if already {
+        if verbose > 0 {
+            eprintln!("agy settings.json: {} already present", AGY_RTK_PERMISSION);
+        }
+        return Ok(false);
+    }
+
+    if settings.get("permissions").is_none() {
+        settings["permissions"] = serde_json::json!({"allow": []});
+    }
+    if settings["permissions"].get("allow").is_none() {
+        settings["permissions"]["allow"] = serde_json::json!([]);
+    }
+    settings["permissions"]["allow"]
+        .as_array_mut()
+        .context("permissions.allow is not an array")?
+        .push(serde_json::Value::String(AGY_RTK_PERMISSION.to_string()));
+
+    let serialized =
+        serde_json::to_string_pretty(&settings).context("Failed to serialize agy settings.json")?;
+
+    if dry_run {
+        println!(
+            "[dry-run] would add {} to agy settings.json: {}",
+            AGY_RTK_PERMISSION,
+            path.display()
+        );
+        return Ok(true);
+    }
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let tmp = NamedTempFile::new_in(path.parent().context("agy settings.json has no parent")?)?;
+    fs::write(tmp.path(), &serialized)?;
+    tmp.persist(path)
+        .with_context(|| format!("Failed to write {}", path.display()))?;
+
+    if verbose > 0 {
+        eprintln!("Added {} to {}", AGY_RTK_PERMISSION, path.display());
+    }
+
+    Ok(true)
+}
+
+/// Remove `command(rtk)` from `permissions.allow` in agy's settings.json.
+/// Returns true if the file was modified.
+fn revoke_agy_rtk_permission(path: &Path, dry_run: bool, verbose: u8) -> Result<bool> {
+    if !path.exists() {
+        return Ok(false);
+    }
+
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    let mut settings: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return Ok(false),
+    };
+
+    let allow = match settings
+        .pointer_mut("/permissions/allow")
+        .and_then(|v| v.as_array_mut())
+    {
+        Some(arr) => arr,
+        None => return Ok(false),
+    };
+
+    let before = allow.len();
+    allow.retain(|v| v.as_str() != Some(AGY_RTK_PERMISSION));
+    if allow.len() == before {
+        return Ok(false);
+    }
+
+    let serialized =
+        serde_json::to_string_pretty(&settings).context("Failed to serialize agy settings.json")?;
+
+    if dry_run {
+        println!(
+            "[dry-run] would remove {} from agy settings.json: {}",
+            AGY_RTK_PERMISSION,
+            path.display()
+        );
+        return Ok(true);
+    }
+
+    let tmp = NamedTempFile::new_in(path.parent().context("agy settings.json has no parent")?)?;
+    fs::write(tmp.path(), &serialized)?;
+    tmp.persist(path)
+        .with_context(|| format!("Failed to write {}", path.display()))?;
+
+    if verbose > 0 {
+        eprintln!("Removed {} from {}", AGY_RTK_PERMISSION, path.display());
+    }
+
+    Ok(true)
 }
 
 /// Patch `~/.gemini/config/hooks.json` with RTK's named PreToolUse hook.
@@ -1956,6 +2083,17 @@ fn uninstall_agy_cli(global: bool, ctx: InitContext) -> Result<()> {
                     hooks_path.display()
                 ));
             }
+        }
+    }
+
+    // Also revoke command(rtk) from settings.json.
+    if let Ok(settings_path) = resolve_agy_settings_path() {
+        if let Ok(true) = revoke_agy_rtk_permission(&settings_path, dry_run, verbose) {
+            removed.push(format!(
+                "agy settings.json: removed {} ({})",
+                AGY_RTK_PERMISSION,
+                settings_path.display()
+            ));
         }
     }
 

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -12,10 +12,11 @@ use crate::hooks::constants::{
 };
 
 use super::constants::{
-    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND,
-    GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_INIT_FILE,
-    HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON, HOOKS_SUBDIR, PRE_TOOL_USE_KEY,
-    REWRITE_HOOK_FILE, SETTINGS_JSON,
+    ANTIGRAVITY_DIR, ANTIGRAVITY_HOOK_COMMAND, ANTIGRAVITY_TOOL_MATCHER, BEFORE_TOOL_KEY,
+    CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND, GEMINI_HOOK_FILE, HERMES_DIR,
+    HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE,
+    HERMES_PLUGIN_NAME, HOOKS_JSON, HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE,
+    SETTINGS_JSON,
 };
 use super::integrity;
 
@@ -606,6 +607,7 @@ pub fn uninstall(
     gemini: bool,
     codex: bool,
     cursor: bool,
+    antigravity_cli: bool,
     ctx: InitContext,
 ) -> Result<()> {
     let InitContext { verbose, dry_run } = ctx;
@@ -641,6 +643,11 @@ pub fn uninstall(
         if dry_run {
             print_dry_run_footer();
         }
+        return Ok(());
+    }
+
+    if antigravity_cli {
+        uninstall_agy_cli(global, ctx)?;
         return Ok(());
     }
 
@@ -1730,6 +1737,215 @@ fn run_antigravity_mode_at(base_dir: &Path, ctx: InitContext) -> Result<()> {
     } else {
         println!("  Antigravity will now use rtk commands for token savings.");
         println!("  Test with: git status\n");
+    }
+
+    Ok(())
+}
+
+// ─── Google Antigravity CLI (agy) hook support ─────────────────
+
+/// Entry point for `rtk init --agent agy`.
+///
+/// global=true  → `~/.agents/hooks.json`
+/// global=false → `.agents/hooks.json` (project-local)
+pub fn run_agy_cli_mode(global: bool, ctx: InitContext) -> Result<()> {
+    let InitContext { dry_run, .. } = ctx;
+
+    let hooks_json_path = if global {
+        let agents_dir = resolve_home_subdir(ANTIGRAVITY_DIR)?;
+        agents_dir.join(HOOKS_JSON)
+    } else {
+        PathBuf::from(ANTIGRAVITY_DIR).join(HOOKS_JSON)
+    };
+
+    if !dry_run {
+        if let Some(parent) = hooks_json_path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
+        }
+    }
+
+    let patched = patch_agy_hooks_json(&hooks_json_path, ctx)?;
+
+    if dry_run {
+        print_dry_run_footer();
+    } else {
+        let scope = if global { "global" } else { "project-local" };
+        if patched {
+            println!("\nGoogle Antigravity CLI (agy) hook installed ({scope}).\n");
+        } else {
+            println!("\nGoogle Antigravity CLI (agy) hook already present ({scope}).\n");
+        }
+        println!("  hooks.json: {}", hooks_json_path.display());
+        println!("  Restart agy. Test with: git status\n");
+    }
+
+    Ok(())
+}
+
+/// Patch `hooks.json` with the RTK PreToolUse hook for agy.
+/// Returns true if the file was modified.
+fn patch_agy_hooks_json(path: &Path, ctx: InitContext) -> Result<bool> {
+    let InitContext { verbose, dry_run } = ctx;
+
+    let mut root = if path.exists() {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+        if content.trim().is_empty() {
+            serde_json::json!({})
+        } else {
+            serde_json::from_str(&content)
+                .with_context(|| format!("Failed to parse {} as JSON", path.display()))?
+        }
+    } else {
+        serde_json::json!({})
+    };
+
+    if agy_hook_already_present(&root) {
+        if verbose > 0 {
+            eprintln!("agy hooks.json: RTK hook already present");
+        }
+        return Ok(false);
+    }
+
+    insert_agy_hook_entry(&mut root)?;
+
+    let serialized =
+        serde_json::to_string_pretty(&root).context("Failed to serialize hooks.json")?;
+
+    if dry_run {
+        println!("[dry-run] would patch agy hooks.json: {}", path.display());
+        if verbose > 0 {
+            println!("[dry-run] content:\n{}", serialized);
+        }
+        return Ok(true);
+    }
+
+    if path.exists() {
+        let backup = path.with_extension("json.bak");
+        fs::copy(path, &backup)
+            .with_context(|| format!("Failed to backup to {}", backup.display()))?;
+        if verbose > 0 {
+            eprintln!("Backup: {}", backup.display());
+        }
+    }
+
+    atomic_write(path, &serialized)?;
+    Ok(true)
+}
+
+/// Returns true if an RTK hook is already in the agy hooks.json PreToolUse array.
+fn agy_hook_already_present(root: &serde_json::Value) -> bool {
+    root.get("hooks")
+        .and_then(|h| h.get(PRE_TOOL_USE_KEY))
+        .and_then(|v| v.as_array())
+        .is_some_and(|arr| {
+            arr.iter().any(|entry| {
+                entry
+                    .get("command")
+                    .and_then(|c| c.as_str())
+                    .is_some_and(|cmd| cmd.contains("rtk"))
+            })
+        })
+}
+
+/// Insert the RTK PreToolUse hook entry into the agy hooks.json root.
+fn insert_agy_hook_entry(root: &mut serde_json::Value) -> Result<()> {
+    let root_obj = root
+        .as_object_mut()
+        .context("agy hooks.json root is not an object")?;
+
+    let hooks = root_obj
+        .entry("hooks")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .context("hooks value is not an object")?;
+
+    let pre_tool_use = hooks
+        .entry(PRE_TOOL_USE_KEY)
+        .or_insert_with(|| serde_json::json!([]))
+        .as_array_mut()
+        .context("PreToolUse value is not an array")?;
+
+    pre_tool_use.push(serde_json::json!({
+        "type": "command",
+        "command": ANTIGRAVITY_HOOK_COMMAND,
+        "toolNameMatcher": ANTIGRAVITY_TOOL_MATCHER
+    }));
+
+    Ok(())
+}
+
+/// Remove RTK agy artifacts during uninstall.
+fn uninstall_agy_cli(global: bool, ctx: InitContext) -> Result<()> {
+    let InitContext { verbose, dry_run } = ctx;
+
+    let hooks_json_path = if global {
+        let agents_dir = match resolve_home_subdir(ANTIGRAVITY_DIR) {
+            Ok(d) => d,
+            Err(_) => {
+                println!("RTK agy hook was not installed (nothing to remove)");
+                return Ok(());
+            }
+        };
+        agents_dir.join(HOOKS_JSON)
+    } else {
+        PathBuf::from(ANTIGRAVITY_DIR).join(HOOKS_JSON)
+    };
+
+    let mut removed = Vec::new();
+
+    if hooks_json_path.exists() {
+        let content = fs::read_to_string(&hooks_json_path)
+            .with_context(|| format!("Failed to read {}", hooks_json_path.display()))?;
+
+        if let Ok(mut root) = serde_json::from_str::<serde_json::Value>(&content) {
+            if let Some(arr) = root
+                .pointer_mut(&format!("/hooks/{}", PRE_TOOL_USE_KEY))
+                .and_then(|v| v.as_array_mut())
+            {
+                let before = arr.len();
+                arr.retain(|entry| {
+                    !entry
+                        .get("command")
+                        .and_then(|c| c.as_str())
+                        .is_some_and(|cmd| cmd.contains("rtk"))
+                });
+                if arr.len() < before {
+                    if dry_run {
+                        println!(
+                            "[dry-run] would remove RTK hook from agy hooks.json: {}",
+                            hooks_json_path.display()
+                        );
+                    } else {
+                        let serialized = serde_json::to_string_pretty(&root)?;
+                        atomic_write(&hooks_json_path, &serialized)?;
+                        if verbose > 0 {
+                            eprintln!(
+                                "Removed RTK hook from agy hooks.json: {}",
+                                hooks_json_path.display()
+                            );
+                        }
+                    }
+                    removed.push(format!(
+                        "agy hooks.json: removed RTK hook ({})",
+                        hooks_json_path.display()
+                    ));
+                }
+            }
+        }
+    }
+
+    if dry_run {
+        print_dry_run_footer();
+    } else if !removed.is_empty() {
+        println!("RTK uninstalled (agy):");
+        for item in &removed {
+            println!("  - {}", item);
+        }
+        println!("\nRestart agy to apply changes.");
+    } else {
+        println!("RTK agy hook was not installed (nothing to remove)");
     }
 
     Ok(())
@@ -5438,7 +5654,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         with_claude_dir_override(&tmp, |claude_dir| {
             run_default_mode(true, PatchMode::Auto, false, InitContext::default()).unwrap();
-            uninstall(true, false, false, false, InitContext::default()).unwrap();
+            uninstall(true, false, false, false, false, InitContext::default()).unwrap();
 
             assert!(!claude_dir.join(RTK_MD).exists(), "RTK.md must be removed");
             let settings_content =
@@ -5565,7 +5781,7 @@ mod tests {
                 dry_run: true,
                 ..Default::default()
             };
-            uninstall(true, false, false, false, dry).unwrap();
+            uninstall(true, false, false, false, false, dry).unwrap();
 
             // Files must still exist with identical content
             assert!(
@@ -5678,6 +5894,31 @@ mod tests {
             "RTK end marker must be removed"
         );
     }
+
+    #[test]
+    fn test_claude_md_mode_refuses_malformed_block() {
+        let tmp = TempDir::new().unwrap();
+        with_claude_dir_override(&tmp, |claude_dir| {
+            let claude_md = claude_dir.join(CLAUDE_MD);
+            let malformed = format!(
+                "# Existing notes\n\n{}\nincomplete RTK block\n",
+                RTK_BLOCK_START
+            );
+            fs::write(&claude_md, &malformed).unwrap();
+
+            let result = run_claude_md_mode(true, false, InitContext::default());
+
+            assert!(
+                result.is_err(),
+                "Malformed CLAUDE.md must cause a hard error, not silent skip"
+            );
+
+            let after = fs::read_to_string(&claude_md).unwrap();
+            assert_eq!(after, malformed, "File must not be modified when malformed");
+        });
+    }
+
+    // ─── Copilot tests ───────────────────────────────────────────────
 
     #[test]
     fn test_copilot_init_preserves_existing_instructions() {

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -6056,29 +6056,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_claude_md_mode_refuses_malformed_block() {
-        let tmp = TempDir::new().unwrap();
-        with_claude_dir_override(&tmp, |claude_dir| {
-            let claude_md = claude_dir.join(CLAUDE_MD);
-            let malformed = format!(
-                "# Existing notes\n\n{}\nincomplete RTK block\n",
-                RTK_BLOCK_START
-            );
-            fs::write(&claude_md, &malformed).unwrap();
-
-            let result = run_claude_md_mode(true, false, InitContext::default());
-
-            assert!(
-                result.is_err(),
-                "Malformed CLAUDE.md must cause a hard error, not silent skip"
-            );
-
-            let after = fs::read_to_string(&claude_md).unwrap();
-            assert_eq!(after, malformed, "File must not be modified when malformed");
-        });
-    }
-
     // ─── Copilot tests ───────────────────────────────────────────────
 
     #[test]

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -8,15 +8,15 @@ use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 
 use crate::hooks::constants::{
-    CONFIG_DIR, CURSOR_DIR, GEMINI_DIR, OPENCODE_PLUGIN_FILE, OPENCODE_SUBDIR, PLUGIN_SUBDIR,
+    CONFIG_DIR, CURSOR_DIR, GEMINI_DIR, HOOKS_JSON, OPENCODE_PLUGIN_FILE, OPENCODE_SUBDIR,
+    PLUGIN_SUBDIR,
 };
 
 use super::constants::{
-    ANTIGRAVITY_DIR, ANTIGRAVITY_HOOK_COMMAND, ANTIGRAVITY_TOOL_MATCHER, BEFORE_TOOL_KEY,
-    CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND, GEMINI_HOOK_FILE, HERMES_DIR,
-    HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE,
-    HERMES_PLUGIN_NAME, HOOKS_JSON, HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE,
-    SETTINGS_JSON,
+    AGY_CLI_SUBDIR, ANTIGRAVITY_HOOK_COMMAND, BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND,
+    CODEX_DIR, CURSOR_HOOK_COMMAND, GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR,
+    HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_SUBDIR,
+    PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use super::integrity;
 
@@ -1743,135 +1743,151 @@ fn run_antigravity_mode_at(base_dir: &Path, ctx: InitContext) -> Result<()> {
 }
 
 // ─── Google Antigravity CLI (agy) hook support ─────────────────
+//
+// agy stores config in ~/.gemini/antigravity-cli/settings.json and uses the
+// same BeforeTool hook format as Gemini CLI.  Two matchers are registered —
+// one for "run_command" (CommandLine field) and one for "Bash" (command field)
+// — because agy uses both depending on context.
 
-/// Entry point for `rtk init --agent agy`.
+/// Entry point for `rtk init --agent agy` (global-only, like Gemini CLI).
 ///
-/// global=true  → `~/.agents/hooks.json`
-/// global=false → `.agents/hooks.json` (project-local)
+/// Writes hook entries into `~/.gemini/antigravity-cli/settings.json`.
 pub fn run_agy_cli_mode(global: bool, ctx: InitContext) -> Result<()> {
     let InitContext { dry_run, .. } = ctx;
 
-    let hooks_json_path = if global {
-        let agents_dir = resolve_home_subdir(ANTIGRAVITY_DIR)?;
-        agents_dir.join(HOOKS_JSON)
-    } else {
-        PathBuf::from(ANTIGRAVITY_DIR).join(HOOKS_JSON)
-    };
-
-    if !dry_run {
-        if let Some(parent) = hooks_json_path.parent() {
-            fs::create_dir_all(parent)
-                .with_context(|| format!("Failed to create directory: {}", parent.display()))?;
-        }
+    if !global {
+        anyhow::bail!("agy CLI support is global-only. Use: rtk init -g --agent agy");
     }
 
-    let patched = patch_agy_hooks_json(&hooks_json_path, ctx)?;
+    let agy_dir = resolve_agy_dir()?;
+    let settings_path = agy_dir.join(SETTINGS_JSON);
+
+    if !dry_run {
+        fs::create_dir_all(&agy_dir)
+            .with_context(|| format!("Failed to create agy config dir: {}", agy_dir.display()))?;
+    }
+
+    let patched = patch_agy_settings(&settings_path, ctx)?;
 
     if dry_run {
         print_dry_run_footer();
     } else {
-        let scope = if global { "global" } else { "project-local" };
         if patched {
-            println!("\nGoogle Antigravity CLI (agy) hook installed ({scope}).\n");
+            println!("\nGoogle Antigravity CLI (agy) hook installed (global).\n");
         } else {
-            println!("\nGoogle Antigravity CLI (agy) hook already present ({scope}).\n");
+            println!("\nGoogle Antigravity CLI (agy) hook already present (global).\n");
         }
-        println!("  hooks.json: {}", hooks_json_path.display());
+        println!("  settings.json: {}", settings_path.display());
         println!("  Restart agy. Test with: git status\n");
     }
 
     Ok(())
 }
 
-/// Patch `hooks.json` with the RTK PreToolUse hook for agy.
+fn resolve_agy_dir() -> Result<PathBuf> {
+    let gemini_dir = resolve_home_subdir(GEMINI_DIR)?;
+    Ok(gemini_dir.join(AGY_CLI_SUBDIR))
+}
+
+/// Patch `~/.gemini/antigravity-cli/settings.json` with RTK BeforeTool hooks.
 /// Returns true if the file was modified.
-fn patch_agy_hooks_json(path: &Path, ctx: InitContext) -> Result<bool> {
+fn patch_agy_settings(path: &Path, ctx: InitContext) -> Result<bool> {
     let InitContext { verbose, dry_run } = ctx;
 
-    let mut root = if path.exists() {
+    let mut settings: serde_json::Value = if path.exists() {
         let content = fs::read_to_string(path)
             .with_context(|| format!("Failed to read {}", path.display()))?;
-        if content.trim().is_empty() {
-            serde_json::json!({})
-        } else {
-            serde_json::from_str(&content)
-                .with_context(|| format!("Failed to parse {} as JSON", path.display()))?
-        }
+        serde_json::from_str(&content).unwrap_or(serde_json::json!({}))
     } else {
         serde_json::json!({})
     };
 
-    if agy_hook_already_present(&root) {
+    if agy_hook_already_present(&settings) {
         if verbose > 0 {
-            eprintln!("agy hooks.json: RTK hook already present");
+            eprintln!("agy settings.json: RTK hook already present");
         }
         return Ok(false);
     }
 
-    insert_agy_hook_entry(&mut root)?;
+    insert_agy_hook_entries(&mut settings)?;
 
     let serialized =
-        serde_json::to_string_pretty(&root).context("Failed to serialize hooks.json")?;
+        serde_json::to_string_pretty(&settings).context("Failed to serialize agy settings.json")?;
 
     if dry_run {
-        println!("[dry-run] would patch agy hooks.json: {}", path.display());
+        println!(
+            "[dry-run] would patch agy settings.json: {}",
+            path.display()
+        );
         if verbose > 0 {
             println!("[dry-run] content:\n{}", serialized);
         }
         return Ok(true);
     }
 
-    if path.exists() {
-        let backup = path.with_extension("json.bak");
-        fs::copy(path, &backup)
-            .with_context(|| format!("Failed to backup to {}", backup.display()))?;
-        if verbose > 0 {
-            eprintln!("Backup: {}", backup.display());
-        }
+    let tmp = NamedTempFile::new_in(
+        path.parent()
+            .context("agy settings.json has no parent directory")?,
+    )?;
+    fs::write(tmp.path(), &serialized)?;
+    tmp.persist(path)
+        .with_context(|| format!("Failed to write {}", path.display()))?;
+
+    if verbose > 0 {
+        eprintln!("Patched {}", path.display());
     }
 
-    atomic_write(path, &serialized)?;
     Ok(true)
 }
 
-/// Returns true if an RTK hook is already in the agy hooks.json PreToolUse array.
-fn agy_hook_already_present(root: &serde_json::Value) -> bool {
-    root.get("hooks")
-        .and_then(|h| h.get(PRE_TOOL_USE_KEY))
+/// Returns true if an RTK BeforeTool hook is already present in agy settings.json.
+fn agy_hook_already_present(settings: &serde_json::Value) -> bool {
+    settings
+        .pointer(&format!("/hooks/{}", BEFORE_TOOL_KEY))
         .and_then(|v| v.as_array())
         .is_some_and(|arr| {
             arr.iter().any(|entry| {
                 entry
-                    .get("command")
-                    .and_then(|c| c.as_str())
-                    .is_some_and(|cmd| cmd.contains("rtk"))
+                    .get("hooks")
+                    .and_then(|h| h.as_array())
+                    .is_some_and(|hooks| {
+                        hooks.iter().any(|h| {
+                            h.get("command")
+                                .and_then(|c| c.as_str())
+                                .is_some_and(|cmd| cmd.contains("rtk"))
+                        })
+                    })
             })
         })
 }
 
-/// Insert the RTK PreToolUse hook entry into the agy hooks.json root.
-fn insert_agy_hook_entry(root: &mut serde_json::Value) -> Result<()> {
-    let root_obj = root
+/// Insert RTK BeforeTool hook entries into agy settings.json.
+///
+/// Registers one entry per tool name so agy calls the hook for both
+/// shell-execution tools it uses: "run_command" and "Bash".
+fn insert_agy_hook_entries(settings: &mut serde_json::Value) -> Result<()> {
+    let settings_obj = settings
         .as_object_mut()
-        .context("agy hooks.json root is not an object")?;
+        .context("agy settings.json is not an object")?;
 
-    let hooks = root_obj
+    let hooks = settings_obj
         .entry("hooks")
         .or_insert_with(|| serde_json::json!({}))
         .as_object_mut()
         .context("hooks value is not an object")?;
 
-    let pre_tool_use = hooks
-        .entry(PRE_TOOL_USE_KEY)
+    let before_tool = hooks
+        .entry(BEFORE_TOOL_KEY)
         .or_insert_with(|| serde_json::json!([]))
         .as_array_mut()
-        .context("PreToolUse value is not an array")?;
+        .context("BeforeTool value is not an array")?;
 
-    pre_tool_use.push(serde_json::json!({
-        "type": "command",
-        "command": ANTIGRAVITY_HOOK_COMMAND,
-        "toolNameMatcher": ANTIGRAVITY_TOOL_MATCHER
-    }));
+    for matcher in &["run_command", "Bash"] {
+        before_tool.push(serde_json::json!({
+            "matcher": matcher,
+            "hooks": [{"type": "command", "command": ANTIGRAVITY_HOOK_COMMAND}]
+        }));
+    }
 
     Ok(())
 }
@@ -1880,56 +1896,70 @@ fn insert_agy_hook_entry(root: &mut serde_json::Value) -> Result<()> {
 fn uninstall_agy_cli(global: bool, ctx: InitContext) -> Result<()> {
     let InitContext { verbose, dry_run } = ctx;
 
-    let hooks_json_path = if global {
-        let agents_dir = match resolve_home_subdir(ANTIGRAVITY_DIR) {
-            Ok(d) => d,
-            Err(_) => {
-                println!("RTK agy hook was not installed (nothing to remove)");
-                return Ok(());
-            }
-        };
-        agents_dir.join(HOOKS_JSON)
-    } else {
-        PathBuf::from(ANTIGRAVITY_DIR).join(HOOKS_JSON)
+    if !global {
+        println!("RTK agy hook was not installed (nothing to remove)");
+        return Ok(());
+    }
+
+    let settings_path = match resolve_agy_dir() {
+        Ok(d) => d.join(SETTINGS_JSON),
+        Err(_) => {
+            println!("RTK agy hook was not installed (nothing to remove)");
+            return Ok(());
+        }
     };
 
     let mut removed = Vec::new();
 
-    if hooks_json_path.exists() {
-        let content = fs::read_to_string(&hooks_json_path)
-            .with_context(|| format!("Failed to read {}", hooks_json_path.display()))?;
+    if settings_path.exists() {
+        let content = fs::read_to_string(&settings_path)
+            .with_context(|| format!("Failed to read {}", settings_path.display()))?;
 
-        if let Ok(mut root) = serde_json::from_str::<serde_json::Value>(&content) {
-            if let Some(arr) = root
-                .pointer_mut(&format!("/hooks/{}", PRE_TOOL_USE_KEY))
+        if let Ok(mut settings) = serde_json::from_str::<serde_json::Value>(&content) {
+            if let Some(arr) = settings
+                .pointer_mut(&format!("/hooks/{}", BEFORE_TOOL_KEY))
                 .and_then(|v| v.as_array_mut())
             {
                 let before = arr.len();
                 arr.retain(|entry| {
                     !entry
-                        .get("command")
-                        .and_then(|c| c.as_str())
-                        .is_some_and(|cmd| cmd.contains("rtk"))
+                        .get("hooks")
+                        .and_then(|h| h.as_array())
+                        .is_some_and(|hooks| {
+                            hooks.iter().any(|h| {
+                                h.get("command")
+                                    .and_then(|c| c.as_str())
+                                    .is_some_and(|cmd| cmd.contains("rtk"))
+                            })
+                        })
                 });
                 if arr.len() < before {
                     if dry_run {
                         println!(
-                            "[dry-run] would remove RTK hook from agy hooks.json: {}",
-                            hooks_json_path.display()
+                            "[dry-run] would remove RTK hooks from agy settings.json: {}",
+                            settings_path.display()
                         );
                     } else {
-                        let serialized = serde_json::to_string_pretty(&root)?;
-                        atomic_write(&hooks_json_path, &serialized)?;
+                        let serialized = serde_json::to_string_pretty(&settings)?;
+                        let tmp = NamedTempFile::new_in(
+                            settings_path
+                                .parent()
+                                .context("settings.json has no parent")?,
+                        )?;
+                        fs::write(tmp.path(), &serialized)?;
+                        tmp.persist(&settings_path).with_context(|| {
+                            format!("Failed to write {}", settings_path.display())
+                        })?;
                         if verbose > 0 {
                             eprintln!(
-                                "Removed RTK hook from agy hooks.json: {}",
-                                hooks_json_path.display()
+                                "Removed RTK hooks from agy settings.json: {}",
+                                settings_path.display()
                             );
                         }
                     }
                     removed.push(format!(
-                        "agy hooks.json: removed RTK hook ({})",
-                        hooks_json_path.display()
+                        "agy settings.json: removed RTK hooks ({})",
+                        settings_path.display()
                     ));
                 }
             }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -1773,7 +1773,7 @@ pub fn run_agy_cli_mode(global: bool, ctx: InitContext) -> Result<()> {
         .context("Failed to resolve rtk binary path")?
         .to_string_lossy()
         .to_string();
-    let hook_command = format!("{} hook antigravity", rtk_bin);
+    let hook_command = format!("\"{}\" hook antigravity", rtk_bin);
 
     let config_dir = resolve_agy_config_dir()?;
     let hooks_path = config_dir.join(HOOKS_JSON);
@@ -1824,7 +1824,12 @@ fn grant_agy_rtk_permission(path: &Path, dry_run: bool, verbose: u8) -> Result<b
     let mut settings: serde_json::Value = if path.exists() {
         let content = fs::read_to_string(path)
             .with_context(|| format!("Failed to read {}", path.display()))?;
-        serde_json::from_str(&content).unwrap_or(serde_json::json!({}))
+        serde_json::from_str(&content).with_context(|| {
+            format!(
+                "agy settings.json is not valid JSON: {}. Fix or remove it and retry.",
+                path.display()
+            )
+        })?
     } else {
         serde_json::json!({})
     };
@@ -1939,7 +1944,12 @@ fn patch_agy_hooks_json(path: &Path, ctx: InitContext, hook_command: &str) -> Re
     let mut hooks: serde_json::Value = if path.exists() {
         let content = fs::read_to_string(path)
             .with_context(|| format!("Failed to read {}", path.display()))?;
-        serde_json::from_str(&content).unwrap_or(serde_json::json!({}))
+        serde_json::from_str(&content).with_context(|| {
+            format!(
+                "agy hooks.json is not valid JSON: {}. Fix or remove it and retry.",
+                path.display()
+            )
+        })?
     } else {
         serde_json::json!({})
     };
@@ -2022,7 +2032,7 @@ fn insert_agy_hook_entry(hooks: &mut serde_json::Value, hook_command: &str) -> R
             "enabled": true,
             "PreToolUse": [
                 {
-                    "toolNameMatcher": "^(run_command|Bash)$",
+                    "toolNameMatcher": "^(run_command|Bash|bash)$",
                     "hooks": [{"type": "command", "command": hook_command}]
                 }
             ]
@@ -6260,5 +6270,126 @@ mod tests {
             let after = fs::read_to_string(&claude_md).unwrap();
             assert_eq!(after, malformed, "File must not be modified when malformed");
         });
+    }
+
+    // ── agy install/uninstall tests ───────────────────────────────────────────
+
+    fn make_tmp() -> TempDir {
+        tempfile::tempdir().expect("tempdir")
+    }
+
+    #[test]
+    fn test_patch_agy_hooks_json_creates_file_when_missing() {
+        let tmp = make_tmp();
+        let path = tmp.path().join("hooks.json");
+        let patched = patch_agy_hooks_json(
+            &path,
+            InitContext::default(),
+            "/usr/bin/rtk hook antigravity",
+        )
+        .unwrap();
+        assert!(patched, "should return true when file is created");
+        let content = fs::read_to_string(&path).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert!(
+            v.get("rtk-antigravity").is_some(),
+            "hook entry must be written"
+        );
+    }
+
+    #[test]
+    fn test_patch_agy_hooks_json_noop_when_already_present() {
+        let tmp = make_tmp();
+        let path = tmp.path().join("hooks.json");
+        let cmd = "/usr/bin/rtk hook antigravity";
+        patch_agy_hooks_json(&path, InitContext::default(), cmd).unwrap();
+        let patched = patch_agy_hooks_json(&path, InitContext::default(), cmd).unwrap();
+        assert!(!patched, "second call with same command must be a no-op");
+    }
+
+    #[test]
+    fn test_patch_agy_hooks_json_errors_on_invalid_json() {
+        let tmp = make_tmp();
+        let path = tmp.path().join("hooks.json");
+        fs::write(&path, "not json at all").unwrap();
+        let result = patch_agy_hooks_json(
+            &path,
+            InitContext::default(),
+            "/usr/bin/rtk hook antigravity",
+        );
+        assert!(
+            result.is_err(),
+            "corrupt hooks.json must produce an error, not silent overwrite"
+        );
+        let original = fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            original, "not json at all",
+            "corrupt file must not be modified"
+        );
+    }
+
+    #[test]
+    fn test_grant_agy_rtk_permission_creates_file_when_missing() {
+        let tmp = make_tmp();
+        let path = tmp.path().join("settings.json");
+        let granted = grant_agy_rtk_permission(&path, false, 0).unwrap();
+        assert!(granted);
+        let content = fs::read_to_string(&path).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let allow = v
+            .pointer("/permissions/allow")
+            .and_then(|a| a.as_array())
+            .unwrap();
+        assert!(allow.iter().any(|e| e.as_str() == Some(AGY_RTK_PERMISSION)));
+    }
+
+    #[test]
+    fn test_grant_agy_rtk_permission_idempotent() {
+        let tmp = make_tmp();
+        let path = tmp.path().join("settings.json");
+        grant_agy_rtk_permission(&path, false, 0).unwrap();
+        let granted = grant_agy_rtk_permission(&path, false, 0).unwrap();
+        assert!(!granted, "second grant must be a no-op");
+    }
+
+    #[test]
+    fn test_grant_agy_rtk_permission_errors_on_invalid_json() {
+        let tmp = make_tmp();
+        let path = tmp.path().join("settings.json");
+        fs::write(&path, "{bad json}").unwrap();
+        let result = grant_agy_rtk_permission(&path, false, 0);
+        assert!(
+            result.is_err(),
+            "corrupt settings.json must produce an error"
+        );
+        let original = fs::read_to_string(&path).unwrap();
+        assert_eq!(original, "{bad json}", "corrupt file must not be modified");
+    }
+
+    #[test]
+    fn test_revoke_agy_rtk_permission_idempotent() {
+        let tmp = make_tmp();
+        let path = tmp.path().join("settings.json");
+        // Nothing to revoke — missing file is a no-op.
+        let revoked = revoke_agy_rtk_permission(&path, false, 0).unwrap();
+        assert!(!revoked);
+        // Grant then revoke then revoke again.
+        grant_agy_rtk_permission(&path, false, 0).unwrap();
+        let revoked = revoke_agy_rtk_permission(&path, false, 0).unwrap();
+        assert!(revoked);
+        let revoked = revoke_agy_rtk_permission(&path, false, 0).unwrap();
+        assert!(!revoked, "second revoke must be a no-op");
+    }
+
+    #[test]
+    fn test_agy_hook_tool_name_matcher_includes_bash_lowercase() {
+        let tmp = make_tmp();
+        let path = tmp.path().join("hooks.json");
+        patch_agy_hooks_json(&path, InitContext::default(), "/rtk hook antigravity").unwrap();
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(
+            content.contains("bash"),
+            "toolNameMatcher must include lowercase 'bash'"
+        );
     }
 }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -13,10 +13,10 @@ use crate::hooks::constants::{
 };
 
 use super::constants::{
-    AGY_CLI_SUBDIR, BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR,
-    CURSOR_HOOK_COMMAND, GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR,
-    HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_SUBDIR,
-    PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
+    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND,
+    GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_INIT_FILE,
+    HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_SUBDIR, PRE_TOOL_USE_KEY,
+    REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use super::integrity;
 
@@ -1744,14 +1744,21 @@ fn run_antigravity_mode_at(base_dir: &Path, ctx: InitContext) -> Result<()> {
 
 // ─── Google Antigravity CLI (agy) hook support ─────────────────
 //
-// agy stores config in ~/.gemini/antigravity-cli/settings.json and uses the
-// same BeforeTool hook format as Gemini CLI.  Two matchers are registered —
-// one for "run_command" (CommandLine field) and one for "Bash" (command field)
-// — because agy uses both depending on context.
+// agy reads hooks from ~/.gemini/config/hooks.json using a named-hook format:
+//   { "hook-name": { "enabled": true, "PreToolUse": [{ "toolNameMatcher": "...", "hooks": [...] }] } }
+//
+// This is distinct from Gemini CLI's settings.json BeforeTool format.
+// The hook command receives the tool call as JSON (stdin) and writes a
+// PreToolHookResult protojson (stdout).  See `rtk hook antigravity`.
 
-/// Entry point for `rtk init --agent agy` (global-only, like Gemini CLI).
+/// Named key for RTK's entry in agy's hooks.json.
+const AGY_HOOK_NAME: &str = "rtk-antigravity";
+/// Subdirectory of ~/.gemini that holds agy's hooks.json.
+const AGY_CONFIG_SUBDIR: &str = "config";
+
+/// Entry point for `rtk init --agent agy` (global-only).
 ///
-/// Writes hook entries into `~/.gemini/antigravity-cli/settings.json`.
+/// Writes the RTK hook entry into `~/.gemini/config/hooks.json`.
 pub fn run_agy_cli_mode(global: bool, ctx: InitContext) -> Result<()> {
     let InitContext { dry_run, .. } = ctx;
 
@@ -1766,15 +1773,16 @@ pub fn run_agy_cli_mode(global: bool, ctx: InitContext) -> Result<()> {
         .to_string();
     let hook_command = format!("{} hook antigravity", rtk_bin);
 
-    let agy_dir = resolve_agy_dir()?;
-    let settings_path = agy_dir.join(SETTINGS_JSON);
+    let config_dir = resolve_agy_config_dir()?;
+    let hooks_path = config_dir.join(HOOKS_JSON);
 
     if !dry_run {
-        fs::create_dir_all(&agy_dir)
-            .with_context(|| format!("Failed to create agy config dir: {}", agy_dir.display()))?;
+        fs::create_dir_all(&config_dir).with_context(|| {
+            format!("Failed to create agy config dir: {}", config_dir.display())
+        })?;
     }
 
-    let patched = patch_agy_settings(&settings_path, ctx, &hook_command)?;
+    let patched = patch_agy_hooks_json(&hooks_path, ctx, &hook_command)?;
 
     if dry_run {
         print_dry_run_footer();
@@ -1784,24 +1792,24 @@ pub fn run_agy_cli_mode(global: bool, ctx: InitContext) -> Result<()> {
         } else {
             println!("\nGoogle Antigravity CLI (agy) hook already present (global).\n");
         }
-        println!("  settings.json: {}", settings_path.display());
+        println!("  hooks.json: {}", hooks_path.display());
         println!("  Restart agy. Test with: git status\n");
     }
 
     Ok(())
 }
 
-fn resolve_agy_dir() -> Result<PathBuf> {
+fn resolve_agy_config_dir() -> Result<PathBuf> {
     let gemini_dir = resolve_home_subdir(GEMINI_DIR)?;
-    Ok(gemini_dir.join(AGY_CLI_SUBDIR))
+    Ok(gemini_dir.join(AGY_CONFIG_SUBDIR))
 }
 
-/// Patch `~/.gemini/antigravity-cli/settings.json` with RTK BeforeTool hooks.
+/// Patch `~/.gemini/config/hooks.json` with RTK's named PreToolUse hook.
 /// Returns true if the file was modified.
-fn patch_agy_settings(path: &Path, ctx: InitContext, hook_command: &str) -> Result<bool> {
+fn patch_agy_hooks_json(path: &Path, ctx: InitContext, hook_command: &str) -> Result<bool> {
     let InitContext { verbose, dry_run } = ctx;
 
-    let mut settings: serde_json::Value = if path.exists() {
+    let mut hooks: serde_json::Value = if path.exists() {
         let content = fs::read_to_string(path)
             .with_context(|| format!("Failed to read {}", path.display()))?;
         serde_json::from_str(&content).unwrap_or(serde_json::json!({}))
@@ -1809,26 +1817,22 @@ fn patch_agy_settings(path: &Path, ctx: InitContext, hook_command: &str) -> Resu
         serde_json::json!({})
     };
 
-    if agy_hook_command_matches(&settings, hook_command) {
+    if agy_hook_command_matches(&hooks, hook_command) {
         if verbose > 0 {
-            eprintln!("agy settings.json: RTK hook already present");
+            eprintln!("agy hooks.json: RTK hook already present");
         }
         return Ok(false);
     }
 
-    // Remove any stale RTK entries (e.g. old installs with bare `rtk` command).
-    remove_agy_rtk_entries(&mut settings);
-
-    insert_agy_hook_entries(&mut settings, hook_command)?;
+    // Remove any stale RTK entry (e.g. old install with different path).
+    remove_agy_hook_entry(&mut hooks);
+    insert_agy_hook_entry(&mut hooks, hook_command)?;
 
     let serialized =
-        serde_json::to_string_pretty(&settings).context("Failed to serialize agy settings.json")?;
+        serde_json::to_string_pretty(&hooks).context("Failed to serialize agy hooks.json")?;
 
     if dry_run {
-        println!(
-            "[dry-run] would patch agy settings.json: {}",
-            path.display()
-        );
+        println!("[dry-run] would patch agy hooks.json: {}", path.display());
         if verbose > 0 {
             println!("[dry-run] content:\n{}", serialized);
         }
@@ -1837,7 +1841,7 @@ fn patch_agy_settings(path: &Path, ctx: InitContext, hook_command: &str) -> Resu
 
     let tmp = NamedTempFile::new_in(
         path.parent()
-            .context("agy settings.json has no parent directory")?,
+            .context("agy hooks.json has no parent directory")?,
     )?;
     fs::write(tmp.path(), &serialized)?;
     tmp.persist(path)
@@ -1850,19 +1854,19 @@ fn patch_agy_settings(path: &Path, ctx: InitContext, hook_command: &str) -> Resu
     Ok(true)
 }
 
-/// Returns true when an existing entry already uses exactly `hook_command`.
-/// A mismatch (bare `rtk` vs absolute path) triggers re-installation.
-fn agy_hook_command_matches(settings: &serde_json::Value, hook_command: &str) -> bool {
-    settings
-        .pointer(&format!("/hooks/{}", BEFORE_TOOL_KEY))
+/// Returns true when the RTK hook entry already uses exactly `hook_command`.
+fn agy_hook_command_matches(hooks: &serde_json::Value, hook_command: &str) -> bool {
+    hooks
+        .get(AGY_HOOK_NAME)
+        .and_then(|entry| entry.get("PreToolUse"))
         .and_then(|v| v.as_array())
         .is_some_and(|arr| {
-            arr.iter().any(|entry| {
-                entry
+            arr.iter().any(|matcher| {
+                matcher
                     .get("hooks")
                     .and_then(|h| h.as_array())
-                    .is_some_and(|hooks| {
-                        hooks.iter().any(|h| {
+                    .is_some_and(|hook_arr| {
+                        hook_arr.iter().any(|h| {
                             h.get("command")
                                 .and_then(|c| c.as_str())
                                 .is_some_and(|cmd| cmd == hook_command)
@@ -1872,54 +1876,31 @@ fn agy_hook_command_matches(settings: &serde_json::Value, hook_command: &str) ->
         })
 }
 
-/// Remove all RTK-owned BeforeTool entries (any command containing "rtk").
-fn remove_agy_rtk_entries(settings: &mut serde_json::Value) {
-    if let Some(arr) = settings
-        .pointer_mut(&format!("/hooks/{}", BEFORE_TOOL_KEY))
-        .and_then(|v| v.as_array_mut())
-    {
-        arr.retain(|entry| {
-            !entry
-                .get("hooks")
-                .and_then(|h| h.as_array())
-                .is_some_and(|hooks| {
-                    hooks.iter().any(|h| {
-                        h.get("command")
-                            .and_then(|c| c.as_str())
-                            .is_some_and(|cmd| cmd.contains("rtk"))
-                    })
-                })
-        });
+/// Remove RTK's named hook entry from hooks.json.
+fn remove_agy_hook_entry(hooks: &mut serde_json::Value) {
+    if let Some(obj) = hooks.as_object_mut() {
+        obj.remove(AGY_HOOK_NAME);
     }
 }
 
-/// Insert RTK BeforeTool hook entries into agy settings.json.
-///
-/// Registers one entry per tool name so agy calls the hook for both
-/// shell-execution tools it uses: "run_command" and "Bash".
-fn insert_agy_hook_entries(settings: &mut serde_json::Value, hook_command: &str) -> Result<()> {
-    let settings_obj = settings
+/// Insert RTK's named PreToolUse hook entry into hooks.json.
+fn insert_agy_hook_entry(hooks: &mut serde_json::Value, hook_command: &str) -> Result<()> {
+    let obj = hooks
         .as_object_mut()
-        .context("agy settings.json is not an object")?;
+        .context("agy hooks.json is not an object")?;
 
-    let hooks = settings_obj
-        .entry("hooks")
-        .or_insert_with(|| serde_json::json!({}))
-        .as_object_mut()
-        .context("hooks value is not an object")?;
-
-    let before_tool = hooks
-        .entry(BEFORE_TOOL_KEY)
-        .or_insert_with(|| serde_json::json!([]))
-        .as_array_mut()
-        .context("BeforeTool value is not an array")?;
-
-    for matcher in &["run_command", "Bash"] {
-        before_tool.push(serde_json::json!({
-            "matcher": matcher,
-            "hooks": [{"type": "command", "command": hook_command}]
-        }));
-    }
+    obj.insert(
+        AGY_HOOK_NAME.to_string(),
+        serde_json::json!({
+            "enabled": true,
+            "PreToolUse": [
+                {
+                    "toolNameMatcher": "^(run_command|Bash)$",
+                    "hooks": [{"type": "command", "command": hook_command}]
+                }
+            ]
+        }),
+    );
 
     Ok(())
 }
@@ -1933,8 +1914,8 @@ fn uninstall_agy_cli(global: bool, ctx: InitContext) -> Result<()> {
         return Ok(());
     }
 
-    let settings_path = match resolve_agy_dir() {
-        Ok(d) => d.join(SETTINGS_JSON),
+    let hooks_path = match resolve_agy_config_dir() {
+        Ok(d) => d.join(HOOKS_JSON),
         Err(_) => {
             println!("RTK agy hook was not installed (nothing to remove)");
             return Ok(());
@@ -1943,57 +1924,37 @@ fn uninstall_agy_cli(global: bool, ctx: InitContext) -> Result<()> {
 
     let mut removed = Vec::new();
 
-    if settings_path.exists() {
-        let content = fs::read_to_string(&settings_path)
-            .with_context(|| format!("Failed to read {}", settings_path.display()))?;
+    if hooks_path.exists() {
+        let content = fs::read_to_string(&hooks_path)
+            .with_context(|| format!("Failed to read {}", hooks_path.display()))?;
 
-        if let Ok(mut settings) = serde_json::from_str::<serde_json::Value>(&content) {
-            if let Some(arr) = settings
-                .pointer_mut(&format!("/hooks/{}", BEFORE_TOOL_KEY))
-                .and_then(|v| v.as_array_mut())
-            {
-                let before = arr.len();
-                arr.retain(|entry| {
-                    !entry
-                        .get("hooks")
-                        .and_then(|h| h.as_array())
-                        .is_some_and(|hooks| {
-                            hooks.iter().any(|h| {
-                                h.get("command")
-                                    .and_then(|c| c.as_str())
-                                    .is_some_and(|cmd| cmd.contains("rtk"))
-                            })
-                        })
-                });
-                if arr.len() < before {
-                    if dry_run {
-                        println!(
-                            "[dry-run] would remove RTK hooks from agy settings.json: {}",
-                            settings_path.display()
+        if let Ok(mut hooks) = serde_json::from_str::<serde_json::Value>(&content) {
+            if hooks.get(AGY_HOOK_NAME).is_some() {
+                if dry_run {
+                    println!(
+                        "[dry-run] would remove RTK hook from agy hooks.json: {}",
+                        hooks_path.display()
+                    );
+                } else {
+                    remove_agy_hook_entry(&mut hooks);
+                    let serialized = serde_json::to_string_pretty(&hooks)?;
+                    let tmp = NamedTempFile::new_in(
+                        hooks_path.parent().context("hooks.json has no parent")?,
+                    )?;
+                    fs::write(tmp.path(), &serialized)?;
+                    tmp.persist(&hooks_path)
+                        .with_context(|| format!("Failed to write {}", hooks_path.display()))?;
+                    if verbose > 0 {
+                        eprintln!(
+                            "Removed RTK hook from agy hooks.json: {}",
+                            hooks_path.display()
                         );
-                    } else {
-                        let serialized = serde_json::to_string_pretty(&settings)?;
-                        let tmp = NamedTempFile::new_in(
-                            settings_path
-                                .parent()
-                                .context("settings.json has no parent")?,
-                        )?;
-                        fs::write(tmp.path(), &serialized)?;
-                        tmp.persist(&settings_path).with_context(|| {
-                            format!("Failed to write {}", settings_path.display())
-                        })?;
-                        if verbose > 0 {
-                            eprintln!(
-                                "Removed RTK hooks from agy settings.json: {}",
-                                settings_path.display()
-                            );
-                        }
                     }
-                    removed.push(format!(
-                        "agy settings.json: removed RTK hooks ({})",
-                        settings_path.display()
-                    ));
                 }
+                removed.push(format!(
+                    "agy hooks.json: removed RTK hook ({})",
+                    hooks_path.display()
+                ));
             }
         }
     }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -13,8 +13,8 @@ use crate::hooks::constants::{
 };
 
 use super::constants::{
-    AGY_CLI_SUBDIR, ANTIGRAVITY_HOOK_COMMAND, BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND,
-    CODEX_DIR, CURSOR_HOOK_COMMAND, GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR,
+    AGY_CLI_SUBDIR, BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR,
+    CURSOR_HOOK_COMMAND, GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR,
     HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_SUBDIR,
     PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
@@ -1759,6 +1759,13 @@ pub fn run_agy_cli_mode(global: bool, ctx: InitContext) -> Result<()> {
         anyhow::bail!("agy CLI support is global-only. Use: rtk init -g --agent agy");
     }
 
+    // Use the absolute path so agy can find the binary regardless of its PATH.
+    let rtk_bin = std::env::current_exe()
+        .context("Failed to resolve rtk binary path")?
+        .to_string_lossy()
+        .to_string();
+    let hook_command = format!("{} hook antigravity", rtk_bin);
+
     let agy_dir = resolve_agy_dir()?;
     let settings_path = agy_dir.join(SETTINGS_JSON);
 
@@ -1767,7 +1774,7 @@ pub fn run_agy_cli_mode(global: bool, ctx: InitContext) -> Result<()> {
             .with_context(|| format!("Failed to create agy config dir: {}", agy_dir.display()))?;
     }
 
-    let patched = patch_agy_settings(&settings_path, ctx)?;
+    let patched = patch_agy_settings(&settings_path, ctx, &hook_command)?;
 
     if dry_run {
         print_dry_run_footer();
@@ -1791,7 +1798,7 @@ fn resolve_agy_dir() -> Result<PathBuf> {
 
 /// Patch `~/.gemini/antigravity-cli/settings.json` with RTK BeforeTool hooks.
 /// Returns true if the file was modified.
-fn patch_agy_settings(path: &Path, ctx: InitContext) -> Result<bool> {
+fn patch_agy_settings(path: &Path, ctx: InitContext, hook_command: &str) -> Result<bool> {
     let InitContext { verbose, dry_run } = ctx;
 
     let mut settings: serde_json::Value = if path.exists() {
@@ -1802,14 +1809,17 @@ fn patch_agy_settings(path: &Path, ctx: InitContext) -> Result<bool> {
         serde_json::json!({})
     };
 
-    if agy_hook_already_present(&settings) {
+    if agy_hook_command_matches(&settings, hook_command) {
         if verbose > 0 {
             eprintln!("agy settings.json: RTK hook already present");
         }
         return Ok(false);
     }
 
-    insert_agy_hook_entries(&mut settings)?;
+    // Remove any stale RTK entries (e.g. old installs with bare `rtk` command).
+    remove_agy_rtk_entries(&mut settings);
+
+    insert_agy_hook_entries(&mut settings, hook_command)?;
 
     let serialized =
         serde_json::to_string_pretty(&settings).context("Failed to serialize agy settings.json")?;
@@ -1840,8 +1850,9 @@ fn patch_agy_settings(path: &Path, ctx: InitContext) -> Result<bool> {
     Ok(true)
 }
 
-/// Returns true if an RTK BeforeTool hook is already present in agy settings.json.
-fn agy_hook_already_present(settings: &serde_json::Value) -> bool {
+/// Returns true when an existing entry already uses exactly `hook_command`.
+/// A mismatch (bare `rtk` vs absolute path) triggers re-installation.
+fn agy_hook_command_matches(settings: &serde_json::Value, hook_command: &str) -> bool {
     settings
         .pointer(&format!("/hooks/{}", BEFORE_TOOL_KEY))
         .and_then(|v| v.as_array())
@@ -1854,18 +1865,39 @@ fn agy_hook_already_present(settings: &serde_json::Value) -> bool {
                         hooks.iter().any(|h| {
                             h.get("command")
                                 .and_then(|c| c.as_str())
-                                .is_some_and(|cmd| cmd.contains("rtk"))
+                                .is_some_and(|cmd| cmd == hook_command)
                         })
                     })
             })
         })
 }
 
+/// Remove all RTK-owned BeforeTool entries (any command containing "rtk").
+fn remove_agy_rtk_entries(settings: &mut serde_json::Value) {
+    if let Some(arr) = settings
+        .pointer_mut(&format!("/hooks/{}", BEFORE_TOOL_KEY))
+        .and_then(|v| v.as_array_mut())
+    {
+        arr.retain(|entry| {
+            !entry
+                .get("hooks")
+                .and_then(|h| h.as_array())
+                .is_some_and(|hooks| {
+                    hooks.iter().any(|h| {
+                        h.get("command")
+                            .and_then(|c| c.as_str())
+                            .is_some_and(|cmd| cmd.contains("rtk"))
+                    })
+                })
+        });
+    }
+}
+
 /// Insert RTK BeforeTool hook entries into agy settings.json.
 ///
 /// Registers one entry per tool name so agy calls the hook for both
 /// shell-execution tools it uses: "run_command" and "Bash".
-fn insert_agy_hook_entries(settings: &mut serde_json::Value) -> Result<()> {
+fn insert_agy_hook_entries(settings: &mut serde_json::Value, hook_command: &str) -> Result<()> {
     let settings_obj = settings
         .as_object_mut()
         .context("agy settings.json is not an object")?;
@@ -1885,7 +1917,7 @@ fn insert_agy_hook_entries(settings: &mut serde_json::Value) -> Result<()> {
     for matcher in &["run_command", "Bash"] {
         before_tool.push(serde_json::json!({
             "matcher": matcher,
-            "hooks": [{"type": "command", "command": ANTIGRAVITY_HOOK_COMMAND}]
+            "hooks": [{"type": "command", "command": hook_command}]
         }));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,8 +43,10 @@ pub enum AgentTarget {
     Cline,
     /// Kilo Code
     Kilocode,
-    /// Google Antigravity
+    /// Google Antigravity IDE (formerly Antigravity)
     Antigravity,
+    /// Google Antigravity CLI (agy) - successor to Gemini CLI
+    Agy,
     /// Hermes CLI
     Hermes,
 }
@@ -774,6 +776,9 @@ enum HookCommands {
     Gemini,
     /// Process Copilot preToolUse hook (VS Code + Copilot CLI, reads JSON from stdin)
     Copilot,
+    /// Process Google Antigravity (agy) CLI PreToolUse hook (reads JSON from stdin)
+    #[command(alias = "agy")]
+    Antigravity,
     /// Check how a command would be rewritten by the hook engine (dry-run)
     Check {
         /// Target agent
@@ -1376,13 +1381,15 @@ fn uninstall_init_dispatch<UninstallHermes, UninstallStandard>(
 ) -> Result<()>
 where
     UninstallHermes: FnOnce(hooks::init::InitContext) -> Result<()>,
-    UninstallStandard: FnOnce(bool, bool, bool, bool, hooks::init::InitContext) -> Result<()>,
+    UninstallStandard:
+        FnOnce(bool, bool, bool, bool, bool, hooks::init::InitContext) -> Result<()>,
 {
     if agent == Some(AgentTarget::Hermes) {
         uninstall_hermes(ctx)
     } else {
         let cursor = agent == Some(AgentTarget::Cursor);
-        uninstall_standard(global, gemini, codex, cursor, ctx)
+        let antigravity_cli = agent == Some(AgentTarget::Agy);
+        uninstall_standard(global, gemini, codex, cursor, antigravity_cli, ctx)
     }
 }
 
@@ -1848,10 +1855,12 @@ fn run_cli() -> Result<i32> {
             } else if agent == Some(AgentTarget::Antigravity) {
                 if global {
                     anyhow::bail!(
-                        "Antigravity is project-scoped. Use: rtk init --agent antigravity"
+                        "Antigravity IDE is project-scoped. Use: rtk init --agent antigravity"
                     );
                 }
                 hooks::init::run_antigravity_mode(ctx)?;
+            } else if agent == Some(AgentTarget::Agy) {
+                hooks::init::run_agy_cli_mode(global, ctx)?;
             } else if agent == Some(AgentTarget::Hermes) {
                 hooks::init::run_hermes_mode(ctx)?;
             } else {
@@ -2185,6 +2194,10 @@ fn run_cli() -> Result<i32> {
             }
             HookCommands::Copilot => {
                 hooks::hook_cmd::run_copilot()?;
+                0
+            }
+            HookCommands::Antigravity => {
+                hooks::hook_cmd::run_antigravity()?;
                 0
             }
             HookCommands::Check { agent: _, command } => {
@@ -2705,7 +2718,7 @@ mod tests {
                 assert!(ctx.dry_run);
                 Ok(())
             },
-            |_, _, _, _, _| {
+            |_, _, _, _, _, _| {
                 standard_called.set(true);
                 Ok(())
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -1381,8 +1381,7 @@ fn uninstall_init_dispatch<UninstallHermes, UninstallStandard>(
 ) -> Result<()>
 where
     UninstallHermes: FnOnce(hooks::init::InitContext) -> Result<()>,
-    UninstallStandard:
-        FnOnce(bool, bool, bool, bool, bool, hooks::init::InitContext) -> Result<()>,
+    UninstallStandard: FnOnce(bool, bool, bool, bool, bool, hooks::init::InitContext) -> Result<()>,
 {
     if agent == Some(AgentTarget::Hermes) {
         uninstall_hermes(ctx)


### PR DESCRIPTION
## Summary

- Adds `rtk hook antigravity` — a `PreToolUse` hook for the Google Antigravity CLI (`agy`) that rewrites bare shell commands to their `rtk`-prefixed equivalents before the model executes them
- `rtk init --agent agy` configures `~/.gemini/antigravity-cli/settings.json` with the hook and grants `command(rtk)` permission so retries are auto-approved
- Handles both simple (`tool_name`/`tool_input`) and rich (`toolCall.name`/`toolCall.args`) agy payload formats
- `RTK_HOOK_DEBUG=1` logs full request/response pairs to `~/.local/share/rtk/agy-hook-debug.log`

## How it works

agy's `overwrite` field in `PreToolHookResult` is silently ignored (confirmed via debug logging — correct payload sent, original command executed). The hook therefore uses the `denyReason` strategy:

1. Hook intercepts `run_command` / `Bash` tool calls
2. If the command has an RTK equivalent, hook returns `{"denyReason": "RTK: use 'rtk git log' instead of 'git log' (60-90% token savings)"}`
3. Model reads the reason and retries with the `rtk`-prefixed command
4. `command(rtk)` in the allow list auto-approves the retry — no user prompt

Commands already prefixed with `rtk` or in the passthrough list pass through with `{"allowTool": true}`.

## Test plan

- [x] `cargo test --all` — 1924 tests pass, zero clippy warnings
- [x] `rtk init --agent agy` writes correct `~/.gemini/antigravity-cli/settings.json`
- [x] Hook rejects bare `git log` with denyReason naming `rtk git log`
- [x] Hook passes through `rtk git log` with `allowTool: true`
- [x] Hook passes through non-shell tools (e.g. `read_file`) with `allowTool: true`
- [x] `RTK_HOOK_DEBUG=1` writes input/output to debug log

## Known limitation

agy does not honour the `overwrite` field in `PreToolHookResult` — only `allowTool` and `denyReason` are implemented. The deny-and-retry pattern produces a `⚠ Tool call denied` notice in the agy UI before the model retries with the RTK command. Transparent rewriting will be possible once agy implements `overwrite` support.

This issue reported in [this topic](https://discuss.ai.google.dev/t/pretoolhookresult-overwrite-is-broken-under-toolpermission-request-review/165839?u=lok1s) on discuss.ai.google.dev. More visibility on this bug report required.

<img width="792" height="588" alt="image" src="https://github.com/user-attachments/assets/1cc14ecc-062b-49b9-b80f-c3c70a34d0f1" />
Tested in Antigravity CLI v1.0.2