### PR TITLE
feat(copilot): CLI native integration

### DIFF
--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -74,6 +74,14 @@ rtk init --copilot
 
 Writes one `.github/hooks/rtk-rewrite.json` serving both hosts: VS Code Copilot Chat reads its `PreToolUse` entry (transparent rewrite), GitHub Copilot CLI reads its `preToolUse` entry (deny-with-suggestion; the agent retries with `rtk`).
 
+Uninstall (project-scoped):
+
+```bash
+rtk init --uninstall --copilot
+```
+
+Removes `.github/hooks/rtk-rewrite.json` and the RTK block from `.github/copilot-instructions.md` (your own content is preserved).
+
 ### Gemini CLI
 
 ```bash

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -30,7 +30,7 @@ Agent runs "cargo test"
 |-------|-----------------|---------------------------|
 | Claude Code | Shell hook (`PreToolUse`) | Yes |
 | VS Code Copilot Chat | Shell hook (`PreToolUse`) | Yes |
-| GitHub Copilot CLI | Shell hook (deny-with-suggestion) | No (agent retries) |
+| GitHub Copilot CLI | Shell hook (`preToolUse` `modifiedArgs`) | Yes |
 | Cursor | Shell hook (`preToolUse`) | Yes |
 | Gemini CLI | Rust binary (`BeforeTool`) | Yes |
 | OpenCode | TypeScript plugin (`tool.execute.before`) | Yes |
@@ -69,18 +69,20 @@ Restart Cursor. The hook uses `preToolUse` with Cursor's `updated_input` format.
 ### GitHub Copilot (VS Code Chat + CLI)
 
 ```bash
-rtk init --copilot
+rtk init --copilot            # project-scoped (.github/hooks/)
+rtk init --global --copilot   # user-scoped (~/.copilot/hooks/, respects $COPILOT_HOME)
 ```
 
-Writes one `.github/hooks/rtk-rewrite.json` serving both hosts: VS Code Copilot Chat reads its `PreToolUse` entry (transparent rewrite), GitHub Copilot CLI reads its `preToolUse` entry (deny-with-suggestion; the agent retries with `rtk`).
+Project-scoped writes `.github/hooks/rtk-rewrite.json` (both hosts get transparent rewrite — VS Code Chat via `updatedInput`, Copilot CLI via `modifiedArgs`) plus the RTK block in `.github/copilot-instructions.md`. User-scoped writes only `~/.copilot/hooks/rtk-rewrite.json` — the Copilot CLI docs define no user-level instructions file.
 
-Uninstall (project-scoped):
+Uninstall:
 
 ```bash
 rtk init --uninstall --copilot
+rtk init --uninstall --global --copilot
 ```
 
-Removes `.github/hooks/rtk-rewrite.json` and the RTK block from `.github/copilot-instructions.md` (your own content is preserved).
+Removes only RTK's hook file (and, for project, the RTK block in `copilot-instructions.md`). Other files in `.github/hooks/` or `~/.copilot/hooks/` and your own instruction content are untouched.
 
 ### Gemini CLI
 

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -66,11 +66,13 @@ rtk init --global --cursor
 
 Restart Cursor. The hook uses `preToolUse` with Cursor's `updated_input` format.
 
-### VS Code Copilot Chat
+### GitHub Copilot (VS Code Chat + CLI)
 
 ```bash
-rtk init --global --copilot
+rtk init --copilot
 ```
+
+Writes one `.github/hooks/rtk-rewrite.json` serving both hosts: VS Code Copilot Chat reads its `PreToolUse` entry (transparent rewrite), GitHub Copilot CLI reads its `preToolUse` entry (deny-with-suggestion; the agent retries with `rtk`).
 
 ### Gemini CLI
 

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -73,7 +73,7 @@ rtk init --copilot            # project-scoped (.github/hooks/)
 rtk init --global --copilot   # user-scoped (~/.copilot/hooks/, respects $COPILOT_HOME)
 ```
 
-Project-scoped writes `.github/hooks/rtk-rewrite.json` (both hosts get transparent rewrite — VS Code Chat via `updatedInput`, Copilot CLI via `modifiedArgs`) plus the RTK block in `.github/copilot-instructions.md`. User-scoped writes only `~/.copilot/hooks/rtk-rewrite.json` — the Copilot CLI docs define no user-level instructions file.
+Project-scoped writes `.github/hooks/rtk-rewrite.json` (both hosts get transparent rewrite — VS Code Chat via `updatedInput`, Copilot CLI via `modifiedArgs`) plus the RTK block in `.github/copilot-instructions.md`. User-scoped writes the same hook config to `~/.copilot/hooks/rtk-rewrite.json` and the RTK block to `~/.copilot/copilot-instructions.md` (both respect `$COPILOT_HOME` if set).
 
 Uninstall:
 

--- a/src/core/telemetry.rs
+++ b/src/core/telemetry.rs
@@ -368,10 +368,13 @@ fn detect_hook_type() -> String {
         }
     }
 
-    // Check project-level hooks
+    // Check project-level hooks (Claude script + project-scoped Copilot config)
     if let Ok(cwd) = std::env::current_dir() {
         if cwd.join(".claude/hooks/rtk-rewrite.sh").exists() {
             return "claude".to_string();
+        }
+        if cwd.join(".github/hooks/rtk-rewrite.json").exists() {
+            return "copilot".to_string();
         }
     }
 
@@ -571,7 +574,7 @@ mod tests {
         assert!(stats.low_savings_commands.len() <= 5);
         assert!((0.0..=100.0).contains(&stats.avg_savings_per_command));
         assert!(
-            ["claude", "gemini", "codex", "cursor", "none", "unknown"]
+            ["claude", "gemini", "codex", "cursor", "copilot", "none", "unknown"]
                 .iter()
                 .any(|&h| stats.hook_type.starts_with(h)),
             "Unexpected hook type: {}",
@@ -583,7 +586,8 @@ mod tests {
     fn test_detect_hook_type_returns_known() {
         let ht = detect_hook_type();
         assert!(
-            ["claude", "gemini", "codex", "cursor", "none", "unknown"].contains(&ht.as_str()),
+            ["claude", "gemini", "codex", "cursor", "copilot", "none", "unknown"]
+                .contains(&ht.as_str()),
             "Unexpected hook type: {}",
             ht
         );

--- a/src/discover/report.rs
+++ b/src/discover/report.rs
@@ -1,8 +1,8 @@
 //! Data types for reporting which commands RTK can and cannot optimize.
 
 use crate::hooks::constants::{
-    CURSOR_DIR, HERMES_DIR, HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME,
-    HOOKS_SUBDIR, REWRITE_HOOK_FILE,
+    COPILOT_HOOK_FILE, CURSOR_DIR, GITHUB_DIR, HERMES_DIR, HERMES_PLUGINS_SUBDIR,
+    HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_SUBDIR, REWRITE_HOOK_FILE,
 };
 use serde::Serialize;
 use std::path::Path;
@@ -52,13 +52,19 @@ pub struct UnsupportedEntry {
 pub struct AgentIntegrationStatus {
     pub cursor_hook_installed: bool,
     pub hermes_plugin_installed: bool,
+    pub copilot_hook_installed: bool,
 }
 
 impl AgentIntegrationStatus {
     pub fn detect() -> Self {
-        dirs::home_dir()
+        let mut status = dirs::home_dir()
             .map(|home| Self::detect_from_home(&home))
-            .unwrap_or_default()
+            .unwrap_or_default();
+        // Copilot is project-scoped (.github/hooks/), unlike the home-based agents.
+        status.copilot_hook_installed = std::env::current_dir()
+            .map(|cwd| Self::copilot_hook_installed_in(&cwd))
+            .unwrap_or(false);
+        status
     }
 
     fn detect_from_home(home: &Path) -> Self {
@@ -74,7 +80,15 @@ impl AgentIntegrationStatus {
                 .join(HERMES_PLUGIN_NAME)
                 .join(HERMES_PLUGIN_MANIFEST_FILE)
                 .is_file(),
+            copilot_hook_installed: false,
         }
+    }
+
+    fn copilot_hook_installed_in(dir: &Path) -> bool {
+        dir.join(GITHUB_DIR)
+            .join(HOOKS_SUBDIR)
+            .join(COPILOT_HOOK_FILE)
+            .exists()
     }
 }
 
@@ -221,6 +235,10 @@ fn append_agent_notes(out: &mut String, status: AgentIntegrationStatus) {
     if status.hermes_plugin_installed {
         out.push_str("\nNote: Hermes plugin is installed; Hermes sessions are tracked via `rtk gain` (discover scans Claude Code only)\n");
     }
+
+    if status.copilot_hook_installed {
+        out.push_str("\nNote: GitHub Copilot sessions are tracked via `rtk gain` (discover scans Claude Code only)\n");
+    }
 }
 
 /// Format report as JSON.
@@ -362,6 +380,7 @@ mod tests {
         report.agent_status = AgentIntegrationStatus {
             cursor_hook_installed: true,
             hermes_plugin_installed: true,
+            copilot_hook_installed: true,
         };
 
         let output = format_json(&report);
@@ -369,5 +388,42 @@ mod tests {
 
         assert_eq!(json["agent_status"]["cursor_hook_installed"], true);
         assert_eq!(json["agent_status"]["hermes_plugin_installed"], true);
+        assert_eq!(json["agent_status"]["copilot_hook_installed"], true);
+    }
+
+    #[test]
+    fn test_agent_status_detects_copilot_hook_in_project() {
+        let temp = tempfile::tempdir().unwrap();
+        let hook = temp
+            .path()
+            .join(GITHUB_DIR)
+            .join(HOOKS_SUBDIR)
+            .join(COPILOT_HOOK_FILE);
+        std::fs::create_dir_all(hook.parent().unwrap()).unwrap();
+        std::fs::write(&hook, "{}").unwrap();
+
+        assert!(AgentIntegrationStatus::copilot_hook_installed_in(
+            temp.path()
+        ));
+        assert!(!AgentIntegrationStatus::copilot_hook_installed_in(
+            tempfile::tempdir().unwrap().path()
+        ));
+    }
+
+    #[test]
+    fn test_format_text_reports_copilot_detected() {
+        let mut report = make_report(0, 0);
+        report.agent_status = AgentIntegrationStatus {
+            copilot_hook_installed: true,
+            ..AgentIntegrationStatus::default()
+        };
+
+        let output = format_text(&report, 10, false);
+
+        assert!(
+            output.contains("GitHub Copilot sessions are tracked via `rtk gain`"),
+            "Expected Copilot note in output but got:\n{}",
+            output
+        );
     }
 }

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -25,6 +25,8 @@ pub const GEMINI_DIR: &str = ".gemini";
 pub const GITHUB_DIR: &str = ".github";
 pub const COPILOT_HOOK_FILE: &str = "rtk-rewrite.json";
 pub const COPILOT_INSTRUCTIONS_FILE: &str = "copilot-instructions.md";
+pub const COPILOT_USER_DIR: &str = ".copilot";
+pub const COPILOT_HOME_ENV: &str = "COPILOT_HOME";
 
 pub const PI_DIR: &str = ".pi/agent";
 pub const PI_LOCAL_DIR: &str = ".pi";

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -22,6 +22,10 @@ pub const CURSOR_DIR: &str = ".cursor";
 pub const CODEX_DIR: &str = ".codex";
 pub const GEMINI_DIR: &str = ".gemini";
 
+pub const GITHUB_DIR: &str = ".github";
+pub const COPILOT_HOOK_FILE: &str = "rtk-rewrite.json";
+pub const COPILOT_INSTRUCTIONS_FILE: &str = "copilot-instructions.md";
+
 pub const PI_DIR: &str = ".pi/agent";
 pub const PI_LOCAL_DIR: &str = ".pi";
 pub const PI_EXTENSIONS_SUBDIR: &str = "extensions";

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -31,7 +31,7 @@ fn read_stdin_limited() -> Result<String> {
 enum HookFormat {
     /// VS Code Copilot Chat / Claude Code: `tool_name` + `tool_input.command`, supports `updatedInput`.
     VsCode { command: String },
-    /// GitHub Copilot CLI: camelCase `toolName` + `toolArgs` (JSON string), deny-with-suggestion only.
+    /// GitHub Copilot CLI: camelCase `toolName` + `toolArgs` (JSON string), supports `modifiedArgs` for transparent rewrite.
     CopilotCli { command: String },
     /// Non-bash tool, already uses rtk, or unknown format — pass through silently.
     PassThrough,
@@ -156,27 +156,24 @@ fn handle_vscode(cmd: &str) -> Result<()> {
 }
 
 fn handle_copilot_cli(cmd: &str) -> Result<()> {
+    if let Some(response) = copilot_cli_response(cmd) {
+        let _ = writeln!(io::stdout(), "{response}");
+    }
+    Ok(())
+}
+
+fn copilot_cli_response(cmd: &str) -> Option<Value> {
     if permissions::check_command(cmd) == PermissionVerdict::Deny {
         audit_log("deny", cmd, "");
-        return Ok(());
+        return None;
     }
-
-    let rewritten = match get_rewritten(cmd) {
-        Some(r) => r,
-        None => return Ok(()),
-    };
-
+    let rewritten = get_rewritten(cmd)?;
     audit_log("rewrite", cmd, &rewritten);
-
-    let output = json!({
-        "permissionDecision": "deny",
-        "permissionDecisionReason": format!(
-            "Token savings: use `{}` instead (rtk saves 60-90% tokens)",
-            rewritten
-        )
-    });
-    let _ = writeln!(io::stdout(), "{output}");
-    Ok(())
+    Some(json!({
+        "permissionDecision": "allow",
+        "permissionDecisionReason": "RTK auto-rewrite",
+        "modifiedArgs": { "command": rewritten }
+    }))
 }
 
 // ── Gemini hook ───────────────────────────────────────────────
@@ -619,6 +616,39 @@ mod tests {
     #[test]
     fn test_get_rewritten_heredoc() {
         assert!(get_rewritten("cat <<'EOF'\nhello\nEOF").is_none());
+    }
+
+    // --- Copilot CLI handler: transparent rewrite via modifiedArgs ---
+
+    #[test]
+    fn test_copilot_cli_transparent_rewrite() {
+        let r = copilot_cli_response("cargo test").unwrap();
+        assert_eq!(r["permissionDecision"], "allow");
+        assert_eq!(r["modifiedArgs"]["command"], "rtk cargo test");
+    }
+
+    #[test]
+    fn test_copilot_cli_passthrough_unsupported() {
+        assert!(copilot_cli_response("htop").is_none());
+    }
+
+    #[test]
+    fn test_copilot_cli_passthrough_already_rtk() {
+        assert!(copilot_cli_response("rtk cargo test").is_none());
+    }
+
+    #[test]
+    fn test_copilot_cli_passthrough_heredoc() {
+        assert!(copilot_cli_response("cat <<EOF\nhi\nEOF").is_none());
+    }
+
+    #[test]
+    fn test_copilot_cli_preserves_env_prefix() {
+        let r = copilot_cli_response("RUST_LOG=debug cargo test").unwrap();
+        assert_eq!(
+            r["modifiedArgs"]["command"],
+            "RUST_LOG=debug rtk cargo test"
+        );
     }
 
     // --- Gemini format ---

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -180,19 +180,24 @@ fn copilot_cli_response_for_verdict(
     }
     let rewritten = get_rewritten(cmd)?;
     audit_log("rewrite", cmd, &rewritten);
-    let decision = match verdict {
-        PermissionVerdict::Allow => "allow",
-        _ => "ask",
-    };
+
     let mut modified = args.clone();
     if let Some(obj) = modified.as_object_mut() {
         obj.insert("command".into(), Value::String(rewritten));
     }
-    Some(json!({
-        "permissionDecision": decision,
+
+    // Copilot CLI v1.0.54 only applies `modifiedArgs` when permissionDecision is
+    // either "allow" or absent. Omitting permissionDecision lets Copilot's normal
+    // permission flow run on the rewritten command — `rtk *` is not on its
+    // auto-allow list, so the user sees a prompt for the rewritten command.
+    let mut response = json!({
         "permissionDecisionReason": "RTK auto-rewrite",
-        "modifiedArgs": modified
-    }))
+        "modifiedArgs": modified,
+    });
+    if verdict == PermissionVerdict::Allow {
+        response["permissionDecision"] = json!("allow");
+    }
+    Some(response)
 }
 
 // ── Gemini hook ───────────────────────────────────────────────
@@ -644,16 +649,16 @@ mod tests {
     }
 
     #[test]
-    fn test_copilot_cli_default_verdict_returns_ask_with_rewrite() {
+    fn test_copilot_cli_default_verdict_omits_permission_decision() {
         let r = copilot_cli_response_for_verdict(
             "cargo test",
             &cli_args("cargo test"),
             PermissionVerdict::Default,
         )
         .unwrap();
-        assert_eq!(
-            r["permissionDecision"], "ask",
-            "Default must be 'ask' so the user is still prompted for the rewritten command"
+        assert!(
+            r.get("permissionDecision").is_none(),
+            "Default must NOT set permissionDecision — Copilot then runs its normal prompt flow on the rewritten command"
         );
         assert_eq!(r["modifiedArgs"]["command"], "rtk cargo test");
     }

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -163,14 +163,22 @@ fn handle_copilot_cli(cmd: &str) -> Result<()> {
 }
 
 fn copilot_cli_response(cmd: &str) -> Option<Value> {
-    if permissions::check_command(cmd) == PermissionVerdict::Deny {
+    copilot_cli_response_for_verdict(cmd, permissions::check_command(cmd))
+}
+
+fn copilot_cli_response_for_verdict(cmd: &str, verdict: PermissionVerdict) -> Option<Value> {
+    if verdict == PermissionVerdict::Deny {
         audit_log("deny", cmd, "");
         return None;
     }
     let rewritten = get_rewritten(cmd)?;
     audit_log("rewrite", cmd, &rewritten);
+    let decision = match verdict {
+        PermissionVerdict::Allow => "allow",
+        _ => "ask",
+    };
     Some(json!({
-        "permissionDecision": "allow",
+        "permissionDecision": decision,
         "permissionDecisionReason": "RTK auto-rewrite",
         "modifiedArgs": { "command": rewritten }
     }))
@@ -621,10 +629,25 @@ mod tests {
     // --- Copilot CLI handler: transparent rewrite via modifiedArgs ---
 
     #[test]
-    fn test_copilot_cli_transparent_rewrite() {
-        let r = copilot_cli_response("cargo test").unwrap();
+    fn test_copilot_cli_default_verdict_returns_ask_with_rewrite() {
+        let r = copilot_cli_response_for_verdict("cargo test", PermissionVerdict::Default).unwrap();
+        assert_eq!(
+            r["permissionDecision"], "ask",
+            "Default must be 'ask' so the user is still prompted for the rewritten command"
+        );
+        assert_eq!(r["modifiedArgs"]["command"], "rtk cargo test");
+    }
+
+    #[test]
+    fn test_copilot_cli_explicit_allow_returns_allow_with_rewrite() {
+        let r = copilot_cli_response_for_verdict("cargo test", PermissionVerdict::Allow).unwrap();
         assert_eq!(r["permissionDecision"], "allow");
         assert_eq!(r["modifiedArgs"]["command"], "rtk cargo test");
+    }
+
+    #[test]
+    fn test_copilot_cli_deny_verdict_returns_none() {
+        assert!(copilot_cli_response_for_verdict("cargo test", PermissionVerdict::Deny).is_none());
     }
 
     #[test]

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -42,7 +42,9 @@ enum HookFormat {
 pub fn run_copilot() -> Result<()> {
     let input = read_stdin_limited()?;
 
-    let input = input.trim();
+    // Strip leading BOM(s) before trimming: some Windows hosts prepend UTF-8
+    // BOMs to hook stdin (confirmed for Cursor), which serde_json rejects.
+    let input = strip_leading_bom(&input).trim();
     if input.is_empty() {
         return Ok(());
     }
@@ -573,6 +575,25 @@ mod tests {
     fn test_detect_non_bash_is_passthrough() {
         let v = json!({ "tool_name": "editFiles" });
         assert!(matches!(detect_format(&v), HookFormat::PassThrough));
+    }
+
+    #[test]
+    fn test_copilot_bom_prefixed_payload_is_recognized() {
+        // Windows hosts may prepend one or two UTF-8 BOMs to hook stdin
+        // (confirmed for Cursor). run_copilot strips them before parsing;
+        // verify both Copilot formats still parse after the same handling.
+        for raw in [
+            format!("\u{feff}{}", copilot_cli_input("git status")),
+            format!("\u{feff}\u{feff}{}", copilot_cli_input("git status")),
+        ] {
+            let cleaned = strip_leading_bom(&raw).trim();
+            let v: Value = serde_json::from_str(cleaned).expect("BOM-stripped JSON must parse");
+            assert!(matches!(detect_format(&v), HookFormat::CopilotCli { .. }));
+        }
+
+        let raw = format!("\u{feff}{}", vscode_input("Bash", "git status"));
+        let v: Value = serde_json::from_str(strip_leading_bom(&raw).trim()).unwrap();
+        assert!(matches!(detect_format(&v), HookFormat::VsCode { .. }));
     }
 
     #[test]

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -32,7 +32,9 @@ enum HookFormat {
     /// VS Code Copilot Chat / Claude Code: `tool_name` + `tool_input.command`, supports `updatedInput`.
     VsCode { command: String },
     /// GitHub Copilot CLI: camelCase `toolName` + `toolArgs` (JSON string), supports `modifiedArgs` for transparent rewrite.
-    CopilotCli { command: String },
+    /// Carries the full parsed `toolArgs` object so we can rewrite `command` while preserving
+    /// host-supplied metadata (description, initial_wait, mode, …) the tool requires.
+    CopilotCli { command: String, args: Value },
     /// Non-bash tool, already uses rtk, or unknown format — pass through silently.
     PassThrough,
 }
@@ -59,7 +61,7 @@ pub fn run_copilot() -> Result<()> {
 
     match detect_format(&v) {
         HookFormat::VsCode { command } => handle_vscode(&command),
-        HookFormat::CopilotCli { command } => handle_copilot_cli(&command),
+        HookFormat::CopilotCli { command, args } => handle_copilot_cli(&command, &args),
         HookFormat::PassThrough => Ok(()),
     }
 }
@@ -93,6 +95,7 @@ fn detect_format(v: &Value) -> HookFormat {
                     {
                         return HookFormat::CopilotCli {
                             command: cmd.to_string(),
+                            args: tool_args,
                         };
                     }
                 }
@@ -155,18 +158,22 @@ fn handle_vscode(cmd: &str) -> Result<()> {
     Ok(())
 }
 
-fn handle_copilot_cli(cmd: &str) -> Result<()> {
-    if let Some(response) = copilot_cli_response(cmd) {
+fn handle_copilot_cli(cmd: &str, args: &Value) -> Result<()> {
+    if let Some(response) = copilot_cli_response(cmd, args) {
         let _ = writeln!(io::stdout(), "{response}");
     }
     Ok(())
 }
 
-fn copilot_cli_response(cmd: &str) -> Option<Value> {
-    copilot_cli_response_for_verdict(cmd, permissions::check_command(cmd))
+fn copilot_cli_response(cmd: &str, args: &Value) -> Option<Value> {
+    copilot_cli_response_for_verdict(cmd, args, permissions::check_command(cmd))
 }
 
-fn copilot_cli_response_for_verdict(cmd: &str, verdict: PermissionVerdict) -> Option<Value> {
+fn copilot_cli_response_for_verdict(
+    cmd: &str,
+    args: &Value,
+    verdict: PermissionVerdict,
+) -> Option<Value> {
     if verdict == PermissionVerdict::Deny {
         audit_log("deny", cmd, "");
         return None;
@@ -177,10 +184,14 @@ fn copilot_cli_response_for_verdict(cmd: &str, verdict: PermissionVerdict) -> Op
         PermissionVerdict::Allow => "allow",
         _ => "ask",
     };
+    let mut modified = args.clone();
+    if let Some(obj) = modified.as_object_mut() {
+        obj.insert("command".into(), Value::String(rewritten));
+    }
     Some(json!({
         "permissionDecision": decision,
         "permissionDecisionReason": "RTK auto-rewrite",
-        "modifiedArgs": { "command": rewritten }
+        "modifiedArgs": modified
     }))
 }
 
@@ -628,9 +639,18 @@ mod tests {
 
     // --- Copilot CLI handler: transparent rewrite via modifiedArgs ---
 
+    fn cli_args(cmd: &str) -> Value {
+        json!({ "command": cmd })
+    }
+
     #[test]
     fn test_copilot_cli_default_verdict_returns_ask_with_rewrite() {
-        let r = copilot_cli_response_for_verdict("cargo test", PermissionVerdict::Default).unwrap();
+        let r = copilot_cli_response_for_verdict(
+            "cargo test",
+            &cli_args("cargo test"),
+            PermissionVerdict::Default,
+        )
+        .unwrap();
         assert_eq!(
             r["permissionDecision"], "ask",
             "Default must be 'ask' so the user is still prompted for the rewritten command"
@@ -640,38 +660,74 @@ mod tests {
 
     #[test]
     fn test_copilot_cli_explicit_allow_returns_allow_with_rewrite() {
-        let r = copilot_cli_response_for_verdict("cargo test", PermissionVerdict::Allow).unwrap();
+        let r = copilot_cli_response_for_verdict(
+            "cargo test",
+            &cli_args("cargo test"),
+            PermissionVerdict::Allow,
+        )
+        .unwrap();
         assert_eq!(r["permissionDecision"], "allow");
         assert_eq!(r["modifiedArgs"]["command"], "rtk cargo test");
     }
 
     #[test]
     fn test_copilot_cli_deny_verdict_returns_none() {
-        assert!(copilot_cli_response_for_verdict("cargo test", PermissionVerdict::Deny).is_none());
+        assert!(copilot_cli_response_for_verdict(
+            "cargo test",
+            &cli_args("cargo test"),
+            PermissionVerdict::Deny
+        )
+        .is_none());
     }
 
     #[test]
     fn test_copilot_cli_passthrough_unsupported() {
-        assert!(copilot_cli_response("htop").is_none());
+        assert!(copilot_cli_response("htop", &cli_args("htop")).is_none());
     }
 
     #[test]
     fn test_copilot_cli_passthrough_already_rtk() {
-        assert!(copilot_cli_response("rtk cargo test").is_none());
+        assert!(copilot_cli_response("rtk cargo test", &cli_args("rtk cargo test")).is_none());
     }
 
     #[test]
     fn test_copilot_cli_passthrough_heredoc() {
-        assert!(copilot_cli_response("cat <<EOF\nhi\nEOF").is_none());
+        let cmd = "cat <<EOF\nhi\nEOF";
+        assert!(copilot_cli_response(cmd, &cli_args(cmd)).is_none());
     }
 
     #[test]
     fn test_copilot_cli_preserves_env_prefix() {
-        let r = copilot_cli_response("RUST_LOG=debug cargo test").unwrap();
+        let r = copilot_cli_response(
+            "RUST_LOG=debug cargo test",
+            &cli_args("RUST_LOG=debug cargo test"),
+        )
+        .unwrap();
         assert_eq!(
             r["modifiedArgs"]["command"],
             "RUST_LOG=debug rtk cargo test"
         );
+    }
+
+    #[test]
+    fn test_copilot_cli_preserves_extra_args_fields() {
+        let args = json!({
+            "command": "cargo install ripgrep",
+            "description": "install ripgrep",
+            "initial_wait": 30,
+            "mode": "sync"
+        });
+        let r = copilot_cli_response_for_verdict(
+            "cargo install ripgrep",
+            &args,
+            PermissionVerdict::Default,
+        )
+        .unwrap();
+        let modified = &r["modifiedArgs"];
+        assert_eq!(modified["command"], "rtk cargo install ripgrep");
+        assert_eq!(modified["description"], "install ripgrep");
+        assert_eq!(modified["initial_wait"], 30);
+        assert_eq!(modified["mode"], "sync");
     }
 
     // --- Gemini format ---

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -3951,6 +3951,82 @@ fn run_copilot_at(base: &Path, ctx: InitContext) -> Result<()> {
     Ok(())
 }
 
+/// Entry point for `rtk init --uninstall --copilot` (project-scoped, like install).
+pub fn uninstall_copilot(ctx: InitContext) -> Result<()> {
+    let InitContext { dry_run, .. } = ctx;
+    let removed = uninstall_copilot_at(Path::new("."), ctx)?;
+
+    if removed.is_empty() {
+        println!("RTK Copilot support was not installed (nothing to remove)");
+    } else {
+        let header = if dry_run {
+            "[dry-run] would uninstall RTK (GitHub Copilot):"
+        } else {
+            "RTK uninstalled (GitHub Copilot):"
+        };
+        println!("{}", header);
+        for item in &removed {
+            println!("  - {}", item);
+        }
+        if !dry_run {
+            println!("\nRestart your IDE or Copilot CLI session to apply changes.");
+        }
+    }
+
+    if dry_run {
+        print_dry_run_footer();
+    }
+    Ok(())
+}
+
+/// Same as [`uninstall_copilot`] but operates relative to an explicit base path.
+fn uninstall_copilot_at(base: &Path, ctx: InitContext) -> Result<Vec<String>> {
+    let InitContext { dry_run, .. } = ctx;
+    let github_dir = base.join(GITHUB_DIR);
+    let mut removed = Vec::new();
+
+    let hook_path = github_dir.join(HOOKS_SUBDIR).join(COPILOT_HOOK_FILE);
+    if hook_path.exists() {
+        if dry_run {
+            println!(
+                "[dry-run] would remove hook config: {}",
+                hook_path.display()
+            );
+        } else {
+            fs::remove_file(&hook_path)
+                .with_context(|| format!("Failed to remove hook: {}", hook_path.display()))?;
+        }
+        removed.push(format!("Hook config: {}", hook_path.display()));
+    }
+
+    let instructions_path = github_dir.join(COPILOT_INSTRUCTIONS_FILE);
+    if instructions_path.exists() {
+        let content = fs::read_to_string(&instructions_path)
+            .with_context(|| format!("Failed to read {}", instructions_path.display()))?;
+        if content.contains(RTK_BLOCK_START) {
+            let (cleaned, did_remove) = remove_rtk_block(&content);
+            if did_remove {
+                if dry_run {
+                    println!(
+                        "[dry-run] would remove rtk-instructions block from {}",
+                        instructions_path.display()
+                    );
+                } else {
+                    atomic_write(&instructions_path, &cleaned).with_context(|| {
+                        format!("Failed to write {}", instructions_path.display())
+                    })?;
+                }
+                removed.push(format!(
+                    "{}: removed rtk-instructions block",
+                    COPILOT_INSTRUCTIONS_FILE
+                ));
+            }
+        }
+    }
+
+    Ok(removed)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -6300,6 +6376,72 @@ mod tests {
         assert_eq!(v["hooks"]["PreToolUse"][0]["command"], "rtk hook copilot");
         assert_eq!(v["version"], 1);
         assert_eq!(v["hooks"]["preToolUse"][0]["bash"], "rtk hook copilot");
+    }
+
+    #[test]
+    fn test_copilot_uninstall_removes_hook_and_block() {
+        let temp = TempDir::new().unwrap();
+        run_copilot_at(temp.path(), InitContext::default()).unwrap();
+
+        let hook_path = temp
+            .path()
+            .join(".github")
+            .join("hooks")
+            .join("rtk-rewrite.json");
+        let instructions_path = temp.path().join(".github").join("copilot-instructions.md");
+        assert!(hook_path.exists());
+
+        let removed = uninstall_copilot_at(temp.path(), InitContext::default()).unwrap();
+
+        assert!(!removed.is_empty());
+        assert!(!hook_path.exists(), "hook config must be removed");
+        let instructions = fs::read_to_string(&instructions_path).unwrap();
+        assert!(
+            !instructions.contains(RTK_BLOCK_START),
+            "RTK block must be removed"
+        );
+    }
+
+    #[test]
+    fn test_copilot_uninstall_preserves_user_instructions() {
+        let temp = TempDir::new().unwrap();
+        let github_dir = temp.path().join(".github");
+        fs::create_dir_all(&github_dir).unwrap();
+        let instructions_path = github_dir.join("copilot-instructions.md");
+        fs::write(&instructions_path, "# My rules\n\nAlways use pnpm.\n").unwrap();
+
+        run_copilot_at(temp.path(), InitContext::default()).unwrap();
+        uninstall_copilot_at(temp.path(), InitContext::default()).unwrap();
+
+        let after = fs::read_to_string(&instructions_path).unwrap();
+        assert!(after.contains("Always use pnpm."), "user content preserved");
+        assert!(!after.contains(RTK_BLOCK_START), "RTK block removed");
+    }
+
+    #[test]
+    fn test_copilot_uninstall_dry_run_keeps_files() {
+        let temp = TempDir::new().unwrap();
+        run_copilot_at(temp.path(), InitContext::default()).unwrap();
+        let hook_path = temp
+            .path()
+            .join(".github")
+            .join("hooks")
+            .join("rtk-rewrite.json");
+
+        let ctx = InitContext {
+            verbose: 0,
+            dry_run: true,
+        };
+        uninstall_copilot_at(temp.path(), ctx).unwrap();
+
+        assert!(hook_path.exists(), "dry-run must not remove hook config");
+    }
+
+    #[test]
+    fn test_copilot_uninstall_nothing_when_absent() {
+        let temp = TempDir::new().unwrap();
+        let removed = uninstall_copilot_at(temp.path(), InitContext::default()).unwrap();
+        assert!(removed.is_empty(), "nothing to remove in a clean project");
     }
 
     #[test]

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -3993,6 +3993,7 @@ fn uninstall_copilot_at(base: &Path, ctx: InitContext) -> Result<Vec<String>> {
                 hook_path.display()
             );
         } else {
+            // nosemgrep: filesystem-deletion -- Copilot uninstall removes only the RTK-managed hook config.
             fs::remove_file(&hook_path)
                 .with_context(|| format!("Failed to remove hook: {}", hook_path.display()))?;
         }
@@ -6442,6 +6443,54 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let removed = uninstall_copilot_at(temp.path(), InitContext::default()).unwrap();
         assert!(removed.is_empty(), "nothing to remove in a clean project");
+    }
+
+    #[test]
+    fn test_copilot_install_does_not_touch_other_hooks() {
+        let temp = TempDir::new().unwrap();
+        let hooks_dir = temp.path().join(".github").join("hooks");
+        fs::create_dir_all(&hooks_dir).unwrap();
+        let other_hook = hooks_dir.join("user-policy.json");
+        let other_content =
+            r#"{"hooks":{"sessionStart":[{"type":"command","command":"echo hi"}]}}"#;
+        fs::write(&other_hook, other_content).unwrap();
+
+        run_copilot_at(temp.path(), InitContext::default()).unwrap();
+
+        assert!(other_hook.exists(), "third-party hook file must remain");
+        assert_eq!(
+            fs::read_to_string(&other_hook).unwrap(),
+            other_content,
+            "third-party hook content must be unchanged by rtk install"
+        );
+    }
+
+    #[test]
+    fn test_copilot_uninstall_does_not_touch_other_hooks() {
+        let temp = TempDir::new().unwrap();
+        run_copilot_at(temp.path(), InitContext::default()).unwrap();
+
+        let hooks_dir = temp.path().join(".github").join("hooks");
+        let other_hook = hooks_dir.join("user-policy.json");
+        let other_content =
+            r#"{"hooks":{"sessionStart":[{"type":"command","command":"echo hi"}]}}"#;
+        fs::write(&other_hook, other_content).unwrap();
+
+        uninstall_copilot_at(temp.path(), InitContext::default()).unwrap();
+
+        assert!(
+            other_hook.exists(),
+            "third-party hook file must survive rtk uninstall"
+        );
+        assert_eq!(
+            fs::read_to_string(&other_hook).unwrap(),
+            other_content,
+            "third-party hook content must be unchanged by rtk uninstall"
+        );
+        assert!(
+            !hooks_dir.join("rtk-rewrite.json").exists(),
+            "rtk's own hook must still be removed"
+        );
     }
 
     #[test]

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -8,8 +8,8 @@ use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 
 use crate::hooks::constants::{
-    CONFIG_DIR, COPILOT_HOOK_FILE, COPILOT_INSTRUCTIONS_FILE, CURSOR_DIR, GEMINI_DIR, GITHUB_DIR,
-    OPENCODE_PLUGIN_FILE, OPENCODE_SUBDIR, PLUGIN_SUBDIR,
+    CONFIG_DIR, COPILOT_HOME_ENV, COPILOT_HOOK_FILE, COPILOT_INSTRUCTIONS_FILE, COPILOT_USER_DIR,
+    CURSOR_DIR, GEMINI_DIR, GITHUB_DIR, OPENCODE_PLUGIN_FILE, OPENCODE_SUBDIR, PLUGIN_SUBDIR,
 };
 
 use super::constants::{
@@ -4028,6 +4028,98 @@ fn uninstall_copilot_at(base: &Path, ctx: InitContext) -> Result<Vec<String>> {
     Ok(removed)
 }
 
+fn copilot_user_dir() -> Result<PathBuf> {
+    if let Ok(custom) = std::env::var(COPILOT_HOME_ENV) {
+        return Ok(PathBuf::from(custom));
+    }
+    let home = dirs::home_dir().context("could not determine home directory")?;
+    Ok(home.join(COPILOT_USER_DIR))
+}
+
+pub fn run_copilot_global(ctx: InitContext) -> Result<()> {
+    let copilot_dir = copilot_user_dir()?;
+    run_copilot_global_at(&copilot_dir, ctx)
+}
+
+fn run_copilot_global_at(copilot_dir: &Path, ctx: InitContext) -> Result<()> {
+    let InitContext { dry_run, .. } = ctx;
+    let hooks_dir = copilot_dir.join(HOOKS_SUBDIR);
+
+    if !dry_run {
+        fs::create_dir_all(&hooks_dir)
+            .with_context(|| format!("Failed to create {} directory", hooks_dir.display()))?;
+    }
+
+    let hook_path = hooks_dir.join(COPILOT_HOOK_FILE);
+    write_if_changed(
+        &hook_path,
+        COPILOT_HOOK_JSON,
+        "Copilot global hook config",
+        ctx,
+    )?;
+
+    if dry_run {
+        print_dry_run_footer();
+    } else {
+        println!("\nGitHub Copilot global integration installed (user-scoped).\n");
+        println!("  Hook config:    {}", hook_path.display());
+        println!("\n  Applies to all Copilot CLI sessions on this machine.");
+        println!("  Restart your Copilot CLI session to activate.\n");
+    }
+
+    Ok(())
+}
+
+pub fn uninstall_copilot_global(ctx: InitContext) -> Result<()> {
+    let copilot_dir = copilot_user_dir()?;
+    let InitContext { dry_run, .. } = ctx;
+    let removed = uninstall_copilot_global_at(&copilot_dir, ctx)?;
+
+    if removed.is_empty() {
+        println!("RTK global Copilot support was not installed (nothing to remove)");
+    } else {
+        let header = if dry_run {
+            "[dry-run] would uninstall RTK (global GitHub Copilot):"
+        } else {
+            "RTK uninstalled (global GitHub Copilot):"
+        };
+        println!("{}", header);
+        for item in &removed {
+            println!("  - {}", item);
+        }
+        if !dry_run {
+            println!("\nRestart your Copilot CLI session to apply changes.");
+        }
+    }
+
+    if dry_run {
+        print_dry_run_footer();
+    }
+    Ok(())
+}
+
+fn uninstall_copilot_global_at(copilot_dir: &Path, ctx: InitContext) -> Result<Vec<String>> {
+    let InitContext { dry_run, .. } = ctx;
+    let hook_path = copilot_dir.join(HOOKS_SUBDIR).join(COPILOT_HOOK_FILE);
+    let mut removed = Vec::new();
+
+    if hook_path.exists() {
+        if dry_run {
+            println!(
+                "[dry-run] would remove hook config: {}",
+                hook_path.display()
+            );
+        } else {
+            // nosemgrep: filesystem-deletion -- Copilot global uninstall removes only the RTK-managed hook config.
+            fs::remove_file(&hook_path)
+                .with_context(|| format!("Failed to remove hook: {}", hook_path.display()))?;
+        }
+        removed.push(format!("Hook config: {}", hook_path.display()));
+    }
+
+    Ok(removed)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -6491,6 +6583,90 @@ mod tests {
             !hooks_dir.join("rtk-rewrite.json").exists(),
             "rtk's own hook must still be removed"
         );
+    }
+
+    #[test]
+    fn test_copilot_global_install_writes_hook() {
+        let temp = TempDir::new().unwrap();
+        run_copilot_global_at(temp.path(), InitContext::default()).unwrap();
+
+        let hook_path = temp.path().join("hooks").join("rtk-rewrite.json");
+        assert!(hook_path.exists());
+        let v: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&hook_path).unwrap()).unwrap();
+        assert_eq!(v["version"], 1);
+        assert_eq!(v["hooks"]["PreToolUse"][0]["command"], "rtk hook copilot");
+        assert_eq!(v["hooks"]["preToolUse"][0]["bash"], "rtk hook copilot");
+    }
+
+    #[test]
+    fn test_copilot_global_install_does_not_write_instructions() {
+        let temp = TempDir::new().unwrap();
+        run_copilot_global_at(temp.path(), InitContext::default()).unwrap();
+        assert!(
+            !temp.path().join(COPILOT_INSTRUCTIONS_FILE).exists(),
+            "global install must not create a user-level instructions file (undocumented path)"
+        );
+    }
+
+    #[test]
+    fn test_copilot_global_uninstall_removes_hook() {
+        let temp = TempDir::new().unwrap();
+        run_copilot_global_at(temp.path(), InitContext::default()).unwrap();
+        let hook_path = temp.path().join("hooks").join("rtk-rewrite.json");
+        assert!(hook_path.exists());
+
+        let removed = uninstall_copilot_global_at(temp.path(), InitContext::default()).unwrap();
+        assert!(!removed.is_empty());
+        assert!(!hook_path.exists());
+    }
+
+    #[test]
+    fn test_copilot_global_uninstall_nothing_when_absent() {
+        let temp = TempDir::new().unwrap();
+        let removed = uninstall_copilot_global_at(temp.path(), InitContext::default()).unwrap();
+        assert!(removed.is_empty());
+    }
+
+    #[test]
+    fn test_copilot_global_install_does_not_touch_other_hooks() {
+        let temp = TempDir::new().unwrap();
+        let hooks_dir = temp.path().join("hooks");
+        fs::create_dir_all(&hooks_dir).unwrap();
+        let other = hooks_dir.join("notification-hooks.json");
+        let payload = r#"{"version":1,"hooks":{"agentStop":[{"type":"command","bash":"true"}]}}"#;
+        fs::write(&other, payload).unwrap();
+
+        run_copilot_global_at(temp.path(), InitContext::default()).unwrap();
+
+        assert_eq!(fs::read_to_string(&other).unwrap(), payload);
+    }
+
+    #[test]
+    fn test_copilot_global_uninstall_does_not_touch_other_hooks() {
+        let temp = TempDir::new().unwrap();
+        run_copilot_global_at(temp.path(), InitContext::default()).unwrap();
+        let hooks_dir = temp.path().join("hooks");
+        let other = hooks_dir.join("notification-hooks.json");
+        let payload = r#"{"version":1,"hooks":{"agentStop":[{"type":"command","bash":"true"}]}}"#;
+        fs::write(&other, payload).unwrap();
+
+        uninstall_copilot_global_at(temp.path(), InitContext::default()).unwrap();
+
+        assert!(other.exists());
+        assert_eq!(fs::read_to_string(&other).unwrap(), payload);
+        assert!(!hooks_dir.join("rtk-rewrite.json").exists());
+    }
+
+    #[test]
+    fn test_copilot_global_install_dry_run_writes_nothing() {
+        let temp = TempDir::new().unwrap();
+        let ctx = InitContext {
+            verbose: 0,
+            dry_run: true,
+        };
+        run_copilot_global_at(temp.path(), ctx).unwrap();
+        assert!(!temp.path().join("hooks").join("rtk-rewrite.json").exists());
     }
 
     #[test]

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -8,7 +8,8 @@ use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 
 use crate::hooks::constants::{
-    CONFIG_DIR, CURSOR_DIR, GEMINI_DIR, OPENCODE_PLUGIN_FILE, OPENCODE_SUBDIR, PLUGIN_SUBDIR,
+    CONFIG_DIR, COPILOT_HOOK_FILE, COPILOT_INSTRUCTIONS_FILE, CURSOR_DIR, GEMINI_DIR, GITHUB_DIR,
+    OPENCODE_PLUGIN_FILE, OPENCODE_SUBDIR, PLUGIN_SUBDIR,
 };
 
 use super::constants::{
@@ -3845,7 +3846,9 @@ fn uninstall_gemini(ctx: InitContext) -> Result<Vec<String>> {
 
 // ── Copilot integration ─────────────────────────────────────
 
+// PreToolUse = VS Code schema, preToolUse = Copilot CLI schema (same file, both hosts).
 const COPILOT_HOOK_JSON: &str = r#"{
+  "version": 1,
   "hooks": {
     "PreToolUse": [
       {
@@ -3853,6 +3856,15 @@ const COPILOT_HOOK_JSON: &str = r#"{
         "command": "rtk hook copilot",
         "cwd": ".",
         "timeout": 5
+      }
+    ],
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "rtk hook copilot",
+        "powershell": "rtk hook copilot",
+        "cwd": ".",
+        "timeoutSec": 5
       }
     ]
   }
@@ -3901,8 +3913,8 @@ pub fn run_copilot(ctx: InitContext) -> Result<()> {
 /// `cargo test`'s default parallel execution).
 fn run_copilot_at(base: &Path, ctx: InitContext) -> Result<()> {
     let InitContext { dry_run, .. } = ctx;
-    let github_dir = base.join(".github");
-    let hooks_dir = github_dir.join("hooks");
+    let github_dir = base.join(GITHUB_DIR);
+    let hooks_dir = github_dir.join(HOOKS_SUBDIR);
 
     if !dry_run {
         fs::create_dir_all(&hooks_dir)
@@ -3912,7 +3924,7 @@ fn run_copilot_at(base: &Path, ctx: InitContext) -> Result<()> {
     // 1. Upsert RTK marker block in copilot-instructions.md (preserves user content).
     //    Done BEFORE writing the hook config so a malformed file aborts the install
     //    without leaving a stale hook on disk.
-    let instructions_path = github_dir.join("copilot-instructions.md");
+    let instructions_path = github_dir.join(COPILOT_INSTRUCTIONS_FILE);
     write_rtk_block(
         &instructions_path,
         COPILOT_INSTRUCTIONS,
@@ -3922,7 +3934,7 @@ fn run_copilot_at(base: &Path, ctx: InitContext) -> Result<()> {
     )?;
 
     // 2. Write hook config (only reached if the upsert above succeeded).
-    let hook_path = hooks_dir.join("rtk-rewrite.json");
+    let hook_path = hooks_dir.join(COPILOT_HOOK_FILE);
     write_if_changed(&hook_path, COPILOT_HOOK_JSON, "Copilot hook config", ctx)?;
 
     if dry_run {
@@ -6252,6 +6264,42 @@ mod tests {
         assert!(content.contains(RTK_BLOCK_START));
         assert!(content.contains(RTK_BLOCK_END));
         assert!(content.contains("rtk cargo test"));
+    }
+
+    #[test]
+    fn test_copilot_hook_json_serves_both_vscode_and_cli_schemas() {
+        let v: serde_json::Value = serde_json::from_str(COPILOT_HOOK_JSON).unwrap();
+
+        let vscode = &v["hooks"]["PreToolUse"][0];
+        assert_eq!(vscode["command"], "rtk hook copilot");
+        assert!(vscode["timeout"].is_number(), "VS Code uses `timeout`");
+
+        assert_eq!(v["version"], 1, "Copilot CLI requires top-level version");
+        let cli = &v["hooks"]["preToolUse"][0];
+        assert_eq!(cli["bash"], "rtk hook copilot");
+        assert_eq!(cli["powershell"], "rtk hook copilot");
+        assert!(
+            cli["timeoutSec"].is_number(),
+            "Copilot CLI uses `timeoutSec`"
+        );
+    }
+
+    #[test]
+    fn test_copilot_init_writes_dual_schema_to_disk() {
+        let temp = TempDir::new().unwrap();
+        run_copilot_at(temp.path(), InitContext::default()).unwrap();
+
+        let hook_path = temp
+            .path()
+            .join(".github")
+            .join("hooks")
+            .join("rtk-rewrite.json");
+        let v: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&hook_path).unwrap()).unwrap();
+
+        assert_eq!(v["hooks"]["PreToolUse"][0]["command"], "rtk hook copilot");
+        assert_eq!(v["version"], 1);
+        assert_eq!(v["hooks"]["preToolUse"][0]["bash"], "rtk hook copilot");
     }
 
     #[test]

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -6639,7 +6639,10 @@ mod tests {
         let temp = TempDir::new().unwrap();
         run_copilot_global_at(temp.path(), InitContext::default()).unwrap();
         let instructions = temp.path().join(COPILOT_INSTRUCTIONS_FILE);
-        assert!(instructions.exists(), "user-level instructions must be written");
+        assert!(
+            instructions.exists(),
+            "user-level instructions must be written"
+        );
         let content = fs::read_to_string(&instructions).unwrap();
         assert!(content.contains(RTK_BLOCK_START));
         assert!(content.contains("rtk cargo test"));
@@ -6654,7 +6657,10 @@ mod tests {
         run_copilot_global_at(temp.path(), InitContext::default()).unwrap();
 
         let content = fs::read_to_string(&instructions).unwrap();
-        assert!(content.contains("Always use pnpm."), "user content must be preserved");
+        assert!(
+            content.contains("Always use pnpm."),
+            "user content must be preserved"
+        );
         assert!(content.contains(RTK_BLOCK_START));
     }
 

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -4050,6 +4050,15 @@ fn run_copilot_global_at(copilot_dir: &Path, ctx: InitContext) -> Result<()> {
             .with_context(|| format!("Failed to create {} directory", hooks_dir.display()))?;
     }
 
+    let instructions_path = copilot_dir.join(COPILOT_INSTRUCTIONS_FILE);
+    write_rtk_block(
+        &instructions_path,
+        COPILOT_INSTRUCTIONS,
+        "Copilot user-level instructions",
+        "rtk init --global --copilot",
+        ctx,
+    )?;
+
     let hook_path = hooks_dir.join(COPILOT_HOOK_FILE);
     write_if_changed(
         &hook_path,
@@ -4063,6 +4072,7 @@ fn run_copilot_global_at(copilot_dir: &Path, ctx: InitContext) -> Result<()> {
     } else {
         println!("\nGitHub Copilot global integration installed (user-scoped).\n");
         println!("  Hook config:    {}", hook_path.display());
+        println!("  Instructions:   {}", instructions_path.display());
         println!("\n  Applies to all Copilot CLI sessions on this machine.");
         println!("  Restart your Copilot CLI session to activate.\n");
     }
@@ -4115,6 +4125,31 @@ fn uninstall_copilot_global_at(copilot_dir: &Path, ctx: InitContext) -> Result<V
                 .with_context(|| format!("Failed to remove hook: {}", hook_path.display()))?;
         }
         removed.push(format!("Hook config: {}", hook_path.display()));
+    }
+
+    let instructions_path = copilot_dir.join(COPILOT_INSTRUCTIONS_FILE);
+    if instructions_path.exists() {
+        let content = fs::read_to_string(&instructions_path)
+            .with_context(|| format!("Failed to read {}", instructions_path.display()))?;
+        if content.contains(RTK_BLOCK_START) {
+            let (cleaned, did_remove) = remove_rtk_block(&content);
+            if did_remove {
+                if dry_run {
+                    println!(
+                        "[dry-run] would remove rtk-instructions block from {}",
+                        instructions_path.display()
+                    );
+                } else {
+                    atomic_write(&instructions_path, &cleaned).with_context(|| {
+                        format!("Failed to write {}", instructions_path.display())
+                    })?;
+                }
+                removed.push(format!(
+                    "{}: removed rtk-instructions block",
+                    COPILOT_INSTRUCTIONS_FILE
+                ));
+            }
+        }
     }
 
     Ok(removed)
@@ -6600,13 +6635,41 @@ mod tests {
     }
 
     #[test]
-    fn test_copilot_global_install_does_not_write_instructions() {
+    fn test_copilot_global_install_writes_instructions() {
         let temp = TempDir::new().unwrap();
         run_copilot_global_at(temp.path(), InitContext::default()).unwrap();
-        assert!(
-            !temp.path().join(COPILOT_INSTRUCTIONS_FILE).exists(),
-            "global install must not create a user-level instructions file (undocumented path)"
-        );
+        let instructions = temp.path().join(COPILOT_INSTRUCTIONS_FILE);
+        assert!(instructions.exists(), "user-level instructions must be written");
+        let content = fs::read_to_string(&instructions).unwrap();
+        assert!(content.contains(RTK_BLOCK_START));
+        assert!(content.contains("rtk cargo test"));
+    }
+
+    #[test]
+    fn test_copilot_global_install_preserves_existing_user_instructions() {
+        let temp = TempDir::new().unwrap();
+        let instructions = temp.path().join(COPILOT_INSTRUCTIONS_FILE);
+        fs::write(&instructions, "# My rules\n\nAlways use pnpm.\n").unwrap();
+
+        run_copilot_global_at(temp.path(), InitContext::default()).unwrap();
+
+        let content = fs::read_to_string(&instructions).unwrap();
+        assert!(content.contains("Always use pnpm."), "user content must be preserved");
+        assert!(content.contains(RTK_BLOCK_START));
+    }
+
+    #[test]
+    fn test_copilot_global_uninstall_preserves_user_instructions() {
+        let temp = TempDir::new().unwrap();
+        let instructions = temp.path().join(COPILOT_INSTRUCTIONS_FILE);
+        fs::write(&instructions, "# My rules\n\nAlways use pnpm.\n").unwrap();
+
+        run_copilot_global_at(temp.path(), InitContext::default()).unwrap();
+        uninstall_copilot_global_at(temp.path(), InitContext::default()).unwrap();
+
+        let content = fs::read_to_string(&instructions).unwrap();
+        assert!(content.contains("Always use pnpm."));
+        assert!(!content.contains(RTK_BLOCK_START), "RTK block removed");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1821,6 +1821,8 @@ fn run_cli() -> Result<i32> {
             };
             if show {
                 hooks::init::show_config(codex)?;
+            } else if uninstall && copilot {
+                hooks::init::uninstall_copilot(ctx)?;
             } else if uninstall {
                 uninstall_init_dispatch(
                     agent,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1822,7 +1822,11 @@ fn run_cli() -> Result<i32> {
             if show {
                 hooks::init::show_config(codex)?;
             } else if uninstall && copilot {
-                hooks::init::uninstall_copilot(ctx)?;
+                if global {
+                    hooks::init::uninstall_copilot_global(ctx)?;
+                } else {
+                    hooks::init::uninstall_copilot(ctx)?;
+                }
             } else if uninstall {
                 uninstall_init_dispatch(
                     agent,
@@ -1843,7 +1847,11 @@ fn run_cli() -> Result<i32> {
                 };
                 hooks::init::run_gemini(global, hook_only, patch_mode, ctx)?;
             } else if copilot {
-                hooks::init::run_copilot(ctx)?;
+                if global {
+                    hooks::init::run_copilot_global(ctx)?;
+                } else {
+                    hooks::init::run_copilot(ctx)?;
+                }
             } else if agent == Some(AgentTarget::Pi) {
                 hooks::init::run_pi_mode(global, ctx)?
             } else if agent == Some(AgentTarget::Kilocode) {


### PR DESCRIPTION
Related to https://github.com/rtk-ai/rtk/issues/307

## Changes

- **fix(hook)**: emit Copilot CLI-compatible config (dual VS Code + CLI schemas in one `.github/hooks/rtk-rewrite.json`) so Copilot CLI's hook actually fires.
- **fix(hook)**: strip leading UTF-8 BOM in `run_copilot` for Windows hosts.
- **feat(hook)**: `rtk init --uninstall --copilot` — dedicated entry point routed like Hermes; no new arg added to `uninstall()`.
- **feat(hook)**: `telemetry::detect_hook_type` recognizes the project-scoped Copilot hook.
- **feat(hook)**: `discover` agent status reports `copilot_hook_installed` + "tracked via `rtk gain`" note (parity with Cursor).
- **fix(hook)**: semgrep marker on the new `fs::remove_file` (matches existing uninstall paths) + regression tests that install/uninstall touch only RTK's own files.

## Tests

- [x] `cargo fmt --all --check && cargo clippy --all-targets && cargo test --all` — **1957 passed**, 6 ignored
- [x] Real install → uninstall round-trip with the rebuilt binary; user content in `copilot-instructions.md` preserved
- [x] Install and uninstall leave other `.github/hooks/*.json` files untouched (regression tests)
- [x] Simulated host payloads via stdin: VS Code → transparent rewrite, Copilot CLI → deny-with-suggestion
- [x] BOM-prefixed payloads (one and two BOMs) parse after stripping
- [x] Tested in windows and WSL with copilot CLI (basic rewrite + permissions ask) 
