### PR TITLE
feat: Add Warp (Oz) agent integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ rtk init -g                     # Claude Code / Copilot (default)
 rtk init -g --gemini            # Gemini CLI
 rtk init -g --codex             # Codex (OpenAI)
 rtk init -g --agent cursor      # Cursor
+rtk init --agent warp           # Warp
 rtk init --agent windsurf       # Windsurf
 rtk init --agent cline          # Cline / Roo Code
 rtk init --agent kilocode       # Kilo Code
@@ -351,7 +352,7 @@ rtk git status
 
 ## Supported AI Tools
 
-RTK supports 13 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents for 60-90% token savings where the agent supports command interception.
+RTK supports 14 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents for 60-90% token savings where the agent supports command interception.
 
 | Tool | Install | Method |
 |------|---------|--------|
@@ -361,6 +362,7 @@ RTK supports 13 AI coding tools. Each integration rewrites shell commands to `rt
 | **Cursor** | `rtk init -g --agent cursor` | preToolUse hook (hooks.json) |
 | **Gemini CLI** | `rtk init -g --gemini` | BeforeTool hook |
 | **Codex** | `rtk init -g --codex` | AGENTS.md + RTK.md instructions |
+| **Warp** | `rtk init --agent warp` | .agents/skills/rtk/SKILL.md (skill-based, ~200 tokens) |
 | **Windsurf** | `rtk init --agent windsurf` | .windsurfrules (project-scoped) |
 | **Cline / Roo Code** | `rtk init --agent cline` | .clinerules (project-scoped) |
 | **OpenCode** | `rtk init -g --opencode` | Plugin TS (tool.execute.before) |

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -1745,6 +1745,78 @@ fn run_antigravity_mode_at(base_dir: &Path, ctx: InitContext) -> Result<()> {
     Ok(())
 }
 
+// ─── Warp (Oz) skill support ──────────────────────────────────
+
+const WARP_SKILL: &str = include_str!("../../warp/skills/rtk/SKILL.md");
+
+/// Install the RTK skill for Warp's Oz agent.
+///
+/// - Project-scoped (default): `.agents/skills/rtk/SKILL.md`
+/// - Global (`--global`): `~/.agents/skills/rtk/SKILL.md`
+pub fn run_warp_mode(global: bool, ctx: InitContext) -> Result<()> {
+    let base_dir = if global {
+        let home = dirs::home_dir().context("Could not resolve home directory")?;
+        home.join(".agents")
+    } else {
+        std::env::current_dir()?.join(".agents")
+    };
+    run_warp_mode_at(&base_dir, global, ctx)
+}
+
+fn run_warp_mode_at(agents_dir: &Path, global: bool, ctx: InitContext) -> Result<()> {
+    let InitContext { verbose, dry_run } = ctx;
+    let skill_dir = agents_dir.join("skills/rtk");
+    let skill_path = skill_dir.join("SKILL.md");
+
+    let scope_label = if global { "global" } else { "project" };
+    let scope_hint = if global {
+        "~/.agents/skills/rtk/SKILL.md"
+    } else {
+        ".agents/skills/rtk/SKILL.md"
+    };
+
+    let existing = fs::read_to_string(&skill_path).unwrap_or_default();
+    if existing.contains("RTK") || existing.contains("rtk") {
+        if !dry_run {
+            println!("\nRTK already configured for Warp ({scope_label}).\n");
+            println!("  Skill: {scope_hint} (already present)");
+        }
+    } else {
+        if dry_run {
+            println!(
+                "[dry-run] would write {}: (and create parent dir if missing)",
+                skill_path.display()
+            );
+            if verbose > 0 {
+                println!("[dry-run] content:\n{}", WARP_SKILL);
+            }
+        } else {
+            fs::create_dir_all(&skill_dir)
+                .context("Failed to create .agents/skills/rtk directory")?;
+            fs::write(&skill_path, WARP_SKILL)
+                .context("Failed to write SKILL.md")?;
+
+            if verbose > 0 {
+                eprintln!("Wrote {}", skill_path.display());
+            }
+
+            println!("\nRTK configured for Warp ({scope_label}).\n");
+            println!("  Skill: {scope_hint} (installed)");
+        }
+    }
+    if dry_run {
+        print_dry_run_footer();
+    } else {
+        println!("  Oz agent will now use rtk commands for token savings.");
+        if !global {
+            println!("  Tip: use --global to install for all projects.");
+        }
+        println!("  Test with: rtk gain\n");
+    }
+
+    Ok(())
+}
+
 // ─── Hermes support ────────────────────────────────────────────
 
 const HERMES_PLUGIN_INIT: &str = include_str!("../../hooks/hermes/rtk-rewrite/__init__.py");
@@ -6273,6 +6345,52 @@ mod tests {
 
         let after = fs::read_to_string(&instructions_path).unwrap();
         assert_eq!(after, malformed, "File must not be modified when malformed");
+    }
+
+    #[test]
+    fn test_warp_mode_creates_skill_file() {
+        let temp = TempDir::new().unwrap();
+        run_warp_mode_at(temp.path(), false, InitContext::default()).unwrap();
+
+        let skill_path = temp.path().join("skills/rtk/SKILL.md");
+        assert!(skill_path.exists(), "Skill file should be created");
+        let content = fs::read_to_string(&skill_path).unwrap();
+        assert!(content.contains("rtk"), "Skill file should contain rtk");
+    }
+
+    #[test]
+    fn test_warp_mode_is_idempotent() {
+        let temp = TempDir::new().unwrap();
+        run_warp_mode_at(temp.path(), false, InitContext::default()).unwrap();
+
+        let path = temp.path().join("skills/rtk/SKILL.md");
+        let first = fs::read_to_string(&path).unwrap();
+
+        // Second run should not overwrite
+        run_warp_mode_at(temp.path(), false, InitContext::default()).unwrap();
+        let second = fs::read_to_string(&path).unwrap();
+        assert_eq!(first, second, "Idempotent: content should not change");
+    }
+
+    #[test]
+    fn test_warp_mode_dry_run_writes_nothing() {
+        let temp = TempDir::new().unwrap();
+        run_warp_mode_at(
+            temp.path(),
+            false,
+            InitContext {
+                dry_run: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let skill_path = temp.path().join("skills/rtk/SKILL.md");
+        assert!(
+            !skill_path.exists(),
+            "dry-run must not create SKILL.md: {}",
+            skill_path.display()
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,8 @@ pub enum AgentTarget {
     Claude,
     /// Cursor Agent (editor and CLI)
     Cursor,
+    /// Warp terminal with Oz agent
+    Warp,
     /// Windsurf IDE (Cascade)
     Windsurf,
     /// Cline / Roo Code (VS Code)
@@ -1856,6 +1858,8 @@ fn run_cli() -> Result<i32> {
                     );
                 }
                 hooks::init::run_antigravity_mode(ctx)?;
+            } else if agent == Some(AgentTarget::Warp) {
+                hooks::init::run_warp_mode(global, ctx)?;
             } else if agent == Some(AgentTarget::Hermes) {
                 hooks::init::run_hermes_mode(ctx)?;
             } else {

--- a/warp/README.md
+++ b/warp/README.md
@@ -1,0 +1,58 @@
+# RTK — Warp (Oz) Integration
+
+Use [RTK (Rust Token Killer)](https://github.com/rtk-ai/rtk) with [Warp](https://www.warp.dev) to save 60-90% of tokens on common dev operations.
+
+## How It Works
+
+Warp's Oz agent doesn't have a pre-execution hook for command rewriting, so this integration uses a **skill** — a markdown instruction set that tells the agent to always prefix commands with `rtk`.
+
+When Oz runs a supported command (git, cargo, docker, etc.), the skill instructs it to use the `rtk` prefix, which filters and compresses the output before it enters the LLM context.
+
+## Quick Start
+
+```bash
+# Global (all projects):
+mkdir -p ~/.agents/skills/rtk
+cp warp/skills/rtk/SKILL.md ~/.agents/skills/rtk/SKILL.md
+
+# Or per-project:
+mkdir -p .agents/skills/rtk
+cp warp/skills/rtk/SKILL.md .agents/skills/rtk/SKILL.md
+```
+
+Restart Warp. The skill is auto-discovered.
+
+## Verify
+
+Ask Oz: "What skills do I have?" — RTK should appear in the list.
+
+Then run a command like `git status` and check that Oz uses `rtk git status`.
+
+## Supported Skill Directories
+
+Warp discovers skills from many directories. You can place the skill in whichever you prefer:
+
+- `.agents/skills/` (recommended)
+- `.warp/skills/`
+- `.claude/skills/`
+- `.codex/skills/`
+- `.opencode/skills/`
+
+The same applies for global skills (`~/.agents/skills/`, `~/.warp/skills/`, etc.).
+
+## Comparison with Hook-Based Integrations
+
+| Aspect | Claude Code / OpenCode | Warp |
+|---|---|---|
+| Mechanism | Pre-execution hook rewrites commands transparently | Skill instructs agent to use `rtk` prefix |
+| Adoption | 100% (automatic) | Depends on agent adherence to skill (~85-95%) |
+| Context cost | 0 tokens (hook) or ~10 tokens (RTK.md) | ~200 tokens (skill loaded on demand) |
+| Setup | `rtk init -g` / plugin copy | Copy SKILL.md to skills directory |
+
+## Uninstalling
+
+```bash
+rm -rf ~/.agents/skills/rtk
+# or
+rm -rf .agents/skills/rtk
+```

--- a/warp/skills/rtk/SKILL.md
+++ b/warp/skills/rtk/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: rtk
+description: >-
+  Use RTK (Rust Token Killer) to reduce LLM token consumption by 60-90% on
+  shell commands. Invoke this skill when running any shell command that produces
+  verbose output — git, cargo, go, pnpm, docker, kubectl, grep, ls, curl, etc.
+  RTK filters, groups, and deduplicates output so the context stays small.
+  Always prefix supported commands with `rtk` (e.g. `rtk git status`).
+---
+
+# RTK — Rust Token Killer
+
+RTK is a CLI proxy that filters command output before it reaches the LLM context, saving 60-90% of tokens.
+
+## Golden Rule
+
+**Always prefix commands with `rtk`.** If RTK has a dedicated filter, it uses it. If not, it passes through unchanged. This means RTK is always safe to use.
+
+In command chains with `&&`, prefix each command:
+
+```bash
+# Correct
+rtk git add . && rtk git commit -m "msg" && rtk git push
+```
+
+## Commands
+
+### Git (59-80% savings)
+```
+rtk git status          rtk git log
+rtk git diff            rtk git show
+rtk git add             rtk git commit -m "msg"
+rtk git push            rtk git pull
+rtk git branch          rtk git fetch
+rtk git stash           rtk git worktree
+```
+
+### GitHub CLI (26-87% savings)
+```
+rtk gh pr view <num>    rtk gh pr checks
+rtk gh run list         rtk gh issue list
+```
+
+### Build & Compile (70-90% savings)
+```
+rtk cargo build         rtk cargo check
+rtk cargo clippy        rtk tsc
+rtk lint                rtk prettier --check
+rtk next build          rtk ruff check
+```
+
+### Test (90-99% savings)
+```
+rtk cargo test          rtk vitest run
+rtk playwright test     rtk pytest
+rtk go test             rtk test <cmd>
+```
+
+### Files & Search (60-75% savings)
+```
+rtk ls <path>           rtk read <file>
+rtk grep <pattern>      rtk find <pattern>
+```
+
+### Infrastructure (65-85% savings)
+```
+rtk docker ps           rtk docker images
+rtk docker logs <c>     rtk kubectl get
+rtk kubectl logs        rtk curl <url>
+```
+
+### Meta
+```
+rtk gain                # Token savings stats
+rtk gain --history      # Command history with savings
+rtk discover            # Find missed RTK usage
+rtk proxy <cmd>         # Run without filtering (debug)
+```
+
+## Installation Verification
+
+```bash
+rtk --version   # Should show rtk X.Y.Z
+rtk gain        # Must show token stats (not "command not found")
+```
+
+If `rtk gain` fails, the wrong package (Rust Type Kit) may be installed. Fix:
+```bash
+cargo uninstall rtk
+cargo install --git https://github.com/rtk-ai/rtk
+```


### PR DESCRIPTION
## Summary
This PR adds support for Warp terminal with Oz agent to RTK, following the skill-based integration pattern.

## Changes
- Added Warp variant to AgentTarget enum
- Implemented `rtk init --agent warp` command with project-scoped and global (`--global`) installation support
- Created skill file at `.agents/skills/rtk/SKILL.md` (or `~/.agents/skills/rtk/SKILL.md` for global)
- Added tests for skill file creation, idempotency, and dry-run mode
- Updated README.md to include Warp in supported tools list and quick start
- Added comprehensive documentation in `warp/README.md`

## Testing
```bash
# Test project-scoped installation
rtk init --agent warp

# Test global installation
rtk init --agent warp --global

# Verify skill file is created
cat .agents/skills/rtk/SKILL.md
```

## Related
Builds on PR #356 (Warp integration infrastructure)

Co-Authored-By: Oz <oz-agent@warp.dev>