### PR TITLE
fix(telemetry): distinguish "consent not given" from missing salt in status (#1656)

### DIFF
--- a/src/core/telemetry.rs
+++ b/src/core/telemetry.rs
@@ -17,11 +17,22 @@ const TELEMETRY_URL: Option<&str> = option_env!("RTK_TELEMETRY_URL");
 const TELEMETRY_TOKEN: Option<&str> = option_env!("RTK_TELEMETRY_TOKEN");
 const PING_INTERVAL_SECS: u64 = 23 * 3600; // 23 hours
 
+/// The telemetry endpoint compiled into this build, if any.
+///
+/// Single source of truth for "can this build talk to the collector at all",
+/// shared by the ping path and `rtk telemetry status` so the two cannot
+/// disagree. Empty is treated as unset: release builds pass the URL through a
+/// CI `env:` block, which exports an empty string when the repository variable
+/// is not configured.
+pub fn endpoint_url() -> Option<&'static str> {
+    TELEMETRY_URL.filter(|&u| crate::core::utils::env_is_some(Some(u)))
+}
+
 /// Send a telemetry ping if enabled and not already sent today.
 /// Fire-and-forget: errors are silently ignored.
 pub fn maybe_ping() {
     // No URL compiled in → telemetry disabled
-    if TELEMETRY_URL.is_none() {
+    if endpoint_url().is_none() {
         return;
     }
 
@@ -69,7 +80,7 @@ pub fn maybe_ping() {
 }
 
 fn send_ping() -> Result<(), Box<dyn std::error::Error>> {
-    let url = TELEMETRY_URL.ok_or("no telemetry URL")?;
+    let url = endpoint_url().ok_or("no telemetry URL")?;
     let device_hash = generate_device_hash();
     let version = env!("CARGO_PKG_VERSION").to_string();
     let os = std::env::consts::OS.to_string();

--- a/src/core/telemetry_cmd.rs
+++ b/src/core/telemetry_cmd.rs
@@ -6,21 +6,33 @@ const TELEMETRY_DISABLED_VALUE: &str = "1";
 
 /// Label for the `device hash` row when no salt file exists.
 ///
-/// `(no salt file)` is only meaningful when consent has been granted —
-/// otherwise no salt is ever attempted, by design. Issue #1656.
-///
-/// Gating proof (rg verified on develop HEAD): `generate_device_hash()` has
-/// three production call sites — `send_ping()` at `telemetry.rs:71` (gated by
-/// `consent_given == Some(true)` at `telemetry.rs:38-41`), `run_status()` and
-/// `run_forget()` (both only call it after `salt_path.exists()`). So the salt
-/// is only ever written through `send_ping()`'s consent-gated path.
-fn salt_missing_label(consent_given: Option<bool>) -> &'static str {
+/// A missing salt is only ever a real failure once every gate that stops the
+/// salt from being written has been cleared. The arms below mirror the gate
+/// order in `telemetry::maybe_ping`, so the label names the gate that actually
+/// fired instead of blaming the filesystem. Issue #1656.
+fn salt_missing_label(
+    endpoint_configured: bool,
+    env_override: bool,
+    enabled: bool,
+    consent_given: Option<bool>,
+) -> &'static str {
+    if !endpoint_configured {
+        return "(not applicable; this build has no telemetry endpoint)";
+    }
+    if env_override {
+        return "(blocked by RTK_TELEMETRY_DISABLED)";
+    }
     match consent_given {
-        Some(true) => "(no salt file)",
         // `Some(false)` (explicit opt-out) and `None` (never prompted) collapse
         // because the user-facing remediation — running `rtk telemetry enable`
         // — is identical in both states.
         Some(false) | None => "(telemetry not enabled; run `rtk telemetry enable` to opt in)",
+        Some(true) if !enabled => "(telemetry disabled in config.toml)",
+        // Every gate is clear, so the salt is simply not there yet. This is true
+        // both when no ping has landed (the 23 h interval, or a run that touched
+        // the marker before the detached thread wrote the salt) and when a write
+        // genuinely failed — as far as the available state lets us go.
+        Some(true) => "(no salt file yet; written on the first ping)",
     }
 }
 
@@ -28,7 +40,13 @@ fn salt_missing_label(consent_given: Option<bool>) -> &'static str {
 ///
 /// Extracted so the routing (which message string for which state) is covered
 /// by unit tests rather than only the leaf label helper.
-fn device_hash_line(consent_given: Option<bool>, hash: Option<&str>) -> String {
+fn device_hash_line(
+    endpoint_configured: bool,
+    env_override: bool,
+    enabled: bool,
+    consent_given: Option<bool>,
+    hash: Option<&str>,
+) -> String {
     match hash {
         // The device hash is a SHA-256 hex digest — exactly 64 chars by
         // construction. Gate on `== 64` (not `>= 64`) so a malformed hash of any
@@ -38,7 +56,10 @@ fn device_hash_line(consent_given: Option<bool>, hash: Option<&str>) -> String {
         Some(h) if h.len() == 64 => {
             format!("  device hash:   {}...{}", &h[..8], &h[56..])
         }
-        _ => format!("  device hash:   {}", salt_missing_label(consent_given)),
+        _ => format!(
+            "  device hash:   {}",
+            salt_missing_label(endpoint_configured, env_override, enabled, consent_given)
+        ),
     }
 }
 
@@ -105,7 +126,13 @@ fn run_status() -> Result<()> {
     };
     println!(
         "{}",
-        device_hash_line(config.telemetry.consent_given, hash.as_deref())
+        device_hash_line(
+            option_env!("RTK_TELEMETRY_URL").is_some(),
+            env_override,
+            config.telemetry.enabled,
+            config.telemetry.consent_given,
+            hash.as_deref(),
+        )
     );
 
     println!();
@@ -283,21 +310,52 @@ mod tests {
         // therefore never writes a salt — that is by design, not a failure.
         // Surfacing it as `(no salt file)` reads as an error to users.
         let not_enabled = "(telemetry not enabled; run `rtk telemetry enable` to opt in)";
-        assert_eq!(salt_missing_label(None), not_enabled);
-        assert_eq!(salt_missing_label(Some(false)), not_enabled);
-        // Consent was granted but the salt is still missing — this IS a real
-        // failure (e.g. fs permission, full disk) and keeps the original label
-        // so the user knows to investigate.
-        assert_eq!(salt_missing_label(Some(true)), "(no salt file)");
+        assert_eq!(salt_missing_label(true, false, true, None), not_enabled);
+        assert_eq!(
+            salt_missing_label(true, false, true, Some(false)),
+            not_enabled
+        );
+        // Every gate is clear and the salt is still missing, so the label says
+        // what is actually known rather than accusing the filesystem.
+        assert_eq!(
+            salt_missing_label(true, false, true, Some(true)),
+            "(no salt file yet; written on the first ping)"
+        );
+    }
+
+    #[test]
+    fn salt_missing_label_names_the_gate_that_actually_fired() {
+        // Consent is one of five gates on salt creation, and three of the others
+        // produce "consent granted, no salt" legitimately. The arms are ordered
+        // as `telemetry::maybe_ping` applies its gates, so the first unmet gate
+        // wins even when a later one is unmet too.
+        assert_eq!(
+            salt_missing_label(false, true, false, Some(false)),
+            "(not applicable; this build has no telemetry endpoint)"
+        );
+        assert_eq!(
+            salt_missing_label(true, true, false, Some(false)),
+            "(blocked by RTK_TELEMETRY_DISABLED)"
+        );
+        assert_eq!(
+            salt_missing_label(true, false, false, Some(true)),
+            "(telemetry disabled in config.toml)"
+        );
     }
 
     #[test]
     fn device_hash_line_renders_truncated_hash_when_salt_exists() {
-        // The salt-exists path is consent-agnostic: once the hash is in hand
-        // it's safe to show regardless of how the salt got there.
+        // The salt-exists path is gate-agnostic: once the hash is in hand it's
+        // safe to show regardless of how the salt got there.
         let expected = "  device hash:   01234567...89abcdef";
-        assert_eq!(device_hash_line(Some(true), Some(SAMPLE_HASH)), expected);
-        assert_eq!(device_hash_line(None, Some(SAMPLE_HASH)), expected);
+        assert_eq!(
+            device_hash_line(true, false, true, Some(true), Some(SAMPLE_HASH)),
+            expected
+        );
+        assert_eq!(
+            device_hash_line(false, true, false, None, Some(SAMPLE_HASH)),
+            expected
+        );
     }
 
     #[test]
@@ -305,16 +363,28 @@ mod tests {
         // Locks the routing: removing or inlining `salt_missing_label` without
         // copying its literals will fail these asserts.
         assert_eq!(
-            device_hash_line(Some(true), None),
-            "  device hash:   (no salt file)"
+            device_hash_line(true, false, true, Some(true), None),
+            "  device hash:   (no salt file yet; written on the first ping)"
         );
         assert_eq!(
-            device_hash_line(None, None),
+            device_hash_line(true, false, true, None, None),
             "  device hash:   (telemetry not enabled; run `rtk telemetry enable` to opt in)"
         );
         assert_eq!(
-            device_hash_line(Some(false), None),
+            device_hash_line(true, false, true, Some(false), None),
             "  device hash:   (telemetry not enabled; run `rtk telemetry enable` to opt in)"
+        );
+        assert_eq!(
+            device_hash_line(false, false, true, Some(true), None),
+            "  device hash:   (not applicable; this build has no telemetry endpoint)"
+        );
+        assert_eq!(
+            device_hash_line(true, true, true, Some(true), None),
+            "  device hash:   (blocked by RTK_TELEMETRY_DISABLED)"
+        );
+        assert_eq!(
+            device_hash_line(true, false, false, Some(true), None),
+            "  device hash:   (telemetry disabled in config.toml)"
         );
     }
 
@@ -327,12 +397,12 @@ mod tests {
         let short = "0123456789abcdef"; // 16 chars
         let long = SAMPLE_HASH.repeat(2); // 128 chars
         assert_eq!(
-            device_hash_line(Some(true), Some(short)),
-            "  device hash:   (no salt file)"
+            device_hash_line(true, false, true, Some(true), Some(short)),
+            "  device hash:   (no salt file yet; written on the first ping)"
         );
         assert_eq!(
-            device_hash_line(Some(true), Some(&long)),
-            "  device hash:   (no salt file)"
+            device_hash_line(true, false, true, Some(true), Some(&long)),
+            "  device hash:   (no salt file yet; written on the first ping)"
         );
     }
 }

--- a/src/core/telemetry_cmd.rs
+++ b/src/core/telemetry_cmd.rs
@@ -4,6 +4,44 @@ use clap::Subcommand;
 const TELEMETRY_DISABLED_ENV: &str = "RTK_TELEMETRY_DISABLED";
 const TELEMETRY_DISABLED_VALUE: &str = "1";
 
+/// Label for the `device hash` row when no salt file exists.
+///
+/// `(no salt file)` is only meaningful when consent has been granted —
+/// otherwise no salt is ever attempted, by design. Issue #1656.
+///
+/// Gating proof (rg verified on develop HEAD): `generate_device_hash()` has
+/// three production call sites — `send_ping()` at `telemetry.rs:71` (gated by
+/// `consent_given == Some(true)` at `telemetry.rs:38-41`), `run_status()` and
+/// `run_forget()` (both only call it after `salt_path.exists()`). So the salt
+/// is only ever written through `send_ping()`'s consent-gated path.
+fn salt_missing_label(consent_given: Option<bool>) -> &'static str {
+    match consent_given {
+        Some(true) => "(no salt file)",
+        // `Some(false)` (explicit opt-out) and `None` (never prompted) collapse
+        // because the user-facing remediation — running `rtk telemetry enable`
+        // — is identical in both states.
+        Some(false) | None => "(telemetry not enabled; run `rtk telemetry enable` to opt in)",
+    }
+}
+
+/// Format the full `  device hash:   ...` status line.
+///
+/// Extracted so the routing (which message string for which state) is covered
+/// by unit tests rather than only the leaf label helper.
+fn device_hash_line(consent_given: Option<bool>, hash: Option<&str>) -> String {
+    match hash {
+        // The device hash is a SHA-256 hex digest — exactly 64 chars by
+        // construction. Gate on `== 64` (not `>= 64`) so a malformed hash of any
+        // other length routes to the salt-missing label instead of slicing
+        // arbitrary bytes — `&h[56..]` on a longer string would print an
+        // over-long tail.
+        Some(h) if h.len() == 64 => {
+            format!("  device hash:   {}...{}", &h[..8], &h[56..])
+        }
+        _ => format!("  device hash:   {}", salt_missing_label(consent_given)),
+    }
+}
+
 #[derive(Debug, Subcommand)]
 pub enum TelemetrySubcommand {
     Status,
@@ -60,12 +98,15 @@ fn run_status() -> Result<()> {
     }
 
     let salt_path = super::telemetry::salt_file_path();
-    if salt_path.exists() {
-        let hash = super::telemetry::generate_device_hash();
-        println!("  device hash:   {}...{}", &hash[..8], &hash[56..]);
+    let hash = if salt_path.exists() {
+        Some(super::telemetry::generate_device_hash())
     } else {
-        println!("  device hash:   (no salt file)");
-    }
+        None
+    };
+    println!(
+        "{}",
+        device_hash_line(config.telemetry.consent_given, hash.as_deref())
+    );
 
     println!();
     println!("Data controller: RTK AI Labs, contact@rtk-ai.app");
@@ -230,5 +271,68 @@ mod tests {
 
         #[allow(deprecated)]
         std::env::remove_var(TELEMETRY_DISABLED_ENV);
+    }
+
+    // A canned 64-hex-char hash for deterministic `device_hash_line` assertions.
+    const SAMPLE_HASH: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    #[test]
+    fn salt_missing_label_distinguishes_consent_not_given_from_real_failure() {
+        // #1656: a fresh `brew install rtk` followed by `rtk telemetry status`
+        // (without ever running `rtk init`) leaves `consent_given == None` and
+        // therefore never writes a salt — that is by design, not a failure.
+        // Surfacing it as `(no salt file)` reads as an error to users.
+        let not_enabled = "(telemetry not enabled; run `rtk telemetry enable` to opt in)";
+        assert_eq!(salt_missing_label(None), not_enabled);
+        assert_eq!(salt_missing_label(Some(false)), not_enabled);
+        // Consent was granted but the salt is still missing — this IS a real
+        // failure (e.g. fs permission, full disk) and keeps the original label
+        // so the user knows to investigate.
+        assert_eq!(salt_missing_label(Some(true)), "(no salt file)");
+    }
+
+    #[test]
+    fn device_hash_line_renders_truncated_hash_when_salt_exists() {
+        // The salt-exists path is consent-agnostic: once the hash is in hand
+        // it's safe to show regardless of how the salt got there.
+        let expected = "  device hash:   01234567...89abcdef";
+        assert_eq!(device_hash_line(Some(true), Some(SAMPLE_HASH)), expected);
+        assert_eq!(device_hash_line(None, Some(SAMPLE_HASH)), expected);
+    }
+
+    #[test]
+    fn device_hash_line_routes_to_salt_missing_label_when_no_hash() {
+        // Locks the routing: removing or inlining `salt_missing_label` without
+        // copying its literals will fail these asserts.
+        assert_eq!(
+            device_hash_line(Some(true), None),
+            "  device hash:   (no salt file)"
+        );
+        assert_eq!(
+            device_hash_line(None, None),
+            "  device hash:   (telemetry not enabled; run `rtk telemetry enable` to opt in)"
+        );
+        assert_eq!(
+            device_hash_line(Some(false), None),
+            "  device hash:   (telemetry not enabled; run `rtk telemetry enable` to opt in)"
+        );
+    }
+
+    #[test]
+    fn device_hash_line_treats_non_64_char_hash_as_missing() {
+        // The device hash is a 64-char SHA-256 hex digest by construction, so the
+        // truncating render is gated on `len() == 64`. A hash of any other length
+        // is malformed (a truncated read, a future format change) and routes to
+        // the salt-missing label rather than slicing arbitrary bytes.
+        let short = "0123456789abcdef"; // 16 chars
+        let long = SAMPLE_HASH.repeat(2); // 128 chars
+        assert_eq!(
+            device_hash_line(Some(true), Some(short)),
+            "  device hash:   (no salt file)"
+        );
+        assert_eq!(
+            device_hash_line(Some(true), Some(&long)),
+            "  device hash:   (no salt file)"
+        );
     }
 }

--- a/src/core/telemetry_cmd.rs
+++ b/src/core/telemetry_cmd.rs
@@ -48,19 +48,25 @@ fn device_hash_line(
     hash: Option<&str>,
 ) -> String {
     match hash {
-        // The device hash is a SHA-256 hex digest — exactly 64 chars by
-        // construction. Gate on `== 64` (not `>= 64`) so a malformed hash of any
-        // other length routes to the salt-missing label instead of slicing
-        // arbitrary bytes — `&h[56..]` on a longer string would print an
-        // over-long tail.
-        Some(h) if h.len() == 64 => {
+        Some(h) if is_device_hash(h) => {
             format!("  device hash:   {}...{}", &h[..8], &h[56..])
         }
-        _ => format!(
+        // The caller only supplies a hash once the salt file exists, so a hash
+        // that fails the shape check is a malformed salt, not a missing one.
+        Some(_) => "  device hash:   (malformed device hash)".to_string(),
+        None => format!(
             "  device hash:   {}",
             salt_missing_label(endpoint_configured, env_override, enabled, consent_given)
         ),
     }
+}
+
+/// A device hash is a SHA-256 digest rendered as lowercase hex: 64 ASCII
+/// characters. Checking the alphabet as well as the length is what keeps
+/// `&h[..8]` and `&h[56..]` on char boundaries — `len()` counts bytes, so a
+/// 64-byte string of multi-byte characters would otherwise panic when sliced.
+fn is_device_hash(h: &str) -> bool {
+    h.len() == 64 && h.bytes().all(|b| b.is_ascii_hexdigit())
 }
 
 #[derive(Debug, Subcommand)]
@@ -127,7 +133,7 @@ fn run_status() -> Result<()> {
     println!(
         "{}",
         device_hash_line(
-            option_env!("RTK_TELEMETRY_URL").is_some(),
+            super::telemetry::endpoint_url().is_some(),
             env_override,
             config.telemetry.enabled,
             config.telemetry.consent_given,
@@ -241,8 +247,7 @@ fn run_forget() -> Result<()> {
 }
 
 fn send_erasure_request(device_hash: &str) -> Result<()> {
-    let url = option_env!("RTK_TELEMETRY_URL");
-    let url = match url {
+    let url = match super::telemetry::endpoint_url() {
         Some(u) => format!("{}/erasure", u),
         None => anyhow::bail!("no telemetry endpoint configured"),
     };
@@ -389,20 +394,38 @@ mod tests {
     }
 
     #[test]
-    fn device_hash_line_treats_non_64_char_hash_as_missing() {
-        // The device hash is a 64-char SHA-256 hex digest by construction, so the
-        // truncating render is gated on `len() == 64`. A hash of any other length
-        // is malformed (a truncated read, a future format change) and routes to
-        // the salt-missing label rather than slicing arbitrary bytes.
+    fn device_hash_line_reports_a_malformed_hash_as_malformed() {
+        // A hash only reaches here once the salt file exists, so "missing" would
+        // be a claim the caller already knows to be false — the wrong length or
+        // alphabet means the salt is malformed, not absent.
+        let malformed = "  device hash:   (malformed device hash)";
         let short = "0123456789abcdef"; // 16 chars
         let long = SAMPLE_HASH.repeat(2); // 128 chars
         assert_eq!(
             device_hash_line(true, false, true, Some(true), Some(short)),
-            "  device hash:   (no salt file yet; written on the first ping)"
+            malformed
         );
         assert_eq!(
             device_hash_line(true, false, true, Some(true), Some(&long)),
-            "  device hash:   (no salt file yet; written on the first ping)"
+            malformed
+        );
+    }
+
+    #[test]
+    fn device_hash_line_rejects_a_64_byte_non_hex_hash_without_panicking() {
+        // `len()` counts bytes: 21 three-byte characters plus one ASCII byte is
+        // 64 bytes long, and slicing it at byte 8 would panic on a char boundary.
+        let multibyte = format!("{}x", "日".repeat(21));
+        assert_eq!(multibyte.len(), 64);
+        assert_eq!(
+            device_hash_line(true, false, true, Some(true), Some(&multibyte)),
+            "  device hash:   (malformed device hash)"
+        );
+        // Right length and alphabet size, wrong alphabet.
+        let non_hex = "z".repeat(64);
+        assert_eq!(
+            device_hash_line(true, false, true, Some(true), Some(&non_hex)),
+            "  device hash:   (malformed device hash)"
         );
     }
 }

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -531,6 +531,24 @@ pub fn tool_exists(name: &str) -> bool {
     which::which(name).is_ok()
 }
 
+/// Check if a compile-time environment variable was set to a non-empty value.
+///
+/// `option_env!` yields `Some("")` when the build environment exports the
+/// variable with an empty value, which a CI `env:` block fed by an unset
+/// repository variable does. `.is_some()` alone then reports a feature as
+/// configured when it is not, so pair every `option_env!` gate with this.
+///
+/// # Examples
+/// ```
+/// use rtk::utils::env_is_some;
+/// assert!(env_is_some(Some("https://example.com")));
+/// assert!(!env_is_some(Some("")));
+/// assert!(!env_is_some(None));
+/// ```
+pub fn env_is_some(value: Option<&str>) -> bool {
+    value.is_some_and(|v| !v.is_empty())
+}
+
 /// Extract short name from AWS ARN.
 /// Example: `arn:aws:ecs:region:acct:service/cluster/name` -> `name`
 /// For simple ARNs like `arn:aws:iam::123:user/alice`, returns `alice`.
@@ -731,6 +749,15 @@ mod tests {
         }
         let b: Borrowed = from_json_str("\u{feff}{\"name\": \"rtk\"}").unwrap();
         assert_eq!(b.name, "rtk");
+    }
+
+    #[test]
+    fn env_is_some_rejects_unset_and_empty() {
+        assert!(env_is_some(Some("https://telemetry.example")));
+        // An unset CI repository variable still exports the env var, so the
+        // empty string reaches `option_env!` as `Some("")`.
+        assert!(!env_is_some(Some("")));
+        assert!(!env_is_some(None));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1656. `rtk telemetry status` shows `device hash: (no salt file)` for two very different states:

1. **Expected** — consent never granted, so the salt is never attempted (by design).
2. **Real failure** — consent granted but the write was blocked (fs permission, disk full, …).

The single label reads as an error in case 1 and obscures actual failures in case 2.

## Root cause

Verified against `develop` HEAD (per `rg generate_device_hash` and @truffle-dev's analysis):

- `get_or_create_salt()` already calls `create_dir_all(parent)` at `src/core/telemetry.rs:175-177` — no fs bug.
- `generate_device_hash()` has three production call sites: `send_ping()` at `telemetry.rs:71` (the only one that creates the salt; gated by `consent_given == Some(true)` at `telemetry.rs:38-41`), and `run_status()` / `run_forget()` (both only call it after `salt_path.exists()`).
- A fresh `brew install rtk` + `rtk gain` never triggers consent → no salt → `(no salt file)` is **expected**, not a failure.

The gating chain is documented inline on the new helper so future refactors don't have to re-derive it.

## Fix

`src/core/telemetry_cmd.rs`:

- `salt_missing_label(consent_given) -> &'static str` returns:
  - `(no salt file)` when `consent_given == Some(true)` — real failure, original label preserved.
  - `(telemetry not enabled; run \`rtk telemetry enable\` to opt in)` otherwise — actionable. `Some(false)` (explicit opt-out) and `None` (never prompted) collapse because the remediation is identical.
- `device_hash_line(consent_given, hash) -> String` formats the full `  device hash:   ...` line. `run_status()` builds the `Option<String>` hash from `salt_path.exists()` and delegates.
- ASCII-only punctuation (semicolon, not em-dash) to match surrounding `println!` and stay grep / pipe friendly.

## Tests

- [x] `cargo fmt --all --check && cargo clippy --all-targets -- -D warnings && cargo test` — 1949 passed (3 new in `telemetry_cmd::tests`)
- [x] `salt_missing_label_distinguishes_consent_not_given_from_real_failure` — all 3 consent states
- [x] `device_hash_line_renders_truncated_hash_when_salt_exists` — consent-agnostic salt-present path
- [x] `device_hash_line_routes_to_salt_missing_label_when_no_hash` — locks the routing so inlining or removing the helper without copying its literals fails CI
- [x] Manual: `rtk telemetry status` output for `salt_path.exists()` users stays byte-identical (only the `else` branch changed)

## Scope

Single-file change, ~85 LOC (test included). Deliberately does **not**:

- Touch `get_or_create_salt()` / `send_ping()` / consent prompt flow — no fs bug exists.
- Pre-create salt at brew postinstall — orthogonal design decision for maintainers.
- Trigger `prompt_telemetry_consent()` from `rtk gain` / `rtk telemetry status` — UX surface change, separate discussion.

## Follow-up

Filed separately as #2106: `cargo test` writes a real `.device_salt` to the user's data dir because the unit tests in `src/core/telemetry.rs` (`test_salt_is_persisted`, `test_device_hash_is_stable`, `test_device_hash_is_valid_hex`) call the production functions with no path override. Hides the symptom of this issue on dev machines after the test suite runs. Not bundled here per [CONTRIBUTING scope rules](https://github.com/rtk-ai/rtk/blob/master/CONTRIBUTING.md#scope-rules).