### PR TITLE
feat(discover): add fnm (Fast Node Manager) filter and hook rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ rtk pip list                    # Python packages (auto-detect uv)
 rtk pip outdated                # Outdated packages
 rtk bundle install              # Ruby gems (strip Using lines)
 rtk prisma generate             # Schema generation (no ASCII art)
+rtk fnm use 20                  # Node version switch (ANSI/progress stripped)
 ```
 
 ### AWS

--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -1627,8 +1627,8 @@ match_command = "^make\\b"
         let filters = make_filters(BUILTIN_TOML);
         assert_eq!(
             filters.len(),
-            63,
-            "Expected exactly 63 built-in filters, got {}. \
+            64,
+            "Expected exactly 64 built-in filters, got {}. \
              Update this count when adding/removing filters in src/filters/.",
             filters.len()
         );
@@ -1685,11 +1685,11 @@ expected = "output line 1\noutput line 2"
         let combined = format!("{}\n\n{}", BUILTIN_TOML, new_filter);
         let filters = make_filters(&combined);
 
-        // All 63 existing filters still present + 1 new = 64
+        // All 64 existing filters still present + 1 new = 65
         assert_eq!(
             filters.len(),
-            64,
-            "Expected 64 filters after concat (63 built-in + 1 new)"
+            65,
+            "Expected 65 filters after concat (64 built-in + 1 new)"
         );
 
         // New filter is discoverable

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -40,6 +40,7 @@ pub fn category_avg_tokens(category: &str, subcmd: &str) -> usize {
         "GitHub" => 200,
         "GitLab" => 200,
         "PackageManager" => 150,
+        "NodeVersionManager" => 40,
         _ => 150,
     }
 }

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -80,6 +80,15 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
+        pattern: r"^fnm\s+(list-remote|use|install|uninstall|list|ls|current|default)(\s|$)",
+        rtk_cmd: "rtk fnm",
+        rewrite_prefixes: &["fnm"],
+        category: "NodeVersionManager",
+        savings_pct: 25.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
+    RtkRule {
         pattern: r"^(cat|head|tail)\s+",
         rtk_cmd: "rtk read",
         rewrite_prefixes: &["cat", "head", "tail"],

--- a/src/filters/fnm.toml
+++ b/src/filters/fnm.toml
@@ -1,0 +1,169 @@
+[filters.fnm]
+description = "Compact fnm (Fast Node Manager) output — strip download/extract progress, keep version lines and errors. Excludes `fnm env` and `fnm exec` so shell evals and wrapped child commands stay untouched."
+match_command = "^fnm\\s+(list-remote|use|install|uninstall|list|ls|current|default)(\\s|$)"
+strip_ansi = true
+filter_stderr = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^Downloading\\s",
+  "^Extracting\\s",
+]
+truncate_lines_at = 200
+max_lines = 50
+on_empty = "fnm: ok"
+
+[[tests.fnm]]
+name = "use success line passes through"
+input = "Using Node v20.20.2"
+expected = "Using Node v20.20.2"
+
+[[tests.fnm]]
+name = "install success line passes through"
+input = "Installing Node v20.20.2 (arm64)"
+expected = "Installing Node v20.20.2 (arm64)"
+
+[[tests.fnm]]
+name = "missing version error preserved verbatim"
+input = "error: Requested version v99.x.x is not currently installed"
+expected = "error: Requested version v99.x.x is not currently installed"
+
+[[tests.fnm]]
+name = "list output preserved"
+input = "* v20.20.2 default\n* v22.22.3\n* system"
+expected = "* v20.20.2 default\n* v22.22.3\n* system"
+
+[[tests.fnm]]
+name = "current output preserved"
+input = "v20.20.2"
+expected = "v20.20.2"
+
+[[tests.fnm]]
+name = "install with download progress strips noise"
+input = "Downloading https://nodejs.org/dist/v22.22.3/node-v22.22.3-darwin-arm64.tar.xz\nExtracting node-v22.22.3-darwin-arm64.tar.xz\nInstalling Node v22.22.3 (arm64)"
+expected = "Installing Node v22.22.3 (arm64)"
+
+[[tests.fnm]]
+name = "empty after stripping falls back to on_empty"
+input = "\nDownloading foo\nExtracting foo\n"
+expected = "fnm: ok"
+
+[[tests.fnm]]
+name = "uninstall error preserved"
+input = "error: Can't find a matching version"
+expected = "error: Can't find a matching version"
+
+[[tests.fnm]]
+name = "list-remote truncates at max_lines with recovery hint"
+input = """v0.1.14
+v0.1.15
+v0.1.16
+v0.1.17
+v0.1.18
+v0.1.19
+v0.1.20
+v0.1.21
+v0.1.22
+v0.1.23
+v0.1.24
+v0.1.25
+v0.1.26
+v0.1.27
+v0.1.28
+v0.1.29
+v0.1.30
+v0.1.31
+v0.1.32
+v0.1.33
+v0.1.100
+v0.10.0
+v0.10.1
+v0.10.2
+v0.10.3
+v0.10.4
+v0.10.5
+v0.10.6
+v0.10.7
+v0.10.8
+v0.10.9
+v0.10.10
+v0.10.11
+v0.10.12
+v0.10.13
+v0.10.14
+v0.10.15
+v0.10.16
+v0.10.17
+v0.10.18
+v0.10.19
+v0.10.20
+v0.10.21
+v0.10.22
+v0.10.23
+v0.10.24
+v0.10.25
+v0.10.26
+v0.10.27
+v0.10.28
+v0.10.29
+v0.10.30
+v0.10.31
+v0.10.32
+v0.10.33
+v0.10.34"""
+expected = """v0.1.14
+v0.1.15
+v0.1.16
+v0.1.17
+v0.1.18
+v0.1.19
+v0.1.20
+v0.1.21
+v0.1.22
+v0.1.23
+v0.1.24
+v0.1.25
+v0.1.26
+v0.1.27
+v0.1.28
+v0.1.29
+v0.1.30
+v0.1.31
+v0.1.32
+v0.1.33
+v0.1.100
+v0.10.0
+v0.10.1
+v0.10.2
+v0.10.3
+v0.10.4
+v0.10.5
+v0.10.6
+v0.10.7
+v0.10.8
+v0.10.9
+v0.10.10
+v0.10.11
+v0.10.12
+v0.10.13
+v0.10.14
+v0.10.15
+v0.10.16
+v0.10.17
+v0.10.18
+v0.10.19
+v0.10.20
+v0.10.21
+v0.10.22
+v0.10.23
+v0.10.24
+v0.10.25
+v0.10.26
+v0.10.27
+v0.10.28
+v0.10.29
+... (6 lines truncated)"""
+
+[[tests.fnm]]
+name = "ANSI color codes stripped from list output"
+input = "\u001b[32m* v20.20.2 default\u001b[0m\n\u001b[32m* v22.22.3\u001b[0m\n* system"
+expected = "* v20.20.2 default\n* v22.22.3\n* system"


### PR DESCRIPTION
## Summary

Closes #1538. Adds a TOML filter for `fnm` (Fast Node Manager) and registers it in the discover/hook engine so `fnm use|install|list|list-remote|...` get auto-rewritten to `rtk fnm ...`.

## Why

`fnm` is a popular Node version manager (~14k stars). Without a handler, `rtk hook check` returns "No rewrite" for `fnm use` / `fnm install` / `fnm list-remote`, so output sits unfiltered in agent sessions (~249 invocations / 30 days per #1538). Pairs naturally with the existing `npm`/`npx`/`pnpm` handlers. The clear win is `fnm list-remote`, which prints ~850 Node versions per call.

## Fix

- `src/filters/fnm.toml` — new filter. `match_command = "^fnm\s+(list-remote |use|install|uninstall|list|ls|current|default)(\s|$)"`. `strip_ansi = true`, `filter_stderr = true` (fnm writes errors to stderr — without merging, an error like `Requested version v99.x.x is not currently installed` would be eaten by terminal stderr while `on_empty` fired "fnm: ok" on the empty stdout, which is misleading). `strip_lines_matching` drops blank / `Downloading ` / `Extracting ` lines. `max_lines = 50` truncates `list-remote` with a built-in recovery hint. `on_empty = "fnm: ok"`. 10 inline tests cover: use success, install success, missing-version error, list, current, install with progress-strip, on_empty fallback, uninstall error, ANSI codes stripped, list-remote truncation with recovery hint.
- `src/discover/rules.rs` — new `RtkRule { rewrite_prefixes: &["fnm"], rtk_cmd: "rtk fnm", category: "NodeVersionManager", savings_pct: 25.0 }`. The TOML `match_command` and the rules.rs `pattern` are character-aligned (both use `(\s|$)` boundary, with `list-remote` placed before `list` in the alternation so the engine picks the longer match) so the two layers can never disagree on which subcommands are handled.
- `src/discover/registry.rs` — register `NodeVersionManager => 40` in `category_avg_tokens` (most fnm output is 1-3 lines — 40 tokens avg is honest; falls through to default 150 otherwise).
- `src/core/toml_filter.rs` — bump builtin filter count assertion 59 → 60 (and the concat test 60 → 61).
- `README.md` — list `rtk fnm use 20` under Package Managers.

## Tests

- [x] `cargo fmt --all --check && cargo clippy --all-targets && cargo test` — 1946 passed, 0 failed, 0 clippy warnings, fmt clean
- [x] Manual on a real fnm install (1.39.0):
  - `rtk hook check "fnm use 20"` → `rtk fnm use 20` (exit 0)
  - `rtk hook check "fnm install 22"` → `rtk fnm install 22` (exit 0)
  - `rtk hook check "fnm list-remote"` → `rtk fnm list-remote` (exit 0)
  - `rtk hook check "fnm env"` → `No rewrite for: fnm env` (exit 1, intentional — see Scope)
  - `rtk fnm list-remote` → 51 lines incl. `... (796 lines truncated)` recovery hint (was 846 lines raw, ~94% savings on this case)
  - `rtk fnm use 99` → `error: We can't find the necessary environment variables...` (exit 1, error visible through stderr merge)
  - `rtk fnm use 20` → `Using Node v20.20.2` (exit 0, passthrough)
  - `rtk fnm list` → version list intact (exit 0)
- [x] 10 inline TOML tests in `fnm.toml` (run by the builtin test harness)

## Scope

**Out of scope, intentionally:**
- **`fnm env` and `eval "$(fnm env)"`** — the filter would corrupt the shell exports that `eval` consumes, and more fundamentally the hook engine routes on the leading token, so `eval "$(fnm env)"` cannot be intercepted by an `fnm` rewrite prefix at all. Letting both forms pass through raw keeps `eval "$(fnm env)"` working untouched. The issue lists `eval "$(fnm env)"` as a pain point (~123 invocations/30d), but lexer-aware unwrapping of `eval` is a much bigger change and out of scope for this PR.
- **`fnm exec --using=20 -- <child>`** — would otherwise let the filter's blank/`Downloading`/`Extracting` strips eat legitimate output from the wrapped child command. Excluded from both `match_command` and the rewrite pattern.

**Honest about savings:** for the small-output subcommands (`use`, `install`, `current`, `list`), output is already 1–3 lines and there's near-zero savings — they go through the chain mainly so RTK analytics see them as supported rather than "missed opportunity". The genuine savings come from `list-remote` (94% on the local test). The headline `savings_pct = 25` averages those cases conservatively (below the 60% threshold cited in CONTRIBUTING, which is calibrated for noisy command output).

## Follow-up

- If users report meaningful noise from `fnm install` on first-download (uncached, slow network), revisit `strip_lines_matching` to cover additional progress patterns.
- `subcmd_savings` is left empty; a future pass could break out per-subcommand averages (e.g. `list-remote ~94%`, `use ~0%`) once we have real usage data.
- Lexer-aware unwrapping of `eval "$(...)"` would let RTK intercept `eval "$(fnm env)"` style invocations — useful beyond fnm (e.g. `eval "$(direnv hook bash)"`). Tracked separately.