### PR TITLE
fix(openclaw): add TypeScript build for OpenClaw 2026.5.4+ compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,8 @@ claudedocs
 
 # icm 
 .fastembed_cache/
+
+# Build output
+dist/
+openclaw/node_modules/
+openclaw/package-lock.json

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -24,20 +24,31 @@ curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/instal
 
 ### Install the plugin
 
+**Option A: Build from source**
+
 ```bash
-# Copy the plugin to OpenClaw's extensions directory
+cd openclaw
+npm install
+npm run build
+
+# Copy to OpenClaw's extensions directory
 mkdir -p ~/.openclaw/extensions/rtk-rewrite
-cp openclaw/index.ts openclaw/openclaw.plugin.json ~/.openclaw/extensions/rtk-rewrite/
+cp dist/index.js openclaw.plugin.json ~/.openclaw/extensions/rtk-rewrite/
 
 # Restart the gateway
 openclaw gateway restart
 ```
 
-### Or install via OpenClaw CLI
+**Option B: Install via OpenClaw CLI**
 
 ```bash
-openclaw plugins install ./openclaw
+cd openclaw
+npm install
+npm run build
+openclaw plugins install .
 ```
+
+> **Note:** OpenClaw 2026.5.4+ requires compiled JavaScript for plugins. The TypeScript source must be built before installation.
 
 ## Configuration
 
@@ -80,6 +91,15 @@ Handled by `rtk rewrite` guards:
 | `git status` | 66% |
 | `grep` (single file) | 52% |
 | `find -name` | 48% |
+
+## Development
+
+```bash
+cd openclaw
+npm install
+npm run build    # Compile TypeScript
+npm run clean    # Remove build artifacts
+```
 
 ## License
 

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -2,7 +2,8 @@
   "name": "@rtk-ai/rtk-rewrite",
   "version": "1.0.0",
   "description": "RTK plugin for OpenClaw — rewrites shell commands for 60-90% LLM token savings",
-  "main": "index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -18,12 +19,24 @@
     "llm",
     "cli-proxy"
   ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "prepublishOnly": "npm run build"
+  },
   "files": [
-    "index.ts",
+    "dist",
     "openclaw.plugin.json",
     "README.md"
   ],
+  "devDependencies": {
+    "@types/node": "^25.9.1",
+    "typescript": "^5.4.0"
+  },
   "peerDependencies": {
     "rtk": ">=0.28.0"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }

--- a/openclaw/tsconfig.json
+++ b/openclaw/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["index.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Fixes #1719 — OpenClaw plugin fails to load on OpenClaw 2026.5.4+ because the plugin ships only TypeScript source (`index.ts`) without compiled JavaScript output.

## Changes

- Add `tsconfig.json` for TypeScript compilation
- Update `package.json` with:
  - Build scripts (`npm run build`)
  - `@types/node` dev dependency
  - `main` pointing to `dist/index.js`
  - `types` pointing to `dist/index.d.ts`
- Update README with build instructions for users on OpenClaw 2026.5.4+
- Add `dist/` and `openclaw/node_modules/` to `.gitignore`

## Testing

```bash
cd openclaw
npm install
npm run build  # Compiles successfully to dist/index.js
```

The compiled output can be copied to `~/.openclaw/extensions/rtk-rewrite/` and loads without error on OpenClaw 2026.5.4.

## Notes

The build is intentionally not committed — users run `npm run build` during installation. This keeps the repo clean and avoids committing generated artifacts.