### PR TITLE
fix(openclaw): add TypeScript build for OpenClaw 2026.5.4+ compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,9 @@ claudedocs
 
 # icm 
 .fastembed_cache/
+
+# Build output
+
+openclaw/node_modules/
+openclaw/package-lock.json
+openclaw/index.js

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -24,20 +24,31 @@ curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/instal
 
 ### Install the plugin
 
+**Option A: Build from source**
+
 ```bash
-# Copy the plugin to OpenClaw's extensions directory
+cd openclaw
+npm install
+npm run build
+
+# Copy to OpenClaw's extensions directory
 mkdir -p ~/.openclaw/extensions/rtk-rewrite
-cp openclaw/index.ts openclaw/openclaw.plugin.json ~/.openclaw/extensions/rtk-rewrite/
+cp index.js openclaw.plugin.json ~/.openclaw/extensions/rtk-rewrite/
 
 # Restart the gateway
 openclaw gateway restart
 ```
 
-### Or install via OpenClaw CLI
+**Option B: Install via OpenClaw CLI**
 
 ```bash
-openclaw plugins install ./openclaw
+cd openclaw
+npm install
+npm run build
+openclaw plugins install .
 ```
+
+> **Note:** OpenClaw 2026.5.4+ requires compiled JavaScript for plugins. The TypeScript source must be built before installation.
 
 ## Configuration
 
@@ -80,6 +91,15 @@ Handled by `rtk rewrite` guards:
 | `git status` | 66% |
 | `grep` (single file) | 52% |
 | `find -name` | 48% |
+
+## Development
+
+```bash
+cd openclaw
+npm install
+npm run build    # Compile TypeScript
+npm run clean    # Remove build artifacts
+```
 
 ## License
 

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -2,7 +2,7 @@
   "name": "@rtk-ai/rtk-rewrite",
   "version": "1.0.0",
   "description": "RTK plugin for OpenClaw — rewrites shell commands for 60-90% LLM token savings",
-  "main": "index.ts",
+  "main": "index.js",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -18,12 +18,24 @@
     "llm",
     "cli-proxy"
   ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -f index.js",
+    "prepublishOnly": "npm run build"
+  },
   "files": [
-    "index.ts",
+    "index.js",
     "openclaw.plugin.json",
     "README.md"
   ],
+  "devDependencies": {
+    "@types/node": "^25.9.1",
+    "typescript": "^5.4.0"
+  },
   "peerDependencies": {
     "rtk": ">=0.28.0"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }

--- a/openclaw/tsconfig.json
+++ b/openclaw/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": ".",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": ["index.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Fixes #1719

OpenClaw 2026.5.4+ needs compiled JS for plugins — can't load `.ts` directly. Plugin was shipping only `index.ts`, so it failed on startup.

## What I changed

- `tsconfig.json` — new file, tells tsc to compile `index.ts` → `index.js`
- `package.json` — added build script, pointed `main` to `index.js`, added typescript + @types/node as devDeps
- `README.md` — updated install instructions to include the build step
- `.gitignore` — ignore `index.js` (build artifact), `node_modules/`, `package-lock.json`

## How to install (after this fix)

```bash
cd openclaw
npm install
npm run build
cp index.js openclaw.plugin.json ~/.openclaw/extensions/rtk-rewrite/
openclaw gateway restart
```

## Tested

```bash
cd openclaw
npm install && npm run build
node -e "require('./index.js')"  # loads fine
```