### PR TITLE
fix(discover): add cargo nextest to rewrite rule

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1101,10 +1101,47 @@ mod tests {
     }
 
     #[test]
+    fn test_classify_cargo_nextest() {
+        assert_eq!(
+            classify_command("cargo nextest run"),
+            Classification::Supported {
+                rtk_equivalent: "rtk cargo",
+                category: "Cargo",
+                estimated_savings_pct: 90.0,
+                status: RtkStatus::Existing,
+            }
+        );
+    }
+
+    #[test]
+    fn test_rewrite_cargo_nextest() {
+        assert_eq!(
+            rewrite_command_no_prefixes("cargo nextest run", &[]),
+            Some("rtk cargo nextest run".into())
+        );
+    }
+
+    #[test]
+    fn test_classify_cargo_nextest_with_args() {
+        assert_eq!(
+            classify_command("cargo nextest run --no-fail-fast --release"),
+            Classification::Supported {
+                rtk_equivalent: "rtk cargo",
+                category: "Cargo",
+                estimated_savings_pct: 90.0,
+                status: RtkStatus::Existing,
+            }
+        );
+    }
+
+    #[test]
     fn test_registry_covers_all_cargo_subcommands() {
-        // Verify that every CargoCommand variant (Build, Test, Clippy, Check, Fmt)
-        // except Other has a matching pattern in the registry
-        for subcmd in ["build", "test", "clippy", "check", "fmt"] {
+        // Verify every cargo subcommand registered in the rule (filter-backed
+        // CargoCommand variants Build/Test/Clippy/Check/Install/Nextest plus
+        // the `fmt` passthrough) classifies as Supported.
+        for subcmd in [
+            "build", "test", "clippy", "check", "fmt", "install", "nextest",
+        ] {
             let cmd = format!("cargo {subcmd}");
             match classify_command(&cmd) {
                 Classification::Supported { .. } => {}

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -44,12 +44,12 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        pattern: r"^cargo\s+(build|test|clippy|check|fmt|install)",
+        pattern: r"^cargo\s+(build|test|clippy|check|fmt|install|nextest)",
         rtk_cmd: "rtk cargo",
         rewrite_prefixes: &["cargo"],
         category: "Cargo",
         savings_pct: 80.0,
-        subcmd_savings: &[("test", 90.0), ("check", 80.0)],
+        subcmd_savings: &[("test", 90.0), ("check", 80.0), ("nextest", 90.0)],
         subcmd_status: &[("fmt", RtkStatus::Passthrough)],
     },
     RtkRule {


### PR DESCRIPTION
## Summary

- Closes #2046 — `rtk rewrite \"cargo nextest run\"` previously returned exit 1 ("no RTK equivalent"), so the Claude Code hook never rewrote `cargo nextest` calls even though `rtk cargo nextest` is fully implemented in `src/cmds/rust/cargo_cmd.rs` with a dedicated 90%-savings filter.

## Root cause

`src/discover/rules.rs:47` — the cargo rule's pattern alternation only matched `(build|test|clippy|check|fmt|install)`. `nextest` was missing, so `RegexSet` never matched `cargo nextest …` and `classify_command` fell through to `Unsupported`.

## Fix

- Add `nextest` to the alternation: `^cargo\s+(build|test|clippy|check|fmt|install|nextest)`.
- Register `(\"nextest\", 90.0)` in `subcmd_savings`, matching `test` (both filters reduce to a one-line pass/fail summary, see `filter_cargo_nextest` in `src/cmds/rust/cargo_cmd.rs:583`).
- No changes to `rewrite_prefixes` or `subcmd_status` — `nextest` reuses cargo's existing prefix and is `Existing` (not passthrough).

## Tests

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --all-targets` — 0 warnings
- [x] `cargo test --all` — 1948 passed, 0 failed (2 new tests included)
- [x] New unit tests in `src/discover/registry.rs`:
  - `test_classify_cargo_nextest` — `cargo nextest run` → `Supported { rtk_equivalent: \"rtk cargo\", category: \"Cargo\", estimated_savings_pct: 90.0, status: Existing }`
  - `test_rewrite_cargo_nextest` — `cargo nextest run` → `rtk cargo nextest run`
- [x] Manual repro (release build):
  - Before: `rtk rewrite \"cargo nextest run\"` → empty output, EC=1
  - After: `rtk rewrite \"cargo nextest run\"` → `rtk cargo nextest run`, EC=3 (matches `cargo test` / `cargo build` baseline; reporter's expected EC=0 was a minor misstatement — EC=3 is RTK's normal \"rewrite suggested\" status)

## Scope

- Does **not** touch `src/cmds/rust/cargo_cmd.rs` — the nextest filter already exists and is reachable as `rtk cargo nextest` once routed via Clap.
- Does **not** add nextest to `rewrite_prefixes` (cargo invocations always start with literal `cargo`; no aliases needed).