### PR TITLE
fix: rewrite rg --files to rtk find

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -3,7 +3,7 @@
 use lazy_static::lazy_static;
 use regex::{Regex, RegexSet};
 
-use super::lexer::{split_on_operators, tokenize, TokenKind};
+use super::lexer::{shell_split, split_on_operators, tokenize, TokenKind};
 use super::rules::{IGNORED_EXACT, IGNORED_PREFIXES, RULES};
 
 /// Result of classifying a command.
@@ -560,7 +560,9 @@ fn rewrite_compound(
                 let is_pipe_incompatible = seg.starts_with("find ")
                     || seg == "find"
                     || seg.starts_with("fd ")
-                    || seg == "fd";
+                    || seg == "fd"
+                    || seg == "rg --files"
+                    || seg.starts_with("rg --files ");
                 let rewritten = if is_pipe_incompatible {
                     seg.to_string()
                 } else {
@@ -787,6 +789,10 @@ fn rewrite_segment_inner(
         return rewrite_line_range(cmd_part).map(|r| format!("{}{}", r, redirect_suffix));
     }
 
+    if is_rg_files_invocation(cmd_part) {
+        return rewrite_rg_files(cmd_part, redirect_suffix);
+    }
+
     // Most cat flags (-v, -A, -e, -t, -s, -b, --show-all, etc.) have different
     // semantics than rtk read or no equivalent at all. Only `-n` (line numbers)
     // maps correctly to `rtk read -n`. Skip rewrite for any other flag.
@@ -850,6 +856,28 @@ fn rewrite_segment_inner(
     }
 
     None
+}
+
+fn is_rg_files_invocation(cmd_part: &str) -> bool {
+    strip_word_prefix(cmd_part, "rg")
+        .map(|rest| rest == "--files" || rest.starts_with("--files "))
+        .unwrap_or(false)
+}
+
+fn rewrite_rg_files(cmd_part: &str, redirect_suffix: &str) -> Option<String> {
+    let rest = strip_word_prefix(cmd_part, "rg")?;
+    let paths = strip_word_prefix(rest, "--files")?;
+
+    if paths.is_empty() {
+        return Some(format!("rtk find{}", redirect_suffix));
+    }
+
+    let args = shell_split(paths);
+    if args.len() != 1 || args[0].starts_with('-') {
+        return None;
+    }
+
+    Some(format!("rtk find '*' {}{}", paths, redirect_suffix))
 }
 
 /// Strip a command prefix with word-boundary check.
@@ -1418,6 +1446,35 @@ mod tests {
         assert_eq!(
             rewrite_command_no_prefixes("rg \"fn main\"", &[]),
             Some("rtk grep \"fn main\"".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_rg_files_to_find() {
+        assert_eq!(
+            rewrite_command_no_prefixes("rg --files", &[]),
+            Some("rtk find".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_rg_files_path_to_find() {
+        assert_eq!(
+            rewrite_command_no_prefixes("rg --files src", &[]),
+            Some("rtk find '*' src".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_rg_files_pipe_skipped() {
+        assert_eq!(rewrite_command_no_prefixes("rg --files | wc -l", &[]), None);
+    }
+
+    #[test]
+    fn test_rewrite_rg_files_unsupported_flags_skipped() {
+        assert_eq!(
+            rewrite_command_no_prefixes("rg --files --hidden", &[]),
+            None
         );
     }
 


### PR DESCRIPTION
Fixes #2060

## Changes
- route `rg --files` to `rtk find` instead of `rtk grep --files`
- route `rg --files <path>` to `rtk find '*' <path>`
- leave piped or unsupported `rg --files` forms alone instead of producing a broken grep command

## Verification
- `cargo fmt --check`
- `cargo test test_rewrite_rg_files -- --nocapture`
- `cargo test test_rewrite_rg_pattern -- --nocapture`
- `cargo test discover::registry::tests:: -- --nocapture`
- `cargo run --quiet -- rewrite 'rg --files'` -> `rtk find`
- `cargo run --quiet -- rewrite 'rg --files src'` -> `rtk find '*' src`