### PR TITLE
feat(moon): add rtk moon filter — chrome strip + per-task tool routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +344,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "env_home"
@@ -652,6 +669,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +932,7 @@ dependencies = [
  "flate2",
  "getrandom 0.4.2",
  "ignore",
+ "insta",
  "lazy_static",
  "libc",
  "quick-xml",
@@ -1076,6 +1106,12 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ libc = "0.2"
 toml = "0.8"
 
 [dev-dependencies]
+insta = "1"
 
 [profile.release]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ rtk cargo clippy                # Cargo clippy (-80%)
 rtk ruff check                  # Python linting (JSON, -80%)
 rtk golangci-lint run           # Go linting (JSON, -85%)
 rtk rubocop                     # Ruby linting (JSON, -60%+)
+rtk moon run :typecheck         # moonrepo (chrome strip + per-task tool routing)
 ```
 
 ### Package Managers

--- a/src/cmds/README.md
+++ b/src/cmds/README.md
@@ -34,6 +34,7 @@ Each subdirectory has its own README with file descriptions, parsing strategies,
 - **[`cloud/`](cloud/README.md)** — aws, docker/kubectl, curl, wget, psql — Docker/Kubectl sub-enums, JSON forced output
 - **[`system/`](system/README.md)** — ls, tree, read, grep, find, wc, env, json, log, deps, summary, format, smart — format_cmd routing, filter levels, language detection
 - **[`ruby/`](ruby/README.md)** — rake/rails test, rspec, rubocop — JSON injection pattern, `ruby_exec()` bundle exec auto-detection
+- **[`build/`](build/README.md)** — moon — task-runner orchestration with per-task underlying-tool routing via `moon query tasks` + StreamFilter state machine
 
 ## Execution Flow
 

--- a/src/cmds/build/README.md
+++ b/src/cmds/build/README.md
@@ -1,0 +1,22 @@
+# Build / Task-Runner Filters
+
+Filters for monorepo task runners that orchestrate underlying tools.
+
+## Modules
+
+- `moon_cmd` — wraps [moon](https://moonrepo.dev) task runner. Strips moon's
+  chrome (banners, hash suffixes, decoration) and routes each task's
+  stdout/stderr through the matching rtk filter for its underlying command
+  (vitest, tsc, eslint, prettier, cargo test, ...). See issue #1877.
+
+## Why a separate ecosystem
+
+Task runners are language-agnostic and orchestrate other tools across the
+project graph. They need cross-command routing (detect the underlying tool
+per task, apply that tool's filter) which the `system/` ecosystem does not
+do, and they don't belong to any single language stack (`js/`, `rust/`, ...).
+
+Related TOML-only filters that conceptually belong here but don't need a
+Rust module today: `src/filters/turbo.toml`, `nx.toml`, `just.toml`,
+`task.toml`, `make.toml`. They live in `src/filters/` because their
+filtering needs no detection or routing logic.

--- a/src/cmds/build/README.md
+++ b/src/cmds/build/README.md
@@ -5,9 +5,32 @@ Filters for monorepo task runners that orchestrate underlying tools.
 ## Modules
 
 - `moon_cmd` — wraps [moon](https://moonrepo.dev) task runner. Strips moon's
-  chrome (banners, hash suffixes, decoration) and routes each task's
-  stdout/stderr through the matching rtk filter for its underlying command
-  (vitest, tsc, eslint, prettier, cargo test, ...). See issue #1877.
+  chrome (upgrade banner, `▮▮▮▮` decoration, `(hash)` suffix, `❯❯❯❯` footer)
+  and routes each sequential-mode task's body through the matching rtk
+  filter for its underlying command via `moon query tasks` → `TaskMap`
+  detection. Currently routes `prettier`, `vitest`/`jest`, `tsc`, and
+  `eslint`/`biome`. See issue #1877.
+
+## How filtering applies
+
+Only `moon run/ci/check/exec` invocations go through the filter — `moon
+query`/`graph`/`--version` etc. pass through raw so we don't pay the
+`moon query tasks` overhead (~150ms on large workspaces) for non-task
+commands.
+
+## Known limitations (follow-up work)
+
+- **Parallel-mode bodies passthrough.** When moon runs tasks in parallel
+  (the common case — dep graph), task bodies are prefixed with
+  ` <project>:<task> | ` and currently bypass the per-tool filter to
+  avoid breaking tools that need batch context (prettier's filter
+  collapses multi-line output into a canonical summary; called per-line
+  it would emit that summary repeatedly). A future PR could buffer
+  parallel bodies per-task and apply the filter once on task completion.
+- **No `bun test` filter.** Bun's test runner emits plain text; the
+  existing rtk `vitest_cmd` parser requires JSON. Adding `filter_bun_test_output`
+  in `cmds/js/` and routing `bun` in `filter_for_tool` would unlock
+  compression for `audit:test`-style tasks.
 
 ## Why a separate ecosystem
 

--- a/src/cmds/build/mod.rs
+++ b/src/cmds/build/mod.rs
@@ -1,0 +1,1 @@
+automod::dir!(pub "src/cmds/build");

--- a/src/cmds/build/moon_cmd.rs
+++ b/src/cmds/build/moon_cmd.rs
@@ -4,9 +4,10 @@
 //! task's stdout/stderr through the matching rtk filter for its underlying
 //! command. See issue #1877.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use lazy_static::lazy_static;
 use regex::Regex;
+use serde::Deserialize;
 use std::collections::HashMap;
 
 use crate::core::runner::{self, RunOptions};
@@ -41,21 +42,58 @@ const PASSTHROUGH_SUBCOMMANDS: &[&str] = &[
     "upgrade",
 ];
 
+/// Serde helper: root of `moon query tasks` JSON output.
+#[derive(Debug, Deserialize)]
+struct QueryTasksRoot {
+    tasks: HashMap<String, HashMap<String, QueryTask>>,
+}
+
+/// Serde helper: minimal task fields we care about (other fields are ignored).
+#[derive(Debug, Deserialize)]
+struct QueryTask {
+    command: String,
+}
+
 /// Maps a `project:task` identifier to the underlying tool's command name
 /// (e.g. `"audit:format" -> "prettier"`). Built from `moon query tasks` in
 /// Task 4; defaulted to empty for chrome-only mode in Task 3.
 #[derive(Debug, Default, Clone)]
 pub struct TaskMap {
-    #[allow(dead_code)]
     tasks: HashMap<String, String>,
 }
 
 impl TaskMap {
     /// Return the underlying command for a `project:task` id, or `None` if
-    /// the task is unknown.
+    /// the task is unknown. Used by Task 5 per-task routing.
     #[allow(dead_code)]
     pub fn tool_for(&self, project_task: &str) -> Option<&str> {
         self.tasks.get(project_task).map(|s| s.as_str())
+    }
+
+    /// Parse the output of `moon query tasks`. The JSON has shape
+    /// `{"tasks": {"<project>": {"<task>": {"command": "...", ...}}}, "options": {...}}`.
+    /// Unknown fields (like `options` at the root, `args` inside task) are ignored.
+    pub fn from_query_json(json: &str) -> anyhow::Result<Self> {
+        let root: QueryTasksRoot = serde_json::from_str(json)
+            .context("Failed to parse moon query tasks JSON")?;
+        let mut tasks = HashMap::with_capacity(root.tasks.len() * 4);
+        for (project, project_tasks) in root.tasks {
+            for (task_name, task) in project_tasks {
+                tasks.insert(format!("{}:{}", project, task_name), task.command);
+            }
+        }
+        Ok(Self { tasks })
+    }
+
+    /// Number of `project:task` entries in the map.
+    pub fn len(&self) -> usize {
+        self.tasks.len()
+    }
+
+    /// True when no tasks have been loaded (e.g. when `moon query tasks` failed).
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.tasks.is_empty()
     }
 }
 
@@ -87,6 +125,52 @@ lazy_static! {
         Regex::new(r"Daemon, AI skill, async experiments").unwrap(),
         Regex::new(r"Run moon upgrade or install").unwrap(),
     ];
+}
+
+/// Run `moon query tasks` to build the task->tool map. Returns an empty
+/// map (not Err) on failure so the filter still falls back to chrome-only
+/// stripping rather than blocking the user.
+fn build_task_map(verbose: u8) -> TaskMap {
+    let output = resolved_command("moon")
+        .arg("query")
+        .arg("tasks")
+        .output();
+
+    match output {
+        Ok(out) if out.status.success() => {
+            let json = String::from_utf8_lossy(&out.stdout);
+            match TaskMap::from_query_json(&json) {
+                Ok(map) => map,
+                Err(e) => {
+                    if verbose > 0 {
+                        eprintln!(
+                            "rtk moon: failed to parse moon query tasks ({}); chrome-only filtering",
+                            e
+                        );
+                    }
+                    TaskMap::default()
+                }
+            }
+        }
+        Ok(out) => {
+            if verbose > 0 {
+                eprintln!(
+                    "rtk moon: `moon query tasks` exited {}; chrome-only filtering",
+                    out.status.code().unwrap_or(-1)
+                );
+            }
+            TaskMap::default()
+        }
+        Err(e) => {
+            if verbose > 0 {
+                eprintln!(
+                    "rtk moon: could not execute `moon query tasks` ({}); chrome-only filtering",
+                    e
+                );
+            }
+            TaskMap::default()
+        }
+    }
 }
 
 /// Apply chrome stripping to moon output. When `task_map` is non-empty, Task 5
@@ -139,7 +223,10 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         cmd.arg(arg);
     }
 
-    let task_map = TaskMap::default();
+    let task_map = build_task_map(verbose);
+    if verbose > 0 {
+        eprintln!("rtk moon: detected {} tasks in workspace", task_map.len());
+    }
     runner::run_filtered(
         cmd,
         "moon",
@@ -225,5 +312,25 @@ mod tests {
             "expected >=15% savings on cache-hit fixture, got {:.1}%",
             s
         );
+    }
+
+    #[test]
+    fn builds_taskmap_from_real_query_json() {
+        let json = include_str!("../../../tests/fixtures/moon/query_tasks.json");
+        let map = TaskMap::from_query_json(json).expect("parses query JSON");
+        // The fixture is from yulii/ops-platform which has audit:format -> prettier.
+        assert_eq!(map.tool_for("audit:format"), Some("prettier"));
+    }
+
+    #[test]
+    fn taskmap_from_malformed_json_returns_err() {
+        let result = TaskMap::from_query_json("not json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn taskmap_from_empty_json_is_empty() {
+        let map = TaskMap::from_query_json(r#"{"tasks": {}}"#).expect("parses");
+        assert_eq!(map.tool_for("anything:anything"), None);
     }
 }

--- a/src/cmds/build/moon_cmd.rs
+++ b/src/cmds/build/moon_cmd.rs
@@ -70,9 +70,12 @@ lazy_static! {
     static ref HASH_SUFFIX_RE: Regex =
         Regex::new(r",\s*[0-9a-f]{8}\)$").unwrap();
 
-    /// Task-start lines have only a bare hash in parens — drop the whole paren.
+    /// Task-start lines after chrome-prefix stripping look like
+    /// `<project>:<task> (<8-hex-hash>)`. Capture the identifier (group 1) so we
+    /// can drop just the hash without nuking unrelated lines that happen to end
+    /// in `(<hex>)` (e.g. `bun test v1.3.14 (0d9b296a)` — bun's version hash).
     static ref BARE_HASH_RE: Regex =
-        Regex::new(r"\s*\([0-9a-f]{8}\)$").unwrap();
+        Regex::new(r"^([a-z0-9_\-]+:[a-z0-9_\-]+)\s*\([0-9a-f]{8}\)$").unwrap();
 
     /// Footer line (single-task runs only).
     static ref FOOTER_RE: Regex =
@@ -110,8 +113,9 @@ pub fn filter_moon_output(input: &str, _task_map: &TaskMap) -> String {
             let stripped = CHROME_PREFIX_RE.replace(line, "");
             // Strip task-completion hash suffix `, <hash>)` → keep duration/cached.
             let stripped = HASH_SUFFIX_RE.replace(&stripped, ")");
-            // Strip task-start bare-hash suffix `(<hash>)` entirely.
-            let stripped = BARE_HASH_RE.replace(&stripped, "");
+            // Strip task-start bare-hash suffix `(<hash>)` from `project:task (hash)` lines,
+            // preserving the identifier.
+            let stripped = BARE_HASH_RE.replace(&stripped, "$1");
             Some(stripped.into_owned())
         })
         .collect::<Vec<_>>()

--- a/src/cmds/build/moon_cmd.rs
+++ b/src/cmds/build/moon_cmd.rs
@@ -36,8 +36,7 @@ pub struct TaskMap {
 
 impl TaskMap {
     /// Return the underlying command for a `project:task` id, or `None` if
-    /// the task is unknown. Used by Task 5 per-task routing.
-    #[allow(dead_code)]
+    /// the task is unknown. Used by MoonStreamFilter per-task routing.
     pub fn tool_for(&self, project_task: &str) -> Option<&str> {
         self.tasks.get(project_task).map(|s| s.as_str())
     }
@@ -63,6 +62,8 @@ impl TaskMap {
     }
 
     /// True when no tasks have been loaded (e.g. when `moon query tasks` failed).
+    /// Pairs with `len()` to satisfy clippy's `len_without_is_empty` lint;
+    /// no production caller today, so the dead_code allow is intentional.
     #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.tasks.is_empty()
@@ -618,5 +619,67 @@ mod tests {
         );
         assert!(!filtered.contains("▮▮▮▮"), "chrome prefix leaked: {}", filtered);
         insta::assert_snapshot!(filtered);
+    }
+
+    /// Real fixtures route tsc errors through parallel-mode prefix (which
+    /// passes the body through unchanged), so the `filter_for_tool` →
+    /// `filter_tsc_output` branch is not exercised by them. This synthetic
+    /// fixture builds a SEQUENTIAL-mode tsc task (no `project:task | `
+    /// prefix on body lines) so the routing branch fires and we can verify
+    /// the tsc filter actually runs.
+    #[test]
+    fn routes_sequential_tsc_body_through_filter_for_tool() {
+        let task_map = TaskMap::from_query_json(
+            r#"{"tasks": {"audit": {"typecheck": {"command": "tsc"}}}}"#,
+        )
+        .unwrap();
+        // Sequential mode: no ` audit:typecheck | ` prefix on body lines.
+        let input = "▮▮▮▮ audit:typecheck (deadbeef)\n\
+                     src/foo.ts(1,1): error TS2322: Type 'number' is not assignable to type 'string'.\n\
+                     src/foo.ts(2,5): error TS2304: Cannot find name 'foo'.\n\
+                     ▮▮▮▮ audit:typecheck (200ms, deadbeef)\n";
+        let filtered = filter_moon_streaming(input, task_map);
+
+        // The tsc filter must run — its output differs from raw passthrough.
+        // We don't snapshot here because filter_tsc_output's exact output may
+        // evolve; instead we assert the routing happened by checking the
+        // tsc filter emitted a recognizable structure. filter_tsc_output
+        // wraps TscHandler which groups errors by file; even minimal output
+        // should contain the file path.
+        assert!(
+            filtered.contains("src/foo.ts"),
+            "tsc filter dropped the file path: {}",
+            filtered
+        );
+        assert!(!filtered.contains("▮▮▮▮"), "chrome leaked: {}", filtered);
+        // Errors must survive whatever transform tsc filter applies.
+        assert!(
+            filtered.contains("TS2322") && filtered.contains("TS2304"),
+            "tsc filter lost an error code: {}",
+            filtered
+        );
+    }
+
+    /// Tools without a filter_for_tool entry (e.g. bun) must still survive
+    /// chrome stripping with the body intact. Smoke test for the
+    /// `None => body` branch in flush_active_body.
+    #[test]
+    fn passes_unfiltered_tool_body_through_unchanged() {
+        let task_map = TaskMap::from_query_json(
+            r#"{"tasks": {"audit": {"test": {"command": "bun"}}}}"#,
+        )
+        .unwrap();
+        let input = "▮▮▮▮ audit:test (deadbeef)\n\
+                     bun test v1.3.14 (cafef00d)\n\
+                     custom-marker-string-not-from-any-filter\n\
+                     ▮▮▮▮ audit:test (100ms, deadbeef)\n";
+        let filtered = filter_moon_streaming(input, task_map);
+
+        assert!(
+            filtered.contains("custom-marker-string-not-from-any-filter"),
+            "unfiltered body line was dropped: {}",
+            filtered
+        );
+        assert!(!filtered.contains("▮▮▮▮"), "chrome leaked: {}", filtered);
     }
 }

--- a/src/cmds/build/moon_cmd.rs
+++ b/src/cmds/build/moon_cmd.rs
@@ -5,6 +5,9 @@
 //! command. See issue #1877.
 
 use anyhow::Result;
+use lazy_static::lazy_static;
+use regex::Regex;
+use std::collections::HashMap;
 
 use crate::core::runner::{self, RunOptions};
 use crate::core::utils::resolved_command;
@@ -38,6 +41,83 @@ const PASSTHROUGH_SUBCOMMANDS: &[&str] = &[
     "upgrade",
 ];
 
+/// Maps a `project:task` identifier to the underlying tool's command name
+/// (e.g. `"audit:format" -> "prettier"`). Built from `moon query tasks` in
+/// Task 4; defaulted to empty for chrome-only mode in Task 3.
+#[derive(Debug, Default, Clone)]
+pub struct TaskMap {
+    #[allow(dead_code)]
+    tasks: HashMap<String, String>,
+}
+
+impl TaskMap {
+    /// Return the underlying command for a `project:task` id, or `None` if
+    /// the task is unknown.
+    #[allow(dead_code)]
+    pub fn tool_for(&self, project_task: &str) -> Option<&str> {
+        self.tasks.get(project_task).map(|s| s.as_str())
+    }
+}
+
+lazy_static! {
+    /// moon's decoration prefix: 4× U+25AE BLACK VERTICAL RECTANGLE + space.
+    static ref CHROME_PREFIX_RE: Regex =
+        Regex::new(r"^▮▮▮▮ ").unwrap();
+
+    /// Hash suffix on task completion lines: `(<duration>, <8-hex-hash>)` or
+    /// `(cached, <8-hex-hash>)`. Strip the trailing `, <hash>)` while keeping
+    /// the duration / cached marker.
+    static ref HASH_SUFFIX_RE: Regex =
+        Regex::new(r",\s*[0-9a-f]{8}\)$").unwrap();
+
+    /// Task-start lines have only a bare hash in parens — drop the whole paren.
+    static ref BARE_HASH_RE: Regex =
+        Regex::new(r"\s*\([0-9a-f]{8}\)$").unwrap();
+
+    /// Footer line (single-task runs only).
+    static ref FOOTER_RE: Regex =
+        Regex::new(r"❯❯❯❯\s*to the moon").unwrap();
+
+    /// Upgrade nag lines detected individually.
+    static ref UPGRADE_BANNER_RES: [Regex; 3] = [
+        Regex::new(r"There's a new version of moon available").unwrap(),
+        Regex::new(r"Daemon, AI skill, async experiments").unwrap(),
+        Regex::new(r"Run moon upgrade or install").unwrap(),
+    ];
+}
+
+/// Apply chrome stripping to moon output. When `task_map` is non-empty, Task 5
+/// will additionally route per-task body lines through matching tool filters;
+/// for now `task_map` is unused.
+pub fn filter_moon_output(input: &str, _task_map: &TaskMap) -> String {
+    input
+        .lines()
+        .filter_map(|line| {
+            // Drop upgrade banner lines anywhere they appear.
+            if UPGRADE_BANNER_RES.iter().any(|re| re.is_match(line)) {
+                return None;
+            }
+            // Handle footer — may be glued to "Time: ..." on same line.
+            if FOOTER_RE.is_match(line) {
+                let cleaned = FOOTER_RE.replace(line, "");
+                let cleaned = cleaned.trim_end();
+                if cleaned.is_empty() {
+                    return None;
+                }
+                return Some(cleaned.to_string());
+            }
+            // Strip the decoration prefix.
+            let stripped = CHROME_PREFIX_RE.replace(line, "");
+            // Strip task-completion hash suffix `, <hash>)` → keep duration/cached.
+            let stripped = HASH_SUFFIX_RE.replace(&stripped, ")");
+            // Strip task-start bare-hash suffix `(<hash>)` entirely.
+            let stripped = BARE_HASH_RE.replace(&stripped, "");
+            Some(stripped.into_owned())
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// Entry point for `rtk moon <args>`.
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     // Subcommand check: if the first arg is one of the passthrough subcommands,
@@ -50,23 +130,96 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         }
     }
 
-    // For run/ci/check (and anything else not in passthrough list), we'll
-    // filter in later tasks. For now: passthrough so the command works
-    // end-to-end while we iterate.
     let mut cmd = resolved_command("moon");
     for arg in args {
         cmd.arg(arg);
     }
-    if verbose > 0 {
-        eprintln!("rtk moon: passthrough (skeleton — filtering added in later tasks)");
-    }
 
+    let task_map = TaskMap::default();
     runner::run_filtered(
         cmd,
         "moon",
         &args.join(" "),
-        // Identity filter — returns input unchanged.
-        |s| s.to_string(),
+        move |s| filter_moon_output(s, &task_map),
         RunOptions::default(),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use insta::assert_snapshot;
+
+    fn count_tokens(s: &str) -> usize {
+        s.split_whitespace().count()
+    }
+
+    fn savings_pct(raw: &str, filtered: &str) -> f64 {
+        let r = count_tokens(raw) as f64;
+        let f = count_tokens(filtered) as f64;
+        100.0 * (1.0 - f / r)
+    }
+
+    #[test]
+    fn strips_chrome_from_typecheck_success() {
+        let input = include_str!("../../../tests/fixtures/moon/run_typecheck_success.txt");
+        let output = filter_moon_output(input, &TaskMap::default());
+        assert_snapshot!(output);
+    }
+
+    #[test]
+    fn strips_chrome_from_cache_hit() {
+        let input = include_str!("../../../tests/fixtures/moon/run_cache_hit.txt");
+        let output = filter_moon_output(input, &TaskMap::default());
+        assert_snapshot!(output);
+    }
+
+    #[test]
+    fn preserves_failure_body_in_test_run() {
+        let input = include_str!("../../../tests/fixtures/moon/run_test_failure.txt");
+        let output = filter_moon_output(input, &TaskMap::default());
+        // The failure message must still be present after chrome stripping.
+        assert!(
+            output.contains("fail") || output.contains("error") || output.contains("Expected"),
+            "failure indicator lost during chrome strip: {}",
+            output
+        );
+        assert_snapshot!(output);
+    }
+
+    #[test]
+    fn strips_chrome_from_summary_detailed() {
+        let input = include_str!("../../../tests/fixtures/moon/run_summary_detailed.txt");
+        let output = filter_moon_output(input, &TaskMap::default());
+        // SUMMARY section body lines have no chrome prefix — they pass through.
+        // The "Loading changed files" preamble has chrome prefix and gets stripped.
+        assert_snapshot!(output);
+    }
+
+    #[test]
+    fn savings_chrome_only_success_fixture() {
+        let raw = include_str!("../../../tests/fixtures/moon/run_typecheck_success.txt");
+        let filtered = filter_moon_output(raw, &TaskMap::default());
+        let s = savings_pct(raw, &filtered);
+        assert!(
+            s >= 20.0,
+            "expected >=20% savings on success fixture, got {:.1}%",
+            s
+        );
+    }
+
+    #[test]
+    fn savings_chrome_only_cache_hit_fixture() {
+        let raw = include_str!("../../../tests/fixtures/moon/run_cache_hit.txt");
+        let filtered = filter_moon_output(raw, &TaskMap::default());
+        let s = savings_pct(raw, &filtered);
+        // The cache-hit fixture is only 7 lines; most content is non-chrome task
+        // body output, so chrome-only stripping nets ~21%. Real ≥60% savings are
+        // reached in Task 6 after per-task tool filtering is added (Task 5).
+        assert!(
+            s >= 15.0,
+            "expected >=15% savings on cache-hit fixture, got {:.1}%",
+            s
+        );
+    }
 }

--- a/src/cmds/build/moon_cmd.rs
+++ b/src/cmds/build/moon_cmd.rs
@@ -14,35 +14,6 @@ use crate::core::runner::{self, RunOptions};
 use crate::core::stream::StreamFilter;
 use crate::core::utils::resolved_command;
 
-/// Subcommands that should bypass filtering — structured output (DOT graphs,
-/// JSON), info / setup commands, or long-running servers where filtering
-/// would corrupt the stream. Verified against `moon --help` for moon 2.0.4.
-const PASSTHROUGH_SUBCOMMANDS: &[&str] = &[
-    "action-graph",
-    "bin",
-    "completions",
-    "docker",
-    "ext",
-    "extension",
-    "hash",
-    "init",
-    "mcp",
-    "migrate",
-    "project",
-    "project-graph",
-    "projects",
-    "query",
-    "setup",
-    "task",
-    "task-graph",
-    "tasks",
-    "teardown",
-    "template",
-    "templates",
-    "toolchain",
-    "upgrade",
-];
-
 /// Serde helper: root of `moon query tasks` JSON output.
 #[derive(Debug, Deserialize)]
 struct QueryTasksRoot {
@@ -409,16 +380,26 @@ pub fn filter_moon_output(input: &str, _task_map: &TaskMap) -> String {
         .join("\n")
 }
 
+/// Subcommands where rtk's chrome stripping + tool routing adds value. Other
+/// subcommands (--version, --help, query, graph, info commands, etc.) skip
+/// the StreamFilter path so we don't pay for `moon query tasks` (~150ms on
+/// large workspaces) when there's nothing to filter.
+const FILTERED_SUBCOMMANDS: &[&str] = &["run", "ci", "check", "exec"];
+
 /// Entry point for `rtk moon <args>`.
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
-    // Subcommand check: if the first arg is one of the passthrough subcommands,
-    // execute moon without filtering. Track usage but apply no transform.
-    if let Some(first) = args.first() {
-        if PASSTHROUGH_SUBCOMMANDS.contains(&first.as_str()) {
-            let os_args: Vec<std::ffi::OsString> =
-                args.iter().map(std::ffi::OsString::from).collect();
-            return runner::run_passthrough("moon", &os_args, verbose);
-        }
+    // Filter only when the first arg is a known filterable subcommand. For
+    // everything else (--version, --help, info commands, passthrough list)
+    // exec moon raw — chrome only appears in run/ci/check/exec output.
+    let should_filter = args
+        .first()
+        .map(|first| FILTERED_SUBCOMMANDS.contains(&first.as_str()))
+        .unwrap_or(false);
+
+    if !should_filter {
+        let os_args: Vec<std::ffi::OsString> =
+            args.iter().map(std::ffi::OsString::from).collect();
+        return runner::run_passthrough("moon", &os_args, verbose);
     }
 
     let mut cmd = resolved_command("moon");

--- a/src/cmds/build/moon_cmd.rs
+++ b/src/cmds/build/moon_cmd.rs
@@ -11,6 +11,7 @@ use serde::Deserialize;
 use std::collections::HashMap;
 
 use crate::core::runner::{self, RunOptions};
+use crate::core::stream::StreamFilter;
 use crate::core::utils::resolved_command;
 
 /// Subcommands that should bypass filtering — structured output (DOT graphs,
@@ -173,9 +174,219 @@ fn build_task_map(verbose: u8) -> TaskMap {
     }
 }
 
-/// Apply chrome stripping to moon output. When `task_map` is non-empty, Task 5
-/// will additionally route per-task body lines through matching tool filters;
-/// for now `task_map` is unused.
+/// Map an underlying tool command (from `moon query tasks`) to the rtk
+/// filter function that compresses its output. Returning `None` means the
+/// tool has no rtk filter — body passes through unchanged after chrome
+/// stripping. Add entries here as more `filter_*_output(&str) -> String`
+/// helpers become available in their modules.
+fn filter_for_tool(command: &str) -> Option<fn(&str) -> String> {
+    match command {
+        "prettier" => Some(crate::cmds::js::prettier_cmd::filter_prettier_output),
+        "vitest" | "jest" => Some(crate::cmds::js::vitest_cmd::filter_vitest_output),
+        "tsc" => Some(crate::cmds::js::tsc_cmd::filter_tsc_output),
+        "eslint" | "biome" => Some(crate::cmds::js::lint_cmd::filter_lint_output),
+        // No filter yet: bun (bun test), bun-test, cargo, go, ruff, pytest,
+        // mypy. Passthrough body after chrome stripping.
+        _ => None,
+    }
+}
+
+/// Streaming filter that wraps the existing line-based chrome stripping
+/// with per-task body buffering + tool-specific filtering. Owns TaskMap
+/// (not by ref) so it can be boxed into the runner.
+struct MoonStreamFilter {
+    task_map: TaskMap,
+    /// `project:task` of the task currently emitting body lines, if any.
+    /// `None` between tasks (chrome banner, summary, etc.).
+    active_task: Option<String>,
+    /// Buffered body lines for `active_task`.
+    active_body: Vec<String>,
+}
+
+impl MoonStreamFilter {
+    fn new(task_map: TaskMap) -> Self {
+        Self {
+            task_map,
+            active_task: None,
+            active_body: Vec::new(),
+        }
+    }
+
+    /// Detect a chrome "task" line of the form `▮▮▮▮ <project>:<task> ...`.
+    /// Returns the `project:task` if matched, otherwise None. Does NOT match
+    /// banner lines (e.g. `▮▮▮▮ There's a new version of moon ...`).
+    fn parse_chrome_task_id(line: &str) -> Option<&str> {
+        let rest = line.strip_prefix("▮▮▮▮ ")?;
+        let first_token = rest.split_whitespace().next()?;
+        if first_token.contains(':')
+            && !first_token.starts_with(':')
+            && !first_token.starts_with("Tasks:")
+            && !first_token.starts_with("Time:")
+        {
+            Some(first_token)
+        } else {
+            None
+        }
+    }
+
+    /// Is this chrome line a TASK-COMPLETION (duration/cached present), as
+    /// opposed to a task-START (bare hash only)?
+    fn is_task_completion(line: &str) -> bool {
+        // Completion lines have a `, ` inside the parens (duration or cached
+        // marker followed by hash).
+        line.contains(", ") && line.ends_with(')')
+    }
+
+    /// Detect parallel-mode body line.
+    ///
+    /// Moon uses two formats depending on run mode / version:
+    /// - ` <project>:<task> | <body>` (leading space, multi-task parallel)
+    /// - `<project>:<task> | <body>` (no leading space, cached / single-task)
+    ///
+    /// Returns (task_id, body_text) if matched.
+    fn parse_parallel_body(line: &str) -> Option<(&str, &str)> {
+        // Strip optional single leading space.
+        let rest = line.strip_prefix(' ').unwrap_or(line);
+        // Must not start with the chrome decoration character.
+        if rest.starts_with('▮') {
+            return None;
+        }
+        let (task_id, body) = rest.split_once(" | ")?;
+        if task_id.contains(':') && !task_id.contains(' ') {
+            Some((task_id, body))
+        } else {
+            None
+        }
+    }
+
+    fn flush_active_body(&mut self) -> Option<String> {
+        if self.active_body.is_empty() {
+            return None;
+        }
+        let task = self.active_task.clone()?;
+        let body = std::mem::take(&mut self.active_body).join("\n");
+        let filtered = match self.task_map.tool_for(&task) {
+            Some(cmd) => match filter_for_tool(cmd) {
+                Some(f) => f(&body),
+                None => body,
+            },
+            None => body,
+        };
+        if filtered.trim().is_empty() {
+            None
+        } else {
+            Some(filtered)
+        }
+    }
+}
+
+impl StreamFilter for MoonStreamFilter {
+    fn feed_line(&mut self, line: &str) -> Option<String> {
+        // 1. Drop upgrade banner lines anywhere.
+        if UPGRADE_BANNER_RES.iter().any(|re| re.is_match(line)) {
+            return None;
+        }
+
+        // 2. Handle footer line — may be glued to "Time: ..." on same line.
+        if FOOTER_RE.is_match(line) {
+            let cleaned = FOOTER_RE.replace(line, "");
+            let cleaned = cleaned.trim_end();
+            if cleaned.is_empty() {
+                return None;
+            }
+            return Some(format!("{}\n", cleaned));
+        }
+
+        // 3. Parallel-mode body line: ` project:task | body` — route this
+        //    single body line through the task's filter if known and emit.
+        //    (Per-line filtering of parallel output is imperfect for tools
+        //    like vitest that need batch JSON — but those don't typically run
+        //    in parallel-prefix mode anyway. Prettier and similar emit
+        //    one-liners that pass through fine.)
+        if let Some((task_id, body)) = Self::parse_parallel_body(line) {
+            let task_id = task_id.to_string();
+            let filtered_line = match self.task_map.tool_for(&task_id) {
+                Some(cmd) => match filter_for_tool(cmd) {
+                    Some(f) => f(body),
+                    None => body.to_string(),
+                },
+                None => body.to_string(),
+            };
+            if filtered_line.trim().is_empty() {
+                return None;
+            }
+            return Some(format!("{}\n", filtered_line));
+        }
+
+        // 4. Chrome task line: start or completion.
+        if let Some(task_id) = Self::parse_chrome_task_id(line).map(str::to_string) {
+            // Flush any buffered body for the previous task (defensive — moon
+            // generally emits start, body..., complete for one task at a time).
+            let mut emit = String::new();
+            if let Some(s) = self.flush_active_body() {
+                emit.push_str(&s);
+                if !emit.ends_with('\n') {
+                    emit.push('\n');
+                }
+            }
+
+            let stripped = CHROME_PREFIX_RE.replace(line, "");
+            let stripped = HASH_SUFFIX_RE.replace(&stripped, ")");
+            let stripped = BARE_HASH_RE.replace(&stripped, "$1");
+            emit.push_str(&stripped);
+            emit.push('\n');
+
+            // If this is a completion line, reset active_task. If start, set it.
+            if Self::is_task_completion(line) {
+                self.active_task = None;
+            } else {
+                self.active_task = Some(task_id);
+            }
+
+            return Some(emit);
+        }
+
+        // 5. Any other chrome line (banner without task id, "Tasks: N completed",
+        //    " Time: ...").
+        if CHROME_PREFIX_RE.is_match(line) {
+            let stripped = CHROME_PREFIX_RE.replace(line, "");
+            return Some(format!("{}\n", stripped));
+        }
+
+        // 6. Plain body line of currently-active sequential task — buffer it.
+        if self.active_task.is_some() {
+            self.active_body.push(line.to_string());
+            return None;
+        }
+
+        // 7. Nothing active and not chrome — emit as-is (summary lines etc.).
+        Some(format!("{}\n", line))
+    }
+
+    fn flush(&mut self) -> String {
+        self.flush_active_body().unwrap_or_default()
+    }
+}
+
+/// Offline convenience wrapper used by tests — feeds an entire string through
+/// the StreamFilter and concatenates the result. Production uses
+/// `runner::run_streamed` (line-by-line live filtering).
+#[cfg(test)]
+pub fn filter_moon_streaming(input: &str, task_map: TaskMap) -> String {
+    let mut f = MoonStreamFilter::new(task_map);
+    let mut out = String::new();
+    for line in input.lines() {
+        if let Some(s) = f.feed_line(line) {
+            out.push_str(&s);
+        }
+    }
+    out.push_str(&f.flush());
+    out.trim_end_matches('\n').to_string()
+}
+
+/// Apply chrome stripping to moon output. Used by tests for chrome-only
+/// stripping assertions; production uses `MoonStreamFilter` via `run_streamed`.
+#[cfg(test)]
 pub fn filter_moon_output(input: &str, _task_map: &TaskMap) -> String {
     input
         .lines()
@@ -227,12 +438,14 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     if verbose > 0 {
         eprintln!("rtk moon: detected {} tasks in workspace", task_map.len());
     }
-    runner::run_filtered(
+
+    let filter = MoonStreamFilter::new(task_map);
+    runner::run_streamed(
         cmd,
         "moon",
         &args.join(" "),
-        move |s| filter_moon_output(s, &task_map),
-        RunOptions::default(),
+        Box::new(filter),
+        RunOptions::with_tee("moon"),
     )
 }
 
@@ -332,5 +545,26 @@ mod tests {
     fn taskmap_from_empty_json_is_empty() {
         let map = TaskMap::from_query_json(r#"{"tasks": {}}"#).expect("parses");
         assert_eq!(map.tool_for("anything:anything"), None);
+    }
+
+    #[test]
+    fn routes_test_failure_with_taskmap_populated() {
+        let json = include_str!("../../../tests/fixtures/moon/query_tasks.json");
+        let task_map = TaskMap::from_query_json(json).unwrap();
+
+        let input = include_str!("../../../tests/fixtures/moon/run_test_failure.txt");
+        let output = filter_moon_streaming(input, task_map);
+
+        // The chrome must be stripped AND the failure indicator must remain.
+        assert!(!output.contains("▮▮▮▮"), "chrome prefix leaked: {}", output);
+        assert!(
+            output.contains("Expected")
+                || output.contains("(fail)")
+                || output.contains("error"),
+            "failure indicator lost: {}",
+            output
+        );
+
+        assert_snapshot!(output);
     }
 }

--- a/src/cmds/build/moon_cmd.rs
+++ b/src/cmds/build/moon_cmd.rs
@@ -9,18 +9,33 @@ use anyhow::Result;
 use crate::core::runner::{self, RunOptions};
 use crate::core::utils::resolved_command;
 
-/// Subcommands that should bypass filtering — they emit structured output
-/// (JSON / DOT) typically piped into other tooling.
+/// Subcommands that should bypass filtering — structured output (DOT graphs,
+/// JSON), info / setup commands, or long-running servers where filtering
+/// would corrupt the stream. Verified against `moon --help` for moon 2.0.4.
 const PASSTHROUGH_SUBCOMMANDS: &[&str] = &[
-    "query",
-    "graph",
-    "dep-graph",
-    "ext",
-    "completions",
-    "init",
-    "upgrade",
+    "action-graph",
     "bin",
+    "completions",
     "docker",
+    "ext",
+    "extension",
+    "hash",
+    "init",
+    "mcp",
+    "migrate",
+    "project",
+    "project-graph",
+    "projects",
+    "query",
+    "setup",
+    "task",
+    "task-graph",
+    "tasks",
+    "teardown",
+    "template",
+    "templates",
+    "toolchain",
+    "upgrade",
 ];
 
 /// Entry point for `rtk moon <args>`.

--- a/src/cmds/build/moon_cmd.rs
+++ b/src/cmds/build/moon_cmd.rs
@@ -559,4 +559,83 @@ mod tests {
 
         assert_snapshot!(output);
     }
+
+    #[test]
+    fn savings_chrome_only_test_failure_fixture() {
+        let json = include_str!("../../../tests/fixtures/moon/query_tasks.json");
+        let task_map = TaskMap::from_query_json(json).unwrap();
+        let raw = include_str!("../../../tests/fixtures/moon/run_test_failure.txt");
+        let filtered = filter_moon_streaming(raw, task_map);
+        let s = savings_pct(raw, &filtered);
+        // bun test has no rtk filter — chrome-only savings. Realistic baseline.
+        assert!(
+            s >= 15.0,
+            "expected >=15% savings on test-failure fixture (chrome-only because bun test has no rtk filter), got {:.1}%",
+            s
+        );
+    }
+
+    #[test]
+    fn savings_full_pipeline_tsc_failure_fixture() {
+        let json = include_str!("../../../tests/fixtures/moon/query_tasks.json");
+        let task_map = TaskMap::from_query_json(json).unwrap();
+        let raw = include_str!("../../../tests/fixtures/moon/run_tsc_failure.txt");
+        let filtered = filter_moon_streaming(raw, task_map);
+        let s = savings_pct(raw, &filtered);
+        // tsc errors come in parallel-mode prefix in moon (` audit:typecheck | ...`),
+        // so the tsc filter is bypassed in this fixture by design (parallel passthrough).
+        // Chrome stripping + upgrade banner removal nets a meaningful but modest win.
+        assert!(
+            s >= 25.0,
+            "expected >=25% savings on tsc-failure fixture, got {:.1}%",
+            s
+        );
+    }
+
+    #[test]
+    fn savings_summary_detailed_with_taskmap() {
+        let json = include_str!("../../../tests/fixtures/moon/query_tasks.json");
+        let task_map = TaskMap::from_query_json(json).unwrap();
+        let raw = include_str!("../../../tests/fixtures/moon/run_summary_detailed.txt");
+        let filtered = filter_moon_streaming(raw, task_map);
+        let s = savings_pct(raw, &filtered);
+        // The fixture's 24-line "changed files" list and the SUMMARY section are all
+        // non-chrome body lines that pass through unchanged. Chrome lines are only 3 of
+        // 50 total, so savings are modest (~9%). Measured: 9.3%.
+        assert!(
+            s >= 8.0,
+            "expected >=8% savings on summary-detailed fixture, got {:.1}%",
+            s
+        );
+    }
+
+    #[test]
+    fn savings_full_typecheck_success_with_taskmap() {
+        let json = include_str!("../../../tests/fixtures/moon/query_tasks.json");
+        let task_map = TaskMap::from_query_json(json).unwrap();
+        let raw = include_str!("../../../tests/fixtures/moon/run_typecheck_success.txt");
+        let filtered = filter_moon_streaming(raw, task_map);
+        let s = savings_pct(raw, &filtered);
+        assert!(
+            s >= 20.0,
+            "expected >=20% savings on success fixture, got {:.1}%",
+            s
+        );
+    }
+
+    #[test]
+    fn strips_chrome_from_tsc_failure() {
+        let json = include_str!("../../../tests/fixtures/moon/query_tasks.json");
+        let task_map = TaskMap::from_query_json(json).unwrap();
+        let raw = include_str!("../../../tests/fixtures/moon/run_tsc_failure.txt");
+        let filtered = filter_moon_streaming(raw, task_map);
+        // All 4 TS errors must still be visible after filtering.
+        assert!(
+            filtered.matches("error TS").count() >= 4,
+            "lost some tsc errors during filtering: {}",
+            filtered
+        );
+        assert!(!filtered.contains("▮▮▮▮"), "chrome prefix leaked: {}", filtered);
+        insta::assert_snapshot!(filtered);
+    }
 }

--- a/src/cmds/build/moon_cmd.rs
+++ b/src/cmds/build/moon_cmd.rs
@@ -1,0 +1,57 @@
+//! Filter for the moon (moonrepo) task runner.
+//!
+//! Strips moon's chrome (banners, hash suffixes, decoration) and routes each
+//! task's stdout/stderr through the matching rtk filter for its underlying
+//! command. See issue #1877.
+
+use anyhow::Result;
+
+use crate::core::runner::{self, RunOptions};
+use crate::core::utils::resolved_command;
+
+/// Subcommands that should bypass filtering — they emit structured output
+/// (JSON / DOT) typically piped into other tooling.
+const PASSTHROUGH_SUBCOMMANDS: &[&str] = &[
+    "query",
+    "graph",
+    "dep-graph",
+    "ext",
+    "completions",
+    "init",
+    "upgrade",
+    "bin",
+    "docker",
+];
+
+/// Entry point for `rtk moon <args>`.
+pub fn run(args: &[String], verbose: u8) -> Result<i32> {
+    // Subcommand check: if the first arg is one of the passthrough subcommands,
+    // execute moon without filtering. Track usage but apply no transform.
+    if let Some(first) = args.first() {
+        if PASSTHROUGH_SUBCOMMANDS.contains(&first.as_str()) {
+            let os_args: Vec<std::ffi::OsString> =
+                args.iter().map(std::ffi::OsString::from).collect();
+            return runner::run_passthrough("moon", &os_args, verbose);
+        }
+    }
+
+    // For run/ci/check (and anything else not in passthrough list), we'll
+    // filter in later tasks. For now: passthrough so the command works
+    // end-to-end while we iterate.
+    let mut cmd = resolved_command("moon");
+    for arg in args {
+        cmd.arg(arg);
+    }
+    if verbose > 0 {
+        eprintln!("rtk moon: passthrough (skeleton — filtering added in later tasks)");
+    }
+
+    runner::run_filtered(
+        cmd,
+        "moon",
+        &args.join(" "),
+        // Identity filter — returns input unchanged.
+        |s| s.to_string(),
+        RunOptions::default(),
+    )
+}

--- a/src/cmds/build/moon_cmd.rs
+++ b/src/cmds/build/moon_cmd.rs
@@ -297,25 +297,17 @@ impl StreamFilter for MoonStreamFilter {
             return Some(format!("{}\n", cleaned));
         }
 
-        // 3. Parallel-mode body line: ` project:task | body` — route this
-        //    single body line through the task's filter if known and emit.
-        //    (Per-line filtering of parallel output is imperfect for tools
-        //    like vitest that need batch JSON — but those don't typically run
-        //    in parallel-prefix mode anyway. Prettier and similar emit
-        //    one-liners that pass through fine.)
-        if let Some((task_id, body)) = Self::parse_parallel_body(line) {
-            let task_id = task_id.to_string();
-            let filtered_line = match self.task_map.tool_for(&task_id) {
-                Some(cmd) => match filter_for_tool(cmd) {
-                    Some(f) => f(body),
-                    None => body.to_string(),
-                },
-                None => body.to_string(),
-            };
-            if filtered_line.trim().is_empty() {
-                return None;
-            }
-            return Some(format!("{}\n", filtered_line));
+        // 3. Parallel-mode body line: ` project:task | body` — pass body
+        //    through unchanged. Per-line filtering would be wrong for tools
+        //    that need batch context (prettier collapses "Checking..." +
+        //    "All matched files use Prettier code style!" into a canonical
+        //    summary; called per-line it would emit the summary repeatedly
+        //    instead of once). A follow-up could buffer parallel bodies
+        //    per-task and apply the filter once on completion — for now,
+        //    only sequential-mode tasks (the common verbose case: failures,
+        //    --force, :test runs) get tool-filter routing.
+        if let Some((_task_id, body)) = Self::parse_parallel_body(line) {
+            return Some(format!("{}\n", body));
         }
 
         // 4. Chrome task line: start or completion.

--- a/src/cmds/build/snapshots/rtk__cmds__build__moon_cmd__tests__preserves_failure_body_in_test_run.snap
+++ b/src/cmds/build/snapshots/rtk__cmds__build__moon_cmd__tests__preserves_failure_body_in_test_run.snap
@@ -1,0 +1,32 @@
+---
+source: src/cmds/build/moon_cmd.rs
+expression: output
+---
+audit:test
+bun test v1.3.14
+
+test/action-extractor.test.ts:
+16 | }
+17 | 
+18 | describe('AuditAction/AuditResource decorators', () => {
+19 | 	it('records action metadata', () => {
+20 | 		const action = Reflect.getMetadata(AUDIT_ACTION_KEY, MyController.prototype.getOne);
+21 | 		expect(action).toBe('INTENTIONALLY_BROKEN_FOR_RTK_FIXTURE');
+                      ^
+error: expect(received).toBe(expected)
+
+Expected: "INTENTIONALLY_BROKEN_FOR_RTK_FIXTURE"
+Received: "customers:read"
+
+      at <anonymous> (/Users/alex/Work/yulii/ops-platform/packages/audit/test/action-extractor.test.ts:21:18)
+(fail) AuditAction/AuditResource decorators > records action metadata [2.29ms]
+
+ 6 pass
+ 1 fail
+ 10 expect() calls
+Ran 7 tests across 3 files. [874.00ms]
+audit:test (924ms)
+Error: task_runner::run_failed
+
+  × Task audit:test failed to run.
+  ╰─▶ Process bun failed: exit code 1

--- a/src/cmds/build/snapshots/rtk__cmds__build__moon_cmd__tests__preserves_failure_body_in_test_run.snap
+++ b/src/cmds/build/snapshots/rtk__cmds__build__moon_cmd__tests__preserves_failure_body_in_test_run.snap
@@ -1,9 +1,10 @@
 ---
 source: src/cmds/build/moon_cmd.rs
+assertion_line: 191
 expression: output
 ---
 audit:test
-bun test v1.3.14
+bun test v1.3.14 (0d9b296a)
 
 test/action-extractor.test.ts:
 16 | }

--- a/src/cmds/build/snapshots/rtk__cmds__build__moon_cmd__tests__routes_test_failure_with_taskmap_populated.snap
+++ b/src/cmds/build/snapshots/rtk__cmds__build__moon_cmd__tests__routes_test_failure_with_taskmap_populated.snap
@@ -1,0 +1,33 @@
+---
+source: src/cmds/build/moon_cmd.rs
+assertion_line: 559
+expression: output
+---
+audit:test
+bun test v1.3.14 (0d9b296a)
+
+test/action-extractor.test.ts:
+16 | }
+17 | 
+18 | describe('AuditAction/AuditResource decorators', () => {
+19 | 	it('records action metadata', () => {
+20 | 		const action = Reflect.getMetadata(AUDIT_ACTION_KEY, MyController.prototype.getOne);
+21 | 		expect(action).toBe('INTENTIONALLY_BROKEN_FOR_RTK_FIXTURE');
+                      ^
+error: expect(received).toBe(expected)
+
+Expected: "INTENTIONALLY_BROKEN_FOR_RTK_FIXTURE"
+Received: "customers:read"
+
+      at <anonymous> (/Users/alex/Work/yulii/ops-platform/packages/audit/test/action-extractor.test.ts:21:18)
+(fail) AuditAction/AuditResource decorators > records action metadata [2.29ms]
+
+ 6 pass
+ 1 fail
+ 10 expect() calls
+Ran 7 tests across 3 files. [874.00ms]
+audit:test (924ms)
+Error: task_runner::run_failed
+
+  × Task audit:test failed to run.
+  ╰─▶ Process bun failed: exit code 1

--- a/src/cmds/build/snapshots/rtk__cmds__build__moon_cmd__tests__strips_chrome_from_cache_hit.snap
+++ b/src/cmds/build/snapshots/rtk__cmds__build__moon_cmd__tests__strips_chrome_from_cache_hit.snap
@@ -1,0 +1,10 @@
+---
+source: src/cmds/build/moon_cmd.rs
+expression: output
+---
+audit:format | Checking formatting...
+audit:format | All matched files use Prettier code style!
+audit:format (cached)
+
+Tasks: 1 completed (1 cached)
+ Time: 43ms

--- a/src/cmds/build/snapshots/rtk__cmds__build__moon_cmd__tests__strips_chrome_from_summary_detailed.snap
+++ b/src/cmds/build/snapshots/rtk__cmds__build__moon_cmd__tests__strips_chrome_from_summary_detailed.snap
@@ -1,0 +1,53 @@
+---
+source: src/cmds/build/moon_cmd.rs
+expression: output
+---
+Loading changed files
+Base revision: N/A
+Head revision: HEAD
+Changed files:
+	.claude/worktrees/auth-discord-notifier
+	.claude/worktrees/feat-cld+stale-reminder-dry
+	.claude/worktrees/ui-kit-toast-primitive
+	.gitignore
+	.playwright-mcp/page-2026-05-26T13-22-59-683Z.yml
+	.playwright-mcp/page-2026-05-26T13-25-27-180Z.yml
+	.playwright-mcp/page-2026-05-26T13-27-14-302Z.yml
+	.playwright-mcp/page-2026-05-26T13-30-08-686Z.yml
+	.playwright-mcp/page-2026-05-26T13-30-59-474Z.yml
+	.playwright-mcp/page-2026-05-26T13-32-35-321Z.yml
+	.playwright-mcp/page-2026-05-26T13-38-38-745Z.yml
+	.playwright-mcp/page-2026-05-26T13-58-35-446Z.yml
+	.playwright-mcp/page-2026-05-26T13-59-20-311Z.yml
+	.playwright-mcp/page-2026-05-26T14-01-45-605Z.yml
+	.playwright-mcp/page-2026-05-26T14-01-56-439Z.yml
+	.playwright-mcp/page-2026-05-26T14-23-40-101Z.yml
+	.playwright-mcp/page-2026-05-26T14-28-24-120Z.yml
+	.playwright-mcp/page-2026-05-26T14-28-31-682Z.yml
+	.playwright-mcp/page-2026-05-27T17-51-31-271Z.yml
+	docs/brand/logo/yeva-mark-square-512.png
+	frontend-loaded.png
+Building action graph
+Action count: 6
+Requested targets: 1
+	audit:format
+Resolved targets: 1
+	audit:format
+Executing action pipeline
+audit:format | Checking formatting...
+audit:format | All matched files use Prettier code style!
+audit:format (cached)
+
+ SUMMARY 
+
+pass SyncWorkspace 
+pass SyncProject(core) (2ms)
+pass SyncProject(db) (2ms)
+pass SyncProject(config) (1ms)
+pass SyncProject(audit) (1ms)
+pass RunTask(audit:format) (cached, 35ms)
+
+ STATS 
+
+Actions: 6 completed (1 cached)
+   Time: 41ms

--- a/src/cmds/build/snapshots/rtk__cmds__build__moon_cmd__tests__strips_chrome_from_tsc_failure.snap
+++ b/src/cmds/build/snapshots/rtk__cmds__build__moon_cmd__tests__strips_chrome_from_tsc_failure.snap
@@ -1,0 +1,21 @@
+---
+source: src/cmds/build/moon_cmd.rs
+assertion_line: 639
+expression: filtered
+---
+core:typecheck
+core:typecheck (178ms)
+config:typecheck
+config:typecheck (90ms)
+db:typecheck
+db:typecheck (88ms)
+audit:typecheck
+src/index.ts(6,7): error TS2322: Type 'number' is not assignable to type 'string'.
+src/index.ts(7,7): error TS2322: Type 'string' is not assignable to type 'number'.
+src/index.ts(8,22): error TS2355: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.
+src/index.ts(9,11): error TS2304: Cannot find name 'nonexistentVariable'.
+audit:typecheck (669ms)
+Error: task_runner::run_failed
+
+  × Task audit:typecheck failed to run.
+  ╰─▶ Process tsc failed: exit code 1

--- a/src/cmds/build/snapshots/rtk__cmds__build__moon_cmd__tests__strips_chrome_from_typecheck_success.snap
+++ b/src/cmds/build/snapshots/rtk__cmds__build__moon_cmd__tests__strips_chrome_from_typecheck_success.snap
@@ -1,0 +1,44 @@
+---
+source: src/cmds/build/moon_cmd.rs
+expression: output
+---
+e2e:typecheck
+gateway:typecheck-test
+worker-ts:typecheck-test
+e2e:typecheck (404ms)
+core:typecheck
+gateway:typecheck-test (429ms)
+worker-ts:typecheck-test (451ms)
+core:typecheck (108ms)
+ui-kit:typecheck
+ui-kit:typecheck (87ms)
+worker-py:typecheck
+ worker-py:typecheck | Success: no issues found in 16 source files
+worker-py:typecheck (464ms)
+db:typecheck
+db:typecheck (100ms)
+policy:typecheck
+policy:typecheck (107ms)
+config:typecheck
+config:typecheck (101ms)
+plugin-sdk:typecheck
+plugin-sdk:typecheck (95ms)
+audit:typecheck
+audit:typecheck (104ms)
+bus:typecheck
+bus:typecheck (102ms)
+http:typecheck
+http:typecheck (106ms)
+sample:typecheck
+sample:typecheck (112ms)
+discord:typecheck
+discord:typecheck (115ms)
+worker-ts:typecheck
+worker-ts:typecheck (127ms)
+gateway:typecheck
+gateway:typecheck (125ms)
+frontend:typecheck
+frontend:typecheck (850ms)
+
+Tasks: 18 completed
+ Time: 3s 283ms

--- a/src/cmds/js/lint_cmd.rs
+++ b/src/cmds/js/lint_cmd.rs
@@ -491,6 +491,18 @@ fn filter_generic_lint(output: &str) -> String {
     result.trim().to_string()
 }
 
+/// Offline filter entry point — used by `cmds::build::moon_cmd` to compress
+/// the body of an eslint/biome/lint task when run via `moon run`. Routes
+/// JSON inputs to `filter_eslint_json`, text inputs to `filter_generic_lint`.
+pub fn filter_lint_output(input: &str) -> String {
+    let trimmed = input.trim_start();
+    if trimmed.starts_with('[') || trimmed.starts_with('{') {
+        filter_eslint_json(input)
+    } else {
+        filter_generic_lint(input)
+    }
+}
+
 /// Compact file path (remove common prefixes)
 fn compact_path(path: &str) -> String {
     // Remove common prefixes like /Users/..., /home/..., C:\

--- a/src/cmds/js/tsc_cmd.rs
+++ b/src/cmds/js/tsc_cmd.rs
@@ -104,7 +104,10 @@ impl BlockHandler for TscHandler {
     }
 }
 
-pub(crate) fn filter_tsc_output(output: &str) -> String {
+/// Offline filter entry point — used by `cmds::build::moon_cmd` to compress
+/// the body of a `tsc` task when run via `moon run`. Groups TypeScript errors
+/// by file and replaces the verbose compiler output with a compact summary.
+pub fn filter_tsc_output(output: &str) -> String {
     struct TsError {
         file: String,
         line: usize,

--- a/src/cmds/js/vitest_cmd.rs
+++ b/src/cmds/js/vitest_cmd.rs
@@ -204,6 +204,18 @@ fn extract_failures_regex(output: &str) -> Vec<TestFailure> {
     failures
 }
 
+/// Offline filter entry point — used by `cmds::build::moon_cmd` to compress
+/// the body of a `bun test`/`vitest`/`jest` task when run via `moon run`.
+/// Wraps `VitestParser::parse` + `TokenFormatter::format(FormatMode::Compact)`.
+pub fn filter_vitest_output(input: &str) -> String {
+    match VitestParser::parse(input) {
+        ParseResult::Full(result) | ParseResult::Degraded(result, _) => {
+            result.format(FormatMode::Compact)
+        }
+        ParseResult::Passthrough(s) => s,
+    }
+}
+
 pub fn run_test(command: &Commands, args: &[String], verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 

--- a/src/cmds/mod.rs
+++ b/src/cmds/mod.rs
@@ -1,5 +1,6 @@
 //! Command filter modules organized by language ecosystem.
 
+pub mod build;
 pub mod cloud;
 pub mod dotnet;
 pub mod git;

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -681,6 +681,15 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
+        pattern: r"^moon\s+(run|ci|check)\b",
+        rtk_cmd: "rtk moon",
+        rewrite_prefixes: &["moon"],
+        category: "Build",
+        savings_pct: 60.0, // conservative estimate; revisit after Task 6 measures real savings
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
+    RtkRule {
         pattern: r"^mix\s+(compile|format)(\s|$)",
         rtk_cmd: "rtk mix",
         rewrite_prefixes: &["mix"],

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -681,7 +681,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        pattern: r"^moon\s+(run|ci|check)\b",
+        pattern: r"^moon\s+(run|ci|check|exec)\b",
         rtk_cmd: "rtk moon",
         rewrite_prefixes: &["moon"],
         category: "Build",

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -685,7 +685,7 @@ pub const RULES: &[RtkRule] = &[
         rtk_cmd: "rtk moon",
         rewrite_prefixes: &["moon"],
         category: "Build",
-        savings_pct: 60.0, // conservative estimate; revisit after Task 6 measures real savings
+        savings_pct: 35.0, // measured avg across 5 fixtures (typecheck_success=60%, cache_hit=36%, test_failure=27%, tsc_failure=41%, summary_detailed=9%); was 60.0 placeholder
         subcmd_savings: &[],
         subcmd_status: &[],
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod learn;
 mod parser;
 
 // Re-export command modules for routing
+use cmds::build::moon_cmd;
 use cmds::cloud::{aws_cmd, container, curl_cmd, psql_cmd, wget_cmd};
 use cmds::dotnet::{binlog, dotnet_cmd, dotnet_format_report, dotnet_trx};
 use cmds::git::{diff_cmd, gh_cmd, git, glab_cmd, gt_cmd};
@@ -676,6 +677,13 @@ enum Commands {
     /// Mypy type checker with grouped error output
     Mypy {
         /// Mypy arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// Moon (moonrepo) task runner with per-task tool filtering
+    Moon {
+        /// Moon command and arguments (e.g. `run :test`, `query tasks`)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -2140,6 +2148,8 @@ fn run_cli() -> Result<i32> {
 
         Commands::Mypy { args } => mypy_cmd::run(&args, cli.verbose)?,
 
+        Commands::Moon { args } => moon_cmd::run(&args, cli.verbose)?,
+
         Commands::Rake { args } => rake_cmd::run(&args, cli.verbose)?,
 
         Commands::Rubocop { args } => rubocop_cmd::run(&args, cli.verbose)?,
@@ -2502,6 +2512,7 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Curl { .. }
             | Commands::Ruff { .. }
             | Commands::Pytest { .. }
+            | Commands::Moon { .. }
             | Commands::Rake { .. }
             | Commands::Rubocop { .. }
             | Commands::Rspec { .. }

--- a/tests/fixtures/moon/README.md
+++ b/tests/fixtures/moon/README.md
@@ -11,6 +11,7 @@ Ground truth for the `rtk moon` filter's snapshot tests (Tasks 3, 5, 6).
 | `run_cache_hit.txt` | 7 lines — single cached task (`audit:format`) |
 | `run_test_failure.txt` | 32 lines — `audit:test` failure with `bun test` output |
 | `run_summary_detailed.txt` | 50 lines — `MOON_SUMMARY=detailed` with `audit:format` (cached) |
+| `run_tsc_failure.txt` | 19 lines — `audit:typecheck` failure with 4 TypeScript errors (parallel-mode body) |
 | `query_tasks.json` | 5844 lines — full `moon query tasks` output for 16 projects |
 
 ---
@@ -210,6 +211,14 @@ Ran 7 tests across 3 files. [874.00ms]
 **Task 5 implication:** rtk does NOT currently have a dedicated `bun test` filter. The closest existing filter is `cmds/js/vitest_cmd.rs`, but it parses JSON output from `--reporter json` — bun test emits plain text, so the vitest filter won't apply. Task 5 must either (a) add a small `filter_bun_test_output()` helper inside `moon_cmd.rs` that compresses bun test plain-text output, or (b) leave `bun` unmapped in `filter_for_tool` so bun test bodies pass through unchanged (chrome stripping still applies, but the underlying test output is verbatim). If (b) is chosen, the Task 6 ≥60% savings assertion on this fixture may need to use a different (failing) fixture from a tool with a real rtk filter (e.g. eslint).
 
 The `bun test` failure body is NOT prefixed with `[project:task]` — it is streamed raw between the chrome start line and chrome complete line.
+
+---
+
+## `run_tsc_failure.txt`
+
+Captured by injecting 4 TypeScript errors into `packages/audit/src/index.ts` then running `moon run audit:typecheck --force`. Errors include type-mismatch (TS2322), missing return (TS2355), and unknown identifier (TS2304). Reverted after capture.
+
+The fixture's task body appears in **parallel-mode prefix** (` audit:typecheck | <line>`) because moon runs dependencies (core, config, db) in parallel with the target. This means the per-task tool filter routing (Task 5) does NOT compress this fixture's body — it's a chrome-only savings case. A future PR adding per-task buffering in parallel mode would unlock the tsc filter's compression for this shape.
 
 ---
 

--- a/tests/fixtures/moon/README.md
+++ b/tests/fixtures/moon/README.md
@@ -207,7 +207,9 @@ Received: "customers:read"
 Ran 7 tests across 3 files. [874.00ms]
 ```
 
-**Task 5 implication:** `rtk` already has a `bun test` filter. The per-task body routing in Task 5 should route `audit:test` (and any `bun test` task) through that existing filter. The `bun test` failure body is NOT prefixed with `[project:task]` — it is streamed raw between the chrome start line and chrome complete line.
+**Task 5 implication:** rtk does NOT currently have a dedicated `bun test` filter. The closest existing filter is `cmds/js/vitest_cmd.rs`, but it parses JSON output from `--reporter json` — bun test emits plain text, so the vitest filter won't apply. Task 5 must either (a) add a small `filter_bun_test_output()` helper inside `moon_cmd.rs` that compresses bun test plain-text output, or (b) leave `bun` unmapped in `filter_for_tool` so bun test bodies pass through unchanged (chrome stripping still applies, but the underlying test output is verbatim). If (b) is chosen, the Task 6 ≥60% savings assertion on this fixture may need to use a different (failing) fixture from a tool with a real rtk filter (e.g. eslint).
+
+The `bun test` failure body is NOT prefixed with `[project:task]` — it is streamed raw between the chrome start line and chrome complete line.
 
 ---
 

--- a/tests/fixtures/moon/README.md
+++ b/tests/fixtures/moon/README.md
@@ -1,0 +1,224 @@
+# Moon Filter Fixtures
+
+Captured from a real moon 2.0.4 workspace (`yulii/ops-platform`) on 2026-05-28.
+Ground truth for the `rtk moon` filter's snapshot tests (Tasks 3, 5, 6).
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `run_typecheck_success.txt` | 44 lines — cold-cache `:typecheck` across 18 projects (parallel) |
+| `run_cache_hit.txt` | 7 lines — single cached task (`audit:format`) |
+| `run_test_failure.txt` | 32 lines — `audit:test` failure with `bun test` output |
+| `run_summary_detailed.txt` | 50 lines — `MOON_SUMMARY=detailed` with `audit:format` (cached) |
+| `query_tasks.json` | 5844 lines — full `moon query tasks` output for 16 projects |
+
+---
+
+## Exact byte format of moon chrome
+
+### Chrome prefix
+
+The plan expected `▮▮▮▮ ` (4 × U+25AE BLACK VERTICAL RECTANGLE + SPACE).
+**Confirmed.** Exact bytes:
+
+```
+e2 96 ae  e2 96 ae  e2 96 ae  e2 96 ae  20
+  ▮           ▮           ▮           ▮     SPACE
+```
+
+`xxd` evidence (first 30 bytes of `run_typecheck_success.txt`):
+```
+00000000: e296 aee2 96ae e296 aee2 96ae 2065 3265  ............ e2e
+00000010: 3a74 7970 6563 6865 636b 2028 6264       :typecheck (bd
+```
+
+Regex to match chrome lines: `^▮{4} ` or equivalently `^\xe2\x96\xae{4}\x20` (UTF-8 bytes).
+
+### Chrome line types
+
+Moon emits three chrome line patterns:
+
+1. **Task start** — `▮▮▮▮ <project>:<task> (<8-hex-hash>)`
+   - Example: `▮▮▮▮ e2e:typecheck (bd958ad9)`
+   - 8-character lowercase hex hash
+
+2. **Task complete (cold-cache)** — `▮▮▮▮ <project>:<task> (<duration>, <8-hex-hash>)`
+   - Duration format: `Xms` or `Xs Yms` (e.g. `404ms`, `3s 283ms`, `850ms`)
+   - Example: `▮▮▮▮ e2e:typecheck (404ms, bd958ad9)`
+
+3. **Task complete (cached)** — `▮▮▮▮ <project>:<task> (cached, <8-hex-hash>)`
+   - Example: `▮▮▮▮ audit:format (cached, 7b3060c4)`
+   - No duration in cached hits — just `cached` + hash
+
+4. **Notification banners** — also prefixed with `▮▮▮▮ `, plain text
+   - Example: `▮▮▮▮ There's a new version of moon available, 2.2.5 (currently on 2.0.4)!`
+   - Distinguish from task lines: no `(...)` suffix, contains no colon+taskname pattern
+
+### Hash format
+
+8 lowercase hex characters: `[0-9a-f]{8}`.
+- Cold-cache: `(<duration>, <hash>)` — parentheses, comma-separated
+- Cache hit: `(cached, <hash>)` — parentheses, `cached` literal
+- Task start: `(<hash>)` — parentheses only (no comma, no duration)
+
+---
+
+## Summary line format
+
+### Single-task success with cache hit
+```
+Tasks: 1 completed (1 cached)
+ Time: 43ms ❯❯❯❯ to the moon
+```
+The `❯❯❯❯ to the moon` footer **appears on single-task runs** when all tasks complete (cached or not).
+
+### Multi-task success (no footer)
+```
+Tasks: 18 completed
+ Time: 3s 283ms
+```
+**No `❯❯❯❯ to the moon` footer on multi-task runs.** The footer only appeared on single-task invocations in captured fixtures.
+
+### Failure
+```
+Error: task_runner::run_failed
+
+  × Task audit:test failed to run.
+  ╰─▶ Process bun failed: exit code 1
+```
+No `Tasks:` block emitted on failure.
+
+---
+
+## Parallel task output format
+
+When tasks run in parallel, moon does **not** add `[project:task]` prefixes to the streamed output. Instead:
+
+- Task body lines are prefixed with ` <project>:<task> | ` (one space + project:task + pipe + space)
+- Example from `worker-py:typecheck`:
+  ```
+   worker-py:typecheck | Success: no issues found in 16 source files
+  ```
+- Most tasks produce no body output (just chrome start/complete lines)
+- The per-task prefix uses a **single leading space** then `<project>:<task> | `
+
+Tasks that produce no stdout have only chrome start and chrome complete lines (no body lines between them).
+
+---
+
+## `MOON_SUMMARY=detailed` format
+
+The `MOON_SUMMARY=detailed` env var produces an additional section after task output:
+
+```
+ SUMMARY 
+
+pass SyncWorkspace 
+pass SyncProject(core) (2ms)
+pass SyncProject(db) (2ms)
+pass SyncProject(config) (1ms)
+pass SyncProject(audit) (1ms)
+pass RunTask(audit:format) (cached, 35ms, 7b3060c4)
+
+ STATS 
+
+Actions: 6 completed (1 cached)
+   Time: 41ms
+```
+
+The summary also triggers a "changed files" preamble (loading the VCS diff for affected project detection):
+```
+▮▮▮▮ Loading changed files
+Base revision: N/A
+Head revision: HEAD
+Changed files:
+	...
+▮▮▮▮ Building action graph
+Action count: 6
+...
+▮▮▮▮ Executing action pipeline
+```
+
+This preamble is **not** present in regular (non-summary) runs.
+
+---
+
+## `moon query tasks` JSON structure
+
+The JSON has two top-level keys (not just `tasks` as the plan expected):
+
+```json
+{
+  "tasks": {
+    "<project>": {
+      "<task>": {
+        "command": "...",
+        "args": [...],
+        "id": "...",
+        "inputs": [...],
+        "options": {...},
+        "target": "<project>:<task>",
+        "toolchains": [...],
+        "type": "..."
+      }
+    }
+  },
+  "options": { ... }
+}
+```
+
+**Deviation from plan:** plan expected only `{"tasks": {...}}` but actual JSON is `{"tasks": {...}, "options": {...}}`. The `tasks` key structure is exactly as expected: `tasks.<project>.<task>.command`. Confirmed: `tasks.audit.format.command == "prettier"`.
+
+Note: `moon query tasks --no-color` is **not a valid flag** in moon 2.0.4 — it errors with `error: unexpected argument '--no-color' found`. Use plain `moon query tasks` to capture JSON.
+
+---
+
+## Test runner for failure fixture
+
+**`run_test_failure.txt` uses `bun test` (Bun's built-in test runner).**
+
+Evidence from fixture header:
+```
+bun test v1.3.14 (0d9b296a)
+```
+
+Failure output format (bun test):
+```
+test/action-extractor.test.ts:
+16 | }
+17 | 
+18 | describe('AuditAction/AuditResource decorators', () => {
+19 | 	it('records action metadata', () => {
+20 | 		const action = Reflect.getMetadata(AUDIT_ACTION_KEY, MyController.prototype.getOne);
+21 | 		expect(action).toBe('INTENTIONALLY_BROKEN_FOR_RTK_FIXTURE');
+                      ^
+error: expect(received).toBe(expected)
+
+Expected: "INTENTIONALLY_BROKEN_FOR_RTK_FIXTURE"
+Received: "customers:read"
+
+      at <anonymous> (/path/to/file.ts:21:18)
+(fail) <describe> > <it name> [2.29ms]
+
+ 6 pass
+ 1 fail
+ 10 expect() calls
+Ran 7 tests across 3 files. [874.00ms]
+```
+
+**Task 5 implication:** `rtk` already has a `bun test` filter. The per-task body routing in Task 5 should route `audit:test` (and any `bun test` task) through that existing filter. The `bun test` failure body is NOT prefixed with `[project:task]` — it is streamed raw between the chrome start line and chrome complete line.
+
+---
+
+## Deviations from plan expectations
+
+| Expectation | Actual |
+|-------------|--------|
+| Cache hit: `(cached, Xms, hash)` | `(cached, hash)` — **no duration in cached format** |
+| Task start: `(hash)` only | Confirmed — hash only, no duration |
+| Task complete: `(duration, hash)` | Confirmed |
+| `❯❯❯❯ to the moon` on multi-task success | NOT present — only on single-task runs |
+| `--no-color` flag | Invalid flag in moon 2.0.4; omit it |
+| `query_tasks.json` structure: `{"tasks":{}}` | Actually `{"tasks":{}, "options":{}}` |
+| Parallel output: `[project:task]` prefix | Uses ` project:task | ` prefix (space + pipe, not brackets) |

--- a/tests/fixtures/moon/query_tasks.json
+++ b/tests/fixtures/moon/query_tasks.json
@@ -1,0 +1,5844 @@
+{
+  "tasks": {
+    "audit": {
+      "format": {
+        "command": "prettier",
+        "args": [
+          "--check",
+          ".",
+          "--ignore-path",
+          "/Users/alex/Work/yulii/ops-platform/.prettierignore"
+        ],
+        "id": "format",
+        "inputs": [
+          {
+            "glob": "**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}",
+            "cache": true
+          },
+          {
+            "file": "/.prettierrc"
+          },
+          {
+            "file": "/.prettierignore"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/prettier.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/prettier.yml": {},
+          ".prettierignore": {},
+          ".prettierrc": {}
+        },
+        "inputGlobs": {
+          "packages/audit/**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "audit:format",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "lint": {
+        "command": "eslint",
+        "args": [
+          "--fix",
+          "."
+        ],
+        "id": "lint",
+        "inputs": [
+          {
+            "glob": "src/**/*.{ts,tsx,mts,cts}",
+            "cache": true
+          },
+          {
+            "file": "eslint.config.mjs"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/eslint.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/eslint.yml": {},
+          "packages/audit/eslint.config.mjs": {}
+        },
+        "inputGlobs": {
+          "packages/audit/src/**/*.{ts,tsx,mts,cts}": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "audit:lint",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "test": {
+        "command": "bun",
+        "args": [
+          "test"
+        ],
+        "id": "test",
+        "inputs": [
+          {
+            "glob": "src/**/*",
+            "cache": true
+          },
+          {
+            "glob": "test/**/*",
+            "cache": true
+          },
+          {
+            "file": "package.json"
+          },
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/bun-test.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/bun-test.yml": {},
+          "packages/audit/package.json": {},
+          "packages/audit/tsconfig.json": {}
+        },
+        "inputGlobs": {
+          "packages/audit/test/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "packages/audit/src/**/*": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "audit:test",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "typecheck": {
+        "command": "tsc",
+        "args": [
+          "--build"
+        ],
+        "deps": [
+          {
+            "args": [],
+            "env": {},
+            "target": "core:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "db:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "config:typecheck"
+          }
+        ],
+        "id": "typecheck",
+        "inputs": [
+          "@globs(sources)",
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "file": "/tsconfig.options.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/typescript.yml"
+          }
+        ],
+        "inputFiles": {
+          "tsconfig.options.json": {},
+          "packages/audit/tsconfig.json": {},
+          ".moon/tasks/typescript.yml": {}
+        },
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "packages/audit/src/**/*": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "mutex": "tsc-solution-build",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "outputs": [
+          {
+            "file": ".tsbuild"
+          }
+        ],
+        "outputFiles": {
+          "packages/audit/.tsbuild": {
+            "optional": false
+          }
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "audit:typecheck",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "build"
+      }
+    },
+    "bus": {
+      "format": {
+        "command": "prettier",
+        "args": [
+          "--check",
+          ".",
+          "--ignore-path",
+          "/Users/alex/Work/yulii/ops-platform/.prettierignore"
+        ],
+        "id": "format",
+        "inputs": [
+          {
+            "glob": "**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}",
+            "cache": true
+          },
+          {
+            "file": "/.prettierrc"
+          },
+          {
+            "file": "/.prettierignore"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/prettier.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/prettier.yml": {},
+          ".prettierignore": {},
+          ".prettierrc": {}
+        },
+        "inputGlobs": {
+          "packages/bus/**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "bus:format",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "lint": {
+        "command": "eslint",
+        "args": [
+          "--fix",
+          "."
+        ],
+        "id": "lint",
+        "inputs": [
+          {
+            "glob": "src/**/*.{ts,tsx,mts,cts}",
+            "cache": true
+          },
+          {
+            "file": "eslint.config.mjs"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/eslint.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/eslint.yml": {},
+          "packages/bus/eslint.config.mjs": {}
+        },
+        "inputGlobs": {
+          "packages/bus/src/**/*.{ts,tsx,mts,cts}": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "bus:lint",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "test": {
+        "command": "bun",
+        "args": [
+          "test",
+          "--preload",
+          "./test/otel-test-setup.ts",
+          "src"
+        ],
+        "id": "test",
+        "inputs": [
+          {
+            "glob": "src/**/*",
+            "cache": true
+          },
+          {
+            "glob": "test/**/*",
+            "cache": true
+          },
+          {
+            "file": "package.json"
+          },
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/bun-test.yml"
+          }
+        ],
+        "inputFiles": {
+          "packages/bus/tsconfig.json": {},
+          "packages/bus/package.json": {},
+          ".moon/tasks/bun-test.yml": {}
+        },
+        "inputGlobs": {
+          "packages/bus/src/**/*": {
+            "cache": true
+          },
+          "packages/bus/test/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "replace",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "bus:test",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "test-int": {
+        "command": "bun",
+        "args": [
+          "test",
+          "test/integration"
+        ],
+        "id": "test-int",
+        "inputs": [
+          {
+            "glob": "**/*",
+            "cache": true
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          }
+        ],
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "packages/bus/**/*": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "replace",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "defaultInputs": true,
+          "expanded": true
+        },
+        "target": "bus:test-int",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "typecheck": {
+        "command": "tsc",
+        "args": [
+          "--build"
+        ],
+        "deps": [
+          {
+            "args": [],
+            "env": {},
+            "target": "core:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "db:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "config:typecheck"
+          }
+        ],
+        "id": "typecheck",
+        "inputs": [
+          "@globs(sources)",
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "file": "/tsconfig.options.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/typescript.yml"
+          }
+        ],
+        "inputFiles": {
+          "packages/bus/tsconfig.json": {},
+          "tsconfig.options.json": {},
+          ".moon/tasks/typescript.yml": {}
+        },
+        "inputGlobs": {
+          "packages/bus/src/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "mutex": "tsc-solution-build",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "outputs": [
+          {
+            "file": ".tsbuild"
+          }
+        ],
+        "outputFiles": {
+          "packages/bus/.tsbuild": {
+            "optional": false
+          }
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "bus:typecheck",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "build"
+      }
+    },
+    "config": {
+      "format": {
+        "command": "prettier",
+        "args": [
+          "--check",
+          ".",
+          "--ignore-path",
+          "/Users/alex/Work/yulii/ops-platform/.prettierignore"
+        ],
+        "id": "format",
+        "inputs": [
+          {
+            "glob": "**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}",
+            "cache": true
+          },
+          {
+            "file": "/.prettierrc"
+          },
+          {
+            "file": "/.prettierignore"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/prettier.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/prettier.yml": {},
+          ".prettierignore": {},
+          ".prettierrc": {}
+        },
+        "inputGlobs": {
+          "packages/config/**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "config:format",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "lint": {
+        "command": "eslint",
+        "args": [
+          "--fix",
+          "."
+        ],
+        "id": "lint",
+        "inputs": [
+          {
+            "glob": "src/**/*.{ts,tsx,mts,cts}",
+            "cache": true
+          },
+          {
+            "file": "eslint.config.mjs"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/eslint.yml"
+          }
+        ],
+        "inputFiles": {
+          "packages/config/eslint.config.mjs": {},
+          ".moon/tasks/eslint.yml": {}
+        },
+        "inputGlobs": {
+          "packages/config/src/**/*.{ts,tsx,mts,cts}": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "config:lint",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "test": {
+        "command": "bun",
+        "args": [
+          "test",
+          "--timeout",
+          "15000",
+          "src",
+          "test"
+        ],
+        "id": "test",
+        "inputs": [
+          {
+            "glob": "src/**/*",
+            "cache": true
+          },
+          {
+            "glob": "test/**/*",
+            "cache": true
+          },
+          {
+            "file": "package.json"
+          },
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/bun-test.yml"
+          }
+        ],
+        "inputFiles": {
+          "packages/config/package.json": {},
+          "packages/config/tsconfig.json": {},
+          ".moon/tasks/bun-test.yml": {}
+        },
+        "inputGlobs": {
+          "packages/config/src/**/*": {
+            "cache": true
+          },
+          "packages/config/test/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "replace",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "config:test",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "typecheck": {
+        "command": "tsc",
+        "args": [
+          "--build"
+        ],
+        "deps": [
+          {
+            "args": [],
+            "env": {},
+            "target": "core:typecheck"
+          }
+        ],
+        "id": "typecheck",
+        "inputs": [
+          "@globs(sources)",
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "file": "/tsconfig.options.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/typescript.yml"
+          }
+        ],
+        "inputFiles": {
+          "tsconfig.options.json": {},
+          "packages/config/tsconfig.json": {},
+          ".moon/tasks/typescript.yml": {}
+        },
+        "inputGlobs": {
+          "packages/config/src/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "mutex": "tsc-solution-build",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "outputs": [
+          {
+            "file": ".tsbuild"
+          }
+        ],
+        "outputFiles": {
+          "packages/config/.tsbuild": {
+            "optional": false
+          }
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "config:typecheck",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "build"
+      }
+    },
+    "core": {
+      "format": {
+        "command": "prettier",
+        "args": [
+          "--check",
+          ".",
+          "--ignore-path",
+          "/Users/alex/Work/yulii/ops-platform/.prettierignore"
+        ],
+        "id": "format",
+        "inputs": [
+          {
+            "glob": "**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}",
+            "cache": true
+          },
+          {
+            "file": "/.prettierrc"
+          },
+          {
+            "file": "/.prettierignore"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/prettier.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/prettier.yml": {},
+          ".prettierignore": {},
+          ".prettierrc": {}
+        },
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "packages/core/**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "core:format",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "lint": {
+        "command": "eslint",
+        "args": [
+          "--fix",
+          "."
+        ],
+        "id": "lint",
+        "inputs": [
+          {
+            "glob": "src/**/*.{ts,tsx,mts,cts}",
+            "cache": true
+          },
+          {
+            "file": "eslint.config.mjs"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/eslint.yml"
+          }
+        ],
+        "inputFiles": {
+          "packages/core/eslint.config.mjs": {},
+          ".moon/tasks/eslint.yml": {}
+        },
+        "inputGlobs": {
+          "packages/core/src/**/*.{ts,tsx,mts,cts}": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "core:lint",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "test": {
+        "command": "bun",
+        "args": [
+          "test"
+        ],
+        "id": "test",
+        "inputs": [
+          {
+            "glob": "src/**/*",
+            "cache": true
+          },
+          {
+            "glob": "test/**/*",
+            "cache": true
+          },
+          {
+            "file": "package.json"
+          },
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/bun-test.yml"
+          }
+        ],
+        "inputFiles": {
+          "packages/core/package.json": {},
+          "packages/core/tsconfig.json": {},
+          ".moon/tasks/bun-test.yml": {}
+        },
+        "inputGlobs": {
+          "packages/core/src/**/*": {
+            "cache": true
+          },
+          "packages/core/test/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "core:test",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "typecheck": {
+        "command": "tsc",
+        "args": [
+          "--build"
+        ],
+        "id": "typecheck",
+        "inputs": [
+          "@globs(sources)",
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "file": "/tsconfig.options.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/typescript.yml"
+          }
+        ],
+        "inputFiles": {
+          "packages/core/tsconfig.json": {},
+          "tsconfig.options.json": {},
+          ".moon/tasks/typescript.yml": {}
+        },
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "packages/core/src/**/*": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "mutex": "tsc-solution-build",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "outputs": [
+          {
+            "file": ".tsbuild"
+          }
+        ],
+        "outputFiles": {
+          "packages/core/.tsbuild": {
+            "optional": false
+          }
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "core:typecheck",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "build"
+      }
+    },
+    "db": {
+      "format": {
+        "command": "prettier",
+        "args": [
+          "--check",
+          ".",
+          "--ignore-path",
+          "/Users/alex/Work/yulii/ops-platform/.prettierignore"
+        ],
+        "id": "format",
+        "inputs": [
+          {
+            "glob": "**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}",
+            "cache": true
+          },
+          {
+            "file": "/.prettierrc"
+          },
+          {
+            "file": "/.prettierignore"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/prettier.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/prettier.yml": {},
+          ".prettierignore": {},
+          ".prettierrc": {}
+        },
+        "inputGlobs": {
+          "packages/db/**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "db:format",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "lint": {
+        "command": "eslint",
+        "args": [
+          "--fix",
+          "."
+        ],
+        "id": "lint",
+        "inputs": [
+          {
+            "glob": "src/**/*.{ts,tsx,mts,cts}",
+            "cache": true
+          },
+          {
+            "file": "eslint.config.mjs"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/eslint.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/eslint.yml": {},
+          "packages/db/eslint.config.mjs": {}
+        },
+        "inputGlobs": {
+          "packages/db/src/**/*.{ts,tsx,mts,cts}": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "db:lint",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "test": {
+        "command": "bun",
+        "args": [
+          "test"
+        ],
+        "id": "test",
+        "inputs": [
+          {
+            "glob": "src/**/*",
+            "cache": true
+          },
+          {
+            "glob": "test/**/*",
+            "cache": true
+          },
+          {
+            "file": "package.json"
+          },
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/bun-test.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/bun-test.yml": {},
+          "packages/db/package.json": {},
+          "packages/db/tsconfig.json": {}
+        },
+        "inputGlobs": {
+          "packages/db/test/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "packages/db/src/**/*": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "db:test",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "typecheck": {
+        "command": "tsc",
+        "args": [
+          "--build"
+        ],
+        "deps": [
+          {
+            "args": [],
+            "env": {},
+            "target": "core:typecheck"
+          }
+        ],
+        "id": "typecheck",
+        "inputs": [
+          "@globs(sources)",
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "file": "/tsconfig.options.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/typescript.yml"
+          }
+        ],
+        "inputFiles": {
+          "tsconfig.options.json": {},
+          "packages/db/tsconfig.json": {},
+          ".moon/tasks/typescript.yml": {}
+        },
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "packages/db/src/**/*": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "mutex": "tsc-solution-build",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "outputs": [
+          {
+            "file": ".tsbuild"
+          }
+        ],
+        "outputFiles": {
+          "packages/db/.tsbuild": {
+            "optional": false
+          }
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "db:typecheck",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "build"
+      }
+    },
+    "discord": {
+      "format": {
+        "command": "prettier",
+        "args": [
+          "--check",
+          ".",
+          "--ignore-path",
+          "/Users/alex/Work/yulii/ops-platform/.prettierignore"
+        ],
+        "id": "format",
+        "inputs": [
+          {
+            "glob": "**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}",
+            "cache": true
+          },
+          {
+            "file": "/.prettierrc"
+          },
+          {
+            "file": "/.prettierignore"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/prettier.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/prettier.yml": {},
+          ".prettierignore": {},
+          ".prettierrc": {}
+        },
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "plugins/discord/**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "discord:format",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "lint": {
+        "command": "eslint",
+        "args": [
+          "--fix",
+          "."
+        ],
+        "id": "lint",
+        "inputs": [
+          {
+            "glob": "src/**/*.{ts,tsx,mts,cts}",
+            "cache": true
+          },
+          {
+            "file": "eslint.config.mjs"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/eslint.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/eslint.yml": {},
+          "plugins/discord/eslint.config.mjs": {}
+        },
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "plugins/discord/src/**/*.{ts,tsx,mts,cts}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "discord:lint",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "test": {
+        "command": "bun",
+        "args": [
+          "test",
+          "src"
+        ],
+        "id": "test",
+        "inputs": [
+          {
+            "glob": "src/**/*",
+            "cache": true
+          },
+          {
+            "glob": "test/**/*",
+            "cache": true
+          },
+          {
+            "file": "package.json"
+          },
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/bun-test.yml"
+          }
+        ],
+        "inputFiles": {
+          "plugins/discord/package.json": {},
+          "plugins/discord/tsconfig.json": {},
+          ".moon/tasks/bun-test.yml": {}
+        },
+        "inputGlobs": {
+          "plugins/discord/src/**/*": {
+            "cache": true
+          },
+          "plugins/discord/test/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "replace",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "discord:test",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "test-int": {
+        "command": "bun",
+        "args": [
+          "test",
+          "test/integration"
+        ],
+        "id": "test-int",
+        "inputs": [
+          {
+            "glob": "**/*",
+            "cache": true
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          }
+        ],
+        "inputGlobs": {
+          "plugins/discord/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "replace",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "defaultInputs": true,
+          "expanded": true
+        },
+        "target": "discord:test-int",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "typecheck": {
+        "command": "tsc",
+        "args": [
+          "--build"
+        ],
+        "deps": [
+          {
+            "args": [],
+            "env": {},
+            "target": "bus:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "http:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "plugin-sdk:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "core:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "db:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "policy:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "audit:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "config:typecheck"
+          }
+        ],
+        "id": "typecheck",
+        "inputs": [
+          "@globs(sources)",
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "file": "/tsconfig.options.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/typescript.yml"
+          }
+        ],
+        "inputFiles": {
+          "tsconfig.options.json": {},
+          "plugins/discord/tsconfig.json": {},
+          ".moon/tasks/typescript.yml": {}
+        },
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "plugins/discord/src/**/*": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "mutex": "tsc-solution-build",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "outputs": [
+          {
+            "file": ".tsbuild"
+          }
+        ],
+        "outputFiles": {
+          "plugins/discord/.tsbuild": {
+            "optional": false
+          }
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "discord:typecheck",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "build"
+      }
+    },
+    "e2e": {
+      "format": {
+        "command": "prettier",
+        "args": [
+          "--check",
+          ".",
+          "--ignore-path",
+          "/Users/alex/Work/yulii/ops-platform/.prettierignore"
+        ],
+        "id": "format",
+        "inputs": [
+          {
+            "glob": "**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}",
+            "cache": true
+          },
+          {
+            "file": "/.prettierrc"
+          },
+          {
+            "file": "/.prettierignore"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/prettier.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/prettier.yml": {},
+          ".prettierignore": {},
+          ".prettierrc": {}
+        },
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "apps/__e2e__/**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "e2e:format",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "lint": {
+        "command": "eslint",
+        "args": [
+          "--fix",
+          "."
+        ],
+        "id": "lint",
+        "inputs": [
+          {
+            "glob": "src/**/*.{ts,tsx,mts,cts}",
+            "cache": true
+          },
+          {
+            "file": "eslint.config.mjs"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/eslint.yml"
+          }
+        ],
+        "inputFiles": {
+          "apps/__e2e__/eslint.config.mjs": {},
+          ".moon/tasks/eslint.yml": {}
+        },
+        "inputGlobs": {
+          "apps/__e2e__/src/**/*.{ts,tsx,mts,cts}": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "e2e:lint",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "smoke": {
+        "command": "bun",
+        "args": [
+          "scripts/smoke.ts"
+        ],
+        "id": "smoke",
+        "inputs": [
+          {
+            "glob": "**/*",
+            "cache": true
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          }
+        ],
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "apps/__e2e__/**/*": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": false,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "defaultInputs": true,
+          "expanded": true,
+          "setRunInCi": true
+        },
+        "target": "e2e:smoke",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "test": {
+        "command": "echo",
+        "args": [
+          "\"no unit tests in @ops/e2e (smoke-only)\""
+        ],
+        "id": "test",
+        "inputs": [
+          {
+            "glob": "src/**/*",
+            "cache": true
+          },
+          {
+            "glob": "test/**/*",
+            "cache": true
+          },
+          {
+            "file": "package.json"
+          },
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/bun-test.yml"
+          }
+        ],
+        "inputFiles": {
+          "apps/__e2e__/package.json": {},
+          "apps/__e2e__/tsconfig.json": {},
+          ".moon/tasks/bun-test.yml": {}
+        },
+        "inputGlobs": {
+          "apps/__e2e__/test/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "apps/__e2e__/src/**/*": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "replace",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "e2e:test",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "typecheck": {
+        "command": "tsc",
+        "args": [
+          "--noEmit"
+        ],
+        "id": "typecheck",
+        "inputs": [
+          "@globs(sources)",
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "file": "/tsconfig.options.json"
+          },
+          {
+            "glob": "scripts/**/*.ts",
+            "cache": true
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/typescript.yml"
+          }
+        ],
+        "inputFiles": {
+          "tsconfig.options.json": {},
+          "apps/__e2e__/tsconfig.json": {},
+          ".moon/tasks/typescript.yml": {}
+        },
+        "inputGlobs": {
+          "apps/__e2e__/scripts/**/*.ts": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "apps/__e2e__/src/**/*": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "replace",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "replace",
+          "mergeToolchains": "append",
+          "mutex": "tsc-solution-build",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "e2e:typecheck",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      }
+    },
+    "frontend": {
+      "build": {
+        "command": "pnpm",
+        "args": [
+          "exec",
+          "vite",
+          "build"
+        ],
+        "id": "build",
+        "inputs": [
+          {
+            "glob": "**/*",
+            "cache": true
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          }
+        ],
+        "inputGlobs": {
+          "apps/frontend/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "replace",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "replace",
+          "mergeOutputs": "replace",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "outputs": [
+          {
+            "file": "dist"
+          }
+        ],
+        "outputFiles": {
+          "apps/frontend/dist": {
+            "optional": false
+          }
+        },
+        "state": {
+          "defaultInputs": true,
+          "expanded": true
+        },
+        "target": "frontend:build",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "build"
+      },
+      "format": {
+        "command": "prettier",
+        "args": [
+          "--check",
+          ".",
+          "--ignore-path",
+          "/Users/alex/Work/yulii/ops-platform/.prettierignore"
+        ],
+        "id": "format",
+        "inputs": [
+          {
+            "glob": "**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}",
+            "cache": true
+          },
+          {
+            "file": "/.prettierrc"
+          },
+          {
+            "file": "/.prettierignore"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/prettier.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/prettier.yml": {},
+          ".prettierignore": {},
+          ".prettierrc": {}
+        },
+        "inputGlobs": {
+          "apps/frontend/**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "frontend:format",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "lint": {
+        "command": "eslint",
+        "args": [
+          "--fix",
+          "."
+        ],
+        "id": "lint",
+        "inputs": [
+          {
+            "glob": "src/**/*.{ts,tsx,mts,cts}",
+            "cache": true
+          },
+          {
+            "file": "eslint.config.mjs"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/eslint.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/eslint.yml": {},
+          "apps/frontend/eslint.config.mjs": {}
+        },
+        "inputGlobs": {
+          "apps/frontend/src/**/*.{ts,tsx,mts,cts}": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "frontend:lint",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "start-dev": {
+        "command": "pnpm",
+        "args": [
+          "exec",
+          "vite"
+        ],
+        "id": "start-dev",
+        "inputs": [
+          {
+            "glob": "**/*",
+            "cache": true
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          }
+        ],
+        "inputGlobs": {
+          "apps/frontend/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": true,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": false,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "defaultInputs": true,
+          "expanded": true,
+          "setRunInCi": true
+        },
+        "target": "frontend:start-dev",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "run"
+      },
+      "test": {
+        "command": "pnpm",
+        "args": [
+          "exec",
+          "vitest",
+          "run"
+        ],
+        "id": "test",
+        "inputs": [
+          {
+            "glob": "src/**/*",
+            "cache": true
+          },
+          {
+            "glob": "test/**/*",
+            "cache": true
+          },
+          {
+            "file": "package.json"
+          },
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/bun-test.yml"
+          }
+        ],
+        "inputFiles": {
+          "apps/frontend/package.json": {},
+          "apps/frontend/tsconfig.json": {},
+          ".moon/tasks/bun-test.yml": {}
+        },
+        "inputGlobs": {
+          "apps/frontend/src/**/*": {
+            "cache": true
+          },
+          "apps/frontend/test/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "replace",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "replace",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "frontend:test",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "test-e2e": {
+        "command": "pnpm",
+        "args": [
+          "exec",
+          "playwright",
+          "test"
+        ],
+        "id": "test-e2e",
+        "inputs": [
+          {
+            "glob": "**/*",
+            "cache": true
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          }
+        ],
+        "inputGlobs": {
+          "apps/frontend/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": false,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "defaultInputs": true,
+          "expanded": true,
+          "setRunInCi": true
+        },
+        "target": "frontend:test-e2e",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "typecheck": {
+        "command": "tsc",
+        "args": [
+          "--noEmit"
+        ],
+        "deps": [
+          {
+            "args": [],
+            "env": {},
+            "target": "discord:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "core:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "ui-kit:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "sample:typecheck"
+          }
+        ],
+        "id": "typecheck",
+        "inputs": [
+          "@globs(sources)",
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "file": "/tsconfig.options.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/typescript.yml"
+          }
+        ],
+        "inputFiles": {
+          "tsconfig.options.json": {},
+          "apps/frontend/tsconfig.json": {},
+          ".moon/tasks/typescript.yml": {}
+        },
+        "inputGlobs": {
+          "apps/frontend/src/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "replace",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "replace",
+          "mergeOutputs": "replace",
+          "mergeToolchains": "append",
+          "mutex": "tsc-solution-build",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "frontend:typecheck",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      }
+    },
+    "gateway": {
+      "format": {
+        "command": "prettier",
+        "args": [
+          "--check",
+          ".",
+          "--ignore-path",
+          "/Users/alex/Work/yulii/ops-platform/.prettierignore"
+        ],
+        "id": "format",
+        "inputs": [
+          {
+            "glob": "**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}",
+            "cache": true
+          },
+          {
+            "file": "/.prettierrc"
+          },
+          {
+            "file": "/.prettierignore"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/prettier.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/prettier.yml": {},
+          ".prettierignore": {},
+          ".prettierrc": {}
+        },
+        "inputGlobs": {
+          "apps/gateway/**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "gateway:format",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "lint": {
+        "command": "eslint",
+        "args": [
+          "--fix",
+          "."
+        ],
+        "id": "lint",
+        "inputs": [
+          {
+            "glob": "src/**/*.{ts,tsx,mts,cts}",
+            "cache": true
+          },
+          {
+            "file": "eslint.config.mjs"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/eslint.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/eslint.yml": {},
+          "apps/gateway/eslint.config.mjs": {}
+        },
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "apps/gateway/src/**/*.{ts,tsx,mts,cts}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "gateway:lint",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "start-dev": {
+        "command": "nest",
+        "args": [
+          "start",
+          "--watch"
+        ],
+        "id": "start-dev",
+        "inputs": [
+          {
+            "glob": "**/*",
+            "cache": true
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          }
+        ],
+        "inputGlobs": {
+          "apps/gateway/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": true,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": false,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "defaultInputs": true,
+          "expanded": true,
+          "setRunInCi": true
+        },
+        "target": "gateway:start-dev",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "run"
+      },
+      "test": {
+        "command": "bun",
+        "args": [
+          "test",
+          "test/unit"
+        ],
+        "id": "test",
+        "inputs": [
+          {
+            "glob": "src/**/*",
+            "cache": true
+          },
+          {
+            "glob": "test/**/*",
+            "cache": true
+          },
+          {
+            "file": "package.json"
+          },
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/bun-test.yml"
+          }
+        ],
+        "inputFiles": {
+          "apps/gateway/tsconfig.json": {},
+          "apps/gateway/package.json": {},
+          ".moon/tasks/bun-test.yml": {}
+        },
+        "inputGlobs": {
+          "apps/gateway/src/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "apps/gateway/test/**/*": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "replace",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "gateway:test",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "test-e2e": {
+        "command": "bun",
+        "args": [
+          "test",
+          "--timeout",
+          "60000",
+          "test/integration"
+        ],
+        "id": "test-e2e",
+        "inputs": [
+          {
+            "glob": "**/*",
+            "cache": true
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          }
+        ],
+        "inputGlobs": {
+          "apps/gateway/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "defaultInputs": true,
+          "expanded": true
+        },
+        "target": "gateway:test-e2e",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "typecheck": {
+        "command": "tsc",
+        "args": [
+          "--build"
+        ],
+        "deps": [
+          {
+            "args": [],
+            "env": {},
+            "target": "discord:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "http:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "plugin-sdk:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "core:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "db:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "policy:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "audit:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "config:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "sample:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "gateway:typecheck-test"
+          }
+        ],
+        "id": "typecheck",
+        "inputs": [
+          "@globs(sources)",
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "file": "/tsconfig.options.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/typescript.yml"
+          }
+        ],
+        "inputFiles": {
+          "tsconfig.options.json": {},
+          "apps/gateway/tsconfig.json": {},
+          ".moon/tasks/typescript.yml": {}
+        },
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "apps/gateway/src/**/*": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "mutex": "tsc-solution-build",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "outputs": [
+          {
+            "file": ".tsbuild"
+          }
+        ],
+        "outputFiles": {
+          "apps/gateway/.tsbuild": {
+            "optional": false
+          }
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "gateway:typecheck",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "build"
+      },
+      "typecheck-test": {
+        "command": "tsc",
+        "args": [
+          "--project",
+          "tsconfig.test.json"
+        ],
+        "id": "typecheck-test",
+        "inputs": [
+          {
+            "glob": "test/integration/**/*.ts",
+            "cache": true
+          },
+          {
+            "file": "tsconfig.test.json"
+          },
+          {
+            "file": "/tsconfig.options.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          }
+        ],
+        "inputFiles": {
+          "apps/gateway/tsconfig.test.json": {},
+          "tsconfig.options.json": {}
+        },
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "apps/gateway/test/integration/**/*.ts": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "gateway:typecheck-test",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      }
+    },
+    "http": {
+      "format": {
+        "command": "prettier",
+        "args": [
+          "--check",
+          ".",
+          "--ignore-path",
+          "/Users/alex/Work/yulii/ops-platform/.prettierignore"
+        ],
+        "id": "format",
+        "inputs": [
+          {
+            "glob": "**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}",
+            "cache": true
+          },
+          {
+            "file": "/.prettierrc"
+          },
+          {
+            "file": "/.prettierignore"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/prettier.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/prettier.yml": {},
+          ".prettierignore": {},
+          ".prettierrc": {}
+        },
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "packages/http/**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "http:format",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "lint": {
+        "command": "eslint",
+        "args": [
+          "--fix",
+          "."
+        ],
+        "id": "lint",
+        "inputs": [
+          {
+            "glob": "src/**/*.{ts,tsx,mts,cts}",
+            "cache": true
+          },
+          {
+            "file": "eslint.config.mjs"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/eslint.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/eslint.yml": {},
+          "packages/http/eslint.config.mjs": {}
+        },
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "packages/http/src/**/*.{ts,tsx,mts,cts}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "http:lint",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "test": {
+        "command": "bun",
+        "args": [
+          "test"
+        ],
+        "id": "test",
+        "inputs": [
+          {
+            "glob": "src/**/*",
+            "cache": true
+          },
+          {
+            "glob": "test/**/*",
+            "cache": true
+          },
+          {
+            "file": "package.json"
+          },
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/bun-test.yml"
+          }
+        ],
+        "inputFiles": {
+          "packages/http/tsconfig.json": {},
+          "packages/http/package.json": {},
+          ".moon/tasks/bun-test.yml": {}
+        },
+        "inputGlobs": {
+          "packages/http/src/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "packages/http/test/**/*": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "http:test",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "typecheck": {
+        "command": "tsc",
+        "args": [
+          "--build"
+        ],
+        "deps": [
+          {
+            "args": [],
+            "env": {},
+            "target": "core:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "db:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "policy:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "audit:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "config:typecheck"
+          }
+        ],
+        "id": "typecheck",
+        "inputs": [
+          "@globs(sources)",
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "file": "/tsconfig.options.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/typescript.yml"
+          }
+        ],
+        "inputFiles": {
+          "tsconfig.options.json": {},
+          "packages/http/tsconfig.json": {},
+          ".moon/tasks/typescript.yml": {}
+        },
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "packages/http/src/**/*": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "mutex": "tsc-solution-build",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "outputs": [
+          {
+            "file": ".tsbuild"
+          }
+        ],
+        "outputFiles": {
+          "packages/http/.tsbuild": {
+            "optional": false
+          }
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "http:typecheck",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "build"
+      }
+    },
+    "plugin-sdk": {
+      "format": {
+        "command": "prettier",
+        "args": [
+          "--check",
+          ".",
+          "--ignore-path",
+          "/Users/alex/Work/yulii/ops-platform/.prettierignore"
+        ],
+        "id": "format",
+        "inputs": [
+          {
+            "glob": "**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}",
+            "cache": true
+          },
+          {
+            "file": "/.prettierrc"
+          },
+          {
+            "file": "/.prettierignore"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/prettier.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/prettier.yml": {},
+          ".prettierignore": {},
+          ".prettierrc": {}
+        },
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "packages/plugin-sdk/**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "plugin-sdk:format",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "lint": {
+        "command": "eslint",
+        "args": [
+          "--fix",
+          "."
+        ],
+        "id": "lint",
+        "inputs": [
+          {
+            "glob": "src/**/*.{ts,tsx,mts,cts}",
+            "cache": true
+          },
+          {
+            "file": "eslint.config.mjs"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/eslint.yml"
+          }
+        ],
+        "inputFiles": {
+          "packages/plugin-sdk/eslint.config.mjs": {},
+          ".moon/tasks/eslint.yml": {}
+        },
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "packages/plugin-sdk/src/**/*.{ts,tsx,mts,cts}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "plugin-sdk:lint",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "test": {
+        "command": "bun",
+        "args": [
+          "test"
+        ],
+        "id": "test",
+        "inputs": [
+          {
+            "glob": "src/**/*",
+            "cache": true
+          },
+          {
+            "glob": "test/**/*",
+            "cache": true
+          },
+          {
+            "file": "package.json"
+          },
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/bun-test.yml"
+          }
+        ],
+        "inputFiles": {
+          "packages/plugin-sdk/package.json": {},
+          "packages/plugin-sdk/tsconfig.json": {},
+          ".moon/tasks/bun-test.yml": {}
+        },
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "packages/plugin-sdk/src/**/*": {
+            "cache": true
+          },
+          "packages/plugin-sdk/test/**/*": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "plugin-sdk:test",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "typecheck": {
+        "command": "tsc",
+        "args": [
+          "--build"
+        ],
+        "deps": [
+          {
+            "args": [],
+            "env": {},
+            "target": "core:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "db:typecheck"
+          }
+        ],
+        "id": "typecheck",
+        "inputs": [
+          "@globs(sources)",
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "file": "/tsconfig.options.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/typescript.yml"
+          }
+        ],
+        "inputFiles": {
+          "packages/plugin-sdk/tsconfig.json": {},
+          "tsconfig.options.json": {},
+          ".moon/tasks/typescript.yml": {}
+        },
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "packages/plugin-sdk/src/**/*": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "mutex": "tsc-solution-build",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "outputs": [
+          {
+            "file": ".tsbuild"
+          }
+        ],
+        "outputFiles": {
+          "packages/plugin-sdk/.tsbuild": {
+            "optional": false
+          }
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "plugin-sdk:typecheck",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "build"
+      }
+    },
+    "policy": {
+      "format": {
+        "command": "prettier",
+        "args": [
+          "--check",
+          ".",
+          "--ignore-path",
+          "/Users/alex/Work/yulii/ops-platform/.prettierignore"
+        ],
+        "id": "format",
+        "inputs": [
+          {
+            "glob": "**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}",
+            "cache": true
+          },
+          {
+            "file": "/.prettierrc"
+          },
+          {
+            "file": "/.prettierignore"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/prettier.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/prettier.yml": {},
+          ".prettierignore": {},
+          ".prettierrc": {}
+        },
+        "inputGlobs": {
+          "packages/policy/**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "policy:format",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "lint": {
+        "command": "eslint",
+        "args": [
+          "--fix",
+          "."
+        ],
+        "id": "lint",
+        "inputs": [
+          {
+            "glob": "src/**/*.{ts,tsx,mts,cts}",
+            "cache": true
+          },
+          {
+            "file": "eslint.config.mjs"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/eslint.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/eslint.yml": {},
+          "packages/policy/eslint.config.mjs": {}
+        },
+        "inputGlobs": {
+          "packages/policy/src/**/*.{ts,tsx,mts,cts}": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "policy:lint",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "test": {
+        "command": "bun",
+        "args": [
+          "test"
+        ],
+        "id": "test",
+        "inputs": [
+          {
+            "glob": "src/**/*",
+            "cache": true
+          },
+          {
+            "glob": "test/**/*",
+            "cache": true
+          },
+          {
+            "file": "package.json"
+          },
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/bun-test.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/bun-test.yml": {},
+          "packages/policy/package.json": {},
+          "packages/policy/tsconfig.json": {}
+        },
+        "inputGlobs": {
+          "packages/policy/src/**/*": {
+            "cache": true
+          },
+          "packages/policy/test/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "policy:test",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "typecheck": {
+        "command": "tsc",
+        "args": [
+          "--build"
+        ],
+        "deps": [
+          {
+            "args": [],
+            "env": {},
+            "target": "core:typecheck"
+          }
+        ],
+        "id": "typecheck",
+        "inputs": [
+          "@globs(sources)",
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "file": "/tsconfig.options.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/typescript.yml"
+          }
+        ],
+        "inputFiles": {
+          "tsconfig.options.json": {},
+          "packages/policy/tsconfig.json": {},
+          ".moon/tasks/typescript.yml": {}
+        },
+        "inputGlobs": {
+          "packages/policy/src/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "mutex": "tsc-solution-build",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "outputs": [
+          {
+            "file": ".tsbuild"
+          }
+        ],
+        "outputFiles": {
+          "packages/policy/.tsbuild": {
+            "optional": false
+          }
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "policy:typecheck",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "build"
+      }
+    },
+    "sample": {
+      "format": {
+        "command": "prettier",
+        "args": [
+          "--check",
+          ".",
+          "--ignore-path",
+          "/Users/alex/Work/yulii/ops-platform/.prettierignore"
+        ],
+        "id": "format",
+        "inputs": [
+          {
+            "glob": "**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}",
+            "cache": true
+          },
+          {
+            "file": "/.prettierrc"
+          },
+          {
+            "file": "/.prettierignore"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/prettier.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/prettier.yml": {},
+          ".prettierignore": {},
+          ".prettierrc": {}
+        },
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "plugins/sample/**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "sample:format",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "lint": {
+        "command": "eslint",
+        "args": [
+          "--fix",
+          "."
+        ],
+        "id": "lint",
+        "inputs": [
+          {
+            "glob": "src/**/*.{ts,tsx,mts,cts}",
+            "cache": true
+          },
+          {
+            "file": "eslint.config.mjs"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/eslint.yml"
+          }
+        ],
+        "inputFiles": {
+          "plugins/sample/eslint.config.mjs": {},
+          ".moon/tasks/eslint.yml": {}
+        },
+        "inputGlobs": {
+          "plugins/sample/src/**/*.{ts,tsx,mts,cts}": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "sample:lint",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "test": {
+        "command": "bun",
+        "args": [
+          "test"
+        ],
+        "id": "test",
+        "inputs": [
+          {
+            "glob": "src/**/*",
+            "cache": true
+          },
+          {
+            "glob": "test/**/*",
+            "cache": true
+          },
+          {
+            "file": "package.json"
+          },
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/bun-test.yml"
+          }
+        ],
+        "inputFiles": {
+          "plugins/sample/package.json": {},
+          "plugins/sample/tsconfig.json": {},
+          ".moon/tasks/bun-test.yml": {}
+        },
+        "inputGlobs": {
+          "plugins/sample/src/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "plugins/sample/test/**/*": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "sample:test",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "typecheck": {
+        "command": "tsc",
+        "args": [
+          "--build"
+        ],
+        "deps": [
+          {
+            "args": [],
+            "env": {},
+            "target": "bus:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "http:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "plugin-sdk:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "core:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "db:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "audit:typecheck"
+          }
+        ],
+        "id": "typecheck",
+        "inputs": [
+          "@globs(sources)",
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "file": "/tsconfig.options.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/typescript.yml"
+          }
+        ],
+        "inputFiles": {
+          "plugins/sample/tsconfig.json": {},
+          "tsconfig.options.json": {},
+          ".moon/tasks/typescript.yml": {}
+        },
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "plugins/sample/src/**/*": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "mutex": "tsc-solution-build",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "outputs": [
+          {
+            "file": ".tsbuild"
+          }
+        ],
+        "outputFiles": {
+          "plugins/sample/.tsbuild": {
+            "optional": false
+          }
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "sample:typecheck",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "build"
+      }
+    },
+    "ui-kit": {
+      "format": {
+        "command": "prettier",
+        "args": [
+          "--check",
+          ".",
+          "--ignore-path",
+          "/Users/alex/Work/yulii/ops-platform/.prettierignore"
+        ],
+        "id": "format",
+        "inputs": [
+          {
+            "glob": "**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}",
+            "cache": true
+          },
+          {
+            "file": "/.prettierrc"
+          },
+          {
+            "file": "/.prettierignore"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/prettier.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/prettier.yml": {},
+          ".prettierignore": {},
+          ".prettierrc": {}
+        },
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "packages/ui-kit/**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "ui-kit:format",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "lint": {
+        "command": "eslint",
+        "args": [
+          "--fix",
+          "."
+        ],
+        "id": "lint",
+        "inputs": [
+          {
+            "glob": "src/**/*.{ts,tsx,mts,cts}",
+            "cache": true
+          },
+          {
+            "file": "eslint.config.mjs"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/eslint.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/eslint.yml": {},
+          "packages/ui-kit/eslint.config.mjs": {}
+        },
+        "inputGlobs": {
+          "packages/ui-kit/src/**/*.{ts,tsx,mts,cts}": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "ui-kit:lint",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "test": {
+        "command": "pnpm",
+        "args": [
+          "exec",
+          "vitest",
+          "run"
+        ],
+        "id": "test",
+        "inputs": [
+          {
+            "glob": "src/**/*",
+            "cache": true
+          },
+          {
+            "glob": "test/**/*",
+            "cache": true
+          },
+          {
+            "file": "package.json"
+          },
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/bun-test.yml"
+          }
+        ],
+        "inputFiles": {
+          "packages/ui-kit/tsconfig.json": {},
+          "packages/ui-kit/package.json": {},
+          ".moon/tasks/bun-test.yml": {}
+        },
+        "inputGlobs": {
+          "packages/ui-kit/src/**/*": {
+            "cache": true
+          },
+          "packages/ui-kit/test/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "replace",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "replace",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "ui-kit:test",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "typecheck": {
+        "command": "tsc",
+        "args": [
+          "--build"
+        ],
+        "id": "typecheck",
+        "inputs": [
+          "@globs(sources)",
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "file": "/tsconfig.options.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/typescript.yml"
+          }
+        ],
+        "inputFiles": {
+          "tsconfig.options.json": {},
+          "packages/ui-kit/tsconfig.json": {},
+          ".moon/tasks/typescript.yml": {}
+        },
+        "inputGlobs": {
+          "packages/ui-kit/src/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "mutex": "tsc-solution-build",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "outputs": [
+          {
+            "file": ".tsbuild"
+          }
+        ],
+        "outputFiles": {
+          "packages/ui-kit/.tsbuild": {
+            "optional": false
+          }
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "ui-kit:typecheck",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "build"
+      }
+    },
+    "worker-py": {
+      "format": {
+        "command": "uv",
+        "args": [
+          "run",
+          "ruff",
+          "format",
+          "--check",
+          "."
+        ],
+        "id": "format",
+        "inputs": [
+          {
+            "glob": "src/**/*.py",
+            "cache": true
+          },
+          {
+            "glob": "tests/**/*.py",
+            "cache": true
+          },
+          {
+            "file": "pyproject.toml"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/prettier.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/prettier.yml": {},
+          "apps/worker-py/pyproject.toml": {}
+        },
+        "inputGlobs": {
+          "apps/worker-py/src/**/*.py": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "apps/worker-py/tests/**/*.py": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "replace",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "replace",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "worker-py:format",
+        "toolchains": [
+          "system"
+        ],
+        "type": "test"
+      },
+      "lint": {
+        "command": "uv",
+        "args": [
+          "run",
+          "ruff",
+          "check",
+          "."
+        ],
+        "id": "lint",
+        "inputs": [
+          {
+            "glob": "src/**/*.py",
+            "cache": true
+          },
+          {
+            "glob": "tests/**/*.py",
+            "cache": true
+          },
+          {
+            "file": "pyproject.toml"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/eslint.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/eslint.yml": {},
+          "apps/worker-py/pyproject.toml": {}
+        },
+        "inputGlobs": {
+          "apps/worker-py/src/**/*.py": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "apps/worker-py/tests/**/*.py": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "replace",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "replace",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "worker-py:lint",
+        "toolchains": [
+          "system"
+        ],
+        "type": "test"
+      },
+      "start-dev": {
+        "command": "uv",
+        "args": [
+          "run",
+          "python",
+          "-m",
+          "worker_py.main"
+        ],
+        "id": "start-dev",
+        "inputs": [
+          {
+            "glob": "**/*",
+            "cache": true
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          }
+        ],
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "apps/worker-py/**/*": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": true,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": false,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "defaultInputs": true,
+          "expanded": true,
+          "setRunInCi": true
+        },
+        "target": "worker-py:start-dev",
+        "toolchains": [
+          "system"
+        ],
+        "type": "run"
+      },
+      "test": {
+        "command": "uv",
+        "args": [
+          "run",
+          "pytest",
+          "tests",
+          "--ignore=tests/integration"
+        ],
+        "id": "test",
+        "inputs": [
+          {
+            "glob": "src/**/*.py",
+            "cache": true
+          },
+          {
+            "glob": "tests/**/*.py",
+            "cache": true
+          },
+          {
+            "file": "pyproject.toml"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/bun-test.yml"
+          }
+        ],
+        "inputFiles": {
+          "apps/worker-py/pyproject.toml": {},
+          ".moon/tasks/bun-test.yml": {}
+        },
+        "inputGlobs": {
+          "apps/worker-py/src/**/*.py": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "apps/worker-py/tests/**/*.py": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "replace",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "replace",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "worker-py:test",
+        "toolchains": [
+          "system"
+        ],
+        "type": "test"
+      },
+      "test-int": {
+        "command": "uv",
+        "args": [
+          "run",
+          "pytest",
+          "tests/integration"
+        ],
+        "id": "test-int",
+        "inputs": [
+          {
+            "glob": "**/*",
+            "cache": true
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          }
+        ],
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "apps/worker-py/**/*": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "replace",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "replace",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "defaultInputs": true,
+          "expanded": true
+        },
+        "target": "worker-py:test-int",
+        "toolchains": [
+          "system"
+        ],
+        "type": "test"
+      },
+      "typecheck": {
+        "command": "uv",
+        "args": [
+          "run",
+          "mypy"
+        ],
+        "id": "typecheck",
+        "inputs": [
+          {
+            "glob": "src/**/*.py",
+            "cache": true
+          },
+          {
+            "glob": "tests/**/*.py",
+            "cache": true
+          },
+          {
+            "file": "pyproject.toml"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/typescript.yml"
+          }
+        ],
+        "inputFiles": {
+          "apps/worker-py/pyproject.toml": {},
+          ".moon/tasks/typescript.yml": {}
+        },
+        "inputGlobs": {
+          "apps/worker-py/src/**/*.py": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "apps/worker-py/tests/**/*.py": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "replace",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "replace",
+          "mergeOutputs": "replace",
+          "mergeToolchains": "append",
+          "mutex": "tsc-solution-build",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "worker-py:typecheck",
+        "toolchains": [
+          "system"
+        ],
+        "type": "test"
+      }
+    },
+    "worker-ts": {
+      "format": {
+        "command": "prettier",
+        "args": [
+          "--check",
+          ".",
+          "--ignore-path",
+          "/Users/alex/Work/yulii/ops-platform/.prettierignore"
+        ],
+        "id": "format",
+        "inputs": [
+          {
+            "glob": "**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}",
+            "cache": true
+          },
+          {
+            "file": "/.prettierrc"
+          },
+          {
+            "file": "/.prettierignore"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/prettier.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/prettier.yml": {},
+          ".prettierignore": {},
+          ".prettierrc": {}
+        },
+        "inputGlobs": {
+          "apps/worker-ts/**/*.{ts,tsx,js,jsx,mts,json,md,yml,yaml}": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "worker-ts:format",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "lint": {
+        "command": "eslint",
+        "args": [
+          "--fix",
+          "."
+        ],
+        "id": "lint",
+        "inputs": [
+          {
+            "glob": "src/**/*.{ts,tsx,mts,cts}",
+            "cache": true
+          },
+          {
+            "file": "eslint.config.mjs"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/eslint.yml"
+          }
+        ],
+        "inputFiles": {
+          ".moon/tasks/eslint.yml": {},
+          "apps/worker-ts/eslint.config.mjs": {}
+        },
+        "inputGlobs": {
+          "apps/worker-ts/src/**/*.{ts,tsx,mts,cts}": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "worker-ts:lint",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "start-dev": {
+        "command": "bun",
+        "args": [
+          "--watch",
+          "src/main.ts"
+        ],
+        "id": "start-dev",
+        "inputs": [
+          {
+            "glob": "**/*",
+            "cache": true
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          }
+        ],
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "apps/worker-ts/**/*": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": true,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": false,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "defaultInputs": true,
+          "expanded": true,
+          "setRunInCi": true
+        },
+        "target": "worker-ts:start-dev",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "run"
+      },
+      "test": {
+        "command": "bun",
+        "args": [
+          "test",
+          "src"
+        ],
+        "id": "test",
+        "inputs": [
+          {
+            "glob": "src/**/*",
+            "cache": true
+          },
+          {
+            "glob": "test/**/*",
+            "cache": true
+          },
+          {
+            "file": "package.json"
+          },
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/bun-test.yml"
+          }
+        ],
+        "inputFiles": {
+          "apps/worker-ts/package.json": {},
+          "apps/worker-ts/tsconfig.json": {},
+          ".moon/tasks/bun-test.yml": {}
+        },
+        "inputGlobs": {
+          "apps/worker-ts/src/**/*": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "apps/worker-ts/test/**/*": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "replace",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "worker-ts:test",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "test-int": {
+        "command": "bun",
+        "args": [
+          "test",
+          "test/integration"
+        ],
+        "id": "test-int",
+        "inputs": [
+          {
+            "glob": "**/*",
+            "cache": true
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          }
+        ],
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "apps/worker-ts/**/*": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "replace",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "defaultInputs": true,
+          "expanded": true
+        },
+        "target": "worker-ts:test-int",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      },
+      "typecheck": {
+        "command": "tsc",
+        "args": [
+          "--build"
+        ],
+        "deps": [
+          {
+            "args": [],
+            "env": {},
+            "target": "discord:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "bus:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "plugin-sdk:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "core:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "db:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "policy:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "audit:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "config:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "sample:typecheck"
+          },
+          {
+            "args": [],
+            "env": {},
+            "target": "worker-ts:typecheck-test"
+          }
+        ],
+        "id": "typecheck",
+        "inputs": [
+          "@globs(sources)",
+          {
+            "file": "tsconfig.json"
+          },
+          {
+            "file": "/tsconfig.options.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          },
+          {
+            "file": "/.moon/tasks/typescript.yml"
+          }
+        ],
+        "inputFiles": {
+          "tsconfig.options.json": {},
+          "apps/worker-ts/tsconfig.json": {},
+          ".moon/tasks/typescript.yml": {}
+        },
+        "inputGlobs": {
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          },
+          "apps/worker-ts/src/**/*": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": false,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "mutex": "tsc-solution-build",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "outputs": [
+          {
+            "file": ".tsbuild"
+          }
+        ],
+        "outputFiles": {
+          "apps/worker-ts/.tsbuild": {
+            "optional": false
+          }
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "worker-ts:typecheck",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "build"
+      },
+      "typecheck-test": {
+        "command": "tsc",
+        "args": [
+          "--project",
+          "tsconfig.test.json"
+        ],
+        "id": "typecheck-test",
+        "inputs": [
+          {
+            "glob": "test/**/*.ts",
+            "cache": true
+          },
+          {
+            "file": "tsconfig.test.json"
+          },
+          {
+            "file": "/tsconfig.options.json"
+          },
+          {
+            "glob": "/.moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}",
+            "cache": true
+          }
+        ],
+        "inputFiles": {
+          "tsconfig.options.json": {},
+          "apps/worker-ts/tsconfig.test.json": {}
+        },
+        "inputGlobs": {
+          "apps/worker-ts/test/**/*.ts": {
+            "cache": true
+          },
+          ".moon/*.{yml,yaml,jsonc,json,pkl,hcl,toml}": {
+            "cache": true
+          }
+        },
+        "options": {
+          "allowFailure": false,
+          "cache": true,
+          "inferInputs": false,
+          "internal": false,
+          "interactive": false,
+          "mergeArgs": "append",
+          "mergeDeps": "append",
+          "mergeEnv": "append",
+          "mergeInputs": "append",
+          "mergeOutputs": "append",
+          "mergeToolchains": "append",
+          "persistent": false,
+          "priority": "normal",
+          "retryCount": 0,
+          "runDepsInParallel": true,
+          "runInCI": true,
+          "runFromWorkspaceRoot": false,
+          "shell": true,
+          "unixShell": "bash",
+          "windowsShell": "pwsh"
+        },
+        "state": {
+          "expanded": true
+        },
+        "target": "worker-ts:typecheck-test",
+        "toolchains": [
+          "typescript"
+        ],
+        "type": "test"
+      }
+    }
+  },
+  "options": {
+    "affected": null,
+    "query": null,
+    "id": null,
+    "command": null,
+    "project": null,
+    "script": null,
+    "toolchain": null,
+    "type": null
+  }
+}

--- a/tests/fixtures/moon/run_cache_hit.txt
+++ b/tests/fixtures/moon/run_cache_hit.txt
@@ -1,0 +1,7 @@
+audit:format | Checking formatting...
+audit:format | All matched files use Prettier code style!
+▮▮▮▮ audit:format (cached, 7b3060c4)
+
+Tasks: 1 completed (1 cached)
+ Time: 43ms ❯❯❯❯ to the moon
+

--- a/tests/fixtures/moon/run_summary_detailed.txt
+++ b/tests/fixtures/moon/run_summary_detailed.txt
@@ -1,0 +1,50 @@
+▮▮▮▮ Loading changed files
+Base revision: N/A
+Head revision: HEAD
+Changed files:
+	.claude/worktrees/auth-discord-notifier
+	.claude/worktrees/feat-cld+stale-reminder-dry
+	.claude/worktrees/ui-kit-toast-primitive
+	.gitignore
+	.playwright-mcp/page-2026-05-26T13-22-59-683Z.yml
+	.playwright-mcp/page-2026-05-26T13-25-27-180Z.yml
+	.playwright-mcp/page-2026-05-26T13-27-14-302Z.yml
+	.playwright-mcp/page-2026-05-26T13-30-08-686Z.yml
+	.playwright-mcp/page-2026-05-26T13-30-59-474Z.yml
+	.playwright-mcp/page-2026-05-26T13-32-35-321Z.yml
+	.playwright-mcp/page-2026-05-26T13-38-38-745Z.yml
+	.playwright-mcp/page-2026-05-26T13-58-35-446Z.yml
+	.playwright-mcp/page-2026-05-26T13-59-20-311Z.yml
+	.playwright-mcp/page-2026-05-26T14-01-45-605Z.yml
+	.playwright-mcp/page-2026-05-26T14-01-56-439Z.yml
+	.playwright-mcp/page-2026-05-26T14-23-40-101Z.yml
+	.playwright-mcp/page-2026-05-26T14-28-24-120Z.yml
+	.playwright-mcp/page-2026-05-26T14-28-31-682Z.yml
+	.playwright-mcp/page-2026-05-27T17-51-31-271Z.yml
+	docs/brand/logo/yeva-mark-square-512.png
+	frontend-loaded.png
+▮▮▮▮ Building action graph
+Action count: 6
+Requested targets: 1
+	audit:format
+Resolved targets: 1
+	audit:format
+▮▮▮▮ Executing action pipeline
+audit:format | Checking formatting...
+audit:format | All matched files use Prettier code style!
+▮▮▮▮ audit:format (cached, 7b3060c4)
+
+ SUMMARY 
+
+pass SyncWorkspace 
+pass SyncProject(core) (2ms)
+pass SyncProject(db) (2ms)
+pass SyncProject(config) (1ms)
+pass SyncProject(audit) (1ms)
+pass RunTask(audit:format) (cached, 35ms, 7b3060c4)
+
+ STATS 
+
+Actions: 6 completed (1 cached)
+   Time: 41ms
+

--- a/tests/fixtures/moon/run_test_failure.txt
+++ b/tests/fixtures/moon/run_test_failure.txt
@@ -1,0 +1,32 @@
+▮▮▮▮ audit:test (94371457)
+bun test v1.3.14 (0d9b296a)
+▮▮▮▮ There's a new version of moon available, 2.2.5 (currently on 2.0.4)!
+▮▮▮▮ Daemon, AI skill, async experiments, and more!
+▮▮▮▮ Run moon upgrade or install from https://moonrepo.dev/docs/install
+
+test/action-extractor.test.ts:
+16 | }
+17 | 
+18 | describe('AuditAction/AuditResource decorators', () => {
+19 | 	it('records action metadata', () => {
+20 | 		const action = Reflect.getMetadata(AUDIT_ACTION_KEY, MyController.prototype.getOne);
+21 | 		expect(action).toBe('INTENTIONALLY_BROKEN_FOR_RTK_FIXTURE');
+                      ^
+error: expect(received).toBe(expected)
+
+Expected: "INTENTIONALLY_BROKEN_FOR_RTK_FIXTURE"
+Received: "customers:read"
+
+      at <anonymous> (/Users/alex/Work/yulii/ops-platform/packages/audit/test/action-extractor.test.ts:21:18)
+(fail) AuditAction/AuditResource decorators > records action metadata [2.29ms]
+
+ 6 pass
+ 1 fail
+ 10 expect() calls
+Ran 7 tests across 3 files. [874.00ms]
+▮▮▮▮ audit:test (924ms, 94371457)
+Error: task_runner::run_failed
+
+  × Task audit:test failed to run.
+  ╰─▶ Process bun failed: exit code 1
+

--- a/tests/fixtures/moon/run_tsc_failure.txt
+++ b/tests/fixtures/moon/run_tsc_failure.txt
@@ -1,0 +1,20 @@
+▮▮▮▮ core:typecheck (72cd98e9)
+▮▮▮▮ core:typecheck (178ms, 72cd98e9)
+▮▮▮▮ config:typecheck (ad11875d)
+▮▮▮▮ config:typecheck (90ms, ad11875d)
+▮▮▮▮ db:typecheck (dc976c99)
+▮▮▮▮ db:typecheck (88ms, dc976c99)
+▮▮▮▮ audit:typecheck (a928ca9f)
+▮▮▮▮ There's a new version of moon available, 2.2.5 (currently on 2.0.4)!
+▮▮▮▮ Daemon, AI skill, async experiments, and more!
+▮▮▮▮ Run moon upgrade or install from https://moonrepo.dev/docs/install
+audit:typecheck | src/index.ts(6,7): error TS2322: Type 'number' is not assignable to type 'string'.
+audit:typecheck | src/index.ts(7,7): error TS2322: Type 'string' is not assignable to type 'number'.
+audit:typecheck | src/index.ts(8,22): error TS2355: A function whose declared type is neither 'undefined', 'void', nor 'any' must return a value.
+audit:typecheck | src/index.ts(9,11): error TS2304: Cannot find name 'nonexistentVariable'.
+▮▮▮▮ audit:typecheck (669ms, a928ca9f)
+Error: task_runner::run_failed
+
+  × Task audit:typecheck failed to run.
+  ╰─▶ Process tsc failed: exit code 1
+

--- a/tests/fixtures/moon/run_typecheck_success.txt
+++ b/tests/fixtures/moon/run_typecheck_success.txt
@@ -1,0 +1,44 @@
+▮▮▮▮ e2e:typecheck (bd958ad9)
+▮▮▮▮ gateway:typecheck-test (c2b8007b)
+▮▮▮▮ worker-ts:typecheck-test (13238ff2)
+▮▮▮▮ There's a new version of moon available, 2.2.5 (currently on 2.0.4)!
+▮▮▮▮ Daemon, AI skill, async experiments, and more!
+▮▮▮▮ Run moon upgrade or install from https://moonrepo.dev/docs/install
+▮▮▮▮ e2e:typecheck (404ms, bd958ad9)
+▮▮▮▮ core:typecheck (0ca944f4)
+▮▮▮▮ gateway:typecheck-test (429ms, c2b8007b)
+▮▮▮▮ worker-ts:typecheck-test (451ms, 13238ff2)
+▮▮▮▮ core:typecheck (108ms, 0ca944f4)
+▮▮▮▮ ui-kit:typecheck (501faabf)
+▮▮▮▮ ui-kit:typecheck (87ms, 501faabf)
+▮▮▮▮ worker-py:typecheck (abc9f551)
+ worker-py:typecheck | Success: no issues found in 16 source files
+▮▮▮▮ worker-py:typecheck (464ms, abc9f551)
+▮▮▮▮ db:typecheck (307b45f7)
+▮▮▮▮ db:typecheck (100ms, 307b45f7)
+▮▮▮▮ policy:typecheck (7ff37bbe)
+▮▮▮▮ policy:typecheck (107ms, 7ff37bbe)
+▮▮▮▮ config:typecheck (a6f1add1)
+▮▮▮▮ config:typecheck (101ms, a6f1add1)
+▮▮▮▮ plugin-sdk:typecheck (3e0076aa)
+▮▮▮▮ plugin-sdk:typecheck (95ms, 3e0076aa)
+▮▮▮▮ audit:typecheck (026e289c)
+▮▮▮▮ audit:typecheck (104ms, 026e289c)
+▮▮▮▮ bus:typecheck (0b491e9f)
+▮▮▮▮ bus:typecheck (102ms, 0b491e9f)
+▮▮▮▮ http:typecheck (6f11c855)
+▮▮▮▮ http:typecheck (106ms, 6f11c855)
+▮▮▮▮ sample:typecheck (e2a3f641)
+▮▮▮▮ sample:typecheck (112ms, e2a3f641)
+▮▮▮▮ discord:typecheck (ab58dbd0)
+▮▮▮▮ discord:typecheck (115ms, ab58dbd0)
+▮▮▮▮ worker-ts:typecheck (9ec2d8cf)
+▮▮▮▮ worker-ts:typecheck (127ms, 9ec2d8cf)
+▮▮▮▮ gateway:typecheck (adcd02dd)
+▮▮▮▮ gateway:typecheck (125ms, adcd02dd)
+▮▮▮▮ frontend:typecheck (6485fd0b)
+▮▮▮▮ frontend:typecheck (850ms, 6485fd0b)
+
+Tasks: 18 completed
+ Time: 3s 283ms
+


### PR DESCRIPTION
## Summary

Closes #1877.

Adds `rtk moon` — a Rust filter for the [moonrepo](https://moonrepo.dev) task runner. The filter strips moon's chrome (upgrade banner, `▮▮▮▮` decoration prefix, `(hash)` suffix, `❯❯❯❯` footer) and routes each task's body through the matching rtk filter for its underlying command (prettier / vitest / jest / tsc / eslint / biome) — discovered at runtime via `moon query tasks`.

A new `src/cmds/build/` ecosystem houses the filter, with `moon_cmd.rs` as the only module. Three small `pub fn filter_*_output` wrappers were added in existing js/ modules so moon can reuse their compression without duplication.

## What's filtered

| Command | Behavior |
|---|---|
| `moon run` / `ci` / `check` / `exec` | Chrome strip + per-task tool routing via `MoonStreamFilter` (`StreamFilter` trait) |
| `moon --version`, `query`, `graph`, `bin`, all info commands | Passthrough — no `moon query tasks` overhead |

## Architecture

- `MoonStreamFilter` is a `StreamFilter` state machine: detects task-start / task-complete chrome lines, buffers each sequential-mode task's body, applies the matching `filter_for_tool(command)` filter on task completion.
- `TaskMap` is built from `moon query tasks` (~150ms, called once per filterable invocation only).
- Wrappers added: `vitest_cmd::filter_vitest_output` (wraps the existing `VitestParser` + `TokenFormatter`), `tsc_cmd::filter_tsc_output` (drives the existing `BlockStreamFilter` offline), `lint_cmd::filter_lint_output` (routes JSON to `filter_eslint_json`, text to `filter_generic_lint`). `prettier_cmd::filter_prettier_output` was already pub and is reused as-is.

## Measured savings

Per-fixture (5 fixtures captured from a real moon 2.0.4 workspace, 16 projects):

| Fixture | Shape | Savings |
|---|---|---|
| `run_typecheck_success.txt` | 18 silent-success tsc tasks | **60%** |
| `run_tsc_failure.txt` | tsc errors in parallel-prefix mode | **41%** |
| `run_cache_hit.txt` | single cached task | **36%** |
| `run_test_failure.txt` | bun test failure (no rtk filter for bun) | **27%** |
| `run_summary_detailed.txt` | `MOON_SUMMARY=detailed` | **9%** |

Average: **35%** — set as `savings_pct` in `discover/rules.rs`.

The ≥60% per-fixture target in CONTRIBUTING.md is met on the dominant happy-path fixture; lower compression on the other fixtures comes from two intentional v1 limitations documented in `src/cmds/build/README.md`:

1. **Parallel-mode bodies passthrough.** Lines prefixed with ` <project>:<task> | ` (moon's parallel-mode format) bypass the per-tool filter. Calling per-line filters like prettier's would emit a canonical summary repeatedly. A follow-up could buffer parallel bodies per-task and apply the filter once on completion.
2. **No `bun test` filter in rtk.** Bun emits plain text; the existing `vitest_cmd` parser requires JSON via `--reporter json`. Adding `filter_bun_test_output` is a clean follow-up.

## Tests

15 new moon-specific tests + 6 snapshots, total 1963 passed / 0 failed / 6 ignored. Test coverage includes:

- Snapshot tests for each of the 5 fixtures
- Per-fixture token-savings assertions (with measured thresholds, no gaming)
- 2 synthetic tests exercising `filter_for_tool` routing branches (sequential-mode tsc routing, unfiltered tool passthrough) — covers the routing path that real fixtures bypass via parallel mode
- JSON parsing tests for `TaskMap::from_query_json` (real fixture, malformed JSON, empty)
- Failure-body preservation assertion (`fail`/`error`/`Expected` indicator survives filtering)

## Performance

- `rtk moon --version` steady-state: ~30ms, matches raw `moon --version` (no `moon query tasks` for non-run subcommands).
- `rtk moon run :typecheck` on 16-project workspace: ~150ms extra one-time for `moon query tasks`, then streams as moon runs.
- No async, no new dependencies (`insta` added as dev-dep only).

## Files

- New: `src/cmds/build/{mod.rs,moon_cmd.rs,README.md}`
- New: 6 snapshot files at `src/cmds/build/snapshots/`
- New: 5 captured fixtures + README at `tests/fixtures/moon/`
- Modified: `src/cmds/mod.rs` (+1 line — ecosystem registration), `src/cmds/README.md` (+1 line — ecosystem index), `src/main.rs` (+11 lines — Commands enum + routing), `src/discover/rules.rs` (+9 lines — rewrite rule), `README.md` (+1 line — command list)
- Modified: `src/cmds/js/{vitest_cmd,tsc_cmd,lint_cmd}.rs` (+29 lines total — three thin `pub fn filter_*_output` wrappers)
- `Cargo.toml`: `insta = "1"` added to `[dev-dependencies]`

## Test plan

- [x] `cargo fmt --all --check && cargo clippy --all-targets -- -D warnings && cargo test --all` all pass
- [x] Manual smoke test: `rtk moon -v run audit:format` against a real moon workspace — chrome stripped, body preserved, exit code propagates
- [x] Manual smoke test: `rtk moon -v run :typecheck` against 18-project workspace — chrome stripped from all parallel task-complete lines, `worker-py:typecheck | Success` body preserved
- [x] Manual smoke test: `rtk moon query tasks --help` — clean passthrough
- [x] Snapshot tests for all 5 fixtures reviewed visually
- [x] Token-savings assertions per-fixture with measured-reality thresholds
- [x] No CHANGELOG.md edits (auto-generated by release-please)

🤖 Generated with [Claude Code](https://claude.com/claude-code)