### PR TITLE
feat: add ps, du, make as TOML-filtered proxy subcommands

### DIFF
--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -23,6 +23,9 @@
 ///   7. max_lines            — absolute line cap
 ///   8. on_empty             — message if result is empty
 use super::constants::{FILTERS_TOML, RTK_DATA_DIR};
+use crate::core::runner::{self, RunOptions};
+use crate::core::utils::resolved_command;
+use anyhow::Context;
 use lazy_static::lazy_static;
 use regex::{Regex, RegexSet};
 use serde::Deserialize;
@@ -681,6 +684,55 @@ pub fn find_matching_filter(command: &str) -> Option<&'static CompiledFilter> {
         }
     }
     result
+}
+
+// ---------------------------------------------------------------------------
+// TOML proxy — for commands with TOML filters but no custom Rust filter
+// ---------------------------------------------------------------------------
+
+/// Run a native command with its TOML filter applied.
+///
+/// Used by commands that have a TOML filter (`src/filters/<cmd>.toml`) but no
+/// custom Rust filter implementation.  This avoids the `run_fallback` path
+/// which wastes a Clap parse cycle and records a spurious parse failure.
+///
+/// Returns `Ok(exit_code)` or propagates execution errors.
+pub fn run_with_toml_filter(command: &str, args: &[String], verbose: u8) -> anyhow::Result<i32> {
+    let args_display = args.join(" ");
+
+    // Look up the TOML filter for this command
+    let lookup_cmd = std::iter::once(command)
+        .chain(args.iter().map(|s| s.as_str()))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let filter = find_matching_filter(&lookup_cmd).with_context(|| {
+        format!(
+            "No TOML filter found for '{}' — this command should not use run_with_toml_filter",
+            command
+        )
+    })?;
+
+    if verbose > 0 {
+        eprintln!(
+            "Running: {} {} (toml filter: {})",
+            command, args_display, filter.name
+        );
+    }
+
+    // Build and execute the native command
+    let mut cmd = resolved_command(command);
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    runner::run_filtered(
+        cmd,
+        command,
+        &args_display,
+        move |stdout| apply_filter(filter, stdout),
+        RunOptions::stdout_only(),
+    )
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -400,6 +400,27 @@ enum Commands {
         args: Vec<String>,
     },
 
+    /// Process list with compact output (TOML-filtered proxy to native ps)
+    Ps {
+        /// Arguments passed to ps (supports all native ps flags like -aux, -ef)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// Disk usage with compact output (TOML-filtered proxy to native du)
+    Du {
+        /// Arguments passed to du (supports all native du flags like -sh, -h)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// Build automation with compact output (TOML-filtered proxy to native make)
+    Make {
+        /// Arguments passed to make (supports all native make flags and targets)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
     /// Show token savings summary and history
     Gain {
         /// Filter statistics to current project (current working directory) // added
@@ -1233,7 +1254,8 @@ fn run_fallback(parse_error: clap::Error) -> Result<i32> {
                     &combined_raw,
                     &filtered,
                 );
-                core::tracking::record_parse_failure_silent(&raw_command, &error_message, true);
+                // Don't record as parse failure — the TOML filter handled it successfully.
+                // Parse failures are only meaningful when the command actually failed.
 
                 Ok(exit_code)
             }
@@ -1906,6 +1928,12 @@ fn run_cli() -> Result<i32> {
 
         Commands::Wc { args } => wc_cmd::run(&args, cli.verbose)?,
 
+        Commands::Ps { args } => core::toml_filter::run_with_toml_filter("ps", &args, cli.verbose)?,
+        Commands::Du { args } => core::toml_filter::run_with_toml_filter("du", &args, cli.verbose)?,
+        Commands::Make { args } => {
+            core::toml_filter::run_with_toml_filter("make", &args, cli.verbose)?
+        }
+
         Commands::Gain {
             project, // added
             graph,
@@ -2509,6 +2537,10 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Go { .. }
             | Commands::GolangciLint { .. }
             | Commands::Gt { .. }
+            | Commands::Wc { .. }
+            | Commands::Ps { .. }
+            | Commands::Du { .. }
+            | Commands::Make { .. }
     )
 }
 


### PR DESCRIPTION
## Problem

Issue #1604 Problem 3: The hook rewrites commands like `ps`, `du`, `make` to `rtk ps`, `rtk du`, `rtk make`, but these have no corresponding `Commands` enum variants. This causes:

1. Wasted Clap parse cycle (always fails)
2. Falls through to `run_fallback()` which records a spurious `parse_failure`
3. Extra overhead for commands that already have working TOML filters

## Solution

- **Add `Ps`, `Du`, `Make` as proper `Commands` variants** with `trailing_var_arg` pattern (same as `Wc`)
- **Add `run_with_toml_filter()` generic helper** in `toml_filter.rs` — reusable for any future TOML-only command
- **Remove `record_parse_failure_silent`** from the TOML branch of `run_fallback` — successful TOML filtering is not a parse failure
- **Add to `is_operational_command`** whitelist (also added `Wc` which was missing)

## Testing

- `cargo fmt --all` ✓
- `cargo clippy --all-targets` ✓ (zero warnings)
- `cargo test --all` ✓ (1946 passed, 0 failed)
- `rtk ps aux` — filtered process list, no stderr
- `rtk du -sh .` — filtered disk usage, no stderr
- `rtk make --version` — filtered version info, no stderr
- `rtk wc -l Cargo.toml` — existing command unaffected
- `rtk curl --version` — fallback path still works