### PR TITLE
fix(discover): rewrite dotnet test/restore/format, not just build

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -2337,6 +2337,30 @@ mod tests {
     }
 
     #[test]
+    fn test_rewrite_dotnet_subcommands() {
+        // All four subcommands have dedicated `rtk dotnet` proxies, so the rewrite
+        // rule must route them (issue #1830 — only `build` was covered before).
+        for sub in ["build", "test", "restore", "format"] {
+            assert_eq!(
+                rewrite_command_no_prefixes(&format!("dotnet {}", sub), &[]),
+                Some(format!("rtk dotnet {}", sub)),
+                "dotnet {} should rewrite",
+                sub
+            );
+        }
+        // Trailing args are preserved (the \b stops at the subcommand).
+        assert_eq!(
+            rewrite_command_no_prefixes("dotnet test --filter Category=Unit", &[]),
+            Some("rtk dotnet test --filter Category=Unit".into())
+        );
+        // Subcommands without a proxy must NOT be rewritten.
+        assert_eq!(rewrite_command_no_prefixes("dotnet publish", &[]), None);
+        assert_eq!(rewrite_command_no_prefixes("dotnet run", &[]), None);
+        // Word boundary guards against false prefixes.
+        assert_eq!(rewrite_command_no_prefixes("dotnet builder", &[]), None);
+    }
+
+    #[test]
     fn test_rewrite_compound_and() {
         assert_eq!(
             rewrite_command_no_prefixes("git add . && cargo test", &[]),

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -2338,8 +2338,8 @@ mod tests {
 
     #[test]
     fn test_rewrite_dotnet_subcommands() {
-        // All four subcommands have dedicated `rtk dotnet` proxies, so the rewrite
-        // rule must route them (issue #1830 — only `build` was covered before).
+        // All four subcommands have dedicated `rtk dotnet` proxies, so the
+        // rewrite rule must route them.
         for sub in ["build", "test", "restore", "format"] {
             assert_eq!(
                 rewrite_command_no_prefixes(&format!("dotnet {}", sub), &[]),

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -695,7 +695,7 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
-        pattern: r"^dotnet\s+build\b",
+        pattern: r"^dotnet\s+(build|test|restore|format)\b",
         rtk_cmd: "rtk dotnet",
         rewrite_prefixes: &["dotnet"],
         category: "Build",


### PR DESCRIPTION
## Summary

- `rtk dotnet test`, `rtk dotnet restore`, and `rtk dotnet format` proxies already exist and route to dedicated handlers, but `rtk rewrite` only matched `dotnet build` — so the Claude Code hook silently passed the other three through unfiltered. Fixes #1830.

## Root cause

The `dotnet` rewrite rule in `src/discover/rules.rs` used `pattern: r"^dotnet\s+build\b"`, covering only `build`. `DotnetCommands::Test/Restore/Format` all dispatch to real handlers (`src/main.rs:1709-1711`), so the proxies work when invoked directly — only the rewrite registry was missing them.

## Fix

Widen the rule's pattern to `^dotnet\s+(build|test|restore|format)\b`. The output filters already handle all four; this is purely a routing fix (one regex).

## Tests

- `test_rewrite_dotnet_subcommands` — all four rewrite to `rtk dotnet <sub>`; `dotnet publish` / `dotnet run` (no proxy) are left untouched.
- Full suite: 1947 passed, clippy clean, `cargo fmt --check` clean.

## Manual verification

```
dotnet build    -> rtk dotnet build
dotnet test     -> rtk dotnet test
dotnet restore  -> rtk dotnet restore
dotnet format   -> rtk dotnet format
dotnet publish  -> (not rewritten)
```

## Scope

Only the four subcommands with existing proxies. `dotnet build` and the three new subcommands now share one rule and behave identically (same permission verdict / exit code). The exit-code (ask vs auto-allow) is governed by a separate permission layer and is unchanged by this routing fix.