### PR TITLE
fix(cicd): scope semgrep filesystem-deletion rule to exclude src/hooks/

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -101,6 +101,9 @@ rules:
       - pattern: fs::remove_dir_all(...)
       - pattern: std::fs::remove_file(...)
       - pattern: std::fs::remove_dir_all(...)
+    paths:
+      exclude:
+        - src/hooks/
     message: >
       File/directory deletion detected. Expected in hooks/init cleanup,
       surprising in a filter module. Verify intent.


### PR DESCRIPTION
## Summary

- The `filesystem-deletion` semgrep rule has no `paths:` scoping, so it flags `src/hooks/` even though its own message says deletion is *"Expected in hooks/init cleanup"*. Fixes #1954.

## Root cause

`.semgrep.yml` rule `filesystem-deletion` matches `fs::remove_file(...)` / `remove_dir_all(...)` repo-wide. CI runs `semgrep scan --config .semgrep.yml --baseline-commit <base> --error`, so any PR adding a *new* deletion to `src/hooks/init.rs` (e.g. a new agent's uninstall path) produces a fresh finding and fails the scan — a guaranteed false positive for every future agent-uninstall PR (e.g. Pi support #1741). The existing ~10 deletions in `init.rs` only pass because they predate the baseline.

## Fix

Add `paths.exclude: src/hooks/` to the rule, so it flags deletions in filter modules (the surprising case) but not in the hooks/init cleanup code (the expected case).

## Verification (semgrep before/after)

Ran `semgrep scan --config .semgrep.yml` locally:

| Target | Before (no exclude) | After (exclude src/hooks/) |
|---|---|---|
| `src/hooks/init.rs` | **10** findings | **0** |
| whole `src/hooks/` | (flagged) | **0** |
| `src/core/tee.rs` (filter module) | 1 | **1** (still flagged) |

The rule still catches deletions outside `src/hooks/`, confirming the exclude isn't over-broad.

## Scope

Config-only, 3 lines. No Rust changes, so no unit test applies — the behavior is verified by the semgrep runs above. Does not touch any other rule.