### PR TITLE
docs: Change 'cursor' to 'agent cursor' in init command

### DIFF
--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -61,7 +61,7 @@ rtk init --show    # shows hook status
 ### Cursor
 
 ```bash
-rtk init --global --cursor
+rtk init --global --agent cursor
 ```
 
 Restart Cursor. The hook uses `preToolUse` with Cursor's `updated_input` format.


### PR DESCRIPTION
Updated the command for initializing Cursor agent.

## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

- `--cursor` isn't recognised as a command `--agent cursor `install the hooks correctly

## Test plan
<!-- How did you verify this works? -->

- [N/A] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [X] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
