### PR TITLE
fix: non-ASCII / UTF-8 robustness (git filenames, gain truncation, proxy capture)

### DIFF
--- a/src/analytics/gain.rs
+++ b/src/analytics/gain.rs
@@ -246,11 +246,9 @@ pub fn run(
                 println!("──────────────────────────────────────────────────────────");
                 for rec in recent {
                     let time = rec.timestamp.with_timezone(&Local).format("%m-%d %H:%M");
-                    let cmd_short = if rec.rtk_cmd.len() > 25 {
-                        format!("{}...", &rec.rtk_cmd[..22])
-                    } else {
-                        rec.rtk_cmd.clone()
-                    };
+                    // char-safe truncation: commands may contain multibyte UTF-8,
+                    // and slicing on a byte boundary would panic
+                    let cmd_short = crate::core::utils::truncate(&rec.rtk_cmd, 25);
                     // added: tier indicators by savings level
                     let sign = if rec.savings_pct >= 70.0 {
                         "▲"
@@ -707,11 +705,8 @@ fn show_failures(tracker: &Tracker) -> Result<()> {
         println!("{}", styled("Top Commands (by frequency)", true));
         println!("{}", "─".repeat(60));
         for (cmd, count) in &summary.top_commands {
-            let cmd_display = if cmd.len() > 50 {
-                format!("{}...", &cmd[..47])
-            } else {
-                cmd.clone()
-            };
+            // char-safe truncation: avoid panicking when a command contains multibyte UTF-8
+            let cmd_display = crate::core::utils::truncate(cmd, 50);
             println!("  {:>4}x  {}", count, cmd_display);
         }
         println!();
@@ -727,11 +722,8 @@ fn show_failures(tracker: &Tracker) -> Result<()> {
                 &rec.timestamp
             };
             let status = if rec.fallback_succeeded { "ok" } else { "FAIL" };
-            let cmd_display = if rec.raw_command.len() > 40 {
-                format!("{}...", &rec.raw_command[..37])
-            } else {
-                rec.raw_command.clone()
-            };
+            // char-safe truncation: avoid panicking when a command contains multibyte UTF-8
+            let cmd_display = crate::core::utils::truncate(&rec.raw_command, 40);
             println!("  {} [{}] {}", ts_short, status, cmd_display);
         }
         println!();

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -31,6 +31,10 @@ pub enum GitCommand {
 /// prepended before any subcommand arguments.
 fn git_cmd(global_args: &[String]) -> Command {
     let mut cmd = resolved_command("git");
+    // Render non-ASCII (CJK, etc.) filenames as UTF-8 instead of git's default
+    // octal escapes (\nnn). Must be injected with -c before the subcommand;
+    // global_args and the subcommand are appended after.
+    cmd.arg("-c").arg("core.quotepath=false");
     for arg in global_args {
         cmd.arg(arg);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2431,8 +2431,8 @@ fn run_cli() -> Result<i32> {
                 .join()
                 .map_err(|_| anyhow::anyhow!("stderr streaming thread panicked"))??;
 
-            let stdout = String::from_utf8_lossy(&stdout_bytes);
-            let stderr = String::from_utf8_lossy(&stderr_bytes);
+            let stdout = decode_captured(&stdout_bytes);
+            let stderr = decode_captured(&stderr_bytes);
             let full_output = format!("{}{}", stdout, stderr);
 
             // Track usage (input = output since no filtering)
@@ -2473,6 +2473,22 @@ fn run_cli() -> Result<i32> {
     };
 
     Ok(code)
+}
+
+/// Decode captured streaming bytes into a string. `captured` is truncated at a
+/// 1 MiB cap, so its tail may stop in the middle of a multibyte UTF-8 sequence;
+/// in that case decode only up to the valid boundary to avoid emitting a
+/// spurious trailing replacement char (U+FFFD). Genuinely invalid mid-stream
+/// bytes (e.g. binary output) keep the lossy behavior.
+fn decode_captured(bytes: &[u8]) -> std::borrow::Cow<'_, str> {
+    match std::str::from_utf8(bytes) {
+        Ok(s) => std::borrow::Cow::Borrowed(s),
+        // error_len() == None means the error is an unexpected end of input (an
+        // incomplete trailing sequence cut off by the cap), so take the valid
+        // prefix only; Some(_) means an invalid byte mid-stream, so stay lossy.
+        Err(e) if e.error_len().is_none() => String::from_utf8_lossy(&bytes[..e.valid_up_to()]),
+        Err(_) => String::from_utf8_lossy(bytes),
+    }
 }
 
 /// Returns true for commands that are invoked via the hook pipeline


### PR DESCRIPTION
Three small, independent fixes for handling non-ASCII (CJK and other multibyte UTF-8) text. Each is in its own commit.

## 1. `git`: non-ASCII filenames shown as octal escapes
Git escapes non-ASCII path bytes as octal `\nnn` by default (`core.quotepath=true`), and rtk passed that through unchanged.

```
# before
$ rtk git status
?? "\345\214\205\350\243\271\347\260\275\346\224\266\346\270\205\345\226\256.txt"
# after
$ rtk git status
?? 包裹簽收清單.txt
```

Affects `git status`, `git log --name-only`, `git diff --stat`, etc. Fix injects `-c core.quotepath=false` at the single `git_cmd()` chokepoint. No effect on ASCII paths.

## 2. `gain`: byte-index slicing can panic on multibyte input
`gain --history` and the failure summary truncated command strings with `&cmd[..47]` / `&rec.rtk_cmd[..22]` / `&rec.raw_command[..37]`. A command containing multibyte UTF-8 (a non-ASCII search pattern, a non-ASCII commit message, etc.) can land the cut mid-codepoint and panic. Switched to the existing char-safe `utils::truncate()`.

## 3. `proxy`: spurious replacement char at the 1 MiB capture cap
The proxy streaming path caps the captured copy at 1 MiB. When the cap lands inside a multibyte sequence, `from_utf8_lossy` appended a trailing `U+FFFD` to the tracked output. `decode_captured()` trims an incomplete trailing sequence while preserving lossy behavior for genuinely invalid mid-stream bytes. (User-facing stdout was already byte-exact; this only affected the captured copy used for tracking.)

## Testing
`cargo build --release` clean. Verified before/after on a repo with CJK filenames and commit messages for #1; `gain --history` no longer panics for #2.