### PR TITLE
docs(hooks): add "reading the full output" to agent instructions

### DIFF
--- a/hooks/antigravity/rules.md
+++ b/hooks/antigravity/rules.md
@@ -30,3 +30,15 @@ rtk proxy <cmd>       # Run raw (no filtering, for debugging)
 ## Why
 
 RTK filters and compresses command output before it reaches the LLM context, saving 60-90% tokens on common operations. Always use `rtk <cmd>` instead of raw commands.
+
+## Reading the full output
+
+RTK output is a filtered summary — for most commands it keeps what matters
+(test failures, panics, and build errors are preserved). When you need the
+complete, unfiltered output to confirm a claim (tests really passed, build is
+really clean) rather than skim it, get the raw output instead of trusting the
+summary:
+
+- Run `rtk proxy <cmd>` to re-run the command with no filtering.
+- Or, when the filtered output ends with `[full output: <path>]`, read that
+  file directly — it is the complete, unfiltered log already on disk.

--- a/hooks/claude/rtk-awareness.md
+++ b/hooks/claude/rtk-awareness.md
@@ -26,4 +26,16 @@ which rtk             # Verify correct binary
 All other commands are automatically rewritten by the Claude Code hook.
 Example: `git status` → `rtk git status` (transparent, 0 tokens overhead)
 
-Refer to CLAUDE.md for full command reference.
+## Reading the full output
+
+RTK output is a filtered summary — for most commands it keeps what matters
+(test failures, panics, and build errors are preserved). When you need the
+complete, unfiltered output to confirm a claim (tests really passed, build is
+really clean) rather than skim it, get the raw output instead of trusting the
+summary:
+
+- Run `rtk proxy <cmd>` to re-run the command with no filtering.
+- Or, when the filtered output ends with `[full output: <path>]`, read that
+  file directly — it is the complete, unfiltered log already on disk.
+
+Run `rtk --help` for the full command reference.

--- a/hooks/cline/rules.md
+++ b/hooks/cline/rules.md
@@ -30,3 +30,15 @@ rtk proxy <cmd>       # Run raw (no filtering, for debugging)
 ## Why
 
 RTK filters and compresses command output before it reaches the LLM context, saving 60-90% tokens on common operations. Always use `rtk <cmd>` instead of raw commands.
+
+## Reading the full output
+
+RTK output is a filtered summary — for most commands it keeps what matters
+(test failures, panics, and build errors are preserved). When you need the
+complete, unfiltered output to confirm a claim (tests really passed, build is
+really clean) rather than skim it, get the raw output instead of trusting the
+summary:
+
+- Run `rtk proxy <cmd>` to re-run the command with no filtering.
+- Or, when the filtered output ends with `[full output: <path>]`, read that
+  file directly — it is the complete, unfiltered log already on disk.

--- a/hooks/codex/rtk-awareness.md
+++ b/hooks/codex/rtk-awareness.md
@@ -30,3 +30,15 @@ rtk --version
 rtk gain
 which rtk
 ```
+
+## Reading the full output
+
+RTK output is a filtered summary — for most commands it keeps what matters
+(test failures, panics, and build errors are preserved). When you need the
+complete, unfiltered output to confirm a claim (tests really passed, build is
+really clean) rather than skim it, get the raw output instead of trusting the
+summary:
+
+- Run `rtk proxy <cmd>` to re-run the command with no filtering.
+- Or, when the filtered output ends with `[full output: <path>]`, read that
+  file directly — it is the complete, unfiltered log already on disk.

--- a/hooks/copilot/rtk-awareness.md
+++ b/hooks/copilot/rtk-awareness.md
@@ -58,3 +58,15 @@ When Copilot CLI adds `updatedInput` support, only `rtk hook` needs updating —
 | GitHub Copilot CLI    | `PreToolUse` deny-with-suggestion       | Denial + retry           | `.github/hooks/rtk-rewrite.json`   |
 | OpenCode              | Plugin `tool.execute.before`            | Transparent rewrite      | `hooks/opencode-rtk.ts`            |
 | (any)                 | Custom instructions                     | Prompt-level guidance    | `.github/copilot-instructions.md`  |
+
+## Reading the full output
+
+RTK output is a filtered summary — for most commands it keeps what matters
+(test failures, panics, and build errors are preserved). When you need the
+complete, unfiltered output to confirm a claim (tests really passed, build is
+really clean) rather than skim it, get the raw output instead of trusting the
+summary:
+
+- Run `rtk proxy <cmd>` to re-run the command with no filtering.
+- Or, when the filtered output ends with `[full output: <path>]`, read that
+  file directly — it is the complete, unfiltered log already on disk.

--- a/hooks/kilocode/rules.md
+++ b/hooks/kilocode/rules.md
@@ -30,3 +30,15 @@ rtk proxy <cmd>       # Run raw (no filtering, for debugging)
 ## Why
 
 RTK filters and compresses command output before it reaches the LLM context, saving 60-90% tokens on common operations. Always use `rtk <cmd>` instead of raw commands.
+
+## Reading the full output
+
+RTK output is a filtered summary — for most commands it keeps what matters
+(test failures, panics, and build errors are preserved). When you need the
+complete, unfiltered output to confirm a claim (tests really passed, build is
+really clean) rather than skim it, get the raw output instead of trusting the
+summary:
+
+- Run `rtk proxy <cmd>` to re-run the command with no filtering.
+- Or, when the filtered output ends with `[full output: <path>]`, read that
+  file directly — it is the complete, unfiltered log already on disk.

--- a/hooks/windsurf/rules.md
+++ b/hooks/windsurf/rules.md
@@ -30,3 +30,15 @@ rtk proxy <cmd>       # Run raw (no filtering, for debugging)
 ## Why
 
 RTK filters and compresses command output before it reaches the LLM context, saving 60-90% tokens on common operations. Always use `rtk <cmd>` instead of raw commands.
+
+## Reading the full output
+
+RTK output is a filtered summary — for most commands it keeps what matters
+(test failures, panics, and build errors are preserved). When you need the
+complete, unfiltered output to confirm a claim (tests really passed, build is
+really clean) rather than skim it, get the raw output instead of trusting the
+summary:
+
+- Run `rtk proxy <cmd>` to re-run the command with no filtering.
+- Or, when the filtered output ends with `[full output: <path>]`, read that
+  file directly — it is the complete, unfiltered log already on disk.


### PR DESCRIPTION
## Summary

- Adds a **"Reading the full output"** section to every agent instruction template (`hooks/*/rtk-awareness.md` and `rules.md`). The templates tell agents to run commands through `rtk`, but not how to recover the complete, *unfiltered* output when the filtered summary isn't enough — e.g. to confirm a "tests pass" / "build clean" claim rather than skim it. Both raw paths already exist (`rtk proxy <cmd>` and the `[full output: <path>]` tee log) but weren't documented where agents actually read. Mirrors the principle already in `CONTRIBUTING.md` (respect explicitly-requested detail).
- The Claude template also replaces a dangling `Refer to CLAUDE.md` line with `rtk --help`.
- Docs-only; the section is identical across all 7 templates.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test` — fmt clean, test **1974 passed, 0 failed**. (clippy hits a pre-existing `uninlined_format_args` lint in `build.rs`, untouched by this docs-only diff; CI is green on `develop`.)
- [x] Manual testing: inspected `rtk cargo test` (filtered) vs `rtk proxy cargo test` (raw) vs the `[full output: <path>]` tee log against a failing and a non-compiling crate — the documented behavior matches.
