### PR TITLE
fix(grep): exclude token-bomb dirs from recursive search (#2064)

### DIFF
--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -312,6 +312,20 @@ pub fn run(
         eprintln!("grep: '{}' in {}", pattern_display, path_display);
     }
 
+    let filt = config::filters();
+    // Skip exclusions when the user explicitly searches inside an ignored dir
+    // (e.g. `rtk grep foo node_modules/pkg`) — they asked for it on purpose.
+    // With multiple search paths, any explicit ignored-dir target disables the
+    // exclusions so a deliberately-named path never silently returns zero hits.
+    let (exclude_globs, grep_excludes) = if paths
+        .iter()
+        .any(|p| path_targets_ignored_dir(p, &filt.ignore_dirs))
+    {
+        (Vec::new(), Vec::new())
+    } else {
+        (ignore_globs(&filt), ignore_grep_excludes(&filt))
+    };
+
     let mut rg_cmd = resolved_command("rg");
     // --no-ignore-vcs: match grep -r behavior (don't skip .gitignore'd files).
     // Without this, rg returns 0 matches for files in .gitignore, causing
@@ -321,6 +335,9 @@ pub fn run(
     // -0: NUL-separate filename. Allows the parser to disambiguate filenames or
     // content containing `:digits:` patterns (issue #1436).
     rg_cmd.args(["-nH0", "--no-heading", "--no-ignore-vcs"]);
+    // Re-exclude token-bomb dirs/files (node_modules, *.min.js, …) that
+    // --no-ignore-vcs would otherwise descend, causing token expansion (#2064).
+    rg_cmd.args(&exclude_globs);
 
     if let Some(ft) = file_type {
         rg_cmd.arg("--type").arg(ft);
@@ -349,6 +366,9 @@ pub fn run(
             for p in &patterns {
                 grep_cmd.args(["-e", p]);
             }
+            // Mirror the rg exclusions so the (non-gitignore-aware) system grep
+            // also skips node_modules and friends (#2064).
+            grep_cmd.args(&grep_excludes);
             // --null (not -Z): on BSD/macOS grep -Z means --decompress, not the
             // NUL filename separator parse_match_line() needs (issue #2310).
             grep_cmd.args(["-rnH", "--null", "--"]);
@@ -495,6 +515,52 @@ fn parse_match_line(line: &str) -> Option<(String, usize, &str)> {
         let (_, [file, line_num, content]) = caps.extract();
         let line_num: usize = line_num.parse().ok()?;
         Some((file.to_string(), line_num, content))
+    })
+}
+
+/// Build `rg --glob '!PATTERN'` exclusion args from the configured ignore list
+/// (`config.filters.ignore_dirs` + `ignore_files`).
+///
+/// `rtk grep` passes `--no-ignore-vcs` so it still searches most .gitignore'd
+/// files (avoids false negatives, #1436-era behavior). But that also makes rg
+/// descend dependency/build dirs like `node_modules`, dumping minified vendored
+/// code and causing token *expansion* instead of reduction (#2064). These globs
+/// re-exclude only the well-known token-bomb dirs/files. rg still honors an
+/// explicitly-given path inside an excluded dir (e.g. `rtk grep foo node_modules/pkg`),
+/// so no result the user explicitly asked for is lost.
+fn ignore_globs(filt: &config::FilterConfig) -> Vec<String> {
+    filt.ignore_dirs
+        .iter()
+        .chain(filt.ignore_files.iter())
+        .flat_map(|p| ["--glob".to_string(), format!("!{p}")])
+        .collect()
+}
+
+/// Same exclusion list as [`ignore_globs`] but expressed as `grep`
+/// `--exclude-dir=` / `--exclude=` args, for the system-grep fallback path
+/// (taken when `rg` is not installed). Without this the fallback execs a
+/// non-gitignore-aware grep that descends `node_modules` (#2064).
+///
+/// Note: unlike rg's `--glob`, `grep --exclude-dir` suppresses matches even for
+/// an explicitly-given path inside the excluded dir. The caller compensates by
+/// not applying any exclusions when the search path itself targets an ignored
+/// dir (see [`path_targets_ignored_dir`]), keeping both paths consistent.
+fn ignore_grep_excludes(filt: &config::FilterConfig) -> Vec<String> {
+    filt.ignore_dirs
+        .iter()
+        .map(|d| format!("--exclude-dir={d}"))
+        .chain(filt.ignore_files.iter().map(|f| format!("--exclude={f}")))
+        .collect()
+}
+
+/// True if the search `path` explicitly points at (or into) one of the ignored
+/// dirs, e.g. `node_modules/pkg`. In that case the user clearly wants to search
+/// there, so exclusions must be skipped entirely — otherwise `grep --exclude-dir`
+/// would return zero hits for a path the user named on purpose (#2064).
+fn path_targets_ignored_dir(path: &str, ignore_dirs: &[String]) -> bool {
+    std::path::Path::new(path).components().any(|c| {
+        matches!(c, std::path::Component::Normal(name)
+            if ignore_dirs.iter().any(|d| name == d.as_str()))
     })
 }
 
@@ -1059,6 +1125,72 @@ mod tests {
     #[test]
     fn test_format_flag_detects_files() {
         assert!(has_format_flag(&["--files"]));
+    }
+
+    // --- #2064: re-exclude token-bomb dirs even with --no-ignore-vcs ---
+
+    fn has_glob_pair(globs: &[String], pat: &str) -> bool {
+        globs
+            .windows(2)
+            .any(|w| w[0] == "--glob" && w[1] == format!("!{pat}"))
+    }
+
+    #[test]
+    fn test_ignore_globs_exclude_node_modules() {
+        // BUG #2064: rtk grep -rn descends node_modules (--no-ignore-vcs), dumping
+        // minified vendored code → token expansion. The default ignore list must
+        // produce rg exclusion globs. Fails before the fix (empty), passes after.
+        let globs = ignore_globs(&config::FilterConfig::default());
+        assert!(
+            has_glob_pair(&globs, "node_modules"),
+            "node_modules must be excluded: {globs:?}"
+        );
+        assert!(
+            has_glob_pair(&globs, "*.min.js"),
+            "*.min.js must be excluded: {globs:?}"
+        );
+        assert!(
+            has_glob_pair(&globs, "target"),
+            "target must be excluded: {globs:?}"
+        );
+    }
+
+    #[test]
+    fn test_ignore_globs_empty_config_yields_nothing() {
+        let filt = config::FilterConfig {
+            ignore_dirs: vec![],
+            ignore_files: vec![],
+        };
+        assert!(ignore_globs(&filt).is_empty());
+    }
+
+    #[test]
+    fn test_path_targets_ignored_dir() {
+        let dirs = config::FilterConfig::default().ignore_dirs;
+        // Explicit searches into an ignored dir → exclusions must be skipped.
+        assert!(path_targets_ignored_dir("node_modules/pkg-a", &dirs));
+        assert!(path_targets_ignored_dir("./node_modules", &dirs));
+        assert!(path_targets_ignored_dir("a/b/vendor/c", &dirs));
+        // Normal project searches → exclusions apply.
+        assert!(!path_targets_ignored_dir(".", &dirs));
+        assert!(!path_targets_ignored_dir("src", &dirs));
+        // Substring of an ignored name must NOT trigger (component-anchored).
+        assert!(!path_targets_ignored_dir("my-node_modules-helper", &dirs));
+    }
+
+    #[test]
+    fn test_ignore_grep_excludes_for_fallback() {
+        // The system-grep fallback path must mirror the rg exclusions so rg-less
+        // machines also skip node_modules (#2064 reporter had no rg installed).
+        let excludes = ignore_grep_excludes(&config::FilterConfig::default());
+        assert!(
+            excludes.iter().any(|e| e == "--exclude-dir=node_modules"),
+            "fallback grep must exclude node_modules dir: {excludes:?}"
+        );
+        assert!(
+            excludes.iter().any(|e| e == "--exclude=*.min.js"),
+            "fallback grep must exclude *.min.js: {excludes:?}"
+        );
     }
 
     // --- truncation accuracy ---

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -150,6 +150,12 @@ pub fn limits() -> LimitsConfig {
     Config::load().map(|c| c.limits).unwrap_or_default()
 }
 
+/// Get filter config (ignore_dirs / ignore_files). Falls back to defaults if
+/// config can't be loaded.
+pub fn filters() -> FilterConfig {
+    Config::load().map(|c| c.filters).unwrap_or_default()
+}
+
 impl Config {
     pub fn load() -> Result<Self> {
         let path = get_config_path()?;


### PR DESCRIPTION
## Summary
- Fixes #2064: `rtk grep -rn <pat> <dir>` descends `node_modules` and dumps minified vendored code, turning a token *reducer* into a token *expander* (~57× the gitignore-aware grep in the report).
- Re-excludes only well-known token-bomb dirs/files, while keeping `--no-ignore-vcs` so genuinely-searched .gitignore'd files (configs, etc.) are still found.

> Target branch is `develop` per CONTRIBUTING.

## Root cause
`src/cmds/system/grep_cmd.rs` passes `--no-ignore-vcs` to rg (intentional, to avoid false negatives for .gitignore'd files — comment at the call site). The side effect: rg descends dependency/build dirs like `node_modules`, emitting megabytes of minified single-line bundles. When rg is absent, the fallback execs system `grep -rnHZ` (BSD grep on macOS), which is not gitignore-aware and descends `node_modules` too.

## Fix
Wire the **existing but previously-unused** `config.filters.ignore_dirs` / `ignore_files` list (`node_modules`, `target`, `.venv`, `vendor`, `*.min.js`, `*.lock`, …) into:
- the rg invocation as `--glob '!<pat>'`, and
- the system-grep fallback as `--exclude-dir=<dir>` / `--exclude=<file>`.

## Correctness (no false negatives)
- rg honors an explicitly-given path inside an excluded dir, so `rtk grep foo node_modules/pkg` works.
- `grep --exclude-dir` does **not** honor that (verified on BSD grep). To keep both paths consistent and never drop a result the user asked for on purpose, **exclusions are skipped entirely when the search path itself targets an ignored dir** (`path_targets_ignored_dir`). The check is path-component-anchored, so `my-node_modules-helper` is unaffected.

## Tests
- `cargo fmt --all --check && cargo clippy --all-targets && cargo test` — all green (1986 passed).
- New unit tests (red→green): `test_ignore_globs_exclude_node_modules`, `test_ignore_globs_empty_config_yields_nothing`, `test_ignore_grep_excludes_for_fallback`, `test_path_targets_ignored_dir`.
- Manual before/after on a frontend-style repo with `node_modules`:
  - `rtk grep define .` → **10,517 chars → 104 chars** (node_modules no longer dumped).
  - `rtk grep define node_modules/pkg-a` → still returns the matches (explicit path honored).

_Token-savings ≥60% checklist item is N/A: this is a correctness/expansion fix on the existing grep filter, not a new compression filter — and it strictly reduces output. Cites design principle #1 (Correctness over Token Savings)._

## Scope
- Intentionally keeps `--no-ignore-vcs` (false-negative-avoidance preserved for non-token-bomb gitignore'd files).
- Reuses the existing `FilterConfig` ignore list rather than inventing a new hard-coded set, so users can already customize it via config.
- No shell-string interpolation; all args go through `Command::arg`.

## Follow-up
- Related #1219 / #1833 frame the `-rn` fallback as a coverage/measurement gap; this PR addresses the severity (expansion) side and is independent of those.