### PR TITLE
fix(tree): use native Windows flags

### DIFF
--- a/src/cmds/system/tree.rs
+++ b/src/cmds/system/tree.rs
@@ -24,15 +24,8 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
 
     let mut cmd = resolved_command("tree");
 
-    let show_all = args.iter().any(|a| a == "-a" || a == "--all");
-    let has_ignore = args.iter().any(|a| a == "-I" || a.starts_with("--ignore="));
-
-    if !show_all && !has_ignore {
-        let ignore_pattern = NOISE_DIRS.join("|");
-        cmd.arg("-I").arg(&ignore_pattern);
-    }
-
-    for arg in args {
+    let forwarded_args = tree_args_for_platform(args);
+    for arg in &forwarded_args {
         cmd.arg(arg);
     }
 
@@ -62,6 +55,70 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     )
 }
 
+fn tree_args_for_platform(args: &[String]) -> Vec<String> {
+    if cfg!(windows) {
+        windows_tree_args(args)
+    } else {
+        unix_tree_args(args)
+    }
+}
+
+fn unix_tree_args(args: &[String]) -> Vec<String> {
+    let mut forwarded = Vec::new();
+    let show_all = args.iter().any(|a| a == "-a" || a == "--all");
+    let has_ignore = args.iter().any(|a| a == "-I" || a.starts_with("--ignore="));
+
+    if !show_all && !has_ignore {
+        forwarded.push("-I".to_string());
+        forwarded.push(NOISE_DIRS.join("|"));
+    }
+
+    forwarded.extend(args.iter().cloned());
+    forwarded
+}
+
+fn windows_tree_args(args: &[String]) -> Vec<String> {
+    let mut forwarded = Vec::new();
+    let mut has_files = false;
+    let mut has_ascii = false;
+    let mut skip_next = false;
+
+    // Windows tree.com only accepts slash flags; Unix -I/--all options break it.
+    for arg in args {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+
+        let lower = arg.to_ascii_lowercase();
+        match lower.as_str() {
+            "/f" => {
+                has_files = true;
+                forwarded.push(arg.clone());
+            }
+            "/a" => {
+                has_ascii = true;
+                forwarded.push(arg.clone());
+            }
+            "-a" | "--all" => {}
+            "-i" => {
+                skip_next = true;
+            }
+            _ if lower.starts_with("--ignore=") || lower.starts_with("-i") => {}
+            _ => forwarded.push(arg.clone()),
+        }
+    }
+
+    if !has_files {
+        forwarded.push("/F".to_string());
+    }
+    if !has_ascii {
+        forwarded.push("/A".to_string());
+    }
+
+    forwarded
+}
+
 fn filter_tree_output(raw: &str) -> String {
     let lines: Vec<&str> = raw.lines().collect();
 
@@ -72,6 +129,10 @@ fn filter_tree_output(raw: &str) -> String {
     let mut filtered_lines = Vec::new();
 
     for line in lines {
+        if is_windows_tree_header(line) {
+            continue;
+        }
+
         // Skip the final summary line (e.g., "5 directories, 23 files")
         if line.contains("director") && line.contains("file") {
             continue;
@@ -91,6 +152,14 @@ fn filter_tree_output(raw: &str) -> String {
     }
 
     filtered_lines.join("\n") + "\n"
+}
+
+fn is_windows_tree_header(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.eq_ignore_ascii_case("Folder PATH listing")
+        || trimmed
+            .to_ascii_lowercase()
+            .starts_with("volume serial number is ")
 }
 
 #[cfg(test)]
@@ -123,6 +192,37 @@ mod tests {
         let input = "";
         let output = filter_tree_output(input);
         assert_eq!(output, "\n");
+    }
+
+    #[test]
+    fn test_filter_removes_windows_headers() {
+        let input = "Folder PATH listing\nVolume serial number is 0000014E 7957:0E10\nC:\\PROJECT\n+---src\n|       main.rs\n";
+        let output = filter_tree_output(input);
+        assert!(!output.contains("Folder PATH listing"));
+        assert!(!output.contains("Volume serial number"));
+        assert!(output.contains("C:\\PROJECT"));
+        assert!(output.contains("main.rs"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_windows_tree_args_uses_native_flags() {
+        let args = vec![".".to_string()];
+        let output = tree_args_for_platform(&args);
+        assert_eq!(output, vec![".", "/F", "/A"]);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_windows_tree_args_drops_unix_ignore_flags() {
+        let args = vec![
+            "-I".to_string(),
+            "target|node_modules".to_string(),
+            "--all".to_string(),
+            ".".to_string(),
+        ];
+        let output = tree_args_for_platform(&args);
+        assert_eq!(output, vec![".", "/F", "/A"]);
     }
 
     #[test]


### PR DESCRIPTION
﻿## What

Fix tk tree on Windows by routing arguments through a platform-specific adapter before spawning native 	ree.

On Unix, RTK keeps the existing behavior and injects -I <noise dirs> so noisy folders stay out of the output. On Windows, RTK now avoids Unix-only options and uses the native 	ree.com slash flags instead:

- /F so files are included in the tree output
- /A so output uses stable ASCII characters

The Windows filter also removes the 	ree.com banner lines before returning output to the agent.

## Why

Windows ships 	ree.com, which does not support Unix 	ree flags like -I or --all. RTK was injecting the Unix ignore pattern unconditionally, so tk tree failed with:

`	ext
Too many parameters - node_modules|.git|target|...
`

Fixes #1936.

Addresses the tree-specific part of #1949.

## Validation

`	ext
rtk cargo fmt --all --check
rtk cargo test cmds::system::tree -- --nocapture
rtk cargo clippy --all-targets
rtk proxy .\target\debug\rtk.exe tree target\tree-repro-windows
`

Targeted results:

`	ext
cargo test: 9 passed, 1983 filtered out
cargo clippy: No issues found
`

Manual Windows smoke output now renders the test tree instead of the parameter error:

`	ext
C:\USERS\CUONG\RTK\TARGET\TREE-REPRO-WINDOWS
+---src
|       main.rs
|
\---target
        noise.txt
`

Full tk cargo test still has existing unrelated Windows failures in core::stream::tests where Unix commands such as 	rue, alse, and cat are not found.
