### PR TITLE
fix(tee): render absolute path in hint, no `~` shorthand

### DIFF
--- a/src/core/tee.rs
+++ b/src/core/tee.rs
@@ -169,11 +169,6 @@ pub fn tee_raw(raw: &str, command_slug: &str, exit_code: i32) -> Option<PathBuf>
 }
 
 fn display_path(path: &std::path::Path) -> String {
-    if let Some(home) = dirs::home_dir() {
-        if let Ok(relative) = path.strip_prefix(&home) {
-            return format!("~/{}", relative.display());
-        }
-    }
     path.display().to_string()
 }
 
@@ -445,6 +440,30 @@ mod tests {
         assert!(hint.starts_with("[full output: "));
         assert!(hint.ends_with(']'));
         assert!(hint.contains("123_cargo_test.log"));
+    }
+
+    #[test]
+    fn test_display_path_never_emits_tilde_for_home_paths() {
+        // Hint paths are meant to be copy-pasted into a shell. `~` does not
+        // expand inside double quotes, and an unquoted `~/Library/Application
+        // Support/...` splits on the space. Render absolute paths only.
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+        let path = home.join("Library/Application Support/rtk/tee/7_curl.log");
+        let display = display_path(&path);
+        assert!(
+            !display.starts_with('~'),
+            "display_path must render absolute paths, got {display:?}"
+        );
+        assert_eq!(display, path.display().to_string());
+    }
+
+    #[test]
+    fn test_display_path_preserves_paths_with_spaces() {
+        let path = PathBuf::from("/var/folders/x y z/rtk/tee/9_test.log");
+        let display = display_path(&path);
+        assert_eq!(display, "/var/folders/x y z/rtk/tee/9_test.log");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The tee hint string is meant to be copy-pasted into a shell. With the `~` shorthand `display_path` currently emits, the path on macOS renders as:

```
[full output: ~/Library/Application Support/rtk/tee/7_curl.log]
```

That's not shell-safe:

- `cat "~/Library/Application Support/rtk/tee/..."` does not expand `~` inside double quotes
- `cat ~/Library/Application Support/rtk/tee/...` splits on the unquoted space

## Fix

Drop the `strip_prefix(home)` branch in `display_path`. The path passed in is already absolute (built from `data_local_dir()`), so the helper collapses to a one-line `path.display().to_string()`. Two regression tests cover the home-prefixed and space-containing shapes.

## Notes

Supersedes #1657, which I opened against the pre-refactor `format_hint` before #1895 extracted `display_path`. Closing #1657 in favor of this. Closes #1644.

`cargo test --quiet tee::tests` is 22/22 green; `cargo fmt --check` and `cargo clippy -- -D warnings` are clean.