### PR TITLE
fix(go): respect build failure exit status

### DIFF
--- a/src/cmds/go/go_cmd.rs
+++ b/src/cmds/go/go_cmd.rs
@@ -92,11 +92,11 @@ pub fn run_build(args: &[String], verbose: u8) -> Result<i32> {
         eprintln!("Running: go build {}", args.join(" "));
     }
 
-    runner::run_filtered(
+    runner::run_filtered_with_exit(
         cmd,
         "go build",
         &args.join(" "),
-        filter_go_build,
+        filter_go_build_with_exit,
         crate::core::runner::RunOptions::with_tee("go_build"),
     )
 }
@@ -571,6 +571,10 @@ fn is_go_test_failure_line(line: &str) -> bool {
 
 /// Filter go build output - show only errors
 pub(crate) fn filter_go_build(output: &str) -> String {
+    filter_go_build_with_exit(output, 0)
+}
+
+fn filter_go_build_with_exit(output: &str, exit_code: i32) -> String {
     let mut errors: Vec<String> = Vec::new();
 
     for line in output.lines() {
@@ -581,7 +585,11 @@ pub(crate) fn filter_go_build(output: &str) -> String {
     }
 
     if errors.is_empty() {
-        return "Go build: Success".to_string();
+        return if exit_code == 0 {
+            "Go build: Success".to_string()
+        } else {
+            format_go_build_failure(output, exit_code)
+        };
     }
 
     let mut result = String::new();
@@ -599,6 +607,37 @@ pub(crate) fn filter_go_build(output: &str) -> String {
         if let Some(hint) = crate::core::tee::force_tee_tail_hint(&all_errors, "go-build", MAX_GO_BUILD_ERRORS + 1) {
             result.push_str(&format!("  {}\n", hint));
         }
+    }
+
+    result.trim().to_string()
+}
+
+fn format_go_build_failure(output: &str, exit_code: i32) -> String {
+    let lines: Vec<String> = output
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect();
+
+    if lines.is_empty() {
+        return format!("Go build: failed (exit {})", exit_code);
+    }
+
+    let mut result = String::new();
+    result.push_str(&format!("Go build: failed (exit {})\n", exit_code));
+    result.push_str("═══════════════════════════════════════\n");
+
+    const MAX_GO_BUILD_ERRORS: usize = CAP_ERRORS;
+    for (i, line) in lines.iter().take(MAX_GO_BUILD_ERRORS).enumerate() {
+        result.push_str(&format!("{}. {}\n", i + 1, truncate(line, 120)));
+    }
+
+    if lines.len() > MAX_GO_BUILD_ERRORS {
+        result.push_str(&format!(
+            "\n… +{} more output lines\n",
+            lines.len() - MAX_GO_BUILD_ERRORS
+        ));
     }
 
     result.trim().to_string()
@@ -646,6 +685,7 @@ fn is_go_build_error_line(line: &str) -> bool {
         "go: build failed",
         "go: error ",
         "error: ",
+        "pattern ",
         "go: updates to go.mod needed",
         "go: inconsistent vendoring",
         "no go files in ",
@@ -989,6 +1029,28 @@ go: cannot load module missing listed in go.work file: open missing/go.mod: no s
         );
         assert!(result.contains("no Go files in /tmp/example"));
         assert!(result.contains("go: cannot load module missing listed in go.work file"));
+    }
+
+    #[test]
+    fn test_filter_go_build_preserves_package_pattern_errors() {
+        let output = r#"pattern ./...: directory prefix . does not contain main module or its selected dependencies
+pattern ./...: directory prefix . does not contain modules listed in go.work or their selected dependencies"#;
+
+        let result = filter_go_build(output);
+        assert!(result.contains("2 errors"));
+        assert!(result.contains("does not contain main module"));
+        assert!(result.contains("does not contain modules listed in go.work"));
+        assert!(!result.contains("Success"));
+    }
+
+    #[test]
+    fn test_filter_go_build_nonzero_exit_never_reports_success() {
+        let output = "opaque go build failure from stderr";
+
+        let result = filter_go_build_with_exit(output, 1);
+        assert!(result.contains("Go build: failed (exit 1)"));
+        assert!(result.contains(output));
+        assert!(!result.contains("Success"));
     }
 
     #[test]

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -62,10 +62,77 @@ impl<'a> RunOptions<'a> {
     }
 }
 
+pub type CaptureFilter<'a> = Box<dyn Fn(&str) -> String + 'a>;
+pub type ExitAwareCaptureFilter<'a> = Box<dyn Fn(&str, i32) -> String + 'a>;
+
 pub enum RunMode<'a> {
-    Filtered(Box<dyn Fn(&str) -> String + 'a>),
+    Filtered(CaptureFilter<'a>),
+    FilteredWithExit(ExitAwareCaptureFilter<'a>),
     Streamed(Box<dyn StreamFilter + 'a>),
     Passthrough,
+}
+
+fn run_captured_filter<F>(
+    mut cmd: Command,
+    tool_name: &str,
+    cmd_label: &str,
+    filter_fn: F,
+    opts: RunOptions<'_>,
+    timer: tracking::TimedExecution,
+) -> Result<i32>
+where
+    F: Fn(&str, i32) -> String,
+{
+    let stdin_mode = if opts.inherit_stdin {
+        StdinMode::Inherit
+    } else {
+        StdinMode::Null
+    };
+    let result = stream::run_streaming(&mut cmd, stdin_mode, FilterMode::CaptureOnly)
+        .with_context(|| format!("Failed to run {}", tool_name))?;
+
+    let exit_code = result.exit_code;
+    let raw = &result.raw;
+    let raw_stdout = &result.raw_stdout;
+
+    if opts.skip_filter_on_failure && exit_code != 0 {
+        if !result.raw_stdout.trim().is_empty() {
+            print!("{}", result.raw_stdout);
+        }
+        if !result.raw_stderr.trim().is_empty() {
+            eprint!("{}", result.raw_stderr);
+        }
+        timer.track(cmd_label, &format!("rtk {}", cmd_label), raw, raw);
+        return Ok(exit_code);
+    }
+
+    let text_to_filter = if opts.filter_stdout_only {
+        raw_stdout
+    } else {
+        raw
+    };
+    let filtered = filter_fn(text_to_filter, exit_code);
+
+    if let Some(label) = opts.tee_label {
+        print_with_hint(&filtered, raw, label, exit_code);
+    } else if opts.no_trailing_newline {
+        print!("{}", filtered);
+    } else {
+        println!("{}", filtered);
+    }
+
+    let raw_for_tracking = if opts.filter_stdout_only {
+        raw_stdout
+    } else {
+        raw
+    };
+    timer.track(
+        cmd_label,
+        &format!("rtk {}", cmd_label),
+        raw_for_tracking,
+        &filtered,
+    );
+    Ok(exit_code)
 }
 
 pub fn run(
@@ -79,58 +146,22 @@ pub fn run(
     let cmd_label = format!("{} {}", tool_name, args_display);
 
     match mode {
-        RunMode::Filtered(filter_fn) => {
-            let stdin_mode = if opts.inherit_stdin {
-                StdinMode::Inherit
-            } else {
-                StdinMode::Null
-            };
-            let result = stream::run_streaming(&mut cmd, stdin_mode, FilterMode::CaptureOnly)
-                .with_context(|| format!("Failed to run {}", tool_name))?;
-
-            let exit_code = result.exit_code;
-            let raw = &result.raw;
-            let raw_stdout = &result.raw_stdout;
-
-            if opts.skip_filter_on_failure && exit_code != 0 {
-                if !result.raw_stdout.trim().is_empty() {
-                    print!("{}", result.raw_stdout);
-                }
-                if !result.raw_stderr.trim().is_empty() {
-                    eprint!("{}", result.raw_stderr);
-                }
-                timer.track(&cmd_label, &format!("rtk {}", cmd_label), raw, raw);
-                return Ok(exit_code);
-            }
-
-            let text_to_filter = if opts.filter_stdout_only {
-                raw_stdout
-            } else {
-                raw
-            };
-            let filtered = filter_fn(text_to_filter);
-
-            if let Some(label) = opts.tee_label {
-                print_with_hint(&filtered, raw, label, exit_code);
-            } else if opts.no_trailing_newline {
-                print!("{}", filtered);
-            } else {
-                println!("{}", filtered);
-            }
-
-            let raw_for_tracking = if opts.filter_stdout_only {
-                raw_stdout
-            } else {
-                raw
-            };
-            timer.track(
-                &cmd_label,
-                &format!("rtk {}", cmd_label),
-                raw_for_tracking,
-                &filtered,
-            );
-            Ok(exit_code)
-        }
+        RunMode::Filtered(filter_fn) => run_captured_filter(
+            cmd,
+            tool_name,
+            &cmd_label,
+            move |text, _| filter_fn(text),
+            opts,
+            timer,
+        ),
+        RunMode::FilteredWithExit(filter_fn) => run_captured_filter(
+            cmd,
+            tool_name,
+            &cmd_label,
+            move |text, exit_code| filter_fn(text, exit_code),
+            opts,
+            timer,
+        ),
         RunMode::Streamed(filter) => {
             let result =
                 stream::run_streaming(&mut cmd, StdinMode::Null, FilterMode::Streaming(filter))
@@ -178,6 +209,25 @@ where
         tool_name,
         args_display,
         RunMode::Filtered(Box::new(filter_fn)),
+        opts,
+    )
+}
+
+pub fn run_filtered_with_exit<F>(
+    cmd: Command,
+    tool_name: &str,
+    args_display: &str,
+    filter_fn: F,
+    opts: RunOptions<'_>,
+) -> Result<i32>
+where
+    F: Fn(&str, i32) -> String,
+{
+    run(
+        cmd,
+        tool_name,
+        args_display,
+        RunMode::FilteredWithExit(Box::new(filter_fn)),
         opts,
     )
 }


### PR DESCRIPTION
Closes #2185.

## Summary

- Gate `rtk go build` success output on the wrapped process exit code.
- Surface unrecognized non-zero `go build` output instead of reporting `Go build: Success`.
- Preserve Go package-pattern/module-resolution errors such as `pattern ./...: directory prefix ...`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all --quiet`
- [x] Manual repro in an empty directory: `target/debug/rtk go build ./...`