### PR TITLE
docs: fix contributing guide typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,9 +85,9 @@ When implementing a new filter/cmds, be aware of the [Design Philosophy](#design
 
 - Interactive TUIs (htop, vim, less): not batch-mode compatible
 - Binary output (images, compiled artifacts): no text to filter
-- Trivial commands: not worth the overhead and may loose important informations
+- Trivial commands: not worth the overhead and may lose important information
 - Commands with no text output: nothing to compress
-- Others features not related to a LLM-proxy like RTK
+- Other features not related to a LLM-proxy like RTK
 
 ### TOML vs Rust: Which One?
 


### PR DESCRIPTION
Summary:
- Fixes typos in the contributing guide.
- Keeps the change text-only with no behavior impact.

Testing:
- `git diff --check`
- `uvx codespell` on the changed file