### PR TITLE
ci: add aarch64-unknown-linux-musl release target (closes #1331)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,10 @@ jobs:
             os: ubuntu-latest
             archive: tar.gz
             cross: true
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            archive: tar.gz
+            setup_cross_toolchain: true
           # Windows
           - target: x86_64-pc-windows-msvc
             os: windows-latest
@@ -78,6 +82,15 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y musl-tools
+
+      # Sets up a native musl cross-compiler + linker for targets like
+      # aarch64-unknown-linux-musl so the standard `cargo build` step below
+      # works and build-time env (RTK_TELEMETRY_*) passes through normally.
+      - name: Set up cross toolchain
+        if: matrix.setup_cross_toolchain
+        uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
 
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}

--- a/install.sh
+++ b/install.sh
@@ -45,6 +45,19 @@ detect_arch() {
     esac
 }
 
+# Detect C library (glibc vs musl)
+# Alpine and other lightweight distros use musl; the glibc binaries fail there
+# with "Error relocating ... symbol not found". Default to gnu, switch to musl
+# only when musl is detected.
+detect_libc() {
+    LIBC="gnu"
+    if [ -f /lib/ld-musl-x86_64.so.1 ] || [ -f /lib/ld-musl-aarch64.so.1 ]; then
+        LIBC="musl"
+    elif ldd --version 2>&1 | grep -qi musl; then
+        LIBC="musl"
+    fi
+}
+
 # Get latest release version
 # Primary: parse the 302 redirect on /releases/latest (no API call, no rate limit).
 # Fallback: the GitHub REST API (subject to 60 req/hour anonymous limit).
@@ -74,7 +87,13 @@ get_target() {
         linux)
             case "$ARCH" in
                 x86_64)  TARGET="x86_64-unknown-linux-musl";;
-                aarch64) TARGET="aarch64-unknown-linux-gnu";;
+                aarch64)
+                    if [ "$LIBC" = "musl" ]; then
+                        TARGET="aarch64-unknown-linux-musl"
+                    else
+                        TARGET="aarch64-unknown-linux-gnu"
+                    fi
+                    ;;
             esac
             ;;
         darwin)
@@ -134,6 +153,7 @@ main() {
 
     detect_os
     detect_arch
+    detect_libc
     get_target
     if [ -n "$RTK_VERSION" ]; then
         VERSION="$RTK_VERSION"


### PR DESCRIPTION
Fixes #1331.

  Alpine/musl ARM64 systems cannot run the glibc binary (`aarch64-unknown-linux-gnu`) — it fails with symbol relocation errors (`fcntl64`, `__res_init`).
  This adds a statically-linked musl build for ARM64, mirroring the existing `x86_64-unknown-linux-musl` asset.

  - **release.yml**: add `aarch64-unknown-linux-musl` to the build matrix, built via `taiki-e/setup-cross-toolchain-action` so the standard `cargo build`
  step and `RTK_TELEMETRY_*` compile-time env work unchanged.
  - **install.sh**: detect musl libc and select the musl asset on aarch64 Linux (glibc systems keep the gnu binary).