### PR TITLE
fix(rewrite): handle newline-separated commands

### DIFF
--- a/src/discover/lexer.rs
+++ b/src/discover/lexer.rs
@@ -133,6 +133,23 @@ pub fn tokenize(input: &str) -> Vec<ParsedToken> {
                 byte_pos += char_len;
                 current_start = byte_pos;
             }
+            '\n' | '\r' => {
+                flush_arg(&mut tokens, &mut current, current_start);
+                let start = byte_pos;
+                let mut value = c.to_string();
+                byte_pos += char_len;
+                if c == '\r' && chars.peek() == Some(&'\n') {
+                    chars.next();
+                    byte_pos += 1;
+                    value.push('\n');
+                }
+                tokens.push(ParsedToken {
+                    kind: TokenKind::Operator,
+                    value,
+                    offset: start,
+                });
+                current_start = byte_pos;
+            }
             '&' => {
                 flush_arg(&mut tokens, &mut current, current_start);
                 let start = byte_pos;
@@ -492,6 +509,30 @@ mod tests {
         assert!(tokens
             .iter()
             .any(|t| t.kind == TokenKind::Operator && t.value == ";"));
+    }
+
+    #[test]
+    fn test_newline_operator() {
+        let tokens = tokenize("cmd1\ncmd2");
+        assert!(tokens
+            .iter()
+            .any(|t| t.kind == TokenKind::Operator && t.value == "\n"));
+    }
+
+    #[test]
+    fn test_crlf_operator() {
+        let tokens = tokenize("cmd1\r\ncmd2");
+        assert!(tokens
+            .iter()
+            .any(|t| t.kind == TokenKind::Operator && t.value == "\r\n"));
+    }
+
+    #[test]
+    fn test_quoted_newline_not_operator() {
+        let tokens = tokenize("echo \"cmd1\ncmd2\"");
+        assert!(!tokens
+            .iter()
+            .any(|t| t.kind == TokenKind::Operator && t.value.contains('\n')));
     }
 
     #[test]
@@ -1023,6 +1064,11 @@ mod tests {
             split_on_operators(r#"echo "a && b" && cargo test"#, false),
             vec![r#"echo "a && b""#, "cargo test"]
         );
+    }
+
+    #[test]
+    fn test_split_on_operators_newline() {
+        assert_eq!(split_on_operators("a\nb", false), vec!["a", "b"]);
     }
 
     #[test]

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -461,7 +461,7 @@ fn collapse_line_continuations(s: &str) -> std::borrow::Cow<'_, str> {
 
 /// Returns `None` if the command is unsupported or ignored (hook should pass through).
 ///
-/// Handles compound commands (`&&`, `||`, `;`) by rewriting each segment independently.
+/// Handles compound commands (`&&`, `||`, `;`, newline) by rewriting each segment independently.
 /// For pipes (`|`), only rewrites the left-hand command (pipe targets stay raw),
 /// but continues rewriting segments after subsequent `&&`/`||`/`;` operators.
 /// Also strips user-configured transparent wrapper prefixes
@@ -506,6 +506,8 @@ pub fn rewrite_command(
     let has_compound = trimmed.contains("&&")
         || trimmed.contains("||")
         || trimmed.contains(';')
+        || trimmed.contains('\n')
+        || trimmed.contains('\r')
         || trimmed.contains('|')
         || trimmed.contains(" & ");
     if !has_compound && (trimmed.starts_with("rtk ") || trimmed == "rtk") {
@@ -515,7 +517,11 @@ pub fn rewrite_command(
     rewrite_compound(trimmed, &compiled, &normalized_prefixes)
 }
 
-/// Rewrite a compound command (with `&&`, `||`, `;`, `|`) by rewriting each segment.
+fn is_newline_operator(value: &str) -> bool {
+    value == "\n" || value == "\r\n" || value == "\r"
+}
+
+/// Rewrite a compound command (with `&&`, `||`, `;`, newline, `|`) by rewriting each segment.
 fn rewrite_compound(
     cmd: &str,
     excluded: &[ExcludePattern],
@@ -539,7 +545,9 @@ fn rewrite_compound(
                     any_changed = true;
                 }
                 result.push_str(&rewritten);
-                if tok.value == ";" {
+                if is_newline_operator(&tok.value) {
+                    result.push_str(&tok.value);
+                } else if tok.value == ";" {
                     result.push(';');
                     let after = tok.offset + tok.value.len();
                     if after < cmd.len() {
@@ -551,7 +559,12 @@ fn rewrite_compound(
                     result.push(' ');
                 }
                 seg_start = tok.offset + tok.value.len();
-                while seg_start < cmd.len() && cmd.as_bytes().get(seg_start) == Some(&b' ') {
+                while seg_start < cmd.len()
+                    && cmd
+                        .as_bytes()
+                        .get(seg_start)
+                        .is_some_and(|b| *b == b' ' || *b == b'\t')
+                {
                     seg_start += 1;
                 }
             }
@@ -3112,6 +3125,47 @@ mod tests {
         assert_eq!(
             rewrite_command_no_prefixes("git status; cargo test", &[]),
             Some("rtk git status; rtk cargo test".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_compound_newline_after_unsupported_segment() {
+        let input = "cd /tmp\ngrep -c x /tmp/f.txt\ngrep -c x /tmp/f.txt";
+        let expected = "cd /tmp\nrtk grep -c x /tmp/f.txt\nrtk grep -c x /tmp/f.txt";
+
+        assert_eq!(
+            rewrite_command_no_prefixes(input, &[]),
+            Some(expected.into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_compound_newline_after_supported_segment() {
+        let input = "grep -c x /tmp/f.txt\ngrep -c x /tmp/f.txt";
+        let expected = "rtk grep -c x /tmp/f.txt\nrtk grep -c x /tmp/f.txt";
+
+        assert_eq!(
+            rewrite_command_no_prefixes(input, &[]),
+            Some(expected.into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_compound_crlf_separator() {
+        let input = "grep -c x /tmp/f.txt\r\ngrep -c x /tmp/f.txt";
+        let expected = "rtk grep -c x /tmp/f.txt\r\nrtk grep -c x /tmp/f.txt";
+
+        assert_eq!(
+            rewrite_command_no_prefixes(input, &[]),
+            Some(expected.into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_pipe_group_then_newline() {
+        assert_eq!(
+            rewrite_command_no_prefixes("git log | head -5\ngit status", &[]),
+            Some("rtk git log | head -5\nrtk git status".into())
         );
     }
 

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -387,6 +387,15 @@ mod tests {
     }
 
     #[test]
+    fn test_newline_compound_command_deny() {
+        let deny = vec!["git push --force".to_string()];
+        assert_eq!(
+            check_command_with_rules("git status\ngit push --force", &deny, &[], &[]),
+            PermissionVerdict::Deny
+        );
+    }
+
+    #[test]
     fn test_compound_command_ask() {
         let ask = vec!["git push".to_string()];
         assert_eq!(
@@ -421,6 +430,24 @@ mod tests {
         assert_eq!(
             check_command_with_rules("cat file | rm -rf /", &deny, &[], &[]),
             PermissionVerdict::Deny
+        );
+    }
+
+    #[test]
+    fn test_newline_allow_requires_every_segment() {
+        let allow = vec!["git status".to_string()];
+        assert_eq!(
+            check_command_with_rules("git status\ngit push origin main", &[], &[], &allow),
+            PermissionVerdict::Default
+        );
+    }
+
+    #[test]
+    fn test_newline_all_segments_allowed() {
+        let allow = vec!["git status".to_string(), "git diff".to_string()];
+        assert_eq!(
+            check_command_with_rules("git status\ngit diff --stat", &[], &[], &allow),
+            PermissionVerdict::Allow
         );
     }
 


### PR DESCRIPTION
Closes #2191.

## Summary

- Treat top-level newline and CRLF separators like other shell command separators during `rtk rewrite`.
- Rewrite every newline-delimited segment independently while preserving quoted newlines, heredoc passthrough, line-continuation collapse, and pipe group behavior.
- Cover hook permission checks so newline-separated commands are evaluated segment-by-segment before allow/deny/ask decisions.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all --quiet`
- [x] Manual repro: `target/debug/rtk rewrite "$(printf 'cd /tmp\ngrep -c x /tmp/f.txt\ngrep -c x /tmp/f.txt')"`