### PR TITLE
feat(codex): add PreToolUse hook support

### DIFF
--- a/hooks/codex/README.md
+++ b/hooks/codex/README.md
@@ -4,6 +4,30 @@
 
 ## Specifics
 
-- Prompt-level guidance via awareness document -- no programmatic hook
-- `rtk-awareness.md` is injected into `AGENTS.md` with an `@RTK.md` reference
-- Installed to `$CODEX_HOME` when set, otherwise `~/.codex/`, by `rtk init --codex`
+- Command-based `PreToolUse` hook via Codex `hooks.json`.
+- Returns `hookSpecificOutput.updatedInput.command` to rewrite shell commands before execution.
+- Codex accepts `updatedInput` only with `permissionDecision: "allow"`, so RTK uses a dedicated `rtk hook codex` processor.
+- `rtk-awareness.md` is still injected into `AGENTS.md` with an `@RTK.md` reference as prompt-level backup guidance.
+- Installed locally to `.codex/hooks.json` by `rtk init --codex`, or globally to `$CODEX_HOME/hooks.json` / `~/.codex/hooks.json` by `rtk init -g --codex`.
+
+## Hook entry
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^Bash$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "rtk hook codex",
+            "timeout": 10,
+            "statusMessage": "RTK rewriting shell command"
+          }
+        ]
+      }
+    ]
+  }
+}
+```

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -88,13 +88,13 @@ Rules are loaded from all Claude Code `settings.json` files (project + global, i
 | Copilot VS Code (rtk hook copilot) | Yes | `permissionDecision: "ask"` — user prompted |
 | Gemini CLI (rtk hook gemini) | No (allow/deny only) | allow (limitation — no ask mode in Gemini) |
 | Copilot CLI (rtk hook copilot) | No updatedInput | deny-with-suggestion (unchanged) |
-| Codex | ask parsed but no-op | allow (limitation — fails open) |
+| Codex CLI (rtk hook codex) | No (updatedInput requires allow) | allow (limitation — Codex rejects ask with updatedInput) |
 
 ### Implementation
 
 - `permissions.rs` — loads deny/ask/allow rules, evaluates precedence, returns `PermissionVerdict`
 - `rewrite_cmd.rs` — maps verdict to exit code (consumed by shell hook)
-- `hook_cmd.rs` — maps verdict to JSON `permissionDecision` field (Copilot/Gemini)
+- `hook_cmd.rs` — maps verdict to JSON `permissionDecision` field (Copilot/Gemini/Codex)
 
 ## Exit Code Contract
 

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -10,6 +10,8 @@ pub const BEFORE_TOOL_KEY: &str = "BeforeTool";
 
 /// Native Rust hook command for Claude Code (replaces rtk-rewrite.sh).
 pub const CLAUDE_HOOK_COMMAND: &str = "rtk hook claude";
+/// Native Rust hook command for Codex CLI.
+pub const CODEX_HOOK_COMMAND: &str = "rtk hook codex";
 /// Native Rust hook command for Cursor (replaces rtk-rewrite.sh).
 pub const CURSOR_HOOK_COMMAND: &str = "rtk hook cursor";
 

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -420,6 +420,93 @@ fn run_claude_inner(input: &str) -> Option<String> {
     }
 }
 
+// ── Codex CLI native hook ──────────────────────────────────────
+
+fn process_codex_payload(v: &Value) -> PayloadAction {
+    let cmd = match v
+        .pointer("/tool_input/command")
+        .and_then(|c| c.as_str())
+        .filter(|c| !c.is_empty())
+    {
+        Some(c) => c,
+        None => return PayloadAction::Ignore,
+    };
+
+    if permissions::check_command(cmd) == PermissionVerdict::Deny {
+        return PayloadAction::Skip {
+            reason: "skip:deny_rule",
+            cmd: cmd.to_string(),
+        };
+    }
+
+    let rewritten = match get_rewritten(cmd) {
+        Some(r) => r,
+        None => {
+            return PayloadAction::Skip {
+                reason: "skip:no_match",
+                cmd: cmd.to_string(),
+            };
+        }
+    };
+
+    PayloadAction::Rewrite {
+        cmd: cmd.to_string(),
+        rewritten: rewritten.clone(),
+        output: json!({
+            "hookSpecificOutput": {
+                "hookEventName": PRE_TOOL_USE_KEY,
+                "permissionDecision": "allow",
+                "permissionDecisionReason": "RTK auto-rewrite",
+                "updatedInput": { "command": rewritten }
+            }
+        }),
+    }
+}
+
+/// Run the Codex CLI PreToolUse hook natively.
+pub fn run_codex() -> Result<()> {
+    let input = read_stdin_limited()?;
+
+    let input = input.trim();
+    if input.is_empty() {
+        return Ok(());
+    }
+
+    let v: Value = match serde_json::from_str(input) {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = writeln!(io::stderr(), "[rtk hook] Failed to parse JSON input: {e}");
+            return Ok(());
+        }
+    };
+
+    match process_codex_payload(&v) {
+        PayloadAction::Rewrite {
+            cmd,
+            rewritten,
+            output,
+        } => {
+            audit_log("rewrite", &cmd, &rewritten);
+            let _ = writeln!(io::stdout(), "{output}");
+        }
+        PayloadAction::Skip { reason, cmd } => {
+            audit_log(reason, &cmd, "");
+        }
+        PayloadAction::Ignore => {}
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+fn run_codex_inner(input: &str) -> Option<String> {
+    let v: Value = serde_json::from_str(input).ok()?;
+    match process_codex_payload(&v) {
+        PayloadAction::Rewrite { output, .. } => Some(output.to_string()),
+        _ => None,
+    }
+}
+
 // ── Cursor native hook ─────────────────────────────────────────
 
 /// Cursor on Windows ships hook payloads with one or more leading
@@ -913,6 +1000,56 @@ mod tests {
     fn test_claude_no_tool_input_passthrough() {
         let input = json!({ "tool_name": "Bash" }).to_string();
         assert!(run_claude_inner(&input).is_none());
+    }
+
+    // --- Codex handler ---
+
+    fn codex_input(cmd: &str) -> String {
+        json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": { "command": cmd },
+            "tool_use_id": "call_123",
+            "session_id": "session_123",
+            "turn_id": "turn_123",
+            "cwd": "/tmp",
+            "transcript_path": null,
+            "model": "gpt-5.1-codex",
+            "permission_mode": "default"
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn test_codex_rewrite_git_status() {
+        let result = run_codex_inner(&codex_input("git status")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let hook = &v["hookSpecificOutput"];
+
+        assert_eq!(hook["hookEventName"], PRE_TOOL_USE_KEY);
+        assert_eq!(hook["permissionDecision"], "allow");
+        assert_eq!(hook["permissionDecisionReason"], "RTK auto-rewrite");
+        assert_eq!(hook["updatedInput"]["command"], "rtk git status");
+    }
+
+    #[test]
+    fn test_codex_rewrite_preserves_allowed_shape_only() {
+        let result = run_codex_inner(&codex_input("GIT_PAGER=cat git status")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let hook = &v["hookSpecificOutput"];
+
+        assert_eq!(hook["permissionDecision"], "allow");
+        assert_eq!(
+            hook["updatedInput"],
+            json!({ "command": "GIT_PAGER=cat rtk git status" })
+        );
+    }
+
+    #[test]
+    fn test_codex_passthrough_no_output() {
+        assert!(run_codex_inner(&codex_input("htop")).is_none());
+        assert!(run_codex_inner(&codex_input("rtk git status")).is_none());
+        assert!(run_codex_inner("not valid json {{{").is_none());
     }
 
     // --- Cursor handler ---

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -13,11 +13,11 @@ use crate::hooks::constants::{
 };
 
 use super::constants::{
-    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND,
-    GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_INIT_FILE,
-    HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON, HOOKS_SUBDIR,
-    PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR, PI_PLUGIN_FILE,
-    PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
+    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CODEX_HOOK_COMMAND,
+    CURSOR_HOOK_COMMAND, GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR,
+    HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON,
+    HOOKS_SUBDIR, PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR,
+    PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use super::integrity;
 
@@ -273,13 +273,7 @@ pub fn run(
         if hook_only {
             anyhow::bail!("--codex cannot be combined with --hook-only");
         }
-        if matches!(patch_mode, PatchMode::Auto) {
-            anyhow::bail!("--codex cannot be combined with --auto-patch");
-        }
-        if matches!(patch_mode, PatchMode::Skip) {
-            anyhow::bail!("--codex cannot be combined with --no-patch");
-        }
-        run_codex_mode(global, ctx)?;
+        run_codex_mode(global, patch_mode, ctx)?;
     } else {
         // Validation: Global-only features
         if install_opencode && !global {
@@ -920,6 +914,37 @@ fn uninstall_codex_at(codex_dir: &Path, ctx: InitContext) -> Result<Vec<String>>
         ctx,
     )? {
         removed.push("AGENTS.md: removed @RTK.md reference".to_string());
+    }
+
+    let hooks_json_path = codex_dir.join(HOOKS_JSON);
+    if hooks_json_path.exists() {
+        let content = fs::read_to_string(&hooks_json_path)
+            .with_context(|| format!("Failed to read {}", hooks_json_path.display()))?;
+
+        if !content.trim().is_empty() {
+            let mut root: serde_json::Value =
+                serde_json::from_str(&content).with_context(|| {
+                    format!("Failed to parse {} as JSON", hooks_json_path.display())
+                })?;
+            if remove_codex_hook_from_json(&mut root) {
+                if dry_run {
+                    println!(
+                        "[dry-run] would remove RTK entry from Codex hooks.json: {}",
+                        hooks_json_path.display()
+                    );
+                } else {
+                    let backup_path = hooks_json_path.with_extension("json.bak");
+                    fs::copy(&hooks_json_path, &backup_path).ok();
+                    let serialized = serde_json::to_string_pretty(&root)
+                        .context("Failed to serialize hooks.json")?;
+                    atomic_write(&hooks_json_path, &serialized)?;
+                    if verbose > 0 {
+                        eprintln!("Removed RTK hook from Codex hooks.json");
+                    }
+                }
+                removed.push("hooks.json: removed RTK PreToolUse hook".to_string());
+            }
+        }
     }
 
     Ok(removed)
@@ -2253,21 +2278,38 @@ fn normalized_yaml_scalar(value: &str) -> Option<String> {
     (!trimmed.is_empty()).then(|| trimmed.to_string())
 }
 
-fn run_codex_mode(global: bool, ctx: InitContext) -> Result<()> {
-    let (agents_md_path, rtk_md_path) = if global {
+fn run_codex_mode(global: bool, patch_mode: PatchMode, ctx: InitContext) -> Result<()> {
+    let (agents_md_path, rtk_md_path, hooks_json_path) = if global {
         let codex_dir = resolve_codex_dir()?;
-        (codex_dir.join(AGENTS_MD), codex_dir.join(RTK_MD))
+        (
+            codex_dir.join(AGENTS_MD),
+            codex_dir.join(RTK_MD),
+            codex_dir.join(HOOKS_JSON),
+        )
     } else {
-        (PathBuf::from(AGENTS_MD), PathBuf::from(RTK_MD))
+        (
+            PathBuf::from(AGENTS_MD),
+            PathBuf::from(RTK_MD),
+            PathBuf::from(".codex").join(HOOKS_JSON),
+        )
     };
 
-    run_codex_mode_with_paths(agents_md_path, rtk_md_path, global, ctx)
+    run_codex_mode_with_paths(
+        agents_md_path,
+        rtk_md_path,
+        hooks_json_path,
+        global,
+        patch_mode,
+        ctx,
+    )
 }
 
 fn run_codex_mode_with_paths(
     agents_md_path: PathBuf,
     rtk_md_path: PathBuf,
+    hooks_json_path: PathBuf,
     global: bool,
+    patch_mode: PatchMode,
     ctx: InitContext,
 ) -> Result<()> {
     let InitContext { dry_run, .. } = ctx;
@@ -2297,6 +2339,7 @@ fn run_codex_mode_with_paths(
 
     write_if_changed(&rtk_md_path, RTK_SLIM_CODEX, RTK_MD, ctx)?;
     let added_ref = patch_agents_md(&agents_md_path, &rtk_md_ref, ctx)?;
+    let hook_result = patch_codex_hooks_json(&hooks_json_path, patch_mode, ctx)?;
 
     if !dry_run {
         println!("\nRTK configured for Codex CLI.\n");
@@ -2305,6 +2348,16 @@ fn run_codex_mode_with_paths(
             println!("  AGENTS.md: {} reference added", rtk_md_ref);
         } else {
             println!("  AGENTS.md: {} reference already present", rtk_md_ref);
+        }
+        println!("  hooks.json: {}", hooks_json_path.display());
+        match hook_result {
+            PatchResult::Patched => println!("  hooks.json: RTK PreToolUse hook added"),
+            PatchResult::AlreadyPresent => {
+                println!("  hooks.json: RTK PreToolUse hook already present")
+            }
+            PatchResult::Declined => println!("  hooks.json: hook patch declined"),
+            PatchResult::Skipped => println!("  hooks.json: hook patch skipped"),
+            PatchResult::WouldPatch => {}
         }
         if global {
             println!(
@@ -2317,6 +2370,7 @@ fn run_codex_mode_with_paths(
                 agents_md_path.display()
             );
         }
+        println!("  Restart Codex CLI. Test with: git status");
     }
 
     Ok(())
@@ -2616,6 +2670,181 @@ fn patch_agents_md(path: &Path, rtk_md_ref: &str, ctx: InitContext) -> Result<bo
     }
 
     Ok(true)
+}
+
+fn print_codex_manual_instructions(hook_command: &str) {
+    println!("\n  MANUAL STEP: Add this to $CODEX_HOME/hooks.json or ~/.codex/hooks.json:");
+    println!("  {{");
+    println!("    \"hooks\": {{ \"PreToolUse\": [{{");
+    println!("      \"matcher\": \"^Bash$\",");
+    println!("      \"hooks\": [{{ \"type\": \"command\",");
+    println!("        \"command\": \"{}\"", hook_command);
+    println!("      }}]");
+    println!("    }}]}}");
+    println!("  }}");
+    println!("\n  Then restart Codex CLI. Test with: git status\n");
+}
+
+fn patch_codex_hooks_json(path: &Path, mode: PatchMode, ctx: InitContext) -> Result<PatchResult> {
+    let InitContext { verbose, dry_run } = ctx;
+    let mut root = if path.exists() {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+        if content.trim().is_empty() {
+            serde_json::json!({})
+        } else {
+            serde_json::from_str(&content)
+                .with_context(|| format!("Failed to parse {} as JSON", path.display()))?
+        }
+    } else {
+        serde_json::json!({})
+    };
+
+    if codex_hook_already_present(&root) {
+        if verbose > 0 {
+            eprintln!("Codex hooks.json: RTK hook already present");
+        }
+        return Ok(PatchResult::AlreadyPresent);
+    }
+
+    match mode {
+        PatchMode::Skip => {
+            print_codex_manual_instructions(CODEX_HOOK_COMMAND);
+            return Ok(PatchResult::Skipped);
+        }
+        PatchMode::Ask => {
+            if dry_run {
+                println!(
+                    "[dry-run] would prompt before patching Codex hooks.json: {}",
+                    path.display()
+                );
+            } else if !prompt_user_consent(path)? {
+                print_codex_manual_instructions(CODEX_HOOK_COMMAND);
+                return Ok(PatchResult::Declined);
+            }
+        }
+        PatchMode::Auto => {}
+    }
+
+    insert_codex_hook_entry(&mut root)?;
+
+    let serialized =
+        serde_json::to_string_pretty(&root).context("Failed to serialize hooks.json")?;
+
+    if dry_run {
+        println!("[dry-run] would patch Codex hooks.json: {}", path.display());
+        if verbose > 0 {
+            println!("[dry-run] content:\n{}", serialized);
+        }
+        return Ok(PatchResult::WouldPatch);
+    }
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "Failed to create Codex hooks directory: {}",
+                parent.display()
+            )
+        })?;
+    }
+
+    if path.exists() {
+        let backup_path = path.with_extension("json.bak");
+        fs::copy(path, &backup_path)
+            .with_context(|| format!("Failed to backup to {}", backup_path.display()))?;
+        if verbose > 0 {
+            eprintln!("Backup: {}", backup_path.display());
+        }
+    }
+
+    atomic_write(path, &serialized)?;
+    Ok(PatchResult::Patched)
+}
+
+fn codex_hook_already_present(root: &serde_json::Value) -> bool {
+    let hooks = match root
+        .get("hooks")
+        .and_then(|h| h.get(PRE_TOOL_USE_KEY))
+        .and_then(|p| p.as_array())
+    {
+        Some(arr) => arr,
+        None => return false,
+    };
+
+    hooks
+        .iter()
+        .filter_map(|entry| entry.get("hooks")?.as_array())
+        .flatten()
+        .filter_map(|hook| hook.get("command")?.as_str())
+        .any(|cmd| {
+            cmd == CODEX_HOOK_COMMAND
+                || cmd == CLAUDE_HOOK_COMMAND
+                || cmd.contains(REWRITE_HOOK_FILE)
+        })
+}
+
+fn insert_codex_hook_entry(root: &mut serde_json::Value) -> Result<()> {
+    let root_obj = match root.as_object_mut() {
+        Some(obj) => obj,
+        None => {
+            *root = serde_json::json!({});
+            root.as_object_mut().expect("just-created json object")
+        }
+    };
+
+    let hooks = root_obj
+        .entry("hooks")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .context("hooks value is not an object")?;
+
+    let pre_tool_use = hooks
+        .entry(PRE_TOOL_USE_KEY)
+        .or_insert_with(|| serde_json::json!([]))
+        .as_array_mut()
+        .context("PreToolUse value is not an array")?;
+
+    pre_tool_use.push(serde_json::json!({
+        "matcher": "^Bash$",
+        "hooks": [{
+            "type": "command",
+            "command": CODEX_HOOK_COMMAND,
+            "timeout": 10,
+            "statusMessage": "RTK rewriting shell command"
+        }]
+    }));
+    Ok(())
+}
+
+fn remove_codex_hook_from_json(root: &mut serde_json::Value) -> bool {
+    let pre_tool_use = match root
+        .get_mut("hooks")
+        .and_then(|h| h.get_mut(PRE_TOOL_USE_KEY))
+        .and_then(|p| p.as_array_mut())
+    {
+        Some(arr) => arr,
+        None => return false,
+    };
+
+    let original_len = pre_tool_use.len();
+    pre_tool_use.retain(|entry| {
+        !entry
+            .get("hooks")
+            .and_then(|hooks| hooks.as_array())
+            .is_some_and(|hooks| {
+                hooks.iter().any(|hook| {
+                    hook.get("command")
+                        .and_then(|command| command.as_str())
+                        .is_some_and(|cmd| {
+                            cmd == CODEX_HOOK_COMMAND
+                                || cmd == CLAUDE_HOOK_COMMAND
+                                || cmd.contains(REWRITE_HOOK_FILE)
+                        })
+                })
+            })
+    });
+
+    pre_tool_use.len() < original_len
 }
 
 fn has_rtk_reference(content: &str, refs: &[&str]) -> bool {
@@ -3529,6 +3758,22 @@ fn show_codex_config() -> Result<()> {
         println!("[--] Global RTK.md: not found");
     }
 
+    let global_hooks_json = codex_dir.join(HOOKS_JSON);
+    if global_hooks_json.exists() {
+        let content = fs::read_to_string(&global_hooks_json)?;
+        if let Ok(root) = serde_json::from_str::<serde_json::Value>(&content) {
+            if codex_hook_already_present(&root) {
+                println!("[ok] Global hooks.json: RTK PreToolUse hook");
+            } else {
+                println!("[--] Global hooks.json: exists but rtk hook not configured");
+            }
+        } else {
+            println!("[!!] Global hooks.json: invalid JSON");
+        }
+    } else {
+        println!("[--] Global hooks.json: not found");
+    }
+
     if global_agents_md.exists() {
         let content = fs::read_to_string(&global_agents_md)?;
         if has_rtk_reference(&content, &[RTK_MD_REF, global_rtk_md_ref.as_str()]) {
@@ -3548,6 +3793,22 @@ fn show_codex_config() -> Result<()> {
         println!("[--] Local RTK.md: not found");
     }
 
+    let local_hooks_json = PathBuf::from(".codex").join(HOOKS_JSON);
+    if local_hooks_json.exists() {
+        let content = fs::read_to_string(&local_hooks_json)?;
+        if let Ok(root) = serde_json::from_str::<serde_json::Value>(&content) {
+            if codex_hook_already_present(&root) {
+                println!("[ok] Local hooks.json: RTK PreToolUse hook");
+            } else {
+                println!("[--] Local hooks.json: exists but rtk hook not configured");
+            }
+        } else {
+            println!("[!!] Local hooks.json: invalid JSON");
+        }
+    } else {
+        println!("[--] Local hooks.json: not found");
+    }
+
     if local_agents_md.exists() {
         let content = fs::read_to_string(&local_agents_md)?;
         if has_rtk_reference(&content, &[RTK_MD_REF]) {
@@ -3562,8 +3823,10 @@ fn show_codex_config() -> Result<()> {
     }
 
     println!("\nUsage:");
-    println!("  rtk init --codex              # Configure local AGENTS.md + RTK.md");
-    println!("  rtk init -g --codex           # Configure $CODEX_HOME/AGENTS.md + $CODEX_HOME/RTK.md (or ~/.codex/)");
+    println!(
+        "  rtk init --codex              # Configure local AGENTS.md + RTK.md + .codex/hooks.json"
+    );
+    println!("  rtk init -g --codex           # Configure $CODEX_HOME/AGENTS.md + RTK.md + hooks.json (or ~/.codex/)");
     println!("  rtk init -g --codex --uninstall  # Remove global Codex RTK artifacts");
 
     Ok(())
@@ -4359,47 +4622,43 @@ mod tests {
     }
 
     #[test]
-    fn test_codex_mode_rejects_auto_patch() {
-        let err = run(
+    fn test_codex_mode_accepts_auto_patch() {
+        let temp = TempDir::new().unwrap();
+        let agents_md = temp.path().join(AGENTS_MD);
+        let rtk_md = temp.path().join(RTK_MD);
+        let hooks_json = temp.path().join(".codex").join(HOOKS_JSON);
+
+        run_codex_mode_with_paths(
+            agents_md,
+            rtk_md,
+            hooks_json.clone(),
             false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            true,
             PatchMode::Auto,
             InitContext::default(),
         )
-        .unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "--codex cannot be combined with --auto-patch"
-        );
+        .unwrap();
+
+        assert!(hooks_json.exists());
     }
 
     #[test]
-    fn test_codex_mode_rejects_no_patch() {
-        let err = run(
+    fn test_codex_mode_accepts_no_patch() {
+        let temp = TempDir::new().unwrap();
+        let agents_md = temp.path().join(AGENTS_MD);
+        let rtk_md = temp.path().join(RTK_MD);
+        let hooks_json = temp.path().join(".codex").join(HOOKS_JSON);
+
+        run_codex_mode_with_paths(
+            agents_md,
+            rtk_md,
+            hooks_json.clone(),
             false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            false,
-            true,
             PatchMode::Skip,
             InitContext::default(),
         )
-        .unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "--codex cannot be combined with --no-patch"
-        );
+        .unwrap();
+
+        assert!(!hooks_json.exists());
     }
 
     #[test]
@@ -4975,10 +5234,13 @@ mod tests {
         let agents_md = temp.path().join("AGENTS.md");
         let rtk_md = temp.path().join("RTK.md");
 
+        let hooks_json = temp.path().join("hooks.json");
         run_codex_mode_with_paths(
             agents_md.clone(),
             rtk_md.clone(),
+            hooks_json.clone(),
             true,
+            PatchMode::Auto,
             InitContext::default(),
         )
         .unwrap();
@@ -4988,6 +5250,13 @@ mod tests {
         assert_eq!(
             fs::read_to_string(&agents_md).unwrap(),
             format!("{}\n", codex_rtk_md_ref(temp.path()))
+        );
+        let hooks: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&hooks_json).unwrap()).unwrap();
+        assert!(codex_hook_already_present(&hooks));
+        assert_eq!(
+            hooks["hooks"][PRE_TOOL_USE_KEY][0]["hooks"][0]["command"],
+            CODEX_HOOK_COMMAND
         );
     }
 
@@ -5032,6 +5301,76 @@ mod tests {
     }
 
     #[test]
+    fn test_insert_codex_hook_entry_empty_root() {
+        let mut json_content = serde_json::json!({});
+        insert_codex_hook_entry(&mut json_content).unwrap();
+
+        let pre_tool_use = json_content["hooks"][PRE_TOOL_USE_KEY].as_array().unwrap();
+        assert_eq!(pre_tool_use.len(), 1);
+        assert_eq!(pre_tool_use[0]["matcher"], "^Bash$");
+        assert_eq!(pre_tool_use[0]["hooks"][0]["type"], "command");
+        assert_eq!(pre_tool_use[0]["hooks"][0]["command"], CODEX_HOOK_COMMAND);
+        assert_eq!(pre_tool_use[0]["hooks"][0]["timeout"], 10);
+    }
+
+    #[test]
+    fn test_codex_hook_already_present_new_command() {
+        let json_content = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "^Bash$",
+                    "hooks": [{
+                        "type": "command",
+                        "command": CODEX_HOOK_COMMAND
+                    }]
+                }]
+            }
+        });
+
+        assert!(codex_hook_already_present(&json_content));
+    }
+
+    #[test]
+    fn test_codex_hook_already_present_legacy_claude_command() {
+        let json_content = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "^Bash$",
+                    "hooks": [{
+                        "type": "command",
+                        "command": CLAUDE_HOOK_COMMAND
+                    }]
+                }]
+            }
+        });
+
+        assert!(codex_hook_already_present(&json_content));
+    }
+
+    #[test]
+    fn test_remove_codex_hook_from_json() {
+        let mut json_content = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "^Bash$",
+                        "hooks": [{"type": "command", "command": CODEX_HOOK_COMMAND}]
+                    },
+                    {
+                        "matcher": "^Bash$",
+                        "hooks": [{"type": "command", "command": "other hook"}]
+                    }
+                ]
+            }
+        });
+
+        assert!(remove_codex_hook_from_json(&mut json_content));
+        let pre_tool_use = json_content["hooks"][PRE_TOOL_USE_KEY].as_array().unwrap();
+        assert_eq!(pre_tool_use.len(), 1);
+        assert_eq!(pre_tool_use[0]["hooks"][0]["command"], "other hook");
+    }
+
+    #[test]
     fn test_uninstall_codex_at_is_idempotent() {
         let temp = TempDir::new().unwrap();
         let codex_dir = temp.path();
@@ -5041,12 +5380,20 @@ mod tests {
         fs::write(&agents_md, "# Team rules\n\n@RTK.md\n").unwrap();
         fs::write(&rtk_md, "codex config").unwrap();
 
+        let hooks_json = codex_dir.join(HOOKS_JSON);
+        let mut hooks = serde_json::json!({});
+        insert_codex_hook_entry(&mut hooks).unwrap();
+        fs::write(&hooks_json, serde_json::to_string_pretty(&hooks).unwrap()).unwrap();
+
         let removed_first = uninstall_codex_at(codex_dir, InitContext::default()).unwrap();
         let removed_second = uninstall_codex_at(codex_dir, InitContext::default()).unwrap();
 
-        assert_eq!(removed_first.len(), 2);
+        assert_eq!(removed_first.len(), 3);
         assert!(removed_second.is_empty());
         assert!(!rtk_md.exists());
+        let hooks_after: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&hooks_json).unwrap()).unwrap();
+        assert!(!codex_hook_already_present(&hooks_after));
 
         let content = fs::read_to_string(&agents_md).unwrap();
         assert!(!content.contains("@RTK.md"));
@@ -5130,10 +5477,13 @@ mod tests {
         let agents_md = temp.path().join("AGENTS.md");
         let rtk_md = temp.path().join("RTK.md");
 
+        let hooks_json = temp.path().join("hooks.json");
         run_codex_mode_with_paths(
             agents_md.clone(),
             rtk_md.clone(),
+            hooks_json.clone(),
             true,
+            PatchMode::Auto,
             InitContext {
                 dry_run: true,
                 ..Default::default()
@@ -5150,6 +5500,11 @@ mod tests {
             !agents_md.exists(),
             "dry-run must not create AGENTS.md: {}",
             agents_md.display()
+        );
+        assert!(
+            !hooks_json.exists(),
+            "dry-run must not create hooks.json: {}",
+            hooks_json.display()
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -369,7 +369,7 @@ enum Commands {
         #[arg(long)]
         uninstall: bool,
 
-        /// Target Codex CLI (uses AGENTS.md + RTK.md, no Claude hook patching)
+        /// Target Codex CLI (uses AGENTS.md + RTK.md + hooks.json)
         #[arg(long)]
         codex: bool,
 
@@ -769,6 +769,8 @@ enum Commands {
 enum HookCommands {
     /// Process Claude Code PreToolUse hook (reads JSON from stdin)
     Claude,
+    /// Process Codex CLI PreToolUse hook (reads JSON from stdin)
+    Codex,
     /// Process Cursor Agent hook (reads JSON from stdin)
     Cursor,
     /// Process Gemini CLI BeforeTool hook (reads JSON from stdin)
@@ -2198,6 +2200,10 @@ fn run_cli() -> Result<i32> {
         Commands::Hook { command } => match command {
             HookCommands::Claude => {
                 hooks::hook_cmd::run_claude()?;
+                0
+            }
+            HookCommands::Codex => {
+                hooks::hook_cmd::run_codex()?;
                 0
             }
             HookCommands::Cursor => {


### PR DESCRIPTION
## Summary
- add Codex CLI PreToolUse hook processing via `rtk hook codex`
- patch Codex `hooks.json` during `rtk init --codex --auto-patch`
- update Codex hook documentation and support matrix

## Verification
- `cargo fmt --check`
- `env -u CFLAGS cargo test hook_cmd -- --nocapture`
- `env -u CFLAGS cargo test codex -- --nocapture`
- `env -u CFLAGS cargo check`
