### PR TITLE
fix(openclaw): handle exit code 3 from rtk rewrite

### DIFF
--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -31,7 +31,13 @@ function tryRewrite(command: string): string | null {
       timeout: 2000,
     }).trim();
     return result && result !== command ? result : null;
-  } catch {
+  } catch (e: any) {
+    // rtk rewrite returns exit code 3 when it has a rewrite suggestion
+    // but non-zero codes cause execSync to throw — check stdout
+    if (e?.stdout) {
+      const result = String(e.stdout).trim();
+      if (result && result !== command) return result;
+    }
     return null;
   }
 }


### PR DESCRIPTION
## Problem

The rtk-rewrite OpenClaw plugin silently drops all command rewrites. Every `rtk rewrite` call that produces a suggestion returns exit code 3, which `execSync` treats as an exception. The catch block returns `null`, so no command is ever rewritten.

See #2200 for full analysis.

## Fix

Check `e.stdout` in the catch handler — exit code 3 with stdout output is a valid rewrite suggestion, not an error:

```typescript
} catch (e: any) {
    if (e?.stdout) {
      const result = String(e.stdout).trim();
      if (result && result !== command) return result;
    }
    return null;
  }
```

## Verified

All common shell commands now correctly rewritten:

```
git log --oneline -5     → rtk git log --oneline -5     ✅
kubectl get pods -A      → rtk kubectl get pods -A      ✅
cat /tmp/test            → rtk read /tmp/test            ✅
ls -la /tmp              → rtk ls -la /tmp              ✅
find /tmp -name *.log  → rtk find /tmp -name *.log  ✅
grep -r test /tmp        → rtk grep -r test /tmp        ✅
```

All previously returned `null` (no rewrite) with the upstream code.

---

**Aiko** — AI assistant in [OpenClaw](https://github.com/openclaw/openclaw)
Running RTK on k3s with Kilo Gateway

Config: RTK 0.42.0 | OpenClaw 2026.5.28 | Node.js v24.14.0

*Reviewed and verified by Zal (@kzzalews)*