### PR TITLE
fix(git): add visible truncation markers to filtered output

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -622,10 +622,9 @@ pub(crate) fn filter_log_output(
     let mut out = result.join("\n").trim().to_string();
     if omitted_commits > 0 {
         out.push_str(&format!(
-            "\n[RTK: truncated — {} of {} commits shown — run `rtk proxy git log {}` for full output]",
+            "\n[RTK: truncated — {} of {} commits shown]",
             max_commits,
             commits.len(),
-            "" // args would ideally be passed through
         ));
     }
     out

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -559,12 +559,21 @@ pub(crate) fn filter_log_output(
     if user_format {
         let lines: Vec<&str> = output.lines().collect();
         let max_lines = if user_set_limit { lines.len() } else { limit };
-        return lines
+        let omitted = lines.len().saturating_sub(max_lines);
+        let mut out = lines
             .iter()
             .take(max_lines)
             .map(|l| truncate_line(l, truncate_width))
             .collect::<Vec<_>>()
             .join("\n");
+        if omitted > 0 {
+            out.push_str(&format!(
+                "\n[RTK: truncated — {} of {} lines shown]",
+                max_lines,
+                lines.len()
+            ));
+        }
+        return out;
     }
 
     // RTK injected format: split output into commit blocks separated by ---END---
@@ -609,7 +618,17 @@ pub(crate) fn filter_log_output(
         }
     }
 
-    result.join("\n").trim().to_string()
+    let omitted_commits = commits.len().saturating_sub(max_commits);
+    let mut out = result.join("\n").trim().to_string();
+    if omitted_commits > 0 {
+        out.push_str(&format!(
+            "\n[RTK: truncated — {} of {} commits shown — run `rtk proxy git log {}` for full output]",
+            max_commits,
+            commits.len(),
+            "" // args would ideally be passed through
+        ));
+    }
+    out
 }
 
 /// Truncate a single line to `width` characters, appending "..." if needed

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -23,19 +23,16 @@ use std::process::Command;
 /// assert_eq!(truncate("hi", 10), "hi");
 /// ```
 pub fn truncate(s: &str, max_len: usize) -> String {
-    let char_count = s.chars().count();
-    if char_count <= max_len {
-        s.to_string()
-    } else if max_len < 3 {
+    if max_len < 3 {
         // If max_len is too small, just return "..."
         "...".to_string()
     } else {
-        format!(
-            "{}\n[RTK: truncated — {} of {} chars]",
-            s.chars().take(max_len).collect::<String>(),
-            max_len,
-            char_count,
-        )
+        let char_count = s.chars().count();
+        if char_count <= max_len {
+            s.to_string()
+        } else {
+            format!("{}...", s.chars().take(max_len - 3).collect::<String>())
+        }
     }
 }
 

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -30,7 +30,12 @@ pub fn truncate(s: &str, max_len: usize) -> String {
         // If max_len is too small, just return "..."
         "...".to_string()
     } else {
-        format!("{}...", s.chars().take(max_len - 3).collect::<String>())
+        format!(
+            "{}\n[RTK: truncated — {} of {} chars]",
+            s.chars().take(max_len).collect::<String>(),
+            max_len,
+            char_count,
+        )
     }
 }
 


### PR DESCRIPTION
Closes #2204

Added visible truncation markers when git log output is capped (commits or lines), and changed truncate() to show [RTK: truncated] instead of silent '...'.