### PR TITLE
fix: truncate kubectl exec output before LLM context

### DIFF
--- a/src/cmds/system/local_llm.rs
+++ b/src/cmds/system/local_llm.rs
@@ -3,12 +3,22 @@
 use anyhow::{Context, Result};
 use regex::Regex;
 use std::fs;
+use std::io::Read;
 use std::path::Path;
 
 use crate::core::filter::Language;
+use crate::core::truncate::CAP_INVENTORY;
+use crate::core::utils::{strip_ansi, truncate};
+
+const SMART_STDIN_MAX_LINES: usize = CAP_INVENTORY;
+const SMART_STDIN_MAX_LINE_LEN: usize = 160;
 
 /// Heuristic-based code summarizer - no external model needed
-pub fn run(file: &Path, _model: &str, _force_download: bool, verbose: u8) -> Result<()> {
+pub fn run(file: Option<&Path>, _model: &str, _force_download: bool, verbose: u8) -> Result<()> {
+    let Some(file) = file else {
+        return run_stdin(verbose);
+    };
+
     if verbose > 0 {
         eprintln!("Analyzing: {}", file.display());
     }
@@ -28,6 +38,51 @@ pub fn run(file: &Path, _model: &str, _force_download: bool, verbose: u8) -> Res
     println!("{}", summary.line2);
 
     Ok(())
+}
+
+fn run_stdin(verbose: u8) -> Result<()> {
+    if verbose > 0 {
+        eprintln!("Analyzing stdin");
+    }
+
+    let mut input = String::new();
+    std::io::stdin()
+        .read_to_string(&mut input)
+        .context("Failed to read stdin")?;
+
+    print!("{}", filter_stdin(&input));
+    Ok(())
+}
+
+pub fn filter_stdin(input: &str) -> String {
+    let clean = strip_ansi(input);
+    let lines: Vec<&str> = clean.lines().collect();
+    if lines.is_empty() {
+        return String::new();
+    }
+
+    let needs_line_cap = lines.len() > SMART_STDIN_MAX_LINES;
+    let needs_width_cap = lines
+        .iter()
+        .any(|line| line.chars().count() > SMART_STDIN_MAX_LINE_LEN);
+    if !needs_line_cap && !needs_width_cap {
+        return clean;
+    }
+
+    let mut output: Vec<String> = lines
+        .iter()
+        .take(SMART_STDIN_MAX_LINES)
+        .map(|line| truncate(line, SMART_STDIN_MAX_LINE_LEN))
+        .collect();
+
+    if lines.len() > SMART_STDIN_MAX_LINES {
+        output.push(format!(
+            "[{} more lines]",
+            lines.len() - SMART_STDIN_MAX_LINES
+        ));
+    }
+
+    output.join("\n")
 }
 
 struct CodeSummary {
@@ -314,5 +369,18 @@ def load_config():
 "#;
         let summary = analyze_code(code, &Language::Python);
         assert!(summary.line1.contains("Python"));
+    }
+
+    #[test]
+    fn test_filter_stdin_truncates_structured_output() {
+        let input = (0..55)
+            .map(|idx| format!("root {:>5} {}", idx, "x".repeat(200)))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let output = filter_stdin(&input);
+        assert!(output.lines().count() <= SMART_STDIN_MAX_LINES + 1);
+        assert!(output.contains("[5 more lines]"));
+        assert!(output.lines().next().unwrap().ends_with("..."));
     }
 }

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1012,6 +1012,14 @@ fn rewrite_pipeline_final_stage(
     transparent_prefixes: &[String],
 ) -> Option<String> {
     let final_stage_start = analysis.final_stage_start?;
+    let pipeline = cmd[segment_start..analysis.end_offset].trim();
+    let first_stage = pipeline
+        .split_once('|')
+        .map_or(pipeline, |(stage, _)| stage)
+        .trim();
+    if is_kubectl_exec_segment(first_stage) {
+        return None;
+    }
     let final_stage = cmd[final_stage_start..analysis.end_offset].trim();
 
     rewrite_segment_inner(
@@ -1166,6 +1174,163 @@ fn rewrite_line_range(cmd: &str) -> Option<String> {
         }
     }
     None
+}
+
+enum KubectlExecRewrite {
+    Rewrite(String),
+    Passthrough,
+}
+
+const KUBECTL_EXEC_FILE_OUTPUT_COMMANDS: &[&str] = &["cat", "less", "more", "tail"];
+const KUBECTL_EXEC_STRUCTURED_OUTPUT_COMMANDS: &[&str] = &["ps", "env", "printenv", "df"];
+const KUBECTL_EXEC_MANAGEMENT_COMMANDS: &[&str] =
+    &["rm", "kill", "mkdir", "chmod", "chown", "mv", "cp", "touch"];
+
+fn is_kubectl_exec_segment(cmd: &str) -> bool {
+    let trimmed = cmd.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    let (env_prefix, rest_after_env) = strip_disabled_prefix(trimmed);
+    if !env_prefix.is_empty() {
+        return is_kubectl_exec_segment(rest_after_env);
+    }
+
+    for &prefix in SHELL_KEYWORD_PREFIXES {
+        if let Some(rest) = strip_word_prefix(trimmed, prefix) {
+            return is_kubectl_exec_segment(rest);
+        }
+    }
+
+    is_kubectl_exec_command(trimmed)
+}
+
+fn rewrite_kubectl_exec(cmd_part: &str, redirect_suffix: &str) -> Option<KubectlExecRewrite> {
+    let inner = parse_kubectl_exec_inner_command(cmd_part)?;
+
+    if !redirect_suffix.is_empty() {
+        return Some(KubectlExecRewrite::Passthrough);
+    }
+
+    let inner_command = first_command_word(inner)?;
+    if inner_command == "head" || KUBECTL_EXEC_MANAGEMENT_COMMANDS.contains(&inner_command.as_str())
+    {
+        return Some(KubectlExecRewrite::Passthrough);
+    }
+
+    if KUBECTL_EXEC_FILE_OUTPUT_COMMANDS.contains(&inner_command.as_str()) {
+        return Some(KubectlExecRewrite::Rewrite(format!(
+            "{} | tail -100",
+            cmd_part
+        )));
+    }
+
+    if KUBECTL_EXEC_STRUCTURED_OUTPUT_COMMANDS.contains(&inner_command.as_str()) {
+        return Some(KubectlExecRewrite::Rewrite(format!(
+            "{} | rtk smart",
+            cmd_part
+        )));
+    }
+
+    Some(KubectlExecRewrite::Passthrough)
+}
+
+fn parse_kubectl_exec_inner_command(cmd: &str) -> Option<&str> {
+    let tokens = tokenize(cmd);
+    let args: Vec<&ParsedToken> = tokens
+        .iter()
+        .filter(|token| token.kind == TokenKind::Arg)
+        .collect();
+
+    let first = args.first()?.value.as_str();
+    if first.rsplit('/').next().unwrap_or(first) != "kubectl" {
+        return None;
+    }
+
+    let exec_idx = kubectl_exec_arg_index(&args)?;
+    for token in args.iter().skip(exec_idx + 1) {
+        if token.value == "--" {
+            return Some(cmd[token.offset + token.value.len()..].trim());
+        }
+    }
+
+    None
+}
+
+fn is_kubectl_exec_command(cmd: &str) -> bool {
+    let tokens = tokenize(cmd);
+    let args: Vec<&ParsedToken> = tokens
+        .iter()
+        .filter(|token| token.kind == TokenKind::Arg)
+        .collect();
+
+    let Some(first) = args.first() else {
+        return false;
+    };
+    if first.value.rsplit('/').next().unwrap_or(&first.value) != "kubectl" {
+        return false;
+    }
+
+    kubectl_exec_arg_index(&args).is_some()
+}
+
+fn kubectl_exec_arg_index(args: &[&ParsedToken]) -> Option<usize> {
+    let mut idx = 1;
+    while let Some(token) = args.get(idx) {
+        let value = token.value.as_str();
+        if value == "exec" {
+            return Some(idx);
+        }
+        if value == "--" || !value.starts_with('-') {
+            return None;
+        }
+
+        if kubectl_global_flag_takes_value(value) && !value.contains('=') {
+            idx += 1;
+        }
+        idx += 1;
+    }
+
+    None
+}
+
+fn kubectl_global_flag_takes_value(flag: &str) -> bool {
+    let name = flag.split_once('=').map_or(flag, |(name, _)| name);
+    matches!(
+        name,
+        "-n" | "--namespace"
+            | "--context"
+            | "--kubeconfig"
+            | "--cluster"
+            | "--user"
+            | "--as"
+            | "--as-group"
+            | "--token"
+            | "--server"
+            | "--request-timeout"
+            | "--cache-dir"
+            | "--certificate-authority"
+            | "--client-certificate"
+            | "--client-key"
+            | "--tls-server-name"
+            | "-s"
+    )
+}
+
+fn first_command_word(cmd: &str) -> Option<String> {
+    let (_, rest_after_env) = strip_disabled_prefix(cmd);
+    let first = tokenize(rest_after_env.trim())
+        .into_iter()
+        .find(|token| token.kind == TokenKind::Arg)?;
+    Some(
+        first
+            .value
+            .rsplit('/')
+            .next()
+            .unwrap_or(&first.value)
+            .to_string(),
+    )
 }
 
 /// Transparent wrappers that RULES can also match as a whole string, so an
@@ -1365,6 +1530,16 @@ fn rewrite_segment_inner(
         && (cmd_part.starts_with("head -") || cmd_part.starts_with("tail "))
     {
         return rewrite_line_range(cmd_part).map(|r| format!("{}{}", r, redirect_suffix));
+    }
+
+    if let Some(kubectl_exec) = rewrite_kubectl_exec(cmd_part, redirect_suffix) {
+        return match kubectl_exec {
+            KubectlExecRewrite::Rewrite(rewritten) => Some(rewritten),
+            KubectlExecRewrite::Passthrough => Some(trimmed.to_string()),
+        };
+    }
+    if is_kubectl_exec_command(cmd_part) {
+        return None;
     }
 
     // Most cat flags (-v, -A, -e, -t, -s, -b, --show-all, etc.) have different
@@ -3233,6 +3408,60 @@ mod tests {
         assert_eq!(
             rewrite_command_no_prefixes("kubectl describe pod mypod", &[]),
             Some("rtk kubectl describe pod mypod".into())
+        );
+    }
+
+    #[test]
+    fn test_classify_kubectl_exec() {
+        assert!(matches!(
+            classify_command("kubectl exec -n prod mypod -- cat /var/log/app.log"),
+            Classification::Supported {
+                rtk_equivalent: "rtk kubectl",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_rewrite_kubectl_exec_file_output() {
+        assert_eq!(
+            rewrite_command_no_prefixes("kubectl exec -n prod mypod -- cat /var/log/app.log", &[]),
+            Some("kubectl exec -n prod mypod -- cat /var/log/app.log | tail -100".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("kubectl -n prod exec mypod -- cat /var/log/app.log", &[]),
+            Some("kubectl -n prod exec mypod -- cat /var/log/app.log | tail -100".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_kubectl_exec_structured_output() {
+        assert_eq!(
+            rewrite_command_no_prefixes("kubectl exec mypod -- ps aux", &[]),
+            Some("kubectl exec mypod -- ps aux | rtk smart".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("kubectl exec mypod -- env", &[]),
+            Some("kubectl exec mypod -- env | rtk smart".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_kubectl_exec_preserves_mutating_or_ambiguous_commands() {
+        assert_eq!(
+            rewrite_command_no_prefixes("kubectl exec mypod -- rm /tmp/file", &[]),
+            None
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("kubectl exec mypod cat /var/log/app.log", &[]),
+            None
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes(
+                "kubectl exec mypod -- cat /var/log/app.log | tail -100",
+                &[]
+            ),
+            None
         );
     }
 

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -400,7 +400,7 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
-        pattern: r"^kubectl\s+(get|logs|describe|apply)",
+        pattern: r"^kubectl\s+(get|logs|describe|apply|exec)",
         rtk_cmd: "rtk kubectl",
         rewrite_prefixes: &["kubectl"],
         category: "Infra",

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,7 +119,7 @@ enum Commands {
     /// Generate 2-line technical summary (heuristic-based)
     Smart {
         /// File to analyze
-        file: PathBuf,
+        file: Option<PathBuf>,
         /// Model: heuristic
         #[arg(short, long, default_value = "heuristic")]
         model: String,
@@ -1650,7 +1650,7 @@ fn run_cli() -> Result<i32> {
             model,
             force_download,
         } => {
-            local_llm::run(&file, &model, force_download, cli.verbose)?;
+            local_llm::run(file.as_deref(), &model, force_download, cli.verbose)?;
             0
         }
 


### PR DESCRIPTION
## Summary

- Rewrite high-output `kubectl exec` file commands through `tail -100`.
- Rewrite structured `kubectl exec` output through `rtk smart`, which now accepts stdin.
- Leave mutating commands, redirects, existing pipes, and legacy exec syntax unchanged.

Fixes #2057

## Tests

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --no-fail-fast`
- Manual matrix via `rtk rewrite` for file, structured, mutating, piped, and global-flag forms.