### PR TITLE
fix(ruby): route rspec/rubocop version queries to passthrough

### DIFF
--- a/scripts/test-ruby.sh
+++ b/scripts/test-ruby.sh
@@ -70,6 +70,23 @@ assert_output() {
     fi
 }
 
+# Assert command output does NOT contain needle (regression guard, e.g. warnings)
+assert_not_contains() {
+    local name="$1"; local needle="$2"; shift 2
+    local output
+    output=$("$@" 2>&1) || true
+    if echo "$output" | grep -qi "$needle"; then
+        FAIL=$((FAIL + 1))
+        FAILURES+=("$name")
+        printf "  ${RED}FAIL${NC}  %s\n" "$name"
+        printf "        unexpected: '%s'\n" "$needle"
+        printf "        got: %s\n" "$(echo "$output" | head -3)"
+    else
+        PASS=$((PASS + 1))
+        printf "  ${GREEN}PASS${NC}  %s\n" "$name"
+    fi
+}
+
 skip_test() {
     local name="$1"; local reason="$2"
     SKIP=$((SKIP + 1))
@@ -292,6 +309,29 @@ assert_output "rtk rubocop (with offenses)" \
 assert_output "rtk rubocop app/ (with offenses)" \
     "rubocop_bait\|offense" \
     rtk rubocop app/
+
+# ── Version queries (#1946) ──────────────────────────
+# `--version` short-circuits before any formatter runs, so it prints plain text
+# (never the JSON report). It must pass through clean, with no JSON-parse warning.
+
+section "Version queries (#1946)"
+
+assert_output "rtk rspec --version (clean)" \
+    "RSpec" \
+    rtk rspec --version
+assert_not_contains "rtk rspec --version (no JSON warning)" \
+    "JSON parse failed\|format not recognized" \
+    rtk rspec --version
+
+assert_output "rtk rubocop --version (clean)" \
+    "[0-9]\.[0-9]" \
+    rtk rubocop --version
+assert_not_contains "rtk rubocop --version (no JSON warning)" \
+    "JSON parse failed\|format not recognized" \
+    rtk rubocop --version
+assert_not_contains "rtk rubocop -V (no JSON warning)" \
+    "JSON parse failed\|format not recognized" \
+    rtk rubocop -V
 
 # ── 3. Minitest (rake test) ──────────────────────────
 

--- a/src/cmds/ruby/rspec_cmd.rs
+++ b/src/cmds/ruby/rspec_cmd.rs
@@ -69,6 +69,12 @@ struct RspecSummary {
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     let mut cmd = ruby_exec("rspec");
 
+    // A `--version` query short-circuits inside rspec before any formatter runs,
+    // so it always prints plain text ("RSpec 3.x …"), never the JSON report — even
+    // if we inject `--format json`. Detect it up front and pass the output through
+    // untouched instead of trying to parse it as a test report (#1946).
+    let is_version = is_version_query(args);
+
     let has_format = args.iter().any(|a| {
         a == "--format"
             || a == "-f"
@@ -76,14 +82,18 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
             || (a.starts_with("-f") && a.len() > 2 && !a.starts_with("--"))
     });
 
-    if !has_format {
+    if !has_format && !is_version {
         cmd.arg("--format").arg("json");
     }
 
     cmd.args(args);
 
     if verbose > 0 {
-        let injected = if has_format { "" } else { " --format json" };
+        let injected = if has_format || is_version {
+            ""
+        } else {
+            " --format json"
+        };
         eprintln!("Running: rspec{} {}", injected, args.join(" "));
     }
 
@@ -92,7 +102,9 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         "rspec",
         &args.join(" "),
         move |stdout| {
-            if has_format {
+            if is_version {
+                stdout.trim_end().to_string()
+            } else if has_format {
                 let stripped = strip_noise(stdout);
                 filter_rspec_text(&stripped)
             } else {
@@ -101,6 +113,12 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         },
         runner::RunOptions::stdout_only().tee("rspec"),
     )
+}
+
+/// True when args are an rspec `--version`/`-v` query. These print plain text and
+/// must bypass JSON-report parsing (#1946).
+fn is_version_query(args: &[String]) -> bool {
+    args.iter().any(|a| a == "--version" || a == "-v")
 }
 
 // ── Noise stripping ─────────────────────────────────────────────────────────
@@ -1020,5 +1038,14 @@ rspec ./spec/models/user_spec.rb:5 # User is valid
     fn test_has_format_flag_equals() {
         let args = ["--format=json".to_string()];
         assert!(args.iter().any(|a| a.starts_with("--format=")));
+    }
+
+    #[test]
+    fn test_is_version_query_rspec() {
+        assert!(is_version_query(&["--version".to_string()]));
+        assert!(is_version_query(&["-v".to_string()]));
+        assert!(is_version_query(&["spec/foo_spec.rb".to_string(), "--version".to_string()]));
+        assert!(!is_version_query(&["spec/foo_spec.rb".to_string()]));
+        assert!(!is_version_query(&["--format".to_string(), "json".to_string()]));
     }
 }

--- a/src/cmds/ruby/rubocop_cmd.rs
+++ b/src/cmds/ruby/rubocop_cmd.rs
@@ -57,11 +57,16 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         .iter()
         .any(|a| a == "-a" || a == "-A" || a == "--auto-correct" || a == "--auto-correct-all");
 
+    // A version query (`--version`/`-v`, or `--verbose-version`/`-V`) prints a
+    // plain version string, not the JSON report — even with `--format json`
+    // injected. Pass it through untouched instead of parsing it as offenses (#1946).
+    let is_version = is_version_query(args);
+
     let has_format = args
         .iter()
         .any(|a| a.starts_with("--format") || a.starts_with("-f"));
 
-    if !has_format && !is_autocorrect {
+    if !has_format && !is_autocorrect && !is_version {
         cmd.arg("--format").arg("json");
     }
 
@@ -76,7 +81,9 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         "rubocop",
         &args.join(" "),
         move |stdout| {
-            if has_format || is_autocorrect {
+            if is_version {
+                stdout.trim_end().to_string()
+            } else if has_format || is_autocorrect {
                 filter_rubocop_text(stdout)
             } else {
                 filter_rubocop_json(stdout)
@@ -84,6 +91,14 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         },
         runner::RunOptions::stdout_only().tee("rubocop"),
     )
+}
+
+/// True when args are a rubocop version query: `--version`/`-v` or the verbose
+/// form `--verbose-version`/`-V`. These print plain text and must bypass
+/// JSON-report parsing (#1946).
+fn is_version_query(args: &[String]) -> bool {
+    args.iter()
+        .any(|a| a == "--version" || a == "-v" || a == "--verbose-version" || a == "-V")
 }
 
 // ── JSON filtering ───────────────────────────────────────────────────────────
@@ -634,5 +649,15 @@ mod tests {
             "should show +2 more files overflow: {}",
             result
         );
+    }
+
+    #[test]
+    fn test_is_version_query_rubocop() {
+        assert!(is_version_query(&["--version".to_string()]));
+        assert!(is_version_query(&["-v".to_string()]));
+        assert!(is_version_query(&["--verbose-version".to_string()]));
+        assert!(is_version_query(&["-V".to_string()]));
+        assert!(!is_version_query(&["lib/foo.rb".to_string()]));
+        assert!(!is_version_query(&["-a".to_string()]));
     }
 }


### PR DESCRIPTION
## Summary

`rtk rspec --version` and `rtk rubocop --version` emit two spurious warnings on every call:

```console
$ rtk rubocop --version
[rtk] rubocop: JSON parse failed (invalid type: floating point `1.87`, expected struct RubocopOutput at line 1 column 4)
[rtk] rubocop (JSON parse error): output format not recognized, showing last 5 lines
1.87.0
```

The rspec/rubocop filters inject `--format json` and deserialize stdout into a strict report struct. But a **version query short-circuits inside the tool before any formatter runs**, so it always prints plain text — `rubocop --version` → bare `1.87.0` (read as a JSON float, hence `invalid type: floating point`), `rspec --version` → a multi-line version block. The strict parse rejects it and the fallback adds a second warning.

Fix: detect version flags in `run()` and route them to **passthrough** — no `--format json` injection, no report parse — mirroring how the Python filters (ruff/pip) route by subcommand before deserializing.

```console
$ rtk rubocop --version   →  1.87.0
$ rtk rubocop -V          →  1.87.0 (using Parser 3.3.11.1, ...) [arm64-darwin25]
$ rtk rspec --version     →  RSpec 3.13\n  - rspec-core 3.13.6 ...
```

Reproduced and verified on rtk 0.42.0, macOS, rspec 3.13.6, rubocop 1.87.0 (unwrapped tools).

## Relationship to #1982

This **supersedes #1982** (thanks @YOMXXX for surfacing the bug). That PR detects the minimal `{"version":"..."}` JSON shape and prettifies it. But that shape only appears behind the reporter's custom `.cmd` wrapper — real `rubocop`/`rspec` never emit it, because `--version` bypasses the formatter entirely. So a JSON-shape check fixes the wrapped case but leaves the warning firing for everyone running the tools normally. Routing at the invocation layer is a superset: wrapped JSON passes through raw, unwrapped text passes through clean. It's also a smaller change (+57/-5 in the modules vs +174/-0).

## Testing

- 2 new unit tests (`is_version_query` on both tools, incl. negative cases for `--format`/`-a`); existing 29 rspec / 19 rubocop tests green.
- `scripts/test-ruby.sh`: new "Version queries (#1946)" section with a reusable `assert_not_contains` regression guard asserting no JSON-parse warning leaks. Verified passing against a local build.
- `cargo fmt --all -- --check` and `cargo clippy` clean on the touched modules.

## Notes

- Version-flag set confirmed against `rspec --help` / `rubocop --help`: rspec `-v`/`--version`; rubocop adds `-V`/`--verbose-version`.
- The passthrough is `stdout.trim_end()` — infallible and fully isolated from the report-parse path, which is unchanged.

Fixes #1946.
