### PR TITLE
feat(filters): add eas-build and expo TOML filters

### DIFF
--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -1621,8 +1621,8 @@ match_command = "^make\\b"
         let filters = make_filters(BUILTIN_TOML);
         assert_eq!(
             filters.len(),
-            59,
-            "Expected exactly 59 built-in filters, got {}. \
+            61,
+            "Expected exactly 61 built-in filters, got {}. \
              Update this count when adding/removing filters in src/filters/.",
             filters.len()
         );
@@ -1679,11 +1679,11 @@ expected = "output line 1\noutput line 2"
         let combined = format!("{}\n\n{}", BUILTIN_TOML, new_filter);
         let filters = make_filters(&combined);
 
-        // All 59 existing filters still present + 1 new = 60
+        // All 61 existing filters still present + 1 new = 62
         assert_eq!(
             filters.len(),
-            60,
-            "Expected 60 filters after concat (59 built-in + 1 new)"
+            62,
+            "Expected 62 filters after concat (61 built-in + 1 new)"
         );
 
         // New filter is discoverable

--- a/src/filters/eas-build.toml
+++ b/src/filters/eas-build.toml
@@ -1,0 +1,49 @@
+[filters.eas-build]
+description = "Compact `eas build` output — strip fingerprint/compress/upload/wait noise, keep build URL, status, artifacts, errors"
+match_command = "^(npx\\s+)?eas\\s+build\\b"
+strip_ansi = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^\\s*Computing project fingerprint",
+  "^\\s*✔ Computed project fingerprint",
+  "^\\s*Compressing project files",
+  "^\\s*✔ Compressed project files",
+  "^\\s*Uploading to EAS Build",
+  "^\\s*✔ Uploaded to EAS Build",
+  "^\\s*Using remote .* credentials",
+  "^\\s*Waiting for build to complete\\.",
+  "^\\s*Loading ",
+]
+max_lines = 50
+on_empty = "eas build: ok"
+
+[[tests.eas-build]]
+name = "strips upload/fingerprint noise, keeps build url, status and artifact"
+input = """
+Computing project fingerprint
+✔ Computed project fingerprint
+Compressing project files
+✔ Uploaded to EAS Build (12.3 MB)
+Build details: https://expo.dev/accounts/adam/projects/mova/builds/abc123
+Waiting for build to complete. You can press Ctrl+C to exit.
+✔ Build finished
+🤖 Android app:
+https://expo.dev/artifacts/eas/xyz.aab
+"""
+expected = "Build details: https://expo.dev/accounts/adam/projects/mova/builds/abc123\n✔ Build finished\n🤖 Android app:\nhttps://expo.dev/artifacts/eas/xyz.aab"
+
+[[tests.eas-build]]
+name = "keeps build errors"
+input = """
+Computing project fingerprint
+Compressing project files
+✔ Uploaded to EAS Build (12.3 MB)
+Error: Gradle build failed with unknown error. See logs for the "Run gradlew" phase for more information.
+Build failed
+"""
+expected = "Error: Gradle build failed with unknown error. See logs for the \"Run gradlew\" phase for more information.\nBuild failed"
+
+[[tests.eas-build]]
+name = "empty input returns on_empty message"
+input = ""
+expected = "eas build: ok"

--- a/src/filters/expo.toml
+++ b/src/filters/expo.toml
@@ -1,0 +1,34 @@
+[filters.expo]
+description = "Compact Expo CLI output — strip Metro bundler progress and interactive hints, keep warnings, errors and results"
+match_command = "^(npx\\s+)?expo\\b"
+strip_ansi = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^\\s*Starting Metro Bundler",
+  "^\\s*Starting project at",
+  "^\\w+ Bundling \\d",
+  "^\\s*› ",
+  "^\\s*Logs for your project will appear below",
+  "^\\s*Waiting on http://",
+]
+max_lines = 50
+on_empty = "expo: ok"
+
+[[tests.expo]]
+name = "strips bundler progress and hints, keeps bundling-complete, warnings and errors"
+input = """
+Starting Metro Bundler
+Android Bundling 0%
+Android Bundling 45%
+Android Bundling complete 1234ms
+› Press a │ open Android
+› Press r │ reload app
+Warning: useEffect has a missing dependency
+error: Unable to resolve module './Foo' from App.tsx
+"""
+expected = "Android Bundling complete 1234ms\nWarning: useEffect has a missing dependency\nerror: Unable to resolve module './Foo' from App.tsx"
+
+[[tests.expo]]
+name = "empty input returns on_empty message"
+input = ""
+expected = "expo: ok"


### PR DESCRIPTION
## What

Adds two TOML filters covering the **Expo / EAS** toolchain — a gap in current coverage (`xcodebuild.toml` exists for the native iOS side, but the Expo/React Native toolchain didn't).

- **`eas-build`** — strips fingerprint / compress / upload / "waiting for build" progress noise; keeps the build-details URL, final status, artifact links, and errors.
- **`expo`** — strips Metro bundler progress and interactive key-hints; keeps `Bundling complete` lines, warnings, and errors.

Both mirror the existing `xcodebuild.toml` pattern (strip-noise, keep-signal; never reformat).

## Why

Expo/React Native is a common stack, and `eas build` / `expo start` emit hundreds of progress lines per run — a large token sink with low signal.

## Tests

- Inline `[[tests.*]]` for both filters (happy path, error path, empty input).
- `rtk verify`: **150/150** inline tests pass.
- `cargo test`: 1996 passed, 0 failed. `cargo fmt --check` and `cargo clippy --all-targets` clean.
- Bumped the built-in filter-count assertions 59 → 61.

## Notes

Regexes anchored where possible; `expo` deliberately keeps `Bundling complete` while dropping `Bundling <n>%` progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
