### PR TITLE
fix(git): inherit stdin for git fetch/pull so SSH auth works (#2211)

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -2,7 +2,8 @@
 
 use crate::core::args_utils;
 use crate::core::stream::{
-    self, exec_capture, CaptureResult, FilterMode, LineHandler, LineStreamFilter, StdinMode,
+    self, exec_capture, exec_capture_inherit_stdin, CaptureResult, FilterMode, LineHandler,
+    LineStreamFilter, StdinMode,
 };
 use crate::core::tracking;
 use crate::core::truncate::CAP_WARNINGS;
@@ -1149,7 +1150,7 @@ fn run_pull(args: &[String], verbose: u8, global_args: &[String]) -> Result<i32>
         cmd.arg(arg);
     }
 
-    let result = exec_capture(&mut cmd).context("Failed to run git pull")?;
+    let result = exec_capture_inherit_stdin(&mut cmd).context("Failed to run git pull")?;
 
     let raw_output = format!("{}\n{}", result.stdout, result.stderr);
 
@@ -1445,7 +1446,7 @@ fn run_fetch(args: &[String], verbose: u8, global_args: &[String]) -> Result<i32
         cmd.arg(arg);
     }
 
-    let result = exec_capture(&mut cmd).context("Failed to run git fetch")?;
+    let result = exec_capture_inherit_stdin(&mut cmd).context("Failed to run git fetch")?;
     let raw = result.combined();
 
     if !result.success() {

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -541,6 +541,20 @@ pub fn exec_capture(cmd: &mut Command) -> Result<CaptureResult> {
     })
 }
 
+/// Like [`exec_capture`] but inherits the parent's stdin so the child can talk to the
+/// terminal. Required for remote git operations (fetch/pull) where SSH or a credential
+/// helper may prompt for a passphrase/password — `exec_capture` nulls stdin, which makes
+/// those auth flows fail with "Could not read from remote repository" (issue #2211).
+pub fn exec_capture_inherit_stdin(cmd: &mut Command) -> Result<CaptureResult> {
+    cmd.stdin(Stdio::inherit());
+    let output = cmd.output().context("Failed to execute command")?;
+    Ok(CaptureResult {
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        exit_code: status_to_exit_code(output.status),
+    })
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
@@ -807,6 +821,25 @@ pub(crate) mod tests {
     fn test_exec_capture_failure() {
         let mut cmd = Command::new("false");
         let result = exec_capture(&mut cmd).unwrap();
+        assert!(!result.success());
+        assert_eq!(result.exit_code, 1);
+    }
+
+    #[test]
+    fn test_exec_capture_inherit_stdin_captures_output() {
+        // Inheriting stdin must not interfere with stdout/stderr capture (issue #2211).
+        let mut cmd = Command::new("echo");
+        cmd.arg("hello_inherit");
+        let result = exec_capture_inherit_stdin(&mut cmd).unwrap();
+        assert!(result.success());
+        assert_eq!(result.exit_code, 0);
+        assert!(result.stdout.contains("hello_inherit"));
+    }
+
+    #[test]
+    fn test_exec_capture_inherit_stdin_failure() {
+        let mut cmd = Command::new("false");
+        let result = exec_capture_inherit_stdin(&mut cmd).unwrap();
         assert!(!result.success());
         assert_eq!(result.exit_code, 1);
     }


### PR DESCRIPTION
## Summary

- **Fixes #2211**: `rtk git fetch/pull` no longer fail with a false `fatal: Could not read from remote repository` error when the remote needs interactive auth.
- Root cause: `run_fetch/run_pull` used `exec_capture`, which hardcodes `stdin(Stdio::null())`. Closing stdin breaks SSH passphrase / host-key / HTTPS credential-helper prompts, so git **genuinely** exits non-zero — which `run_fetch` then surfaced as `FAILED`.
- Adds `exec_capture_inherit_stdin` (stdin inherited, stdout/stderr still piped for the compact summary) and uses it in `run_fetch` + `run_pull`. The other ~80 `exec_capture` callers are untouched and keep stdin closed.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test` — zero warnings, **1998 passed / 0 failed** (incl. 2 new tests for `exec_capture_inherit_stdin`).
- [x] Manual testing: `rtk <command>` output inspected
  - `rtk git fetch origin develop` → `ok fetched (1 new refs)`, exit `0` (no false access error); `rtk proxy git fetch origin develop` parity confirmed.
  - **Deterministic before/after** (shadow `git` with a fake on `PATH` that reports whether `git fetch` got usable stdin, since rtk resolves `git` via `resolved_command`):
    - Pre-fix binary (`HEAD~1`): child git sees `STDIN_RESULT=EOF` ← the `/dev/null` that broke auth.
    - This PR: child git sees `STDIN_RESULT=GOT:SENTINEL` ← stdin inherited, so `ssh`/credential helper can read.

**Files changed**
- `src/core/stream.rs` — new `exec_capture_inherit_stdin` helper + 2 unit tests.
- `src/cmds/git/git.rs` — `run_fetch` and `run_pull` switched to the new helper; import updated.
