### PR TITLE
fix(tsc): handle pretty diagnostics

### DIFF
--- a/src/cmds/js/tsc_cmd.rs
+++ b/src/cmds/js/tsc_cmd.rs
@@ -7,13 +7,16 @@ use crate::core::utils::{resolved_command, strip_ansi, tool_exists, truncate};
 use anyhow::Result;
 use regex::Regex;
 use std::borrow::Cow;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::LazyLock;
 
-/// Unparseable failure output is limited to this many non-empty lines. The
-/// runner tees the full raw output and prints a recovery hint, except when tee
-/// is disabled (`RTK_TEE=0` or `config.tee.enabled = false`): then these lines
-/// are the only surviving copy, which is why both ends are kept.
+/// Unparseable failure output is limited to this many non-empty lines, split
+/// between head and tail. The runner tees the full raw output and prints a
+/// recovery hint, so the hidden middle stays reachable, with two exceptions the
+/// cap accounts for: output under `MIN_TEE_SIZE` bytes gets no tee, so it is
+/// printed whole; and with tee disabled (`RTK_TEE=0` or
+/// `config.tee.enabled = false`) these lines are the only surviving copy, which
+/// is why both ends are kept.
 const MAX_UNPARSED_LINES: usize = CAP_WARNINGS;
 /// Deviation: tsc and npx print the cause first (`Unknown compiler option`,
 /// `This is not the tsc command`) and boilerplate after it, so a plain tail
@@ -62,6 +65,12 @@ fn parse_diagnostic(line: &str) -> Option<Diagnostic<'_>> {
         code: caps.get(2)?.as_str(),
         message: caps.get(3)?.as_str(),
     })
+}
+
+/// One line of the raw failure dump: width-capped like every other emission.
+fn push_dump_line(summary: &mut String, line: &str) {
+    summary.push_str(&truncate(line, 120));
+    summary.push('\n');
 }
 
 fn clean_line(line: &str) -> Cow<'_, str> {
@@ -158,30 +167,55 @@ impl BlockHandler for TscHandler {
             // no project, unparseable output). "No errors found" would be a
             // false green, so report the failure with the head and tail of the
             // raw output; only the retained lines are ANSI-stripped.
-            let lines: Vec<&str> = raw.lines().filter(|line| !line.trim().is_empty()).collect();
             let mut summary = format!(
                 "TypeScript: compiler exited with code {exit_code}, but RTK parsed no diagnostics\n"
             );
 
-            if lines.len() <= MAX_UNPARSED_LINES {
-                for line in lines {
-                    summary.push_str(clean_line(line).as_ref());
-                    summary.push('\n');
+            if raw.len() < crate::core::tee::MIN_TEE_SIZE {
+                for line in raw.lines() {
+                    let line = clean_line(line);
+                    if line.trim().is_empty() {
+                        continue;
+                    }
+                    push_dump_line(&mut summary, line.as_ref());
                 }
                 return Some(summary);
             }
 
             let head_len = MAX_UNPARSED_HEAD_LINES.min(MAX_UNPARSED_LINES);
             let tail_len = MAX_UNPARSED_LINES.saturating_sub(head_len);
-            let hidden = lines.len() - head_len - tail_len;
-            for line in &lines[..head_len] {
-                summary.push_str(clean_line(line).as_ref());
-                summary.push('\n');
+            let mut head: Vec<Cow<'_, str>> = Vec::with_capacity(head_len);
+            let mut tail: VecDeque<Cow<'_, str>> = VecDeque::with_capacity(tail_len);
+            let mut total = 0;
+
+            for line in raw.lines() {
+                let line = clean_line(line);
+                if line.trim().is_empty() {
+                    continue;
+                }
+                total += 1;
+                if head.len() < head_len {
+                    head.push(line);
+                    continue;
+                }
+                if tail_len == 0 {
+                    continue;
+                }
+                if tail.len() == tail_len {
+                    tail.pop_front();
+                }
+                tail.push_back(line);
             }
-            summary.push_str(&format!("... +{hidden} more lines\n"));
-            for line in &lines[lines.len() - tail_len..] {
-                summary.push_str(clean_line(line).as_ref());
-                summary.push('\n');
+
+            let hidden = total - head.len() - tail.len();
+            for line in head {
+                push_dump_line(&mut summary, line.as_ref());
+            }
+            if hidden > 0 {
+                summary.push_str(&format!("... +{hidden} more lines\n"));
+            }
+            for line in tail {
+                push_dump_line(&mut summary, line.as_ref());
             }
             return Some(summary);
         }
@@ -555,20 +589,72 @@ src/app.ts(1,7): error TS2322: Type 'string' is not assignable to type 'number'.
 
     #[test]
     fn test_tsc_stream_failed_unparsed_output_keeps_head_and_tail() {
-        let input: String = (1..=30).map(|i| format!("junk line {i}\n")).collect();
+        let padding = "x".repeat(30);
+        let input: String = (1..=30)
+            .map(|i| format!("junk line {i} {padding}\n"))
+            .collect();
         let mut f = BlockStreamFilter::new(TscHandler::new());
         let result = run_block_filter(&mut f, &input, 2);
         assert!(result.contains("compiler exited with code 2"), "got: {}", result);
         for i in 1..=5 {
-            assert!(result.contains(&format!("junk line {i}\n")), "got: {}", result);
+            assert!(result.contains(&format!("junk line {i} {padding}\n")), "got: {}", result);
         }
         assert!(result.contains("... +20 more lines"), "got: {}", result);
         for i in 26..=30 {
-            assert!(result.contains(&format!("junk line {i}\n")), "got: {}", result);
+            assert!(result.contains(&format!("junk line {i} {padding}\n")), "got: {}", result);
         }
-        assert!(!result.contains("junk line 6\n"), "got: {}", result);
-        assert!(!result.contains("junk line 25\n"), "got: {}", result);
+        assert!(!result.contains(&format!("junk line 6 {padding}\n")), "got: {}", result);
+        assert!(!result.contains(&format!("junk line 25 {padding}\n")), "got: {}", result);
         assert_eq!(result.lines().count(), 1 + 5 + 1 + 5);
+    }
+
+    #[test]
+    fn test_tsc_stream_failed_unparsed_output_ignores_escape_only_lines() {
+        let padding = "x".repeat(30);
+        let mut input = "\x1b[0m\n\x1b[32m\x1b[0m\n\x1b[0m\n".to_string();
+        for i in 1..=30 {
+            input.push_str(&format!("real line {i} {padding}\n"));
+        }
+
+        let mut f = BlockStreamFilter::new(TscHandler::new());
+        let result = run_block_filter(&mut f, &input, 2);
+        for i in 1..=5 {
+            assert!(result.contains(&format!("real line {i} {padding}\n")), "got: {}", result);
+        }
+        assert!(result.contains("... +20 more lines"), "got: {}", result);
+        for i in 26..=30 {
+            assert!(result.contains(&format!("real line {i} {padding}\n")), "got: {}", result);
+        }
+        assert!(!result.contains("\n\n"), "got: {}", result);
+        assert_eq!(result.lines().count(), 1 + 5 + 1 + 5);
+    }
+
+    #[test]
+    fn test_tsc_stream_failed_unparsed_output_under_tee_floor_is_complete() {
+        let input: String = (1..=15).map(|i| format!("short {i}\n")).collect();
+        let mut f = BlockStreamFilter::new(TscHandler::new());
+        let result = run_block_filter(&mut f, &input, 1);
+
+        for i in 1..=15 {
+            assert!(result.contains(&format!("short {i}\n")), "got: {}", result);
+        }
+        assert!(!result.contains("... +"), "got: {}", result);
+    }
+
+    #[test]
+    fn test_tsc_stream_failed_unparsed_output_caps_line_width() {
+        let long_line = "z".repeat(300);
+        let padding = "x".repeat(30);
+        let mut input = format!("{long_line}\n");
+        for i in 1..=10 {
+            input.push_str(&format!("padding line {i} {padding}\n"));
+        }
+
+        let mut f = BlockStreamFilter::new(TscHandler::new());
+        let result = run_block_filter(&mut f, &input, 1);
+        let emitted_long_line = result.lines().nth(1).expect("long line should be emitted");
+        assert!(emitted_long_line.chars().count() <= 120, "got: {}", result);
+        assert!(emitted_long_line.ends_with("..."), "got: {}", result);
     }
 
     #[test]

--- a/src/cmds/js/tsc_cmd.rs
+++ b/src/cmds/js/tsc_cmd.rs
@@ -10,17 +10,13 @@ use std::borrow::Cow;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::LazyLock;
 
-/// Unparseable failure output is limited to this many non-empty lines, split
-/// between head and tail. The runner tees the full raw output and prints a
-/// recovery hint, so the hidden middle stays reachable, with two exceptions the
-/// cap accounts for: output under `MIN_TEE_SIZE` bytes gets no tee, so it is
-/// printed whole; and with tee disabled (`RTK_TEE=0` or
-/// `config.tee.enabled = false`) these lines are the only surviving copy, which
-/// is why both ends are kept.
+/// Cap on the non-empty lines kept when RTK cannot parse failure output. With
+/// tee disabled (`RTK_TEE=0`, `config.tee.enabled = false`) these lines are the
+/// only surviving copy of the failure.
 const MAX_UNPARSED_LINES: usize = CAP_WARNINGS;
-/// Deviation: tsc and npx print the cause first (`Unknown compiler option`,
-/// `This is not the tsc command`) and boilerplate after it, so a plain tail
-/// would drop the cause; split the cap between head and tail.
+/// tsc and npx print the cause first (`Unknown compiler option`, `This is not
+/// the tsc command`) and boilerplate after it, so spending the whole cap on a
+/// tail would drop the cause.
 const MAX_UNPARSED_HEAD_LINES: usize = reduced(MAX_UNPARSED_LINES, 5);
 
 static TSC_ERROR: LazyLock<Regex> = LazyLock::new(|| {
@@ -67,7 +63,6 @@ fn parse_diagnostic(line: &str) -> Option<Diagnostic<'_>> {
     })
 }
 
-/// One line of the raw failure dump: width-capped like every other emission.
 fn push_dump_line(summary: &mut String, line: &str) {
     summary.push_str(&truncate(line, 120));
     summary.push('\n');
@@ -128,8 +123,7 @@ impl TscHandler {
 
 impl BlockHandler for TscHandler {
     /// `--pretty` wraps every field in ANSI escapes; strip them once so
-    /// matching and the emitted block both see plain text. Plain lines are
-    /// passed through without allocating.
+    /// matching and the emitted block both see plain text.
     fn normalize_line<'a>(&self, line: &'a str) -> Cow<'a, str> {
         clean_line(line)
     }
@@ -165,8 +159,8 @@ impl BlockHandler for TscHandler {
             }
             // tsc failed without one diagnostic RTK understands (missing binary,
             // no project, unparseable output). "No errors found" would be a
-            // false green, so report the failure with the head and tail of the
-            // raw output; only the retained lines are ANSI-stripped.
+            // false green, so surface the failure with both ends of the raw
+            // output.
             let mut summary = format!(
                 "TypeScript: compiler exited with code {exit_code}, but RTK parsed no diagnostics\n"
             );

--- a/src/cmds/js/tsc_cmd.rs
+++ b/src/cmds/js/tsc_cmd.rs
@@ -2,17 +2,23 @@
 
 use crate::core::runner;
 use crate::core::stream::{BlockHandler, BlockStreamFilter};
-use crate::core::truncate::CAP_WARNINGS;
+use crate::core::truncate::{reduced, CAP_WARNINGS};
 use crate::core::utils::{resolved_command, strip_ansi, tool_exists, truncate};
 use anyhow::Result;
-use regex::{Captures, Regex};
+use regex::Regex;
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
 
-/// Unparseable failure output is tailed to this many non-empty lines; the
-/// runner tees the full raw output and prints the recovery hint.
-const MAX_UNPARSED_TAIL_LINES: usize = CAP_WARNINGS;
+/// Unparseable failure output is limited to this many non-empty lines. The
+/// runner tees the full raw output and prints a recovery hint, except when tee
+/// is disabled (`RTK_TEE=0` or `config.tee.enabled = false`): then these lines
+/// are the only surviving copy, which is why both ends are kept.
+const MAX_UNPARSED_LINES: usize = CAP_WARNINGS;
+/// Deviation: tsc and npx print the cause first (`Unknown compiler option`,
+/// `This is not the tsc command`) and boilerplate after it, so a plain tail
+/// would drop the cause; split the cap between head and tail.
+const MAX_UNPARSED_HEAD_LINES: usize = reduced(MAX_UNPARSED_LINES, 5);
 
 static TSC_ERROR: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^(.+?)\((\d+),(\d+)\):\s+(error|warning)\s+(TS\d+):\s+(.+)$").unwrap()
@@ -21,13 +27,49 @@ static TSC_ERROR: LazyLock<Regex> = LazyLock::new(|| {
 static TSC_PRETTY_ERROR: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^(.+?):(\d+):(\d+)\s+-\s+(error|warning)\s+(TS\d+):\s+(.+)$").unwrap()
 });
+static TSC_GLOBAL_ERROR: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(error|warning)\s+(TS\d+):\s+(.+)$").unwrap());
 
-/// Match a diagnostic line in either the default or the `--pretty` layout.
-/// Callers pick the capture groups they need, so nothing is allocated here.
-fn tsc_error_captures(line: &str) -> Option<Captures<'_>> {
-    TSC_ERROR
-        .captures(line)
-        .or_else(|| TSC_PRETTY_ERROR.captures(line))
+struct Diagnostic<'a> {
+    file: Option<&'a str>,
+    line: Option<&'a str>,
+    code: &'a str,
+    message: &'a str,
+}
+
+/// Match default, `--pretty`, and file-less TypeScript diagnostics without allocating.
+fn parse_diagnostic(line: &str) -> Option<Diagnostic<'_>> {
+    if let Some(caps) = TSC_ERROR.captures(line) {
+        return Some(Diagnostic {
+            file: caps.get(1).map(|value| value.as_str()),
+            line: caps.get(2).map(|value| value.as_str()),
+            code: caps.get(5)?.as_str(),
+            message: caps.get(6)?.as_str(),
+        });
+    }
+    if let Some(caps) = TSC_PRETTY_ERROR.captures(line) {
+        return Some(Diagnostic {
+            file: caps.get(1).map(|value| value.as_str()),
+            line: caps.get(2).map(|value| value.as_str()),
+            code: caps.get(5)?.as_str(),
+            message: caps.get(6)?.as_str(),
+        });
+    }
+    let caps = TSC_GLOBAL_ERROR.captures(line)?;
+    Some(Diagnostic {
+        file: None,
+        line: None,
+        code: caps.get(2)?.as_str(),
+        message: caps.get(3)?.as_str(),
+    })
+}
+
+fn clean_line(line: &str) -> Cow<'_, str> {
+    if line.contains('\x1b') {
+        Cow::Owned(strip_ansi(line))
+    } else {
+        Cow::Borrowed(line)
+    }
 }
 
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
@@ -80,11 +122,7 @@ impl BlockHandler for TscHandler {
     /// matching and the emitted block both see plain text. Plain lines are
     /// passed through without allocating.
     fn normalize_line<'a>(&self, line: &'a str) -> Cow<'a, str> {
-        if line.contains('\x1b') {
-            Cow::Owned(strip_ansi(line))
-        } else {
-            Cow::Borrowed(line)
-        }
+        clean_line(line)
     }
 
     fn should_skip(&mut self, line: &str) -> bool {
@@ -92,10 +130,15 @@ impl BlockHandler for TscHandler {
     }
 
     fn is_block_start(&mut self, line: &str) -> bool {
-        if let Some(caps) = tsc_error_captures(line) {
+        if let Some(diagnostic) = parse_diagnostic(line) {
             self.error_count += 1;
-            self.files.insert(caps[1].to_string());
-            *self.code_counts.entry(caps[5].to_string()).or_insert(0) += 1;
+            if let Some(file) = diagnostic.file {
+                self.files.insert(file.to_string());
+            }
+            *self
+                .code_counts
+                .entry(diagnostic.code.to_string())
+                .or_insert(0) += 1;
             true
         } else {
             false
@@ -111,30 +154,47 @@ impl BlockHandler for TscHandler {
             if exit_code == 0 {
                 return Some("TypeScript: No errors found\n".to_string());
             }
-            // tsc failed without one parseable diagnostic (missing binary, bad
-            // flags, TS5058 config errors). "No errors found" would be a false
-            // green, so report the failure with the tail of the raw output.
-            let clean = strip_ansi(raw);
-            let lines: Vec<&str> = clean.lines().filter(|l| !l.trim().is_empty()).collect();
-            let hidden = lines.len().saturating_sub(MAX_UNPARSED_TAIL_LINES);
+            // tsc failed without one diagnostic RTK understands (missing binary,
+            // no project, unparseable output). "No errors found" would be a
+            // false green, so report the failure with the head and tail of the
+            // raw output; only the retained lines are ANSI-stripped.
+            let lines: Vec<&str> = raw.lines().filter(|line| !line.trim().is_empty()).collect();
             let mut summary = format!(
                 "TypeScript: compiler exited with code {exit_code}, but RTK parsed no diagnostics\n"
             );
-            if hidden > 0 {
-                summary.push_str(&format!("... +{hidden} more lines\n"));
+
+            if lines.len() <= MAX_UNPARSED_LINES {
+                for line in lines {
+                    summary.push_str(clean_line(line).as_ref());
+                    summary.push('\n');
+                }
+                return Some(summary);
             }
-            for line in &lines[hidden..] {
-                summary.push_str(line);
+
+            let head_len = MAX_UNPARSED_HEAD_LINES.min(MAX_UNPARSED_LINES);
+            let tail_len = MAX_UNPARSED_LINES.saturating_sub(head_len);
+            let hidden = lines.len() - head_len - tail_len;
+            for line in &lines[..head_len] {
+                summary.push_str(clean_line(line).as_ref());
+                summary.push('\n');
+            }
+            summary.push_str(&format!("... +{hidden} more lines\n"));
+            for line in &lines[lines.len() - tail_len..] {
+                summary.push_str(clean_line(line).as_ref());
                 summary.push('\n');
             }
             return Some(summary);
         }
 
-        let mut result = format!(
-            "TypeScript: {} errors in {} files\n",
-            self.error_count,
-            self.files.len()
-        );
+        let mut result = if self.files.is_empty() {
+            format!("TypeScript: {} errors\n", self.error_count)
+        } else {
+            format!(
+                "TypeScript: {} errors in {} files\n",
+                self.error_count,
+                self.files.len()
+            )
+        };
 
         if self.code_counts.len() > 1 {
             let mut counts: Vec<_> = self.code_counts.iter().collect();
@@ -153,26 +213,26 @@ impl BlockHandler for TscHandler {
 
 pub(crate) fn filter_tsc_output(output: &str) -> String {
     struct TsError {
-        file: String,
-        line: usize,
+        file: Option<String>,
+        line: Option<usize>,
         code: String,
         message: String,
         context_lines: Vec<String>,
     }
 
     let mut errors: Vec<TsError> = Vec::new();
-    let clean_output = strip_ansi(output);
+    let clean_output = clean_line(output);
     let lines: Vec<&str> = clean_output.lines().collect();
     let mut i = 0;
 
     while i < lines.len() {
         let line = lines[i];
-        if let Some(caps) = tsc_error_captures(line) {
+        if let Some(diagnostic) = parse_diagnostic(line) {
             let mut err = TsError {
-                file: caps[1].to_string(),
-                line: caps[2].parse().unwrap_or(0),
-                code: caps[5].to_string(),
-                message: caps[6].to_string(),
+                file: diagnostic.file.map(str::to_string),
+                line: diagnostic.line.and_then(|value| value.parse().ok()),
+                code: diagnostic.code.to_string(),
+                message: diagnostic.message.to_string(),
                 context_lines: Vec::new(),
             };
 
@@ -182,7 +242,7 @@ pub(crate) fn filter_tsc_output(output: &str) -> String {
                 let next = lines[i];
                 if !next.is_empty()
                     && (next.starts_with("  ") || next.starts_with('\t'))
-                    && tsc_error_captures(next).is_none()
+                    && parse_diagnostic(next).is_none()
                 {
                     err.context_lines.push(next.trim().to_string());
                     i += 1;
@@ -204,10 +264,14 @@ pub(crate) fn filter_tsc_output(output: &str) -> String {
         return "TypeScript compilation completed".to_string();
     }
 
-    // Group by file
+    let global_errors: Vec<&TsError> = errors.iter().filter(|err| err.file.is_none()).collect();
+
+    // Group file-scoped diagnostics without counting the global bucket as a file.
     let mut by_file: HashMap<String, Vec<&TsError>> = HashMap::new();
     for err in &errors {
-        by_file.entry(err.file.clone()).or_default().push(err);
+        if let Some(file) = &err.file {
+            by_file.entry(file.clone()).or_default().push(err);
+        }
     }
 
     // Count by error code for summary
@@ -216,12 +280,15 @@ pub(crate) fn filter_tsc_output(output: &str) -> String {
         *by_code.entry(err.code.clone()).or_insert(0) += 1;
     }
 
-    let mut result = String::new();
-    result.push_str(&format!(
-        "TypeScript: {} errors in {} files\n",
-        errors.len(),
-        by_file.len()
-    ));
+    let mut result = if by_file.is_empty() {
+        format!("TypeScript: {} errors\n", errors.len())
+    } else {
+        format!(
+            "TypeScript: {} errors in {} files\n",
+            errors.len(),
+            by_file.len()
+        )
+    };
 
     // Top error codes summary (compact, one line)
     let mut code_counts: Vec<_> = by_code.iter().collect();
@@ -236,6 +303,21 @@ pub(crate) fn filter_tsc_output(output: &str) -> String {
         result.push_str(&format!("Top codes: {}\n\n", codes_str.join(", ")));
     }
 
+    if !global_errors.is_empty() {
+        result.push_str(&format!("global ({} errors)\n", global_errors.len()));
+        for err in global_errors {
+            result.push_str(&format!(
+                "  {} {}\n",
+                err.code,
+                truncate(&err.message, 120)
+            ));
+            for ctx in &err.context_lines {
+                result.push_str(&format!("    {}\n", truncate(ctx, 120)));
+            }
+        }
+        result.push('\n');
+    }
+
     // Files sorted by error count (most errors first)
     let mut files_sorted: Vec<_> = by_file.iter().collect();
     files_sorted.sort_by_key(|b| std::cmp::Reverse(b.1.len()));
@@ -247,7 +329,7 @@ pub(crate) fn filter_tsc_output(output: &str) -> String {
         for err in *file_errors {
             result.push_str(&format!(
                 "  L{}: {} {}\n",
-                err.line,
+                err.line.unwrap_or(0),
                 err.code,
                 truncate(&err.message, 120)
             ));
@@ -285,16 +367,33 @@ Found 4 errors in 2 files.
 
     #[test]
     fn test_filter_tsc_output_pretty_ansi_error() {
-        let output = "\
-\x1b[96msrc/app.ts\x1b[0m:\x1b[93m1\x1b[0m:\x1b[93m7\x1b[0m - \x1b[91merror\x1b[0m\x1b[90m TS2322: \x1b[0mType 'string' is not assignable to type 'number'.
-  const x: number = \"string\";
-";
+        let output = include_str!("../../../tests/fixtures/tsc_pretty_raw.txt");
         let result = filter_tsc_output(output);
-        assert!(result.contains("TypeScript: 1 errors in 1 files"));
-        assert!(result.contains("src/app.ts (1 errors)"));
+        assert!(result.contains("TypeScript: 3 errors in 1 files"));
+        assert!(result.contains("src/index.ts (3 errors)"));
+        assert!(result.contains("L1:"));
+        assert_eq!(result.matches("L4:").count(), 2);
         assert!(result.contains("TS2322"));
-        assert!(result.contains("Type 'string' is not assignable to type 'number'"));
         assert!(!result.contains("\x1b["));
+    }
+
+    #[test]
+    fn test_filter_tsc_output_global_error() {
+        let result = filter_tsc_output(
+            "error TS5058: The specified path does not exist: 'tsconfig.json'.",
+        );
+        assert!(result.contains("TS5058"));
+        assert!(result.contains("global (1 errors)"));
+        assert!(!result.contains("completed"));
+    }
+
+    #[test]
+    fn test_filter_tsc_output_global_error_continuation() {
+        let output = include_str!("../../../tests/fixtures/tsc_global_config_error_raw.txt");
+        let result = filter_tsc_output(output);
+        assert!(result.contains("TS2688"));
+        assert!(result.contains("The file is in the program because:"));
+        assert!(result.contains("global (1 errors)"));
     }
 
     #[test]
@@ -385,41 +484,102 @@ Found 3 errors in 2 files.
 
     #[test]
     fn test_tsc_stream_pretty_ansi_errors() {
-        let input = "\
-\x1b[96msrc/app.ts\x1b[0m:\x1b[93m1\x1b[0m:\x1b[93m7\x1b[0m - \x1b[91merror\x1b[0m\x1b[90m TS2322: \x1b[0mType 'string' is not assignable to type 'number'.
-  const x: number = \"string\";
-\x1b[31mFound 1 error in src/app.ts:1\x1b[0m
-";
+        let input = include_str!("../../../tests/fixtures/tsc_pretty_raw.txt");
         let mut f = BlockStreamFilter::new(TscHandler::new());
         let result = run_block_filter(&mut f, input, 2);
-        assert!(result.contains("TS2322"), "got: {}", result);
         assert!(
-            result.contains("Type 'string' is not assignable to type 'number'"),
+            result.contains("src/index.ts:1:7 - error TS2322:"),
             "got: {}",
             result
         );
-        assert!(result.contains("1 errors in 1 files"), "got: {}", result);
-        assert!(!result.contains("No errors found"), "got: {}", result);
-        assert!(!result.contains("Found 1 error"), "got: {}", result);
-        assert!(!result.contains("\x1b["), "emitted block keeps escapes: {}", result);
         assert!(
-            result.starts_with("src/app.ts:1:7 - error TS2322:"),
+            result.contains("src/index.ts:4:8 - error TS2322:"),
+            "got: {}",
+            result
+        );
+        assert!(
+            result.contains("src/index.ts:4:16 - error TS2322:"),
+            "got: {}",
+            result
+        );
+        assert!(result.contains("3 errors in 1 files"), "got: {}", result);
+        assert!(!result.contains("Found 3 errors"), "got: {}", result);
+        assert!(!result.contains("\x1b["), "emitted block keeps escapes: {}", result);
+        // Real pretty output separates code frames with a blank line; the compact filter drops them.
+        assert!(!result.contains("const x: number"), "got: {}", result);
+        assert!(
+            !result.contains("The expected type comes from"),
             "got: {}",
             result
         );
     }
 
     #[test]
-    fn test_tsc_stream_failed_unparsed_output_is_tailed() {
+    fn test_tsc_stream_global_error_with_continuation() {
+        let input = include_str!("../../../tests/fixtures/tsc_global_config_error_raw.txt");
+        let mut f = BlockStreamFilter::new(TscHandler::new());
+        let result = run_block_filter(&mut f, input, 2);
+        assert!(result.contains("TS2688"), "got: {}", result);
+        assert!(
+            result.contains("The file is in the program because:"),
+            "got: {}",
+            result
+        );
+        assert_eq!(result.lines().last(), Some("TypeScript: 1 errors"));
+        assert!(!result.contains("parsed no diagnostics"), "got: {}", result);
+        assert!(!result.contains("No errors found"), "got: {}", result);
+    }
+
+    #[test]
+    fn test_tsc_stream_mixed_global_and_file_errors() {
+        let input = "\
+error TS5023: Unknown compiler option 'foo'.
+src/app.ts(1,7): error TS2322: Type 'string' is not assignable to type 'number'.
+";
+        let mut f = BlockStreamFilter::new(TscHandler::new());
+        let result = run_block_filter(&mut f, input, 2);
+        assert!(result.contains("TS5023"), "got: {}", result);
+        assert!(result.contains("TS2322"), "got: {}", result);
+        assert!(result.contains("2 errors in 1 files"), "got: {}", result);
+    }
+
+    #[test]
+    fn test_tsc_stream_pretty_global_error() {
+        let input = "\x1b[91merror\x1b[0m\x1b[90m TS5058: \x1b[0mThe specified path does not exist: 'nope.json'.";
+        let mut f = BlockStreamFilter::new(TscHandler::new());
+        let result = run_block_filter(&mut f, input, 1);
+        assert!(result.contains("error TS5058:"), "got: {}", result);
+        assert!(result.contains("1 errors"), "got: {}", result);
+        assert!(!result.contains("\x1b["), "got: {}", result);
+    }
+
+    #[test]
+    fn test_tsc_stream_failed_unparsed_output_keeps_head_and_tail() {
         let input: String = (1..=30).map(|i| format!("junk line {i}\n")).collect();
         let mut f = BlockStreamFilter::new(TscHandler::new());
         let result = run_block_filter(&mut f, &input, 2);
         assert!(result.contains("compiler exited with code 2"), "got: {}", result);
+        for i in 1..=5 {
+            assert!(result.contains(&format!("junk line {i}\n")), "got: {}", result);
+        }
         assert!(result.contains("... +20 more lines"), "got: {}", result);
-        assert!(result.contains("junk line 21\n"), "got: {}", result);
-        assert!(result.contains("junk line 30\n"), "got: {}", result);
-        assert!(!result.contains("junk line 20\n"), "got: {}", result);
-        assert_eq!(result.lines().count(), 1 + 1 + MAX_UNPARSED_TAIL_LINES);
+        for i in 26..=30 {
+            assert!(result.contains(&format!("junk line {i}\n")), "got: {}", result);
+        }
+        assert!(!result.contains("junk line 6\n"), "got: {}", result);
+        assert!(!result.contains("junk line 25\n"), "got: {}", result);
+        assert_eq!(result.lines().count(), 1 + 5 + 1 + 5);
+    }
+
+    #[test]
+    fn test_tsc_stream_failed_without_project_keeps_cause() {
+        let input = include_str!("../../../tests/fixtures/tsc_no_project_raw.txt");
+        let mut f = BlockStreamFilter::new(TscHandler::new());
+        let result = run_block_filter(&mut f, input, 1);
+        assert!(result.contains("compiler exited with code 1"), "got: {}", result);
+        assert!(result.contains("Version 6.0.3"), "got: {}", result);
+        assert!(result.contains("tsc: The TypeScript Compiler"), "got: {}", result);
+        assert!(result.contains("... +"), "got: {}", result);
     }
 
     #[test]

--- a/src/cmds/js/tsc_cmd.rs
+++ b/src/cmds/js/tsc_cmd.rs
@@ -2,15 +2,33 @@
 
 use crate::core::runner;
 use crate::core::stream::{BlockHandler, BlockStreamFilter};
-use crate::core::utils::{resolved_command, tool_exists, truncate};
+use crate::core::truncate::CAP_WARNINGS;
+use crate::core::utils::{resolved_command, strip_ansi, tool_exists, truncate};
 use anyhow::Result;
-use regex::Regex;
+use regex::{Captures, Regex};
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
+
+/// Unparseable failure output is tailed to this many non-empty lines; the
+/// runner tees the full raw output and prints the recovery hint.
+const MAX_UNPARSED_TAIL_LINES: usize = CAP_WARNINGS;
 
 static TSC_ERROR: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^(.+?)\((\d+),(\d+)\):\s+(error|warning)\s+(TS\d+):\s+(.+)$").unwrap()
 });
+/// `--pretty` layout: `file:line:col - error TSxxxx: message` (ANSI already stripped).
+static TSC_PRETTY_ERROR: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^(.+?):(\d+):(\d+)\s+-\s+(error|warning)\s+(TS\d+):\s+(.+)$").unwrap()
+});
+
+/// Match a diagnostic line in either the default or the `--pretty` layout.
+/// Callers pick the capture groups they need, so nothing is allocated here.
+fn tsc_error_captures(line: &str) -> Option<Captures<'_>> {
+    TSC_ERROR
+        .captures(line)
+        .or_else(|| TSC_PRETTY_ERROR.captures(line))
+}
 
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     let tsc_exists = tool_exists("tsc");
@@ -58,12 +76,23 @@ impl TscHandler {
 }
 
 impl BlockHandler for TscHandler {
+    /// `--pretty` wraps every field in ANSI escapes; strip them once so
+    /// matching and the emitted block both see plain text. Plain lines are
+    /// passed through without allocating.
+    fn normalize_line<'a>(&self, line: &'a str) -> Cow<'a, str> {
+        if line.contains('\x1b') {
+            Cow::Owned(strip_ansi(line))
+        } else {
+            Cow::Borrowed(line)
+        }
+    }
+
     fn should_skip(&mut self, line: &str) -> bool {
         line.starts_with("Found ")
     }
 
     fn is_block_start(&mut self, line: &str) -> bool {
-        if let Some(caps) = TSC_ERROR.captures(line) {
+        if let Some(caps) = tsc_error_captures(line) {
             self.error_count += 1;
             self.files.insert(caps[1].to_string());
             *self.code_counts.entry(caps[5].to_string()).or_insert(0) += 1;
@@ -77,9 +106,28 @@ impl BlockHandler for TscHandler {
         line.starts_with("  ") || line.starts_with('\t')
     }
 
-    fn format_summary(&self, _exit_code: i32, _raw: &str) -> Option<String> {
+    fn format_summary(&self, exit_code: i32, raw: &str) -> Option<String> {
         if self.error_count == 0 {
-            return Some("TypeScript: No errors found\n".to_string());
+            if exit_code == 0 {
+                return Some("TypeScript: No errors found\n".to_string());
+            }
+            // tsc failed without one parseable diagnostic (missing binary, bad
+            // flags, TS5058 config errors). "No errors found" would be a false
+            // green, so report the failure with the tail of the raw output.
+            let clean = strip_ansi(raw);
+            let lines: Vec<&str> = clean.lines().filter(|l| !l.trim().is_empty()).collect();
+            let hidden = lines.len().saturating_sub(MAX_UNPARSED_TAIL_LINES);
+            let mut summary = format!(
+                "TypeScript: compiler exited with code {exit_code}, but RTK parsed no diagnostics\n"
+            );
+            if hidden > 0 {
+                summary.push_str(&format!("... +{hidden} more lines\n"));
+            }
+            for line in &lines[hidden..] {
+                summary.push_str(line);
+                summary.push('\n');
+            }
+            return Some(summary);
         }
 
         let mut result = format!(
@@ -113,12 +161,13 @@ pub(crate) fn filter_tsc_output(output: &str) -> String {
     }
 
     let mut errors: Vec<TsError> = Vec::new();
-    let lines: Vec<&str> = output.lines().collect();
+    let clean_output = strip_ansi(output);
+    let lines: Vec<&str> = clean_output.lines().collect();
     let mut i = 0;
 
     while i < lines.len() {
         let line = lines[i];
-        if let Some(caps) = TSC_ERROR.captures(line) {
+        if let Some(caps) = tsc_error_captures(line) {
             let mut err = TsError {
                 file: caps[1].to_string(),
                 line: caps[2].parse().unwrap_or(0),
@@ -133,7 +182,7 @@ pub(crate) fn filter_tsc_output(output: &str) -> String {
                 let next = lines[i];
                 if !next.is_empty()
                     && (next.starts_with("  ") || next.starts_with('\t'))
-                    && !TSC_ERROR.is_match(next)
+                    && tsc_error_captures(next).is_none()
                 {
                     err.context_lines.push(next.trim().to_string());
                     i += 1;
@@ -149,7 +198,7 @@ pub(crate) fn filter_tsc_output(output: &str) -> String {
     }
 
     if errors.is_empty() {
-        if output.contains("Found 0 errors") {
+        if clean_output.contains("Found 0 errors") {
             return "TypeScript: No errors found".to_string();
         }
         return "TypeScript compilation completed".to_string();
@@ -235,6 +284,20 @@ Found 4 errors in 2 files.
     }
 
     #[test]
+    fn test_filter_tsc_output_pretty_ansi_error() {
+        let output = "\
+\x1b[96msrc/app.ts\x1b[0m:\x1b[93m1\x1b[0m:\x1b[93m7\x1b[0m - \x1b[91merror\x1b[0m\x1b[90m TS2322: \x1b[0mType 'string' is not assignable to type 'number'.
+  const x: number = \"string\";
+";
+        let result = filter_tsc_output(output);
+        assert!(result.contains("TypeScript: 1 errors in 1 files"));
+        assert!(result.contains("src/app.ts (1 errors)"));
+        assert!(result.contains("TS2322"));
+        assert!(result.contains("Type 'string' is not assignable to type 'number'"));
+        assert!(!result.contains("\x1b["));
+    }
+
+    #[test]
     fn test_every_error_message_shown() {
         let output = "\
 src/api.ts(10,5): error TS2322: Type 'string' is not assignable to type 'number'.
@@ -292,6 +355,13 @@ src/app.tsx(20,5): error TS2345: Argument of type 'number' is not assignable to 
         assert!(result.contains("No errors found"));
     }
 
+    #[test]
+    fn test_filter_no_errors_with_ansi() {
+        let output = "\x1b[32mFound 0 errors.\x1b[0m Watching for file changes.";
+        let result = filter_tsc_output(output);
+        assert!(result.contains("No errors found"));
+    }
+
     // --- Streaming handler tests ---
 
     use crate::core::stream::tests::run_block_filter;
@@ -311,6 +381,63 @@ Found 3 errors in 2 files.
         assert!(result.contains("TS2345"), "got: {}", result);
         assert!(result.contains("3 errors in 2 files"), "got: {}", result);
         assert!(!result.contains("Found 3"), "got: {}", result);
+    }
+
+    #[test]
+    fn test_tsc_stream_pretty_ansi_errors() {
+        let input = "\
+\x1b[96msrc/app.ts\x1b[0m:\x1b[93m1\x1b[0m:\x1b[93m7\x1b[0m - \x1b[91merror\x1b[0m\x1b[90m TS2322: \x1b[0mType 'string' is not assignable to type 'number'.
+  const x: number = \"string\";
+\x1b[31mFound 1 error in src/app.ts:1\x1b[0m
+";
+        let mut f = BlockStreamFilter::new(TscHandler::new());
+        let result = run_block_filter(&mut f, input, 2);
+        assert!(result.contains("TS2322"), "got: {}", result);
+        assert!(
+            result.contains("Type 'string' is not assignable to type 'number'"),
+            "got: {}",
+            result
+        );
+        assert!(result.contains("1 errors in 1 files"), "got: {}", result);
+        assert!(!result.contains("No errors found"), "got: {}", result);
+        assert!(!result.contains("Found 1 error"), "got: {}", result);
+        assert!(!result.contains("\x1b["), "emitted block keeps escapes: {}", result);
+        assert!(
+            result.starts_with("src/app.ts:1:7 - error TS2322:"),
+            "got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_tsc_stream_failed_unparsed_output_is_tailed() {
+        let input: String = (1..=30).map(|i| format!("junk line {i}\n")).collect();
+        let mut f = BlockStreamFilter::new(TscHandler::new());
+        let result = run_block_filter(&mut f, &input, 2);
+        assert!(result.contains("compiler exited with code 2"), "got: {}", result);
+        assert!(result.contains("... +20 more lines"), "got: {}", result);
+        assert!(result.contains("junk line 21\n"), "got: {}", result);
+        assert!(result.contains("junk line 30\n"), "got: {}", result);
+        assert!(!result.contains("junk line 20\n"), "got: {}", result);
+        assert_eq!(result.lines().count(), 1 + 1 + MAX_UNPARSED_TAIL_LINES);
+    }
+
+    #[test]
+    fn test_tsc_stream_failed_unparsed_output_not_success() {
+        let input = "\
+\x1b[31mThis is not the tsc command you are looking for\x1b[0m
+Use npm install typescript before using npx
+";
+        let mut f = BlockStreamFilter::new(TscHandler::new());
+        let result = run_block_filter(&mut f, input, 1);
+        assert!(result.contains("compiler exited with code 1"), "got: {}", result);
+        assert!(
+            result.contains("This is not the tsc command you are looking for"),
+            "got: {}",
+            result
+        );
+        assert!(!result.contains("No errors found"), "got: {}", result);
+        assert!(!result.contains("\x1b["), "got: {}", result);
     }
 
     #[test]

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -1025,8 +1025,7 @@ pub(crate) mod tests {
 
     #[test]
     fn block_handler_normalize_line_feeds_matching_and_emission() {
-        // The handler matches on the normalized line and the emitted block is
-        // the normalized text, so normalization happens exactly once per line.
+        // Both the match and the emitted block see the normalized line.
         let mut f = BlockStreamFilter::new(UpperHandler);
         let out = run_block_filter(&mut f, "err: one\n  detail\nnoise\n", 0);
         assert_eq!(out, "ERR: ONE\n  DETAIL\n");

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use std::borrow::Cow;
 use std::io::{self, BufRead, BufReader, BufWriter, Read, Write};
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
@@ -47,6 +48,12 @@ pub trait StreamFilter {
 }
 
 pub trait BlockHandler {
+    /// Rewrite a raw line before it is matched or emitted — the place to
+    /// strip ANSI escapes for tools that colour by default. Identity unless
+    /// a handler opts in, so the rest of the pipeline sees raw bytes.
+    fn normalize_line<'a>(&self, line: &'a str) -> Cow<'a, str> {
+        Cow::Borrowed(line)
+    }
     fn should_skip(&mut self, line: &str) -> bool;
     fn is_block_start(&mut self, line: &str) -> bool;
     fn is_block_continuation(&mut self, line: &str, block: &[String]) -> bool;
@@ -83,6 +90,8 @@ impl<H: BlockHandler> BlockStreamFilter<H> {
 
 impl<H: BlockHandler> StreamFilter for BlockStreamFilter<H> {
     fn feed_line(&mut self, line: &str) -> Option<String> {
+        let line = self.handler.normalize_line(line);
+        let line = line.as_ref();
         if self.handler.should_skip(line) {
             return None;
         }
@@ -992,6 +1001,35 @@ pub(crate) mod tests {
             output.push_str(&post);
         }
         output
+    }
+
+    struct UpperHandler;
+
+    impl BlockHandler for UpperHandler {
+        fn normalize_line<'a>(&self, line: &'a str) -> Cow<'a, str> {
+            Cow::Owned(line.to_uppercase())
+        }
+        fn should_skip(&mut self, _line: &str) -> bool {
+            false
+        }
+        fn is_block_start(&mut self, line: &str) -> bool {
+            line.starts_with("ERR")
+        }
+        fn is_block_continuation(&mut self, line: &str, _block: &[String]) -> bool {
+            line.starts_with("  ")
+        }
+        fn format_summary(&self, _exit_code: i32, _raw: &str) -> Option<String> {
+            None
+        }
+    }
+
+    #[test]
+    fn block_handler_normalize_line_feeds_matching_and_emission() {
+        // The handler matches on the normalized line and the emitted block is
+        // the normalized text, so normalization happens exactly once per line.
+        let mut f = BlockStreamFilter::new(UpperHandler);
+        let out = run_block_filter(&mut f, "err: one\n  detail\nnoise\n", 0);
+        assert_eq!(out, "ERR: ONE\n  DETAIL\n");
     }
 
     struct TestHandler;

--- a/src/core/tee.rs
+++ b/src/core/tee.rs
@@ -5,7 +5,7 @@ use crate::core::config::Config;
 use std::path::PathBuf;
 
 /// Minimum output size to tee (smaller outputs don't need recovery)
-const MIN_TEE_SIZE: usize = 500;
+pub(crate) const MIN_TEE_SIZE: usize = 500;
 
 /// Default max files to keep in tee directory
 const DEFAULT_MAX_FILES: usize = 20;

--- a/tests/fixtures/tsc_global_config_error_raw.txt
+++ b/tests/fixtures/tsc_global_config_error_raw.txt
@@ -1,0 +1,3 @@
+error TS2688: Cannot find type definition file for 'nonexistent-types-pkg'.
+  The file is in the program because:
+    Entry point of type library 'nonexistent-types-pkg' specified in compilerOptions

--- a/tests/fixtures/tsc_no_project_raw.txt
+++ b/tests/fixtures/tsc_no_project_raw.txt
@@ -1,0 +1,144 @@
+Version 6.0.3
+tsc: The TypeScript Compiler - Version 6.0.3
+
+COMMON COMMANDS
+
+  tsc
+  Compiles the current project (tsconfig.json in the working directory.)
+
+  tsc app.ts util.ts
+  Ignoring tsconfig.json, compiles the specified files with default compiler options.
+
+  tsc -b
+  Build a composite project in the working directory.
+
+  tsc --init
+  Creates a tsconfig.json with the recommended settings in the working directory.
+
+  tsc -p ./path/to/tsconfig.json
+  Compiles the TypeScript project located at the specified path.
+
+  tsc --help --all
+  An expanded version of this information, showing all possible compiler options
+
+  tsc --noEmit
+  tsc --target esnext
+  Compiles the current project, with additional settings.
+
+COMMAND LINE FLAGS
+
+--help, -h
+Print this message.
+
+--watch, -w
+Watch input files.
+
+--all
+Show all compiler options.
+
+--version, -v
+Print the compiler's version.
+
+--init
+Initializes a TypeScript project and creates a tsconfig.json file.
+
+--project, -p
+Compile the project given the path to its configuration file, or to a folder with a 'tsconfig.json'.
+
+--showConfig
+Print the final configuration instead of building.
+
+--ignoreConfig
+Ignore the tsconfig found and build with commandline options and files.
+
+--build, -b
+Build one or more projects and their dependencies, if out of date
+
+COMMON COMPILER OPTIONS
+
+--pretty
+Enable color and formatting in TypeScript's output to make compiler errors easier to read.
+type: boolean
+default: true
+
+--declaration, -d
+Generate .d.ts files from TypeScript and JavaScript files in your project.
+type: boolean
+default: `false`, unless `composite` is set
+
+--declarationMap
+Create sourcemaps for d.ts files.
+type: boolean
+default: false
+
+--emitDeclarationOnly
+Only output d.ts files and not JavaScript files.
+type: boolean
+default: false
+
+--sourceMap
+Create source map files for emitted JavaScript files.
+type: boolean
+default: false
+
+--noEmit
+Disable emitting files from a compilation.
+type: boolean
+default: false
+
+--target, -t
+Set the JavaScript language version for emitted JavaScript and include compatible library declarations.
+one of: es6/es2015, es2016, es2017, es2018, es2019, es2020, es2021, es2022, es2023, es2024, es2025, esnext
+default: es2025
+
+--module, -m
+Specify what module code is generated.
+one of: commonjs, es6/es2015, es2020, es2022, esnext, node16, node18, node20, nodenext, preserve
+default: undefined
+
+--lib
+Specify a set of bundled library declaration files that describe the target runtime environment.
+one or more: es5, es6/es2015, es7/es2016, es2017, es2018, es2019, es2020, es2021, es2022, es2023, es2024, es2025, esnext, dom, dom.iterable, dom.asynciterable, webworker, webworker.importscripts, webworker.iterable, webworker.asynciterable, scripthost, es2015.core, es2015.collection, es2015.generator, es2015.iterable, es2015.promise, es2015.proxy, es2015.reflect, es2015.symbol, es2015.symbol.wellknown, es2016.array.include, es2016.intl, es2017.arraybuffer, es2017.date, es2017.object, es2017.sharedmemory, es2017.string, es2017.intl, es2017.typedarrays, es2018.asyncgenerator, es2018.asynciterable/esnext.asynciterable, es2018.intl, es2018.promise, es2018.regexp, es2019.array, es2019.object, es2019.string, es2019.symbol/esnext.symbol, es2019.intl, es2020.bigint/esnext.bigint, es2020.date, es2020.promise, es2020.sharedmemory, es2020.string, es2020.symbol.wellknown, es2020.intl, es2020.number, es2021.promise, es2021.string, es2021.weakref/esnext.weakref, es2021.intl, es2022.array, es2022.error, es2022.intl, es2022.object, es2022.string, es2022.regexp, es2023.array, es2023.collection, es2023.intl, es2024.arraybuffer, es2024.collection, es2024.object/esnext.object, es2024.promise, es2024.regexp/esnext.regexp, es2024.sharedmemory, es2024.string/esnext.string, es2025.collection, es2025.float16/esnext.float16, es2025.intl, es2025.iterator/esnext.iterator, es2025.promise/esnext.promise, es2025.regexp, esnext.array, esnext.collection, esnext.date, esnext.decorators, esnext.disposable, esnext.error, esnext.intl, esnext.sharedmemory, esnext.temporal, esnext.typedarrays, decorators, decorators.legacy
+default: undefined
+
+--allowJs
+Allow JavaScript files to be a part of your program. Use the 'checkJs' option to get errors from these files.
+type: boolean
+default: `false`, unless `checkJs` is set
+
+--checkJs
+Enable error reporting in type-checked JavaScript files.
+type: boolean
+default: false
+
+--jsx
+Specify what JSX code is generated.
+one of: preserve, react, react-native, react-jsx, react-jsxdev
+default: undefined
+
+--outFile
+Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output.
+
+--outDir
+Specify an output folder for all emitted files.
+
+--removeComments
+Disable emitting comments.
+type: boolean
+default: false
+
+--strict
+Enable all strict type-checking options.
+type: boolean
+default: true
+
+--types
+Specify type package names to be included without being referenced in a source file.
+
+--esModuleInterop
+Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility.
+type: boolean
+default: true
+
+You can learn about all of the compiler options at https://aka.ms/tsc
+

--- a/tests/fixtures/tsc_pretty_raw.txt
+++ b/tests/fixtures/tsc_pretty_raw.txt
@@ -1,0 +1,28 @@
+[96msrc/index.ts[0m:[93m1[0m:[93m7[0m - [91merror[0m[90m TS2322: [0mType 'string' is not assignable to type 'number'.
+
+[7m1[0m const x: number = "hello";
+[7m [0m [91m      ~[0m
+
+[96msrc/index.ts[0m:[93m4[0m:[93m8[0m - [91merror[0m[90m TS2322: [0mType 'string' is not assignable to type 'number'.
+
+[7m4[0m take({ a: "x", b: 1 });
+[7m [0m [91m       ~[0m
+
+  [96msrc/index.ts[0m:[93m2[0m:[93m17[0m
+    [7m2[0m interface Foo { a: number; b: string }
+    [7m [0m [96m                ~[0m
+    The expected type comes from property 'a' which is declared here on type 'Foo'
+
+[96msrc/index.ts[0m:[93m4[0m:[93m16[0m - [91merror[0m[90m TS2322: [0mType 'number' is not assignable to type 'string'.
+
+[7m4[0m take({ a: "x", b: 1 });
+[7m [0m [91m               ~[0m
+
+  [96msrc/index.ts[0m:[93m2[0m:[93m28[0m
+    [7m2[0m interface Foo { a: number; b: string }
+    [7m [0m [96m                           ~[0m
+    The expected type comes from property 'b' which is declared here on type 'Foo'
+
+
+Found 3 errors in the same file, starting at: src/index.ts[90m:1[0m
+


### PR DESCRIPTION
## Summary
- Strip ANSI before matching TypeScript diagnostic lines.
- Parse `tsc --pretty` diagnostics in `file:line:col - error TSxxxx` form.
- Avoid reporting `TypeScript: No errors found` when the compiler exits non-zero and RTK parsed no diagnostics.

## Test plan
- `cargo fmt --all --check`
- `cargo test --bin rtk -- cmds::js::tsc_cmd`
- `cargo test --bin rtk`
- `cargo run --quiet --bin rtk -- tsc --noEmit --pretty -p /tmp/rtk-1772/tsconfig.json` exits 2 and reports `TS2322` plus `TypeScript: 1 errors in 1 files`

Fixes #1772

Fixes #3220

Partially addresses #3738 (ANSI escapes are stripped on the `tsc` path only).
