### PR TITLE
[codex] add Codex PreToolUse hook parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ RTK supports 14 AI coding tools. Each integration rewrites shell commands to `rt
 | **GitHub Copilot CLI** | `rtk init -g --copilot` | PreToolUse deny-with-suggestion (CLI limitation) |
 | **Cursor** | `rtk init -g --agent cursor` | preToolUse hook (hooks.json) |
 | **Gemini CLI** | `rtk init -g --gemini` | BeforeTool hook |
-| **Codex** | `rtk init -g --codex` | AGENTS.md + RTK.md instructions |
+| **Codex** | `rtk init -g --codex` | AGENTS.md + RTK.md instructions; `rtk hook codex` for PreToolUse |
 | **Windsurf** | `rtk init -g --agent windsurf` | .windsurfrules (project-scoped) |
 | **Cline / Roo Code** | `rtk init --agent cline` | .clinerules (project-scoped) |
 | **OpenCode** | `rtk init -g --opencode` | Plugin TS (tool.execute.before) |

--- a/docs/contributing/TECHNICAL.md
+++ b/docs/contributing/TECHNICAL.md
@@ -333,7 +333,7 @@ RTK supports the following LLM agents through hook integrations:
 | Gemini CLI | Rust binary | `rtk hook gemini` reads JSON | Yes (`hookSpecificOutput`) |
 | Cline/Roo Code | Rules file | Prompt-level guidance | N/A (prompt) |
 | Windsurf | Rules file | Prompt-level guidance | N/A (prompt) |
-| Codex CLI | Awareness doc | AGENTS.md integration | N/A (prompt) |
+| Codex CLI | Rust binary | `rtk hook codex` reads `PreToolUse` JSON | Yes (`updatedInput`) |
 | OpenCode | TS plugin | `tool.execute.before` event | Yes (in-place mutation) |
 
 > **Details**: [`hooks/README.md`](../hooks/README.md) has the full JSON schemas for each agent. [`src/hooks/README.md`](../src/hooks/README.md) covers installation, integrity verification, and the rewrite command.

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -38,7 +38,7 @@ Each agent subdirectory has its own README with hook-specific details:
 - **[`cursor/`](cursor/README.md)** — Shell hook, Cursor JSON format, empty `{}` response requirement
 - **[`cline/`](cline/README.md)** — Rules file (prompt-level), `.clinerules` project-local installation
 - **[`windsurf/`](windsurf/README.md)** — Rules file (prompt-level), `.windsurfrules` workspace-scoped
-- **[`codex/`](codex/README.md)** — Awareness document, `AGENTS.md` integration, `$CODEX_HOME` or `~/.codex/` location
+- **[`codex/`](codex/README.md)** — Awareness document plus native `rtk hook codex` PreToolUse parser
 - **[`opencode/`](opencode/README.md)** — TypeScript plugin, `zx` library, `tool.execute.before` event, in-place mutation
 - **[`pi/`](pi/README.md)** — TypeScript extension, `tool_call` event, `isToolCallEventType` guard, in-place mutation, `~/.pi/agent/extensions/`
 - **[`hermes/`](hermes/README.md)** — Python plugin, `pre_tool_call` hook, in-place terminal command mutation
@@ -54,7 +54,7 @@ Each agent subdirectory has its own README with hook-specific details:
 | Gemini CLI | Rust binary (`rtk hook gemini`) | Transparent rewrite | Yes (`hookSpecificOutput`) |
 | Cline / Roo Code | Custom instructions (rules file) | Prompt-level guidance | N/A |
 | Windsurf | Custom instructions (rules file) | Prompt-level guidance | N/A |
-| Codex CLI | AGENTS.md / instructions | Prompt-level guidance | N/A |
+| Codex CLI | Rust binary (`rtk hook codex`) | Transparent rewrite | Yes (`updatedInput`) |
 | OpenCode | TypeScript plugin (`tool.execute.before`) | In-place mutation | Yes |
 | Pi | TypeScript extension (`tool_call` event) | In-place mutation | Yes |
 | Hermes | Python plugin (`pre_tool_call`) | In-place mutation | Yes |
@@ -123,6 +123,21 @@ Returns `{}` when no rewrite (Cursor requires JSON for all paths).
 ### VS Code Copilot Chat (Rust Binary)
 
 **Input** (stdin, snake_case):
+
+```json
+{
+  "tool_name": "exec_command",
+  "tool_input": { "cmd": "git status" }
+}
+```
+
+**Output**: Same as Claude Code format (with `updatedInput`). Codex accepts
+both `tool_input.command` and `tool_input.cmd`; the hook preserves the original
+field name in `updatedInput`.
+
+### Codex CLI (Rust Binary)
+
+**Input** (stdin):
 
 ```json
 {

--- a/hooks/codex/README.md
+++ b/hooks/codex/README.md
@@ -4,6 +4,38 @@
 
 ## Specifics
 
-- Prompt-level guidance via awareness document -- no programmatic hook
+- Prompt-level guidance via awareness document remains supported
 - `rtk-awareness.md` is injected into `AGENTS.md` with an `@RTK.md` reference
+- `rtk hook codex` processes Codex `PreToolUse` JSON from stdin and emits a rewritten
+  `updatedInput.command` or `updatedInput.cmd` when RTK supports the shell command
 - Installed to `$CODEX_HOME` when set, otherwise `~/.codex/`, by `rtk init --codex`
+
+## Native Hook
+
+Add this to `$CODEX_HOME/hooks.json` (usually `~/.codex/hooks.json`) or the
+equivalent inline `[hooks]` table in `config.toml`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^Bash$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "rtk hook codex",
+            "statusMessage": "Rewriting shell command with RTK"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Codex requires non-managed hooks to be reviewed and trusted before they run.
+Use `/hooks` in Codex to review the hook after adding it.
+
+The parser accepts both `tool_input.command` and Codex's `tool_input.cmd`
+shell-command field, preserving the original field name in `updatedInput`.

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -305,7 +305,7 @@ fn audit_log_inner(action: &str, original: &str, rewritten: &str) -> Option<()> 
     .ok()
 }
 
-// ── Claude Code native hook ────────────────────────────────────
+// ── Claude Code / Codex native PreToolUse hook ─────────────────
 
 enum PayloadAction {
     Rewrite {
@@ -320,13 +320,40 @@ enum PayloadAction {
     Ignore,
 }
 
-fn process_claude_payload(v: &Value) -> PayloadAction {
-    let cmd = match v
-        .pointer("/tool_input/command")
-        .and_then(|c| c.as_str())
-        .filter(|c| !c.is_empty())
-    {
-        Some(c) => c,
+#[derive(Clone, Copy)]
+enum CommandField {
+    Command,
+    Cmd,
+}
+
+impl CommandField {
+    fn key(self) -> &'static str {
+        match self {
+            Self::Command => "command",
+            Self::Cmd => "cmd",
+        }
+    }
+
+    fn pointer(self) -> &'static str {
+        match self {
+            Self::Command => "/tool_input/command",
+            Self::Cmd => "/tool_input/cmd",
+        }
+    }
+}
+
+fn extract_command<'a>(v: &'a Value, fields: &[CommandField]) -> Option<(CommandField, &'a str)> {
+    fields.iter().find_map(|field| {
+        v.pointer(field.pointer())
+            .and_then(|c| c.as_str())
+            .filter(|c| !c.is_empty())
+            .map(|cmd| (*field, cmd))
+    })
+}
+
+fn process_pre_tool_use_payload(v: &Value, fields: &[CommandField]) -> PayloadAction {
+    let (field, cmd) = match extract_command(v, fields) {
+        Some(found) => found,
         None => return PayloadAction::Ignore,
     };
 
@@ -351,7 +378,7 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
     let updated_input = {
         let mut ti = v.get("tool_input").cloned().unwrap_or_else(|| json!({}));
         if let Some(obj) = ti.as_object_mut() {
-            obj.insert("command".into(), Value::String(rewritten.clone()));
+            obj.insert(field.key().into(), Value::String(rewritten.clone()));
         }
         ti
     };
@@ -376,8 +403,7 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
     }
 }
 
-/// Run the Claude Code PreToolUse hook natively.
-pub fn run_claude() -> Result<()> {
+fn run_pre_tool_use_hook(agent: &str, fields: &[CommandField]) -> Result<()> {
     let input = read_stdin_limited()?;
 
     let input = input.trim();
@@ -388,12 +414,15 @@ pub fn run_claude() -> Result<()> {
     let v: Value = match serde_json::from_str(input) {
         Ok(v) => v,
         Err(e) => {
-            let _ = writeln!(io::stderr(), "[rtk hook] Failed to parse JSON input: {e}");
+            let _ = writeln!(
+                io::stderr(),
+                "[rtk hook {agent}] Failed to parse JSON input: {e}"
+            );
             return Ok(());
         }
     };
 
-    match process_claude_payload(&v) {
+    match process_pre_tool_use_payload(&v, fields) {
         PayloadAction::Rewrite {
             cmd,
             rewritten,
@@ -411,13 +440,33 @@ pub fn run_claude() -> Result<()> {
     Ok(())
 }
 
+/// Run the Claude Code PreToolUse hook natively.
+pub fn run_claude() -> Result<()> {
+    run_pre_tool_use_hook("claude", &[CommandField::Command])
+}
+
+/// Run the Codex PreToolUse hook natively.
+pub fn run_codex() -> Result<()> {
+    run_pre_tool_use_hook("codex", &[CommandField::Command, CommandField::Cmd])
+}
+
 #[cfg(test)]
-fn run_claude_inner(input: &str) -> Option<String> {
+fn run_pre_tool_use_inner(input: &str, fields: &[CommandField]) -> Option<String> {
     let v: Value = serde_json::from_str(input).ok()?;
-    match process_claude_payload(&v) {
+    match process_pre_tool_use_payload(&v, fields) {
         PayloadAction::Rewrite { output, .. } => Some(output.to_string()),
         _ => None,
     }
+}
+
+#[cfg(test)]
+fn run_claude_inner(input: &str) -> Option<String> {
+    run_pre_tool_use_inner(input, &[CommandField::Command])
+}
+
+#[cfg(test)]
+fn run_codex_inner(input: &str) -> Option<String> {
+    run_pre_tool_use_inner(input, &[CommandField::Command, CommandField::Cmd])
 }
 
 // ── Cursor native hook ─────────────────────────────────────────
@@ -913,6 +962,111 @@ mod tests {
     fn test_claude_no_tool_input_passthrough() {
         let input = json!({ "tool_name": "Bash" }).to_string();
         assert!(run_claude_inner(&input).is_none());
+    }
+
+    // --- Codex handler ---
+
+    fn codex_input(cmd: &str) -> String {
+        json!({
+            "tool_name": "Bash",
+            "tool_input": { "command": cmd }
+        })
+        .to_string()
+    }
+
+    fn codex_exec_command_input(cmd: &str) -> String {
+        json!({
+            "tool_name": "exec_command",
+            "tool_input": {
+                "cmd": cmd,
+                "yield_time_ms": 1000,
+                "max_output_tokens": 2000
+            }
+        })
+        .to_string()
+    }
+
+    fn codex_input_with_fields(cmd: &str, timeout: u64, description: &str) -> String {
+        json!({
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": cmd,
+                "timeout": timeout,
+                "description": description
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn test_codex_rewrite_git_status() {
+        let result = run_codex_inner(&codex_input("git status")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let cmd = v
+            .pointer("/hookSpecificOutput/updatedInput/command")
+            .and_then(|c| c.as_str())
+            .unwrap();
+        assert_eq!(cmd, "rtk git status");
+    }
+
+    #[test]
+    fn test_codex_rewrite_exec_command_cmd_field() {
+        let result = run_codex_inner(&codex_exec_command_input("git status")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let updated = &v["hookSpecificOutput"]["updatedInput"];
+        assert_eq!(updated["cmd"], "rtk git status");
+        assert_eq!(updated["yield_time_ms"], 1000);
+        assert_eq!(updated["max_output_tokens"], 2000);
+        assert!(updated.get("command").is_none());
+    }
+
+    #[test]
+    fn test_claude_ignores_codex_cmd_field() {
+        assert!(run_claude_inner(&codex_exec_command_input("git status")).is_none());
+    }
+
+    #[test]
+    fn test_codex_rewrite_preserves_tool_input_fields() {
+        let input = codex_input_with_fields("git status", 30000, "Check repo status");
+        let result = run_codex_inner(&input).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let updated = &v["hookSpecificOutput"]["updatedInput"];
+        assert_eq!(updated["command"], "rtk git status");
+        assert_eq!(updated["timeout"], 30000);
+        assert_eq!(updated["description"], "Check repo status");
+    }
+
+    #[test]
+    fn test_codex_passthrough_no_output() {
+        assert!(run_codex_inner(&codex_input("htop")).is_none());
+    }
+
+    #[test]
+    fn test_codex_heredoc_passthrough() {
+        assert!(run_codex_inner(&codex_input("cat <<EOF\nhello\nEOF")).is_none());
+    }
+
+    #[test]
+    fn test_codex_env_prefix_preserved() {
+        let result = run_codex_inner(&codex_input("GIT_PAGER=cat git status")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let cmd = v
+            .pointer("/hookSpecificOutput/updatedInput/command")
+            .and_then(|c| c.as_str())
+            .unwrap();
+        assert_eq!(cmd, "GIT_PAGER=cat rtk git status");
+    }
+
+    #[test]
+    fn test_codex_json_output_structure() {
+        let result = run_codex_inner(&codex_input("git status")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let hook = &v["hookSpecificOutput"];
+
+        assert_eq!(hook["hookEventName"], PRE_TOOL_USE_KEY);
+        assert_eq!(hook["permissionDecisionReason"], "RTK auto-rewrite");
+        assert!(hook["updatedInput"].is_object());
+        assert!(hook["updatedInput"]["command"].is_string());
     }
 
     // --- Cursor handler ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -769,6 +769,8 @@ enum Commands {
 enum HookCommands {
     /// Process Claude Code PreToolUse hook (reads JSON from stdin)
     Claude,
+    /// Process Codex PreToolUse hook (reads JSON from stdin)
+    Codex,
     /// Process Cursor Agent hook (reads JSON from stdin)
     Cursor,
     /// Process Gemini CLI BeforeTool hook (reads JSON from stdin)
@@ -2200,6 +2202,10 @@ fn run_cli() -> Result<i32> {
                 hooks::hook_cmd::run_claude()?;
                 0
             }
+            HookCommands::Codex => {
+                hooks::hook_cmd::run_codex()?;
+                0
+            }
             HookCommands::Cursor => {
                 hooks::hook_cmd::run_cursor()?;
                 0
@@ -2857,6 +2863,17 @@ mod tests {
             cli.command,
             Commands::Hook {
                 command: HookCommands::Claude
+            }
+        ));
+    }
+
+    #[test]
+    fn test_hook_codex_parses() {
+        let cli = Cli::try_parse_from(["rtk", "hook", "codex"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Hook {
+                command: HookCommands::Codex
             }
         ));
     }


### PR DESCRIPTION
## Summary
- add native `rtk hook codex` CLI subcommand
- share the PreToolUse rewrite core while keeping Claude and Codex entrypoints scoped separately
- support Claude-style `tool_input.command` and Codex-style `tool_input.cmd`, preserving the original field name in `updatedInput`
- document manual Codex hook configuration

## Validation
- `cargo fmt --check`
- `cargo test hook_cmd` (60 passed)
- `cargo test test_hook_codex_parses`
- `cargo test test_hook_claude_parses`
- `cargo test` (2005 passed, 7 ignored)
- stdin smoke test for `cargo run --quiet -- hook codex` with `tool_input.command`
- stdin smoke test for `cargo run --quiet -- hook codex` with `tool_input.cmd`

## Codex CLI check
Codex CLI 0.136.0 was available locally. I tested with an isolated `CODEX_HOME`, both `hooks.json` and inline `config.toml` hook config, `--dangerously-bypass-hook-trust`, and a clean `env -i` run. In this Codex Desktop-launched environment, `codex exec` recorded model function calls named `exec_command` and did not invoke user PreToolUse hooks, so there was no runtime hook stdin payload to capture from `codex exec`. The parser is therefore validated by unit tests plus direct stdin CLI smoke tests, and it includes the observed Codex shell field name `cmd`.