### PR TITLE
feat(oc): add Openshift CLI support with shared k8s filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,9 @@ rtk docker compose ps           # Compose services
 rtk kubectl pods                # Compact pod list
 rtk kubectl logs <pod>          # Deduplicated logs
 rtk kubectl services            # Compact service list
+rtk oc get pods                 # OpenShift pod summary
+rtk oc get services             # OpenShift service list
+rtk oc logs <pod>               # Deduplicated logs
 ```
 
 ### Data & Analytics

--- a/src/cmds/cloud/README.md
+++ b/src/cmds/cloud/README.md
@@ -5,7 +5,7 @@
 ## Specifics
 
 - `aws_cmd.rs` — 25 specialized filters covering STS, S3, EC2, ECS, RDS, CloudFormation, CloudWatch Logs, Lambda, IAM, DynamoDB, EKS, SQS, Secrets Manager. Forces `--output json` for structured parsing, uses `force_tee_hint()` for truncation recovery, strips Lambda secrets. Shared runner `run_aws_filtered()` handles boilerplate for JSON-based filters; text-based filters (S3 ls, S3 sync/cp) have dedicated runners
-- `container.rs` handles both Docker and Kubernetes; `DockerCommands` and `KubectlCommands` sub-enums in `main.rs` route to `container::run()` -- uses passthrough for unknown subcommands
+- `container.rs` handles Docker, Kubernetes, and OpenShift; `DockerCommands`, `KubectlCommands`, and `OcCommands` sub-enums in `main.rs` route to `container::run()` -- uses passthrough for unknown subcommands
 - `curl_cmd.rs` truncates long responses, saves full output to file for recovery
 - `wget_cmd.rs` wraps wget with output filtering
 - `psql_cmd.rs` filters PostgreSQL query output

--- a/src/cmds/cloud/container.rs
+++ b/src/cmds/cloud/container.rs
@@ -27,24 +27,24 @@ pub fn run(cmd: ContainerCmd, args: &[String], verbose: u8) -> Result<i32> {
         ContainerCmd::DockerPsAll => docker_ps_all(verbose),
         ContainerCmd::DockerImages => docker_images(verbose),
         ContainerCmd::DockerLogs => docker_logs(args, verbose),
-        ContainerCmd::KubectlPods => kubectl_pods(args, verbose),
-        ContainerCmd::KubectlServices => kubectl_services(args, verbose),
-        ContainerCmd::KubectlLogs => kubectl_logs(args, verbose),
+        ContainerCmd::KubectlPods => k8s_pods("kubectl", args, verbose),
+        ContainerCmd::KubectlServices => k8s_services("kubectl", args, verbose),
+        ContainerCmd::KubectlLogs => k8s_logs("kubectl", args, verbose),
     }
 }
 
-fn run_kubectl_json<F>(cmd: Command, label: &str, filter_fn: F) -> Result<i32>
+fn run_k8s_json<F>(cmd: Command, tool: &str, label: &str, filter_fn: F) -> Result<i32>
 where
     F: Fn(&Value) -> String,
 {
     runner::run_filtered(
         cmd,
-        "kubectl",
+        tool,
         label,
         |stdout| match serde_json::from_str::<Value>(stdout) {
             Ok(json) => filter_fn(&json),
             Err(e) => {
-                eprintln!("[rtk] kubectl: JSON parse failed: {}", e);
+                eprintln!("[rtk] {}: JSON parse failed: {}", tool, e);
                 stdout.to_string()
             }
         },
@@ -330,13 +330,13 @@ fn docker_logs(args: &[String], _verbose: u8) -> Result<i32> {
     )
 }
 
-fn kubectl_pods(args: &[String], _verbose: u8) -> Result<i32> {
-    let mut cmd = resolved_command("kubectl");
+pub fn k8s_pods(tool: &str, args: &[String], _verbose: u8) -> Result<i32> {
+    let mut cmd = resolved_command(tool);
     cmd.args(["get", "pods", "-o", "json"]);
     for arg in args {
         cmd.arg(arg);
     }
-    run_kubectl_json(cmd, "get pods", format_kubectl_pods)
+    run_k8s_json(cmd, tool, "get pods", format_kubectl_pods)
 }
 
 fn format_kubectl_pods(json: &Value) -> String {
@@ -416,13 +416,13 @@ fn format_kubectl_pods(json: &Value) -> String {
     out
 }
 
-fn kubectl_services(args: &[String], _verbose: u8) -> Result<i32> {
-    let mut cmd = resolved_command("kubectl");
+pub fn k8s_services(tool: &str, args: &[String], _verbose: u8) -> Result<i32> {
+    let mut cmd = resolved_command(tool);
     cmd.args(["get", "services", "-o", "json"]);
     for arg in args {
         cmd.arg(arg);
     }
-    run_kubectl_json(cmd, "get services", format_kubectl_services)
+    run_k8s_json(cmd, tool, "get services", format_kubectl_services)
 }
 
 fn format_kubectl_services(json: &Value) -> String {
@@ -477,14 +477,14 @@ fn format_kubectl_services(json: &Value) -> String {
     out
 }
 
-fn kubectl_logs(args: &[String], _verbose: u8) -> Result<i32> {
+pub fn k8s_logs(tool: &str, args: &[String], _verbose: u8) -> Result<i32> {
     let pod = args.first().map(|s| s.as_str()).unwrap_or("");
     if pod.is_empty() {
-        println!("Usage: rtk kubectl logs <pod>");
+        println!("Usage: rtk {} logs <pod>", tool);
         return Ok(0);
     }
 
-    let mut cmd = resolved_command("kubectl");
+    let mut cmd = resolved_command(tool);
     cmd.args(["logs", "--tail", "100", pod]);
     for arg in args.iter().skip(1) {
         cmd.arg(arg);
@@ -493,7 +493,7 @@ fn kubectl_logs(args: &[String], _verbose: u8) -> Result<i32> {
     let label = format!("logs {}", pod);
     runner::run_filtered(
         cmd,
-        "kubectl",
+        tool,
         &label,
         |stdout| {
             format!(
@@ -751,17 +751,26 @@ pub fn run_compose_passthrough(args: &[OsString], verbose: u8) -> Result<i32> {
 }
 
 pub fn run_kubectl_get(args: &[String], verbose: u8) -> Result<i32> {
-    match kubectl_get_target(args) {
-        Some(("pods", rest)) => run(ContainerCmd::KubectlPods, rest, verbose),
-        Some(("services", rest)) => run(ContainerCmd::KubectlServices, rest, verbose),
-        _ => run_kubectl_get_passthrough(args, verbose),
+    run_k8s_get("kubectl", args, verbose)
+}
+
+fn run_k8s_get(tool: &str, args: &[String], verbose: u8) -> Result<i32> {
+    match k8s_get_target(args) {
+        Some(("pods", rest)) => k8s_pods(tool, rest, verbose),
+        Some(("services", rest)) => k8s_services(tool, rest, verbose),
+        _ => {
+            let passthrough_args: Vec<OsString> = std::iter::once(OsString::from("get"))
+                .chain(args.iter().map(|arg| OsString::from(arg.as_str())))
+                .collect();
+            crate::core::runner::run_passthrough(tool, &passthrough_args, verbose)
+        }
     }
 }
 
-fn kubectl_get_target(args: &[String]) -> Option<(&'static str, &[String])> {
+fn k8s_get_target(args: &[String]) -> Option<(&'static str, &[String])> {
     let resource = args.first()?.as_str();
     let rest = &args[1..];
-    if kubectl_get_requests_raw_output(rest) {
+    if k8s_get_requests_raw_output(rest) {
         return None;
     }
 
@@ -772,7 +781,7 @@ fn kubectl_get_target(args: &[String]) -> Option<(&'static str, &[String])> {
     }
 }
 
-fn kubectl_get_requests_raw_output(args: &[String]) -> bool {
+fn k8s_get_requests_raw_output(args: &[String]) -> bool {
     args.iter().any(|arg| {
         matches!(
             arg.as_str(),
@@ -782,15 +791,16 @@ fn kubectl_get_requests_raw_output(args: &[String]) -> bool {
     })
 }
 
-fn run_kubectl_get_passthrough(args: &[String], verbose: u8) -> Result<i32> {
-    let passthrough_args: Vec<OsString> = std::iter::once(OsString::from("get"))
-        .chain(args.iter().map(|arg| OsString::from(arg.as_str())))
-        .collect();
-    run_kubectl_passthrough(&passthrough_args, verbose)
-}
-
 pub fn run_kubectl_passthrough(args: &[OsString], verbose: u8) -> Result<i32> {
     crate::core::runner::run_passthrough("kubectl", args, verbose)
+}
+
+pub fn run_oc_get(args: &[String], verbose: u8) -> Result<i32> {
+    run_k8s_get("oc", args, verbose)
+}
+
+pub fn run_oc_passthrough(args: &[OsString], verbose: u8) -> Result<i32> {
+    crate::core::runner::run_passthrough("oc", args, verbose)
 }
 
 #[cfg(test)]
@@ -931,12 +941,12 @@ api-1  | Connected to database";
     }
 
     #[test]
-    fn test_kubectl_get_target_pods_aliases() {
+    fn test_k8s_get_target_pods_aliases() {
         for resource in ["po", "pod", "pods"] {
             let args = vec![resource.to_string(), "-n".to_string(), "default".to_string()];
 
             assert_eq!(
-                kubectl_get_target(&args),
+                k8s_get_target(&args),
                 Some(("pods", &args[1..])),
                 "failed for {resource}"
             );
@@ -944,12 +954,12 @@ api-1  | Connected to database";
     }
 
     #[test]
-    fn test_kubectl_get_target_services_aliases() {
+    fn test_k8s_get_target_services_aliases() {
         for resource in ["svc", "service", "services"] {
             let args = vec![resource.to_string(), "-A".to_string()];
 
             assert_eq!(
-                kubectl_get_target(&args),
+                k8s_get_target(&args),
                 Some(("services", &args[1..])),
                 "failed for {resource}"
             );
@@ -957,14 +967,14 @@ api-1  | Connected to database";
     }
 
     #[test]
-    fn test_kubectl_get_target_unsupported_resource() {
+    fn test_k8s_get_target_unsupported_resource() {
         let args = vec!["deployments".to_string()];
 
-        assert_eq!(kubectl_get_target(&args), None);
+        assert_eq!(k8s_get_target(&args), None);
     }
 
     #[test]
-    fn test_kubectl_get_target_respects_output_flags() {
+    fn test_k8s_get_target_respects_output_flags() {
         for output_flag in ["-o", "-owide", "--output", "--output=json"] {
             let args = vec![
                 "pods".to_string(),
@@ -973,10 +983,27 @@ api-1  | Connected to database";
             ];
 
             assert_eq!(
-                kubectl_get_target(&args),
+                k8s_get_target(&args),
                 None,
                 "should pass through {output_flag}"
             );
         }
+    }
+
+    // ── oc support ────────────────────────────────────────
+
+    #[test]
+    fn test_oc_pods_savings() {
+        let input_str = include_str!("../../../tests/fixtures/oc_pods.json");
+        let input: Value = serde_json::from_str(input_str).expect("fixture should parse");
+        let output = format_kubectl_pods(&input);
+        let input_tokens = input_str.split_whitespace().count();
+        let output_tokens = output.split_whitespace().count();
+        let savings = 100.0 - (output_tokens as f64 / input_tokens as f64 * 100.0);
+        assert!(
+            savings >= 60.0,
+            "Expected >=60% savings, got {:.1}%",
+            savings
+        );
     }
 }

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -390,6 +390,15 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
+        pattern: r"^oc\s+(get|logs|describe|apply|status|adm)",
+        rtk_cmd: "rtk oc",
+        rewrite_prefixes: &["oc"],
+        category: "Infra",
+        savings_pct: 85.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
+    RtkRule {
         pattern: r"^tree(\s|$)",
         rtk_cmd: "rtk tree",
         rewrite_prefixes: &["tree"],

--- a/src/main.rs
+++ b/src/main.rs
@@ -293,6 +293,12 @@ enum Commands {
         command: KubectlCommands,
     },
 
+    /// OpenShift CLI (oc) commands with compact output
+    Oc {
+        #[command(subcommand)]
+        command: OcCommands,
+    },
+
     /// Run command and show heuristic summary
     Summary {
         /// Command to run and summarize
@@ -983,6 +989,41 @@ enum KubectlCommands {
 }
 
 #[derive(Debug, Subcommand)]
+enum OcCommands {
+    /// Get OpenShift resources (compact for pods/services)
+    Get {
+        /// oc get arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// List pods
+    Pods {
+        #[arg(short, long)]
+        namespace: Option<String>,
+        /// All namespaces
+        #[arg(short = 'A', long)]
+        all: bool,
+    },
+    /// List services
+    Services {
+        #[arg(short, long)]
+        namespace: Option<String>,
+        /// All namespaces
+        #[arg(short = 'A', long)]
+        all: bool,
+    },
+    /// Show pod logs (deduplicated)
+    Logs {
+        pod: String,
+        #[arg(short, long)]
+        container: Option<String>,
+    },
+    /// Passthrough: runs any unsupported oc subcommand directly
+    #[command(external_subcommand)]
+    Other(Vec<OsString>),
+}
+
+#[derive(Debug, Subcommand)]
 enum PrismaCommands {
     /// Generate Prisma Client (strip ASCII art)
     Generate {
@@ -1312,6 +1353,26 @@ enum GtCommands {
 /// e.g. `git log --format="%H %s"` → ["git", "log", "--format=%H %s"]
 fn shell_split(input: &str) -> Vec<String> {
     discover::lexer::shell_split(input)
+}
+
+fn build_k8s_namespace_args(namespace: Option<String>, all: bool) -> Vec<String> {
+    let mut args = Vec::new();
+    if all {
+        args.push("-A".to_string());
+    } else if let Some(n) = namespace {
+        args.push("-n".to_string());
+        args.push(n);
+    }
+    args
+}
+
+fn build_k8s_logs_args(pod: String, container: Option<String>) -> Vec<String> {
+    let mut args = vec![pod];
+    if let Some(cont) = container {
+        args.push("-c".to_string());
+        args.push(cont);
+    }
+    args
 }
 
 /// Merge pnpm global filters args with other ones for standard String-based commands
@@ -1756,34 +1817,35 @@ fn run_cli() -> Result<i32> {
         Commands::Kubectl { command } => match command {
             KubectlCommands::Get { args } => container::run_kubectl_get(&args, cli.verbose)?,
             KubectlCommands::Pods { namespace, all } => {
-                let mut args: Vec<String> = Vec::new();
-                if all {
-                    args.push("-A".to_string());
-                } else if let Some(n) = namespace {
-                    args.push("-n".to_string());
-                    args.push(n);
-                }
+                let args = build_k8s_namespace_args(namespace, all);
                 container::run(container::ContainerCmd::KubectlPods, &args, cli.verbose)?
             }
             KubectlCommands::Services { namespace, all } => {
-                let mut args: Vec<String> = Vec::new();
-                if all {
-                    args.push("-A".to_string());
-                } else if let Some(n) = namespace {
-                    args.push("-n".to_string());
-                    args.push(n);
-                }
+                let args = build_k8s_namespace_args(namespace, all);
                 container::run(container::ContainerCmd::KubectlServices, &args, cli.verbose)?
             }
             KubectlCommands::Logs { pod, container: c } => {
-                let mut args = vec![pod];
-                if let Some(cont) = c {
-                    args.push("-c".to_string());
-                    args.push(cont);
-                }
+                let args = build_k8s_logs_args(pod, c);
                 container::run(container::ContainerCmd::KubectlLogs, &args, cli.verbose)?
             }
             KubectlCommands::Other(args) => container::run_kubectl_passthrough(&args, cli.verbose)?,
+        },
+
+        Commands::Oc { command } => match command {
+            OcCommands::Get { args } => container::run_oc_get(&args, cli.verbose)?,
+            OcCommands::Pods { namespace, all } => {
+                let args = build_k8s_namespace_args(namespace, all);
+                container::k8s_pods("oc", &args, cli.verbose)?
+            }
+            OcCommands::Services { namespace, all } => {
+                let args = build_k8s_namespace_args(namespace, all);
+                container::k8s_services("oc", &args, cli.verbose)?
+            }
+            OcCommands::Logs { pod, container: c } => {
+                let args = build_k8s_logs_args(pod, c);
+                container::k8s_logs("oc", &args, cli.verbose)?
+            }
+            OcCommands::Other(args) => container::run_oc_passthrough(&args, cli.verbose)?,
         },
 
         Commands::Summary { command } => {
@@ -2504,6 +2566,7 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Dotnet { .. }
             | Commands::Docker { .. }
             | Commands::Kubectl { .. }
+            | Commands::Oc { .. }
             | Commands::Summary { .. }
             | Commands::Grep { .. }
             | Commands::Wget { .. }
@@ -2689,6 +2752,30 @@ mod tests {
                 command: KubectlCommands::Get { args },
             } => assert_eq!(args, vec!["pods", "-n", "default"]),
             _ => panic!("Expected Kubectl Get command"),
+        }
+    }
+
+    #[test]
+    fn test_try_parse_oc_get() {
+        let cli = Cli::try_parse_from(["rtk", "oc", "get", "pods", "-n", "default"]).unwrap();
+
+        match cli.command {
+            Commands::Oc {
+                command: OcCommands::Get { args },
+            } => assert_eq!(args, vec!["pods", "-n", "default"]),
+            _ => panic!("Expected Oc Get command"),
+        }
+    }
+
+    #[test]
+    fn test_try_parse_oc_other() {
+        let cli = Cli::try_parse_from(["rtk", "oc", "new-project", "test"]).unwrap();
+
+        match cli.command {
+            Commands::Oc {
+                command: OcCommands::Other(_),
+            } => {}
+            _ => panic!("Expected Oc Other command"),
         }
     }
 

--- a/tests/fixtures/oc_pods.json
+++ b/tests/fixtures/oc_pods.json
@@ -1,0 +1,450 @@
+{
+  "apiVersion": "v1",
+  "kind": "List",
+  "metadata": {
+    "resourceVersion": ""
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "alertmanager-main-0",
+        "namespace": "openshift-monitoring"
+      },
+      "status": {
+        "phase": "Running",
+        "containerStatuses": [
+          {
+            "name": "alertmanager",
+            "restartCount": 0
+          },
+          {
+            "name": "config-reloader",
+            "restartCount": 0
+          },
+          {
+            "name": "kube-rbac-proxy",
+            "restartCount": 0
+          },
+          {
+            "name": "kube-rbac-proxy-metric",
+            "restartCount": 0
+          },
+          {
+            "name": "kube-rbac-proxy-web",
+            "restartCount": 0
+          },
+          {
+            "name": "prom-label-proxy",
+            "restartCount": 0
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertmanager-main-1",
+        "namespace": "openshift-monitoring"
+      },
+      "status": {
+        "phase": "Running",
+        "containerStatuses": [
+          {
+            "name": "alertmanager",
+            "restartCount": 0
+          },
+          {
+            "name": "config-reloader",
+            "restartCount": 0
+          },
+          {
+            "name": "kube-rbac-proxy",
+            "restartCount": 0
+          },
+          {
+            "name": "kube-rbac-proxy-metric",
+            "restartCount": 0
+          },
+          {
+            "name": "kube-rbac-proxy-web",
+            "restartCount": 0
+          },
+          {
+            "name": "prom-label-proxy",
+            "restartCount": 0
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "cluster-monitoring-operator-7fb9fd4c5d-wm2k6",
+        "namespace": "openshift-monitoring"
+      },
+      "status": {
+        "phase": "Running",
+        "containerStatuses": [
+          {
+            "name": "cluster-monitoring-operator",
+            "restartCount": 0
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-state-metrics-75586fdddb-5zw6b",
+        "namespace": "openshift-monitoring"
+      },
+      "status": {
+        "phase": "Running",
+        "containerStatuses": [
+          {
+            "name": "kube-rbac-proxy-main",
+            "restartCount": 0
+          },
+          {
+            "name": "kube-rbac-proxy-self",
+            "restartCount": 0
+          },
+          {
+            "name": "kube-state-metrics",
+            "restartCount": 0
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "metrics-server-fdfb77995-jmqnm",
+        "namespace": "openshift-monitoring"
+      },
+      "status": {
+        "phase": "Running",
+        "containerStatuses": [
+          {
+            "name": "metrics-server",
+            "restartCount": 0
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "metrics-server-fdfb77995-w4r8p",
+        "namespace": "openshift-monitoring"
+      },
+      "status": {
+        "phase": "Running",
+        "containerStatuses": [
+          {
+            "name": "metrics-server",
+            "restartCount": 0
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "monitoring-plugin-85b45d978c-27rfm",
+        "namespace": "openshift-monitoring"
+      },
+      "status": {
+        "phase": "Running",
+        "containerStatuses": [
+          {
+            "name": "monitoring-plugin",
+            "restartCount": 0
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "monitoring-plugin-85b45d978c-64g98",
+        "namespace": "openshift-monitoring"
+      },
+      "status": {
+        "phase": "Running",
+        "containerStatuses": [
+          {
+            "name": "monitoring-plugin",
+            "restartCount": 0
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "node-exporter-5fw9f",
+        "namespace": "openshift-monitoring"
+      },
+      "status": {
+        "phase": "Running",
+        "containerStatuses": [
+          {
+            "name": "kube-rbac-proxy",
+            "restartCount": 0
+          },
+          {
+            "name": "node-exporter",
+            "restartCount": 0
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "node-exporter-gbnrd",
+        "namespace": "openshift-monitoring"
+      },
+      "status": {
+        "phase": "Running",
+        "containerStatuses": [
+          {
+            "name": "kube-rbac-proxy",
+            "restartCount": 0
+          },
+          {
+            "name": "node-exporter",
+            "restartCount": 0
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "openshift-state-metrics-856bc7fff5-p8s92",
+        "namespace": "openshift-monitoring"
+      },
+      "status": {
+        "phase": "Running",
+        "containerStatuses": [
+          {
+            "name": "kube-rbac-proxy-main",
+            "restartCount": 0
+          },
+          {
+            "name": "kube-rbac-proxy-self",
+            "restartCount": 0
+          },
+          {
+            "name": "openshift-state-metrics",
+            "restartCount": 0
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "prometheus-k8s-0",
+        "namespace": "openshift-monitoring"
+      },
+      "status": {
+        "phase": "Running",
+        "containerStatuses": [
+          {
+            "name": "config-reloader",
+            "restartCount": 0
+          },
+          {
+            "name": "kube-rbac-proxy",
+            "restartCount": 0
+          },
+          {
+            "name": "kube-rbac-proxy-thanos",
+            "restartCount": 0
+          },
+          {
+            "name": "kube-rbac-proxy-web",
+            "restartCount": 0
+          },
+          {
+            "name": "prometheus",
+            "restartCount": 0
+          },
+          {
+            "name": "thanos-sidecar",
+            "restartCount": 0
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "prometheus-k8s-1",
+        "namespace": "openshift-monitoring"
+      },
+      "status": {
+        "phase": "Running",
+        "containerStatuses": [
+          {
+            "name": "config-reloader",
+            "restartCount": 0
+          },
+          {
+            "name": "kube-rbac-proxy",
+            "restartCount": 0
+          },
+          {
+            "name": "kube-rbac-proxy-thanos",
+            "restartCount": 0
+          },
+          {
+            "name": "kube-rbac-proxy-web",
+            "restartCount": 0
+          },
+          {
+            "name": "prometheus",
+            "restartCount": 0
+          },
+          {
+            "name": "thanos-sidecar",
+            "restartCount": 0
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "prometheus-operator-5978c4f47f-9zwdq",
+        "namespace": "openshift-monitoring"
+      },
+      "status": {
+        "phase": "Running",
+        "containerStatuses": [
+          {
+            "name": "kube-rbac-proxy",
+            "restartCount": 0
+          },
+          {
+            "name": "prometheus-operator",
+            "restartCount": 0
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "prometheus-operator-admission-webhook-6485c485f4-8cfhf",
+        "namespace": "openshift-monitoring"
+      },
+      "status": {
+        "phase": "Running",
+        "containerStatuses": [
+          {
+            "name": "prometheus-operator-admission-webhook",
+            "restartCount": 0
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "prometheus-operator-admission-webhook-6485c485f4-b655d",
+        "namespace": "openshift-monitoring"
+      },
+      "status": {
+        "phase": "Running",
+        "containerStatuses": [
+          {
+            "name": "prometheus-operator-admission-webhook",
+            "restartCount": 0
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "telemeter-client-5d75f79f95-hr22b",
+        "namespace": "openshift-monitoring"
+      },
+      "status": {
+        "phase": "Running",
+        "containerStatuses": [
+          {
+            "name": "kube-rbac-proxy",
+            "restartCount": 0
+          },
+          {
+            "name": "reload",
+            "restartCount": 0
+          },
+          {
+            "name": "telemeter-client",
+            "restartCount": 0
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "thanos-querier-5fcf655bd-4h2m2",
+        "namespace": "openshift-monitoring"
+      },
+      "status": {
+        "phase": "Running",
+        "containerStatuses": [
+          {
+            "name": "kube-rbac-proxy",
+            "restartCount": 0
+          },
+          {
+            "name": "kube-rbac-proxy-metrics",
+            "restartCount": 0
+          },
+          {
+            "name": "kube-rbac-proxy-rules",
+            "restartCount": 0
+          },
+          {
+            "name": "kube-rbac-proxy-web",
+            "restartCount": 0
+          },
+          {
+            "name": "prom-label-proxy",
+            "restartCount": 0
+          },
+          {
+            "name": "thanos-query",
+            "restartCount": 0
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "thanos-querier-5fcf655bd-wd28r",
+        "namespace": "openshift-monitoring"
+      },
+      "status": {
+        "phase": "Running",
+        "containerStatuses": [
+          {
+            "name": "kube-rbac-proxy",
+            "restartCount": 0
+          },
+          {
+            "name": "kube-rbac-proxy-metrics",
+            "restartCount": 0
+          },
+          {
+            "name": "kube-rbac-proxy-rules",
+            "restartCount": 0
+          },
+          {
+            "name": "kube-rbac-proxy-web",
+            "restartCount": 0
+          },
+          {
+            "name": "prom-label-proxy",
+            "restartCount": 0
+          },
+          {
+            "name": "thanos-query",
+            "restartCount": 0
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add OpenShift CLI (`oc`) support: `oc get pods`, `oc get services`, and `oc logs` now get the same compact filtering as their kubectl equivalents
- Generalize kubectl helpers (`k8s_pods`, `k8s_services`, `k8s_logs`) to accept a tool parameter, enabling code reuse between kubectl and oc
- Add rewrite rule in `discover/rules.rs` so hooks auto-rewrite `oc` commands to `rtk oc`

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test` — 1949 tests pass
- [x] Manual testing: `rtk oc get pods -n openshift-monitoring` produces filtered summary
- [x] Manual testing: `rtk oc get services -n openshift-monitoring` produces compact service list
- [x] Manual testing: `rtk oc new-project test` passes through via external_subcommand
- [x] Token savings test: ≥60% savings verified with real sanitized fixture from ROSA HCP cluster
- [x] `rtk gain` confirms oc commands tracked with >0% savings

## Scoping 

As per the scope rules, I tried to focus this PR to adding initial functionality for `oc` support through the k8s-shared commands only (pods, services, logs). oc-specific resource filters (routes, imagestreams, etc.) can come from follow-up PRs.