### PR TITLE
feat(hooks): add native Windows PowerShell hook (rtk-rewrite.ps1)

### DIFF
--- a/hooks/claude/rtk-rewrite.ps1
+++ b/hooks/claude/rtk-rewrite.ps1
@@ -1,0 +1,126 @@
+# RTK PreToolUse hook for Claude Code on Windows (native PowerShell).
+# Counterpart of hooks/claude/rtk-rewrite.sh for users who run Claude Code on
+# native Windows (no WSL / Unix shell). Requires: rtk >= 0.23.0 in PATH.
+#
+# Why a dedicated implementation instead of a thin `& rtk rewrite $cmd` wrapper:
+# Windows PowerShell 5.1 strips embedded double-quotes when a string is passed as
+# a native-command argument, so `& rtk rewrite $cmd` corrupts the command before
+# rtk sees it. For example the input
+#     git diff; echo "a (b)"
+# reaches rtk as
+#     git diff; echo a (b)
+# and the rewritten result `... echo a (b)` is invalid shell (unbalanced "("),
+# which breaks the very command the hook was meant to optimize. (rtk's own output
+# is correctly quoted; the corruption happens purely in PowerShell argument
+# passing.) This script therefore builds the child process command line itself
+# using MSVCRT / CommandLineToArgvW quoting, so the exact command reaches
+# `rtk rewrite` untouched on both Windows PowerShell 5.1 and PowerShell 7+.
+#
+# Install (PreToolUse, matcher "Bash"):
+#   powershell.exe -ExecutionPolicy Bypass -NoProfile -File <path>\rtk-rewrite.ps1
+#
+# Exit code protocol from `rtk rewrite` (identical to rtk-rewrite.sh):
+#   0 + stdout = auto-allow the rewrite
+#   1          = no equivalent, passthrough unchanged
+#   2          = deny rule matched, passthrough (Claude Code native deny handles it)
+#   3 + stdout = ask rule matched, rewrite but do NOT auto-allow
+
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$OutputEncoding = [System.Text.Encoding]::UTF8
+
+$rtk = Get-Command rtk -ErrorAction SilentlyContinue
+if (-not $rtk) {
+    [Console]::Error.WriteLine("[rtk] WARNING: rtk not found in PATH. Hook is a no-op.")
+    exit 0
+}
+
+$json = [Console]::In.ReadToEnd()
+if (-not $json) { exit 0 }
+
+try {
+    $data = $json | ConvertFrom-Json -ErrorAction Stop
+} catch {
+    exit 0
+}
+
+$cmd = $data.tool_input.command
+if (-not $cmd) { exit 0 }
+
+function ConvertTo-NativeArg([string]$s) {
+    # Quote a single argument per the MSVCRT / CommandLineToArgvW rules so it
+    # reaches the child process intact (PowerShell would otherwise mangle quotes).
+    if ($s.Length -eq 0) { return '""' }
+    if ($s -notmatch '[ \t"]') { return $s }
+    $sb = [System.Text.StringBuilder]::new()
+    [void]$sb.Append('"')
+    $bs = 0
+    foreach ($ch in $s.ToCharArray()) {
+        if ($ch -eq '\') {
+            $bs++
+        }
+        elseif ($ch -eq '"') {
+            [void]$sb.Append('\' * ($bs * 2 + 1))
+            [void]$sb.Append('"')
+            $bs = 0
+        }
+        else {
+            if ($bs -gt 0) { [void]$sb.Append('\' * $bs); $bs = 0 }
+            [void]$sb.Append($ch)
+        }
+    }
+    [void]$sb.Append('\' * ($bs * 2))
+    [void]$sb.Append('"')
+    return $sb.ToString()
+}
+
+# Invoke `rtk rewrite <cmd>` with a hand-quoted command line. Any failure falls
+# through to passthrough (exit 0) so the hook can never break command execution.
+try {
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName = $rtk.Source
+    $psi.Arguments = "rewrite " + (ConvertTo-NativeArg $cmd)
+    $psi.UseShellExecute = $false
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.CreateNoWindow = $true
+    $psi.StandardOutputEncoding = [System.Text.Encoding]::UTF8
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    $rewritten = $proc.StandardOutput.ReadToEnd()
+    [void]$proc.StandardError.ReadToEnd()
+    $proc.WaitForExit()
+    $exitCode = $proc.ExitCode
+    $rewritten = $rewritten.Replace("`r`n", "`n").TrimEnd("`n")
+} catch {
+    exit 0
+}
+
+function Emit-Update {
+    param([string]$NewCmd, [bool]$AutoAllow)
+    $hookOut = @{
+        hookEventName = "PreToolUse"
+        updatedInput  = @{ command = $NewCmd }
+    }
+    if ($AutoAllow) {
+        $hookOut.permissionDecision       = "allow"
+        $hookOut.permissionDecisionReason = "RTK auto-rewrite"
+    }
+    @{ hookSpecificOutput = $hookOut } | ConvertTo-Json -Compress -Depth 10
+}
+
+switch ($exitCode) {
+    0 {
+        if ($rewritten -and $rewritten -ne $cmd) {
+            Emit-Update -NewCmd $rewritten -AutoAllow $true
+        }
+    }
+    3 {
+        if ($rewritten -and $rewritten -ne $cmd) {
+            Emit-Update -NewCmd $rewritten -AutoAllow $false
+        }
+    }
+    default {
+        # 1 / 2 / unknown — passthrough
+    }
+}
+
+exit 0

--- a/hooks/claude/test-rtk-rewrite.ps1
+++ b/hooks/claude/test-rtk-rewrite.ps1
@@ -1,0 +1,20 @@
+# Smoke test for hooks/claude/rtk-rewrite.ps1.
+# Drives the hook exactly as Claude Code does: spawns it as a separate process
+# with the tool_input JSON on stdin and prints the emitted hookSpecificOutput.
+# Requires rtk >= 0.23.0 in PATH. Run:  powershell -File test-rtk-rewrite.ps1
+$hook = Join-Path $PSScriptRoot "rtk-rewrite.ps1"
+$cases = @(
+    'git diff; echo "a (b)"',                  # quotes+parens must survive
+    'git status && grep -n "def foo(" .',      # multiple rewrites + quoted paren
+    'git commit -m "fix(ci): pin (1M)"',       # parens inside a commit message
+    'git log --oneline | grep "fix(x)"',       # quoted paren after a pipe
+    'ls -la',                                   # plain rewrite, no quotes
+    'echo "plain text, no rewrite target"'     # passthrough (no rtk equivalent)
+)
+foreach ($c in $cases) {
+    $json = (@{ tool_input = @{ command = $c } } | ConvertTo-Json -Compress)
+    $out = ($json | powershell.exe -ExecutionPolicy Bypass -NoProfile -File $hook) -join "`n"
+    Write-Output ("IN : " + $c)
+    Write-Output ("OUT: " + $out)
+    Write-Output ""
+}


### PR DESCRIPTION
### Problem

On native Windows (no WSL), Claude Code has no working auto-rewrite hook — the docs note the bash hook `rtk-rewrite.sh` "requires a Unix shell", so Windows falls back to CLAUDE.md-injection and loses automatic rewriting.

A naive PowerShell port that simply calls `& rtk rewrite $cmd` does **not** work on **Windows PowerShell 5.1**: when a string is passed as a native-command argument, PowerShell 5.1 strips embedded double-quotes, so the command is corrupted *before* rtk sees it. Example (verified on PowerShell `5.1.26100`):

```
INPUT : git diff; echo "a (b)"
& rtk rewrite $cmd  ->  rtk git diff; echo a (b)     # quotes gone -> bash: syntax error near `('
```

rtk itself is blameless — given the command via argv correctly (e.g. from bash), `rtk rewrite 'git diff; echo "a (b)"'` returns `rtk git diff; echo "a (b)"` with quotes intact. The corruption is purely PowerShell argument passing.

### Fix

Add `hooks/claude/rtk-rewrite.ps1` that builds the child-process command line itself using MSVCRT / CommandLineToArgvW quoting (via `ProcessStartInfo`), so the exact command reaches `rtk rewrite` untouched on both Windows PowerShell 5.1 and PowerShell 7+. Behavior mirrors `rtk-rewrite.sh` exactly:

- same exit-code protocol (`0` auto-allow / `1` passthrough / `2` deny / `3` ask);
- same `hookSpecificOutput` (`updatedInput.command`, `permissionDecision: allow` for exit 0);
- fail-safe: any error path exits `0` (passthrough), so the hook can never break command execution.

### Testing

Verified end-to-end (hook spawned as a separate process with tool_input JSON on stdin, mirroring Claude Code) — quotes/parens/`&&`/pipes all survive:

| input | rewritten command |
|---|---|
| `git diff; echo "a (b)"` | `rtk git diff; echo "a (b)"` |
| `git status && grep -n "def foo(" .` | `rtk git status && rtk grep -n "def foo(" .` |
| `git commit -m "fix(ci): pin (1M)"` | `rtk git commit -m "fix(ci): pin (1M)"` |
| `git log --oneline \| grep "fix(x)"` | `rtk git log --oneline \| grep "fix(x)"` |
| `echo "plain text, no rewrite target"` | (passthrough, unchanged) |

A smoke test is included at `hooks/claude/test-rtk-rewrite.ps1`.

### Install (PreToolUse, matcher "Bash")

```
powershell.exe -ExecutionPolicy Bypass -NoProfile -File <path>\rtk-rewrite.ps1
```
