### PR TITLE
docs(readme): clarify Copilot init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ rtk gain        # Should show token savings stats
 
 ```bash
 # 1. Install for your AI tool
-rtk init -g                     # Claude Code / Copilot (default)
+rtk init -g                     # Claude Code
+rtk init -g --copilot           # Copilot
 rtk init -g --gemini            # Gemini CLI
 rtk init -g --codex             # Codex (OpenAI)
 rtk init -g --agent cursor      # Cursor


### PR DESCRIPTION
## Summary
- split the Quick Start Claude Code and Copilot init commands
- document `rtk init -g --copilot` explicitly for Copilot

Closes #2244.

## Testing
- `git diff --check`
