### PR TITLE
fix(permissions): split commands on newlines to close allow-rule bypass

### DIFF
--- a/src/discover/lexer.rs
+++ b/src/discover/lexer.rs
@@ -226,6 +226,21 @@ pub fn tokenize(input: &str) -> Vec<ParsedToken> {
                 });
                 current_start = byte_pos;
             }
+            '\n' | '\r' => {
+                // A newline terminates a command, exactly like `;`. Without this,
+                // newlines fall through to the whitespace arm below and are treated
+                // as mere argument separators, so a multi-line command collapses
+                // into a single segment — letting allow-rule prefix matching on the
+                // first line approve every statement after it.
+                flush_arg(&mut tokens, &mut current, current_start);
+                tokens.push(ParsedToken {
+                    kind: TokenKind::Operator,
+                    value: c.to_string(),
+                    offset: byte_pos,
+                });
+                byte_pos += char_len;
+                current_start = byte_pos;
+            }
             c if c.is_whitespace() => {
                 flush_arg(&mut tokens, &mut current, current_start);
                 byte_pos += c.len_utf8();
@@ -1014,6 +1029,21 @@ mod tests {
         assert_eq!(
             split_on_operators("a && b | c ; d", false),
             vec!["a", "b", "c", "d"]
+        );
+    }
+
+    #[test]
+    fn test_split_on_operators_newline() {
+        // Newlines separate commands, exactly like `;`. A multi-line command
+        // must not collapse into a single segment, or allow-rule prefix matching
+        // on the first line would approve every later line.
+        assert_eq!(split_on_operators("a\nb\nc", false), vec!["a", "b", "c"]);
+        // Mixed with other operators.
+        assert_eq!(split_on_operators("a\nb | c", false), vec!["a", "b", "c"]);
+        // A newline inside quotes is NOT a separator.
+        assert_eq!(
+            split_on_operators("echo \"a\nb\"\ncargo test", false),
+            vec!["echo \"a\nb\"", "cargo test"]
         );
     }
 

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -695,6 +695,33 @@ mod tests {
     }
 
     #[test]
+    fn test_compound_allow_newline_separator() {
+        // A newline must split segments like `&&`/`;`. Regression for the
+        // permission bypass where a multi-line command was treated as a single
+        // segment and prefix-matched on its first line, auto-allowing every
+        // statement after the first newline.
+        let allow = vec!["git log".to_string(), "cat *".to_string()];
+
+        // Allowed first line, unallowed trailing line → must NOT escalate to Allow.
+        assert_eq!(
+            check_command_with_rules("git log -1\ngit push --force-with-lease", &[], &[], &allow),
+            PermissionVerdict::Default,
+            "first-line allow must not approve a newline-separated trailing command"
+        );
+        assert_eq!(
+            check_command_with_rules("cat f\nrm -rf /", &[], &[], &allow),
+            PermissionVerdict::Default,
+            "a safe first line must not launder a destructive trailing line"
+        );
+
+        // Every line allowed → Allow (legitimate multi-line case still works).
+        assert_eq!(
+            check_command_with_rules("git log -1\ncat f", &[], &[], &allow),
+            PermissionVerdict::Allow
+        );
+    }
+
+    #[test]
     fn test_compound_ask_still_wins_over_partial_allow() {
         // If any segment hits an ask rule, verdict is Ask (ask > allow).
         let ask = vec!["git push".to_string()];


### PR DESCRIPTION
## What

Treat a newline (`\n`/`\r`) as a command separator in the lexer's `tokenize`, so newline-separated statements are split into independent segments.

Fixes #2262.

## Why

`tokenize` (`src/discover/lexer.rs`) split compound commands only on `|`, `||`, `;` and `&&` — never newlines. Combined with the permission checker's prefix-based allow matching (`command_matches_pattern`), a newline-separated block collapsed into a single segment matched solely by its first line. A block led by an allow-listed read command (`git log`, `cat`, `ls`, …) therefore had its entire contents auto-allowed by the `rtk hook claude` PreToolUse hook, so trailing statements such as `rm -rf --no-preserve-root /`, `git push --force-with-lease` or `git commit --amend` ran with no prompt — bypassing the user's allow/deny rules. Full analysis in #2262.

This is the same newline-blindness as #2191 (there framed as a token-savings miss); the per-segment allow hardening from #1213 is defeated by it, because the dangerous statement is never isolated as its own segment.

## Change

Emit an `Operator` token for `\n`/`\r`, mirroring the existing `;` handling, ahead of the whitespace arm. Quoted newlines and `\`-line-continuations are already handled upstream, so only real unquoted newlines split.

Side effect: the rewrite path now rewrites every line of a multi-line command instead of only the first (previously only the leading line was rewritten — see #2191), inserting spaces around the newline. Harmless for execution; no existing tests regressed.

## Verification

- `cargo fmt --all --check`, `cargo clippy --all-targets`: clean
- `cargo test --all`: **2007 passed, 0 failed** (2 new tests)
- Behavioural check against the freshly built `rtk hook claude`:
  - `cat …\nrm -rf …` → no `permissionDecision` (previously `allow`)
  - `git log\ngit push --force-with-lease` → no `permissionDecision` (previously `allow`)
  - `git log | tail`, bare `git log` → still `allow` (legitimate cases preserved)

## Tests added

- `discover::lexer::tests::test_split_on_operators_newline` — newline splitting, including quoted newlines that must **not** split
- `hooks::permissions::tests::test_compound_allow_newline_separator` — a safe first line must not launder an unallowed trailing line
