### PR TITLE
fix(find): support -print flag as no-op

### DIFF
--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -59,7 +59,7 @@ fn next_arg(args: &[String], i: &mut usize) -> Option<String> {
 /// Check if args contain native find flags (-name, -type, -maxdepth, etc.)
 fn has_native_find_flags(args: &[String]) -> bool {
     args.iter()
-        .any(|a| a == "-name" || a == "-type" || a == "-maxdepth" || a == "-iname")
+        .any(|a| a == "-name" || a == "-type" || a == "-maxdepth" || a == "-iname" || a == "-print")
 }
 
 /// Native find flags that RTK cannot handle correctly.
@@ -130,6 +130,9 @@ fn parse_native_find_args(args: &[String]) -> Result<FindArgs> {
                 if let Some(val) = next_arg(args, &mut i) {
                     parsed.max_depth = Some(val.parse().context("invalid -maxdepth value")?);
                 }
+            }
+            "-print" => {
+                // Native find's default action. RTK already prints matches, so this is a no-op.
             }
             flag if flag.starts_with('-') => {
                 eprintln!("rtk find: unknown flag '{}', ignored", flag);
@@ -491,6 +494,21 @@ mod tests {
         let parsed = parse_find_args(&args(&["-name", "*.rs"])).unwrap();
         assert_eq!(parsed.pattern, "*.rs");
         assert_eq!(parsed.path, ".");
+    }
+
+    #[test]
+    fn parse_native_find_print_is_noop() {
+        let parsed = parse_find_args(&args(&[".", "-maxdepth", "2", "-type", "f", "-print"])).unwrap();
+        assert_eq!(parsed.path, ".");
+        assert_eq!(parsed.max_depth, Some(2));
+        assert_eq!(parsed.file_type, "f");
+    }
+
+    #[test]
+    fn parse_native_find_print_without_other_flags() {
+        let parsed = parse_find_args(&args(&[".", "-print"])).unwrap();
+        assert_eq!(parsed.path, ".");
+        assert_eq!(parsed.pattern, "*");
     }
 
     // --- parse_find_args: unsupported flags ---


### PR DESCRIPTION
## Problem

`rtk find . -name "*.rs" -print` warns:
```
rtk find: unknown flag '-print', ignored
```

The `-print` flag is the default action in standard `find(1)`. RTK already prints matches, so this should be a no-op.

## Root Cause

`has_native_find_flags()` didn't recognize `-print`, causing it to fall through to the "unknown flag" warning handler.

## Changes

- Add `-print` to `has_native_find_flags()` so RTK enters native parsing mode
- Add `-print` case in `parse_native_find_args()` as a no-op (RTK already prints matches)
- Add 2 unit tests for `-print` behavior

## Verification

```bash
cargo fmt --all --check && cargo clippy --all-targets && cargo test
# 2007 passed, 0 failed
```

## Notes

- Output format stays as-is (grouped by directory for token savings — intentional RTK behavior)
- Does NOT add `-print0` (which is in `UNSUPPORTED_FIND_FLAGS` — different semantics)
