### PR TITLE
docs(readme): add dedicated Claude Code setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,24 +101,50 @@ rtk gain        # Should show token savings stats
 
 ## Claude Code Setup
 
-RTK's primary integration is [Claude Code](https://claude.com/claude-code). Once the binary is installed, three steps wire it up:
+RTK's primary integration is [Claude Code](https://claude.com/claude-code). After the binary is installed (see [Installation](#installation) above), three steps wire it up.
+
+### 1. Connect it globally
+
+So Claude automatically intercepts and compresses Bash output across **all** your projects — without you editing config files by hand — run:
 
 ```bash
-# 1. Install the hook globally (all Claude Code projects)
 rtk init -g
-
-# 2. Restart Claude Code so it picks up the new PreToolUse hook
-
-# 3. Verify the hook is registered
-rtk init --show
 ```
 
-`rtk init -g` installs a `PreToolUse` hook into `~/.claude/settings.json` and a short `~/.claude/RTK.md` instruction file. After restart, Claude Code's Bash commands (e.g. `git status`) are transparently rewritten to their `rtk` equivalents (`rtk git status`) before execution — you get compact output with zero token overhead and nothing to remember.
+This installs a `PreToolUse` hook plus a short `~/.claude/RTK.md` instruction file. When it asks:
+
+```
+Patch existing ~/.claude/settings.json? [y/N]
+```
+
+type `y` and press Enter. That injects the hook into Claude Code's global config (`~/.claude/settings.json`), with a `.bak` backup written alongside it.
+
+> **Non-interactive?** Use `rtk init -g --auto-patch` (CI/CD) to skip the prompt.
+
+### 2. Restart Claude Code
+
+Start a fresh session so it picks up the new hook:
+
+```bash
+claude
+```
+
+### 3. Verify it's active
+
+Inside Claude Code, ask it to run a command, e.g. *"run git status"*. Behind the scenes the shell call is rewritten from `git status` to `rtk git status`, so the output is stripped by 60–90% before it reaches your token context — with zero token overhead and nothing for you to remember.
+
+Check live savings anytime in a separate terminal:
+
+```bash
+rtk gain          # token savings stats
+rtk init --show   # confirm the hook is registered
+```
+
+### Other init variants
 
 ```bash
 rtk init                    # Current project only (./CLAUDE.md)
 rtk init -g --hook-only     # Hook only, skip RTK.md
-rtk init -g --auto-patch    # Non-interactive (CI/CD)
 rtk init -g --uninstall     # Remove hook + RTK.md + settings.json entry
 ```
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,33 @@ rtk gain        # Should show token savings stats
 
 > **Name collision warning**: Another project named "rtk" (Rust Type Kit) exists on crates.io. If `rtk gain` fails, you have the wrong package. Use `cargo install --git` above instead.
 
+## Claude Code Setup
+
+RTK's primary integration is [Claude Code](https://claude.com/claude-code). Once the binary is installed, three steps wire it up:
+
+```bash
+# 1. Install the hook globally (all Claude Code projects)
+rtk init -g
+
+# 2. Restart Claude Code so it picks up the new PreToolUse hook
+
+# 3. Verify the hook is registered
+rtk init --show
+```
+
+`rtk init -g` installs a `PreToolUse` hook into `~/.claude/settings.json` and a short `~/.claude/RTK.md` instruction file. After restart, Claude Code's Bash commands (e.g. `git status`) are transparently rewritten to their `rtk` equivalents (`rtk git status`) before execution — you get compact output with zero token overhead and nothing to remember.
+
+```bash
+rtk init                    # Current project only (./CLAUDE.md)
+rtk init -g --hook-only     # Hook only, skip RTK.md
+rtk init -g --auto-patch    # Non-interactive (CI/CD)
+rtk init -g --uninstall     # Remove hook + RTK.md + settings.json entry
+```
+
+> **Note:** The hook runs on Bash tool calls only. Claude Code built-in tools like `Read`, `Grep`, and `Glob` bypass it, so call `rtk read`, `rtk grep`, or `rtk find` explicitly when you want RTK filtering there.
+
+For other agents (Gemini, Codex, Cursor, Windsurf, …) see [Quick Start](#quick-start) below and the [Supported AI Tools](#supported-ai-tools) table. Detailed setup lives in [INSTALL.md](INSTALL.md).
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## What

Adds a dedicated **Claude Code Setup** section to the README, placed under Installation (right after *Verify Installation*).

## Why

Claude Code is RTK's flagship integration, but the README previously only mentioned it inline in *Quick Start* (`rtk init -g`) and in the *Supported AI Tools* table. There was no single, step-by-step "here's how to wire RTK into Claude Code" section, which is the first thing most users want after installing the binary.

## Changes

- New `## Claude Code Setup` section covering the three-step flow: install hook (`rtk init -g`), restart, verify (`rtk init --show`)
- Brief explanation of what the hook does (transparent Bash rewrite, zero token overhead)
- Common `rtk init` variants (project-only, `--hook-only`, `--auto-patch`, `--uninstall`)
- Scope note: the hook only applies to Bash tool calls; `Read`/`Grep`/`Glob` bypass it
- Pointers to Quick Start, the Supported AI Tools table, and INSTALL.md for other agents and deeper detail

Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)