### PR TITLE
fix: keep filter output faithful for find, ls -R, env, and cargo

### DIFF
--- a/src/cmds/rust/cargo_cmd.rs
+++ b/src/cmds/rust/cargo_cmd.rs
@@ -35,6 +35,7 @@ pub fn run(cmd: CargoCommand, args: &[String], verbose: u8) -> Result<i32> {
 // --- Stream handlers ---
 
 struct CargoBuildHandler {
+    subcommand: String,
     compiled: usize,
     warnings: usize,
     error_count: usize,
@@ -42,8 +43,9 @@ struct CargoBuildHandler {
 }
 
 impl CargoBuildHandler {
-    fn new() -> Self {
+    fn new(subcommand: &str) -> Self {
         Self {
+            subcommand: subcommand.to_string(),
             compiled: 0,
             warnings: 0,
             error_count: 0,
@@ -95,15 +97,15 @@ impl BlockHandler for CargoBuildHandler {
 
     fn format_summary(&self, _exit_code: i32, _raw: &str) -> Option<String> {
         if self.error_count == 0 && self.warnings == 0 {
-            let mut s = format!("cargo build ({} crates compiled)", self.compiled);
+            let mut s = format!("cargo {} ({} crates compiled)", self.subcommand, self.compiled);
             if let Some(ref finished) = self.finished_line {
                 s = format!("{}\n{}", s, finished);
             }
             Some(format!("{}\n", s))
         } else {
             Some(format!(
-                "═══════════════════════════════════════\ncargo build: {} errors, {} warnings ({} crates)\n",
-                self.error_count, self.warnings, self.compiled
+                "═══════════════════════════════════════\ncargo {}: {} errors, {} warnings ({} crates)\n",
+                self.subcommand, self.error_count, self.warnings, self.compiled
             ))
         }
     }
@@ -303,7 +305,7 @@ fn run_build(args: &[String], verbose: u8) -> Result<i32> {
         "build",
         args,
         verbose,
-        Box::new(BlockStreamFilter::new(CargoBuildHandler::new())),
+        Box::new(BlockStreamFilter::new(CargoBuildHandler::new("build"))),
     )
 }
 
@@ -325,7 +327,7 @@ fn run_check(args: &[String], verbose: u8) -> Result<i32> {
         "check",
         args,
         verbose,
-        Box::new(BlockStreamFilter::new(CargoBuildHandler::new())),
+        Box::new(BlockStreamFilter::new(CargoBuildHandler::new("check"))),
     )
 }
 
@@ -759,7 +761,7 @@ fn filter_cargo_nextest(output: &str) -> String {
 }
 
 fn filter_cargo_build(output: &str) -> String {
-    let mut handler = CargoBuildHandler::new();
+    let mut handler = CargoBuildHandler::new("build");
     let mut blocks: Vec<Vec<String>> = Vec::new();
     let mut current_block: Vec<String> = Vec::new();
     let mut in_block = false;
@@ -2106,7 +2108,7 @@ error: test run failed
     #[test]
     fn test_cargo_build_stream_success() {
         let input = "   Compiling libc v0.2.153\n   Compiling cfg-if v1.0.0\n   Compiling rtk v0.5.0\n    Finished dev [unoptimized + debuginfo] target(s) in 15.23s\n";
-        let mut f = BlockStreamFilter::new(CargoBuildHandler::new());
+        let mut f = BlockStreamFilter::new(CargoBuildHandler::new("build"));
         let result = run_block_filter(&mut f, input, 0);
         assert!(result.contains("3 crates compiled"), "got: {}", result);
         assert!(result.contains("Finished"), "got: {}", result);
@@ -2124,7 +2126,7 @@ error[E0308]: mismatched types
 
 error: aborting due to 1 previous error
 "#;
-        let mut f = BlockStreamFilter::new(CargoBuildHandler::new());
+        let mut f = BlockStreamFilter::new(CargoBuildHandler::new("build"));
         let result = run_block_filter(&mut f, input, 1);
         assert!(result.contains("E0308"), "got: {}", result);
         assert!(result.contains("mismatched types"), "got: {}", result);

--- a/src/cmds/system/env_cmd.rs
+++ b/src/cmds/system/env_cmd.rs
@@ -24,6 +24,7 @@ pub fn run(filter: Option<&str>, show_all: bool, verbose: u8) -> Result<()> {
     let mut lang_vars = Vec::new();
     let mut cloud_vars = Vec::new();
     let mut tool_vars = Vec::new();
+    let mut sensitive_vars = Vec::new();
     let mut other_vars = Vec::new();
 
     for (key, value) in &vars {
@@ -59,6 +60,11 @@ pub fn run(filter: Option<&str>, show_all: bool, verbose: u8) -> Result<()> {
             cloud_vars.push(entry);
         } else if is_tool_var(key) {
             tool_vars.push(entry);
+        } else if is_sensitive {
+            // Never silently drop a secret-bearing var: surfacing it (masked)
+            // tells the reader it is set without leaking the value. Dropping it
+            // entirely would make `rtk env` imply the variable is unset.
+            sensitive_vars.push(entry);
         } else if filter.is_some() || is_interesting_var(key) {
             other_vars.push(entry);
         }
@@ -106,6 +112,13 @@ pub fn run(filter: Option<&str>, show_all: bool, verbose: u8) -> Result<()> {
         }
     }
 
+    if !sensitive_vars.is_empty() {
+        println!("\nSensitive (masked):");
+        for (k, v) in &sensitive_vars {
+            println!("  {}={}", k, v);
+        }
+    }
+
     if !other_vars.is_empty() {
         const MAX_OTHER_VARS: usize = CAP_LIST;
         println!("\nOther:");
@@ -122,6 +135,7 @@ pub fn run(filter: Option<&str>, show_all: bool, verbose: u8) -> Result<()> {
         + lang_vars.len()
         + cloud_vars.len()
         + tool_vars.len()
+        + sensitive_vars.len()
         + other_vars.len().min(20);
     if filter.is_none() {
         println!("\nTotal: {} vars (showing {} relevant)", total, shown);

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -314,13 +314,14 @@ pub fn run(
     println!("{}F {}D:", total_files, dirs_count);
     println!();
 
-    // Display with proper --max limiting (count individual files)
+    // Display with --max limiting at DIRECTORY boundaries: every fully shown
+    // directory line is complete, so a reader can trust it. A directory is shown
+    // partially only when it alone exceeds the budget, and then it is explicitly
+    // marked "(+N more here)" so it is never mistaken for a complete listing.
     let mut shown = 0;
+    let mut shown_dirs = 0;
+    let mut partial_hidden = 0;
     for dir in &dirs {
-        if shown >= max_results {
-            break;
-        }
-
         let files_in_dir = &by_dir[dir];
         let dir_display = if dir.len() > 50 {
             format!("...{}", &dir[dir.len() - 47..])
@@ -328,25 +329,44 @@ pub fn run(
             dir.clone()
         };
 
-        let remaining_budget = max_results - shown;
-        if files_in_dir.len() <= remaining_budget {
+        if shown + files_in_dir.len() <= max_results {
+            // Whole directory fits within the budget.
             println!("{}/ {}", dir_display, files_in_dir.join(" "));
             shown += files_in_dir.len();
-        } else {
-            // Partial display: show only what fits in budget
-            let partial: Vec<_> = files_in_dir
-                .iter()
-                .take(remaining_budget)
-                .cloned()
-                .collect();
-            println!("{}/ {}", dir_display, partial.join(" "));
+            shown_dirs += 1;
+        } else if shown == 0 {
+            // First directory alone exceeds the budget: show what fits, but mark
+            // it explicitly so it cannot be read as a complete directory listing.
+            let partial: Vec<_> = files_in_dir.iter().take(max_results).cloned().collect();
+            partial_hidden = files_in_dir.len() - partial.len();
+            println!(
+                "{}/ {} (+{} more here)",
+                dir_display,
+                partial.join(" "),
+                partial_hidden
+            );
             shown += partial.len();
+            shown_dirs += 1;
+            break;
+        } else {
+            // Stop before partially showing this directory (never truncate mid-dir).
             break;
         }
     }
 
-    if shown < total_files {
-        println!("+{} more", total_files - shown);
+    // Report what was not shown at directory granularity, so the reader knows
+    // whole directories are missing (use `rtk proxy find ...` for the full set).
+    let hidden_dirs = dirs_count - shown_dirs;
+    let hidden_in_unshown_dirs = total_files - shown - partial_hidden;
+    if hidden_in_unshown_dirs > 0 {
+        if hidden_dirs > 0 {
+            println!(
+                "+{} more in {} more dir(s)",
+                hidden_in_unshown_dirs, hidden_dirs
+            );
+        } else {
+            println!("+{} more", hidden_in_unshown_dirs);
+        }
     }
 
     // Extension summary

--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -238,37 +238,62 @@ fn perms_to_octal(perms: &str) -> Option<String> {
 /// Returns (entries, summary, parsed_count) so caller can suppress summary when piped.
 /// parsed_count tracks how many non-header lines were successfully parsed.
 /// If parsed_count == 0 but raw had content, caller should fall back to raw output.
-fn compact_ls(raw: &str, show_all: bool, show_long: bool) -> (String, String, usize) {
-    use std::collections::HashMap;
+/// Returns the directory path from an `ls -R` section header (e.g. `src/cmds:`
+/// -> `src/cmds`), or `None` if the line is not a section header.
+///
+/// `ls -R` introduces each directory with a `path:` line. A header is a
+/// non-empty line ending in ':' that is neither a `total` line nor a parseable
+/// `ls -la` entry, so a file literally named `foo:` is never mistaken for one.
+fn section_header(line: &str) -> Option<&str> {
+    let trimmed = line.trim_end();
+    if trimmed.starts_with("total ") || parse_ls_line(line).is_some() {
+        return None;
+    }
+    match trimmed.strip_suffix(':') {
+        Some(path) if !path.is_empty() => Some(path),
+        _ => None,
+    }
+}
 
-    let mut dirs: Vec<(String, Option<String>)> = Vec::new(); // (name, octal_perms)
-    let mut files: Vec<(String, String, Option<String>)> = Vec::new(); // (name, size, octal_perms)
-    let mut by_ext: HashMap<String, usize> = HashMap::new();
-    let mut lines_seen: usize = 0;
-    let mut parsed_count: usize = 0;
-    let mut dotdirs: usize = 0;
+/// One directory's worth of parsed entries: dirs first, then files.
+#[derive(Default)]
+struct SectionEntries {
+    dirs: Vec<(String, Option<String>)>, // (name, octal_perms)
+    files: Vec<(String, String, Option<String>)>, // (name, size, octal_perms)
+}
 
-    for line in raw.lines() {
+/// Parse a single section's `ls -la` lines, updating the shared extension
+/// histogram and counters.
+fn parse_section(
+    lines: &[&str],
+    show_all: bool,
+    show_long: bool,
+    by_ext: &mut std::collections::HashMap<String, usize>,
+    lines_seen: &mut usize,
+    parsed_count: &mut usize,
+    dotdirs: &mut usize,
+) -> SectionEntries {
+    let mut out = SectionEntries::default();
+    for line in lines {
         if line.starts_with("total ") || line.is_empty() {
             continue;
         }
-        lines_seen += 1;
+        *lines_seen += 1;
 
         let Some((file_type, perms, size, name)) = parse_ls_line(line) else {
             if is_dotdir(line) {
-                dotdirs += 1;
+                *dotdirs += 1;
             }
             continue;
         };
-        parsed_count += 1;
+        *parsed_count += 1;
 
         // Filter noise dirs unless -a
         if !show_all && NOISE_DIRS.iter().any(|noise| name == *noise) {
             continue;
         }
 
-        // Only parse perms when the user actually wants the long listing —
-        // skip the work otherwise.
+        // Only parse perms when the user actually wants the long listing.
         let octal = if show_long {
             perms_to_octal(&perms)
         } else {
@@ -276,7 +301,7 @@ fn compact_ls(raw: &str, show_all: bool, show_long: bool) -> (String, String, us
         };
 
         if file_type == 'd' {
-            dirs.push((name, octal));
+            out.dirs.push((name, octal));
         } else {
             // Regular files, symlinks, character/block devices, pipes, sockets
             let ext = if let Some(pos) = name.rfind('.') {
@@ -285,11 +310,108 @@ fn compact_ls(raw: &str, show_all: bool, show_long: bool) -> (String, String, us
                 "no ext".to_string()
             };
             *by_ext.entry(ext).or_insert(0) += 1;
-            files.push((name, human_size(size), octal));
+            out.files.push((name, human_size(size), octal));
         }
     }
+    out
+}
 
-    if dirs.is_empty() && files.is_empty() {
+/// Append a section's dirs (first) then files to the compact output.
+fn render_section(sect: &SectionEntries, entries: &mut String) {
+    for (name, octal) in &sect.dirs {
+        if let Some(octal) = octal {
+            entries.push_str(octal);
+            entries.push_str("  ");
+        }
+        entries.push_str(name);
+        entries.push_str("/\n");
+    }
+    for (name, size, octal) in &sect.files {
+        if let Some(octal) = octal {
+            entries.push_str(octal);
+            entries.push_str("  ");
+        }
+        entries.push_str(name);
+        entries.push_str("  ");
+        entries.push_str(size);
+        entries.push('\n');
+    }
+}
+
+/// Parse ls -la output into compact format.
+///
+/// Without `show_long`:
+///   name/        (dirs)
+///   name  size   (files)
+///
+/// With `show_long` (user passed `-l`):
+///   755  name/        (dirs)
+///   644  name  size   (files)
+///
+/// For `ls -R`, each directory's entries are kept under their `path:` header so
+/// the directory structure is preserved instead of being flattened into one
+/// list where files can no longer be mapped to their directory.
+///
+/// Returns (entries, summary, parsed_count) so caller can suppress summary when
+/// piped. parsed_count tracks how many non-header lines were successfully
+/// parsed. If parsed_count == 0 but raw had content, caller should fall back to
+/// raw output.
+fn compact_ls(raw: &str, show_all: bool, show_long: bool) -> (String, String, usize) {
+    use std::collections::HashMap;
+
+    // Split into `ls -R` sections. Non-recursive output is a single header-less
+    // section and renders exactly as a flat listing (unchanged behavior).
+    let mut sections: Vec<(Option<&str>, Vec<&str>)> = vec![(None, Vec::new())];
+    for line in raw.lines() {
+        if let Some(header) = section_header(line) {
+            sections.push((Some(header), Vec::new()));
+        } else {
+            sections
+                .last_mut()
+                .expect("sections always has at least one element")
+                .1
+                .push(line);
+        }
+    }
+    let recursive = sections.iter().any(|(h, _)| h.is_some());
+
+    let mut by_ext: HashMap<String, usize> = HashMap::new();
+    let mut lines_seen: usize = 0;
+    let mut parsed_count: usize = 0;
+    let mut dotdirs: usize = 0;
+    let mut total_files: usize = 0;
+    let mut total_dirs: usize = 0;
+    let mut entries = String::new();
+
+    for (header, lines) in &sections {
+        let sect = parse_section(
+            lines,
+            show_all,
+            show_long,
+            &mut by_ext,
+            &mut lines_seen,
+            &mut parsed_count,
+            &mut dotdirs,
+        );
+
+        // Emit the `path:` header (recursive listings only) so every file stays
+        // anchored to its directory.
+        if recursive {
+            if let Some(h) = header {
+                if !entries.is_empty() {
+                    entries.push('\n');
+                }
+                entries.push_str(h);
+                entries.push_str(":\n");
+            }
+        }
+
+        total_dirs += sect.dirs.len();
+        total_files += sect.files.len();
+        render_section(&sect, &mut entries);
+    }
+
+    if total_dirs == 0 && total_files == 0 {
         if lines_seen > 0 && parsed_count == 0 {
             if dotdirs == lines_seen {
                 // Only . and .. entries (empty directory)
@@ -301,32 +423,8 @@ fn compact_ls(raw: &str, show_all: bool, show_long: bool) -> (String, String, us
         return ("(empty)\n".to_string(), String::new(), 0);
     }
 
-    let mut entries = String::new();
-
-    // Dirs first, compact
-    for (name, octal) in &dirs {
-        if let Some(octal) = octal {
-            entries.push_str(octal);
-            entries.push_str("  ");
-        }
-        entries.push_str(name);
-        entries.push_str("/\n");
-    }
-
-    // Files with size
-    for (name, size, octal) in &files {
-        if let Some(octal) = octal {
-            entries.push_str(octal);
-            entries.push_str("  ");
-        }
-        entries.push_str(name);
-        entries.push_str("  ");
-        entries.push_str(size);
-        entries.push('\n');
-    }
-
     // Summary line (separate so caller can suppress when piped)
-    let mut summary = format!("\nSummary: {} files, {} dirs", files.len(), dirs.len());
+    let mut summary = format!("\nSummary: {} files, {} dirs", total_files, total_dirs);
     if !by_ext.is_empty() {
         // inline single-line summary — fewer entries to avoid wrapping.
         const MAX_EXT_SUMMARY: usize = reduced(CAP_WARNINGS, 5);
@@ -352,6 +450,53 @@ fn compact_ls(raw: &str, show_all: bool, show_long: bool) -> (String, String, us
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_compact_recursive_preserves_headers() {
+        // `ls -R` emits one `path:` header per directory. The compactor must keep
+        // each file under its directory header instead of flattening everything.
+        let input = "src:\n\
+                     total 0\n\
+                     drwxr-xr-x  2 user staff  64 Jan  1 12:00 git\n\
+                     -rw-r--r--  1 user staff 100 Jan  1 12:00 main.rs\n\
+                     \n\
+                     src/git:\n\
+                     total 0\n\
+                     -rw-r--r--  1 user staff 200 Jan  1 12:00 mod.rs\n\
+                     -rw-r--r--  1 user staff 300 Jan  1 12:00 commit.rs\n";
+        let (entries, _summary, parsed) = compact_ls(input, false, false);
+        assert!(parsed >= 3, "expected parsed entries, got {parsed}: {entries}");
+        assert!(entries.contains("src:\n"), "missing src header: {entries}");
+        assert!(
+            entries.contains("src/git:\n"),
+            "missing src/git header: {entries}"
+        );
+        // Files stay under the correct header rather than being pooled.
+        let git_pos = entries.find("src/git:").expect("src/git header present");
+        assert!(
+            entries[git_pos..].contains("mod.rs"),
+            "mod.rs not under src/git: {entries}"
+        );
+        assert!(
+            entries.find("main.rs").expect("main.rs present") < git_pos,
+            "main.rs should appear under src: before src/git: {entries}"
+        );
+    }
+
+    #[test]
+    fn test_compact_non_recursive_has_no_headers() {
+        // A normal (non -R) listing has no `path:` header and must not gain one.
+        let input = "total 8\n\
+                     drwxr-xr-x  2 user staff  64 Jan  1 12:00 src\n\
+                     -rw-r--r--  1 user staff 100 Jan  1 12:00 Cargo.toml\n";
+        let (entries, _summary, _parsed) = compact_ls(input, false, false);
+        assert!(
+            !entries.contains(':'),
+            "non-recursive output gained a header: {entries}"
+        );
+        assert!(entries.contains("src/"));
+        assert!(entries.contains("Cargo.toml"));
+    }
 
     #[test]
     fn test_compact_basic() {


### PR DESCRIPTION
## Summary
Keeps RTK's filtered output faithful to the data that was requested, in four cases (one fix per commit):

- **find**: truncate at directory boundaries instead of mid-directory, mark a partial directory explicitly (`(+N more here)`), and report the remainder per directory (`+N more in M more dir(s)`) so whole missing directories stay visible.
- **ls -R**: parse and render per `path:` section so directory headers are preserved instead of flattened; non-recursive output is unchanged. Adds tests for both cases.
- **env**: surface uncategorized secret-bearing variables in a `Sensitive (masked)` section instead of dropping them entirely (values stay masked, so nothing leaks).
- **cargo**: label the summary with the actual subcommand, so `rtk cargo check` no longer reports `cargo build`.

Closes #2271

## Test plan
- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test` (all green)
- [x] Manual testing: `rtk <command>` output inspected before/after for find, ls -R, env, and cargo check
