### PR TITLE
fix(gh): passthrough run view job output

### DIFF
--- a/src/cmds/git/gh_cmd.rs
+++ b/src/cmds/git/gh_cmd.rs
@@ -770,12 +770,12 @@ fn format_run_list(json: &Value, ultra_compact: bool) -> String {
 }
 
 /// Check if run view args should bypass filtering and pass through directly.
-/// Flags like --log-failed, --log, and --json produce output that the filter
-/// would incorrectly strip.
+/// Flags like --job, --log-failed, --log, and --json produce output that the
+/// workflow-run summary filter would incorrectly strip or reshape.
 fn should_passthrough_run_view(extra_args: &[String]) -> bool {
     extra_args
         .iter()
-        .any(|a| a == "--log-failed" || a == "--log" || a == "--json")
+        .any(|a| a == "--job" || a == "--log-failed" || a == "--log" || a == "--json")
 }
 
 fn view_run(args: &[String], _verbose: u8) -> Result<i32> {
@@ -1172,6 +1172,14 @@ mod tests {
     }
 
     #[test]
+    fn test_run_view_passthrough_job() {
+        assert!(should_passthrough_run_view(&[
+            "--job".into(),
+            "67890".into()
+        ]));
+    }
+
+    #[test]
     fn test_run_view_no_passthrough_empty() {
         assert!(!should_passthrough_run_view(&[]));
     }
@@ -1212,6 +1220,16 @@ mod tests {
         let (id, extra) = extract_identifier_and_extra_args(&args).unwrap();
         assert_eq!(id, "12345");
         assert_eq!(extra, vec!["--job", "67890"]);
+    }
+
+    #[test]
+    fn test_parse_optional_identifier_with_job_only() {
+        // gh run view --job 67890
+        let args: Vec<String> = vec!["--job".into(), "67890".into()];
+        let (id, extra) = parse_optional_identifier(&args);
+        assert_eq!(id, None);
+        assert_eq!(extra, vec!["--job", "67890"]);
+        assert!(should_passthrough_run_view(&extra));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- pass `gh run view --job <id>` through to `gh` instead of the workflow-run summary filter
- keep existing passthrough behavior for `--log`, `--log-failed`, and `--json`
- add regression coverage for the job-only argument shape from #1568

## Why

`gh run view --job <id>` does not have a positional run id. It produces job-level output that should not be reshaped by the run summary formatter, and recent reports on #1568 show the job-only path still needs explicit coverage.

Fixes #1568.

## Checks

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo test run_view`
- `cargo test test_parse_optional_identifier_with_job_only`
- `cargo test --all` (2007 passed, 0 failed, 7 ignored)
- `cargo clippy --all-targets`