### PR TITLE
feat(hooks): add Whale agent support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ claudedocs
 
 # Vitals provenance data
 .vitals/
+.omx/
 .worktrees/
 
 # icm 

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -89,7 +89,7 @@ This data directly drives our roadmap. For example, if telemetry shows that 40% 
 
 | Field | Example | Purpose |
 |-------|---------|---------|
-| `hook_type` | `claude` | Which AI agent hook is installed (claude/gemini/codex/cursor/none) |
+| `hook_type` | `claude` | Which AI agent hook is installed (claude/gemini/codex/cursor/copilot/whale/none) |
 | `custom_toml_filters` | `3` | Number of user-created TOML filter files — DSL adoption |
 
 ### Configuration (user maturity)

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -37,6 +37,7 @@ Agent runs "cargo test"
 | OpenClaw | TypeScript plugin (`before_tool_call`) | Yes |
 | Pi | TypeScript extension (`tool_call` event) | Yes |
 | Hermes | Python plugin (`terminal` command mutation) | Yes |
+| Whale | Shell hook (`PreToolUse`) | Yes |
 | Cline / Roo Code | Rules file (prompt-level) | N/A |
 | Windsurf | Rules file (prompt-level) | N/A |
 | Codex CLI | AGENTS.md instructions | N/A |
@@ -119,6 +120,27 @@ rtk init --uninstall --agent pi --global
 
 Removes only the installed Pi extension file.
 
+### Whale
+
+```bash
+# Project-local (default)
+rtk init --agent whale
+
+# Global — all projects, respects $WHALE_HOME
+rtk init --agent whale --global
+```
+
+Creates or updates `.whale/config.toml` (local) or `~/.whale/config.toml` / `$WHALE_HOME/config.toml` (global) with a `[[hooks.PreToolUse]]` entry for `shell_run`. The hook calls `rtk hook whale` and returns Whale's `updated_input` format for transparent command rewrite.
+
+Uninstall:
+
+```bash
+rtk init --uninstall --agent whale
+rtk init --uninstall --agent whale --global
+```
+
+Removes only RTK's managed Whale hook block.
+
 ### OpenClaw
 
 ```bash
@@ -200,7 +222,7 @@ For full hook support on Windows, use [WSL](https://learn.microsoft.com/en-us/wi
 
 ## Graceful degradation
 
-Hooks never block command execution. If RTK is missing, the hook exits cleanly and the raw command runs unchanged:
+Hooks never block command execution because of hook failures. If RTK is missing, the hook exits cleanly and the raw command runs unchanged. Commands may still be blocked when your RTK permission rules explicitly deny them:
 
 - RTK binary not found: warning to stderr, exit 0
 - Invalid JSON input: pass through unchanged

--- a/docs/guide/resources/telemetry.md
+++ b/docs/guide/resources/telemetry.md
@@ -94,7 +94,7 @@ This data directly drives our roadmap. For example, if telemetry shows that 40% 
 
 | Field | Example | Purpose |
 |-------|---------|---------|
-| `hook_type` | `claude` | Which AI agent hook is installed (claude/gemini/codex/cursor/none) |
+| `hook_type` | `claude` | Which AI agent hook is installed (claude/gemini/codex/cursor/copilot/whale/none) |
 | `custom_toml_filters` | `3` | Number of user-created TOML filter files — DSL adoption |
 
 ### Configuration (user maturity)

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -52,6 +52,7 @@ Each agent subdirectory has its own README with hook-specific details:
 | GitHub Copilot CLI | Rust binary (`rtk hook copilot`) | Deny-with-suggestion | No (agent retries) |
 | Cursor | Shell hook (`preToolUse`) | Transparent rewrite | Yes (`updated_input`) |
 | Gemini CLI | Rust binary (`rtk hook gemini`) | Transparent rewrite | Yes (`hookSpecificOutput`) |
+| Whale | Rust binary (`rtk hook whale`) | Transparent rewrite | Yes (`updated_input`) |
 | Cline / Roo Code | Custom instructions (rules file) | Prompt-level guidance | N/A |
 | Windsurf | Custom instructions (rules file) | Prompt-level guidance | N/A |
 | Codex CLI | AGENTS.md / instructions | Prompt-level guidance | N/A |
@@ -213,7 +214,7 @@ Example: `cargo fmt --all && cargo test` becomes `rtk cargo fmt --all && rtk car
 
 ## Exit Code Contract
 
-Hooks must **never block command execution**. All error paths (missing binary, bad JSON, rewrite failure) must exit 0 so the agent's command runs unmodified. A hook that exits non-zero prevents the user's command from executing.
+Hooks must **never block command execution because of hook failures**. All error paths (missing binary, bad JSON, rewrite failure) must exit 0 so the agent's command runs unmodified. A hook may still block when the user's RTK permission rules explicitly deny the command.
 
 When there is no rewrite to apply, the hook must produce no output (or `{}` for Cursor, which requires JSON on all paths).
 
@@ -223,7 +224,7 @@ When there is no rewrite to apply, the hook must produce no output (or `{}` for 
 
 ## Graceful Degradation
 
-Hooks are **non-blocking** -- they never prevent a command from executing:
+Hooks are **fail-open** -- they never prevent a command from executing because RTK itself failed:
 
 - jq not installed: warning to stderr, exit 0 (command runs raw)
 - rtk binary not found: warning to stderr, exit 0

--- a/src/core/telemetry.rs
+++ b/src/core/telemetry.rs
@@ -6,7 +6,7 @@ use crate::core::tracking;
 use sha2::{Digest, Sha256};
 use std::fmt::Write as FmtWrite;
 use std::io::Write as IoWrite;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 static CACHED_SALT: OnceLock<String> = OnceLock::new();
@@ -352,7 +352,17 @@ fn detect_hook_type() -> String {
         Some(h) => h,
         None => return "unknown".to_string(),
     };
+    let cwd = std::env::current_dir().ok();
+    let whale_home = whale_home_from_env();
 
+    detect_hook_type_from_paths(&home, cwd.as_deref(), whale_home.as_deref())
+}
+
+fn detect_hook_type_from_paths(
+    home: &Path,
+    cwd: Option<&Path>,
+    whale_home: Option<&Path>,
+) -> String {
     // Check in order of popularity
     let checks = [
         (home.join(".claude/hooks/rtk-rewrite.sh"), "claude"),
@@ -368,17 +378,49 @@ fn detect_hook_type() -> String {
         }
     }
 
+    match whale_home {
+        Some(whale_home) => {
+            if whale_config_has_rtk_hook(&whale_home.join("config.toml")) {
+                return "whale".to_string();
+            }
+        }
+        None => {
+            if whale_config_has_rtk_hook(&home.join(".whale/config.toml"))
+                || whale_config_has_rtk_hook(&home.join(".whale/config.local.toml"))
+            {
+                return "whale".to_string();
+            }
+        }
+    }
+
     // Check project-level hooks (Claude script + project-scoped Copilot config)
-    if let Ok(cwd) = std::env::current_dir() {
+    if let Some(cwd) = cwd {
         if cwd.join(".claude/hooks/rtk-rewrite.sh").exists() {
             return "claude".to_string();
         }
         if cwd.join(".github/hooks/rtk-rewrite.json").exists() {
             return "copilot".to_string();
         }
+        if whale_config_has_rtk_hook(&cwd.join(".whale/config.toml"))
+            || whale_config_has_rtk_hook(&cwd.join(".whale/config.local.toml"))
+        {
+            return "whale".to_string();
+        }
     }
 
     "none".to_string()
+}
+
+fn whale_home_from_env() -> Option<PathBuf> {
+    let value = std::env::var_os("WHALE_HOME")?;
+    let value = value.to_string_lossy().trim().to_string();
+    (!value.is_empty()).then(|| PathBuf::from(value))
+}
+
+fn whale_config_has_rtk_hook(path: &std::path::Path) -> bool {
+    std::fs::read_to_string(path)
+        .map(|content| content.contains("rtk hook whale"))
+        .unwrap_or(false)
 }
 
 /// Count user-defined TOML filter files (project-local + global).
@@ -574,7 +616,7 @@ mod tests {
         assert!(stats.low_savings_commands.len() <= 5);
         assert!((0.0..=100.0).contains(&stats.avg_savings_per_command));
         assert!(
-            ["claude", "gemini", "codex", "cursor", "copilot", "none", "unknown"]
+            ["claude", "gemini", "codex", "cursor", "copilot", "whale", "none", "unknown",]
                 .iter()
                 .any(|&h| stats.hook_type.starts_with(h)),
             "Unexpected hook type: {}",
@@ -586,10 +628,68 @@ mod tests {
     fn test_detect_hook_type_returns_known() {
         let ht = detect_hook_type();
         assert!(
-            ["claude", "gemini", "codex", "cursor", "copilot", "none", "unknown"]
+            ["claude", "gemini", "codex", "cursor", "copilot", "whale", "none", "unknown",]
                 .contains(&ht.as_str()),
             "Unexpected hook type: {}",
             ht
+        );
+    }
+
+    #[test]
+    fn test_whale_config_detects_local_hook_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join("config.local.toml");
+        std::fs::write(
+            &config,
+            "[[hooks.PreToolUse]]\nmatch = \"shell_run\"\ncommand = \"rtk hook whale\"\n",
+        )
+        .unwrap();
+
+        assert!(whale_config_has_rtk_hook(&config));
+    }
+
+    #[test]
+    fn test_whale_home_overrides_default_home_config() {
+        let default_home = tempfile::tempdir().unwrap();
+        let default_whale_dir = default_home.path().join(".whale");
+        std::fs::create_dir_all(&default_whale_dir).unwrap();
+        std::fs::write(
+            default_whale_dir.join("config.toml"),
+            "[[hooks.PreToolUse]]\nmatch = \"shell_run\"\ncommand = \"rtk hook whale\"\n",
+        )
+        .unwrap();
+
+        let whale_home = tempfile::tempdir().unwrap();
+        std::fs::write(whale_home.path().join("config.toml"), "# no RTK hook\n").unwrap();
+
+        assert_eq!(
+            detect_hook_type_from_paths(default_home.path(), None, Some(whale_home.path())),
+            "none"
+        );
+    }
+
+    #[test]
+    fn test_whale_project_config_still_detected_with_whale_home() {
+        let default_home = tempfile::tempdir().unwrap();
+        let whale_home = tempfile::tempdir().unwrap();
+        std::fs::write(whale_home.path().join("config.toml"), "# no RTK hook\n").unwrap();
+
+        let project = tempfile::tempdir().unwrap();
+        let project_whale_dir = project.path().join(".whale");
+        std::fs::create_dir_all(&project_whale_dir).unwrap();
+        std::fs::write(
+            project_whale_dir.join("config.local.toml"),
+            "[[hooks.PreToolUse]]\nmatch = \"shell_run\"\ncommand = \"rtk hook whale\"\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            detect_hook_type_from_paths(
+                default_home.path(),
+                Some(project.path()),
+                Some(whale_home.path())
+            ),
+            "whale"
         );
     }
 

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -39,3 +39,7 @@ pub const HERMES_PLUGINS_SUBDIR: &str = "plugins";
 pub const HERMES_PLUGIN_NAME: &str = "rtk-rewrite";
 pub const HERMES_PLUGIN_INIT_FILE: &str = "__init__.py";
 pub const HERMES_PLUGIN_MANIFEST_FILE: &str = "plugin.yaml";
+
+pub const WHALE_DIR: &str = ".whale";
+pub const WHALE_HOME_ENV: &str = "WHALE_HOME";
+pub const WHALE_CONFIG_FILE: &str = "config.toml";

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -313,6 +313,10 @@ enum PayloadAction {
         rewritten: String,
         output: Value,
     },
+    Block {
+        cmd: String,
+        output: Value,
+    },
     Skip {
         reason: &'static str,
         cmd: String,
@@ -402,6 +406,10 @@ pub fn run_claude() -> Result<()> {
             audit_log("rewrite", &cmd, &rewritten);
             let _ = writeln!(io::stdout(), "{output}");
         }
+        PayloadAction::Block { cmd, output } => {
+            audit_log("deny", &cmd, "");
+            let _ = writeln!(io::stdout(), "{output}");
+        }
         PayloadAction::Skip { reason, cmd } => {
             audit_log(reason, &cmd, "");
         }
@@ -416,6 +424,117 @@ fn run_claude_inner(input: &str) -> Option<String> {
     let v: Value = serde_json::from_str(input).ok()?;
     match process_claude_payload(&v) {
         PayloadAction::Rewrite { output, .. } => Some(output.to_string()),
+        _ => None,
+    }
+}
+
+// ── Whale native hook ─────────────────────────────────────────
+
+fn process_whale_payload(v: &Value) -> PayloadAction {
+    process_whale_payload_for_verdict(v, permissions::check_command)
+}
+
+fn process_whale_payload_for_verdict(
+    v: &Value,
+    verdict_for_command: impl FnOnce(&str) -> PermissionVerdict,
+) -> PayloadAction {
+    let tool_name = v.get("tool_name").and_then(|t| t.as_str()).unwrap_or("");
+    if tool_name != "shell_run" {
+        return PayloadAction::Ignore;
+    }
+
+    let cmd = match v
+        .pointer("/tool_args/command")
+        .or_else(|| v.pointer("/tool_input/command"))
+        .and_then(|c| c.as_str())
+        .filter(|c| !c.is_empty())
+    {
+        Some(c) => c,
+        None => return PayloadAction::Ignore,
+    };
+
+    if verdict_for_command(cmd) == PermissionVerdict::Deny {
+        return PayloadAction::Block {
+            cmd: cmd.to_string(),
+            output: json!({
+                "decision": "block",
+                "reason": "Blocked by RTK permission rule"
+            }),
+        };
+    }
+
+    let rewritten = match get_rewritten(cmd) {
+        Some(r) => r,
+        None => {
+            return PayloadAction::Skip {
+                reason: "skip:no_match",
+                cmd: cmd.to_string(),
+            }
+        }
+    };
+
+    let mut updated_input = v.get("tool_args").cloned().unwrap_or_else(|| json!({}));
+    if let Some(obj) = updated_input.as_object_mut() {
+        obj.insert("command".into(), Value::String(rewritten.clone()));
+    }
+
+    PayloadAction::Rewrite {
+        cmd: cmd.to_string(),
+        rewritten,
+        output: json!({
+            "decision": "pass",
+            "reason": "RTK auto-rewrite",
+            "updated_input": updated_input
+        }),
+    }
+}
+
+/// Run the Whale PreToolUse hook natively.
+pub fn run_whale() -> Result<()> {
+    let input = read_stdin_limited()?;
+
+    let input = strip_leading_bom(&input).trim();
+    if input.is_empty() {
+        return Ok(());
+    }
+
+    let v: Value = match serde_json::from_str(input) {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = writeln!(io::stderr(), "[rtk hook] Failed to parse JSON input: {e}");
+            return Ok(());
+        }
+    };
+
+    match process_whale_payload(&v) {
+        PayloadAction::Rewrite {
+            cmd,
+            rewritten,
+            output,
+        } => {
+            audit_log("rewrite", &cmd, &rewritten);
+            let _ = writeln!(io::stdout(), "{output}");
+        }
+        PayloadAction::Block { cmd, output } => {
+            audit_log("deny", &cmd, "");
+            let _ = writeln!(io::stdout(), "{output}");
+        }
+        PayloadAction::Skip { reason, cmd } => {
+            audit_log(reason, &cmd, "");
+        }
+        PayloadAction::Ignore => {}
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+fn run_whale_inner(input: &str) -> Option<String> {
+    let input = strip_leading_bom(input);
+    let v: Value = serde_json::from_str(input).ok()?;
+    match process_whale_payload(&v) {
+        PayloadAction::Rewrite { output, .. } => Some(output.to_string()),
+        PayloadAction::Block { output, .. } => Some(output.to_string()),
         _ => None,
     }
 }
@@ -913,6 +1032,67 @@ mod tests {
     fn test_claude_no_tool_input_passthrough() {
         let input = json!({ "tool_name": "Bash" }).to_string();
         assert!(run_claude_inner(&input).is_none());
+    }
+
+    // --- Whale handler ---
+
+    fn whale_input(tool: &str, cmd: &str) -> String {
+        json!({
+            "event": "PreToolUse",
+            "tool_name": tool,
+            "tool_args": {
+                "command": cmd,
+                "cwd": "/tmp/project"
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn test_whale_rewrite_git_status() {
+        let result = run_whale_inner(&whale_input("shell_run", "git status")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(v["decision"], "pass");
+        assert_eq!(v["updated_input"]["command"], "rtk git status");
+        assert_eq!(v["updated_input"]["cwd"], "/tmp/project");
+        assert!(v.get("hookSpecificOutput").is_none());
+    }
+
+    #[test]
+    fn test_whale_passthrough_non_shell_tool() {
+        assert!(run_whale_inner(&whale_input("file_read", "git status")).is_none());
+    }
+
+    #[test]
+    fn test_whale_denied_command_blocks() {
+        let input = whale_input("shell_run", "git status");
+        let v: Value = serde_json::from_str(&input).unwrap();
+        let action = process_whale_payload_for_verdict(&v, |_| PermissionVerdict::Deny);
+
+        let PayloadAction::Block { output, .. } = action else {
+            panic!("expected Whale deny to block");
+        };
+        assert_eq!(output["decision"], "block");
+        assert_eq!(output["reason"], "Blocked by RTK permission rule");
+        assert!(output.get("updated_input").is_none());
+    }
+
+    #[test]
+    fn test_whale_passthrough_already_rtk() {
+        assert!(run_whale_inner(&whale_input("shell_run", "rtk git status")).is_none());
+    }
+
+    #[test]
+    fn test_whale_passthrough_heredoc() {
+        assert!(run_whale_inner(&whale_input("shell_run", "cat <<EOF\nhello\nEOF")).is_none());
+    }
+
+    #[test]
+    fn test_whale_strips_utf8_bom() {
+        let payload = whale_input("shell_run", "cargo test");
+        let result = run_whale_inner(&format!("\u{feff}{payload}")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(v["updated_input"]["command"], "rtk cargo test");
     }
 
     // --- Cursor handler ---

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -17,7 +17,8 @@ use super::constants::{
     GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_INIT_FILE,
     HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON, HOOKS_SUBDIR,
     PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR, PI_PLUGIN_FILE,
-    PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
+    PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON, WHALE_CONFIG_FILE, WHALE_DIR,
+    WHALE_HOME_ENV,
 };
 use super::integrity;
 
@@ -70,6 +71,8 @@ const GEMINI_MD: &str = "GEMINI.md";
 
 const RTK_BLOCK_START: &str = "<!-- rtk-instructions";
 const RTK_BLOCK_END: &str = "<!-- /rtk-instructions -->";
+const WHALE_RTK_BLOCK_START: &str = "# rtk-whale-hook-start";
+const WHALE_RTK_BLOCK_END: &str = "# rtk-whale-hook-end";
 
 /// Control flow for settings.json patching
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -2906,6 +2909,180 @@ fn print_pi_result(plugin_path: &Path, installed: bool) {
     println!();
     println!("Pi will load the extension automatically on next start.");
     println!("Verify: pi -e {} --no-session", plugin_path.display());
+}
+
+fn resolve_whale_home() -> Result<PathBuf> {
+    if let Some(raw) = std::env::var_os(WHALE_HOME_ENV) {
+        let trimmed = raw.to_string_lossy().trim().to_string();
+        if !trimmed.is_empty() {
+            return Ok(PathBuf::from(trimmed));
+        }
+    }
+
+    dirs::home_dir()
+        .map(|home| home.join(WHALE_DIR))
+        .context("Could not determine home directory for Whale config")
+}
+
+fn whale_config_path(global: bool) -> Result<PathBuf> {
+    if global {
+        Ok(resolve_whale_home()?.join(WHALE_CONFIG_FILE))
+    } else {
+        Ok(PathBuf::from(WHALE_DIR).join(WHALE_CONFIG_FILE))
+    }
+}
+
+fn whale_hook_block() -> &'static str {
+    r#"# rtk-whale-hook-start
+[[hooks.PreToolUse]]
+match = "shell_run"
+command = "rtk hook whale"
+timeout = 30
+# rtk-whale-hook-end
+"#
+}
+
+fn patch_whale_config(existing: &str) -> String {
+    let without_managed = remove_whale_rtk_block(existing);
+    if without_managed.contains("rtk hook whale") {
+        return without_managed;
+    }
+
+    let mut patched = without_managed.trim_end().to_string();
+    if !patched.is_empty() {
+        patched.push_str("\n\n");
+    }
+    patched.push_str(whale_hook_block());
+    patched
+}
+
+fn remove_whale_rtk_block(existing: &str) -> String {
+    let Some(start) = existing.find(WHALE_RTK_BLOCK_START) else {
+        return existing.to_string();
+    };
+    let Some(end_rel) = existing[start..].find(WHALE_RTK_BLOCK_END) else {
+        return existing.to_string();
+    };
+
+    let mut end = start + end_rel + WHALE_RTK_BLOCK_END.len();
+    if existing[end..].starts_with("\r\n") {
+        end += 2;
+    } else if existing[end..].starts_with('\n') {
+        end += 1;
+    }
+
+    let mut cleaned = String::with_capacity(existing.len() - (end - start));
+    cleaned.push_str(&existing[..start]);
+    cleaned.push_str(&existing[end..]);
+    while cleaned.contains("\n\n\n") {
+        cleaned = cleaned.replace("\n\n\n", "\n\n");
+    }
+    cleaned.trim_end().to_string()
+}
+
+pub fn run_whale_mode(global: bool, ctx: InitContext) -> Result<()> {
+    let InitContext { verbose, dry_run } = ctx;
+    let config_path = whale_config_path(global)?;
+    let existing = if config_path.exists() {
+        fs::read_to_string(&config_path)
+            .with_context(|| format!("Failed to read Whale config: {}", config_path.display()))?
+    } else {
+        String::new()
+    };
+    let patched = patch_whale_config(&existing);
+
+    if patched == existing {
+        if dry_run {
+            println!(
+                "[dry-run] Whale config already contains RTK hook: {}",
+                config_path.display()
+            );
+            print_dry_run_footer();
+        } else {
+            println!("RTK Whale hook already configured:");
+            println!("  Config: {}", config_path.display());
+        }
+        return Ok(());
+    }
+
+    if dry_run {
+        println!(
+            "[dry-run] would update Whale config: {}",
+            config_path.display()
+        );
+        if verbose > 0 {
+            println!("[dry-run] content:\n{}", patched);
+        }
+        print_dry_run_footer();
+        return Ok(());
+    }
+
+    if let Some(parent) = config_path.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "Failed to create Whale config directory: {}",
+                parent.display()
+            )
+        })?;
+    }
+    atomic_write(&config_path, &patched)
+        .with_context(|| format!("Failed to write Whale config: {}", config_path.display()))?;
+
+    println!("RTK configured for Whale:");
+    println!("  Config: {}", config_path.display());
+    println!("  Hook: rtk hook whale");
+    println!();
+    println!("Restart Whale. Project hooks may need review; run `/hooks trust all` if prompted.");
+    Ok(())
+}
+
+pub fn uninstall_whale(global: bool, ctx: InitContext) -> Result<()> {
+    let InitContext { verbose, dry_run } = ctx;
+    let config_path = whale_config_path(global)?;
+    if !config_path.exists() {
+        println!("RTK Whale hook was not installed (nothing to remove)");
+        if dry_run {
+            print_dry_run_footer();
+        }
+        return Ok(());
+    }
+
+    let existing = fs::read_to_string(&config_path)
+        .with_context(|| format!("Failed to read Whale config: {}", config_path.display()))?;
+    let patched = remove_whale_rtk_block(&existing);
+    if patched == existing {
+        println!("RTK Whale managed hook block was not found (nothing to remove)");
+        if dry_run {
+            print_dry_run_footer();
+        }
+        return Ok(());
+    }
+
+    if dry_run {
+        println!(
+            "[dry-run] would update Whale config: {}",
+            config_path.display()
+        );
+        if verbose > 0 {
+            println!("[dry-run] content:\n{}", patched);
+        }
+        print_dry_run_footer();
+        return Ok(());
+    }
+
+    if patched.trim().is_empty() {
+        // nosemgrep: filesystem-deletion -- uninstall removes only an empty RTK-managed Whale config file.
+        fs::remove_file(&config_path)
+            .with_context(|| format!("Failed to remove Whale config: {}", config_path.display()))?;
+        println!("RTK uninstalled (Whale):");
+        println!("  - Removed empty config: {}", config_path.display());
+    } else {
+        atomic_write(&config_path, &patched)
+            .with_context(|| format!("Failed to write Whale config: {}", config_path.display()))?;
+        println!("RTK uninstalled (Whale):");
+        println!("  - Config: removed RTK hook block");
+    }
+    Ok(())
 }
 
 /// Return OpenCode plugin path: ~/.config/opencode/plugins/rtk.ts
@@ -6386,6 +6563,46 @@ mod tests {
             plugin.exists(),
             "dry-run uninstall must not remove the local Pi extension"
         );
+    }
+
+    #[test]
+    fn test_patch_whale_config_adds_managed_hook_block() {
+        let patched = patch_whale_config("model = \"deepseek-v4\"\n");
+        assert!(patched.contains(WHALE_RTK_BLOCK_START));
+        assert!(patched.contains("[[hooks.PreToolUse]]"));
+        assert!(patched.contains("match = \"shell_run\""));
+        assert!(patched.contains("command = \"rtk hook whale\""));
+        assert!(patched.starts_with("model = \"deepseek-v4\""));
+    }
+
+    #[test]
+    fn test_patch_whale_config_is_idempotent() {
+        let once = patch_whale_config("");
+        let twice = patch_whale_config(&once);
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn test_patch_whale_config_does_not_duplicate_manual_hook() {
+        let existing =
+            "[[hooks.PreToolUse]]\nmatch = \"shell_run\"\ncommand = \"rtk hook whale\"\n";
+        assert_eq!(patch_whale_config(existing), existing);
+    }
+
+    #[test]
+    fn test_remove_whale_rtk_block_preserves_user_config() {
+        let existing = format!(
+            "model = \"deepseek-v4\"\n\n{}[other]\nvalue = 1\n",
+            whale_hook_block()
+        );
+        let cleaned = remove_whale_rtk_block(&existing);
+        assert_eq!(cleaned, "model = \"deepseek-v4\"\n\n[other]\nvalue = 1");
+    }
+
+    #[test]
+    fn test_remove_whale_rtk_block_ignores_unmanaged_config() {
+        let existing = "[[hooks.PreToolUse]]\ncommand = \"echo ok\"\n";
+        assert_eq!(remove_whale_rtk_block(existing), existing);
     }
 
     // ─── Copilot tests ───────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,8 @@ pub enum AgentTarget {
     Pi,
     /// Hermes CLI
     Hermes,
+    /// Whale coding agent
+    Whale,
 }
 
 #[derive(Parser)]
@@ -775,6 +777,8 @@ enum HookCommands {
     Gemini,
     /// Process Copilot preToolUse hook (VS Code + Copilot CLI, reads JSON from stdin)
     Copilot,
+    /// Process Whale PreToolUse hook (reads JSON from stdin)
+    Whale,
     /// Check how a command would be rewritten by the hook engine (dry-run)
     Check {
         /// Target agent
@@ -1838,6 +1842,8 @@ fn run_cli() -> Result<i32> {
                 } else {
                     hooks::init::uninstall_copilot(ctx)?;
                 }
+            } else if uninstall && agent == Some(AgentTarget::Whale) {
+                hooks::init::uninstall_whale(global, ctx)?;
             } else if uninstall {
                 uninstall_init_dispatch(
                     agent,
@@ -1879,6 +1885,8 @@ fn run_cli() -> Result<i32> {
                 hooks::init::run_antigravity_mode(ctx)?;
             } else if agent == Some(AgentTarget::Hermes) {
                 hooks::init::run_hermes_mode(ctx)?;
+            } else if agent == Some(AgentTarget::Whale) {
+                hooks::init::run_whale_mode(global, ctx)?;
             } else {
                 let install_opencode = opencode;
                 let install_claude = !opencode;
@@ -2210,6 +2218,10 @@ fn run_cli() -> Result<i32> {
             }
             HookCommands::Copilot => {
                 hooks::hook_cmd::run_copilot()?;
+                0
+            }
+            HookCommands::Whale => {
+                hooks::hook_cmd::run_whale()?;
                 0
             }
             HookCommands::Check { agent: _, command } => {
@@ -2684,6 +2696,17 @@ mod tests {
     }
 
     #[test]
+    fn test_try_parse_init_agent_whale() {
+        let cli = Cli::try_parse_from(["rtk", "init", "--agent", "whale"]).unwrap();
+        match cli.command {
+            Commands::Init { agent, .. } => {
+                assert_eq!(agent, Some(AgentTarget::Whale));
+            }
+            _ => panic!("Expected Init command"),
+        }
+    }
+
+    #[test]
     fn test_try_parse_kubectl_get_alias() {
         let cli = Cli::try_parse_from(["rtk", "kubectl", "get", "pods", "-n", "default"]).unwrap();
 
@@ -2703,6 +2726,20 @@ mod tests {
                 agent, uninstall, ..
             } => {
                 assert_eq!(agent, Some(AgentTarget::Hermes));
+                assert!(uninstall);
+            }
+            _ => panic!("Expected Init command"),
+        }
+    }
+
+    #[test]
+    fn test_try_parse_init_agent_whale_uninstall() {
+        let cli = Cli::try_parse_from(["rtk", "init", "--agent", "whale", "--uninstall"]).unwrap();
+        match cli.command {
+            Commands::Init {
+                agent, uninstall, ..
+            } => {
+                assert_eq!(agent, Some(AgentTarget::Whale));
                 assert!(uninstall);
             }
             _ => panic!("Expected Init command"),


### PR DESCRIPTION
## Summary

- Add Whale as a supported RTK agent target for `rtk init --agent whale` and `rtk hook whale`.
- Install and uninstall a managed Whale `PreToolUse` hook in project config or `$WHALE_HOME` / `~/.whale` for global config.
- Track Whale hook installation in telemetry and document the new integration.

Closes #2207.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test`
- [x] `bash scripts/check-test-presence.sh origin/develop`
- [x] Manual testing: installed/uninstalled Whale hook in temp project and temp `WHALE_HOME`
- [x] Manual testing: verified `rtk hook whale` rewrites `shell_run` payloads with Whale `updated_input`
- [x] Manual testing: verified real Whale `exec` session runs rewritten `rtk git status` command through the hook


