### PR TITLE
docs: clarify PowerShell cmdlet usage for Codex

### DIFF
--- a/hooks/codex/rtk-awareness.md
+++ b/hooks/codex/rtk-awareness.md
@@ -15,6 +15,20 @@ rtk npm run build
 rtk pytest -q
 ```
 
+## PowerShell cmdlets
+
+PowerShell cmdlets (e.g., `Get-Content`, `Select-String`) are not standalone executables on PATH. Run them through `rtk powershell`:
+
+```powershell
+rtk powershell -NoProfile -Command "Get-Content -LiteralPath 'file.txt'"
+```
+
+Do NOT call cmdlets directly:
+
+```
+rtk Get-Content file.txt   # ✗ fails
+```
+
 ## Meta Commands
 
 ```bash


### PR DESCRIPTION
Adds a PowerShell cmdlets section to the Codex RTK awareness template explaining that PowerShell cmdlets must be run through 
rtk powershell -NoProfile -Command ... rather than directly.

Problem: Get-Content, Select-String, and other PowerShell cmdlets are not standalone PATH executables. Calling 
rtk Get-Content file.txt fails on Windows because there is no Get-Content.exe on PATH.

Change: Added a short section after the basic examples showing correct usage (
rtk powershell ...) and incorrect usage to avoid.

Verification: The template change is compiled into rtk init --codex via include_str!