### PR TITLE
Add whitelist mode for command filtering (#2231)

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,7 +1,7 @@
 //! Reads user settings from config.toml.
 
 use super::constants::{CONFIG_TOML, DEFAULT_HISTORY_DAYS, RTK_DATA_DIR};
-use anyhow::Result;
+use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -27,8 +27,22 @@ pub struct Config {
 pub struct HooksConfig {
     /// Commands to exclude from auto-rewrite (e.g. ["curl", "playwright"]).
     /// Survives `rtk init -g` re-runs since config.toml is user-owned.
+    /// Mutually exclusive with `include_commands`.
     #[serde(default)]
     pub exclude_commands: Vec<String>,
+
+    /// Whitelist mode: only rewrite commands listed here.
+    /// When set, every command **not** in this list passes through unchanged.
+    /// Mutually exclusive with `exclude_commands` — setting both is a
+    /// configuration error (RTK will refuse to start the hook).
+    ///
+    /// Example:
+    /// ```toml
+    /// [hooks]
+    /// include_commands = ["git status", "cargo build"]
+    /// ```
+    #[serde(default)]
+    pub include_commands: Vec<String>,
 
     /// Wrapper prefixes that should be transparently stripped before routing
     /// to a filter, then re-prepended on the rewrite. For example, with
@@ -51,6 +65,20 @@ pub struct HooksConfig {
     /// not anything else.
     #[serde(default)]
     pub transparent_prefixes: Vec<String>,
+}
+
+impl HooksConfig {
+    /// Validate that `include_commands` and `exclude_commands` are not both set.
+    /// Returns an error when both contain at least one entry.
+    pub fn validate(&self) -> Result<()> {
+        if !self.include_commands.is_empty() && !self.exclude_commands.is_empty() {
+            bail!(
+                "[hooks] `include_commands` and `exclude_commands` are mutually exclusive. \
+                 Remove one of them from your config.toml."
+            );
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -157,6 +185,7 @@ impl Config {
         if path.exists() {
             let content = std::fs::read_to_string(&path)?;
             let config: Config = toml::from_str(&content)?;
+            config.hooks.validate()?;
             Ok(config)
         } else {
             Ok(Config::default())
@@ -223,6 +252,7 @@ exclude_commands = ["curl", "gh"]
     fn test_hooks_config_default_empty() {
         let config = Config::default();
         assert!(config.hooks.exclude_commands.is_empty());
+        assert!(config.hooks.include_commands.is_empty());
         assert!(config.hooks.transparent_prefixes.is_empty());
     }
 
@@ -295,5 +325,84 @@ consent_date = "2026-04-10T12:00:00Z"
             config.telemetry.consent_date.as_deref(),
             Some("2026-04-10T12:00:00Z")
         );
+    }
+
+    // --- include_commands (#2231) ---
+
+    #[test]
+    fn test_include_commands_deserialize() {
+        let toml = r#"
+[hooks]
+include_commands = ["git status", "cargo build"]
+"#;
+        let config: Config = toml::from_str(toml).expect("valid toml");
+        assert_eq!(
+            config.hooks.include_commands,
+            vec!["git status", "cargo build"]
+        );
+        assert!(config.hooks.exclude_commands.is_empty());
+    }
+
+    #[test]
+    fn test_include_commands_missing_is_empty() {
+        // Older configs without include_commands must still parse.
+        let toml = r#"
+[hooks]
+exclude_commands = ["curl"]
+"#;
+        let config: Config = toml::from_str(toml).expect("valid toml");
+        assert!(config.hooks.include_commands.is_empty());
+    }
+
+    #[test]
+    fn test_include_commands_only_validates_ok() {
+        let hooks = HooksConfig {
+            include_commands: vec!["git status".into()],
+            exclude_commands: vec![],
+            transparent_prefixes: vec![],
+        };
+        assert!(hooks.validate().is_ok());
+    }
+
+    #[test]
+    fn test_exclude_commands_only_validates_ok() {
+        let hooks = HooksConfig {
+            include_commands: vec![],
+            exclude_commands: vec!["curl".into()],
+            transparent_prefixes: vec![],
+        };
+        assert!(hooks.validate().is_ok());
+    }
+
+    #[test]
+    fn test_neither_configured_validates_ok() {
+        let hooks = HooksConfig::default();
+        assert!(hooks.validate().is_ok());
+    }
+
+    #[test]
+    fn test_both_configured_is_error() {
+        let hooks = HooksConfig {
+            include_commands: vec!["git status".into()],
+            exclude_commands: vec!["curl".into()],
+            transparent_prefixes: vec![],
+        };
+        let err = hooks.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("mutually exclusive"),
+            "error message should mention mutual exclusion: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_both_empty_is_not_an_error() {
+        // Both fields present but empty is OK — TOML allows setting both to [].
+        let hooks = HooksConfig {
+            include_commands: vec![],
+            exclude_commands: vec![],
+            transparent_prefixes: vec![],
+        };
+        assert!(hooks.validate().is_ok());
     }
 }

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -478,9 +478,16 @@ fn collapse_line_continuations(s: &str) -> std::borrow::Cow<'_, str> {
 /// starts with `"foo bar "` (or strictly equals `"foo bar"`), not anything
 /// else. Matching is literal, not pattern-based: configure the exact concrete
 /// prefix you use.
+///
+/// When `included` is non-empty, **whitelist mode** is active: only commands
+/// that match one of the `included` patterns are eligible for rewriting; all
+/// others pass through unchanged. `included` and `excluded` are mutually
+/// exclusive and must not both be non-empty (the caller must enforce this via
+/// [`crate::core::config::HooksConfig::validate`]).
 pub fn rewrite_command(
     cmd: &str,
     excluded: &[String],
+    included: &[String],
     transparent_prefixes: &[String],
 ) -> Option<String> {
     // Bash line continuations (`\<NL>`, `\<CRLF>`) and the leading whitespace that
@@ -497,7 +504,8 @@ pub fn rewrite_command(
         return None;
     }
 
-    let compiled = compile_exclude_patterns(excluded);
+    let compiled_excluded = compile_exclude_patterns(excluded);
+    let compiled_included = compile_exclude_patterns(included);
     let normalized_prefixes = normalize_transparent_prefixes(transparent_prefixes);
 
     // Simple (non-compound) already-RTK command — return as-is.
@@ -512,13 +520,19 @@ pub fn rewrite_command(
         return Some(trimmed.to_string());
     }
 
-    rewrite_compound(trimmed, &compiled, &normalized_prefixes)
+    rewrite_compound(
+        trimmed,
+        &compiled_excluded,
+        &compiled_included,
+        &normalized_prefixes,
+    )
 }
 
 /// Rewrite a compound command (with `&&`, `||`, `;`, `|`) by rewriting each segment.
 fn rewrite_compound(
     cmd: &str,
     excluded: &[ExcludePattern],
+    included: &[ExcludePattern],
     transparent_prefixes: &[String],
 ) -> Option<String> {
     let tokens = tokenize(cmd);
@@ -533,7 +547,7 @@ fn rewrite_compound(
         match tok.kind {
             TokenKind::Operator => {
                 let seg = cmd[seg_start..tok.offset].trim();
-                let rewritten = rewrite_segment(seg, excluded, transparent_prefixes)
+                let rewritten = rewrite_segment(seg, excluded, included, transparent_prefixes)
                     .unwrap_or_else(|| seg.to_string());
                 if rewritten != seg {
                     any_changed = true;
@@ -564,7 +578,7 @@ fn rewrite_compound(
                 let rewritten = if is_pipe_incompatible {
                     seg.to_string()
                 } else {
-                    rewrite_segment(seg, excluded, transparent_prefixes)
+                    rewrite_segment(seg, excluded, included, transparent_prefixes)
                         .unwrap_or_else(|| seg.to_string())
                 };
                 if rewritten != seg {
@@ -593,7 +607,7 @@ fn rewrite_compound(
             }
             TokenKind::Shellism if tok.value == "&" => {
                 let seg = cmd[seg_start..tok.offset].trim();
-                let rewritten = rewrite_segment(seg, excluded, transparent_prefixes)
+                let rewritten = rewrite_segment(seg, excluded, included, transparent_prefixes)
                     .unwrap_or_else(|| seg.to_string());
                 if rewritten != seg {
                     any_changed = true;
@@ -610,8 +624,8 @@ fn rewrite_compound(
     }
 
     let seg = cmd[seg_start..].trim();
-    let rewritten =
-        rewrite_segment(seg, excluded, transparent_prefixes).unwrap_or_else(|| seg.to_string());
+    let rewritten = rewrite_segment(seg, excluded, included, transparent_prefixes)
+        .unwrap_or_else(|| seg.to_string());
     if rewritten != seg {
         any_changed = true;
     }
@@ -709,9 +723,10 @@ fn normalize_transparent_prefixes(prefixes: &[String]) -> Vec<String> {
 fn rewrite_segment(
     seg: &str,
     excluded: &[ExcludePattern],
+    included: &[ExcludePattern],
     transparent_prefixes: &[String],
 ) -> Option<String> {
-    rewrite_segment_inner(seg, excluded, transparent_prefixes, 0)
+    rewrite_segment_inner(seg, excluded, included, transparent_prefixes, 0)
 }
 
 fn is_excluded(cmd: &str, excluded: &[ExcludePattern]) -> bool {
@@ -724,6 +739,7 @@ fn is_excluded(cmd: &str, excluded: &[ExcludePattern]) -> bool {
 fn rewrite_segment_inner(
     seg: &str,
     excluded: &[ExcludePattern],
+    included: &[ExcludePattern],
     transparent_prefixes: &[String],
     depth: usize,
 ) -> Option<String> {
@@ -747,8 +763,13 @@ fn rewrite_segment_inner(
             );
             return None;
         }
-        let rewritten =
-            rewrite_segment_inner(rest_after_env, excluded, transparent_prefixes, depth + 1)?;
+        let rewritten = rewrite_segment_inner(
+            rest_after_env,
+            excluded,
+            included,
+            transparent_prefixes,
+            depth + 1,
+        )?;
         return Some(format!("{}{}", env_prefix, rewritten));
     }
 
@@ -757,8 +778,14 @@ fn rewrite_segment_inner(
             if rest.is_empty() {
                 return None;
             }
-            return rewrite_segment_inner(rest, excluded, transparent_prefixes, depth + 1)
-                .map(|rewritten| format!("{} {}", prefix, rewritten));
+            return rewrite_segment_inner(
+                rest,
+                excluded,
+                included,
+                transparent_prefixes,
+                depth + 1,
+            )
+            .map(|rewritten| format!("{} {}", prefix, rewritten));
         }
     }
 
@@ -769,8 +796,14 @@ fn rewrite_segment_inner(
             if rest.is_empty() {
                 return None;
             }
-            return rewrite_segment_inner(rest, excluded, transparent_prefixes, depth + 1)
-                .map(|rewritten| format!("{} {}", prefix, rewritten));
+            return rewrite_segment_inner(
+                rest,
+                excluded,
+                included,
+                transparent_prefixes,
+                depth + 1,
+            )
+            .map(|rewritten| format!("{} {}", prefix, rewritten));
         }
     }
 
@@ -802,7 +835,12 @@ fn rewrite_segment_inner(
         Classification::Supported { rtk_equivalent, .. } => {
             let stripped = ENV_PREFIX.replace(cmd_part, "");
             let cmd_clean = stripped.trim();
+            // Blacklist mode: skip if command matches exclude list.
             if is_excluded(cmd_clean, excluded) {
+                return None;
+            }
+            // Whitelist mode: skip if include list is set and command is NOT listed.
+            if !included.is_empty() && !is_excluded(cmd_clean, included) {
                 return None;
             }
             rtk_equivalent
@@ -873,7 +911,7 @@ mod tests {
     use super::*;
 
     fn rewrite_command_no_prefixes(cmd: &str, excluded: &[String]) -> Option<String> {
-        super::rewrite_command(cmd, excluded, &[])
+        super::rewrite_command(cmd, excluded, &[], &[])
     }
 
     #[test]
@@ -3662,7 +3700,7 @@ mod tests {
     fn test_transparent_prefix_strips_and_reprepends() {
         let prefixes = vec!["shadowenv exec --".to_string()];
         assert_eq!(
-            super::rewrite_command("shadowenv exec -- git status", &[], &prefixes),
+            super::rewrite_command("shadowenv exec -- git status", &[], &[], &prefixes),
             Some("shadowenv exec -- rtk git status".into())
         );
     }
@@ -3671,7 +3709,7 @@ mod tests {
     fn test_transparent_prefix_with_test_runner() {
         let prefixes = vec!["shadowenv exec --".to_string()];
         assert_eq!(
-            super::rewrite_command("shadowenv exec -- cargo test", &[], &prefixes),
+            super::rewrite_command("shadowenv exec -- cargo test", &[], &[], &prefixes),
             Some("shadowenv exec -- rtk cargo test".into())
         );
     }
@@ -3680,7 +3718,7 @@ mod tests {
     fn test_transparent_prefix_unknown_inner_returns_none() {
         let prefixes = vec!["shadowenv exec --".to_string()];
         assert_eq!(
-            super::rewrite_command("shadowenv exec -- htop", &[], &prefixes),
+            super::rewrite_command("shadowenv exec -- htop", &[], &[], &prefixes),
             None
         );
     }
@@ -3689,7 +3727,7 @@ mod tests {
     fn test_transparent_prefix_not_matched_is_passthrough() {
         // Without the prefix configured, the wrapper breaks routing.
         assert_eq!(
-            super::rewrite_command("shadowenv exec -- git status", &[], &[]),
+            super::rewrite_command("shadowenv exec -- git status", &[], &[], &[]),
             None
         );
     }
@@ -3700,7 +3738,7 @@ mod tests {
         // user layer strips shadowenv exec --, inner `git status` routes.
         let prefixes = vec!["shadowenv exec --".to_string()];
         assert_eq!(
-            super::rewrite_command("noglob shadowenv exec -- git status", &[], &prefixes),
+            super::rewrite_command("noglob shadowenv exec -- git status", &[], &[], &prefixes),
             Some("noglob shadowenv exec -- rtk git status".into())
         );
     }
@@ -3709,7 +3747,7 @@ mod tests {
     fn test_transparent_prefix_composed_with_env_prefix() {
         let prefixes = vec!["bundle exec".to_string()];
         assert_eq!(
-            super::rewrite_command("RAILS_ENV=test bundle exec git status", &[], &prefixes),
+            super::rewrite_command("RAILS_ENV=test bundle exec git status", &[], &[], &prefixes),
             Some("RAILS_ENV=test bundle exec rtk git status".into())
         );
     }
@@ -3726,7 +3764,7 @@ mod tests {
     fn test_transparent_prefix_multiple_configured() {
         let prefixes = vec!["shadowenv exec --".to_string(), "direnv exec .".to_string()];
         assert_eq!(
-            super::rewrite_command("direnv exec . git status", &[], &prefixes),
+            super::rewrite_command("direnv exec . git status", &[], &[], &prefixes),
             Some("direnv exec . rtk git status".into())
         );
     }
@@ -3749,7 +3787,7 @@ mod tests {
     fn test_transparent_prefix_overlapping_entries_use_longest_match() {
         let prefixes = vec!["docker".to_string(), "docker exec app".to_string()];
         assert_eq!(
-            super::rewrite_command("docker exec app git status", &[], &prefixes),
+            super::rewrite_command("docker exec app git status", &[], &[], &prefixes),
             Some("docker exec app rtk git status".into())
         );
     }
@@ -3759,7 +3797,7 @@ mod tests {
         // A prefix `"foo"` must NOT match `"foobar git status"`.
         let prefixes = vec!["foo".to_string()];
         assert_eq!(
-            super::rewrite_command("foobar git status", &[], &prefixes),
+            super::rewrite_command("foobar git status", &[], &[], &prefixes),
             None
         );
     }
@@ -3768,7 +3806,7 @@ mod tests {
     fn test_transparent_prefix_empty_rest_returns_none() {
         let prefixes = vec!["shadowenv exec --".to_string()];
         assert_eq!(
-            super::rewrite_command("shadowenv exec --", &[], &prefixes),
+            super::rewrite_command("shadowenv exec --", &[], &[], &prefixes),
             None
         );
     }
@@ -3778,7 +3816,7 @@ mod tests {
         // A blank entry in the config should not cause spurious matches or panics.
         let prefixes = vec!["".to_string(), "   ".to_string()];
         assert_eq!(
-            super::rewrite_command("git status", &[], &prefixes),
+            super::rewrite_command("git status", &[], &[], &prefixes),
             Some("rtk git status".into())
         );
     }
@@ -3790,6 +3828,7 @@ mod tests {
         assert_eq!(
             super::rewrite_command(
                 "shadowenv exec -- git status && shadowenv exec -- cargo test",
+                &[],
                 &[],
                 &prefixes
             ),
@@ -3804,7 +3843,7 @@ mod tests {
         let prefixes = vec!["shadowenv exec --".to_string()];
         let excluded = vec!["git".to_string()];
         assert_eq!(
-            super::rewrite_command("shadowenv exec -- git status", &excluded, &prefixes),
+            super::rewrite_command("shadowenv exec -- git status", &excluded, &[], &prefixes),
             None
         );
     }
@@ -3821,7 +3860,7 @@ mod tests {
         cmd.push_str("git status");
         // Doesn't matter exactly what it returns — just that it doesn't stack-
         // overflow or loop forever. Exercise the code path.
-        let _ = super::rewrite_command(&cmd, &[], &prefixes);
+        let _ = super::rewrite_command(&cmd, &[], &[], &prefixes);
     }
 
     #[test]
@@ -3971,5 +4010,93 @@ mod tests {
             collapse_line_continuations("git diff HEAD~1"),
             std::borrow::Cow::<str>::Borrowed("git diff HEAD~1"),
         );
+    }
+
+    // --- include_commands whitelist (#2231) ---
+
+    fn rewrite_command_with_included(cmd: &str, included: &[String]) -> Option<String> {
+        super::rewrite_command(cmd, &[], included, &[])
+    }
+
+    #[test]
+    fn test_include_only_listed_command_is_rewritten() {
+        let included = vec!["git status".to_string()];
+        assert_eq!(
+            rewrite_command_with_included("git status", &included),
+            Some("rtk git status".into())
+        );
+    }
+
+    #[test]
+    fn test_include_unlisted_command_passes_through() {
+        // cargo build is supported by RTK but NOT in the include list → no rewrite.
+        let included = vec!["git status".to_string()];
+        assert_eq!(
+            rewrite_command_with_included("cargo build", &included),
+            None
+        );
+    }
+
+    #[test]
+    fn test_include_empty_means_no_whitelist_restriction() {
+        // When include_commands is empty the whitelist is inactive —
+        // all supported commands should still be rewritten.
+        let included: Vec<String> = vec![];
+        assert_eq!(
+            rewrite_command_with_included("cargo test", &included),
+            Some("rtk cargo test".into())
+        );
+    }
+
+    #[test]
+    fn test_include_multiple_entries_any_matches() {
+        let included = vec!["git status".to_string(), "cargo build".to_string()];
+        assert_eq!(
+            rewrite_command_with_included("cargo build", &included),
+            Some("rtk cargo build".into())
+        );
+        assert_eq!(
+            rewrite_command_with_included("git status", &included),
+            Some("rtk git status".into())
+        );
+    }
+
+    #[test]
+    fn test_include_non_matching_supported_command_passes_through() {
+        let included = vec!["git status".to_string()];
+        // go test is supported but not included → passes through.
+        assert_eq!(
+            rewrite_command_with_included("go test ./...", &included),
+            None
+        );
+    }
+
+    #[test]
+    fn test_include_compound_only_listed_segment_rewritten() {
+        // git status is included; cargo test is not.
+        // The compound should rewrite git status but leave cargo test alone.
+        let included = vec!["git status".to_string()];
+        assert_eq!(
+            rewrite_command_with_included("git status && cargo test", &included),
+            Some("rtk git status && cargo test".into())
+        );
+    }
+
+    #[test]
+    fn test_include_prefix_pattern_matches_with_args() {
+        // "cargo build" in include_commands should match "cargo build --release"
+        // because compile_exclude_patterns appends `($|\s)` to the escaped literal.
+        let included = vec!["cargo build".to_string()];
+        assert_eq!(
+            rewrite_command_with_included("cargo build --release", &included),
+            Some("rtk cargo build --release".into())
+        );
+    }
+
+    #[test]
+    fn test_include_does_not_rewrite_unsupported_command() {
+        // htop is not in RTK's registry; even if listed it should not be rewritten.
+        let included = vec!["htop".to_string()];
+        assert_eq!(rewrite_command_with_included("htop", &included), None);
     }
 }

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -112,11 +112,17 @@ fn get_rewritten(cmd: &str) -> Option<String> {
         return None;
     }
 
-    let (excluded, transparent_prefixes) = crate::core::config::Config::load()
-        .map(|c| (c.hooks.exclude_commands, c.hooks.transparent_prefixes))
+    let (excluded, included, transparent_prefixes) = crate::core::config::Config::load()
+        .map(|c| {
+            (
+                c.hooks.exclude_commands,
+                c.hooks.include_commands,
+                c.hooks.transparent_prefixes,
+            )
+        })
         .unwrap_or_default();
 
-    let rewritten = rewrite_command(cmd, &excluded, &transparent_prefixes)?;
+    let rewritten = rewrite_command(cmd, &excluded, &included, &transparent_prefixes)?;
 
     if rewritten == cmd {
         return None;
@@ -234,11 +240,17 @@ pub fn run_gemini() -> Result<()> {
         return Ok(());
     }
 
-    let (excluded, transparent_prefixes) = crate::core::config::Config::load()
-        .map(|c| (c.hooks.exclude_commands, c.hooks.transparent_prefixes))
+    let (excluded, included, transparent_prefixes) = crate::core::config::Config::load()
+        .map(|c| {
+            (
+                c.hooks.exclude_commands,
+                c.hooks.include_commands,
+                c.hooks.transparent_prefixes,
+            )
+        })
         .unwrap_or_default();
 
-    match rewrite_command(cmd, &excluded, &transparent_prefixes) {
+    match rewrite_command(cmd, &excluded, &included, &transparent_prefixes) {
         Some(ref rewritten) => {
             audit_log("rewrite", cmd, rewritten);
             print_rewrite(rewritten);
@@ -551,7 +563,7 @@ mod tests {
     use super::*;
 
     fn rewrite_command_no_prefixes(cmd: &str, excluded: &[String]) -> Option<String> {
-        crate::discover::registry::rewrite_command(cmd, excluded, &[])
+        crate::discover::registry::rewrite_command(cmd, excluded, &[], &[])
     }
 
     // --- Copilot format detection ---

--- a/src/hooks/rewrite_cmd.rs
+++ b/src/hooks/rewrite_cmd.rs
@@ -16,8 +16,14 @@ use std::io::Write;
 /// | 2    | (none)   | Deny rule matched — hook defers to Claude Code native deny.  |
 /// | 3    | rewritten| Ask rule matched — hook rewrites but lets Claude Code prompt.|
 pub fn run(cmd: &str) -> anyhow::Result<()> {
-    let (excluded, transparent_prefixes) = crate::core::config::Config::load()
-        .map(|c| (c.hooks.exclude_commands, c.hooks.transparent_prefixes))
+    let (excluded, included, transparent_prefixes) = crate::core::config::Config::load()
+        .map(|c| {
+            (
+                c.hooks.exclude_commands,
+                c.hooks.include_commands,
+                c.hooks.transparent_prefixes,
+            )
+        })
         .unwrap_or_default();
 
     // SECURITY: check deny/ask BEFORE rewrite so non-RTK commands are also covered.
@@ -27,7 +33,7 @@ pub fn run(cmd: &str) -> anyhow::Result<()> {
         std::process::exit(2);
     }
 
-    match registry::rewrite_command(cmd, &excluded, &transparent_prefixes) {
+    match registry::rewrite_command(cmd, &excluded, &included, &transparent_prefixes) {
         Some(rewritten) => match verdict {
             PermissionVerdict::Allow => {
                 print!("{}", rewritten);
@@ -54,7 +60,7 @@ mod tests {
     use super::*;
 
     fn rewrite_command_no_prefixes(cmd: &str) -> Option<String> {
-        registry::rewrite_command(cmd, &[], &[])
+        registry::rewrite_command(cmd, &[], &[], &[])
     }
 
     #[test]
@@ -152,7 +158,7 @@ mod tests {
 
             // Verify the rewrite exists (so the hook would output it),
             // but the exit code forces user confirmation.
-            assert!(registry::rewrite_command("git status", &[], &[]).is_some());
+            assert!(registry::rewrite_command("git status", &[], &[], &[]).is_some());
             assert_eq!(expected_exit_code(&verdict), 3);
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2215,10 +2215,17 @@ fn run_cli() -> Result<i32> {
             HookCommands::Check { agent: _, command } => {
                 use crate::discover::registry::rewrite_command;
                 let raw = command.join(" ");
-                let (excluded, transparent_prefixes) = crate::core::config::Config::load()
-                    .map(|c| (c.hooks.exclude_commands, c.hooks.transparent_prefixes))
-                    .unwrap_or_default();
-                match rewrite_command(&raw, &excluded, &transparent_prefixes) {
+                let (excluded, included, transparent_prefixes) =
+                    crate::core::config::Config::load()
+                        .map(|c| {
+                            (
+                                c.hooks.exclude_commands,
+                                c.hooks.include_commands,
+                                c.hooks.transparent_prefixes,
+                            )
+                        })
+                        .unwrap_or_default();
+                match rewrite_command(&raw, &excluded, &included, &transparent_prefixes) {
                     Some(rewritten) => {
                         println!("{}", rewritten);
                         0


### PR DESCRIPTION
…g (#2231)

Add support for [hooks].include_commands in config.toml, providing a whitelist-mode counterpart to the existing exclude_commands blacklist.

## Behaviour

- When include_commands is non-empty, ONLY commands that match one of the listed patterns are rewritten by RTK; all others pass through unchanged.
- When include_commands is empty (default), behaviour is identical to the previous release — no filtering change for existing users.
- include_commands and exclude_commands are mutually exclusive. Config::load() returns an error if both contain at least one entry, preventing silent misconfiguration.

## Implementation

### src/core/config.rs
- Add include_commands: Vec<String> field to HooksConfig (serde default = []).
- Add HooksConfig::validate() which errors when both fields are non-empty.
- Call validate() inside Config::load() so every code path that loads config is protected.
- Update test_hooks_config_default_empty to assert include_commands is also empty by default.
- New tests: deserialize, only-include OK, only-exclude OK, neither OK, both-set error, both-empty OK.

### src/discover/registry.rs
- rewrite_command() gains a new included: &[String] parameter (position 3, before transparent_prefixes). Callers pass &[] to preserve old behaviour.
- rewrite_compound() and rewrite_segment()/rewrite_segment_inner() gain the same parameter and thread it through all recursive calls.
- Whitelist check inside rewrite_segment_inner(): after classify_command confirms a command is supported and it is not excluded, if included is non-empty the command MUST also match included — otherwise return None (pass through).
- Reuses compile_exclude_patterns() for include patterns: same literal- prefix and anchored-regex matching logic, zero duplication.
- All existing transparent_prefix test call-sites updated to 4-arg form.
- New tests: listed command rewritten, unlisted passes through, empty include = no restriction, multiple entries, compound partial rewrite, prefix-pattern with args, unsupported command not rewritten.

### src/hooks/hook_cmd.rs
- get_rewritten() and run_gemini() now destructure (excluded, included, transparent_prefixes) from config and pass included to rewrite_command().
- Test helper rewrite_command_no_prefixes updated to 4-arg form.

### src/hooks/rewrite_cmd.rs
- run() now loads included from config and passes to registry::rewrite_command().
- Test helper and exit_code_protocol test updated to 4-arg form.

### src/main.rs
- HookCommands::Check handler updated to load and pass include_commands.

## Backward compatibility
- All three of excluded, included, transparent_prefixes are Vec default [].
- Old configs with only exclude_commands or neither field continue to work unchanged; validate() only errors when both are non-empty.
- Public rewrite_command signature change is additive; no external callers exist outside this crate.

## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

-

## Test plan
<!-- How did you verify this works? -->

- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
