### PR TITLE
fix: add delegation confirmation to prevent LLM confusion loops

### DIFF
--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -118,7 +118,12 @@ where
     } else if opts.no_trailing_newline {
         print!("{}", filtered);
     } else {
-        println!("{}", filtered);
+        if !filtered.trim().is_empty() {
+            println!("{}", filtered);
+        }
+        if exit_code == 0 {
+            println!("rtk: {} done", tool_name);
+        }
     }
 
     let raw_for_tracking = if opts.filter_stdout_only {


### PR DESCRIPTION
## Problem

When RTK runs a delegated command like `ruff check`, the output shows the full command in the bash tool result (e.g. `$ rtk ruff check ... --fix`) followed by the filtered output (`Ruff: No issues found`). LLMs misinterpret the `$ rtk` prefix as a typo for the underlying tool (`ruff`), causing them to re-execute the command directly in an infinite loop.

## Solution

After every successful filtered command, RTK now prints a delegation confirmation line:

```
rtk: <tool> done
```

This makes it unambiguous that `rtk` was intentional and the command successfully completed. The LLM sees both names in the same line and understands the delegation was correct.

### Example output before

```
$ rtk ruff check src/main.py --fix
Ruff: No issues found
```

### Example output after

```
$ rtk ruff check src/main.py --fix
Ruff: No issues found
rtk: ruff done
```

## Testing

- Unit tests on filter functions pass unchanged (the change is in the runner, not the filters)
- The `rtk: <tool> done` line only appears for commands that succeed (`exit_code == 0`)
- Commands using `tee_label` or `no_trailing_newline` paths are unaffected

Fixes #2280

---

Collaborated & Orchestrated by ClosedLoop.AI | [www.closedloop.ai](https://www.closedloop.ai) · [github.com/rtk-ai](https://github.com/rtk-ai)