### PR TITLE
fix(find): reject unsafe bare native actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ rtk grep "pattern" .            # Grouped search results
 rtk diff file1 file2            # Condensed diff
 ```
 
+`rtk find` compacts simple searches such as `-name`, `-iname`, `-type`, and `-maxdepth`. Compound native expressions/actions such as `(...)`, `-o`, `!`, `-exec`, `-delete`, or `-print0` automatically fall back to native `find`; use `rtk proxy find ...` when you want raw native behavior explicitly.
+
 ### Git
 ```bash
 rtk git status                  # Compact status
@@ -185,6 +187,8 @@ rtk rspec                       # RSpec tests (JSON, -60%+)
 rtk err <cmd>                   # Filter errors only from any command
 rtk test <cmd>                  # Generic test wrapper - failures only (-90%)
 ```
+
+`rtk test` expects a test-runner command, for example `rtk test cargo test`. It is not POSIX `test`; use `rtk run "test -d path"` or direct `test -d path` for shell condition checks.
 
 ### Build & Lint
 ```bash

--- a/docs/guide/resources/troubleshooting.md
+++ b/docs/guide/resources/troubleshooting.md
@@ -62,6 +62,34 @@ rtk gain    # should now show token savings stats
    cat ~/.claude/settings.json | grep rtk
    ```
 
+## `rtk find` does not handle my native `find` expression
+
+**Symptom:** A command with native `find` predicates or actions behaves differently than expected:
+
+```bash
+rtk find . -type f \( -name 'package.json' -o -name 'Cargo.toml' \)
+```
+
+**Cause:** `rtk find` only compacts simple searches itself (`-name`, `-iname`, `-type`, `-maxdepth`). Compound expressions and actions need native `find` semantics.
+
+**Fix:** Recent RTK versions automatically fall back to native `find` for compound expressions/actions. To force raw native behavior explicitly:
+
+```bash
+rtk proxy find . -type f \( -name 'package.json' -o -name 'Cargo.toml' \)
+```
+
+## `rtk test -d path` does not check for a directory
+
+**Cause:** `rtk test` runs test-runner commands and filters failures. It is not POSIX `test`.
+
+**Fix:**
+
+```bash
+rtk run "test -d path"
+# or
+test -d path
+```
+
 ## RTK not found after `cargo install`
 
 **Symptom:**

--- a/docs/guide/resources/what-rtk-covers.md
+++ b/docs/guide/resources/what-rtk-covers.md
@@ -110,7 +110,7 @@ Typical savings: 60-99%.
 | Command | Savings | What changes |
 |---------|---------|--------------|
 | `ls` | 80% | Tree format with file counts |
-| `find` | 75% | Tree format |
+| `find` | 75% | Tree format for simple searches; native fallback for compound expressions/actions |
 | `grep` | 70% | Truncated lines, grouped by file |
 | `diff` | 65% | Context reduced |
 | `wc` | 60% | Compact counts |

--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -182,7 +182,9 @@ Records input/output tokens, savings %, execution times with 90-day retention.
 rtk find [args...]
 ```
 
-Supporte a la fois la syntaxe RTK et la syntaxe native `find` (`-name`, `-type`, etc.).
+Supporte a la fois la syntaxe RTK et les recherches natives simples (`-name`, `-iname`, `-type`, `-maxdepth`).
+
+Pour les expressions natives composees ou les actions (`(...)`, `-o`, `!`, `-exec`, `-delete`, `-print0`, etc.), `rtk find` bascule automatiquement vers `find` natif. Utilisez `rtk proxy find ...` si vous voulez demander explicitement la sortie native non filtree.
 
 **Economies :** ~80%
 
@@ -522,6 +524,8 @@ rtk test npm test
 rtk test bun test
 rtk test pytest
 ```
+
+`rtk test` attend une commande de runner de tests. Ce n'est pas le builtin POSIX `test`; pour verifier une condition shell, utilisez `rtk run "test -d path"` ou `test -d path` directement.
 
 **Avant / Apres :**
 ```

--- a/src/cmds/system/README.md
+++ b/src/cmds/system/README.md
@@ -6,6 +6,7 @@
 
 - `read.rs` uses `core/filter` for language-aware code stripping (FilterLevel: none/minimal/aggressive)
 - `grep_cmd.rs` reads `core/config` for `limits.grep_max_results` and `limits.grep_max_per_file`. Format-altering flags (`-c`, `-l`, `-L`, `-o`, `-Z`) bypass RTK filtering and run raw.
+- `find_cmd.rs` compacts simple native searches (`-name`, `-iname`, `-type`, `-maxdepth`) and falls back to native `find` for compound expressions/actions such as `(...)`, `-o`, `!`, `-exec`, `-delete`, and `-print0`.
 - `local_llm.rs` (`rtk smart`) uses `core/filter` for heuristic file summarization
 - `format_cmd.rs` is a cross-ecosystem dispatcher: auto-detects and routes to `prettier_cmd` or `ruff_cmd` (black is handled inline, not as a separate module)
 

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -1,10 +1,11 @@
 //! Filters find results by grouping files by directory.
 
-use crate::core::tracking;
+use crate::core::{tracking, utils};
 use anyhow::{Context, Result};
 use ignore::WalkBuilder;
 use std::collections::HashMap;
 use std::path::Path;
+use std::process::Stdio;
 
 /// Match a filename against a glob pattern (supports `*` and `?`).
 fn glob_match(pattern: &str, name: &str) -> bool {
@@ -62,17 +63,85 @@ fn has_native_find_flags(args: &[String]) -> bool {
         .any(|a| a == "-name" || a == "-type" || a == "-maxdepth" || a == "-iname")
 }
 
-/// Native find flags that RTK cannot handle correctly.
-/// These involve compound predicates, actions, or semantics we don't support.
-const UNSUPPORTED_FIND_FLAGS: &[&str] = &[
-    "-not", "!", "-or", "-o", "-and", "-a", "-exec", "-execdir", "-delete", "-print0", "-newer",
-    "-perm", "-size", "-mtime", "-mmin", "-atime", "-amin", "-ctime", "-cmin", "-empty", "-link",
-    "-regex", "-iregex",
+/// Native find tokens that RTK's compact parser should not try to emulate.
+/// These involve compound predicates, actions, output formats, or unsupported
+/// native semantics. Fall back to native `find` instead.
+const NATIVE_FIND_FALLBACK_TOKENS: &[&str] = &[
+    "(", ")", "\\(", "\\)", "-not", "!", "-or", "-o", "-and", "-a", "-exec", "-execdir",
+    "-ok", "-okdir", "-delete", "-print", "-print0", "-printf", "-fprint", "-fprint0",
+    "-fprintf", "-ls", "-fls", "-prune", "-quit", "-depth", "-mindepth", "-newer", "-perm",
+    "-size", "-mtime", "-mmin", "-atime", "-amin", "-ctime", "-cmin", "-empty", "-link",
+    "-links", "-regex", "-iregex", "-path", "-ipath", "-wholename", "-iwholename", "-user",
+    "-group", "-uid", "-gid", "-readable", "-writable", "-executable", "-xtype", "-samefile",
+    "-inum", "-true", "-false",
 ];
 
-fn has_unsupported_find_flags(args: &[String]) -> bool {
+const SUPPORTED_NATIVE_FIND_FLAGS: &[&str] = &["-name", "-iname", "-type", "-maxdepth"];
+const NATIVE_FIND_ACTION_TOKENS: &[&str] = &["-exec", "-execdir", "-ok", "-okdir", "-delete"];
+const NATIVE_FIND_NARROWING_PREDICATES: &[&str] = &[
+    "-name",
+    "-iname",
+    "-type",
+    "-newer",
+    "-perm",
+    "-size",
+    "-mtime",
+    "-mmin",
+    "-atime",
+    "-amin",
+    "-ctime",
+    "-cmin",
+    "-empty",
+    "-link",
+    "-links",
+    "-regex",
+    "-iregex",
+    "-path",
+    "-ipath",
+    "-wholename",
+    "-iwholename",
+    "-user",
+    "-group",
+    "-uid",
+    "-gid",
+    "-readable",
+    "-writable",
+    "-executable",
+    "-xtype",
+    "-samefile",
+    "-inum",
+];
+
+fn has_native_find_action(args: &[String]) -> bool {
     args.iter()
-        .any(|a| UNSUPPORTED_FIND_FLAGS.contains(&a.as_str()))
+        .any(|a| NATIVE_FIND_ACTION_TOKENS.contains(&a.as_str()))
+}
+
+fn has_native_find_narrowing_predicate(args: &[String]) -> bool {
+    args.iter()
+        .any(|a| NATIVE_FIND_NARROWING_PREDICATES.contains(&a.as_str()))
+}
+
+fn should_reject_native_find_action(args: &[String]) -> bool {
+    has_native_find_action(args) && !has_native_find_narrowing_predicate(args)
+}
+
+fn should_run_native_find(args: &[String]) -> bool {
+    if should_reject_native_find_action(args) {
+        return false;
+    }
+
+    if args
+        .iter()
+        .any(|a| NATIVE_FIND_FALLBACK_TOKENS.contains(&a.as_str()))
+    {
+        return true;
+    }
+
+    has_native_find_flags(args)
+        && args.iter().any(|a| {
+            a.starts_with('-') && !SUPPORTED_NATIVE_FIND_FLAGS.contains(&a.as_str())
+        })
 }
 
 /// Parse arguments from raw args vec, supporting both native find and RTK syntax.
@@ -82,12 +151,6 @@ fn has_unsupported_find_flags(args: &[String]) -> bool {
 fn parse_find_args(args: &[String]) -> Result<FindArgs> {
     if args.is_empty() {
         return Ok(FindArgs::default());
-    }
-
-    if has_unsupported_find_flags(args) {
-        anyhow::bail!(
-            "rtk find does not support compound predicates or actions (e.g. -not, -exec). Use `find` directly."
-        );
     }
 
     if has_native_find_flags(args) {
@@ -177,7 +240,17 @@ fn parse_rtk_find_args(args: &[String]) -> Result<FindArgs> {
 }
 
 /// Entry point from main.rs — parses raw args then delegates to run().
-pub fn run_from_args(args: &[String], verbose: u8) -> Result<()> {
+pub fn run_from_args(args: &[String], verbose: u8) -> Result<i32> {
+    if should_reject_native_find_action(args) {
+        anyhow::bail!(
+            "rtk find refuses native find actions like -delete/-exec without a narrowing predicate; use `rtk proxy find ...` for raw native find behavior"
+        );
+    }
+
+    if should_run_native_find(args) {
+        return run_native_find(args, verbose);
+    }
+
     let parsed = parse_find_args(args)?;
     run(
         &parsed.pattern,
@@ -187,7 +260,38 @@ pub fn run_from_args(args: &[String], verbose: u8) -> Result<()> {
         &parsed.file_type,
         parsed.case_insensitive,
         verbose,
-    )
+    )?;
+    Ok(0)
+}
+
+fn run_native_find(args: &[String], verbose: u8) -> Result<i32> {
+    let timer = tracking::TimedExecution::start();
+    let command_text = if args.is_empty() {
+        "find".to_string()
+    } else {
+        format!("find {}", args.join(" "))
+    };
+    let rtk_command_text = if args.is_empty() {
+        "rtk find (native fallback)".to_string()
+    } else {
+        format!("rtk find {} (native fallback)", args.join(" "))
+    };
+
+    if verbose > 0 {
+        eprintln!("rtk find: using native find for {}", args.join(" "));
+    }
+
+    let status = utils::resolved_command("find")
+        .args(args)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .context("Failed to execute native find")?;
+
+    timer.track_passthrough(&command_text, &rtk_command_text);
+
+    Ok(utils::exit_code_from_status(&status, "find"))
 }
 
 pub fn run(
@@ -493,20 +597,73 @@ mod tests {
         assert_eq!(parsed.path, ".");
     }
 
-    // --- parse_find_args: unsupported flags ---
+    // --- native fallback detection ---
 
     #[test]
-    fn parse_native_find_rejects_not() {
-        let result = parse_find_args(&args(&[".", "-name", "*.rs", "-not", "-name", "*_test.rs"]));
-        assert!(result.is_err());
-        let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("compound predicates"));
+    fn native_find_fallback_detects_not() {
+        assert!(should_run_native_find(&args(&[
+            ".",
+            "-name",
+            "*.rs",
+            "-not",
+            "-name",
+            "*_test.rs"
+        ])));
     }
 
     #[test]
-    fn parse_native_find_rejects_exec() {
-        let result = parse_find_args(&args(&[".", "-name", "*.tmp", "-exec", "rm", "{}", ";"]));
+    fn native_find_fallback_detects_exec() {
+        assert!(should_run_native_find(&args(&[
+            ".", "-name", "*.tmp", "-exec", "rm", "{}", ";"
+        ])));
+    }
+
+    #[test]
+    fn native_find_action_rejects_bare_delete() {
+        let command = args(&["-delete"]);
+        assert!(should_reject_native_find_action(&command));
+        assert!(!should_run_native_find(&command));
+
+        let result = run_from_args(&command, 0);
         assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("refuses"));
+    }
+
+    #[test]
+    fn native_find_action_rejects_exec_without_predicate() {
+        assert!(should_reject_native_find_action(&args(&[
+            ".", "-exec", "rm", "{}", ";"
+        ])));
+    }
+
+    #[test]
+    fn native_find_action_allows_predicated_delete() {
+        let command = args(&[".", "-name", "*.tmp", "-delete"]);
+        assert!(!should_reject_native_find_action(&command));
+        assert!(should_run_native_find(&command));
+    }
+
+    #[test]
+    fn native_find_fallback_detects_compound_or_expression() {
+        assert!(should_run_native_find(&args(&[
+            ".",
+            "-type",
+            "f",
+            "(",
+            "-name",
+            "package.json",
+            "-o",
+            "-name",
+            "Cargo.toml",
+            ")"
+        ])));
+    }
+
+    #[test]
+    fn native_find_fallback_ignores_simple_native_expression() {
+        assert!(!should_run_native_find(&args(&[
+            ".", "-name", "*.rs", "-type", "f", "-maxdepth", "3"
+        ])));
     }
 
     // --- parse_find_args: RTK syntax ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -1144,6 +1144,24 @@ const RTK_META_COMMANDS: &[&str] = &[
     "rewrite",
 ];
 
+const POSIX_TEST_UNARY_FLAGS: &[&str] = &[
+    "-b", "-c", "-d", "-e", "-f", "-g", "-h", "-k", "-L", "-n", "-O", "-p", "-r", "-S", "-s", "-u",
+    "-w", "-x", "-z", "-G",
+];
+
+fn posix_test_misuse_message(command: &[String]) -> Option<String> {
+    let first = command.first()?;
+    if !POSIX_TEST_UNARY_FLAGS.contains(&first.as_str()) {
+        return None;
+    }
+
+    let expression = command.join(" ");
+    Some(format!(
+        "rtk test is for test runners, not POSIX test; use `rtk run \"test {}\"` or direct `test {}`",
+        expression, expression
+    ))
+}
+
 fn run_fallback(parse_error: clap::Error) -> Result<i32> {
     let args: Vec<String> = std::env::args().skip(1).collect();
 
@@ -1665,6 +1683,9 @@ fn run_cli() -> Result<i32> {
         }
 
         Commands::Test { command } => {
+            if let Some(message) = posix_test_misuse_message(&command) {
+                anyhow::bail!("{}", message);
+            }
             let cmd = command.join(" ");
             runner::run_test(&cmd, cli.verbose)?
         }
@@ -1692,10 +1713,7 @@ fn run_cli() -> Result<i32> {
             0
         }
 
-        Commands::Find { args } => {
-            find_cmd::run_from_args(&args, cli.verbose)?;
-            0
-        }
+        Commands::Find { args } => find_cmd::run_from_args(&args, cli.verbose)?,
 
         Commands::Diff { file1, file2 } => {
             if let Some(f2) = file2 {
@@ -2847,6 +2865,32 @@ mod tests {
                 assert_eq!(args, vec!["echo", "hello"]);
             }
             _ => panic!("Expected Run command"),
+        }
+    }
+
+    #[test]
+    fn test_posix_test_flag_gets_targeted_message() {
+        let command = vec!["-d".to_string(), "path".to_string()];
+        let message = posix_test_misuse_message(&command).unwrap();
+        assert!(message.contains("rtk test is for test runners"));
+        assert!(message.contains("rtk run \"test -d path\""));
+    }
+
+    #[test]
+    fn test_test_runner_command_does_not_get_posix_message() {
+        let command = vec!["cargo".to_string(), "test".to_string()];
+        assert!(posix_test_misuse_message(&command).is_none());
+    }
+
+    #[test]
+    fn test_test_command_with_dash_d_still_parses() {
+        let cli = Cli::try_parse_from(["rtk", "test", "-d", "path"]).unwrap();
+        match cli.command {
+            Commands::Test { command } => {
+                assert_eq!(command, vec!["-d", "path"]);
+                assert!(posix_test_misuse_message(&command).is_some());
+            }
+            _ => panic!("Expected Test command"),
         }
     }
 


### PR DESCRIPTION
## Summary
- fall back to native `find` for compound expressions/actions that RTK should not emulate
- reject bare native actions like `-delete`/`-exec` unless a narrowing predicate is present
- clarify `rtk find` and `rtk test` behavior in user docs

## Why
Bare native action forms such as `rtk find -delete` can default to the current directory when delegated to native `find`, creating a destructive footgun.

## Verification
- `rtk cargo fmt --all --check`
- `rtk cargo test find_cmd -- --nocapture`
- `rtk cargo clippy --all-targets`
- `rtk cargo test --all`
- `rtk git diff --check`