### PR TITLE
refacto(cmds): strip decorator noise from filter output

### DIFF
--- a/src/cmds/cloud/wget_cmd.rs
+++ b/src/cmds/cloud/wget_cmd.rs
@@ -78,7 +78,7 @@ pub fn run_stdout(url: &str, args: &[String], verbose: u8) -> Result<i32> {
                 total,
                 format_size(result.stdout.len() as u64)
             ));
-            rtk_output.push_str("--- first 10 lines ---\n");
+            rtk_output.push_str("first 10 lines:\n");
             for line in lines.iter().take(10) {
                 rtk_output.push_str(&format!("{}\n", truncate_line(line, 100)));
             }

--- a/src/cmds/dotnet/dotnet_cmd.rs
+++ b/src/cmds/dotnet/dotnet_cmd.rs
@@ -368,7 +368,6 @@ fn format_dotnet_format_output(
     }
 
     let mut output = format!("Format: {} files need formatting", changed_count);
-    output.push_str("\n---------------------------------------");
 
     const MAX_FORMAT_FILES: usize = CAP_LIST;
     for (index, file) in summary
@@ -1056,12 +1055,6 @@ fn format_build_output(summary: &binlog::BuildSummary, _binlog_path: &Path) -> S
         }
     }
 
-    let sep = if !warnings.is_empty() || !errors.is_empty() {
-        "---------------------------------------"
-    } else {
-        ""
-    };
-
     let verdict = format!(
         "{} dotnet build: {} projects, {} errors, {} warnings ({})",
         status_icon,
@@ -1076,7 +1069,7 @@ fn format_build_output(summary: &binlog::BuildSummary, _binlog_path: &Path) -> S
     // definitive verdict. Mirrors native `dotnet build`, which ends with
     // `Build succeeded.` / `Build FAILED.`. See issue #1574.
     // Warnings before errors: errors survive `| tail -N` immediately above the verdict.
-    [warnings, errors, sep.into(), verdict]
+    [warnings, errors, verdict]
         .into_iter()
         .filter(|s| !s.is_empty())
         .collect::<Vec<_>>()
@@ -1218,24 +1211,9 @@ fn format_test_output(
         }
     }
 
-    let sep = if !failed_tests_section.is_empty()
-        || !warnings_section.is_empty()
-        || !errors_section.is_empty()
-    {
-        "---------------------------------------"
-    } else {
-        ""
-    };
-
     // Status line emitted last; see format_build_output (issue #1574).
     // Warnings before errors: errors survive `| tail -N` immediately above the verdict.
-    [
-        failed_tests_section,
-        warnings_section,
-        errors_section,
-        sep.into(),
-        header,
-    ]
+    [failed_tests_section, warnings_section, errors_section, header]
     .into_iter()
     .filter(|s| !s.is_empty())
     .collect::<Vec<_>>()
@@ -1311,12 +1289,6 @@ fn format_restore_output(
         }
     }
 
-    let sep = if !warnings_section.is_empty() || !errors_section.is_empty() {
-        "---------------------------------------"
-    } else {
-        ""
-    };
-
     let verdict = format!(
         "{} dotnet restore: {} projects, {} errors, {} warnings ({})",
         status_icon, summary.restored_projects, summary.errors, summary.warnings, duration
@@ -1324,7 +1296,7 @@ fn format_restore_output(
 
     // Status line emitted last; see format_build_output (issue #1574).
     // Warnings before errors: errors survive `| tail -N` immediately above the verdict.
-    [warnings_section, errors_section, sep.into(), verdict]
+    [warnings_section, errors_section, verdict]
         .into_iter()
         .filter(|s| !s.is_empty())
         .collect::<Vec<_>>()

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -251,10 +251,10 @@ fn run_diff(
 
     let mut final_output = result.stdout.clone();
     if !diff_result.stdout.is_empty() {
-        println!("\n--- Changes ---");
+        println!("\nChanges:");
         let compacted = compact_diff(&diff_result.stdout, max_lines.unwrap_or(500));
         println!("{}", compacted);
-        final_output.push_str("\n--- Changes ---\n");
+        final_output.push_str("\nChanges:\n");
         final_output.push_str(&compacted);
     }
 
@@ -363,7 +363,7 @@ fn run_show(
     let mut final_output = summary_result.stdout.clone();
     if !diff_text.is_empty() {
         if verbose > 0 {
-            println!("\n--- Changes ---");
+            println!("\nChanges:");
         }
         let compacted = compact_diff(diff_text, max_lines.unwrap_or(500));
         println!("{}", compacted);

--- a/src/cmds/go/go_cmd.rs
+++ b/src/cmds/go/go_cmd.rs
@@ -431,7 +431,6 @@ pub(crate) fn filter_go_test_json(output: &str) -> String {
         result.push_str(&format!(", {} skipped", total_skip));
     }
     result.push_str(&format!(" in {} packages\n", total_packages));
-    result.push_str("═══════════════════════════════════════\n");
 
     // Show package-level failures first (timeouts, signals, panics).
     // Skip packages that already have individual test-level failures — those are displayed
@@ -586,7 +585,6 @@ pub(crate) fn filter_go_build(output: &str) -> String {
 
     let mut result = String::new();
     result.push_str(&format!("Go build: {} errors\n", errors.len()));
-    result.push_str("═══════════════════════════════════════\n");
 
     const MAX_GO_BUILD_ERRORS: usize = CAP_ERRORS;
     for (i, error) in errors.iter().take(MAX_GO_BUILD_ERRORS).enumerate() {
@@ -678,7 +676,6 @@ fn filter_go_vet(output: &str) -> String {
 
     let mut result = String::new();
     result.push_str(&format!("Go vet: {} issues\n", issues.len()));
-    result.push_str("═══════════════════════════════════════\n");
 
     const MAX_GO_VET_ISSUES: usize = CAP_ERRORS;
     for (i, issue) in issues.iter().take(MAX_GO_VET_ISSUES).enumerate() {

--- a/src/cmds/go/golangci_cmd.rs
+++ b/src/cmds/go/golangci_cmd.rs
@@ -310,7 +310,6 @@ pub(crate) fn filter_golangci_json(output: &str, version: u32) -> String {
         "golangci-lint: {} issues in {} files\n",
         total_issues, total_files
     ));
-    result.push_str("═══════════════════════════════════════\n");
 
     // Show top linters
     let mut linter_counts: Vec<_> = by_linter.iter().collect();

--- a/src/cmds/js/lint_cmd.rs
+++ b/src/cmds/js/lint_cmd.rs
@@ -268,7 +268,6 @@ fn filter_eslint_json(output: &str) -> String {
         "ESLint: {} errors, {} warnings in {} files\n",
         total_errors, total_warnings, total_files
     ));
-    result.push_str("═══════════════════════════════════════\n");
 
     // Show top rules
     let mut rule_counts: Vec<_> = by_rule.iter().collect();
@@ -394,7 +393,6 @@ fn filter_pylint_json(output: &str) -> String {
         result.push('\n');
     }
 
-    result.push_str("═══════════════════════════════════════\n");
 
     // Show top symbols (rules)
     let mut symbol_counts: Vec<_> = by_symbol.iter().collect();
@@ -471,7 +469,6 @@ fn filter_generic_lint(output: &str) -> String {
 
     let mut result = String::new();
     result.push_str(&format!("Lint: {} errors, {} warnings\n", errors, warnings));
-    result.push_str("═══════════════════════════════════════\n");
 
     const MAX_ISSUES: usize = CAP_ERRORS;
     for issue in issues.iter().take(MAX_ISSUES) {

--- a/src/cmds/js/next_cmd.rs
+++ b/src/cmds/js/next_cmd.rs
@@ -115,7 +115,6 @@ fn filter_next_build(output: &str) -> String {
     // Build filtered output
     let mut result = String::new();
     result.push_str("Next.js Build\n");
-    result.push_str("═══════════════════════════════════════\n");
 
     if already_built && routes_total == 0 {
         result.push_str("Already built (using cache)\n\n");

--- a/src/cmds/js/prettier_cmd.rs
+++ b/src/cmds/js/prettier_cmd.rs
@@ -94,7 +94,6 @@ pub fn filter_prettier_output(output: &str) -> String {
                 "Prettier: {} files need formatting\n",
                 files_to_format.len()
             ));
-            result.push_str("═══════════════════════════════════════\n");
 
             const MAX_PRETTIER_FILES: usize = CAP_WARNINGS;
             for (i, file) in files_to_format.iter().take(MAX_PRETTIER_FILES).enumerate() {

--- a/src/cmds/js/prisma_cmd.rs
+++ b/src/cmds/js/prisma_cmd.rs
@@ -277,7 +277,6 @@ fn filter_migrate_dev(output: &str) -> String {
 
     if !migration_name.is_empty() {
         result.push_str(&format!("Migration: {}\n", migration_name));
-        result.push_str("═══════════════════════════════════════\n");
     }
 
     result.push_str("Changes:\n");

--- a/src/cmds/js/tsc_cmd.rs
+++ b/src/cmds/js/tsc_cmd.rs
@@ -84,7 +84,7 @@ impl BlockHandler for TscHandler {
         }
 
         let mut result = format!(
-            "═══════════════════════════════════════\nTypeScript: {} errors in {} files\n",
+            "TypeScript: {} errors in {} files\n",
             self.error_count,
             self.files.len()
         );
@@ -174,7 +174,6 @@ pub(crate) fn filter_tsc_output(output: &str) -> String {
         errors.len(),
         by_file.len()
     ));
-    result.push_str("═══════════════════════════════════════\n");
 
     // Top error codes summary (compact, one line)
     let mut code_counts: Vec<_> = by_code.iter().collect();

--- a/src/cmds/python/mypy_cmd.rs
+++ b/src/cmds/python/mypy_cmd.rs
@@ -164,7 +164,6 @@ pub fn filter_mypy_output(output: &str) -> String {
             errors.len(),
             by_file.len()
         ));
-        result.push_str("═══════════════════════════════════════\n");
 
         // Top error codes summary (only when 2+ distinct codes)
         let mut code_counts: Vec<_> = by_code.iter().collect();

--- a/src/cmds/python/pip_cmd.rs
+++ b/src/cmds/python/pip_cmd.rs
@@ -153,7 +153,6 @@ fn filter_pip_list(output: &str) -> String {
 
     let mut result = String::new();
     result.push_str(&format!("pip list: {} packages\n", packages.len()));
-    result.push_str("═══════════════════════════════════════\n");
 
     // Group by first letter for easier scanning
     let mut by_letter: std::collections::HashMap<char, Vec<&Package>> =
@@ -203,7 +202,6 @@ fn filter_pip_outdated(output: &str) -> String {
 
     let mut result = String::new();
     result.push_str(&format!("pip outdated: {} packages\n", packages.len()));
-    result.push_str("═══════════════════════════════════════\n");
 
     const MAX_PIP_PACKAGES: usize = CAP_LIST;
     for (i, pkg) in packages.iter().take(MAX_PIP_PACKAGES).enumerate() {

--- a/src/cmds/python/pytest_cmd.rs
+++ b/src/cmds/python/pytest_cmd.rs
@@ -202,7 +202,6 @@ fn build_pytest_summary(
         result.push_str(&format!(", {} xpassed", xpassed));
     }
     result.push('\n');
-    result.push_str("═══════════════════════════════════════\n");
 
     // Surface xfail/xpass entries (with their reasons) — XPASS in particular
     // signals that something expected-to-fail now passes.

--- a/src/cmds/python/ruff_cmd.rs
+++ b/src/cmds/python/ruff_cmd.rs
@@ -144,7 +144,6 @@ pub fn filter_ruff_check_json(output: &str) -> String {
         result.push_str(&format!(" ({} fixable)", fixable_count));
     }
     result.push('\n');
-    result.push_str("═══════════════════════════════════════\n");
 
     // Show top rules
     let mut rule_counts: Vec<_> = by_rule.iter().collect();
@@ -288,7 +287,6 @@ pub fn filter_ruff_format(output: &str) -> String {
                 "Ruff format: {} files need formatting\n",
                 files_to_format.len()
             ));
-            result.push_str("═══════════════════════════════════════\n");
 
             const MAX_RUFF_FORMAT_FILES: usize = CAP_WARNINGS;
             for (i, file) in files_to_format

--- a/src/cmds/ruby/rspec_cmd.rs
+++ b/src/cmds/ruby/rspec_cmd.rs
@@ -214,7 +214,6 @@ fn build_rspec_summary(rspec: &RspecOutput) -> String {
         result.push_str(&format!(", {} pending", s.pending_count));
     }
     result.push_str(&format!(" ({:.2}s)\n", s.duration));
-    result.push_str("═══════════════════════════════════════\n");
 
     let failures: Vec<&RspecExample> = rspec
         .examples
@@ -230,7 +229,7 @@ fn build_rspec_summary(rspec: &RspecOutput) -> String {
 
     for (i, example) in failures.iter().take(MAX_RSPEC_FAILURES).enumerate() {
         result.push_str(&format!(
-            "{}. ❌ {}\n   {}:{}\n",
+            "{}. ✗ {}\n   {}:{}\n",
             i + 1,
             example.full_description,
             example.file_path,
@@ -353,9 +352,8 @@ fn filter_rspec_text(output: &str) -> String {
             return format!("RSpec: {}", summary_line);
         }
         let mut result = format!("RSpec: {}\n", summary_line);
-        result.push_str("═══════════════════════════════════════\n\n");
         for (i, failure) in failures.iter().take(MAX_RSPEC_FAILURES).enumerate() {
-            result.push_str(&format!("{}. ❌ {}\n", i + 1, failure));
+            result.push_str(&format!("{}. ✗ {}\n", i + 1, failure));
             if i < failures.len().min(MAX_RSPEC_FAILURES) - 1 {
                 result.push('\n');
             }
@@ -596,7 +594,7 @@ mod tests {
     fn test_filter_rspec_with_failures() {
         let result = filter_rspec_output(with_failures_json());
         assert!(result.contains("1 passed, 1 failed"));
-        assert!(result.contains("❌ User saves to database"));
+        assert!(result.contains("✗ User saves to database"));
         assert!(result.contains("user_spec.rb:10"));
         assert!(result.contains("ExpectationNotMetError"));
         assert!(result.contains("expected true but got false"));
@@ -672,7 +670,7 @@ Failures:
         let result = filter_rspec_output(text);
         assert!(result.contains("RSpec:"));
         assert!(result.contains("4 examples, 1 failure"));
-        assert!(result.contains("❌"), "should show failure marker");
+        assert!(result.contains("✗"), "should show failure marker");
     }
 
     #[test]
@@ -698,7 +696,7 @@ Failures:
 "#;
         let result = filter_rspec_text(text);
         assert!(result.contains("2 failures"));
-        assert!(result.contains("❌"));
+        assert!(result.contains("✗"));
         // Should show spec file path, not gem backtrace
         assert!(result.contains("spec/models/user_spec.rb:15"));
     }
@@ -741,9 +739,9 @@ Failures:
           "summary_line": "6 examples, 6 failures"
         }"#;
         let result = filter_rspec_output(json);
-        assert!(result.contains("1. ❌"), "should show first failure");
-        assert!(result.contains("5. ❌"), "should show fifth failure");
-        assert!(!result.contains("6. ❌"), "should not show sixth inline");
+        assert!(result.contains("1. ✗"), "should show first failure");
+        assert!(result.contains("5. ✗"), "should show fifth failure");
+        assert!(!result.contains("6. ✗"), "should not show sixth inline");
         assert!(
             result.contains("+1 more"),
             "should show overflow count: {}",
@@ -946,9 +944,9 @@ Failures:
 14 examples, 7 failures
 "#;
         let result = filter_rspec_text(text);
-        assert!(result.contains("1. ❌"), "should show first failure");
-        assert!(result.contains("5. ❌"), "should show fifth failure");
-        assert!(!result.contains("6. ❌"), "should not show sixth inline");
+        assert!(result.contains("1. ✗"), "should show first failure");
+        assert!(result.contains("5. ✗"), "should show fifth failure");
+        assert!(!result.contains("6. ✗"), "should not show sixth inline");
         assert!(
             result.contains("+2 more"),
             "should show overflow count: {}",

--- a/src/cmds/rust/cargo_cmd.rs
+++ b/src/cmds/rust/cargo_cmd.rs
@@ -140,7 +140,7 @@ impl BlockHandler for CargoBuildHandler {
             Some(format!("{}\n", s))
         } else {
             Some(format!(
-                "═══════════════════════════════════════\ncargo build: {} errors, {} warnings ({} crates)\n",
+                "cargo build: {} errors, {} warnings ({} crates)\n",
                 self.error_count, self.warnings, self.compiled
             ))
         }
@@ -526,7 +526,6 @@ fn filter_cargo_install(output: &str) -> String {
                 deps_info
             ));
         }
-        result.push_str("═══════════════════════════════════════\n");
 
         const MAX_INSTALL_ERRORS: usize = CAP_ERRORS;
         for (i, err) in errors.iter().enumerate().take(MAX_INSTALL_ERRORS) {
@@ -834,7 +833,7 @@ fn filter_cargo_build(output: &str) -> String {
     }
 
     let mut result = format!(
-        "cargo build: {} errors, {} warnings ({} crates)\n═══════════════════════════════════════\n",
+        "cargo build: {} errors, {} warnings ({} crates)\n",
         handler.error_count, handler.warnings, handler.compiled
     );
     const MAX_CHECK_BLOCKS: usize = CAP_ERRORS;
@@ -1049,7 +1048,6 @@ pub(crate) fn filter_cargo_test(output: &str) -> String {
 
     if !failures.is_empty() {
         result.push_str(&format!("FAILURES ({}):\n", failures.len()));
-        result.push_str("═══════════════════════════════════════\n");
         const MAX_FAILURES: usize = CAP_WARNINGS;
         for (i, failure) in failures.iter().enumerate().take(MAX_FAILURES) {
             result.push_str(&format!("{}. {}\n", i + 1, truncate(failure, 200)));
@@ -1206,7 +1204,6 @@ fn filter_cargo_clippy(output: &str) -> String {
         "cargo clippy: {} errors, {} warnings\n",
         error_count, warning_count
     ));
-    result.push_str("═══════════════════════════════════════\n");
 
     // Show full error blocks so developers can see what needs fixing
     if !error_blocks.is_empty() {

--- a/src/cmds/system/format_cmd.rs
+++ b/src/cmds/system/format_cmd.rs
@@ -235,7 +235,6 @@ fn filter_black_output(output: &str) -> String {
             "Format (black): {} files need formatting\n",
             count
         ));
-        result.push_str("═══════════════════════════════════════\n");
 
         if !files_to_format.is_empty() {
             const MAX_FORMAT_FILES: usize = CAP_WARNINGS;


### PR DESCRIPTION
Separator lines (`═══`, `---`) and an emoji status marker added tokens to filtered output without giving the LLM any extra signal — the summary headers and section labels already delimit the content.

RTK output must never add noise over the raw command. This strips those decorators across the command filters, keeps the semantic labels (e.g. `Changes:`), and replaces the one emoji marker with plain monochrome unicode.

No behavior change beyond cleaner output. `cargo fmt`/`clippy` clean, all tests pass.