### PR TITLE
fix(lint): mark truncated parse fallbacks

### DIFF
--- a/src/cmds/go/golangci_cmd.rs
+++ b/src/cmds/go/golangci_cmd.rs
@@ -4,7 +4,8 @@ use crate::core::config;
 use crate::core::runner;
 use crate::core::stream::exec_capture;
 use crate::core::truncate::CAP_WARNINGS;
-use crate::core::utils::{resolved_command, truncate};
+use crate::core::utils::resolved_command;
+use crate::parser::truncate_output;
 use anyhow::Result;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -271,7 +272,7 @@ pub(crate) fn filter_golangci_json(output: &str, version: u32) -> String {
             return format!(
                 "golangci-lint (JSON parse failed: {})\n{}",
                 e,
-                truncate(output, config::limits().passthrough_max_chars)
+                truncate_output(output, config::limits().passthrough_max_chars)
             );
         }
     };
@@ -429,6 +430,18 @@ mod tests {
         assert!(result.contains("gosimple"));
         assert!(result.contains("main.go"));
         assert!(result.contains("utils.go"));
+    }
+
+    #[test]
+    fn test_filter_golangci_parse_failure_marks_truncated_passthrough() {
+        let long_invalid_json = "{".repeat(crate::core::config::limits().passthrough_max_chars + 20);
+        let result = filter_golangci_json(&long_invalid_json, 2);
+
+        assert!(result.contains("golangci-lint (JSON parse failed:"));
+        assert!(
+            result.contains("[RTK:PASSTHROUGH] Output truncated"),
+            "parse fallback should make truncation visible, got:\n{result}"
+        );
     }
 
     #[test]

--- a/src/cmds/python/ruff_cmd.rs
+++ b/src/cmds/python/ruff_cmd.rs
@@ -4,6 +4,7 @@ use crate::core::config;
 use crate::core::runner;
 use crate::core::truncate::CAP_WARNINGS;
 use crate::core::utils::{resolved_command, truncate};
+use crate::parser::truncate_output;
 use anyhow::Result;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -101,7 +102,7 @@ pub fn filter_ruff_check_json(output: &str) -> String {
             return format!(
                 "Ruff check (JSON parse failed: {})\n{}",
                 e,
-                truncate(output, config::limits().passthrough_max_chars)
+                truncate_output(output, config::limits().passthrough_max_chars)
             );
         }
     };
@@ -385,6 +386,18 @@ mod tests {
         assert!(result.contains("utils.py"));
         assert!(result.contains("Violations:"), "Violations section missing");
         assert!(result.contains("1:8"), "line:col location missing");
+    }
+
+    #[test]
+    fn test_filter_ruff_check_parse_failure_marks_truncated_passthrough() {
+        let long_invalid_json = "{".repeat(crate::core::config::limits().passthrough_max_chars + 20);
+        let result = filter_ruff_check_json(&long_invalid_json);
+
+        assert!(result.contains("Ruff check (JSON parse failed:"));
+        assert!(
+            result.contains("[RTK:PASSTHROUGH] Output truncated"),
+            "parse fallback should make truncation visible, got:\n{result}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #2204 for the lint fallback paths that still used silent character truncation when structured output parsing failed.

- use the existing passthrough truncation marker for Ruff JSON parse failures
- use the existing passthrough truncation marker for golangci-lint JSON parse failures
- add regression tests so long malformed JSON output visibly reports `[RTK:PASSTHROUGH] Output truncated`

This does not overlap with #2205, which focuses on git log output.

## Validation

- `cargo fmt --check`
- `cargo test cmds::python::ruff_cmd::tests`
- `cargo test cmds::go::golangci_cmd::tests`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

## AI assistance

I used Codex to help prepare this patch, reviewed the diff, and ran the validation commands above locally.
