### PR TITLE
fix(filter-quality): preserve error signal in go test/vet/golangci filters

### DIFF
--- a/src/cmds/go/go_cmd.rs
+++ b/src/cmds/go/go_cmd.rs
@@ -71,12 +71,16 @@ pub fn run_test(args: &[String], verbose: u8) -> Result<i32> {
         filter_go_test_json
     };
 
+    // No tee: the raw stream is `go test -json` (3–8× more verbose than native
+    // output). A `[full output: …go_test.log]` pointer just advertises that
+    // firehose — agents cat it and pull back more bytes than the unfiltered run.
+    // The filter surfaces build errors and per-test failure detail inline instead.
     runner::run_filtered(
         cmd,
         "go test",
         &args.join(" "),
         filter,
-        crate::core::runner::RunOptions::stdout_only().tee("go_test"),
+        crate::core::runner::RunOptions::stdout_only(),
     )
 }
 
@@ -279,6 +283,27 @@ fn run_go_tool_golangci_lint(args: &[OsString], verbose: u8) -> Result<i32> {
         &*stdout
     };
 
+    let exit_code = exit_code_from_output(&output, "go tool golangci-lint");
+    // golangci-lint: exit 0 = clean, exit 1 = lint issues found (not an error),
+    // exit 2+ = config/build error, None = killed by signal (OOM, SIGKILL)
+    let mapped_exit = if exit_code == 1 { 0 } else { exit_code };
+
+    // User chose their own output format — emit it verbatim rather than parsing
+    // it as JSON (which would fail and surface a parse-error string).
+    if has_format {
+        print!("{}", stdout);
+        if !stderr.trim().is_empty() {
+            eprint!("{}", stderr);
+        }
+        timer.track(
+            "go tool golangci-lint",
+            "rtk go tool golangci-lint (passthrough)",
+            &raw,
+            &raw,
+        );
+        return Ok(mapped_exit);
+    }
+
     let filtered = golangci_cmd::filter_golangci_json(json_output, version);
     println!("{}", filtered);
 
@@ -293,10 +318,7 @@ fn run_go_tool_golangci_lint(args: &[OsString], verbose: u8) -> Result<i32> {
         &filtered,
     );
 
-    let exit_code = exit_code_from_output(&output, "go tool golangci-lint");
-    // golangci-lint: exit 0 = clean, exit 1 = lint issues found (not an error),
-    // exit 2+ = config/build error, None = killed by signal (OOM, SIGKILL)
-    Ok(if exit_code == 1 { 0 } else { exit_code })
+    Ok(mapped_exit)
 }
 
 /// Parse go test -json output (NDJSON format)
@@ -697,35 +719,39 @@ fn is_go_build_error_line(line: &str) -> bool {
         || lower.contains("function main is undeclared in the main package")
 }
 
-/// Filter go vet output - show issues
+/// Filter go vet output - show issues.
+///
+/// vet only prints when something is wrong, so every non-`#` line is signal —
+/// including location-less compiler/cgo failures (`fatal error: …`) that have
+/// no `.go:`. Filtering on `.go:` dropped those and reported "No issues found"
+/// on a hard failure; truncation cut the message tail an agent retries to read.
 fn filter_go_vet(output: &str) -> String {
-    let mut issues: Vec<String> = Vec::new();
-
-    for line in output.lines() {
-        let trimmed = line.trim();
-
-        // Collect issue lines (vet reports issues with file:line:col format)
-        if !trimmed.is_empty() && !trimmed.starts_with('#') && trimmed.contains(".go:") {
-            issues.push(trimmed.to_string());
-        }
-    }
+    let issues: Vec<&str> = output
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .collect();
 
     if issues.is_empty() {
         return "Go vet: No issues found".to_string();
     }
 
-    let mut result = String::new();
-    result.push_str(&format!("Go vet: {} issues\n", issues.len()));
+    let mut result = format!("Go vet: {} issues\n", issues.len());
 
     const MAX_GO_VET_ISSUES: usize = CAP_ERRORS;
     for (i, issue) in issues.iter().take(MAX_GO_VET_ISSUES).enumerate() {
-        result.push_str(&format!("{}. {}\n", i + 1, truncate(issue, 120)));
+        result.push_str(&format!("{}. {}\n", i + 1, issue));
     }
 
     if issues.len() > MAX_GO_VET_ISSUES {
-        result.push_str(&format!("\n… +{} more issues\n", issues.len() - MAX_GO_VET_ISSUES));
+        result.push_str(&format!(
+            "\n… +{} more issues\n",
+            issues.len() - MAX_GO_VET_ISSUES
+        ));
         let all_issues = issues.join("\n");
-        if let Some(hint) = crate::core::tee::force_tee_tail_hint(&all_issues, "go-vet", MAX_GO_VET_ISSUES + 1) {
+        if let Some(hint) =
+            crate::core::tee::force_tee_tail_hint(&all_issues, "go-vet", MAX_GO_VET_ISSUES + 1)
+        {
             result.push_str(&format!("  {}\n", hint));
         }
     }
@@ -902,6 +928,36 @@ mod tests {
     }
 
     #[test]
+    fn test_filter_go_test_surfaces_cgo_build_error_inline() {
+        // A cgo build failure (missing C header) must show the compiler error
+        // line inline — this is the one actionable fact. With no tee pointer,
+        // the agent has no firehose to fall back to, so the signal must be here.
+        let output = r##"{"Action":"start","Package":"example.com/sniff"}
+{"ImportPath":"example.com/sniff","Action":"build-output","Output":"# example.com/sniff\n"}
+{"ImportPath":"example.com/sniff","Action":"build-output","Output":"./capture.go:7:11: fatal error: pcap.h: No such file or directory\n"}
+{"ImportPath":"example.com/sniff","Action":"build-fail"}
+{"Package":"example.com/sniff","Action":"fail","FailedBuild":"example.com/sniff"}"##;
+
+        let result = filter_go_test_json(output);
+        assert!(
+            result.contains("[build failed]"),
+            "Expected build-failed marker, got: {}",
+            result
+        );
+        assert!(
+            result.contains("pcap.h: No such file or directory"),
+            "Compiler error line must survive inline, got: {}",
+            result
+        );
+        // The "# package" header is noise and should be dropped.
+        assert!(
+            !result.contains("# example.com/sniff"),
+            "Package header should be stripped, got: {}",
+            result
+        );
+    }
+
+    #[test]
     fn test_filter_go_build_success() {
         let output = "";
         let result = filter_go_build(output);
@@ -1067,6 +1123,45 @@ utils.go:15:5: unreachable code"#;
         assert!(result.contains("2 issues"));
         assert!(result.contains("Printf format"));
         assert!(result.contains("unreachable code"));
+    }
+
+    #[test]
+    fn test_filter_go_vet_preserves_location_less_cgo_error() {
+        // cgo/compiler failures have no `.go:` anchor — the old `.go:`-only
+        // filter dropped them and reported "No issues found" on a hard failure.
+        let output = r#"# example.com/sniff
+fatal error: pcap.h: No such file or directory
+compilation terminated."#;
+
+        let result = filter_go_vet(output);
+        assert!(
+            !result.contains("No issues found"),
+            "Must not claim success on a cgo failure, got: {}",
+            result
+        );
+        assert!(
+            result.contains("fatal error: pcap.h: No such file or directory"),
+            "Compiler error line must survive, got: {}",
+            result
+        );
+        assert!(
+            !result.contains("# example.com/sniff"),
+            "Package header should be stripped, got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_filter_go_vet_does_not_truncate_long_message() {
+        // The actionable detail of a `could not import` line lives at its tail;
+        // a mid-message cut is exactly what an agent retries to recover.
+        let long = "./capture.go:9:2: could not import github.com/google/gopacket/pcap (-: # github.com/google/gopacket/pcap: fatal error: pcap.h: No such file or directory)";
+        let result = filter_go_vet(long);
+        assert!(
+            result.contains("pcap.h: No such file or directory"),
+            "Message tail must not be truncated, got: {}",
+            result
+        );
     }
 
     #[test]

--- a/src/cmds/go/golangci_cmd.rs
+++ b/src/cmds/go/golangci_cmd.rs
@@ -3,7 +3,7 @@
 use crate::core::config;
 use crate::core::runner;
 use crate::core::stream::exec_capture;
-use crate::core::truncate::CAP_WARNINGS;
+use crate::core::truncate::CAP_ERRORS;
 use crate::core::utils::{resolved_command, truncate};
 use anyhow::Result;
 use serde::Deserialize;
@@ -50,10 +50,8 @@ struct Position {
     #[serde(rename = "Filename")]
     filename: String,
     #[serde(rename = "Line")]
-    #[allow(dead_code)]
     line: usize,
     #[serde(rename = "Column")]
-    #[allow(dead_code)]
     column: usize,
     #[serde(rename = "Offset", default)]
     #[allow(dead_code)]
@@ -65,7 +63,6 @@ struct Issue {
     #[serde(rename = "FromLinter")]
     from_linter: String,
     #[serde(rename = "Text")]
-    #[allow(dead_code)]
     text: String,
     #[serde(rename = "Pos")]
     pos: Position,
@@ -119,6 +116,12 @@ pub(crate) fn detect_major_version() -> u32 {
 
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     match classify_invocation(args) {
+        // A user-chosen output format wins: forcing our JSON parse onto a
+        // non-JSON format breaks and emits a parse-error string that reads as a
+        // tool failure. Honor what they asked for verbatim.
+        Invocation::FilteredRun(invocation) if has_output_flag(&invocation.run_args) => {
+            run_passthrough(args, verbose)
+        }
         Invocation::FilteredRun(invocation) => run_filtered(args, &invocation, verbose),
         Invocation::Passthrough => run_passthrough(args, verbose),
     }
@@ -261,19 +264,17 @@ fn format_command(base: &str, args: &[String]) -> String {
     }
 }
 
-/// Filter golangci-lint JSON output - group by linter and file
+/// Filter golangci-lint JSON output into standard `file:line:col: message (linter)`
+/// findings, with per-linter counts as a header.
 pub(crate) fn filter_golangci_json(output: &str, version: u32) -> String {
     let result: Result<GolangciOutput, _> = serde_json::from_str(output);
 
     let golangci_output = match result {
         Ok(o) => o,
-        Err(e) => {
-            return format!(
-                "golangci-lint (JSON parse failed: {})\n{}",
-                e,
-                truncate(output, config::limits().passthrough_max_chars)
-            );
-        }
+        // Not JSON (user-supplied output format, or an unexpected shape): hand
+        // back the linter's own output rather than a "JSON parse failed" string
+        // that reads as a tool failure and provokes retries.
+        Err(_) => return truncate(output.trim(), config::limits().passthrough_max_chars),
     };
 
     let issues = golangci_output.issues;
@@ -283,88 +284,57 @@ pub(crate) fn filter_golangci_json(output: &str, version: u32) -> String {
     }
 
     let total_issues = issues.len();
-
-    // Count unique files
     let unique_files: std::collections::HashSet<_> =
         issues.iter().map(|i| &i.pos.filename).collect();
     let total_files = unique_files.len();
 
-    // Group by linter
-    let mut by_linter: HashMap<String, usize> = HashMap::new();
+    let mut by_linter: HashMap<&str, usize> = HashMap::new();
     for issue in &issues {
-        *by_linter.entry(issue.from_linter.clone()).or_insert(0) += 1;
+        *by_linter.entry(issue.from_linter.as_str()).or_insert(0) += 1;
     }
+    let mut linter_counts: Vec<_> = by_linter.into_iter().collect();
+    linter_counts.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+    let linters_summary = linter_counts
+        .iter()
+        .map(|(linter, count)| format!("{} ({}x)", linter, count))
+        .collect::<Vec<_>>()
+        .join(", ");
 
-    // Group by file
-    let mut by_file: HashMap<&str, usize> = HashMap::new();
-    for issue in &issues {
-        *by_file.entry(issue.pos.filename.as_str()).or_insert(0) += 1;
-    }
+    let mut result = format!(
+        "golangci-lint: {} issues in {} files\nLinters: {}\n\n",
+        total_issues, total_files, linters_summary
+    );
 
-    let mut file_counts: Vec<_> = by_file.iter().collect();
-    file_counts.sort_by(|a, b| b.1.cmp(a.1));
+    const MAX_GOLANGCI_ISSUES: usize = CAP_ERRORS;
+    for issue in issues.iter().take(MAX_GOLANGCI_ISSUES) {
+        result.push_str(&format!(
+            "{}:{}:{}: {} ({})\n",
+            compact_path(&issue.pos.filename),
+            issue.pos.line,
+            issue.pos.column,
+            issue.text.trim(),
+            issue.from_linter,
+        ));
 
-    // Build output
-    let mut result = String::new();
-    result.push_str(&format!(
-        "golangci-lint: {} issues in {} files\n",
-        total_issues, total_files
-    ));
-
-    // Show top linters
-    let mut linter_counts: Vec<_> = by_linter.iter().collect();
-    linter_counts.sort_by(|a, b| b.1.cmp(a.1));
-
-    if !linter_counts.is_empty() {
-        result.push_str("Top linters:\n");
-        for (linter, count) in linter_counts.iter().take(10) {
-            result.push_str(&format!("  {} ({}x)\n", linter, count));
-        }
-        result.push('\n');
-    }
-
-    // Show top files
-    const MAX_GOLANGCI_FILES: usize = CAP_WARNINGS;
-    result.push_str("Top files:\n");
-    for (file, count) in file_counts.iter().take(MAX_GOLANGCI_FILES) {
-        let short_path = compact_path(file);
-        result.push_str(&format!("  {} ({} issues)\n", short_path, count));
-
-        // Show top 3 linters in this file
-        let mut file_linters: HashMap<String, Vec<&Issue>> = HashMap::new();
-        for issue in issues.iter().filter(|i| i.pos.filename.as_str() == **file) {
-            file_linters
-                .entry(issue.from_linter.clone())
-                .or_default()
-                .push(issue);
-        }
-
-        let mut file_linter_counts: Vec<_> = file_linters.iter().collect();
-        file_linter_counts.sort_by_key(|b| std::cmp::Reverse(b.1.len()));
-
-        for (linter, linter_issues) in file_linter_counts.iter().take(3) {
-            result.push_str(&format!("    {} ({})\n", linter, linter_issues.len()));
-
-            // v2 only: show first source line for this linter-file group
-            if version >= 2 {
-                if let Some(first_issue) = linter_issues.first() {
-                    if let Some(source_line) = first_issue.source_lines.first() {
-                        let trimmed = source_line.trim();
-                        let display = match trimmed.char_indices().nth(80) {
-                            Some((i, _)) => &trimmed[..i],
-                            None => trimmed,
-                        };
-                        result.push_str(&format!("      → {}\n", display));
-                    }
+        // v2 carries the offending source line — keep it as secondary context.
+        if version >= 2 {
+            if let Some(source_line) = issue.source_lines.first() {
+                let trimmed = source_line.trim();
+                if !trimmed.is_empty() {
+                    let display = match trimmed.char_indices().nth(80) {
+                        Some((i, _)) => &trimmed[..i],
+                        None => trimmed,
+                    };
+                    result.push_str(&format!("    → {}\n", display));
                 }
             }
         }
     }
 
-    if file_counts.len() > MAX_GOLANGCI_FILES {
+    if total_issues > MAX_GOLANGCI_ISSUES {
         result.push_str(&format!(
-            "\n... +{} more files\n",
-            file_counts.len() - MAX_GOLANGCI_FILES
+            "\n... +{} more issues\n",
+            total_issues - MAX_GOLANGCI_ISSUES
         ));
     }
 
@@ -429,6 +399,48 @@ mod tests {
         assert!(result.contains("gosimple"));
         assert!(result.contains("main.go"));
         assert!(result.contains("utils.go"));
+    }
+
+    #[test]
+    fn test_filter_golangci_surfaces_message_and_location() {
+        // The violation message (Text) is the actionable signal — counts alone
+        // forced agents to retry to recover it.
+        let output = r#"{
+  "Issues": [
+    {
+      "FromLinter": "typecheck",
+      "Text": "could not import github.com/google/gopacket/pcap (fatal error: pcap.h: No such file or directory)",
+      "Pos": {"Filename": "internal/sniff/capture.go", "Line": 9, "Column": 2}
+    }
+  ]
+}"#;
+
+        let result = filter_golangci_json(output, 1);
+        assert!(
+            result.contains("capture.go:9:2:"),
+            "Expected file:line:col, got: {}",
+            result
+        );
+        assert!(
+            result.contains("pcap.h: No such file or directory"),
+            "Expected the violation message, got: {}",
+            result
+        );
+        assert!(
+            result.contains("(typecheck)"),
+            "Expected the linter name per finding, got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_filter_golangci_parse_failure_is_clean_passthrough() {
+        // A non-JSON payload (e.g. user-supplied --out-format) must not emit a
+        // scary "JSON parse failed" string that reads as a tool failure.
+        let raw = "internal/foo.go:10:2: something is wrong (govet)";
+        let result = filter_golangci_json(raw, 1);
+        assert!(!result.contains("parse failed"), "got: {}", result);
+        assert!(result.contains("something is wrong"), "got: {}", result);
     }
 
     #[test]
@@ -550,6 +562,16 @@ mod tests {
             classify_invocation(&["version".into()]),
             Invocation::Passthrough
         );
+    }
+
+    #[test]
+    fn test_has_output_flag_detects_user_formats() {
+        assert!(has_output_flag(&["--out-format=line-number".into()]));
+        assert!(has_output_flag(&["--out-format".into(), "tab".into()]));
+        assert!(has_output_flag(&["--output.json.path".into(), "out.json".into()]));
+        assert!(has_output_flag(&["--output.json.path=out.json".into()]));
+        assert!(!has_output_flag(&["./...".into()]));
+        assert!(!has_output_flag(&["--fix".into()]));
     }
 
     #[test]
@@ -721,3 +743,4 @@ mod tests {
         );
     }
 }
+


### PR DESCRIPTION
## Problem

These three Go filters all caused agent retries with the same root cause: RTK kept the **cosmetic summary** but dropped the **one actionable line** (the error/failure message), then advertised a verbose tee-log. So agents retried — `cat`/`tail`/`grep`-ing the firehose or re-running with `--out-format` overrides — pulling back **more bytes than the unfiltered output**.

## Fixes (all in `src/cmds/go/`)

| Filter | Before | After |
|--------|--------|-------|
| **go test** | summary + `[full output: …go_test.log]` pointer to the raw `go test -json` dump (3–8× verbose); agents `cat`'d it on failure | drop the tee — build errors & per-test failures are already inline |
| **go vet** | only `.go:` lines kept → location-less `fatal error: pcap.h: No such file or directory` dropped, then **"No issues found"** on a hard failure; message truncated mid-line | keep every finding line; never claim success on failure; no mid-message truncation |
| **golangci-lint** | counts grouped by linter/file — the violation message (`Text`) was parsed and **discarded** | standard `file:line:col: message (linter)` findings, linter counts as a header |
| **golangci-lint** | force-parsed JSON even when the user passed `--out-format`, emitting `golangci-lint (JSON parse failed: …)` (reads as a tool failure) | passthrough verbatim on user `--out-format`/`--output.*` flags |

## Compression

Savings stay high vs raw — golangci **78–84%** (was a misleading ~93% that omitted the message). `go vet` passes tiny failures through at ~0% **by design**: compressing 323 B costs a retry turn for no gain. `go test` compression slightly *improved* (pointer removed). The lost percentage points are repaid many times over by eliminating the 12–169 KB retry reads the missing signal caused.

## Out of scope

Cross-cutting idempotency items (pipe-awareness, re-run escalation, full-path basename matching) live in the hook/rewrite + session-state layer, not these filters — left for a follow-up.

## Testing

- `cargo fmt --all` · `cargo clippy --all-targets` (clean) · `cargo test --all` → **2073 passed, 0 failed, 7 ignored**
- New tests: cgo build-failure surfaces inline (go test); location-less cgo error + no mid-message truncation (go vet); message+location surfaced + clean parse-failure passthrough + format-flag detection (golangci)
