### PR TITLE
fix(core): stop capture hanging on orphaned pipes

### DIFF
--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -2,6 +2,8 @@ use anyhow::{Context, Result};
 use std::io::{self, BufRead, BufReader, BufWriter, Write};
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 #[cfg(test)]
 use regex::Regex;
@@ -241,8 +243,198 @@ pub fn status_to_exit_code(status: std::process::ExitStatus) -> i32 {
     1
 }
 
+/// Collapse single-line terminal redraw controls to the final rendered text before
+/// filters parse output. Models a one-line cursor: `\r` returns to column 0, `\b` moves
+/// left, printable chars overlay at the cursor, `\n` commits the line.
+///
+/// CSI escape sequences (`ESC [ … final`) are parsed as a *unit* — this is the fix for the
+/// real defect: erase-in-line (`ESC [ K`) is honored against the cursor, so a *shrinking*
+/// redraw (`\r` + erase, the way programs clean up a longer previous frame) resolves
+/// correctly instead of leaving a stale tail or leaking the literal escape bytes. A bare
+/// `\r` overlay alone cannot express that erase, which is why the previous frame's tail
+/// survived before this fix.
+///
+/// Every *other* CSI sequence (SGR colour, cursor motion) is overlaid through the SAME
+/// write path as printable text — collapse does not strip colour (that is `strip_ansi`'s
+/// separate, config-gated job), and a later `\r` redraw overwrites prior escape bytes cell
+/// for cell rather than shifting them, so a same-or-longer coloured redraw resolves cleanly.
+///
+/// Scope boundary: this models the *cursor*, not per-cell colour *attributes*. So a
+/// genuinely *shorter* coloured frame overlaying a longer one can leave a trailing reset
+/// (`ESC[0m`) from the prior frame in the collapsed bytes — harmless, and `strip_ansi`
+/// removes it downstream where it matters. Tracking that would require a full VT attribute
+/// model, which is out of scope (rtk is not a terminal emulator).
+fn collapse_terminal_control(text: &str) -> String {
+    let mut visible = String::new();
+    let mut line: Vec<char> = Vec::new();
+    let mut cursor = 0usize;
+    let mut chars = text.chars().peekable();
+
+    // Overlay one char at the cursor (shared by printable chars and re-emitted escapes),
+    // padding with spaces if the cursor was advanced past the current end (e.g. post-erase).
+    let overlay = |line: &mut Vec<char>, cursor: &mut usize, ch: char| {
+        while line.len() < *cursor {
+            line.push(' ');
+        }
+        if *cursor < line.len() {
+            line[*cursor] = ch;
+        } else {
+            line.push(ch);
+        }
+        *cursor += 1;
+    };
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\r' if chars.peek() == Some(&'\n') => {
+                chars.next();
+                visible.extend(line.drain(..));
+                visible.push('\n');
+                cursor = 0;
+            }
+            '\r' => {
+                cursor = 0;
+            }
+            '\n' => {
+                visible.extend(line.drain(..));
+                visible.push('\n');
+                cursor = 0;
+            }
+            '\u{8}' => {
+                cursor = cursor.saturating_sub(1);
+            }
+            '\u{1b}' => {
+                // Escape. Parse a CSI sequence (ESC '[' params… final) as a unit. A CSI
+                // final byte is 0x40–0x7E; bytes before it are parameter/intermediate bytes.
+                if chars.peek() == Some(&'[') {
+                    chars.next(); // consume '['
+                    let mut params = String::new();
+                    let final_byte = loop {
+                        match chars.next() {
+                            Some(c) if ('\u{40}'..='\u{7e}').contains(&c) => break Some(c),
+                            Some(c) => params.push(c),
+                            None => break None, // truncated sequence at EOF
+                        }
+                    };
+                    match final_byte {
+                        // Erase-in-line — the operation collapse exists to honor.
+                        Some('K') => match params.as_str() {
+                            "" | "0" => line.truncate(cursor), // cursor → end of line
+                            "1" => {
+                                for cell in line.iter_mut().take(cursor + 1) {
+                                    *cell = ' '; // start of line → cursor
+                                }
+                            }
+                            "2" => line.clear(), // whole line
+                            _ => line.truncate(cursor),
+                        },
+                        // Any other CSI: overlay the sequence verbatim through the SAME write
+                        // path as printable text, so colour passes through unchanged (prior
+                        // contract) and a later `\r` redraw overwrites it rather than shifting.
+                        Some(fb) => {
+                            overlay(&mut line, &mut cursor, '\u{1b}');
+                            overlay(&mut line, &mut cursor, '[');
+                            for c in params.chars() {
+                                overlay(&mut line, &mut cursor, c);
+                            }
+                            overlay(&mut line, &mut cursor, fb);
+                        }
+                        None => {} // truncated at EOF — drop
+                    }
+                }
+                // A lone ESC (not a CSI) is dropped — zero-width control data.
+            }
+            ch => {
+                overlay(&mut line, &mut cursor, ch);
+            }
+        }
+    }
+
+    visible.extend(line);
+    visible
+}
+
 // ISSUE #897: ChildGuard RAII prevents zombie processes that caused kernel panic
 pub const RAW_CAP: usize = 10_485_760; // 10 MiB
+
+// After the direct child exits, a descendant may still hold the captured pipe open
+// (e.g. `ng build` leaves an `esbuild --service` grandchild on node's stderr). Reading
+// until pipe EOF would then block forever, so we wait on the direct child and only
+// briefly drain whatever is already buffered. See docs/pr_briefs/004-pipe-eof-grandchild-hang.
+const STREAM_POST_EXIT_IDLE_GRACE: Duration = Duration::from_millis(200);
+const STREAM_POST_EXIT_MAX_DRAIN: Duration = Duration::from_secs(2);
+
+/// Spawn a background thread that reads a child pipe line-by-line into a shared buffer,
+/// appending `\n` after each line and honoring [`RAW_CAP`]. Signals `done_tx` once the
+/// pipe reaches EOF. The buffer is readable at any time, so a caller can recover output
+/// already collected even if the thread is still blocked on a pipe held open by a
+/// detached grandchild. Terminal redraw controls are collapsed by the caller on the
+/// final buffer (see [`collapse_terminal_control`]).
+fn spawn_capture_reader<R: io::Read + Send + 'static>(
+    pipe: R,
+    label: &'static str,
+    done_tx: mpsc::Sender<()>,
+) -> Arc<Mutex<String>> {
+    let buf = Arc::new(Mutex::new(String::new()));
+    let buf_for_thread = Arc::clone(&buf);
+    std::thread::spawn(move || {
+        let mut capped = false;
+        for line in BufReader::new(pipe).lines().map_while(Result::ok) {
+            let mut b = buf_for_thread.lock().expect("capture buffer lock poisoned");
+            if b.len() + line.len() < RAW_CAP {
+                b.push_str(&line);
+                b.push('\n');
+            } else if !capped {
+                capped = true;
+                eprintln!("[rtk] warning: {label} exceeds 10 MiB — capture truncated");
+            }
+        }
+        let _ = done_tx.send(());
+    });
+    buf
+}
+
+/// Block until both reader threads report EOF, OR the captured output goes idle for
+/// [`STREAM_POST_EXIT_IDLE_GRACE`] after the child has already exited, OR the overall
+/// [`STREAM_POST_EXIT_MAX_DRAIN`] cap is hit. Called only after the direct child exits,
+/// so a still-open pipe held by a descendant can no longer cause an unbounded wait.
+fn drain_capture_readers(
+    done_rx: &mpsc::Receiver<()>,
+    stdout_buf: &Arc<Mutex<String>>,
+    stderr_buf: &Arc<Mutex<String>>,
+) {
+    let captured_len = |a: &Arc<Mutex<String>>, b: &Arc<Mutex<String>>| {
+        a.lock().expect("capture buffer lock poisoned").len()
+            + b.lock().expect("capture buffer lock poisoned").len()
+    };
+    let started = Instant::now();
+    let mut completed = 0;
+    let mut last_len = captured_len(stdout_buf, stderr_buf);
+
+    while completed < 2 && started.elapsed() < STREAM_POST_EXIT_MAX_DRAIN {
+        match done_rx.recv_timeout(STREAM_POST_EXIT_IDLE_GRACE) {
+            Ok(()) => completed += 1,
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                let current_len = captured_len(stdout_buf, stderr_buf);
+                if current_len == last_len {
+                    break; // no new output during the grace window — descendant holds the pipe
+                }
+                last_len = current_len;
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+}
+
+/// Join a reader thread only if it has already finished; otherwise leave it detached.
+/// A thread still blocked in `pipe.read()` on a pipe held open by a detached descendant
+/// would block `join()` indefinitely — the exact hang we are avoiding — so we never wait
+/// on an unfinished reader.
+fn try_join_finished(handle: std::thread::JoinHandle<()>) {
+    if handle.is_finished() {
+        handle.join().ok();
+    }
+}
 
 pub fn run_streaming(
     cmd: &mut Command,
@@ -361,11 +553,44 @@ pub fn run_streaming(
             let stderr_handle = io::stderr();
             let mut err_out = stderr_handle.lock();
 
-            for msg in rx {
+            // Consume streamed lines, but never block on pipe EOF: once the DIRECT child
+            // has exited, only drain briefly. A descendant that inherited the pipe (e.g.
+            // `ng build`'s esbuild service) keeps the write-end open forever, so a plain
+            // `for msg in rx` would hang. We poll the channel and, on an idle gap, check
+            // the child via try_wait (which caches the reaped status for the wait() below).
+            let mut child_exited_at: Option<Instant> = None;
+            'consume: loop {
+                let msg = match rx.recv_timeout(STREAM_POST_EXIT_IDLE_GRACE) {
+                    Ok(msg) => msg,
+                    Err(mpsc::RecvTimeoutError::Disconnected) => break, // both readers hit EOF
+                    Err(mpsc::RecvTimeoutError::Timeout) => {
+                        if child_exited_at.is_none() {
+                            if let Some(_status) =
+                                child.0.try_wait().context("Failed to poll child")?
+                            {
+                                child_exited_at = Some(Instant::now());
+                            }
+                        }
+                        // Child exited and the stream went idle for a full grace window →
+                        // remaining writers are detached descendants; stop draining.
+                        if child_exited_at.is_some() {
+                            break;
+                        }
+                        continue;
+                    }
+                };
+                // Hard cap: even if a descendant keeps emitting after the child exited,
+                // don't drain forever.
+                if let Some(t) = child_exited_at {
+                    if t.elapsed() > STREAM_POST_EXIT_MAX_DRAIN {
+                        break;
+                    }
+                }
                 let (line, is_stderr) = match msg {
                     StreamLine::Stderr(l) => (l, true),
                     StreamLine::Stdout(l) => (l, false),
                 };
+                let line = collapse_terminal_control(&line);
                 if is_stderr {
                     if !capped_err {
                         if raw_stderr.len() + line.len() < RAW_CAP {
@@ -390,7 +615,7 @@ pub fn run_streaming(
                     filtered.push_str(&output);
                     let dest: &mut dyn Write = if is_stderr { &mut err_out } else { &mut out };
                     match write!(dest, "{}", output) {
-                        Err(e) if e.kind() == io::ErrorKind::BrokenPipe => break,
+                        Err(e) if e.kind() == io::ErrorKind::BrokenPipe => break 'consume,
                         Err(e) => return Err(e.into()),
                         Ok(_) => {}
                     }
@@ -411,75 +636,81 @@ pub fn run_streaming(
             saved_filter = Some(filter);
         }
 
-        stdout_thread.join().ok();
-        stderr_thread.join().ok();
+        // Drop our receiver so any reader thread still blocked in `send()` unblocks and
+        // exits. A thread blocked in `pipe.read()` on a pipe held open by a detached
+        // descendant cannot be force-joined without blocking us again, so we deliberately
+        // do NOT join it here — it exits when the pipe finally closes. `try_join_finished`
+        // only waits on threads that have already finished.
+        drop(rx);
+        try_join_finished(stdout_thread);
+        try_join_finished(stderr_thread);
     } else {
-        let stderr_thread = std::thread::spawn(move || -> String {
-            let mut raw_err = String::new();
-            let mut capped = false;
-            for line in BufReader::new(stderr).lines().map_while(Result::ok) {
-                if raw_err.len() + line.len() < RAW_CAP {
-                    raw_err.push_str(&line);
-                    raw_err.push('\n');
-                } else if !capped {
-                    capped = true;
+        // Non-streaming capture (Buffered / CaptureOnly). Read both pipes on background
+        // threads, then wait on the DIRECT child and only briefly drain afterwards, so a
+        // descendant that inherited the pipe (e.g. esbuild) can't cause an unbounded wait.
+        let (done_tx, done_rx) = mpsc::channel();
+        let stdout_buf = spawn_capture_reader(stdout, "output", done_tx.clone());
+        let stderr_buf = spawn_capture_reader(stderr, "stderr", done_tx);
+
+        let status = child.0.wait().context("Failed to wait for child")?;
+        drain_capture_readers(&done_rx, &stdout_buf, &stderr_buf);
+        if let Some(t) = stdin_thread {
+            t.join().ok();
+        }
+
+        // Collapse terminal redraw controls on the final buffers (matches the streaming
+        // path and exec_capture); see collapse_terminal_control / upstream #2581.
+        raw_stdout = collapse_terminal_control(&std::mem::take(
+            &mut *stdout_buf.lock().expect("capture buffer lock poisoned"),
+        ));
+        raw_stderr = collapse_terminal_control(&std::mem::take(
+            &mut *stderr_buf.lock().expect("capture buffer lock poisoned"),
+        ));
+
+        let stdout_handle = io::stdout();
+        let mut out = stdout_handle.lock();
+        match stdout_mode {
+            FilterMode::Passthrough => unreachable!("handled by early-return above"),
+            FilterMode::Streaming(_) => unreachable!("handled by is_streaming branch"),
+            FilterMode::Buffered(filter_fn) => {
+                filtered = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    filter_fn(&raw_stdout)
+                }))
+                .unwrap_or_else(|_| {
+                    eprintln!("[rtk] warning: filter panicked — passing through raw output");
+                    raw_stdout.clone()
+                });
+                match write!(out, "{}", filtered) {
+                    Err(e) if e.kind() == io::ErrorKind::BrokenPipe => {}
+                    Err(e) => return Err(e.into()),
+                    Ok(_) => {}
                 }
             }
-            raw_err
-        });
+            FilterMode::CaptureOnly => {
+                filtered = raw_stdout.clone();
+            }
+        }
 
-        {
-            let stdout_handle = io::stdout();
-            let mut out = stdout_handle.lock();
+        let exit_code = status_to_exit_code(status);
+        let raw = format!("{}{}", raw_stdout, raw_stderr);
 
-            match stdout_mode {
-                FilterMode::Passthrough => unreachable!("handled by early-return above"),
-                FilterMode::Streaming(_) => unreachable!("handled by is_streaming branch"),
-                FilterMode::Buffered(filter_fn) => {
-                    for line in BufReader::new(stdout).lines().map_while(Result::ok) {
-                        if raw_stdout.len() + line.len() < RAW_CAP {
-                            raw_stdout.push_str(&line);
-                            raw_stdout.push('\n');
-                        } else if !capped_out {
-                            capped_out = true;
-                            eprintln!(
-                                "[rtk] warning: output exceeds 10 MiB — filter input truncated"
-                            );
-                        }
-                    }
-                    filtered = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        filter_fn(&raw_stdout)
-                    }))
-                    .unwrap_or_else(|_| {
-                        eprintln!("[rtk] warning: filter panicked — passing through raw output");
-                        raw_stdout.clone()
-                    });
-                    match write!(out, "{}", filtered) {
-                        Err(e) if e.kind() == io::ErrorKind::BrokenPipe => {}
-                        Err(e) => return Err(e.into()),
-                        Ok(_) => {}
-                    }
-                }
-                FilterMode::CaptureOnly => {
-                    for line in BufReader::new(stdout).lines().map_while(Result::ok) {
-                        if raw_stdout.len() + line.len() < RAW_CAP {
-                            raw_stdout.push_str(&line);
-                            raw_stdout.push('\n');
-                        } else if !capped_out {
-                            capped_out = true;
-                            eprintln!(
-                                "[rtk] warning: output exceeds 10 MiB — filter input truncated"
-                            );
-                        }
-                    }
-                    filtered = raw_stdout.clone();
+        if let Some(mut f) = saved_filter {
+            if let Some(post) = f.on_exit(exit_code, &raw) {
+                filtered.push_str(&post);
+                match write!(io::stdout().lock(), "{}", post) {
+                    Err(e) if e.kind() == io::ErrorKind::BrokenPipe => {}
+                    Err(e) => return Err(e.into()),
+                    Ok(_) => {}
                 }
             }
         }
 
-        raw_stderr = stderr_thread.join().unwrap_or_else(|e| {
-            eprintln!("[rtk] warning: stderr reader thread panicked: {:?}", e);
-            String::new()
+        return Ok(StreamResult {
+            exit_code,
+            raw,
+            raw_stdout,
+            raw_stderr,
+            filtered,
         });
     }
     if let Some(t) = stdin_thread {
@@ -533,11 +764,40 @@ impl CaptureResult {
 
 pub fn exec_capture(cmd: &mut Command) -> Result<CaptureResult> {
     cmd.stdin(Stdio::null());
-    let output = cmd.output().context("Failed to execute command")?;
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+
+    // RAII so a `?` below still reaps the child rather than leaking a zombie.
+    struct ChildGuard(std::process::Child);
+    impl Drop for ChildGuard {
+        fn drop(&mut self) {
+            self.0.wait().ok();
+        }
+    }
+    let mut child = ChildGuard(cmd.spawn().context("Failed to execute command")?);
+
+    let stdout_pipe = child.0.stdout.take().context("No child stdout handle")?;
+    let stderr_pipe = child.0.stderr.take().context("No child stderr handle")?;
+
+    // Read both pipes on background threads into shared buffers. A descendant that
+    // inherited the pipe (e.g. an `esbuild --service` grandchild) keeps the write-end
+    // open after the direct child exits, so reading to EOF on this thread — what plain
+    // `cmd.output()` does — would block forever. Adopted from #2322's exec_capture half.
+    let (done_tx, done_rx) = mpsc::channel();
+    let stdout_buf = spawn_capture_reader(stdout_pipe, "stdout", done_tx.clone());
+    let stderr_buf = spawn_capture_reader(stderr_pipe, "stderr", done_tx);
+
+    let status = child.0.wait().context("Failed to wait for command")?;
+    // Child exited: bounded-drain whatever the readers already buffered, then return even
+    // if a detached descendant still holds the pipe open (see drain_capture_readers).
+    drain_capture_readers(&done_rx, &stdout_buf, &stderr_buf);
+
+    let stdout = std::mem::take(&mut *stdout_buf.lock().expect("capture buffer lock poisoned"));
+    let stderr = std::mem::take(&mut *stderr_buf.lock().expect("capture buffer lock poisoned"));
     Ok(CaptureResult {
-        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-        exit_code: status_to_exit_code(output.status),
+        stdout: collapse_terminal_control(&stdout),
+        stderr: collapse_terminal_control(&stderr),
+        exit_code: status_to_exit_code(status),
     })
 }
 
@@ -805,6 +1065,96 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn test_run_streaming_capture_only_collapses_carriage_return_progress() {
+        // nosemgrep: interpreter-execution
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "printf 'step 1\\rstep 2\\n'"]);
+        let result = run_streaming(&mut cmd, StdinMode::Null, FilterMode::CaptureOnly).unwrap();
+        assert_eq!(result.raw_stdout, "step 2\n");
+        assert_eq!(result.filtered, "step 2\n");
+    }
+
+    // ── collapse_terminal_control: terminal-faithful redraw resolution ────────────
+    // Ground truth = what a real VT100-ish terminal renders. A bare `\r` moves the
+    // cursor to column 0 but does NOT clear the line, so a shorter frame overlaying a
+    // longer one leaves the old tail (this is faithful, not a bug). Programs that want a
+    // clean shrink emit `\r` + ESC[K (erase to end of line) or pad with spaces.
+
+    #[test]
+    fn test_collapse_bare_cr_overlay_is_faithful() {
+        // No clear: `Done` overlays `Down`, tail `loading 100%` survives — exactly what a
+        // real terminal shows for a bare `\r` with no erase. Must NOT be "fixed" away.
+        assert_eq!(
+            collapse_terminal_control("Downloading 100%\rDone\n"),
+            "Doneloading 100%\n"
+        );
+    }
+
+    #[test]
+    fn test_collapse_progress_bar_keeps_final() {
+        assert_eq!(
+            collapse_terminal_control("Building 10%\rBuilding 60%\rBuilding 100%\n"),
+            "Building 100%\n"
+        );
+    }
+
+    #[test]
+    fn test_collapse_backspace_overwrites() {
+        assert_eq!(collapse_terminal_control("abc\u{8}D\n"), "abD\n");
+    }
+
+    #[test]
+    fn test_collapse_plain_and_crlf_unchanged() {
+        assert_eq!(
+            collapse_terminal_control("line1\nline2\nline3\n"),
+            "line1\nline2\nline3\n"
+        );
+        assert_eq!(collapse_terminal_control("a\r\nb\r\n"), "a\nb\n");
+    }
+
+    // ── The bug: ESC[K (erase to end of line) is not honored ──────────────────────
+    // Real shrinking redraws use `\r` + ESC[K. #2581's collapse has no ANSI awareness,
+    // so it (a) leaks the literal escape into output and (b) leaves the stale tail.
+    // These tests pin the terminal-correct result and FAIL until ESC[K is handled.
+
+    #[test]
+    fn test_collapse_cr_then_erase_to_eol_clears_tail() {
+        // `Downloading 100%` then `\r`, erase-to-EOL, `Done` → terminal shows `Done`.
+        assert_eq!(
+            collapse_terminal_control("Downloading 100%\r\x1b[KDone\n"),
+            "Done\n"
+        );
+    }
+
+    #[test]
+    fn test_collapse_erase_to_eol_midline() {
+        // `abcdef`, `\r`, write `XY`, erase-to-EOL → `XY` (tail `cdef` cleared, no escape leak).
+        assert_eq!(collapse_terminal_control("abcdef\rXY\x1b[K\n"), "XY\n");
+    }
+
+    #[test]
+    fn test_collapse_preserves_sgr_color() {
+        // SGR colour is NOT collapse's concern — the pipe capture path passed colour
+        // through to the command filters (which strip it themselves where needed), so
+        // collapse must not start stripping it. Only erase-in-line (ESC[K) is intercepted.
+        assert_eq!(
+            collapse_terminal_control("\x1b[32mPASS\x1b[0m\n"),
+            "\x1b[32mPASS\x1b[0m\n"
+        );
+    }
+
+    #[test]
+    fn test_collapse_colored_progress_redraw_keeps_final_with_color() {
+        // A coloured progress line redrawn via `\r`: the final frame (with its colour
+        // codes) survives, earlier frames collapse away. Pins that re-emitted CSI bytes
+        // participate in overlay/redraw like normal cells, not a one-way shift.
+        assert_eq!(
+            collapse_terminal_control("\x1b[33m50%\x1b[0m\r\x1b[32m100%\x1b[0m\n"),
+            "\x1b[32m100%\x1b[0m\n"
+        );
+    }
+
+    #[test]
     fn test_exec_capture_success() {
         let mut cmd = Command::new("echo");
         cmd.arg("hello_capture");
@@ -840,6 +1190,24 @@ pub(crate) mod tests {
         let combined = result.combined();
         assert!(combined.contains("out_msg"));
         assert!(combined.contains("err_msg"));
+    }
+
+    #[test]
+    fn test_exec_capture_collapses_carriage_return_progress() {
+        // nosemgrep: interpreter-execution
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "printf 'Downloading... 0%%\\rDownloading... 3%%\\n'"]);
+        let result = exec_capture(&mut cmd).unwrap();
+        assert_eq!(result.stdout, "Downloading... 3%\n");
+    }
+
+    #[test]
+    fn test_exec_capture_applies_backspace_overwrites() {
+        // nosemgrep: interpreter-execution
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "printf 'abc\\bD\\n'"]);
+        let result = exec_capture(&mut cmd).unwrap();
+        assert_eq!(result.stdout, "abD\n");
     }
 
     #[test]
@@ -1127,5 +1495,129 @@ pub(crate) mod tests {
         let result = run_line_filter(&mut f, "DROP a\nDROP b\nkeep\n", 0);
         // Only "keep" was observed, so summary says "1 kept"
         assert!(result.contains("demo: 1 kept"), "got: {}", result);
+    }
+
+    // ── Regression: pipe held open by a detached grandchild must not hang ──────────
+    // Mirrors the `ng build` → `esbuild --service` case: the direct child exits but a
+    // background descendant keeps the captured stdout/stderr pipe open. run_streaming
+    // must return promptly with the child's output and exit code, not block on pipe EOF.
+    // See docs/pr_briefs/004-pipe-eof-grandchild-hang.
+
+    #[cfg(not(windows))]
+    #[test]
+    fn test_capture_only_returns_when_grandchild_holds_pipe() {
+        // A grandchild `sleep 5` inherits stdout/stderr and outlives the direct child.
+        // nosemgrep: interpreter-execution
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "(sleep 5) & echo out_msg; echo err_msg >&2; exit 0"]);
+
+        let start = Instant::now();
+        let result = run_streaming(&mut cmd, StdinMode::Null, FilterMode::CaptureOnly).unwrap();
+
+        assert!(
+            start.elapsed() < Duration::from_secs(4),
+            "run_streaming must return after the direct child exits, not wait for the \
+             grandchild to close the pipe (took {:?})",
+            start.elapsed()
+        );
+        assert_eq!(result.exit_code, 0);
+        assert!(
+            result.raw_stdout.contains("out_msg"),
+            "stdout: {:?}",
+            result.raw_stdout
+        );
+        assert!(
+            result.raw_stderr.contains("err_msg"),
+            "stderr: {:?}",
+            result.raw_stderr
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn test_streaming_returns_when_grandchild_holds_pipe() {
+        // Same scenario but through the live-streaming filter path.
+        // nosemgrep: interpreter-execution
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "(sleep 5) & echo keep_me; exit 0"]);
+
+        let filter = LineStreamFilter::new(CountingLineHandler {
+            observed: Vec::new(),
+            skip_prefixes: vec![],
+            summary_tag: "t",
+        });
+        let start = Instant::now();
+        let result = run_streaming(
+            &mut cmd,
+            StdinMode::Null,
+            FilterMode::Streaming(Box::new(filter)),
+        )
+        .unwrap();
+
+        assert!(
+            start.elapsed() < Duration::from_secs(4),
+            "streaming run_streaming must not block on a grandchild-held pipe (took {:?})",
+            start.elapsed()
+        );
+        assert_eq!(result.exit_code, 0);
+        assert!(
+            result.raw_stdout.contains("keep_me"),
+            "stdout: {:?}",
+            result.raw_stdout
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn test_exec_capture_returns_when_grandchild_holds_pipe() {
+        // The buffered capture path (git/docker/wget/dotnet/ccusage all use exec_capture)
+        // must bound the post-exit drain too: a `sleep 2` grandchild inherits the pipe and
+        // outlives the direct child, so a plain `cmd.output()` would block until the pipe
+        // EOFs ~2s later. Adopted from #2322's exec_capture half (the author fixed both
+        // sites); our re-derived branch had only fixed run_streaming.
+        // nosemgrep: interpreter-execution
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "(sleep 2) & echo out_msg; echo err_msg >&2; exit 0"]);
+
+        let start = Instant::now();
+        let result = exec_capture(&mut cmd).unwrap();
+
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "exec_capture must return after the direct child exits, not wait for the \
+             grandchild to close the pipe (took {:?})",
+            start.elapsed()
+        );
+        assert_eq!(result.exit_code, 0);
+        assert!(
+            result.stdout.contains("out_msg"),
+            "stdout: {:?}",
+            result.stdout
+        );
+        assert!(
+            result.stderr.contains("err_msg"),
+            "stderr: {:?}",
+            result.stderr
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn test_capture_only_no_truncation_on_fast_exit() {
+        // A command that writes then exits immediately: output must not be lost to the
+        // post-exit drain shortcut (the readers must still be drained of buffered bytes).
+        // nosemgrep: interpreter-execution
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "printf 'line1\\nline2\\nline3\\n'; exit 0"]);
+
+        let result = run_streaming(&mut cmd, StdinMode::Null, FilterMode::CaptureOnly).unwrap();
+        assert_eq!(result.exit_code, 0);
+        assert!(
+            result.raw_stdout.contains("line1"),
+            "stdout: {:?}",
+            result.raw_stdout
+        );
+        assert!(result.raw_stdout.contains("line2"));
+        assert!(result.raw_stdout.contains("line3"));
     }
 }


### PR DESCRIPTION
Fixes #2320

## Summary
- replace `Command::output()` in `exec_capture` with explicit spawn/wait plus background stdout/stderr readers
- return after the direct child exits once captured output is idle, with a bounded post-exit drain
- add a regression test for a child that exits while a background descendant still holds the captured pipes open

## Why
Some `rtk dotnet ...` commands can start helper descendants such as credential providers or MSBuild nodes. If those descendants inherit captured stdout/stderr, `Command::output()` waits for pipe EOF even after the direct `dotnet` child has exited, so RTK can appear to hang indefinitely. Waiting on the direct child separately avoids that EOF dependency while still preserving captured output from the command.

## Validation
- `cargo fmt --check`
- `cargo test core::stream::tests::test_exec_capture_returns_after_child_exits_when_grandchild_holds_pipe -- --nocapture`
- `cargo test core::stream::tests::test_exec_capture -- --nocapture`
- `cargo test core::stream -- --nocapture`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `git diff --check`