### PR TITLE
fix(tee): quote recovery hint paths with spaces

### DIFF
--- a/src/core/tee.rs
+++ b/src/core/tee.rs
@@ -183,6 +183,7 @@ fn needs_shell_quoting(path: &str) -> bool {
             || matches!(
                 c,
                 '\'' | '"'
+                    | '\\'
                     | '$'
                     | '`'
                     | '!'
@@ -510,6 +511,15 @@ mod tests {
         assert_eq!(
             display_shell_path(&path),
             "\"/tmp/rtk/Application Support/123_go_test.log\""
+        );
+    }
+
+    #[test]
+    fn test_display_shell_path_quotes_backslashes() {
+        let path = PathBuf::from(r"/tmp/rtk/tee/path\segment.log");
+        assert_eq!(
+            display_shell_path(&path),
+            r#""/tmp/rtk/tee/path\\segment.log""#
         );
     }
 

--- a/src/core/tee.rs
+++ b/src/core/tee.rs
@@ -223,7 +223,8 @@ fn display_shell_path(path: &std::path::Path) -> String {
     }
 
     if let Some(relative) = display.strip_prefix("~/") {
-        return format!("\"$HOME/{}\"", escape_double_quoted_path(relative));
+        let relative = relative.replace(std::path::MAIN_SEPARATOR, "/");
+        return format!("\"$HOME/{}\"", escape_double_quoted_path(&relative));
     }
 
     format!("\"{}\"", escape_double_quoted_path(&display))

--- a/src/core/tee.rs
+++ b/src/core/tee.rs
@@ -177,8 +177,59 @@ fn display_path(path: &std::path::Path) -> String {
     path.display().to_string()
 }
 
+fn needs_shell_quoting(path: &str) -> bool {
+    path.chars().any(|c| {
+        c.is_whitespace()
+            || matches!(
+                c,
+                '\'' | '"'
+                    | '$'
+                    | '`'
+                    | '!'
+                    | '#'
+                    | '&'
+                    | '('
+                    | ')'
+                    | ';'
+                    | '<'
+                    | '>'
+                    | '?'
+                    | '['
+                    | ']'
+                    | '{'
+                    | '}'
+                    | '|'
+                    | '*'
+            )
+    })
+}
+
+fn escape_double_quoted_path(path: &str) -> String {
+    let mut escaped = String::with_capacity(path.len());
+    for c in path.chars() {
+        if matches!(c, '\\' | '"' | '$' | '`') {
+            escaped.push('\\');
+        }
+        escaped.push(c);
+    }
+    escaped
+}
+
+fn display_shell_path(path: &std::path::Path) -> String {
+    let display = display_path(path);
+    if !needs_shell_quoting(&display) {
+        return display;
+    }
+
+    if let Some(relative) = display.strip_prefix("~/") {
+        return format!("\"$HOME/{}\"", escape_double_quoted_path(relative));
+    }
+
+    format!("\"{}\"", escape_double_quoted_path(&display))
+}
+
 fn format_hint(path: &std::path::Path) -> String {
-    format!("[full output: {}]", display_path(path))
+    format!("[full output: {}]", display_shell_path(path))
 }
 
 /// Convenience: tee + format hint in one call.
@@ -231,7 +282,7 @@ pub fn force_tee_tail_hint(
     Some(format!(
         "[see remaining: tail -n +{} {}]",
         line_offset,
-        display_path(&path)
+        display_shell_path(&path)
     ))
 }
 
@@ -445,6 +496,62 @@ mod tests {
         assert!(hint.starts_with("[full output: "));
         assert!(hint.ends_with(']'));
         assert!(hint.contains("123_cargo_test.log"));
+    }
+
+    #[test]
+    fn test_display_shell_path_preserves_simple_paths() {
+        let path = PathBuf::from("/tmp/rtk/tee/123_cargo_test.log");
+        assert_eq!(display_shell_path(&path), "/tmp/rtk/tee/123_cargo_test.log");
+    }
+
+    #[test]
+    fn test_display_shell_path_quotes_paths_with_spaces() {
+        let path = PathBuf::from("/tmp/rtk/Application Support/123_go_test.log");
+        assert_eq!(
+            display_shell_path(&path),
+            "\"/tmp/rtk/Application Support/123_go_test.log\""
+        );
+    }
+
+    #[test]
+    fn test_display_shell_path_uses_home_var_for_home_paths_with_spaces() {
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+        let path = home
+            .join("Library")
+            .join("Application Support")
+            .join("rtk")
+            .join("tee")
+            .join("123_go_test.log");
+
+        assert_eq!(
+            display_shell_path(&path),
+            "\"$HOME/Library/Application Support/rtk/tee/123_go_test.log\""
+        );
+    }
+
+    #[test]
+    fn test_format_hint_avoids_backslash_escaped_whitespace() {
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+        let path = home
+            .join("Library")
+            .join("Application Support")
+            .join("rtk")
+            .join("tee")
+            .join("123_go_test.log");
+        let hint = format_hint(&path);
+
+        assert_eq!(
+            hint,
+            "[full output: \"$HOME/Library/Application Support/rtk/tee/123_go_test.log\"]"
+        );
+        assert!(
+            !hint.contains("\\ "),
+            "hint should not encourage backslash-escaped whitespace"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1858. RTK recovery hints can point at macOS tee files under `~/Library/Application Support/...`. When that path is copied into a shell command, agents tend to use backslash-escaped whitespace (`Application\ Support`), which makes Claude Code ask for permission again.

This keeps simple hint paths unchanged, but renders paths that need shell quoting as copy-paste-safe double-quoted paths. For home-relative paths with spaces, it uses `"$HOME/..."` instead of quoting `~`, because `~` does not expand inside quotes.

Related to #2187, but this keeps the compact `~/...` display for simple paths and directly quotes paths with spaces instead of only rendering an absolute path.

## Validation

- `cargo fmt --check`
- `cargo test core::tee::tests`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`