### PR TITLE
fix(git): preserve merge commits in log output

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -429,6 +429,47 @@ fn run_log(
     let timer = tracking::TimedExecution::start();
 
     let mut cmd = git_cmd(global_args);
+    let log_plan = configure_log_command(&mut cmd, args);
+
+    let result = exec_capture(&mut cmd).context("Failed to run git log")?;
+
+    if !result.success() {
+        eprintln!("{}", result.stderr);
+        return Ok(result.exit_code);
+    }
+
+    if verbose > 0 {
+        eprintln!("Git log output:");
+    }
+
+    // Post-process: truncate long messages, cap lines only if RTK set the default
+    let filtered = filter_log_output(
+        &result.stdout,
+        log_plan.limit,
+        log_plan.user_set_limit,
+        log_plan.has_format_flag,
+    );
+    let filtered = never_worse(&result.stdout, &filtered).to_string();
+    println!("{}", filtered);
+
+    timer.track(
+        &format!("git log {}", args.join(" ")),
+        &format!("rtk git log {}", args.join(" ")),
+        &result.stdout,
+        &filtered,
+    );
+
+    Ok(0)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LogCommandPlan {
+    limit: usize,
+    user_set_limit: bool,
+    has_format_flag: bool,
+}
+
+fn configure_log_command(cmd: &mut Command, args: &[String]) -> LogCommandPlan {
     cmd.arg("log");
 
     // Check if user provided format flags
@@ -465,44 +506,17 @@ fn run_log(
         (10, false)
     };
 
-    // Only add --no-merges if user didn't explicitly request merge commits
-    let wants_merges = args
-        .iter()
-        .any(|arg| arg == "--merges" || arg == "--min-parents=2" || arg == "--no-merges");
-    // Don't add --no-merges if user explicitly requested merges or an exact count (-n N / --max-count)
-    if !wants_merges && !has_limit_flag {
-        cmd.arg("--no-merges");
-    }
-
-    // Pass all user arguments
+    // Preserve git log semantics: merge commits can be HEAD and are essential
+    // for merge/PR verification, so RTK must not hide them by default.
     for arg in args {
         cmd.arg(arg);
     }
 
-    let result = exec_capture(&mut cmd).context("Failed to run git log")?;
-
-    if !result.success() {
-        eprintln!("{}", result.stderr);
-        return Ok(result.exit_code);
+    LogCommandPlan {
+        limit,
+        user_set_limit,
+        has_format_flag,
     }
-
-    if verbose > 0 {
-        eprintln!("Git log output:");
-    }
-
-    // Post-process: truncate long messages, cap lines only if RTK set the default
-    let filtered = filter_log_output(&result.stdout, limit, user_set_limit, has_format_flag);
-    let filtered = never_worse(&result.stdout, &filtered).to_string();
-    println!("{}", filtered);
-
-    timer.track(
-        &format!("git log {}", args.join(" ")),
-        &format!("rtk git log {}", args.join(" ")),
-        &result.stdout,
-        &filtered,
-    );
-
-    Ok(0)
 }
 
 /// Filter git log output: truncate long messages, cap lines
@@ -1818,6 +1832,12 @@ pub fn run_passthrough(args: &[OsString], global_args: &[String], verbose: u8) -
 mod tests {
     use super::*;
 
+    fn command_args(cmd: &Command) -> Vec<String> {
+        cmd.get_args()
+            .map(|arg| arg.to_string_lossy().to_string())
+            .collect()
+    }
+
     #[test]
     fn test_git_cmd_no_global_args() {
         let cmd = git_cmd(&[]);
@@ -2346,6 +2366,41 @@ A  added.rs
             !result_user.contains("..."),
             "User limit should not truncate 90-char line"
         );
+    }
+
+    #[test]
+    fn test_configure_log_command_preserves_merge_commits_by_default() {
+        let mut cmd = git_cmd(&[]);
+        let plan = configure_log_command(&mut cmd, &[]);
+        let args = command_args(&cmd);
+
+        assert_eq!(
+            plan,
+            LogCommandPlan {
+                limit: 10,
+                user_set_limit: false,
+                has_format_flag: false
+            }
+        );
+        assert!(!args.contains(&"--no-merges".to_string()));
+    }
+
+    #[test]
+    fn test_configure_log_command_preserves_merge_commits_with_oneline() {
+        let mut cmd = git_cmd(&[]);
+        let args_in = vec!["--oneline".to_string()];
+        let plan = configure_log_command(&mut cmd, &args_in);
+        let args = command_args(&cmd);
+
+        assert_eq!(
+            plan,
+            LogCommandPlan {
+                limit: 50,
+                user_set_limit: false,
+                has_format_flag: true
+            }
+        );
+        assert!(!args.contains(&"--no-merges".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #2305.

## Summary
- stop adding `--no-merges` to default `rtk git log` invocations
- preserve merge commits for plain log output and formatted output such as `--oneline`
- factor log command setup so the default plan is covered by regression tests

## Why
`rtk git log` previously injected `--no-merges` whenever the user did not pass an explicit count, which made merge commits invisible in common verification commands like `rtk git log --oneline`. Merge commits can be `HEAD`, so hiding them changes normal `git log` semantics and breaks merge/PR verification.

## Validation
- `cargo fmt --check`
- `cargo test cmds::git::git::tests::test_configure_log_command_preserves_merge_commits`
- `cargo test cmds::git::git::tests`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (2147 passed, 8 ignored)
- CLI smoke in a temp repo with a real merge commit: raw `git log --oneline` and `rtk git log --oneline` both listed the merge commit first.