### PR TITLE
fix(grep): stabilize argument parsing — trailing_var_arg, -v invert-match, --version passthrough, safe rg invocation

### DIFF
--- a/docs/contributing/ARCHITECTURE.md
+++ b/docs/contributing/ARCHITECTURE.md
@@ -746,7 +746,7 @@ Single-threaded execution with `Mutex<Option<Tracker>>` for future-proofing. No 
 └────────────────────────────────────────────────────────────────────────┘
 
 main.rs:47-49
-#[arg(short, long, action = clap::ArgAction::Count, global = true)]
+#[arg(short, long, action = clap::ArgAction::Count)]
 verbose: u8,
 
 Levels:
@@ -773,7 +773,7 @@ if verbose > 0 {
 └────────────────────────────────────────────────────────────────────────┘
 
 main.rs:51-53
-#[arg(short = 'u', long, global = true)]
+#[arg(long, global = true)]
 ultra_compact: bool,
 
 Features:

--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -14,26 +14,28 @@ use std::collections::HashMap;
 /// for a missing entry is a visible wrong result, not a silent corruption.
 const VALUE_FLAGS_SHORT: &[u8] = b"ABCgfjm";
 
-/// Normalise a flag arg for rg forwarding.
+/// Normalise short flags arg for rg forwarding.
+/// Returns `None` when the entire flag is stripped (grep-ism recursive flags).
+fn strip_r(arg: &str) -> Option<String> {
+    match arg
+        .chars()
+        .filter(|&c| c != 'r' && c != 'R')
+        .collect::<String>()
+    {
+        s if !s.is_empty() => Some(s),
+        _ => None,
+    }
+}
+
+/// Normalise long flag arg for rg forwarding.
 /// Returns `None` when the flag should be dropped (grep-ism recursive flags).
-fn process_flag(arg: &str) -> Option<String> {
-    if arg == "--recursive" {
-        return None;
+fn strip_recursive(arg: &str) -> Option<String> {
+    match arg {
+        // Drop recursive flags that would change semantics in rg.
+        "--recursive" => None,
+        // Everything else pass through unchanged.
+        _ => Some(arg.to_string()),
     }
-    // Long flags pass through unchanged.
-    if arg.starts_with("--") {
-        return Some(arg.to_string());
-    }
-    // Short clusters: strip `r`/`R` (grep recursive; rg -r means --replace).
-    if let Some(rest) = arg.strip_prefix('-') {
-        let cleaned: String = rest.chars().filter(|&c| c != 'r' && c != 'R').collect();
-        return if cleaned.is_empty() {
-            None
-        } else {
-            Some(format!("-{}", cleaned))
-        };
-    }
-    Some(arg.to_string())
 }
 
 /// Extracts `(patterns, paths, flags)` from the raw trailing args.
@@ -48,7 +50,7 @@ fn process_flag(arg: &str) -> Option<String> {
 /// as their value so it is not mistaken for the pattern. Combined clusters like
 /// `-rn` have `r`/`R` stripped before forwarding. `--` marks everything after
 /// it as positional even if flag-shaped.
-fn extract_pattern_path(args: &[String]) -> (Vec<String>, Vec<String>, Vec<String>) {
+fn extract_pattern_path<T: AsRef<str>>(args: &[T]) -> (Vec<String>, Vec<String>, Vec<String>) {
     let mut e_patterns: Vec<String> = Vec::new();
     let mut positionals: Vec<String> = Vec::new();
     let mut flags: Vec<String> = Vec::new();
@@ -56,10 +58,10 @@ fn extract_pattern_path(args: &[String]) -> (Vec<String>, Vec<String>, Vec<Strin
     let mut i = 0;
 
     while i < args.len() {
-        let arg = &args[i];
+        let arg = args[i].as_ref();
 
         if past_dashdash {
-            positionals.push(arg.clone());
+            positionals.push(arg.to_string());
             i += 1;
             continue;
         }
@@ -70,68 +72,61 @@ fn extract_pattern_path(args: &[String]) -> (Vec<String>, Vec<String>, Vec<Strin
             continue;
         }
 
-        if arg.starts_with('-') {
-            // Long flags (--foo, --recursive): strip or pass through unchanged
-            if arg.starts_with("--") {
-                if let Some(cleaned) = process_flag(arg) {
-                    flags.push(cleaned);
-                }
-                i += 1;
-                continue;
+        // Long flags (--foo, --recursive): strip or pass through unchanged
+        if arg.starts_with("--") {
+            if let Some(cleaned) = strip_recursive(arg) {
+                flags.push(cleaned);
             }
-
-            let rest = arg.strip_prefix('-').unwrap_or(""); // bytes after the leading '-'
-            if rest.is_empty() {
-                // Bare `-`: treat as positional (stdin)
-                positionals.push(arg.clone());
-                i += 1;
-                continue;
-            }
-
-            let last = *rest.as_bytes().last().unwrap();
-            let last_is_e = last == b'e';
-            let last_takes_value = last_is_e || VALUE_FLAGS_SHORT.contains(&last);
-
-            if last_takes_value {
-                // Emit cleaned prefix (everything before last char, r/R stripped)
-                let prefix: String = rest[..rest.len() - 1]
-                    .chars()
-                    .filter(|&c| c != 'r' && c != 'R')
-                    .collect();
-                if !prefix.is_empty() {
-                    flags.push(format!("-{}", prefix));
-                }
-
-                let value = if i + 1 < args.len() {
-                    let v = args[i + 1].clone();
-                    i += 2;
-                    Some(v)
-                } else {
-                    i += 1;
-                    None
-                };
-
-                if last_is_e {
-                    if let Some(v) = value {
-                        e_patterns.push(v);
-                    }
-                } else {
-                    flags.push(format!("-{}", last as char));
-                    if let Some(v) = value {
-                        flags.push(v);
-                    }
-                }
-            } else {
-                // No value-taking flag at end: strip r/R, forward remainder
-                let cleaned: String = rest.chars().filter(|&c| c != 'r' && c != 'R').collect();
-                if !cleaned.is_empty() {
-                    flags.push(format!("-{}", cleaned));
-                }
-                i += 1;
-            }
-        } else {
-            positionals.push(arg.clone());
             i += 1;
+            continue;
+        }
+
+        match arg.strip_prefix('-') {
+            Some(rest) if !rest.is_empty() => {
+                let last = *rest.as_bytes().last().unwrap();
+                let last_is_e = last == b'e';
+                let last_takes_value = last_is_e || VALUE_FLAGS_SHORT.contains(&last);
+
+                if last_takes_value {
+                    // Emit cleaned prefix (everything before last char, r/R stripped)
+                    if let Some(prefix) = strip_r(&rest[..rest.len() - 1]) {
+                        flags.push(format!("-{}", prefix));
+                    }
+
+                    let value = if i + 1 < args.len() {
+                        let v = args[i + 1].as_ref().to_string();
+                        i += 2;
+                        Some(v)
+                    } else {
+                        i += 1;
+                        None
+                    };
+
+                    if last_is_e {
+                        if let Some(v) = value {
+                            e_patterns.push(v);
+                        } else {
+                            // -e without a value: treat "e" as a normal flag to avoid losing the pattern.
+                            flags.push("-e".to_string());
+                        }
+                    } else {
+                        flags.push(format!("-{}", last as char));
+                        if let Some(v) = value {
+                            flags.push(v);
+                        }
+                    }
+                } else {
+                    // No value-taking flag at end: strip r/R, forward remainder
+                    if let Some(cleaned) = strip_r(rest) {
+                        flags.push(format!("-{}", cleaned));
+                    }
+                    i += 1;
+                }
+            }
+            _ => {
+                positionals.push(arg.to_string());
+                i += 1;
+            }
         }
     }
 
@@ -148,7 +143,6 @@ fn extract_pattern_path(args: &[String]) -> (Vec<String>, Vec<String>, Vec<Strin
     (patterns, paths, flags)
 }
 
-#[allow(clippy::too_many_arguments)]
 pub fn run(
     max_line_len: usize,
     max_results: usize,
@@ -193,7 +187,7 @@ pub fn run(
         return Ok(1);
     }
 
-    let display_pattern = if patterns.len() == 1 {
+    let pattern_display = if patterns.len() == 1 {
         patterns[0].clone()
     } else {
         patterns.join("|")
@@ -207,7 +201,7 @@ pub fn run(
     let path_display = paths.join(" ");
 
     if verbose > 0 {
-        eprintln!("grep: '{}' in {}", display_pattern, path_display);
+        eprintln!("grep: '{}' in {}", pattern_display, path_display);
     }
 
     let mut rg_cmd = resolved_command("rg");
@@ -261,12 +255,12 @@ pub fn run(
         }
 
         let args_display = if extra_args.is_empty() {
-            format!("'{}' {}", display_pattern, path_display)
+            format!("'{}' {}", pattern_display, path_display)
         } else {
             format!(
                 "{} '{}' {}",
                 extra_args.join(" "),
-                display_pattern,
+                pattern_display,
                 path_display
             )
         };
@@ -286,10 +280,10 @@ pub fn run(
         if exit_code == 2 && !result.stderr.trim().is_empty() {
             eprintln!("{}", result.stderr.trim());
         }
-        let msg = format!("0 matches for '{}'", display_pattern);
+        let msg = format!("0 matches for '{}'", pattern_display);
         println!("{}", msg);
         timer.track(
-            &format!("grep -rn '{}' {}", display_pattern, path_display),
+            &format!("grep -rn '{}' {}", pattern_display, path_display),
             "rtk grep",
             &raw_output,
             &msg,
@@ -300,7 +294,7 @@ pub fn run(
     let context_re = if context_only {
         Regex::new(&format!(
             "(?i).{{0,20}}{}.*",
-            regex::escape(&display_pattern)
+            regex::escape(&pattern_display)
         ))
         .ok()
     } else {
@@ -312,7 +306,7 @@ pub fn run(
         let Some((file, line_num, content)) = parse_match_line(line) else {
             continue;
         };
-        let cleaned = clean_line(content, max_line_len, context_re.as_ref(), &display_pattern);
+        let cleaned = clean_line(content, max_line_len, context_re.as_ref(), &pattern_display);
         by_file.entry(file).or_default().push((line_num, cleaned));
     }
 
@@ -352,7 +346,7 @@ pub fn run(
 
     print!("{}", rtk_output);
     timer.track(
-        &format!("grep -rn '{}' {}", display_pattern, path_display),
+        &format!("grep -rn '{}' {}", pattern_display, path_display),
         "rtk grep",
         &raw_output,
         &rtk_output,
@@ -383,10 +377,10 @@ fn parse_match_line(line: &str) -> Option<(String, usize, &str)> {
     })
 }
 
-fn has_format_flag(extra_args: &[String]) -> bool {
+fn has_format_flag<T: AsRef<str>>(extra_args: &[T]) -> bool {
     extra_args.iter().any(|arg| {
         matches!(
-            arg.as_str(),
+            arg.as_ref(),
             "-c" | "--count"
                 | "-l"
                 | "--files-with-matches"
@@ -510,126 +504,122 @@ mod tests {
     // --- process_flag ---
 
     #[test]
-    fn test_process_flag_strip_r() {
-        assert_eq!(process_flag("-r"), None);
-        assert_eq!(process_flag("-R"), None);
-        assert_eq!(process_flag("-rn"), Some("-n".to_string()));
-        assert_eq!(process_flag("-Rni"), Some("-ni".to_string()));
-        assert_eq!(process_flag("-i"), Some("-i".to_string()));
+    fn test_strip_r() {
+        assert_eq!(strip_r(""), None);
+        assert_eq!(strip_r("r"), None);
+        assert_eq!(strip_r("rr"), None);
+        assert_eq!(strip_r("R"), None);
+        assert_eq!(strip_r("rn"), Some("n".to_string()));
+        assert_eq!(strip_r("Rni"), Some("ni".to_string()));
+        assert_eq!(strip_r("i"), Some("i".to_string()));
     }
 
     #[test]
-    fn test_process_flag_strip_recursive() {
-        // process_flag is now only called for long flags
-        assert_eq!(process_flag("--recursive"), None);
-        assert_eq!(process_flag("--glob"), Some("--glob".to_string()));
-        assert_eq!(process_flag("--type"), Some("--type".to_string()));
+    fn test_strip_recursive() {
+        assert_eq!(strip_recursive("--recursive"), None);
+        assert_eq!(strip_recursive("--glob"), Some("--glob".to_string()));
+        assert_eq!(strip_recursive("--type"), Some("--type".to_string()));
     }
 
     // --- extract_pattern_path ---
 
-    fn s(v: &[&str]) -> Vec<String> {
-        v.iter().map(|x| x.to_string()).collect()
-    }
-
     #[test]
     fn test_extract_simple() {
-        let (patterns, paths, flags) = extract_pattern_path(&s(&["foo", "src/"]));
-        assert_eq!(patterns, s(&["foo"]));
-        assert_eq!(paths, s(&["src/"]));
+        let (patterns, paths, flags) = extract_pattern_path(&["foo", "src/"]);
+        assert_eq!(patterns, vec!["foo"]);
+        assert_eq!(paths, vec!["src/"]);
         assert!(flags.is_empty());
     }
 
     #[test]
     fn test_extract_with_bool_flag() {
-        let (patterns, paths, flags) = extract_pattern_path(&s(&["-i", "foo", "src/"]));
-        assert_eq!(patterns, s(&["foo"]));
-        assert_eq!(paths, s(&["src/"]));
-        assert_eq!(flags, s(&["-i"]));
+        let (patterns, paths, flags) = extract_pattern_path(&["-i", "foo", "src/"]);
+        assert_eq!(patterns, vec!["foo"]);
+        assert_eq!(paths, vec!["src/"]);
+        assert_eq!(flags, vec!["-i"]);
     }
 
     #[test]
     fn test_extract_value_taking_flag() {
         // -A 2 must not steal "error" as its value
-        let (patterns, paths, flags) = extract_pattern_path(&s(&["-A", "2", "error", "src"]));
-        assert_eq!(patterns, s(&["error"]));
-        assert_eq!(paths, s(&["src"]));
-        assert_eq!(flags, s(&["-A", "2"]));
+        let (patterns, paths, flags) = extract_pattern_path(&["-A", "2", "error", "src"]);
+        assert_eq!(patterns, vec!["error"]);
+        assert_eq!(paths, vec!["src"]);
+        assert_eq!(flags, vec!["-A", "2"]);
     }
 
     #[test]
     fn test_extract_cluster_strip_r() {
         // -rn: r stripped, n forwarded (not leaked to rg as --replace value)
-        let (patterns, paths, flags) = extract_pattern_path(&s(&["-rn", "foo", "src"]));
-        assert_eq!(patterns, s(&["foo"]));
-        assert_eq!(paths, s(&["src"]));
-        assert_eq!(flags, s(&["-n"]));
+        let (patterns, paths, flags) = extract_pattern_path(&["-rn", "foo", "src"]);
+        assert_eq!(patterns, vec!["foo"]);
+        assert_eq!(paths, vec!["src"]);
+        assert_eq!(flags, vec!["-n"]);
     }
 
     #[test]
     fn test_extract_cluster_ending_in_e() {
         // -rne PATTERN: r stripped, n in prefix, e consumes PATTERN as pattern
-        let (patterns, paths, flags) = extract_pattern_path(&s(&["-rne", "PATTERN", "src"]));
-        assert_eq!(patterns, s(&["PATTERN"]));
-        assert_eq!(paths, s(&["src"]));
-        assert_eq!(flags, s(&["-n"]));
+        let (patterns, paths, flags) = extract_pattern_path(&["-rne", "PATTERN", "src"]);
+        assert_eq!(patterns, vec!["PATTERN"]);
+        assert_eq!(paths, vec!["src"]);
+        assert_eq!(flags, vec!["-n"]);
     }
 
     #[test]
     fn test_extract_cluster_ending_in_value_flag() {
         // -rA 2: r stripped, A consumes 2 as context value
-        let (patterns, paths, flags) = extract_pattern_path(&s(&["-rA", "2", "foo", "src"]));
-        assert_eq!(patterns, s(&["foo"]));
-        assert_eq!(paths, s(&["src"]));
-        assert_eq!(flags, s(&["-A", "2"]));
+        let (patterns, paths, flags) = extract_pattern_path(&["-rA", "2", "foo", "src"]);
+        assert_eq!(patterns, vec!["foo"]);
+        assert_eq!(paths, vec!["src"]);
+        assert_eq!(flags, vec!["-A", "2"]);
     }
 
     #[test]
     fn test_extract_multi_path() {
-        let (patterns, paths, flags) = extract_pattern_path(&s(&["TODO", "src", "tests"]));
-        assert_eq!(patterns, s(&["TODO"]));
-        assert_eq!(paths, s(&["src", "tests"]));
+        let (patterns, paths, flags) = extract_pattern_path(&["TODO", "src", "tests"]);
+        assert_eq!(patterns, vec!["TODO"]);
+        assert_eq!(paths, vec!["src", "tests"]);
         assert!(flags.is_empty());
     }
 
     #[test]
     fn test_extract_glob_value() {
         // -g '*.md' must not steal "agent" as its value
-        let (patterns, paths, flags) =
-            extract_pattern_path(&s(&["-i", "x", "agent", "-g", "*.md"]));
-        assert_eq!(patterns, s(&["x"]));
-        assert_eq!(paths, s(&["agent"]));
-        assert_eq!(flags, s(&["-i", "-g", "*.md"]));
+        let (patterns, paths, flags) = extract_pattern_path(&["-i", "x", "agent", "-g", "*.md"]);
+        assert_eq!(patterns, vec!["x"]);
+        assert_eq!(paths, vec!["agent"]);
+        assert_eq!(flags, vec!["-i", "-g", "*.md"]);
     }
 
     #[test]
     fn test_extract_e_flag() {
-        let (patterns, paths, flags) = extract_pattern_path(&s(&["-e", "fn run", "src"]));
-        assert_eq!(patterns, s(&["fn run"]));
-        assert_eq!(paths, s(&["src"]));
+        let (patterns, paths, flags) = extract_pattern_path(&["-e", "fn run", "src"]);
+        assert_eq!(patterns, vec!["fn run"]);
+        assert_eq!(paths, vec!["src"]);
         assert!(flags.is_empty());
     }
 
     #[test]
     fn test_extract_multi_e() {
-        let (patterns, paths, flags) = extract_pattern_path(&s(&["-e", "foo", "-e", "bar", "src"]));
-        assert_eq!(patterns, s(&["foo", "bar"]));
-        assert_eq!(paths, s(&["src"]));
+        let (patterns, paths, flags) = extract_pattern_path(&["-e", "foo", "-e", "bar", "src"]);
+        assert_eq!(patterns, vec!["foo", "bar"]);
+        assert_eq!(paths, vec!["src"]);
         assert!(flags.is_empty());
     }
 
     #[test]
     fn test_extract_dashdash_boundary() {
         // After --, args are positional even if they look like flags
-        let (patterns, paths, flags) = extract_pattern_path(&s(&["--", "--version"]));
-        assert_eq!(patterns, s(&["--version"]));
+        let (patterns, paths, flags) = extract_pattern_path(&["--", "--version"]);
+        assert_eq!(patterns, vec!["--version"]);
         assert!(paths.is_empty());
         assert!(flags.is_empty());
     }
 
     #[test]
     fn test_extract_no_args() {
-        let (patterns, paths, flags) = extract_pattern_path(&[]);
+        let (patterns, paths, flags) = extract_pattern_path::<&str>(&[]);
         assert!(patterns.is_empty());
         assert!(paths.is_empty());
         assert!(flags.is_empty());
@@ -638,9 +628,18 @@ mod tests {
     #[test]
     fn test_extract_default_path_empty() {
         // Caller is responsible for defaulting empty paths to ["."]
-        let (patterns, paths, _) = extract_pattern_path(&s(&["foo"]));
-        assert_eq!(patterns, s(&["foo"]));
+        let (patterns, paths, _) = extract_pattern_path(&["foo"]);
+        assert_eq!(patterns, vec!["foo"]);
         assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_extract_ending_e() {
+        let (patterns, paths, flags) =
+            extract_pattern_path(&["-e", "foo", "-e", "bar", "src", "-e"]);
+        assert_eq!(patterns, vec!["foo", "bar"]);
+        assert_eq!(paths, vec!["src"]);
+        assert_eq!(flags, vec!["-e"]);
     }
 
     // --- truncation accuracy ---
@@ -668,42 +667,37 @@ mod tests {
 
     #[test]
     fn test_format_flag_detects_count() {
-        assert!(has_format_flag(&["-c".to_string()]));
-        assert!(has_format_flag(&["--count".to_string()]));
+        assert!(has_format_flag(&["-c"]));
+        assert!(has_format_flag(&["--count"]));
     }
 
     #[test]
     fn test_format_flag_detects_files_with_matches() {
-        assert!(has_format_flag(&["-l".to_string()]));
-        assert!(has_format_flag(&["--files-with-matches".to_string()]));
+        assert!(has_format_flag(&["-l"]));
+        assert!(has_format_flag(&["--files-with-matches"]));
     }
 
     #[test]
     fn test_format_flag_detects_files_without_match() {
-        assert!(has_format_flag(&["-L".to_string()]));
-        assert!(has_format_flag(&["--files-without-match".to_string()]));
+        assert!(has_format_flag(&["-L"]));
+        assert!(has_format_flag(&["--files-without-match"]));
     }
 
     #[test]
     fn test_format_flag_detects_only_matching() {
-        assert!(has_format_flag(&["-o".to_string()]));
-        assert!(has_format_flag(&["--only-matching".to_string()]));
+        assert!(has_format_flag(&["-o"]));
+        assert!(has_format_flag(&["--only-matching"]));
     }
 
     #[test]
     fn test_format_flag_detects_null() {
-        assert!(has_format_flag(&["-Z".to_string()]));
-        assert!(has_format_flag(&["--null".to_string()]));
+        assert!(has_format_flag(&["-Z"]));
+        assert!(has_format_flag(&["--null"]));
     }
 
     #[test]
     fn test_format_flag_ignores_normal_flags() {
-        assert!(!has_format_flag(&[
-            "-i".to_string(),
-            "-w".to_string(),
-            "-A".to_string(),
-            "3".to_string(),
-        ]));
+        assert!(!has_format_flag(&["-i", "-w", "-A", "3"]));
     }
 
     // Verify line numbers are always enabled in rg invocation (grep_cmd.rs:24).

--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -8,48 +8,67 @@ use anyhow::{Context, Result};
 use regex::Regex;
 use std::collections::HashMap;
 
-/// Short flags (exact 2-char form `-X`) that consume one following token as their value.
-/// `-e` is handled separately — its value goes into `patterns`, not `flags`.
-/// Deliberately small: unknown flags pass through unchanged. The failure mode
-/// for a missing entry is a visible wrong result, not a silent corruption.
-const VALUE_FLAGS_SHORT: &[u8] = b"ABCgfjm";
+/// Short single-char flags that consume one following token (or inline remainder)
+/// as their value. `-e` is handled separately — its value goes to `patterns`.
+/// Includes all rg short flags that take a value argument except `-e` and `-r`
+/// (stripped) and `-E` (dialect, left to #2138). Failure mode for a missing
+/// entry: the value becomes a positional (visible wrong result, not silent).
+const VALUE_FLAGS_SHORT: &[u8] = b"ABCgfjmtTdM";
 
-/// Normalise short flags arg for rg forwarding.
-/// Returns `None` when the entire flag is stripped (grep-ism recursive flags).
-fn strip_r(arg: &str) -> Option<String> {
-    match arg
-        .chars()
-        .filter(|&c| c != 'r' && c != 'R')
-        .collect::<String>()
-    {
-        s if !s.is_empty() => Some(s),
-        _ => None,
-    }
-}
+/// Long flags that consume the NEXT token as their value (space-separated form).
+/// Inline `=` form (`--flag=value`) is one token and passes through unchanged.
+/// `--regexp` is handled separately (its value goes to `patterns`).
+/// `--encoding` value is consumed correctly here; dialect routing is #2138's job.
+const VALUE_FLAGS_LONG: &[&str] = &[
+    "--file",
+    "--glob",
+    "--iglob",
+    "--type",
+    "--type-not",
+    "--type-add",
+    "--type-clear",
+    "--max-count",
+    "--max-depth",
+    "--max-filesize",
+    "--max-columns",
+    "--after-context",
+    "--before-context",
+    "--context",
+    "--encoding",
+    "--engine",
+    "--sort",
+    "--sortr",
+    "--threads",
+    "--replace",
+    "--pre",
+    "--pre-glob",
+    "--path-separator",
+    "--ignore-file",
+    "--field-match-separator",
+    "--field-context-separator",
+    "--context-separator",
+    "--color",
+    "--colors",
+];
 
-/// Normalise long flag arg for rg forwarding.
-/// Returns `None` when the flag should be dropped (grep-ism recursive flags).
+/// Drop `--recursive` (grep-ism); pass all other long flags through unchanged.
 fn strip_recursive(arg: &str) -> Option<String> {
     match arg {
-        // Drop recursive flags that would change semantics in rg.
         "--recursive" => None,
-        // Everything else pass through unchanged.
         _ => Some(arg.to_string()),
     }
 }
 
 /// Extracts `(patterns, paths, flags)` from the raw trailing args.
 ///
-/// - `patterns`: first non-flag positional prepended to any `-e` values.
-///   All patterns are passed to rg as `-e` flags, so positional and `-e` are
-///   interchangeable from rg's perspective. Empty → caller should error.
-/// - `paths`: all subsequent non-flag positionals. Empty → caller defaults to `["."]`.
-/// - `flags`: other flags forwarded to rg (recursive flags already stripped).
+/// - `patterns`: positional pattern + all `-e`/`--regexp` values. Empty → error.
+/// - `paths`: subsequent non-flag positionals. Empty → caller defaults to `["."]`.
+/// - `flags`: other flags forwarded to rg (`-r`/`-R`/`--recursive` stripped).
 ///
-/// Value-taking short flags (see `VALUE_FLAGS_SHORT`) consume the next token
-/// as their value so it is not mistaken for the pattern. Combined clusters like
-/// `-rn` have `r`/`R` stripped before forwarding. `--` marks everything after
-/// it as positional even if flag-shaped.
+/// Short clusters are scanned left-to-right; the first value-taking letter
+/// terminates the cluster — everything after it is its inline value, not a
+/// separate flag. Long value-taking flags consume the next token. `--` marks
+/// everything after it as positional.
 fn extract_pattern_path<T: AsRef<str>>(args: &[T]) -> (Vec<String>, Vec<String>, Vec<String>) {
     let mut e_patterns: Vec<String> = Vec::new();
     let mut positionals: Vec<String> = Vec::new();
@@ -72,8 +91,29 @@ fn extract_pattern_path<T: AsRef<str>>(args: &[T]) -> (Vec<String>, Vec<String>,
             continue;
         }
 
-        // Long flags (--foo, --recursive): strip or pass through unchanged
         if arg.starts_with("--") {
+            // --regexp is the long form of -e: value goes to patterns.
+            if arg == "--regexp" {
+                if i + 1 < args.len() {
+                    e_patterns.push(args[i + 1].as_ref().to_string());
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+                continue;
+            }
+            // Other long value-taking flags: consume next token as value.
+            if VALUE_FLAGS_LONG.contains(&arg) {
+                flags.push(arg.to_string());
+                if i + 1 < args.len() {
+                    flags.push(args[i + 1].as_ref().to_string());
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+                continue;
+            }
+            // Drop --recursive; pass everything else through.
             if let Some(cleaned) = strip_recursive(arg) {
                 flags.push(cleaned);
             }
@@ -83,42 +123,56 @@ fn extract_pattern_path<T: AsRef<str>>(args: &[T]) -> (Vec<String>, Vec<String>,
 
         match arg.strip_prefix('-') {
             Some(rest) if !rest.is_empty() => {
-                let last = *rest.as_bytes().last().unwrap();
-                let last_is_e = last == b'e';
-                let last_takes_value = last_is_e || VALUE_FLAGS_SHORT.contains(&last);
-
-                if last_takes_value {
-                    // Emit cleaned prefix (everything before last char, r/R stripped)
-                    if let Some(prefix) = strip_r(&rest[..rest.len() - 1]) {
-                        flags.push(format!("-{}", prefix));
+                // Left-to-right scan: r/R stripped, first value-taking char terminates.
+                let bytes = rest.as_bytes();
+                let mut bool_acc = String::new();
+                let mut consumed_value = false;
+                let mut j = 0;
+                while j < bytes.len() {
+                    let ch = bytes[j];
+                    if ch == b'r' || ch == b'R' {
+                        j += 1;
+                        continue;
                     }
-
-                    let value = if i + 1 < args.len() {
-                        let v = args[i + 1].as_ref().to_string();
-                        i += 2;
-                        Some(v)
-                    } else {
-                        i += 1;
-                        None
-                    };
-
-                    if last_is_e {
-                        if let Some(v) = value {
-                            e_patterns.push(v);
+                    let is_e = ch == b'e';
+                    if is_e || VALUE_FLAGS_SHORT.contains(&ch) {
+                        if !bool_acc.is_empty() {
+                            flags.push(format!("-{}", bool_acc));
+                        }
+                        // Inline value = bytes after this char in the cluster.
+                        let inline = std::str::from_utf8(&bytes[j + 1..]).unwrap_or("");
+                        if is_e {
+                            if !inline.is_empty() {
+                                e_patterns.push(inline.to_string());
+                                i += 1;
+                            } else if i + 1 < args.len() {
+                                e_patterns.push(args[i + 1].as_ref().to_string());
+                                i += 2;
+                            } else {
+                                flags.push("-e".to_string());
+                                i += 1;
+                            }
                         } else {
-                            // -e without a value: treat "e" as a normal flag to avoid losing the pattern.
-                            flags.push("-e".to_string());
+                            flags.push(format!("-{}", ch as char));
+                            if !inline.is_empty() {
+                                flags.push(inline.to_string());
+                                i += 1;
+                            } else if i + 1 < args.len() {
+                                flags.push(args[i + 1].as_ref().to_string());
+                                i += 2;
+                            } else {
+                                i += 1;
+                            }
                         }
-                    } else {
-                        flags.push(format!("-{}", last as char));
-                        if let Some(v) = value {
-                            flags.push(v);
-                        }
+                        consumed_value = true;
+                        break;
                     }
-                } else {
-                    // No value-taking flag at end: strip r/R, forward remainder
-                    if let Some(cleaned) = strip_r(rest) {
-                        flags.push(format!("-{}", cleaned));
+                    bool_acc.push(ch as char);
+                    j += 1;
+                }
+                if !consumed_value {
+                    if !bool_acc.is_empty() {
+                        flags.push(format!("-{}", bool_acc));
                     }
                     i += 1;
                 }
@@ -130,8 +184,8 @@ fn extract_pattern_path<T: AsRef<str>>(args: &[T]) -> (Vec<String>, Vec<String>,
         }
     }
 
-    // If -e was used: all positionals are paths; -e values are the patterns.
-    // If -e was not used: first positional is the pattern, rest are paths.
+    // If -e/--regexp was used: all positionals are paths.
+    // Otherwise: first positional is the pattern, rest are paths.
     let (patterns, paths) = if !e_patterns.is_empty() {
         (e_patterns, positionals)
     } else {
@@ -382,6 +436,7 @@ fn has_format_flag<T: AsRef<str>>(extra_args: &[T]) -> bool {
         matches!(
             arg.as_ref(),
             "-c" | "--count"
+                | "--count-matches"
                 | "-l"
                 | "--files-with-matches"
                 | "-L"
@@ -390,6 +445,9 @@ fn has_format_flag<T: AsRef<str>>(extra_args: &[T]) -> bool {
                 | "--only-matching"
                 | "-Z"
                 | "--null"
+                | "--json"
+                | "--passthru"
+                | "--files"
         )
     })
 }
@@ -501,18 +559,7 @@ mod tests {
         assert_eq!(rg_pattern, "fn foo|pub.*bar");
     }
 
-    // --- process_flag ---
-
-    #[test]
-    fn test_strip_r() {
-        assert_eq!(strip_r(""), None);
-        assert_eq!(strip_r("r"), None);
-        assert_eq!(strip_r("rr"), None);
-        assert_eq!(strip_r("R"), None);
-        assert_eq!(strip_r("rn"), Some("n".to_string()));
-        assert_eq!(strip_r("Rni"), Some("ni".to_string()));
-        assert_eq!(strip_r("i"), Some("i".to_string()));
-    }
+    // --- strip_recursive ---
 
     #[test]
     fn test_strip_recursive() {
@@ -640,6 +687,172 @@ mod tests {
         assert_eq!(patterns, vec!["foo", "bar"]);
         assert_eq!(paths, vec!["src"]);
         assert_eq!(flags, vec!["-e"]);
+    }
+
+    // --- inline short flag values (Bug 5) ---
+
+    #[test]
+    fn test_extract_inline_e_value() {
+        // -ecarrot: e hits at j=0, inline="carrot", no r-stripping on value
+        let (patterns, paths, flags) = extract_pattern_path(&["-ecarrot", "file"]);
+        assert_eq!(patterns, vec!["carrot"]);
+        assert_eq!(paths, vec!["file"]);
+        assert!(flags.is_empty());
+    }
+
+    #[test]
+    fn test_extract_inline_e_value_no_rstrip() {
+        // -ecarrot: the 'r' in "carrot" must NOT be stripped (it's value, not a flag)
+        let (patterns, _, _) = extract_pattern_path(&["-ecarrot", "file"]);
+        assert_eq!(patterns, vec!["carrot"], "r in inline value must not be stripped");
+    }
+
+    #[test]
+    fn test_extract_inline_g_value() {
+        // -g*.rs: g hits at j=0, inline="*.rs", no r-stripping on value
+        let (patterns, paths, flags) = extract_pattern_path(&["aaa", "sub", "-g*.rs"]);
+        assert_eq!(patterns, vec!["aaa"]);
+        assert_eq!(paths, vec!["sub"]);
+        assert_eq!(flags, vec!["-g", "*.rs"]);
+    }
+
+    #[test]
+    fn test_extract_inline_g_value_no_rstrip() {
+        // -g*.rs: the 'r' in "*.rs" must NOT be stripped
+        let (_, _, flags) = extract_pattern_path(&["aaa", "sub", "-g*.rs"]);
+        assert!(flags.contains(&"*.rs".to_string()), "r in glob value must not be stripped");
+    }
+
+    // --- long value-taking flags (Bug 5) ---
+
+    #[test]
+    fn test_extract_long_glob_value() {
+        let (patterns, paths, flags) =
+            extract_pattern_path(&["compact", "sub", "--glob", "*.md"]);
+        assert_eq!(patterns, vec!["compact"]);
+        assert_eq!(paths, vec!["sub"]);
+        assert_eq!(flags, vec!["--glob", "*.md"]);
+    }
+
+    #[test]
+    fn test_extract_long_max_count() {
+        let (patterns, paths, flags) =
+            extract_pattern_path(&["--max-count", "1", "fn", "file"]);
+        assert_eq!(patterns, vec!["fn"]);
+        assert_eq!(paths, vec!["file"]);
+        assert_eq!(flags, vec!["--max-count", "1"]);
+    }
+
+    #[test]
+    fn test_extract_short_type() {
+        // -t rust: type filter, value must not become pattern
+        let (patterns, paths, flags) = extract_pattern_path(&["-t", "rust", "fn", "src"]);
+        assert_eq!(patterns, vec!["fn"]);
+        assert_eq!(paths, vec!["src"]);
+        assert_eq!(flags, vec!["-t", "rust"]);
+    }
+
+    #[test]
+    fn test_extract_short_max_depth() {
+        // -d 3: max-depth, value must not become pattern
+        let (patterns, paths, flags) = extract_pattern_path(&["-d", "3", "foo", "src"]);
+        assert_eq!(patterns, vec!["foo"]);
+        assert_eq!(paths, vec!["src"]);
+        assert_eq!(flags, vec!["-d", "3"]);
+    }
+
+    #[test]
+    fn test_extract_short_max_columns() {
+        // -M 120: max-columns, value must not become pattern
+        let (patterns, paths, flags) = extract_pattern_path(&["-M", "120", "foo", "src"]);
+        assert_eq!(patterns, vec!["foo"]);
+        assert_eq!(paths, vec!["src"]);
+        assert_eq!(flags, vec!["-M", "120"]);
+    }
+
+    #[test]
+    fn test_extract_long_regexp() {
+        // --regexp is the long form of -e; value goes to patterns
+        let (patterns, paths, flags) = extract_pattern_path(&["--regexp", "fn run", "src"]);
+        assert_eq!(patterns, vec!["fn run"]);
+        assert_eq!(paths, vec!["src"]);
+        assert!(flags.is_empty());
+    }
+
+    #[test]
+    fn test_extract_long_regexp_multi() {
+        // --regexp can be combined with -e
+        let (patterns, paths, _) =
+            extract_pattern_path(&["--regexp", "foo", "-e", "bar", "src"]);
+        assert_eq!(patterns, vec!["foo", "bar"]);
+        assert_eq!(paths, vec!["src"]);
+    }
+
+    #[test]
+    fn test_extract_long_ignore_file() {
+        let (patterns, paths, flags) =
+            extract_pattern_path(&["--ignore-file", ".myignore", "foo", "src"]);
+        assert_eq!(patterns, vec!["foo"]);
+        assert_eq!(paths, vec!["src"]);
+        assert_eq!(flags, vec!["--ignore-file", ".myignore"]);
+    }
+
+    #[test]
+    fn test_extract_long_engine() {
+        let (patterns, paths, flags) =
+            extract_pattern_path(&["--engine", "pcre2", "foo", "src"]);
+        assert_eq!(patterns, vec!["foo"]);
+        assert_eq!(paths, vec!["src"]);
+        assert_eq!(flags, vec!["--engine", "pcre2"]);
+    }
+
+    #[test]
+    fn test_extract_long_type_clear() {
+        let (patterns, paths, flags) =
+            extract_pattern_path(&["--type-clear", "rust", "foo", "src"]);
+        assert_eq!(patterns, vec!["foo"]);
+        assert_eq!(paths, vec!["src"]);
+        assert_eq!(flags, vec!["--type-clear", "rust"]);
+    }
+
+    #[test]
+    fn test_extract_long_path_separator() {
+        let (patterns, paths, flags) =
+            extract_pattern_path(&["--path-separator", "/", "foo", "src"]);
+        assert_eq!(patterns, vec!["foo"]);
+        assert_eq!(paths, vec!["src"]);
+        assert_eq!(flags, vec!["--path-separator", "/"]);
+    }
+
+    #[test]
+    fn test_extract_long_flag_inline_eq_passthrough() {
+        // --glob=*.rs is one token (inline =): passes through as-is, not consumed as pair
+        let (patterns, paths, flags) = extract_pattern_path(&["foo", "src", "--glob=*.rs"]);
+        assert_eq!(patterns, vec!["foo"]);
+        assert_eq!(paths, vec!["src"]);
+        assert_eq!(flags, vec!["--glob=*.rs"]);
+    }
+
+    // --- has_format_flag additions ---
+
+    #[test]
+    fn test_format_flag_detects_count_matches() {
+        assert!(has_format_flag(&["--count-matches"]));
+    }
+
+    #[test]
+    fn test_format_flag_detects_json() {
+        assert!(has_format_flag(&["--json"]));
+    }
+
+    #[test]
+    fn test_format_flag_detects_passthru() {
+        assert!(has_format_flag(&["--passthru"]));
+    }
+
+    #[test]
+    fn test_format_flag_detects_files() {
+        assert!(has_format_flag(&["--files"]));
     }
 
     // --- truncation accuracy ---

--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -13,42 +13,42 @@ use std::collections::HashMap;
 /// Includes all rg short flags that take a value argument except `-e` and `-r`
 /// (stripped) and `-E` (dialect, left to #2138). Failure mode for a missing
 /// entry: the value becomes a positional (visible wrong result, not silent).
-const VALUE_FLAGS_SHORT: &[u8] = b"ABCgfjmtTdM";
+const VALUE_FLAGS_SHORT: &[u8] = b"ABCMTdfgjmt";
 
 /// Long flags that consume the NEXT token as their value (space-separated form).
 /// Inline `=` form (`--flag=value`) is one token and passes through unchanged.
 /// `--regexp` is handled separately (its value goes to `patterns`).
 /// `--encoding` value is consumed correctly here; dialect routing is #2138's job.
 const VALUE_FLAGS_LONG: &[&str] = &[
+    "--after-context",
+    "--before-context",
+    "--color",
+    "--colors",
+    "--context",
+    "--context-separator",
+    "--encoding",
+    "--engine",
+    "--field-context-separator",
+    "--field-match-separator",
     "--file",
     "--glob",
     "--iglob",
-    "--type",
-    "--type-not",
-    "--type-add",
-    "--type-clear",
+    "--ignore-file",
+    "--max-columns",
     "--max-count",
     "--max-depth",
     "--max-filesize",
-    "--max-columns",
-    "--after-context",
-    "--before-context",
-    "--context",
-    "--encoding",
-    "--engine",
+    "--path-separator",
+    "--pre",
+    "--pre-glob",
+    "--replace",
     "--sort",
     "--sortr",
     "--threads",
-    "--replace",
-    "--pre",
-    "--pre-glob",
-    "--path-separator",
-    "--ignore-file",
-    "--field-match-separator",
-    "--field-context-separator",
-    "--context-separator",
-    "--color",
-    "--colors",
+    "--type",
+    "--type-add",
+    "--type-clear",
+    "--type-not",
 ];
 
 /// Result of parsing the content of a short flag cluster (the part after `-`).
@@ -629,10 +629,22 @@ mod tests {
         assert_eq!(parse_cluster("r"), ClusterResult::Boolean(None));
         assert_eq!(parse_cluster("R"), ClusterResult::Boolean(None));
         assert_eq!(parse_cluster("rR"), ClusterResult::Boolean(None));
-        assert_eq!(parse_cluster("rn"), ClusterResult::Boolean(Some("n".to_string())));
-        assert_eq!(parse_cluster("Rni"), ClusterResult::Boolean(Some("ni".to_string())));
-        assert_eq!(parse_cluster("n"), ClusterResult::Boolean(Some("n".to_string())));
-        assert_eq!(parse_cluster("ni"), ClusterResult::Boolean(Some("ni".to_string())));
+        assert_eq!(
+            parse_cluster("rn"),
+            ClusterResult::Boolean(Some("n".to_string()))
+        );
+        assert_eq!(
+            parse_cluster("Rni"),
+            ClusterResult::Boolean(Some("ni".to_string()))
+        );
+        assert_eq!(
+            parse_cluster("n"),
+            ClusterResult::Boolean(Some("n".to_string()))
+        );
+        assert_eq!(
+            parse_cluster("ni"),
+            ClusterResult::Boolean(Some("ni".to_string()))
+        );
     }
 
     #[test]

--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -1,25 +1,93 @@
 //! Filters grep output by grouping matches by file.
 
-use crate::core::config;
 use crate::core::stream::exec_capture;
 use crate::core::tracking;
 use crate::core::utils::resolved_command;
+use crate::core::{args_utils, config};
 use anyhow::{Context, Result};
 use regex::Regex;
 use std::collections::HashMap;
 
+/// Extracts (pattern, path, flags) from the raw trailing args.
+///
+/// Scans for the first and second non-flag positional arguments. Everything
+/// after `--` is also considered positional. Flags (args starting with `-`)
+/// are collected as pass-through args for rg.
+fn extract_pattern_path(args: &[String]) -> (Option<String>, String, Vec<String>) {
+    let mut positionals: Vec<String> = Vec::new();
+    let mut flags: Vec<String> = Vec::new();
+    let mut past_dashdash = false;
+
+    for arg in args {
+        if arg == "--" {
+            past_dashdash = true;
+            continue;
+        }
+        if past_dashdash || !arg.starts_with('-') {
+            positionals.push(arg.clone());
+        } else {
+            flags.push(arg.clone());
+        }
+    }
+
+    let pattern = positionals.first().cloned();
+    let path = positionals
+        .get(1)
+        .cloned()
+        .unwrap_or_else(|| ".".to_string());
+
+    // Any extra positionals beyond pattern+path go back into flags for rg.
+    for extra in positionals.iter().skip(2) {
+        flags.push(extra.clone());
+    }
+
+    (pattern, path, flags)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn run(
-    pattern: &str,
-    path: &str,
     max_line_len: usize,
     max_results: usize,
     context_only: bool,
     file_type: Option<&str>,
-    extra_args: &[String],
+    args: &[String],
     verbose: u8,
 ) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
+
+    // --version / --help: pass through to rg without filtering.
+    // Note: Clap strips `--` before populating trailing_var_arg, so both
+    // `rtk grep --version` and `rtk grep -- --version` land here identically.
+    if args
+        .iter()
+        .any(|a| a == "--version" || a == "--help" || a == "-h")
+    {
+        let mut rg_cmd = resolved_command("rg");
+        rg_cmd.args(args);
+        let result = exec_capture(&mut rg_cmd)
+            .or_else(|_| {
+                // rg unavailable: fall back to system grep.
+                let mut grep_cmd = resolved_command("grep");
+                grep_cmd.args(args);
+                exec_capture(&mut grep_cmd)
+            })
+            .context("grep/rg failed")?;
+        print!("{}", result.stdout);
+        if !result.stderr.is_empty() {
+            eprint!("{}", result.stderr);
+        }
+        return Ok(result.exit_code);
+    }
+
+    // Re-insert `--` when clap's trailing_var_arg consumed it
+    let args = args_utils::restore_double_dash(args);
+
+    let (pattern_opt, path, extra_args) = extract_pattern_path(&args);
+
+    let Some(pattern) = pattern_opt else {
+        eprintln!("rtk grep: pattern required");
+        return Ok(1);
+    };
 
     if verbose > 0 {
         eprintln!("grep: '{}' in {}", pattern, path);
@@ -36,13 +104,13 @@ pub fn run(
     // -H: always emit the filename.
     // -0: NUL-separate filename. Allows the parser to disambiguate filenames or
     // content containing `:digits:` patterns (issue #1436).
-    rg_cmd.args(["-nH0", "--no-heading", "--no-ignore-vcs", &rg_pattern, path]);
+    rg_cmd.args(["-nH0", "--no-heading", "--no-ignore-vcs"]);
 
     if let Some(ft) = file_type {
         rg_cmd.arg("--type").arg(ft);
     }
 
-    for arg in extra_args {
+    for arg in &extra_args {
         // Fix: skip grep-ism -r flag (rg is recursive by default; rg -r means --replace)
         if arg == "-r" || arg == "--recursive" {
             continue;
@@ -50,17 +118,25 @@ pub fn run(
         rg_cmd.arg(arg);
     }
 
+    // `--` after all flags, before pattern + path: prevents rg from interpreting
+    // patterns starting with `-` (e.g. `--version`) as its own flags.
+    rg_cmd.args(["--", &rg_pattern, &path]);
+
     let result = exec_capture(&mut rg_cmd)
         .or_else(|_| {
+            // rg unavailable: fall back to system grep with the original,
+            // untranslated pattern (grep interprets BRE natively).
+            // `--` before pattern keeps grep from misreading flag-like patterns.
             let mut grep_cmd = resolved_command("grep");
-            // When we fall back to grep, include all args, not just -rnHZ.
-            grep_cmd.args(["-rnHZ", pattern, path]).args(extra_args);
+            grep_cmd
+                .args(&extra_args)
+                .args(["-rnHZ", "--", &pattern, &path]);
             exec_capture(&mut grep_cmd)
         })
         .context("grep/rg failed")?;
 
     // Passthrough output flags that produce output that is already small.
-    if has_format_flag(extra_args) {
+    if has_format_flag(&extra_args) {
         print!("{}", result.stdout);
         if !result.stderr.is_empty() {
             eprint!("{}", result.stderr.trim());
@@ -98,13 +174,8 @@ pub fn run(
         return Ok(exit_code);
     }
 
-    // Always filter: truncate long lines, apply per-file and global caps.
-    // Output in standard file:line:content format that AI agents can parse.
-    // (A passthrough approach yields 0% savings — no reason for RTK to exist on that path.)
-    let total_matches = result.stdout.lines().count();
-
     let context_re = if context_only {
-        Regex::new(&format!("(?i).{{0,20}}{}.*", regex::escape(pattern))).ok()
+        Regex::new(&format!("(?i).{{0,20}}{}.*", regex::escape(&pattern))).ok()
     } else {
         None
     };
@@ -114,9 +185,12 @@ pub fn run(
         let Some((file, line_num, content)) = parse_match_line(line) else {
             continue;
         };
-        let cleaned = clean_line(content, max_line_len, context_re.as_ref(), pattern);
+        let cleaned = clean_line(content, max_line_len, context_re.as_ref(), &pattern);
         by_file.entry(file).or_default().push((line_num, cleaned));
     }
+
+    // Derive total from parsed results so the header matches what we show.
+    let total_matches: usize = by_file.values().map(|v| v.len()).sum();
 
     let mut rtk_output = String::new();
     rtk_output.push_str(&format!(
@@ -324,6 +398,51 @@ mod tests {
             .collect();
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0], "-i");
+    }
+
+    // --- extract_pattern_path ---
+
+    #[test]
+    fn test_extract_pattern_path_simple() {
+        let args = vec!["foo".to_string(), "src/".to_string()];
+        let (pat, path, flags) = extract_pattern_path(&args);
+        assert_eq!(pat.as_deref(), Some("foo"));
+        assert_eq!(path, "src/");
+        assert!(flags.is_empty());
+    }
+
+    #[test]
+    fn test_extract_pattern_path_with_flags() {
+        let args = vec!["-i".to_string(), "foo".to_string(), "src/".to_string()];
+        let (pat, path, flags) = extract_pattern_path(&args);
+        assert_eq!(pat.as_deref(), Some("foo"));
+        assert_eq!(path, "src/");
+        assert_eq!(flags, vec!["-i"]);
+    }
+
+    #[test]
+    fn test_extract_pattern_path_default_path() {
+        let args = vec!["foo".to_string()];
+        let (pat, path, _flags) = extract_pattern_path(&args);
+        assert_eq!(pat.as_deref(), Some("foo"));
+        assert_eq!(path, ".");
+    }
+
+    #[test]
+    fn test_extract_pattern_path_no_args() {
+        let (pat, path, _flags) = extract_pattern_path(&[]);
+        assert!(pat.is_none());
+        assert_eq!(path, ".");
+    }
+
+    #[test]
+    fn test_extract_pattern_path_dashdash() {
+        // After --, args are positional even if they look like flags
+        let args = vec!["--".to_string(), "--version".to_string()];
+        let (pat, path, flags) = extract_pattern_path(&args);
+        assert_eq!(pat.as_deref(), Some("--version"));
+        assert_eq!(path, ".");
+        assert!(flags.is_empty());
     }
 
     // --- truncation accuracy ---

--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -51,12 +51,63 @@ const VALUE_FLAGS_LONG: &[&str] = &[
     "--colors",
 ];
 
-/// Strip `r`/`R` from the boolean-flag portion of a short cluster.
-/// Returns `None` when nothing remains (the cluster was purely recursive flags).
+/// Result of parsing the content of a short flag cluster (the part after `-`).
+#[derive(Debug, PartialEq)]
+enum ClusterResult {
+    /// All chars were boolean flags or `r`/`R` (stripped).
+    /// `None` when the entire cluster reduces to nothing after stripping.
+    Boolean(Option<String>),
+    /// A value-taking flag was encountered. Scanning stops here.
+    ValueTaking {
+        /// Boolean flags before the value-taking char, `r`/`R` stripped.
+        prefix: Option<String>,
+        /// The value-taking flag char (`e`, `A`, `g`, etc.).
+        flag: char,
+        /// Bytes after `flag` in the cluster — its inline value.
+        /// Empty string means "consume the next token instead."
+        inline: String,
+    },
+}
+
+/// Parse the content of a short flag cluster (everything after the leading `-`).
 ///
-/// IMPORTANT: must only be called on the accumulated flag-letter prefix, never
-/// on inline values — `strip_r("carrot")` would corrupt the value to `"caot"`,
-/// which is exactly the original bug this function replaces.
+/// Scans left-to-right: strips `r`/`R`, accumulates boolean flag letters, and
+/// stops at the first value-taking flag (from `VALUE_FLAGS_SHORT` or `e`).
+/// Everything after that flag char in the cluster is its inline value and is
+/// returned verbatim — no `r`/`R` stripping is applied to it.
+///
+/// This is the only place in the codebase that touches cluster bytes.
+fn parse_cluster(rest: &str) -> ClusterResult {
+    let bytes = rest.as_bytes();
+    let mut raw_prefix = String::new();
+    let mut j = 0;
+    while j < bytes.len() {
+        let ch = bytes[j];
+        let is_e = ch == b'e';
+        if is_e || VALUE_FLAGS_SHORT.contains(&ch) {
+            let prefix = strip_r(&raw_prefix);
+            // Inline value = bytes after this char; returned verbatim (no stripping).
+            let inline = std::str::from_utf8(&bytes[j + 1..])
+                .unwrap_or("")
+                .to_string();
+            return ClusterResult::ValueTaking {
+                prefix,
+                flag: ch as char,
+                inline,
+            };
+        }
+        raw_prefix.push(ch as char);
+        j += 1;
+    }
+    ClusterResult::Boolean(strip_r(&raw_prefix))
+}
+
+/// Strip `r`/`R` from a string of flag letters.
+/// Returns `None` when nothing remains after stripping.
+///
+/// Only called on accumulated flag letters (never on inline values).
+/// `strip_r("carrot")` → `Some("caot")` — this shows exactly why it must not
+/// touch value bytes; that corruption was the original `-ecarrot` bug.
 fn strip_r(flag_letters: &str) -> Option<String> {
     let s: String = flag_letters
         .chars()
@@ -140,62 +191,46 @@ fn extract_pattern_path<T: AsRef<str>>(args: &[T]) -> (Vec<String>, Vec<String>,
         }
 
         match arg.strip_prefix('-') {
-            Some(rest) if !rest.is_empty() => {
-                // Left-to-right scan: accumulate flag letters (including r/R) into
-                // raw_prefix; strip_r is called at emit time so it is never applied
-                // to inline value bytes (which follow the first value-taking char).
-                let bytes = rest.as_bytes();
-                let mut raw_prefix = String::new();
-                let mut consumed_value = false;
-                let mut j = 0;
-                while j < bytes.len() {
-                    let ch = bytes[j];
-                    let is_e = ch == b'e';
-                    if is_e || VALUE_FLAGS_SHORT.contains(&ch) {
-                        // Emit the boolean prefix with r/R stripped.
-                        if let Some(prefix) = strip_r(&raw_prefix) {
-                            flags.push(format!("-{}", prefix));
-                        }
-                        // Inline value = bytes after this char in the cluster.
-                        // strip_r is NOT called here — these are value bytes, not flags.
-                        let inline = std::str::from_utf8(&bytes[j + 1..]).unwrap_or("");
-                        if is_e {
-                            if !inline.is_empty() {
-                                e_patterns.push(inline.to_string());
-                                i += 1;
-                            } else if i + 1 < args.len() {
-                                e_patterns.push(args[i + 1].as_ref().to_string());
-                                i += 2;
-                            } else {
-                                flags.push("-e".to_string());
-                                i += 1;
-                            }
-                        } else {
-                            flags.push(format!("-{}", ch as char));
-                            if !inline.is_empty() {
-                                flags.push(inline.to_string());
-                                i += 1;
-                            } else if i + 1 < args.len() {
-                                flags.push(args[i + 1].as_ref().to_string());
-                                i += 2;
-                            } else {
-                                i += 1;
-                            }
-                        }
-                        consumed_value = true;
-                        break;
-                    }
-                    raw_prefix.push(ch as char);
-                    j += 1;
-                }
-                if !consumed_value {
-                    // Pure boolean cluster: strip r/R, emit remainder.
-                    if let Some(stripped) = strip_r(&raw_prefix) {
-                        flags.push(format!("-{}", stripped));
+            Some(rest) if !rest.is_empty() => match parse_cluster(rest) {
+                ClusterResult::Boolean(prefix) => {
+                    if let Some(s) = prefix {
+                        flags.push(format!("-{}", s));
                     }
                     i += 1;
                 }
-            }
+                ClusterResult::ValueTaking {
+                    prefix,
+                    flag,
+                    inline,
+                } => {
+                    if let Some(s) = prefix {
+                        flags.push(format!("-{}", s));
+                    }
+                    if flag == 'e' {
+                        if !inline.is_empty() {
+                            e_patterns.push(inline);
+                            i += 1;
+                        } else if i + 1 < args.len() {
+                            e_patterns.push(args[i + 1].as_ref().to_string());
+                            i += 2;
+                        } else {
+                            flags.push("-e".to_string());
+                            i += 1;
+                        }
+                    } else {
+                        flags.push(format!("-{}", flag));
+                        if !inline.is_empty() {
+                            flags.push(inline);
+                            i += 1;
+                        } else if i + 1 < args.len() {
+                            flags.push(args[i + 1].as_ref().to_string());
+                            i += 2;
+                        } else {
+                            i += 1;
+                        }
+                    }
+                }
+            },
             _ => {
                 positionals.push(arg.to_string());
                 i += 1;
@@ -578,26 +613,112 @@ mod tests {
         assert_eq!(rg_pattern, "fn foo|pub.*bar");
     }
 
-    // --- strip_r / strip_recursive ---
+    // --- parse_cluster ---
+
+    fn vt(prefix: Option<&str>, flag: char, inline: &str) -> ClusterResult {
+        ClusterResult::ValueTaking {
+            prefix: prefix.map(|s| s.to_string()),
+            flag,
+            inline: inline.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_parse_cluster_boolean_only() {
+        // Pure boolean clusters: r/R stripped, remainder emitted
+        assert_eq!(parse_cluster("r"), ClusterResult::Boolean(None));
+        assert_eq!(parse_cluster("R"), ClusterResult::Boolean(None));
+        assert_eq!(parse_cluster("rR"), ClusterResult::Boolean(None));
+        assert_eq!(parse_cluster("rn"), ClusterResult::Boolean(Some("n".to_string())));
+        assert_eq!(parse_cluster("Rni"), ClusterResult::Boolean(Some("ni".to_string())));
+        assert_eq!(parse_cluster("n"), ClusterResult::Boolean(Some("n".to_string())));
+        assert_eq!(parse_cluster("ni"), ClusterResult::Boolean(Some("ni".to_string())));
+    }
+
+    #[test]
+    fn test_parse_cluster_e_no_inline() {
+        // -e: value-taking, empty inline → caller consumes next token
+        assert_eq!(parse_cluster("e"), vt(None, 'e', ""));
+    }
+
+    #[test]
+    fn test_parse_cluster_e_inline_value() {
+        // -ecarrot: inline="carrot" — no r/R stripping on the value bytes
+        assert_eq!(parse_cluster("ecarrot"), vt(None, 'e', "carrot"));
+    }
+
+    #[test]
+    fn test_parse_cluster_e_inline_value_no_rstrip() {
+        // The 'r' chars in "carrot" must survive verbatim in the inline field.
+        // If strip_r were called on inline bytes, this would return "caot".
+        let ClusterResult::ValueTaking { inline, .. } = parse_cluster("ecarrot") else {
+            panic!("expected ValueTaking");
+        };
+        assert_eq!(inline, "carrot");
+    }
+
+    #[test]
+    fn test_parse_cluster_g_inline_glob() {
+        // -g*.rs: inline="*.rs" — 'r' in "*.rs" must not be stripped
+        assert_eq!(parse_cluster("g*.rs"), vt(None, 'g', "*.rs"));
+        let ClusterResult::ValueTaking { inline, .. } = parse_cluster("g*.rs") else {
+            panic!("expected ValueTaking");
+        };
+        assert_eq!(inline, "*.rs");
+    }
+
+    #[test]
+    fn test_parse_cluster_rne() {
+        // -rne: r stripped, n in boolean prefix, e is value-taking (empty inline)
+        assert_eq!(parse_cluster("rne"), vt(Some("n"), 'e', ""));
+    }
+
+    #[test]
+    fn test_parse_cluster_r_a() {
+        // -rA: r stripped, A is value-taking (empty inline → consume next token)
+        assert_eq!(parse_cluster("rA"), vt(None, 'A', ""));
+    }
+
+    #[test]
+    fn test_parse_cluster_ni_a() {
+        // -niA: n and i boolean, A value-taking
+        assert_eq!(parse_cluster("niA"), vt(Some("ni"), 'A', ""));
+    }
+
+    #[test]
+    fn test_parse_cluster_ai_inline() {
+        // -Ai: A value-taking, inline="i" (the 'i' is A's value, not a separate flag)
+        assert_eq!(parse_cluster("Ai"), vt(None, 'A', "i"));
+    }
+
+    #[test]
+    fn test_parse_cluster_short_type() {
+        assert_eq!(parse_cluster("t"), vt(None, 't', ""));
+        assert_eq!(parse_cluster("tpy"), vt(None, 't', "py")); // inline type name
+    }
+
+    #[test]
+    fn test_parse_cluster_short_max_columns() {
+        assert_eq!(parse_cluster("M"), vt(None, 'M', ""));
+        assert_eq!(parse_cluster("M120"), vt(None, 'M', "120"));
+    }
+
+    // --- strip_r ---
 
     #[test]
     fn test_strip_r() {
-        // Pure r/R → None (whole cluster dropped)
         assert_eq!(strip_r("r"), None);
         assert_eq!(strip_r("R"), None);
-        assert_eq!(strip_r("rr"), None);
         assert_eq!(strip_r("rR"), None);
         assert_eq!(strip_r(""), None);
-        // Mixed → r/R removed, rest kept
         assert_eq!(strip_r("rn"), Some("n".to_string()));
         assert_eq!(strip_r("Rni"), Some("ni".to_string()));
-        assert_eq!(strip_r("rni"), Some("ni".to_string()));
         assert_eq!(strip_r("i"), Some("i".to_string()));
-        // Reveals the danger: strip_r must NEVER be called on value bytes.
-        // Calling it on "carrot" strips both 'r's and produces "caot" — this
-        // is exactly the original bug (-ecarrot matching "caot" instead of "carrot").
+        // Shows why it must only be called on flag letters, not value bytes:
         assert_eq!(strip_r("carrot"), Some("caot".to_string()));
     }
+
+    // --- strip_recursive ---
 
     #[test]
     fn test_strip_recursive() {

--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -8,40 +8,116 @@ use anyhow::{Context, Result};
 use regex::Regex;
 use std::collections::HashMap;
 
-/// Extracts (pattern, path, flags) from the raw trailing args.
+/// Short flags (exact 2-char form `-X`) that consume one following token as their value.
+/// `-e` is handled separately — its value goes into `patterns`, not `flags`.
+/// Deliberately small: unknown flags pass through unchanged. The failure mode
+/// for a missing entry is a visible wrong result, not a silent corruption.
+const VALUE_FLAGS_SHORT: &[u8] = b"ABCgfjm";
+
+/// Normalise a flag arg for rg forwarding.
+/// Returns `None` when the flag should be dropped (grep-ism recursive flags).
+fn process_flag(arg: &str) -> Option<String> {
+    if arg == "--recursive" {
+        return None;
+    }
+    // Long flags pass through unchanged.
+    if arg.starts_with("--") {
+        return Some(arg.to_string());
+    }
+    // Short clusters: strip `r`/`R` (grep recursive; rg -r means --replace).
+    if let Some(rest) = arg.strip_prefix('-') {
+        let cleaned: String = rest.chars().filter(|&c| c != 'r' && c != 'R').collect();
+        return if cleaned.is_empty() {
+            None
+        } else {
+            Some(format!("-{}", cleaned))
+        };
+    }
+    Some(arg.to_string())
+}
+
+/// Extracts `(patterns, paths, flags)` from the raw trailing args.
 ///
-/// Scans for the first and second non-flag positional arguments. Everything
-/// after `--` is also considered positional. Flags (args starting with `-`)
-/// are collected as pass-through args for rg.
-fn extract_pattern_path(args: &[String]) -> (Option<String>, String, Vec<String>) {
+/// - `patterns`: first non-flag positional prepended to any `-e` values.
+///   All patterns are passed to rg as `-e` flags, so positional and `-e` are
+///   interchangeable from rg's perspective. Empty → caller should error.
+/// - `paths`: all subsequent non-flag positionals. Empty → caller defaults to `["."]`.
+/// - `flags`: other flags forwarded to rg (recursive flags already stripped).
+///
+/// Value-taking short flags (see `VALUE_FLAGS_SHORT`) consume the next token
+/// as their value so it is not mistaken for the pattern. Combined clusters like
+/// `-rn` have `r`/`R` stripped before forwarding. `--` marks everything after
+/// it as positional even if flag-shaped.
+fn extract_pattern_path(args: &[String]) -> (Vec<String>, Vec<String>, Vec<String>) {
+    let mut e_patterns: Vec<String> = Vec::new();
     let mut positionals: Vec<String> = Vec::new();
     let mut flags: Vec<String> = Vec::new();
     let mut past_dashdash = false;
+    let mut i = 0;
 
-    for arg in args {
-        if arg == "--" {
-            past_dashdash = true;
+    while i < args.len() {
+        let arg = &args[i];
+
+        if past_dashdash {
+            positionals.push(arg.clone());
+            i += 1;
             continue;
         }
-        if past_dashdash || !arg.starts_with('-') {
-            positionals.push(arg.clone());
+
+        if arg == "--" {
+            past_dashdash = true;
+            i += 1;
+            continue;
+        }
+
+        if arg.starts_with('-') {
+            // -e: consume value into patterns (not flags)
+            if arg == "-e" {
+                if i + 1 < args.len() {
+                    e_patterns.push(args[i + 1].clone());
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+                continue;
+            }
+
+            // Exact 2-char value-taking flag: consume next token as value
+            if arg.len() == 2
+                && VALUE_FLAGS_SHORT.contains(&arg.as_bytes()[1])
+            {
+                flags.push(arg.clone());
+                if i + 1 < args.len() {
+                    flags.push(args[i + 1].clone());
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+                continue;
+            }
+
+            // Strip recursive flags; pass everything else through
+            if let Some(cleaned) = process_flag(arg) {
+                flags.push(cleaned);
+            }
+            i += 1;
         } else {
-            flags.push(arg.clone());
+            positionals.push(arg.clone());
+            i += 1;
         }
     }
 
-    let pattern = positionals.first().cloned();
-    let path = positionals
-        .get(1)
-        .cloned()
-        .unwrap_or_else(|| ".".to_string());
+    // If -e was used: all positionals are paths; -e values are the patterns.
+    // If -e was not used: first positional is the pattern, rest are paths.
+    let (patterns, paths) = if !e_patterns.is_empty() {
+        (e_patterns, positionals)
+    } else {
+        let paths = positionals.iter().skip(1).cloned().collect();
+        let patterns = positionals.into_iter().take(1).collect();
+        (patterns, paths)
+    };
 
-    // Any extra positionals beyond pattern+path go back into flags for rg.
-    for extra in positionals.iter().skip(2) {
-        flags.push(extra.clone());
-    }
-
-    (pattern, path, flags)
+    (patterns, paths, flags)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -82,19 +158,29 @@ pub fn run(
     // Re-insert `--` when clap's trailing_var_arg consumed it
     let args = args_utils::restore_double_dash(args);
 
-    let (pattern_opt, path, extra_args) = extract_pattern_path(&args);
+    let (patterns, paths, extra_args) = extract_pattern_path(&args);
 
-    let Some(pattern) = pattern_opt else {
-        eprintln!("rtk grep: pattern required");
+    if patterns.is_empty() {
+        eprintln!("rtk grep: pattern required (positional or -e)");
         return Ok(1);
-    };
-
-    if verbose > 0 {
-        eprintln!("grep: '{}' in {}", pattern, path);
     }
 
-    // Fix: convert BRE alternation \| → | for rg (which uses PCRE-style regex)
-    let rg_pattern = pattern.replace(r"\|", "|");
+    let display_pattern = if patterns.len() == 1 {
+        patterns[0].clone()
+    } else {
+        patterns.join("|")
+    };
+
+    let paths = if paths.is_empty() {
+        vec![".".to_string()]
+    } else {
+        paths
+    };
+    let path_display = paths.join(" ");
+
+    if verbose > 0 {
+        eprintln!("grep: '{}' in {}", display_pattern, path_display);
+    }
 
     let mut rg_cmd = resolved_command("rg");
     // --no-ignore-vcs: match grep -r behavior (don't skip .gitignore'd files).
@@ -110,27 +196,31 @@ pub fn run(
         rg_cmd.arg("--type").arg(ft);
     }
 
-    for arg in &extra_args {
-        // Fix: skip grep-ism -r flag (rg is recursive by default; rg -r means --replace)
-        if arg == "-r" || arg == "--recursive" {
-            continue;
-        }
-        rg_cmd.arg(arg);
+    // extra_args is already stripped of -r/-R/-recursive by extract_pattern_path
+    rg_cmd.args(&extra_args);
+
+    // All patterns as -e flags (BRE \| → | translation for rg's PCRE engine).
+    // Using -e keeps `--` semantically as a flag/path separator, not part of the pattern.
+    for p in &patterns {
+        rg_cmd.args(["-e", &p.replace(r"\|", "|")]);
     }
 
-    // `--` after all flags, before pattern + path: prevents rg from interpreting
-    // patterns starting with `-` (e.g. `--version`) as its own flags.
-    rg_cmd.args(["--", &rg_pattern, &path]);
+    // `--` after all flags: prevents rg from interpreting path args starting
+    // with `-` as its own flags.
+    rg_cmd.arg("--");
+    rg_cmd.args(&paths);
 
     let result = exec_capture(&mut rg_cmd)
         .or_else(|_| {
             // rg unavailable: fall back to system grep with the original,
-            // untranslated pattern (grep interprets BRE natively).
-            // `--` before pattern keeps grep from misreading flag-like patterns.
+            // untranslated patterns (grep interprets BRE natively).
             let mut grep_cmd = resolved_command("grep");
-            grep_cmd
-                .args(&extra_args)
-                .args(["-rnHZ", "--", &pattern, &path]);
+            grep_cmd.args(&extra_args);
+            for p in &patterns {
+                grep_cmd.args(["-e", p]);
+            }
+            grep_cmd.args(["-rnHZ", "--"]);
+            grep_cmd.args(&paths);
             exec_capture(&mut grep_cmd)
         })
         .context("grep/rg failed")?;
@@ -143,9 +233,9 @@ pub fn run(
         }
 
         let args_display = if extra_args.is_empty() {
-            format!("'{}' {}", pattern, path)
+            format!("'{}' {}", display_pattern, path_display)
         } else {
-            format!("{} '{}' {}", extra_args.join(" "), pattern, path)
+            format!("{} '{}' {}", extra_args.join(" "), display_pattern, path_display)
         };
 
         timer.track_passthrough(
@@ -163,10 +253,10 @@ pub fn run(
         if exit_code == 2 && !result.stderr.trim().is_empty() {
             eprintln!("{}", result.stderr.trim());
         }
-        let msg = format!("0 matches for '{}'", pattern);
+        let msg = format!("0 matches for '{}'", display_pattern);
         println!("{}", msg);
         timer.track(
-            &format!("grep -rn '{}' {}", pattern, path),
+            &format!("grep -rn '{}' {}", display_pattern, path_display),
             "rtk grep",
             &raw_output,
             &msg,
@@ -175,7 +265,11 @@ pub fn run(
     }
 
     let context_re = if context_only {
-        Regex::new(&format!("(?i).{{0,20}}{}.*", regex::escape(&pattern))).ok()
+        Regex::new(&format!(
+            "(?i).{{0,20}}{}.*",
+            regex::escape(&display_pattern)
+        ))
+        .ok()
     } else {
         None
     };
@@ -185,7 +279,7 @@ pub fn run(
         let Some((file, line_num, content)) = parse_match_line(line) else {
             continue;
         };
-        let cleaned = clean_line(content, max_line_len, context_re.as_ref(), &pattern);
+        let cleaned = clean_line(content, max_line_len, context_re.as_ref(), &display_pattern);
         by_file.entry(file).or_default().push((line_num, cleaned));
     }
 
@@ -225,7 +319,7 @@ pub fn run(
 
     print!("{}", rtk_output);
     timer.track(
-        &format!("grep -rn '{}' {}", pattern, path),
+        &format!("grep -rn '{}' {}", display_pattern, path_display),
         "rtk grep",
         &raw_output,
         &rtk_output,
@@ -357,14 +451,6 @@ mod tests {
     }
 
     #[test]
-    fn test_extra_args_accepted() {
-        // Test that the function signature accepts extra_args
-        // This is a compile-time test - if it compiles, the signature is correct
-        let _extra: Vec<String> = vec!["-i".to_string(), "-A".to_string(), "3".to_string()];
-        // No need to actually run - we're verifying the parameter exists
-    }
-
-    #[test]
     fn test_clean_line_multibyte() {
         // Thai text that exceeds max_len in bytes
         let line = "  สวัสดีครับ นี่คือข้อความที่ยาวมากสำหรับทดสอบ  ";
@@ -388,61 +474,117 @@ mod tests {
         assert_eq!(rg_pattern, "fn foo|pub.*bar");
     }
 
-    // Fix: -r flag (grep recursive) is stripped from extra_args (rg is recursive by default)
+    // --- process_flag ---
+
     #[test]
-    fn test_recursive_flag_stripped() {
-        let extra_args: Vec<String> = vec!["-r".to_string(), "-i".to_string()];
-        let filtered: Vec<&String> = extra_args
-            .iter()
-            .filter(|a| *a != "-r" && *a != "--recursive")
-            .collect();
-        assert_eq!(filtered.len(), 1);
-        assert_eq!(filtered[0], "-i");
+    fn test_process_flag_strip_r() {
+        assert_eq!(process_flag("-r"), None);
+        assert_eq!(process_flag("-R"), None);
+        assert_eq!(process_flag("--recursive"), None);
+        assert_eq!(process_flag("-rn"), Some("-n".to_string()));
+        assert_eq!(process_flag("-Rni"), Some("-ni".to_string()));
+        assert_eq!(process_flag("-i"), Some("-i".to_string()));
+        assert_eq!(process_flag("--glob"), Some("--glob".to_string()));
     }
 
     // --- extract_pattern_path ---
 
+    fn s(v: &[&str]) -> Vec<String> {
+        v.iter().map(|x| x.to_string()).collect()
+    }
+
     #[test]
-    fn test_extract_pattern_path_simple() {
-        let args = vec!["foo".to_string(), "src/".to_string()];
-        let (pat, path, flags) = extract_pattern_path(&args);
-        assert_eq!(pat.as_deref(), Some("foo"));
-        assert_eq!(path, "src/");
+    fn test_extract_simple() {
+        let (patterns, paths, flags) = extract_pattern_path(&s(&["foo", "src/"]));
+        assert_eq!(patterns, s(&["foo"]));
+        assert_eq!(paths, s(&["src/"]));
         assert!(flags.is_empty());
     }
 
     #[test]
-    fn test_extract_pattern_path_with_flags() {
-        let args = vec!["-i".to_string(), "foo".to_string(), "src/".to_string()];
-        let (pat, path, flags) = extract_pattern_path(&args);
-        assert_eq!(pat.as_deref(), Some("foo"));
-        assert_eq!(path, "src/");
-        assert_eq!(flags, vec!["-i"]);
+    fn test_extract_with_bool_flag() {
+        let (patterns, paths, flags) = extract_pattern_path(&s(&["-i", "foo", "src/"]));
+        assert_eq!(patterns, s(&["foo"]));
+        assert_eq!(paths, s(&["src/"]));
+        assert_eq!(flags, s(&["-i"]));
     }
 
     #[test]
-    fn test_extract_pattern_path_default_path() {
-        let args = vec!["foo".to_string()];
-        let (pat, path, _flags) = extract_pattern_path(&args);
-        assert_eq!(pat.as_deref(), Some("foo"));
-        assert_eq!(path, ".");
+    fn test_extract_value_taking_flag() {
+        // -A 2 must not steal "error" as its value
+        let (patterns, paths, flags) = extract_pattern_path(&s(&["-A", "2", "error", "src"]));
+        assert_eq!(patterns, s(&["error"]));
+        assert_eq!(paths, s(&["src"]));
+        assert_eq!(flags, s(&["-A", "2"]));
     }
 
     #[test]
-    fn test_extract_pattern_path_no_args() {
-        let (pat, path, _flags) = extract_pattern_path(&[]);
-        assert!(pat.is_none());
-        assert_eq!(path, ".");
+    fn test_extract_cluster_strip_r() {
+        // -rn: r stripped, n forwarded (not leaked to rg as --replace value)
+        let (patterns, paths, flags) = extract_pattern_path(&s(&["-rn", "foo", "src"]));
+        assert_eq!(patterns, s(&["foo"]));
+        assert_eq!(paths, s(&["src"]));
+        assert_eq!(flags, s(&["-n"]));
     }
 
     #[test]
-    fn test_extract_pattern_path_dashdash() {
+    fn test_extract_multi_path() {
+        let (patterns, paths, flags) = extract_pattern_path(&s(&["TODO", "src", "tests"]));
+        assert_eq!(patterns, s(&["TODO"]));
+        assert_eq!(paths, s(&["src", "tests"]));
+        assert!(flags.is_empty());
+    }
+
+    #[test]
+    fn test_extract_glob_value() {
+        // -g '*.md' must not steal "agent" as its value
+        let (patterns, paths, flags) =
+            extract_pattern_path(&s(&["-i", "x", "agent", "-g", "*.md"]));
+        assert_eq!(patterns, s(&["x"]));
+        assert_eq!(paths, s(&["agent"]));
+        assert_eq!(flags, s(&["-i", "-g", "*.md"]));
+    }
+
+    #[test]
+    fn test_extract_e_flag() {
+        let (patterns, paths, flags) = extract_pattern_path(&s(&["-e", "fn run", "src"]));
+        assert_eq!(patterns, s(&["fn run"]));
+        assert_eq!(paths, s(&["src"]));
+        assert!(flags.is_empty());
+    }
+
+    #[test]
+    fn test_extract_multi_e() {
+        let (patterns, paths, flags) =
+            extract_pattern_path(&s(&["-e", "foo", "-e", "bar", "src"]));
+        assert_eq!(patterns, s(&["foo", "bar"]));
+        assert_eq!(paths, s(&["src"]));
+        assert!(flags.is_empty());
+    }
+
+    #[test]
+    fn test_extract_dashdash_boundary() {
         // After --, args are positional even if they look like flags
-        let args = vec!["--".to_string(), "--version".to_string()];
-        let (pat, path, flags) = extract_pattern_path(&args);
-        assert_eq!(pat.as_deref(), Some("--version"));
-        assert_eq!(path, ".");
+        let (patterns, paths, flags) = extract_pattern_path(&s(&["--", "--version"]));
+        assert_eq!(patterns, s(&["--version"]));
+        assert!(paths.is_empty());
         assert!(flags.is_empty());
+    }
+
+    #[test]
+    fn test_extract_no_args() {
+        let (patterns, paths, flags) = extract_pattern_path(&[]);
+        assert!(patterns.is_empty());
+        assert!(paths.is_empty());
+        assert!(flags.is_empty());
+    }
+
+    #[test]
+    fn test_extract_default_path_empty() {
+        // Caller is responsible for defaulting empty paths to ["."]
+        let (patterns, paths, _) = extract_pattern_path(&s(&["foo"]));
+        assert_eq!(patterns, s(&["foo"]));
+        assert!(paths.is_empty());
     }
 
     // --- truncation accuracy ---

--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -51,6 +51,24 @@ const VALUE_FLAGS_LONG: &[&str] = &[
     "--colors",
 ];
 
+/// Strip `r`/`R` from the boolean-flag portion of a short cluster.
+/// Returns `None` when nothing remains (the cluster was purely recursive flags).
+///
+/// IMPORTANT: must only be called on the accumulated flag-letter prefix, never
+/// on inline values — `strip_r("carrot")` would corrupt the value to `"caot"`,
+/// which is exactly the original bug this function replaces.
+fn strip_r(flag_letters: &str) -> Option<String> {
+    let s: String = flag_letters
+        .chars()
+        .filter(|&c| c != 'r' && c != 'R')
+        .collect();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
+}
+
 /// Drop `--recursive` (grep-ism); pass all other long flags through unchanged.
 fn strip_recursive(arg: &str) -> Option<String> {
     match arg {
@@ -123,23 +141,23 @@ fn extract_pattern_path<T: AsRef<str>>(args: &[T]) -> (Vec<String>, Vec<String>,
 
         match arg.strip_prefix('-') {
             Some(rest) if !rest.is_empty() => {
-                // Left-to-right scan: r/R stripped, first value-taking char terminates.
+                // Left-to-right scan: accumulate flag letters (including r/R) into
+                // raw_prefix; strip_r is called at emit time so it is never applied
+                // to inline value bytes (which follow the first value-taking char).
                 let bytes = rest.as_bytes();
-                let mut bool_acc = String::new();
+                let mut raw_prefix = String::new();
                 let mut consumed_value = false;
                 let mut j = 0;
                 while j < bytes.len() {
                     let ch = bytes[j];
-                    if ch == b'r' || ch == b'R' {
-                        j += 1;
-                        continue;
-                    }
                     let is_e = ch == b'e';
                     if is_e || VALUE_FLAGS_SHORT.contains(&ch) {
-                        if !bool_acc.is_empty() {
-                            flags.push(format!("-{}", bool_acc));
+                        // Emit the boolean prefix with r/R stripped.
+                        if let Some(prefix) = strip_r(&raw_prefix) {
+                            flags.push(format!("-{}", prefix));
                         }
                         // Inline value = bytes after this char in the cluster.
+                        // strip_r is NOT called here — these are value bytes, not flags.
                         let inline = std::str::from_utf8(&bytes[j + 1..]).unwrap_or("");
                         if is_e {
                             if !inline.is_empty() {
@@ -167,12 +185,13 @@ fn extract_pattern_path<T: AsRef<str>>(args: &[T]) -> (Vec<String>, Vec<String>,
                         consumed_value = true;
                         break;
                     }
-                    bool_acc.push(ch as char);
+                    raw_prefix.push(ch as char);
                     j += 1;
                 }
                 if !consumed_value {
-                    if !bool_acc.is_empty() {
-                        flags.push(format!("-{}", bool_acc));
+                    // Pure boolean cluster: strip r/R, emit remainder.
+                    if let Some(stripped) = strip_r(&raw_prefix) {
+                        flags.push(format!("-{}", stripped));
                     }
                     i += 1;
                 }
@@ -559,7 +578,26 @@ mod tests {
         assert_eq!(rg_pattern, "fn foo|pub.*bar");
     }
 
-    // --- strip_recursive ---
+    // --- strip_r / strip_recursive ---
+
+    #[test]
+    fn test_strip_r() {
+        // Pure r/R → None (whole cluster dropped)
+        assert_eq!(strip_r("r"), None);
+        assert_eq!(strip_r("R"), None);
+        assert_eq!(strip_r("rr"), None);
+        assert_eq!(strip_r("rR"), None);
+        assert_eq!(strip_r(""), None);
+        // Mixed → r/R removed, rest kept
+        assert_eq!(strip_r("rn"), Some("n".to_string()));
+        assert_eq!(strip_r("Rni"), Some("ni".to_string()));
+        assert_eq!(strip_r("rni"), Some("ni".to_string()));
+        assert_eq!(strip_r("i"), Some("i".to_string()));
+        // Reveals the danger: strip_r must NEVER be called on value bytes.
+        // Calling it on "carrot" strips both 'r's and produces "caot" — this
+        // is exactly the original bug (-ecarrot matching "caot" instead of "carrot").
+        assert_eq!(strip_r("carrot"), Some("caot".to_string()));
+    }
 
     #[test]
     fn test_strip_recursive() {
@@ -704,7 +742,11 @@ mod tests {
     fn test_extract_inline_e_value_no_rstrip() {
         // -ecarrot: the 'r' in "carrot" must NOT be stripped (it's value, not a flag)
         let (patterns, _, _) = extract_pattern_path(&["-ecarrot", "file"]);
-        assert_eq!(patterns, vec!["carrot"], "r in inline value must not be stripped");
+        assert_eq!(
+            patterns,
+            vec!["carrot"],
+            "r in inline value must not be stripped"
+        );
     }
 
     #[test]
@@ -720,15 +762,17 @@ mod tests {
     fn test_extract_inline_g_value_no_rstrip() {
         // -g*.rs: the 'r' in "*.rs" must NOT be stripped
         let (_, _, flags) = extract_pattern_path(&["aaa", "sub", "-g*.rs"]);
-        assert!(flags.contains(&"*.rs".to_string()), "r in glob value must not be stripped");
+        assert!(
+            flags.contains(&"*.rs".to_string()),
+            "r in glob value must not be stripped"
+        );
     }
 
     // --- long value-taking flags (Bug 5) ---
 
     #[test]
     fn test_extract_long_glob_value() {
-        let (patterns, paths, flags) =
-            extract_pattern_path(&["compact", "sub", "--glob", "*.md"]);
+        let (patterns, paths, flags) = extract_pattern_path(&["compact", "sub", "--glob", "*.md"]);
         assert_eq!(patterns, vec!["compact"]);
         assert_eq!(paths, vec!["sub"]);
         assert_eq!(flags, vec!["--glob", "*.md"]);
@@ -736,8 +780,7 @@ mod tests {
 
     #[test]
     fn test_extract_long_max_count() {
-        let (patterns, paths, flags) =
-            extract_pattern_path(&["--max-count", "1", "fn", "file"]);
+        let (patterns, paths, flags) = extract_pattern_path(&["--max-count", "1", "fn", "file"]);
         assert_eq!(patterns, vec!["fn"]);
         assert_eq!(paths, vec!["file"]);
         assert_eq!(flags, vec!["--max-count", "1"]);
@@ -782,8 +825,7 @@ mod tests {
     #[test]
     fn test_extract_long_regexp_multi() {
         // --regexp can be combined with -e
-        let (patterns, paths, _) =
-            extract_pattern_path(&["--regexp", "foo", "-e", "bar", "src"]);
+        let (patterns, paths, _) = extract_pattern_path(&["--regexp", "foo", "-e", "bar", "src"]);
         assert_eq!(patterns, vec!["foo", "bar"]);
         assert_eq!(paths, vec!["src"]);
     }
@@ -799,8 +841,7 @@ mod tests {
 
     #[test]
     fn test_extract_long_engine() {
-        let (patterns, paths, flags) =
-            extract_pattern_path(&["--engine", "pcre2", "foo", "src"]);
+        let (patterns, paths, flags) = extract_pattern_path(&["--engine", "pcre2", "foo", "src"]);
         assert_eq!(patterns, vec!["foo"]);
         assert_eq!(paths, vec!["src"]);
         assert_eq!(flags, vec!["--engine", "pcre2"]);

--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -71,36 +71,64 @@ fn extract_pattern_path(args: &[String]) -> (Vec<String>, Vec<String>, Vec<Strin
         }
 
         if arg.starts_with('-') {
-            // -e: consume value into patterns (not flags)
-            if arg == "-e" {
-                if i + 1 < args.len() {
-                    e_patterns.push(args[i + 1].clone());
-                    i += 2;
-                } else {
-                    i += 1;
+            // Long flags (--foo, --recursive): strip or pass through unchanged
+            if arg.starts_with("--") {
+                if let Some(cleaned) = process_flag(arg) {
+                    flags.push(cleaned);
                 }
+                i += 1;
                 continue;
             }
 
-            // Exact 2-char value-taking flag: consume next token as value
-            if arg.len() == 2
-                && VALUE_FLAGS_SHORT.contains(&arg.as_bytes()[1])
-            {
-                flags.push(arg.clone());
-                if i + 1 < args.len() {
-                    flags.push(args[i + 1].clone());
-                    i += 2;
-                } else {
-                    i += 1;
-                }
+            let rest = arg.strip_prefix('-').unwrap_or(""); // bytes after the leading '-'
+            if rest.is_empty() {
+                // Bare `-`: treat as positional (stdin)
+                positionals.push(arg.clone());
+                i += 1;
                 continue;
             }
 
-            // Strip recursive flags; pass everything else through
-            if let Some(cleaned) = process_flag(arg) {
-                flags.push(cleaned);
+            let last = *rest.as_bytes().last().unwrap();
+            let last_is_e = last == b'e';
+            let last_takes_value = last_is_e || VALUE_FLAGS_SHORT.contains(&last);
+
+            if last_takes_value {
+                // Emit cleaned prefix (everything before last char, r/R stripped)
+                let prefix: String = rest[..rest.len() - 1]
+                    .chars()
+                    .filter(|&c| c != 'r' && c != 'R')
+                    .collect();
+                if !prefix.is_empty() {
+                    flags.push(format!("-{}", prefix));
+                }
+
+                let value = if i + 1 < args.len() {
+                    let v = args[i + 1].clone();
+                    i += 2;
+                    Some(v)
+                } else {
+                    i += 1;
+                    None
+                };
+
+                if last_is_e {
+                    if let Some(v) = value {
+                        e_patterns.push(v);
+                    }
+                } else {
+                    flags.push(format!("-{}", last as char));
+                    if let Some(v) = value {
+                        flags.push(v);
+                    }
+                }
+            } else {
+                // No value-taking flag at end: strip r/R, forward remainder
+                let cleaned: String = rest.chars().filter(|&c| c != 'r' && c != 'R').collect();
+                if !cleaned.is_empty() {
+                    flags.push(format!("-{}", cleaned));
+                }
+                i += 1;
             }
-            i += 1;
         } else {
             positionals.push(arg.clone());
             i += 1;
@@ -235,7 +263,12 @@ pub fn run(
         let args_display = if extra_args.is_empty() {
             format!("'{}' {}", display_pattern, path_display)
         } else {
-            format!("{} '{}' {}", extra_args.join(" "), display_pattern, path_display)
+            format!(
+                "{} '{}' {}",
+                extra_args.join(" "),
+                display_pattern,
+                path_display
+            )
         };
 
         timer.track_passthrough(
@@ -480,11 +513,17 @@ mod tests {
     fn test_process_flag_strip_r() {
         assert_eq!(process_flag("-r"), None);
         assert_eq!(process_flag("-R"), None);
-        assert_eq!(process_flag("--recursive"), None);
         assert_eq!(process_flag("-rn"), Some("-n".to_string()));
         assert_eq!(process_flag("-Rni"), Some("-ni".to_string()));
         assert_eq!(process_flag("-i"), Some("-i".to_string()));
+    }
+
+    #[test]
+    fn test_process_flag_strip_recursive() {
+        // process_flag is now only called for long flags
+        assert_eq!(process_flag("--recursive"), None);
         assert_eq!(process_flag("--glob"), Some("--glob".to_string()));
+        assert_eq!(process_flag("--type"), Some("--type".to_string()));
     }
 
     // --- extract_pattern_path ---
@@ -528,6 +567,24 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_cluster_ending_in_e() {
+        // -rne PATTERN: r stripped, n in prefix, e consumes PATTERN as pattern
+        let (patterns, paths, flags) = extract_pattern_path(&s(&["-rne", "PATTERN", "src"]));
+        assert_eq!(patterns, s(&["PATTERN"]));
+        assert_eq!(paths, s(&["src"]));
+        assert_eq!(flags, s(&["-n"]));
+    }
+
+    #[test]
+    fn test_extract_cluster_ending_in_value_flag() {
+        // -rA 2: r stripped, A consumes 2 as context value
+        let (patterns, paths, flags) = extract_pattern_path(&s(&["-rA", "2", "foo", "src"]));
+        assert_eq!(patterns, s(&["foo"]));
+        assert_eq!(paths, s(&["src"]));
+        assert_eq!(flags, s(&["-A", "2"]));
+    }
+
+    #[test]
     fn test_extract_multi_path() {
         let (patterns, paths, flags) = extract_pattern_path(&s(&["TODO", "src", "tests"]));
         assert_eq!(patterns, s(&["TODO"]));
@@ -555,8 +612,7 @@ mod tests {
 
     #[test]
     fn test_extract_multi_e() {
-        let (patterns, paths, flags) =
-            extract_pattern_path(&s(&["-e", "foo", "-e", "bar", "src"]));
+        let (patterns, paths, flags) = extract_pattern_path(&s(&["-e", "foo", "-e", "bar", "src"]));
         assert_eq!(patterns, s(&["foo", "bar"]));
         assert_eq!(paths, s(&["src"]));
         assert!(flags.is_empty());

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,8 +62,8 @@ struct Cli {
     #[command(subcommand)]
     command: Commands,
 
-    /// Verbosity level (-v, -vv, -vvv)
-    #[arg(short, long, action = clap::ArgAction::Count, global = true)]
+    /// Verbosity level (-v, -vv, -vvv) — only recognized before the subcommand
+    #[arg(short, long, action = clap::ArgAction::Count)]
     verbose: u8,
 
     /// Ultra-compact mode: ASCII icons, inline format (Level 2 optimizations)
@@ -302,11 +302,6 @@ enum Commands {
 
     /// Compact grep - strips whitespace, truncates, groups by file
     Grep {
-        /// Pattern to search
-        pattern: String,
-        /// Path to search in
-        #[arg(default_value = ".")]
-        path: String,
         /// Max line length
         #[arg(short = 'l', long, default_value = "80")]
         max_len: usize,
@@ -319,10 +314,7 @@ enum Commands {
         /// Filter by file type (e.g., ts, py, rust)
         #[arg(short = 't', long)]
         file_type: Option<String>,
-        /// Show line numbers (always on, accepted for grep/rg compatibility)
-        #[arg(short = 'n', long)]
-        line_numbers: bool,
-        /// Extra ripgrep arguments (e.g., -i, -A 3, -w, --glob)
+        /// Pattern, path, and any grep/rg flags (e.g. -v, -i, -A 3, --glob, --version)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         extra_args: Vec<String>,
     },
@@ -1800,17 +1792,12 @@ fn run_cli() -> Result<i32> {
         }
 
         Commands::Grep {
-            pattern,
-            path,
             max_len,
             max,
             context_only,
             file_type,
-            line_numbers: _, // no-op: line numbers always enabled in grep_cmd::run
             extra_args,
         } => grep_cmd::run(
-            &pattern,
-            &path,
             max_len,
             max,
             context_only,


### PR DESCRIPTION
## Summary
 `rtk grep` had three distinct bugs that made it unreliable in real usage:

 1. **Clap parse failure for any unknown flag before the pattern** — `rtk grep --version`, `rtk grep --glob '*.ts' pattern`, `rtk grep --type-add 'web:*.html' pattern` all failed with
 "unexpected argument" Clap errors because `pattern` was a required positional and Clap tried to interpret any flag before it as a named subcommand flag.

 2. **`-v` verbose flag silently swallowing grep's invert-match** — `rtk grep -v pattern .` ran a normal (non-inverted) search because `verbose` was declared `global = true`, causing Clap
 to consume every `-v` anywhere in the arg list as RTK verbosity.

 3. **rg misinterpreting flag-shaped patterns** — `rtk grep -- --version` called `rg ... "--version" .` without a `--` separator before the pattern. rg interpreted `--version` as its own
 version flag, printed its version info (not in NUL match format), causing "7 matches in 0 files" output (total from pre-parse line count, zero from empty `by_file` map).

### Changes

 **`src/main.rs`**

 - Removed `global = true` from the `verbose` flag. `-v` is now only recognized before the subcommand; any `-v` after `grep` flows into `args` and is forwarded to rg as invert-match.
 - Removed `pattern`, `path`, and `line_numbers` as Clap-managed fields from the `Grep` variant. A single `trailing_var_arg` field `args: Vec<String>` captures everything — pattern, path,
 and any grep/rg flag — without Clap needing to know about them. New rg flags no longer require a `main.rs` change.

 **`src/cmds/system/grep_cmd.rs`**

 - Added `extract_pattern_path(args)` — scans the flat arg slice, assigns the first and second non-flag tokens as pattern and path (default `.`), collects the rest as `extra_args` for rg.
 Handles `--` boundary correctly.
 - Added early passthrough for `--version` / `--help` / `-h` — routes directly to rg (or grep fallback) without filtering.
 - Added `--` before `<pattern> <path>` in both rg and grep invocations — prevents rg/grep from misinterpreting flag-shaped patterns.
 - Fixed `total_matches` — derived from `by_file.values().map(|v| v.len()).sum()` after parsing, so the "N matches in M files" header is always consistent with what's displayed.

 ### Issues fixed

 | Issue | Title |
 |-------|-------|
 | #2167 | rtk grep calls system grep — breaks `-g`/`--glob` flags |
 | #2120 | `--fixed-strings` before pattern causes fallback to native grep |
 | #880  | 65 grep failures, 0 savings (invert-match `-v` swallowed) |

### Test plan
- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing:
  -`rtk grep --version` ✅️
  -`rtk -vvv grep --version` ✅️
  -`rtk grep -- --version` ✅️
  -`rtk grep -v TODO src/` ✅️
  -`rtk grep 'fn run' src/` ✅️
  -`rtk grep -i -A 2 'error' src/` ✅️
