### PR TITLE
feat(cli): add clang-format changed-file summary

### DIFF
--- a/docs/guide/resources/what-rtk-covers.md
+++ b/docs/guide/resources/what-rtk-covers.md
@@ -94,6 +94,12 @@ Typical savings: 60-99%.
 | `dotnet test` | 85-90% | Failures only |
 | `dotnet format` | 75% | Changed files only |
 
+## C / C++
+
+| Command | Savings | What changes |
+|---------|---------|--------------|
+| `clang-format -i` | 70% | Changed files only; diagnostics preserved |
+
 ## Docker / Kubernetes
 
 | Command | Savings | What changes |

--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -714,6 +714,19 @@ Affiche uniquement les fichiers necessitant un formatage.
 
 ---
 
+### `rtk clang-format` -- Formatage C/C++
+
+**Economies :** ~70% pour `-i`
+
+```bash
+rtk clang-format -i src/main.cpp include/app.hpp
+```
+
+En mode `-i`, affiche uniquement les fichiers modifies ou `clang-format: no changes`.
+`--files=<list>` est developpe quand la liste est lisible. Les modes hors `-i`, stdin/stdout, `--dry-run`/`-n` et `--output-replacements-xml` restent en passthrough avec le code de sortie natif. Avec `-i`, `--Werror` conserve le resume RTK tout en preservant les diagnostics natifs et le code de sortie de `clang-format`.
+
+---
+
 ### `rtk format` -- Formateur universel
 
 ```bash
@@ -779,6 +792,17 @@ Sortie JSON compressee.
 rtk prettier --check .
 rtk prettier --write src/
 ```
+
+---
+
+### `rtk clang-format` -- clang-format
+
+```bash
+rtk clang-format -i file.cpp
+rtk clang-format --dry-run --Werror file.cpp
+```
+
+`-i` resume les fichiers reellement modifies. Les diagnostics et les modes qui produisent une sortie normale passent tels quels.
 
 ---
 

--- a/src/cmds/system/README.md
+++ b/src/cmds/system/README.md
@@ -8,6 +8,7 @@
 - `grep_cmd.rs` reads `core/config` for `limits.grep_max_results` and `limits.grep_max_per_file`. Format-altering flags (`-c`, `-l`, `-L`, `-o`, `-Z`) bypass RTK filtering and run raw.
 - `local_llm.rs` (`rtk smart`) uses `core/filter` for heuristic file summarization
 - `format_cmd.rs` is a cross-ecosystem dispatcher: auto-detects and routes to `prettier_cmd` or `ruff_cmd` (black is handled inline, not as a separate module)
+- `clang_format_cmd.rs` wraps `clang-format -i`: snapshots input files, preserves diagnostics, and reports only files whose bytes changed
 
 ## Cross-command
 

--- a/src/cmds/system/clang_format_cmd.rs
+++ b/src/cmds/system/clang_format_cmd.rs
@@ -1,0 +1,580 @@
+//! Runs clang-format and summarizes files changed by in-place formatting.
+
+use crate::core::runner;
+use crate::core::stream::status_to_exit_code;
+use crate::core::tracking;
+use crate::core::truncate::CAP_LIST;
+use crate::core::utils::resolved_command;
+use anyhow::{Context, Result};
+use std::collections::HashSet;
+use std::ffi::OsString;
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+const MAX_CHANGED_FILES: usize = CAP_LIST;
+
+#[derive(Debug, PartialEq, Eq)]
+enum InvocationPlan {
+    Passthrough,
+    Summarize { files: Vec<PathBuf> },
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct ParsedArgs {
+    in_place: bool,
+    dry_run: bool,
+    output_replacements_xml: bool,
+    stdin_seen: bool,
+    response_file_seen: bool,
+    files: Vec<PathBuf>,
+    file_lists: Vec<PathBuf>,
+}
+
+#[derive(Debug)]
+struct FileSnapshot {
+    path: PathBuf,
+    display: String,
+    before: Vec<u8>,
+}
+
+pub fn run(args: &[String], verbose: u8) -> Result<i32> {
+    match plan_invocation(args) {
+        InvocationPlan::Passthrough => run_passthrough(args, verbose),
+        InvocationPlan::Summarize { files } => run_in_place_with_summary(args, &files, verbose),
+    }
+}
+
+fn run_passthrough(args: &[String], verbose: u8) -> Result<i32> {
+    let os_args: Vec<OsString> = args.iter().map(OsString::from).collect();
+    runner::run_passthrough("clang-format", &os_args, verbose)
+}
+
+fn run_in_place_with_summary(args: &[String], files: &[PathBuf], verbose: u8) -> Result<i32> {
+    let snapshots = snapshot_files(files);
+    if snapshots.is_empty() {
+        return run_passthrough(args, verbose);
+    }
+
+    if verbose > 0 {
+        eprintln!("Running: clang-format {}", args.join(" "));
+    }
+
+    let timer = tracking::TimedExecution::start();
+    let mut cmd = resolved_command("clang-format");
+    cmd.args(args);
+
+    let output = cmd.output().context("Failed to run clang-format")?;
+    write_all_preserving_broken_pipe(io::stdout(), &output.stdout)?;
+    write_all_preserving_broken_pipe(io::stderr(), &output.stderr)?;
+
+    let exit_code = status_to_exit_code(output.status);
+    let changed = changed_files(&snapshots);
+    let summary = format_changed_summary(&changed);
+
+    if !output.stdout.is_empty() && !output.stdout.ends_with(b"\n") {
+        write_all_preserving_broken_pipe(io::stdout(), b"\n")?;
+    }
+    write_all_preserving_broken_pipe(io::stdout(), summary.as_bytes())?;
+    write_all_preserving_broken_pipe(io::stdout(), b"\n")?;
+
+    let args_display = args.join(" ");
+    timer.track_passthrough(
+        &format!("clang-format {}", args_display),
+        &format!("rtk clang-format {} (summary)", args_display),
+    );
+
+    Ok(exit_code)
+}
+
+fn write_all_preserving_broken_pipe(mut writer: impl Write, bytes: &[u8]) -> io::Result<()> {
+    if let Err(err) = writer.write_all(bytes) {
+        if err.kind() == io::ErrorKind::BrokenPipe {
+            return Ok(());
+        }
+        return Err(err);
+    }
+    if let Err(err) = writer.flush() {
+        if err.kind() == io::ErrorKind::BrokenPipe {
+            return Ok(());
+        }
+        return Err(err);
+    }
+    Ok(())
+}
+
+fn plan_invocation(args: &[String]) -> InvocationPlan {
+    let parsed = parse_args(args);
+    if !parsed.in_place
+        || parsed.dry_run
+        || parsed.output_replacements_xml
+        || parsed.stdin_seen
+        || parsed.response_file_seen
+    {
+        return InvocationPlan::Passthrough;
+    }
+
+    let Some(files) = expand_files(parsed.files, &parsed.file_lists) else {
+        return InvocationPlan::Passthrough;
+    };
+
+    if files.is_empty() {
+        InvocationPlan::Passthrough
+    } else {
+        InvocationPlan::Summarize { files }
+    }
+}
+
+fn parse_args(args: &[String]) -> ParsedArgs {
+    let mut parsed = ParsedArgs::default();
+    let mut i = 0;
+    let mut end_of_options = false;
+
+    while i < args.len() {
+        let arg = &args[i];
+
+        if end_of_options {
+            observe_positional(arg, &mut parsed);
+            i += 1;
+            continue;
+        }
+
+        if arg == "--" {
+            end_of_options = true;
+            i += 1;
+            continue;
+        }
+
+        if arg.starts_with('@') {
+            parsed.response_file_seen = true;
+            i += 1;
+            continue;
+        }
+
+        if is_in_place_flag(arg) {
+            parsed.in_place = true;
+            i += 1;
+            continue;
+        }
+
+        if is_dry_run_flag(arg) {
+            parsed.dry_run = true;
+            i += 1;
+            continue;
+        }
+
+        if is_output_replacements_xml_flag(arg) {
+            parsed.output_replacements_xml = true;
+            i += 1;
+            continue;
+        }
+
+        if let Some(path) = inline_files_arg(arg) {
+            parsed.file_lists.push(PathBuf::from(path));
+            i += 1;
+            continue;
+        }
+
+        if is_files_arg(arg) {
+            if let Some(next) = args.get(i + 1) {
+                parsed.file_lists.push(PathBuf::from(next));
+                i += 2;
+            } else {
+                i += 1;
+            }
+            continue;
+        }
+
+        if option_takes_next_value(arg) {
+            i += 2;
+            continue;
+        }
+
+        if arg.starts_with('-') {
+            if arg == "-" {
+                parsed.stdin_seen = true;
+            }
+            i += 1;
+            continue;
+        }
+
+        observe_positional(arg, &mut parsed);
+        i += 1;
+    }
+
+    parsed
+}
+
+fn observe_positional(arg: &str, parsed: &mut ParsedArgs) {
+    if arg == "-" {
+        parsed.stdin_seen = true;
+    } else {
+        parsed.files.push(PathBuf::from(arg));
+    }
+}
+
+fn is_in_place_flag(arg: &str) -> bool {
+    arg == "-i" || bool_option_enabled(arg, "-i") || bool_option_enabled(arg, "--inplace")
+}
+
+fn is_dry_run_flag(arg: &str) -> bool {
+    arg == "-n" || bool_option_enabled(arg, "--dry-run") || bool_option_enabled(arg, "-dry-run")
+}
+
+fn is_output_replacements_xml_flag(arg: &str) -> bool {
+    bool_option_enabled(arg, "--output-replacements-xml")
+        || bool_option_enabled(arg, "-output-replacements-xml")
+}
+
+fn bool_option_enabled(arg: &str, name: &str) -> bool {
+    if arg == name {
+        return true;
+    }
+
+    let Some(value) = arg.strip_prefix(&format!("{}=", name)) else {
+        return false;
+    };
+    !matches!(
+        value.to_ascii_lowercase().as_str(),
+        "0" | "false" | "no" | "off"
+    )
+}
+
+fn inline_files_arg(arg: &str) -> Option<&str> {
+    arg.strip_prefix("--files=")
+        .or_else(|| arg.strip_prefix("-files="))
+}
+
+fn is_files_arg(arg: &str) -> bool {
+    arg == "--files" || arg == "-files"
+}
+
+fn option_takes_next_value(arg: &str) -> bool {
+    matches!(
+        arg,
+        "--assume-filename"
+            | "-assume-filename"
+            | "--cursor"
+            | "-cursor"
+            | "--fallback-style"
+            | "-fallback-style"
+            | "--ferror-limit"
+            | "-ferror-limit"
+            | "--length"
+            | "-length"
+            | "--lines"
+            | "-lines"
+            | "--offset"
+            | "-offset"
+            | "--qualifier-alignment"
+            | "-qualifier-alignment"
+            | "--style"
+            | "-style"
+            | "--Wno-error"
+            | "-Wno-error"
+    )
+}
+
+fn expand_files(mut files: Vec<PathBuf>, file_lists: &[PathBuf]) -> Option<Vec<PathBuf>> {
+    for list_path in file_lists {
+        let content = std::fs::read_to_string(list_path).ok()?;
+        for line in content.lines() {
+            let entry = line.trim();
+            if entry.is_empty() {
+                continue;
+            }
+            if entry == "-" {
+                return None;
+            }
+            files.push(PathBuf::from(entry));
+        }
+    }
+    Some(files)
+}
+
+fn snapshot_files(files: &[PathBuf]) -> Vec<FileSnapshot> {
+    let mut snapshots = Vec::new();
+    let mut seen = HashSet::new();
+
+    for path in files {
+        let Ok(before) = std::fs::read(path) else {
+            continue;
+        };
+        let key = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
+        if !seen.insert(key) {
+            continue;
+        }
+        snapshots.push(FileSnapshot {
+            path: path.clone(),
+            display: path.display().to_string(),
+            before,
+        });
+    }
+
+    snapshots
+}
+
+fn changed_files(snapshots: &[FileSnapshot]) -> Vec<String> {
+    snapshots
+        .iter()
+        .filter_map(|snapshot| match std::fs::read(&snapshot.path) {
+            Ok(after) if after != snapshot.before => Some(snapshot.display.clone()),
+            Err(_) => Some(snapshot.display.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn format_changed_summary(changed_files: &[String]) -> String {
+    if changed_files.is_empty() {
+        return "clang-format: no changes".to_string();
+    }
+
+    let mut output = format!(
+        "clang-format: changed {} {}",
+        changed_files.len(),
+        if changed_files.len() == 1 {
+            "file"
+        } else {
+            "files"
+        }
+    );
+
+    let all_lines: Vec<String> = changed_files
+        .iter()
+        .enumerate()
+        .map(|(index, file)| format!("{}. {}", index + 1, file))
+        .collect();
+
+    for line in all_lines.iter().take(MAX_CHANGED_FILES) {
+        output.push('\n');
+        output.push_str(line);
+    }
+
+    if changed_files.len() > MAX_CHANGED_FILES {
+        output.push_str(&format!(
+            "\n... +{} more files",
+            changed_files.len() - MAX_CHANGED_FILES
+        ));
+        let all_text = all_lines.join("\n");
+        if let Some(hint) = crate::core::tee::force_tee_tail_hint(
+            &all_text,
+            "clang-format-files",
+            MAX_CHANGED_FILES + 1,
+        ) {
+            output.push(' ');
+            output.push_str(&hint);
+        }
+    }
+
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    fn s(args: &[&str]) -> Vec<String> {
+        args.iter().map(|arg| arg.to_string()).collect()
+    }
+
+    #[test]
+    fn test_parse_in_place_files() {
+        let parsed = parse_args(&s(&["-i", "--style", "file", "a.cpp", "b.hpp"]));
+        assert!(parsed.in_place);
+        assert!(!parsed.dry_run);
+        assert_eq!(parsed.files, vec![PathBuf::from("a.cpp"), PathBuf::from("b.hpp")]);
+    }
+
+    #[test]
+    fn test_parse_assume_filename_is_not_input_file() {
+        let parsed = parse_args(&s(&["-i", "--assume-filename", "virtual.cpp"]));
+        assert!(parsed.in_place);
+        assert!(parsed.files.is_empty());
+        assert!(!parsed.stdin_seen);
+    }
+
+    #[test]
+    fn test_parse_stdin_passthrough_marker() {
+        let parsed = parse_args(&s(&["-i", "--assume-filename=virtual.cpp", "-"]));
+        assert!(parsed.in_place);
+        assert!(parsed.stdin_seen);
+    }
+
+    #[test]
+    fn test_parse_dry_run_and_xml_flags() {
+        let parsed = parse_args(&s(&[
+            "-i",
+            "--dry-run",
+            "--Werror",
+            "--output-replacements-xml",
+            "a.cpp",
+        ]));
+        assert!(parsed.in_place);
+        assert!(parsed.dry_run);
+        assert!(parsed.output_replacements_xml);
+    }
+
+    #[test]
+    fn test_plan_passes_through_stdout_producing_mode() {
+        assert_eq!(
+            plan_invocation(&s(&["file.cpp"])),
+            InvocationPlan::Passthrough
+        );
+    }
+
+    #[test]
+    fn test_plan_passes_through_stdin_mode() {
+        assert_eq!(
+            plan_invocation(&s(&["-i", "--assume-filename", "file.cpp", "-"])),
+            InvocationPlan::Passthrough
+        );
+    }
+
+    #[test]
+    fn test_plan_passes_through_dry_run_werror() {
+        assert_eq!(
+            plan_invocation(&s(&["--dry-run", "--Werror", "file.cpp"])),
+            InvocationPlan::Passthrough
+        );
+    }
+
+    #[test]
+    fn test_plan_passes_through_dash_n_dry_run() {
+        assert_eq!(
+            plan_invocation(&s(&["-i", "-n", "file.cpp"])),
+            InvocationPlan::Passthrough
+        );
+    }
+
+    #[test]
+    fn test_plan_passes_through_output_replacements_xml() {
+        assert_eq!(
+            plan_invocation(&s(&["-i", "--output-replacements-xml", "file.cpp"])),
+            InvocationPlan::Passthrough
+        );
+    }
+
+    #[test]
+    fn test_plan_passes_through_response_file() {
+        assert_eq!(
+            plan_invocation(&s(&["-i", "@clang-format.args"])),
+            InvocationPlan::Passthrough
+        );
+    }
+
+    #[test]
+    fn test_sort_includes_does_not_hide_input_file() {
+        assert_eq!(
+            plan_invocation(&s(&["-i", "--sort-includes", "file.cpp"])),
+            InvocationPlan::Summarize {
+                files: vec![PathBuf::from("file.cpp")]
+            }
+        );
+    }
+
+    #[test]
+    fn test_expand_files_list() {
+        let mut list = NamedTempFile::new().unwrap();
+        writeln!(list, "a.cpp").unwrap();
+        writeln!(list, "b.hpp").unwrap();
+
+        let plan = plan_invocation(&s(&[
+            "-i",
+            "--files",
+            list.path().to_str().unwrap(),
+            "c.cc",
+        ]));
+
+        assert_eq!(
+            plan,
+            InvocationPlan::Summarize {
+                files: vec![
+                    PathBuf::from("c.cc"),
+                    PathBuf::from("a.cpp"),
+                    PathBuf::from("b.hpp"),
+                ]
+            }
+        );
+    }
+
+    #[test]
+    fn test_expand_inline_files_list() {
+        let mut list = NamedTempFile::new().unwrap();
+        writeln!(list, "a.cpp").unwrap();
+
+        let plan = plan_invocation(&s(&[
+            "-i",
+            &format!("--files={}", list.path().display()),
+        ]));
+
+        assert_eq!(
+            plan,
+            InvocationPlan::Summarize {
+                files: vec![PathBuf::from("a.cpp")]
+            }
+        );
+    }
+
+    #[test]
+    fn test_unreadable_files_list_passes_through() {
+        assert_eq!(
+            plan_invocation(&s(&["-i", "--files=/missing/clang-format-list"])),
+            InvocationPlan::Passthrough
+        );
+    }
+
+    #[test]
+    fn test_format_no_changes_summary() {
+        assert_eq!(
+            format_changed_summary(&[]),
+            "clang-format: no changes".to_string()
+        );
+    }
+
+    #[test]
+    fn test_format_changed_files_summary() {
+        let changed = vec!["a.cpp".to_string(), "src/b.hpp".to_string()];
+        let summary = format_changed_summary(&changed);
+        assert!(summary.starts_with("clang-format: changed 2 files"));
+        assert!(summary.contains("1. a.cpp"));
+        assert!(summary.contains("2. src/b.hpp"));
+    }
+
+    #[test]
+    fn test_partial_failure_summary_still_reports_changed_files() {
+        let changed = vec!["formatted-before-error.cpp".to_string()];
+        let summary = format_changed_summary(&changed);
+        assert!(summary.contains("clang-format: changed 1 file"));
+        assert!(summary.contains("formatted-before-error.cpp"));
+        assert!(!summary.contains("no changes"));
+    }
+
+    #[test]
+    fn test_format_changed_files_truncates_with_hint_text() {
+        let changed: Vec<String> = (0..(MAX_CHANGED_FILES + 2))
+            .map(|index| format!("file{index}.cpp"))
+            .collect();
+        let summary = format_changed_summary(&changed);
+        assert!(summary.contains("clang-format: changed 22 files"));
+        assert!(summary.contains("... +2 more files"));
+    }
+
+    #[test]
+    fn test_changed_files_detects_byte_changes_for_partial_failure_reporting() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "int main(){{return 0;}}").unwrap();
+
+        let snapshots = snapshot_files(&[file.path().to_path_buf()]);
+        std::fs::write(file.path(), "int main() { return 0; }\n").unwrap();
+
+        let changed = changed_files(&snapshots);
+        assert_eq!(changed, vec![file.path().display().to_string()]);
+    }
+
+    #[test]
+    fn test_snapshot_ignores_unreadable_files() {
+        let snapshots = snapshot_files(&[PathBuf::from("/missing/file.cpp")]);
+        assert!(snapshots.is_empty());
+    }
+}

--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -295,6 +295,7 @@ const RUST_HANDLED_COMMANDS: &[&str] = &[
     "lint",
     "prettier",
     "format",
+    "clang-format",
     "playwright",
     "cargo",
     "npm",

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1101,6 +1101,19 @@ mod tests {
     }
 
     #[test]
+    fn test_classify_clang_format() {
+        assert_eq!(
+            classify_command("clang-format -i src/main.cpp"),
+            Classification::Supported {
+                rtk_equivalent: "rtk clang-format",
+                category: "Build",
+                estimated_savings_pct: 70.0,
+                status: RtkStatus::Existing,
+            }
+        );
+    }
+
+    #[test]
     fn test_registry_covers_all_cargo_subcommands() {
         // Verify that every CargoCommand variant (Build, Test, Clippy, Check, Fmt)
         // except Other has a matching pattern in the registry
@@ -1387,6 +1400,14 @@ mod tests {
         assert_eq!(
             rewrite_command_no_prefixes("cat src/main.rs", &[]),
             Some("rtk read src/main.rs".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_clang_format_keeps_args() {
+        assert_eq!(
+            rewrite_command_no_prefixes("clang-format -i --style=file src/main.cpp", &[]),
+            Some("rtk clang-format -i --style=file src/main.cpp".into())
         );
     }
 

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -217,6 +217,15 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
+        pattern: r"^clang-format(\s|$)",
+        rtk_cmd: "rtk clang-format",
+        rewrite_prefixes: &["clang-format"],
+        category: "Build",
+        savings_pct: 70.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
+    RtkRule {
         pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?next\s+build",
         rtk_cmd: "rtk next",
         rewrite_prefixes: &[

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,8 @@ use cmds::python::{mypy_cmd, pip_cmd, pytest_cmd, ruff_cmd};
 use cmds::ruby::{rake_cmd, rspec_cmd, rubocop_cmd};
 use cmds::rust::{cargo_cmd, runner};
 use cmds::system::{
-    deps, env_cmd, find_cmd, format_cmd, grep_cmd, json_cmd, local_llm, log_cmd, ls, pipe_cmd,
-    read, summary, tree, wc_cmd,
+    clang_format_cmd, deps, env_cmd, find_cmd, format_cmd, grep_cmd, json_cmd, local_llm, log_cmd,
+    ls, pipe_cmd, read, summary, tree, wc_cmd,
 };
 
 use anyhow::{Context, Result};
@@ -520,6 +520,14 @@ enum Commands {
     /// Universal format checker (prettier, black, ruff format)
     Format {
         /// Formatter arguments (auto-detects formatter from project files)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// clang-format wrapper with changed-file summaries for -i mode
+    #[command(name = "clang-format")]
+    ClangFormat {
+        /// clang-format arguments
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -2036,6 +2044,8 @@ fn run_cli() -> Result<i32> {
 
         Commands::Format { args } => format_cmd::run(&args, cli.verbose)?,
 
+        Commands::ClangFormat { args } => clang_format_cmd::run(&args, cli.verbose)?,
+
         Commands::Playwright { args } => playwright_cmd::run(&args, cli.verbose)?,
 
         Commands::Cargo { command } => match command {
@@ -2526,6 +2536,7 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Next { .. }
             | Commands::Lint { .. }
             | Commands::Prettier { .. }
+            | Commands::ClangFormat { .. }
             | Commands::Playwright { .. }
             | Commands::Cargo { .. }
             | Commands::Npm { .. }
@@ -3280,6 +3291,35 @@ mod tests {
                 assert!(global);
             }
             _ => panic!("Expected Init command"),
+        }
+    }
+
+    #[test]
+    fn test_clang_format_trailing_args_parse() {
+        let cli = Cli::try_parse_from([
+            "rtk",
+            "clang-format",
+            "-i",
+            "--style=file",
+            "--assume-filename",
+            "virtual.cpp",
+            "src/main.cpp",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::ClangFormat { args } => {
+                assert_eq!(
+                    args,
+                    vec![
+                        "-i",
+                        "--style=file",
+                        "--assume-filename",
+                        "virtual.cpp",
+                        "src/main.cpp",
+                    ]
+                );
+            }
+            _ => panic!("Expected ClangFormat command"),
         }
     }
 }


### PR DESCRIPTION
## Summary

- add `rtk clang-format` for `clang-format -i` workflows
- summarize only files whose bytes actually changed while preserving native diagnostics and exit codes
- keep stdin/stdout-producing, dry-run, XML, response-file, and unreadable `--files` cases on native passthrough
- add discovery/rewrite coverage and docs

Closes #2238.

## Verification

- `cargo fmt --all`
- `cargo clippy --all-targets`
- `cargo test --all`
- `bash scripts/check-test-presence.sh origin/develop`
- `cargo test clang_format`
- `cargo test discover::registry`
- manual checks for changed/no-change summaries, parse diagnostics, `--dry-run --Werror`, passthrough stdout/stderr, partial failure with changed files, and pipe-to-`head -n 1`

## Notes

Implemented with Codex CLI and independently reviewed with Claude Opus 4.8 before submission.