### PR TITLE
feat(hooks): add warn_on_missing opt-out for startup hook banner

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -23,7 +23,11 @@ pub struct Config {
     pub limits: LimitsConfig,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+fn default_warn_on_missing() -> bool {
+    true
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct HooksConfig {
     /// Commands to exclude from auto-rewrite (e.g. ["curl", "playwright"]).
     /// Survives `rtk init -g` re-runs since config.toml is user-owned.
@@ -51,6 +55,26 @@ pub struct HooksConfig {
     /// not anything else.
     #[serde(default)]
     pub transparent_prefixes: Vec<String>,
+
+    /// When `false`, suppress the per-invocation "[rtk] /!\\ No hook installed"
+    /// warning (and the related "Hook outdated" warning) emitted to stderr
+    /// from `src/hooks/hook_check.rs`. Use this to silence the banner for
+    /// users who run rtk without a Claude Code hook on purpose.
+    ///
+    /// Default: `true` — preserves the pre-config behavior of always warning
+    /// once per day when a hook is missing or outdated.
+    #[serde(default = "default_warn_on_missing")]
+    pub warn_on_missing: bool,
+}
+
+impl Default for HooksConfig {
+    fn default() -> Self {
+        Self {
+            exclude_commands: Vec::new(),
+            transparent_prefixes: Vec::new(),
+            warn_on_missing: true,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -295,5 +319,61 @@ consent_date = "2026-04-10T12:00:00Z"
             config.telemetry.consent_date.as_deref(),
             Some("2026-04-10T12:00:00Z")
         );
+    }
+
+    #[test]
+    fn test_warn_on_missing_default_true() {
+        // The struct default and Config::default() must both flip the banner
+        // on. Otherwise the pre-config "always warn" behavior would silently
+        // change for new users without a config.toml.
+        assert!(HooksConfig::default().warn_on_missing);
+        assert!(Config::default().hooks.warn_on_missing);
+    }
+
+    #[test]
+    fn test_warn_on_missing_deserialize_false() {
+        let toml = r#"
+[hooks]
+warn_on_missing = false
+"#;
+        let config: Config = toml::from_str(toml).expect("valid toml");
+        assert!(!config.hooks.warn_on_missing);
+    }
+
+    #[test]
+    fn test_warn_on_missing_deserialize_true() {
+        let toml = r#"
+[hooks]
+warn_on_missing = true
+"#;
+        let config: Config = toml::from_str(toml).expect("valid toml");
+        assert!(config.hooks.warn_on_missing);
+    }
+
+    #[test]
+    fn test_warn_on_missing_missing_field_defaults_true() {
+        // Backwards compat: config.toml files written before this field
+        // existed must still parse and keep the historical "warn by default"
+        // behavior.
+        let toml = r#"
+[hooks]
+exclude_commands = ["curl"]
+"#;
+        let config: Config = toml::from_str(toml).expect("valid toml");
+        assert_eq!(config.hooks.exclude_commands, vec!["curl"]);
+        assert!(config.hooks.warn_on_missing);
+    }
+
+    #[test]
+    fn test_warn_on_missing_roundtrip() {
+        let mut config = Config::default();
+        config.hooks.warn_on_missing = false;
+        let serialized = toml::to_string_pretty(&config).expect("serialize");
+        assert!(
+            serialized.contains("warn_on_missing = false"),
+            "expected serialized config to include the field, got:\n{serialized}"
+        );
+        let parsed: Config = toml::from_str(&serialized).expect("deserialize");
+        assert!(!parsed.hooks.warn_on_missing);
     }
 }

--- a/src/hooks/hook_check.rs
+++ b/src/hooks/hook_check.rs
@@ -89,12 +89,34 @@ fn binary_hook_registered(claude_dir: &std::path::Path) -> bool {
 /// Check if the installed hook is missing or outdated, warn once per day.
 pub fn maybe_warn() {
     // Don't block startup — fail silently on any error
-    let _ = check_and_warn();
+    let warn_on_missing = crate::core::config::Config::load()
+        .map(|c| c.hooks.warn_on_missing)
+        .unwrap_or(true);
+    let _ = check_and_warn(warn_on_missing);
+}
+
+/// Pure decision: should we emit the startup banner right now?
+///
+/// Combines the live hook status with the user-configurable opt-out
+/// (`[hooks] warn_on_missing = false` in `config.toml`).
+fn should_emit(hook_status: &HookStatus, warn_on_missing: bool) -> bool {
+    match hook_status {
+        HookStatus::Ok => false,
+        HookStatus::Missing | HookStatus::Outdated => warn_on_missing,
+    }
 }
 
 /// Single source of truth: delegates to `status()` then rate-limits the warning.
-fn check_and_warn() -> Option<()> {
-    let warning = match status() {
+///
+/// `warn_on_missing` is plumbed in (rather than read from config here) so the
+/// decision is testable without touching the real config directory.
+fn check_and_warn(warn_on_missing: bool) -> Option<()> {
+    let hook_status = status();
+    if !should_emit(&hook_status, warn_on_missing) {
+        return Some(());
+    }
+
+    let warning = match hook_status {
         HookStatus::Ok => return Some(()),
         HookStatus::Missing => {
             "[rtk] /!\\ No hook installed — run `rtk init -g` for automatic token savings"
@@ -319,5 +341,33 @@ mod tests {
             "Expected valid HookStatus variant, got {:?}",
             s
         );
+    }
+
+    #[test]
+    fn test_should_emit_ok_never_warns() {
+        // If the hook is fine, the user opt-out is irrelevant.
+        assert!(!should_emit(&HookStatus::Ok, true));
+        assert!(!should_emit(&HookStatus::Ok, false));
+    }
+
+    #[test]
+    fn test_should_emit_missing_respects_setting() {
+        assert!(
+            should_emit(&HookStatus::Missing, true),
+            "Missing + warn_on_missing=true should emit"
+        );
+        assert!(
+            !should_emit(&HookStatus::Missing, false),
+            "Missing + warn_on_missing=false must stay silent (this is the no-banner opt-out)"
+        );
+    }
+
+    #[test]
+    fn test_should_emit_outdated_respects_setting() {
+        // Outdated shares the same opt-out as Missing — they're both hook
+        // state warnings, and the user either wants the banner family or
+        // doesn't.
+        assert!(should_emit(&HookStatus::Outdated, true));
+        assert!(!should_emit(&HookStatus::Outdated, false));
     }
 }


### PR DESCRIPTION
- src/core/config.rs
- src/hooks/hook_check.rs

Adds a `[hooks] warn_on_missing` setting (default `true`) so users can silence the per-invocation "[rtk] /!\ No hook installed" warning that fires when no Claude Code hook is registered. This also covers the companion "Hook outdated" warning — they're the same banner family.

Implementation:
- New field on `HooksConfig` with `Default` implementation and a serde `default = "default_warn_on_missing"` fallback so older config.toml files keep the historical "warn by default" behavior.
- `maybe_warn` now reads the setting and threads the bool into `check_and_warn`, which short-circuits via a new pure `should_emit` helper before touching the rate-limit marker.
- The pure helper makes the gating decision testable without touching the real config directory or filesystem marker.

Tests:
- 5 new config tests cover default, explicit true/false, missing-field backwards compat, and serialize/deserialize roundtrip.
- 3 new hook_check tests cover the `should_emit` truth table for Ok / Missing / Outdated against both `warn_on_missing` values.

## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

-

## Test plan
<!-- How did you verify this works? -->

- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
