### PR TITLE
fix(grep): use PCRE-converted pattern with -E flag in grep fallback

### DIFF
--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -54,7 +54,7 @@ pub fn run(
         .or_else(|_| {
             let mut grep_cmd = resolved_command("grep");
             // When we fall back to grep, include all args, not just -rnHZ.
-            grep_cmd.args(["-rnHZ", pattern, path]).args(extra_args);
+            grep_cmd.args(["-rnHEZ", &rg_pattern, path]).args(extra_args);
             exec_capture(&mut grep_cmd)
         })
         .context("grep/rg failed")?;


### PR DESCRIPTION
## Problem

When rtk grep falls back from rg to grep (when rg is unavailable), the fallback uses the original BRE pattern and lacks the `-E` (extended regex) flag. This causes patterns with BRE-to-PCRE conversion to fail silently:

1. User passes a BRE pattern like `fn foo\|pub.*bar` to `rtk grep`
2. rtk converts it to PCRE `fn foo|pub.*bar` for rg
3. When rg is unavailable, grep receives `fn foo|pub.*bar` (PCRE) but **without** `-E`, grep treats `|` as a literal pipe character
4. **Result**: zero matches returned, misleading AI agents into thinking the pattern was not found

## Fix

- Use the PCRE-converted pattern (`rg_pattern`) instead of the original BRE pattern in the grep fallback
- Add `-E` (extended regex) flag to the grep invocation so `|` alternation is interpreted correctly

```diff
-            grep_cmd.args(["-rnHZ", pattern, path]).args(extra_args);
+            grep_cmd.args(["-rnHEZ", &rg_pattern, path]).args(extra_args);
```

## Before

```
$ rtk grep "fn foo\|pub.*bar" .
0 matches for 'fn foo\|pub.*bar'
```

## After

```
$ rtk grep "fn foo\|pub.*bar" .
X matches in YF:

[file] src/main.rs (3):
   10: fn foo() { ... }
   25: pub struct Bar { ... }
```