### PR TITLE
feat(hook): emit Claude Code PermissionRequest decisions (fallback for anthropics/claude-code#15897)

### DIFF
--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -96,6 +96,38 @@ Rules are loaded from all Claude Code `settings.json` files (project + global, i
 - `rewrite_cmd.rs` — maps verdict to exit code (consumed by shell hook)
 - `hook_cmd.rs` — maps verdict to JSON `permissionDecision` field (Copilot/Gemini)
 
+### Claude Code event: PreToolUse vs PermissionRequest
+
+`rtk hook claude` reads `hook_event_name` and emits the matching JSON shape, so the
+same command can be registered on either Claude Code event:
+
+| Event | Output shape | Honors `updatedInput`? |
+|-------|--------------|------------------------|
+| `PreToolUse` (default) | `hookSpecificOutput.updatedInput` + `permissionDecision` | Yes — but **currently ignored by Claude Code** ([anthropics/claude-code#15897](https://github.com/anthropics/claude-code/issues/15897)) |
+| `PermissionRequest` | `hookSpecificOutput.decision.{behavior, updatedInput}` | Yes |
+
+`PermissionRequest` is a fallback for #15897. It only fires when Claude Code is about to
+prompt the user, so its rewrite uses `decision.behavior: "allow"` (the only form that
+carries `updatedInput`). Unlike `PreToolUse`'s `permissionDecision: "allow"`, this does
+**not** unconditionally run the command — Claude Code re-evaluates the *rewritten* command
+against the user's ask/deny rules, so an `ask` rule covering `Bash(rtk:*)` still prompts the
+user, preserving least-privilege.
+
+Registration is event-specific and not yet wired into `rtk init` (the emission primitive
+ships first; auto-registration + the `Bash(rtk:*)` ask rule are a planned follow-up). To opt
+in manually, add to `settings.json`:
+
+```json
+{
+  "permissions": { "ask": ["Bash(rtk:*)"] },
+  "hooks": {
+    "PermissionRequest": [
+      { "matcher": "Bash", "hooks": [{ "type": "command", "command": "rtk hook claude" }] }
+    ]
+  }
+}
+```
+
 ## Exit Code Contract
 
 Hook processors in `hook_cmd.rs` must return `Ok(())` on every path — success, no-match, parse error, and unexpected input. Returning `Err` propagates to `main()` and exits non-zero, which blocks the agent's command from executing. This violates the non-blocking guarantee documented in `hooks/README.md`.

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -6,6 +6,7 @@ pub const SETTINGS_JSON: &str = "settings.json";
 pub const SETTINGS_LOCAL_JSON: &str = "settings.local.json";
 pub const HOOKS_JSON: &str = "hooks.json";
 pub const PRE_TOOL_USE_KEY: &str = "PreToolUse";
+pub const PERMISSION_REQUEST_KEY: &str = "PermissionRequest";
 pub const BEFORE_TOOL_KEY: &str = "BeforeTool";
 
 /// Native Rust hook command for Claude Code (replaces rtk-rewrite.sh).

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -3,7 +3,7 @@
 //! Uses `writeln!(stdout, ...)` instead of `println!` — accidental stdout/stderr
 //! corrupts the JSON protocol (Claude Code bug #4669 silently disables the hook).
 
-use super::constants::PRE_TOOL_USE_KEY;
+use super::constants::{PERMISSION_REQUEST_KEY, PRE_TOOL_USE_KEY};
 use super::permissions::{self, PermissionVerdict};
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
@@ -339,6 +339,66 @@ enum PayloadAction {
     Ignore,
 }
 
+/// Claude Code hook events RTK can be registered on.
+///
+/// Both deliver the same `tool_name` + `tool_input.command` payload and accept
+/// `updatedInput`, but they wrap the decision differently (see [`build_hook_output`]).
+enum ClaudeEvent {
+    /// Fires before every tool call. Honors `updatedInput` directly — but the
+    /// field is currently ignored by Claude Code (anthropics/claude-code#15897).
+    PreToolUse,
+    /// Fires only when a permission prompt is about to be shown. Honors
+    /// `updatedInput` (nested under `decision`), used as a fallback for #15897.
+    PermissionRequest,
+}
+
+/// Read which event Claude Code invoked the hook on. Defaults to `PreToolUse`
+/// when `hook_event_name` is absent (older payloads and direct invocations).
+fn claude_event(v: &Value) -> ClaudeEvent {
+    match v.get("hook_event_name").and_then(|e| e.as_str()) {
+        Some(PERMISSION_REQUEST_KEY) => ClaudeEvent::PermissionRequest,
+        _ => ClaudeEvent::PreToolUse,
+    }
+}
+
+/// Build the `hookSpecificOutput` body for the given event.
+fn build_hook_output(event: ClaudeEvent, updated_input: Value, allow: bool) -> Value {
+    match event {
+        ClaudeEvent::PreToolUse => {
+            let mut out = json!({
+                "hookEventName": PRE_TOOL_USE_KEY,
+                "permissionDecisionReason": "RTK auto-rewrite",
+                "updatedInput": updated_input
+            });
+            // AskRewrite omits permissionDecision so Claude Code runs its normal
+            // prompt flow on the rewritten command (never auto-allow on ask).
+            if allow {
+                out.as_object_mut()
+                    .unwrap()
+                    .insert("permissionDecision".into(), json!("allow"));
+            }
+            out
+        }
+        ClaudeEvent::PermissionRequest => {
+            // On PermissionRequest, `updatedInput` is only honored alongside
+            // `decision.behavior: "allow"` — Claude Code drops it otherwise.
+            // Unlike PreToolUse's `permissionDecision: "allow"`, this does NOT
+            // unconditionally run the command: Claude Code re-evaluates the
+            // *rewritten* command against the user's ask/deny rules, so an ask
+            // rule covering `Bash(rtk:*)` still prompts the user. That re-prompt
+            // — not withholding the decision — is what preserves least-privilege
+            // here, so both allow- and ask-verdict rewrites use "allow".
+            json!({
+                "hookEventName": PERMISSION_REQUEST_KEY,
+                "decision": {
+                    "behavior": "allow",
+                    "updatedInput": updated_input
+                }
+            })
+        }
+    }
+}
+
 fn process_claude_payload(v: &Value) -> PayloadAction {
     let cmd = match v
         .pointer("/tool_input/command")
@@ -374,18 +434,7 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
         ti
     };
 
-    let mut hook_output = json!({
-        "hookEventName": PRE_TOOL_USE_KEY,
-        "permissionDecisionReason": "RTK auto-rewrite",
-        "updatedInput": updated_input
-    });
-
-    if allow {
-        hook_output
-            .as_object_mut()
-            .unwrap()
-            .insert("permissionDecision".into(), json!("allow"));
-    }
+    let hook_output = build_hook_output(claude_event(v), updated_input, allow);
 
     PayloadAction::Rewrite {
         cmd: cmd.to_string(),
@@ -1010,6 +1059,92 @@ mod tests {
         assert_eq!(hook["permissionDecisionReason"], "RTK auto-rewrite");
         assert!(hook["updatedInput"].is_object());
         assert!(hook["updatedInput"]["command"].is_string());
+    }
+
+    // --- Claude PermissionRequest event (anthropics/claude-code#15897 fallback) ---
+
+    fn claude_permissionrequest_input(cmd: &str) -> String {
+        json!({
+            "hook_event_name": PERMISSION_REQUEST_KEY,
+            "tool_name": "Bash",
+            "tool_input": { "command": cmd }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn test_claude_permissionrequest_rewrite_shape() {
+        // On the PermissionRequest event the rewrite is nested under `decision`
+        // with `behavior: "allow"`, not at the top of `hookSpecificOutput`.
+        let result = run_claude_inner(&claude_permissionrequest_input("git status")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let hook = &v["hookSpecificOutput"];
+
+        assert_eq!(hook["hookEventName"], PERMISSION_REQUEST_KEY);
+        assert_eq!(hook["decision"]["behavior"], "allow");
+        assert_eq!(
+            hook["decision"]["updatedInput"]["command"],
+            "rtk git status"
+        );
+        // PreToolUse-shaped fields must NOT appear on the PermissionRequest event.
+        assert!(hook["updatedInput"].is_null());
+        assert!(hook["permissionDecision"].is_null());
+    }
+
+    #[test]
+    fn test_claude_permissionrequest_preserves_tool_input_fields() {
+        let input = json!({
+            "hook_event_name": PERMISSION_REQUEST_KEY,
+            "tool_name": "Bash",
+            "tool_input": { "command": "git status", "timeout": 30000, "description": "Status" }
+        })
+        .to_string();
+        let result = run_claude_inner(&input).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let updated = &v["hookSpecificOutput"]["decision"]["updatedInput"];
+        assert_eq!(updated["command"], "rtk git status");
+        assert_eq!(updated["timeout"], 30000);
+        assert_eq!(updated["description"], "Status");
+    }
+
+    #[test]
+    fn test_claude_permissionrequest_passthrough_unsupported() {
+        assert!(run_claude_inner(&claude_permissionrequest_input("htop")).is_none());
+    }
+
+    #[test]
+    fn test_claude_permissionrequest_already_rtk_passthrough() {
+        assert!(run_claude_inner(&claude_permissionrequest_input("rtk git status")).is_none());
+    }
+
+    #[test]
+    fn test_claude_permissionrequest_substitution_not_rewritten() {
+        // Unattestable constructs must never be auto-allowed on PermissionRequest
+        // either — RTK skips so Claude Code evaluates the original natively.
+        assert!(run_claude_inner(&claude_permissionrequest_input(
+            "git status $(rm -rf /tmp/x)"
+        ))
+        .is_none());
+    }
+
+    #[test]
+    fn test_claude_explicit_pretooluse_event_keeps_legacy_shape() {
+        // An explicit PreToolUse event (and any unknown/absent event) renders the
+        // original top-level `updatedInput` shape, not the `decision` wrapper.
+        let input = json!({
+            "hook_event_name": PRE_TOOL_USE_KEY,
+            "tool_name": "Bash",
+            "tool_input": { "command": "git status" }
+        })
+        .to_string();
+        let result = run_claude_inner(&input).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(v["hookSpecificOutput"]["hookEventName"], PRE_TOOL_USE_KEY);
+        assert_eq!(
+            v["hookSpecificOutput"]["updatedInput"]["command"],
+            "rtk git status"
+        );
+        assert!(v["hookSpecificOutput"]["decision"].is_null());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Makes `rtk hook claude` **event-aware**: it now reads `hook_event_name` from the
payload and renders the matching JSON shape, so the same `rtk hook claude` command
works whether Claude Code invokes it on the **PreToolUse** event (today's default)
or the **PermissionRequest** event.

This is the **emission primitive** (Part 1). It is additive and changes no default
behavior — registration on the PermissionRequest event is opt-in and documented, and
left to a follow-up PR (see *Scope / follow-up* below).

## The bug we're working around

rtk's Claude Code integration rewrites commands transparently by returning
`hookSpecificOutput.updatedInput` from a **PreToolUse** hook (`rtk hook claude`).

**Claude Code currently ignores `updatedInput` on the PreToolUse event** —
[anthropics/claude-code#15897](https://github.com/anthropics/claude-code/issues/15897).
The hook still runs and its `permissionDecision` is honored, but the `updatedInput`
rewrite is silently dropped, so `git status` runs as `git status` instead of
`rtk git status`. On affected Claude Code versions, transparent rewriting is a no-op.

Reproduced on Claude Code `2.1.x` (single PreToolUse hook, `allow` + `updatedInput`):
the hook fires, but the original command executes and the rewrite is discarded.
`permissionDecision: "deny"` from the same hook *is* honored, confirming the hook
output is parsed — only `updatedInput` is ignored on this event.

## The fix

`updatedInput` **does** take effect on Claude Code's **PermissionRequest** event,
where it lives under `decision.updatedInput`. So `process_claude_payload` now branches
on the event:

| Event | Output shape |
|-------|--------------|
| `PreToolUse` (default / absent `hook_event_name`) | `hookSpecificOutput.updatedInput` (+ `permissionDecision` on allow) — **unchanged** |
| `PermissionRequest` | `hookSpecificOutput.decision.{behavior:"allow", updatedInput}` |

All rewrite + permission logic is unchanged — this only adds a second rendering of the
existing `HookDecision`. The PreToolUse path is byte-for-byte identical to before.

## Design note: least-privilege on PermissionRequest

rtk's rule (e.g. anthropics/claude-code#1155, the Copilot CVE tests) is to **never
auto-allow a command the host would have prompted for**. PermissionRequest only fires
when Claude Code is *about to prompt*, and `updatedInput` is only honored alongside
`decision.behavior: "allow"` — there is no "rewrite without deciding" form like
PreToolUse's bare `updatedInput` or Copilot's `modifiedArgs`.

The reconciliation: `decision.behavior: "allow"` on PermissionRequest does **not**
unconditionally execute the command. Claude Code **re-evaluates the rewritten command
against the user's ask/deny rules**. So with an `ask` rule covering `Bash(rtk:*)`, the
rewritten `rtk …` command re-prompts the user — same "rewrite + prompt" semantics rtk
already gives `ask`-verdict commands on other hosts, just achieved via re-evaluation.
(Verified empirically against Claude Code 2.1.x.)

## Scope / follow-up (open question for maintainers)

To keep this PR focused and non-breaking, it ships **only the emission**. It does **not**:

- register the hook on the PermissionRequest event in `rtk init`, or
- add the `Bash(rtk:*)` `ask` rule that preserves least-privilege.

Those are deferred so you can decide the policy (opt-in flag? auto-add the ask rule?
version-gate on affected Claude Code builds?). Manual opt-in is documented in
`src/hooks/README.md`. Happy to send the `rtk init` wiring as Part 2 once the approach
is agreed.

## Tests

Added to `src/hooks/hook_cmd.rs` (unit tests, same style as the existing Claude tests):

- `test_claude_permissionrequest_rewrite_shape` — rewrite nested under `decision.{behavior, updatedInput}`; no PreToolUse-shaped fields leak.
- `test_claude_permissionrequest_preserves_tool_input_fields` — `timeout`/`description` survive the rewrite.
- `test_claude_permissionrequest_passthrough_unsupported` — unsupported command → no output.
- `test_claude_permissionrequest_already_rtk_passthrough` — already-`rtk` → no output.
- `test_claude_permissionrequest_substitution_not_rewritten` — unattestable construct never auto-allowed.
- `test_claude_explicit_pretooluse_event_keeps_legacy_shape` — explicit/absent event keeps the original shape.

## Checklist

- [x] `cargo fmt --all --check && cargo clippy --all-targets && cargo test` passes (2151 passed, 0 failed)
- [x] Unit tests added for changed code
- [x] Docs updated (`src/hooks/README.md`)
- [x] Manual test: `rtk hook claude` exercised for both events + passthrough via the built binary
- [x] No default-behavior change (PreToolUse output unchanged; new path only via opt-in registration)
- [ ] CLA — will sign via CLA Assistant

Targets `develop` per CONTRIBUTING.md.
