### PR TITLE
fix(init): write cline rules to .clinerules/rtk.md when dir exists

### DIFF
--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -1552,14 +1552,21 @@ const CLINE_RULES: &str = include_str!("../../hooks/cline/rules.md");
 
 fn run_cline_mode(ctx: InitContext) -> Result<()> {
     let InitContext { verbose, dry_run } = ctx;
-    // Cline reads .clinerules from the project root (workspace-scoped)
-    let rules_path = PathBuf::from(".clinerules");
+    // Cline reads .clinerules from the project root (workspace-scoped).
+    // If .clinerules already exists as a directory, write into .clinerules/rtk.md
+    // so we don't crash trying to write a file over a directory.
+    let clinerules_dir = PathBuf::from(".clinerules");
+    let rules_path = if clinerules_dir.is_dir() {
+        clinerules_dir.join("rtk.md")
+    } else {
+        clinerules_dir
+    };
 
     let existing = fs::read_to_string(&rules_path).unwrap_or_default();
     if existing.contains("RTK") || existing.contains("rtk") {
         if !dry_run {
             println!("\nRTK already configured for Cline in this project.\n");
-            println!("  Rules: .clinerules (already present)");
+            println!("  Rules: {} (already present)", rules_path.display());
         }
     } else {
         let new_content = if existing.trim().is_empty() {
@@ -1576,14 +1583,15 @@ fn run_cline_mode(ctx: InitContext) -> Result<()> {
                 println!("[dry-run] content:\n{}", new_content);
             }
         } else {
-            fs::write(&rules_path, &new_content).context("Failed to write .clinerules")?;
+            fs::write(&rules_path, &new_content)
+                .with_context(|| format!("Failed to write {}", rules_path.display()))?;
 
             if verbose > 0 {
-                eprintln!("Wrote .clinerules");
+                eprintln!("Wrote {}", rules_path.display());
             }
 
             println!("\nRTK configured for Cline.\n");
-            println!("  Rules: .clinerules (installed)");
+            println!("  Rules: {} (installed)", rules_path.display());
         }
     }
     if !dry_run {


### PR DESCRIPTION
## Summary

`rtk init --agent cline` crashes when `.clinerules` already exists as a directory, because it tries to write a file at the same path. This PR detects that case upfront and redirects the write target to `.clinerules/rtk.md`, which is a valid Cline rules location per the [Cline docs](https://docs.cline.bot/customization/cline-rules). All other paths (no `.clinerules`, or `.clinerules` as a plain file) retain existing behaviour unchanged.

Closes #2349

## Changes

- `src/hooks/init.rs` — in `run_cline_mode`, check `is_dir()` on `.clinerules` before resolving the write path; if it is a directory, use `.clinerules/rtk.md` instead. Also updated all user-facing messages to show the actual resolved path rather than the hardcoded string.

## Test plan

- [ ] `cargo build` passes
- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] Manual: run `rtk init --agent cline` in a repo where `.clinerules/` is an existing directory — confirm it writes `.clinerules/rtk.md` without crashing
- [ ] Manual: run `rtk init --agent cline` in a repo with no `.clinerules` — confirm existing behaviour (writes `.clinerules` file) is unchanged
- [ ] Manual: run `rtk init --agent cline` in a repo where `.clinerules` is a plain file — confirm existing append behaviour is unchanged