### PR TITLE
fix(cli): use clap external_subcommand for passthrough instead of run_fallback

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -766,6 +766,13 @@ enum Commands {
         args: Vec<String>,
     },
 
+    /// Passthrough an unrecognised command to the OS (not an RTK subcommand).
+    /// Silently proxies the command to the native binary without recording a
+    /// parse failure — the parse_failures table remains actionable (only real
+    /// errors).
+    #[command(external_subcommand)]
+    Passthrough(Vec<OsString>),
+
     /// Hook processors for LLM CLI tools (Gemini CLI, Copilot, etc.)
     Hook {
         #[command(subcommand)]
@@ -2461,6 +2468,33 @@ fn run_cli() -> Result<i32> {
             0
         }
 
+        Commands::Passthrough(args) => {
+            let raw = args
+                .iter()
+                .map(|s| s.to_string_lossy())
+                .collect::<Vec<_>>()
+                .join(" ");
+            let cmd_name = args[0].to_string_lossy();
+            let status = core::utils::resolved_command(&cmd_name)
+                .args(&args[1..])
+                .stdin(std::process::Stdio::inherit())
+                .stdout(std::process::Stdio::inherit())
+                .stderr(std::process::Stdio::inherit())
+                .status();
+
+            match status {
+                Ok(s) => {
+                    let timer = core::tracking::TimedExecution::start();
+                    timer.track_passthrough(&raw, &format!("rtk passthrough: {}", raw));
+                    core::utils::exit_code_from_status(&s, &raw)
+                }
+                Err(e) => {
+                    eprintln!("[rtk: {}]", e);
+                    127
+                }
+            }
+        }
+
         Commands::Untrust => {
             hooks::trust::run_untrust()?;
             0
@@ -2769,13 +2803,12 @@ mod tests {
 
     #[test]
     fn test_try_parse_unknown_subcommand_is_error() {
-        match Cli::try_parse_from(["rtk", "nonexistent-command"]) {
-            Err(e) => assert!(!matches!(
-                e.kind(),
-                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
-            )),
-            Ok(_) => panic!("Expected parse error for unknown subcommand"),
-        }
+        let cli = Cli::try_parse_from(["rtk", "nonexistent-command"]);
+        assert!(cli.is_ok(), "unknown subcommand should parse as Passthrough");
+        assert!(
+            matches!(cli.unwrap().command, Commands::Passthrough(ref args) if args == &[OsString::from("nonexistent-command")]),
+            "unknown subcommand should be captured as Passthrough"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When a user runs `rtk` with a non-RTK subcommand (e.g. `rtk uv pip install`, `rtk whoami`), Clap's `try_parse()` fails because the subcommand is not recognized. This falls through to `run_fallback()`, which proxy-executes the command **and** records every invocation as a `parse_failure` in the SQLite tracking database — even when the proxy execution succeeds.

This pollutes the `parse_failures` table with noise, making it harder to spot genuine parse errors.

## Real-world impact

From a real production tracking database (946 total commands tracked):

```
Total parse_failures:   45
  - Successful fallbacks (noise): 41  (91%)
  - Genuine failures:               4   (9%)
```

**91% of the `parse_failures` table is noise.** Every `uv pip install ...`, `git ...`, or any command that Clap doesn't recognize gets logged as a failure, even though it was successfully proxied to the native binary:

```
# Noise (successful fallbacks logged as failures):
cmd: uv pip install -e .
err: error: unrecognized subcommand 'uv'

cmd: uv pip install pytest
err: error: unrecognized subcommand 'uv'

cmd: git -C /path status test_15816
err: unrecognized subcommand
```

The genuine failures (only 9%) are drowned out:

```
# Real failures:
cmd: diff -q d:\WorkPlace\...
err: error: unexpected argument '-q' found

cmd: ps aux
err: error: unrecognized subcommand 'ps'
```

With this fix, the `parse_failures` table becomes actionable — every entry is a real error worth investigating.

## Fix

Add a `Passthrough` variant with `#[command(external_subcommand)]` to the top-level `Commands` enum. This tells Clap to accept any unrecognized subcommand as a valid parse. The dispatch handler proxy-executes the command without recording a parse failure.

### Before (behavior unchanged for known subcommands)

```
rtk whoami → Clap parse error → run_fallback() → proxy-executes + records parse_failure
```

### After

```
rtk whoami → Clap parses as Commands::Passthrough(["whoami"]) → proxy-executes, no parse_failure
```

## Changes

- **src/main.rs**: Add `Passthrough(Vec<OsString>)` variant with `#[command(external_subcommand)]` to `Commands` enum
- **src/main.rs**: Handle `Commands::Passthrough` in dispatch: proxy-execute via `resolved_command`, track as passthrough, no parse_failure recording
- **src/main.rs**: Update `test_try_parse_unknown_subcommand_is_error` to expect `Ok(Passthrough)` instead of `Err`

## Test plan

- `cargo build` — clean
- `cargo test --bin rtk` — 2126 passed (16 pre-existing Windows failures in `core::stream::tests` unaffected)
- Manual smoke test: `cargo run -- whoami` → correctly prints username
- Manual smoke test: `cargo run -- rewrite "echo hello"` → exit 1 (no rewrite available, expected)
- Manual smoke test: `cargo run -- dir` → exit 127 (dir is CMD built-in, expected)

## Rationale

`run_fallback` remains in place for genuine Clap parse errors (bad flags, missing required args on known subcommands). Only the "unknown subcommand" class of errors is now handled properly via Clap's idiomatic `external_subcommand` mechanism.