### PR TITLE
feat(windows): native Windows support without WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Download from [releases](https://github.com/rtk-ai/rtk/releases):
 - Linux: `rtk-x86_64-unknown-linux-musl.tar.gz` / `rtk-aarch64-unknown-linux-gnu.tar.gz`
 - Windows: `rtk-x86_64-pc-windows-msvc.zip`
 
-> **Windows users**: Extract the zip and place `rtk.exe` somewhere in your PATH (e.g. `C:\Users\<you>\.local\bin`). Run RTK from **Command Prompt**, **PowerShell**, or **Windows Terminal** — do not double-click the `.exe` (it will flash and close). For the best experience, use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) where the full hook system works natively. See [Windows setup](#windows) below for details.
+> **Windows users**: Extract the zip and place `rtk.exe` somewhere in your PATH (e.g. `C:\Users\<you>\.local\bin`). Run RTK from **Command Prompt**, **PowerShell**, or **Windows Terminal** — do not double-click the `.exe` (it will flash and close). RTK is fully supported on native Windows (no WSL required); for the best filter coverage also install [Coreutils for Windows](https://github.com/microsoft/coreutils) with `winget install Microsoft.Coreutils`. See [Windows setup](#windows) below for details.
 
 ### Verify Installation
 
@@ -316,40 +316,42 @@ After install, **restart Claude Code**.
 
 ## Windows
 
-RTK works on Windows with some limitations. The auto-rewrite hook (`rtk-rewrite.sh`) requires a Unix shell, so on native Windows RTK falls back to **CLAUDE.md injection mode** — your AI assistant receives RTK instructions but commands are not rewritten automatically.
+RTK runs **natively on Windows — no WSL required**. The auto-rewrite hook is the `rtk hook claude` binary command (pure Rust), so it installs and runs the same on Windows, Linux, and macOS. Binary resolution honors PATH and PATHEXT, and commands are spawned directly (bypassing PowerShell's `ls`/`cat` aliases).
 
-### Recommended: WSL (full support)
-
-For the best experience, use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) (Windows Subsystem for Linux). Inside WSL, RTK works exactly like Linux — full hook support, auto-rewrite, everything:
-
-```bash
-# Inside WSL
-curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
-rtk init -g
-```
-
-### Native Windows (limited support)
-
-On native Windows (cmd.exe / PowerShell), RTK filters work but the hook does not auto-rewrite commands:
+### Native Windows setup
 
 ```powershell
-# 1. Download and extract rtk-x86_64-pc-windows-msvc.zip from releases
-# 2. Add rtk.exe to your PATH
-# 3. Initialize (falls back to CLAUDE.md injection)
-rtk init -g
-# 4. Use rtk explicitly
-rtk cargo test
+# 1. Install RTK (or download rtk-x86_64-pc-windows-msvc.zip from releases and add rtk.exe to PATH)
+winget install Microsoft.Coreutils   # 2. recommended — enables ls/grep/wc/head/... filters
+rtk init -g                          # 3. installs the Claude Code hook (auto-rewrite)
+rtk verify                           # 4. confirms hook integrity + reports coreutils status
+rtk cargo test                       # use it
 rtk git status
 ```
 
 **Important**: Do not double-click `rtk.exe` — it is a CLI tool that prints usage and exits immediately. Always run it from a terminal (Command Prompt, PowerShell, or Windows Terminal).
 
-| Feature | WSL | Native Windows |
-|---------|-----|----------------|
-| Filters (cargo, git, etc.) | Full | Full |
-| Auto-rewrite hook | Yes | No (CLAUDE.md fallback) |
-| `rtk init -g` | Hook mode | CLAUDE.md mode |
-| `rtk gain` / analytics | Full | Full |
+### Coreutils for Windows
+
+Some RTK filters wrap UNIX-style commands (`ls`, `grep`, `wc`, `head`, `tail`, `sort`, `uniq`, `cat`). On Linux/macOS these are part of the base system; on Windows, install [Coreutils for Windows](https://github.com/microsoft/coreutils):
+
+```powershell
+winget install Microsoft.Coreutils
+```
+
+It ships each utility under its standard name (`ls.exe`, `grep.exe`, …) on PATH, which RTK resolves via the `which` crate. Filters whose engine is pure Rust (`rtk find`, `rtk read`, `rtk json`, …) work with no extra install. If a wrapped tool is missing, the corresponding filter falls back to raw command output — `rtk verify` reports which tools are present.
+
+### WSL
+
+[WSL](https://learn.microsoft.com/en-us/windows/wsl/install) is still fully supported — inside WSL, RTK behaves exactly like Linux. It is now an option, not a requirement.
+
+| Feature | Native Windows | WSL | Linux/macOS |
+|---------|----------------|-----|-------------|
+| Filters (cargo, git, etc.) | Full | Full | Full |
+| Auto-rewrite hook (`rtk hook claude`) | Full | Full | Full |
+| `rtk init -g` | Hook mode | Hook mode | Hook mode |
+| UNIX-style filters (ls, grep, wc) | With Coreutils | Built-in | Built-in |
+| `rtk gain` / analytics | Full | Full | Full |
 
 ## Supported AI Tools
 

--- a/README.md
+++ b/README.md
@@ -341,6 +341,18 @@ winget install Microsoft.Coreutils
 
 It ships each utility under its standard name (`ls.exe`, `grep.exe`, …) on PATH, which RTK resolves via the `which` crate. Filters whose engine is pure Rust (`rtk find`, `rtk read`, `rtk json`, …) work with no extra install. If a wrapped tool is missing, the corresponding filter falls back to raw command output — `rtk verify` reports which tools are present.
 
+### PowerShell-native commands
+
+PowerShell cmdlets (`Get-ChildItem`, `Get-Content`, `Select-String`, …), functions, aliases, and cmd.exe builtins (`dir`, `echo`) are not standalone executables on PATH — they only exist inside a shell. When RTK can't resolve a command as a PATH binary on Windows, it runs it through PowerShell instead of failing, so these work transparently:
+
+```powershell
+rtk Get-ChildItem        # runs via PowerShell
+rtk Get-Content file.txt # runs via PowerShell
+rtk dir                  # cmd builtin → PowerShell alias
+```
+
+RTK prefers PowerShell 7+ (`pwsh`) and falls back to Windows PowerShell (`powershell`), and runs with `-NoProfile` for fast, predictable execution. Output is passed through unfiltered; commands that RTK has a dedicated filter for (and whose tool is on PATH) are still filtered as usual.
+
 ### WSL
 
 [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) is still fully supported — inside WSL, RTK behaves exactly like Linux. It is now an option, not a requirement.
@@ -351,6 +363,7 @@ It ships each utility under its standard name (`ls.exe`, `grep.exe`, …) on PAT
 | Auto-rewrite hook (`rtk hook claude`) | Full | Full | Full |
 | `rtk init -g` | Hook mode | Hook mode | Hook mode |
 | UNIX-style filters (ls, grep, wc) | With Coreutils | Built-in | Built-in |
+| PowerShell-native commands (cmdlets) | Via PowerShell | n/a | n/a |
 | `rtk gain` / analytics | Full | Full | Full |
 
 ## Supported AI Tools

--- a/src/cmds/system/env_cmd.rs
+++ b/src/cmds/system/env_cmd.rs
@@ -69,12 +69,13 @@ pub fn run(filter: Option<&str>, show_all: bool, verbose: u8) -> Result<()> {
         println!("PATH Variables:");
         for (k, v) in &path_vars {
             if k == "PATH" {
-                // Split PATH for readability
-                let paths: Vec<&str> = v.split(':').collect();
+                // Split PATH for readability. `split_paths` is platform-aware:
+                // `:` on Unix, `;` on Windows.
+                let paths: Vec<std::path::PathBuf> = env::split_paths(v).collect();
                 println!("  PATH ({} entries):", paths.len());
                 const MAX_PATH_ENTRIES: usize = CAP_WARNINGS;
                 for p in paths.iter().take(MAX_PATH_ENTRIES) {
-                    println!("    {}", p);
+                    println!("    {}", p.display());
                 }
                 if paths.len() > MAX_PATH_ENTRIES {
                     println!("    ... +{} more", paths.len() - MAX_PATH_ENTRIES);
@@ -215,6 +216,19 @@ fn is_interesting_var(key: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_path_split_uses_platform_separator() {
+        // Build a PATH-like value with the platform separator (`:` on Unix,
+        // `;` on Windows), then confirm split_paths recovers both entries.
+        let entries = [PathBuf::from("/a/b"), PathBuf::from("/c/d")];
+        let joined = env::join_paths(&entries).expect("join_paths");
+        let split: Vec<PathBuf> = env::split_paths(&joined).collect();
+        assert_eq!(split.len(), 2);
+        assert_eq!(split[0], entries[0]);
+        assert_eq!(split[1], entries[1]);
+    }
 
     #[test]
     fn test_mask_value_short() {

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -658,9 +658,11 @@ pub(crate) mod tests {
         assert!(result.raw.is_empty());
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn test_run_streaming_exit_code_preserved() {
-        // nosemgrep: interpreter-execution
+        // Uses `sh`; exit codes 0/1 are covered cross-platform by the
+        // `true`/`false` tests above. nosemgrep: interpreter-execution
         let mut cmd = Command::new("sh");
         cmd.args(["-c", "exit 42"]);
         let result = run_streaming(&mut cmd, StdinMode::Null, FilterMode::Passthrough).unwrap();
@@ -723,9 +725,10 @@ pub(crate) mod tests {
         assert_eq!(result.exit_code, 0);
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn test_run_streaming_raw_cap_at_10mb() {
-        // nosemgrep: interpreter-execution
+        // Uses `sh` + `dd`/`/dev/zero` to generate ~11 MiB. nosemgrep: interpreter-execution
         let mut cmd = Command::new("sh");
         // ~11 MiB of 80-char lines (fast: fewer lines than `yes | head -6M`)
         cmd.args([
@@ -744,9 +747,10 @@ pub(crate) mod tests {
         );
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn test_run_streaming_stderr_cap_at_10mb() {
-        // nosemgrep: interpreter-execution
+        // Uses `sh` + `dd`/`/dev/zero` to generate ~11 MiB. nosemgrep: interpreter-execution
         let mut cmd = Command::new("sh");
         // ~11 MiB on stderr, nothing on stdout
         cmd.args([
@@ -811,18 +815,20 @@ pub(crate) mod tests {
         assert_eq!(result.exit_code, 1);
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn test_exec_capture_stderr() {
-        // nosemgrep: interpreter-execution
+        // Uses `sh` for stderr redirection. nosemgrep: interpreter-execution
         let mut cmd = Command::new("sh");
         cmd.args(["-c", "echo err_msg >&2"]);
         let result = exec_capture(&mut cmd).unwrap();
         assert!(result.stderr.contains("err_msg"));
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn test_exec_capture_combined() {
-        // nosemgrep: interpreter-execution
+        // Uses `sh` for stderr redirection. nosemgrep: interpreter-execution
         let mut cmd = Command::new("sh");
         cmd.args(["-c", "echo out_msg; echo err_msg >&2"]);
         let result = exec_capture(&mut cmd).unwrap();

--- a/src/core/telemetry.rs
+++ b/src/core/telemetry.rs
@@ -207,7 +207,7 @@ fn random_salt() -> String {
 
 pub fn salt_file_path() -> PathBuf {
     dirs::data_local_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .unwrap_or_else(std::env::temp_dir)
         .join("rtk")
         .join(".device_salt")
 }
@@ -436,7 +436,7 @@ fn install_method_from_path(path: &str) -> &'static str {
 
 pub fn telemetry_marker_path() -> PathBuf {
     let data_dir = dirs::data_local_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .unwrap_or_else(std::env::temp_dir)
         .join(RTK_DATA_DIR);
     let _ = std::fs::create_dir_all(&data_dir);
     data_dir.join(".telemetry_last_ping")

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -355,6 +355,62 @@ pub fn resolved_command(name: &str) -> Command {
     }
 }
 
+/// Build the PowerShell argument tail that runs a parsed command line
+/// (`program` + `args`) as a native PowerShell command.
+///
+/// PowerShell concatenates the tokens that follow `-Command` into the command
+/// text, so cmdlets (`Get-ChildItem`), functions, and aliases run natively.
+/// `-NoProfile` keeps startup fast and predictable — built-in cmdlets always
+/// resolve, though profile-defined custom aliases/functions will not.
+///
+/// Pure and cross-platform so the argument shape can be unit-tested everywhere;
+/// only invoked from the Windows arm of [`passthrough_command`], hence the
+/// `dead_code` allowance on non-Windows non-test builds.
+#[cfg_attr(not(windows), allow(dead_code))]
+pub fn powershell_invocation(program: &str, args: &[String]) -> Vec<String> {
+    let mut v = vec![
+        "-NoProfile".to_string(),
+        "-NoLogo".to_string(),
+        "-Command".to_string(),
+        program.to_string(),
+    ];
+    v.extend(args.iter().cloned());
+    v
+}
+
+/// PowerShell executable to use, preferring PowerShell 7+ (`pwsh`) and falling
+/// back to Windows PowerShell (`powershell`).
+#[cfg(windows)]
+pub fn powershell_exe() -> &'static str {
+    if tool_exists("pwsh") {
+        "pwsh"
+    } else {
+        "powershell"
+    }
+}
+
+/// Build the passthrough `Command` for a parsed command line, with `args`
+/// already applied.
+///
+/// On Windows, a command that does not resolve to a PATH binary is assumed to be
+/// PowerShell-native — a cmdlet/function/alias (e.g. `Get-ChildItem`) or a
+/// cmd.exe builtin (e.g. `dir`) — and is run through PowerShell, since such
+/// commands are not standalone executables. On every other platform this is
+/// equivalent to `resolved_command(program).args(args)`.
+pub fn passthrough_command(program: &str, args: &[String]) -> Command {
+    #[cfg(windows)]
+    {
+        if resolve_binary(program).is_err() {
+            let mut c = Command::new(powershell_exe());
+            c.args(powershell_invocation(program, args));
+            return c;
+        }
+    }
+    let mut c = resolved_command(program);
+    c.args(args);
+    c
+}
+
 /// Check if a tool exists on PATH (PATHEXT-aware on Windows).
 ///
 /// Replaces manual `Command::new("which").arg(tool)` checks that fail on Windows.
@@ -646,6 +702,32 @@ mod tests {
         );
     }
 
+    // ===== PowerShell passthrough tests (PR #2355) =====
+
+    #[test]
+    fn test_powershell_invocation_no_args() {
+        let argv = powershell_invocation("Get-ChildItem", &[]);
+        assert_eq!(
+            argv,
+            vec!["-NoProfile", "-NoLogo", "-Command", "Get-ChildItem"]
+        );
+    }
+
+    #[test]
+    fn test_powershell_invocation_with_args() {
+        let argv = powershell_invocation("Get-Content", &["foo.txt".to_string()]);
+        assert_eq!(
+            argv,
+            vec![
+                "-NoProfile",
+                "-NoLogo",
+                "-Command",
+                "Get-Content",
+                "foo.txt"
+            ]
+        );
+    }
+
     // ===== tool_exists tests (issue #212) =====
 
     #[test]
@@ -806,6 +888,32 @@ mod tests {
             assert!(
                 result.is_ok(),
                 "which_in should find .cmd wrapper on Windows"
+            );
+        }
+
+        #[test]
+        fn test_passthrough_command_routes_cmdlet_to_powershell() {
+            // Get-ChildItem is a PowerShell cmdlet, not a PATH binary, so
+            // passthrough_command must route it through PowerShell.
+            let cmd = passthrough_command("Get-ChildItem", &[]);
+            let program = cmd.get_program().to_string_lossy().to_lowercase();
+            assert!(
+                program.contains("powershell") || program.contains("pwsh"),
+                "cmdlet should route through PowerShell, got program: {}",
+                program
+            );
+        }
+
+        #[test]
+        fn test_passthrough_command_uses_direct_exec_for_path_binary() {
+            // A resolvable binary (cargo is always on PATH in CI) must be
+            // executed directly, never via PowerShell.
+            let cmd = passthrough_command("cargo", &["--version".to_string()]);
+            let program = cmd.get_program().to_string_lossy().to_lowercase();
+            assert!(
+                !program.contains("powershell") && !program.contains("pwsh"),
+                "resolvable binary should run directly, got program: {}",
+                program
             );
         }
     }

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -362,6 +362,24 @@ pub fn tool_exists(name: &str) -> bool {
     which::which(name).is_ok()
 }
 
+/// UNIX-style commands rtk's filters delegate to that are part of the base
+/// system on Linux/macOS. On Windows they are provided by Microsoft Coreutils
+/// (`winget install Microsoft.Coreutils`), which exposes each under its standard
+/// name (`ls.exe`, `grep.exe`, …) on PATH — resolved here via `which`.
+pub const COREUTILS_TOOLS: &[&str] = &["ls", "wc", "grep", "head", "tail", "sort", "uniq", "cat"];
+
+/// Returns the subset of [`COREUTILS_TOOLS`] not found on PATH.
+///
+/// Cross-platform so it can be unit-tested everywhere, but only meaningful on
+/// Windows (callers gate the resulting guidance behind `cfg!(windows)`).
+pub fn missing_coreutils() -> Vec<&'static str> {
+    COREUTILS_TOOLS
+        .iter()
+        .copied()
+        .filter(|t| !tool_exists(t))
+        .collect()
+}
+
 /// Extract short name from AWS ARN.
 /// Example: `arn:aws:ecs:region:acct:service/cluster/name` -> `name`
 /// For simple ARNs like `arn:aws:iam::123:user/alice`, returns `alice`.
@@ -405,6 +423,19 @@ mod tests {
     #[test]
     fn test_truncate_short_string() {
         assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn test_missing_coreutils_is_subset() {
+        // Whatever is missing must be drawn from the known list, with no dups.
+        let missing = missing_coreutils();
+        for tool in &missing {
+            assert!(
+                COREUTILS_TOOLS.contains(tool),
+                "{tool} not in COREUTILS_TOOLS"
+            );
+        }
+        assert!(missing.len() <= COREUTILS_TOOLS.len());
     }
 
     #[test]

--- a/src/hooks/hook_audit_cmd.rs
+++ b/src/hooks/hook_audit_cmd.rs
@@ -1,19 +1,26 @@
 //! Audits hook activity logs to show what commands were rewritten and when.
 
+use crate::core::constants::RTK_DATA_DIR;
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-/// Default log file location (aligned with hook's $HOME/.local/share/rtk/).
+/// Default log file location.
+///
+/// `RTK_AUDIT_DIR` overrides everything. Otherwise the log lives under the
+/// platform data dir (`dirs::data_local_dir()`), matching `tracking.rs` and
+/// `tee.rs` — i.e. `~/.local/share/rtk/` on Linux, `%LOCALAPPDATA%\rtk\` on
+/// Windows. (The legacy bash hook used `$HOME/.local/share/rtk/`; the modern
+/// default install registers the `rtk hook claude` binary instead, so this
+/// `dirs`-based path is the cross-platform source of truth.)
 fn default_log_path() -> PathBuf {
     if let Ok(dir) = std::env::var("RTK_AUDIT_DIR") {
-        PathBuf::from(dir).join("hook-audit.log")
-    } else {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-        PathBuf::from(home)
-            .join(".local/share/rtk")
-            .join("hook-audit.log")
+        return PathBuf::from(dir).join("hook-audit.log");
     }
+    dirs::data_local_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join(RTK_DATA_DIR)
+        .join("hook-audit.log")
 }
 
 /// A single parsed audit log entry.
@@ -199,6 +206,24 @@ mod tests {
     fn test_parse_line_invalid() {
         assert!(parse_line("garbage").is_none());
         assert!(parse_line("").is_none());
+    }
+
+    #[test]
+    fn test_default_log_path_is_cross_platform() {
+        // RTK_AUDIT_DIR override wins and is used verbatim.
+        let tmp = std::env::temp_dir().join("rtk-audit-test");
+        std::env::set_var("RTK_AUDIT_DIR", &tmp);
+        let overridden = default_log_path();
+        assert_eq!(overridden, tmp.join("hook-audit.log"));
+        std::env::remove_var("RTK_AUDIT_DIR");
+
+        // Default path lives under the platform data dir, never a hardcoded
+        // Unix path. It must end in `rtk/hook-audit.log` and not start with /tmp.
+        let default = default_log_path();
+        assert!(
+            default.ends_with("rtk/hook-audit.log") || default.ends_with("rtk\\hook-audit.log")
+        );
+        assert!(!default.starts_with("/tmp"));
     }
 
     #[test]

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -1195,11 +1195,31 @@ fn run_default_mode(
     // 6. Generate user-global filters template (~/.config/rtk/filters.toml)
     generate_global_filters_template(ctx)?;
 
+    // 7. On Windows, nudge toward Coreutils so ls/wc/grep/… filters work.
+    if !dry_run {
+        warn_missing_coreutils();
+    }
+
     if !dry_run {
         println!(); // Final newline
     }
 
     Ok(())
+}
+
+/// On Windows, print a one-line hint if the UNIX-style commands rtk's filters
+/// rely on are absent. They ship with Microsoft Coreutils. No-op on Unix, where
+/// these tools are part of the base system.
+fn warn_missing_coreutils() {
+    if cfg!(windows) {
+        let missing = crate::core::utils::missing_coreutils();
+        if !missing.is_empty() {
+            println!(
+                "\n  note: {} not found on PATH — filters for these fall back to raw output.\n        Install with: winget install Microsoft.Coreutils",
+                missing.join(", ")
+            );
+        }
+    }
 }
 
 /// Migrate old hook script to new binary command.

--- a/src/hooks/verify_cmd.rs
+++ b/src/hooks/verify_cmd.rs
@@ -3,12 +3,15 @@
 use anyhow::Result;
 
 use crate::core::toml_filter;
+use crate::core::utils;
 
 /// Run TOML filter inline tests.
 ///
 /// - `filter`: if `Some`, only run tests for that filter name
 /// - `require_all`: fail if any filter has no inline tests
 pub fn run(filter: Option<String>, require_all: bool) -> Result<()> {
+    check_environment();
+
     let results = toml_filter::run_filter_tests(filter.as_deref());
 
     let total = results.outcomes.len();
@@ -46,4 +49,25 @@ pub fn run(filter: Option<String>, require_all: bool) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Print a one-line environment summary. On Windows, reports whether the
+/// UNIX-style commands rtk's filters rely on are available (provided by
+/// Microsoft Coreutils) and how to install them if not. No-op elsewhere, since
+/// these tools are part of the base system on Linux/macOS.
+fn check_environment() {
+    if cfg!(windows) {
+        let missing = utils::missing_coreutils();
+        if missing.is_empty() {
+            println!(
+                "coreutils: ok ({} commands on PATH)",
+                utils::COREUTILS_TOOLS.len()
+            );
+        } else {
+            println!(
+                "coreutils: missing {} — some filters (ls, wc, grep, …) will fall back to raw output.\n  Install with: winget install Microsoft.Coreutils",
+                missing.join(", ")
+            );
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1194,15 +1194,13 @@ fn run_fallback(parse_error: clap::Error) -> Result<i32> {
         // TOML match: capture stdout for filtering
         let result = if filter.filter_stderr {
             // Merge stderr into stdout so the filter can strip banners emitted by tools like liquibase
-            core::utils::resolved_command(&args[0])
-                .args(&args[1..])
+            core::utils::passthrough_command(&args[0], &args[1..])
                 .stdin(std::process::Stdio::inherit())
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped()) // captured for merging
                 .output()
         } else {
-            core::utils::resolved_command(&args[0])
-                .args(&args[1..])
+            core::utils::passthrough_command(&args[0], &args[1..])
                 .stdin(std::process::Stdio::inherit())
                 .stdout(std::process::Stdio::piped()) // capture
                 .stderr(std::process::Stdio::inherit()) // stderr always direct
@@ -1254,8 +1252,7 @@ fn run_fallback(parse_error: clap::Error) -> Result<i32> {
         }
     } else {
         // No TOML match: original passthrough behaviour (Stdio::inherit, streaming)
-        let status = core::utils::resolved_command(&args[0])
-            .args(&args[1..])
+        let status = core::utils::passthrough_command(&args[0], &args[1..])
             .stdin(std::process::Stdio::inherit())
             .stdout(std::process::Stdio::inherit())
             .stderr(std::process::Stdio::inherit())


### PR DESCRIPTION
This pull request significantly improves RTK's native Windows support, especially around UNIX-style command filters, and enhances cross-platform behavior and documentation. The most important changes include updating documentation to clarify full Windows support (no WSL required), introducing detection and user guidance for missing Coreutils tools on Windows, and refactoring platform-specific paths and logic for better portability and testability. Several tests and code paths were updated to ensure robust cross-platform operation.

**Windows Support and Documentation:**

* Updated `README.md` to clarify that RTK is fully supported on native Windows (no WSL required), and added guidance to install Microsoft Coreutils for full filter functionality. The documentation now includes improved setup instructions and a feature comparison table across Windows, WSL, and Linux/macOS. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L91-R91) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L319-R354)

**Coreutils Tool Detection and User Guidance:**

* Added a `COREUTILS_TOOLS` constant and a `missing_coreutils` function in `src/core/utils.rs` to detect missing UNIX-style tools (like `ls`, `grep`, etc.) on PATH. On Windows, commands now print a one-line hint to install Microsoft Coreutils if any tools are missing. [[1]](diffhunk://#diff-ea5415f92a3ac8407c3511fcead2ef0e412db262b85672110d830ead44d27f03R365-R382) [[2]](diffhunk://#diff-ea5415f92a3ac8407c3511fcead2ef0e412db262b85672110d830ead44d27f03R428-R440) [[3]](diffhunk://#diff-1626295723a7a0874c0b715fd7717c4ab0e8790756238e2792e7adcbc4b93fbcR1198-R1224) [[4]](diffhunk://#diff-7f541836b30677974dd6007748e0721816b01902391d390b8962fd2d5374eaf5R6-R14) [[5]](diffhunk://#diff-7f541836b30677974dd6007748e0721816b01902391d390b8962fd2d5374eaf5R53-R73)

**Cross-Platform Path Handling and Environment Logic:**

* Refactored all uses of hardcoded Unix paths to use platform-aware APIs (`dirs::data_local_dir`, `std::env::temp_dir`) for log and telemetry file locations, ensuring correct behavior on Windows and other platforms. [[1]](diffhunk://#diff-5c7db861e23c248d8123d1a3a2a9b43c1afe6faeb28e204c6e813f4794ca6e13R3-R23) [[2]](diffhunk://#diff-5c7db861e23c248d8123d1a3a2a9b43c1afe6faeb28e204c6e813f4794ca6e13R211-R228) [[3]](diffhunk://#diff-b0407fd4aff737f7f3a327b6ab2ad04991cf22fb1cb5d9e64039082bc025ea90L210-R210) [[4]](diffhunk://#diff-b0407fd4aff737f7f3a327b6ab2ad04991cf22fb1cb5d9e64039082bc025ea90L439-R439)
* Updated PATH variable splitting in `env_cmd.rs` to use `env::split_paths` for platform-aware handling, and added corresponding unit tests. [[1]](diffhunk://#diff-3c1dc7539078d888e173a10bb879ebd2411f4efdb7b2d37ce876d761fd6b48f2L72-R78) [[2]](diffhunk://#diff-3c1dc7539078d888e173a10bb879ebd2411f4efdb7b2d37ce876d761fd6b48f2R219-R231)

**Testing Improvements:**

* Added or updated tests to ensure platform-specific logic is correct, including tests for path splitting, coreutils detection, and log path resolution. Some streaming and exec tests are now gated to run only on non-Windows platforms where appropriate. [[1]](diffhunk://#diff-3c1dc7539078d888e173a10bb879ebd2411f4efdb7b2d37ce876d761fd6b48f2R219-R231) [[2]](diffhunk://#diff-51ae460d85a5f10365c04383574e609eb5ab3a9c7c0bf41daa99099ca9817bb5R661-R665) [[3]](diffhunk://#diff-51ae460d85a5f10365c04383574e609eb5ab3a9c7c0bf41daa99099ca9817bb5R728-R731) [[4]](diffhunk://#diff-51ae460d85a5f10365c04383574e609eb5ab3a9c7c0bf41daa99099ca9817bb5R750-R753) [[5]](diffhunk://#diff-51ae460d85a5f10365c04383574e609eb5ab3a9c7c0bf41daa99099ca9817bb5R818-R831) [[6]](diffhunk://#diff-5c7db861e23c248d8123d1a3a2a9b43c1afe6faeb28e204c6e813f4794ca6e13R211-R228) [[7]](diffhunk://#diff-ea5415f92a3ac8407c3511fcead2ef0e412db262b85672110d830ead44d27f03R428-R440)

These changes collectively make RTK's Windows experience first-class, improve user onboarding, and ensure robust cross-platform operation.