### PR TITLE
refactor(hook): slim agent awareness for hooked agents

### DIFF
--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -188,6 +188,14 @@ Support is blocked on upstream `BeforeToolCallback` ([mistral-vibe#531](https://
 
 Rules file integrations (Cline, Windsurf, Codex, Kilo Code, Antigravity) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it. Plugin integrations (OpenCode, Pi) use in-place mutation via the agent's TypeScript extension API.
 
+## What RTK tells the agent
+
+For **full hook** and **plugin** integrations the rewrite is automatic, so RTK injects only a one-paragraph awareness note (e.g. `~/.claude/RTK.md`, `.github/copilot-instructions.md`): rtk is running, output is filtered to save tokens, and `rtk proxy <cmd>` returns the raw output if a filter ever drops something the agent needs. These agents are never told to type `rtk` themselves — that would be redundant.
+
+**Rules file** integrations have no hook, so their files keep the explicit "prefix commands with `rtk`" guidance — the model is the only thing that can apply it.
+
+`rtk init` (project-local, no `-g`) mirrors this: if a usable Claude hook is already installed it writes the slim note plus an `@RTK.md` reference; otherwise it falls back to the full prefix instructions. `rtk init --claude-md` always writes the full instructions (the no-hook / Windows fallback).
+
 ## Windows support
 
 The shell hook (`rtk-rewrite.sh`) requires a Unix shell. On native Windows:

--- a/hooks/claude/rtk-awareness.md
+++ b/hooks/claude/rtk-awareness.md
@@ -1,29 +1,3 @@
 # RTK - Rust Token Killer
 
-**Usage**: Token-optimized CLI proxy (60-90% savings on dev operations)
-
-## Meta Commands (always use rtk directly)
-
-```bash
-rtk gain              # Show token savings analytics
-rtk gain --history    # Show command usage history with savings
-rtk discover          # Analyze Claude Code history for missed opportunities
-rtk proxy <cmd>       # Execute raw command without filtering (for debugging)
-```
-
-## Installation Verification
-
-```bash
-rtk --version         # Should show: rtk X.Y.Z
-rtk gain              # Should work (not "command not found")
-which rtk             # Verify correct binary
-```
-
-⚠️ **Name collision**: If `rtk gain` fails, you may have reachingforthejack/rtk (Rust Type Kit) installed instead.
-
-## Hook-Based Usage
-
-All other commands are automatically rewritten by the Claude Code hook.
-Example: `git status` → `rtk git status` (transparent, 0 tokens overhead)
-
-Refer to CLAUDE.md for full command reference.
+**rtk is running.** It transparently rewrites your shell commands to a token-optimized `rtk` equivalent before they execute and compresses their output to save tokens — this is automatic and you don't need to add `rtk` yourself. If a command's output ever looks wrong, truncated, or is missing information you need, re-run it with `rtk proxy <cmd>` to bypass the filtering and get the raw, unfiltered output.

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -1091,6 +1091,21 @@ fn insert_hook_entry(root: &mut serde_json::Value, hook_command: &str) -> Result
     Ok(())
 }
 
+/// True when a usable rewrite hook is already registered, so a caller can
+/// pick the slim awareness note over the verbose prefix instructions.
+fn claude_hook_usable() -> bool {
+    let Ok(claude_dir) = resolve_claude_dir() else {
+        return false;
+    };
+    let Ok(content) = fs::read_to_string(claude_dir.join(SETTINGS_JSON)) else {
+        return false;
+    };
+    let Ok(root) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return false;
+    };
+    hook_already_present(&root, CLAUDE_HOOK_COMMAND)
+}
+
 /// Check if RTK hook is already present in settings.json
 /// Matches on legacy rtk-rewrite.sh path OR new `rtk hook claude` command
 fn hook_already_present(root: &serde_json::Value, hook_command: &str) -> bool {
@@ -1122,8 +1137,27 @@ fn run_default_mode(
 ) -> Result<()> {
     let InitContext { dry_run, .. } = ctx;
     if !global {
-        // Local init: inject CLAUDE.md + generate project-local filters template
-        run_claude_md_mode(false, install_opencode, ctx)?;
+        // Without a hook to rewrite for it, the agent must prefix itself, so
+        // fall back to the verbose instructions. `--claude-md` forces them too.
+        if claude_hook_usable() {
+            let rtk_md_path = PathBuf::from(RTK_MD);
+            let claude_md_path = PathBuf::from(CLAUDE_MD);
+
+            write_if_changed(&rtk_md_path, RTK_SLIM, RTK_MD, ctx)?;
+            let migrated = patch_claude_md(&claude_md_path, ctx)?;
+
+            if !dry_run {
+                println!("\nRTK configured (project-local).\n");
+                println!("  RTK.md:    {}", rtk_md_path.display());
+                println!("  CLAUDE.md: @RTK.md reference added");
+                if migrated {
+                    println!("\n  [ok] Migrated: removed 137-line RTK block from CLAUDE.md");
+                    println!("              replaced with @RTK.md");
+                }
+            }
+        } else {
+            run_claude_md_mode(false, install_opencode, ctx)?;
+        }
         generate_project_filters_template(ctx)?;
         return Ok(());
     }
@@ -3880,31 +3914,9 @@ const COPILOT_HOOK_JSON: &str = r#"{
 "#;
 
 const COPILOT_INSTRUCTIONS: &str = r#"<!-- rtk-instructions v2 -->
-# RTK — Token-Optimized CLI
+# RTK — Rust Token Killer
 
-**rtk** is a CLI proxy that filters and compresses command outputs, saving 60-90% tokens.
-
-## Rule
-
-Always prefix shell commands with `rtk`:
-
-```bash
-# Instead of:              Use:
-git status                 rtk git status
-git log -10                rtk git log -10
-cargo test                 rtk cargo test
-docker ps                  rtk docker ps
-kubectl get pods           rtk kubectl pods
-```
-
-## Meta commands (use directly)
-
-```bash
-rtk gain              # Token savings dashboard
-rtk gain --history    # Per-command savings history
-rtk discover          # Find missed rtk opportunities
-rtk proxy <cmd>       # Run raw (no filtering) but track usage
-```
+**rtk is running.** It transparently rewrites your shell commands to a token-optimized `rtk` equivalent before they execute and compresses their output to save tokens — this is automatic and you don't need to add `rtk` yourself. If a command's output ever looks wrong, truncated, or is missing information you need, re-run it with `rtk proxy <cmd>` to bypass the filtering and get the raw, unfiltered output.
 <!-- /rtk-instructions -->
 "#;
 
@@ -5917,23 +5929,63 @@ mod tests {
     }
 
     #[test]
-    fn test_local_init_no_hook() {
+    fn test_local_init_no_hook_keeps_verbose() {
         let tmp = TempDir::new().unwrap();
         let _cwd_guard = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let cwd = std::env::current_dir().unwrap();
         std::env::set_current_dir(tmp.path()).unwrap();
 
-        let result = run_default_mode(false, PatchMode::Auto, false, InitContext::default());
+        // Empty claude dir => no usable hook.
+        with_claude_dir_override(&tmp, |_| {
+            run_default_mode(false, PatchMode::Auto, false, InitContext::default()).unwrap();
+        });
         std::env::set_current_dir(&cwd).unwrap();
 
-        result.unwrap();
+        let claude_md = fs::read_to_string(tmp.path().join(CLAUDE_MD)).unwrap();
         assert!(
-            tmp.path().join(CLAUDE_MD).exists(),
-            "local CLAUDE.md must be created"
+            claude_md.contains(RTK_BLOCK_START),
+            "no usable hook => verbose rewrite context must be kept"
+        );
+        assert!(
+            !tmp.path().join(RTK_MD).exists(),
+            "verbose mode must not write the slim RTK.md"
         );
         assert!(
             !tmp.path().join(SETTINGS_JSON).exists(),
             "settings.json must not be created for local init"
+        );
+    }
+
+    #[test]
+    fn test_local_init_with_hook_is_slim() {
+        let tmp = TempDir::new().unwrap();
+        let _cwd_guard = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        with_claude_dir_override(&tmp, |claude_dir| {
+            let settings = format!(
+                r#"{{"hooks":{{"PreToolUse":[{{"hooks":[{{"type":"command","command":"{}"}}]}}]}}}}"#,
+                CLAUDE_HOOK_COMMAND
+            );
+            fs::write(claude_dir.join(SETTINGS_JSON), settings).unwrap();
+
+            run_default_mode(false, PatchMode::Auto, false, InitContext::default()).unwrap();
+        });
+        std::env::set_current_dir(&cwd).unwrap();
+
+        assert!(
+            tmp.path().join(RTK_MD).exists(),
+            "usable hook => slim RTK.md must be written"
+        );
+        let claude_md = fs::read_to_string(tmp.path().join(CLAUDE_MD)).unwrap();
+        assert!(
+            claude_md.contains(RTK_MD_REF),
+            "@RTK.md reference must be added"
+        );
+        assert!(
+            !claude_md.contains(RTK_BLOCK_START),
+            "usable hook => no verbose block in CLAUDE.md"
         );
     }
 
@@ -6479,7 +6531,7 @@ mod tests {
             "Stale RTK block content must be removed"
         );
         assert!(
-            updated.contains("rtk cargo test"),
+            updated.contains("rtk proxy <cmd>"),
             "Fresh COPILOT_INSTRUCTIONS content must be present"
         );
     }
@@ -6517,7 +6569,7 @@ mod tests {
         let content = fs::read_to_string(&instructions_path).unwrap();
         assert!(content.contains(RTK_BLOCK_START));
         assert!(content.contains(RTK_BLOCK_END));
-        assert!(content.contains("rtk cargo test"));
+        assert!(content.contains("rtk proxy <cmd>"));
     }
 
     #[test]
@@ -6695,7 +6747,7 @@ mod tests {
         );
         let content = fs::read_to_string(&instructions).unwrap();
         assert!(content.contains(RTK_BLOCK_START));
-        assert!(content.contains("rtk cargo test"));
+        assert!(content.contains("rtk proxy <cmd>"));
     }
 
     #[test]


### PR DESCRIPTION
## Why

Stop polluting the LLM context with rtk instructions. When a hook already rewrites commands transparently, telling the agent to "always prefix with `rtk`" is redundant noise.

## What

Hooked/plugin agents now get a one-paragraph *"rtk is running + `rtk proxy` to bypass"* note instead of the verbose "always prefix" block:

- **Claude** (`RTK.md`), **Gemini** (`GEMINI.md`) — shared `RTK_SLIM`, now agent-neutral (previously named the "Claude Code hook" even inside `GEMINI.md`).
- **Copilot** (`copilot-instructions.md`) — both VS Code Chat and Copilot CLI share this file, so both hosts are now slim. The `<!-- rtk-instructions -->` markers are kept so uninstall still strips the block.
- **Local `rtk init`** mirrors global only when a usable hook is present (new `claude_hook_usable()`); with no usable hook it keeps the verbose instructions so the model still knows to prefix. `rtk init --claude-md` unchanged.
- **Rules-file agents** (Cline, Windsurf, Codex, Kilo Code, Antigravity) — unchanged; no hook, so they keep the prefix guidance.

Docs: `supported-agents.md` now explains what each integration tier receives.

> **Long term** this awareness note should be removed entirely: once hooks are fully reliable, rtk stays invisible and the context carries zero rtk text.

## Tests

- New: `test_local_init_no_hook_keeps_verbose`, `test_local_init_with_hook_is_slim`.
- Updated 3 Copilot assertions to the new slim marker (`rtk proxy <cmd>`).
- `cargo fmt --all --check && cargo clippy --all-targets && cargo test` — green (2146 passed, 8 ignored) on this branch base.

## Verify with real usage of hosts before merge

- [ ] Gemini CLI: bash-wrapper hook actually rewrites (no fallback if bash absent)
- [ ] Copilot VS Code Chat: hook fires with slim `copilot-instructions.md`
- [ ] Copilot CLI: hook fires with slim `copilot-instructions.md`