### PR TITLE
feat(discover): count hook-rewritten commands as captured, not missed

### DIFF
--- a/src/discover/mod.rs
+++ b/src/discover/mod.rs
@@ -72,8 +72,15 @@ pub fn run(
         }
     }
 
+    // Commands the Claude Code hook already rewrote to rtk at execution time.
+    // Transcripts record the model-authored command (pre-rewrite), so without
+    // this cross-reference every hook-captured command would be reported as
+    // a missed saving.
+    let hook_rewritten = crate::hooks::hook_audit_cmd::load_rewritten_originals(since_days);
+
     let mut total_commands: usize = 0;
     let mut already_rtk: usize = 0;
+    let mut hook_captured: usize = 0;
     let mut parse_errors: usize = 0;
     let mut rtk_disabled_count: usize = 0;
     let mut rtk_disabled_cmds: HashMap<String, usize> = HashMap::new();
@@ -94,6 +101,14 @@ pub fn run(
 
         for ext_cmd in &extracted {
             let parts = split_command_chain(&ext_cmd.command);
+
+            // Already captured by the hook at execution time — not a missed saving.
+            if !hook_rewritten.is_empty() && hook_rewritten.contains(ext_cmd.command.trim()) {
+                total_commands += parts.len();
+                hook_captured += parts.len();
+                continue;
+            }
+
             for part in parts {
                 total_commands += 1;
 
@@ -257,6 +272,7 @@ pub fn run(
         sessions_scanned: sessions.len(),
         total_commands,
         already_rtk,
+        hook_captured,
         since_days,
         supported,
         unsupported,

--- a/src/discover/report.rs
+++ b/src/discover/report.rs
@@ -98,6 +98,9 @@ pub struct DiscoverReport {
     pub sessions_scanned: usize,
     pub total_commands: usize,
     pub already_rtk: usize,
+    /// Commands already rewritten to rtk by the agent hook at execution time
+    /// (cross-referenced from the hook audit log; 0 when auditing is disabled).
+    pub hook_captured: usize,
     pub since_days: u64,
     pub supported: Vec<SupportedEntry>,
     pub unsupported: Vec<UnsupportedEntry>,
@@ -140,6 +143,17 @@ pub fn format_text(report: &DiscoverReport, limit: usize, verbose: bool) -> Stri
             0.0
         }
     ));
+    if report.hook_captured > 0 {
+        out.push_str(&format!(
+            "Captured by hook rewrite: {} commands ({:.1}%)\n",
+            report.hook_captured,
+            if report.total_commands > 0 {
+                report.hook_captured as f64 * 100.0 / report.total_commands as f64
+            } else {
+                0.0
+            }
+        ));
+    }
 
     if report.supported.is_empty() && report.unsupported.is_empty() {
         out.push_str("\nNo missed savings found. RTK usage looks good!\n");
@@ -279,6 +293,7 @@ mod tests {
             sessions_scanned: 1,
             total_commands,
             already_rtk,
+            hook_captured: 0,
             since_days: 30,
             supported: vec![],
             unsupported: vec![],
@@ -291,6 +306,21 @@ mod tests {
 
     // B6 regression: integer division truncated small percentages to 0%.
     // Example: 3/1000 = 0% (old bug), should be "0.3%".
+    #[test]
+    fn test_hook_captured_line_rendered_when_nonzero() {
+        let mut report = make_report(1000, 3);
+        report.hook_captured = 500;
+        let output = format_text(&report, 10, false);
+        assert!(output.contains("Captured by hook rewrite: 500 commands (50.0%)"));
+    }
+
+    #[test]
+    fn test_hook_captured_line_hidden_when_zero() {
+        let report = make_report(1000, 3);
+        let output = format_text(&report, 10, false);
+        assert!(!output.contains("Captured by hook rewrite"));
+    }
+
     #[test]
     fn test_already_rtk_percent_shows_decimal() {
         let report = make_report(1000, 3);

--- a/src/hooks/hook_audit_cmd.rs
+++ b/src/hooks/hook_audit_cmd.rs
@@ -68,6 +68,78 @@ fn filter_since_days(entries: &[AuditEntry], days: u64) -> Vec<&AuditEntry> {
         .collect()
 }
 
+/// Reverse of `sanitize_log_field` in hook_cmd.rs: restore `\\`, `\|`, `\n`, `\r`.
+fn unescape_log_field(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            match chars.next() {
+                Some('\\') => out.push('\\'),
+                Some('|') => out.push('|'),
+                Some('n') => out.push('\n'),
+                Some('r') => out.push('\r'),
+                Some(other) => {
+                    out.push('\\');
+                    out.push(other);
+                }
+                None => out.push('\\'),
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Load the set of original commands the hook rewrote within the last N days
+/// (0 = no time filter). Best-effort: any read/parse failure yields an empty
+/// set so callers (e.g. `rtk discover`) never fail because of the audit log.
+pub fn load_rewritten_originals(since_days: u64) -> std::collections::HashSet<String> {
+    load_rewritten_originals_from(&default_log_path(), since_days)
+}
+
+fn load_rewritten_originals_from(
+    path: &std::path::Path,
+    since_days: u64,
+) -> std::collections::HashSet<String> {
+    let mut set = std::collections::HashSet::new();
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return set;
+    };
+
+    // Log timestamps are local time without timezone suffix (see audit_log_inner).
+    let cutoff = if since_days > 0 {
+        Some(
+            (chrono::Local::now() - chrono::Duration::days(since_days as i64))
+                .format("%Y-%m-%dT%H:%M:%S")
+                .to_string(),
+        )
+    } else {
+        None
+    };
+
+    for line in content.lines() {
+        let Some(entry) = parse_line(line) else {
+            continue;
+        };
+        if entry.action != "rewrite" {
+            continue;
+        }
+        if let Some(ref cutoff) = cutoff {
+            if entry.timestamp.as_str() < cutoff.as_str() {
+                continue;
+            }
+        }
+        set.insert(
+            unescape_log_field(entry.original_cmd.trim())
+                .trim()
+                .to_string(),
+        );
+    }
+    set
+}
+
 pub fn run(since_days: u64, verbose: u8) -> Result<()> {
     let log_path = default_log_path();
 
@@ -177,6 +249,71 @@ pub fn run(since_days: u64, verbose: u8) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_unescape_log_field_roundtrip() {
+        // Mirrors sanitize_log_field in hook_cmd.rs
+        assert_eq!(unescape_log_field(r"git log \| head"), "git log | head");
+        assert_eq!(unescape_log_field(r"echo a\nb"), "echo a\nb");
+        assert_eq!(unescape_log_field(r"path\\to"), r"path\to");
+        assert_eq!(unescape_log_field("plain"), "plain");
+    }
+
+    #[test]
+    fn test_load_rewritten_originals_filters_action_and_unescapes() {
+        let tmp = std::env::temp_dir().join(format!("rtk-audit-test-{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let log = tmp.join("hook-audit.log");
+        std::fs::write(
+            &log,
+            "2026-06-01T10:00:00 | rewrite | git add . | rtk git add .\n\
+             2026-06-01T10:00:01 | skip:no_match | htop | -\n\
+             2026-06-01T10:00:02 | rewrite | grep -n foo \\| head -5 | rtk grep -n foo \\| head -5\n\
+             malformed line\n\
+             2026-06-01T10:00:03 | skip:defer | cd /tmp | -\n",
+        )
+        .unwrap();
+
+        let set = load_rewritten_originals_from(&log, 0);
+        assert_eq!(set.len(), 2);
+        assert!(set.contains("git add ."));
+        assert!(set.contains("grep -n foo | head -5"));
+        assert!(!set.contains("htop"));
+        assert!(!set.contains("cd /tmp"));
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn test_load_rewritten_originals_since_days_cutoff() {
+        let tmp = std::env::temp_dir().join(format!("rtk-audit-cutoff-{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let log = tmp.join("hook-audit.log");
+        let recent = chrono::Local::now().format("%Y-%m-%dT%H:%M:%S");
+        std::fs::write(
+            &log,
+            format!(
+                "2001-01-01T00:00:00 | rewrite | git old | rtk git old\n\
+                 {recent} | rewrite | git new | rtk git new\n"
+            ),
+        )
+        .unwrap();
+
+        let set = load_rewritten_originals_from(&log, 30);
+        assert!(set.contains("git new"));
+        assert!(!set.contains("git old"));
+
+        let all = load_rewritten_originals_from(&log, 0);
+        assert_eq!(all.len(), 2);
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn test_load_rewritten_originals_missing_file_is_empty() {
+        let set = load_rewritten_originals_from(std::path::Path::new("/nonexistent/audit.log"), 30);
+        assert!(set.is_empty());
+    }
 
     #[test]
     fn test_parse_line_rewrite() {


### PR DESCRIPTION
## Problem

`rtk discover` scans the model-authored `tool_use` commands in Claude Code transcripts. When the PreToolUse hook rewrites a command via `updatedInput` (e.g. `git add .` → `rtk git add .`), the transcript still records the original command — the rewrite happens after the model authors it. As a result, every hook-captured command is reported as a *missed* saving, and `Already using RTK` only counts commands the model literally typed with an `rtk ` prefix.

On a host with the hook active this makes the report wildly misleading. Real example: discover claimed **0.2% adoption and ~5.4M tokens missed**, while `rtk gain` showed **131M tokens already saved (63.6%)** and the hook audit log showed 21,775 rewrites in the same window.

## Fix

Cross-reference the hook audit log (`hook-audit.log`, written by `rtk hook` when `RTK_HOOK_AUDIT=1`):

- New `hook_audit_cmd::load_rewritten_originals(since_days)` builds a set of original commands with action `rewrite`, unescaping the pipe-delimited log fields (reverse of `sanitize_log_field`). Best-effort: any read/parse failure returns an empty set, so discover never fails because of the audit log, and behavior is unchanged when auditing is disabled.
- `discover::run` classifies a transcript command found in that set as **hook-captured** instead of feeding it into the missed-savings buckets.
- The report gains a `hook_captured` field and a `Captured by hook rewrite: N commands (X%)` line (only rendered when non-zero, so existing output is unchanged for users without audit logs).

After the fix on the same host: `Captured by hook rewrite: 46,251 commands (35.0%)`, and the missed-savings list shrinks to commands the hook genuinely skipped (`skip:no_match`/`skip:defer`) or that predate audit logging.

## Tests

- `unescape_log_field` round-trip vs `sanitize_log_field`
- loader: action filtering, escaped-pipe originals, malformed lines, `since_days` cutoff, missing file → empty set
- report: line rendered when non-zero, hidden when zero

`cargo fmt --all && cargo clippy --all-targets && cargo test --all` clean (the 3 `unattestable_passthrough` failures on my host are a pre-existing environment-isolation issue — those tests read the live `~/.claude/settings.json` permission lists and fail on any host with allow/deny rules configured; they pass with a clean `$HOME`. Happy to file separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)