### PR TITLE
feat: add CodeBuddy hook integration

### DIFF
--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -39,3 +39,9 @@ pub const HERMES_PLUGINS_SUBDIR: &str = "plugins";
 pub const HERMES_PLUGIN_NAME: &str = "rtk-rewrite";
 pub const HERMES_PLUGIN_INIT_FILE: &str = "__init__.py";
 pub const HERMES_PLUGIN_MANIFEST_FILE: &str = "plugin.yaml";
+
+pub const CODEBUDDY_DIR: &str = ".codebuddy";
+/// Native Rust hook command for CodeBuddy.
+pub const CODEBUDDY_HOOK_COMMAND: &str = "rtk hook codebuddy";
+/// CodeBuddy matcher: catches both CLI mode (Bash) and IDE mode (execute_command).
+pub const CODEBUDDY_MATCHER: &str = "Bash|execute_command";

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -429,10 +429,150 @@ pub fn run_claude() -> Result<()> {
     Ok(())
 }
 
+// ── CodeBuddy native hook ───────────────────────────────────────
+//
+// CodeBuddy (Tencent Cloud AI code editor) uses a hook protocol fully
+// compatible with Claude Code's specification, with three differences
+// in the output JSON:
+//   1. Requires top-level `"continue": true`
+//   2. Requires `"permissionDecision": "allow"` for rewrites to apply
+//   3. Reads `"modifiedInput"` (Claude Code reads `"updatedInput"`)
+//
+// We emit BOTH `updatedInput` and `modifiedInput` so the same hook
+// output works with Claude Code and CodeBuddy.
+
+fn process_codebuddy_payload(v: &Value) -> PayloadAction {
+    // CodeBuddy IDE uses "execute_command" as tool_name; CLI mode uses "Bash".
+    // Also accept standard Claude Code tool_name values.
+    let tool_name = v.get("tool_name").and_then(|t| t.as_str()).unwrap_or("");
+
+    if !matches!(
+        tool_name,
+        "Bash" | "execute_command" | "bash" | "runTerminalCommand"
+    ) {
+        return PayloadAction::Ignore;
+    }
+
+    let cmd = match v
+        .pointer("/tool_input/command")
+        .and_then(|c| c.as_str())
+        .filter(|c| !c.is_empty())
+    {
+        Some(c) => c,
+        None => return PayloadAction::Ignore,
+    };
+
+    let (rewritten, _allow) = match decide_hook_action(cmd, permissions::Host::Claude) {
+        HookDecision::Deny => {
+            return PayloadAction::Skip {
+                reason: "skip:deny_rule",
+                cmd: cmd.to_string(),
+            }
+        }
+        HookDecision::Defer => {
+            return PayloadAction::Skip {
+                reason: "skip:defer",
+                cmd: cmd.to_string(),
+            }
+        }
+        HookDecision::AllowRewrite(r) => r,
+        HookDecision::AskRewrite(r) => r, // CodeBuddy always applies the rewrite
+    };
+
+    let updated_input = {
+        let mut ti = v.get("tool_input").cloned().unwrap_or_else(|| json!({}));
+        if let Some(obj) = ti.as_object_mut() {
+            obj.insert("command".into(), Value::String(rewritten.clone()));
+        }
+        ti
+    };
+
+    // Build the hookSpecificOutput with both updatedInput (Claude Code)
+    // and modifiedInput (CodeBuddy) so either agent can read the rewrite.
+    let mut hook_output = json!({
+        "hookEventName": PRE_TOOL_USE_KEY,
+        "permissionDecisionReason": "RTK auto-rewrite",
+        "updatedInput": updated_input.clone(),
+        "modifiedInput": updated_input,
+    });
+
+    // CodeBuddy requires permissionDecision: "allow" for the rewrite to apply.
+    hook_output
+        .as_object_mut()
+        .unwrap()
+        .insert("permissionDecision".into(), json!("allow"));
+
+    // Wrap in the top-level `continue: true` that CodeBuddy requires.
+    let mut output = json!({
+        "continue": true,
+        "hookSpecificOutput": hook_output,
+    });
+
+    // Also set top-level permissionDecision for CodeBuddy compatibility.
+    output
+        .as_object_mut()
+        .unwrap()
+        .insert("permissionDecision".into(), json!("allow"));
+
+    PayloadAction::Rewrite {
+        cmd: cmd.to_string(),
+        rewritten,
+        output,
+    }
+}
+
+/// Run the CodeBuddy PreToolUse hook.
+///
+/// Reads JSON from stdin (same protocol as Claude Code), rewrites shell
+/// commands through RTK, and emits a dual-format response that works with
+/// both Claude Code (`updatedInput`) and CodeBuddy (`modifiedInput`).
+pub fn run_codebuddy() -> Result<()> {
+    let input = read_stdin_limited()?;
+
+    let input = strip_leading_bom(&input).trim();
+    if input.is_empty() {
+        return Ok(());
+    }
+
+    let v: Value = match serde_json::from_str(input) {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = writeln!(io::stderr(), "[rtk hook] Failed to parse JSON input: {e}");
+            return Ok(());
+        }
+    };
+
+    match process_codebuddy_payload(&v) {
+        PayloadAction::Rewrite {
+            cmd,
+            rewritten,
+            output,
+        } => {
+            audit_log("rewrite", &cmd, &rewritten);
+            let _ = writeln!(io::stdout(), "{output}");
+        }
+        PayloadAction::Skip { reason, cmd } => {
+            audit_log(reason, &cmd, "");
+        }
+        PayloadAction::Ignore => {}
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 fn run_claude_inner(input: &str) -> Option<String> {
     let v: Value = serde_json::from_str(input).ok()?;
     match process_claude_payload(&v) {
+        PayloadAction::Rewrite { output, .. } => Some(output.to_string()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+fn run_codebuddy_inner(input: &str) -> Option<String> {
+    let v: Value = serde_json::from_str(input).ok()?;
+    match process_codebuddy_payload(&v) {
         PayloadAction::Rewrite { output, .. } => Some(output.to_string()),
         _ => None,
     }
@@ -1390,5 +1530,139 @@ mod tests {
         ))
         .unwrap();
         assert_eq!(v["decision"], "deny");
+    }
+
+    // --- CodeBuddy handler ---
+
+    fn codebuddy_input(tool: &str, cmd: &str) -> String {
+        json!({
+            "tool_name": tool,
+            "tool_input": { "command": cmd }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn test_codebuddy_rewrite_git_status() {
+        let result = run_codebuddy_inner(&codebuddy_input("Bash", "git status")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+
+        // Top-level continue
+        assert_eq!(v["continue"], true);
+        // Top-level permissionDecision
+        assert_eq!(v["permissionDecision"], "allow");
+        // hookSpecificOutput
+        let hook = &v["hookSpecificOutput"];
+        assert_eq!(hook["hookEventName"], PRE_TOOL_USE_KEY);
+        assert_eq!(hook["permissionDecision"], "allow");
+        assert_eq!(hook["permissionDecisionReason"], "RTK auto-rewrite");
+        // Both updatedInput and modifiedInput present with rewritten command
+        assert_eq!(hook["updatedInput"]["command"], "rtk git status");
+        assert_eq!(hook["modifiedInput"]["command"], "rtk git status");
+    }
+
+    #[test]
+    fn test_codebuddy_ide_tool_name() {
+        // CodeBuddy IDE mode uses "execute_command" as tool_name
+        let result =
+            run_codebuddy_inner(&codebuddy_input("execute_command", "git status")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(v["continue"], true);
+        assert_eq!(v["hookSpecificOutput"]["modifiedInput"]["command"], "rtk git status");
+    }
+
+    #[test]
+    fn test_codebuddy_passthrough_non_bash() {
+        // Non-shell tools should be ignored
+        assert!(run_codebuddy_inner(&codebuddy_input("Read", "some_file.rs")).is_none());
+        assert!(run_codebuddy_inner(&codebuddy_input("editFiles", "")).is_none());
+    }
+
+    #[test]
+    fn test_codebuddy_passthrough_unsupported() {
+        assert!(run_codebuddy_inner(&codebuddy_input("Bash", "htop")).is_none());
+    }
+
+    #[test]
+    fn test_codebuddy_passthrough_already_rtk() {
+        assert!(run_codebuddy_inner(&codebuddy_input("Bash", "rtk git status")).is_none());
+    }
+
+    #[test]
+    fn test_codebuddy_substitution_not_rewritten() {
+        assert!(run_codebuddy_inner(&codebuddy_input(
+            "Bash",
+            "git status `rm -rf /tmp/x`"
+        ))
+        .is_none());
+        assert!(run_codebuddy_inner(&codebuddy_input(
+            "Bash",
+            "git status $(rm -rf /tmp/x)"
+        ))
+        .is_none());
+    }
+
+    #[test]
+    fn test_codebuddy_heredoc_passthrough() {
+        assert!(run_codebuddy_inner(&codebuddy_input("Bash", "cat <<EOF\nhello\nEOF")).is_none());
+    }
+
+    #[test]
+    fn test_codebuddy_empty_command_passthrough() {
+        let input = json!({
+            "tool_name": "Bash",
+            "tool_input": { "command": "" }
+        })
+        .to_string();
+        assert!(run_codebuddy_inner(&input).is_none());
+    }
+
+    #[test]
+    fn test_codebuddy_malformed_json_passthrough() {
+        assert!(run_codebuddy_inner("not valid json {{{").is_none());
+    }
+
+    #[test]
+    fn test_codebuddy_env_prefix_preserved() {
+        let result =
+            run_codebuddy_inner(&codebuddy_input("Bash", "GIT_PAGER=cat git status")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(
+            v["hookSpecificOutput"]["modifiedInput"]["command"],
+            "GIT_PAGER=cat rtk git status"
+        );
+    }
+
+    #[test]
+    fn test_codebuddy_compound_command() {
+        let result = run_codebuddy_inner(&codebuddy_input("Bash", "git add . && cargo test"))
+            .unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(
+            v["hookSpecificOutput"]["modifiedInput"]["command"],
+            "rtk git add . && rtk cargo test"
+        );
+    }
+
+    #[test]
+    fn test_codebuddy_preserves_tool_input_fields() {
+        let input = json!({
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": "git status",
+                "timeout": 30000,
+                "description": "Check repo status"
+            }
+        })
+        .to_string();
+        let result = run_codebuddy_inner(&input).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let hook = &v["hookSpecificOutput"];
+        // Both updatedInput and modifiedInput should preserve extra fields
+        for key in ["updatedInput", "modifiedInput"] {
+            assert_eq!(hook[key]["command"], "rtk git status");
+            assert_eq!(hook[key]["timeout"], 30000);
+            assert_eq!(hook[key]["description"], "Check repo status");
+        }
     }
 }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -13,11 +13,12 @@ use crate::hooks::constants::{
 };
 
 use super::constants::{
-    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND,
-    GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_INIT_FILE,
-    HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON, HOOKS_SUBDIR,
-    PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR, PI_PLUGIN_FILE,
-    PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
+    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEBUDDY_DIR, CODEBUDDY_HOOK_COMMAND,
+    CODEBUDDY_MATCHER, CODEX_DIR, CURSOR_HOOK_COMMAND, GEMINI_HOOK_FILE, HERMES_DIR,
+    HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE,
+    HERMES_PLUGIN_NAME, HOOKS_JSON, HOOKS_SUBDIR, PI_CODING_AGENT_DIR_ENV, PI_DIR,
+    PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR, PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE,
+    SETTINGS_JSON,
 };
 use super::integrity;
 
@@ -2783,6 +2784,231 @@ fn codex_rtk_md_ref(codex_dir: &Path) -> String {
 
 fn resolve_opencode_dir() -> Result<PathBuf> {
     resolve_home_subdir(CONFIG_DIR).map(|p| p.join(OPENCODE_SUBDIR))
+}
+
+// ─── CodeBuddy support ─────────────────────────────────────────────
+
+/// Resolve CodeBuddy config directory (global: ~/.codebuddy).
+fn resolve_codebuddy_dir() -> Result<PathBuf> {
+    resolve_home_subdir(CODEBUDDY_DIR)
+}
+
+/// Run `rtk init --agent codebuddy`: patch `~/.codebuddy/settings.json`
+/// with the RTK PreToolUse hook entry.
+pub fn run_codebuddy_mode(ctx: InitContext) -> Result<()> {
+    let InitContext { dry_run, .. } = ctx;
+    let codebuddy_dir = resolve_codebuddy_dir()?;
+
+    if !dry_run {
+        fs::create_dir_all(&codebuddy_dir).with_context(|| {
+            format!(
+                "Failed to create CodeBuddy config directory: {}",
+                codebuddy_dir.display()
+            )
+        })?;
+    }
+
+    let settings_path = codebuddy_dir.join(SETTINGS_JSON);
+    let patched = patch_codebuddy_settings_json(&settings_path, ctx)?;
+
+    if dry_run {
+        print_dry_run_footer();
+    } else {
+        println!("\nRTK configured for CodeBuddy.\n");
+        println!("  Command:    {}", CODEBUDDY_HOOK_COMMAND);
+        println!("  Settings:   {}", settings_path.display());
+        if patched {
+            println!("  Settings:   RTK PreToolUse hook added");
+        } else {
+            println!("  Settings:   RTK PreToolUse hook already present");
+        }
+        println!(
+            "  Matcher:    {} (CLI + IDE modes)",
+            CODEBUDDY_MATCHER
+        );
+        println!("  Restart CodeBuddy. Test with: git status\n");
+    }
+
+    Ok(())
+}
+
+/// Patch `~/.codebuddy/settings.json` to add the RTK PreToolUse hook.
+/// Returns `true` if the file was modified.
+fn patch_codebuddy_settings_json(path: &Path, ctx: InitContext) -> Result<bool> {
+    let InitContext { verbose, dry_run } = ctx;
+
+    let mut root = if path.exists() {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+        if content.trim().is_empty() {
+            serde_json::json!({})
+        } else {
+            serde_json::from_str(&content)
+                .with_context(|| format!("Failed to parse {} as JSON", path.display()))?
+        }
+    } else {
+        serde_json::json!({})
+    };
+
+    // Check idempotency: skip if RTK hook is already present
+    if codebuddy_hook_already_present(&root) {
+        if verbose > 0 {
+            eprintln!("CodeBuddy settings.json: RTK hook already present");
+        }
+        return Ok(false);
+    }
+
+    insert_codebuddy_hook_entry(&mut root)?;
+
+    let serialized =
+        serde_json::to_string_pretty(&root).context("Failed to serialize settings.json")?;
+
+    if dry_run {
+        println!(
+            "[dry-run] would patch CodeBuddy settings.json: {}",
+            path.display()
+        );
+        if verbose > 0 {
+            println!("[dry-run] content:\n{}", serialized);
+        }
+        return Ok(true);
+    }
+
+    // Backup if exists
+    if path.exists() {
+        let backup_path = path.with_extension("json.bak");
+        fs::copy(path, &backup_path)
+            .with_context(|| format!("Failed to backup to {}", backup_path.display()))?;
+        if verbose > 0 {
+            eprintln!("Backup: {}", backup_path.display());
+        }
+    }
+
+    atomic_write(path, &serialized)?;
+    Ok(true)
+}
+
+/// Insert the RTK PreToolUse hook entry into CodeBuddy's settings.json.
+fn insert_codebuddy_hook_entry(root: &mut serde_json::Value) -> Result<()> {
+    let root_obj = match root.as_object_mut() {
+        Some(obj) => obj,
+        None => {
+            *root = serde_json::json!({});
+            root.as_object_mut().expect("just-created json object")
+        }
+    };
+
+    let hooks = root_obj
+        .entry("hooks")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .context("hooks value is not an object")?;
+
+    let pre_tool_use = hooks
+        .entry(PRE_TOOL_USE_KEY)
+        .or_insert_with(|| serde_json::json!([]))
+        .as_array_mut()
+        .context("PreToolUse value is not an array")?;
+
+    pre_tool_use.push(serde_json::json!({
+        "matcher": CODEBUDDY_MATCHER,
+        "hooks": [{
+            "type": "command",
+            "command": CODEBUDDY_HOOK_COMMAND
+        }]
+    }));
+    Ok(())
+}
+
+/// Check if the RTK CodeBuddy hook is already present in settings.json.
+fn codebuddy_hook_already_present(root: &serde_json::Value) -> bool {
+    let pre_tool_use_array = match root
+        .get("hooks")
+        .and_then(|h| h.get(PRE_TOOL_USE_KEY))
+        .and_then(|p| p.as_array())
+    {
+        Some(arr) => arr,
+        None => return false,
+    };
+
+    pre_tool_use_array
+        .iter()
+        .filter_map(|entry| entry.get("hooks")?.as_array())
+        .flatten()
+        .filter_map(|hook| hook.get("command")?.as_str())
+        .any(|cmd| cmd == CODEBUDDY_HOOK_COMMAND)
+}
+
+/// Uninstall RTK hook from CodeBuddy settings.json.
+pub fn uninstall_codebuddy(ctx: InitContext) -> Result<()> {
+    let InitContext { dry_run, verbose } = ctx;
+    let codebuddy_dir = resolve_codebuddy_dir()?;
+    let settings_path = codebuddy_dir.join(SETTINGS_JSON);
+
+    if !settings_path.exists() {
+        println!("CodeBuddy settings.json not found (nothing to remove)");
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(&settings_path)
+        .with_context(|| format!("Failed to read {}", settings_path.display()))?;
+    let mut root: serde_json::Value = serde_json::from_str(&content)
+        .with_context(|| format!("Failed to parse {}", settings_path.display()))?;
+
+    if !remove_codebuddy_hook_entries(&mut root) {
+        println!("RTK hook not found in CodeBuddy settings.json (nothing to remove)");
+        return Ok(());
+    }
+
+    let serialized =
+        serde_json::to_string_pretty(&root).context("Failed to serialize settings.json")?;
+
+    if dry_run {
+        println!(
+            "[dry-run] would remove RTK hook from CodeBuddy settings.json: {}",
+            settings_path.display()
+        );
+        if verbose > 0 {
+            println!("[dry-run] content:\n{}", serialized);
+        }
+        print_dry_run_footer();
+    } else {
+        // Backup
+        let backup_path = settings_path.with_extension("json.bak");
+        let _ = fs::copy(&settings_path, &backup_path);
+        atomic_write(&settings_path, &serialized)?;
+        println!("RTK hook removed from CodeBuddy settings.json");
+        println!("  Settings: {}", settings_path.display());
+    }
+
+    Ok(())
+}
+
+/// Remove RTK hook entries from CodeBuddy settings.json in-memory.
+/// Returns true if any entries were removed.
+fn remove_codebuddy_hook_entries(root: &mut serde_json::Value) -> bool {
+    let pre_tool_use = match root
+        .get_mut("hooks")
+        .and_then(|h| h.get_mut(PRE_TOOL_USE_KEY))
+        .and_then(|p| p.as_array_mut())
+    {
+        Some(arr) => arr,
+        None => return false,
+    };
+
+    let before_len = pre_tool_use.len();
+    pre_tool_use.retain(|entry| {
+        entry
+            .get("hooks")
+            .and_then(|h| h.as_array())
+            .map(|hooks| {
+                !hooks
+                    .iter()
+                    .any(|h| h.get("command").and_then(|c| c.as_str()) == Some(CODEBUDDY_HOOK_COMMAND))
+            })
+            .unwrap_or(true)
+    });
+    pre_tool_use.len() != before_len
 }
 
 // ─── Pi coding agent support ──────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,8 @@ pub enum AgentTarget {
     Pi,
     /// Hermes CLI
     Hermes,
+    /// CodeBuddy (Tencent Cloud AI code editor)
+    Codebuddy,
 }
 
 #[derive(Parser)]
@@ -783,6 +785,8 @@ enum HookCommands {
     Gemini,
     /// Process Copilot preToolUse hook (VS Code + Copilot CLI, reads JSON from stdin)
     Copilot,
+    /// Process CodeBuddy PreToolUse hook (reads JSON from stdin, dual Claude/CodeBuddy format)
+    Codebuddy,
     /// Check how a command would be rewritten by the hook engine (dry-run)
     Check {
         /// Target agent
@@ -1847,15 +1851,19 @@ fn run_cli() -> Result<i32> {
                     hooks::init::uninstall_copilot(ctx)?;
                 }
             } else if uninstall {
-                uninstall_init_dispatch(
-                    agent,
-                    global,
-                    gemini,
-                    codex,
-                    ctx,
-                    hooks::init::uninstall_hermes,
-                    hooks::init::uninstall,
-                )?;
+                if agent == Some(AgentTarget::Codebuddy) {
+                    hooks::init::uninstall_codebuddy(ctx)?;
+                } else {
+                    uninstall_init_dispatch(
+                        agent,
+                        global,
+                        gemini,
+                        codex,
+                        ctx,
+                        hooks::init::uninstall_hermes,
+                        hooks::init::uninstall,
+                    )?;
+                }
             } else if gemini {
                 let patch_mode = if auto_patch {
                     hooks::init::PatchMode::Auto
@@ -1887,6 +1895,8 @@ fn run_cli() -> Result<i32> {
                 hooks::init::run_antigravity_mode(ctx)?;
             } else if agent == Some(AgentTarget::Hermes) {
                 hooks::init::run_hermes_mode(ctx)?;
+            } else if agent == Some(AgentTarget::Codebuddy) {
+                hooks::init::run_codebuddy_mode(ctx)?;
             } else {
                 let install_opencode = opencode;
                 let install_claude = !opencode;
@@ -2220,6 +2230,10 @@ fn run_cli() -> Result<i32> {
             }
             HookCommands::Copilot => {
                 hooks::hook_cmd::run_copilot()?;
+                0
+            }
+            HookCommands::Codebuddy => {
+                hooks::hook_cmd::run_codebuddy()?;
                 0
             }
             HookCommands::Check { agent: _, command } => {


### PR DESCRIPTION
## Summary

Adds first-class CodeBuddy (Tencent Cloud AI code editor) support to rtk.

Closes #1966
Related: #1967, #2071, #2111

## Background

CodeBuddy is Tencent Cloud's AI code editor with a hooks system fully compatible with the Claude Code Hooks specification. The only differences are in the output JSON format:

1. Requires top-level `"continue": true`
2. Requires `"permissionDecision": "allow"` for rewrites to apply
3. Reads `"modifiedInput"` (Claude Code reads `"updatedInput"`)

The hook emits **both** `updatedInput` and `modifiedInput` so the same output works with both agents.

## Changes

### `src/hooks/constants.rs`
- Add `CODEBUDDY_DIR` (`.codebuddy`), `CODEBUDDY_HOOK_COMMAND`, `CODEBUDDY_MATCHER` (`Bash|execute_command`)

### `src/hooks/hook_cmd.rs`
- Add `run_codebuddy()` — the hook command entry point
- Add `process_codebuddy_payload()` — handles dual-format output
- Add `run_codebuddy_inner()` — test helper
- 12 new unit tests covering: rewrite, IDE tool names, passthrough, edge cases

### `src/hooks/init.rs`
- Add `run_codebuddy_mode()` — patches `~/.codebuddy/settings.json`
- Add `uninstall_codebuddy()` — removes RTK hook from settings
- Add helper functions for JSON patching with idempotency and backup

### `src/main.rs`
- Add `Codebuddy` variant to `AgentTarget` and `HookCommands` enums
- Wire init, uninstall, and hook dispatch

## Usage

```bash
# Initialize
rtk init --agent codebuddy

# Hook (called automatically by CodeBuddy)
rtk hook codebuddy

# Uninstall
rtk init --agent codebuddy --uninstall
```

## Tool Name Mapping

CodeBuddy uses IDE-style tool names. The matcher `Bash|execute_command` catches both CLI and IDE modes:

| CLI style | IDE style |
|-----------|-----------|
| `Bash` | `execute_command` |

## Settings Written

```json
{
  "hooks": {
    "PreToolUse": [
      {
        "matcher": "Bash|execute_command",
        "hooks": [
          {
            "type": "command",
            "command": "rtk hook codebuddy"
          }
        ]
      }
    ]
  }
}
```

## Testing

- 12 new unit tests in `hook_cmd.rs`
- Cannot run `cargo test` locally (no Rust toolchain on this machine) — CI will validate

## Checklist

- [x] Targets `develop` branch (not `master`)
- [x] Dual-format output (`updatedInput` + `modifiedInput`)
- [x] Top-level `continue: true` and `permissionDecision: "allow"`
- [x] Idempotent init (skips if hook already present)
- [x] Settings backup before modification
- [x] Uninstall support
- [x] Unit tests
- [ ] `cargo fmt --all --check` (pending CI)
- [ ] `cargo clippy --all-targets` (pending CI)
- [ ] `cargo test` (pending CI)