### PR TITLE
fix(discover,learn): encode Windows drive colon in project path slug

### DIFF
--- a/src/discover/provider.rs
+++ b/src/discover/provider.rs
@@ -117,15 +117,15 @@ impl ClaudeProvider {
 
     /// Encode a filesystem path to Claude Code's directory name format.
     ///
-    /// Claude Code replaces `/`, `.`, `_`, `\`, and any non-ASCII character
+    /// Claude Code replaces `/`, `.`, `_`, `\`, `:`, and any non-ASCII character
     /// with `-` when computing the project directory slug under `~/.claude/projects/`.
     ///
     /// `/Users/foo/bar`          → `-Users-foo-bar`
     /// `/Users/first.last/bar`   → `-Users-first-last-bar`
     /// `/home/chris/2_project`   → `-home-chris-2-project`
-    /// `C:\Users\foo\bar`        → `C:-Users-foo-bar`
+    /// `C:\Users\foo\bar`        → `C--Users-foo-bar`
     pub fn encode_project_path(path: &str) -> String {
-        const SANITIZED_CHARS: &[char] = &['/', '.', '_', '\\', ' ', '[', ']'];
+        const SANITIZED_CHARS: &[char] = &['/', '.', '_', '\\', ' ', '[', ']', ':'];
 
         path.chars()
             .map(|c| {
@@ -403,10 +403,23 @@ mod tests {
 
     #[test]
     fn test_encode_project_path_windows() {
-        // Windows backslashes are also replaced with '-'
+        // Windows backslashes AND the drive colon are replaced with '-':
+        // Claude Code stores C:\Users\foo\bar as projects/C--Users-foo-bar.
         assert_eq!(
             ClaudeProvider::encode_project_path(r"C:\Users\foo\bar"),
-            "C:-Users-foo-bar"
+            "C--Users-foo-bar"
+        );
+    }
+
+    #[test]
+    fn test_encode_project_path_windows_drive_colon() {
+        // If the drive colon is kept (e.g. "F:-Desktop-..."), the encoded cwd
+        // can never be a substring of Claude's real directory name
+        // ("F--Desktop-..."), so the default project filter of `rtk discover`
+        // and `rtk learn` matches zero sessions on every native-Windows setup.
+        assert_eq!(
+            ClaudeProvider::encode_project_path(r"F:\Desktop\AI\claude\vector_fading"),
+            "F--Desktop-AI-claude-vector-fading"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #2367 — on native Windows, `rtk discover` and `rtk learn` always scanned **0 sessions** without `--all`/`--project`, because `encode_project_path()` kept the drive colon (`C:\Users\foo` → `C:-Users-foo`) while Claude Code's project slug encodes it to a dash (`C--Users-foo`). The cwd-derived default filter could therefore never substring-match the real `~/.claude/projects/` directory name.

## Changes

- Add `':'` to `SANITIZED_CHARS` in `encode_project_path()` (same treatment #2172 gave spaces/brackets/non-ASCII)
- Correct the doc-comment example (`C:\Users\foo\bar` → `C--Users-foo-bar`)
- Fix `test_encode_project_path_windows`, which pinned the wrong expectation
- Add `test_encode_project_path_windows_drive_colon` regression test

Both `discover` and `learn` build their default filter from this function, hence the dual scope.

## Verification

- `cargo test`: **2149 passed, 8 ignored** (full suite, Windows 11)
- Real-world before/after on Windows 11 + Claude Code, rtk 0.42.3 base:
  - before: `rtk discover` → `Scanned: 0 sessions (last 30 days), 0 Bash commands`
  - after (encoder parity, validated via the equivalent `--project` substring): `Scanned: 504 sessions (last 30 days), 3382 Bash commands`

## Notes

- Unix paths containing `:` are legal but Claude Code encodes them to `-` there too, so the change strictly improves parity on all platforms.
- Complementary to #2228 (default to `--all`): that PR masks the no-flag symptom; this one fixes the encoder so cwd-scoped filtering actually works on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)