### PR TITLE
fix(discover+ccusage): Windows drive colon not sanitized in slug + accept ccusage 20.x 'period' field

### DIFF
--- a/src/analytics/ccusage.rs
+++ b/src/analytics/ccusage.rs
@@ -77,6 +77,7 @@ struct MonthlyResponse {
 
 #[derive(Debug, Deserialize)]
 struct MonthlyEntry {
+    #[serde(alias = "period")]
     month: String,
     #[serde(flatten)]
     metrics: CcusageMetrics,
@@ -233,6 +234,32 @@ mod tests {
         assert_eq!(periods[0].key, "2026-01");
         assert_eq!(periods[0].metrics.input_tokens, 1000);
         assert_eq!(periods[0].metrics.total_cost, 12.34);
+    }
+
+    #[test]
+    fn test_parse_monthly_period_field() {
+        // ccusage 20.x changed the field name from "month" to "period" in the
+        // all-agents monthly response. Both must be accepted.
+        let json = r#"{
+            "monthly": [
+                {
+                    "period": "2026-02",
+                    "inputTokens": 2000,
+                    "outputTokens": 800,
+                    "cacheCreationTokens": 0,
+                    "cacheReadTokens": 0,
+                    "totalTokens": 2800,
+                    "totalCost": 9.99
+                }
+            ]
+        }"#;
+
+        let result = parse_json(json, Granularity::Monthly);
+        assert!(result.is_ok(), "should accept 'period' field: {:?}", result);
+        let periods = result.unwrap();
+        assert_eq!(periods.len(), 1);
+        assert_eq!(periods[0].key, "2026-02");
+        assert_eq!(periods[0].metrics.total_cost, 9.99);
     }
 
     #[test]

--- a/src/discover/provider.rs
+++ b/src/discover/provider.rs
@@ -117,15 +117,15 @@ impl ClaudeProvider {
 
     /// Encode a filesystem path to Claude Code's directory name format.
     ///
-    /// Claude Code replaces `/`, `.`, `_`, `\`, and any non-ASCII character
+    /// Claude Code replaces `/`, `.`, `_`, `\`, `:`, and any non-ASCII character
     /// with `-` when computing the project directory slug under `~/.claude/projects/`.
     ///
     /// `/Users/foo/bar`          → `-Users-foo-bar`
     /// `/Users/first.last/bar`   → `-Users-first-last-bar`
     /// `/home/chris/2_project`   → `-home-chris-2-project`
-    /// `C:\Users\foo\bar`        → `C:-Users-foo-bar`
+    /// `C:\Users\foo\bar`        → `C--Users-foo-bar`
     pub fn encode_project_path(path: &str) -> String {
-        const SANITIZED_CHARS: &[char] = &['/', '.', '_', '\\', ' ', '[', ']'];
+        const SANITIZED_CHARS: &[char] = &['/', '.', '_', '\\', ' ', '[', ']', ':'];
 
         path.chars()
             .map(|c| {
@@ -403,10 +403,21 @@ mod tests {
 
     #[test]
     fn test_encode_project_path_windows() {
-        // Windows backslashes are also replaced with '-'
+        // Windows drive colons and backslashes are both replaced with '-',
+        // matching Claude Code's own slug generation on Windows.
         assert_eq!(
             ClaudeProvider::encode_project_path(r"C:\Users\foo\bar"),
-            "C:-Users-foo-bar"
+            "C--Users-foo-bar"
+        );
+    }
+
+    #[test]
+    fn test_encode_project_path_windows_with_space() {
+        // Spaces are also replaced; matches real-world paths like "f:\AMPLIA_APP 1"
+        // which Claude Code slugifies to "f--AMPLIA-APP-1".
+        assert_eq!(
+            ClaudeProvider::encode_project_path(r"f:\AMPLIA_APP 1"),
+            "f--AMPLIA-APP-1"
         );
     }
 


### PR DESCRIPTION
Two independent bugs found running `rtk` on Windows (Win10) with ccusage 20.9.

## Bug 1 — `rtk discover` scans 0 sessions on Windows

**Affected:** all Windows paths with a drive letter (e.g. `f:\AMPLIA_APP 1`)

**Root cause:** `encode_project_path` in `src/discover/provider.rs` did not include `:` in `SANITIZED_CHARS`. Claude Code replaces **both** backslash and colon with `-` when generating project slugs:
```
f:\AMPLIA_APP 1  →  f--AMPLIA-APP-1   (Claude Code / actual directory)
f:\AMPLIA_APP 1  →  f:-AMPLIA-APP-1   (RTK before this fix)
```
The substring match in `discover_sessions_in_projects_dir` always missed every project directory on Windows.

**Fix:** Add `:` to `SANITIZED_CHARS`.
- Corrects the `test_encode_project_path_windows` assertion (was asserting the wrong slug)
- Adds `test_encode_project_path_windows_with_space` as a regression test

## Bug 2 — `rtk cc-economics` shows $0 with ccusage ≥ 20.x

**Root cause:** ccusage 20.x changed the monthly JSON field from `"month"` to `"period"` in the all-agents response. Serde deserialization silently returned `Ok(None)`, zeroing out the economics report.

**Fix:** Add `#[serde(alias = "period")]` to `MonthlyEntry.month` in `src/analytics/ccusage.rs` — backwards-compatible, accepts both old and new field names.
- Adds `test_parse_monthly_period_field` as a regression test