### PR TITLE
feat(read): add Auto filter level that scales by file size

### DIFF
--- a/src/cmds/system/read.rs
+++ b/src/cmds/system/read.rs
@@ -35,8 +35,15 @@ pub fn run(
         eprintln!("Detected language: {:?}", lang);
     }
 
+    // Resolve Auto to a concrete level based on file size (opt-in via --level auto)
+    let line_count = content.lines().count();
+    let resolved = level.resolve(line_count);
+    if verbose > 0 && level == FilterLevel::Auto && resolved != FilterLevel::None {
+        eprintln!("rtk: auto-filter: {} lines → {}", line_count, resolved);
+    }
+
     // Apply filter
-    let filter = filter::get_filter(level);
+    let filter = filter::get_filter(resolved);
     let mut filtered = filter.filter(&content, &lang);
 
     // Safety: if filter emptied a non-empty file, fall back to raw content

--- a/src/core/filter.rs
+++ b/src/core/filter.rs
@@ -9,6 +9,23 @@ pub enum FilterLevel {
     None,
     Minimal,
     Aggressive,
+    /// Automatically select filter based on file size:
+    /// <100 lines → None, 100-500 → Minimal, >500 → Aggressive
+    Auto,
+}
+
+impl FilterLevel {
+    /// Resolve Auto to a concrete level given the number of lines in a file.
+    pub fn resolve(self, line_count: usize) -> FilterLevel {
+        match self {
+            FilterLevel::Auto => match line_count {
+                0..=99 => FilterLevel::None,
+                100..=500 => FilterLevel::Minimal,
+                _ => FilterLevel::Aggressive,
+            },
+            other => other,
+        }
+    }
 }
 
 impl FromStr for FilterLevel {
@@ -19,6 +36,7 @@ impl FromStr for FilterLevel {
             "none" => Ok(FilterLevel::None),
             "minimal" => Ok(FilterLevel::Minimal),
             "aggressive" => Ok(FilterLevel::Aggressive),
+            "auto" => Ok(FilterLevel::Auto),
             _ => Err(format!("Unknown filter level: {}", s)),
         }
     }
@@ -30,6 +48,7 @@ impl std::fmt::Display for FilterLevel {
             FilterLevel::None => write!(f, "none"),
             FilterLevel::Minimal => write!(f, "minimal"),
             FilterLevel::Aggressive => write!(f, "aggressive"),
+            FilterLevel::Auto => write!(f, "auto"),
         }
     }
 }
@@ -314,7 +333,7 @@ impl FilterStrategy for AggressiveFilter {
 
 pub fn get_filter(level: FilterLevel) -> Box<dyn FilterStrategy> {
     match level {
-        FilterLevel::None => Box::new(NoFilter),
+        FilterLevel::None | FilterLevel::Auto => Box::new(NoFilter),
         FilterLevel::Minimal => Box::new(MinimalFilter),
         FilterLevel::Aggressive => Box::new(AggressiveFilter),
     }
@@ -376,6 +395,45 @@ mod tests {
             FilterLevel::from_str("aggressive").unwrap(),
             FilterLevel::Aggressive
         );
+        assert_eq!(FilterLevel::from_str("auto").unwrap(), FilterLevel::Auto);
+    }
+
+    #[test]
+    fn test_filter_level_display_roundtrip() {
+        for level in [
+            FilterLevel::None,
+            FilterLevel::Minimal,
+            FilterLevel::Aggressive,
+            FilterLevel::Auto,
+        ] {
+            assert_eq!(FilterLevel::from_str(&level.to_string()).unwrap(), level);
+        }
+    }
+
+    #[test]
+    fn test_auto_resolve_scales_with_file_size() {
+        // Small files: no filtering (the LLM needs to see everything)
+        assert_eq!(FilterLevel::Auto.resolve(0), FilterLevel::None);
+        assert_eq!(FilterLevel::Auto.resolve(99), FilterLevel::None);
+        // Medium files: minimal filtering
+        assert_eq!(FilterLevel::Auto.resolve(100), FilterLevel::Minimal);
+        assert_eq!(FilterLevel::Auto.resolve(500), FilterLevel::Minimal);
+        // Large files: aggressive filtering
+        assert_eq!(FilterLevel::Auto.resolve(501), FilterLevel::Aggressive);
+        assert_eq!(FilterLevel::Auto.resolve(5000), FilterLevel::Aggressive);
+    }
+
+    #[test]
+    fn test_resolve_is_identity_for_explicit_levels() {
+        // Non-Auto levels are returned unchanged regardless of line count
+        for level in [
+            FilterLevel::None,
+            FilterLevel::Minimal,
+            FilterLevel::Aggressive,
+        ] {
+            assert_eq!(level.resolve(10), level);
+            assert_eq!(level.resolve(10_000), level);
+        }
     }
 
     #[test]


### PR DESCRIPTION
  ## Summary

  - Add `FilterLevel::Auto` — a filter level that scales by file size instead of being fixed. It resolves to a concrete level from the file's line count: **<100 lines → None, 100–500 → Minimal, >500 → Aggressive**.
  - Wired into `rtk read` (file path only) as an **opt-in** via `--level auto`. The default (`none`) is unchanged, so no existing behavior changes for anyone.
  - This directly follows the project's *Correctness vs Token Savings* principle: small files pass through untouched (the agent needs full context), while large files — where the tokens actually pile up — get aggressive compression.

  ### Why

  A fixed filter level is a poor fit for a mixed codebase: `none` wastes tokens on huge files, `aggressive` strips context from small ones that the agent needs to read in full. `Auto` removes that trade-off by picking the level per file.
  
  The logic is intentionally tiny and lives entirely in `FilterLevel::resolve()`, so it's easy to review and the thresholds are trivial to tune.
  
  ### Changes

  - `src/core/filter.rs`: add the `Auto` variant + `resolve(line_count)`, plus `FromStr` (`"auto"`), `Display`, and `get_filter` handling (Auto maps to no-op when unresolved, as a safety default).
  - `src/cmds/system/read.rs`: resolve `Auto` by line count before filtering. Only the file path is touched — stdin is a stream with no file-size semantics, so it's left as-is.
  - Tests: `"auto"` parsing, Display↔FromStr roundtrip, resolve scaling across the three bands, and identity for explicit (non-Auto) levels.

  Happy to make `auto` the **default** for `rtk read` in a follow-up if you'd like — I kept it opt-in here so this PR changes no existing behavior.

  ## Test plan

  - [x] `cargo fmt --all && cargo clippy --all-targets && cargo test` — fmt clean, no new clippy warnings in changed files, **1609 passed / 0 failed**
  - [x] Manual testing:
    - `rtk read <small_file.rs> --level auto` → unfiltered (resolves to None)
    - `rtk read <large_file.rs> --level auto -v` → logs `auto-filter: N lines → aggressive`, output compressed
