### PR TITLE
fix(openclaw): make the rewrite plugin work end-to-end on OpenClaw 2026.6.x

### DIFF
--- a/openclaw/index.js
+++ b/openclaw/index.js
@@ -7,13 +7,16 @@
  * All rewrite logic lives in `rtk rewrite` (src/discover/registry.rs).
  * This plugin is a thin delegate — to add or change rules, edit the
  * Rust registry, not this file.
+ *
+ * Compiled from upstream index.ts (rtk v0.42.3) — types stripped only,
+ * logic identical. OpenClaw 2026.6.5 managed installs require JS output.
  */
 
 import { execFileSync } from "node:child_process";
 
-let rtkAvailable: boolean | null = null;
+let rtkAvailable = null;
 
-function checkRtk(): boolean {
+function checkRtk() {
   if (rtkAvailable !== null) return rtkAvailable;
   try {
     execFileSync("which", ["rtk"], { stdio: "ignore" });
@@ -24,33 +27,30 @@ function checkRtk(): boolean {
   return rtkAvailable;
 }
 
-// `rtk rewrite` exit-code protocol (see hooks/claude/rtk-rewrite.sh):
+// `rtk rewrite` exit-code protocol (hooks/claude/rtk-rewrite.sh):
 //   0 + stdout  rewrite found, allow-classified
 //   1           no RTK equivalent — pass through unchanged
-//   2           deny rule matched — pass original through so native policy sees it
-//   3 + stdout  rewrite found, ask-classified — rewrite; host exec policy still governs
-// execFileSync throws on any non-zero exit, so status 3 must be recovered
-// from the error object — otherwise the plugin never rewrites anything.
-function tryRewrite(command: string): string | null {
-  let stdout: string | null = null;
+//   2           deny rule matched — pass through so native policy sees the original
+//   3 + stdout  rewrite found, ask-classified — rewrite; OpenClaw exec policy still governs
+function tryRewrite(command) {
+  let stdout = null;
   try {
     stdout = execFileSync("rtk", ["rewrite", command], {
       encoding: "utf-8",
       timeout: 2000,
-    }).toString();
+    });
   } catch (err) {
-    const e = err as { status?: number; stdout?: string | Buffer };
-    if (e && e.status === 3 && e.stdout) {
-      stdout = e.stdout.toString();
+    if (err && err.status === 3 && err.stdout) {
+      stdout = err.stdout;
     } else {
       return null;
     }
   }
-  const result = stdout.trim();
+  const result = stdout.toString().trim();
   return result && result !== command ? result : null;
 }
 
-export default function register(api: any) {
+export default function register(api) {
   const pluginConfig = api.config ?? {};
   const enabled = pluginConfig.enabled !== false;
   const verbose = pluginConfig.verbose === true;
@@ -64,7 +64,7 @@ export default function register(api: any) {
 
   api.on(
     "before_tool_call",
-    (event: { toolName: string; params: Record<string, unknown> }) => {
+    (event) => {
       if (event.toolName !== "exec") return;
 
       const command = event.params?.command;

--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -1,10 +1,11 @@
 {
   "id": "rtk-rewrite",
   "name": "RTK Token Optimizer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Transparently rewrites shell commands to their RTK equivalents for 60-90% LLM token savings",
   "homepage": "https://github.com/rtk-ai/rtk",
   "license": "Apache-2.0",
+  "activation": { "onCapabilities": ["hook"] },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@rtk-ai/rtk-rewrite",
-  "version": "1.0.0",
-  "description": "RTK plugin for OpenClaw — rewrites shell commands for 60-90% LLM token savings",
-  "main": "index.ts",
+  "version": "1.0.1",
+  "description": "RTK plugin for OpenClaw \u2014 rewrites shell commands for 60-90% LLM token savings",
+  "main": "index.js",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -20,7 +20,14 @@
   ],
   "files": [
     "index.ts",
+    "index.js",
     "openclaw.plugin.json",
     "README.md"
-  ]
+  ],
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

The OpenClaw plugin as shipped never rewrites anything on current OpenClaw (tested against 2026.6.5). This PR is the complete working set — four independent defects fixed together, verified end-to-end against live gateways. Fixes 1–3 overlap with open PRs #2202/#2220 (exit code 3), #2113 (TS build), and #1236/#1455 (extensions metadata) — credit to those authors; any one of them alone still leaves the plugin broken. Fix 4 is, as far as I can tell, not reported anywhere yet and is required even with 1–3 applied.

Closes #1810
Closes #944
Closes #1719

## The four defects

1. **Exit-code protocol** — `rtk rewrite` signals a rewrite with **exit code 3** (rewrite/ask) and the rewrite on stdout (per `hooks/claude/rtk-rewrite.sh`: 0+stdout allow-rewrite, 1 no-equivalent, 2 deny, 3+stdout ask-rewrite). `execFileSync` throws on non-zero exit, so `tryRewrite` returned `null` for every ask-classified rewrite — i.e. nearly always. Fixed by recovering status 3 + stdout from the thrown error, and passing through on 1/2 so the host's native deny policy still sees the original command.
2. **TypeScript entry** — OpenClaw managed installs reject TS entry points ("compiled runtime output required"). Ship compiled `index.js` (types stripped, logic identical) with `main` pointing at it; `index.ts` stays as source.
3. **Missing `openclaw.extensions`** — required in package.json for managed installs to register the entry point.
4. **Gateway startup activation intent (new)** — OpenClaw 2026.6.x excludes hook-only installed plugins from the Gateway startup plugin plan unless the manifest declares activation intent. Without `"activation": { "onCapabilities": ["hook"] }`, the agent runtime's restricted plugin load silently skips the plugin: `plugins inspect` reports loaded and embedded CLI runs rewrite, but daemon-served agent turns never do. A daemon can even mask this intermittently — any unrestricted plugin-load event in the process (e.g. a subagent spawn) registers the hooks for the process lifetime, which makes the failure look nondeterministic across identically-configured gateways.

## Verification

A/B against a throwaway local OpenClaw 2026.6.5 gateway: pre-fix, a daemon-served `exec` of `ls -la <dir>` returns raw output; post-fix the identical turn returns the rtk-compressed form, with the rewritten command recorded in rtk's gain history and the original command preserved in the session transcript (the host applies rewritten params at execution time only — worth knowing when verifying: the transcript is not evidence of failure).