### PR TITLE
fix(diff): report modified-only diffs and follow diff exit convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ rtk read file.rs -l aggressive  # Signatures only (strips bodies)
 rtk smart file.rs               # 2-line heuristic code summary
 rtk find "*.rs" .               # Compact find results
 rtk grep "pattern" .            # Grouped search results
-rtk diff file1 file2            # Condensed diff
+rtk diff file1 file2            # Condensed diff (exit 1 if files differ)
 ```
 
 ### Git

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -527,7 +527,9 @@ assert_ok      "rtk discover"                 rtk discover
 
 section "Diff"
 
-assert_ok      "rtk diff two files"           rtk diff Cargo.toml LICENSE
+assert_ok       "rtk diff identical files"     rtk diff Cargo.toml Cargo.toml
+assert_fails    "rtk diff differing files"     rtk diff Cargo.toml LICENSE
+assert_contains "rtk diff shows changes"       "added" rtk diff Cargo.toml LICENSE
 
 # ── 37. Wc ────────────────────────────────────────────
 

--- a/src/cmds/git/diff_cmd.rs
+++ b/src/cmds/git/diff_cmd.rs
@@ -5,8 +5,9 @@ use anyhow::Result;
 use std::fs;
 use std::path::Path;
 
-/// Ultra-condensed diff - only changed lines, no context
-pub fn run(file1: &Path, file2: &Path, verbose: u8) -> Result<()> {
+/// Ultra-condensed diff - only changed lines, no context.
+/// Returns the diff-convention exit code: 0 if identical, 1 if files differ.
+pub fn run(file1: &Path, file2: &Path, verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
     if verbose > 0 {
@@ -17,30 +18,7 @@ pub fn run(file1: &Path, file2: &Path, verbose: u8) -> Result<()> {
     let content2 = fs::read_to_string(file2)?;
     let raw = format!("{}\n---\n{}", content1, content2);
 
-    let lines1: Vec<&str> = content1.lines().collect();
-    let lines2: Vec<&str> = content2.lines().collect();
-    let diff = compute_diff(&lines1, &lines2);
-    let mut rtk = String::new();
-
-    if diff.added == 0 && diff.removed == 0 {
-        rtk.push_str("[ok] Files are identical");
-        println!("{}", rtk);
-        timer.track(
-            &format!("diff {} {}", file1.display(), file2.display()),
-            "rtk diff",
-            &raw,
-            &rtk,
-        );
-        return Ok(());
-    }
-
-    rtk.push_str(&format!("{} → {}\n", file1.display(), file2.display()));
-    rtk.push_str(&format!(
-        "   +{} added, -{} removed, ~{} modified\n\n",
-        diff.added, diff.removed, diff.modified
-    ));
-
-    rtk.push_str(&format_diff_changes(&diff));
+    let (rtk, exit_code) = render_file_diff(file1, file2, &content1, &content2);
 
     print!("{}", rtk);
     timer.track(
@@ -49,7 +27,28 @@ pub fn run(file1: &Path, file2: &Path, verbose: u8) -> Result<()> {
         &raw,
         &rtk,
     );
-    Ok(())
+    Ok(exit_code)
+}
+
+/// Renders the condensed file comparison and returns it with the
+/// diff-convention exit code (0 = identical, 1 = differences found).
+fn render_file_diff(file1: &Path, file2: &Path, content1: &str, content2: &str) -> (String, i32) {
+    let lines1: Vec<&str> = content1.lines().collect();
+    let lines2: Vec<&str> = content2.lines().collect();
+    let diff = compute_diff(&lines1, &lines2);
+
+    if diff.changes.is_empty() {
+        return ("[ok] Files are identical\n".to_string(), 0);
+    }
+
+    let mut rtk = String::new();
+    rtk.push_str(&format!("{} → {}\n", file1.display(), file2.display()));
+    rtk.push_str(&format!(
+        "   +{} added, -{} removed, ~{} modified\n\n",
+        diff.added, diff.removed, diff.modified
+    ));
+    rtk.push_str(&format_diff_changes(&diff));
+    (rtk, 1)
 }
 
 /// Run diff from stdin (piped command output)
@@ -305,6 +304,64 @@ mod tests {
         assert_eq!(result.added, 0);
         assert_eq!(result.removed, 0);
         assert!(result.changes.is_empty());
+    }
+
+    // --- render_file_diff (issue #2364 regression) ---
+
+    #[test]
+    fn test_render_modified_only_yaml_not_identical() {
+        // "a: 1" vs "a: 2" is classified as modified (similarity > 0.5);
+        // the identical check must not ignore modified-only diffs.
+        let (out, code) = render_file_diff(
+            Path::new("one.yaml"),
+            Path::new("two.yaml"),
+            "a: 1\n",
+            "a: 2\n",
+        );
+        assert!(
+            !out.contains("identical"),
+            "modified-only diff reported as identical:\n{}",
+            out
+        );
+        assert!(out.contains("~1 modified"));
+        assert!(out.contains("a: 1"));
+        assert!(out.contains("a: 2"));
+        assert_eq!(code, 1, "differing files must exit 1 (diff convention)");
+    }
+
+    #[test]
+    fn test_render_modified_only_json_not_identical() {
+        let (out, code) = render_file_diff(
+            Path::new("j1.json"),
+            Path::new("j2.json"),
+            "{\"a\": 1}\n",
+            "{\"a\": 2}\n",
+        );
+        assert!(
+            !out.contains("identical"),
+            "modified-only diff reported as identical:\n{}",
+            out
+        );
+        assert_eq!(code, 1);
+    }
+
+    #[test]
+    fn test_render_identical_files_exit_zero() {
+        let (out, code) = render_file_diff(
+            Path::new("a.yaml"),
+            Path::new("b.yaml"),
+            "a: 1\nb: 2\n",
+            "a: 1\nb: 2\n",
+        );
+        assert!(out.contains("[ok] Files are identical"));
+        assert_eq!(code, 0);
+    }
+
+    #[test]
+    fn test_render_added_removed_exit_one() {
+        let (out, code) = render_file_diff(Path::new("t1.txt"), Path::new("t2.txt"), "x\n", "y\n");
+        assert!(out.contains("+1 added, -1 removed"));
+        assert_eq!(code, 1);
     }
 
     // --- condense_unified_diff ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -1707,11 +1707,11 @@ fn run_cli() -> Result<i32> {
 
         Commands::Diff { file1, file2 } => {
             if let Some(f2) = file2 {
-                diff_cmd::run(&file1, &f2, cli.verbose)?;
+                diff_cmd::run(&file1, &f2, cli.verbose)?
             } else {
                 diff_cmd::run_stdin(cli.verbose)?;
+                0
             }
-            0
         }
 
         Commands::Log { file } => {


### PR DESCRIPTION
## Summary

Fixes #2364 — `rtk diff` reported differing YAML/JSON files as `[ok] Files are identical` (exit 0), hiding real changes from agents comparing config files.

## Root cause

Not extension-related: `compute_diff` classifies similar lines (character-set similarity > 0.5, e.g. `a: 1` vs `a: 2`) as **modified**, but the identical check in `run()` only tested `added == 0 && removed == 0`, ignoring the modified count. Structured files like YAML/JSON trigger this because their changed lines stay near-identical character-wise; the issue's `.txt` repro worked only because `x` vs `y` has zero similarity and lands in added/removed.

## Changes

- `src/cmds/git/diff_cmd.rs` — extracted render logic into a pure, testable `render_file_diff()`; the identical check now uses `diff.changes.is_empty()`; returns the diff-convention exit code (0 = identical, 1 = differing), also fixing the secondary observation in the issue.
- `src/main.rs` — `Commands::Diff` propagates the exit code (same `Result<i32>` pattern as `go_cmd` / `core::runner`).
- `scripts/test-all.sh` — diff smoke test updated for the exit convention (identical → ok, differing → non-zero + output contains changes).
- `README.md` — exit semantics documented in the command list.

## Testing

- TDD: 4 new regression tests written first (red on the old logic), covering the exact repro cases from the issue (`a: 1`/`a: 2` YAML, `{"a": 1}`/`{"a": 2}` JSON, identical files, added/removed `.txt`).
- `cargo fmt --all --check && cargo clippy --all-targets && cargo test` — clean, 2154 passed.
- Manual verification of all repro scenarios from the issue with the built binary (output + exit codes match `/usr/bin/diff` semantics).

### Behavior change note

`rtk diff` previously always exited 0. It now exits 1 when files differ, matching `diff` convention — as requested in the issue's "Expected" section, and required by scripts using `diff && echo same` semantics under the hook rewrite.