### PR TITLE
fix(hook): apply exclude_commands to head/tail rewrites

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -784,6 +784,9 @@ fn rewrite_segment_inner(
     }
 
     if cmd_part.starts_with("head -") || cmd_part.starts_with("tail ") {
+        if is_excluded(cmd_part, excluded) {
+            return None;
+        }
         return rewrite_line_range(cmd_part).map(|r| format!("{}{}", r, redirect_suffix));
     }
 
@@ -3431,6 +3434,45 @@ mod tests {
     fn test_exclude_bare_anchor_ignored() {
         let excluded = vec!["^".to_string()];
         assert!(rewrite_command_no_prefixes("git status", &excluded).is_some());
+    }
+
+    // --- exclude_commands on head/tail rewrites (#2363) ---
+
+    #[test]
+    fn test_exclude_head_line_range_rewrite() {
+        let excluded = vec!["head".to_string()];
+        assert_eq!(
+            rewrite_command_no_prefixes("head -20 package.json", &excluded),
+            None
+        );
+    }
+
+    #[test]
+    fn test_exclude_tail_line_range_rewrite() {
+        let excluded = vec!["tail".to_string()];
+        assert_eq!(
+            rewrite_command_no_prefixes("tail -n 50 app.log", &excluded),
+            None
+        );
+    }
+
+    #[test]
+    fn test_head_still_rewrites_when_not_excluded() {
+        let excluded = vec!["curl".to_string()];
+        assert_eq!(
+            rewrite_command_no_prefixes("head -20 package.json", &excluded),
+            Some("rtk read package.json --max-lines 20".into())
+        );
+    }
+
+    #[test]
+    fn test_exclude_head_with_redirect_suffix() {
+        // Exclusion must apply to the command part, ignoring trailing redirects
+        let excluded = vec!["head".to_string()];
+        assert_eq!(
+            rewrite_command_no_prefixes("head -20 package.json 2>&1", &excluded),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #2363 — entries in `[hooks] exclude_commands` had no effect on the `head -N file` / `tail -n N file` rewrites, while the same entries worked for every other command.

## Root cause

Exactly as diagnosed in the issue: in `rewrite_segment_inner` (`src/discover/registry.rs`), the `head -` / `tail ` short-circuit returns a `rewrite_line_range()` result before the flow reaches the `is_excluded()` check that the regular `classify_command` path goes through. The exclusion list was never consulted on that path.

## Change

One guard added inside the short-circuit: `is_excluded(cmd_part, excluded)` → `return None` before rewriting. The check runs on `cmd_part` (trailing redirects already stripped), so `head -20 file 2>&1` is excluded consistently with the plain form.

## Testing

- TDD: 4 new unit tests written first (3 red on the old code), following the existing `exclude_commands (#243)` test conventions:
  - `head` excluded → no rewrite
  - `tail` excluded → no rewrite
  - `head` with trailing redirect excluded → no rewrite
  - `head` NOT in the exclusion list → still rewrites to `rtk read --max-lines` (no over-exclusion)
- `cargo fmt --all --check && cargo clippy --all-targets && cargo test` — clean, 2154 passed.
- Manual verification with the issue's exact repro config (`exclude_commands = ["head", "tail", "rg"]`, isolated `$HOME`):

```console
$ rtk hook check "head -20 package.json"
No rewrite for: head -20 package.json   # was: rtk read package.json --max-lines 20

$ rtk hook check "tail -n 50 app.log"
No rewrite for: tail -n 50 app.log

$ rtk hook check "git status"
rtk git status                          # other commands unaffected
```

No doc updates needed: this makes the behavior match what `exclude_commands` already documents.