### PR TITLE
fix(read): only treat /* at line start as block comment opener

### DIFF
--- a/src/core/filter.rs
+++ b/src/core/filter.rs
@@ -172,8 +172,10 @@ impl FilterStrategy for MinimalFilter {
 
             // Handle block comments
             if let (Some(start), Some(end)) = (patterns.block_start, patterns.block_end) {
+                // starts_with, not contains: `/*` inside a string literal or
+                // glob (e.g. "src/*.rs") must not open a comment block (#2385)
                 if !in_docstring
-                    && trimmed.contains(start)
+                    && trimmed.starts_with(start)
                     && !trimmed.starts_with(patterns.doc_block_start.unwrap_or("###"))
                 {
                     in_block_comment = true;
@@ -468,6 +470,76 @@ fn main() {
         let result = filter.filter(code, &Language::Rust);
         assert!(!result.contains("// This is a comment"));
         assert!(result.contains("fn main()"));
+    }
+
+    // --- block comment detection (#2385) ---
+
+    #[test]
+    fn test_minimal_keeps_code_with_inline_block_marker() {
+        // `/*` inside a string literal is not a comment opener
+        let code = "let glob = \"src/*.rs\";\nfn bar() {}\nfn baz() {}";
+        let filter = MinimalFilter;
+        let result = filter.filter(code, &Language::Rust);
+        assert!(
+            result.contains("let glob = \"src/*.rs\";"),
+            "line with /* in string literal must be kept, got:\n{}",
+            result
+        );
+        assert!(
+            result.contains("fn bar()") && result.contains("fn baz()"),
+            "block-comment state must not leak past a non-comment line, got:\n{}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_minimal_same_line_block_comment_no_state_leak() {
+        let code = "/* inline comment */\nfn foo() {}";
+        let filter = MinimalFilter;
+        let result = filter.filter(code, &Language::Rust);
+        assert!(
+            !result.contains("inline comment"),
+            "comment-only line is dropped"
+        );
+        assert!(
+            result.contains("fn foo()"),
+            "code after same-line block comment must be kept, got:\n{}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_minimal_still_drops_multiline_block_comment() {
+        let code = "/* start\nstill comment\n*/\nfn after() {}";
+        let filter = MinimalFilter;
+        let result = filter.filter(code, &Language::Rust);
+        assert!(!result.contains("still comment"));
+        assert!(result.contains("fn after()"));
+    }
+
+    #[test]
+    fn test_minimal_keeps_python_inline_triple_quote_assignment() {
+        let code = "x = \"\"\"inline\"\"\"\ndef f():\n    pass";
+        let filter = MinimalFilter;
+        let result = filter.filter(code, &Language::Python);
+        assert!(
+            result.contains("x = "),
+            "assignment with inline triple-quote must be kept, got:\n{}",
+            result
+        );
+        assert!(result.contains("def f():"));
+    }
+
+    #[test]
+    fn test_minimal_keeps_url_with_trailing_line_comment() {
+        let code = "const API: &str = \"http://example.com/v1\";  // endpoint\nfn foo() {}";
+        let filter = MinimalFilter;
+        let result = filter.filter(code, &Language::Rust);
+        assert!(
+            result.contains("http://example.com/v1"),
+            "URL line must be kept, got:\n{}",
+            result
+        );
     }
 
     // --- truncation accuracy ---

--- a/src/core/filter.rs
+++ b/src/core/filter.rs
@@ -476,7 +476,6 @@ fn main() {
 
     #[test]
     fn test_minimal_keeps_code_with_inline_block_marker() {
-        // `/*` inside a string literal is not a comment opener
         let code = "let glob = \"src/*.rs\";\nfn bar() {}\nfn baz() {}";
         let filter = MinimalFilter;
         let result = filter.filter(code, &Language::Rust);


### PR DESCRIPTION
## Summary

Fixes #2385 — `MinimalFilter` dropped valid code lines containing `/*` as a substring, and worse: when no `*/` followed on the same line, `in_block_comment` leaked and **silently swallowed the rest of the file**.

## Root cause

In `src/core/filter.rs`, the block-comment opener detection used `trimmed.contains(start)` instead of `starts_with(start)`. Any line with `/*` anywhere — string literals, globs (`"src/*.rs"`), regex patterns — entered block-comment state and was dropped; since such lines rarely contain a closing `*/`, every subsequent line was dropped too.

While reproducing, I narrowed the issue's reported scope in two ways (verified empirically on develop):

- **URL lines with `//` were NOT affected** — line-comment detection already uses `starts_with`, so repro lines 1–2 from the issue pass through unchanged even before this fix. The real blast radius is `/*`-in-string + the state leak.
- **The same-line `/* ... */` case** (issue's bug 2) resolves itself once openers require line-start: only genuine comment lines enter block state now, and a comment-only `/* inline */` line being dropped is the filter working as intended (consistent with the issue's "Expected" section: drop only when markers start the trimmed line).

Repro on develop vs this branch:

```console
# develop — glob line dropped AND everything after it swallowed
$ rtk read example.rs --level minimal
const API: &str = "http://example.com/v1";  // endpoint
let re = regex::Regex::new(r"https?://\w+").unwrap();
fn foo() {}

# this branch — full file view, only the real comment line stripped
$ rtk read example.rs --level minimal
const API: &str = "http://example.com/v1";  // endpoint
let re = regex::Regex::new(r"https?://\w+").unwrap();
fn foo() {}
let glob = "src/*.rs";
fn bar() {}
fn baz() {}
```

## Change

One-word fix (`contains` → `starts_with`) in the opener detection, with a comment documenting the constraint. Side benefit: Python inline triple-quote assignments (`x = """inline"""`) are no longer dropped either (same `contains` path).

## Testing

- TDD: 5 new unit tests written first (2 red on develop):
  - `/*` in string literal kept + **no state leak** past it (the truncation regression)
  - Python `x = """inline"""` assignment kept
  - same-line `/* inline */` comment dropped without leaking state
  - multi-line `/* ... */` blocks still stripped (existing behavior guarded)
  - URL + trailing `// comment` line kept (documents that the issue's URL claim was already safe)
- `cargo fmt --all --check && cargo clippy --all-targets && cargo test` — clean, 2155 passed.
- Manual verification with the issue's repro file (above).