### PR TITLE
fix(filter): preserve inline comment markers

### DIFF
--- a/src/core/filter.rs
+++ b/src/core/filter.rs
@@ -173,7 +173,7 @@ impl FilterStrategy for MinimalFilter {
             // Handle block comments
             if let (Some(start), Some(end)) = (patterns.block_start, patterns.block_end) {
                 if !in_docstring
-                    && trimmed.contains(start)
+                    && trimmed.starts_with(start)
                     && !trimmed.starts_with(patterns.doc_block_start.unwrap_or("###"))
                 {
                     in_block_comment = true;
@@ -467,6 +467,25 @@ fn main() {
         let filter = MinimalFilter;
         let result = filter.filter(code, &Language::Rust);
         assert!(!result.contains("// This is a comment"));
+        assert!(result.contains("fn main()"));
+    }
+
+    #[test]
+    fn test_minimal_filter_preserves_comment_markers_in_code() {
+        let code = r#"
+const API: &str = "http://example.com/v1"; // endpoint
+let pattern = "/* not a comment */";
+let value = 1; /* trailing comment */
+/* single-line block comment */
+fn main() {}
+"#;
+        let filter = MinimalFilter;
+        let result = filter.filter(code, &Language::Rust);
+
+        assert!(result.contains("http://example.com/v1"));
+        assert!(result.contains("\"/* not a comment */\""));
+        assert!(result.contains("let value = 1;"));
+        assert!(!result.contains("single-line block comment"));
         assert!(result.contains("fn main()"));
     }
 


### PR DESCRIPTION
## Summary

- only enter block-comment filtering when the trimmed line starts with the block marker
- preserve valid code containing block markers in string literals or trailing comments
- add regression coverage for inline markers and standalone block comments

Fixes #2385

AI disclosure: Codex assisted with the implementation and test.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test --all` (2151 passed, 8 ignored)
- [ ] Manual testing: `rtk <command>` output inspected
