### PR TITLE
fix: keep release panic=unwind so filter catch_unwind fails open

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,12 @@ toml = "0.8"
 opt-level = 3
 lto = true
 codegen-units = 1
-panic = "abort"
+# Must stay "unwind": filter execution relies on std::panic::catch_unwind to
+# fail open (see core::stream and cmds::system::pipe_cmd — "filter panicked,
+# passing through raw output"). Under panic = "abort" that recovery is dead
+# code in release builds: any panic inside a filter aborts the whole process
+# with SIGABRT instead of degrading to raw passthrough.
+panic = "unwind"
 strip = true
 
 # cargo-deb configuration

--- a/src/main.rs
+++ b/src/main.rs
@@ -1152,6 +1152,21 @@ const RTK_META_COMMANDS: &[&str] = &[
     "rewrite",
 ];
 
+/// Run a filter closure, failing open to `raw` if it panics.
+///
+/// Mirrors the `catch_unwind` fail-open guards in `core::stream` and
+/// `cmds::system::pipe_cmd`: a filter bug should degrade to raw passthrough,
+/// never take down rtk. The default panic hook still prints the panic location
+/// to stderr before we recover, which is useful for diagnosing the filter bug.
+/// Requires `panic = "unwind"` in the release profile to be effective (see
+/// Cargo.toml / tests/release_profile_panic.rs).
+fn filter_or_passthrough<F: FnOnce() -> String>(raw: &str, filter_fn: F) -> String {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(filter_fn)).unwrap_or_else(|_| {
+        eprintln!("[rtk] warning: filter panicked — passing through raw output");
+        raw.to_string()
+    })
+}
+
 fn run_fallback(parse_error: clap::Error) -> Result<i32> {
     let args: Vec<String> = std::env::args().skip(1).collect();
 
@@ -1229,7 +1244,9 @@ fn run_fallback(parse_error: clap::Error) -> Result<i32> {
                     None
                 };
 
-                let filtered = core::toml_filter::apply_filter(filter, &combined_raw);
+                let filtered = filter_or_passthrough(&combined_raw, || {
+                    core::toml_filter::apply_filter(filter, &combined_raw)
+                });
                 println!("{}", filtered);
                 if let Some(hint) = tee_hint {
                     println!("{}", hint);
@@ -2548,6 +2565,19 @@ mod tests {
     use super::*;
     use clap::Parser;
     use std::cell::Cell;
+
+    #[test]
+    fn test_filter_or_passthrough_recovers_from_panic() {
+        // A panicking filter must not take down rtk — it falls back to raw output.
+        let out = filter_or_passthrough("raw output", || panic!("filter bug"));
+        assert_eq!(out, "raw output");
+    }
+
+    #[test]
+    fn test_filter_or_passthrough_returns_filtered_value() {
+        let out = filter_or_passthrough("raw", || "filtered".to_string());
+        assert_eq!(out, "filtered");
+    }
 
     #[test]
     fn test_git_commit_single_message() {

--- a/tests/release_profile_panic.rs
+++ b/tests/release_profile_panic.rs
@@ -1,0 +1,37 @@
+//! Regression guard for the release panic strategy.
+//!
+//! rtk's filter execution fails open via `std::panic::catch_unwind`
+//! (`core::stream`, `cmds::system::pipe_cmd`): when a filter panics, rtk is
+//! supposed to print a warning and pass the raw output through untouched.
+//!
+//! `catch_unwind` only works under `panic = "unwind"`. If the release profile
+//! is built with `panic = "abort"`, that recovery becomes dead code in the
+//! shipped binary — any panic inside a filter aborts the whole process with
+//! SIGABRT instead of degrading to raw passthrough. The unit tests for the
+//! fail-open behavior still pass because `cargo test` builds with unwind, so
+//! the regression is invisible to the normal test suite. This test inspects the
+//! manifest directly so a reintroduced `panic = "abort"` fails CI.
+//!
+//! See: https://github.com/rtk-ai/rtk/issues/2400
+
+#[test]
+fn release_profile_does_not_abort_on_panic() {
+    let manifest = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"))
+        .expect("read Cargo.toml");
+    let value: toml::Value = manifest.parse().expect("parse Cargo.toml");
+
+    let panic_setting = value
+        .get("profile")
+        .and_then(|p| p.get("release"))
+        .and_then(|r| r.get("panic"))
+        .and_then(|v| v.as_str());
+
+    // Either unset (defaults to unwind) or explicitly "unwind" is acceptable.
+    // "abort" defeats the filter catch_unwind fail-open path.
+    assert_ne!(
+        panic_setting,
+        Some("abort"),
+        "[profile.release] panic = \"abort\" defeats filter catch_unwind fail-open \
+         (filters would SIGABRT instead of passing through raw output). Use \"unwind\"."
+    );
+}


### PR DESCRIPTION
## Summary
- `[profile.release]` sets `panic = "abort"`, which makes `std::panic::catch_unwind` a no-op — so the filter fail-open recovery in `core::stream` and `cmds::system::pipe_cmd` ("filter panicked — passing through raw output") is dead code in release builds. Any panic inside a filter aborts the whole process with SIGABRT instead of degrading to raw passthrough (#2400; seen in the wild on `gcloud … list --format=…`).
- Fix: set `[profile.release] panic = "unwind"` so the existing `catch_unwind` actually fails open. Adds a manifest-level regression guard (the normal suite can't catch this — `cargo test` always builds with unwind, which is why it shipped).
- Also: `run_fallback` applied the matched TOML filter (`core::toml_filter::apply_filter`) with **no** `catch_unwind`, unlike the streaming/pipe paths. Wrapped it in a `filter_or_passthrough` helper so a filter panic there also fails open (and the default panic hook prints the location, which helps diagnose the underlying filter bug).

## Test plan
- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test` — fmt clean, clippy clean, 2153 passed / 0 failed (stable 1.96.0)
- [x] `cargo test --test release_profile_panic` — passes; verified it FAILS when `panic` is flipped back to `abort`
- [x] `cargo test filter_or_passthrough` — new fallback fail-open tests (panic → passthrough; normal → filtered value)
- [x] `cargo test test_panicking_filter_returns_passthrough` — existing fail-open test still passes

> Trade-off: `panic = "unwind"` slightly increases binary size (landing pads); it does not affect startup time. Correctness + the fail-open behavior the codebase already implements/tests outweigh the size delta.

Closes #2400