### PR TITLE
feat: make bundled SQLite optional via Cargo feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,13 @@ readme = "README.md"
 keywords = ["cli", "llm", "token", "filter", "productivity"]
 categories = ["command-line-utilities", "development-tools"]
 
+[features]
+default = ["bundled-sqlite"]
+## Bundle SQLite from source (self-contained binary).
+## Disable with `--no-default-features` on musl-based systems (Alpine Linux)
+## where compiling SQLite from C source is slow — requires sqlite-dev installed.
+bundled-sqlite = ["rusqlite/bundled"]
+
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 anyhow = "1.0"
@@ -23,7 +30,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 colored = "2"
 dirs = "5"
-rusqlite = { version = "0.31", features = ["bundled"] }
+rusqlite = { version = "0.31" }
 toml = "0.8"
 chrono = "0.4"
 tempfile = "3"


### PR DESCRIPTION
## Problem

On musl-based systems (Alpine Linux, aarch64), building RTK from source compiles SQLite from C source every time via `rusqlite`'s `features = ["bundled"]`. On ARM64 this takes **20+ minutes** just for SQLite compilation.

## Solution

Move the `bundled` feature into a local Cargo feature flag so it can be toggled at build time:

```toml
[features]
default = ["bundled-sqlite"]
bundled-sqlite = ["rusqlite/bundled"]
```

- **Default build** (`cargo build --release`): bundled SQLite, same as before — no change for existing users.
- **Alpine/musl build** (`cargo build --release --no-default-features`): uses system SQLite via pkg-config. Requires `sqlite-dev` package, builds in ~2 minutes.

## Changes

**`Cargo.toml`**: 7 lines added (features section), 1 line changed (rusqlite dep).

## Verification

- `cargo check --no-default-features` ✅ — compiles in 2 min 14 s on aarch64 Alpine
- `cargo check` (default features) ✅ — rusqlite bundled still works
