### PR TITLE
Add rewrite for "rg --files" -> rtk find

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ git status  # Automatically rewritten to rtk git status
 
 Hook-based agents rewrite Bash commands (e.g., `git status` -> `rtk git status`) before execution. Plugin-based agents, including Hermes, use their plugin API to rewrite commands before execution. The agent receives compact output without needing to call `rtk` explicitly.
 
+Common shell file-discovery commands rewrite too: `find . -name "*.rs"` maps to `rtk find "*.rs" .`, and plain `rg --files` / `rg --files <path>` map to `rtk find "*" .` / `rtk find "*" <path>`.
+
 **Important:** the hook only runs on Bash tool calls. Claude Code built-in tools like `Read`, `Grep`, and `Glob` do not pass through the Bash hook, so they are not auto-rewritten. To get RTK's compact output for those workflows, use shell commands (`cat`/`head`/`tail`, `rg`/`grep`, `find`) or call `rtk read`, `rtk grep`, or `rtk find` directly.
 
 ## How It Works

--- a/docs/guide/resources/what-rtk-covers.md
+++ b/docs/guide/resources/what-rtk-covers.md
@@ -111,6 +111,7 @@ Typical savings: 60-99%.
 |---------|---------|--------------|
 | `ls` | 80% | Tree format with file counts |
 | `find` | 75% | Tree format |
+| `rg --files [path]` | 70% | Rewritten to `rtk find "*" .` or `rtk find "*" <path>` for plain file listings |
 | `grep` | 70% | Truncated lines, grouped by file |
 | `diff` | 65% | Context reduced |
 | `wc` | 60% | Compact counts |

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -116,8 +116,12 @@ pub fn classify_command(cmd: &str) -> Classification {
         return Classification::Ignored;
     }
 
-    if starts_with_rg_files_token(cmd_clean) {
-        if parse_rg_files(cmd_clean).is_some() {
+    // Normalize absolute binary paths before the rg --files special case so
+    // `/usr/bin/rg --files` follows the same rewrite path as plain `rg`.
+    let cmd_normalized = strip_absolute_path(cmd_clean);
+
+    if starts_with_rg_files_token(&cmd_normalized) {
+        if parse_rg_files(&cmd_normalized).is_some() {
             return Classification::Supported {
                 rtk_equivalent: "rtk find",
                 category: "Files",
@@ -130,8 +134,6 @@ pub fn classify_command(cmd: &str) -> Classification {
         };
     }
 
-    // Normalize absolute binary paths: /usr/bin/grep → grep (#485)
-    let cmd_normalized = strip_absolute_path(cmd_clean);
     // Strip git global options: git -C /tmp status → git status (#163)
     let cmd_normalized = strip_git_global_opts(&cmd_normalized);
     // Strip golangci-lint global options before `run` so classify/rewrite stays
@@ -833,8 +835,9 @@ fn rewrite_segment_inner(
         return rewrite_line_range(cmd_part).map(|r| format!("{}{}", r, redirect_suffix));
     }
 
-    if starts_with_rg_files_token(cmd_part) {
-        return parse_rg_files(cmd_part)
+    let cmd_part_normalized = strip_absolute_path(cmd_part);
+    if starts_with_rg_files_token(&cmd_part_normalized) {
+        return parse_rg_files(&cmd_part_normalized)
             .map(|path| format!("rtk find '*' {}{}", path, redirect_suffix));
     }
 
@@ -1502,6 +1505,14 @@ mod tests {
     }
 
     #[test]
+    fn test_rewrite_rg_files_absolute_path() {
+        assert_eq!(
+            rewrite_command_no_prefixes("/usr/bin/rg --files src", &[]),
+            Some("rtk find '*' src".into())
+        );
+    }
+
+    #[test]
     fn test_rewrite_pwd_and_rg_files() {
         assert_eq!(
             rewrite_command_no_prefixes("pwd && rg --files", &[]),
@@ -1513,6 +1524,7 @@ mod tests {
     fn test_rewrite_rg_files_unsupported_forms_skipped() {
         for command in [
             "rg --files --hidden",
+            "/usr/bin/rg --files --hidden",
             "rg --files -g '*.rs'",
             "rg --files src tests",
         ] {

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -116,6 +116,20 @@ pub fn classify_command(cmd: &str) -> Classification {
         return Classification::Ignored;
     }
 
+    if starts_with_rg_files_token(cmd_clean) {
+        if parse_rg_files(cmd_clean).is_some() {
+            return Classification::Supported {
+                rtk_equivalent: "rtk find",
+                category: "Files",
+                estimated_savings_pct: 70.0,
+                status: super::report::RtkStatus::Existing,
+            };
+        }
+        return Classification::Unsupported {
+            base_command: "rg".to_string(),
+        };
+    }
+
     // Normalize absolute binary paths: /usr/bin/grep → grep (#485)
     let cmd_normalized = strip_absolute_path(cmd_clean);
     // Strip git global options: git -C /tmp status → git status (#163)
@@ -650,6 +664,38 @@ fn rewrite_line_range(cmd: &str) -> Option<String> {
     None
 }
 
+fn parse_rg_files(cmd: &str) -> Option<String> {
+    let tokens = tokenize(cmd);
+    if !(tokens.len() == 2 || tokens.len() == 3) || tokens.iter().any(|t| t.kind != TokenKind::Arg)
+    {
+        return None;
+    }
+
+    if tokens[0].value != "rg" || tokens[1].value != "--files" {
+        return None;
+    }
+
+    if tokens.len() == 2 {
+        return Some(".".to_string());
+    }
+
+    let path = tokens[2].value.as_str();
+    if path.starts_with('-') {
+        None
+    } else {
+        Some(path.to_string())
+    }
+}
+
+fn starts_with_rg_files_token(cmd: &str) -> bool {
+    let tokens = tokenize(cmd);
+    tokens.len() >= 2
+        && tokens[0].kind == TokenKind::Arg
+        && tokens[0].value == "rg"
+        && tokens[1].kind == TokenKind::Arg
+        && tokens[1].value == "--files"
+}
+
 /// Shell prefix builtins that modify how the shell runs a command
 /// but don't change which command runs. Strip before routing, re-prepend after.
 const SHELL_PREFIX_BUILTINS: &[&str] = &["noglob", "command", "builtin", "exec", "nocorrect"];
@@ -785,6 +831,11 @@ fn rewrite_segment_inner(
 
     if cmd_part.starts_with("head -") || cmd_part.starts_with("tail ") {
         return rewrite_line_range(cmd_part).map(|r| format!("{}{}", r, redirect_suffix));
+    }
+
+    if starts_with_rg_files_token(cmd_part) {
+        return parse_rg_files(cmd_part)
+            .map(|path| format!("rtk find '*' {}{}", path, redirect_suffix));
     }
 
     // Most cat flags (-v, -A, -e, -t, -s, -b, --show-all, etc.) have different
@@ -1418,6 +1469,66 @@ mod tests {
         assert_eq!(
             rewrite_command_no_prefixes("rg \"fn main\"", &[]),
             Some("rtk grep \"fn main\"".into())
+        );
+    }
+
+    #[test]
+    fn test_classify_rg_files() {
+        assert_eq!(
+            classify_command("rg --files"),
+            Classification::Supported {
+                rtk_equivalent: "rtk find",
+                category: "Files",
+                estimated_savings_pct: 70.0,
+                status: RtkStatus::Existing,
+            }
+        );
+    }
+
+    #[test]
+    fn test_rewrite_rg_files() {
+        assert_eq!(
+            rewrite_command_no_prefixes("rg --files", &[]),
+            Some("rtk find '*' .".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_rg_files_with_path() {
+        assert_eq!(
+            rewrite_command_no_prefixes("rg --files src", &[]),
+            Some("rtk find '*' src".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_pwd_and_rg_files() {
+        assert_eq!(
+            rewrite_command_no_prefixes("pwd && rg --files", &[]),
+            Some("pwd && rtk find '*' .".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_rg_files_unsupported_forms_skipped() {
+        for command in [
+            "rg --files --hidden",
+            "rg --files -g '*.rs'",
+            "rg --files src tests",
+        ] {
+            assert_eq!(rewrite_command_no_prefixes(command, &[]), None, "{command}");
+        }
+    }
+
+    #[test]
+    fn test_rewrite_rg_files_with_matches_still_uses_grep() {
+        assert_eq!(
+            rewrite_command_no_prefixes("rg --files-with-matches TODO src", &[]),
+            Some("rtk grep --files-with-matches TODO src".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("rg --files-without-match TODO src", &[]),
+            Some("rtk grep --files-without-match TODO src".into())
         );
     }
 


### PR DESCRIPTION
## Summary
- rewrite `rg --files` to `rtk find '*' .`

[Codex loves to do this, 4200+ instances in my history]

Limited scope to most foolproof [bare --files and `--files <path>`]; no additional flags are supported like --hidden; did not scope creep to adding multi-path support to "rtk find" either

## Test plan

- [X] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [X] Manual testing: `rtk <command>` output inspected, but this is unchanged, the only difference is adding a new rewrite path pointing to rtk find
- verified rtk rewrite 'rg --files' -> rtk find '*' .
- verified rtk rewrite 'rg --files src' -> rtk find '*' src
- verified /usr/bin/rg --files src also rewrites correctly
- verified unsupported forms like rg --files --hidden and rg --files src tests are left unrevised