### PR TITLE
[codex] Improve read savings across agent integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,12 @@ Four strategies applied per command type:
 ### Files
 ```bash
 rtk ls .                        # Token-optimized directory tree
-rtk read file.rs                # Smart file reading
+rtk read file.rs                # Compact read (minimal filter, auto-window large files)
+rtk read file.rs -l none        # Exact raw file content
 rtk read file.rs -l aggressive  # Signatures only (strips bodies)
+rtk read --symbol run file.rs   # Requested symbol with nearby context
+rtk read --changed file.rs      # Suppress unchanged repeat reads
+rtk read --total-max-lines 300 a.rs b.rs  # Shared multi-file budget
 rtk smart file.rs               # 2-line heuristic code summary
 rtk find "*.rs" .               # Compact find results
 rtk grep "pattern" .            # Grouped search results

--- a/hooks/antigravity/rules.md
+++ b/hooks/antigravity/rules.md
@@ -6,6 +6,9 @@
 
 Always prefix shell commands with `rtk` to minimize token consumption.
 
+Prefer `rtk read <file>` for file exploration. Use `--symbol <name>` for focused context,
+`--changed` for repeat checks, and `-l none` only when exact content is required.
+
 Examples:
 
 ```bash

--- a/hooks/claude/rtk-awareness.md
+++ b/hooks/claude/rtk-awareness.md
@@ -26,4 +26,8 @@ which rtk             # Verify correct binary
 All other commands are automatically rewritten by the Claude Code hook.
 Example: `git status` → `rtk git status` (transparent, 0 tokens overhead)
 
+For file exploration and analysis, prefer `rtk read <file>` over the built-in Read tool.
+Use `rtk read --symbol <name> <file>` for focused code context, `rtk read --changed <file>`
+for repeat checks, and the built-in Read tool or `rtk read -l none` when exact content is required for editing.
+
 Refer to CLAUDE.md for full command reference.

--- a/hooks/cline/rules.md
+++ b/hooks/cline/rules.md
@@ -6,6 +6,9 @@
 
 Always prefix shell commands with `rtk` to minimize token consumption.
 
+Prefer `rtk read <file>` for file exploration. Use `--symbol <name>` for focused context,
+`--changed` for repeat checks, and `-l none` only when exact content is required.
+
 Examples:
 
 ```bash

--- a/hooks/codex/rtk-awareness.md
+++ b/hooks/codex/rtk-awareness.md
@@ -6,6 +6,10 @@
 
 Always prefix shell commands with `rtk`.
 
+For file exploration and analysis, prefer `rtk read <file>` over native file-read tools.
+Use `rtk read --symbol <name> <file>` for focused code context, `rtk read --changed <file>`
+for repeat checks, and `rtk read -l none <file>` only when exact content is required for editing.
+
 Examples:
 
 ```bash

--- a/hooks/copilot/rtk-awareness.md
+++ b/hooks/copilot/rtk-awareness.md
@@ -7,6 +7,10 @@
 The `.github/copilot-instructions.md` file is loaded at session start by both Copilot CLI and VS Code Copilot Chat.
 It instructs Copilot to prefix commands with `rtk` automatically.
 
+For file exploration and analysis, prefer `rtk read <file>` over native file-read tools.
+Use `rtk read --symbol <name> <file>` for focused context, `rtk read --changed <file>`
+for repeat checks, and `rtk read -l none <file>` only when exact content is required.
+
 The `.github/hooks/rtk-rewrite.json` hook adds a `PreToolUse` safety net via `rtk hook` —
 a cross-platform Rust binary that intercepts raw bash tool calls and rewrites them.
 No shell scripts, no `jq` dependency, works on Windows natively.

--- a/hooks/kilocode/rules.md
+++ b/hooks/kilocode/rules.md
@@ -6,6 +6,9 @@
 
 Always prefix shell commands with `rtk` to minimize token consumption.
 
+Prefer `rtk read <file>` for file exploration. Use `--symbol <name>` for focused context,
+`--changed` for repeat checks, and `-l none` only when exact content is required.
+
 Examples:
 
 ```bash

--- a/hooks/windsurf/rules.md
+++ b/hooks/windsurf/rules.md
@@ -6,6 +6,9 @@
 
 Always prefix shell commands with `rtk` to minimize token consumption.
 
+Prefer `rtk read <file>` for file exploration. Use `--symbol <name>` for focused context,
+`--changed` for repeat checks, and `-l none` only when exact content is required.
+
 Examples:
 
 ```bash

--- a/src/cmds/system/read.rs
+++ b/src/cmds/system/read.rs
@@ -3,17 +3,46 @@
 use crate::core::filter::{self, FilterLevel, Language};
 use crate::core::tracking;
 use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+const SMALL_FILE_LINES: usize = 160;
+const MEDIUM_FILE_LINES: usize = 600;
+const MEDIUM_COMPACT_MAX_LINES: usize = 200;
+const LARGE_COMPACT_MAX_LINES: usize = 120;
+const DATA_COMPACT_MAX_LINES: usize = 80;
+const SYMBOL_CONTEXT_LINES: usize = 12;
+
+#[derive(Default, Deserialize, Serialize)]
+struct ReadHashCache {
+    files: HashMap<String, String>,
+}
+
+pub struct ReadOptions<'a> {
+    pub level: FilterLevel,
+    pub max_lines: Option<usize>,
+    pub tail_lines: Option<usize>,
+    pub line_numbers: bool,
+    pub symbol: Option<&'a str>,
+    pub changed: bool,
+}
 
 pub fn run(
     file: &Path,
-    level: FilterLevel,
-    max_lines: Option<usize>,
-    tail_lines: Option<usize>,
-    line_numbers: bool,
+    options: ReadOptions<'_>,
     verbose: u8,
 ) -> Result<()> {
+    let ReadOptions {
+        level,
+        max_lines,
+        tail_lines,
+        line_numbers,
+        symbol,
+        changed,
+    } = options;
     let timer = tracking::TimedExecution::start();
 
     if verbose > 0 {
@@ -23,6 +52,11 @@ pub fn run(
     // Read file content
     let content = fs::read_to_string(file)
         .with_context(|| format!("Failed to read file: {}", file.display()))?;
+
+    if changed && !record_changed(file, &content)? {
+        println!("[unchanged: {}]", file.display());
+        return Ok(());
+    }
 
     // Detect language from extension
     let lang = file
@@ -49,6 +83,10 @@ pub fn run(
         filtered = content.clone();
     }
 
+    if let Some(symbol) = symbol {
+        filtered = extract_symbol_context(&filtered, symbol);
+    }
+
     if verbose > 0 {
         let original_lines = content.lines().count();
         let filtered_lines = filtered.lines().count();
@@ -63,7 +101,7 @@ pub fn run(
         );
     }
 
-    filtered = apply_line_window(&filtered, max_lines, tail_lines, &lang);
+    filtered = apply_default_line_window(&filtered, level, max_lines, tail_lines, &lang);
 
     let rtk_output = if line_numbers {
         format_with_line_numbers(&filtered)
@@ -81,14 +119,19 @@ pub fn run(
 }
 
 pub fn run_stdin(
-    level: FilterLevel,
-    max_lines: Option<usize>,
-    tail_lines: Option<usize>,
-    line_numbers: bool,
+    options: ReadOptions<'_>,
     verbose: u8,
 ) -> Result<()> {
     use std::io::{self, Read as IoRead};
 
+    let ReadOptions {
+        level,
+        max_lines,
+        tail_lines,
+        line_numbers,
+        symbol,
+        ..
+    } = options;
     let timer = tracking::TimedExecution::start();
 
     if verbose > 0 {
@@ -112,6 +155,9 @@ pub fn run_stdin(
     // Apply filter
     let filter = filter::get_filter(level);
     let mut filtered = filter.filter(&content, &lang);
+    if let Some(symbol) = symbol {
+        filtered = extract_symbol_context(&filtered, symbol);
+    }
 
     if verbose > 0 {
         let original_lines = content.lines().count();
@@ -127,7 +173,7 @@ pub fn run_stdin(
         );
     }
 
-    filtered = apply_line_window(&filtered, max_lines, tail_lines, &lang);
+    filtered = apply_default_line_window(&filtered, level, max_lines, tail_lines, &lang);
 
     let rtk_output = if line_numbers {
         format_with_line_numbers(&filtered)
@@ -176,6 +222,96 @@ fn apply_line_window(
     content.to_string()
 }
 
+fn apply_default_line_window(
+    content: &str,
+    level: FilterLevel,
+    max_lines: Option<usize>,
+    tail_lines: Option<usize>,
+    lang: &Language,
+) -> String {
+    let effective_max_lines =
+        if tail_lines.is_some() || max_lines.is_some() || level == FilterLevel::None {
+            max_lines
+        } else {
+            adaptive_max_lines(content, lang)
+        };
+
+    apply_line_window(content, effective_max_lines, tail_lines, lang)
+}
+
+fn adaptive_max_lines(content: &str, lang: &Language) -> Option<usize> {
+    let lines = content.lines().count();
+    if lines <= SMALL_FILE_LINES {
+        None
+    } else if *lang == Language::Data {
+        Some(DATA_COMPACT_MAX_LINES)
+    } else if lines <= MEDIUM_FILE_LINES {
+        Some(MEDIUM_COMPACT_MAX_LINES)
+    } else {
+        Some(LARGE_COMPACT_MAX_LINES)
+    }
+}
+
+fn extract_symbol_context(content: &str, symbol: &str) -> String {
+    let lines: Vec<&str> = content.lines().collect();
+    let matches: Vec<usize> = lines
+        .iter()
+        .enumerate()
+        .filter_map(|(i, line)| line.contains(symbol).then_some(i))
+        .collect();
+    if matches.is_empty() {
+        return format!("[symbol not found: {symbol}]\n");
+    }
+
+    let mut keep = vec![false; lines.len()];
+    for index in matches {
+        let start = index.saturating_sub(SYMBOL_CONTEXT_LINES);
+        let end = (index + SYMBOL_CONTEXT_LINES + 1).min(lines.len());
+        keep[start..end].fill(true);
+    }
+
+    let mut output = String::new();
+    let mut previous_kept = false;
+    for (line, keep_line) in lines.iter().zip(keep) {
+        if keep_line {
+            if !previous_kept && !output.is_empty() {
+                output.push_str("[...]\n");
+            }
+            output.push_str(line);
+            output.push('\n');
+        }
+        previous_kept = keep_line;
+    }
+    output
+}
+
+fn read_hash_cache_path() -> PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join("rtk")
+        .join("read-hashes.json")
+}
+
+fn record_changed(file: &Path, content: &str) -> Result<bool> {
+    let cache_path = read_hash_cache_path();
+    let mut cache: ReadHashCache = fs::read_to_string(&cache_path)
+        .ok()
+        .and_then(|value| serde_json::from_str(&value).ok())
+        .unwrap_or_default();
+    let key = fs::canonicalize(file)
+        .unwrap_or_else(|_| file.to_path_buf())
+        .to_string_lossy()
+        .into_owned();
+    let hash = format!("{:x}", Sha256::digest(content.as_bytes()));
+    let changed = cache.files.get(&key) != Some(&hash);
+    cache.files.insert(key, hash);
+    if let Some(parent) = cache_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(cache_path, serde_json::to_vec(&cache)?)?;
+    Ok(changed)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -194,7 +330,18 @@ fn main() {{
         )?;
 
         // Just verify it doesn't panic
-        run(file.path(), FilterLevel::Minimal, None, None, false, 0)?;
+        run(
+            file.path(),
+            ReadOptions {
+                level: FilterLevel::Minimal,
+                max_lines: None,
+                tail_lines: None,
+                line_numbers: false,
+                symbol: None,
+                changed: false,
+            },
+            0,
+        )?;
         Ok(())
     }
 
@@ -227,6 +374,78 @@ fn main() {{
         assert!(output.contains("more lines"));
     }
 
+    #[test]
+    fn test_default_compact_window_truncates_filtered_large_reads() {
+        let input = (0..500)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let output =
+            apply_default_line_window(&input, FilterLevel::Minimal, None, None, &Language::Unknown);
+
+        assert!(output.contains("more lines"));
+        assert!(
+            output.lines().count() < 260,
+            "default compact read should stay bounded, got {} lines",
+            output.lines().count()
+        );
+    }
+
+    #[test]
+    fn test_adaptive_window_keeps_small_files_complete() {
+        let input = (0..100)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert_eq!(
+            apply_default_line_window(&input, FilterLevel::Minimal, None, None, &Language::Rust),
+            input
+        );
+    }
+
+    #[test]
+    fn test_adaptive_window_is_tighter_for_large_data_files() {
+        let input = (0..500)
+            .map(|i| format!("key{i}=value"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let output =
+            apply_default_line_window(&input, FilterLevel::Minimal, None, None, &Language::Data);
+        assert!(output.lines().count() <= DATA_COMPACT_MAX_LINES + 1);
+    }
+
+    #[test]
+    fn test_extract_symbol_context_omits_unrelated_regions() {
+        let input = (0..100)
+            .map(|i| {
+                if i == 70 {
+                    "fn wanted() {}".to_string()
+                } else {
+                    format!("line {i}")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let output = extract_symbol_context(&input, "wanted");
+        assert!(output.contains("fn wanted() {}"));
+        assert!(!output.contains("line 1\n"));
+        assert!(output.lines().count() <= SYMBOL_CONTEXT_LINES * 2 + 1);
+    }
+
+    #[test]
+    fn test_default_compact_window_does_not_truncate_raw_reads() {
+        let input = (0..500)
+            .map(|i| format!("line {}", i))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let output =
+            apply_default_line_window(&input, FilterLevel::None, None, None, &Language::Unknown);
+
+        assert_eq!(output, input);
+    }
+
     fn rtk_bin() -> std::path::PathBuf {
         std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("target")
@@ -246,7 +465,11 @@ fn main() {{
         writeln!(f2, "charlie\ndelta").unwrap();
 
         let output = std::process::Command::new(&bin)
-            .args(["read", &f1.path().to_string_lossy(), &f2.path().to_string_lossy()])
+            .args([
+                "read",
+                &f1.path().to_string_lossy(),
+                &f2.path().to_string_lossy(),
+            ])
             .output()
             .expect("failed to run rtk read");
 
@@ -266,15 +489,28 @@ fn main() {{
         writeln!(f1, "valid content").unwrap();
 
         let output = std::process::Command::new(&bin)
-            .args(["read", &f1.path().to_string_lossy(), "/tmp/rtk_nonexistent_file.txt"])
+            .args([
+                "read",
+                &f1.path().to_string_lossy(),
+                "/tmp/rtk_nonexistent_file.txt",
+            ])
             .output()
             .expect("failed to run rtk read");
 
-        assert!(!output.status.success(), "should exit non-zero on missing file");
+        assert!(
+            !output.status.success(),
+            "should exit non-zero on missing file"
+        );
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
-        assert!(stdout.contains("valid content"), "valid file should still be printed");
-        assert!(stderr.contains("rtk_nonexistent_file"), "should report missing file on stderr");
+        assert!(
+            stdout.contains("valid content"),
+            "valid file should still be printed"
+        );
+        assert!(
+            stderr.contains("rtk_nonexistent_file"),
+            "should report missing file on stderr"
+        );
     }
 
     #[test]

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -73,6 +73,14 @@ lazy_static! {
     static ref TAIL_N_SPACE: Regex = Regex::new(r"^tail\s+-n\s+(\d+)\s+(\S+)$").unwrap();
     static ref TAIL_LINES_EQ: Regex = Regex::new(r"^tail\s+--lines=(\d+)\s+(\S+)$").unwrap();
     static ref TAIL_LINES_SPACE: Regex = Regex::new(r"^tail\s+--lines\s+(\d+)\s+(\S+)$").unwrap();
+    static ref GET_CONTENT: Regex = Regex::new(r"(?i)^Get-Content\s+(\S+)$").unwrap();
+    static ref GET_CONTENT_HEAD: Regex =
+        Regex::new(r"(?i)^Get-Content\s+(?:-TotalCount|-Head)\s+(\d+)\s+(\S+)$").unwrap();
+    static ref GET_CONTENT_TAIL: Regex =
+        Regex::new(r"(?i)^Get-Content\s+-Tail\s+(\d+)\s+(\S+)$").unwrap();
+    static ref WINDOWS_TYPE: Regex = Regex::new(r"(?i)^type\s+(\S+)$").unwrap();
+    static ref SED_HEAD: Regex =
+        Regex::new(r#"^sed\s+-n\s+['"]?1,(\d+)p['"]?\s+(\S+)$"#).unwrap();
 }
 
 const GOLANGCI_GLOBAL_OPT_WITH_VALUE: &[&str] = &[
@@ -650,6 +658,31 @@ fn rewrite_line_range(cmd: &str) -> Option<String> {
     None
 }
 
+fn rewrite_platform_read(cmd: &str) -> Option<String> {
+    for re in [&*GET_CONTENT, &*WINDOWS_TYPE] {
+        if let Some(caps) = re.captures(cmd) {
+            return Some(format!("rtk read {}", caps.get(1)?.as_str()));
+        }
+    }
+    for re in [&*GET_CONTENT_HEAD, &*SED_HEAD] {
+        if let Some(caps) = re.captures(cmd) {
+            return Some(format!(
+                "rtk read {} --max-lines {}",
+                caps.get(2)?.as_str(),
+                caps.get(1)?.as_str()
+            ));
+        }
+    }
+    if let Some(caps) = GET_CONTENT_TAIL.captures(cmd) {
+        return Some(format!(
+            "rtk read {} --tail-lines {}",
+            caps.get(2)?.as_str(),
+            caps.get(1)?.as_str()
+        ));
+    }
+    None
+}
+
 /// Shell prefix builtins that modify how the shell runs a command
 /// but don't change which command runs. Strip before routing, re-prepend after.
 const SHELL_PREFIX_BUILTINS: &[&str] = &["noglob", "command", "builtin", "exec", "nocorrect"];
@@ -785,6 +818,9 @@ fn rewrite_segment_inner(
 
     if cmd_part.starts_with("head -") || cmd_part.starts_with("tail ") {
         return rewrite_line_range(cmd_part).map(|r| format!("{}{}", r, redirect_suffix));
+    }
+    if let Some(rewritten) = rewrite_platform_read(cmd_part) {
+        return Some(format!("{}{}", rewritten, redirect_suffix));
     }
 
     // Most cat flags (-v, -A, -e, -t, -s, -b, --show-all, etc.) have different
@@ -1814,6 +1850,34 @@ mod tests {
         assert_eq!(
             rewrite_command_no_prefixes("tail --lines 7 src/lib.rs", &[]),
             Some("rtk read src/lib.rs --tail-lines 7".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_powershell_and_windows_reads() {
+        assert_eq!(
+            rewrite_command_no_prefixes("Get-Content README.md", &[]),
+            Some("rtk read README.md".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("Get-Content -TotalCount 40 README.md", &[]),
+            Some("rtk read README.md --max-lines 40".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("Get-Content -Tail 20 app.log", &[]),
+            Some("rtk read app.log --tail-lines 20".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("type README.md", &[]),
+            Some("rtk read README.md".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_sed_head_range() {
+        assert_eq!(
+            rewrite_command_no_prefixes("sed -n '1,100p' README.md", &[]),
+            Some("rtk read README.md --max-lines 100".into())
         );
     }
 

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -189,6 +189,9 @@ rtk prisma              # Prisma without ASCII art (88%)
 ```bash
 rtk ls <path>           # Tree format, compact (65%)
 rtk read <file>         # Code reading with filtering (60%)
+rtk read --symbol <name> <file> # Focused symbol context
+rtk read --changed <file>       # Suppress unchanged repeat reads
+rtk read -l none <file>         # Exact content for editing
 rtk grep <pattern>      # Search grouped by file (75%). Format flags (-c, -l, -L, -o, -Z) run raw.
 rtk find <pattern>      # Find grouped by directory (70%)
 ```
@@ -3911,6 +3914,9 @@ cargo test                 rtk cargo test
 docker ps                  rtk docker ps
 kubectl get pods           rtk kubectl pods
 ```
+
+For file exploration, prefer `rtk read <file>`. Use `--symbol <name>` for focused
+context, `--changed` for repeat checks, and `-l none` only for exact editing content.
 
 ## Meta commands (use directly)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,8 +96,8 @@ enum Commands {
         /// Files to read (supports multiple, like cat)
         #[arg(required = true, num_args = 1..)]
         files: Vec<PathBuf>,
-        /// Filter: none (default, full content), minimal, aggressive
-        #[arg(short, long, default_value = "none")]
+        /// Filter: minimal (default, strips comments/blank lines), none, aggressive
+        #[arg(short, long, default_value = "minimal")]
         level: core::filter::FilterLevel,
         /// Max lines
         #[arg(short, long, conflicts_with = "tail_lines")]
@@ -108,6 +108,15 @@ enum Commands {
         /// Show line numbers
         #[arg(short = 'n', long)]
         line_numbers: bool,
+        /// Show only matches for a symbol with nearby context
+        #[arg(long)]
+        symbol: Option<String>,
+        /// Suppress unchanged files using a persistent content hash
+        #[arg(long)]
+        changed: bool,
+        /// Shared maximum lines across all files
+        #[arg(long, conflicts_with_all = ["max_lines", "tail_lines"])]
+        total_max_lines: Option<usize>,
     },
 
     /// Generate 2-line technical summary (heuristic-based)
@@ -1446,9 +1455,16 @@ fn run_cli() -> Result<i32> {
             max_lines,
             tail_lines,
             line_numbers,
+            symbol,
+            changed,
+            total_max_lines,
         } => {
             let mut had_error = false;
             let mut stdin_seen = false;
+            let shared_max_lines = total_max_lines.map(|total| {
+                let file_count = files.len().max(1);
+                (total / file_count).max(1)
+            });
             for file in &files {
                 let result = if file == Path::new("-") {
                     if stdin_seen {
@@ -1456,14 +1472,28 @@ fn run_cli() -> Result<i32> {
                         continue;
                     }
                     stdin_seen = true;
-                    read::run_stdin(level, max_lines, tail_lines, line_numbers, cli.verbose)
+                    read::run_stdin(
+                        read::ReadOptions {
+                            level,
+                            max_lines: max_lines.or(shared_max_lines),
+                            tail_lines,
+                            line_numbers,
+                            symbol: symbol.as_deref(),
+                            changed,
+                        },
+                        cli.verbose,
+                    )
                 } else {
                     read::run(
                         file,
-                        level,
-                        max_lines,
-                        tail_lines,
-                        line_numbers,
+                        read::ReadOptions {
+                            level,
+                            max_lines: max_lines.or(shared_max_lines),
+                            tail_lines,
+                            line_numbers,
+                            symbol: symbol.as_deref(),
+                            changed,
+                        },
                         cli.verbose,
                     )
                 };
@@ -2548,6 +2578,46 @@ mod tests {
     use super::*;
     use clap::Parser;
     use std::cell::Cell;
+
+    #[test]
+    fn test_read_defaults_to_minimal_filter() {
+        let cli = Cli::try_parse_from(["rtk", "read", "src/main.rs"]).unwrap();
+        match cli.command {
+            Commands::Read { level, .. } => {
+                assert_eq!(level, core::filter::FilterLevel::Minimal);
+            }
+            _ => panic!("Expected Read command"),
+        }
+    }
+
+    #[test]
+    fn test_read_supports_shared_budget_symbol_and_changed_mode() {
+        let cli = Cli::try_parse_from([
+            "rtk",
+            "read",
+            "--total-max-lines",
+            "100",
+            "--symbol",
+            "wanted",
+            "--changed",
+            "a.rs",
+            "b.rs",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Read {
+                total_max_lines,
+                symbol,
+                changed,
+                ..
+            } => {
+                assert_eq!(total_max_lines, Some(100));
+                assert_eq!(symbol.as_deref(), Some("wanted"));
+                assert!(changed);
+            }
+            _ => panic!("Expected Read command"),
+        }
+    }
 
     #[test]
     fn test_git_commit_single_message() {


### PR DESCRIPTION
## Summary

- add adaptive, content-aware default windows for compact reads
- add symbol-focused reads, shared multi-file budgets, and hash-backed unchanged suppression
- rewrite PowerShell, Windows `type`, and common `sed` read commands through `rtk read`
- teach all installed agent awareness templates to prefer compact reads for exploration

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test cmds::system::read::tests --no-fail-fast` (10 passed, 3 ignored)
- `cargo test test_rewrite_ --no-fail-fast` (157 passed)
- `cargo build --release`
- full suite: 2140 passed, 17 failed, 8 ignored; failures are existing Windows environment/process-spawn tests
- controlled 100-largest-file comparison: savings improved from 89.7% to 93.7%, producing 39.1% less output than the previous compact default
