### PR TITLE
fix(err): don't re-split argv in err/test so exit codes survive

### DIFF
--- a/src/cmds/rust/runner.rs
+++ b/src/cmds/rust/runner.rs
@@ -114,32 +114,48 @@ fn build_shell_command(command: &str) -> Command {
     }
 }
 
-/// Run a command and filter output to show only errors/warnings
-pub fn run_err(command: &str, verbose: u8) -> Result<i32> {
-    if verbose > 0 {
-        eprintln!("Running: {}", command);
+// A single token is treated as a shell line so things like `make && make test`
+// still work. Anything already split into argv is run as-is, otherwise joining
+// it back and handing it to `sh -c` would re-split quoted args and swallow the
+// real exit code (same approach as proxy mode).
+fn build_command(argv: &[String]) -> Command {
+    if argv.len() == 1 {
+        build_shell_command(&argv[0])
+    } else {
+        let mut c = Command::new(&argv[0]);
+        c.args(&argv[1..]);
+        c
     }
-    let cmd = build_shell_command(command);
+}
+
+/// Run a command and filter output to show only errors/warnings
+pub fn run_err(command: &[String], verbose: u8) -> Result<i32> {
+    let display = command.join(" ");
+    if verbose > 0 {
+        eprintln!("Running: {}", display);
+    }
+    let cmd = build_command(command);
     crate::core::runner::run_streamed(
         cmd,
         "err",
-        command,
+        &display,
         Box::new(ErrorStreamFilter::new()),
         crate::core::runner::RunOptions::with_tee("err"),
     )
 }
 
 /// Run tests and show only failures
-pub fn run_test(command: &str, verbose: u8) -> Result<i32> {
+pub fn run_test(command: &[String], verbose: u8) -> Result<i32> {
+    let display = command.join(" ");
     if verbose > 0 {
-        eprintln!("Running tests: {}", command);
+        eprintln!("Running tests: {}", display);
     }
-    let cmd = build_shell_command(command);
-    let command_owned = command.to_string();
+    let cmd = build_command(command);
+    let command_owned = display.clone();
     crate::core::runner::run_filtered(
         cmd,
         "test",
-        command,
+        &display,
         move |raw| extract_test_summary(raw, &command_owned),
         crate::core::runner::RunOptions::with_tee("test"),
     )
@@ -289,5 +305,44 @@ mod tests {
         let filtered = filter_errors(output);
         assert!(filtered.contains("error"));
         assert!(!filtered.contains("info"));
+    }
+
+    fn argv(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn collect_args(cmd: &Command) -> Vec<String> {
+        cmd.get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn test_build_command_keeps_quoted_args() {
+        // `sh -c 'exit 7'` should reach sh as two args, not get re-split.
+        let cmd = build_command(&argv(&["sh", "-c", "exit 7"]));
+        assert_eq!(cmd.get_program().to_string_lossy(), "sh");
+        assert_eq!(collect_args(&cmd), vec!["-c", "exit 7"]);
+    }
+
+    #[test]
+    fn test_build_command_arg_with_spaces() {
+        let cmd = build_command(&argv(&["echo", "a b"]));
+        assert_eq!(cmd.get_program().to_string_lossy(), "echo");
+        assert_eq!(collect_args(&cmd), vec!["a b"]);
+    }
+
+    #[test]
+    fn test_build_command_single_token_uses_shell() {
+        let cmd = build_command(&argv(&["echo hi | grep hi"]));
+        let program = cmd.get_program().to_string_lossy().into_owned();
+        let args = collect_args(&cmd);
+        if cfg!(target_os = "windows") {
+            assert_eq!(program, "cmd");
+            assert_eq!(args, vec!["/C", "echo hi | grep hi"]);
+        } else {
+            assert_eq!(program, "sh");
+            assert_eq!(args, vec!["-c", "echo hi | grep hi"]);
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1668,13 +1668,21 @@ fn run_cli() -> Result<i32> {
         }
 
         Commands::Err { command } => {
-            let cmd = command.join(" ");
-            runner::run_err(&cmd, cli.verbose)?
+            if command.is_empty() {
+                anyhow::bail!(
+                    "err requires a command to execute\nUsage: rtk err <command> [args...]"
+                );
+            }
+            runner::run_err(&command, cli.verbose)?
         }
 
         Commands::Test { command } => {
-            let cmd = command.join(" ");
-            runner::run_test(&cmd, cli.verbose)?
+            if command.is_empty() {
+                anyhow::bail!(
+                    "test requires a command to execute\nUsage: rtk test <command> [args...]"
+                );
+            }
+            runner::run_test(&command, cli.verbose)?
         }
 
         Commands::Json {


### PR DESCRIPTION
## Summary

Fixes #2389. `rtk err` and `rtk test` corrupted quoted arguments and **masked the child command's exit code**, so a failing command could be reported as a success.

`rtk err sh -c 'exit 7'` returned `0` instead of `7`.

### Root cause

Both commands collect the child as a `Vec<String>` (`trailing_var_arg`), then joined it with spaces and ran it through a **second** `sh -c`. The join dropped the original quoting, so the inner shell re-split the arguments:

```
rtk err sh -c 'exit 7'   ->   sh -c "sh -c exit 7"
```

`exit` received `7` as a separate, ignored argument → exit code 0.

### Fix

New `build_command()` mirrors `rtk proxy` semantics:

- **single token** → still runs through the shell, so operators (`|`, `&&`, redirections) keep working (`rtk err 'make && make test'`);
- **multiple tokens** → executed verbatim with no re-shelling, preserving quoting and the real exit code.

`run_err`/`run_test` now take `&[String]`; the joined string is used only as the display/tracking label. Empty invocations now error with a usage message instead of running `sh -c ""` and exiting 0.

The identical bug in `rtk test` is fixed by the same change.

### Behavior change (intentional)

Passing shell operators as **separate unquoted tokens** (`rtk err cmd1 '|' cmd2`) is no longer interpreted by the shell. Use the single-string form (`rtk err 'cmd1 | cmd2'`) for shell operators — same rule as `rtk proxy`.

## Tests

- New unit tests on `build_command` (verbatim argv, whitespace-preserving args, single-token shell form).
- Verified end-to-end:
  - `rtk err sh -c 'exit 7'` → exit **7**
  - `rtk err sh -c 'echo "a b"; exit 3'` → `a b` intact, exit **3**
  - `rtk test sh -c 'exit 5'` → exit **5**
  - `rtk err 'echo hi | grep hi'` → pipe still works
  - `rtk err` (no args) → usage error, exit 1

Pre-commit gate (`cargo fmt --all && cargo clippy --all-targets && cargo test`) passes; clippy is clean. (3 unrelated `hooks::rewrite_cmd::unattestable_passthrough` tests fail on a clean `develop` checkout in this local environment — they read local permission config — and are untouched by this change.)
