### PR TITLE
fix(filter): don't treat /* inside strings as a block comment

### DIFF
--- a/src/core/filter.rs
+++ b/src/core/filter.rs
@@ -170,10 +170,13 @@ impl FilterStrategy for MinimalFilter {
         for line in content.lines() {
             let trimmed = line.trim();
 
-            // Handle block comments
+            // Handle block comments. Only treat a line as opening a block
+            // comment when it actually starts with the marker — using `contains`
+            // here would also match `/*` inside a string literal or a trailing
+            // comment and wrongly swallow the surrounding code.
             if let (Some(start), Some(end)) = (patterns.block_start, patterns.block_end) {
                 if !in_docstring
-                    && trimmed.contains(start)
+                    && trimmed.starts_with(start)
                     && !trimmed.starts_with(patterns.doc_block_start.unwrap_or("###"))
                 {
                     in_block_comment = true;
@@ -467,6 +470,38 @@ fn main() {
         let filter = MinimalFilter;
         let result = filter.filter(code, &Language::Rust);
         assert!(!result.contains("// This is a comment"));
+        assert!(result.contains("fn main()"));
+    }
+
+    #[test]
+    fn test_minimal_filter_keeps_code_with_block_comment_markers() {
+        // A `/*` inside a string or a trailing block comment must not make the
+        // filter drop the line (or everything after it). See #2385.
+        let code = r#"
+let pattern = "/* not a comment */";
+let re = "start /*";
+let x = 5; /* inline note */
+fn keep_me() {}
+"#;
+        let result = MinimalFilter.filter(code, &Language::Rust);
+        assert!(result.contains("let pattern"));
+        assert!(result.contains("let re"));
+        assert!(result.contains("let x = 5;"));
+        assert!(result.contains("fn keep_me()"));
+    }
+
+    #[test]
+    fn test_minimal_filter_still_strips_block_comments() {
+        let code = r#"
+/* a standalone comment */
+/*
+ * multi-line comment
+ */
+fn main() {}
+"#;
+        let result = MinimalFilter.filter(code, &Language::Rust);
+        assert!(!result.contains("standalone comment"));
+        assert!(!result.contains("multi-line comment"));
         assert!(result.contains("fn main()"));
     }
 


### PR DESCRIPTION
## Summary

Fixes #2385. The minimal code filter dropped real code lines that happened to contain `/*`.

`MinimalFilter` opened a block comment whenever a line **contained** `/*` (`trimmed.contains(start)`), so:

- a `/*` inside a string literal or a trailing comment dropped the whole line;
- if that line had no matching `*/`, every following line was dropped too until one showed up.

```rust
let re = "start /*";   // dropped
let x = 5;             // dropped (still "inside" the phantom comment)
```

### Fix

Match the opening marker with `starts_with` instead of `contains` — the same way line comments are already detected one block below. Only a line that actually *begins* with `/*` opens a block comment; doc blocks (`/**`) are still preserved, and genuine standalone/multi-line block comments are still stripped.

## Tests

- `test_minimal_filter_keeps_code_with_block_comment_markers` — code with `/*` in a string / trailing comment is preserved (fails on the old `contains` version, passes now).
- `test_minimal_filter_still_strips_block_comments` — standalone and multi-line block comments are still removed.

Verified end-to-end with the issue's reproduction:

```
$ rtk read example.rs --level minimal
const API: &str = "http://example.com/v1"; // endpoint
let re = "start /*";
let pattern = "/* not a comment */";
let x = 5; /* inline note */
fn foo() {}
```

(only the standalone `/* ... */` line is stripped; no code is lost).

Pre-commit gate (`cargo fmt --all && cargo clippy --all-targets && cargo test`) passes; clippy is clean.
