### PR TITLE
fix(aws): keep eks describe-cluster detail instead of one summary line

### DIFF
--- a/src/cmds/cloud/aws_cmd.rs
+++ b/src/cmds/cloud/aws_cmd.rs
@@ -1320,6 +1320,22 @@ fn filter_s3_objects(json_str: &str) -> Option<FilterResult> {
     })
 }
 
+// Join a JSON string array, capping at `cap`. Sets `dropped` when items are
+// hidden so the caller can flag the result for raw recovery.
+fn join_str_array(arr: &Value, cap: usize, dropped: &mut bool) -> Option<String> {
+    let items = arr.as_array()?;
+    if items.is_empty() {
+        return None;
+    }
+    let shown: Vec<&str> = items.iter().take(cap).filter_map(|x| x.as_str()).collect();
+    let mut s = shown.join(",");
+    if items.len() > cap {
+        *dropped = true;
+        s.push_str(&format!(" +{}", items.len() - cap));
+    }
+    Some(s)
+}
+
 fn filter_eks_cluster(json_str: &str) -> Option<FilterResult> {
     let v: Value = serde_json::from_str(json_str).ok()?;
     let cluster = &v["cluster"];
@@ -1328,10 +1344,130 @@ fn filter_eks_cluster(json_str: &str) -> Option<FilterResult> {
     let status = cluster["status"].as_str().unwrap_or("?");
     let version = cluster["version"].as_str().unwrap_or("?");
     let endpoint = cluster["endpoint"].as_str().unwrap_or("?");
-    // certificateAuthority intentionally NOT read (base64 cert, 1000+ chars)
 
-    let text = format!("{} {} k8s/{} {}", name, status, version, endpoint);
-    Some(FilterResult::new(text))
+    // describe-cluster is an inspection command: the detail IS the signal. Keep
+    // the one-line summary but also surface the config fields users actually run
+    // it to see, compactly. certificateAuthority holds a 1000+ char base64 blob,
+    // so we only note its presence instead of dumping it.
+    let mut out = vec![format!("{} {} k8s/{} {}", name, status, version, endpoint)];
+    let mut dropped = false;
+
+    if let Some(pv) = cluster["platformVersion"].as_str() {
+        out.push(format!("  platform: {}", pv));
+    }
+
+    let vpc = &cluster["resourcesVpcConfig"];
+    if vpc.is_object() {
+        let mut parts = Vec::new();
+        if let Some(subnets) = join_str_array(&vpc["subnetIds"], 8, &mut dropped) {
+            parts.push(format!("subnets={}", subnets));
+        }
+        if let Some(sgs) = join_str_array(&vpc["securityGroupIds"], 8, &mut dropped) {
+            parts.push(format!("sgs={}", sgs));
+        }
+        if let Some(public) = vpc["endpointPublicAccess"].as_bool() {
+            parts.push(format!("public={}", public));
+        }
+        if let Some(private) = vpc["endpointPrivateAccess"].as_bool() {
+            parts.push(format!("private={}", private));
+        }
+        if !parts.is_empty() {
+            out.push(format!("  vpc: {}", parts.join(" ")));
+        }
+    }
+
+    let net = &cluster["kubernetesNetworkConfig"];
+    if net.is_object() {
+        let mut parts = Vec::new();
+        if let Some(cidr) = net["serviceIpv4Cidr"].as_str() {
+            parts.push(format!("svcCidr={}", cidr));
+        }
+        if let Some(family) = net["ipFamily"].as_str() {
+            parts.push(format!("ipFamily={}", family));
+        }
+        if !parts.is_empty() {
+            out.push(format!("  network: {}", parts.join(" ")));
+        }
+    }
+
+    if let Some(setups) = cluster["logging"]["clusterLogging"].as_array() {
+        let mut enabled: Vec<String> = Vec::new();
+        for setup in setups {
+            if setup["enabled"].as_bool() == Some(true) {
+                if let Some(types) = setup["types"].as_array() {
+                    enabled.extend(types.iter().filter_map(|t| t.as_str().map(String::from)));
+                }
+            }
+        }
+        let value = if enabled.is_empty() {
+            "disabled".to_string()
+        } else {
+            enabled.join(",")
+        };
+        out.push(format!("  logging: {}", value));
+    }
+
+    if let Some(issuer) = cluster["identity"]["oidc"]["issuer"].as_str() {
+        out.push(format!("  oidc: {}", issuer));
+    }
+
+    if let Some(enc) = cluster["encryptionConfig"].as_array().and_then(|a| a.first()) {
+        let key = enc["provider"]["keyArn"].as_str().unwrap_or("?");
+        let resources = join_str_array(&enc["resources"], 4, &mut dropped).unwrap_or_default();
+        out.push(format!("  encryption: {} ({})", key, resources));
+    }
+
+    if let Some(mode) = cluster["accessConfig"]["authenticationMode"].as_str() {
+        out.push(format!("  access: {}", mode));
+    }
+
+    if cluster["certificateAuthority"]["data"].as_str().is_some() {
+        out.push("  ca: present".to_string());
+    }
+
+    if let Some(tags) = cluster["tags"].as_object() {
+        if !tags.is_empty() {
+            let mut pairs: Vec<String> = tags
+                .iter()
+                .take(MAX_ITEMS)
+                .map(|(k, val)| format!("{}={}", k, val.as_str().unwrap_or("?")))
+                .collect();
+            if tags.len() > MAX_ITEMS {
+                dropped = true;
+                pairs.push(format!("+{}", tags.len() - MAX_ITEMS));
+            }
+            out.push(format!("  tags: {}", pairs.join(" ")));
+        }
+    }
+
+    // Health issues are the field users most need when a cluster misbehaves.
+    if let Some(issues) = cluster["health"]["issues"].as_array() {
+        if issues.is_empty() {
+            out.push("  health: ok".to_string());
+        } else {
+            let summarized: Vec<String> = issues
+                .iter()
+                .take(MAX_ITEMS)
+                .map(|i| {
+                    let code = i["code"].as_str().unwrap_or("?");
+                    let msg = i["message"].as_str().unwrap_or("");
+                    format!("{}: {}", code, crate::core::utils::truncate(msg, 120))
+                })
+                .collect();
+            out.push(format!(
+                "  health: {} issue(s): {}",
+                issues.len(),
+                summarized.join("; ")
+            ));
+        }
+    }
+
+    let text = out.join("\n");
+    Some(if dropped {
+        FilterResult::truncated(text)
+    } else {
+        FilterResult::new(text)
+    })
 }
 
 lazy_static! {
@@ -2350,6 +2486,78 @@ mod tests {
         // certificateAuthority should NOT appear
         assert!(!result.text.contains("LS0tLS1CRUdJTi"));
         assert!(!result.text.contains("VERY_LONG"));
+        // but its presence is noted
+        assert!(result.text.contains("ca: present"));
+        assert!(result.text.contains("logging: api,audit"));
+        assert!(result.text.contains("platform: eks.5"));
+    }
+
+    #[test]
+    fn test_filter_eks_cluster_preserves_detail_fields() {
+        let json = r#"{
+            "cluster": {
+                "name": "prod",
+                "status": "ACTIVE",
+                "version": "1.29",
+                "endpoint": "https://EP.eks.amazonaws.com",
+                "resourcesVpcConfig": {
+                    "subnetIds": ["subnet-a", "subnet-b"],
+                    "securityGroupIds": ["sg-1"],
+                    "endpointPublicAccess": true,
+                    "endpointPrivateAccess": false
+                },
+                "kubernetesNetworkConfig": {"serviceIpv4Cidr": "10.100.0.0/16", "ipFamily": "ipv4"},
+                "logging": {"clusterLogging": [{"types": ["audit"], "enabled": false}]},
+                "identity": {"oidc": {"issuer": "https://oidc.eks.amazonaws.com/id/XYZ"}},
+                "encryptionConfig": [{"resources": ["secrets"], "provider": {"keyArn": "arn:aws:kms:us-east-1:1:key/abc"}}],
+                "accessConfig": {"authenticationMode": "API_AND_CONFIG_MAP"},
+                "tags": {"env": "prod"},
+                "health": {"issues": [{"code": "InsufficientNumberOfReplicas", "message": "control plane unhealthy"}]}
+            }
+        }"#;
+        let result = filter_eks_cluster(json).unwrap();
+        let t = &result.text;
+        assert!(t.contains("subnets=subnet-a,subnet-b"));
+        assert!(t.contains("sgs=sg-1"));
+        assert!(t.contains("public=true"));
+        assert!(t.contains("private=false"));
+        assert!(t.contains("svcCidr=10.100.0.0/16"));
+        assert!(t.contains("logging: disabled"));
+        assert!(t.contains("oidc: https://oidc.eks.amazonaws.com/id/XYZ"));
+        assert!(t.contains("encryption: arn:aws:kms:us-east-1:1:key/abc (secrets)"));
+        assert!(t.contains("access: API_AND_CONFIG_MAP"));
+        assert!(t.contains("tags: env=prod"));
+        assert!(t.contains("health: 1 issue(s): InsufficientNumberOfReplicas: control plane unhealthy"));
+    }
+
+    #[test]
+    fn test_filter_eks_cluster_savings_and_signal() {
+        let raw = include_str!("../../../tests/fixtures/aws_eks_describe_cluster.json");
+        let result = filter_eks_cluster(raw).unwrap();
+
+        // Key fields the issue asked for are preserved...
+        for needle in [
+            "production-cluster ACTIVE",
+            "vpc: subnets=",
+            "public=true",
+            "private=true",
+            "network: svcCidr=10.100.0.0/16",
+            "logging: api,audit,authenticator",
+            "oidc: https://oidc.eks",
+            "encryption: arn:aws:kms",
+            "access: API_AND_CONFIG_MAP",
+            "tags: env=production",
+            "health: ok",
+        ] {
+            assert!(result.text.contains(needle), "missing: {needle}");
+        }
+        // ...the base64 CA blob is not dumped...
+        assert!(!result.text.contains("LS0tLS1CRUdJTi"));
+
+        // ...and we still cut most of the tokens.
+        let count = |s: &str| s.split_whitespace().count();
+        let savings = 100.0 - (count(&result.text) as f64 / count(raw) as f64 * 100.0);
+        assert!(savings >= 60.0, "expected >=60% savings, got {savings:.1}%");
     }
 
     #[test]

--- a/tests/fixtures/aws_eks_describe_cluster.json
+++ b/tests/fixtures/aws_eks_describe_cluster.json
@@ -1,0 +1,81 @@
+{
+    "cluster": {
+        "name": "production-cluster",
+        "arn": "arn:aws:eks:us-east-1:123456789012:cluster/production-cluster",
+        "createdAt": "2024-01-15T10:30:00.000000+00:00",
+        "version": "1.28",
+        "endpoint": "https://ABCDEF1234567890.gr7.us-east-1.eks.amazonaws.com",
+        "roleArn": "arn:aws:iam::123456789012:role/eksClusterRole",
+        "resourcesVpcConfig": {
+            "subnetIds": [
+                "subnet-0a1b2c3d4e5f6071",
+                "subnet-1a2b3c4d5e6f7082",
+                "subnet-2a3b4c5d6e7f8093"
+            ],
+            "securityGroupIds": [
+                "sg-0a1b2c3d4e5f6071"
+            ],
+            "clusterSecurityGroupId": "sg-9z8y7x6w5v4u3t2s",
+            "vpcId": "vpc-0a1b2c3d4e5f6071",
+            "endpointPublicAccess": true,
+            "endpointPrivateAccess": true,
+            "publicAccessCidrs": [
+                "0.0.0.0/0"
+            ]
+        },
+        "kubernetesNetworkConfig": {
+            "serviceIpv4Cidr": "10.100.0.0/16",
+            "ipFamily": "ipv4"
+        },
+        "logging": {
+            "clusterLogging": [
+                {
+                    "types": [
+                        "api",
+                        "audit",
+                        "authenticator"
+                    ],
+                    "enabled": true
+                },
+                {
+                    "types": [
+                        "controllerManager",
+                        "scheduler"
+                    ],
+                    "enabled": false
+                }
+            ]
+        },
+        "identity": {
+            "oidc": {
+                "issuer": "https://oidc.eks.us-east-1.amazonaws.com/id/ABCDEF1234567890"
+            }
+        },
+        "status": "ACTIVE",
+        "certificateAuthority": {
+            "data": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmxjbTVsZEdWekxXTmhNQjRYRFRJME1ERXhOVEV3TXpBd01Gb1hEVE0wTURFeE1qRXdNekF3TUZvd0ZURVRNQkVHQTFVRUF4TUthM1ZpWlhKdVpYUmxjeTFqWVR0PQ=="
+        },
+        "platformVersion": "eks.5",
+        "tags": {
+            "env": "production",
+            "team": "platform",
+            "cost-center": "eng-1234"
+        },
+        "encryptionConfig": [
+            {
+                "resources": [
+                    "secrets"
+                ],
+                "provider": {
+                    "keyArn": "arn:aws:kms:us-east-1:123456789012:key/abcd1234-5678-90ab-cdef-1234567890ab"
+                }
+            }
+        ],
+        "accessConfig": {
+            "authenticationMode": "API_AND_CONFIG_MAP"
+        },
+        "health": {
+            "issues": []
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1466. `rtk aws eks describe-cluster` compressed the whole cluster response down to a single summary line (`name status k8s/version endpoint`) and silently dropped every other field. `describe-cluster` is an inspection command — the detail *is* the signal — so this made it unusable for debugging.

### Before

```
production-cluster ACTIVE k8s/1.28 https://ABCDEF1234567890.gr7.us-east-1.eks.amazonaws.com
```

### After

```
production-cluster ACTIVE k8s/1.28 https://ABCDEF1234567890.gr7.us-east-1.eks.amazonaws.com
  platform: eks.5
  vpc: subnets=subnet-0a1b2c3d4e5f6071,subnet-1a2b3c4d5e6f7082,subnet-2a3b4c5d6e7f8093 sgs=sg-0a1b2c3d4e5f6071 public=true private=true
  network: svcCidr=10.100.0.0/16 ipFamily=ipv4
  logging: api,audit,authenticator
  oidc: https://oidc.eks.us-east-1.amazonaws.com/id/ABCDEF1234567890
  encryption: arn:aws:kms:us-east-1:123456789012:key/abcd1234-5678-90ab-cdef-1234567890ab (secrets)
  access: API_AND_CONFIG_MAP
  ca: present
  tags: env=production team=platform cost-center=eng-1234
  health: ok
```

## What changed

`filter_eks_cluster` now keeps the summary line and appends the config fields the issue listed — VPC (subnets / security groups / endpoint access), Kubernetes networking, enabled log types, OIDC issuer, encryption (KMS key + resources), access mode, tags, and **health issues** (the field you most need when a cluster misbehaves) — one compact line each.

- The `certificateAuthority` base64 blob (1000+ chars) is still not dumped; its presence is noted as `ca: present`.
- Long subnet / security-group / tag lists are capped with a `+N` marker, and the result is flagged for raw-output recovery whenever anything is dropped (existing `FilterResult::truncated` mechanism).

## Tests

`src/cmds/cloud/aws_cmd.rs`:
- extended `test_filter_eks_cluster` (summary + `ca: present` + logging/platform),
- `test_filter_eks_cluster_preserves_detail_fields` — asserts every new field,
- `test_filter_eks_cluster_savings_and_signal` — runs a realistic 90-line fixture (`tests/fixtures/aws_eks_describe_cluster.json`), checks the signal is preserved, the CA blob is gone, and token savings stay ≥60%.

`cargo fmt --all && cargo clippy --all-targets && cargo test` — clippy clean, cloud module green (no regressions).
