### PR TITLE
fix: align OpenCode and OpenClaw TypeScript plugins with Pi contract

### DIFF
--- a/hooks/opencode/rtk.ts
+++ b/hooks/opencode/rtk.ts
@@ -1,5 +1,7 @@
 import type { Plugin } from "@opencode-ai/plugin"
 
+const MIN_SUPPORTED_RTK_MINOR = 23
+
 // RTK OpenCode plugin — rewrites commands to use rtk for token savings.
 // Requires: rtk >= 0.23.0 in PATH.
 //
@@ -8,32 +10,66 @@ import type { Plugin } from "@opencode-ai/plugin"
 // To add or change rewrite rules, edit the Rust registry — not this file.
 
 export const RtkOpenCodePlugin: Plugin = async ({ $ }) => {
-  try {
-    await $`which rtk`.quiet()
-  } catch {
-    console.warn("[rtk] rtk binary not found in PATH — plugin disabled")
-    return {}
-  }
+  if (!await probeRtk($)) return {}
 
   return {
     "tool.execute.before": async (input, output) => {
-      const tool = String(input?.tool ?? "").toLowerCase()
+      const tool = String((input as any)?.tool ?? "").toLowerCase()
       if (tool !== "bash" && tool !== "shell") return
+
       const args = output?.args
       if (!args || typeof args !== "object") return
 
       const command = (args as Record<string, unknown>).command
-      if (typeof command !== "string" || !command) return
+      if (typeof command !== "string" || !command.trim()) return
+      if (command.startsWith("rtk ")) return
+      if (process.env.RTK_DISABLED === "1") return
 
-      try {
-        const result = await $`rtk rewrite ${command}`.quiet().nothrow()
-        const rewritten = String(result.stdout).trim()
-        if (rewritten && rewritten !== command) {
-          ;(args as Record<string, unknown>).command = rewritten
-        }
-      } catch {
-        // rtk rewrite failed — pass through unchanged
+      const rewritten = await rewriteCommand($, command)
+      if (rewritten) {
+        ;(args as Record<string, unknown>).command = rewritten
       }
     },
   }
+}
+
+async function probeRtk($: any): Promise<boolean> {
+  try {
+    const result = await $`rtk --version`.quiet().nothrow()
+    if (result.exitCode !== 0) {
+      console.warn("[rtk] rtk binary not found in PATH — plugin disabled")
+      return false
+    }
+
+    const parsed = parseSemver(String(result.stdout).replace(/^rtk\s+/, ""))
+    if (!parsed) return true
+
+    const [major, minor] = parsed
+    if (major === 0 && minor < MIN_SUPPORTED_RTK_MINOR) {
+      console.warn(`[rtk] rtk ${String(result.stdout).trim()} is too old (need >= 0.23.0) — plugin disabled`)
+      return false
+    }
+
+    return true
+  } catch (err) {
+    console.warn("[rtk] rtk probe failed unexpectedly — plugin disabled", err)
+    return false
+  }
+}
+
+async function rewriteCommand($: any, command: string): Promise<string | null> {
+  const result = await $`rtk rewrite ${command}`
+    .quiet()
+    .nothrow()
+
+  if (result.exitCode !== 0 && result.exitCode !== 3) return null
+
+  const rewritten = String(result.stdout).trim()
+  return rewritten && rewritten !== command ? rewritten : null
+}
+
+function parseSemver(raw: string): [number, number, number] | null {
+  const m = raw.trim().match(/(\d+)\.(\d+)\.(\d+)/)
+  if (!m) return null
+  return [parseInt(m[1], 10), parseInt(m[2], 10), parseInt(m[3], 10)]
 }

--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -9,33 +9,50 @@
  * Rust registry, not this file.
  */
 
-import { execFileSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 
-let rtkAvailable: boolean | null = null;
+const MIN_SUPPORTED_RTK_MINOR = 23;
+const REWRITE_TIMEOUT_MS = 2_000;
 
-function checkRtk(): boolean {
-  if (rtkAvailable !== null) return rtkAvailable;
-  try {
-    execFileSync("which", ["rtk"], { stdio: "ignore" });
-    rtkAvailable = true;
-  } catch {
-    rtkAvailable = false;
+function parseSemver(raw: string): [number, number, number] | null {
+  const m = raw.trim().match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!m) return null;
+  return [parseInt(m[1], 10), parseInt(m[2], 10), parseInt(m[3], 10)];
+}
+
+function probeRtk(): boolean {
+  const result = spawnSync("rtk", ["--version"], {
+    encoding: "utf-8",
+    timeout: REWRITE_TIMEOUT_MS,
+  });
+  if (result.error) {
+    console.warn("[rtk] rtk probe failed unexpectedly — plugin disabled", result.error);
+    return false;
   }
-  return rtkAvailable;
+  if (result.status !== 0) {
+    console.warn("[rtk] rtk binary not found in PATH — plugin disabled");
+    return false;
+  }
+  const parsed = parseSemver((result.stdout ?? "").replace(/^rtk\s+/, ""));
+  if (!parsed) return true;
+  const [major, minor] = parsed;
+  if (major === 0 && minor < MIN_SUPPORTED_RTK_MINOR) {
+    console.warn(
+      `[rtk] rtk ${(result.stdout ?? "").trim()} is too old (need >= 0.23.0) — plugin disabled`
+    );
+    return false;
+  }
+  return true;
 }
 
 function tryRewrite(command: string): string | null {
-  try {
-    const result = execFileSync("rtk", ["rewrite", command], {
-      encoding: "utf-8",
-      timeout: 2000,
-    })
-      .toString()
-      .trim();
-    return result && result !== command ? result : null;
-  } catch {
-    return null;
-  }
+  const result = spawnSync("rtk", ["rewrite", command], {
+    encoding: "utf-8",
+    timeout: REWRITE_TIMEOUT_MS,
+  });
+  if (result.status !== 0 && result.status !== 3) return null;
+  const stdout = (result.stdout ?? "").trim();
+  return stdout && stdout !== command ? stdout : null;
 }
 
 export default function register(api: any) {
@@ -45,10 +62,7 @@ export default function register(api: any) {
 
   if (!enabled) return;
 
-  if (!checkRtk()) {
-    console.warn("[rtk] rtk binary not found in PATH — plugin disabled");
-    return;
-  }
+  if (!probeRtk()) return;
 
   api.on(
     "before_tool_call",
@@ -56,7 +70,9 @@ export default function register(api: any) {
       if (event.toolName !== "exec") return;
 
       const command = event.params?.command;
-      if (typeof command !== "string") return;
+      if (typeof command !== "string" || !command.trim()) return;
+      if (command.startsWith("rtk ")) return;
+      if (process.env.RTK_DISABLED === "1") return;
 
       const rewritten = tryRewrite(command);
       if (!rewritten) return;


### PR DESCRIPTION
## Summary

  Align the OpenCode and OpenClaw TypeScript plugins with the Pi rewrite contract.

  ## Changes

  - replace `which rtk` with `rtk --version`
  - enforce minimum supported version (`>= 0.23.0`)
  - respect `RTK_DISABLED=1`
  - skip commands already starting with `rtk `
  - only accept rewrites on exit code `0` or `3`
  - switch OpenClaw from `execFileSync` to `spawnSync` so exit code `3` is handled correctly
  - improve OpenClaw probe warnings for unexpected failures

  ## Why

  `which rtk` is a weaker probe here:
  - it depends on the runtime environment exposing `which`
  - it does not verify that the resolved `rtk` supports `rtk rewrite`
  - it does not let us enforce the minimum supported version

  `rtk --version` checks the actual binary we want to use and lets us validate compatibility in the same step.

## Test plan
I wrote and verified some unit tests locally, but left them out to keep things in line with the other TypeScript hooks. Can add them too if that makes sense.

- [X] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [X] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
