### PR TITLE
fix(grep): prevent silent fallback to system grep when rg flags precede pattern

### DIFF
--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -25,8 +25,15 @@ pub fn run(
         eprintln!("grep: '{}' in {}", pattern, path);
     }
 
-    // Fix: convert BRE alternation \| → | for rg (which uses PCRE-style regex)
-    let rg_pattern = pattern.replace(r"\|", "|");
+    let is_fixed_strings = extra_args.iter().any(|a| a == "--fixed-strings" || a == "-F");
+
+    // Convert BRE alternation \| → | for rg (which uses PCRE-style regex),
+    // but skip when --fixed-strings is active (pattern is literal).
+    let rg_pattern = if is_fixed_strings {
+        pattern.to_string()
+    } else {
+        pattern.replace(r"\|", "|")
+    };
 
     let mut rg_cmd = resolved_command("rg");
     // --no-ignore-vcs: match grep -r behavior (don't skip .gitignore'd files).
@@ -50,11 +57,34 @@ pub fn run(
         rg_cmd.arg(arg);
     }
 
+    let has_rg_only_flags = extra_args.iter().any(|a| {
+        a == "--pcre2" || a == "--glob" || a == "-g" || a.starts_with("--glob=")
+    });
+
     let result = exec_capture(&mut rg_cmd)
-        .or_else(|_| {
+        .or_else(|e| {
+            if has_rg_only_flags {
+                return Err(e);
+            }
+            eprintln!("rtk: rg not found, falling back to grep (install ripgrep for best results)");
             let mut grep_cmd = resolved_command("grep");
-            // When we fall back to grep, include all args, not just -rnHZ.
-            grep_cmd.args(["-rnHZ", pattern, path]).args(extra_args);
+            grep_cmd.args(["-rnHZ", pattern, path]);
+            for arg in extra_args {
+                match arg.as_str() {
+                    "--fixed-strings" => {
+                        grep_cmd.arg("-F");
+                    }
+                    "--word-regexp" => {
+                        grep_cmd.arg("-w");
+                    }
+                    "--ignore-case" => {
+                        grep_cmd.arg("-i");
+                    }
+                    _ => {
+                        grep_cmd.arg(arg);
+                    }
+                }
+            }
             exec_capture(&mut grep_cmd)
         })
         .context("grep/rg failed")?;
@@ -314,6 +344,32 @@ mod tests {
         assert_eq!(rg_pattern, "fn foo|pub.*bar");
     }
 
+    #[test]
+    fn test_bre_translation_skipped_for_fixed_strings() {
+        let pattern = r"foo\|bar";
+        let extra_args = vec!["--fixed-strings".to_string()];
+        let is_fixed = extra_args.iter().any(|a| a == "--fixed-strings" || a == "-F");
+        let rg_pattern = if is_fixed {
+            pattern.to_string()
+        } else {
+            pattern.replace(r"\|", "|")
+        };
+        assert_eq!(rg_pattern, r"foo\|bar", "fixed-strings must preserve literal pattern");
+    }
+
+    #[test]
+    fn test_bre_translation_skipped_for_fixed_strings_short() {
+        let pattern = r"foo\|bar";
+        let extra_args = vec!["-F".to_string()];
+        let is_fixed = extra_args.iter().any(|a| a == "--fixed-strings" || a == "-F");
+        let rg_pattern = if is_fixed {
+            pattern.to_string()
+        } else {
+            pattern.replace(r"\|", "|")
+        };
+        assert_eq!(rg_pattern, r"foo\|bar", "-F must preserve literal pattern");
+    }
+
     // Fix: -r flag (grep recursive) is stripped from extra_args (rg is recursive by default)
     #[test]
     fn test_recursive_flag_stripped() {
@@ -506,5 +562,57 @@ mod tests {
             );
         }
         // If rg is not installed, skip gracefully (test still passes)
+    }
+
+    // --- grep fallback flag translation ---
+
+    fn has_rg_only_flags(extra_args: &[String]) -> bool {
+        extra_args
+            .iter()
+            .any(|a| a == "--pcre2" || a == "--glob" || a == "-g" || a.starts_with("--glob="))
+    }
+
+    fn translate_args_for_grep(extra_args: &[String]) -> Vec<String> {
+        let mut grep_args: Vec<String> = Vec::new();
+        for arg in extra_args {
+            match arg.as_str() {
+                "--fixed-strings" => grep_args.push("-F".into()),
+                "--word-regexp" => grep_args.push("-w".into()),
+                "--ignore-case" => grep_args.push("-i".into()),
+                _ => grep_args.push(arg.clone()),
+            }
+        }
+        grep_args
+    }
+
+    #[test]
+    fn test_grep_fallback_blocked_by_pcre2() {
+        assert!(has_rg_only_flags(&["--pcre2".into(), "-w".into()]));
+    }
+
+    #[test]
+    fn test_grep_fallback_blocked_by_glob() {
+        assert!(has_rg_only_flags(&["--glob".into(), "*.rs".into()]));
+        assert!(has_rg_only_flags(&["-g".into(), "*.rs".into()]));
+        assert!(has_rg_only_flags(&["--glob=*.rs".into()]));
+    }
+
+    #[test]
+    fn test_grep_fallback_allowed_for_compatible_flags() {
+        assert!(!has_rg_only_flags(&["-w".into(), "-i".into()]));
+        assert!(!has_rg_only_flags(&["--fixed-strings".into()]));
+        assert!(!has_rg_only_flags(&["-A".into(), "3".into()]));
+    }
+
+    #[test]
+    fn test_grep_fallback_translates_long_flags() {
+        let args: Vec<String> = vec!["--fixed-strings".into(), "--word-regexp".into(), "--ignore-case".into()];
+        assert_eq!(translate_args_for_grep(&args), vec!["-F", "-w", "-i"]);
+    }
+
+    #[test]
+    fn test_grep_fallback_passes_short_flags_through() {
+        let args: Vec<String> = vec!["-w".into(), "-i".into(), "-F".into()];
+        assert_eq!(translate_args_for_grep(&args), vec!["-w", "-i", "-F"]);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -322,7 +322,22 @@ enum Commands {
         /// Show line numbers (always on, accepted for grep/rg compatibility)
         #[arg(short = 'n', long)]
         line_numbers: bool,
-        /// Extra ripgrep arguments (e.g., -i, -A 3, -w, --glob)
+        /// Whole-word match (passed to ripgrep)
+        #[arg(short = 'w', long = "word-regexp")]
+        word_regexp: bool,
+        /// Case-insensitive search (passed to ripgrep)
+        #[arg(short = 'i', long = "ignore-case")]
+        ignore_case: bool,
+        /// Fixed-string match (passed to ripgrep)
+        #[arg(short = 'F', long = "fixed-strings")]
+        fixed_strings: bool,
+        /// Enable PCRE2 regex engine
+        #[arg(long)]
+        pcre2: bool,
+        /// Filter by glob pattern (passed to ripgrep)
+        #[arg(short = 'g', long = "glob")]
+        glob: Vec<String>,
+        /// Extra ripgrep arguments (e.g., -A 3, --glob)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         extra_args: Vec<String>,
     },
@@ -1807,17 +1822,42 @@ fn run_cli() -> Result<i32> {
             context_only,
             file_type,
             line_numbers: _, // no-op: line numbers always enabled in grep_cmd::run
+            word_regexp,
+            ignore_case,
+            fixed_strings,
+            pcre2,
+            glob,
             extra_args,
-        } => grep_cmd::run(
-            &pattern,
-            &path,
-            max_len,
-            max,
-            context_only,
-            file_type.as_deref(),
-            &extra_args,
-            cli.verbose,
-        )?,
+        } => {
+            let mut all_extra: Vec<String> = Vec::new();
+            if word_regexp {
+                all_extra.push("-w".to_string());
+            }
+            if ignore_case {
+                all_extra.push("-i".to_string());
+            }
+            if fixed_strings {
+                all_extra.push("--fixed-strings".to_string());
+            }
+            if pcre2 {
+                all_extra.push("--pcre2".to_string());
+            }
+            for g in &glob {
+                all_extra.push("--glob".to_string());
+                all_extra.push(g.clone());
+            }
+            all_extra.extend(extra_args);
+            grep_cmd::run(
+                &pattern,
+                &path,
+                max_len,
+                max,
+                context_only,
+                file_type.as_deref(),
+                &all_extra,
+                cli.verbose,
+            )?
+        }
 
         Commands::Init {
             global,
@@ -3280,6 +3320,173 @@ mod tests {
                 assert!(global);
             }
             _ => panic!("Expected Init command"),
+        }
+    }
+
+    // --- #2120: grep flags before pattern must not trigger fallback ---
+
+    #[test]
+    fn test_grep_word_flag_before_pattern() {
+        let cli = Cli::try_parse_from(["rtk", "grep", "-w", "class", "./src"]).unwrap();
+        match cli.command {
+            Commands::Grep {
+                pattern,
+                path,
+                word_regexp,
+                ..
+            } => {
+                assert_eq!(pattern, "class");
+                assert_eq!(path, "./src");
+                assert!(word_regexp);
+            }
+            _ => panic!("Expected Grep command"),
+        }
+    }
+
+    #[test]
+    fn test_grep_ignore_case_before_pattern() {
+        let cli = Cli::try_parse_from(["rtk", "grep", "-i", "pattern", "."]).unwrap();
+        match cli.command {
+            Commands::Grep {
+                pattern,
+                ignore_case,
+                ..
+            } => {
+                assert_eq!(pattern, "pattern");
+                assert!(ignore_case);
+            }
+            _ => panic!("Expected Grep command"),
+        }
+    }
+
+    #[test]
+    fn test_grep_pcre2_before_pattern() {
+        let cli =
+            Cli::try_parse_from(["rtk", "grep", "--pcre2", "(?<=fn )\\w+", "."]).unwrap();
+        match cli.command {
+            Commands::Grep {
+                pattern, pcre2, ..
+            } => {
+                assert_eq!(pattern, "(?<=fn )\\w+");
+                assert!(pcre2);
+            }
+            _ => panic!("Expected Grep command"),
+        }
+    }
+
+    #[test]
+    fn test_grep_fixed_strings_before_pattern() {
+        let cli =
+            Cli::try_parse_from(["rtk", "grep", "--fixed-strings", "fn run(", "."]).unwrap();
+        match cli.command {
+            Commands::Grep {
+                pattern,
+                fixed_strings,
+                ..
+            } => {
+                assert_eq!(pattern, "fn run(");
+                assert!(fixed_strings);
+            }
+            _ => panic!("Expected Grep command"),
+        }
+    }
+
+    #[test]
+    fn test_grep_glob_before_pattern() {
+        let cli =
+            Cli::try_parse_from(["rtk", "grep", "-g", "*.rs", "fn main", "."]).unwrap();
+        match cli.command {
+            Commands::Grep {
+                pattern,
+                path,
+                glob,
+                ..
+            } => {
+                assert_eq!(pattern, "fn main");
+                assert_eq!(path, ".");
+                assert_eq!(glob, vec!["*.rs"]);
+            }
+            _ => panic!("Expected Grep command"),
+        }
+    }
+
+    #[test]
+    fn test_grep_multiple_flags_before_pattern() {
+        let cli =
+            Cli::try_parse_from(["rtk", "grep", "-w", "-i", "class", "./src"]).unwrap();
+        match cli.command {
+            Commands::Grep {
+                pattern,
+                path,
+                word_regexp,
+                ignore_case,
+                ..
+            } => {
+                assert_eq!(pattern, "class");
+                assert_eq!(path, "./src");
+                assert!(word_regexp);
+                assert!(ignore_case);
+            }
+            _ => panic!("Expected Grep command"),
+        }
+    }
+
+    #[test]
+    fn test_grep_flags_after_pattern_still_works() {
+        let cli =
+            Cli::try_parse_from(["rtk", "grep", "class", "./src", "-w", "--pcre2"]).unwrap();
+        match cli.command {
+            Commands::Grep {
+                pattern,
+                path,
+                word_regexp,
+                pcre2,
+                ..
+            } => {
+                assert_eq!(pattern, "class");
+                assert_eq!(path, "./src");
+                assert!(word_regexp);
+                assert!(pcre2);
+            }
+            _ => panic!("Expected Grep command"),
+        }
+    }
+
+    #[test]
+    fn test_grep_combined_short_flags() {
+        let cli = Cli::try_parse_from(["rtk", "grep", "-wi", "class", "./src"]).unwrap();
+        match cli.command {
+            Commands::Grep {
+                pattern,
+                path,
+                word_regexp,
+                ignore_case,
+                ..
+            } => {
+                assert_eq!(pattern, "class");
+                assert_eq!(path, "./src");
+                assert!(word_regexp);
+                assert!(ignore_case);
+            }
+            _ => panic!("Expected Grep command"),
+        }
+    }
+
+    #[test]
+    fn test_grep_flags_with_default_path() {
+        let cli = Cli::try_parse_from(["rtk", "grep", "-w", "class"]).unwrap();
+        match cli.command {
+            Commands::Grep {
+                pattern,
+                path,
+                word_regexp,
+                ..
+            } => {
+                assert_eq!(pattern, "class");
+                assert_eq!(path, ".");
+                assert!(word_regexp);
+            }
+            _ => panic!("Expected Grep command"),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add explicit clap definitions for commonly-used ripgrep flags (`-w`, `-i`, `-F`/`--fixed-strings`, `--pcre2`, `-g`/`--glob`) so they parse correctly regardless of position relative to the pattern argument, preventing clap rejection and silent fallback to system grep.
- Skip BRE `\|` to `|` translation when `--fixed-strings` is active (pattern should be literal).
- Block grep fallback when rg-only flags are present (`--pcre2`, `--glob`), letting the error propagate so the LLM knows rg is missing rather than silently getting wrong results.
- Translate long-form flags to grep-compatible short forms when fallback does activate.
- Emit a stderr warning when the grep fallback fires.

## Problem

When AI coding assistants invoke `rg -w "class" .`, the hook rewrites it to `rtk grep -w "class" .`. Clap did not recognize `-w`/`-i`/`-F`/`--pcre2`/`-g` and treated them as parse errors, triggering `run_fallback()` which silently executed system grep instead of ripgrep. The LLM believed it was calling ripgrep (with its output format, flag semantics, and default recursion) but received GNU grep output instead, causing confusion and incorrect conclusions.

## Related Issues

- Fixes #2120 - `rtk grep` falls back to native grep when `--fixed-strings` is placed before pattern/path
- Fixes #2167 - `rtk grep` calls system grep instead of ripgrep, breaks `-g`/`--glob` flags
- Partially addresses #2064 - grep fallback causes token expansion via system grep descending node_modules (this PR prevents the fallback from triggering for the common case of flags-before-pattern)

## Test plan

- [x] 9 new unit tests covering flag parsing (single flags, combined `-wi`, default path, flags after pattern)
- [x] 5 new unit tests covering grep fallback behavior (blocked by rg-only flags, allowed for compatible flags, long-form translation)
- [x] 2 new unit tests for BRE translation skip with `--fixed-strings`/`-F`
- [x] Full test suite passes (2166 tests)
- [x] Manual testing: `rtk grep -w "class" .`, `rtk grep --pcre2 "(?<=fn )\w+" .`, `rtk grep -g "*.rs" "fn run" .`, `rtk grep --fixed-strings "fn run(" .`