### PR TITLE
Add support for MiMoCode (Xiaomi opencode fork)

### DIFF
--- a/hooks/mimocode/README.md
+++ b/hooks/mimocode/README.md
@@ -1,0 +1,11 @@
+# MiMoCode Hooks
+
+> Part of [`hooks/`](../README.md) — see also [`src/hooks/`](../../src/hooks/README.md) for installation code
+
+## Specifics
+
+- TypeScript plugin using the zx library (not a shell hook)
+- Intercepts `tool.execute.before` events, calls `rtk rewrite` as a subprocess
+- Uses `.quiet().nothrow()` to silently ignore failures
+- Mutates `args.command` in-place if rewrite differs from original
+- Installed to `~/.config/mimocode/plugins/rtk.ts` by `rtk init --agent mimocode`

--- a/hooks/mimocode/rtk.ts
+++ b/hooks/mimocode/rtk.ts
@@ -1,0 +1,39 @@
+import type { Plugin } from "@mimo-ai/plugin"
+
+// RTK MiMoCode plugin — rewrites commands to use rtk for token savings.
+// Requires: rtk >= 0.23.0 in PATH.
+//
+// This is a thin delegating plugin: all rewrite logic lives in `rtk rewrite`,
+// which is the single source of truth (src/discover/registry.rs).
+// To add or change rewrite rules, edit the Rust registry — not this file.
+
+export const RtkMiMoCodePlugin: Plugin = async ({ $ }) => {
+  try {
+    await $`which rtk`.quiet()
+  } catch {
+    console.warn("[rtk] rtk binary not found in PATH — plugin disabled")
+    return {}
+  }
+
+  return {
+    "tool.execute.before": async (input, output) => {
+      const tool = String(input?.tool ?? "").toLowerCase()
+      if (tool !== "bash" && tool !== "shell") return
+      const args = output?.args
+      if (!args || typeof args !== "object") return
+
+      const command = (args as Record<string, unknown>).command
+      if (typeof command !== "string" || !command) return
+
+      try {
+        const result = await $`rtk rewrite ${command}`.quiet().nothrow()
+        const rewritten = String(result.stdout).trim()
+        if (rewritten && rewritten !== command) {
+          ;(args as Record<string, unknown>).command = rewritten
+        }
+      } catch {
+        // rtk rewrite failed — pass through unchanged
+      }
+    },
+  }
+}

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -39,3 +39,7 @@ pub const HERMES_PLUGINS_SUBDIR: &str = "plugins";
 pub const HERMES_PLUGIN_NAME: &str = "rtk-rewrite";
 pub const HERMES_PLUGIN_INIT_FILE: &str = "__init__.py";
 pub const HERMES_PLUGIN_MANIFEST_FILE: &str = "plugin.yaml";
+
+pub const MIMOCODE_SUBDIR: &str = "mimocode";
+pub const MIMOCODE_PLUGIN_FILE: &str = "rtk.ts";
+pub const MIMOCODE_HOME_ENV: &str = "MIMOCODE_HOME";

--- a/src/hooks/hook_check.rs
+++ b/src/hooks/hook_check.rs
@@ -153,7 +153,8 @@ mod tests {
     use crate::hooks::constants::{
         CODEX_DIR, CONFIG_DIR, CURSOR_DIR, GEMINI_DIR, GEMINI_HOOK_FILE, HERMES_DIR,
         HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME,
-        OPENCODE_PLUGIN_FILE, OPENCODE_SUBDIR, PLUGIN_SUBDIR,
+        MIMOCODE_PLUGIN_FILE, MIMOCODE_SUBDIR, OPENCODE_PLUGIN_FILE, OPENCODE_SUBDIR,
+        PLUGIN_SUBDIR,
     };
 
     fn other_integration_installed(home: &std::path::Path) -> bool {
@@ -162,6 +163,10 @@ mod tests {
                 .join(OPENCODE_SUBDIR)
                 .join(PLUGIN_SUBDIR)
                 .join(OPENCODE_PLUGIN_FILE),
+            home.join(CONFIG_DIR)
+                .join(MIMOCODE_SUBDIR)
+                .join(PLUGIN_SUBDIR)
+                .join(MIMOCODE_PLUGIN_FILE),
             home.join(CURSOR_DIR)
                 .join(HOOKS_SUBDIR)
                 .join(REWRITE_HOOK_FILE),

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -9,7 +9,8 @@ use tempfile::NamedTempFile;
 
 use crate::hooks::constants::{
     CONFIG_DIR, COPILOT_HOME_ENV, COPILOT_HOOK_FILE, COPILOT_INSTRUCTIONS_FILE, COPILOT_USER_DIR,
-    CURSOR_DIR, GEMINI_DIR, GITHUB_DIR, OPENCODE_PLUGIN_FILE, OPENCODE_SUBDIR, PLUGIN_SUBDIR,
+    CURSOR_DIR, GEMINI_DIR, GITHUB_DIR, MIMOCODE_HOME_ENV, MIMOCODE_PLUGIN_FILE, MIMOCODE_SUBDIR,
+    OPENCODE_PLUGIN_FILE, OPENCODE_SUBDIR, PLUGIN_SUBDIR,
 };
 
 use super::constants::{
@@ -23,6 +24,9 @@ use super::integrity;
 
 // Embedded OpenCode plugin (auto-rewrite)
 const OPENCODE_PLUGIN: &str = include_str!("../../hooks/opencode/rtk.ts");
+
+// Embedded MiMoCode plugin (auto-rewrite, opencode fork by Xiaomi)
+const MIMOCODE_PLUGIN: &str = include_str!("../../hooks/mimocode/rtk.ts");
 
 // Embedded Pi extension (auto-rewrite)
 const PI_PLUGIN: &str = include_str!("../../hooks/pi/rtk.ts");
@@ -2974,6 +2978,135 @@ fn remove_opencode_plugin(ctx: InitContext) -> Result<Vec<PathBuf>> {
     }
 
     Ok(removed)
+}
+
+// ─── MiMoCode support (Xiaomi opencode fork) ──────────────────────────
+
+/// Resolve MiMoCode config directory, honouring `MIMOCODE_HOME` override.
+/// Default: `~/.config/mimocode/`
+fn resolve_mimocode_dir() -> Result<PathBuf> {
+    if let Ok(dir) = std::env::var(MIMOCODE_HOME_ENV) {
+        if !dir.is_empty() {
+            return Ok(PathBuf::from(dir));
+        }
+    }
+    resolve_home_subdir(CONFIG_DIR).map(|p| p.join(MIMOCODE_SUBDIR))
+}
+
+/// Return MiMoCode plugin path: ~/.config/mimocode/plugins/rtk.ts
+fn mimocode_plugin_path(mimocode_dir: &Path) -> PathBuf {
+    mimocode_dir.join(PLUGIN_SUBDIR).join(MIMOCODE_PLUGIN_FILE)
+}
+
+/// Write MiMoCode plugin file if missing or outdated
+fn ensure_mimocode_plugin_installed(path: &Path, ctx: InitContext) -> Result<bool> {
+    let InitContext { dry_run, .. } = ctx;
+    if !dry_run {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "Failed to create MiMoCode plugin directory: {}",
+                    parent.display()
+                )
+            })?;
+        }
+    }
+    write_if_changed(path, MIMOCODE_PLUGIN, "MiMoCode plugin", ctx)
+}
+
+/// Remove MiMoCode plugin file
+fn remove_mimocode_plugin(ctx: InitContext) -> Result<Vec<PathBuf>> {
+    let InitContext { verbose, dry_run } = ctx;
+    let mimocode_dir = resolve_mimocode_dir()?;
+    let path = mimocode_plugin_path(&mimocode_dir);
+    let mut removed = Vec::new();
+
+    if path.exists() {
+        if dry_run {
+            println!("[dry-run] would remove MiMoCode plugin: {}", path.display());
+        } else {
+            fs::remove_file(&path)
+                .with_context(|| format!("Failed to remove MiMoCode plugin: {}", path.display()))?;
+            if verbose > 0 {
+                eprintln!("Removed MiMoCode plugin: {}", path.display());
+            }
+        }
+        removed.push(path);
+    }
+
+    Ok(removed)
+}
+
+/// Uninstall MiMoCode extension for the given scope.
+pub fn uninstall_mimocode(_global: bool, ctx: InitContext) -> Result<()> {
+    let InitContext {
+        verbose: _,
+        dry_run,
+    } = ctx;
+    let removed = remove_mimocode_plugin(ctx)?;
+
+    if dry_run {
+        print_dry_run_footer();
+    } else if !removed.is_empty() {
+        println!("RTK uninstalled (MiMoCode):");
+        for item in &removed {
+            println!("  - {}", item.display());
+        }
+        println!("\nRestart MiMoCode to apply changes.");
+    } else {
+        println!("RTK MiMoCode plugin was not installed (nothing to remove)");
+    }
+    Ok(())
+}
+
+/// Install the MiMoCode plugin (hook-only; no AGENTS.md injection).
+///
+/// global=true  → `$MIMOCODE_HOME/plugins/rtk.ts` or `~/.config/mimocode/plugins/rtk.ts`
+/// global=false → `~/.config/mimocode/plugins/rtk.ts` (MiMoCode is global-only)
+pub fn run_mimocode_mode(global: bool, ctx: InitContext) -> Result<()> {
+    let InitContext {
+        verbose: _,
+        dry_run,
+    } = ctx;
+
+    let mimocode_dir = resolve_mimocode_dir()?;
+    let plugin_path = mimocode_plugin_path(&mimocode_dir);
+
+    if !dry_run {
+        if let Some(parent) = plugin_path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "Failed to create MiMoCode plugin directory: {}",
+                    parent.display()
+                )
+            })?;
+        }
+    }
+
+    let installed = ensure_mimocode_plugin_installed(&plugin_path, ctx)?;
+
+    if dry_run {
+        print_dry_run_footer();
+    } else {
+        let status = if installed {
+            "installed"
+        } else {
+            "already up to date"
+        };
+        println!("RTK MiMoCode plugin {}:", status);
+        println!("  Plugin: {}", plugin_path.display());
+        println!();
+        println!("Restart MiMoCode to activate. Test with: git status");
+        if !global {
+            println!();
+            println!(
+                "Note: MiMoCode plugin is installed globally at {}",
+                plugin_path.display()
+            );
+        }
+    }
+
+    Ok(())
 }
 
 // ─── Cursor Agent support ─────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,8 @@ pub enum AgentTarget {
     Pi,
     /// Hermes CLI
     Hermes,
+    /// MiMoCode (Xiaomi opencode fork)
+    Mimocode,
 }
 
 #[derive(Parser)]
@@ -336,6 +338,10 @@ enum Commands {
         /// Install OpenCode plugin (in addition to Claude Code)
         #[arg(long)]
         opencode: bool,
+
+        /// Install MiMoCode plugin (Xiaomi opencode fork)
+        #[arg(long)]
+        mimocode: bool,
 
         /// Initialize for Gemini CLI instead of Claude Code
         #[arg(long)]
@@ -1385,21 +1391,26 @@ fn main() {
     std::process::exit(code);
 }
 
-fn uninstall_init_dispatch<UninstallHermes, UninstallStandard>(
+#[allow(clippy::too_many_arguments)]
+fn uninstall_init_dispatch<UninstallHermes, UninstallMimocode, UninstallStandard>(
     agent: Option<AgentTarget>,
     global: bool,
     gemini: bool,
     codex: bool,
     ctx: hooks::init::InitContext,
     uninstall_hermes: UninstallHermes,
+    uninstall_mimocode: UninstallMimocode,
     uninstall_standard: UninstallStandard,
 ) -> Result<()>
 where
     UninstallHermes: FnOnce(hooks::init::InitContext) -> Result<()>,
+    UninstallMimocode: FnOnce(bool, hooks::init::InitContext) -> Result<()>,
     UninstallStandard: FnOnce(bool, bool, bool, bool, bool, hooks::init::InitContext) -> Result<()>,
 {
     if agent == Some(AgentTarget::Hermes) {
         uninstall_hermes(ctx)
+    } else if agent == Some(AgentTarget::Mimocode) {
+        uninstall_mimocode(global, ctx)
     } else {
         let cursor = agent == Some(AgentTarget::Cursor);
         let pi = agent == Some(AgentTarget::Pi);
@@ -1822,6 +1833,7 @@ fn run_cli() -> Result<i32> {
         Commands::Init {
             global,
             opencode,
+            mimocode,
             gemini,
             agent,
             show,
@@ -1854,6 +1866,7 @@ fn run_cli() -> Result<i32> {
                     codex,
                     ctx,
                     hooks::init::uninstall_hermes,
+                    hooks::init::uninstall_mimocode,
                     hooks::init::uninstall,
                 )?;
             } else if gemini {
@@ -1887,6 +1900,8 @@ fn run_cli() -> Result<i32> {
                 hooks::init::run_antigravity_mode(ctx)?;
             } else if agent == Some(AgentTarget::Hermes) {
                 hooks::init::run_hermes_mode(ctx)?;
+            } else if mimocode || agent == Some(AgentTarget::Mimocode) {
+                hooks::init::run_mimocode_mode(global, ctx)?;
             } else {
                 let install_opencode = opencode;
                 let install_claude = !opencode;
@@ -2722,6 +2737,7 @@ mod tests {
     #[test]
     fn test_init_uninstall_dispatch_routes_hermes_to_hermes_cleanup() {
         let hermes_called = Cell::new(false);
+        let mimocode_called = Cell::new(false);
         let standard_called = Cell::new(false);
         let ctx = hooks::init::InitContext {
             verbose: 2,
@@ -2740,6 +2756,10 @@ mod tests {
                 assert!(ctx.dry_run);
                 Ok(())
             },
+            |_, _| {
+                mimocode_called.set(true);
+                Ok(())
+            },
             |_, _, _, _, _, _| {
                 standard_called.set(true);
                 Ok(())
@@ -2748,6 +2768,67 @@ mod tests {
 
         assert!(result.is_ok());
         assert!(hermes_called.get());
+        assert!(!mimocode_called.get());
+        assert!(!standard_called.get());
+    }
+
+    #[test]
+    fn test_try_parse_init_agent_mimocode() {
+        let cli = Cli::try_parse_from(["rtk", "init", "--agent", "mimocode"]).unwrap();
+        match cli.command {
+            Commands::Init { agent, .. } => {
+                assert_eq!(agent, Some(AgentTarget::Mimocode));
+            }
+            _ => panic!("Expected Init command"),
+        }
+    }
+
+    #[test]
+    fn test_try_parse_init_mimocode_flag() {
+        let cli = Cli::try_parse_from(["rtk", "init", "--mimocode"]).unwrap();
+        match cli.command {
+            Commands::Init { mimocode, .. } => {
+                assert!(mimocode);
+            }
+            _ => panic!("Expected Init command"),
+        }
+    }
+
+    #[test]
+    fn test_init_uninstall_dispatch_routes_mimocode() {
+        let hermes_called = Cell::new(false);
+        let mimocode_called = Cell::new(false);
+        let standard_called = Cell::new(false);
+        let ctx = hooks::init::InitContext {
+            verbose: 1,
+            dry_run: false,
+        };
+
+        let result = uninstall_init_dispatch(
+            Some(AgentTarget::Mimocode),
+            true,
+            false,
+            false,
+            ctx,
+            |_| {
+                hermes_called.set(true);
+                Ok(())
+            },
+            |global, ctx| {
+                mimocode_called.set(true);
+                assert!(global);
+                assert_eq!(ctx.verbose, 1);
+                Ok(())
+            },
+            |_, _, _, _, _, _| {
+                standard_called.set(true);
+                Ok(())
+            },
+        );
+
+        assert!(result.is_ok());
+        assert!(!hermes_called.get());
+        assert!(mimocode_called.get());
         assert!(!standard_called.get());
     }
 


### PR DESCRIPTION
close #2380

MiMoCode is an open-source AI coding agent built as a fork of OpenCode. This adds plugin-based integration using the same tool.execute.before hook pattern as OpenCode, installing to ~/.config/mimocode/plugins/rtk.ts.

Usage:
  rtk init --mimocode
  rtk init --agent mimocode
  rtk init --agent mimocode --uninstall

## Summary

Add support for mimocode

## Test plan
<!-- How did you verify this works? -->

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
