### PR TITLE
feat(jvm): add Apache Ant support with compact output filter

### DIFF
--- a/src/cmds/jvm/ant_cmd.rs
+++ b/src/cmds/jvm/ant_cmd.rs
@@ -1,0 +1,280 @@
+//! Filters Apache Ant (`ant`) command output — strips target chatter, task
+//! announcements, and buildfile location noise while preserving compile errors,
+//! BUILD SUCCESSFUL/FAILED, and the total-time summary.
+
+use crate::core::runner;
+use crate::core::utils::{exit_code_from_output, resolved_build_command, strip_ansi, truncate};
+use anyhow::{Context, Result};
+use lazy_static::lazy_static;
+use regex::Regex;
+use std::ffi::OsString;
+
+/// Native Ant targets that rtk filters directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AntCommand {
+    Build,
+    Clean,
+    Test,
+    Compile,
+    Package,
+    Install,
+}
+
+impl AntCommand {
+    fn target(self) -> &'static str {
+        match self {
+            AntCommand::Build => "build",
+            AntCommand::Clean => "clean",
+            AntCommand::Test => "test",
+            AntCommand::Compile => "compile",
+            AntCommand::Package => "package",
+            AntCommand::Install => "install",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            AntCommand::Build => "ant build",
+            AntCommand::Clean => "ant clean",
+            AntCommand::Test => "ant test",
+            AntCommand::Compile => "ant compile",
+            AntCommand::Package => "ant package",
+            AntCommand::Install => "ant install",
+        }
+    }
+
+    fn tee_label(self) -> &'static str {
+        match self {
+            AntCommand::Build => "ant_build",
+            AntCommand::Clean => "ant_clean",
+            AntCommand::Test => "ant_test",
+            AntCommand::Compile => "ant_compile",
+            AntCommand::Package => "ant_package",
+            AntCommand::Install => "ant_install",
+        }
+    }
+}
+
+lazy_static! {
+    // Lines we always preserve regardless of other rules.
+    static ref RE_KEEP_BUILD_RESULT: Regex =
+        Regex::new(r"^BUILD (SUCCESSFUL|FAILED)").unwrap();
+    static ref RE_KEEP_ERROR: Regex =
+        Regex::new(r"(?i)error:").unwrap();
+    static ref RE_KEEP_FAILED: Regex =
+        Regex::new(r"(?i)failed:?").unwrap();
+    static ref RE_KEEP_TOTAL_TIME: Regex =
+        Regex::new(r"^Total time:").unwrap();
+    // [javac] lines with file:line compile errors, e.g. "/path/Foo.java:42: error:"
+    static ref RE_KEEP_JAVAC_ERROR: Regex =
+        Regex::new(r"^\s+\[javac\].*:\d+").unwrap();
+
+    // Lines we strip (noise).
+    static ref RE_STRIP_BUILDFILE: Regex =
+        Regex::new(r"^Buildfile:").unwrap();
+    // Lowercase target labels: "compile:", "init:", etc.
+    static ref RE_STRIP_TARGET: Regex =
+        Regex::new(r"^[a-z][a-zA-Z0-9_-]+:$").unwrap();
+    // Generic harmless task chatter (echo, delete, mkdir, copy, move, etc.).
+    static ref RE_STRIP_TASK_CHATTER: Regex =
+        Regex::new(r"^\s+\[(echo|delete|mkdir|copy|move|propertyfile|fixcrlf)\]").unwrap();
+    // [javac] informational chatter only — never strip lines that contain
+    // diagnostic context (source snippets, carets, symbol/location, error count
+    // summaries). Stripping all `[javac]` lines drops the user-actionable
+    // continuation lines that follow a `file:line: error:` header.
+    static ref RE_STRIP_JAVAC_INFO: Regex =
+        Regex::new(r"^\s+\[javac\]\s+(?:Compiling\b|Note:|Compiled\b|warning:\s*\[options\])").unwrap();
+}
+
+/// Execute a known ant target with compact filtering.
+pub fn run(cmd: AntCommand, args: &[String], verbose: u8) -> Result<i32> {
+    let mut command = resolved_build_command("ant");
+    command.arg(cmd.target());
+    for arg in args {
+        command.arg(arg);
+    }
+
+    if verbose > 0 {
+        eprintln!("Running: {} {}", cmd.label(), args.join(" "));
+    }
+
+    let tee = cmd.tee_label();
+    let filter: fn(&str) -> String = match cmd {
+        AntCommand::Test => |raw| filter_ant_test(&strip_ansi(raw)),
+        _ => |raw| filter_ant_build(&strip_ansi(raw)),
+    };
+    let filter = move |raw: &str| filter(raw);
+
+    runner::run_filtered(
+        command,
+        cmd.label(),
+        &args.join(" "),
+        filter,
+        runner::RunOptions::with_tee(tee),
+    )
+}
+
+/// Passthrough for any `ant` invocation rtk doesn't specialise.
+pub fn run_passthrough(args: &[OsString], verbose: u8) -> Result<i32> {
+    if args.is_empty() {
+        anyhow::bail!("ant: no target specified");
+    }
+
+    let mut command = resolved_build_command("ant");
+    for arg in args {
+        command.arg(arg);
+    }
+
+    if verbose > 0 {
+        let joined = args
+            .iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect::<Vec<_>>()
+            .join(" ");
+        eprintln!("Running: ant {}", joined);
+    }
+
+    let output = command.output().context("Failed to run ant")?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let raw = format!("{}\n{}", stdout, stderr);
+
+    let filtered = filter_ant_build(&strip_ansi(&raw));
+    println!("{}", filtered);
+
+    Ok(exit_code_from_output(&output, "ant"))
+}
+
+/// Build/compile/clean/package/install filter — strips target announcements and
+/// task chatter, keeps errors and BUILD banner.
+pub fn filter_ant_build(output: &str) -> String {
+    let mut kept: Vec<String> = Vec::new();
+
+    for line in output.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        // Always preserve these.
+        if RE_KEEP_BUILD_RESULT.is_match(line)
+            || RE_KEEP_TOTAL_TIME.is_match(line)
+            || RE_KEEP_JAVAC_ERROR.is_match(line)
+            || RE_KEEP_ERROR.is_match(line)
+            || RE_KEEP_FAILED.is_match(line)
+        {
+            kept.push(truncate(line.trim_end(), 240).to_string());
+            continue;
+        }
+
+        // Strip these patterns.
+        if RE_STRIP_BUILDFILE.is_match(line)
+            || RE_STRIP_TARGET.is_match(line)
+            || RE_STRIP_TASK_CHATTER.is_match(line)
+            || RE_STRIP_JAVAC_INFO.is_match(line)
+        {
+            continue;
+        }
+
+        kept.push(truncate(line.trim_end(), 240).to_string());
+    }
+
+    if kept.is_empty() {
+        return "ant: ok".to_string();
+    }
+
+    kept.join("\n")
+}
+
+/// Test filter — same as build filter (Ant test output structure is similar).
+pub fn filter_ant_test(output: &str) -> String {
+    filter_ant_build(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_successful_build_collapses_chatter_keeps_banner() {
+        let output = "\
+Buildfile: /path/to/build.xml
+
+clean:
+   [delete] Deleting directory /tmp/build
+
+init:
+    [mkdir] Created dir: /tmp/build/classes
+
+compile:
+    [javac] Compiling 47 source files to /tmp/build/classes
+
+BUILD SUCCESSFUL
+
+Total time: 4 seconds
+";
+        let filtered = filter_ant_build(output);
+        assert!(
+            filtered.contains("BUILD SUCCESSFUL"),
+            "BUILD SUCCESSFUL must be preserved, got:\n{}",
+            filtered
+        );
+        assert!(
+            filtered.contains("Total time:"),
+            "Total time must be preserved, got:\n{}",
+            filtered
+        );
+        assert!(!filtered.contains("Buildfile:"), "Buildfile line should be stripped");
+        assert!(!filtered.contains("clean:"), "target label should be stripped");
+        assert!(!filtered.contains("[delete]"), "delete task should be stripped");
+        assert!(!filtered.contains("[mkdir]"), "mkdir task should be stripped");
+        assert!(
+            !filtered.contains("Compiling 47"),
+            "plain [javac] chatter without errors should be stripped"
+        );
+    }
+
+    #[test]
+    fn test_failed_compile_preserves_error_and_banner() {
+        let output = "\
+Buildfile: /path/to/build.xml
+
+compile:
+    [javac] Compiling 47 source files to /tmp/build/classes
+    [javac] /path/Foo.java:42: error: cannot find symbol
+    [javac] /path/Bar.java:10: error: incompatible types
+
+BUILD FAILED
+/path/build.xml:35: Compile failed; see the compiler error output for details.
+
+Total time: 4 seconds
+";
+        let filtered = filter_ant_build(output);
+        assert!(
+            filtered.contains("BUILD FAILED"),
+            "BUILD FAILED must be preserved, got:\n{}",
+            filtered
+        );
+        assert!(
+            filtered.contains("/path/Foo.java:42: error:"),
+            "compile error line must be preserved, got:\n{}",
+            filtered
+        );
+        assert!(
+            filtered.contains("/path/Bar.java:10: error:"),
+            "second compile error must be preserved, got:\n{}",
+            filtered
+        );
+        assert!(
+            filtered.contains("Total time:"),
+            "Total time must be preserved, got:\n{}",
+            filtered
+        );
+        assert!(!filtered.contains("Buildfile:"), "Buildfile line should be stripped");
+    }
+
+    #[test]
+    fn test_empty_input_passes_through() {
+        assert_eq!(filter_ant_build(""), "ant: ok");
+        assert_eq!(filter_ant_build("   \n\n   "), "ant: ok");
+    }
+}

--- a/src/cmds/jvm/ant_cmd.rs
+++ b/src/cmds/jvm/ant_cmd.rs
@@ -73,12 +73,15 @@ lazy_static! {
     // Lines we strip (noise).
     static ref RE_STRIP_BUILDFILE: Regex =
         Regex::new(r"^Buildfile:").unwrap();
-    // Lowercase target labels: "compile:", "init:", etc.
+    // Target labels: "compile:", "init:", and internal hyphen-prefixed targets
+    // like "-check-git-state:" / "-ivy-fail-disallowed-ivy-version:".
     static ref RE_STRIP_TARGET: Regex =
-        Regex::new(r"^[a-z][a-zA-Z0-9_-]+:$").unwrap();
-    // Generic harmless task chatter (echo, delete, mkdir, copy, move, etc.).
+        Regex::new(r"^-?[a-z][a-zA-Z0-9_.-]*:$").unwrap();
+    // Generic harmless task chatter (echo, delete, mkdir, copy, move, ivy
+    // resolution noise, etc.). [javac]/[junit]/[testng] are handled separately
+    // so diagnostics and test results are never swept up here.
     static ref RE_STRIP_TASK_CHATTER: Regex =
-        Regex::new(r"^\s+\[(echo|delete|mkdir|copy|move|propertyfile|fixcrlf)\]").unwrap();
+        Regex::new(r"^\s*\[(echo|delete|mkdir|copy|move|propertyfile|fixcrlf|loadresource|ivy:[a-z]+)\]").unwrap();
     // [javac] informational chatter only — never strip lines that contain
     // diagnostic context (source snippets, carets, symbol/location, error count
     // summaries). Stripping all `[javac]` lines drops the user-actionable
@@ -328,6 +331,49 @@ Total time: 0 seconds
             filtered
         );
         assert!(filtered.contains("BUILD FAILED"));
+        assert!(filtered.contains("Total time:"));
+    }
+
+    #[test]
+    fn test_strips_hyphen_targets_and_ivy_chatter() {
+        // Ivy/Ant builds (e.g. lucene-solr) emit hyphen-prefixed internal
+        // targets and repeated ivy/loadresource task chatter.
+        // Note: ivy/loadresource chatter is often emitted at column 0 (no
+        // leading indent), unlike [javac]; the strip pattern must allow both.
+        let output = "\
+-check-git-state:
+-ivy-fail-disallowed-ivy-version:
+[loadresource] Do not set property disallowed.ivy.jars.list as its length is 0.
+[ivy:configure] :: Apache Ivy 2.4.0 :: http://ant.apache.org/ivy/ ::
+[ivy:retrieve] :: retrieving :: org.apache#lucene
+compile:
+    [javac] Compiling 200 source files
+
+BUILD SUCCESSFUL
+Total time: 12 seconds
+";
+        let filtered = filter_ant_build(output);
+        assert!(
+            !filtered.contains("-check-git-state:"),
+            "hyphen-prefixed target should be stripped, got:\n{}",
+            filtered
+        );
+        assert!(
+            !filtered.contains("-ivy-fail-disallowed"),
+            "hyphen-prefixed ivy target should be stripped, got:\n{}",
+            filtered
+        );
+        assert!(
+            !filtered.contains("[ivy:configure]") && !filtered.contains("[ivy:retrieve]"),
+            "ivy task chatter should be stripped, got:\n{}",
+            filtered
+        );
+        assert!(
+            !filtered.contains("[loadresource]"),
+            "loadresource chatter should be stripped, got:\n{}",
+            filtered
+        );
+        assert!(filtered.contains("BUILD SUCCESSFUL"));
         assert!(filtered.contains("Total time:"));
     }
 

--- a/src/cmds/jvm/ant_cmd.rs
+++ b/src/cmds/jvm/ant_cmd.rs
@@ -3,6 +3,7 @@
 //! BUILD SUCCESSFUL/FAILED, and the total-time summary.
 
 use crate::core::runner;
+use crate::core::truncate::CAP_ERRORS;
 use crate::core::utils::{exit_code_from_output, resolved_build_command, strip_ansi, truncate};
 use anyhow::{Context, Result};
 use lazy_static::lazy_static;
@@ -83,7 +84,7 @@ lazy_static! {
     // summaries). Stripping all `[javac]` lines drops the user-actionable
     // continuation lines that follow a `file:line: error:` header.
     static ref RE_STRIP_JAVAC_INFO: Regex =
-        Regex::new(r"^\s+\[javac\]\s+(?:Compiling\b|Note:|Compiled\b|warning:\s*\[options\])").unwrap();
+        Regex::new(r"^\s+\[javac\]\s+(?:Compiling\b|Note:|Compiled\b|warning:\s*\[options\]|Usage:|use --help\b)").unwrap();
 }
 
 /// Execute a known ant target with compact filtering.
@@ -149,33 +150,51 @@ pub fn run_passthrough(args: &[OsString], verbose: u8) -> Result<i32> {
 /// task chatter, keeps errors and BUILD banner.
 pub fn filter_ant_build(output: &str) -> String {
     let mut kept: Vec<String> = Vec::new();
+    // Cap the `[javac]` diagnostic flood: a failed compile can emit hundreds of
+    // multi-line error blocks. Keep the first CAP_ERRORS lines (the leading
+    // errors with their full source/caret/symbol context), summarise the rest,
+    // and always preserve the BUILD banner that follows.
+    let mut javac_lines = 0usize;
+    let mut dropped = 0usize;
+    let mut marker_pos: Option<usize> = None;
 
     for line in output.lines() {
         if line.trim().is_empty() {
             continue;
         }
 
-        // Always preserve these.
-        if RE_KEEP_BUILD_RESULT.is_match(line)
+        let is_keep = RE_KEEP_BUILD_RESULT.is_match(line)
             || RE_KEEP_TOTAL_TIME.is_match(line)
             || RE_KEEP_JAVAC_ERROR.is_match(line)
             || RE_KEEP_ERROR.is_match(line)
-            || RE_KEEP_FAILED.is_match(line)
+            || RE_KEEP_FAILED.is_match(line);
+
+        // Strip noise unless the line is an error/result we always keep.
+        if !is_keep
+            && (RE_STRIP_BUILDFILE.is_match(line)
+                || RE_STRIP_TARGET.is_match(line)
+                || RE_STRIP_TASK_CHATTER.is_match(line)
+                || RE_STRIP_JAVAC_INFO.is_match(line))
         {
-            kept.push(truncate(line.trim_end(), 240).to_string());
             continue;
         }
 
-        // Strip these patterns.
-        if RE_STRIP_BUILDFILE.is_match(line)
-            || RE_STRIP_TARGET.is_match(line)
-            || RE_STRIP_TASK_CHATTER.is_match(line)
-            || RE_STRIP_JAVAC_INFO.is_match(line)
-        {
-            continue;
+        // Cap [javac] diagnostic lines; non-javac lines (BUILD banner, the
+        // build.xml failure trail, Total time) are never capped.
+        if line.trim_start().starts_with("[javac]") {
+            javac_lines += 1;
+            if javac_lines > CAP_ERRORS {
+                marker_pos.get_or_insert(kept.len());
+                dropped += 1;
+                continue;
+            }
         }
 
         kept.push(truncate(line.trim_end(), 240).to_string());
+    }
+
+    if let Some(pos) = marker_pos {
+        kept.insert(pos, format!("    … +{} more javac lines", dropped));
     }
 
     if kept.is_empty() {
@@ -276,5 +295,70 @@ Total time: 4 seconds
     fn test_empty_input_passes_through() {
         assert_eq!(filter_ant_build(""), "ant: ok");
         assert_eq!(filter_ant_build("   \n\n   "), "ant: ok");
+    }
+
+    #[test]
+    fn test_strips_javac_usage_help_keeps_error() {
+        let output = "\
+compile:
+    [javac] Compiling 22 source files to /tmp/out
+    [javac] error: release version 7 not supported
+    [javac] Usage: javac <options> <source files>
+    [javac] use --help for a list of possible options
+
+BUILD FAILED
+/path/build.xml:764: Compile failed; see the compiler error output for details.
+
+Total time: 0 seconds
+";
+        let filtered = filter_ant_build(output);
+        assert!(
+            filtered.contains("error: release version 7 not supported"),
+            "real javac error must be preserved, got:\n{}",
+            filtered
+        );
+        assert!(
+            !filtered.contains("Usage: javac"),
+            "javac usage help should be stripped, got:\n{}",
+            filtered
+        );
+        assert!(
+            !filtered.contains("use --help"),
+            "javac --help hint should be stripped, got:\n{}",
+            filtered
+        );
+        assert!(filtered.contains("BUILD FAILED"));
+        assert!(filtered.contains("Total time:"));
+    }
+
+    #[test]
+    fn test_caps_javac_error_flood_keeps_banner() {
+        let mut input = String::from("compile:\n");
+        // 60 distinct compile errors, each with a caret context line (120 javac lines).
+        for i in 0..60 {
+            input.push_str(&format!(
+                "    [javac] /path/File{i}.java:{i}: error: cannot find symbol\n    [javac]            ^\n"
+            ));
+        }
+        input.push_str("\nBUILD FAILED\n/path/build.xml:52: Compile failed; see details.\n\nTotal time: 1 second\n");
+
+        let filtered = filter_ant_build(&input);
+        let javac_kept = filtered
+            .lines()
+            .filter(|l| l.trim_start().starts_with("[javac]"))
+            .count();
+        assert!(
+            javac_kept <= CAP_ERRORS,
+            "javac flood must be capped at {CAP_ERRORS}, kept {javac_kept}:\n{filtered}"
+        );
+        assert!(
+            filtered.contains("more javac lines"),
+            "must summarise dropped javac lines, got:\n{}",
+            filtered
+        );
+        // First error retained with full context; banner never dropped.
+        assert!(filtered.contains("/path/File0.java:0: error:"));
+        assert!(filtered.contains("BUILD FAILED"));
+        assert!(filtered.contains("Total time:"));
     }
 }

--- a/src/cmds/system/pipe_cmd.rs
+++ b/src/cmds/system/pipe_cmd.rs
@@ -26,6 +26,7 @@ pub fn resolve_filter(name: &str) -> Option<fn(&str) -> String> {
         "ruff-check" => Some(crate::cmds::python::ruff_cmd::filter_ruff_check_json),
         "ruff-format" => Some(crate::cmds::python::ruff_cmd::filter_ruff_format),
         "prettier" => Some(crate::cmds::js::prettier_cmd::filter_prettier_output),
+        "ant" => Some(crate::cmds::jvm::ant_cmd::filter_ant_build),
         _ => None,
     }
 }
@@ -230,7 +231,7 @@ pub fn run(filter_name: Option<&str>, passthrough: bool) -> Result<()> {
             anyhow::anyhow!(
                 "Unknown filter '{}'. Available: cargo-test, pytest, go-test, go-build, \
                  tsc, vitest, grep, rg, find, fd, git-log, git-diff, git-status, \
-                 log, mypy, ruff-check, ruff-format, prettier",
+                 log, mypy, ruff-check, ruff-format, prettier, ant",
                 name
             )
         })?,

--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -1620,8 +1620,8 @@ match_command = "^make\\b"
         let filters = make_filters(BUILTIN_TOML);
         assert_eq!(
             filters.len(),
-            58,
-            "Expected exactly 58 built-in filters, got {}. \
+            59,
+            "Expected exactly 59 built-in filters, got {}. \
              Update this count when adding/removing filters in src/filters/.",
             filters.len()
         );
@@ -1678,11 +1678,11 @@ expected = "output line 1\noutput line 2"
         let combined = format!("{}\n\n{}", BUILTIN_TOML, new_filter);
         let filters = make_filters(&combined);
 
-        // All 58 existing filters still present + 1 new = 59
+        // All 59 existing filters still present + 1 new = 60
         assert_eq!(
             filters.len(),
-            59,
-            "Expected 59 filters after concat (58 built-in + 1 new)"
+            60,
+            "Expected 60 filters after concat (59 built-in + 1 new)"
         );
 
         // New filter is discoverable

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -355,6 +355,42 @@ pub fn resolved_command(name: &str) -> Command {
     }
 }
 
+/// Resolve a build tool, preferring a project-local wrapper script.
+///
+/// Many JVM build tools ship a wrapper next to the project root (`mvnw`,
+/// `gradlew`, `antw`) that pins the tool version. Prefer it when present,
+/// otherwise fall back to PATH resolution via [`resolved_command`].
+///
+/// # Arguments
+/// * `name` - Build tool name (e.g., "mvn", "gradle", "ant")
+pub fn resolved_build_command(name: &str) -> Command {
+    let wrapper = format!("{}w", name);
+
+    // On Windows, prefer the native wrapper first — `./mvnw` (a shebang shell
+    // script) doesn't execute under CreateProcess, while `mvnw.cmd` /
+    // `gradlew.bat` do. Most repos ship both side-by-side.
+    #[cfg(target_os = "windows")]
+    {
+        for ext in &["cmd", "bat"] {
+            let win_wrapper = format!("{}.{}", wrapper, ext);
+            if std::path::Path::new(&win_wrapper).exists() {
+                return Command::new(format!(".\\{}", win_wrapper));
+            }
+        }
+    }
+
+    // Unix-style wrapper (macOS, Linux, also works under Git Bash if no .cmd).
+    #[cfg(not(target_os = "windows"))]
+    {
+        let unix_wrapper = std::path::Path::new(&wrapper);
+        if unix_wrapper.exists() {
+            return Command::new(format!("./{}", wrapper));
+        }
+    }
+
+    resolved_command(name)
+}
+
 /// Check if a tool exists on PATH (PATHEXT-aware on Windows).
 ///
 /// Replaces manual `Command::new("which").arg(tool)` checks that fail on Windows.

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -699,6 +699,15 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
+        pattern: r"^ant\s+(build|clean|test|compile|package|install)\b",
+        rtk_cmd: "rtk ant",
+        rewrite_prefixes: &["ant"],
+        category: "Build",
+        savings_pct: 75.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
+    RtkRule {
         pattern: r"^ping\b",
         rtk_cmd: "rtk ping",
         rewrite_prefixes: &["ping"],

--- a/src/filters/ant.toml
+++ b/src/filters/ant.toml
@@ -1,0 +1,52 @@
+[filters.ant]
+description = "Compact Apache Ant build output"
+match_command = "^ant\\s+\\w"
+strip_ansi = true
+strip_lines_matching = [
+  "^Buildfile:",
+  "^[a-z][a-zA-Z0-9_-]+:$",
+  "^\\s+\\[(echo|delete|mkdir|copy|move|propertyfile|fixcrlf)\\]",
+  "^\\s*$",
+]
+on_empty = "ant: ok"
+
+[[tests.ant]]
+name = "successful build collapses chatter, keeps BUILD SUCCESSFUL"
+input = """
+Buildfile: /path/to/build.xml
+
+clean:
+   [delete] Deleting directory /tmp/build
+
+init:
+    [mkdir] Created dir: /tmp/build/classes
+
+compile:
+    [javac] Compiling 47 source files to /tmp/build/classes
+
+BUILD SUCCESSFUL
+
+Total time: 4 seconds
+"""
+expected = "    [javac] Compiling 47 source files to /tmp/build/classes\nBUILD SUCCESSFUL\nTotal time: 4 seconds"
+
+[[tests.ant]]
+name = "failed compile preserves error line and BUILD FAILED"
+input = """
+Buildfile: /path/to/build.xml
+
+compile:
+    [javac] Compiling 3 source files to /tmp/build/classes
+    [javac] /path/Foo.java:42: error: cannot find symbol
+
+BUILD FAILED
+/path/build.xml:35: Compile failed; see the compiler error output for details.
+
+Total time: 2 seconds
+"""
+expected = "    [javac] Compiling 3 source files to /tmp/build/classes\n    [javac] /path/Foo.java:42: error: cannot find symbol\nBUILD FAILED\n/path/build.xml:35: Compile failed; see the compiler error output for details.\nTotal time: 2 seconds"
+
+[[tests.ant]]
+name = "empty input returns on_empty sentinel"
+input = ""
+expected = "ant: ok"

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use cmds::js::{
     lint_cmd, next_cmd, npm_cmd, playwright_cmd, pnpm_cmd, prettier_cmd, prisma_cmd, tsc_cmd,
     vitest_cmd,
 };
-use cmds::jvm::{gradlew_cmd, mvn_cmd};
+use cmds::jvm::{ant_cmd, gradlew_cmd, mvn_cmd};
 use cmds::python::{mypy_cmd, pip_cmd, pytest_cmd, ruff_cmd};
 use cmds::ruby::{rake_cmd, rspec_cmd, rubocop_cmd};
 use cmds::rust::{cargo_cmd, runner};
@@ -736,6 +736,12 @@ enum Commands {
         args: Vec<String>,
     },
 
+    /// Apache Ant commands with compact output (build, clean, test, compile, package, install)
+    Ant {
+        #[command(subcommand)]
+        command: AntCommands,
+    },
+
     /// Show hook rewrite audit metrics (requires RTK_HOOK_AUDIT=1)
     #[command(name = "hook-audit")]
     HookAudit {
@@ -1119,6 +1125,43 @@ enum GoCommands {
         args: Vec<String>,
     },
     /// Passthrough: runs any unsupported go subcommand directly
+    #[command(external_subcommand)]
+    Other(Vec<OsString>),
+}
+
+#[derive(Debug, Subcommand)]
+enum AntCommands {
+    /// Run the `build` target with compact output (use Other to invoke the default target instead)
+    Build {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Clean build artifacts with compact output
+    Clean {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Run tests with compact output
+    Test {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Compile sources with compact output
+    Compile {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Package the project with compact output
+    Package {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Install artifacts with compact output
+    Install {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Passthrough: run any other ant target with noise-filtered output
     #[command(external_subcommand)]
     Other(Vec<OsString>),
 }
@@ -2186,6 +2229,28 @@ fn run_cli() -> Result<i32> {
         Commands::Gradlew { args } => gradlew_cmd::run(&args, cli.verbose)?,
 
         Commands::Mvn { args } => mvn_cmd::run(&args, cli.verbose)?,
+
+        Commands::Ant { command } => match command {
+            AntCommands::Build { args } => {
+                ant_cmd::run(ant_cmd::AntCommand::Build, &args, cli.verbose)?
+            }
+            AntCommands::Clean { args } => {
+                ant_cmd::run(ant_cmd::AntCommand::Clean, &args, cli.verbose)?
+            }
+            AntCommands::Test { args } => {
+                ant_cmd::run(ant_cmd::AntCommand::Test, &args, cli.verbose)?
+            }
+            AntCommands::Compile { args } => {
+                ant_cmd::run(ant_cmd::AntCommand::Compile, &args, cli.verbose)?
+            }
+            AntCommands::Package { args } => {
+                ant_cmd::run(ant_cmd::AntCommand::Package, &args, cli.verbose)?
+            }
+            AntCommands::Install { args } => {
+                ant_cmd::run(ant_cmd::AntCommand::Install, &args, cli.verbose)?
+            }
+            AntCommands::Other(args) => ant_cmd::run_passthrough(&args, cli.verbose)?,
+        },
 
         Commands::HookAudit { since } => {
             hooks::hook_audit_cmd::run(since, cli.verbose)?;

--- a/tests/fixtures/jvm/ant_compile.txt
+++ b/tests/fixtures/jvm/ant_compile.txt
@@ -1,0 +1,33 @@
+Buildfile: /home/runner/project/build.xml
+
+clean:
+   [delete] Deleting directory /home/runner/project/build
+
+init:
+    [mkdir] Created dir: /home/runner/project/build/classes
+    [mkdir] Created dir: /home/runner/project/build/test-classes
+    [mkdir] Created dir: /home/runner/project/build/reports
+
+compile:
+    [javac] Compiling 23 source files to /home/runner/project/build/classes
+    [javac] Note: /home/runner/project/src/com/example/util/StringUtils.java uses unchecked or unsafe operations.
+    [javac] Note: Recompile with -Xlint:unchecked for details.
+
+compile-tests:
+    [javac] Compiling 8 source files to /home/runner/project/build/test-classes
+    [javac] /home/runner/project/src/test/com/example/service/OrderServiceTest.java:42: error: cannot find symbol
+    [javac]     Order order = orderService.createOrder(null);
+    [javac]                                            ^
+    [javac]   symbol:   variable null
+    [javac]   location: class OrderServiceTest
+    [javac] /home/runner/project/src/test/com/example/service/OrderServiceTest.java:67: error: incompatible types
+    [javac]     List<String> ids = orderService.getOrderIds();
+    [javac]                                               ^
+    [javac]   required: List<String>
+    [javac]   found:    List<Long>
+    [javac] 2 errors
+
+BUILD FAILED
+/home/runner/project/build.xml:34: Compile failed; see the compiler error output for details.
+
+Total time: 3 seconds


### PR DESCRIPTION
## Summary

Adds first-class **Apache Ant** support to rtk's JVM toolchain — an `rtk ant` command (build/clean/test/compile/package/install + passthrough) that compresses Ant build logs while preserving everything actionable.

Ant joins the existing `mvn` and `gradlew` JVM filters; this PR is additive and does **not** touch them.

### What's included (3 commits)
1. **`feat(jvm): add Apache Ant support`** — `ant_cmd.rs` filter, a `resolved_build_command()` helper in `core::utils` (prefers a project-local `./antw`/`./mvnw`/`./gradlew` wrapper), main.rs wiring, an `ant <target>` hook rewrite rule, and an `ant.toml` TOML-DSL filter.
2. **`feat(pipe): add ant filter to stdin pipe registry`** — `rtk pipe -f ant` so captured/piped Ant output can be filtered without re-running a build.
3. **`feat(jvm): cap Ant javac error flood + strip javac help noise`** — benchmark-driven: strips `[javac] Usage:` / `use --help` boilerplate and caps the `[javac]` diagnostic flood at `CAP_ERRORS` with a `… +N more javac lines` marker, while always preserving the first errors *with* their source/caret context and the `BUILD FAILED`/failure trail.

### What it strips / keeps
- **Strips**: `Buildfile:` lines, lowercase target labels (`compile:`), task chatter (`[echo]`/`[mkdir]`/`[delete]`/`[copy]`/…), `[javac] Compiling…`/`Note:`/`Usage:`/`use --help` noise.
- **Keeps**: `BUILD SUCCESSFUL`/`BUILD FAILED`, `Total time:`, `file:line: error:` compile errors (with context), and the build.xml failure trail.

## Benchmarks

Validated against real Ant build logs (both **failed** builds — the filter never hides a failure):

| Project | Ant | Raw→Filtered (lines) | Compression |
|---|---|---|---|
| derby (100-error compile flood) | 1.10.15 | 480 → 25 | **94.8%** |
| tomcat8.5 (`release version 7` error) | 1.10.15 | 34 → 3 | **91.2%** |

Failure is always surfaced; the first errors retain full caret/import context; the remainder is summarised.

## Testing
- 5 inline unit tests in `ant_cmd.rs` (chatter collapse, error+banner preservation, javac help stripping, flood capping, empty input) + 3 inline `ant.toml` filter tests.
- Full suite green: `cargo fmt --all && cargo clippy --all-targets && cargo test --all` (2200 passing).

## Note on #1241
This supersedes #1241 (`feat(jvm): add Maven, Gradle, and Ant support`). That PR was opened from a fork's `master` branch and had grown to conflict with `develop`; its Maven and Gradle filters have since landed on `develop` independently. This PR is the rebased, focused remainder — **Ant** — cut cleanly from `develop` per CONTRIBUTING. Maven-filter improvements (batch-flag injection, PGP-block collapse, stack/line dedup) will follow as separate focused PRs.

CLA: signed under @ryanmurf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)