### PR TITLE
Add The Conductor twist for Hermes warnings

### DIFF
--- a/hooks/hermes/README.md
+++ b/hooks/hermes/README.md
@@ -24,6 +24,14 @@ Hermes loads plugins from Python, so the plugin entrypoint is Python. The Python
 
 All rewrite rules stay in Rust inside `rtk rewrite`. When RTK adds or changes command rewrite behavior, the Hermes plugin picks up that behavior by delegating to the RTK binary.
 
+## The Conductor twist
+
+Set `RTK_HERMES_CONDUCTOR=1` to brand Hermes plugin warnings as `The Conductor` while keeping the same fail-open behavior:
+
+```bash
+RTK_HERMES_CONDUCTOR=1 hermes
+```
+
 ## Fail-open behavior
 
 The plugin does not block command execution. If anything goes wrong, Hermes runs the original command unchanged.

--- a/hooks/hermes/rtk-rewrite/__init__.py
+++ b/hooks/hermes/rtk-rewrite/__init__.py
@@ -4,6 +4,7 @@ All rewrite logic lives in RTK's Rust ``rtk rewrite`` command; this module
 only bridges Hermes ``pre_tool_call`` payloads to that command and fails open.
 """
 
+import os
 import shutil
 import subprocess
 import sys
@@ -76,5 +77,10 @@ def _pre_tool_call(tool_name=None, args=None, **_kwargs):
         return
 
 
+def _conductor_twist_enabled():
+    return os.environ.get("RTK_HERMES_CONDUCTOR", "").lower() in {"1", "true", "yes", "on"}
+
+
 def _warn(message):
-    print(f"rtk: hermes plugin warning: {message}", file=sys.stderr)
+    warning_name = "The Conductor" if _conductor_twist_enabled() else "hermes plugin"
+    print(f"rtk: {warning_name} warning: {message}", file=sys.stderr)

--- a/hooks/hermes/tests/test_rtk_rewrite_plugin.py
+++ b/hooks/hermes/tests/test_rtk_rewrite_plugin.py
@@ -233,6 +233,29 @@ class RtkRewritePluginTest(unittest.TestCase):
         self.assertEqual({"command": "git status"}, args)
         self.assertEqual("rtk: hermes plugin warning: boom\n", stderr.getvalue())
 
+    def test_conductor_twist_env_var_brands_warning_without_blocking_command(self):
+        module, callback = self.load_callback()
+        args = {"command": "git status"}
+
+        with mock.patch.dict(os.environ, {"RTK_HERMES_CONDUCTOR": "1"}):
+            with mock.patch.object(module.subprocess, "run", side_effect=RuntimeError("boom")):
+                with mock.patch.object(module.sys, "stderr", new_callable=io.StringIO) as stderr:
+                    callback(tool_name="terminal", args=args)
+
+        self.assertEqual({"command": "git status"}, args)
+        self.assertEqual("rtk: The Conductor warning: boom\n", stderr.getvalue())
+
+    def test_conductor_twist_env_var_accepts_true_and_yes(self):
+        module = load_plugin_module()
+
+        for value in ("true", "TRUE", "yes", "YES", "on", "ON"):
+            with self.subTest(value=value):
+                with mock.patch.dict(os.environ, {"RTK_HERMES_CONDUCTOR": value}):
+                    with mock.patch.object(module.sys, "stderr", new_callable=io.StringIO) as stderr:
+                        module._warn("baton ready")
+
+                self.assertEqual("rtk: The Conductor warning: baton ready\n", stderr.getvalue())
+
     def test_non_terminal_tool_is_noop(self):
         module, callback = self.load_callback()
         args = {"command": "git status"}


### PR DESCRIPTION
## Summary
- Adds an opt-in `RTK_HERMES_CONDUCTOR` switch for Hermes plugin warning branding
- Keeps the existing fail-open command behavior unchanged
- Documents the switch in the Hermes plugin README

## Test Plan
- `python -m unittest discover -s hooks/hermes`
