### PR TITLE
feat: add Flutter and Dart command filters with compact output

### DIFF
--- a/src/cmds/dart/dart_cmd.rs
+++ b/src/cmds/dart/dart_cmd.rs
@@ -1,0 +1,57 @@
+//! Dart command filters.
+
+use anyhow::Result;
+use crate::core::runner;
+use std::ffi::OsString;
+
+use crate::cmds::flutter::flutter_cmd::{filter_analyze_output, run_flutter_filtered};
+
+pub fn run_analyze(args: &[String], verbose: u8) -> Result<i32> {
+    run_flutter_filtered(
+        &["analyze"],
+        args,
+        "dart analyze",
+        verbose,
+        "dart_analyze",
+        |raw| filter_analyze_output(raw, "dart"),
+    )
+}
+
+pub fn run_other(args: &[OsString], verbose: u8) -> Result<i32> {
+    if verbose > 0 {
+        eprintln!("Running: dart {}", format_os_args(args));
+    }
+    runner::run_passthrough("dart", args, verbose)
+}
+
+fn format_os_args(args: &[OsString]) -> String {
+    args.iter()
+        .map(|arg| arg.to_string_lossy().to_string())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn count_tokens(text: &str) -> usize {
+        text.split_whitespace().count()
+    }
+
+    #[test]
+    fn test_dart_analyze_shares_flutter_parser() {
+        let input = "Analyzing dart package...\ninfo • Example warning • lib/foo.dart:1:1 • prefer_final_locals\n1 issue found. (ran in 0.1s)";
+        let output = filter_analyze_output(input, "dart");
+        assert!(output.contains("1 issues found in 1 files"));
+        assert!(output.contains("lib/foo.dart"));
+    }
+
+    #[test]
+    fn test_dart_analyze_savings_on_synthetic_input() {
+        let input = "Analyzing dart package...\ninfo • Example warning • lib/foo.dart:1:1 • prefer_final_locals\nwarning • Example warning • lib/foo.dart:2:1 • prefer_final_locals\n2 issues found. (ran in 0.1s)";
+        let output = filter_analyze_output(input, "dart");
+        let savings = 100.0 - (count_tokens(&output) as f64 / count_tokens(input) as f64 * 100.0);
+        assert!(savings >= 8.0, "Expected savings, got {:.1}%", savings);
+    }
+}

--- a/src/cmds/dart/mod.rs
+++ b/src/cmds/dart/mod.rs
@@ -1,0 +1,1 @@
+automod::dir!(pub "src/cmds/dart");

--- a/src/cmds/flutter/flutter_cmd.rs
+++ b/src/cmds/flutter/flutter_cmd.rs
@@ -1,0 +1,618 @@
+//! Flutter command filters.
+
+use anyhow::Result;
+use crate::core::runner::{self, RunOptions};
+use crate::core::utils::{resolved_command, truncate};
+use std::collections::HashMap;
+use std::ffi::OsString;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum Severity {
+    Error,
+    Warning,
+    Info,
+    Other,
+}
+
+impl Severity {
+    fn rank(self) -> u8 {
+        match self {
+            Severity::Error => 3,
+            Severity::Warning => 2,
+            Severity::Info => 1,
+            Severity::Other => 0,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Severity::Error => "error",
+            Severity::Warning => "warning",
+            Severity::Info => "info",
+            Severity::Other => "other",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct AnalyzeIssue {
+    severity: Severity,
+    file: String,
+    line: usize,
+    column: usize,
+    rule: String,
+    message: String,
+}
+
+#[derive(Debug, Clone)]
+struct AnalyzeGroup {
+    severity: Severity,
+    rule: String,
+    message: String,
+    line: usize,
+    column: usize,
+    count: usize,
+}
+
+#[derive(Debug, Clone)]
+struct FlutterTestFailure {
+    file: String,
+    title: String,
+    details: Vec<String>,
+}
+
+pub fn run_analyze(args: &[String], verbose: u8) -> Result<i32> {
+    run_flutter_filtered(
+        &["analyze"],
+        args,
+        "flutter analyze",
+        verbose,
+        "flutter_analyze",
+        |raw| filter_analyze_output(raw, "flutter"),
+    )
+}
+
+pub fn run_pub_get(args: &[String], verbose: u8) -> Result<i32> {
+    run_flutter_filtered(
+        &["pub", "get"],
+        args,
+        "flutter pub get",
+        verbose,
+        "flutter_pub_get",
+        filter_pub_get_output,
+    )
+}
+
+pub fn run_test(args: &[String], verbose: u8) -> Result<i32> {
+    run_flutter_filtered(
+        &["test"],
+        args,
+        "flutter test",
+        verbose,
+        "flutter_test",
+        filter_flutter_test_output,
+    )
+}
+
+pub fn run_other(args: &[OsString], verbose: u8) -> Result<i32> {
+    run_passthrough_command("flutter", &[], args, verbose)
+}
+
+pub fn run_pub_other(args: &[OsString], verbose: u8) -> Result<i32> {
+    run_passthrough_command("flutter", &["pub"], args, verbose)
+}
+
+pub(crate) fn run_flutter_filtered<F>(
+    base_args: &[&str],
+    args: &[String],
+    display_command: &str,
+    verbose: u8,
+    tee_label: &str,
+    filter: F,
+) -> Result<i32>
+where
+    F: Fn(&str) -> String,
+{
+    let mut cmd = resolved_command("flutter");
+    for base in base_args {
+        cmd.arg(base);
+    }
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    let command_text = if args.is_empty() {
+        display_command.to_string()
+    } else {
+        format!("{} {}", display_command, args.join(" "))
+    };
+
+    if verbose > 0 {
+        eprintln!("Running: {}", command_text);
+    }
+
+    runner::run_filtered(
+        cmd,
+        display_command,
+        &command_text,
+        filter,
+        RunOptions::with_tee(tee_label),
+    )
+}
+
+fn run_passthrough_command(
+    binary: &str,
+    base_args: &[&str],
+    args: &[OsString],
+    verbose: u8,
+) -> Result<i32> {
+    let mut os_args: Vec<OsString> = base_args.iter().map(|arg| OsString::from(*arg)).collect();
+    os_args.extend(args.iter().cloned());
+
+    if verbose > 0 {
+        eprintln!("Running: {} {}", binary, format_os_args(&os_args));
+    }
+
+    runner::run_passthrough(binary, &os_args, verbose)
+}
+
+pub(crate) fn filter_analyze_output(output: &str, tool_name: &str) -> String {
+    let mut issues = Vec::new();
+    let mut reported_total = None;
+    let mut duration = None;
+
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with("Analyzing ") {
+            continue;
+        }
+
+        if let Some((total, parsed_duration)) = parse_analyze_summary_line(trimmed) {
+            reported_total = Some(total);
+            duration = parsed_duration;
+            continue;
+        }
+
+        if let Some(issue) = parse_analyze_issue(trimmed) {
+            issues.push(issue);
+        }
+    }
+
+    if issues.is_empty() {
+        return format!("{}: no issues", tool_name);
+    }
+
+    format_analyze_issues(tool_name, &issues, reported_total, duration.as_deref())
+}
+
+fn parse_analyze_issue(line: &str) -> Option<AnalyzeIssue> {
+    let mut parts = line.splitn(4, " • ");
+    let severity = parse_severity(parts.next()?.trim());
+    let message = parts.next()?.trim().to_string();
+    let location = parts.next()?.trim();
+    let rule = parts.next()?.trim().to_string();
+
+    let mut location_parts = location.rsplitn(3, ':');
+    let column = location_parts.next()?.parse::<usize>().ok()?;
+    let line_num = location_parts.next()?.parse::<usize>().ok()?;
+    let file = compact_flutter_path(location_parts.next()?);
+
+    Some(AnalyzeIssue {
+        severity,
+        file,
+        line: line_num,
+        column,
+        rule,
+        message,
+    })
+}
+
+fn parse_severity(label: &str) -> Severity {
+    match label {
+        "error" => Severity::Error,
+        "warning" => Severity::Warning,
+        "info" => Severity::Info,
+        _ => Severity::Other,
+    }
+}
+
+fn parse_analyze_summary_line(line: &str) -> Option<(usize, Option<String>)> {
+    if line.contains("No issues found") {
+        return Some((0, None));
+    }
+
+    if !line.contains("issue found") && !line.contains("issues found") {
+        return None;
+    }
+
+    let issues = line.split_whitespace().next()?.parse().ok()?;
+    let duration = line.find("(ran in ").and_then(|start| {
+        let rest = &line[start + "(ran in ".len()..];
+        let end = rest.find('s')?;
+        Some(rest[..end].to_string())
+    });
+
+    Some((issues, duration))
+}
+
+fn format_analyze_issues(
+    tool_name: &str,
+    issues: &[AnalyzeIssue],
+    reported_total: Option<usize>,
+    duration: Option<&str>,
+) -> String {
+    let mut files: HashMap<String, Vec<AnalyzeIssue>> = HashMap::new();
+
+    for issue in issues {
+        files
+            .entry(issue.file.clone())
+            .or_default()
+            .push(issue.clone());
+    }
+
+    let total_issues = reported_total.unwrap_or(issues.len());
+    let total_files = files.len();
+
+    let mut file_entries: Vec<(String, Vec<AnalyzeIssue>)> = files.into_iter().collect();
+    file_entries.sort_by(|a, b| b.1.len().cmp(&a.1.len()).then_with(|| a.0.cmp(&b.0)));
+
+    let mut result = String::new();
+    result.push_str(&format!(
+        "{} issues found in {} files",
+        total_issues, total_files
+    ));
+    if let Some(duration) = duration {
+        result.push_str(&format!(" (ran in {}s)", duration));
+    }
+    result.push('\n');
+
+    for (file, file_issues) in file_entries {
+        result.push_str(&format!("{} ({})\n", file, file_issues.len()));
+
+        let mut groups: HashMap<(Severity, String, String), AnalyzeGroup> = HashMap::new();
+        for issue in file_issues {
+            let key = (issue.severity, issue.rule.clone(), issue.message.clone());
+            groups
+                .entry(key)
+                .and_modify(|group| {
+                    group.count += 1;
+                    group.line = group.line.min(issue.line);
+                    group.column = group.column.min(issue.column);
+                })
+                .or_insert(AnalyzeGroup {
+                    severity: issue.severity,
+                    rule: issue.rule.clone(),
+                    message: issue.message.clone(),
+                    line: issue.line,
+                    column: issue.column,
+                    count: 1,
+                });
+        }
+
+        let mut group_entries: Vec<AnalyzeGroup> = groups.into_values().collect();
+        group_entries.sort_by(|a, b| {
+            b.severity
+                .rank()
+                .cmp(&a.severity.rank())
+                .then_with(|| b.count.cmp(&a.count))
+                .then_with(|| a.rule.cmp(&b.rule))
+                .then_with(|| a.line.cmp(&b.line))
+        });
+
+        for group in group_entries {
+            result.push_str(&format!(
+                "  {} {} L{}:{} ({}x) {}\n",
+                group.severity.as_str(),
+                group.rule,
+                group.line,
+                group.column,
+                group.count,
+                truncate(&group.message, 96),
+            ));
+        }
+
+        result.push('\n');
+    }
+
+    let result = result.trim().to_string();
+    if result.is_empty() {
+        format!("{}: no issues", tool_name)
+    } else {
+        result
+    }
+}
+
+fn filter_pub_get_output(output: &str) -> String {
+    let mut lines: Vec<String> = Vec::new();
+
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || is_pub_noise_line(trimmed) {
+            continue;
+        }
+
+        lines.push(trimmed.to_string());
+    }
+
+    if lines.is_empty() {
+        return "flutter pub get: ok".to_string();
+    }
+
+    dedupe_consecutive(lines).join("\n")
+}
+
+fn is_pub_noise_line(line: &str) -> bool {
+    line == "Downloading packages..."
+        || line == "Got dependencies!"
+        || line.starts_with("Resolving dependencies")
+        || line.starts_with('+')
+        || line.starts_with('>')
+        || line.starts_with("Precompiling executables")
+        || line.starts_with("Running " )
+}
+
+fn dedupe_consecutive(lines: Vec<String>) -> Vec<String> {
+    let mut deduped: Vec<String> = Vec::new();
+    for line in lines {
+        if deduped.last().map(|prev| prev == &line).unwrap_or(false) {
+            continue;
+        }
+        deduped.push(line);
+    }
+    deduped
+}
+
+pub(crate) fn filter_flutter_test_output(output: &str) -> String {
+    let mut passed: Option<usize> = None;
+    let mut failed: Option<usize> = None;
+    let mut failure_blocks: Vec<FlutterTestFailure> = Vec::new();
+    let mut current_failure: Option<FlutterTestFailure> = None;
+    let mut context_lines: Vec<String> = Vec::new();
+    let mut failing_tests: Vec<String> = Vec::new();
+    let mut in_failing_tests = false;
+
+    for line in output.lines() {
+        let trimmed = line.trim_end();
+
+        if let Some((seen_passed, seen_failed)) = parse_test_counts(trimmed) {
+            passed = Some(seen_passed);
+            failed = Some(seen_failed);
+        }
+
+        if trimmed == "Failing tests:" {
+            if let Some(block) = current_failure.take() {
+                failure_blocks.push(block);
+            }
+            in_failing_tests = true;
+            continue;
+        }
+
+        if in_failing_tests {
+            if trimmed.is_empty() {
+                continue;
+            }
+            failing_tests.push(trimmed.to_string());
+            continue;
+        }
+
+        if is_test_progress_line(trimmed) {
+            if let Some(block) = current_failure.take() {
+                failure_blocks.push(block);
+            }
+
+            if trimmed.contains("[E]") {
+                if let Some(block) = parse_test_failure_header(trimmed) {
+                    current_failure = Some(block);
+                }
+            }
+            continue;
+        }
+
+        if let Some(block) = current_failure.as_mut() {
+            if trimmed.is_empty() {
+                if !block.details.last().map(|s| s.is_empty()).unwrap_or(false) {
+                    block.details.push(String::new());
+                }
+                continue;
+            }
+
+            if is_test_failure_detail(trimmed) || block.details.len() < 6 {
+                block.details.push(trimmed.to_string());
+            }
+            continue;
+        }
+
+        if !trimmed.is_empty() && !trimmed.starts_with("loading ") {
+            context_lines.push(trimmed.to_string());
+        }
+    }
+
+    if let Some(block) = current_failure.take() {
+        failure_blocks.push(block);
+    }
+
+    if passed.is_none() && failed.is_none() && failure_blocks.is_empty() {
+        return "flutter test: no output".to_string();
+    }
+
+    let mut result = String::new();
+    if let (Some(pass_count), Some(fail_count)) = (passed, failed) {
+        result.push_str(&format!("{} passed, {} failed", pass_count, fail_count));
+    } else if let Some(fail_count) = failed {
+        result.push_str(&format!("{} failed", fail_count));
+    } else {
+        result.push_str(&format!("{} failures", failure_blocks.len()));
+    }
+    result.push('\n');
+
+    if !context_lines.is_empty() {
+        result.push('\n');
+        result.push_str("Context:\n");
+        for line in context_lines.iter().take(5) {
+            result.push_str(&format!("  {}\n", truncate(line, 120)));
+        }
+        if context_lines.len() > 5 {
+            result.push_str(&format!("  ... +{} more\n", context_lines.len() - 5));
+        }
+    }
+
+    if !failure_blocks.is_empty() {
+        result.push('\n');
+        result.push_str("Failures:\n");
+        for (idx, block) in failure_blocks.iter().enumerate() {
+            result.push_str(&format!("{}. {} ({})\n", idx + 1, block.title, block.file));
+            for detail in &block.details {
+                if detail.is_empty() {
+                    result.push('\n');
+                } else {
+                    result.push_str(&format!("   {}\n", truncate(detail, 120)));
+                }
+            }
+            result.push('\n');
+        }
+    }
+
+    if !failing_tests.is_empty() {
+        result.push_str("Failing tests:\n");
+        for line in failing_tests {
+            result.push_str(&format!("  {}\n", truncate(&line, 120)));
+        }
+    }
+
+    result.trim().to_string()
+}
+
+fn is_test_progress_line(line: &str) -> bool {
+    let bytes = line.as_bytes();
+    bytes.len() >= 7
+        && bytes[0].is_ascii_digit()
+        && bytes[1].is_ascii_digit()
+        && bytes[2] == b':'
+        && bytes[3].is_ascii_digit()
+        && bytes[4].is_ascii_digit()
+        && bytes[5] == b' '
+        && bytes[6] == b'+'
+}
+
+fn parse_test_counts(line: &str) -> Option<(usize, usize)> {
+    if !is_test_progress_line(line) {
+        return None;
+    }
+
+    let after_plus = line.split_once('+')?.1;
+    let passed = after_plus.split_whitespace().next()?.parse().ok()?;
+    let failed = after_plus
+        .split_once(" -")
+        .and_then(|(_, rest)| rest.split_whitespace().next())
+        .and_then(|value| value.trim_end_matches(':').parse().ok())
+        .unwrap_or(0);
+
+    Some((passed, failed))
+}
+
+fn parse_test_failure_header(line: &str) -> Option<FlutterTestFailure> {
+    let mut parts = line.splitn(3, ": ");
+    let _time = parts.next()?;
+    let file = compact_flutter_path(parts.next()?);
+    let title = parts.next()?.trim_end_matches(" [E]").trim().to_string();
+
+    Some(FlutterTestFailure {
+        file,
+        title,
+        details: Vec::new(),
+    })
+}
+
+fn is_test_failure_detail(line: &str) -> bool {
+    line.starts_with("══╡")
+        || line.starts_with("The following TestFailure")
+        || line.starts_with("The test description was:")
+        || line.starts_with("This was caught")
+        || line.starts_with("When the exception was thrown")
+        || line.starts_with("Expected:")
+        || line.starts_with("Actual:")
+        || line.starts_with("Which:")
+        || line.starts_with("Test failed.")
+        || line.starts_with('#')
+        || line.starts_with("package:")
+        || line.starts_with("file://")
+}
+
+fn compact_flutter_path(path: &str) -> String {
+    let path = path.trim_start_matches("file://");
+    if let Some(idx) = path.find("/rtk_flutter/") {
+        path[idx + "/rtk_flutter/".len()..].to_string()
+    } else {
+        path.to_string()
+    }
+}
+
+fn format_os_args(args: &[OsString]) -> String {
+    args.iter()
+        .map(|arg| arg.to_string_lossy().to_string())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn count_tokens(text: &str) -> usize {
+        text.split_whitespace().count()
+    }
+
+    #[test]
+    fn test_filter_analyze_output_groups_by_file() {
+        let input = include_str!("../../../tests/fixtures/flutter_analyze_raw.txt");
+        let output = filter_analyze_output(input, "flutter");
+        assert!(output.contains("20 issues found in 3 files"));
+        assert!(output.contains("lib/main.dart"));
+        assert!(output.contains("L21:5"));
+        assert!(output.contains("unused_element"));
+        assert!(!output.contains("Analyzing rtk_flutter"));
+    }
+
+    #[test]
+    fn test_filter_analyze_output_savings() {
+        let input = include_str!("../../../tests/fixtures/flutter_analyze_raw.txt");
+        let output = filter_analyze_output(input, "flutter");
+        let savings = 100.0 - (count_tokens(&output) as f64 / count_tokens(input) as f64 * 100.0);
+        assert!(savings >= 34.0, "Expected at least 34% savings, got {:.1}%", savings);
+    }
+
+    #[test]
+    fn test_filter_pub_get_output_strips_package_noise() {
+        let input = include_str!("../../../tests/fixtures/flutter_pub_get_raw.txt");
+        let output = filter_pub_get_output(input);
+        assert!(output.contains("Changed 58 dependencies"));
+        assert!(output.contains("packages have newer versions"));
+        assert!(!output.contains("Downloading packages"));
+    }
+
+    #[test]
+    fn test_filter_pub_get_output_savings() {
+        let input = include_str!("../../../tests/fixtures/flutter_pub_get_raw.txt");
+        let output = filter_pub_get_output(input);
+        let savings = 100.0 - (count_tokens(&output) as f64 / count_tokens(input) as f64 * 100.0);
+        assert!(savings >= 60.0, "Expected at least 60% savings, got {:.1}%", savings);
+    }
+
+    #[test]
+    fn test_filter_flutter_test_output_keeps_failures() {
+        let input = include_str!("../../../tests/fixtures/flutter_test_raw.txt");
+        let output = filter_flutter_test_output(input);
+        assert!(output.contains("11 passed, 3 failed"));
+        assert!(output.contains("Failures:"));
+        assert!(output.contains("Failing tests:"));
+        assert!(output.contains("counter starts at 5"));
+    }
+
+    #[test]
+    fn test_filter_flutter_test_output_savings() {
+        let input = include_str!("../../../tests/fixtures/flutter_test_verbose_raw.txt");
+        let output = filter_flutter_test_output(input);
+        let savings = 100.0 - (count_tokens(&output) as f64 / count_tokens(input) as f64 * 100.0);
+        assert!(savings >= 60.0, "Expected at least 60% savings, got {:.1}%", savings);
+    }
+}

--- a/src/cmds/flutter/mod.rs
+++ b/src/cmds/flutter/mod.rs
@@ -1,0 +1,1 @@
+automod::dir!(pub "src/cmds/flutter");

--- a/src/cmds/mod.rs
+++ b/src/cmds/mod.rs
@@ -1,7 +1,9 @@
 //! Command filter modules organized by language ecosystem.
 
+pub mod dart;
 pub mod cloud;
 pub mod dotnet;
+pub mod flutter;
 pub mod git;
 pub mod go;
 pub mod js;

--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -305,6 +305,8 @@ const RUST_HANDLED_COMMANDS: &[&str] = &[
     "pytest",
     "mypy",
     "pip",
+    "flutter",
+    "dart",
     "go",
     "golangci-lint",
     "rewrite",

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -40,6 +40,8 @@ pub fn category_avg_tokens(category: &str, subcmd: &str) -> usize {
         "GitHub" => 200,
         "GitLab" => 200,
         "PackageManager" => 150,
+        "Flutter" => 220,
+        "Dart" => 180,
         _ => 150,
     }
 }
@@ -1124,6 +1126,16 @@ mod tests {
             match classify_command(&cmd) {
                 Classification::Supported { .. } => {}
                 other => panic!("git {subcmd} should be Supported, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_registry_covers_flutter_and_dart_commands() {
+        for cmd in ["flutter analyze", "flutter pub get", "flutter test", "dart analyze"] {
+            match classify_command(cmd) {
+                Classification::Supported { .. } => {}
+                other => panic!("{cmd} should be Supported, got {other:?}"),
             }
         }
     }

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -878,6 +878,24 @@ pub const RULES: &[RtkRule] = &[
         subcmd_savings: &[],
         subcmd_status: &[],
     },
+    RtkRule {
+        pattern: r"^flutter\s+(analyze|pub\s+get|test)(\s|$)",
+        rtk_cmd: "rtk flutter",
+        rewrite_prefixes: &["flutter"],
+        category: "Flutter",
+        savings_pct: 75.0,
+        subcmd_savings: &[("analyze", 70.0), ("pub get", 85.0), ("test", 80.0)],
+        subcmd_status: &[],
+    },
+    RtkRule {
+        pattern: r"^dart\s+analyze(\s|$)",
+        rtk_cmd: "rtk dart",
+        rewrite_prefixes: &["dart"],
+        category: "Dart",
+        savings_pct: 75.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
 ];
 
 pub const IGNORED_PREFIXES: &[&str] = &[

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,9 @@ mod parser;
 
 // Re-export command modules for routing
 use cmds::cloud::{aws_cmd, container, curl_cmd, psql_cmd, wget_cmd};
+use cmds::dart::dart_cmd;
 use cmds::dotnet::{binlog, dotnet_cmd, dotnet_format_report, dotnet_trx};
+use cmds::flutter::flutter_cmd;
 use cmds::git::{diff_cmd, gh_cmd, git, glab_cmd, gt_cmd};
 use cmds::go::{go_cmd, golangci_cmd};
 use cmds::js::{
@@ -467,6 +469,18 @@ enum Commands {
         /// Create default config file
         #[arg(long)]
         create: bool,
+    },
+
+    /// Flutter commands with compact output
+    Flutter {
+        #[command(subcommand)]
+        command: FlutterCommands,
+    },
+
+    /// Dart commands with compact output
+    Dart {
+        #[command(subcommand)]
+        command: DartCommands,
     },
 
     /// Jest commands with compact output
@@ -1127,6 +1141,56 @@ enum GoCommands {
         args: Vec<String>,
     },
     /// Passthrough: runs any unsupported go subcommand directly
+    #[command(external_subcommand)]
+    Other(Vec<OsString>),
+}
+
+#[derive(Debug, Subcommand)]
+enum FlutterCommands {
+    /// Analyze Flutter project output
+    Analyze {
+        /// Additional flutter analyze arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Test Flutter project output
+    Test {
+        /// Additional flutter test arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Flutter pub commands
+    Pub {
+        #[command(subcommand)]
+        command: FlutterPubCommands,
+    },
+    /// Passthrough: runs any unsupported flutter subcommand directly
+    #[command(external_subcommand)]
+    Other(Vec<OsString>),
+}
+
+#[derive(Debug, Subcommand)]
+enum FlutterPubCommands {
+    /// flutter pub get with compact output
+    Get {
+        /// Additional flutter pub get arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Passthrough: runs any unsupported flutter pub subcommand directly
+    #[command(external_subcommand)]
+    Other(Vec<OsString>),
+}
+
+#[derive(Debug, Subcommand)]
+enum DartCommands {
+    /// Analyze Dart project output
+    Analyze {
+        /// Additional dart analyze arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+    /// Passthrough: runs any unsupported dart subcommand directly
     #[command(external_subcommand)]
     Other(Vec<OsString>),
 }
@@ -1990,6 +2054,25 @@ fn run_cli() -> Result<i32> {
             0
         }
 
+        Commands::Flutter { command } => match command {
+            FlutterCommands::Analyze { args } => flutter_cmd::run_analyze(&args, cli.verbose)?,
+            FlutterCommands::Test { args } => flutter_cmd::run_test(&args, cli.verbose)?,
+            FlutterCommands::Pub { command } => match command {
+                FlutterPubCommands::Get { args } => {
+                    flutter_cmd::run_pub_get(&args, cli.verbose)?
+                }
+                FlutterPubCommands::Other(args) => {
+                    flutter_cmd::run_pub_other(&args, cli.verbose)?
+                }
+            },
+            FlutterCommands::Other(args) => flutter_cmd::run_other(&args, cli.verbose)?,
+        },
+
+        Commands::Dart { command } => match command {
+            DartCommands::Analyze { args } => dart_cmd::run_analyze(&args, cli.verbose)?,
+            DartCommands::Other(args) => dart_cmd::run_other(&args, cli.verbose)?,
+        },
+
         Commands::Jest { ref args } | Commands::Vitest { ref args } => {
             vitest_cmd::run_test(&cli.command, args, cli.verbose)?
         }
@@ -2520,6 +2603,8 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Summary { .. }
             | Commands::Grep { .. }
             | Commands::Wget { .. }
+            | Commands::Flutter { .. }
+            | Commands::Dart { .. }
             | Commands::Vitest { .. }
             | Commands::Prisma { .. }
             | Commands::Tsc { .. }

--- a/tests/fixtures/flutter_analyze_raw.txt
+++ b/tests/fixtures/flutter_analyze_raw.txt
@@ -1,0 +1,24 @@
+Analyzing rtk_flutter...
+
+   info • Don't invoke 'print' in production code. Try using a logging framework • lib/main.dart:21:5 • avoid_print
+   info • Local variables should be final. Try making the variable final • lib/main.dart:26:5 • prefer_final_locals
+   info • Don't invoke 'print' in production code. Try using a logging framework • lib/main.dart:28:5 • avoid_print
+   info • Constructors in '@immutable' classes should be declared as 'const'. Try adding 'const' to the constructor declaration • lib/main.dart:35:3 • prefer_const_constructors_in_immutables
+   info • Unnecessary use of double quotes. Try using single quotes unless the string contains single quotes • lib/main.dart:40:14 • prefer_single_quotes
+   info • Unnecessary use of double quotes. Try using single quotes unless the string contains single quotes • lib/main.dart:44:31 • prefer_single_quotes
+   info • An uninitialized field should have an explicit type annotation. Try adding a type annotation • lib/models/user.dart:4:7 • prefer_typing_uninitialized_variables
+   info • Missing type annotation. Try replacing 'var' with a type annotation • lib/models/user.dart:4:7 • strict_top_level_inference
+   info • Missing type annotation. Try adding a type annotation • lib/models/user.dart:12:3 • strict_top_level_inference
+   info • The method 'toJson' should have a return type but doesn't. Try adding a return type to the method • lib/models/user.dart:12:3 • always_declare_return_types
+   info • Don't invoke 'print' in production code. Try using a logging framework • lib/models/user.dart:20:5 • avoid_print
+   info • Local variables should be final. Try making the variable final • lib/models/user.dart:25:5 • prefer_final_locals
+warning • The declaration '_unusedPrivateMethod' isn't referenced. Try removing the declaration of '_unusedPrivateMethod' • lib/models/user.dart:30:8 • unused_element
+   info • Don't invoke 'print' in production code. Try using a logging framework • lib/models/user.dart:31:5 • avoid_print
+   info • Don't invoke 'print' in production code. Try using a logging framework • lib/services/api_service.dart:14:5 • avoid_print
+   info • Local variables should be final. Try making the variable final • lib/services/api_service.dart:19:7 • prefer_final_locals
+   info • Don't invoke 'print' in production code. Try using a logging framework • lib/services/api_service.dart:23:5 • avoid_print
+   info • Local variables should be final. Try making the variable final • lib/services/api_service.dart:29:5 • prefer_final_locals
+   info • Local variables should be final. Try making the variable final • lib/services/api_service.dart:35:5 • prefer_final_locals
+warning • The value of the local variable 'unused' isn't used. Try removing the variable or using it • lib/services/api_service.dart:35:9 • unused_local_variable
+
+20 issues found. (ran in 3.4s)

--- a/tests/fixtures/flutter_pub_get_raw.txt
+++ b/tests/fixtures/flutter_pub_get_raw.txt
@@ -1,0 +1,67 @@
+Resolving dependencies...
+Downloading packages...
++ _fe_analyzer_shared 100.0.0
++ analyzer 13.0.0
++ args 2.7.0
++ build 4.0.6
++ build_config 1.3.0
++ build_daemon 4.1.1
++ build_runner 2.15.0
++ built_collection 5.1.1
++ built_value 8.12.6
++ checked_yaml 2.0.4
++ code_builder 4.11.1
++ convert 3.1.2
++ crypto 3.0.7
++ dart_style 3.1.9
++ ffi 2.2.0
++ file 7.0.1
++ fixnum 1.1.1
++ flutter_web_plugins 0.0.0 from sdk flutter
++ glob 2.1.3
++ graphs 2.3.2
++ http 1.6.0
++ http_multi_server 3.2.2
++ http_parser 4.1.2
++ intl 0.19.0 (0.20.2 available)
++ io 1.0.5
++ json_annotation 4.12.0
++ logging 1.3.0
+  matcher 0.12.19 (0.12.20 available)
+  meta 1.18.0 (1.18.2 available)
++ mime 2.0.0
++ mockito 5.7.0
++ nested 1.0.0
++ package_config 2.2.0
++ path_provider_linux 2.2.1
++ path_provider_platform_interface 2.1.2
++ path_provider_windows 2.3.0
++ platform 3.1.6
++ plugin_platform_interface 2.1.8
++ pool 1.5.2
++ provider 6.1.5+1
++ pub_semver 2.2.0
++ pubspec_parse 1.5.0
++ shared_preferences 2.5.5
++ shared_preferences_android 2.4.23
++ shared_preferences_foundation 2.5.6
++ shared_preferences_linux 2.4.1
++ shared_preferences_platform_interface 2.4.2
++ shared_preferences_web 2.4.3
++ shared_preferences_windows 2.4.1
++ shelf 1.4.2
++ shelf_web_socket 3.0.0
++ source_gen 4.2.3
++ stream_transform 2.1.1
+  test_api 0.7.11 (0.7.12 available)
++ typed_data 1.4.0
+  vector_math 2.2.0 (2.3.0 available)
++ watcher 1.2.1
++ web 1.1.1
++ web_socket 1.0.1
++ web_socket_channel 3.0.3
++ xdg_directories 1.1.0
++ yaml 3.1.3
+Changed 58 dependencies!
+5 packages have newer versions incompatible with dependency constraints.
+Try `flutter pub outdated` for more information.

--- a/tests/fixtures/flutter_test_raw.txt
+++ b/tests/fixtures/flutter_test_raw.txt
@@ -1,0 +1,81 @@
+00:00 +0: loading /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart
+00:00 +0: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget shows initial count of 0
+00:00 +1: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget shows initial count of 0
+00:00 +2: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget shows initial count of 0
+00:00 +3: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget shows initial count of 0
+00:00 +4: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget shows initial count of 0
+00:00 +5: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget shows initial count of 0
+00:00 +5 -1: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget shows initial count of 0
+00:00 +5 -1: /home/carlosfiori/projects/rtk_flutter/test/unit/user_test.dart: User model age validation fails for negative age [E]
+  Expected: a value greater than <0>
+    Actual: <-1>
+     Which: is not a value greater than <0>
+  Age should be positive but was -1
+
+  package:matcher                                     expect
+  package:flutter_test/src/widget_tester.dart 473:18  expect
+  test/unit/user_test.dart 37:7                       main.<fn>.<fn>
+
+00:00 +6 -1: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget shows initial count of 0
+00:00 +7 -1: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget shows initial count of 0
+00:00 +7 -2: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget shows initial count of 0
+00:00 +7 -2: /home/carlosfiori/projects/rtk_flutter/test/unit/user_test.dart: AdminUser strict permission check fails for regular admin [E]
+  Expected: true
+    Actual: <false>
+  Expected admin to have strict permission but got false
+
+  package:matcher                                     expect
+  package:flutter_test/src/widget_tester.dart 473:18  expect
+  test/unit/user_test.dart 56:7                       main.<fn>.<fn>
+
+00:00 +7 -2: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget shows initial count of 0
+Fetching user from https://jsonplaceholder.typicode.com/users/1
+Error: 400
+00:00 +8 -2: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget increments counter on FAB tap
+Fetching user from https://jsonplaceholder.typicode.com/users/1
+Error: 400
+Counter incremented to 1
+00:00 +9 -2: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget reset button returns counter to 0
+Fetching user from https://jsonplaceholder.typicode.com/users/1
+Error: 400
+Counter incremented to 1
+Counter incremented to 2
+Reset from 2 to 0
+00:00 +10 -2: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget shows title in app bar
+Fetching user from https://jsonplaceholder.typicode.com/users/1
+Error: 400
+00:00 +11 -2: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget counter starts at 5 - intentional failure
+Fetching user from https://jsonplaceholder.typicode.com/users/1
+Error: 400
+══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
+The following TestFailure was thrown running a test:
+Expected: exactly one matching candidate
+  Actual: _TextWidgetFinder:<Found 0 widgets with text "5": []>
+   Which: means none were found but one was expected
+Expected counter to start at 5, but it starts at 0
+
+When the exception was thrown, this was the stack:
+#4      main.<anonymous closure>.<anonymous closure> (file:///home/carlosfiori/projects/rtk_flutter/test/widget_test.dart:57:7)
+<asynchronous suspension>
+#5      testWidgets.<anonymous closure>.<anonymous closure> (package:flutter_test/src/widget_tester.dart:192:15)
+<asynchronous suspension>
+#6      TestWidgetsFlutterBinding._runTestBody (package:flutter_test/src/binding.dart:1952:5)
+<asynchronous suspension>
+<asynchronous suspension>
+(elided one frame from package:stack_trace)
+
+This was caught by the test expectation on the following line:
+  file:///home/carlosfiori/projects/rtk_flutter/test/widget_test.dart line 57
+The test description was:
+  counter starts at 5 - intentional failure
+════════════════════════════════════════════════════════════════════════════════════════════════════
+00:00 +11 -3: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget counter starts at 5 - intentional failure [E]
+  Test failed. See exception logs above.
+  The test description was: counter starts at 5 - intentional failure
+
+00:01 +11 -3: Some tests failed.
+
+Failing tests:
+  /home/carlosfiori/projects/rtk_flutter/test/unit/user_test.dart: AdminUser strict permission check fails for regular admin
+  /home/carlosfiori/projects/rtk_flutter/test/unit/user_test.dart: User model age validation fails for negative age
+  /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget counter starts at 5 - intentional failure

--- a/tests/fixtures/flutter_test_verbose_raw.txt
+++ b/tests/fixtures/flutter_test_verbose_raw.txt
@@ -1,0 +1,81 @@
+00:00 +0: loading /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart
+00:00 +0: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget shows initial count of 0
+00:00 +1: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget shows initial count of 0
+00:00 +2: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget shows initial count of 0
+00:00 +3: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget shows initial count of 0
+00:00 +4: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget shows initial count of 0
+00:00 +5: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget shows initial count of 0
+00:00 +5 -1: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget shows initial count of 0
+00:00 +5 -1: /home/carlosfiori/projects/rtk_flutter/test/unit/user_test.dart: User model age validation fails for negative age [E]
+  Expected: a value greater than <0>
+    Actual: <-1>
+     Which: is not a value greater than <0>
+  Age should be positive but was -1
+
+  package:matcher                                     expect
+  package:flutter_test/src/widget_tester.dart 473:18  expect
+  test/unit/user_test.dart 37:7                       main.<fn>.<fn>
+
+00:00 +6 -1: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget shows initial count of 0
+00:00 +7 -1: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget shows initial count of 0
+00:00 +7 -2: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget shows initial count of 0
+00:00 +7 -2: /home/carlosfiori/projects/rtk_flutter/test/unit/user_test.dart: AdminUser strict permission check fails for regular admin [E]
+  Expected: true
+    Actual: <false>
+  Expected admin to have strict permission but got false
+
+  package:matcher                                     expect
+  package:flutter_test/src/widget_tester.dart 473:18  expect
+  test/unit/user_test.dart 56:7                       main.<fn>.<fn>
+
+00:00 +7 -2: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget shows initial count of 0
+Fetching user from https://jsonplaceholder.typicode.com/users/1
+Error: 400
+00:00 +8 -2: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget increments counter on FAB tap
+Fetching user from https://jsonplaceholder.typicode.com/users/1
+Error: 400
+Counter incremented to 1
+00:00 +9 -2: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget reset button returns counter to 0
+Fetching user from https://jsonplaceholder.typicode.com/users/1
+Error: 400
+Counter incremented to 1
+Counter incremented to 2
+Reset from 2 to 0
+00:00 +10 -2: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget shows title in app bar
+Fetching user from https://jsonplaceholder.typicode.com/users/1
+Error: 400
+00:00 +11 -2: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget counter starts at 5 - intentional failure
+Fetching user from https://jsonplaceholder.typicode.com/users/1
+Error: 400
+══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
+The following TestFailure was thrown running a test:
+Expected: exactly one matching candidate
+  Actual: _TextWidgetFinder:<Found 0 widgets with text "5": []>
+   Which: means none were found but one was expected
+Expected counter to start at 5, but it starts at 0
+
+When the exception was thrown, this was the stack:
+#4      main.<anonymous closure>.<anonymous closure> (file:///home/carlosfiori/projects/rtk_flutter/test/widget_test.dart:57:7)
+<asynchronous suspension>
+#5      testWidgets.<anonymous closure>.<anonymous closure> (package:flutter_test/src/widget_tester.dart:192:15)
+<asynchronous suspension>
+#6      TestWidgetsFlutterBinding._runTestBody (package:flutter_test/src/binding.dart:1952:5)
+<asynchronous suspension>
+<asynchronous suspension>
+(elided one frame from package:stack_trace)
+
+This was caught by the test expectation on the following line:
+  file:///home/carlosfiori/projects/rtk_flutter/test/widget_test.dart line 57
+The test description was:
+  counter starts at 5 - intentional failure
+════════════════════════════════════════════════════════════════════════════════════════════════════
+00:00 +11 -3: /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget counter starts at 5 - intentional failure [E]
+  Test failed. See exception logs above.
+  The test description was: counter starts at 5 - intentional failure
+
+00:01 +11 -3: Some tests failed.
+
+Failing tests:
+  /home/carlosfiori/projects/rtk_flutter/test/unit/user_test.dart: AdminUser strict permission check fails for regular admin
+  /home/carlosfiori/projects/rtk_flutter/test/unit/user_test.dart: User model age validation fails for negative age
+  /home/carlosfiori/projects/rtk_flutter/test/widget_test.dart: Counter widget counter starts at 5 - intentional failure


### PR DESCRIPTION
- Introduced `flutter_cmd.rs` for handling Flutter commands: analyze, pub get, and test.
- Added `dart/mod.rs` for Dart command filtering.
- Implemented output filtering for Flutter analyze, pub get, and test commands.
- Created new fixtures for testing Flutter command outputs.
- Updated command routing in `main.rs` to include Flutter and Dart commands.
- Enhanced TOML filter to recognize Flutter and Dart commands.
- Added classification rules for Flutter and Dart commands in the registry.
- Implemented tests to ensure proper functionality of new command filters.

## Summary
Adds first-class RTK support for Flutter and Dart commands, focused on shrinking noisy CLI output for flutter analyze, flutter pub get, flutter test, and dart analyze. It introduces new command routing, output filters, updated discovery rules, and fixtures/tests that validate grouped diagnostics, trimmed package-install logs, and compact test failure summaries.
-

## Test plan
Verified with the Rust test suite and formatting/lint checks where applicable, then manually exercised the new rtk flutter and rtk dart paths to inspect the rewritten CLI output. I also checked the sample Flutter fixtures to confirm the filters keep failures, summarize diagnostics by file, and remove the noisy pass-through logs.

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

