### PR TITLE
fix(git): wire up status_max_files and status_max_untracked config limits

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -1,6 +1,8 @@
 //! Filters git output — log, status, diff, and more — keeping just the essential info.
 
 use crate::core::args_utils;
+use crate::core::config;
+use crate::core::config::LimitsConfig;
 use crate::core::stream::{
     self, exec_capture, CaptureResult, FilterMode, LineHandler, LineStreamFilter, StdinMode,
 };
@@ -623,14 +625,19 @@ fn truncate_line(line: &str, width: usize) -> String {
 }
 
 pub(crate) fn format_status_output(porcelain: &str) -> String {
-    format_status_inner(porcelain, None)
+    format_status_inner(porcelain, None, None)
 }
 
+#[allow(dead_code)]
 pub(crate) fn format_status_output_detached(porcelain: &str, detached_ref: &str) -> String {
-    format_status_inner(porcelain, Some(detached_ref))
+    format_status_inner(porcelain, Some(detached_ref), None)
 }
 
-fn format_status_inner(porcelain: &str, detached: Option<&str>) -> String {
+fn format_status_inner(
+    porcelain: &str,
+    detached: Option<&str>,
+    limits: Option<&LimitsConfig>,
+) -> String {
     let lines: Vec<&str> = porcelain
         .lines()
         .filter(|line| !line.trim().is_empty())
@@ -652,8 +659,48 @@ fn format_status_inner(porcelain: &str, detached: Option<&str>) -> String {
         }
     }
 
-    for line in lines.iter().skip(1) {
-        output.push((*line).to_string());
+    // When limits are provided, cap tracked (staged/modified) and untracked files
+    // separately so the user's status_max_files and status_max_untracked knobs work.
+    if let Some(limits) = limits {
+        let mut tracked_count = 0usize;
+        let mut untracked_count = 0usize;
+        let mut tracked_hidden = 0usize;
+        let mut untracked_hidden = 0usize;
+
+        for line in lines.iter().skip(1) {
+            let is_untracked = line.starts_with("??");
+            if is_untracked {
+                if untracked_count < limits.status_max_untracked {
+                    output.push((*line).to_string());
+                    untracked_count += 1;
+                } else {
+                    untracked_hidden += 1;
+                }
+            } else {
+                if tracked_count < limits.status_max_files {
+                    output.push((*line).to_string());
+                    tracked_count += 1;
+                } else {
+                    tracked_hidden += 1;
+                }
+            }
+        }
+
+        let mut hints = Vec::new();
+        if tracked_hidden > 0 {
+            hints.push(format!("... +{} more changed file(s)", tracked_hidden));
+        }
+        if untracked_hidden > 0 {
+            hints.push(format!("... +{} more untracked file(s)", untracked_hidden));
+        }
+        for hint in hints {
+            output.push(hint);
+        }
+    } else {
+        // No limits: preserve existing unbounded behaviour for backward compat.
+        for line in lines.iter().skip(1) {
+            output.push((*line).to_string());
+        }
     }
 
     if lines.len() == 1 && lines[0].starts_with("##") {
@@ -879,9 +926,12 @@ fn run_status(args: &[String], verbose: u8, global_args: &[String]) -> Result<i3
         return Ok(result.exit_code);
     }
 
+    let limits = config::limits();
     let formatted = match extract_detached_head(&raw_output) {
-        Some(detached_ref) => format_status_output_detached(&result.stdout, &detached_ref),
-        None => format_status_output(&result.stdout),
+        Some(detached_ref) => {
+            format_status_inner(&result.stdout, Some(&detached_ref), Some(&limits))
+        }
+        None => format_status_inner(&result.stdout, None, Some(&limits)),
     };
 
     // Surface in-progress state (rebase/merge/cherry-pick/bisect/am) from the


### PR DESCRIPTION
`git status` has two user-configurable knobs in `LimitsConfig` — `status_max_files` and `status_max_untracked` — that have serde defaults and are documented in `src/core/README.md`, but no code ever reads them. The porcelain status formatter iterates every line without any cap, so setting `status_max_files = 2` in `config.toml` is a silent no-op.

The root cause is that `format_status_inner` was refactored to a straightforward porcelain-lines iterator when the compact-status rewrite landed, and the cap logic was never ported across. The fields sat orphaned in `config.rs` ever since.

This wires them up. `format_status_inner` now accepts an optional `LimitsConfig`. When limits are provided (from `run_status` via `config::limits()`), tracked files and untracked files are counted separately and capped at their respective limits, with a `"... +N more"` hint appended when files are hidden. When no limits are passed, the existing unbounded path runs unchanged, so all existing tests pass without modification.

The public `format_status_output` and `format_status_output_detached` wrappers continue to work unbounded for backward compatibility. The only production caller that gets limits is `run_status`, which is the actual `rtk git status` execution path.

Verified with `cargo test`: 2194 passed, 0 related failures (1 pre-existing sandbox infra failure on `test_tool_exists_finds_git`), all 8 `test_format_status_output_*` tests pass, all 252 git-module tests pass. `cargo check` is clean.

