### PR TITLE
fix(grep): keep rg on the ripgrep path — split the rg/grep rewrite rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ rtk filters and compresses command outputs before they reach your LLM context. S
 |-----------|-----------|----------|-----|---------|
 | `ls` / `tree` | 10x | 2,000 | 400 | -80% |
 | `cat` / `read` | 20x | 40,000 | 12,000 | -70% |
-| `grep` / `rg` | 8x | 16,000 | 3,200 | -80% |
+| `grep` | 8x | 16,000 | 3,200 | -80% |
 | `git status` | 10x | 3,000 | 600 | -80% |
 | `git diff` | 5x | 10,000 | 2,500 | -75% |
 | `git log` | 5x | 2,500 | 500 | -80% |
@@ -55,6 +55,11 @@ rtk filters and compresses command outputs before they reach your LLM context. S
 | **Total** | | **~118,000** | **~23,900** | **-80%** |
 
 > Estimates based on medium-sized TypeScript/Rust projects. Actual savings vary by project size.
+
+**Note on `rg`:** `rg` (ripgrep) is rewritten to `rtk rg`, a verbatim passthrough that forwards
+every argument to ripgrep and preserves its exact semantics. It is intentionally absent from the
+table above — as a passthrough it does not filter output, so it yields **no token savings**.
+Ripgrep's output is already compact, so preserving it verbatim is preferred over grouping.
 
 ## Installation
 
@@ -120,7 +125,7 @@ git status  # Automatically rewritten to rtk git status
 
 Hook-based agents rewrite Bash commands (e.g., `git status` -> `rtk git status`) before execution. Plugin-based agents, including Hermes, use their plugin API to rewrite commands before execution. The agent receives compact output without needing to call `rtk` explicitly.
 
-**Important:** the hook only runs on Bash tool calls. Claude Code built-in tools like `Read`, `Grep`, and `Glob` do not pass through the Bash hook, so they are not auto-rewritten. To get RTK's compact output for those workflows, use shell commands (`cat`/`head`/`tail`, `rg`/`grep`, `find`) or call `rtk read`, `rtk grep`, or `rtk find` directly.
+**Important:** the hook only runs on Bash tool calls. Claude Code built-in tools like `Read`, `Grep`, and `Glob` do not pass through the Bash hook, so they are not auto-rewritten. To get RTK's compact output for those workflows, use shell commands (`cat`/`head`/`tail`, `grep`, `rg`, `find`) or call `rtk read`, `rtk grep`, `rtk rg`, or `rtk find` directly. (`rtk rg` is the verbatim passthrough noted above.)
 
 ## How It Works
 

--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -202,7 +202,12 @@ Supporte a la fois la syntaxe RTK et la syntaxe native `find` (`-name`, `-type`,
 
 ### `rtk grep` -- Recherche dans le contenu
 
-**Objectif :** Remplace `grep` et `rg` avec une sortie groupee par fichier, tronquee.
+**Objectif :** Remplace `grep` avec une sortie groupee par fichier, tronquee.
+
+> Note : `rg` (ripgrep) n'est plus reecrit vers `rtk grep`. Il est reecrit vers
+> `rtk rg`, un passthrough qui transmet tous les arguments a ripgrep sans
+> filtrage, afin de preserver la semantique exacte de ripgrep (flags `--glob`,
+> `-g`, `-r`=`--replace`, recherche recursive par defaut, etc.).
 
 **Syntaxe :**
 ```bash
@@ -219,13 +224,13 @@ rtk grep <pattern> [chemin] [options]
 | `--file-type` | `-t` | tous | Filtrer par type (ts, py, rust, etc.) |
 | `--line-numbers` | `-n` | oui | Numeros de ligne (toujours actif) |
 
-Les arguments supplementaires sont transmis a `rg` (ripgrep). Les flags qui changent le format de sortie (`-c`, `-l`, `-L`, `-o`, `-Z`) passent directement a `rg`/`grep` sans filtrage RTK.
+Les arguments supplementaires sont transmis au moteur ripgrep sous-jacent. Les flags qui changent le format de sortie (`-c`, `-l`, `-L`, `-o`, `-Z`) passent directement au moteur sous-jacent sans filtrage RTK.
 
 **Economies :** ~80%
 
 **Avant / Apres :**
 ```
-# rg "fn run" (20 lignes)                   # rtk grep "fn run" (10 lignes)
+# grep "fn run" (20 lignes)                 # rtk grep "fn run" (10 lignes)
 src/git.rs:45:pub fn run(...)                src/git.rs
 src/git.rs:120:fn run_status(...)              45: pub fn run(...)
 src/ls.rs:12:pub fn run(...)                   120: fn run_status(...)
@@ -1255,7 +1260,8 @@ rtk verify
 | `gh pr/issue/run` | `rtk gh ...` |
 | `cargo test/build/clippy/check` | `rtk cargo ...` |
 | `cat/head/tail <fichier>` | `rtk read <fichier>` |
-| `rg/grep <pattern>` | `rtk grep <pattern>` |
+| `grep <pattern>` | `rtk grep <pattern>` |
+| `rg <pattern>` | `rtk rg <pattern>` (passthrough ripgrep verbatim) |
 | `ls` | `rtk ls` |
 | `tree` | `rtk tree` |
 | `wc` | `rtk wc` |

--- a/hooks/claude/test-rtk-rewrite.sh
+++ b/hooks/claude/test-rtk-rewrite.sh
@@ -107,7 +107,13 @@ test_rewrite "grep -rn pattern src/" \
 
 test_rewrite "rg pattern src/" \
   "rg pattern src/" \
-  "rtk grep pattern src/"
+  "rtk rg pattern src/"
+
+# rg keeps ripgrep-only flags (e.g. -g/--glob, -r=--replace) on the rtk rg
+# passthrough path instead of the grep-flavored rtk grep translation.
+test_rewrite "rg -g '*.rs' pattern" \
+  "rg -g '*.rs' pattern" \
+  "rtk rg -g '*.rs' pattern"
 
 test_rewrite "cargo test" \
   "cargo test" \

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1415,9 +1415,75 @@ mod tests {
 
     #[test]
     fn test_rewrite_rg_pattern() {
+        // `rg` routes to `rtk rg` (ripgrep passthrough), not `rtk grep`.
         assert_eq!(
             rewrite_command_no_prefixes("rg \"fn main\"", &[]),
-            Some("rtk grep \"fn main\"".into())
+            Some("rtk rg \"fn main\"".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_grep_pattern() {
+        // `grep` stays on the `rtk grep` filter.
+        assert_eq!(
+            rewrite_command_no_prefixes("grep \"fn main\" src/", &[]),
+            Some("rtk grep \"fn main\" src/".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_rg_forwards_args_to_rtk_rg() {
+        // The rewrite only swaps the target (`rg` → `rtk rg`); every argument is
+        // carried over verbatim. The split matters because of the TARGET: `rtk rg`
+        // falls through `run_fallback` to the real ripgrep, so ripgrep-only flags
+        // and flag ordering reach ripgrep intact instead of hitting the
+        // grep-flavored `rtk grep` runtime path (grep_cmd.rs) that drops/rejects them.
+        assert_eq!(
+            rewrite_command_no_prefixes("rg --hidden -g '*.rs' --stats foo", &[]),
+            Some("rtk rg --hidden -g '*.rs' --stats foo".into())
+        );
+        // `-r` means ripgrep's --replace (NOT grep's recursive). It must reach
+        // `rtk rg` verbatim; routing it to `rtk grep` would strip it at runtime.
+        assert_eq!(
+            rewrite_command_no_prefixes("rg -r 'NEW' pattern", &[]),
+            Some("rtk rg -r 'NEW' pattern".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_rg_pathless_pattern() {
+        // Path-less `rg PATTERN` (ripgrep recurses CWD) must reach real ripgrep
+        // via `rtk rg`, not `rtk grep` (which would read stdin under system grep).
+        assert_eq!(
+            rewrite_command_no_prefixes("rg TODO", &[]),
+            Some("rtk rg TODO".into())
+        );
+    }
+
+    #[test]
+    fn test_classify_rg_routes_to_rtk_rg() {
+        // `rtk rg` is a verbatim passthrough, so estimated savings is 0%.
+        assert_eq!(
+            classify_command("rg --glob '*.py' alpha"),
+            Classification::Supported {
+                rtk_equivalent: "rtk rg",
+                category: "Files",
+                estimated_savings_pct: 0.0,
+                status: RtkStatus::Existing,
+            }
+        );
+    }
+
+    #[test]
+    fn test_classify_grep_routes_to_rtk_grep() {
+        assert_eq!(
+            classify_command("grep -rn pattern src/"),
+            Classification::Supported {
+                rtk_equivalent: "rtk grep",
+                category: "Files",
+                estimated_savings_pct: 75.0,
+                status: RtkStatus::Existing,
+            }
         );
     }
 

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -88,10 +88,33 @@ pub const RULES: &[RtkRule] = &[
         subcmd_savings: &[],
         subcmd_status: &[],
     },
+    // `rg` and `grep` are split into two rules so each stays on its own backend.
+    // `rtk grep` runs ripgrep but applies grep-flavored argument translation
+    // (strips -r/-R/--recursive, translates BRE `\|` to PCRE `|`, defaults the
+    // path to `.`, forwards only a curated rg-flag allowlist). That translation
+    // corrupts genuine ripgrep invocations: ripgrep-only flags (`--hidden`,
+    // `-g`/`--glob`, `--stats`, `-uu`, `-P`, `--json`) and arbitrary flag
+    // ordering get dropped or rejected, and `rg PATTERN` (recursive over CWD)
+    // is mishandled (#1824, #2167, #2301, #2338). Routing `rg` to `rtk rg`
+    // keeps it on a faithful ripgrep path — `rtk rg` is not a Clap subcommand,
+    // so it falls through `run_fallback` in `main.rs`, which executes the real
+    // `rg` binary with every argument forwarded verbatim (metrics still tracked).
     RtkRule {
-        pattern: r"^(rg|grep)\s+",
+        pattern: r"^rg\s+",
+        rtk_cmd: "rtk rg",
+        rewrite_prefixes: &["rg"],
+        category: "Files",
+        // `rtk rg` is a verbatim passthrough (no output filtering), so the
+        // estimated savings is 0% — anything higher makes `rtk discover`
+        // falsely report `rg` as a high-value missed optimization.
+        savings_pct: 0.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
+    RtkRule {
+        pattern: r"^grep\s+",
         rtk_cmd: "rtk grep",
-        rewrite_prefixes: &["rg", "grep"],
+        rewrite_prefixes: &["grep"],
         category: "Files",
         savings_pct: 75.0,
         subcmd_savings: &[],


### PR DESCRIPTION
## Summary

The single rewrite rule `^(rg|grep)\s+` in `src/discover/rules.rs` collapses **both**
tools onto `rtk grep`. `rtk grep` runs ripgrep as its backend but applies
**grep-flavored** argument translation (`src/cmds/system/grep_cmd.rs`): it strips
`-r`/`-R`/`--recursive`, rewrites BRE `\|` to PCRE `|`, defaults empty paths to `.`,
and forwards only a curated allowlist of rg flags. That translation is correct for
`grep`, but it silently corrupts genuine **ripgrep** invocations:

- ripgrep-only flags (`--hidden`, `-g`/`--glob`, `--stats`, `-uu`, `-P`, `--json`)
  are dropped or rejected;
- the short-flag collision is decisive — `-r` is *recursive* in grep but `--replace`
  in ripgrep, so a grep-flavored wrapper that strips `-r` changes what `rg` means;
- path-less `rg PATTERN` (ripgrep recurses CWD) is mishandled.

This PR keeps each tool on its own backend by **splitting the one rule into two**:
`grep` keeps routing to `rtk grep` (unchanged), and `rg` now routes to `rtk rg`.
`rtk rg` is intentionally **not** a Clap subcommand, so it falls through
`run_fallback` in `main.rs`, which executes the real `rg` binary with every argument
forwarded **verbatim** (still metrics-tracked). No crossover in either direction;
ripgrep semantics stay faithful.

This is the **minimal, conflict-free** version of what the larger #2183 attempted.
It does not change `grep`'s backend and adds no new filtered subcommand, so it avoids
the conflicts/pushback #2183 hit while still resolving the `rg` correctness issues.
A real filtered `rtk rg` subcommand can come later as a separate, additive change.

### Changes

**`src/discover/rules.rs`**

- Split the `^(rg|grep)\s+` rule into `^rg\s+` → `rtk rg` and `^grep\s+` → `rtk grep`.
- The new `rg` rule carries `savings_pct: 0.0` because `rtk rg` is a verbatim
  passthrough (no output filtering). Keeping the inherited 75% would make
  `rtk discover` falsely report `rg` as a high-value missed optimization.

**`src/discover/registry.rs`**

- Updated `test_rewrite_rg_pattern` to expect `rtk rg` (was `rtk grep`).
- Added tests: `rg` and `grep` each route to their own target; ripgrep-only flags,
  flag ordering, the `-r`=`--replace` case, and path-less `rg PATTERN` are forwarded
  verbatim to `rtk rg`; classify reports `rtk rg` at 0% and `rtk grep` at 75%.

**Docs** (`README.md`, `docs/usage/FEATURES.md`)

- Updated the auto-rewrite table and the `rtk grep` section so `rg` is documented as
  rewriting to `rtk rg` (verbatim ripgrep passthrough), not `rtk grep`.

### Issues fixed

| Issue | Title |
|-------|-------|
| #1824 | rg auto-rewrite to rtk grep breaks normal ripgrep flag ordering (`--glob`, `-g`, `--version`) |
| #2167 | rtk grep calls system grep instead of ripgrep — breaks -g/--glob flags |
| #2301 | `rtk hook claude` rewrites `rg` → `rtk grep` so path-less ripgrep searches silently return 0 matches / hang on stdin |
| #2338 | rtk rewrite should keep rg on the ripgrep path |

### Known limitations / follow-ups (out of scope here)

`rtk rg` is intentionally **not** a Clap subcommand — it relies on `run_fallback`,
which is the generic path for any unknown `rtk <cmd>`. That path has two pre-existing
warts that now also apply to the (newly intentional) `rg` route:

1. When a `.rtk/filters.toml` exists and is untrusted, `run_fallback` prints
   `[rtk] WARNING: untrusted project filters …` (and runs TOML-filter lookup) before
   the ripgrep output — so it is not byte-for-byte clean passthrough in that case.
2. A successful fallback run records `record_parse_failure_silent(.., true)`, so
   legitimate `rg` usage shows up under `rtk gain --failures` as a parse failure.

These are broader `run_fallback` behaviors (true for every unknown command today), not
needed to fix the `rg` correctness bugs this PR targets. The minimal, safe follow-up is
to make declared passthrough tools first-class — e.g. special-case `args[0] == "rg"` in
`run_fallback` to skip the TOML/trust-warning path and the parse-failure accounting — or
add a real filtered `rtk rg` subcommand (the #2183 direction). I kept that out of this PR
to stay minimal and conflict-free; happy to send it as a focused follow-up.

### Relation to #2183

#2183 ("respect the invoked tool — grep runs grep, rg runs ripgrep") is still OPEN
and CONFLICTING. It took a bigger approach: a real filtered `rtk rg` subcommand **and**
switching `rtk grep` to system grep. This PR does **not** supersede that design wholesale —
it lands the smallest slice that fixes the open `rg` issues (the rewrite-rule split)
without touching `grep`'s backend or adding a subcommand, so it rebases cleanly on the
current `develop` and stays in scope. If maintainers prefer #2183's larger direction,
this can be closed; otherwise this unblocks the `rg` correctness issues now.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --all` — 2198 passed (the 2 local failures in
  `hooks::rewrite_cmd::tests::unattestable_passthrough::{test_plain_command_still_rewrites,
  test_fd_dup_redirect_still_rewrites}` are pre-existing on `develop` and depend on the
  developer's local Claude Code permission allow-list for `git status`; with a clean
  `$HOME` — as on CI — all of them pass, and they are unrelated to this diff)
- [x] Manual testing (built binary):
  ```
  rtk rewrite "rg --hidden -g '*.rs' --stats foo"  ->  rtk rg --hidden -g '*.rs' --stats foo
  rtk rewrite "rg -r 'NEW' pattern"                ->  rtk rg -r 'NEW' pattern
  rtk rewrite "rg TODO"                            ->  rtk rg TODO
  rtk rewrite "grep -rn foo src/"                  ->  rtk grep -rn foo src/
  rtk rg --glob '*.rs' 'pub fn run' src/discover/  ->  runs real ripgrep, matches (was: grep: unrecognized option --glob)
  ```
