### PR TITLE
fix(copilot): add missing 'get' to kubectl example in init template

### DIFF
--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -6889,20 +6889,4 @@ mod tests {
             hook_path.display()
         );
     }
-
-    #[test]
-    fn test_copilot_instructions_kubectl_get_not_dropped() {
-        // Regression: COPILOT_INSTRUCTIONS template previously translated
-        // 'kubectl get pods' to 'rtk kubectl pods', dropping the 'get' subcommand.
-        // Copilot agents following the template would run a failing command.
-        assert!(
-            COPILOT_INSTRUCTIONS.contains("rtk kubectl get pods"),
-            "COPILOT_INSTRUCTIONS must include 'rtk kubectl get pods' (not 'rtk kubectl pods')"
-        );
-        assert!(
-            !COPILOT_INSTRUCTIONS.contains("rtk kubectl pods\n")
-                && !COPILOT_INSTRUCTIONS.contains("rtk kubectl pods`"),
-            "COPILOT_INSTRUCTIONS must not contain 'rtk kubectl pods' without 'get'"
-        );
-    }
 }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -3909,7 +3909,7 @@ git status                 rtk git status
 git log -10                rtk git log -10
 cargo test                 rtk cargo test
 docker ps                  rtk docker ps
-kubectl get pods           rtk kubectl pods
+kubectl get pods           rtk kubectl get pods
 ```
 
 ## Meta commands (use directly)
@@ -6887,6 +6887,22 @@ mod tests {
             !hook_path.exists(),
             "Hook config must not be written when the upsert aborts: {}",
             hook_path.display()
+        );
+    }
+
+    #[test]
+    fn test_copilot_instructions_kubectl_get_not_dropped() {
+        // Regression: COPILOT_INSTRUCTIONS template previously translated
+        // 'kubectl get pods' to 'rtk kubectl pods', dropping the 'get' subcommand.
+        // Copilot agents following the template would run a failing command.
+        assert!(
+            COPILOT_INSTRUCTIONS.contains("rtk kubectl get pods"),
+            "COPILOT_INSTRUCTIONS must include 'rtk kubectl get pods' (not 'rtk kubectl pods')"
+        );
+        assert!(
+            !COPILOT_INSTRUCTIONS.contains("rtk kubectl pods\n")
+                && !COPILOT_INSTRUCTIONS.contains("rtk kubectl pods`"),
+            "COPILOT_INSTRUCTIONS must not contain 'rtk kubectl pods' without 'get'"
         );
     }
 }


### PR DESCRIPTION
The COPILOT_INSTRUCTIONS template translated 'kubectl get pods' to 'rtk kubectl pods', dropping the 'get' subcommand. This might confuse ai models, for that we try to keep the normal and rtk command in sync to prevent hallucinations.

Fix: change 'rtk kubectl pods' to 'rtk kubectl get pods' in the COPILOT_INSTRUCTIONS template string.

## Summary

Fix the tempalte to be a faithfull translation of the input.

Fixes #2471

## Test plan

ran a debug build, and used rtk init --copilot

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.


