### PR TITLE
fix(diff): exit 2 on unreadable operand per POSIX diff convention

### DIFF
--- a/src/cmds/git/diff_cmd.rs
+++ b/src/cmds/git/diff_cmd.rs
@@ -417,7 +417,6 @@ mod tests {
 
     #[test]
     fn test_diff_trouble_distinct_from_differ_and_same() {
-        // POSIX diff: 0 = same, 1 = differ, 2 = trouble — all distinct.
         assert_ne!(DIFF_EXIT_TROUBLE, 0);
         assert_ne!(DIFF_EXIT_TROUBLE, 1);
     }

--- a/src/cmds/git/diff_cmd.rs
+++ b/src/cmds/git/diff_cmd.rs
@@ -5,8 +5,13 @@ use anyhow::Result;
 use std::fs;
 use std::path::Path;
 
+/// POSIX diff "trouble" exit code: returned when an operand cannot be read
+/// (missing or unreadable file), distinct from 1 (files differ) and 0 (same).
+const DIFF_EXIT_TROUBLE: i32 = 2;
+
 /// Ultra-condensed diff - only changed lines, no context.
-/// Returns the diff-convention exit code: 0 if identical, 1 if files differ.
+/// Returns the diff-convention exit code: 0 if identical, 1 if files differ,
+/// 2 if an operand cannot be read.
 pub fn run(file1: &Path, file2: &Path, verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
@@ -14,8 +19,10 @@ pub fn run(file1: &Path, file2: &Path, verbose: u8) -> Result<i32> {
         eprintln!("Comparing: {} vs {}", file1.display(), file2.display());
     }
 
-    let content1 = fs::read_to_string(file1)?;
-    let content2 = fs::read_to_string(file2)?;
+    let (content1, content2) = match read_operands(file1, file2) {
+        Ok(contents) => contents,
+        Err(code) => return Ok(code),
+    };
     let raw = format!("{}\n---\n{}", content1, content2);
 
     let (rtk, exit_code) = render_file_diff(file1, file2, &content1, &content2);
@@ -28,6 +35,20 @@ pub fn run(file1: &Path, file2: &Path, verbose: u8) -> Result<i32> {
         &rtk,
     );
     Ok(exit_code)
+}
+
+/// Reads both operands. On any I/O error, prints a diff-style message to
+/// stderr and returns `DIFF_EXIT_TROUBLE` (2) as the error variant. Reading
+/// via `?` in `run` would collapse to exit 1 in main's error handler, which
+/// is indistinguishable from "files differ" — masking the failure (#2446).
+fn read_operands(file1: &Path, file2: &Path) -> std::result::Result<(String, String), i32> {
+    let read = |path: &Path| {
+        fs::read_to_string(path).map_err(|e| {
+            eprintln!("rtk diff: {}: {}", path.display(), e);
+            DIFF_EXIT_TROUBLE
+        })
+    };
+    Ok((read(file1)?, read(file2)?))
 }
 
 /// Renders the condensed file comparison and returns it with the
@@ -362,6 +383,43 @@ mod tests {
         let (out, code) = render_file_diff(Path::new("t1.txt"), Path::new("t2.txt"), "x\n", "y\n");
         assert!(out.contains("+1 added, -1 removed"));
         assert_eq!(code, 1);
+    }
+
+    // --- read_operands error exit code (issue #2446) ---
+
+    #[test]
+    fn test_read_operands_first_file_missing_exits_2() {
+        let existing = concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml");
+        let missing = concat!(env!("CARGO_MANIFEST_DIR"), "/rtk-no-such-file-2446.tmp");
+        assert_eq!(
+            read_operands(Path::new(missing), Path::new(existing)).unwrap_err(),
+            DIFF_EXIT_TROUBLE
+        );
+    }
+
+    #[test]
+    fn test_read_operands_second_file_missing_exits_2() {
+        let existing = concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml");
+        let missing = concat!(env!("CARGO_MANIFEST_DIR"), "/rtk-no-such-file-2446.tmp");
+        assert_eq!(
+            read_operands(Path::new(existing), Path::new(missing)).unwrap_err(),
+            DIFF_EXIT_TROUBLE
+        );
+    }
+
+    #[test]
+    fn test_read_operands_both_exist_ok() {
+        let a = concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml");
+        let b = concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.lock");
+        let (c1, c2) = read_operands(Path::new(a), Path::new(b)).expect("both files readable");
+        assert!(!c1.is_empty() && !c2.is_empty());
+    }
+
+    #[test]
+    fn test_diff_trouble_distinct_from_differ_and_same() {
+        // POSIX diff: 0 = same, 1 = differ, 2 = trouble — all distinct.
+        assert_ne!(DIFF_EXIT_TROUBLE, 0);
+        assert_ne!(DIFF_EXIT_TROUBLE, 1);
     }
 
     // --- condense_unified_diff ---


### PR DESCRIPTION
## Summary

Completes #2446. `rtk diff` now follows the full POSIX diff exit-code convention:

| Scenario | Before #2394 | After #2394 (merged) | This PR |
|---|---|---|---|
| Files identical | 0 ✓ | 0 ✓ | 0 ✓ |
| Files differ | 0 ✗ | **1 ✓** | 1 ✓ |
| Unreadable operand (missing file, etc.) | 1 ✗ | 1 ✗ | **2 ✓** |

The differing-files row was resolved by #2394 (merged). This PR closes the remaining gap: I/O errors.

## Root cause

`run()` read both operands with `?`. A read failure propagated up to `main()`'s error handler, which returns exit **1** for any `Err` — indistinguishable from "files differ". So a typo'd path or a deleted file was silently reported as a difference (exit 1) instead of trouble (exit 2).

## Fix

Read the operands explicitly via a small `read_operands` helper: on any I/O error it prints a diff-style message to stderr and returns exit code 2, mirroring system `diff`. No change to the identical/differ paths.

```console
$ rtk diff one.yaml missing.yaml; echo "exit:$?"
rtk diff: missing.yaml: No such file or directory (os error 2)
exit:2                  # was: exit:1

$ diff one.yaml missing.yaml; echo "exit:$?"   # system diff, for parity
diff: missing.yaml: No such file or directory
exit:2
```

## Testing

- 4 new unit tests: first-operand-missing → 2, second-operand-missing → 2, both-readable → Ok, and exit-2 distinct from 0/1. Paths built from `CARGO_MANIFEST_DIR` so they don't depend on cwd.
- `cargo fmt --all --check && cargo clippy --all-targets && cargo test` — clean, 2203 passed.
- Manual verification against system `diff` for all three exit codes (0/1/2).

No output-format change, so token savings are unaffected (the error path prints a one-line stderr message, same as before).