### PR TITLE
fix(hook): prevent flag injection in rtk-rewrite hooks (#1350)

### DIFF
--- a/hooks/claude/rtk-rewrite.sh
+++ b/hooks/claude/rtk-rewrite.sh
@@ -52,7 +52,10 @@ if [ -z "$CMD" ]; then
 fi
 
 # Delegate all rewrite + permission logic to the Rust binary.
-REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null)
+# The `--` terminator is REQUIRED: without it, a command like "--help" or "-h"
+# would be interpreted by clap as a flag to `rtk rewrite`, causing the help text
+# to be emitted as the rewritten command and fed back to the agent (issue #1350).
+REWRITTEN=$(rtk rewrite -- "$CMD" 2>/dev/null)
 EXIT_CODE=$?
 
 case $EXIT_CODE in

--- a/hooks/claude/test-rtk-rewrite.sh
+++ b/hooks/claude/test-rtk-rewrite.sh
@@ -327,6 +327,34 @@ test_rewrite "node (no pattern)" \
 
 echo ""
 
+# ---- SECTION 5b: Flag injection safety (#1350) ----
+# Without the `--` terminator before "$CMD", an input like "--help" would be
+# interpreted by clap as a flag to `rtk rewrite`, causing the help text to be
+# emitted as the "rewritten" command and shell-executed by the agent.
+# Each of these inputs must produce NO rewrite.
+echo "--- Flag injection safety (#1350) ---"
+test_rewrite "flag injection: --help must not trigger clap help" \
+  "--help" \
+  ""
+
+test_rewrite "flag injection: -h must not trigger clap short help" \
+  "-h" \
+  ""
+
+test_rewrite "flag injection: --version must not trigger clap version" \
+  "--version" \
+  ""
+
+test_rewrite "flag injection: -V must not trigger clap short version" \
+  "-V" \
+  ""
+
+test_rewrite "flag injection: lone -- must not crash the hook" \
+  "--" \
+  ""
+
+echo ""
+
 # ---- SECTION 6: Audit logging ----
 echo "--- Audit logging (RTK_HOOK_AUDIT=1) ---"
 

--- a/hooks/cursor/rtk-rewrite.sh
+++ b/hooks/cursor/rtk-rewrite.sh
@@ -41,7 +41,10 @@ fi
 # Delegate all rewrite logic to the Rust binary.
 # Exit codes: 0 = allow rewrite, 1 = no rewrite (passthrough),
 #             2 = deny, 3 = ask.
-REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null)
+# The `--` terminator is REQUIRED: without it, a command like "--help" or "-h"
+# would be interpreted by clap as a flag to `rtk rewrite`, causing the help text
+# to be emitted as the rewritten command and fed back to the agent (issue #1350).
+REWRITTEN=$(rtk rewrite -- "$CMD" 2>/dev/null)
 RC=$?
 if [ "$RC" -ne 0 ] && [ "$RC" -ne 3 ]; then
   echo '{}'

--- a/src/main.rs
+++ b/src/main.rs
@@ -3367,6 +3367,38 @@ mod tests {
         }
     }
 
+    /// SECURITY: Hooks call `rtk rewrite -- "$CMD"` to prevent flag injection.
+    /// Without the `--` terminator, a command like "--help" or "-h" would be
+    /// interpreted by clap as a flag to the `rewrite` subcommand — clap would
+    /// print help text and exit 0, the hook would then feed that help text
+    /// back to the agent as the rewritten command, which is shell-executed.
+    /// See issue #1350. This test asserts that `--` causes hyphen-prefixed
+    /// inputs to be captured as positional args rather than triggering clap's
+    /// built-in help/version paths.
+    #[test]
+    fn test_rewrite_clap_double_dash_blocks_flag_injection() {
+        let injection_inputs = ["--help", "-h", "--version", "-V"];
+        for injected in injection_inputs {
+            let result = Cli::try_parse_from(["rtk", "rewrite", "--", injected]);
+            assert!(
+                result.is_ok(),
+                "`rtk rewrite -- {injected:?}` must parse without triggering clap"
+            );
+            if let Ok(cli) = result {
+                match cli.command {
+                    Commands::Rewrite { ref args } => {
+                        assert_eq!(
+                            args,
+                            &vec![injected.to_string()],
+                            "{injected:?} must be captured as a positional arg, not a flag"
+                        );
+                    }
+                    _ => panic!("expected Rewrite command"),
+                }
+            }
+        }
+    }
+
     #[test]
     fn test_merge_filters_with_no_args() {
         let filters = vec![];


### PR DESCRIPTION
Fixes #1350.

The Claude/Cursor rewrite hooks called `rtk rewrite "$CMD"` without a `--` terminator. When a user command begins with a hyphen (`--help`, `-h`), clap interprets it as a flag to the `rewrite` subcommand: it prints help/usage text and exits 0. The hook then feeds that help text back to the agent as the "rewritten" command, which is shell-executed — a flag-injection footgun.

## Fix
- Add the `--` terminator: `rtk rewrite -- "$CMD"` in both `hooks/claude/rtk-rewrite.sh` and `hooks/cursor/rtk-rewrite.sh`, so hyphen-prefixed input is always captured as a positional arg.
- Add a clap-level regression test asserting `rtk rewrite -- <flagish>` parses the input as a positional rather than triggering clap's built-in help/version paths.
- Add hook-level shell tests (section 5b) covering `--help`, `-h`, `--version`, `-V`, and lone `--`.

## Test verification (RED → GREEN)

RED - prod fix reverted (`rtk rewrite "$CMD"`), `hooks/claude/test-rtk-rewrite.sh` section 5b:
```
--- Flag injection safety (#1350) ---
  FAIL flag injection: --help must not trigger clap help
  -h, --help
  FAIL flag injection: -h must not trigger clap short help
  -h, --help           Print help (see more with '--help')
```

GREEN - with the `--` terminator, after rebasing onto current `develop`:
```
--- Flag injection safety (#1350) ---
  PASS flag injection: --help must not trigger clap help -> (no rewrite)
  PASS flag injection: -h must not trigger clap short help -> (no rewrite)
  PASS flag injection: --version must not trigger clap version -> (no rewrite)
  PASS flag injection: -V must not trigger clap short version -> (no rewrite)
  PASS flag injection: lone -- must not crash the hook -> (no rewrite)
```

Rust targeted regression:
```
cargo test test_rewrite_clap_double_dash_blocks_flag_injection
test tests::test_rewrite_clap_double_dash_blocks_flag_injection ... ok
test result: ok. 1 passed; 0 failed
```

Full local gate after rebase:
```
cargo fmt --all --check && cargo clippy --all-targets && cargo test
test result: ok. 2393 passed; 0 failed; 8 ignored
test result: ok. 6 passed; 0 failed
test result: ok. 11 passed; 0 failed
test result: ok. 6 passed; 0 failed
test result: ok. 14 passed; 0 failed
test result: ok. 5 passed; 0 failed
test result: ok. 11 passed; 0 failed
```

(Re-proposes the work from the accidentally-closed #1370, rebased onto current `develop`.)
