### PR TITLE
fix(json): only flag strict ISO dates, not 10-char dashed strings (#1416)

### DIFF
--- a/src/cmds/system/json_cmd.rs
+++ b/src/cmds/system/json_cmd.rs
@@ -8,6 +8,9 @@ use std::fs;
 use std::io::{self, Read};
 use std::path::Path;
 
+const ISO_DATE_LEN: usize = 10;
+const ISO_DATE_DASH_POSITIONS: [usize; 2] = [4, 7];
+
 /// Reject non-JSON files with a clear error before doing any I/O.
 fn validate_json_extension(file: &Path) -> Result<()> {
     if let Some(ext) = file.extension().and_then(|e| e.to_str()) {
@@ -213,7 +216,7 @@ fn extract_schema(value: &Value, depth: usize, max_depth: usize) -> String {
                 // Check if it looks like a URL, date, etc.
                 if s.starts_with("http") {
                     format!("{}url", indent)
-                } else if s.contains('-') && s.len() == 10 {
+                } else if is_iso_calendar_date(s) {
                     format!("{}date?", indent)
                 } else {
                     format!("{}string", indent)
@@ -274,6 +277,17 @@ fn extract_schema(value: &Value, depth: usize, max_depth: usize) -> String {
             }
         }
     }
+}
+
+fn is_iso_calendar_date(value: &str) -> bool {
+    value.len() == ISO_DATE_LEN
+        && value.bytes().enumerate().all(|(index, byte)| {
+            if ISO_DATE_DASH_POSITIONS.contains(&index) {
+                byte == b'-'
+            } else {
+                byte.is_ascii_digit()
+            }
+        })
 }
 
 #[cfg(test)]
@@ -363,5 +377,47 @@ mod tests {
     #[test]
     fn test_compact_truncates_mixed_ascii_multibyte_string() {
         assert_value_truncated(&("a".repeat(76) + &"日本語".repeat(5)));
+    }
+
+    // Regression for #1416: 10-char strings containing `-` (e.g. EKS cluster
+    // names like `my-cluster`) were classified as `date?`. The schema
+    // extractor must only flag strict ISO dates `YYYY-MM-DD`.
+    #[test]
+    fn test_extract_schema_eks_cluster_name_is_string_not_date() {
+        let json: Value =
+            serde_json::from_str(r#"{"clusters": ["my-cluster"]}"#).unwrap();
+        let schema = extract_schema(&json, 0, 5);
+        assert!(
+            !schema.contains("date?"),
+            "10-char dashed cluster name must not be tagged as date?: {}",
+            schema
+        );
+        assert!(schema.contains("string"));
+    }
+
+    #[test]
+    fn test_extract_schema_iso_date_still_flagged() {
+        let json: Value = serde_json::from_str(r#"{"birthday": "2024-01-15"}"#).unwrap();
+        let schema = extract_schema(&json, 0, 5);
+        assert!(schema.contains("date?"), "ISO date should still be flagged: {}", schema);
+    }
+
+    // Adjacent 10-char dashed strings that aren't dates must classify as string.
+    #[test]
+    fn test_extract_schema_dashed_non_date_strings() {
+        for sample in [
+            "my-cluster",   // EKS cluster name
+            "abcd-12-xy",   // 10-char dashed identifier
+            "foo-bar-ab",   // dashes but not date format
+        ] {
+            let json: Value = serde_json::from_str(&format!(r#"{{"v": "{}"}}"#, sample)).unwrap();
+            let schema = extract_schema(&json, 0, 5);
+            assert!(
+                !schema.contains("date?"),
+                "{} must not be tagged as date?: {}",
+                sample,
+                schema
+            );
+        }
     }
 }


### PR DESCRIPTION
Fixes #1416.

`extract_schema` flagged any 10-character string containing a `-` as `date?`. Cluster names like `argocd-dev` (10 chars, dashed) were therefore rendered as `date?` instead of `string`, so the real value disappeared from the inferred schema.

## Fix

Replace the `s.contains('-') && s.len() == 10` heuristic with `is_iso_calendar_date()`, an allocation-free byte scan that accepts only the strict `YYYY-MM-DD` shape (ASCII digits everywhere except `-` at index 4 and 7). No regex, so the schema path keeps its current cost.

## Reproduction

`extract_schema` is the `rtk json --keys-only` path.

Before, on `develop`:

```
$ echo '{"clusters": ["argocd-dev"], "birthday": "2024-01-15"}' | rtk json - --keys-only
{
  birthday: date?,
  clusters:
  [
    date?
  ]
}
```

After:

```
{
  birthday: date?,
  clusters:
  [
    string
  ]
}
```

Real ISO dates are still flagged.

## Test verification (RED → GREEN)

RED — the new tests on unmodified `develop`:

```
test cmds::system::json_cmd::tests::test_extract_schema_dashed_non_date_strings ... FAILED
test cmds::system::json_cmd::tests::test_extract_schema_eks_cluster_name_is_string_not_date ... FAILED

thread '...test_extract_schema_eks_cluster_name_is_string_not_date' panicked:
10-char dashed cluster name must not be tagged as date?: {
  clusters:
  [
    date?
  ]
}

test result: FAILED. 11 passed; 2 failed
```

GREEN — with the fix:

```
test result: ok. 13 passed; 0 failed
```

Full suite `cargo test --all`: 2625 passed on `develop` → 2628 passed here, 0 failed.

## Note on scope

`rtk aws eks list-clusters` (the command quoted in #1416) now routes through `filter_json_compact`, which preserves string values, so that specific command no longer prints `date?` on `develop`. The misclassification the issue diagnosed is still live in the schema extractor, and that is what this PR fixes — happy to drop the `Fixes` keyword if you would rather keep #1416 open.

Rebased onto current `develop`. Re-proposes the accidentally-closed #1530.
