### PR TITLE
fix(init): honor RTK_TELEMETRY_DISABLED in consent prompt (#1307)

### DIFF
--- a/src/core/telemetry.rs
+++ b/src/core/telemetry.rs
@@ -25,8 +25,8 @@ pub fn maybe_ping() {
         return;
     }
 
-    // Check opt-out: env var
-    if std::env::var("RTK_TELEMETRY_DISABLED").unwrap_or_default() == "1" {
+    // Check opt-out: env var (single source of truth in telemetry_cmd)
+    if super::telemetry_cmd::telemetry_disabled_by_env() {
         return;
     }
 

--- a/src/core/telemetry_cmd.rs
+++ b/src/core/telemetry_cmd.rs
@@ -1,6 +1,9 @@
 use anyhow::{Context, Result};
 use clap::Subcommand;
 
+const TELEMETRY_DISABLED_ENV: &str = "RTK_TELEMETRY_DISABLED";
+const TELEMETRY_DISABLED_VALUE: &str = "1";
+
 #[derive(Debug, Subcommand)]
 pub enum TelemetrySubcommand {
     Status,
@@ -26,7 +29,7 @@ pub fn run(command: &TelemetrySubcommand) -> Result<()> {
 /// `telemetry::maybe_ping` never diverge — if the accepted values ever grow
 /// (e.g. `"true"`, `"y"`), they change here once.
 pub fn telemetry_disabled_by_env() -> bool {
-    std::env::var("RTK_TELEMETRY_DISABLED").unwrap_or_default() == "1"
+    std::env::var(TELEMETRY_DISABLED_ENV).unwrap_or_default() == TELEMETRY_DISABLED_VALUE
 }
 
 fn run_status() -> Result<()> {
@@ -191,4 +194,41 @@ fn send_erasure_request(device_hash: &str) -> Result<()> {
         .send_string(&payload.to_string())?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression for #1307: the env opt-out must short-circuit telemetry
+    /// consent paths so `rtk init` cannot hang in non-interactive environments.
+    /// All cases are bundled in one test to serialize env-var mutations.
+    #[test]
+    fn test_telemetry_disabled_by_env_honors_opt_out() {
+        #[allow(deprecated)]
+        std::env::remove_var(TELEMETRY_DISABLED_ENV);
+        assert!(
+            !telemetry_disabled_by_env(),
+            "unset env must not count as disabled"
+        );
+
+        #[allow(deprecated)]
+        std::env::set_var(TELEMETRY_DISABLED_ENV, TELEMETRY_DISABLED_VALUE);
+        assert!(
+            telemetry_disabled_by_env(),
+            "RTK_TELEMETRY_DISABLED=1 must disable telemetry prompts (issue #1307)"
+        );
+
+        for other in ["0", "true", "false", "yes", "no", ""] {
+            #[allow(deprecated)]
+            std::env::set_var(TELEMETRY_DISABLED_ENV, other);
+            assert!(
+                !telemetry_disabled_by_env(),
+                "value {other:?} must not be treated as disabled"
+            );
+        }
+
+        #[allow(deprecated)]
+        std::env::remove_var(TELEMETRY_DISABLED_ENV);
+    }
 }

--- a/src/core/telemetry_cmd.rs
+++ b/src/core/telemetry_cmd.rs
@@ -18,6 +18,17 @@ pub fn run(command: &TelemetrySubcommand) -> Result<()> {
     }
 }
 
+/// Returns true when telemetry is explicitly disabled through the
+/// `RTK_TELEMETRY_DISABLED` env var (value `"1"`).
+///
+/// Single source of truth for the env opt-out so the consent prompt
+/// (`init::prompt_telemetry_consent`), the status command, and
+/// `telemetry::maybe_ping` never diverge — if the accepted values ever grow
+/// (e.g. `"true"`, `"y"`), they change here once.
+pub fn telemetry_disabled_by_env() -> bool {
+    std::env::var("RTK_TELEMETRY_DISABLED").unwrap_or_default() == "1"
+}
+
 fn run_status() -> Result<()> {
     let config = crate::core::config::Config::load().unwrap_or_default();
 
@@ -33,7 +44,7 @@ fn run_status() -> Result<()> {
         "no"
     };
 
-    let env_override = std::env::var("RTK_TELEMETRY_DISABLED").unwrap_or_default() == "1";
+    let env_override = telemetry_disabled_by_env();
 
     println!("Telemetry status:");
     println!("  consent:       {}", consent_str);

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -467,6 +467,17 @@ pub fn save_telemetry_consent(accepted: bool) -> Result<()> {
         .context("Failed to save telemetry consent to config.toml")
 }
 
+/// Returns true when telemetry is explicitly disabled through the
+/// `RTK_TELEMETRY_DISABLED` env var (value `"1"`).
+///
+/// Kept as a small pure function so the consent prompt short-circuits before
+/// touching stdin, and so tests can cover the opt-out path without a TTY.
+/// Mirrors the check in `telemetry::maybe_ping` so both the prompt and the
+/// ping honour the same env toggle.
+fn telemetry_disabled_by_env() -> bool {
+    std::env::var("RTK_TELEMETRY_DISABLED").unwrap_or_default() == "1"
+}
+
 fn prompt_telemetry_consent() -> Result<()> {
     use std::io::{self, BufRead, IsTerminal};
 
@@ -475,6 +486,16 @@ fn prompt_telemetry_consent() -> Result<()> {
         Some(true) => return Ok(()),
         Some(false) => return Ok(()),
         None => {}
+    }
+
+    // Explicit opt-out must short-circuit before the TTY heuristic: some
+    // non-interactive environments (devcontainer `postCreateCommand`, certain
+    // CI agents) hand rtk a pseudo-TTY, so `is_terminal()` returns true even
+    // though no human is available to answer — the prompt then hangs forever.
+    // Setting `RTK_TELEMETRY_DISABLED=1` is the documented workaround, so the
+    // init prompt has to honour it too, not only `telemetry::maybe_ping`.
+    if telemetry_disabled_by_env() {
+        return Ok(());
     }
 
     if !io::stdin().is_terminal() {
@@ -4754,6 +4775,42 @@ mod tests {
             RTK_INSTRUCTIONS.contains(RTK_BLOCK_END),
             "RTK_INSTRUCTIONS must end with RTK_BLOCK_END marker"
         );
+    }
+
+    /// Regression for #1307: `RTK_TELEMETRY_DISABLED=1` must short-circuit the
+    /// consent prompt so `rtk init` cannot hang in non-interactive environments.
+    /// All cases are bundled in one test to serialize env-var mutations (env is
+    /// process-global and cargo runs tests in parallel).
+    #[test]
+    fn test_telemetry_disabled_by_env_honors_opt_out() {
+        const VAR: &str = "RTK_TELEMETRY_DISABLED";
+
+        #[allow(deprecated)]
+        std::env::remove_var(VAR);
+        assert!(
+            !telemetry_disabled_by_env(),
+            "unset env must not count as disabled"
+        );
+
+        #[allow(deprecated)]
+        std::env::set_var(VAR, "1");
+        assert!(
+            telemetry_disabled_by_env(),
+            "RTK_TELEMETRY_DISABLED=1 must disable the consent prompt (issue #1307)"
+        );
+
+        // Only the exact value "1" is the opt-out, matching telemetry::maybe_ping.
+        for other in ["0", "true", "false", "yes", "no", ""] {
+            #[allow(deprecated)]
+            std::env::set_var(VAR, other);
+            assert!(
+                !telemetry_disabled_by_env(),
+                "value {other:?} must not be treated as disabled"
+            );
+        }
+
+        #[allow(deprecated)]
+        std::env::remove_var(VAR);
     }
 
     #[test]

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -4766,42 +4766,6 @@ mod tests {
         );
     }
 
-    /// Regression for #1307: `RTK_TELEMETRY_DISABLED=1` must short-circuit the
-    /// consent prompt so `rtk init` cannot hang in non-interactive environments.
-    /// All cases are bundled in one test to serialize env-var mutations (env is
-    /// process-global and cargo runs tests in parallel).
-    #[test]
-    fn test_telemetry_disabled_by_env_honors_opt_out() {
-        const VAR: &str = "RTK_TELEMETRY_DISABLED";
-
-        #[allow(deprecated)]
-        std::env::remove_var(VAR);
-        assert!(
-            !crate::core::telemetry_cmd::telemetry_disabled_by_env(),
-            "unset env must not count as disabled"
-        );
-
-        #[allow(deprecated)]
-        std::env::set_var(VAR, "1");
-        assert!(
-            crate::core::telemetry_cmd::telemetry_disabled_by_env(),
-            "RTK_TELEMETRY_DISABLED=1 must disable the consent prompt (issue #1307)"
-        );
-
-        // Only the exact value "1" is the opt-out, matching telemetry::maybe_ping.
-        for other in ["0", "true", "false", "yes", "no", ""] {
-            #[allow(deprecated)]
-            std::env::set_var(VAR, other);
-            assert!(
-                !crate::core::telemetry_cmd::telemetry_disabled_by_env(),
-                "value {other:?} must not be treated as disabled"
-            );
-        }
-
-        #[allow(deprecated)]
-        std::env::remove_var(VAR);
-    }
-
     #[test]
     fn test_migration_removes_old_block() {
         let input = format!(

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -467,17 +467,6 @@ pub fn save_telemetry_consent(accepted: bool) -> Result<()> {
         .context("Failed to save telemetry consent to config.toml")
 }
 
-/// Returns true when telemetry is explicitly disabled through the
-/// `RTK_TELEMETRY_DISABLED` env var (value `"1"`).
-///
-/// Kept as a small pure function so the consent prompt short-circuits before
-/// touching stdin, and so tests can cover the opt-out path without a TTY.
-/// Mirrors the check in `telemetry::maybe_ping` so both the prompt and the
-/// ping honour the same env toggle.
-fn telemetry_disabled_by_env() -> bool {
-    std::env::var("RTK_TELEMETRY_DISABLED").unwrap_or_default() == "1"
-}
-
 fn prompt_telemetry_consent() -> Result<()> {
     use std::io::{self, BufRead, IsTerminal};
 
@@ -494,7 +483,7 @@ fn prompt_telemetry_consent() -> Result<()> {
     // though no human is available to answer — the prompt then hangs forever.
     // Setting `RTK_TELEMETRY_DISABLED=1` is the documented workaround, so the
     // init prompt has to honour it too, not only `telemetry::maybe_ping`.
-    if telemetry_disabled_by_env() {
+    if crate::core::telemetry_cmd::telemetry_disabled_by_env() {
         return Ok(());
     }
 
@@ -4788,14 +4777,14 @@ mod tests {
         #[allow(deprecated)]
         std::env::remove_var(VAR);
         assert!(
-            !telemetry_disabled_by_env(),
+            !crate::core::telemetry_cmd::telemetry_disabled_by_env(),
             "unset env must not count as disabled"
         );
 
         #[allow(deprecated)]
         std::env::set_var(VAR, "1");
         assert!(
-            telemetry_disabled_by_env(),
+            crate::core::telemetry_cmd::telemetry_disabled_by_env(),
             "RTK_TELEMETRY_DISABLED=1 must disable the consent prompt (issue #1307)"
         );
 
@@ -4804,7 +4793,7 @@ mod tests {
             #[allow(deprecated)]
             std::env::set_var(VAR, other);
             assert!(
-                !telemetry_disabled_by_env(),
+                !crate::core::telemetry_cmd::telemetry_disabled_by_env(),
                 "value {other:?} must not be treated as disabled"
             );
         }


### PR DESCRIPTION
Fixes #1307.

`rtk init`'s telemetry consent prompt only bailed on a non-TTY check. Some non-interactive environments (devcontainer `postCreateCommand`, certain CI agents) hand rtk a pseudo-TTY, so `is_terminal()` returns true and the prompt blocks forever waiting on stdin. `RTK_TELEMETRY_DISABLED=1` is the documented opt-out and is honoured by `telemetry::maybe_ping`, but the consent prompt ignored it.

## Fix
Add a `telemetry_disabled_by_env()` helper and short-circuit `prompt_telemetry_consent()` with `return Ok(())` when `RTK_TELEMETRY_DISABLED=1`, before the TTY heuristic — mirroring the check already used in `maybe_ping`.

## Test verification (RED → GREEN)
The hang itself only reproduces under a real pseudo-TTY, which the test harness can't provide; the original regression remains guarded by the unit test on `telemetry_disabled_by_env()`.

RED - patch reverted (helper removed):
```
error[E0425]: cannot find function `telemetry_disabled_by_env` in this scope
error: could not compile `rtk` (bin "rtk" test) due to 4 previous errors
```

GREEN - with the original fix:
```
running 1 test
test result: ok. 1 passed; 0 failed
```

Reviewer follow-up RED - with the test-location change reverted:
```
FAIL: test missing from telemetry_cmd.rs
```

Reviewer follow-up GREEN - after moving the test to `telemetry_cmd`:
```
207:    fn test_telemetry_disabled_by_env_honors_opt_out() {
PASS: test lives in telemetry_cmd.rs
PASS: test removed from init.rs
```

Full gate after rebase onto current `develop`:
```
cargo fmt --all --check && cargo clippy --all-targets && cargo test
test result: ok. 2363 passed; 0 failed; 8 ignored
test result: ok. 6 passed; 0 failed
test result: ok. 11 passed; 0 failed
test result: ok. 6 passed; 0 failed
test result: ok. 14 passed; 0 failed
test result: ok. 5 passed; 0 failed
test result: ok. 11 passed; 0 failed
```

(Re-proposes the accidentally-closed #1369, rebased onto current `develop`.)
