### PR TITLE
fix(gradle): match normalized gradlew/gradle basename lookups (#1177, #1178)

### DIFF
--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -1965,4 +1965,38 @@ expected = "output line 1\noutput line 2"
         );
         assert_eq!(found.unwrap().name, "my-new-tool");
     }
+
+    /// Verify the gradle filter matches the normalized lookup string RTK actually
+    /// produces at runtime. RTK strips leading `./` and uses the basename, so
+    /// `rtk ./gradlew tasks` produces lookup `"gradlew tasks"`, not `"./gradlew tasks"`.
+    /// Regression test for #1177: the old regex `^(gradle|gradlew|\\./)gradlew?\b`
+    /// never matched the basename form and caused every Gradle invocation to fall
+    /// through to passthrough.
+    #[test]
+    fn test_gradle_filter_matches_normalized_lookup() {
+        let filters = make_filters(BUILTIN_TOML);
+
+        // These are the exact strings RTK's basename-normalisation produces at runtime.
+        for lookup in &["gradlew tasks", "gradle build", "gradlew --version"] {
+            let found = find_filter_in(lookup, &filters);
+            assert!(
+                found.is_some(),
+                "gradle filter must match normalized lookup {:?} (basename, no ./)",
+                lookup
+            );
+            assert_eq!(
+                found.unwrap().name,
+                "gradle",
+                "wrong filter matched for {:?}",
+                lookup
+            );
+        }
+
+        // Must NOT match unrelated commands.
+        assert!(
+            find_filter_in("gradlewrapper build", &filters).map(|f| f.name.as_str())
+                != Some("gradle"),
+            "gradle filter must not match 'gradlewrapper'"
+        );
+    }
 }

--- a/src/filters/gradle.toml
+++ b/src/filters/gradle.toml
@@ -1,6 +1,6 @@
 [filters.gradle]
 description = "Compact Gradle build output — strip progress, keep tasks and errors"
-match_command = "^(gradle|gradlew|\\./)gradlew?\\b"
+match_command = "^gradlew?\\b"
 strip_ansi = true
 strip_lines_matching = [
   "^\\s*$",
@@ -14,6 +14,9 @@ strip_lines_matching = [
   "^> Task :.*FROM-CACHE$",
   "^Starting a Gradle Daemon",
   "^Daemon will be stopped",
+  "^Calculating task graph",
+  "^Reusing configuration cache",
+  "^Configuration cache",
 ]
 truncate_lines_at = 150
 max_lines = 50
@@ -33,3 +36,13 @@ expected = "BUILD SUCCESSFUL in 8s\n7 actionable tasks: 7 executed"
 name = "empty after stripping"
 input = "> Configuring project :app\n"
 expected = "gradle: ok"
+
+[[tests.gradle]]
+name = "strips configuration cache chatter, keeps task output"
+input = "Calculating task graph as no cached configuration is available for tasks: build\nReusing configuration cache.\nConfiguration cache entry stored.\n> Task :compileJava\n> Task :test\nBUILD SUCCESSFUL in 5s"
+expected = "> Task :compileJava\n> Task :test\nBUILD SUCCESSFUL in 5s"
+
+[[tests.gradle]]
+name = "gradlew help output — daemon and daemon-stopped stripped"
+input = "Starting a Gradle Daemon (subsequent builds will be faster)\n> Task :help\n\nWelcome to Gradle 8.6.\n\nDaemon will be stopped at the end of the build stopping after idling timeout of 3 hours"
+expected = "> Task :help\nWelcome to Gradle 8.6."

--- a/src/filters/gradle.toml
+++ b/src/filters/gradle.toml
@@ -16,7 +16,7 @@ strip_lines_matching = [
   "^Daemon will be stopped",
   "^Calculating task graph",
   "^Reusing configuration cache",
-  "^Configuration cache",
+  "^Configuration cache entry (stored|reused)",
 ]
 truncate_lines_at = 150
 max_lines = 50
@@ -46,3 +46,8 @@ expected = "> Task :compileJava\n> Task :test\nBUILD SUCCESSFUL in 5s"
 name = "gradlew help output — daemon and daemon-stopped stripped"
 input = "Starting a Gradle Daemon (subsequent builds will be faster)\n> Task :help\n\nWelcome to Gradle 8.6.\n\nDaemon will be stopped at the end of the build stopping after idling timeout of 3 hours"
 expected = "> Task :help\nWelcome to Gradle 8.6."
+
+[[tests.gradle]]
+name = "keeps configuration cache problems, strips only entry stored/reused"
+input = "Configuration cache entry stored.\nConfiguration cache problems found in this build.\nConfiguration cache entry discarded with 1 problem.\n> Task :compileJava\nBUILD FAILED in 3s"
+expected = "Configuration cache problems found in this build.\nConfiguration cache entry discarded with 1 problem.\n> Task :compileJava\nBUILD FAILED in 3s"


### PR DESCRIPTION
Fixes #1177. Fixes #1178.

RTK normalises command lookups to the basename of `argv[0]`, so `rtk ./gradlew tasks` is looked up as `"gradlew tasks"`, not `"./gradlew tasks"` (`src/main.rs`, and `strip_absolute_path()` in `src/discover/registry.rs` for the hook rewrite path). The gradle filter's `match_command` — `^(gradle|gradlew|\./)gradlew?\b` — matches neither `"gradlew tasks"` nor `"gradle build"`, so every real `rtk ./gradlew` / `rtk gradle` invocation fell through to passthrough (#1177), keeping the generic Gradle runtime chatter that isn't build signal (#1178).

Note `rtk gradlew …` (no `./`) is a clap subcommand handled by the Rust `gradlew_cmd` module and never reaches the TOML fallback. The paths that do reach it are `rtk ./gradlew …` and `rtk gradle …`, which is exactly what `^gradlew?\b` covers.

## Fix

- `match_command` → `^gradlew?\b`, matching the normalised basename lookups RTK actually produces (#1177).
- `strip_lines_matching` gains the generic configuration-cache/task-graph chatter listed in #1178: `Calculating task graph …`, `Reusing configuration cache.`, `Configuration cache entry stored/reused.`
- The last pattern is deliberately scoped to `entry (stored|reused)` rather than a bare `^Configuration cache`, so Gradle's actionable diagnostics — `Configuration cache problems found in this build.` and `Configuration cache entry discarded with N problems.` — are still shown.
- Tests: a Rust regression test (`test_gradle_filter_matches_normalized_lookup`) that builds the real builtin filter set and asserts the gradle filter matches the exact lookup strings RTK produces at runtime, plus three inline `[[tests.gradle]]` cases covering the config-cache chatter, `gradlew help` output, and the "problems must survive" invariant.

## Test verification (RED → GREEN)

**#1177 — the issue's MWE, on unmodified `develop`:**
```
$ RTK_TOML_DEBUG=1 rtk ./gradlew help
[rtk:toml] looking up filter for: "gradlew help" (63 filters loaded)
[rtk:toml] no filter matched — passthrough
Calculating task graph as no cached configuration is available for tasks: help
Reusing configuration cache.
Starting a Gradle Daemon (subsequent builds will be faster)
> Task :help

Welcome to Gradle 8.6.

BUILD SUCCESSFUL in 5s
```

With this PR:
```
$ RTK_TOML_DEBUG=1 rtk ./gradlew help
[rtk:toml] looking up filter for: "gradlew help" (63 filters loaded)
[rtk:toml] matched filter: 'gradle'
> Task :help
Welcome to Gradle 8.6.
BUILD SUCCESSFUL in 5s
```

**Unit level.** RED on `develop` with only the new tests applied:
```
$ cargo test --all test_gradle_filter_matches_normalized_lookup
panicked at src/core/toml_filter.rs:1982:
gradle filter must match normalized lookup "gradlew tasks" (basename, no ./)
test result: FAILED. 0 passed; 1 failed

$ rtk verify --filter gradle
FAIL [gradle] strips configuration cache chatter, keeps task output
  expected: "> Task :compileJava\n> Task :test\nBUILD SUCCESSFUL in 5s"
  actual:   "Calculating task graph as no cached configuration is available for tasks: build\nReusing configuration cache.\nConfiguration cache entry stored.\n> Task :compileJava\n> Task :test\nBUILD SUCCESSFUL in 5s"
4/5 tests passed
```

GREEN with the fix:
```
$ cargo test --all test_gradle_filter_matches_normalized_lookup
test result: ok. 1 passed

$ rtk verify --filter gradle
6/6 tests passed
```

Full suite: `cargo test --all` 2626 passed / 0 failed / 8 ignored (`develop`: 2625 / 0 / 8 — the delta is this PR's new test); `rtk verify` 157/157 inline filter tests (`develop`: 154/154). The `benchmark` job is red on `develop` itself for unrelated reasons and is unaffected by this change.
