### PR TITLE
fix(tracking): record stats for hook-rewritten commands (#1082)

### DIFF
--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -12,11 +12,30 @@ else
 fi
 BENCH_DIR="$(pwd)/scripts/benchmark"
 RTK_ROOT="$(pwd)"
+readonly FILE_URL_PREFIX="file://"
+readonly CURL_JSON_FIXTURE_NAME="rtk_benchmark_curl_json"
+readonly CURL_JSON_FIXTURE_CONTENT='{"products":[{"id":101,"name":"Laptop","price":999.99,"stock":50},{"id":102,"name":"Mouse","price":29.99,"stock":200}],"total":2,"page":1}'
+BENCH_TEMP_FILES=()
+
+cleanup_benchmark_temp_files() {
+  if [ "${#BENCH_TEMP_FILES[@]}" -gt 0 ]; then
+    rm -f "${BENCH_TEMP_FILES[@]}"
+  fi
+}
+trap cleanup_benchmark_temp_files EXIT
 
 if [ -z "$CI" ]; then
   rm -rf "$BENCH_DIR"
   mkdir -p "$BENCH_DIR/unix" "$BENCH_DIR/rtk" "$BENCH_DIR/diff"
 fi
+
+make_curl_json_fixture_url() {
+  local fixture
+  fixture=$(mktemp "${TMPDIR:-/tmp}/${CURL_JSON_FIXTURE_NAME}.XXXXXX")
+  BENCH_TEMP_FILES+=("$fixture")
+  printf "%s\n" "$CURL_JSON_FIXTURE_CONTENT" > "$fixture"
+  printf "%s%s\n" "$FILE_URL_PREFIX" "$fixture"
+}
 
 safe_name() {
   echo "$1" | tr ' /' '_-' | tr -cd 'a-zA-Z0-9_-'
@@ -138,6 +157,20 @@ bench() {
     } > "$BENCH_DIR/diff/${prefix}-${filename}.md"
   fi
 }
+
+if [ "${1:-}" = "--self-test" ]; then
+  curl_json_url=$(make_curl_json_fixture_url)
+  curl_out=$(curl -s "$curl_json_url")
+  rtk_out=$("$RTK" curl "$curl_json_url")
+
+  if [ "$curl_out" != "$rtk_out" ]; then
+    echo "FAIL: curl json benchmark fixture is not deterministic"
+    exit 1
+  fi
+
+  echo "PASS: curl json benchmark fixture is deterministic"
+  exit 0
+fi
 
 section() {
   echo ""
@@ -346,7 +379,8 @@ bench "wc" "wc Cargo.toml src/main.rs" "$RTK wc Cargo.toml src/main.rs"
 # ===================
 section "curl"
 if command -v curl &> /dev/null; then
-  bench "curl json" "curl -s https://mockhttp.org/json/1" "$RTK curl https://mockhttp.org/json/1"
+  CURL_JSON_URL=$(make_curl_json_fixture_url)
+  bench "curl json" "curl -s '$CURL_JSON_URL'" "$RTK curl '$CURL_JSON_URL'"
   bench "curl text" "curl -s https://mockhttp.org/robots.txt" "$RTK curl https://mockhttp.org/robots.txt"
 fi
 
@@ -355,8 +389,8 @@ fi
 # ===================
 if command -v wget &> /dev/null; then
   section "wget"
-  bench "wget" "wget -qO- https://mockhttp.org/json/1" "$RTK wget https://mockhttp.org/json/1"
-  rm -f 1 2>/dev/null
+  bench "wget" "wget -qO- https://mockhttp.org/json" "$RTK wget https://mockhttp.org/json"
+  rm -f json 2>/dev/null
 fi
 
 # ===================

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -251,12 +251,18 @@ impl Tracker {
         if let Some(parent) = db_path.parent() {
             crate::core::utils::create_private_dir(parent)?;
         }
+        Self::open_at_path(&db_path)
+    }
 
+    /// Open (or create) the history DB at an explicit path, applying the same
+    /// pragmas and schema as `new()`. Kept separate so tests can target an
+    /// isolated file without mutating the process-global RTK_DB_PATH env var.
+    fn open_at_path(db_path: &std::path::Path) -> Result<Self> {
         // Create the file ourselves so SQLite derives the -wal/-shm modes from
         // an already-private DB instead of the umask.
         crate::core::utils::open_private(
             std::fs::OpenOptions::new().write(true).create(true),
-            &db_path,
+            db_path,
         )
         .with_context(|| {
             format!(
@@ -265,13 +271,19 @@ impl Tracker {
             )
         })?;
 
-        let conn = Connection::open(&db_path)?;
-        // WAL mode + busy_timeout for concurrent access (multiple Claude Code instances).
+        let conn = Connection::open(db_path)?;
+        // Set busy_timeout first, separately from journal_mode=WAL.
+        // When the Claude Code hook rewrites a command it first spawns `rtk rewrite`,
+        // which starts a background telemetry thread that opens the DB.  If that
+        // process exits before the thread finishes, the WAL shared-memory file
+        // (.db-shm) can be briefly inconsistent, causing `PRAGMA journal_mode=WAL`
+        // to return a transient error.  Because execute_batch() stops on the first
+        // error, bundling both pragmas meant busy_timeout silently stayed at 0,
+        // making every lock-contention attempt fail immediately instead of waiting.
+        // Running them separately guarantees busy_timeout is always applied.
+        let _ = conn.execute_batch("PRAGMA busy_timeout=5000;");
         // Non-fatal: NFS/read-only filesystems may not support WAL.
-        let _ = conn.execute_batch(
-            "PRAGMA journal_mode=WAL;
-             PRAGMA busy_timeout=5000;",
-        );
+        let _ = conn.execute_batch("PRAGMA journal_mode=WAL;");
         conn.execute(
             "CREATE TABLE IF NOT EXISTS commands (
                 id INTEGER PRIMARY KEY,
@@ -336,7 +348,7 @@ impl Tracker {
             [],
         )?;
 
-        restrict_db_files(&db_path);
+        restrict_db_files(db_path);
 
         Ok(Self { conn })
     }
@@ -1394,14 +1406,27 @@ impl TimedExecution {
         let input_tokens = estimate_tokens(input);
         let output_tokens = estimate_tokens(output);
 
-        if let Ok(tracker) = Tracker::new() {
-            let _ = tracker.record(
-                original_cmd,
-                rtk_cmd,
-                input_tokens,
-                output_tokens,
-                elapsed_ms,
-            );
+        // Retry once on transient DB-open failures.  When a Claude Code hook
+        // rewrites a command it first invokes `rtk rewrite`, which spawns a
+        // background telemetry thread that briefly holds a DB connection.  If
+        // that process exits before the thread finishes, SQLite's WAL shared-
+        // memory file (.db-shm) may be inconsistent for a few milliseconds,
+        // causing Tracker::new() to fail.  A single short sleep + retry is
+        // sufficient to outlast that window without blocking the user.
+        for attempt in 0..2u8 {
+            if let Ok(tracker) = Tracker::new() {
+                let _ = tracker.record(
+                    original_cmd,
+                    rtk_cmd,
+                    input_tokens,
+                    output_tokens,
+                    elapsed_ms,
+                );
+                return;
+            }
+            if attempt == 0 {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
         }
     }
 
@@ -1427,9 +1452,17 @@ impl TimedExecution {
     /// ```
     pub fn track_passthrough(&self, original_cmd: &str, rtk_cmd: &str) {
         let elapsed_ms = self.start.elapsed().as_millis() as u64;
-        // input_tokens=0, output_tokens=0 won't dilute savings statistics
-        if let Ok(tracker) = Tracker::new() {
-            let _ = tracker.record(original_cmd, rtk_cmd, 0, 0, elapsed_ms);
+        // input_tokens=0, output_tokens=0 won't dilute savings statistics.
+        // Same retry logic as track() to handle transient DB-open failures in
+        // hook execution contexts.
+        for attempt in 0..2u8 {
+            if let Ok(tracker) = Tracker::new() {
+                let _ = tracker.record(original_cmd, rtk_cmd, 0, 0, elapsed_ms);
+                return;
+            }
+            if attempt == 0 {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
         }
     }
 }
@@ -1458,6 +1491,10 @@ pub fn args_display(args: &[OsString]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Serializes tests that mutate the process-global RTK_DB_PATH env var so they
+    // don't race each other (set_var/remove_var is process-wide).
+    static DB_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     // 1. estimate_tokens — verify ~4 chars/token ratio
     #[test]
@@ -1586,9 +1623,7 @@ mod tests {
     #[test]
     fn test_db_path_env_and_default() {
         use std::env;
-        use std::sync::Mutex;
-        static ENV_LOCK: Mutex<()> = Mutex::new(());
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = DB_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
         let custom_path = env::temp_dir().join("rtk_test_custom.db");
         env::set_var("RTK_DB_PATH", &custom_path);
@@ -1642,7 +1677,91 @@ mod tests {
         );
     }
 
-    // 12. record_parse_failure + get_parse_failure_summary roundtrip
+    // 12. busy_timeout pragma lets a tracked write WAIT for a concurrent writer's
+    // lock instead of failing immediately. Regression for #1082: both pragmas were
+    // in one execute_batch() call, so a transient journal_mode=WAL error left
+    // busy_timeout at 0 and every lock-contended write failed with SQLITE_BUSY —
+    // exactly the hook-spawned concurrent-rtk case where gain stats went missing.
+    // We reproduce real contention: a second connection holds the write lock on a
+    // background thread while the tracker attempts its INSERT.
+    #[test]
+    fn test_record_waits_for_concurrent_write_lock() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        // The competing writer holds the lock this long: well under the 5s
+        // busy_timeout (so the waiting write succeeds when the fix is present) but
+        // long enough that a busy_timeout of 0 fails immediately.
+        const LOCK_HOLD_MS: u64 = 300;
+
+        // Isolated temp dir (auto-removed on drop, no RTK_DB_PATH env mutation) so
+        // this can't race the other tracking tests that use the default DB under
+        // `cargo test --all`.
+        let pid = std::process::id();
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let db_path = dir.path().join("busy_timeout.db");
+
+        // Connection carrying the busy_timeout pragma (the fix), at the isolated path.
+        let tracker = Tracker::open_at_path(&db_path).expect("tracker open must succeed");
+
+        // Competing writer grabs the write lock and holds it briefly on a thread.
+        let (locked_tx, locked_rx) = mpsc::channel();
+        let lock_path = db_path.clone();
+        let blocker = std::thread::spawn(move || {
+            let conn = Connection::open(&lock_path).expect("blocker open must succeed");
+            conn.execute_batch("BEGIN IMMEDIATE;")
+                .expect("blocker must acquire the write lock");
+            locked_tx.send(()).expect("signal lock held");
+            std::thread::sleep(Duration::from_millis(LOCK_HOLD_MS));
+            conn.execute_batch("COMMIT;")
+                .expect("blocker must release the write lock");
+        });
+
+        locked_rx
+            .recv()
+            .expect("blocker must signal the lock is held");
+
+        // With busy_timeout=5000 this INSERT waits for the lock; with busy_timeout=0
+        // (the bug) it returns SQLITE_BUSY immediately and the stat is lost.
+        let cmd = format!("git status hook_{}", pid);
+        let result = tracker.record("git status", &cmd, 100, 20, 5);
+
+        blocker.join().expect("blocker thread must finish");
+        // `dir` is dropped at end of scope, removing the temp DB (no explicit
+        // fs::remove_file — keeps the filesystem-deletion lint clean).
+
+        result.expect("record must wait for the concurrent lock and succeed (busy_timeout)");
+    }
+
+    // 13. TimedExecution::track succeeds even when a concurrent reader holds the DB.
+    // Regression: hook-rewritten commands previously failed to record because a
+    // background telemetry thread (from `rtk rewrite`) held the DB open at the
+    // moment the tracking write was attempted, and busy_timeout was 0.
+    #[test]
+    fn test_track_records_with_concurrent_reader() {
+        let pid = std::process::id();
+        let hook_cmd = format!("rtk git status hook_rewritten_{}", pid);
+
+        // Simulate concurrent reader (e.g., telemetry thread from `rtk rewrite`)
+        let reader = Tracker::new().expect("reader must open");
+
+        // Now track — must succeed despite the concurrent reader connection
+        let timer = TimedExecution::start();
+        timer.track("git status", &hook_cmd, "raw output", "filtered");
+
+        // Verify the record was actually written (not silently dropped)
+        let verify = Tracker::new().expect("verify tracker must open");
+        let recent = verify.get_recent(20).expect("get_recent must work");
+        assert!(
+            recent.iter().any(|r| r.rtk_cmd == hook_cmd),
+            "hook-rewritten tracking record must be present in DB (got {} records)",
+            recent.len()
+        );
+
+        drop(reader);
+    }
+
+    // 14. record_parse_failure + get_parse_failure_summary roundtrip
     #[test]
     fn test_parse_failure_roundtrip() {
         let tracker = Tracker::new().expect("Failed to create tracker");
@@ -1660,7 +1779,7 @@ mod tests {
         assert!(summary.recent.iter().any(|r| r.raw_command == test_cmd));
     }
 
-    // 13. recovery_rate calculation
+    // 15. recovery_rate calculation
     #[test]
     fn test_parse_failure_recovery_rate() {
         let tracker = Tracker::new().expect("Failed to create tracker");


### PR DESCRIPTION
Fixes #1082.

`rtk gain` stats were silently missing for commands rewritten via the Claude Code hook. The hook spawns a second `rtk` process while another holds the SQLite history DB, so the tracking write hit lock contention. Two problems compounded it: `busy_timeout` and `journal_mode=WAL` were set in a single `execute_batch()` call, so a transient WAL error left `busy_timeout` at 0 — and with `busy_timeout=0` every contended write failed immediately with `SQLITE_BUSY` and was dropped (`let _ = tracker.record(...)`).

## Fix
Set `PRAGMA busy_timeout=5000` separately from `journal_mode=WAL` so the timeout is always applied, and add a bounded retry around the record path. A contended write now waits for the lock instead of being lost.

## Test verification (RED → GREEN)
`test_record_waits_for_concurrent_write_lock` reproduces real contention: a background thread holds the write lock (`BEGIN IMMEDIATE`) while the tracker attempts its INSERT.

RED — `busy_timeout` reverted to 0 (the bug):
```
test core::tracking::tests::test_record_waits_for_concurrent_write_lock ... FAILED
record must wait for the concurrent lock and succeed (busy_timeout): database is locked
test result: FAILED. 0 passed; 1 failed
```

GREEN — with `busy_timeout=5000`:
```
test core::tracking::tests::test_record_waits_for_concurrent_write_lock ... ok
test result: ok. 1 passed; 0 failed
```
Full `core::tracking` module: 15 passed, 0 failed (no baseline regression).

(Re-proposes the accidentally-closed #1223, rebased onto current `develop`. The original branch's test wrote two trackers sequentially and so did not actually fail without the fix; it has been replaced with the lock-contention test above.)

## CI benchmark verification (RED → GREEN)
The benchmark job was red only on `curl json` because the script compared two separate network calls to `mockhttp.org/json`; that endpoint can return different JSON bodies, making a pass-through filter look negative. The benchmark now uses one local `file://` JSON fixture for both `curl` and `rtk curl`.

RED — old script had no deterministic self-test output:
```
$ bash scripts/benchmark.sh --self-test | grep -F 'PASS: curl json benchmark fixture is deterministic'
(no PASS line; exit 1)
```

GREEN — with the fixture-backed benchmark:
```
$ bash scripts/benchmark.sh --self-test
PASS: curl json benchmark fixture is deterministic
```
