### PR TITLE
feat(windows): native auto-rewrite hook support + install.ps1

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,6 +47,14 @@ cargo uninstall rtk
 curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/master/install.sh | sh
 ```
 
+### Quick Install (Windows)
+
+```powershell
+irm https://raw.githubusercontent.com/rtk-ai/rtk/master/install.ps1 | iex
+```
+
+Installs `rtk.exe` to `%USERPROFILE%\.local\bin`. Open a new terminal, then run `rtk init -g` to register the native `rtk hook claude` auto-rewrite hook (works on native Windows, no WSL required).
+
 After installation, **verify you have the correct rtk**:
 ```bash
 rtk gain  # Must show token savings stats (not "command not found")

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/instal
 > echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc  # or ~/.zshrc
 > ```
 
+### Quick Install (Windows)
+
+```powershell
+irm https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.ps1 | iex
+```
+
+> Installs `rtk.exe` to `%USERPROFILE%\.local\bin`. Open a new terminal so PATH refreshes, then run `rtk init -g` to register the native Claude Code auto-rewrite hook. See [Windows setup](#windows) for details.
+
 ### Cargo
 
 ```bash
@@ -88,7 +96,7 @@ Download from [releases](https://github.com/rtk-ai/rtk/releases):
 - Linux: `rtk-x86_64-unknown-linux-musl.tar.gz` / `rtk-aarch64-unknown-linux-gnu.tar.gz`
 - Windows: `rtk-x86_64-pc-windows-msvc.zip`
 
-> **Windows users**: Extract the zip and place `rtk.exe` somewhere in your PATH (e.g. `C:\Users\<you>\.local\bin`). Run RTK from **Command Prompt**, **PowerShell**, or **Windows Terminal** — do not double-click the `.exe` (it will flash and close). For the best experience, use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) where the full hook system works natively. See [Windows setup](#windows) below for details.
+> **Windows users**: Run `irm https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.ps1 | iex`, or extract the zip and place `rtk.exe` somewhere in your PATH (e.g. `C:\Users\<you>\.local\bin`). Run RTK from **Command Prompt**, **PowerShell**, or **Windows Terminal** — do not double-click the `.exe` (it will flash and close). Native Windows now gets the same auto-rewrite hook as macOS/Linux via `rtk init -g`; WSL is optional. See [Windows setup](#windows) below for details.
 
 ### Verify Installation
 
@@ -316,11 +324,30 @@ After install, **restart Claude Code**.
 
 ## Windows
 
-RTK works on Windows with some limitations. The auto-rewrite hook (`rtk-rewrite.sh`) requires a Unix shell, so on native Windows RTK falls back to **CLAUDE.md injection mode** — your AI assistant receives RTK instructions but commands are not rewritten automatically.
+**Native Windows now has full auto-rewrite support — same as macOS/Linux, no WSL required.**
 
-### Recommended: WSL (full support)
+Modern RTK no longer relies on the `rtk-rewrite.sh` shell script. The Claude Code hook is a native Rust subcommand, `rtk hook claude`, that reads the PreToolUse JSON from stdin and writes the rewritten command to stdout. It runs identically on every platform, so `rtk init -g` registers the real auto-rewrite hook on native Windows too (cmd.exe, PowerShell, Windows Terminal).
 
-For the best experience, use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) (Windows Subsystem for Linux). Inside WSL, RTK works exactly like Linux — full hook support, auto-rewrite, everything:
+### Native Windows (full support)
+
+```powershell
+# 1. Install (downloads rtk.exe to %USERPROFILE%\.local\bin)
+irm https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.ps1 | iex
+
+# 2. Open a NEW terminal so PATH refreshes, then register the hook
+rtk init -g
+
+# 3. Restart Claude Code, then test — this is rewritten automatically
+git status
+```
+
+Prefer to install manually? Download and extract `rtk-x86_64-pc-windows-msvc.zip` from [releases](https://github.com/rtk-ai/rtk/releases), put `rtk.exe` somewhere on your PATH (e.g. `C:\Users\<you>\.local\bin`), then run `rtk init -g`.
+
+**Important**: Do not double-click `rtk.exe` — it is a CLI tool that prints usage and exits immediately. Always run it from a terminal (Command Prompt, PowerShell, or Windows Terminal).
+
+### WSL
+
+[WSL](https://learn.microsoft.com/en-us/windows/wsl/install) remains fully supported and behaves exactly like Linux. Use it if your workflow already lives inside WSL — it is no longer *required* for auto-rewrite:
 
 ```bash
 # Inside WSL
@@ -328,28 +355,14 @@ curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/instal
 rtk init -g
 ```
 
-### Native Windows (limited support)
-
-On native Windows (cmd.exe / PowerShell), RTK filters work but the hook does not auto-rewrite commands:
-
-```powershell
-# 1. Download and extract rtk-x86_64-pc-windows-msvc.zip from releases
-# 2. Add rtk.exe to your PATH
-# 3. Initialize (falls back to CLAUDE.md injection)
-rtk init -g
-# 4. Use rtk explicitly
-rtk cargo test
-rtk git status
-```
-
-**Important**: Do not double-click `rtk.exe` — it is a CLI tool that prints usage and exits immediately. Always run it from a terminal (Command Prompt, PowerShell, or Windows Terminal).
-
-| Feature | WSL | Native Windows |
-|---------|-----|----------------|
+| Feature | Native Windows | WSL |
+|---------|----------------|-----|
 | Filters (cargo, git, etc.) | Full | Full |
-| Auto-rewrite hook | Yes | No (CLAUDE.md fallback) |
-| `rtk init -g` | Hook mode | CLAUDE.md mode |
+| Auto-rewrite hook (`rtk hook claude`) | Yes | Yes |
+| `rtk init -g` | Hook mode | Hook mode |
 | `rtk gain` / analytics | Full | Full |
+
+> Note: the native `rtk hook claude` hook covers **Claude Code**. A few other agents still ship Unix-shell wrappers (e.g. the Gemini CLI hook); those specific integrations may still need WSL on Windows until they migrate to the native subcommand.
 
 ## Supported AI Tools
 

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -186,17 +186,22 @@ Support is blocked on upstream `BeforeToolCallback` ([mistral-vibe#531](https://
 | **Plugin** | TypeScript, JavaScript, or Python in agent's plugin system | Transparent, in-place mutation when the agent allows it |
 | **Rules file** | Prompt-level instructions | Guidance only — agent is told to prefer `rtk <cmd>` |
 
-Rules file integrations (Cline, Windsurf, Codex, Kilo Code, Antigravity) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it. Plugin integrations (OpenCode, Pi) use in-place mutation via the agent's TypeScript extension API.
+Rules file integrations (Cline, Windsurf, Codex, Kilo Code, Antigravity) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it. Claude Code and Cursor use native Rust subcommands (`rtk hook claude` / `rtk hook cursor`) and run on every platform including native Windows; Gemini's hook is still a shell wrapper and needs WSL on Windows. Plugin integrations (OpenCode, Pi) use in-place mutation via the agent's TypeScript extension API.
 
 ## Windows support
 
-The shell hook (`rtk-rewrite.sh`) requires a Unix shell. On native Windows:
+The Claude Code and Cursor hooks are native Rust subcommands (`rtk hook claude`, `rtk hook cursor`) that read JSON from stdin and write JSON to stdout. They do **not** depend on a Unix shell, so they work on native Windows exactly like macOS/Linux:
 
-- `rtk init -g` automatically falls back to **CLAUDE.md injection mode** (prompt-level instructions)
+- `rtk init -g` registers the real `rtk hook claude` auto-rewrite hook (no CLAUDE.md fallback)
 - Filters work normally (`rtk cargo test`, `rtk git status`)
-- Auto-rewrite does not work — the AI assistant is instructed to use RTK but commands are not intercepted
+- Auto-rewrite works — commands are intercepted and rewritten before the agent sees them
 
-For full hook support on Windows, use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install). Inside WSL, all agents with shell hook integration (Claude Code, Cursor, Gemini) work identically to Linux.
+Some agents still ship Unix-shell wrappers that need a shell on Windows:
+
+- **Gemini CLI**: the hook is registered as a `#!/bin/bash` wrapper script, so on native Windows it requires [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) until it migrates to the native `rtk hook gemini` subcommand.
+- **Rules-file agents** (Cline, Windsurf, Codex, Kilo Code, Antigravity) are prompt-level and platform-independent.
+
+WSL remains fully supported for every agent and behaves identically to Linux.
 
 ## Graceful degradation
 

--- a/docs/guide/resources/troubleshooting.md
+++ b/docs/guide/resources/troubleshooting.md
@@ -103,20 +103,24 @@ rtk --version
 - Or open PowerShell or Windows Terminal
 - Then run: `rtk --version`
 
-### Hook not working (no auto-rewrite)
+### Hook not working (no auto-rewrite) on Windows
 
-**Symptom:** `rtk init -g` shows "Falling back to --claude-md mode" on Windows.
+**Symptom:** Commands like `git status` are not being rewritten to `rtk git status` on native Windows.
 
-**Cause:** The auto-rewrite hook (`rtk-rewrite.sh`) requires a Unix shell. Native Windows doesn't have one.
+**Cause:** The Claude Code hook is the native `rtk hook claude` subcommand — it works on native Windows, so this is almost always a registration or PATH issue, not a platform limitation.
 
-**Fix:** Use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) for full hook support:
-```bash
-# Inside WSL
-curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
-rtk init -g    # full hook mode works in WSL
-```
+**Fix:**
+1. Confirm `rtk.exe` is on your PATH: open a **new** terminal and run `rtk --version`.
+2. Register the hook: `rtk init -g` (it writes `rtk hook claude` into `~/.claude/settings.json`).
+3. Verify it is recognized: `rtk init --show` should report `[ok] Hook: rtk hook claude`.
+4. **Restart Claude Code** so it reloads `settings.json`.
+5. Sanity-check the hook directly:
+   ```powershell
+   '{"tool_name":"Bash","tool_input":{"command":"git status"}}' | rtk hook claude
+   # Expect JSON whose updatedInput.command is "rtk git status"
+   ```
 
-On native Windows, RTK falls back to CLAUDE.md injection. Your AI assistant gets RTK instructions but won't auto-rewrite commands. It can still use RTK manually: `rtk cargo test`, `rtk git status`, etc.
+WSL also works and behaves exactly like Linux, but it is no longer required for Claude Code auto-rewrite.
 
 ### Node.js tools not found
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,126 @@
+# rtk installer for Windows - https://github.com/rtk-ai/rtk
+# Usage:
+#   irm https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.ps1 | iex
+#
+# Installs the native rtk.exe to %USERPROFILE%\.local\bin so the Claude Code
+# `rtk hook claude` PreToolUse hook works exactly like macOS/Linux: commands are
+# rewritten automatically, no WSL required.
+#
+# Optional environment variables:
+#   $env:RTK_VERSION      Pin a specific release, e.g. "v0.42.4"
+#   $env:RTK_INSTALL_DIR  Override install directory (default: ~/.local/bin)
+
+$ErrorActionPreference = 'Stop'
+
+$Repo        = 'rtk-ai/rtk'
+$BinaryName  = 'rtk.exe'
+$Target      = 'x86_64-pc-windows-msvc'
+$InstallDir  = if ($env:RTK_INSTALL_DIR) { $env:RTK_INSTALL_DIR } else { Join-Path $HOME '.local\bin' }
+
+function Write-Info  { param($m) Write-Host "[INFO] $m"  -ForegroundColor Green }
+function Write-Warn  { param($m) Write-Host "[WARN] $m"  -ForegroundColor Yellow }
+function Write-Err   { param($m) Write-Host "[ERROR] $m" -ForegroundColor Red; exit 1 }
+
+function Get-LatestVersion {
+    # Resolve the latest tag via the /releases/latest redirect (no API rate limit).
+    try {
+        $resp = Invoke-WebRequest -Uri "https://github.com/$Repo/releases/latest" `
+            -MaximumRedirection 0 -ErrorAction SilentlyContinue
+    } catch {
+        $resp = $_.Exception.Response
+    }
+    $location = $null
+    if ($resp -and $resp.Headers) {
+        $location = $resp.Headers['Location']
+        if ($location -is [array]) { $location = $location[0] }
+    }
+    if ($location -and $location -match '/tag/([^/\s]+)') {
+        return $Matches[1]
+    }
+    # Fallback to the REST API.
+    Write-Warn 'Redirect lookup failed, falling back to GitHub API...'
+    $api = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest"
+    if ($api.tag_name) { return $api.tag_name }
+    Write-Err 'Failed to get latest version (set $env:RTK_VERSION=vX.Y.Z to pin)'
+}
+
+function Install-Rtk {
+    if ($env:PROCESSOR_ARCHITECTURE -ne 'AMD64' -and $env:PROCESSOR_ARCHITEW6432 -ne 'AMD64') {
+        Write-Warn "Detected non-AMD64 architecture ($env:PROCESSOR_ARCHITECTURE). Only x86_64 Windows builds are published; continuing anyway."
+    }
+
+    $version = if ($env:RTK_VERSION) {
+        Write-Info "Using pinned version: $env:RTK_VERSION"
+        $env:RTK_VERSION
+    } else {
+        Get-LatestVersion
+    }
+
+    Write-Info "Target:  $Target"
+    Write-Info "Version: $version"
+
+    $downloadUrl = "https://github.com/$Repo/releases/download/$version/rtk-$Target.zip"
+    $tempDir     = Join-Path ([System.IO.Path]::GetTempPath()) "rtk-install-$([System.IO.Path]::GetRandomFileName())"
+    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+    $archive = Join-Path $tempDir 'rtk.zip'
+
+    Write-Info "Downloading from: $downloadUrl"
+    try {
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $archive
+    } catch {
+        Write-Err "Failed to download binary: $_"
+    }
+
+    Write-Info 'Extracting...'
+    Expand-Archive -Path $archive -DestinationPath $tempDir -Force
+
+    $extracted = Join-Path $tempDir $BinaryName
+    if (-not (Test-Path $extracted)) {
+        Write-Err "Archive did not contain $BinaryName"
+    }
+
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    Copy-Item -Path $extracted -Destination (Join-Path $InstallDir $BinaryName) -Force
+
+    Remove-Item -Recurse -Force $tempDir
+
+    Write-Info "Successfully installed $BinaryName to $InstallDir\$BinaryName"
+}
+
+function Test-PathEntry {
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    $normalized = $InstallDir.TrimEnd('\')
+    if ($userPath -and ($userPath -split ';' | ForEach-Object { $_.TrimEnd('\') }) -contains $normalized) {
+        return $true
+    }
+    return $false
+}
+
+function Confirm-Installation {
+    $exe = Join-Path $InstallDir $BinaryName
+    if (Test-Path $exe) {
+        $ver = & $exe --version
+        Write-Info "Verification: $ver"
+    } else {
+        Write-Warn 'Binary installed but not found at expected path.'
+        return
+    }
+
+    if (-not (Test-PathEntry)) {
+        Write-Warn "$InstallDir is not on your user PATH."
+        Write-Warn 'Add it (new terminals will pick it up):'
+        Write-Warn "  [Environment]::SetEnvironmentVariable('Path', `"`$([Environment]::GetEnvironmentVariable('Path','User'));$InstallDir`", 'User')"
+    }
+}
+
+Write-Info "Installing rtk for Windows..."
+Install-Rtk
+Confirm-Installation
+
+Write-Host ''
+Write-Info "Installation complete. Next steps:"
+Write-Host '  1. Open a NEW terminal (so PATH refreshes), then verify:  rtk --version'
+Write-Host '  2. Register the Claude Code hook (full auto-rewrite):      rtk init -g'
+Write-Host '  3. Restart Claude Code, then test:                         git status'
+Write-Host ''
+Write-Info 'Native Windows now has the same auto-rewrite hook as macOS/Linux. WSL is no longer required.'


### PR DESCRIPTION
## Summary

Native Windows already runs the auto-rewrite hook today — the Claude Code hook is the platform-agnostic `rtk hook claude` subcommand, and `rtk init -g` registers it on Windows with no special-casing. But the docs still tell Windows users that auto-rewrite doesn't work and that they fall back to "CLAUDE.md injection mode". This PR closes that gap and adds a first-class Windows installer.

### Why the docs are stale

- `src/hooks/constants.rs`: `CLAUDE_HOOK_COMMAND = "rtk hook claude"` (native Rust, not a shell script).
- `src/hooks/init.rs` `run_default_mode()` calls `patch_settings_json_command(CLAUDE_HOOK_COMMAND, ...)` on **all** platforms — there is no `cfg!(windows)` branch forcing `run_claude_md_mode`.
- `src/hooks/hook_cmd.rs` `run_claude()` reads stdin JSON / writes stdout JSON and already strips Windows UTF-8 BOMs.

So the "requires a Unix shell → falls back to CLAUDE.md" wording predates the migration to the native subcommand.

## Changes

- **`install.ps1`** (new): PowerShell installer that mirrors `install.sh` — resolves the latest release via the `/releases/latest` redirect (API fallback), downloads `rtk-x86_64-pc-windows-msvc.zip`, installs `rtk.exe` to `%USERPROFILE%\.local\bin`, and verifies PATH. Supports `$env:RTK_VERSION` / `$env:RTK_INSTALL_DIR`.
- **README.md / INSTALL.md**: add a Windows quick-install (`irm ... | iex`) and rewrite the Windows section so native auto-rewrite is the documented default; WSL is presented as optional.
- **docs/troubleshooting.md, docs/supported-agents.md**: replace the outdated fallback guidance with native-hook instructions, and honestly note that the **Gemini** hook is still a `#!/bin/bash` wrapper and needs WSL on native Windows until it migrates to `rtk hook gemini`.

## Verification

- `install.ps1` passes `[System.Management.Automation.Language.Parser]::ParseFile` (no syntax errors).
- End-to-end on native Windows 11 (PowerShell, no WSL) with the published `rtk-x86_64-pc-windows-msvc.zip` (v0.42.4):
  - `rtk init -g` → `rtk init --show` reports `[ok] Hook: rtk hook claude`, existing `settings.json` keys preserved (deep-merge).
  - `echo '{"tool_name":"Bash","tool_input":{"command":"git status"}}' | rtk hook claude` → `updatedInput.command` = `rtk git status`.
  - `cargo test` → `rtk cargo test`; unsupported commands (e.g. `htop`) pass through unchanged.

## Scope / notes

- Docs + new installer only; no changes to Rust source or behavior.
- No tests added: `install.ps1` is a thin installer with no Rust logic, consistent with the existing untested `install.sh`. Happy to add a CI lint (e.g. PSScriptAnalyzer) if maintainers want one.
- Out of scope (follow-up): migrating the Gemini hook from the bash wrapper to a native `rtk hook gemini` registration so it too works on native Windows.
