### PR TITLE
docs: clarify Copilot initialization in quick start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ rtk gain        # Should show token savings stats
 
 ```bash
 # 1. Install for your AI tool
-rtk init -g                     # Claude Code / Copilot (default)
+rtk init -g                     # Claude Code
+rtk init -g --copilot           # Copilot
 rtk init -g --gemini            # Gemini CLI
 rtk init -g --codex             # Codex (OpenAI)
 rtk init -g --agent cursor      # Cursor


### PR DESCRIPTION
## Summary
Updated the Quick Start section in the README to clarify the initialization commands for Claude Code and GitHub Copilot.

## Changes
- Updated `rtk init -g` description to indicate Claude Code initialization.
- Added `rtk init -g --copilot` command for GitHub Copilot initialization.

Fixes #2244