### PR TITLE
fix(git): propagate exit code on git status failure in compact path

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -862,9 +862,21 @@ fn run_status(args: &[String], verbose: u8, global_args: &[String]) -> Result<i3
     let mut cmd = build_status_command(args, global_args);
     let result = exec_capture(&mut cmd).context("Failed to run git status")?;
 
-    if !result.stderr.is_empty() && result.stderr.contains("not a git repository") {
-        let message = "Not a git repository".to_string();
-        eprintln!("{}", message);
+    // Any git status failure must propagate, not be flattened into a clean
+    // working tree + exit 0 (#2497). The non-compact path above already guards
+    // on success; the compact path previously only caught "not a git repository"
+    // and let every other failure (corrupt index, lock contention, …) fall
+    // through to a success-looking summary. Keep the friendly message for the
+    // common not-a-repo case; surface raw stderr otherwise.
+    if !result.success() {
+        let message = if result.stderr.contains("not a git repository") {
+            "Not a git repository".to_string()
+        } else {
+            result.stderr.trim().to_string()
+        };
+        if !message.is_empty() {
+            eprintln!("{}", message);
+        }
         let original_cmd = if args.is_empty() {
             "git status".to_string()
         } else {
@@ -1892,6 +1904,30 @@ mod tests {
         let cmd = build_status_command(&args, &[]);
         let cmd_args: Vec<_> = cmd.get_args().collect();
         assert_eq!(cmd_args, vec!["status", "--porcelain", "-uno"]);
+    }
+
+    #[test]
+    fn test_run_status_compact_propagates_non_repo_failure() {
+        // #2497: a `git status` failure other than "not a git repository"
+        // (here: a corrupt index) must propagate a non-zero exit, not be
+        // flattened into "Clean working tree" + exit 0.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let p = dir.path().to_string_lossy().into_owned();
+        assert!(
+            Command::new("git")
+                .args(["-C", &p, "init", "-q"])
+                .status()
+                .expect("git init")
+                .success(),
+            "git init should succeed"
+        );
+        std::fs::write(dir.path().join(".git/index"), "corrupt-index").expect("corrupt index");
+        let global = vec!["-C".to_string(), p];
+        let code = run_status(&[], 0, &global).expect("run_status");
+        assert_ne!(
+            code, 0,
+            "corrupt-index git status must not be reported as success"
+        );
     }
 
     #[test]

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -862,12 +862,6 @@ fn run_status(args: &[String], verbose: u8, global_args: &[String]) -> Result<i3
     let mut cmd = build_status_command(args, global_args);
     let result = exec_capture(&mut cmd).context("Failed to run git status")?;
 
-    // Any git status failure must propagate, not be flattened into a clean
-    // working tree + exit 0 (#2497). The non-compact path above already guards
-    // on success; the compact path previously only caught "not a git repository"
-    // and let every other failure (corrupt index, lock contention, …) fall
-    // through to a success-looking summary. Keep the friendly message for the
-    // common not-a-repo case; surface raw stderr otherwise.
     if !result.success() {
         let message = if result.stderr.contains("not a git repository") {
             "Not a git repository".to_string()


### PR DESCRIPTION
Part of #2497 (1/3).

## Problem

`rtk git status` (compact path) reported a clean working tree with **exit 0** when `git status` actually failed for any reason other than "not a git repository" — e.g. a corrupt index, a lock conflict, or unreadable refs. The non-compact path already guards on `result.success()` (git.rs:824); the compact path only special-cased the not-a-repo string and let every other failure fall through to the formatted summary + `Ok(0)`.

```console
# repo with a corrupted .git/index
$ git status            # native
fatal: .git/index: index file smaller than expected     # exit 128
$ rtk git status        # before this PR
Clean working tree                                       # exit 0  ✗
```

## Fix

Replace the narrow `"not a git repository"` check with a general `if !result.success()` guard (mirroring the non-compact path). The friendly `Not a git repository` message is preserved for that common case; any other failure surfaces git's stderr and returns its real exit code.

```console
$ rtk git status        # after
fatal: .git/index: index file smaller than expected
                        # exit 128  ✓ (matches native git)
```

## Testing

- New test `test_run_status_compact_propagates_non_repo_failure`: inits a temp repo, corrupts `.git/index`, asserts `run_status` returns a non-zero exit (uses `git -C` via global args; assertion is `!= 0` so it's exit-code-agnostic and cross-platform).
- `cargo fmt --all --check && cargo clippy --all-targets && cargo test` — clean, 2200 passed.
- Manual verification vs native git:
  - corrupt index → exit 128 (was 0)
  - clean repo → `* main / clean — nothing to commit`, exit 0 (no regression)
  - dirty repo → `?? f2`, exit 0 (no regression)
  - non-git dir → `Not a git repository`, exit 128 (friendly message preserved)

Same masking-failure class as #1581 / #1535 / #2446 / #2494. Sibling fixes for `run_worktree` and `run_stash` will follow as separate PRs under #2497.