### PR TITLE
fix(git): propagate exit code on git worktree list failure

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -1715,7 +1715,6 @@ fn run_worktree(args: &[String], verbose: u8, global_args: &[String]) -> Result<
     let result = exec_capture(&mut cmd).context("Failed to run git worktree list")?;
 
     if !result.success() {
-        eprintln!("FAILED: git worktree list");
         if !result.stderr.trim().is_empty() {
             eprintln!("{}", result.stderr);
         }

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -1714,9 +1714,6 @@ fn run_worktree(args: &[String], verbose: u8, global_args: &[String]) -> Result<
     cmd.args(["worktree", "list"]);
     let result = exec_capture(&mut cmd).context("Failed to run git worktree list")?;
 
-    // A failed `git worktree list` (e.g. run outside a repo) must propagate, not
-    // be flattened to empty output + exit 0. The has_action branch above already
-    // guards on success (#2497).
     if !result.success() {
         eprintln!("FAILED: git worktree list");
         if !result.stderr.trim().is_empty() {

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -1714,6 +1714,23 @@ fn run_worktree(args: &[String], verbose: u8, global_args: &[String]) -> Result<
     cmd.args(["worktree", "list"]);
     let result = exec_capture(&mut cmd).context("Failed to run git worktree list")?;
 
+    // A failed `git worktree list` (e.g. run outside a repo) must propagate, not
+    // be flattened to empty output + exit 0. The has_action branch above already
+    // guards on success (#2497).
+    if !result.success() {
+        eprintln!("FAILED: git worktree list");
+        if !result.stderr.trim().is_empty() {
+            eprintln!("{}", result.stderr);
+        }
+        timer.track(
+            "git worktree list",
+            "rtk git worktree",
+            &result.stdout,
+            &result.stderr,
+        );
+        return Ok(result.exit_code);
+    }
+
     let filtered = filter_worktree_list(&result.stdout);
     println!("{}", filtered);
     timer.track(
@@ -2043,6 +2060,16 @@ mod tests {
         assert!(result.contains("abc1234"));
         assert!(result.contains("[main]"));
         assert!(result.contains("[feature]"));
+    }
+
+    #[test]
+    fn test_run_worktree_list_propagates_failure() {
+        // #2497: `git worktree list` outside a repo exits non-zero; rtk must not
+        // report success (empty output + exit 0).
+        let dir = tempfile::tempdir().expect("tempdir");
+        let global = vec!["-C".to_string(), dir.path().to_string_lossy().into_owned()];
+        let code = run_worktree(&[], 0, &global).expect("run_worktree");
+        assert_ne!(code, 0, "git worktree list failure must propagate");
     }
 
     #[test]


### PR DESCRIPTION
Part of #2497 (2/3).

## Problem

`rtk git worktree` (list mode) never checked `result.success()` — a failed `git worktree list` (e.g. run outside a repository) was flattened to empty output + **exit 0**. The `has_action` branch right above it (add/remove/prune/…) already guards on success and returns the real exit code; only list mode was missing the guard.

```console
$ cd /non-git-dir
$ git worktree list     # native → exit 128 (fatal: not a git repository)
$ rtk git worktree      # before this PR
                        # empty output, exit 0  ✗
```

## Fix

Add `if !result.success()` before the format/print/`Ok(0)` fall-through: surface `git`'s stderr (with a `FAILED: git worktree list` header, matching the sibling handlers) and return `result.exit_code`.

```console
$ rtk git worktree      # after
FAILED: git worktree list
fatal: not a git repository (or any of the parent directories): .git
                        # exit 128  ✓
```

## Testing

- New test `test_run_worktree_list_propagates_failure`: runs `run_worktree` against a non-git temp dir via `git -C`, asserts a non-zero exit (`!= 0`, exit-code-agnostic / cross-platform).
- `cargo fmt --all --check && cargo clippy --all-targets && cargo test` — clean, 2200 passed.
- Manual verification: non-git dir → exit 128 (was 0); real repo → worktree list + exit 0 (no regression).

Same masking-failure class as #1581 / #1535 / #2446 / #2494. `run_status` is #2498; `run_stash` PR follows.