### PR TITLE
test(git): cover exit-code propagation for git stash list/show failure

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -2078,6 +2078,22 @@ mod tests {
     }
 
     #[test]
+    fn test_run_stash_list_propagates_failure() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let global = vec!["-C".to_string(), dir.path().to_string_lossy().into_owned()];
+        let code = run_stash(Some("list"), &[], 0, &global).expect("run_stash list");
+        assert_ne!(code, 0, "git stash list failure must propagate");
+    }
+
+    #[test]
+    fn test_run_stash_show_propagates_failure() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let global = vec!["-C".to_string(), dir.path().to_string_lossy().into_owned()];
+        let code = run_stash(Some("show"), &[], 0, &global).expect("run_stash show");
+        assert_ne!(code, 0, "git stash show failure must propagate");
+    }
+
+    #[test]
     fn test_filter_worktree_list() {
         let output =
             "/home/user/project  abc1234 [main]\n/home/user/worktrees/feat  def5678 [feature]\n";


### PR DESCRIPTION
Part of #2497 (3/3).

## Problem

`run_stash`'s `list` and `show` branches printed output and returned `Ok(0)` without checking `result.success()`. A failed `git stash list` (e.g. outside a repo) was reported as `No stashes` + exit 0, and `git stash show` failures as `Empty stash` + exit 0. The `apply`/`pop`/`push` branches already guard on success.

```console
$ cd /non-git-dir
$ git stash list        # native → exit 128
$ rtk git stash list    # before
No stashes              # exit 0  ✗
```

## Fix

Add `if !result.success()` guards to both branches: surface git's stderr (`FAILED: git stash list/show` header) and return the real exit code.

Behavior now matches native git exactly:

| scenario | native | rtk after |
|---|---|---|
| `stash list`, no stashes (valid repo) | exit 0 | `No stashes`, exit 0 ✓ (unchanged) |
| `stash list`, non-git dir | exit 128 | `FAILED…` exit 128 ✓ |
| `stash show`, no stashes | exit 1 (`No stash entries found`) | surfaces it, exit 1 ✓ |
| `stash show`, non-git dir | exit 128 | `FAILED…` exit 128 ✓ |

Note `git stash list` exits 0 when there are genuinely no stashes, so the friendly `No stashes` success path is preserved — only real failures now propagate.

## Testing

- New tests `test_run_stash_list_propagates_failure` and `test_run_stash_show_propagates_failure` (non-git temp dir via `git -C`, assert non-zero exit; `!= 0` so cross-platform).
- `cargo fmt --all --check && cargo clippy --all-targets && cargo test` — clean, 2201 passed.
- Manual verification of all four scenarios above against native git.

Completes the #2497 series (`run_status` #2498, `run_worktree` #2499). Same masking-failure class as #1581 / #1535 / #2446 / #2494.