### PR TITLE
feat(read): support for offset and slice read

### DIFF
--- a/src/cmds/system/read.rs
+++ b/src/cmds/system/read.rs
@@ -7,11 +7,36 @@ use anyhow::{Context, Result};
 use std::fs;
 use std::path::Path;
 
+enum LineRange {
+    Full,
+    Empty,
+    Head(usize),           // n > 0
+    Tail(usize),           // n > 0
+    From(usize),           // start >= 0
+    Slice((usize, usize)), // start >= 0, limit > 0
+}
+
+impl LineRange {
+    fn from_args(offset: Option<usize>, limit: Option<usize>, tail_lines: Option<usize>) -> Self {
+        match (offset, limit, tail_lines) {
+            (_, Some(0), _) | (_, _, Some(0)) => Self::Empty,
+            (Some(offset), Some(limit), _) => Self::Slice((offset.saturating_sub(1), limit)),
+            (Some(offset), None, _) => Self::From(offset.saturating_sub(1)),
+            (None, Some(limit), _) => Self::Head(limit),
+            (None, None, Some(tail)) => Self::Tail(tail),
+            _ => Self::Full,
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 pub fn run(
     file: &Path,
     level: FilterLevel,
     max_lines: Option<usize>,
     tail_lines: Option<usize>,
+    offset: Option<usize>,
+    limit: Option<usize>,
     line_numbers: bool,
     verbose: u8,
 ) -> Result<()> {
@@ -64,15 +89,16 @@ pub fn run(
         );
     }
 
-    filtered = apply_line_window(&filtered, max_lines, tail_lines, &lang);
+    let range = LineRange::from_args(offset, limit, tail_lines);
+    let (line_start, filtered) = apply_line_window(&filtered, max_lines, &range, &lang);
 
     let (raw, rtk_output) = if line_numbers {
         (
-            format_with_line_numbers(&content),
-            format_with_line_numbers(&filtered),
+            format_with_line_numbers(&content, 1),
+            format_with_line_numbers(&filtered, line_start),
         )
     } else {
-        (content.clone(), filtered.clone())
+        (content, filtered)
     };
     let shown = never_worse(&raw, &rtk_output);
     print!("{}", shown);
@@ -89,6 +115,8 @@ pub fn run_stdin(
     level: FilterLevel,
     max_lines: Option<usize>,
     tail_lines: Option<usize>,
+    offset: Option<usize>,
+    limit: Option<usize>,
     line_numbers: bool,
     verbose: u8,
 ) -> Result<()> {
@@ -116,7 +144,7 @@ pub fn run_stdin(
 
     // Apply filter
     let filter = filter::get_filter(level);
-    let mut filtered = filter.filter(&content, &lang);
+    let filtered = filter.filter(&content, &lang);
 
     if verbose > 0 {
         let original_lines = content.lines().count();
@@ -132,15 +160,16 @@ pub fn run_stdin(
         );
     }
 
-    filtered = apply_line_window(&filtered, max_lines, tail_lines, &lang);
+    let range = LineRange::from_args(offset, limit, tail_lines);
+    let (line_start, filtered) = apply_line_window(&filtered, max_lines, &range, &lang);
 
     let (raw, rtk_output) = if line_numbers {
         (
-            format_with_line_numbers(&content),
-            format_with_line_numbers(&filtered),
+            format_with_line_numbers(&content, 1),
+            format_with_line_numbers(&filtered, line_start),
         )
     } else {
-        (content.clone(), filtered.clone())
+        (content, filtered)
     };
     let shown = never_worse(&raw, &rtk_output);
     print!("{}", shown);
@@ -149,12 +178,19 @@ pub fn run_stdin(
     Ok(())
 }
 
-fn format_with_line_numbers(content: &str) -> String {
+fn format_with_line_numbers(content: &str, display_start: usize) -> String {
     let lines: Vec<&str> = content.lines().collect();
-    let width = lines.len().to_string().len();
+    let width = (display_start + lines.len().saturating_sub(1))
+        .to_string()
+        .len();
     let mut out = String::new();
     for (i, line) in lines.iter().enumerate() {
-        out.push_str(&format!("{:>width$} │ {}\n", i + 1, line, width = width));
+        out.push_str(&format!(
+            "{:>width$} │ {}\n",
+            display_start + i,
+            line,
+            width = width
+        ));
     }
     out
 }
@@ -162,27 +198,62 @@ fn format_with_line_numbers(content: &str) -> String {
 fn apply_line_window(
     content: &str,
     max_lines: Option<usize>,
-    tail_lines: Option<usize>,
+    range: &LineRange,
     lang: &Language,
-) -> String {
-    if let Some(tail) = tail_lines {
-        if tail == 0 {
-            return String::new();
+) -> (usize, String) {
+    let start_ptr = content.as_ptr() as usize;
+
+    let (line_start, windowed) = match range {
+        LineRange::Empty => return (1, String::new()),
+        LineRange::Tail(n) => {
+            // we do a double pass instead of a Vec<&str> collection to save memory
+            let total = content.lines().count();
+            let start = total.saturating_sub(*n);
+            let byte_start = content
+                .lines()
+                .nth(start)
+                .map(|line| line.as_ptr() as usize - start_ptr)
+                .unwrap_or(0);
+            return (start + 1, content[byte_start..].to_string());
         }
-        let lines: Vec<&str> = content.lines().collect();
-        let start = lines.len().saturating_sub(tail);
-        let mut result = lines[start..].join("\n");
-        if content.ends_with('\n') {
-            result.push('\n');
+        LineRange::Head(n) => {
+            if let Some(line) = content.lines().nth(*n) {
+                let byte_stop = line.as_ptr() as usize - start_ptr;
+                (1, &content[..byte_stop])
+            } else {
+                (1, content)
+            }
         }
-        return result;
-    }
+        LineRange::From(n) => {
+            if let Some(line) = content.lines().nth(*n) {
+                let byte_start = line.as_ptr() as usize - start_ptr;
+                (*n + 1, &content[byte_start..])
+            } else {
+                (*n + 1, &content[0..0])
+            }
+        }
+        LineRange::Slice((start, limit)) => {
+            let mut lines = content.lines();
+            if let Some(line) = lines.nth(*start) {
+                let byte_start = line.as_ptr() as usize - start_ptr;
+                if let Some(line) = lines.nth(*limit - 1) {
+                    let byte_stop = line.as_ptr() as usize - start_ptr;
+                    (*start + 1, &content[byte_start..byte_stop])
+                } else {
+                    (*start + 1, &content[byte_start..])
+                }
+            } else {
+                (*start + 1, &content[0..0])
+            }
+        }
+        LineRange::Full => (1, content),
+    };
 
     if let Some(max) = max_lines {
-        return filter::smart_truncate(content, max, lang);
+        (line_start, filter::smart_truncate(windowed, max, lang))
+    } else {
+        (line_start, windowed.to_string())
     }
-
-    content.to_string()
 }
 
 #[cfg(test)]
@@ -203,7 +274,16 @@ fn main() {{
         )?;
 
         // Just verify it doesn't panic
-        run(file.path(), FilterLevel::Minimal, None, None, false, 0)?;
+        run(
+            file.path(),
+            FilterLevel::Minimal,
+            None,
+            None,
+            None,
+            None,
+            false,
+            0,
+        )?;
         Ok(())
     }
 
@@ -214,26 +294,126 @@ fn main() {{
         // Compile-time verification that the function exists with correct signature
     }
 
+    fn window(offset: Option<usize>, limit: Option<usize>, tail: Option<usize>) -> LineRange {
+        LineRange::from_args(offset, limit, tail)
+    }
+
+    fn gen_lines(lines: usize, newline: bool) -> String {
+        let mut buffer = (1..=lines)
+            .map(|n| format!("line {}\n", n))
+            .collect::<String>();
+        if !newline {
+            buffer.pop();
+        }
+        buffer
+    }
+
+    fn get_range(input: &str, range: &LineRange) -> (usize, String) {
+        apply_line_window(input, None, range, &Language::Unknown)
+    }
+
     #[test]
     fn test_apply_line_window_tail_lines() {
-        let input = "a\nb\nc\nd\n";
-        let output = apply_line_window(input, None, Some(2), &Language::Unknown);
-        assert_eq!(output, "c\nd\n");
+        let (start, output) = get_range(&gen_lines(4, true), &window(None, None, Some(2)));
+        assert_eq!(start, 3);
+        assert_eq!(output, "line 3\nline 4\n");
     }
 
     #[test]
     fn test_apply_line_window_tail_lines_no_trailing_newline() {
-        let input = "a\nb\nc\nd";
-        let output = apply_line_window(input, None, Some(2), &Language::Unknown);
-        assert_eq!(output, "c\nd");
+        let (start, output) = get_range(&gen_lines(4, false), &window(None, None, Some(2)));
+        assert_eq!(start, 3);
+        assert_eq!(output, "line 3\nline 4");
     }
 
     #[test]
-    fn test_apply_line_window_max_lines_still_works() {
-        let input = "a\nb\nc\nd\n";
-        let output = apply_line_window(input, Some(2), None, &Language::Unknown);
-        assert!(output.starts_with("a\n"));
-        assert!(output.contains("more lines"));
+    fn test_apply_line_window_max_lines() {
+        let (start, output) = apply_line_window(
+            &gen_lines(4, true),
+            Some(2),
+            &window(None, None, None),
+            &Language::Unknown,
+        );
+        assert_eq!(start, 1);
+        assert!(output.starts_with("line 1\n"));
+        assert!(output.contains("3 more lines"));
+    }
+
+    #[test]
+    fn test_apply_line_window_offset_only() {
+        let (start, output) = get_range(&gen_lines(4, true), &window(Some(2), None, None));
+        assert_eq!(start, 2);
+        assert_eq!(output, "line 2\nline 3\nline 4\n");
+    }
+
+    #[test]
+    fn test_apply_line_window_offset_and_max_lines() {
+        let (start, output) = apply_line_window(
+            &gen_lines(4, true),
+            Some(2),
+            &window(Some(2), None, None),
+            &Language::Unknown,
+        );
+        assert_eq!(start, 2);
+        assert!(output.starts_with("line 2\n"));
+        assert!(output.contains("2 more lines"));
+    }
+
+    #[test]
+    fn test_apply_line_window_offset_beyond_end() {
+        let (start, output) = get_range(&gen_lines(2, true), &window(Some(3), None, None));
+        assert_eq!(start, 3);
+        assert_eq!(output, "");
+    }
+
+    #[test]
+    fn test_apply_line_window_empty_range() {
+        let (_, output) = get_range(&gen_lines(2, true), &window(Some(2), Some(0), None));
+        assert_eq!(output, "");
+    }
+
+    #[test]
+    fn test_apply_line_window_head() {
+        let (start, output) = get_range(&gen_lines(5, true), &window(None, Some(3), None));
+        assert_eq!(start, 1);
+        assert_eq!(output, "line 1\nline 2\nline 3\n");
+    }
+
+    #[test]
+    fn test_apply_line_window_head_beyond_end() {
+        let (start, output) = get_range(&gen_lines(2, true), &window(None, Some(3), None));
+        assert_eq!(start, 1);
+        assert_eq!(output, "line 1\nline 2\n");
+    }
+
+    #[test]
+    fn test_apply_line_window_slice() {
+        let (start, output) = get_range(&gen_lines(5, true), &window(Some(3), Some(2), None));
+        assert_eq!(start, 3);
+        assert_eq!(output, "line 3\nline 4\n");
+    }
+
+    #[test]
+    fn test_apply_line_window_slice_beyond_end() {
+        let (start, output) = get_range(&gen_lines(5, true), &window(Some(3), Some(10), None));
+        assert_eq!(start, 3);
+        assert_eq!(output, "line 3\nline 4\nline 5\n");
+    }
+
+    #[test]
+    fn test_apply_line_window_slice_start_beyond_end() {
+        let (start, output) = get_range(&gen_lines(5, true), &window(Some(6), Some(1), None));
+        assert_eq!(start, 6);
+        assert_eq!(output, "");
+    }
+
+    #[test]
+    fn test_read_slice_with_line_numbers() {
+        let (start, output) = get_range(&gen_lines(5, true), &window(Some(3), Some(2), None));
+        assert_eq!(start, 3);
+        let output = format_with_line_numbers(&output, start);
+        assert!(output.contains("3 │ line 3\n"), "line 3 wrong: {output:?}");
+        assert!(output.contains("4 │ line 4\n"), "line 4 wrong: {output:?}");
     }
 
     fn rtk_bin() -> std::path::PathBuf {
@@ -255,7 +435,11 @@ fn main() {{
         writeln!(f2, "charlie\ndelta").unwrap();
 
         let output = std::process::Command::new(&bin)
-            .args(["read", &f1.path().to_string_lossy(), &f2.path().to_string_lossy()])
+            .args([
+                "read",
+                &f1.path().to_string_lossy(),
+                &f2.path().to_string_lossy(),
+            ])
             .output()
             .expect("failed to run rtk read");
 
@@ -275,15 +459,28 @@ fn main() {{
         writeln!(f1, "valid content").unwrap();
 
         let output = std::process::Command::new(&bin)
-            .args(["read", &f1.path().to_string_lossy(), "/tmp/rtk_nonexistent_file.txt"])
+            .args([
+                "read",
+                &f1.path().to_string_lossy(),
+                "/tmp/rtk_nonexistent_file.txt",
+            ])
             .output()
             .expect("failed to run rtk read");
 
-        assert!(!output.status.success(), "should exit non-zero on missing file");
+        assert!(
+            !output.status.success(),
+            "should exit non-zero on missing file"
+        );
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
-        assert!(stdout.contains("valid content"), "valid file should still be printed");
-        assert!(stderr.contains("rtk_nonexistent_file"), "should report missing file on stderr");
+        assert!(
+            stdout.contains("valid content"),
+            "valid file should still be printed"
+        );
+        assert!(
+            stderr.contains("rtk_nonexistent_file"),
+            "should report missing file on stderr"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,8 +104,14 @@ enum Commands {
         #[arg(short, long, conflicts_with = "tail_lines")]
         max_lines: Option<usize>,
         /// Keep only last N lines
-        #[arg(long, conflicts_with = "max_lines")]
+        #[arg(long, conflicts_with = "max_lines", conflicts_with = "offset")]
         tail_lines: Option<usize>,
+        /// Start reading from line N (1-based); combine with --max-lines for windowed reads
+        #[arg(long, conflicts_with = "tail_lines")]
+        offset: Option<usize>,
+        /// Exact line count to read from the current position (no smart truncation); combine with --offset for a precise window
+        #[arg(long, conflicts_with = "tail_lines")]
+        limit: Option<usize>,
         /// Show line numbers
         #[arg(short = 'n', long)]
         line_numbers: bool,
@@ -1480,6 +1486,42 @@ fn validate_pnpm_filters(filters: &[String], command: &PnpmCommands) -> Option<S
     }
 }
 
+/// Detect and reinterpret trailing numeric positionals in `files` as a line range.
+///
+/// Claude emits `rtk read <file> <start> [<end>]` when instructed to prefer `rtk read`
+/// over its built-in Read tool (issue #1104). Clap greedily captures the integers into
+/// `files`; this function pops them and sets `offset`/`limit` when exactly one real path
+/// remains, leaving multi-file invocations untouched.
+fn resolve_positional_line_range(
+    files: &mut Vec<PathBuf>,
+    offset: &mut Option<usize>,
+    limit: &mut Option<usize>,
+) {
+    let num_args: Vec<usize> = files
+        .iter()
+        .rev()
+        .take(2)
+        .filter_map(|pb| {
+            pb.to_str()
+                .and_then(|s| s.parse::<usize>().ok())
+                .filter(|_| !pb.exists())
+        })
+        .collect();
+
+    match num_args[..] {
+        [end_line, start_line] if files.len() == 3 => {
+            *offset = Some(start_line);
+            *limit = Some(end_line.saturating_sub(start_line).saturating_add(1));
+            files.truncate(1);
+        }
+        [start_line] if files.len() == 2 => {
+            *offset = Some(start_line);
+            files.truncate(1);
+        }
+        _ => {}
+    }
+}
+
 fn main() {
     // Reset SIGPIPE to default handler so writing to a closed pipe
     // e.g `rtk git log | head` exits silently instead of panicking.
@@ -1558,12 +1600,19 @@ fn run_cli() -> Result<i32> {
 
         // ISSUE #989: support multiple files (cat file1 file2 → rtk read file1 file2)
         Commands::Read {
-            files,
+            mut files,
             level,
             max_lines,
             tail_lines,
+            mut offset,
+            mut limit,
             line_numbers,
         } => {
+            // Support positional `rtk read <file> <start> [<end>]` emitted by Claude when
+            // instructed to prefer rtk read over its built-in Read tool (issue #1104).
+            if offset.is_none() && limit.is_none() {
+                resolve_positional_line_range(&mut files, &mut offset, &mut limit);
+            }
             let mut had_error = false;
             let mut stdin_seen = false;
             for file in &files {
@@ -1573,13 +1622,23 @@ fn run_cli() -> Result<i32> {
                         continue;
                     }
                     stdin_seen = true;
-                    read::run_stdin(level, max_lines, tail_lines, line_numbers, cli.verbose)
+                    read::run_stdin(
+                        level,
+                        max_lines,
+                        tail_lines,
+                        offset,
+                        limit,
+                        line_numbers,
+                        cli.verbose,
+                    )
                 } else {
                     read::run(
                         file,
                         level,
                         max_lines,
                         tail_lines,
+                        offset,
+                        limit,
                         line_numbers,
                         cli.verbose,
                     )
@@ -3530,5 +3589,75 @@ mod tests {
             }
             _ => panic!("Expected Init command"),
         }
+    }
+
+    // ── resolve_positional_line_range ─────────────────────────────────────────
+
+    fn pb(s: &str) -> PathBuf {
+        PathBuf::from(s)
+    }
+
+    #[test]
+    fn test_positional_start_end() {
+        let mut files = vec![pb("file.rs"), pb("10"), pb("20")];
+        let mut offset = None;
+        let mut limit = None;
+        resolve_positional_line_range(&mut files, &mut offset, &mut limit);
+        assert_eq!(files, vec![pb("file.rs")]);
+        assert_eq!(offset, Some(10));
+        assert_eq!(limit, Some(11)); // 20 - 10 + 1
+    }
+
+    #[test]
+    fn test_positional_start_only() {
+        let mut files = vec![pb("file.rs"), pb("10")];
+        let mut offset = None;
+        let mut limit = None;
+        resolve_positional_line_range(&mut files, &mut offset, &mut limit);
+        assert_eq!(files, vec![pb("file.rs")]);
+        assert_eq!(offset, Some(10));
+        assert_eq!(limit, None);
+    }
+
+    #[test]
+    fn test_positional_multi_file_untouched() {
+        let mut files = vec![pb("a.rs"), pb("b.rs"), pb("10"), pb("20")];
+        let mut offset = None;
+        let mut limit = None;
+        resolve_positional_line_range(&mut files, &mut offset, &mut limit);
+        assert_eq!(files, vec![pb("a.rs"), pb("b.rs"), pb("10"), pb("20")]);
+        assert_eq!(offset, None);
+        assert_eq!(limit, None);
+    }
+
+    #[test]
+    fn test_positional_no_numerics_untouched() {
+        let mut files = vec![pb("file.rs")];
+        let mut offset = None;
+        let mut limit = None;
+        resolve_positional_line_range(&mut files, &mut offset, &mut limit);
+        assert_eq!(files, vec![pb("file.rs")]);
+        assert_eq!(offset, None);
+        assert_eq!(limit, None);
+    }
+
+    #[test]
+    fn test_positional_end_equals_start() {
+        let mut files = vec![pb("file.rs"), pb("5"), pb("5")];
+        let mut offset = None;
+        let mut limit = None;
+        resolve_positional_line_range(&mut files, &mut offset, &mut limit);
+        assert_eq!(offset, Some(5));
+        assert_eq!(limit, Some(1)); // single line
+    }
+
+    #[test]
+    fn test_positional_end_less_than_start_saturates() {
+        let mut files = vec![pb("file.rs"), pb("10"), pb("5")];
+        let mut offset = None;
+        let mut limit = None;
+        resolve_positional_line_range(&mut files, &mut offset, &mut limit);
+        assert_eq!(offset, Some(10));
+        assert_eq!(limit, Some(1)); // saturating_sub(10) = 0, +1 = 1
     }
 }


### PR DESCRIPTION
## Summary

Adds windowed read support to `rtk read`, addressing two related needs:

- **Named flags** for explicit use: `--offset <N>` (start from line N, 1-based), `--limit <N>` (read exactly N lines), combinable for a precise slice
- **Positional line range** for Claude compatibility: `rtk read <file> <start> <end>` (inclusive end), and `rtk read <file> <start>` (read to EOF) — matches the form Claude emits when instructed to prefer `rtk read` over its built-in Read tool (fixes #1104)

Internal changes:
- `LineRange` enum unifies all windowing modes (Full, Head, Tail, From, Slice, Empty)
- `apply_line_window` returns `(line_start, content)` so `--line-numbers` / `-n` displays correct line numbers for windowed output
- `format_with_line_numbers` accepts a `display_start` offset instead of always starting at 1
- `resolve_positional_line_range` detects trailing numeric positionals in `files` and rewrites them to `offset`/`limit` — only fires for single-file invocations; multi-file calls are left untouched

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test --all`
- [x] Unit tests for `resolve_positional_line_range` (start+end, start-only, multi-file passthrough, no-numerics, end==start, end<start)
- [x] Manual: `rtk read <file> --offset 10`
- [x] Manual: `rtk read <file> --offset 10 --limit 20`
- [x] Manual: `rtk read <file> --tail-lines 10 -n` — correct line numbers
- [x] Manual: `rtk read <file> 10 20` — positional form
- [x] Manual: `rtk read <file> 10` — offset-only positional form