### PR TITLE
fix(init): preserve kubectl get in copilot template

### DIFF
--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -3909,7 +3909,7 @@ git status                 rtk git status
 git log -10                rtk git log -10
 cargo test                 rtk cargo test
 docker ps                  rtk docker ps
-kubectl get pods           rtk kubectl pods
+kubectl get pods           rtk kubectl get pods
 ```
 
 ## Meta commands (use directly)
@@ -6573,6 +6573,8 @@ mod tests {
         assert!(content.contains(RTK_BLOCK_START));
         assert!(content.contains(RTK_BLOCK_END));
         assert!(content.contains("rtk cargo test"));
+        assert!(content.contains("kubectl get pods           rtk kubectl get pods"));
+        assert!(!content.contains("kubectl get pods           rtk kubectl pods"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep the `get` subcommand in the Copilot instructions template for `kubectl get pods`
- add a regression assertion to the Copilot init test so the incorrect `rtk kubectl pods` mapping does not come back

Fixes #2471.

## Verification
- `cargo test copilot_init --quiet`