### PR TITLE
[codex] fix native test expression passthrough

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1460,6 +1460,12 @@ where
     }
 }
 
+fn is_native_test_expression(command: &[String]) -> bool {
+    command
+        .first()
+        .is_some_and(|arg| arg == "!" || arg == "(" || arg.starts_with('-'))
+}
+
 fn run_cli() -> Result<i32> {
     // Fire-and-forget telemetry ping (1/day, non-blocking)
     core::telemetry::maybe_ping();
@@ -1726,8 +1732,13 @@ fn run_cli() -> Result<i32> {
         }
 
         Commands::Test { command } => {
-            let cmd = command.join(" ");
-            runner::run_test(&cmd, cli.verbose)?
+            if is_native_test_expression(&command) {
+                let args: Vec<OsString> = command.into_iter().map(OsString::from).collect();
+                core::runner::run_passthrough("test", &args, cli.verbose)?
+            } else {
+                let cmd = command.join(" ");
+                runner::run_test(&cmd, cli.verbose)?
+            }
         }
 
         Commands::Json {
@@ -2850,6 +2861,18 @@ mod tests {
             )),
             Ok(_) => panic!("Expected parse error for unknown subcommand"),
         }
+    }
+
+    #[test]
+    fn test_dash_d_routes_to_native_test_expression() {
+        let command = vec!["-d".to_string(), "graphify-out".to_string()];
+        assert!(is_native_test_expression(&command));
+    }
+
+    #[test]
+    fn test_cargo_test_stays_test_runner() {
+        let command = vec!["cargo".to_string(), "test".to_string()];
+        assert!(!is_native_test_expression(&command));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1461,9 +1461,13 @@ where
 }
 
 fn is_native_test_expression(command: &[String]) -> bool {
-    command
-        .first()
-        .is_some_and(|arg| arg == "!" || arg == "(" || arg.starts_with('-'))
+    match command.first().map(String::as_str) {
+        // `!` and `(` are shell syntax too, so they only mark a native
+        // expression when what they apply to is one.
+        Some("!") | Some("(") => is_native_test_expression(&command[1..]),
+        Some(arg) => arg.starts_with('-'),
+        None => false,
+    }
 }
 
 fn run_cli() -> Result<i32> {
@@ -2866,6 +2870,18 @@ mod tests {
     #[test]
     fn test_dash_d_routes_to_native_test_expression() {
         let command = vec!["-d".to_string(), "graphify-out".to_string()];
+        assert!(is_native_test_expression(&command));
+    }
+
+    #[test]
+    fn test_bang_before_command_is_not_a_native_expression() {
+        let command = vec!["!".to_string(), "false".to_string()];
+        assert!(!is_native_test_expression(&command));
+    }
+
+    #[test]
+    fn test_bang_before_operator_is_a_native_expression() {
+        let command = vec!["!".to_string(), "-d".to_string(), "dir".to_string()];
         assert!(is_native_test_expression(&command));
     }
 

--- a/tests/native_test_expression_test.rs
+++ b/tests/native_test_expression_test.rs
@@ -1,0 +1,91 @@
+#![cfg(unix)]
+//! End-to-end coverage for `Commands::Test` routing.
+//!
+//! `rtk test` doubles as a wrapper around a test runner and as the POSIX `test`
+//! utility. The unit tests in `main.rs` cover `is_native_test_expression` on its
+//! own; these run the binary so an inverted or removed branch in the `Commands::Test`
+//! arm fails here instead of shipping.
+
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn exit_code(cwd: &Path, args: &[&str]) -> i32 {
+    Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .env("LC_ALL", "C")
+        .env("HOME", cwd.join("home"))
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("spawn rtk")
+        .status
+        .code()
+        .expect("rtk exited via signal")
+}
+
+fn fixture() -> TempDir {
+    let dir = TempDir::new().expect("create tempdir");
+    std::fs::create_dir(dir.path().join("home")).expect("create home");
+    std::fs::create_dir(dir.path().join("adir")).expect("create adir");
+    std::fs::write(dir.path().join("afile"), b"").expect("create afile");
+    dir
+}
+
+/// A native expression must reach the system `test`, whose exit code is the answer.
+/// Routing it through the shell wrapper instead yields `sh: 0: Illegal option -d`
+/// and exit 2 for every one of these.
+#[test]
+fn native_expressions_carry_the_test_exit_code() {
+    let dir = fixture();
+    let cwd = dir.path();
+
+    assert_eq!(exit_code(cwd, &["test", "-d", "adir"]), 0);
+    assert_eq!(exit_code(cwd, &["test", "-d", "nodir"]), 1);
+    assert_eq!(exit_code(cwd, &["test", "-f", "afile"]), 0);
+    assert_eq!(exit_code(cwd, &["test", "-f", "nofile"]), 1);
+    assert_eq!(exit_code(cwd, &["test", "-e", "adir"]), 0);
+}
+
+/// `!` negates, so these are the cases the shell wrapper answered backwards
+/// rather than loudly: it reported "not a directory" as true for a directory
+/// that exists, because `-d` was a missing command and `!` inverted its 127.
+#[test]
+fn negated_expressions_are_not_answered_backwards() {
+    let dir = fixture();
+    let cwd = dir.path();
+
+    assert_eq!(exit_code(cwd, &["test", "!", "-d", "adir"]), 1);
+    assert_eq!(exit_code(cwd, &["test", "!", "-d", "nodir"]), 0);
+}
+
+/// `!` and `(` are shell syntax as well as `test` syntax. They mark a native
+/// expression only when what they apply to is one, so a command behind `!` still
+/// runs under the shell and keeps the exit code negation it had before.
+#[test]
+fn bang_before_a_command_still_runs_the_command() {
+    let dir = fixture();
+    let cwd = dir.path();
+
+    assert_eq!(exit_code(cwd, &["test", "!", "false"]), 0);
+    assert_eq!(exit_code(cwd, &["test", "!", "true"]), 1);
+}
+
+/// Argument boundaries survive: the passthrough passes argv through, where the
+/// shell wrapper re-split a joined string and saw three arguments here.
+#[test]
+fn native_expressions_keep_argument_boundaries() {
+    let dir = fixture();
+    std::fs::write(dir.path().join("a file"), b"").expect("create spaced file");
+
+    assert_eq!(exit_code(dir.path(), &["test", "-f", "a file"]), 0);
+}
+
+/// The other direction: a command to run under the test filter still goes to the
+/// filter, not to the system `test`, which would reject it as too many arguments.
+#[test]
+fn commands_still_reach_the_test_runner() {
+    let dir = fixture();
+
+    assert_eq!(exit_code(dir.path(), &["test", "echo", "hello"]), 0);
+}


### PR DESCRIPTION
## What changed

- Detect native POSIX `test` expressions passed through `rtk test`, such as `rtk test -d graphify-out`.
- Route those expressions to the system `test` command via passthrough.
- Keep regular RTK test filtering intact for commands like `rtk test cargo test`.
- Add regression coverage and a changelog entry.

## Problem

`rtk test -d graphify-out` failed with:

```text
sh: 0: Illegal option -d
```

Running `test -d graphify-out` directly worked.

## Root cause

`test` is also an RTK subcommand. Clap correctly routed `rtk test -d graphify-out` to `Commands::Test`, but that handler joined the remaining args into a string and executed it through `sh -c` for RTK's test-output filtering.

That produced `sh -c "-d graphify-out"`. POSIX `sh` interpreted `-d` as an option to the shell command itself, not as an argument to `test`, which caused `Illegal option -d`.

## Proposed solution

When `Commands::Test` receives a native `test` expression (`-d`, `-f`, `!`, `(`, etc.), bypass the RTK test-output wrapper and run the system `test` command directly with the original arguments. This keeps shell parsing out of the path and preserves the native `test` exit semantics.

## Validation

- `rtk cargo +1.91.0 fmt --all && rtk cargo +1.91.0 clippy --all-targets && rtk cargo +1.91.0 test --all`
- `rtk proxy ./target/debug/rtk test -d .`
- `rtk proxy ./target/debug/rtk test -d graphify-out`
- `rtk proxy ./target/debug/rtk test true`