### PR TITLE
fix(init): create Claude config dir for global init

### DIFF
--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -373,6 +373,7 @@ fn write_if_changed(path: &Path, content: &str, name: &str, ctx: InitContext) ->
                 println!("[dry-run] content:\n{}", content);
             }
         } else {
+            ensure_parent_dir(path)?;
             atomic_write(path, content)
                 .with_context(|| format!("Failed to write {}: {}", name, path.display()))?;
             if verbose > 0 {
@@ -381,6 +382,19 @@ fn write_if_changed(path: &Path, content: &str, name: &str, ctx: InitContext) ->
         }
         Ok(true)
     }
+}
+
+fn ensure_parent_dir(path: &Path) -> Result<()> {
+    let Some(parent) = path.parent() else {
+        return Ok(());
+    };
+
+    if parent.as_os_str().is_empty() {
+        return Ok(());
+    }
+
+    fs::create_dir_all(parent)
+        .with_context(|| format!("Failed to create directory: {}", parent.display()))
 }
 
 /// Resolve the final write target: if `path` is a symlink, follow it so
@@ -1013,6 +1027,7 @@ fn patch_settings_json_command(
     }
 
     // Atomic write
+    ensure_parent_dir(&settings_path)?;
     atomic_write(&settings_path, &serialized)?;
 
     println!("\n  settings.json: hook added");
@@ -5872,14 +5887,45 @@ mod tests {
     fn with_claude_dir_override<F: FnOnce(&Path)>(tmp: &TempDir, f: F) {
         let _guard = CLAUDE_DIR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let claude_dir = tmp.path().join(CLAUDE_DIR);
+        let home_dir = tmp.path().join("home");
         fs::create_dir_all(&claude_dir).unwrap();
 
         let orig = std::env::var_os("CLAUDE_CONFIG_DIR");
+        let orig_home = std::env::var_os("HOME");
         std::env::set_var("CLAUDE_CONFIG_DIR", &claude_dir);
+        std::env::set_var("HOME", &home_dir);
         f(&claude_dir);
         match orig {
             Some(v) => std::env::set_var("CLAUDE_CONFIG_DIR", v),
             None => std::env::remove_var("CLAUDE_CONFIG_DIR"),
+        }
+        match orig_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    fn with_missing_claude_dir_override<F: FnOnce(&Path)>(tmp: &TempDir, f: F) {
+        let _guard = CLAUDE_DIR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let claude_dir = tmp.path().join(CLAUDE_DIR);
+        let home_dir = tmp.path().join("home");
+        assert!(
+            !claude_dir.exists(),
+            "test precondition: Claude config dir must be missing"
+        );
+
+        let orig = std::env::var_os("CLAUDE_CONFIG_DIR");
+        let orig_home = std::env::var_os("HOME");
+        std::env::set_var("CLAUDE_CONFIG_DIR", &claude_dir);
+        std::env::set_var("HOME", &home_dir);
+        f(&claude_dir);
+        match orig {
+            Some(v) => std::env::set_var("CLAUDE_CONFIG_DIR", v),
+            None => std::env::remove_var("CLAUDE_CONFIG_DIR"),
+        }
+        match orig_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
         }
     }
 
@@ -5915,6 +5961,28 @@ mod tests {
             assert!(
                 content.contains(CLAUDE_HOOK_COMMAND),
                 "settings.json must contain hook command"
+            );
+        });
+    }
+
+    #[test]
+    fn test_global_default_mode_creates_missing_claude_dir() {
+        let tmp = TempDir::new().unwrap();
+        with_missing_claude_dir_override(&tmp, |claude_dir| {
+            run_default_mode(true, PatchMode::Auto, false, InitContext::default()).unwrap();
+
+            assert!(
+                claude_dir.exists(),
+                "missing Claude config dir must be created"
+            );
+            assert!(claude_dir.join(RTK_MD).exists(), "RTK.md must be created");
+            assert!(
+                claude_dir.join(CLAUDE_MD).exists(),
+                "CLAUDE.md must be created"
+            );
+            assert!(
+                claude_dir.join(SETTINGS_JSON).exists(),
+                "settings.json must be created"
             );
         });
     }
@@ -6011,6 +6079,28 @@ mod tests {
     }
 
     #[test]
+    fn test_global_hook_only_mode_creates_missing_claude_dir() {
+        let tmp = TempDir::new().unwrap();
+        with_missing_claude_dir_override(&tmp, |claude_dir| {
+            run_hook_only_mode(true, PatchMode::Auto, false, InitContext::default()).unwrap();
+
+            assert!(
+                claude_dir.exists(),
+                "missing Claude config dir must be created"
+            );
+            assert!(
+                !claude_dir.join(RTK_MD).exists(),
+                "RTK.md must NOT be created in hook-only mode"
+            );
+            let settings = fs::read_to_string(claude_dir.join(SETTINGS_JSON)).unwrap();
+            assert!(
+                settings.contains(CLAUDE_HOOK_COMMAND),
+                "settings.json must contain hook command"
+            );
+        });
+    }
+
+    #[test]
     fn test_run_default_mode_dry_run_writes_nothing() {
         let tmp = TempDir::new().unwrap();
         with_claude_dir_override(&tmp, |claude_dir| {
@@ -6031,6 +6121,23 @@ mod tests {
             assert!(
                 !claude_dir.join(SETTINGS_JSON).exists(),
                 "dry-run must not create settings.json"
+            );
+        });
+    }
+
+    #[test]
+    fn test_run_default_mode_dry_run_does_not_create_missing_claude_dir() {
+        let tmp = TempDir::new().unwrap();
+        with_missing_claude_dir_override(&tmp, |claude_dir| {
+            let dry = InitContext {
+                dry_run: true,
+                ..Default::default()
+            };
+            run_default_mode(true, PatchMode::Auto, false, dry).unwrap();
+
+            assert!(
+                !claude_dir.exists(),
+                "dry-run must not create missing Claude config dir"
             );
         });
     }


### PR DESCRIPTION
## Summary
- create the Claude config parent directory before global init writes RTK.md or settings.json
- fix fresh-home failures where atomic writes could not create temp files inside a missing ~/.claude directory
- add regression coverage for default global init, hook-only global init, and dry-run behavior with a missing Claude config dir

Fixes #2519.

## Context
Plain global init can currently fail on a fresh machine or user profile when ~/.claude does not exist:

```
rtk: Failed to write RTK.md: ~/.claude/RTK.md: Failed to create temp file in ~/.claude: No such file or directory (os error 2)
```

The underlying issue is that atomic_write() creates its tempfile inside the target file's parent directory. That parent directory must exist before NamedTempFile::new_in(parent) is called.

Related: #1840 fixes the separate Cursor-only path for `rtk init -g --agent cursor` and missing ~/.cursor. This PR intentionally stays focused on the default/global Claude init path.

## CONTRIBUTING.md alignment
- Focused PR: one bug fix in the hook init path; no unrelated refactors or formatting churn.
- Conventional commit: `fix(init): create Claude config dir for global init`.
- Target branch: `develop`.
- Documentation: not updated because this is a bug fix for existing documented init behavior, not a new hook feature or behavior surface.
- Changelog: not edited manually; release-please owns it.

## Test plan
- [x] Unit tests added/updated for changed code
- [x] Edge cases covered: missing Claude config dir, hook-only global init, dry-run with missing dir
- [x] `cargo fmt --all --check`
- [x] `cargo test missing_claude_dir -- --nocapture`
- [x] `cargo test --all` (2212 passed, 8 ignored)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Manual test with temp `HOME` and `CLAUDE_CONFIG_DIR`: `./target/debug/rtk init -g --auto-patch`
- [x] Snapshot tests not applicable: no snapshots changed
- [x] Token savings/truncation checklist not applicable: this PR does not add or change output filters
