### PR TITLE
docs(readme): replace hardcoded version pins with version-agnostic check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This is a fork with critical fixes for git argument parsing and modern JavaScrip
 
 **Verify correct installation:**
 ```bash
-rtk --version  # Should show "rtk 0.28.2" (or newer)
+rtk --version  # Should print a version (e.g. "rtk 0.42.4" or newer), not "command not found"
 rtk gain       # Should show token savings stats (NOT "command not found")
 ```
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Download from [releases](https://github.com/rtk-ai/rtk/releases):
 ### Verify Installation
 
 ```bash
-rtk --version   # Should show "rtk 0.28.2"
+rtk --version   # Should print a version (e.g. "rtk 0.42.4"), not "command not found"
 rtk gain        # Should show token savings stats
 ```
 

--- a/README_es.md
+++ b/README_es.md
@@ -69,7 +69,7 @@ cargo install --git https://github.com/rtk-ai/rtk
 ### Verificacion
 
 ```bash
-rtk --version   # Debe mostrar "rtk 0.27.x"
+rtk --version   # Debe mostrar una versión (p. ej. "rtk 0.42.4"), no "command not found"
 rtk gain        # Debe mostrar estadisticas de ahorro
 ```
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -74,7 +74,7 @@ cargo install --git https://github.com/rtk-ai/rtk
 ### Verification
 
 ```bash
-rtk --version   # Doit afficher "rtk 0.27.x"
+rtk --version   # Doit afficher une version (ex. "rtk 0.42.4"), pas "command not found"
 rtk gain        # Doit afficher les statistiques d'economies
 ```
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -69,7 +69,7 @@ cargo install --git https://github.com/rtk-ai/rtk
 ### 確認
 
 ```bash
-rtk --version   # "rtk 0.27.x" と表示されるはず
+rtk --version   # バージョンが表示されるはず（例: "rtk 0.42.4"）。"command not found" はNG
 rtk gain        # トークン節約統計が表示されるはず
 ```
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -69,7 +69,7 @@ cargo install --git https://github.com/rtk-ai/rtk
 ### 확인
 
 ```bash
-rtk --version   # "rtk 0.27.x" 표시되어야 함
+rtk --version   # 버전이 표시되어야 함 (예: "rtk 0.42.4"), "command not found" 아님
 rtk gain        # 토큰 절약 통계 표시되어야 함
 ```
 

--- a/README_pt.md
+++ b/README_pt.md
@@ -70,7 +70,7 @@ cargo install --git https://github.com/rtk-ai/rtk
 ### Verificação
 
 ```bash
-rtk --version   # Deve exibir "rtk 0.28.2"
+rtk --version   # Deve exibir uma versão (ex.: "rtk 0.42.4"), não "command not found"
 rtk gain        # Deve exibir estatísticas de economia
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -70,7 +70,7 @@ cargo install --git https://github.com/rtk-ai/rtk
 ### 验证
 
 ```bash
-rtk --version   # 应显示 "rtk 0.27.x"
+rtk --version   # 应显示版本号（例如 "rtk 0.42.4"），而非 "command not found"
 rtk gain        # 应显示 token 节省统计
 ```
 


### PR DESCRIPTION
## Summary

- Replace hardcoded `rtk --version` example (`0.28.2` / `0.27.x`) with a version-agnostic check that confirms the binary runs instead of pinning a number that goes stale on every release.
- Apply across all docs: `README.md`, `CLAUDE.md`, and the 6 translated READMEs (`es`, `fr`, `ja`, `ko`, `pt`, `zh`).
- Docs-only change — no code, no behavior change.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test` (no Rust touched; gate clean)
- [x] Manual: `grep -rn 'rtk 0\.[0-9]' README*.md CLAUDE.md` → only `0.42.4` examples remain, no stale pins
