### PR TITLE
fix(grep): disable help flag to allow -h passthrough

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -307,6 +307,7 @@ enum Commands {
     },
 
     /// Compact grep - strips whitespace, truncates, groups by file
+    #[command(disable_help_flag = true)]
     Grep {
         /// Max line length
         #[arg(short = 'l', long, default_value = "80")]


### PR DESCRIPTION
Fixes #2391.

Add `#[command(disable_help_flag = true)]` to the `Grep` variant in `src/main.rs` so clap does not intercept `-h` as `--help` before `trailing_var_arg` can collect it.

This follows the exact pattern of merged PR #650 (psql disable_help_flag).

## Problem

`rtk grep -h PATTERN FILE` prints rtk's help text and exits 0 instead of forwarding `-h` to the underlying grep/rg. This happens because clap's auto-generated `-h`/`--help` short flag is recognized before the `trailing_var_arg` collection runs, so `grep_cmd::run()` never executes.

## Fix

One-line addition to `src/main.rs`:

```rust
/// Compact grep - strips whitespace, truncates, groups by file
#[command(disable_help_flag = true)]
Grep {
```

## Side effect

`rtk grep --help` will forward to rg/grep help instead of showing rtk's grep usage. This matches the psql behavior where `rtk psql --help` shows psql's help, not rtk's.

## Testing

- `rtk grep -h alpha a.txt b.txt` no longer prints rtk help, shows search matches
- Exit code matches grep/rg exit code (0 for matches, 1 for no matches)
- `rtk grep -v pattern .` still works (invert-match)
- `rtk grep -rn pattern .` still works
- `cargo check` passes

This is complementary to PR #2334 (rewrite-layer passthrough), not competing. PR #2334 prevents the hook from creating the problematic invocation; this fix ensures correctness even if `-h` reaches `rtk grep` directly. Both fixes can coexist.

DCO: Signed-off.