### PR TITLE
fix(grep): disable help flag to allow -h passthrough

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -307,6 +307,7 @@ enum Commands {
     },
 
     /// Compact grep - strips whitespace, truncates, groups by file
+    #[command(disable_help_flag = true)]
     Grep {
         /// Max line length
         #[arg(short = 'l', long, default_value = "80")]


### PR DESCRIPTION
Fixes #2391.

Add `#[command(disable_help_flag = true)]` to the `Grep` variant so clap does not intercept `-h` as `--help` before `trailing_var_arg` can collect it.

Follows the pattern of merged PR #650 (psql disable_help_flag).

## Problem

`rtk grep -h PATTERN FILE` prints rtk's help text and exits 0 instead of forwarding `-h` to grep/rg. Clap's auto-generated help flag intercepts `-h` before the trailing var-arg collection runs.

## Fix

One-line addition to `src/main.rs`:

```rust
/// Compact grep - strips whitespace, truncates, groups by file
#[command(disable_help_flag = true)]
Grep {
```

## Side effect

`rtk grep --help` forwards to rg/grep help instead of rtk's usage text. This matches the psql behavior.

## Tests

- `rtk grep -h alpha a.txt b.txt` shows search matches, not help text
- `rtk grep --help` forwards to underlying tool help
- `rtk grep -v pattern .` still works
- `cargo test` passes

Complementary to PR #2334 (rewrite-layer passthrough). Both fixes can coexist.

DCO: Signed-off.