### PR TITLE
fix(rewrite): strip rtk prefix from shell builtins

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -509,6 +509,11 @@ pub fn rewrite_command(
         || trimmed.contains(';')
         || trimmed.contains('|')
         || trimmed.contains(" & ");
+    if !has_compound {
+        if let Some(stripped) = strip_redundant_rtk_shell_builtin(trimmed) {
+            return Some(stripped.to_string());
+        }
+    }
     if !has_compound && (trimmed.starts_with("rtk ") || trimmed == "rtk") {
         return Some(trimmed.to_string());
     }
@@ -786,6 +791,10 @@ fn rewrite_segment_inner(
     // e.g. "git status 2>&1" → match "git status", re-append " 2>&1"
     let (cmd_part, redirect_suffix) = strip_trailing_redirects(trimmed);
 
+    if let Some(stripped) = strip_redundant_rtk_shell_builtin(cmd_part) {
+        return Some(format!("{}{}", stripped, redirect_suffix));
+    }
+
     // Already RTK — pass through unchanged
     if cmd_part.starts_with("rtk ") || cmd_part == "rtk" {
         return Some(trimmed.to_string());
@@ -873,6 +882,23 @@ fn strip_word_prefix<'a>(cmd: &'a str, prefix: &str) -> Option<&'a str> {
     } else {
         None
     }
+}
+
+fn strip_redundant_rtk_shell_builtin(cmd: &str) -> Option<&str> {
+    const SHELL_BUILTINS: &[&str] = &[
+        ".", "alias", "cd", "export", "popd", "pushd", "set", "source", "ulimit", "umask",
+        "unalias", "unset",
+    ];
+
+    let rest = strip_word_prefix(cmd, "rtk")?.trim_start();
+    if rest.is_empty() {
+        return None;
+    }
+
+    SHELL_BUILTINS
+        .iter()
+        .any(|builtin| strip_word_prefix(rest, builtin).is_some())
+        .then_some(rest)
 }
 
 #[cfg(test)]
@@ -1010,6 +1036,26 @@ mod tests {
     #[test]
     fn test_classify_rtk_already() {
         assert_eq!(classify_command("rtk git status"), Classification::Ignored);
+    }
+
+    #[test]
+    fn test_rewrite_strips_redundant_rtk_prefix_from_shell_builtin() {
+        assert_eq!(
+            rewrite_command_no_prefixes("rtk cd /tmp", &[]),
+            Some("cd /tmp".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("rtk export FOO=bar", &[]),
+            Some("export FOO=bar".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_strips_redundant_rtk_prefix_from_builtin_in_compound() {
+        assert_eq!(
+            rewrite_command_no_prefixes("rtk cd /tmp && rtk npm init -y", &[]),
+            Some("cd /tmp && rtk npm init -y".into())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- strip redundant `rtk` prefix from shell builtins during rewrite
- preserve already-prefixed RTK commands such as `rtk git status`
- cover simple and compound shell-builtin rewrites

Fixes #2508

## Tests
- cargo +1.93.0 fmt --all -- --check
- cargo +1.93.0 test --all
- cargo +1.93.0 clippy --all-targets -- -D warnings