### PR TITLE
feat(tracking+gain): per-session token savings tracking

### DIFF
--- a/src/analytics/gain.rs
+++ b/src/analytics/gain.rs
@@ -1,11 +1,11 @@
 //! Shows users how many tokens RTK has saved them over time.
 
 use crate::core::display_helpers::{format_duration, print_period_table};
-use crate::core::tracking::{DayStats, MonthStats, Tracker, WeekStats};
+use crate::core::tracking::{DayStats, MonthStats, SessionStat, Tracker, WeekStats};
 use crate::core::utils::format_tokens;
 use crate::hooks::hook_check;
 use anyhow::{Context, Result};
-use chrono::Local;
+use chrono::{Local, Utc};
 use colored::Colorize;
 use serde::Serialize;
 use std::io::IsTerminal;
@@ -13,9 +13,10 @@ use std::path::PathBuf;
 
 #[allow(clippy::too_many_arguments)]
 pub fn run(
-    project: bool, // added: per-project scope flag
+    project: bool,
     graph: bool,
     history: bool,
+    session: Option<&str>,
     quota: bool,
     tier: &str,
     daily: bool,
@@ -45,6 +46,15 @@ pub fn run(
 
     if failures {
         return show_failures(&tracker);
+    }
+
+    if let Some(session_filter) = session {
+        // "" means bare --session (show all); non-empty means filter by prefix
+        let filter = if session_filter.is_empty() { None } else { Some(session_filter) };
+        let sessions = tracker
+            .get_by_session(filter)
+            .context("Failed to load session data from database")?;
+        return show_session_view(&sessions, filter);
     }
 
     // Handle export formats
@@ -682,6 +692,73 @@ fn check_rtk_disabled_bypass() -> Option<String> {
     } else {
         None
     }
+}
+
+fn show_session_view(sessions: &[SessionStat], filter: Option<&str>) -> Result<()> {
+    if sessions.is_empty() {
+        if let Some(f) = filter {
+            println!("No session found matching '{f}'.");
+        } else {
+            println!("No session data yet.");
+            println!(
+                "Session tracking requires CLAUDE_CODE_SESSION_ID to be set (Claude Code ≥ v2.x)."
+            );
+        }
+        return Ok(());
+    }
+
+    let title = if filter.is_some() {
+        format!("RTK Session Savings — {}", sessions[0].session_id)
+    } else {
+        "RTK Session Savings".to_string()
+    };
+    println!("{}", styled(&title, true));
+    println!("{}", "─".repeat(62));
+    println!(
+        "{:<10}  {:<12}  {:>5}  {:>8}  {:>6}",
+        "Session", "Last Seen", "Cmds", "Saved", "Avg%"
+    );
+    println!("{}", "─".repeat(62));
+
+    for s in sessions {
+        let age = {
+            let secs = (Utc::now() - s.last_seen).num_seconds().max(0) as u64;
+            if secs < 60 {
+                "just now".to_string()
+            } else if secs < 3600 {
+                format!("{}m ago", secs / 60)
+            } else if secs < 86400 {
+                format!("{}h ago", secs / 3600)
+            } else {
+                format!("{}d ago", secs / 86400)
+            }
+        };
+        let short_id = if s.session_id.len() >= 8 {
+            &s.session_id[..8]
+        } else {
+            &s.session_id
+        };
+        let pct_cell = colorize_pct_cell(s.avg_savings_pct, &format!("{:.1}%", s.avg_savings_pct));
+        println!(
+            "{:<10}  {:<12}  {:>5}  {:>8}  {}",
+            short_id,
+            age,
+            s.commands,
+            format_tokens(s.saved_tokens),
+            pct_cell,
+        );
+    }
+
+    println!("{}", "─".repeat(62));
+    let total_cmds: usize = sessions.iter().map(|s| s.commands).sum();
+    let total_saved: usize = sessions.iter().map(|s| s.saved_tokens).sum();
+    println!(
+        "Total: {} sessions  •  {} commands  •  {} saved",
+        sessions.len(),
+        total_cmds,
+        format_tokens(total_saved),
+    );
+    Ok(())
 }
 
 fn show_failures(tracker: &Tracker) -> Result<()> {

--- a/src/analytics/gain.rs
+++ b/src/analytics/gain.rs
@@ -115,28 +115,7 @@ pub fn run(
         }
         println!();
 
-        // added: KPI-style aligned output
-        print_kpi("Total commands", summary.total_commands.to_string());
-        print_kpi("Input tokens", format_tokens(summary.total_input));
-        print_kpi("Output tokens", format_tokens(summary.total_output));
-        print_kpi(
-            "Tokens saved",
-            format!(
-                "{} ({:.1}%)",
-                format_tokens(summary.total_saved),
-                summary.avg_savings_pct
-            ),
-        );
-        print_kpi(
-            "Total exec time",
-            format!(
-                "{} (avg {})",
-                format_duration(summary.total_time_ms),
-                format_duration(summary.avg_time_ms)
-            ),
-        );
-        print_efficiency_meter(summary.avg_savings_pct);
-        println!();
+        print_summary_kpis(&summary);
 
         // Warn about hook issues that silently kill savings (stderr, not stdout)
         match hook_check::status() {
@@ -164,90 +143,7 @@ pub fn run(
             eprintln!();
         }
 
-        if !summary.by_command.is_empty() {
-            // added: styled section header
-            println!("{}", styled("By Command", true));
-
-            // added: dynamic column widths for clean alignment
-            let cmd_width = 24usize;
-            let impact_width = 10usize;
-            let count_width = summary
-                .by_command
-                .iter()
-                .map(|(_, count, _, _, _)| count.to_string().len())
-                .max()
-                .unwrap_or(5)
-                .max(5);
-            let saved_width = summary
-                .by_command
-                .iter()
-                .map(|(_, _, saved, _, _)| format_tokens(*saved).len())
-                .max()
-                .unwrap_or(5)
-                .max(5);
-            let time_width = summary
-                .by_command
-                .iter()
-                .map(|(_, _, _, _, avg_time)| format_duration(*avg_time).len())
-                .max()
-                .unwrap_or(6)
-                .max(6);
-
-            let table_width = 3
-                + 2
-                + cmd_width
-                + 2
-                + count_width
-                + 2
-                + saved_width
-                + 2
-                + 6
-                + 2
-                + time_width
-                + 2
-                + impact_width;
-            println!("{}", "─".repeat(table_width));
-            println!(
-                "{:>3}  {:<cmd_width$}  {:>count_width$}  {:>saved_width$}  {:>6}  {:>time_width$}  {:<impact_width$}",
-                "#", "Command", "Count", "Saved", "Avg%", "Time", "Impact",
-                cmd_width = cmd_width, count_width = count_width,
-                saved_width = saved_width, time_width = time_width,
-                impact_width = impact_width
-            );
-            println!("{}", "─".repeat(table_width));
-
-            let max_saved = summary
-                .by_command
-                .iter()
-                .map(|(_, _, saved, _, _)| *saved)
-                .max()
-                .unwrap_or(1);
-
-            for (idx, (cmd, count, saved, pct, avg_time)) in summary.by_command.iter().enumerate() {
-                let row_idx = format!("{:>2}.", idx + 1);
-                let cmd_cell = style_command_cell(&truncate_for_column(cmd, cmd_width)); // added: colored command
-                let count_cell = format!("{:>count_width$}", count, count_width = count_width);
-                let saved_cell = format!(
-                    "{:>saved_width$}",
-                    format_tokens(*saved),
-                    saved_width = saved_width
-                );
-                let pct_plain = format!("{:>6}", format!("{pct:.1}%"));
-                let pct_cell = colorize_pct_cell(*pct, &pct_plain); // added: color-coded percentage
-                let time_cell = format!(
-                    "{:>time_width$}",
-                    format_duration(*avg_time),
-                    time_width = time_width
-                );
-                let impact = mini_bar(*saved, max_saved, impact_width); // added: impact bar
-                println!(
-                    "{}  {}  {}  {}  {}  {}  {}",
-                    row_idx, cmd_cell, count_cell, saved_cell, pct_cell, time_cell, impact
-                );
-            }
-            println!("{}", "─".repeat(table_width));
-            println!();
-        }
+        print_by_command_table(&summary.by_command);
 
         if graph && !summary.by_day.is_empty() {
             println!("{}", styled("Daily Savings (last 30 days)", true)); // added: styled header
@@ -763,22 +659,7 @@ fn show_session_view(sessions: &[SessionStat], filter: Option<&str>) -> Result<(
     Ok(())
 }
 
-fn show_session_detail(session_filter: &str, summary: &GainSummary) -> Result<()> {
-    if summary.total_commands == 0 {
-        println!("No data found for session '{session_filter}'.");
-        return Ok(());
-    }
-
-    println!(
-        "{}",
-        styled(
-            &format!("RTK Token Savings — Session {session_filter}"),
-            true
-        )
-    );
-    println!("{}", "═".repeat(60));
-    println!();
-
+fn print_summary_kpis(summary: &GainSummary) {
     print_kpi("Total commands", summary.total_commands.to_string());
     print_kpi("Input tokens", format_tokens(summary.total_input));
     print_kpi("Output tokens", format_tokens(summary.total_output));
@@ -800,72 +681,109 @@ fn show_session_detail(session_filter: &str, summary: &GainSummary) -> Result<()
     );
     print_efficiency_meter(summary.avg_savings_pct);
     println!();
+}
 
-    if !summary.by_command.is_empty() {
-        println!("{}", styled("By Command", true));
-
-        let cmd_width = 24usize;
-        let impact_width = 10usize;
-        let count_width = summary
-            .by_command
-            .iter()
-            .map(|(_, count, _, _, _)| count.to_string().len())
-            .max()
-            .unwrap_or(5)
-            .max(5);
-        let saved_width = summary
-            .by_command
-            .iter()
-            .map(|(_, _, saved, _, _)| format_tokens(*saved).len())
-            .max()
-            .unwrap_or(5)
-            .max(5);
-        let time_width = summary
-            .by_command
-            .iter()
-            .map(|(_, _, _, _, avg_time)| format_duration(*avg_time).len())
-            .max()
-            .unwrap_or(6)
-            .max(6);
-
-        let table_width =
-            3 + 2 + cmd_width + 2 + count_width + 2 + saved_width + 2 + 6 + 2 + time_width + 2 + impact_width;
-        println!("{}", "─".repeat(table_width));
-        println!(
-            "{:>3}  {:<cmd_width$}  {:>count_width$}  {:>saved_width$}  {:>6}  {:>time_width$}  {:<impact_width$}",
-            "#", "Command", "Count", "Saved", "Avg%", "Time", "Impact",
-            cmd_width = cmd_width, count_width = count_width,
-            saved_width = saved_width, time_width = time_width,
-            impact_width = impact_width
-        );
-        println!("{}", "─".repeat(table_width));
-
-        let max_saved = summary
-            .by_command
-            .iter()
-            .map(|(_, _, saved, _, _)| *saved)
-            .max()
-            .unwrap_or(1);
-
-        for (idx, (cmd, count, saved, pct, avg_time)) in summary.by_command.iter().enumerate() {
-            let row_idx = format!("{:>2}.", idx + 1);
-            let cmd_cell = style_command_cell(&truncate_for_column(cmd, cmd_width));
-            let count_cell = format!("{:>count_width$}", count, count_width = count_width);
-            let saved_cell =
-                format!("{:>saved_width$}", format_tokens(*saved), saved_width = saved_width);
-            let pct_plain = format!("{:>6}", format!("{pct:.1}%"));
-            let pct_cell = colorize_pct_cell(*pct, &pct_plain);
-            let time_cell =
-                format!("{:>time_width$}", format_duration(*avg_time), time_width = time_width);
-            let impact = mini_bar(*saved, max_saved, impact_width);
-            println!(
-                "{}  {}  {}  {}  {}  {}  {}",
-                row_idx, cmd_cell, count_cell, saved_cell, pct_cell, time_cell, impact
-            );
-        }
-        println!("{}", "─".repeat(table_width));
-        println!();
+fn print_by_command_table(by_command: &[(String, usize, usize, f64, u64)]) {
+    if by_command.is_empty() {
+        return;
     }
+    println!("{}", styled("By Command", true));
+
+    let cmd_width = 24usize;
+    let impact_width = 10usize;
+    let count_width = by_command
+        .iter()
+        .map(|(_, count, _, _, _)| count.to_string().len())
+        .max()
+        .unwrap_or(5)
+        .max(5);
+    let saved_width = by_command
+        .iter()
+        .map(|(_, _, saved, _, _)| format_tokens(*saved).len())
+        .max()
+        .unwrap_or(5)
+        .max(5);
+    let time_width = by_command
+        .iter()
+        .map(|(_, _, _, _, avg_time)| format_duration(*avg_time).len())
+        .max()
+        .unwrap_or(6)
+        .max(6);
+
+    let table_width = 3
+        + 2
+        + cmd_width
+        + 2
+        + count_width
+        + 2
+        + saved_width
+        + 2
+        + 6
+        + 2
+        + time_width
+        + 2
+        + impact_width;
+    println!("{}", "─".repeat(table_width));
+    println!(
+        "{:>3}  {:<cmd_width$}  {:>count_width$}  {:>saved_width$}  {:>6}  {:>time_width$}  {:<impact_width$}",
+        "#", "Command", "Count", "Saved", "Avg%", "Time", "Impact",
+        cmd_width = cmd_width, count_width = count_width,
+        saved_width = saved_width, time_width = time_width,
+        impact_width = impact_width
+    );
+    println!("{}", "─".repeat(table_width));
+
+    let max_saved = by_command
+        .iter()
+        .map(|(_, _, saved, _, _)| *saved)
+        .max()
+        .unwrap_or(1);
+
+    for (idx, (cmd, count, saved, pct, avg_time)) in by_command.iter().enumerate() {
+        let row_idx = format!("{:>2}.", idx + 1);
+        let cmd_cell = style_command_cell(&truncate_for_column(cmd, cmd_width));
+        let count_cell = format!("{:>count_width$}", count, count_width = count_width);
+        let saved_cell = format!(
+            "{:>saved_width$}",
+            format_tokens(*saved),
+            saved_width = saved_width
+        );
+        let pct_plain = format!("{:>6}", format!("{pct:.1}%"));
+        let pct_cell = colorize_pct_cell(*pct, &pct_plain);
+        let time_cell = format!(
+            "{:>time_width$}",
+            format_duration(*avg_time),
+            time_width = time_width
+        );
+        let impact = mini_bar(*saved, max_saved, impact_width);
+        println!(
+            "{}  {}  {}  {}  {}  {}  {}",
+            row_idx, cmd_cell, count_cell, saved_cell, pct_cell, time_cell, impact
+        );
+    }
+    println!("{}", "─".repeat(table_width));
+    println!();
+}
+
+fn show_session_detail(session_filter: &str, summary: &GainSummary) -> Result<()> {
+    if summary.total_commands == 0 {
+        println!("No data found for session '{session_filter}'.");
+        return Ok(());
+    }
+
+    println!(
+        "{}",
+        styled(
+            &format!("RTK Token Savings — Session {session_filter}"),
+            true
+        )
+    );
+    println!("{}", "═".repeat(60));
+    println!();
+
+    print_summary_kpis(summary);
+
+    print_by_command_table(&summary.by_command);
 
     Ok(())
 }

--- a/src/analytics/gain.rs
+++ b/src/analytics/gain.rs
@@ -1,7 +1,7 @@
 //! Shows users how many tokens RTK has saved them over time.
 
 use crate::core::display_helpers::{format_duration, print_period_table};
-use crate::core::tracking::{DayStats, MonthStats, SessionStat, Tracker, WeekStats};
+use crate::core::tracking::{DayStats, GainSummary, MonthStats, SessionStat, Tracker, WeekStats};
 use crate::core::utils::format_tokens;
 use crate::hooks::hook_check;
 use anyhow::{Context, Result};
@@ -49,12 +49,19 @@ pub fn run(
     }
 
     if let Some(session_filter) = session {
-        // "" means bare --session (show all); non-empty means filter by prefix
-        let filter = if session_filter.is_empty() { None } else { Some(session_filter) };
-        let sessions = tracker
-            .get_by_session(filter)
-            .context("Failed to load session data from database")?;
-        return show_session_view(&sessions, filter);
+        if session_filter.is_empty() {
+            // bare --session: show session list
+            let sessions = tracker
+                .get_by_session(None)
+                .context("Failed to load session data from database")?;
+            return show_session_view(&sessions, None);
+        } else {
+            // --session <id>: show full gain detail scoped to this session
+            let summary = tracker
+                .get_summary_for_session(session_filter)
+                .context("Failed to load session summary from database")?;
+            return show_session_detail(session_filter, &summary);
+        }
     }
 
     // Handle export formats
@@ -707,10 +714,9 @@ fn show_session_view(sessions: &[SessionStat], filter: Option<&str>) -> Result<(
         return Ok(());
     }
 
-    let title = if filter.is_some() {
-        format!("RTK Session Savings — {}", sessions[0].session_id)
-    } else {
-        "RTK Session Savings".to_string()
+    let title = match filter {
+        Some(f) => format!("RTK Session Savings — prefix '{f}'"),
+        None => "RTK Session Savings".to_string(),
     };
     println!("{}", styled(&title, true));
     println!("{}", "─".repeat(62));
@@ -733,11 +739,7 @@ fn show_session_view(sessions: &[SessionStat], filter: Option<&str>) -> Result<(
                 format!("{}d ago", secs / 86400)
             }
         };
-        let short_id = if s.session_id.len() >= 8 {
-            &s.session_id[..8]
-        } else {
-            &s.session_id
-        };
+        let short_id: String = s.session_id.chars().take(8).collect();
         let pct_cell = colorize_pct_cell(s.avg_savings_pct, &format!("{:.1}%", s.avg_savings_pct));
         println!(
             "{:<10}  {:<12}  {:>5}  {:>8}  {}",
@@ -758,6 +760,113 @@ fn show_session_view(sessions: &[SessionStat], filter: Option<&str>) -> Result<(
         total_cmds,
         format_tokens(total_saved),
     );
+    Ok(())
+}
+
+fn show_session_detail(session_filter: &str, summary: &GainSummary) -> Result<()> {
+    if summary.total_commands == 0 {
+        println!("No data found for session '{session_filter}'.");
+        return Ok(());
+    }
+
+    println!(
+        "{}",
+        styled(
+            &format!("RTK Token Savings — Session {session_filter}"),
+            true
+        )
+    );
+    println!("{}", "═".repeat(60));
+    println!();
+
+    print_kpi("Total commands", summary.total_commands.to_string());
+    print_kpi("Input tokens", format_tokens(summary.total_input));
+    print_kpi("Output tokens", format_tokens(summary.total_output));
+    print_kpi(
+        "Tokens saved",
+        format!(
+            "{} ({:.1}%)",
+            format_tokens(summary.total_saved),
+            summary.avg_savings_pct
+        ),
+    );
+    print_kpi(
+        "Total exec time",
+        format!(
+            "{} (avg {})",
+            format_duration(summary.total_time_ms),
+            format_duration(summary.avg_time_ms)
+        ),
+    );
+    print_efficiency_meter(summary.avg_savings_pct);
+    println!();
+
+    if !summary.by_command.is_empty() {
+        println!("{}", styled("By Command", true));
+
+        let cmd_width = 24usize;
+        let impact_width = 10usize;
+        let count_width = summary
+            .by_command
+            .iter()
+            .map(|(_, count, _, _, _)| count.to_string().len())
+            .max()
+            .unwrap_or(5)
+            .max(5);
+        let saved_width = summary
+            .by_command
+            .iter()
+            .map(|(_, _, saved, _, _)| format_tokens(*saved).len())
+            .max()
+            .unwrap_or(5)
+            .max(5);
+        let time_width = summary
+            .by_command
+            .iter()
+            .map(|(_, _, _, _, avg_time)| format_duration(*avg_time).len())
+            .max()
+            .unwrap_or(6)
+            .max(6);
+
+        let table_width =
+            3 + 2 + cmd_width + 2 + count_width + 2 + saved_width + 2 + 6 + 2 + time_width + 2 + impact_width;
+        println!("{}", "─".repeat(table_width));
+        println!(
+            "{:>3}  {:<cmd_width$}  {:>count_width$}  {:>saved_width$}  {:>6}  {:>time_width$}  {:<impact_width$}",
+            "#", "Command", "Count", "Saved", "Avg%", "Time", "Impact",
+            cmd_width = cmd_width, count_width = count_width,
+            saved_width = saved_width, time_width = time_width,
+            impact_width = impact_width
+        );
+        println!("{}", "─".repeat(table_width));
+
+        let max_saved = summary
+            .by_command
+            .iter()
+            .map(|(_, _, saved, _, _)| *saved)
+            .max()
+            .unwrap_or(1);
+
+        for (idx, (cmd, count, saved, pct, avg_time)) in summary.by_command.iter().enumerate() {
+            let row_idx = format!("{:>2}.", idx + 1);
+            let cmd_cell = style_command_cell(&truncate_for_column(cmd, cmd_width));
+            let count_cell = format!("{:>count_width$}", count, count_width = count_width);
+            let saved_cell =
+                format!("{:>saved_width$}", format_tokens(*saved), saved_width = saved_width);
+            let pct_plain = format!("{:>6}", format!("{pct:.1}%"));
+            let pct_cell = colorize_pct_cell(*pct, &pct_plain);
+            let time_cell =
+                format!("{:>time_width$}", format_duration(*avg_time), time_width = time_width);
+            let impact = mini_bar(*saved, max_saved, impact_width);
+            println!(
+                "{}  {}  {}  {}  {}  {}  {}",
+                row_idx, cmd_cell, count_cell, saved_cell, pct_cell, time_cell, impact
+            );
+        }
+        println!("{}", "─".repeat(table_width));
+        println!();
+    }
+
     Ok(())
 }
 

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -48,6 +48,11 @@ fn current_project_path_string() -> String {
         .unwrap_or_default()
 }
 
+/// Get the current Claude Code session ID from the environment.
+fn current_session_id() -> String {
+    std::env::var("CLAUDE_CODE_SESSION_ID").unwrap_or_default()
+}
+
 /// Build SQL filter params for project-scoped queries.
 /// Returns (exact_match, glob_prefix) for WHERE clause.
 /// Uses GLOB instead of LIKE to avoid `_` and `%` in paths acting as wildcards. // changed: GLOB
@@ -131,6 +136,24 @@ pub struct GainSummary {
     pub by_command: Vec<(String, usize, usize, f64, u64)>,
     /// Last 30 days of activity: (date, saved_tokens)
     pub by_day: Vec<(String, usize)>,
+}
+
+/// Per-session statistics for token savings.
+///
+/// Groups all commands recorded under the same `CLAUDE_CODE_SESSION_ID`
+/// so users can see how much each Claude Code session saved.
+#[derive(Debug)]
+pub struct SessionStat {
+    /// Short session ID (first 8 chars of the UUID)
+    pub session_id: String,
+    /// UTC timestamp of the most recent command in this session
+    pub last_seen: DateTime<Utc>,
+    /// Number of commands recorded for this session
+    pub commands: usize,
+    /// Total tokens saved across all commands in this session
+    pub saved_tokens: usize,
+    /// Average savings percentage across all commands in this session
+    pub avg_savings_pct: f64,
 }
 
 /// Daily statistics for token savings and execution metrics.
@@ -307,6 +330,15 @@ impl Tracker {
             "CREATE INDEX IF NOT EXISTS idx_project_path_timestamp ON commands(project_path, timestamp)",
             [],
         );
+        // Migration: add session_id column for per-session gain tracking
+        let _ = conn.execute(
+            "ALTER TABLE commands ADD COLUMN session_id TEXT DEFAULT ''",
+            [],
+        );
+        let _ = conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_session_id ON commands(session_id)",
+            [],
+        );
 
         conn.execute(
             "CREATE TABLE IF NOT EXISTS parse_failures (
@@ -348,7 +380,8 @@ impl Tracker {
                 saved_tokens INTEGER NOT NULL,
                 savings_pct REAL NOT NULL,
                 exec_time_ms INTEGER DEFAULT 0,
-                project_path TEXT DEFAULT ''
+                project_path TEXT DEFAULT '',
+                session_id TEXT DEFAULT ''
             )",
             [],
         )?;
@@ -358,6 +391,10 @@ impl Tracker {
         )?;
         self.conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_project_path_timestamp ON commands(project_path, timestamp)",
+            [],
+        )?;
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_session_id ON commands(session_id)",
             [],
         )?;
         self.conn.execute(
@@ -414,16 +451,18 @@ impl Tracker {
             0.0
         };
 
-        let project_path = current_project_path_string(); // added: record cwd
+        let project_path = current_project_path_string();
+        let session_id = current_session_id();
 
         self.conn.execute(
-            "INSERT INTO commands (timestamp, original_cmd, rtk_cmd, project_path, input_tokens, output_tokens, saved_tokens, savings_pct, exec_time_ms)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)", // added: project_path
+            "INSERT INTO commands (timestamp, original_cmd, rtk_cmd, project_path, session_id, input_tokens, output_tokens, saved_tokens, savings_pct, exec_time_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             params![
                 Utc::now().to_rfc3339(),
                 original_cmd,
                 rtk_cmd,
-                project_path, // added
+                project_path,
+                session_id,
                 input_tokens as i64,
                 output_tokens as i64,
                 saved as i64,
@@ -957,6 +996,44 @@ impl Tracker {
                 })
             },
         )?;
+
+        Ok(rows.collect::<Result<Vec<_>, _>>()?)
+    }
+
+    /// Get per-session token savings, most recent session first.
+    ///
+    /// Only returns sessions with a non-empty `session_id` (i.e. commands
+    /// recorded while `CLAUDE_CODE_SESSION_ID` was set in the environment).
+    /// Limited to the 20 most recent sessions.
+    /// Get per-session token savings, most recent session first.
+    ///
+    /// When `filter` is `Some(prefix)`, only sessions whose ID starts with
+    /// that prefix are returned (useful for short IDs like `"2a35ea7f"`).
+    /// When `filter` is `None`, returns up to 20 most recent sessions.
+    pub fn get_by_session(&self, filter: Option<&str>) -> Result<Vec<SessionStat>> {
+        let prefix_filter = filter.map(|f| format!("{f}%"));
+        let mut stmt = self.conn.prepare(
+            "SELECT session_id, MAX(timestamp), COUNT(*), SUM(saved_tokens), AVG(savings_pct)
+             FROM commands
+             WHERE session_id != ''
+               AND (?1 IS NULL OR session_id LIKE ?1)
+             GROUP BY session_id
+             ORDER BY MAX(timestamp) DESC
+             LIMIT 20",
+        )?;
+
+        let rows = stmt.query_map(params![prefix_filter], |row| {
+            let last_seen = DateTime::parse_from_rfc3339(&row.get::<_, String>(1)?)
+                .map(|dt| dt.with_timezone(&Utc))
+                .unwrap_or_else(|_| Utc::now());
+            Ok(SessionStat {
+                session_id: row.get(0)?,
+                last_seen,
+                commands: row.get::<_, i64>(2)? as usize,
+                saved_tokens: row.get::<_, i64>(3)? as usize,
+                avg_savings_pct: row.get(4)?,
+            })
+        })?;
 
         Ok(rows.collect::<Result<Vec<_>, _>>()?)
     }
@@ -1684,6 +1761,169 @@ mod tests {
         assert_eq!(
             failures.total, 0,
             "parse_failures table should be empty after reset"
+        );
+    }
+
+    // ── get_by_session tests ──────────────────────────────────────────────────
+
+    fn insert_with_session(
+        tracker: &Tracker,
+        original_cmd: &str,
+        rtk_cmd: &str,
+        input_tokens: usize,
+        output_tokens: usize,
+        session_id: &str,
+    ) {
+        let saved = input_tokens.saturating_sub(output_tokens);
+        let pct = if input_tokens > 0 {
+            saved as f64 / input_tokens as f64 * 100.0
+        } else {
+            0.0
+        };
+        tracker
+            .conn
+            .execute(
+                "INSERT INTO commands (timestamp, original_cmd, rtk_cmd, project_path, session_id,
+                  input_tokens, output_tokens, saved_tokens, savings_pct, exec_time_ms)
+                 VALUES (datetime('now'), ?1, ?2, '', ?3, ?4, ?5, ?6, ?7, 10)",
+                rusqlite::params![
+                    original_cmd,
+                    rtk_cmd,
+                    session_id,
+                    input_tokens as i64,
+                    output_tokens as i64,
+                    saved as i64,
+                    pct,
+                ],
+            )
+            .expect("insert failed");
+    }
+
+    #[test]
+    fn test_get_by_session_groups_correctly() {
+        let tracker = Tracker::new_in_memory().expect("in-memory tracker");
+
+        insert_with_session(&tracker, "git log", "rtk git log", 1000, 100, "sess-aaa");
+        insert_with_session(&tracker, "git status", "rtk git status", 500, 50, "sess-aaa");
+        insert_with_session(&tracker, "cargo test", "rtk cargo test", 2000, 200, "sess-bbb");
+
+        let sessions = tracker.get_by_session(None).expect("get_by_session failed");
+        assert_eq!(sessions.len(), 2, "should have 2 distinct sessions");
+
+        let aaa = sessions.iter().find(|s| s.session_id == "sess-aaa").unwrap();
+        assert_eq!(aaa.commands, 2);
+        assert_eq!(aaa.saved_tokens, 1350); // (1000-100) + (500-50)
+
+        let bbb = sessions.iter().find(|s| s.session_id == "sess-bbb").unwrap();
+        assert_eq!(bbb.commands, 1);
+        assert_eq!(bbb.saved_tokens, 1800);
+    }
+
+    #[test]
+    fn test_get_by_session_excludes_empty_session_id() {
+        let tracker = Tracker::new_in_memory().expect("in-memory tracker");
+
+        // Insert directly with explicit empty session_id (simulates pre-session-tracking records)
+        tracker
+            .conn
+            .execute(
+                "INSERT INTO commands (timestamp, original_cmd, rtk_cmd, project_path, session_id,
+                  input_tokens, output_tokens, saved_tokens, savings_pct, exec_time_ms)
+                 VALUES (datetime('now'), 'git status', 'rtk git status', '', '',
+                         500, 50, 450, 90.0, 10)",
+                [],
+            )
+            .expect("insert failed");
+        // command with a session ID
+        insert_with_session(&tracker, "git log", "rtk git log", 1000, 100, "sess-aaa");
+
+        let sessions = tracker.get_by_session(None).expect("get_by_session failed");
+        assert_eq!(sessions.len(), 1, "empty session_id must be excluded");
+        assert_eq!(sessions[0].session_id, "sess-aaa");
+    }
+
+    #[test]
+    fn test_get_by_session_orders_most_recent_first() {
+        let tracker = Tracker::new_in_memory().expect("in-memory tracker");
+
+        // Insert older session first
+        tracker
+            .conn
+            .execute(
+                "INSERT INTO commands (timestamp, original_cmd, rtk_cmd, project_path, session_id,
+                  input_tokens, output_tokens, saved_tokens, savings_pct, exec_time_ms)
+                 VALUES ('2026-01-01T00:00:00Z', 'git log', 'rtk git log', '', 'sess-old',
+                         1000, 100, 900, 90.0, 10)",
+                [],
+            )
+            .expect("insert failed");
+        tracker
+            .conn
+            .execute(
+                "INSERT INTO commands (timestamp, original_cmd, rtk_cmd, project_path, session_id,
+                  input_tokens, output_tokens, saved_tokens, savings_pct, exec_time_ms)
+                 VALUES ('2026-06-01T00:00:00Z', 'cargo test', 'rtk cargo test', '', 'sess-new',
+                         2000, 200, 1800, 90.0, 10)",
+                [],
+            )
+            .expect("insert failed");
+
+        let sessions = tracker.get_by_session(None).expect("get_by_session failed");
+        assert_eq!(sessions[0].session_id, "sess-new", "newest session must be first");
+        assert_eq!(sessions[1].session_id, "sess-old");
+    }
+
+    #[test]
+    fn test_get_by_session_empty_db() {
+        let tracker = Tracker::new_in_memory().expect("in-memory tracker");
+        let sessions = tracker.get_by_session(None).expect("get_by_session failed");
+        assert!(sessions.is_empty(), "empty db should return empty vec");
+    }
+
+    #[test]
+    fn test_get_by_session_prefix_filter() {
+        let tracker = Tracker::new_in_memory().expect("in-memory tracker");
+
+        insert_with_session(&tracker, "git log", "rtk git log", 1000, 100, "aaaa-1111");
+        insert_with_session(&tracker, "git status", "rtk git status", 500, 50, "aaaa-2222");
+        insert_with_session(&tracker, "cargo test", "rtk cargo test", 2000, 200, "bbbb-3333");
+
+        // filter by "aaaa" prefix matches both aaaa-* sessions
+        let filtered = tracker
+            .get_by_session(Some("aaaa"))
+            .expect("get_by_session failed");
+        assert_eq!(filtered.len(), 2, "prefix 'aaaa' should match 2 sessions");
+        assert!(filtered.iter().all(|s| s.session_id.starts_with("aaaa")));
+
+        // filter by full ID matches exactly one
+        let exact = tracker
+            .get_by_session(Some("aaaa-1111"))
+            .expect("get_by_session failed");
+        assert_eq!(exact.len(), 1);
+        assert_eq!(exact[0].session_id, "aaaa-1111");
+
+        // filter by non-matching prefix returns empty
+        let none = tracker
+            .get_by_session(Some("zzzz"))
+            .expect("get_by_session failed");
+        assert!(none.is_empty());
+    }
+
+    #[test]
+    fn test_get_by_session_savings_pct() {
+        let tracker = Tracker::new_in_memory().expect("in-memory tracker");
+
+        // 80% savings
+        insert_with_session(&tracker, "git log", "rtk git log", 1000, 200, "sess-x");
+        // 60% savings
+        insert_with_session(&tracker, "git status", "rtk git status", 1000, 400, "sess-x");
+
+        let sessions = tracker.get_by_session(None).expect("get_by_session failed");
+        assert_eq!(sessions.len(), 1);
+        let pct = sessions[0].avg_savings_pct;
+        assert!(
+            (pct - 70.0).abs() < 1.0,
+            "avg savings pct should be ~70%, got {pct:.1}%"
         );
     }
 }

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -1000,31 +1000,128 @@ impl Tracker {
         Ok(rows.collect::<Result<Vec<_>, _>>()?)
     }
 
-    /// Get per-session token savings, most recent session first.
+    /// Get full gain summary scoped to sessions whose ID starts with `prefix`.
     ///
-    /// Only returns sessions with a non-empty `session_id` (i.e. commands
-    /// recorded while `CLAUDE_CODE_SESSION_ID` was set in the environment).
-    /// Limited to the 20 most recent sessions.
+    /// Mirrors `get_summary_filtered` but filters by `session_id GLOB prefix*`
+    /// instead of project path. Used by `rtk gain --session <id>`.
+    pub fn get_summary_for_session(&self, prefix: &str) -> Result<GainSummary> {
+        let glob = format!("{prefix}*");
+        let mut total_commands = 0usize;
+        let mut total_input = 0usize;
+        let mut total_output = 0usize;
+        let mut total_saved = 0usize;
+        let mut total_time_ms = 0u64;
+
+        let mut stmt = self.conn.prepare(
+            "SELECT input_tokens, output_tokens, saved_tokens, exec_time_ms
+             FROM commands
+             WHERE session_id GLOB ?1",
+        )?;
+        let rows = stmt.query_map(params![glob], |row| {
+            Ok((
+                row.get::<_, i64>(0)? as usize,
+                row.get::<_, i64>(1)? as usize,
+                row.get::<_, i64>(2)? as usize,
+                row.get::<_, i64>(3)? as u64,
+            ))
+        })?;
+        for row in rows {
+            let (input, output, saved, time_ms) = row?;
+            total_commands += 1;
+            total_input += input;
+            total_output += output;
+            total_saved += saved;
+            total_time_ms += time_ms;
+        }
+
+        let avg_savings_pct = if total_input > 0 {
+            (total_saved as f64 / total_input as f64) * 100.0
+        } else {
+            0.0
+        };
+        let avg_time_ms = if total_commands > 0 {
+            total_time_ms / total_commands as u64
+        } else {
+            0
+        };
+
+        let by_command = {
+            let mut stmt = self.conn.prepare(
+                "SELECT rtk_cmd, COUNT(*), SUM(saved_tokens), AVG(savings_pct), AVG(exec_time_ms)
+                 FROM commands
+                 WHERE session_id GLOB ?1
+                 GROUP BY rtk_cmd
+                 ORDER BY SUM(saved_tokens) DESC
+                 LIMIT 10",
+            )?;
+            let rows = stmt.query_map(params![glob], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, i64>(1)? as usize,
+                    row.get::<_, i64>(2)? as usize,
+                    row.get::<_, f64>(3)?,
+                    row.get::<_, f64>(4)? as u64,
+                ))
+            })?;
+            rows.collect::<Result<Vec<_>, _>>()?
+        };
+
+        let by_day = {
+            let mut stmt = self.conn.prepare(
+                "SELECT DATE(timestamp), SUM(saved_tokens)
+                 FROM commands
+                 WHERE session_id GLOB ?1
+                 GROUP BY DATE(timestamp)
+                 ORDER BY DATE(timestamp) ASC
+                 LIMIT 30",
+            )?;
+            let rows = stmt.query_map(params![glob], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)? as usize))
+            })?;
+            rows.collect::<Result<Vec<_>, _>>()?
+        };
+
+        Ok(GainSummary {
+            total_commands,
+            total_input,
+            total_output,
+            total_saved,
+            avg_savings_pct,
+            total_time_ms,
+            avg_time_ms,
+            by_command,
+            by_day,
+        })
+    }
+
     /// Get per-session token savings, most recent session first.
     ///
     /// When `filter` is `Some(prefix)`, only sessions whose ID starts with
     /// that prefix are returned (useful for short IDs like `"2a35ea7f"`).
     /// When `filter` is `None`, returns up to 20 most recent sessions.
+    /// Rows with empty `session_id` (recorded outside Claude Code) are excluded.
     pub fn get_by_session(&self, filter: Option<&str>) -> Result<Vec<SessionStat>> {
-        let prefix_filter = filter.map(|f| format!("{f}%"));
+        // Use GLOB (not LIKE) to match project convention — avoids _ and % in user input
+        // acting as wildcards. GLOB uses * for any-sequence, consistent with project_path filter.
+        let prefix_filter = filter.map(|f| format!("{f}*"));
+        // LIMIT only applies to the "show all" view; prefix searches return all matches.
+        let limit: i64 = if filter.is_some() { i64::MAX } else { 20 };
         let mut stmt = self.conn.prepare(
-            "SELECT session_id, MAX(timestamp), COUNT(*), SUM(saved_tokens), AVG(savings_pct)
+            "SELECT session_id, MAX(timestamp), COUNT(*),
+                    COALESCE(SUM(saved_tokens), 0), COALESCE(AVG(savings_pct), 0.0)
              FROM commands
              WHERE session_id != ''
-               AND (?1 IS NULL OR session_id LIKE ?1)
+               AND (?1 IS NULL OR session_id GLOB ?1)
              GROUP BY session_id
              ORDER BY MAX(timestamp) DESC
-             LIMIT 20",
+             LIMIT ?2",
         )?;
 
-        let rows = stmt.query_map(params![prefix_filter], |row| {
+        let rows = stmt.query_map(params![prefix_filter, limit], |row| {
             let last_seen = DateTime::parse_from_rfc3339(&row.get::<_, String>(1)?)
                 .map(|dt| dt.with_timezone(&Utc))
+                // Deliberate fallback: a corrupt timestamp floats to top rather than
+                // failing the entire query — consistent with get_recent_filtered.
                 .unwrap_or_else(|_| Utc::now());
             Ok(SessionStat {
                 session_id: row.get(0)?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -430,6 +430,9 @@ enum Commands {
         /// Output format: text, json, csv
         #[arg(short, long, default_value = "text")]
         format: String,
+        /// Show per-session token savings; optionally filter to a specific session ID prefix
+        #[arg(short = 'S', long, value_name = "SESSION_ID", num_args = 0..=1, default_missing_value = "")]
+        session: Option<String>,
         /// Show parse failure log (commands that fell back to raw execution)
         #[arg(short = 'F', long)]
         failures: bool,
@@ -1990,9 +1993,10 @@ fn run_cli() -> Result<i32> {
         Commands::Wc { args } => wc_cmd::run(&args, cli.verbose)?,
 
         Commands::Gain {
-            project, // added
+            project,
             graph,
             history,
+            session,
             quota,
             tier,
             daily,
@@ -2005,9 +2009,10 @@ fn run_cli() -> Result<i32> {
             yes,
         } => {
             analytics::gain::run(
-                project, // added: pass project flag
+                project,
                 graph,
                 history,
+                session.as_deref(),
                 quota,
                 &tier,
                 daily,


### PR DESCRIPTION
## What

Adds per-session token savings tracking to `rtk gain`. Each Claude Code session gets its own row in the tracking database so you can see exactly how much each session saved.

## Changes

**`src/core/tracking.rs`**
- New `session_id TEXT DEFAULT ''` column on the `commands` table (migration-safe `ALTER TABLE`)
- Index on `session_id` for fast per-session queries
- `SessionStat` struct: `session_id`, `last_seen`, `commands`, `saved_tokens`, `avg_savings_pct`
- `Tracker::get_by_session(filter)` — groups commands by `CLAUDE_CODE_SESSION_ID`, most recent first, empty IDs excluded
- `Tracker::get_summary_for_session(prefix)` — full `GainSummary` scoped to one session (used for detail view)
- `record()` now captures `CLAUDE_CODE_SESSION_ID` from env on every insert

**`src/analytics/gain.rs`**
- `--session [<SESSION_ID>]` flag (short `-S`):
  - bare `--session` → table of all sessions (most recent 20), sorted newest first
  - `--session <prefix>` → detailed gain summary scoped to that session (same layout as global `rtk gain`)
- Extracted `print_summary_kpis()` and `print_by_command_table()` helpers (no behaviour change — reduces duplication between global and per-session views)

**`src/main.rs`**
- Plumbing for the new `--session` flag on the `Gain` command

## Usage

```
# List all sessions (most recent 20)
rtk gain --session

# Session   Last Seen     Cmds     Saved   Avg%
# ──────────────────────────────────────────────────────────────
# 2a35ea7f  3m ago          42    128.4k  83.1%
# f1c90b12  1h ago          17     45.2k  79.6%
# …
# Total: 5 sessions  •  91 commands  •  234.7k saved

# Full gain detail scoped to a session (prefix or full UUID)
rtk gain --session 2a35ea7f
```

## Notes

- Sessions with no `CLAUDE_CODE_SESSION_ID` (recorded before this change, or commands run outside Claude Code) are silently excluded from session views — they still count in the global `rtk gain` summary
- `get_by_session` uses GLOB not LIKE for prefix matching (consistent with existing `project_path` filter — avoids `_` and `%` acting as wildcards)
- Existing databases are migrated automatically on first run; `new_in_memory()` (tests) uses the full schema directly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)