### PR TITLE
fix(gemini): correct path for Antigravity settings and hooks

### DIFF
--- a/src/core/telemetry.rs
+++ b/src/core/telemetry.rs
@@ -361,7 +361,7 @@ fn detect_hook_type() -> String {
     let checks = [
         (claude_dir.join("hooks/rtk-rewrite.sh"), "claude"),
         (claude_dir.join("hooks/rtk-rewrite.json"), "claude"),
-        (home.join(".gemini/hooks/rtk-hook.sh"), "gemini"),
+        (home.join(".gemini/antigravity-cli/hooks/rtk-hook-gemini.sh"), "gemini"),
         (home.join(".codex/AGENTS.md"), "codex"),
         (home.join(".cursor/hooks/rtk-rewrite.json"), "cursor"),
     ];

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -20,7 +20,7 @@ pub const OPENCODE_PLUGIN_FILE: &str = "rtk.ts";
 
 pub const CURSOR_DIR: &str = ".cursor";
 pub const CODEX_DIR: &str = ".codex";
-pub const GEMINI_DIR: &str = ".gemini";
+pub const GEMINI_DIR: &str = ".gemini/antigravity-cli";
 
 pub const GITHUB_DIR: &str = ".github";
 pub const COPILOT_HOOK_FILE: &str = "rtk-rewrite.json";

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -3659,7 +3659,7 @@ pub fn run_gemini(
         write_if_changed(&gemini_md_path, RTK_SLIM, GEMINI_MD, ctx)?;
     }
 
-    // 3. Patch ~/.gemini/settings.json
+    // 3. Patch ~/.gemini/antigravity-cli/settings.json
     patch_gemini_settings(&gemini_dir, &hook_path, patch_mode, ctx)?;
 
     if dry_run {
@@ -3675,7 +3675,7 @@ pub fn run_gemini(
     Ok(())
 }
 
-/// Patch ~/.gemini/settings.json with the BeforeTool hook
+/// Patch ~/.gemini/antigravity-cli/settings.json with the BeforeTool hook
 fn patch_gemini_settings(
     gemini_dir: &Path,
     hook_path: &Path,


### PR DESCRIPTION
This PR corrects the configuration path for the Gemini / Antigravity CLI.

### Changes:
- Updated `GEMINI_DIR` from `".gemini"` to `".gemini/antigravity-cli"` in `src/hooks/constants.rs` so that settings and hooks are correctly loaded/patched in the actual Antigravity CLI config directory.
- Updated `detect_hook_type` check in `src/core/telemetry.rs` to check the correct path.
- Updated comments in `src/hooks/init.rs` to refer to the correct settings file path.