### PR TITLE
fix(build): target-aware stack flag so windows-gnu toolchain links

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,7 +9,16 @@ fn main() {
         // main-thread stack during process startup. Reserve a larger stack for
         // the CLI binary so `rtk.exe --version`, `--help`, and hook entry
         // points start reliably without requiring ad-hoc RUSTFLAGS.
-        println!("cargo:rustc-link-arg=/STACK:8388608");
+        //
+        // NOTE: build.rs `cfg(target_env)` reflects the *host* target, not the
+        // *target* being compiled. Read CARGO's TARGET env var to pick the
+        // correct linker syntax (MSVC vs GNU).
+        let target = std::env::var("TARGET").unwrap_or_default();
+        if target.contains("msvc") {
+            println!("cargo:rustc-link-arg=/STACK:8388608");
+        } else if target.contains("gnu") {
+            println!("cargo:rustc-link-arg=-Wl,--stack,8388608");
+        }
     }
 
     let filters_dir = Path::new("src/filters");


### PR DESCRIPTION
## Problem

Building rtk from source (or `cargo install --git`) on the `x86_64-pc-windows-gnu` toolchain fails during the final link:

```
error: linking with `x86_64-w64-mingw32-gcc` failed: exit code: 1
  = note: ld.exe: cannot find /STACK:8388608: No such file or directory
          collect2.exe: error: ld returned 1 exit status
```

This makes rtk impossible to install for anyone on the GNU toolchain (e.g. users with only MSYS2/MinGW and no MSVC Build Tools). See #1814.

## Root cause

`build.rs` reserves a larger main-thread stack (correct — Clap + the command graph can exceed the default 1 MiB), but the flag is injected under `#[cfg(windows)]` only:

```rust
println!("cargo:rustc-link-arg=/STACK:8388608");
```

`/STACK:N` is **MSVC linker syntax**. On `windows-gnu`, the GNU linker (`ld`, driven by `gcc`) doesn't recognize it and treats it as a file path → link failure.

## Fix

Branch on the target being built. Subtlety: `#[cfg(target_env = ...)]` inside build.rs reflects the **host**, not the target being compiled, so we read Cargo's `TARGET` env var instead:

- `*-pc-windows-msvc` → `/STACK:8388608` (unchanged)
- `*-pc-windows-gnu` → `-Wl,--stack,8388608` (GNU equivalent)

## Verification

Built and installed on Windows 11 with `stable-x86_64-pc-windows-gnu` + MinGW-w64 (UCRT), where it previously failed with the exact error above. After the fix, `cargo +stable-x86_64-pc-windows-gnu install --path . --locked` succeeds; `rtk --version` / `rtk gain` work.

Fixes #1814
