### PR TITLE
grep: detect format flags bundled inside short-flag clusters

### DIFF
--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -500,8 +500,9 @@ fn parse_match_line(line: &str) -> Option<(String, usize, &str)> {
 
 fn has_format_flag<T: AsRef<str>>(extra_args: &[T]) -> bool {
     extra_args.iter().any(|arg| {
-        matches!(
-            arg.as_ref(),
+        let s = arg.as_ref();
+        if matches!(
+            s,
             "-c" | "--count"
                 | "--count-matches"
                 | "-l"
@@ -515,7 +516,20 @@ fn has_format_flag<T: AsRef<str>>(extra_args: &[T]) -> bool {
                 | "--json"
                 | "--passthru"
                 | "--files"
-        )
+        ) {
+            return true;
+        }
+        // extract_pattern_path merges boolean short flags into one cluster
+        // token (e.g. `-rln` becomes `-ln` after stripping `r`), so a format
+        // flag like `-l` can arrive bundled with others rather than as its
+        // own arg. Clusters only ever contain boolean letters (see
+        // parse_cluster), so scanning characters here is safe.
+        if let Some(rest) = s.strip_prefix('-') {
+            if !rest.is_empty() && !rest.starts_with('-') {
+                return rest.chars().any(|c| matches!(c, 'c' | 'l' | 'L' | 'o' | 'Z'));
+            }
+        }
+        false
     })
 }
 
@@ -1117,6 +1131,24 @@ mod tests {
     #[test]
     fn test_format_flag_ignores_normal_flags() {
         assert!(!has_format_flag(&["-i", "-w", "-A", "3"]));
+    }
+
+    #[test]
+    fn test_format_flag_detects_clustered_l() {
+        // `-rln` becomes `-ln` after extract_pattern_path strips the `r`.
+        // -l (files-with-matches) is bundled with -n here, not standalone.
+        assert!(has_format_flag(&["-ln"]));
+    }
+
+    #[test]
+    fn test_format_flag_detects_clustered_c() {
+        assert!(has_format_flag(&["-ic"]));
+    }
+
+    #[test]
+    fn test_format_flag_ignores_double_dash() {
+        // Long flags must not be mistaken for a short cluster.
+        assert!(!has_format_flag(&["--ignore-case"]));
     }
 
     // Verify line numbers are always enabled in rg invocation (grep_cmd.rs:24).


### PR DESCRIPTION

Follow-up to #2543 — this fixes the second part of it.

`has_format_flag` checks `extra_args` for things like `-l`/`-c`/`-o` so it knows to skip the usual match-line parsing and just pass rg's output straight through (since those flags change rg's output format entirely). That check only matches exact tokens though, and `extract_pattern_path` merges plain boolean short flags into one combined token before they get here — so `-rln` becomes `-ln` after `r` is stripped, and `-ln` never matches `-l` exactly.

End result: something like `rtk grep -rln pattern path` runs rg with `-l` correctly, but then tries to parse the (now filenames-only) output as if it were normal `file:line:content` matches, finds nothing that fits that shape, and reports "0 matches" even when there clearly are matches. That's worse than just erroring, since it looks identical to a real empty result.

Fix is small — `has_format_flag` now also scans the individual letters of a short cluster (long flags and exact single-flag matches are unaffected). Added a few tests for the clustered case plus one to make sure long flags like `--ignore-case` don't get walked character-by-character by mistake.

Tested locally:
- `rtk grep -rln pattern path` now correctly falls through to passthrough and shows the real file list instead of "0 matches in 0 files"
- `rtk grep -rn pattern path` unaffected
- existing grep_cmd test suite passes (72 tests)

closes #2543 