### PR TITLE
fix(filter): preserve inline comment markers in code

### DIFF
--- a/src/core/filter.rs
+++ b/src/core/filter.rs
@@ -170,17 +170,20 @@ impl FilterStrategy for MinimalFilter {
         for line in content.lines() {
             let trimmed = line.trim();
 
-            // Handle block comments
+            // Handle full-line block comments.
             if let (Some(start), Some(end)) = (patterns.block_start, patterns.block_end) {
-                if !in_docstring
-                    && trimmed.contains(start)
-                    && !trimmed.starts_with(patterns.doc_block_start.unwrap_or("###"))
-                {
-                    in_block_comment = true;
-                }
                 if in_block_comment {
                     if trimmed.contains(end) {
                         in_block_comment = false;
+                    }
+                    continue;
+                }
+                if !in_docstring
+                    && trimmed.starts_with(start)
+                    && !trimmed.starts_with(patterns.doc_block_start.unwrap_or("###"))
+                {
+                    if !trimmed.contains(end) {
+                        in_block_comment = true;
                     }
                     continue;
                 }
@@ -468,6 +471,44 @@ fn main() {
         let result = filter.filter(code, &Language::Rust);
         assert!(!result.contains("// This is a comment"));
         assert!(result.contains("fn main()"));
+    }
+
+    #[test]
+    fn test_minimal_filter_preserves_comment_markers_inside_code() {
+        let code = r#"
+const API: &str = "http://example.com/v1";  // endpoint
+let re = regex::Regex::new(r"https?://\w+").unwrap();
+let glob = "packages/*";
+let inline = call(/* keep this expression line */);
+fn foo() {}
+"#;
+        let filter = MinimalFilter;
+        let result = filter.filter(code, &Language::Rust);
+
+        assert!(result.contains(r#"const API: &str = "http://example.com/v1";"#));
+        assert!(result.contains(r#"let re = regex::Regex::new(r"https?://\w+").unwrap();"#));
+        assert!(result.contains(r#"let glob = "packages/*";"#));
+        assert!(result.contains("let inline = call(/* keep this expression line */);"));
+        assert!(result.contains("fn foo() {}"));
+    }
+
+    #[test]
+    fn test_minimal_filter_removes_full_line_block_comments_only() {
+        let code = r#"
+fn before() {}
+/* single-line block comment */
+/*
+ * multi-line block comment
+ */
+fn after() {}
+"#;
+        let filter = MinimalFilter;
+        let result = filter.filter(code, &Language::Rust);
+
+        assert!(result.contains("fn before() {}"));
+        assert!(result.contains("fn after() {}"));
+        assert!(!result.contains("single-line block comment"));
+        assert!(!result.contains("multi-line block comment"));
     }
 
     // --- truncation accuracy ---


### PR DESCRIPTION
## Summary

`rtk read --level minimal` no longer drops valid source lines just because they contain comment-looking markers inside strings or inline expressions. Before this fix, a Rust line like `let glob = "packages/*";` could enter block-comment mode and hide that line plus following code until a later `*/` appeared.

The filter now treats block comments as removable only when the trimmed line starts with the block-comment opener, preserving inline markers while still removing full-line single-line and multi-line block comments.

Closes rtk-ai/rtk#2385.

## Testing

- `rtk cargo test core::filter`
- `rtk cargo fmt --all --check`
- `rtk cargo test`
- `rtk cargo clippy --all-targets`

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This is a local CLI filtering fix with regression coverage and no service, deployment, or runtime infrastructure surface.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
