### PR TITLE
fix(grep): correctly handle all flag shapes and never exceed raw output

### DIFF
--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -1,8 +1,8 @@
 //! Filters grep output by grouping matches by file.
 
-use crate::core::stream::exec_capture;
+use crate::core::stream::{exec_capture, CaptureResult};
 use crate::core::tracking;
-use crate::core::utils::resolved_command;
+use crate::core::utils::{resolved_command, strip_ansi};
 use crate::core::{args_utils, config};
 use anyhow::{Context, Result};
 use regex::Regex;
@@ -128,6 +128,69 @@ fn strip_recursive(arg: &str) -> Option<String> {
     }
 }
 
+/// Ripgrep-only flags the grep fallback drops so grep doesn't abort (issue #2167).
+const RG_ONLY_LONG: &[&str] = &[
+    "--glob",
+    "--iglob",
+    "--type",
+    "--type-not",
+    "--type-add",
+    "--type-clear",
+    "--hidden",
+    "--no-ignore",
+    "--pcre2",
+    "--json",
+    "--stats",
+    "--sort",
+    "--sortr",
+    "--engine",
+    "--mmap",
+    "--no-mmap",
+    "--trim",
+    "--one-file-system",
+    "--max-columns",
+    "--max-depth",
+    "--max-filesize",
+    "--path-separator",
+    "--field-context-separator",
+    "--field-match-separator",
+    "--pre",
+    "--pre-glob",
+];
+
+fn strip_rg_only<T: AsRef<str>>(extra_args: &[T]) -> Vec<&str> {
+    let mut out = Vec::new();
+    let mut skip_next = false;
+    for arg in extra_args {
+        let a = arg.as_ref();
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        let name = a.split('=').next().unwrap_or(a);
+        let rg_only = RG_ONLY_LONG.contains(&name) || a == "-g" || a == "-T";
+        if rg_only {
+            let takes_value = a == "-g" || a == "-T" || VALUE_FLAGS_LONG.contains(&name);
+            if takes_value && !a.contains('=') {
+                skip_next = true;
+            }
+            continue;
+        }
+        out.push(a);
+    }
+    out
+}
+
+fn has_shape_flag<T: AsRef<str>>(extra_args: &[T]) -> bool {
+    extra_args.iter().any(|arg| {
+        let name = arg.as_ref().split('=').next().unwrap_or("");
+        matches!(
+            name,
+            "--column" | "--vimgrep" | "-b" | "--byte-offset" | "--null-data"
+        )
+    })
+}
+
 /// Extracts `(patterns, paths, flags)` from the raw trailing args.
 ///
 /// - `patterns`: positional pattern + all `-e`/`--regexp` values. Empty → error.
@@ -251,6 +314,109 @@ fn extract_pattern_path<T: AsRef<str>>(args: &[T]) -> (Vec<String>, Vec<String>,
     (patterns, paths, flags)
 }
 
+fn unparsed_signal(stdout: &str) -> usize {
+    stdout
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim();
+            !trimmed.is_empty() && trimmed != "--" && parse_match_line(line).is_none()
+        })
+        .count()
+}
+
+/// Run rg; fall back to system grep when rg can't run or rejects the invocation
+/// (exit 2, no output) so any grep-ism (e.g. --include) still works (#2543).
+/// #2167: if grep also aborts on a flag, retry it bare.
+fn grep_capture<T: AsRef<str>>(
+    rg_base: &[&str],
+    grep_base: &[&str],
+    file_type: Option<&str>,
+    extra_args: &[T],
+    patterns: &[String],
+    paths: &[String],
+) -> Result<CaptureResult> {
+    let mut rg_cmd = resolved_command("rg");
+    rg_cmd.args(rg_base);
+    if let Some(ft) = file_type {
+        rg_cmd.arg("--type").arg(ft);
+    }
+    rg_cmd.args(extra_args.iter().map(|a| a.as_ref()));
+    for p in patterns {
+        rg_cmd.args(["-e", &p.replace(r"\|", "|")]);
+    }
+    rg_cmd.arg("--");
+    rg_cmd.args(paths);
+
+    match exec_capture(&mut rg_cmd) {
+        Ok(r) if !(r.exit_code == 2 && r.stdout.is_empty()) => Ok(r),
+        _ => {
+            // --null not -Z: BSD grep -Z is --decompress (#2310); strip_rg_only (#2167).
+            let stripped = strip_rg_only(extra_args);
+            let result = run_grep_fallback(grep_base, file_type, &stripped, patterns, paths)?;
+            if result.exit_code == 2 && result.stdout.is_empty() && result.stderr.contains("option") {
+                // grep aborted on an rg-only flag that strip_rg_only missed; retry bare (#2167).
+                run_grep_fallback(grep_base, file_type, &[], patterns, paths)
+            } else {
+                Ok(result)
+            }
+        }
+    }
+}
+
+fn run_grep_fallback(
+    grep_base: &[&str],
+    file_type: Option<&str>,
+    extra_args: &[&str],
+    patterns: &[String],
+    paths: &[String],
+) -> Result<CaptureResult> {
+    let mut grep_cmd = resolved_command("grep");
+    grep_cmd.args(grep_base);
+    // file_type cannot be translated to grep syntax; silently skip.
+    let _ = file_type;
+    grep_cmd.args(extra_args);
+    for p in patterns {
+        grep_cmd.args(["-e", p]);
+    }
+    grep_cmd.arg("--");
+    grep_cmd.args(paths);
+    exec_capture(&mut grep_cmd).context("grep/rg failed")
+}
+
+#[allow(clippy::too_many_arguments)]
+fn passthrough<T: AsRef<str>>(
+    timer: &tracking::TimedExecution,
+    base: &[&str],
+    grep_base: &[&str],
+    file_type: Option<&str>,
+    extra_args: &[T],
+    patterns: &[String],
+    paths: &[String],
+    pattern_display: &str,
+    path_display: &str,
+) -> Result<i32> {
+    let result = grep_capture(base, grep_base, file_type, extra_args, patterns, paths)
+        .context("grep/rg failed")?;
+
+    print!("{}", strip_ansi(&result.stdout));
+    if !result.stderr.is_empty() {
+        eprint!("{}", result.stderr.trim());
+    }
+
+    let args_display = if extra_args.is_empty() {
+        format!("'{}' {}", pattern_display, path_display)
+    } else {
+        let joined: Vec<&str> = extra_args.iter().map(|a| a.as_ref()).collect();
+        format!("{} '{}' {}", joined.join(" "), pattern_display, path_display)
+    };
+
+    timer.track_passthrough(
+        &format!("grep {}", args_display),
+        &format!("rtk grep {} (passthrough)", args_display),
+    );
+    Ok(result.exit_code)
+}
+
 pub fn run(
     max_line_len: usize,
     max_results: usize,
@@ -312,75 +478,31 @@ pub fn run(
         eprintln!("grep: '{}' in {}", pattern_display, path_display);
     }
 
-    let mut rg_cmd = resolved_command("rg");
-    // --no-ignore-vcs: match grep -r behavior (don't skip .gitignore'd files).
-    // Without this, rg returns 0 matches for files in .gitignore, causing
-    // false negatives that make AI agents draw wrong conclusions.
-    // Using --no-ignore-vcs (not --no-ignore) so .ignore/.rgignore are still respected.
-    // -H: always emit the filename.
-    // -0: NUL-separate filename. Allows the parser to disambiguate filenames or
-    // content containing `:digits:` patterns (issue #1436).
-    rg_cmd.args(["-nH0", "--no-heading", "--no-ignore-vcs"]);
-
-    if let Some(ft) = file_type {
-        rg_cmd.arg("--type").arg(ft);
-    }
-
-    // extra_args is already stripped of -r/-R/-recursive by extract_pattern_path
-    rg_cmd.args(&extra_args);
-
-    // All patterns as -e flags (BRE \| → | translation for rg's PCRE engine).
-    // Using -e keeps `--` semantically as a flag/path separator, not part of the pattern.
-    for p in &patterns {
-        rg_cmd.args(["-e", &p.replace(r"\|", "|")]);
-    }
-
-    // `--` after all flags: prevents rg from interpreting path args starting
-    // with `-` as its own flags.
-    rg_cmd.arg("--");
-    rg_cmd.args(&paths);
-
-    let result = exec_capture(&mut rg_cmd)
-        .or_else(|_| {
-            // rg unavailable: fall back to system grep with the original,
-            // untranslated patterns (grep interprets BRE natively).
-            let mut grep_cmd = resolved_command("grep");
-            grep_cmd.args(&extra_args);
-            for p in &patterns {
-                grep_cmd.args(["-e", p]);
-            }
-            // --null (not -Z): on BSD/macOS grep -Z means --decompress, not the
-            // NUL filename separator parse_match_line() needs (issue #2310).
-            grep_cmd.args(["-rnH", "--null", "--"]);
-            grep_cmd.args(&paths);
-            exec_capture(&mut grep_cmd)
-        })
-        .context("grep/rg failed")?;
-
-    // Passthrough output flags that produce output that is already small.
-    if has_format_flag(&extra_args) {
-        print!("{}", result.stdout);
-        if !result.stderr.is_empty() {
-            eprint!("{}", result.stderr.trim());
-        }
-
-        let args_display = if extra_args.is_empty() {
-            format!("'{}' {}", pattern_display, path_display)
-        } else {
-            format!(
-                "{} '{}' {}",
-                extra_args.join(" "),
-                pattern_display,
-                path_display
-            )
-        };
-
-        timer.track_passthrough(
-            &format!("grep {}", args_display),
-            &format!("rtk grep {} (passthrough)", args_display),
+    // format/shape flags: native passthrough, no -0 NUL leak (#2333).
+    if has_format_flag(&extra_args) || has_shape_flag(&extra_args) {
+        return passthrough(
+            &timer,
+            &["--no-heading", "--no-ignore-vcs"],
+            &["-r"],
+            file_type,
+            &extra_args,
+            &patterns,
+            &paths,
+            &pattern_display,
+            &path_display,
         );
-        return Ok(result.exit_code);
     }
+
+    // GROUP path: -0 NUL-disambiguates file:line for the reparse (#1436).
+    let result = grep_capture(
+        &["-nH0", "--no-heading", "--no-ignore-vcs"],
+        &["-rnH", "--null"],
+        file_type,
+        &extra_args,
+        &patterns,
+        &paths,
+    )
+    .context("grep/rg failed")?;
 
     let exit_code = result.exit_code;
     let raw_output = result.stdout.clone();
@@ -411,6 +533,22 @@ pub fn run(
         return Ok(exit_code);
     }
 
+    // Safety net: unparseable shape → passthrough verbatim, never silently drop (#2333).
+    let signal = unparsed_signal(&raw_output);
+    if signal > 0 {
+        return passthrough(
+            &timer,
+            &["-nH", "--no-heading", "--no-ignore-vcs"],
+            &["-rnH"],
+            file_type,
+            &extra_args,
+            &patterns,
+            &paths,
+            &pattern_display,
+            &path_display,
+        );
+    }
+
     let context_re = if context_only {
         Regex::new(&format!(
             "(?i).{{0,20}}{}.*",
@@ -421,17 +559,23 @@ pub fn run(
         None
     };
 
-    let mut by_file: HashMap<String, Vec<(usize, String)>> = HashMap::new();
-    for line in result.stdout.lines() {
-        let Some((file, line_num, content)) = parse_match_line(line) else {
+    let mut by_file: HashMap<String, Vec<(usize, bool, String)>> = HashMap::new();
+    for line in raw_output.lines() {
+        let Some((file, line_num, is_match, content)) = parse_match_line(line) else {
             continue;
         };
         let cleaned = clean_line(content, max_line_len, context_re.as_ref(), &pattern_display);
-        by_file.entry(file).or_default().push((line_num, cleaned));
+        by_file
+            .entry(file)
+            .or_default()
+            .push((line_num, is_match, cleaned));
     }
 
-    // Derive total from parsed results so the header matches what we show.
-    let total_matches: usize = by_file.values().map(|v| v.len()).sum();
+    let total_matches: usize = by_file
+        .values()
+        .flat_map(|v| v.iter())
+        .filter(|(_, is_match, _)| *is_match)
+        .count();
 
     let mut rtk_output = String::new();
     rtk_output.push_str(&format!(
@@ -445,56 +589,73 @@ pub fn run(
     files.sort_by_key(|(f, _)| *f);
 
     let per_file = config::limits().grep_max_per_file;
-    for (file, matches) in files {
+    for (file, entries) in files {
         if shown >= max_results {
             break;
         }
 
         let file_display = compact_path(file);
-        for (line_num, content) in matches.iter().take(per_file) {
+        for (line_num, is_match, content) in entries.iter().take(per_file) {
             if shown >= max_results {
                 break;
             }
-            rtk_output.push_str(&format!("{}:{}:{}\n", file_display, line_num, content));
+            if *is_match {
+                rtk_output.push_str(&format!("{}:{}:{}\n", file_display, line_num, content));
+            } else {
+                rtk_output.push_str(&format!("{}-{}-{}\n", file_display, line_num, content));
+            }
             shown += 1;
         }
     }
 
-    if total_matches > shown {
-        rtk_output.push_str(&format!("[+{} more]\n", total_matches - shown));
+    let total_lines: usize = by_file.values().map(|v| v.len()).sum();
+    if total_lines > shown {
+        rtk_output.push_str(&format!("[+{} more]\n", total_lines - shown));
     }
 
-    print!("{}", rtk_output);
+    // Never-worse: show plain `file:line:content` (NUL `-0` -> `:`) if grouping didn't shrink it.
+    let plain = raw_output.replace('\0', ":");
+    let output = if rtk_output.len() < plain.len() {
+        rtk_output
+    } else {
+        plain
+    };
+
+    print!("{}", output);
     timer.track(
         &format!("grep -rn '{}' {}", pattern_display, path_display),
         "rtk grep",
         &raw_output,
-        &rtk_output,
+        &output,
     );
 
     Ok(exit_code)
 }
 
-/// Parses a single rg/grep match line of the form `file\0line_number:content`.
+/// Parses a single rg/grep match or context line of the form
+/// `file\0line_number[:-]content`.
 ///
 /// Requires the underlying command to be invoked with `-0` (rg) or `--null`
-/// (grep) so the filename is NUL-separated from `line:content`. NUL cannot
-/// appear in
-/// file paths, so the parser is unambiguous regardless of:
+/// (grep) so the filename is NUL-separated from `line[:-]content`. NUL cannot
+/// appear in file paths, so the parser is unambiguous regardless of:
 ///   - content with `:` or `::` (e.g. `ClassRegistry::init(...)`, issue #1436);
 ///   - paths with embedded `:` (Windows drive letters, weird filenames like
 ///     `badly_named:52:file.txt`).
 ///
-/// Returns `None` for lines that do not match the expected shape (e.g. rg
-/// `-A`/`-B` context lines that use `-` as separator).
-fn parse_match_line(line: &str) -> Option<(String, usize, &str)> {
+/// Returns `None` for lines that do not match the expected shape.
+/// The `bool` in the tuple is `true` for match lines (`:` separator) and
+/// `false` for context lines (`-` separator, emitted by -A/-B/-C).
+fn parse_match_line(line: &str) -> Option<(String, usize, bool, &str)> {
     lazy_static::lazy_static! {
-        static ref MATCH_LINE_RE: Regex = Regex::new(r"^([^\x00]+)\x00(\d+):(.*)$").unwrap();
+        static ref MATCH_LINE_RE: Regex = Regex::new(r"^([^\x00]+)\x00(\d+)([:-])(.*)$").unwrap();
     }
     MATCH_LINE_RE.captures(line).and_then(|caps| {
-        let (_, [file, line_num, content]) = caps.extract();
-        let line_num: usize = line_num.parse().ok()?;
-        Some((file.to_string(), line_num, content))
+        let file = caps.get(1)?.as_str().to_string();
+        let line_num: usize = caps.get(2)?.as_str().parse().ok()?;
+        let sep = caps.get(3)?.as_str();
+        let content = caps.get(4)?.as_str();
+        let is_match = sep == ":";
+        Some((file, line_num, is_match, content))
     })
 }
 
@@ -1119,6 +1280,39 @@ mod tests {
         assert!(!has_format_flag(&["-i", "-w", "-A", "3"]));
     }
 
+    #[test]
+    fn test_strip_rg_only_drops_glob_and_value() {
+        assert_eq!(strip_rg_only(&["--glob", "*.rs", "-i"]), vec!["-i"]);
+        assert_eq!(strip_rg_only(&["-g", "*.rs", "-i"]), vec!["-i"]);
+    }
+
+    #[test]
+    fn test_strip_rg_only_drops_inline_glob() {
+        assert_eq!(strip_rg_only(&["--glob=*.rs", "-i"]), vec!["-i"]);
+    }
+
+    #[test]
+    fn test_strip_rg_only_drops_bool_flags() {
+        assert_eq!(
+            strip_rg_only(&["--hidden", "--pcre2", "--json", "-n"]),
+            vec!["-n"]
+        );
+    }
+
+    #[test]
+    fn test_strip_rg_only_drops_type_and_value() {
+        assert_eq!(strip_rg_only(&["--type", "rust", "-w"]), vec!["-w"]);
+        assert_eq!(strip_rg_only(&["-T", "rust", "-w"]), vec!["-w"]);
+    }
+
+    #[test]
+    fn test_strip_rg_only_keeps_grep_compatible() {
+        assert_eq!(
+            strip_rg_only(&["-i", "-w", "-A", "3", "-v"]),
+            vec!["-i", "-w", "-A", "3", "-v"]
+        );
+    }
+
     // Verify line numbers are always enabled in rg invocation (grep_cmd.rs:24).
     // The -n/--line-numbers clap flag in main.rs is a no-op accepted for compat.
     #[test]
@@ -1138,14 +1332,15 @@ mod tests {
     }
 
     // --- issue #1436: parse_match_line robustness ---
-    // Input shape is `file\0line:content` (rg --null / grep -Z).
+    // Input shape is `file\0line[:-]content` (rg --null / grep -Z).
 
     #[test]
     fn test_parse_match_line_simple() {
         let line = "file.php\x0010:use Foo\\Bar;";
-        let (file, line_num, content) = parse_match_line(line).unwrap();
+        let (file, line_num, is_match, content) = parse_match_line(line).unwrap();
         assert_eq!(file, "file.php");
         assert_eq!(line_num, 10);
+        assert!(is_match);
         assert_eq!(content, "use Foo\\Bar;");
     }
 
@@ -1155,9 +1350,10 @@ mod tests {
     #[test]
     fn test_parse_match_line_content_with_double_colon() {
         let line = "externalImportShell.class.php\x0081:        $this->queueProcessModel = ClassRegistry::init('Collections.QueueProcess');";
-        let (file, line_num, content) = parse_match_line(line).unwrap();
+        let (file, line_num, is_match, content) = parse_match_line(line).unwrap();
         assert_eq!(file, "externalImportShell.class.php");
         assert_eq!(line_num, 81);
+        assert!(is_match);
         assert_eq!(
             content,
             "        $this->queueProcessModel = ClassRegistry::init('Collections.QueueProcess');"
@@ -1169,9 +1365,10 @@ mod tests {
     #[test]
     fn test_parse_match_line_windows_path() {
         let line = "C:\\src\\file.rs\x0042:fn main() {}";
-        let (file, line_num, content) = parse_match_line(line).unwrap();
+        let (file, line_num, is_match, content) = parse_match_line(line).unwrap();
         assert_eq!(file, r"C:\src\file.rs");
         assert_eq!(line_num, 42);
+        assert!(is_match);
         assert_eq!(content, "fn main() {}");
     }
 
@@ -1180,9 +1377,10 @@ mod tests {
     #[test]
     fn test_parse_match_line_filename_with_colons() {
         let line = "badly_named:52:file.txt\x001:xxx";
-        let (file, line_num, content) = parse_match_line(line).unwrap();
+        let (file, line_num, is_match, content) = parse_match_line(line).unwrap();
         assert_eq!(file, "badly_named:52:file.txt");
         assert_eq!(line_num, 1);
+        assert!(is_match);
         assert_eq!(content, "xxx");
     }
 
@@ -1191,9 +1389,10 @@ mod tests {
     #[test]
     fn test_parse_match_line_content_with_digit_colons() {
         let line = "log.txt\x007:debug: counter is :42: now";
-        let (file, line_num, content) = parse_match_line(line).unwrap();
+        let (file, line_num, is_match, content) = parse_match_line(line).unwrap();
         assert_eq!(file, "log.txt");
         assert_eq!(line_num, 7);
+        assert!(is_match);
         assert_eq!(content, "debug: counter is :42: now");
     }
 
@@ -1212,10 +1411,22 @@ mod tests {
     #[test]
     fn test_parse_match_line_empty_content() {
         let line = "file.rs\x007:";
-        let (file, line_num, content) = parse_match_line(line).unwrap();
+        let (file, line_num, is_match, content) = parse_match_line(line).unwrap();
         assert_eq!(file, "file.rs");
         assert_eq!(line_num, 7);
+        assert!(is_match);
         assert_eq!(content, "");
+    }
+
+    // Context line: separator is `-` → is_match==false
+    #[test]
+    fn test_parse_match_line_context_line() {
+        let line = "file.txt\x004-after1";
+        let (file, line_num, is_match, content) = parse_match_line(line).unwrap();
+        assert_eq!(file, "file.txt");
+        assert_eq!(line_num, 4);
+        assert!(!is_match, "dash separator must yield is_match==false");
+        assert_eq!(content, "after1");
     }
 
     #[test]
@@ -1236,5 +1447,50 @@ mod tests {
             );
         }
         // If rg is not installed, skip gracefully (test still passes)
+    }
+
+    // --- unparsed_signal ---
+
+    #[test]
+    fn test_unparsed_signal_parseable_lines_yield_zero() {
+        // NUL-separated match lines all parse → signal == 0
+        let stdout = "file.txt\x001:hello\nfile.txt\x002:world\n";
+        assert_eq!(unparsed_signal(stdout), 0);
+    }
+
+    #[test]
+    fn test_unparsed_signal_context_separator_not_counted() {
+        // The `--` context separator emitted by rg/grep between match groups
+        // must not be counted as an unparsed line.
+        let stdout = "file.txt\x001:hello\n--\nfile.txt\x003:world\n";
+        assert_eq!(unparsed_signal(stdout), 0);
+    }
+
+    #[test]
+    fn test_unparsed_signal_empty_line_not_counted() {
+        let stdout = "file.txt\x001:hello\n\nfile.txt\x002:world\n";
+        assert_eq!(unparsed_signal(stdout), 0);
+    }
+
+    #[test]
+    fn test_unparsed_signal_bare_colon_line_counted() {
+        // A line like "file.rs:1:content" (no NUL) is what --heading or
+        // --no-filename output looks like — it must be counted.
+        let stdout = "file.rs:1:content\n";
+        assert_eq!(unparsed_signal(stdout), 1);
+    }
+
+    #[test]
+    fn test_unparsed_signal_binary_notice_counted() {
+        // rg emits "Binary file foo matches" for binary files; no NUL → counted.
+        let stdout = "Binary file foo matches\n";
+        assert_eq!(unparsed_signal(stdout), 1);
+    }
+
+    #[test]
+    fn test_unparsed_signal_context_lines_parse_ok() {
+        // Context lines (dash separator) parse via the updated regex → not counted.
+        let stdout = "file.txt\x003-context_before\nfile.txt\x004:match\nfile.txt\x005-context_after\n";
+        assert_eq!(unparsed_signal(stdout), 0);
     }
 }

--- a/tests/grep_compress_test.rs
+++ b/tests/grep_compress_test.rs
@@ -317,3 +317,36 @@ fn small_grep_not_worse_than_plain() {
         "header that costs more than raw must be dropped:\n{stdout}"
     );
 }
+
+// --- #2543: bundled files-with-matches cluster (-rln / -ln) lists files, not "0 matches" ---
+
+#[test]
+fn bundled_files_with_matches_cluster_lists_files() {
+    if !rg_available() {
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("a.txt"), "TODO alpha\n").expect("write");
+    std::fs::write(dir.path().join("b.txt"), "TODO beta\n").expect("write");
+    std::fs::write(dir.path().join("c.txt"), "nothing here\n").expect("write");
+    let path = dir.path().to_str().unwrap();
+
+    let out = rtk()
+        .args(["grep", "-rln", "TODO", path])
+        .output()
+        .expect("rtk grep");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !stdout.contains("0 matches"),
+        "-rln must list files, not report a false '0 matches' (#2543):\n{stdout}"
+    );
+    assert!(
+        stdout.contains("a.txt") && stdout.contains("b.txt"),
+        "-rln must list every matching file:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("c.txt"),
+        "-rln must not list non-matching files:\n{stdout}"
+    );
+}

--- a/tests/grep_compress_test.rs
+++ b/tests/grep_compress_test.rs
@@ -1,0 +1,319 @@
+#![cfg(unix)]
+//! Integration tests for the GROUP path with context flags (-A/-B/-C) and the
+//! safety-net passthrough for flags that break the NUL-based reparse.
+
+use std::process::Command;
+
+fn rtk() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_rtk"))
+}
+
+fn rg_available() -> bool {
+    Command::new("rg")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn write_temp(content: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("test.txt");
+    std::fs::write(&path, content).expect("write");
+    (dir, path)
+}
+
+// --- context compression (the gain win) ---
+
+#[test]
+fn after_context_yields_grouped_header_with_correct_match_count() {
+    if !rg_available() {
+        return;
+    }
+    let long = "x".repeat(120);
+    let content =
+        format!("before {long}\nMATCH {long}\nafter1 {long}\nafter2 {long}\nend {long}\n");
+    let (_dir, path) = write_temp(&content);
+    let out = rtk()
+        .args(["grep", "-A2", "MATCH", path.to_str().unwrap()])
+        .output()
+        .expect("rtk grep");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        stdout.contains("1 matches"),
+        "header must count only the match line, not context lines:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("after1"),
+        "after-context line 1 missing:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("after2"),
+        "after-context line 2 missing:\n{stdout}"
+    );
+}
+
+#[test]
+fn after_context_uses_dash_separator_for_context_lines() {
+    if !rg_available() {
+        return;
+    }
+    let (_dir, path) = write_temp("MATCH\nafter1\n");
+    let out = rtk()
+        .args(["grep", "-A1", "MATCH", path.to_str().unwrap()])
+        .output()
+        .expect("rtk grep");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    let has_context_dash = stdout.lines().any(|l| l.contains("-after1"));
+    assert!(
+        has_context_dash,
+        "context lines must use dash separator:\n{stdout}"
+    );
+}
+
+#[test]
+fn plain_grep_still_shows_grouped_header() {
+    if !rg_available() {
+        return;
+    }
+    let long = "x".repeat(120);
+    let content = format!("foo {long}\nbaz\nfoo {long}\n");
+    let (_dir, path) = write_temp(&content);
+    let out = rtk()
+        .args(["grep", "foo", path.to_str().unwrap()])
+        .output()
+        .expect("rtk grep");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        stdout.contains("matches in"),
+        "grouped header must show when grouping compresses:\n{stdout}"
+    );
+}
+
+#[test]
+fn true_no_match_exits_1() {
+    if !rg_available() {
+        return;
+    }
+    let (_dir, path) = write_temp("hello world\n");
+    let out = rtk()
+        .args(["grep", "zzzz_no_match_xyz", path.to_str().unwrap()])
+        .output()
+        .expect("rtk grep");
+
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "true no-match must exit 1, not 0"
+    );
+}
+
+// --- safety net: flags that break the NUL-based reparse ---
+
+#[test]
+fn no_line_number_flag_produces_output_not_zero_matches() {
+    if !rg_available() {
+        return;
+    }
+    let (_dir, path) = write_temp("hello world\n");
+    let out = rtk()
+        .args(["grep", "-N", "hello", path.to_str().unwrap()])
+        .output()
+        .expect("rtk grep");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !stdout.contains("0 matches"),
+        "-N output must not be reported as '0 matches':\n{stdout}"
+    );
+    assert!(
+        stdout.contains("hello"),
+        "-N output must contain the matching line:\n{stdout}"
+    );
+}
+
+#[test]
+fn no_filename_flag_produces_output_not_zero_matches() {
+    if !rg_available() {
+        return;
+    }
+    let (_dir, path) = write_temp("hello world\n");
+    let out = rtk()
+        .args(["grep", "-I", "hello", path.to_str().unwrap()])
+        .output()
+        .expect("rtk grep");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !stdout.contains("0 matches"),
+        "-I output must not be reported as '0 matches':\n{stdout}"
+    );
+    assert!(
+        stdout.contains("hello"),
+        "-I output must contain the matching line:\n{stdout}"
+    );
+}
+
+#[test]
+fn heading_flag_produces_output_not_zero_matches() {
+    if !rg_available() {
+        return;
+    }
+    let (_dir, path) = write_temp("hello world\n");
+    let out = rtk()
+        .args(["grep", "--heading", "hello", path.to_str().unwrap()])
+        .output()
+        .expect("rtk grep");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !stdout.contains("0 matches"),
+        "--heading output must not be reported as '0 matches':\n{stdout}"
+    );
+    assert!(
+        stdout.contains("hello"),
+        "--heading output must contain the matching line:\n{stdout}"
+    );
+}
+
+#[test]
+fn pretty_flag_produces_output_not_zero_matches() {
+    if !rg_available() {
+        return;
+    }
+    let (_dir, path) = write_temp("hello world\n");
+    let out = rtk()
+        .args(["grep", "-p", "hello", path.to_str().unwrap()])
+        .output()
+        .expect("rtk grep");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !stdout.contains("0 matches"),
+        "-p output must not be reported as '0 matches':\n{stdout}"
+    );
+    assert!(
+        stdout.contains("hello"),
+        "-p output must contain the matching line:\n{stdout}"
+    );
+}
+
+// --- shape flags: passthrough, no NUL leak ---
+
+#[test]
+fn column_flag_output_has_no_nul() {
+    if !rg_available() {
+        return;
+    }
+    let (_dir, path) = write_temp("hello world\n");
+    let out = rtk()
+        .args(["grep", "--column", "hello", path.to_str().unwrap()])
+        .output()
+        .expect("rtk grep");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !stdout.contains('\u{0}'),
+        "--column output must not contain NUL:\n{stdout:?}"
+    );
+    assert!(
+        stdout.contains("hello"),
+        "--column output must contain the match:\n{stdout}"
+    );
+}
+
+// --- token savings (the compression gain) ---
+
+fn count_tokens(s: &str) -> usize {
+    s.split_whitespace().count()
+}
+
+#[test]
+fn bulky_grep_yields_token_savings() {
+    if !rg_available() {
+        return;
+    }
+    let filler: String = (0..50).map(|i| format!("word{i} ")).collect();
+    let mut content = String::new();
+    for i in 0..20 {
+        content.push_str(&format!("MATCH line {i} {filler}\n"));
+    }
+    let (_dir, path) = write_temp(&content);
+
+    let raw = Command::new("rg")
+        .args(["-nH", "MATCH", path.to_str().unwrap()])
+        .output()
+        .expect("rg");
+    let raw_tokens = count_tokens(&String::from_utf8_lossy(&raw.stdout));
+
+    let out = rtk()
+        .args(["grep", "MATCH", path.to_str().unwrap()])
+        .output()
+        .expect("rtk grep");
+    let rtk_tokens = count_tokens(&String::from_utf8_lossy(&out.stdout));
+
+    let savings = 100.0 - (rtk_tokens as f64 / raw_tokens as f64 * 100.0);
+    assert!(
+        savings >= 50.0,
+        "expected >=50% token savings, got {savings:.1}% (raw={raw_tokens}, rtk={rtk_tokens})"
+    );
+}
+
+// --- grep-only syntax falls back to system grep (#2543) ---
+
+#[test]
+fn grep_only_flags_fall_back_to_system_grep() {
+    if !rg_available() {
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("a.java"), "DRAFT in java\n").expect("write");
+    std::fs::write(dir.path().join("b.txt"), "DRAFT in text\n").expect("write");
+    let path = dir.path().to_str().unwrap();
+
+    let out = rtk()
+        .args(["grep", "-rn", "DRAFT", "--include=*.java", path])
+        .output()
+        .expect("rtk grep");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        stdout.contains("a.java"),
+        "--include=*.java should match the java file:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("b.txt"),
+        "--include=*.java should exclude the txt file:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("grep failed") && !stdout.contains("unrecognized"),
+        "rg-incompatible flag must fall back to grep, not error:\n{stdout}"
+    );
+}
+
+// --- never-worse guard: small greps must not cost more than plain grep ---
+
+#[test]
+fn small_grep_not_worse_than_plain() {
+    if !rg_available() {
+        return;
+    }
+    let (_dir, path) = write_temp("foo\n");
+    let out = rtk()
+        .args(["grep", "foo", path.to_str().unwrap()])
+        .output()
+        .expect("rtk grep");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        stdout.contains(":1:foo"),
+        "should show the match:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("matches in"),
+        "header that costs more than raw must be dropped:\n{stdout}"
+    );
+}

--- a/tests/grep_context_test.rs
+++ b/tests/grep_context_test.rs
@@ -1,0 +1,111 @@
+#![cfg(unix)]
+//! Regressions from the #2333 grep overhaul: -A/-B/-C must keep context lines,
+//! -c/-o must not leak ripgrep's NUL separator.
+
+use std::process::Command;
+
+fn rtk() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_rtk"))
+}
+
+fn rg_available() -> bool {
+    Command::new("rg")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn after_context_lines_are_shown() {
+    if !rg_available() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let f = dir.path().join("ctx.txt");
+    std::fs::write(&f, "before1\nbefore2\nMATCHME\nafter1\nafter2\nafter3\n").unwrap();
+    let out = rtk()
+        .args(["grep", "-A2", "MATCHME", f.to_str().unwrap()])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("after1"),
+        "missing after-context line 1:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("after2"),
+        "missing after-context line 2:\n{stdout}"
+    );
+    assert!(!stdout.contains("after3"), "leaked beyond -A2:\n{stdout}");
+}
+
+#[test]
+fn before_context_lines_are_shown() {
+    if !rg_available() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let f = dir.path().join("ctx.txt");
+    std::fs::write(&f, "before1\nbefore2\nMATCHME\nafter1\n").unwrap();
+    let out = rtk()
+        .args(["grep", "-B1", "MATCHME", f.to_str().unwrap()])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("before2"),
+        "missing before-context line:\n{stdout}"
+    );
+    assert!(!stdout.contains("before1"), "leaked beyond -B1:\n{stdout}");
+}
+
+#[test]
+fn count_output_has_no_nul_separator() {
+    if !rg_available() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let f = dir.path().join("nul.txt");
+    std::fs::write(&f, "TODO one\nnope\nTODO two\n").unwrap();
+    let out = rtk()
+        .args(["grep", "-c", "TODO", f.to_str().unwrap()])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains('\u{0}'),
+        "NUL leaked into -c output: {stdout:?}"
+    );
+    assert!(
+        stdout.contains('2'),
+        "count missing from -c output: {stdout:?}"
+    );
+}
+
+#[test]
+fn only_matching_output_has_no_nul_separator() {
+    if !rg_available() {
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let f = dir.path().join("nul.txt");
+    std::fs::write(&f, "TODO one\nnope\nTODO two\n").unwrap();
+    let out = rtk()
+        .args(["grep", "-o", "TODO", f.to_str().unwrap()])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains('\u{0}'),
+        "NUL leaked into -o output: {stdout:?}"
+    );
+    assert!(
+        stdout.contains("TODO"),
+        "match missing from -o output: {stdout:?}"
+    );
+    assert!(
+        !stdout.contains("1:TODO"),
+        "line-number prefix leaked into -o output: {stdout:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Make rtk grep produce correct output for every valid grep invocation and never cost more tokens than plain grep.

The #2333 arg-parsing rework routed many flag shapes through the grouping reparse, which silently dropped unparseable lines and returned success, producing wrong/empty results (and grep failed on --include) that pushed agents to unfiltered rtk proxy grep.
 
- Context (-A/-B/-C): grouped + compressed instead of dropped; header counts matches only.
- Unrepresentable output (-N, -I, --color, -p, --heading, --field-match-separator, binary notices): passed through verbatim, never a false "0 matches".
- Format/shape flags (-c/-l/-o/-Z/--column/-b/--vimgrep/--null-data): clean passthrough, no NUL leak.
- grep-only syntax (--include/--exclude/…): ripgrep fast path, falls back to system grep on rg error.
- Never-worse guard: never emits more than plain file:line:content grep.
  
 ## Related
 
- Resolves #2543 (-r/-rn rejected on 0.42.4; -rln false "0 matches" on develop).
- Supersedes #2224 (rg-only flags leaking to the grep fallback) — folded into strip_rg_only + the rg-error fallback.

## Test plan

- [x] cargo fmt --all && cargo clippy --all-targets && cargo test --all — clean, 2242 tests pass.
- [x] New integration tests: context compression, safety-net passthrough, NUL-free format/shape, grep-only-flag fallback, token savings, never-worse guard.
- [x] Correctness battery vs bare grep across 18 shapes — no NUL, no false 0-matches, no dropped matches, never bigger than raw.
- [x] Real hook path verified in tracking DB — routed (not proxy), 52% on bulky, 0% (never negative) on small.
