### PR TITLE
fix(core): never-worse output guard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,8 @@ The LLM doesn't know RTK is involved for which commands, hooks rewrite commands 
 
 Don't invent new output formats. Don't add RTK-specific headers or markers in the default output. The filtered output should be indistinguishable from "a shorter version of the real command."
 
+Enforce it with `guard::never_worse(raw, filtered)` — print and track the value it returns (use `runner::emit_guarded(filtered, hint, raw)` when appending a tee hint). It guarantees RTK never emits more tokens than the raw command, down to emitting nothing when the command produced nothing.
+
 ### Never Block
 
 If a filter fails, fall back to raw output. RTK should never prevent a command from executing or producing output. Better to pass through unfiltered than to error out. Same for hooks: exit 0 on all error paths so the agent's command runs unmodified.

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -248,7 +248,6 @@ bench "deps" "cat Cargo.toml" "$RTK deps"
 section "env"
 bench "env" "env" "$RTK env"
 bench "env -f PATH" "env | grep PATH" "$RTK env -f PATH"
-bench "env --show-all" "env" "$RTK env --show-all"
 
 # ===================
 # err

--- a/src/cmds/cloud/aws_cmd.rs
+++ b/src/cmds/cloud/aws_cmd.rs
@@ -407,17 +407,14 @@ fn run_s3_ls(extra_args: &[String], verbose: u8) -> Result<i32> {
     }
 
     let result = filter_s3_ls(&stdout);
-    if result.truncated {
-        if let Some(hint) = crate::core::tee::force_tee_hint(&raw, "aws_s3_ls") {
-            println!("{}\n{}", result.text, hint);
-        } else {
-            println!("{}", result.text);
-        }
+    let hint = if result.truncated {
+        crate::core::tee::force_tee_hint(&raw, "aws_s3_ls")
     } else {
-        println!("{}", result.text);
-    }
+        None
+    };
+    let shown = crate::core::runner::emit_guarded(&result.text, hint.as_deref(), &raw);
 
-    timer.track("aws s3 ls", "rtk aws s3 ls", &raw, &result.text);
+    timer.track("aws s3 ls", "rtk aws s3 ls", &raw, &shown);
     Ok(0)
 }
 
@@ -460,17 +457,14 @@ fn run_s3_transfer(operation: &str, extra_args: &[String], verbose: u8) -> Resul
     }
 
     let result = filter_s3_transfer(&stdout);
-    if result.truncated {
-        if let Some(hint) = force_tee_hint(&raw, &slug) {
-            println!("{}\n{}", result.text, hint);
-        } else {
-            println!("{}", result.text);
-        }
+    let hint = if result.truncated {
+        force_tee_hint(&raw, &slug)
     } else {
-        println!("{}", result.text);
-    }
+        None
+    };
+    let shown = crate::core::runner::emit_guarded(&result.text, hint.as_deref(), &raw);
 
-    timer.track(&cmd_label, &rtk_label, &raw, &result.text);
+    timer.track(&cmd_label, &rtk_label, &raw, &shown);
     Ok(0)
 }
 

--- a/src/cmds/cloud/aws_cmd.rs
+++ b/src/cmds/cloud/aws_cmd.rs
@@ -3,6 +3,7 @@
 //! Replaces verbose `--output table`/`text` with JSON, then compresses.
 //! Specialized filters for high-frequency commands (STS, S3, EC2, ECS, RDS, CloudFormation).
 
+use crate::core::guard::never_worse;
 use crate::core::tee::force_tee_hint;
 use crate::core::tracking;
 use crate::core::truncate::{CAP_INVENTORY, CAP_LIST};
@@ -258,6 +259,7 @@ fn run_generic(subcommand: &str, args: &[String], verbose: u8, full_sub: &str) -
 
     let filtered = match json_cmd::filter_json_compact(&raw, JSON_COMPRESS_DEPTH) {
         Ok(compact) => {
+            let compact = never_worse(&raw, &compact).to_string();
             println!("{}", compact);
             compact
         }
@@ -361,19 +363,14 @@ fn run_aws_filtered(
         FilterResult::new(stdout.clone())
     });
 
-    if result.truncated {
-        if let Some(hint) = crate::core::tee::force_tee_hint(&raw, &slug) {
-            println!("{}\n{}", result.text, hint);
-        } else {
-            println!("{}", result.text);
-        }
-    } else if let Some(hint) = crate::core::tee::tee_and_hint(&raw, &slug, 0) {
-        println!("{}\n{}", result.text, hint);
+    let hint = if result.truncated {
+        crate::core::tee::force_tee_hint(&raw, &slug)
     } else {
-        println!("{}", result.text);
-    }
+        crate::core::tee::tee_and_hint(&raw, &slug, 0)
+    };
+    let shown = crate::core::runner::emit_guarded(&result.text, hint.as_deref(), &raw);
 
-    timer.track(&cmd_label, &rtk_label, &raw, &result.text);
+    timer.track(&cmd_label, &rtk_label, &raw, &shown);
     Ok(0)
 }
 

--- a/src/cmds/cloud/container.rs
+++ b/src/cmds/cloud/container.rs
@@ -58,24 +58,32 @@ where
 fn docker_ps(_verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
-    let raw = exec_capture(resolved_command("docker").args(["ps"]))
-        .map(|r| r.stdout)
-        .unwrap_or_default();
+    let base = exec_capture(resolved_command("docker").args(["ps"]))
+        .context("Failed to run docker ps")?;
+    if !base.success() {
+        eprint!("{}", base.stderr);
+        print!("{}", base.stdout);
+        timer.track("docker ps", "rtk docker ps", &base.stdout, &base.stdout);
+        return Ok(base.exit_code);
+    }
+    let raw = base.stdout;
 
-    let result = exec_capture(resolved_command("docker").args([
+    let stdout = match exec_capture(resolved_command("docker").args([
         "ps",
         "--format",
         "{{.ID}}\t{{.Names}}\t{{.Status}}\t{{.Image}}\t{{.Ports}}",
     ]))
-    .context("Failed to run docker ps")?;
+    .ok()
+    .filter(|r| r.success())
+    {
+        Some(r) => r.stdout,
+        None => {
+            print!("{}", raw);
+            timer.track("docker ps", "rtk docker ps", &raw, &raw);
+            return Ok(0);
+        }
+    };
 
-    if !result.success() {
-        eprint!("{}", result.stderr);
-        timer.track("docker ps", "rtk docker ps", &raw, &raw);
-        return Ok(result.exit_code);
-    }
-
-    let stdout = result.stdout;
     let mut rtk = String::new();
 
     if stdout.trim().is_empty() {
@@ -111,27 +119,36 @@ fn docker_ps(_verbose: u8) -> Result<i32> {
 fn docker_ps_all(_verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
-    let raw = exec_capture(resolved_command("docker").args(["ps", "-a"]))
-        .map(|r| r.stdout)
-        .unwrap_or_default();
+    let base = exec_capture(resolved_command("docker").args(["ps", "-a"]))
+        .context("Failed to run docker ps -a")?;
+    if !base.success() {
+        eprint!("{}", base.stderr);
+        print!("{}", base.stdout);
+        timer.track("docker ps -a", "rtk docker ps -a", &base.stdout, &base.stdout);
+        return Ok(base.exit_code);
+    }
+    let raw = base.stdout;
 
-    let result = exec_capture(resolved_command("docker").args([
+    let stdout = match exec_capture(resolved_command("docker").args([
         "ps",
         "-a",
         "--format",
         "{{.State}}\t{{.ID}}\t{{.Names}}\t{{.Status}}\t{{.Image}}\t{{.Ports}}",
     ]))
-    .context("Failed to run docker ps -a")?;
-
-    if !result.success() {
-        eprint!("{}", result.stderr);
-        timer.track("docker ps -a", "rtk docker ps -a", &raw, &raw);
-        return Ok(result.exit_code);
-    }
+    .ok()
+    .filter(|r| r.success())
+    {
+        Some(r) => r.stdout,
+        None => {
+            print!("{}", raw);
+            timer.track("docker ps -a", "rtk docker ps -a", &raw, &raw);
+            return Ok(0);
+        }
+    };
 
     let mut running_lines: Vec<String> = Vec::new();
     let mut stopped_lines: Vec<String> = Vec::new();
-    for line in result.stdout.lines().filter(|l| !l.trim().is_empty()) {
+    for line in stdout.lines().filter(|l| !l.trim().is_empty()) {
         let parts: Vec<&str> = line.split('\t').collect();
         let state = parts.first().copied().unwrap_or("");
         let is_running = matches!(state, "running" | "restarting");
@@ -218,24 +235,32 @@ fn format_container_line_from_parts(parts: &[&str], with_ports: bool) -> Option<
 fn docker_images(_verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
-    let raw = exec_capture(resolved_command("docker").args(["images"]))
-        .map(|r| r.stdout)
-        .unwrap_or_default();
+    let base = exec_capture(resolved_command("docker").args(["images"]))
+        .context("Failed to run docker images")?;
+    if !base.success() {
+        eprint!("{}", base.stderr);
+        print!("{}", base.stdout);
+        timer.track("docker images", "rtk docker images", &base.stdout, &base.stdout);
+        return Ok(base.exit_code);
+    }
+    let raw = base.stdout;
 
-    let result = exec_capture(resolved_command("docker").args([
+    let stdout = match exec_capture(resolved_command("docker").args([
         "images",
         "--format",
         "{{.Repository}}:{{.Tag}}\t{{.Size}}",
     ]))
-    .context("Failed to run docker images")?;
+    .ok()
+    .filter(|r| r.success())
+    {
+        Some(r) => r.stdout,
+        None => {
+            print!("{}", raw);
+            timer.track("docker images", "rtk docker images", &raw, &raw);
+            return Ok(0);
+        }
+    };
 
-    if !result.success() {
-        eprint!("{}", result.stderr);
-        timer.track("docker images", "rtk docker images", &raw, &raw);
-        return Ok(result.exit_code);
-    }
-
-    let stdout = result.stdout;
     let lines: Vec<&str> = stdout.lines().collect();
     let mut rtk = String::new();
 

--- a/src/cmds/cloud/container.rs
+++ b/src/cmds/cloud/container.rs
@@ -86,11 +86,6 @@ fn docker_ps(_verbose: u8) -> Result<i32> {
 
     let mut rtk = String::new();
 
-    if stdout.trim().is_empty() {
-        timer.track("docker ps", "rtk docker ps", &raw, "");
-        return Ok(0);
-    }
-
     const MAX_CONTAINERS: usize = CAP_LIST;
     let lines: Vec<String> = stdout
         .lines()
@@ -263,11 +258,6 @@ fn docker_images(_verbose: u8) -> Result<i32> {
 
     let lines: Vec<&str> = stdout.lines().collect();
     let mut rtk = String::new();
-
-    if lines.is_empty() {
-        timer.track("docker images", "rtk docker images", &raw, "");
-        return Ok(0);
-    }
 
     let mut total_size_mb: f64 = 0.0;
     for line in &lines {

--- a/src/cmds/cloud/container.rs
+++ b/src/cmds/cloud/container.rs
@@ -1,5 +1,6 @@
 //! Filters Docker and kubectl output into compact summaries.
 
+use crate::core::guard::never_worse;
 use crate::core::runner::{self, RunOptions};
 use crate::core::stream::exec_capture;
 use crate::core::tracking;
@@ -78,9 +79,7 @@ fn docker_ps(_verbose: u8) -> Result<i32> {
     let mut rtk = String::new();
 
     if stdout.trim().is_empty() {
-        rtk.push_str("[docker] 0 containers");
-        println!("{}", rtk);
-        timer.track("docker ps", "rtk docker ps", &raw, &rtk);
+        timer.track("docker ps", "rtk docker ps", &raw, "");
         return Ok(0);
     }
 
@@ -103,8 +102,9 @@ fn docker_ps(_verbose: u8) -> Result<i32> {
         }
     }
 
-    print!("{}", rtk);
-    timer.track("docker ps", "rtk docker ps", &raw, &rtk);
+    let shown = never_worse(&raw, &rtk);
+    print!("{}", shown);
+    timer.track("docker ps", "rtk docker ps", &raw, shown);
     Ok(0)
 }
 
@@ -180,8 +180,9 @@ fn docker_ps_all(_verbose: u8) -> Result<i32> {
         }
     }
 
-    print!("{}", rtk);
-    timer.track("docker ps -a", "rtk docker ps -a", &raw, &rtk);
+    let shown = never_worse(&raw, &rtk);
+    print!("{}", shown);
+    timer.track("docker ps -a", "rtk docker ps -a", &raw, shown);
     Ok(0)
 }
 
@@ -239,9 +240,7 @@ fn docker_images(_verbose: u8) -> Result<i32> {
     let mut rtk = String::new();
 
     if lines.is_empty() {
-        rtk.push_str("[docker] 0 images");
-        println!("{}", rtk);
-        timer.track("docker images", "rtk docker images", &raw, &rtk);
+        timer.track("docker images", "rtk docker images", &raw, "");
         return Ok(0);
     }
 
@@ -299,8 +298,9 @@ fn docker_images(_verbose: u8) -> Result<i32> {
         }
     }
 
-    print!("{}", rtk);
-    timer.track("docker images", "rtk docker images", &raw, &rtk);
+    let shown = never_worse(&raw, &rtk);
+    print!("{}", shown);
+    timer.track("docker images", "rtk docker images", &raw, shown);
     Ok(0)
 }
 
@@ -692,10 +692,11 @@ pub fn run_compose_ps(all: bool, verbose: u8) -> Result<i32> {
     }
 
     let rtk = format_compose_ps(&structured);
-    println!("{}", rtk);
+    let shown = never_worse(&raw, &rtk);
+    println!("{}", shown);
     let label = if all { "docker compose ps -a" } else { "docker compose ps" };
     let rtk_label = if all { "rtk docker compose ps -a" } else { "rtk docker compose ps" };
-    timer.track(label, rtk_label, &raw, &rtk);
+    timer.track(label, rtk_label, &raw, shown);
     Ok(0)
 }
 

--- a/src/cmds/cloud/curl_cmd.rs
+++ b/src/cmds/cloud/curl_cmd.rs
@@ -76,16 +76,14 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     let is_tty = std::io::stdout().is_terminal();
     let filtered = filter_curl_output(&raw, is_tty);
 
-    println!("{}", filtered.content);
-    if let Some(hint) = &filtered.tee_hint {
-        println!("{}", hint);
-    }
+    let shown =
+        crate::core::runner::emit_guarded(&filtered.content, filtered.tee_hint.as_deref(), &raw);
 
     timer.track(
         &format!("curl {}", args.join(" ")),
         &format!("rtk curl {}", args.join(" ")),
         &raw,
-        &filtered.content,
+        &shown,
     );
 
     Ok(exit_code)

--- a/src/cmds/cloud/wget_cmd.rs
+++ b/src/cmds/cloud/wget_cmd.rs
@@ -1,3 +1,4 @@
+use crate::core::guard::never_worse;
 use crate::core::stream::exec_capture;
 use crate::core::tracking;
 use crate::core::utils::resolved_command;
@@ -35,13 +36,15 @@ pub fn run(url: &str, args: &[String], verbose: u8) -> Result<i32> {
             filename,
             format_size(size)
         );
-        println!("{}", msg);
-        timer.track(&format!("wget {}", url), "rtk wget", &raw_output, &msg);
+        let shown = never_worse(&raw_output, &msg);
+        println!("{}", shown);
+        timer.track(&format!("wget {}", url), "rtk wget", &raw_output, shown);
     } else {
         let error = parse_error(&result.stderr, &result.stdout);
         let msg = format!("{} FAILED: {}", compact_url(url), error);
-        println!("{}", msg);
-        timer.track(&format!("wget {}", url), "rtk wget", &raw_output, &msg);
+        let shown = never_worse(&raw_output, &msg);
+        println!("{}", shown);
+        timer.track(&format!("wget {}", url), "rtk wget", &raw_output, shown);
         return Ok(result.exit_code);
     }
 
@@ -89,18 +92,20 @@ pub fn run_stdout(url: &str, args: &[String], verbose: u8) -> Result<i32> {
                 rtk_output.push_str(&format!("{}\n", line));
             }
         }
-        print!("{}", rtk_output);
+        let shown = never_worse(&result.stdout, &rtk_output);
+        print!("{}", shown);
         timer.track(
             &format!("wget -O - {}", url),
             "rtk wget -o",
             &result.stdout,
-            &rtk_output,
+            shown,
         );
     } else {
         let error = parse_error(&result.stderr, "");
         let msg = format!("{} FAILED: {}", compact_url(url), error);
-        println!("{}", msg);
-        timer.track(&format!("wget -O - {}", url), "rtk wget -o", &result.stderr, &msg);
+        let shown = never_worse(&result.stderr, &msg);
+        println!("{}", shown);
+        timer.track(&format!("wget -O - {}", url), "rtk wget -o", &result.stderr, shown);
         return Ok(result.exit_code);
     }
 

--- a/src/cmds/dotnet/dotnet_cmd.rs
+++ b/src/cmds/dotnet/dotnet_cmd.rs
@@ -1,6 +1,7 @@
 //! Filters dotnet CLI output — build, test, and format results.
 
 use crate::binlog;
+use crate::core::guard::never_worse;
 use crate::core::stream::exec_capture;
 use crate::core::tracking;
 use crate::core::truncate::{CAP_ERRORS, CAP_LIST, CAP_WARNINGS};
@@ -54,13 +55,14 @@ pub fn run_format(args: &[String], verbose: u8) -> Result<i32> {
     let check_mode = !has_write_mode_override(args);
     let filtered =
         format_report_summary_or_raw(report_path.as_deref(), check_mode, &raw, command_started_at);
-    println!("{}", filtered);
+    let shown = never_worse(&raw, &filtered);
+    println!("{}", shown);
 
     timer.track(
         &format!("dotnet format {}", args.join(" ")),
         &format!("rtk dotnet format {}", args.join(" ")),
         &raw,
-        &filtered,
+        shown,
     );
 
     if cleanup_report_path {
@@ -226,13 +228,14 @@ fn run_dotnet_with_binlog(subcommand: &str, args: &[String], verbose: u8) -> Res
         &filtered,
     );
 
-    println!("{}", output_to_print);
+    let shown = never_worse(&raw, &output_to_print);
+    println!("{}", shown);
 
     timer.track(
         &format!("dotnet {} {}", subcommand, args.join(" ")),
         &format!("rtk dotnet {} {}", subcommand, args.join(" ")),
         &raw,
-        &output_to_print,
+        shown,
     );
 
     cleanup_temp_file(&binlog_path);

--- a/src/cmds/git/diff_cmd.rs
+++ b/src/cmds/git/diff_cmd.rs
@@ -1,5 +1,6 @@
 //! Compares two files and shows only the changed lines.
 
+use crate::core::guard::never_worse;
 use crate::core::tracking;
 use anyhow::Result;
 use std::fs;
@@ -20,12 +21,13 @@ pub fn run(file1: &Path, file2: &Path, verbose: u8) -> Result<i32> {
 
     let (rtk, exit_code) = render_file_diff(file1, file2, &content1, &content2);
 
-    print!("{}", rtk);
+    let shown = never_worse(&raw, &rtk);
+    print!("{}", shown);
     timer.track(
         &format!("diff {} {}", file1.display(), file2.display()),
         "rtk diff",
         &raw,
-        &rtk,
+        shown,
     );
     Ok(exit_code)
 }
@@ -61,9 +63,10 @@ pub fn run_stdin(_verbose: u8) -> Result<()> {
 
     // Parse unified diff format
     let condensed = condense_unified_diff(&input);
-    println!("{}", condensed);
+    let shown = never_worse(&input, &condensed);
+    println!("{}", shown);
 
-    timer.track("diff (stdin)", "rtk diff (stdin)", &input, &condensed);
+    timer.track("diff (stdin)", "rtk diff (stdin)", &input, shown);
 
     Ok(())
 }

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -1,6 +1,7 @@
 //! Filters git output — log, status, diff, and more — keeping just the essential info.
 
 use crate::core::args_utils;
+use crate::core::guard::never_worse;
 use crate::core::stream::{
     self, exec_capture, CaptureResult, FilterMode, LineHandler, LineStreamFilter, StdinMode,
 };
@@ -179,9 +180,6 @@ fn run_diff(
         eprintln!("Git diff summary:");
     }
 
-    // Print stat summary first
-    println!("{}", result.stdout.trim());
-
     // Now get actual diff but compact it
     let mut diff_cmd = git_cmd(global_args);
     diff_cmd.arg("diff");
@@ -191,20 +189,22 @@ fn run_diff(
 
     let diff_result = exec_capture(&mut diff_cmd).context("Failed to run git diff")?;
 
-    let mut final_output = result.stdout.clone();
-    if !diff_result.stdout.is_empty() {
-        println!("\nChanges:");
+    let printed = if !diff_result.stdout.is_empty() {
         let compacted = compact_diff(&diff_result.stdout, max_lines.unwrap_or(500));
-        println!("{}", compacted);
-        final_output.push_str("\nChanges:\n");
-        final_output.push_str(&compacted);
-    }
+        format!("{}\n\nChanges:\n{}", result.stdout.trim(), compacted)
+    } else {
+        result.stdout.trim().to_string()
+    };
+
+    let raw = format!("{}\n{}", result.stdout, diff_result.stdout);
+    let shown = never_worse(&raw, &printed);
+    println!("{}", shown);
 
     timer.track(
         &format!("git diff {}", args.join(" ")),
         &format!("rtk git diff {}", args.join(" ")),
-        &format!("{}\n{}", result.stdout, diff_result.stdout),
-        &final_output,
+        &raw,
+        shown,
     );
 
     Ok(0)
@@ -279,7 +279,7 @@ fn run_show(
         eprintln!("{}", summary_result.stderr);
         return Ok(summary_result.exit_code);
     }
-    println!("{}", summary_result.stdout.trim());
+    let mut printed = summary_result.stdout.trim().to_string();
 
     // Step 2: --stat summary
     let mut stat_cmd = git_cmd(global_args);
@@ -290,7 +290,8 @@ fn run_show(
     let stat_result = exec_capture(&mut stat_cmd).context("Failed to run git show --stat")?;
     let stat_text = stat_result.stdout.trim();
     if !stat_text.is_empty() {
-        println!("{}", stat_text);
+        printed.push('\n');
+        printed.push_str(stat_text);
     }
 
     // Step 3: compacted diff
@@ -302,21 +303,23 @@ fn run_show(
     let diff_result = exec_capture(&mut diff_cmd).context("Failed to run git show (diff)")?;
     let diff_text = diff_result.stdout.trim();
 
-    let mut final_output = summary_result.stdout.clone();
     if !diff_text.is_empty() {
         if verbose > 0 {
-            println!("\nChanges:");
+            printed.push_str("\n\nChanges:");
         }
         let compacted = compact_diff(diff_text, max_lines.unwrap_or(500));
-        println!("{}", compacted);
-        final_output.push_str(&format!("\n{}", compacted));
+        printed.push('\n');
+        printed.push_str(&compacted);
     }
+
+    let shown = never_worse(&raw_output, &printed);
+    println!("{}", shown);
 
     timer.track(
         &format!("git show {}", args.join(" ")),
         &format!("rtk git show {}", args.join(" ")),
         &raw_output,
-        &final_output,
+        shown,
     );
 
     Ok(0)
@@ -489,6 +492,7 @@ fn run_log(
 
     // Post-process: truncate long messages, cap lines only if RTK set the default
     let filtered = filter_log_output(&result.stdout, limit, user_set_limit, has_format_flag);
+    let filtered = never_worse(&result.stdout, &filtered).to_string();
     println!("{}", filtered);
 
     timer.track(
@@ -840,6 +844,7 @@ fn run_status(args: &[String], verbose: u8, global_args: &[String]) -> Result<i3
 
         // Apply minimal filtering: strip ANSI, remove hints, empty lines
         let filtered = filter_status_with_args(&result.stdout);
+        let filtered = never_worse(&result.stdout, &filtered).to_string();
         print!("{}", filtered);
 
         timer.track(
@@ -875,7 +880,8 @@ fn run_status(args: &[String], verbose: u8, global_args: &[String]) -> Result<i3
         } else {
             format!("rtk git status {}", args.join(" "))
         };
-        timer.track(&original_cmd, &rtk_cmd, &raw_output, &message);
+        let shown = never_worse(&raw_output, &message);
+        timer.track(&original_cmd, &rtk_cmd, &raw_output, shown);
         return Ok(result.exit_code);
     }
 
@@ -892,7 +898,8 @@ fn run_status(args: &[String], verbose: u8, global_args: &[String]) -> Result<i3
         None => formatted,
     };
 
-    println!("{}", final_output);
+    let shown = never_worse(&raw_output, &final_output);
+    println!("{}", shown);
 
     let original_cmd = if args.is_empty() {
         "git status".to_string()
@@ -905,7 +912,7 @@ fn run_status(args: &[String], verbose: u8, global_args: &[String]) -> Result<i3
         format!("rtk git status {}", args.join(" "))
     };
 
-    timer.track(&original_cmd, &rtk_cmd, &raw_output, &final_output);
+    timer.track(&original_cmd, &rtk_cmd, &raw_output, shown);
 
     Ok(0)
 }
@@ -1370,6 +1377,7 @@ fn run_branch(args: &[String], verbose: u8, global_args: &[String]) -> Result<i3
     }
 
     let filtered = filter_branch_output(&result.stdout);
+    let filtered = never_worse(&result.stdout, &filtered).to_string();
     println!("{}", filtered);
 
     timer.track(
@@ -1525,13 +1533,15 @@ fn run_stash(
             let result = exec_capture(&mut cmd).context("Failed to run git stash list")?;
 
             if result.stdout.trim().is_empty() {
-                let msg = "No stashes";
-                println!("{}", msg);
-                timer.track("git stash list", "rtk git stash list", &result.stdout, msg);
-                return Ok(0);
+                if !result.success() && !result.stderr.trim().is_empty() {
+                    eprintln!("{}", result.stderr.trim());
+                }
+                timer.track("git stash list", "rtk git stash list", &result.stdout, "");
+                return Ok(result.exit_code);
             }
 
             let filtered = filter_stash_list(&result.stdout);
+            let filtered = never_worse(&result.stdout, &filtered).to_string();
             println!("{}", filtered);
             timer.track(
                 "git stash list",
@@ -1548,21 +1558,22 @@ fn run_stash(
             }
             let result = exec_capture(&mut cmd).context("Failed to run git stash show")?;
 
-            let filtered = if result.stdout.trim().is_empty() {
-                let msg = "Empty stash";
-                println!("{}", msg);
-                msg.to_string()
-            } else {
-                let compacted = compact_diff(&result.stdout, 100);
-                println!("{}", compacted);
-                compacted
-            };
+            if result.stdout.trim().is_empty() {
+                if !result.success() && !result.stderr.trim().is_empty() {
+                    eprintln!("{}", result.stderr.trim());
+                }
+                timer.track("git stash show", "rtk git stash show", &result.stdout, "");
+                return Ok(result.exit_code);
+            }
 
+            let compacted = compact_diff(&result.stdout, 100);
+            let compacted = never_worse(&result.stdout, &compacted).to_string();
+            println!("{}", compacted);
             timer.track(
                 "git stash show",
                 "rtk git stash show",
                 &result.stdout,
-                &filtered,
+                &compacted,
             );
         }
         Some("apply") | Some("branch") | Some("clear") | Some("create") | Some("drop")
@@ -1715,6 +1726,7 @@ fn run_worktree(args: &[String], verbose: u8, global_args: &[String]) -> Result<
     let result = exec_capture(&mut cmd).context("Failed to run git worktree list")?;
 
     let filtered = filter_worktree_list(&result.stdout);
+    let filtered = never_worse(&result.stdout, &filtered).to_string();
     println!("{}", filtered);
     timer.track(
         "git worktree list",

--- a/src/cmds/git/gt_cmd.rs
+++ b/src/cmds/git/gt_cmd.rs
@@ -59,11 +59,8 @@ fn run_gt_filtered(
         filter_fn(&clean)
     };
 
-    if let Some(hint) = crate::core::tee::tee_and_hint(&raw, tee_label, cmd_output.exit_code) {
-        println!("{}\n{}", output, hint);
-    } else {
-        println!("{}", output);
-    }
+    let hint = crate::core::tee::tee_and_hint(&raw, tee_label, cmd_output.exit_code);
+    let shown = crate::core::runner::emit_guarded(&output, hint.as_deref(), &raw);
 
     if !cmd_output.stderr.trim().is_empty() {
         eprintln!("{}", cmd_output.stderr.trim());
@@ -75,7 +72,7 @@ fn run_gt_filtered(
         format!("gt {} {}", subcmd_str, args.join(" "))
     };
     let rtk_label = format!("rtk {}", label);
-    timer.track(&label, &rtk_label, &raw, &output);
+    timer.track(&label, &rtk_label, &raw, &shown);
 
     Ok(cmd_output.exit_code)
 }

--- a/src/cmds/go/go_cmd.rs
+++ b/src/cmds/go/go_cmd.rs
@@ -1,5 +1,6 @@
 //! Filters Go command output — test results, build errors, vet warnings.
 
+use crate::core::guard::never_worse;
 use crate::core::runner;
 use crate::core::tracking;
 use crate::core::truncate::CAP_ERRORS;
@@ -280,7 +281,8 @@ fn run_go_tool_golangci_lint(args: &[OsString], verbose: u8) -> Result<i32> {
     };
 
     let filtered = golangci_cmd::filter_golangci_json(json_output, version);
-    println!("{}", filtered);
+    let shown = never_worse(&raw, &filtered);
+    println!("{}", shown);
 
     if !stderr.trim().is_empty() && verbose > 0 {
         eprintln!("{}", stderr.trim());
@@ -290,7 +292,7 @@ fn run_go_tool_golangci_lint(args: &[OsString], verbose: u8) -> Result<i32> {
         "go tool golangci-lint",
         "rtk go tool golangci-lint",
         &raw,
-        &filtered,
+        shown,
     );
 
     let exit_code = exit_code_from_output(&output, "go tool golangci-lint");

--- a/src/cmds/js/lint_cmd.rs
+++ b/src/cmds/js/lint_cmd.rs
@@ -199,17 +199,14 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         _ => filter_generic_lint(&raw),
     };
 
-    if let Some(hint) = crate::core::tee::tee_and_hint(&raw, "lint", result.exit_code) {
-        println!("{}\n{}", filtered, hint);
-    } else {
-        println!("{}", filtered);
-    }
+    let hint = crate::core::tee::tee_and_hint(&raw, "lint", result.exit_code);
+    let shown = crate::core::runner::emit_guarded(&filtered, hint.as_deref(), &raw);
 
     timer.track(
         &format!("{} {}", linter, args.join(" ")),
         &format!("rtk lint {} {}", linter, args.join(" ")),
         &raw,
-        &filtered,
+        &shown,
     );
 
     if !result.success() {

--- a/src/cmds/js/playwright_cmd.rs
+++ b/src/cmds/js/playwright_cmd.rs
@@ -314,17 +314,14 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         }
     };
 
-    if let Some(hint) = crate::core::tee::tee_and_hint(&raw, "playwright", result.exit_code) {
-        println!("{}\n{}", filtered, hint);
-    } else {
-        println!("{}", filtered);
-    }
+    let hint = crate::core::tee::tee_and_hint(&raw, "playwright", result.exit_code);
+    let shown = crate::core::runner::emit_guarded(&filtered, hint.as_deref(), &raw);
 
     timer.track(
         &format!("playwright {}", args.join(" ")),
         &format!("rtk playwright {}", args.join(" ")),
         &raw,
-        &filtered,
+        &shown,
     );
 
     // Preserve exit code for CI/CD

--- a/src/cmds/js/pnpm_cmd.rs
+++ b/src/cmds/js/pnpm_cmd.rs
@@ -1,5 +1,6 @@
 //! Filters pnpm output — dependency trees, install logs, outdated packages.
 
+use crate::core::guard::never_worse;
 use crate::core::stream::exec_capture;
 use crate::core::tracking;
 use crate::core::truncate::CAP_LIST;
@@ -405,13 +406,14 @@ fn run_list(depth: usize, args: &[String], verbose: u8) -> Result<i32> {
         }
     };
 
-    println!("{}", filtered);
+    let shown = never_worse(&result.stdout, &filtered);
+    println!("{}", shown);
 
     timer.track(
         &format!("pnpm list --depth={}", depth),
         &format!("rtk pnpm list --depth={}", depth),
         &result.stdout,
-        &filtered,
+        shown,
     );
 
     Ok(0)
@@ -455,13 +457,15 @@ fn run_outdated(args: &[String], verbose: u8) -> Result<i32> {
         }
     };
 
-    if filtered.trim().is_empty() {
-        println!("All packages up-to-date");
+    let display = if filtered.trim().is_empty() {
+        "All packages up-to-date".to_string()
     } else {
-        println!("{}", filtered);
-    }
+        filtered.clone()
+    };
+    let shown = never_worse(&combined, &display);
+    println!("{}", shown);
 
-    timer.track("pnpm outdated", "rtk pnpm outdated", &combined, &filtered);
+    timer.track("pnpm outdated", "rtk pnpm outdated", &combined, shown);
 
     Ok(0)
 }
@@ -490,9 +494,10 @@ fn run_install(args: &[String], verbose: u8) -> Result<i32> {
     let combined = result.combined();
     let filtered = filter_pnpm_install(&combined);
 
-    println!("{}", filtered);
+    let shown = never_worse(&combined, &filtered);
+    println!("{}", shown);
 
-    timer.track("pnpm install", "rtk pnpm install", &combined, &filtered);
+    timer.track("pnpm install", "rtk pnpm install", &combined, shown);
 
     Ok(0)
 }

--- a/src/cmds/js/prisma_cmd.rs
+++ b/src/cmds/js/prisma_cmd.rs
@@ -1,5 +1,6 @@
 //! Filters Prisma CLI output by stripping ASCII art and verbose decoration.
 
+use crate::core::guard::never_worse;
 use crate::core::stream::exec_capture;
 use crate::core::tracking;
 use crate::core::utils::{resolved_command, tool_exists};
@@ -70,8 +71,9 @@ fn run_generate(args: &[String], verbose: u8) -> Result<i32> {
     }
 
     let filtered = filter_prisma_generate(&raw);
-    println!("{}", filtered);
-    timer.track("prisma generate", "rtk prisma generate", &raw, &filtered);
+    let shown = never_worse(&raw, &filtered);
+    println!("{}", shown);
+    timer.track("prisma generate", "rtk prisma generate", &raw, shown);
 
     Ok(0)
 }
@@ -129,8 +131,9 @@ fn run_migrate(subcommand: MigrateSubcommand, args: &[String], verbose: u8) -> R
         MigrateSubcommand::Deploy => filter_migrate_deploy(&raw),
     };
 
-    println!("{}", filtered);
-    timer.track(cmd_name, &format!("rtk {}", cmd_name), &raw, &filtered);
+    let shown = never_worse(&raw, &filtered);
+    println!("{}", shown);
+    timer.track(cmd_name, &format!("rtk {}", cmd_name), &raw, shown);
 
     Ok(0)
 }
@@ -165,8 +168,9 @@ fn run_db_push(args: &[String], verbose: u8) -> Result<i32> {
     }
 
     let filtered = filter_db_push(&raw);
-    println!("{}", filtered);
-    timer.track("prisma db push", "rtk prisma db push", &raw, &filtered);
+    let shown = never_worse(&raw, &filtered);
+    println!("{}", shown);
+    timer.track("prisma db push", "rtk prisma db push", &raw, shown);
 
     Ok(0)
 }

--- a/src/cmds/js/vitest_cmd.rs
+++ b/src/cmds/js/vitest_cmd.rs
@@ -256,16 +256,14 @@ pub fn run_test(command: &Commands, args: &[String], verbose: u8) -> Result<i32>
     );
     let tee_label = format!("{}_run", framework);
 
-    println!(
-        "{}",
-        render_test_output(&filtered, &combined, &tee_label, result.exit_code)
-    );
+    let rendered = render_test_output(&filtered, &combined, &tee_label, result.exit_code);
+    let shown = crate::core::runner::emit_guarded(&rendered, None, &combined);
 
     timer.track(
         format!("{} run", framework).as_str(),
         format!("rtk {} run", framework).as_str(),
         &combined,
-        &filtered.text,
+        &shown,
     );
 
     if !result.success() {

--- a/src/cmds/python/pip_cmd.rs
+++ b/src/cmds/python/pip_cmd.rs
@@ -1,5 +1,6 @@
 //! Filters pip and uv package manager output.
 
+use crate::core::guard::never_worse;
 use crate::core::stream::exec_capture;
 use crate::core::tracking;
 use crate::core::truncate::{CAP_INVENTORY, CAP_LIST};
@@ -78,7 +79,7 @@ fn run_list(base_cmd: &str, args: &[String], verbose: u8) -> Result<(String, Str
 
     let raw = format!("{}\n{}", result.stdout, result.stderr);
 
-    let filtered = filter_pip_list(&result.stdout);
+    let filtered = never_worse(&raw, &filter_pip_list(&result.stdout)).to_string();
     println!("{}", filtered);
 
     Ok((raw, filtered, result.exit_code))
@@ -106,7 +107,7 @@ fn run_outdated(base_cmd: &str, args: &[String], verbose: u8) -> Result<(String,
 
     let raw = format!("{}\n{}", result.stdout, result.stderr);
 
-    let filtered = filter_pip_outdated(&result.stdout);
+    let filtered = never_worse(&raw, &filter_pip_outdated(&result.stdout)).to_string();
     println!("{}", filtered);
 
     Ok((raw, filtered, result.exit_code))

--- a/src/cmds/system/deps.rs
+++ b/src/cmds/system/deps.rs
@@ -1,5 +1,6 @@
 //! Summarizes project dependencies from lock files and manifests.
 
+use crate::core::guard::never_worse;
 use crate::core::tracking;
 use crate::core::truncate::{reduced, CAP_WARNINGS};
 use anyhow::Result;
@@ -73,8 +74,9 @@ pub fn run(path: &Path, verbose: u8) -> Result<()> {
         rtk.push_str(&format!("No dependency files found in {}", dir.display()));
     }
 
-    print!("{}", rtk);
-    timer.track("cat */deps", "rtk deps", &raw, &rtk);
+    let shown = never_worse(&raw, &rtk);
+    print!("{}", shown);
+    timer.track("cat */deps", "rtk deps", &raw, shown);
     Ok(())
 }
 

--- a/src/cmds/system/env_cmd.rs
+++ b/src/cmds/system/env_cmd.rs
@@ -1,22 +1,20 @@
-//! Filters environment variables, hiding secrets and noise.
+//! Filters environment variables, compacting noise.
 
 use crate::core::guard::never_worse;
 use crate::core::tracking;
 use crate::core::truncate::{CAP_LIST, CAP_WARNINGS};
 use anyhow::Result;
-use std::collections::HashSet;
 use std::env;
 use std::fmt::Write;
 
-/// Show filtered environment variables (hide sensitive data)
-pub fn run(filter: Option<&str>, show_all: bool, verbose: u8) -> Result<()> {
+/// Show filtered environment variables
+pub fn run(filter: Option<&str>, verbose: u8) -> Result<()> {
     let timer = tracking::TimedExecution::start();
 
     if verbose > 0 {
         eprintln!("Environment variables:");
     }
 
-    let sensitive_patterns = get_sensitive_patterns();
     let mut vars: Vec<(String, String)> = env::vars().collect();
     vars.sort_by(|a, b| a.0.cmp(&b.0));
 
@@ -35,14 +33,7 @@ pub fn run(filter: Option<&str>, show_all: bool, verbose: u8) -> Result<()> {
             }
         }
 
-        // Check if sensitive
-        let is_sensitive = sensitive_patterns
-            .iter()
-            .any(|p| key.to_lowercase().contains(p));
-
-        let display_value = if is_sensitive && !show_all {
-            mask_value(value)
-        } else if value.len() > 100 {
+        let display_value = if value.len() > 100 {
             let preview: String = value.chars().take(50).collect();
             format!("{}... ({} chars)", preview, value.chars().count())
         } else {
@@ -138,33 +129,6 @@ pub fn run(filter: Option<&str>, show_all: bool, verbose: u8) -> Result<()> {
     Ok(())
 }
 
-fn get_sensitive_patterns() -> HashSet<&'static str> {
-    let mut set = HashSet::new();
-    set.insert("key");
-    set.insert("secret");
-    set.insert("password");
-    set.insert("token");
-    set.insert("credential");
-    set.insert("auth");
-    set.insert("private");
-    set.insert("api_key");
-    set.insert("apikey");
-    set.insert("access_key");
-    set.insert("jwt");
-    set
-}
-
-fn mask_value(value: &str) -> String {
-    let chars: Vec<char> = value.chars().collect();
-    if chars.len() <= 4 {
-        "****".to_string()
-    } else {
-        let prefix: String = chars[..2].iter().collect();
-        let suffix: String = chars[chars.len() - 2..].iter().collect();
-        format!("{}****{}", prefix, suffix)
-    }
-}
-
 fn is_lang_var(key: &str) -> bool {
     let patterns = [
         "RUST", "CARGO", "PYTHON", "PIP", "NODE", "NPM", "YARN", "DENO", "BUN", "JAVA", "MAVEN",
@@ -219,32 +183,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_mask_value_short() {
-        assert_eq!(mask_value("abc"), "****");
-        assert_eq!(mask_value(""), "****");
-    }
-
-    #[test]
-    fn test_mask_value_long() {
-        let result = mask_value("supersecrettoken");
-        assert!(result.contains("****"), "Masked value should contain ****");
-        assert!(result.starts_with("su"), "Should preserve 2-char prefix");
-        assert!(result.ends_with("en"), "Should preserve 2-char suffix");
-    }
-
-    #[test]
-    fn test_mask_value_exactly_four() {
-        assert_eq!(mask_value("abcd"), "****");
-    }
-
-    #[test]
-    fn test_mask_value_five_chars() {
-        let result = mask_value("abcde");
-        assert!(result.starts_with("ab"));
-        assert!(result.ends_with("de"));
-    }
-
-    #[test]
     fn test_is_lang_var_rust() {
         assert!(is_lang_var("RUST_LOG"));
         assert!(is_lang_var("CARGO_HOME"));
@@ -294,14 +232,5 @@ mod tests {
     fn test_is_interesting_var_negative() {
         assert!(!is_interesting_var("RANDOM_VAR"));
         assert!(!is_interesting_var("MY_CUSTOM_VAR"));
-    }
-
-    #[test]
-    fn test_sensitive_patterns_contains_keys() {
-        let patterns = get_sensitive_patterns();
-        assert!(patterns.contains("key"));
-        assert!(patterns.contains("secret"));
-        assert!(patterns.contains("password"));
-        assert!(patterns.contains("token"));
     }
 }

--- a/src/cmds/system/env_cmd.rs
+++ b/src/cmds/system/env_cmd.rs
@@ -1,5 +1,6 @@
 //! Filters environment variables, hiding secrets and noise.
 
+use crate::core::guard::never_worse;
 use crate::core::tracking;
 use crate::core::truncate::{CAP_LIST, CAP_WARNINGS};
 use anyhow::Result;
@@ -64,56 +65,56 @@ pub fn run(filter: Option<&str>, show_all: bool, verbose: u8) -> Result<()> {
         }
     }
 
-    // Print categorized
+    let mut body = String::new();
     if !path_vars.is_empty() {
-        println!("PATH Variables:");
+        let _ = writeln!(body, "PATH Variables:");
         for (k, v) in &path_vars {
             if k == "PATH" {
                 // Split PATH for readability
                 let paths: Vec<&str> = v.split(':').collect();
-                println!("  PATH ({} entries):", paths.len());
+                let _ = writeln!(body, "  PATH ({} entries):", paths.len());
                 const MAX_PATH_ENTRIES: usize = CAP_WARNINGS;
                 for p in paths.iter().take(MAX_PATH_ENTRIES) {
-                    println!("    {}", p);
+                    let _ = writeln!(body, "    {}", p);
                 }
                 if paths.len() > MAX_PATH_ENTRIES {
-                    println!("    ... +{} more", paths.len() - MAX_PATH_ENTRIES);
+                    let _ = writeln!(body, "    ... +{} more", paths.len() - MAX_PATH_ENTRIES);
                 }
             } else {
-                println!("  {}={}", k, v);
+                let _ = writeln!(body, "  {}={}", k, v);
             }
         }
     }
 
     if !lang_vars.is_empty() {
-        println!("\nLanguage/Runtime:");
+        let _ = writeln!(body, "\nLanguage/Runtime:");
         for (k, v) in &lang_vars {
-            println!("  {}={}", k, v);
+            let _ = writeln!(body, "  {}={}", k, v);
         }
     }
 
     if !cloud_vars.is_empty() {
-        println!("\nCloud/Services:");
+        let _ = writeln!(body, "\nCloud/Services:");
         for (k, v) in &cloud_vars {
-            println!("  {}={}", k, v);
+            let _ = writeln!(body, "  {}={}", k, v);
         }
     }
 
     if !tool_vars.is_empty() {
-        println!("\nTools:");
+        let _ = writeln!(body, "\nTools:");
         for (k, v) in &tool_vars {
-            println!("  {}={}", k, v);
+            let _ = writeln!(body, "  {}={}", k, v);
         }
     }
 
     if !other_vars.is_empty() {
         const MAX_OTHER_VARS: usize = CAP_LIST;
-        println!("\nOther:");
+        let _ = writeln!(body, "\nOther:");
         for (k, v) in other_vars.iter().take(MAX_OTHER_VARS) {
-            println!("  {}={}", k, v);
+            let _ = writeln!(body, "  {}={}", k, v);
         }
         if other_vars.len() > MAX_OTHER_VARS {
-            println!("  ... +{} more", other_vars.len() - MAX_OTHER_VARS);
+            let _ = writeln!(body, "  ... +{} more", other_vars.len() - MAX_OTHER_VARS);
         }
     }
 
@@ -124,15 +125,16 @@ pub fn run(filter: Option<&str>, show_all: bool, verbose: u8) -> Result<()> {
         + tool_vars.len()
         + other_vars.len().min(20);
     if filter.is_none() {
-        println!("\nTotal: {} vars (showing {} relevant)", total, shown);
+        let _ = writeln!(body, "\nTotal: {} vars (showing {} relevant)", total, shown);
     }
 
     let raw: String = vars.iter().fold(String::new(), |mut output, (k, v)| {
         let _ = writeln!(output, "{}={}", k, v);
         output
     });
-    let rtk = format!("{} vars -> {} shown", total, shown);
-    timer.track("env", "rtk env", &raw, &rtk);
+    let shown_body = never_worse(&raw, &body);
+    print!("{}", shown_body);
+    timer.track("env", "rtk env", &raw, shown_body);
     Ok(())
 }
 

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -1,5 +1,6 @@
 //! Filters find results by grouping files by directory.
 
+use crate::core::guard::never_worse;
 use crate::core::tracking;
 use anyhow::{Context, Result};
 use ignore::WalkBuilder;
@@ -278,13 +279,11 @@ pub fn run(
     let raw_output = files.join("\n");
 
     if files.is_empty() {
-        let msg = format!("0 for '{}'", effective_pattern);
-        println!("{}", msg);
         timer.track(
             &format!("find {} -name '{}'", path, effective_pattern),
             "rtk find",
             &raw_output,
-            &msg,
+            "",
         );
         return Ok(());
     }
@@ -311,13 +310,14 @@ pub fn run(
     let dirs_count = dirs.len();
     let total_files = files.len();
 
-    println!("{}F {}D:", total_files, dirs_count);
-    println!();
+    let mut body = String::new();
+    body.push_str(&format!("{}F {}D:\n", total_files, dirs_count));
+    body.push('\n');
 
     // Display with proper --max limiting (count individual files)
-    let mut shown = 0;
+    let mut displayed = 0;
     for dir in &dirs {
-        if shown >= max_results {
+        if displayed >= max_results {
             break;
         }
 
@@ -328,10 +328,10 @@ pub fn run(
             dir.clone()
         };
 
-        let remaining_budget = max_results - shown;
+        let remaining_budget = max_results - displayed;
         if files_in_dir.len() <= remaining_budget {
-            println!("{}/ {}", dir_display, files_in_dir.join(" "));
-            shown += files_in_dir.len();
+            body.push_str(&format!("{}/ {}\n", dir_display, files_in_dir.join(" ")));
+            displayed += files_in_dir.len();
         } else {
             // Partial display: show only what fits in budget
             let partial: Vec<_> = files_in_dir
@@ -339,14 +339,14 @@ pub fn run(
                 .take(remaining_budget)
                 .cloned()
                 .collect();
-            println!("{}/ {}", dir_display, partial.join(" "));
-            shown += partial.len();
+            body.push_str(&format!("{}/ {}\n", dir_display, partial.join(" ")));
+            displayed += partial.len();
             break;
         }
     }
 
-    if shown < total_files {
-        println!("+{} more", total_files - shown);
+    if displayed < total_files {
+        body.push_str(&format!("+{} more\n", total_files - displayed));
     }
 
     // Extension summary
@@ -359,9 +359,8 @@ pub fn run(
         *by_ext.entry(ext).or_default() += 1;
     }
 
-    let mut ext_line = String::new();
     if by_ext.len() > 1 {
-        println!();
+        body.push('\n');
         let mut exts: Vec<_> = by_ext.iter().collect();
         exts.sort_by(|a, b| b.1.cmp(a.1));
         let ext_str: Vec<String> = exts
@@ -369,16 +368,17 @@ pub fn run(
             .take(5)
             .map(|(e, c)| format!(".{}({})", e, c))
             .collect();
-        ext_line = format!("ext: {}", ext_str.join(" "));
-        println!("{}", ext_line);
+        let ext_line = format!("ext: {}", ext_str.join(" "));
+        body.push_str(&format!("{}\n", ext_line));
     }
 
-    let rtk_output = format!("{}F {}D + {}", total_files, dirs_count, ext_line);
+    let shown = never_worse(&raw_output, &body);
+    print!("{}", shown);
     timer.track(
         &format!("find {} -name '{}'", path, effective_pattern),
         "rtk find",
         &raw_output,
-        &rtk_output,
+        shown,
     );
 
     Ok(())

--- a/src/cmds/system/format_cmd.rs
+++ b/src/cmds/system/format_cmd.rs
@@ -1,5 +1,6 @@
 //! Runs code formatters (Prettier, Ruff) and shows only files that changed.
 
+use crate::core::guard::never_worse;
 use crate::core::stream::exec_capture;
 use crate::core::tracking;
 use crate::core::truncate::CAP_WARNINGS;
@@ -124,13 +125,14 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         _ => raw.trim().to_string(),
     };
 
-    println!("{}", filtered);
+    let shown = never_worse(&raw, &filtered);
+    println!("{}", shown);
 
     timer.track(
         &format!("{} {}", formatter, user_args.join(" ")),
         &format!("rtk format {} {}", formatter, user_args.join(" ")),
         &raw,
-        &filtered,
+        shown,
     );
 
     Ok(result.exit_code)

--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -400,13 +400,11 @@ pub fn run(
             eprintln!("{}", msg);
             return Ok(exit_code);
         }
-        let msg = format!("0 matches for '{}'", pattern_display);
-        println!("{}", msg);
         timer.track(
             &format!("grep -rn '{}' {}", pattern_display, path_display),
             "rtk grep",
             &raw_output,
-            &msg,
+            "",
         );
         return Ok(exit_code);
     }
@@ -464,12 +462,13 @@ pub fn run(
         rtk_output.push_str(&format!("[+{} more]\n", total_matches - shown));
     }
 
-    print!("{}", rtk_output);
+    let guarded = crate::core::guard::never_worse(&raw_output, &rtk_output);
+    print!("{}", guarded);
     timer.track(
         &format!("grep -rn '{}' {}", pattern_display, path_display),
         "rtk grep",
         &raw_output,
-        &rtk_output,
+        guarded,
     );
 
     Ok(exit_code)

--- a/src/cmds/system/json_cmd.rs
+++ b/src/cmds/system/json_cmd.rs
@@ -1,5 +1,6 @@
 //! Inspects JSON structure without showing values, saving tokens on large payloads.
 
+use crate::core::guard::never_worse;
 use crate::core::tracking;
 use anyhow::{bail, Context, Result};
 use serde_json::Value;
@@ -52,12 +53,13 @@ pub fn run(file: &Path, max_depth: usize, schema_only: bool, verbose: u8) -> Res
     } else {
         filter_json_compact(&content, max_depth)?
     };
-    println!("{}", output);
+    let shown = never_worse(&content, &output);
+    println!("{}", shown);
     timer.track(
         &format!("cat {}", file.display()),
         "rtk json",
         &content,
-        &output,
+        shown,
     );
     Ok(())
 }
@@ -81,8 +83,9 @@ pub fn run_stdin(max_depth: usize, schema_only: bool, verbose: u8) -> Result<()>
     } else {
         filter_json_compact(&content, max_depth)?
     };
-    println!("{}", output);
-    timer.track("cat - (stdin)", "rtk json -", &content, &output);
+    let shown = never_worse(&content, &output);
+    println!("{}", shown);
+    timer.track("cat - (stdin)", "rtk json -", &content, shown);
     Ok(())
 }
 

--- a/src/cmds/system/log_cmd.rs
+++ b/src/cmds/system/log_cmd.rs
@@ -1,5 +1,6 @@
 //! Deduplicates repeated log lines and shows counts instead.
 
+use crate::core::guard::never_worse;
 use crate::core::tracking;
 use crate::core::truncate::{reduced, CAP_WARNINGS};
 use anyhow::Result;
@@ -31,12 +32,13 @@ pub fn run_file(file: &Path, verbose: u8) -> Result<()> {
 
     let content = fs::read_to_string(file)?;
     let result = analyze_logs(&content);
-    println!("{}", result);
+    let shown = never_worse(&content, &result);
+    println!("{}", shown);
     timer.track(
         &format!("cat {}", file.display()),
         "rtk log",
         &content,
-        &result,
+        shown,
     );
     Ok(())
 }
@@ -53,9 +55,10 @@ pub fn run_stdin(_verbose: u8) -> Result<()> {
     }
 
     let result = analyze_logs(&content);
-    println!("{}", result);
+    let shown = never_worse(&content, &result);
+    println!("{}", shown);
 
-    timer.track("log (stdin)", "rtk log (stdin)", &content, &result);
+    timer.track("log (stdin)", "rtk log (stdin)", &content, shown);
 
     Ok(())
 }

--- a/src/cmds/system/pipe_cmd.rs
+++ b/src/cmds/system/pipe_cmd.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use std::io::Read;
 
+use crate::core::guard::never_worse;
 use crate::core::stream::RAW_CAP;
 use crate::core::truncate::{CAP_LIST, CAP_WARNINGS};
 
@@ -238,7 +239,8 @@ pub fn run(filter_name: Option<&str>, passthrough: bool) -> Result<()> {
     };
 
     let output = apply_filter(filter_fn, &buf);
-    print!("{}", output);
+    let shown = never_worse(&buf, &output);
+    print!("{}", shown);
     Ok(())
 }
 

--- a/src/cmds/system/read.rs
+++ b/src/cmds/system/read.rs
@@ -1,6 +1,7 @@
 //! Reads source files with optional language-aware filtering to strip boilerplate.
 
 use crate::core::filter::{self, FilterLevel, Language};
+use crate::core::guard::never_worse;
 use crate::core::tracking;
 use anyhow::{Context, Result};
 use std::fs;
@@ -70,12 +71,13 @@ pub fn run(
     } else {
         filtered.clone()
     };
-    print!("{}", rtk_output);
+    let shown = never_worse(&content, &rtk_output);
+    print!("{}", shown);
     timer.track(
         &format!("cat {}", file.display()),
         "rtk read",
         &content,
-        &rtk_output,
+        shown,
     );
     Ok(())
 }
@@ -134,9 +136,10 @@ pub fn run_stdin(
     } else {
         filtered.clone()
     };
-    print!("{}", rtk_output);
+    let shown = never_worse(&content, &rtk_output);
+    print!("{}", shown);
 
-    timer.track("cat - (stdin)", "rtk read -", &content, &rtk_output);
+    timer.track("cat - (stdin)", "rtk read -", &content, shown);
     Ok(())
 }
 

--- a/src/cmds/system/read.rs
+++ b/src/cmds/system/read.rs
@@ -66,17 +66,20 @@ pub fn run(
 
     filtered = apply_line_window(&filtered, max_lines, tail_lines, &lang);
 
-    let rtk_output = if line_numbers {
-        format_with_line_numbers(&filtered)
+    let (raw, rtk_output) = if line_numbers {
+        (
+            format_with_line_numbers(&content),
+            format_with_line_numbers(&filtered),
+        )
     } else {
-        filtered.clone()
+        (content.clone(), filtered.clone())
     };
-    let shown = never_worse(&content, &rtk_output);
+    let shown = never_worse(&raw, &rtk_output);
     print!("{}", shown);
     timer.track(
         &format!("cat {}", file.display()),
         "rtk read",
-        &content,
+        &raw,
         shown,
     );
     Ok(())
@@ -131,15 +134,18 @@ pub fn run_stdin(
 
     filtered = apply_line_window(&filtered, max_lines, tail_lines, &lang);
 
-    let rtk_output = if line_numbers {
-        format_with_line_numbers(&filtered)
+    let (raw, rtk_output) = if line_numbers {
+        (
+            format_with_line_numbers(&content),
+            format_with_line_numbers(&filtered),
+        )
     } else {
-        filtered.clone()
+        (content.clone(), filtered.clone())
     };
-    let shown = never_worse(&content, &rtk_output);
+    let shown = never_worse(&raw, &rtk_output);
     print!("{}", shown);
 
-    timer.track("cat - (stdin)", "rtk read -", &content, shown);
+    timer.track("cat - (stdin)", "rtk read -", &raw, shown);
     Ok(())
 }
 

--- a/src/cmds/system/summary.rs
+++ b/src/cmds/system/summary.rs
@@ -1,5 +1,6 @@
 //! Runs a command and produces a heuristic summary of its output.
 
+use crate::core::guard::never_worse;
 use crate::core::stream::exec_capture;
 use crate::core::tracking;
 use crate::core::truncate::CAP_WARNINGS;
@@ -33,8 +34,9 @@ pub fn run(command: &str, verbose: u8) -> Result<i32> {
     let raw = format!("{}\n{}", result.stdout, result.stderr);
 
     let summary = summarize_output(&raw, command, result.success());
-    println!("{}", summary);
-    timer.track(command, "rtk summary", &raw, &summary);
+    let shown = never_worse(&raw, &summary);
+    println!("{}", shown);
+    timer.track(command, "rtk summary", &raw, shown);
     Ok(result.exit_code)
 }
 

--- a/src/core/guard.rs
+++ b/src/core/guard.rs
@@ -1,0 +1,56 @@
+//! Never-worse output guard: RTK never emits more tokens than the raw command.
+
+use crate::core::tracking::estimate_tokens;
+
+/// Returns `filtered`, or `raw` when `filtered` would emit more tokens.
+pub fn never_worse<'a>(raw: &'a str, filtered: &'a str) -> &'a str {
+    if estimate_tokens(filtered) > estimate_tokens(raw) {
+        raw
+    } else {
+        filtered
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keeps_filtered_when_smaller() {
+        let raw = "a".repeat(400);
+        assert_eq!(never_worse(&raw, "ok"), "ok");
+    }
+
+    #[test]
+    fn falls_back_to_raw_when_filtered_bigger() {
+        let raw = "{}";
+        let filtered = "{\n  \"pretty\": true\n}";
+        assert_eq!(never_worse(raw, filtered), raw);
+    }
+
+    #[test]
+    fn tie_keeps_filtered() {
+        assert_eq!(never_worse("abcd", "wxyz"), "wxyz");
+    }
+
+    #[test]
+    fn token_boundary_follows_estimate_tokens() {
+        assert_eq!(never_worse("abcd", "abcde"), "abcd");
+        assert_eq!(never_worse("abcdefgh", "ijklmnop"), "ijklmnop");
+    }
+
+    #[test]
+    fn empty_raw_returns_raw() {
+        assert_eq!(never_worse("", "0 matches"), "");
+    }
+
+    #[test]
+    fn empty_filtered_returns_filtered() {
+        assert_eq!(never_worse("data", ""), "");
+    }
+
+    #[test]
+    fn both_empty_returns_filtered() {
+        assert_eq!(never_worse("", ""), "");
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod constants;
 pub mod display_helpers;
 pub mod filter;
+pub mod guard;
 pub mod runner;
 pub mod stream;
 pub mod tee;

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -6,12 +6,28 @@ use std::process::Command;
 use crate::core::stream::{self, FilterMode, StdinMode, StreamFilter};
 use crate::core::tracking;
 
-pub fn print_with_hint(filtered: &str, raw: &str, tee_label: &str, exit_code: i32) {
-    if let Some(hint) = crate::core::tee::tee_and_hint(raw, tee_label, exit_code) {
-        println!("{}\n{}", filtered, hint);
-    } else {
-        println!("{}", filtered);
-    }
+/// Compose `filtered` with an optional recovery `hint`, cap the total at `raw`
+/// (never emit more tokens than the command), print it, and return what was
+/// emitted so the caller tracks exactly that.
+pub fn emit_guarded(filtered: &str, hint: Option<&str>, raw: &str) -> String {
+    let body = match hint {
+        Some(h) => format!("{}\n{}", filtered, h),
+        None => filtered.to_string(),
+    };
+    let shown = crate::core::guard::never_worse(raw, &body).to_string();
+    println!("{}", shown);
+    shown
+}
+
+pub fn print_with_hint(
+    filtered: &str,
+    tee_raw: &str,
+    guard_raw: &str,
+    tee_label: &str,
+    exit_code: i32,
+) -> String {
+    let hint = crate::core::tee::tee_and_hint(tee_raw, tee_label, exit_code);
+    emit_guarded(filtered, hint.as_deref(), guard_raw)
 }
 
 #[derive(Default)]
@@ -113,24 +129,29 @@ where
     };
     let filtered = filter_fn(text_to_filter, exit_code);
 
-    if let Some(label) = opts.tee_label {
-        print_with_hint(&filtered, raw, label, exit_code);
-    } else if opts.no_trailing_newline {
-        print!("{}", filtered);
-    } else {
-        println!("{}", filtered);
-    }
-
     let raw_for_tracking = if opts.filter_stdout_only {
         raw_stdout
     } else {
         raw
     };
+
+    let shown = if let Some(label) = opts.tee_label {
+        print_with_hint(&filtered, raw, raw_for_tracking, label, exit_code)
+    } else {
+        let guarded = crate::core::guard::never_worse(raw_for_tracking, &filtered).to_string();
+        if opts.no_trailing_newline {
+            print!("{}", guarded);
+        } else {
+            println!("{}", guarded);
+        }
+        guarded
+    };
+
     timer.track(
         cmd_label,
         &format!("rtk {}", cmd_label),
         raw_for_tracking,
-        &filtered,
+        &shown,
     );
     Ok(exit_code)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -244,14 +244,11 @@ enum Commands {
         path: PathBuf,
     },
 
-    /// Show environment variables (filtered, sensitive masked)
+    /// Show environment variables (filtered)
     Env {
         /// Filter by name (e.g. PATH, AWS)
         #[arg(short, long)]
         filter: Option<String>,
-        /// Show all (include sensitive)
-        #[arg(long)]
-        show_all: bool,
     },
 
     /// Find files with compact tree output (accepts native find flags like -name, -type)
@@ -1751,8 +1748,8 @@ fn run_cli() -> Result<i32> {
             0
         }
 
-        Commands::Env { filter, show_all } => {
-            env_cmd::run(filter.as_deref(), show_all, cli.verbose)?;
+        Commands::Env { filter } => {
+            env_cmd::run(filter.as_deref(), cli.verbose)?;
             0
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1268,16 +1268,14 @@ fn run_fallback(parse_error: clap::Error) -> Result<i32> {
                 };
 
                 let filtered = core::toml_filter::apply_filter(filter, &combined_raw);
-                println!("{}", filtered);
-                if let Some(hint) = tee_hint {
-                    println!("{}", hint);
-                }
+                let shown =
+                    core::runner::emit_guarded(&filtered, tee_hint.as_deref(), &combined_raw);
 
                 timer.track(
                     &raw_command,
                     &format!("rtk:toml {}", raw_command),
                     &combined_raw,
-                    &filtered,
+                    &shown,
                 );
                 core::tracking::record_parse_failure_silent(&raw_command, &error_message, true);
 

--- a/tests/guard_integration_test.rs
+++ b/tests/guard_integration_test.rs
@@ -1,0 +1,151 @@
+//! End-to-end proof of the never-worse guard (src/core/guard.rs).
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn rtk_stdin(args: &[&str], input: &str) -> String {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn rtk");
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(input.as_bytes())
+        .expect("write stdin");
+    let out = child.wait_with_output().expect("wait rtk");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+#[test]
+fn guard_shows_raw_when_filter_would_bloat_tiny_input() {
+    let input = "{\"a\":1,\"b\":2,\"c\":3,\"d\":4}";
+    let out = rtk_stdin(&["json", "-"], input);
+
+    assert_eq!(
+        out.trim(),
+        input,
+        "guard should emit the raw minified JSON, not a larger pretty-printed form"
+    );
+    assert!(
+        out.trim().len() <= input.len(),
+        "never-worse violated: {} chars emitted for a {}-char raw input",
+        out.trim().len(),
+        input.len()
+    );
+}
+
+#[test]
+fn guard_does_not_block_real_compression() {
+    let mut input = String::from("{");
+    for i in 0..60 {
+        input.push_str(&format!("\"key_{i}\":\"value_{i}\","));
+    }
+    input.push_str("\"last\":1}");
+
+    let out = rtk_stdin(&["json", "-"], &input);
+    assert!(
+        out.len() < input.len(),
+        "filter should compress large input (guard must not over-trigger): {} vs {}",
+        out.len(),
+        input.len()
+    );
+}
+
+fn rtk_in_dir(dir: &std::path::Path, args: &[&str]) -> (String, Option<i32>) {
+    let out = Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args(args)
+        .current_dir(dir)
+        .stderr(Stdio::null())
+        .output()
+        .expect("spawn rtk");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        out.status.code(),
+    )
+}
+
+fn rg_available() -> bool {
+    Command::new("rg")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn init_git_repo() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    for args in [
+        &["init", "-q"][..],
+        &["config", "user.email", "t@t.t"][..],
+        &["config", "user.name", "t"][..],
+        &["commit", "-q", "--allow-empty", "-m", "init"][..],
+    ] {
+        let ok = Command::new("git")
+            .args(args)
+            .current_dir(dir.path())
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        assert!(ok, "git setup failed: {args:?}");
+    }
+    dir
+}
+
+#[test]
+fn grep_no_match_emits_empty_not_a_message() {
+    if !rg_available() {
+        return;
+    }
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("a.txt"), "hello world\n").expect("write");
+    let (out, code) = rtk_in_dir(dir.path(), &["grep", "zzz_no_match_xyz", "."]);
+    assert!(
+        out.trim().is_empty(),
+        "no-match grep must emit empty, not a '0 matches' line: {out:?}"
+    );
+    assert_eq!(code, Some(1), "grep no-match must preserve exit 1");
+}
+
+#[test]
+fn find_no_results_emits_empty() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("a.txt"), "x").expect("write");
+    let (out, _) = rtk_in_dir(dir.path(), &["find", ".", "-name", "zzz_no_match_xyz"]);
+    assert!(
+        out.trim().is_empty(),
+        "no-result find must emit empty, not a '0 for' line: {out:?}"
+    );
+}
+
+#[test]
+fn git_stash_list_no_stashes_emits_empty() {
+    let dir = init_git_repo();
+    let (out, code) = rtk_in_dir(dir.path(), &["git", "stash", "list"]);
+    assert!(
+        out.trim().is_empty(),
+        "no-stashes must emit empty, not 'No stashes': {out:?}"
+    );
+    assert_eq!(code, Some(0));
+}
+
+#[test]
+fn git_stash_show_no_stash_emits_empty_and_propagates_failure() {
+    // Regression: previously printed "Empty stash" and returned Ok(0), masking
+    // the underlying `git stash show` failure.
+    let dir = init_git_repo();
+    let (out, code) = rtk_in_dir(dir.path(), &["git", "stash", "show"]);
+    assert!(
+        out.trim().is_empty(),
+        "must emit empty, not 'Empty stash': {out:?}"
+    );
+    assert_ne!(
+        code,
+        Some(0),
+        "a real git stash show failure must not be masked as exit 0"
+    );
+}


### PR DESCRIPTION
## Summary

Never-worse guard so RTK never emits more tokens than the command the agent ran. `core::guard::never_worse(raw, filtered)` returns `raw` when `filtered` is larger — and is applied only where `filtered` is a structural compression of a **faithfully captured** `raw` (the agent's exact command + args, nothing added, no extra process).

`never_worse` stays **pure** (empty `raw` → empty). Guard concerns that involve *execution* (a baseline run failing) are fixed in the execution layer, not by weakening the guard.

## What's guarded (faithful `raw`, compress-only)

- **Shared sink**: `runner::emit_guarded` / `print_with_hint` compose body + tee hint and guard the whole; `run_captured_filter` covers the `run_filtered*` family.
- **TOML filters**  one central guard site (project / `.rtk` / global / built-in).
- **read**  `raw` made faithful to `cat` / `cat -n` (line numbers are faithful to the command, so they're compared like-for-like, not dropped).
- **pipe**  stdin filter mode now guarded.
- **aws**  JSON subcommands already guarded; the two **s3 text** paths (`s3 ls`, `s3 sync/cp`) now route through `emit_guarded` too (#2551 class).
- **docker** (`ps` / `ps -a` / `images`) — **the agent's command is now authoritative**: it ran a plain command for `raw` and a separate `--format` command for parsing, capturing the plain run with `unwrap_or_default()`; a failed plain run while `--format` succeeded left `raw` empty and `never_worse("", summary)` dropped real output. Now the real command is the source of truth (faithful failure on error), `--format` is a best-effort parse aid that falls back to `raw`, and the guard always sees a real baseline. Parsers unchanged.
- **grep** — rebased onto develop's grep rewrite (#2550), re-applying our no-result rule: a genuine no-match emits **empty** (like real `grep`), never a `0 matches` line that exceeds empty `raw`.

## Deferred — separate "adds-info" follow-up (out of scope: these emit data the command never produced / run an extra process)

- **git add** — `git add` is silent; RTK runs an extra `git diff --cached --stat` to synthesize an `ok N files…` summary (guarding it would suppress the summary).
- **dotnet** — injects `-bl`/`--logger` and reads a binlog the agent's command never produced.
- **git status / git show** — same authoritative-command restructure as docker (two-run today); higher risk because porcelain drops the rebase/merge state header, so done carefully and separately.

## Documented exceptions (unguardable by design)

- **streaming** (`tsc`, `gradlew`, `cargo`) — no full buffer exists mid-stream; safe by construction (subset emit + bounded flush).
- **proxy / passthrough** — `output == raw` by definition.

## Related
- Resolves #2551.
- Generalizes the grep-specific guard from #2550 (now merged from develop).

## Test plan
- [x] `fmt` + `clippy` + `cargo test --all` — green (2259 passed).
- [x] guard unit + integration tests; empty-raw / no-match regressions.
- [x] docker authoritative-command verified live (`ps` / `ps -a` / `images`); aws s3 + pipe + read + env covered.
- [x] develop merged; grep conflict resolved (develop's rewrite + our no-match→empty).
