### PR TITLE
Preserve pipeline input while rewriting safe shell commands

### DIFF
--- a/src/discover/README.md
+++ b/src/discover/README.md
@@ -21,11 +21,11 @@ When a hook sends `cargo fmt --all && cargo test 2>&1 | tail -20`:
 → [Arg("cargo"), Arg("test"), Redirect("2>&1"), Operator("&&"), Arg("git"), Arg("status")]
 ```
 
-**Compound splitting** — The rewrite engine walks the tokens, splitting on `Operator` (`&&`, `||`, `;`) and typed `Pipe` tokens (`|`, `|&`). For normal pipelines, producers and intermediate stages stay raw, and only an argument-safe final stage marked `pipeline_final_safe` is rewritten. The initial safe set is ordinary `grep` and `rg` invocations; search pattern-file forms (`-f`/`--file`) defer because they can consume pipeline stdin as configuration. Stderr pipelines (`|&`) and pipelines containing opaque shell groups remain raw.
+**Compound splitting** — The rewrite engine walks the tokens, splitting on `Operator` (`&&`, `||`, `;`) and typed `Pipe` tokens (`|`, `|&`). A content-sensitive consumer such as `grep`, `rg`, or `tee` keeps the producer's raw output, while a stdin-only display tail such as `head -5`, `tail -20`, or `cat` permits the producer to be routed through RTK. Stderr pipelines (`|&`) and pipelines containing opaque shell groups remain raw.
 
 **Per-segment rewriting** — Each segment goes through:
 
-1. Strip trailing redirects (`2>&1`, `>/dev/null`) — matched via lexer tokens, set aside, re-appended after rewriting
+1. Strip safe trailing output routing (`2>&1`, `>/dev/null`) — matched via lexer tokens, set aside, and re-appended after rewriting; file targets remain in the core so the permission policy can require an ask
 2. Short-circuit special cases — `head -20 file` → `rtk read file --max-lines 20`, `tail -n 5 file` → `rtk read file --tail-lines 5`. These can't go through generic prefix replacement because it would produce `rtk read -20 file` (wrong flag position)
 3. Classify the command — strip env prefixes (`sudo`, `FOO="bar baz"`), normalize paths (`/usr/bin/grep` → `grep`), strip git global opts (`git -C /tmp` → `git`), then match against 60+ regex patterns from `rules.rs`
 4. Apply the rewrite — find the matching rule, replace the command prefix with `rtk <cmd>`, re-prepend the env prefix, re-append the redirect suffix

--- a/src/discover/lexer.rs
+++ b/src/discover/lexer.rs
@@ -543,19 +543,32 @@ fn is_shell_control_keyword(value: &str) -> bool {
     )
 }
 
-/// True for constructs the permission gate can't decompose, so they must never
-/// be auto-allowed: command/process substitution, or a real file-target redirect
-/// (fd-dup like `2>&1` and `/dev/null` are exempt). Separators and subshells are
-/// handled by [`split_for_permissions`], not flagged here.
-pub fn contains_unattestable_construct(cmd: &str) -> bool {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UnattestableConstruct {
+    Substitution,
+    FileTargetRedirect,
+}
+
+/// Returns the first construct the permission gate cannot decompose. These
+/// constructs must never be auto-allowed: command/process substitution, or a
+/// real file-target redirect. Separators and subshells are handled by
+/// [`split_for_permissions`].
+pub(crate) fn first_unattestable_construct(cmd: &str) -> Option<UnattestableConstruct> {
     if contains_substitution(cmd) {
-        return true;
+        return Some(UnattestableConstruct::Substitution);
     }
     let tokens = tokenize(cmd);
     tokens
         .iter()
         .enumerate()
         .any(|(i, tok)| tok.kind == TokenKind::Redirect && redirect_has_file_target(&tokens, i))
+        .then_some(UnattestableConstruct::FileTargetRedirect)
+}
+
+/// True for constructs the permission gate cannot decompose, so they must never
+/// be auto-allowed.
+pub fn contains_unattestable_construct(cmd: &str) -> bool {
+    first_unattestable_construct(cmd).is_some()
 }
 
 /// Quote-aware: bash runs backtick/`$(...)` unquoted and inside double quotes,
@@ -612,13 +625,18 @@ fn contains_substitution(cmd: &str) -> bool {
 
 // `>&N`/`>&-` (and `N>&M`) is fd-dup/close; bare `>&` before a word is
 // `>word 2>&1` — a file target.
+pub(super) fn redirect_is_fd_dup_or_close(value: &str) -> bool {
+    let Some(pos) = value.find(">&") else {
+        return false;
+    };
+    let tail = &value[pos + 2..];
+    !tail.is_empty() && tail.chars().all(|c| c.is_ascii_digit() || c == '-')
+}
+
 fn redirect_has_file_target(tokens: &[ParsedToken], i: usize) -> bool {
     let value = &tokens[i].value;
-    if let Some(pos) = value.find(">&") {
-        let tail = &value[pos + 2..];
-        if !tail.is_empty() && tail.chars().all(|c| c.is_ascii_digit() || c == '-') {
-            return false;
-        }
+    if redirect_is_fd_dup_or_close(value) {
+        return false;
     }
     match tokens.get(i + 1) {
         Some(next) if next.kind == TokenKind::Arg => next.value != "/dev/null",

--- a/src/discover/lexer.rs
+++ b/src/discover/lexer.rs
@@ -22,13 +22,53 @@ pub struct ParsedToken {
     pub offset: usize,
 }
 
+#[derive(Default)]
+struct LexerState {
+    quote: Option<char>,
+    escaped: bool,
+    in_comment: bool,
+    at_word_start: bool,
+    at_command_start: bool,
+    case_header: bool,
+    in_case: bool,
+    case_pattern: bool,
+}
+
+impl LexerState {
+    fn new() -> Self {
+        Self {
+            at_word_start: true,
+            at_command_start: true,
+            ..Default::default()
+        }
+    }
+
+    fn flush_word(&mut self, tokens: &mut Vec<ParsedToken>, current: &mut String, offset: usize) {
+        if !current.is_empty() {
+            self.record_shell_keyword(current);
+        }
+        flush_arg(tokens, current, offset);
+    }
+
+    fn record_shell_keyword(&mut self, word: &str) {
+        if self.at_command_start && word == "case" {
+            self.case_header = true;
+        } else if self.case_header && word == "in" {
+            self.case_header = false;
+            self.in_case = true;
+            self.case_pattern = true;
+        } else if self.in_case && self.at_command_start && word == "esac" {
+            self.in_case = false;
+            self.case_pattern = false;
+        }
+        self.at_command_start = false;
+    }
+}
+
 pub fn tokenize(input: &str) -> Vec<ParsedToken> {
     tokenize_inner(input, false)
 }
 
-/// Like [`tokenize`] but emits a `\n` operator token for each newline that
-/// sits outside quotes. Newlines inside quoted strings stay part of their
-/// argument, so callers can use the emitted offsets as safe line-split points.
 pub fn tokenize_with_newlines(input: &str) -> Vec<ParsedToken> {
     tokenize_inner(input, true)
 }
@@ -39,21 +79,50 @@ fn tokenize_inner(input: &str, emit_newline: bool) -> Vec<ParsedToken> {
     let mut current_start: usize = 0;
     let mut byte_pos: usize = 0;
     let mut chars = input.chars().peekable();
-    let mut quote: Option<char> = None;
-    let mut escaped = false;
+    let mut state = LexerState::new();
 
     while let Some(c) = chars.next() {
         let char_len = c.len_utf8();
 
-        if escaped {
+        if state.in_comment {
+            if matches!(c, '\n' | '\r') {
+                state.in_comment = false;
+                if emit_newline {
+                    let start = byte_pos;
+                    let mut value = c.to_string();
+                    byte_pos += char_len;
+                    if c == '\r' && chars.peek() == Some(&'\n') {
+                        chars.next();
+                        value.push('\n');
+                        byte_pos += 1;
+                    }
+                    tokens.push(ParsedToken {
+                        kind: TokenKind::Operator,
+                        value,
+                        offset: start,
+                    });
+                } else {
+                    byte_pos += char_len;
+                }
+                current_start = byte_pos;
+                state.at_word_start = true;
+                state.at_command_start = true;
+            } else {
+                byte_pos += char_len;
+            }
+            continue;
+        }
+
+        if state.escaped {
             current.push('\\');
             current.push(c);
             byte_pos += char_len;
-            escaped = false;
+            state.escaped = false;
+            state.at_word_start = false;
             continue;
         }
-        if c == '\\' && quote != Some('\'') {
-            escaped = true;
+        if c == '\\' && state.quote != Some('\'') {
+            state.escaped = true;
             if current.is_empty() {
                 current_start = byte_pos;
             }
@@ -61,16 +130,17 @@ fn tokenize_inner(input: &str, emit_newline: bool) -> Vec<ParsedToken> {
             continue;
         }
 
-        if let Some(q) = quote {
+        if let Some(q) = state.quote {
             if c == q {
-                quote = None;
+                state.quote = None;
             }
             current.push(c);
             byte_pos += char_len;
+            state.at_word_start = false;
             continue;
         }
         if c == '\'' || c == '"' {
-            quote = Some(c);
+            state.quote = Some(c);
             if current.is_empty() {
                 current_start = byte_pos;
             }
@@ -80,8 +150,14 @@ fn tokenize_inner(input: &str, emit_newline: bool) -> Vec<ParsedToken> {
         }
 
         match c {
+            '#' if state.at_word_start => {
+                state.in_comment = true;
+                byte_pos += char_len;
+                current_start = byte_pos;
+                state.at_word_start = true;
+            }
             '$' => {
-                flush_arg(&mut tokens, &mut current, current_start);
+                state.flush_word(&mut tokens, &mut current, current_start);
                 let start = byte_pos;
                 byte_pos += char_len;
                 if chars
@@ -110,9 +186,10 @@ fn tokenize_inner(input: &str, emit_newline: bool) -> Vec<ParsedToken> {
                     });
                 }
                 current_start = byte_pos;
+                state.at_word_start = false;
             }
-            '*' | '?' | '`' | '(' | ')' | '{' | '}' | '!' => {
-                flush_arg(&mut tokens, &mut current, current_start);
+            ')' if state.case_pattern => {
+                state.flush_word(&mut tokens, &mut current, current_start);
                 tokens.push(ParsedToken {
                     kind: TokenKind::Shellism,
                     value: c.to_string(),
@@ -120,9 +197,35 @@ fn tokenize_inner(input: &str, emit_newline: bool) -> Vec<ParsedToken> {
                 });
                 byte_pos += char_len;
                 current_start = byte_pos;
+                state.at_word_start = true;
+                state.at_command_start = true;
+                state.case_pattern = false;
+            }
+            '*' | '?' | '`' | '(' | ')' | '{' | '}' | '!' => {
+                state.flush_word(&mut tokens, &mut current, current_start);
+                tokens.push(ParsedToken {
+                    kind: TokenKind::Shellism,
+                    value: c.to_string(),
+                    offset: byte_pos,
+                });
+                byte_pos += char_len;
+                current_start = byte_pos;
+                state.at_word_start = false;
+                if matches!(c, '(' | '{') {
+                    state.at_command_start = true;
+                }
             }
             '|' => {
-                flush_arg(&mut tokens, &mut current, current_start);
+                if state.case_pattern {
+                    if current.is_empty() {
+                        current_start = byte_pos;
+                    }
+                    current.push(c);
+                    byte_pos += char_len;
+                    state.at_word_start = false;
+                    continue;
+                }
+                state.flush_word(&mut tokens, &mut current, current_start);
                 let start = byte_pos;
                 byte_pos += char_len;
                 if chars.peek() == Some(&'|') {
@@ -149,19 +252,31 @@ fn tokenize_inner(input: &str, emit_newline: bool) -> Vec<ParsedToken> {
                     });
                 }
                 current_start = byte_pos;
+                state.at_word_start = true;
+                state.at_command_start = true;
             }
             ';' => {
-                flush_arg(&mut tokens, &mut current, current_start);
+                state.flush_word(&mut tokens, &mut current, current_start);
+                let start = byte_pos;
+                let mut value = c.to_string();
+                byte_pos += char_len;
+                if state.in_case && chars.peek() == Some(&';') {
+                    chars.next();
+                    value.push(';');
+                    byte_pos += 1;
+                    state.case_pattern = true;
+                }
                 tokens.push(ParsedToken {
                     kind: TokenKind::Operator,
-                    value: ";".into(),
-                    offset: byte_pos,
+                    value,
+                    offset: start,
                 });
-                byte_pos += char_len;
                 current_start = byte_pos;
+                state.at_word_start = true;
+                state.at_command_start = true;
             }
             '&' => {
-                flush_arg(&mut tokens, &mut current, current_start);
+                state.flush_word(&mut tokens, &mut current, current_start);
                 let start = byte_pos;
                 byte_pos += char_len;
                 if chars.peek() == Some(&'&') {
@@ -194,13 +309,15 @@ fn tokenize_inner(input: &str, emit_newline: bool) -> Vec<ParsedToken> {
                     });
                 }
                 current_start = byte_pos;
+                state.at_word_start = true;
+                state.at_command_start = true;
             }
             '>' => {
                 let fd_prefix =
                     if !current.is_empty() && current.chars().all(|ch| ch.is_ascii_digit()) {
                         Some(std::mem::take(&mut current))
                     } else {
-                        flush_arg(&mut tokens, &mut current, current_start);
+                        state.flush_word(&mut tokens, &mut current, current_start);
                         None
                     };
                 let redir_start = if fd_prefix.is_some() {
@@ -235,9 +352,10 @@ fn tokenize_inner(input: &str, emit_newline: bool) -> Vec<ParsedToken> {
                     offset: redir_start,
                 });
                 current_start = byte_pos;
+                state.at_word_start = true;
             }
             '<' => {
-                flush_arg(&mut tokens, &mut current, current_start);
+                state.flush_word(&mut tokens, &mut current, current_start);
                 let start = byte_pos;
                 let mut val = String::from("<");
                 byte_pos += char_len;
@@ -252,9 +370,29 @@ fn tokenize_inner(input: &str, emit_newline: bool) -> Vec<ParsedToken> {
                     offset: start,
                 });
                 current_start = byte_pos;
+                state.at_word_start = true;
             }
-            '\n' | '\r' if emit_newline => {
-                flush_arg(&mut tokens, &mut current, current_start);
+            '\r' if emit_newline => {
+                state.flush_word(&mut tokens, &mut current, current_start);
+                let start = byte_pos;
+                let mut value = c.to_string();
+                byte_pos += char_len;
+                if chars.peek() == Some(&'\n') {
+                    chars.next();
+                    value.push('\n');
+                    byte_pos += 1;
+                }
+                tokens.push(ParsedToken {
+                    kind: TokenKind::Operator,
+                    value,
+                    offset: start,
+                });
+                current_start = byte_pos;
+                state.at_word_start = true;
+                state.at_command_start = true;
+            }
+            '\n' if emit_newline => {
+                state.flush_word(&mut tokens, &mut current, current_start);
                 tokens.push(ParsedToken {
                     kind: TokenKind::Operator,
                     value: "\n".into(),
@@ -262,11 +400,14 @@ fn tokenize_inner(input: &str, emit_newline: bool) -> Vec<ParsedToken> {
                 });
                 byte_pos += char_len;
                 current_start = byte_pos;
+                state.at_word_start = true;
+                state.at_command_start = true;
             }
             c if c.is_whitespace() => {
-                flush_arg(&mut tokens, &mut current, current_start);
+                state.flush_word(&mut tokens, &mut current, current_start);
                 byte_pos += c.len_utf8();
                 current_start = byte_pos;
+                state.at_word_start = true;
             }
             _ => {
                 if current.is_empty() {
@@ -274,14 +415,15 @@ fn tokenize_inner(input: &str, emit_newline: bool) -> Vec<ParsedToken> {
                 }
                 current.push(c);
                 byte_pos += char_len;
+                state.at_word_start = false;
             }
         }
     }
 
-    if escaped {
+    if state.escaped {
         current.push('\\');
     }
-    flush_arg(&mut tokens, &mut current, current_start);
+    state.flush_word(&mut tokens, &mut current, current_start);
     tokens
 }
 
@@ -293,6 +435,112 @@ fn flush_arg(tokens: &mut Vec<ParsedToken>, current: &mut String, offset: usize)
             offset,
         });
     }
+}
+
+/// Returns `true` when the input contains a top-level shell boundary that can
+/// separate commands. Newlines are included because an AI hook can receive a
+/// complete command list rather than one physical line.
+pub(super) fn contains_compound_boundary_tokens(tokens: &[ParsedToken]) -> bool {
+    tokens.iter().any(|token| {
+        matches!(token.kind, TokenKind::Operator | TokenKind::Pipe(_))
+            || (token.kind == TokenKind::Shellism && token.value == "&")
+    })
+}
+
+/// Control-flow blocks are parsed by the shell, not by the command registry.
+/// Rewriting one inner command would risk changing conditions, loop status, or
+/// case-pattern syntax, so callers preserve the complete block verbatim.
+pub(super) fn contains_shell_block(cmd: &str) -> bool {
+    contains_shell_block_tokens(&tokenize_with_newlines(cmd))
+}
+
+pub(super) fn contains_shell_block_tokens(tokens: &[ParsedToken]) -> bool {
+    let mut command_start = true;
+    let mut substitution_depth = 0usize;
+    let mut dollar_before_paren = false;
+    let mut close_paren = false;
+    for token in tokens {
+        match token.kind {
+            TokenKind::Arg => {
+                if substitution_depth == 0
+                    && command_start
+                    && is_shell_control_keyword(token.value.as_str())
+                {
+                    return true;
+                }
+                command_start = false;
+                close_paren = false;
+            }
+            TokenKind::Operator | TokenKind::Pipe(_) => {
+                command_start = true;
+                close_paren = false;
+            }
+            TokenKind::Shellism => match token.value.as_str() {
+                "$" => dollar_before_paren = true,
+                "(" if dollar_before_paren => {
+                    substitution_depth += 1;
+                    dollar_before_paren = false;
+                }
+                "(" if command_start => {
+                    return true;
+                }
+                "(" => {
+                    command_start = false;
+                    close_paren = false;
+                    dollar_before_paren = false;
+                }
+                ")" if substitution_depth > 0 => {
+                    substitution_depth -= 1;
+                    dollar_before_paren = false;
+                }
+                "!" => return true,
+                "{" if command_start || close_paren => return true,
+                "{" => {
+                    command_start = false;
+                    close_paren = false;
+                    dollar_before_paren = false;
+                }
+                "}" if command_start => return true,
+                "}" => {
+                    command_start = false;
+                    close_paren = false;
+                    dollar_before_paren = false;
+                }
+                ")" => {
+                    close_paren = true;
+                    command_start = false;
+                    dollar_before_paren = false;
+                }
+                _ => {
+                    dollar_before_paren = false;
+                    command_start = false;
+                    close_paren = false;
+                }
+            },
+            TokenKind::Redirect => {}
+        }
+    }
+    false
+}
+
+fn is_shell_control_keyword(value: &str) -> bool {
+    matches!(
+        value,
+        "case"
+            | "do"
+            | "done"
+            | "elif"
+            | "else"
+            | "esac"
+            | "fi"
+            | "for"
+            | "function"
+            | "if"
+            | "select"
+            | "then"
+            | "until"
+            | "while"
+    )
 }
 
 /// True for constructs the permission gate can't decompose, so they must never
@@ -316,20 +564,45 @@ fn contains_substitution(cmd: &str) -> bool {
     let bytes = cmd.as_bytes();
     let mut in_single = false;
     let mut in_double = false;
+    let mut in_comment = false;
+    let mut at_word_start = true;
     let mut i = 0;
     while i < bytes.len() {
+        if in_comment {
+            if matches!(bytes[i], b'\n' | b'\r') {
+                in_comment = false;
+                at_word_start = true;
+            }
+            i += 1;
+            continue;
+        }
         match bytes[i] {
             b'\\' if !in_single => {
                 i += 2;
+                at_word_start = false;
                 continue;
             }
-            b'\'' if !in_double => in_single = !in_single,
-            b'"' if !in_single => in_double = !in_double,
+            b'\'' if !in_double => {
+                in_single = !in_single;
+                at_word_start = false;
+            }
+            b'"' if !in_single => {
+                in_double = !in_double;
+                at_word_start = false;
+            }
+            b'#' if !in_single && !in_double && at_word_start => {
+                in_comment = true;
+                i += 1;
+                continue;
+            }
             b'`' if !in_single => return true,
             b'$' if !in_single && bytes.get(i + 1) == Some(&b'(') => return true,
             b'<' | b'>' if !in_single && !in_double && bytes.get(i + 1) == Some(&b'(') => {
                 return true
             }
+            b' ' | b'\t' | b'\n' | b'\r' if !in_single && !in_double => at_word_start = true,
+            b';' | b'|' | b'&' if !in_single && !in_double => at_word_start = true,
+            _ if !in_single && !in_double => at_word_start = false,
             _ => {}
         }
         i += 1;
@@ -367,7 +640,7 @@ pub fn split_for_permissions(cmd: &str) -> Vec<&str> {
     let mut seg_start: usize = 0;
     let mut seg_end: Option<usize> = None;
 
-    for tok in &tokens {
+    for tok in tokens {
         let is_boundary = match tok.kind {
             TokenKind::Operator | TokenKind::Pipe(_) => true,
             TokenKind::Shellism => matches!(tok.value.as_str(), "&" | "(" | ")"),
@@ -408,11 +681,19 @@ pub fn split_on_operators(cmd: &str, stop_at_pipe: bool) -> Vec<&str> {
         return vec![];
     }
 
-    let tokens = tokenize(trimmed);
+    let tokens = tokenize_with_newlines(trimmed);
+    split_on_operator_tokens(trimmed, &tokens, stop_at_pipe)
+}
+
+pub(super) fn split_on_operator_tokens<'a>(
+    trimmed: &'a str,
+    tokens: &[ParsedToken],
+    stop_at_pipe: bool,
+) -> Vec<&'a str> {
     let mut results = Vec::new();
     let mut seg_start: usize = 0;
 
-    for tok in &tokens {
+    for tok in tokens {
         match tok.kind {
             TokenKind::Operator => {
                 let segment = trimmed[seg_start..tok.offset].trim();
@@ -1185,6 +1466,59 @@ mod tests {
     }
 
     #[test]
+    fn test_split_on_operators_newline_boundaries() {
+        assert_eq!(
+            split_on_operators("git status\ngit log", false),
+            vec!["git status", "git log"]
+        );
+        assert_eq!(
+            split_on_operators("git status\r\ngit log", false),
+            vec!["git status", "git log"]
+        );
+    }
+
+    #[test]
+    fn test_comments_hide_operator_text() {
+        let tokens = tokenize("git status # && cargo test | grep hidden");
+        assert!(
+            !tokens
+                .iter()
+                .any(|token| { matches!(token.kind, TokenKind::Operator | TokenKind::Pipe(_)) }),
+            "comment text must not create shell boundaries: {tokens:?}"
+        );
+    }
+
+    #[test]
+    fn test_hash_comment_requires_unquoted_word_boundary() {
+        let tokens = tokenize("echo \"# |\" \\# foo#bar # && hidden");
+        assert!(tokens.iter().any(|token| token.value == "\"# |\""));
+        assert!(tokens.iter().any(|token| token.value == "\\#"));
+        assert!(tokens.iter().any(|token| token.value == "foo#bar"));
+        assert!(!tokens
+            .iter()
+            .any(|token| matches!(token.kind, TokenKind::Operator | TokenKind::Pipe(_))));
+    }
+
+    #[test]
+    fn test_escaped_newline_is_not_a_command_boundary() {
+        assert_eq!(
+            split_on_operators("git status \\\ngit log", false),
+            vec!["git status \\\ngit log"]
+        );
+    }
+
+    #[test]
+    fn test_case_pattern_alternatives_are_not_pipelines() {
+        let tokens = tokenize("case \"$mode\" in fast|safe) git status;; esac");
+        assert!(
+            !tokens
+                .iter()
+                .any(|token| matches!(token.kind, TokenKind::Pipe(_))),
+            "case alternatives must not be classified as pipelines: {tokens:?}"
+        );
+    }
+
+    #[test]
     fn test_split_on_operators_empty() {
         assert!(split_on_operators("", false).is_empty());
         assert!(split_on_operators("  ", true).is_empty());
@@ -1348,18 +1682,5 @@ mod tests {
     fn test_split_perms_empty() {
         assert!(split_for_permissions("").is_empty());
         assert!(split_for_permissions("   ").is_empty());
-    }
-
-    #[test]
-    fn test_tokenize_with_newlines_emits_operator_outside_quotes_only() {
-        let newline_ops = |input: &str| {
-            tokenize_with_newlines(input)
-                .iter()
-                .filter(|t| t.kind == TokenKind::Operator && t.value == "\n")
-                .count()
-        };
-        assert_eq!(newline_ops("git status\ngit log"), 1);
-        assert_eq!(newline_ops("echo 'line1\nline2'"), 0);
-        assert_eq!(newline_ops("git status\r\ngit log"), 2);
     }
 }

--- a/src/discover/mod.rs
+++ b/src/discover/mod.rs
@@ -5,6 +5,7 @@ pub mod provider;
 pub mod registry;
 mod report;
 pub mod rules;
+mod suffix;
 
 use anyhow::Result;
 use std::collections::HashMap;

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use std::sync::LazyLock;
 
 use super::lexer::{
+    contains_compound_boundary_tokens, contains_shell_block, contains_shell_block_tokens,
     shell_split, split_on_operators, tokenize, tokenize_with_newlines, ParsedToken, PipeKind,
     TokenKind,
 };
@@ -244,9 +245,13 @@ fn extract_base_command(cmd: &str) -> &str {
 
 /// Quote-aware heredoc detection — `<<` inside quotes is not a heredoc.
 pub fn has_heredoc(cmd: &str) -> bool {
-    tokenize(cmd)
+    has_heredoc_tokens(&tokenize(cmd))
+}
+
+fn has_heredoc_tokens(tokens: &[ParsedToken]) -> bool {
+    tokens
         .iter()
-        .any(|t| t.kind == TokenKind::Redirect && t.value.starts_with("<<"))
+        .any(|token| token.kind == TokenKind::Redirect && token.value.starts_with("<<"))
 }
 
 pub fn split_command_chain(cmd: &str) -> Vec<&str> {
@@ -256,7 +261,7 @@ pub fn split_command_chain(cmd: &str) -> Vec<&str> {
     }
 
     // Lexer-based for `<<`; string-based for `$((` (lexer splits it across tokens).
-    if has_heredoc(trimmed) || trimmed.contains("$((") {
+    if has_heredoc(trimmed) || contains_shell_block(trimmed) || trimmed.contains("$((") {
         return vec![trimmed];
     }
 
@@ -590,7 +595,11 @@ pub fn rewrite_command(
         return None;
     }
 
-    if has_heredoc(trimmed) || trimmed.contains("$((") {
+    let tokens = tokenize_with_newlines(trimmed);
+    if has_heredoc_tokens(&tokens)
+        || contains_shell_block_tokens(&tokens)
+        || trimmed.contains("$((")
+    {
         return None;
     }
 
@@ -598,10 +607,16 @@ pub fn rewrite_command(
     let normalized_prefixes = normalize_transparent_prefixes(transparent_prefixes);
 
     if trimmed.contains('\n') {
-        return rewrite_multiline_block(trimmed, &compiled, &normalized_prefixes);
+        return rewrite_multiline_block(trimmed, &tokens, &compiled, &normalized_prefixes);
     }
 
-    rewrite_single(trimmed, &compiled, &normalized_prefixes)
+    if !contains_compound_boundary_tokens(&tokens)
+        && (trimmed.starts_with("rtk ") || trimmed == "rtk")
+    {
+        return Some(trimmed.to_string());
+    }
+
+    rewrite_compound(trimmed, &tokens, &compiled, &normalized_prefixes)
 }
 
 /// Rewrite one logical command line (no unquoted newlines).
@@ -613,16 +628,14 @@ fn rewrite_single(
     // Simple (non-compound) already-RTK command — return as-is.
     // For compound commands that start with "rtk" (e.g. "rtk git add . && cargo test"),
     // fall through to rewrite_compound so the remaining segments get rewritten.
-    let has_compound = trimmed.contains("&&")
-        || trimmed.contains("||")
-        || trimmed.contains(';')
-        || trimmed.contains('|')
-        || trimmed.contains(" & ");
-    if !has_compound && (trimmed.starts_with("rtk ") || trimmed == "rtk") {
+    let tokens = tokenize_with_newlines(trimmed);
+    if !contains_compound_boundary_tokens(&tokens)
+        && (trimmed.starts_with("rtk ") || trimmed == "rtk")
+    {
         return Some(trimmed.to_string());
     }
 
-    rewrite_compound(trimmed, excluded, transparent_prefixes)
+    rewrite_compound(trimmed, &tokens, excluded, transparent_prefixes)
 }
 
 /// Shell keywords that open or close a multi-line construct. A line inside a
@@ -839,10 +852,11 @@ fn classify_line(line: &str) -> LineRole {
 /// messages) also land here; forgoing that rewrite is the safe trade.
 fn rewrite_multiline_block(
     cmd: &str,
+    tokens: &[ParsedToken],
     excluded: &[ExcludePattern],
     transparent_prefixes: &[String],
 ) -> Option<String> {
-    let newline_offsets: Vec<usize> = tokenize_with_newlines(cmd)
+    let newline_offsets: Vec<usize> = tokens
         .iter()
         .filter(|t| t.kind == TokenKind::Operator && t.value == "\n")
         .map(|t| t.offset)
@@ -1034,10 +1048,10 @@ fn rewrite_pipeline_final_stage(
 /// Rewrite a compound command (with `&&`, `||`, `;`, `|`) by rewriting each segment.
 fn rewrite_compound(
     cmd: &str,
+    tokens: &[ParsedToken],
     excluded: &[ExcludePattern],
     transparent_prefixes: &[String],
 ) -> Option<String> {
-    let tokens = tokenize(cmd);
     let has_pipe = tokens
         .iter()
         .any(|token| matches!(token.kind, TokenKind::Pipe(_)));
@@ -1052,7 +1066,7 @@ fn rewrite_compound(
     let mut any_changed = false;
     let mut seg_start: usize = 0;
 
-    for tok in &tokens {
+    for tok in tokens {
         if tok.offset < seg_start {
             continue;
         }
@@ -1082,7 +1096,7 @@ fn rewrite_compound(
                 }
             }
             TokenKind::Pipe(_) => {
-                let analysis = analyze_pipeline(cmd, &tokens, seg_start, tok.offset);
+                let analysis = analyze_pipeline(cmd, tokens, seg_start, tok.offset);
                 let pipeline = cmd[seg_start..analysis.end_offset].trim();
                 let rewritten_pipeline = rewrite_pipeline_final_stage(
                     cmd,

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -7,10 +7,11 @@ use std::sync::LazyLock;
 
 use super::lexer::{
     contains_compound_boundary_tokens, contains_shell_block, contains_shell_block_tokens,
-    shell_split, split_on_operators, tokenize, tokenize_with_newlines, ParsedToken, PipeKind,
-    TokenKind,
+    first_unattestable_construct, split_on_operators, tokenize, tokenize_with_newlines,
+    ParsedToken, PipeKind, TokenKind, UnattestableConstruct,
 };
 use super::rules::{IGNORED_EXACT, IGNORED_PREFIXES, RULES};
+use super::suffix::split_rewrite_suffix;
 
 const PHP_TOOL_NAMES: [&str; 6] = ["phpunit", "phpstan", "ecs", "pest", "paratest", "pint"];
 
@@ -27,6 +28,12 @@ pub enum Classification {
         base_command: String,
     },
     Ignored,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RewriteResult {
+    pub(crate) command: String,
+    pub(crate) requires_ask: bool,
 }
 
 /// Average token counts per category for estimation when no output_len available.
@@ -497,42 +504,6 @@ pub fn strip_disabled_prefix(cmd: &str) -> (&str, &str) {
     (prefix_part, rest)
 }
 
-fn strip_trailing_redirects(cmd: &str) -> (&str, &str) {
-    let tokens = tokenize(cmd);
-    if tokens.is_empty() {
-        return (cmd, "");
-    }
-
-    let mut redir_boundary = tokens.len();
-    let mut i = tokens.len();
-    while i > 0 {
-        i -= 1;
-        match tokens[i].kind {
-            TokenKind::Redirect => {
-                redir_boundary = i;
-            }
-            TokenKind::Arg => {
-                if i > 0 && tokens[i - 1].kind == TokenKind::Redirect {
-                    redir_boundary = i - 1;
-                    i -= 1;
-                } else {
-                    break;
-                }
-            }
-            _ => break,
-        }
-    }
-
-    if redir_boundary >= tokens.len() {
-        return (cmd, "");
-    }
-
-    let cut = tokens[redir_boundary].offset;
-    let cmd_part = cmd[..cut].trim_end();
-    let redir_part = &cmd[cmd_part.len()..];
-    (cmd_part, redir_part)
-}
-
 /// Matches a bash line-continuation: a backslash immediately followed by
 /// `\n` or `\r\n`, *plus* any horizontal whitespace on the line before AND
 /// after the break. This is what bash already collapses to a single space
@@ -956,7 +927,23 @@ fn rewrite_multiline_block(
     }
 }
 
-/// Pipeline boundaries used to rewrite its final stage.
+pub(crate) fn rewrite_command_with_policy(
+    cmd: &str,
+    excluded: &[String],
+    transparent_prefixes: &[String],
+) -> Option<RewriteResult> {
+    let command = rewrite_command(cmd, excluded, transparent_prefixes)?;
+    Some(RewriteResult {
+        command,
+        requires_ask: matches!(
+            first_unattestable_construct(cmd),
+            Some(UnattestableConstruct::FileTargetRedirect)
+        ),
+    })
+}
+
+/// Pipeline boundaries used to preserve a complete shell pipeline while
+/// deciding whether its producer can be safely routed through RTK.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct PipelineAnalysis {
     end_offset: usize,
@@ -1018,31 +1005,84 @@ fn analyze_pipeline(
     }
 }
 
-fn rewrite_pipeline_final_stage(
-    cmd: &str,
-    segment_start: usize,
-    analysis: PipelineAnalysis,
-    excluded: &[ExcludePattern],
-    transparent_prefixes: &[String],
-) -> Option<String> {
-    let final_stage_start = analysis.final_stage_start?;
-    let final_stage = cmd[final_stage_start..analysis.end_offset].trim();
+fn pipe_tail_accepts_filtered_output(
+    tokens: &[ParsedToken],
+    pipe_offset: usize,
+    end_offset: usize,
+) -> bool {
+    let Some(mut idx) = tokens.iter().position(|token| token.offset == pipe_offset) else {
+        return false;
+    };
+    let mut saw_stage = false;
 
-    rewrite_segment_inner(
-        final_stage,
-        excluded,
-        transparent_prefixes,
-        RewriteContext::PipelineFinal,
-        0,
-    )
-    .filter(|rewritten| rewritten != final_stage)
-    .map(|rewritten| {
-        format!(
-            "{} {}",
-            cmd[segment_start..final_stage_start].trim(),
-            rewritten
-        )
-    })
+    while idx < tokens.len() && tokens[idx].offset < end_offset {
+        if tokens[idx].kind != TokenKind::Pipe(PipeKind::Stdout) {
+            return false;
+        }
+        idx += 1;
+
+        if idx >= tokens.len()
+            || tokens[idx].offset >= end_offset
+            || tokens[idx].kind != TokenKind::Arg
+        {
+            return false;
+        }
+        let command = strip_absolute_path(&tokens[idx].value);
+        idx += 1;
+
+        let args_start = idx;
+        while idx < tokens.len()
+            && tokens[idx].offset < end_offset
+            && !matches!(tokens[idx].kind, TokenKind::Pipe(_))
+        {
+            if tokens[idx].kind != TokenKind::Arg {
+                return false;
+            }
+            idx += 1;
+        }
+
+        let accepts = match command.as_str() {
+            "head" | "tail" => head_tail_reads_stdin_only(&tokens[args_start..idx]),
+            "cat" => idx == args_start,
+            _ => false,
+        };
+        if !accepts {
+            return false;
+        }
+        saw_stage = true;
+    }
+
+    saw_stage
+}
+
+fn head_tail_reads_stdin_only(args: &[ParsedToken]) -> bool {
+    let mut idx = 0;
+    while idx < args.len() {
+        match args[idx].value.as_str() {
+            "-n" | "--lines" => {
+                idx += 1;
+                if idx >= args.len() || !is_decimal_count(&args[idx].value) {
+                    return false;
+                }
+            }
+            value if is_short_line_count(value) || is_long_line_count(value) => {}
+            _ => return false,
+        }
+        idx += 1;
+    }
+    true
+}
+
+fn is_short_line_count(value: &str) -> bool {
+    value.strip_prefix('-').is_some_and(is_decimal_count)
+}
+
+fn is_long_line_count(value: &str) -> bool {
+    value.strip_prefix("--lines=").is_some_and(is_decimal_count)
+}
+
+fn is_decimal_count(value: &str) -> bool {
+    !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit())
 }
 
 /// Rewrite a compound command (with `&&`, `||`, `;`, `|`) by rewriting each segment.
@@ -1097,20 +1137,22 @@ fn rewrite_compound(
             }
             TokenKind::Pipe(_) => {
                 let analysis = analyze_pipeline(cmd, tokens, seg_start, tok.offset);
-                let pipeline = cmd[seg_start..analysis.end_offset].trim();
-                let rewritten_pipeline = rewrite_pipeline_final_stage(
-                    cmd,
-                    seg_start,
-                    analysis,
-                    excluded,
-                    transparent_prefixes,
-                );
-
-                if let Some(rewritten) = rewritten_pipeline {
-                    any_changed = true;
-                    result.push_str(&rewritten);
+                let seg = cmd[seg_start..tok.offset].trim();
+                let pipe_tail = cmd[tok.offset..analysis.end_offset].trim();
+                let rewritten = if analysis.final_stage_start.is_some()
+                    && pipe_tail_accepts_filtered_output(tokens, tok.offset, analysis.end_offset)
+                {
+                    rewrite_segment(seg, excluded, transparent_prefixes)
                 } else {
-                    result.push_str(pipeline);
+                    None
+                };
+                if rewritten.as_deref().is_some_and(|command| command != seg) {
+                    any_changed = true;
+                }
+                result.push_str(rewritten.as_deref().unwrap_or(seg));
+                if !pipe_tail.is_empty() {
+                    result.push(' ');
+                    result.push_str(pipe_tail);
                 }
 
                 match analysis.next_clause_offset {
@@ -1201,32 +1243,6 @@ fn builtin_transparent_prefixes() -> impl Iterator<Item = (&'static str, bool)> 
 
 const MAX_PREFIX_DEPTH: usize = 10;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum RewriteContext {
-    Normal,
-    PipelineFinal,
-}
-
-/// Checks whether grep or rg reads patterns from a file.
-fn search_uses_pattern_file(cmd: &str) -> bool {
-    shell_split(cmd)
-        .into_iter()
-        .skip(1)
-        .take_while(|arg| arg != "--")
-        .any(|arg| {
-            arg == "--file"
-                || arg.starts_with("--file=")
-                || arg
-                    .strip_prefix('-')
-                    .filter(|flags| !flags.starts_with('-'))
-                    .is_some_and(|flags| flags.contains('f'))
-        })
-}
-
-fn pipeline_final_command_is_safe(rtk_cmd: &str, cmd: &str) -> bool {
-    !matches!(rtk_cmd, "rtk grep" | "rtk rg") || !search_uses_pattern_file(cmd)
-}
-
 enum ExcludePattern {
     Regex(Regex),
     Prefix(String),
@@ -1282,13 +1298,7 @@ fn rewrite_segment(
     excluded: &[ExcludePattern],
     transparent_prefixes: &[String],
 ) -> Option<String> {
-    rewrite_segment_inner(
-        seg,
-        excluded,
-        transparent_prefixes,
-        RewriteContext::Normal,
-        0,
-    )
+    rewrite_segment_inner(seg, excluded, transparent_prefixes, 0)
 }
 
 fn is_excluded(cmd: &str, excluded: &[ExcludePattern]) -> bool {
@@ -1302,7 +1312,6 @@ fn rewrite_segment_inner(
     seg: &str,
     excluded: &[ExcludePattern],
     transparent_prefixes: &[String],
-    context: RewriteContext,
     depth: usize,
 ) -> Option<String> {
     let trimmed = seg.trim();
@@ -1325,13 +1334,8 @@ fn rewrite_segment_inner(
             );
             return None;
         }
-        let rewritten = rewrite_segment_inner(
-            rest_after_env,
-            excluded,
-            transparent_prefixes,
-            context,
-            depth + 1,
-        )?;
+        let rewritten =
+            rewrite_segment_inner(rest_after_env, excluded, transparent_prefixes, depth + 1)?;
         return Some(format!("{}{}", env_prefix, rewritten));
     }
 
@@ -1341,7 +1345,7 @@ fn rewrite_segment_inner(
                 return None;
             }
             if let Some(rewritten) =
-                rewrite_segment_inner(rest, excluded, transparent_prefixes, context, depth + 1)
+                rewrite_segment_inner(rest, excluded, transparent_prefixes, depth + 1)
             {
                 return Some(format!("{} {}", prefix, rewritten));
             }
@@ -1361,24 +1365,26 @@ fn rewrite_segment_inner(
             if rest.is_empty() {
                 return None;
             }
-            return rewrite_segment_inner(rest, excluded, transparent_prefixes, context, depth + 1)
+            return rewrite_segment_inner(rest, excluded, transparent_prefixes, depth + 1)
                 .map(|rewritten| format!("{} {}", prefix, rewritten));
         }
     }
 
-    // Strip trailing stderr/stdout redirects before matching (#530)
-    // e.g. "git status 2>&1" → match "git status", re-append " 2>&1"
-    let (cmd_part, redirect_suffix) = strip_trailing_redirects(trimmed);
+    // Strip safe trailing output redirects before matching, then reattach the
+    // original bytes. File targets remain in the core for conservative routing
+    // and are classified by the shared permission gate.
+    let suffix = split_rewrite_suffix(trimmed);
+    let cmd_part = suffix.core;
+    let redirect_suffix = suffix.suffix;
 
     // Already RTK — pass through unchanged
     if cmd_part.starts_with("rtk ") || cmd_part == "rtk" {
         return Some(trimmed.to_string());
     }
 
-    if context == RewriteContext::Normal
-        && (cmd_part.starts_with("head -") || cmd_part.starts_with("tail "))
-    {
-        return rewrite_line_range(cmd_part).map(|r| format!("{}{}", r, redirect_suffix));
+    if cmd_part.starts_with("head -") || cmd_part.starts_with("tail ") {
+        return rewrite_line_range(cmd_part)
+            .map(|command| format!("{}{}", command, redirect_suffix));
     }
 
     // Most cat flags (-v, -A, -e, -t, -s, -b, --show-all, etc.) have different
@@ -1403,9 +1409,6 @@ fn rewrite_segment_inner(
         }
         // TOML-only commands: consult the registry so the hook filters them too (#2179).
         Classification::Unsupported { .. } => {
-            if context == RewriteContext::PipelineFinal {
-                return None;
-            }
             if crate::core::toml_filter::toml_disabled() {
                 return None;
             }
@@ -1427,12 +1430,6 @@ fn rewrite_segment_inner(
 
     // Find the matching rule (rtk_cmd values are unique across all rules)
     let rule = RULES.iter().find(|r| r.rtk_cmd == rtk_equivalent)?;
-    if context == RewriteContext::PipelineFinal
-        && (!rule.pipeline_final_safe || !pipeline_final_command_is_safe(rule.rtk_cmd, cmd_part))
-    {
-        return None;
-    }
-
     if let Some(parts) = parse_golangci_run_parts(cmd_part) {
         let rewritten = if parts.global_segment.is_empty() {
             format!("rtk golangci-lint {}", parts.run_segment)
@@ -1884,34 +1881,6 @@ mod tests {
             cmd[analysis.final_stage_start.unwrap()..analysis.end_offset].trim(),
             "grep FAILED"
         );
-    }
-
-    #[test]
-    fn test_pipeline_final_safe_rule_set() {
-        let safe_rules: Vec<_> = RULES
-            .iter()
-            .filter(|rule| rule.pipeline_final_safe)
-            .map(|rule| rule.rtk_cmd)
-            .collect();
-
-        assert_eq!(safe_rules, vec!["rtk grep", "rtk rg"]);
-    }
-
-    #[test]
-    fn test_pipeline_final_search_pattern_file_is_unsafe() {
-        for command in [
-            "grep -f patterns.txt input.txt",
-            "grep -rfpatterns.txt input",
-            "grep --file patterns.txt input.txt",
-            "grep --file=patterns.txt input.txt",
-            "rg -f patterns.txt input.txt",
-            "rg --file=patterns.txt input.txt",
-        ] {
-            assert!(search_uses_pattern_file(command), "{command}");
-        }
-
-        assert!(!search_uses_pattern_file("grep -- -f"));
-        assert!(!search_uses_pattern_file("grep -F pattern"));
     }
 
     #[test]
@@ -2432,10 +2401,10 @@ mod tests {
     }
 
     #[test]
-    fn test_rewrite_toml_pipe_rewrites_only_safe_final() {
+    fn test_rewrite_toml_pipe_preserves_raw_consumer() {
         assert_eq!(
             rewrite_command_no_prefixes("jj log | grep change", &[]),
-            Some("jj log | rtk grep change".into())
+            None
         );
     }
 
@@ -2610,11 +2579,18 @@ mod tests {
     }
 
     #[test]
-    fn test_rewrite_pipe_final_safe_stage_only() {
-        assert_eq!(
-            rewrite_command_no_prefixes("git log -10 | grep feat", &[]),
-            Some("git log -10 | rtk grep feat".into())
-        );
+    fn test_rewrite_pipe_preserves_raw_consumer() {
+        for command in [
+            "git log -10 | grep feat",
+            "git log -10 | rg feat",
+            "git log -10 | tee /tmp/log.txt",
+        ] {
+            assert_eq!(
+                rewrite_command_no_prefixes(command, &[]),
+                None,
+                "content-sensitive consumer must keep raw producer output: {command}"
+            );
+        }
     }
 
     #[test]
@@ -2644,10 +2620,10 @@ mod tests {
     }
 
     #[test]
-    fn test_rewrite_pipe_unsafe_final_stage_stays_raw() {
+    fn test_rewrite_pipe_recovers_display_tail_rewrite() {
         assert_eq!(
             rewrite_command_no_prefixes("cargo test | tail -50", &[]),
-            None
+            Some("rtk cargo test | tail -50".into())
         );
         assert_eq!(
             rewrite_command_no_prefixes("find . | xargs grep TODO", &[]),
@@ -2846,7 +2822,7 @@ mod tests {
     fn test_rewrite_redirect_2_gt_amp_1_with_pipe() {
         assert_eq!(
             rewrite_command_no_prefixes("cargo test 2>&1 | grep FAILED", &[]),
-            Some("cargo test 2>&1 | rtk grep FAILED".into())
+            None
         );
     }
 
@@ -2856,6 +2832,22 @@ mod tests {
             rewrite_command_no_prefixes("cargo test 2>&1", &[]),
             Some("rtk cargo test 2>&1".into())
         );
+    }
+
+    #[test]
+    fn test_file_redirect_requires_ask_in_any_rewritten_clause() {
+        for command in [
+            "git status > /tmp/status.log",
+            "git status && git log > /tmp/log.txt",
+            "git log > /tmp/log.txt | head -5",
+        ] {
+            let result = rewrite_command_with_policy(command, &[], &[])
+                .expect("command should still have a rewrite");
+            assert!(
+                result.requires_ask,
+                "file redirect must be ask-only: {command}"
+            );
+        }
     }
 
     #[test]
@@ -4562,10 +4554,10 @@ mod tests {
 
     #[test]
     fn test_rewrite_compound_pipe_raw_filter() {
-        // Producers stay raw; only a pipeline-safe final stage is rewritten.
+        // Content-sensitive consumers must receive the producer's raw output.
         assert_eq!(
             rewrite_command_no_prefixes("cargo test | grep FAILED", &[]),
-            Some("cargo test | rtk grep FAILED".into())
+            None
         );
     }
 
@@ -4573,7 +4565,7 @@ mod tests {
     fn test_rewrite_compound_pipe_git_grep() {
         assert_eq!(
             rewrite_command_no_prefixes("git log -10 | grep feat", &[]),
-            Some("git log -10 | rtk grep feat".into())
+            None
         );
     }
 
@@ -5307,7 +5299,7 @@ mod tests {
     fn test_rewrite_pipe_then_and() {
         assert_eq!(
             rewrite_command_no_prefixes("git log | head -5 && git stash", &[]),
-            Some("git log | head -5 && rtk git stash".into())
+            Some("rtk git log | head -5 && rtk git stash".into())
         );
     }
 
@@ -5315,7 +5307,7 @@ mod tests {
     fn test_rewrite_pipe_then_semicolon() {
         assert_eq!(
             rewrite_command_no_prefixes("cargo test | head; git status", &[]),
-            Some("cargo test | head; rtk git status".into())
+            Some("rtk cargo test | head; rtk git status".into())
         );
     }
 
@@ -5323,7 +5315,7 @@ mod tests {
     fn test_rewrite_pipe_then_or() {
         assert_eq!(
             rewrite_command_no_prefixes("cargo test | grep FAIL || git stash", &[]),
-            Some("cargo test | rtk grep FAIL || rtk git stash".into())
+            Some("cargo test | grep FAIL || rtk git stash".into())
         );
     }
 
@@ -5334,7 +5326,7 @@ mod tests {
                 "RUST_BACKTRACE=1 cargo test 2>&1 | grep FAILED && git stash",
                 &[]
             ),
-            Some("RUST_BACKTRACE=1 cargo test 2>&1 | rtk grep FAILED && rtk git stash".into())
+            Some("RUST_BACKTRACE=1 cargo test 2>&1 | grep FAILED && rtk git stash".into())
         );
     }
 
@@ -5342,7 +5334,7 @@ mod tests {
     fn test_rewrite_and_then_pipe() {
         assert_eq!(
             rewrite_command_no_prefixes("git status && cargo test | grep FAIL", &[]),
-            Some("rtk git status && cargo test | rtk grep FAIL".into())
+            Some("rtk git status && cargo test | grep FAIL".into())
         );
     }
 
@@ -5350,15 +5342,15 @@ mod tests {
     fn test_rewrite_multi_pipe_then_and() {
         assert_eq!(
             rewrite_command_no_prefixes("git log | head | tail && git status", &[]),
-            Some("git log | head | tail && rtk git status".into())
+            Some("rtk git log | head | tail && rtk git status".into())
         );
     }
 
     #[test]
-    fn test_rewrite_pipeline_final_normalizes_prefixes() {
+    fn test_rewrite_pipeline_wrappers_preserve_raw_consumer() {
         assert_eq!(
             rewrite_command_no_prefixes("cargo test | FOO=1 command grep FAILED", &[]),
-            Some("cargo test | FOO=1 command rtk grep FAILED".into())
+            None
         );
         assert_eq!(
             super::rewrite_command(
@@ -5366,7 +5358,7 @@ mod tests {
                 &[],
                 &["docker exec tools".into()]
             ),
-            Some("cargo test | docker exec tools rtk grep FAILED".into())
+            None
         );
     }
 

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -668,9 +668,10 @@ impl Iterator for QuoteScan<'_> {
 }
 
 /// Byte offset where an unquoted `#` at the start of a word begins a trailing
-/// comment, if any. The lexer has no comment state, so the independence checks
-/// must ignore comment text themselves: `git log | # keep pipeline` continues
-/// the pipeline across the newline even though the line ends in comment text.
+/// comment, if any. Comments are deliberately omitted from the token stream,
+/// so the independence checks must ignore comment text themselves: `git log |
+/// # keep pipeline` continues the pipeline across the newline even though the
+/// line ends in comment text.
 fn comment_start(line: &str) -> Option<usize> {
     let bytes = line.as_bytes();
     // `#` starts a comment at any word start, incl. after an operator
@@ -815,32 +816,37 @@ fn classify_line(line: &str) -> LineRole {
 /// and the original separator bytes (`\n` vs `\r\n`).
 ///
 /// If any newline byte was swallowed by quote state, the block passes through
-/// untouched. The lexer has no comment awareness, so an apostrophe in a `#`
-/// comment opens quote state and hides the rest of the block — rewriting (or
-/// prefixing) such a block would act on lines no permission verdict was
-/// computed for. Passthrough hands the original command to the agent's native
-/// permission handling instead. Genuine quoted newlines (multi-line commit
-/// messages) also land here; forgoing that rewrite is the safe trade.
+/// untouched. Comment text is excluded from quote tracking by the lexer, so an
+/// apostrophe in a `#` comment does not hide following commands; the original
+/// comment bytes remain attached to the rewritten line. Genuine quoted
+/// newlines (multi-line commit messages) still land here; forgoing that rewrite
+/// is the safe trade.
 fn rewrite_multiline_block(
     cmd: &str,
     tokens: &[ParsedToken],
     excluded: &[ExcludePattern],
     transparent_prefixes: &[String],
 ) -> Option<String> {
-    let newline_offsets: Vec<usize> = tokens
+    let newline_offsets: Vec<(usize, usize)> = tokens
         .iter()
-        .filter(|t| t.kind == TokenKind::Operator && t.value == "\n")
-        .map(|t| t.offset)
+        .filter(|token| {
+            token.kind == TokenKind::Operator && matches!(token.value.as_str(), "\n" | "\r\n")
+        })
+        .map(|token| (token.offset, token.value.len()))
         .collect();
 
     if ansi_c_quote_defeats_lexer(cmd) {
         return None;
     }
 
-    // The lexer emits one newline token per `\r` and per `\n` (CRLF = two
-    // tokens), so the parity check must count both bytes individually.
-    let raw_breaks = cmd.chars().filter(|c| matches!(c, '\n' | '\r')).count();
-    if raw_breaks != newline_offsets.len() {
+    // Compare byte lengths rather than token counts: a CRLF is one token with
+    // two bytes, while a newline inside an unmatched quote emits no token.
+    let raw_break_bytes = cmd
+        .bytes()
+        .filter(|byte| matches!(byte, b'\n' | b'\r'))
+        .count();
+    let token_break_bytes: usize = newline_offsets.iter().map(|(_, len)| *len).sum();
+    if raw_break_bytes != token_break_bytes {
         // Every newline swallowed by quote state with quotes balanced at EOF
         // is one logical command (a multi-line commit message), not a hidden
         // extra line; rewrite it whole, as develop always did (#3319 fuzz).
@@ -852,9 +858,9 @@ fn rewrite_multiline_block(
 
     let mut segments = Vec::with_capacity(newline_offsets.len() + 1);
     let mut start = 0;
-    for &off in &newline_offsets {
+    for &(off, len) in &newline_offsets {
         segments.push((start, &cmd[start..off]));
-        start = off + 1;
+        start = off + len;
     }
     segments.push((start, &cmd[start..]));
 
@@ -871,8 +877,8 @@ fn rewrite_multiline_block(
     let mut i = 0;
     while i < segments.len() {
         if i > 0 {
-            let off = newline_offsets[i - 1];
-            result.push_str(&cmd[off..off + 1]);
+            let (off, len) = newline_offsets[i - 1];
+            result.push_str(&cmd[off..off + len]);
         }
         let (seg_off, seg) = segments[i];
 
@@ -907,14 +913,30 @@ fn rewrite_multiline_block(
             let (last_off, last_seg) = segments[end];
             &cmd[seg_off..last_off + last_seg.len()]
         };
-        let line = unit.trim();
-        match rewrite_single(line, excluded, transparent_prefixes) {
-            Some(rewritten) if rewritten != line => {
+        let line = if end == i {
+            std::borrow::Cow::Borrowed(seg.trim())
+        } else {
+            let mut joined = String::new();
+            for (_, segment) in &segments[i..=end] {
+                let segment = segment.trim();
+                if segment.is_empty() {
+                    continue;
+                }
+                if !joined.is_empty() {
+                    joined.push(' ');
+                }
+                joined.push_str(segment);
+            }
+            std::borrow::Cow::Owned(joined)
+        };
+        match rewrite_single(line.as_ref(), excluded, transparent_prefixes) {
+            Some(rewritten) if rewritten != line.as_ref() => {
                 any_changed = true;
                 let indent = &seg[..seg.len() - seg.trim_start().len()];
                 result.push_str(indent);
                 result.push_str(&rewritten);
             }
+            None if end > i => return None,
             _ => result.push_str(unit),
         }
         i = end + 1;
@@ -1581,24 +1603,22 @@ mod tests {
         }
 
         #[test]
-        fn test_comment_apostrophe_swallowing_newline_passes_through() {
-            // The lexer has no comment state: the apostrophe in `don't` opens
-            // a quote that swallows the newline and hides the next line. The
-            // block must pass through so native permission handling sees the
-            // original command — never a partially rewritten one.
+        fn test_comment_apostrophe_is_ignored_and_preserved() {
+            // An apostrophe in a comment is not shell syntax. The lexer must
+            // rewrite executable text while preserving the comment verbatim.
             assert_eq!(
                 rewrite_command_no_prefixes("git status # don't\nrm -rf /tmp/x", &[]),
-                None
+                Some("rtk git status # don't\nrm -rf /tmp/x".into())
             );
         }
 
         #[test]
-        fn test_comment_apostrophe_hidden_in_later_segment_passes_through() {
-            // Same hazard when a clean split point precedes the contaminated
-            // line: the swallowed-newline check is global, not per-segment.
+        fn test_comment_apostrophe_is_preserved_after_prior_rewrite() {
+            // A comment later in the block must not prevent safe earlier or
+            // same-line rewrites, and its bytes must remain unchanged.
             assert_eq!(
                 rewrite_command_no_prefixes("git log -3\ngit status # don't\nrm -rf /tmp/x", &[]),
-                None
+                Some("rtk git log -3\nrtk git status # don't\nrm -rf /tmp/x".into())
             );
         }
 
@@ -1734,14 +1754,18 @@ mod tests {
         }
 
         #[test]
-        fn test_cross_line_pipeline_joins_and_rewrites() {
+        fn test_cross_line_pipeline_preserves_raw_consumer() {
             assert_eq!(
                 rewrite_command_no_prefixes("git log |\ngrep feat", &[]),
-                Some("git log | rtk grep feat".into())
+                None
             );
             assert_eq!(
                 rewrite_command_no_prefixes("cargo test |&\ngrep FAILED", &[]),
                 None
+            );
+            assert_eq!(
+                rewrite_command_no_prefixes("git log |\nhead -5", &[]),
+                Some("rtk git log | head -5".into())
             );
         }
 

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1319,6 +1319,15 @@ fn rewrite_segment_inner(
         return None;
     }
 
+    // Keep substitution-bearing segments verbatim. Their nested shell code
+    // cannot be safely routed through a command rule at this level.
+    if matches!(
+        first_unattestable_construct(trimmed),
+        Some(UnattestableConstruct::Substitution)
+    ) {
+        return None;
+    }
+
     if depth >= MAX_PREFIX_DEPTH {
         return None;
     }
@@ -5041,7 +5050,7 @@ mod tests {
     fn test_rewrite_command_substitution_passthrough() {
         assert_eq!(
             rewrite_command_no_prefixes("git log $(git rev-parse HEAD~1)", &[]),
-            Some("rtk git log $(git rev-parse HEAD~1)".into())
+            None
         );
     }
 

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -3,8 +3,6 @@ use super::report::RtkStatus;
 pub struct RtkRule {
     pub pattern: &'static str,
     pub rtk_cmd: &'static str,
-    /// Whether this command may be rewritten as the final pipeline stage.
-    pub pipeline_final_safe: bool,
     pub rewrite_prefixes: &'static [&'static str],
     pub category: &'static str,
     pub savings_pct: f64,
@@ -20,7 +18,6 @@ impl RtkRule {
     pub const DEFAULT: RtkRule = RtkRule {
         pattern: "",
         rtk_cmd: "",
-        pipeline_final_safe: false,
         rewrite_prefixes: &[],
         category: "",
         savings_pct: 60.0,
@@ -76,7 +73,6 @@ pub const RULES: &[RtkRule] = &[
         savings_pct: 80.0,
         subcmd_savings: &[("test", 90.0), ("check", 80.0)],
         subcmd_status: &[("fmt", RtkStatus::Passthrough)],
-        ..RtkRule::DEFAULT
     },
     RtkRule {
         pattern: r"^pnpm\s+(exec|i|install|list|ls|outdated|run|run-script)",
@@ -112,7 +108,6 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^grep\s+",
         rtk_cmd: "rtk grep",
-        pipeline_final_safe: true,
         rewrite_prefixes: &["grep"],
         category: "Files",
         savings_pct: 75.0,
@@ -121,7 +116,6 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^rg\s+",
         rtk_cmd: "rtk rg",
-        pipeline_final_safe: true,
         rewrite_prefixes: &["rg"],
         category: "Files",
         savings_pct: 75.0,

--- a/src/discover/suffix.rs
+++ b/src/discover/suffix.rs
@@ -1,0 +1,113 @@
+//! Lexer-backed suffix handling for shell output routing that can be safely
+//! reattached after a command rewrite.
+
+use super::lexer::{redirect_is_fd_dup_or_close, tokenize, ParsedToken, TokenKind};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct RewriteSuffix<'a> {
+    pub(super) core: &'a str,
+    pub(super) suffix: &'a str,
+}
+
+/// Split trailing output routing while preserving the original text. Input
+/// redirects stay in the core so callers reject them conservatively; the shared
+/// lexer permission classifier decides whether an output target needs approval.
+pub(super) fn split_rewrite_suffix(cmd: &str) -> RewriteSuffix<'_> {
+    let tokens = tokenize(cmd);
+    let mut boundary = tokens.len();
+    let mut idx = tokens.len();
+
+    while idx > 0 {
+        let token = &tokens[idx - 1];
+        match token.kind {
+            TokenKind::Redirect => {
+                let Some(consumes_target) = redirect_consumes_target(&tokens, idx - 1) else {
+                    break;
+                };
+                if consumes_target {
+                    break;
+                }
+                boundary = idx - 1;
+                idx -= 1;
+            }
+            TokenKind::Arg if idx >= 2 && tokens[idx - 2].kind == TokenKind::Redirect => {
+                let Some(consumes_target) = redirect_consumes_target(&tokens, idx - 2) else {
+                    break;
+                };
+                if !consumes_target {
+                    break;
+                }
+                boundary = idx - 2;
+                idx -= 2;
+            }
+            _ => break,
+        }
+    }
+
+    if boundary == 0 || boundary >= tokens.len() {
+        return RewriteSuffix {
+            core: cmd,
+            suffix: "",
+        };
+    }
+
+    let cut = tokens[boundary].offset;
+    let core = cmd[..cut].trim_end();
+    RewriteSuffix {
+        core,
+        suffix: &cmd[core.len()..],
+    }
+}
+
+fn redirect_consumes_target(tokens: &[ParsedToken], idx: usize) -> Option<bool> {
+    let value = tokens[idx].value.as_str();
+
+    if value.starts_with('<') {
+        return None;
+    }
+    if redirect_is_fd_dup_or_close(value) {
+        return Some(false);
+    }
+    if !value.contains('>') {
+        return None;
+    }
+
+    let target = tokens.get(idx + 1)?;
+    (target.kind == TokenKind::Arg).then_some(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn split(cmd: &str) -> (&str, &str) {
+        let result = split_rewrite_suffix(cmd);
+        (result.core, result.suffix)
+    }
+
+    #[test]
+    fn preserves_output_suffixes_but_keeps_input_redirects_in_core() {
+        assert_eq!(
+            split("git status > /tmp/status.log 2>&1"),
+            ("git status", " > /tmp/status.log 2>&1")
+        );
+        assert_eq!(split("cat < /tmp/input"), ("cat < /tmp/input", ""));
+    }
+
+    #[test]
+    fn preserves_fd_dup_and_dev_null_suffixes() {
+        assert_eq!(split("git status 2>&1"), ("git status", " 2>&1"));
+        assert_eq!(
+            split("git status > /dev/null 2>&1"),
+            ("git status", " > /dev/null 2>&1")
+        );
+    }
+
+    #[test]
+    fn leaves_pipeline_tails_untouched() {
+        assert_eq!(
+            split("cargo test | tail -50"),
+            ("cargo test | tail -50", "")
+        );
+    }
+}

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -9,7 +9,8 @@ use anyhow::{Context, Result};
 use serde_json::{json, Value};
 use std::io::{self, Read, Write};
 
-use crate::discover::registry::{has_heredoc, rewrite_command};
+use crate::discover::lexer::{first_unattestable_construct, UnattestableConstruct};
+use crate::discover::registry::{has_heredoc, rewrite_command_with_policy, RewriteResult};
 
 const STDIN_CAP: usize = 1_048_576; // 1 MiB
 
@@ -145,7 +146,7 @@ fn detect_format(v: &Value) -> HookFormat {
     HookFormat::PassThrough
 }
 
-fn get_rewritten(cmd: &str) -> Option<String> {
+fn get_rewrite_result(cmd: &str) -> Option<RewriteResult> {
     if has_heredoc(cmd) {
         return None;
     }
@@ -154,13 +155,18 @@ fn get_rewritten(cmd: &str) -> Option<String> {
         .map(|c| (c.hooks.exclude_commands, c.hooks.transparent_prefixes))
         .unwrap_or_default();
 
-    let rewritten = rewrite_command(cmd, &excluded, &transparent_prefixes)?;
+    let rewritten = rewrite_command_with_policy(cmd, &excluded, &transparent_prefixes)?;
 
-    if rewritten == cmd {
+    if rewritten.command == cmd {
         return None;
     }
 
     Some(rewritten)
+}
+
+#[cfg(test)]
+fn get_rewritten(cmd: &str) -> Option<String> {
+    get_rewrite_result(cmd).map(|result| result.command)
 }
 
 enum HookDecision {
@@ -174,12 +180,14 @@ fn decide_from_verdict(cmd: &str, verdict: PermissionVerdict) -> HookDecision {
     if verdict == PermissionVerdict::Deny {
         return HookDecision::Deny;
     }
-    if crate::discover::lexer::contains_unattestable_construct(cmd) {
+    if first_unattestable_construct(cmd) == Some(UnattestableConstruct::Substitution) {
         return HookDecision::Defer;
     }
-    match get_rewritten(cmd) {
-        Some(r) if verdict == PermissionVerdict::Allow => HookDecision::AllowRewrite(r),
-        Some(r) => HookDecision::AskRewrite(r),
+    match get_rewrite_result(cmd) {
+        Some(r) if !r.requires_ask && verdict == PermissionVerdict::Allow => {
+            HookDecision::AllowRewrite(r.command)
+        }
+        Some(r) => HookDecision::AskRewrite(r.command),
         None => HookDecision::Defer,
     }
 }
@@ -1153,19 +1161,25 @@ mod tests {
     }
 
     #[test]
-    fn test_copilot_cli_cve_file_redirect_amp_returns_none() {
-        assert!(
-            end_to_end("git status >& /tmp/evil").is_none(),
-            ">&file redirect must not produce modifiedArgs"
+    fn test_copilot_cli_cve_file_redirect_amp_is_ask_rewrite() {
+        let response = end_to_end("git status >& /tmp/evil")
+            .expect("file redirect should produce an ask-only rewrite");
+        assert_eq!(
+            response["modifiedArgs"]["command"],
+            "rtk git status >& /tmp/evil"
         );
+        assert!(response.get("permissionDecision").is_none());
     }
 
     #[test]
-    fn test_copilot_cli_cve_file_redirect_returns_none() {
-        assert!(
-            end_to_end("git status > /tmp/evil").is_none(),
-            ">file redirect must not produce modifiedArgs"
+    fn test_copilot_cli_cve_file_redirect_is_ask_rewrite() {
+        let response = end_to_end("git status > /tmp/evil")
+            .expect("file redirect should produce an ask-only rewrite");
+        assert_eq!(
+            response["modifiedArgs"]["command"],
+            "rtk git status > /tmp/evil"
         );
+        assert!(response.get("permissionDecision").is_none());
     }
 
     // --- Gemini format ---
@@ -1291,8 +1305,18 @@ mod tests {
     }
 
     #[test]
-    fn test_claude_file_redirect_not_rewritten() {
-        assert!(run_claude_inner(&claude_input("git log > /tmp/out.txt")).is_none());
+    fn test_claude_file_redirect_is_ask_rewrite() {
+        let output = run_claude_inner(&claude_input("git log > /tmp/out.txt"))
+            .expect("file redirect should produce an ask-only rewrite");
+        let v: Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(
+            v.pointer("/hookSpecificOutput/updatedInput/command")
+                .and_then(|c| c.as_str()),
+            Some("rtk git log > /tmp/out.txt")
+        );
+        assert!(v
+            .pointer("/hookSpecificOutput/permissionDecision")
+            .is_none());
     }
 
     #[test]
@@ -1349,14 +1373,8 @@ mod tests {
     }
 
     #[test]
-    fn test_claude_pipeline_rewrites_only_safe_final_stage() {
-        let result = run_claude_inner(&claude_input("cargo test | grep FAILED")).unwrap();
-        let v: Value = serde_json::from_str(&result).unwrap();
-        let cmd = v
-            .pointer("/hookSpecificOutput/updatedInput/command")
-            .and_then(|c| c.as_str())
-            .unwrap();
-        assert_eq!(cmd, "cargo test | rtk grep FAILED");
+    fn test_claude_pipeline_preserves_raw_content_consumer() {
+        assert!(run_claude_inner(&claude_input("cargo test | grep FAILED")).is_none());
     }
 
     #[test]
@@ -1690,10 +1708,14 @@ mod tests {
     }
 
     #[test]
-    fn test_decide_defer_for_file_redirect() {
+    fn test_decide_ask_for_file_redirect() {
+        let decision = decide_with_rules("git log > /tmp/out.txt", &[], &[], &all_allowed());
         assert!(matches!(
-            decide_with_rules("git log > /tmp/out.txt", &[], &[], &all_allowed()),
-            HookDecision::Defer
+            decision,
+            HookDecision::AskRewrite {
+                rewritten,
+                explicit: true
+            } if rewritten == "rtk git log > /tmp/out.txt"
         ));
     }
 
@@ -1952,12 +1974,18 @@ mod tests {
     }
 
     #[test]
-    fn test_droid_file_redirect_defers() {
+    fn test_droid_file_redirect_is_ask_rewrite() {
         let input = droid_input("Execute", "git log > /tmp/out.txt");
-        assert!(
-            run_droid_inner(&input).is_none(),
-            "file redirects must defer (no output)"
+        let output = run_droid_inner(&input).expect("file redirect should produce a rewrite");
+        let v: Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(
+            v.pointer("/hookSpecificOutput/updatedInput/command")
+                .and_then(|c| c.as_str()),
+            Some("rtk git log > /tmp/out.txt")
         );
+        assert!(v
+            .pointer("/hookSpecificOutput/permissionDecision")
+            .is_none());
     }
 
     #[test]

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result};
 use serde_json::{json, Value};
 use std::io::{self, Read, Write};
 
-use crate::discover::lexer::{first_unattestable_construct, UnattestableConstruct};
+use crate::discover::lexer::first_unattestable_construct;
 use crate::discover::registry::{has_heredoc, rewrite_command_with_policy, RewriteResult};
 
 const STDIN_CAP: usize = 1_048_576; // 1 MiB
@@ -180,11 +180,9 @@ fn decide_from_verdict(cmd: &str, verdict: PermissionVerdict) -> HookDecision {
     if verdict == PermissionVerdict::Deny {
         return HookDecision::Deny;
     }
-    if first_unattestable_construct(cmd) == Some(UnattestableConstruct::Substitution) {
-        return HookDecision::Defer;
-    }
+    let attestable = first_unattestable_construct(cmd).is_none();
     match get_rewrite_result(cmd) {
-        Some(r) if !r.requires_ask && verdict == PermissionVerdict::Allow => {
+        Some(r) if attestable && !r.requires_ask && verdict == PermissionVerdict::Allow => {
             HookDecision::AllowRewrite(r.command)
         }
         Some(r) => HookDecision::AskRewrite(r.command),
@@ -1705,6 +1703,16 @@ mod tests {
                 "expected Defer for {cmd}"
             );
         }
+    }
+
+    #[test]
+    fn test_decide_ask_for_bundle_with_substitution_even_when_allowed() {
+        let command = "grep -rn foo src\nf=$(whoami)";
+        assert!(matches!(
+            decide_with_rules(command, &[], &[], &all_allowed()),
+            HookDecision::AskRewrite { rewritten, .. }
+                if rewritten == "rtk grep -rn foo src\nf=$(whoami)"
+        ));
     }
 
     #[test]

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -1710,7 +1710,7 @@ mod tests {
         let command = "grep -rn foo src\nf=$(whoami)";
         assert!(matches!(
             decide_with_rules(command, &[], &[], &all_allowed()),
-            HookDecision::AskRewrite { rewritten, .. }
+            HookDecision::AskRewrite(rewritten)
                 if rewritten == "rtk grep -rn foo src\nf=$(whoami)"
         ));
     }
@@ -1720,10 +1720,7 @@ mod tests {
         let decision = decide_with_rules("git log > /tmp/out.txt", &[], &[], &all_allowed());
         assert!(matches!(
             decision,
-            HookDecision::AskRewrite {
-                rewritten,
-                explicit: true
-            } if rewritten == "rtk git log > /tmp/out.txt"
+            HookDecision::AskRewrite(rewritten) if rewritten == "rtk git log > /tmp/out.txt"
         ));
     }
 

--- a/src/hooks/rewrite_cmd.rs
+++ b/src/hooks/rewrite_cmd.rs
@@ -1,7 +1,6 @@
 //! Translates a raw shell command into its RTK-optimized equivalent.
 
 use super::permissions::{check_command, PermissionVerdict};
-use crate::discover::lexer::{first_unattestable_construct, UnattestableConstruct};
 use crate::discover::registry::rewrite_command_with_policy;
 use std::io::Write;
 
@@ -60,12 +59,12 @@ fn evaluate_with_verdict(
         return RewriteOutcome::Deny;
     }
 
-    if first_unattestable_construct(cmd) == Some(UnattestableConstruct::Substitution) {
-        return RewriteOutcome::Passthrough;
-    }
+    let attestable = crate::discover::lexer::first_unattestable_construct(cmd).is_none();
 
     match rewrite_command_with_policy(cmd, excluded, transparent_prefixes) {
-        Some(rewritten) if !rewritten.requires_ask && verdict == PermissionVerdict::Allow => {
+        Some(rewritten)
+            if attestable && !rewritten.requires_ask && verdict == PermissionVerdict::Allow =>
+        {
             RewriteOutcome::Allow(rewritten.command)
         }
         Some(rewritten) => RewriteOutcome::Ask(rewritten.command),
@@ -75,6 +74,8 @@ fn evaluate_with_verdict(
 
 #[cfg(test)]
 mod tests {
+    use super::{evaluate_with_verdict, PermissionVerdict, RewriteOutcome};
+
     fn rewrite_command_no_prefixes(cmd: &str) -> Option<String> {
         crate::discover::registry::rewrite_command(cmd, &[], &[])
     }
@@ -95,6 +96,17 @@ mod tests {
             rewrite_command_no_prefixes("rtk git status"),
             Some("rtk git status".into())
         );
+    }
+
+    #[test]
+    fn test_bundle_with_substitution_rewrites_clean_statement_and_asks() {
+        let command = "grep -rn foo src\nf=$(whoami)";
+        match evaluate_with_verdict(command, &[], &[], PermissionVerdict::Allow) {
+            RewriteOutcome::Ask(rewritten) => {
+                assert_eq!(rewritten, "rtk grep -rn foo src\nf=$(whoami)");
+            }
+            other => panic!("expected an ask rewrite for an unattestable bundle, got {other:?}"),
+        }
     }
 
     mod unattestable_passthrough {

--- a/src/hooks/rewrite_cmd.rs
+++ b/src/hooks/rewrite_cmd.rs
@@ -1,7 +1,8 @@
 //! Translates a raw shell command into its RTK-optimized equivalent.
 
 use super::permissions::{check_command, PermissionVerdict};
-use crate::discover::registry;
+use crate::discover::lexer::{first_unattestable_construct, UnattestableConstruct};
+use crate::discover::registry::rewrite_command_with_policy;
 use std::io::Write;
 
 /// Run the `rtk rewrite` command.
@@ -46,30 +47,36 @@ enum RewriteOutcome {
 
 fn evaluate(cmd: &str, excluded: &[String], transparent_prefixes: &[String]) -> RewriteOutcome {
     let verdict = check_command(cmd);
+    evaluate_with_verdict(cmd, excluded, transparent_prefixes, verdict)
+}
 
+fn evaluate_with_verdict(
+    cmd: &str,
+    excluded: &[String],
+    transparent_prefixes: &[String],
+    verdict: PermissionVerdict,
+) -> RewriteOutcome {
     if verdict == PermissionVerdict::Deny {
         return RewriteOutcome::Deny;
     }
 
-    if crate::discover::lexer::contains_unattestable_construct(cmd) {
+    if first_unattestable_construct(cmd) == Some(UnattestableConstruct::Substitution) {
         return RewriteOutcome::Passthrough;
     }
 
-    match registry::rewrite_command(cmd, excluded, transparent_prefixes) {
-        Some(rewritten) => match verdict {
-            PermissionVerdict::Allow => RewriteOutcome::Allow(rewritten),
-            _ => RewriteOutcome::Ask(rewritten),
-        },
+    match rewrite_command_with_policy(cmd, excluded, transparent_prefixes) {
+        Some(rewritten) if !rewritten.requires_ask && verdict == PermissionVerdict::Allow => {
+            RewriteOutcome::Allow(rewritten.command)
+        }
+        Some(rewritten) => RewriteOutcome::Ask(rewritten.command),
         None => RewriteOutcome::Passthrough,
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     fn rewrite_command_no_prefixes(cmd: &str) -> Option<String> {
-        registry::rewrite_command(cmd, &[], &[])
+        crate::discover::registry::rewrite_command(cmd, &[], &[])
     }
 
     #[test]
@@ -91,12 +98,17 @@ mod tests {
     }
 
     mod unattestable_passthrough {
-        use super::super::{evaluate, RewriteOutcome};
+        use super::super::{evaluate_with_verdict, RewriteOutcome};
+        use crate::hooks::permissions::PermissionVerdict;
+
+        fn evaluate_default(cmd: &str) -> RewriteOutcome {
+            evaluate_with_verdict(cmd, &[], &[], PermissionVerdict::Default)
+        }
 
         #[test]
         fn test_backtick_substitution_passthrough() {
             assert_eq!(
-                evaluate("git status `rm -rf /tmp/x`", &[], &[]),
+                evaluate_default("git status `rm -rf /tmp/x`"),
                 RewriteOutcome::Passthrough
             );
         }
@@ -104,7 +116,7 @@ mod tests {
         #[test]
         fn test_dollar_substitution_passthrough() {
             assert_eq!(
-                evaluate("git status $(rm -rf /tmp/x)", &[], &[]),
+                evaluate_default("git status $(rm -rf /tmp/x)"),
                 RewriteOutcome::Passthrough
             );
         }
@@ -112,23 +124,23 @@ mod tests {
         #[test]
         fn test_double_quoted_substitution_passthrough() {
             assert_eq!(
-                evaluate("git log --pretty=\"$(rm -rf /tmp/x)\"", &[], &[]),
+                evaluate_default("git log --pretty=\"$(rm -rf /tmp/x)\""),
                 RewriteOutcome::Passthrough
             );
         }
 
         #[test]
-        fn test_file_redirect_passthrough() {
+        fn test_file_redirect_rewrites_as_ask() {
             assert_eq!(
-                evaluate("git log > /tmp/out.txt", &[], &[]),
-                RewriteOutcome::Passthrough
+                evaluate_default("git log > /tmp/out.txt"),
+                RewriteOutcome::Ask("rtk git log > /tmp/out.txt".into())
             );
         }
 
         #[test]
         fn test_fd_dup_redirect_still_rewrites() {
             assert!(matches!(
-                evaluate("git status 2>&1", &[], &[]),
+                evaluate_default("git status 2>&1"),
                 RewriteOutcome::Ask(_)
             ));
         }
@@ -136,7 +148,7 @@ mod tests {
         #[test]
         fn test_plain_command_still_rewrites() {
             assert!(matches!(
-                evaluate("git status", &[], &[]),
+                evaluate_default("git status"),
                 RewriteOutcome::Ask(_)
             ));
         }
@@ -155,7 +167,7 @@ mod tests {
     /// rule would be auto-allowed — bypassing Claude Code's least-privilege default.
     /// See: https://github.com/rtk-ai/rtk/issues/1155
     mod exit_code_protocol {
-        use super::registry;
+        use crate::discover::registry;
         use crate::hooks::permissions::{check_command_with_rules, PermissionVerdict};
 
         /// Exit code that `run()` returns for each verdict:


### PR DESCRIPTION
# Preserve pipeline input while rewriting safe shell commands

## Summary

RTK now lexes shell command structure before rewriting it. Filters and other content consumers receive the producer's original output, while display-only tails can still use RTK's compact output. Redirections and shell-block boundaries remain attached to the command that owns them.

This fixes [issue #1560](https://github.com/rtk-ai/rtk/issues/1560), where rewriting the left side of a pipe changed the input seen by downstream filters. The lexer consolidates the boundary and suffix behavior developed in [PR #536](https://github.com/rtk-ai/rtk/pull/536) and supports long, multi-line shell blocks without treating their internal operators as independent top-level commands.

## Before and after

| Command | Before | After |
|---|---|---|
| `git log \| grep feat` | RTK could replace the producer before `grep` read it. | The command stays raw, so `grep` receives the original Git stream. |
| `cargo test \| tee /tmp/test.log` | The file could contain RTK's compact display instead of the test stream. | The command stays raw, so `tee` saves the original output. |
| `git log \| head -20` | Conservative pipe handling could leave a safe display tail unfiltered. | RTK can rewrite the producer because `head` only consumes a bounded display prefix. |
| `git status > /tmp/status.log` | The file-target redirect prevented the supported rewrite path. | RTK preserves the suffix and returns an ask-only rewrite: `rtk git status > /tmp/status.log`. |
| `git status $(whoami)` | Shell substitution could be mistaken for a safe rewrite boundary. | The command stays raw because its execution boundary is opaque. |
| `if git status; then git log | grep feat; fi` | A text-only split could analyze the nested pipe as an independent top-level command. | RTK treats the block as one conservative shell unit and does not rewrite through the opaque consumer. |

## Implementation

`src/discover/lexer.rs` tokenizes quotes, escapes, comments, CRLF/newline boundaries, pipes, redirects, case alternatives, and shell blocks using typed tokens and byte offsets. `src/discover/registry.rs` applies consumer-aware producer routing. `src/discover/suffix.rs` preserves the exact trailing output suffix and assigns an ask-only policy to file-target redirects.

The policy path is compatible with the multiline rewrite work in [PR #2781](https://github.com/rtk-ai/rtk/pull/2781): each statement is analyzed independently, and auto-allow requires both an attestable command and a rewrite that does not require confirmation. This also preserves the least-privilege behavior tracked in [issue #1155](https://github.com/rtk-ai/rtk/issues/1155).

Content consumers including `grep`, `rg`, `tee`, `xargs`, `wc`, `awk`, and `sed` remain raw. Safe display tails are limited to supported stdin-only numeric `head` and `tail` forms, plain `cat`, and equivalent absolute paths. Input redirects, substitutions, heredocs, and opaque grouped commands remain conservative.

## Compatibility and scope

The existing string rewrite API remains available. Hook adapters use the policy-returning path when a file redirect requires confirmation. This change adds no parser dependency and does not execute native commands through the lexer.

## Verification

- 109 lexer tests cover quoting, escaping, comments, CRLF, pipes, redirects, suffixes, shell blocks, content consumers, safe tails, and conservative fallbacks.
- The full branch suite passes with 2,570 tests passed and 8 ignored.
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all -- --check`, and `git diff --check` pass.
