### PR TITLE
Keep Codex approval authoritative when RTK rewrites Bash commands

### DIFF
--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -89,7 +89,7 @@ Rules are loaded from all Claude Code `settings.json` files (project + global, i
 | Cursor (rtk hook cursor) | Ready | `permission: "ask",` — users will be prompted when Cursor enforces the permission; in the meantime, allow |
 | Gemini CLI (rtk hook gemini) | No (allow/deny only) | allow (limitation — no ask mode in Gemini) |
 | Copilot CLI (rtk hook copilot) | No updatedInput | deny-with-suggestion (unchanged) |
-| Codex | ask parsed but no-op | allow (limitation — fails open) |
+| Codex | Codex owns approval and execpolicy rules | no-op in default/ask modes; safe rewrites are allowed only in `bypassPermissions` |
 
 ### Implementation
 

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -539,7 +539,7 @@ fn process_codex_payload(v: &Value) -> PayloadAction {
         None => return PayloadAction::Ignore,
     };
 
-    let decision = decide_hook_action(cmd, permissions::Host::Claude);
+    let decision = decide_hook_action(cmd, permissions::Host::Codex);
     process_codex_payload_with_decision(v, cmd, decision)
 }
 
@@ -575,6 +575,13 @@ fn pre_tool_use_deny_output(reason: &str) -> Value {
             "permissionDecisionReason": reason
         }
     })
+}
+
+fn is_codex_bash_pre_tool_use(v: &Value) -> bool {
+    v.get("tool_name").and_then(Value::as_str) == Some("Bash")
+        && v.get("hook_event_name")
+            .and_then(Value::as_str)
+            .is_some_and(|event| event == PRE_TOOL_USE_KEY)
 }
 
 /// Run the Claude Code PreToolUse hook natively.
@@ -635,9 +642,11 @@ fn run_claude_inner(input: &str) -> Option<String> {
 // Codex rejects `updatedInput` unless the same hook output also carries
 // `permissionDecision: "allow"`. Claude can rewrite and still let its
 // native prompt run by omitting `permissionDecision`; Codex cannot. In
-// Codex's `default` permission mode, RTK therefore emits `{}` unless an
-// explicit RTK allow rule matches. Codex's `bypassPermissions` mode already
-// disables approval prompts, so eligible RTK rewrites may be allowed there.
+// Codex's default and prompt modes, RTK therefore emits `{}` and leaves the
+// original command to Codex. Codex's `bypassPermissions` mode already
+// disables approval prompts, so safe RTK rewrites may be allowed there.
+// Codex's approval and execpolicy settings are intentionally not read as
+// Claude settings; Codex remains the authority for Codex commands.
 // Codex semantics permit multiple matching hooks to run concurrently —
 // unlike Claude #1515, there is no manifest fallthrough to engineer here.
 
@@ -662,8 +671,7 @@ pub fn run_codex() -> Result<()> {
     // Codex currently fires PreToolUse only for the Bash tool; defend
     // against future event/tool expansion by emitting `{}` for anything
     // else rather than misinterpreting the payload.
-    let tool_name = v.get("tool_name").and_then(|t| t.as_str()).unwrap_or("");
-    if tool_name != "Bash" {
+    if !is_codex_bash_pre_tool_use(&v) {
         let _ = writeln!(io::stdout(), "{{}}");
         return Ok(());
     }
@@ -697,8 +705,7 @@ pub fn run_codex() -> Result<()> {
 #[cfg(test)]
 fn run_codex_inner(input: &str) -> Option<String> {
     let v: Value = serde_json::from_str(input).ok()?;
-    let tool_name = v.get("tool_name").and_then(|t| t.as_str()).unwrap_or("");
-    if tool_name != "Bash" {
+    if !is_codex_bash_pre_tool_use(&v) {
         return None;
     }
     match process_codex_payload(&v) {
@@ -716,8 +723,7 @@ fn run_codex_inner_with_rules(
     allow: &[String],
 ) -> Option<String> {
     let v: Value = serde_json::from_str(input).ok()?;
-    let tool_name = v.get("tool_name").and_then(|t| t.as_str()).unwrap_or("");
-    if tool_name != "Bash" {
+    if !is_codex_bash_pre_tool_use(&v) {
         return None;
     }
     let cmd = v
@@ -1668,6 +1674,26 @@ mod tests {
     }
 
     #[test]
+    fn test_codex_bypass_mode_keeps_file_redirect_ask_only() {
+        let input: Value = serde_json::from_str(&codex_input_with_mode(
+            "git log > /tmp/out.txt",
+            "bypassPermissions",
+        ))
+        .unwrap();
+        assert!(matches!(
+            process_codex_payload_with_decision(
+                &input,
+                "git log > /tmp/out.txt",
+                HookDecision::AskRewrite {
+                    rewritten: "rtk git log > /tmp/out.txt".into(),
+                    explicit: true,
+                },
+            ),
+            PayloadAction::Skip { .. }
+        ));
+    }
+
+    #[test]
     fn test_codex_non_allow_rewrites_return_none_to_avoid_invalid_schema() {
         // Codex rejects `updatedInput` unless permissionDecision is `allow`;
         // default/ask rewrites therefore emit no output and let Codex handle
@@ -1719,6 +1745,17 @@ mod tests {
         let input = json!({
             "hook_event_name": "PreToolUse",
             "tool_name": "shell_view",
+            "tool_input": { "command": "git status" }
+        })
+        .to_string();
+        assert!(run_codex_allowed(&input).is_none());
+    }
+
+    #[test]
+    fn test_codex_non_pre_tool_event_returns_none() {
+        let input = json!({
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
             "tool_input": { "command": "git status" }
         })
         .to_string();
@@ -1779,6 +1816,7 @@ mod tests {
         // the rewrite. codex_input() already adds them — this verifies
         // a smaller payload with NONE of them rewrites identically.
         let minimal = json!({
+            "hook_event_name": "PreToolUse",
             "tool_name": "Bash",
             "tool_input": { "command": "git status" }
         })
@@ -1787,6 +1825,14 @@ mod tests {
         let minimal_out = run_codex_allowed(&minimal).unwrap();
         let full_out = run_codex_allowed(&full).unwrap();
         assert_eq!(minimal_out, full_out);
+    }
+
+    #[test]
+    fn test_codex_does_not_load_claude_permission_rules() {
+        assert_eq!(
+            permissions::check_command_for("git status", permissions::Host::Codex),
+            PermissionVerdict::Default
+        );
     }
 
     // --- Cursor handler ---

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -416,12 +416,30 @@ enum PayloadAction {
         rewritten: String,
         output: Value,
     },
+    Deny {
+        cmd: String,
+        reason: String,
+    },
     Skip {
         reason: &'static str,
         cmd: String,
     },
     Ignore,
 }
+
+#[derive(Clone, Copy)]
+enum AskRewriteHandling {
+    EmitWithoutAllow,
+    Skip(&'static str),
+}
+
+#[derive(Clone, Copy)]
+enum DenyHandling {
+    Skip(&'static str),
+    Emit(&'static str),
+}
+
+const RTK_PERMISSION_DENY_REASON: &str = "Blocked by RTK permission rule";
 
 fn process_claude_payload(v: &Value) -> PayloadAction {
     let cmd = match v
@@ -433,13 +451,38 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
         None => return PayloadAction::Ignore,
     };
 
-    let (rewritten, allow) = match decide_hook_action(cmd, permissions::Host::Claude) {
-        HookDecision::Deny => {
-            return PayloadAction::Skip {
-                reason: "skip:deny_rule",
-                cmd: cmd.to_string(),
+    let decision = decide_hook_action(cmd, permissions::Host::Claude);
+    process_pre_tool_use_payload_with_decision(
+        v,
+        cmd,
+        decision,
+        DenyHandling::Skip("skip:deny_rule"),
+        AskRewriteHandling::EmitWithoutAllow,
+    )
+}
+
+fn process_pre_tool_use_payload_with_decision(
+    v: &Value,
+    cmd: &str,
+    decision: HookDecision,
+    deny_handling: DenyHandling,
+    ask_rewrite_handling: AskRewriteHandling,
+) -> PayloadAction {
+    let (rewritten, allow) = match decision {
+        HookDecision::Deny => match deny_handling {
+            DenyHandling::Skip(reason) => {
+                return PayloadAction::Skip {
+                    reason,
+                    cmd: cmd.to_string(),
+                }
             }
-        }
+            DenyHandling::Emit(reason) => {
+                return PayloadAction::Deny {
+                    cmd: cmd.to_string(),
+                    reason: reason.to_string(),
+                }
+            }
+        },
         HookDecision::Defer => {
             return PayloadAction::Skip {
                 reason: "skip:defer",
@@ -447,7 +490,15 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
             }
         }
         HookDecision::AllowRewrite(r) => (r, true),
-        HookDecision::AskRewrite(r) => (r, false),
+        HookDecision::AskRewrite(r) => match ask_rewrite_handling {
+            AskRewriteHandling::EmitWithoutAllow => (r, false),
+            AskRewriteHandling::Skip(reason) => {
+                return PayloadAction::Skip {
+                    reason,
+                    cmd: cmd.to_string(),
+                }
+            }
+        },
     };
 
     let updated_input = {
@@ -476,6 +527,54 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
         rewritten,
         output: json!({ "hookSpecificOutput": hook_output }),
     }
+}
+
+fn process_codex_payload(v: &Value) -> PayloadAction {
+    let cmd = match v
+        .pointer("/tool_input/command")
+        .and_then(|c| c.as_str())
+        .filter(|c| !c.is_empty())
+    {
+        Some(c) => c,
+        None => return PayloadAction::Ignore,
+    };
+
+    let decision = decide_hook_action(cmd, permissions::Host::Claude);
+    process_codex_payload_with_decision(v, cmd, decision)
+}
+
+fn process_codex_payload_with_decision(
+    v: &Value,
+    cmd: &str,
+    decision: HookDecision,
+) -> PayloadAction {
+    let decision = if v.get("permission_mode").and_then(Value::as_str) == Some("bypassPermissions")
+    {
+        match decision {
+            HookDecision::AskRewrite(rewritten) => HookDecision::AllowRewrite(rewritten),
+            decision => decision,
+        }
+    } else {
+        decision
+    };
+
+    process_pre_tool_use_payload_with_decision(
+        v,
+        cmd,
+        decision,
+        DenyHandling::Emit(RTK_PERMISSION_DENY_REASON),
+        AskRewriteHandling::Skip("skip:codex_requires_allow_for_updated_input"),
+    )
+}
+
+fn pre_tool_use_deny_output(reason: &str) -> Value {
+    json!({
+        "hookSpecificOutput": {
+            "hookEventName": PRE_TOOL_USE_KEY,
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason
+        }
+    })
 }
 
 /// Run the Claude Code PreToolUse hook natively.
@@ -507,6 +606,9 @@ pub fn run_claude() -> Result<()> {
         PayloadAction::Skip { reason, cmd } => {
             audit_log(reason, &cmd, "");
         }
+        PayloadAction::Deny { reason, cmd, .. } => {
+            audit_log("deny", &cmd, &reason);
+        }
         PayloadAction::Ignore => {}
     }
 
@@ -518,6 +620,115 @@ fn run_claude_inner(input: &str) -> Option<String> {
     let v: Value = serde_json::from_str(input).ok()?;
     match process_claude_payload(&v) {
         PayloadAction::Rewrite { output, .. } => Some(output.to_string()),
+        _ => None,
+    }
+}
+
+// ── Codex CLI native hook ──────────────────────────────────────
+//
+// Codex's PreToolUse protocol (per developers.openai.com/codex/hooks):
+//   stdin  : {"hook_event_name":"PreToolUse","tool_name":"Bash",
+//             "tool_input":{"command":"..."}, session_id, turn_id, cwd, ...}
+//   stdout : {"hookSpecificOutput":{"hookEventName":"PreToolUse",
+//             "permissionDecision":"allow|deny", "updatedInput":{"command":"..."}}}
+//
+// Codex rejects `updatedInput` unless the same hook output also carries
+// `permissionDecision: "allow"`. Claude can rewrite and still let its
+// native prompt run by omitting `permissionDecision`; Codex cannot. In
+// Codex's `default` permission mode, RTK therefore emits `{}` unless an
+// explicit RTK allow rule matches. Codex's `bypassPermissions` mode already
+// disables approval prompts, so eligible RTK rewrites may be allowed there.
+// Codex semantics permit multiple matching hooks to run concurrently —
+// unlike Claude #1515, there is no manifest fallthrough to engineer here.
+
+/// Run the Codex CLI PreToolUse hook natively.
+pub fn run_codex() -> Result<()> {
+    let input = read_stdin_limited()?;
+    let input = input.trim();
+    if input.is_empty() {
+        let _ = writeln!(io::stdout(), "{{}}");
+        return Ok(());
+    }
+
+    let v: Value = match serde_json::from_str(input) {
+        Ok(v) => v,
+        Err(_) => {
+            // Fail-open: emit neutral no-opinion, no stderr noise.
+            let _ = writeln!(io::stdout(), "{{}}");
+            return Ok(());
+        }
+    };
+
+    // Codex currently fires PreToolUse only for the Bash tool; defend
+    // against future event/tool expansion by emitting `{}` for anything
+    // else rather than misinterpreting the payload.
+    let tool_name = v.get("tool_name").and_then(|t| t.as_str()).unwrap_or("");
+    if tool_name != "Bash" {
+        let _ = writeln!(io::stdout(), "{{}}");
+        return Ok(());
+    }
+
+    match process_codex_payload(&v) {
+        PayloadAction::Rewrite {
+            cmd,
+            rewritten,
+            output,
+        } => {
+            audit_log("rewrite", &cmd, &rewritten);
+            let _ = writeln!(io::stdout(), "{output}");
+        }
+        PayloadAction::Skip { reason, cmd } => {
+            audit_log(reason, &cmd, "");
+            let _ = writeln!(io::stdout(), "{{}}");
+        }
+        PayloadAction::Deny { cmd, reason } => {
+            audit_log("deny", &cmd, &reason);
+            let output = pre_tool_use_deny_output(&reason);
+            let _ = writeln!(io::stdout(), "{output}");
+        }
+        PayloadAction::Ignore => {
+            let _ = writeln!(io::stdout(), "{{}}");
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+fn run_codex_inner(input: &str) -> Option<String> {
+    let v: Value = serde_json::from_str(input).ok()?;
+    let tool_name = v.get("tool_name").and_then(|t| t.as_str()).unwrap_or("");
+    if tool_name != "Bash" {
+        return None;
+    }
+    match process_codex_payload(&v) {
+        PayloadAction::Rewrite { output, .. } => Some(output.to_string()),
+        PayloadAction::Deny { reason, .. } => Some(pre_tool_use_deny_output(&reason).to_string()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+fn run_codex_inner_with_rules(
+    input: &str,
+    deny: &[String],
+    ask: &[String],
+    allow: &[String],
+) -> Option<String> {
+    let v: Value = serde_json::from_str(input).ok()?;
+    let tool_name = v.get("tool_name").and_then(|t| t.as_str()).unwrap_or("");
+    if tool_name != "Bash" {
+        return None;
+    }
+    let cmd = v
+        .pointer("/tool_input/command")
+        .and_then(|c| c.as_str())
+        .filter(|c| !c.is_empty())?;
+    let verdict = permissions::check_command_with_rules(cmd, deny, ask, allow);
+    let decision = decide_from_verdict(cmd, verdict);
+    match process_codex_payload_with_decision(&v, cmd, decision) {
+        PayloadAction::Rewrite { output, .. } => Some(output.to_string()),
+        PayloadAction::Deny { reason, .. } => Some(pre_tool_use_deny_output(&reason).to_string()),
         _ => None,
     }
 }
@@ -1377,6 +1588,205 @@ mod tests {
     fn test_claude_no_tool_input_passthrough() {
         let input = json!({ "tool_name": "Bash" }).to_string();
         assert!(run_claude_inner(&input).is_none());
+    }
+
+    // --- Codex handler ---
+
+    fn codex_input(cmd: &str) -> String {
+        codex_input_with_mode(cmd, "default")
+    }
+
+    fn codex_input_with_mode(cmd: &str, permission_mode: &str) -> String {
+        // Codex PreToolUse stdin includes session/turn metadata that RTK
+        // ignores, plus the canonical Bash payload. Tests use the full
+        // shape to catch regressions where extra fields confuse parsing.
+        json!({
+            "session_id": "s-1234",
+            "tool_use_id": "tu-5678",
+            "turn_id": "t-9012",
+            "cwd": "/repo",
+            "permission_mode": permission_mode,
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": { "command": cmd }
+        })
+        .to_string()
+    }
+
+    fn run_codex_allowed(input: &str) -> Option<String> {
+        run_codex_inner_with_rules(input, &[], &[], &["*".to_string()])
+    }
+
+    fn run_codex_allowed_json(input: &str) -> Option<Value> {
+        run_codex_allowed(input).map(|result| serde_json::from_str(&result).unwrap())
+    }
+
+    #[test]
+    fn test_codex_allowed_rewrites_emit_allow_with_updated_input() {
+        let cases = [
+            ("simple command", "git status", "rtk git status"),
+            (
+                "compound command",
+                "git add . && cargo test",
+                "rtk git add . && rtk cargo test",
+            ),
+            (
+                "environment prefix",
+                "GIT_PAGER=cat git status",
+                "GIT_PAGER=cat rtk git status",
+            ),
+        ];
+
+        for (name, input_command, expected_command) in cases {
+            let v = run_codex_allowed_json(&codex_input(input_command)).unwrap();
+            let hook = &v["hookSpecificOutput"];
+            assert_eq!(hook["hookEventName"], PRE_TOOL_USE_KEY, "{name}");
+            assert_eq!(hook["permissionDecision"], "allow", "{name}");
+            assert_eq!(
+                hook["permissionDecisionReason"], "RTK auto-rewrite",
+                "{name}"
+            );
+            assert_eq!(hook["updatedInput"]["command"], expected_command, "{name}");
+        }
+    }
+
+    #[test]
+    fn test_codex_bypass_mode_allows_rewrite_without_rtk_allow_rule() {
+        let result = run_codex_inner_with_rules(
+            &codex_input_with_mode("git status", "bypassPermissions"),
+            &[],
+            &[],
+            &[],
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(v["hookSpecificOutput"]["permissionDecision"], "allow");
+        assert_eq!(
+            v["hookSpecificOutput"]["updatedInput"]["command"],
+            "rtk git status"
+        );
+    }
+
+    #[test]
+    fn test_codex_non_allow_rewrites_return_none_to_avoid_invalid_schema() {
+        // Codex rejects `updatedInput` unless permissionDecision is `allow`;
+        // default/ask rewrites therefore emit no output and let Codex handle
+        // the original command through its native permission flow.
+        let cases = [
+            ("default", vec![], vec![], vec![]),
+            (
+                "ask",
+                vec![],
+                vec!["git *".to_string()],
+                vec!["git *".to_string()],
+            ),
+        ];
+
+        for (name, deny, ask, allow) in cases {
+            assert!(
+                run_codex_inner_with_rules(&codex_input("git status"), &deny, &ask, &allow)
+                    .is_none(),
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_codex_deny_emits_block_without_updated_input() {
+        let result = run_codex_inner_with_rules(
+            &codex_input("git status"),
+            &["git status".to_string()],
+            &[],
+            &["*".to_string()],
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let hook = &v["hookSpecificOutput"];
+        assert_eq!(hook["hookEventName"], PRE_TOOL_USE_KEY);
+        assert_eq!(hook["permissionDecision"], "deny");
+        assert_eq!(
+            hook["permissionDecisionReason"],
+            "Blocked by RTK permission rule"
+        );
+        assert!(hook.get("updatedInput").is_none());
+    }
+
+    #[test]
+    fn test_codex_non_bash_tool_returns_none() {
+        // Codex PreToolUse currently only fires for Bash, but defensive:
+        // if a future Codex sends shell_view or fs_read here, RTK must
+        // refuse rather than misinterpret.
+        let input = json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "shell_view",
+            "tool_input": { "command": "git status" }
+        })
+        .to_string();
+        assert!(run_codex_allowed(&input).is_none());
+    }
+
+    #[test]
+    fn test_codex_skip_cases_return_none() {
+        // htop has no RTK rewrite; already-prefixed and redirected commands
+        // must also skip so Codex sees no hook output (-> "{}" in I/O wrapper).
+        for command in ["htop", "rtk git status", "git log > /tmp/out.txt"] {
+            assert!(
+                run_codex_allowed(&codex_input(command)).is_none(),
+                "{command}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_codex_substitution_not_rewritten() {
+        // CVE-class: command substitution payloads must skip so Codex
+        // applies its own permission policy instead of auto-allowing.
+        assert!(run_codex_allowed(&codex_input("git status `rm -rf /tmp/x`")).is_none());
+        assert!(run_codex_allowed(&codex_input("git status $(rm -rf /tmp/x)")).is_none());
+    }
+
+    #[test]
+    fn test_codex_invalid_payloads_return_none() {
+        let cases = [
+            ("malformed json", "not valid json {{{".to_string()),
+            (
+                "empty command",
+                json!({
+                    "hook_event_name": "PreToolUse",
+                    "tool_name": "Bash",
+                    "tool_input": { "command": "" }
+                })
+                .to_string(),
+            ),
+            (
+                "missing tool_input",
+                json!({
+                    "hook_event_name": "PreToolUse",
+                    "tool_name": "Bash"
+                })
+                .to_string(),
+            ),
+        ];
+
+        for (name, input) in cases {
+            assert!(run_codex_inner(&input).is_none(), "{name}");
+        }
+    }
+
+    #[test]
+    fn test_codex_extra_session_fields_ignored() {
+        // session_id / turn_id / cwd / permission_mode must not affect
+        // the rewrite. codex_input() already adds them — this verifies
+        // a smaller payload with NONE of them rewrites identically.
+        let minimal = json!({
+            "tool_name": "Bash",
+            "tool_input": { "command": "git status" }
+        })
+        .to_string();
+        let full = codex_input("git status");
+        let minimal_out = run_codex_allowed(&minimal).unwrap();
+        let full_out = run_codex_allowed(&full).unwrap();
+        assert_eq!(minimal_out, full_out);
     }
 
     // --- Cursor handler ---

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -539,24 +539,23 @@ fn process_codex_payload(v: &Value) -> PayloadAction {
         None => return PayloadAction::Ignore,
     };
 
-    let decision = decide_hook_action(cmd, permissions::Host::Codex);
-    process_codex_payload_with_decision(v, cmd, decision)
+    let verdict = permissions::check_command_for(cmd, permissions::Host::Codex);
+    process_codex_payload_with_verdict(v, cmd, verdict)
 }
 
-fn process_codex_payload_with_decision(
+fn process_codex_payload_with_verdict(
     v: &Value,
     cmd: &str,
-    decision: HookDecision,
+    verdict: permissions::PermissionVerdict,
 ) -> PayloadAction {
-    let decision = if v.get("permission_mode").and_then(Value::as_str) == Some("bypassPermissions")
+    let mut decision = decide_from_verdict(cmd, verdict.clone());
+    if v.get("permission_mode").and_then(Value::as_str) == Some("bypassPermissions")
+        && verdict == permissions::PermissionVerdict::Default
     {
-        match decision {
-            HookDecision::AskRewrite(rewritten) => HookDecision::AllowRewrite(rewritten),
-            decision => decision,
+        if let HookDecision::AskRewrite(rewritten) = decision {
+            decision = HookDecision::AllowRewrite(rewritten);
         }
-    } else {
-        decision
-    };
+    }
 
     process_pre_tool_use_payload_with_decision(
         v,
@@ -731,8 +730,7 @@ fn run_codex_inner_with_rules(
         .and_then(|c| c.as_str())
         .filter(|c| !c.is_empty())?;
     let verdict = permissions::check_command_with_rules(cmd, deny, ask, allow);
-    let decision = decide_from_verdict(cmd, verdict);
-    match process_codex_payload_with_decision(&v, cmd, decision) {
+    match process_codex_payload_with_verdict(&v, cmd, verdict) {
         PayloadAction::Rewrite { output, .. } => Some(output.to_string()),
         PayloadAction::Deny { reason, .. } => Some(pre_tool_use_deny_output(&reason).to_string()),
         _ => None,
@@ -1674,23 +1672,22 @@ mod tests {
     }
 
     #[test]
-    fn test_codex_bypass_mode_keeps_file_redirect_ask_only() {
-        let input: Value = serde_json::from_str(&codex_input_with_mode(
-            "git log > /tmp/out.txt",
-            "bypassPermissions",
-        ))
-        .unwrap();
-        assert!(matches!(
-            process_codex_payload_with_decision(
-                &input,
-                "git log > /tmp/out.txt",
-                HookDecision::AskRewrite {
-                    rewritten: "rtk git log > /tmp/out.txt".into(),
-                    explicit: true,
-                },
-            ),
-            PayloadAction::Skip { .. }
-        ));
+    fn test_codex_bypass_mode_keeps_ask_verdict_out_of_allow() {
+        for command in ["git status", "git log > /tmp/out.txt"] {
+            let input: Value =
+                serde_json::from_str(&codex_input_with_mode(command, "bypassPermissions")).unwrap();
+            assert!(
+                matches!(
+                    process_codex_payload_with_verdict(
+                        &input,
+                        command,
+                        permissions::PermissionVerdict::Ask,
+                    ),
+                    PayloadAction::Skip { .. }
+                ),
+                "explicit Ask must not become an allow rewrite: {command}"
+            );
+        }
     }
 
     #[test]

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -33,6 +33,9 @@ pub fn check_command(cmd: &str) -> PermissionVerdict {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Host {
     Claude,
+    /// Codex applies its own approval and execpolicy rules. RTK does not
+    /// reuse Claude settings for this host.
+    Codex,
     Cursor,
     Gemini,
     Droid,
@@ -41,6 +44,7 @@ pub enum Host {
 pub fn check_command_for(cmd: &str, host: Host) -> PermissionVerdict {
     let (deny_rules, ask_rules, allow_rules) = match host {
         Host::Claude => load_permission_rules(),
+        Host::Codex => (Vec::new(), Vec::new(), Vec::new()),
         Host::Cursor => load_cursor_rules(),
         Host::Gemini => load_gemini_rules(),
         Host::Droid => load_droid_rules(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -866,6 +866,8 @@ enum HookCommands {
     Copilot,
     /// Process Factory Droid PreToolUse hook (reads JSON from stdin)
     Droid,
+    /// Process Codex CLI PreToolUse hook (reads JSON from stdin)
+    Codex,
     /// Check how a command would be rewritten by the hook engine (dry-run)
     Check {
         /// Target agent
@@ -2436,6 +2438,10 @@ fn run_cli() -> Result<i32> {
             }
             HookCommands::Droid => {
                 hooks::hook_cmd::run_droid()?;
+                0
+            }
+            HookCommands::Codex => {
+                hooks::hook_cmd::run_codex()?;
                 0
             }
             HookCommands::Check { agent: _, command } => {


### PR DESCRIPTION
# Keep Codex approval authoritative when RTK rewrites Bash commands

## Summary

RTK now provides a native `rtk hook codex` handler for Codex `PreToolUse` events. It returns Codex-valid JSON and never claims an approval that Codex has not granted.

The change addresses [issue #1812](https://github.com/rtk-ai/rtk/issues/1812) and the failure reported as `PreToolUse hook returned updatedInput without permissionDecision:allow`. Codex receives `updatedInput` only with `permissionDecision: "allow"`; a deny response includes a non-empty reason and no replacement command.

## Before and after

| Input or policy | Before | After |
|---|---|---|
| `rtk hook codex` | RTK had no native Codex PreToolUse response path. | RTK accepts Codex hook JSON and returns a valid response shape. |
| Default or ask mode, `git status` | A rewrite could include `updatedInput` without `allow`, which Codex rejects. | RTK returns `{}` and leaves approval and execution to Codex. |
| `bypassPermissions`, `git status` | RTK could not provide a native rewrite response. | RTK returns `permissionDecision: "allow"` with `updatedInput.command: "rtk git status"`. |
| A denied command | A host-specific response could omit Codex's required reason or include an invalid replacement. | RTK returns `permissionDecision: "deny"` with a non-empty reason and no `updatedInput`. |
| Non-Bash or non-`PreToolUse` input | An unrelated event could be interpreted as a command rewrite. | RTK returns `{}` and does nothing. |

## Implementation

`Host::Codex` uses the shared rewrite and permission helpers without reading Claude settings. `process_codex_payload` preserves ask-only file redirects, renders neutral/allow/deny responses according to Codex's schema, and keeps Codex responsible for approval and execution policy. The other host adapters keep their existing response schemas.

Hook-file installation is intentionally separate so the protocol contract and settings-file mutation can be reviewed independently.

Codex can still display one status line for each matching PreToolUse handler; this change does not remove or disable foreign handlers. It ensures RTK's own response is valid when Codex executes it alongside other handlers.

## Verification

- 20 Codex-focused tests cover event and tool filtering, malformed input, default and ask neutrality, bypass rewriting, file redirects, deny reasons, and extra Codex fields.
- The full branch suite passes with 2,574 tests passed and 8 ignored.
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --all -- --check`, and `git diff --check` pass.
