### PR TITLE
docs(readme): fix troubleshooting link in README_ko.md

### DIFF
--- a/README_ko.md
+++ b/README_ko.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="https://www.rtk-ai.app">웹사이트</a> &bull;
   <a href="#설치">설치</a> &bull;
-  <a href="docs/TROUBLESHOOTING.md">문제 해결</a> &bull;
+  <a href="https://www.rtk-ai.app/guide/troubleshooting">문제 해결</a> &bull;
   <a href="docs/contributing/ARCHITECTURE.md">아키텍처</a> &bull;
   <a href="https://discord.gg/RySmvNF5kF">Discord</a>
 </p>


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

- Fixes the troubleshooting link in `README_ko.md` that pointed to a non-resolving local path (`docs/TROUBLESHOOTING.md`)
- Updates it to the official guide URL: `https://www.rtk-ai.app/guide/troubleshooting`
- Closes #2561

## Test plan
<!-- How did you verify this works? -->
- [x] Verified the rendered Markdown link resolves to the correct URL