### PR TITLE
fix(hook): fail open when stdin payload stalls

### DIFF
--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -8,21 +8,37 @@ use super::permissions::{self, PermissionVerdict};
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
 use std::io::{self, Read, Write};
+use std::sync::mpsc::{self, RecvTimeoutError};
+use std::thread;
+use std::time::Duration;
 
 use crate::discover::registry::{has_heredoc, rewrite_command};
 
 const STDIN_CAP: usize = 1_048_576; // 1 MiB
+const STDIN_READ_TIMEOUT: Duration = Duration::from_secs(1);
 
 fn read_stdin_limited() -> Result<String> {
-    let mut input = String::new();
-    io::stdin()
-        .take((STDIN_CAP + 1) as u64)
-        .read_to_string(&mut input)
-        .context("Failed to read stdin")?;
-    if input.len() > STDIN_CAP {
-        anyhow::bail!("hook stdin exceeds {} byte limit", STDIN_CAP);
+    let (tx, rx) = mpsc::sync_channel(1);
+
+    thread::spawn(move || {
+        let mut input = String::new();
+        let result = io::stdin()
+            .take((STDIN_CAP + 1) as u64)
+            .read_to_string(&mut input)
+            .context("Failed to read stdin")
+            .and_then(|_| {
+                if input.len() > STDIN_CAP {
+                    anyhow::bail!("hook stdin exceeds {} byte limit", STDIN_CAP);
+                }
+                Ok(input)
+            });
+        let _ = tx.send(result);
+    });
+
+    match rx.recv_timeout(STDIN_READ_TIMEOUT) {
+        Ok(result) => result,
+        Err(RecvTimeoutError::Timeout | RecvTimeoutError::Disconnected) => Ok(String::new()),
     }
-    Ok(input)
 }
 
 // ── Copilot hook (VS Code + Copilot CLI) ──────────────────────

--- a/tests/hook_stdin_timeout_test.rs
+++ b/tests/hook_stdin_timeout_test.rs
@@ -1,0 +1,79 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[test]
+fn claude_hook_rewrites_payload_arriving_on_stdin() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args(["hook", "claude"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn rtk hook claude");
+
+    let mut stdin = child.stdin.take().expect("child stdin");
+    stdin
+        .write_all(br#"{"tool_name":"Bash","tool_input":{"command":"git status"}}"#)
+        .expect("write hook payload");
+    drop(stdin);
+
+    let output = child.wait_with_output().expect("collect hook output");
+    assert!(
+        output.status.success(),
+        "hook should exit 0, got {:?}, stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let response: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("hook JSON response");
+    assert_eq!(
+        response
+            .pointer("/hookSpecificOutput/updatedInput/command")
+            .and_then(|v| v.as_str()),
+        Some("rtk git status")
+    );
+}
+
+#[test]
+fn claude_hook_fails_open_when_stdin_stays_open_without_payload() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args(["hook", "claude"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn rtk hook claude");
+
+    let stdin = child.stdin.take().expect("child stdin");
+    let deadline = Instant::now() + Duration::from_secs(3);
+
+    loop {
+        if child.try_wait().expect("poll child").is_some() {
+            drop(stdin);
+            let output = child.wait_with_output().expect("collect hook output");
+            assert!(
+                output.status.success(),
+                "hook should fail open with exit 0, got {:?}, stderr={}",
+                output.status.code(),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert!(
+                output.stdout.is_empty(),
+                "hook should emit no rewrite when no payload arrives, got {}",
+                String::from_utf8_lossy(&output.stdout)
+            );
+            return;
+        }
+
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("rtk hook claude blocked on open stdin without payload");
+        }
+
+        thread::sleep(Duration::from_millis(25));
+    }
+}


### PR DESCRIPTION
## Summary
- add a 1s deadline around hook stdin payload reads so `rtk hook claude` cannot block indefinitely when stdin stays open without data
- preserve the existing empty-input fail-open path by returning no rewrite on timeout
- add integration coverage for normal payload rewrites and stalled stdin fail-open behavior

Fixes #2553

## Verification
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 clippy --all-targets`
- `cargo +1.93.0 test --test hook_stdin_timeout_test -- --nocapture`
- `cargo +1.93.0 test test_claude_ -- --nocapture`
- `git diff --check`

## Known baseline issue
- `cargo +1.93.0 test --all` currently fails on upstream `develop` at `tests/grep_compress_test.rs::small_grep_not_worse_than_plain`, unrelated to this hook change; this appears covered by existing PR #2554.