### PR TITLE
fix(opencode): export plugin as default

### DIFF
--- a/hooks/opencode/rtk.ts
+++ b/hooks/opencode/rtk.ts
@@ -37,3 +37,5 @@ export const RtkOpenCodePlugin: Plugin = async ({ $ }) => {
     },
   }
 }
+
+export default RtkOpenCodePlugin

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -4259,6 +4259,14 @@ mod tests {
     }
 
     #[test]
+    fn test_opencode_plugin_template_exports_default() {
+        assert!(
+            OPENCODE_PLUGIN.contains("export default RtkOpenCodePlugin"),
+            "OpenCode loader requires a default plugin export"
+        );
+    }
+
+    #[test]
     fn test_opencode_plugin_remove() {
         let temp = TempDir::new().unwrap();
         let opencode_dir = temp.path().join("opencode");


### PR DESCRIPTION
## Summary
- add the default export required by the OpenCode plugin loader
- add a regression test so the embedded `rtk init -g --opencode` plugin template keeps a default export

Fixes #2516

## Verification
- `cargo +1.93.0 test test_opencode_plugin_template_exports_default -- --nocapture`
- `cargo +1.93.0 test test_opencode_plugin_ -- --nocapture`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 clippy --all-targets`
- `git diff --check`
- `cargo +1.93.0 test --all -- --skip small_grep_not_worse_than_plain`

## Known baseline issue
- `cargo +1.93.0 test --all` currently fails on upstream `develop` at `tests/grep_compress_test.rs::small_grep_not_worse_than_plain`, unrelated to this OpenCode change; this appears covered by existing PR #2554.