### PR TITLE
fix(lint): preserve biome routing

### DIFF
--- a/src/cmds/js/lint_cmd.rs
+++ b/src/cmds/js/lint_cmd.rs
@@ -9,7 +9,8 @@ use crate::mypy_cmd;
 use crate::ruff_cmd;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use serde_json::Value;
+use std::{collections::HashMap, fs};
 
 #[derive(Debug, Deserialize, Serialize)]
 struct EslintMessage {
@@ -87,6 +88,89 @@ fn detect_linter(args: &[String]) -> (&str, bool) {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct InferredLinter {
+    name: &'static str,
+    args: Vec<String>,
+}
+
+fn infer_linter_from_current_package_json() -> Option<InferredLinter> {
+    let raw = fs::read_to_string("package.json").ok()?;
+    let package_json: Value = serde_json::from_str(&raw).ok()?;
+    infer_linter_from_package_json(&package_json)
+}
+
+fn infer_linter_from_package_json(package_json: &Value) -> Option<InferredLinter> {
+    if let Some(script) = package_json
+        .get("scripts")
+        .and_then(|scripts| scripts.get("lint"))
+        .and_then(Value::as_str)
+    {
+        if let Some(inferred) = infer_linter_from_script(script) {
+            return Some(inferred);
+        }
+    }
+
+    if package_has_dependency(package_json, "@biomejs/biome")
+        || package_has_dependency(package_json, "biome")
+    {
+        return Some(InferredLinter {
+            name: "biome",
+            args: vec!["check".to_string()],
+        });
+    }
+
+    if package_has_dependency(package_json, "eslint") {
+        return Some(InferredLinter {
+            name: "eslint",
+            args: Vec::new(),
+        });
+    }
+
+    None
+}
+
+fn infer_linter_from_script(script: &str) -> Option<InferredLinter> {
+    let tokens = crate::discover::lexer::shell_split(script);
+    for (idx, token) in tokens.iter().enumerate() {
+        let tool = normalized_tool_name(token);
+        let name = match tool {
+            "biome" => "biome",
+            "eslint" => "eslint",
+            "ruff" => "ruff",
+            "pylint" => "pylint",
+            "mypy" => "mypy",
+            _ => continue,
+        };
+        return Some(InferredLinter {
+            name,
+            args: tokens[idx + 1..].to_vec(),
+        });
+    }
+    None
+}
+
+fn normalized_tool_name(token: &str) -> &str {
+    let basename = token.rsplit(['/', '\\']).next().unwrap_or(token);
+    basename
+        .strip_suffix(".cmd")
+        .or_else(|| basename.strip_suffix(".CMD"))
+        .or_else(|| basename.strip_suffix(".exe"))
+        .or_else(|| basename.strip_suffix(".EXE"))
+        .unwrap_or(basename)
+}
+
+fn package_has_dependency(package_json: &Value, name: &str) -> bool {
+    ["dependencies", "devDependencies", "peerDependencies"]
+        .iter()
+        .any(|section| {
+            package_json
+                .get(*section)
+                .and_then(Value::as_object)
+                .is_some_and(|deps| deps.contains_key(name))
+        })
+}
+
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
@@ -94,6 +178,12 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     let effective_args = &args[skip..];
 
     let (linter, explicit) = detect_linter(effective_args);
+    let inferred = if explicit {
+        None
+    } else {
+        infer_linter_from_current_package_json()
+    };
+    let linter = inferred.as_ref().map(|i| i.name).unwrap_or(linter);
 
     // Python linters use resolved_command() directly (they're on PATH via pip/pipx)
     // JS linters use package_manager_exec (npx/pnpm exec)
@@ -138,7 +228,15 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         1
     };
 
-    for arg in &effective_args[start_idx..] {
+    let forwarded_args: Vec<String> = inferred
+        .as_ref()
+        .map(|i| i.args.clone())
+        .unwrap_or_default()
+        .into_iter()
+        .chain(effective_args[start_idx..].iter().cloned())
+        .collect();
+
+    for arg in &forwarded_args {
         // Skip --output-format if we already added it
         if linter == "ruff" && arg.starts_with("--output-format") {
             continue;
@@ -151,9 +249,8 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
 
     // Default to current directory if no path specified (for ruff/pylint/mypy/eslint)
     if matches!(linter, "ruff" | "pylint" | "mypy" | "eslint") {
-        let has_path = effective_args
+        let has_path = forwarded_args
             .iter()
-            .skip(start_idx)
             .any(|a| !a.starts_with('-') && !a.contains('='));
         if !has_path {
             cmd.arg(".");
@@ -693,6 +790,35 @@ mod tests {
         let effective = &full_args[skip..];
         let (linter, _) = detect_linter(effective);
         assert_eq!(linter, "biome");
+    }
+
+    #[test]
+    fn test_infer_linter_from_package_json_lint_script_biome() {
+        let package_json = serde_json::json!({
+            "scripts": {
+                "lint": "biome check --diagnostic-level=warn"
+            },
+            "devDependencies": {
+                "eslint": "^9.0.0"
+            }
+        });
+
+        let inferred = infer_linter_from_package_json(&package_json).unwrap();
+        assert_eq!(inferred.name, "biome");
+        assert_eq!(inferred.args, vec!["check", "--diagnostic-level=warn"]);
+    }
+
+    #[test]
+    fn test_infer_linter_from_package_json_dependencies() {
+        let package_json = serde_json::json!({
+            "devDependencies": {
+                "@biomejs/biome": "^2.0.0"
+            }
+        });
+
+        let inferred = infer_linter_from_package_json(&package_json).unwrap();
+        assert_eq!(inferred.name, "biome");
+        assert_eq!(inferred.args, vec!["check"]);
     }
 
     #[test]

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -960,16 +960,29 @@ fn rewrite_segment_inner(
     // Try each rewrite prefix (longest first) with word-boundary check
     for &prefix in rule.rewrite_prefixes {
         if let Some(rest) = strip_word_prefix(strip_target, prefix) {
+            let rtk_cmd = rtk_command_for_rewrite_prefix(rule.rtk_cmd, prefix);
             let rewritten = if rest.is_empty() {
-                format!("{}{}", rule.rtk_cmd, redirect_suffix)
+                format!("{}{}", rtk_cmd, redirect_suffix)
             } else {
-                format!("{} {}{}", rule.rtk_cmd, rest, redirect_suffix)
+                format!("{} {}{}", rtk_cmd, rest, redirect_suffix)
             };
             return Some(rewritten);
         }
     }
 
     None
+}
+
+fn rtk_command_for_rewrite_prefix(rtk_cmd: &str, prefix: &str) -> String {
+    if rtk_cmd != "rtk lint" {
+        return rtk_cmd.to_string();
+    }
+
+    match prefix.split_whitespace().next_back() {
+        Some("biome") => "rtk lint biome".to_string(),
+        Some("eslint") => "rtk lint eslint".to_string(),
+        _ => rtk_cmd.to_string(),
+    }
 }
 
 /// Strip a command prefix with word-boundary check.
@@ -2966,13 +2979,36 @@ mod tests {
             "lint",
         ];
         for command in commands {
+            let expected = if command.split_whitespace().any(|part| part == "biome") {
+                "rtk lint biome"
+            } else if command.split_whitespace().any(|part| part == "eslint") {
+                "rtk lint eslint"
+            } else {
+                "rtk lint"
+            };
             assert_eq!(
                 rewrite_command_no_prefixes(command, &[]),
-                Some("rtk lint".into()),
+                Some(expected.into()),
                 "Failed for command: {}",
                 command
             );
         }
+    }
+
+    #[test]
+    fn test_rewrite_lint_preserves_explicit_linter_name() {
+        assert_eq!(
+            rewrite_command_no_prefixes("biome check", &[]),
+            Some("rtk lint biome check".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("npm exec biome check", &[]),
+            Some("rtk lint biome check".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("eslint src --max-warnings=0", &[]),
+            Some("rtk lint eslint src --max-warnings=0".into())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep explicit biome/eslint rewrite prefixes when routing through `rtk lint`
- infer the package linter from `package.json` lint scripts/dependencies before defaulting to ESLint
- add regression coverage for explicit Biome rewrites and package.json Biome inference

Fixes #2540

## Verification
- `cargo +1.93.0 test preserves_explicit_linter -- --nocapture`
- `cargo +1.93.0 test infer_linter -- --nocapture`
- `cargo +1.93.0 test rewrite_lint -- --nocapture`
- `cargo +1.93.0 test lint -- --nocapture`
- `cargo +1.93.0 run --quiet -- rewrite "biome check"`
- `cargo +1.93.0 run --quiet -- rewrite "npm exec biome check"`
- `cargo +1.93.0 run --quiet -- rewrite "eslint src --max-warnings=0"`
- `cargo +1.93.0 run --quiet -- rewrite "npm run lint"`
- `cargo +1.93.0 fmt --all -- --check`
- `cargo +1.93.0 clippy --all-targets`
- `cargo +1.93.0 test --all -- --skip small_grep_not_worse_than_plain`
- `git diff --check`