### PR TITLE
fix(hook): suppress missing-hook warning in hook entrypoints

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1479,9 +1479,10 @@ fn run_cli() -> Result<i32> {
         }
     };
 
-    // Warn if installed hook is outdated/missing (1/day, non-blocking).
-    // Skip for Gain — it shows its own inline hook warning.
-    if !matches!(cli.command, Commands::Gain { .. }) {
+    // Warn for normal operational commands only. Hook entrypoints and rewrite
+    // probes may be invoked by a project-local hook even when no global hook is
+    // registered, so warning there pollutes every intercepted command.
+    if should_warn_about_hook_status(&cli.command) {
         hooks::hook_check::maybe_warn();
     }
 
@@ -2595,6 +2596,13 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Go { .. }
             | Commands::GolangciLint { .. }
             | Commands::Gt { .. }
+    )
+}
+
+fn should_warn_about_hook_status(cmd: &Commands) -> bool {
+    !matches!(
+        cmd,
+        Commands::Gain { .. } | Commands::Hook { .. } | Commands::Rewrite { .. }
     )
 }
 

--- a/tests/hook_warning_test.rs
+++ b/tests/hook_warning_test.rs
@@ -1,0 +1,74 @@
+use std::process::{Command, Stdio};
+
+#[test]
+fn hook_claude_does_not_warn_when_global_hook_is_missing() {
+    let home = tempfile::tempdir().expect("temp home");
+    std::fs::create_dir(home.path().join(".claude")).expect("create .claude");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args(["hook", "claude"])
+        .env("HOME", home.path())
+        .env("XDG_DATA_HOME", home.path().join(".local/share"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+
+            let input = r#"{"tool_name":"Bash","tool_input":{"command":"git status"}}"#;
+            child
+                .stdin
+                .as_mut()
+                .expect("stdin")
+                .write_all(input.as_bytes())?;
+            child.wait_with_output()
+        })
+        .expect("run rtk hook claude");
+
+    assert!(
+        output.status.success(),
+        "hook command failed: {:?}",
+        output.status
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("No hook installed"),
+        "hook command should not emit no-hook warning while it is processing a hook payload; stderr: {stderr}"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("rtk git status"),
+        "expected hook rewrite output, got: {stdout}"
+    );
+}
+
+#[test]
+fn rewrite_does_not_warn_when_global_hook_is_missing() {
+    let home = tempfile::tempdir().expect("temp home");
+    std::fs::create_dir(home.path().join(".claude")).expect("create .claude");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args(["rewrite", "git", "status"])
+        .env("HOME", home.path())
+        .env("XDG_DATA_HOME", home.path().join(".local/share"))
+        .output()
+        .expect("run rtk rewrite");
+
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "rewrite should preserve ask-verdict exit code"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("No hook installed"),
+        "rewrite command should not emit no-hook warning while used by hook scripts; stderr: {stderr}"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout.trim(), "rtk git status");
+}


### PR DESCRIPTION
## Summary
- skip global hook status warnings for hook processors and rewrite probes
- keep normal operational commands on the existing warning path, while `rtk gain` keeps its inline warning
- add integration coverage for project-local Claude hook and legacy rewrite script paths

Fixes #2024

## Verification
- `cargo +1.93.0 fmt --check`
- `git diff --check`
- `cargo +1.93.0 test --test hook_warning_test -- --nocapture`
- `cargo +1.93.0 test hook_check -- --nocapture`
- `cargo +1.93.0 clippy --all-targets`
- `cargo +1.93.0 test --all -- --skip small_grep_not_worse_than_plain`
