### PR TITLE
feat(dispatch): run rtk as a busybox-style multi-call binary via argv[0]

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,26 @@ rtk init --show             # Verify installation
 
 After install, **restart Claude Code**.
 
+### Manual: tool-name symlinks (advanced)
+
+If you can't use the hook (e.g. a shell or agent that doesn't support command interception), rtk also runs as a **multi-call binary** like busybox: symlink a supported tool's name to the rtk executable and rtk transparently rewrites the invocation, falling back to the real tool when it has no equivalent.
+
+```bash
+# Put the symlinks early on PATH so they shadow the real tools.
+mkdir -p ~/.rtk/shims
+ln -s "$(command -v rtk)" ~/.rtk/shims/head
+ln -s "$(command -v rtk)" ~/.rtk/shims/git
+export PATH="$HOME/.rtk/shims:$PATH"
+
+head file.txt        # runs `rtk read file.txt`
+git log              # runs `rtk git log`
+head -c 10 file.bin  # no usable rtk rewrite -> execs the real `head`
+```
+
+Notes:
+- Only tools rtk knows how to rewrite are intercepted; everything else (and any invocation with no rtk equivalent) execs the genuine tool found further down `PATH`.
+- Unix only. There is no `exec` on native Windows and symlinks need elevated privileges, so use WSL or the hook there instead.
+
 ## Windows
 
 RTK works on Windows with some limitations. The auto-rewrite hook (`rtk-rewrite.sh`) requires a Unix shell, so on native Windows RTK falls back to **CLAUDE.md injection mode** — your AI assistant receives RTK instructions but commands are not rewritten automatically.

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -7,7 +7,8 @@
 
 use anyhow::{Context, Result};
 use regex::Regex;
-use std::path::PathBuf;
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// Truncates a string to `max_len` characters, appending `...` if needed.
@@ -320,7 +321,36 @@ pub fn package_manager_exec(tool: &str) -> Command {
 /// # Returns
 /// Full path to the resolved binary, or error if not found.
 pub fn resolve_binary(name: &str) -> Result<PathBuf> {
-    which::which(name).context(format!("Binary '{}' not found on PATH", name))
+    let candidates = which::which_all(name)
+        .map_err(anyhow::Error::new)
+        .with_context(|| format!("Binary '{}' not found on PATH", name))?;
+    first_non_self_candidate(candidates)
+        .with_context(|| format!("Binary '{}' not found on PATH", name))
+}
+
+/// First candidate that isn't an rtk multi-call shim (a symlink whose target's
+/// file name is `rtk`).
+fn first_non_self_candidate(candidates: impl IntoIterator<Item = PathBuf>) -> Result<PathBuf> {
+    for candidate in candidates {
+        if is_rtk_shim(&candidate) {
+            continue;
+        }
+        return Ok(candidate);
+    }
+    anyhow::bail!("no non-self candidate")
+}
+
+fn is_rtk_shim(p: &Path) -> bool {
+    match std::fs::symlink_metadata(p) {
+        Ok(m) if m.file_type().is_symlink() => {
+            std::fs::canonicalize(p)
+                .ok()
+                .as_deref()
+                .and_then(Path::file_name)
+                == Some(OsStr::new("rtk"))
+        }
+        _ => false,
+    }
 }
 
 /// Create a `Command` with PATHEXT-aware binary resolution.
@@ -599,6 +629,54 @@ mod tests {
             "resolved path filename should start with 'cargo', got: {}",
             filename
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_first_non_self_candidate_skips_rtk_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = std::env::temp_dir().join(format!("rtk_self_excl_{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let fake_rtk = tmp.join("rtk");
+        std::fs::write(&fake_rtk, "").unwrap();
+        let shim = tmp.join("head");
+        symlink(&fake_rtk, &shim).unwrap();
+        let real = tmp.join("real_head");
+        std::fs::write(&real, "").unwrap();
+
+        let picked = first_non_self_candidate(vec![shim, real.clone()]);
+
+        std::fs::remove_dir_all(&tmp).ok();
+        assert_eq!(picked.unwrap(), real, "must skip the rtk-symlink candidate");
+    }
+
+    #[test]
+    fn test_first_non_self_candidate_returns_first_when_none_is_self() {
+        // Matches legacy `which::which` behavior when no candidate is a shim.
+        let a = PathBuf::from("/usr/bin/cargo");
+        let b = PathBuf::from("/usr/local/bin/cargo");
+        let picked = first_non_self_candidate(vec![a.clone(), b]).unwrap();
+        assert_eq!(picked, a);
+    }
+
+    #[test]
+    fn test_first_non_self_candidate_empty_is_err() {
+        assert!(first_non_self_candidate(Vec::<PathBuf>::new()).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_first_non_self_candidate_does_not_skip_regular_file_named_rtk() {
+        let tmp = std::env::temp_dir().join(format!("rtk_regfile_{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let regular_rtk = tmp.join("rtk");
+        std::fs::write(&regular_rtk, "").unwrap();
+
+        let picked = first_non_self_candidate(vec![regular_rtk.clone()]).unwrap();
+
+        std::fs::remove_dir_all(&tmp).ok();
+        assert_eq!(picked, regular_rtk);
     }
 
     // ===== resolved_command tests (issue #212) =====

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -44,6 +44,11 @@ pub fn category_avg_tokens(category: &str, subcmd: &str) -> usize {
     }
 }
 
+/// Whether `name` is a base tool rtk knows how to rewrite (e.g. "git", "head").
+pub fn is_known_tool(name: &str) -> bool {
+    RULES.iter().any(|r| r.rewrite_prefixes.contains(&name))
+}
+
 lazy_static! {
     static ref REGEX_SET: RegexSet =
         RegexSet::new(RULES.iter().map(|r| r.pattern)).expect("invalid regex patterns");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1465,19 +1465,153 @@ where
     }
 }
 
-fn run_cli() -> Result<i32> {
-    // Fire-and-forget telemetry ping (1/day, non-blocking)
-    core::telemetry::maybe_ping();
+/// What to do when rtk is launched, decided once from argv[0].
+enum Argv0Dispatch {
+    Cli,
+    /// Parse `synth`; on parse failure, exec the real tool (`base`/`args`).
+    Synthesized {
+        synth: Vec<OsString>,
+        base: String,
+        args: Vec<OsString>,
+    },
+    Passthrough {
+        base: String,
+        args: Vec<OsString>,
+    },
+}
 
-    let cli = match Cli::try_parse() {
-        Ok(cli) => cli,
-        Err(e) => {
-            if matches!(e.kind(), ErrorKind::DisplayHelp | ErrorKind::DisplayVersion) {
-                e.exit();
+/// Multi-call dispatch from argv[0]: a `<tool>` symlink (e.g. `head` -> rtk) is
+/// translated to the equivalent `rtk <sub>` argv, else routed to the real tool.
+fn argv0_dispatch() -> Argv0Dispatch {
+    let mut raw: Vec<OsString> = std::env::args_os().collect();
+    let base = raw
+        .first()
+        .and_then(|a| Path::new(a).file_name())
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+
+    if !discover::registry::is_known_tool(&base) {
+        return Argv0Dispatch::Cli;
+    }
+
+    let tool_args = raw.split_off(1);
+
+    let (excluded, transparent) = core::config::Config::load()
+        .map(|c| (c.hooks.exclude_commands, c.hooks.transparent_prefixes))
+        .unwrap_or_default();
+
+    match synthesize_rtk_argv(&base, &tool_args, &excluded, &transparent) {
+        Some(synth) => Argv0Dispatch::Synthesized {
+            synth,
+            base,
+            args: tool_args,
+        },
+        None => Argv0Dispatch::Passthrough {
+            base,
+            args: tool_args,
+        },
+    }
+}
+
+/// Pure core of [`argv0_dispatch`]: map a literal `(tool, args)` to an
+/// `rtk <sub> ...` argv, or `None` when there is no rtk equivalent.
+///
+/// The rewrite registry works on shell strings, but `args` are already-split
+/// literals. To avoid a lossy quote/escape round-trip, the rewrite is used only
+/// to derive the `rtk <sub>` prefix: the unchanged tail is spliced back from the
+/// original `OsString` args verbatim.
+fn synthesize_rtk_argv(
+    base: &str,
+    args: &[OsString],
+    excluded: &[String],
+    transparent: &[String],
+) -> Option<Vec<OsString>> {
+    let mut cmd = String::from(base);
+    for a in args {
+        cmd.push(' ');
+        cmd.push_str(&a.to_string_lossy());
+    }
+
+    // argv elements are literal, but `rewrite_command` parses shell syntax. Only
+    // proceed if the join round-trips exactly (one `Arg` per element); otherwise
+    // a literal `&&`/pipe/space would be misread, so pass through to the tool.
+    let toks = discover::lexer::tokenize(&cmd);
+    if toks.len() != args.len() + 1
+        || toks
+            .iter()
+            .any(|t| t.kind != discover::lexer::TokenKind::Arg)
+    {
+        return None;
+    }
+
+    let rewritten = discover::registry::rewrite_command(&cmd, excluded, transparent)?;
+    if rewritten == cmd {
+        return None;
+    }
+    let rtk_toks = discover::lexer::shell_split(&rewritten);
+    if rtk_toks.first().map(String::as_str) != Some("rtk") {
+        return None;
+    }
+
+    // Match the shared suffix in `shell_split` space, then rebuild the tail
+    // from original `OsString` args (preserves quotes/escapes/non-UTF8).
+    let orig_toks = discover::lexer::shell_split(&cmd);
+    let shared = rtk_toks
+        .iter()
+        .rev()
+        .zip(orig_toks.iter().rev())
+        .take_while(|(rewritten_tok, orig)| rewritten_tok == orig)
+        .count()
+        .min(args.len());
+
+    let mut synth: Vec<OsString> = rtk_toks[..rtk_toks.len() - shared]
+        .iter()
+        .map(OsString::from)
+        .collect();
+    synth.extend(args[args.len() - shared..].iter().cloned());
+    Some(synth)
+}
+
+/// Exec the real tool behind an argv[0] symlink (self-excluding resolution).
+#[cfg(unix)]
+fn exec_real_tool(base: &str, args: &[OsString]) -> Result<i32> {
+    use std::os::unix::process::CommandExt;
+    let path = core::utils::resolve_binary(base)?;
+    let err = std::process::Command::new(path).args(args).exec();
+    Err(anyhow::anyhow!("failed to exec '{}': {}", base, err))
+}
+
+/// Non-Unix fallback: no `exec`, so spawn, wait, and forward the exit code.
+#[cfg(not(unix))]
+fn exec_real_tool(base: &str, args: &[OsString]) -> Result<i32> {
+    let path = core::utils::resolve_binary(base)?;
+    let status = std::process::Command::new(path)
+        .args(args)
+        .status()
+        .with_context(|| format!("failed to exec '{}'", base))?;
+    Ok(status.code().unwrap_or(1))
+}
+
+fn run_cli() -> Result<i32> {
+    let cli = match argv0_dispatch() {
+        Argv0Dispatch::Synthesized { synth, base, args } => match Cli::try_parse_from(&synth) {
+            Ok(cli) => cli,
+            Err(_) => return exec_real_tool(&base, &args),
+        },
+        // No telemetry on passthrough — symlinked tools must stay observably transparent.
+        Argv0Dispatch::Passthrough { base, args } => return exec_real_tool(&base, &args),
+        Argv0Dispatch::Cli => match Cli::try_parse() {
+            Ok(cli) => cli,
+            Err(e) => {
+                if matches!(e.kind(), ErrorKind::DisplayHelp | ErrorKind::DisplayVersion) {
+                    e.exit();
+                }
+                return run_fallback(e);
             }
-            return run_fallback(e);
-        }
+        },
     };
+
+    core::telemetry::maybe_ping();
 
     // Warn if installed hook is outdated/missing (1/day, non-blocking).
     // Skip for Gain — it shows its own inline hook warning.
@@ -3434,5 +3568,67 @@ mod tests {
             }
             _ => panic!("Expected Init command"),
         }
+    }
+
+    fn synth(base: &str, args: &[&str]) -> Option<Vec<String>> {
+        let args: Vec<OsString> = args.iter().map(OsString::from).collect();
+        synthesize_rtk_argv(base, &args, &[], &[]).map(|v| {
+            v.into_iter()
+                .map(|o| o.to_string_lossy().into_owned())
+                .collect()
+        })
+    }
+
+    #[test]
+    fn argv0_known_tool_with_rewrite_yields_rtk_argv() {
+        assert_eq!(
+            synth("git", &["log"]),
+            Some(vec!["rtk".into(), "git".into(), "log".into()])
+        );
+    }
+
+    #[test]
+    fn argv0_known_tool_alias_maps_to_subcommand() {
+        assert_eq!(
+            synth("head", &["file.txt"]),
+            Some(vec!["rtk".into(), "read".into(), "file.txt".into()])
+        );
+    }
+
+    #[test]
+    fn argv0_invoked_as_rtk_is_none() {
+        assert_eq!(synth("rtk", &["git", "log"]), None);
+    }
+
+    #[test]
+    fn argv0_unknown_tool_is_none() {
+        assert_eq!(synth("totally-not-a-tool", &["--help"]), None);
+    }
+
+    #[test]
+    fn argv0_known_tool_without_rewrite_is_none() {
+        // `git` is known but a bare `git` has no rewritable subcommand.
+        assert_eq!(synth("git", &[]), None);
+    }
+
+    #[test]
+    fn argv0_literal_operator_arg_falls_through() {
+        // A literal `&&` arg must not be reinterpreted as a shell operator.
+        assert_eq!(synth("git", &["log", "&&", "rm", "-rf", "x"]), None);
+    }
+
+    #[test]
+    fn argv0_arg_with_quotes_survives_verbatim() {
+        // The tail must be spliced from the original argv, not re-split from the
+        // rewritten shell string (which would strip the literal quotes).
+        assert_eq!(
+            synth("git", &["log", "--format='%h'"]),
+            Some(vec![
+                "rtk".into(),
+                "git".into(),
+                "log".into(),
+                "--format='%h'".into(),
+            ])
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Run rtk as a busybox-style multi-call binary: when invoked under a tool's name via a symlink (e.g. head -> rtk), it rewrites the invocation to the equivalent `rtk <sub>` via the rewrite registry, and execs the real tool when there's no equivalent (or the synthesized form fails to parse)
- Self-excluding binary resolution (resolve_binary skips PATH candidates that are symlinks resolving to a file named `rtk`) so a tool -> rtk symlink can't re-exec rtk forever — it always finds the genuine tool further down PATH
- The arg tail is spliced from the original OsString args (not re-split from a shell string), so quotes/escapes/non-UTF8 survive verbatim; a lexer round-trip guard passes structured/compound args straight through to the real tool
- Manual usage documented in README.md

## Why
I want to wire rtk into a Nix derivation that builds an idempotent, declarative setup across multiple tools on a machine. The auto-rewrite hook needs a Unix shell + per-agent hook config and mutates state at runtime, which doesn't fit a pure/idempotent Nix build. 

With argv0 dispatch I can declaratively create tool -> rtk symlinks (`ln -s rtk head`) in the derivation output and have those tools transparently routed through rtk's filters — no hook, no runtime mutation, reproducible across hosts. 

Tools rtk doesn't rewrite (or invocations with no equivalent) pass straight through to the real binary, so shadowing them on PATH is safe.

## Test plan
<!-- How did you verify this works? -->

```bash
# Build, then create tool-name symlinks pointing at the rtk binary.
RTK="$(pwd)/target/debug/rtk"
mkdir -p /tmp/rtk-shims
ln -sf "$RTK" /tmp/rtk-shims/head
ln -sf "$RTK" /tmp/rtk-shims/git
export PATH="/tmp/rtk-shims:$PATH"   # shadow the real tools

# Invoked under a tool's name -> rewritten to the rtk equivalent:
head file.txt           # runs `rtk read file.txt`
git log                 # runs `rtk git log`
```