### PR TITLE
fix(rewrite): stop rewritting gradle to gradlew

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -4314,13 +4314,10 @@ mod tests {
     }
 
     #[test]
-    fn test_classify_gradle() {
+    fn test_classify_gradle_not_rewritten() {
         assert!(matches!(
             classify_command("gradle build"),
-            Classification::Supported {
-                rtk_equivalent: "rtk gradlew",
-                ..
-            }
+            Classification::Unsupported { .. }
         ));
     }
 
@@ -4349,11 +4346,8 @@ mod tests {
     }
 
     #[test]
-    fn test_rewrite_gradle() {
-        assert_eq!(
-            rewrite_command_no_prefixes("gradle build", &[]),
-            Some("rtk gradlew build".into())
-        );
+    fn test_rewrite_gradle_not_rewritten() {
+        assert_eq!(rewrite_command_no_prefixes("gradle build", &[]), None);
     }
 
     #[test]

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -717,9 +717,9 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
-        pattern: r"^(?:\./gradlew|gradlew\.bat|gradlew|gradle)(?:\s+(test|build|clean|assemble\w*|install\w*|check|lint\w*|dependencies))?(\s|$)",
+        pattern: r"^(?:\./gradlew|gradlew\.bat|gradlew)(?:\s+(test|build|clean|assemble\w*|install\w*|check|lint\w*|dependencies))?(\s|$)",
         rtk_cmd: "rtk gradlew",
-        rewrite_prefixes: &["./gradlew", "gradlew.bat", "gradlew", "gradle"],
+        rewrite_prefixes: &["./gradlew", "gradlew.bat", "gradlew"],
         category: "Build",
         savings_pct: 75.0,
         subcmd_savings: &[("test", 90.0), ("build", 80.0), ("check", 80.0)],


### PR DESCRIPTION
## Summary

The rewrite rule treats `gradle` and `gradlew` as interchangeable, but they're different binaries. Users managing Gradle via mise/sdkman get their `gradle` commands silently rewritten to the project wrapper (`gradlew`), which may be a different version or not exist.

Removed `gradle` from the rewrite pattern so only wrapper variants (`./gradlew`, `gradlew`, `gradlew.bat`) are rewritten.

Fixes #2374

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] Manual testing: `gradle build` should no longer be rewritten to `gradlew build`
- [ ] Manual testing: `./gradlew build` and `gradlew build` should still rewrite correctly