### PR TITLE
fix(ci): make curl benchmark deterministic

### DIFF
--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -346,8 +346,18 @@ bench "wc" "wc Cargo.toml src/main.rs" "$RTK wc Cargo.toml src/main.rs"
 # ===================
 section "curl"
 if command -v curl &> /dev/null; then
-  bench "curl json" "curl -s https://mockhttp.org/json" "$RTK curl https://mockhttp.org/json"
-  bench "curl text" "curl -s https://mockhttp.org/robots.txt" "$RTK curl https://mockhttp.org/robots.txt"
+  CURL_JSON_FILE="/tmp/rtk_bench_curl.json"
+  CURL_TEXT_FILE="/tmp/rtk_bench_curl.txt"
+  cat > "$CURL_JSON_FILE" << 'JSONEOF'
+{"slideshow":{"author":"Yours Truly","date":"date of publication","title":"Sample Slide Show"}}
+JSONEOF
+  cat > "$CURL_TEXT_FILE" << 'TEXTEOF'
+User-agent: *
+Disallow: /deny
+TEXTEOF
+  bench "curl json" "curl -s file://$CURL_JSON_FILE" "$RTK curl file://$CURL_JSON_FILE"
+  bench "curl text" "curl -s file://$CURL_TEXT_FILE" "$RTK curl file://$CURL_TEXT_FILE"
+  rm -f "$CURL_JSON_FILE" "$CURL_TEXT_FILE"
 fi
 
 # ===================


### PR DESCRIPTION
## Summary
- Replace the benchmark curl/httpbin text and JSON calls with local `file://` fixtures.
- Avoids comparing two independent external network responses in the benchmark job.
- Keeps the benchmark exercising the `rtk curl` path while removing the flaky `curl text` negative-token failure seen across open PRs.

## Verification
- bash -n scripts/benchmark.sh
- git diff --check
- cargo +1.93.0 build --release
- Manual `curl -s file://...` vs `target/release/rtk curl file://...` check for both JSON and text fixtures

Note: a full local `CI=1 scripts/benchmark.sh` run still fails in this worktree because local warm-cache commands like `cargo build` produce tiny raw output and become existing unrelated negative cases. The curl rows specifically now report equal token counts instead of a negative result.
