### PR TITLE
feat(hook): add Devin agent integration

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -42,6 +42,7 @@ Each agent subdirectory has its own README with hook-specific details:
 - **[`opencode/`](opencode/README.md)** — TypeScript plugin, `zx` library, `tool.execute.before` event, in-place mutation
 - **[`pi/`](pi/README.md)** — TypeScript extension, `tool_call` event, `isToolCallEventType` guard, in-place mutation, `~/.pi/agent/extensions/`
 - **[`hermes/`](hermes/README.md)** — Python plugin, `pre_tool_call` hook, in-place terminal command mutation
+- **[`devin/`](devin/README.md)** — Binary hook (`rtk hook devin`), `PreToolUse` JSON format (Claude-compatible), patches `~/.config/devin/config.json`
 
 ## Supported Agents
 
@@ -58,6 +59,7 @@ Each agent subdirectory has its own README with hook-specific details:
 | OpenCode | TypeScript plugin (`tool.execute.before`) | In-place mutation | Yes |
 | Pi | TypeScript extension (`tool_call` event) | In-place mutation | Yes |
 | Hermes | Python plugin (`pre_tool_call`) | In-place mutation | Yes |
+| Devin for Terminal | Rust binary (`rtk hook devin`) | Transparent rewrite | Yes (`updatedInput`) |
 
 ## JSON Formats by Agent
 
@@ -84,6 +86,14 @@ Each agent subdirectory has its own README with hook-specific details:
   }
 }
 ```
+
+### Devin for Terminal (Binary Hook)
+
+**Input**: Same as Claude Code.
+
+**Output**: Same as Claude Code format (with `updatedInput`).
+
+Devin uses the same JSON protocol as Claude Code. The `rtk hook devin` binary command delegates to the Claude payload processor, so no shell script or `jq` is needed.
 
 ### Cursor (Shell Hook)
 

--- a/hooks/devin/README.md
+++ b/hooks/devin/README.md
@@ -1,0 +1,27 @@
+# Devin Hooks
+
+> Part of [`hooks/`](../README.md) — see also [`src/hooks/`](../../src/hooks/README.md) for installation code
+
+## Specifics
+
+- Devin for Terminal uses the same `PreToolUse` JSON protocol as Claude Code
+- Binary hook: `rtk hook devin` (implemented in `src/hooks/hook_cmd.rs`, delegates to the Claude payload processor)
+- No shell script, `jq`, or version guard required — the Rust binary handles all JSON I/O
+- Returns `updatedInput` JSON for transparent command rewrite (agent doesn't know RTK is involved)
+- Devin invocations are distinguishable from Claude Code in logs and analytics thanks to the dedicated `rtk hook devin` entry point
+
+## Installation
+
+```bash
+rtk init --agent devin
+```
+
+This patches `~/.config/devin/config.json` with a `PreToolUse` hook entry pointing at `rtk hook devin`.
+
+## Uninstall
+
+```bash
+rtk init --agent devin --uninstall
+```
+
+Removes the RTK hook entry from `~/.config/devin/config.json` (a `.json.bak` backup is created).

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -32,6 +32,7 @@ LLM agent integration layer that installs, validates, and executes command-rewri
 | Cursor | `rtk init -g --agent cursor` | Cursor hook | hooks.json |
 | Pi | `rtk init --agent pi` | `.pi/extensions/rtk.ts` | -- |
 | Hermes | `rtk init --agent hermes` | Python plugin in `~/.hermes/plugins/rtk-rewrite/` | `config.yaml` `plugins.enabled` |
+| Devin | `rtk init --agent devin` | `rtk hook devin` in `~/.config/devin/config.json` | `config.json` (Claude-compatible `PreToolUse` format) |
 
 
 ## Integrity Verification

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -1,6 +1,7 @@
 pub const REWRITE_HOOK_FILE: &str = "rtk-rewrite.sh";
 pub const GEMINI_HOOK_FILE: &str = "rtk-hook-gemini.sh";
 pub const CLAUDE_DIR: &str = ".claude";
+pub const DEVIN_DIR: &str = ".config/devin";
 pub const HOOKS_SUBDIR: &str = "hooks";
 pub const SETTINGS_JSON: &str = "settings.json";
 pub const SETTINGS_LOCAL_JSON: &str = "settings.local.json";
@@ -12,6 +13,10 @@ pub const BEFORE_TOOL_KEY: &str = "BeforeTool";
 pub const CLAUDE_HOOK_COMMAND: &str = "rtk hook claude";
 /// Native Rust hook command for Cursor (replaces rtk-rewrite.sh).
 pub const CURSOR_HOOK_COMMAND: &str = "rtk hook cursor";
+/// Native Rust hook command for Devin for Terminal.
+/// Devin uses the Claude-compatible PreToolUse JSON protocol, so the
+/// binary hook delegates to the same payload processor as `rtk hook claude`.
+pub const DEVIN_HOOK_COMMAND: &str = "rtk hook devin";
 
 pub const CONFIG_DIR: &str = ".config";
 pub const OPENCODE_SUBDIR: &str = "opencode";

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -429,6 +429,15 @@ pub fn run_claude() -> Result<()> {
     Ok(())
 }
 
+/// Run the Devin for Terminal PreToolUse hook.
+///
+/// Devin uses the same JSON protocol as Claude Code, so this delegates to
+/// `process_claude_payload`. The separate entry point exists so that Devin
+/// invocations are distinguishable from Claude Code in logs and analytics.
+pub fn run_devin() -> Result<()> {
+    run_claude()
+}
+
 #[cfg(test)]
 fn run_claude_inner(input: &str) -> Option<String> {
     let v: Value = serde_json::from_str(input).ok()?;

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -13,11 +13,11 @@ use crate::hooks::constants::{
 };
 
 use super::constants::{
-    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND,
-    GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_INIT_FILE,
-    HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON, HOOKS_SUBDIR,
-    PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR, PI_PLUGIN_FILE,
-    PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
+    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND, DEVIN_DIR,
+    DEVIN_HOOK_COMMAND, GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR,
+    HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON,
+    HOOKS_SUBDIR, PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR,
+    PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use super::integrity;
 
@@ -418,6 +418,38 @@ fn atomic_write(path: &Path, content: &str) -> Result<()> {
         )
     })?;
 
+    Ok(())
+}
+
+/// Read a JSON file, returning an empty `{}` object if the file is missing
+/// or empty. Used for config files that share the Claude Code settings.json
+/// structure (e.g. Devin's ~/.config/devin/config.json).
+fn read_json_or_empty(path: &Path) -> Result<serde_json::Value> {
+    if !path.exists() {
+        return Ok(serde_json::json!({}));
+    }
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    if content.trim().is_empty() {
+        return Ok(serde_json::json!({}));
+    }
+    serde_json::from_str(&content)
+        .with_context(|| format!("Failed to parse {} as JSON", path.display()))
+}
+
+/// Serialize `root` to pretty JSON, back up the existing file (if any), and
+/// atomically write the new content.
+fn backup_and_write(path: &Path, root: &serde_json::Value) -> Result<()> {
+    let serialized =
+        serde_json::to_string_pretty(root).context("Failed to serialize JSON config")?;
+
+    if path.exists() {
+        let backup_path = path.with_extension("json.bak");
+        fs::copy(path, &backup_path)
+            .with_context(|| format!("Failed to backup to {}", backup_path.display()))?;
+    }
+
+    atomic_write(path, &serialized)?;
     Ok(())
 }
 
@@ -2974,6 +3006,137 @@ fn remove_opencode_plugin(ctx: InitContext) -> Result<Vec<PathBuf>> {
     }
 
     Ok(removed)
+}
+
+// ─── Devin for Terminal support ───────────────────────────────────────
+//
+// Devin for Terminal uses the same PreToolUse JSON protocol as Claude Code,
+// so installation only needs to patch ~/.config/devin/config.json with a
+// `rtk hook devin` entry (the binary hook handles all JSON I/O). No shell
+// script is involved.
+
+fn resolve_devin_dir() -> Result<PathBuf> {
+    resolve_home_subdir(DEVIN_DIR)
+}
+
+/// Entry point for `rtk init --agent devin`.
+/// Patches ~/.config/devin/config.json with the RTK PreToolUse hook.
+pub fn run_devin_mode(ctx: InitContext) -> Result<()> {
+    let InitContext { dry_run, verbose } = ctx;
+    let devin_dir = resolve_devin_dir()?;
+    let config_path = devin_dir.join("config.json");
+
+    if !dry_run {
+        fs::create_dir_all(&devin_dir).with_context(|| {
+            format!("Failed to create Devin directory: {}", devin_dir.display())
+        })?;
+    }
+
+    // Read or create config.json (same structure as Claude Code settings.json)
+    let mut root = read_json_or_empty(&config_path)?;
+
+    if hook_already_present(&root, DEVIN_HOOK_COMMAND) {
+        if verbose > 0 {
+            eprintln!("  Devin hook already present in config.json");
+        }
+        if dry_run {
+            print_dry_run_footer();
+        } else {
+            println!(
+                "\nRTK for Devin: hook already present in {}\n",
+                config_path.display()
+            );
+        }
+        return Ok(());
+    }
+
+    insert_hook_entry(&mut root, DEVIN_HOOK_COMMAND)?;
+
+    if dry_run {
+        println!(
+            "[dry-run] would patch Devin config: {}",
+            config_path.display()
+        );
+        if verbose > 0 {
+            let serialized =
+                serde_json::to_string_pretty(&root).context("Failed to serialize config.json")?;
+            println!("[dry-run] content:\n{}", serialized);
+        }
+        print_dry_run_footer();
+        return Ok(());
+    }
+
+    backup_and_write(&config_path, &root)?;
+    println!("\nRTK configured for Devin for Terminal.\n");
+    println!("  config.json: hook registered ({})", DEVIN_HOOK_COMMAND);
+    println!("  Restart Devin. Test with: git status\n");
+    Ok(())
+}
+
+/// Uninstall the RTK hook from ~/.config/devin/config.json.
+pub fn uninstall_devin(ctx: InitContext) -> Result<()> {
+    let InitContext { dry_run, verbose } = ctx;
+    let config_path = resolve_devin_dir()?.join("config.json");
+
+    if !config_path.exists() {
+        println!("RTK Devin support was not installed (nothing to remove)");
+        return Ok(());
+    }
+
+    let mut root = read_json_or_empty(&config_path)?;
+    if !remove_devin_hook_from_json(&mut root) {
+        println!("RTK Devin support was not installed (nothing to remove)");
+        return Ok(());
+    }
+
+    if dry_run {
+        println!(
+            "[dry-run] would remove RTK hook from {}",
+            config_path.display()
+        );
+        print_dry_run_footer();
+        return Ok(());
+    }
+
+    backup_and_write(&config_path, &root)?;
+    if verbose > 0 {
+        eprintln!("Removed RTK hook from {}", config_path.display());
+    }
+    println!("RTK uninstalled for Devin:");
+    println!("  - config.json: removed RTK hook");
+    Ok(())
+}
+
+/// Remove RTK hook entries from a Devin config.json root.
+/// Matches `rtk hook devin`, `rtk hook claude`, and legacy `rtk-rewrite.sh`.
+fn remove_devin_hook_from_json(root: &mut serde_json::Value) -> bool {
+    let pre_tool_use = match root
+        .get_mut("hooks")
+        .and_then(|h| h.get_mut(PRE_TOOL_USE_KEY))
+        .and_then(|p| p.as_array_mut())
+    {
+        Some(arr) => arr,
+        None => return false,
+    };
+
+    let original_len = pre_tool_use.len();
+    pre_tool_use.retain(|entry| {
+        if let Some(hooks_array) = entry.get("hooks").and_then(|h| h.as_array()) {
+            for hook in hooks_array {
+                if let Some(cmd) = hook.get("command").and_then(|c| c.as_str()) {
+                    if cmd == DEVIN_HOOK_COMMAND
+                        || cmd == CLAUDE_HOOK_COMMAND
+                        || cmd.contains(REWRITE_HOOK_FILE)
+                    {
+                        return false;
+                    }
+                }
+            }
+        }
+        true
+    });
+
+    pre_tool_use.len() < original_len
 }
 
 // ─── Cursor Agent support ─────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,8 @@ pub enum AgentTarget {
     Pi,
     /// Hermes CLI
     Hermes,
+    /// Devin for Terminal
+    Devin,
 }
 
 #[derive(Parser)]
@@ -781,6 +783,8 @@ enum HookCommands {
     Gemini,
     /// Process Copilot preToolUse hook (VS Code + Copilot CLI, reads JSON from stdin)
     Copilot,
+    /// Process Devin for Terminal PreToolUse hook (Claude-compatible JSON from stdin)
+    Devin,
     /// Check how a command would be rewritten by the hook engine (dry-run)
     Check {
         /// Target agent
@@ -1458,6 +1462,8 @@ where
 {
     if agent == Some(AgentTarget::Hermes) {
         uninstall_hermes(ctx)
+    } else if agent == Some(AgentTarget::Devin) {
+        hooks::init::uninstall_devin(ctx)
     } else {
         let cursor = agent == Some(AgentTarget::Cursor);
         let pi = agent == Some(AgentTarget::Pi);
@@ -1941,6 +1947,8 @@ fn run_cli() -> Result<i32> {
                 hooks::init::run_antigravity_mode(ctx)?;
             } else if agent == Some(AgentTarget::Hermes) {
                 hooks::init::run_hermes_mode(ctx)?;
+            } else if agent == Some(AgentTarget::Devin) {
+                hooks::init::run_devin_mode(ctx)?;
             } else {
                 let install_opencode = opencode;
                 let install_claude = !opencode;
@@ -2274,6 +2282,10 @@ fn run_cli() -> Result<i32> {
             }
             HookCommands::Copilot => {
                 hooks::hook_cmd::run_copilot()?;
+                0
+            }
+            HookCommands::Devin => {
+                hooks::hook_cmd::run_devin()?;
                 0
             }
             HookCommands::Check { agent: _, command } => {


### PR DESCRIPTION
Replaces #1851 with a rebased, trimmed implementation that fits the current binary-hook architecture.

## Credit

The original integration was written by **@AdrtH** (Adrien Truy) in #1851. This PR rebases their work onto the latest `develop` and trims it to fit the current binary-hook architecture per review feedback. All credit for the original implementation goes to them.

## What changed

Devin for Terminal uses the Claude-compatible `PreToolUse` JSON protocol, so this integration is a thin binary hook — no shell script, `jq`, or version guard needed.

- **`rtk hook devin`** subcommand (`HookCommands::Devin` in `src/main.rs`) delegates to the existing `process_claude_payload` in `src/hooks/hook_cmd.rs` — same JSON I/O as `rtk hook claude`, with a separate entry point for log/analytics clarity
- **`DEVIN_HOOK_COMMAND = "rtk hook devin"`** constant in `src/hooks/constants.rs`
- **`rtk init --agent devin`** patches `~/.config/devin/config.json` with the hook entry; `--uninstall` removes it (with `.json.bak` backup).Reuses existing `insert_hook_entry` / `hook_already_present` helpers
- **No shell scripts** — dropped `hooks/devin/rtk-rewrite.sh` and `hooks/devin/test-rtk-rewrite.sh` from the original PR

## Diff size

232 insertions across 7 files (down from 809 insertions + 535 lines of shell scripts in #1851).

## Verification

- `cargo fmt --check`: clean
- `cargo clippy --all-targets`: zero warnings
- `cargo test --all`: 2251 tests pass, 0 failed
- Manual: install, idempotent re-install, uninstall, dry-run all verified

Supersedes #1851.