### PR TITLE
fix(hook): handle AskRewrite in Cursor hook when no rules configured

### DIFF
--- a/hooks/cursor/rtk-rewrite.sh
+++ b/hooks/cursor/rtk-rewrite.sh
@@ -40,21 +40,27 @@ fi
 
 # Delegate all rewrite logic to the Rust binary.
 # Exit codes: 0 = allow rewrite, 1 = no rewrite (passthrough),
-#             2 = deny, 3 = ask (Cursor has no ask UX, treat as allow).
+#             2 = deny, 3 = ask.
 REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null)
 RC=$?
-if [ "$RC" -eq 1 ] || [ "$RC" -eq 2 ] || [ -z "$REWRITTEN" ]; then
+if [ "$RC" -eq 1 ] || [ "$RC" -eq 2 ]; then
   echo '{}'
   exit 0
 fi
 
 # No change — nothing to do.
-if [ "$CMD" = "$REWRITTEN" ]; then
+if [ -z "$REWRITTEN" ] || [ "$CMD" = "$REWRITTEN" ]; then
   echo '{}'
   exit 0
 fi
 
-jq -n --arg cmd "$REWRITTEN" '{
-  "permission": "allow",
+# RC 3 = ask (not enforced by Cursor yet, but future-proof).
+PERMISSION="allow"
+if [ "$RC" -eq 3 ]; then
+  PERMISSION="ask"
+fi
+
+jq -n --arg cmd "$REWRITTEN" --arg perm "$PERMISSION" '{
+  "permission": $perm,
   "updated_input": { "command": $cmd }
 }'

--- a/hooks/cursor/rtk-rewrite.sh
+++ b/hooks/cursor/rtk-rewrite.sh
@@ -39,8 +39,14 @@ if [ -z "$CMD" ]; then
 fi
 
 # Delegate all rewrite logic to the Rust binary.
-# rtk rewrite exits 1 when there's no rewrite — hook passes through silently.
-REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null) || { echo '{}'; exit 0; }
+# Exit codes: 0 = allow rewrite, 1 = no rewrite (passthrough),
+#             2 = deny, 3 = ask (Cursor has no ask UX, treat as allow).
+REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null)
+RC=$?
+if [ "$RC" -eq 1 ] || [ "$RC" -eq 2 ] || [ -z "$REWRITTEN" ]; then
+  echo '{}'
+  exit 0
+fi
 
 # No change — nothing to do.
 if [ "$CMD" = "$REWRITTEN" ]; then

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -482,15 +482,14 @@ pub fn run_cursor() -> Result<()> {
         }
     };
 
-    let has_rules = permissions::cursor_has_explicit_rules();
     let output = match decide_hook_action(&cmd, permissions::Host::Cursor) {
         HookDecision::AllowRewrite(rewritten) => {
             audit_log("rewrite", &cmd, &rewritten);
             cursor_allow(&rewritten)
         }
-        HookDecision::AskRewrite(rewritten) if !has_rules => {
+        HookDecision::AskRewrite(rewritten) => {
             audit_log("rewrite", &cmd, &rewritten);
-            cursor_allow(&rewritten)
+            cursor_ask(&rewritten)
         }
         other => {
             if matches!(other, HookDecision::Deny) {
@@ -507,6 +506,15 @@ fn cursor_allow(rewritten: &str) -> String {
     json!({
         "continue": true,
         "permission": "allow",
+        "updated_input": { "command": rewritten }
+    })
+    .to_string()
+}
+
+fn cursor_ask(rewritten: &str) -> String {
+    json!({
+        "continue": true,
+        "permission": "ask",
         "updated_input": { "command": rewritten }
     })
     .to_string()
@@ -540,10 +548,9 @@ fn run_cursor_inner_with_rules(
     };
 
     let verdict = permissions::check_command_with_rules(&cmd, deny_rules, ask_rules, allow_rules);
-    let has_rules = !deny_rules.is_empty() || !ask_rules.is_empty() || !allow_rules.is_empty();
     match decide_from_verdict(&cmd, verdict) {
         HookDecision::AllowRewrite(rewritten) => cursor_allow(&rewritten),
-        HookDecision::AskRewrite(rewritten) if !has_rules => cursor_allow(&rewritten),
+        HookDecision::AskRewrite(rewritten) => cursor_ask(&rewritten),
         _ => "{}".to_string(),
     }
 }
@@ -1056,7 +1063,7 @@ mod tests {
     fn test_cursor_default_verdict_rewrites() {
         let result = run_cursor_inner(&cursor_input("git status"));
         let v: Value = serde_json::from_str(&result).unwrap();
-        assert_eq!(v["permission"], "allow");
+        assert_eq!(v["permission"], "ask");
         assert_eq!(v["updated_input"]["command"], "rtk git status");
     }
 
@@ -1073,14 +1080,15 @@ mod tests {
     }
 
     #[test]
-    fn test_cursor_unallowed_segment_defers() {
+    fn test_cursor_unallowed_segment_asks() {
         let out = run_cursor_inner_with_rules(
             &cursor_input("git status && rm -rf /tmp/x"),
             &[],
             &[],
             &["git *".to_string()],
         );
-        assert_eq!(out, "{}");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["permission"], "ask");
     }
 
     #[test]

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -488,7 +488,7 @@ pub fn run_cursor() -> Result<()> {
             cursor_allow(&rewritten)
         }
         HookDecision::AskRewrite(rewritten) => {
-            audit_log("rewrite", &cmd, &rewritten);
+            audit_log("ask", &cmd, &rewritten);
             cursor_ask(&rewritten)
         }
         other => {

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -482,8 +482,13 @@ pub fn run_cursor() -> Result<()> {
         }
     };
 
+    let has_rules = permissions::cursor_has_explicit_rules();
     let output = match decide_hook_action(&cmd, permissions::Host::Cursor) {
         HookDecision::AllowRewrite(rewritten) => {
+            audit_log("rewrite", &cmd, &rewritten);
+            cursor_allow(&rewritten)
+        }
+        HookDecision::AskRewrite(rewritten) if !has_rules => {
             audit_log("rewrite", &cmd, &rewritten);
             cursor_allow(&rewritten)
         }
@@ -535,8 +540,10 @@ fn run_cursor_inner_with_rules(
     };
 
     let verdict = permissions::check_command_with_rules(&cmd, deny_rules, ask_rules, allow_rules);
+    let has_rules = !deny_rules.is_empty() || !ask_rules.is_empty() || !allow_rules.is_empty();
     match decide_from_verdict(&cmd, verdict) {
         HookDecision::AllowRewrite(rewritten) => cursor_allow(&rewritten),
+        HookDecision::AskRewrite(rewritten) if !has_rules => cursor_allow(&rewritten),
         _ => "{}".to_string(),
     }
 }
@@ -1046,8 +1053,11 @@ mod tests {
     }
 
     #[test]
-    fn test_cursor_no_allow_rule_defers() {
-        assert_eq!(run_cursor_inner(&cursor_input("git status")), "{}");
+    fn test_cursor_default_verdict_rewrites() {
+        let result = run_cursor_inner(&cursor_input("git status"));
+        let v: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(v["permission"], "allow");
+        assert_eq!(v["updated_input"]["command"], "rtk git status");
     }
 
     #[test]

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -223,11 +223,6 @@ fn global_config(dir: &str, file: &str) -> Option<Value> {
     read_json(&dirs::home_dir()?.join(dir).join(file))
 }
 
-pub(crate) fn cursor_has_explicit_rules() -> bool {
-    let (deny, ask, allow) = load_cursor_rules();
-    !deny.is_empty() || !ask.is_empty() || !allow.is_empty()
-}
-
 fn load_cursor_rules() -> (Vec<String>, Vec<String>, Vec<String>) {
     let mut deny = Vec::new();
     let mut allow = Vec::new();

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -223,6 +223,11 @@ fn global_config(dir: &str, file: &str) -> Option<Value> {
     read_json(&dirs::home_dir()?.join(dir).join(file))
 }
 
+pub(crate) fn cursor_has_explicit_rules() -> bool {
+    let (deny, _ask, allow) = load_cursor_rules();
+    !deny.is_empty() || !allow.is_empty()
+}
+
 fn load_cursor_rules() -> (Vec<String>, Vec<String>, Vec<String>) {
     let mut deny = Vec::new();
     let mut allow = Vec::new();

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -224,8 +224,8 @@ fn global_config(dir: &str, file: &str) -> Option<Value> {
 }
 
 pub(crate) fn cursor_has_explicit_rules() -> bool {
-    let (deny, _ask, allow) = load_cursor_rules();
-    !deny.is_empty() || !allow.is_empty()
+    let (deny, ask, allow) = load_cursor_rules();
+    !deny.is_empty() || !ask.is_empty() || !allow.is_empty()
 }
 
 fn load_cursor_rules() -> (Vec<String>, Vec<String>, Vec<String>) {


### PR DESCRIPTION
## Summary

- Fix RTK being completely non-functional on fresh Cursor installs where no explicit permission rules exist in `~/.cursor/cli-config.json`
- When no rules are configured (the default), every command gets `AskRewrite` verdict — but the hook only handled `AllowRewrite`, silently dropping all rewrites
- Now treat `AskRewrite` as allow when no rules are configured (Cursor has no ask-the-user UX); preserve conservative defer behavior when explicit rules exist
- Also fix the legacy shell script (`rtk-rewrite.sh`) which treated exit code 3 (ask) as failure via `||` short-circuit
- Align `cursor_has_explicit_rules()` to include ask rules, matching the inline check in `run_cursor_inner_with_rules()`

Fixes #2372

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Updated unit test: `test_cursor_default_verdict_rewrites` verifies that with no rules, `git status` rewrites to `rtk git status` with `permission: allow`
- [ ] Manual testing: fresh Cursor install with no `cli-config.json` rules — commands should rewrite to `rtk` prefixed versions
- [ ] Manual testing: Cursor with explicit deny/allow rules — conservative behavior preserved