### PR TITLE
fix(docs): update broken troubleshooting links in translated READMEs

### DIFF
--- a/README_es.md
+++ b/README_es.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="https://www.rtk-ai.app">Sitio web</a> &bull;
   <a href="#instalacion">Instalar</a> &bull;
-  <a href="docs/TROUBLESHOOTING.md">Solucion de problemas</a> &bull;
+  <a href="https://www.rtk-ai.app/guide/troubleshooting">Solucion de problemas</a> &bull;
   <a href="docs/contributing/ARCHITECTURE.md">Arquitectura</a> &bull;
   <a href="https://discord.gg/RySmvNF5kF">Discord</a>
 </p>
@@ -166,7 +166,7 @@ rtk discover                    # Descubrir ahorros perdidos
 
 ## Documentacion
 
-- **[TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)** - Resolver problemas comunes
+- **[Solucion de problemas](https://www.rtk-ai.app/guide/troubleshooting)** - Resolver problemas comunes
 - **[INSTALL.md](INSTALL.md)** - Guia de instalacion detallada
 - **[ARCHITECTURE.md](docs/contributing/ARCHITECTURE.md)** - Arquitectura tecnica
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="https://www.rtk-ai.app">Site web</a> &bull;
   <a href="#installation">Installer</a> &bull;
-  <a href="docs/TROUBLESHOOTING.md">Depannage</a> &bull;
+  <a href="https://www.rtk-ai.app/guide/troubleshooting">Depannage</a> &bull;
   <a href="docs/contributing/ARCHITECTURE.md">Architecture</a> &bull;
   <a href="https://discord.gg/RySmvNF5kF">Discord</a>
 </p>
@@ -198,7 +198,7 @@ mode = "failures"
 
 ## Documentation
 
-- **[TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)** - Resoudre les problemes courants
+- **[Depannage](https://www.rtk-ai.app/guide/troubleshooting)** - Resoudre les problemes courants
 - **[INSTALL.md](INSTALL.md)** - Guide d'installation detaille
 - **[ARCHITECTURE.md](docs/contributing/ARCHITECTURE.md)** - Architecture technique
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="https://www.rtk-ai.app">ウェブサイト</a> &bull;
   <a href="#インストール">インストール</a> &bull;
-  <a href="docs/TROUBLESHOOTING.md">トラブルシューティング</a> &bull;
+  <a href="https://www.rtk-ai.app/guide/troubleshooting">トラブルシューティング</a> &bull;
   <a href="docs/contributing/ARCHITECTURE.md">アーキテクチャ</a> &bull;
   <a href="https://discord.gg/RySmvNF5kF">Discord</a>
 </p>
@@ -165,7 +165,7 @@ rtk discover                    # 見逃した節約機会を発見
 
 ## ドキュメント
 
-- **[TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)** - よくある問題の解決
+- **[トラブルシューティング](https://www.rtk-ai.app/guide/troubleshooting)** - よくある問題の解決
 - **[INSTALL.md](INSTALL.md)** - 詳細インストールガイド
 - **[ARCHITECTURE.md](docs/contributing/ARCHITECTURE.md)** - 技術アーキテクチャ
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="https://www.rtk-ai.app">웹사이트</a> &bull;
   <a href="#설치">설치</a> &bull;
-  <a href="docs/TROUBLESHOOTING.md">문제 해결</a> &bull;
+  <a href="https://www.rtk-ai.app/guide/troubleshooting">문제 해결</a> &bull;
   <a href="docs/contributing/ARCHITECTURE.md">아키텍처</a> &bull;
   <a href="https://discord.gg/RySmvNF5kF">Discord</a>
 </p>
@@ -165,7 +165,7 @@ rtk discover                    # 놓친 절약 기회 발견
 
 ## 문서
 
-- **[TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)** - 일반적인 문제 해결
+- **[문제 해결](https://www.rtk-ai.app/guide/troubleshooting)** - 일반적인 문제 해결
 - **[INSTALL.md](INSTALL.md)** - 상세 설치 가이드
 - **[ARCHITECTURE.md](docs/contributing/ARCHITECTURE.md)** - 기술 아키텍처
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="https://www.rtk-ai.app">官网</a> &bull;
   <a href="#安装">安装</a> &bull;
-  <a href="docs/TROUBLESHOOTING.md">故障排除</a> &bull;
+  <a href="https://www.rtk-ai.app/guide/troubleshooting">故障排除</a> &bull;
   <a href="docs/contributing/ARCHITECTURE.md">架构</a> &bull;
   <a href="https://discord.gg/RySmvNF5kF">Discord</a>
 </p>
@@ -172,7 +172,7 @@ rtk discover                    # 发现遗漏的节省机会
 
 ## 文档
 
-- **[TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)** - 解决常见问题
+- **[故障排除](https://www.rtk-ai.app/guide/troubleshooting)** - 解决常见问题
 - **[INSTALL.md](INSTALL.md)** - 详细安装指南
 - **[ARCHITECTURE.md](docs/contributing/ARCHITECTURE.md)** - 技术架构
 


### PR DESCRIPTION
## Summary

- Replace broken `docs/TROUBLESHOOTING.md` references with the live guide URL (`https://www.rtk-ai.app/guide/troubleshooting`) across all translated READMEs
- Fixes `README_ko.md`, `README_es.md`, `README_fr.md`, `README_ja.md`, and `README_zh.md` — both the navigation header link and the documentation section link
- Localize link text from the English filename to each language's native label (e.g. `TROUBLESHOOTING.md` -> `문제 해결`, `故障排除`, etc.)
- Matches the main `README.md` which already uses the live URL

Fixes #2561

## Test plan

- [x] Verified `docs/TROUBLESHOOTING.md` does not exist in the repo
- [x] Verified main `README.md` already uses `https://www.rtk-ai.app/guide/troubleshooting`
- [ ] Click both links in each translated README on GitHub to confirm they resolve