### PR TITLE
fix(hook): apply exclude_commands to head/tail rewrites

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1364,6 +1364,9 @@ fn rewrite_segment_inner(
     if context == RewriteContext::Normal
         && (cmd_part.starts_with("head -") || cmd_part.starts_with("tail "))
     {
+        if is_excluded(cmd_part, excluded) {
+            return None;
+        }
         return rewrite_line_range(cmd_part).map(|r| format!("{}{}", r, redirect_suffix));
     }
 
@@ -3043,6 +3046,32 @@ mod tests {
         assert_eq!(
             rewrite_command_no_prefixes("tail --lines 7 a.log b.log", &[]),
             None
+        );
+    }
+
+    // --- head/tail exclude_commands ---
+
+    #[test]
+    fn test_rewrite_head_excluded() {
+        assert_eq!(
+            rewrite_command_no_prefixes("head -20 package.json", &["head".to_string()]),
+            None
+        );
+    }
+
+    #[test]
+    fn test_rewrite_tail_excluded() {
+        assert_eq!(
+            rewrite_command_no_prefixes("tail -n 10 server.log", &["tail".to_string()]),
+            None
+        );
+    }
+
+    #[test]
+    fn test_rewrite_head_not_excluded_when_tail_is() {
+        assert_eq!(
+            rewrite_command_no_prefixes("head -20 package.json", &["tail".to_string()]),
+            Some("rtk read package.json --max-lines 20".into())
         );
     }
 


### PR DESCRIPTION
## Summary

- The head/tail short-circuit in `rewrite_segment_inner` returned a rewrite before reaching the exclusion check, so `hooks.exclude_commands` entries for head/tail were silently ignored
- Add the `is_excluded()` check before the `rewrite_line_range()` call, matching the pattern used by other commands in the same function

Fixes #2363

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Added unit tests: head excluded, tail excluded, cross-exclusion (excluding tail doesn't affect head)
- [ ] Manual testing: add `head` to `hooks.exclude_commands` in config, verify `head -20 file` is no longer rewritten