### PR TITLE
fix(grep): skip redundant header on single-match results

### DIFF
--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -576,11 +576,14 @@ pub fn run(
         .count();
 
     let mut rtk_output = String::new();
-    rtk_output.push_str(&format!(
-        "{} matches in {} files:\n\n",
-        total_matches,
-        by_file.len()
-    ));
+    if total_matches > 1 || by_file.len() > 1 {
+        let match_word = if total_matches == 1 { "match" } else { "matches" };
+        let file_word = if by_file.len() == 1 { "file" } else { "files" };
+        rtk_output.push_str(&format!(
+            "{} {} in {} {}:\n\n",
+            total_matches, match_word, by_file.len(), file_word
+        ));
+    }
 
     let mut shown = 0;
     let mut files: Vec<_> = by_file.iter().collect();


### PR DESCRIPTION
## Summary

Fixes #2608 — `rtk grep` emitted a redundant `"N matches in M files:"` header even for single-match results.

- Header is now suppressed when there is exactly 1 match in 1 file (saves tokens)
- Fixed grammar: `"1 matches in 1 files"` → `"1 match in 1 file"` for all remaining cases
- Multi-match and multi-file results continue to show the header with correct pluralization

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| 1 match, 1 file | `1 matches in 1 files:\n\nsrc/main.rs:42:...` | `src/main.rs:42:...` |
| 3 matches, 1 file | `3 matches in 1 files:\n\n...` | `3 matches in 1 file:\n\n...` |
| 2 matches, 2 files | `2 matches in 2 files:\n\n...` | `2 matches in 2 files:\n\n...` (unchanged) |

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets` passes (zero warnings)
- [x] `cargo test --all` passes (all tests)