### PR TITLE
fix(dotnet): pass MSBuild query invocations through verbatim

### DIFF
--- a/src/cmds/dotnet/dotnet_cmd.rs
+++ b/src/cmds/dotnet/dotnet_cmd.rs
@@ -112,6 +112,14 @@ pub fn run_passthrough(args: &[OsString], verbose: u8) -> Result<i32> {
 }
 
 fn run_dotnet_with_binlog(subcommand: &str, args: &[String], verbose: u8) -> Result<i32> {
+    // MSBuild query invocations (-getProperty / -getItem / -getTargetResult) make dotnet
+    // print only the requested value(s) to stdout — which may be empty or arbitrary text.
+    // Injecting a binlog and compacting that output would corrupt or discard the result,
+    // so run these verbatim.
+    if is_query_invocation(args) {
+        return run_dotnet_query_passthrough(subcommand, args, verbose);
+    }
+
     let timer = tracking::TimedExecution::start();
     let binlog_path = build_binlog_path(subcommand);
     let should_expect_binlog = subcommand != "test" || has_binlog_arg(args);
@@ -248,6 +256,43 @@ fn run_dotnet_with_binlog(subcommand: &str, args: &[String], verbose: u8) -> Res
     if verbose > 0 {
         eprintln!("Binlog cleaned up: {}", binlog_path.display());
     }
+
+    Ok(result.exit_code)
+}
+
+/// Run a dotnet MSBuild query invocation verbatim: no binlog injection, no compaction.
+/// The requested value(s) are printed to stdout exactly as dotnet emits them.
+fn run_dotnet_query_passthrough(subcommand: &str, args: &[String], verbose: u8) -> Result<i32> {
+    let timer = tracking::TimedExecution::start();
+
+    let mut cmd = resolved_command("dotnet");
+    cmd.env(DOTNET_CLI_UI_LANGUAGE, DOTNET_CLI_UI_LANGUAGE_VALUE);
+    cmd.arg(subcommand);
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    if verbose > 0 {
+        eprintln!(
+            "Running (query passthrough): dotnet {} {}",
+            subcommand,
+            args.join(" ")
+        );
+    }
+
+    let result = exec_capture(&mut cmd)
+        .with_context(|| format!("Failed to run dotnet {}", subcommand))?;
+
+    print!("{}", result.stdout);
+    eprint!("{}", result.stderr);
+
+    let raw = format!("{}\n{}", result.stdout, result.stderr);
+    timer.track(
+        &format!("dotnet {} {}", subcommand, args.join(" ")),
+        &format!("rtk dotnet {} {}", subcommand, args.join(" ")),
+        &raw,
+        &raw,
+    );
 
     Ok(result.exit_code)
 }
@@ -550,6 +595,32 @@ fn build_effective_dotnet_args(
     }
 
     effective
+}
+
+/// MSBuild query switches that make dotnet print only the requested value(s) to stdout.
+const MSBUILD_QUERY_SWITCHES: [&str; 3] = ["getproperty", "getitem", "gettargetresult"];
+
+/// Detect an MSBuild query invocation: `-getProperty:`, `-getItem:`, or `-getTargetResult:`.
+///
+/// Handles all three MSBuild switch prefixes (`-`, `--`, `/`), requires a mandatory `:` after
+/// the keyword (so `-getPropertyGroup` does not match), and compares case-insensitively to
+/// mirror MSBuild's own switch parsing.
+fn is_query_invocation(args: &[String]) -> bool {
+    args.iter().any(|arg| {
+        let stripped = arg
+            .strip_prefix("--")
+            .or_else(|| arg.strip_prefix('-'))
+            .or_else(|| arg.strip_prefix('/'));
+        let Some(rest) = stripped else {
+            return false;
+        };
+        let Some((keyword, _value)) = rest.split_once(':') else {
+            return false;
+        };
+        MSBUILD_QUERY_SWITCHES
+            .iter()
+            .any(|switch| keyword.eq_ignore_ascii_case(switch))
+    })
 }
 
 fn has_binlog_arg(args: &[String]) -> bool {
@@ -1409,6 +1480,37 @@ mod tests {
 
         let args = vec!["--configuration".to_string(), "Release".to_string()];
         assert!(!has_binlog_arg(&args));
+    }
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn test_is_query_invocation_detects_switches() {
+        assert!(is_query_invocation(&args(&["-getProperty:OutputPath"])));
+        assert!(is_query_invocation(&args(&["--getProperty:OutputPath"])));
+        assert!(is_query_invocation(&args(&["/getProperty:OutputPath"])));
+        assert!(is_query_invocation(&args(&["-getItem:Compile"])));
+        assert!(is_query_invocation(&args(&["-getTargetResult:Build"])));
+        // Case-insensitive, mirroring MSBuild.
+        assert!(is_query_invocation(&args(&["-GETPROPERTY:Foo"])));
+        // Present among other args.
+        assert!(is_query_invocation(&args(&[
+            "MyApp.csproj",
+            "-getProperty:TargetFramework"
+        ])));
+    }
+
+    #[test]
+    fn test_is_query_invocation_rejects_non_queries() {
+        assert!(!is_query_invocation(&args(&["build"])));
+        assert!(!is_query_invocation(&args(&["--configuration", "Release"])));
+        // Mandatory colon: a longer switch name without ':' must not match.
+        assert!(!is_query_invocation(&args(&["-getPropertyGroup"])));
+        assert!(!is_query_invocation(&args(&["-getProperty"])));
+        // Empty args.
+        assert!(!is_query_invocation(&[]));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

MSBuild exposes a family of *query* switches that turn a build command into a value-extraction command rather than a real build:

- `-getProperty:<name>` — print the evaluated value of one or more MSBuild properties (e.g. `OutputPath`, `TargetFramework`)
- `-getItem:<type>` — print the items of a given type
- `-getTargetResult:<target>` — print the result of running a target

When you run e.g. `dotnet build -getProperty:TargetFramework`, dotnet does **not** produce normal build output. It prints *only* the requested value(s) to stdout — which may be a single token, several lines, JSON, or even empty. Scripts and tooling routinely consume this output directly.

rtk was treating these invocations as ordinary `dotnet build` runs. That path:

1. injects a `-bl:<tempfile>` binlog argument, and
2. parses the binlog/console output and **compacts it into a build summary** (`ok dotnet build: ...`).

The result: the actual queried value was discarded and replaced with a build-summary line. Anything reading the value back (a shell script capturing `$(rtk dotnet build -getProperty:OutputPath)`, a CI step, etc.) got garbage, which caused real, hard-to-diagnose failures.

## Fix

Detect MSBuild query invocations before the binlog/compaction path runs, and route them to a verbatim passthrough instead.

Detection (`is_query_invocation`) mirrors MSBuild's own switch parsing:
- handles all three switch prefixes — `-`, `--`, and `/`
- requires a mandatory `:` after the keyword, so `-getPropertyGroup` and bare `-getProperty` do **not** match
- compares case-insensitively

The passthrough (`run_dotnet_query_passthrough`) injects nothing (no `-bl`, no `-v:minimal`, no `-nologo`), prints stdout/stderr exactly as dotnet emits them, propagates the exit code, and records usage with no token savings (input == output). This covers both `dotnet build` and `dotnet restore`, which share the binlog code path.

## Tests

Added unit tests covering:
- all three switches across all three prefixes, plus case-insensitivity and presence among other args
- negative cases: regular build flags, the mandatory-colon guard (`-getPropertyGroup`, bare `-getProperty`), and empty args

Full suite: `cargo fmt --all` ✓, `cargo clippy --all-targets` (clean) ✓, `cargo test --all` (2261 passed) ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)