### PR TITLE
fix(grep): stop -l/-t shadowing native grep flags

### DIFF
--- a/.claude/hooks/rtk-suggest.sh
+++ b/.claude/hooks/rtk-suggest.sh
@@ -75,7 +75,11 @@ elif echo "$FIRST_CMD" | grep -qE '^cargo\s+fmt(\s|$)'; then
 elif echo "$FIRST_CMD" | grep -qE '^cat\s+'; then
   SUGGESTION=$(echo "$CMD" | sed 's/^cat /rtk read /')
 elif echo "$FIRST_CMD" | grep -qE '^(rg|grep)\s+'; then
-  SUGGESTION=$(echo "$CMD" | sed -E 's/^(rg|grep) /rtk grep /')
+  # Keep the engine. Mapping `rg` -> `rtk grep` swaps ripgrep for GNU grep, so
+  # rg-only flags break: `rg -t rust FOO` became `rtk grep -t rust FOO`, which
+  # grep rejects with `invalid option -- t`. `rtk rg` is the ripgrep-backed
+  # variant and takes rg's flags verbatim.
+  SUGGESTION=$(echo "$CMD" | sed -E 's/^rg /rtk rg /; s/^grep /rtk grep /')
 elif echo "$FIRST_CMD" | grep -qE '^ls(\s|$)'; then
   SUGGESTION=$(echo "$CMD" | sed 's/^ls/rtk ls/')
 elif echo "$FIRST_CMD" | grep -qE '^tree(\s|$)'; then

--- a/.claude/hooks/rtk-suggest.sh
+++ b/.claude/hooks/rtk-suggest.sh
@@ -75,11 +75,7 @@ elif echo "$FIRST_CMD" | grep -qE '^cargo\s+fmt(\s|$)'; then
 elif echo "$FIRST_CMD" | grep -qE '^cat\s+'; then
   SUGGESTION=$(echo "$CMD" | sed 's/^cat /rtk read /')
 elif echo "$FIRST_CMD" | grep -qE '^(rg|grep)\s+'; then
-  # Keep the engine. Mapping `rg` -> `rtk grep` swaps ripgrep for GNU grep, so
-  # rg-only flags break: `rg -t rust FOO` became `rtk grep -t rust FOO`, which
-  # grep rejects with `invalid option -- t`. `rtk rg` is the ripgrep-backed
-  # variant and takes rg's flags verbatim.
-  SUGGESTION=$(echo "$CMD" | sed -E 's/^rg /rtk rg /; s/^grep /rtk grep /')
+  SUGGESTION=$(echo "$CMD" | sed -E 's/^(rg|grep) /rtk grep /')
 elif echo "$FIRST_CMD" | grep -qE '^ls(\s|$)'; then
   SUGGESTION=$(echo "$CMD" | sed 's/^ls/rtk ls/')
 elif echo "$FIRST_CMD" | grep -qE '^tree(\s|$)'; then

--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -218,7 +218,6 @@ rtk grep <pattern> [chemin] [options]
 | `--max-len` |  | 80 | Longueur maximale de ligne (pas de raccourci, `-l` est reserve a `grep --files-with-matches`) |
 | `--max` |  | 200 | Nombre maximum de resultats (pas de raccourci, `-m` est reserve a `grep --max-count`) |
 | `--context-only` |  | non | Afficher uniquement le contexte du match (pas de raccourci, `-c` est reserve a `grep --count`) |
-| `--line-numbers` | `-n` | oui | Numeros de ligne (toujours actif) |
 
 Les arguments supplementaires sont transmis a `rg` (ripgrep). Les flags qui changent le format de sortie (`-c`, `-l`, `-L`, `-o`, `-Z`) passent directement a `rg`/`grep` sans filtrage RTK.
 

--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -215,17 +215,19 @@ rtk grep <pattern> [chemin] [options]
 
 | Option | Court | Defaut | Description |
 |--------|-------|--------|-------------|
-| `--max-len` |  | 80 | Longueur maximale de ligne (pas de raccourci, `-l` est reserve a `grep --files-with-matches`) |
-| `--max` |  | 200 | Nombre maximum de resultats (pas de raccourci, `-m` est reserve a `grep --max-count`) |
-| `--context-only` |  | non | Afficher uniquement le contexte du match (pas de raccourci, `-c` est reserve a `grep --count`) |
+| `--max-len` |  | 80 | Longueur maximale de ligne |
+| `--max` |  | 200 | Nombre maximum de resultats |
+| `--context-only` |  | non | Afficher uniquement le contexte du match |
 
-Les arguments supplementaires sont transmis a `rg` (ripgrep). Les flags qui changent le format de sortie (`-c`, `-l`, `-L`, `-o`, `-Z`) passent directement a `rg`/`grep` sans filtrage RTK.
+Aucune de ces options n'a de raccourci : `-l`, `-m` et `-c` sont reserves aux flags natifs de meme lettre (`--files-with-matches`, `--max-count`, `--count`) et sont transmis au moteur.
 
-Il n'y a pas d'option `--file-type` : `-t TYPE` est propre a ripgrep et est transmis tel quel au moteur. `rtk rg -t rust` filtre donc par type, tandis que `rtk grep -t rust` remonte l'erreur de grep lui-meme (`invalid option -- 't'`), grep n'ayant pas ce flag.
+Les arguments supplementaires sont transmis au moteur reellement invoque -- `grep` pour `rtk grep`, `rg` pour `rtk rg`, RTK ne substituant jamais l'un a l'autre. Un flag propre a ripgrep (`--glob`, `-t`) n'est donc valide que sous `rtk rg`. Les flags qui changent le format de sortie (`-c`, `-l`, `-L`, `-o`, `-Z`) passent directement au moteur sans filtrage RTK.
+
+Il n'y a pas d'option `--file-type` : `rtk rg -t rust` filtre par type, `rtk grep -t rust` remonte l'erreur de grep (`invalid option -- 't'`).
 
 **Avant / Apres :**
 ```
-# rg "fn run" (20 lignes)                   # rtk grep "fn run" (10 lignes)
+# grep -rn "fn run" (20 lignes)             # rtk grep -rn "fn run" (10 lignes)
 src/git.rs:45:pub fn run(...)                src/git.rs
 src/git.rs:120:fn run_status(...)              45: pub fn run(...)
 src/ls.rs:12:pub fn run(...)                   120: fn run_status(...)

--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -215,13 +215,14 @@ rtk grep <pattern> [chemin] [options]
 
 | Option | Court | Defaut | Description |
 |--------|-------|--------|-------------|
-| `--max-len` | `-l` | 80 | Longueur maximale de ligne |
+| `--max-len` |  | 80 | Longueur maximale de ligne (pas de raccourci, `-l` est reserve a `grep --files-with-matches`) |
 | `--max` |  | 200 | Nombre maximum de resultats (pas de raccourci, `-m` est reserve a `grep --max-count`) |
 | `--context-only` |  | non | Afficher uniquement le contexte du match (pas de raccourci, `-c` est reserve a `grep --count`) |
-| `--file-type` | `-t` | tous | Filtrer par type (ts, py, rust, etc.) |
 | `--line-numbers` | `-n` | oui | Numeros de ligne (toujours actif) |
 
 Les arguments supplementaires sont transmis a `rg` (ripgrep). Les flags qui changent le format de sortie (`-c`, `-l`, `-L`, `-o`, `-Z`) passent directement a `rg`/`grep` sans filtrage RTK.
+
+Il n'y a pas d'option `--file-type` : `-t TYPE` est propre a ripgrep et est transmis tel quel au moteur. `rtk rg -t rust` filtre donc par type, tandis que `rtk grep -t rust` remonte l'erreur de grep lui-meme (`invalid option -- 't'`), grep n'ayant pas ce flag.
 
 **Avant / Apres :**
 ```

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -215,7 +215,7 @@ bench "git show" "git show HEAD --stat 2>/dev/null || true" "$RTK git show HEAD 
 section "grep"
 bench "grep fn" "grep -rn 'fn ' src/ || true" "$RTK grep -rn 'fn ' src/"
 bench "grep struct" "grep -rn 'struct ' src/ || true" "$RTK grep -rn 'struct ' src/"
-bench "grep -l 40" "grep -rn 'fn ' src/ || true" "$RTK grep -rn 'fn ' src/ -l 40"
+bench "grep --max-len 40" "grep -rn 'fn ' src/ || true" "$RTK grep --max-len 40 -rn 'fn ' src/"
 bench "grep -c" "grep -ron 'fn ' src/ || true" "$RTK grep -rc 'fn ' src/"
 
 # ===================

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -259,7 +259,15 @@ section "Grep"
 
 assert_ok      "rtk grep pattern"             rtk grep "pub fn" src/
 assert_contains "rtk grep finds results"      "pub fn" rtk grep "pub fn" src/
-assert_ok      "rtk grep with file type"      rtk grep "pub fn" src/ -t rust
+# `-t` is rg-only. rtk used to swallow it via its own --file-type option, which
+# never reached the engine, so this asserted a silent no-op. --file-type is gone;
+# `-t` now flows to the engine, so pin it against the engine that has it.
+assert_fails   "rtk grep -t rejected by grep"  rtk grep "pub fn" src/ -t rust
+if command -v rg >/dev/null 2>&1; then
+    assert_ok  "rtk rg with file type"         rtk rg "pub fn" src/ -t rust
+else
+    skip_test  "rtk rg with file type"         "rg not installed"
+fi
 
 section "Grep (extra args passthrough)"
 

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -258,22 +258,13 @@ fi
 section "Grep"
 
 # All three need -r: `grep PATTERN <dir>` without it exits 2 ("Is a directory"),
-# which made the first two assertions red and the third one INERT -- assert_fails
-# passed on the directory error whether or not `-t` was handled correctly.
+# which made the first two assertions red and the third one inert.
 assert_ok      "rtk grep pattern"             rtk grep -r "pub fn" src/
 assert_contains "rtk grep finds results"      "pub fn" rtk grep -r "pub fn" src/
-# `-t` is rg-only. rtk used to swallow it via its own --file-type option, which
-# never reached the engine, so the old assertion here pinned a silent no-op.
-#
-# This form is deliberate and fragile to get right. The pattern MUST match and
-# the path MUST be a single file with `-t` FIRST, so that the only reason the
-# command can fail is `-t` itself:
-#   - re-add --file-type with `short = 't'`  -> -t binds, "fn main" matches,
-#                                               exit 0, and assert_fails fires.
-#   - as shipped                             -> -t reaches grep, exit 2.
-# A directory path (exit 2, "Is a directory"), a non-matching pattern (exit 1),
-# or `-t` after another flag (trailing_var_arg swallows it before clap sees it)
-# all make this assertion inert -- it passes either way.
+# `-t` is rg-only. The form matters: the pattern must match, the path must be a
+# single file, and `-t` must come first, so the only reason to fail is `-t`
+# itself -- a directory, a non-matching pattern, or `-t` after another flag all
+# make this assertion pass either way.
 assert_fails   "rtk grep -t rejected by grep"  rtk grep -t rust "fn main" src/main.rs
 if command -v rg >/dev/null 2>&1; then
     assert_ok  "rtk rg with file type"         rtk rg "pub fn" src/ -t rust

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -257,12 +257,24 @@ fi
 
 section "Grep"
 
-assert_ok      "rtk grep pattern"             rtk grep "pub fn" src/
-assert_contains "rtk grep finds results"      "pub fn" rtk grep "pub fn" src/
+# All three need -r: `grep PATTERN <dir>` without it exits 2 ("Is a directory"),
+# which made the first two assertions red and the third one INERT -- assert_fails
+# passed on the directory error whether or not `-t` was handled correctly.
+assert_ok      "rtk grep pattern"             rtk grep -r "pub fn" src/
+assert_contains "rtk grep finds results"      "pub fn" rtk grep -r "pub fn" src/
 # `-t` is rg-only. rtk used to swallow it via its own --file-type option, which
-# never reached the engine, so this asserted a silent no-op. --file-type is gone;
-# `-t` now flows to the engine, so pin it against the engine that has it.
-assert_fails   "rtk grep -t rejected by grep"  rtk grep "pub fn" src/ -t rust
+# never reached the engine, so the old assertion here pinned a silent no-op.
+#
+# This form is deliberate and fragile to get right. The pattern MUST match and
+# the path MUST be a single file with `-t` FIRST, so that the only reason the
+# command can fail is `-t` itself:
+#   - re-add --file-type with `short = 't'`  -> -t binds, "fn main" matches,
+#                                               exit 0, and assert_fails fires.
+#   - as shipped                             -> -t reaches grep, exit 2.
+# A directory path (exit 2, "Is a directory"), a non-matching pattern (exit 1),
+# or `-t` after another flag (trailing_var_arg swallows it before clap sees it)
+# all make this assertion inert -- it passes either way.
+assert_fails   "rtk grep -t rejected by grep"  rtk grep -t rust "fn main" src/main.rs
 if command -v rg >/dev/null 2>&1; then
     assert_ok  "rtk rg with file type"         rtk rg "pub fn" src/ -t rust
 else

--- a/scripts/test-aristote.sh
+++ b/scripts/test-aristote.sh
@@ -121,9 +121,16 @@ assert_ok       "rtk read --max-lines 10"       rtk read --max-lines 10 "$ARISTO
 
 section "Grep"
 
-assert_ok       "rtk grep import"               rtk grep "import" "$ARISTOTE/src"
-assert_ok       "rtk grep with type filter"     rtk grep "useState" "$ARISTOTE/src" -t tsx
-assert_contains "rtk grep finds components"     "import" rtk grep "import" "$ARISTOTE/src"
+# `grep PATTERN <dir>` without -r exits 2 ("Is a directory").
+assert_ok       "rtk grep import"               rtk grep -r "import" "$ARISTOTE/src"
+assert_contains "rtk grep finds components"     "import" rtk grep -r "import" "$ARISTOTE/src"
+
+# `-t` is rg-only, so the type filter belongs to the rg engine.
+if command -v rg >/dev/null 2>&1; then
+    assert_ok   "rtk rg with type filter"       rtk rg "useState" "$ARISTOTE/src" -t tsx
+else
+    skip_test   "rtk rg with type filter"       "rg not installed"
+fi
 
 # ── 4. Git ───────────────────────────────────────────
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -313,46 +313,15 @@ enum Commands {
 
     /// Compact grep - strips whitespace, truncates, groups by file
     Grep {
-        // NOTE: rtk's own tuning options here are intentionally long-only.
-        // Their natural short forms collide with native grep/rg flags of the
-        // same letter, which users routinely pass. A short option here shadows
-        // the native flag and either crashes clap or silently applies the wrong
-        // semantics, defeating the `extra_args` passthrough. Keep them long-only
-        // so native flags reach src/cmds/system/search.rs, the shared filter
-        // behind both `rtk grep` and `rtk rg`. (Continues the `-v`/`-n`/pattern/
-        // path cleanup from 84616d1.)
-        //
-        // This does NOT clear every shadowed short. Clap's auto `-h` still wins
-        // over grep/rg's --no-filename before the first positional, and after it
-        // `-h` reaches search.rs's --version/--help check and execs unfiltered.
-        // Help handling is #2532's scope, not this variant's -- do not "finish"
-        // it here by adding disable_help_flag without reading that PR first.
-        //
-        // Removing a short here also does not make the flag safe end-to-end.
-        // search.rs shares one VALUE_FLAGS_SHORT table across both engines, so a
-        // letter that takes a value in rg but not grep (`-t`, `-T`, `-r`) still
-        // eats the next token inside a cluster: `rtk grep -rt FOO .` consumes
-        // FOO as -t's value regardless of what clap does. That is a search.rs
-        // defect, tracked separately.
+        // rtk's own options here are long-only: a short form shadows the native
+        // grep/rg flag of the same letter and captures it before it can reach
+        // src/cmds/system/search.rs, the shared filter behind `rtk grep` and
+        // `rtk rg`.
         /// Max line length
-        // No short: `-l` is grep's --files-with-matches. Binding it to --max-len
-        // (a `usize`) split behavior on whether the PATTERN parsed as a number.
-        //
-        // Non-numeric pattern: clap rejected it, run_fallback re-ran raw grep,
-        // and the user got the right answer. Wasteful, not harmful -- and note
-        // `-l` is a has_format_flag passthrough on the fixed path too, so no
-        // compaction was "lost"; there is none to lose for this flag.
-        //
-        // Numeric pattern: clap ACCEPTED it. `rtk grep -l 8080 a.txt b.txt` set
-        // max_len=8080 and left a.txt as the pattern, b.txt as the only path --
-        // no error, no fallback, silently empty output and exit 1 on a file that
-        // does match. With a single file it is worse: the filename becomes the
-        // pattern, no path is left, and rtk falls back to reading stdin -- which
-        // exits 1 on /dev/null and hangs outright on an interactive terminal.
-        // That silent wrong answer, reached through a hook the user never opted
-        // into, is the real reason this short had to go.
-        // Pinned by tests::test_grep_parse_files_with_matches_l (clap layer) and
-        // numeric_pattern_with_files_with_matches_flag (end to end).
+        // No short: `-l` is grep's --files-with-matches. Bound to a `usize` it
+        // accepted numeric patterns -- `rtk grep -l 8080 a.txt b.txt` set
+        // max_len=8080, took a.txt as the pattern, and returned empty output
+        // with no error.
         #[arg(long, default_value = "80")]
         max_len: usize,
         /// Max results to show
@@ -367,11 +336,9 @@ enum Commands {
         /// Show only match context (not full line)
         #[arg(long)]
         context_only: bool,
-        // No --file-type / `-t`: `-t TYPE` is rg's type filter, and the option
-        // never did anything under `rtk grep` -- it was destructured away at the
-        // call site and never reached the engine. Removed rather than left as a
-        // parse-only no-op; `rtk rg -t rust` still filters by type, since it
-        // forwards `-t` to real ripgrep.
+        // No --file-type: `-t TYPE` is rg's type filter and the option never
+        // reached the engine, so `rtk rg -t rust` filters by type while
+        // `rtk grep -t rust` surfaces grep's own error.
         /// Pattern, path, and any grep/rg flags (e.g. -v, -i, -A 3, --glob, --version)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         extra_args: Vec<String>,
@@ -3738,13 +3705,9 @@ mod tests {
 
     // --- grep argument routing (clap layer) ---
     //
-    // The `Grep` variant funnels the pattern, path, and every native grep/rg
-    // flag into a single `trailing_var_arg` slot so `src/cmds/system/search.rs`
-    // -- the shared filter behind both `rtk grep` and `rtk rg` -- can parse them
-    // with full grep/rg semantics. Commit 84616d1 ("fix(grep): stabilize
-    // argument parsing") moved to this design but left the struct's own short
-    // options in place, where they still shadowed native flags of the same
-    // letter. These tests pin the routing.
+    // The `Grep` variant funnels the pattern, path, and every native grep/rg flag
+    // into one trailing slot so `src/cmds/system/search.rs` parses them with full
+    // grep/rg semantics. These tests pin that routing.
 
     /// Parse `rtk grep …` and return the captured `extra_args`, or `None` if
     /// clap rejects the invocation (e.g. a colliding short option mis-binds).
@@ -3754,9 +3717,6 @@ mod tests {
             _ => None,
         }
     }
-
-    // Characterization: behavior that must be PRESERVED (passes today, untested
-    // until now). Guards the 84616d1 design against regression.
 
     #[test]
     fn test_grep_parse_simple_pattern_path() {
@@ -3787,8 +3747,8 @@ mod tests {
 
     #[test]
     fn test_grep_parse_invert_match_v_not_shadowed() {
-        // Regression guard for 84616d1: `-v` (invert-match) must reach grep,
-        // not be captured as rtk's top-level verbose flag.
+        // `-v` (invert-match) must reach grep, not be captured as rtk's
+        // top-level verbose flag.
         assert_eq!(
             grep_extra_args(&["rtk", "grep", "-v", "FOO", "file"]).unwrap(),
             vec!["-v", "FOO", "file"]
@@ -3797,17 +3757,12 @@ mod tests {
 
     #[test]
     fn test_grep_parse_alternation_pattern_intact() {
-        // Extended-regex alternation must pass through untouched (#1436 lineage).
+        // Extended-regex alternation must pass through untouched.
         assert_eq!(
             grep_extra_args(&["rtk", "grep", "-nE", "a|b", "file"]).unwrap(),
             vec!["-nE", "a|b", "file"]
         );
     }
-
-    // The fix: native `-l`/`-m`/`-t` must route to search.rs, not be captured by
-    // the struct's own short options. `-l` mis-bound to `max_len: usize`, so clap
-    // rejected the pattern outright; `-m`/`-t` silently swallowed their value with
-    // the wrong semantics. (`-m` was fixed separately in #3259; pinned here too.)
 
     #[test]
     fn test_grep_parse_files_with_matches_l() {
@@ -3820,11 +3775,8 @@ mod tests {
 
     #[test]
     fn test_grep_parse_type_t_forwarded() {
-        // `-t TYPE` is rg-only, so it must reach the engine rather than binding
-        // to an rtk option. search.rs lists `t` in VALUE_FLAGS_SHORT and forwards
-        // it verbatim: under `rtk rg` it filters by type, under `rtk grep` it
-        // surfaces grep's own `invalid option -- 't'` instead of being silently
-        // dropped.
+        // `-t TYPE` is rg-only and must reach the engine: `rtk rg` filters by
+        // type, `rtk grep` surfaces grep's own `invalid option -- 't'`.
         assert_eq!(
             grep_extra_args(&["rtk", "grep", "-t", "rust", "FOO", "src/"]).unwrap(),
             vec!["-t", "rust", "FOO", "src/"]
@@ -3833,18 +3785,14 @@ mod tests {
 
     #[test]
     fn test_grep_file_type_option_is_gone() {
-        // `--file-type` was removed, not merely un-shorted. Guard against it
-        // creeping back: an unknown long flag is NOT a clap error here (the
-        // trailing slot accepts it), it must route to extra_args and be the
-        // engine's problem. If someone re-adds the option, clap binds it and
-        // extra_args loses these two tokens.
+        // `--file-type` was removed, not merely un-shorted: an unknown long flag
+        // routes to extra_args and is the engine's problem. Re-adding the option
+        // would bind it here and cost extra_args these two tokens.
         assert_eq!(
             grep_extra_args(&["rtk", "grep", "--file-type", "rust", "FOO", "src/"]).unwrap(),
             vec!["--file-type", "rust", "FOO", "src/"]
         );
     }
-
-    // --- additional grep characterization (preserved behavior, was untested) ---
 
     /// Parse `rtk grep …` into the full `Grep` field set for inspection.
     fn parse_grep(args: &[&str]) -> Result<(usize, usize, bool, Vec<String>), clap::Error> {
@@ -3861,9 +3809,8 @@ mod tests {
 
     #[test]
     fn test_grep_long_options_bind_before_pattern() {
-        // rtk's tuning knobs are long-only (the short forms were removed to stop
-        // shadowing native grep flags). They must still bind when placed before
-        // the pattern, and only the pattern/path land in extra_args.
+        // Long-only knobs must still bind when placed before the pattern, with
+        // only the pattern/path landing in extra_args.
         let (max_len, max, context_only, extra_args) = parse_grep(&[
             "rtk",
             "grep",
@@ -3884,12 +3831,9 @@ mod tests {
 
     #[test]
     fn test_grep_options_after_pattern_stay_in_extra_args() {
-        // Positional gotcha: once the pattern starts the trailing slot, later
-        // tokens — even rtk's own `--max-len` — are NOT parsed as options; they
-        // pass through verbatim. (Native grep ordering: flags come before the
-        // pattern.) The mechanism is `allow_hyphen_values` on `extra_args`, not
-        // `trailing_var_arg` — dropping the latter leaves this behavior intact,
-        // so do not read this test as a guard on `trailing_var_arg`.
+        // Once the pattern starts the trailing slot, later tokens — even rtk's
+        // own `--max-len` — pass through verbatim rather than binding as options.
+        // The mechanism is `allow_hyphen_values`, not `trailing_var_arg`.
         let (max_len, _, _, extra_args) =
             parse_grep(&["rtk", "grep", "FOO", "--max-len", "40"]).unwrap();
         assert_eq!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -313,8 +313,21 @@ enum Commands {
 
     /// Compact grep - strips whitespace, truncates, groups by file
     Grep {
+        // NOTE: rtk's own tuning options here are intentionally long-only.
+        // Their natural short forms collide with native grep/rg flags of the
+        // same letter, which users routinely pass. A short option here shadows
+        // the native flag and either crashes clap or silently applies the wrong
+        // semantics, defeating the `extra_args` passthrough. Keep them long-only
+        // so native flags reach src/cmds/system/search.rs, the shared filter
+        // behind both `rtk grep` and `rtk rg`. (Completes the `-v`/`-n`/pattern/
+        // path cleanup from 84616d1.)
         /// Max line length
-        #[arg(short = 'l', long, default_value = "80")]
+        // No short: `-l` is grep's --files-with-matches. Bound to RTK's
+        // --max-len (a `usize`), `rtk grep -l PATTERN` could not parse at all --
+        // clap aborted with exit 2 and rtk fell back to raw grep, losing all
+        // compaction. Without the short, `-l` flows to extra_args and reaches
+        // grep/rg, which lists matching filenames as the user intended.
+        #[arg(long, default_value = "80")]
         max_len: usize,
         /// Max results to show
         // No short: `-m` is GNU grep's --max-count (stop after N matches per
@@ -328,9 +341,11 @@ enum Commands {
         /// Show only match context (not full line)
         #[arg(long)]
         context_only: bool,
-        /// Filter by file type (e.g., ts, py, rust)
-        #[arg(short = 't', long)]
-        file_type: Option<String>,
+        // No --file-type / `-t`: `-t TYPE` is rg's type filter, and the option
+        // never did anything under `rtk grep` -- it was destructured away at the
+        // call site and never reached the engine. Removed rather than left as a
+        // parse-only no-op; `rtk rg -t rust` still filters by type, since it
+        // forwards `-t` to real ripgrep.
         /// Pattern, path, and any grep/rg flags (e.g. -v, -i, -A 3, --glob, --version)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         extra_args: Vec<String>,
@@ -2005,7 +2020,6 @@ fn run_cli() -> Result<i32> {
             max_len,
             max,
             context_only,
-            file_type: _,
             extra_args,
         } => search::run(
             search::Engine::Grep,
@@ -3694,5 +3708,182 @@ mod tests {
             }
             _ => panic!("Expected Init command"),
         }
+    }
+
+    // --- grep argument routing (clap layer) ---
+    //
+    // The `Grep` variant funnels the pattern, path, and every native grep/rg
+    // flag into a single `trailing_var_arg` slot so `src/cmds/system/search.rs`
+    // -- the shared filter behind both `rtk grep` and `rtk rg` -- can parse them
+    // with full grep/rg semantics. Commit 84616d1 ("fix(grep): stabilize
+    // argument parsing") moved to this design but left the struct's own short
+    // options in place, where they still shadowed native flags of the same
+    // letter. These tests pin the routing.
+
+    /// Parse `rtk grep …` and return the captured `extra_args`, or `None` if
+    /// clap rejects the invocation (e.g. a colliding short option mis-binds).
+    fn grep_extra_args(args: &[&str]) -> Option<Vec<String>> {
+        match Cli::try_parse_from(args).ok()?.command {
+            Commands::Grep { extra_args, .. } => Some(extra_args),
+            _ => None,
+        }
+    }
+
+    // Characterization: behavior that must be PRESERVED (passes today, untested
+    // until now). Guards the 84616d1 design against regression.
+
+    #[test]
+    fn test_grep_parse_simple_pattern_path() {
+        assert_eq!(
+            grep_extra_args(&["rtk", "grep", "FOO", "src/"]).unwrap(),
+            vec!["FOO", "src/"]
+        );
+    }
+
+    #[test]
+    fn test_grep_parse_combined_short_cluster() {
+        // `-rn` is a native grep cluster (recursive + line-numbers); it must
+        // reach search.rs intact, not be intercepted by clap.
+        assert_eq!(
+            grep_extra_args(&["rtk", "grep", "-rn", "FOO", "src/"]).unwrap(),
+            vec!["-rn", "FOO", "src/"]
+        );
+    }
+
+    #[test]
+    fn test_grep_parse_value_flag_after_context() {
+        // `-A 3` (after-context) — the value must not be stolen by clap.
+        assert_eq!(
+            grep_extra_args(&["rtk", "grep", "-A", "3", "FOO", "file"]).unwrap(),
+            vec!["-A", "3", "FOO", "file"]
+        );
+    }
+
+    #[test]
+    fn test_grep_parse_invert_match_v_not_shadowed() {
+        // Regression guard for 84616d1: `-v` (invert-match) must reach grep,
+        // not be captured as rtk's top-level verbose flag.
+        assert_eq!(
+            grep_extra_args(&["rtk", "grep", "-v", "FOO", "file"]).unwrap(),
+            vec!["-v", "FOO", "file"]
+        );
+    }
+
+    #[test]
+    fn test_grep_parse_alternation_pattern_intact() {
+        // Extended-regex alternation must pass through untouched (#1436 lineage).
+        assert_eq!(
+            grep_extra_args(&["rtk", "grep", "-nE", "a|b", "file"]).unwrap(),
+            vec!["-nE", "a|b", "file"]
+        );
+    }
+
+    // The fix: native `-l`/`-m`/`-t` must route to search.rs, not be captured by
+    // the struct's own short options. `-l` mis-bound to `max_len: usize`, so clap
+    // rejected the pattern outright; `-m`/`-t` silently swallowed their value with
+    // the wrong semantics. (`-m` was fixed separately in #3259; pinned here too.)
+
+    #[test]
+    fn test_grep_parse_files_with_matches_l() {
+        // Native grep `-l` (files-with-matches). Must parse and pass `-l` through.
+        assert_eq!(
+            grep_extra_args(&["rtk", "grep", "-l", "FOO", "src/"]).unwrap(),
+            vec!["-l", "FOO", "src/"]
+        );
+    }
+
+    #[test]
+    fn test_grep_parse_max_count_m_forwarded() {
+        // Native grep `-m N` (max-count). The value `5` must reach search.rs,
+        // not be eaten as rtk's `--max`.
+        assert_eq!(
+            grep_extra_args(&["rtk", "grep", "-m", "5", "FOO", "file"]).unwrap(),
+            vec!["-m", "5", "FOO", "file"]
+        );
+    }
+
+    #[test]
+    fn test_grep_parse_type_t_forwarded() {
+        // `-t TYPE` is rg-only, so it must reach the engine rather than binding
+        // to an rtk option. search.rs lists `t` in VALUE_FLAGS_SHORT and forwards
+        // it verbatim: under `rtk rg` it filters by type, under `rtk grep` it
+        // surfaces grep's own `invalid option -- 't'` instead of being silently
+        // dropped.
+        assert_eq!(
+            grep_extra_args(&["rtk", "grep", "-t", "rust", "FOO", "src/"]).unwrap(),
+            vec!["-t", "rust", "FOO", "src/"]
+        );
+    }
+
+    // --- additional grep characterization (preserved behavior, was untested) ---
+
+    /// Parse `rtk grep …` into the full `Grep` field set for inspection.
+    fn parse_grep(args: &[&str]) -> Result<(usize, usize, bool, Vec<String>), clap::Error> {
+        match Cli::try_parse_from(args)?.command {
+            Commands::Grep {
+                max_len,
+                max,
+                context_only,
+                extra_args,
+            } => Ok((max_len, max, context_only, extra_args)),
+            _ => unreachable!("parsed a grep command"),
+        }
+    }
+
+    #[test]
+    fn test_grep_long_options_bind_before_pattern() {
+        // rtk's tuning knobs are long-only (the short forms were removed to stop
+        // shadowing native grep flags). They must still bind when placed before
+        // the pattern, and only the pattern/path land in extra_args.
+        let (max_len, max, context_only, extra_args) = parse_grep(&[
+            "rtk",
+            "grep",
+            "--max-len",
+            "40",
+            "--max",
+            "5",
+            "--context-only",
+            "FOO",
+            "path",
+        ])
+        .unwrap();
+        assert_eq!(max_len, 40);
+        assert_eq!(max, 5);
+        assert!(context_only);
+        assert_eq!(extra_args, vec!["FOO", "path"]);
+    }
+
+    #[test]
+    fn test_grep_options_after_pattern_stay_in_extra_args() {
+        // trailing_var_arg gotcha: once the pattern starts the trailing slot,
+        // later tokens — even rtk's own `--max-len` — are NOT parsed as options;
+        // they pass through verbatim. (Native grep ordering: flags come before
+        // the pattern.)
+        let (max_len, _, _, extra_args) =
+            parse_grep(&["rtk", "grep", "FOO", "--max-len", "40"]).unwrap();
+        assert_eq!(
+            max_len, 80,
+            "option after pattern must NOT bind (default kept)"
+        );
+        assert_eq!(extra_args, vec!["FOO", "--max-len", "40"]);
+    }
+
+    #[test]
+    fn test_grep_version_routes_to_extra_args() {
+        // `--version` is not a subcommand flag (version isn't propagated), so it
+        // lands in extra_args and grep_cmd::run forwards it to rg --version.
+        assert_eq!(
+            grep_extra_args(&["rtk", "grep", "--version"]).unwrap(),
+            vec!["--version"]
+        );
+    }
+
+    #[test]
+    fn test_grep_double_dash_consumed_by_clap() {
+        // clap strips the `--` separator before populating trailing_var_arg.
+        // core::args_utils::restore_double_dash re-inserts it at runtime — this
+        // test pins the premise that helper depends on.
+        let (_, _, _, extra_args) = parse_grep(&["rtk", "grep", "--", "-v", "file"]).unwrap();
+        assert_eq!(extra_args, vec!["-v", "file"], "clap must consume the --");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -319,8 +319,21 @@ enum Commands {
         // the native flag and either crashes clap or silently applies the wrong
         // semantics, defeating the `extra_args` passthrough. Keep them long-only
         // so native flags reach src/cmds/system/search.rs, the shared filter
-        // behind both `rtk grep` and `rtk rg`. (Completes the `-v`/`-n`/pattern/
+        // behind both `rtk grep` and `rtk rg`. (Continues the `-v`/`-n`/pattern/
         // path cleanup from 84616d1.)
+        //
+        // This does NOT clear every shadowed short. Clap's auto `-h` still wins
+        // over grep/rg's --no-filename before the first positional, and after it
+        // `-h` reaches search.rs's --version/--help check and execs unfiltered.
+        // Help handling is #2532's scope, not this variant's -- do not "finish"
+        // it here by adding disable_help_flag without reading that PR first.
+        //
+        // Removing a short here also does not make the flag safe end-to-end.
+        // search.rs shares one VALUE_FLAGS_SHORT table across both engines, so a
+        // letter that takes a value in rg but not grep (`-t`, `-T`, `-r`) still
+        // eats the next token inside a cluster: `rtk grep -rt FOO .` consumes
+        // FOO as -t's value regardless of what clap does. That is a search.rs
+        // defect, tracked separately.
         /// Max line length
         // No short: `-l` is grep's --files-with-matches. Bound to RTK's
         // --max-len (a `usize`), `rtk grep -l PATTERN` could not parse at all --
@@ -3793,16 +3806,6 @@ mod tests {
     }
 
     #[test]
-    fn test_grep_parse_max_count_m_forwarded() {
-        // Native grep `-m N` (max-count). The value `5` must reach search.rs,
-        // not be eaten as rtk's `--max`.
-        assert_eq!(
-            grep_extra_args(&["rtk", "grep", "-m", "5", "FOO", "file"]).unwrap(),
-            vec!["-m", "5", "FOO", "file"]
-        );
-    }
-
-    #[test]
     fn test_grep_parse_type_t_forwarded() {
         // `-t TYPE` is rg-only, so it must reach the engine rather than binding
         // to an rtk option. search.rs lists `t` in VALUE_FLAGS_SHORT and forwards
@@ -3812,6 +3815,19 @@ mod tests {
         assert_eq!(
             grep_extra_args(&["rtk", "grep", "-t", "rust", "FOO", "src/"]).unwrap(),
             vec!["-t", "rust", "FOO", "src/"]
+        );
+    }
+
+    #[test]
+    fn test_grep_file_type_option_is_gone() {
+        // `--file-type` was removed, not merely un-shorted. Guard against it
+        // creeping back: an unknown long flag is NOT a clap error here (the
+        // trailing slot accepts it), it must route to extra_args and be the
+        // engine's problem. If someone re-adds the option, clap binds it and
+        // extra_args loses these two tokens.
+        assert_eq!(
+            grep_extra_args(&["rtk", "grep", "--file-type", "rust", "FOO", "src/"]).unwrap(),
+            vec!["--file-type", "rust", "FOO", "src/"]
         );
     }
 
@@ -3855,10 +3871,12 @@ mod tests {
 
     #[test]
     fn test_grep_options_after_pattern_stay_in_extra_args() {
-        // trailing_var_arg gotcha: once the pattern starts the trailing slot,
-        // later tokens — even rtk's own `--max-len` — are NOT parsed as options;
-        // they pass through verbatim. (Native grep ordering: flags come before
-        // the pattern.)
+        // Positional gotcha: once the pattern starts the trailing slot, later
+        // tokens — even rtk's own `--max-len` — are NOT parsed as options; they
+        // pass through verbatim. (Native grep ordering: flags come before the
+        // pattern.) The mechanism is `allow_hyphen_values` on `extra_args`, not
+        // `trailing_var_arg` — dropping the latter leaves this behavior intact,
+        // so do not read this test as a guard on `trailing_var_arg`.
         let (max_len, _, _, extra_args) =
             parse_grep(&["rtk", "grep", "FOO", "--max-len", "40"]).unwrap();
         assert_eq!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -335,11 +335,24 @@ enum Commands {
         // FOO as -t's value regardless of what clap does. That is a search.rs
         // defect, tracked separately.
         /// Max line length
-        // No short: `-l` is grep's --files-with-matches. Bound to RTK's
-        // --max-len (a `usize`), `rtk grep -l PATTERN` could not parse at all --
-        // clap aborted with exit 2 and rtk fell back to raw grep, losing all
-        // compaction. Without the short, `-l` flows to extra_args and reaches
-        // grep/rg, which lists matching filenames as the user intended.
+        // No short: `-l` is grep's --files-with-matches. Binding it to --max-len
+        // (a `usize`) split behavior on whether the PATTERN parsed as a number.
+        //
+        // Non-numeric pattern: clap rejected it, run_fallback re-ran raw grep,
+        // and the user got the right answer. Wasteful, not harmful -- and note
+        // `-l` is a has_format_flag passthrough on the fixed path too, so no
+        // compaction was "lost"; there is none to lose for this flag.
+        //
+        // Numeric pattern: clap ACCEPTED it. `rtk grep -l 8080 a.txt b.txt` set
+        // max_len=8080 and left a.txt as the pattern, b.txt as the only path --
+        // no error, no fallback, silently empty output and exit 1 on a file that
+        // does match. With a single file it is worse: the filename becomes the
+        // pattern, no path is left, and rtk falls back to reading stdin -- which
+        // exits 1 on /dev/null and hangs outright on an interactive terminal.
+        // That silent wrong answer, reached through a hook the user never opted
+        // into, is the real reason this short had to go.
+        // Pinned by tests::test_grep_parse_files_with_matches_l (clap layer) and
+        // numeric_pattern_with_files_with_matches_flag (end to end).
         #[arg(long, default_value = "80")]
         max_len: usize,
         /// Max results to show
@@ -3889,7 +3902,8 @@ mod tests {
     #[test]
     fn test_grep_version_routes_to_extra_args() {
         // `--version` is not a subcommand flag (version isn't propagated), so it
-        // lands in extra_args and grep_cmd::run forwards it to rg --version.
+        // lands in extra_args, and search::run's --version/--help check execs it
+        // against the engine unfiltered.
         assert_eq!(
             grep_extra_args(&["rtk", "grep", "--version"]).unwrap(),
             vec!["--version"]

--- a/tests/search_compress_test.rs
+++ b/tests/search_compress_test.rs
@@ -316,6 +316,55 @@ fn small_grep_not_worse_than_plain() {
     );
 }
 
+// --- #2628: rtk's own long options still bind after the short forms were removed ---
+
+#[test]
+fn max_len_long_option_still_binds_to_rtk() {
+    if !rg_available() {
+        return;
+    }
+    // The other half of #2628: dropping the `-l` short must not stop the long
+    // form from reaching rtk's truncation. Needs a bulky match set -- a small
+    // result passes through uncompressed under the never-worse-than-plain
+    // guard, so a one-line file would prove nothing either way.
+    let body: String = (0..60)
+        .map(|i| format!("MATCH {i} {}\n", "x".repeat(400)))
+        .collect();
+    let (_dir, path) = write_temp(&body);
+    let file = path.to_str().unwrap();
+
+    // Measure matched lines only. rtk's own trailer ("+N more ... [see
+    // remaining: tail ...]") is fixed-width chrome that --max-len does not
+    // govern, and it is the longest line in either run.
+    let widest_match = |args: &[&str]| -> usize {
+        let out = rtk().args(args).output().expect("rtk grep");
+        assert!(
+            out.status.success(),
+            "stderr={}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .filter(|l| l.starts_with("MATCH "))
+            .map(|l| l.chars().count())
+            .max()
+            .unwrap_or(0)
+    };
+
+    let narrow = widest_match(&["grep", "--max-len", "40", "MATCH", file]);
+    let default = widest_match(&["grep", "MATCH", file]);
+
+    assert!(
+        narrow > 0 && default > 0,
+        "expected matched lines in both runs"
+    );
+    assert!(
+        narrow < default,
+        "--max-len must still bind after the short form was removed \
+         (narrow={narrow}, default={default})"
+    );
+}
+
 // --- #2543: bundled files-with-matches cluster (-rln / -ln) lists files, not "0 matches" ---
 
 #[test]

--- a/tests/search_compress_test.rs
+++ b/tests/search_compress_test.rs
@@ -39,7 +39,7 @@ fn write_temp(content: &str) -> (tempfile::TempDir, std::path::PathBuf) {
 
 #[test]
 fn single_file_context_shown_without_header() {
-    if !rg_available() {
+    if !grep_available() {
         return;
     }
     let long = "x".repeat(120);
@@ -64,7 +64,7 @@ fn single_file_context_shown_without_header() {
 
 #[test]
 fn after_context_uses_dash_separator_for_context_lines() {
-    if !rg_available() {
+    if !grep_available() {
         return;
     }
     let (_dir, path) = write_temp("MATCH\nafter1\n");
@@ -83,7 +83,7 @@ fn after_context_uses_dash_separator_for_context_lines() {
 
 #[test]
 fn capped_single_file_shows_header() {
-    if !rg_available() {
+    if !grep_available() {
         return;
     }
     let filler: String = (0..40).map(|i| format!("w{i} ")).collect();
@@ -103,7 +103,7 @@ fn capped_single_file_shows_header() {
 
 #[test]
 fn true_no_match_exits_1() {
-    if !rg_available() {
+    if !grep_available() {
         return;
     }
     let (_dir, path) = write_temp("hello world\n");
@@ -145,7 +145,7 @@ fn no_line_number_flag_produces_output_not_zero_matches() {
 
 #[test]
 fn no_filename_flag_produces_output_not_zero_matches() {
-    if !rg_available() {
+    if !grep_available() {
         return;
     }
     let (_dir, path) = write_temp("hello world\n");
@@ -242,7 +242,7 @@ fn count_tokens(s: &str) -> usize {
 // Covers #545: grep savings are measured against the real grep output.
 #[test]
 fn bulky_grep_yields_token_savings() {
-    if !rg_available() {
+    if !rg_available() || !grep_available() {
         return;
     }
     let filler: String = (0..50).map(|i| format!("word{i} ")).collect();
@@ -275,7 +275,7 @@ fn bulky_grep_yields_token_savings() {
 
 #[test]
 fn grep_only_flags_fall_back_to_system_grep() {
-    if !rg_available() {
+    if !grep_available() {
         return;
     }
     let dir = tempfile::tempdir().expect("tempdir");
@@ -307,7 +307,7 @@ fn grep_only_flags_fall_back_to_system_grep() {
 
 #[test]
 fn small_grep_not_worse_than_plain() {
-    if !rg_available() {
+    if !grep_available() {
         return;
     }
     let (_dir, path) = write_temp("foo\n");
@@ -327,7 +327,7 @@ fn small_grep_not_worse_than_plain() {
     );
 }
 
-// --- #2628: a numeric pattern must not bind to rtk's removed `-l` short ---
+// --- a numeric pattern must not bind to rtk's removed `-l` short ---
 
 #[test]
 fn numeric_pattern_with_files_with_matches_flag() {
@@ -428,7 +428,7 @@ fn max_len_long_option_still_binds_to_rtk() {
 
 #[test]
 fn bundled_files_with_matches_cluster_lists_files() {
-    if !rg_available() {
+    if !grep_available() {
         return;
     }
     let dir = tempfile::tempdir().expect("tempdir");

--- a/tests/search_compress_test.rs
+++ b/tests/search_compress_test.rs
@@ -17,6 +17,17 @@ fn rg_available() -> bool {
         .unwrap_or(false)
 }
 
+/// `rtk grep` shells out to `grep`, never `rg` (`search.rs`: `Engine::Grep => "grep"`).
+/// Guarding a grep-engine test on `rg_available()` makes it silently skip -- and
+/// report success -- on a box without ripgrep, which is a false green.
+fn grep_available() -> bool {
+    Command::new("grep")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
 fn write_temp(content: &str) -> (tempfile::TempDir, std::path::PathBuf) {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("test.txt");
@@ -320,7 +331,7 @@ fn small_grep_not_worse_than_plain() {
 
 #[test]
 fn max_len_long_option_still_binds_to_rtk() {
-    if !rg_available() {
+    if !grep_available() {
         return;
     }
     // The other half of #2628: dropping the `-l` short must not stop the long

--- a/tests/search_compress_test.rs
+++ b/tests/search_compress_test.rs
@@ -327,6 +327,54 @@ fn small_grep_not_worse_than_plain() {
     );
 }
 
+// --- #2628: a numeric pattern must not bind to rtk's removed `-l` short ---
+
+#[test]
+fn numeric_pattern_with_files_with_matches_flag() {
+    if !grep_available() {
+        return;
+    }
+    // The pattern MUST parse as a usize for this test to gate anything. With
+    // `-l` bound to `--max-len: usize`, a non-numeric pattern makes clap fail,
+    // and run_fallback then re-runs raw grep and prints the right answer -- so
+    // a word pattern passes with or without the fix. A numeric pattern instead
+    // binds silently: `-l 8080` sets max_len=8080, leaving the first filename
+    // as the pattern and the second as the only path. No error, no fallback,
+    // wrong answer.
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("hit.txt"), "listen on port 8080 today\n").expect("write");
+    std::fs::write(dir.path().join("miss.txt"), "nothing numeric here\n").expect("write");
+    let hit = dir.path().join("hit.txt");
+    let miss = dir.path().join("miss.txt");
+
+    let out = rtk()
+        .args([
+            "grep",
+            "-l",
+            "8080",
+            hit.to_str().unwrap(),
+            miss.to_str().unwrap(),
+        ])
+        .output()
+        .expect("rtk grep");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        out.status.success(),
+        "`grep -l <number>` must find the match (#2628); status={:?} stderr={}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        stdout.contains("hit.txt"),
+        "-l must report the file containing 8080:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("miss.txt"),
+        "-l must not report the non-matching file:\n{stdout}"
+    );
+}
+
 // --- #2628: rtk's own long options still bind after the short forms were removed ---
 
 #[test]


### PR DESCRIPTION
## Summary
- Makes `rtk grep`'s `--max-len` long-only (dropping the `-l` short) and removes `--file-type`/`-t` entirely, so the native grep/rg flags of those letters reach the engine (`src/cmds/system/search.rs`) instead of binding to rtk's own options. `-m` was already fixed on `develop` by #3259 — this finishes the cleanup that 84616d1 started and #3259 continued.
- The `-l` bug had two faces, split on whether the pattern parsed as a number:
  - **Non-numeric pattern** (`rtk grep -l telemetry src/`): clap rejected `telemetry` as a `usize`, `run_fallback` re-ran raw grep — right answer, zero savings. Wasteful, not harmful.
  - **Numeric pattern** (`rtk grep -l 8080 a.txt b.txt`): clap **accepted** it — `max_len=8080`, `a.txt` became the pattern, `b.txt` the only path. No error, no fallback, silently wrong output (and with a single file, a stdin fallback that hangs an interactive terminal). This silent wrong answer, reached through a hook rewrite the user never typed, is the real motivation.
- **User-visible change for `-t`**: `-t TYPE` is rg-only. Before, `rtk grep -t rust PAT` *silently dropped* the flag — it bound to `--file-type`, which was destructured away at the call site and never reached the engine. Now `-t` is forwarded verbatim: `rtk rg -t rust` filters by type as always, while `rtk grep -t rust` surfaces grep's own `invalid option -- 't'`. Loud beats silently-ignored, so `--file-type` is removed outright rather than left as a parse-only no-op.
- Supporting fixes this surfaced:
  - `.claude/hooks/rtk-suggest.sh`: `rg …` now suggests `rtk rg …` (was `rtk grep …`, which swapped ripgrep for GNU grep and broke rg-only flags like `-t`).
  - `scripts/benchmark.sh`: the `-l 40` bench invocation used the removed short; now `--max-len 40` before the pattern.
  - `scripts/test-all.sh`: the three grep smoke assertions were red or inert (missing `-r` made `grep PAT <dir>` exit 2 regardless); rewritten so the `-t` assertion can only fail because of `-t` itself.
  - `docs/usage/FEATURES.md`: drops the advertised `-l`/`-t` shorts, explains why, and removes a stale `--line-numbers | -n` row (the `Grep` variant has no such option).

## Context / how this differs from the other grep PRs
Not the broad "grep rejects `-r`/`-E`/`-A`" problem from #2614 (largely resolved by 84616d1). This is the residual: rtk's own `Grep` short options shadowing native flags. Complements (does not overlap) #2224's rg-only-flag fallback handling; independent of #2532 (`-h` passthrough — deliberately untouched here, see the NOTE in the variant).

## Test plan
- [x] `cargo fmt --all --check` clean, `cargo clippy --all-targets` clean, `cargo test`: **2852 passed; 0 failed; 8 ignored** plus all integration suites green (incl. the two new end-to-end tests in `tests/search_compress_test.rs`).
- [x] Behavior, `-l` (the silent-wrong-answer case):
  ```
  $ rtk grep -l 8080 hit.txt miss.txt   # hit.txt contains "port 8080"
  hit.txt                                # exit 0 — was: empty output, exit 1
  ```
- [x] Behavior, `-t`:
  ```
  $ rtk grep -t rust "fn main" src/main.rs
  grep: invalid option -- t              # exit 2 — was: silently unfiltered results
  ```
- [x] Mutation proof (scratch worktree, compiling mutant): re-adding `#[arg(short = 't', long)] file_type` fails exactly `test_grep_parse_type_t_forwarded` + `test_grep_file_type_option_is_gone` (`15 passed; 2 failed`), and flips the smoke command above to exit 0 — so the new `assert_fails` smoke assertion genuinely fires on regression. Restored tree re-verified green.
- [x] Passthrough unchanged: `-rn`, `-A 3`, `-v`, `-nE 'a|b'`, `--version`, `--` all pinned by new clap-layer tests.

Refs: #2614, #1604, #1436
