### PR TITLE
feat: add Kimi Code CLI awareness integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to rtk (Rust Token Killer) will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Features
+
+* **kimi:** add Kimi Code CLI awareness integration
+  * New `rtk init -g --agent kimi` writes RTK awareness into `~/.kimi-code/AGENTS.md`
+  * Uses prompt-level awareness because Kimi Code CLI 0.20.1 ignores `updatedInput` in `PreToolUse` hooks
+
 ## [0.42.4](https://github.com/rtk-ai/rtk/compare/v0.42.3...v0.42.4) (2026-06-12)
 
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -174,6 +174,28 @@ rtk init --show
 # Should show: ✅ Hook: ... (thin delegator, up to date)
 ```
 
+## Other AI Agents
+
+### Kimi Code CLI
+
+```bash
+rtk init -g --agent kimi
+```
+
+Installs global awareness instructions for Kimi Code CLI by creating or patching:
+
+- `~/.kimi-code/AGENTS.md` — instructions telling Kimi to prefix shell commands with `rtk`
+
+Restart Kimi Code CLI. Kimi will then emit commands such as `rtk git status` directly.
+
+> **Note:** Kimi Code CLI 0.20.1 ignores the `updatedInput` field of `PreToolUse` hooks, and references between Markdown files (`@RTK.md`) are not loaded. RTK therefore writes awareness instructions directly into `AGENTS.md`.
+
+Uninstall:
+
+```bash
+rtk init -g --uninstall --agent kimi
+```
+
 ## Common User Flows
 
 ### First-Time User (Recommended)

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ rtk init --agent antigravity    # Google Antigravity
 rtk init -g --agent pi          # Pi
 rtk init --agent hermes         # Hermes
 rtk init -g --agent droid       # Factory Droid
+rtk init -g --agent kimi        # Kimi Code CLI (AGENTS.md awareness)
 
 # 2. Restart your AI tool, then test
 git status  # Automatically rewritten to rtk git status
@@ -386,6 +387,7 @@ RTK supports 15 AI coding tools. Each integration rewrites shell commands to `rt
 | **Kilo Code** | `rtk init --agent kilocode` | .kilocode/rules/rtk-rules.md (project-scoped) |
 | **Google Antigravity** | `rtk init --agent antigravity` | .agents/rules/antigravity-rtk-rules.md (project-scoped) |
 | **Factory Droid** | `rtk init -g --agent droid` (or per-project) | PreToolUse hook in `~/.factory/hooks.json` (matcher `Execute`) |
+| **Kimi Code CLI** | `rtk init -g --agent kimi` | AGENTS.md instructions (`~/.kimi-code/AGENTS.md`) |
 
 For per-agent setup details, override controls, and graceful degradation, see the [Supported Agents guide](https://www.rtk-ai.app/guide/getting-started/supported-agents). The Hermes plugin source and tests live in `hooks/hermes/`; installed Hermes runtime files still live under `~/.hermes/plugins/rtk-rewrite/`.
 

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -1,6 +1,6 @@
 ---
 title: Supported Agents
-description: How to integrate RTK with Claude Code, Cursor, Copilot, Cline, Windsurf, Codex, OpenCode, Hermes, Kilo Code, Antigravity, and Factory Droid
+description: How to integrate RTK with Claude Code, Cursor, Copilot, Cline, Windsurf, Codex, OpenCode, Hermes, Kilo Code, Antigravity, Factory Droid, and Kimi Code CLI
 sidebar:
   order: 3
 ---
@@ -43,6 +43,7 @@ Agent runs "cargo test"
 | Codex CLI | AGENTS.md instructions | N/A |
 | Kilo Code | Rules file (prompt-level) | N/A |
 | Google Antigravity | Rules file (prompt-level) | N/A |
+| Kimi Code CLI | AGENTS.md instructions | N/A |
 | Mistral Vibe | Planned ([#800](https://github.com/rtk-ai/rtk/issues/800)) | Pending upstream |
 
 ## Installation by agent
@@ -195,6 +196,27 @@ rtk init --agent antigravity    # creates .agents/rules/antigravity-rtk-rules.md
 
 Antigravity reads `.agents/rules/` as custom instructions. RTK adds guidance telling Antigravity to prefer `rtk <cmd>` over raw commands.
 
+### Kimi Code CLI
+
+```bash
+rtk init -g --agent kimi
+```
+
+RTK installs awareness instructions directly into `~/.kimi-code/AGENTS.md`, the file Kimi Code CLI consumes:
+
+- Explains that shell commands should be prefixed with `rtk`
+- Provides examples (`rtk git status`, `rtk cargo test`, etc.)
+
+Restart Kimi Code CLI after installation. The model is then expected to emit `rtk ...` commands on its own.
+
+> **Limitation:** Kimi Code CLI 0.20.1 does not consume the `updatedInput` field returned by `PreToolUse` hooks, and `@RTK.md` references inside `instructions.md` are not loaded. RTK therefore uses prompt-level awareness written directly to `AGENTS.md`.
+
+Uninstall:
+
+```bash
+rtk init -g --uninstall --agent kimi
+```
+
 ### Mistral Vibe (planned)
 
 Support is blocked on upstream `BeforeToolCallback` ([mistral-vibe#531](https://github.com/mistralai/mistral-vibe/issues/531)). Tracked in [#800](https://github.com/rtk-ai/rtk/issues/800).
@@ -207,7 +229,7 @@ Support is blocked on upstream `BeforeToolCallback` ([mistral-vibe#531](https://
 | **Plugin** | TypeScript, JavaScript, or Python in agent's plugin system | Transparent, in-place mutation when the agent allows it |
 | **Rules file** | Prompt-level instructions | Guidance only — agent is told to prefer `rtk <cmd>` |
 
-Rules file integrations (Cline, Windsurf, Codex, Kilo Code, Antigravity) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it. Plugin integrations (OpenCode, Pi) use in-place mutation via the agent's TypeScript extension API.
+Rules file integrations (Cline, Windsurf, Codex, Kilo Code, Antigravity, Kimi Code CLI) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it. Plugin integrations (OpenCode, Pi) use in-place mutation via the agent's TypeScript extension API.
 
 ## Windows support
 

--- a/hooks/kimi/rtk-awareness.md
+++ b/hooks/kimi/rtk-awareness.md
@@ -1,0 +1,35 @@
+# RTK - Rust Token Killer (Kimi Code CLI)
+
+**Usage**: Token-optimized CLI proxy for shell commands (60-90% savings on dev operations).
+
+## Rule
+
+Always prefix shell commands with `rtk`.
+
+Examples:
+
+```bash
+rtk git status
+rtk cargo test
+rtk npm run build
+rtk pytest -q
+rtk docker ps
+```
+
+## Meta Commands (always use rtk directly)
+
+```bash
+rtk gain              # Show token savings analytics
+rtk gain --history    # Show recent command savings history
+rtk proxy <cmd>       # Execute raw command without filtering (for debugging)
+```
+
+## Verification
+
+```bash
+rtk --version
+rtk gain
+which rtk
+```
+
+Run all shell commands through `rtk` to minimize token usage.

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -58,3 +58,8 @@ pub const HERMES_PLUGINS_SUBDIR: &str = "plugins";
 pub const HERMES_PLUGIN_NAME: &str = "rtk-rewrite";
 pub const HERMES_PLUGIN_INIT_FILE: &str = "__init__.py";
 pub const HERMES_PLUGIN_MANIFEST_FILE: &str = "plugin.yaml";
+
+/// Kimi Code CLI config directory, joined onto the resolved home directory.
+pub const KIMI_DIR: &str = ".kimi-code";
+/// Kimi Code CLI AGENTS.md file. RTK writes awareness instructions here.
+pub const KIMI_AGENTS_FILE: &str = "AGENTS.md";

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -9,7 +9,8 @@ use tempfile::NamedTempFile;
 
 use crate::hooks::constants::{
     CONFIG_DIR, COPILOT_HOME_ENV, COPILOT_HOOK_FILE, COPILOT_INSTRUCTIONS_FILE, COPILOT_USER_DIR,
-    CURSOR_DIR, GEMINI_DIR, GITHUB_DIR, OPENCODE_PLUGIN_FILE, OPENCODE_SUBDIR, PLUGIN_SUBDIR,
+    CURSOR_DIR, GEMINI_DIR, GITHUB_DIR, KIMI_AGENTS_FILE, KIMI_DIR, OPENCODE_PLUGIN_FILE,
+    OPENCODE_SUBDIR, PLUGIN_SUBDIR,
 };
 
 use super::constants::{
@@ -32,6 +33,7 @@ const PI_PLUGIN: &str = include_str!("../../hooks/pi/rtk.ts");
 // Embedded slim RTK awareness instructions
 const RTK_SLIM: &str = include_str!("../../hooks/claude/rtk-awareness.md");
 const RTK_SLIM_CODEX: &str = include_str!("../../hooks/codex/rtk-awareness.md");
+const RTK_SLIM_KIMI: &str = include_str!("../../hooks/kimi/rtk-awareness.md");
 
 /// Template written by `rtk init` when no filters.toml exists yet.
 const FILTERS_TEMPLATE: &str = r#"# Project-local RTK filters — commit this file with your repo.
@@ -2843,6 +2845,199 @@ fn resolve_hermes_home_from_env(
     home_dir
         .map(|home| home.join(HERMES_DIR))
         .context("Cannot determine Hermes home directory. Set $HERMES_HOME or $HOME.")
+}
+
+// ─── Kimi Code CLI support ───────────────────────────────────────────
+
+const KIMI_AGENTS_START_MARKER: &str = "<!-- RTK-AWARENESS-START -->";
+const KIMI_AGENTS_END_MARKER: &str = "<!-- RTK-AWARENESS-END -->";
+
+/// Resolve Kimi config directory, honouring `KIMI_CODE_CONFIG_DIR` override.
+pub fn resolve_kimi_dir() -> Result<PathBuf> {
+    resolve_kimi_dir_from(
+        std::env::var_os("KIMI_CODE_CONFIG_DIR").map(PathBuf::from),
+        dirs::home_dir(),
+    )
+}
+
+fn resolve_kimi_dir_from(kimi_dir: Option<PathBuf>, home_dir: Option<PathBuf>) -> Result<PathBuf> {
+    if let Some(path) = kimi_dir.filter(|path| !path.as_os_str().is_empty()) {
+        return Ok(path);
+    }
+    home_dir
+        .map(|home| home.join(KIMI_DIR))
+        .context("Cannot determine Kimi config directory. Set $KIMI_CODE_CONFIG_DIR or $HOME.")
+}
+
+/// Entry point for `rtk init -g --agent kimi`.
+pub fn run_kimi_mode(ctx: InitContext) -> Result<()> {
+    let InitContext { dry_run, .. } = ctx;
+    let kimi_dir = resolve_kimi_dir()?;
+
+    if !dry_run {
+        fs::create_dir_all(&kimi_dir).with_context(|| {
+            format!(
+                "Failed to create Kimi config directory: {}",
+                kimi_dir.display()
+            )
+        })?;
+    }
+
+    let agents_path = kimi_dir.join(KIMI_AGENTS_FILE);
+    write_kimi_agents(&agents_path, RTK_SLIM_KIMI, ctx)?;
+
+    generate_global_filters_template(ctx)?;
+
+    if dry_run {
+        print_dry_run_footer();
+    } else {
+        println!("\nRTK configured for Kimi Code CLI (global).\n");
+        println!("  AGENTS.md:   {}", agents_path.display());
+        println!("  Restart Kimi Code CLI. Test with: git status\n");
+    }
+
+    Ok(())
+}
+
+/// Write or append a delimited RTK awareness section to Kimi AGENTS.md.
+fn write_kimi_agents(path: &Path, content: &str, ctx: InitContext) -> Result<bool> {
+    let InitContext { verbose, dry_run } = ctx;
+
+    let existing = if path.exists() {
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?
+    } else {
+        String::new()
+    };
+
+    if existing.contains(KIMI_AGENTS_START_MARKER) {
+        if verbose > 0 {
+            eprintln!("RTK awareness already present in {}", path.display());
+        }
+        return Ok(false);
+    }
+
+    let section = format!(
+        "{}\n{}\n{}\n",
+        KIMI_AGENTS_START_MARKER,
+        content.trim(),
+        KIMI_AGENTS_END_MARKER
+    );
+
+    let new_content = if existing.trim().is_empty() {
+        section
+    } else {
+        format!("{}\n\n{}", existing.trim_end(), section)
+    };
+
+    if dry_run {
+        println!(
+            "[dry-run] would write RTK awareness to {}: {}",
+            KIMI_AGENTS_FILE,
+            path.display()
+        );
+        return Ok(true);
+    }
+
+    atomic_write(path, &new_content)
+        .with_context(|| format!("Failed to write {}", path.display()))?;
+
+    if verbose > 0 {
+        eprintln!("Wrote RTK awareness to {}", path.display());
+    }
+
+    Ok(true)
+}
+
+/// Remove Kimi Code CLI RTK awareness section from AGENTS.md.
+pub fn uninstall_kimi(ctx: InitContext) -> Result<()> {
+    let InitContext { verbose, dry_run } = ctx;
+    let kimi_dir = match resolve_kimi_dir() {
+        Ok(d) => d,
+        Err(_) => {
+            println!("Kimi Code CLI config directory not found (nothing to remove)");
+            return Ok(());
+        }
+    };
+
+    let agents_path = kimi_dir.join(KIMI_AGENTS_FILE);
+    if !agents_path.exists() {
+        println!("RTK Kimi Code CLI support was not installed (nothing to remove)");
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(&agents_path)
+        .with_context(|| format!("Failed to read {}", agents_path.display()))?;
+
+    if !content.contains(KIMI_AGENTS_START_MARKER) {
+        println!(
+            "RTK awareness not found in {} (nothing to remove)",
+            KIMI_AGENTS_FILE
+        );
+        return Ok(());
+    }
+
+    let cleaned =
+        remove_delimited_section(&content, KIMI_AGENTS_START_MARKER, KIMI_AGENTS_END_MARKER);
+
+    if dry_run {
+        println!(
+            "[dry-run] would remove RTK awareness from {}: {}",
+            KIMI_AGENTS_FILE,
+            agents_path.display()
+        );
+        print_dry_run_footer();
+        return Ok(());
+    }
+
+    let trimmed = cleaned.trim();
+    if trimmed.is_empty() {
+        fs::remove_file(&agents_path)
+            .with_context(|| format!("Failed to remove {}", agents_path.display()))?;
+        println!("Removed {}: {}", KIMI_AGENTS_FILE, agents_path.display());
+    } else {
+        atomic_write(&agents_path, trimmed)
+            .with_context(|| format!("Failed to write {}", agents_path.display()))?;
+        println!(
+            "Removed RTK awareness from {}: {}",
+            KIMI_AGENTS_FILE,
+            agents_path.display()
+        );
+    }
+
+    println!("\nRestart Kimi Code CLI to apply changes.");
+
+    if verbose > 0 {
+        eprintln!("Kimi Code CLI artifacts removed");
+    }
+
+    Ok(())
+}
+
+fn remove_delimited_section(content: &str, start: &str, end: &str) -> String {
+    let mut result = String::new();
+    let mut lines = content.lines().peekable();
+    let mut skip = false;
+
+    while let Some(line) = lines.next() {
+        if line.trim() == start {
+            skip = true;
+            continue;
+        }
+        if line.trim() == end {
+            skip = false;
+            // swallow a single following blank line if present
+            if lines.peek().map(|l| l.trim().is_empty()).unwrap_or(false) {
+                lines.next();
+            }
+            continue;
+        }
+        if !skip {
+            result.push_str(line);
+            result.push('\n');
+        }
+    }
+
+    result
 }
 
 // ─── Factory Droid support ──────────────────────────────────────────
@@ -7768,5 +7963,109 @@ mod tests {
             "Hook config must not be written when the upsert aborts: {}",
             hook_path.display()
         );
+    }
+
+    // --- Kimi Code CLI support tests ---
+
+    #[test]
+    fn test_resolve_kimi_dir_prefers_env() {
+        let temp = TempDir::new().unwrap();
+        let env_dir = temp.path().join("kimi-env");
+        let result = resolve_kimi_dir_from(Some(env_dir.clone()), Some(temp.path().to_path_buf()));
+        assert_eq!(result.unwrap(), env_dir);
+    }
+
+    #[test]
+    fn test_resolve_kimi_dir_falls_back_to_home() {
+        let temp = TempDir::new().unwrap();
+        let result = resolve_kimi_dir_from(None, Some(temp.path().to_path_buf()));
+        assert_eq!(result.unwrap(), temp.path().join(KIMI_DIR));
+    }
+
+    fn run_kimi_mode_at(kimi_dir: &Path, ctx: InitContext) {
+        std::env::set_var("KIMI_CODE_CONFIG_DIR", kimi_dir.as_os_str());
+        let result = run_kimi_mode(ctx);
+        std::env::remove_var("KIMI_CODE_CONFIG_DIR");
+        result.unwrap();
+    }
+
+    #[test]
+    fn test_kimi_mode_creates_artifacts() {
+        let temp = TempDir::new().unwrap();
+        let kimi_dir = temp.path().join(".kimi-code");
+
+        run_kimi_mode_at(&kimi_dir, InitContext::default());
+
+        let agents_path = kimi_dir.join(KIMI_AGENTS_FILE);
+        assert!(agents_path.exists());
+
+        let content = fs::read_to_string(&agents_path).unwrap();
+        assert!(content.contains(KIMI_AGENTS_START_MARKER));
+        assert!(content.contains("Rust Token Killer"));
+        assert!(content.contains("rtk git status"));
+    }
+
+    #[test]
+    fn test_kimi_mode_dry_run_writes_nothing() {
+        let temp = TempDir::new().unwrap();
+        let kimi_dir = temp.path().join(".kimi-code");
+
+        let ctx = InitContext {
+            verbose: 0,
+            dry_run: true,
+        };
+        run_kimi_mode_at(&kimi_dir, ctx);
+
+        assert!(!kimi_dir.exists());
+    }
+
+    #[test]
+    fn test_kimi_mode_idempotent() {
+        let temp = TempDir::new().unwrap();
+        let kimi_dir = temp.path().join(".kimi-code");
+
+        run_kimi_mode_at(&kimi_dir, InitContext::default());
+        run_kimi_mode_at(&kimi_dir, InitContext::default());
+
+        let content = fs::read_to_string(kimi_dir.join(KIMI_AGENTS_FILE)).unwrap();
+        let count = content.matches(KIMI_AGENTS_START_MARKER).count();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_kimi_uninstall_removes_artifacts() {
+        let temp = TempDir::new().unwrap();
+        let kimi_dir = temp.path().join(".kimi-code");
+
+        run_kimi_mode_at(&kimi_dir, InitContext::default());
+        assert!(kimi_dir.join(KIMI_AGENTS_FILE).exists());
+
+        std::env::set_var("KIMI_CODE_CONFIG_DIR", kimi_dir.as_os_str());
+        uninstall_kimi(InitContext::default()).unwrap();
+        std::env::remove_var("KIMI_CODE_CONFIG_DIR");
+
+        assert!(!kimi_dir.join(KIMI_AGENTS_FILE).exists());
+    }
+
+    #[test]
+    fn test_kimi_uninstall_preserves_other_content() {
+        let temp = TempDir::new().unwrap();
+        let kimi_dir = temp.path().join(".kimi-code");
+        fs::create_dir_all(&kimi_dir).unwrap();
+        let agents_path = kimi_dir.join(KIMI_AGENTS_FILE);
+        fs::write(&agents_path, "# User instructions\n\nKeep this line.\n").unwrap();
+
+        run_kimi_mode_at(&kimi_dir, InitContext::default());
+        assert!(fs::read_to_string(&agents_path)
+            .unwrap()
+            .contains("Keep this line."));
+
+        std::env::set_var("KIMI_CODE_CONFIG_DIR", kimi_dir.as_os_str());
+        uninstall_kimi(InitContext::default()).unwrap();
+        std::env::remove_var("KIMI_CODE_CONFIG_DIR");
+
+        let content = fs::read_to_string(&agents_path).unwrap();
+        assert!(content.contains("Keep this line."));
+        assert!(!content.contains(KIMI_AGENTS_START_MARKER));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,8 @@ pub enum AgentTarget {
     Hermes,
     /// Factory Droid CLI
     Droid,
+    /// Kimi Code CLI (Moonshot AI)
+    Kimi,
 }
 
 #[derive(Parser)]
@@ -1532,6 +1534,8 @@ where
         uninstall_hermes(ctx)
     } else if agent == Some(AgentTarget::Droid) {
         hooks::init::uninstall_droid(global, ctx)
+    } else if agent == Some(AgentTarget::Kimi) {
+        hooks::init::uninstall_kimi(ctx)
     } else {
         let cursor = agent == Some(AgentTarget::Cursor);
         let pi = agent == Some(AgentTarget::Pi);
@@ -2029,6 +2033,13 @@ fn run_cli() -> Result<i32> {
                 hooks::init::run_hermes_mode(ctx)?;
             } else if agent == Some(AgentTarget::Droid) {
                 hooks::init::run_droid_mode(global, ctx)?;
+            } else if agent == Some(AgentTarget::Kimi) {
+                if !global {
+                    anyhow::bail!(
+                        "Kimi Code CLI support is global-only. Use: rtk init -g --agent kimi"
+                    );
+                }
+                hooks::init::run_kimi_mode(ctx)?;
             } else {
                 let install_opencode = opencode;
                 let install_claude = !opencode;


### PR DESCRIPTION
# feat: add Kimi Code CLI awareness integration

## Summary

This PR adds support for [Kimi Code CLI](https://www.moonshot.cn/) (Moonshot AI) to RTK using prompt-level awareness. Kimi Code CLI 0.20.1 ignores the `updatedInput` field of `PreToolUse` hooks, so RTK writes awareness instructions directly into `~/.kimi-code/AGENTS.md` instead of registering a hook.

## What changed

- **New CLI surface**
  - `rtk init -g --agent kimi` — writes/updates `~/.kimi-code/AGENTS.md` with RTK awareness instructions
  - `rtk init -g --uninstall --agent kimi` — removes the RTK section from `AGENTS.md`

- **Kimi installer (`src/hooks/init.rs`)**
  - `resolve_kimi_dir()` honors `$KIMI_CODE_CONFIG_DIR`
  - `run_kimi_mode()` writes a delimited RTK awareness section to `~/.kimi-code/AGENTS.md`
  - Idempotent: re-running `rtk init -g --agent kimi` does not duplicate the section
  - `uninstall_kimi()` removes only the RTK section and deletes `AGENTS.md` if it becomes empty

- **Documentation**
  - `README.md` — added Kimi to the quick-start list and to the "Supported AI Tools" table
  - `INSTALL.md` — added a "Kimi Code CLI" section with install/uninstall steps
  - `docs/guide/getting-started/supported-agents.md` — added Kimi to the agent table and installation-by-agent section
  - `CHANGELOG.md` — added an `[Unreleased]` entry

- **Tests**
  - Init tests in `src/hooks/init.rs` (resolve dir, artifact creation, dry-run, idempotency, uninstall, preserve other content)

## Why awareness instructions instead of a hook

Live debugging showed that Kimi Code CLI 0.20.1:

- Fires `PreToolUse` hooks correctly.
- Consumes `permissionDecision: "deny"` to block tool calls.
- **Ignores `updatedInput`** returned by the hook, so command rewriting is not possible today.
- Also ignores `@RTK.md` references inside `instructions.md`.

The only working integration path found was to write instructions directly to `~/.kimi-code/AGENTS.md`, which Kimi Code CLI loads as agent guidance.

## Generated file example

After `rtk init -g --agent kimi`, `~/.kimi-code/AGENTS.md` contains:

```markdown
<!-- RTK-AWARENESS-START -->
# RTK - Rust Token Killer (Kimi Code CLI)

**Usage**: Token-optimized CLI proxy for shell commands (60-90% savings on dev operations).

## Rule

Always prefix shell commands with `rtk`.

Examples:

```bash
rtk git status
rtk cargo test
rtk npm run build
```

...
<!-- RTK-AWARENESS-END -->
```

## How to test

```bash
# Build and run tests
cargo fmt --all
cargo clippy --all-targets
cargo test
cargo build --release

# Install for Kimi (dry-run first to inspect)
rtk init -g --agent kimi --dry-run

# Install for real
rtk init -g --agent kimi

# Inspect generated file
cat ~/.kimi-code/AGENTS.md

# Restart Kimi Code CLI, then run inside a repo:
rtk git status

# Uninstall
rtk init -g --uninstall --agent kimi
```

## Verification

Local verification run on Windows 11:

```text
cargo fmt --all           → ok
cargo clippy --all-targets → ok
cargo test                → 2440 passed; 0 failed; 8 ignored
cargo build --release     → ok
```

## Checklist

- [x] Code follows the existing Rust style (`cargo fmt`)
- [x] Clippy passes (`cargo clippy --all-targets`)
- [x] All tests pass (`cargo test`)
- [x] Release build compiles (`cargo build --release`)
- [x] README / INSTALL / docs updated
- [x] CHANGELOG updated
- [x] No new dependencies added
