### PR TITLE
[codex] fix env-stable rewrite tests and grep header

### DIFF
--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -575,12 +575,7 @@ pub fn run(
         .filter(|(_, is_match, _)| *is_match)
         .count();
 
-    let mut rtk_output = String::new();
-    rtk_output.push_str(&format!(
-        "{} matches in {} files:\n\n",
-        total_matches,
-        by_file.len()
-    ));
+    let mut body_output = String::new();
 
     let mut shown = 0;
     let mut files: Vec<_> = by_file.iter().collect();
@@ -598,9 +593,9 @@ pub fn run(
                 break;
             }
             if *is_match {
-                rtk_output.push_str(&format!("{}:{}:{}\n", file_display, line_num, content));
+                body_output.push_str(&format!("{}:{}:{}\n", file_display, line_num, content));
             } else {
-                rtk_output.push_str(&format!("{}-{}-{}\n", file_display, line_num, content));
+                body_output.push_str(&format!("{}-{}-{}\n", file_display, line_num, content));
             }
             shown += 1;
         }
@@ -608,8 +603,21 @@ pub fn run(
 
     let total_lines: usize = by_file.values().map(|v| v.len()).sum();
     if total_lines > shown {
-        rtk_output.push_str(&format!("[+{} more]\n", total_lines - shown));
+        body_output.push_str(&format!("[+{} more]\n", total_lines - shown));
     }
+
+    let should_show_header =
+        total_matches > 1 || by_file.len() > 1 || total_lines != total_matches || total_lines > shown;
+    let rtk_output = if should_show_header {
+        format!(
+            "{} matches in {} files:\n\n{}",
+            total_matches,
+            by_file.len(),
+            body_output
+        )
+    } else {
+        body_output
+    };
 
     // Never-worse: show plain `file:line:content` (NUL `-0` -> `:`) if grouping didn't shrink it.
     let plain = raw_output.replace('\0', ":");

--- a/src/hooks/rewrite_cmd.rs
+++ b/src/hooks/rewrite_cmd.rs
@@ -46,7 +46,15 @@ enum RewriteOutcome {
 
 fn evaluate(cmd: &str, excluded: &[String], transparent_prefixes: &[String]) -> RewriteOutcome {
     let verdict = check_command(cmd);
+    evaluate_with_verdict(cmd, verdict, excluded, transparent_prefixes)
+}
 
+fn evaluate_with_verdict(
+    cmd: &str,
+    verdict: PermissionVerdict,
+    excluded: &[String],
+    transparent_prefixes: &[String],
+) -> RewriteOutcome {
     if verdict == PermissionVerdict::Deny {
         return RewriteOutcome::Deny;
     }
@@ -91,12 +99,16 @@ mod tests {
     }
 
     mod unattestable_passthrough {
-        use super::super::{evaluate, RewriteOutcome};
+        use super::super::{evaluate_with_verdict, PermissionVerdict, RewriteOutcome};
+
+        fn evaluate_default(cmd: &str) -> RewriteOutcome {
+            evaluate_with_verdict(cmd, PermissionVerdict::Default, &[], &[])
+        }
 
         #[test]
         fn test_backtick_substitution_passthrough() {
             assert_eq!(
-                evaluate("git status `rm -rf /tmp/x`", &[], &[]),
+                evaluate_default("git status `rm -rf /tmp/x`"),
                 RewriteOutcome::Passthrough
             );
         }
@@ -104,7 +116,7 @@ mod tests {
         #[test]
         fn test_dollar_substitution_passthrough() {
             assert_eq!(
-                evaluate("git status $(rm -rf /tmp/x)", &[], &[]),
+                evaluate_default("git status $(rm -rf /tmp/x)"),
                 RewriteOutcome::Passthrough
             );
         }
@@ -112,7 +124,7 @@ mod tests {
         #[test]
         fn test_double_quoted_substitution_passthrough() {
             assert_eq!(
-                evaluate("git log --pretty=\"$(rm -rf /tmp/x)\"", &[], &[]),
+                evaluate_default("git log --pretty=\"$(rm -rf /tmp/x)\""),
                 RewriteOutcome::Passthrough
             );
         }
@@ -120,7 +132,7 @@ mod tests {
         #[test]
         fn test_file_redirect_passthrough() {
             assert_eq!(
-                evaluate("git log > /tmp/out.txt", &[], &[]),
+                evaluate_default("git log > /tmp/out.txt"),
                 RewriteOutcome::Passthrough
             );
         }
@@ -128,7 +140,7 @@ mod tests {
         #[test]
         fn test_fd_dup_redirect_still_rewrites() {
             assert!(matches!(
-                evaluate("git status 2>&1", &[], &[]),
+                evaluate_default("git status 2>&1"),
                 RewriteOutcome::Ask(_)
             ));
         }
@@ -136,7 +148,7 @@ mod tests {
         #[test]
         fn test_plain_command_still_rewrites() {
             assert!(matches!(
-                evaluate("git status", &[], &[]),
+                evaluate_default("git status"),
                 RewriteOutcome::Ask(_)
             ));
         }


### PR DESCRIPTION
## What changed

- Isolated `rtk rewrite` unit tests from the caller's real Claude permission config by adding an internal `evaluate_with_verdict` path.
- Preserved runtime behavior: production `evaluate()` still reads real permissions via `check_command()`.
- Dropped the grep summary header for a single non-context match so tiny greps do not get larger than the useful output.

## Why

On machines with broad Claude Bash allow rules, `rtk rewrite "git status"` correctly returns an allow exit code. The unit tests assumed a blank permission state and failed in that environment. Separately, the grep never-worse integration test showed one-match output could include a header that made the compact output noisier than necessary.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets`
- `cargo test --test grep_compress_test`
- `cargo test --all`
