### PR TITLE
refactor(hooks): inject the permission verdict so rewrite_cmd tests don't read ~/.claude/settings.json

### DIFF
--- a/src/hooks/rewrite_cmd.rs
+++ b/src/hooks/rewrite_cmd.rs
@@ -46,7 +46,20 @@ enum RewriteOutcome {
 
 fn evaluate(cmd: &str, excluded: &[String], transparent_prefixes: &[String]) -> RewriteOutcome {
     let verdict = check_command(cmd);
+    evaluate_with_verdict(cmd, verdict, excluded, transparent_prefixes)
+}
 
+/// Core of `evaluate`, with the permission `verdict` injected rather than read
+/// from the host's settings. Production passes `check_command(cmd)`; tests pass an
+/// explicit verdict so they don't depend on the machine's real Claude/rtk rules
+/// (which made `git status` / `rm -rf` outcomes environment-dependent — a deny
+/// rule for `rm -rf` or an allow rule for `git status` flipped the result).
+fn evaluate_with_verdict(
+    cmd: &str,
+    verdict: PermissionVerdict,
+    excluded: &[String],
+    transparent_prefixes: &[String],
+) -> RewriteOutcome {
     if verdict == PermissionVerdict::Deny {
         return RewriteOutcome::Deny;
     }
@@ -91,12 +104,23 @@ mod tests {
     }
 
     mod unattestable_passthrough {
-        use super::super::{evaluate, RewriteOutcome};
+        use super::super::{evaluate_with_verdict, RewriteOutcome};
+        use crate::hooks::permissions::PermissionVerdict;
+
+        // These exercise the unattestable-construct / rewrite logic, NOT permission
+        // rules — so they inject a neutral verdict instead of calling check_command
+        // (which reads the machine's real Claude/rtk settings and made outcomes
+        // environment-dependent). `Ask` is the neutral choice: it doesn't short-
+        // circuit on Deny and isn't Allow, so the rewrite-vs-passthrough branch is
+        // what's actually under test.
+        fn eval(cmd: &str) -> RewriteOutcome {
+            evaluate_with_verdict(cmd, PermissionVerdict::Ask, &[], &[])
+        }
 
         #[test]
         fn test_backtick_substitution_passthrough() {
             assert_eq!(
-                evaluate("git status `rm -rf /tmp/x`", &[], &[]),
+                eval("git status `rm -rf /tmp/x`"),
                 RewriteOutcome::Passthrough
             );
         }
@@ -104,7 +128,7 @@ mod tests {
         #[test]
         fn test_dollar_substitution_passthrough() {
             assert_eq!(
-                evaluate("git status $(rm -rf /tmp/x)", &[], &[]),
+                eval("git status $(rm -rf /tmp/x)"),
                 RewriteOutcome::Passthrough
             );
         }
@@ -112,32 +136,42 @@ mod tests {
         #[test]
         fn test_double_quoted_substitution_passthrough() {
             assert_eq!(
-                evaluate("git log --pretty=\"$(rm -rf /tmp/x)\"", &[], &[]),
+                eval("git log --pretty=\"$(rm -rf /tmp/x)\""),
                 RewriteOutcome::Passthrough
             );
         }
 
         #[test]
         fn test_file_redirect_passthrough() {
-            assert_eq!(
-                evaluate("git log > /tmp/out.txt", &[], &[]),
-                RewriteOutcome::Passthrough
-            );
+            assert_eq!(eval("git log > /tmp/out.txt"), RewriteOutcome::Passthrough);
         }
 
         #[test]
         fn test_fd_dup_redirect_still_rewrites() {
-            assert!(matches!(
-                evaluate("git status 2>&1", &[], &[]),
-                RewriteOutcome::Ask(_)
-            ));
+            assert!(matches!(eval("git status 2>&1"), RewriteOutcome::Ask(_)));
         }
 
         #[test]
         fn test_plain_command_still_rewrites() {
+            assert!(matches!(eval("git status"), RewriteOutcome::Ask(_)));
+        }
+
+        // Deny still short-circuits regardless of construct — pin that too, now that
+        // the verdict is injectable (previously untestable without real rules).
+        #[test]
+        fn test_deny_verdict_short_circuits() {
+            assert_eq!(
+                evaluate_with_verdict("git status", PermissionVerdict::Deny, &[], &[]),
+                RewriteOutcome::Deny
+            );
+        }
+
+        // Allow verdict on a rewritable command yields Allow (not Ask).
+        #[test]
+        fn test_allow_verdict_yields_allow() {
             assert!(matches!(
-                evaluate("git status", &[], &[]),
-                RewriteOutcome::Ask(_)
+                evaluate_with_verdict("git status", PermissionVerdict::Allow, &[], &[]),
+                RewriteOutcome::Allow(_)
             ));
         }
     }


### PR DESCRIPTION
## Problem

`rewrite_cmd.rs`'s `unattestable_passthrough` tests call `evaluate(cmd, …)`, which calls `check_command(cmd)` → `permissions::load_permission_rules()` — reading the **host's real Claude permission rules** at test time. So **3 of 6 tests fail on any machine with ordinary deny/allow rules** (a `deny` for `rm -rf` pre-empts the expected `Passthrough`; an `allow` for `git status` turns the expected `Ask` into `Allow`) while passing on default-config CI — "green on CI, red on my box."

## Root cause + fix

`evaluate` mixes the permission **verdict** (I/O — reads host settings) with the **rewrite/passthrough decision** (pure logic over the command string), with no seam. This extracts `evaluate_with_verdict(cmd, verdict, excluded, transparent)` holding the existing body; `evaluate` becomes `check_command(cmd)` + delegation. Production behavior is byte-identical; tests inject an explicit `PermissionVerdict` (`Ask` neutral for the passthrough/rewrite branch; `Deny`/`Allow` to pin the verdict-dependent branches that were previously untestable without real rules). This mirrors the permission layer's own `check_command_with_rules` injection pattern.

## Files

- `src/hooks/rewrite_cmd.rs` — split out `evaluate_with_verdict`; test module injects the verdict.

## Test plan

- [x] `cargo fmt --all --check && cargo clippy --all-targets && cargo test`
- [x] `cargo test --bin rtk rewrite_cmd::tests::unattestable_passthrough` — 8 pass on any machine regardless of `~/.claude/settings.json` (was 3 failing locally).
- [x] +2 tests pin the verdict→outcome mapping: `Deny` → `RewriteOutcome::Deny` (short-circuit), `Allow` → `RewriteOutcome::Allow(_)`.

## Context

The exact bug (rewrite_cmd permission tests reading host settings) is unreported, but it is the same *class* of test-isolation defect upstream is already fixing for telemetry: #2106 (telemetry tests write a real `.device_salt`) and #2603 (adds telemetry test-isolation helpers — the same injection pattern). Filed as a sibling to that work; see also the related issue. Test-only, no production behavior change.


---
Closes #2640.
