### PR TITLE
fix: COPILOT_INSTRUCTIONS example drops kubectl get subcommand

### DIFF
--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -4210,6 +4210,22 @@ mod tests {
     }
 
     #[test]
+    fn test_copilot_instructions_kubectl_example_preserves_subcommand() {
+        // Regression test for #2471: the mapping example previously rewrote
+        // "kubectl get pods" to "rtk kubectl pods", silently dropping `get`.
+        // The real rewrite rule (src/discover/rules.rs, rtk_cmd: "rtk kubectl")
+        // preserves the subcommand, so the doc example must match that behavior.
+        assert!(
+            COPILOT_INSTRUCTIONS.contains("kubectl get pods           rtk kubectl get pods"),
+            "COPILOT_INSTRUCTIONS kubectl example must map to `rtk kubectl get pods`"
+        );
+        assert!(
+            !COPILOT_INSTRUCTIONS.contains("rtk kubectl pods"),
+            "COPILOT_INSTRUCTIONS must not drop the `get` subcommand from the kubectl example"
+        );
+    }
+
+    #[test]
     fn test_init_has_version_marker() {
         assert!(
             RTK_INSTRUCTIONS.contains(RTK_BLOCK_START),

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -3909,7 +3909,7 @@ git status                 rtk git status
 git log -10                rtk git log -10
 cargo test                 rtk cargo test
 docker ps                  rtk docker ps
-kubectl get pods           rtk kubectl pods
+kubectl get pods           rtk kubectl get pods
 ```
 
 ## Meta commands (use directly)


### PR DESCRIPTION
## Summary
- Fixes #2471: the `COPILOT_INSTRUCTIONS` template generated by `rtk init` for GitHub Copilot mapped `kubectl get pods` → `rtk kubectl pods`, silently dropping the `get` subcommand.
- The actual rewrite rule (`src/discover/rules.rs`, `rtk_cmd: "rtk kubectl"`) correctly preserves subcommands via `strip_word_prefix` — only this doc example in `src/hooks/init.rs` was wrong, so users following the example would run an incorrect command.

## Change
- `src/hooks/init.rs`: `kubectl get pods           rtk kubectl pods` → `kubectl get pods           rtk kubectl get pods`
- Added `test_copilot_instructions_kubectl_example_preserves_subcommand`: pins the correct mapping string and asserts the buggy `rtk kubectl pods` string is absent from `COPILOT_INSTRUCTIONS`, so this can't silently regress.

## Test plan
- [x] Added a unit test (`src/hooks/init.rs`) following the existing test style in this file (plain `&str::contains` assertions against the const, same pattern as `test_init_mentions_all_top_level_commands`).
- [x] Searched the repo for other occurrences of the same incorrect mapping — none found (other examples in the same table, e.g. `docker ps`, are correct).
- [x] Verified the existing test `test_init_mentions_all_top_level_commands` asserts against `RTK_INSTRUCTIONS` (a separate const), not `COPILOT_INSTRUCTIONS`, so it's unaffected by this change.
- [ ] `cargo test` — could not run locally: my sandbox has a 32-bit MinGW only and no MSVC Build Tools / working 64-bit linker (tried MSVC toolchain 1.91 — `link.exe not found`/wrong `link.exe` picked up from PATH; tried GNU toolchain 1.91 — `dlltool` 32-bit/64-bit bfd-target mismatch). Didn't want to install VS Build Tools without checking first. Would appreciate CI confirming, or happy to address review feedback if the test needs adjusting.
