### PR TITLE
fix(diff): rtk diff reports CRLF/LF-only differences as identical

### DIFF
--- a/src/cmds/git/diff_cmd.rs
+++ b/src/cmds/git/diff_cmd.rs
@@ -40,7 +40,23 @@ fn render_file_diff(file1: &Path, file2: &Path, content1: &str, content2: &str) 
     let diff = compute_diff(&lines1, &lines2);
 
     if diff.changes.is_empty() {
-        return ("[ok] Files are identical\n".to_string(), 0);
+        // `str::lines()` strips `\r` along with `\n`, so two files whose
+        // lines are textually identical but whose raw bytes differ (CRLF
+        // vs LF terminators, or a missing trailing newline) collapse to an
+        // empty diff here. Fall back to a byte comparison before declaring
+        // the files identical — see #2627.
+        if content1 == content2 {
+            return ("[ok] Files are identical\n".to_string(), 0);
+        }
+        return (
+            format!(
+                "{} → {}\n   Files differ only in {} (no visible line changes)\n",
+                file1.display(),
+                file2.display(),
+                describe_byte_only_difference(content1, content2)
+            ),
+            1,
+        );
     }
 
     let mut rtk = String::new();
@@ -143,6 +159,21 @@ fn compute_diff(lines1: &[&str], lines2: &[&str]) -> DiffResult {
         modified,
         changes,
     }
+}
+
+/// Explains a byte-level difference between two files whose `str::lines()`
+/// output is identical (so `compute_diff` found no changes). Used when the
+/// files are not byte-equal but no line-level diff was detected.
+fn describe_byte_only_difference(content1: &str, content2: &str) -> String {
+    let crlf1 = content1.contains("\r\n");
+    let crlf2 = content2.contains("\r\n");
+    if crlf1 != crlf2 {
+        return "line endings (CRLF vs LF)".to_string();
+    }
+    if content1.ends_with('\n') != content2.ends_with('\n') {
+        return "trailing newline".to_string();
+    }
+    "line endings or trailing whitespace".to_string()
 }
 
 fn similarity(a: &str, b: &str) -> f64 {
@@ -358,6 +389,74 @@ mod tests {
         );
         assert!(out.contains("[ok] Files are identical"));
         assert_eq!(code, 0);
+    }
+
+    // --- render_file_diff (issue #2627 regression: CRLF vs LF) ---
+
+    #[test]
+    fn test_render_crlf_vs_lf_not_identical() {
+        // Same text content, different line terminators. `str::lines()`
+        // strips both `\n` and `\r\n` uniformly, so the line-based diff
+        // sees no changes — the byte-comparison fallback must catch this.
+        let (out, code) = render_file_diff(
+            Path::new("crlf.txt"),
+            Path::new("lf.txt"),
+            "a\r\nb\r\nc\r\n",
+            "a\nb\nc\n",
+        );
+        assert!(
+            !out.contains("identical"),
+            "CRLF vs LF files reported as identical:\n{}",
+            out
+        );
+        assert!(out.contains("CRLF vs LF"));
+        assert_eq!(code, 1, "differing files must exit 1 (diff convention)");
+    }
+
+    #[test]
+    fn test_render_trailing_newline_diff_not_identical() {
+        // Same lines, but one file has a trailing newline and the other
+        // doesn't — also invisible to `str::lines()`.
+        let (out, code) = render_file_diff(
+            Path::new("with_nl.txt"),
+            Path::new("no_nl.txt"),
+            "a\nb\n",
+            "a\nb",
+        );
+        assert!(
+            !out.contains("identical"),
+            "trailing-newline-only diff reported as identical:\n{}",
+            out
+        );
+        assert_eq!(code, 1);
+    }
+
+    #[test]
+    fn test_render_crlf_both_files_still_identical() {
+        // Both files use CRLF consistently and have the same content —
+        // must still report identical (this is the true byte-equal case).
+        let (out, code) =
+            render_file_diff(Path::new("a.txt"), Path::new("b.txt"), "a\r\nb\r\n", "a\r\nb\r\n");
+        assert!(out.contains("[ok] Files are identical"));
+        assert_eq!(code, 0);
+    }
+
+    // --- describe_byte_only_difference ---
+
+    #[test]
+    fn test_describe_byte_only_difference_crlf_vs_lf() {
+        assert_eq!(
+            describe_byte_only_difference("a\r\nb\r\n", "a\nb\n"),
+            "line endings (CRLF vs LF)"
+        );
+    }
+
+    #[test]
+    fn test_describe_byte_only_difference_trailing_newline() {
+        assert_eq!(
+            describe_byte_only_difference("a\nb\n", "a\nb"),
+            "trailing newline"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixes #2627.

`rtk diff <file1> <file2>` reported two files as identical (exit 0) when they differed only in line-ending bytes (CRLF vs LF) — or, more generally, in anything `str::lines()` normalizes away (it strips `\r` along with `\n`, and treats a missing trailing newline as just "one fewer empty trailing line").

```bash
printf 'a\r\nb\r\nc\r\n' > x   # CRLF
printf 'a\nb\nc\n'       > y   # LF
rtk diff x y; echo "exit=$?"
# before: [ok] Files are identical / exit=0   (wrong — bytes differ, `diff` sees this)
```

## Root cause
`render_file_diff` splits both files with `content.lines()` before comparing (`src/cmds/git/diff_cmd.rs`). `str::lines()` treats `\r\n` and `\n` as equivalent line terminators, so a CRLF file and an LF file with the same text collapse to identical line vectors, and `compute_diff` finds zero changes — the early-return then reports "identical" with no byte comparison.

## Fix
In `render_file_diff`, when the line-based diff finds no changes, fall back to an explicit byte comparison (`content1 == content2`) before declaring the files identical:
- Byte-equal → still "[ok] Files are identical", exit 0 (unchanged behavior).
- Byte-different but line-identical → report the files differ, with a short description of the cause (`describe_byte_only_difference`: CRLF vs LF, trailing newline, or generic), exit 1 (diff convention).

## Scope note
The issue also flags `condense_unified_diff` (this file) and `compact_diff` (`src/cmds/git/git.rs`) as sharing the same `str::lines()` pattern, but says those paths weren't independently verified to reproduce the bug. I scoped this PR to the confirmed, reproducible case (`rtk diff <file> <file>` / `render_file_diff`) rather than changing unverified code paths. Happy to follow up on those separately if confirmed.

## Test plan
- [x] Added regression tests in `src/cmds/git/diff_cmd.rs`: CRLF-vs-LF (reproduces the exact issue), trailing-newline-only diff, and a same-CRLF-on-both-sides case to confirm true identical files still short-circuit correctly. Also unit tests for the new `describe_byte_only_difference` helper.
- [ ] `cargo test` — could not run locally (no working MSVC/64-bit linker in my sandbox; see comment on #2642 for details). The change is isolated to `render_file_diff` and a new pure helper function with no external dependencies; existing tests for that function (`test_render_identical_files_exit_zero`, `test_render_modified_only_yaml_not_identical`, etc.) are untouched and should still pass since the byte-equal fast path is preserved. Appreciate CI confirming.
