### PR TITLE
fix(ls): strip unsupported --depth flag instead of erroring

### DIFF
--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -20,6 +20,9 @@ lazy_static! {
 }
 
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
+    let args = strip_unsupported_depth_flag(args);
+    let args = args.as_slice();
+
     let show_all = args
         .iter()
         .any(|a| (a.starts_with('-') && !a.starts_with("--") && a.contains('a')) || a == "--all");
@@ -124,6 +127,43 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
             .early_exit_on_failure()
             .no_trailing_newline(),
     )
+}
+
+/// `rtk ls` always lists a single directory level (it shells out to plain
+/// `ls -la`, with no recursion); `--depth` is not implemented. Native `ls`
+/// doesn't understand `--depth` either and errors on it (`unknown option --
+/// depth`), so strip the flag — and its value, in either `--depth N` or
+/// `--depth=N` form — before it reaches native `ls` or gets mistaken for a
+/// path argument. See #2365.
+fn strip_unsupported_depth_flag(args: &[String]) -> Vec<String> {
+    let mut out = Vec::with_capacity(args.len());
+    let mut iter = args.iter().peekable();
+    let mut stripped = false;
+
+    while let Some(arg) = iter.next() {
+        if arg == "--depth" {
+            stripped = true;
+            // Only consume the next token if it looks like the depth value
+            // (all digits); otherwise leave it alone — it's likely a path.
+            if iter.peek().is_some_and(|next| {
+                !next.is_empty() && next.chars().all(|c| c.is_ascii_digit())
+            }) {
+                iter.next();
+            }
+            continue;
+        }
+        if arg.starts_with("--depth=") {
+            stripped = true;
+            continue;
+        }
+        out.push(arg.clone());
+    }
+
+    if stripped {
+        eprintln!("rtk: --depth is not supported by `rtk ls` (no recursion); ignoring");
+    }
+
+    out
 }
 
 /// Format bytes into human-readable size
@@ -352,6 +392,50 @@ fn compact_ls(raw: &str, show_all: bool, show_long: bool) -> (String, String, us
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- strip_unsupported_depth_flag (issue #2365) ---
+
+    #[test]
+    fn test_strip_depth_separate_value() {
+        let args = vec!["--depth".to_string(), "3".to_string()];
+        let out = strip_unsupported_depth_flag(&args);
+        assert!(out.is_empty(), "got: {out:?}");
+    }
+
+    #[test]
+    fn test_strip_depth_equals_value() {
+        let args = vec!["--depth=3".to_string()];
+        let out = strip_unsupported_depth_flag(&args);
+        assert!(out.is_empty(), "got: {out:?}");
+    }
+
+    #[test]
+    fn test_strip_depth_preserves_surrounding_args() {
+        let args = vec![
+            "-la".to_string(),
+            "--depth".to_string(),
+            "2".to_string(),
+            "src".to_string(),
+        ];
+        let out = strip_unsupported_depth_flag(&args);
+        assert_eq!(out, vec!["-la".to_string(), "src".to_string()]);
+    }
+
+    #[test]
+    fn test_strip_depth_without_numeric_value_keeps_next_arg() {
+        // Malformed usage (no number after --depth): don't eat the next
+        // token, since it's more likely a path than a depth value.
+        let args = vec!["--depth".to_string(), "src".to_string()];
+        let out = strip_unsupported_depth_flag(&args);
+        assert_eq!(out, vec!["src".to_string()]);
+    }
+
+    #[test]
+    fn test_strip_depth_absent_is_noop() {
+        let args = vec!["-la".to_string(), "src".to_string()];
+        let out = strip_unsupported_depth_flag(&args);
+        assert_eq!(out, args);
+    }
 
     #[test]
     fn test_compact_basic() {


### PR DESCRIPTION
## Summary
Fixes #2365.

```bash
rtk ls --depth 1
# ls: unknown option -- depth
```

`src/cmds/system/ls.rs::run` forwards any unrecognized `--*` flag straight to native `ls` (except `--all`). `--depth` isn't a real `ls` flag, so it errors. There's a second, sneakier bug: since nothing in `run` knows `--depth` takes a value, the separate-token form (`--depth 3`) lets `3` fall through the `paths` filter (anything not starting with `-`) and get passed to `ls` as a positional path argument — so even if `--depth` itself were silently dropped, `3` would still corrupt the target path list.

## Why strip instead of implement
`rtk ls` always lists a single directory level — it shells out to plain `ls -la` with no recursion logic anywhere in `compact_ls`/`run`. There's no existing depth/recursion concept to "limit", so implementing real depth-limited recursive listing would be a new feature, not a fix for this bug report. The existing smoke test (`scripts/test-aristote.sh:104`, `assert_ok "rtk ls --depth 3" rtk ls --depth 3 ...`) only asserts the command doesn't fail — it doesn't assert recursive behavior — so I scoped this PR to making the flag harmless rather than building recursion.

## Fix
Added `strip_unsupported_depth_flag`, called at the top of `run`, which removes `--depth` and its value in both forms (`--depth N` and `--depth=N`) before flag/path splitting, and prints a one-line stderr notice (`rtk: --depth is not supported by \`rtk ls\` (no recursion); ignoring`) so the behavior isn't silent. It only consumes the next token as the depth value when it's all-digits, so a malformed `--depth <path>` invocation doesn't accidentally eat a real path argument.

## Test plan
- [x] Added unit tests for `strip_unsupported_depth_flag`: separate-token form, `--depth=N` form, surrounding args preserved, malformed usage (non-numeric next token) leaves the next arg alone, and a no-op case when `--depth` is absent.
- [x] Confirmed via `src/main.rs` that `Ls { args }` uses `trailing_var_arg = true, allow_hyphen_values = true`, so `--depth` and its value reach `ls::run` as raw string tokens exactly as the new function expects (clap doesn't intercept or validate it first).
- [ ] `cargo test` — could not run locally (no working MSVC/64-bit linker in my sandbox; same caveat as my other open PRs in this repo). The change is additive and isolated to a new pure function plus three lines wiring it into `run`; existing `compact_ls`/`parse_ls_line` tests are untouched. Appreciate CI confirming.
