### PR TITLE
docs(readme): clarify grep versus ripgrep usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ git status  # Automatically rewritten to rtk git status
 
 Hook-based agents rewrite Bash commands (e.g., `git status` -> `rtk git status`) before execution. Plugin-based agents, including Hermes, use their plugin API to rewrite commands before execution. The agent receives compact output without needing to call `rtk` explicitly.
 
-**Important:** the hook only runs on Bash tool calls. Claude Code built-in tools like `Read`, `Grep`, and `Glob` do not pass through the Bash hook, so they are not auto-rewritten. To get RTK's compact output for those workflows, use shell commands (`cat`/`head`/`tail`, `rg`/`grep`, `find`) or call `rtk read`, `rtk grep`, or `rtk find` directly.
+**Important:** the hook only runs on Bash tool calls. Claude Code built-in tools like `Read`, `Grep`, and `Glob` do not pass through the Bash hook, so they are not auto-rewritten. To get RTK's compact output for those workflows, use shell commands (`cat`/`head`/`tail`, `rg`/`grep`, `find`) or call `rtk read`, `rtk grep`, `rtk rg`, or `rtk find` directly.
+
+RTK preserves the search tool you invoke: `grep` is rewritten to `rtk grep` and still runs system `grep`; `rg` is rewritten to `rtk rg` and runs ripgrep. Install ripgrep if you want your agent or shell workflow to use `rg`, but RTK will not silently swap `grep` commands to ripgrep.
 
 ## How It Works
 
@@ -149,7 +151,8 @@ rtk read file.rs                # Smart file reading
 rtk read file.rs -l aggressive  # Signatures only (strips bodies)
 rtk smart file.rs               # 2-line heuristic code summary
 rtk find "*.rs" .               # Compact find results
-rtk grep "pattern" .            # Grouped search results
+rtk grep "pattern" .            # Grouped system grep results
+rtk rg "pattern" .              # Grouped ripgrep results (requires rg)
 rtk diff file1 file2            # Condensed diff (exit 1 if files differ)
 ```
 

--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -202,11 +202,12 @@ Supporte a la fois la syntaxe RTK et la syntaxe native `find` (`-name`, `-type`,
 
 ### `rtk grep` -- Recherche dans le contenu
 
-**Objectif :** Remplace `grep` et `rg` avec une sortie groupee par fichier, tronquee.
+**Objectif :** Remplace `grep` avec une sortie groupee par fichier, tronquee. Pour ripgrep, utilisez `rtk rg`, qui conserve le moteur `rg` et applique le meme regroupement de sortie.
 
 **Syntaxe :**
 ```bash
 rtk grep <pattern> [chemin] [options]
+rtk rg <pattern> [chemin] [options]
 ```
 
 **Options :**
@@ -219,13 +220,13 @@ rtk grep <pattern> [chemin] [options]
 | `--file-type` | `-t` | tous | Filtrer par type (ts, py, rust, etc.) |
 | `--line-numbers` | `-n` | oui | Numeros de ligne (toujours actif) |
 
-Les arguments supplementaires sont transmis a `rg` (ripgrep). Les flags qui changent le format de sortie (`-c`, `-l`, `-L`, `-o`, `-Z`) passent directement a `rg`/`grep` sans filtrage RTK.
+Les arguments supplementaires sont transmis au moteur invoque : `rtk grep` execute `grep`, tandis que `rtk rg` execute `rg` (ripgrep). Les flags qui changent le format de sortie (`-c`, `-l`, `-L`, `-o`, `-Z`) passent directement au moteur sous-jacent sans filtrage RTK.
 
 **Economies :** ~80%
 
 **Avant / Apres :**
 ```
-# rg "fn run" (20 lignes)                   # rtk grep "fn run" (10 lignes)
+# rg "fn run" (20 lignes)                   # rtk rg "fn run" (10 lignes)
 src/git.rs:45:pub fn run(...)                src/git.rs
 src/git.rs:120:fn run_status(...)              45: pub fn run(...)
 src/ls.rs:12:pub fn run(...)                   120: fn run_status(...)
@@ -1255,7 +1256,8 @@ rtk verify
 | `gh pr/issue/run` | `rtk gh ...` |
 | `cargo test/build/clippy/check` | `rtk cargo ...` |
 | `cat/head/tail <fichier>` | `rtk read <fichier>` |
-| `rg/grep <pattern>` | `rtk grep <pattern>` |
+| `grep <pattern>` | `rtk grep <pattern>` |
+| `rg <pattern>` | `rtk rg <pattern>` |
 | `ls` | `rtk ls` |
 | `tree` | `rtk tree` |
 | `wc` | `rtk wc` |


### PR DESCRIPTION
## Summary
- Clarify that RTK preserves the search tool invoked by the user or agent: `grep` routes to `rtk grep`, while `rg` routes to `rtk rg`.
- Document `rtk rg` in the README and usage guide so users know ripgrep is only needed when their workflow uses `rg`.
- Sync the usage docs with the post-#2641 behavior instead of saying `rtk grep` replaces both `grep` and `rg`.

Fixes #2613

## Test plan
- [x] `git diff --check`
- [x] README/docs content probes for `rtk rg`, grep/rg preservation, and no silent grep->ripgrep swap
- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test` — not run locally; docs-only change and this host does not have `cargo` installed
- [ ] Manual testing: `rtk <command>` output inspected — not applicable; documentation-only clarification
