### PR TITLE
fix(discover): detect Claude Code hook to flag overstated missed savings

### DIFF
--- a/src/discover/report.rs
+++ b/src/discover/report.rs
@@ -1,8 +1,9 @@
 //! Data types for reporting which commands RTK can and cannot optimize.
 
 use crate::hooks::constants::{
-    COPILOT_HOOK_FILE, CURSOR_DIR, GITHUB_DIR, HERMES_DIR, HERMES_PLUGINS_SUBDIR,
-    HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_SUBDIR, REWRITE_HOOK_FILE,
+    CLAUDE_DIR, CLAUDE_HOOK_COMMAND, COPILOT_HOOK_FILE, CURSOR_DIR, GITHUB_DIR, HERMES_DIR,
+    HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_SUBDIR,
+    PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use serde::Serialize;
 use std::path::Path;
@@ -50,6 +51,7 @@ pub struct UnsupportedEntry {
 
 #[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq, Default)]
 pub struct AgentIntegrationStatus {
+    pub claude_hook_installed: bool,
     pub cursor_hook_installed: bool,
     pub hermes_plugin_installed: bool,
     pub copilot_hook_installed: bool,
@@ -69,6 +71,7 @@ impl AgentIntegrationStatus {
 
     fn detect_from_home(home: &Path) -> Self {
         Self {
+            claude_hook_installed: Self::claude_hook_installed_in(home),
             cursor_hook_installed: home
                 .join(CURSOR_DIR)
                 .join(HOOKS_SUBDIR)
@@ -82,6 +85,32 @@ impl AgentIntegrationStatus {
                 .is_file(),
             copilot_hook_installed: false,
         }
+    }
+
+    fn claude_hook_installed_in(home: &Path) -> bool {
+        let settings_path = home.join(CLAUDE_DIR).join(SETTINGS_JSON);
+        let content = match std::fs::read_to_string(&settings_path) {
+            Ok(c) if !c.trim().is_empty() => c,
+            _ => return false,
+        };
+        let root: serde_json::Value = match serde_json::from_str(&content) {
+            Ok(v) => v,
+            Err(_) => return false,
+        };
+        let pre_tool_use = match root
+            .get("hooks")
+            .and_then(|h| h.get(PRE_TOOL_USE_KEY))
+            .and_then(|p| p.as_array())
+        {
+            Some(arr) => arr,
+            None => return false,
+        };
+        pre_tool_use
+            .iter()
+            .filter_map(|entry| entry.get("hooks")?.as_array())
+            .flatten()
+            .filter_map(|hook| hook.get("command")?.as_str())
+            .any(|cmd| cmd.starts_with(CLAUDE_HOOK_COMMAND))
     }
 
     fn copilot_hook_installed_in(dir: &Path) -> bool {
@@ -228,6 +257,14 @@ pub fn format_text(report: &DiscoverReport, limit: usize, verbose: bool) -> Stri
 }
 
 fn append_agent_notes(out: &mut String, status: AgentIntegrationStatus) {
+    if status.claude_hook_installed {
+        out.push_str(
+            "\nNote: Claude Code PreToolUse hook is installed — commands above are already\n\
+             auto-rewritten at execution time. The transcript records pre-rewrite text,\n\
+             so these counts overstate missed savings. See `rtk gain` for actual savings.\n",
+        );
+    }
+
     if status.cursor_hook_installed {
         out.push_str("\nNote: Cursor sessions are tracked via `rtk gain` (discover scans Claude Code only)\n");
     }
@@ -378,6 +415,7 @@ mod tests {
     fn test_format_json_includes_agent_status() {
         let mut report = make_report(0, 0);
         report.agent_status = AgentIntegrationStatus {
+            claude_hook_installed: true,
             cursor_hook_installed: true,
             hermes_plugin_installed: true,
             copilot_hook_installed: true,
@@ -386,6 +424,7 @@ mod tests {
         let output = format_json(&report);
         let json: serde_json::Value = serde_json::from_str(&output).unwrap();
 
+        assert_eq!(json["agent_status"]["claude_hook_installed"], true);
         assert_eq!(json["agent_status"]["cursor_hook_installed"], true);
         assert_eq!(json["agent_status"]["hermes_plugin_installed"], true);
         assert_eq!(json["agent_status"]["copilot_hook_installed"], true);
@@ -425,5 +464,126 @@ mod tests {
             "Expected Copilot note in output but got:\n{}",
             output
         );
+    }
+
+    #[test]
+    fn test_agent_status_detects_claude_hook_in_settings() {
+        let temp_home = tempfile::tempdir().unwrap();
+        let settings_path = temp_home.path().join(CLAUDE_DIR).join(SETTINGS_JSON);
+        std::fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &settings_path,
+            r#"{
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [
+                                { "type": "command", "command": "rtk hook claude" }
+                            ]
+                        }
+                    ]
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let status = AgentIntegrationStatus::detect_from_home(temp_home.path());
+        assert!(status.claude_hook_installed);
+    }
+
+    #[test]
+    fn test_agent_status_no_claude_hook_without_settings() {
+        let temp_home = tempfile::tempdir().unwrap();
+        let status = AgentIntegrationStatus::detect_from_home(temp_home.path());
+        assert!(!status.claude_hook_installed);
+    }
+
+    #[test]
+    fn test_agent_status_no_claude_hook_with_empty_settings() {
+        let temp_home = tempfile::tempdir().unwrap();
+        let settings_path = temp_home.path().join(CLAUDE_DIR).join(SETTINGS_JSON);
+        std::fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+        std::fs::write(&settings_path, "{}").unwrap();
+
+        let status = AgentIntegrationStatus::detect_from_home(temp_home.path());
+        assert!(!status.claude_hook_installed);
+    }
+
+    #[test]
+    fn test_agent_status_no_claude_hook_with_other_hooks() {
+        let temp_home = tempfile::tempdir().unwrap();
+        let settings_path = temp_home.path().join(CLAUDE_DIR).join(SETTINGS_JSON);
+        std::fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &settings_path,
+            r#"{
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [
+                                { "type": "command", "command": "some-other-hook" }
+                            ]
+                        }
+                    ]
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let status = AgentIntegrationStatus::detect_from_home(temp_home.path());
+        assert!(!status.claude_hook_installed);
+    }
+
+    #[test]
+    fn test_format_text_reports_claude_hook_detected() {
+        let mut report = make_report(100, 50);
+        report.supported = vec![SupportedEntry {
+            command: "git status".to_string(),
+            count: 40,
+            rtk_equivalent: "rtk git",
+            category: "Git",
+            estimated_savings_tokens: 4500,
+            estimated_savings_pct: 80.0,
+            rtk_status: RtkStatus::Existing,
+        }];
+        report.agent_status = AgentIntegrationStatus {
+            claude_hook_installed: true,
+            ..AgentIntegrationStatus::default()
+        };
+
+        let output = format_text(&report, 10, false);
+
+        assert!(
+            output.contains("PreToolUse hook is installed"),
+            "Expected Claude hook note in output but got:\n{}",
+            output
+        );
+        assert!(
+            output.contains("overstate missed savings"),
+            "Expected overstate warning in output but got:\n{}",
+            output
+        );
+        assert!(
+            output.contains("rtk gain"),
+            "Expected rtk gain reference in output but got:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_format_json_includes_claude_hook_status() {
+        let mut report = make_report(0, 0);
+        report.agent_status = AgentIntegrationStatus {
+            claude_hook_installed: true,
+            ..AgentIntegrationStatus::default()
+        };
+
+        let output = format_json(&report);
+        let json: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+        assert_eq!(json["agent_status"]["claude_hook_installed"], true);
+        assert_eq!(json["agent_status"]["cursor_hook_installed"], false);
     }
 }


### PR DESCRIPTION
## Summary

Closes #2648.

When the Claude Code PreToolUse hook is configured, `rtk discover` scans pre-rewrite transcript text and inflates "MISSED SAVINGS" — reporting up to ~877K tokens saveable while `rtk gain` shows 226M tokens already saved (a ~99% discrepancy).

**Root cause**: `AgentIntegrationStatus` detected Cursor, Hermes, and Copilot hooks but not the Claude Code PreToolUse hook in `~/.claude/settings.json`.

**Fix**:
- Add `claude_hook_installed` field to `AgentIntegrationStatus`
- Detect the hook by parsing `~/.claude/settings.json` for a `PreToolUse` entry with `rtk hook claude` (same pattern as `hook_check.rs::binary_hook_registered()`)
- Append a note to the discover report explaining the overcount and directing users to `rtk gain`

## Test plan

- [x] New test: detects Claude hook from settings.json with correct structure
- [x] New test: returns false when settings.json is missing/empty/has other hooks
- [x] New test: report text includes the warning note when hook is detected
- [x] New test: JSON output includes `claude_hook_installed: true`
- [x] Existing tests pass (15 report tests total, 2237 tests project-wide)
- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test --all` clean

