### PR TITLE
fix(diff): remove misleading overflow indicator from condense_unified_diff

### DIFF
--- a/src/cmds/git/diff_cmd.rs
+++ b/src/cmds/git/diff_cmd.rs
@@ -400,7 +400,7 @@ diff --git a/b.rs b/b.rs
         assert!(result.is_empty());
     }
 
-    // --- truncation accuracy ---
+    // --- overflow indicator ---
 
     fn make_large_unified_diff(added: usize, removed: usize) -> String {
         let mut lines = vec![
@@ -441,7 +441,7 @@ diff --git a/b.rs b/b.rs
 
     #[test]
     fn test_condense_unified_diff_no_false_overflow() {
-        // 8 changes total — all fit within the 10-line display cap, no overflow message
+        // Counter-case to the 200-change test above: no indicator at small sizes either.
         let diff = make_large_unified_diff(4, 4);
         let result = condense_unified_diff(&diff);
         assert!(

--- a/src/cmds/git/diff_cmd.rs
+++ b/src/cmds/git/diff_cmd.rs
@@ -176,10 +176,6 @@ fn condense_unified_diff(diff: &str) -> String {
                     for c in &changes {
                         result.push(format!("  {}", c));
                     }
-                    let total = added + removed;
-                    if total > 10 {
-                        result.push(format!("  ... +{} more", total - 10));
-                    }
                 }
                 current_file = line
                     .trim_start_matches("+++ ")
@@ -203,10 +199,6 @@ fn condense_unified_diff(diff: &str) -> String {
         result.push(format!("[file] {} (+{} -{})", current_file, added, removed));
         for c in &changes {
             result.push(format!("  {}", c));
-        }
-        let total = added + removed;
-        if total > 10 {
-            result.push(format!("  ... +{} more", total - 10));
         }
     }
 
@@ -427,20 +419,23 @@ diff --git a/b.rs b/b.rs
     }
 
     #[test]
-    fn test_condense_unified_diff_overflow_count_accuracy() {
-        // 100 added + 100 removed = 200 total changes, only 10 shown
-        // True overflow = 200 - 10 = 190
-        // Bug: changes vec capped at 15, so old code showed "+5 more" (15-10) instead of "+190 more"
+    fn test_condense_unified_diff_large_no_false_overflow_indicator() {
+        // All 200 changes are shown in full (never truncate diff content).
+        // No misleading "... +N more" should appear.
         let diff = make_large_unified_diff(100, 100);
         let result = condense_unified_diff(&diff);
         assert!(
-            result.contains("+190 more"),
-            "Expected '+190 more' but got:\n{}",
+            !result.contains("more"),
+            "No overflow indicator expected when all lines are shown, got:\n{}",
             result
         );
         assert!(
-            !result.contains("+5 more"),
-            "Bug still present: showing '+5 more' instead of true overflow"
+            result.contains("+new_value_99"),
+            "Last added line must be present (no truncation)"
+        );
+        assert!(
+            result.contains("-old_value_99"),
+            "Last removed line must be present (no truncation)"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes #2653.

`condense_unified_diff` prints ALL change lines in full (honoring the "Never truncate diff content" comment), then appends `... +N more` when total changes exceed 10. This misleads LLM consumers into requesting "remaining" data that was already shown, wasting tokens on redundant fetches.

**Before**: 200 changes printed, then `... +190 more` (implies 190 lines were hidden)
**After**: 200 changes printed, no misleading indicator

## Test plan

- [x] Updated `test_condense_unified_diff_overflow_count_accuracy` → renamed to `test_condense_unified_diff_large_no_false_overflow_indicator`, now asserts NO overflow message appears and verifies all lines are present
- [x] Existing `test_condense_unified_diff_no_false_overflow` continues to pass
- [x] All 23 diff_cmd tests pass
- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test --all` clean (2237 tests, 0 failures)