### PR TITLE
fix(curl): use signal-aware exit code instead of unwrap_or(1)

### DIFF
--- a/src/cmds/cloud/curl_cmd.rs
+++ b/src/cmds/cloud/curl_cmd.rs
@@ -11,6 +11,7 @@
 //! otherwise replace non-UTF-8 bytes with U+FFFD and corrupt the stream
 //! (`#1087`).
 
+use crate::core::stream::status_to_exit_code;
 use crate::core::tee::force_tee_hint;
 use crate::core::tracking;
 use crate::core::utils::resolved_command;
@@ -38,7 +39,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     // every non-UTF-8 byte with U+FFFD (3 bytes), corrupting e.g. gzip
     // magic `1f 8b 08 00` into `1f ef bf bd 08 00` (#1087).
     let output = cmd.output().context("Failed to run curl")?;
-    let exit_code = output.status.code().unwrap_or(1);
+    let exit_code = status_to_exit_code(output.status);
 
     // Skip filtering on failure: curl can return HTML error bodies that would
     // be misleading to summarize, and we want the real exit code surfaced.


### PR DESCRIPTION
## Summary

- Replace `output.status.code().unwrap_or(1)` with the existing `status_to_exit_code()` helper from `core/stream.rs`
- Signal-killed curl processes (OOM, SIGTERM) now report `128+signal` instead of a generic exit 1

Closes #2656