### PR TITLE
fix(pnpm): propagate exit code from pnpm outdated

### DIFF
--- a/src/cmds/js/pnpm_cmd.rs
+++ b/src/cmds/js/pnpm_cmd.rs
@@ -432,6 +432,12 @@ fn run_outdated(args: &[String], verbose: u8) -> Result<i32> {
     }
 
     let result = exec_capture(&mut cmd).context("Failed to run pnpm outdated")?;
+
+    if !result.success() && !result.stderr.is_empty() {
+        eprint!("{}", result.stderr);
+        return Ok(result.exit_code);
+    }
+
     let combined = result.combined();
 
     // Parse output using PnpmOutdatedParser
@@ -467,7 +473,7 @@ fn run_outdated(args: &[String], verbose: u8) -> Result<i32> {
 
     timer.track("pnpm outdated", "rtk pnpm outdated", &combined, shown);
 
-    Ok(0)
+    Ok(result.exit_code)
 }
 
 fn run_install(args: &[String], verbose: u8) -> Result<i32> {


### PR DESCRIPTION
## Summary

- Add stderr-guarded failure check to `run_outdated()` — real errors (network, auth) now bail early and surface the error message
- Propagate exit code instead of hardcoded `Ok(0)` — CI/CD pipelines see the correct exit 1 when outdated packages are found
- Normal "outdated found" path (exit 1, empty stderr) still flows through RTK's JSON parsing and table formatting

Consistent with how `run_list()` and `run_install()` handle failures in the same file.

Closes #2658