### PR TITLE
fix(pnpm): propagate exit code from pnpm outdated

### DIFF
--- a/src/cmds/js/pnpm_cmd.rs
+++ b/src/cmds/js/pnpm_cmd.rs
@@ -432,6 +432,15 @@ fn run_outdated(args: &[String], verbose: u8) -> Result<i32> {
     }
 
     let result = exec_capture(&mut cmd).context("Failed to run pnpm outdated")?;
+
+    // Propagate exit code from pnpm outdated unless it's a legitimate "packages
+    // are outdated" exit (exit 1 with empty stderr, which pnpm uses to signal
+    // outdated packages rather than an actual error).
+    if !result.success() && !result.stderr.is_empty() {
+        eprint!("{}", result.stderr);
+        return Ok(result.exit_code);
+    }
+
     let combined = result.combined();
 
     // Parse output using PnpmOutdatedParser
@@ -467,7 +476,7 @@ fn run_outdated(args: &[String], verbose: u8) -> Result<i32> {
 
     timer.track("pnpm outdated", "rtk pnpm outdated", &combined, shown);
 
-    Ok(0)
+    Ok(result.exit_code)
 }
 
 fn run_install(args: &[String], verbose: u8) -> Result<i32> {


### PR DESCRIPTION
pnpm outdated always returned Ok(0) regardless of the underlying command result, masking failures like network errors or auth issues. Also, pnpm returns exit 1 for legitimate 'packages are outdated' results (with empty stderr), so we only bail on real errors (non-empty stderr).

Closes #2658