### PR TITLE
fix(git): recognize -n<N> combined form in git log limit detection

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -441,10 +441,11 @@ fn run_log(
         arg.starts_with("--oneline") || arg.starts_with("--pretty") || arg.starts_with("--format")
     });
 
-    // Check if user provided limit flag (-N, -n N, --max-count=N, --max-count N)
+    // Check if user provided limit flag (-N, -n N, -nN, --max-count=N, --max-count N)
     let has_limit_flag = args.iter().any(|arg| {
         (arg.starts_with('-') && arg.chars().nth(1).is_some_and(|c| c.is_ascii_digit()))
             || arg == "-n"
+            || (arg.starts_with("-n") && arg[2..].bytes().next().is_some_and(|b| b.is_ascii_digit()))
             || arg.starts_with("--max-count")
     });
 
@@ -522,6 +523,12 @@ fn parse_user_limit(args: &[String]) -> Option<usize> {
             && arg.chars().nth(1).is_some_and(|c| c.is_ascii_digit())
         {
             if let Ok(n) = arg[1..].parse::<usize>() {
+                return Some(n);
+            }
+        }
+        // -n20 (combined form)
+        if let Some(rest) = arg.strip_prefix("-n") {
+            if let Ok(n) = rest.parse::<usize>() {
                 return Some(n);
             }
         }
@@ -2704,6 +2711,12 @@ A  added.rs
     #[test]
     fn test_parse_user_limit_combined() {
         let args: Vec<String> = vec!["-20".into()];
+        assert_eq!(parse_user_limit(&args), Some(20));
+    }
+
+    #[test]
+    fn test_parse_user_limit_n_combined() {
+        let args: Vec<String> = vec!["-n20".into()];
         assert_eq!(parse_user_limit(&args), Some(20));
     }
 


### PR DESCRIPTION
## Summary

- `rtk git log -n20` silently truncated to 10 commits because the combined `-n<N>` form was not recognized by `has_limit_flag` or `parse_user_limit()`
- Added detection for `-n<digits>` in both the limit flag check and the parser
- Added regression test for the combined form

## Root Cause

`has_limit_flag` checked for `-<digit>` (like `-20`), `-n` (standalone), and `--max-count`, but not `-n<digits>`. When undetected, RTK injected its own `-10` limit and set `filter_log_output` to truncate at 10 commits — silently losing half the user's requested output.

## Test plan

- [x] New test `test_parse_user_limit_n_combined` verifies `-n20` parses to `Some(20)`
- [x] Existing tests for `-20`, `-n 15`, `--max-count=30`, `--max-count 25` still pass
- [x] `cargo fmt && cargo clippy --all-targets && cargo test --all` passes

Fixes #2665