### PR TITLE
feat(hook): signal/bulk passthrough for control-marker commands

### DIFF
--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -112,6 +112,13 @@ fn get_rewritten(cmd: &str) -> Option<String> {
         return None;
     }
 
+    // Signal commands emit canonical control markers (`git push`'s `To <repo>`
+    // line, `git status` porcelain, `gh pr` state) that downstream agents grep
+    // against. Bypass rewriting so raw stdout reaches the caller unreshaped.
+    if super::passthrough::is_signal_command(cmd) {
+        return None;
+    }
+
     let (excluded, transparent_prefixes) = crate::core::config::Config::load()
         .map(|c| (c.hooks.exclude_commands, c.hooks.transparent_prefixes))
         .unwrap_or_default();
@@ -619,7 +626,16 @@ mod tests {
 
     #[test]
     fn test_get_rewritten_supported() {
-        assert!(get_rewritten("git status").is_some());
+        assert!(get_rewritten("git diff").is_some());
+    }
+
+    #[test]
+    fn test_get_rewritten_signal_command_passthrough() {
+        // Signal commands bypass rewriting so their canonical control markers
+        // (git push's `To <repo>`, git status porcelain) reach the caller raw.
+        assert!(get_rewritten("git status").is_none());
+        assert!(get_rewritten("git push origin main").is_none());
+        assert!(get_rewritten("gh pr view 123").is_none());
     }
 
     #[test]
@@ -754,7 +770,7 @@ mod tests {
 
     #[test]
     fn test_copilot_cli_cve_safe_forms_still_rewrite() {
-        for cmd in ["git status", "git status 2>&1"] {
+        for cmd in ["git diff", "git diff 2>&1"] {
             let r = end_to_end(cmd).unwrap_or_else(|| panic!("expected rewrite for {cmd:?}"));
             assert_eq!(
                 r["modifiedArgs"]["command"].as_str().unwrap(),
@@ -905,25 +921,33 @@ mod tests {
     }
 
     #[test]
-    fn test_claude_rewrite_git_status() {
-        let result = run_claude_inner(&claude_input("git status")).unwrap();
+    fn test_claude_rewrite_git_diff() {
+        let result = run_claude_inner(&claude_input("git diff")).unwrap();
         let v: Value = serde_json::from_str(&result).unwrap();
         let cmd = v
             .pointer("/hookSpecificOutput/updatedInput/command")
             .and_then(|c| c.as_str())
             .unwrap();
-        assert_eq!(cmd, "rtk git status");
+        assert_eq!(cmd, "rtk git diff");
+    }
+
+    #[test]
+    fn test_claude_signal_command_passthrough() {
+        // A signal command produces no rewrite payload — Claude Code runs the
+        // original command natively so the canonical marker survives.
+        assert!(run_claude_inner(&claude_input("git push origin main")).is_none());
+        assert!(run_claude_inner(&claude_input("git status")).is_none());
     }
 
     #[test]
     fn test_claude_rewrite_preserves_tool_input_fields() {
-        let input = claude_input_with_fields("git status", 30000, "Check repo status");
+        let input = claude_input_with_fields("git diff", 30000, "Show working diff");
         let result = run_claude_inner(&input).unwrap();
         let v: Value = serde_json::from_str(&result).unwrap();
         let updated = &v["hookSpecificOutput"]["updatedInput"];
-        assert_eq!(updated["command"], "rtk git status");
+        assert_eq!(updated["command"], "rtk git diff");
         assert_eq!(updated["timeout"], 30000);
-        assert_eq!(updated["description"], "Check repo status");
+        assert_eq!(updated["description"], "Show working diff");
     }
 
     #[test]
@@ -948,7 +972,7 @@ mod tests {
     #[test]
     fn test_claude_fd_dup_redirect_still_rewritten() {
         // `2>&1` is attestable — the rewrite proceeds as normal.
-        assert!(run_claude_inner(&claude_input("git status 2>&1")).is_some());
+        assert!(run_claude_inner(&claude_input("git diff 2>&1")).is_some());
     }
 
     #[test]
@@ -978,13 +1002,13 @@ mod tests {
 
     #[test]
     fn test_claude_env_prefix_preserved() {
-        let result = run_claude_inner(&claude_input("GIT_PAGER=cat git status")).unwrap();
+        let result = run_claude_inner(&claude_input("GIT_PAGER=cat git diff")).unwrap();
         let v: Value = serde_json::from_str(&result).unwrap();
         let cmd = v
             .pointer("/hookSpecificOutput/updatedInput/command")
             .and_then(|c| c.as_str())
             .unwrap();
-        assert_eq!(cmd, "GIT_PAGER=cat rtk git status");
+        assert_eq!(cmd, "GIT_PAGER=cat rtk git diff");
     }
 
     #[test]
@@ -1000,7 +1024,7 @@ mod tests {
 
     #[test]
     fn test_claude_json_output_structure() {
-        let result = run_claude_inner(&claude_input("git status")).unwrap();
+        let result = run_claude_inner(&claude_input("git diff")).unwrap();
         let v: Value = serde_json::from_str(&result).unwrap();
         let hook = &v["hookSpecificOutput"];
 
@@ -1034,11 +1058,11 @@ mod tests {
 
     #[test]
     fn test_cursor_rewrite_flat_format() {
-        let result = run_cursor_allowed(&cursor_input("git status"));
+        let result = run_cursor_allowed(&cursor_input("git diff"));
         let v: Value = serde_json::from_str(&result).unwrap();
         // Cursor preToolUse expects allow/deny for rewrite application.
         assert_eq!(v["permission"], "allow");
-        assert_eq!(v["updated_input"]["command"], "rtk git status");
+        assert_eq!(v["updated_input"]["command"], "rtk git diff");
         assert!(v.get("hookSpecificOutput").is_none());
         // `continue: true` keeps the Cursor preToolUse panel from collapsing
         // to `Output: {}`; without it the rewrite is invisible to users.
@@ -1108,14 +1132,14 @@ mod tests {
 
     #[test]
     fn test_cursor_compound_rewrite_includes_continue() {
-        let cmd = "cd \"/tmp/proj\" && git status";
+        let cmd = "cd \"/tmp/proj\" && git diff";
         let result = run_cursor_allowed(&cursor_input(cmd));
         let v: Value = serde_json::from_str(&result).unwrap();
         assert_eq!(v["continue"], true);
         assert_eq!(v["permission"], "allow");
         assert_eq!(
             v["updated_input"]["command"],
-            "cd \"/tmp/proj\" && rtk git status"
+            "cd \"/tmp/proj\" && rtk git diff"
         );
     }
 
@@ -1124,13 +1148,13 @@ mod tests {
         // Some Cursor builds prepend a single UTF-8 BOM to hook stdin.
         // serde_json rejects BOM-prefixed input, so without the strip
         // the hook returned `{}` and the rewrite became a silent no-op.
-        let payload = cursor_input("git status");
+        let payload = cursor_input("git diff");
         let with_single_bom = format!("\u{feff}{}", payload);
         let result = run_cursor_allowed(&with_single_bom);
         let v: Value = serde_json::from_str(&result).unwrap();
         assert_eq!(v["continue"], true);
         assert_eq!(v["permission"], "allow");
-        assert_eq!(v["updated_input"]["command"], "rtk git status");
+        assert_eq!(v["updated_input"]["command"], "rtk git diff");
     }
 
     #[test]
@@ -1139,13 +1163,13 @@ mod tests {
         // UTF-8 BOMs (`EF BB BF EF BB BF`), confirmed via a stdin
         // tracer wrapping `rtk hook cursor` on Cursor 3.2.x. This is
         // the real-world payload shape the loop needs to survive.
-        let payload = cursor_input("git status");
+        let payload = cursor_input("git diff");
         let with_double_bom = format!("\u{feff}\u{feff}{}", payload);
         let result = run_cursor_allowed(&with_double_bom);
         let v: Value = serde_json::from_str(&result).unwrap();
         assert_eq!(v["continue"], true);
         assert_eq!(v["permission"], "allow");
-        assert_eq!(v["updated_input"]["command"], "rtk git status");
+        assert_eq!(v["updated_input"]["command"], "rtk git diff");
     }
 
     #[test]
@@ -1278,7 +1302,7 @@ mod tests {
     #[test]
     fn test_decide_allow_for_attestable_allowed_command() {
         assert!(matches!(
-            decide_with_rules("git status", &[], &[], &all_allowed()),
+            decide_with_rules("git diff", &[], &[], &all_allowed()),
             HookDecision::AllowRewrite(_)
         ));
     }
@@ -1286,8 +1310,17 @@ mod tests {
     #[test]
     fn test_decide_ask_for_default_verdict() {
         assert!(matches!(
-            decide_with_rules("git status", &[], &[], &[]),
+            decide_with_rules("git diff", &[], &[], &[]),
             HookDecision::AskRewrite(_)
+        ));
+    }
+
+    #[test]
+    fn test_decide_defer_for_signal_command() {
+        // Signal commands have no rewrite available → Defer, even when allowed.
+        assert!(matches!(
+            decide_with_rules("git push origin main", &[], &[], &all_allowed()),
+            HookDecision::Defer
         ));
     }
 
@@ -1332,7 +1365,7 @@ mod tests {
     #[test]
     fn test_decide_allow_for_fd_dup_redirect() {
         assert!(matches!(
-            decide_with_rules("git status 2>&1", &[], &[], &all_allowed()),
+            decide_with_rules("git diff 2>&1", &[], &[], &all_allowed()),
             HookDecision::AllowRewrite(_)
         ));
     }
@@ -1353,11 +1386,11 @@ mod tests {
     #[test]
     fn test_gemini_allow_emits_rewrite() {
         let v: Value =
-            serde_json::from_str(&gemini_render("git status", &[], &[], &all_allowed())).unwrap();
+            serde_json::from_str(&gemini_render("git diff", &[], &[], &all_allowed())).unwrap();
         assert_eq!(v["decision"], "allow");
         assert_eq!(
             v["hookSpecificOutput"]["tool_input"]["command"],
-            "rtk git status"
+            "rtk git diff"
         );
     }
 

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -7,6 +7,7 @@ pub mod hook_check;
 pub mod hook_cmd;
 pub mod init;
 pub mod integrity;
+pub mod passthrough;
 pub mod permissions;
 pub mod rewrite_cmd;
 pub mod trust;

--- a/src/hooks/passthrough.rs
+++ b/src/hooks/passthrough.rs
@@ -1,0 +1,219 @@
+//! Signal-vs-bulk classifier for hook command passthrough.
+//!
+//! Some commands emit a small *control signal* — `git push`'s `To <repo>`
+//! marker, `git status`'s porcelain lines, `gh pr` state — that downstream
+//! agents grep against canonical strings to gate next-step decisions. Routing
+//! those through rtk's reduction pipeline reshapes or inflates the marker, so
+//! the agent misclassifies a successful operation as hung or failed.
+//!
+//! This module ships a default allowlist of substring patterns whose command
+//! bypasses rewriting (raw stdout reaches the caller). Operators extend or
+//! replace it via `~/.config/rtk/passthrough.toml`:
+//!
+//! ```toml
+//! [signal]
+//! # Replaces the built-in default set.
+//! patterns = ["git push", "git status", "gh pr"]
+//!
+//! [signal.extend]
+//! # Appends to whatever the effective `[signal]` set is.
+//! patterns = ["glab mr", "kubectl get pods"]
+//! ```
+//!
+//! Matching is a case-sensitive substring test against the reconstructed
+//! command line.
+
+use crate::core::constants::RTK_DATA_DIR;
+use serde::Deserialize;
+use std::path::PathBuf;
+
+/// Operator override file, alongside `config.toml` in the rtk config dir.
+const PASSTHROUGH_TOML: &str = "passthrough.toml";
+
+/// Built-in signal patterns: SCM client status/markers and forge clients whose
+/// stdout is a control signal, not bulk output. Small and stable by design.
+const DEFAULT_SIGNAL_PATTERNS: &[&str] = &[
+    "git push",
+    "git pull",
+    "git fetch",
+    "git merge",
+    "git status",
+    "git remote",
+    "git rev-parse",
+    "git branch",
+    "gh pr",
+    "gh issue",
+    "gh release",
+    "gh api",
+    "gh run",
+    "glab mr",
+    "glab issue",
+];
+
+#[derive(Debug, Default, Deserialize)]
+struct PassthroughFile {
+    #[serde(default)]
+    signal: SignalConfig,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SignalConfig {
+    /// When present, replaces the built-in default patterns entirely.
+    #[serde(default)]
+    patterns: Option<Vec<String>>,
+    /// Appended to the effective pattern set (defaults or replacement).
+    #[serde(default)]
+    extend: SignalExtend,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SignalExtend {
+    #[serde(default)]
+    patterns: Vec<String>,
+}
+
+fn passthrough_path() -> Option<PathBuf> {
+    let config_dir = dirs::config_dir()?;
+    Some(config_dir.join(RTK_DATA_DIR).join(PASSTHROUGH_TOML))
+}
+
+/// Load the operator override file. Missing or malformed files fall back to
+/// defaults — a bad override must never block the hook pipeline.
+fn load_passthrough_file() -> PassthroughFile {
+    let path = match passthrough_path() {
+        Some(p) => p,
+        None => return PassthroughFile::default(),
+    };
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return PassthroughFile::default(),
+    };
+    toml::from_str(&content).unwrap_or_default()
+}
+
+/// Resolve the effective pattern set: operator `[signal] patterns` replace the
+/// built-ins, then `[signal.extend] patterns` are appended.
+fn resolve_patterns(file: &PassthroughFile) -> Vec<String> {
+    let mut patterns: Vec<String> = match &file.signal.patterns {
+        Some(p) => p.clone(),
+        None => DEFAULT_SIGNAL_PATTERNS
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+    };
+    patterns.extend(file.signal.extend.patterns.iter().cloned());
+    patterns
+}
+
+/// Case-sensitive substring match of any pattern against the command line.
+fn matches(cmd: &str, patterns: &[String]) -> bool {
+    patterns
+        .iter()
+        .any(|p| !p.is_empty() && cmd.contains(p.as_str()))
+}
+
+/// Whether `cmd` is a signal command whose stdout must bypass rtk rewriting.
+pub fn is_signal_command(cmd: &str) -> bool {
+    matches(cmd, &resolve_patterns(&load_passthrough_file()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn defaults() -> PassthroughFile {
+        PassthroughFile::default()
+    }
+
+    #[test]
+    fn test_default_patterns_match_git_signal_commands() {
+        let patterns = resolve_patterns(&defaults());
+        assert!(matches("git push origin main", &patterns));
+        assert!(matches("git status", &patterns));
+        assert!(matches("git rev-parse HEAD", &patterns));
+        assert!(matches("GIT_PAGER=cat git status", &patterns));
+    }
+
+    #[test]
+    fn test_default_patterns_match_forge_clients() {
+        let patterns = resolve_patterns(&defaults());
+        assert!(matches("gh pr view 123", &patterns));
+        assert!(matches("gh run list", &patterns));
+        assert!(matches("glab mr list", &patterns));
+    }
+
+    #[test]
+    fn test_default_patterns_skip_bulk_commands() {
+        let patterns = resolve_patterns(&defaults());
+        assert!(!matches("git log -p", &patterns));
+        assert!(!matches("ls -la", &patterns));
+        assert!(!matches("find . -name '*.rs'", &patterns));
+        assert!(!matches("docker logs web", &patterns));
+        // `git add`/`git commit` are bulk-safe and not in the signal set.
+        assert!(!matches("git add .", &patterns));
+    }
+
+    #[test]
+    fn test_match_is_case_sensitive() {
+        let patterns = resolve_patterns(&defaults());
+        assert!(!matches("GIT PUSH origin main", &patterns));
+    }
+
+    #[test]
+    fn test_signal_patterns_replace_defaults() {
+        let toml = r#"
+[signal]
+patterns = ["git push"]
+"#;
+        let file: PassthroughFile = toml::from_str(toml).expect("valid toml");
+        let patterns = resolve_patterns(&file);
+        assert!(matches("git push origin main", &patterns));
+        // `git status` was in the defaults but is no longer present.
+        assert!(!matches("git status", &patterns));
+    }
+
+    #[test]
+    fn test_signal_extend_appends_to_defaults() {
+        let toml = r#"
+[signal.extend]
+patterns = ["kubectl get pods"]
+"#;
+        let file: PassthroughFile = toml::from_str(toml).expect("valid toml");
+        let patterns = resolve_patterns(&file);
+        // Defaults remain in effect.
+        assert!(matches("git push origin main", &patterns));
+        // Extension is appended.
+        assert!(matches("kubectl get pods -n default", &patterns));
+    }
+
+    #[test]
+    fn test_signal_extend_appends_to_replacement() {
+        let toml = r#"
+[signal]
+patterns = ["git push"]
+
+[signal.extend]
+patterns = ["glab mr"]
+"#;
+        let file: PassthroughFile = toml::from_str(toml).expect("valid toml");
+        let patterns = resolve_patterns(&file);
+        assert!(matches("git push origin main", &patterns));
+        assert!(matches("glab mr create", &patterns));
+        assert!(!matches("git status", &patterns));
+    }
+
+    #[test]
+    fn test_empty_pattern_never_matches_everything() {
+        let patterns = vec![String::new()];
+        assert!(!matches("git status", &patterns));
+        assert!(!matches("anything", &patterns));
+    }
+
+    #[test]
+    fn test_missing_signal_section_uses_defaults() {
+        // An override file that omits [signal] keeps the built-in set.
+        let file: PassthroughFile = toml::from_str("").expect("valid toml");
+        let patterns = resolve_patterns(&file);
+        assert!(matches("git push origin main", &patterns));
+    }
+}

--- a/src/hooks/rewrite_cmd.rs
+++ b/src/hooks/rewrite_cmd.rs
@@ -55,6 +55,12 @@ fn evaluate(cmd: &str, excluded: &[String], transparent_prefixes: &[String]) -> 
         return RewriteOutcome::Passthrough;
     }
 
+    // Signal commands emit canonical control markers the caller greps against —
+    // pass them through unrewritten so raw stdout survives intact.
+    if super::passthrough::is_signal_command(cmd) {
+        return RewriteOutcome::Passthrough;
+    }
+
     match registry::rewrite_command(cmd, excluded, transparent_prefixes) {
         Some(rewritten) => match verdict {
             PermissionVerdict::Allow => RewriteOutcome::Allow(rewritten),
@@ -128,7 +134,7 @@ mod tests {
         #[test]
         fn test_fd_dup_redirect_still_rewrites() {
             assert!(matches!(
-                evaluate("git status 2>&1", &[], &[]),
+                evaluate("git diff 2>&1", &[], &[]),
                 RewriteOutcome::Ask(_)
             ));
         }
@@ -136,9 +142,23 @@ mod tests {
         #[test]
         fn test_plain_command_still_rewrites() {
             assert!(matches!(
-                evaluate("git status", &[], &[]),
+                evaluate("git diff", &[], &[]),
                 RewriteOutcome::Ask(_)
             ));
+        }
+
+        #[test]
+        fn test_signal_command_passes_through() {
+            // `git status`/`git push` emit control markers the caller greps —
+            // they must pass through unrewritten even when attestable.
+            assert_eq!(
+                evaluate("git status", &[], &[]),
+                RewriteOutcome::Passthrough
+            );
+            assert_eq!(
+                evaluate("git push origin main", &[], &[]),
+                RewriteOutcome::Passthrough
+            );
         }
     }
 


### PR DESCRIPTION
Resolves #2121.

## Summary

`rtk hook` rewrites the stdout of every Bash tool invocation. When the output is a small control signal (`git push`'s `To <repo>` line, `git status` porcelain, `gh pr` state) that downstream agents grep against, reshaping it drops the marker and the agent misreads a successful command as hung or failed.

- New `src/hooks/passthrough.rs` classifies a command as signal vs bulk. A small built-in allowlist of substring patterns (`git push`/`pull`/`fetch`/`merge`/`status`/`remote`/`rev-parse`/`branch`, `gh pr`/`issue`/`release`/`api`/`run`, `glab mr`/`issue`) marks the signal set.
- Operators override it through `~/.config/rtk/passthrough.toml`: `[signal] patterns` replaces the built-ins, `[signal.extend] patterns` appends. A missing or malformed file falls back to the defaults, so a bad override can never block the hook pipeline.
- Both rewrite paths (`hook_cmd::get_rewritten` and `rewrite_cmd::evaluate`) short-circuit signal commands to passthrough, so their raw stdout reaches the caller unreshaped. Bulk commands (`git log -p`, `ls -la`, `docker logs`) are unaffected.

## Test plan

- `cargo fmt --all -- --check`, `cargo clippy --all-targets`, `cargo check`: clean.
- `cargo test hooks::`: 355 passed, 0 failed.
- Behavioral check: before the change `rtk rewrite "git status"` returned `rtk git status`; after, it passes through unrewritten.
- New tests cover the default allowlist, the replace/extend override semantics, case-sensitivity, the empty-pattern guard, and passthrough across the claude/cursor/gemini hook surfaces.
