### PR TITLE
fix(git): respect combined -n log limits

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -436,12 +436,8 @@ fn run_log(
         arg.starts_with("--oneline") || arg.starts_with("--pretty") || arg.starts_with("--format")
     });
 
-    // Check if user provided limit flag (-N, -n N, --max-count=N, --max-count N)
-    let has_limit_flag = args.iter().any(|arg| {
-        (arg.starts_with('-') && arg.chars().nth(1).is_some_and(|c| c.is_ascii_digit()))
-            || arg == "-n"
-            || arg.starts_with("--max-count")
-    });
+    // Check if user provided limit flag (-N, -nN, -n N, --max-count=N, --max-count N)
+    let has_limit_flag = args.iter().any(|arg| is_log_limit_arg(arg));
 
     // Apply RTK defaults only if user didn't specify them
     // Use %b (body) to preserve first line of commit body for agent context
@@ -507,7 +503,7 @@ fn run_log(
 
 /// Filter git log output: truncate long messages, cap lines
 /// Parse the user-specified limit from git log args.
-/// Handles: -20, -n 20, --max-count=20, --max-count 20
+/// Handles: -20, -n20, -n 20, --max-count=20, --max-count 20
 fn parse_user_limit(args: &[String]) -> Option<usize> {
     let mut iter = args.iter();
     while let Some(arg) = iter.next() {
@@ -518,6 +514,14 @@ fn parse_user_limit(args: &[String]) -> Option<usize> {
         {
             if let Ok(n) = arg[1..].parse::<usize>() {
                 return Some(n);
+            }
+        }
+        // -n20 (combined short option form)
+        if let Some(rest) = arg.strip_prefix("-n") {
+            if !rest.is_empty() {
+                if let Ok(n) = rest.parse::<usize>() {
+                    return Some(n);
+                }
             }
         }
         // -n 20 (two-token form)
@@ -544,6 +548,15 @@ fn parse_user_limit(args: &[String]) -> Option<usize> {
         }
     }
     None
+}
+
+fn is_log_limit_arg(arg: &str) -> bool {
+    (arg.starts_with('-') && arg.chars().nth(1).is_some_and(|c| c.is_ascii_digit()))
+        || arg == "-n"
+        || arg.strip_prefix("-n").is_some_and(|rest| {
+            !rest.is_empty() && rest.chars().all(|c| c.is_ascii_digit())
+        })
+        || arg.starts_with("--max-count")
 }
 
 /// When `user_set_limit` is true, the user explicitly passed `-N` to git log,
@@ -2351,6 +2364,12 @@ A  added.rs
     #[test]
     fn test_parse_user_limit_combined() {
         let args: Vec<String> = vec!["-20".into()];
+        assert_eq!(parse_user_limit(&args), Some(20));
+    }
+
+    #[test]
+    fn test_parse_user_limit_n_combined() {
+        let args: Vec<String> = vec!["-n20".into()];
         assert_eq!(parse_user_limit(&args), Some(20));
     }
 


### PR DESCRIPTION
## Summary
- Fixes #2665.
- Treats combined `git log -n<N>` arguments, such as `-n20`, as explicit user limit flags.
- Parses the combined short-option form so RTK does not inject/default-filter the output down to 10 commits.

## Test plan
- [x] `cargo run --quiet -- git log -n20 | rg -c '^---END---$|^[0-9a-f]{7,} '` before fix -> `10`; after fix -> `20`\n- [x] `cargo fmt --all`\n- [x] `cargo clippy --all-targets -- -D warnings`\n- [x] `cargo test cmds::git::git::tests -- --nocapture`\n- [x] `cargo test`\n\n## Notes\nThis keeps the existing handling for `-20`, `-n 20`, `--max-count=20`, and `--max-count 20` unchanged.