### PR TITLE
feat(discover): skip tiny real outputs in missed-savings estimate

### DIFF
--- a/src/discover/mod.rs
+++ b/src/discover/mod.rs
@@ -18,6 +18,8 @@ use report::{DiscoverReport, SupportedEntry, UnsupportedEntry};
 
 use crate::discover::registry::prefix_contains_rtk_disabled;
 
+const MIN_DISCOVER_FALLBACK_OUTPUT_TOKENS: usize = 100;
+
 /// Aggregation bucket for supported commands.
 struct SupportedBucket {
     rtk_equivalent: &'static str,
@@ -121,6 +123,12 @@ pub fn run(
                         estimated_savings_pct,
                         status,
                     } => {
+                        let output_tokens =
+                            match discover_output_tokens(ext_cmd.output_len, category, part) {
+                                Some(tokens) => tokens,
+                                None => continue,
+                            };
+
                         let bucket = supported_map.entry(rtk_equivalent).or_insert_with(|| {
                             SupportedBucket {
                                 rtk_equivalent,
@@ -133,16 +141,6 @@ pub fn run(
                         });
 
                         bucket.count += 1;
-
-                        // Estimate tokens for this command
-                        let output_tokens = if let Some(len) = ext_cmd.output_len {
-                            // Real: from tool_result content length
-                            len / 4
-                        } else {
-                            // Fallback: category average
-                            let subcmd = extract_subcmd(part);
-                            category_avg_tokens(category, subcmd)
-                        };
 
                         let savings =
                             (output_tokens as f64 * estimated_savings_pct / 100.0) as usize;
@@ -274,6 +272,19 @@ pub fn run(
     Ok(())
 }
 
+fn discover_output_tokens(output_len: Option<usize>, category: &str, cmd: &str) -> Option<usize> {
+    match output_len {
+        Some(len) => {
+            let tokens = len.div_ceil(4);
+            (tokens >= MIN_DISCOVER_FALLBACK_OUTPUT_TOKENS).then_some(tokens)
+        }
+        None => {
+            let subcmd = extract_subcmd(cmd);
+            Some(category_avg_tokens(category, subcmd))
+        }
+    }
+}
+
 /// Extract the subcommand from a command string (second word).
 fn extract_subcmd(cmd: &str) -> &str {
     let parts: Vec<&str> = cmd.trim().splitn(3, char::is_whitespace).collect();
@@ -293,5 +304,35 @@ fn truncate_command(cmd: &str) -> String {
         0 => String::new(),
         1 => parts[0].to_string(),
         _ => format!("{} {}", parts[0], parts[1]),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn small_real_outputs_are_not_reported_as_missed_savings() {
+        let len = (MIN_DISCOVER_FALLBACK_OUTPUT_TOKENS - 1) * 4;
+
+        assert_eq!(discover_output_tokens(Some(len), "Git", "git push"), None);
+    }
+
+    #[test]
+    fn large_real_outputs_are_reported_as_missed_savings() {
+        let len = MIN_DISCOVER_FALLBACK_OUTPUT_TOKENS * 4;
+
+        assert_eq!(
+            discover_output_tokens(Some(len), "Git", "git diff"),
+            Some(MIN_DISCOVER_FALLBACK_OUTPUT_TOKENS)
+        );
+    }
+
+    #[test]
+    fn missing_output_size_keeps_category_average_estimate() {
+        assert_eq!(
+            discover_output_tokens(None, "Git", "git diff"),
+            Some(category_avg_tokens("Git", "diff"))
+        );
     }
 }


### PR DESCRIPTION
Resolves #2130.

## Summary

`rtk discover` flags commands RTK handles but cannot profitably compress as missed savings, even when the real output was tiny. For example, a session with many small `git push` outputs was reported as thousands of saveable tokens.

- When the measured output size is known (`output_len`), `discover` now skips a supported command whose output is below `MIN_DISCOVER_FALLBACK_OUTPUT_TOKENS` (100 tokens), so genuinely small outputs no longer inflate the estimate.
- When the output size is unknown, the existing category-average estimate is unchanged.

This narrows the false positives the issue describes. It does not yet add the persisted fallback-size logging or the `--accurate` mode the issue also proposes, and the estimate still uses category averages when real output size is unavailable. Happy to follow up on those if you would like them in this PR or a separate one.

## Test plan

- `cargo fmt --all -- --check`, `cargo clippy --all-targets`: clean.
- `cargo test discover::`: 428 passed, 0 failed.
- Behavioral check: a discover run over a log with a small-output `git push` reported it as saveable before the change and omits it after.
- New unit tests cover the threshold boundary (below is skipped, at or above is kept) and the unknown-size category-average fallback.
