### PR TITLE
fix(run): propagate signal exit code instead of unwrap_or(1)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2331,7 +2331,7 @@ fn run_cli() -> Result<i32> {
                     .arg(&raw)
                     .status()
                     .with_context(|| format!("Failed to execute: {}", raw))?;
-                status.code().unwrap_or(1)
+                core::utils::exit_code_from_status(&status, "run")
             }
         }
 


### PR DESCRIPTION
## Summary

- Replace `status.code().unwrap_or(1)` with `exit_code_from_status(&status, "run")` in `Commands::Run` (main.rs:2334)
- Signal kills (SIGTERM, SIGKILL, OOM) now produce POSIX-conventional `128+signal` exit codes instead of silently mapping to `1`
- Uses the same helper already used by `Commands::Proxy` at line 2515

Fixes #2680

## Test plan

- [x] `cargo fmt --all` — no formatting changes
- [x] `cargo clippy --all-targets` — no warnings
- [x] `cargo test --all` — all tests pass
- [ ] Manual: `rtk run "sleep 99" &; kill -TERM $!` should exit 143 (not 1)