### PR TITLE
feat(runner): skip filtering for short output (auto-passthrough)

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -131,6 +131,19 @@ pub struct LimitsConfig {
     pub status_max_untracked: usize,
     /// Max chars for parser passthrough fallback (default: 2000)
     pub passthrough_max_chars: usize,
+    /// Skip filtering when output has ≤ this many lines (default: 5, 0 = disabled)
+    #[serde(default = "default_short_line_threshold")]
+    pub short_line_threshold: usize,
+    /// Skip filtering when output has ≤ this many bytes (default: 500, 0 = disabled)
+    #[serde(default = "default_short_byte_threshold")]
+    pub short_byte_threshold: usize,
+}
+
+fn default_short_line_threshold() -> usize {
+    5
+}
+fn default_short_byte_threshold() -> usize {
+    500
 }
 
 impl Default for LimitsConfig {
@@ -141,6 +154,8 @@ impl Default for LimitsConfig {
             status_max_files: 15,
             status_max_untracked: 10,
             passthrough_max_chars: 2000,
+            short_line_threshold: default_short_line_threshold(),
+            short_byte_threshold: default_short_byte_threshold(),
         }
     }
 }
@@ -295,5 +310,44 @@ consent_date = "2026-04-10T12:00:00Z"
             config.telemetry.consent_date.as_deref(),
             Some("2026-04-10T12:00:00Z")
         );
+    }
+
+    #[test]
+    fn test_config_short_thresholds_defaults() {
+        let config = Config::default();
+        assert_eq!(config.limits.short_line_threshold, 5);
+        assert_eq!(config.limits.short_byte_threshold, 500);
+    }
+
+    #[test]
+    fn test_config_short_thresholds_deserialize() {
+        let toml = r#"
+[limits]
+grep_max_results = 200
+grep_max_per_file = 25
+status_max_files = 15
+status_max_untracked = 10
+passthrough_max_chars = 2000
+short_line_threshold = 10
+short_byte_threshold = 1000
+"#;
+        let config: Config = toml::from_str(toml).expect("valid toml");
+        assert_eq!(config.limits.short_line_threshold, 10);
+        assert_eq!(config.limits.short_byte_threshold, 1000);
+    }
+
+    #[test]
+    fn test_config_short_thresholds_missing_uses_defaults() {
+        let toml = r#"
+[limits]
+grep_max_results = 100
+grep_max_per_file = 25
+status_max_files = 15
+status_max_untracked = 10
+passthrough_max_chars = 2000
+"#;
+        let config: Config = toml::from_str(toml).expect("valid toml");
+        assert_eq!(config.limits.short_line_threshold, 5);
+        assert_eq!(config.limits.short_byte_threshold, 500);
     }
 }

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -88,6 +88,16 @@ pub enum RunMode<'a> {
     Passthrough,
 }
 
+fn should_auto_passthrough(text: &str) -> bool {
+    let limits = crate::core::config::limits();
+    let line_threshold = limits.short_line_threshold;
+    let byte_threshold = limits.short_byte_threshold;
+    if line_threshold == 0 || byte_threshold == 0 {
+        return false;
+    }
+    text.len() <= byte_threshold && text.lines().count() <= line_threshold
+}
+
 fn run_captured_filter<F>(
     mut cmd: Command,
     tool_name: &str,
@@ -118,6 +128,15 @@ where
         if !result.raw_stderr.trim().is_empty() {
             eprint!("{}", result.raw_stderr);
         }
+        timer.track(cmd_label, &format!("rtk {}", cmd_label), raw, raw);
+        return Ok(exit_code);
+    }
+
+    if should_auto_passthrough(raw) {
+        if let Some(label) = opts.tee_label {
+            crate::core::tee::tee_raw(raw, label, exit_code);
+        }
+        print!("{}", raw);
         timer.track(cmd_label, &format!("rtk {}", cmd_label), raw, raw);
         return Ok(exit_code);
     }
@@ -283,4 +302,39 @@ pub fn run_streamed(
         RunMode::Streamed(filter),
         opts,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_should_auto_passthrough_short() {
+        assert!(should_auto_passthrough("line one\nline two\n"));
+    }
+
+    #[test]
+    fn test_should_auto_passthrough_long() {
+        let long = "a]n".repeat(200);
+        assert!(!should_auto_passthrough(&long));
+    }
+
+    #[test]
+    fn test_should_auto_passthrough_many_lines() {
+        let lines = "line\n".repeat(10);
+        assert!(!should_auto_passthrough(&lines));
+    }
+
+    #[test]
+    fn test_should_auto_passthrough_empty() {
+        assert!(should_auto_passthrough(""));
+    }
+
+    #[test]
+    fn test_should_auto_passthrough_at_boundary() {
+        let exactly_5_lines = "a\nb\nc\nd\ne";
+        assert!(should_auto_passthrough(exactly_5_lines));
+        let six_lines = "a\nb\nc\nd\ne\nf";
+        assert!(!should_auto_passthrough(six_lines));
+    }
 }


### PR DESCRIPTION
## Summary

RTK compressed all output regardless of size, adding overhead and removing useful text from already-short outputs (1-2 lines). For example, `git branch` showing 2 lines would get processed through the full filter pipeline for zero benefit.

### Fix

Add a **dual-threshold** auto-passthrough check in `run_captured_filter` (before the filter function runs):
- **`short_line_threshold`** (default: 5) — max line count for passthrough
- **`short_byte_threshold`** (default: 500) — max byte count for passthrough
- Both must be satisfied (AND logic): a few very long lines still get filtered, many short lines still get filtered
- Setting either threshold to 0 disables the feature entirely

When triggered, the raw output is printed directly, tee file is written (for `rtk tee` recovery), and tracking records 0% savings.

### Files changed

- **`src/core/config.rs`** — Add `short_line_threshold` and `short_byte_threshold` to `LimitsConfig` with `#[serde(default)]` for backward compatibility
- **`src/core/runner.rs`** — Add `should_auto_passthrough()` function, insert early-return in `run_captured_filter`

### Tests added

Config tests:
- `test_config_short_thresholds_defaults` — default values (5 lines, 500 bytes)
- `test_config_short_thresholds_deserialize` — explicit config values
- `test_config_short_thresholds_missing_uses_defaults` — backward compat with old configs

Runner tests:
- `test_should_auto_passthrough_short` — short output triggers passthrough
- `test_should_auto_passthrough_long` — long bytes prevents passthrough
- `test_should_auto_passthrough_many_lines` — many lines prevents passthrough
- `test_should_auto_passthrough_empty` — empty output triggers passthrough
- `test_should_auto_passthrough_at_boundary` — exact boundary behavior (5 lines = pass, 6 = filter)

### Config example

```toml
[limits]
short_line_threshold = 5    # 0 to disable
short_byte_threshold = 500  # 0 to disable
```

Fixes #2673