### PR TITLE
fix(dotnet): parse MTP multi-line test run summary

### DIFF
--- a/src/cmds/dotnet/binlog.rs
+++ b/src/cmds/dotnet/binlog.rs
@@ -88,6 +88,12 @@ static TEST_SUMMARY_RE: LazyLock<Regex> = LazyLock::new(|| {
     )
     .expect("valid regex")
 });
+static MTP_MULTILINE_SUMMARY_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?mi)Test\s+run\s+summary:\s*(?:Passed!|Failed!)\s*\n\s*total:\s*(?P<total>\d+)\s*\n\s*failed:\s*(?P<failed>\d+)\s*\n\s*(?:succeeded|passed):\s*(?P<passed>\d+)\s*\n\s*skipped:\s*(?P<skipped>\d+)\s*\n\s*duration:\s*(?P<duration>[^\r\n]+)"
+    )
+    .expect("valid regex")
+});
 static FAILED_TEST_HEAD_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?m)^\s*Failed\s+(?P<name>[^\r\n\[]+)\s+\[[^\]\r\n]+\]\s*$").expect("valid regex")
 });
@@ -918,6 +924,31 @@ pub fn parse_test_from_text(text: &str) -> TestSummary {
         }
     }
 
+    if summary.total == 0 {
+        if let Some(captures) = MTP_MULTILINE_SUMMARY_RE.captures_iter(&scrubbed).last() {
+            summary.passed = captures
+                .name("passed")
+                .and_then(|m| m.as_str().parse::<usize>().ok())
+                .unwrap_or(summary.passed);
+            summary.failed = captures
+                .name("failed")
+                .and_then(|m| m.as_str().parse::<usize>().ok())
+                .unwrap_or(summary.failed);
+            summary.skipped = captures
+                .name("skipped")
+                .and_then(|m| m.as_str().parse::<usize>().ok())
+                .unwrap_or(summary.skipped);
+            summary.total = captures
+                .name("total")
+                .and_then(|m| m.as_str().parse::<usize>().ok())
+                .unwrap_or(summary.total);
+
+            if let Some(duration) = captures.name("duration") {
+                summary.duration_text = Some(duration.as_str().trim().to_string());
+            }
+        }
+    }
+
     let lines: Vec<&str> = scrubbed.lines().collect();
     let mut idx = 0;
     while idx < lines.len() {
@@ -1663,5 +1694,43 @@ Time Elapsed 00:00:00.12
 
         let selected = select_best_issues(primary.clone(), fallback);
         assert_eq!(selected, primary);
+    }
+
+    #[test]
+    fn test_parse_test_from_text_mtp_multiline_passed() {
+        let input = "\
+Determining projects to restore...
+  All projects are up-to-date for restore.
+Test run summary: Passed!
+  total: 72
+  failed: 0
+  succeeded: 72
+  skipped: 0
+  duration: 1s 672ms
+";
+        let summary = parse_test_from_text(input);
+        assert_eq!(summary.total, 72);
+        assert_eq!(summary.passed, 72);
+        assert_eq!(summary.failed, 0);
+        assert_eq!(summary.skipped, 0);
+        assert_eq!(summary.duration_text.as_deref(), Some("1s 672ms"));
+    }
+
+    #[test]
+    fn test_parse_test_from_text_mtp_multiline_failed() {
+        let input = "\
+Test run summary: Failed!
+  total: 50
+  failed: 3
+  succeeded: 45
+  skipped: 2
+  duration: 2s 100ms
+";
+        let summary = parse_test_from_text(input);
+        assert_eq!(summary.total, 50);
+        assert_eq!(summary.passed, 45);
+        assert_eq!(summary.failed, 3);
+        assert_eq!(summary.skipped, 2);
+        assert_eq!(summary.duration_text.as_deref(), Some("2s 100ms"));
     }
 }


### PR DESCRIPTION
## Summary

The Microsoft Testing Platform (.NET 10) writes test results in a multi-line
format that the existing regexes couldn't match, causing `rtk dotnet test` to
report "counts unavailable" even when tests passed successfully.

**Before:** `ok dotnet test: completed (binlog-only mode, counts unavailable, 0 warnings)`
**After:** `ok dotnet test: 72 tests passed, 0 warnings in 1 projects (1s 672ms)`

## Root cause

MTP outputs a multi-line summary:
```
Test run summary: Passed!
  total: 72
  failed: 0
  succeeded: 72
  skipped: 0
  duration: 1s 672ms
```

But `TEST_RESULT_RE` expects VSTest's single-line `Passed! - Failed: 0, Passed: 72, ...`
format, and `TEST_SUMMARY_RE` expects single-line `Test summary: total: 72, failed: 0, ...`.
Neither matches the multi-line MTP format, so all counts stay at zero.

## Fix

Add `MTP_MULTILINE_SUMMARY_RE` as a fallback regex in `parse_test_from_text`. It only
triggers when the earlier regexes find no counts (`summary.total == 0`), keeping backward
compatibility with VSTest and single-line MTP formats.

## Changes

- `src/cmds/dotnet/binlog.rs`: Add `MTP_MULTILINE_SUMMARY_RE` lazy_static regex and
  fallback parsing block in `parse_test_from_text`
- Two new unit tests: `test_parse_test_from_text_mtp_multiline_passed` and
  `test_parse_test_from_text_mtp_multiline_failed`

## Test plan

- [x] `cargo fmt --all` — no formatting issues
- [x] `cargo clippy --all-targets` — no warnings
- [x] `cargo test --all` — all tests pass (including 2 new MTP tests)
- [x] New tests verify both Passed! and Failed! MTP summary formats

Fixes #2279