### PR TITLE
feat(init): add Kiro agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ rtk init -g --agent windsurf    # Windsurf
 rtk init --agent cline          # Cline / Roo Code
 rtk init --agent kilocode       # Kilo Code
 rtk init --agent antigravity    # Google Antigravity
+rtk init --agent kiro           # Kiro (AWS AI IDE)
 rtk init -g --agent pi          # Pi
 rtk init --agent hermes         # Hermes
 
@@ -384,6 +385,7 @@ RTK supports 14 AI coding tools. Each integration rewrites shell commands to `rt
 | **Mistral Vibe** | Planned ([#800](https://github.com/rtk-ai/rtk/issues/800)) | Blocked on upstream |
 | **Kilo Code** | `rtk init --agent kilocode` | .kilocode/rules/rtk-rules.md (project-scoped) |
 | **Google Antigravity** | `rtk init --agent antigravity` | .agents/rules/antigravity-rtk-rules.md (project-scoped) |
+| **Kiro** | `rtk init --agent kiro` | .kiro/steering/rtk-rules.md (project-scoped) |
 
 For per-agent setup details, override controls, and graceful degradation, see the [Supported Agents guide](https://www.rtk-ai.app/guide/getting-started/supported-agents). The Hermes plugin source and tests live in `hooks/hermes/`; installed Hermes runtime files still live under `~/.hermes/plugins/rtk-rewrite/`.
 

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -1,6 +1,6 @@
 ---
 title: Supported Agents
-description: How to integrate RTK with Claude Code, Cursor, Copilot, Cline, Windsurf, Codex, OpenCode, Hermes, Kilo Code, and Antigravity
+description: How to integrate RTK with Claude Code, Cursor, Copilot, Cline, Windsurf, Codex, OpenCode, Hermes, Kilo Code, and Antigravity, and Kiro
 sidebar:
   order: 3
 ---
@@ -26,23 +26,24 @@ Agent runs "cargo test"
 
 ## Supported agents
 
-| Agent | Integration tier | Can rewrite transparently? |
-|-------|-----------------|---------------------------|
-| Claude Code | Shell hook (`PreToolUse`) | Yes |
+| Agent                | Integration tier | Can rewrite transparently? |
+|----------------------|-----------------|---------------------------|
+| Claude Code          | Shell hook (`PreToolUse`) | Yes |
 | VS Code Copilot Chat | Shell hook (`PreToolUse`) | Yes |
-| GitHub Copilot CLI | Shell hook (`preToolUse` `modifiedArgs`) | Yes |
-| Cursor | Shell hook (`preToolUse`) | Yes |
-| Gemini CLI | Rust binary (`BeforeTool`) | Yes |
-| OpenCode | TypeScript plugin (`tool.execute.before`) | Yes |
-| OpenClaw | TypeScript plugin (`before_tool_call`) | Yes |
-| Pi | TypeScript extension (`tool_call` event) | Yes |
-| Hermes | Python plugin (`terminal` command mutation) | Yes |
-| Cline / Roo Code | Rules file (prompt-level) | N/A |
-| Windsurf | Rules file (prompt-level) | N/A |
-| Codex CLI | AGENTS.md instructions | N/A |
-| Kilo Code | Rules file (prompt-level) | N/A |
-| Google Antigravity | Rules file (prompt-level) | N/A |
-| Mistral Vibe | Planned ([#800](https://github.com/rtk-ai/rtk/issues/800)) | Pending upstream |
+| GitHub Copilot CLI   | Shell hook (`preToolUse` `modifiedArgs`) | Yes |
+| Cursor               | Shell hook (`preToolUse`) | Yes |
+| Gemini CLI           | Rust binary (`BeforeTool`) | Yes |
+| OpenCode             | TypeScript plugin (`tool.execute.before`) | Yes |
+| OpenClaw             | TypeScript plugin (`before_tool_call`) | Yes |
+| Pi                   | TypeScript extension (`tool_call` event) | Yes |
+| Hermes               | Python plugin (`terminal` command mutation) | Yes |
+| Cline / Roo Code     | Rules file (prompt-level) | N/A |
+| Windsurf             | Rules file (prompt-level) | N/A |
+| Codex CLI            | AGENTS.md instructions | N/A |
+| Kilo Code            | Rules file (prompt-level) | N/A |
+| Google Antigravity   | Rules file (prompt-level) | N/A |
+| Kiro                 | Rules file (prompt-level) | N/A |
+| Mistral Vibe         | Planned ([#800](https://github.com/rtk-ai/rtk/issues/800)) | Pending upstream |
 
 ## Installation by agent
 
@@ -174,6 +175,14 @@ rtk init --agent antigravity    # creates .agents/rules/antigravity-rtk-rules.md
 
 Antigravity reads `.agents/rules/` as custom instructions. RTK adds guidance telling Antigravity to prefer `rtk <cmd>` over raw commands.
 
+### Kiro
+
+```bash
+rtk init --agent kiro    # creates .kiro/steering/rtk-rules.md in current project
+```
+
+Kiro reads `.kiro/steering/` as steering files (project context). RTK adds guidance telling Kiro to prefer `rtk <cmd>` over raw commands.
+
 ### Mistral Vibe (planned)
 
 Support is blocked on upstream `BeforeToolCallback` ([mistral-vibe#531](https://github.com/mistralai/mistral-vibe/issues/531)). Tracked in [#800](https://github.com/rtk-ai/rtk/issues/800).
@@ -186,7 +195,7 @@ Support is blocked on upstream `BeforeToolCallback` ([mistral-vibe#531](https://
 | **Plugin** | TypeScript, JavaScript, or Python in agent's plugin system | Transparent, in-place mutation when the agent allows it |
 | **Rules file** | Prompt-level instructions | Guidance only — agent is told to prefer `rtk <cmd>` |
 
-Rules file integrations (Cline, Windsurf, Codex, Kilo Code, Antigravity) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it. Plugin integrations (OpenCode, Pi) use in-place mutation via the agent's TypeScript extension API.
+Rules file integrations (Cline, Windsurf, Codex, Kilo Code, Antigravity, Kiro) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it. Plugin integrations (OpenCode, Pi) use in-place mutation via the agent's TypeScript extension API.
 
 ## Windows support
 

--- a/hooks/kiro/README.md
+++ b/hooks/kiro/README.md
@@ -1,0 +1,9 @@
+# Kiro Hooks
+
+> Part of [`hooks/`](../README.md) — see also [`src/hooks/`](../../src/hooks/README.md) for installation code
+
+## Specifics
+
+- Prompt-level guidance only (no programmatic hook) -- relies on Kiro reading steering files
+- `rules.md` contains the instruction to prefix all shell commands with `rtk`, usage examples, and meta commands
+- Installed to `.kiro/steering/rtk-rules.md` (project-local) by `rtk init --agent kiro`

--- a/hooks/kiro/rules.md
+++ b/hooks/kiro/rules.md
@@ -1,0 +1,32 @@
+# RTK - Rust Token Killer (Kiro)
+
+**Usage**: Token-optimized CLI proxy for shell commands.
+
+## Rule
+
+Always prefix shell commands with `rtk` to minimize token consumption.
+
+Examples:
+
+```bash
+rtk git status
+rtk cargo test
+rtk ls src/
+rtk grep "pattern" src/
+rtk find "*.rs" .
+rtk docker ps
+rtk gh pr list
+```
+
+## Meta Commands
+
+```bash
+rtk gain              # Show token savings
+rtk gain --history    # Command history with savings
+rtk discover          # Find missed RTK opportunities
+rtk proxy <cmd>       # Run raw (no filtering, for debugging)
+```
+
+## Why
+
+RTK filters and compresses command output before it reaches the LLM context, saving 60-90% tokens on common operations. Always use `rtk <cmd>` instead of raw commands.

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -1757,6 +1757,63 @@ fn run_antigravity_mode_at(base_dir: &Path, ctx: InitContext) -> Result<()> {
     Ok(())
 }
 
+// ─── Kiro support ─────────────────────────────────────────────
+
+const KIRO_RULES: &str = include_str!("../../hooks/kiro/rules.md");
+
+pub fn run_kiro_mode(ctx: InitContext) -> Result<()> {
+    run_kiro_mode_at(&std::env::current_dir()?, ctx)
+}
+
+fn run_kiro_mode_at(base_dir: &Path, ctx: InitContext) -> Result<()> {
+    let InitContext { verbose, dry_run } = ctx;
+    // Kiro reads .kiro/steering/ from the project root (workspace-scoped)
+    let target_dir = base_dir.join(".kiro/steering");
+    let rules_path = target_dir.join("rtk-rules.md");
+
+    let existing = fs::read_to_string(&rules_path).unwrap_or_default();
+    if existing.contains("RTK") || existing.contains("rtk") {
+        if !dry_run {
+            println!("\nRTK already configured for Kiro in this project.\n");
+            println!("  Rules: .kiro/steering/rtk-rules.md (already present)");
+        }
+    } else {
+        let new_content = if existing.trim().is_empty() {
+            KIRO_RULES.to_string()
+        } else {
+            format!("{}\n\n{}", existing.trim(), KIRO_RULES)
+        };
+        if dry_run {
+            println!(
+                "[dry-run] would write {}: (and create parent dir if missing)",
+                rules_path.display()
+            );
+            if verbose > 0 {
+                println!("[dry-run] content:\n{}", new_content);
+            }
+        } else {
+            fs::create_dir_all(&target_dir).context("Failed to create .kiro/steering directory")?;
+            fs::write(&rules_path, &new_content)
+                .context("Failed to write .kiro/steering/rtk-rules.md")?;
+
+            if verbose > 0 {
+                eprintln!("Wrote .kiro/steering/rtk-rules.md");
+            }
+
+            println!("\nRTK configured for Kiro.\n");
+            println!("  Rules: .kiro/steering/rtk-rules.md (installed)");
+        }
+    }
+    if dry_run {
+        print_dry_run_footer();
+    } else {
+        println!("  Kiro will now use rtk commands for token savings.");
+        println!("  Test with: git status\n");
+    }
+
+    Ok(())
+}
+
 // ─── Hermes support ────────────────────────────────────────────
 
 const HERMES_PLUGIN_INIT: &str = include_str!("../../hooks/hermes/rtk-rewrite/__init__.py");
@@ -4463,6 +4520,31 @@ mod tests {
 
         // Second run should not overwrite
         run_antigravity_mode_at(temp.path(), InitContext::default()).unwrap();
+        let second = fs::read_to_string(&path).unwrap();
+        assert_eq!(first, second, "Idempotent: content should not change");
+    }
+
+    #[test]
+    fn test_kiro_mode_creates_rules_file() {
+        let temp = TempDir::new().unwrap();
+        run_kiro_mode_at(temp.path(), InitContext::default()).unwrap();
+
+        let rules_path = temp.path().join(".kiro/steering/rtk-rules.md");
+        assert!(rules_path.exists(), "Rules file should be created");
+        let content = fs::read_to_string(&rules_path).unwrap();
+        assert!(content.contains("RTK"), "Rules file should contain RTK");
+    }
+
+    #[test]
+    fn test_kiro_mode_is_idempotent() {
+        let temp = TempDir::new().unwrap();
+        run_kiro_mode_at(temp.path(), InitContext::default()).unwrap();
+
+        let path = temp.path().join(".kiro/steering/rtk-rules.md");
+        let first = fs::read_to_string(&path).unwrap();
+
+        // Second run should not overwrite
+        run_kiro_mode_at(temp.path(), InitContext::default()).unwrap();
         let second = fs::read_to_string(&path).unwrap();
         assert_eq!(first, second, "Idempotent: content should not change");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,8 @@ pub enum AgentTarget {
     Pi,
     /// Hermes CLI
     Hermes,
+    /// Kiro (AWS AI IDE)
+    Kiro,
 }
 
 #[derive(Parser)]
@@ -1944,6 +1946,11 @@ fn run_cli() -> Result<i32> {
                     );
                 }
                 hooks::init::run_antigravity_mode(ctx)?;
+            } else if agent == Some(AgentTarget::Kiro) {
+                if global {
+                    anyhow::bail!("Kiro is project-scoped. Use: rtk init --agent kiro");
+                }
+                hooks::init::run_kiro_mode(ctx)?;
             } else if agent == Some(AgentTarget::Hermes) {
                 hooks::init::run_hermes_mode(ctx)?;
             } else {


### PR DESCRIPTION
## Summary

Adds `rtk init --agent kiro`, a new rules-file integration for [Kiro](https://kiro.dev) (AWS's agentic AI IDE).

Kiro reads `.kiro/steering/*.md` as steering files (project context). This installs token-savings guidance to `.kiro/steering/rtk-rules.md`, telling Kiro to prefer `rtk <cmd>` over raw commands — the same prompt-level approach already used for Antigravity and Kilo Code.

## Changes

- **`src/main.rs`** — add `AgentTarget::Kiro` and route `--agent kiro` (project-scoped, rejects `-g`)
- **`src/hooks/init.rs`** — `run_kiro_mode` writes/updates `.kiro/steering/rtk-rules.md`; idempotent and dry-run aware; 2 unit tests
- **`hooks/kiro/rules.md`** — the embedded steering file (mirrors `hooks/antigravity/rules.md`)
- **`hooks/kiro/README.md`** — per-agent hook README
- **docs + top-level `README.md`** — Kiro added to the supported-agents table, install section, and quick-start

## Integration tier

Rules file (prompt-level) — identical mechanism to Antigravity / Kilo Code / Cline / Windsurf. No programmatic hook, since Kiro does not yet expose a tool-interception API.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets` — 0 warnings
- [x] `cargo test --all` — all pass, including `test_kiro_mode_creates_rules_file` and `test_kiro_mode_is_idempotent`
- [x] `cargo install --path .`, then verified end-to-end:
  - `rtk init --agent kiro` creates `.kiro/steering/rtk-rules.md`
  - `--dry-run` writes nothing
  - second run is idempotent ("already configured")
  - `rtk init -g --agent kiro` errors (project-scoped), exit 1
  - `kiro` listed in `rtk init --help`
