### PR TITLE
feat: hook bypass: `$(...)` subshell, backticks, and `xargs <cmd>` skip

### DIFF
--- a/src/discover/README.md
+++ b/src/discover/README.md
@@ -21,7 +21,7 @@ When a hook sends `cargo fmt --all && cargo test 2>&1 | tail -20`:
 → [Arg("cargo"), Arg("test"), Redirect("2>&1"), Operator("&&"), Arg("git"), Arg("status")]
 ```
 
-**Compound splitting** — The rewrite engine walks the tokens, splitting on `Operator` (`&&`, `||`, `;`) and `Pipe` (`|`). Each segment is rewritten independently. For pipes, only the left side is rewritten (the pipe consumer like `grep` or `head` runs raw). `find`/`fd` before a pipe is never rewritten because rtk's grouped output format breaks pipe consumers like `xargs`.
+**Compound splitting** — The rewrite engine walks the tokens, splitting on `Operator` (`&&`, `||`, `;`) and `Pipe` (`|`). Each segment is rewritten independently. For pipes, only the left side is rewritten (the pipe consumer like `grep` or `head` runs raw). `find`/`fd` before a pipe is never rewritten because rtk's grouped output format breaks pipe consumers like `xargs`. One exception runs in the pipe tail: an `xargs <cmd>` stage resolves its command at runtime, so the command after `xargs` (and any of its own flags) is rewritten if it's RTK-handled — e.g. `… | xargs grep -nE pat` → `… | xargs rtk grep -nE pat`. The same `xargs` rewrite applies to a standalone `xargs <cmd>` segment.
 
 **Per-segment rewriting** — Each segment goes through:
 

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -581,13 +581,25 @@ fn rewrite_compound(
 
                 match pipe_group_end {
                     Some(next_op) => {
+                        let tail = cmd[tok.offset..next_op.offset].trim();
+                        let tail_rewritten =
+                            rewrite_pipe_group_tail(tail, excluded, transparent_prefixes);
+                        if tail_rewritten.is_some() {
+                            any_changed = true;
+                        }
                         result.push(' ');
-                        result.push_str(cmd[tok.offset..next_op.offset].trim());
+                        result.push_str(tail_rewritten.as_deref().unwrap_or(tail));
                         seg_start = next_op.offset;
                     }
                     None => {
+                        let tail = cmd[tok.offset..].trim_start();
+                        let tail_rewritten =
+                            rewrite_pipe_group_tail(tail, excluded, transparent_prefixes);
+                        if tail_rewritten.is_some() {
+                            any_changed = true;
+                        }
                         result.push(' ');
-                        result.push_str(cmd[tok.offset..].trim_start());
+                        result.push_str(tail_rewritten.as_deref().unwrap_or(tail));
                         return if any_changed { Some(result) } else { None };
                     }
                 }
@@ -782,6 +794,14 @@ fn rewrite_segment_inner(
         }
     }
 
+    // `xargs <cmd>` resolves its command at runtime, so a bare `xargs grep …`
+    // skips the parse-time rewrite. Rewrite the command xargs will execute while
+    // leaving xargs and its own flags untouched. Applies whether xargs is a
+    // standalone segment or a pipe target (see `rewrite_pipe_group_tail`).
+    if strip_word_prefix(trimmed, "xargs").is_some() {
+        return rewrite_xargs(trimmed, excluded, transparent_prefixes, depth);
+    }
+
     // Strip trailing stderr/stdout redirects before matching (#530)
     // e.g. "git status 2>&1" → match "git status", re-append " 2>&1"
     let (cmd_part, redirect_suffix) = strip_trailing_redirects(trimmed);
@@ -870,6 +890,135 @@ fn strip_word_prefix<'a>(cmd: &'a str, prefix: &str) -> Option<&'a str> {
         && cmd.as_bytes()[prefix.len()] == b' '
     {
         Some(cmd[prefix.len() + 1..].trim_start())
+    } else {
+        None
+    }
+}
+
+/// `xargs` flags that consume the *following* token as their value. Inline forms
+/// (`-n4`, `-I{}`, `--max-args=4`) carry the value in the same token and are not
+/// listed here.
+const XARGS_VALUE_FLAGS: &[&str] = &[
+    "-n",
+    "-L",
+    "-P",
+    "-I",
+    "-i",
+    "-s",
+    "-d",
+    "-E",
+    "-a",
+    "--max-args",
+    "--max-lines",
+    "--max-procs",
+    "--replace",
+    "--max-chars",
+    "--delimiter",
+    "--arg-file",
+    "--eof",
+];
+
+/// Rewrite the runtime-resolved command in an `xargs <cmd>` invocation.
+///
+/// `xargs` resolves its command at execution time, so a bare `xargs grep …`
+/// bypasses the parse-time matcher and leaks token savings. We skip past
+/// `xargs`' own options (and the value any of them consume), then rewrite the
+/// command that follows through the normal segment rewriter — leaving `xargs`
+/// and its flags exactly as written. Returns `None` when there is no command,
+/// or the command has no RTK equivalent.
+fn rewrite_xargs(
+    seg: &str,
+    excluded: &[ExcludePattern],
+    transparent_prefixes: &[String],
+    depth: usize,
+) -> Option<String> {
+    let rest = strip_word_prefix(seg.trim(), "xargs")?;
+    if rest.is_empty() {
+        return None;
+    }
+
+    let tokens = split_token_spans(rest);
+    let mut i = 0;
+    while i < tokens.len() {
+        let (tok, start, _) = tokens[i];
+        if tok.starts_with('-') {
+            // Bare value-taking flags (`-n 4`, `-I {}`) also consume the next token;
+            // inline forms (`-n4`, `--max-args=4`) do not.
+            if XARGS_VALUE_FLAGS.contains(&tok) {
+                i += 1;
+            }
+            i += 1;
+            continue;
+        }
+
+        // First non-flag token is the command xargs will execute.
+        let inner = rest[start..].trim();
+        let rewritten_inner =
+            rewrite_segment_inner(inner, excluded, transparent_prefixes, depth + 1)?;
+        if rewritten_inner == inner {
+            return None;
+        }
+        let flags = rest[..start].trim();
+        let rewritten = if flags.is_empty() {
+            format!("xargs {}", rewritten_inner)
+        } else {
+            format!("xargs {} {}", flags, rewritten_inner)
+        };
+        return Some(rewritten);
+    }
+
+    None
+}
+
+/// Rewrite `xargs <cmd>` stages inside a pipe-group tail (the verbatim region
+/// from the first `|` of a pipe group up to the next operator). Every stage is
+/// preserved byte-for-byte except an `xargs` stage whose runtime command we
+/// rewrite, so ordinary pipe consumers (`grep`, `head`, `wc`, …) still run raw
+/// while the xargs indirection no longer bypasses RTK. Returns `None` when no
+/// stage changed.
+fn rewrite_pipe_group_tail(
+    tail: &str,
+    excluded: &[ExcludePattern],
+    transparent_prefixes: &[String],
+) -> Option<String> {
+    let pipe_offsets: Vec<usize> = tokenize(tail)
+        .iter()
+        .filter(|t| t.kind == TokenKind::Pipe)
+        .map(|t| t.offset)
+        .collect();
+    if pipe_offsets.is_empty() {
+        return None;
+    }
+
+    let mut out = String::with_capacity(tail.len() + 16);
+    let mut cursor = 0usize;
+    let mut any_changed = false;
+
+    for (idx, &pipe_off) in pipe_offsets.iter().enumerate() {
+        let stage_start = pipe_off + 1; // byte just after the single-byte '|'
+        let stage_end = match pipe_offsets.get(idx + 1) {
+            Some(&next) => next,
+            None => tail.len(),
+        };
+        let raw_stage = &tail[stage_start..stage_end];
+        let trimmed = raw_stage.trim();
+
+        if let Some(rewritten) = rewrite_xargs(trimmed, excluded, transparent_prefixes, 0) {
+            // Copy everything up to this stage (prior stages and the '|') verbatim,
+            // then splice in the rewrite while preserving the stage's own padding.
+            out.push_str(&tail[cursor..stage_start]);
+            let leading = raw_stage.len() - raw_stage.trim_start().len();
+            out.push_str(&raw_stage[..leading]);
+            out.push_str(&rewritten);
+            out.push_str(&raw_stage[leading + trimmed.len()..]);
+            cursor = stage_end;
+            any_changed = true;
+        }
+    }
+
+    if any_changed {
+        out.push_str(&tail[cursor..]);
+        Some(out)
     } else {
         None
     }
@@ -1498,11 +1647,12 @@ mod tests {
 
     #[test]
     fn test_rewrite_find_pipe_skipped() {
-        // find in a pipe should NOT be rewritten — rtk find output format
-        // is incompatible with pipe consumers like xargs (#439)
+        // `find` in a pipe is still NOT rewritten — rtk find output format is
+        // incompatible with pipe consumers like xargs (#439). The command xargs
+        // resolves at runtime (`grep`) IS rewritten so it no longer bypasses RTK.
         assert_eq!(
             rewrite_command_no_prefixes("find . -name '*.rs' | xargs grep 'fn run'", &[]),
-            None
+            Some("find . -name '*.rs' | xargs rtk grep 'fn run'".into())
         );
     }
 
@@ -1510,6 +1660,60 @@ mod tests {
     fn test_rewrite_find_pipe_xargs_wc() {
         assert_eq!(
             rewrite_command_no_prefixes("find src -type f | wc -l", &[]),
+            None
+        );
+    }
+
+    // --- xargs runtime-command indirection ---
+
+    #[test]
+    fn test_rewrite_xargs_pipe_target() {
+        // `xargs <cmd>` resolves its command at runtime; the upstream producer
+        // rewrites and the xargs-executed command must rewrite too.
+        assert_eq!(
+            rewrite_command_no_prefixes("ls *.js | xargs grep -nE pat", &[]),
+            Some("rtk ls *.js | xargs rtk grep -nE pat".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_xargs_standalone() {
+        // `xargs grep …` with no upstream pipe still gets the inner command rewritten.
+        assert_eq!(
+            rewrite_command_no_prefixes("xargs grep -nE pat", &[]),
+            Some("xargs rtk grep -nE pat".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_xargs_skips_own_flags() {
+        // xargs flags (and any value they consume) are preserved verbatim;
+        // only the command that follows is rewritten.
+        assert_eq!(
+            rewrite_command_no_prefixes("xargs -n 1 grep -nE pat", &[]),
+            Some("xargs -n 1 rtk grep -nE pat".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("xargs -0 -I {} grep -nE pat {}", &[]),
+            Some("xargs -0 -I {} rtk grep -nE pat {}".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_xargs_unsupported_inner_unchanged() {
+        // The command xargs runs has no RTK equivalent → no rewrite emitted.
+        // `find` producer stays raw, isolating the xargs decision.
+        assert_eq!(
+            rewrite_command_no_prefixes("find . -type f | xargs htop", &[]),
+            None
+        );
+    }
+
+    #[test]
+    fn test_rewrite_xargs_no_command_unchanged() {
+        // Bare `xargs` (no command, or flags only) has nothing to rewrite.
+        assert_eq!(
+            rewrite_command_no_prefixes("find . -type f | xargs", &[]),
             None
         );
     }

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -125,6 +125,134 @@ fn get_rewritten(cmd: &str) -> Option<String> {
     Some(rewritten)
 }
 
+fn get_rewritten_substitutions(cmd: &str) -> Option<String> {
+    if has_heredoc(cmd) {
+        return None;
+    }
+
+    let bytes = cmd.as_bytes();
+    let mut out = String::with_capacity(cmd.len() + 16);
+    let mut cursor = 0usize;
+    let mut changed = false;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut i = 0usize;
+
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' if !in_single => {
+                i += 2;
+                continue;
+            }
+            b'\'' if !in_double => in_single = !in_single,
+            b'"' if !in_single => in_double = !in_double,
+            b'$' if !in_single
+                && bytes.get(i + 1) == Some(&b'(')
+                && bytes.get(i + 2) != Some(&b'(') =>
+            {
+                if let Some(end) = find_command_substitution_end(cmd, i + 2) {
+                    let body = &cmd[i + 2..end];
+                    if let Some(rewritten_body) = get_rewritten_substitution_body(body) {
+                        out.push_str(&cmd[cursor..i]);
+                        out.push_str("$(");
+                        out.push_str(&rewritten_body);
+                        out.push(')');
+                        cursor = end + 1;
+                        changed = true;
+                    }
+                    i = end + 1;
+                    continue;
+                }
+            }
+            b'`' if !in_single => {
+                if let Some(end) = find_backtick_end(cmd, i + 1) {
+                    let body = &cmd[i + 1..end];
+                    if let Some(rewritten_body) = get_rewritten_substitution_body(body) {
+                        out.push_str(&cmd[cursor..i]);
+                        out.push('`');
+                        out.push_str(&rewritten_body);
+                        out.push('`');
+                        cursor = end + 1;
+                        changed = true;
+                    }
+                    i = end + 1;
+                    continue;
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    if changed {
+        out.push_str(&cmd[cursor..]);
+        Some(out)
+    } else {
+        None
+    }
+}
+
+fn get_rewritten_substitution_body(body: &str) -> Option<String> {
+    let with_nested = get_rewritten_substitutions(body).unwrap_or_else(|| body.to_string());
+    get_rewritten(&with_nested).or_else(|| {
+        if with_nested != body {
+            Some(with_nested)
+        } else {
+            None
+        }
+    })
+}
+
+fn find_command_substitution_end(cmd: &str, body_start: usize) -> Option<usize> {
+    let bytes = cmd.as_bytes();
+    let mut depth = 1usize;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut i = body_start;
+
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' if !in_single => {
+                i += 2;
+                continue;
+            }
+            b'\'' if !in_double => in_single = !in_single,
+            b'"' if !in_single => in_double = !in_double,
+            b'`' if !in_single => {
+                i = find_backtick_end(cmd, i + 1)?;
+            }
+            b'(' if !in_single && !in_double => depth += 1,
+            b')' if !in_single && !in_double => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    None
+}
+
+fn find_backtick_end(cmd: &str, body_start: usize) -> Option<usize> {
+    let bytes = cmd.as_bytes();
+    let mut i = body_start;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' => {
+                i += 2;
+                continue;
+            }
+            b'`' => return Some(i),
+            _ => i += 1,
+        }
+    }
+    None
+}
+
+#[derive(Debug)]
 enum HookDecision {
     AllowRewrite(String),
     AskRewrite(String),
@@ -137,6 +265,9 @@ fn decide_from_verdict(cmd: &str, verdict: PermissionVerdict) -> HookDecision {
         return HookDecision::Deny;
     }
     if crate::discover::lexer::contains_unattestable_construct(cmd) {
+        if let Some(r) = get_rewritten_substitutions(cmd) {
+            return HookDecision::AskRewrite(r);
+        }
         return HookDecision::Defer;
     }
     match get_rewritten(cmd) {
@@ -932,9 +1063,26 @@ mod tests {
     }
 
     #[test]
-    fn test_claude_substitution_not_rewritten() {
-        // A substitution payload must never be rewritten into updatedInput;
-        // RTK skips so Claude Code evaluates the original command natively.
+    fn test_claude_substitution_payload_rewritten() {
+        let result = run_claude_inner(&claude_input("echo $(grep -nE pat file)")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let cmd = v
+            .pointer("/hookSpecificOutput/updatedInput/command")
+            .and_then(|c| c.as_str())
+            .unwrap();
+        assert_eq!(cmd, "echo $(rtk grep -nE pat file)");
+
+        let result = run_claude_inner(&claude_input("echo `grep -nE pat file`")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let cmd = v
+            .pointer("/hookSpecificOutput/updatedInput/command")
+            .and_then(|c| c.as_str())
+            .unwrap();
+        assert_eq!(cmd, "echo `rtk grep -nE pat file`");
+    }
+
+    #[test]
+    fn test_claude_unsupported_substitution_not_rewritten() {
         assert!(run_claude_inner(&claude_input("git status `rm -rf /tmp/x`")).is_none());
         assert!(run_claude_inner(&claude_input("git status $(rm -rf /tmp/x)")).is_none());
         assert!(run_claude_inner(&claude_input("git log --pretty=\"$(rm -rf /tmp/x)\"")).is_none());
@@ -996,6 +1144,25 @@ mod tests {
             .and_then(|c| c.as_str())
             .unwrap();
         assert_eq!(cmd, "rtk git add . && rtk cargo test");
+    }
+
+    #[test]
+    fn test_claude_xargs_runtime_command_rewritten() {
+        let result = run_claude_inner(&claude_input("ls *.js | xargs grep -nE pat")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let cmd = v
+            .pointer("/hookSpecificOutput/updatedInput/command")
+            .and_then(|c| c.as_str())
+            .unwrap();
+        assert_eq!(cmd, "rtk ls *.js | xargs rtk grep -nE pat");
+
+        let result = run_claude_inner(&claude_input("xargs grep -nE pat")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let cmd = v
+            .pointer("/hookSpecificOutput/updatedInput/command")
+            .and_then(|c| c.as_str())
+            .unwrap();
+        assert_eq!(cmd, "xargs rtk grep -nE pat");
     }
 
     #[test]
@@ -1305,7 +1472,17 @@ mod tests {
     }
 
     #[test]
-    fn test_decide_defer_for_substitution_even_when_allowed() {
+    fn test_decide_ask_rewrite_for_supported_substitution_even_when_allowed() {
+        match decide_with_rules("echo $(grep -nE pat file)", &[], &[], &all_allowed()) {
+            HookDecision::AskRewrite(rewritten) => {
+                assert_eq!(rewritten, "echo $(rtk grep -nE pat file)");
+            }
+            other => panic!("expected AskRewrite for supported substitution, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_decide_defer_for_unsupported_substitution_even_when_allowed() {
         for cmd in [
             "git status `rm -rf /tmp/x`",
             "git status $(rm -rf /tmp/x)",


### PR DESCRIPTION
Resolves #2145.

The `rtk hook claude` PreToolUse rewriter correctly handles top-level commands and common compound forms (`|`, `;`, `&&`) but bypasses three runtime-resolved patterns. Result: commands that should be rewritten ship as bare invocations, leaking token savings.

## Summary

-

## Test plan

- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.