### PR TITLE
feat(rewrite): support bare turbo commands

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -3544,6 +3544,30 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_rewrite_bare_turbo() {
+        for command in ["turbo lint", "turbo run build", "turbo dev"] {
+            assert_eq!(
+                rewrite_command_no_prefixes(command, &[]),
+                Some(format!("rtk {command}")),
+                "Failed for command: {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_classify_bare_turbo() {
+        assert_eq!(
+            classify_command("turbo lint"),
+            Classification::Supported {
+                rtk_equivalent: "rtk turbo",
+                category: "Build",
+                estimated_savings_pct: 80.0,
+                status: RtkStatus::Existing,
+            }
+        );
+    }
+
     // --- #508: RTK_DISABLED detection helpers ---
 
     #[test]

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -80,6 +80,15 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
+        pattern: r"^turbo(\s|$)",
+        rtk_cmd: "rtk turbo",
+        rewrite_prefixes: &["turbo"],
+        category: "Build",
+        savings_pct: 80.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
+    RtkRule {
         pattern: r"^(cat|head|tail)\s+",
         rtk_cmd: "rtk read",
         rewrite_prefixes: &["cat", "head", "tail"],


### PR DESCRIPTION
## Summary
- Fixes #531.
- Add a rewrite rule for bare `turbo` invocations so commands like `turbo build` route to `rtk turbo build`.
- Cover rewrite and classification behavior with registry tests.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo test turbo -- --nocapture`
- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] Manual testing: `rtk turbo build` output inspected