### PR TITLE
ci(pr): enforce conventional titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,30 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+    branches: [develop, master]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic-title:
+    name: conventional title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            style
+            test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,10 @@ feat!(hook): change rewrite config format
 
 These commit messages directly become CHANGELOG entries when release-please creates a release PR. Write them as if they will be read by users.
 
+### Pull request titles
+
+Pull request titles targeting `develop` or `master` must also use Conventional Commit format. Release PRs from `develop` to `master` should be squash-merged so the squash title becomes the release-please commit message.
+
 ---
 
 ## Branch Naming Convention


### PR DESCRIPTION
## Summary
- Fixes #805.
- Add a PR-title workflow using `amannn/action-semantic-pull-request` for PRs targeting `develop` or `master`.
- Document that PR titles should follow Conventional Commit format, including release PR squash-title guidance.

## Test plan
- [x] `git diff --check`
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-title.yml"); puts "yaml ok"'`
- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] Manual testing: `rtk <command>` output inspected