### PR TITLE
feat(hooks): allow configured ask rewrites

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ For per-agent setup details, override controls, and graceful degradation, see th
 ```toml
 [hooks]
 exclude_commands = ["curl", "playwright"]  # skip rewrite for these
+allow_ask_commands = ["jest", "vitest"]    # auto-allow ask-level rewrites
 
 [tee]
 enabled = true          # save raw output on failure (default: true)

--- a/docs/guide/getting-started/configuration.md
+++ b/docs/guide/getting-started/configuration.md
@@ -49,6 +49,7 @@ enabled = true              # anonymous daily ping — see Telemetry & Privacy f
 
 [hooks]
 exclude_commands = []       # commands to never auto-rewrite
+allow_ask_commands = []     # ask-level rewrites to auto-allow by command name
 ```
 
 For full details on what is collected, opt-out options, and GDPR rights, see [Telemetry & Privacy](../resources/telemetry.md).
@@ -103,6 +104,15 @@ exclude_commands = ["^curl", "^wget", "git rebase"]
 ```
 
 Invalid regex patterns fall back to prefix matching.
+
+Allow specific ask-level rewrites without disabling RTK for those commands:
+
+```toml
+[hooks]
+allow_ask_commands = ["jest", "vitest"]
+```
+
+This only applies after RTK finds a rewrite for that command; deny rules and unsafe shell constructs still take precedence.
 
 Or for a single invocation:
 

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -83,6 +83,7 @@ enabled = true
 
 [hooks]
 exclude_commands = ["curl", "playwright"]  # Never auto-rewrite these
+allow_ask_commands = ["jest", "vitest"]    # Auto-allow ask-level rewrites
 
 [limits]
 grep_max_results = 200

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -30,6 +30,11 @@ pub struct HooksConfig {
     #[serde(default)]
     pub exclude_commands: Vec<String>,
 
+    /// Ask-level rewritten commands that should be auto-allowed by hooks.
+    /// Entries are command names, e.g. ["jest", "vitest"].
+    #[serde(default)]
+    pub allow_ask_commands: Vec<String>,
+
     /// Wrapper prefixes that should be transparently stripped before routing
     /// to a filter, then re-prepended on the rewrite. For example, with
     /// `transparent_prefixes = ["docker exec mycontainer"]`, the command
@@ -223,7 +228,18 @@ exclude_commands = ["curl", "gh"]
     fn test_hooks_config_default_empty() {
         let config = Config::default();
         assert!(config.hooks.exclude_commands.is_empty());
+        assert!(config.hooks.allow_ask_commands.is_empty());
         assert!(config.hooks.transparent_prefixes.is_empty());
+    }
+
+    #[test]
+    fn test_hooks_config_allow_ask_commands_deserialize() {
+        let toml = r#"
+[hooks]
+allow_ask_commands = ["jest", "vitest"]
+"#;
+        let config: Config = toml::from_str(toml).expect("valid toml");
+        assert_eq!(config.hooks.allow_ask_commands, vec!["jest", "vitest"]);
     }
 
     #[test]
@@ -248,6 +264,7 @@ exclude_commands = ["curl"]
 "#;
         let config: Config = toml::from_str(toml).expect("valid toml");
         assert_eq!(config.hooks.exclude_commands, vec!["curl"]);
+        assert!(config.hooks.allow_ask_commands.is_empty());
         assert!(config.hooks.transparent_prefixes.is_empty());
     }
 
@@ -260,6 +277,7 @@ history_days = 90
 "#;
         let config: Config = toml::from_str(toml).expect("valid toml");
         assert!(config.hooks.exclude_commands.is_empty());
+        assert!(config.hooks.allow_ask_commands.is_empty());
     }
 
     #[test]

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -4,7 +4,7 @@
 //! corrupts the JSON protocol (Claude Code bug #4669 silently disables the hook).
 
 use super::constants::PRE_TOOL_USE_KEY;
-use super::permissions::{self, PermissionVerdict};
+use super::permissions::{self, ask_rewrite_is_allowed, PermissionVerdict};
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
 use std::io::{self, Read, Write};
@@ -107,16 +107,34 @@ fn detect_format(v: &Value) -> HookFormat {
     HookFormat::PassThrough
 }
 
+#[cfg(test)]
 fn get_rewritten(cmd: &str) -> Option<String> {
+    let (excluded, transparent_prefixes, _allow_ask_commands) = load_hook_rewrite_config();
+    get_rewritten_with_config(cmd, &excluded, &transparent_prefixes)
+}
+
+fn load_hook_rewrite_config() -> (Vec<String>, Vec<String>, Vec<String>) {
+    crate::core::config::Config::load()
+        .map(|c| {
+            (
+                c.hooks.exclude_commands,
+                c.hooks.transparent_prefixes,
+                c.hooks.allow_ask_commands,
+            )
+        })
+        .unwrap_or_default()
+}
+
+fn get_rewritten_with_config(
+    cmd: &str,
+    excluded: &[String],
+    transparent_prefixes: &[String],
+) -> Option<String> {
     if has_heredoc(cmd) {
         return None;
     }
 
-    let (excluded, transparent_prefixes) = crate::core::config::Config::load()
-        .map(|c| (c.hooks.exclude_commands, c.hooks.transparent_prefixes))
-        .unwrap_or_default();
-
-    let rewritten = rewrite_command(cmd, &excluded, &transparent_prefixes)?;
+    let rewritten = rewrite_command(cmd, excluded, transparent_prefixes)?;
 
     if rewritten == cmd {
         return None;
@@ -133,14 +151,32 @@ enum HookDecision {
 }
 
 fn decide_from_verdict(cmd: &str, verdict: PermissionVerdict) -> HookDecision {
+    let (excluded, transparent_prefixes, allow_ask_commands) = load_hook_rewrite_config();
+    decide_from_verdict_with_config(
+        cmd,
+        verdict,
+        &excluded,
+        &transparent_prefixes,
+        &allow_ask_commands,
+    )
+}
+
+fn decide_from_verdict_with_config(
+    cmd: &str,
+    verdict: PermissionVerdict,
+    excluded: &[String],
+    transparent_prefixes: &[String],
+    allow_ask_commands: &[String],
+) -> HookDecision {
     if verdict == PermissionVerdict::Deny {
         return HookDecision::Deny;
     }
     if crate::discover::lexer::contains_unattestable_construct(cmd) {
         return HookDecision::Defer;
     }
-    match get_rewritten(cmd) {
+    match get_rewritten_with_config(cmd, excluded, transparent_prefixes) {
         Some(r) if verdict == PermissionVerdict::Allow => HookDecision::AllowRewrite(r),
+        Some(r) if ask_rewrite_is_allowed(&r, allow_ask_commands) => HookDecision::AllowRewrite(r),
         Some(r) => HookDecision::AskRewrite(r),
         None => HookDecision::Defer,
     }
@@ -535,7 +571,7 @@ fn run_cursor_inner_with_rules(
     };
 
     let verdict = permissions::check_command_with_rules(&cmd, deny_rules, ask_rules, allow_rules);
-    match decide_from_verdict(&cmd, verdict) {
+    match decide_from_verdict_with_config(&cmd, verdict, &[], &[], &[]) {
         HookDecision::AllowRewrite(rewritten) => cursor_allow(&rewritten),
         _ => "{}".to_string(),
     }
@@ -749,7 +785,11 @@ mod tests {
             &[],
             &["Bash(git:*)".to_string()],
         );
-        copilot_cli_response_from_decision(&cli_args(cmd), decide_from_verdict(cmd, verdict), cmd)
+        copilot_cli_response_from_decision(
+            &cli_args(cmd),
+            decide_from_verdict_with_config(cmd, verdict, &[], &[], &[]),
+            cmd,
+        )
     }
 
     #[test]
@@ -1268,7 +1308,7 @@ mod tests {
         allow: &[String],
     ) -> HookDecision {
         let verdict = permissions::check_command_with_rules(cmd, deny, ask, allow);
-        decide_from_verdict(cmd, verdict)
+        decide_from_verdict_with_config(cmd, verdict, &[], &[], &[])
     }
 
     fn all_allowed() -> Vec<String> {
@@ -1287,6 +1327,30 @@ mod tests {
     fn test_decide_ask_for_default_verdict() {
         assert!(matches!(
             decide_with_rules("git status", &[], &[], &[]),
+            HookDecision::AskRewrite(_)
+        ));
+    }
+
+    #[test]
+    fn test_decide_allow_for_configured_ask_rewrite() {
+        let verdict = permissions::check_command_with_rules("git status", &[], &[], &[]);
+        assert!(matches!(
+            decide_from_verdict_with_config("git status", verdict, &[], &[], &["git".to_string()]),
+            HookDecision::AllowRewrite(_)
+        ));
+    }
+
+    #[test]
+    fn test_decide_ask_when_allow_ask_commands_misses() {
+        let verdict = permissions::check_command_with_rules("git status", &[], &[], &[]);
+        assert!(matches!(
+            decide_from_verdict_with_config(
+                "git status",
+                verdict,
+                &[],
+                &[],
+                &["vitest".to_string()]
+            ),
             HookDecision::AskRewrite(_)
         ));
     }

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -1,6 +1,6 @@
 use super::constants::{CLAUDE_DIR, CURSOR_DIR, GEMINI_DIR, SETTINGS_JSON, SETTINGS_LOCAL_JSON};
 use crate::core::stream::exec_capture;
-use crate::discover::lexer::split_for_permissions;
+use crate::discover::lexer::{split_for_permissions, tokenize, TokenKind};
 use serde_json::Value;
 use std::path::PathBuf;
 
@@ -112,6 +112,61 @@ pub(crate) fn check_command_with_rules(
     } else {
         PermissionVerdict::Default
     }
+}
+
+/// Return true when every command segment in an ask-level rewrite is explicitly
+/// opted into auto-allow by `[hooks].allow_ask_commands`.
+pub(crate) fn ask_rewrite_is_allowed(rewritten: &str, allow_ask_commands: &[String]) -> bool {
+    let allowed: Vec<String> = allow_ask_commands
+        .iter()
+        .filter_map(|entry| command_name_from_segment(entry))
+        .collect();
+    if allowed.is_empty() {
+        return false;
+    }
+
+    let segments = split_for_permissions(rewritten);
+    !segments.is_empty()
+        && segments.iter().all(|segment| {
+            command_name_from_segment(segment)
+                .as_ref()
+                .is_some_and(|name| allowed.iter().any(|allowed| allowed == name))
+        })
+}
+
+fn command_name_from_segment(segment: &str) -> Option<String> {
+    let mut args = tokenize(segment)
+        .into_iter()
+        .filter(|token| token.kind == TokenKind::Arg)
+        .map(|token| token.value);
+
+    while let Some(arg) = args.next() {
+        if is_env_assignment(&arg) || is_shell_wrapper(&arg) {
+            continue;
+        }
+        if arg == "rtk" {
+            return args.next();
+        }
+        return Some(arg);
+    }
+
+    None
+}
+
+fn is_env_assignment(arg: &str) -> bool {
+    let Some((name, _value)) = arg.split_once('=') else {
+        return false;
+    };
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first.is_ascii_alphabetic() || first == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+fn is_shell_wrapper(arg: &str) -> bool {
+    matches!(arg, "noglob" | "command" | "builtin" | "exec" | "nocorrect")
 }
 
 /// Load deny, ask, and allow Bash rules from all Claude Code settings files.
@@ -993,5 +1048,35 @@ mod tests {
             check_command_with_rules("rm -rf /", &[], &[], &allow),
             PermissionVerdict::Default
         );
+    }
+
+    #[test]
+    fn test_ask_rewrite_is_allowed_for_configured_command_name() {
+        let allow = vec!["vitest".to_string()];
+        assert!(ask_rewrite_is_allowed("rtk vitest --run", &allow));
+    }
+
+    #[test]
+    fn test_ask_rewrite_allowlist_accepts_rtk_prefixed_entry() {
+        let allow = vec!["rtk vitest".to_string()];
+        assert!(ask_rewrite_is_allowed("rtk vitest --run", &allow));
+    }
+
+    #[test]
+    fn test_ask_rewrite_allowlist_requires_all_segments() {
+        let allow = vec!["vitest".to_string()];
+        assert!(!ask_rewrite_is_allowed(
+            "rtk vitest --run && rtk git status",
+            &allow
+        ));
+    }
+
+    #[test]
+    fn test_ask_rewrite_allowlist_skips_env_and_rtk_prefixes() {
+        let allow = vec!["cargo".to_string()];
+        assert!(ask_rewrite_is_allowed(
+            "RUST_LOG=debug rtk cargo test",
+            &allow
+        ));
     }
 }

--- a/src/hooks/rewrite_cmd.rs
+++ b/src/hooks/rewrite_cmd.rs
@@ -1,6 +1,6 @@
 //! Translates a raw shell command into its RTK-optimized equivalent.
 
-use super::permissions::{check_command, PermissionVerdict};
+use super::permissions::{ask_rewrite_is_allowed, check_command, PermissionVerdict};
 use crate::discover::registry;
 use std::io::Write;
 
@@ -16,11 +16,17 @@ use std::io::Write;
 /// | 2    | (none)   | Deny rule matched — hook defers to Claude Code native deny.  |
 /// | 3    | rewritten| Ask rule matched — hook rewrites but lets Claude Code prompt.|
 pub fn run(cmd: &str) -> anyhow::Result<()> {
-    let (excluded, transparent_prefixes) = crate::core::config::Config::load()
-        .map(|c| (c.hooks.exclude_commands, c.hooks.transparent_prefixes))
+    let (excluded, transparent_prefixes, allow_ask_commands) = crate::core::config::Config::load()
+        .map(|c| {
+            (
+                c.hooks.exclude_commands,
+                c.hooks.transparent_prefixes,
+                c.hooks.allow_ask_commands,
+            )
+        })
         .unwrap_or_default();
 
-    match evaluate(cmd, &excluded, &transparent_prefixes) {
+    match evaluate(cmd, &excluded, &transparent_prefixes, &allow_ask_commands) {
         RewriteOutcome::Allow(rewritten) => {
             print!("{}", rewritten);
             let _ = std::io::stdout().flush();
@@ -44,7 +50,12 @@ enum RewriteOutcome {
     Ask(String),
 }
 
-fn evaluate(cmd: &str, excluded: &[String], transparent_prefixes: &[String]) -> RewriteOutcome {
+fn evaluate(
+    cmd: &str,
+    excluded: &[String],
+    transparent_prefixes: &[String],
+    allow_ask_commands: &[String],
+) -> RewriteOutcome {
     let verdict = check_command(cmd);
 
     if verdict == PermissionVerdict::Deny {
@@ -56,10 +67,13 @@ fn evaluate(cmd: &str, excluded: &[String], transparent_prefixes: &[String]) -> 
     }
 
     match registry::rewrite_command(cmd, excluded, transparent_prefixes) {
-        Some(rewritten) => match verdict {
-            PermissionVerdict::Allow => RewriteOutcome::Allow(rewritten),
-            _ => RewriteOutcome::Ask(rewritten),
-        },
+        Some(rewritten)
+            if verdict == PermissionVerdict::Allow
+                || ask_rewrite_is_allowed(&rewritten, allow_ask_commands) =>
+        {
+            RewriteOutcome::Allow(rewritten)
+        }
+        Some(rewritten) => RewriteOutcome::Ask(rewritten),
         None => RewriteOutcome::Passthrough,
     }
 }
@@ -70,6 +84,10 @@ mod tests {
 
     fn rewrite_command_no_prefixes(cmd: &str) -> Option<String> {
         registry::rewrite_command(cmd, &[], &[])
+    }
+
+    fn evaluate_default(cmd: &str) -> RewriteOutcome {
+        evaluate(cmd, &[], &[], &[])
     }
 
     #[test]
@@ -91,12 +109,12 @@ mod tests {
     }
 
     mod unattestable_passthrough {
-        use super::super::{evaluate, RewriteOutcome};
+        use super::{evaluate_default, RewriteOutcome};
 
         #[test]
         fn test_backtick_substitution_passthrough() {
             assert_eq!(
-                evaluate("git status `rm -rf /tmp/x`", &[], &[]),
+                evaluate_default("git status `rm -rf /tmp/x`"),
                 RewriteOutcome::Passthrough
             );
         }
@@ -104,7 +122,7 @@ mod tests {
         #[test]
         fn test_dollar_substitution_passthrough() {
             assert_eq!(
-                evaluate("git status $(rm -rf /tmp/x)", &[], &[]),
+                evaluate_default("git status $(rm -rf /tmp/x)"),
                 RewriteOutcome::Passthrough
             );
         }
@@ -112,7 +130,7 @@ mod tests {
         #[test]
         fn test_double_quoted_substitution_passthrough() {
             assert_eq!(
-                evaluate("git log --pretty=\"$(rm -rf /tmp/x)\"", &[], &[]),
+                evaluate_default("git log --pretty=\"$(rm -rf /tmp/x)\""),
                 RewriteOutcome::Passthrough
             );
         }
@@ -120,7 +138,7 @@ mod tests {
         #[test]
         fn test_file_redirect_passthrough() {
             assert_eq!(
-                evaluate("git log > /tmp/out.txt", &[], &[]),
+                evaluate_default("git log > /tmp/out.txt"),
                 RewriteOutcome::Passthrough
             );
         }
@@ -128,7 +146,7 @@ mod tests {
         #[test]
         fn test_fd_dup_redirect_still_rewrites() {
             assert!(matches!(
-                evaluate("git status 2>&1", &[], &[]),
+                evaluate_default("git status 2>&1"),
                 RewriteOutcome::Ask(_)
             ));
         }
@@ -136,10 +154,26 @@ mod tests {
         #[test]
         fn test_plain_command_still_rewrites() {
             assert!(matches!(
-                evaluate("git status", &[], &[]),
+                evaluate_default("git status"),
                 RewriteOutcome::Ask(_)
             ));
         }
+    }
+
+    #[test]
+    fn test_allow_ask_commands_promotes_default_rewrite_to_allow() {
+        assert!(matches!(
+            evaluate("git status", &[], &[], &["git".to_string()]),
+            RewriteOutcome::Allow(rewritten) if rewritten == "rtk git status"
+        ));
+    }
+
+    #[test]
+    fn test_allow_ask_commands_does_not_promote_unlisted_rewrite() {
+        assert!(matches!(
+            evaluate("git status", &[], &[], &["vitest".to_string()]),
+            RewriteOutcome::Ask(_)
+        ));
     }
 
     /// SECURITY: Verify the exit code protocol for permission verdicts.


### PR DESCRIPTION
## Summary
- Fixes #1344.
- Add `[hooks].allow_ask_commands` so users can opt specific ask-level rewritten commands into auto-allow behavior.
- Apply the allowlist consistently to `rtk rewrite` exit-code handling and JSON hook decisions while preserving deny and unsafe-shell safeguards.
- Document the new config key and add focused tests for config parsing and hook/rewrite behavior.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo test allow_ask -- --nocapture`
- [x] `git diff --check`
- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] Manual testing: `rtk rewrite "vitest --run"` output inspected