### PR TITLE
docs: document native-Windows manual settings.json hook (no WSL)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -137,6 +137,38 @@ RTK backs up existing settings.json before changes. Restore if needed:
 cp ~/.claude/settings.json.bak ~/.claude/settings.json
 ```
 
+### Native Windows (without WSL)
+
+On native Windows, the Unix `.sh` hook script cannot run directly. If `rtk init -g`
+falls back to CLAUDE.md mode but you want full hook mode coverage in Claude Code,
+add the Rust hook processor directly to `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "rtk hook claude"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+If your `settings.json` already has a `hooks.PreToolUse` array, append the object
+with `"matcher": "Bash"` to that array instead of replacing existing hooks. Make
+sure `rtk` is on the PATH used by the PowerShell session that launches Claude Code,
+then restart Claude Code and test with `git status`.
+
+This native Windows path has been verified with PowerShell 7.6.3. WSL users should
+keep using the standard `rtk init -g` hook flow inside WSL.
+
 ### Alternative: Local Project Setup
 
 **Best for: Single project without hook**

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Download from [releases](https://github.com/rtk-ai/rtk/releases):
 - Linux: `rtk-x86_64-unknown-linux-musl.tar.gz` / `rtk-aarch64-unknown-linux-gnu.tar.gz`
 - Windows: `rtk-x86_64-pc-windows-msvc.zip`
 
+Native Windows users can enable hook mode without WSL by adding the manual
+`settings.json` entry in [INSTALL.md](INSTALL.md#native-windows-without-wsl).
+
 ### Verify Installation
 
 ```bash

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -167,6 +167,23 @@ Then add to `~/.claude/settings.json` (replace `~` with full path):
 
 ---
 
+## Problem: Native Windows uses CLAUDE.md mode but you want hook mode
+
+### Symptom
+On native Windows, `rtk init -g` cannot run the Unix `.sh` hook script and Claude
+Code stays in CLAUDE.md mode, so Bash tool calls are not transparently rewritten.
+
+### Solution
+Use the native Windows `settings.json` hook entry instead of the `.sh` wrapper.
+See [Native Windows (without WSL)](../INSTALL.md#native-windows-without-wsl) for
+the copy-pasteable `PreToolUse` snippet using `"command": "rtk hook claude"`.
+
+Append the RTK entry to any existing `hooks.PreToolUse` array, restart Claude
+Code, and test with `git status`. This applies to native PowerShell sessions; WSL
+users should keep using the standard installer flow inside WSL.
+
+---
+
 ## Problem: RTK not working in OpenCode
 
 ### Symptom


### PR DESCRIPTION
## Summary
Documents how to enable RTK hook mode on native Windows (without WSL), where the Unix `.sh` hook script can't run and `rtk init -g` falls back to CLAUDE.md mode. Adds a copy-pasteable `settings.json` `PreToolUse` entry using `rtk hook claude`, a matching TROUBLESHOOTING entry, and a README pointer.

The native-Windows path was verified with PowerShell 7.6.3. WSL users keep the standard `rtk init -g` flow.

Fixes #2503

AI was used for assistance.
