### PR TITLE
fix: make OpenCode plugin work under OpenCode Desktop (Node runtime)

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ OpenCode supports plugins that can intercept tool execution. RTK provides a glob
 
 > **Note**: This plugin uses OpenCode's `tool.execute.before` hook. Known limitation: plugin hooks do not intercept subagent tool calls ([upstream issue](https://github.com/sst/opencode/issues/5894)). See [OpenCode plugin docs](https://open-code.ai/en/docs/plugins) for API details.
 
+**Desktop support:** The plugin works in both OpenCode CLI (Bun runtime) and OpenCode Desktop (Node runtime). For Desktop on macOS, GUI apps may not inherit your shell `PATH`, so the plugin resolves `rtk` from `RTK_BIN`, `PATH`, `~/.local/bin/rtk`, `~/.cargo/bin/rtk`, and common Homebrew locations.
+
 **Install OpenCode plugin:**
 ```bash
 rtk init -g --opencode

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -198,6 +198,14 @@ OpenCode must be restarted to load the plugin.
 rtk init --show  # Should show "OpenCode: plugin installed"
 ```
 
+**6. OpenCode Desktop path check (macOS GUI launches):**
+OpenCode Desktop runs plugins with Node.js and may not inherit your shell `PATH`.
+The plugin looks for `rtk` via `RTK_BIN`, `PATH`, `~/.local/bin/rtk`,
+`~/.cargo/bin/rtk`, `/opt/homebrew/bin/rtk`, and `/usr/local/bin/rtk`.
+If `rtk --version` works in your terminal but Desktop still runs raw commands,
+install or symlink the correct `rtk` binary into one of those locations, or set
+`RTK_BIN` to the absolute path before launching OpenCode Desktop.
+
 ---
 
 ## Problem: RTK commands fail on Windows ("program not found" or "No such file")

--- a/hooks/opencode-rtk.ts
+++ b/hooks/opencode-rtk.ts
@@ -1,17 +1,136 @@
 import type { Plugin } from "@opencode-ai/plugin"
+import { execFile } from "node:child_process"
+import { existsSync } from "node:fs"
+import { homedir } from "node:os"
+import { delimiter, join } from "node:path"
+import { promisify } from "node:util"
 
 // RTK OpenCode plugin — rewrites commands to use rtk for token savings.
-// Requires: rtk >= 0.23.0 in PATH.
+// Requires: rtk >= 0.23.0.
 //
 // This is a thin delegating plugin: all rewrite logic lives in `rtk rewrite`,
 // which is the single source of truth (src/discover/registry.rs).
 // To add or change rewrite rules, edit the Rust registry — not this file.
 
-export const RtkOpenCodePlugin: Plugin = async ({ $ }) => {
+const execFileAsync = promisify(execFile)
+
+type BunShellResult = {
+  stdout?: unknown
+  exitCode?: number
+  exited?: number
+}
+
+type BunShell = (
+  strings: TemplateStringsArray,
+  ...values: unknown[]
+) => {
+  quiet: () => {
+    nothrow: () => Promise<BunShellResult>
+  }
+}
+
+type ExecFileError = Error & {
+  code?: number | string
+  stdout?: unknown
+}
+
+let rtkPath: string | null | undefined
+
+function resolveRtkPath(): string | null {
+  if (rtkPath !== undefined) return rtkPath
+
+  const candidates = [
+    process.env.RTK_BIN,
+    ...pathCandidates("rtk"),
+    join(homedir(), ".local", "bin", "rtk"),
+    join(homedir(), ".cargo", "bin", "rtk"),
+    "/opt/homebrew/bin/rtk",
+    "/usr/local/bin/rtk",
+  ].filter(Boolean) as string[]
+
+  rtkPath = candidates.find((candidate) => existsSync(candidate)) ?? null
+  return rtkPath
+}
+
+function pathCandidates(binary: string): string[] {
+  const dirs = (process.env.PATH ?? "").split(delimiter).filter(Boolean)
+  const exts =
+    process.platform === "win32"
+      ? (process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";")
+      : [""]
+
+  return dirs.flatMap((dir) => exts.map((ext) => join(dir, `${binary}${ext}`)))
+}
+
+function getBunShell(): BunShell | undefined {
+  return (globalThis as typeof globalThis & { Bun?: { $?: BunShell } }).Bun?.$
+}
+
+function toText(value: unknown): string {
+  if (value instanceof Uint8Array) return new TextDecoder().decode(value)
+  return String(value ?? "")
+}
+
+function exitCodeFrom(value: BunShellResult): number {
+  return value.exitCode ?? value.exited ?? 0
+}
+
+function rewrittenCommand(
+  command: string,
+  stdout: unknown,
+  exitCode: number,
+): string | null {
+  if (exitCode !== 0) return null
+
+  const rewritten = toText(stdout).trim()
+  return rewritten && rewritten !== command ? rewritten : null
+}
+
+async function rewriteWithBun(
+  rtk: string,
+  command: string,
+): Promise<string | null | undefined> {
+  const shell = getBunShell()
+  if (!shell) return undefined
+
   try {
-    await $`which rtk`.quiet()
+    const result = await shell`${rtk} rewrite ${command}`.quiet().nothrow()
+    return rewrittenCommand(command, result.stdout, exitCodeFrom(result))
   } catch {
-    console.warn("[rtk] rtk binary not found in PATH — plugin disabled")
+    return undefined
+  }
+}
+
+async function rewriteWithNode(
+  rtk: string,
+  command: string,
+): Promise<string | null> {
+  try {
+    const result = await execFileAsync(rtk, ["rewrite", command], {
+      encoding: "utf8",
+      timeout: 2000,
+    })
+    return rewrittenCommand(command, result.stdout, 0)
+  } catch (error) {
+    const childError = error as ExecFileError
+    const exitCode =
+      typeof childError.code === "number" ? childError.code : 1
+
+    return rewrittenCommand(command, childError.stdout, exitCode)
+  }
+}
+
+async function tryRewrite(command: string): Promise<string | null> {
+  const rtk = resolveRtkPath()
+  if (!rtk) return null
+
+  const bunResult = await rewriteWithBun(rtk, command)
+  return bunResult === undefined ? rewriteWithNode(rtk, command) : bunResult
+}
+
+export const RtkOpenCodePlugin: Plugin = async () => {
+  if (!resolveRtkPath()) {
+    console.warn("[rtk] rtk binary not found — plugin disabled")
     return {}
   }
 
@@ -26,9 +145,8 @@ export const RtkOpenCodePlugin: Plugin = async ({ $ }) => {
       if (typeof command !== "string" || !command) return
 
       try {
-        const result = await $`rtk rewrite ${command}`.quiet().nothrow()
-        const rewritten = String(result.stdout).trim()
-        if (rewritten && rewritten !== command) {
+        const rewritten = await tryRewrite(command)
+        if (rewritten) {
           ;(args as Record<string, unknown>).command = rewritten
         }
       } catch {


### PR DESCRIPTION
## Summary
Makes the OpenCode plugin work under OpenCode Desktop, which runs plugins in a Node runtime rather than Bun. GUI launches on macOS may not inherit the shell `PATH`, so the plugin now resolves the `rtk` binary from `RTK_BIN`, `PATH`, `~/.local/bin`, `~/.cargo/bin`, and the common Homebrew locations, and falls back to `node:child_process` when the Bun shell helper is absent.

Fixes #2650

AI was used for assistance.
