### PR TITLE
fix(gradle): correct match_command regex to match bare gradle/gradlew

### DIFF
--- a/src/filters/gradle.toml
+++ b/src/filters/gradle.toml
@@ -1,6 +1,6 @@
 [filters.gradle]
 description = "Compact Gradle build output — strip progress, keep tasks and errors"
-match_command = "^(gradle|gradlew|\\./)gradlew?\\b"
+match_command = "^(\\./)?(gradlew?)\\b"
 strip_ansi = true
 strip_lines_matching = [
   "^\\s*$",


### PR DESCRIPTION
## Summary

- Fix the `match_command` regex in `src/filters/gradle.toml` which never matches bare `gradle` or `gradlew` commands
- The alternation group `(gradle|gradlew|\\./)` captured the entire command name, then required another `gradlew?` suffix — creating impossible matches like `gradlegradle`
- Only `./gradle` and `./gradlew` worked; bare `gradle build` and `gradlew build` silently fell through to unfiltered output

## Fix

Change regex from `^(gradle|gradlew|\\./)gradlew?\\b` to `^(\\./)?(gradlew?)\\b` — makes `./` prefix optional, captures command name directly.

| Input | Before | After |
|-------|--------|-------|
| `gradle build` | NO MATCH | MATCH |
| `gradlew build` | NO MATCH | MATCH |
| `./gradle build` | MATCH | MATCH |
| `./gradlew build` | MATCH | MATCH |

## Test plan

- [x] Verified regex with Python `re` module (all 4 forms match)
- [x] `cargo clippy --all-targets` passes
- [x] `cargo test --all` passes
- [x] Existing inline `[[tests.gradle]]` blocks still pass (they test filter pipeline, not match_command)

Fixes #2708