### PR TITLE
fix(tracking): parse RFC3339 timestamps in first_seen_days()

### DIFF
--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -1120,9 +1120,15 @@ impl Tracker {
             };
         match oldest {
             Some(ts) => {
-                let first = chrono::NaiveDateTime::parse_from_str(&ts, "%Y-%m-%dT%H:%M:%S")
-                    .or_else(|_| chrono::NaiveDateTime::parse_from_str(&ts, "%Y-%m-%d %H:%M:%S"))
-                    .map(|dt| dt.and_utc())
+                let first = chrono::DateTime::parse_from_rfc3339(&ts)
+                    .map(|dt| dt.with_timezone(&chrono::Utc))
+                    .or_else(|_| {
+                        chrono::NaiveDateTime::parse_from_str(&ts, "%Y-%m-%dT%H:%M:%S")
+                            .or_else(|_| {
+                                chrono::NaiveDateTime::parse_from_str(&ts, "%Y-%m-%d %H:%M:%S")
+                            })
+                            .map(|dt| dt.and_utc())
+                    })
                     .unwrap_or_else(|_| chrono::Utc::now());
                 let days = (chrono::Utc::now() - first).num_days();
                 Ok(days.max(0))
@@ -1756,5 +1762,22 @@ mod tests {
             let mode = std::fs::metadata(p).expect("metadata").permissions().mode() & 0o777;
             assert_eq!(mode, 0o600, "expected 0600 on {}", p.display());
         }
+    }
+
+    #[test]
+    fn test_first_seen_days_parses_rfc3339() {
+        let tracker = Tracker::new().expect("Failed to create tracker");
+        let test_cmd = format!("rtk first_seen_test_{}", std::process::id());
+        tracker
+            .record("first_seen_cmd", &test_cmd, 100, 20, 10)
+            .expect("Failed to record");
+
+        let days = tracker
+            .first_seen_days()
+            .expect("first_seen_days should not error");
+        assert!(
+            days >= 0,
+            "first_seen_days must be non-negative, got {days}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Fix `first_seen_days()` which always returns 0 due to timestamp parse format mismatch
- Timestamps are stored as RFC3339 (`2026-06-28T12:00:00.123456+00:00`) but parsed with `NaiveDateTime` format `%Y-%m-%dT%H:%M:%S` — missing fractional seconds and timezone offset
- Both parse attempts fail silently, falling back to `Utc::now()`, making `(now - now).num_days()` always 0
- Use `DateTime::parse_from_rfc3339()` as primary parser (matching the existing correct usage on line 951 in the same file)
- Keep `NaiveDateTime` formats as fallbacks for databases created by older RTK versions

## Test plan

- [x] Added `test_first_seen_days_parses_rfc3339` test verifying the function returns non-negative days
- [x] `cargo clippy --all-targets` passes
- [x] `cargo test --all` passes

Fixes #2710