### PR TITLE
fix(filter): handle Python single-line docstrings in MinimalFilter

### DIFF
--- a/src/core/filter.rs
+++ b/src/core/filter.rs
@@ -185,7 +185,14 @@ impl FilterStrategy for MinimalFilter {
 
             // Handle Python docstrings (keep them in minimal mode)
             if *lang == Language::Python && trimmed.starts_with("\"\"\"") {
-                in_docstring = !in_docstring;
+                if !in_docstring {
+                    in_docstring = true;
+                    if trimmed.len() > 3 && trimmed[3..].contains("\"\"\"") {
+                        in_docstring = false;
+                    }
+                } else {
+                    in_docstring = false;
+                }
                 result.push_str(line);
                 result.push('\n');
                 continue;
@@ -543,5 +550,25 @@ fn main() {
         let input = "a\nb\nc";
         let output = smart_truncate(input, 3, &Language::Unknown);
         assert_eq!(output, input);
+    }
+
+    #[test]
+    fn test_python_single_line_docstring_does_not_corrupt_state() {
+        let filter = MinimalFilter;
+        let input = r#"def add(a, b):
+    """Return the sum."""
+    # this comment should be stripped
+    return a + b
+"#;
+        let output = filter.filter(input, &Language::Python);
+        assert!(
+            output.contains("Return the sum"),
+            "docstring should be kept"
+        );
+        assert!(
+            !output.contains("this comment should be stripped"),
+            "comment after single-line docstring must be stripped"
+        );
+        assert!(output.contains("return a + b"), "code must be kept");
     }
 }

--- a/src/core/filter.rs
+++ b/src/core/filter.rs
@@ -201,6 +201,9 @@ impl FilterStrategy for MinimalFilter {
             if in_docstring {
                 result.push_str(line);
                 result.push('\n');
+                if trimmed.ends_with("\"\"\"") {
+                    in_docstring = false;
+                }
                 continue;
             }
 
@@ -570,5 +573,39 @@ fn main() {
             "comment after single-line docstring must be stripped"
         );
         assert!(output.contains("return a + b"), "code must be kept");
+    }
+
+    #[test]
+    fn test_python_multiline_docstring_closing_on_content_line() {
+        let filter = MinimalFilter;
+        let input = r#"def subtract(self, a, b):
+    """Subtract b from a
+    and return result."""
+    # subtract comment
+    return a - b
+
+def multiply(self, a, b):
+    # multiply comment, no docstring before
+    return a * b
+"#;
+        let output = filter.filter(input, &Language::Python);
+        assert!(
+            output.contains("Subtract b from a"),
+            "docstring content should be kept"
+        );
+        assert!(
+            output.contains("and return result."),
+            "docstring closing line should be kept"
+        );
+        assert!(
+            !output.contains("subtract comment"),
+            "comment after multi-line docstring must be stripped"
+        );
+        assert!(
+            !output.contains("multiply comment"),
+            "comment in unrelated method must be stripped"
+        );
+        assert!(output.contains("return a - b"), "code must be kept");
+        assert!(output.contains("return a * b"), "code must be kept");
     }
 }


### PR DESCRIPTION
## Summary

- Fix `MinimalFilter` state corruption when encountering Python single-line docstrings like `"""Return the sum."""`
- The `in_docstring` flag was toggled to `true` but never reset when the closing `"""` appeared on the same line
- All subsequent lines were treated as docstring content, preventing comment stripping and reducing token savings

## Fix

After toggling `in_docstring` on, check if the rest of the line (after the opening `"""`) contains a closing `"""`:

```rust
if !in_docstring {
    in_docstring = true;
    if trimmed.len() > 3 && trimmed[3..].contains("\"\"\"") {
        in_docstring = false;
    }
} else {
    in_docstring = false;
}
```

## Test plan

- [x] Added `test_python_single_line_docstring_does_not_corrupt_state` test
- [x] Verifies: docstring content kept, subsequent comment stripped, code preserved
- [x] `cargo clippy --all-targets` passes
- [x] `cargo test --all` passes

Fixes #2712