### PR TITLE
fix(search): surface error exit codes and guard against false zero matches

### DIFF
--- a/src/cmds/system/search.rs
+++ b/src/cmds/system/search.rs
@@ -578,7 +578,13 @@ pub fn run(
     }
 
     if result.stdout.trim().is_empty() {
-        timer.track(&real_cmd, &rtk_label, &raw_output, "");
+        if exit_code >= 2 && !result.stderr.is_empty() {
+            let msg = format!("{}: error (exit {})\n", engine.label(), exit_code);
+            print!("{}", msg);
+            timer.track(&real_cmd, &rtk_label, &raw_output, &msg);
+        } else {
+            timer.track(&real_cmd, &rtk_label, &raw_output, "");
+        }
         return Ok(exit_code);
     }
 
@@ -609,6 +615,10 @@ pub fn run(
         .flat_map(|v| v.iter())
         .filter(|(_, is_match, _)| *is_match)
         .count();
+
+    if total_matches == 0 && exit_code == 0 && !raw_output.trim().is_empty() {
+        return passthrough(&timer, engine, &args, &real_cmd);
+    }
 
     // Mirror what the real command prints: the filename only when grep/rg would
     // show one (multiple files, a directory, -r or -H), the line number only with


### PR DESCRIPTION
## Summary

Two defensive improvements to the rg/grep search handler that address the root patterns behind #2563:

1. **Surface error exit codes to stdout**: When rg/grep exits with code >= 2 (error) and stdout is empty, print an error indicator to stdout. In hook contexts (Claude Code), stderr may not be surfaced to the agent — without stdout output, the agent sees silence and may misinterpret it as "no matches"

2. **Guard against false "0 matches"**: When `total_matches` is 0 but the engine exited successfully (code 0) with non-empty output, fall through to passthrough instead of reporting "0 matches in 0 files". This catches edge cases where `parse_match_line` fails to parse an unexpected output format — the raw output is preserved rather than silently replaced with a false zero count

## Context

Issue #2563 reported false "0 matches" with escaped regex patterns via the hook pipeline. The original issue was on rtk 0.42.1 which lacked a native search handler; the current native handler (added later) correctly passes patterns through. These changes add defensive guards so that if parsing ever fails partially, the handler falls back to passthrough rather than emitting misleading results.

## Test plan

- [x] `cargo clippy --all-targets` passes
- [x] `cargo test --all` passes (all 11 search tests pass including `grep_and_rg_use_their_own_regex_dialect`)

Relates to #2563