### PR TITLE
fix(hook): add output transparency section to RTK instructions

### DIFF
--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -133,6 +133,10 @@ git add . && git commit -m "msg" && git push
 rtk git add . && rtk git commit -m "msg" && rtk git push
 ```
 
+## Output Transparency
+
+RTK intentionally compresses and restructures command output to save tokens. Filtered output may look different from raw command output — for example, grep results grouped by file, test output showing only failures, or logs deduplicated with counts. This is expected and correct. If you need the exact unfiltered output of any command, use `rtk proxy <cmd>`.
+
 ## RTK Commands by Workflow
 
 ### Build & Compile (80-90% savings)


### PR DESCRIPTION
## Summary

When RTK is installed as a silent PreToolUse auto-rewrite hook, safety-tuned LLMs can flag RTK's filtered output as tampered because the output shape differs from what the original command produces (e.g., grep results grouped by file, diffs compacted, lists truncated with `+N more`).

This PR adds an "Output Transparency" section to the `RTK_INSTRUCTIONS` constant (injected into CLAUDE.md by `rtk init`). The section explicitly tells the LLM that:
- RTK intentionally compresses and restructures output
- Output may look different from raw commands — this is expected and correct
- `rtk proxy <cmd>` is available for exact unfiltered output

This converts "unexplained output mismatch" into "expected behavior from a known tool," addressing the most common trigger for tamper heuristics.

### Changes

- **`src/hooks/init.rs`**: Add 4-line "Output Transparency" section to `RTK_INSTRUCTIONS`

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test --all` passes
- [x] Existing `test_init_contains_key_commands` and `test_init_has_version_marker` tests pass
- [x] No changes to filter pipeline, hook processor, or output format

Fixes #2445