### PR TITLE
fix: propagate golangci-lint exit code in filtered run

### DIFF
--- a/src/cmds/go/golangci_cmd.rs
+++ b/src/cmds/go/golangci_cmd.rs
@@ -157,7 +157,7 @@ fn run_filtered(original_args: &[String], invocation: &RunInvocation, verbose: u
 
     // golangci-lint: exit 0 = clean, exit 1 = lint issues found (not an error),
     // exit 2+ = config/build error, None = killed by signal (OOM, SIGKILL)
-    Ok(if exit_code == 1 { 0 } else { exit_code })
+    Ok(exit_code)
 }
 
 fn run_passthrough(args: &[String], verbose: u8) -> Result<i32> {


### PR DESCRIPTION
- rtk golangci-lint run now returns exit 1 when lint issues are found
- Previously the exit code was inverted, masking lint failures
- Automation like pre-commit hooks and CI/CD now correctly detect lint failures
- Fixes #2735

## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

-

## Test plan
<!-- How did you verify this works? -->

- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
