### PR TITLE
fix(git): handle -n<N> combined form in git log

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -436,10 +436,12 @@ fn run_log(
         arg.starts_with("--oneline") || arg.starts_with("--pretty") || arg.starts_with("--format")
     });
 
-    // Check if user provided limit flag (-N, -n N, --max-count=N, --max-count N)
+    // Check if user provided limit flag (-N, -n N, -nN, --max-count=N, --max-count N)
     let has_limit_flag = args.iter().any(|arg| {
         (arg.starts_with('-') && arg.chars().nth(1).is_some_and(|c| c.is_ascii_digit()))
             || arg == "-n"
+            || (arg.starts_with("-n") && arg.len() > 2
+                && arg[2..].chars().all(|c| c.is_ascii_digit()))
             || arg.starts_with("--max-count")
     });
 
@@ -517,6 +519,12 @@ fn parse_user_limit(args: &[String]) -> Option<usize> {
             && arg.chars().nth(1).is_some_and(|c| c.is_ascii_digit())
         {
             if let Ok(n) = arg[1..].parse::<usize>() {
+                return Some(n);
+            }
+        }
+        // -n20 (combined form)
+        if arg.starts_with("-n") && arg.len() > 2 {
+            if let Ok(n) = arg[2..].parse::<usize>() {
                 return Some(n);
             }
         }
@@ -2352,6 +2360,18 @@ A  added.rs
     fn test_parse_user_limit_combined() {
         let args: Vec<String> = vec!["-20".into()];
         assert_eq!(parse_user_limit(&args), Some(20));
+    }
+
+    #[test]
+    fn test_parse_user_limit_n_combined() {
+        let args: Vec<String> = vec!["-n20".into()];
+        assert_eq!(parse_user_limit(&args), Some(20));
+    }
+
+    #[test]
+    fn test_parse_user_limit_n_combined_single_digit() {
+        let args: Vec<String> = vec!["-n5".into()];
+        assert_eq!(parse_user_limit(&args), Some(5));
     }
 
     #[test]


### PR DESCRIPTION
The combined form git log -n<N> (e.g., -n20) was not detected by has_limit_flag or parse_user_limit in run_log. This caused two problems: RTK injected its own -10 limit argument, and filter_log_output used limit=10 with user_set_limit=false, truncating the visible output to 10 commits even though git correctly emitted the user-requested count.

Fix has_limit_flag to detect -n<digits> as a limit flag, and add -n<digits> parsing to parse_user_limit. Both sites already handled the equivalent forms -20 and -n 20.

Includes tests for -n20 multi-digit and -n5 single-digit forms.

Fixes #2665