### PR TITLE
fix(hook): minor cursor fixes and code cleanups

### DIFF
--- a/docs/contributing/TECHNICAL.md
+++ b/docs/contributing/TECHNICAL.md
@@ -329,7 +329,7 @@ RTK supports the following LLM agents through hook integrations:
 | Claude Code | Shell hook | `PreToolUse` in `settings.json` | Yes (`updatedInput`) |
 | GitHub Copilot (VS Code) | Rust binary | `rtk hook copilot` reads JSON | Yes (`updatedInput`) |
 | GitHub Copilot CLI | Rust binary | `rtk hook copilot` reads JSON | No (deny + suggestion) |
-| Cursor | Shell hook | `preToolUse` hook | Yes (`updated_input`) |
+| Cursor | Rust binary | `rtk hook cursor` reads JSON | Yes (`updated_input`) |
 | Gemini CLI | Rust binary | `rtk hook gemini` reads JSON | Yes (`hookSpecificOutput`) |
 | Cline/Roo Code | Rules file | Prompt-level guidance | N/A (prompt) |
 | Windsurf | Rules file | Prompt-level guidance | N/A (prompt) |

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -50,7 +50,7 @@ Each agent subdirectory has its own README with hook-specific details:
 | Claude Code | Shell hook (`PreToolUse`) | Transparent rewrite | Yes (`updatedInput`) |
 | VS Code Copilot Chat | Rust binary (`rtk hook copilot`) | Transparent rewrite | Yes (`updatedInput`) |
 | GitHub Copilot CLI | Rust binary (`rtk hook copilot`) | Deny-with-suggestion | No (agent retries) |
-| Cursor | Shell hook (`preToolUse`) | Transparent rewrite | Yes (`updated_input`) |
+| Cursor | Rust binary | Transparent rewrite | Yes (`updated_input`) |
 | Gemini CLI | Rust binary (`rtk hook gemini`) | Transparent rewrite | Yes (`hookSpecificOutput`) |
 | Cline / Roo Code | Custom instructions (rules file) | Prompt-level guidance | N/A |
 | Windsurf | Custom instructions (rules file) | Prompt-level guidance | N/A |

--- a/hooks/cursor/rtk-rewrite.sh
+++ b/hooks/cursor/rtk-rewrite.sh
@@ -43,7 +43,7 @@ fi
 #             2 = deny, 3 = ask.
 REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null)
 RC=$?
-if [ "$RC" -eq 1 ] || [ "$RC" -eq 2 ]; then
+if [ "$RC" -ne 0 ] && [ "$RC" -ne 3 ]; then
   echo '{}'
   exit 0
 fi
@@ -61,6 +61,7 @@ if [ "$RC" -eq 3 ]; then
 fi
 
 jq -n --arg cmd "$REWRITTEN" --arg perm "$PERMISSION" '{
+  "continue": true,
   "permission": $perm,
   "updated_input": { "command": $cmd }
 }'

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -86,6 +86,7 @@ Rules are loaded from all Claude Code `settings.json` files (project + global, i
 |------|------------|-------------------|
 | Claude Code (rtk-rewrite.sh) | Yes | `permissionDecision: "ask"` — user prompted |
 | Copilot VS Code (rtk hook copilot) | Yes | `permissionDecision: "ask"` — user prompted |
+| Cursor (rtk hook cursor) | Ready | `permission: "ask",` — users will be prompted when Cursor enforces the permission; in the meantime, allow |
 | Gemini CLI (rtk hook gemini) | No (allow/deny only) | allow (limitation — no ask mode in Gemini) |
 | Copilot CLI (rtk hook copilot) | No updatedInput | deny-with-suggestion (unchanged) |
 | Codex | ask parsed but no-op | allow (limitation — fails open) |

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -1065,6 +1065,9 @@ mod tests {
         let v: Value = serde_json::from_str(&result).unwrap();
         assert_eq!(v["permission"], "ask");
         assert_eq!(v["updated_input"]["command"], "rtk git status");
+        // `continue: true` keeps the Cursor preToolUse panel from collapsing
+        // to `Output: {}`; without it the rewrite is invisible to users.
+        assert_eq!(v["continue"], true);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Building on #2609:
- Fix the documentation, as Cursor now uses the native Rust binary hook
- Update rtk-rewrite.sh so it fails on any exit code other than 0 or 3
- Test that "continue": true is also present for "permission": "ask" and sync shell rewrite hook

## Test plan
- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] Manual testing: `rtk <command>` output inspected
