### PR TITLE
fix(parser): use byte offsets instead of char indices in extract_json_object

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -167,13 +167,12 @@ pub fn extract_json_object(input: &str) -> Option<&str> {
         found_start?
     };
 
-    // Brace-balance forward from start_pos
+    // Brace-balance forward from start_pos using byte offsets (not char indices)
     let mut depth = 0;
     let mut in_string = false;
     let mut escape_next = false;
-    let chars: Vec<char> = input[start_pos..].chars().collect();
 
-    for (i, &ch) in chars.iter().enumerate() {
+    for (byte_offset, ch) in input[start_pos..].char_indices() {
         if escape_next {
             escape_next = false;
             continue;
@@ -186,8 +185,7 @@ pub fn extract_json_object(input: &str) -> Option<&str> {
             '}' if !in_string => {
                 depth -= 1;
                 if depth == 0 {
-                    // Found matching closing brace
-                    let end_pos = start_pos + i + 1; // +1 to include the `}`
+                    let end_pos = start_pos + byte_offset + ch.len_utf8();
                     return Some(&input[start_pos..end_pos]);
                 }
             }
@@ -317,6 +315,38 @@ Scope: all 6 workspace projects
         let input = r#"{"numTotalTests": 1, "message": "test {should} not confuse parser"}"#;
         let extracted = extract_json_object(input).expect("Should extract JSON");
         assert!(extracted.contains("test {should} not confuse parser"));
+        assert_eq!(extracted, input);
+    }
+
+    #[test]
+    fn test_extract_json_object_cjk_values() {
+        let input = r#"{"name": "테스트", "결과": "성공", "count": 3}"#;
+        let extracted = extract_json_object(input).expect("Should extract JSON with CJK");
+        assert_eq!(extracted, input);
+    }
+
+    #[test]
+    fn test_extract_json_object_emoji_values() {
+        let input = r#"{"status": "🎉 passed", "icon": "✅", "count": 1}"#;
+        let extracted = extract_json_object(input).expect("Should extract JSON with emoji");
+        assert_eq!(extracted, input);
+    }
+
+    #[test]
+    fn test_extract_json_object_cjk_prefix() {
+        let input =
+            "빌드 출력 시작\n경고: 사용되지 않음\n\n{\"numTotalTests\": 5, \"passed\": true}\n";
+        let extracted = extract_json_object(input).expect("Should extract JSON after CJK prefix");
+        assert!(extracted.contains("numTotalTests"));
+        assert!(extracted.starts_with('{'));
+        assert!(extracted.ends_with('}'));
+    }
+
+    #[test]
+    fn test_extract_json_object_mixed_multibyte_nested() {
+        let input = r#"{"results": [{"名前": "テスト1", "data": {"emoji": "🚀"}}]}"#;
+        let extracted =
+            extract_json_object(input).expect("Should extract nested JSON with mixed multibyte");
         assert_eq!(extracted, input);
     }
 }


### PR DESCRIPTION
## Summary
- `extract_json_object()` used char indices from `enumerate()` as byte offsets for string slicing
- Multi-byte UTF-8 characters (CJK, emoji) caused `'not a char boundary'` panic
- Switched from `Vec<char>` + `enumerate()` to `char_indices()` which yields correct byte offsets

Fixes #2509

## Test plan
- [x] Added regression tests for CJK values, emoji values, CJK prefix, and mixed multi-byte nested JSON
- [x] All 15 parser tests pass
- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test --all` passes (2 pre-existing failures in `rewrite_cmd` unrelated to this change)