### PR TITLE
fix(next): drop redundant leading `build` arg so `rtk next build` exits 0 on success

### DIFF
--- a/src/cmds/js/next_cmd.rs
+++ b/src/cmds/js/next_cmd.rs
@@ -20,7 +20,12 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
 
     cmd.arg("build");
 
-    for arg in args {
+    // `rtk next` always runs `next build`, so a redundant leading `build` token
+    // (the natural `rtk next build` invocation) must be dropped — otherwise the
+    // child becomes `next build build`, which Next.js parses as a `[directory]`
+    // positional ("Invalid project directory provided, no such directory: .../build")
+    // and exits 1 on an otherwise-clean build. See normalize_build_args.
+    for arg in normalize_build_args(args) {
         cmd.arg(arg);
     }
 
@@ -36,6 +41,18 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         filter_next_build,
         runner::RunOptions::default(),
     )
+}
+
+/// `rtk next` already injects the `build` subcommand, so a leading redundant
+/// `build` token (from the natural `rtk next build` invocation) is stripped to
+/// avoid `next build build`, which Next.js rejects as an invalid `[directory]`
+/// positional and exits 1 on an otherwise-successful build. Any other args
+/// (e.g. `--debug`, `--no-lint`) pass through unchanged.
+fn normalize_build_args(args: &[String]) -> &[String] {
+    match args.first() {
+        Some(first) if first.as_str() == "build" => &args[1..],
+        _ => args,
+    }
 }
 
 /// Filter Next.js build output - extract routes, bundles, warnings
@@ -214,6 +231,38 @@ Route (app)                    Size     First Load JS
         assert!(result.contains("Next.js Build"));
         assert!(result.contains("routes"));
         assert!(!result.contains("Creating an optimized")); // Should filter verbose logs
+    }
+
+    #[test]
+    fn test_normalize_build_args_strips_redundant_build() {
+        // `rtk next build` → args ["build"] must not become `next build build`.
+        let only_build = vec!["build".to_string()];
+        assert!(normalize_build_args(&only_build).is_empty());
+
+        // `rtk next build --debug` → keep the flags, drop the redundant `build`.
+        let with_flag = vec!["build".to_string(), "--debug".to_string()];
+        assert_eq!(
+            normalize_build_args(&with_flag).to_vec(),
+            vec!["--debug".to_string()]
+        );
+
+        // `rtk next --debug` (no redundant token) is unchanged.
+        let flag_only = vec!["--debug".to_string()];
+        assert_eq!(
+            normalize_build_args(&flag_only).to_vec(),
+            vec!["--debug".to_string()]
+        );
+
+        // `rtk next` (no args) is unchanged.
+        let empty: Vec<String> = Vec::new();
+        assert!(normalize_build_args(&empty).is_empty());
+
+        // A later `build` token (e.g. a flag value) is NOT stripped — only a leading one.
+        let trailing = vec!["--debug".to_string(), "build".to_string()];
+        assert_eq!(
+            normalize_build_args(&trailing).to_vec(),
+            vec!["--debug".to_string(), "build".to_string()]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

`rtk next build` exits **1** on a fully successful Next.js build (the summary even prints `Errors: 0 | Warnings: 0`). Fixes #2756.

## Root cause

`rtk next` always injects the `build` subcommand, then appends every trailing arg. Because `Next` uses `trailing_var_arg`, the natural `rtk next build` invocation passes `["build"]` through as well, so the child runs **`next build build`**. Next.js parses the second `build` as the `[directory]` positional and aborts:

```
Invalid project directory provided, no such directory: <cwd>/build
```

…returning exit 1. The error phrasing isn't matched by `filter_next_build`'s `errors` heuristic, so the summary still reports `Errors: 0`, masking the failure.

## Fix

`normalize_build_args` strips a single redundant **leading** `build` token before the args are appended, so both `rtk next` and `rtk next build` run `next build`. All other flags (`--debug`, `--no-lint`, …) pass through unchanged; a non-leading `build` token (e.g. a flag value) is left intact.

## Verification

- **Root cause reproduced empirically** (Windows 11, Next.js 16):
  - `npx next build` → exit **0**
  - `npx next build build` → exit **1**: `Invalid project directory provided, no such directory: ...\build`
  - `rtk next build` (0.43.0) → exit **1**, prints `Next.js Build / Errors: 0 | Warnings: 0`
- Added unit test `test_normalize_build_args_strips_redundant_build` covering: leading `build` stripped, `build --debug` → `--debug`, no-redundant-token unchanged, empty unchanged, and a non-leading `build` preserved.

> Note: I couldn't run `cargo test` locally — this machine has the rust-msvc toolchain but no MSVC C++ linker (`link.exe` not found), so the crate's native deps don't link here. The change is a small pure function; CI will compile + run the new test. Happy to adjust if the project prefers a different normalization (e.g. erroring on an explicit `build` rather than silently stripping).

## Manual test

```
# before: exit 1 on a green build
# after:  exit 0
rtk next build && echo OK
```
