### PR TITLE
fix: separate Copilot init command from Claude Code in Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ rtk gain        # Should show token savings stats
 
 ```bash
 # 1. Install for your AI tool
-rtk init -g                     # Claude Code / Copilot (default)
+rtk init -g                     # Claude Code (default)
+rtk init -g --copilot           # GitHub Copilot
 rtk init -g --gemini            # Gemini CLI
 rtk init -g --codex             # Codex (OpenAI)
 rtk init -g --agent cursor      # Cursor


### PR DESCRIPTION
The Quick Start section listed `rtk init -g` as "Claude Code / Copilot (default)", but this command only works for Claude Code. Copilot requires the `--copilot` flag.

**Before:**
```
rtk init -g                     # Claude Code / Copilot (default)
```

**After:**
```
rtk init -g                     # Claude Code (default)
rtk init -g --copilot           # GitHub Copilot
```

Fixes #2244