### PR TITLE
fix: update Korean README troubleshooting link to correct URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ rtk gain        # Should show token savings stats
 
 ```bash
 # 1. Install for your AI tool
-rtk init -g                     # Claude Code / Copilot (default)
+rtk init -g                     # Claude Code (default)
+rtk init -g --copilot           # GitHub Copilot
 rtk init -g --gemini            # Gemini CLI
 rtk init -g --codex             # Codex (OpenAI)
 rtk init -g --agent cursor      # Cursor

--- a/README_ko.md
+++ b/README_ko.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="https://www.rtk-ai.app">웹사이트</a> &bull;
   <a href="#설치">설치</a> &bull;
-  <a href="docs/TROUBLESHOOTING.md">문제 해결</a> &bull;
+  <a href="https://www.rtk-ai.app/guide/troubleshooting">문제 해결</a> &bull;
   <a href="docs/contributing/ARCHITECTURE.md">아키텍처</a> &bull;
   <a href="https://discord.gg/RySmvNF5kF">Discord</a>
 </p>


### PR DESCRIPTION
The troubleshooting link in `README_ko.md` pointed to `docs/TROUBLESHOOTING.md` (404), but should point to the website at `https://www.rtk-ai.app/guide/troubleshooting`, matching the English README.

Fixes #2561