### PR TITLE
docs: recommend ripgrep for better grep performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ Hook-based agents rewrite Bash commands (e.g., `git status` -> `rtk git status`)
 
 **Important:** the hook only runs on Bash tool calls. Claude Code built-in tools like `Read`, `Grep`, and `Glob` do not pass through the Bash hook, so they are not auto-rewritten. To get RTK's compact output for those workflows, use shell commands (`cat`/`head`/`tail`, `rg`/`grep`, `find`) or call `rtk read`, `rtk grep`, or `rtk find` directly.
 
+> **Tip:** Install [ripgrep](https://github.com/BurntSushi/ripgrep) (`rg`) — it's significantly faster than GNU grep and RTK's `rtk rg` runs it natively with the same compact output filter.
+
 ## How It Works
 
 ```
@@ -150,7 +152,8 @@ rtk read file.rs                # Smart file reading
 rtk read file.rs -l aggressive  # Signatures only (strips bodies)
 rtk smart file.rs               # 2-line heuristic code summary
 rtk find "*.rs" .               # Compact find results
-rtk grep "pattern" .            # Grouped search results
+rtk grep "pattern" .            # Grouped grep search results (install ripgrep for faster searches)
+rtk rg "pattern" .              # Native ripgrep search
 rtk diff file1 file2            # Condensed diff (exit 1 if files differ)
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ rtk gain        # Should show token savings stats
 
 ```bash
 # 1. Install for your AI tool
-rtk init -g                     # Claude Code / Copilot (default)
+rtk init -g                     # Claude Code (default)
+rtk init -g --copilot           # GitHub Copilot
 rtk init -g --gemini            # Gemini CLI
 rtk init -g --codex             # Codex (OpenAI)
 rtk init -g --agent cursor      # Cursor

--- a/README_ko.md
+++ b/README_ko.md
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="https://www.rtk-ai.app">웹사이트</a> &bull;
   <a href="#설치">설치</a> &bull;
-  <a href="docs/TROUBLESHOOTING.md">문제 해결</a> &bull;
+  <a href="https://www.rtk-ai.app/guide/troubleshooting">문제 해결</a> &bull;
   <a href="docs/contributing/ARCHITECTURE.md">아키텍처</a> &bull;
   <a href="https://discord.gg/RySmvNF5kF">Discord</a>
 </p>


### PR DESCRIPTION
This PR:
1. Adds a tip about installing ripgrep for faster searches
2. Documents the `rtk rg` native ripgrep command in the Files section

Closes #2613