### PR TITLE
fix(uv): remove uv run from transparent prefixes to fix rewrite conflicts

### DIFF
--- a/src/cmds/python/uv_cmd.rs
+++ b/src/cmds/python/uv_cmd.rs
@@ -58,7 +58,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         .context("Failed to run uv")?;
     let filtered = filter_uv_run_output(&result.raw, result.exit_code);
 
-    runner::print_with_hint(&filtered, &result.raw, "uv", result.exit_code);
+    runner::print_with_hint(&filtered, &result.raw, &result.raw, "uv", result.exit_code);
     timer.track(&original_cmd, &rtk_cmd, &result.raw, &filtered);
 
     Ok(result.exit_code)

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -653,13 +653,8 @@ fn rewrite_line_range(cmd: &str) -> Option<String> {
 
 /// Built-in transparent wrappers that use the same strip/recurse/re-prepend
 /// contract as user-configured `transparent_prefixes`.
-const BUILTIN_TRANSPARENT_PREFIXES: &[&str] = &[
-    "noglob",
-    "command",
-    "builtin",
-    "exec",
-    "nocorrect",
-];
+const BUILTIN_TRANSPARENT_PREFIXES: &[&str] =
+    &["noglob", "command", "builtin", "exec", "nocorrect"];
 
 const MAX_PREFIX_DEPTH: usize = 10;
 

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -471,7 +471,7 @@ fn collapse_line_continuations(s: &str) -> std::borrow::Cow<'_, str> {
 /// being run, only *how* it's run — e.g. `docker exec mycontainer`,
 /// `direnv exec .`, `poetry run`, or `bundle exec`. Stripping it lets the inner
 /// command match a filter; the prefix is then re-prepended to the rewrite. The
-/// built-in [`BUILTIN_TRANSPARENT_PREFIXES`] (`uv run`, `noglob`, `command`,
+/// built-in [`BUILTIN_TRANSPARENT_PREFIXES`] (`noglob`, `command`,
 /// `builtin`, `exec`, `nocorrect`) are always applied in addition to
 /// user-configured prefixes.
 ///
@@ -654,7 +654,6 @@ fn rewrite_line_range(cmd: &str) -> Option<String> {
 /// Built-in transparent wrappers that use the same strip/recurse/re-prepend
 /// contract as user-configured `transparent_prefixes`.
 const BUILTIN_TRANSPARENT_PREFIXES: &[&str] = &[
-    "uv run",
     "noglob",
     "command",
     "builtin",
@@ -2338,7 +2337,7 @@ mod tests {
     fn test_rewrite_uv_run_pytest() {
         assert_eq!(
             rewrite_command_no_prefixes("uv run pytest tests/", &[]),
-            Some("uv run rtk pytest tests/".into())
+            Some("rtk uv run pytest tests/".into())
         );
     }
 
@@ -2346,7 +2345,7 @@ mod tests {
     fn test_rewrite_env_uv_run_pytest() {
         assert_eq!(
             rewrite_command_no_prefixes("PYTHONPATH=. uv run pytest tests/", &[]),
-            Some("PYTHONPATH=. uv run rtk pytest tests/".into())
+            Some("PYTHONPATH=. rtk uv run pytest tests/".into())
         );
     }
 
@@ -2354,7 +2353,7 @@ mod tests {
     fn test_rewrite_uv_run_python_m_pytest() {
         assert_eq!(
             rewrite_command_no_prefixes("uv run python -m pytest -q", &[]),
-            Some("uv run rtk pytest -q".into())
+            Some("rtk uv run python -m pytest -q".into())
         );
     }
 
@@ -2362,23 +2361,23 @@ mod tests {
     fn test_rewrite_uv_run_supported_inner_command() {
         assert_eq!(
             rewrite_command_no_prefixes("uv run ruff check .", &[]),
-            Some("uv run rtk ruff check .".into())
+            Some("rtk uv run ruff check .".into())
         );
     }
 
     #[test]
-    fn test_rewrite_uv_run_options_are_not_parsed() {
+    fn test_rewrite_uv_run_options_are_passed_through() {
         assert_eq!(
             rewrite_command_no_prefixes("uv run --unknown pytest tests/", &[]),
-            None
+            Some("rtk uv run --unknown pytest tests/".into())
         );
         assert_eq!(
             rewrite_command_no_prefixes("uv run -m pytest -q", &[]),
-            None
+            Some("rtk uv run -m pytest -q".into())
         );
         assert_eq!(
             rewrite_command_no_prefixes("uv run --module pytest -q", &[]),
-            None
+            Some("rtk uv run --module pytest -q".into())
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2988,6 +2988,7 @@ mod tests {
             "golangci-lint",
             "gradlew",
             "mvn",
+            "uv",
         ];
 
         let unclassified: Vec<String> = Cli::command()


### PR DESCRIPTION
## Summary

`uv run` was listed in both `BUILTIN_TRANSPARENT_PREFIXES` and `RULES`, causing a routing conflict:

- The transparent prefix check would strip `uv run` and try to match the inner command
- When the inner command (e.g. `python script.py`) wasn't RTK-supported, it returned `None` — no rewrite at all
- Commands like `uv run --unknown pytest` or `uv run -m pytest` were silently dropped

**Fix:** Remove `uv run` from `BUILTIN_TRANSPARENT_PREFIXES` so all `uv run` commands route through the RULES-based `rtk uv` path, which delegates to `uv_cmd.rs` for proper filtering.

Also fixes a compilation issue where `print_with_hint` signature changed (added `guard_raw` arg) but `uv_cmd.rs` wasn't updated.

## Changes

- Remove `uv run` from `BUILTIN_TRANSPARENT_PREFIXES` in `registry.rs`
- Pass `guard_raw` arg to `print_with_hint` in `uv_cmd.rs` (signature fix)
- Update tests to reflect new routing: `uv run pytest` → `rtk uv run pytest` (not `uv run rtk pytest`)
- Apply rustfmt to `BUILTIN_TRANSPARENT_PREFIXES` array

## Test plan

- [x] Updated existing `uv run` rewrite tests to match new routing behavior
- [x] `uv run --unknown pytest` and `uv run -m pytest` now rewrite correctly instead of returning `None`
- [x] `cargo check` passes