### PR TITLE
chore(scripts): switch benches to mockhttp.org as httpbin.org is struggling at the moment

### DIFF
--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -346,8 +346,8 @@ bench "wc" "wc Cargo.toml src/main.rs" "$RTK wc Cargo.toml src/main.rs"
 # ===================
 section "curl"
 if command -v curl &> /dev/null; then
-  bench "curl json" "curl -s https://httpbin.org/json" "$RTK curl https://httpbin.org/json"
-  bench "curl text" "curl -s https://httpbin.org/robots.txt" "$RTK curl https://httpbin.org/robots.txt"
+  bench "curl json" "curl -s https://mockhttp.org/json" "$RTK curl https://mockhttp.org/json"
+  bench "curl text" "curl -s https://mockhttp.org/robots.txt" "$RTK curl https://mockhttp.org/robots.txt"
 fi
 
 # ===================
@@ -355,7 +355,7 @@ fi
 # ===================
 if command -v wget &> /dev/null; then
   section "wget"
-  bench "wget" "wget -qO- https://httpbin.org/json" "$RTK wget https://httpbin.org/json"
+  bench "wget" "wget -qO- https://mockhttp.org/json" "$RTK wget https://mockhttp.org/json"
   rm -f json 2>/dev/null
 fi
 

--- a/scripts/benchmark/run.ts
+++ b/scripts/benchmark/run.ts
@@ -137,7 +137,7 @@ if (shouldRun(3)) {
   await testCmd("log:large", `${RTK} log /tmp/large.log`);
 
   // Network
-  await testCmd("net:curl", `${RTK} curl https://httpbin.org/get`, "any");
+  await testCmd("net:curl", `${RTK} curl https://mockhttp.org/get`, "any");
 
   // GitHub
   await testCmd("gh:pr list", `cd /home/ubuntu/rtk && ${RTK} gh pr list`, "any");

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -230,8 +230,8 @@ assert_help    "rtk cargo"                    rtk cargo
 
 section "Curl (new)"
 
-assert_contains "rtk curl JSON detect" "string" rtk curl https://httpbin.org/json
-assert_ok       "rtk curl plain text"          rtk curl https://httpbin.org/robots.txt
+assert_contains "rtk curl JSON detect" "string" rtk curl https://mockhttp.org/json
+assert_ok       "rtk curl plain text"          rtk curl https://mockhttp.org/robots.txt
 assert_help     "rtk curl"                     rtk curl
 
 # ── 8. Npm / Npx ────────────────────────────────────
@@ -351,7 +351,7 @@ assert_ok      "rtk init --show"              rtk init --show
 section "Wget"
 
 if command -v wget >/dev/null 2>&1; then
-    assert_ok  "rtk wget stdout"              rtk wget https://httpbin.org/robots.txt -O
+    assert_ok  "rtk wget stdout"              rtk wget https://mockhttp.org/robots.txt -O
 else
     skip_test "rtk wget" "wget not installed"
 fi


### PR DESCRIPTION
## Summary

httpbin.org sometimes returns 503s or takes 20+ seconds to respond, which causes the benchmarks to fail

## Test plan
- [x] Manual testing: `./benchmark.sh` output inspected

```sh
  ✅ 22 good  ⚠️ 37 warn  🔴 3 negative  ❌ 0 fail    22/62 (35%)
  Tokens: 100941 → 8033  (-92%)
```