### PR TITLE
feat(cmds): add lowercase PowerShell aliases and modular handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,11 @@ rtk cargo test
 rtk git status
 ```
 
+Common PowerShell inspection commands can use RTK's existing filters through
+PowerShell-style aliases, including `Get-ChildItem`/`get-childitem`,
+`Get-Content`/`get-content`, `Select-String`/`select-string`, and
+`Measure-Object`/`measure-object`.
+
 **Important**: Do not double-click `rtk.exe` — it is a CLI tool that prints usage and exits immediately. Always run it from a terminal (Command Prompt, PowerShell, or Windows Terminal).
 
 | Feature | WSL | Native Windows |

--- a/src/cmds/mod.rs
+++ b/src/cmds/mod.rs
@@ -6,6 +6,7 @@ pub mod git;
 pub mod go;
 pub mod js;
 pub mod jvm;
+pub mod powershell;
 pub mod python;
 pub mod ruby;
 pub mod rust;

--- a/src/cmds/powershell.rs
+++ b/src/cmds/powershell.rs
@@ -1,0 +1,378 @@
+//! PowerShell command shims that route common inspection commands into RTK filters.
+
+use crate::cmds::system::{ls, read, search, wc_cmd};
+use crate::core::filter::FilterLevel;
+use crate::core::utils::tool_exists;
+use anyhow::{Context, Result};
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+fn is_powershell_flag(arg: &str, name: &str) -> bool {
+    arg.eq_ignore_ascii_case(name)
+}
+
+pub fn run_read_command(
+    files: &[PathBuf],
+    level: FilterLevel,
+    max_lines: Option<usize>,
+    tail_lines: Option<usize>,
+    line_numbers: bool,
+    verbose: u8,
+) -> Result<i32> {
+    let mut had_error = false;
+    let mut stdin_seen = false;
+    for file in files {
+        let result = if file == Path::new("-") {
+            if stdin_seen {
+                eprintln!("rtk: warning: stdin specified more than once");
+                continue;
+            }
+            stdin_seen = true;
+            read::run_stdin(level, max_lines, tail_lines, line_numbers, verbose)
+        } else {
+            read::run(file, level, max_lines, tail_lines, line_numbers, verbose)
+        };
+        if let Err(e) = result {
+            eprintln!("cat: {}: {}", file.display(), e.root_cause());
+            had_error = true;
+        }
+    }
+    Ok(if had_error { 1 } else { 0 })
+}
+
+pub fn run_get_child_item(args: &[String], verbose: u8) -> Result<i32> {
+    let mut translated = Vec::new();
+    let mut recurse = false;
+    let mut show_all = false;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            x if is_powershell_flag(x, "-Force") => {
+                translated.push("-a".to_string());
+                show_all = true;
+            }
+            x if is_powershell_flag(x, "-Recurse") => {
+                translated.push("-R".to_string());
+                recurse = true;
+            }
+            x if is_powershell_flag(x, "-Path") || is_powershell_flag(x, "-LiteralPath") => {
+                let value = args
+                    .get(i + 1)
+                    .context("Get-ChildItem: missing value for -Path/-LiteralPath")?;
+                translated.push(value.clone());
+                i += 1;
+            }
+            x if x.starts_with('-') => {
+                anyhow::bail!("Get-ChildItem: unsupported PowerShell flag: {}", x);
+            }
+            other => translated.push(other.to_string()),
+        }
+        i += 1;
+    }
+
+    if !cfg!(windows) {
+        return ls::run(&translated, verbose);
+    }
+
+    let mut paths: Vec<PathBuf> = translated
+        .into_iter()
+        .filter(|a| !a.starts_with('-'))
+        .map(PathBuf::from)
+        .collect();
+    if paths.is_empty() {
+        paths.push(PathBuf::from("."));
+    }
+
+    for (idx, root) in paths.iter().enumerate() {
+        if idx > 0 {
+            println!();
+        }
+        if paths.len() > 1 {
+            println!("{}:", root.display());
+        }
+        render_get_child_item_path(root, recurse, show_all)?;
+    }
+    Ok(0)
+}
+
+fn render_get_child_item_path(root: &Path, recurse: bool, show_all: bool) -> Result<()> {
+    let root_meta = fs::metadata(root)
+        .with_context(|| format!("Get-ChildItem: failed to access {}", root.display()))?;
+
+    let walker = if root_meta.is_dir() {
+        if recurse {
+            WalkDir::new(root).min_depth(1)
+        } else {
+            WalkDir::new(root).min_depth(1).max_depth(1)
+        }
+    } else {
+        WalkDir::new(root).min_depth(0).max_depth(0)
+    };
+
+    for entry in walker.into_iter().filter_map(Result::ok) {
+        let path = entry.path();
+        let name = if recurse && root_meta.is_dir() {
+            path.strip_prefix(root)
+                .unwrap_or(path)
+                .display()
+                .to_string()
+        } else {
+            path.file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| path.display().to_string())
+        };
+
+        let leaf_hidden = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.starts_with('.'));
+        if !show_all && leaf_hidden {
+            continue;
+        }
+
+        let md = entry
+            .metadata()
+            .with_context(|| format!("Get-ChildItem: failed to stat {}", path.display()))?;
+        if md.is_dir() {
+            println!("{}/", name);
+        } else {
+            println!("{} {}B", name, md.len());
+        }
+    }
+    Ok(())
+}
+
+pub fn run_get_content(args: &[String], verbose: u8) -> Result<i32> {
+    let mut files = Vec::<PathBuf>::new();
+    let mut max_lines = None;
+    let mut tail_lines = None;
+    let line_numbers = false;
+    let mut level = FilterLevel::None;
+    let mut i = 0;
+
+    while i < args.len() {
+        match args[i].as_str() {
+            x if is_powershell_flag(x, "-Path") || is_powershell_flag(x, "-LiteralPath") => {
+                let value = args
+                    .get(i + 1)
+                    .context("Get-Content: missing value for -Path/-LiteralPath")?;
+                files.push(PathBuf::from(value));
+                i += 1;
+            }
+            x if is_powershell_flag(x, "-Tail") => {
+                let value = args
+                    .get(i + 1)
+                    .context("Get-Content: missing value for -Tail")?;
+                tail_lines = Some(value.parse().context("Get-Content: invalid -Tail value")?);
+                i += 1;
+            }
+            x if is_powershell_flag(x, "-TotalCount") => {
+                let value = args
+                    .get(i + 1)
+                    .context("Get-Content: missing value for -TotalCount")?;
+                max_lines = Some(
+                    value
+                        .parse()
+                        .context("Get-Content: invalid -TotalCount value")?,
+                );
+                i += 1;
+            }
+            x if is_powershell_flag(x, "-Raw") => {
+                level = FilterLevel::None;
+            }
+            x if is_powershell_flag(x, "-ReadCount")
+                || is_powershell_flag(x, "-Encoding")
+                || is_powershell_flag(x, "-Wait")
+                || is_powershell_flag(x, "-AsByteStream") =>
+            {
+                anyhow::bail!("Get-Content: unsupported PowerShell flag: {}", x);
+            }
+            x if x.starts_with('-') => {
+                anyhow::bail!("Get-Content: unsupported PowerShell flag: {}", x);
+            }
+            other => files.push(PathBuf::from(other)),
+        }
+        i += 1;
+    }
+
+    if files.is_empty() {
+        return read::run_stdin(level, max_lines, tail_lines, line_numbers, verbose).map(|_| 0);
+    }
+
+    run_read_command(&files, level, max_lines, tail_lines, line_numbers, verbose)
+}
+
+pub fn run_select_string(args: &[String], verbose: u8) -> Result<i32> {
+    let mut translated = Vec::<String>::new();
+    let mut pattern: Option<String> = None;
+    let mut paths: Vec<String> = Vec::new();
+    let mut case_sensitive = false;
+    let mut simple_match = false;
+    let mut not_match = false;
+    let mut list_only = false;
+    let mut i = 0;
+
+    while i < args.len() {
+        match args[i].as_str() {
+            x if is_powershell_flag(x, "-Pattern") => {
+                let value = args
+                    .get(i + 1)
+                    .context("Select-String: missing value for -Pattern")?;
+                pattern = Some(value.clone());
+                i += 1;
+            }
+            x if is_powershell_flag(x, "-Path") || is_powershell_flag(x, "-LiteralPath") => {
+                let value = args
+                    .get(i + 1)
+                    .context("Select-String: missing value for -Path/-LiteralPath")?;
+                paths.push(value.clone());
+                i += 1;
+            }
+            x if is_powershell_flag(x, "-CaseSensitive") => case_sensitive = true,
+            x if is_powershell_flag(x, "-SimpleMatch") => simple_match = true,
+            x if is_powershell_flag(x, "-NotMatch") => not_match = true,
+            x if is_powershell_flag(x, "-List") => list_only = true,
+            x if is_powershell_flag(x, "-Context")
+                || is_powershell_flag(x, "-AllMatches")
+                || is_powershell_flag(x, "-Quiet")
+                || is_powershell_flag(x, "-Encoding")
+                || is_powershell_flag(x, "-Include")
+                || is_powershell_flag(x, "-Exclude")
+                || is_powershell_flag(x, "-Raw") =>
+            {
+                anyhow::bail!("Select-String: unsupported PowerShell flag: {}", x);
+            }
+            x if x.starts_with('-') => {
+                anyhow::bail!("Select-String: unsupported PowerShell flag: {}", x);
+            }
+            other => {
+                if pattern.is_none() {
+                    pattern = Some(other.to_string());
+                } else {
+                    paths.push(other.to_string());
+                }
+            }
+        }
+        i += 1;
+    }
+
+    let pattern = pattern.context("Select-String: missing search pattern")?;
+    if !case_sensitive {
+        translated.push("-i".to_string());
+    }
+    if simple_match {
+        translated.push("-F".to_string());
+    }
+    if not_match {
+        translated.push("-v".to_string());
+    }
+    if list_only {
+        translated.push("-l".to_string());
+    }
+    translated.push(pattern);
+    translated.extend(paths);
+
+    let engine = if tool_exists("rg") {
+        search::Engine::Rg
+    } else {
+        search::Engine::Grep
+    };
+    search::run(engine, 80, 200, false, &translated, verbose)
+}
+
+pub fn run_measure_object(args: &[String], verbose: u8) -> Result<i32> {
+    let mut translated = Vec::<String>::new();
+    let mut saw_mode = false;
+    let mut i = 0;
+
+    while i < args.len() {
+        match args[i].as_str() {
+            x if is_powershell_flag(x, "-Line") => {
+                translated.push("-l".to_string());
+                saw_mode = true;
+            }
+            x if is_powershell_flag(x, "-Word") => {
+                translated.push("-w".to_string());
+                saw_mode = true;
+            }
+            x if is_powershell_flag(x, "-Character") || is_powershell_flag(x, "-Chars") => {
+                translated.push("-m".to_string());
+                saw_mode = true;
+            }
+            x if is_powershell_flag(x, "-InputObject")
+                || is_powershell_flag(x, "-Sum")
+                || is_powershell_flag(x, "-Average")
+                || is_powershell_flag(x, "-Maximum")
+                || is_powershell_flag(x, "-Minimum")
+                || is_powershell_flag(x, "-Property") =>
+            {
+                anyhow::bail!("Measure-Object: unsupported PowerShell flag: {}", x);
+            }
+            x if x.starts_with('-') => {
+                anyhow::bail!("Measure-Object: unsupported PowerShell flag: {}", x);
+            }
+            other => translated.push(other.to_string()),
+        }
+        i += 1;
+    }
+
+    if !saw_mode {
+        anyhow::bail!("Measure-Object: specify at least one of -Line, -Word, or -Character");
+    }
+
+    if !cfg!(windows) {
+        return wc_cmd::run(&translated, verbose);
+    }
+
+    let mut line = false;
+    let mut word = false;
+    let mut character = false;
+    let mut inputs: Vec<PathBuf> = Vec::new();
+    for arg in &translated {
+        match arg.as_str() {
+            "-l" => line = true,
+            "-w" => word = true,
+            "-m" => character = true,
+            other => inputs.push(PathBuf::from(other)),
+        }
+    }
+
+    let mut content = String::new();
+    if inputs.is_empty() {
+        std::io::stdin()
+            .lock()
+            .read_to_string(&mut content)
+            .context("Measure-Object: failed to read stdin")?;
+    } else {
+        for file in &inputs {
+            content.push_str(
+                &fs::read_to_string(file).with_context(|| {
+                    format!("Measure-Object: failed to read {}", file.display())
+                })?,
+            );
+            content.push('\n');
+        }
+    }
+
+    let lines = if line { content.lines().count() } else { 0 };
+    let words = if word {
+        content.split_whitespace().count()
+    } else {
+        0
+    };
+    let chars = if character {
+        content.chars().count()
+    } else {
+        0
+    };
+
+    match (line, word, character) {
+        (true, false, false) => println!("{}", lines),
+        (false, true, false) => println!("{}", words),
+        (false, false, true) => println!("{}", chars),
+        _ => println!("{} {} {}", lines, words, chars),
+    }
+    Ok(0)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,11 +16,12 @@ use cmds::js::{
     vitest_cmd,
 };
 use cmds::jvm::{gradlew_cmd, mvn_cmd};
+use cmds::powershell;
 use cmds::python::{mypy_cmd, pip_cmd, pytest_cmd, ruff_cmd};
 use cmds::ruby::{rake_cmd, rspec_cmd, rubocop_cmd};
 use cmds::rust::{cargo_cmd, runner};
 use cmds::system::{
-    deps, env_cmd, find_cmd, format_cmd, json_cmd, local_llm, log_cmd, ls, pipe_cmd, read, search,
+    deps, env_cmd, find_cmd, format_cmd, json_cmd, local_llm, log_cmd, ls, pipe_cmd, search,
     summary, tree, wc_cmd,
 };
 
@@ -398,6 +399,50 @@ enum Commands {
     /// Word/line/byte count with compact output (strips paths and padding)
     Wc {
         /// Arguments passed to wc (files, flags like -l, -w, -c)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// PowerShell Get-ChildItem with compact output (routes to ls filter)
+    #[command(
+        name = "Get-ChildItem",
+        aliases = ["get-childitem", "gci"]
+    )]
+    GetChildItem {
+        /// PowerShell-style arguments (e.g. -Force, -Recurse, -Path)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// PowerShell Get-Content with compact output (routes to read filter)
+    #[command(
+        name = "Get-Content",
+        aliases = ["get-content", "gc"]
+    )]
+    GetContent {
+        /// PowerShell-style arguments (e.g. -Tail, -TotalCount, -Path)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// PowerShell Select-String with compact output (routes to grep filter)
+    #[command(
+        name = "Select-String",
+        aliases = ["select-string", "sls"]
+    )]
+    SelectString {
+        /// PowerShell-style arguments (e.g. -Pattern, -Path, -SimpleMatch)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// PowerShell Measure-Object with compact output (routes to wc filter)
+    #[command(
+        name = "Measure-Object",
+        aliases = ["measure-object", "mo"]
+    )]
+    MeasureObject {
+        /// PowerShell-style arguments (e.g. -Line, -Word, -Character)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -1496,6 +1541,7 @@ fn run_cli() -> Result<i32> {
 
     let code = match cli.command {
         Commands::Ls { args } => ls::run(&args, cli.verbose)?,
+        Commands::GetChildItem { args } => powershell::run_get_child_item(&args, cli.verbose)?,
 
         Commands::Tree { args } => tree::run(&args, cli.verbose)?,
 
@@ -1506,38 +1552,16 @@ fn run_cli() -> Result<i32> {
             max_lines,
             tail_lines,
             line_numbers,
-        } => {
-            let mut had_error = false;
-            let mut stdin_seen = false;
-            for file in &files {
-                let result = if file == Path::new("-") {
-                    if stdin_seen {
-                        eprintln!("rtk: warning: stdin specified more than once");
-                        continue;
-                    }
-                    stdin_seen = true;
-                    read::run_stdin(level, max_lines, tail_lines, line_numbers, cli.verbose)
-                } else {
-                    read::run(
-                        file,
-                        level,
-                        max_lines,
-                        tail_lines,
-                        line_numbers,
-                        cli.verbose,
-                    )
-                };
-                if let Err(e) = result {
-                    eprintln!("cat: {}: {}", file.display(), e.root_cause());
-                    had_error = true;
-                }
-            }
-            if had_error {
-                1
-            } else {
-                0
-            }
-        }
+        } => powershell::run_read_command(
+            &files,
+            level,
+            max_lines,
+            tail_lines,
+            line_numbers,
+            cli.verbose,
+        )?,
+
+        Commands::GetContent { args } => powershell::run_get_content(&args, cli.verbose)?,
 
         Commands::Smart {
             file,
@@ -1877,6 +1901,7 @@ fn run_cli() -> Result<i32> {
         Commands::Rg { extra_args } => {
             search::run(search::Engine::Rg, 80, 200, false, &extra_args, cli.verbose)?
         }
+        Commands::SelectString { args } => powershell::run_select_string(&args, cli.verbose)?,
 
         Commands::Init {
             global,
@@ -1993,6 +2018,7 @@ fn run_cli() -> Result<i32> {
         }
 
         Commands::Wc { args } => wc_cmd::run(&args, cli.verbose)?,
+        Commands::MeasureObject { args } => powershell::run_measure_object(&args, cli.verbose)?,
 
         Commands::Gain {
             project, // added
@@ -2558,8 +2584,10 @@ fn is_operational_command(cmd: &Commands) -> bool {
     matches!(
         cmd,
         Commands::Ls { .. }
+            | Commands::GetChildItem { .. }
             | Commands::Tree { .. }
             | Commands::Read { .. }
+            | Commands::GetContent { .. }
             | Commands::Smart { .. }
             | Commands::Git { .. }
             | Commands::Gh { .. }
@@ -2579,6 +2607,7 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Oc { .. }
             | Commands::Summary { .. }
             | Commands::Grep { .. }
+            | Commands::SelectString { .. }
             | Commands::Rg { .. }
             | Commands::Wget { .. }
             | Commands::Vitest { .. }
@@ -2601,6 +2630,7 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Go { .. }
             | Commands::GolangciLint { .. }
             | Commands::Gt { .. }
+            | Commands::MeasureObject { .. }
     )
 }
 
@@ -3188,6 +3218,47 @@ mod tests {
                 }
                 _ => panic!("expected Rewrite command"),
             }
+        }
+    }
+
+    #[test]
+    fn test_powershell_alias_get_child_item() {
+        let cli = Cli::try_parse_from(["rtk", "get-childitem", "-Force", "C:\\src"]).unwrap();
+        match cli.command {
+            Commands::GetChildItem { args } => assert_eq!(args, vec!["-Force", "C:\\src"]),
+            other => panic!("expected GetChildItem command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_powershell_alias_get_content() {
+        let cli = Cli::try_parse_from(["rtk", "get-content", "README.md"]).unwrap();
+        match cli.command {
+            Commands::GetContent { args } => {
+                assert_eq!(args, vec!["README.md"]);
+            }
+            other => panic!("expected GetContent command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_powershell_alias_select_string() {
+        let cli = Cli::try_parse_from(["rtk", "select-string", "-Pattern", "TODO", "src/main.rs"])
+            .unwrap();
+        match cli.command {
+            Commands::SelectString { args } => {
+                assert_eq!(args, vec!["-Pattern", "TODO", "src/main.rs"]);
+            }
+            other => panic!("expected SelectString command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_powershell_alias_measure_object() {
+        let cli = Cli::try_parse_from(["rtk", "measure-object", "-Line"]).unwrap();
+        match cli.command {
+            Commands::MeasureObject { args } => assert_eq!(args, vec!["-Line"]),
+            other => panic!("expected MeasureObject command, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

- Add PowerShell inspection command support for the most common commands: `Get-ChildItem`, `Get-Content`, `Select-String`, and `Measure-Object`.
- Add lowercase aliases for those commands so they work naturally in PowerShell's case-insensitive style.
- Move the PowerShell handlers into `src/cmds/powershell.rs` and update the README plus parser tests.

## Test plan
<!-- How did you verify this works? -->

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk get-childitem -Force .` output inspected
- [x] Manual testing: `rtk get-content -Tail 5 README.md` output inspected
- [x] Manual testing: `rtk select-string -Pattern TODO src\main.rs` output inspected
- [x] Manual testing: `rtk measure-object -Line README.md` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.