### PR TITLE
fix(openclaw): plugin manifest and configurable exit-3 handling

### DIFF
--- a/openclaw/index.ts
+++ b/openclaw/index.ts
@@ -12,7 +12,7 @@
  *   0 + stdout  Allow — rewrite found, explicitly allowed → auto-apply
  *   1           No RTK equivalent → pass through unchanged
  *   2           Deny rule matched → block the call
- *   3 + stdout  Ask rule matched (or default) → rewrite, require approval
+ *   3 + stdout  Ask rule matched (or default) → rewrite, approval depends on config
  *
  * See: src/hooks/rewrite_cmd.rs
  */
@@ -32,19 +32,19 @@ function checkRtk(): boolean {
   return rtkAvailable;
 }
 
+type RewriteVerdict = "ask" | "deny";
+
 /**
  * Delegate to `rtk rewrite` and interpret the exit code.
  *
  * Returns a tuple `[rewritten, verdict?]`:
  *   [string]        — rewrite, auto-apply (exit 0)
- *   [string, "ask"] — rewrite, require user approval (exit 3)
+ *   [string, "ask"] — rewrite, approval depends on config (exit 3)
  *   [null, "deny"]  — command matched a deny rule (exit 2)
  *   [null]          — no rewrite / passthrough (exit 1 or no change)
  */
-type RewriteVerdict = "ask" | "deny";
-
 function tryRewrite(
-  command: string
+  command: string,
 ): [string | null, RewriteVerdict?] {
   try {
     const result = execFileSync("rtk", ["rewrite", command], {
@@ -56,7 +56,7 @@ function tryRewrite(
     // Exit 0 — Allow: rewrite and auto-apply
     return [result && result !== command ? result : null];
   } catch (e: any) {
-    // Exit 3 — Ask: rewrite available but user must approve
+    // Exit 3 — Ask: rewrite available, approval depends on config
     if (e?.status === 3 && e.stdout) {
       const result = e.stdout.toString().trim();
       if (result && result !== command) return [result, "ask"];
@@ -76,6 +76,7 @@ export default function register(api: any) {
   const pluginConfig = api.config ?? {};
   const enabled = pluginConfig.enabled !== false;
   const verbose = pluginConfig.verbose === true;
+  const approvalMode: "auto" | "ask" = pluginConfig.approvalMode ?? "auto";
 
   if (!enabled) return;
 
@@ -109,7 +110,7 @@ export default function register(api: any) {
 
       if (verbose) {
         console.log(
-          `[rtk] ${command} -> ${rewritten}${verdict === "ask" ? " (approval required)" : ""}`
+          `[rtk] ${command} -> ${rewritten}${verdict === "ask" ? ` (${approvalMode === "auto" ? "auto-applied" : "approval required"})` : ""}`,
         );
       }
 
@@ -127,16 +128,13 @@ export default function register(api: any) {
         params: { ...event.params, command: rewritten },
       };
 
-      // Exit 3 — Ask: rewrite but require user approval
-      if (verdict === "ask") {
+      // Exit 3 — Ask: require approval only when approvalMode is "ask"
+      if (verdict === "ask" && approvalMode === "ask") {
         result.requireApproval = {
           title: "RTK rewrite suggestion",
           description: `Rewrite: \`${command}\` → \`${rewritten}\``,
           severity: "info",
           timeoutBehavior: "deny",
-          // "allow-always" omitted: OpenClaw does not auto-persist approval
-          // for plugin hooks — see:
-          // https://docs.openclaw.ai/plugins/plugin-permission-requests#troubleshooting
           allowedDecisions: ["allow-once", "deny"],
           onResolution: (decision: string) => {
             if (verbose) {
@@ -148,10 +146,10 @@ export default function register(api: any) {
 
       return result;
     },
-    { priority: 10 }
+    { priority: 10 },
   );
 
   if (verbose) {
-    console.log("[rtk] OpenClaw plugin registered");
+    console.log(`[rtk] OpenClaw plugin registered (approvalMode: ${approvalMode})`);
   }
 }

--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -5,6 +5,9 @@
   "description": "Transparently rewrites shell commands to their RTK equivalents for 60-90% LLM token savings",
   "homepage": "https://github.com/rtk-ai/rtk",
   "license": "Apache-2.0",
+  "activation": {
+    "onStartup": true
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
@@ -18,11 +21,18 @@
         "type": "boolean",
         "default": false,
         "description": "Log rewrite decisions to console for debugging"
+      },
+      "approvalMode": {
+        "type": "string",
+        "enum": ["auto", "ask"],
+        "default": "auto",
+        "description": "How to handle exit-3 (ask) rewrites: 'auto' applies silently, 'ask' prompts the user"
       }
     }
   },
   "uiHints": {
     "enabled": { "label": "Enable RTK rewriting" },
-    "verbose": { "label": "Verbose logging" }
+    "verbose": { "label": "Verbose logging" },
+    "approvalMode": { "label": "Approval mode" }
   }
 }

--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -2,6 +2,7 @@
   "name": "@rtk-ai/rtk-rewrite",
   "version": "1.0.0",
   "description": "RTK plugin for OpenClaw — rewrites shell commands for 60-90% LLM token savings",
+  "type": "module",
   "main": "index.ts",
   "license": "Apache-2.0",
   "repository": {
@@ -22,5 +23,8 @@
     "index.ts",
     "openclaw.plugin.json",
     "README.md"
-  ]
+  ],
+  "openclaw": {
+    "extensions": ["./index.ts"]
+  }
 }


### PR DESCRIPTION
Fixes #1717

## Problem

The OpenClaw plugin was discoverable in `plugins list` but the runtime never loaded, so `before_tool_call` did not intercept `exec` commands. Additionally, exit code 3 (ask) always triggered `requireApproval`, which blocks exec for up to 120s — after timeout the command is denied, making the plugin unusable in practice.

## Root causes

1. **`package.json` missing `openclaw.extensions`** — OpenClaw cannot determine the entry point without it.
2. **`openclaw.plugin.json` missing `activation.onStartup`** — since OpenClaw 2026.6.x, omitting this field no longer startup-loads the plugin implicitly.
3. **Exit code 3 always triggered `requireApproval`** — 120s timeout makes this path unusable for automated agent workflows.

## Changes

### `package.json`
- Added `"type": "module"`
- Added `"openclaw": { "extensions": ["./index.ts"] }`

### `openclaw.plugin.json`
- Added `"activation": { "onStartup": true }`
- Added `approvalMode` to `configSchema` (`"auto" | "ask"`, default `"auto"`)

### `index.ts`
- Added `approvalMode` config field (default `"auto"`)
- Exit 3 + `"auto"` mode: rewrite applied silently (no approval prompt)
- Exit 3 + `"ask"` mode: existing `requireApproval` behavior preserved
- Updated JSDoc to reflect configurable exit-3 handling

## Testing

Tested on OpenClaw 2026.6.10 with RTK 0.43.0.

- `plugins inspect rtk-rewrite --runtime` shows `status: loaded`, `hookCount: 1`
- `before_tool_call` hook fires and rewrites `git status` → `rtk git status`
- `approvalMode: "auto"` (default) — no approval prompts, rewrites apply transparently
- `approvalMode: "ask"` — approval card appears with allow-once/deny buttons
- Deny rules (exit 2) block correctly regardless of approvalMode