### PR TITLE
fix(analytics): truncate display strings on UTF-8 char boundaries

### DIFF
--- a/src/analytics/gain.rs
+++ b/src/analytics/gain.rs
@@ -713,8 +713,9 @@ fn show_failures(tracker: &Tracker) -> Result<()> {
         println!("{}", styled("Recent Failures (last 10)", true));
         println!("{}", "─".repeat(60));
         for rec in &summary.recent {
-            // ISSUE #2787: show the full string when byte 16 is not a char boundary
-            let ts_short = rec.timestamp.get(..16).unwrap_or(&rec.timestamp);
+            // ISSUE #2787: floor to the previous char boundary so the prefix
+            // never exceeds 16 bytes and never lands mid-character
+            let ts_short = &rec.timestamp[..rec.timestamp.floor_char_boundary(16)];
             let status = if rec.fallback_succeeded { "ok" } else { "FAIL" };
             let cmd_display = truncate(&rec.raw_command, 40);
             println!("  {} [{}] {}", ts_short, status, cmd_display);

--- a/src/analytics/gain.rs
+++ b/src/analytics/gain.rs
@@ -2,7 +2,7 @@
 
 use crate::core::display_helpers::{format_duration, print_period_table};
 use crate::core::tracking::{DayStats, MonthStats, Tracker, WeekStats};
-use crate::core::utils::format_tokens;
+use crate::core::utils::{format_tokens, truncate};
 use crate::hooks::hook_check;
 use anyhow::{Context, Result};
 use chrono::Local;
@@ -246,11 +246,7 @@ pub fn run(
                 println!("──────────────────────────────────────────────────────────");
                 for rec in recent {
                     let time = rec.timestamp.with_timezone(&Local).format("%m-%d %H:%M");
-                    let cmd_short = if rec.rtk_cmd.len() > 25 {
-                        format!("{}...", &rec.rtk_cmd[..22])
-                    } else {
-                        rec.rtk_cmd.clone()
-                    };
+                    let cmd_short = truncate(&rec.rtk_cmd, 25);
                     // added: tier indicators by savings level
                     let sign = if rec.savings_pct >= 70.0 {
                         "▲"
@@ -707,11 +703,7 @@ fn show_failures(tracker: &Tracker) -> Result<()> {
         println!("{}", styled("Top Commands (by frequency)", true));
         println!("{}", "─".repeat(60));
         for (cmd, count) in &summary.top_commands {
-            let cmd_display = if cmd.len() > 50 {
-                format!("{}...", &cmd[..47])
-            } else {
-                cmd.clone()
-            };
+            let cmd_display = truncate(cmd, 50);
             println!("  {:>4}x  {}", count, cmd_display);
         }
         println!();
@@ -721,17 +713,10 @@ fn show_failures(tracker: &Tracker) -> Result<()> {
         println!("{}", styled("Recent Failures (last 10)", true));
         println!("{}", "─".repeat(60));
         for rec in &summary.recent {
-            let ts_short = if rec.timestamp.len() >= 16 {
-                &rec.timestamp[..16]
-            } else {
-                &rec.timestamp
-            };
+            // ISSUE #2787: show the full string when byte 16 is not a char boundary
+            let ts_short = rec.timestamp.get(..16).unwrap_or(&rec.timestamp);
             let status = if rec.fallback_succeeded { "ok" } else { "FAIL" };
-            let cmd_display = if rec.raw_command.len() > 40 {
-                format!("{}...", &rec.raw_command[..37])
-            } else {
-                rec.raw_command.clone()
-            };
+            let cmd_display = truncate(&rec.raw_command, 40);
             println!("  {} [{}] {}", ts_short, status, cmd_display);
         }
         println!();

--- a/src/analytics/session_cmd.rs
+++ b/src/analytics/session_cmd.rs
@@ -110,7 +110,7 @@ pub fn run(_verbose: u8) -> Result<()> {
             .file_stem()
             .and_then(|s| s.to_str())
             .unwrap_or("unknown");
-        let short_id = id.get(..8).unwrap_or(id);
+        let short_id = &id[..id.floor_char_boundary(8)];
 
         // Extract date from mtime
         let date = fs::metadata(path)

--- a/src/analytics/session_cmd.rs
+++ b/src/analytics/session_cmd.rs
@@ -110,7 +110,7 @@ pub fn run(_verbose: u8) -> Result<()> {
             .file_stem()
             .and_then(|s| s.to_str())
             .unwrap_or("unknown");
-        let short_id = if id.len() > 8 { &id[..8] } else { id };
+        let short_id = id.get(..8).unwrap_or(id);
 
         // Extract date from mtime
         let date = fs::metadata(path)

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -639,6 +639,17 @@ mod tests {
         assert!(result.ends_with("..."));
     }
 
+    #[test]
+    fn test_truncate_multibyte_cyrillic_issue_2787() {
+        // Regression: `rtk gain --history` panicked slicing this at byte 22,
+        // which falls inside 'н' (Cyrillic chars are 2 bytes each)
+        let cmd = "rtk ls -la Ародинамический расчёт Новый";
+        let result = truncate(cmd, 25);
+        assert_eq!(result.chars().count(), 25);
+        assert!(result.ends_with("..."));
+        assert_eq!(result, "rtk ls -la Ародинамиче...");
+    }
+
     // ===== resolve_binary tests (issue #212) =====
 
     #[test]


### PR DESCRIPTION
Fixes #2787

## Problem

`rtk gain --history` panicked when a tracked command contained non-ASCII text (Cyrillic, CJK, emoji):

```
thread 'main' panicked at src/analytics/gain.rs:250:54:
end byte index 22 is not a char boundary; it is inside 'Н' (bytes 21..23 of string)
```

## Root cause

Display code in `src/analytics/` truncated strings with raw byte slicing (`s.len() > N` then `&s[..M]`), which panics when the cut lands inside a multi-byte UTF-8 character. These were hand-inlined byte-based copies of the char-safe `core::utils::truncate()` helper that the rest of the codebase already uses. This is the 5th recurrence of this defect class (previous fixes: da486bf tee, c5ec92f git, 533894a json, #2751 parser); an audit of all string-slice sites in `src/` confirmed the remaining unsafe ones were all in `src/analytics/`.

Every fixed site was first reproduced as a real panic against the pre-fix binary with crafted data:

| Site | Panic reproduced |
|---|---|
| `gain.rs` history command | `byte index 22 is not a char boundary` |
| `gain.rs` failures top commands | `byte index 47 is not a char boundary` |
| `gain.rs` failures recent commands | `byte index 37 is not a char boundary` |
| `gain.rs` failures timestamp prefix | `byte index 16 is not a char boundary` |
| `session_cmd.rs` session id prefix | `byte index 8 is not a char boundary` |

## Fix

- Replace the three ad-hoc truncations with the shared `core::utils::truncate()` (chars-based, existing helper, no new dependency).
- Use `.get(..n).unwrap_or(full)` for the timestamp and session id prefix slices: valid prefix when the boundary is clean, full string instead of a panic otherwise.
- Add a Cyrillic regression test with the exact string from the issue, next to the existing Thai/CJK/emoji truncate tests.

## Verification

- The issue repro (`rtk ls -la "D:\...Ародинамический..."` tracked, then `rtk gain --history`) now renders correctly with exit 0.
- All 5 sites verified fixed end-to-end against the same crafted data (isolated `RTK_DB_PATH` databases and a sandboxed `CLAUDE_CONFIG_DIR`).
- No regression: old vs new binary output on pure-ASCII data is byte-identical for `gain --history`, `gain --failures` and `session`, with every truncation branch exercised (ellipsis present in compared output).
- `cargo fmt --all --check`, `cargo clippy --all-targets` (zero warnings), `cargo test --all` (2371 passed).

## Checklist

- [x] Unit tests added (regression test in `src/core/utils.rs`)
- [x] Token savings: N/A (display fix, no filter change)
- [x] Truncated list recovery hints: N/A (`CAP_*` applies to filter output lists; the 10-row display limits here are pre-existing SQL `LIMIT 10`, unchanged)
- [x] Edge cases covered (Cyrillic, CJK, emoji, mid-char prefix boundaries)
- [x] Pre-commit gate passes
- [x] Manual test: `rtk gain --history`, `rtk gain --failures`, `rtk session` inspected

Follow-up candidate (out of scope here): enable `clippy::string_slice` repo-wide to prevent this defect class permanently; it requires `#[allow]` annotations on the ~20 verified-safe slice sites.