### PR TITLE
Fix #2762: `rtk gain` reports unreproducible savings — `read`/`grep`/`tail` show 0% compres

### DIFF
--- a/src/cmds/system/read.rs
+++ b/src/cmds/system/read.rs
@@ -66,6 +66,7 @@ pub fn run(
 
     filtered = apply_line_window(&filtered, max_lines, tail_lines, &lang);
 
+    let raw_for_tracking = tracking_baseline(&content, max_lines, tail_lines, line_numbers, &lang);
     let (raw, rtk_output) = if line_numbers {
         (
             format_with_line_numbers(&content),
@@ -79,7 +80,7 @@ pub fn run(
     timer.track(
         &format!("cat {}", file.display()),
         "rtk read",
-        &raw,
+        &raw_for_tracking,
         shown,
     );
     Ok(())
@@ -134,6 +135,7 @@ pub fn run_stdin(
 
     filtered = apply_line_window(&filtered, max_lines, tail_lines, &lang);
 
+    let raw_for_tracking = tracking_baseline(&content, max_lines, tail_lines, line_numbers, &lang);
     let (raw, rtk_output) = if line_numbers {
         (
             format_with_line_numbers(&content),
@@ -145,7 +147,7 @@ pub fn run_stdin(
     let shown = never_worse(&raw, &rtk_output);
     print!("{}", shown);
 
-    timer.track("cat - (stdin)", "rtk read -", &raw, shown);
+    timer.track("cat - (stdin)", "rtk read -", &raw_for_tracking, shown);
     Ok(())
 }
 
@@ -183,6 +185,37 @@ fn apply_line_window(
     }
 
     content.to_string()
+}
+
+fn tracking_baseline(
+    content: &str,
+    max_lines: Option<usize>,
+    tail_lines: Option<usize>,
+    line_numbers: bool,
+    lang: &Language,
+) -> String {
+    let baseline = if let Some(max) = max_lines {
+        head_window(content, max)
+    } else {
+        apply_line_window(content, max_lines, tail_lines, lang)
+    };
+    if line_numbers {
+        format_with_line_numbers(&baseline)
+    } else {
+        baseline
+    }
+}
+
+fn head_window(content: &str, max_lines: usize) -> String {
+    if max_lines == 0 {
+        return String::new();
+    }
+    let lines: Vec<&str> = content.lines().take(max_lines).collect();
+    let mut result = lines.join("\n");
+    if content.ends_with('\n') && !lines.is_empty() {
+        result.push('\n');
+    }
+    result
 }
 
 #[cfg(test)]
@@ -234,6 +267,34 @@ fn main() {{
         let output = apply_line_window(input, Some(2), None, &Language::Unknown);
         assert!(output.starts_with("a\n"));
         assert!(output.contains("more lines"));
+    }
+
+    #[test]
+    fn test_tracking_baseline_matches_head_window() {
+        let input = "a\nb\nc\nd\n";
+        let baseline = tracking_baseline(input, Some(2), None, false, &Language::Unknown);
+        assert_eq!(baseline, "a\nb\n");
+    }
+
+    #[test]
+    fn test_tracking_baseline_matches_tail_window() {
+        let input = "a\nb\nc\nd\n";
+        let baseline = tracking_baseline(input, None, Some(2), false, &Language::Unknown);
+        assert_eq!(baseline, "c\nd\n");
+    }
+
+    #[test]
+    fn test_tracking_baseline_keeps_plain_read_full_file() {
+        let input = "a\nb\nc\nd\n";
+        let baseline = tracking_baseline(input, None, None, false, &Language::Unknown);
+        assert_eq!(baseline, input);
+    }
+
+    #[test]
+    fn test_tracking_baseline_applies_line_numbers_after_window() {
+        let input = "a\nb\nc\nd\n";
+        let baseline = tracking_baseline(input, None, Some(2), true, &Language::Unknown);
+        assert_eq!(baseline, "1 │ c\n2 │ d\n");
     }
 
     fn rtk_bin() -> std::path::PathBuf {

--- a/src/cmds/system/read.rs
+++ b/src/cmds/system/read.rs
@@ -66,23 +66,15 @@ pub fn run(
 
     filtered = apply_line_window(&filtered, max_lines, tail_lines, &lang);
 
-    let raw_for_tracking = tracking_baseline(&content, max_lines, tail_lines, line_numbers, &lang);
-    let (raw, rtk_output) = if line_numbers {
-        (
-            format_with_line_numbers(&content),
-            format_with_line_numbers(&filtered),
-        )
+    let raw = tracking_baseline(&content, max_lines, tail_lines, line_numbers, &lang);
+    let rtk_output = if line_numbers {
+        format_with_line_numbers(&filtered)
     } else {
-        (content.clone(), filtered.clone())
+        filtered.clone()
     };
     let shown = never_worse(&raw, &rtk_output);
     print!("{}", shown);
-    timer.track(
-        &format!("cat {}", file.display()),
-        "rtk read",
-        &raw_for_tracking,
-        shown,
-    );
+    timer.track(&format!("cat {}", file.display()), "rtk read", &raw, shown);
     Ok(())
 }
 
@@ -135,19 +127,16 @@ pub fn run_stdin(
 
     filtered = apply_line_window(&filtered, max_lines, tail_lines, &lang);
 
-    let raw_for_tracking = tracking_baseline(&content, max_lines, tail_lines, line_numbers, &lang);
-    let (raw, rtk_output) = if line_numbers {
-        (
-            format_with_line_numbers(&content),
-            format_with_line_numbers(&filtered),
-        )
+    let raw = tracking_baseline(&content, max_lines, tail_lines, line_numbers, &lang);
+    let rtk_output = if line_numbers {
+        format_with_line_numbers(&filtered)
     } else {
-        (content.clone(), filtered.clone())
+        filtered.clone()
     };
     let shown = never_worse(&raw, &rtk_output);
     print!("{}", shown);
 
-    timer.track("cat - (stdin)", "rtk read -", &raw_for_tracking, shown);
+    timer.track("cat - (stdin)", "rtk read -", &raw, shown);
     Ok(())
 }
 

--- a/src/cmds/system/search.rs
+++ b/src/cmds/system/search.rs
@@ -559,7 +559,7 @@ pub fn run(
     };
 
     print!("{}", output);
-    timer.track(&real_cmd, &rtk_label, &raw_output, &output);
+    timer.track(&real_cmd, &rtk_label, &plain, &output);
 
     Ok(exit_code)
 }

--- a/tests/gain_accounting_test.rs
+++ b/tests/gain_accounting_test.rs
@@ -1,0 +1,84 @@
+use serde_json::Value;
+use std::process::Command;
+
+fn rtk() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_rtk"))
+}
+
+fn gain_total_saved(db_path: &std::path::Path) -> u64 {
+    let output = rtk()
+        .env("RTK_DB_PATH", db_path)
+        .args(["gain", "--format", "json"])
+        .output()
+        .expect("rtk gain");
+    assert!(
+        output.status.success(),
+        "rtk gain failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value = serde_json::from_slice(&output.stdout).expect("gain json");
+    json["summary"]["total_saved"]
+        .as_u64()
+        .expect("summary.total_saved")
+}
+
+#[test]
+fn read_tail_window_reports_no_savings_against_tail_baseline() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("tracking.db");
+    let file = dir.path().join("large.log");
+    let content: String = (0..12)
+        .map(|i| format!("line-{i} {}\n", "x".repeat(120)))
+        .collect();
+    std::fs::write(&file, content).expect("write fixture");
+
+    let output = rtk()
+        .env("RTK_DB_PATH", &db_path)
+        .args(["read", "--tail-lines", "2", file.to_str().unwrap()])
+        .output()
+        .expect("rtk read");
+    assert!(
+        output.status.success(),
+        "rtk read failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        format!("line-10 {}\nline-11 {}\n", "x".repeat(120), "x".repeat(120))
+    );
+
+    assert_eq!(gain_total_saved(&db_path), 0);
+}
+
+#[test]
+fn uncapped_grep_reports_no_savings_against_faithful_baseline() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("tracking.db");
+    let file = dir.path().join("sample.txt");
+    std::fs::write(&file, format!("foo {}\n", "x".repeat(120))).expect("write fixture");
+
+    let probe = Command::new("grep")
+        .args(["--null", "-n", "-H", "foo", file.to_str().unwrap()])
+        .output();
+    if !probe.map(|o| o.status.success()).unwrap_or(false) {
+        return;
+    }
+
+    let output = rtk()
+        .env("RTK_DB_PATH", &db_path)
+        .args(["grep", "-n", "foo", file.to_str().unwrap()])
+        .output()
+        .expect("rtk grep");
+    assert!(
+        output.status.success(),
+        "rtk grep failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        format!("1:foo {}\n", "x".repeat(120))
+    );
+
+    assert_eq!(gain_total_saved(&db_path), 0);
+}

--- a/tests/gain_accounting_test.rs
+++ b/tests/gain_accounting_test.rs
@@ -52,6 +52,56 @@ fn read_tail_window_reports_no_savings_against_tail_baseline() {
 }
 
 #[test]
+fn read_max_window_reports_savings_against_head_baseline_when_shorter() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("tracking.db");
+    let file = dir.path().join("large.log");
+    let content: String = (0..12)
+        .map(|i| format!("line-{i} {}\n", "x".repeat(120)))
+        .collect();
+    std::fs::write(&file, content).expect("write fixture");
+
+    let output = rtk()
+        .env("RTK_DB_PATH", &db_path)
+        .args(["read", "--max-lines", "4", file.to_str().unwrap()])
+        .output()
+        .expect("rtk read");
+    assert!(
+        output.status.success(),
+        "rtk read failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("more lines"));
+
+    assert!(
+        gain_total_saved(&db_path) > 0,
+        "shortened --max-lines output should record real savings"
+    );
+}
+
+#[test]
+fn read_head_window_guard_falls_back_to_head_baseline() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("tracking.db");
+    let file = dir.path().join("tiny.txt");
+    std::fs::write(&file, "a\nb\n").expect("write fixture");
+
+    let output = rtk()
+        .env("RTK_DB_PATH", &db_path)
+        .args(["read", "--max-lines", "1", file.to_str().unwrap()])
+        .output()
+        .expect("rtk read");
+    assert!(
+        output.status.success(),
+        "rtk read failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "a\n");
+
+    assert_eq!(gain_total_saved(&db_path), 0);
+}
+
+#[test]
 fn uncapped_grep_reports_no_savings_against_faithful_baseline() {
     let dir = tempfile::tempdir().expect("tempdir");
     let db_path = dir.path().join("tracking.db");

--- a/tests/gain_accounting_test.rs
+++ b/tests/gain_accounting_test.rs
@@ -82,3 +82,36 @@ fn uncapped_grep_reports_no_savings_against_faithful_baseline() {
 
     assert_eq!(gain_total_saved(&db_path), 0);
 }
+
+#[test]
+fn capped_grep_reports_savings_against_faithful_baseline() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("tracking.db");
+    let file = dir.path().join("sample.txt");
+    let filler = "x".repeat(160);
+    let content: String = (0..40)
+        .map(|i| format!("foo line {i} {filler}\n"))
+        .collect();
+    std::fs::write(&file, content).expect("write fixture");
+
+    let probe = Command::new("grep")
+        .args(["--null", "-n", "-H", "foo", file.to_str().unwrap()])
+        .output();
+    if !probe.map(|o| o.status.success()).unwrap_or(false) {
+        return;
+    }
+
+    let output = rtk()
+        .env("RTK_DB_PATH", &db_path)
+        .args(["grep", "--max", "5", "foo", file.to_str().unwrap()])
+        .output()
+        .expect("rtk grep");
+    assert!(
+        output.status.success(),
+        "rtk grep failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let saved = gain_total_saved(&db_path);
+    assert!(saved > 0, "capped grep should record real savings");
+}


### PR DESCRIPTION
## Summary
- Fixes https://github.com/rtk-ai/rtk/issues/2762
- Keeps the patch focused on issue #2762

## Changed Files
- `src/cmds/system/read.rs`
- `src/cmds/system/search.rs`
- `tests/gain_accounting_test.rs`

## Verification
- [x] `git diff --check`
- [ ] `cargo test`

## Notes
This PR was prepared from Fast Fix Studio after local publish checks passed.