### PR TITLE
feat: clarify or clear tee logs in telemetry forget

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ All data is **aggregate counts or anonymized command names** (first 3 words, no 
 rtk telemetry status     # Check current consent state
 rtk telemetry enable     # Give consent (interactive prompt)
 rtk telemetry disable    # Withdraw consent — stops all collection immediately
-rtk telemetry forget     # Withdraw consent + delete all local data + request server-side erasure
+rtk telemetry forget     # Withdraw consent + delete all local data (salt, marker, history DB, tee logs) + request server-side erasure
 ```
 
 **Override via environment:**

--- a/docs/guide/getting-started/configuration.md
+++ b/docs/guide/getting-started/configuration.md
@@ -82,6 +82,8 @@ Your AI assistant can then read the file if it needs more detail, without re-run
 | Min size | 500 bytes | Outputs shorter than this are not saved |
 | Max file size | 1 MB | Truncated above this |
 
+Tee logs are removed by `rtk telemetry forget`; the directory is `~/.local/share/rtk/tee/` (override with `RTK_TEE_DIR` or `tee.directory`).
+
 ## Excluding commands from auto-rewrite
 
 Prevent specific commands from being rewritten by the hook:

--- a/docs/guide/resources/telemetry.md
+++ b/docs/guide/resources/telemetry.md
@@ -149,14 +149,14 @@ Under the EU General Data Protection Regulation, you have the right to:
 
 - **Access** your data: `rtk telemetry status` shows your device hash; the telemetry payload is fully documented above.
 - **Rectification**: since data is anonymous and aggregate, rectification is not applicable.
-- **Erasure** (Art. 17): run `rtk telemetry forget` to delete local data and send an erasure request to the server. Alternatively, email contact@rtk-ai.app with your device hash.
+- **Erasure** (Art. 17): run `rtk telemetry forget` to delete local data, including tee recovery logs, and send an erasure request to the server. Alternatively, email contact@rtk-ai.app with your device hash.
 - **Restriction of processing**: `rtk telemetry disable` stops all data collection immediately.
 - **Portability**: the local SQLite database at `~/.local/share/rtk/history.db` contains all locally stored data.
 - **Objection**: `rtk telemetry disable` or `export RTK_TELEMETRY_DISABLED=1`.
 
 ## Erasure Procedure
 
-1. Run `rtk telemetry forget` — this disables telemetry, deletes your device salt, ping marker, and local tracking database (`history.db`), then sends an erasure request to the server.
+1. Run `rtk telemetry forget` — this disables telemetry, deletes your device salt, ping marker, local tracking database (`history.db`), and tee recovery logs, then sends an erasure request to the server.
 2. If the server is unreachable, the CLI prints your full device hash and fallback instructions to email contact@rtk-ai.app for manual erasure.
 3. You can also email contact@rtk-ai.app directly to request manual erasure.
 

--- a/src/core/tee.rs
+++ b/src/core/tee.rs
@@ -168,6 +168,32 @@ pub fn tee_raw(raw: &str, command_slug: &str, exit_code: i32) -> Option<PathBuf>
     )
 }
 
+/// Delete all tee recovery `.log` files.
+///
+/// Returns (dir, files_deleted) if the tee directory is determinable; count is
+/// 0 when the dir doesn't exist.
+pub fn purge_tee_logs() -> Option<(PathBuf, usize)> {
+    let config = Config::load().ok()?;
+    let tee_dir = get_tee_dir(&config)?;
+    if !tee_dir.exists() {
+        return Some((tee_dir, 0));
+    }
+
+    let mut deleted = 0;
+    if let Ok(entries) = std::fs::read_dir(&tee_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().is_some_and(|ext| ext == "log")
+                && std::fs::remove_file(&path).is_ok()
+            {
+                deleted += 1;
+            }
+        }
+    }
+
+    Some((tee_dir, deleted))
+}
+
 fn display_path(path: &std::path::Path) -> String {
     if let Some(home) = dirs::home_dir() {
         if let Ok(relative) = path.strip_prefix(&home) {
@@ -436,6 +462,25 @@ mod tests {
             let filename = format!("{:010}_{}.log", 1000000 + i, "test");
             assert!(dir.join(&filename).exists());
         }
+    }
+
+    #[test]
+    fn test_purge_tee_logs_only_removes_logs() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let dir = tmpdir.path();
+        let log_path = dir.join("123_test.log");
+        let other_path = dir.join("notes.txt");
+
+        fs::write(&log_path, "raw output").unwrap();
+        fs::write(&other_path, "keep me").unwrap();
+
+        std::env::set_var("RTK_TEE_DIR", dir);
+        let result = purge_tee_logs();
+        std::env::remove_var("RTK_TEE_DIR");
+
+        assert_eq!(result, Some((dir.to_path_buf(), 1)));
+        assert!(!log_path.exists());
+        assert!(other_path.exists());
     }
 
     #[test]

--- a/src/core/telemetry_cmd.rs
+++ b/src/core/telemetry_cmd.rs
@@ -140,6 +140,18 @@ fn run_forget() -> Result<()> {
         }
     }
 
+    // Purge tee recovery logs (may contain raw command output)
+    if let Some((tee_dir, deleted)) = super::tee::purge_tee_logs() {
+        if deleted > 0 {
+            println!(
+                "Tee recovery logs deleted: {} ({} file{})",
+                tee_dir.display(),
+                deleted,
+                if deleted == 1 { "" } else { "s" }
+            );
+        }
+    }
+
     // Send server-side erasure request
     if let Some(hash) = device_hash {
         match send_erasure_request(&hash) {


### PR DESCRIPTION
Resolves #1789.

`rtk telemetry forget` deletes telemetry salt/marker data and the local history database, but it does not clear tee recovery logs. User-facing docs say `telemetry forget` deletes "all local data", while tee logs can contain raw command output.

## Summary

-

## Test plan

- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.