### PR TITLE
feat(rules): rewrite mise/just/task runners into rtk (#607 phase 1)

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1064,6 +1064,60 @@ mod tests {
         );
     }
 
+    // --- Task runners: mise, just, task (#607) ---
+
+    #[test]
+    fn test_classify_mise_run() {
+        assert!(matches!(
+            classify_command("mise run lint"),
+            Classification::Supported {
+                rtk_equivalent: "rtk mise",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_rewrite_mise_run() {
+        assert_eq!(
+            rewrite_command_no_prefixes("mise run lint", &[]),
+            Some("rtk mise run lint".to_string())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_mise_exec_and_install() {
+        assert_eq!(
+            rewrite_command_no_prefixes("mise exec -- node -v", &[]),
+            Some("rtk mise exec -- node -v".to_string())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("mise install node", &[]),
+            Some("rtk mise install node".to_string())
+        );
+    }
+
+    #[test]
+    fn test_mise_non_task_subcommands_not_rewritten() {
+        // Only run/exec/install/upgrade are compressed by mise.toml; other
+        // subcommands (ls, activate, which) must pass through untouched so we
+        // never wrap shell-integration output like `eval "$(mise activate)"`.
+        assert_eq!(rewrite_command_no_prefixes("mise ls", &[]), None);
+        assert_eq!(rewrite_command_no_prefixes("mise activate bash", &[]), None);
+    }
+
+    #[test]
+    fn test_rewrite_just_and_task() {
+        assert_eq!(
+            rewrite_command_no_prefixes("just test", &[]),
+            Some("rtk just test".to_string())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("task build", &[]),
+            Some("rtk task build".to_string())
+        );
+    }
+
     #[test]
     fn test_classify_cat_file() {
         assert_eq!(

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -775,6 +775,37 @@ pub const RULES: &[RtkRule] = &[
         subcmd_savings: &[],
         subcmd_status: &[],
     },
+    // Task runners (mise, just, task/go-task). The hook rewrites the invocation
+    // so it flows through run_fallback, which applies the matching TOML filter
+    // (src/filters/{mise,just,task}.toml) to strip runner boilerplate. Patterns
+    // mirror each filter's `match_command` scope. See issue #607.
+    RtkRule {
+        pattern: r"^mise\s+(run|exec|install|upgrade)(\s|$)",
+        rtk_cmd: "rtk mise",
+        rewrite_prefixes: &["mise"],
+        category: "Build",
+        savings_pct: 40.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
+    RtkRule {
+        pattern: r"^just\b",
+        rtk_cmd: "rtk just",
+        rewrite_prefixes: &["just"],
+        category: "Build",
+        savings_pct: 40.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
+    RtkRule {
+        pattern: r"^task\b",
+        rtk_cmd: "rtk task",
+        rewrite_prefixes: &["task"],
+        category: "Build",
+        savings_pct: 40.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+    },
     RtkRule {
         pattern: r"^markdownlint\b",
         rtk_cmd: "rtk markdownlint",


### PR DESCRIPTION
## Summary

Phase 1 (the quick-win) of #607 — task runner support. Task runners hide the underlying command from the hook: `mise run lint` is seen as `mise`, so nothing is rewritten and RTK filtering never activates (0% savings).

The TOML filters `src/filters/{mise,just,task}.toml` have shipped since **v0.31.0** but were **dormant**: no rewrite rule routed these commands through rtk, so `rtk rewrite "mise run lint"` returned no rewrite and the hook let `mise` pass through raw.

## Change

Add 3 rewrite rules in `rules.rs`, each mirroring its filter's `match_command` scope:

| Pattern | → |
|---|---|
| `^mise\s+(run\|exec\|install\|upgrade)` | `rtk mise` |
| `^just\b` | `rtk just` |
| `^task\b` | `rtk task` |

The hook now rewrites the invocation, which flows through `run_fallback` and applies the matching TOML filter to strip runner boilerplate — the existing filters are activated with no new module. `mise` is scoped to task-bearing subcommands so shell integration (`eval "$(mise activate)"`, `mise ls`, `mise which`) is left untouched.

## Verification

- `cargo fmt` / `cargo clippy --all-targets` clean; 5 new unit tests (classify + rewrite + negative scoping).
- End-to-end against fake runners (rewrite → `run_fallback` → TOML filter):
  - `mise run lint`: 147B → 34B (77%), install boilerplate stripped
  - `task build`: 104B → 14B (87%), `task:` headers stripped
  - `just test`: light filter (strips blanks / recipe headers)
  - exit codes propagated (raw 2 / rtk 2), error output preserved
  - `mise ls` / `mise activate` / `mise which` correctly **not** rewritten

## Scope

Phase 1 only (rewrite rules + boilerplate stripping). Phases 2–4 (Rust module with underlying-tool delegation, config introspection, discover integration) remain follow-ups.

Refs #607

🤖 Generated with [Claude Code](https://claude.com/claude-code)