### PR TITLE
feat(cloud): add rtk web for HTML-to-Markdown fetches (#1426)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "env_home"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1111,7 @@ dependencies = [
  "colored",
  "dirs",
  "ego-tree",
+ "encoding_rs",
  "flate2",
  "getrandom 0.4.2",
  "ignore",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +377,27 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
+name = "ego-tree"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "env_home"
@@ -416,6 +481,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +564,16 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -724,10 +808,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
 
 [[package]]
 name = "memchr"
@@ -744,6 +848,12 @@ dependencies = [
  "adler2",
  "simd-adler32",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "num-traits"
@@ -773,10 +883,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pkg-config"
@@ -792,6 +978,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -835,6 +1027,15 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "redox_users"
@@ -900,6 +1101,7 @@ dependencies = [
  "clap",
  "colored",
  "dirs",
+ "ego-tree",
  "flate2",
  "getrandom 0.4.2",
  "ignore",
@@ -908,6 +1110,7 @@ dependencies = [
  "quick-xml",
  "regex",
  "rusqlite",
+ "scraper",
  "serde",
  "serde_json",
  "sha2",
@@ -930,6 +1133,21 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -996,6 +1214,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scraper"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd0be4d296f048bfb06dd01bbc80ef789ddd2e55583e8d2e6b804942abfabc2"
+dependencies = [
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
+name = "selectors"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
+dependencies = [
+ "bitflags",
+ "cssparser",
+ "derive_more",
+ "log",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc",
+ "smallvec",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,6 +1313,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,6 +1345,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1361,30 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "strsim"
@@ -1134,6 +1431,16 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
+ "utf-8",
 ]
 
 [[package]]
@@ -1220,6 +1527,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1258,6 +1571,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -1394,6 +1713,18 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ flate2 = "1.0"
 quick-xml = "0.37"
 which = "8"
 automod = "1"
+scraper = "0.27.0"
+ego-tree = "0.11"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ which = "8"
 automod = "1"
 scraper = "0.27.0"
 ego-tree = "0.11"
+encoding_rs = "0.8"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ rtk deps                        # Dependencies summary
 rtk env -f AWS                  # Filtered env vars
 rtk log app.log                 # Deduplicated logs
 rtk curl <url>                  # Truncate + save full output
+rtk web <url>                   # Fetch + convert HTML to compact Markdown
 rtk wget <url>                  # Download, strip progress bars
 rtk summary <long command>      # Heuristic summary
 rtk proxy <command>             # Raw passthrough + tracking

--- a/src/cmds/cloud/README.md
+++ b/src/cmds/cloud/README.md
@@ -7,5 +7,6 @@
 - `aws_cmd.rs` — 25 specialized filters covering STS, S3, EC2, ECS, RDS, CloudFormation, CloudWatch Logs, Lambda, IAM, DynamoDB, EKS, SQS, Secrets Manager. Forces `--output json` for structured parsing, uses `force_tee_hint()` for truncation recovery, strips Lambda secrets. Shared runner `run_aws_filtered()` handles boilerplate for JSON-based filters; text-based filters (S3 ls, S3 sync/cp) have dedicated runners
 - `container.rs` handles Docker, Kubernetes, and OpenShift; `DockerCommands`, `KubectlCommands`, and `OcCommands` sub-enums in `main.rs` route to `container::run()` -- uses passthrough for unknown subcommands
 - `curl_cmd.rs` truncates long responses, saves full output to file for recovery
+- `web_cmd.rs` — explicit `rtk web <url>` (#1426): fetches via `curl`, and for `text/html` responses strips script/style/nav/etc., extracts the main/article content, and converts to Markdown with de-duplicated numbered link references. Non-HTML content (JSON, XML, binary) passes through unchanged, same passthrough philosophy as `curl_cmd.rs`
 - `wget_cmd.rs` wraps wget with output filtering
 - `psql_cmd.rs` filters PostgreSQL query output

--- a/src/cmds/cloud/web_cmd.rs
+++ b/src/cmds/cloud/web_cmd.rs
@@ -12,8 +12,9 @@
 //! text, binary) and any content that fails to look like HTML is passed
 //! through unchanged.
 
+use crate::core::runner;
 use crate::core::tracking;
-use crate::core::utils::resolved_command;
+use crate::core::utils::{exit_code_from_output, resolved_command};
 use anyhow::{Context, Result};
 use scraper::{ElementRef, Html, Node, Selector};
 use std::collections::HashMap;
@@ -41,7 +42,12 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     }
 
     let output = cmd.output().context("Failed to run curl")?;
-    let exit_code = output.status.code().unwrap_or(1);
+    // Uses the shared signal-aware helper rather than `.code().unwrap_or(1)` —
+    // the latter silently reports 1 for a signal-killed curl (e.g. timeout
+    // SIGTERM) instead of the conventional 128+signal, the same class of bug
+    // fixed for `rtk run` in #2681. `curl_cmd` still has the old pattern; not
+    // touching it here since that's a pre-existing, separately-scoped issue.
+    let exit_code = exit_code_from_output(&output, "web");
 
     // Skip filtering on failure: curl can return an HTML error body that
     // would be misleading to summarize, and we want the real exit code
@@ -73,21 +79,23 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
 
     // Non-goal for v1 (#1426): only HTML is transformed. JSON, XML, plain
     // text and anything else passes through byte-for-byte.
-    if !looks_like_html(&headers, &raw) {
-        print!("{raw}");
-        std::io::stdout().flush().ok();
-        timer.track_passthrough(&format!("curl {}", url), &format!("rtk web {}", url));
-        return Ok(exit_code);
-    }
+    let content = if looks_like_html(&headers, &raw) {
+        html_to_markdown(&raw)
+    } else {
+        raw.clone()
+    };
 
-    let markdown = html_to_markdown(&raw);
-    print!("{markdown}");
-    std::io::stdout().flush().ok();
+    // `emit_guarded` applies the same never-worse safety net `curl_cmd` uses
+    // (see `core::guard::never_worse`): if the Markdown conversion ever came
+    // out larger than the raw response — pathological/adversarial HTML — the
+    // raw body is shown instead, so `rtk web` can never regress to costing
+    // more tokens than plain `curl` would have.
+    let shown = runner::emit_guarded(&content, None, &raw);
     timer.track(
         &format!("curl {}", url),
         &format!("rtk web {}", url),
         &raw,
-        &markdown,
+        &shown,
     );
 
     Ok(exit_code)

--- a/src/cmds/cloud/web_cmd.rs
+++ b/src/cmds/cloud/web_cmd.rs
@@ -323,6 +323,9 @@ struct MarkdownContext {
     links: Vec<String>,
     link_index: HashMap<String, usize>,
     in_pre: usize,
+    /// One entry per open list: `Some(count)` for `<ol>` (next item number),
+    /// `None` for `<ul>`. Depth drives nested-list indentation.
+    list_stack: Vec<Option<usize>>,
 }
 
 impl MarkdownContext {
@@ -409,12 +412,45 @@ fn walk(node: ego_tree::NodeRef<'_, Node>, ctx: &mut MarkdownContext) {
                 }
                 "li" => {
                     ctx.open_block();
-                    ctx.out.push_str("- ");
+                    let depth = ctx.list_stack.len().saturating_sub(1);
+                    ctx.out.push_str(&"  ".repeat(depth));
+                    match ctx.list_stack.last_mut() {
+                        Some(Some(n)) => {
+                            *n += 1;
+                            let marker = format!("{}. ", n);
+                            ctx.out.push_str(&marker);
+                        }
+                        _ => ctx.out.push_str("- "),
+                    }
                     walk_children(node, ctx);
                     return;
                 }
-                "ul" | "ol" => {
+                "ul" => {
                     ctx.open_block();
+                    ctx.list_stack.push(None);
+                    walk_children(node, ctx);
+                    ctx.list_stack.pop();
+                    return;
+                }
+                "ol" => {
+                    ctx.open_block();
+                    ctx.list_stack.push(Some(0));
+                    walk_children(node, ctx);
+                    ctx.list_stack.pop();
+                    return;
+                }
+                "table" | "tr" => {
+                    ctx.open_block();
+                    walk_children(node, ctx);
+                    return;
+                }
+                "td" | "th" => {
+                    // Pipe-separated cells on one row per `tr` — plain rows,
+                    // no alignment header; enough to stop adjacent cell text
+                    // fusing into one word.
+                    if !ctx.out.is_empty() && !ctx.out.ends_with('\n') {
+                        ctx.out.push_str(" | ");
+                    }
                     walk_children(node, ctx);
                     return;
                 }
@@ -583,6 +619,31 @@ mod tests {
     fn test_is_binary_matches_curl_cmd_semantics() {
         assert!(is_binary(&[0x1f, 0x8b, 0x08, 0x00]));
         assert!(!is_binary(b"<html></html>"));
+    }
+
+    #[test]
+    fn test_html_to_markdown_ordered_lists_numbered() {
+        let html = "<html><body><main><ol><li>Alpha</li><li>Beta</li></ol><ul><li>Dash</li></ul></main></body></html>";
+        let md = html_to_markdown(html);
+        assert!(md.contains("1. Alpha"));
+        assert!(md.contains("2. Beta"));
+        assert!(md.contains("- Dash"));
+    }
+
+    #[test]
+    fn test_html_to_markdown_nested_lists_indented() {
+        let html = "<html><body><main><ul><li>Outer<ul><li>Inner</li></ul></li></ul></main></body></html>";
+        let md = html_to_markdown(html);
+        assert!(md.contains("- Outer"));
+        assert!(md.contains("  - Inner"));
+    }
+
+    #[test]
+    fn test_html_to_markdown_table_cells_separated() {
+        let html = "<html><body><main><table><tr><th>Name</th><th>Age</th></tr><tr><td>Ada</td><td>36</td></tr></table></main></body></html>";
+        let md = html_to_markdown(html);
+        assert!(md.contains("Name | Age"), "th cells must not fuse: {md}");
+        assert!(md.contains("Ada | 36"), "td cells must not fuse: {md}");
     }
 
     #[test]

--- a/src/cmds/cloud/web_cmd.rs
+++ b/src/cmds/cloud/web_cmd.rs
@@ -1,0 +1,494 @@
+//! Fetches a URL and converts HTML responses into compact, LLM-friendly Markdown.
+//!
+//! Implements the "RTK Web Hook" proposed in #1426 as a narrow, explicit v1
+//! (`rtk web <url>`, Option A from the issue) rather than a transparent
+//! `curl` rewrite: HTML pages are full of `<script>`/`<style>`/navigation
+//! noise that costs tokens without adding meaning, but blindly rewriting
+//! every `curl` call risks corrupting JSON/XML/binary responses. Keeping it
+//! an opt-in command sidesteps that risk entirely for v1; automatic rewriting
+//! can be revisited later per the issue's own suggested rollout.
+//!
+//! Mirrors `curl_cmd`'s safety rails: non-HTML content (JSON, XML, plain
+//! text, binary) and any content that fails to look like HTML is passed
+//! through unchanged.
+
+use crate::core::tracking;
+use crate::core::utils::resolved_command;
+use anyhow::{Context, Result};
+use scraper::{ElementRef, Html, Node, Selector};
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::io::Write as _;
+
+pub fn run(args: &[String], verbose: u8) -> Result<i32> {
+    let timer = tracking::TimedExecution::start();
+
+    let Some(url) = args.first() else {
+        eprintln!("Usage: rtk web <url>");
+        return Ok(1);
+    };
+
+    let header_file = tempfile::NamedTempFile::new().context("Failed to create temp file")?;
+
+    let mut cmd = resolved_command("curl");
+    cmd.arg("-s").arg("-L").arg("-D").arg(header_file.path());
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    if verbose > 0 {
+        eprintln!("Running: curl -s -L -D <tmp> {}", args.join(" "));
+    }
+
+    let output = cmd.output().context("Failed to run curl")?;
+    let exit_code = output.status.code().unwrap_or(1);
+
+    // Skip filtering on failure: curl can return an HTML error body that
+    // would be misleading to summarize, and we want the real exit code
+    // surfaced (mirrors curl_cmd's failure handling).
+    if !output.status.success() {
+        let stderr_str = String::from_utf8_lossy(&output.stderr);
+        let stdout_str = String::from_utf8_lossy(&output.stdout);
+        let msg = if stderr_str.trim().is_empty() {
+            stdout_str.trim().to_string()
+        } else {
+            stderr_str.trim().to_string()
+        };
+        eprintln!("FAILED: web {}", msg);
+        return Ok(exit_code);
+    }
+
+    // Binary detection first: from_utf8_lossy would corrupt any non-UTF-8
+    // payload (images, archives, ...) by replacing invalid bytes with U+FFFD.
+    if is_binary(&output.stdout) {
+        std::io::stdout()
+            .write_all(&output.stdout)
+            .context("Failed to write response to stdout")?;
+        timer.track_passthrough(&format!("curl {}", url), &format!("rtk web {}", url));
+        return Ok(exit_code);
+    }
+
+    let raw = String::from_utf8_lossy(&output.stdout).into_owned();
+    let headers = std::fs::read_to_string(header_file.path()).unwrap_or_default();
+
+    // Non-goal for v1 (#1426): only HTML is transformed. JSON, XML, plain
+    // text and anything else passes through byte-for-byte.
+    if !looks_like_html(&headers, &raw) {
+        print!("{raw}");
+        std::io::stdout().flush().ok();
+        timer.track_passthrough(&format!("curl {}", url), &format!("rtk web {}", url));
+        return Ok(exit_code);
+    }
+
+    let markdown = html_to_markdown(&raw);
+    print!("{markdown}");
+    std::io::stdout().flush().ok();
+    timer.track(
+        &format!("curl {}", url),
+        &format!("rtk web {}", url),
+        &raw,
+        &markdown,
+    );
+
+    Ok(exit_code)
+}
+
+/// Returns `true` if `bytes` is not valid UTF-8 (see `curl_cmd::is_binary` —
+/// duplicated rather than shared because the two modules are expected to
+/// diverge further, e.g. `web` will eventually sniff more content types).
+fn is_binary(bytes: &[u8]) -> bool {
+    std::str::from_utf8(bytes).is_err()
+}
+
+/// Decides whether `body` should go through the HTML->Markdown pipeline.
+///
+/// Prefers the `Content-Type` header from the *final* response in the
+/// redirect chain (curl's `-D` with `-L` appends one header block per hop).
+/// Falls back to sniffing the body for a small set of unambiguous HTML
+/// signals when no usable header is present — e.g. a proxy stripped it, or
+/// the server just didn't send one.
+fn looks_like_html(headers: &str, body: &str) -> bool {
+    if let Some(content_type) = last_header_value(headers, "content-type") {
+        let content_type = content_type.to_ascii_lowercase();
+        if content_type.contains("html") {
+            return true;
+        }
+        // Explicit non-HTML content type: trust it over body sniffing so a
+        // JSON/XML API response is never misdetected as HTML because it
+        // happens to contain a "<" character somewhere in a string value.
+        if !content_type.is_empty() {
+            return false;
+        }
+    }
+
+    let trimmed = body.trim_start();
+    let head: String = trimmed.chars().take(512).collect::<String>().to_ascii_lowercase();
+    head.contains("<!doctype html") || head.contains("<html")
+}
+
+/// Returns the value of the last occurrence of `name` across all header
+/// blocks in `headers` (one block per redirect hop), case-insensitive.
+fn last_header_value(headers: &str, name: &str) -> Option<String> {
+    let normalized = headers.replace("\r\n", "\n");
+    let last_block = normalized
+        .split("\n\n")
+        .map(str::trim)
+        .filter(|block| !block.is_empty())
+        .last()?;
+
+    let prefix = format!("{}:", name.to_ascii_lowercase());
+    last_block.lines().find_map(|line| {
+        let lower = line.to_ascii_lowercase();
+        lower
+            .starts_with(&prefix)
+            .then(|| line[prefix.len()..].trim().to_string())
+    })
+}
+
+/// Tags whose entire subtree carries no reader-facing content.
+const SKIP_SUBTREE: &[&str] = &[
+    "script",
+    "style",
+    "noscript",
+    "template",
+    "head",
+    "iframe",
+    "svg",
+    "form",
+    "button",
+    "nav",
+    "footer",
+    "aside",
+];
+
+/// Converts an HTML document into compact Markdown: strips non-content
+/// subtrees, extracts the main content container, preserves headings /
+/// lists / code blocks / emphasis, and de-duplicates links into numbered
+/// references (`[1]`, `[2]`, ...) instead of repeating long URLs inline.
+///
+/// html5ever-backed parsing (via `scraper`) never fails hard on malformed
+/// markup — it degrades gracefully instead of erroring — so this always
+/// returns a String; there is no fallible path to a raw-passthrough here.
+fn html_to_markdown(raw: &str) -> String {
+    let document = Html::parse_document(raw);
+    let root = select_main_content(&document);
+
+    let mut ctx = MarkdownContext::default();
+    walk(*root, &mut ctx);
+    ctx.finish()
+}
+
+fn select_main_content(document: &Html) -> ElementRef<'_> {
+    for selector in ["main", "article", "[role=\"main\"]"] {
+        if let Some(el) = Selector::parse(selector)
+            .ok()
+            .and_then(|s| document.select(&s).next())
+        {
+            return el;
+        }
+    }
+    Selector::parse("body")
+        .ok()
+        .and_then(|s| document.select(&s).next())
+        .unwrap_or_else(|| document.root_element())
+}
+
+#[derive(Default)]
+struct MarkdownContext {
+    out: String,
+    links: Vec<String>,
+    link_index: HashMap<String, usize>,
+    in_pre: usize,
+}
+
+impl MarkdownContext {
+    /// Ensures the next write starts on a fresh paragraph (single blank
+    /// line between blocks, never more, regardless of how much trailing
+    /// whitespace the source HTML had).
+    fn open_block(&mut self) {
+        let trimmed = self.out.trim_end_matches(' ');
+        let extra_newlines = trimmed.len() - trimmed.trim_end_matches('\n').len();
+        self.out.truncate(trimmed.trim_end_matches('\n').len());
+        if !self.out.is_empty() {
+            self.out.push('\n');
+            self.out.push('\n');
+        }
+        let _ = extra_newlines; // trailing newlines already normalized above
+    }
+
+    fn push_inline(&mut self, text: &str) {
+        if self.in_pre > 0 {
+            self.out.push_str(text);
+            return;
+        }
+        // HTML collapses runs of whitespace (including newlines) to a
+        // single space outside <pre>; replicate that here.
+        let collapsed = text.split_whitespace().collect::<Vec<_>>().join(" ");
+        if collapsed.is_empty() {
+            return;
+        }
+        let needs_space = text.starts_with(char::is_whitespace)
+            && !self.out.is_empty()
+            && !self.out.ends_with(['\n', ' ']);
+        if needs_space {
+            self.out.push(' ');
+        }
+        self.out.push_str(&collapsed);
+    }
+
+    fn link_ref(&mut self, href: &str) -> usize {
+        if let Some(&idx) = self.link_index.get(href) {
+            return idx;
+        }
+        self.links.push(href.to_string());
+        let idx = self.links.len();
+        self.link_index.insert(href.to_string(), idx);
+        idx
+    }
+
+    fn finish(self) -> String {
+        let body = self.out.trim().to_string();
+        if self.links.is_empty() {
+            return body;
+        }
+        let mut out = body;
+        out.push_str("\n\n");
+        for (i, href) in self.links.iter().enumerate() {
+            let _ = writeln!(out, "[{}] {}", i + 1, href);
+        }
+        out
+    }
+}
+
+fn walk(node: ego_tree::NodeRef<'_, Node>, ctx: &mut MarkdownContext) {
+    match node.value() {
+        Node::Text(text) => ctx.push_inline(text),
+        Node::Element(el) => {
+            let tag = el.name();
+            if SKIP_SUBTREE.contains(&tag) {
+                return;
+            }
+
+            match tag {
+                "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => {
+                    ctx.open_block();
+                    let level = tag.as_bytes()[1] - b'0';
+                    ctx.out.push_str(&"#".repeat(level as usize));
+                    ctx.out.push(' ');
+                    walk_children(node, ctx);
+                    return;
+                }
+                "p" | "div" | "section" | "article" | "main" | "blockquote" => {
+                    ctx.open_block();
+                    walk_children(node, ctx);
+                    return;
+                }
+                "li" => {
+                    ctx.open_block();
+                    ctx.out.push_str("- ");
+                    walk_children(node, ctx);
+                    return;
+                }
+                "ul" | "ol" => {
+                    ctx.open_block();
+                    walk_children(node, ctx);
+                    return;
+                }
+                "pre" => {
+                    ctx.open_block();
+                    ctx.out.push_str("```\n");
+                    ctx.in_pre += 1;
+                    walk_children(node, ctx);
+                    ctx.in_pre -= 1;
+                    ctx.out.push_str("\n```");
+                    return;
+                }
+                "code" if ctx.in_pre == 0 => {
+                    ctx.out.push('`');
+                    walk_children(node, ctx);
+                    ctx.out.push('`');
+                    return;
+                }
+                "strong" | "b" => {
+                    ctx.out.push_str("**");
+                    walk_children(node, ctx);
+                    ctx.out.push_str("**");
+                    return;
+                }
+                "em" | "i" => {
+                    ctx.out.push('*');
+                    walk_children(node, ctx);
+                    ctx.out.push('*');
+                    return;
+                }
+                "br" => {
+                    ctx.out.push('\n');
+                    return;
+                }
+                "hr" => {
+                    ctx.open_block();
+                    ctx.out.push_str("---");
+                    return;
+                }
+                "a" => {
+                    if let Some(href) = el.attr("href") {
+                        let start = ctx.out.len();
+                        walk_children(node, ctx);
+                        let text = ctx.out[start..].to_string();
+                        ctx.out.truncate(start);
+                        let label = if text.trim().is_empty() {
+                            href.to_string()
+                        } else {
+                            text
+                        };
+                        let idx = ctx.link_ref(href);
+                        let _ = write!(ctx.out, "[{}][{}]", label, idx);
+                        return;
+                    }
+                }
+                _ => {}
+            }
+        }
+        _ => {}
+    }
+    walk_children(node, ctx);
+}
+
+fn walk_children(node: ego_tree::NodeRef<'_, Node>, ctx: &mut MarkdownContext) {
+    for child in node.children() {
+        walk(child, ctx);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_looks_like_html_from_content_type_header() {
+        let headers = "HTTP/1.1 200 OK\nContent-Type: text/html; charset=utf-8\n\n";
+        assert!(looks_like_html(headers, "irrelevant"));
+    }
+
+    #[test]
+    fn test_looks_like_html_rejects_json_content_type() {
+        let headers = "HTTP/1.1 200 OK\nContent-Type: application/json\n\n";
+        assert!(!looks_like_html(headers, "<html so this would false-positive on sniff>"));
+    }
+
+    #[test]
+    fn test_looks_like_html_uses_last_redirect_hop() {
+        let headers = "HTTP/1.1 301 Moved\nContent-Type: text/plain\nLocation: /next\n\nHTTP/1.1 200 OK\nContent-Type: text/html\n\n";
+        assert!(looks_like_html(headers, "irrelevant"));
+    }
+
+    #[test]
+    fn test_looks_like_html_sniffs_body_without_header() {
+        assert!(looks_like_html("", "<!DOCTYPE html><html><body>hi</body></html>"));
+        assert!(!looks_like_html("", "{\"key\": \"value\"}"));
+    }
+
+    #[test]
+    fn test_html_to_markdown_strips_script_and_style() {
+        let html = r#"<html><head><style>.x{color:red}</style></head>
+            <body><script>alert(1)</script><main><p>Hello world</p></main></body></html>"#;
+        let md = html_to_markdown(html);
+        assert_eq!(md, "Hello world");
+    }
+
+    #[test]
+    fn test_html_to_markdown_headings_and_lists() {
+        let html = r#"<html><body><main>
+            <h1>Title</h1>
+            <ul><li>One</li><li>Two</li></ul>
+        </main></body></html>"#;
+        let md = html_to_markdown(html);
+        assert!(md.contains("# Title"));
+        assert!(md.contains("- One"));
+        assert!(md.contains("- Two"));
+    }
+
+    #[test]
+    fn test_html_to_markdown_dedupes_links_into_references() {
+        let html = r#"<html><body><article>
+            <p><a href="https://example.com/page">first</a></p>
+            <p><a href="https://example.com/page">second</a></p>
+        </article></body></html>"#;
+        let md = html_to_markdown(html);
+        assert!(md.contains("[first][1]"));
+        assert!(md.contains("[second][1]"));
+        assert_eq!(md.matches("https://example.com/page").count(), 1);
+    }
+
+    #[test]
+    fn test_html_to_markdown_prefers_main_over_nav() {
+        let html = r#"<html><body>
+            <nav><a href="/a">Nav link</a></nav>
+            <main><p>Real content</p></main>
+            <footer>Copyright</footer>
+        </body></html>"#;
+        let md = html_to_markdown(html);
+        assert!(md.contains("Real content"));
+        assert!(!md.contains("Nav link"));
+        assert!(!md.contains("Copyright"));
+    }
+
+    #[test]
+    fn test_html_to_markdown_preserves_code_blocks() {
+        let html = r#"<html><body><main><pre><code>fn main() {}</code></pre></main></body></html>"#;
+        let md = html_to_markdown(html);
+        assert!(md.contains("```"));
+        assert!(md.contains("fn main() {}"));
+    }
+
+    #[test]
+    fn test_html_to_markdown_never_panics_on_malformed_html() {
+        let inputs = [
+            "<html><body><p>unclosed",
+            "<div><span><p></div></span>",
+            "not html at all, just text",
+            "",
+            "<html>&amp;&lt;broken&gt;entities&amp;</html>",
+        ];
+        for input in inputs {
+            let _ = html_to_markdown(input);
+        }
+    }
+
+    #[test]
+    fn test_is_binary_matches_curl_cmd_semantics() {
+        assert!(is_binary(&[0x1f, 0x8b, 0x08, 0x00]));
+        assert!(!is_binary(b"<html></html>"));
+    }
+
+    /// A page-shaped fixture — nav/header/footer chrome, inline scripts and
+    /// styles, and repeated long links around a real content block — is the
+    /// exact scenario #1426 exists to fix. Verified against live pages during
+    /// development (example.com ~69%, a Wikipedia article ~83%); this fixture
+    /// pins a deterministic floor so the savings claim doesn't regress silently.
+    #[test]
+    fn test_html_to_markdown_meets_token_savings_floor() {
+        let raw = include_str!("web_cmd_fixture.html");
+        let markdown = html_to_markdown(raw);
+
+        let count_tokens = |s: &str| s.split_whitespace().count();
+        let input_tokens = count_tokens(raw);
+        let output_tokens = count_tokens(&markdown);
+        let savings = 100.0 - (output_tokens as f64 / input_tokens as f64 * 100.0);
+
+        assert!(
+            savings >= 60.0,
+            "web: expected >=60% token savings, got {:.1}% ({} -> {} tokens)",
+            savings,
+            input_tokens,
+            output_tokens
+        );
+        assert!(markdown.contains("Article Heading"));
+        assert!(markdown.contains("first paragraph"));
+        assert!(!markdown.contains("Home"), "nav chrome should be stripped");
+        assert!(
+            !markdown.contains("Copyright"),
+            "footer chrome should be stripped"
+        );
+    }
+}

--- a/src/cmds/cloud/web_cmd.rs
+++ b/src/cmds/cloud/web_cmd.rs
@@ -234,6 +234,57 @@ const SKIP_SUBTREE: &[&str] = &[
     "aside",
 ];
 
+/// ARIA landmark roles that mark a subtree as page chrome rather than
+/// content — the attribute-level equivalent of the `nav`/`footer`/`aside`
+/// entries in [`SKIP_SUBTREE`], for sites that use `<div role="navigation">`
+/// instead of semantic tags.
+const SKIP_ROLES: &[&str] = &[
+    "navigation",
+    "banner",
+    "complementary",
+    "contentinfo",
+    "search",
+];
+
+/// id/class tokens that mark an element as page chrome (what readability
+/// implementations score down). Matched against whole tokens after splitting
+/// on whitespace, `-` and `_`, so `mw-footer` and `vector-menu` are skipped
+/// while `navy-blue` (token `navy`) survives.
+const SKIP_CLASS_TOKENS: &[&str] = &[
+    "nav",
+    "navbar",
+    "navigation",
+    "menu",
+    "dropdown",
+    "sidebar",
+    "breadcrumb",
+    "breadcrumbs",
+    "banner",
+    "cookie",
+    "cookies",
+    "footer",
+    "toc",
+];
+
+/// Returns `true` when an element's attributes identify it as page chrome
+/// (navigation, banners, cookie bars, ...) that should be pruned wholesale.
+fn is_chrome_element(el: &scraper::node::Element) -> bool {
+    if let Some(role) = el.attr("role") {
+        let role = role.to_ascii_lowercase();
+        if SKIP_ROLES.contains(&role.as_str()) {
+            return true;
+        }
+    }
+    ["id", "class"].iter().any(|attr| {
+        el.attr(attr).is_some_and(|value| {
+            let lower = value.to_ascii_lowercase();
+            lower
+                .split(|c: char| c.is_whitespace() || c == '-' || c == '_')
+                .any(|token| SKIP_CLASS_TOKENS.contains(&token))
+        })
+    })
+}
+
 /// Converts an HTML document into compact Markdown: strips non-content
 /// subtrees, extracts the main content container, preserves headings /
 /// lists / code blocks / emphasis, and de-duplicates links into numbered
@@ -338,7 +389,7 @@ fn walk(node: ego_tree::NodeRef<'_, Node>, ctx: &mut MarkdownContext) {
         Node::Text(text) => ctx.push_inline(text),
         Node::Element(el) => {
             let tag = el.name();
-            if SKIP_SUBTREE.contains(&tag) {
+            if SKIP_SUBTREE.contains(&tag) || is_chrome_element(el) {
                 return;
             }
 
@@ -532,6 +583,24 @@ mod tests {
     fn test_is_binary_matches_curl_cmd_semantics() {
         assert!(is_binary(&[0x1f, 0x8b, 0x08, 0x00]));
         assert!(!is_binary(b"<html></html>"));
+    }
+
+    #[test]
+    fn test_html_to_markdown_skips_chrome_by_class_id_and_role() {
+        let html = r#"<html><body><main>
+            <div class="vector-menu mw-portlet">Language switcher junk</div>
+            <div id="site-footer-inner">Footer junk</div>
+            <div role="navigation">More nav junk</div>
+            <div class="navy-blue">Navy blue is fine</div>
+            <p>Article text</p>
+        </main></body></html>"#;
+        let md = html_to_markdown(html);
+        assert!(md.contains("Article text"));
+        assert!(
+            md.contains("Navy blue is fine"),
+            "token matching must not fire on substrings like navy"
+        );
+        assert!(!md.contains("junk"));
     }
 
     #[test]

--- a/src/cmds/cloud/web_cmd.rs
+++ b/src/cmds/cloud/web_cmd.rs
@@ -16,6 +16,7 @@ use crate::core::runner;
 use crate::core::tracking;
 use crate::core::utils::{exit_code_from_output, resolved_command};
 use anyhow::{Context, Result};
+use encoding_rs::{Encoding, UTF_8, WINDOWS_1252};
 use scraper::{ElementRef, Html, Node, Selector};
 use std::collections::HashMap;
 use std::fmt::Write as _;
@@ -64,26 +65,45 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         return Ok(exit_code);
     }
 
-    // Binary detection first: from_utf8_lossy would corrupt any non-UTF-8
-    // payload (images, archives, ...) by replacing invalid bytes with U+FFFD.
-    if is_binary(&output.stdout) {
-        std::io::stdout()
-            .write_all(&output.stdout)
-            .context("Failed to write response to stdout")?;
-        timer.track_passthrough(&format!("curl {}", url), &format!("rtk web {}", url));
+    let headers = std::fs::read_to_string(header_file.path()).unwrap_or_default();
+
+    // HTML detection must happen BEFORE the binary check: a legacy-charset
+    // page (windows-1250/1252, shift_jis, ...) contains non-UTF-8 bytes and
+    // would otherwise be misclassified as binary and dumped raw — silently
+    // producing zero savings on exactly the pages this command exists for.
+    // The sniff prefix is lossy-decoded, which is safe because every signal
+    // it looks for (doctype, `<html`, `charset=`) is pure ASCII and legacy
+    // encodings are ASCII-compatible.
+    let sniff_prefix = String::from_utf8_lossy(&output.stdout[..output.stdout.len().min(1024)]);
+
+    if !looks_like_html(&headers, &sniff_prefix) {
+        // Non-goal for v1 (#1426): only HTML is transformed. JSON, XML, plain
+        // text and binary all pass through byte-for-byte. Binary must bypass
+        // the lossy conversion that would corrupt it with U+FFFD.
+        if is_binary(&output.stdout) {
+            std::io::stdout()
+                .write_all(&output.stdout)
+                .context("Failed to write response to stdout")?;
+            timer.track_passthrough(&format!("curl {}", url), &format!("rtk web {}", url));
+            return Ok(exit_code);
+        }
+        let raw = String::from_utf8_lossy(&output.stdout).into_owned();
+        let shown = runner::emit_guarded(&raw, None, &raw);
+        timer.track(
+            &format!("curl {}", url),
+            &format!("rtk web {}", url),
+            &raw,
+            &shown,
+        );
         return Ok(exit_code);
     }
 
-    let raw = String::from_utf8_lossy(&output.stdout).into_owned();
-    let headers = std::fs::read_to_string(header_file.path()).unwrap_or_default();
-
-    // Non-goal for v1 (#1426): only HTML is transformed. JSON, XML, plain
-    // text and anything else passes through byte-for-byte.
-    let content = if looks_like_html(&headers, &raw) {
-        html_to_markdown(&raw)
-    } else {
-        raw.clone()
-    };
+    let encoding = detect_encoding(&headers, &output.stdout);
+    // decode() never fails — undecodable byte sequences become U+FFFD — and
+    // handles a BOM (which overrides the detected label, per the standard).
+    let (decoded, _, _) = encoding.decode(&output.stdout);
+    let raw = decoded.into_owned();
+    let content = html_to_markdown(&raw);
 
     // `emit_guarded` applies the same never-worse safety net `curl_cmd` uses
     // (see `core::guard::never_worse`): if the Markdown conversion ever came
@@ -151,6 +171,51 @@ fn last_header_value(headers: &str, name: &str) -> Option<String> {
             .starts_with(&prefix)
             .then(|| line[prefix.len()..].trim().to_string())
     })
+}
+
+/// Resolves the encoding to decode an HTML body with, in standard priority
+/// order: `charset=` in the Content-Type header, then a `<meta charset>` /
+/// `http-equiv` declaration in the first 1024 bytes (a simplified version of
+/// the WHATWG prescan), then UTF-8 if the body validates as it, and finally
+/// windows-1252 — the Encoding Standard's fallback for undeclared legacy
+/// content, matching what browsers do.
+fn detect_encoding(headers: &str, body: &[u8]) -> &'static Encoding {
+    let header_charset = last_header_value(headers, "content-type")
+        .and_then(|ct| extract_charset(&ct))
+        .and_then(|label| Encoding::for_label(label.as_bytes()));
+    if let Some(enc) = header_charset {
+        return enc;
+    }
+
+    // Legacy encodings are ASCII-compatible, so a lossy prefix is safe for
+    // locating the (pure-ASCII) meta declaration.
+    let prefix = String::from_utf8_lossy(&body[..body.len().min(1024)]);
+    if let Some(enc) = extract_charset(&prefix).and_then(|label| Encoding::for_label(label.as_bytes()))
+    {
+        return enc;
+    }
+
+    if std::str::from_utf8(body).is_ok() {
+        UTF_8
+    } else {
+        WINDOWS_1252
+    }
+}
+
+/// Pulls the value of the first `charset=` occurrence out of `text` (a
+/// Content-Type header value or an HTML prefix), tolerating optional quotes
+/// and whitespace. Returns `None` when no declaration is present.
+fn extract_charset(text: &str) -> Option<String> {
+    let lower = text.to_ascii_lowercase();
+    let start = lower.find("charset")? + "charset".len();
+    let rest = lower[start..].trim_start();
+    let rest = rest.strip_prefix('=')?.trim_start();
+    let rest = rest.trim_start_matches(['"', '\'']);
+    let end = rest
+        .find(|c: char| c == '"' || c == '\'' || c == ';' || c == '>' || c.is_whitespace())
+        .unwrap_or(rest.len());
+    let label = rest[..end].trim();
+    (!label.is_empty()).then(|| label.to_string())
 }
 
 /// Tags whose entire subtree carries no reader-facing content.
@@ -467,6 +532,72 @@ mod tests {
     fn test_is_binary_matches_curl_cmd_semantics() {
         assert!(is_binary(&[0x1f, 0x8b, 0x08, 0x00]));
         assert!(!is_binary(b"<html></html>"));
+    }
+
+    #[test]
+    fn test_extract_charset_variants() {
+        assert_eq!(
+            extract_charset("text/html; charset=utf-8").as_deref(),
+            Some("utf-8")
+        );
+        assert_eq!(
+            extract_charset("text/html; charset=\"windows-1250\"").as_deref(),
+            Some("windows-1250")
+        );
+        assert_eq!(
+            extract_charset("<meta charset='iso-8859-2'>").as_deref(),
+            Some("iso-8859-2")
+        );
+        assert_eq!(extract_charset("text/html"), None);
+    }
+
+    #[test]
+    fn test_detect_encoding_header_charset_wins_over_meta() {
+        let headers = "HTTP/1.1 200 OK\nContent-Type: text/html; charset=windows-1250\n\n";
+        let body = b"<meta charset=\"utf-8\"><p>x</p>";
+        assert_eq!(detect_encoding(headers, body).name(), "windows-1250");
+    }
+
+    #[test]
+    fn test_detect_encoding_meta_fallback_when_header_has_no_charset() {
+        let headers = "HTTP/1.1 200 OK\nContent-Type: text/html\n\n";
+        let body =
+            b"<!DOCTYPE html><meta http-equiv=\"Content-Type\" content=\"text/html; charset=windows-1250\">";
+        assert_eq!(detect_encoding(headers, body).name(), "windows-1250");
+    }
+
+    #[test]
+    fn test_detect_encoding_utf8_then_1252_fallback() {
+        let headers = "HTTP/1.1 200 OK\nContent-Type: text/html\n\n";
+        assert_eq!(
+            detect_encoding(headers, b"<html>plain ascii</html>").name(),
+            "UTF-8"
+        );
+        // 0xE9 = 'e-acute' in windows-1252 — an invalid byte sequence as UTF-8.
+        assert_eq!(
+            detect_encoding(headers, b"<html>caf\xE9</html>").name(),
+            "windows-1252"
+        );
+    }
+
+    /// The regression this phase exists for: a windows-1250 page contains
+    /// non-UTF-8 bytes, so the old order (binary check before HTML detection)
+    /// dumped it raw with zero savings. Decoding must produce correct Czech
+    /// diacritics, not U+FFFD.
+    #[test]
+    fn test_windows_1250_page_converts_instead_of_passthrough() {
+        let html = "<html><body><main><p>Příliš žluťoučký kůň úpěl ďábelské ódy</p></main></body></html>";
+        let (bytes, _, _) = encoding_rs::WINDOWS_1250.encode(html);
+        assert!(
+            is_binary(&bytes),
+            "fixture must be non-UTF-8 or it proves nothing"
+        );
+        let headers = "HTTP/1.1 200 OK\nContent-Type: text/html; charset=windows-1250\n\n";
+        let sniff = String::from_utf8_lossy(&bytes[..bytes.len().min(1024)]);
+        assert!(looks_like_html(headers, &sniff));
+        let (decoded, _, _) = detect_encoding(headers, &bytes).decode(&bytes);
+        let md = html_to_markdown(&decoded);
+        assert_eq!(md, "Příliš žluťoučký kůň úpěl ďábelské ódy");
     }
 
     /// A page-shaped fixture — nav/header/footer chrome, inline scripts and

--- a/src/cmds/cloud/web_cmd_fixture.html
+++ b/src/cmds/cloud/web_cmd_fixture.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Example Article Page</title>
+    <meta name="description" content="A fixture page shaped like a typical blog/docs article, used to pin the #1426 token-savings floor for `rtk web`.">
+    <style>
+        :root { --bg: #ffffff; --fg: #111111; --accent: #3366cc; }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; color: var(--fg); background: var(--bg); }
+        header.site-header { display: flex; justify-content: space-between; align-items: center; padding: 1rem 2rem; border-bottom: 1px solid #eee; }
+        nav.main-nav ul { display: flex; list-style: none; gap: 1.5rem; }
+        nav.main-nav a { text-decoration: none; color: var(--fg); font-weight: 600; }
+        main { max-width: 720px; margin: 0 auto; padding: 2rem; }
+        article h1 { font-size: 2rem; margin-bottom: 1rem; }
+        article p { line-height: 1.6; margin-bottom: 1rem; }
+        aside.sidebar { float: right; width: 240px; padding: 1rem; background: #f7f7f7; }
+        footer.site-footer { padding: 2rem; border-top: 1px solid #eee; color: #666; font-size: 0.85rem; }
+        .cta-button { display: inline-block; padding: 0.5rem 1rem; background: var(--accent); color: #fff; border-radius: 4px; }
+    </style>
+    <script>
+        window.analyticsQueue = window.analyticsQueue || [];
+        function trackEvent(category, action, label) {
+            window.analyticsQueue.push({ category: category, action: action, label: label, ts: Date.now() });
+            if (window.analyticsQueue.length > 50) {
+                fetch('/collect', { method: 'POST', body: JSON.stringify(window.analyticsQueue) });
+                window.analyticsQueue = [];
+            }
+        }
+        document.addEventListener('DOMContentLoaded', function () {
+            document.querySelectorAll('a').forEach(function (link) {
+                link.addEventListener('click', function () {
+                    trackEvent('outbound', 'click', link.getAttribute('href'));
+                });
+            });
+            var lazyImages = document.querySelectorAll('img[data-src]');
+            lazyImages.forEach(function (img) {
+                img.setAttribute('src', img.getAttribute('data-src'));
+                img.removeAttribute('data-src');
+            });
+        });
+    </script>
+    <script async src="https://cdn.example.com/vendor/tracker.min.js"></script>
+    <noscript>You need JavaScript enabled to see some features of this site.</noscript>
+</head>
+<body>
+    <header class="site-header">
+        <div class="logo">Example Docs</div>
+        <nav class="main-nav">
+            <ul>
+                <li><a href="/home">Home</a></li>
+                <li><a href="/docs">Docs</a></li>
+                <li><a href="/blog">Blog</a></li>
+                <li><a href="/pricing">Pricing</a></li>
+                <li><a href="/about">About</a></li>
+                <li><a href="/contact">Contact</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <article>
+            <h1>Article Heading</h1>
+            <p>This is the first paragraph of the real article content. It explains the topic in plain language so a reader (or a language model) can understand the point of the page without wading through markup.</p>
+            <p>Here is a second paragraph with a link to more information: <a href="https://example.com/docs/reference/very/long/canonical/path/that/repeats/below">read the reference docs</a>. The same link appears again later in the article.</p>
+            <h2>A Subsection</h2>
+            <p>Some supporting detail goes here, including a repeated reference to <a href="https://example.com/docs/reference/very/long/canonical/path/that/repeats/below">the same reference docs</a> so the link-deduplication path is exercised too.</p>
+            <ul>
+                <li>First supporting point</li>
+                <li>Second supporting point</li>
+                <li>Third supporting point</li>
+            </ul>
+            <pre><code>fn example() -&gt; i32 {
+    42
+}</code></pre>
+            <p>A closing paragraph wraps up the article and invites the reader to take an action.</p>
+            <a class="cta-button" href="/signup">Get started</a>
+        </article>
+    </main>
+
+    <aside class="sidebar">
+        <h3>Related links</h3>
+        <ul>
+            <li><a href="/related/one">Related article one</a></li>
+            <li><a href="/related/two">Related article two</a></li>
+            <li><a href="/related/three">Related article three</a></li>
+        </ul>
+    </aside>
+
+    <footer class="site-footer">
+        <p>Copyright 2026 Example Docs. All rights reserved.</p>
+        <nav>
+            <ul>
+                <li><a href="/privacy">Privacy Policy</a></li>
+                <li><a href="/terms">Terms of Service</a></li>
+                <li><a href="/security">Security</a></li>
+                <li><a href="/sitemap.xml">Sitemap</a></li>
+            </ul>
+        </nav>
+    </footer>
+    <script>
+        trackEvent('page', 'view', window.location.pathname);
+    </script>
+</body>
+</html>

--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -301,6 +301,7 @@ const RUST_HANDLED_COMMANDS: &[&str] = &[
     "npm",
     "npx",
     "curl",
+    "web",
     "discover",
     "ruff",
     "pytest",

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod learn;
 mod parser;
 
 // Re-export command modules for routing
-use cmds::cloud::{aws_cmd, container, curl_cmd, psql_cmd, wget_cmd};
+use cmds::cloud::{aws_cmd, container, curl_cmd, psql_cmd, web_cmd, wget_cmd};
 use cmds::dotnet::{binlog, dotnet_cmd, dotnet_format_report, dotnet_trx};
 use cmds::git::{diff_cmd, gh_cmd, git, glab_cmd, gt_cmd};
 use cmds::go::{go_cmd, golangci_cmd};
@@ -557,6 +557,13 @@ enum Commands {
     /// Curl with auto-JSON detection and schema output
     Curl {
         /// Curl arguments (URL + options)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// Fetch a URL and convert HTML responses to compact Markdown (#1426)
+    Web {
+        /// URL to fetch (plus optional curl-compatible flags)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -2180,6 +2187,8 @@ fn run_cli() -> Result<i32> {
 
         Commands::Curl { args } => curl_cmd::run(&args, cli.verbose)?,
 
+        Commands::Web { args } => web_cmd::run(&args, cli.verbose)?,
+
         Commands::Discover {
             project,
             limit,
@@ -2665,6 +2674,7 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Npm { .. }
             | Commands::Npx { .. }
             | Commands::Curl { .. }
+            | Commands::Web { .. }
             | Commands::Ruff { .. }
             | Commands::Pytest { .. }
             | Commands::Php { .. }
@@ -3047,6 +3057,7 @@ mod tests {
             "npm",
             "npx",
             "curl",
+            "web",
             "ruff",
             "pytest",
             "mypy",


### PR DESCRIPTION
## Summary

- Adds `rtk web <url>` (#1426): fetches via `curl`, and for `text/html` responses strips `script`/`style`/`nav`/`header`/`footer`/`aside`/`form` noise, extracts the main/article content, and converts it to Markdown with de-duplicated numbered link references (`[1]`, `[2]`, ...) instead of repeated inline URLs
- Implemented as **Option A** from the issue — an explicit opt-in command, not a transparent `curl` rewrite. Non-HTML responses (JSON, XML, binary) pass through byte-for-byte, so existing `rtk curl` behavior for APIs is completely untouched. `web` is intentionally left out of the auto-rewrite patterns in `src/discover/rules.rs` for the same reason, matching the issue's own "Non-goals for v1"
- **Legacy-charset pages decode correctly**: pages in windows-1250/1252, iso-8859-2, shift_jis etc. are detected (header `charset=` → meta prescan → UTF-8 validation → windows-1252 fallback, the Encoding Standard's order) and decoded via `encoding_rs` before conversion — without this they'd be misread as binary and passed through raw with zero savings
- **Page chrome is pruned at attribute level too**: ARIA landmark roles (`navigation`, `banner`, `contentinfo`, ...) and an id/class token blocklist (`nav`, `menu`, `dropdown`, `sidebar`, `cookie`, `footer`, ...) catch div-built navigation that tag-level skipping misses (token-boundary matching: `mw-footer` pruned, `navy-blue` survives)
- New deps: `scraper` + `ego-tree` (both ISC, `rust-scraper` org) and `encoding_rs` (Firefox's WHATWG Encoding implementation, Apache/MIT+BSD, dep tree = `cfg-if` only). html5ever-backed parsing degrades gracefully on malformed HTML instead of erroring, which matters here since this crate builds with `panic = "abort"`

Thanks @talvaknin744 for the detailed proposal — this follows your suggested v1 scope closely (explicit command, HTML-only, raw output on parse failure, non-goals respected: no JS rendering, no full reader-mode heuristics, no LLM summarization).

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test` — clean, 2391 tests passing (0 regressions)
- [x] `bash scripts/check-test-presence.sh` passes; the repo's dangerous-patterns grep (`Command::new("sh")`, `unwrap()`, `panic!`, `unsafe`, etc.) comes back clean on this diff
- [x] Manual testing against **live** URLs; token numbers recorded by rtk's own tracking (`rtk gain`), not hand-estimated:

  | URL | Result |
  |---|---|
  | `en.wikipedia.org/wiki/Rust_(programming_language)` | 247,523 → 42,311 tokens (**82.9% saved**); after chrome-pruning the 53-entry language-nav list is gone and output shrank a further ~13% (169K → 148K chars) with article body intact |
  | local server, `Content-Type: text/html; charset=windows-1250` | body confirmed non-UTF-8; decodes to correct Czech diacritics and converts to Markdown (previously: raw passthrough, zero savings) |
  | `example.com` | 140 → 44 tokens (68.6% saved) |
  | `jsonplaceholder.typicode.com/todos/1` (control — must NOT be transformed) | passthrough byte-identical, confirmed |

- [x] Deterministic fixture test (`web_cmd_fixture.html`: nav/header/footer/script/style noise around a real article) pins a **>=60% savings floor** in CI without requiring network access — currently passing at 72.2%
- [x] Signal-killed curl propagates `128+signal` via the shared `exit_code_from_output()` helper (same bug class as #2681), and output goes through the `never_worse` guard (#2551/#2554) so `rtk web` can never emit more tokens than plain `curl`
- [x] Tables render as pipe-separated rows (adjacent `td` text no longer fuses into one word) and `ol` lists number `1.` `2.` with nested-list indentation

Fixes #1426
