### PR TITLE
feat: harden permissions for local history DB and tee logs

### DIFF
--- a/src/core/fs_perms.rs
+++ b/src/core/fs_perms.rs
@@ -1,0 +1,61 @@
+//! Best-effort restrictive permissions for RTK-owned local data.
+//!
+//! On Windows, RTK relies on per-user local app-data ACLs.
+
+use std::path::Path;
+
+/// Restrict a file RTK writes to owner read/write on Unix.
+pub fn restrict_file(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+    }
+
+    #[cfg(not(unix))]
+    let _ = path;
+}
+
+/// Restrict an RTK-owned directory to owner-only access on Unix.
+///
+/// Callers must only pass RTK's default local-data directories, not user-configured paths.
+pub fn restrict_dir(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700));
+    }
+
+    #[cfg(not(unix))]
+    let _ = path;
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn test_restrict_file_sets_owner_read_write() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let path = tmpdir.path().join("history.db");
+        std::fs::write(&path, "test").unwrap();
+
+        restrict_file(&path);
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn test_restrict_dir_sets_owner_only() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let path = tmpdir.path().join("rtk");
+        std::fs::create_dir(&path).unwrap();
+
+        restrict_dir(&path);
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700);
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod constants;
 pub mod display_helpers;
 pub mod filter;
+pub mod fs_perms;
 pub mod guard;
 pub mod runner;
 pub mod stream;

--- a/src/core/tee.rs
+++ b/src/core/tee.rs
@@ -1,6 +1,7 @@
 //! Raw output recovery -- saves unfiltered output to disk on command failure.
 
 use super::constants::RTK_DATA_DIR;
+use super::fs_perms;
 use crate::core::config::Config;
 use std::path::PathBuf;
 
@@ -47,7 +48,15 @@ fn get_tee_dir(config: &Config) -> Option<PathBuf> {
     }
 
     // Default: ~/.local/share/rtk/tee/
+    default_tee_dir()
+}
+
+fn default_tee_dir() -> Option<PathBuf> {
     dirs::data_local_dir().map(|d| d.join(RTK_DATA_DIR).join("tee"))
+}
+
+fn default_data_dir() -> Option<PathBuf> {
+    dirs::data_local_dir().map(|d| d.join(RTK_DATA_DIR))
 }
 
 /// Rotate old tee files: keep only the last `max_files`, delete oldest.
@@ -112,6 +121,14 @@ fn write_tee_file(
     max_files: usize,
 ) -> Option<PathBuf> {
     std::fs::create_dir_all(tee_dir).ok()?;
+    if default_tee_dir().as_deref() == Some(tee_dir) {
+        if let Some(parent) = tee_dir.parent() {
+            if default_data_dir().as_deref() == Some(parent) {
+                fs_perms::restrict_dir(parent);
+            }
+        }
+        fs_perms::restrict_dir(tee_dir);
+    }
 
     let slug = sanitize_slug(command_slug);
     let epoch = std::time::SystemTime::now()
@@ -139,6 +156,7 @@ fn write_tee_file(
     };
 
     std::fs::write(&filepath, content).ok()?;
+    fs_perms::restrict_file(&filepath);
 
     // Rotate old files
     cleanup_old_files(tee_dir, max_files);

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -62,6 +62,7 @@ fn project_filter_params(project_path: Option<&str>) -> (Option<String>, Option<
 }
 
 use super::constants::{DEFAULT_HISTORY_DAYS, HISTORY_DB, RTK_DATA_DIR};
+use super::fs_perms;
 
 /// Main tracking interface for recording and querying command history.
 ///
@@ -250,6 +251,9 @@ impl Tracker {
         let db_path = get_db_path()?;
         if let Some(parent) = db_path.parent() {
             std::fs::create_dir_all(parent)?;
+            if default_data_dir().as_deref() == Some(parent) {
+                fs_perms::restrict_dir(parent);
+            }
         }
 
         let conn = Connection::open(&db_path)?;
@@ -322,6 +326,10 @@ impl Tracker {
             "CREATE INDEX IF NOT EXISTS idx_pf_timestamp ON parse_failures(timestamp)",
             [],
         )?;
+
+        fs_perms::restrict_file(&db_path);
+        fs_perms::restrict_file(&sqlite_sidecar_path(&db_path, "-wal"));
+        fs_perms::restrict_file(&sqlite_sidecar_path(&db_path, "-shm"));
 
         Ok(Self { conn })
     }
@@ -1235,6 +1243,16 @@ fn get_db_path() -> Result<PathBuf> {
     Ok(data_dir.join(RTK_DATA_DIR).join(HISTORY_DB))
 }
 
+fn default_data_dir() -> Option<PathBuf> {
+    dirs::data_local_dir().map(|d| d.join(RTK_DATA_DIR))
+}
+
+fn sqlite_sidecar_path(db_path: &std::path::Path, suffix: &str) -> PathBuf {
+    let mut path = db_path.as_os_str().to_os_string();
+    path.push(suffix);
+    PathBuf::from(path)
+}
+
 /// Individual parse failure record.
 #[derive(Debug)]
 pub struct ParseFailureRecord {
@@ -1565,6 +1583,18 @@ mod tests {
             db_path.ends_with("rtk/history.db"),
             "expected default path ending with rtk/history.db, got: {}",
             db_path.display()
+        );
+    }
+
+    #[test]
+    fn test_sqlite_sidecar_path_appends_suffix() {
+        assert_eq!(
+            sqlite_sidecar_path(std::path::Path::new("/tmp/rtk-history"), "-wal"),
+            PathBuf::from("/tmp/rtk-history-wal")
+        );
+        assert_eq!(
+            sqlite_sidecar_path(std::path::Path::new("/tmp/history.db"), "-shm"),
+            PathBuf::from("/tmp/history.db-shm")
         );
     }
 


### PR DESCRIPTION
Resolves #1790.

RTK stores privacy-relevant local history and raw tee output under the platform local data directory. In v0.39.0, the tracking DB and tee log paths are created with default filesystem behavior rather than explicit restrictive Unix permissions.

## Summary

-

## Test plan

- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.