### PR TITLE
fix(init): upsert GEMINI.md instead of clobbering user content

### DIFF
--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -3721,8 +3721,19 @@ pub fn run_gemini(
     // 2. Install GEMINI.md (RTK awareness for Gemini)
     if !hook_only {
         let gemini_md_path = gemini_dir.join(GEMINI_MD);
-        // Reuse the same slim RTK awareness content
-        write_if_changed(&gemini_md_path, RTK_SLIM, GEMINI_MD, ctx)?;
+        // Upsert an RTK-owned marker block instead of overwriting the file, so a
+        // user's existing GEMINI.md is preserved (#834).
+        let block = format!(
+            "{RTK_BLOCK_START} v2 -->\n{}\n{RTK_BLOCK_END}",
+            RTK_SLIM.trim()
+        );
+        write_rtk_block(
+            &gemini_md_path,
+            &block,
+            GEMINI_MD,
+            "rtk init -g --gemini",
+            ctx,
+        )?;
     }
 
     // 3. Patch ~/.gemini/settings.json
@@ -3882,16 +3893,30 @@ fn uninstall_gemini(ctx: InitContext) -> Result<Vec<String>> {
         removed.push(format!("Gemini hook: {}", hook_path.display()));
     }
 
-    // Remove GEMINI.md
+    // Remove only the RTK marker block from GEMINI.md, preserving user content (#834).
+    // Delete the file only if nothing but the block was in it.
     let gemini_md = gemini_dir.join(GEMINI_MD);
     if gemini_md.exists() {
-        if dry_run {
-            println!("[dry-run] would remove GEMINI.md: {}", gemini_md.display());
-        } else {
-            fs::remove_file(&gemini_md)
-                .with_context(|| format!("Failed to remove {}", gemini_md.display()))?;
+        let content = fs::read_to_string(&gemini_md)
+            .with_context(|| format!("Failed to read {}", gemini_md.display()))?;
+        if content.contains(RTK_BLOCK_START) {
+            let (cleaned, did_remove) = remove_rtk_block(&content);
+            if did_remove {
+                if dry_run {
+                    println!(
+                        "[dry-run] would remove rtk-instructions block from {}",
+                        gemini_md.display()
+                    );
+                } else if cleaned.trim().is_empty() {
+                    fs::remove_file(&gemini_md)
+                        .with_context(|| format!("Failed to remove {}", gemini_md.display()))?;
+                } else {
+                    atomic_write(&gemini_md, &cleaned)
+                        .with_context(|| format!("Failed to write {}", gemini_md.display()))?;
+                }
+                removed.push(format!("{}: removed rtk-instructions block", GEMINI_MD));
+            }
         }
-        removed.push(format!("GEMINI.md: {}", gemini_md.display()));
     }
 
     // Remove hook from settings.json
@@ -4410,6 +4435,34 @@ mod tests {
         let (content, action) = upsert_rtk_block(&input, RTK_INSTRUCTIONS);
         assert_eq!(action, RtkBlockUpsert::Malformed);
         assert_eq!(content, input);
+    }
+
+    // GEMINI.md install/uninstall must never clobber a user's existing file (#834).
+    #[test]
+    fn test_gemini_md_upsert_and_remove_preserve_user_content() {
+        let user = "# My Gemini notes\n\nDo the thing.";
+        let block = format!(
+            "{RTK_BLOCK_START} v2 -->\n{}\n{RTK_BLOCK_END}",
+            RTK_SLIM.trim()
+        );
+
+        // Install: block appended, user content preserved.
+        let (installed, action) = upsert_rtk_block(user, &block);
+        assert_eq!(action, RtkBlockUpsert::Added);
+        assert!(installed.contains("My Gemini notes"));
+        assert!(installed.contains(RTK_BLOCK_START));
+        assert!(installed.contains("Rust Token Killer"));
+
+        // Re-install is idempotent.
+        let (again, action2) = upsert_rtk_block(&installed, &block);
+        assert_eq!(action2, RtkBlockUpsert::Unchanged);
+        assert_eq!(again, installed);
+
+        // Uninstall: only the block is removed, user content stays.
+        let (removed, did_remove) = remove_rtk_block(&installed);
+        assert!(did_remove);
+        assert!(removed.contains("My Gemini notes"));
+        assert!(!removed.contains(RTK_BLOCK_START));
     }
 
     #[test]


### PR DESCRIPTION
## Problem (#834)

`rtk init -g --gemini` **overwrites** the entire `~/.gemini/GEMINI.md` with RTK's awareness content (`write_if_changed`), destroying any user instructions already in the file. Uninstall is just as destructive — it `fs::remove_file()`s the whole file. Multiple users have hit this data loss (see #834 / #835).

## Fix

Wrap the RTK awareness content in the shared `<!-- rtk-instructions -->` marker block and write it through `write_rtk_block()` — the same append/update-in-place mechanism already used for `CLAUDE.md` and Copilot instructions. Uninstall now strips **only** the marker block via `remove_rtk_block()`, deleting the file solely when nothing else remains.

No new helpers — this reuses `write_rtk_block` / `upsert_rtk_block` / `remove_rtk_block` already on `develop`.

## Verification

Unit test added (`test_gemini_md_upsert_and_remove_preserve_user_content`) + end-to-end against a real `GEMINI.md` with pre-existing user content:

| Step | Result |
|------|--------|
| install | `[ok] Added GEMINI.md` — user content intact, block appended (137 → 1157 bytes) |
| re-install | idempotent — single block, user content intact |
| uninstall | removes only the block; user content preserved byte-for-byte |

`cargo fmt` / `cargo clippy --all-targets` clean; `init` test suite green.

## Credit

Takeover of #835 (abandoned by its author @bnaylor); same approach, rebased onto the current `init.rs`. Credited via `Co-authored-by`.

Closes #834

🤖 Generated with [Claude Code](https://claude.com/claude-code)