### PR TITLE
fix(rewrite): stop rewriting sudo commands (pass them through)

### DIFF
--- a/docs/guide/getting-started/configuration.md
+++ b/docs/guide/getting-started/configuration.md
@@ -92,7 +92,7 @@ Prevent specific commands from being rewritten by the hook:
 exclude_commands = ["git rebase", "git cherry-pick", "docker exec"]
 ```
 
-Patterns match against the full command after stripping env prefixes (`sudo`, `VAR=val`), so `"psql"` excludes both `psql -h localhost` and `PGPASSWORD=x psql -h localhost`.
+Patterns match against the full command after stripping env prefixes (`VAR=val`), so `"psql"` excludes both `psql -h localhost` and `PGPASSWORD=x psql -h localhost`.
 
 Subcommand patterns work too: `"git push"` excludes `git push origin main` but not `git status`.
 

--- a/src/discover/README.md
+++ b/src/discover/README.md
@@ -52,12 +52,12 @@ The classification logic is shared between discover and rewrite — same pattern
 
 ## Env Prefix Handling
 
-The `ENV_PREFIX` regex strips env variable assignments, `sudo`, and `env` from the front of commands. It handles:
+The `ENV_PREFIX` regex strips env variable assignments and `env` from the front of commands. `sudo` is deliberately not stripped, so sudo-prefixed commands stay unclassified and pass through unrewritten. It handles:
 - Unquoted: `FOO=bar`
 - Double-quoted with spaces: `FOO="bar baz"`
 - Single-quoted: `FOO='bar baz'`
 - Escaped quotes: `FOO="he said \"hello\""`
-- Chained: `A="x y" B=1 sudo git status`
+- Chained: `A="x y" B=1 env git status`
 
 The prefix is stripped twice: once in `classify_command()` to match the underlying command against rules, and again in `rewrite_segment()` to extract it for re-prepending to the rewritten command.
 

--- a/src/discover/README.md
+++ b/src/discover/README.md
@@ -27,7 +27,7 @@ When a hook sends `cargo fmt --all && cargo test 2>&1 | tail -20`:
 
 1. Strip trailing redirects (`2>&1`, `>/dev/null`) — matched via lexer tokens, set aside, re-appended after rewriting
 2. Short-circuit special cases — `head -20 file` → `rtk read file --max-lines 20`, `tail -n 5 file` → `rtk read file --tail-lines 5`. These can't go through generic prefix replacement because it would produce `rtk read -20 file` (wrong flag position)
-3. Classify the command — strip env prefixes (`sudo`, `FOO="bar baz"`), normalize paths (`/usr/bin/grep` → `grep`), strip git global opts (`git -C /tmp` → `git`), then match against 60+ regex patterns from `rules.rs`
+3. Classify the command — strip env prefixes (`FOO="bar baz"`), normalize paths (`/usr/bin/grep` → `grep`), strip git global opts (`git -C /tmp` → `git`), then match against 60+ regex patterns from `rules.rs`
 4. Apply the rewrite — find the matching rule, replace the command prefix with `rtk <cmd>`, re-prepend the env prefix, re-append the redirect suffix
 
 **Guards along the way:**

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -61,7 +61,11 @@ lazy_static! {
         let unquoted = r#"[^\s]*"#;
         let env_value = format!("(?:{}|{}|{})", double_quoted, single_quoted, unquoted);
         let env_assign = format!(r#"[A-Z_][A-Z0-9_]*={}"#, env_value);
-        Regex::new(&format!(r#"^(?:sudo\s+|env\s+|{}\s+)+"#, env_assign)).unwrap()
+        // NOTE: `sudo` is intentionally NOT stripped here. Rewriting `sudo docker ps`
+        // to `sudo rtk docker ps` breaks at runtime because `rtk` is not on root's
+        // secure_path, and (where it is) would run rtk itself as root. sudo commands
+        // are left untouched so they pass through unchanged. See #146.
+        Regex::new(&format!(r#"^(?:env\s+|{}\s+)+"#, env_assign)).unwrap()
     };
     // Git global options that appear before the subcommand: -C <path>, -c <key=val>,
     // --git-dir <dir>, --work-tree <dir>, and flag-only options (#163)
@@ -113,7 +117,7 @@ pub fn classify_command(cmd: &str) -> Classification {
         }
     }
 
-    // Strip env prefixes (sudo, env VAR=val, VAR=val)
+    // Strip env prefixes (env VAR=val, VAR=val); sudo is left untouched (#146)
     let stripped = ENV_PREFIX.replace(trimmed, "");
     let cmd_clean = stripped.trim();
     if cmd_clean.is_empty() {
@@ -1156,16 +1160,16 @@ mod tests {
     }
 
     #[test]
-    fn test_classify_sudo_stripped() {
-        assert_eq!(
-            classify_command("sudo docker ps"),
-            Classification::Supported {
-                rtk_equivalent: "rtk docker",
-                category: "Infra",
-                estimated_savings_pct: 85.0,
-                status: RtkStatus::Existing,
+    fn test_classify_sudo_not_stripped() {
+        // sudo is intentionally not stripped: sudo commands stay unclassified so
+        // they pass through unchanged rather than rewriting to a broken `sudo rtk`.
+        match classify_command("sudo docker ps") {
+            Classification::Unsupported { base_command } => {
+                // sudo is not peeled off, so the command is seen as-is (not `docker`).
+                assert_eq!(base_command, "sudo docker");
             }
-        );
+            other => panic!("expected Unsupported, got {:?}", other),
+        }
     }
 
     #[test]
@@ -3588,11 +3592,15 @@ mod tests {
     // --- sudo / env prefix + rewrite ---
 
     #[test]
-    fn test_rewrite_sudo_docker() {
+    fn test_rewrite_sudo_passthrough() {
+        // sudo commands are not rewritten (#146): `sudo rtk …` would fail under
+        // root's secure_path / run rtk as root. They pass through unchanged.
+        assert_eq!(rewrite_command_no_prefixes("sudo docker ps", &[]), None);
         assert_eq!(
-            rewrite_command_no_prefixes("sudo docker ps", &[]),
-            Some("sudo rtk docker ps".into())
+            rewrite_command_no_prefixes("sudo -u root docker ps", &[]),
+            None
         );
+        assert_eq!(rewrite_command_no_prefixes("sudo git status", &[]), None);
     }
 
     #[test]
@@ -4141,8 +4149,17 @@ mod tests {
     #[test]
     fn test_env_prefix_composed_with_builtin() {
         assert_eq!(
+            rewrite_command_no_prefixes("FOO=bar noglob git status", &[]),
+            Some("FOO=bar noglob rtk git status".into())
+        );
+    }
+
+    #[test]
+    fn test_sudo_with_builtin_not_rewritten() {
+        // A leading sudo blocks the rewrite even when a transparent builtin follows.
+        assert_eq!(
             rewrite_command_no_prefixes("sudo noglob git status", &[]),
-            Some("sudo noglob rtk git status".into())
+            None
         );
     }
 

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -66,7 +66,11 @@ static ENV_PREFIX: LazyLock<Regex> = LazyLock::new(|| {
     let unquoted = r#"[^\s]*"#;
     let env_value = format!("(?:{}|{}|{})", double_quoted, single_quoted, unquoted);
     let env_assign = format!(r#"[A-Z_][A-Z0-9_]*={}"#, env_value);
-    Regex::new(&format!(r#"^(?:sudo\s+|env\s+|{}\s+)+"#, env_assign)).unwrap()
+    // NOTE: `sudo` is intentionally NOT stripped here. Rewriting `sudo docker ps`
+    // to `sudo rtk docker ps` breaks at runtime because `rtk` is not on root's
+    // secure_path, and (where it is) would run rtk itself as root. sudo commands
+    // are left untouched so they pass through unchanged. See #146.
+    Regex::new(&format!(r#"^(?:env\s+|{}\s+)+"#, env_assign)).unwrap()
 });
 // Git global options that appear before the subcommand: -C <path>, -c <key=val>,
 // --git-dir <dir>, --work-tree <dir>, and flag-only options (#163)
@@ -122,7 +126,7 @@ pub fn classify_command(cmd: &str) -> Classification {
         }
     }
 
-    // Strip env prefixes (sudo, env VAR=val, VAR=val)
+    // Strip env prefixes (env VAR=val, VAR=val); sudo is left untouched (#146)
     let stripped = ENV_PREFIX.replace(trimmed, "");
     let cmd_clean = stripped.trim();
     if cmd_clean.is_empty() {
@@ -2161,16 +2165,16 @@ mod tests {
     }
 
     #[test]
-    fn test_classify_sudo_stripped() {
-        assert_eq!(
-            classify_command("sudo docker ps"),
-            Classification::Supported {
-                rtk_equivalent: "rtk docker",
-                category: "Infra",
-                estimated_savings_pct: 85.0,
-                status: RtkStatus::Existing,
+    fn test_classify_sudo_not_stripped() {
+        // sudo is intentionally not stripped: sudo commands stay unclassified so
+        // they pass through unchanged rather than rewriting to a broken `sudo rtk`.
+        match classify_command("sudo docker ps") {
+            Classification::Unsupported { base_command } => {
+                // sudo is not peeled off, so the command is seen as-is (not `docker`).
+                assert_eq!(base_command, "sudo docker");
             }
-        );
+            other => panic!("expected Unsupported, got {:?}", other),
+        }
     }
 
     #[test]
@@ -4889,10 +4893,29 @@ mod tests {
     // --- sudo / env prefix + rewrite ---
 
     #[test]
-    fn test_rewrite_sudo_docker() {
+    fn test_rewrite_sudo_passthrough() {
+        // sudo commands are not rewritten (#146): `sudo rtk …` would fail under
+        // root's secure_path / run rtk as root. They pass through unchanged.
+        assert_eq!(rewrite_command_no_prefixes("sudo docker ps", &[]), None);
         assert_eq!(
-            rewrite_command_no_prefixes("sudo docker ps", &[]),
-            Some("sudo rtk docker ps".into())
+            rewrite_command_no_prefixes("sudo -u root docker ps", &[]),
+            None
+        );
+        assert_eq!(rewrite_command_no_prefixes("sudo git status", &[]), None);
+        // The passthrough must also survive an env prefix in front of sudo, a bare
+        // `sudo`, and must not catch `sudoedit` (#3569's motivating cases).
+        assert_eq!(
+            rewrite_command_no_prefixes("FOO=1 sudo docker ps", &[]),
+            None
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("env FOO=1 sudo docker ps", &[]),
+            None
+        );
+        assert_eq!(rewrite_command_no_prefixes("sudo", &[]), None);
+        assert_eq!(
+            rewrite_command_no_prefixes("sudoedit /etc/hosts", &[]),
+            None
         );
     }
 
@@ -5583,8 +5606,17 @@ mod tests {
     #[test]
     fn test_env_prefix_composed_with_builtin() {
         assert_eq!(
+            rewrite_command_no_prefixes("FOO=bar noglob git status", &[]),
+            Some("FOO=bar noglob rtk git status".into())
+        );
+    }
+
+    #[test]
+    fn test_sudo_with_builtin_not_rewritten() {
+        // A leading sudo blocks the rewrite even when a transparent builtin follows.
+        assert_eq!(
             rewrite_command_no_prefixes("sudo noglob git status", &[]),
-            Some("sudo noglob rtk git status".into())
+            None
         );
     }
 

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1404,9 +1404,9 @@ fn rewrite_segment_inner(
     if context == RewriteContext::Normal
         && (cmd_part.starts_with("head -") || cmd_part.starts_with("tail "))
     {
-        // head/tail rewrite to `rtk read`, so honour exclude_commands here too —
-        // this branch returns before the checks below and used to ignore the list.
-        // Any sudo/env prefix has already been peeled by strip_disabled_prefix above.
+        // head/tail rewrite to `rtk read`, so honour exclude_commands here too:
+        // this branch returns before the checks below. Any env prefix has already
+        // been peeled by strip_disabled_prefix above.
         if is_excluded(cmd_part, excluded) {
             return None;
         }
@@ -3049,12 +3049,8 @@ mod tests {
             rewrite_command_no_prefixes("tail -20 src/main.rs", &excluded),
             None
         );
-        // A sudo/env prefix is peeled by strip_disabled_prefix before this branch,
+        // An env prefix is peeled by strip_disabled_prefix before this branch,
         // so the exclusion still applies to the wrapped head/tail.
-        assert_eq!(
-            rewrite_command_no_prefixes("sudo head -20 src/main.rs", &excluded),
-            None
-        );
         assert_eq!(
             rewrite_command_no_prefixes("RUST_LOG=debug tail -20 src/main.rs", &excluded),
             None


### PR DESCRIPTION
## Problem (#146)

The env-prefix stripper (added in the original auto-rewrite hook) treats `sudo` like `env` / `VAR=val` and rewrites `sudo docker ps` → `sudo rtk docker ps`. Two problems:

1. **It breaks the command.** `rtk` installs to `~/.local/bin`, which is **not** on sudo's `secure_path` — so `sudo rtk docker ps` fails with `rtk: command not found` under root. Reported on #146 by a user.
2. **Where rtk *is* on secure_path, it runs rtk as root** — a large parsing/SQLite binary executing with elevated privileges, an unnecessary-privilege footgun for what is only output filtering.

## Fix (option "pass through")

Drop `sudo` from the env-prefix regex. sudo commands are now left **untouched** and pass through unchanged.

- The **permission verdict path is unaffected** — it never used this regex and already matches sudo commands as-is (`sudo:*` rules keep working), so least-privilege behaviour is unchanged.
- `env` / `VAR=val` prefixes and transparent builtins (`noglob`, `command`, …) still rewrite normally.

## Verification

| Input | Before | After |
|-------|--------|-------|
| `sudo docker ps` | `sudo rtk docker ps` (broken under root) | *(pass through)* |
| `sudo -u root docker ps` | *(not handled)* | *(pass through)* |
| `sudo noglob git status` | `sudo noglob rtk git status` | *(pass through)* |
| `env FOO=bar docker ps` | `env FOO=bar rtk docker ps` | unchanged ✅ |
| `FOO=bar docker ps` / `noglob git status` / `docker ps` | rewritten | unchanged ✅ |

Tests updated (`test_classify_sudo_not_stripped`, `test_rewrite_sudo_passthrough`, `test_sudo_with_builtin_not_rewritten`); `cargo fmt` / `cargo clippy --all-targets` clean; full test suite green (2361 passed).

## Note

This is the safe, minimal resolution. A future "real" sudo feature (rtk orchestrating `sudo <cmd>` while staying a non-root process) could be revisited separately if the docker/kubectl-under-sudo savings justify it — but it must never run rtk itself as root.

Refs #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)