### PR TITLE
fix(grep): add regression test for --ultra-compact grep data loss

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3583,6 +3583,34 @@ mod tests {
     }
 
     #[test]
+    fn test_ultra_compact_grep_parses_correctly() {
+        let cli = Cli::try_parse_from([
+            "rtk",
+            "--ultra-compact",
+            "grep",
+            "-r",
+            "permissions",
+            "/tmp/dir",
+        ])
+        .unwrap();
+        assert!(
+            cli.ultra_compact,
+            "--ultra-compact must be parsed as a global flag, not consumed by grep"
+        );
+        match cli.command {
+            Commands::Grep { extra_args, .. } => {
+                assert!(
+                    !extra_args.contains(&"--ultra-compact".to_string()),
+                    "--ultra-compact must not leak into grep extra_args: {:?}",
+                    extra_args
+                );
+                assert_eq!(extra_args, vec!["-r", "permissions", "/tmp/dir"]);
+            }
+            _ => panic!("Expected Commands::Grep"),
+        }
+    }
+
+    #[test]
     fn test_npx_unknown_tool_passthrough() {
         // The bug (rtk-ai/rtk#815) was that unknown tools under `rtk npx`
         // were dispatched to `npm` instead of `npx`. At the parse level, the

--- a/tests/search_error_test.rs
+++ b/tests/search_error_test.rs
@@ -106,6 +106,43 @@ fn no_match_stays_exit_1_and_empty() {
 }
 
 #[test]
+fn ultra_compact_grep_returns_matches_not_error() {
+    let d = tempfile::tempdir().unwrap();
+    let f1 = d.path().join("sample.txt");
+    let f2 = d.path().join("sample2.txt");
+    std::fs::write(&f1, "alpha permissions one\nbeta permissions two\n").unwrap();
+    std::fs::write(&f2, "permissions here\nmore permissions\n").unwrap();
+
+    let normal = rtk(&["grep", "-r", "permissions", d.path().to_str().unwrap()]);
+    let compact = rtk(&[
+        "--ultra-compact",
+        "grep",
+        "-r",
+        "permissions",
+        d.path().to_str().unwrap(),
+    ]);
+
+    assert_eq!(
+        compact.status.code(),
+        Some(0),
+        "--ultra-compact grep must exit 0 when matches exist"
+    );
+    let stderr = String::from_utf8_lossy(&compact.stderr);
+    assert!(
+        !stderr.contains("No such file"),
+        "--ultra-compact must not cause ENOENT: {stderr}"
+    );
+    assert!(
+        !compact.stdout.is_empty(),
+        "--ultra-compact grep must return matches, not silently drop them"
+    );
+    assert_eq!(
+        compact.stdout, normal.stdout,
+        "--ultra-compact must not alter grep match output"
+    );
+}
+
+#[test]
 fn rg_bad_regex_surfaces_error_exit_2() {
     if !rg_available() {
         return;


### PR DESCRIPTION
## Summary
- `--ultra-compact grep` was reported to fail with ENOENT and exit 0, silently dropping all matches (#2620)
- The bug no longer reproduces on current develop — likely fixed by recent grep error-handling improvements (`05f3c54`, `eafadce`)
- This PR adds targeted regression tests to prevent future regressions

## Changes
- **Integration test** (`tests/search_error_test.rs`): verifies `rtk --ultra-compact grep -r` returns identical matches to `rtk grep -r`, exits 0, and produces no ENOENT errors
- **Clap parsing test** (`src/main.rs`): verifies `--ultra-compact` is parsed as a global flag and does not leak into grep's `extra_args`

Fixes #2620

## Test plan
- [ ] `cargo test ultra_compact_grep_returns_matches_not_error` passes
- [ ] `cargo test test_ultra_compact_grep_parses_correctly` passes
- [ ] Full CI passes on all platforms (macOS, Linux, Windows)