### PR TITLE
feat: codex now support PreToolUse hook

### DIFF
--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -28,7 +28,7 @@ LLM agent integration layer that installs, validates, and executes command-rewri
 | Claude-MD (legacy) | `rtk init --claude-md` | 134-line RTK block | CLAUDE.md |
 | Windsurf | `rtk init -g --agent windsurf` | `.windsurfrules` | -- |
 | Cline | `rtk init --agent cline` | `.clinerules` | -- |
-| Codex | `rtk init --codex` | RTK.md in `$CODEX_HOME` or `~/.codex` | AGENTS.md |
+| Codex | `rtk init --codex` | RTK.md in `$CODEX_HOME` or `~/.codex` | AGENTS.md, hooks.json |
 | Cursor | `rtk init -g --agent cursor` | Cursor hook | hooks.json |
 | Pi | `rtk init --agent pi` | `.pi/extensions/rtk.ts` | -- |
 | Hermes | `rtk init --agent hermes` | Python plugin in `~/.hermes/plugins/rtk-rewrite/` | `config.yaml` `plugins.enabled` |
@@ -89,13 +89,13 @@ Rules are loaded from all Claude Code `settings.json` files (project + global, i
 | Cursor (rtk hook cursor) | Ready | `permission: "ask",` — users will be prompted when Cursor enforces the permission; in the meantime, allow |
 | Gemini CLI (rtk hook gemini) | No (allow/deny only) | allow (limitation — no ask mode in Gemini) |
 | Copilot CLI (rtk hook copilot) | No updatedInput | deny-with-suggestion (unchanged) |
-| Codex | ask parsed but no-op | allow (limitation — fails open) |
+| Codex (rtk hook codex) | ask parsed but no-op | allow (limitation — fails open; requires `[features] hooks = true` and `/hooks` trust) |
 
 ### Implementation
 
 - `permissions.rs` — loads deny/ask/allow rules, evaluates precedence, returns `PermissionVerdict`
 - `rewrite_cmd.rs` — maps verdict to exit code (consumed by shell hook)
-- `hook_cmd.rs` — maps verdict to JSON `permissionDecision` field (Copilot/Gemini)
+- `hook_cmd.rs` — maps verdict to JSON `permissionDecision` field (Copilot/Gemini/Codex)
 
 ## Exit Code Contract
 

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -12,6 +12,8 @@ pub const BEFORE_TOOL_KEY: &str = "BeforeTool";
 pub const CLAUDE_HOOK_COMMAND: &str = "rtk hook claude";
 /// Native Rust hook command for Cursor (replaces rtk-rewrite.sh).
 pub const CURSOR_HOOK_COMMAND: &str = "rtk hook cursor";
+/// Native Rust hook command for Codex CLI PreToolUse hooks.
+pub const CODEX_HOOK_COMMAND: &str = "rtk hook codex";
 
 pub const CONFIG_DIR: &str = ".config";
 pub const OPENCODE_SUBDIR: &str = "opencode";

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -284,6 +284,94 @@ fn print_gemini(decision: &str, rewrite: Option<&str>) {
     let _ = writeln!(io::stdout(), "{}", gemini_json(decision, rewrite));
 }
 
+// ── Codex CLI hook ────────────────────────────────────────────
+
+/// Run the Codex CLI PreToolUse hook.
+pub fn run_codex() -> Result<()> {
+    let input = match read_stdin_limited() {
+        Ok(input) => input,
+        Err(_) => return Ok(()),
+    };
+    let output = run_codex_inner(&input);
+    if !output.is_empty() {
+        let _ = writeln!(io::stdout(), "{output}");
+    }
+    Ok(())
+}
+
+fn codex_response_from_decision(tool_input: &Value, decision: HookDecision, cmd: &str) -> String {
+    match decision {
+        HookDecision::AllowRewrite(rewritten) | HookDecision::AskRewrite(rewritten) => {
+            audit_log("rewrite", cmd, &rewritten);
+            let mut updated_input = tool_input.clone();
+            if let Some(obj) = updated_input.as_object_mut() {
+                obj.insert("command".into(), Value::String(rewritten));
+            }
+            codex_allow(updated_input)
+        }
+        HookDecision::Deny => {
+            audit_log("deny", cmd, "");
+            codex_deny("Blocked by RTK permission rule")
+        }
+        HookDecision::Defer => String::new(),
+    }
+}
+
+fn codex_allow(updated_input: Value) -> String {
+    json!({
+        "hookSpecificOutput": {
+            "hookEventName": PRE_TOOL_USE_KEY,
+            "permissionDecision": "allow",
+            "permissionDecisionReason": "RTK auto-rewrite",
+            "updatedInput": updated_input
+        }
+    })
+    .to_string()
+}
+
+fn codex_deny(reason: &str) -> String {
+    json!({
+        "hookSpecificOutput": {
+            "hookEventName": PRE_TOOL_USE_KEY,
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason
+        }
+    })
+    .to_string()
+}
+
+fn run_codex_inner(input: &str) -> String {
+    let input = strip_leading_bom(input).trim();
+    if input.is_empty() {
+        return String::new();
+    }
+
+    let v: Value = match serde_json::from_str(input) {
+        Ok(v) => v,
+        Err(_) => return String::new(),
+    };
+
+    if v.get("tool_name").and_then(|t| t.as_str()) != Some("Bash") {
+        return String::new();
+    }
+
+    let tool_input = v.get("tool_input").cloned().unwrap_or_else(|| json!({}));
+    let cmd = match tool_input
+        .get("command")
+        .and_then(|c| c.as_str())
+        .filter(|c| !c.is_empty())
+    {
+        Some(c) => c.to_string(),
+        None => return String::new(),
+    };
+
+    codex_response_from_decision(
+        &tool_input,
+        decide_hook_action(&cmd, permissions::Host::Codex),
+        &cmd,
+    )
+}
+
 // ── Audit logging ─────────────────────────────────────────────
 
 /// Best-effort audit log when RTK_HOOK_AUDIT=1.
@@ -1167,6 +1255,45 @@ mod tests {
         assert_eq!(v["continue"], true);
         assert_eq!(v["permission"], "allow");
         assert_eq!(v["updated_input"]["command"], "rtk git status");
+    }
+
+    // --- Codex handler ---
+
+    fn codex_input(tool: &str, cmd: &str) -> String {
+        json!({
+            "tool_name": tool,
+            "tool_input": {
+                "command": cmd,
+                "description": "check status"
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn test_codex_default_verdict_allows_rewrite() {
+        let result = run_codex_inner(&codex_input("Bash", "git status"));
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let hook = &v["hookSpecificOutput"];
+
+        assert_eq!(hook["hookEventName"], PRE_TOOL_USE_KEY);
+        assert_eq!(hook["permissionDecision"], "allow");
+        assert_eq!(hook["permissionDecisionReason"], "RTK auto-rewrite");
+        assert_eq!(hook["updatedInput"]["command"], "rtk git status");
+        assert_eq!(hook["updatedInput"]["description"], "check status");
+    }
+
+    #[test]
+    fn test_codex_non_bash_passthrough() {
+        assert_eq!(run_codex_inner(&codex_input("Read", "git status")), "");
+    }
+
+    #[test]
+    fn test_codex_heredoc_passthrough() {
+        assert_eq!(
+            run_codex_inner(&codex_input("Bash", "cat <<EOF\nhello\nEOF")),
+            ""
+        );
     }
 
     #[test]

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -13,11 +13,11 @@ use crate::hooks::constants::{
 };
 
 use super::constants::{
-    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND,
-    GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_INIT_FILE,
-    HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON, HOOKS_SUBDIR,
-    PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR, PI_PLUGIN_FILE,
-    PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
+    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CODEX_HOOK_COMMAND,
+    CURSOR_HOOK_COMMAND, GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR,
+    HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON,
+    HOOKS_SUBDIR, PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR,
+    PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use super::integrity;
 
@@ -932,6 +932,37 @@ fn uninstall_codex_at(codex_dir: &Path, ctx: InitContext) -> Result<Vec<String>>
         ctx,
     )? {
         removed.push("AGENTS.md: removed @RTK.md reference".to_string());
+    }
+
+    let hooks_json_path = codex_dir.join(HOOKS_JSON);
+    if hooks_json_path.exists() {
+        let content = fs::read_to_string(&hooks_json_path)
+            .with_context(|| format!("Failed to read {}", hooks_json_path.display()))?;
+
+        if !content.trim().is_empty() {
+            if let Ok(mut root) = serde_json::from_str::<serde_json::Value>(&content) {
+                if remove_codex_hook_from_json(&mut root) {
+                    if dry_run {
+                        println!(
+                            "[dry-run] would remove RTK entry from Codex hooks.json: {}",
+                            hooks_json_path.display()
+                        );
+                    } else {
+                        let backup_path = hooks_json_path.with_extension("json.bak");
+                        fs::copy(&hooks_json_path, &backup_path).ok();
+
+                        let serialized = serde_json::to_string_pretty(&root)
+                            .context("Failed to serialize hooks.json")?;
+                        atomic_write(&hooks_json_path, &serialized)?;
+
+                        if verbose > 0 {
+                            eprintln!("Removed RTK hook from Codex hooks.json");
+                        }
+                    }
+                    removed.push("hooks.json: removed RTK entry".to_string());
+                }
+            }
+        }
     }
 
     Ok(removed)
@@ -2366,6 +2397,15 @@ fn run_codex_mode_with_paths(
 
     write_if_changed(&rtk_md_path, RTK_SLIM_CODEX, RTK_MD, ctx)?;
     let added_ref = patch_agents_md(&agents_md_path, &rtk_md_ref, ctx)?;
+    let hooks_json_path = if global {
+        rtk_md_path
+            .parent()
+            .context("RTK.md path missing parent directory")?
+            .join(HOOKS_JSON)
+    } else {
+        PathBuf::from(CODEX_DIR).join(HOOKS_JSON)
+    };
+    let patched_hook = patch_codex_hooks_json(&hooks_json_path, ctx)?;
 
     if !dry_run {
         println!("\nRTK configured for Codex CLI.\n");
@@ -2386,6 +2426,17 @@ fn run_codex_mode_with_paths(
                 agents_md_path.display()
             );
         }
+        println!("\nCodex PreToolUse hook registered.");
+        println!("  Command:    {}", CODEX_HOOK_COMMAND);
+        println!("  hooks.json: {}", hooks_json_path.display());
+        if patched_hook {
+            println!("  hooks.json: RTK PreToolUse entry added");
+        } else {
+            println!("  hooks.json: RTK PreToolUse entry already present");
+        }
+        println!(
+            "\n  Enable Codex hooks with `[features] hooks = true` in config.toml, then run `/hooks` to trust this command."
+        );
     }
 
     Ok(())
@@ -3352,6 +3403,157 @@ fn remove_cursor_hook_from_json(root: &mut serde_json::Value) -> bool {
     });
 
     pre_tool_use.len() < original_len
+}
+
+/// Patch Codex hooks.json to add the RTK PreToolUse hook.
+/// Returns true if the file was modified.
+fn patch_codex_hooks_json(path: &Path, ctx: InitContext) -> Result<bool> {
+    let InitContext { verbose, dry_run } = ctx;
+    let mut root = if path.exists() {
+        let content = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+        if content.trim().is_empty() {
+            serde_json::json!({})
+        } else {
+            serde_json::from_str(&content)
+                .with_context(|| format!("Failed to parse {} as JSON", path.display()))?
+        }
+    } else {
+        serde_json::json!({})
+    };
+
+    if codex_hook_already_present(&root) {
+        if verbose > 0 {
+            eprintln!("Codex hooks.json: RTK hook already present");
+        }
+        return Ok(false);
+    }
+
+    insert_codex_hook_entry(&mut root)?;
+
+    let serialized =
+        serde_json::to_string_pretty(&root).context("Failed to serialize hooks.json")?;
+
+    if dry_run {
+        println!("[dry-run] would patch Codex hooks.json: {}", path.display());
+        if verbose > 0 {
+            println!("[dry-run] content:\n{}", serialized);
+        }
+        return Ok(true);
+    }
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "Failed to create Codex hooks.json directory: {}",
+                parent.display()
+            )
+        })?;
+    }
+
+    if path.exists() {
+        let backup_path = path.with_extension("json.bak");
+        fs::copy(path, &backup_path)
+            .with_context(|| format!("Failed to backup to {}", backup_path.display()))?;
+        if verbose > 0 {
+            eprintln!("Backup: {}", backup_path.display());
+        }
+    }
+
+    atomic_write(path, &serialized)?;
+
+    Ok(true)
+}
+
+fn entry_has_rtk_codex_hook(entry: &serde_json::Value) -> bool {
+    entry
+        .get("hooks")
+        .and_then(|h| h.as_array())
+        .is_some_and(|hooks| {
+            hooks.iter().any(|hook| {
+                hook.get("command").and_then(|c| c.as_str()) == Some(CODEX_HOOK_COMMAND)
+            })
+        })
+}
+
+/// Check if RTK PreToolUse hook is already present in Codex hooks.json.
+fn codex_hook_already_present(root: &serde_json::Value) -> bool {
+    root.get("hooks")
+        .and_then(|h| h.get(PRE_TOOL_USE_KEY))
+        .and_then(|p| p.as_array())
+        .is_some_and(|entries| entries.iter().any(entry_has_rtk_codex_hook))
+}
+
+/// Insert RTK PreToolUse entry into Codex hooks.json.
+fn insert_codex_hook_entry(root: &mut serde_json::Value) -> Result<()> {
+    let root_obj = match root.as_object_mut() {
+        Some(obj) => obj,
+        None => {
+            *root = serde_json::json!({});
+            root.as_object_mut().expect("just-created json object")
+        }
+    };
+
+    let hooks = root_obj
+        .entry("hooks")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .context("hooks value is not an object")?;
+
+    let pre_tool_use = hooks
+        .entry(PRE_TOOL_USE_KEY)
+        .or_insert_with(|| serde_json::json!([]))
+        .as_array_mut()
+        .context("PreToolUse value is not an array")?;
+
+    pre_tool_use.push(serde_json::json!({
+        "matcher": "Bash",
+        "hooks": [{
+            "type": "command",
+            "command": CODEX_HOOK_COMMAND,
+            "statusMessage": "RTK rewrite",
+            "timeout": 30
+        }]
+    }));
+    Ok(())
+}
+
+/// Remove RTK PreToolUse entry from Codex hooks.json.
+/// Returns true if an entry was found and removed.
+fn remove_codex_hook_from_json(root: &mut serde_json::Value) -> bool {
+    let pre_tool_use = match root
+        .get_mut("hooks")
+        .and_then(|h| h.get_mut(PRE_TOOL_USE_KEY))
+        .and_then(|p| p.as_array_mut())
+    {
+        Some(arr) => arr,
+        None => return false,
+    };
+
+    let mut removed = false;
+    for entry in pre_tool_use.iter_mut() {
+        let Some(hooks) = entry.get_mut("hooks").and_then(|h| h.as_array_mut()) else {
+            continue;
+        };
+        let original_len = hooks.len();
+        hooks.retain(|hook| {
+            hook.get("command").and_then(|c| c.as_str()) != Some(CODEX_HOOK_COMMAND)
+        });
+        if hooks.len() < original_len {
+            removed = true;
+        }
+    }
+
+    if removed {
+        pre_tool_use.retain(|entry| {
+            entry
+                .get("hooks")
+                .and_then(|h| h.as_array())
+                .is_none_or(|hooks| !hooks.is_empty())
+        });
+    }
+
+    removed
 }
 
 /// Show current rtk configuration
@@ -5066,6 +5268,7 @@ mod tests {
         .unwrap();
 
         assert!(rtk_md.exists());
+        assert!(temp.path().join(HOOKS_JSON).exists());
         assert_eq!(fs::read_to_string(&rtk_md).unwrap(), RTK_SLIM_CODEX);
         assert_eq!(
             fs::read_to_string(&agents_md).unwrap(),
@@ -5272,6 +5475,10 @@ mod tests {
             !agents_md.exists(),
             "dry-run must not create AGENTS.md: {}",
             agents_md.display()
+        );
+        assert!(
+            !temp.path().join(HOOKS_JSON).exists(),
+            "dry-run must not create hooks.json"
         );
     }
 
@@ -5787,6 +5994,180 @@ mod tests {
 
         let removed = remove_cursor_hook_from_json(&mut json_content);
         assert!(!removed);
+    }
+
+    #[test]
+    fn test_insert_codex_hook_entry_empty() {
+        let mut json_content = serde_json::json!({});
+        insert_codex_hook_entry(&mut json_content).unwrap();
+
+        let pre_tool_use = json_content["hooks"][PRE_TOOL_USE_KEY].as_array().unwrap();
+        assert_eq!(pre_tool_use.len(), 1);
+        assert_eq!(pre_tool_use[0]["matcher"], "Bash");
+        assert_eq!(pre_tool_use[0]["hooks"][0]["type"], "command");
+        assert_eq!(pre_tool_use[0]["hooks"][0]["command"], CODEX_HOOK_COMMAND);
+        assert_eq!(pre_tool_use[0]["hooks"][0]["statusMessage"], "RTK rewrite");
+        assert_eq!(pre_tool_use[0]["hooks"][0]["timeout"], 30);
+    }
+
+    #[test]
+    fn test_codex_hook_already_present_nested() {
+        let json_content = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": CODEX_HOOK_COMMAND
+                    }]
+                }]
+            }
+        });
+
+        assert!(codex_hook_already_present(&json_content));
+    }
+
+    #[test]
+    fn test_insert_codex_hook_preserves_existing_user_hooks() {
+        let mut json_content = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "user hook"
+                    }]
+                }],
+                "PostToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "after hook"
+                    }]
+                }]
+            }
+        });
+
+        insert_codex_hook_entry(&mut json_content).unwrap();
+
+        let pre_tool_use = json_content["hooks"][PRE_TOOL_USE_KEY].as_array().unwrap();
+        assert_eq!(pre_tool_use.len(), 2);
+        assert_eq!(pre_tool_use[0]["hooks"][0]["command"], "user hook");
+        assert_eq!(pre_tool_use[1]["hooks"][0]["command"], CODEX_HOOK_COMMAND);
+        assert_eq!(
+            json_content["hooks"]["PostToolUse"][0]["hooks"][0]["command"],
+            "after hook"
+        );
+    }
+
+    #[test]
+    fn test_patch_codex_hooks_json_preserves_existing_user_hooks() {
+        let temp = TempDir::new().unwrap();
+        let hooks_json = temp.path().join(HOOKS_JSON);
+        fs::write(
+            &hooks_json,
+            serde_json::to_string_pretty(&serde_json::json!({
+                "hooks": {
+                    "PreToolUse": [{
+                        "matcher": "Bash",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "user hook"
+                        }]
+                    }]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let patched = patch_codex_hooks_json(&hooks_json, InitContext::default()).unwrap();
+        assert!(patched);
+
+        let json_content: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&hooks_json).unwrap()).unwrap();
+        let pre_tool_use = json_content["hooks"][PRE_TOOL_USE_KEY].as_array().unwrap();
+        assert_eq!(pre_tool_use.len(), 2);
+        assert_eq!(pre_tool_use[0]["hooks"][0]["command"], "user hook");
+        assert_eq!(pre_tool_use[1]["hooks"][0]["command"], CODEX_HOOK_COMMAND);
+    }
+
+    #[test]
+    fn test_remove_codex_hook_from_json_preserves_unrelated_user_hook() {
+        let mut json_content = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "user hook"
+                        }]
+                    },
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{
+                            "type": "command",
+                            "command": CODEX_HOOK_COMMAND
+                        }]
+                    }
+                ]
+            }
+        });
+
+        let removed = remove_codex_hook_from_json(&mut json_content);
+        assert!(removed);
+
+        let pre_tool_use = json_content["hooks"][PRE_TOOL_USE_KEY].as_array().unwrap();
+        assert_eq!(pre_tool_use.len(), 1);
+        assert_eq!(pre_tool_use[0]["hooks"][0]["command"], "user hook");
+    }
+
+    #[test]
+    fn test_remove_codex_hook_from_json_nested_hook_preserves_siblings() {
+        let mut json_content = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "user hook"
+                        },
+                        {
+                            "type": "command",
+                            "command": CODEX_HOOK_COMMAND
+                        }
+                    ]
+                }]
+            }
+        });
+
+        let removed = remove_codex_hook_from_json(&mut json_content);
+        assert!(removed);
+
+        let nested = json_content["hooks"][PRE_TOOL_USE_KEY][0]["hooks"]
+            .as_array()
+            .unwrap();
+        assert_eq!(nested.len(), 1);
+        assert_eq!(nested[0]["command"], "user hook");
+    }
+
+    #[test]
+    fn test_remove_codex_hook_not_present() {
+        let mut json_content = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "user hook"
+                    }]
+                }]
+            }
+        });
+
+        assert!(!remove_codex_hook_from_json(&mut json_content));
     }
 
     // ─── Legacy migration tests ──────────────────────────────────────

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -31,6 +31,7 @@ pub fn check_command(cmd: &str) -> PermissionVerdict {
 pub enum Host {
     Claude,
     Cursor,
+    Codex,
     Gemini,
 }
 
@@ -38,6 +39,7 @@ pub fn check_command_for(cmd: &str, host: Host) -> PermissionVerdict {
     let (deny_rules, ask_rules, allow_rules) = match host {
         Host::Claude => load_permission_rules(),
         Host::Cursor => load_cursor_rules(),
+        Host::Codex => load_codex_rules(),
         Host::Gemini => load_gemini_rules(),
     };
     check_command_with_rules(cmd, &deny_rules, &ask_rules, &allow_rules)
@@ -234,6 +236,13 @@ fn load_cursor_rules() -> (Vec<String>, Vec<String>, Vec<String>) {
         append_wrapped_rules(perms.get("allow"), &["Shell("], &mut allow);
     }
     (deny, Vec::new(), allow)
+}
+
+/// Codex's approval model lives in `config.toml` (`approval_policy` and
+/// `sandbox_mode`), not in RTK-readable Bash allow/deny lists. RTK defers
+/// permission gating to Codex, so every command resolves to Default.
+fn load_codex_rules() -> (Vec<String>, Vec<String>, Vec<String>) {
+    (Vec::new(), Vec::new(), Vec::new())
 }
 
 // Gemini honors project `.gemini/settings.json` when the folder is trusted.

--- a/src/main.rs
+++ b/src/main.rs
@@ -849,6 +849,8 @@ enum HookCommands {
     Claude,
     /// Process Cursor Agent hook (reads JSON from stdin)
     Cursor,
+    /// Process Codex CLI PreToolUse hook (reads JSON from stdin)
+    Codex,
     /// Process Gemini CLI BeforeTool hook (reads JSON from stdin)
     Gemini,
     /// Process Copilot preToolUse hook (VS Code + Copilot CLI, reads JSON from stdin)
@@ -2359,6 +2361,10 @@ fn run_cli() -> Result<i32> {
                 hooks::hook_cmd::run_cursor()?;
                 0
             }
+            HookCommands::Codex => {
+                hooks::hook_cmd::run_codex()?;
+                0
+            }
             HookCommands::Gemini => {
                 hooks::hook_cmd::run_gemini()?;
                 0
@@ -3130,6 +3136,17 @@ mod tests {
             cli.command,
             Commands::Hook {
                 command: HookCommands::Claude
+            }
+        ));
+    }
+
+    #[test]
+    fn test_hook_codex_parses() {
+        let cli = Cli::try_parse_from(["rtk", "hook", "codex"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Hook {
+                command: HookCommands::Codex
             }
         ));
     }


### PR DESCRIPTION
Resolves #1812.

As the title suggests, could you add a PreToolUse hook to the Codex, similar to the one in Claude's code?

## Summary

-

## Test plan

- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.