### PR TITLE
fix(find): fail closed on unknown flags instead of warn-and-broaden

### DIFF
--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -133,7 +133,14 @@ fn parse_native_find_args(args: &[String]) -> Result<FindArgs> {
                 }
             }
             flag if flag.starts_with('-') => {
-                eprintln!("rtk find: unknown flag '{}', ignored", flag);
+                // Fail closed: dropping an unknown predicate and continuing would
+                // silently run a BROADER query (e.g. a `-newermt` filter lost while
+                // still exiting 0), which scripted and agent callers consume as the
+                // real answer. Unknown flags get the same treatment as -not/-exec.
+                anyhow::bail!(
+                    "rtk find does not support flag '{}'. Use `find` directly.",
+                    flag
+                );
             }
             _ => {}
         }
@@ -506,6 +513,23 @@ mod tests {
     #[test]
     fn parse_native_find_rejects_exec() {
         let result = parse_find_args(&args(&[".", "-name", "*.tmp", "-exec", "rm", "{}", ";"]));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_native_find_rejects_unknown_flag_newermt() {
+        // Previously warned "unknown flag '-newermt', ignored" and ran a BROADER
+        // query (time filter dropped, exit 0). Unknown predicates must fail closed.
+        let result = parse_find_args(&args(&[".", "-newermt", "2025-01-01", "-name", "*.txt"]));
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("-newermt"));
+        assert!(msg.contains("Use `find` directly"));
+    }
+
+    #[test]
+    fn parse_native_find_rejects_unknown_flag_anewer() {
+        let result = parse_find_args(&args(&[".", "-anewer", "ref.txt", "-name", "*.rs"]));
         assert!(result.is_err());
     }
 


### PR DESCRIPTION
Fixes #2821.

## Problem

`rtk find` handles unknown predicates by printing a stderr warning and continuing:

```console
$ rtk find . -newermt '2025-01-01' -name '*.txt'
rtk find: unknown flag '-newermt', ignored
<UNFILTERED list including files older than 2025>   # exit 0
```

The dropped predicate means the walk runs a **broader** query than the user asked for, while still exiting 0. Scripted and LLM-agent callers can't act on stderr warnings, so the superset is consumed as the real answer (this fed a wrong file set into a session-audit pipeline for us). `-not`/`-exec` already hard-fail; `-newermt`-class flags miss the exact-match `UNSUPPORTED_FIND_FLAGS` list and fall into the warn arm instead.

## Fix

The unknown-flag arm in `parse_native_find_args` now bails the same way the compound-predicate guard does:

```
rtk find does not support flag '-newermt'. Use `find` directly.
```

exit 1 via the existing error path. Per the "Correctness VS Token Savings" principle: an explicit user predicate is intent; dropping it should never be a warning.

## Test plan

- 2 new unit tests (`parse_native_find_rejects_unknown_flag_newermt`, `..._anewer`) mirroring the existing `parse_native_find_rejects_not` template — RED on master's warn-and-continue, GREEN here.
- Full `cargo test`: 2360+ pass; the only failures ever observed were `core::tracking::tests::test_timed_execution_*` timing assertions, which also flake on clean master under parallel load and pass in isolation on both — unrelated to this diff.
- Manual: `rtk find . -newermt 2025-01-01 -name '*.txt'` → error + exit 1; `rtk find . -name '*.txt'` unchanged.
