### PR TITLE
fix(search): group multi-file matches under per-file filename header

### DIFF
--- a/src/cmds/system/search.rs
+++ b/src/cmds/system/search.rs
@@ -501,9 +501,10 @@ pub fn run(
                 break;
             }
             let sep = if *is_match { ':' } else { '-' };
-            if show_file {
+            // File-header mode: filename once per file (first match), then bare line:content.
+            if show_file && file_shown == 0 {
                 body.push_str(&file_display);
-                body.push(sep);
+                body.push('\n');
             }
             if show_line {
                 body.push_str(&line_num.to_string());
@@ -552,7 +553,10 @@ pub fn run(
         body
     };
 
-    let output = if capped && rtk_output.len() < plain.len() {
+    // Prefer rtk_output for multi-file or capped searches, but only when it does
+    // not exceed the raw `plain` baseline: heading + clean_line normally shrink
+    // it, and the size guard also self-heals if a future change bloats the body.
+    let output = if (capped || show_file) && rtk_output.len() <= plain.len() {
         rtk_output
     } else {
         plain


### PR DESCRIPTION
## Summary
- Group `rtk grep` / `rtk rg` multi-file matches under a per-file filename header (rg's `--heading` style) instead of repeating the path on every line.
- Minimal change to the shared `search::run` renderer (~7 lines, no new state — reuses the existing `file_shown` counter), so both engines benefit.
- Self-healing output selection: the grouped form is used only when `rtk_output.len() <= plain.len()`, guaranteeing RTK never emits more than the raw command.

Fixes #2175. A more minimal, more robust alternative to #2199.

## Intent
Agent sessions capture non-TTY stdout, so `rg` falls back to the grep-like `file:line:content` format and RTK mirrored it — repeating the file path on every match. For files with many matches this wastes tokens. Heading-style grouping dedupes the path once per file.

* e.g. `grep -rn "first positional" src`
## Before
```
src/cmds/git/glab_cmd.rs:167:/// Extract the first positional identifier (MR/issue number or URL) from args,
src/cmds/system/search.rs:238:    // Otherwise: first positional is the pattern, rest are paths.
```

## After
```
src/cmds/git/glab_cmd.rs
167:/// Extract the first positional identifier (MR/issue number or URL) from args,
src/cmds/system/search.rs
238:// Otherwise: first positional is the pattern, rest are paths.
```

No blank line between file blocks — deliberate, to maximise token savings.

## How it works
Two edits in `src/cmds/system/search.rs`:
1. **Renderer** — when `show_file`, print the filename once on the first entry of each file (guarded by `file_shown == 0`), then bare `line:content`.
2. **Output selection** — `if (capped || show_file) && rtk_output.len() <= plain.len()`. Heading + `clean_line` normally shrink the output; the `<=` guard also self-heals if a future change ever bloats the body (falls back to the faithful baseline).

Single-file searches keep their existing behaviour (no filename). Passthrough shape flags (`-c`/`-l`/`-o`/`--null`/`--json`/…) are untouched.

## Differences vs #2199
- Smaller surface area: core logic ~7 lines, no new state.
- Covers both `grep` and `rg` (shared `search::run`); #2175 was filed for `grep` only.
- Self-healing `<=` size guard ensures the compact form is never larger than the raw output.
- No inter-file blank lines for extra token savings.

## Test plan
- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test` → 2358 passed, 0 failed
- [x] Manual: inspected `rtk grep -ir …` and `rtk rg …` across multi-file, single-file, and capped cases
- [ ] Add a `cfg(unix)` integration test asserting the heading format for multi-file search (per CONTRIBUTING — can add before merge)