### PR TITLE
feat(secrets): hard-exclude credential files in grep/rg/find/read

### DIFF
--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -184,29 +184,18 @@ fn parse_rtk_find_args(args: &[String]) -> Result<FindArgs> {
 /// Entry point from main.rs — parses raw args then delegates to run().
 pub fn run_from_args(args: &[String], verbose: u8) -> Result<()> {
     let parsed = parse_find_args(args)?;
-    run(
-        &parsed.pattern,
-        &parsed.path,
-        parsed.max_results,
-        parsed.max_depth,
-        &parsed.file_type,
-        parsed.case_insensitive,
-        parsed.include_secrets,
-        verbose,
-    )
+    run(&parsed, verbose)
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn run(
-    pattern: &str,
-    path: &str,
-    max_results: usize,
-    max_depth: Option<usize>,
-    file_type: &str,
-    case_insensitive: bool,
-    include_secrets: bool,
-    verbose: u8,
-) -> Result<()> {
+fn run(args: &FindArgs, verbose: u8) -> Result<()> {
+    let pattern = args.pattern.as_str();
+    let path = args.path.as_str();
+    let max_results = args.max_results;
+    let max_depth = args.max_depth;
+    let file_type = args.file_type.as_str();
+    let case_insensitive = args.case_insensitive;
+    let include_secrets = args.include_secrets;
+
     let timer = tracking::TimedExecution::start();
 
     // Treat "." as match-all
@@ -579,19 +568,39 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    /// `run` with the common test shape: type "f", case-sensitive, secrets
+    /// excluded, quiet.
+    fn run_with(
+        pattern: &str,
+        path: &str,
+        max_results: usize,
+        max_depth: Option<usize>,
+    ) -> Result<()> {
+        run(
+            &FindArgs {
+                pattern: pattern.to_string(),
+                path: path.to_string(),
+                max_results,
+                max_depth,
+                ..FindArgs::default()
+            },
+            0,
+        )
+    }
+
     // --- #1101: dotfile pattern should not skip hidden files ---
 
     #[test]
     fn find_dotfile_pattern_includes_hidden() {
         // .gitignore exists at the repo root — must be found when using a dotfile pattern
-        let result = run(".gitignore", ".", 50, Some(1), "f", false, false, 0);
+        let result = run_with(".gitignore", ".", 50, Some(1));
         assert!(result.is_ok(), "run with dotfile pattern should not error");
     }
 
     #[test]
     fn find_regular_pattern_skips_hidden() {
         // Non-dot pattern should not error (hidden dirs remain skipped)
-        let result = run("*.rs", "src", 5, None, "f", false, false, 0);
+        let result = run_with("*.rs", "src", 5, None);
         assert!(result.is_ok());
     }
 
@@ -600,34 +609,34 @@ mod tests {
     #[test]
     fn find_rs_files_in_src() {
         // Should find .rs files without error
-        let result = run("*.rs", "src", 100, None, "f", false, false, 0);
+        let result = run_with("*.rs", "src", 100, None);
         assert!(result.is_ok());
     }
 
     #[test]
     fn find_dot_pattern_works() {
         // "." pattern should not error (was broken before)
-        let result = run(".", "src", 10, None, "f", false, false, 0);
+        let result = run_with(".", "src", 10, None);
         assert!(result.is_ok());
     }
 
     #[test]
     fn find_no_matches() {
-        let result = run("*.xyz_nonexistent", "src", 50, None, "f", false, false, 0);
+        let result = run_with("*.xyz_nonexistent", "src", 50, None);
         assert!(result.is_ok());
     }
 
     #[test]
     fn find_respects_max() {
         // With max=2, should not error
-        let result = run("*.rs", "src", 2, None, "f", false, false, 0);
+        let result = run_with("*.rs", "src", 2, None);
         assert!(result.is_ok());
     }
 
     #[test]
     fn find_gitignored_excluded() {
         // target/ is in .gitignore — files inside should not appear
-        let result = run("*", ".", 1000, None, "f", false, false, 0);
+        let result = run_with("*", ".", 1000, None);
         assert!(result.is_ok());
         // We can't easily capture stdout in unit tests, but at least
         // verify it runs without error. The smoke tests verify content.

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -218,7 +218,7 @@ fn run(args: &FindArgs, verbose: u8) -> Result<()> {
         .git_global(true)
         .git_exclude(true);
     if !include_secrets {
-        // #2817: hard-exclude credential files (and prune credential dirs),
+        // hard-exclude credential files (and prune credential dirs),
         // independent of .gitignore. `--include-secrets` lifts this.
         builder.filter_entry(|entry| {
             let is_dir = entry.file_type().is_some_and(|t| t.is_dir());

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -1,7 +1,7 @@
 //! Filters find results by grouping files by directory.
 
 use crate::core::guard::never_worse;
-use crate::core::tracking;
+use crate::core::{secrets, tracking};
 use anyhow::{Context, Result};
 use ignore::WalkBuilder;
 use std::collections::HashMap;
@@ -35,6 +35,7 @@ struct FindArgs {
     max_depth: Option<usize>,
     file_type: String,
     case_insensitive: bool,
+    include_secrets: bool,
 }
 
 impl Default for FindArgs {
@@ -46,6 +47,7 @@ impl Default for FindArgs {
             max_depth: None,
             file_type: "f".to_string(),
             case_insensitive: false,
+            include_secrets: false,
         }
     }
 }
@@ -132,6 +134,7 @@ fn parse_native_find_args(args: &[String]) -> Result<FindArgs> {
                     parsed.max_depth = Some(val.parse().context("invalid -maxdepth value")?);
                 }
             }
+            secrets::INCLUDE_SECRETS_FLAG => parsed.include_secrets = true,
             flag if flag.starts_with('-') => {
                 eprintln!("rtk find: unknown flag '{}', ignored", flag);
             }
@@ -169,6 +172,7 @@ fn parse_rtk_find_args(args: &[String]) -> Result<FindArgs> {
                     parsed.file_type = val;
                 }
             }
+            secrets::INCLUDE_SECRETS_FLAG => parsed.include_secrets = true,
             _ => {}
         }
         i += 1;
@@ -187,10 +191,12 @@ pub fn run_from_args(args: &[String], verbose: u8) -> Result<()> {
         parsed.max_depth,
         &parsed.file_type,
         parsed.case_insensitive,
+        parsed.include_secrets,
         verbose,
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn run(
     pattern: &str,
     path: &str,
@@ -198,6 +204,7 @@ pub fn run(
     max_depth: Option<usize>,
     file_type: &str,
     case_insensitive: bool,
+    include_secrets: bool,
     verbose: u8,
 ) -> Result<()> {
     let timer = tracking::TimedExecution::start();
@@ -221,6 +228,14 @@ pub fn run(
         .git_ignore(true) // respect .gitignore
         .git_global(true)
         .git_exclude(true);
+    if !include_secrets {
+        // #2817: hard-exclude credential files (and prune credential dirs),
+        // independent of .gitignore. `--include-secrets` lifts this.
+        builder.filter_entry(|entry| {
+            let is_dir = entry.file_type().is_some_and(|t| t.is_dir());
+            !secrets::is_secret_entry(entry.path(), is_dir)
+        });
+    }
     if let Some(depth) = max_depth {
         builder.max_depth(Some(depth));
     }
@@ -569,14 +584,14 @@ mod tests {
     #[test]
     fn find_dotfile_pattern_includes_hidden() {
         // .gitignore exists at the repo root — must be found when using a dotfile pattern
-        let result = run(".gitignore", ".", 50, Some(1), "f", false, 0);
+        let result = run(".gitignore", ".", 50, Some(1), "f", false, false, 0);
         assert!(result.is_ok(), "run with dotfile pattern should not error");
     }
 
     #[test]
     fn find_regular_pattern_skips_hidden() {
         // Non-dot pattern should not error (hidden dirs remain skipped)
-        let result = run("*.rs", "src", 5, None, "f", false, 0);
+        let result = run("*.rs", "src", 5, None, "f", false, false, 0);
         assert!(result.is_ok());
     }
 
@@ -585,34 +600,34 @@ mod tests {
     #[test]
     fn find_rs_files_in_src() {
         // Should find .rs files without error
-        let result = run("*.rs", "src", 100, None, "f", false, 0);
+        let result = run("*.rs", "src", 100, None, "f", false, false, 0);
         assert!(result.is_ok());
     }
 
     #[test]
     fn find_dot_pattern_works() {
         // "." pattern should not error (was broken before)
-        let result = run(".", "src", 10, None, "f", false, 0);
+        let result = run(".", "src", 10, None, "f", false, false, 0);
         assert!(result.is_ok());
     }
 
     #[test]
     fn find_no_matches() {
-        let result = run("*.xyz_nonexistent", "src", 50, None, "f", false, 0);
+        let result = run("*.xyz_nonexistent", "src", 50, None, "f", false, false, 0);
         assert!(result.is_ok());
     }
 
     #[test]
     fn find_respects_max() {
         // With max=2, should not error
-        let result = run("*.rs", "src", 2, None, "f", false, 0);
+        let result = run("*.rs", "src", 2, None, "f", false, false, 0);
         assert!(result.is_ok());
     }
 
     #[test]
     fn find_gitignored_excluded() {
         // target/ is in .gitignore — files inside should not appear
-        let result = run("*", ".", 1000, None, "f", false, 0);
+        let result = run("*", ".", 1000, None, "f", false, false, 0);
         assert!(result.is_ok());
         // We can't easily capture stdout in unit tests, but at least
         // verify it runs without error. The smoke tests verify content.

--- a/src/cmds/system/read.rs
+++ b/src/cmds/system/read.rs
@@ -2,19 +2,29 @@
 
 use crate::core::filter::{self, FilterLevel, Language};
 use crate::core::guard::never_worse;
-use crate::core::tracking;
+use crate::core::{secrets, tracking};
 use anyhow::{Context, Result};
 use std::fs;
 use std::path::Path;
 
+#[allow(clippy::too_many_arguments)]
 pub fn run(
     file: &Path,
     level: FilterLevel,
     max_lines: Option<usize>,
     tail_lines: Option<usize>,
     line_numbers: bool,
+    include_secrets: bool,
     verbose: u8,
 ) -> Result<()> {
+    // #2817: refuse to print credential files into the transcript by default.
+    if !include_secrets && secrets::is_secret_path(file) {
+        anyhow::bail!(
+            "looks like a credential/secret file; refusing to print it (rerun with {} to override)",
+            secrets::INCLUDE_SECRETS_FLAG
+        );
+    }
+
     let timer = tracking::TimedExecution::start();
 
     if verbose > 0 {
@@ -203,7 +213,7 @@ fn main() {{
         )?;
 
         // Just verify it doesn't panic
-        run(file.path(), FilterLevel::Minimal, None, None, false, 0)?;
+        run(file.path(), FilterLevel::Minimal, None, None, false, false, 0)?;
         Ok(())
     }
 

--- a/src/cmds/system/read.rs
+++ b/src/cmds/system/read.rs
@@ -7,7 +7,6 @@ use anyhow::{Context, Result};
 use std::fs;
 use std::path::Path;
 
-#[allow(clippy::too_many_arguments)]
 pub fn run(
     file: &Path,
     level: FilterLevel,

--- a/src/cmds/system/read.rs
+++ b/src/cmds/system/read.rs
@@ -16,7 +16,7 @@ pub fn run(
     include_secrets: bool,
     verbose: u8,
 ) -> Result<()> {
-    // #2817: refuse to print credential files into the transcript by default.
+    // refuse to print credential files into the transcript by default.
     if !include_secrets && secrets::is_secret_path(file) {
         anyhow::bail!(
             "looks like a credential/secret file; refusing to print it (rerun with {} to override)",

--- a/src/cmds/system/search.rs
+++ b/src/cmds/system/search.rs
@@ -9,7 +9,7 @@
 use crate::core::stream::{exec_capture, exec_capture_stdin, CaptureResult};
 use crate::core::tracking;
 use crate::core::utils::{resolved_command, strip_ansi};
-use crate::core::{args_utils, config};
+use crate::core::{args_utils, config, secrets};
 use anyhow::{Context, Result};
 use regex::Regex;
 use std::collections::HashMap;
@@ -311,14 +311,24 @@ fn engine_capture<T: AsRef<str>>(
 }
 
 /// Runs the agent's command verbatim for forms RTK does not group: format/shape
-/// flags and pattern-less modes (`--files`, `--type-list`).
+/// flags and pattern-less modes (`--files`, `--type-list`). Unless the agent
+/// passed `--include-secrets`, engine-native exclusions keep credential files
+/// out of the output (#2817); prepended so a trailing `--` cannot demote them
+/// to positionals.
 fn passthrough<T: AsRef<str>>(
     timer: &tracking::TimedExecution,
     engine: Engine,
     args: &[T],
     real_cmd: &str,
+    include_secrets: bool,
 ) -> Result<i32> {
     let mut cmd = resolved_command(engine.bin());
+    if !include_secrets {
+        cmd.args(match engine {
+            Engine::Grep => secrets::grep_exclude_flags(),
+            Engine::Rg => secrets::rg_exclude_flags(),
+        });
+    }
     for a in args {
         cmd.arg(a.as_ref());
     }
@@ -368,13 +378,15 @@ pub fn run(
 
     // Re-insert `--` when clap's trailing_var_arg consumed it
     let args = args_utils::restore_double_dash(args);
+    // #2817: credential files are excluded by default; the flag lifts it.
+    let (args, include_secrets) = secrets::strip_include_secrets(&args);
     let real_cmd = format!("{} {}", engine.label(), args.join(" "));
     let rtk_label = format!("rtk {}", engine.label());
 
     let (patterns, paths, extra_args) = extract_pattern_path(&args);
 
     if patterns.is_empty() {
-        return passthrough(&timer, engine, &args, &real_cmd);
+        return passthrough(&timer, engine, &args, &real_cmd, include_secrets);
     }
 
     let pattern_display = if patterns.len() == 1 {
@@ -391,7 +403,7 @@ pub fn run(
 
     // format/shape flags (-c/-l/-o/...): already-minimal native output, passthrough.
     if has_format_flag(&extra_args) {
-        return passthrough(&timer, engine, &args, &real_cmd);
+        return passthrough(&timer, engine, &args, &real_cmd, include_secrets);
     }
 
     let result = engine_capture(engine, &extra_args, &patterns, &paths)?;
@@ -402,7 +414,7 @@ pub fn run(
     // Unparseable shape re-runs verbatim below (with its own stderr), so handle it
     // before surfacing this run's stderr (#2333).
     if unparsed_signal(&raw_output) > 0 {
-        return passthrough(&timer, engine, &args, &real_cmd);
+        return passthrough(&timer, engine, &args, &real_cmd, include_secrets);
     }
 
     if !result.stderr.is_empty() {
@@ -436,6 +448,23 @@ pub fn run(
             .push((line_num, is_match, cleaned));
     }
 
+    // #2817: drop matches from credential files. Done on the parsed results —
+    // not via engine flags — so it works identically for grep and rg, matches
+    // case-insensitively, and sees through innocuously-named symlinks.
+    let mut excluded_files = 0usize;
+    let mut excluded_matches = 0usize;
+    if !include_secrets {
+        by_file.retain(|file, entries| {
+            if secrets::is_secret_path(std::path::Path::new(file)) {
+                excluded_files += 1;
+                excluded_matches += entries.iter().filter(|(_, is_match, _)| *is_match).count();
+                false
+            } else {
+                true
+            }
+        });
+    }
+
     let total_matches: usize = by_file
         .values()
         .flat_map(|v| v.iter())
@@ -461,11 +490,16 @@ pub fn run(
         && !extra_args.iter().any(|f| f == "--no-line-number");
 
     // Faithful baseline: exactly what the real command prints, full content.
+    // Files excluded above are absent from `by_file` and must not leak back
+    // in through this path either.
     let mut plain = String::new();
     for line in raw_output.lines() {
         let Some((file, line_num, is_match, content)) = parse_match_line(line) else {
             continue;
         };
+        if !by_file.contains_key(&file) {
+            continue;
+        }
         let sep = if is_match { ':' } else { '-' };
         if show_file {
             plain.push_str(&file);
@@ -559,6 +593,14 @@ pub fn run(
     };
 
     print!("{}", output);
+    if excluded_files > 0 {
+        eprintln!(
+            "rtk: {} match(es) in {} credential file(s) hidden (rerun with {} to show them)",
+            excluded_matches,
+            excluded_files,
+            secrets::INCLUDE_SECRETS_FLAG
+        );
+    }
     timer.track(&real_cmd, &rtk_label, &raw_output, &output);
 
     Ok(exit_code)

--- a/src/cmds/system/search.rs
+++ b/src/cmds/system/search.rs
@@ -314,14 +314,43 @@ fn engine_capture<T: AsRef<str>>(
 /// flags and pattern-less modes (`--files`, `--type-list`). Unless the agent
 /// passed `--include-secrets`, engine-native exclusions keep credential files
 /// out of the output (#2817); prepended so a trailing `--` cannot demote them
-/// to positionals.
+/// to positionals. Explicitly-named credential files (`paths`) are dropped
+/// with a stderr note instead of relying on the engine's name-glob exclusion,
+/// which would both stay silent — a plausible-but-wrong "no match" — and miss
+/// innocuously-named symlinks.
 fn passthrough<T: AsRef<str>>(
     timer: &tracking::TimedExecution,
     engine: Engine,
     args: &[T],
+    paths: &[String],
     real_cmd: &str,
     include_secrets: bool,
 ) -> Result<i32> {
+    let mut args: Vec<&str> = args.iter().map(|a| a.as_ref()).collect();
+    if !include_secrets {
+        let mut kept_paths = paths.len();
+        for p in paths {
+            if secrets::is_secret_path(std::path::Path::new(p)) {
+                eprintln!(
+                    "rtk: {}: credential file hidden (rerun with {} to search it)",
+                    p,
+                    secrets::INCLUDE_SECRETS_FLAG
+                );
+                if let Some(pos) = args.iter().position(|a| a == p) {
+                    args.remove(pos);
+                }
+                kept_paths -= 1;
+            }
+        }
+        // Every named file was a credential file: nothing left to search.
+        // Don't run the engine — with no file operands it would read stdin.
+        // Mirror the engine's "no lines selected" exit code.
+        if kept_paths == 0 && !paths.is_empty() {
+            timer.track_passthrough(real_cmd, &format!("rtk {} (passthrough)", real_cmd));
+            return Ok(1);
+        }
+    }
+
     let mut cmd = resolved_command(engine.bin());
     if !include_secrets {
         cmd.args(match engine {
@@ -330,7 +359,7 @@ fn passthrough<T: AsRef<str>>(
         });
     }
     for a in args {
-        cmd.arg(a.as_ref());
+        cmd.arg(a);
     }
     let result = exec_capture_stdin(&mut cmd).context("search failed")?;
 
@@ -386,7 +415,7 @@ pub fn run(
     let (patterns, paths, extra_args) = extract_pattern_path(&args);
 
     if patterns.is_empty() {
-        return passthrough(&timer, engine, &args, &real_cmd, include_secrets);
+        return passthrough(&timer, engine, &args, &paths, &real_cmd, include_secrets);
     }
 
     let pattern_display = if patterns.len() == 1 {
@@ -403,7 +432,7 @@ pub fn run(
 
     // format/shape flags (-c/-l/-o/...): already-minimal native output, passthrough.
     if has_format_flag(&extra_args) {
-        return passthrough(&timer, engine, &args, &real_cmd, include_secrets);
+        return passthrough(&timer, engine, &args, &paths, &real_cmd, include_secrets);
     }
 
     let result = engine_capture(engine, &extra_args, &patterns, &paths)?;
@@ -414,7 +443,7 @@ pub fn run(
     // Unparseable shape re-runs verbatim below (with its own stderr), so handle it
     // before surfacing this run's stderr (#2333).
     if unparsed_signal(&raw_output) > 0 {
-        return passthrough(&timer, engine, &args, &real_cmd, include_secrets);
+        return passthrough(&timer, engine, &args, &paths, &real_cmd, include_secrets);
     }
 
     if !result.stderr.is_empty() {

--- a/src/cmds/system/search.rs
+++ b/src/cmds/system/search.rs
@@ -407,7 +407,7 @@ pub fn run(
 
     // Re-insert `--` when clap's trailing_var_arg consumed it
     let args = args_utils::restore_double_dash(args);
-    // #2817: credential files are excluded by default; the flag lifts it.
+    // credential files are excluded by default; the flag lifts it.
     let (args, include_secrets) = secrets::strip_include_secrets(&args);
     let real_cmd = format!("{} {}", engine.label(), args.join(" "));
     let rtk_label = format!("rtk {}", engine.label());
@@ -477,7 +477,7 @@ pub fn run(
             .push((line_num, is_match, cleaned));
     }
 
-    // #2817: drop matches from credential files. Done on the parsed results —
+    // drop matches from credential files. Done on the parsed results —
     // not via engine flags — so it works identically for grep and rg, matches
     // case-insensitively, and sees through innocuously-named symlinks.
     let mut excluded_files = 0usize;
@@ -515,8 +515,8 @@ pub fn run(
             .any(|f| f == "--with-filename" || f == "--recursive");
     // Always surface the line number (the openable position) unless the agent
     // explicitly turned it off; the filename is the only conditional part.
-    let show_line = !has_short_flag(&extra_args, 'N')
-        && !extra_args.iter().any(|f| f == "--no-line-number");
+    let show_line =
+        !has_short_flag(&extra_args, 'N') && !extra_args.iter().any(|f| f == "--no-line-number");
 
     // Faithful baseline: exactly what the real command prints, full content.
     // Files excluded above are absent from `by_file` and must not leak back

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -7,6 +7,7 @@ pub mod display_helpers;
 pub mod filter;
 pub mod guard;
 pub mod runner;
+pub mod secrets;
 pub mod stream;
 pub mod tee;
 pub mod telemetry;

--- a/src/core/secrets.rs
+++ b/src/core/secrets.rs
@@ -37,8 +37,11 @@ const NAME_PREFIXES: &[&str] = &[
 /// containing credentials.
 const NAME_SUFFIXES: &[&str] = &[".pem", ".key", ".p12", ".kdbx", ".tfstate", ".tfvars"];
 
-/// Directory components whose entire subtree is credential-bearing.
-const SECRET_DIRS: &[&str] = &[".aws", ".azure", ".kube", ".docker", "secrets"];
+/// Directory components whose entire subtree is credential-bearing. Only
+/// unambiguous dotted config dirs belong here — a generic name like `secrets`
+/// would hide legitimate source modules (e.g. `src/secrets/`); credential
+/// *files* inside such dirs are still caught by the name rules.
+const SECRET_DIRS: &[&str] = &[".aws", ".azure", ".kube", ".docker"];
 
 /// Adjacent (parent, child) directory pairs — precise enough to avoid
 /// excluding e.g. a source directory that merely happens to be named `gcloud`.
@@ -83,7 +86,7 @@ fn literal_is_secret(path: &Path) -> bool {
 }
 
 /// True when `name` matches a deny-listed directory name. Used by walkers to
-/// prune descent into e.g. `.aws/` or `secrets/`.
+/// prune descent into e.g. `.aws/` or `.kube/`.
 pub fn is_secret_dir_name(name: &str) -> bool {
     let name = name.to_ascii_lowercase();
     SECRET_DIRS.contains(&name.as_str())
@@ -232,12 +235,13 @@ mod tests {
         assert!(secret("/home/u/.aws/credentials"));
         assert!(secret("/home/u/.aws/config"));
         assert!(secret(".kube/config"));
-        assert!(secret("deploy/secrets/token.txt"));
         assert!(secret("/home/u/.config/gcloud/access_tokens.db"));
         assert!(secret("/home/u/.docker/config.json"));
-        // A *file* named "secrets" is not a directory rule hit…
-        assert!(!secret("src/secrets"));
-        // …and unrelated dirs stay searchable.
+        // Generic `secrets` dirs are NOT excluded (would hide source modules);
+        // credential files inside them are still caught by name rules.
+        assert!(!secret("deploy/secrets/notes.txt"));
+        assert!(secret("deploy/secrets/token.pem"));
+        // Unrelated dirs stay searchable.
         assert!(!secret("src/config/mod.rs"));
         assert!(!secret("gcloud/main.rs"));
     }

--- a/src/core/secrets.rs
+++ b/src/core/secrets.rs
@@ -1,0 +1,281 @@
+//! Hard deny-list for credential/secret files (#2817).
+//!
+//! `.gitignore` is not a security boundary: `rtk grep` shells out to the system
+//! grep, which happily prints `.env` files and private keys straight into agent
+//! transcripts. This module provides a single, engine-independent exclude list
+//! applied by every filesystem-walking subcommand (`grep`/`rg`, `find`, `read`).
+//! It is unconditional by design — it does not depend on being inside a git
+//! repo or on `.gitignore` being correct — and can only be lifted explicitly
+//! with `--include-secrets`.
+//!
+//! Matching is case-insensitive and, because a filename-only check is
+//! bypassable via an innocuously-named symlink, symlinks are also matched
+//! against their resolved target.
+
+use std::path::{Component, Path};
+
+/// CLI flag that lifts the exclusion. Parsed manually by subcommands whose
+/// args are `trailing_var_arg` (grep/rg/find); a regular clap flag on `read`.
+pub const INCLUDE_SECRETS_FLAG: &str = "--include-secrets";
+
+/// File names that are credentials wherever they appear.
+const EXACT_NAMES: &[&str] = &[".env", ".git-credentials", ".pgpass", ".dockercfg"];
+
+/// File-name prefixes: `.env.local`, `id_rsa.pub`, `.netrc.bak`, …
+const NAME_PREFIXES: &[&str] = &[
+    ".env.",
+    "id_rsa",
+    "id_ed25519",
+    "id_dsa",
+    "id_ecdsa",
+    ".npmrc",
+    ".pypirc",
+    ".netrc",
+];
+
+/// File-name suffixes (extensions) that denote key material or state
+/// containing credentials.
+const NAME_SUFFIXES: &[&str] = &[".pem", ".key", ".p12", ".kdbx", ".tfstate", ".tfvars"];
+
+/// Directory components whose entire subtree is credential-bearing.
+const SECRET_DIRS: &[&str] = &[".aws", ".azure", ".kube", ".docker", "secrets"];
+
+/// Adjacent (parent, child) directory pairs — precise enough to avoid
+/// excluding e.g. a source directory that merely happens to be named `gcloud`.
+const SECRET_DIR_PAIRS: &[(&str, &str)] = &[(".config", "gcloud")];
+
+/// Case-insensitive check of a bare file name against the deny tables.
+fn name_is_secret(name: &str) -> bool {
+    let name = name.to_ascii_lowercase();
+    EXACT_NAMES.contains(&name.as_str())
+        || NAME_PREFIXES.iter().any(|p| name.starts_with(p))
+        || NAME_SUFFIXES.iter().any(|s| name.ends_with(s))
+}
+
+/// Check path components (directories) against the deny tables. The final
+/// component is a file/entry name judged separately (`name_is_secret` /
+/// `is_secret_dir_name`), so only its ancestors count as directories here.
+fn components_are_secret(path: &Path) -> bool {
+    let comps: Vec<String> = path
+        .components()
+        .filter_map(|c| match c {
+            Component::Normal(s) => Some(s.to_string_lossy().to_ascii_lowercase()),
+            _ => None,
+        })
+        .collect();
+    let Some((_, ancestors)) = comps.split_last() else {
+        return false;
+    };
+
+    ancestors.iter().any(|c| SECRET_DIRS.contains(&c.as_str()))
+        || comps
+            .windows(2)
+            .any(|w| SECRET_DIR_PAIRS.contains(&(w[0].as_str(), w[1].as_str())))
+}
+
+/// Literal (non-symlink-resolving) check.
+fn literal_is_secret(path: &Path) -> bool {
+    let name_hit = path
+        .file_name()
+        .map(|n| name_is_secret(&n.to_string_lossy()))
+        .unwrap_or(false);
+    name_hit || components_are_secret(path)
+}
+
+/// True when `name` matches a deny-listed directory name. Used by walkers to
+/// prune descent into e.g. `.aws/` or `secrets/`.
+pub fn is_secret_dir_name(name: &str) -> bool {
+    let name = name.to_ascii_lowercase();
+    SECRET_DIRS.contains(&name.as_str())
+}
+
+/// Walker-oriented check: `true` for deny-listed directories (so walkers can
+/// prune descent) and for secret files (symlink-target aware).
+pub fn is_secret_entry(path: &Path, is_dir: bool) -> bool {
+    if is_dir {
+        path.file_name()
+            .map(|n| is_secret_dir_name(&n.to_string_lossy()))
+            .unwrap_or(false)
+            || components_are_secret(path)
+    } else {
+        is_secret_path(path)
+    }
+}
+
+/// True when `path` denotes a credential/secret file, either literally or —
+/// when it is a symlink — via its resolved target (#2817: an innocuously-named
+/// symlink pointing at a secret file must not bypass the exclusion).
+pub fn is_secret_path(path: &Path) -> bool {
+    if literal_is_secret(path) {
+        return true;
+    }
+    match std::fs::symlink_metadata(path) {
+        Ok(md) if md.file_type().is_symlink() => std::fs::canonicalize(path)
+            .map(|target| literal_is_secret(&target))
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
+/// `--exclude`/`--exclude-dir` flags for a system-grep passthrough run.
+/// fnmatch is case-sensitive, so this is best-effort; the grouping path
+/// re-checks results with `is_secret_path`.
+pub fn grep_exclude_flags() -> Vec<String> {
+    let mut flags: Vec<String> = Vec::new();
+    for n in EXACT_NAMES {
+        flags.push(format!("--exclude={}", n));
+    }
+    for p in NAME_PREFIXES {
+        flags.push(format!("--exclude={}*", p));
+    }
+    for s in NAME_SUFFIXES {
+        flags.push(format!("--exclude=*{}", s));
+    }
+    for d in SECRET_DIRS {
+        flags.push(format!("--exclude-dir={}", d));
+    }
+    flags
+}
+
+/// `--iglob` exclusion flags for a ripgrep passthrough run (case-insensitive).
+pub fn rg_exclude_flags() -> Vec<String> {
+    let mut flags: Vec<String> = Vec::new();
+    for n in EXACT_NAMES {
+        flags.push(format!("--iglob=!**/{}", n));
+    }
+    for p in NAME_PREFIXES {
+        flags.push(format!("--iglob=!**/{}*", p));
+    }
+    for s in NAME_SUFFIXES {
+        flags.push(format!("--iglob=!**/*{}", s));
+    }
+    for d in SECRET_DIRS {
+        flags.push(format!("--iglob=!**/{}/**", d));
+    }
+    for (a, b) in SECRET_DIR_PAIRS {
+        flags.push(format!("--iglob=!**/{}/{}/**", a, b));
+    }
+    flags
+}
+
+/// Removes `--include-secrets` from `args` (only before a bare `--`, after
+/// which everything is positional). Returns the cleaned args and whether the
+/// flag was present.
+pub fn strip_include_secrets(args: &[String]) -> (Vec<String>, bool) {
+    let mut found = false;
+    let mut out = Vec::with_capacity(args.len());
+    let mut positional_only = false;
+    for a in args {
+        if a == "--" {
+            positional_only = true;
+        }
+        if !positional_only && a == INCLUDE_SECRETS_FLAG {
+            found = true;
+            continue;
+        }
+        out.push(a.clone());
+    }
+    (out, found)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn secret(p: &str) -> bool {
+        is_secret_path(&PathBuf::from(p))
+    }
+
+    #[test]
+    fn exact_names() {
+        assert!(secret(".env"));
+        assert!(secret("app/.env"));
+        assert!(secret("./.git-credentials"));
+        assert!(secret(".pgpass"));
+        assert!(!secret("environment.rs"));
+        assert!(!secret("env.rs"));
+    }
+
+    #[test]
+    fn prefixes() {
+        assert!(secret(".env.local"));
+        assert!(secret(".env.production"));
+        assert!(secret("id_rsa"));
+        assert!(secret("keys/id_rsa.pub"));
+        assert!(secret("id_ed25519"));
+        assert!(secret(".npmrc"));
+        assert!(secret(".netrc.bak"));
+        assert!(!secret("id_card.rs"));
+    }
+
+    #[test]
+    fn suffixes() {
+        assert!(secret("server.pem"));
+        assert!(secret("certs/tls.key"));
+        assert!(secret("vault.kdbx"));
+        assert!(secret("infra/terraform.tfstate"));
+        assert!(secret("prod.tfvars"));
+        assert!(!secret("monkey.rs"));
+        assert!(!secret("keyboard.ts"));
+    }
+
+    #[test]
+    fn case_insensitive() {
+        assert!(secret(".ENV"));
+        assert!(secret("SECRET.PEM"));
+        assert!(secret("ID_RSA"));
+    }
+
+    #[test]
+    fn secret_directories() {
+        assert!(secret("/home/u/.aws/credentials"));
+        assert!(secret("/home/u/.aws/config"));
+        assert!(secret(".kube/config"));
+        assert!(secret("deploy/secrets/token.txt"));
+        assert!(secret("/home/u/.config/gcloud/access_tokens.db"));
+        assert!(secret("/home/u/.docker/config.json"));
+        // A *file* named "secrets" is not a directory rule hit…
+        assert!(!secret("src/secrets"));
+        // …and unrelated dirs stay searchable.
+        assert!(!secret("src/config/mod.rs"));
+        assert!(!secret("gcloud/main.rs"));
+    }
+
+    #[test]
+    fn strip_flag() {
+        let args: Vec<String> = ["-rn", "--include-secrets", "PAT", "."]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let (cleaned, found) = strip_include_secrets(&args);
+        assert!(found);
+        assert_eq!(cleaned, vec!["-rn", "PAT", "."]);
+
+        // After `--` the token is positional and must survive.
+        let args: Vec<String> = ["PAT", "--", "--include-secrets"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let (cleaned, found) = strip_include_secrets(&args);
+        assert!(!found);
+        assert_eq!(cleaned, vec!["PAT", "--", "--include-secrets"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_target_is_checked() {
+        let dir = std::env::temp_dir().join(format!("rtk_secrets_test_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let target = dir.join("secret.pem");
+        std::fs::write(&target, "FAKE").expect("write target");
+        let link = dir.join("innocuous.txt");
+        let _ = std::fs::remove_file(&link);
+        std::os::unix::fs::symlink(&target, &link).expect("create symlink");
+
+        assert!(is_secret_path(&link), "symlink to secret must be excluded");
+        assert!(!is_secret_path(&dir.join("plain.txt")));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,9 @@ enum Commands {
         /// Show line numbers
         #[arg(short = 'n', long)]
         line_numbers: bool,
+        /// Also read credential/secret files (.env, keys, …) excluded by default
+        #[arg(long)]
+        include_secrets: bool,
     },
 
     /// Generate 2-line technical summary (heuristic-based)
@@ -1566,6 +1569,7 @@ fn run_cli() -> Result<i32> {
             max_lines,
             tail_lines,
             line_numbers,
+            include_secrets,
         } => {
             let mut had_error = false;
             let mut stdin_seen = false;
@@ -1584,6 +1588,7 @@ fn run_cli() -> Result<i32> {
                         max_lines,
                         tail_lines,
                         line_numbers,
+                        include_secrets,
                         cli.verbose,
                     )
                 };


### PR DESCRIPTION
Fixes #2817.

`rtk grep` shells out to the system grep, which prints `.env` files, private keys, and cloud credentials straight into agent transcripts — even inside a git repo where those files are listed in `.gitignore` and `rtk find` (gitignore-aware) correctly excludes them.

## Approach

New `src/core/secrets.rs`: a single, engine-independent deny list (`.env*`, `*.pem`/`*.key`/`*.p12`/`*.kdbx`, `id_rsa*`/`id_ed25519*`/`id_dsa*`/`id_ecdsa*`, `.npmrc*`/`.pypirc*`/`.netrc*`, `.git-credentials`, `.pgpass`, `.dockercfg`, `*.tfstate`/`*.tfvars`, and the `.aws`/`.azure`/`.kube`/`.docker`/`.config/gcloud` directories). Applied unconditionally — no git repo or correct `.gitignore` required. Matching is case-insensitive, and symlinks are matched against their resolved target, so an innocuously-named link to a secret file cannot bypass the exclusion.

Generic directory names like `secrets/` are deliberately **not** excluded: that would hide legitimate source modules (e.g. `src/secrets/` rotation code) from agents. Credential files inside such directories are still caught by the name rules.

Applied in:

- **grep/rg grouping path** — matches from credential files are dropped on the parsed results, not via engine flags, so it works identically for both engines and sees through symlinks. A stderr note keeps it visible:
  ```
  rtk: 3 match(es) in 3 credential file(s) hidden (rerun with --include-secrets to show them)
  ```
- **grep/rg passthrough path** (`-l`/`-c`/`-o`/`--files`/unparseable shapes) — explicitly-named credential files are dropped with a per-file stderr warning rather than silently skipped, so an agent never gets a plausible-but-wrong "no match"; if every named file was a credential file the engine is not run at all (it would fall back to reading stdin) and the no-match exit code is mirrored. Recursive scans get engine-native exclusions prepended (`--exclude`/`--exclude-dir` for grep, `--iglob` for rg).
- **find** — `WalkBuilder::filter_entry` prunes credential directories and drops secret files.
- **read** — refuses credential files with a clear error and exit 1.

`--include-secrets` lifts the exclusion on every subcommand (legitimate case: auditing a secrets file's structure); `rtk proxy` remains the raw escape hatch.

Exit codes stay truthful throughout: when matches exist but are hidden, the engine's real exit code is kept and stderr explains the empty stdout — no fabricated codes.

## Not included (possible follow-ups from the issue)

- Output-side redaction of secret-shaped values (`AKIA…`, `sk-…`, PEM headers) as defense in depth
- `rtk env` value masking

## Verification

- 10 new unit tests: deny-table matching (exact/prefix/suffix/case/dirs), `--include-secrets` stripping incl. after `--`, symlink-target resolution
- `cargo test --all`: 2417 passed; clippy clean
- Startup: 6.6 ms mean (hyperfine, release build) — within the <10 ms target
- End-to-end against the issue's repro on macOS (BSD grep) and against `rtk rg`: gitignored `.env`/`.pem`/`.aws/credentials` no longer printed by any path; explicit-file, recursive, passthrough (`-l`, `-c`), find, and read all covered; `src/secrets/` source code remains searchable; control searches unaffected

Note on the issue's repro file: `secret.txt` remains searchable by design — this implements the hard filename deny list (the shape of `git-deny-patterns.json`), not gitignore awareness, and `secret.txt` matches no deny pattern. Making `rtk grep` gitignore-aware is a separate discussion (#2606).