### PR TITLE
fix(proxy): stop blocking on orphaned stdio pipes after the child exits

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2528,49 +2528,87 @@ fn run_cli() -> Result<i32> {
 
             const CAP: usize = 1_048_576;
 
-            let stdout_handle = thread::spawn(move || -> std::io::Result<Vec<u8>> {
-                let mut reader = stdout_pipe;
-                let mut captured = Vec::new();
-                let mut buf = [0u8; 8192];
-
-                loop {
-                    let count = reader.read(&mut buf)?;
-                    if count == 0 {
-                        break;
+            // The reader threads only stop at pipe EOF. EOF never arrives
+            // when a descendant of the child (build daemon, background job)
+            // inherits the pipe write end and outlives it, so a plain join()
+            // blocks rtk forever after the command itself finished (#2320).
+            // Once the child has exited, wait briefly for the readers to
+            // drain, then detach any reader still blocked on an orphaned
+            // pipe — std::process::exit() in main() reaps it. Captures are
+            // shared so tracking still sees what was streamed on detach.
+            fn finish_reader(
+                handle: thread::JoinHandle<std::io::Result<()>>,
+                stream: &str,
+                deadline: std::time::Instant,
+            ) -> Result<()> {
+                while !handle.is_finished() {
+                    if std::time::Instant::now() >= deadline {
+                        return Ok(());
                     }
-                    if captured.len() < CAP {
-                        let take = count.min(CAP - captured.len());
-                        captured.extend_from_slice(&buf[..take]);
-                    }
-                    let mut out = std::io::stdout().lock();
-                    out.write_all(&buf[..count])?;
-                    out.flush()?;
+                    thread::sleep(std::time::Duration::from_millis(10));
                 }
+                handle
+                    .join()
+                    .map_err(|_| anyhow::anyhow!("{} streaming thread panicked", stream))?
+                    .map_err(anyhow::Error::from)
+            }
 
-                Ok(captured)
-            });
+            let stdout_buf = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+            let stderr_buf = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
 
-            let stderr_handle = thread::spawn(move || -> std::io::Result<Vec<u8>> {
-                let mut reader = stderr_pipe;
-                let mut captured = Vec::new();
-                let mut buf = [0u8; 8192];
+            let stdout_handle = {
+                let captured = std::sync::Arc::clone(&stdout_buf);
+                thread::spawn(move || -> std::io::Result<()> {
+                    let mut reader = stdout_pipe;
+                    let mut buf = [0u8; 8192];
 
-                loop {
-                    let count = reader.read(&mut buf)?;
-                    if count == 0 {
-                        break;
+                    loop {
+                        let count = reader.read(&mut buf)?;
+                        if count == 0 {
+                            break;
+                        }
+                        {
+                            let mut captured = captured.lock().unwrap_or_else(|p| p.into_inner());
+                            if captured.len() < CAP {
+                                let take = count.min(CAP - captured.len());
+                                captured.extend_from_slice(&buf[..take]);
+                            }
+                        }
+                        let mut out = std::io::stdout().lock();
+                        out.write_all(&buf[..count])?;
+                        out.flush()?;
                     }
-                    if captured.len() < CAP {
-                        let take = count.min(CAP - captured.len());
-                        captured.extend_from_slice(&buf[..take]);
-                    }
-                    let mut err = std::io::stderr().lock();
-                    err.write_all(&buf[..count])?;
-                    err.flush()?;
-                }
 
-                Ok(captured)
-            });
+                    Ok(())
+                })
+            };
+
+            let stderr_handle = {
+                let captured = std::sync::Arc::clone(&stderr_buf);
+                thread::spawn(move || -> std::io::Result<()> {
+                    let mut reader = stderr_pipe;
+                    let mut buf = [0u8; 8192];
+
+                    loop {
+                        let count = reader.read(&mut buf)?;
+                        if count == 0 {
+                            break;
+                        }
+                        {
+                            let mut captured = captured.lock().unwrap_or_else(|p| p.into_inner());
+                            if captured.len() < CAP {
+                                let take = count.min(CAP - captured.len());
+                                captured.extend_from_slice(&buf[..take]);
+                            }
+                        }
+                        let mut err = std::io::stderr().lock();
+                        err.write_all(&buf[..count])?;
+                        err.flush()?;
+                    }
+
+                    Ok(())
+                })
+            };
 
             let status = child
                 .0
@@ -2579,12 +2617,14 @@ fn run_cli() -> Result<i32> {
                 .wait()
                 .context(format!("Failed waiting for command: {}", cmd_name))?;
 
-            let stdout_bytes = stdout_handle
-                .join()
-                .map_err(|_| anyhow::anyhow!("stdout streaming thread panicked"))??;
-            let stderr_bytes = stderr_handle
-                .join()
-                .map_err(|_| anyhow::anyhow!("stderr streaming thread panicked"))??;
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+            finish_reader(stdout_handle, "stdout", deadline)?;
+            finish_reader(stderr_handle, "stderr", deadline)?;
+
+            let stdout_bytes =
+                std::mem::take(&mut *stdout_buf.lock().unwrap_or_else(|p| p.into_inner()));
+            let stderr_bytes =
+                std::mem::take(&mut *stderr_buf.lock().unwrap_or_else(|p| p.into_inner()));
 
             let stdout = String::from_utf8_lossy(&stdout_bytes);
             let stderr = String::from_utf8_lossy(&stderr_bytes);

--- a/tests/proxy_orphan_pipe_test.rs
+++ b/tests/proxy_orphan_pipe_test.rs
@@ -1,0 +1,76 @@
+//! The proxy path must return when the child exits, even if a descendant
+//! of the child keeps the inherited stdout/stderr pipes open (#2320).
+
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Command whose direct child exits immediately while leaving behind a
+/// quiet descendant that holds the inherited stdout/stderr pipes for ~30s.
+#[cfg(unix)]
+fn orphan_pipe_args() -> Vec<&'static str> {
+    vec!["proxy", "sh", "-c", "echo ready; sleep 30 & exit 0"]
+}
+
+#[cfg(windows)]
+fn orphan_pipe_args() -> Vec<&'static str> {
+    vec![
+        "proxy",
+        "cmd",
+        "/c",
+        "echo ready& start /b waitfor RtkOrphanPipeTest /t 30 & exit /b 0",
+    ]
+}
+
+#[test]
+fn proxy_exits_when_child_dies_despite_orphaned_pipe() {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_rtk"));
+    cmd.args(orphan_pipe_args())
+        .stdin(Stdio::null())
+        .stderr(Stdio::null());
+
+    // On Windows the orphan inherits rtk's own stdout handle too (handle
+    // inheritance is table-wide), so reading a pipe here would block on the
+    // very orphan this test creates. The streamed-output check is unix-only.
+    #[cfg(unix)]
+    cmd.stdout(Stdio::piped());
+    #[cfg(windows)]
+    cmd.stdout(Stdio::null());
+
+    let mut child = cmd.spawn().expect("spawn rtk");
+
+    // Well over the 2s drain grace, well under the 30s the orphan lives.
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let status = loop {
+        match child.try_wait().expect("try_wait rtk") {
+            Some(status) => break status,
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("rtk proxy hung on an orphaned pipe after the child exited");
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    };
+
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "child exited 0, rtk must forward its exit code"
+    );
+
+    #[cfg(unix)]
+    {
+        use std::io::Read;
+        let mut stdout = String::new();
+        child
+            .stdout
+            .take()
+            .expect("stdout")
+            .read_to_string(&mut stdout)
+            .expect("read rtk stdout");
+        assert!(
+            stdout.contains("ready"),
+            "child output should be streamed through, got: {stdout:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- The proxy path blocked forever after the wrapped command exited whenever a descendant of the child kept the inherited stdout/stderr pipe write ends open (build daemons, watchers, background jobs): the reader threads never saw EOF, so the unconditional `join()` never returned. Deterministic repro and full analysis in #2829 (same mechanism as #2320, reproduced on Windows and unix).
- After `child.wait()` returns, the reader threads are now joined with a 2s grace period and detached if still blocked on an orphaned pipe; `std::process::exit()` in `main()` reaps them. Captured output moved to shared buffers so tracking still records exactly what was streamed when a reader is detached.
- Adds an integration test that leaves a quiet ~30s orphan holding the pipes and asserts `rtk proxy` returns promptly with the child's exit code (and, on unix, that the child's output was streamed through).

Fixes #2829

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test` (Windows 11, stable)
- [x] New test `proxy_exits_when_child_dies_despite_orphaned_pipe` fails on `develop` (hangs until the 15s deadline) and passes with this change
- [x] Manual before/after: `rtk proxy cmd /c "start /b waitfor ZZZ /t 20 & exit /b 0"` — before: returns after ~20.2s (when the orphan dies; forever with a real daemon); after: returns in ~2s with exit code 0 and identical output
- [x] Manual sanity: `rtk proxy git status`, `rtk proxy cmd /c "echo hi & exit /b 3"` — output and exit codes unchanged, no added latency on the normal EOF path
