### PR TITLE
fix(discover): encode -p project path for sanitized transcript dir names

### DIFF
--- a/src/discover/mod.rs
+++ b/src/discover/mod.rs
@@ -54,7 +54,8 @@ pub fn run(
     let project_filter = if all {
         None
     } else if let Some(p) = project {
-        Some(p.to_string())
+        let encoded = ClaudeProvider::encode_project_path(p);
+        Some(encoded)
     } else {
         // Default: current working directory
         let cwd = std::env::current_dir()?;


### PR DESCRIPTION
## Summary

Fixes #2834 — `rtk discover -p /absolute/path` silently matched 0 sessions.

## Problem

Claude Code stores transcripts under sanitized directory names where `/` becomes `-` (e.g., `~/.claude/projects/-home-user-projects-my-app/`). When a user provides `-p /absolute/path`, the filter value containing `/` characters can never substring-match the sanitized directory names.

The CWD fallback path in `mod.rs` already correctly encodes the path with `encode_project_path()`, but the explicit `-p` path was used raw.

## Fix

Apply `ClaudeProvider::encode_project_path()` to the `-p` value before using it as a filter — the same encoding already applied for the default current-working-directory path.

## Change

- `src/discover/mod.rs`: 1 line changed — encode `-p` path before filtering

## Verification

The existing tests for `encode_project_path` (in `provider.rs`) already cover:
- Absolute Unix paths: `/Users/foo/bar` → `-Users-foo-bar`
- Dots in paths: `/Users/first.last/my-project` → `-Users-first-last-my-project`
- Underscores: `/home/chris/2_project-files/proj` → `-home-chris-2-project-files-proj`
- Non-ASCII, Windows backslashes, spaces, brackets

The `test_match_project_filter` test validates that encoded paths correctly contain project name substrings.

Local `cargo` build could not run (no C compiler in this environment). The change follows the exact same pattern as the existing CWD encoding on lines 62-63 of the same file.