### PR TITLE
fix(grep): preserve -- separator between non-adjacent match blocks

### DIFF
--- a/src/cmds/system/search.rs
+++ b/src/cmds/system/search.rs
@@ -339,6 +339,20 @@ fn has_short_flag(flags: &[String], ch: char) -> bool {
         .any(|f| f.starts_with('-') && !f.starts_with("--") && f[1..].contains(ch))
 }
 
+fn has_context_flag(flags: &[String]) -> bool {
+    has_short_flag(flags, 'A')
+        || has_short_flag(flags, 'B')
+        || has_short_flag(flags, 'C')
+        || flags.iter().any(|f| {
+            f == "--after-context"
+                || f == "--before-context"
+                || f == "--context"
+                || f.starts_with("--after-context=")
+                || f.starts_with("--before-context=")
+                || f.starts_with("--context=")
+        })
+}
+
 pub fn run(
     engine: Engine,
     max_line_len: usize,
@@ -482,6 +496,8 @@ pub fn run(
         plain.push('\n');
     }
 
+    let has_context = has_context_flag(&extra_args);
+
     let per_file = config::limits().grep_max_per_file;
     let mut files: Vec<_> = by_file.iter().collect();
     files.sort_by_key(|(f, _)| *f);
@@ -504,7 +520,7 @@ pub fn run(
             if shown >= max_results {
                 break;
             }
-            if prev_line > 0 && *line_num > prev_line + 1 {
+            if has_context && prev_line > 0 && *line_num > prev_line + 1 {
                 body.push_str("--\n");
             }
             prev_line = *line_num;
@@ -1383,5 +1399,33 @@ mod tests {
         // Context lines (dash separator) parse via the updated regex → not counted.
         let stdout = "file.txt\x003-context_before\nfile.txt\x004:match\nfile.txt\x005-context_after\n";
         assert_eq!(unparsed_signal(stdout), 0);
+    }
+
+    // --- has_context_flag ---
+
+    #[test]
+    fn test_has_context_flag_short() {
+        let f = |args: &[&str]| -> bool {
+            has_context_flag(&args.iter().map(|s| s.to_string()).collect::<Vec<_>>())
+        };
+        assert!(f(&["-A", "3"]));
+        assert!(f(&["-B", "2"]));
+        assert!(f(&["-C", "1"]));
+        assert!(!f(&["-rn"]));
+        assert!(!f(&["-i", "-w"]));
+    }
+
+    #[test]
+    fn test_has_context_flag_long() {
+        let f = |args: &[&str]| -> bool {
+            has_context_flag(&args.iter().map(|s| s.to_string()).collect::<Vec<_>>())
+        };
+        assert!(f(&["--after-context", "3"]));
+        assert!(f(&["--before-context", "2"]));
+        assert!(f(&["--context", "1"]));
+        assert!(f(&["--after-context=3"]));
+        assert!(f(&["--before-context=2"]));
+        assert!(f(&["--context=1"]));
+        assert!(!f(&["--color", "auto"]));
     }
 }

--- a/src/cmds/system/search.rs
+++ b/src/cmds/system/search.rs
@@ -464,6 +464,9 @@ pub fn run(
     let mut plain = String::new();
     for line in raw_output.lines() {
         let Some((file, line_num, is_match, content)) = parse_match_line(line) else {
+            if line == "--" {
+                plain.push_str("--\n");
+            }
             continue;
         };
         let sep = if is_match { ':' } else { '-' };
@@ -496,10 +499,15 @@ pub fn run(
 
         let file_display = compact_path(file);
         let mut file_shown = 0;
+        let mut prev_line: usize = 0;
         for (line_num, is_match, content) in entries.iter().take(per_file) {
             if shown >= max_results {
                 break;
             }
+            if prev_line > 0 && *line_num > prev_line + 1 {
+                body.push_str("--\n");
+            }
+            prev_line = *line_num;
             let sep = if *is_match { ':' } else { '-' };
             if show_file {
                 body.push_str(&file_display);

--- a/tests/grep_context_test.rs
+++ b/tests/grep_context_test.rs
@@ -114,6 +114,36 @@ fn group_separator_between_non_adjacent_matches() {
 }
 
 #[test]
+fn no_separator_without_context_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let f = dir.path().join("nosep.txt");
+    std::fs::write(
+        &f,
+        "match line 1\nfiller\nfiller\nfiller\nmatch line 2\nfiller\nfiller\nmatch line 3\n",
+    )
+    .unwrap();
+
+    let out = rtk()
+        .args(["grep", "-n", "match", f.to_str().unwrap()])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !stdout.contains("--"),
+        "plain grep without -A/-B/-C must not insert -- separators:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("match line 1"),
+        "first match must be present:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("match line 3"),
+        "third match must be present:\n{stdout}"
+    );
+}
+
+#[test]
 fn only_matching_output_has_no_nul_separator() {
     if !rg_available() {
         return;

--- a/tests/grep_context_test.rs
+++ b/tests/grep_context_test.rs
@@ -84,6 +84,36 @@ fn count_output_has_no_nul_separator() {
 }
 
 #[test]
+fn group_separator_between_non_adjacent_matches() {
+    let dir = tempfile::tempdir().unwrap();
+    let f = dir.path().join("sep.txt");
+    std::fs::write(
+        &f,
+        "alpha match here\nfiller 1\nfiller 2\nfiller 3\nfiller 4\nfiller 5\nbeta match here\n",
+    )
+    .unwrap();
+
+    let out = rtk()
+        .args(["grep", "-A1", "match", f.to_str().unwrap()])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        stdout.contains("--"),
+        "missing group separator between non-adjacent match blocks:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("alpha match here"),
+        "first match must be present:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("beta match here"),
+        "second match must be present:\n{stdout}"
+    );
+}
+
+#[test]
 fn only_matching_output_has_no_nul_separator() {
     if !rg_available() {
         return;

--- a/tests/grep_faithful_format_test.rs
+++ b/tests/grep_faithful_format_test.rs
@@ -94,6 +94,17 @@ fn context_flags_match_grep_n() {
     assert_eq_grep_n(&["-C1", "MATCH", &f]);
 }
 
+#[test]
+fn context_group_separator_matches_grep_n() {
+    let d = tempfile::tempdir().unwrap();
+    let f = write(
+        d.path(),
+        "sep.txt",
+        "match A\nfill1\nfill2\nfill3\nmatch B\n",
+    );
+    assert_eq_grep_n(&["-A1", "match", &f]);
+}
+
 // #1436: a single-file `-n` search with `::` content and a BRE pattern with
 // literal `()` must equal grep exactly — no broadened matches, and no synthetic
 // `[file]` bucket from splitting on `::`.


### PR DESCRIPTION
## Summary
- `grep -A/-B/-C` context output was dropping the `--` group separator between non-adjacent match blocks
- Consumers (human or LLM) could not tell where one match ended and the next began
- Fixed by preserving `--` in both the faithful baseline and grouped output paths

Fixes #2795

## Test plan
- [x] Added regression test (`group_separator_between_non_adjacent_matches`)
- [x] Added faithful format test (`context_group_separator_matches_grep_n`)
- [x] Verified output matches native `grep -n -A1` exactly
- [x] `cargo fmt && cargo clippy --all-targets && cargo test --all` passes