### PR TITLE
feat: add cat output filter

### DIFF
--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -1896,8 +1896,8 @@ match_command = "^make\\b"
         let filters = make_filters(BUILTIN_TOML);
         assert_eq!(
             filters.len(),
-            63,
-            "Expected exactly 63 built-in filters, got {}. \
+            64,
+            "Expected exactly 64 built-in filters, got {}. \
              Update this count when adding/removing filters in src/filters/.",
             filters.len()
         );
@@ -1954,11 +1954,11 @@ expected = "output line 1\noutput line 2"
         let combined = format!("{}\n\n{}", BUILTIN_TOML, new_filter);
         let filters = make_filters(&combined);
 
-        // All 63 existing filters still present + 1 new = 64
+        // All 64 existing filters still present + 1 new = 65
         assert_eq!(
             filters.len(),
-            64,
-            "Expected 64 filters after concat (63 built-in + 1 new)"
+            65,
+            "Expected 65 filters after concat (64 built-in + 1 new)"
         );
 
         // New filter is discoverable

--- a/src/filters/cat.toml
+++ b/src/filters/cat.toml
@@ -1,0 +1,25 @@
+[filters.cat]
+description = "Compact cat output — limit total lines, truncate wide content"
+match_command = "^cat(\\s|$)"
+strip_ansi = true
+strip_lines_matching = [
+  "^\\s*$",
+]
+max_lines = 100
+truncate_lines_at = 200
+on_empty = "cat: ok"
+
+[[tests.cat]]
+name = "file content preserved up to limit"
+input = "line 1\nline 2\nline 3\nline 4\nline 5"
+expected = "line 1\nline 2\nline 3\nline 4\nline 5"
+
+[[tests.cat]]
+name = "trailing blank lines stripped"
+input = "some content\n\n\n"
+expected = "some content"
+
+[[tests.cat]]
+name = "empty input passes through"
+input = ""
+expected = "cat: ok"


### PR DESCRIPTION
Adds a compact output filter for `cat`, one of the most commonly used commands that was missing from the built-in filters list.

Files changed: src/filters/cat.toml (new), src/core/toml_filter.rs (filter count bump)

Closes #2803

## Verification

- `cargo test` passes (2360 tests, 0 failures)
- New filter has 3 inline tests: basic output, trailing blanks, empty input