### PR TITLE
fix(cc-economics): accept ccusage v20 'period' field via serde alias

### DIFF
--- a/src/analytics/ccusage.rs
+++ b/src/analytics/ccusage.rs
@@ -53,6 +53,7 @@ struct DailyResponse {
 
 #[derive(Debug, Deserialize)]
 struct DailyEntry {
+    #[serde(alias = "period")]
     date: String,
     #[serde(flatten)]
     metrics: CcusageMetrics,
@@ -65,6 +66,7 @@ struct WeeklyResponse {
 
 #[derive(Debug, Deserialize)]
 struct WeeklyEntry {
+    #[serde(alias = "period")]
     week: String, // ISO week start (Monday)
     #[serde(flatten)]
     metrics: CcusageMetrics,
@@ -77,6 +79,7 @@ struct MonthlyResponse {
 
 #[derive(Debug, Deserialize)]
 struct MonthlyEntry {
+    #[serde(alias = "period")]
     month: String,
     #[serde(flatten)]
     metrics: CcusageMetrics,


### PR DESCRIPTION
## Problem

`rtk cc-economics` (and its `--daily` / `--weekly` breakdowns) fails with ccusage >= 20:

```
rtk: Failed to fetch ccusage monthly data: Failed to parse ccusage JSON output:
Invalid JSON structure for monthly data: missing field `month` at line 39 column 5
```

ccusage v20 switched its root `daily` / `weekly` / `monthly` commands to a unified multi-agent schema where the period-key field is always named `period` (plus new `agent` / `metadata` fields, which serde already ignores):

```json
{ "monthly": [ { "agent": "all", "period": "2026-05", "inputTokens": 15838, "totalCost": 659.17, ... } ] }
```

`src/analytics/ccusage.rs` requires `date` / `week` / `month` respectively, so deserialization fails for all three granularities. All other required fields (`inputTokens`, `outputTokens`, `totalTokens`, `totalCost`) are unchanged in v20.

## Fix

Add `#[serde(alias = "period")]` to the three entry structs. This is backward-compatible: old ccusage versions still emit `date` / `week` / `month`, new ones emit `period`, and the two never appear together.

## Verification

- Reproduced on rtk 0.42.4 and dev-0.44.0-rc.308 with ccusage 20.0.14 (pnpm global, Windows 11).
- Verified the equivalent field-mapping end-to-end on the same machine via a PATH shim that routes rtk's exact invocations to `ccusage claude <granularity>` (which still emits the legacy field names): `cc-economics`, `--daily`, `--weekly`, and `--all` all render correctly with the legacy names mapped.
- Note: this branch is **not compiled locally** (no Rust toolchain on this machine) — the change is attribute-only; CI should verify the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
