### PR TITLE
fix(search): actionable error when engine binary is missing

### DIFF
--- a/src/cmds/system/search.rs
+++ b/src/cmds/system/search.rs
@@ -287,6 +287,15 @@ impl Engine {
             Engine::Rg => &["-n", "--with-filename", "--null"],
         }
     }
+
+    /// Context for a spawn failure (binary missing): name the engine and the
+    /// sibling to retry with, so the agent can self-correct in one step.
+    fn spawn_failure_hint(self) -> &'static str {
+        match self {
+            Engine::Grep => "could not run 'grep' — install it or retry with 'rtk rg'",
+            Engine::Rg => "could not run 'rg' — install ripgrep or retry with 'rtk grep'",
+        }
+    }
 }
 
 /// Runs the agent's exact engine + flags for the grouping path, appending only the
@@ -307,7 +316,7 @@ fn engine_capture<T: AsRef<str>>(
     }
     cmd.arg("--");
     cmd.args(paths);
-    exec_capture_stdin(&mut cmd).context("search failed")
+    exec_capture_stdin(&mut cmd).context(engine.spawn_failure_hint())
 }
 
 /// Runs the agent's command verbatim for forms RTK does not group: format/shape
@@ -322,7 +331,7 @@ fn passthrough<T: AsRef<str>>(
     for a in args {
         cmd.arg(a.as_ref());
     }
-    let result = exec_capture_stdin(&mut cmd).context("search failed")?;
+    let result = exec_capture_stdin(&mut cmd).context(engine.spawn_failure_hint())?;
 
     print!("{}", strip_ansi(&result.stdout));
     if !result.stderr.is_empty() {
@@ -372,7 +381,7 @@ pub fn run(
     {
         let mut cmd = resolved_command(engine.bin());
         cmd.args(args);
-        let result = exec_capture(&mut cmd).context("search failed")?;
+        let result = exec_capture(&mut cmd).context(engine.spawn_failure_hint())?;
         print!("{}", result.stdout);
         if !result.stderr.is_empty() {
             eprint!("{}", result.stderr);

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -533,7 +533,12 @@ impl CaptureResult {
 
 pub fn exec_capture(cmd: &mut Command) -> Result<CaptureResult> {
     cmd.stdin(Stdio::null());
-    let output = cmd.output().context("Failed to execute command")?;
+    let output = cmd.output().with_context(|| {
+        format!(
+            "failed to execute '{}'",
+            cmd.get_program().to_string_lossy()
+        )
+    })?;
     Ok(CaptureResult {
         stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
         stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
@@ -544,7 +549,12 @@ pub fn exec_capture(cmd: &mut Command) -> Result<CaptureResult> {
 /// Like [`exec_capture`] but inherits stdin so a wrapped engine can read a piped stdin.
 pub fn exec_capture_stdin(cmd: &mut Command) -> Result<CaptureResult> {
     cmd.stdin(Stdio::inherit());
-    let output = cmd.output().context("Failed to execute command")?;
+    let output = cmd.output().with_context(|| {
+        format!(
+            "failed to execute '{}'",
+            cmd.get_program().to_string_lossy()
+        )
+    })?;
     Ok(CaptureResult {
         stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
         stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
@@ -556,6 +566,18 @@ pub fn exec_capture_stdin(cmd: &mut Command) -> Result<CaptureResult> {
 pub(crate) mod tests {
     use super::*;
     use std::process::Command;
+
+    #[test]
+    fn exec_capture_missing_binary_names_it_in_error() {
+        let mut cmd = Command::new("rtk-test-no-such-binary");
+        let Err(err) = exec_capture(&mut cmd) else {
+            panic!("spawn must fail");
+        };
+        assert!(
+            format!("{err:#}").contains("rtk-test-no-such-binary"),
+            "error must name the binary: {err:#}"
+        );
+    }
 
     struct LineFilter<F: FnMut(&str) -> Option<String>> {
         f: F,

--- a/tests/search_error_test.rs
+++ b/tests/search_error_test.rs
@@ -105,6 +105,26 @@ fn no_match_stays_exit_1_and_empty() {
 }
 
 #[test]
+fn missing_engine_error_is_actionable() {
+    let (_d, f) = write_temp("fn alpha\n");
+    let out = Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args(["grep", "fn", &f])
+        .env("PATH", "/nonexistent")
+        .output()
+        .expect("rtk");
+    assert!(!out.status.success(), "a missing engine must not exit 0");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("could not run '"),
+        "the error must name the missing engine:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("retry with"),
+        "the error must give a next step:\n{stderr}"
+    );
+}
+
+#[test]
 fn rg_bad_regex_surfaces_error_exit_2() {
     if !rg_available() {
         return;


### PR DESCRIPTION
## Problem

When the search engine binary cannot be spawned (missing from PATH -- sandboxes, slim containers, restricted environments), rtk surfaces:

```
rtk: search failed: Failed to execute command: No such file or directory (os error 2)
```

No binary name, no next step. An agent hitting this has to burn 1-2 extra tool calls guessing whether it is a path problem, a flag problem, or a missing engine.

## Change

After this PR the same failure reads:

```
rtk: could not run 'grep' -- install it or retry with 'rtk rg': failed to execute 'grep': No such file or directory (os error 2)
```

- **`core/stream.rs`**: `exec_capture` / `exec_capture_stdin` spawn errors now name the program they tried to run. This is the shared layer, so every command that spawns through these helpers gets diagnosable errors, not just search.
- **`cmds/system/search.rs`**: the three `.context("search failed")` sites now use an engine-specific hint naming the missing binary and the sibling engine to retry with.

## What this does NOT change

- Engine errors (exit >= 2) still pass stderr through verbatim with no synthetic lines, and no-match stays a silent exit 1 -- all existing assertions in `tests/search_error_test.rs` (#2465 / #1436) pass unchanged. This PR only touches the spawn-failure path, where the engine never ran and there is no stderr to surface.
- No behavior, exit code, output format, or performance changes. Error-path strings only.

## Tests

- `missing_engine_error_is_actionable` (integration): runs `rtk grep` with an empty PATH and asserts the error names the engine and contains a next step.
- `exec_capture_missing_binary_names_it_in_error` (unit): asserts spawn errors name the binary.
- `cargo fmt --all && cargo clippy --all-targets && cargo test --all`: clean, 2417 passed.