### PR TITLE
fix(find): round dir-display truncation up to a char boundary (fixes #2851)

### DIFF
--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -26,6 +26,18 @@ fn glob_match_inner(pat: &[u8], name: &[u8]) -> bool {
     }
 }
 
+/// Truncate a long directory path for display, keeping the last ~47 bytes.
+/// The cut is rounded up to a char boundary so multi-byte UTF-8 (e.g. 'é')
+/// at the cut point doesn't panic (issue #2851).
+fn dir_display(dir: &str) -> String {
+    if dir.len() > 50 {
+        let cut = dir.ceil_char_boundary(dir.len() - 47);
+        format!("...{}", &dir[cut..])
+    } else {
+        dir.to_string()
+    }
+}
+
 /// Parsed arguments from either native find or RTK find syntax.
 #[derive(Debug)]
 struct FindArgs {
@@ -322,11 +334,7 @@ pub fn run(
         }
 
         let files_in_dir = &by_dir[dir];
-        let dir_display = if dir.len() > 50 {
-            format!("...{}", &dir[dir.len() - 47..])
-        } else {
-            dir.clone()
-        };
+        let dir_display = dir_display(dir);
 
         let remaining_budget = max_results - displayed;
         if files_in_dir.len() <= remaining_budget {
@@ -391,6 +399,23 @@ mod tests {
     /// Convert string slices to Vec<String> for test convenience.
     fn args(values: &[&str]) -> Vec<String> {
         values.iter().map(|s| s.to_string()).collect()
+    }
+
+    // --- dir_display unit tests ---
+
+    #[test]
+    fn dir_display_truncates_multibyte_on_char_boundary() {
+        // 57 bytes: the naive cut lands at byte 10, inside 'é' (bytes 9..11)
+        // and used to panic (issue #2851)
+        let dir = "Les Plongées de Juliette/5-Pipeline/Versions-imprimables";
+        let out = dir_display(dir);
+        assert!(out.starts_with("..."));
+        assert!(out.ends_with("Versions-imprimables"));
+    }
+
+    #[test]
+    fn dir_display_leaves_short_paths_unchanged() {
+        assert_eq!(dir_display("src/cmds"), "src/cmds");
     }
 
     // --- glob_match unit tests ---


### PR DESCRIPTION
## Problem

`rtk find` panics when the grouped-results display truncates a directory path longer than 50 bytes and the raw byte slice `&dir[dir.len() - 47..]` lands inside a multi-byte UTF-8 character:

```
thread 'main' panicked at src/cmds/system/find_cmd.rs:326:34:
start byte index 10 is not a char boundary; it is inside 'é' (bytes 9..11 of string)
```

Reported in #2851. Note the issue title mentions the unknown-flag path, but while preparing this fix I narrowed it down: the flag is irrelevant — the actual trigger is any grouped display of a matched directory path > 50 bytes with a multi-byte character straddling the cut point (`"Les Plongées de Juliette/5-Pipeline/Versions-imprimables"` is 57 bytes, so the cut lands at byte 10, inside the `é`). I've noted this on the issue.

## Fix

- Extract the truncation into a small `dir_display()` helper and round the cut up with `str::ceil_char_boundary()`, the same pattern already used in `pipe_cmd.rs`, `json_cmd.rs`, `gain.rs` and `session_cmd.rs` for the sibling bugs (#2318 / #2509 family).
- Add regression tests (multi-byte path at the exact panic geometry + short-path passthrough).

## Validation

- `cargo test`: 2417 passed.
- Real-world repro from #2851 no longer panics:
  ```sh
  mkdir -p 'Les Plongées de Juliette/5-Pipeline/Versions-imprimables'
  touch 'Les Plongées de Juliette/5-Pipeline/Versions-imprimables/X_Index-Tableau-de-Bord.pdf'
  rtk find . -name '*Index-Tableau-de-Bord.pdf' -print
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)