### PR TITLE
feat: add git checkout support

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -2,6 +2,7 @@
 
 use crate::core::args_utils;
 use crate::core::guard::never_worse;
+use crate::core::runner::{self, RunOptions};
 use crate::core::stream::{
     self, exec_capture, CaptureResult, FilterMode, LineHandler, LineStreamFilter, StdinMode,
 };
@@ -23,6 +24,7 @@ pub enum GitCommand {
     Show,
     Add,
     Commit,
+    Checkout,
     Push,
     Pull,
     Branch,
@@ -95,6 +97,7 @@ pub fn run(
         GitCommand::Show => run_show(args, max_lines, verbose, global_args),
         GitCommand::Add => run_add(args, verbose, global_args),
         GitCommand::Commit => run_commit(args, verbose, global_args),
+        GitCommand::Checkout => run_checkout(args, verbose, global_args),
         GitCommand::Push => run_push(args, verbose, global_args),
         GitCommand::Pull => run_pull(args, verbose, global_args),
         GitCommand::Branch => run_branch(args, verbose, global_args),
@@ -1077,6 +1080,183 @@ fn classify_commit_outcome(success: bool, stdout: &str, exit_code: i32) -> Commi
         CommitOutcome::Ok(compact)
     } else {
         CommitOutcome::Failed(exit_code)
+    }
+}
+
+fn run_checkout(args: &[String], verbose: u8, global_args: &[String]) -> Result<i32> {
+    let args = args_utils::restore_double_dash(args);
+
+    if verbose > 0 {
+        eprintln!("git checkout");
+    }
+
+    let mut cmd = git_cmd(global_args);
+    cmd.arg("checkout");
+    for arg in &args {
+        cmd.arg(arg);
+    }
+
+    let args_display = args.join(" ");
+    let args_for_filter = args.clone();
+    runner::run_filtered_with_exit(
+        cmd,
+        "git checkout",
+        &args_display,
+        move |raw, exit_code| format_checkout_output(&args_for_filter, raw, exit_code),
+        RunOptions::with_tee("git_checkout"),
+    )
+}
+
+fn format_checkout_output(args: &[String], raw: &str, exit_code: i32) -> String {
+    if exit_code == 0 {
+        format_checkout_success(args, raw)
+    } else {
+        filter_checkout_failure(raw)
+    }
+}
+
+fn format_checkout_success(args: &[String], raw: &str) -> String {
+    if let Some(restored) = checkout_restored_count(args) {
+        return format!("ok {} {}", restored, pluralize(restored, "file restored", "files restored"));
+    }
+    if let Some(branch) = checkout_reset_branch_arg(args) {
+        return format!("ok {}", branch);
+    }
+
+    for line in raw.lines().map(str::trim) {
+        if let Some(branch) = quoted_suffix(line, "Switched to a new branch ") {
+            return format!("ok {} (new)", branch);
+        }
+        if let Some(branch) = quoted_suffix(line, "Switched to branch ") {
+            return format!("ok {}", branch);
+        }
+        if let Some(branch) = quoted_suffix(line, "Already on ") {
+            return format!("ok {}", branch);
+        }
+        if let Some(rest) = line.strip_prefix("HEAD is now at ") {
+            let hash = rest.split_whitespace().next().unwrap_or("HEAD");
+            return format!("ok HEAD {}", hash);
+        }
+        if line.starts_with("Updated ") && line.contains(" path") {
+            return format!("ok {}", line.to_ascii_lowercase());
+        }
+    }
+
+    if let Some(branch) = checkout_new_branch_arg(args) {
+        return format!("ok {} (new)", branch);
+    }
+    if let Some(branch) = checkout_branch_arg(args) {
+        return format!("ok {}", branch);
+    }
+
+    "ok".to_string()
+}
+
+fn checkout_restored_count(args: &[String]) -> Option<usize> {
+    let separator = args.iter().position(|arg| arg == "--")?;
+    let count = args[separator + 1..]
+        .iter()
+        .filter(|arg| !arg.is_empty())
+        .count();
+    (count > 0).then_some(count)
+}
+
+fn checkout_new_branch_arg(args: &[String]) -> Option<&str> {
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "-b" | "--orphan" => return iter.next().map(String::as_str),
+            "-B" => {
+                iter.next();
+            }
+            _ => {
+                if let Some(branch) = arg.strip_prefix("--orphan=") {
+                    return Some(branch);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn checkout_reset_branch_arg(args: &[String]) -> Option<&str> {
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if arg == "-B" {
+            return iter.next().map(String::as_str);
+        }
+    }
+    None
+}
+
+fn checkout_branch_arg(args: &[String]) -> Option<&str> {
+    if args.iter().any(|arg| arg == "--") {
+        return None;
+    }
+
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "-b" | "-B" | "--orphan" => {
+                iter.next();
+            }
+            "-t" | "--track" | "--detach" => {}
+            _ if arg.starts_with('-') => {}
+            _ => return Some(arg),
+        }
+    }
+    None
+}
+
+fn quoted_suffix<'a>(line: &'a str, prefix: &str) -> Option<&'a str> {
+    line.strip_prefix(prefix)
+        .and_then(|rest| rest.strip_prefix('\''))
+        .and_then(|rest| rest.strip_suffix('\''))
+}
+
+fn pluralize<'a>(count: usize, singular: &'a str, plural: &'a str) -> &'a str {
+    if count == 1 { singular } else { plural }
+}
+
+fn filter_checkout_failure(raw: &str) -> String {
+    let mut important = Vec::new();
+    let mut in_file_list = false;
+
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let is_header = trimmed.starts_with("error:")
+            || trimmed.starts_with("fatal:")
+            || trimmed.starts_with("CONFLICT");
+
+        if is_header {
+            in_file_list =
+                trimmed.contains("following") && trimmed.contains("files") && trimmed.ends_with(':');
+            important.push(trimmed.to_string());
+            continue;
+        }
+
+        if in_file_list {
+            if trimmed.starts_with("Please ") || trimmed.starts_with("Aborting") {
+                in_file_list = false;
+            } else if line.starts_with(char::is_whitespace) {
+                important.push(line.to_string());
+                continue;
+            }
+        }
+
+        if trimmed.starts_with("Aborting") {
+            important.push(trimmed.to_string());
+        }
+    }
+
+    if important.is_empty() {
+        raw.trim().to_string()
+    } else {
+        important.join("\n")
     }
 }
 

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1346,6 +1346,14 @@ mod tests {
     }
 
     #[test]
+    fn test_rewrite_git_checkout() {
+        assert_eq!(
+            rewrite_command_no_prefixes("git checkout main", &[]),
+            Some("rtk git checkout main".into())
+        );
+    }
+
+    #[test]
     fn test_rewrite_git_log() {
         assert_eq!(
             rewrite_command_no_prefixes("git log -10", &[]),

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -12,7 +12,7 @@ pub struct RtkRule {
 
 pub const RULES: &[RtkRule] = &[
     RtkRule {
-        pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|push|pull|branch|fetch|stash|worktree)",
+        pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|checkout|push|pull|branch|fetch|stash|worktree)",
         rtk_cmd: "rtk git",
         rewrite_prefixes: &["git", "yadm"],
         category: "Git",

--- a/src/main.rs
+++ b/src/main.rs
@@ -902,6 +902,12 @@ enum GitCommands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+    /// Checkout branch or restore paths → "ok"
+    Checkout {
+        /// Git checkout arguments (supports -b, branch names, refs, -- paths)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
     /// Push → "ok \<branch\>"
     Push {
         /// Git push arguments (supports -u, remote, branch, etc.)
@@ -1680,6 +1686,13 @@ fn run_cli() -> Result<i32> {
                 }
                 GitCommands::Commit { args } => git::run(
                     git::GitCommand::Commit,
+                    &args,
+                    None,
+                    cli.verbose,
+                    &global_args,
+                )?,
+                GitCommands::Checkout { args } => git::run(
+                    git::GitCommand::Checkout,
                     &args,
                     None,
                     cli.verbose,

--- a/tests/guard_integration_test.rs
+++ b/tests/guard_integration_test.rs
@@ -56,17 +56,22 @@ fn guard_does_not_block_real_compression() {
     );
 }
 
-fn rtk_in_dir(dir: &std::path::Path, args: &[&str]) -> (String, Option<i32>) {
+fn rtk_output_in_dir(dir: &std::path::Path, args: &[&str]) -> (String, String, Option<i32>) {
     let out = Command::new(env!("CARGO_BIN_EXE_rtk"))
         .args(args)
         .current_dir(dir)
-        .stderr(Stdio::null())
         .output()
         .expect("spawn rtk");
     (
         String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
         out.status.code(),
     )
+}
+
+fn rtk_in_dir(dir: &std::path::Path, args: &[&str]) -> (String, Option<i32>) {
+    let (stdout, _, code) = rtk_output_in_dir(dir, args);
+    (stdout, code)
 }
 
 fn rg_available() -> bool {
@@ -80,7 +85,7 @@ fn rg_available() -> bool {
 fn init_git_repo() -> tempfile::TempDir {
     let dir = tempfile::tempdir().expect("tempdir");
     for args in [
-        &["init", "-q"][..],
+        &["init", "-q", "-b", "main"][..],
         &["config", "user.email", "t@t.t"][..],
         &["config", "user.name", "t"][..],
         &["commit", "-q", "--allow-empty", "-m", "init"][..],
@@ -94,6 +99,24 @@ fn init_git_repo() -> tempfile::TempDir {
         assert!(ok, "git setup failed: {args:?}");
     }
     dir
+}
+
+fn git_in_dir(dir: &std::path::Path, args: &[&str]) {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("spawn git");
+    assert!(
+        out.status.success(),
+        "git command failed: {args:?}\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn read_text_normalized(path: &std::path::Path) -> String {
+    std::fs::read_to_string(path).unwrap().replace("\r\n", "\n")
 }
 
 #[test]
@@ -149,5 +172,98 @@ fn git_stash_show_no_stash_emits_empty_and_propagates_failure() {
         code,
         Some(0),
         "a real git stash show failure must not be masked as exit 0"
+    );
+}
+
+#[test]
+fn git_checkout_branch_switch_emits_compact_ok() {
+    let dir = init_git_repo();
+    git_in_dir(dir.path(), &["checkout", "-q", "-b", "feature/test"]);
+
+    let (out, code) = rtk_in_dir(dir.path(), &["git", "checkout", "main"]);
+
+    assert_eq!(code, Some(0));
+    assert_eq!(out.trim(), "ok main");
+}
+
+#[test]
+fn git_checkout_new_branch_emits_compact_ok() {
+    let dir = init_git_repo();
+
+    let (out, code) = rtk_in_dir(dir.path(), &["git", "checkout", "-b", "feature/test"]);
+
+    assert_eq!(code, Some(0));
+    assert_eq!(out.trim(), "ok feature/test (new)");
+}
+
+#[test]
+fn git_checkout_reset_branch_does_not_claim_new_branch() {
+    let dir = init_git_repo();
+
+    let (out, code) = rtk_in_dir(dir.path(), &["git", "checkout", "-B", "feature/test"]);
+
+    assert_eq!(code, Some(0));
+    assert_eq!(out.trim(), "ok feature/test");
+}
+
+#[test]
+fn git_checkout_file_restore_emits_restored_count() {
+    let dir = init_git_repo();
+    std::fs::write(dir.path().join("a.txt"), "original\n").expect("write a");
+    std::fs::write(dir.path().join("b.txt"), "original\n").expect("write b");
+    git_in_dir(dir.path(), &["add", "a.txt", "b.txt"]);
+    git_in_dir(dir.path(), &["commit", "-q", "-m", "add files"]);
+
+    std::fs::write(dir.path().join("a.txt"), "changed\n").expect("write a");
+    std::fs::write(dir.path().join("b.txt"), "changed\n").expect("write b");
+
+    let (out, code) = rtk_in_dir(
+        dir.path(),
+        &["git", "checkout", "HEAD", "--", "a.txt", "b.txt"],
+    );
+
+    assert_eq!(code, Some(0));
+    assert!(
+        out.trim().is_empty() || out.trim() == "ok 2 files restored",
+        "guarded output may stay empty when native git emits no success text: {out:?}"
+    );
+    assert_eq!(
+        read_text_normalized(&dir.path().join("a.txt")),
+        "original\n"
+    );
+    assert_eq!(
+        read_text_normalized(&dir.path().join("b.txt")),
+        "original\n"
+    );
+}
+
+#[test]
+fn git_checkout_dirty_tree_error_keeps_file_list() {
+    let dir = init_git_repo();
+    std::fs::write(dir.path().join("a.txt"), "main\n").expect("write a");
+    git_in_dir(dir.path(), &["add", "a.txt"]);
+    git_in_dir(dir.path(), &["commit", "-q", "-m", "add a"]);
+    git_in_dir(dir.path(), &["checkout", "-q", "-b", "feature/test"]);
+    std::fs::write(dir.path().join("a.txt"), "feature\n").expect("write feature");
+    git_in_dir(dir.path(), &["commit", "-am", "feature change"]);
+    git_in_dir(dir.path(), &["checkout", "-q", "main"]);
+    std::fs::write(dir.path().join("a.txt"), "dirty\n").expect("write dirty");
+
+    let (stdout, stderr, code) =
+        rtk_output_in_dir(dir.path(), &["git", "checkout", "feature/test"]);
+    let combined = format!("{stdout}{stderr}");
+
+    assert_ne!(code, Some(0));
+    assert!(
+        combined.contains("error:"),
+        "dirty checkout failure should keep error header: {combined:?}"
+    );
+    assert!(
+        combined.contains("a.txt"),
+        "dirty checkout failure should keep conflicting filename: {combined:?}"
+    );
+    assert!(
+        combined.contains("Aborting"),
+        "dirty checkout failure should keep abort line: {combined:?}"
     );
 }


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->
Closed #1728
- Add compact `rtk git checkout` support for branch switching, new/reset branch checkout, and path restore forms.
- Enable hook rewrite coverage for `git checkout ...`.
-  Preserve checkout exit codes while surfacing concise `ok ...` success output and focused failure messages.

## Test plan
<!-- How did you verify this works? -->

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected
```
  cargo build

  tmp=$(mktemp -d)
  cd "$tmp"
  git init -q -b main
  git config user.email t@t.t
  git config user.name t
  git commit -q --allow-empty -m init

  /path/to/rtk/target/debug/rtk git checkout -b feature/test
  # expect: ok feature/test (new)

  /path/to/rtk/target/debug/rtk git checkout main
  # expect: ok main

  check path restore：

  printf 'original\n' > a.txt
  printf 'original\n' > b.txt
  git add a.txt b.txt
  git commit -q -m 'add files'

  printf 'changed\n' > a.txt
  printf 'changed\n' > b.txt

  /path/to/rtk/target/debug/rtk git checkout HEAD -- a.txt b.txt
  # expect: ok 2 files restored
```
> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
