### PR TITLE
fix(deps): bump quick-xml 0.37 → 0.41 (RUSTSEC-2026-0194/0195)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ sha2 = "0.10"
 ureq = "2"
 getrandom = "0.4"
 flate2 = "1.0"
-quick-xml = "0.37"
+quick-xml = "0.41"
 which = "8"
 automod = "1"
 

--- a/src/cmds/dotnet/dotnet_cmd.rs
+++ b/src/cmds/dotnet/dotnet_cmd.rs
@@ -618,7 +618,7 @@ fn scan_mtp_kind_in_file(path: &Path) -> MtpProjectKind {
                 );
             }
             Ok(Event::Text(e)) if inside_mtp_element => {
-                if let Ok(text) = e.unescape() {
+                if let Ok(text) = e.decode() {
                     if text.trim().eq_ignore_ascii_case("true") {
                         return MtpProjectKind::VsTestBridge;
                     }

--- a/src/cmds/dotnet/dotnet_trx.rs
+++ b/src/cmds/dotnet/dotnet_trx.rs
@@ -3,7 +3,7 @@
 use crate::binlog::{FailedTest, TestSummary};
 use chrono::{DateTime, FixedOffset};
 use quick_xml::events::{BytesStart, Event};
-use quick_xml::Reader;
+use quick_xml::{Reader, XmlVersion};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
@@ -21,7 +21,9 @@ fn extract_attr_value(
             continue;
         }
 
-        if let Ok(value) = attr.decode_and_unescape_value(reader.decoder()) {
+        if let Ok(value) =
+            attr.decoded_and_normalized_value(XmlVersion::default(), reader.decoder())
+        {
             return Some(value.into_owned());
         }
     }


### PR DESCRIPTION
## What

Bumps `quick-xml` from **0.37.5 → 0.41.0** to clear two RustSec advisories flagged by `osv-scanner`:

- **RUSTSEC-2026-0194**
- **RUSTSEC-2026-0195**

Both advisories are against `quick-xml 0.37.5` (a direct dependency); 0.41.0 is the first release that clears them.

## API migration

quick-xml 0.41 reworked text/attribute decoding. `quick-xml` is used in exactly two dotnet call sites, both required small, mechanical changes:

| File | Before (0.37) | After (0.41) | Notes |
|------|---------------|--------------|-------|
| `src/cmds/dotnet/dotnet_cmd.rs` | `BytesText::unescape()` | `BytesText::decode()` | `unescape()` was removed. The call reads the MTP `<UseTestingPlatformRunner>true</…>` boolean text node — no entity resolution needed, so `decode()` is the correct equivalent. |
| `src/cmds/dotnet/dotnet_trx.rs` | `Attribute::decode_and_unescape_value(decoder)` | `Attribute::decoded_and_normalized_value(XmlVersion::default(), decoder)` | The old method is deprecated (compiled under `-D warnings`). `XmlVersion::default()` is XML 1.0, matching TRX files. Normalization is a no-op for the simple attribute values parsed (`testName`, `outcome`, counter integers, timestamps). |

Note: the TRX `Event::Text`/`Event::CData` handlers already consumed raw bytes via `String::from_utf8_lossy`, so they were unaffected by the entity-handling redesign.

## Validation

- `cargo build` — clean
- `cargo build --release` — clean
- `cargo clippy --all-targets` — no issues
- dotnet test suite (116 tests) — pass

The one unrelated failure in `tests/grep_compress_test.rs::small_grep_not_worse_than_plain` is **pre-existing on `develop`** (verified by stashing this change) and does not involve quick-xml or the dotnet modules.

## Risk

Low. Two localized, mechanical call-site migrations behind a green dotnet test suite. No behavior change for realistic inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)