### PR TITLE
fix: detect absolute rtk path in Claude hook settings

### DIFF
--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -13,17 +13,6 @@ pub const CLAUDE_HOOK_COMMAND: &str = "rtk hook claude";
 /// Native Rust hook command for Cursor (replaces rtk-rewrite.sh).
 pub const CURSOR_HOOK_COMMAND: &str = "rtk hook cursor";
 
-pub fn is_claude_hook_command(command: &str) -> bool {
-    let parts = crate::discover::lexer::shell_split(command);
-    let [binary, hook, claude] = parts.as_slice() else {
-        return false;
-    };
-
-    let binary_name = binary.rsplit(['/', '\\']).next().unwrap_or(binary);
-
-    binary_name == "rtk" && hook == "hook" && claude == "claude"
-}
-
 pub const CONFIG_DIR: &str = ".config";
 pub const OPENCODE_SUBDIR: &str = "opencode";
 pub const PLUGIN_SUBDIR: &str = "plugins";
@@ -50,24 +39,3 @@ pub const HERMES_PLUGINS_SUBDIR: &str = "plugins";
 pub const HERMES_PLUGIN_NAME: &str = "rtk-rewrite";
 pub const HERMES_PLUGIN_INIT_FILE: &str = "__init__.py";
 pub const HERMES_PLUGIN_MANIFEST_FILE: &str = "plugin.yaml";
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn claude_hook_command_matches_bare_and_absolute_rtk() {
-        assert!(is_claude_hook_command("rtk hook claude"));
-        assert!(is_claude_hook_command("/opt/homebrew/bin/rtk hook claude"));
-        assert!(is_claude_hook_command(
-            "\"/opt/homebrew/bin/rtk\" hook claude"
-        ));
-    }
-
-    #[test]
-    fn claude_hook_command_rejects_other_commands() {
-        assert!(!is_claude_hook_command("not-rtk hook claude"));
-        assert!(!is_claude_hook_command("/opt/homebrew/bin/rtk hook cursor"));
-        assert!(!is_claude_hook_command("echo rtk hook claude"));
-    }
-}

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -13,6 +13,17 @@ pub const CLAUDE_HOOK_COMMAND: &str = "rtk hook claude";
 /// Native Rust hook command for Cursor (replaces rtk-rewrite.sh).
 pub const CURSOR_HOOK_COMMAND: &str = "rtk hook cursor";
 
+pub fn is_claude_hook_command(command: &str) -> bool {
+    let parts = crate::discover::lexer::shell_split(command);
+    let [binary, hook, claude] = parts.as_slice() else {
+        return false;
+    };
+
+    let binary_name = binary.rsplit(['/', '\\']).next().unwrap_or(binary);
+
+    binary_name == "rtk" && hook == "hook" && claude == "claude"
+}
+
 pub const CONFIG_DIR: &str = ".config";
 pub const OPENCODE_SUBDIR: &str = "opencode";
 pub const PLUGIN_SUBDIR: &str = "plugins";
@@ -39,3 +50,24 @@ pub const HERMES_PLUGINS_SUBDIR: &str = "plugins";
 pub const HERMES_PLUGIN_NAME: &str = "rtk-rewrite";
 pub const HERMES_PLUGIN_INIT_FILE: &str = "__init__.py";
 pub const HERMES_PLUGIN_MANIFEST_FILE: &str = "plugin.yaml";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claude_hook_command_matches_bare_and_absolute_rtk() {
+        assert!(is_claude_hook_command("rtk hook claude"));
+        assert!(is_claude_hook_command("/opt/homebrew/bin/rtk hook claude"));
+        assert!(is_claude_hook_command(
+            "\"/opt/homebrew/bin/rtk\" hook claude"
+        ));
+    }
+
+    #[test]
+    fn claude_hook_command_rejects_other_commands() {
+        assert!(!is_claude_hook_command("not-rtk hook claude"));
+        assert!(!is_claude_hook_command("/opt/homebrew/bin/rtk hook cursor"));
+        assert!(!is_claude_hook_command("echo rtk hook claude"));
+    }
+}

--- a/src/hooks/hook_check.rs
+++ b/src/hooks/hook_check.rs
@@ -1,9 +1,8 @@
 //! Detects whether RTK hooks are installed and warns if they are outdated.
 
-use super::constants::{
-    is_claude_hook_command, HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
-};
+use super::constants::{HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON};
 use super::init::resolve_claude_dir;
+use super::is_claude_hook_command;
 use crate::core::constants::RTK_DATA_DIR;
 use std::path::PathBuf;
 

--- a/src/hooks/hook_check.rs
+++ b/src/hooks/hook_check.rs
@@ -1,7 +1,7 @@
 //! Detects whether RTK hooks are installed and warns if they are outdated.
 
 use super::constants::{
-    CLAUDE_HOOK_COMMAND, HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
+    is_claude_hook_command, HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use super::init::resolve_claude_dir;
 use crate::core::constants::RTK_DATA_DIR;
@@ -82,7 +82,7 @@ fn binary_hook_registered(claude_dir: &std::path::Path) -> bool {
         .filter_map(|entry| entry.get("hooks")?.as_array())
         .flatten()
         .filter_map(|hook| hook.get("command")?.as_str())
-        .any(|cmd| cmd == CLAUDE_HOOK_COMMAND)
+        .any(is_claude_hook_command)
 }
 
 /// Check if the installed hook is missing or outdated, warn once per day.
@@ -209,6 +209,29 @@ mod tests {
         // Clone works
         let s = HookStatus::Missing;
         assert_eq!(s.clone(), HookStatus::Missing);
+    }
+
+    #[test]
+    fn test_binary_hook_registered_accepts_absolute_rtk_path() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join(SETTINGS_JSON),
+            r#"{
+                "hooks": {
+                    "PreToolUse": [{
+                        "matcher": "Bash",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "/opt/homebrew/bin/rtk hook claude",
+                            "timeout": 5
+                        }]
+                    }]
+                }
+            }"#,
+        )
+        .expect("write settings");
+
+        assert!(binary_hook_registered(tmp.path()));
     }
 
     #[test]

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -13,13 +13,14 @@ use crate::hooks::constants::{
 };
 
 use super::constants::{
-    is_claude_hook_command, BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR,
-    CURSOR_HOOK_COMMAND, GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR,
-    HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON,
-    HOOKS_SUBDIR, PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR,
-    PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
+    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND,
+    GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_INIT_FILE,
+    HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON, HOOKS_SUBDIR,
+    PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR, PI_PLUGIN_FILE,
+    PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use super::integrity;
+use super::is_claude_hook_command;
 
 // Embedded OpenCode plugin (auto-rewrite)
 const OPENCODE_PLUGIN: &str = include_str!("../../hooks/opencode/rtk.ts");
@@ -555,7 +556,7 @@ fn remove_hook_from_json(root: &mut serde_json::Value) -> bool {
             for hook in hooks_array {
                 if let Some(command) = hook.get("command").and_then(|c| c.as_str()) {
                     // Match both legacy script path and new binary command
-                    if command.contains(REWRITE_HOOK_FILE) || command == CLAUDE_HOOK_COMMAND {
+                    if command.contains(REWRITE_HOOK_FILE) || is_claude_hook_command(command) {
                         return false;
                     }
                 }
@@ -5629,6 +5630,40 @@ mod tests {
                         "hooks": [{
                             "type": "command",
                             "command": CLAUDE_HOOK_COMMAND
+                        }]
+                    }
+                ]
+            }
+        });
+
+        let removed = remove_hook_from_json(&mut json_content);
+        assert!(removed);
+
+        let pre_tool_use = json_content["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(pre_tool_use.len(), 1);
+        assert_eq!(
+            pre_tool_use[0]["hooks"][0]["command"].as_str().unwrap(),
+            "/some/other/hook.sh"
+        );
+    }
+
+    #[test]
+    fn test_remove_hook_from_json_absolute_new_command() {
+        let mut json_content = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "/some/other/hook.sh"
+                        }]
+                    },
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "/opt/homebrew/bin/rtk hook claude"
                         }]
                     }
                 ]

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -13,11 +13,11 @@ use crate::hooks::constants::{
 };
 
 use super::constants::{
-    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND,
-    GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_INIT_FILE,
-    HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON, HOOKS_SUBDIR,
-    PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR, PI_PLUGIN_FILE,
-    PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
+    is_claude_hook_command, BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR,
+    CURSOR_HOOK_COMMAND, GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR,
+    HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON,
+    HOOKS_SUBDIR, PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR,
+    PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use super::integrity;
 
@@ -1121,7 +1121,7 @@ fn hook_already_present(root: &serde_json::Value, hook_command: &str) -> bool {
         .flatten()
         .filter_map(|hook| hook.get("command")?.as_str())
         .any(|cmd| {
-            cmd == hook_command || cmd == CLAUDE_HOOK_COMMAND || cmd.contains(REWRITE_HOOK_FILE)
+            cmd == hook_command || is_claude_hook_command(cmd) || cmd.contains(REWRITE_HOOK_FILE)
         })
 }
 
@@ -5367,6 +5367,24 @@ mod tests {
                     "hooks": [{
                         "type": "command",
                         "command": CLAUDE_HOOK_COMMAND
+                    }]
+                }]
+            }
+        });
+
+        assert!(hook_already_present(&json_content, CLAUDE_HOOK_COMMAND));
+    }
+
+    #[test]
+    fn test_hook_already_present_absolute_new_command() {
+        let json_content = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "/opt/homebrew/bin/rtk hook claude",
+                        "timeout": 5
                     }]
                 }]
             }

--- a/src/hooks/integrity.rs
+++ b/src/hooks/integrity.rs
@@ -12,8 +12,9 @@
 //!
 //! Reference: SA-2025-RTK-001 (Finding F-01)
 
-use super::constants::{is_claude_hook_command, HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE};
+use super::constants::{HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE};
 use super::init::resolve_claude_dir;
+use super::is_claude_hook_command;
 use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
 use std::fs;

--- a/src/hooks/integrity.rs
+++ b/src/hooks/integrity.rs
@@ -12,7 +12,7 @@
 //!
 //! Reference: SA-2025-RTK-001 (Finding F-01)
 
-use super::constants::{HOOKS_SUBDIR, REWRITE_HOOK_FILE};
+use super::constants::{is_claude_hook_command, HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE};
 use super::init::resolve_claude_dir;
 use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
@@ -211,10 +211,10 @@ pub fn run_verify(verbose: u8) -> Result<()> {
     if !hook_path.exists() && !hash_file.exists() {
         // Check if the native binary command is registered in settings.json
         let claude_dir = resolve_claude_dir().context("Cannot determine claude directory")?;
-        let settings_path = claude_dir.join("settings.json");
+        let settings_path = claude_dir.join(super::constants::SETTINGS_JSON);
         if settings_path.exists() {
             let content = fs::read_to_string(&settings_path).unwrap_or_default();
-            if content.contains("rtk hook claude") {
+            if settings_has_claude_hook(&content) {
                 println!("PASS  native binary hook registered in settings.json");
                 println!("      command: rtk hook claude");
                 println!("      (no script file — integrity check not applicable)");
@@ -321,6 +321,22 @@ pub fn runtime_check() -> Result<()> {
     Ok(())
 }
 
+fn settings_has_claude_hook(content: &str) -> bool {
+    let Ok(root) = serde_json::from_str::<serde_json::Value>(content) else {
+        return false;
+    };
+
+    root.get("hooks")
+        .and_then(|h| h.get(PRE_TOOL_USE_KEY))
+        .and_then(|p| p.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| entry.get("hooks")?.as_array())
+        .flatten()
+        .filter_map(|hook| hook.get("command")?.as_str())
+        .any(is_claude_hook_command)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -364,6 +380,24 @@ mod tests {
 
         let status = verify_hook_at(&hook).unwrap();
         assert_eq!(status, IntegrityStatus::Verified);
+    }
+
+    #[test]
+    fn test_settings_has_claude_hook_accepts_absolute_rtk_path() {
+        let settings = r#"{
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "Bash",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "/opt/homebrew/bin/rtk hook claude",
+                        "timeout": 5
+                    }]
+                }]
+            }
+        }"#;
+
+        assert!(settings_has_claude_hook(settings));
     }
 
     #[test]

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -11,3 +11,35 @@ pub mod permissions;
 pub mod rewrite_cmd;
 pub mod trust;
 pub mod verify_cmd;
+
+pub fn is_claude_hook_command(command: &str) -> bool {
+    let parts = crate::discover::lexer::shell_split(command);
+    let [binary, hook, claude] = parts.as_slice() else {
+        return false;
+    };
+
+    let binary_name = binary.rsplit(['/', '\\']).next().unwrap_or(binary);
+
+    binary_name == "rtk" && hook == "hook" && claude == "claude"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claude_hook_command_matches_bare_and_absolute_rtk() {
+        assert!(is_claude_hook_command("rtk hook claude"));
+        assert!(is_claude_hook_command("/opt/homebrew/bin/rtk hook claude"));
+        assert!(is_claude_hook_command(
+            "\"/opt/homebrew/bin/rtk\" hook claude"
+        ));
+    }
+
+    #[test]
+    fn claude_hook_command_rejects_other_commands() {
+        assert!(!is_claude_hook_command("not-rtk hook claude"));
+        assert!(!is_claude_hook_command("/opt/homebrew/bin/rtk hook cursor"));
+        assert!(!is_claude_hook_command("echo rtk hook claude"));
+    }
+}


### PR DESCRIPTION
Fixes #2884

## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

- recognize Claude hook commands where `rtk` is configured with an absolute path

## Test plan
<!-- How did you verify this works? -->

- [ ] I prepared the following `settings.json` and confirmed that this implementation works as expected in my local environment.

```json
{
  "hooks": {
      "PreToolUse": [{
        "matcher": "Bash",
        "hooks": [{
          "type": "command",
          "command": "/opt/homebrew/bin/rtk hook claude",
          "timeout": 5
        }]
      }]
   }
}
```

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
