### PR TITLE
fix(cargo): rewrite cargo nextest commands

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1222,9 +1222,10 @@ mod tests {
 
     #[test]
     fn test_registry_covers_all_cargo_subcommands() {
-        // Verify that every CargoCommand variant (Build, Test, Clippy, Check, Fmt)
-        // except Other has a matching pattern in the registry
-        for subcmd in ["build", "test", "clippy", "check", "fmt"] {
+        // Verify that every CargoCommand variant except Other has a matching pattern in the registry.
+        for subcmd in [
+            "build", "test", "clippy", "check", "fmt", "install", "nextest",
+        ] {
             let cmd = format!("cargo {subcmd}");
             match classify_command(&cmd) {
                 Classification::Supported { .. } => {}
@@ -1400,6 +1401,14 @@ mod tests {
         assert_eq!(
             rewrite_command_no_prefixes("cargo test", &[]),
             Some("rtk cargo test".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_cargo_nextest_run() {
+        assert_eq!(
+            rewrite_command_no_prefixes("cargo nextest run", &[]),
+            Some("rtk cargo nextest run".into())
         );
     }
 

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -44,12 +44,12 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        pattern: r"^cargo\s+(build|test|clippy|check|fmt|install)",
+        pattern: r"^cargo\s+(build|test|nextest|clippy|check|fmt|install)",
         rtk_cmd: "rtk cargo",
         rewrite_prefixes: &["cargo"],
         category: "Cargo",
         savings_pct: 80.0,
-        subcmd_savings: &[("test", 90.0), ("check", 80.0)],
+        subcmd_savings: &[("test", 90.0), ("nextest", 90.0), ("check", 80.0)],
         subcmd_status: &[("fmt", RtkStatus::Passthrough)],
     },
     RtkRule {


### PR DESCRIPTION
## Summary
- Register `cargo nextest` in the rewrite registry so hooks can map it to `rtk cargo nextest`.
- Cover the rewrite and keep Cargo subcommand registry coverage current.

Fixes #2046

## Test plan
- [x] `CARGO_INCREMENTAL=0 cargo fmt --all -- --check`
- [x] `CARGO_INCREMENTAL=0 cargo clippy --all-targets`
- [x] `CARGO_INCREMENTAL=0 cargo test`
- [x] Manual testing: `CARGO_INCREMENTAL=0 cargo run --quiet -- rewrite "cargo nextest run"` prints `rtk cargo nextest run`