### PR TITLE
fix(hooks): honor exclude_commands for head/tail line-range fast path

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -865,6 +865,11 @@ fn rewrite_segment_inner(
     }
 
     if cmd_part.starts_with("head -") || cmd_part.starts_with("tail ") {
+        let stripped = ENV_PREFIX.replace(cmd_part, "");
+        let cmd_clean = stripped.trim();
+        if is_excluded(cmd_clean, excluded) {
+            return None;
+        }
         return rewrite_line_range(cmd_part).map(|r| format!("{}{}", r, redirect_suffix));
     }
 
@@ -3695,6 +3700,30 @@ mod tests {
             rewrite_command_no_prefixes("git push origin main", &excluded),
             None
         );
+    }
+
+    #[test]
+    fn test_exclude_tail_line_range_fast_path() {
+        let excluded = vec!["tail".to_string()];
+        assert_eq!(
+            rewrite_command_no_prefixes("tail -5 sample.txt", &excluded),
+            None
+        );
+    }
+
+    #[test]
+    fn test_exclude_head_line_range_fast_path() {
+        let excluded = vec!["head".to_string()];
+        assert_eq!(
+            rewrite_command_no_prefixes("head -5 sample.txt", &excluded),
+            None
+        );
+    }
+
+    #[test]
+    fn test_head_line_range_fast_path_still_rewrites_when_not_excluded() {
+        let excluded: Vec<String> = vec![];
+        assert!(rewrite_command_no_prefixes("head -5 sample.txt", &excluded).is_some());
     }
 
     #[test]


### PR DESCRIPTION
Closes #2823

`[hooks] exclude_commands` is bypassed for `head`/`tail` because the line-range fast path in `rewrite_segment_inner` returns before the exclusion check:

```rust
if cmd_part.starts_with("head -") || cmd_part.starts_with("tail ") {
    return rewrite_line_range(cmd_part).map(|r| format!("{}{}", r, redirect_suffix));
}
```

`is_excluded` is only consulted in the `Classification::Supported` and `Unsupported` arms further down, both downstream of this early return.

Repro before this fix (config: `[hooks] exclude_commands = ["tail", "head", "rg"]`):

```console
$ rtk rewrite "tail -3 sample.txt"
rtk read sample.txt --tail-lines 3     # rewritten despite the exclusion
```

**Fix:** moved the same `is_excluded` check the `Supported` arm already uses (ENV_PREFIX-stripped command matched against the configured `ExcludePattern` list) in front of the fast path's early return, so excluded `head`/`tail` invocations fall through to the raw-passthrough path like every other excluded command.

Adds three regression tests in `src/discover/registry.rs`:
- `test_exclude_tail_line_range_fast_path` — excluded `tail` no longer rewrites
- `test_exclude_head_line_range_fast_path` — excluded `head` no longer rewrites
- `test_head_line_range_fast_path_still_rewrites_when_not_excluded` — guards against fixing this by disabling the fast path entirely

Ran the mandatory gate locally:
- `cargo fmt --all` — no changes needed
- `cargo clippy --all-targets` — clean
- `cargo test --all` — 2396 passed (+ 6/11/11/14/5/11 in the other suites), 0 failed