### PR TITLE
fix(find): stop panicking on multi-byte UTF-8 directory names

### DIFF
--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -26,6 +26,23 @@ fn glob_match_inner(pat: &[u8], name: &[u8]) -> bool {
     }
 }
 
+/// Shorten a directory path for display, keeping the trailing ~47 bytes
+/// prefixed with "...". Byte-index truncation can land inside a
+/// multi-byte UTF-8 character (e.g. an accented letter), so this walks
+/// forward from the target byte offset to the next valid char boundary
+/// instead of slicing blindly -- the loop always terminates at
+/// `dir.len()`, which is always a boundary.
+fn truncate_dir_display(dir: &str) -> String {
+    if dir.len() <= 50 {
+        return dir.to_string();
+    }
+    let target = dir.len() - 47;
+    let start = (target..=dir.len())
+        .find(|&i| dir.is_char_boundary(i))
+        .unwrap_or(dir.len());
+    format!("...{}", &dir[start..])
+}
+
 /// Parsed arguments from either native find or RTK find syntax.
 #[derive(Debug)]
 struct FindArgs {
@@ -322,11 +339,7 @@ pub fn run(
         }
 
         let files_in_dir = &by_dir[dir];
-        let dir_display = if dir.len() > 50 {
-            format!("...{}", &dir[dir.len() - 47..])
-        } else {
-            dir.clone()
-        };
+        let dir_display = truncate_dir_display(dir);
 
         let remaining_budget = max_results - displayed;
         if files_in_dir.len() <= remaining_budget {
@@ -391,6 +404,33 @@ mod tests {
     /// Convert string slices to Vec<String> for test convenience.
     fn args(values: &[&str]) -> Vec<String> {
         values.iter().map(|s| s.to_string()).collect()
+    }
+
+    // --- truncate_dir_display unit tests ---
+
+    #[test]
+    fn truncate_dir_display_does_not_panic_on_multibyte_boundary() {
+        // Exact reproduction from the reported panic: a directory name
+        // whose 47-bytes-from-the-end cut point lands inside 'é'.
+        let dir = "Les Plongées de Juliette/5-Pipeline/Versions-imprimables";
+        assert!(dir.len() > 50);
+        // Must not panic, and must not lose or corrupt UTF-8 data.
+        let result = truncate_dir_display(dir);
+        assert!(result.starts_with("..."));
+        assert!(result.is_char_boundary(0));
+    }
+
+    #[test]
+    fn truncate_dir_display_passes_through_short_paths() {
+        assert_eq!(truncate_dir_display("src/cmds"), "src/cmds");
+    }
+
+    #[test]
+    fn truncate_dir_display_truncates_long_ascii_paths() {
+        let dir = "a/".repeat(30); // 60 bytes, all ASCII
+        let result = truncate_dir_display(&dir);
+        assert!(result.starts_with("..."));
+        assert!(result.len() <= dir.len());
     }
 
     // --- glob_match unit tests ---


### PR DESCRIPTION
Closes #2851

`rtk find`'s output formatter truncates long directory names for display with a raw byte-offset slice:

```rust
format!("...{}", &dir[dir.len() - 47..])
```

If `dir.len() - 47` lands inside a multi-byte UTF-8 character (e.g. an accented letter like `é`), this panics with `byte index is not a char boundary` instead of printing a truncated path.

Repro (from the issue, reproduced in a unit test):

```sh
mkdir -p 'Les Plongées de Juliette/5-Pipeline/Versions-imprimables'
touch 'Les Plongées de Juliette/5-Pipeline/Versions-imprimables/LES-PLONGEES_Index-Tableau-de-Bord.pdf'
rtk find . -name '*Index-Tableau-de-Bord.pdf' -print
```
```
thread 'main' panicked at src/cmds/system/find_cmd.rs:326:34:
start byte index 10 is not a char boundary; it is inside 'é' (bytes 9..11 of string)
```

I confirmed byte 10 in that exact directory string is a UTF-8 continuation byte (0xA9), matching the panic message precisely.

**Fix:** extracted the truncation into a `truncate_dir_display` helper and walk forward from the target byte offset to the next valid `char_boundary` before slicing, instead of slicing blindly. The loop always terminates at `dir.len()` (always a boundary), so it can't infinite-loop or panic.

Adds three unit tests:
- `truncate_dir_display_does_not_panic_on_multibyte_boundary` — the exact directory name from the report
- `truncate_dir_display_passes_through_short_paths`
- `truncate_dir_display_truncates_long_ascii_paths`

**Note on the "unknown flag" condition:** the report mentions the panic only appeared alongside an unknown flag like `-print`. That didn't reproduce as a separate condition on my end — any directory name long enough to hit this truncation path panics regardless of flags, and this fix covers that unconditionally. If there's a second, flag-specific bug still lurking, happy to dig further with a maintainer pointer.

Ran the mandatory gate locally:
- `cargo fmt --all` — no changes needed
- `cargo clippy --all-targets` — clean
- `cargo test --all` — 2396 passed (+ 6/11/11/14/5/11 in the other suites), 0 failed