### PR TITLE
fix(benchmark): resolve file URLs with spaces on Windows

### DIFF
--- a/scripts/benchmark/rebuild.ts
+++ b/scripts/benchmark/rebuild.ts
@@ -5,8 +5,9 @@
  */
 
 import { vmEnsureReady, vmBuildRtk } from "./lib/vm";
+import { fileURLToPath } from "node:url";
 
-const PROJECT_ROOT = new URL("../../", import.meta.url).pathname.replace(/\/$/, "");
+const PROJECT_ROOT = fileURLToPath(new URL("../..", import.meta.url));
 
 await vmEnsureReady();
 const info = await vmBuildRtk(PROJECT_ROOT);

--- a/scripts/benchmark/run.ts
+++ b/scripts/benchmark/run.ts
@@ -12,9 +12,13 @@
  */
 
 import { $ } from "bun";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { vmEnsureReady, vmBuildRtk, vmExec, RTK_BIN } from "./lib/vm";
 import { testCmd, testSavings, testRewrite, skipTest, getCounts } from "./lib/test";
 import { saveReport } from "./lib/report";
+
+const PROJECT_ROOT = fileURLToPath(new URL("../..", import.meta.url));
 
 const args = process.argv.slice(2);
 const quick = args.includes("--quick");
@@ -28,9 +32,7 @@ if (args.includes("--phase") && phaseOnly === null) {
 }
 const reportPath = args.includes("--report")
   ? args[args.indexOf("--report") + 1]
-  : `${new URL("../../", import.meta.url).pathname.replace(/\/$/, "")}/benchmark-report.txt`;
-
-const PROJECT_ROOT = new URL("../../", import.meta.url).pathname.replace(/\/$/, "");
+  : resolve(PROJECT_ROOT, "benchmark-report.txt");
 const RTK = RTK_BIN;
 
 function shouldRun(phase: number): boolean {


### PR DESCRIPTION
## Summary
- Replace manual `new URL(...).pathname.replace(...)` path handling in benchmark scripts with `fileURLToPath(...)`
- Keep the default benchmark report path cross-platform by resolving it from the decoded project root
- Fixes Windows paths that contain spaces by avoiding URL-encoded `%20` paths and leading `/C:/...` drive paths

Fixes #2891

## Test plan
- [x] `bun build scripts/benchmark/run.ts scripts/benchmark/rebuild.ts --outdir .tmp-bun-build --target=bun`
- [x] Manual Windows file URL check: `file:///C:/Users/John%20Doe/...` now resolves to `C:\Users\John Doe\...` instead of `/C:/Users/John%20Doe/...`
- [x] `git diff --check`

Note: I could not run the full benchmark scripts locally because they require `multipass`; I verified the scripts bundle and the Windows path conversion directly.
