### PR TITLE
fix(find): support multiple path arguments

### DIFF
--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -212,6 +212,16 @@ pub fn run(
 ) -> Result<()> {
     let timer = tracking::TimedExecution::start();
 
+    // Duplicate roots would be walked and reported twice for no benefit; dedup
+    // keeps the search and the output no larger than the set of distinct roots.
+    let mut deduped_paths: Vec<String> = Vec::with_capacity(paths.len());
+    for p in paths {
+        if !deduped_paths.contains(p) {
+            deduped_paths.push(p.clone());
+        }
+    }
+    let paths: &[String] = &deduped_paths;
+
     // paths is guaranteed non-empty by both parse_native_find_args and
     // parse_rtk_find_args (they default to ["."] via FindArgs::default()).
     let single_root = paths.len() == 1;

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -424,6 +424,7 @@ pub fn run(
 mod tests {
     use super::*;
 
+    /// Convert string slices to Vec<String> for test convenience.
     fn args(values: &[&str]) -> Vec<String> {
         values.iter().map(|s| s.to_string()).collect()
     }

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -30,7 +30,7 @@ fn glob_match_inner(pat: &[u8], name: &[u8]) -> bool {
 #[derive(Debug)]
 struct FindArgs {
     pattern: String,
-    path: String,
+    paths: Vec<String>,
     max_results: usize,
     max_depth: Option<usize>,
     file_type: String,
@@ -41,7 +41,7 @@ impl Default for FindArgs {
     fn default() -> Self {
         Self {
             pattern: "*".to_string(),
-            path: ".".to_string(),
+            paths: vec![".".to_string()],
             max_results: 50,
             max_depth: None,
             file_type: "f".to_string(),
@@ -55,6 +55,16 @@ impl Default for FindArgs {
 fn next_arg(args: &[String], i: &mut usize) -> Option<String> {
     *i += 1;
     args.get(*i).cloned()
+}
+
+/// Collect leading non-flag arguments as paths, advancing `i` past them.
+fn collect_leading_paths(args: &[String], i: &mut usize) -> Vec<String> {
+    let mut paths = Vec::new();
+    while *i < args.len() && !args[*i].starts_with('-') {
+        paths.push(args[*i].clone());
+        *i += 1;
+    }
+    paths
 }
 
 /// Check if args contain native find flags (-name, -type, -maxdepth, etc.)
@@ -98,15 +108,15 @@ fn parse_find_args(args: &[String]) -> Result<FindArgs> {
     }
 }
 
-/// Parse native find syntax: `find [path] -name "*.rs" -type f -maxdepth 3`
+/// Parse native find syntax: `find [path...] -name "*.rs" -type f -maxdepth 3`
 fn parse_native_find_args(args: &[String]) -> Result<FindArgs> {
     let mut parsed = FindArgs::default();
     let mut i = 0;
 
-    // First non-flag argument is the path (standard find behavior)
-    if !args[0].starts_with('-') {
-        parsed.path = args[0].clone();
-        i = 1;
+    // Leading non-flag arguments are paths (standard find behavior: `find p1 p2 ... -name ...`)
+    let paths = collect_leading_paths(args, &mut i);
+    if !paths.is_empty() {
+        parsed.paths = paths;
     }
 
     while i < args.len() {
@@ -143,7 +153,7 @@ fn parse_native_find_args(args: &[String]) -> Result<FindArgs> {
     Ok(parsed)
 }
 
-/// Parse RTK syntax: `find <pattern> [path] [-m max] [-t type]`
+/// Parse RTK syntax: `find <pattern> [path...] [-m max] [-t type]`
 fn parse_rtk_find_args(args: &[String]) -> Result<FindArgs> {
     let mut parsed = FindArgs {
         pattern: args[0].clone(),
@@ -151,10 +161,10 @@ fn parse_rtk_find_args(args: &[String]) -> Result<FindArgs> {
     };
     let mut i = 1;
 
-    // Second positional arg (if not a flag) is the path
-    if i < args.len() && !args[i].starts_with('-') {
-        parsed.path = args[i].clone();
-        i += 1;
+    // Leading non-flag args after the pattern are paths
+    let paths = collect_leading_paths(args, &mut i);
+    if !paths.is_empty() {
+        parsed.paths = paths;
     }
 
     while i < args.len() {
@@ -182,7 +192,7 @@ pub fn run_from_args(args: &[String], verbose: u8) -> Result<()> {
     let parsed = parse_find_args(args)?;
     run(
         &parsed.pattern,
-        &parsed.path,
+        &parsed.paths,
         parsed.max_results,
         parsed.max_depth,
         &parsed.file_type,
@@ -193,7 +203,7 @@ pub fn run_from_args(args: &[String], verbose: u8) -> Result<()> {
 
 pub fn run(
     pattern: &str,
-    path: &str,
+    paths: &[String],
     max_results: usize,
     max_depth: Option<usize>,
     file_type: &str,
@@ -202,11 +212,15 @@ pub fn run(
 ) -> Result<()> {
     let timer = tracking::TimedExecution::start();
 
+    // paths is guaranteed non-empty by both parse_native_find_args and
+    // parse_rtk_find_args (they default to ["."] via FindArgs::default()).
+    let single_root = paths.len() == 1;
+
     // Treat "." as match-all
     let effective_pattern = if pattern == "." { "*" } else { pattern };
 
     if verbose > 0 {
-        eprintln!("find: {} in {}", effective_pattern, path);
+        eprintln!("find: {} in {}", effective_pattern, paths.join(", "));
     }
 
     let want_dirs = file_type == "d";
@@ -215,12 +229,16 @@ pub fn run(
     // entries; otherwise skip them to keep results tidy (#1101).
     let search_hidden = effective_pattern.starts_with('.');
 
-    let mut builder = WalkBuilder::new(path);
+    let mut builder = WalkBuilder::new(&paths[0]);
+    for p in &paths[1..] {
+        builder.add(p);
+    }
     builder
         .hidden(!search_hidden) // skip hidden files/dirs unless pattern targets dotfiles
         .git_ignore(true) // respect .gitignore
         .git_global(true)
         .git_exclude(true);
+
     if let Some(depth) = max_depth {
         builder.max_depth(Some(depth));
     }
@@ -262,16 +280,24 @@ pub fn run(
             continue;
         }
 
-        // Store path relative to search root
-        let display_path = entry_path
-            .strip_prefix(path)
-            .unwrap_or(entry_path)
-            .to_string_lossy()
-            .to_string();
+        files.push(entry_path.to_string_lossy().to_string());
+    }
 
-        if !display_path.is_empty() {
-            files.push(display_path);
-        }
+    // With a single root, display paths relative to it; with multiple roots, keep
+    // the given root as a prefix so files from different roots don't collide
+    // (e.g. `folder1/foo.txt` vs `folder2/bar.txt` rather than both showing as
+    // `foo.txt`/`bar.txt` with no indication of which root they came from).
+    if single_root {
+        files = files
+            .into_iter()
+            .filter_map(|f| {
+                let stripped = Path::new(&f)
+                    .strip_prefix(&paths[0])
+                    .map(|p| p.to_string_lossy().to_string())
+                    .unwrap_or(f);
+                (!stripped.is_empty()).then_some(stripped)
+            })
+            .collect();
     }
 
     files.sort();
@@ -280,7 +306,7 @@ pub fn run(
 
     if files.is_empty() {
         timer.track(
-            &format!("find {} -name '{}'", path, effective_pattern),
+            &format!("find {} -name '{}'", paths.join(" "), effective_pattern),
             "rtk find",
             &raw_output,
             "",
@@ -375,7 +401,7 @@ pub fn run(
     let shown = never_worse(&raw_output, &body);
     print!("{}", shown);
     timer.track(
-        &format!("find {} -name '{}'", path, effective_pattern),
+        &format!("find {} -name '{}'", paths.join(" "), effective_pattern),
         "rtk find",
         &raw_output,
         shown,
@@ -388,7 +414,6 @@ pub fn run(
 mod tests {
     use super::*;
 
-    /// Convert string slices to Vec<String> for test convenience.
     fn args(values: &[&str]) -> Vec<String> {
         values.iter().map(|s| s.to_string()).collect()
     }
@@ -444,7 +469,7 @@ mod tests {
     fn parse_native_find_name() {
         let parsed = parse_find_args(&args(&[".", "-name", "*.rs"])).unwrap();
         assert_eq!(parsed.pattern, "*.rs");
-        assert_eq!(parsed.path, ".");
+        assert_eq!(parsed.paths, vec!["."]);
         assert_eq!(parsed.file_type, "f");
         assert_eq!(parsed.max_results, 50);
     }
@@ -453,8 +478,21 @@ mod tests {
     fn parse_native_find_name_and_type() {
         let parsed = parse_find_args(&args(&["src", "-name", "*.rs", "-type", "f"])).unwrap();
         assert_eq!(parsed.pattern, "*.rs");
-        assert_eq!(parsed.path, "src");
+        assert_eq!(parsed.paths, vec!["src"]);
         assert_eq!(parsed.file_type, "f");
+    }
+
+    #[test]
+    fn parse_native_find_three_paths() {
+        let parsed = parse_find_args(&args(&["a", "b", "c", "-name", "*.rs"])).unwrap();
+        assert_eq!(parsed.pattern, "*.rs");
+        assert_eq!(parsed.paths, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn parse_native_find_duplicate_paths() {
+        let parsed = parse_find_args(&args(&["a", "a", "-name", "*.txt"])).unwrap();
+        assert_eq!(parsed.paths, vec!["a", "a"]);
     }
 
     #[test]
@@ -490,7 +528,7 @@ mod tests {
         // `find -name "*.rs"` without explicit path defaults to "."
         let parsed = parse_find_args(&args(&["-name", "*.rs"])).unwrap();
         assert_eq!(parsed.pattern, "*.rs");
-        assert_eq!(parsed.path, ".");
+        assert_eq!(parsed.paths, vec!["."]);
     }
 
     // --- parse_find_args: unsupported flags ---
@@ -515,21 +553,28 @@ mod tests {
     fn parse_rtk_syntax_pattern_only() {
         let parsed = parse_find_args(&args(&["*.rs"])).unwrap();
         assert_eq!(parsed.pattern, "*.rs");
-        assert_eq!(parsed.path, ".");
+        assert_eq!(parsed.paths, vec!["."]);
     }
 
     #[test]
     fn parse_rtk_syntax_pattern_and_path() {
         let parsed = parse_find_args(&args(&["*.rs", "src"])).unwrap();
         assert_eq!(parsed.pattern, "*.rs");
-        assert_eq!(parsed.path, "src");
+        assert_eq!(parsed.paths, vec!["src"]);
+    }
+
+    #[test]
+    fn parse_rtk_syntax_multiple_paths() {
+        let parsed = parse_find_args(&args(&["*.rs", "src", "tests"])).unwrap();
+        assert_eq!(parsed.pattern, "*.rs");
+        assert_eq!(parsed.paths, vec!["src", "tests"]);
     }
 
     #[test]
     fn parse_rtk_syntax_with_flags() {
         let parsed = parse_find_args(&args(&["*.rs", "src", "-m", "10", "-t", "d"])).unwrap();
         assert_eq!(parsed.pattern, "*.rs");
-        assert_eq!(parsed.path, "src");
+        assert_eq!(parsed.paths, vec!["src"]);
         assert_eq!(parsed.max_results, 10);
         assert_eq!(parsed.file_type, "d");
     }
@@ -538,7 +583,7 @@ mod tests {
     fn parse_empty_args() {
         let parsed = parse_find_args(&args(&[])).unwrap();
         assert_eq!(parsed.pattern, "*");
-        assert_eq!(parsed.path, ".");
+        assert_eq!(parsed.paths, vec!["."]);
     }
 
     // --- run_from_args integration tests ---
@@ -569,14 +614,14 @@ mod tests {
     #[test]
     fn find_dotfile_pattern_includes_hidden() {
         // .gitignore exists at the repo root — must be found when using a dotfile pattern
-        let result = run(".gitignore", ".", 50, Some(1), "f", false, 0);
+        let result = run(".gitignore", &args(&["."]), 50, Some(1), "f", false, 0);
         assert!(result.is_ok(), "run with dotfile pattern should not error");
     }
 
     #[test]
     fn find_regular_pattern_skips_hidden() {
         // Non-dot pattern should not error (hidden dirs remain skipped)
-        let result = run("*.rs", "src", 5, None, "f", false, 0);
+        let result = run("*.rs", &args(&["src"]), 5, None, "f", false, 0);
         assert!(result.is_ok());
     }
 
@@ -585,34 +630,42 @@ mod tests {
     #[test]
     fn find_rs_files_in_src() {
         // Should find .rs files without error
-        let result = run("*.rs", "src", 100, None, "f", false, 0);
+        let result = run("*.rs", &args(&["src"]), 100, None, "f", false, 0);
         assert!(result.is_ok());
     }
 
     #[test]
     fn find_dot_pattern_works() {
         // "." pattern should not error (was broken before)
-        let result = run(".", "src", 10, None, "f", false, 0);
+        let result = run(".", &args(&["src"]), 10, None, "f", false, 0);
         assert!(result.is_ok());
     }
 
     #[test]
     fn find_no_matches() {
-        let result = run("*.xyz_nonexistent", "src", 50, None, "f", false, 0);
+        let result = run(
+            "*.xyz_nonexistent",
+            &args(&["src"]),
+            50,
+            None,
+            "f",
+            false,
+            0,
+        );
         assert!(result.is_ok());
     }
 
     #[test]
     fn find_respects_max() {
         // With max=2, should not error
-        let result = run("*.rs", "src", 2, None, "f", false, 0);
+        let result = run("*.rs", &args(&["src"]), 2, None, "f", false, 0);
         assert!(result.is_ok());
     }
 
     #[test]
     fn find_gitignored_excluded() {
         // target/ is in .gitignore — files inside should not appear
-        let result = run("*", ".", 1000, None, "f", false, 0);
+        let result = run("*", &args(&["."]), 1000, None, "f", false, 0);
         assert!(result.is_ok());
         // We can't easily capture stdout in unit tests, but at least
         // verify it runs without error. The smoke tests verify content.

--- a/tests/guard_integration_test.rs
+++ b/tests/guard_integration_test.rs
@@ -187,9 +187,10 @@ fn find_one_valid_one_invalid_path_subprocess() {
 }
 
 #[test]
-fn find_duplicate_paths_shows_duplicate_matches() {
-    // Native `find a a -name "*.txt"` prints the match twice (no dedup across
-    // repeated path args); rtk find should match that behavior.
+fn find_duplicate_paths_dedups_to_a_single_match() {
+    // Unlike native find (which prints the match once per repeated path arg),
+    // rtk find dedups identical paths: searching the same root twice wastes a
+    // walk and would produce misleading duplicate results.
     let dir = tempfile::tempdir().expect("tempdir");
     std::fs::create_dir_all(dir.path().join("folder1")).expect("mkdir folder1");
     std::fs::write(dir.path().join("folder1/foo.txt"), "x").expect("write foo");
@@ -200,8 +201,8 @@ fn find_duplicate_paths_shows_duplicate_matches() {
     );
     let occurrences = out.matches("foo.txt").count();
     assert_eq!(
-        occurrences, 2,
-        "expected foo.txt to appear twice for a duplicated path arg, got {occurrences}: {out:?}"
+        occurrences, 1,
+        "expected foo.txt to appear once after deduping a repeated path arg, got {occurrences}: {out:?}"
     );
 }
 

--- a/tests/guard_integration_test.rs
+++ b/tests/guard_integration_test.rs
@@ -148,6 +148,64 @@ fn find_no_results_emits_empty() {
 }
 
 #[test]
+fn find_multiple_paths_returns_matches_from_both() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(dir.path().join("folder1")).expect("mkdir folder1");
+    std::fs::create_dir_all(dir.path().join("folder2")).expect("mkdir folder2");
+    std::fs::write(dir.path().join("folder1/foo.txt"), "x").expect("write foo");
+    std::fs::write(dir.path().join("folder2/bar.txt"), "x").expect("write bar");
+
+    let (out, _) = rtk_in_dir(
+        dir.path(),
+        &["find", "folder1", "folder2", "-name", "*.txt"],
+    );
+    assert!(
+        out.contains("foo.txt"),
+        "expected foo.txt from the first path in output: {out:?}"
+    );
+    assert!(
+        out.contains("bar.txt"),
+        "expected bar.txt from the second path in output: {out:?}"
+    );
+}
+
+#[test]
+fn find_one_valid_one_invalid_path_subprocess() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(dir.path().join("folder1")).expect("mkdir folder1");
+    std::fs::write(dir.path().join("folder1/foo.txt"), "x").expect("write foo");
+
+    let (out, code) = rtk_in_dir(
+        dir.path(),
+        &["find", "folder1", "does_not_exist", "-name", "*.txt"],
+    );
+    assert_eq!(code, Some(0), "invalid root should not fail the command");
+    assert!(
+        out.contains("foo.txt"),
+        "expected foo.txt from the valid path in output: {out:?}"
+    );
+}
+
+#[test]
+fn find_duplicate_paths_shows_duplicate_matches() {
+    // Native `find a a -name "*.txt"` prints the match twice (no dedup across
+    // repeated path args); rtk find should match that behavior.
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(dir.path().join("folder1")).expect("mkdir folder1");
+    std::fs::write(dir.path().join("folder1/foo.txt"), "x").expect("write foo");
+
+    let (out, _) = rtk_in_dir(
+        dir.path(),
+        &["find", "folder1", "folder1", "-name", "*.txt"],
+    );
+    let occurrences = out.matches("foo.txt").count();
+    assert_eq!(
+        occurrences, 2,
+        "expected foo.txt to appear twice for a duplicated path arg, got {occurrences}: {out:?}"
+    );
+}
+
+#[test]
 fn git_stash_list_no_stashes_emits_empty() {
     let dir = init_git_repo();
     let (out, code) = rtk_in_dir(dir.path(), &["git", "stash", "list"]);


### PR DESCRIPTION
## Summary

- `rtk find` silently searched only the first path argument, dropping matches from any additional paths with no warning or error (#2839). This made it unsafe as a PreToolUse hook filter, since an agent could be told a file "does not exist" when it only existed under a dropped path.
- Both native (`find path1 path2 -name ...`) and RTK-shorthand (`find <pattern> path1 path2 ...`) syntaxes now collect all leading path arguments, and `run()` walks every given root through a single `WalkBuilder`.
- Display paths are stripped relative to the root when a single path is given (unchanged behavior); with multiple distinct roots, each result keeps its root prefix so files from different roots don't collide in the by-directory grouping.
- Identical path arguments are deduped before searching: a repeated root is walked once and reported once, rather than duplicating results, keeping output as compact and unambiguous as any other single-path search.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk find pathA pathB -name "*.txt"` inspected, confirmed matches from both paths; confirmed single-path output format unchanged; confirmed a repeated path argument (`rtk find a a -name "*.txt"`) dedups to a single match
- [x] Added unit tests for multi-path parsing and subprocess integration tests reproducing the original issue #2839 repro, plus a dedup regression test

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.