### PR TITLE
fix: preserve grep patterns in hook rewrites

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1432,6 +1432,28 @@ fn shell_split(input: &str) -> Vec<String> {
     discover::lexer::shell_split(input)
 }
 
+fn shell_join_args(args: &[String]) -> String {
+    args.iter()
+        .map(|arg| shell_quote_arg(arg))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn shell_quote_arg(arg: &str) -> String {
+    if arg.is_empty() {
+        return "''".to_string();
+    }
+
+    if arg
+        .bytes()
+        .all(|b| matches!(b, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'_' | b'-' | b'.' | b'/' | b':' | b'=' | b',' | b'+' | b'%'))
+    {
+        return arg.to_string();
+    }
+
+    format!("'{}'", arg.replace('\'', "'\\''"))
+}
+
 fn build_k8s_namespace_args(namespace: Option<String>, all: bool) -> Vec<String> {
     let mut args = Vec::new();
     if all {
@@ -2394,7 +2416,11 @@ fn run_cli() -> Result<i32> {
             }
             HookCommands::Check { agent: _, command } => {
                 use crate::discover::registry::rewrite_command;
-                let raw = command.join(" ");
+                let raw = if command.len() == 1 {
+                    command[0].clone()
+                } else {
+                    shell_join_args(&command)
+                };
                 let (excluded, transparent_prefixes) = crate::core::config::Config::load()
                     .map(|c| (c.hooks.exclude_commands, c.hooks.transparent_prefixes))
                     .unwrap_or_default();
@@ -2412,7 +2438,11 @@ fn run_cli() -> Result<i32> {
         },
 
         Commands::Rewrite { args } => {
-            let cmd = args.join(" ");
+            let cmd = if args.len() == 1 {
+                args[0].clone()
+            } else {
+                shell_join_args(&args)
+            };
             hooks::rewrite_cmd::run(&cmd)?;
             0
         }

--- a/tests/hook_rewrite_test.rs
+++ b/tests/hook_rewrite_test.rs
@@ -1,0 +1,54 @@
+#![cfg(unix)]
+
+use std::process::Command;
+
+fn rtk(args: &[&str]) -> (String, String, Option<i32>) {
+    let out = Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args(args)
+        .output()
+        .expect("rtk");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        out.status.code(),
+    )
+}
+
+#[test]
+fn hook_check_preserves_grep_regex_alternation_as_one_arg() {
+    let (stdout, _stderr, code) = rtk(&[
+        "hook",
+        "check",
+        "grep",
+        "-r",
+        "taper|ended|15m",
+        ".",
+        "--include=*.py",
+    ]);
+
+    assert_eq!(code, Some(0));
+    assert_eq!(
+        stdout.trim(),
+        "rtk grep -r 'taper|ended|15m' . '--include=*.py'"
+    );
+}
+
+#[test]
+fn rewrite_multi_arg_preserves_grep_regex_alternation_as_one_arg() {
+    let (stdout, _stderr, code) = rtk(&[
+        "rewrite",
+        "grep",
+        "-rnE",
+        "\\.set\\(|\\.setex\\(|\\.setnx\\(",
+        "/tmp/code",
+    ]);
+
+    assert!(
+        matches!(code, Some(0) | Some(3)),
+        "unexpected exit code: {code:?}"
+    );
+    assert_eq!(
+        stdout.trim(),
+        "rtk grep -rnE '\\.set\\(|\\.setex\\(|\\.setnx\\(' /tmp/code"
+    );
+}


### PR DESCRIPTION
## Summary
- Preserve argv token boundaries when `rtk hook check` / multi-arg `rtk rewrite` reconstruct shell commands.
- Shell-quote arguments containing metacharacters so grep alternation patterns like `a|b|c` are not treated as pipeline operators by the rewrite engine.
- Add regression coverage for the issue #880 grep patterns reported in hook rewrites.

Fixes rtk-ai/rtk#880.

## Verification
```text
$ cargo test --test hook_rewrite_test -- --nocapture
running 2 tests
test hook_check_preserves_grep_regex_alternation_as_one_arg ... ok
test rewrite_multi_arg_preserves_grep_regex_alternation_as_one_arg ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

```text
$ cargo fmt --all && cargo clippy --all-targets && cargo test --all
Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.93s
Finished `test` profile [unoptimized + debuginfo] target(s) in 15.32s
test result: ok. 2429 passed; 0 failed; 8 ignored; 0 measured; 0 filtered out
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```
