### PR TITLE
fix(hooks): recognize absolute-path rtk hook claude in settings.json

### DIFF
--- a/src/hooks/hook_check.rs
+++ b/src/hooks/hook_check.rs
@@ -58,6 +58,23 @@ pub fn status() -> HookStatus {
     }
 }
 
+/// Returns true when `cmd` registers the Claude Code RTK hook, including
+/// absolute-path invocations like `/opt/homebrew/bin/rtk hook claude`.
+pub fn claude_hook_command_matches(cmd: &str) -> bool {
+    if cmd == CLAUDE_HOOK_COMMAND || cmd.contains(REWRITE_HOOK_FILE) {
+        return true;
+    }
+    let normalized = cmd.replace('\\', "/");
+    if normalized.ends_with(CLAUDE_HOOK_COMMAND)
+        || normalized.contains(&format!("/{CLAUDE_HOOK_COMMAND}"))
+    {
+        return true;
+    }
+    // Windows: `...\rtk.exe hook claude`
+    normalized.ends_with("rtk.exe hook claude")
+        || normalized.contains("/rtk.exe hook claude")
+}
+
 /// Check if the native binary command is registered in settings.json
 fn binary_hook_registered(claude_dir: &std::path::Path) -> bool {
     let settings_path = claude_dir.join(SETTINGS_JSON);
@@ -82,7 +99,7 @@ fn binary_hook_registered(claude_dir: &std::path::Path) -> bool {
         .filter_map(|entry| entry.get("hooks")?.as_array())
         .flatten()
         .filter_map(|hook| hook.get("command")?.as_str())
-        .any(|cmd| cmd == CLAUDE_HOOK_COMMAND)
+        .any(claude_hook_command_matches)
 }
 
 /// Check if the installed hook is missing or outdated, warn once per day.
@@ -175,6 +192,19 @@ mod tests {
                 .join(HERMES_PLUGIN_MANIFEST_FILE),
         ];
         paths.iter().any(|p| p.exists())
+    }
+
+    #[test]
+    fn test_claude_hook_command_matches_absolute_path() {
+        assert!(claude_hook_command_matches(
+            "/opt/homebrew/bin/rtk hook claude"
+        ));
+        assert!(claude_hook_command_matches(
+            r"C:\Program Files\rtk\rtk.exe hook claude"
+        ));
+        assert!(claude_hook_command_matches(CLAUDE_HOOK_COMMAND));
+        assert!(!claude_hook_command_matches("rtk hook gemini"));
+        assert!(!claude_hook_command_matches("/usr/bin/grep foo"));
     }
 
     #[test]

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -20,6 +20,7 @@ use super::constants::{
     HOOKS_SUBDIR, PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR,
     PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
+use super::hook_check::claude_hook_command_matches;
 use super::integrity;
 
 // Embedded OpenCode plugin (auto-rewrite)
@@ -1121,9 +1122,7 @@ fn hook_already_present(root: &serde_json::Value, hook_command: &str) -> bool {
         .filter_map(|entry| entry.get("hooks")?.as_array())
         .flatten()
         .filter_map(|hook| hook.get("command")?.as_str())
-        .any(|cmd| {
-            cmd == hook_command || cmd == CLAUDE_HOOK_COMMAND || cmd.contains(REWRITE_HOOK_FILE)
-        })
+        .any(|cmd| cmd == hook_command || claude_hook_command_matches(cmd))
 }
 
 /// Default mode: hook + slim RTK.md + @RTK.md reference


### PR DESCRIPTION
## Summary

- Add `claude_hook_command_matches()` so hook detection recognizes absolute-path commands like `/opt/homebrew/bin/rtk hook claude`
- Use the helper in `hook_check::binary_hook_registered` and `init::hook_already_present`

Fixes #2884

## Motivation

Users on macOS often configure Claude Code hooks with an absolute path to `rtk` because hook commands run under `/bin/sh` without Homebrew on PATH. `rtk gain` and `rtk init -g` incorrectly warned "No hook installed" even when the hook was active and tracking commands.

## Changes

- `src/hooks/hook_check.rs`: new matcher + unit test; `binary_hook_registered` delegates to it
- `src/hooks/init.rs`: `hook_already_present` uses the shared matcher

## Tests

- `cargo fmt --all && cargo clippy --all-targets` — passed
- `cargo test hooks::hook_check` — passed (14 tests)
- composer-2.5 review: **APPROVE**

## Notes

Uninstall path (`remove_hook_from_json`) still uses exact matching for removal; detection is fixed here. A follow-up could reuse the helper for uninstall symmetry.