### PR TITLE
fix(init): add always_on trigger frontmatter to antigravity rules

### DIFF
--- a/hooks/antigravity/rules.md
+++ b/hooks/antigravity/rules.md
@@ -1,4 +1,8 @@
+---
+trigger: always_on
+---
 # RTK - Rust Token Killer (Google Antigravity)
+
 
 **Usage**: Token-optimized CLI proxy for shell commands.
 


### PR DESCRIPTION
When running `rtk init --agent antigravity`, the tool generates a workspace rules file at `.agents/rules/antigravity-rtk-rules.md`. However, the generated Markdown file is missing the YAML frontmatter required by Google Antigravity to automatically register the rule. As a result, the agent does not load the rule at startup. This PR fixes it by prepending `trigger: always_on` frontmatter to the template file.