### PR TITLE
fix(discover): make git global-opt stripping quote-aware

### DIFF
--- a/src/discover/provider.rs
+++ b/src/discover/provider.rs
@@ -117,15 +117,16 @@ impl ClaudeProvider {
 
     /// Encode a filesystem path to Claude Code's directory name format.
     ///
-    /// Claude Code replaces `/`, `.`, `_`, `\`, and any non-ASCII character
+    /// Claude Code replaces `/`, `.`, `_`, `\`, `(`, `)`, and any non-ASCII character
     /// with `-` when computing the project directory slug under `~/.claude/projects/`.
     ///
-    /// `/Users/foo/bar`          → `-Users-foo-bar`
-    /// `/Users/first.last/bar`   → `-Users-first-last-bar`
-    /// `/home/chris/2_project`   → `-home-chris-2-project`
-    /// `C:\Users\foo\bar`        → `C:-Users-foo-bar`
+    /// `/Users/foo/bar`             → `-Users-foo-bar`
+    /// `/Users/first.last/bar`      → `-Users-first-last-bar`
+    /// `/home/chris/2_project`      → `-home-chris-2-project`
+    /// `/Users/dev/old projects (2024)` → `-Users-dev-old-projects--2024-`
+    /// `C:\Users\foo\bar`           → `C:-Users-foo-bar`
     pub fn encode_project_path(path: &str) -> String {
-        const SANITIZED_CHARS: &[char] = &['/', '.', '_', '\\', ' ', '[', ']'];
+        const SANITIZED_CHARS: &[char] = &['/', '.', '_', '\\', ' ', '[', ']', '(', ')'];
 
         path.chars()
             .map(|c| {
@@ -392,6 +393,16 @@ mod tests {
     }
 
     #[test]
+    fn test_encode_project_path_parens() {
+        // Claude Code also replaces '(' and ')' with '-'. Verified against a real
+        // ~/.claude/projects/ directory for a path containing "(1998)" -> "--1998--".
+        assert_eq!(
+            ClaudeProvider::encode_project_path("/Users/dev/old projects (2024)/repo"),
+            "-Users-dev-old-projects--2024--repo"
+        );
+    }
+
+    #[test]
     fn test_encode_project_path_non_ascii() {
         // Non-ASCII characters are each replaced with '-' (https://github.com/anthropics/claude-code/issues/40946)
         // '/home/user/' + '外' + '主' + '/app' -> '-home-user' + '-' + '-' + '-' + '-' + 'app'
@@ -459,6 +470,34 @@ mod tests {
         let sessions = ClaudeProvider::discover_sessions_in_projects_dir(
             projects_dir.path(),
             Some("rtk"),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(
+            sessions[0].file_name().and_then(|name| name.to_str()),
+            Some("matching.jsonl")
+        );
+    }
+
+    // The project filter passed here mirrors what discover::mod.rs::run() derives
+    // from the cwd: encode_project_path() output used as a substring match against
+    // the on-disk directory name. If the encoding doesn't sanitize a character the
+    // same way Claude Code does, the filter silently matches nothing.
+    #[test]
+    fn test_discover_sessions_applies_project_filter_with_parens() {
+        let projects_dir = tempfile::tempdir().unwrap();
+        let matching_project = projects_dir
+            .path()
+            .join("-Users-dev-old-projects--2024--repo");
+        std::fs::create_dir_all(&matching_project).unwrap();
+        std::fs::write(matching_project.join("matching.jsonl"), "").unwrap();
+
+        let filter = ClaudeProvider::encode_project_path("/Users/dev/old projects (2024)/repo");
+        let sessions = ClaudeProvider::discover_sessions_in_projects_dir(
+            projects_dir.path(),
+            Some(&filter),
             None,
         )
         .unwrap();

--- a/src/discover/provider.rs
+++ b/src/discover/provider.rs
@@ -481,10 +481,7 @@ mod tests {
         );
     }
 
-    // The project filter passed here mirrors what discover::mod.rs::run() derives
-    // from the cwd: encode_project_path() output used as a substring match against
-    // the on-disk directory name. If the encoding doesn't sanitize a character the
-    // same way Claude Code does, the filter silently matches nothing.
+    // Mirrors discover::mod.rs::run(): encode_project_path() output used as a substring match against the on-disk directory name.
     #[test]
     fn test_discover_sessions_applies_project_filter_with_parens() {
         let projects_dir = tempfile::tempdir().unwrap();

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -325,8 +325,10 @@ fn normalize_php_tool_path(path: &str) -> String {
 /// Git global options that take a separate value token: -C <path>, -c <key=val>,
 /// --git-dir <dir>, --work-tree <dir>.
 const GIT_GLOBAL_OPT_WITH_VALUE: &[&str] = &["-C", "-c", "--git-dir", "--work-tree"];
+
 /// Git global options that also accept `--flag=value` form.
 const GIT_GLOBAL_OPT_EQ: &[&str] = &["--git-dir", "--work-tree"];
+
 /// Git global flag-only options that take no value.
 const GIT_GLOBAL_OPT_FLAG: &[&str] = &[
     "--no-pager",

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -63,10 +63,6 @@ lazy_static! {
         let env_assign = format!(r#"[A-Z_][A-Z0-9_]*={}"#, env_value);
         Regex::new(&format!(r#"^(?:sudo\s+|env\s+|{}\s+)+"#, env_assign)).unwrap()
     };
-    // Git global options that appear before the subcommand: -C <path>, -c <key=val>,
-    // --git-dir <dir>, --work-tree <dir>, and flag-only options (#163)
-    static ref GIT_GLOBAL_OPT: Regex =
-        Regex::new(r"^(?:(?:-C\s+\S+|-c\s+\S+|--git-dir(?:=\S+|\s+\S+)|--work-tree(?:=\S+|\s+\S+)|--no-pager|--no-optional-locks|--bare|--literal-pathspecs)\s+)+").unwrap();
     // Issue #1362: each capture expects a SINGLE file argument (`\S+$`). Multi-file
     // invocations like `head -3 a b c` fail to match so the segment is passed through
     // to the native `head`/`tail` binary — which already handles multi-file with
@@ -326,17 +322,63 @@ fn normalize_php_tool_path(path: &str) -> String {
     normalized
 }
 
+/// Git global options that take a separate value token: -C <path>, -c <key=val>,
+/// --git-dir <dir>, --work-tree <dir>.
+const GIT_GLOBAL_OPT_WITH_VALUE: &[&str] = &["-C", "-c", "--git-dir", "--work-tree"];
+/// Git global options that also accept `--flag=value` form.
+const GIT_GLOBAL_OPT_EQ: &[&str] = &["--git-dir", "--work-tree"];
+/// Git global flag-only options that take no value.
+const GIT_GLOBAL_OPT_FLAG: &[&str] = &[
+    "--no-pager",
+    "--no-optional-locks",
+    "--bare",
+    "--literal-pathspecs",
+];
+
 /// Strip git global options before the subcommand (#163).
 /// `git -C /tmp status` → `git status`, preserving the rest.
 /// Returns the original string unchanged if not a git command.
+///
+/// Uses the shared tokenizer rather than a bare-whitespace split so a quoted
+/// value (e.g. `-C "/path with spaces"`) is treated as one argument instead
+/// of being cut off at the first space inside the quotes.
 fn strip_git_global_opts(cmd: &str) -> String {
     // Only applies to commands starting with "git "
     if !cmd.starts_with("git ") {
         return cmd.to_string();
     }
     let after_git = &cmd[4..]; // skip "git "
-    let stripped = GIT_GLOBAL_OPT.replace(after_git, "");
-    format!("git {}", stripped.trim())
+    let tokens = tokenize(after_git);
+
+    let mut i = 0;
+    while let Some(tok) = tokens.get(i) {
+        if tok.kind != TokenKind::Arg {
+            break;
+        }
+        if GIT_GLOBAL_OPT_FLAG.contains(&tok.value.as_str()) {
+            i += 1;
+            continue;
+        }
+        if GIT_GLOBAL_OPT_WITH_VALUE.contains(&tok.value.as_str()) {
+            match tokens.get(i + 1) {
+                Some(value_tok) if value_tok.kind == TokenKind::Arg => {
+                    i += 2;
+                    continue;
+                }
+                _ => break,
+            }
+        }
+        if let Some(eq_pos) = tok.value.find('=') {
+            if GIT_GLOBAL_OPT_EQ.contains(&&tok.value[..eq_pos]) {
+                i += 1;
+                continue;
+            }
+        }
+        break;
+    }
+
+    let remainder_start = tokens.get(i).map(|t| t.offset).unwrap_or(after_git.len());
+    format!("git {}", after_git[remainder_start..].trim())
 }
 
 /// Strip golangci-lint global options before the `run` subcommand.
@@ -3946,6 +3988,72 @@ mod tests {
         assert_eq!(strip_git_global_opts("git --no-pager log"), "git log");
         assert_eq!(strip_git_global_opts("git status"), "git status");
         assert_eq!(strip_git_global_opts("cargo test"), "cargo test");
+    }
+
+    // A quoted -C value can contain spaces or parens (e.g. macOS folder names
+    // like "old projects (2024)"); the value must stay intact as one argument.
+    #[test]
+    fn test_strip_git_global_opts_quoted_path_with_space() {
+        assert_eq!(
+            strip_git_global_opts(r#"git -C "/Users/dev/old projects (2024)/repo" diff"#),
+            "git diff"
+        );
+        assert_eq!(
+            strip_git_global_opts("git -C '/Users/dev/old projects/repo' status"),
+            "git status"
+        );
+    }
+
+    // --git-dir/--work-tree also accept `--flag=value` (no space), a separate
+    // code path from the space-separated `-C <value>` form above.
+    #[test]
+    fn test_strip_git_global_opts_eq_form() {
+        assert_eq!(
+            strip_git_global_opts("git --git-dir=/tmp/foo.git status"),
+            "git status"
+        );
+        assert_eq!(
+            strip_git_global_opts("git --work-tree=/tmp/wt status"),
+            "git status"
+        );
+        assert_eq!(
+            strip_git_global_opts(r#"git --git-dir="/Users/dev/old projects (2024)/.git" status"#),
+            "git status"
+        );
+    }
+
+    #[test]
+    fn test_strip_git_global_opts_dash_c_key_value() {
+        assert_eq!(
+            strip_git_global_opts("git -c user.name=Dev status"),
+            "git status"
+        );
+    }
+
+    #[test]
+    fn test_strip_git_global_opts_chained() {
+        assert_eq!(
+            strip_git_global_opts("git --no-pager -C /tmp/foo status"),
+            "git status"
+        );
+    }
+
+    // A global-opt flag with no following value shouldn't be consumed or panic;
+    // the string is returned with the (incomplete) flag left in place.
+    #[test]
+    fn test_strip_git_global_opts_dangling_flag() {
+        assert_eq!(strip_git_global_opts("git -C"), "git -C");
+    }
+
+    #[test]
+    fn test_rewrite_git_dash_c_quoted_path_with_space() {
+        assert_eq!(
+            rewrite_command_no_prefixes(
+                r#"git -C "/Users/dev/old projects (2024)/repo" diff"#,
+                &[]
+            ),
+            Some(r#"rtk git -C "/Users/dev/old projects (2024)/repo" diff"#.to_string())
+        );
     }
 
     #[test]

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -12,7 +12,11 @@ pub struct RtkRule {
 
 pub const RULES: &[RtkRule] = &[
     RtkRule {
-        pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|checkout|push|pull|branch|fetch|stash|worktree)",
+        // -C/-c/--git-dir/--work-tree are already stripped by
+        // strip_git_global_opts() in registry.rs before this pattern is matched,
+        // so this pattern doesn't need to (and can't reliably, without duplicating
+        // the tokenizer) account for them here.
+        pattern: r"^(?:git|yadm)\s+(status|log|diff|show|add|commit|checkout|push|pull|branch|fetch|stash|worktree)",
         rtk_cmd: "rtk git",
         rewrite_prefixes: &["git", "yadm"],
         category: "Git",

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -12,10 +12,6 @@ pub struct RtkRule {
 
 pub const RULES: &[RtkRule] = &[
     RtkRule {
-        // -C/-c/--git-dir/--work-tree are already stripped by
-        // strip_git_global_opts() in registry.rs before this pattern is matched,
-        // so this pattern doesn't need to (and can't reliably, without duplicating
-        // the tokenizer) account for them here.
         pattern: r"^(?:git|yadm)\s+(status|log|diff|show|add|commit|checkout|push|pull|branch|fetch|stash|worktree)",
         rtk_cmd: "rtk git",
         rewrite_prefixes: &["git", "yadm"],


### PR DESCRIPTION
## Summary

Fixes #2896.

- `git -C`/`-c`/`--git-dir`/`--work-tree` values were split with a bare `\S+` regex in `strip_git_global_opts`, so a quoted value containing a space or parens (e.g. a macOS folder like `old projects (2024)`) got truncated mid-argument. The corrupted string then failed classification, so `rtk hook claude` silently skipped the rewrite (zero savings, no warning) and `rtk discover` failed to detect the command.
- Replaced the regex with a token walk over the existing quote-aware lexer (`discover::lexer::tokenize`), so quoted values with spaces/parens are treated as a single argument.
- Removed the now-dead `-[Cc]\s+\S+\s+` clause from the git `RULES` pattern in `rules.rs` — `strip_git_global_opts` always normalizes the command before this pattern is matched, so the clause could never fire (confirmed via trace of every call site).
- Added `(` and `)` to `encode_project_path`'s sanitized-character set in `provider.rs`, matching Claude Code's actual project-directory slug algorithm (verified against a real `~/.claude/projects/` directory containing `(1998)` in its path, encoded as `--1998--`). This fixes `rtk discover` reporting `Scanned: 0 sessions` for project paths containing parentheses.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test --all` — clean, all tests pass except 2 pre-existing/unrelated failures in `hooks::rewrite_cmd::tests::unattestable_passthrough` (confirmed identical on unmodified `develop` via `git stash`)
- [x] Added unit tests for `strip_git_global_opts`: quoted `-C` value (double/single quote, space+parens), `--git-dir=`/`--work-tree=` equals form (including quoted), `-c key=val`, chained global opts, dangling flag edge case
- [x] Added end-to-end `rewrite_command_no_prefixes` test for the quoted-parens `-C` case
- [x] Added `encode_project_path` parens test and a `discover_sessions_in_projects_dir` regression test mirroring the real filter-construction path in `discover::mod.rs::run()`
- [x] Manually verified against the built binary: reproduced the exact issue repro (`git -C "..." diff` via `rtk hook claude`), confirmed it now rewrites correctly; set up a real directory on disk containing spaces+parens with a fake `CLAUDE_CONFIG_DIR` session, confirmed `rtk discover` now finds and reports the session instead of `Scanned: 0 sessions`