### PR TITLE
feat(hook): rewrite npm and pnpm test commands

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -3301,6 +3301,33 @@ mod tests {
     }
 
     #[test]
+    fn test_rewrite_npm_and_pnpm_test_scripts() {
+        assert_eq!(
+            rewrite_command_no_prefixes("npm test -- --watch", &[]),
+            Some("rtk npm test -- --watch".to_string()),
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("npm t", &[]),
+            Some("rtk npm t".to_string()),
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("pnpm test -- --watch", &[]),
+            Some("rtk pnpm test -- --watch".to_string()),
+        );
+    }
+
+    #[test]
+    fn test_rewrite_unsupported_js_runtimes_stay_passthrough() {
+        for command in ["yarn test", "bun test", "node script.js"] {
+            assert_eq!(
+                rewrite_command_no_prefixes(command, &[]),
+                None,
+                "{command} should stay passthrough until RTK has a matching filter",
+            );
+        }
+    }
+
+    #[test]
     fn test_rewrite_npx() {
         assert_eq!(
             rewrite_command_no_prefixes("npx svgo", &[]),

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -53,7 +53,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[("fmt", RtkStatus::Passthrough)],
     },
     RtkRule {
-        pattern: r"^pnpm\s+(exec|i|install|list|ls|outdated|run|run-script)",
+        pattern: r"^pnpm\s+(exec|i|install|list|ls|outdated|run|run-script|test)(\s|$)",
         rtk_cmd: "rtk pnpm",
         rewrite_prefixes: &["pnpm"],
         category: "PackageManager",
@@ -62,7 +62,7 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        pattern: r"^npm\s+(exec|run|run-script|rum|urn|x)(\s|$)",
+        pattern: r"^npm\s+(exec|run|run-script|rum|urn|x|test|t)(\s|$)",
         rtk_cmd: "rtk npm",
         rewrite_prefixes: &["npm"],
         category: "PackageManager",


### PR DESCRIPTION
## Summary

- route `npm test` and its `npm t` alias through `rtk npm`
- route `pnpm test` through `rtk pnpm`
- add regression coverage for arguments and keep unsupported `yarn`, `bun`, and `node` commands as passthrough

## Why

The hook rewrite registry covered `npm run` and `pnpm run`, but omitted the package managers' direct `test` commands. As a result, hooks left these common test invocations unoptimized even though RTK already exposes the corresponding command paths.

## Impact

Hook users now get transparent RTK routing for direct npm and pnpm test invocations, including trailing test-runner arguments. Commands without a real RTK filter remain unchanged.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets`
- `cargo test` (2,435 unit tests and 11 integration tests passed; 8 tests ignored by the project)

Part of #2921.
