### PR TITLE
perf(hook): avoid Pi package barrel import

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -40,7 +40,7 @@ Each agent subdirectory has its own README with hook-specific details:
 - **[`windsurf/`](windsurf/README.md)** — Rules file (prompt-level), `.windsurfrules` workspace-scoped
 - **[`codex/`](codex/README.md)** — Awareness document, `AGENTS.md` integration, `$CODEX_HOME` or `~/.codex/` location
 - **[`opencode/`](opencode/README.md)** — TypeScript plugin, `zx` library, `tool.execute.before` event, in-place mutation
-- **[`pi/`](pi/README.md)** — TypeScript extension, `tool_call` event, `isToolCallEventType` guard, in-place mutation, `~/.pi/agent/extensions/`
+- **[`pi/`](pi/README.md)** — TypeScript extension, `tool_call` event, local `isBashToolCallEvent` guard, in-place mutation, `~/.pi/agent/extensions/`
 - **[`hermes/`](hermes/README.md)** — Python plugin, `pre_tool_call` hook, in-place terminal command mutation
 
 ## Supported Agents

--- a/hooks/pi/README.md
+++ b/hooks/pi/README.md
@@ -15,7 +15,7 @@ with other Pi extensions.
 ## Specifics
 
 - TypeScript extension using Pi's `ExtensionAPI` (not a shell hook, no `zx` dependency)
-- Subscribes to `tool_call` event, narrows to `bash` tool via `isToolCallEventType`
+- Subscribes to `tool_call` event, narrows to `bash` tool via a local `isBashToolCallEvent` guard (avoids importing the package's value-exported `isToolCallEventType`, which pulls in its whole barrel at extension load)
 - Calls `rtk rewrite` via `pi.exec`; mutates `event.input.command` in-place if rewrite differs
 - All error paths return `undefined` (pass through); RTK never blocks execution
 - Version guard at load time: checks `rtk >= 0.23.0`; warns and registers no-op if too old or missing

--- a/hooks/pi/rtk.ts
+++ b/hooks/pi/rtk.ts
@@ -19,6 +19,12 @@ import type {
 const REWRITE_TIMEOUT_MS = 2_000
 const MIN_SUPPORTED_RTK_MINOR = 23
 
+// Local reimplementation of the package's `isToolCallEventType("bash", event)` type
+// guard. That helper is a value export, so importing it pulls in the whole
+// `@earendil-works/pi-coding-agent` barrel at extension load — profiled at ~250ms
+// warmed, vs ~10ms for a type-only import. `BashToolCallEvent`/`ToolCallEvent`
+// below are type-only imports and are erased at compile time, so they carry none
+// of that cost. See #2753.
 function isBashToolCallEvent(event: ToolCallEvent): event is BashToolCallEvent {
   return event.toolName === "bash"
 }

--- a/hooks/pi/rtk.ts
+++ b/hooks/pi/rtk.ts
@@ -10,11 +10,18 @@
 //   1           No RTK equivalent → pass through unchanged
 //   3 + stdout  Rewrite (advisory) → mutate command
 
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
-import { isToolCallEventType } from "@earendil-works/pi-coding-agent"
+import type {
+  BashToolCallEvent,
+  ExtensionAPI,
+  ToolCallEvent,
+} from "@earendil-works/pi-coding-agent"
 
 const REWRITE_TIMEOUT_MS = 2_000
 const MIN_SUPPORTED_RTK_MINOR = 23
+
+function isBashToolCallEvent(event: ToolCallEvent): event is BashToolCallEvent {
+  return event.toolName === "bash"
+}
 
 // Parse "X.Y.Z" semver, return [major, minor, patch] or null.
 function parseSemver(raw: string): [number, number, number] | null {
@@ -58,7 +65,7 @@ export default async function (pi: ExtensionAPI) {
 
   pi.on("tool_call", async (event, ctx) => {
     try {
-      if (!isToolCallEventType("bash", event)) return
+      if (!isBashToolCallEvent(event)) return
 
       const cmd = event.input.command
       if (typeof cmd !== "string" || cmd.trim() === "") return

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -7089,6 +7089,9 @@ mod tests {
                 content.contains("rtk rewrite"),
                 "extension must delegate to rtk rewrite"
             );
+            // Regression guard for #2753: a value import (e.g. `import { isToolCallEventType }`)
+            // pulls in the whole @earendil-works/pi-coding-agent barrel at extension load,
+            // adding ~250ms of startup latency. Only `import type { ... }` is allowed.
             assert!(
                 !content.contains("import {"),
                 "extension must not load the Pi package at runtime"

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -7089,6 +7089,10 @@ mod tests {
                 content.contains("rtk rewrite"),
                 "extension must delegate to rtk rewrite"
             );
+            assert!(
+                !content.contains("import {"),
+                "extension must not load the Pi package at runtime"
+            );
         });
     }
 


### PR DESCRIPTION
## Summary

- Replace the runtime package import with a local type guard, so the Pi extension does not load the package barrel at startup.
- Add a regression check that rejects value imports in the installed extension.

Fixes #2753

## Test plan

- [x] Type-checked `hooks/pi/rtk.ts` against `@earendil-works/pi-coding-agent` 0.80.6
- [x] `cargo test test_run_pi_mode_global_installs_plugin`
- [x] `cargo fmt --all --check && cargo clippy --all-targets && cargo test`

## Timing

With Bun 1.3.14 on macOS arm64, loading the package barrel took about 250 ms after warmup. Loading the small extensions module took about 10 ms.
