### PR TITLE
feat(zcode): add global agent instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ rtk init --agent antigravity    # Google Antigravity
 rtk init -g --agent pi          # Pi
 rtk init --agent hermes         # Hermes
 rtk init -g --agent droid       # Factory Droid
+rtk init -g --agent zcode       # ZCode Agent
 
 # 2. Restart your AI tool, then test
 git status  # Automatically rewritten to rtk git status
@@ -366,7 +367,7 @@ rtk init -g
 
 ## Supported AI Tools
 
-RTK supports 15 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents for 60-90% token savings where the agent supports command interception.
+RTK supports 16 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents for 60-90% token savings where the agent supports command interception.
 
 | Tool | Install | Method |
 |------|---------|--------|
@@ -386,6 +387,7 @@ RTK supports 15 AI coding tools. Each integration rewrites shell commands to `rt
 | **Kilo Code** | `rtk init --agent kilocode` | .kilocode/rules/rtk-rules.md (project-scoped) |
 | **Google Antigravity** | `rtk init --agent antigravity` | .agents/rules/antigravity-rtk-rules.md (project-scoped) |
 | **Factory Droid** | `rtk init -g --agent droid` (or per-project) | PreToolUse hook in `~/.factory/hooks.json` (matcher `Execute`) |
+| **ZCode Agent** | `rtk init -g --agent zcode` | User-level `~/.zcode/AGENTS.md` instructions |
 
 For per-agent setup details, override controls, and graceful degradation, see the [Supported Agents guide](https://www.rtk-ai.app/guide/getting-started/supported-agents). The Hermes plugin source and tests live in `hooks/hermes/`; installed Hermes runtime files still live under `~/.hermes/plugins/rtk-rewrite/`.
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -4,7 +4,7 @@
 
 **Deployed hook artifacts** — the actual files installed on user machines by `rtk init`. These are shell scripts, TypeScript plugins, and rules files that run outside the Rust binary. They are **thin delegates**: parse agent-specific JSON, call `rtk rewrite` as a subprocess, format agent-specific response. Zero filtering logic lives here.
 
-Owns: per-agent hook scripts and configuration files for 9 supported agents (Claude Code, Copilot, Cursor, Cline, Windsurf, Codex, OpenCode, Hermes, Pi).
+Owns: per-agent hook scripts and configuration files for supported coding agents.
 
 Does **not** own: hook installation/uninstallation (that's `src/hooks/init.rs`), the rewrite pattern registry (that's `discover/registry`), or integrity verification (that's `src/hooks/integrity.rs`).
 
@@ -58,6 +58,7 @@ Each agent subdirectory has its own README with hook-specific details:
 | OpenCode | TypeScript plugin (`tool.execute.before`) | In-place mutation | Yes |
 | Pi | TypeScript extension (`tool_call` event) | In-place mutation | Yes |
 | Hermes | Python plugin (`pre_tool_call`) | In-place mutation | Yes |
+| ZCode Agent | User-level `AGENTS.md` | Prompt-level guidance | N/A |
 
 ## JSON Formats by Agent
 

--- a/hooks/zcode/README.md
+++ b/hooks/zcode/README.md
@@ -1,0 +1,9 @@
+# ZCode Agent Integration
+
+> Part of [`hooks/`](../README.md) — see also [`src/hooks/`](../../src/hooks/README.md) for installation code.
+
+## Specifics
+
+- Prompt-level guidance only; ZCode reads user-level `AGENTS.md` at task start.
+- `rtk-awareness.md` tells ZCode Agent to prefix shell commands with `rtk`.
+- Installed to `~/.zcode/AGENTS.md` by `rtk init -g --agent zcode`.

--- a/hooks/zcode/rtk-awareness.md
+++ b/hooks/zcode/rtk-awareness.md
@@ -1,0 +1,30 @@
+<!-- rtk-instructions v1 -->
+# RTK - Rust Token Killer (ZCode Agent)
+
+Always prefix shell commands with `rtk` to minimize token consumption.
+
+Examples:
+
+```bash
+rtk git status
+rtk cargo test
+rtk ls src/
+rtk grep "pattern" src/
+rtk find "*.rs" .
+rtk docker ps
+rtk gh pr list
+```
+
+## Meta Commands
+
+```bash
+rtk gain              # Show token savings
+rtk gain --history    # Show command usage history
+rtk discover          # Find missed RTK opportunities
+rtk proxy <cmd>       # Run raw output for debugging
+```
+
+RTK filters and compresses command output before it reaches the agent context,
+saving 60-90% tokens on common development operations. Use `rtk <cmd>` instead
+of raw commands whenever possible.
+<!-- /rtk-instructions -->

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -32,6 +32,7 @@ LLM agent integration layer that installs, validates, and executes command-rewri
 | Cursor | `rtk init -g --agent cursor` | Cursor hook | hooks.json |
 | Pi | `rtk init --agent pi` | `.pi/extensions/rtk.ts` | -- |
 | Hermes | `rtk init --agent hermes` | Python plugin in `~/.hermes/plugins/rtk-rewrite/` | `config.yaml` `plugins.enabled` |
+| ZCode | `rtk init -g --agent zcode` | User-level RTK instructions | `~/.zcode/AGENTS.md` |
 
 
 ## Integrity Verification

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -23,6 +23,7 @@ pub const OPENCODE_PLUGIN_FILE: &str = "rtk.ts";
 pub const CURSOR_DIR: &str = ".cursor";
 pub const CODEX_DIR: &str = ".codex";
 pub const GEMINI_DIR: &str = ".gemini";
+pub const ZCODE_DIR: &str = ".zcode";
 
 pub const GITHUB_DIR: &str = ".github";
 pub const COPILOT_HOOK_FILE: &str = "rtk-rewrite.json";

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -18,7 +18,7 @@ use super::constants::{
     DROID_HOOK_COMMAND, DROID_SETTINGS_FILE, GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR,
     HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON,
     HOOKS_SUBDIR, PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR,
-    PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
+    PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON, ZCODE_DIR,
 };
 use super::integrity;
 use super::is_claude_hook_command;
@@ -32,6 +32,7 @@ const PI_PLUGIN: &str = include_str!("../../hooks/pi/rtk.ts");
 // Embedded slim RTK awareness instructions
 const RTK_SLIM: &str = include_str!("../../hooks/claude/rtk-awareness.md");
 const RTK_SLIM_CODEX: &str = include_str!("../../hooks/codex/rtk-awareness.md");
+const ZCODE_INSTRUCTIONS: &str = include_str!("../../hooks/zcode/rtk-awareness.md");
 
 /// Template written by `rtk init` when no filters.toml exists yet.
 const FILTERS_TEMPLATE: &str = r#"# Project-local RTK filters — commit this file with your repo.
@@ -3319,6 +3320,102 @@ fn resolve_opencode_dir() -> Result<PathBuf> {
     resolve_home_subdir(CONFIG_DIR).map(|p| p.join(OPENCODE_SUBDIR))
 }
 
+// ─── ZCode Agent support ─────────────────────────────────────────────
+
+fn resolve_zcode_dir() -> Result<PathBuf> {
+    resolve_home_subdir(ZCODE_DIR)
+}
+
+/// Install RTK instructions into ZCode's user-level AGENTS.md.
+///
+/// ZCode loads this file for every task, whereas skills are selected explicitly.
+/// RTK therefore installs its always-on guidance at the user level.
+pub fn run_zcode_mode(ctx: InitContext) -> Result<()> {
+    let zcode_dir = resolve_zcode_dir()?;
+    run_zcode_mode_at(&zcode_dir, ctx)
+}
+
+fn run_zcode_mode_at(zcode_dir: &Path, ctx: InitContext) -> Result<()> {
+    let InitContext { dry_run, .. } = ctx;
+    let agents_path = zcode_dir.join(AGENTS_MD);
+    if !dry_run {
+        fs::create_dir_all(zcode_dir).with_context(|| {
+            format!(
+                "Failed to create ZCode config directory: {}",
+                zcode_dir.display()
+            )
+        })?;
+    }
+
+    write_rtk_block(
+        &agents_path,
+        ZCODE_INSTRUCTIONS,
+        "ZCode instructions",
+        "rtk init -g --agent zcode",
+        ctx,
+    )?;
+
+    if !dry_run {
+        println!("\nRTK configured for ZCode Agent.\n");
+        println!("  Instructions: {}", agents_path.display());
+        println!("  ZCode Agent will now use rtk commands for token savings.");
+        println!("  Restart ZCode. Test with: git status\n");
+    }
+
+    Ok(())
+}
+
+pub fn uninstall_zcode(ctx: InitContext) -> Result<()> {
+    let zcode_dir = resolve_zcode_dir()?;
+    uninstall_zcode_at(&zcode_dir, ctx)
+}
+
+fn uninstall_zcode_at(zcode_dir: &Path, ctx: InitContext) -> Result<()> {
+    let InitContext { verbose, dry_run } = ctx;
+    let agents_path = zcode_dir.join(AGENTS_MD);
+    if !agents_path.exists() {
+        if !dry_run {
+            println!("RTK ZCode instructions were not installed (nothing to remove)");
+        }
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(&agents_path).with_context(|| {
+        format!(
+            "Failed to read ZCode instructions: {}",
+            agents_path.display()
+        )
+    })?;
+    let (cleaned, removed) = remove_rtk_block(&content);
+    if !removed {
+        if !dry_run {
+            println!("RTK ZCode instructions were not installed (nothing to remove)");
+        }
+        return Ok(());
+    }
+
+    if dry_run {
+        println!(
+            "[dry-run] would remove RTK instructions from {}",
+            agents_path.display()
+        );
+        print_dry_run_footer();
+        return Ok(());
+    }
+
+    atomic_write(&agents_path, &cleaned).with_context(|| {
+        format!(
+            "Failed to write ZCode instructions: {}",
+            agents_path.display()
+        )
+    })?;
+    if verbose > 0 {
+        eprintln!("Removed RTK instructions from {}", agents_path.display());
+    }
+    println!("RTK uninstalled for ZCode Agent.");
+    Ok(())
+}
+
 // ─── Pi coding agent support ──────────────────────────────────────────
 
 /// Resolve Pi config directory, honouring `PI_CODING_AGENT_DIR` override.
@@ -5000,6 +5097,45 @@ mod tests {
         run_antigravity_mode_at(temp.path(), InitContext::default()).unwrap();
         let second = fs::read_to_string(&path).unwrap();
         assert_eq!(first, second, "Idempotent: content should not change");
+    }
+
+    #[test]
+    fn test_zcode_mode_creates_global_instructions() {
+        let temp = TempDir::new().unwrap();
+        run_zcode_mode_at(temp.path(), InitContext::default()).unwrap();
+
+        let agents_path = temp.path().join(AGENTS_MD);
+        let content = fs::read_to_string(agents_path).unwrap();
+        assert!(content.contains(RTK_BLOCK_START));
+        assert!(content.contains("Always prefix shell commands with `rtk`"));
+    }
+
+    #[test]
+    fn test_zcode_mode_preserves_user_instructions_and_is_idempotent() {
+        let temp = TempDir::new().unwrap();
+        let agents_path = temp.path().join(AGENTS_MD);
+        fs::write(&agents_path, "# Team preferences\n\nPrefer cargo fmt.\n").unwrap();
+
+        run_zcode_mode_at(temp.path(), InitContext::default()).unwrap();
+        let first = fs::read_to_string(&agents_path).unwrap();
+        run_zcode_mode_at(temp.path(), InitContext::default()).unwrap();
+        let second = fs::read_to_string(&agents_path).unwrap();
+
+        assert!(first.contains("Prefer cargo fmt."));
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn test_zcode_uninstall_preserves_user_instructions() {
+        let temp = TempDir::new().unwrap();
+        let agents_path = temp.path().join(AGENTS_MD);
+        fs::write(&agents_path, "# Team preferences\n\nPrefer cargo fmt.\n").unwrap();
+        run_zcode_mode_at(temp.path(), InitContext::default()).unwrap();
+
+        uninstall_zcode_at(temp.path(), InitContext::default()).unwrap();
+        let content = fs::read_to_string(agents_path).unwrap();
+        assert!(content.contains("Prefer cargo fmt."));
+        assert!(!content.contains(RTK_BLOCK_START));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,8 @@ pub enum AgentTarget {
     Kilocode,
     /// Google Antigravity
     Antigravity,
+    /// ZCode Agent
+    Zcode,
     /// Pi coding agent
     Pi,
     /// Hermes CLI
@@ -1986,6 +1988,13 @@ fn run_cli() -> Result<i32> {
                 } else {
                     hooks::init::uninstall_copilot(ctx)?;
                 }
+            } else if uninstall && agent == Some(AgentTarget::Zcode) {
+                if !global {
+                    anyhow::bail!(
+                        "ZCode instructions are user-scoped. Use: rtk init -g --agent zcode"
+                    );
+                }
+                hooks::init::uninstall_zcode(ctx)?;
             } else if uninstall {
                 uninstall_init_dispatch(
                     agent,
@@ -2013,6 +2022,13 @@ fn run_cli() -> Result<i32> {
                 }
             } else if agent == Some(AgentTarget::Pi) {
                 hooks::init::run_pi_mode(global, ctx)?
+            } else if agent == Some(AgentTarget::Zcode) {
+                if !global {
+                    anyhow::bail!(
+                        "ZCode instructions are user-scoped. Use: rtk init -g --agent zcode"
+                    );
+                }
+                hooks::init::run_zcode_mode(ctx)?;
             } else if agent == Some(AgentTarget::Kilocode) {
                 if global {
                     anyhow::bail!("Kilo Code is project-scoped. Use: rtk init --agent kilocode");
@@ -2868,6 +2884,18 @@ mod tests {
         match cli.command {
             Commands::Init { agent, .. } => {
                 assert_eq!(agent, Some(AgentTarget::Hermes));
+            }
+            _ => panic!("Expected Init command"),
+        }
+    }
+
+    #[test]
+    fn test_try_parse_init_agent_zcode() {
+        let cli = Cli::try_parse_from(["rtk", "init", "--agent", "zcode", "--global"]).unwrap();
+        match cli.command {
+            Commands::Init { agent, global, .. } => {
+                assert_eq!(agent, Some(AgentTarget::Zcode));
+                assert!(global);
             }
             _ => panic!("Expected Init command"),
         }


### PR DESCRIPTION
## Summary

Adds rtk init -g --agent zcode for ZCode Agent.

- Installs an RTK-owned, idempotent instruction block in ~/.zcode/AGENTS.md.
- Adds safe --uninstall support that preserves existing user instructions.
- Documents the integration and adds parser, installation, idempotency, and uninstall tests.

ZCode automatically reads its user-level AGENTS.md for each task, so this uses that documented always-on integration point rather than an opt-in skill.

Closes #2898.

## Validation

- cargo fmt --all --check
- cargo test
- cargo clippy --all-targets
- Manual install/uninstall run in a temporary home directory

## Notes

AI-assisted contribution.