### PR TITLE
fix(init): make --agent cursor install Cursor hooks only

### DIFF
--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -329,7 +329,6 @@ pub fn run(
                 }
             }
 
-            // Cursor hooks (additive, installed alongside Claude Code)
             if install_cursor {
                 install_cursor_hooks(ctx)?;
             }
@@ -3549,6 +3548,14 @@ fn install_cursor_hooks(ctx: InitContext) -> Result<()> {
 
     // Create or patch hooks.json with binary command
     let hooks_json_path = cursor_dir.join(HOOKS_JSON);
+    if !dry_run {
+        fs::create_dir_all(&cursor_dir).with_context(|| {
+            format!(
+                "Failed to create Cursor config directory: {}",
+                cursor_dir.display()
+            )
+        })?;
+    }
     let patched = patch_cursor_hooks_json(&hooks_json_path, ctx)?;
 
     // Report (skip in dry-run)
@@ -6746,6 +6753,7 @@ mod tests {
     use std::sync::Mutex;
     static CLAUDE_DIR_LOCK: Mutex<()> = Mutex::new(());
     static PI_DIR_LOCK: Mutex<()> = Mutex::new(());
+    static HOME_LOCK: Mutex<()> = Mutex::new(());
     /// Serialises all tests that mutate the process-wide working directory.
     static CWD_LOCK: Mutex<()> = Mutex::new(());
 
@@ -6775,6 +6783,59 @@ mod tests {
             Some(v) => std::env::set_var(PI_CODING_AGENT_DIR_ENV, v),
             None => std::env::remove_var(PI_CODING_AGENT_DIR_ENV),
         }
+    }
+
+    fn with_home_override<F: FnOnce(&Path)>(tmp: &TempDir, f: F) {
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let orig = std::env::var_os("HOME");
+        std::env::set_var("HOME", tmp.path());
+        f(tmp.path());
+        match orig {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    fn test_run_cursor_only_global_skips_claude_artifacts() {
+        let tmp = TempDir::new().unwrap();
+        with_home_override(&tmp, |_| {
+            with_claude_dir_override(&tmp, |claude_dir| {
+                run(
+                    true,
+                    false,
+                    false,
+                    true,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    PatchMode::Skip,
+                    InitContext::default(),
+                )
+                .unwrap();
+
+                assert!(
+                    !claude_dir.join(RTK_MD).exists(),
+                    "cursor-only init must not create RTK.md"
+                );
+                assert!(
+                    !claude_dir.join(CLAUDE_MD).exists(),
+                    "cursor-only init must not create CLAUDE.md"
+                );
+                assert!(
+                    !claude_dir.join(SETTINGS_JSON).exists(),
+                    "cursor-only init must not create settings.json"
+                );
+
+                let hooks_json = tmp.path().join(".cursor").join(HOOKS_JSON);
+                assert!(
+                    hooks_json.exists(),
+                    "cursor-only init must create ~/.cursor/hooks.json"
+                );
+            });
+        });
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2030,11 +2030,13 @@ fn run_cli() -> Result<i32> {
             } else if agent == Some(AgentTarget::Droid) {
                 hooks::init::run_droid_mode(global, ctx)?;
             } else {
-                let install_opencode = opencode;
-                let install_claude = !opencode;
-                let install_cursor = agent == Some(AgentTarget::Cursor);
-                let install_windsurf = agent == Some(AgentTarget::Windsurf);
-                let install_cline = agent == Some(AgentTarget::Cline);
+                let (
+                    install_claude,
+                    install_opencode,
+                    install_cursor,
+                    install_windsurf,
+                    install_cline,
+                ) = init_install_targets(agent, opencode);
 
                 let patch_mode = if auto_patch {
                     hooks::init::PatchMode::Auto
@@ -2723,6 +2725,20 @@ fn is_operational_command(cmd: &Commands) -> bool {
     )
 }
 
+/// Resolve which assistant integrations `rtk init` should configure.
+fn init_install_targets(
+    agent: Option<AgentTarget>,
+    opencode: bool,
+) -> (bool, bool, bool, bool, bool) {
+    (
+        !opencode && agent.is_none_or(|a| a == AgentTarget::Claude),
+        opencode,
+        agent == Some(AgentTarget::Cursor),
+        agent == Some(AgentTarget::Windsurf),
+        agent == Some(AgentTarget::Cline),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2871,6 +2887,34 @@ mod tests {
             }
             _ => panic!("Expected Init command"),
         }
+    }
+
+    #[test]
+    fn init_install_targets_cursor_skips_claude() {
+        let (install_claude, install_opencode, install_cursor, install_windsurf, install_cline) =
+            init_install_targets(Some(AgentTarget::Cursor), false);
+        assert!(!install_claude);
+        assert!(!install_opencode);
+        assert!(install_cursor);
+        assert!(!install_windsurf);
+        assert!(!install_cline);
+    }
+
+    #[test]
+    fn init_install_targets_default_installs_claude() {
+        let (install_claude, install_opencode, install_cursor, _, _) =
+            init_install_targets(None, false);
+        assert!(install_claude);
+        assert!(!install_opencode);
+        assert!(!install_cursor);
+    }
+
+    #[test]
+    fn init_install_targets_explicit_claude_installs_claude() {
+        let (install_claude, _, install_cursor, _, _) =
+            init_install_targets(Some(AgentTarget::Claude), false);
+        assert!(install_claude);
+        assert!(!install_cursor);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fix `rtk init -g --agent cursor` incorrectly running Claude Code setup (`~/.claude/RTK.md`, `CLAUDE.md`, `settings.json`) alongside Cursor hooks
- `--agent cursor` now installs Cursor hooks only; Claude setup runs only when no agent is specified or `--agent claude` is explicit
- Create `~/.cursor` before writing `hooks.json` so Cursor-only install works on fresh machines

## Test plan
- [x] `cargo fmt --all && cargo clippy --all-targets`
- [x] `cargo test init_install_targets`
- [x] `cargo test test_run_cursor_only_global_skips_claude_artifacts`
- [x] Manual E2E: isolated `HOME` — only `~/.cursor/hooks.json` created, no `~/.claude` artifacts
- [x] Manual E2E: real machine — `rtk init -g --agent cursor` shows Cursor output only (no Claude prompts)


Made with [Cursor](https://cursor.com)