### PR TITLE
fix(pytest): stop false 'No tests collected' on ANSI and double-quiet output

### DIFF
--- a/src/cmds/python/pytest_cmd.rs
+++ b/src/cmds/python/pytest_cmd.rs
@@ -2,7 +2,7 @@
 
 use crate::core::runner;
 use crate::core::truncate::CAP_WARNINGS;
-use crate::core::utils::{resolved_command, tool_exists, truncate};
+use crate::core::utils::{resolved_command, strip_ansi, tool_exists, truncate};
 use anyhow::Result;
 
 const MAX_XFAIL: usize = CAP_WARNINGS;
@@ -61,6 +61,12 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
 }
 
 pub(crate) fn filter_pytest_output(output: &str) -> String {
+    // pytest colors its output under FORCE_COLOR / PY_COLORS / CI. An
+    // ANSI-wrapped count (`\x1b[32m30 passed`) defeats the numeric parse
+    // below — worst case a colored `1 failed` silently DROPS the failure
+    // count from the summary. Strip escapes before parsing.
+    let output = strip_ansi(output);
+
     let mut state = ParseState::Header;
     let mut test_files: Vec<String> = Vec::new();
     let mut failures: Vec<String> = Vec::new();
@@ -101,6 +107,14 @@ pub(crate) fn filter_pytest_output(output: &str) -> String {
             && (trimmed.contains(" passed")
                 || trimmed.contains(" failed")
                 || trimmed.contains(" skipped"))
+            && trimmed.contains(" in ")
+        {
+            summary_line = trimmed.to_string();
+            continue;
+        // "no tests ran in 0.00s" (=== wrapped or bare) is a real summary:
+        // it is the one case "Pytest: No tests collected" is true for.
+        } else if summary_line.is_empty()
+            && trimmed.contains("no tests ran")
             && trimmed.contains(" in ")
         {
             summary_line = trimmed.to_string();
@@ -150,6 +164,15 @@ pub(crate) fn filter_pytest_output(output: &str) -> String {
     // Save last failure if any
     if !current_failure.is_empty() {
         failures.push(current_failure.join("\n"));
+    }
+
+    // No summary line at all: a doubly-quiet run (`-q` injected here on top
+    // of `addopts = -q` in the project's pytest.ini gives `-qq`, which prints
+    // no final summary), a collection error, or non-session output like
+    // `--version`. The filter cannot know what happened — fall back to the
+    // raw output (Never Block) instead of claiming "No tests collected".
+    if summary_line.is_empty() {
+        return output.trim_end().to_string();
     }
 
     // Build compact output
@@ -514,6 +537,48 @@ collected 3 items
             !result.contains("No tests collected"),
             "Should not say 'No tests collected' when tests were skipped. Got: {}",
             result
+        );
+    }
+
+    #[test]
+    fn test_filter_pytest_ansi_colored_summary() {
+        // pytest colors its output under FORCE_COLOR/PY_COLORS/CI; the
+        // ANSI-wrapped count (`\x1b[32m30 passed`) must still parse.
+        let output = "\u{1b}[32m.\u{1b}[0m\u{1b}[32m.\u{1b}[0m\u{1b}[32m [100%]\u{1b}[0m\n\
+                      \u{1b}[32m30 passed\u{1b}[0m\u{1b}[33m, 1 warning\u{1b}[0m\u{1b}[32m in 0.11s\u{1b}[0m";
+        let result = filter_pytest_output(output);
+        assert_eq!(result, "Pytest: 30 passed");
+    }
+
+    #[test]
+    fn test_filter_pytest_ansi_colored_failure_count_preserved() {
+        // A colored `1 failed` must not fall out of the counts — that would
+        // report a failing run as all-passed.
+        let output = "\u{1b}[31mF\u{1b}[0m\u{1b}[32m.\u{1b}[0m\n\
+                      \u{1b}[31m1 failed\u{1b}[0m\u{1b}[32m, 1 passed\u{1b}[0m\u{1b}[31m in 0.05s\u{1b}[0m";
+        let result = filter_pytest_output(output);
+        assert!(result.contains("1 failed"), "got: {result}");
+    }
+
+    #[test]
+    fn test_filter_pytest_double_quiet_passthrough() {
+        // rtk injects `-q`; a project with `addopts = -q` in pytest.ini ends
+        // up at `-qq`, where pytest prints NO final summary line at all.
+        // Claiming "No tests collected" would be a false negative (tests ran,
+        // failures may exist) — fall back to the raw output instead.
+        let output = r#"=============================== warnings summary ===============================
+.venv/lib/python3.13/site-packages/fastapi/testclient.py:1
+  StarletteDeprecationWarning: `httpx` with `starlette.testclient` is deprecated
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html"#;
+        let result = filter_pytest_output(output);
+        assert!(
+            !result.contains("No tests collected"),
+            "must not claim nothing was collected without a summary line; got: {result}"
+        );
+        assert!(
+            result.contains("warnings summary"),
+            "raw output should pass through; got: {result}"
         );
     }
 }


### PR DESCRIPTION
## Summary
- `filter_pytest_output` now strips ANSI before parsing — a colored `\x1b[32m30 passed` no longer parses to zero, and a colored `1 failed` no longer drops out of the counts (a failing run was being reported as all-passed)
- With **no summary line at all** (rtk's injected `-q` + a project's `addopts = -q` → `-qq`, which prints none), the filter now falls back to the raw output instead of claiming `Pytest: No tests collected` — per the **Never Block** principle: if the filter can't tell what happened, don't invent an answer
- `no tests ran in …` is recognized as a genuine summary line, so a truly empty run still reports `No tests collected` exactly as before

Fixes #2960

## Implementation notes
- Reuses the existing `core::utils::strip_ansi` (no new dependency, no new helper)
- The passthrough is a 3-line guard in front of `build_pytest_summary`; the zero-count early return inside it is untouched, so #2850 / #2346 (collection-error parsing) apply cleanly on top — their dedicated parsing supersedes the fallback for that case, and until then the fallback stops those failures being masked too
- +4 lines of behavior change, the rest is tests

## Test plan
- [x] `test_filter_pytest_ansi_colored_summary` — colored all-pass summary parses (was `No tests collected`)
- [x] `test_filter_pytest_ansi_colored_failure_count_preserved` — colored `1 failed, 1 passed` keeps the failure (was `Pytest: 1 passed`)
- [x] `test_filter_pytest_double_quiet_passthrough` — no summary line → raw output, never `No tests collected`
- [x] Existing `test_filter_pytest_no_tests` (truly empty run) and `test_filter_pytest_quiet_mode_failures` (#565's regression test) still pass
- [x] End-to-end against a real project (`addopts = -q`, 20 passing tests): before `Pytest: No tests collected`, after the real pytest output
- [x] End-to-end with a colored failing run: before `Pytest: 1 passed`, after `Pytest: 1 passed, 1 failed` (exit 1 preserved)
- [x] `cargo fmt --check && cargo clippy --all-targets && cargo test` — 2441 passed, 0 failed, no new warnings