### PR TITLE
feat(hook): add Grok Build Codex-style awareness support

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ rtk init --agent antigravity    # Google Antigravity
 rtk init -g --agent pi          # Pi
 rtk init --agent hermes         # Hermes
 rtk init -g --agent droid       # Factory Droid
+rtk init -g --agent grok        # Grok Build
 
 # 2. Restart your AI tool, then test
 git status  # Automatically rewritten to rtk git status
@@ -366,7 +367,7 @@ rtk init -g
 
 ## Supported AI Tools
 
-RTK supports 15 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents for 60-90% token savings where the agent supports command interception.
+RTK supports 16 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents for 60-90% token savings where the agent supports command interception.
 
 | Tool | Install | Method |
 |------|---------|--------|
@@ -375,6 +376,7 @@ RTK supports 15 AI coding tools. Each integration rewrites shell commands to `rt
 | **GitHub Copilot CLI** | `rtk init -g --copilot` | PreToolUse deny-with-suggestion (CLI limitation) |
 | **Cursor** | `rtk init -g --agent cursor` | preToolUse hook (hooks.json) |
 | **Gemini CLI** | `rtk init -g --gemini` | BeforeTool hook |
+| **Grok Build** | `rtk init -g --agent grok` | Global `~/.grok/AGENTS.md` RTK block (+ `RTK.md` sidecar); soft prefer-rtk |
 | **Codex** | `rtk init -g --codex` | AGENTS.md + RTK.md instructions |
 | **Windsurf** | `rtk init -g --agent windsurf` | .windsurfrules (project-scoped) |
 | **Cline / Roo Code** | `rtk init --agent cline` | .clinerules (project-scoped) |

--- a/docs/contributing/TECHNICAL.md
+++ b/docs/contributing/TECHNICAL.md
@@ -317,6 +317,7 @@ Start here, then drill down into each README for file-level details.
 | [`windsurf/`](../hooks/windsurf/README.md) | Windsurf / Cascade | Rules file (workspace-scoped) |
 | [`codex/`](../hooks/codex/README.md) | OpenAI Codex CLI | Awareness document, AGENTS.md integration |
 | [`opencode/`](../hooks/opencode/README.md) | OpenCode | TypeScript plugin, zx library, in-place mutation |
+| [`grok/`](../hooks/grok/README.md) | Grok Build | Codex-style awareness (`~/.grok/AGENTS.md` + `RTK.md` sidecar); no PreToolUse rewrite |
 
 ---
 
@@ -331,6 +332,7 @@ RTK supports the following LLM agents through hook integrations:
 | GitHub Copilot CLI | Rust binary | `rtk hook copilot` reads JSON | No (deny + suggestion) |
 | Cursor | Rust binary | `rtk hook cursor` reads JSON | Yes (`updated_input`) |
 | Gemini CLI | Rust binary | `rtk hook gemini` reads JSON | Yes (`hookSpecificOutput`) |
+| Grok Build | Awareness doc | `~/.grok/AGENTS.md` managed block + `RTK.md` sidecar (Codex-style prompt guidance) | N/A (prompt) |
 | Cline/Roo Code | Rules file | Prompt-level guidance | N/A (prompt) |
 | Windsurf | Rules file | Prompt-level guidance | N/A (prompt) |
 | Codex CLI | Awareness doc | AGENTS.md integration | N/A (prompt) |

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -1,6 +1,6 @@
 ---
 title: Supported Agents
-description: How to integrate RTK with Claude Code, Cursor, Copilot, Cline, Windsurf, Codex, OpenCode, Hermes, Kilo Code, Antigravity, and Factory Droid
+description: How to integrate RTK with Claude Code, Cursor, Copilot, Cline, Windsurf, Codex, Grok Build, OpenCode, Hermes, Kilo Code, Antigravity, and Factory Droid
 sidebar:
   order: 3
 ---
@@ -41,6 +41,7 @@ Agent runs "cargo test"
 | Cline / Roo Code | Rules file (prompt-level) | N/A |
 | Windsurf | Rules file (prompt-level) | N/A |
 | Codex CLI | AGENTS.md instructions | N/A |
+| Grok Build | `~/.grok/AGENTS.md` instructions | N/A |
 | Kilo Code | Rules file (prompt-level) | N/A |
 | Google Antigravity | Rules file (prompt-level) | N/A |
 | Mistral Vibe | Planned ([#800](https://github.com/rtk-ai/rtk/issues/800)) | Pending upstream |
@@ -179,6 +180,20 @@ rtk init --codex           # project-scoped (AGENTS.md)
 rtk init --global --codex  # user-global (~/.codex/AGENTS.md)
 ```
 
+### Grok Build
+
+```bash
+rtk init -g --agent grok   # global-only (~/.grok/AGENTS.md + RTK.md sidecar)
+```
+
+Grok only auto-loads **recognized** instruction filenames under `~/.grok/` (for example `AGENTS.md`). RTK installs a managed prefer-`rtk` block into `~/.grok/AGENTS.md` and keeps a human-readable `~/.grok/RTK.md` sidecar (not auto-loaded). Soft guidance only — Grok does not apply Claude-style command mutation. Restart Grok (or start a new session) and verify with `grok inspect`.
+
+Uninstall:
+
+```bash
+rtk init -g --uninstall --agent grok
+```
+
 ### Kilo Code
 
 ```bash
@@ -207,7 +222,7 @@ Support is blocked on upstream `BeforeToolCallback` ([mistral-vibe#531](https://
 | **Plugin** | TypeScript, JavaScript, or Python in agent's plugin system | Transparent, in-place mutation when the agent allows it |
 | **Rules file** | Prompt-level instructions | Guidance only — agent is told to prefer `rtk <cmd>` |
 
-Rules file integrations (Cline, Windsurf, Codex, Kilo Code, Antigravity) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it. Plugin integrations (OpenCode, Pi) use in-place mutation via the agent's TypeScript extension API.
+Rules file integrations (Cline, Windsurf, Codex, Grok Build, Kilo Code, Antigravity) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it. Plugin integrations (OpenCode, Pi) use in-place mutation via the agent's TypeScript extension API.
 
 ## Windows support
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -4,7 +4,7 @@
 
 **Deployed hook artifacts** — the actual files installed on user machines by `rtk init`. These are shell scripts, TypeScript plugins, and rules files that run outside the Rust binary. They are **thin delegates**: parse agent-specific JSON, call `rtk rewrite` as a subprocess, format agent-specific response. Zero filtering logic lives here.
 
-Owns: per-agent hook scripts and configuration files for 9 supported agents (Claude Code, Copilot, Cursor, Cline, Windsurf, Codex, OpenCode, Hermes, Pi).
+Owns: per-agent hook scripts and configuration files for 10 supported agents (Claude Code, Copilot, Cursor, Cline, Windsurf, Codex, OpenCode, Hermes, Pi, Grok).
 
 Does **not** own: hook installation/uninstallation (that's `src/hooks/init.rs`), the rewrite pattern registry (that's `discover/registry`), or integrity verification (that's `src/hooks/integrity.rs`).
 
@@ -42,6 +42,7 @@ Each agent subdirectory has its own README with hook-specific details:
 - **[`opencode/`](opencode/README.md)** — TypeScript plugin, `zx` library, `tool.execute.before` event, in-place mutation
 - **[`pi/`](pi/README.md)** — TypeScript extension, `tool_call` event, `isToolCallEventType` guard, in-place mutation, `~/.pi/agent/extensions/`
 - **[`hermes/`](hermes/README.md)** — Python plugin, `pre_tool_call` hook, in-place terminal command mutation
+- **[`grok/`](grok/README.md)** — Codex-style awareness (`~/.grok/AGENTS.md` + `RTK.md` sidecar); no PreToolUse rewrite
 
 ## Supported Agents
 
@@ -52,6 +53,7 @@ Each agent subdirectory has its own README with hook-specific details:
 | GitHub Copilot CLI | Rust binary (`rtk hook copilot`) | Deny-with-suggestion | No (agent retries) |
 | Cursor | Rust binary | Transparent rewrite | Yes (`updated_input`) |
 | Gemini CLI | Rust binary (`rtk hook gemini`) | Transparent rewrite | Yes (`hookSpecificOutput`) |
+| Grok Build | `AGENTS.md` managed block (+ `RTK.md` sidecar) | Prompt-level guidance | N/A |
 | Cline / Roo Code | Custom instructions (rules file) | Prompt-level guidance | N/A |
 | Windsurf | Custom instructions (rules file) | Prompt-level guidance | N/A |
 | Codex CLI | AGENTS.md / instructions | Prompt-level guidance | N/A |
@@ -156,6 +158,10 @@ Returns `{}` when no rewrite (Cursor requires JSON for all paths).
 ```
 
 **No rewrite**: `{"decision": "allow"}`
+
+### Grok Build (Awareness only)
+
+No PreToolUse rewrite hook. Install writes a managed RTK block to `~/.grok/AGENTS.md` (auto-loaded) plus optional `~/.grok/RTK.md` sidecar. See [`grok/README.md`](grok/README.md).
 
 ### OpenCode (TypeScript Plugin)
 

--- a/hooks/grok/README.md
+++ b/hooks/grok/README.md
@@ -1,0 +1,69 @@
+# Grok Build Integration
+
+> Part of [`hooks/`](../README.md) — see also [`src/hooks/`](../../src/hooks/README.md) for installation code
+
+## Specifics
+
+- **Codex-style prompt guidance** — no programmatic PreToolUse rewrite
+- Primary artifact: managed RTK block in `~/.grok/AGENTS.md` (recognized global instruction file)
+- Optional sidecar: `~/.grok/RTK.md` (human-readable; **not** auto-loaded by Grok)
+- Grok only auto-loads recognized top-level names under `~/.grok/` (`AGENTS.md`, `Claude.md`, …) — **not** arbitrary `*.md` such as bare `RTK.md`
+- Grok does **not** apply Claude-style `updatedInput` mutation; automatic shell rewrite is not supported
+
+## Install / Uninstall
+
+```bash
+# Install (global only)
+rtk init -g --agent grok
+
+# Uninstall
+rtk init -g --uninstall --agent grok
+```
+
+**Global only.** Artifacts:
+
+| Path | Purpose |
+|------|---------|
+| `~/.grok/AGENTS.md` | Managed `<!-- rtk-instructions -->` block (auto-loaded global rules) |
+| `~/.grok/RTK.md` | Sidecar copy of awareness body (not auto-loaded) |
+
+**AGENTS write** uses the same managed-block upsert as Copilot/Claude: creates or updates the RTK block while preserving other user content.
+
+**Migration:** Install and uninstall remove a legacy hybrid PreToolUse file `~/.grok/hooks/rtk.json` if it invokes `rtk hook grok`. Other files under `~/.grok/hooks/` are left alone.
+
+Restart Grok Build (or start a new session) after install or uninstall so global rules reload. Confirm with:
+
+```bash
+grok inspect
+```
+
+You should see `~/.grok/AGENTS.md` listed among project instructions.
+
+## How it works
+
+1. User runs `rtk init -g --agent grok`.
+2. RTK upserts stock awareness into `~/.grok/AGENTS.md` and writes a matching `~/.grok/RTK.md` sidecar.
+3. Grok includes `AGENTS.md` in context for TUI / headless / ACP sessions.
+4. The model is instructed to prefix shell commands with `rtk` (e.g. `rtk git status`).
+
+There is **no** `rtk hook grok` command. Savings are **soft** (model-dependent), same class as Codex CLI integration.
+
+## Why not only `~/.grok/RTK.md`?
+
+Grok’s project-rules docs list only recognized instruction filenames. Custom top-level names (including `RTK.md`) are not discovered. Codex works better with a soft install because it always loads `AGENTS.md` and resolves `@RTK.md`; RTK’s Grok install therefore writes the instruction body into `AGENTS.md` directly (Grok does not document `@file` includes).
+
+## Why not a PreToolUse rewrite hook?
+
+Grok’s documented PreToolUse API only supports:
+
+```json
+{"decision": "allow"}
+{"decision": "deny", "reason": "..."}
+```
+
+It does not document Claude-style `updatedInput` mutation. Live validation showed allow + mutation still runs the original command, while deny hard-blocks without retry. Codex-style awareness is therefore the supported integration.
+
+## Related
+
+- Codex (same awareness pattern): [`hooks/codex/`](../codex/README.md)
+- Awareness source: [`rtk-awareness.md`](rtk-awareness.md)

--- a/hooks/grok/rtk-awareness.md
+++ b/hooks/grok/rtk-awareness.md
@@ -1,0 +1,36 @@
+# RTK - Rust Token Killer (Grok Build)
+
+Token-optimized CLI proxy for shell commands.
+
+## Rule (mandatory)
+
+When using shell tools, **always** prefix supported commands with `rtk`:
+
+| Instead of | Use |
+|------------|-----|
+| `git status` | `rtk git status` |
+| `cargo test` | `rtk cargo test` |
+| `npm run build` | `rtk npm run build` |
+| `pytest -q` | `rtk pytest -q` |
+
+Do this by default. Prefer `rtk <cmd>` over bare `<cmd>`.
+
+**Exceptions** (only then skip `rtk`):
+- The user explicitly asks for raw/unfiltered output
+- `rtk` is unavailable on PATH
+
+## Meta Commands
+
+```bash
+rtk gain            # Token savings analytics
+rtk gain --history  # Recent command savings history
+rtk proxy <cmd>     # Run raw command without filtering
+```
+
+## Verification
+
+```bash
+rtk --version
+rtk gain
+which rtk
+```

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -6,7 +6,7 @@
 
 The **lifecycle management** layer for LLM agent hooks: install, uninstall, verify integrity, audit usage, and manage trust. This component creates and maintains the hook artifacts that live in `hooks/` (root), but does **not** execute rewrite logic itself — that lives in `discover/registry`.
 
-Owns: `rtk init` installation flows (5 agents via `AgentTarget` enum + 3 special modes: Gemini, Codex, OpenCode), SHA-256 integrity verification, hook version checking, audit log analysis, `rtk rewrite` CLI entry point, and TOML filter trust management.
+Owns: `rtk init` installation flows (`AgentTarget` enum agents including Grok, Cursor, Pi, Hermes, Droid, etc. + special modes: Gemini, Codex, OpenCode, Copilot), SHA-256 integrity verification, hook version checking, audit log analysis, `rtk rewrite` CLI entry point, and TOML filter trust management.
 
 Does **not** own: the deployed hook scripts themselves (that's `hooks/`), the rewrite pattern registry (that's `discover/`), or command filtering (that's `cmds/`).
 
@@ -32,6 +32,7 @@ LLM agent integration layer that installs, validates, and executes command-rewri
 | Cursor | `rtk init -g --agent cursor` | Cursor hook | hooks.json |
 | Pi | `rtk init --agent pi` | `.pi/extensions/rtk.ts` | -- |
 | Hermes | `rtk init --agent hermes` | Python plugin in `~/.hermes/plugins/rtk-rewrite/` | `config.yaml` `plugins.enabled` |
+| Grok Build | `rtk init -g --agent grok` | `~/.grok/AGENTS.md` + `RTK.md` sidecar (Codex-style awareness) | — |
 
 
 ## Integrity Verification
@@ -88,6 +89,7 @@ Rules are loaded from all Claude Code `settings.json` files (project + global, i
 | Copilot VS Code (rtk hook copilot) | Yes | `permissionDecision: "ask"` — user prompted |
 | Cursor (rtk hook cursor) | Ready | `permission: "ask",` — users will be prompted when Cursor enforces the permission; in the meantime, allow |
 | Gemini CLI (rtk hook gemini) | No (allow/deny only) | allow (limitation — no ask mode in Gemini) |
+| Grok Build | N/A (no PreToolUse hook) | awareness only (`~/.grok/AGENTS.md` + `RTK.md`) |
 | Copilot CLI (rtk hook copilot) | No updatedInput | deny-with-suggestion (unchanged) |
 | Codex | ask parsed but no-op | allow (limitation — fails open) |
 

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -58,3 +58,17 @@ pub const HERMES_PLUGINS_SUBDIR: &str = "plugins";
 pub const HERMES_PLUGIN_NAME: &str = "rtk-rewrite";
 pub const HERMES_PLUGIN_INIT_FILE: &str = "__init__.py";
 pub const HERMES_PLUGIN_MANIFEST_FILE: &str = "plugin.yaml";
+
+/// Grok Build config directory under home.
+pub const GROK_DIR: &str = ".grok";
+/// Global agents-instructions filename under `~/.grok/` (recognized by Grok).
+///
+/// Grok only auto-loads recognized top-level names (`AGENTS.md`, `Claude.md`,
+/// …). `RTK.md` alone is not discovered — install must patch this file.
+pub const GROK_AGENTS_FILE: &str = "AGENTS.md";
+/// Optional sidecar awareness body under `~/.grok/` (not auto-loaded by Grok).
+pub const GROK_AWARENESS_FILE: &str = "RTK.md";
+/// Legacy PreToolUse hook file from the hybrid Grok install (migration cleanup).
+pub const GROK_LEGACY_HOOKS_SUBDIR: &str = "hooks";
+/// Legacy RTK-owned hook JSON filename under `~/.grok/hooks/`.
+pub const GROK_LEGACY_HOOK_JSON: &str = "rtk.json";

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -15,10 +15,12 @@ use crate::hooks::constants::{
 use super::constants::{
     BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND, DROID_DIR,
     DROID_EXECUTE_MATCHER, DROID_HOME_ENV, DROID_HOOKS_FILE, DROID_HOOKS_SUBDIR,
-    DROID_HOOK_COMMAND, DROID_SETTINGS_FILE, GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR,
-    HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON,
-    HOOKS_SUBDIR, PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR,
-    PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
+    DROID_HOOK_COMMAND, DROID_SETTINGS_FILE, GEMINI_HOOK_FILE, GROK_AGENTS_FILE,
+    GROK_AWARENESS_FILE, GROK_DIR, GROK_LEGACY_HOOKS_SUBDIR, GROK_LEGACY_HOOK_JSON, HERMES_DIR,
+    HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE,
+    HERMES_PLUGIN_NAME, HOOKS_JSON, HOOKS_SUBDIR, PI_CODING_AGENT_DIR_ENV, PI_DIR,
+    PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR, PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE,
+    SETTINGS_JSON,
 };
 use super::integrity;
 use super::is_claude_hook_command;
@@ -32,6 +34,7 @@ const PI_PLUGIN: &str = include_str!("../../hooks/pi/rtk.ts");
 // Embedded slim RTK awareness instructions
 const RTK_SLIM: &str = include_str!("../../hooks/claude/rtk-awareness.md");
 const RTK_SLIM_CODEX: &str = include_str!("../../hooks/codex/rtk-awareness.md");
+const RTK_SLIM_GROK: &str = include_str!("../../hooks/grok/rtk-awareness.md");
 
 /// Template written by `rtk init` when no filters.toml exists yet.
 const FILTERS_TEMPLATE: &str = r#"# Project-local RTK filters — commit this file with your repo.
@@ -3311,6 +3314,274 @@ fn remove_droid_hook_from_json(root: &mut serde_json::Value, layout: DroidLayout
     modified
 }
 
+// ─── Grok Build support (Codex-style awareness only) ─────────────────
+//
+// Grok does not apply Claude-style PreToolUse command mutation (updatedInput).
+// Soft guidance is installed into ~/.grok/AGENTS.md (recognized global
+// instruction file). ~/.grok/RTK.md alone is NOT auto-loaded by Grok.
+
+fn resolve_grok_dir() -> Result<PathBuf> {
+    resolve_home_subdir(GROK_DIR)
+}
+
+/// Managed RTK block for `~/.grok/AGENTS.md` (inline; Grok does not document `@file` includes).
+fn grok_agents_rtk_block() -> String {
+    format!(
+        "<!-- rtk-instructions v2 -->\n{}\n{}",
+        RTK_SLIM_GROK.trim_end(),
+        RTK_BLOCK_END
+    )
+}
+
+/// Install Grok Build awareness (global-only; Codex-style, no PreToolUse hook).
+pub fn run_grok_mode(global: bool, ctx: InitContext) -> Result<()> {
+    if !global {
+        anyhow::bail!("Grok Build support is global-only. Use: rtk init -g --agent grok");
+    }
+    let grok_dir = resolve_grok_dir()?;
+    run_grok_mode_at(&grok_dir, ctx)
+}
+
+fn run_grok_mode_at(grok_dir: &Path, ctx: InitContext) -> Result<()> {
+    let InitContext { dry_run, .. } = ctx;
+    let agents_path = grok_dir.join(GROK_AGENTS_FILE);
+    let awareness_path = grok_dir.join(GROK_AWARENESS_FILE);
+
+    if !dry_run {
+        fs::create_dir_all(grok_dir).with_context(|| {
+            format!(
+                "Failed to create Grok config directory: {}",
+                grok_dir.display()
+            )
+        })?;
+    }
+
+    // Primary load path: Grok auto-loads recognized names under ~/.grok/ (AGENTS.md).
+    write_rtk_block(
+        &agents_path,
+        &grok_agents_rtk_block(),
+        "Grok AGENTS.md RTK block",
+        "rtk init -g --agent grok",
+        ctx,
+    )?;
+
+    // Optional sidecar (not auto-loaded; kept for human inspection / parity with Codex body file).
+    write_if_changed(
+        &awareness_path,
+        RTK_SLIM_GROK,
+        "Grok awareness sidecar (RTK.md)",
+        ctx,
+    )?;
+
+    // Migrate: drop legacy PreToolUse hook from the hybrid Grok install if present.
+    let legacy_removed = remove_legacy_grok_hook_json(grok_dir, ctx)?;
+
+    if dry_run {
+        print_dry_run_footer();
+    } else {
+        println!("\nRTK configured for Grok Build (global).\n");
+        println!(
+            "  AGENTS.md:  {} (global rules — auto-loaded)",
+            agents_path.display()
+        );
+        println!(
+            "  Sidecar:    {} (not auto-loaded)",
+            awareness_path.display()
+        );
+        println!("  Style:      Codex-like prompt guidance (no PreToolUse rewrite)");
+        if legacy_removed {
+            println!("  Cleanup:    removed legacy ~/.grok/hooks/rtk.json");
+        }
+        println!("\n  Grok loads recognized instruction files under ~/.grok/ (e.g. AGENTS.md).");
+        println!("  Prefer shell commands prefixed with `rtk` (e.g. rtk git status).");
+        println!("  Restart Grok Build (or start a new session) to pick up instructions.");
+        println!("  Verify with: grok inspect\n");
+    }
+
+    Ok(())
+}
+
+/// Uninstall Grok Build integration (global-only).
+pub fn uninstall_grok(global: bool, ctx: InitContext) -> Result<()> {
+    if !global {
+        anyhow::bail!(
+            "Grok Build support is global-only. Use: rtk init -g --uninstall --agent grok"
+        );
+    }
+    let InitContext { dry_run, .. } = ctx;
+    let grok_dir = resolve_grok_dir()?;
+    let removed = uninstall_grok_at(&grok_dir, ctx)?;
+
+    if removed.is_empty() {
+        println!("RTK Grok Build support was not installed (nothing to remove)");
+    } else {
+        let header = if dry_run {
+            "[dry-run] would uninstall RTK for Grok Build:"
+        } else {
+            "RTK uninstalled for Grok Build:"
+        };
+        println!("{}", header);
+        for item in removed {
+            println!("  - {}", item);
+        }
+    }
+
+    if dry_run {
+        print_dry_run_footer();
+    }
+    Ok(())
+}
+
+/// Remove legacy hybrid-install hook JSON if it looks RTK-owned.
+/// Returns true when a file was removed (or would be, in dry-run).
+fn remove_legacy_grok_hook_json(grok_dir: &Path, ctx: InitContext) -> Result<bool> {
+    let InitContext { verbose, dry_run } = ctx;
+    let hook_path = grok_dir
+        .join(GROK_LEGACY_HOOKS_SUBDIR)
+        .join(GROK_LEGACY_HOOK_JSON);
+    if !hook_path.exists() {
+        return Ok(false);
+    }
+    let content = fs::read_to_string(&hook_path)
+        .with_context(|| format!("Failed to read {}", hook_path.display()))?;
+    if !content.contains("hook grok") {
+        return Ok(false);
+    }
+    if dry_run {
+        println!(
+            "[dry-run] would remove legacy Grok hook config: {}",
+            hook_path.display()
+        );
+        return Ok(true);
+    }
+    // nosemgrep: filesystem-deletion -- migration removes only RTK-owned rtk.json.
+    fs::remove_file(&hook_path).with_context(|| {
+        format!(
+            "Failed to remove legacy Grok hook config: {}",
+            hook_path.display()
+        )
+    })?;
+    if verbose > 0 {
+        eprintln!("Removed legacy Grok hook config: {}", hook_path.display());
+    }
+    Ok(true)
+}
+
+fn uninstall_grok_at(grok_dir: &Path, ctx: InitContext) -> Result<Vec<String>> {
+    let InitContext { verbose, dry_run } = ctx;
+    let mut removed = Vec::new();
+
+    // Legacy hybrid hook (if any).
+    if remove_legacy_grok_hook_json(grok_dir, ctx)? {
+        removed.push(format!(
+            "Legacy hook: {}",
+            grok_dir
+                .join(GROK_LEGACY_HOOKS_SUBDIR)
+                .join(GROK_LEGACY_HOOK_JSON)
+                .display()
+        ));
+    }
+
+    // Primary: strip managed RTK block from AGENTS.md (preserve other user content).
+    let agents_path = grok_dir.join(GROK_AGENTS_FILE);
+    if agents_path.exists() {
+        let content = fs::read_to_string(&agents_path)
+            .with_context(|| format!("Failed to read {}", agents_path.display()))?;
+        if content.contains(RTK_BLOCK_START) {
+            let (new_content, did_remove) = remove_rtk_block(&content);
+            if did_remove {
+                if new_content.trim().is_empty() {
+                    if dry_run {
+                        println!(
+                            "[dry-run] would remove empty Grok AGENTS.md: {}",
+                            agents_path.display()
+                        );
+                    } else {
+                        // nosemgrep: filesystem-deletion -- Grok uninstall removes AGENTS.md only when empty after RTK block strip.
+                        fs::remove_file(&agents_path).with_context(|| {
+                            format!(
+                                "Failed to remove {}: {}",
+                                GROK_AGENTS_FILE,
+                                agents_path.display()
+                            )
+                        })?;
+                        if verbose > 0 {
+                            eprintln!(
+                                "Removed empty {}: {}",
+                                GROK_AGENTS_FILE,
+                                agents_path.display()
+                            );
+                        }
+                    }
+                    removed.push(format!("AGENTS.md: {}", agents_path.display()));
+                } else if dry_run {
+                    println!(
+                        "[dry-run] would remove rtk-instructions block from {}",
+                        agents_path.display()
+                    );
+                    removed.push(format!(
+                        "AGENTS.md: removed rtk-instructions block ({})",
+                        agents_path.display()
+                    ));
+                } else {
+                    atomic_write(&agents_path, &new_content).with_context(|| {
+                        format!(
+                            "Failed to write {}: {}",
+                            GROK_AGENTS_FILE,
+                            agents_path.display()
+                        )
+                    })?;
+                    if verbose > 0 {
+                        eprintln!(
+                            "Removed rtk-instructions block from {}",
+                            agents_path.display()
+                        );
+                    }
+                    removed.push(format!(
+                        "AGENTS.md: removed rtk-instructions block ({})",
+                        agents_path.display()
+                    ));
+                }
+            }
+        }
+    }
+
+    // Sidecar RTK.md: only remove when still stock content.
+    let awareness_path = grok_dir.join(GROK_AWARENESS_FILE);
+    if awareness_path.exists() {
+        let content = fs::read_to_string(&awareness_path)
+            .with_context(|| format!("Failed to read {}", awareness_path.display()))?;
+        if content == RTK_SLIM_GROK {
+            if dry_run {
+                println!(
+                    "[dry-run] would remove Grok awareness sidecar: {}",
+                    awareness_path.display()
+                );
+            } else {
+                // nosemgrep: filesystem-deletion -- Grok uninstall removes only unmodified RTK.md.
+                fs::remove_file(&awareness_path).with_context(|| {
+                    format!(
+                        "Failed to remove Grok awareness: {}",
+                        awareness_path.display()
+                    )
+                })?;
+                if verbose > 0 {
+                    eprintln!("Removed Grok awareness: {}", awareness_path.display());
+                }
+            }
+            removed.push(format!("Awareness: {}", awareness_path.display()));
+        } else if verbose > 0 {
+            eprintln!(
+                "Preserved modified {}: {}",
+                GROK_AWARENESS_FILE,
+                awareness_path.display()
+            );
+        }
+    }
+
+    Ok(removed)
+}
+
 fn codex_rtk_md_ref(codex_dir: &Path) -> String {
     format!("@{}", codex_dir.join(RTK_MD).display())
 }
@@ -5912,6 +6183,233 @@ mod tests {
             "stale settings.json entry must be removed"
         );
         assert_eq!(settings["model"], "custom", "user settings must survive");
+    }
+
+    #[test]
+    fn test_grok_install_writes_agents_and_sidecar() {
+        let temp = TempDir::new().unwrap();
+        let grok_dir = temp.path().join(".grok");
+        let ctx = InitContext {
+            verbose: 0,
+            dry_run: false,
+        };
+
+        run_grok_mode_at(&grok_dir, ctx).unwrap();
+
+        let agents_path = grok_dir.join(GROK_AGENTS_FILE);
+        let awareness_path = grok_dir.join(GROK_AWARENESS_FILE);
+        let legacy_hook = grok_dir
+            .join(GROK_LEGACY_HOOKS_SUBDIR)
+            .join(GROK_LEGACY_HOOK_JSON);
+        assert!(agents_path.exists(), "AGENTS.md should be created");
+        assert!(awareness_path.exists(), "RTK.md sidecar should be created");
+        assert!(
+            !legacy_hook.exists(),
+            "Codex-style install must not create PreToolUse rtk.json"
+        );
+        let agents = fs::read_to_string(&agents_path).unwrap();
+        assert!(
+            agents.contains(RTK_BLOCK_START) && agents.contains(RTK_BLOCK_END),
+            "AGENTS.md must contain managed RTK block"
+        );
+        assert!(
+            agents.contains("rtk git status") && agents.to_lowercase().contains("always"),
+            "AGENTS.md must include rtk prefer rule: {agents}"
+        );
+        assert_eq!(fs::read_to_string(&awareness_path).unwrap(), RTK_SLIM_GROK);
+    }
+
+    #[test]
+    fn test_grok_install_idempotent() {
+        let temp = TempDir::new().unwrap();
+        let grok_dir = temp.path().join(".grok");
+        let ctx = InitContext {
+            verbose: 0,
+            dry_run: false,
+        };
+
+        run_grok_mode_at(&grok_dir, ctx).unwrap();
+        let agents_path = grok_dir.join(GROK_AGENTS_FILE);
+        let awareness_path = grok_dir.join(GROK_AWARENESS_FILE);
+        let first_agents = fs::read_to_string(&agents_path).unwrap();
+        let first_sidecar = fs::read_to_string(&awareness_path).unwrap();
+
+        run_grok_mode_at(&grok_dir, ctx).unwrap();
+        let second_agents = fs::read_to_string(&agents_path).unwrap();
+        let second_sidecar = fs::read_to_string(&awareness_path).unwrap();
+
+        assert_eq!(
+            first_agents, second_agents,
+            "AGENTS.md install must be idempotent"
+        );
+        assert_eq!(
+            first_sidecar, second_sidecar,
+            "RTK.md install must be idempotent"
+        );
+        assert_eq!(first_sidecar, RTK_SLIM_GROK);
+    }
+
+    #[test]
+    fn test_grok_uninstall_removes_stock_artifacts() {
+        let temp = TempDir::new().unwrap();
+        let grok_dir = temp.path().join(".grok");
+        let ctx = InitContext {
+            verbose: 0,
+            dry_run: false,
+        };
+
+        run_grok_mode_at(&grok_dir, ctx).unwrap();
+        let agents_path = grok_dir.join(GROK_AGENTS_FILE);
+        let awareness_path = grok_dir.join(GROK_AWARENESS_FILE);
+        assert!(agents_path.exists());
+        assert!(awareness_path.exists());
+
+        let removed = uninstall_grok_at(&grok_dir, ctx).unwrap();
+        assert!(!removed.is_empty());
+        assert!(
+            !agents_path.exists(),
+            "stock-only AGENTS.md should be removed"
+        );
+        assert!(
+            !awareness_path.exists(),
+            "unmodified RTK.md should be removed"
+        );
+
+        let removed_again = uninstall_grok_at(&grok_dir, ctx).unwrap();
+        assert!(removed_again.is_empty());
+    }
+
+    #[test]
+    fn test_grok_install_preserves_user_agents_content() {
+        let temp = TempDir::new().unwrap();
+        let grok_dir = temp.path().join(".grok");
+        fs::create_dir_all(&grok_dir).unwrap();
+        let agents_path = grok_dir.join(GROK_AGENTS_FILE);
+        let custom = "# My Grok global rules\n\nAlways use feature branches.\n";
+        fs::write(&agents_path, custom).unwrap();
+
+        let ctx = InitContext {
+            verbose: 0,
+            dry_run: false,
+        };
+        run_grok_mode_at(&grok_dir, ctx).unwrap();
+
+        let after = fs::read_to_string(&agents_path).unwrap();
+        assert!(
+            after.contains("Always use feature branches"),
+            "user AGENTS.md content must be preserved"
+        );
+        assert!(
+            after.contains(RTK_BLOCK_START),
+            "RTK block must be appended to AGENTS.md"
+        );
+    }
+
+    #[test]
+    fn test_grok_install_overwrites_divergent_sidecar() {
+        let temp = TempDir::new().unwrap();
+        let grok_dir = temp.path().join(".grok");
+        fs::create_dir_all(&grok_dir).unwrap();
+        let awareness_path = grok_dir.join(GROK_AWARENESS_FILE);
+        let custom = "# my global Grok notes\n\nAlways use feature branches.\n";
+        fs::write(&awareness_path, custom).unwrap();
+
+        let ctx = InitContext {
+            verbose: 0,
+            dry_run: false,
+        };
+        run_grok_mode_at(&grok_dir, ctx).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(&awareness_path).unwrap(),
+            RTK_SLIM_GROK,
+            "install must overwrite divergent RTK.md sidecar with stock awareness"
+        );
+    }
+
+    #[test]
+    fn test_grok_install_removes_legacy_hook_json() {
+        let temp = TempDir::new().unwrap();
+        let grok_dir = temp.path().join(".grok");
+        let hooks_dir = grok_dir.join(GROK_LEGACY_HOOKS_SUBDIR);
+        fs::create_dir_all(&hooks_dir).unwrap();
+        let legacy = hooks_dir.join(GROK_LEGACY_HOOK_JSON);
+        fs::write(
+            &legacy,
+            r#"{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"rtk hook grok"}]}]}}"#,
+        )
+        .unwrap();
+        let other = hooks_dir.join("user-hooks.json");
+        fs::write(&other, r#"{"hooks":{}}"#).unwrap();
+
+        let ctx = InitContext {
+            verbose: 0,
+            dry_run: false,
+        };
+        run_grok_mode_at(&grok_dir, ctx).unwrap();
+
+        assert!(!legacy.exists(), "legacy rtk.json must be cleaned up");
+        assert!(other.exists(), "non-RTK hook files must remain");
+        assert!(grok_dir.join(GROK_AGENTS_FILE).exists());
+        assert_eq!(
+            fs::read_to_string(grok_dir.join(GROK_AWARENESS_FILE)).unwrap(),
+            RTK_SLIM_GROK
+        );
+    }
+
+    #[test]
+    fn test_grok_uninstall_preserves_user_agents_and_custom_sidecar() {
+        let temp = TempDir::new().unwrap();
+        let grok_dir = temp.path().join(".grok");
+        let hooks_dir = grok_dir.join(GROK_LEGACY_HOOKS_SUBDIR);
+        fs::create_dir_all(&hooks_dir).unwrap();
+        let other_hook = hooks_dir.join("user-hooks.json");
+        let other_payload = r#"{"hooks":{"PreToolUse":[{"matcher":"Edit","hooks":[{"type":"command","command":"echo user"}]}]}}"#;
+        fs::write(&other_hook, other_payload).unwrap();
+        // Legacy RTK hook present from hybrid install.
+        fs::write(
+            hooks_dir.join(GROK_LEGACY_HOOK_JSON),
+            r#"{"hooks":{"PreToolUse":[{"hooks":[{"command":"rtk hook grok"}]}]}}"#,
+        )
+        .unwrap();
+        // Pre-existing user AGENTS content.
+        let agents_path = grok_dir.join(GROK_AGENTS_FILE);
+        fs::write(&agents_path, "# Team rules\n").unwrap();
+
+        let ctx = InitContext {
+            verbose: 0,
+            dry_run: false,
+        };
+        run_grok_mode_at(&grok_dir, ctx).unwrap();
+        // User edits sidecar after install.
+        let awareness_path = grok_dir.join(GROK_AWARENESS_FILE);
+        let custom = "# custom grok notes\n";
+        fs::write(&awareness_path, custom).unwrap();
+
+        let removed = uninstall_grok_at(&grok_dir, ctx).unwrap();
+        assert!(
+            !removed
+                .iter()
+                .any(|s| s.contains(GROK_AWARENESS_FILE) || s.to_lowercase().contains("awareness")),
+            "should not remove user-edited RTK.md: {:?}",
+            removed
+        );
+
+        assert!(other_hook.exists(), "other hook files must remain");
+        assert_eq!(fs::read_to_string(&other_hook).unwrap(), other_payload);
+        assert!(awareness_path.exists(), "user-edited RTK.md must remain");
+        assert_eq!(fs::read_to_string(&awareness_path).unwrap(), custom);
+        assert!(!hooks_dir.join(GROK_LEGACY_HOOK_JSON).exists());
+
+        let agents_after = fs::read_to_string(&agents_path).unwrap();
+        assert!(
+            agents_after.contains("# Team rules"),
+            "user AGENTS content must remain"
+        );
+        assert!(
+            !agents_after.contains(RTK_BLOCK_START),
+            "RTK block must be stripped from AGENTS.md"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,8 @@ pub enum AgentTarget {
     Hermes,
     /// Factory Droid CLI
     Droid,
+    /// Grok Build (global-only)
+    Grok,
 }
 
 #[derive(Parser)]
@@ -1532,6 +1534,8 @@ where
         uninstall_hermes(ctx)
     } else if agent == Some(AgentTarget::Droid) {
         hooks::init::uninstall_droid(global, ctx)
+    } else if agent == Some(AgentTarget::Grok) {
+        hooks::init::uninstall_grok(global, ctx)
     } else {
         let cursor = agent == Some(AgentTarget::Cursor);
         let pi = agent == Some(AgentTarget::Pi);
@@ -2029,6 +2033,8 @@ fn run_cli() -> Result<i32> {
                 hooks::init::run_hermes_mode(ctx)?;
             } else if agent == Some(AgentTarget::Droid) {
                 hooks::init::run_droid_mode(global, ctx)?;
+            } else if agent == Some(AgentTarget::Grok) {
+                hooks::init::run_grok_mode(global, ctx)?;
             } else {
                 let install_opencode = opencode;
                 let install_claude = !opencode;


### PR DESCRIPTION
## Summary

Closes [#1890](https://github.com/rtk-ai/rtk/issues/1890) ([Support for the new Grok CLI](https://github.com/rtk-ai/rtk/issues/1890)) and [#2136](https://github.com/rtk-ai/rtk/issues/2136) ([Feature Request: Support for Grok Build CLI](https://github.com/rtk-ai/rtk/issues/2136)).

Adds **Grok Build** (xAI) support using **Codex-style prompt guidance** (not Claude-style PreToolUse rewrite).

Grok’s documented PreToolUse API only supports `decision: allow|deny` and does **not** apply Claude-style `updatedInput` mutation. Live validation confirmed allow+mutation still runs the original command, while deny hard-blocks without retry. Therefore this PR installs awareness only.

* **`rtk init -g --agent grok`** (global-only):
  * Writes a managed `<!-- rtk-instructions -->` block to **`~/.grok/AGENTS.md`** (recognized global instruction file; auto-loaded by Grok)
  * Writes **`~/.grok/RTK.md`** sidecar (human-readable; not auto-loaded — custom top-level names like bare `RTK.md` are not discovered)
  * Removes legacy hybrid `~/.grok/hooks/rtk.json` if present (migration from earlier draft)
  * Clean uninstall: `rtk init -g --uninstall --agent grok` (strips managed block; preserves other user AGENTS content)
* **No `rtk hook grok`** — soft model guidance via `AGENTS.md` (TUI, headless, ACP)
* **CLI:** `AgentTarget::Grok` install/uninstall only
* **Docs:** README, `hooks/grok/`, `hooks/README.md`, `src/hooks/README.md`, `TECHNICAL.md`, supported-agents guide

## Test plan

* [x] `cargo fmt --all --check`
* [x] `cargo clippy --all-targets` — zero warnings
* [x] `cargo test` (clean HOME) — Grok init coverage:
  * install writes AGENTS.md managed block + RTK.md sidecar (no PreToolUse JSON)
  * idempotent reinstall
  * preserves existing user AGENTS content when appending RTK block
  * overwrites divergent stock RTK.md sidecar
  * install cleans legacy `hooks/rtk.json`
  * uninstall strips RTK block / removes empty AGENTS.md; preserves custom RTK.md and other hook files
* [x] Manual: `rtk init -g --agent grok --dry-run`; `rtk hook --help` has no `grok` subcommand
* [ ] CI on `rtk-ai/rtk`

## Test result

Live Grok Build: model prefers RTK via soft awareness (`rtk git status` after install). Automatic shell rewrite is **not** claimed.

![Grok Build test result](https://files.catbox.moe/99gfni.png)

## Notes

* Savings are **soft** (model-dependent), same class as Codex CLI.
* Automatic PreToolUse rewrite would require Grok to support Claude-style `updatedInput` (or equivalent); not available today.
* Other agents unchanged.

## Files

| Area | Paths |
|------|--------|
| Install | `src/hooks/init.rs`, `src/main.rs`, `src/hooks/constants.rs` |
| Artifacts / docs | `hooks/grok/*`, `hooks/README.md`, `src/hooks/README.md`, `README.md`, `TECHNICAL.md`, `docs/guide/getting-started/supported-agents.md` |