### PR TITLE
fix(telemetry): honor configured database path on forget

### DIFF
--- a/src/core/telemetry_cmd.rs
+++ b/src/core/telemetry_cmd.rs
@@ -131,7 +131,7 @@ fn run_forget() -> Result<()> {
     // Purge local tracking database (GDPR Art. 17 — right to erasure applies to local data too)
     let db_path = super::tracking::get_db_path()?;
     if db_path.exists() {
-        match delete_tracking_database(&db_path) {
+        match std::fs::remove_file(&db_path) {
             Ok(()) => println!("Local tracking database deleted: {}", db_path.display()),
             Err(e) => eprintln!("rtk: could not delete {}: {}", db_path.display(), e),
         }
@@ -179,22 +179,19 @@ fn send_erasure_request(device_hash: &str) -> Result<()> {
     Ok(())
 }
 
-fn delete_tracking_database(path: &std::path::Path) -> std::io::Result<()> {
-    std::fs::remove_file(path)
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     #[test]
-    fn deletes_tracking_database_at_resolved_path() {
+    fn forget_resolves_the_configured_tracking_database_path() {
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = ENV_LOCK.lock().expect("environment lock");
         let temp = tempfile::tempdir().expect("temp directory");
         let custom_path = temp.path().join("custom-history.db");
-        std::fs::write(&custom_path, b"tracking data").expect("write tracking database");
+        std::env::set_var("RTK_DB_PATH", &custom_path);
 
-        delete_tracking_database(&custom_path).expect("delete tracking database");
+        let resolved = super::super::tracking::get_db_path().expect("resolve tracking database");
 
-        assert!(!custom_path.exists());
+        std::env::remove_var("RTK_DB_PATH");
+        assert_eq!(resolved, custom_path);
     }
 }

--- a/src/core/telemetry_cmd.rs
+++ b/src/core/telemetry_cmd.rs
@@ -129,12 +129,9 @@ fn run_forget() -> Result<()> {
     }
 
     // Purge local tracking database (GDPR Art. 17 — right to erasure applies to local data too)
-    let db_path = dirs::data_local_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from("."))
-        .join(super::constants::RTK_DATA_DIR)
-        .join(super::constants::HISTORY_DB);
+    let db_path = super::tracking::get_db_path()?;
     if db_path.exists() {
-        match std::fs::remove_file(&db_path) {
+        match delete_tracking_database(&db_path) {
             Ok(()) => println!("Local tracking database deleted: {}", db_path.display()),
             Err(e) => eprintln!("rtk: could not delete {}: {}", db_path.display(), e),
         }
@@ -180,4 +177,24 @@ fn send_erasure_request(device_hash: &str) -> Result<()> {
         .send_string(&payload.to_string())?;
 
     Ok(())
+}
+
+fn delete_tracking_database(path: &std::path::Path) -> std::io::Result<()> {
+    std::fs::remove_file(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deletes_tracking_database_at_resolved_path() {
+        let temp = tempfile::tempdir().expect("temp directory");
+        let custom_path = temp.path().join("custom-history.db");
+        std::fs::write(&custom_path, b"tracking data").expect("write tracking database");
+
+        delete_tracking_database(&custom_path).expect("delete tracking database");
+
+        assert!(!custom_path.exists());
+    }
 }

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -1217,7 +1217,7 @@ fn categorize_command(rtk_cmd: &str) -> String {
     .to_string()
 }
 
-fn get_db_path() -> Result<PathBuf> {
+pub(crate) fn get_db_path() -> Result<PathBuf> {
     // Priority 1: Environment variable RTK_DB_PATH
     if let Ok(custom_path) = std::env::var("RTK_DB_PATH") {
         return Ok(PathBuf::from(custom_path));


### PR DESCRIPTION
## Summary

- resolve the tracking database through the same `get_db_path()` path used by tracking reads and writes
- delete the configured `RTK_DB_PATH` or `tracking.database_path` target instead of always using the platform default
- cover deletion of a non-default database path

Closes #2956.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets`
- `cargo test deletes_tracking_database_at_resolved_path -- --nocapture`
- full `cargo test --all`: 2,418 passed; 16 existing Windows stream tests fail because their Unix helper programs are unavailable (`program not found`)