### PR TITLE
fix(docker): forward value-taking command flags

### DIFF
--- a/src/cmds/cloud/container.rs
+++ b/src/cmds/cloud/container.rs
@@ -24,9 +24,9 @@ pub enum ContainerCmd {
 
 pub fn run(cmd: ContainerCmd, args: &[String], verbose: u8) -> Result<i32> {
     match cmd {
-        ContainerCmd::DockerPs => docker_ps(verbose),
-        ContainerCmd::DockerPsAll => docker_ps_all(verbose),
-        ContainerCmd::DockerImages => docker_images(verbose),
+        ContainerCmd::DockerPs => docker_ps(args, verbose),
+        ContainerCmd::DockerPsAll => docker_ps_all(args, verbose),
+        ContainerCmd::DockerImages => docker_images(args, verbose),
         ContainerCmd::DockerLogs => docker_logs(args, verbose),
         ContainerCmd::KubectlPods => k8s_pods("kubectl", args, verbose),
         ContainerCmd::KubectlServices => k8s_services("kubectl", args, verbose),
@@ -55,10 +55,28 @@ where
     )
 }
 
-fn docker_ps(_verbose: u8) -> Result<i32> {
+fn without_value_option(args: &[String], option: &str) -> Vec<String> {
+    let mut filtered = Vec::with_capacity(args.len());
+    let mut index = 0;
+    while index < args.len() {
+        if args[index] == option {
+            index += 2;
+        } else if args[index].starts_with(&format!("{option}=")) {
+            index += 1;
+        } else {
+            filtered.push(args[index].clone());
+            index += 1;
+        }
+    }
+    filtered
+}
+
+fn docker_ps(args: &[String], _verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
-    let base = exec_capture(resolved_command("docker").args(["ps"]))
+    let mut base_args = vec!["ps".to_string()];
+    base_args.extend_from_slice(args);
+    let base = exec_capture(resolved_command("docker").args(&base_args))
         .context("Failed to run docker ps")?;
     if !base.success() {
         eprint!("{}", base.stderr);
@@ -68,11 +86,13 @@ fn docker_ps(_verbose: u8) -> Result<i32> {
     }
     let raw = base.stdout;
 
-    let stdout = match exec_capture(resolved_command("docker").args([
-        "ps",
-        "--format",
-        "{{.ID}}\t{{.Names}}\t{{.Status}}\t{{.Image}}\t{{.Ports}}",
-    ]))
+    let mut format_args = vec!["ps".to_string()];
+    format_args.extend(without_value_option(args, "--format"));
+    format_args.extend([
+        "--format".to_string(),
+        "{{.ID}}\t{{.Names}}\t{{.Status}}\t{{.Image}}\t{{.Ports}}".to_string(),
+    ]);
+    let stdout = match exec_capture(resolved_command("docker").args(&format_args))
     .ok()
     .filter(|r| r.success())
     {
@@ -111,10 +131,12 @@ fn docker_ps(_verbose: u8) -> Result<i32> {
     Ok(0)
 }
 
-fn docker_ps_all(_verbose: u8) -> Result<i32> {
+fn docker_ps_all(args: &[String], _verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
-    let base = exec_capture(resolved_command("docker").args(["ps", "-a"]))
+    let mut base_args = vec!["ps".to_string(), "-a".to_string()];
+    base_args.extend_from_slice(args);
+    let base = exec_capture(resolved_command("docker").args(&base_args))
         .context("Failed to run docker ps -a")?;
     if !base.success() {
         eprint!("{}", base.stderr);
@@ -124,12 +146,13 @@ fn docker_ps_all(_verbose: u8) -> Result<i32> {
     }
     let raw = base.stdout;
 
-    let stdout = match exec_capture(resolved_command("docker").args([
-        "ps",
-        "-a",
-        "--format",
-        "{{.State}}\t{{.ID}}\t{{.Names}}\t{{.Status}}\t{{.Image}}\t{{.Ports}}",
-    ]))
+    let mut format_args = vec!["ps".to_string(), "-a".to_string()];
+    format_args.extend(without_value_option(args, "--format"));
+    format_args.extend([
+        "--format".to_string(),
+        "{{.State}}\t{{.ID}}\t{{.Names}}\t{{.Status}}\t{{.Image}}\t{{.Ports}}".to_string(),
+    ]);
+    let stdout = match exec_capture(resolved_command("docker").args(&format_args))
     .ok()
     .filter(|r| r.success())
     {
@@ -227,10 +250,12 @@ fn format_container_line_from_parts(parts: &[&str], with_ports: bool) -> Option<
     ))
 }
 
-fn docker_images(_verbose: u8) -> Result<i32> {
+fn docker_images(args: &[String], _verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
-    let base = exec_capture(resolved_command("docker").args(["images"]))
+    let mut base_args = vec!["images".to_string()];
+    base_args.extend_from_slice(args);
+    let base = exec_capture(resolved_command("docker").args(&base_args))
         .context("Failed to run docker images")?;
     if !base.success() {
         eprint!("{}", base.stderr);
@@ -240,11 +265,13 @@ fn docker_images(_verbose: u8) -> Result<i32> {
     }
     let raw = base.stdout;
 
-    let stdout = match exec_capture(resolved_command("docker").args([
-        "images",
-        "--format",
-        "{{.Repository}}:{{.Tag}}\t{{.Size}}",
-    ]))
+    let mut format_args = vec!["images".to_string()];
+    format_args.extend(without_value_option(args, "--format"));
+    format_args.extend([
+        "--format".to_string(),
+        "{{.Repository}}:{{.Tag}}\t{{.Size}}".to_string(),
+    ]);
+    let stdout = match exec_capture(resolved_command("docker").args(&format_args))
     .ok()
     .filter(|r| r.success())
     {
@@ -326,8 +353,17 @@ fn docker_logs(args: &[String], _verbose: u8) -> Result<i32> {
         return Ok(0);
     }
 
+    let options = &args[1..];
     let mut cmd = resolved_command("docker");
-    cmd.args(["logs", "--tail", "100", container]);
+    cmd.arg("logs");
+    if !options
+        .iter()
+        .any(|arg| arg == "--tail" || arg.starts_with("--tail="))
+    {
+        cmd.args(["--tail", "100"]);
+    }
+    cmd.args(options);
+    cmd.arg(container);
 
     let label = format!("logs {}", container);
     runner::run_filtered(
@@ -822,6 +858,23 @@ pub fn run_oc_passthrough(args: &[OsString], verbose: u8) -> Result<i32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn docker_structured_query_replaces_only_user_format() {
+        let args = vec![
+            "--filter".to_string(),
+            "name=web".to_string(),
+            "--format".to_string(),
+            "{{.Names}}".to_string(),
+            "--no-trunc".to_string(),
+        ];
+
+        assert_eq!(
+            without_value_option(&args, "--format"),
+            ["--filter", "name=web", "--no-trunc"]
+        );
+        assert!(without_value_option(&["--format={{.Names}}".to_string()], "--format").is_empty());
+    }
 
     // ── format_compose_ps ──────────────────────────────────
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -995,11 +995,20 @@ enum DockerCommands {
     Ps {
         #[arg(short = 'a', long)]
         all: bool,
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
     },
     /// List images
-    Images,
+    Images {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
     /// Show container logs (deduplicated)
-    Logs { container: String },
+    Logs {
+        container: String,
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
     /// Docker Compose commands with compact output
     Compose {
         #[command(subcommand)]
@@ -1871,19 +1880,25 @@ fn run_cli() -> Result<i32> {
         },
 
         Commands::Docker { command } => match command {
-            DockerCommands::Ps { all } => {
+            DockerCommands::Ps { all, args } => {
                 let cmd = if all {
                     container::ContainerCmd::DockerPsAll
                 } else {
                     container::ContainerCmd::DockerPs
                 };
-                container::run(cmd, &[], cli.verbose)?
+                container::run(cmd, &args, cli.verbose)?
             }
-            DockerCommands::Images => {
-                container::run(container::ContainerCmd::DockerImages, &[], cli.verbose)?
+            DockerCommands::Images { args } => {
+                container::run(container::ContainerCmd::DockerImages, &args, cli.verbose)?
             }
-            DockerCommands::Logs { container: c } => {
-                container::run(container::ContainerCmd::DockerLogs, &[c], cli.verbose)?
+            DockerCommands::Logs { container: c, args } => {
+                let mut docker_args = vec![c];
+                docker_args.extend(args);
+                container::run(
+                    container::ContainerCmd::DockerLogs,
+                    &docker_args,
+                    cli.verbose,
+                )?
             }
             DockerCommands::Compose { command: compose } => match compose {
                 ComposeCommands::Ps { all } => container::run_compose_ps(all, cli.verbose)?,
@@ -3568,6 +3583,56 @@ mod tests {
                 assert!(global);
             }
             _ => panic!("Expected Init command"),
+        }
+    }
+
+    #[test]
+    fn docker_ps_accepts_value_taking_flags() {
+        let cli = Cli::try_parse_from([
+            "rtk",
+            "docker",
+            "ps",
+            "--filter",
+            "name=web",
+            "--format",
+            "{{.Names}}",
+        ])
+        .expect("docker ps flags should parse");
+
+        match cli.command {
+            Commands::Docker {
+                command: DockerCommands::Ps { args, .. },
+            } => assert_eq!(args, ["--filter", "name=web", "--format", "{{.Names}}"]),
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn docker_images_accepts_format_flag() {
+        let cli = Cli::try_parse_from(["rtk", "docker", "images", "--format", "{{.Repository}}"])
+            .expect("docker images flags should parse");
+
+        match cli.command {
+            Commands::Docker {
+                command: DockerCommands::Images { args },
+            } => assert_eq!(args, ["--format", "{{.Repository}}"]),
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn docker_logs_accepts_tail_flag() {
+        let cli = Cli::try_parse_from(["rtk", "docker", "logs", "web", "--tail", "3"])
+            .expect("docker logs flags should parse");
+
+        match cli.command {
+            Commands::Docker {
+                command: DockerCommands::Logs { container, args },
+            } => {
+                assert_eq!(container, "web");
+                assert_eq!(args, ["--tail", "3"]);
+            }
+            other => panic!("unexpected command: {other:?}"),
         }
     }
 }


### PR DESCRIPTION
## Summary

- accept trailing Docker options for `ps`, `images`, and `logs`
- forward filters and other value-taking flags to both raw and structured Docker queries
- replace only a user-provided `--format` when RTK needs its own structured template
- keep an explicit `--tail` / `-n` instead of forcing the default 100 lines

Rebased onto the edition 2024 develop, and the flag handling now goes through `arg_tokenizer` instead of string matching. Each subcommand has its own grammar taken from `docker ps/images/logs --help` (Docker 29.2.1), so a flag's value isn't mistaken for a flag (`--since --tail` is a since value, `--filter --format` is a filter value), and clustered or attached short forms like `-qf status=exited`, `-n5` and `-fn 5` are recognized. I checked those forms against the real docker binary.

Closes #2945.

## Validation

- `cargo fmt --all`, `cargo clippy --all-targets` (no warnings)
- `cargo test docker` (16 passed, including the new tokenizer cases)
- full `cargo test --all --no-fail-fast` on Windows: 3627 unit tests pass. The 3 failures (`test_run_worktree_list_propagates_failure`, `run_from_args_propagates_find_exit_status`, `test_read_lines_lossy_preserves_lines_after_invalid_utf8`) are Windows environment issues that also fail on develop here. `missing_configs_are_never_created` failed once under the parallel run and passes on rerun.
