### PR TITLE
docs: clarify Copilot initialization in Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ rtk gain        # Should show token savings stats
 
 ```bash
 # 1. Install for your AI tool
-rtk init -g
-rtk init -g --copilot                    # Claude Code / Copilot (default)
+rtk init -g                     # Claude Code
+rtk init -g --copilot           # Copilot 
 rtk init -g --gemini            # Gemini CLI
 rtk init -g --codex             # Codex (OpenAI)
 rtk init -g --agent cursor      # Cursor

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ rtk gain        # Should show token savings stats
 
 ```bash
 # 1. Install for your AI tool
+rtk init -g
 rtk init -g --copilot                    # Claude Code / Copilot (default)
 rtk init -g --gemini            # Gemini CLI
 rtk init -g --codex             # Codex (OpenAI)

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ rtk gain        # Should show token savings stats
 
 ```bash
 # 1. Install for your AI tool
-rtk init -g                     # Claude Code / Copilot (default)
+rtk init -g --copilot                    # Claude Code / Copilot (default)
 rtk init -g --gemini            # Gemini CLI
 rtk init -g --codex             # Codex (OpenAI)
 rtk init -g --agent cursor      # Cursor


### PR DESCRIPTION
## Summary

- Updated the Quick Start section in the README.
- Added separate initialization commands for Claude Code and Copilot.
- Clarified that Copilot requires the `--copilot` flag.

## Test plan

- [x] Documentation change only.
- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] Manual testing: `rtk <command>` output inspected

Fixes #2244