### PR TITLE
fix: report nonzero vitest process exits

### DIFF
--- a/src/cmds/js/vitest_cmd.rs
+++ b/src/cmds/js/vitest_cmd.rs
@@ -253,6 +253,7 @@ pub fn run_test(command: &Commands, args: &[String], verbose: u8) -> Result<i32>
         &combined,
         passthrough_requested,
         verbose,
+        result.exit_code,
     );
     let tee_label = format!("{}_run", framework);
 
@@ -334,6 +335,7 @@ fn format_test_output(
     combined: &str,
     passthrough_requested: bool,
     verbose: u8,
+    exit_code: i32,
 ) -> FormattedTestOutput {
     if passthrough_requested {
         return format_passthrough_output(combined);
@@ -346,19 +348,29 @@ fn format_test_output(
             if verbose > 0 {
                 eprintln!("{} run (Tier 1: Full JSON parse)", framework);
             }
-            FormattedTestOutput::new(data.format(mode))
+            FormattedTestOutput::new(format_parsed_test_output(&data, mode, exit_code))
         }
         ParseResult::Degraded(data, warnings) => {
             if verbose > 0 {
                 emit_degradation_warning(framework, &warnings.join(", "));
             }
-            FormattedTestOutput::new(data.format(mode))
+            FormattedTestOutput::new(format_parsed_test_output(&data, mode, exit_code))
         }
         ParseResult::Passthrough(_) => {
             emit_passthrough_warning(framework, "All parsing tiers failed");
             format_passthrough_output(stdout)
         }
     }
+}
+
+fn format_parsed_test_output(data: &TestResult, mode: FormatMode, exit_code: i32) -> String {
+    let mut output = data.format(mode);
+    if exit_code != 0 && data.failed == 0 {
+        output.push_str(&format!(
+            "\n[FAIL] Process exited with code {exit_code} despite reporter listing no failed tests"
+        ));
+    }
+    output
 }
 
 fn format_passthrough_output(raw: &str) -> FormattedTestOutput {
@@ -420,6 +432,21 @@ where
 mod tests {
     use super::*;
 
+    const ALL_PASS_JSON: &str = r#"{
+        "numTotalTests": 2,
+        "numPassedTests": 2,
+        "numFailedTests": 0,
+        "numPendingTests": 0,
+        "testResults": []
+    }"#;
+    const FAILED_TEST_JSON: &str = r#"{
+        "numTotalTests": 2,
+        "numPassedTests": 1,
+        "numFailedTests": 1,
+        "numPendingTests": 0,
+        "testResults": []
+    }"#;
+
     fn args(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| value.to_string()).collect()
     }
@@ -444,6 +471,32 @@ mod tests {
         assert_eq!(data.passed, 13);
         assert_eq!(data.failed, 0);
         assert_eq!(data.duration_ms, None);
+    }
+
+    #[test]
+    fn test_all_pass_json_with_nonzero_exit_reports_process_failure() {
+        let output = format_test_output("vitest", ALL_PASS_JSON, ALL_PASS_JSON, false, 0, 1);
+
+        assert!(output.text.contains("PASS (2) FAIL (0)"));
+        assert!(output.text.contains(
+            "[FAIL] Process exited with code 1 despite reporter listing no failed tests"
+        ));
+    }
+
+    #[test]
+    fn test_all_pass_json_with_zero_exit_has_no_process_failure() {
+        let output = format_test_output("vitest", ALL_PASS_JSON, ALL_PASS_JSON, false, 0, 0);
+
+        assert!(output.text.contains("PASS (2) FAIL (0)"));
+        assert!(!output.text.contains("despite reporter listing no failed tests"));
+    }
+
+    #[test]
+    fn test_failed_json_with_nonzero_exit_has_no_process_discrepancy() {
+        let output = format_test_output("vitest", FAILED_TEST_JSON, FAILED_TEST_JSON, false, 0, 1);
+
+        assert!(output.text.contains("PASS (1) FAIL (1)"));
+        assert!(!output.text.contains("despite reporter listing no failed tests"));
     }
 
     #[test]
@@ -575,7 +628,7 @@ Scope: all 6 workspace projects
    Duration  450ms
 "#;
 
-        let filtered = format_test_output("vitest", output, output, true, 0);
+        let filtered = format_test_output("vitest", output, output, true, 0, 0);
 
         assert!(filtered.text.contains("keeps docs path"));
         assert!(filtered.text.contains("keeps app path"));


### PR DESCRIPTION
## Summary

- Fix `rtk vitest run` reporting a false-green summary when Vitest exits nonzero despite its JSON reporter listing no failed tests.
- Preserve existing output for normal passes and reported test failures while surfacing the process exit discrepancy.

Closes #2874.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: ran `rtk vitest run` in a separate real Vitest project for both a normal pass and an uncaught asynchronous error
