### PR TITLE
docs(readme): separate Copilot setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ rtk gain        # Should show token savings stats
 
 ```bash
 # 1. Install for your AI tool
-rtk init -g                     # Claude Code / Copilot (default)
+rtk init -g                     # Claude Code (default)
+rtk init -g --copilot           # GitHub Copilot
 rtk init -g --gemini            # Gemini CLI
 rtk init -g --codex             # Codex (OpenAI)
 rtk init -g --agent cursor      # Cursor


### PR DESCRIPTION
## Summary

- Separate the Claude Code and GitHub Copilot setup commands in Quick Start.
- Show the required `--copilot` flag for GitHub Copilot.

Fixes #2244.

## Test plan

- [x] Verified the Quick Start commands match the Supported AI Tools table.
- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test` (Rust toolchain is not available locally.)