### PR TITLE
fix(stream): decode lossily instead of dropping lines on invalid UTF-8

### DIFF
--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -1,10 +1,39 @@
 use anyhow::{Context, Result};
-use std::io::{self, BufRead, BufReader, BufWriter, Write};
+use std::io::{self, BufRead, BufReader, BufWriter, Read, Write};
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
 
 #[cfg(test)]
 use regex::Regex;
+
+/// Read `reader` line by line, decoding each line lossily (invalid UTF-8
+/// bytes become U+FFFD) instead of erroring.
+///
+/// `BufRead::lines()` returns `Err` for a non-UTF-8 line, and callers
+/// commonly chain `.map_while(Result::ok)` to skip bad lines — but
+/// `map_while` stops at the *first* `None`, so one invalid-UTF-8 line (e.g.
+/// OEM/ANSI bytes from a non-English-locale Windows tool) silently discards
+/// every line after it too, not just the bad one. This reads raw bytes and
+/// never fails on the source encoding, so a garbled line still surfaces
+/// instead of vanishing along with everything downstream of it.
+fn read_lines_lossy(reader: impl Read) -> impl Iterator<Item = String> {
+    let mut reader = BufReader::new(reader);
+    std::iter::from_fn(move || {
+        let mut buf = Vec::new();
+        match reader.read_until(b'\n', &mut buf) {
+            Ok(0) | Err(_) => None,
+            Ok(_) => {
+                if buf.last() == Some(&b'\n') {
+                    buf.pop();
+                    if buf.last() == Some(&b'\r') {
+                        buf.pop();
+                    }
+                }
+                Some(String::from_utf8_lossy(&buf).into_owned())
+            }
+        }
+    })
+}
 
 pub trait StreamFilter {
     fn feed_line(&mut self, line: &str) -> Option<String>;
@@ -298,10 +327,7 @@ pub fn run_streaming(
             Some(std::thread::spawn(move || {
                 let mut writer = BufWriter::new(child_stdin);
                 let stdin_handle = io::stdin();
-                for line in BufReader::new(stdin_handle.lock())
-                    .lines()
-                    .map_while(Result::ok)
-                {
+                for line in read_lines_lossy(stdin_handle.lock()) {
                     if let Some(out) = filter.feed_line(&line) {
                         if writeln!(writer, "{}", out).is_err() {
                             break;
@@ -340,7 +366,7 @@ pub fn run_streaming(
         let (tx, rx) = mpsc::channel();
         let tx_out = tx.clone();
         let stdout_thread = std::thread::spawn(move || {
-            for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+            for line in read_lines_lossy(stdout) {
                 if tx_out.send(StreamLine::Stdout(line)).is_err() {
                     break;
                 }
@@ -348,7 +374,7 @@ pub fn run_streaming(
         });
         let tx_err = tx;
         let stderr_thread = std::thread::spawn(move || {
-            for line in BufReader::new(stderr).lines().map_while(Result::ok) {
+            for line in read_lines_lossy(stderr) {
                 if tx_err.send(StreamLine::Stderr(line)).is_err() {
                     break;
                 }
@@ -417,7 +443,7 @@ pub fn run_streaming(
         let stderr_thread = std::thread::spawn(move || -> String {
             let mut raw_err = String::new();
             let mut capped = false;
-            for line in BufReader::new(stderr).lines().map_while(Result::ok) {
+            for line in read_lines_lossy(stderr) {
                 if raw_err.len() + line.len() < RAW_CAP {
                     raw_err.push_str(&line);
                     raw_err.push('\n');
@@ -436,7 +462,7 @@ pub fn run_streaming(
                 FilterMode::Passthrough => unreachable!("handled by early-return above"),
                 FilterMode::Streaming(_) => unreachable!("handled by is_streaming branch"),
                 FilterMode::Buffered(filter_fn) => {
-                    for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+                    for line in read_lines_lossy(stdout) {
                         if raw_stdout.len() + line.len() < RAW_CAP {
                             raw_stdout.push_str(&line);
                             raw_stdout.push('\n');
@@ -461,7 +487,7 @@ pub fn run_streaming(
                     }
                 }
                 FilterMode::CaptureOnly => {
-                    for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+                    for line in read_lines_lossy(stdout) {
                         if raw_stdout.len() + line.len() < RAW_CAP {
                             raw_stdout.push_str(&line);
                             raw_stdout.push('\n');
@@ -556,6 +582,42 @@ pub fn exec_capture_stdin(cmd: &mut Command) -> Result<CaptureResult> {
 pub(crate) mod tests {
     use super::*;
     use std::process::Command;
+
+    #[test]
+    fn test_read_lines_lossy_preserves_lines_after_invalid_utf8() {
+        // Line 2 contains a lone 0xE3 byte (the cp850 case from the bug report).
+        // `BufRead::lines().map_while(Result::ok)` would stop at that Err and
+        // silently lose line 3 as well — not just the bad byte.
+        let mut data = Vec::new();
+        data.extend_from_slice(b"ERRO A: ascii\n");
+        data.extend_from_slice(&[b'E', b'R', b'R', b'O', b' ', b'B', b':', b' ', 0xE3, b'\n']);
+        data.extend_from_slice(b"ERRO C: ascii again\n");
+
+        let lines: Vec<String> = read_lines_lossy(data.as_slice()).collect();
+        assert_eq!(lines.len(), 3, "got: {:?}", lines);
+        assert_eq!(lines[0], "ERRO A: ascii");
+        assert!(lines[1].starts_with("ERRO B: "), "got: {:?}", lines[1]);
+        assert!(lines[1].contains('\u{FFFD}'), "got: {:?}", lines[1]);
+        assert_eq!(lines[2], "ERRO C: ascii again");
+    }
+
+    #[test]
+    fn test_read_lines_lossy_strips_crlf() {
+        let lines: Vec<String> = read_lines_lossy(&b"a\r\nb\n"[..]).collect();
+        assert_eq!(lines, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn test_read_lines_lossy_no_trailing_newline() {
+        let lines: Vec<String> = read_lines_lossy(&b"only line"[..]).collect();
+        assert_eq!(lines, vec!["only line".to_string()]);
+    }
+
+    #[test]
+    fn test_read_lines_lossy_empty_input() {
+        let lines: Vec<String> = read_lines_lossy(&b""[..]).collect();
+        assert!(lines.is_empty());
+    }
 
     struct LineFilter<F: FnMut(&str) -> Option<String>> {
         f: F,

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -17,21 +17,18 @@ use regex::Regex;
 /// never fails on the source encoding, so a garbled line still surfaces
 /// instead of vanishing along with everything downstream of it.
 fn read_lines_lossy(reader: impl Read) -> impl Iterator<Item = String> {
-    let mut reader = BufReader::new(reader);
-    std::iter::from_fn(move || {
-        let mut buf = Vec::new();
-        match reader.read_until(b'\n', &mut buf) {
-            Ok(0) | Err(_) => None,
-            Ok(_) => {
-                if buf.last() == Some(&b'\n') {
-                    buf.pop();
-                    if buf.last() == Some(&b'\r') {
-                        buf.pop();
-                    }
-                }
-                Some(String::from_utf8_lossy(&buf).into_owned())
+    BufReader::new(reader).split(b'\n').filter_map(|res| {
+        let mut buf = match res {
+            Ok(buf) => buf,
+            Err(e) => {
+                eprintln!("rtk: stream read error: {}", e);
+                return None;
             }
+        };
+        if buf.last() == Some(&b'\r') {
+            buf.pop();
         }
+        Some(String::from_utf8_lossy(&buf).into_owned())
     })
 }
 
@@ -617,6 +614,41 @@ pub(crate) mod tests {
     fn test_read_lines_lossy_empty_input() {
         let lines: Vec<String> = read_lines_lossy(&b""[..]).collect();
         assert!(lines.is_empty());
+    }
+
+    /// A `Read` that yields some good lines, then a genuine I/O error --
+    /// distinct from clean EOF (`Ok(0)`). Before this fix, `Ok(0) | Err(_)`
+    /// treated both the same way, silently truncating output on a real read
+    /// failure instead of surfacing it.
+    struct FailingReader {
+        data: std::io::Cursor<Vec<u8>>,
+        failed: bool,
+    }
+
+    impl Read for FailingReader {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            if self.data.position() as usize >= self.data.get_ref().len() {
+                if !self.failed {
+                    self.failed = true;
+                    return Err(io::Error::other("simulated read failure"));
+                }
+                return Ok(0);
+            }
+            std::io::Read::read(&mut self.data, buf)
+        }
+    }
+
+    #[test]
+    fn test_read_lines_lossy_stops_on_io_error_without_panicking() {
+        let reader = FailingReader {
+            data: std::io::Cursor::new(b"line one\nline two\n".to_vec()),
+            failed: false,
+        };
+        // The two good lines are still yielded; the simulated failure after
+        // them must not panic or hang -- it just ends the iterator, same as
+        // clean EOF would, but via the Err(_) arm instead of Ok(0).
+        let lines: Vec<String> = read_lines_lossy(reader).collect();
+        assert_eq!(lines, vec!["line one".to_string(), "line two".to_string()]);
     }
 
     struct LineFilter<F: FnMut(&str) -> Option<String>> {


### PR DESCRIPTION
## Summary

Fixes #2994.

`run_streaming`'s six call sites all read child stdout/stderr with:

```rust
BufReader::new(stdout).lines().map_while(Result::ok)
```

`BufRead::lines()` returns `Err` for a line that isn't valid UTF-8 (OEM/ANSI
bytes from a non-English-locale Windows tool, per the issue's cp850 repro).
`map_while` stops iteration at the first `None` — so one non-UTF-8 line
doesn't just get dropped, it silently discards every line emitted *after*
it too. A failing build whose error text happens to contain one non-UTF-8
byte can end up looking like a clean, silent success even though the exit
code is non-zero.

## Fix

Added `read_lines_lossy()`, which reads raw bytes via `BufRead::read_until`
and decodes each line with `String::from_utf8_lossy` (invalid bytes become
U+FFFD) instead of erroring out of the iterator. Replaced all 6
`.lines().map_while(Result::ok)` call sites in `run_streaming` with it —
this is the single shared path every filter routes through, so the fix
covers all callers at once.

`rtk pipe` (`cmds/system/pipe_cmd.rs`) already fails loudly on invalid
UTF-8 stdin rather than silently, per the issue's own note — left as-is,
out of scope here.

## Testing

- `cargo test`: 2448 passed, 8 ignored, 0 failed (no regressions)
- 4 new unit tests on `read_lines_lossy` directly, including one that
  reproduces the exact failure mode from the issue: an ASCII line, a line
  with an embedded invalid byte, then another ASCII line — asserts all 3
  lines survive instead of the third silently vanishing
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean