### PR TITLE
fix(init): --agent cursor installs Cursor only and creates ~/.cursor

### DIFF
--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -3521,6 +3521,14 @@ fn install_cursor_hooks(ctx: InitContext) -> Result<()> {
     let InitContext { verbose, dry_run } = ctx;
     let cursor_dir = resolve_cursor_dir()?;
 
+    // Ensure ~/.cursor exists before any write: atomic_write creates its temp
+    // file in the target's parent, which fails on a fresh machine where the
+    // directory does not yet exist (part of #2097).
+    if !dry_run {
+        fs::create_dir_all(&cursor_dir)
+            .with_context(|| format!("Failed to create {}", cursor_dir.display()))?;
+    }
+
     // Migrate old hook script if present
     let old_hook = cursor_dir.join("hooks").join(REWRITE_HOOK_FILE);
     if old_hook.exists() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2031,10 +2031,15 @@ fn run_cli() -> Result<i32> {
                 hooks::init::run_droid_mode(global, ctx)?;
             } else {
                 let install_opencode = opencode;
-                let install_claude = !opencode;
                 let install_cursor = agent == Some(AgentTarget::Cursor);
                 let install_windsurf = agent == Some(AgentTarget::Windsurf);
                 let install_cline = agent == Some(AgentTarget::Cline);
+                // Sibling agents (Cursor, Windsurf, Cline) fall through to this
+                // shared init path; only the default (no --agent) or an explicit
+                // Claude target should install Claude Code files. Without this
+                // guard, `rtk init -g --agent cursor` writes into ~/.claude (#2097).
+                let install_claude =
+                    !opencode && !install_cursor && !install_windsurf && !install_cline;
 
                 let patch_mode = if auto_patch {
                     hooks::init::PatchMode::Auto

--- a/tests/init_agent_cursor_test.rs
+++ b/tests/init_agent_cursor_test.rs
@@ -1,0 +1,79 @@
+#![cfg(unix)]
+//! Regression for #2097: `rtk init -g --agent cursor` must only touch `.cursor/`
+//! and never create or patch Claude Code files under `~/.claude`.
+
+use std::process::{Command, Stdio};
+
+fn rtk() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_rtk"))
+}
+
+#[test]
+fn agent_cursor_dry_run_never_touches_claude() {
+    let home = tempfile::tempdir().unwrap();
+    let out = rtk()
+        .args(["init", "-g", "--agent", "cursor", "--dry-run"])
+        .env("HOME", home.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains("/.claude/"),
+        "cursor init must not touch .claude:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("/.cursor/"),
+        "cursor init must patch .cursor hooks.json:\n{stdout}"
+    );
+    // Dry-run must not create anything on disk.
+    assert!(
+        !home.path().join(".claude").exists(),
+        "dry-run must not create ~/.claude"
+    );
+    assert!(
+        !home.path().join(".cursor").exists(),
+        "dry-run must not create ~/.cursor"
+    );
+}
+
+#[test]
+fn agent_cursor_real_write_creates_no_claude_dir() {
+    // The original #2097 failure was a hard error while creating a temp file
+    // under a non-existent ~/.claude. Prove a real (non-dry-run) install never
+    // creates .claude and does write .cursor/hooks.json.
+    let home = tempfile::tempdir().unwrap();
+    let out = rtk()
+        .args(["init", "-g", "--agent", "cursor", "--auto-patch"])
+        .env("HOME", home.path())
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "cursor init failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !home.path().join(".claude").exists(),
+        "cursor init must not create ~/.claude"
+    );
+    assert!(
+        home.path().join(".cursor").join("hooks.json").exists(),
+        "cursor init must write .cursor/hooks.json"
+    );
+}
+
+#[test]
+fn default_dry_run_still_installs_claude() {
+    let home = tempfile::tempdir().unwrap();
+    let out = rtk()
+        .args(["init", "-g", "--dry-run"])
+        .env("HOME", home.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("/.claude/"),
+        "default init must still install Claude Code files:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Summary
Two defects made `rtk init -g --agent cursor` fail / pollute the home dir:
1. It fell through to the shared init path with `install_claude` derived only from `!opencode`, so it created `RTK.md`, `CLAUDE.md`, and patched `settings.json` under `~/.claude` in addition to patching `.cursor/hooks.json`. On machines without `~/.claude` it failed outright: `Failed to create temp file in ~/.claude: No such file or directory`.
2. Even after removing the `.claude` writes, the Cursor path still failed on a fresh machine because `install_cursor_hooks` never created `~/.cursor` before `atomic_write` placed its temp file there.

Fixes:
- Gate `install_claude` on the absence of a sibling agent target (Cursor, Windsurf, Cline), so only the default or an explicit Claude target installs Claude Code files.
- Create `~/.cursor` (non-dry-run) before patching `hooks.json`.
- Should complete/close #2097 (same root cause as the previously-closed #1465)

## Root cause
- `src/main.rs`, `Commands::Init` handler: `install_claude = !opencode`. Cursor is the only sibling agent that reaches the shared init path (Windsurf/Cline short-circuit earlier in `hooks::init::run`), so it incorrectly triggered the Claude install branch.
- `src/hooks/init.rs`, `install_cursor_hooks`: wrote `hooks.json` via `atomic_write` without ensuring the parent directory exists.

## Fix
```rust
// src/main.rs
let install_cursor = agent == Some(AgentTarget::Cursor);
let install_windsurf = agent == Some(AgentTarget::Windsurf);
let install_cline = agent == Some(AgentTarget::Cline);
let install_claude =
    !opencode && !install_cursor && !install_windsurf && !install_cline;

// src/hooks/init.rs (install_cursor_hooks)
if !dry_run {
    fs::create_dir_all(&cursor_dir)?;
}
```

## Test plan
- `cargo fmt --all && cargo clippy --all-targets && cargo test --all`: pass.
- New `tests/init_agent_cursor_test.rs`:
  - `agent_cursor_dry_run_never_touches_claude`: asserts dry-run output contains no `/.claude/` path and does patch `/.cursor/`.
  - `agent_cursor_real_write_creates_no_claude_dir`: non-dry-run install in a temp `HOME`: exits 0, never creates `~/.claude`, and writes `.cursor/hooks.json`.
  - `default_dry_run_still_installs_claude`: regression: default init still installs Claude Code files.
- `cargo test --bin rtk hooks::init`: 169 existing init tests pass (no regression).

## E2E Validation

Tested locally and providing proofs (Screenshot). All working as expected:

<img width="820" height="1020" alt="image" src="https://github.com/user-attachments/assets/f9589e64-21ff-41e6-bc77-07ee61611269" />