### PR TITLE
fix(grep): tee log for +N more overflow now holds full untruncated lines

### DIFF
--- a/src/cmds/system/search.rs
+++ b/src/cmds/system/search.rs
@@ -118,11 +118,14 @@ fn grep_slug(idx: usize, path: &str) -> String {
 
 /// Format a file's matches as `path<sep>line<sep>content`. Tee blocks use the
 /// real (un-compacted) `path` so recovered lines stay openable.
-fn match_block(path: &str, entries: &[(usize, bool, String)]) -> String {
+/// Renders entries for the tee log using each line's *raw* (untruncated)
+/// content — the tee log's whole purpose is full-fidelity recovery, so it
+/// must not carry the same `clean_line`-truncated text shown in `body`.
+fn match_block(path: &str, entries: &[(usize, bool, String, String)]) -> String {
     let mut s = String::new();
-    for (line_num, is_match, content) in entries {
+    for (line_num, is_match, _cleaned, raw) in entries {
         let sep = if *is_match { ':' } else { '-' };
-        s.push_str(&format!("{}{}{}{}{}\n", path, sep, line_num, sep, content));
+        s.push_str(&format!("{}{}{}{}{}\n", path, sep, line_num, sep, raw));
     }
     s
 }
@@ -438,7 +441,7 @@ pub fn run(
         None
     };
 
-    let mut by_file: HashMap<String, Vec<(usize, bool, String)>> = HashMap::new();
+    let mut by_file: HashMap<String, Vec<(usize, bool, String, String)>> = HashMap::new();
     for line in raw_output.lines() {
         let Some((file, line_num, is_match, content)) = parse_match_line(line) else {
             continue;
@@ -447,13 +450,13 @@ pub fn run(
         by_file
             .entry(file)
             .or_default()
-            .push((line_num, is_match, cleaned));
+            .push((line_num, is_match, cleaned, content.to_string()));
     }
 
     let total_matches: usize = by_file
         .values()
         .flat_map(|v| v.iter())
-        .filter(|(_, is_match, _)| *is_match)
+        .filter(|(_, is_match, _, _)| *is_match)
         .count();
 
     // Mirror what the real command prints: the filename only when grep/rg would
@@ -516,7 +519,7 @@ pub fn run(
         let file_display = compact_path(file);
         let mut file_shown = 0;
         let mut prev_line: usize = 0;
-        for (line_num, is_match, content) in entries.iter().take(per_file) {
+        for (line_num, is_match, content, _raw) in entries.iter().take(per_file) {
             if shown >= max_results {
                 break;
             }
@@ -747,6 +750,27 @@ mod tests {
         let line = "🎉🎊🎈🎁🎂🎄 some text 🎃🎆🎇✨";
         let cleaned = clean_line(line, 15, None, "text");
         assert!(!cleaned.is_empty());
+    }
+
+    #[test]
+    fn test_match_block_uses_raw_not_cleaned_content() {
+        // match_block renders the tee log — the log's whole purpose is
+        // full-fidelity recovery, so it must carry the untruncated line, not
+        // the same clean_line-truncated text already shown in the display.
+        let cleaned = "widget line 0: this is a synthetic sentence about widg...".to_string();
+        let raw = "widget line 0: this is a synthetic sentence about widgets that is deliberately padded past eighty characters so truncation logic can be tested, item widget-0.".to_string();
+        let entries = vec![(1, true, cleaned.clone(), raw.clone())];
+
+        let block = match_block("foo/bar.md", &entries);
+
+        assert!(
+            block.contains("item widget-0."),
+            "tee block should contain the full untruncated line, got: {block}"
+        );
+        assert!(
+            !block.contains(&cleaned),
+            "tee block must not contain the truncated display text, got: {block}"
+        );
     }
 
     // --- parse_cluster ---


### PR DESCRIPTION
## Summary

Fixes #2988 (the tee-log-fidelity half of it — see scope note below).

`rtk grep -r` caps per-file results and truncates long lines via
`clean_line`, then points overflow at a tee log via a `+N more ... [see
remaining: tail -n +N ...]` hint. The bug: `clean_line`'s truncated output
is the *only* copy of each line kept in `by_file`'s entries — the
original, untruncated text is discarded right after truncation. Both the
interactive display *and* the tee log build from that same already-lossy
copy, so the tee log — whose entire purpose is full-fidelity recovery —
was just as truncated as the display it's supposed to recover from. There
was no way to get a matched line's full text back once it crossed the
length threshold, even by following the tool's own pointed-to recovery
path.

## Fix

`by_file`'s entries now carry both the cleaned (display) text and the
original raw text: `(line_num, is_match, cleaned, raw)`. The interactive
`body` output keeps using `cleaned`, unchanged. `match_block` — which
builds both the tee log content and the `skipped_files` overflow block —
now uses `raw` instead. Same compact display, but the recovery path
actually recovers.

## Scope note

The issue also raised two related but distinct observations I left out of
this PR, since they're either a separate bug or a design call for a
maintainer:

- Whether the per-file cap / truncation should default to *off* (matching
  `rtk read`'s behavior) is a design decision, not a pure bug — didn't want
  to bundle a behavior change into a fidelity fix.
- The "single-file mode ignores `--max-len`" observation looked like a
  possibly-separate bug in a different code path; didn't want to guess at
  a fix for something I hadn't isolated.

Happy to open a follow-up for either if a maintainer wants them tackled
separately.

## Testing

- Reproduced the exact fixture from the issue (2 files × 30 matching
  lines, alternating short/padded-past-80-chars) against the local build:
  before the fix, the tee log's recovered lines were still `...`-truncated
  exactly as reported; after the fix, `tail -n +26 <tee log>` shows the
  complete untruncated line text.
- `cargo test`: 2449 passed, 8 ignored, 0 failed (1 more pass than before —
  the new regression test)
- New unit test `test_match_block_uses_raw_not_cleaned_content` on
  `match_block` directly
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean