### PR TITLE
perf(tracking): skip schema migration on warm Tracker::new

### DIFF
--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -252,9 +252,25 @@ impl Tracker {
             std::fs::create_dir_all(parent)?;
         }
 
+        // Fast path: existing DB already has the current schema. Skip CREATE /
+        // ALTER / index probes that dominate Tracker::new on every CLI call.
+        // Bump SCHEMA_MARKER_NAME when migrations change.
+        const SCHEMA_MARKER_NAME: &str = ".tracking_schema_v3";
+        let schema_marker = db_path
+            .parent()
+            .map(|p| p.join(SCHEMA_MARKER_NAME))
+            .unwrap_or_else(|| PathBuf::from(SCHEMA_MARKER_NAME));
+        let db_ready = db_path.is_file() && schema_marker.is_file();
+
         let conn = Connection::open(&db_path)?;
         // WAL mode + busy_timeout for concurrent access (multiple Claude Code instances).
         // Non-fatal: NFS/read-only filesystems may not support WAL.
+        // On the hot path only set busy_timeout (journal_mode is sticky in the file).
+        if db_ready {
+            let _ = conn.execute_batch("PRAGMA busy_timeout=5000;");
+            return Ok(Self { conn });
+        }
+
         let _ = conn.execute_batch(
             "PRAGMA journal_mode=WAL;
              PRAGMA busy_timeout=5000;",
@@ -322,6 +338,9 @@ impl Tracker {
             "CREATE INDEX IF NOT EXISTS idx_pf_timestamp ON parse_failures(timestamp)",
             [],
         )?;
+
+        // Mark schema ready for subsequent process starts.
+        let _ = std::fs::write(&schema_marker, b"v3");
 
         Ok(Self { conn })
     }


### PR DESCRIPTION
## Summary

- When the tracking DB and a versioned schema marker already exist, open SQLite with only `busy_timeout` instead of re-running CREATE/ALTER/index probes on every CLI call
- Schema bootstrap still runs fully on cold start / marker miss; bump the marker name when migrations change
- **Small but real warm-path win** on every tracked command (measured as part of `rtk git status` latency after the git-side fix)

## Test plan

- [x] `cargo fmt --all --check && cargo clippy --all-targets && cargo test`
- [x] Manual testing: first `rtk git status` creates `.tracking_schema_v3` under the RTK data dir; later processes take the warm open path
- [x] Perf (local, Linux x86_64, release, hyperfine `--shell=none`, after the git single-porcelain change):
  - incremental gain on top of dual-git removal: roughly **~11.3 ms → ~10.9 ms** mean for `rtk git status` in A/B remeasures
  - absolute effect is machine- and I/O-dependent (SQLite open dominates less than process spawn); treat as **order-of-magnitude tens of percent of the residual RTK overhead**, not a headline % claim

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.