### PR TITLE
fix(discover): encode Windows drive-colon so project auto-detect matches

### DIFF
--- a/src/discover/provider.rs
+++ b/src/discover/provider.rs
@@ -117,15 +117,15 @@ impl ClaudeProvider {
 
     /// Encode a filesystem path to Claude Code's directory name format.
     ///
-    /// Claude Code replaces `/`, `.`, `_`, `\`, and any non-ASCII character
+    /// Claude Code replaces `/`, `.`, `_`, `\`, `:`, and any non-ASCII character
     /// with `-` when computing the project directory slug under `~/.claude/projects/`.
     ///
     /// `/Users/foo/bar`          → `-Users-foo-bar`
     /// `/Users/first.last/bar`   → `-Users-first-last-bar`
     /// `/home/chris/2_project`   → `-home-chris-2-project`
-    /// `C:\Users\foo\bar`        → `C:-Users-foo-bar`
+    /// `C:\Users\foo\bar`        → `C--Users-foo-bar`
     pub fn encode_project_path(path: &str) -> String {
-        const SANITIZED_CHARS: &[char] = &['/', '.', '_', '\\', ' ', '[', ']'];
+        const SANITIZED_CHARS: &[char] = &['/', '.', '_', '\\', ':', ' ', '[', ']'];
 
         path.chars()
             .map(|c| {
@@ -403,10 +403,25 @@ mod tests {
 
     #[test]
     fn test_encode_project_path_windows() {
-        // Windows backslashes are also replaced with '-'
+        // Windows backslashes AND the drive-letter colon are replaced with '-'.
+        // Claude Code turns a cwd like `C:\Users\foo\bar` into the projects-dir
+        // slug `C--Users-foo-bar`; if the colon is kept (`C:-Users-foo-bar`) the
+        // auto-detected --project filter never matches and `rtk discover` finds
+        // zero sessions on Windows.
         assert_eq!(
             ClaudeProvider::encode_project_path(r"C:\Users\foo\bar"),
-            "C:-Users-foo-bar"
+            "C--Users-foo-bar"
+        );
+    }
+
+    #[test]
+    fn test_encode_project_path_unix_colon() {
+        // A colon anywhere in a POSIX path is also replaced. The slug encoding is
+        // platform-independent, so this is not a Windows-only drive-letter special
+        // case; a colon in a Unix path collapses to '-' the same way.
+        assert_eq!(
+            ClaudeProvider::encode_project_path("/home/user/a:b/proj"),
+            "-home-user-a-b-proj"
         );
     }
 


### PR DESCRIPTION
 ## Problem
  On Windows, `rtk discover` (and `rtk learn`) with no `-p`/`--all` report
  `Scanned: 0 sessions` even when the current project has plenty of history.
  `rtk discover --all` and `rtk discover -p <name>` both work correctly, which
  isolates the fault to current-project auto-detection.

  ## Root cause
  `ClaudeProvider::encode_project_path` (src/discover/provider.rs) reproduces
  Claude Code's cwd→slug encoding to build the `--project` filter, but its
  `SANITIZED_CHARS` set is missing the colon `:`. Claude Code replaces the
  drive-letter colon with `-`, so a cwd of `C:\Users\foo\bar` maps to the
  projects directory `C--Users-foo-bar`. rtk instead produces
  `C:-Users-foo-bar`, and the substring match in
  `discover_sessions_in_projects_dir` (`dir_name.contains(filter)`) then fails,
  so no sessions are found. Unix paths have no `C:`, so the bug is Windows-only.

  ## Fix
  - Add `':'` to `SANITIZED_CHARS`.
  - Update the docstring example and `test_encode_project_path_windows` to expect
    `C--Users-foo-bar`.
  - Add `test_encode_project_path_unix_colon` documenting that the encoding is
    platform-independent (a colon in a POSIX path collapses to `-` the same way),
    so this is not a Windows-only drive-letter special case.

  ## Verification
  Reproduced on Windows 11: for a real project directory
  `C--Users-<user>-Desktop-Projects-<proj>`, `rtk discover` returned 0 sessions
  before the change and the correct session count after — matching the output of
  `rtk discover -p <proj>`.