### PR TITLE
docs: clarify Copilot quick start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ rtk gain        # Should show token savings stats
 
 ```bash
 # 1. Install for your AI tool
-rtk init -g                     # Claude Code / Copilot (default)
+ rtk init -g                     # Claude Code
+rtk init -g --copilot           # Copilot
 rtk init -g --gemini            # Gemini CLI
 rtk init -g --codex             # Codex (OpenAI)
 rtk init -g --agent cursor      # Cursor


### PR DESCRIPTION
## Summary

- Update the Quick Start section to use the correct initialization commands.
- Separate the commands for Claude Code and Copilot to avoid confusion.

Closes #<issue-number>