### PR TITLE
fix(hook): preserve explicit linter rewrites

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -960,16 +960,33 @@ fn rewrite_segment_inner(
     // Try each rewrite prefix (longest first) with word-boundary check
     for &prefix in rule.rewrite_prefixes {
         if let Some(rest) = strip_word_prefix(strip_target, prefix) {
-            let rewritten = if rest.is_empty() {
-                format!("{}{}", rule.rtk_cmd, redirect_suffix)
-            } else {
-                format!("{} {}{}", rule.rtk_cmd, rest, redirect_suffix)
+            let explicit_linter = explicit_linter_from_prefix(rule.rtk_cmd, prefix);
+            let rewritten = match (explicit_linter, rest.is_empty()) {
+                (Some(linter), true) => {
+                    format!("{} {}{}", rule.rtk_cmd, linter, redirect_suffix)
+                }
+                (Some(linter), false) => {
+                    format!("{} {} {}{}", rule.rtk_cmd, linter, rest, redirect_suffix)
+                }
+                (None, true) => format!("{}{}", rule.rtk_cmd, redirect_suffix),
+                (None, false) => format!("{} {}{}", rule.rtk_cmd, rest, redirect_suffix),
             };
             return Some(rewritten);
         }
     }
 
     None
+}
+
+fn explicit_linter_from_prefix<'a>(rtk_cmd: &str, prefix: &'a str) -> Option<&'a str> {
+    if rtk_cmd != "rtk lint" {
+        return None;
+    }
+
+    match prefix.split_whitespace().last() {
+        Some(linter @ ("biome" | "eslint")) => Some(linter),
+        _ => None,
+    }
 }
 
 /// Strip a command prefix with word-boundary check.
@@ -2966,13 +2983,35 @@ mod tests {
             "lint",
         ];
         for command in commands {
+            let linter = command.split_whitespace().last().unwrap();
+            let expected = match linter {
+                "biome" | "eslint" => format!("rtk lint {linter}"),
+                "lint" => "rtk lint".to_string(),
+                _ => unreachable!(),
+            };
             assert_eq!(
                 rewrite_command_no_prefixes(command, &[]),
-                Some("rtk lint".into()),
+                Some(expected),
                 "Failed for command: {}",
                 command
             );
         }
+    }
+
+    #[test]
+    fn test_rewrite_lint_preserves_explicit_linter_arguments() {
+        assert_eq!(
+            rewrite_command_no_prefixes("pnpm exec biome ci .", &[]),
+            Some("rtk lint biome ci .".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("pnpm exec eslint --version", &[]),
+            Some("rtk lint eslint --version".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("RAYON_NUM_THREADS=2 pnpm exec biome ci .", &[]),
+            Some("RAYON_NUM_THREADS=2 rtk lint biome ci .".into())
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #2906

## Summary

- keep `biome` and `eslint` in hook rewrites when the command names them explicitly
- leave generic `lint` script rewrites on the existing auto-detection path

## Test plan

- [x] `cargo fmt --all --check && cargo clippy --all-targets --locked -- -D warnings && cargo test --locked`
- [x] Manual testing: `rtk hook check "pnpm exec biome ci ."` -> `rtk lint biome ci .`