### PR TITLE
fix(hooks): always set permissionDecision so Claude Code applies rewrites

### DIFF
--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -339,7 +339,7 @@ enum PayloadAction {
     Ignore,
 }
 
-fn process_claude_payload(v: &Value) -> PayloadAction {
+fn process_claude_payload(v: &Value, decision: HookDecision) -> PayloadAction {
     let cmd = match v
         .pointer("/tool_input/command")
         .and_then(|c| c.as_str())
@@ -349,7 +349,7 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
         None => return PayloadAction::Ignore,
     };
 
-    let (rewritten, allow) = match decide_hook_action(cmd, permissions::Host::Claude) {
+    let (rewritten, decision_str) = match decision {
         HookDecision::Deny => {
             return PayloadAction::Skip {
                 reason: "skip:deny_rule",
@@ -362,8 +362,8 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
                 cmd: cmd.to_string(),
             }
         }
-        HookDecision::AllowRewrite(r) => (r, true),
-        HookDecision::AskRewrite(r) => (r, false),
+        HookDecision::AllowRewrite(r) => (r, "allow"),
+        HookDecision::AskRewrite(r) => (r, "ask"),
     };
 
     let updated_input = {
@@ -374,18 +374,12 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
         ti
     };
 
-    let mut hook_output = json!({
+    let hook_output = json!({
         "hookEventName": PRE_TOOL_USE_KEY,
+        "permissionDecision": decision_str,
         "permissionDecisionReason": "RTK auto-rewrite",
         "updatedInput": updated_input
     });
-
-    if allow {
-        hook_output
-            .as_object_mut()
-            .unwrap()
-            .insert("permissionDecision".into(), json!("allow"));
-    }
 
     PayloadAction::Rewrite {
         cmd: cmd.to_string(),
@@ -411,7 +405,13 @@ pub fn run_claude() -> Result<()> {
         }
     };
 
-    match process_claude_payload(&v) {
+    let cmd = v
+        .pointer("/tool_input/command")
+        .and_then(|c| c.as_str())
+        .unwrap_or("");
+    let decision = decide_hook_action(cmd, permissions::Host::Claude);
+
+    match process_claude_payload(&v, decision) {
         PayloadAction::Rewrite {
             cmd,
             rewritten,
@@ -431,8 +431,20 @@ pub fn run_claude() -> Result<()> {
 
 #[cfg(test)]
 fn run_claude_inner(input: &str) -> Option<String> {
+    run_claude_inner_with_rules(input, &[], &[], &[])
+}
+
+#[cfg(test)]
+fn run_claude_inner_with_rules(
+    input: &str,
+    deny_rules: &[String],
+    ask_rules: &[String],
+    allow_rules: &[String],
+) -> Option<String> {
     let v: Value = serde_json::from_str(input).ok()?;
-    match process_claude_payload(&v) {
+    let cmd = v.pointer("/tool_input/command").and_then(|c| c.as_str())?;
+    let verdict = permissions::check_command_with_rules(cmd, deny_rules, ask_rules, allow_rules);
+    match process_claude_payload(&v, decide_from_verdict(cmd, verdict)) {
         PayloadAction::Rewrite { output, .. } => Some(output.to_string()),
         _ => None,
     }
@@ -1124,11 +1136,38 @@ mod tests {
         let hook = &v["hookSpecificOutput"];
 
         assert_eq!(hook["hookEventName"], PRE_TOOL_USE_KEY);
-        // permissionDecision is only set when an explicit allow rule matches;
-        // with default-to-ask semantics (no rules configured), it is absent.
+        // Default verdict is ask; permissionDecision must still be present so
+        // Claude Code does not silently discard updatedInput.
+        assert_eq!(hook["permissionDecision"], "ask");
         assert_eq!(hook["permissionDecisionReason"], "RTK auto-rewrite");
         assert!(hook["updatedInput"].is_object());
         assert!(hook["updatedInput"]["command"].is_string());
+    }
+
+    #[test]
+    fn test_claude_allow_rewrite_sets_permission_decision_allow() {
+        let result =
+            run_claude_inner_with_rules(&claude_input("git status"), &[], &[], &["*".to_string()])
+                .unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let hook = &v["hookSpecificOutput"];
+
+        assert_eq!(hook["hookEventName"], PRE_TOOL_USE_KEY);
+        assert_eq!(hook["permissionDecision"], "allow");
+        assert_eq!(hook["permissionDecisionReason"], "RTK auto-rewrite");
+        assert_eq!(hook["updatedInput"]["command"], "rtk git status");
+    }
+
+    #[test]
+    fn test_claude_ask_rewrite_sets_permission_decision_ask() {
+        let result = run_claude_inner(&claude_input("git status")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let hook = &v["hookSpecificOutput"];
+
+        assert_eq!(hook["hookEventName"], PRE_TOOL_USE_KEY);
+        assert_eq!(hook["permissionDecision"], "ask");
+        assert_eq!(hook["permissionDecisionReason"], "RTK auto-rewrite");
+        assert_eq!(hook["updatedInput"]["command"], "rtk git status");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`rtk hook claude` emits a `hookSpecificOutput` containing `updatedInput` but, on the default "ask" path, omits `permissionDecision`. Per the Claude Code hooks schema, `updatedInput` is only applied when `permissionDecision` is explicitly present, so Claude Code silently executes the original command and the rewrite has no effect.

## Root cause

`src/hooks/hook_cmd.rs` had two paths that build Claude-shaped `hookSpecificOutput` and they disagreed:

- The VS Code/Copilot handler (`handle_vscode`, ~line 153) already mapped `AllowRewrite` → `"allow"` and `AskRewrite` → `"ask"` and always emitted `permissionDecision`.
- The native Claude Code handler (`process_claude_payload`, ~line 342) reduced the decision to a `bool`, only inserting `permissionDecision: "allow"` when `allow == true`. On `AskRewrite` the field was omitted entirely.

`AskRewrite` is the default verdict for rewritable commands when no explicit allow rule exists, so most Bash commands were rewritten in RTK's output but never actually changed in Claude Code.

## Fix

Make `process_claude_payload` set `permissionDecision` unconditionally — `"allow"` for `AllowRewrite` and `"ask"` for `AskRewrite` — matching the existing correct path in `handle_vscode`.

## Schema confirmation

The Claude Code hooks documentation states that for `PreToolUse`, `updatedInput` allows modifying tool input parameters, and the example shows it paired with `"permissionDecision": "allow"`. Valid values are `"allow"`, `"deny"`, and `"ask"`. See [Claude Code hooks reference — PreToolUse Decision Control](https://docs.claude.com/en/docs/claude-code/hooks).

## Regression-test evidence

Added tests covering both rewrite verdicts:

- `test_claude_allow_rewrite_sets_permission_decision_allow`
- `test_claude_ask_rewrite_sets_permission_decision_ask`

I temporarily reverted the fix while keeping the new tests. The AskRewrite test failed with:

```
assertion `left == right` failed
  left: Null
 right: "ask"
```

After restoring the fix, both new tests and the full suite pass.

## Gates

- `cargo fmt --all --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` ✅ (2437 unit tests + integration tests)

Closes #3018

Prepared with AI assistance (Kimi K2.7 Code), human-reviewed before submission.
