### PR TITLE
test(hook): cover option-bearing uv runs in Claude chains

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -2577,6 +2577,10 @@ mod tests {
             Some("rtk uv run --unknown pytest tests/".into())
         );
         assert_eq!(
+            rewrite_command_no_prefixes("uv run --extra dev pytest tests/ -q", &[]),
+            Some("rtk uv run --extra dev pytest tests/ -q".into())
+        );
+        assert_eq!(
             rewrite_command_no_prefixes("uv run -m pytest -q", &[]),
             Some("rtk uv run -m pytest -q".into())
         );

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -1118,6 +1118,22 @@ mod tests {
     }
 
     #[test]
+    fn test_claude_compound_uv_run_with_options() {
+        // Claude Code frequently combines setup and option-bearing uv runs in one Bash call.
+        let input = "cd /repo && uv run --extra dev pytest tests/ -q 2>&1 | tail -12";
+        let result = run_claude_inner(&claude_input(input)).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let cmd = v
+            .pointer("/hookSpecificOutput/updatedInput/command")
+            .and_then(|c| c.as_str())
+            .unwrap();
+        assert_eq!(
+            cmd,
+            "cd /repo && rtk uv run --extra dev pytest tests/ -q 2>&1 | tail -12"
+        );
+    }
+
+    #[test]
     fn test_claude_json_output_structure() {
         let result = run_claude_inner(&claude_input("git status")).unwrap();
         let v: Value = serde_json::from_str(&result).unwrap();


### PR DESCRIPTION
## Summary

- add registry coverage for `uv run --extra dev pytest`, the option-bearing form skipped by RTK 0.43.0
- add an end-to-end Claude PreToolUse regression for the frequent compound shape `cd ... && uv run --extra dev pytest ... 2>&1 | tail ...`
- lock in develop's dedicated `rtk uv` routing so this high-frequency Claude Code command keeps receiving an `updatedInput` rewrite

Related to #294. The production routing landed in #1405; this PR covers the stable-version regression at the Claude hook boundary.

## Test plan

- [x] `cargo fmt --all --check && cargo clippy --all-targets && cargo test`
- [x] `cargo test uv_run`
- [x] Manual testing: exact Claude Bash payload rewrites `uv run --extra dev pytest ...` to `rtk uv run --extra dev pytest ...` inside the compound chain

> **Important:** Targets `develop` as required by the contribution guide.