### PR TITLE
fix(go): report failure when build produces unrecognized error output

### DIFF
--- a/src/cmds/go/go_cmd.rs
+++ b/src/cmds/go/go_cmd.rs
@@ -575,6 +575,23 @@ pub(crate) fn filter_go_build(output: &str) -> String {
     filter_go_build_with_exit(output, 0)
 }
 
+fn has_unrecognized_output(output: &str) -> bool {
+    output.lines().any(|l| {
+        let t = l.trim();
+        if t.is_empty() || t.starts_with('#') {
+            return false;
+        }
+        let lower = t.to_lowercase();
+        if lower.starts_with("go: downloading ")
+            || lower.starts_with("go: finding ")
+            || lower.starts_with("go: extracting ")
+        {
+            return false;
+        }
+        !is_go_build_error_line(t)
+    })
+}
+
 fn filter_go_build_with_exit(output: &str, exit_code: i32) -> String {
     let mut errors: Vec<String> = Vec::new();
 
@@ -586,6 +603,9 @@ fn filter_go_build_with_exit(output: &str, exit_code: i32) -> String {
     }
 
     if errors.is_empty() {
+        if has_unrecognized_output(output) {
+            return format_go_build_failure(output, exit_code);
+        }
         return if exit_code == 0 {
             "Go build: Success".to_string()
         } else {
@@ -1050,6 +1070,31 @@ pattern ./...: directory prefix . does not contain modules listed in go.work or 
         assert!(result.contains("Go build: failed (exit 1)"));
         assert!(result.contains(output));
         assert!(!result.contains("Success"));
+    }
+
+    #[test]
+    fn test_filter_go_build_unrecognized_error_not_swallowed() {
+        let output = "stat /some/path/cmd/orator: directory not found\n";
+
+        let result = filter_go_build(output);
+        assert!(
+            result.contains("failed"),
+            "Should report failure, got: {}",
+            result
+        );
+        assert!(
+            result.contains("directory not found"),
+            "Should preserve raw error, got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_filter_go_build_download_lines_still_success() {
+        let output = "go: downloading github.com/foo/bar v1.0.0\n";
+
+        let result = filter_go_build(output);
+        assert!(result.contains("Success"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

\ilter_go_build_with_exit()\ now reports failure with raw output preserved when \go build\ produces unrecognized non-empty output that doesn't match any known error or progress pattern. Previously, unrecognized lines fell through silently and the filter reported success despite the presence of non-download, non-progress output text.

## Problem

\ilter_go_build()\ determined success purely by scanning for known error patterns. When \go build\ failed with an error that didn't match any pattern (e.g. \stat ...: directory not found\ for an invalid package path), the filter swallowed the error and reported success.

A successful \go build\ produces no output (or only \go: downloading ...\ progress lines). Any other unrecognized output indicates an error the filter doesn't understand — it should be passed through, not hidden.

## Changes

- \src/cmds/go/go_cmd.rs\: Added \has_unrecognized_output()\ helper that detects non-empty, non-download, non-progress, non-header output lines that don't match known error patterns. When \errors.is_empty()\ but unrecognized output exists, \ormat_go_build_failure()\ is called regardless of exit code.
- Added tests for unrecognized error output and download-only success

## Test plan

- \cargo clippy --all-targets\ — no warnings
- New test \	est_filter_go_build_unrecognized_error_not_swallowed\ confirms raw error is preserved
- New test \	est_filter_go_build_download_lines_still_success\ confirms download-only output still reports success
- Existing test \	est_filter_go_build_nonzero_exit_never_reports_success\ continues to pass

Fixes #1599