### PR TITLE
fix(learn): ignore parallel tool call cancellations

### DIFF
--- a/src/learn/detector.rs
+++ b/src/learn/detector.rs
@@ -71,7 +71,7 @@ lazy_static! {
 
     // User rejection patterns - NOT actual errors
     static ref USER_REJECTION_RE: Regex = Regex::new(
-        r"(?i)(user (doesn't want|declined|rejected|cancelled)|operation (cancelled|aborted) by user)"
+        r"(?i)(user (doesn't want|declined|rejected|cancelled)|operation (cancelled|aborted) by user|cancelled:\s*parallel tool call)"
     ).unwrap();
 }
 
@@ -365,6 +365,28 @@ mod tests {
         assert!(!is_command_error(true, "The user doesn't want to proceed"));
         assert!(!is_command_error(true, "Operation cancelled by user"));
         assert!(is_command_error(true, "error: permission denied"));
+    }
+
+    #[test]
+    fn test_find_corrections_ignores_parallel_tool_call_cancellation() {
+        let commands = vec![
+            CommandExecution {
+                command:
+                    "git show abc123 --no-stat -p -- backend/app/memory_repository.py"
+                        .to_string(),
+                is_error: true,
+                output: "<tool_use_error>Cancelled: parallel tool call Bash(git show abc123 --no-stat -p -- backend/app/memory_repository.py) errored</tool_use_error>"
+                    .to_string(),
+            },
+            CommandExecution {
+                command: "git show abc123 --no-stat -p -- backend/app/schema.py".to_string(),
+                is_error: false,
+                output: "commit abc123".to_string(),
+            },
+        ];
+
+        let corrections = find_corrections(&commands);
+        assert!(corrections.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Ignore Claude Code parallel tool-call cancellations during `rtk learn` error classification.
- Add a regression test based on the reported cancellation payload to ensure sibling parallel commands are not emitted as CLI corrections.

## Root cause

`is_command_error` filtered explicit user-rejection phrases, but did not recognize:

```text
<tool_use_error>Cancelled: parallel tool call Bash(...) errored</tool_use_error>
```

Because the payload contains `errored`, it passed the generic error-content check. `find_corrections` then treated the next sibling command as a successful replacement and generated a false `Use X not Y` rule.

## Impact

Cancelled parallel work is now excluded before correction pairing, preventing false rules from dominating generated `cli-corrections.md` files.

Fixes #1659.

## Validation

- `cargo test learn::detector::tests:: -- --nocapture` — 16 passed.
- `cargo fmt --all --check` — passed.
- `cargo clippy --all-targets` — passed.
- Full local Windows run: 2,404 passed; 30 existing environment-dependent tests failed because the sandbox blocks `%APPDATA%` writes or expects Unix commands. No `learn` tests failed.
