### PR TITLE
fix(cli): handle non-UTF-8 argv in raw-execution fallback

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1247,12 +1247,22 @@ enum GoCommands {
 }
 
 fn run_fallback(parse_error: clap::Error) -> Result<i32> {
-    let args: Vec<String> = std::env::args().skip(1).collect();
+    // Non-UTF-8 argv is frequently *why* parsing failed (clap rejects it as
+    // InvalidUtf8), so this path must never assume valid UTF-8: std::env::args()
+    // would panic on exactly the input that routed us here.
+    let args_os: Vec<OsString> = std::env::args_os().skip(1).collect();
 
     // No args → show Clap's error (user ran just "rtk" with bad syntax)
-    if args.is_empty() {
+    if args_os.is_empty() {
         parse_error.exit();
     }
+
+    // Lossy copies drive matching, display and tracking; execution below forwards
+    // the original `args_os` bytes so the wrapped tool receives what the user typed.
+    let args: Vec<String> = args_os
+        .iter()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
 
     // RTK meta-commands should never fall back to raw execution.
     // e.g. `rtk gain --badtypo` should show Clap's error, not try to run `gain` from $PATH.
@@ -1289,14 +1299,14 @@ fn run_fallback(parse_error: clap::Error) -> Result<i32> {
         let result = if filter.filter_stderr {
             // Merge stderr into stdout so the filter can strip banners emitted by tools like liquibase
             core::utils::resolved_command(&args[0])
-                .args(&args[1..])
+                .args(&args_os[1..])
                 .stdin(std::process::Stdio::inherit())
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped()) // captured for merging
                 .output()
         } else {
             core::utils::resolved_command(&args[0])
-                .args(&args[1..])
+                .args(&args_os[1..])
                 .stdin(std::process::Stdio::inherit())
                 .stdout(std::process::Stdio::piped()) // capture
                 .stderr(std::process::Stdio::inherit()) // stderr always direct
@@ -1365,7 +1375,7 @@ fn run_fallback(parse_error: clap::Error) -> Result<i32> {
     } else {
         // No TOML match: original passthrough behaviour (Stdio::inherit, streaming)
         let status = core::utils::resolved_command(&args[0])
-            .args(&args[1..])
+            .args(&args_os[1..])
             .stdin(std::process::Stdio::inherit())
             .stdout(std::process::Stdio::inherit())
             .stderr(std::process::Stdio::inherit())

--- a/tests/non_utf8_argv_test.rs
+++ b/tests/non_utf8_argv_test.rs
@@ -1,0 +1,98 @@
+#![cfg(unix)]
+//! Non-UTF-8 bytes in argv must never abort rtk (#3025). Clap rejects such args as
+//! InvalidUtf8, which routes them into the raw-execution fallback — so that fallback
+//! must read argv without assuming UTF-8, and must forward the original bytes to the
+//! wrapped tool rather than a lossy reinterpretation of them.
+
+use std::ffi::OsString;
+use std::os::unix::ffi::OsStringExt;
+use std::process::Command;
+
+/// Leading bytes of a double-encoded UTF-8 sequence: invalid UTF-8 on its own, and
+/// the kind of fragment you grep for when hunting mojibake. From the issue repro.
+const INVALID_PATTERN: &[u8] = b"\xc3\xa2\xe2\x80";
+
+/// A line the pattern above matches, written as raw bytes.
+const MATCHING_LINE: &[u8] = b"\xc3\xa2\xe2\x80\xa0\n";
+
+fn os(bytes: &[u8]) -> OsString {
+    OsString::from_vec(bytes.to_vec())
+}
+
+fn rtk(args: &[OsString]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args(args)
+        .output()
+        .expect("rtk")
+}
+
+#[test]
+fn non_utf8_pattern_does_not_abort() {
+    let d = tempfile::tempdir().unwrap();
+    let f = d.path().join("mojibake.txt");
+    std::fs::write(&f, MATCHING_LINE).unwrap();
+
+    let out = rtk(&[
+        os(b"grep"),
+        os(b"-c"),
+        os(INVALID_PATTERN),
+        f.clone().into_os_string(),
+    ]);
+
+    // Before the fix this aborted: SIGABRT (code() == None) under the release
+    // profile's panic="abort", exit 101 under a debug build.
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "expected a clean exit, got {:?} — stderr: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !String::from_utf8_lossy(&out.stderr).contains("panicked"),
+        "must not panic: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn non_utf8_pattern_forwards_original_bytes() {
+    let d = tempfile::tempdir().unwrap();
+    let f = d.path().join("mojibake.txt");
+    std::fs::write(&f, MATCHING_LINE).unwrap();
+
+    let rtk_out = rtk(&[
+        os(b"grep"),
+        os(b"-c"),
+        os(INVALID_PATTERN),
+        f.clone().into_os_string(),
+    ]);
+
+    // The bytes must reach the engine intact: a lossy conversion would search for
+    // replacement characters instead and silently report zero matches.
+    let native = Command::new("grep")
+        .args([os(b"-c"), os(INVALID_PATTERN), f.into_os_string()])
+        .env("LC_ALL", "C")
+        .output()
+        .expect("grep");
+
+    assert_eq!(
+        String::from_utf8_lossy(&rtk_out.stdout).trim(),
+        String::from_utf8_lossy(&native.stdout).trim(),
+        "rtk must report the same match count as native grep"
+    );
+}
+
+#[test]
+fn non_utf8_arg_to_missing_command_exits_cleanly() {
+    // The fallback's spawn-failure path also walks argv; it must degrade to the
+    // usual 127 rather than aborting.
+    let out = rtk(&[os(b"rtk_no_such_command_xyz"), os(INVALID_PATTERN)]);
+
+    assert_eq!(out.status.code(), Some(127), "expected command-not-found");
+    assert!(
+        !String::from_utf8_lossy(&out.stderr).contains("panicked"),
+        "must not panic: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}


### PR DESCRIPTION
Fixes #3025

## Problem

Any argument containing non-UTF-8 bytes aborted rtk before the wrapped command ran:

```
$ rtk grep -c $'\xc3\xa2\xe2\x80' mojibake.txt
thread 'main' panicked at library/std/src/env.rs:876:51:
called `Result::unwrap()` on an `Err` value: "â\xE2\x80"
```

Exit 134 (SIGABRT) under the release profile's `panic="abort"`, 101 under a debug build. Native `grep` handles the same bytes fine and reports `1`, so rtk turned a working command into a crash.

## Root cause

Not clap. Clap reads argv via `args_os()` and correctly reports `InvalidUtf8` — it never panics. That error routes into `run_fallback()`, which then collected argv with `std::env::args()`, panicking on exactly the input that sent it there. The non-UTF-8 error path was itself non-UTF-8-unsafe:

```
14: rtk::run_fallback
13: <Skip<std::env::Args> as Iterator>::collect::<Vec<String>>
 6: <std::env::Args as Iterator>::next          // per-argument unwrap
```

`std::env::args()` unwraps each argument, so it aborts the moment argv holds bytes that are not valid UTF-8.

## Fix

- Read argv with `std::env::args_os()` and keep the `OsString` values for execution, so the wrapped tool receives the bytes the user actually typed.
- Derive lossy `String` copies for matching, display and tracking (`RTK_META_COMMANDS`, `raw_command`, TOML `lookup_cmd`, `record_parse_failure_silent`), where text is all that is needed.

Forwarding the raw bytes rather than lossily converting them is the deliberate part: `to_string_lossy` alone would stop the abort, but the wrapped tool would then search for replacement characters and silently report zero matches — trading a loud crash for a wrong answer.

Scoped to the one reachable site. `core::args_utils::restore_double_dash` has the same `std::env::args()` call, but every non-UTF-8 argv is rejected by clap and funnelled into `run_fallback` before those callers run — verified by backtrace on `git diff --`, `cargo test --` and `grep -c`. It is a latent hazard rather than a live bug, so it is left for a follow-up rather than changed without a test that can fail.

Known remaining edge: a *command name* (argv[0]) that is itself non-UTF-8 still degrades to a clean 127 instead of resolving, because `resolved_command()` takes `&str`. Widening that signature ripples through many callers, and the outcome is graceful rather than an abort, so it is out of scope here.

## Verification

- Original panic reproduced against a pre-fix binary (`env.rs:876:51`, matching the issue), then confirmed gone.
- Post-fix `rtk grep -c` returns `1` — identical to `LC_ALL=C grep -c` on the same bytes.
- All 3 new tests in `tests/non_utf8_argv_test.rs` fail on unfixed code and pass with the fix: no abort, byte-forwarding vs native grep, and a clean 127 on the spawn-failure path.
- No regression: old vs new binary output is byte-identical on ASCII fallback paths (`echo`, `ls`, missing command, `gain --badtypo`, `git status`).
- `cargo fmt --all --check` clean, `cargo clippy --all-targets` zero warnings, `cargo test --all` 2496 passed / 0 failed.

Verified on Linux (`rust:latest`); the tests are `#![cfg(unix)]` since they build argv from raw bytes via `OsStringExt::from_vec`.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test --all`
- [x] Manual testing: `rtk grep -c $'\xc3\xa2\xe2\x80' <file>` inspected against native `grep`
- [x] Regression tests added, confirmed failing before the fix
- [x] Token savings: N/A (crash fix, no filter change)

---

Happy to contribute here — rtk is a genuinely interesting project, and I'm glad to adjust anything in this PR if you'd prefer a different scope or approach.
