### PR TITLE
fix(runner): surface a failing tool's stderr under stdout-only filtering

### DIFF
--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -122,6 +122,15 @@ where
         return Ok(exit_code);
     }
 
+    // `filter_stdout_only` keeps stderr out of the filter input, so nothing
+    // downstream can surface it — a failing child's diagnostics would be dropped
+    // and the exit code left as the only signal (#3026). Emit them here. Only on
+    // failure: on a successful run stderr is the incidental noise RTK exists to
+    // suppress, and the filtered stdout already carries the result.
+    if opts.filter_stdout_only && exit_code != 0 && !result.raw_stderr.trim().is_empty() {
+        eprint!("{}", result.raw_stderr);
+    }
+
     let text_to_filter = if opts.filter_stdout_only {
         raw_stdout
     } else {

--- a/tests/stderr_passthrough_test.rs
+++ b/tests/stderr_passthrough_test.rs
@@ -1,0 +1,69 @@
+#![cfg(unix)]
+//! A failing tool's stderr must reach the user (#3026). Filters that compress
+//! stdout run with `RunOptions::stdout_only`, which keeps stderr out of the filter
+//! input — so unless the runner emits it, the diagnostics are dropped and the exit
+//! code becomes the only surviving signal.
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::process::Command;
+
+const DIAGNOSTIC: &str = "shim-diagnostic: dependency is missing";
+
+/// A fake `ruff` that fails the way real tools do: message on stderr, nothing on
+/// stdout, nonzero exit. `rtk ruff` filters stdout only, which is the path under
+/// test; `resolved_command` resolves via PATH, so the shim takes precedence.
+fn shim(exit_code: i32) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let bin = dir.path().join("ruff");
+    fs::write(
+        &bin,
+        format!("#!/bin/sh\necho '{DIAGNOSTIC}' >&2\nexit {exit_code}\n"),
+    )
+    .unwrap();
+    fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+    dir
+}
+
+fn rtk_ruff(shim_dir: &tempfile::TempDir, db: &tempfile::TempDir) -> std::process::Output {
+    let path = format!(
+        "{}:{}",
+        shim_dir.path().display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args(["ruff", "check", "."])
+        .env("PATH", path)
+        // Keep tracking off the developer's real database.
+        .env("RTK_DB_PATH", db.path().join("t.db"))
+        .output()
+        .expect("rtk")
+}
+
+#[test]
+fn failing_tool_stderr_reaches_the_user() {
+    let db = tempfile::tempdir().unwrap();
+    let out = rtk_ruff(&shim(1), &db);
+
+    assert_eq!(out.status.code(), Some(1), "exit code must propagate");
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains(DIAGNOSTIC),
+        "diagnostic swallowed — stderr was {:?}, stdout was {:?}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
+#[test]
+fn successful_tool_stderr_stays_suppressed() {
+    // On success stderr is the incidental noise RTK exists to compress away, and
+    // the filtered stdout already carries the result.
+    let db = tempfile::tempdir().unwrap();
+    let out = rtk_ruff(&shim(0), &db);
+
+    assert_eq!(out.status.code(), Some(0));
+    assert!(
+        !String::from_utf8_lossy(&out.stderr).contains(DIAGNOSTIC),
+        "successful run must not leak tool stderr"
+    );
+}


### PR DESCRIPTION
Fixes #3026

## Problem

`uv run rtk pytest` says nothing at all when pytest is missing from the venv — exit 1, a single newline on stdout, empty stderr. As the issue puts it, this is the dangerous quadrant: a test run that produces no output and no error text reads as a quiet pass, and the exit code is the only surviving signal.

```console
$ uv run rtk pytest --version >out.txt 2>err.txt; echo "exit=$?"
exit=1
$ wc -c out.txt err.txt
       1 out.txt        # a single newline
       0 err.txt        # nothing
```

## Root cause

uv is the trigger, not the culprit — and it isn't a spawn failure either.

Filters that compress stdout pass `RunOptions::stdout_only`, which keeps stderr out of the filter input. But `run_captured_filter` only ever emitted `raw_stderr` inside its `skip_filter_on_failure` branch. Callers that pair `stdout_only` with `early_exit_on_failure` (`ls`, `tree`) reach that branch and print stderr; callers that don't captured stderr and dropped it:

| `stdout_only` caller | `early_exit_on_failure` | stderr on failure |
|---|---|---|
| `ls`, `tree` | yes | shown |
| `pytest`, `ruff`, `prettier`, `go test`, `golangci-lint`, `phpunit`, `phpstan`, `pint`, `rubocop` | no | **dropped** |

Why only the *combination* goes mute: standalone `rtk pytest` looks fine because python is absent, so the spawn fails outright and the `anyhow` error prints loudly. Under `uv run` the venv supplies python, so rtk takes its `python -m pytest` fallback, **the spawn succeeds**, and the child's diagnostic goes to the stderr that was being discarded:

```console
$ uv run python -m pytest --version
/tmp/uvp/.venv/bin/python3: No module named pytest     # 51 bytes, exit 1
$ uv run rtk pytest --version
                                                        # 0 bytes, exit 1
```

## Fix

Emit stderr when the child fails:

```rust
if opts.filter_stdout_only && exit_code != 0 && !result.raw_stderr.trim().is_empty() {
    eprint!("{}", result.raw_stderr);
}
```

Only on failure — on a successful run stderr is the incidental noise RTK exists to suppress, and the filtered stdout already carries the result. This is the rule `ls`/`tree` already get via `early_exit_on_failure`, applied to the callers that were missing it. No double-printing: `FilterMode::CaptureOnly` buffers stderr without echoing, and the `skip_filter_on_failure` branch returns before this point.

**This likely covers more than #3026.** The table above is a family, and #2878 ("rtk prettier silently hides prettier 3 failures — stdout-only capture + [warn] filter") names this exact mechanism. I've deliberately scoped this PR to the shared runner defect and made no filter-specific claims; I haven't verified #2878 end-to-end, so I'm flagging the overlap rather than asserting a fix.

## Verification

| | before | after |
|---|---|---|
| `uv run rtk pytest --version` (missing) | exit 1, stderr **0 B** | exit 1, stderr **50 B**: `No module named pytest` |
| `uv run rtk pytest --version` (installed) | exit 0, stderr 0 B | exit 0, stderr **0 B** — unchanged |

Reproduced against real `uv` in a fresh `uv init` + `uv venv` project, both with and without pytest installed.

- New tests in `tests/stderr_passthrough_test.rs` put a failing shim on `PATH` (stderr message, empty stdout, nonzero exit) and drive it through `rtk ruff`, a bare `stdout_only` caller. `failing_tool_stderr_reaches_the_user` fails on the pre-fix runner and passes after; `successful_tool_stderr_stays_suppressed` passes both ways, pinning that no new noise is introduced on success.
- `cargo fmt --all --check` clean, `cargo clippy --all-targets` zero warnings, `cargo test --all` 2495 passed / 0 failed.

Verified on Linux (`rust:latest`); the tests are `#![cfg(unix)]` as they rely on a shell shim and `PermissionsExt`.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test --all`
- [x] Manual testing: `uv run rtk pytest --version` with and without pytest in the venv
- [x] Regression tests added, confirmed failing before the fix
- [x] Token savings: N/A (error-path fix, no filter change)
