### PR TITLE
feat(gain): add scope, version and per-command breakdown to JSON export

### DIFF
--- a/src/analytics/gain.rs
+++ b/src/analytics/gain.rs
@@ -5,7 +5,7 @@ use crate::core::tracking::{DayStats, MonthStats, Tracker, WeekStats};
 use crate::core::utils::{format_tokens, truncate};
 use crate::hooks::hook_check;
 use anyhow::{Context, Result};
-use chrono::Local;
+use chrono::{Local, SecondsFormat, Utc};
 use colored::Colorize;
 use serde::Serialize;
 use std::io::IsTerminal;
@@ -505,13 +505,30 @@ fn print_monthly(tracker: &Tracker, project_scope: Option<&str>) -> Result<()> {
 
 #[derive(Serialize)]
 struct ExportData {
+    /// "global", or the project path when scoped with --project.
+    scope: String,
+    /// Lets downstream tooling adapt when this schema changes.
+    rtk_version: &'static str,
+    generated_at: String,
     summary: ExportSummary,
+    by_command: Vec<ExportCommand>,
     #[serde(skip_serializing_if = "Option::is_none")]
     daily: Option<Vec<DayStats>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     weekly: Option<Vec<WeekStats>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     monthly: Option<Vec<MonthStats>>,
+}
+
+/// One row of the per-command breakdown the text report renders as a table.
+#[derive(Serialize)]
+struct ExportCommand {
+    rank: usize,
+    command: String,
+    count: usize,
+    saved: usize,
+    avg_pct: f64,
+    avg_time_ms: u64,
 }
 
 #[derive(Serialize)]
@@ -538,6 +555,24 @@ fn export_json(
         .context("Failed to load token savings summary from database")?;
 
     let export = ExportData {
+        scope: project_scope.unwrap_or("global").to_string(),
+        rtk_version: env!("CARGO_PKG_VERSION"),
+        generated_at: Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+        by_command: summary
+            .by_command
+            .iter()
+            .enumerate()
+            .map(
+                |(idx, (command, count, saved, avg_pct, avg_time_ms))| ExportCommand {
+                    rank: idx + 1,
+                    command: command.clone(),
+                    count: *count,
+                    saved: *saved,
+                    avg_pct: *avg_pct,
+                    avg_time_ms: *avg_time_ms,
+                },
+            )
+            .collect(),
         summary: ExportSummary {
             total_commands: summary.total_commands,
             total_input: summary.total_input,

--- a/tests/gain_json_test.rs
+++ b/tests/gain_json_test.rs
@@ -1,0 +1,89 @@
+//! `rtk gain --format json` is the scripting surface (#2764): it must stay valid
+//! JSON on stdout, keep token counts as integers rather than the humanized "9.9M"
+//! strings the text report shows, and carry enough context (scope, version) for a
+//! consumer to interpret and version-guard the payload.
+
+use std::process::Command;
+
+/// Record one tracked command so the report has data, then read it back as JSON.
+fn gain_json(extra: &[&str]) -> serde_json::Value {
+    let db = tempfile::tempdir().unwrap();
+    let db_path = db.path().join("t.db");
+
+    let seed = Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args(["grep", "-c", "fn", file!()])
+        .env("RTK_DB_PATH", &db_path)
+        .output()
+        .expect("rtk grep");
+    assert!(seed.status.success(), "seeding command failed");
+
+    let mut args = vec!["gain", "--format", "json"];
+    args.extend_from_slice(extra);
+    let out = Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args(&args)
+        .env("RTK_DB_PATH", &db_path)
+        .output()
+        .expect("rtk gain");
+
+    assert!(
+        out.stderr.is_empty(),
+        "stdout must be the only channel: stderr had {:?}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    serde_json::from_slice(&out.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout was not valid JSON ({e}): {:?}",
+            String::from_utf8_lossy(&out.stdout)
+        )
+    })
+}
+
+#[test]
+fn json_export_carries_scope_version_and_breakdown() {
+    let v = gain_json(&[]);
+
+    assert_eq!(v["scope"], "global");
+    assert_eq!(
+        v["rtk_version"],
+        env!("CARGO_PKG_VERSION"),
+        "consumers version-guard on this"
+    );
+    assert!(
+        v["generated_at"].as_str().is_some_and(|s| s.ends_with('Z')),
+        "generated_at should be RFC3339 UTC, got {:?}",
+        v["generated_at"]
+    );
+    assert!(v["by_command"].is_array(), "per-command breakdown missing");
+}
+
+#[test]
+fn json_export_keeps_token_counts_numeric() {
+    let v = gain_json(&[]);
+
+    // The text report humanizes these ("9.9M"); the JSON must not.
+    for field in [
+        "total_commands",
+        "total_input",
+        "total_output",
+        "total_saved",
+    ] {
+        assert!(
+            v["summary"][field].is_number(),
+            "summary.{field} must be a number, got {:?}",
+            v["summary"][field]
+        );
+    }
+}
+
+#[test]
+fn json_export_reports_project_scope() {
+    let v = gain_json(&["--project"]);
+
+    // --project scopes the report, so the payload must say so rather than
+    // claiming to be global data. Assert the field is a real string first: a
+    // missing key is Null, which would sail past a bare `!= "global"`.
+    let scope = v["scope"]
+        .as_str()
+        .unwrap_or_else(|| panic!("scope missing from payload: {v}"));
+    assert_ne!(scope, "global", "--project run reported itself as global");
+}


### PR DESCRIPTION
Fixes #2764

## Summary

**`rtk gain --format json` already exists** — the issue asks for `rtk gain --json`, and the machine-readable mode has been there all along under `--format json`. Worth saying plainly, since it changes what this PR is: not a new output mode, but filling the gaps that stop the existing one from being usable.

Against the shape requested in the issue, the current export emits only `summary` (plus `daily`/`weekly`/`monthly` when asked). This PR adds what was missing:

- **`by_command`** — the per-command breakdown the text report already renders as a table. This is the data behind "which commands does the agent use most" and one of the issue's stated uses (correlating with `rtk discover` for coverage analysis). It reuses `GainSummary::by_command`, already populated for the text path.
- **`rtk_version`** — explicitly requested: "so downstream tooling can adapt to schema changes".
- **`scope`** — `"global"`, or the project path under `--project`, so a stored payload says what it actually covers rather than being ambiguous once it leaves the machine.
- **`generated_at`** — RFC3339 UTC, for the "ship a daily payload to a central store" use.

```console
$ rtk gain --format json
{
  "scope": "global",
  "rtk_version": "0.42.4",
  "generated_at": "2026-07-17T00:23:14Z",
  "summary": { "total_commands": 3, "total_input": 141, "total_saved": 121, ... },
  "by_command": [
    { "rank": 1, "command": "rtk ls -la /rtk/src", "count": 1, "saved": 121, "avg_pct": 85.8, "avg_time_ms": 7 }
  ]
}
```

## Deliberate deviations from the issue's sketch

- **`summary` keeps its name** instead of becoming `totals`. The key already ships in the current export; renaming it would silently break anyone parsing `--format json` today. Happy to rename if you'd rather take the break now while the surface is young — it's a one-line change.
- **No `--json` alias.** `--format json` covers it, and a second spelling of the same thing is a maintenance cost. Say the word if you want the alias for discoverability, since the issue reporter clearly didn't find `--format`.
- **No `impact` field.** It appears in the issue's sketch, but in the text report it's a rendering artifact (a bar scaled to `max_saved` across the visible rows), not a stored metric. A consumer can compute it from `saved`, and freezing a display detail into the schema seemed like the wrong trade. Easy to add if you disagree.

## Verification

Against the issue's stated requirements:

| Requirement | Result |
|---|---|
| "Emit to stdout, nothing else on stdout" | valid JSON; stderr empty (asserted in tests) |
| "Preserve integer token counts (not the humanized `9.9M`)" | `total_saved` etc. parse as `int` |
| "Include `rtk_version`" | present, asserted equal to `CARGO_PKG_VERSION` |
| `--project` scoping | `scope` reports the project path, not `"global"` |

- Payload parsed with a real JSON parser (`json.load`), not eyeballed.
- New tests in `tests/gain_json_test.rs`. Two fail on the pre-change binary (`json_export_carries_scope_version_and_breakdown`, `json_export_reports_project_scope`); `json_export_keeps_token_counts_numeric` passes both ways by design, pinning existing behaviour against regression.
  - Note: the scope test asserts the field is a string *before* comparing — a missing key deserializes to `Null`, which sails past a bare `!= "global"` and gave a false pass on the first cut.
- `cargo fmt --all --check` clean, `cargo clippy --all-targets` zero warnings, `cargo test --all` 2496 passed / 0 failed.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test --all`
- [x] Manual testing: `rtk gain --format json` and `rtk gain --project --format json` inspected and parsed
- [x] Tests added, confirmed failing before the change
- [x] Token savings: N/A (analytics output, no filter change)
