### PR TITLE
fix(hook): emit ask decision for Claude rewrites

### DIFF
--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -385,6 +385,11 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
             .as_object_mut()
             .unwrap()
             .insert("permissionDecision".into(), json!("allow"));
+    } else if v.get("permission_mode").and_then(Value::as_str) != Some("bypassPermissions") {
+        hook_output
+            .as_object_mut()
+            .unwrap()
+            .insert("permissionDecision".into(), json!("ask"));
     }
 
     PayloadAction::Rewrite {
@@ -1124,11 +1129,26 @@ mod tests {
         let hook = &v["hookSpecificOutput"];
 
         assert_eq!(hook["hookEventName"], PRE_TOOL_USE_KEY);
-        // permissionDecision is only set when an explicit allow rule matches;
-        // with default-to-ask semantics (no rules configured), it is absent.
+        assert_eq!(hook["permissionDecision"], "ask");
         assert_eq!(hook["permissionDecisionReason"], "RTK auto-rewrite");
         assert!(hook["updatedInput"].is_object());
         assert!(hook["updatedInput"]["command"].is_string());
+    }
+
+    #[test]
+    fn test_claude_bypass_ask_omits_permission_decision() {
+        let input = json!({
+            "permission_mode": "bypassPermissions",
+            "tool_name": "Bash",
+            "tool_input": { "command": "git status" }
+        })
+        .to_string();
+        let result = run_claude_inner(&input).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let hook = &v["hookSpecificOutput"];
+
+        assert!(hook.get("permissionDecision").is_none());
+        assert_eq!(hook["updatedInput"]["command"], "rtk git status");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- emit `permissionDecision: "ask"` for Claude Code rewrites that require confirmation
- preserve decision omission for ask rewrites under `bypassPermissions`
- add regression coverage for both default and bypass permission modes

## Root cause

`process_claude_payload` only emitted a permission decision for explicit allow rules. In the default-to-ask path, it returned `updatedInput` without the corresponding `ask` decision, so Claude Code could ignore the rewritten command and execute the original input.

The bypass-mode exception is intentional: Claude Code currently applies `updatedInput` under `bypassPermissions` only when the decision is omitted. Explicit allow behavior is unchanged and remains covered separately by #1648.

## Impact

Default and explicit-ask configurations now prompt against the rewritten `rtk ...` command instead of silently losing the rewrite. Explicit allow and bypass behavior remain unchanged.

Fixes #3018

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets`
- `cargo test hooks::hook_cmd::tests:: -- --nocapture` (91 passed)
- `cargo test` (2,434 unit tests and 11 integration tests passed; 8 ignored)
