### PR TITLE
fix(read): preserve stdin when filtering empties output

### DIFF
--- a/src/cmds/system/read.rs
+++ b/src/cmds/system/read.rs
@@ -37,17 +37,14 @@ pub fn run(
     }
 
     // Apply filter
-    let filter = filter::get_filter(level);
-    let mut filtered = filter.filter(&content, &lang);
+    let (mut filtered, fell_back) = filter_content(&content, &lang, level);
 
-    // Safety: if filter emptied a non-empty file, fall back to raw content
-    if filtered.trim().is_empty() && !content.trim().is_empty() {
+    if fell_back {
         eprintln!(
             "rtk: warning: filter produced empty output for {} ({} bytes), showing raw content",
             file.display(),
             content.len()
         );
-        filtered = content.clone();
     }
 
     if verbose > 0 {
@@ -115,8 +112,14 @@ pub fn run_stdin(
     }
 
     // Apply filter
-    let filter = filter::get_filter(level);
-    let mut filtered = filter.filter(&content, &lang);
+    let (mut filtered, fell_back) = filter_content(&content, &lang, level);
+
+    if fell_back {
+        eprintln!(
+            "rtk: warning: filter produced empty output for stdin ({} bytes), showing raw content",
+            content.len()
+        );
+    }
 
     if verbose > 0 {
         let original_lines = content.lines().count();
@@ -147,6 +150,21 @@ pub fn run_stdin(
 
     timer.track("cat - (stdin)", "rtk read -", &raw, shown);
     Ok(())
+}
+
+fn filter_content(
+    content: &str,
+    lang: &Language,
+    level: FilterLevel,
+) -> (String, bool) {
+    let filtered = filter::get_filter(level).filter(content, lang);
+    let fell_back = filtered.trim().is_empty() && !content.trim().is_empty();
+
+    if fell_back {
+        (content.to_string(), true)
+    } else {
+        (filtered, false)
+    }
 }
 
 fn format_with_line_numbers(content: &str) -> String {
@@ -190,6 +208,37 @@ mod tests {
     use super::*;
     use std::io::Write;
     use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_filter_content_falls_back_for_non_empty_stdin_content() {
+        let content = "// only comment\n";
+
+        let (output, fell_back) =
+            filter_content(content, &Language::Unknown, FilterLevel::Minimal);
+
+        assert!(fell_back);
+        assert_eq!(output, content);
+    }
+
+    #[test]
+    fn test_filter_content_keeps_genuinely_empty_content_empty() {
+        let (output, fell_back) =
+            filter_content("", &Language::Unknown, FilterLevel::Minimal);
+
+        assert!(!fell_back);
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn test_filter_content_preserves_normal_filtered_output() {
+        let content = "// comment\nfn main() {}\n";
+
+        let (output, fell_back) =
+            filter_content(content, &Language::Rust, FilterLevel::Minimal);
+
+        assert!(!fell_back);
+        assert_eq!(output, "fn main() {}");
+    }
 
     #[test]
     fn test_read_rust_file() -> Result<()> {

--- a/tests/read_stdin_test.rs
+++ b/tests/read_stdin_test.rs
@@ -1,0 +1,29 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+#[test]
+fn read_stdin_falls_back_to_raw_when_filter_removes_all_content() {
+    let input = "// only comment\n";
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args(["read", "-", "-l", "minimal"])
+        .env("RTK_DB_PATH", temp_dir.path().join("tracking.db"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn rtk");
+
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(input.as_bytes())
+        .expect("write stdin");
+
+    let output = child.wait_with_output().expect("wait for rtk");
+
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), input);
+    assert!(String::from_utf8_lossy(&output.stderr).contains("showing raw content"));
+}


### PR DESCRIPTION
Fixes #3038

## Summary

- share the existing empty-filter fallback between file and stdin reads
- preserve non-empty stdin content when the selected filter removes everything
- add an end-to-end regression test for `rtk read - -l minimal`

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test --test read_stdin_test`
- [x] Manual testing: `printf '// only comment\n' | rtk read - -l minimal`
- [ ] `cargo test` (2,436 passed; two existing `hooks::rewrite_cmd` tests fail locally because an external allow rule changes their expected outcome, and the same failures reproduce on untouched `upstream/develop`)
