### PR TITLE
fix(hooks): apply exclude_commands to the resolved tool, not just the raw command

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -883,7 +883,14 @@ fn rewrite_segment_inner(
         Classification::Supported { rtk_equivalent, .. } => {
             let stripped = ENV_PREFIX.replace(cmd_part, "");
             let cmd_clean = stripped.trim();
-            if is_excluded(cmd_clean, excluded) {
+            // The exclusion has to cover the tool the classifier resolved to,
+            // not just the raw text: `python -m pytest` classifies as
+            // `rtk pytest`, so `exclude_commands = ["pytest"]` must stop it
+            // even though the raw command starts with `python` (#3035).
+            let resolved_tool = rtk_equivalent
+                .strip_prefix("rtk ")
+                .unwrap_or(rtk_equivalent);
+            if is_excluded(cmd_clean, excluded) || is_excluded(resolved_tool, excluded) {
                 return None;
             }
             rtk_equivalent
@@ -3722,6 +3729,34 @@ mod tests {
     fn test_exclude_does_not_match_hyphenated_command() {
         let excluded = vec!["golangci".to_string()];
         assert!(rewrite_command_no_prefixes("golangci-lint run ./...", &excluded).is_some());
+    }
+
+    // #3035: the exclusion must cover the resolved tool, not just the raw text,
+    // so module/wrapper forms don't slip past it.
+    #[test]
+    fn test_exclude_covers_python_m_form() {
+        let excluded = vec!["pytest".to_string()];
+        assert_eq!(
+            rewrite_command_no_prefixes("python3 -m pytest tests/ -q", &excluded),
+            None
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("python -m pytest tests/", &excluded),
+            None
+        );
+    }
+
+    #[test]
+    fn test_exclude_resolved_tool_requires_word_boundary() {
+        // "py" must not exclude commands resolving to "pytest"
+        let excluded = vec!["py".to_string()];
+        assert!(rewrite_command_no_prefixes("python3 -m pytest tests/", &excluded).is_some());
+    }
+
+    #[test]
+    fn test_exclude_other_tool_does_not_hit_python_m_form() {
+        let excluded = vec!["mypy".to_string()];
+        assert!(rewrite_command_no_prefixes("python3 -m pytest tests/", &excluded).is_some());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #3035.

## Problem

`exclude_commands` is matched against the raw command text, but `classify_command` resolves module/wrapper forms to a different tool. With `exclude_commands = ["pytest"]`:

- `pytest tests/ -q` → excluded ✓
- `python3 -m pytest tests/ -q` → rewritten to `rtk pytest tests/ -q` ✗

The exclusion never sees the tool the classifier actually resolved to, so the rewrite silently swaps the interpreter (`-m` runs the current interpreter with CWD on `sys.path`; the bare shim may be a different Python entirely) — which is exactly the failure the user's exclusion existed to prevent.

## Fix

In the `Classification::Supported` arm of `rewrite_segment_inner`, also test the resolved rtk target (with the `rtk ` prefix stripped) against the exclusion list:

```rust
let resolved_tool = rtk_equivalent.strip_prefix("rtk ").unwrap_or(rtk_equivalent);
if is_excluded(cmd_clean, excluded) || is_excluded(resolved_tool, excluded) {
    return None;
}
```

`compile_exclude_patterns` anchors non-regex patterns as `^escaped($|\s)`, so matching the bare tool name is word-boundary safe: `"py"` does not exclude `pytest` (covered by a test).

## Verified

Unit tests plus end-to-end against a debug build with `exclude_commands = ["pytest"]` in config.toml:

```
pytest tests/ -q            =>  (excluded, exit 1)
python3 -m pytest tests/ -q =>  (excluded, exit 1)   # was: rewritten
python -m pytest tests/     =>  (excluded, exit 1)   # was: rewritten
python3 -m mypy --strict .  => rtk mypy --strict .   # unrelated tool still rewrites
```

Full suite: 2438 passed. Three new regression tests (`test_exclude_covers_python_m_form`, `test_exclude_resolved_tool_requires_word_boundary`, `test_exclude_other_tool_does_not_hit_python_m_form`).

Related but not addressed here: #2823 (head/tail fast path returns before the exclusion check — different code path), #1919, #917.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
