### PR TITLE
fix(read): fall back to raw content when filter empties stdin

### DIFF
--- a/src/cmds/system/read.rs
+++ b/src/cmds/system/read.rs
@@ -118,6 +118,15 @@ pub fn run_stdin(
     let filter = filter::get_filter(level);
     let mut filtered = filter.filter(&content, &lang);
 
+    // Safety: if filter emptied non-empty stdin, fall back to raw content
+    if filtered.trim().is_empty() && !content.trim().is_empty() {
+        eprintln!(
+            "rtk: warning: filter produced empty output for stdin ({} bytes), showing raw content",
+            content.len()
+        );
+        filtered = content.clone();
+    }
+
     if verbose > 0 {
         let original_lines = content.lines().count();
         let filtered_lines = filtered.lines().count();
@@ -302,6 +311,46 @@ fn main() {{
         assert!(
             stderr.contains("stdin specified more than once"),
             "should warn about duplicate stdin, got stderr: {}",
+            stderr
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn test_read_stdin_falls_back_when_filter_empties_input() {
+        use std::io::Write as _;
+        use std::process::Stdio;
+
+        let bin = rtk_bin();
+        assert!(bin.exists(), "Run `cargo build` first");
+
+        let mut child = std::process::Command::new(&bin)
+            .args(["read", "-", "-l", "minimal"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("failed to spawn rtk read");
+
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(b"// only comment\n")
+            .unwrap();
+
+        let output = child.wait_with_output().expect("failed to wait on rtk read");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(
+            stdout.contains("only comment"),
+            "expected raw-content fallback, got empty/filtered stdout: {:?}",
+            stdout
+        );
+        assert!(
+            stderr.contains("showing raw content"),
+            "expected fallback warning on stderr, got: {}",
             stderr
         );
     }


### PR DESCRIPTION
Closes #3038.

## Summary
`rtk read -` (stdin input) could silently return empty output when the
filter stripped the entire input (e.g. a comment-only snippet at
`--level minimal`). The file-path read path already has a safety
fallback for this exact situation, but `run_stdin()` never got the
same check when stdin support was added.

## Fix
Mirrors the existing fallback check from `run()` into `run_stdin()`:
if the filter empties non-empty input, fall back to showing the raw
content with a warning on stderr.

## Repro (before fix)
```
$ printf '// only comment\n' | rtk read - -l minimal
$
```
Empty stdout, no warning, exit 0.

## After fix
```
$ printf '// only comment\n' | rtk read - -l minimal
rtk: warning: filter produced empty output for stdin (16 bytes), showing raw content
// only comment
```

## Tests
- Added `test_read_stdin_falls_back_when_filter_empties_input`,
  following the existing `#[ignore]` real-binary pattern already used
  in this file for stdin tests. Manually verified against the exact
  repro from the issue (shown above).
- `cargo test --bin rtk`: 2433 passed, 9 ignored (the ignored ones —
  including the new one — can't resolve `rtk_bin()` on Windows due to
  the `.exe` extension; pre-existing limitation on every `#[ignore]`
  test in this file, covered by CI on Linux/macOS).
- `cargo fmt --check` and `cargo clippy --all-targets`: both clean.