### PR TITLE
fix(discover): sanitize the drive-letter colon in encode_project_path

### DIFF
--- a/src/discover/provider.rs
+++ b/src/discover/provider.rs
@@ -117,15 +117,15 @@ impl ClaudeProvider {
 
     /// Encode a filesystem path to Claude Code's directory name format.
     ///
-    /// Claude Code replaces `/`, `.`, `_`, `\`, and any non-ASCII character
+    /// Claude Code replaces `/`, `.`, `_`, `\`, `:`, and any non-ASCII character
     /// with `-` when computing the project directory slug under `~/.claude/projects/`.
     ///
     /// `/Users/foo/bar`          → `-Users-foo-bar`
     /// `/Users/first.last/bar`   → `-Users-first-last-bar`
     /// `/home/chris/2_project`   → `-home-chris-2-project`
-    /// `C:\Users\foo\bar`        → `C:-Users-foo-bar`
+    /// `C:\Users\foo\bar`        → `C--Users-foo-bar`
     pub fn encode_project_path(path: &str) -> String {
-        const SANITIZED_CHARS: &[char] = &['/', '.', '_', '\\', ' ', '[', ']'];
+        const SANITIZED_CHARS: &[char] = &['/', '.', '_', '\\', ' ', '[', ']', ':'];
 
         path.chars()
             .map(|c| {
@@ -403,10 +403,40 @@ mod tests {
 
     #[test]
     fn test_encode_project_path_windows() {
-        // Windows backslashes are also replaced with '-'
+        // Windows backslashes AND the drive-letter colon are replaced with '-',
+        // matching Claude Code's actual encoding (verified against real
+        // ~/.claude/projects/ folder names, e.g. `C:\Repos\job-hunter` on disk
+        // as `C--Repos-job-hunter`). See issue #2919 — the colon was previously
+        // left unsanitized, so `rtk discover`'s default current-project filter
+        // never matched its own project's session folder on Windows.
         assert_eq!(
             ClaudeProvider::encode_project_path(r"C:\Users\foo\bar"),
-            "C:-Users-foo-bar"
+            "C--Users-foo-bar"
+        );
+    }
+
+    #[test]
+    fn test_discover_sessions_applies_project_filter_windows_drive_letter() {
+        // Regression test for #2919: the default (no -p, no --all) filter path
+        // encodes the current working directory and must actually match the
+        // real on-disk folder name for a Windows-style path with a drive letter.
+        let projects_dir = tempfile::tempdir().unwrap();
+        let matching_project = projects_dir.path().join("C--Users-foo-bar");
+        std::fs::create_dir_all(&matching_project).unwrap();
+        std::fs::write(matching_project.join("session.jsonl"), "").unwrap();
+
+        let encoded_cwd = ClaudeProvider::encode_project_path(r"C:\Users\foo\bar");
+        let sessions = ClaudeProvider::discover_sessions_in_projects_dir(
+            projects_dir.path(),
+            Some(&encoded_cwd),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            sessions.len(),
+            1,
+            "encoded Windows drive-letter path should match its real session folder"
         );
     }
 


### PR DESCRIPTION
Closes #2919.

## Root cause (more precise than the original title)
Not actually a case-sensitivity issue — Claude Code replaces `:` with
`-` along with `/`, `.`, `_`, `\`, and non-ASCII characters when it
slugs a project's cwd into its session folder name under
`~/.claude/projects/`. `encode_project_path`'s `SANITIZED_CHARS` never
included `:`, so on Windows the filter string kept a literal colon
right after the drive letter while the real on-disk folder name never
had one.

Verified against several of my own real `~/.claude/projects/` folders
before writing the fix:

| Real cwd | Real folder on disk |
|---|---|
| `C:\Repos\job-hunter` | `C--Repos-job-hunter` |
| `G:\Other computers\...\Universal-Brain` | `G--Other-computers-...-Universal-Brain` |

So the default (no `-p`, no `--all`) filter was comparing
`"C:-Users-..."` against the real `"C--Users-..."` — never matches,
hence `Scanned: 0 sessions`, while `--all`/`-p <name>` (which don't
go through this exact comparison) work fine, matching the report.

## Fix
Added `:` to `SANITIZED_CHARS`. The existing
`test_encode_project_path_windows` test was actually asserting the
*buggy* output (`"C:-Users-foo-bar"`) — corrected it, and added an
end-to-end regression test exercising the full
`discover_sessions_in_projects_dir` match path.

## Before / after, live on this machine
```
$ rtk discover   # before
Scanned: 0 sessions (last 30 days), 0 Bash commands

$ rtk discover   # after, same repo, no other changes
Scanned: 30 sessions (last 30 days), 4575 Bash commands
```

## Tests
`cargo test --bin rtk`: 2434 passed, 9 ignored (pre-existing Windows
`.exe`-extension limitation on the `#[ignore]`d real-binary tests
elsewhere in this repo, covered by CI on Linux/macOS — unrelated to
this change). `cargo fmt --check` and `cargo clippy --all-targets`:
both clean.

## Note on the space-in-username report
The issue thread also mentions a separate symptom with a space in the
Windows username (`C:\Users\Jeff Huang\...`). Spaces were already in
`SANITIZED_CHARS` before this fix and I couldn't reproduce a
space-specific failure on this machine (no space in my own username),
so I'm not claiming this PR resolves that report too — flagging it in
case it needs separate follow-up.