### PR TITLE
fix(telemetry): forget respects RTK_DB_PATH/config database_path override

### DIFF
--- a/src/core/telemetry_cmd.rs
+++ b/src/core/telemetry_cmd.rs
@@ -142,15 +142,16 @@ fn run_forget() -> Result<()> {
         let _ = std::fs::remove_file(&marker_path);
     }
 
-    // Purge local tracking database (GDPR Art. 17 — right to erasure applies to local data too)
-    let db_path = dirs::data_local_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from("."))
-        .join(super::constants::RTK_DATA_DIR)
-        .join(super::constants::HISTORY_DB);
-    if db_path.exists() {
-        match std::fs::remove_file(&db_path) {
-            Ok(()) => println!("Local tracking database deleted: {}", db_path.display()),
-            Err(e) => eprintln!("rtk: could not delete {}: {}", db_path.display(), e),
+    // Purge local tracking database (GDPR Art. 17 — right to erasure applies to local data too).
+    // Must go through the same resolver every other read/write uses (RTK_DB_PATH env var,
+    // then config.toml's tracking.database_path, then the default) — a hardcoded default-only
+    // path here would silently miss a redirected database.
+    if let Ok(db_path) = super::tracking::get_db_path() {
+        if db_path.exists() {
+            match std::fs::remove_file(&db_path) {
+                Ok(()) => println!("Local tracking database deleted: {}", db_path.display()),
+                Err(e) => eprintln!("rtk: could not delete {}: {}", db_path.display(), e),
+            }
         }
     }
 


### PR DESCRIPTION
Closes #2956.

## Summary
\`rtk telemetry forget\` (a GDPR Art. 17 erasure request) reconstructed
the tracking database path by hand instead of going through
\`get_db_path()\` — the resolver every other read/write of the database
uses, which checks \`RTK_DB_PATH\`, then \`config.toml\`'s
\`tracking.database_path\`, before falling back to the default. A user
who redirected their database via either override would run \`forget\`
and have it silently miss their actual data.

## Fix
Made \`get_db_path()\` \`pub(crate)\` (it was private to \`tracking.rs\`)
and call it from \`run_forget()\` instead of reimplementing the
default-only path.

## Verified live
\`\`\`
$ RTK_DB_PATH=/tmp/custom.sqlite rtk telemetry forget
Local tracking database deleted: /tmp/custom.sqlite
\`\`\`
Confirmed the file at the overridden path was actually removed, not
left behind while the default location was checked instead.

## Tests
\`cargo test --bin rtk\`: 2434 passed. \`cargo fmt --check\` and
\`cargo clippy --all-targets\`: both clean.