### PR TITLE
fix(find): don't default to files-only when -type is omitted

### DIFF
--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -44,7 +44,11 @@ impl Default for FindArgs {
             path: ".".to_string(),
             max_results: 50,
             max_depth: None,
-            file_type: "f".to_string(),
+            // Empty = no type filter (matches real `find`'s default of matching every
+            // entry type). Only set to "f" or "d" when the caller explicitly passes
+            // -type/-t. See #3016 -- this used to default to "f", silently narrowing
+            // every unfiltered search to files-only.
+            file_type: String::new(),
             case_insensitive: false,
         }
     }
@@ -209,7 +213,9 @@ pub fn run(
         eprintln!("find: {} in {}", effective_pattern, path);
     }
 
+    // "" (no -type/-t given) means match any entry type, like real `find`.
     let want_dirs = file_type == "d";
+    let want_files_only = !file_type.is_empty() && file_type != "d";
 
     // When the pattern targets dotfiles (e.g. -name ".claude.json"), we must walk hidden
     // entries; otherwise skip them to keep results tidy (#1101).
@@ -241,7 +247,7 @@ pub fn run(
         if want_dirs && !is_dir {
             continue;
         }
-        if !want_dirs && is_dir {
+        if want_files_only && is_dir {
             continue;
         }
 
@@ -445,7 +451,8 @@ mod tests {
         let parsed = parse_find_args(&args(&[".", "-name", "*.rs"])).unwrap();
         assert_eq!(parsed.pattern, "*.rs");
         assert_eq!(parsed.path, ".");
-        assert_eq!(parsed.file_type, "f");
+        // No -type given: real `find` matches any entry type. See #3016.
+        assert_eq!(parsed.file_type, "");
         assert_eq!(parsed.max_results, 50);
     }
 
@@ -462,6 +469,15 @@ mod tests {
         let parsed = parse_find_args(&args(&[".", "-type", "d"])).unwrap();
         assert_eq!(parsed.pattern, "*");
         assert_eq!(parsed.file_type, "d");
+    }
+
+    #[test]
+    fn parse_native_find_maxdepth_no_type_matches_any_entry() {
+        // Regression test for #3016: `find <dir> -maxdepth N` with no -type must not
+        // silently narrow to files-only, or directory-only results vanish.
+        let parsed = parse_find_args(&args(&[".", "-maxdepth", "1"])).unwrap();
+        assert_eq!(parsed.file_type, "");
+        assert_eq!(parsed.max_depth, Some(1));
     }
 
     #[test]


### PR DESCRIPTION
Closes #3016.

## Summary
\`FindArgs::default()\` hardcoded \`file_type\` to \`\"f\"\`, so any
\`find\`/\`rtk find\` invocation without an explicit \`-type\`/\`-t\` flag
silently narrowed results to files-only — unlike real \`find\`, which
matches every entry type by default. This made
\`find <dir> -maxdepth N\` silently return empty whenever the only
matches within depth were directories.

## Fix
Changed the default to an empty sentinel meaning "no type filter",
and split \`run()\`'s binary \`want_dirs\` check into two independent
flags (\`want_dirs\` for explicit \`-type d\`, \`want_files_only\` for any
other explicit value) so the empty default falls through both checks
and matches every type.

## Verified against the exact repro from the issue
\`\`\`
$ mkdir -p /tmp/repro/onlydir/nested && echo hi > /tmp/repro/onlydir/nested/file.txt

$ find /tmp/repro/onlydir -maxdepth 1       # native, for reference
/tmp/repro/onlydir
/tmp/repro/onlydir/nested

$ rtk find /tmp/repro/onlydir -maxdepth 1   # before this fix: empty, exit 0
$ rtk find /tmp/repro/onlydir -maxdepth 1   # after: 
nested
\`\`\`

## Tests
Added a regression test on the parse layer
(\`parse_native_find_maxdepth_no_type_matches_any_entry\`) and updated
the existing \`parse_native_find_name\` test, which was asserting the
old buggy default (\`\"f\"\`) — corrected to \`\"\"\`.
\`cargo test --bin rtk\`: 2434 passed. \`cargo fmt --check\` and
\`cargo clippy --all-targets\`: both clean.