### PR TITLE
fix(discover): route bare rg invocations to rtk rg, not rtk grep

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -848,10 +848,22 @@ fn rewrite_segment_inner(
     // Try each rewrite prefix (longest first) with word-boundary check
     for &prefix in rule.rewrite_prefixes {
         if let Some(rest) = strip_word_prefix(cmd_part, prefix) {
-            let rewritten = if rest.is_empty() {
-                format!("{}{}", rule.rtk_cmd, redirect_suffix)
+            // `rg` and `grep` share the `rtk grep` rule, but `rtk grep` is a
+            // POSIX-grep passthrough: it is NOT recursive and rejects ripgrep-only
+            // flags (--hidden/--glob/--type/-g). Downgrading `rg`→`rtk grep` breaks
+            // ripgrep's semantics — flags bomb out and the bare form reads stdin
+            // instead of recursing (an agent then mis-reads it as "rg isn't
+            // installed"; it is). rtk ships a faithful `rtk rg` (real ripgrep), so
+            // route an `rg` invocation there, preserving every flag + recursion.
+            let effective_rtk_cmd = if rule.rtk_cmd == "rtk grep" && prefix == "rg" {
+                "rtk rg"
             } else {
-                format!("{} {}{}", rule.rtk_cmd, rest, redirect_suffix)
+                rule.rtk_cmd
+            };
+            let rewritten = if rest.is_empty() {
+                format!("{}{}", effective_rtk_cmd, redirect_suffix)
+            } else {
+                format!("{} {}{}", effective_rtk_cmd, rest, redirect_suffix)
             };
             return Some(rewritten);
         }
@@ -1423,9 +1435,29 @@ mod tests {
 
     #[test]
     fn test_rewrite_rg_pattern() {
+        // `rg` routes to `rtk rg` (faithful ripgrep), NOT `rtk grep` (POSIX
+        // passthrough): preserves recursion + ripgrep-only flags.
         assert_eq!(
             rewrite_command_no_prefixes("rg \"fn main\"", &[]),
-            Some("rtk grep \"fn main\"".into())
+            Some("rtk rg \"fn main\"".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_rg_preserves_ripgrep_flags() {
+        // ripgrep-only flags must survive (they bomb on `rtk grep`'s POSIX passthrough).
+        assert_eq!(
+            rewrite_command_no_prefixes("rg --hidden -g '*.rs' foo", &[]),
+            Some("rtk rg --hidden -g '*.rs' foo".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_grep_still_maps_to_rtk_grep() {
+        // A real `grep` is unaffected — only `rg` is rerouted to `rtk rg`.
+        assert_eq!(
+            rewrite_command_no_prefixes("grep -rn foo .", &[]),
+            Some("rtk grep -rn foo .".into())
         );
     }
 


### PR DESCRIPTION
## Problem

The command-rewrite registry maps both `rg` and `grep` invocations onto the same rule, `rtk grep`. `rtk grep` is a POSIX-`grep` passthrough: it is not recursive by default and rejects ripgrep-only flags (`--hidden`, `-g`/`--glob`, `--type`, etc).

When an agent or shell runs `rg <ripgrep-flags> <pattern> <dir>` and rtk silently downgrades it to `rtk grep`, one of two things happens:

- ripgrep-only flags are rejected outright, or
- the bare form falls back to reading stdin instead of recursing the directory tree.

Either way the caller sees a failure that looks like "ripgrep isn't installed," even though it is — rtk just routed the call to the wrong tool.

## Fix

`rewrite_segment_inner` now special-cases the `rg` → `rtk grep` mapping: when the matched rule is `rtk grep` *and* the original prefix was `rg` (not `grep`), it routes to `rtk rg` instead — rtk's own faithful ripgrep implementation — preserving recursion and every ripgrep-specific flag. A real `grep` invocation is untouched and still maps to `rtk grep`.

The change is intentionally scoped to `src/discover/registry.rs` only.

## Test evidence

Added two tests alongside the existing rewrite-rule test:

- `test_rewrite_rg_maps_to_rtk_rg` (updated) — `rg "fn main"` → `rtk rg "fn main"`
- `test_rewrite_rg_preserves_ripgrep_flags` (new) — `rg --hidden -g '*.rs' foo` → `rtk rg --hidden -g '*.rs' foo`
- `test_rewrite_grep_still_maps_to_rtk_grep` (new) — `grep -rn foo .` → `rtk grep -rn foo .` (unaffected)

`cargo build --release` is clean. `cargo test --release` currently fails on this branch's base (`origin/develop` HEAD) due to two pre-existing, unrelated `dead_code` lint errors (`FILTERS_TOML`, `TomlFilterRegistry::load`) under the crate's `[lints.rust] warnings = "deny"` setting — reproduced independently on a clean `origin/develop` checkout, so this PR does not introduce or worsen it. With `RUSTFLAGS="--cap-lints warn"` to route around that pre-existing issue: full suite passes, 2211 passed / 0 failed / 8 ignored, including the three tests above.

## Related

This is one of two local fixes we carry against rtk; the other (compound `find` predicates dropping recursion) is tracked as #2453 and is a separate, unrelated change — not included here.
