### PR TITLE
fix(cli)!: preserve argv boundaries and rewrite quoted shell wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,9 @@ rtk go test                     # Go tests (NDJSON, -90%)
 rtk cargo test                  # Cargo tests (-90%)
 rtk rake test                   # Ruby minitest (-90%)
 rtk rspec                       # RSpec tests (JSON, -60%+)
-rtk err <cmd>                   # Filter errors only from any command
-rtk test <cmd>                  # Generic test wrapper - failures only (-90%)
+rtk err <cmd> [args...]         # Direct argv execution, errors/warnings only
+rtk test <cmd> [args...]        # Direct argv execution, failures only (-90%)
+rtk err --shell fish '<script>' # Explicit shell for shell-specific syntax
 ```
 
 ### Build & Lint
@@ -255,9 +256,20 @@ rtk env -f AWS                  # Filtered env vars
 rtk log app.log                 # Deduplicated logs
 rtk curl <url>                  # Truncate + save full output
 rtk wget <url>                  # Download, strip progress bars
-rtk summary <long command>      # Heuristic summary
+rtk summary <cmd> [args...]     # Direct argv execution + heuristic summary
+rtk run <cmd> [args...]         # Raw direct execution (no filtering/tracking)
+rtk run -c '<script>'           # Shell string via sh (cmd on Windows)
+rtk run --shell fish -c '<script>' # Explicit shell for shell-specific syntax
 rtk proxy <command>             # Raw passthrough + tracking
 ```
+
+`rtk run`, `rtk err`, `rtk test`, and `rtk summary` preserve positional
+argument boundaries and do not expand globs, variables, or operators by
+default. Use `-c` with `rtk run`, or `--shell <name>` with the filtered
+wrappers, only when a command intentionally requires shell syntax. Pass an
+explicit shell script as one quoted argument; RTK does not infer the parser
+from `$SHELL` because the environment value may differ from the actual command
+executor.
 
 ### Token Savings Analytics
 ```bash

--- a/README.md
+++ b/README.md
@@ -329,6 +329,20 @@ The most effective way to use rtk. The hook transparently intercepts Bash comman
 
 **Scope note:** this only applies to Bash tool calls. Claude Code built-in tools such as `Read`, `Grep`, and `Glob` bypass the hook, so use shell commands or explicit `rtk` commands when you want RTK filtering there.
 
+Simple quoted shell wrappers are also rewritten without changing the selected
+shell:
+
+```bash
+bash -c "head foo && grep -R bar ."
+# → bash -c "rtk read foo && rtk grep -R bar ."
+```
+
+This support is intentionally conservative: it covers exact `sh -c`,
+`bash -c`, `zsh -c`, and `fish -c` wrappers with a quoted portable script. Shell
+expansion in an outer double quote, additional shell options, redirects to
+files, fish-specific control syntax, and nested wrappers pass through
+unchanged.
+
 ### Setup
 
 ```bash

--- a/docs/contributing/TECHNICAL.md
+++ b/docs/contributing/TECHNICAL.md
@@ -92,6 +92,14 @@ When an LLM agent runs a command (e.g., `git status`):
 
 All rewrite logic lives in Rust (`src/discover/registry.rs`). Hooks are thin delegates that handle agent-specific JSON formats.
 
+Before a hook emits `updatedInput`, the shared lexer rejects constructs whose
+shell semantics cannot be safely attested: command/process substitution,
+parenthesized syntax (including fish command substitution), incomplete
+quoting, file-target redirects, and shell control keywords at command
+boundaries. These commands are returned to the host unchanged. The host still
+owns command parsing and shell selection; RTK never translates syntax between
+fish, POSIX shells, and zsh.
+
 > **Details**: [`hooks/README.md`](../hooks/README.md) covers each agent's JSON format, the rewrite registry, compound command handling, and the `RTK_DISABLED` override.
 
 #### Rewrite Pipeline

--- a/docs/contributing/TECHNICAL.md
+++ b/docs/contributing/TECHNICAL.md
@@ -100,6 +100,15 @@ boundaries. These commands are returned to the host unchanged. The host still
 owns command parsing and shell selection; RTK never translates syntax between
 fish, POSIX shells, and zsh.
 
+The narrow exception is a quoted command string passed through an exact
+`sh -c`, `bash -c`, `zsh -c`, or `fish -c` wrapper. RTK can rewrite the
+portable inner command subset while preserving the original wrapper, quote
+delimiters, whitespace, and suffix arguments. RTK never marks the wrapper
+auto-allowed: Ask-capable hosts receive `Ask`, other hosts retain their native
+permission flow, and inner deny rules still take precedence. Active outer
+expansion, unsupported shell options, fish-specific control syntax, file
+redirects, and nested wrappers remain passthrough.
+
 > **Details**: [`hooks/README.md`](../hooks/README.md) covers each agent's JSON format, the rewrite registry, compound command handling, and the `RTK_DISABLED` override.
 
 #### Rewrite Pipeline
@@ -107,7 +116,7 @@ fish, POSIX shells, and zsh.
 The rewrite pipeline is how RTK intercepts and rewrites commands. The call chain is:
 
 ```
-hook shell → rewrite_cmd.rs → rewrite_command() → rewrite_compound() → rewrite_segment() → classify_command()
+hook shell → rewrite_cmd.rs → rewrite_command() → rewrite_compound() → rewrite_segment() → shell_wrapper/classify_command()
 ```
 
 Traced step by step for `cargo fmt --all && cargo test 2>&1 | tail -20`:
@@ -161,24 +170,29 @@ rewrite_compound(cmd, excluded)                    [src/discover/registry.rs]
   v
 rewrite_segment(seg, excluded)                     [src/discover/registry.rs]
   |
-  |  Step 3 — Strip trailing redirects
+  |  Step 3 — Recognize a conservative quoted shell wrapper
+  |  exact sh/bash/zsh/fish -c + one quoted script
+  |  → rewrite the inner compound command, replace only its byte span
+  |  → unsupported/ambiguous wrapper → None (skip rewrite)
+  |
+  |  Step 4 — Strip trailing redirects
   |  strip_trailing_redirects() re-tokenizes the segment:
   |    "cargo test 2>&1" → cmd_part="cargo test", redirect=" 2>&1"
   |  (simple commands like "cargo fmt --all" → no redirect, suffix is "")
   |
-  |  Step 4 — Already RTK → return as-is
+  |  Step 5 — Already RTK → return as-is
   |
-  |  Step 5 — Special cases (short-circuit before classification)
+  |  Step 6 — Special cases (short-circuit before classification)
   |  head -N / --lines=N → rewrite_line_range() → "rtk read file --max-lines N"
   |  tail -N / -n N / --lines N → rewrite_line_range() → "rtk read file --tail-lines N"
   |  head/tail with unsupported flag (-c, -f) → None (skip rewrite)
   |  cat with incompatible flag (-A, -v, -e) → None (skip rewrite)
   |
-  |  Step 6 — classify_command(cmd_part) [see below]
+  |  Step 7 — classify_command(cmd_part) [see below]
   |  → Supported → check excluded list → continue
   |  → Unsupported/Ignored → None (skip rewrite)
   |
-  |  Step 7 — Build rewritten command
+  |  Step 8 — Build rewritten command
   |  a. Find matching rule from rules.rs
   |  b. Extract env prefix (ENV_PREFIX regex, second pass — first was in classify)
   |     e.g. "GIT_SSH_COMMAND=\"ssh -o ...\" git push" → prefix="GIT_SSH_COMMAND=..."
@@ -213,6 +227,7 @@ LLM Agent executes rewritten command
 Key design decisions:
 - **Lexer-based tokenization**: A single-pass state machine (`lexer.rs`) handles all shell constructs (quotes, escapes, redirects, operators). Used for both compound splitting and redirect stripping.
 - **Segment-level rewriting**: Compound commands are split by operators, each segment rewritten independently. Bash recombines them at execution time.
+- **Conservative shell-wrapper recursion**: Only exact quoted `-c` wrappers enter one level of inner rewriting. The parser preserves byte ranges instead of decoding and re-quoting the script.
 - **Pipe semantics**: Only the left side of `|` is rewritten. The pipe consumer (grep, head, wc) runs raw. `find`/`fd` before a pipe is never rewritten (output format incompatible with xargs).
 - **Double env prefix handling**: `classify_command()` strips env prefixes to match the underlying command against rules. `rewrite_segment()` extracts the same prefix separately to re-prepend it to the rewritten command.
 - **Fallback contract**: If any segment fails to match, it stays raw. `rewrite_command()` returns `None` only when zero segments were rewritten.

--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -511,7 +511,12 @@ Showing 10 of 15 pull requests in org/repo   #42 feat: add vitest (open, 2d)
 **Syntaxe :**
 ```bash
 rtk test <commande...>
+rtk test --shell fish '<commande fish>'
 ```
+
+Par défaut, la commande et ses arguments sont exécutés directement, sans
+expansion par un shell. `--shell` accepte une commande complète comme argument
+unique lorsque la syntaxe d'un shell est nécessaire.
 
 **Economies :** ~90%
 
@@ -542,7 +547,11 @@ test utils::test_edge_case ... FAILED
 **Syntaxe :**
 ```bash
 rtk err <commande...>
+rtk err --shell fish '<commande fish>'
 ```
+
+Sans `--shell`, les limites des arguments sont préservées et les jokers,
+variables et opérateurs ne sont pas interprétés par un shell.
 
 **Economies :** ~80%
 
@@ -991,9 +1000,12 @@ Supprime les barres de progression et le bruit.
 
 ```bash
 rtk summary <commande...>
+rtk summary --shell fish '<commande fish>'
 ```
 
 Utile pour les commandes longues dont la sortie n'a pas de filtre dedie.
+La commande est exécutée directement par défaut ; `--shell` active
+explicitement l'interprétation d'une commande complète par le shell choisi.
 
 ---
 

--- a/hooks/codex/rtk-awareness.md
+++ b/hooks/codex/rtk-awareness.md
@@ -15,6 +15,16 @@ rtk npm run build
 rtk pytest -q
 ```
 
+## Shell-specific scripts
+
+For an intentional shell-specific script, pass one quoted script and select the shell explicitly:
+
+```bash
+rtk run --shell fish -c '<script>'
+```
+
+Otherwise, use portable syntax because the host may evaluate a command before RTK starts.
+
 ## Meta Commands
 
 ```bash

--- a/src/cmds/rust/README.md
+++ b/src/cmds/rust/README.md
@@ -5,5 +5,5 @@
 ## Specifics
 
 - `cargo_cmd.rs` uses `restore_double_dash()` fix: Clap strips `--` but cargo needs it for test flags (e.g., `cargo test -- --nocapture`)
-- `runner.rs` is a generic two-mode runner (`err` = stderr only, `test` = failures only) used as fallback for commands without a dedicated filter
+- `runner.rs` is a generic two-mode runner (`err` = stderr only, `test` = failures only) used as fallback for commands without a dedicated filter. It executes argv directly by default; `--shell <name> '<script>'` is the explicit escape hatch for shell syntax.
 - `runner.rs` is also referenced by other modules outside this directory as a generic command executor

--- a/src/cmds/rust/runner.rs
+++ b/src/cmds/rust/runner.rs
@@ -2,10 +2,9 @@
 
 use crate::core::stream::StreamFilter;
 use crate::core::truncate::{CAP_LIST, CAP_WARNINGS};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use lazy_static::lazy_static;
 use regex::Regex;
-use std::process::Command;
 
 const MAX_RUNNER_FAILURES: usize = CAP_WARNINGS;
 const MAX_RUNNER_LINES: usize = CAP_LIST;
@@ -102,44 +101,36 @@ impl StreamFilter for ErrorStreamFilter {
     }
 }
 
-fn build_shell_command(command: &str) -> Command {
-    if cfg!(target_os = "windows") {
-        let mut c = Command::new("cmd");
-        c.args(["/C", command]);
-        c
-    } else {
-        let mut c = Command::new("sh");
-        c.args(["-c", command]);
-        c
-    }
-}
-
 /// Run a command and filter output to show only errors/warnings
-pub fn run_err(command: &str, verbose: u8) -> Result<i32> {
+pub fn run_err(command: &[String], shell: Option<&str>, verbose: u8) -> Result<i32> {
+    let command_display = crate::core::shell::display_args(command);
     if verbose > 0 {
-        eprintln!("Running: {}", command);
+        eprintln!("Running: {}", command_display);
     }
-    let cmd = build_shell_command(command);
+    let cmd = crate::core::shell::command_from_args(command, shell)
+        .context("Failed to prepare err command")?;
     crate::core::runner::run_streamed(
         cmd,
         "err",
-        command,
+        &command_display,
         Box::new(ErrorStreamFilter::new()),
         crate::core::runner::RunOptions::with_tee("err"),
     )
 }
 
 /// Run tests and show only failures
-pub fn run_test(command: &str, verbose: u8) -> Result<i32> {
+pub fn run_test(command: &[String], shell: Option<&str>, verbose: u8) -> Result<i32> {
+    let command_display = crate::core::shell::display_args(command);
     if verbose > 0 {
-        eprintln!("Running tests: {}", command);
+        eprintln!("Running tests: {}", command_display);
     }
-    let cmd = build_shell_command(command);
-    let command_owned = command.to_string();
+    let cmd = crate::core::shell::command_from_args(command, shell)
+        .context("Failed to prepare test command")?;
+    let command_owned = command_display.clone();
     crate::core::runner::run_filtered(
         cmd,
         "test",
-        command,
+        &command_display,
         move |raw| extract_test_summary(raw, &command_owned),
         crate::core::runner::RunOptions::with_tee("test"),
     )

--- a/src/cmds/system/README.md
+++ b/src/cmds/system/README.md
@@ -8,6 +8,7 @@
 - `search.rs` backs both `rtk grep` and `rtk rg`: it runs the invoked engine (never substituting one for the other) and groups its output, reading `core/config` for `limits.grep_max_results` and `limits.grep_max_per_file`. Format-altering flags (`-c`, `-l`, `-L`, `-o`, `-Z`) bypass RTK filtering and run raw.
 - `local_llm.rs` (`rtk smart`) uses `core/filter` for heuristic file summarization
 - `format_cmd.rs` is a cross-ecosystem dispatcher: auto-detects and routes to `prettier_cmd` or `ruff_cmd` (black is handled inline, not as a separate module)
+- `summary.rs` executes argv directly before summarizing output. Shell-specific syntax requires `--shell <name> '<script>'`; it never guesses from `$SHELL`.
 
 ## Cross-command
 

--- a/src/cmds/system/summary.rs
+++ b/src/cmds/system/summary.rs
@@ -7,36 +7,29 @@ use crate::core::truncate::CAP_WARNINGS;
 use crate::core::utils::truncate;
 use anyhow::{Context, Result};
 use regex::Regex;
-use std::process::Command;
 
 const MAX_SUMMARY_LIST: usize = CAP_WARNINGS;
 const MAX_SUMMARY_KEYS: usize = CAP_WARNINGS;
 
 /// Run a command and provide a heuristic summary
-pub fn run(command: &str, verbose: u8) -> Result<i32> {
+pub fn run(command: &[String], shell: Option<&str>, verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
+    let command_display = crate::core::shell::display_args(command);
 
     if verbose > 0 {
-        eprintln!("Running and summarizing: {}", command);
+        eprintln!("Running and summarizing: {}", command_display);
     }
 
-    let mut cmd = if cfg!(target_os = "windows") {
-        let mut c = Command::new("cmd");
-        c.args(["/C", command]);
-        c
-    } else {
-        let mut c = Command::new("sh");
-        c.args(["-c", command]);
-        c
-    };
+    let mut cmd = crate::core::shell::command_from_args(command, shell)
+        .context("Failed to prepare summary command")?;
     let result = exec_capture(&mut cmd).context("Failed to execute command")?;
 
     let raw = format!("{}\n{}", result.stdout, result.stderr);
 
-    let summary = summarize_output(&raw, command, result.success());
+    let summary = summarize_output(&raw, &command_display, result.success());
     let shown = never_worse(&raw, &summary);
     println!("{}", shown);
-    timer.track(command, "rtk summary", &raw, shown);
+    timer.track(&command_display, "rtk summary", &raw, shown);
     Ok(result.exit_code)
 }
 

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -6,7 +6,7 @@
 
 Domain-agnostic building blocks with **no knowledge of any specific command, hook, or agent**. If a module references "git", "cargo", "claude", or any external tool by name, it does not belong here. Core is a leaf in the dependency graph — it is consumed by all other components but imports from none of them.
 
-Owns: configuration loading, token tracking persistence, TOML filter engine, tee output recovery, display formatting, telemetry, and shared utilities.
+Owns: configuration loading, token tracking persistence, TOML filter engine, tee output recovery, display formatting, explicit shell/direct command construction, telemetry, and shared utilities.
 
 Does **not** own: command-specific filtering logic (that's `cmds/`), hook lifecycle management (that's `src/hooks/`), or analytics dashboards (that's `analytics/`).
 
@@ -110,6 +110,19 @@ Key functions available to all command modules:
 ## Consumer Contracts
 
 Core provides infrastructure that `cmds/` and other components consume. These contracts define expected usage.
+
+### Command Construction (`shell`)
+
+Use `shell::direct_command()` when the caller already has an argv vector. It
+preserves argument boundaries and never expands globs, variables, redirects,
+or operators. Use `shell::shell_command()` only for an intentional command
+string, with an explicit shell when syntax is shell-specific. The platform
+default remains `sh -c` on Unix and `cmd /C` on Windows for compatibility.
+
+Never infer the command parser from `$SHELL`: agent hosts and terminal wrappers
+can execute a different shell while preserving the user's login-shell value.
+Callers that accept `--shell` must require the complete script as one quoted
+argument instead of reconstructing it by joining parsed argv.
 
 ### Tracking (`TimedExecution`)
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -7,6 +7,7 @@ pub mod display_helpers;
 pub mod filter;
 pub mod guard;
 pub mod runner;
+pub mod shell;
 pub mod stream;
 pub mod tee;
 pub mod telemetry;

--- a/src/core/shell.rs
+++ b/src/core/shell.rs
@@ -1,0 +1,132 @@
+//! Builds direct and explicit-shell commands without guessing the caller's shell.
+
+use crate::core::utils::{resolve_binary, resolved_command};
+use anyhow::{bail, Context, Result};
+use std::path::Path;
+use std::process::Command;
+
+/// Build a command that preserves the argument boundaries supplied by Clap.
+pub fn direct_command(args: &[String]) -> Result<Command> {
+    let Some((program, program_args)) = args.split_first() else {
+        bail!("command is required");
+    };
+
+    let mut command = resolved_command(program);
+    command.args(program_args);
+    Ok(command)
+}
+
+/// Build a command string invocation using an explicit shell or the platform default.
+pub fn shell_command(script: &str, shell: Option<&str>) -> Result<Command> {
+    let program = shell.unwrap_or(default_shell());
+    if program.trim().is_empty() {
+        bail!("shell must not be empty");
+    }
+
+    let mut command = match shell {
+        Some(_) => Command::new(
+            resolve_binary(program).with_context(|| format!("Shell '{program}' not found"))?,
+        ),
+        None => resolved_command(program),
+    };
+    command.arg(command_flag(program)).arg(script);
+    Ok(command)
+}
+
+/// Build a direct command by default, or an explicit shell command when requested.
+///
+/// Shell mode requires one argument containing the complete script. This avoids
+/// reconstructing quoting and argument boundaries by joining already-parsed argv.
+pub fn command_from_args(args: &[String], shell: Option<&str>) -> Result<Command> {
+    match shell {
+        Some(shell) => match args {
+            [script] => shell_command(script, Some(shell)),
+            [] => bail!("command is required when --shell is used"),
+            _ => bail!("pass the shell command as one quoted argument after --shell"),
+        },
+        None => direct_command(args),
+    }
+}
+
+pub fn display_args(args: &[String]) -> String {
+    args.join(" ")
+}
+
+#[cfg(windows)]
+fn default_shell() -> &'static str {
+    "cmd"
+}
+
+#[cfg(not(windows))]
+fn default_shell() -> &'static str {
+    "sh"
+}
+
+fn command_flag(shell: &str) -> &'static str {
+    let basename = Path::new(shell)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(shell)
+        .to_ascii_lowercase();
+
+    match basename.as_str() {
+        "cmd" | "cmd.exe" => "/C",
+        "powershell" | "powershell.exe" | "pwsh" | "pwsh.exe" => "-Command",
+        _ => "-c",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+
+    #[test]
+    fn direct_command_preserves_argument_boundaries() {
+        let args = vec![
+            "echo".to_string(),
+            "a b".to_string(),
+            "*".to_string(),
+            "$HOME".to_string(),
+        ];
+        let command = direct_command(&args).expect("build direct command");
+        let actual: Vec<_> = command.get_args().collect();
+
+        assert_eq!(
+            actual,
+            [OsStr::new("a b"), OsStr::new("*"), OsStr::new("$HOME")]
+        );
+    }
+
+    #[test]
+    fn direct_command_requires_program() {
+        assert!(direct_command(&[]).is_err());
+    }
+
+    #[test]
+    fn shell_command_uses_shell_specific_flag() {
+        assert_eq!(command_flag("fish"), "-c");
+        assert_eq!(command_flag("/bin/zsh"), "-c");
+        assert_eq!(command_flag("cmd.exe"), "/C");
+        assert_eq!(command_flag("pwsh"), "-Command");
+    }
+
+    #[test]
+    fn shell_command_rejects_empty_shell() {
+        assert!(shell_command("echo ok", Some(" ")).is_err());
+    }
+
+    #[test]
+    fn shell_mode_requires_one_script_argument() {
+        let split = vec!["echo".to_string(), "ok".to_string()];
+        assert!(command_from_args(&split, Some("unused-shell")).is_err());
+
+        let quoted = vec!["echo ok".to_string()];
+        let current_exe = std::env::current_exe().expect("resolve current test executable");
+        assert!(command_from_args(
+            &quoted,
+            Some(current_exe.to_str().expect("test executable path is UTF-8"))
+        )
+        .is_ok());
+    }
+}

--- a/src/discover/README.md
+++ b/src/discover/README.md
@@ -32,12 +32,13 @@ When a hook sends `cargo fmt --all && cargo test 2>&1 | tail -20`:
 
 **Guards along the way:**
 - `RTK_DISABLED=1` in the env prefix → skip rewrite
+- Command/process substitution, parenthesized syntax, incomplete quoting, or a shell control keyword at a command boundary → defer unchanged to the host
 - `gh` with `--json`/`--jq`/`--template` → skip (structured output, rtk would corrupt it)
 - `cat` with flags other than `-n` → skip (different semantics than `rtk read`)
 - `cat`/`head`/`tail` with `>` or `>>` → skip (write operation, not a read)
 - Command in `hooks.exclude_commands` config → skip
 
-**Result**: `rtk cargo fmt --all && rtk cargo test 2>&1 | tail -20`. Bash handles the `&&` and `|` at execution time — each `rtk` invocation is a separate process.
+**Result**: `rtk cargo fmt --all && rtk cargo test 2>&1 | tail -20`. The host shell handles the `&&` and `|` at execution time — each `rtk` invocation is a separate process. RTK does not select or replace that shell.
 
 ## How History Analysis Works
 

--- a/src/discover/README.md
+++ b/src/discover/README.md
@@ -23,6 +23,22 @@ When a hook sends `cargo fmt --all && cargo test 2>&1 | tail -20`:
 
 **Compound splitting** — The rewrite engine walks the tokens, splitting on `Operator` (`&&`, `||`, `;`) and `Pipe` (`|`). Each segment is rewritten independently. For pipes, only the left side is rewritten (the pipe consumer like `grep` or `head` runs raw). `find`/`fd` before a pipe is never rewritten because rtk's grouped output format breaks pipe consumers like `xargs`.
 
+**Quoted shell wrappers** — An exact `sh -c`, `bash -c`, `zsh -c`, or
+`fish -c` wrapper with one quoted script can recurse through the same compound
+rewrite:
+
+```
+bash -c "head foo && grep -R bar ."
+→ bash -c "rtk read foo && rtk grep -R bar ."
+```
+
+The wrapper parser replaces only the script's byte span, preserving the shell
+path, quote delimiters, whitespace, and suffix arguments. It accepts the
+portable operator subset understood by the shared lexer. Unquoted scripts,
+combined or additional shell options, active expansion in an outer double
+quote, redirects to files, fish-specific control syntax, and nested wrappers
+remain unchanged.
+
 **Per-segment rewriting** — Each segment goes through:
 
 1. Strip trailing redirects (`2>&1`, `>/dev/null`) — matched via lexer tokens, set aside, re-appended after rewriting
@@ -33,6 +49,7 @@ When a hook sends `cargo fmt --all && cargo test 2>&1 | tail -20`:
 **Guards along the way:**
 - `RTK_DISABLED=1` in the env prefix → skip rewrite
 - Command/process substitution, parenthesized syntax, incomplete quoting, or a shell control keyword at a command boundary → defer unchanged to the host
+- Quoted shell wrappers that fall outside the conservative `-c` subset → defer unchanged to the host
 - `gh` with `--json`/`--jq`/`--template` → skip (structured output, rtk would corrupt it)
 - `cat` with flags other than `-n` → skip (different semantics than `rtk read`)
 - `cat`/`head`/`tail` with `>` or `>>` → skip (write operation, not a read)

--- a/src/discover/lexer.rs
+++ b/src/discover/lexer.rs
@@ -272,19 +272,78 @@ fn flush_arg(tokens: &mut Vec<ParsedToken>, current: &mut String, offset: usize)
     }
 }
 
-/// True for constructs the permission gate can't decompose, so they must never
-/// be auto-allowed: command/process substitution, or a real file-target redirect
-/// (fd-dup like `2>&1` and `/dev/null` are exempt). Separators and subshells are
-/// handled by [`split_for_permissions`], not flagged here.
+/// True for constructs the permission gate can't safely interpret, so they must
+/// never be auto-allowed or rewritten. This includes command/process
+/// substitution, parenthesized shell syntax, control keywords at command
+/// boundaries, incomplete quoting, and real file-target redirects. FD duplication
+/// such as `2>&1` and redirects to `/dev/null` remain attestable.
 pub fn contains_unattestable_construct(cmd: &str) -> bool {
-    if contains_substitution(cmd) {
+    if contains_substitution(cmd) || has_unclosed_quote_or_escape(cmd) {
         return true;
     }
-    let tokens = tokenize(cmd);
+
+    let tokens = tokenize_inner(cmd, true);
+    if tokens
+        .iter()
+        .any(|token| token.kind == TokenKind::Shellism && matches!(token.value.as_str(), "(" | ")"))
+        || contains_control_keyword_at_command_position(&tokens)
+    {
+        return true;
+    }
+
     tokens
         .iter()
         .enumerate()
         .any(|(i, tok)| tok.kind == TokenKind::Redirect && redirect_has_file_target(&tokens, i))
+}
+
+fn has_unclosed_quote_or_escape(cmd: &str) -> bool {
+    let mut quote: Option<char> = None;
+    let mut escaped = false;
+
+    for character in cmd.chars() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if character == '\\' && quote != Some('\'') {
+            escaped = true;
+            continue;
+        }
+        if matches!(character, '\'' | '"') {
+            match quote {
+                Some(open) if open == character => quote = None,
+                None => quote = Some(character),
+                _ => {}
+            }
+        }
+    }
+
+    quote.is_some() || escaped
+}
+
+fn contains_control_keyword_at_command_position(tokens: &[ParsedToken]) -> bool {
+    const CONTROL_KEYWORDS: &[&str] = &[
+        "and", "or", "not", "begin", "end", "if", "else", "switch", "case", "for", "while",
+        "function",
+    ];
+
+    let mut command_position = true;
+    for token in tokens {
+        match token.kind {
+            TokenKind::Operator | TokenKind::Pipe => command_position = true,
+            TokenKind::Shellism if token.value == "&" => command_position = true,
+            TokenKind::Arg if command_position => {
+                if CONTROL_KEYWORDS.contains(&token.value.as_str()) {
+                    return true;
+                }
+                command_position = false;
+            }
+            _ => {}
+        }
+    }
+
+    false
 }
 
 /// Quote-aware: bash runs backtick/`$(...)` unquoted and inside double quotes,
@@ -1166,6 +1225,25 @@ mod tests {
     }
 
     #[test]
+    fn test_unattestable_fish_command_substitution() {
+        assert!(contains_unattestable_construct("git status (printf x)"));
+    }
+
+    #[test]
+    fn test_unattestable_fish_control_keyword_at_command_position() {
+        assert!(contains_unattestable_construct("git status; and printf x"));
+        assert!(contains_unattestable_construct(
+            "if test -d src\ngit status\nend"
+        ));
+    }
+
+    #[test]
+    fn test_fish_keyword_as_argument_is_attestable() {
+        assert!(!contains_unattestable_construct("rg and src"));
+        assert!(!contains_unattestable_construct("printf '%s\\n' or"));
+    }
+
+    #[test]
     fn test_unattestable_substitution_inside_double_quotes() {
         assert!(contains_unattestable_construct(
             r#"git log --pretty="$(rm -rf ~)""#
@@ -1183,6 +1261,13 @@ mod tests {
         assert!(!contains_unattestable_construct("echo '$(rm -rf ~)'"));
         assert!(!contains_unattestable_construct("echo '`whoami`'"));
         assert!(!contains_unattestable_construct(r#"echo "\$(rm -rf ~)""#));
+        assert!(!contains_unattestable_construct("echo '(printf x)'"));
+    }
+
+    #[test]
+    fn test_unattestable_incomplete_quoting() {
+        assert!(contains_unattestable_construct("git status 'unfinished"));
+        assert!(contains_unattestable_construct("git status \\"));
     }
 
     #[test]
@@ -1217,10 +1302,8 @@ mod tests {
     }
 
     #[test]
-    fn test_attestable_subshell_and_separators() {
-        assert!(!contains_unattestable_construct(
-            "(git status; cargo build)"
-        ));
+    fn test_unattestable_subshell_but_attestable_separators() {
+        assert!(contains_unattestable_construct("(git status; cargo build)"));
         assert!(!contains_unattestable_construct(
             "git status && cargo build"
         ));

--- a/src/discover/mod.rs
+++ b/src/discover/mod.rs
@@ -5,6 +5,7 @@ pub mod provider;
 pub mod registry;
 mod report;
 pub mod rules;
+pub(crate) mod shell_wrapper;
 
 use anyhow::Result;
 use std::collections::HashMap;

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -5,10 +5,12 @@ use lazy_static::lazy_static;
 use regex::{Regex, RegexSet};
 use std::path::Path;
 
-use super::lexer::{split_on_operators, tokenize, TokenKind};
+use super::lexer::{contains_unattestable_construct, split_on_operators, tokenize, TokenKind};
 use super::rules::{IGNORED_EXACT, IGNORED_PREFIXES, RULES};
+use super::shell_wrapper::parse_shell_wrapper;
 
 const PHP_TOOL_NAMES: [&str; 6] = ["phpunit", "phpstan", "ecs", "pest", "paratest", "pint"];
+const MAX_SHELL_WRAPPER_DEPTH: usize = 1;
 
 /// Result of classifying a command.
 #[derive(Debug, PartialEq)]
@@ -592,7 +594,7 @@ pub fn rewrite_command(
         return Some(trimmed.to_string());
     }
 
-    rewrite_compound(trimmed, &compiled, &normalized_prefixes)
+    rewrite_compound(trimmed, &compiled, &normalized_prefixes, 0)
 }
 
 /// Rewrite a compound command (with `&&`, `||`, `;`, `|`) by rewriting each segment.
@@ -600,6 +602,7 @@ fn rewrite_compound(
     cmd: &str,
     excluded: &[ExcludePattern],
     transparent_prefixes: &[String],
+    shell_wrapper_depth: usize,
 ) -> Option<String> {
     let tokens = tokenize(cmd);
     let mut result = String::with_capacity(cmd.len() + 32);
@@ -613,8 +616,9 @@ fn rewrite_compound(
         match tok.kind {
             TokenKind::Operator => {
                 let seg = cmd[seg_start..tok.offset].trim();
-                let rewritten = rewrite_segment(seg, excluded, transparent_prefixes)
-                    .unwrap_or_else(|| seg.to_string());
+                let rewritten =
+                    rewrite_segment(seg, excluded, transparent_prefixes, shell_wrapper_depth)
+                        .unwrap_or_else(|| seg.to_string());
                 if rewritten != seg {
                     any_changed = true;
                 }
@@ -644,7 +648,7 @@ fn rewrite_compound(
                 let rewritten = if is_pipe_incompatible {
                     seg.to_string()
                 } else {
-                    rewrite_segment(seg, excluded, transparent_prefixes)
+                    rewrite_segment(seg, excluded, transparent_prefixes, shell_wrapper_depth)
                         .unwrap_or_else(|| seg.to_string())
                 };
                 if rewritten != seg {
@@ -673,8 +677,9 @@ fn rewrite_compound(
             }
             TokenKind::Shellism if tok.value == "&" => {
                 let seg = cmd[seg_start..tok.offset].trim();
-                let rewritten = rewrite_segment(seg, excluded, transparent_prefixes)
-                    .unwrap_or_else(|| seg.to_string());
+                let rewritten =
+                    rewrite_segment(seg, excluded, transparent_prefixes, shell_wrapper_depth)
+                        .unwrap_or_else(|| seg.to_string());
                 if rewritten != seg {
                     any_changed = true;
                 }
@@ -690,8 +695,8 @@ fn rewrite_compound(
     }
 
     let seg = cmd[seg_start..].trim();
-    let rewritten =
-        rewrite_segment(seg, excluded, transparent_prefixes).unwrap_or_else(|| seg.to_string());
+    let rewritten = rewrite_segment(seg, excluded, transparent_prefixes, shell_wrapper_depth)
+        .unwrap_or_else(|| seg.to_string());
     if rewritten != seg {
         any_changed = true;
     }
@@ -791,8 +796,9 @@ fn rewrite_segment(
     seg: &str,
     excluded: &[ExcludePattern],
     transparent_prefixes: &[String],
+    shell_wrapper_depth: usize,
 ) -> Option<String> {
-    rewrite_segment_inner(seg, excluded, transparent_prefixes, 0)
+    rewrite_segment_inner(seg, excluded, transparent_prefixes, 0, shell_wrapper_depth)
 }
 
 fn is_excluded(cmd: &str, excluded: &[ExcludePattern]) -> bool {
@@ -807,6 +813,7 @@ fn rewrite_segment_inner(
     excluded: &[ExcludePattern],
     transparent_prefixes: &[String],
     depth: usize,
+    shell_wrapper_depth: usize,
 ) -> Option<String> {
     let trimmed = seg.trim();
     if trimmed.is_empty() {
@@ -815,6 +822,14 @@ fn rewrite_segment_inner(
 
     if depth >= MAX_PREFIX_DEPTH {
         return None;
+    }
+
+    if depth == 0 && shell_wrapper_depth < MAX_SHELL_WRAPPER_DEPTH {
+        if let Some(rewritten) =
+            rewrite_shell_wrapper(trimmed, excluded, transparent_prefixes, shell_wrapper_depth)
+        {
+            return Some(rewritten);
+        }
     }
 
     let (env_prefix, rest_after_env) = strip_disabled_prefix(trimmed);
@@ -828,8 +843,13 @@ fn rewrite_segment_inner(
             );
             return None;
         }
-        let rewritten =
-            rewrite_segment_inner(rest_after_env, excluded, transparent_prefixes, depth + 1)?;
+        let rewritten = rewrite_segment_inner(
+            rest_after_env,
+            excluded,
+            transparent_prefixes,
+            depth + 1,
+            shell_wrapper_depth,
+        )?;
         return Some(format!("{}{}", env_prefix, rewritten));
     }
 
@@ -838,8 +858,14 @@ fn rewrite_segment_inner(
             if rest.is_empty() {
                 return None;
             }
-            return rewrite_segment_inner(rest, excluded, transparent_prefixes, depth + 1)
-                .map(|rewritten| format!("{} {}", prefix, rewritten));
+            return rewrite_segment_inner(
+                rest,
+                excluded,
+                transparent_prefixes,
+                depth + 1,
+                shell_wrapper_depth,
+            )
+            .map(|rewritten| format!("{} {}", prefix, rewritten));
         }
     }
 
@@ -850,8 +876,14 @@ fn rewrite_segment_inner(
             if rest.is_empty() {
                 return None;
             }
-            return rewrite_segment_inner(rest, excluded, transparent_prefixes, depth + 1)
-                .map(|rewritten| format!("{} {}", prefix, rewritten));
+            return rewrite_segment_inner(
+                rest,
+                excluded,
+                transparent_prefixes,
+                depth + 1,
+                shell_wrapper_depth,
+            )
+            .map(|rewritten| format!("{} {}", prefix, rewritten));
         }
     }
 
@@ -970,6 +1002,31 @@ fn rewrite_segment_inner(
     }
 
     None
+}
+
+fn rewrite_shell_wrapper(
+    command: &str,
+    excluded: &[ExcludePattern],
+    transparent_prefixes: &[String],
+    shell_wrapper_depth: usize,
+) -> Option<String> {
+    let wrapper = parse_shell_wrapper(command)?;
+    let script = wrapper.script(command)?;
+    if script.contains(['\n', '\r'])
+        || has_heredoc(script)
+        || script.contains("$((")
+        || contains_unattestable_construct(script)
+    {
+        return None;
+    }
+
+    let rewritten = rewrite_compound(
+        script,
+        excluded,
+        transparent_prefixes,
+        shell_wrapper_depth + 1,
+    )?;
+    wrapper.replace_script(command, &rewritten)
 }
 
 /// Strip a command prefix with word-boundary check.
@@ -4085,6 +4142,100 @@ mod tests {
         assert_eq!(
             rewrite_command_no_prefixes("noglob unknown_cmd --flag", &[]),
             None
+        );
+    }
+
+    // --- quoted shell wrapper tests ---
+
+    #[test]
+    fn test_shell_wrapper_rewrites_bash_command_string() {
+        assert_eq!(
+            rewrite_command_no_prefixes(r#"bash -c "head foo && grep -R bar .""#, &[]),
+            Some(r#"bash -c "rtk read foo && rtk grep -R bar .""#.into())
+        );
+    }
+
+    #[test]
+    fn test_shell_wrapper_rewrites_fish_portable_command_string() {
+        assert_eq!(
+            rewrite_command_no_prefixes("fish -c 'git status; cargo test'", &[]),
+            Some("fish -c 'rtk git status; rtk cargo test'".into())
+        );
+    }
+
+    #[test]
+    fn test_shell_wrapper_preserves_path_quotes_and_suffix_arguments() {
+        assert_eq!(
+            rewrite_command_no_prefixes("/bin/bash -c 'git status' command-name 'a b'", &[]),
+            Some("/bin/bash -c 'rtk git status' command-name 'a b'".into())
+        );
+    }
+
+    #[test]
+    fn test_shell_wrapper_supports_sh_zsh_and_horizontal_spacing() {
+        assert_eq!(
+            rewrite_command_no_prefixes("sh\t-c\t'git status'\tname", &[]),
+            Some("sh\t-c\t'rtk git status'\tname".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("zsh -c 'cargo test'", &[]),
+            Some("zsh -c 'rtk cargo test'".into())
+        );
+    }
+
+    #[test]
+    fn test_shell_wrapper_rewrites_inside_outer_compound_command() {
+        assert_eq!(
+            rewrite_command_no_prefixes(r#"bash -c "git status && cargo test" || git status"#, &[]),
+            Some(r#"bash -c "rtk git status && rtk cargo test" || rtk git status"#.into())
+        );
+    }
+
+    #[test]
+    fn test_shell_wrapper_applies_inner_exclusions() {
+        let excluded = vec!["git".to_string()];
+        assert_eq!(
+            rewrite_command_no_prefixes("bash -c 'git status; cargo test'", &excluded),
+            Some("bash -c 'git status; rtk cargo test'".into())
+        );
+    }
+
+    #[test]
+    fn test_shell_wrapper_preserves_fd_redirect() {
+        assert_eq!(
+            rewrite_command_no_prefixes("bash -c 'git status' 2>&1", &[]),
+            Some("bash -c 'rtk git status' 2>&1".into())
+        );
+    }
+
+    #[test]
+    fn test_shell_wrapper_rejects_unsafe_or_unsupported_scripts() {
+        for command in [
+            "bash -c 'git status $(whoami)'",
+            "bash -c 'git status > /tmp/out'",
+            "bash -c 'git status\ncargo test'",
+            "fish -c 'git status; and cargo test'",
+            "bash -lc 'git status'",
+            r#"bash -c "git status $HOME""#,
+            "command bash -c 'git status'",
+        ] {
+            assert_eq!(
+                rewrite_command_no_prefixes(command, &[]),
+                None,
+                "unsafe or unsupported wrapper must pass through: {command:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_shell_wrapper_does_not_rewrite_nested_wrapper() {
+        assert_eq!(
+            rewrite_command_no_prefixes("bash -c 'bash -c \"git status\"'", &[]),
+            None
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("bash -c 'git status && bash -c \"cargo test\"'", &[]),
+            Some("bash -c 'rtk git status && bash -c \"cargo test\"'".into())
         );
     }
 

--- a/src/discover/shell_wrapper.rs
+++ b/src/discover/shell_wrapper.rs
@@ -1,0 +1,291 @@
+//! Parses the conservative subset of quoted shell -c wrappers that RTK can rewrite.
+
+const SUPPORTED_SHELLS: &[&str] = &["sh", "bash", "zsh", "fish"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ShellWrapper {
+    script_start: usize,
+    script_end: usize,
+}
+
+impl ShellWrapper {
+    pub(crate) fn script<'a>(&self, command: &'a str) -> Option<&'a str> {
+        command.get(self.script_start..self.script_end)
+    }
+
+    pub(crate) fn replace_script(&self, command: &str, rewritten: &str) -> Option<String> {
+        let prefix = command.get(..self.script_start)?;
+        let suffix = command.get(self.script_end..)?;
+        let mut result = String::with_capacity(prefix.len() + rewritten.len() + suffix.len());
+        result.push_str(prefix);
+        result.push_str(rewritten);
+        result.push_str(suffix);
+        Some(result)
+    }
+}
+
+/// Recognize a quoted shell -c script without decoding or re-quoting it.
+///
+/// Double-quoted scripts are accepted only when the outer shell has no active
+/// expansion or escape to evaluate. Unsupported forms return None, leaving the
+/// original command untouched.
+pub(crate) fn parse_shell_wrapper(command: &str) -> Option<ShellWrapper> {
+    let bytes = command.as_bytes();
+    if bytes.contains(&b'\0') {
+        return None;
+    }
+    let shell_end = supported_shell_end(command)?;
+
+    let mut position = skip_horizontal_space(bytes, shell_end);
+    if bytes.get(position..position + 2)? != b"-c" {
+        return None;
+    }
+    position += 2;
+    if !bytes
+        .get(position)
+        .is_some_and(|byte| is_horizontal_space(*byte))
+    {
+        return None;
+    }
+
+    position = skip_horizontal_space(bytes, position);
+    let quote = *bytes.get(position)?;
+    if !matches!(quote, b'\'' | b'"') {
+        return None;
+    }
+
+    let script_start = position + 1;
+    let script_end = find_script_end(bytes, script_start, quote)?;
+    if script_start == script_end {
+        return None;
+    }
+
+    let after_quote = script_end + 1;
+    if bytes
+        .get(after_quote)
+        .is_some_and(|byte| !is_horizontal_space(*byte))
+    {
+        return None;
+    }
+
+    Some(ShellWrapper {
+        script_start,
+        script_end,
+    })
+}
+
+/// Detect a supported shell whose option list requests command-string mode,
+/// including forms that the strict rewrite parser intentionally rejects.
+pub(crate) fn is_shell_wrapper_candidate(command: &str) -> bool {
+    let Some(shell_end) = supported_shell_end(command) else {
+        return false;
+    };
+    let rest_start = skip_horizontal_space(command.as_bytes(), shell_end);
+    let Some(rest) = command.get(rest_start..) else {
+        return false;
+    };
+
+    for option in rest.split_ascii_whitespace() {
+        if option == "--" || !option.starts_with('-') {
+            return false;
+        }
+        if option == "--command"
+            || option
+                .strip_prefix('-')
+                .is_some_and(|flags| !flags.starts_with('-') && flags.contains('c'))
+        {
+            return true;
+        }
+    }
+    false
+}
+
+fn supported_shell_end(command: &str) -> Option<usize> {
+    let shell_end = command
+        .as_bytes()
+        .iter()
+        .position(|byte| is_horizontal_space(*byte))?;
+    let shell = command.get(..shell_end)?;
+    let basename = shell.rsplit(['/', '\\']).next()?;
+    SUPPORTED_SHELLS.contains(&basename).then_some(shell_end)
+}
+
+fn is_horizontal_space(byte: u8) -> bool {
+    matches!(byte, b' ' | b'\t')
+}
+
+fn skip_horizontal_space(bytes: &[u8], mut position: usize) -> usize {
+    while bytes
+        .get(position)
+        .is_some_and(|byte| is_horizontal_space(*byte))
+    {
+        position += 1;
+    }
+    position
+}
+
+fn find_script_end(bytes: &[u8], start: usize, quote: u8) -> Option<usize> {
+    for (offset, byte) in bytes.get(start..)?.iter().copied().enumerate() {
+        if byte == quote {
+            return Some(start + offset);
+        }
+        if matches!(byte, b'\0' | b'\n' | b'\r') {
+            return None;
+        }
+        if quote == b'"' && matches!(byte, b'$' | b'\x60' | b'\\') {
+            return None;
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parsed_script(command: &str) -> Option<&str> {
+        parse_shell_wrapper(command)?.script(command)
+    }
+
+    #[test]
+    fn test_parse_shell_wrapper_double_quoted_bash() {
+        assert_eq!(
+            parsed_script(r#"bash -c "head foo && grep -R bar .""#),
+            Some("head foo && grep -R bar .")
+        );
+    }
+
+    #[test]
+    fn test_parse_shell_wrapper_single_quoted_fish() {
+        assert_eq!(
+            parsed_script("fish -c 'git status; cargo test'"),
+            Some("git status; cargo test")
+        );
+    }
+
+    #[test]
+    fn test_parse_shell_wrapper_preserves_unicode_and_suffix() {
+        let command = "/bin/bash -c 'printf 日本語' command-name 'a b'";
+        let wrapper = parse_shell_wrapper(command).expect("wrapper should parse");
+        assert_eq!(wrapper.script(command), Some("printf 日本語"));
+        assert_eq!(
+            wrapper.replace_script(command, "rtk printf 日本語"),
+            Some("/bin/bash -c 'rtk printf 日本語' command-name 'a b'".into())
+        );
+    }
+
+    #[test]
+    fn test_parse_shell_wrapper_accepts_inner_expansion_in_single_quotes() {
+        assert_eq!(
+            parsed_script("bash -c 'printf \"%s\\n\" \"$HOME\"'"),
+            Some("printf \"%s\\n\" \"$HOME\"")
+        );
+    }
+
+    #[test]
+    fn test_parse_shell_wrapper_rejects_unsupported_shapes() {
+        for command in [
+            "bash -c git status",
+            "bash -c ''",
+            "bash -c 'git status",
+            "bash -c 'git'\" status\"",
+            "bash -lc 'git status'",
+            "bash -e -c 'git status'",
+            "python -c 'git status'",
+            "command bash -c 'git status'",
+            "bash\n-c 'git status'",
+            "bash -c 'git\0status'",
+        ] {
+            assert!(
+                parse_shell_wrapper(command).is_none(),
+                "unsupported wrapper must be rejected: {command:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_shell_wrapper_spans_are_valid_for_malformed_corpus() {
+        let corpus = [
+            "",
+            "日",
+            "bash",
+            "bash ",
+            "bash -",
+            "bash -c",
+            "bash -c ",
+            "bash -c '",
+            "bash -c '日",
+            "bash -c '日本語'",
+            "bash -c \"日本語\"",
+        ];
+
+        for input in corpus {
+            for end in input
+                .char_indices()
+                .map(|(index, _)| index)
+                .chain(std::iter::once(input.len()))
+            {
+                let candidate = &input[..end];
+                if let Some(wrapper) = parse_shell_wrapper(candidate) {
+                    assert!(wrapper.script(candidate).is_some());
+                    assert!(wrapper
+                        .replace_script(candidate, "rtk git status")
+                        .is_some());
+                }
+            }
+        }
+
+        let long_script = format!("bash -c '{}'", "日".repeat(32_768));
+        let wrapper = parse_shell_wrapper(&long_script).expect("long script should parse");
+        assert_eq!(
+            wrapper
+                .script(&long_script)
+                .map(|script| script.chars().count()),
+            Some(32_768)
+        );
+        assert!(wrapper
+            .replace_script(&long_script, "rtk git status")
+            .is_some());
+    }
+
+    #[test]
+    fn test_parse_shell_wrapper_rejects_active_double_quote_expansion() {
+        for command in [
+            r#"bash -c "git status $HOME""#,
+            r#"bash -c "git status $(whoami)""#,
+            "bash -c \"git status \x60whoami\x60\"",
+            r#"bash -c "printf \"escaped\"""#,
+        ] {
+            assert!(
+                parse_shell_wrapper(command).is_none(),
+                "active outer expansion must be rejected: {command:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_shell_wrapper_candidate_includes_unsupported_command_options() {
+        for command in [
+            "bash -c 'git status'",
+            "bash -lc 'git status'",
+            "bash -e -c 'git status'",
+            "fish --command 'git status'",
+            "/bin/zsh -fc 'git status'",
+        ] {
+            assert!(
+                is_shell_wrapper_candidate(command),
+                "command-string wrapper must be recognized: {command:?}"
+            );
+        }
+        for command in [
+            "bash script.sh",
+            "python -c 'git status'",
+            "bash -- script.sh",
+        ] {
+            assert!(
+                !is_shell_wrapper_candidate(command),
+                "non-wrapper must not be recognized: {command:?}"
+            );
+        }
+    }
+}

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -73,6 +73,13 @@ Deny > Ask > Allow (explicit) > Default (ask)
 
 Rules are loaded from all Claude Code `settings.json` files (project + global, including `.local` variants). Only `Bash(...)` rules are extracted; other scopes (Read, Write) are ignored.
 
+Quoted `sh -c`, `bash -c`, `zsh -c`, and `fish -c` scripts add a
+second command-parsing boundary. RTK checks deny rules against both the outer
+wrapper and the parsed inner segments. A wrapper rewrite is never auto-allowed:
+its strongest RTK verdict is `Ask`. Ask-capable hosts prompt, while other
+hosts retain their existing native permission flow. Unsupported or ambiguous
+wrapper syntax is left unchanged for the host to evaluate.
+
 | Verdict | Trigger | rewrite_cmd exit | Hook behavior |
 |---------|---------|-----------------|---------------|
 | Deny | `permissions.deny` rule matched | 2 | Passthrough — host tool handles denial |
@@ -96,6 +103,7 @@ Rules are loaded from all Claude Code `settings.json` files (project + global, i
 - `permissions.rs` — loads deny/ask/allow rules, evaluates precedence, returns `PermissionVerdict`
 - `rewrite_cmd.rs` — maps verdict to exit code (consumed by shell hook)
 - `hook_cmd.rs` — maps verdict to JSON `permissionDecision` field (Copilot/Gemini)
+- `discover/shell_wrapper.rs` — shares conservative script-span parsing between rewrite and permission checks
 
 ## Exit Code Contract
 

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -790,6 +790,23 @@ mod tests {
     }
 
     #[test]
+    fn test_copilot_cli_shell_wrapper_rewrites_without_auto_allow() {
+        let command = "bash -c 'git status; cargo test'";
+        let verdict = permissions::check_command_with_rules(command, &[], &[], &["*".to_string()]);
+        let response = copilot_cli_response_from_decision(
+            &cli_args(command),
+            decide_from_verdict(command, verdict),
+            command,
+        )
+        .expect("wrapper rewrite expected");
+        assert_eq!(
+            response["modifiedArgs"]["command"],
+            "bash -c 'rtk git status; rtk cargo test'"
+        );
+        assert!(response.get("permissionDecision").is_none());
+    }
+
+    #[test]
     fn test_copilot_cli_deny_returns_none() {
         assert!(copilot_cli_response_from_decision(
             &cli_args("cargo test"),
@@ -1046,6 +1063,19 @@ mod tests {
     }
 
     #[test]
+    fn test_claude_shell_wrapper_rewrites_without_auto_allow() {
+        let result = run_claude_inner(&claude_input(r#"bash -c "head foo && grep -R bar .""#))
+            .expect("wrapper rewrite expected");
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let output = &v["hookSpecificOutput"];
+        assert_eq!(
+            output["updatedInput"]["command"],
+            r#"bash -c "rtk read foo && rtk grep -R bar .""#
+        );
+        assert!(output.get("permissionDecision").is_none());
+    }
+
+    #[test]
     fn test_claude_passthrough_no_output() {
         assert!(run_claude_inner(&claude_input("htop")).is_none());
     }
@@ -1179,6 +1209,17 @@ mod tests {
         // `continue: true` keeps the Cursor preToolUse panel from collapsing
         // to `Output: {}`; without it the rewrite is invisible to users.
         assert_eq!(v["continue"], true);
+    }
+
+    #[test]
+    fn test_cursor_shell_wrapper_rewrites_without_auto_allow() {
+        let result = run_cursor_allowed(&cursor_input(r#"bash -c "git status && cargo test""#));
+        let v: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(v["permission"], "ask");
+        assert_eq!(
+            v["updated_input"]["command"],
+            r#"bash -c "rtk git status && rtk cargo test""#
+        );
     }
 
     #[test]
@@ -1424,6 +1465,21 @@ mod tests {
     }
 
     #[test]
+    fn test_decide_asks_for_allowed_shell_wrapper_rewrite() {
+        match decide_with_rules(
+            r#"bash -c "head foo && grep -R bar .""#,
+            &[],
+            &[],
+            &all_allowed(),
+        ) {
+            HookDecision::AskRewrite(rewritten) => {
+                assert_eq!(rewritten, r#"bash -c "rtk read foo && rtk grep -R bar .""#)
+            }
+            _ => panic!("supported shell wrapper must rewrite with confirmation"),
+        }
+    }
+
+    #[test]
     fn test_decide_deny() {
         assert!(matches!(
             decide_with_rules(
@@ -1500,6 +1556,22 @@ mod tests {
     }
 
     #[test]
+    fn test_gemini_shell_wrapper_asks_user_with_rewrite() {
+        let v: Value = serde_json::from_str(&gemini_render(
+            r#"fish -c "git status && cargo test""#,
+            &[],
+            &[],
+            &all_allowed(),
+        ))
+        .unwrap();
+        assert_eq!(v["decision"], "ask_user");
+        assert_eq!(
+            v["hookSpecificOutput"]["tool_input"]["command"],
+            r#"fish -c "rtk git status && rtk cargo test""#
+        );
+    }
+
+    #[test]
     fn test_gemini_substitution_asks_user_without_rewrite() {
         let v: Value = serde_json::from_str(&gemini_render(
             "git status `rm -rf /tmp/x`",
@@ -1561,6 +1633,21 @@ mod tests {
                 .is_none(),
             "RTK must never assert a permission decision for Droid"
         );
+    }
+
+    #[test]
+    fn test_droid_shell_wrapper_rewrites_without_permission_decision() {
+        let input = droid_input("Execute", "bash -c 'git status; cargo test'");
+        let out = run_droid_inner(&input).expect("rewrite expected");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(
+            v.pointer("/hookSpecificOutput/updatedInput/command")
+                .and_then(Value::as_str),
+            Some("bash -c 'rtk git status; rtk cargo test'")
+        );
+        assert!(v
+            .pointer("/hookSpecificOutput/permissionDecision")
+            .is_none());
     }
 
     #[test]

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -1060,6 +1060,12 @@ mod tests {
     }
 
     #[test]
+    fn test_claude_fish_constructs_not_rewritten() {
+        assert!(run_claude_inner(&claude_input("git status (printf x)")).is_none());
+        assert!(run_claude_inner(&claude_input("git status; and printf x")).is_none());
+    }
+
+    #[test]
     fn test_claude_file_redirect_not_rewritten() {
         assert!(run_claude_inner(&claude_input("git log > /tmp/out.txt")).is_none());
     }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -5610,6 +5610,18 @@ mod tests {
     }
 
     #[test]
+    fn test_codex_awareness_documents_explicit_shell_selection() {
+        assert!(
+            RTK_SLIM_CODEX.contains("rtk run --shell fish -c '<script>'"),
+            "Codex awareness must document explicit fish shell selection"
+        );
+        assert!(
+            RTK_SLIM_CODEX.contains("host may evaluate a command before RTK starts"),
+            "Codex awareness must preserve the host-shell caveat"
+        );
+    }
+
+    #[test]
     fn test_resolve_codex_dir_prefers_codex_home_and_ignores_empty_value() {
         let codex_home = PathBuf::from("/tmp/custom-codex-home");
         let home_dir = PathBuf::from("/tmp/home");

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -4,6 +4,7 @@ use super::constants::{
 };
 use crate::core::stream::exec_capture;
 use crate::discover::lexer::split_for_permissions;
+use crate::discover::shell_wrapper::{is_shell_wrapper_candidate, parse_shell_wrapper};
 use serde_json::Value;
 use std::path::PathBuf;
 
@@ -67,6 +68,10 @@ pub(crate) fn check_command_with_rules(
         }
     }
 
+    if let Some(verdict) = check_shell_wrapper_permissions(&segments, deny_rules) {
+        return verdict;
+    }
+
     // Can't decompose substitution / file-target redirects — never auto-allow.
     if crate::discover::lexer::contains_unattestable_construct(cmd) {
         return PermissionVerdict::Ask;
@@ -117,6 +122,36 @@ pub(crate) fn check_command_with_rules(
     } else {
         PermissionVerdict::Default
     }
+}
+
+fn check_shell_wrapper_permissions(
+    segments: &[&str],
+    deny_rules: &[String],
+) -> Option<PermissionVerdict> {
+    let mut contains_shell_wrapper = false;
+    for segment in segments {
+        let segment = segment.trim();
+        let Some(wrapper) = parse_shell_wrapper(segment) else {
+            contains_shell_wrapper |= is_shell_wrapper_candidate(segment);
+            continue;
+        };
+        let Some(script) = wrapper.script(segment) else {
+            return Some(PermissionVerdict::Ask);
+        };
+        contains_shell_wrapper = true;
+        let inner_denied = split_for_permissions(script).iter().any(|inner_segment| {
+            deny_rules
+                .iter()
+                .any(|pattern| command_matches_pattern(inner_segment.trim(), pattern))
+        });
+        if inner_denied {
+            return Some(PermissionVerdict::Deny);
+        }
+    }
+
+    // A quoted shell script hides a second parsing boundary from the host rule.
+    // Rewriting it is useful, but RTK must never turn that into auto-approval.
+    contains_shell_wrapper.then_some(PermissionVerdict::Ask)
 }
 
 /// Load deny, ask, and allow Bash rules from all Claude Code settings files.
@@ -938,6 +973,61 @@ mod tests {
                 "{cmd} must not auto-allow"
             );
         }
+    }
+
+    #[test]
+    fn test_shell_wrapper_never_auto_allowed() {
+        let allow = vec!["*".to_string()];
+        assert_eq!(
+            check_command_with_rules(r#"bash -c "head foo && grep -R bar .""#, &[], &[], &allow),
+            PermissionVerdict::Ask
+        );
+    }
+
+    #[test]
+    fn test_shell_wrapper_inner_deny_wins() {
+        let deny = vec!["rm:*".to_string()];
+        let allow = vec!["*".to_string()];
+        assert_eq!(
+            check_command_with_rules(
+                "bash -c 'git status; rm -rf /tmp/example'",
+                &deny,
+                &[],
+                &allow
+            ),
+            PermissionVerdict::Deny
+        );
+    }
+
+    #[test]
+    fn test_unsupported_shell_wrapper_candidate_never_auto_allowed() {
+        let allow = vec!["*".to_string()];
+        for command in [
+            "bash -lc 'git status'",
+            "bash -e -c 'git status'",
+            "fish --command 'git status'",
+        ] {
+            assert_eq!(
+                check_command_with_rules(command, &[], &[], &allow),
+                PermissionVerdict::Ask,
+                "unsupported command-string wrapper must ask: {command:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_shell_wrapper_inner_deny_wins_inside_outer_compound() {
+        let deny = vec!["rm:*".to_string()];
+        let allow = vec!["*".to_string()];
+        assert_eq!(
+            check_command_with_rules(
+                "bash -c 'git status; rm -rf /tmp/example' && cargo test",
+                &deny,
+                &[],
+                &allow
+            ),
+            PermissionVerdict::Deny
+        );
     }
 
     #[test]

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -929,6 +929,18 @@ mod tests {
     }
 
     #[test]
+    fn test_fish_constructs_never_auto_allowed() {
+        let allow = vec!["*".to_string()];
+        for cmd in ["git status (printf x)", "git status; and printf x"] {
+            assert_eq!(
+                check_command_with_rules(cmd, &[], &[], &allow),
+                PermissionVerdict::Ask,
+                "{cmd} must not auto-allow"
+            );
+        }
+    }
+
+    #[test]
     fn test_double_quoted_substitution_never_auto_allowed() {
         let allow = vec!["git *".to_string()];
         for cmd in [
@@ -972,11 +984,11 @@ mod tests {
     }
 
     #[test]
-    fn test_legitimate_subshell_allow() {
+    fn test_subshell_requires_confirmation() {
         let allow = vec!["git *".to_string(), "cargo *".to_string()];
         assert_eq!(
             check_command_with_rules("(git status; cargo build)", &[], &[], &allow),
-            PermissionVerdict::Allow
+            PermissionVerdict::Ask
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -218,6 +218,9 @@ enum Commands {
 
     /// Run command and show only errors/warnings
     Err {
+        /// Execute one quoted command string with this shell instead of direct argv execution
+        #[arg(long, value_name = "SHELL")]
+        shell: Option<String>,
         /// Command to run
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         command: Vec<String>,
@@ -225,6 +228,9 @@ enum Commands {
 
     /// Run tests and show only failures
     Test {
+        /// Execute one quoted command string with this shell instead of direct argv execution
+        #[arg(long, value_name = "SHELL")]
+        shell: Option<String>,
         /// Test command (e.g. cargo test)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         command: Vec<String>,
@@ -303,6 +309,9 @@ enum Commands {
 
     /// Run command and show heuristic summary
     Summary {
+        /// Execute one quoted command string with this shell instead of direct argv execution
+        #[arg(long, value_name = "SHELL")]
+        shell: Option<String>,
         /// Command to run and summarize
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         command: Vec<String>,
@@ -626,12 +635,20 @@ enum Commands {
         min_occurrences: usize,
     },
 
-    /// Execute a shell command via sh -c (raw, no filtering or tracking)
+    /// Execute argv directly, or a command string through an explicit shell
     Run {
-        /// Command string to execute (use -c for shell-like invocation)
-        #[arg(short = 'c', long = "command")]
+        /// Command string to execute through a shell
+        #[arg(short = 'c', long = "command", conflicts_with = "args")]
         command: Option<String>,
-        /// Positional command arguments (alternative to -c)
+        /// Shell used with -c (defaults to sh on Unix and cmd on Windows)
+        #[arg(
+            long,
+            value_name = "SHELL",
+            requires = "command",
+            conflicts_with = "args"
+        )]
+        shell: Option<String>,
+        /// Program and literal arguments for direct execution (alternative to -c)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -1808,14 +1825,14 @@ fn run_cli() -> Result<i32> {
             }
         }
 
-        Commands::Err { command } => {
-            let cmd = command.join(" ");
-            runner::run_err(&cmd, cli.verbose)?
+        Commands::Err { shell, command } => {
+            runner::run_err(&command, shell.as_deref(), cli.verbose)
+                .context("Failed to run err command")?
         }
 
-        Commands::Test { command } => {
-            let cmd = command.join(" ");
-            runner::run_test(&cmd, cli.verbose)?
+        Commands::Test { shell, command } => {
+            runner::run_test(&command, shell.as_deref(), cli.verbose)
+                .context("Failed to run test command")?
         }
 
         Commands::Json {
@@ -1936,9 +1953,9 @@ fn run_cli() -> Result<i32> {
             OcCommands::Other(args) => container::run_oc_passthrough(&args, cli.verbose)?,
         },
 
-        Commands::Summary { command } => {
-            let cmd = command.join(" ");
-            summary::run(&cmd, cli.verbose)?
+        Commands::Summary { shell, command } => {
+            summary::run(&command, shell.as_deref(), cli.verbose)
+                .context("Failed to run summary command")?
         }
 
         Commands::Grep {
@@ -2432,23 +2449,33 @@ fn run_cli() -> Result<i32> {
             0
         }
 
-        Commands::Run { command, args } => {
-            let raw = match command {
-                Some(c) => c,
-                None if !args.is_empty() => args.join(" "),
-                None => String::new(),
-            };
-            if raw.trim().is_empty() {
+        Commands::Run {
+            command,
+            shell,
+            args,
+        } => {
+            if command
+                .as_deref()
+                .is_none_or(|script| script.trim().is_empty())
+                && args.is_empty()
+            {
                 0
             } else {
-                use std::process::Command as ProcCommand;
-                let shell = if cfg!(windows) { "cmd" } else { "sh" };
-                let flag = if cfg!(windows) { "/C" } else { "-c" };
-                let status = ProcCommand::new(shell)
-                    .arg(flag)
-                    .arg(&raw)
+                let (mut prepared, description) = match command {
+                    Some(script) => (
+                        core::shell::shell_command(&script, shell.as_deref())
+                            .context("Failed to prepare run shell command")?,
+                        format!("shell command: {script}"),
+                    ),
+                    None => (
+                        core::shell::direct_command(&args)
+                            .context("Failed to prepare direct run command")?,
+                        core::shell::display_args(&args),
+                    ),
+                };
+                let status = prepared
                     .status()
-                    .with_context(|| format!("Failed to execute: {}", raw))?;
+                    .with_context(|| format!("Failed to execute {description}"))?;
                 core::utils::exit_code_from_status(&status, "run")
             }
         }
@@ -3135,8 +3162,13 @@ mod tests {
     fn test_run_command_with_dash_c() {
         let cli = Cli::try_parse_from(["rtk", "run", "-c", "git status && echo done"]).unwrap();
         match cli.command {
-            Commands::Run { command, args } => {
+            Commands::Run {
+                command,
+                shell,
+                args,
+            } => {
                 assert_eq!(command, Some("git status && echo done".to_string()));
+                assert!(shell.is_none());
                 assert!(args.is_empty());
             }
             _ => panic!("Expected Run command"),
@@ -3147,12 +3179,40 @@ mod tests {
     fn test_run_command_positional_args() {
         let cli = Cli::try_parse_from(["rtk", "run", "echo", "hello"]).unwrap();
         match cli.command {
-            Commands::Run { command, args } => {
+            Commands::Run {
+                command,
+                shell,
+                args,
+            } => {
                 assert!(command.is_none());
+                assert!(shell.is_none());
                 assert_eq!(args, vec!["echo", "hello"]);
             }
             _ => panic!("Expected Run command"),
         }
+    }
+
+    #[test]
+    fn test_run_command_with_explicit_shell() {
+        let cli =
+            Cli::try_parse_from(["rtk", "run", "--shell", "fish", "-c", "echo (pwd)"]).unwrap();
+        match cli.command {
+            Commands::Run {
+                command,
+                shell,
+                args,
+            } => {
+                assert_eq!(command, Some("echo (pwd)".to_string()));
+                assert_eq!(shell, Some("fish".to_string()));
+                assert!(args.is_empty());
+            }
+            _ => panic!("Expected Run command"),
+        }
+    }
+
+    #[test]
+    fn test_run_shell_requires_command_string() {
+        assert!(Cli::try_parse_from(["rtk", "run", "--shell", "fish", "echo"]).is_err());
     }
 
     #[test]

--- a/tests/rewrite_shell_wrapper_test.rs
+++ b/tests/rewrite_shell_wrapper_test.rs
@@ -1,0 +1,46 @@
+use std::process::{Command, Output};
+
+fn rewrite(command: &str) -> Output {
+    let home = tempfile::tempdir().expect("create isolated home");
+    Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args(["rewrite", command])
+        .current_dir(home.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path())
+        .env("RTK_TELEMETRY_DISABLED", "1")
+        .output()
+        .expect("run rtk rewrite")
+}
+
+#[test]
+fn bash_command_string_rewrites_inner_commands() {
+    let output = rewrite(r#"bash -c "head foo && grep -R bar .""#);
+
+    assert_eq!(output.status.code(), Some(3));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        r#"bash -c "rtk read foo && rtk grep -R bar .""#
+    );
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn fish_portable_command_string_rewrites_inner_commands() {
+    let output = rewrite("fish -c 'git status; cargo test'");
+
+    assert_eq!(output.status.code(), Some(3));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "fish -c 'rtk git status; rtk cargo test'"
+    );
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn unsafe_inner_script_passes_through_without_output() {
+    let output = rewrite("bash -c 'git status $(whoami)'");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+    assert!(output.stderr.is_empty());
+}

--- a/tests/run_shell_test.rs
+++ b/tests/run_shell_test.rs
@@ -1,0 +1,140 @@
+#[cfg(unix)]
+mod unix {
+    use std::process::Command;
+
+    fn rtk() -> Command {
+        Command::new(env!("CARGO_BIN_EXE_rtk"))
+    }
+
+    #[test]
+    fn positional_arguments_are_not_interpreted_by_a_shell() {
+        let output = rtk()
+            .args([
+                "run",
+                "/usr/bin/printf",
+                "[%s]\\n",
+                "a b",
+                "*",
+                "$HOME",
+                ";",
+                "&&",
+                "|",
+                "$(printf injected)",
+                "`id`",
+                "line1\nline2",
+            ])
+            .output()
+            .expect("run rtk");
+
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout),
+            "[a b]\n[*]\n[$HOME]\n[;]\n[&&]\n[|]\n[$(printf injected)]\n[`id`]\n[line1\nline2]\n"
+        );
+    }
+
+    #[test]
+    fn direct_execution_preserves_child_exit_code() {
+        let status = rtk()
+            .args(["run", "/bin/sh", "-c", "exit 42"])
+            .status()
+            .expect("run rtk");
+
+        assert_eq!(status.code(), Some(42));
+    }
+
+    #[test]
+    fn command_string_keeps_posix_shell_default() {
+        let output = rtk()
+            .args([
+                "run",
+                "-c",
+                "value=$(printf posix_ok); printf '%s\\n' \"$value\"",
+            ])
+            .output()
+            .expect("run rtk");
+
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "posix_ok\n");
+    }
+
+    #[test]
+    fn explicit_fish_shell_runs_fish_syntax_when_available() {
+        let Ok(fish) = which::which("fish") else {
+            return;
+        };
+        let output = rtk()
+            .args([
+                "run",
+                "--shell",
+                fish.to_str().expect("fish path is UTF-8"),
+                "-c",
+                "set value (printf fish_ok); printf '%s\\n' $value",
+            ])
+            .output()
+            .expect("run rtk");
+
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "fish_ok\n");
+    }
+
+    #[test]
+    fn explicit_missing_shell_reports_actionable_error() {
+        let output = rtk()
+            .args([
+                "run",
+                "--shell",
+                "rtk-missing-shell-for-test",
+                "-c",
+                "echo ok",
+            ])
+            .output()
+            .expect("run rtk");
+
+        assert!(!output.status.success());
+        assert!(String::from_utf8_lossy(&output.stderr)
+            .contains("Shell 'rtk-missing-shell-for-test' not found"));
+    }
+
+    #[test]
+    fn summary_arguments_are_not_interpreted_by_a_shell() {
+        let output = rtk()
+            .args(["summary", "/bin/echo", "*"])
+            .output()
+            .expect("run rtk summary");
+
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "*\n\n\n");
+    }
+
+    #[test]
+    fn filtered_wrapper_accepts_one_explicit_shell_script() {
+        let Ok(fish) = which::which("fish") else {
+            return;
+        };
+        let output = rtk()
+            .args([
+                "err",
+                "--shell",
+                fish.to_str().expect("fish path is UTF-8"),
+                "printf 'error: fish_ok\\n'",
+            ])
+            .output()
+            .expect("run rtk err");
+
+        assert!(output.status.success());
+        assert!(String::from_utf8_lossy(&output.stdout).contains("error: fish_ok"));
+    }
+
+    #[test]
+    fn filtered_wrapper_rejects_reconstructed_shell_arguments() {
+        let output = rtk()
+            .args(["err", "--shell", "sh", "printf", "error: split"])
+            .output()
+            .expect("run rtk err");
+
+        assert!(!output.status.success());
+        assert!(String::from_utf8_lossy(&output.stderr)
+            .contains("pass the shell command as one quoted argument after --shell"));
+    }
+}


### PR DESCRIPTION
## Summary

This pull request makes RTK's shell boundary explicit across CLI execution and hook rewriting. Generic runners now preserve argv through direct execution, intentional scripts require an explicit command-string mode, ambiguous shell syntax defers unchanged, and exact quoted `sh`, `bash`, `zsh`, and `fish` wrappers can safely rewrite portable inner commands.

This addresses four related limitations in the current execution model:

- `rtk run`, `rtk err`, `rtk test`, and `rtk summary` rebuilt positional arguments with spaces and executed the result through `sh -c` on Unix or `cmd /C` on Windows, which lost argument boundaries and enabled unintended shell expansion.
- Agent hosts can expose a fish login shell through `$SHELL` while evaluating commands with zsh or a POSIX-compatible shell, so guessing the parser from the environment is unreliable.
- The hook safety gate recognized POSIX substitutions but previously missed bare fish command substitution and command-position fish control keywords, allowing uncertain input to be rewritten or auto-allowed.
- Quoted command strings such as `bash -c "head foo && grep -R bar ."` were treated as opaque wrapper arguments, so the portable commands inside them could not use RTK rewrites as reported in #2767.

The host still owns the shell that evaluates hook output. This change makes RTK's own execution and rewrite boundaries explicit; it does not translate syntax between fish, zsh, and POSIX shells or change the host executor.

### Execution model and migration

The updated CLI separates direct argv execution from intentional command-string execution:

- Positional forms such as `rtk run <cmd> [args...]`, `rtk err <cmd> [args...]`, `rtk test <cmd> [args...]`, and `rtk summary <cmd> [args...]` execute the supplied program directly and preserve every argument boundary.
- `rtk run -c '<script>'` retains the existing platform default of `sh -c` on Unix and `cmd /C` on Windows.
- `rtk run --shell fish -c '<script>'` selects a shell explicitly. PowerShell and `pwsh` use `-Command`; other named shells use `-c`.
- `rtk err`, `rtk test`, and `rtk summary` accept `--shell <name> '<script>'` when filtering an intentional shell command.
- Explicit shell mode requires the complete script as one quoted argument, preventing RTK from reconstructing quoting after Clap has parsed argv.
- Installed Codex guidance now recommends explicit `rtk run --shell <name> -c '<script>'` for shell-specific scripts and portable syntax otherwise.

This is a breaking behavior change for callers that relied on implicit shell expansion in positional arguments. Those callers must move shell syntax to `rtk run -c '<script>'` or use `--shell <name>` with one quoted script.

### Conservative hook handling

The shared lexer now treats the following forms as unattestable before rewrite and permission decisions:

- command and process substitution, including bare fish `(...)` syntax;
- parenthesized shell constructs and incomplete quoting or trailing escapes;
- file-target redirects;
- fish control keywords such as `and`, `or`, `if`, `switch`, and `end` when they occur at a command boundary.

Keyword detection is command-position aware, so ordinary arguments such as `rg and src` remain attestable. Ambiguous constructs defer to the host unchanged and resolve to `Ask` rather than `Allow`, even when a wildcard allow rule is configured.

### Quoted shell wrapper rewriting

The rewrite pipeline now recognizes a deliberately narrow command-string wrapper subset:

- Exact `sh -c`, `bash -c`, `zsh -c`, and `fish -c` wrappers are eligible when the script is one balanced single- or double-quoted argument.
- RTK rewrites the existing portable compound-command subset inside the script and replaces only the original script byte span, preserving the shell path, whitespace, quote delimiters, suffix arguments, and file-descriptor redirects.
- Double-quoted scripts are accepted only when the outer shell has no active `$` expansion, backticks, or backslash escapes to evaluate.
- Unquoted or malformed scripts, additional shell options, file redirects, fish-specific control syntax, and nested wrappers pass through unchanged.
- Wrapper rewriting is limited to one level and never grants automatic permission. Ask-capable hosts request confirmation, hosts without an explicit ask response preserve their native permission flow, and an inner deny rule takes precedence over an outer allow rule.

The wrapper parser is shared by rewriting and permission evaluation so the two paths cannot disagree about the supported boundary. Agent protocol tests cover Claude, Cursor, Gemini, Droid, and Copilot behavior.

### Key files changed

The following files are the main review entry points:

| File | Purpose |
|---|---|
| `src/core/shell.rs` | Centralizes direct command construction, explicit shell invocation, platform flags, shell resolution, and script-boundary validation. |
| `src/main.rs` | Adds the `--shell` CLI surface and routes positional commands through direct argv execution. |
| `src/discover/lexer.rs` | Detects parenthesized syntax, command-position control keywords, and incomplete quoting as unattestable. |
| `src/discover/shell_wrapper.rs` | Parses the conservative quoted `-c` wrapper subset and exposes byte spans without decoding or re-quoting scripts. |
| `src/discover/registry.rs` | Applies one-level inner compound rewrites while preserving the original wrapper and passthrough contract. |
| `src/hooks/permissions.rs` | Prevents wrapper auto-allow and evaluates inner deny rules before returning `Ask`. |
| `src/hooks/hook_cmd.rs` | Preserves each supported agent's rewrite and permission protocol for shell wrappers. |
| `hooks/codex/rtk-awareness.md` | Documents explicit shell selection for generated Codex RTK guidance. |
| `tests/run_shell_test.rs` | Covers literal argv preservation, exit codes, default and explicit shells, missing shells, and split-script rejection. |
| `tests/rewrite_shell_wrapper_test.rs` | Covers the issue example, portable fish scripts, conservative passthrough, output, and rewrite exit codes. |

## Test plan

- [x] Run `cargo fmt --all --check`.
- [x] Run `cargo clippy --all-targets -- -D warnings`.
- [x] Run focused shell-wrapper tests, including 27 parser, registry, permission, and agent protocol tests plus the 3 CLI integration tests in `tests/rewrite_shell_wrapper_test.rs`.
- [x] Run `env RIPGREP_CONFIG_PATH=/dev/null cargo test --all` (2,478 unit tests passed, 8 ignored; all integration suites passed).
- [x] Run `env RIPGREP_CONFIG_PATH=/dev/null cargo test --all -- --ignored --nocapture` (8 ignored integration tests passed).
- [x] Run `cargo build --release`.
- [x] Verify direct argv execution, explicit `sh`, `zsh`, and `fish` execution, and quoted `bash -c` and `fish -c` rewriting on macOS.
- [x] Verify ambiguous shell constructs pass through, wildcard allow rules cannot auto-allow wrappers, and inner deny rules take precedence.
- [x] Compare release size, resident memory, and repeated startup/rewrite timings with pre-change release binaries; no material regression was observed. The shell-wrapper change added 16 bytes, with peak memory remaining approximately 1.3 MB.
- [ ] Let CI validate Linux and Windows execution, including `cmd /C`, PowerShell flag selection, and platform-independent wrapper parsing.

The local ripgrep configuration injects `--max-columns=150`, which shortens the raw comparison output used by the existing `bulky_grep_yields_token_savings` test. The unsanitized `cargo test --all` run therefore fails that unrelated assertion; the complete suite passes when `RIPGREP_CONFIG_PATH` is cleared as shown above. This pull request does not change search behavior.

The broad `scripts/test-all.sh` suite was not run because it uses an installed binary and includes `git fetch`, external HTTP calls, and unrelated ecosystem commands.

🤖 Generated with [Codex](https://openai.com/codex/)
