### PR TITLE
feat(git): filter large git show blob dumps with recovery and Latin-1 decoding

### DIFF
--- a/src/cmds/dotnet/dotnet_cmd.rs
+++ b/src/cmds/dotnet/dotnet_cmd.rs
@@ -417,7 +417,7 @@ fn format_dotnet_format_output(
     }
 
     output.push_str(&format!(
-        "\n\nok {} files already formatted\nRun `dotnet format` to apply fixes",
+        "\n\nok {} files already formatted",
         summary.files_unchanged
     ));
     output
@@ -2646,7 +2646,6 @@ mod tests {
         let output = format_dotnet_format_output(&summary, true);
         assert!(output.contains("Format: 2 files need formatting"));
         assert!(output.contains("src/Program.cs (line 42, col 17, WHITESPACE)"));
-        assert!(output.contains("Run `dotnet format` to apply fixes"));
     }
 
     #[test]

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -232,11 +232,12 @@ fn run_show(
         .iter()
         .any(|arg| arg.starts_with("--pretty") || arg.starts_with("--format"));
 
-    // `git show rev:path` prints a blob, not a commit diff. In this mode we should
-    // pass through directly to avoid duplicated output from compact-show steps.
-    let wants_blob_show = args.iter().any(|arg| is_blob_show_arg(arg));
+    // `git show rev:path` prints a blob (file content), not a commit diff. A pathspec
+    // (`--`) keeps it a commit-diff, so that case is excluded from blob handling.
+    let blob_args: Vec<&String> = args.iter().filter(|a| is_blob_show_arg(a)).collect();
+    let wants_blob_show = !blob_args.is_empty() && !args.iter().any(|a| a == "--");
 
-    if wants_stat_only || wants_format || wants_blob_show {
+    if wants_stat_only || wants_format {
         let mut cmd = git_cmd(global_args);
         cmd.arg("show");
         for arg in args {
@@ -247,11 +248,7 @@ fn run_show(
             eprintln!("{}", result.stderr);
             return Ok(result.exit_code);
         }
-        if wants_blob_show {
-            print!("{}", result.stdout);
-        } else {
-            println!("{}", result.stdout.trim());
-        }
+        println!("{}", result.stdout.trim());
 
         timer.track(
             &format!("git show {}", args.join(" ")),
@@ -259,6 +256,58 @@ fn run_show(
             &result.stdout,
             &result.stdout,
         );
+
+        return Ok(0);
+    }
+
+    if wants_blob_show {
+        let mut cmd = git_cmd(global_args);
+        cmd.arg("show");
+        for arg in args {
+            cmd.arg(arg);
+        }
+        // Capture raw bytes: `git show` of an ISO-8859/Latin-1 file (e.g. Oracle
+        // PL/SQL `.pck`) is not UTF-8, and lossy decoding would corrupt accents into
+        // U+FFFD (`É` → `�`) and inflate the output. `decode_output` transcodes safe
+        // Latin-1 losslessly and passes true binary / ambiguous encodings through.
+        let result =
+            crate::core::stream::exec_capture_bytes(&mut cmd).context("Failed to run git show")?;
+        if !result.success() {
+            eprint!("{}", String::from_utf8_lossy(&result.stderr));
+            return Ok(result.exit_code);
+        }
+        let label = format!("git show {}", args.join(" "));
+        let rtk_label = format!("rtk git show {}", args.join(" "));
+        let text = match crate::core::stream::decode_output(&result.stdout) {
+            crate::core::stream::Decoded::Utf8(s) | crate::core::stream::Decoded::Latin1(s) => s,
+            // Binary or ambiguous single-byte encoding: never window or transcode —
+            // write the raw bytes through, tracked as a passthrough.
+            crate::core::stream::Decoded::Binary => {
+                return emit_raw_bytes_passthrough(
+                    &result.stdout,
+                    &label,
+                    &rtk_label,
+                    &timer,
+                    result.exit_code,
+                );
+            }
+        };
+        // A blob dump is unfiltered file content: cap large text blobs to a byte
+        // budget with a tail-recovery pointer, mirroring how the commit-diff path
+        // below caps at `max_lines`. `--max-lines` does not apply here — blob output
+        // is bounded by bytes, not lines. (Recovery for a transcoded Latin-1 blob is
+        // UTF-8-normalized text, not byte-identical to the on-disk ISO-8859 file.)
+        let raw = &text;
+        let shown = if blob_args.len() == 1 {
+            compact_blob_show(raw, blob_args[0])
+        } else {
+            // Multiple blob args are concatenated by git; don't risk cutting the
+            // second blob mid-stream — pass the composite through unchanged.
+            raw.clone()
+        };
+        print!("{}", shown);
+
+        timer.track(&label, &rtk_label, raw, &shown);
 
         return Ok(0);
     }
@@ -332,7 +381,97 @@ fn run_show(
 
 fn is_blob_show_arg(arg: &str) -> bool {
     // Detect `rev:path` style arguments while ignoring flags like `--pretty=format:...`.
-    !arg.starts_with('-') && arg.contains(':')
+    // `:/text` is a commit-message search, not a blob, so it is excluded. `:path` and
+    // `:N:path` (index / merge-stage blobs) start with `:` but ARE blobs, so only the
+    // literal `:/` prefix is filtered out.
+    !arg.starts_with('-') && !arg.starts_with(":/") && arg.contains(':')
+}
+
+/// Byte budget for a blob preview before truncation kicks in (~2k tokens).
+const MAX_BLOB_BYTES: usize = 8192;
+
+/// Decide how to window a `git show <rev>:<path>` blob. Returns
+/// `Some((head, remaining_lines, tail_offset))` when the blob should be truncated,
+/// or `None` to pass it through unchanged: a small blob, a binary blob, a tree
+/// listing, a blob too large for the recovery file to store intact, or a single line
+/// too long to cut at a line boundary.
+///
+/// `max_recoverable` is the byte size the recovery tee file can hold whole; a larger
+/// blob is passed through so the tail hint never promises unrecoverable content.
+///
+/// Pure and side-effect free so it can be unit-tested against real blob fixtures.
+fn blob_truncation(raw: &str, budget: usize, max_recoverable: usize) -> Option<(&str, usize, usize)> {
+    // `git show <rev>:<dir>` prints a tree listing (`tree <rev>:<dir>\n\n...`), not
+    // file content.
+    if raw.starts_with("tree ") {
+        return None;
+    }
+    // Binary blob, or bytes mangled by lossy UTF-8 decoding: never window.
+    if raw.contains('\0') || raw.contains('\u{FFFD}') {
+        return None;
+    }
+    // The recovery tee file is capped: a blob larger than it can store intact could
+    // not be recovered in full via the tail hint, so keep it whole.
+    if raw.len() > max_recoverable {
+        return None;
+    }
+    if raw.len() <= budget {
+        return None;
+    }
+    // Walk back to a valid UTF-8 char boundary at or below the budget before slicing
+    // (slicing mid-codepoint panics — see core::tee::write_tee_file for the same fix).
+    let mut end = budget;
+    while end > 0 && !raw.is_char_boundary(end) {
+        end -= 1;
+    }
+    // Cut at the last line boundary inside the window. No newline means a single line
+    // longer than the budget, which tail-based recovery cannot re-window: pass through.
+    let cut = raw[..end].rfind('\n')? + 1;
+    let head = &raw[..cut];
+    let head_lines = head.lines().count();
+    let total_lines = raw.lines().count();
+    let remaining = total_lines.checked_sub(head_lines).filter(|&r| r > 0)?;
+    // `tail -n +offset` recovers everything from the first un-shown line onward.
+    Some((head, remaining, head_lines + 1))
+}
+
+/// Window a single blob dump: cap large text blobs with a tail-recovery hint, but
+/// only when the full content was successfully tee'd — never drop data without a way
+/// to recover it.
+fn compact_blob_show(raw: &str, blob_arg: &str) -> String {
+    let max_recoverable = crate::core::tee::max_recoverable_bytes();
+    let Some((head, remaining, offset)) = blob_truncation(raw, MAX_BLOB_BYTES, max_recoverable)
+    else {
+        return raw.to_string();
+    };
+    let slug = format!("git-show-{}", blob_arg.rsplit(':').next().unwrap_or(blob_arg));
+    match crate::core::tee::force_tee_tail_hint(raw, &slug, offset) {
+        Some(hint) => {
+            let out = format!("{}... (+{} lines) {}\n", head, remaining, hint);
+            never_worse(raw, &out).to_string()
+        }
+        // Tee unavailable (disabled / RTK_TEE=0): without recovery, keep the blob whole.
+        None => raw.to_string(),
+    }
+}
+
+/// Write raw (binary or non-transcodable) bytes straight to stdout, tracked as a
+/// passthrough. Mirrors the binary path in `cloud/curl_cmd.rs`.
+fn emit_raw_bytes_passthrough(
+    bytes: &[u8],
+    label: &str,
+    rtk_label: &str,
+    timer: &tracking::TimedExecution,
+    exit_code: i32,
+) -> Result<i32> {
+    use std::io::Write;
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+    handle
+        .write_all(bytes)
+        .context("Failed to write blob to stdout")?;
+    timer.track_passthrough(label, rtk_label);
+    Ok(exit_code)
 }
 
 pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
@@ -2281,9 +2420,118 @@ mod tests {
     fn test_is_blob_show_arg() {
         assert!(is_blob_show_arg("develop:modules/pairs_backtest.py"));
         assert!(is_blob_show_arg("HEAD:src/main.rs"));
+        // Index / merge-stage blobs start with `:` but are still blobs.
+        assert!(is_blob_show_arg(":Cargo.toml"));
+        assert!(is_blob_show_arg(":2:conflict.rs"));
         assert!(!is_blob_show_arg("--pretty=format:%h"));
         assert!(!is_blob_show_arg("--format=short"));
         assert!(!is_blob_show_arg("HEAD"));
+        // `:/text` is a commit-message search, not a blob.
+        assert!(!is_blob_show_arg(":/fix the bug"));
+    }
+
+    #[test]
+    fn test_blob_truncation_small_passthrough() {
+        // Real committed file, ~1.7KB < budget: passed through unchanged.
+        let small = include_str!("../../../Cargo.toml");
+        assert!(blob_truncation(small, MAX_BLOB_BYTES, usize::MAX).is_none());
+    }
+
+    #[test]
+    fn test_blob_truncation_large_windowed() {
+        // Real blob fixture (`git show HEAD:src/main.rs | head -350`), ~10.7KB.
+        let large = include_str!("../../../tests/fixtures/git/blob_large.txt");
+        let (head, remaining, offset) =
+            blob_truncation(large, MAX_BLOB_BYTES, usize::MAX).expect("large blob should window");
+        assert!(head.len() <= MAX_BLOB_BYTES);
+        assert!(head.ends_with('\n'), "head must end at a line boundary");
+        let head_lines = head.lines().count();
+        // N formula: remaining == total - head_lines, offset == head_lines + 1.
+        assert_eq!(offset, head_lines + 1);
+        assert_eq!(remaining, large.lines().count() - head_lines);
+        assert!(remaining > 0);
+    }
+
+    #[test]
+    fn test_blob_truncation_exceeds_recoverable_passthrough() {
+        // ~10.7KB real blob. If the recovery tee can only store 5KB, truncating would
+        // promise a tail the tee file cannot hold → pass the blob through whole.
+        let large = include_str!("../../../tests/fixtures/git/blob_large.txt");
+        assert!(large.len() > 5_000);
+        assert!(blob_truncation(large, MAX_BLOB_BYTES, 5_000).is_none());
+        // With ample recovery capacity it windows normally.
+        assert!(blob_truncation(large, MAX_BLOB_BYTES, 1_000_000).is_some());
+    }
+
+    #[test]
+    fn test_blob_truncation_tree_passthrough() {
+        // Real tree listing (`git show HEAD:src`): `tree <rev>:<dir>\n\n...`.
+        let tree = include_str!("../../../tests/fixtures/git/tree_listing.txt");
+        assert!(tree.starts_with("tree "));
+        assert!(blob_truncation(tree, MAX_BLOB_BYTES, usize::MAX).is_none());
+    }
+
+    #[test]
+    fn test_blob_truncation_binary_passthrough() {
+        let mut binary = "x".repeat(9000);
+        binary.push('\0');
+        assert!(blob_truncation(&binary, MAX_BLOB_BYTES, usize::MAX).is_none());
+        // Replacement char from lossy UTF-8 decoding of a binary blob.
+        let lossy = format!("{}\u{FFFD}", "y".repeat(9000));
+        assert!(blob_truncation(&lossy, MAX_BLOB_BYTES, usize::MAX).is_none());
+    }
+
+    #[test]
+    fn test_blob_truncation_giant_single_line_passthrough() {
+        // A single line longer than the budget has no line boundary to cut at.
+        let giant = "a".repeat(20_000);
+        assert!(blob_truncation(&giant, MAX_BLOB_BYTES, usize::MAX).is_none());
+    }
+
+    #[test]
+    fn test_blob_truncation_utf8_boundary_no_panic() {
+        // Multibyte content so the byte budget can land mid-codepoint: must not panic.
+        let mut s = String::new();
+        while s.len() < 9000 {
+            s.push_str("áéíóú-ñ-日本語");
+            s.push('\n');
+        }
+        // Exercise budgets straddling a multibyte char around the window edge.
+        let _ = blob_truncation(&s, MAX_BLOB_BYTES, usize::MAX);
+        let _ = blob_truncation(&s, 8191, usize::MAX);
+        let _ = blob_truncation(&s, 8193, usize::MAX);
+        // Should still window (multi-line, over budget) without crashing.
+        assert!(blob_truncation(&s, MAX_BLOB_BYTES, usize::MAX).is_some());
+    }
+
+    #[test]
+    fn test_blob_truncation_no_trailing_newline() {
+        let mut s = String::new();
+        for i in 0..500 {
+            s.push_str(&format!("line number {i} with a bit of content here\n"));
+        }
+        s.pop(); // drop the final newline
+        let (head, remaining, offset) =
+            blob_truncation(&s, MAX_BLOB_BYTES, usize::MAX).expect("should window");
+        assert_eq!(offset, head.lines().count() + 1);
+        assert_eq!(remaining, s.lines().count() - head.lines().count());
+    }
+
+    #[test]
+    fn test_blob_latin1_fixture_decodes_and_windows() {
+        // Real ISO-8859-1 slice of an Oracle PL/SQL `.pck` (14KB, contains "MÉTODO",
+        // not valid UTF-8). The blob path must transcode it losslessly (no U+FFFD) and
+        // then window it for savings — instead of the old lossy-decode passthrough.
+        let bytes = include_bytes!("../../../tests/fixtures/git/latin1_blob.pck");
+        let crate::core::stream::Decoded::Latin1(text) =
+            crate::core::stream::decode_output(bytes)
+        else {
+            panic!("expected Latin1 decode of the .pck fixture");
+        };
+        assert!(!text.contains('\u{FFFD}'), "transcode must not corrupt");
+        assert!(text.contains("MÉTODO"));
+        assert!(text.len() > MAX_BLOB_BYTES);
+        assert!(blob_truncation(&text, MAX_BLOB_BYTES, usize::MAX).is_some());
     }
 
     #[test]

--- a/src/cmds/go/go_cmd.rs
+++ b/src/cmds/go/go_cmd.rs
@@ -626,7 +626,6 @@ fn format_go_build_failure(output: &str, exit_code: i32) -> String {
 
     let mut result = String::new();
     result.push_str(&format!("Go build: failed (exit {})\n", exit_code));
-    result.push_str("═══════════════════════════════════════\n");
 
     const MAX_GO_BUILD_ERRORS: usize = CAP_ERRORS;
     for (i, line) in lines.iter().take(MAX_GO_BUILD_ERRORS).enumerate() {

--- a/src/cmds/python/pip_cmd.rs
+++ b/src/cmds/python/pip_cmd.rs
@@ -223,8 +223,6 @@ fn filter_pip_outdated(output: &str) -> String {
         ));
     }
 
-    result.push_str("\n[hint] Run `pip install --upgrade <package>` to update\n");
-
     result.trim().to_string()
 }
 

--- a/src/cmds/python/ruff_cmd.rs
+++ b/src/cmds/python/ruff_cmd.rs
@@ -218,13 +218,6 @@ pub fn filter_ruff_check_json(output: &str) -> String {
         }
     }
 
-    if fixable_count > 0 {
-        result.push_str(&format!(
-            "\n[hint] Run `ruff check --fix` to auto-fix {} issues\n",
-            fixable_count
-        ));
-    }
-
     result.trim().to_string()
 }
 
@@ -307,8 +300,6 @@ pub fn filter_ruff_format(output: &str) -> String {
             if files_checked > 0 {
                 result.push_str(&format!("\n{} files already formatted\n", files_checked));
             }
-
-            result.push_str("\n[hint] Run `ruff format` to format these files\n");
         }
     } else {
         // Write mode or other output - show summary

--- a/src/cmds/ruby/rubocop_cmd.rs
+++ b/src/cmds/ruby/rubocop_cmd.rs
@@ -208,10 +208,7 @@ fn filter_rubocop_json(output: &str) -> String {
     }
 
     if correctable_count > 0 {
-        result.push_str(&format!(
-            "\n({} correctable, run `rubocop -A`)",
-            correctable_count
-        ));
+        result.push_str(&format!("\n({} correctable)", correctable_count));
     }
 
     result.trim().to_string()
@@ -457,10 +454,9 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_rubocop_correctable_hint() {
+    fn test_filter_rubocop_correctable_count() {
         let result = filter_rubocop_json(with_offenses_json());
         assert!(result.contains("3 correctable"));
-        assert!(result.contains("rubocop -A"));
     }
 
     #[test]

--- a/src/cmds/system/format_cmd.rs
+++ b/src/cmds/system/format_cmd.rs
@@ -255,8 +255,6 @@ fn filter_black_output(output: &str) -> String {
         if files_unchanged > 0 {
             result.push_str(&format!("\n{} files already formatted\n", files_unchanged));
         }
-
-        result.push_str("\n[hint] Run `black .` to format these files\n");
     } else {
         // Fallback: show raw output
         result.push_str(output.trim());
@@ -358,7 +356,6 @@ Oh no! 💥 💔 💥
         assert!(result.contains("main.py"));
         assert!(result.contains("test_utils.py"));
         assert!(result.contains("3 files already formatted"));
-        assert!(result.contains("Run `black .`"));
     }
 
     #[test]

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -552,10 +552,146 @@ pub fn exec_capture_stdin(cmd: &mut Command) -> Result<CaptureResult> {
     })
 }
 
+/// Raw-byte capture result, for callers that must control decoding themselves —
+/// e.g. non-UTF-8 output that [`exec_capture`]'s `from_utf8_lossy` would corrupt.
+pub struct CaptureBytes {
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+    pub exit_code: i32,
+}
+
+impl CaptureBytes {
+    pub fn success(&self) -> bool {
+        self.exit_code == 0
+    }
+}
+
+/// Like [`exec_capture`] but returns raw bytes so the caller decides how to decode.
+pub fn exec_capture_bytes(cmd: &mut Command) -> Result<CaptureBytes> {
+    cmd.stdin(Stdio::null());
+    let output = cmd.output().context("Failed to execute command")?;
+    Ok(CaptureBytes {
+        stdout: output.stdout,
+        stderr: output.stderr,
+        exit_code: status_to_exit_code(output.status),
+    })
+}
+
+/// How captured bytes were decoded into text.
+pub enum Decoded {
+    /// Valid UTF-8.
+    Utf8(String),
+    /// Not UTF-8, but safe ISO-8859-1 (Latin-1) text transcoded losslessly.
+    Latin1(String),
+    /// Binary, or a byte in the 0x80–0x9F range where ISO-8859-1 and Windows-1252
+    /// disagree — transcoding would guess and could corrupt silently. The caller
+    /// should pass the raw bytes through unchanged.
+    Binary,
+}
+
+/// Decode captured stdout bytes, preferring fidelity over guessing:
+/// - Valid UTF-8 → [`Decoded::Utf8`].
+/// - Invalid UTF-8 that looks binary (NUL / dense control bytes) or uses the
+///   ambiguous 0x80–0x9F range → [`Decoded::Binary`] (pass raw bytes through).
+/// - Otherwise ISO-8859-1 text: each byte 0x00–0xFF maps to U+0000–U+00FF, a
+///   lossless Latin-1 → UTF-8 transcode → [`Decoded::Latin1`].
+///
+/// This fixes the corruption where `from_utf8_lossy` turns Latin-1 accents into
+/// U+FFFD (`É` → `�`), inflating and mangling e.g. ISO-8859 PL/SQL source blobs.
+pub fn decode_output(bytes: &[u8]) -> Decoded {
+    // Check binary first: NUL is a valid UTF-8 codepoint, so a NUL-laden binary blob
+    // can pass `from_utf8` — treat it as binary regardless of UTF-8 validity.
+    if looks_binary(bytes) {
+        return Decoded::Binary;
+    }
+    match std::str::from_utf8(bytes) {
+        Ok(s) => Decoded::Utf8(s.to_string()),
+        Err(_) => {
+            if bytes.iter().any(|&b| (0x80..=0x9F).contains(&b)) {
+                Decoded::Binary
+            } else {
+                Decoded::Latin1(bytes.iter().map(|&b| b as char).collect())
+            }
+        }
+    }
+}
+
+/// Heuristic: a NUL byte, or more than 2% C0 control bytes (excluding tab/newline/CR)
+/// in the first 8 KiB, marks content as binary rather than single-byte text.
+fn looks_binary(bytes: &[u8]) -> bool {
+    if bytes.contains(&0) {
+        return true;
+    }
+    let sample = &bytes[..bytes.len().min(8192)];
+    if sample.is_empty() {
+        return false;
+    }
+    let control = sample
+        .iter()
+        .filter(|&&b| b < 0x09 || (0x0D < b && b < 0x20))
+        .count();
+    control * 100 / sample.len() > 2
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
     use std::process::Command;
+
+    #[test]
+    fn test_decode_output_utf8() {
+        assert!(matches!(decode_output(b"hello world"), Decoded::Utf8(_)));
+        assert!(matches!(
+            decode_output("café ☕".as_bytes()),
+            Decoded::Utf8(_)
+        ));
+    }
+
+    #[test]
+    fn test_decode_output_latin1_lossless() {
+        // 0xC9 = É, 0xF3 = ó in ISO-8859-1; invalid UTF-8, no 0x80-0x9F byte.
+        let bytes = b"M\xC9TODO acci\xF3n";
+        let Decoded::Latin1(s) = decode_output(bytes) else {
+            panic!("expected Latin1");
+        };
+        assert_eq!(s, "MÉTODO acción");
+        assert!(!s.contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn test_decode_output_cp1252_ambiguous_is_binary() {
+        // 0x93/0x94 = smart quotes in CP1252, control C1 in ISO-8859-1: ambiguous,
+        // so pass through raw rather than guess and corrupt silently.
+        assert!(matches!(
+            decode_output(b"say \x93hi\x94 there"),
+            Decoded::Binary
+        ));
+    }
+
+    #[test]
+    fn test_decode_output_binary_nul() {
+        assert!(matches!(
+            decode_output(b"PK\x03\x04\x00\x00binary"),
+            Decoded::Binary
+        ));
+    }
+
+    #[test]
+    fn test_looks_binary() {
+        assert!(looks_binary(b"\x00\x01\x02")); // NUL
+        assert!(!looks_binary(b"plain ascii text\n"));
+        assert!(!looks_binary("café".as_bytes())); // UTF-8 accents, no control
+        assert!(!looks_binary(b"")); // empty is not binary
+                                     // A single ESC in otherwise-text stays under the 2% threshold.
+        assert!(!looks_binary(
+            b"line one\x1bline two with lots of text here\n"
+        ));
+        // Dense control bytes read as binary.
+        let ctrl: Vec<u8> = (0..100)
+            .map(|i| if i % 2 == 0 { 0x01 } else { b'a' })
+            .collect();
+        assert!(looks_binary(&ctrl));
+    }
 
     struct LineFilter<F: FnMut(&str) -> Option<String>> {
         f: F,

--- a/src/core/tee.rs
+++ b/src/core/tee.rs
@@ -221,6 +221,16 @@ pub fn force_tee_hint(raw: &str, command_slug: &str) -> Option<String> {
     Some(format_hint(&path))
 }
 
+/// Maximum content size (bytes) the tee file can store intact. `write_tee_file`
+/// truncates anything larger, so a tail-recovery hint over a bigger blob would point
+/// at incomplete content. Callers that promise full recovery must not truncate beyond
+/// this. Falls back to the built-in default if config can't be loaded.
+pub fn max_recoverable_bytes() -> usize {
+    Config::load()
+        .map(|c| c.tee.max_file_size)
+        .unwrap_or(DEFAULT_MAX_FILE_SIZE)
+}
+
 /// Returns `[see remaining: tail -n +{line_offset} ~/path]`, or None if tee is disabled/skipped.
 pub fn force_tee_tail_hint(
     content: &str,

--- a/src/core/tee.rs
+++ b/src/core/tee.rs
@@ -14,8 +14,10 @@ const DEFAULT_MAX_FILES: usize = 20;
 const DEFAULT_MAX_FILE_SIZE: usize = 1_048_576;
 
 /// Sanitize a command slug for use in filenames.
-/// Replaces non-alphanumeric chars (except underscore/hyphen) with underscore,
-/// truncates at 40 chars.
+/// Replaces non-alphanumeric chars (except underscore/hyphen) with underscore.
+/// Long slugs (usually an embedded file path that duplicates the command the LLM
+/// already issued) collapse to a short readable prefix plus a collision-resistant
+/// hash, keeping recovery filenames unique but compact — fewer tokens per tee hint.
 fn sanitize_slug(slug: &str) -> String {
     let sanitized: String = slug
         .chars()
@@ -27,11 +29,25 @@ fn sanitize_slug(slug: &str) -> String {
             }
         })
         .collect();
-    if sanitized.len() > 40 {
-        sanitized[..40].to_string()
-    } else {
-        sanitized
+    const MAX_READABLE: usize = 24;
+    if sanitized.len() <= MAX_READABLE {
+        return sanitized;
     }
+    let prefix: String = sanitized.chars().take(8).collect();
+    format!("{}_{}", prefix, short_hash(&sanitized))
+}
+
+/// First 6 hex chars (24 bits) of the SHA-256 of `s` — a compact, collision-resistant
+/// tag. Distinct slugs get distinct tags (~1-in-16M collision), so shortening never
+/// makes two different commands share a tee filename (the epoch already scopes writes
+/// to the same second, exactly as before).
+fn short_hash(s: &str) -> String {
+    use sha2::{Digest, Sha256};
+    Sha256::digest(s.as_bytes())
+        .iter()
+        .take(3)
+        .map(|b| format!("{:02x}", b))
+        .collect()
 }
 
 /// Get the tee directory, respecting config and env overrides.
@@ -289,9 +305,23 @@ mod tests {
         assert_eq!(sanitize_slug("cargo test"), "cargo_test");
         assert_eq!(sanitize_slug("cargo-test"), "cargo-test");
         assert_eq!(sanitize_slug("go/test/./pkg"), "go_test___pkg");
-        // Truncate at 40
-        let long = "a".repeat(50);
-        assert_eq!(sanitize_slug(&long).len(), 40);
+        // Long slugs (embedded paths) collapse to a readable prefix + hash, staying short.
+        let long = format!("grep_0_{}", "a".repeat(50));
+        let short = sanitize_slug(&long);
+        assert!(
+            short.len() < 24,
+            "long slug should shorten, got '{}'",
+            short
+        );
+        assert!(
+            short.starts_with("grep_0_a"),
+            "keeps a readable prefix, got '{}'",
+            short
+        );
+        // Deterministic, and different slugs never collide onto the same filename.
+        assert_eq!(sanitize_slug(&long), short);
+        let other = sanitize_slug(&format!("grep_1_{}", "a".repeat(50)));
+        assert_ne!(other, short, "distinct slugs must not collide");
     }
 
     #[test]

--- a/tests/fixtures/git/blob_large.txt
+++ b/tests/fixtures/git/blob_large.txt
@@ -1,0 +1,350 @@
+mod analytics;
+mod cmds;
+mod core;
+mod discover;
+mod hooks;
+mod learn;
+mod parser;
+
+// Re-export command modules for routing
+use cmds::cloud::{aws_cmd, container, curl_cmd, psql_cmd, wget_cmd};
+use cmds::dotnet::{binlog, dotnet_cmd, dotnet_format_report, dotnet_trx};
+use cmds::git::{diff_cmd, gh_cmd, git, glab_cmd, gt_cmd};
+use cmds::go::{go_cmd, golangci_cmd};
+use cmds::js::{
+    lint_cmd, next_cmd, npm_cmd, playwright_cmd, pnpm_cmd, prettier_cmd, prisma_cmd, tsc_cmd,
+    vitest_cmd,
+};
+use cmds::jvm::{gradlew_cmd, mvn_cmd};
+use cmds::php::{ecs_cmd, paratest_cmd, pest_cmd, php_cmd, phpstan_cmd, phpunit_cmd, pint_cmd};
+use cmds::python::{mypy_cmd, pip_cmd, pytest_cmd, ruff_cmd, uv_cmd};
+use cmds::ruby::{rake_cmd, rspec_cmd, rubocop_cmd};
+use cmds::rust::{cargo_cmd, runner};
+use cmds::system::{
+    deps, env_cmd, find_cmd, format_cmd, json_cmd, local_llm, log_cmd, ls, pipe_cmd, read, search,
+    summary, tree, wc_cmd,
+};
+
+use anyhow::{Context, Result};
+use clap::error::ErrorKind;
+use clap::{Parser, Subcommand, ValueEnum};
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+/// Target agent for hook installation.
+#[derive(Debug, Clone, Copy, PartialEq, ValueEnum)]
+pub enum AgentTarget {
+    /// Claude Code (default)
+    Claude,
+    /// Cursor Agent (editor and CLI)
+    Cursor,
+    /// Windsurf IDE (Cascade)
+    Windsurf,
+    /// Cline / Roo Code (VS Code)
+    Cline,
+    /// Kilo Code
+    Kilocode,
+    /// Google Antigravity
+    Antigravity,
+    /// Pi coding agent
+    Pi,
+    /// Hermes CLI
+    Hermes,
+    /// Factory Droid CLI
+    Droid,
+}
+
+#[derive(Parser)]
+#[command(
+    name = "rtk",
+    version,
+    about = "Rust Token Killer - Minimize LLM token consumption",
+    long_about = "A high-performance CLI proxy designed to filter and summarize system outputs before they reach your LLM context."
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+
+    /// Verbosity level (-v, -vv, -vvv) — only recognized before the subcommand
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    verbose: u8,
+
+    /// Ultra-compact mode: ASCII icons, inline format (Level 2 optimizations)
+    #[arg(long, global = true)]
+    ultra_compact: bool,
+
+    /// Set SKIP_ENV_VALIDATION=1 for child processes (Next.js, tsc, lint, prisma)
+    #[arg(long = "skip-env", global = true)]
+    skip_env: bool,
+}
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    /// List directory contents with token-optimized output (proxy to native ls)
+    Ls {
+        /// Arguments passed to ls (supports all native ls flags like -l, -a, -h, -R)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// Directory tree with token-optimized output (proxy to native tree)
+    Tree {
+        /// Arguments passed to tree (supports all native tree flags like -L, -d, -a)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// Read file with intelligent filtering
+    Read {
+        /// Files to read (supports multiple, like cat)
+        #[arg(required = true, num_args = 1..)]
+        files: Vec<PathBuf>,
+        /// Filter: none (default, full content), minimal, aggressive
+        #[arg(short, long, default_value = "none")]
+        level: core::filter::FilterLevel,
+        /// Max lines
+        #[arg(short, long, conflicts_with = "tail_lines")]
+        max_lines: Option<usize>,
+        /// Keep only last N lines
+        #[arg(long, conflicts_with = "max_lines")]
+        tail_lines: Option<usize>,
+        /// Show line numbers
+        #[arg(short = 'n', long)]
+        line_numbers: bool,
+    },
+
+    /// Generate 2-line technical summary (heuristic-based)
+    Smart {
+        /// File to analyze
+        file: PathBuf,
+        /// Model: heuristic
+        #[arg(short, long, default_value = "heuristic")]
+        model: String,
+        /// Force model download
+        #[arg(long)]
+        force_download: bool,
+    },
+
+    /// Git commands with compact output
+    Git {
+        /// Change to directory before executing (like git -C <path>, can be repeated)
+        #[arg(short = 'C', action = clap::ArgAction::Append)]
+        directory: Vec<String>,
+
+        /// Git configuration override (like git -c key=value, can be repeated)
+        #[arg(short = 'c', action = clap::ArgAction::Append)]
+        config_override: Vec<String>,
+
+        /// Set the path to the .git directory
+        #[arg(long = "git-dir")]
+        git_dir: Option<String>,
+
+        /// Set the path to the working tree
+        #[arg(long = "work-tree")]
+        work_tree: Option<String>,
+
+        /// Disable pager (like git --no-pager)
+        #[arg(long = "no-pager")]
+        no_pager: bool,
+
+        /// Skip optional locks (like git --no-optional-locks)
+        #[arg(long = "no-optional-locks")]
+        no_optional_locks: bool,
+
+        /// Treat repository as bare (like git --bare)
+        #[arg(long)]
+        bare: bool,
+
+        /// Treat pathspecs literally (like git --literal-pathspecs)
+        #[arg(long = "literal-pathspecs")]
+        literal_pathspecs: bool,
+
+        #[command(subcommand)]
+        command: GitCommands,
+    },
+
+    /// GitHub CLI (gh) commands with token-optimized output
+    Gh {
+        /// Subcommand: pr, issue, run, repo
+        subcommand: String,
+        /// Additional arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// GitLab CLI (glab) commands with token-optimized output
+    Glab {
+        /// Target repository (owner/repo), passed as glab -R flag
+        #[arg(short = 'R', long = "repo")]
+        repo: Option<String>,
+        /// Target group, passed as glab -g flag
+        #[arg(short = 'g', long = "group")]
+        group: Option<String>,
+        /// Subcommand: mr, issue, ci, pipeline, api
+        subcommand: String,
+        /// Additional arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// AWS CLI with compact output (force JSON, compress)
+    Aws {
+        /// AWS service subcommand (e.g., sts, s3, ec2, ecs, rds, cloudformation)
+        subcommand: String,
+        /// Additional arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// PostgreSQL client with compact output (strip borders, compress tables)
+    #[command(disable_help_flag = true)]
+    Psql {
+        /// psql arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// pnpm commands with ultra-compact output
+    Pnpm {
+        /// pnpm filter arguments (can be repeated: --filter @app1 --filter @app2)
+        #[arg(long, short = 'F')]
+        filter: Vec<String>,
+
+        #[command(subcommand)]
+        command: PnpmCommands,
+    },
+
+    /// Run command and show only errors/warnings
+    Err {
+        /// Command to run
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        command: Vec<String>,
+    },
+
+    /// Run tests and show only failures
+    Test {
+        /// Test command (e.g. cargo test)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        command: Vec<String>,
+    },
+
+    /// Show JSON (compact values by default, or keys-only with --keys-only)
+    Json {
+        /// JSON file
+        file: PathBuf,
+        /// Max depth
+        #[arg(short, long, default_value = "5")]
+        depth: usize,
+        /// Show keys only (strip all values, show structure)
+        #[arg(long)]
+        keys_only: bool,
+    },
+
+    /// Summarize project dependencies
+    Deps {
+        /// Project path
+        #[arg(default_value = ".")]
+        path: PathBuf,
+    },
+
+    /// Show environment variables (filtered)
+    Env {
+        /// Filter by name (e.g. PATH, AWS)
+        #[arg(short, long)]
+        filter: Option<String>,
+    },
+
+    /// Find files with compact tree output (accepts native find flags like -name, -type)
+    Find {
+        /// All find arguments (supports both RTK and native find syntax)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// Ultra-condensed diff (only changed lines)
+    Diff {
+        /// First file or - for stdin (unified diff)
+        file1: PathBuf,
+        /// Second file (optional if stdin)
+        file2: Option<PathBuf>,
+    },
+
+    /// Filter and deduplicate log output
+    Log {
+        /// Log file (omit for stdin)
+        file: Option<PathBuf>,
+    },
+
+    /// .NET commands with compact output (build/test/restore/format)
+    Dotnet {
+        #[command(subcommand)]
+        command: DotnetCommands,
+    },
+
+    /// Docker commands with compact output
+    Docker {
+        #[command(subcommand)]
+        command: DockerCommands,
+    },
+
+    /// Kubectl commands with compact output
+    Kubectl {
+        #[command(subcommand)]
+        command: KubectlCommands,
+    },
+
+    /// OpenShift CLI (oc) commands with compact output
+    Oc {
+        #[command(subcommand)]
+        command: OcCommands,
+    },
+
+    /// Run command and show heuristic summary
+    Summary {
+        /// Command to run and summarize
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        command: Vec<String>,
+    },
+
+    /// Compact grep - strips whitespace, truncates, groups by file
+    Grep {
+        /// Max line length
+        #[arg(short = 'l', long, default_value = "80")]
+        max_len: usize,
+        /// Max results to show
+        #[arg(short, long, default_value = "200")]
+        max: usize,
+        /// Show only match context (not full line)
+        #[arg(long)]
+        context_only: bool,
+        /// Filter by file type (e.g., ts, py, rust)
+        #[arg(short = 't', long)]
+        file_type: Option<String>,
+        /// Pattern, path, and any grep/rg flags (e.g. -v, -i, -A 3, --glob, --version)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        extra_args: Vec<String>,
+    },
+
+    /// Compact ripgrep - runs rg natively, same output filter as grep
+    Rg {
+        /// Pattern, path, and any rg flags (e.g. -v, -i, -t rust, --glob)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        extra_args: Vec<String>,
+    },
+
+    /// Initialize rtk instructions for assistant CLI usage
+    Init {
+        /// Add to global assistant config directory instead of local project file
+        #[arg(short, long)]
+        global: bool,
+
+        /// Install OpenCode plugin (in addition to Claude Code)
+        #[arg(long)]
+        opencode: bool,
+
+        /// Initialize for Gemini CLI instead of Claude Code
+        #[arg(long)]
+        gemini: bool,
+
+        /// Target agent to install hooks for (default: claude)
+        #[arg(long, value_enum)]

--- a/tests/fixtures/git/latin1_blob.pck
+++ b/tests/fixtures/git/latin1_blob.pck
@@ -1,0 +1,309 @@
+encia %TYPE,
+                                pNtrc_Code         IN PTOVENTA.VTA_OPERACION_FUNO.NTRC_CODE%TYPE,
+                                pNumPedidoVta      IN PTOVENTA.VTA_OPERACION_FUNO.NUM_PED_VTA%TYPE,
+                                pEstComisionCash   IN PTOVENTA.VTA_OPERACION_FUNO.EST_COMISION_CASH%TYPE);
+--FIN JPARCO 06052026
+end PTOVENTA_FUNO;
+/
+create or replace package body PTOVENTA.PTOVENTA_FUNO is
+
+  --INI CANTONIO 03/10/2019
+  function EST_FUNO_RECAUDACION RETURN VARCHAR2 IS
+    vRpta VARCHAR2(20);
+  BEGIN
+    SELECT LLAVE_TAB_GRAL
+      INTO vRpta
+      FROM PTOVENTA.PBL_TAB_GRAL PTO
+     WHERE PTO.COD_TAB_GRAL = 'EST_FUNO'
+       AND EST_TAB_GRAL = 'A';
+
+    RETURN vRpta;
+
+  END;
+  -- FIN CANTONIO
+  --INI SLEYVA 05/11/2019
+  function COD_COMERCIO_FARMA RETURN VARCHAR2 IS
+    vRpta VARCHAR2(20);
+  BEGIN
+    SELECT LLAVE_TAB_GRAL
+      INTO vRpta
+      FROM PTOVENTA.PBL_TAB_GRAL PTO
+     WHERE PTO.COD_TAB_GRAL = 'COD_COMERCIO'
+       AND EST_TAB_GRAL = 'A';
+
+    RETURN vRpta;
+
+  END;
+  --INI SLEYVA 05/11/2019
+
+  -- INI SLEYVA 11/10/2019
+  function imprimirVoucherComprobacion(codGrupoCia IN VARCHAR2,
+                                       codLocal    IN VARCHAR2,
+                                       numero      IN VARCHAR2,
+                                       monto       IN VARCHAR2)
+    RETURN FarmaCursor IS
+    curDataCupon FarmaCursor;
+    vIdDoc       IMPRESION_TERMICA.ID_DOC%type;
+    vIpPc        IMPRESION_TERMICA.IP_PC%type;
+    vNumero      VARCHAR2(20);
+    vMonto       VARCHAR(20);
+  BEGIN
+
+    vIdDoc  := FARMA_PRINTER.F_GENERA_ID_DOC;
+    vIpPc   := FARMA_PRINTER.F_GET_IP_SESS;
+    vNumero := 'Numero: ' || numero;
+    vMonto  := 'Monto: S/.' || monto;
+
+    FARMA_PRINTER.P_AGREGA_LOGO_MARCA(vIdDoc_in    => vIdDoc,
+                                      vIpPc_in     => vIpPc,
+                                      vCodGrupoCia => codGrupoCia,
+                                      vCodLocal_in => codLocal);
+
+    FARMA_PRINTER.P_AGREGA_LINEA_BLANCO(vIdDoc, vIpPc);
+
+    FARMA_PRINTER.P_AGREGA_TEXTO(vIdDoc_in    => vIdDoc,
+                                 vIpPc_in     => vIpPc,
+                                 vValor_in    => vNumero,
+                                 vTamanio_in  => FARMA_PRINTER.TAMANIO_3,
+                                 vAlineado_in => FARMA_PRINTER.ALING_CEN,
+                                 vNegrita_in  => FARMA_PRINTER.BOLD_ACT);
+    FARMA_PRINTER.P_AGREGA_LINEA_BLANCO(vIdDoc, vIpPc);
+
+    FARMA_PRINTER.P_AGREGA_TEXTO(vIdDoc_in    => vIdDoc,
+                                 vIpPc_in     => vIpPc,
+                                 vValor_in    => vMonto,
+                                 vTamanio_in  => FARMA_PRINTER.TAMANIO_3,
+                                 vAlineado_in => FARMA_PRINTER.ALING_CEN,
+                                 vNegrita_in  => FARMA_PRINTER.BOLD_ACT);
+    FARMA_PRINTER.P_AGREGA_LINEA_BLANCO(vIdDoc, vIpPc);
+
+    curDataCupon := FARMA_PRINTER.F_CUR_OBTIENE_DOC_IMPRIMIR(vIdDoc, vIpPc);
+
+    RETURN curDataCupon;
+  END;
+  -- FIN  SLEYVA 11/10/2019
+  -- INI SLEYVA 09/10/2019
+  PROCEDURE REGISTRA_OPERACION_FUNO(pCoCompania          IN PTOVENTA.VTA_OPERACION_FUNO.COD_GRUPO_CIA%TYPE,
+                                    pCoLocal             IN PTOVENTA.VTA_OPERACION_FUNO.COD_LOCAL%TYPE,
+                                    pDeRespondeCode      IN PTOVENTA.VTA_OPERACION_FUNO.DESC_RESPONDE_COD%TYPE,
+                                    pVaMonto             IN VARCHAR2,
+                                    pCoAprobacion        IN PTOVENTA.VTA_OPERACION_FUNO.COD_APROBACION%TYPE,
+                                    pDeMensaje           IN PTOVENTA.VTA_OPERACION_FUNO.DES_MENSAJE%TYPE,
+                                    pDeTarjeta           IN PTOVENTA.VTA_OPERACION_FUNO.DES_TARJETA%TYPE,
+                                    pDeIdTarjeta         IN PTOVENTA.VTA_OPERACION_FUNO.DES_ID_TARJETA%TYPE,
+                                    pNuCuotas            IN PTOVENTA.VTA_OPERACION_FUNO.NUM_CUOTAS%TYPE,
+                                    pVaMontoCuota        IN VARCHAR2,
+                                    pTiCredito           IN PTOVENTA.VTA_OPERACION_FUNO.TI_CREDITO%TYPE,
+                                    pDeNombreCliente     IN PTOVENTA.VTA_OPERACION_FUNO.DES_NOMBRE_CLIENTE%TYPE,
+                                    pDeCodigoMoneda      IN PTOVENTA.VTA_OPERACION_FUNO.DES_COD_MONEDA%TYPE,
+                                    pDeAplicacion        IN PTOVENTA.VTA_OPERACION_FUNO.DES_APLICACION%TYPE,
+                                    pDeTipoTransaccion   IN PTOVENTA.VTA_OPERACION_FUNO.DES_TIPO_TRANSACCION%TYPE,
+                                    pCoTipoServicioFuno  IN PTOVENTA.VTA_OPERACION_FUNO.COD_TIPO_SERVICIO_FUNO%TYPE,
+                                    pCoComercio          IN PTOVENTA.VTA_OPERACION_FUNO.COD_COMERCIO%TYPE,
+                                    pCoAdquiriente       IN PTOVENTA.VTA_OPERACION_FUNO.COD_ADQUIRIENTE%TYPE,
+                                    pIdAutorizacion      IN PTOVENTA.VTA_OPERACION_FUNO.ID_AUTORIZACION%TYPE,
+                                    pDeDatetime          IN PTOVENTA.VTA_OPERACION_FUNO.DES_DATETIME%TYPE,
+                                    pDeTipo              IN PTOVENTA.VTA_OPERACION_FUNO.DES_TIPO%TYPE,
+                                    pTiLectura           IN PTOVENTA.VTA_OPERACION_FUNO.TI_LECTURA%TYPE,
+                                    pDeTerminal          IN PTOVENTA.VTA_OPERACION_FUNO.DE_TERMINAL%TYPE,
+                                    pNuLote              IN PTOVENTA.VTA_OPERACION_FUNO.NUM_LOTE%TYPE,
+                                    pNuReferencia        IN PTOVENTA.VTA_OPERACION_FUNO.NUM_REFERENCIA%TYPE,
+                                    pIdCreaOperacionFuno IN PTOVENTA.VTA_OPERACION_FUNO.COD_CREA_OPERACION_FUNO%TYPE,
+                                    pCoCajero            IN PTOVENTA.VTA_OPERACION_FUNO.COD_CAJERO%TYPE,
+                                    pNuCaja              IN PTOVENTA.VTA_OPERACION_FUNO.NUM_CAJA%TYPE,
+                                    pNuTurno             IN PTOVENTA.VTA_OPERACION_FUNO.NUM_TURNO%TYPE,
+                                    pDeOperador          IN PTOVENTA.VTA_OPERACION_FUNO.DES_OPERADOR%TYPE) AS
+    V_CoTipoServicioFuno PTOVENTA.VTA_OPERACION_FUNO.COD_TIPO_SERVICIO_FUNO%TYPE;
+  BEGIN
+    --SE HA DEJADO EL MÉTODO IGUAL A INKAVENTA
+    IF (LENGTH(TRIM(pCoTipoServicioFuno)) = 0) THEN
+        V_CoTipoServicioFuno := NULL;
+    ELSE
+        V_CoTipoServicioFuno := pCoTipoServicioFuno;
+    END IF;
+
+    INSERT INTO PTOVENTA.VTA_OPERACION_FUNO
+      (COD_GRUPO_CIA,
+       COD_LOCAL,
+       COD_TRANSACCION_FUNO,
+       DESC_RESPONDE_COD,
+       VAL_MONTO,
+       COD_APROBACION,
+       DES_MENSAJE,
+       DES_TARJETA,
+       DES_ID_TARJETA,
+       NUM_CUOTAS,
+       VA_MONTO_CUOTA,
+       TI_CREDITO,
+       DES_NOMBRE_CLIENTE,
+       DES_COD_MONEDA,
+       DES_APLICACION,
+       DES_TIPO_TRANSACCION,
+       COD_TIPO_SERVICIO_FUNO,
+       COD_COMERCIO,
+       COD_ADQUIRIENTE,
+       ID_AUTORIZACION,
+       DES_DATETIME,
+       DES_TIPO,
+       TI_LECTURA,
+       DE_TERMINAL,
+       NUM_LOTE,
+       NUM_REFERENCIA,
+       COD_CREA_OPERACION_FUNO,
+       FEC_CREA_OPERACION_FUNO,
+       COD_CAJERO,
+       NUM_CAJA,
+       NUM_TURNO,
+       DES_OPERADOR)
+    Values
+      (pCoCompania,
+       pCoLocal,
+       SEQ_OPERACION_FUNO.NEXTVAL,
+       pDeRespondeCode,
+       TO_NUMBER(SUBSTR(pVaMonto, 0, LENGTH(pVaMonto) - 2) || '.' || SUBSTR(pVaMonto, LENGTH(pVaMonto) - 1), '9999999999999.99'),     --RARGUMEDO 21-05-2020
+       pCoAprobacion,
+       pDeTarjeta,        -- RARGUMEDO 26-05-2020
+       pDeTarjeta,
+       pDeIdTarjeta,
+       pNuCuotas,
+       TO_NUMBER(SUBSTR(pVaMontoCuota, 0, LENGTH(pVaMontoCuota) - 2) || '.' || SUBSTR(pVaMontoCuota, LENGTH(pVaMontoCuota) - 1), '9999999999999.99'),    -- RARGUMEDO 21-05-2020
+       pTiCredito,
+       pDeNombreCliente,
+       pDeCodigoMoneda,
+       pDeAplicacion,
+       pDeTipoTransaccion,
+       V_CoTipoServicioFuno,
+       pCoComercio,
+       pCoAdquiriente,
+       pIdAutorizacion,
+       pDeDateTime,
+       pDeTipo,
+       pTiLectura,
+       pDeTerminal,
+       pNuLote,
+       pNuReferencia,
+       pIdCreaOperacionFuno,
+       sysdate,
+       pCoCajero,
+       pNuCaja,
+       pNuTurno,
+       pDeOperador);
+
+  END;
+  -- FIN SLEYVA 09/10/2019
+
+  -- INI SLEYVA 09/10/2019
+  FUNCTION GET_TRANSACCIONES_FUNO(codigocompania_in IN VTA_COMP_PAGO.COD_GRUPO_CIA%TYPE,
+                                  codigolocal_in    IN VTA_COMP_PAGO.COD_LOCAL%TYPE,
+                                  feTx_in           IN CHAR,
+                                  feTx_fin          IN CHAR)
+    RETURN FarmaCursor IS
+    farmacur FarmaCursor;
+  BEGIN
+    OPEN farmacur FOR
+      SELECT CASE
+               WHEN A.DES_TIPO_TRANSACCION = '03' THEN
+                'DISPOSICIÓN EFECTIVO'
+               WHEN A.DES_TIPO_TRANSACCION = '06' THEN
+                'ANULACIÓN DISPOSICIÓN EFECTIVO'
+               WHEN A.DES_TIPO_TRANSACCION = '13' THEN
+                'PAGO SERVICIOS'
+               WHEN A.DES_TIPO_TRANSACCION = '07' THEN
+                'ANULACIÓN PAGO SERVICIOS'
+               ELSE
+                ' '
+             END || 'Ã' || NVL(A.COD_TIPO_SERVICIO_FUNO, ' ') || 'Ã' ||
+             NVL(B.DES_TIPO_SERVICIO_FUNO, ' ') || 'Ã' ||
+             TO_CHAR(A.VAL_MONTO, '999,999,999.99') || 'Ã' ||
+             NVL(A.COD_APROBACION, ' ') || 'Ã' || NVL(A.DES_TARJETA, ' ') || 'Ã' ||
+             NVL(A.DES_ID_TARJETA, ' ') || 'Ã' ||
+             NVL(A.DES_NOMBRE_CLIENTE, ' ') || 'Ã' || NVL(A.NUM_LOTE, ' ') || 'Ã' ||
+             NVL(A.NUM_REFERENCIA, ' ') || 'Ã' || NVL(A.COD_CAJERO, ' ') || 'Ã' ||
+             TRIM(C.APE_PAT) || ' ' || TRIM(C.APE_MAT) || ' ' ||
+             TRIM(C.NOM_USU) || 'Ã' || A.NUM_CAJA || 'Ã' || A.NUM_TURNO || 'Ã' ||
+             A.DES_OPERADOR  || 'Ã' ||
+			 NVL(A.IP_PC, ' ')
+        FROM PTOVENTA.VTA_OPERACION_FUNO A,
+             VTA_TIPO_SERVICIO_FUNO      B,
+             PBL_USU_LOCAL               C
+       WHERE A.COD_GRUPO_CIA = codigocompania_in
+         AND A.COD_LOCAL = codigolocal_in
+         AND A.FEC_CREA_OPERACION_FUNO BETWEEN
+             TO_DATE(feTx_in || ' 00:00:00', 'DD/MM/YYYY HH24:MI:SS') AND
+             TO_DATE(feTx_fin || ' 23:59:59', 'DD/MM/YYYY HH24:MI:SS')
+         AND A.COD_TIPO_SERVICIO_FUNO = B.COD_TIPO_SERVICIO_FUNO(+)
+         AND A.COD_GRUPO_CIA = C.COD_GRUPO_CIA
+         AND A.COD_LOCAL = C.COD_LOCAL
+         AND A.COD_CAJERO = C.SEC_USU_LOCAL;
+
+    RETURN farmacur;
+  END;
+  -- FIN SLEYVA 09/10/2019
+
+  -- INI SLEYVA 10/10/2019
+  PROCEDURE GRABA_OPERACON_INVALIDA(codigogrupocia_in  IN PTOVENTA.VTA_OPERACIONES_INVALIDAS.COD_GRUPO_CIA%TYPE,
+                                    codigolocal_in     IN PTOVENTA.VTA_OPERACIONES_INVALIDAS.COD_LOCAL%TYPE,
+                                    cocajero_in        IN PTOVENTA.VTA_OPERACIONES_INVALIDAS.COD_CAJERO%TYPE,
+                                    coopesolicitada_in IN PTOVENTA.VTA_OPERACIONES_INVALIDAS.COD_OPERACION_SOLICITADA%TYPE,
+                                    cooperealizada_in  IN PTOVENTA.VTA_OPERACIONES_INVALIDAS.COD_OPERACION_EFECTUADA%TYPE,
+                                    vamonto_in         IN PTOVENTA.VTA_OPERACIONES_INVALIDAS.VAL_MONTO%TYPE,
+                                    idtransaccion_in   IN PTOVENTA.VTA_OPERACIONES_INVALIDAS.COD_TRANSACCION%TYPE,
+                                    cocomercio_in      IN PTOVENTA.VTA_OPERACIONES_INVALIDAS.COD_COMERCIO%TYPE,
+                                    determinal_in      IN PTOVENTA.VTA_OPERACIONES_INVALIDAS.DES_TERMINAL%TYPE,
+                                    nulote_in          IN PTOVENTA.VTA_OPERACIONES_INVALIDAS.NUM_LOTE%TYPE,
+                                    nureferencia_in    IN PTOVENTA.VTA_OPERACIONES_INVALIDAS.NUM_REFERENCIA%TYPE,
+                                    nuap_in            IN PTOVENTA.VTA_OPERACIONES_INVALIDAS.NUM_AP%TYPE) IS
+    V_CO_SECUENCIAL NUMBER;
+  BEGIN
+    SELECT NVL(MAX(COD_SECUENCIAL), 0) + 1
+      INTO V_CO_SECUENCIAL
+      FROM PTOVENTA.VTA_OPERACIONES_INVALIDAS
+     WHERE COD_GRUPO_CIA = codigogrupocia_in
+       AND COD_LOCAL = CODIGOLOCAL_IN;
+
+    INSERT INTO PTOVENTA.VTA_OPERACIONES_INVALIDAS
+      (COD_GRUPO_CIA,
+       COD_LOCAL,
+       COD_SECUENCIAL,
+       FEC_OPERACION,
+       COD_CAJERO,
+       COD_OPERACION_SOLICITADA,
+       COD_OPERACION_EFECTUADA,
+       VAL_MONTO,
+       COD_TRANSACCION,
+       COD_COMERCIO,
+       DES_TERMINAL,
+       NUM_LOTE,
+       NUM_REFERENCIA,
+       NUM_AP)
+    VALUES
+      (codigogrupocia_in,
+       CODIGOLOCAL_IN,
+       V_CO_SECUENCIAL,
+       SYSDATE,
+       COCAJERO_IN,
+       COOPESOLICITADA_IN,
+       COOPEREALIZADA_IN,
+       VAMONTO_IN,
+       IDTRANSACCION_IN,
+       COCOMERCIO_IN,
+       DETERMINAL_IN,
+       NULOTE_IN,
+       NUREFERENCIA_IN,
+       NUAP_IN);
+
+    COMMIT;
+  END;
+  -- FIN SLEYVA 10/10/2019
+  --INI RARGUMEDO 10-02-2020 -- OPERACIONES AGORA
+  PROCEDURE UPDATE_TIPO_RCD(pCoGrupoCia        IN PTOVENTA.VTA_OPERACION_FUNO.cod_grupo_cia%TYPE,
+                            pCoCia             IN PTOVENTA.VTA_OPERACION_FUNO.COD_CIA %TYPE,
+                            pCoLocal           IN PTOVENTA.VTA_OPERACION_FUNO.cod_local %TYPE,
+                            pCoAprobacion      IN PTOVENTA.VTA_OPERACION_FUNO.cod_aprobacion %TYPE,
+                            pDeTarjeta         IN PTOVENTA.VTA_OPERACION_FUNO.des_tarjeta %TYPE,
+                            pDeTipoTransaccion IN PTOVENTA.VTA_OPERACION_FUNO.des_tipo_transaccion %TYPE,
+                            pIdAutorizacion    IN PTOVENTA.VTA_OPERACION_FUNO.id_autorizacion %TYPE,
+                            pNuLote            IN PTOVENTA.VTA_OPERACION_FUNO.num_lote %TYPE,
+                            pNuReferencia      IN PTOVENTA.VTA_OPERACION_FUNO.num_referencia %TYPE,
+                            pNtrc_Code         IN PTOVENTA.VTA_OPERACION_FUNO.NTRC_CODE%TYPE,
+                            pTipR

--- a/tests/fixtures/git/tree_listing.txt
+++ b/tests/fixtures/git/tree_listing.txt
@@ -1,0 +1,11 @@
+tree HEAD:src
+
+analytics/
+cmds/
+core/
+discover/
+filters/
+hooks/
+learn/
+main.rs
+parser/


### PR DESCRIPTION
## Summary

- **`feat(git)`**: `git show <rev>:<path>` blob dumps (previously passed through at 0% savings) are now filtered — large text blobs are capped to an 8 KiB preview with a `tail -n +N` recovery pointer (the full blob is tee'd); small blobs, tree listings, binary, and blobs too large to recover intact pass through unchanged.
- **Encoding fix**: blobs are captured as raw bytes and decoded encoding-aware — ISO-8859 / Latin-1 files (e.g. Oracle PL/SQL `.pck`) are transcoded losslessly instead of being corrupted into U+FFFD by lossy UTF-8, which also unblocks their compression. Ambiguous single-byte encodings (CP1252) and binary pass through raw. Measured on a real 77 KB Latin-1 blob: 0% → **89% savings** with the `É`→`�` corruption removed. (Same class of fix as #1087.)
- **`fix(tee)`**: recovery-file slugs (an embedded path duplicating the command) are hashed when long, saving ~12 tokens per truncation hint and fixing a latent collision where sibling paths in the same second overwrote each other's recovery file.
- **`refactor(output)`**: dropped RTK-invented advisory hints (`[hint] Run ruff/pip/black/dotnet/rubocop…`) and the go-build decorative separator — the counts they restate are already shown, so no signal is lost.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test` — clippy 0 warnings; **2449 tests pass**. (The one failing test, `git_checkout_dirty_tree_error_keeps_file_list`, is pre-existing and locale-dependent — it also fails on a clean `develop`, unrelated to this PR.)
- [x] Manual testing:
  - `rtk git show HEAD:src/main.rs` → 120 KB → 8 KB, `tail -n +N` recovery reconstructs byte-for-byte
  - `rtk git show HEAD:<latin1.pck>` → 89% savings, no `�`, recovery byte-identical to `iconv -f ISO-8859-1`
  - `rtk git show HEAD:<cp1252.pck>` → byte-exact passthrough (no wrong transcode)
  - `rtk git show HEAD:<dir>` (tree) and `HEAD:<binary>` → passthrough unchanged
  - 6 blobs from the same dir in the same second → 6 distinct recovery files (the old truncation collided them)

New unit + fixture tests cover decode (UTF-8 / Latin-1 / CP1252 / binary), byte-cap windowing, recovery-offset math, slug hashing/collision, and edge cases.