### PR TITLE
fix(hooks): treat jq parse errors as passthrough, not empty CMD

### DIFF
--- a/.claude/hooks/rtk-rewrite.sh
+++ b/.claude/hooks/rtk-rewrite.sh
@@ -32,8 +32,16 @@ fi
 set -euo pipefail
 
 INPUT=$(cat)
-CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
-
+# Suppress stderr: invalid JSON escapes (e.g. raw \| in command strings) make jq fail.
+# Check exit code so a parse error does not look like an empty command and silently
+# pass the original tool call through without a rewrite attempt.
+CMD=""
+JQ_EXIT=0
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || JQ_EXIT=$?
+if [ "$JQ_EXIT" -ne 0 ]; then
+  _rtk_audit_log "skip:jq_error" "-"
+  exit 0
+fi
 if [ -z "$CMD" ]; then
   _rtk_audit_log "skip:empty" "-"
   exit 0

--- a/hooks/claude/rtk-rewrite.sh
+++ b/hooks/claude/rtk-rewrite.sh
@@ -45,9 +45,12 @@ if [ ! -f "$CACHE_FILE" ]; then
 fi
 
 INPUT=$(cat)
-CMD=$(jq -r '.tool_input.command // empty' <<<"$INPUT")
-
-if [ -z "$CMD" ]; then
+# Suppress stderr: invalid JSON escapes (e.g. raw \| in command strings) make jq fail.
+# Check exit code so a parse error does not look like an empty command and silently
+# pass the original tool call through without a rewrite attempt.
+CMD=$(jq -r '.tool_input.command // empty' <<<"$INPUT" 2>/dev/null)
+JQ_EXIT=$?
+if [ "$JQ_EXIT" -ne 0 ] || [ -z "$CMD" ]; then
   exit 0
 fi
 

--- a/hooks/cursor/rtk-rewrite.sh
+++ b/hooks/cursor/rtk-rewrite.sh
@@ -31,9 +31,12 @@ if [ -n "$RTK_VERSION" ]; then
 fi
 
 INPUT=$(cat)
-CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
-
-if [ -z "$CMD" ]; then
+# Suppress stderr: invalid JSON escapes (e.g. raw \| in command strings) make jq fail.
+# Check exit code so a parse error does not look like an empty command and silently
+# pass the original tool call through without a rewrite attempt.
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+JQ_EXIT=$?
+if [ "$JQ_EXIT" -ne 0 ] || [ -z "$CMD" ]; then
   echo '{}'
   exit 0
 fi


### PR DESCRIPTION
## Summary
- Check `jq`'s exit code (and silence stderr) when reading `.tool_input.command` in the Claude, Cursor, and `.claude` rewrite hooks.
- Invalid JSON escapes in PreToolUse payloads (for example raw `\|` inside a command string) previously made `jq` fail with an empty `CMD`, which the hooks treated as "no command" and silently passed through.
- Parse failures now explicitly passthrough; valid commands that contain a properly JSON-escaped `\|` still rewrite as before.

## Test plan
- [x] Invalid payload with raw `\|` → hook exits 0, no jq stderr noise
- [x] Valid JSON payload with `\\|` in the command → rewrite proceeds
- [x] Simple command (`git status`) still rewrites under a stub `rtk rewrite`

Fixes #3065
