### PR TITLE
fix(js): preserve failed command output in parser fallbacks

### DIFF
--- a/src/cmds/js/playwright_cmd.rs
+++ b/src/cmds/js/playwright_cmd.rs
@@ -8,8 +8,9 @@ use regex::Regex;
 use serde::Deserialize;
 
 use crate::parser::{
-    emit_degradation_warning, emit_passthrough_warning, truncate_passthrough, FormatMode,
-    OutputParser, ParseResult, TestFailure, TestResult, TokenFormatter,
+    emit_degradation_warning, emit_passthrough_warning, passthrough_warning_reason,
+    truncate_passthrough, FormatMode, OutputParser, ParseResult, TestFailure, TestResult,
+    TokenFormatter,
 };
 
 /// Matches real Playwright JSON reporter output (suites → specs → tests → results)
@@ -289,30 +290,14 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     let result = exec_capture(&mut cmd)
         .context("Failed to run playwright (try: npm install -g playwright)")?;
 
-    let raw = format!("{}\n{}", result.stdout, result.stderr);
+    let raw = result.combined();
 
-    // Parse output using PlaywrightParser
-    let parse_result = PlaywrightParser::parse(&result.stdout);
-    let mode = FormatMode::from_verbosity(verbose);
-
-    let filtered = match parse_result {
-        ParseResult::Full(data) => {
-            if verbose > 0 {
-                eprintln!("playwright test (Tier 1: Full JSON parse)");
-            }
-            data.format(mode)
-        }
-        ParseResult::Degraded(data, warnings) => {
-            if verbose > 0 {
-                emit_degradation_warning("playwright", &warnings.join(", "));
-            }
-            data.format(mode)
-        }
-        ParseResult::Passthrough(raw) => {
-            emit_passthrough_warning("playwright", "All parsing tiers failed");
-            raw
-        }
-    };
+    let filtered = format_playwright_output(
+        &result.stdout,
+        &raw,
+        result.exit_code,
+        verbose,
+    );
 
     let hint = crate::core::tee::tee_and_hint(&raw, "playwright", result.exit_code);
     let shown = crate::core::runner::emit_guarded(&filtered, hint.as_deref(), &raw);
@@ -330,6 +315,32 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     }
 
     Ok(0)
+}
+
+fn format_playwright_output(stdout: &str, combined: &str, exit_code: i32, verbose: u8) -> String {
+    let parse_result = PlaywrightParser::parse(stdout);
+    let mode = FormatMode::from_verbosity(verbose);
+
+    match parse_result {
+        ParseResult::Full(data) => {
+            if verbose > 0 {
+                eprintln!("playwright test (Tier 1: Full JSON parse)");
+            }
+            data.format(mode)
+        }
+        ParseResult::Degraded(data, warnings) => {
+            if verbose > 0 {
+                emit_degradation_warning("playwright", &warnings.join(", "));
+            }
+            data.format(mode)
+        }
+        ParseResult::Passthrough(_) => {
+            if let Some(reason) = passthrough_warning_reason(exit_code) {
+                emit_passthrough_warning("playwright", reason);
+            }
+            truncate_passthrough(combined)
+        }
+    }
 }
 
 #[cfg(test)]
@@ -476,5 +487,33 @@ mod tests {
         let result = PlaywrightParser::parse(invalid);
         assert_eq!(result.tier(), 3); // Passthrough
         assert!(!result.is_ok());
+    }
+
+    #[test]
+    fn test_playwright_successful_json_ignores_combined_stderr() {
+        let stdout = r#"{
+            "stats": {
+                "expected": 2,
+                "unexpected": 0,
+                "skipped": 0,
+                "duration": 100.0
+            },
+            "suites": []
+        }"#;
+        let combined = format!("{stdout}\nWARN noisy stderr line\n");
+
+        let filtered = format_playwright_output(stdout, &combined, 0, 0);
+
+        assert!(filtered.contains("PASS (2) FAIL (0)"));
+        assert!(!filtered.contains("noisy stderr"));
+    }
+
+    #[test]
+    fn test_playwright_failed_command_passthrough_includes_stderr() {
+        let combined = "Error: command not found: playwright\n";
+
+        let filtered = format_playwright_output("", combined, 1, 0);
+
+        assert_eq!(filtered, combined);
     }
 }

--- a/src/cmds/js/pnpm_cmd.rs
+++ b/src/cmds/js/pnpm_cmd.rs
@@ -11,8 +11,9 @@ use std::collections::HashMap;
 use std::ffi::OsString;
 
 use crate::parser::{
-    emit_degradation_warning, emit_passthrough_warning, truncate_passthrough, Dependency,
-    DependencyState, FormatMode, OutputParser, ParseResult, TokenFormatter,
+    emit_degradation_warning, emit_passthrough_warning, passthrough_warning_reason,
+    truncate_passthrough, Dependency, DependencyState, FormatMode, OutputParser, ParseResult,
+    TokenFormatter,
 };
 
 const MAX_LISTING: usize = CAP_LIST;
@@ -43,9 +44,11 @@ struct PnpmOutdatedOutput {
 
 #[derive(Debug, Deserialize)]
 struct PnpmOutdatedPackage {
-    current: String,
+    current: Option<String>,
     latest: String,
     wanted: Option<String>,
+    #[serde(rename = "isDeprecated", default)]
+    is_deprecated: bool,
     #[serde(rename = "dependencyType", default)]
     dependency_type: String,
 }
@@ -199,14 +202,25 @@ impl OutputParser for PnpmOutdatedParser {
                 let mut outdated_count = 0;
 
                 for (name, pkg) in &json.packages {
-                    if pkg.current != pkg.latest {
+                    let current = pkg
+                        .current
+                        .as_deref()
+                        .or(pkg.wanted.as_deref())
+                        .unwrap_or(&pkg.latest);
+                    let latest = if pkg.is_deprecated && current == pkg.latest {
+                        format!("{} (deprecated)", pkg.latest)
+                    } else {
+                        pkg.latest.clone()
+                    };
+
+                    if current != latest {
                         outdated_count += 1;
                     }
 
                     dependencies.push(Dependency {
                         name: name.clone(),
-                        current_version: pkg.current.clone(),
-                        latest_version: Some(pkg.latest.clone()),
+                        current_version: current.to_string(),
+                        latest_version: Some(latest),
                         wanted_version: pkg.wanted.clone(),
                         dev_dependency: pkg.dependency_type == "devDependencies",
                     });
@@ -434,40 +448,66 @@ fn run_outdated(args: &[String], verbose: u8) -> Result<i32> {
     let result = exec_capture(&mut cmd).context("Failed to run pnpm outdated")?;
     let combined = result.combined();
 
-    // Parse output using PnpmOutdatedParser
-    let parse_result = PnpmOutdatedParser::parse(&result.stdout);
-    let mode = FormatMode::from_verbosity(verbose);
+    let formatted = format_outdated_output(
+        &result.stdout,
+        &combined,
+        result.exit_code,
+        verbose,
+    );
 
-    let filtered = match parse_result {
-        ParseResult::Full(data) => {
-            if verbose > 0 {
-                eprintln!("pnpm outdated (Tier 1: Full JSON parse)");
-            }
-            data.format(mode)
-        }
-        ParseResult::Degraded(data, warnings) => {
-            if verbose > 0 {
-                emit_degradation_warning("pnpm outdated", &warnings.join(", "));
-            }
-            data.format(mode)
-        }
-        ParseResult::Passthrough(raw) => {
-            emit_passthrough_warning("pnpm outdated", "All parsing tiers failed");
-            raw
-        }
-    };
-
-    let display = if filtered.trim().is_empty() {
+    let display = if formatted.text.trim().is_empty() {
         "All packages up-to-date".to_string()
     } else {
-        filtered.clone()
+        formatted.text.clone()
     };
     let shown = never_worse(&combined, &display);
     println!("{}", shown);
 
     timer.track("pnpm outdated", "rtk pnpm outdated", &combined, shown);
 
+    if formatted.passthrough && !result.success() {
+        return Ok(result.exit_code);
+    }
+
     Ok(0)
+}
+
+struct FormattedOutdatedOutput {
+    text: String,
+    passthrough: bool,
+}
+
+fn format_outdated_output(
+    stdout: &str,
+    combined: &str,
+    exit_code: i32,
+    verbose: u8,
+) -> FormattedOutdatedOutput {
+    let parse_result = PnpmOutdatedParser::parse(stdout);
+    let mode = FormatMode::from_verbosity(verbose);
+
+    let (text, passthrough) = match parse_result {
+        ParseResult::Full(data) => {
+            if verbose > 0 {
+                eprintln!("pnpm outdated (Tier 1: Full JSON parse)");
+            }
+            (data.format(mode), false)
+        }
+        ParseResult::Degraded(data, warnings) => {
+            if verbose > 0 {
+                emit_degradation_warning("pnpm outdated", &warnings.join(", "));
+            }
+            (data.format(mode), false)
+        }
+        ParseResult::Passthrough(_) => {
+            if let Some(reason) = passthrough_warning_reason(exit_code) {
+                emit_passthrough_warning("pnpm outdated", reason);
+            }
+            (truncate_passthrough(combined), true)
+        }
+    };
+
+    FormattedOutdatedOutput { text, passthrough }
 }
 
 fn run_install(args: &[String], verbose: u8) -> Result<i32> {
@@ -588,6 +628,62 @@ mod tests {
         let data = result.unwrap();
         assert_eq!(data.outdated_count, 1);
         assert_eq!(data.dependencies[0].name, "express");
+    }
+
+    #[test]
+    fn test_pnpm_outdated_parser_json_without_current() {
+        let json = r#"{
+            "left-pad": {
+                "latest": "1.3.0",
+                "wanted": "1.0.0",
+                "isDeprecated": true,
+                "dependencyType": "dependencies"
+            }
+        }"#;
+
+        let result = PnpmOutdatedParser::parse(json);
+        assert_eq!(result.tier(), 1);
+        assert!(result.is_ok());
+
+        let data = result.unwrap();
+        assert_eq!(data.outdated_count, 1);
+        assert_eq!(data.dependencies[0].name, "left-pad");
+        assert_eq!(data.dependencies[0].current_version, "1.0.0");
+        assert_eq!(data.dependencies[0].latest_version.as_deref(), Some("1.3.0"));
+    }
+
+    #[test]
+    fn test_pnpm_outdated_parser_json_deprecated_latest_package() {
+        let json = r#"{
+            "left-pad": {
+                "latest": "1.3.0",
+                "wanted": "1.3.0",
+                "isDeprecated": true,
+                "dependencyType": "dependencies"
+            }
+        }"#;
+
+        let result = PnpmOutdatedParser::parse(json);
+        assert_eq!(result.tier(), 1);
+        assert!(result.is_ok());
+
+        let data = result.unwrap();
+        assert_eq!(data.outdated_count, 1);
+        assert_eq!(data.dependencies[0].current_version, "1.3.0");
+        assert_eq!(
+            data.dependencies[0].latest_version.as_deref(),
+            Some("1.3.0 (deprecated)")
+        );
+    }
+
+    #[test]
+    fn test_pnpm_outdated_failed_command_passthrough_includes_stderr() {
+        let combined = "ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command failed\n";
+
+        let filtered = format_outdated_output("", combined, 1, 0);
+
+        assert_eq!(filtered.text, combined);
+        assert!(filtered.passthrough);
     }
 
     #[test]

--- a/src/cmds/js/vitest_cmd.rs
+++ b/src/cmds/js/vitest_cmd.rs
@@ -9,8 +9,8 @@ use crate::core::tracking;
 use crate::core::utils::{package_manager_exec, strip_ansi};
 use crate::parser::{
     emit_degradation_warning, emit_passthrough_warning, extract_json_object, truncate_output,
-    truncate_passthrough, FormatMode, OutputParser, ParseResult, TestFailure, TestResult,
-    TokenFormatter,
+    passthrough_warning_reason, truncate_passthrough, FormatMode, OutputParser, ParseResult,
+    TestFailure, TestResult, TokenFormatter,
 };
 use crate::Commands;
 
@@ -251,6 +251,7 @@ pub fn run_test(command: &Commands, args: &[String], verbose: u8) -> Result<i32>
         framework,
         &result.stdout,
         &combined,
+        result.exit_code,
         passthrough_requested,
         verbose,
     );
@@ -332,6 +333,7 @@ fn format_test_output(
     framework: &str,
     stdout: &str,
     combined: &str,
+    exit_code: i32,
     passthrough_requested: bool,
     verbose: u8,
 ) -> FormattedTestOutput {
@@ -355,8 +357,10 @@ fn format_test_output(
             FormattedTestOutput::new(data.format(mode))
         }
         ParseResult::Passthrough(_) => {
-            emit_passthrough_warning(framework, "All parsing tiers failed");
-            format_passthrough_output(stdout)
+            if let Some(reason) = passthrough_warning_reason(exit_code) {
+                emit_passthrough_warning(framework, reason);
+            }
+            format_passthrough_output(combined)
         }
     }
 }
@@ -575,12 +579,56 @@ Scope: all 6 workspace projects
    Duration  450ms
 "#;
 
-        let filtered = format_test_output("vitest", output, output, true, 0);
+        let filtered = format_test_output("vitest", output, output, 0, true, 0);
 
         assert!(filtered.text.contains("keeps docs path"));
         assert!(filtered.text.contains("keeps app path"));
         assert!(filtered.text.contains("Tests  2 passed"));
         assert!(!filtered.truncated);
+    }
+
+    #[test]
+    fn test_vitest_successful_json_ignores_combined_stderr() {
+        let stdout = r#"{
+            "numTotalTests": 2,
+            "numPassedTests": 2,
+            "numFailedTests": 0,
+            "numPendingTests": 0,
+            "testResults": []
+        }"#;
+        let combined = format!("{stdout}\nWARN noisy stderr line\n");
+
+        let filtered = format_test_output("vitest", stdout, &combined, 0, false, 0);
+
+        assert!(filtered.text.contains("PASS (2) FAIL (0)"));
+        assert!(!filtered.text.contains("noisy stderr"));
+        assert!(!filtered.truncated);
+    }
+
+    #[test]
+    fn test_vitest_failed_command_passthrough_includes_stderr() {
+        let stdout = "";
+        let combined =
+            "ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command \"vitest\" not found\n";
+
+        let filtered = format_test_output("vitest", stdout, combined, 1, false, 0);
+
+        assert_eq!(filtered.text, combined);
+        assert!(!filtered.truncated);
+        assert_eq!(passthrough_warning_reason(1), None);
+    }
+
+    #[test]
+    fn test_vitest_successful_unparseable_output_reports_parser_gap() {
+        let output = "30.1.2\n";
+
+        let filtered = format_test_output("jest", output, output, 0, false, 0);
+
+        assert_eq!(filtered.text, output);
+        assert_eq!(
+            passthrough_warning_reason(0),
+            Some("All parsing tiers failed")
+        );
     }
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -132,6 +132,11 @@ pub fn emit_passthrough_warning(tool: &str, reason: &str) {
     eprintln!("[RTK:PASSTHROUGH] {} parser: {}", tool, reason);
 }
 
+/// A non-zero command exit explains unparseable output without implying a parser defect.
+pub fn passthrough_warning_reason(exit_code: i32) -> Option<&'static str> {
+    (exit_code == 0).then_some("All parsing tiers failed")
+}
+
 /// Extract a complete JSON object from input that may have non-JSON prefix (pnpm banner, dotenv messages, etc.)
 ///
 /// Strategy:
@@ -257,6 +262,16 @@ mod tests {
         let emoji = "🎉".repeat(200);
         let result = truncate_output(&emoji, 100);
         assert!(result.contains("[RTK:PASSTHROUGH]"));
+    }
+
+    #[test]
+    fn test_passthrough_warning_only_for_successful_commands() {
+        assert_eq!(
+            passthrough_warning_reason(0),
+            Some("All parsing tiers failed")
+        );
+        assert_eq!(passthrough_warning_reason(1), None);
+        assert_eq!(passthrough_warning_reason(127), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

* Preserve combined stdout and stderr when JavaScript command parsers fall back to passthrough, so failed Vitest, Playwright, and pnpm commands retain stderr-only errors.
* Suppress parser-failure warnings for nonzero child exits while still warning on successful but unparseable output.
* Support pnpm v10 `outdated --format json` output when `current` is absent, including deprecated-package reports.

## Test plan

* [x] `cargo fmt --check`
* [x] `cargo test -q`
* [x] Manual test of Vitest, Playwright, and pnpm passthrough and happy-path behavior
* [x] Manual test of `pnpm outdated --format json` exit behavior with pnpm 10.33.2
