### PR TITLE
fix(ls): track savings against the user baseline

### DIFF
--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -20,6 +20,9 @@ lazy_static! {
 }
 
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
+    let baseline_output = capture_ls_baseline(args);
+    let baseline_command = baseline_command(args);
+
     let show_all = args
         .iter()
         .any(|a| (a.starts_with('-') && !a.starts_with("--") && a.contains('a')) || a == "--all");
@@ -82,6 +85,13 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         paths.join(" ")
     };
 
+    let mut run_options = RunOptions::stdout_only()
+        .early_exit_on_failure()
+        .no_trailing_newline();
+    if let Some(output) = baseline_output.as_deref() {
+        run_options = run_options.tracking_baseline(&baseline_command, output);
+    }
+
     runner::run_filtered(
         cmd,
         "ls",
@@ -120,10 +130,31 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
             }
             filtered
         },
-        RunOptions::stdout_only()
-            .early_exit_on_failure()
-            .no_trailing_newline(),
+        run_options,
     )
+}
+
+fn capture_ls_baseline(args: &[String]) -> Option<String> {
+    let mut cmd = resolved_command("ls");
+    cmd.env("LC_ALL", "C");
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    let output = cmd.output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    Some(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+fn baseline_command(args: &[String]) -> String {
+    if args.is_empty() {
+        "ls".to_string()
+    } else {
+        format!("ls {}", args.join(" "))
+    }
 }
 
 /// Format bytes into human-readable size
@@ -352,6 +383,15 @@ fn compact_ls(raw: &str, show_all: bool, show_long: bool) -> (String, String, us
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_baseline_command_matches_user_invocation() {
+        assert_eq!(baseline_command(&[]), "ls");
+        assert_eq!(
+            baseline_command(&["-a".to_string(), "src".to_string()]),
+            "ls -a src"
+        );
+    }
 
     #[test]
     fn test_compact_basic() {

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -40,6 +40,12 @@ pub struct RunOptions<'a> {
     /// can read from a pipe (e.g. `cat file | rtk wc`); without it the child
     /// gets an empty stdin and reports zero.
     pub inherit_stdin: bool,
+    tracking_baseline: Option<TrackingBaseline<'a>>,
+}
+
+struct TrackingBaseline<'a> {
+    command: &'a str,
+    output: &'a str,
 }
 
 impl<'a> RunOptions<'a> {
@@ -74,6 +80,13 @@ impl<'a> RunOptions<'a> {
 
     pub fn inherit_stdin(mut self) -> Self {
         self.inherit_stdin = true;
+        self
+    }
+
+    /// Track savings against the command/output the user would have produced,
+    /// while still using the executed command output for filtering and guards.
+    pub fn tracking_baseline(mut self, command: &'a str, output: &'a str) -> Self {
+        self.tracking_baseline = Some(TrackingBaseline { command, output });
         self
     }
 }
@@ -147,13 +160,26 @@ where
         guarded
     };
 
+    let (tracking_command, tracking_output) = tracking_context(&opts, cmd_label, raw_for_tracking);
+
     timer.track(
-        cmd_label,
-        &format!("rtk {}", cmd_label),
-        raw_for_tracking,
+        tracking_command,
+        &format!("rtk {}", tracking_command),
+        tracking_output,
         &shown,
     );
     Ok(exit_code)
+}
+
+fn tracking_context<'a>(
+    opts: &'a RunOptions<'a>,
+    command: &'a str,
+    output: &'a str,
+) -> (&'a str, &'a str) {
+    opts.tracking_baseline
+        .as_ref()
+        .map(|baseline| (baseline.command, baseline.output))
+        .unwrap_or((command, output))
 }
 
 pub fn run(
@@ -283,4 +309,29 @@ pub fn run_streamed(
         RunMode::Streamed(filter),
         opts,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tracking_context_uses_executed_command_by_default() {
+        let options = RunOptions::default();
+
+        assert_eq!(
+            tracking_context(&options, "ls -la .", "enriched output"),
+            ("ls -la .", "enriched output")
+        );
+    }
+
+    #[test]
+    fn tracking_context_prefers_explicit_baseline() {
+        let options = RunOptions::default().tracking_baseline("ls", "plain output");
+
+        assert_eq!(
+            tracking_context(&options, "ls -la .", "enriched output"),
+            ("ls", "plain output")
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- capture the exact plain ls invocation separately from the enriched ls -la command used for filtering
- add an explicit baseline option to the shared captured-command runner
- keep enriched output for parsing and never-worse display guards while using the plain output only for telemetry
- record the original command as ls plus the user-provided arguments instead of the internal command
- fall back to existing tracking behavior if the baseline command cannot be captured successfully

Fixes #561

## Verification

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features (2,498 passed, 8 ignored)
- cargo build --release --all-features
- isolated live telemetry check recorded original_cmd as ls src/cmds/system, rtk_cmd as rtk ls src/cmds/system, and 44 input tokens rather than the enriched ls -la output