### PR TITLE
feat(qwen): add native hook integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ rtk gain        # Should show the savings dashboard
 # 1. Install for your AI tool
 rtk init -g                     # Claude Code / Copilot (default)
 rtk init -g --gemini            # Gemini CLI
+rtk init -g --qwen              # Qwen Code CLI
 rtk init -g --codex             # Codex (OpenAI)
 rtk init -g --agent cursor      # Cursor
 rtk init -g --agent windsurf    # Windsurf
@@ -381,7 +382,7 @@ rtk init -g
 
 ## Supported AI Tools
 
-RTK supports 15 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents, reducing the bash output the agent reads where the agent supports command interception.
+RTK supports 16 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents, reducing the bash output the agent reads where the agent supports command interception.
 
 | Tool | Install | Method |
 |------|---------|--------|
@@ -390,6 +391,7 @@ RTK supports 15 AI coding tools. Each integration rewrites shell commands to `rt
 | **GitHub Copilot CLI** | `rtk init -g --copilot` | PreToolUse deny-with-suggestion (CLI limitation) |
 | **Cursor** | `rtk init -g --agent cursor` | preToolUse hook (hooks.json) |
 | **Gemini CLI** | `rtk init -g --gemini` | BeforeTool hook |
+| **Qwen Code CLI** | `rtk init -g --qwen` | PreToolUse hook with native permission preservation |
 | **Codex** | `rtk init -g --codex` | AGENTS.md + RTK.md instructions |
 | **Windsurf** | `rtk init -g --agent windsurf` | .windsurfrules (project-scoped) |
 | **Cline / Roo Code** | `rtk init --agent cline` | .clinerules (project-scoped) |

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -6,7 +6,7 @@
 
 The **lifecycle management** layer for LLM agent hooks: install, uninstall, verify integrity, audit usage, and manage trust. This component creates and maintains the hook artifacts that live in `hooks/` (root), but does **not** execute rewrite logic itself — that lives in `discover/registry`.
 
-Owns: `rtk init` installation flows (5 agents via `AgentTarget` enum + 3 special modes: Gemini, Codex, OpenCode), SHA-256 integrity verification, hook version checking, audit log analysis, `rtk rewrite` CLI entry point, and TOML filter trust management.
+Owns: `rtk init` installation flows (agents via `AgentTarget` plus special Gemini, Qwen, Codex, and OpenCode modes), SHA-256 integrity verification, hook version checking, audit log analysis, `rtk rewrite` CLI entry point, and TOML filter trust management.
 
 Does **not** own: the deployed hook scripts themselves (that's `hooks/`), the rewrite pattern registry (that's `discover/`), or command filtering (that's `cmds/`).
 
@@ -88,6 +88,7 @@ Rules are loaded from all Claude Code `settings.json` files (project + global, i
 | Copilot VS Code (rtk hook copilot) | Yes | `permissionDecision: "ask"` — user prompted |
 | Cursor (rtk hook cursor) | Ready | `permission: "ask",` — users will be prompted when Cursor enforces the permission; in the meantime, allow |
 | Gemini CLI (rtk hook gemini) | No (allow/deny only) | allow (limitation — no ask mode in Gemini) |
+| Qwen Code (rtk hook qwen) | Yes | ask |
 | Copilot CLI (rtk hook copilot) | No updatedInput | deny-with-suggestion (unchanged) |
 | Codex | ask parsed but no-op | allow (limitation — fails open) |
 

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -1,5 +1,6 @@
 pub const REWRITE_HOOK_FILE: &str = "rtk-rewrite.sh";
 pub const GEMINI_HOOK_FILE: &str = "rtk-hook-gemini.sh";
+pub const QWEN_HOOK_FILE: &str = "rtk-hook-qwen.sh";
 pub const CLAUDE_DIR: &str = ".claude";
 pub const HOOKS_SUBDIR: &str = "hooks";
 pub const SETTINGS_JSON: &str = "settings.json";
@@ -23,6 +24,7 @@ pub const OPENCODE_PLUGIN_FILE: &str = "rtk.ts";
 pub const CURSOR_DIR: &str = ".cursor";
 pub const CODEX_DIR: &str = ".codex";
 pub const GEMINI_DIR: &str = ".gemini";
+pub const QWEN_DIR: &str = ".qwen";
 
 pub const GITHUB_DIR: &str = ".github";
 pub const COPILOT_HOOK_FILE: &str = "rtk-rewrite.json";

--- a/src/hooks/hook_check.rs
+++ b/src/hooks/hook_check.rs
@@ -152,7 +152,7 @@ mod tests {
     use crate::hooks::constants::{
         CODEX_DIR, CONFIG_DIR, CURSOR_DIR, GEMINI_DIR, GEMINI_HOOK_FILE, HERMES_DIR,
         HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME,
-        OPENCODE_PLUGIN_FILE, OPENCODE_SUBDIR, PLUGIN_SUBDIR,
+        OPENCODE_PLUGIN_FILE, OPENCODE_SUBDIR, PLUGIN_SUBDIR, QWEN_DIR, QWEN_HOOK_FILE,
     };
 
     fn other_integration_installed(home: &std::path::Path) -> bool {
@@ -168,6 +168,7 @@ mod tests {
             home.join(GEMINI_DIR)
                 .join(HOOKS_SUBDIR)
                 .join(GEMINI_HOOK_FILE),
+            home.join(QWEN_DIR).join(HOOKS_SUBDIR).join(QWEN_HOOK_FILE),
             home.join(HERMES_DIR)
                 .join(HERMES_PLUGINS_SUBDIR)
                 .join(HERMES_PLUGIN_NAME)
@@ -289,6 +290,19 @@ mod tests {
     }
 
     #[test]
+    fn test_other_integration_qwen() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp
+            .path()
+            .join(QWEN_DIR)
+            .join(HOOKS_SUBDIR)
+            .join(QWEN_HOOK_FILE);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"hook").unwrap();
+        assert!(other_integration_installed(tmp.path()));
+    }
+
+    #[test]
     fn test_other_integration_hermes() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let path = tmp
@@ -308,6 +322,7 @@ mod tests {
         std::fs::create_dir_all(tmp.path().join(CURSOR_DIR).join(HOOKS_SUBDIR)).unwrap();
         std::fs::create_dir_all(tmp.path().join(CODEX_DIR)).unwrap();
         std::fs::create_dir_all(tmp.path().join(GEMINI_DIR)).unwrap();
+        std::fs::create_dir_all(tmp.path().join(QWEN_DIR)).unwrap();
         std::fs::create_dir_all(
             tmp.path()
                 .join(HERMES_DIR)

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -332,6 +332,115 @@ fn print_gemini(decision: &str, rewrite: Option<&str>) {
     let _ = writeln!(io::stdout(), "{}", gemini_json(decision, rewrite));
 }
 
+// ── Qwen Code hook ────────────────────────────────────────────
+
+/// Run the Qwen Code PreToolUse hook.
+pub fn run_qwen() -> Result<()> {
+    let input = read_stdin_limited()?;
+    let input = strip_leading_bom(&input).trim();
+    if input.is_empty() {
+        return Ok(());
+    }
+
+    let json: Value = match serde_json::from_str(input) {
+        Ok(value) => value,
+        Err(error) => {
+            let _ = writeln!(
+                io::stderr(),
+                "[rtk hook] Failed to parse JSON input: {error}"
+            );
+            return Ok(());
+        }
+    };
+
+    if json.get("tool_name").and_then(Value::as_str) != Some("run_shell_command") {
+        return Ok(());
+    }
+
+    let tool_input = json.get("tool_input").cloned().unwrap_or_else(|| json!({}));
+    let Some(command) = tool_input
+        .get("command")
+        .and_then(Value::as_str)
+        .filter(|command| !command.is_empty())
+    else {
+        return Ok(());
+    };
+
+    let configured_verdict = permissions::check_command_for(command, permissions::Host::Qwen);
+    let verdict = qwen_effective_verdict(
+        configured_verdict,
+        json.get("permission_mode").and_then(Value::as_str),
+    );
+    if let Some(output) = qwen_response(command, &tool_input, verdict) {
+        let _ = writeln!(io::stdout(), "{output}");
+    }
+
+    Ok(())
+}
+
+fn qwen_effective_verdict(
+    configured: PermissionVerdict,
+    permission_mode: Option<&str>,
+) -> PermissionVerdict {
+    if configured == PermissionVerdict::Default && permission_mode == Some("yolo") {
+        PermissionVerdict::Allow
+    } else {
+        configured
+    }
+}
+
+fn qwen_response(command: &str, tool_input: &Value, verdict: PermissionVerdict) -> Option<Value> {
+    match decide_from_verdict(command, verdict) {
+        HookDecision::Deny => {
+            audit_log("deny", command, "");
+            Some(qwen_json("deny", None))
+        }
+        HookDecision::AllowRewrite(rewritten) => {
+            audit_log("rewrite", command, &rewritten);
+            Some(qwen_json(
+                "allow",
+                Some(rewrite_tool_input(tool_input, &rewritten)),
+            ))
+        }
+        HookDecision::AskRewrite { rewritten, .. } => {
+            audit_log("ask", command, &rewritten);
+            Some(qwen_json(
+                "ask",
+                Some(rewrite_tool_input(tool_input, &rewritten)),
+            ))
+        }
+        HookDecision::Defer => None,
+    }
+}
+
+fn rewrite_tool_input(tool_input: &Value, rewritten: &str) -> Value {
+    let mut updated = tool_input.clone();
+    if let Some(object) = updated.as_object_mut() {
+        object.insert("command".to_string(), Value::String(rewritten.to_string()));
+        updated
+    } else {
+        json!({ "command": rewritten })
+    }
+}
+
+fn qwen_json(decision: &str, updated_input: Option<Value>) -> Value {
+    let mut hook_output = json!({
+        "hookEventName": PRE_TOOL_USE_KEY,
+        "permissionDecision": decision,
+        "permissionDecisionReason": if decision == "deny" {
+            "Blocked by RTK permission rule"
+        } else {
+            "RTK auto-rewrite"
+        }
+    });
+
+    if let Some(input) = updated_input {
+        hook_output["updatedInput"] = input;
+    }
+
+    json!({ "hookSpecificOutput": hook_output })
+}
+
 // ── Audit logging ─────────────────────────────────────────────
 
 /// Best-effort audit log when RTK_HOOK_AUDIT=1.
@@ -1680,6 +1789,83 @@ mod tests {
         ))
         .unwrap();
         assert_eq!(v["decision"], "deny");
+    }
+
+    // --- Qwen Code rendering ---
+
+    #[test]
+    fn test_qwen_allow_emits_current_pre_tool_use_schema() {
+        let input = json!({ "command": "git status", "description": "Inspect worktree" });
+        let output = qwen_response("git status", &input, PermissionVerdict::Allow).unwrap();
+
+        assert_eq!(
+            output["hookSpecificOutput"]["hookEventName"],
+            PRE_TOOL_USE_KEY
+        );
+        assert_eq!(output["hookSpecificOutput"]["permissionDecision"], "allow");
+        assert_eq!(
+            output["hookSpecificOutput"]["updatedInput"]["command"],
+            "rtk git status"
+        );
+        assert_eq!(
+            output["hookSpecificOutput"]["updatedInput"]["description"],
+            "Inspect worktree"
+        );
+    }
+
+    #[test]
+    fn test_qwen_default_asks_with_rewritten_input() {
+        let input = json!({ "command": "cargo test" });
+        let output = qwen_response("cargo test", &input, PermissionVerdict::Default).unwrap();
+
+        assert_eq!(output["hookSpecificOutput"]["permissionDecision"], "ask");
+        assert_eq!(
+            output["hookSpecificOutput"]["updatedInput"]["command"],
+            "rtk cargo test"
+        );
+    }
+
+    #[test]
+    fn test_qwen_deny_omits_updated_input() {
+        let input = json!({ "command": "rm -rf /tmp/x" });
+        let output = qwen_response("rm -rf /tmp/x", &input, PermissionVerdict::Deny).unwrap();
+
+        assert_eq!(output["hookSpecificOutput"]["permissionDecision"], "deny");
+        assert!(output["hookSpecificOutput"].get("updatedInput").is_none());
+    }
+
+    #[test]
+    fn test_qwen_unsupported_or_unsafe_commands_defer_to_host() {
+        let unsupported = json!({ "command": "unknown-tool --flag" });
+        assert!(qwen_response(
+            "unknown-tool --flag",
+            &unsupported,
+            PermissionVerdict::Default
+        )
+        .is_none());
+        let unsafe_input = json!({ "command": "git status $(rm -rf /tmp/x)" });
+        assert!(qwen_response(
+            "git status $(rm -rf /tmp/x)",
+            &unsafe_input,
+            PermissionVerdict::Allow
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn test_qwen_yolo_only_upgrades_default_permission() {
+        assert_eq!(
+            qwen_effective_verdict(PermissionVerdict::Default, Some("yolo")),
+            PermissionVerdict::Allow
+        );
+        assert_eq!(
+            qwen_effective_verdict(PermissionVerdict::Ask, Some("yolo")),
+            PermissionVerdict::Ask
+        );
+        assert_eq!(
+            qwen_effective_verdict(PermissionVerdict::Deny, Some("yolo")),
+            PermissionVerdict::Deny
+        );
     }
 
     // --- Factory Droid hook ---

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -18,7 +18,7 @@ use super::constants::{
     DROID_HOOK_COMMAND, DROID_SETTINGS_FILE, GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR,
     HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON,
     HOOKS_SUBDIR, PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR,
-    PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
+    PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, QWEN_DIR, QWEN_HOOK_FILE, REWRITE_HOOK_FILE, SETTINGS_JSON,
 };
 use super::integrity;
 use super::is_claude_hook_command;
@@ -69,6 +69,7 @@ const CLAUDE_MD: &str = "CLAUDE.md";
 const AGENTS_MD: &str = "AGENTS.md";
 const RTK_MD_REF: &str = "@RTK.md";
 const GEMINI_MD: &str = "GEMINI.md";
+const QWEN_MD: &str = "QWEN.md";
 
 const RTK_BLOCK_START: &str = "<!-- rtk-instructions";
 const RTK_BLOCK_END: &str = "<!-- /rtk-instructions -->";
@@ -4446,6 +4447,297 @@ fn uninstall_gemini(ctx: InitContext) -> Result<Vec<String>> {
     Ok(removed)
 }
 
+// ─── Qwen Code support ──────────────────────────────────────────
+
+const QWEN_HOOK_SCRIPT: &str = r#"#!/bin/bash
+exec rtk hook qwen
+"#;
+
+fn resolve_qwen_dir() -> Result<PathBuf> {
+    resolve_home_subdir(QWEN_DIR)
+}
+
+fn qwen_awareness() -> String {
+    RTK_SLIM
+        .replace(
+            "All other commands are automatically rewritten by the Claude Code hook.",
+            "All other commands are automatically rewritten by the Qwen Code hook.",
+        )
+        .replace("Refer to CLAUDE.md", "Refer to QWEN.md")
+}
+
+pub fn run_qwen(
+    global: bool,
+    hook_only: bool,
+    patch_mode: PatchMode,
+    ctx: InitContext,
+) -> Result<()> {
+    let InitContext { dry_run, .. } = ctx;
+    if !global {
+        anyhow::bail!(
+            "Qwen Code support is global-only. Use: rtk init -g --qwen (or --agent qwen)"
+        );
+    }
+
+    let qwen_dir = resolve_qwen_dir()?;
+    let hook_dir = qwen_dir.join(HOOKS_SUBDIR);
+    if !dry_run {
+        fs::create_dir_all(&hook_dir)
+            .with_context(|| format!("Failed to create Qwen hook dir: {}", hook_dir.display()))?;
+    }
+
+    let hook_path = hook_dir.join(QWEN_HOOK_FILE);
+    write_if_changed(&hook_path, QWEN_HOOK_SCRIPT, "Qwen hook", ctx)?;
+
+    #[cfg(unix)]
+    if !dry_run {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&hook_path, fs::Permissions::from_mode(0o755))
+            .with_context(|| format!("Failed to set hook permissions: {}", hook_path.display()))?;
+    }
+
+    if !dry_run {
+        integrity::store_hash(&hook_path).with_context(|| {
+            format!("Failed to store integrity hash for {}", hook_path.display())
+        })?;
+    }
+
+    if !hook_only {
+        let awareness = qwen_awareness();
+        write_if_changed(&qwen_dir.join(QWEN_MD), &awareness, QWEN_MD, ctx)?;
+    }
+
+    patch_qwen_settings(&qwen_dir, &hook_path, patch_mode, ctx)?;
+
+    if dry_run {
+        print_dry_run_footer();
+    } else {
+        println!("\nQwen Code hook installed (global).\n");
+        println!("  Hook: {}", hook_path.display());
+        if !hook_only {
+            println!("  QWEN.md: {}", qwen_dir.join(QWEN_MD).display());
+        }
+        println!("  Restart Qwen Code. Test with: git status\n");
+    }
+
+    Ok(())
+}
+
+fn qwen_hook_entry(hook_command: &str) -> serde_json::Value {
+    serde_json::json!({
+        "matcher": "^run_shell_command$",
+        "hooks": [{
+            "type": "command",
+            "command": hook_command,
+            "name": "rtk-rewrite",
+            "description": "Rewrite supported shell commands through RTK",
+            "timeout": 10000
+        }]
+    })
+}
+
+fn is_qwen_rtk_hook(entry: &serde_json::Value) -> bool {
+    entry
+        .get("hooks")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|hook| hook.get("command").and_then(serde_json::Value::as_str))
+        .any(|command| command.contains("rtk hook qwen") || command.contains(QWEN_HOOK_FILE))
+}
+
+fn insert_qwen_hook(settings: &mut serde_json::Value, hook_command: &str) -> Result<bool> {
+    let hooks = settings
+        .as_object_mut()
+        .context("Qwen settings.json is not an object")?
+        .entry("hooks")
+        .or_insert_with(|| serde_json::json!({}));
+    let pre_tool_use = hooks
+        .as_object_mut()
+        .context("Qwen settings hooks is not an object")?
+        .entry(PRE_TOOL_USE_KEY)
+        .or_insert_with(|| serde_json::json!([]));
+    let entries = pre_tool_use
+        .as_array_mut()
+        .context("Qwen PreToolUse hooks is not an array")?;
+
+    if entries.iter().any(is_qwen_rtk_hook) {
+        return Ok(false);
+    }
+
+    entries.push(qwen_hook_entry(hook_command));
+    Ok(true)
+}
+
+fn remove_qwen_hook(settings: &mut serde_json::Value) -> bool {
+    let Some(entries) = settings
+        .pointer_mut("/hooks/PreToolUse")
+        .and_then(serde_json::Value::as_array_mut)
+    else {
+        return false;
+    };
+
+    let before = entries.len();
+    entries.retain(|entry| !is_qwen_rtk_hook(entry));
+    entries.len() != before
+}
+
+fn patch_qwen_settings(
+    qwen_dir: &Path,
+    hook_path: &Path,
+    patch_mode: PatchMode,
+    ctx: InitContext,
+) -> Result<()> {
+    let InitContext { verbose, dry_run } = ctx;
+    let settings_path = qwen_dir.join(SETTINGS_JSON);
+    let mut settings = if settings_path.exists() {
+        let content = fs::read_to_string(&settings_path)
+            .with_context(|| format!("Failed to read {}", settings_path.display()))?;
+        serde_json::from_str(&content)
+            .with_context(|| format!("Failed to parse {}", settings_path.display()))?
+    } else {
+        serde_json::json!({})
+    };
+
+    if settings
+        .pointer("/hooks/PreToolUse")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|entries| entries.iter().any(is_qwen_rtk_hook))
+    {
+        if verbose > 0 {
+            eprintln!("Qwen settings.json already has RTK hook");
+        }
+        return Ok(());
+    }
+
+    if patch_mode == PatchMode::Skip {
+        println!(
+            "\nManual setup needed: add the RTK PreToolUse hook to {}",
+            settings_path.display()
+        );
+        return Ok(());
+    }
+
+    if patch_mode == PatchMode::Ask {
+        if dry_run {
+            println!(
+                "[dry-run] would prompt before patching {}",
+                settings_path.display()
+            );
+        } else {
+            print!("Patch {} with RTK hook? [y/N] ", settings_path.display());
+            std::io::Write::flush(&mut std::io::stdout())?;
+            let mut answer = String::new();
+            std::io::stdin().read_line(&mut answer)?;
+            if !answer.trim().eq_ignore_ascii_case("y") {
+                println!("Skipped. Add the hook manually later.");
+                return Ok(());
+            }
+        }
+    }
+
+    insert_qwen_hook(&mut settings, &hook_path.to_string_lossy())?;
+    let content = serde_json::to_string_pretty(&settings)?;
+
+    if dry_run {
+        println!(
+            "[dry-run] would patch Qwen settings.json: {}",
+            settings_path.display()
+        );
+        if verbose > 0 {
+            println!("[dry-run] content:\n{}", content);
+        }
+        return Ok(());
+    }
+
+    let tmp = NamedTempFile::new_in(qwen_dir)?;
+    fs::write(tmp.path(), &content)?;
+    tmp.persist(&settings_path)
+        .with_context(|| format!("Failed to write {}", settings_path.display()))?;
+
+    if verbose > 0 {
+        eprintln!("Patched {}", settings_path.display());
+    }
+
+    Ok(())
+}
+
+pub fn uninstall_qwen(global: bool, ctx: InitContext) -> Result<()> {
+    let InitContext { verbose, dry_run } = ctx;
+    if !global {
+        anyhow::bail!("Qwen Code support is global-only. Use: rtk init -g --qwen --uninstall");
+    }
+
+    let qwen_dir = resolve_qwen_dir()?;
+    let hook_path = qwen_dir.join(HOOKS_SUBDIR).join(QWEN_HOOK_FILE);
+    let mut removed = Vec::new();
+
+    if hook_path.exists() {
+        if dry_run {
+            println!("[dry-run] would remove Qwen hook: {}", hook_path.display());
+        } else {
+            // nosemgrep: filesystem-deletion -- Qwen uninstall removes only the RTK-managed hook file.
+            fs::remove_file(&hook_path)
+                .with_context(|| format!("Failed to remove {}", hook_path.display()))?;
+            let _ = integrity::remove_hash(&hook_path);
+        }
+        removed.push(format!("Qwen hook: {}", hook_path.display()));
+    }
+
+    let qwen_md = qwen_dir.join(QWEN_MD);
+    if qwen_md.exists() {
+        if dry_run {
+            println!("[dry-run] would remove QWEN.md: {}", qwen_md.display());
+        } else {
+            // nosemgrep: filesystem-deletion -- Qwen uninstall removes only the RTK-managed instructions file.
+            fs::remove_file(&qwen_md)
+                .with_context(|| format!("Failed to remove {}", qwen_md.display()))?;
+        }
+        removed.push(format!("QWEN.md: {}", qwen_md.display()));
+    }
+
+    let settings_path = qwen_dir.join(SETTINGS_JSON);
+    if settings_path.exists() {
+        let content = fs::read_to_string(&settings_path)?;
+        let mut settings: serde_json::Value = serde_json::from_str(&content)
+            .with_context(|| format!("Failed to parse {}", settings_path.display()))?;
+        if remove_qwen_hook(&mut settings) {
+            if dry_run {
+                println!(
+                    "[dry-run] would remove RTK hook from Qwen settings.json: {}",
+                    settings_path.display()
+                );
+            } else {
+                fs::write(&settings_path, serde_json::to_string_pretty(&settings)?)?;
+            }
+            removed.push("Qwen settings.json: removed RTK hook entry".to_string());
+        }
+    }
+
+    if removed.is_empty() {
+        println!("RTK Qwen support was not installed (nothing to remove)");
+    } else {
+        let prefix = if dry_run {
+            "[dry-run] would uninstall RTK (Qwen):"
+        } else {
+            "RTK uninstalled (Qwen):"
+        };
+        println!("\n{prefix}");
+        for item in &removed {
+            println!("  - {item}");
+        }
+        if !dry_run {
+            println!("\nRestart Qwen Code to apply changes.");
+        }
+    }
+
+    if verbose > 0 && !removed.is_empty() {
+        eprintln!("Qwen artifacts removed");
+    }
+
+    Ok(())
+}
+
 // ── Copilot integration ─────────────────────────────────────
 
 // PreToolUse = VS Code schema, preToolUse = Copilot CLI schema (same file, both hosts).
@@ -4761,6 +5053,64 @@ fn uninstall_copilot_global_at(copilot_dir: &Path, ctx: InitContext) -> Result<V
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn test_insert_qwen_hook_uses_current_schema_and_is_idempotent() {
+        let mut settings = serde_json::json!({
+            "theme": "dark",
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "write_file",
+                    "hooks": [{ "type": "command", "command": "check-write" }]
+                }]
+            }
+        });
+
+        assert!(
+            insert_qwen_hook(&mut settings, "/home/user/.qwen/hooks/rtk-hook-qwen.sh").unwrap()
+        );
+        assert!(
+            !insert_qwen_hook(&mut settings, "/home/user/.qwen/hooks/rtk-hook-qwen.sh").unwrap()
+        );
+
+        let entries = settings["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(entries.len(), 2);
+        let rtk = &entries[1];
+        assert_eq!(rtk["matcher"], "^run_shell_command$");
+        assert_eq!(rtk["hooks"][0]["type"], "command");
+        assert_eq!(rtk["hooks"][0]["name"], "rtk-rewrite");
+        assert_eq!(rtk["hooks"][0]["timeout"], 10000);
+        assert_eq!(settings["theme"], "dark");
+    }
+
+    #[test]
+    fn test_remove_qwen_hook_preserves_other_hooks() {
+        let mut settings = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [
+                    qwen_hook_entry("/tmp/rtk-hook-qwen.sh"),
+                    {
+                        "matcher": "write_file",
+                        "hooks": [{ "type": "command", "command": "check-write" }]
+                    }
+                ]
+            }
+        });
+
+        assert!(remove_qwen_hook(&mut settings));
+        assert!(!remove_qwen_hook(&mut settings));
+        let entries = settings["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["matcher"], "write_file");
+    }
+
+    #[test]
+    fn test_qwen_awareness_uses_qwen_names() {
+        let awareness = qwen_awareness();
+        assert!(awareness.contains("rewritten by the Qwen Code hook"));
+        assert!(awareness.contains("Refer to QWEN.md"));
+        assert!(awareness.contains("Analyze Claude Code history"));
+    }
 
     #[test]
     fn test_init_mentions_all_top_level_commands() {

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -1,5 +1,5 @@
 use super::constants::{
-    CLAUDE_DIR, CURSOR_DIR, DROID_DIR, DROID_HOME_ENV, DROID_SETTINGS_FILE, GEMINI_DIR,
+    CLAUDE_DIR, CURSOR_DIR, DROID_DIR, DROID_HOME_ENV, DROID_SETTINGS_FILE, GEMINI_DIR, QWEN_DIR,
     SETTINGS_JSON, SETTINGS_LOCAL_JSON,
 };
 use crate::core::stream::exec_capture;
@@ -35,6 +35,7 @@ pub enum Host {
     Claude,
     Cursor,
     Gemini,
+    Qwen,
     Droid,
 }
 
@@ -43,6 +44,7 @@ pub fn check_command_for(cmd: &str, host: Host) -> PermissionVerdict {
         Host::Claude => load_permission_rules(),
         Host::Cursor => load_cursor_rules(),
         Host::Gemini => load_gemini_rules(),
+        Host::Qwen => load_qwen_rules(),
         Host::Droid => load_droid_rules(),
     };
     check_command_with_rules(cmd, &deny_rules, &ask_rules, &allow_rules)
@@ -276,6 +278,28 @@ fn load_gemini_rules() -> (Vec<String>, Vec<String>, Vec<String>) {
     (Vec::new(), ask, allow)
 }
 
+fn load_qwen_rules() -> (Vec<String>, Vec<String>, Vec<String>) {
+    global_config(QWEN_DIR, SETTINGS_JSON)
+        .as_ref()
+        .map(qwen_rules_from_settings)
+        .unwrap_or_default()
+}
+
+fn qwen_rules_from_settings(settings: &Value) -> (Vec<String>, Vec<String>, Vec<String>) {
+    let mut deny = Vec::new();
+    let mut ask = Vec::new();
+    let mut allow = Vec::new();
+    let shells = ["Bash(", "Shell(", "run_shell_command("];
+
+    if let Some(perms) = settings.get("permissions") {
+        append_wrapped_rules(perms.get("deny"), &shells, &mut deny);
+        append_wrapped_rules(perms.get("ask"), &shells, &mut ask);
+        append_wrapped_rules(perms.get("allow"), &shells, &mut allow);
+    }
+
+    (deny, ask, allow)
+}
+
 // All four Droid settings scopes: user (honoring $FACTORY_HOME_OVERRIDE) and
 // project `.factory/`, each with settings.json + settings.local.json
 // (docs.factory.ai/cli/configuration/settings). Missing files are skipped.
@@ -475,6 +499,22 @@ fn split_compound_command(cmd: &str) -> Vec<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_qwen_permission_rules_extract_shell_aliases() {
+        let settings = serde_json::json!({
+            "permissions": {
+                "allow": ["Bash(git *)", "Read(**/*)"],
+                "ask": ["Shell(git push *)"],
+                "deny": ["run_shell_command(rm -rf *)"]
+            }
+        });
+
+        let (deny, ask, allow) = qwen_rules_from_settings(&settings);
+        assert_eq!(deny, vec!["rm -rf *"]);
+        assert_eq!(ask, vec!["git push *"]);
+        assert_eq!(allow, vec!["git *"]);
+    }
 
     #[test]
     fn test_parse_bash_pattern() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,8 @@ pub enum AgentTarget {
     Hermes,
     /// Factory Droid CLI
     Droid,
+    /// Qwen Code CLI
+    Qwen,
 }
 
 #[derive(Parser)]
@@ -348,6 +350,13 @@ enum Commands {
         /// Initialize for Gemini CLI instead of Claude Code
         #[arg(long)]
         gemini: bool,
+
+        /// Initialize for Qwen Code CLI instead of Claude Code
+        #[arg(
+            long,
+            conflicts_with_all = ["agent", "gemini", "opencode", "codex", "copilot"]
+        )]
+        qwen: bool,
 
         /// Target agent to install hooks for (default: claude)
         #[arg(long, value_enum)]
@@ -862,6 +871,8 @@ enum HookCommands {
     Cursor,
     /// Process Gemini CLI BeforeTool hook (reads JSON from stdin)
     Gemini,
+    /// Process Qwen Code PreToolUse hook (reads JSON from stdin)
+    Qwen,
     /// Process Copilot preToolUse hook (VS Code + Copilot CLI, reads JSON from stdin)
     Copilot,
     /// Process Factory Droid PreToolUse hook (reads JSON from stdin)
@@ -1995,6 +2006,7 @@ fn run_cli() -> Result<i32> {
             global,
             opencode,
             gemini,
+            qwen,
             agent,
             show,
             claude_md,
@@ -2020,6 +2032,8 @@ fn run_cli() -> Result<i32> {
                 } else {
                     hooks::init::uninstall_copilot(ctx)?;
                 }
+            } else if uninstall && (qwen || agent == Some(AgentTarget::Qwen)) {
+                hooks::init::uninstall_qwen(global, ctx)?;
             } else if uninstall {
                 uninstall_init_dispatch(
                     agent,
@@ -2039,6 +2053,15 @@ fn run_cli() -> Result<i32> {
                     hooks::init::PatchMode::Ask
                 };
                 hooks::init::run_gemini(global, hook_only, patch_mode, ctx)?;
+            } else if qwen || agent == Some(AgentTarget::Qwen) {
+                let patch_mode = if auto_patch {
+                    hooks::init::PatchMode::Auto
+                } else if no_patch {
+                    hooks::init::PatchMode::Skip
+                } else {
+                    hooks::init::PatchMode::Ask
+                };
+                hooks::init::run_qwen(global, hook_only, patch_mode, ctx)?;
             } else if copilot {
                 if global {
                     hooks::init::run_copilot_global(ctx)?;
@@ -2428,6 +2451,10 @@ fn run_cli() -> Result<i32> {
             }
             HookCommands::Gemini => {
                 hooks::hook_cmd::run_gemini()?;
+                0
+            }
+            HookCommands::Qwen => {
+                hooks::hook_cmd::run_qwen()?;
                 0
             }
             HookCommands::Copilot => {
@@ -3617,5 +3644,39 @@ mod tests {
             }
             _ => panic!("Expected Init command"),
         }
+    }
+
+    #[test]
+    fn test_init_qwen_flag_and_agent_value_parse() {
+        let cli = Cli::try_parse_from(["rtk", "init", "--global", "--qwen"]).unwrap();
+        match cli.command {
+            Commands::Init { global, qwen, .. } => {
+                assert!(global);
+                assert!(qwen);
+            }
+            _ => panic!("Expected Init command"),
+        }
+
+        let cli = Cli::try_parse_from(["rtk", "init", "--global", "--agent", "qwen"]).unwrap();
+        match cli.command {
+            Commands::Init { agent, .. } => assert_eq!(agent, Some(AgentTarget::Qwen)),
+            _ => panic!("Expected Init command"),
+        }
+    }
+
+    #[test]
+    fn test_init_qwen_rejects_conflicting_agent() {
+        assert!(Cli::try_parse_from(["rtk", "init", "--qwen", "--agent", "claude"]).is_err());
+    }
+
+    #[test]
+    fn test_qwen_hook_command_parses() {
+        let cli = Cli::try_parse_from(["rtk", "hook", "qwen"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Hook {
+                command: HookCommands::Qwen
+            }
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- add global Qwen Code installation via `rtk init -g --qwen` and `--agent qwen`
- implement the current Qwen `PreToolUse` hook schema with rewritten input and permission preservation
- preserve unrelated Qwen settings/hooks during install and uninstall, with integrity and awareness-file support

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (2,508 passed, 8 ignored)
- `cargo build --release --all-features`
- isolated global install, live hook invocation, and uninstall

Closes #1222