### PR TITLE
feat(files): filter storage metadata paths

### DIFF
--- a/src/cmds/system/README.md
+++ b/src/cmds/system/README.md
@@ -12,3 +12,4 @@
 ## Cross-command
 
 - `format_cmd` routes to `cmds/js/prettier_cmd` and `cmds/python/ruff_cmd`
+- `constants.rs` defines storage metadata exclusions shared by `ls`, `tree`, and `find`; AppleDouble `._*` entries and Synology `@eaDir` trees stay hidden even when normal dotfiles are requested.

--- a/src/cmds/system/constants.rs
+++ b/src/cmds/system/constants.rs
@@ -1,3 +1,5 @@
+use std::path::{Component, Path};
+
 pub const NOISE_DIRS: &[&str] = &[
     "node_modules",
     ".git",
@@ -25,3 +27,40 @@ pub const NOISE_DIRS: &[&str] = &[
     "*.egg-info",
     ".eggs",
 ];
+
+/// Storage metadata that should never appear in compact filesystem discovery.
+pub const SYSTEM_METADATA_PATTERNS: &[&str] = &["._*", "@eaDir"];
+
+pub fn is_system_metadata_name(name: &str) -> bool {
+    name == "@eaDir" || name.starts_with("._")
+}
+
+pub fn is_system_metadata_path(path: &Path) -> bool {
+    path.components().any(|component| match component {
+        Component::Normal(name) => is_system_metadata_name(&name.to_string_lossy()),
+        _ => false,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_appledouble_and_synology_metadata() {
+        assert!(is_system_metadata_name("._index.ts"));
+        assert!(is_system_metadata_name("@eaDir"));
+        assert!(is_system_metadata_path(Path::new(
+            "src/@eaDir/index.ts/SYNOPHOTO_THUMB_XL.jpg"
+        )));
+        assert!(is_system_metadata_path(Path::new("src/._server.ts")));
+    }
+
+    #[test]
+    fn preserves_real_project_paths() {
+        assert!(!is_system_metadata_name(".env"));
+        assert!(!is_system_metadata_name("eaDir"));
+        assert!(!is_system_metadata_path(Path::new("src/index.ts")));
+        assert!(!is_system_metadata_path(Path::new("src/.config/app.toml")));
+    }
+}

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -1,5 +1,6 @@
 //! Filters find results by grouping files by directory.
 
+use super::constants::is_system_metadata_path;
 use crate::core::guard::never_worse;
 use crate::core::tracking;
 use anyhow::{Context, Result};
@@ -220,7 +221,8 @@ pub fn run(
         .hidden(!search_hidden) // skip hidden files/dirs unless pattern targets dotfiles
         .git_ignore(true) // respect .gitignore
         .git_global(true)
-        .git_exclude(true);
+        .git_exclude(true)
+        .filter_entry(|entry| !is_system_metadata_path(entry.path()));
     if let Some(depth) = max_depth {
         builder.max_depth(Some(depth));
     }
@@ -578,6 +580,15 @@ mod tests {
         // Non-dot pattern should not error (hidden dirs remain skipped)
         let result = run("*.rs", "src", 5, None, "f", false, 0);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn metadata_paths_are_pruned_even_for_hidden_searches() {
+        assert!(is_system_metadata_path(Path::new("._index.ts")));
+        assert!(is_system_metadata_path(Path::new(
+            "@eaDir/index.ts/SYNOPHOTO_THUMB_XL.jpg"
+        )));
+        assert!(!is_system_metadata_path(Path::new(".claude/settings.json")));
     }
 
     // --- integration: run on this repo ---

--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -1,6 +1,6 @@
 //! Filters directory listings into a compact tree format.
 
-use super::constants::NOISE_DIRS;
+use super::constants::{is_system_metadata_name, NOISE_DIRS};
 use crate::core::runner::{self, RunOptions};
 use crate::core::truncate::{reduced, CAP_WARNINGS};
 use crate::core::utils::resolved_command;
@@ -262,6 +262,10 @@ fn compact_ls(raw: &str, show_all: bool, show_long: bool) -> (String, String, us
         };
         parsed_count += 1;
 
+        if is_system_metadata_name(&name) {
+            continue;
+        }
+
         // Filter noise dirs unless -a
         if !show_all && NOISE_DIRS.iter().any(|noise| name == *noise) {
             continue;
@@ -398,6 +402,20 @@ mod tests {
         let (entries, _summary, _parsed) = compact_ls(input, true, false);
         assert!(entries.contains(".git/"));
         assert!(entries.contains("src/"));
+    }
+
+    #[test]
+    fn test_compact_always_filters_storage_metadata() {
+        let input = "total 16\n\
+                     drwxr-xr-x  2 user  staff  64 Jan  1 12:00 @eaDir\n\
+                     -rw-r--r--  1 user  staff  32 Jan  1 12:00 ._index.ts\n\
+                     -rw-r--r--  1 user  staff  80 Jan  1 12:00 index.ts\n";
+        let (entries, _summary, parsed) = compact_ls(input, true, false);
+
+        assert!(!entries.contains("@eaDir"));
+        assert!(!entries.contains("._index.ts"));
+        assert!(entries.contains("index.ts"));
+        assert_eq!(parsed, 3);
     }
 
     #[test]

--- a/src/cmds/system/tree.rs
+++ b/src/cmds/system/tree.rs
@@ -3,10 +3,10 @@
 //! This module proxies to the native `tree` command and filters the output
 //! to reduce token usage while preserving structure visibility.
 //!
-//! Token optimization: automatically excludes noise directories via -I pattern
-//! unless -a flag is present (respecting user intent).
+//! Token optimization: automatically excludes noise directories via `-I`
+//! unless `-a` is present. Storage metadata remains excluded in every mode.
 
-use super::constants::NOISE_DIRS;
+use super::constants::{NOISE_DIRS, SYSTEM_METADATA_PATTERNS};
 use crate::core::runner::{self, RunOptions};
 use crate::core::utils::{resolved_command, tool_exists};
 use anyhow::Result;
@@ -27,13 +27,32 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     let show_all = args.iter().any(|a| a == "-a" || a == "--all");
     let has_ignore = args.iter().any(|a| a == "-I" || a.starts_with("--ignore="));
 
-    if !show_all && !has_ignore {
-        let ignore_pattern = NOISE_DIRS.join("|");
+    if !has_ignore {
+        let ignore_pattern = default_ignore_pattern(show_all);
         cmd.arg("-I").arg(&ignore_pattern);
     }
 
-    for arg in args {
-        cmd.arg(arg);
+    let mut index = 0;
+    while index < args.len() {
+        let arg = &args[index];
+        if arg == "-I" {
+            cmd.arg(arg);
+            if let Some(pattern) = args.get(index + 1) {
+                cmd.arg(append_metadata_ignore(pattern));
+                index += 2;
+                continue;
+            }
+        } else if let Some(pattern) = arg.strip_prefix("--ignore=") {
+            cmd.arg(format!(
+                "--ignore={}",
+                append_metadata_ignore(pattern)
+            ));
+            index += 1;
+            continue;
+        } else {
+            cmd.arg(arg);
+        }
+        index += 1;
     }
 
     runner::run_filtered(
@@ -60,6 +79,31 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
             .early_exit_on_failure()
             .no_trailing_newline(),
     )
+}
+
+fn metadata_ignore_pattern() -> String {
+    SYSTEM_METADATA_PATTERNS.join("|")
+}
+
+fn append_metadata_ignore(pattern: &str) -> String {
+    if pattern.is_empty() {
+        metadata_ignore_pattern()
+    } else {
+        format!("{}|{}", pattern, metadata_ignore_pattern())
+    }
+}
+
+fn default_ignore_pattern(show_all: bool) -> String {
+    if show_all {
+        metadata_ignore_pattern()
+    } else {
+        NOISE_DIRS
+            .iter()
+            .copied()
+            .chain(SYSTEM_METADATA_PATTERNS.iter().copied())
+            .collect::<Vec<_>>()
+            .join("|")
+    }
 }
 
 fn filter_tree_output(raw: &str) -> String {
@@ -165,5 +209,27 @@ mod tests {
         assert!(NOISE_DIRS.contains(&".next"));
         assert!(NOISE_DIRS.contains(&"dist"));
         assert!(NOISE_DIRS.contains(&"build"));
+    }
+
+    #[test]
+    fn test_show_all_still_excludes_storage_metadata() {
+        assert_eq!(default_ignore_pattern(true), "._*|@eaDir");
+    }
+
+    #[test]
+    fn test_default_ignore_includes_noise_and_storage_metadata() {
+        let pattern = default_ignore_pattern(false);
+        assert!(pattern.split('|').any(|part| part == "node_modules"));
+        assert!(pattern.split('|').any(|part| part == "._*"));
+        assert!(pattern.split('|').any(|part| part == "@eaDir"));
+    }
+
+    #[test]
+    fn test_user_ignore_is_augmented_with_storage_metadata() {
+        assert_eq!(
+            append_metadata_ignore("vendor|tmp"),
+            "vendor|tmp|._*|@eaDir"
+        );
+        assert_eq!(append_metadata_ignore(""), "._*|@eaDir");
     }
 }


### PR DESCRIPTION
## Summary
- add a shared predicate for AppleDouble `._*` entries and Synology `@eaDir` paths
- remove those entries from compact `ls` output even with `-a`, while preserving legitimate dotfiles
- prune metadata trees from `find` and augment both default and user-provided `tree` ignore patterns

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (2,502 passed, 8 ignored)
- `cargo build --release --all-features`
- live isolated `ls -a` and hidden/non-hidden `find` checks
- controlled native `tree` fixture verified `-a` and user `-I` argv augmentation (system `tree` is not installed)

Closes #2745