### PR TITLE
feat(system): filter journalctl and fs_cli output

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ rtk smart file.rs               # 2-line heuristic code summary
 rtk find "*.rs" .               # Compact find results
 rtk grep "pattern" .            # Grouped search results
 rtk diff file1 file2            # Condensed diff (exit 1 if files differ)
+rtk journalctl -u app -n 100    # Compact systemd logs
+rtk fs_cli -x "sofia status"    # Compact FreeSWITCH tables
 ```
 
 ### Git

--- a/src/cmds/system/README.md
+++ b/src/cmds/system/README.md
@@ -8,6 +8,8 @@
 - `search.rs` backs both `rtk grep` and `rtk rg`: it runs the invoked engine (never substituting one for the other) and groups its output, reading `core/config` for `limits.grep_max_results` and `limits.grep_max_per_file`. Format-altering flags (`-c`, `-l`, `-L`, `-o`, `-Z`) bypass RTK filtering and run raw.
 - `local_llm.rs` (`rtk smart`) uses `core/filter` for heuristic file summarization
 - `format_cmd.rs` is a cross-ecosystem dispatcher: auto-detects and routes to `prettier_cmd` or `ruff_cmd` (black is handled inline, not as a separate module)
+- `journalctl_cmd.rs` compacts human-readable journal lines while structured, streaming, and catalog modes pass through
+- `fs_cli_cmd.rs` removes FreeSWITCH table decoration and redundant row-count footers
 
 ## Cross-command
 

--- a/src/cmds/system/fs_cli_cmd.rs
+++ b/src/cmds/system/fs_cli_cmd.rs
@@ -1,0 +1,141 @@
+//! Compact FreeSWITCH `fs_cli -x` command output.
+
+use crate::core::runner::{self, RunOptions};
+use crate::core::utils::{resolved_command, strip_ansi};
+use anyhow::Result;
+use regex::Regex;
+use std::sync::LazyLock;
+
+static FOOTER_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(\d+)\s+total\.$").unwrap());
+static WIDE_GAP_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\s{2,}").unwrap());
+
+pub fn run(args: &[String], verbose: u8) -> Result<i32> {
+    let mut cmd = resolved_command("fs_cli");
+    cmd.args(args);
+    let args_display = args.join(" ");
+
+    if verbose > 0 {
+        eprintln!("Running: fs_cli {args_display}");
+    }
+
+    runner::run_filtered(
+        cmd,
+        "fs_cli",
+        &args_display,
+        filter_fs_cli,
+        RunOptions::with_tee("fs_cli").early_exit_on_failure(),
+    )
+}
+
+fn filter_fs_cli(raw: &str) -> String {
+    let clean = strip_ansi(raw);
+    let nonempty: Vec<&str> = clean.lines().filter(|line| !line.trim().is_empty()).collect();
+    if nonempty.len() <= 1 || nonempty.iter().any(|line| line.trim_start().starts_with("-ERR")) {
+        return clean.trim_end().to_string();
+    }
+
+    let footer_count = nonempty.last().and_then(|line| {
+        FOOTER_RE
+            .captures(line.trim())
+            .and_then(|captures| captures[1].parse::<usize>().ok())
+    });
+    let mut output = Vec::new();
+
+    for (index, line) in nonempty.iter().enumerate() {
+        let trimmed = line.trim();
+        if is_separator(trimmed) {
+            continue;
+        }
+        if index + 1 == nonempty.len() && footer_count.is_some() {
+            continue;
+        }
+        output.push(compact_table_line(trimmed));
+    }
+
+    if let Some(count) = footer_count {
+        let derived_rows = output.len().saturating_sub(1);
+        if derived_rows != count {
+            output.push(format!("{count} total."));
+        }
+    }
+
+    output.join("\n")
+}
+
+fn is_separator(line: &str) -> bool {
+    let visible: String = line.chars().filter(|ch| !ch.is_whitespace()).collect();
+    visible.len() >= 3
+        && visible
+            .chars()
+            .all(|ch| matches!(ch, '=' | '-' | '+' | '|'))
+}
+
+fn compact_table_line(line: &str) -> String {
+    if line.matches('|').count() >= 2 {
+        return line
+            .split('|')
+            .map(str::trim)
+            .filter(|cell| !cell.is_empty())
+            .collect::<Vec<_>>()
+            .join(" | ");
+    }
+    WIDE_GAP_RE.replace_all(line, " | ").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn removes_decorative_rows_and_derivable_footer() {
+        let raw = "Name                 Type       Data       State\n=================================================\nexternal             profile    10.0.0.1   RUNNING\ninternal             profile    10.0.0.2   RUNNING\n2 total.\n";
+        let filtered = filter_fs_cli(raw);
+
+        assert_eq!(
+            filtered,
+            "Name | Type | Data | State\nexternal | profile | 10.0.0.1 | RUNNING\ninternal | profile | 10.0.0.2 | RUNNING"
+        );
+        assert!(!filtered.contains("===="));
+        assert!(!filtered.contains("2 total"));
+    }
+
+    #[test]
+    fn compacts_pipe_bordered_table() {
+        let raw = "+------+----------+\n| uuid | state    |\n+------+----------+\n| a-1  | ACTIVE   |\n+------+----------+\n1 total.\n";
+        assert_eq!(filter_fs_cli(raw), "uuid | state\na-1 | ACTIVE");
+    }
+
+    #[test]
+    fn keeps_footer_when_row_count_cannot_be_derived() {
+        let raw = "Name Type\nonly one visible row\n5 total.\n";
+        assert!(filter_fs_cli(raw).ends_with("5 total."));
+    }
+
+    #[test]
+    fn small_and_error_outputs_are_unchanged() {
+        assert_eq!(filter_fs_cli("+OK accepted\n"), "+OK accepted");
+        let error = "-ERR command not found\nUsage: show channels\n";
+        assert_eq!(filter_fs_cli(error), error.trim_end());
+    }
+
+    #[test]
+    fn wide_table_saves_at_least_fifteen_percent() {
+        let mut lines = vec![
+            "UUID                                 Direction       State          Codec"
+                .to_string(),
+            "=========================================================================="
+                .to_string(),
+        ];
+        lines.extend((0..50).map(|index| {
+            format!(
+                "00000000-0000-0000-0000-{index:012}    inbound         ACTIVE         PCMU"
+            )
+        }));
+        lines.push("50 total.".to_string());
+        let raw = lines.join("\n");
+        let filtered = filter_fs_cli(&raw);
+
+        assert!(filtered.len() * 20 <= raw.len() * 17);
+    }
+}

--- a/src/cmds/system/journalctl_cmd.rs
+++ b/src/cmds/system/journalctl_cmd.rs
@@ -1,0 +1,229 @@
+//! Compact human-readable `journalctl` output.
+
+use crate::core::runner::{self, RunMode, RunOptions};
+use crate::core::utils::resolved_command;
+use anyhow::Result;
+use regex::Regex;
+use std::sync::LazyLock;
+
+static SHORT_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"^([A-Z][a-z]{2}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})\s+\S+\s+(.+)$"
+    )
+    .unwrap()
+});
+static ISO_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}:\d{2}:\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?\s+\S+\s+(.+)$"
+    )
+    .unwrap()
+});
+
+pub fn run(args: &[String], verbose: u8) -> Result<i32> {
+    let mut cmd = resolved_command("journalctl");
+    cmd.args(args);
+    let args_display = args.join(" ");
+
+    if verbose > 0 {
+        eprintln!("Running: journalctl {args_display}");
+    }
+
+    if should_passthrough(args) {
+        return runner::run(
+            cmd,
+            "journalctl",
+            &args_display,
+            RunMode::Passthrough,
+            RunOptions::default(),
+        );
+    }
+
+    runner::run_filtered(
+        cmd,
+        "journalctl",
+        &args_display,
+        filter_journal,
+        RunOptions::with_tee("journalctl").early_exit_on_failure(),
+    )
+}
+
+fn should_passthrough(args: &[String]) -> bool {
+    let mut index = 0;
+    while index < args.len() {
+        let arg = args[index].as_str();
+        if matches!(arg, "-f" | "--follow" | "-x" | "--catalog") {
+            return true;
+        }
+        if arg == "-o" || arg == "--output" {
+            if args
+                .get(index + 1)
+                .is_some_and(|value| value.starts_with("json"))
+            {
+                return true;
+            }
+            index += 1;
+        } else if arg.starts_with("-ojson")
+            || arg
+                .strip_prefix("--output=")
+                .is_some_and(|value| value.starts_with("json"))
+        {
+            return true;
+        }
+        index += 1;
+    }
+    false
+}
+
+fn filter_journal(raw: &str) -> String {
+    let mut output = Vec::new();
+    let mut pending_display: Option<String> = None;
+    let mut pending_key: Option<String> = None;
+    let mut repeat_count = 0usize;
+
+    for line in raw.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let (display, key) = compact_line(line);
+        if key.is_some() && key == pending_key {
+            repeat_count += 1;
+            continue;
+        }
+
+        flush_pending(
+            &mut output,
+            pending_display.take(),
+            repeat_count,
+        );
+        pending_display = Some(display);
+        pending_key = key;
+        repeat_count = 1;
+    }
+
+    flush_pending(&mut output, pending_display, repeat_count);
+    output.join("\n")
+}
+
+fn flush_pending(output: &mut Vec<String>, pending: Option<String>, count: usize) {
+    let Some(mut line) = pending else {
+        return;
+    };
+    if count > 1 {
+        line.push_str(&format!(" (x{count})"));
+    }
+    output.push(line);
+}
+
+fn compact_line(line: &str) -> (String, Option<String>) {
+    if is_error_or_stacktrace(line) {
+        return (line.to_string(), None);
+    }
+
+    if let Some(captures) = SHORT_RE.captures(line) {
+        let payload = captures[2].to_string();
+        return (format!("{} {}", &captures[1], payload), Some(payload));
+    }
+
+    if let Some(captures) = ISO_RE.captures(line) {
+        let month = month_name(&captures[2]);
+        let day = captures[3].trim_start_matches('0');
+        let payload = captures[5].to_string();
+        return (
+            format!("{month} {day:>2} {} {payload}", &captures[4]),
+            Some(payload),
+        );
+    }
+
+    (line.to_string(), Some(line.to_string()))
+}
+
+fn month_name(month: &str) -> &'static str {
+    match month {
+        "01" => "Jan",
+        "02" => "Feb",
+        "03" => "Mar",
+        "04" => "Apr",
+        "05" => "May",
+        "06" => "Jun",
+        "07" => "Jul",
+        "08" => "Aug",
+        "09" => "Sep",
+        "10" => "Oct",
+        "11" => "Nov",
+        "12" => "Dec",
+        _ => "???",
+    }
+}
+
+fn is_error_or_stacktrace(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    let lower = trimmed.to_ascii_lowercase();
+    line.chars().next().is_some_and(char::is_whitespace)
+        || trimmed.starts_with("at ")
+        || trimmed.starts_with("Caused by:")
+        || ["error", "failed", "exception", "panic", "traceback"]
+            .iter()
+            .any(|needle| lower.contains(needle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_hostname_and_collapses_consecutive_duplicates() {
+        let raw = "Jul 20 10:00:01 host portal[10]: request complete\nJul 20 10:00:02 host portal[10]: request complete\nJul 20 10:00:03 host portal[10]: request complete\n";
+        let filtered = filter_journal(raw);
+
+        assert_eq!(
+            filtered,
+            "Jul 20 10:00:01 portal[10]: request complete (x3)"
+        );
+        assert!(!filtered.contains(" host "));
+    }
+
+    #[test]
+    fn compacts_iso_timestamp_to_short_form() {
+        let raw = "2026-07-20T10:11:12.123+07:00 node service[1]: ready";
+        assert_eq!(filter_journal(raw), "Jul 20 10:11:12 service[1]: ready");
+    }
+
+    #[test]
+    fn preserves_error_and_stacktrace_lines_verbatim() {
+        let raw = "Jul 20 10:00:01 host app[1]: ERROR database unavailable\n    at connect (db.js:10:2)\n";
+        assert_eq!(filter_journal(raw), raw.trim_end());
+    }
+
+    #[test]
+    fn json_follow_and_catalog_modes_passthrough() {
+        assert!(should_passthrough(&["-o".into(), "json".into()]));
+        assert!(should_passthrough(&["--output=json-pretty".into()]));
+        assert!(should_passthrough(&["-ojson".into()]));
+        assert!(should_passthrough(&["--follow".into()]));
+        assert!(should_passthrough(&["-x".into()]));
+        assert!(!should_passthrough(&[
+            "-u".into(),
+            "portal.service".into(),
+            "-n".into(),
+            "50".into()
+        ]));
+    }
+
+    #[test]
+    fn repeated_logs_save_at_least_ninety_percent() {
+        let raw = (0..100)
+            .map(|second| {
+                format!(
+                    "Jul 20 10:00:{:02} host portal[10]: health check passed",
+                    second % 60
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let filtered = filter_journal(&raw);
+
+        assert!(filtered.len() * 10 <= raw.len());
+        assert!(filtered.ends_with("(x100)"));
+    }
+}

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1104,6 +1104,7 @@ fn rewrite_segment_inner(
     // classify_command does, so a small canonical prefix list matches every
     // invocation form instead of enumerating each literal spelling.
     let php_normalized;
+    let system_normalized;
     let strip_target: &str = if rule
         .rtk_cmd
         .strip_prefix("rtk ")
@@ -1116,6 +1117,9 @@ fn rewrite_segment_inner(
         let unwrapped = unwrapped.strip_prefix("./").unwrap_or(unwrapped);
         php_normalized = normalize_php_tool_command(unwrapped);
         &php_normalized
+    } else if matches!(rule.rtk_cmd, "rtk journalctl" | "rtk fs_cli") {
+        system_normalized = strip_absolute_path(cmd_part);
+        &system_normalized
     } else {
         cmd_part
     };
@@ -3956,6 +3960,41 @@ mod tests {
         assert_eq!(
             rewrite_command_no_prefixes("find . -name '*.rs' -type f", &[]),
             Some("rtk find . -name '*.rs' -type f".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_journalctl_direct_and_absolute_path() {
+        assert!(matches!(
+            classify_command("journalctl -u app.service -n 50"),
+            Classification::Supported {
+                rtk_equivalent: "rtk journalctl",
+                category: "System",
+                ..
+            }
+        ));
+        assert_eq!(
+            rewrite_command_no_prefixes("sudo /usr/bin/journalctl -u app.service -n 50", &[]),
+            Some("sudo rtk journalctl -u app.service -n 50".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_fs_cli_direct_and_absolute_path() {
+        assert!(matches!(
+            classify_command("fs_cli -x 'sofia status'"),
+            Classification::Supported {
+                rtk_equivalent: "rtk fs_cli",
+                category: "System",
+                ..
+            }
+        ));
+        assert_eq!(
+            rewrite_command_no_prefixes(
+                "sudo /usr/local/freeswitch/bin/fs_cli -x 'show channels'",
+                &[]
+            ),
+            Some("sudo rtk fs_cli -x 'show channels'".into())
         );
     }
 

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -144,6 +144,26 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
+        pattern: r"^journalctl(?:\s|$)",
+        rtk_cmd: "rtk journalctl",
+        rewrite_prefixes: &["journalctl"],
+        category: "System",
+        savings_pct: 70.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+        pipeline_final_safe: false,
+    },
+    RtkRule {
+        pattern: r"^fs_cli(?:\s|$)",
+        rtk_cmd: "rtk fs_cli",
+        rewrite_prefixes: &["fs_cli"],
+        category: "System",
+        savings_pct: 40.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+        pipeline_final_safe: false,
+    },
+    RtkRule {
         pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?tsc(\s|$)",
         rtk_cmd: "rtk tsc",
         rewrite_prefixes: &[

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,8 @@ use cmds::ruby::{rake_cmd, rspec_cmd, rubocop_cmd};
 use cmds::rust::{cargo_cmd, runner};
 use cmds::scala::sbt_cmd;
 use cmds::system::{
-    deps, env_cmd, find_cmd, format_cmd, json_cmd, local_llm, log_cmd, ls, pipe_cmd, read, search,
-    summary, tree, wc_cmd,
+    deps, env_cmd, find_cmd, format_cmd, fs_cli_cmd, journalctl_cmd, json_cmd, local_llm, log_cmd,
+    ls, pipe_cmd, read, search, summary, tree, wc_cmd,
 };
 
 use anyhow::{Context, Result};
@@ -412,6 +412,21 @@ enum Commands {
     /// Word/line/byte count with compact output (strips paths and padding)
     Wc {
         /// Arguments passed to wc (files, flags like -l, -w, -c)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// systemd journal logs with compact host and duplicate handling
+    Journalctl {
+        /// journalctl arguments (e.g., -u app.service -n 100 --since today)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// FreeSWITCH CLI output with compact table formatting
+    #[command(name = "fs_cli")]
+    FsCli {
+        /// fs_cli arguments (e.g., -x "sofia status")
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -2124,6 +2139,10 @@ fn run_cli() -> Result<i32> {
 
         Commands::Wc { args } => wc_cmd::run(&args, cli.verbose)?,
 
+        Commands::Journalctl { args } => journalctl_cmd::run(&args, cli.verbose)?,
+
+        Commands::FsCli { args } => fs_cli_cmd::run(&args, cli.verbose)?,
+
         Commands::Gain {
             project, // added
             graph,
@@ -2738,6 +2757,8 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Grep { .. }
             | Commands::Rg { .. }
             | Commands::Wget { .. }
+            | Commands::Journalctl { .. }
+            | Commands::FsCli { .. }
             | Commands::Vitest { .. }
             | Commands::Prisma { .. }
             | Commands::Tsc { .. }
@@ -3119,6 +3140,8 @@ mod tests {
             "grep",
             "wget",
             "wc",
+            "journalctl",
+            "fs_cli",
             "jest",
             "vitest",
             "prisma",
@@ -3576,6 +3599,23 @@ mod tests {
             }
             _ => panic!("Expected Commands::Npx for unknown tool"),
         }
+    }
+
+    #[test]
+    fn test_journalctl_and_fs_cli_native_args_parse() {
+        let cli =
+            Cli::try_parse_from(["rtk", "journalctl", "-u", "app.service", "-n", "50"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Journalctl { args }
+                if args == ["-u", "app.service", "-n", "50"]
+        ));
+
+        let cli = Cli::try_parse_from(["rtk", "fs_cli", "-x", "sofia status"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::FsCli { args } if args == ["-x", "sofia status"]
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a native `journalctl` filter that strips repeated hostnames, normalizes ISO timestamps, and collapses consecutive duplicate non-error messages
- preserve error/stacktrace lines and pass through JSON, follow, and catalog modes unchanged
- add a conservative `fs_cli` table filter that removes decorative separators, compacts columns, and only removes derivable totals
- support direct, `sudo`, and absolute-path command rewriting for both tools

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (2,508 passed, 8 ignored)
- `cargo build --release --all-features`
- controlled fake executable checks for passthrough, duplicate/error preservation, table compaction, and absolute-path/sudo rewriting

Closes #2259