### PR TITLE
fix(curl): preserve signal exit codes

### DIFF
--- a/src/cmds/cloud/curl_cmd.rs
+++ b/src/cmds/cloud/curl_cmd.rs
@@ -13,6 +13,7 @@
 
 use crate::core::tee::force_tee_hint;
 use crate::core::tracking;
+use crate::core::stream::status_to_exit_code;
 use crate::core::utils::resolved_command;
 use anyhow::{Context, Result};
 use std::borrow::Cow;
@@ -38,7 +39,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     // every non-UTF-8 byte with U+FFFD (3 bytes), corrupting e.g. gzip
     // magic `1f 8b 08 00` into `1f ef bf bd 08 00` (#1087).
     let output = cmd.output().context("Failed to run curl")?;
-    let exit_code = output.status.code().unwrap_or(1);
+    let exit_code = status_to_exit_code(output.status);
 
     // Skip filtering on failure: curl can return HTML error bodies that would
     // be misleading to summarize, and we want the real exit code surfaced.


### PR DESCRIPTION
## Summary
- convert curl's captured `ExitStatus` with the shared signal-aware helper
- return the standard `128 + signal` code for killed curl processes instead of collapsing them to `1`
- keep normal success and explicit non-zero exit codes unchanged

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features curl_cmd`
- `cargo test --all-features test_exit_code_signal_kill`

Closes #2656