### PR TITLE
fix(npm): recognize extended subcommands

### DIFF
--- a/src/cmds/js/npm_cmd.rs
+++ b/src/cmds/js/npm_cmd.rs
@@ -71,6 +71,21 @@ const NPM_SUBCOMMANDS: &[&str] = &[
     "start",
     "stop",
     "restart",
+    "completion",
+    "edit",
+    "explore",
+    "find-dupes",
+    "help-search",
+    "hook",
+    "install-ci-test",
+    "install-test",
+    "ll",
+    "org",
+    "query",
+    "run-script",
+    "sbom",
+    "shrinkwrap",
+    "unstar",
 ];
 
 pub fn run(args: &[String], verbose: u8, skip_env: bool) -> Result<i32> {
@@ -226,6 +241,34 @@ npm notice
 
         // Explicit "run" should NOT inject another "run"
         assert!(!needs_run_injection(&["run", "build"]));
+    }
+
+    #[test]
+    fn test_extended_official_subcommands_do_not_inject_run() {
+        let subcommands = [
+            "completion",
+            "edit",
+            "explore",
+            "find-dupes",
+            "help-search",
+            "hook",
+            "install-ci-test",
+            "install-test",
+            "ll",
+            "org",
+            "query",
+            "run-script",
+            "sbom",
+            "shrinkwrap",
+            "unstar",
+        ];
+
+        for subcommand in subcommands {
+            assert!(
+                NPM_SUBCOMMANDS.contains(&subcommand),
+                "npm {subcommand} must be routed as a native subcommand"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add 15 official npm commands missing from the native-subcommand allowlist
- prevent commands such as `npm query`, `npm sbom`, and `npm completion` from becoming `npm run ...`
- preserve `run` injection for project script names such as `build`, `dev`, and `lint`
- add an explicit regression matrix for every newly recognized command

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (2,496 passed, 8 ignored)

Closes #2663