### PR TITLE
feat(python): summarize large direct invocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ rtk env -f AWS                  # Filtered env vars
 rtk log app.log                 # Deduplicated logs
 rtk curl <url>                  # Truncate + save full output
 rtk wget <url>                  # Download, strip progress bars
+rtk python script.py            # Summarize output only above 1 KiB
 rtk summary <long command>      # Heuristic summary
 rtk proxy <command>             # Raw passthrough + tracking
 ```

--- a/src/cmds/python/python_cmd.rs
+++ b/src/cmds/python/python_cmd.rs
@@ -1,0 +1,130 @@
+//! Generic Python proxy that summarizes only large, successful output.
+
+use crate::cmds::system::summary;
+use crate::core::runner::{self, RunOptions};
+use crate::core::utils::resolved_command;
+use anyhow::Result;
+use std::ffi::OsString;
+
+const SUMMARY_THRESHOLD_BYTES: usize = 1024;
+
+pub fn run(executable: &str, args: &[String], verbose: u8) -> Result<i32> {
+    if should_passthrough(args) {
+        let args: Vec<OsString> = args.iter().map(OsString::from).collect();
+        return runner::run_passthrough(executable, &args, verbose);
+    }
+
+    let mut cmd = resolved_command(executable);
+    cmd.args(args);
+    let command_label = format!("{} {}", executable, args.join(" "));
+    if verbose > 0 {
+        eprintln!("Running: {}", command_label.trim_end());
+    }
+
+    runner::run_filtered(
+        cmd,
+        executable,
+        &args.join(" "),
+        |raw| filter_output(raw, &command_label, None),
+        RunOptions::default()
+            .inherit_stdin()
+            .early_exit_on_failure(),
+    )
+}
+
+fn should_passthrough(args: &[String]) -> bool {
+    if args.is_empty() {
+        return true;
+    }
+
+    if args.iter().any(|arg| {
+        matches!(
+            arg.as_str(),
+            "-V" | "-VV" | "--version" | "-h" | "--help"
+        )
+            || arg == "-i"
+            || arg == "--inspect"
+            || (arg.starts_with('-')
+                && !arg.starts_with("--")
+                && arg.chars().skip(1).any(|flag| flag == 'i'))
+    }) {
+        return true;
+    }
+
+    args.windows(2).any(|pair| {
+        pair[0] == "-m"
+            && matches!(
+                pair[1].as_str(),
+                "code" | "pdb" | "idlelib" | "IPython" | "ipython"
+            )
+    })
+}
+
+fn filter_output(raw: &str, command_label: &str, recovery_hint: Option<&str>) -> String {
+    if raw.len() <= SUMMARY_THRESHOLD_BYTES {
+        return raw.trim_end_matches(['\r', '\n']).to_string();
+    }
+
+    let mut output = summary::summarize_output(raw, command_label, true);
+    let hint = recovery_hint
+        .map(str::to_string)
+        .or_else(|| crate::core::tee::force_tee_hint(raw, "python"));
+    if let Some(hint) = hint {
+        output.push('\n');
+        output.push_str(&hint);
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interactive_and_version_modes_pass_through() {
+        for args in [
+            vec![],
+            vec!["-i".into()],
+            vec!["-iq".into(), "script.py".into()],
+            vec!["--version".into()],
+            vec!["-m".into(), "pdb".into(), "script.py".into()],
+        ] {
+            assert!(should_passthrough(&args), "expected passthrough for {args:?}");
+        }
+    }
+
+    #[test]
+    fn scripts_and_inline_commands_are_filterable() {
+        for args in [
+            vec!["script.py".into()],
+            vec!["-c".into(), "print(1)".into()],
+            vec!["-m".into(), "http.server".into()],
+            vec!["-".into()],
+        ] {
+            assert!(!should_passthrough(&args), "expected filtering for {args:?}");
+        }
+    }
+
+    #[test]
+    fn short_output_is_preserved() {
+        assert_eq!(filter_output("one\ntwo\n", "python3 demo.py", None), "one\ntwo");
+    }
+
+    #[test]
+    fn large_output_is_summarized_with_recovery() {
+        let raw = (1..=200)
+            .map(|line| format!("debug value {line}: {}", "x".repeat(20)))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let filtered = filter_output(
+            &raw,
+            "python3 demo.py",
+            Some("[full output: /tmp/python.log]"),
+        );
+
+        assert!(filtered.contains("Command: python3 demo.py"));
+        assert!(filtered.contains("200 lines of output"));
+        assert!(filtered.ends_with("[full output: /tmp/python.log]"));
+        assert!(filtered.len() < raw.len());
+    }
+}

--- a/src/cmds/system/summary.rs
+++ b/src/cmds/system/summary.rs
@@ -40,7 +40,7 @@ pub fn run(command: &str, verbose: u8) -> Result<i32> {
     Ok(result.exit_code)
 }
 
-fn summarize_output(output: &str, command: &str, success: bool) -> String {
+pub(crate) fn summarize_output(output: &str, command: &str, success: bool) -> String {
     let lines: Vec<&str> = output.lines().collect();
     let mut result = Vec::new();
 

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -985,6 +985,9 @@ fn rewrite_segment_inner(
             if let Some(rewritten) =
                 rewrite_segment_inner(rest, excluded, transparent_prefixes, context, depth + 1)
             {
+                if prefix == "uv run" && rewritten.starts_with("rtk python --executable ") {
+                    break;
+                }
                 return Some(format!("{} {}", prefix, rewritten));
             }
             // #2768: falling through re-tests the full prefixed string, which is
@@ -4354,6 +4357,50 @@ mod tests {
         assert_eq!(
             rewrite_command_no_prefixes("wc src/*.rs", &[]),
             Some("rtk wc src/*.rs".into())
+        );
+    }
+
+    // --- #2312: generic Python proxy ---
+
+    #[test]
+    fn test_classify_generic_python_commands() {
+        for command in [
+            "python3 script.py",
+            "python3 -c 'print(1)'",
+            "python --version",
+        ] {
+            assert!(matches!(
+                classify_command(command),
+                Classification::Supported {
+                    rtk_equivalent: "rtk python --executable python3"
+                        | "rtk python --executable python",
+                    ..
+                }
+            ));
+        }
+    }
+
+    #[test]
+    fn test_rewrite_generic_python_preserves_executable() {
+        assert_eq!(
+            rewrite_command_no_prefixes("python3 -c 'print(1)'", &[]),
+            Some("rtk python --executable python3 -c 'print(1)'".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("python script.py", &[]),
+            Some("rtk python --executable python script.py".into())
+        );
+    }
+
+    #[test]
+    fn test_specific_python_module_routing_still_wins() {
+        assert_eq!(
+            rewrite_command_no_prefixes("python3 -m pytest tests/", &[]),
+            Some("rtk pytest tests/".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("python -m mypy src/", &[]),
+            Some("rtk mypy src/".into())
         );
     }
 

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -447,6 +447,26 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
+        pattern: r"^python3(?:\s|$)",
+        rtk_cmd: "rtk python --executable python3",
+        rewrite_prefixes: &["python3"],
+        category: "Python",
+        savings_pct: 60.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+        pipeline_final_safe: false,
+    },
+    RtkRule {
+        pattern: r"^python(?:\s|$)",
+        rtk_cmd: "rtk python --executable python",
+        rewrite_prefixes: &["python"],
+        category: "Python",
+        savings_pct: 60.0,
+        subcmd_savings: &[],
+        subcmd_status: &[],
+        pipeline_final_safe: false,
+    },
+    RtkRule {
         pattern: r"^(python3?\s+-m\s+)?mypy(\s|$)",
         rtk_cmd: "rtk mypy",
         rewrite_prefixes: &["python3 -m mypy", "python -m mypy", "mypy"],
@@ -954,6 +974,7 @@ pub const RULES: &[RtkRule] = &[
     },
 ];
 
+#[rustfmt::skip]
 pub const IGNORED_PREFIXES: &[&str] = &[
     "cd ",
     "cd\t",
@@ -984,8 +1005,6 @@ pub const IGNORED_PREFIXES: &[&str] = &[
     "cut ",
     "awk ",
     "sed ",
-    "python3 -c",
-    "python -c",
     "node -e",
     "ruby -e",
     "rtk ",

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use cmds::js::{
 };
 use cmds::jvm::{gradlew_cmd, mvn_cmd};
 use cmds::php::{ecs_cmd, paratest_cmd, pest_cmd, php_cmd, phpstan_cmd, phpunit_cmd, pint_cmd};
-use cmds::python::{mypy_cmd, pip_cmd, pytest_cmd, ruff_cmd, uv_cmd};
+use cmds::python::{mypy_cmd, pip_cmd, pytest_cmd, python_cmd, ruff_cmd, uv_cmd};
 use cmds::ruby::{rake_cmd, rspec_cmd, rubocop_cmd};
 use cmds::rust::{cargo_cmd, runner};
 use cmds::scala::sbt_cmd;
@@ -412,6 +412,17 @@ enum Commands {
     /// Word/line/byte count with compact output (strips paths and padding)
     Wc {
         /// Arguments passed to wc (files, flags like -l, -w, -c)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// Python with large-output summarization
+    #[command(visible_alias = "py")]
+    Python {
+        /// Python executable selected by hook rewriting
+        #[arg(long, hide = true, default_value = "python3")]
+        executable: String,
+        /// Arguments passed to Python
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -2124,6 +2135,8 @@ fn run_cli() -> Result<i32> {
 
         Commands::Wc { args } => wc_cmd::run(&args, cli.verbose)?,
 
+        Commands::Python { executable, args } => python_cmd::run(&executable, &args, cli.verbose)?,
+
         Commands::Gain {
             project, // added
             graph,
@@ -2749,6 +2762,7 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Npm { .. }
             | Commands::Npx { .. }
             | Commands::Curl { .. }
+            | Commands::Python { .. }
             | Commands::Ruff { .. }
             | Commands::Pytest { .. }
             | Commands::Php { .. }
@@ -3119,6 +3133,7 @@ mod tests {
             "grep",
             "wget",
             "wc",
+            "python",
             "jest",
             "vitest",
             "prisma",
@@ -3597,6 +3612,20 @@ mod tests {
                 );
             }
             _ => panic!("Expected Init command"),
+        }
+    }
+
+    #[test]
+    fn test_python_proxy_parses_hidden_executable_and_native_flags() {
+        let cli =
+            Cli::try_parse_from(["rtk", "python", "--executable", "python", "-c", "print(1)"])
+                .unwrap();
+        match cli.command {
+            Commands::Python { executable, args } => {
+                assert_eq!(executable, "python");
+                assert_eq!(args, vec!["-c", "print(1)"]);
+            }
+            _ => panic!("Expected Python command"),
         }
     }
 


### PR DESCRIPTION
## Summary

- add `rtk python` / `rtk py` routing for direct `python` and `python3` invocations
- preserve the original interpreter and keep interactive, debugger, help, and version modes as passthroughs
- retain exact output up to 1 KiB, then apply the existing heuristic summary with full-output recovery
- keep failures verbatim and preserve their exit codes
- retain specialized `pytest` and `mypy` module routing

## Verification

- `cargo test --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- compiled CLI smoke tests for short, large, version, and exit-7 failure paths

Closes #2312