### PR TITLE
tests: fix tests on non en env

### DIFF
--- a/tests/guard_integration_test.rs
+++ b/tests/guard_integration_test.rs
@@ -5,6 +5,7 @@ use std::process::{Command, Stdio};
 
 fn rtk_stdin(args: &[&str], input: &str) -> String {
     let mut child = Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .env("LANG", "C")
         .args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -58,6 +59,7 @@ fn guard_does_not_block_real_compression() {
 
 fn rtk_output_in_dir(dir: &std::path::Path, args: &[&str]) -> (String, String, Option<i32>) {
     let out = Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .env("LANG", "C")
         .args(args)
         .current_dir(dir)
         .output()

--- a/tests/guard_integration_test.rs
+++ b/tests/guard_integration_test.rs
@@ -5,7 +5,7 @@ use std::process::{Command, Stdio};
 
 fn rtk_stdin(args: &[&str], input: &str) -> String {
     let mut child = Command::new(env!("CARGO_BIN_EXE_rtk"))
-        .env("LANG", "C")
+        .env("LC_ALL", "C")
         .args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -59,7 +59,7 @@ fn guard_does_not_block_real_compression() {
 
 fn rtk_output_in_dir(dir: &std::path::Path, args: &[&str]) -> (String, String, Option<i32>) {
     let out = Command::new(env!("CARGO_BIN_EXE_rtk"))
-        .env("LANG", "C")
+        .env("LC_ALL", "C")
         .args(args)
         .current_dir(dir)
         .output()

--- a/tests/search_error_test.rs
+++ b/tests/search_error_test.rs
@@ -7,6 +7,7 @@ use std::process::Command;
 
 fn rtk(args: &[&str]) -> std::process::Output {
     Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .env("LANG", "C")
         .args(args)
         .output()
         .expect("rtk")

--- a/tests/search_error_test.rs
+++ b/tests/search_error_test.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 
 fn rtk(args: &[&str]) -> std::process::Output {
     Command::new(env!("CARGO_BIN_EXE_rtk"))
-        .env("LANG", "C")
+        .env("LC_ALL", "C")
         .args(args)
         .output()
         .expect("rtk")


### PR DESCRIPTION
## Summary
Make `cargo test` on non english env

## Test plan
- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] Manual testing: `rtk <command>` output inspected
