### PR TITLE
Feat/kimi uninstall

### DIFF
--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -1,6 +1,6 @@
 ---
 title: Supported Agents
-description: How to integrate RTK with Claude Code, Cursor, Copilot, Cline, Windsurf, Codex, OpenCode, Hermes, Kilo Code, Antigravity, and Factory Droid
+description: How to integrate RTK with Claude Code, Cursor, Copilot, Cline, Windsurf, Codex, Kimi, OpenCode, Hermes, Kilo Code, Antigravity, and Factory Droid
 sidebar:
   order: 3
 ---
@@ -41,6 +41,7 @@ Agent runs "cargo test"
 | Cline / Roo Code | Rules file (prompt-level) | N/A |
 | Windsurf | Rules file (prompt-level) | N/A |
 | Codex CLI | AGENTS.md instructions | N/A |
+| Kimi AI | AGENTS.md instructions | N/A |
 | Kilo Code | Rules file (prompt-level) | N/A |
 | Google Antigravity | Rules file (prompt-level) | N/A |
 | Mistral Vibe | Planned ([#800](https://github.com/rtk-ai/rtk/issues/800)) | Pending upstream |
@@ -179,6 +180,15 @@ rtk init --codex           # project-scoped (AGENTS.md)
 rtk init --global --codex  # user-global (~/.codex/AGENTS.md)
 ```
 
+### Kimi AI
+
+```bash
+rtk init --agent kimi              # project-scoped (AGENTS.md)
+rtk init --agent kimi --uninstall  # removes the RTK block from AGENTS.md
+```
+
+Kimi Code CLI loads project-level instructions from `AGENTS.md` in the project root — the same mechanism as Codex, so both agents share the file and its single RTK block (uninstalling either removes the shared block; re-running `rtk init` for the other re-adds it). Kimi has no global scope and no command-rewriting hook, so integration is prompt-level only. Verified end-to-end against Kimi Code CLI 0.29.1 (install → instructions honored → uninstall).
+
 ### Kilo Code
 
 ```bash
@@ -207,7 +217,7 @@ Support is blocked on upstream `BeforeToolCallback` ([mistral-vibe#531](https://
 | **Plugin** | TypeScript, JavaScript, or Python in agent's plugin system | Transparent, in-place mutation when the agent allows it |
 | **Rules file** | Prompt-level instructions | Guidance only — agent is told to prefer `rtk <cmd>` |
 
-Rules file integrations (Cline, Windsurf, Codex, Kilo Code, Antigravity) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it. Plugin integrations (OpenCode, Pi) use in-place mutation via the agent's TypeScript extension API.
+Rules file integrations (Cline, Windsurf, Codex, Kimi, Kilo Code, Antigravity) rely on the model following instructions. Full hook integrations (Claude Code, Cursor, Gemini) are guaranteed — the command is rewritten before the agent sees it. Plugin integrations (OpenCode, Pi) use in-place mutation via the agent's TypeScript extension API.
 
 ## Windows support
 

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -5148,6 +5148,35 @@ mod tests {
     }
 
     #[test]
+    fn test_uninstall_kimi_removes_agents_md_block() {
+        let temp = TempDir::new().unwrap();
+        run_kimi_mode_at(temp.path(), InitContext::default()).unwrap();
+
+        let agents_md = temp.path().join("AGENTS.md");
+        let installed = fs::read_to_string(&agents_md).unwrap();
+        assert!(
+            installed.contains(RTK_BLOCK_START),
+            "install should write the RTK instructions block"
+        );
+
+        let removed = uninstall_kimi_at(temp.path(), InitContext::default()).unwrap();
+
+        let content = fs::read_to_string(&agents_md).unwrap();
+        assert!(
+            !content.contains(RTK_BLOCK_START),
+            "uninstall should remove the RTK instructions block"
+        );
+        assert!(
+            removed.iter().any(|r| r.contains("rtk-instructions block")),
+            "uninstall should report the removed block"
+        );
+
+        // Second run is a no-op (nothing left to remove).
+        let removed_again = uninstall_kimi_at(temp.path(), InitContext::default()).unwrap();
+        assert!(removed_again.is_empty(), "Idempotent: nothing to remove");
+    }
+
+    #[test]
     fn test_patch_agents_md_creates_missing_file() {
         let temp = TempDir::new().unwrap();
         let agents_md = temp.path().join("AGENTS.md");

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -627,18 +627,27 @@ fn remove_hook_from_settings(ctx: InitContext) -> Result<bool> {
     Ok(removed)
 }
 
-/// Full uninstall for Claude, Gemini, Codex, Cursor, or Pi artifacts.
+/// Full uninstall for Claude, Gemini, Codex, Cursor, Pi, or Kimi artifacts.
 pub fn uninstall(
     global: bool,
     gemini: bool,
     codex: bool,
     cursor: bool,
     pi: bool,
+    kimi: bool,
     ctx: InitContext,
 ) -> Result<()> {
     let InitContext { verbose, dry_run } = ctx;
     if codex {
         uninstall_codex(global, ctx)?;
+        if dry_run {
+            print_dry_run_footer();
+        }
+        return Ok(());
+    }
+
+    if kimi {
+        uninstall_kimi(global, ctx)?;
         if dry_run {
             print_dry_run_footer();
         }
@@ -1945,6 +1954,74 @@ fn run_kimi_mode_at(base_dir: &Path, ctx: InitContext) -> Result<()> {
     }
 
     Ok(())
+}
+
+// Uninstall mirrors install: Kimi is project-scoped, so only ./AGENTS.md is
+// touched. NOTE: Kimi and Codex share the project-root AGENTS.md and its
+// single RTK block — uninstalling either agent removes the shared block
+// (re-running `rtk init` for the other agent re-adds it idempotently).
+
+fn uninstall_kimi(global: bool, ctx: InitContext) -> Result<()> {
+    let InitContext { dry_run, .. } = ctx;
+    if global {
+        anyhow::bail!("Kimi AI is project-scoped. Use: rtk init --agent kimi --uninstall");
+    }
+
+    let cwd = std::env::current_dir()?;
+    let removed = uninstall_kimi_at(&cwd, ctx)?;
+
+    if removed.is_empty() {
+        println!("RTK was not installed for Kimi AI (nothing to remove)");
+    } else {
+        let header = if dry_run {
+            "[dry-run] would uninstall RTK for Kimi AI:"
+        } else {
+            "RTK uninstalled for Kimi AI:"
+        };
+        println!("{}", header);
+        for item in removed {
+            println!("  - {}", item);
+        }
+    }
+
+    Ok(())
+}
+
+fn uninstall_kimi_at(base_dir: &Path, ctx: InitContext) -> Result<Vec<String>> {
+    let InitContext { verbose, dry_run } = ctx;
+    let mut removed = Vec::new();
+
+    // Kimi reads AGENTS.md from the project root (workspace-scoped).
+    let agents_md_path = base_dir.join(AGENTS_MD);
+    if agents_md_path.exists() {
+        let content = fs::read_to_string(&agents_md_path)
+            .with_context(|| format!("Failed to read AGENTS.md: {}", agents_md_path.display()))?;
+
+        if content.contains(RTK_BLOCK_START) {
+            let (cleaned, did_remove) = remove_rtk_block(&content);
+            if did_remove {
+                if dry_run {
+                    println!(
+                        "[dry-run] would remove rtk-instructions block: {}",
+                        agents_md_path.display()
+                    );
+                } else {
+                    atomic_write(&agents_md_path, &cleaned).with_context(|| {
+                        format!("Failed to write AGENTS.md: {}", agents_md_path.display())
+                    })?;
+                    if verbose > 0 {
+                        eprintln!(
+                            "Removed rtk-instructions block: {}",
+                            agents_md_path.display()
+                        );
+                    }
+                }
+                removed.push("AGENTS.md: removed rtk-instructions block".to_string());
+            }
+        }
+    }
+
+    Ok(removed)
 }
 
 fn uninstall_hermes_at(hermes_home: &Path, ctx: InitContext) -> Result<Vec<String>> {
@@ -6872,7 +6949,16 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         with_claude_dir_override(&tmp, |claude_dir| {
             run_default_mode(true, PatchMode::Auto, false, InitContext::default()).unwrap();
-            uninstall(true, false, false, false, false, InitContext::default()).unwrap();
+            uninstall(
+                true,
+                false,
+                false,
+                false,
+                false,
+                false,
+                InitContext::default(),
+            )
+            .unwrap();
 
             assert!(!claude_dir.join(RTK_MD).exists(), "RTK.md must be removed");
             let settings_content =
@@ -7000,7 +7086,7 @@ mod tests {
                 dry_run: true,
                 ..Default::default()
             };
-            uninstall(true, false, false, false, false, dry).unwrap();
+            uninstall(true, false, false, false, false, false, dry).unwrap();
 
             // Files must still exist with identical content
             assert!(
@@ -7226,7 +7312,16 @@ mod tests {
             let plugin = pi_dir.join(PI_EXTENSIONS_SUBDIR).join(PI_PLUGIN_FILE);
             assert!(plugin.exists());
 
-            uninstall(true, false, false, false, true, InitContext::default()).unwrap();
+            uninstall(
+                true,
+                false,
+                false,
+                false,
+                true,
+                false,
+                InitContext::default(),
+            )
+            .unwrap();
 
             assert!(!plugin.exists(), "plugin must be removed");
         });
@@ -7240,7 +7335,15 @@ mod tests {
         std::env::set_current_dir(tmp.path()).unwrap();
 
         run_pi_mode(false, InitContext::default()).unwrap();
-        let result = uninstall(false, false, false, false, true, InitContext::default());
+        let result = uninstall(
+            false,
+            false,
+            false,
+            false,
+            true,
+            false,
+            InitContext::default(),
+        );
         std::env::set_current_dir(&cwd).unwrap();
         result.unwrap();
 
@@ -7339,6 +7442,7 @@ mod tests {
                 false,
                 false,
                 true,
+                false,
                 InitContext {
                     verbose: 0,
                     dry_run: true,
@@ -7377,6 +7481,7 @@ mod tests {
             false,
             false,
             true,
+            false,
             InitContext {
                 verbose: 0,
                 dry_run: true,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1528,7 +1528,8 @@ fn uninstall_init_dispatch<UninstallHermes, UninstallStandard>(
 ) -> Result<()>
 where
     UninstallHermes: FnOnce(hooks::init::InitContext) -> Result<()>,
-    UninstallStandard: FnOnce(bool, bool, bool, bool, bool, hooks::init::InitContext) -> Result<()>,
+    UninstallStandard:
+        FnOnce(bool, bool, bool, bool, bool, bool, hooks::init::InitContext) -> Result<()>,
 {
     if agent == Some(AgentTarget::Hermes) {
         uninstall_hermes(ctx)
@@ -1537,7 +1538,8 @@ where
     } else {
         let cursor = agent == Some(AgentTarget::Cursor);
         let pi = agent == Some(AgentTarget::Pi);
-        uninstall_standard(global, gemini, codex, cursor, pi, ctx)
+        let kimi = agent == Some(AgentTarget::Kimi);
+        uninstall_standard(global, gemini, codex, cursor, pi, kimi, ctx)
     }
 }
 
@@ -2951,7 +2953,7 @@ mod tests {
                 assert!(ctx.dry_run);
                 Ok(())
             },
-            |_, _, _, _, _, _| {
+            |_, _, _, _, _, _, _| {
                 standard_called.set(true);
                 Ok(())
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -2965,6 +2965,32 @@ mod tests {
     }
 
     #[test]
+    fn test_init_uninstall_dispatch_routes_kimi_to_standard_with_kimi_flag() {
+        let kimi_flag = Cell::new(false);
+        let ctx = hooks::init::InitContext {
+            verbose: 0,
+            dry_run: true,
+        };
+
+        let result = uninstall_init_dispatch(
+            Some(AgentTarget::Kimi),
+            false,
+            false,
+            false,
+            ctx,
+            |_| panic!("kimi must not route to hermes cleanup"),
+            |global, gemini, codex, cursor, pi, kimi, _| {
+                assert!(!global && !gemini && !codex && !cursor && !pi);
+                kimi_flag.set(kimi);
+                Ok(())
+            },
+        );
+
+        assert!(result.is_ok());
+        assert!(kimi_flag.get());
+    }
+
+    #[test]
     fn test_try_parse_help_is_display_help() {
         match Cli::try_parse_from(["rtk", "--help"]) {
             Err(e) => assert_eq!(e.kind(), ErrorKind::DisplayHelp),


### PR DESCRIPTION
## Summary                                                                                                                                                                                            
                                                                                                                                                                                                           
     - Add an uninstall path for Kimi AI: `uninstall_kimi_at()` mirrors `uninstall_codex_at()` — it reads the project-root `AGENTS.md`, removes the RTK instructions block via the existing                
   `remove_rtk_block()`, and writes it back. Previously `rtk init --agent kimi --uninstall` fell through to the standard uninstall handler and left the block behind.                                      
     - Thread a `kimi` flag through `uninstall_init_dispatch()` / `uninstall()`, like the other agents, and bail on `--global` (Kimi is project-scoped, consistent with install).                          
     - Note: Kimi and Codex share the project-root `AGENTS.md` and its single RTK block — uninstalling either agent removes the shared block (re-running `rtk init` for the other agent re-adds it         
   idempotently).                                                                                                                                                                                          
                                                                                                                                                                                                           
## Test plan                                                                                                                                                                                          
                                                                                                                                                                                                           
     - [x] `cargo fmt --all && cargo clippy --all-targets && cargo test` — all green (2439 unit tests + integration suites, 0 failures)                                                                    
     - [x] New tests: `test_uninstall_kimi_removes_agents_md_block` (install → uninstall → block gone → second run is a no-op) and `test_init_uninstall_dispatch_routes_kimi_to_standard_with_kimi_flag`   
   (dispatch passes `kimi = true` instead of falling through)                                                                                                                                              
     - [x] Manual testing: `rtk init --agent kimi` then `rtk init --agent kimi --uninstall` in a scratch project — block added/removed cleanly, pre-existing `AGENTS.md` content preserved; `--dry-run`    
   reports without writing                                                                                                                                                                                 
                                                                                                                                                                                                           
     > **Important:** All PRs must target the `develop` branch (not `master`).                                                                                                                             
     > See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details. 