### PR TITLE
docs(install): pin cargo install to the master release branch

### DIFF
--- a/docs/guide/analytics/gain.md
+++ b/docs/guide/analytics/gain.md
@@ -172,7 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: cargo install rtk
+      - run: cargo install --git https://github.com/rtk-ai/rtk --branch master rtk
       - run: rtk gain --weekly --format json > stats/week-$(date +%Y-%W).json
       - run: git add stats/ && git commit -m "Weekly rtk stats" && git push
 ```

--- a/docs/guide/getting-started/installation.md
+++ b/docs/guide/getting-started/installation.md
@@ -47,9 +47,7 @@ brew install rtk-ai/tap/rtk
 cargo install --git https://github.com/rtk-ai/rtk --branch master rtk
 ```
 
-`master` always tracks the latest stable release. Without `--branch master`, Cargo builds the repository default branch (`develop`), which carries unreleased code and reports a lower version number than the release it is built from.
-
-To follow the development branch on purpose:
+To follow the development branch:
 
 ```bash
 cargo install --git https://github.com/rtk-ai/rtk rtk

--- a/docs/guide/getting-started/installation.md
+++ b/docs/guide/getting-started/installation.md
@@ -47,12 +47,6 @@ brew install rtk-ai/tap/rtk
 cargo install --git https://github.com/rtk-ai/rtk --branch master rtk
 ```
 
-To follow the development branch:
-
-```bash
-cargo install --git https://github.com/rtk-ai/rtk rtk
-```
-
 ## Pre-built binaries (Windows, Linux, macOS)
 
 Download from [GitHub releases](https://github.com/rtk-ai/rtk/releases):

--- a/docs/guide/getting-started/installation.md
+++ b/docs/guide/getting-started/installation.md
@@ -44,6 +44,14 @@ brew install rtk-ai/tap/rtk
 :::
 
 ```bash
+cargo install --git https://github.com/rtk-ai/rtk --branch master rtk
+```
+
+`master` always tracks the latest stable release. Without `--branch master`, Cargo builds the repository default branch (`develop`), which carries unreleased code and reports a lower version number than the release it is built from.
+
+To follow the development branch on purpose:
+
+```bash
 cargo install --git https://github.com/rtk-ai/rtk rtk
 ```
 

--- a/docs/guide/resources/troubleshooting.md
+++ b/docs/guide/resources/troubleshooting.md
@@ -130,7 +130,7 @@ Error: program not found
 
 **Fix:** Update to RTK v0.23.1+:
 ```bash
-cargo install --git https://github.com/rtk-ai/rtk
+cargo install --git https://github.com/rtk-ai/rtk --branch master
 rtk --version    # should be 0.23.1+
 ```
 
@@ -158,10 +158,10 @@ rtk init --show    # should show "OpenCode: plugin installed"
 
 If Rust Type Kit is published to crates.io under the name `rtk`, `cargo install rtk` may install the wrong one.
 
-Always use the explicit URL:
+Always use the explicit URL, pinned to the release branch:
 
 ```bash
-cargo install --git https://github.com/rtk-ai/rtk
+cargo install --git https://github.com/rtk-ai/rtk --branch master
 ```
 
 ## Run the diagnostic script

--- a/docs/usage/TRACKING.md
+++ b/docs/usage/TRACKING.md
@@ -369,7 +369,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install RTK
-        run: cargo install --git https://github.com/rtk-ai/rtk
+        run: cargo install --git https://github.com/rtk-ai/rtk --branch master
 
       - name: Export weekly stats
         run: |


### PR DESCRIPTION
## Problem

`cargo install --git https://github.com/rtk-ai/rtk` resolves the repository **default branch** (`develop`), not the latest release. 

## Fix

Docs-only. No code or behaviour change.
Tested locally