### PR TITLE
fix(discover): sanitize apostrophes in Claude project paths

### DIFF
--- a/src/discover/provider.rs
+++ b/src/discover/provider.rs
@@ -117,15 +117,16 @@ impl ClaudeProvider {
 
     /// Encode a filesystem path to Claude Code's directory name format.
     ///
-    /// Claude Code replaces `/`, `.`, `_`, `\`, and any non-ASCII character
-    /// with `-` when computing the project directory slug under `~/.claude/projects/`.
+    /// Claude Code replaces path separators, `.`, `_`, spaces, brackets,
+    /// apostrophes, and any non-ASCII character with `-` when computing the
+    /// project directory slug under `~/.claude/projects/`.
     ///
     /// `/Users/foo/bar`          → `-Users-foo-bar`
     /// `/Users/first.last/bar`   → `-Users-first-last-bar`
     /// `/home/chris/2_project`   → `-home-chris-2-project`
     /// `C:\Users\foo\bar`        → `C:-Users-foo-bar`
     pub fn encode_project_path(path: &str) -> String {
-        const SANITIZED_CHARS: &[char] = &['/', '.', '_', '\\', ' ', '[', ']'];
+        const SANITIZED_CHARS: &[char] = &['/', '.', '_', '\\', ' ', '[', ']', '\''];
 
         path.chars()
             .map(|c| {
@@ -407,6 +408,14 @@ mod tests {
         assert_eq!(
             ClaudeProvider::encode_project_path(r"C:\Users\foo\bar"),
             "C:-Users-foo-bar"
+        );
+    }
+
+    #[test]
+    fn test_encode_project_path_windows_apostrophe() {
+        assert_eq!(
+            ClaudeProvider::encode_project_path(r"C:\Users\Daniel's PC\project"),
+            "C:-Users-Daniel-s-PC-project"
         );
     }
 


### PR DESCRIPTION
## Summary

- sanitize ASCII apostrophes when encoding Claude Code project paths
- add a Windows regression test for usernames such as `Daniel's PC`
- clarify the documented set of characters replaced in project slugs

## Why

Claude Code replaces apostrophes with `-` in directory names under `~/.claude/projects/`, but RTK preserved them. For Windows users whose username contains an apostrophe, the current-project filter could not match the on-disk session directory and reported zero sessions.

Fixes #3113

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets`
- `cargo test --all` — 2,437 passed, 8 ignored, 0 failed