### PR TITLE
fix(grep): accept GNU grep flags -E/-r/-R/-i/-w/-A/-B/-C (#2614), and stop -E/-r from silently eating the next arg (#2253)

### DIFF
--- a/src/cmds/system/grep_cmd.rs
+++ b/src/cmds/system/grep_cmd.rs
@@ -43,8 +43,7 @@ pub fn run(
     }
 
     for arg in extra_args {
-        // Fix: skip grep-ism -r flag (rg is recursive by default; rg -r means --replace)
-        if arg == "-r" || arg == "--recursive" {
+        if is_rg_incompatible_grep_flag(arg) {
             continue;
         }
         rg_cmd.arg(arg);
@@ -180,6 +179,26 @@ fn parse_match_line(line: &str) -> Option<(String, usize, &str)> {
         let line_num: usize = line_num.parse().ok()?;
         Some((file.to_string(), line_num, content))
     })
+}
+
+/// GNU-grep flags that must NOT be forwarded to ripgrep.
+///
+/// `rg`'s short forms for these collide with grep's and, critically, **take a
+/// value** — so forwarding them silently consumes the following argument
+/// (the mechanism behind rtk-ai/rtk#2253, where a pattern got eaten):
+///
+/// | flag | GNU grep          | ripgrep              |
+/// |------|-------------------|----------------------|
+/// | `-E` | extended regex    | `--encoding=VALUE`   |
+/// | `-r` | recursive         | `--replace=VALUE`    |
+///
+/// Dropping them is semantically correct: `rg` is recursive and
+/// extended-regex by default, so grep's intent is already satisfied.
+fn is_rg_incompatible_grep_flag(arg: &str) -> bool {
+    matches!(
+        arg,
+        "-r" | "--recursive" | "-R" | "--dereference-recursive" | "-E" | "--extended-regexp"
+    )
 }
 
 fn has_format_flag(extra_args: &[String]) -> bool {
@@ -506,5 +525,62 @@ mod tests {
             );
         }
         // If rg is not installed, skip gracefully (test still passes)
+    }
+
+    // ── GNU-grep flag compatibility (rtk-ai/rtk#2614, #2253) ──────────────
+
+    #[test]
+    fn value_taking_rg_collisions_are_dropped() {
+        // rg -E is --encoding=VALUE and rg -r is --replace=VALUE. Forwarding
+        // either would swallow the NEXT argument, silently corrupting the
+        // search (issue #2253). They must never reach rg.
+        for flag in [
+            "-E",
+            "--extended-regexp",
+            "-r",
+            "--recursive",
+            "-R",
+            "--dereference-recursive",
+        ] {
+            assert!(
+                is_rg_incompatible_grep_flag(flag),
+                "{flag} must be dropped before reaching rg"
+            );
+        }
+    }
+
+    #[test]
+    fn identical_semantics_flags_are_forwarded() {
+        // These mean the same thing in grep and rg, so they must pass through.
+        for flag in ["-i", "--ignore-case", "-w", "--word-regexp", "-A", "-B", "-C"] {
+            assert!(
+                !is_rg_incompatible_grep_flag(flag),
+                "{flag} has identical rg semantics and must be forwarded"
+            );
+        }
+    }
+
+    #[test]
+    fn dropping_a_flag_does_not_consume_the_following_argument() {
+        // Regression guard for #2253: filtering must be per-argument, so the
+        // token after a dropped flag survives.
+        let args: Vec<String> = ["-E", "def", "-r", "src/"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let forwarded: Vec<&String> = args
+            .iter()
+            .filter(|a| !is_rg_incompatible_grep_flag(a))
+            .collect();
+        assert_eq!(forwarded, vec!["def", "src/"], "pattern must not be eaten");
+    }
+
+    #[test]
+    fn max_len_short_flag_is_not_reinterpreted_as_gnu_files_with_matches() {
+        // rtk's -l means max_len. GNU grep's -l means --files-with-matches.
+        // We deliberately did NOT change this (no breaking change), so -l must
+        // still be treated as a format flag by the passthrough path only.
+        assert!(has_format_flag(&["-l".to_string()]));
+        assert!(!is_rg_incompatible_grep_flag("-l"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -322,7 +322,33 @@ enum Commands {
         /// Show line numbers (always on, accepted for grep/rg compatibility)
         #[arg(short = 'n', long)]
         line_numbers: bool,
-        /// Extra ripgrep arguments (e.g., -i, -A 3, -w, --glob)
+        /// Extended regex (GNU grep -E). Accepted and dropped: rg is already
+        /// extended-regex by default, and rg's own -E means --encoding=VALUE.
+        #[arg(short = 'E', long = "extended-regexp")]
+        extended_regexp: bool,
+        /// Recursive (GNU grep -r/-R). Accepted and dropped: rg recurses by
+        /// default, and rg's own -r means --replace=VALUE.
+        #[arg(short = 'r', long = "recursive")]
+        recursive: bool,
+        /// Recursive, follow symlinks (GNU grep -R). Accepted and dropped.
+        #[arg(short = 'R', long = "dereference-recursive")]
+        dereference_recursive: bool,
+        /// Case-insensitive match (forwarded to rg)
+        #[arg(short = 'i', long = "ignore-case")]
+        ignore_case: bool,
+        /// Match whole words only (forwarded to rg)
+        #[arg(short = 'w', long = "word-regexp")]
+        word_regexp: bool,
+        /// Lines of context after each match (forwarded to rg)
+        #[arg(short = 'A', long = "after-context", value_name = "NUM")]
+        after_context: Option<usize>,
+        /// Lines of context before each match (forwarded to rg)
+        #[arg(short = 'B', long = "before-context", value_name = "NUM")]
+        before_context: Option<usize>,
+        /// Lines of context around each match (forwarded to rg)
+        #[arg(short = 'C', long = "context", value_name = "NUM")]
+        context: Option<usize>,
+        /// Extra ripgrep arguments (e.g., --glob, -F)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         extra_args: Vec<String>,
     },
@@ -1807,17 +1833,51 @@ fn run_cli() -> Result<i32> {
             context_only,
             file_type,
             line_numbers: _, // no-op: line numbers always enabled in grep_cmd::run
+            // GNU-grep flags rg already implies. Accepted so clap does not reject
+            // the invocation, then intentionally dropped: rg's -E is
+            // --encoding=VALUE and rg's -r is --replace=VALUE, so forwarding
+            // them would silently consume the next argument (see rtk-ai/rtk#2253).
+            extended_regexp: _,
+            recursive: _,
+            dereference_recursive: _,
+            ignore_case,
+            word_regexp,
+            after_context,
+            before_context,
+            context,
             extra_args,
-        } => grep_cmd::run(
-            &pattern,
-            &path,
-            max_len,
-            max,
-            context_only,
-            file_type.as_deref(),
-            &extra_args,
-            cli.verbose,
-        )?,
+        } => {
+            // Translate the GNU-grep flags whose rg semantics are identical.
+            let mut rg_args: Vec<String> = Vec::new();
+            if ignore_case {
+                rg_args.push("-i".to_string());
+            }
+            if word_regexp {
+                rg_args.push("-w".to_string());
+            }
+            for (flag, value) in [
+                ("-A", after_context),
+                ("-B", before_context),
+                ("-C", context),
+            ] {
+                if let Some(n) = value {
+                    rg_args.push(flag.to_string());
+                    rg_args.push(n.to_string());
+                }
+            }
+            rg_args.extend(extra_args.iter().cloned());
+
+            grep_cmd::run(
+                &pattern,
+                &path,
+                max_len,
+                max,
+                context_only,
+                file_type.as_deref(),
+                &rg_args,
+                cli.verbose,
+            )?
+        }
 
         Commands::Init {
             global,


### PR DESCRIPTION
Fixes the clap-layer rejection described in #2614, and closes a silent-corruption path that is the likely mechanism behind #2253.

## Problem

`rtk grep` rejected the most common real-world grep invocations, so the hook's rewrite **guaranteed** a parse failure followed by a silent raw fallback at 0 tokens saved.

From a 5-week local tracking DB (11,932 commands): **2,142 parse failures, 1,970 of them `grep` (92%)**, every one with `fallback_succeeded=1` — they read as success while saving nothing. This independently reproduces @-reporter's 4,416/90-day figure in #2614.

Root cause: the rejected flags arrive **before** the `pattern`/`path` positionals, so `trailing_var_arg` never collected them into `extra_args`. `grep_cmd` already had `-r`-skip and format-flag passthrough logic, but clap failed first, so that code was unreachable.

## Two classes of flag, handled differently

**Dropped** — accepted by clap, never forwarded to rg. Their rg short forms collide with grep's *and take a value*, so forwarding silently consumes the following argument:

| flag | GNU grep | ripgrep |
|---|---|---|
| `-E` | extended regex (bool) | `--encoding=VALUE` |
| `-r` | recursive (bool) | `--replace=VALUE` |

This is very likely the mechanism behind **#2253** ("matches silently rewritten `def` → `n`"): a forwarded `-E`/`-r` eats the pattern. Dropping them is semantically correct — rg is recursive and extended-regex by default, so grep's intent is already satisfied.

**Forwarded** — identical semantics in both tools: `-i`, `-w`, `-A/-B/-C <NUM>`.

## Not changed (deliberate)

`-l` still means `max_len`. Aligning it with GNU's `--files-with-matches` would break existing CLI behavior for anyone scripting `rtk grep -l`, so it is left alone and called out in a test. Happy to do it in a follow-up if maintainers want the breaking change.

## Verification

Against `/usr/bin/grep` (not the rtk-rewritten shell alias):

| case | real grep | rtk grep |
|---|---|---|
| `-E 'fn run\|fn filter'` | 1 | 1 |
| `-ci LAZY_STATIC` | 1 | 1 |
| `-w run` | 3 (L12, 298, 404) | 3 (L12, 298, 404) |

All five previously-failing forms now parse: `-nE`, `-rn --include`, `-c`, `-n -A2`, `-i`.

## Tests

4 regression tests, including a guard that dropping a flag does not consume the following token (the #2253 shape). Suite **2147 → 2151 passing**.

The 3 failures in `hooks::rewrite_cmd::tests::unattestable_passthrough` are **pre-existing on HEAD** — verified by stashing this change and re-running (identical 3 failures, identical 2147 pass count). Unrelated to this PR.

`cargo fmt --all` clean, `cargo clippy --all-targets` 0 warnings.
