### PR TITLE
feat(filters): composer-analyse and phpstan progress-bar collapse

### DIFF
--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -1896,8 +1896,8 @@ match_command = "^make\\b"
         let filters = make_filters(BUILTIN_TOML);
         assert_eq!(
             filters.len(),
-            63,
-            "Expected exactly 63 built-in filters, got {}. \
+            65,
+            "Expected exactly 65 built-in filters, got {}. \
              Update this count when adding/removing filters in src/filters/.",
             filters.len()
         );

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -4569,6 +4569,26 @@ mod tests {
     }
 
     #[test]
+    fn test_rewrite_composer_analyse() {
+        assert_eq!(
+            rewrite_command_no_prefixes("composer analyse", &[]),
+            Some("rtk composer analyse".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("composer check-style", &[]),
+            Some("rtk composer check-style".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_composer_install_still_rewrites() {
+        assert_eq!(
+            rewrite_command_no_prefixes("composer install", &[]),
+            Some("rtk composer install".into())
+        );
+    }
+
+    #[test]
     fn test_classify_pest() {
         assert!(matches!(
             classify_command("vendor/bin/pest tests/"),

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -677,12 +677,18 @@ pub const RULES: &[RtkRule] = &[
         subcmd_status: &[],
     },
     RtkRule {
-        pattern: r"^composer\s+(install|update|require)\b",
+        pattern: r"^composer\s+(install|update|require|analyse|analyze|check-style|validate|test|dump-autoload)\b",
         rtk_cmd: "rtk composer",
         rewrite_prefixes: &["composer"],
         category: "PackageManager",
         savings_pct: 65.0,
-        subcmd_savings: &[],
+        subcmd_savings: &[
+            ("analyse", 65.0),
+            ("analyze", 65.0),
+            ("check-style", 65.0),
+            ("validate", 60.0),
+            ("test", 70.0),
+        ],
         subcmd_status: &[],
     },
     RtkRule {

--- a/src/filters/composer-analyse.toml
+++ b/src/filters/composer-analyse.toml
@@ -1,0 +1,51 @@
+[filters.composer-analyse]
+description = "Compact composer analyse/check-style/validate — strip PHPStan progress noise and PHP deprecations"
+match_command = "^composer\\s+(analyse|analyze|check-style|validate|test|dump-autoload)\\b"
+strip_ansi = true
+filter_stderr = true
+replace = [
+  { pattern = "\\r\\s*\\d+/\\d+ \\[[█░▓\\- ]+\\]\\s*\\d+%", replacement = "" },
+  { pattern = "\\r+", replacement = "\n" },
+  { pattern = "\\s*(?:\\d+/\\d+ \\[[█░▓\\- ]+\\]\\s*\\d+%\\s*)+", replacement = "" },
+  { pattern = "\\d+/\\d+ \\[[█░▓\\- ]+\\]\\s*\\d+%", replacement = "" },
+]
+strip_lines_matching = [
+  "^\\s*$",
+  "^Deprecated:",
+  "^PHP Deprecated:",
+  "^Note: Using configuration file",
+  "^Loading composer",
+  "^> ",
+  "^ -- -+$",
+  "^    \\.\\.+$",
+]
+match_output = [
+  { pattern = "\\[OK\\] No errors", message = "phpstan: ok (no errors)" },
+  { pattern = "No errors$", message = "phpstan: ok (no errors)" },
+]
+max_lines = 80
+tail_lines = 50
+
+[[tests.composer-analyse]]
+name = "strips inline progress bars"
+input = "Note: Using configuration file phpstan.neon.\n 0/2838 [░░░░]   0%\r 20/2838 [░░░░]   0%\r 2838/2838 [████] 100%\n\n [OK] No errors\n"
+expected = "phpstan: ok (no errors)"
+
+[[tests.composer-analyse]]
+name = "strips deprecations and progress"
+input = """
+Deprecated: Constant PDO::MYSQL_ATTR_SSL_CA
+> ./vendor/bin/phpstan analyse
+ 1/1 [████] 100%
+"""
+expected = ""
+
+[[tests.composer-analyse]]
+name = "empty input"
+input = ""
+expected = ""
+
+[[tests.composer-analyse]]
+name = "strips concatenated progress on one line"
+input = "[ERROR] Found 1 error\n            120/2838 [▓░░░░░░░░░░░░░░░░░░░░░░░░░░░]   4%  180/2838 [▓░░░░░░░░░░░░░░░░░░░░░░░░░░░]   6%\n"
+expected = "[ERROR] Found 1 error\n"

--- a/src/filters/phpstan.toml
+++ b/src/filters/phpstan.toml
@@ -1,0 +1,54 @@
+[filters.phpstan]
+description = "Compact PHPStan analyse output — collapse Symfony progress bars (complements rtk phpstan JSON filter for php-wrapper invocations)"
+match_command = "(^|[/\\w.-]+/)phpstan\\b|^php\\s+.*phpstan\\b"
+strip_ansi = true
+filter_stderr = true
+replace = [
+  { pattern = "\\r\\s*\\d+/\\d+ \\[[█░▓\\- ]+\\]\\s*\\d+%", replacement = "" },
+  { pattern = "\\r+", replacement = "\n" },
+  { pattern = "\\s*(?:\\d+/\\d+ \\[[█░▓\\- ]+\\]\\s*\\d+%\\s*)+", replacement = "" },
+  { pattern = "\\d+/\\d+ \\[[█░▓\\- ]+\\]\\s*\\d+%", replacement = "" },
+]
+strip_lines_matching = [
+  "^\\s*$",
+  "^Note: Using configuration file",
+  "^ -- -+$",
+  "^    \\.\\.+$",
+]
+match_output = [
+  { pattern = "\\[OK\\] No errors", message = "phpstan: ok (no errors)" },
+  { pattern = "No errors$", message = "phpstan: ok (no errors)" },
+]
+max_lines = 80
+tail_lines = 50
+
+[[tests.phpstan]]
+name = "collapses carriage-return progress spam"
+input = " 0/10 [░░░░░░░░░░]   0%\r 5/10 [▓▓░░░░░░░░]  50%\r 10/10 [▓▓▓▓▓▓▓▓▓▓] 100%\n\n [OK] No errors\n"
+expected = "phpstan: ok (no errors)"
+
+[[tests.phpstan]]
+name = "strips concatenated progress on one line"
+input = "[ERROR] Found 1 error\n            120/2838 [▓░░░░░░░░░░░░░░░░░░░░░░░░░░░]   4%  180/2838 [▓░░░░░░░░░░░░░░░░░░░░░░░░░░░]   6%\n"
+expected = "[ERROR] Found 1 error\n"
+
+[[tests.phpstan]]
+name = "preserves error findings"
+input = """
+ -- ----------------------------------------------------------------------- 
+     Error                                                                  
+ -- ----------------------------------------------------------------------- 
+     Undefined variable $foo                                                
+ -- ----------------------------------------------------------------------- 
+
+ [ERROR] Found 1 error
+"""
+expected = """
+ -- ----------------------------------------------------------------------- 
+     Error                                                                  
+ -- ----------------------------------------------------------------------- 
+     Undefined variable $foo                                                
+ -- ----------------------------------------------------------------------- 
+
+ [ERROR] Found 1 error
+"""


### PR DESCRIPTION
## Summary

- Add **`composer-analyse.toml`** — strips Symfony `\r` and concatenated progress bars from `composer analyse|check-style|validate|test|dump-autoload`, plus PHP deprecation noise; short-circuits `[OK] No errors`.
- Add **`phpstan.toml`** — same progress collapse for `php … phpstan` / direct `phpstan` invocations (complements the existing `rtk phpstan` JSON filter on develop when stdout is still text/progress).
- Extend hook rewrite rule: `composer analyse|analyze|check-style|validate|test|dump-autoload` → `rtk composer …`.
- Inline tests cover `\r` progress spam, concatenated single-line progress, and error preservation.

## Motivation

On Laravel/PHP repos, captured `composer analyse` output is dominated by PHPStan progress bars (~97% token waste). The develop branch’s `rtk phpstan` JSON filter does not cover the composer-script path or php-wrapper invocations that still emit Symfony progress text.

Related: #1649 (Rust PHP consolidation — complementary, not redundant).

## Test plan

- [x] `cargo test --bin rtk toml_filter::tests::test_builtin` (count 65, all filters have inline tests)
- [x] `cargo test --bin rtk rewrite_composer`
- [ ] CI `cargo test` on PR


Made with [Cursor](https://cursor.com)