### PR TITLE
docs(config): update example to include `max_file_size`

### DIFF
--- a/docs/guide/getting-started/configuration.md
+++ b/docs/guide/getting-started/configuration.md
@@ -42,6 +42,7 @@ ignore_files = ["*.lock", "*.min.js", "*.min.css"]
 enabled = true              # save raw output on failure
 mode = "failures"           # "failures" (default), "always", "never"
 max_files = 20              # rotation: keep last N files
+max_file_size = 1048576     # 1 MB in bytes
 # directory = "/custom/tee/path"  # optional override
 
 [telemetry]


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->
- updates the configuration example in the documentation, it was incomplete and missing an expected value, `max_file_size`.

## Test plan
<!-- How did you verify this works? -->
adding the value to my config allowed rtk to successfully parse it

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
