### PR TITLE
fix(rewrite): only rewrite safe final pipeline stages

### DIFF
--- a/docs/contributing/TECHNICAL.md
+++ b/docs/contributing/TECHNICAL.md
@@ -141,8 +141,9 @@ rewrite_compound(cmd, excluded)                    [src/discover/registry.rs]
   |
   |  Step 2 — Split on operators, rewrite each segment
   |  Operator (&&, ||, ;) → rewrite both sides
-  |  Pipe (|) → rewrite left side only, keep right side raw
-  |             exception: find/fd before pipe → skip rewrite
+  |  Pipe (|) → keep producers/intermediate stages raw
+  |             rewrite only a pipeline-safe final stage
+  |  Stderr pipe (|&) → keep the complete pipeline raw
   |  Shellism (&) → rewrite both sides (background)
   |
   |  Calls rewrite_segment() per segment:
@@ -205,7 +206,7 @@ LLM Agent executes rewritten command
 Key design decisions:
 - **Lexer-based tokenization**: A single-pass state machine (`lexer.rs`) handles all shell constructs (quotes, escapes, redirects, operators). Used for both compound splitting and redirect stripping.
 - **Segment-level rewriting**: Compound commands are split by operators, each segment rewritten independently. Bash recombines them at execution time.
-- **Pipe semantics**: Only the left side of `|` is rewritten. The pipe consumer (grep, head, wc) runs raw. `find`/`fd` before a pipe is never rewritten (output format incompatible with xargs).
+- **Pipe semantics**: Producers and intermediate stages of `|` remain raw. Only an argument-safe final stage whose rule has `pipeline_final_safe` may be rewritten; initially this is limited to ordinary `grep`, `rg`, and `wc` invocations. Search pattern-file forms (`-f`/`--file`) defer because they can consume pipeline stdin as configuration. `|&` is recognized separately and its complete pipeline stays raw.
 - **Double env prefix handling**: `classify_command()` strips env prefixes to match the underlying command against rules. `rewrite_segment()` extracts the same prefix separately to re-prepend it to the rewritten command.
 - **Fallback contract**: If any segment fails to match, it stays raw. `rewrite_command()` returns `None` only when zero segments were rewritten.
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -197,11 +197,12 @@ The registry (`src/discover/registry.rs`) handles command patterns across these 
 
 ### Compound Command Handling
 
-The registry handles `&&`, `||`, `;`, `|`, and `&` operators:
+The registry handles `&&`, `||`, `;`, `|`, `|&`, and `&` operators:
 
-- **Pipe** (`|`): Only the left side is rewritten (right side consumes output format)
+- **Pipe** (`|`): Producers and intermediate stages stay raw; only a pipeline-safe final stage is rewritten
+- **Stderr pipe** (`|&`): The complete pipeline stays raw
 - **And/Or/Semicolon** (`&&`, `||`, `;`): Both sides rewritten independently
-- **find/fd in pipes**: Never rewritten (output format incompatible with xargs/wc/grep)
+- **Pipeline-safe rules**: Initially limited to argument-safe `grep`, `rg`, and `wc` invocations; search pattern-file forms defer
 
 Example: `cargo fmt --all && cargo test` becomes `rtk cargo fmt --all && rtk cargo test`
 

--- a/src/discover/README.md
+++ b/src/discover/README.md
@@ -21,7 +21,7 @@ When a hook sends `cargo fmt --all && cargo test 2>&1 | tail -20`:
 → [Arg("cargo"), Arg("test"), Redirect("2>&1"), Operator("&&"), Arg("git"), Arg("status")]
 ```
 
-**Compound splitting** — The rewrite engine walks the tokens, splitting on `Operator` (`&&`, `||`, `;`) and `Pipe` (`|`). Each segment is rewritten independently. For pipes, only the left side is rewritten (the pipe consumer like `grep` or `head` runs raw). `find`/`fd` before a pipe is never rewritten because rtk's grouped output format breaks pipe consumers like `xargs`.
+**Compound splitting** — The rewrite engine walks the tokens, splitting on `Operator` (`&&`, `||`, `;`) and typed `Pipe` tokens (`|`, `|&`). For normal pipelines, producers and intermediate stages stay raw, and only an argument-safe final stage marked `pipeline_final_safe` is rewritten. The initial safe set is ordinary `grep`, `rg`, and `wc` invocations; search pattern-file forms (`-f`/`--file`) defer because they can consume pipeline stdin as configuration. Stderr pipelines (`|&`) and pipelines containing opaque shell groups remain raw.
 
 **Per-segment rewriting** — Each segment goes through:
 

--- a/src/discover/lexer.rs
+++ b/src/discover/lexer.rs
@@ -1,6 +1,8 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PipeKind {
+    /// Standard stdout pipeline (`|`).
     Stdout,
+    /// Combined stdout-and-stderr pipeline (`|&`).
     StdoutAndStderr,
 }
 

--- a/src/discover/lexer.rs
+++ b/src/discover/lexer.rs
@@ -1,8 +1,14 @@
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PipeKind {
+    Stdout,
+    StdoutAndStderr,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TokenKind {
     Arg,
     Operator,
-    Pipe,
+    Pipe(PipeKind),
     Redirect,
     Shellism,
 }
@@ -118,9 +124,17 @@ fn tokenize_inner(input: &str, emit_newline: bool) -> Vec<ParsedToken> {
                         value: "||".into(),
                         offset: start,
                     });
+                } else if chars.peek() == Some(&'&') {
+                    chars.next();
+                    byte_pos += 1;
+                    tokens.push(ParsedToken {
+                        kind: TokenKind::Pipe(PipeKind::StdoutAndStderr),
+                        value: "|&".into(),
+                        offset: start,
+                    });
                 } else {
                     tokens.push(ParsedToken {
-                        kind: TokenKind::Pipe,
+                        kind: TokenKind::Pipe(PipeKind::Stdout),
                         value: "|".into(),
                         offset: start,
                     });
@@ -346,7 +360,7 @@ pub fn split_for_permissions(cmd: &str) -> Vec<&str> {
 
     for tok in &tokens {
         let is_boundary = match tok.kind {
-            TokenKind::Operator | TokenKind::Pipe => true,
+            TokenKind::Operator | TokenKind::Pipe(_) => true,
             TokenKind::Shellism => matches!(tok.value.as_str(), "&" | "(" | ")"),
             _ => false,
         };
@@ -398,7 +412,7 @@ pub fn split_on_operators(cmd: &str, stop_at_pipe: bool) -> Vec<&str> {
                 }
                 seg_start = tok.offset + tok.value.len();
             }
-            TokenKind::Pipe => {
+            TokenKind::Pipe(_) => {
                 let segment = trimmed[seg_start..tok.offset].trim();
                 if !segment.is_empty() {
                     results.push(segment);
@@ -643,13 +657,35 @@ mod tests {
     #[test]
     fn test_pipe_detection() {
         let tokens = tokenize("cat file | grep pattern");
-        assert!(tokens.iter().any(|t| t.kind == TokenKind::Pipe));
+        assert!(tokens
+            .iter()
+            .any(|t| t.kind == TokenKind::Pipe(PipeKind::Stdout)));
+    }
+
+    #[test]
+    fn test_stderr_pipe_is_atomic() {
+        let tokens = tokenize("cargo test |& grep FAILED");
+        let pipes: Vec<_> = tokens
+            .iter()
+            .filter(|token| matches!(token.kind, TokenKind::Pipe(_)))
+            .collect();
+
+        assert_eq!(pipes.len(), 1);
+        assert_eq!(pipes[0].kind, TokenKind::Pipe(PipeKind::StdoutAndStderr));
+        assert_eq!(pipes[0].value, "|&");
+        assert!(!tokens
+            .iter()
+            .any(|token| token.kind == TokenKind::Shellism && token.value == "&"));
+        assert_eq!(
+            split_for_permissions("cargo test |& grep FAILED"),
+            vec!["cargo test", "grep FAILED"]
+        );
     }
 
     #[test]
     fn test_quoted_pipe_not_pipe() {
         let tokens = tokenize("\"a|b\"");
-        assert!(!tokens.iter().any(|t| t.kind == TokenKind::Pipe));
+        assert!(!tokens.iter().any(|t| matches!(t.kind, TokenKind::Pipe(_))));
     }
 
     #[test]
@@ -657,7 +693,7 @@ mod tests {
         let tokens = tokenize("a | b | c");
         let pipes: Vec<_> = tokens
             .iter()
-            .filter(|t| t.kind == TokenKind::Pipe)
+            .filter(|t| matches!(t.kind, TokenKind::Pipe(_)))
             .collect();
         assert_eq!(pipes.len(), 2);
     }
@@ -896,7 +932,7 @@ mod tests {
         assert!(tokens
             .iter()
             .any(|t| t.kind == TokenKind::Redirect && t.value == "2>&1"));
-        assert!(tokens.iter().any(|t| t.kind == TokenKind::Pipe));
+        assert!(tokens.iter().any(|t| matches!(t.kind, TokenKind::Pipe(_))));
     }
 
     #[test]
@@ -997,7 +1033,7 @@ mod tests {
         let tokens = tokenize("find . -name '*.rs' | xargs grep 'fn run'");
         let pipe_idx = tokens
             .iter()
-            .position(|t| t.kind == TokenKind::Pipe)
+            .position(|t| matches!(t.kind, TokenKind::Pipe(_)))
             .unwrap();
         assert!(pipe_idx > 0);
         let before_pipe: Vec<_> = tokens[..pipe_idx]

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -635,7 +635,7 @@ fn rewrite_compound(
                     seg_start += 1;
                 }
             }
-            TokenKind::Pipe => {
+            TokenKind::Pipe(_) => {
                 let seg = cmd[seg_start..tok.offset].trim();
                 let is_pipe_incompatible = seg.starts_with("find ")
                     || seg == "find"

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -5,7 +5,7 @@ use lazy_static::lazy_static;
 use regex::{Regex, RegexSet};
 use std::path::Path;
 
-use super::lexer::{split_on_operators, tokenize, TokenKind};
+use super::lexer::{shell_split, split_on_operators, tokenize, ParsedToken, PipeKind, TokenKind};
 use super::rules::{IGNORED_EXACT, IGNORED_PREFIXES, RULES};
 
 const PHP_TOOL_NAMES: [&str; 6] = ["phpunit", "phpstan", "ecs", "pest", "paratest", "pint"];
@@ -541,8 +541,8 @@ fn collapse_line_continuations(s: &str) -> std::borrow::Cow<'_, str> {
 /// Returns `None` if the command is unsupported or ignored (hook should pass through).
 ///
 /// Handles compound commands (`&&`, `||`, `;`) by rewriting each segment independently.
-/// For pipes (`|`), only rewrites the left-hand command (pipe targets stay raw),
-/// but continues rewriting segments after subsequent `&&`/`||`/`;` operators.
+/// For pipelines, preserves intermediate stages and only rewrites a pipeline-safe final stage,
+/// then continues rewriting segments after subsequent `&&`/`||`/`;` operators.
 /// Also strips user-configured transparent wrapper prefixes
 /// (`[hooks].transparent_prefixes` in `config.toml`) before routing.
 ///
@@ -595,6 +595,95 @@ pub fn rewrite_command(
     rewrite_compound(trimmed, &compiled, &normalized_prefixes)
 }
 
+/// Pipeline boundaries used to rewrite its final stage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PipelineAnalysis {
+    end_offset: usize,
+    next_clause_offset: Option<usize>,
+    final_stage_start: Option<usize>,
+}
+
+fn analyze_pipeline(
+    cmd: &str,
+    tokens: &[ParsedToken],
+    segment_start: usize,
+    first_pipe_offset: usize,
+) -> PipelineAnalysis {
+    let next_clause_offset = tokens
+        .iter()
+        .find(|token| {
+            token.offset > first_pipe_offset
+                && (token.kind == TokenKind::Operator
+                    || (token.kind == TokenKind::Shellism && token.value == "&"))
+        })
+        .map(|token| token.offset);
+    let end_offset = next_clause_offset.unwrap_or(cmd.len());
+
+    let mut stage_start = segment_start;
+    let mut final_stage_start = None;
+    let mut has_supported_structure = true;
+
+    for token in tokens {
+        if token.offset >= end_offset {
+            break;
+        }
+        if token.offset < first_pipe_offset {
+            continue;
+        }
+        let TokenKind::Pipe(kind) = token.kind else {
+            continue;
+        };
+
+        if cmd[stage_start..token.offset].trim().is_empty() || kind == PipeKind::StdoutAndStderr {
+            has_supported_structure = false;
+        }
+
+        stage_start = token.offset + token.value.len();
+        final_stage_start = Some(stage_start);
+    }
+
+    if cmd[stage_start..end_offset].trim().is_empty() {
+        has_supported_structure = false;
+    }
+
+    PipelineAnalysis {
+        end_offset,
+        next_clause_offset,
+        final_stage_start: if has_supported_structure {
+            final_stage_start
+        } else {
+            None
+        },
+    }
+}
+
+fn rewrite_pipeline_final_stage(
+    cmd: &str,
+    segment_start: usize,
+    analysis: PipelineAnalysis,
+    excluded: &[ExcludePattern],
+    transparent_prefixes: &[String],
+) -> Option<String> {
+    let final_stage_start = analysis.final_stage_start?;
+    let final_stage = cmd[final_stage_start..analysis.end_offset].trim();
+
+    rewrite_segment_inner(
+        final_stage,
+        excluded,
+        transparent_prefixes,
+        RewriteContext::PipelineFinal,
+        0,
+    )
+    .filter(|rewritten| rewritten != final_stage)
+    .map(|rewritten| {
+        format!(
+            "{} {}",
+            cmd[segment_start..final_stage_start].trim(),
+            rewritten
+        )
+    })
+}
+
 /// Rewrite a compound command (with `&&`, `||`, `;`, `|`) by rewriting each segment.
 fn rewrite_compound(
     cmd: &str,
@@ -602,6 +691,16 @@ fn rewrite_compound(
     transparent_prefixes: &[String],
 ) -> Option<String> {
     let tokens = tokenize(cmd);
+    let has_pipe = tokens
+        .iter()
+        .any(|token| matches!(token.kind, TokenKind::Pipe(_)));
+    let has_opaque_grouping = tokens.iter().any(|token| {
+        token.kind == TokenKind::Shellism && matches!(token.value.as_str(), "(" | ")" | "{" | "}")
+    });
+    if has_pipe && has_opaque_grouping {
+        return None;
+    }
+
     let mut result = String::with_capacity(cmd.len() + 32);
     let mut any_changed = false;
     let mut seg_start: usize = 0;
@@ -636,37 +735,29 @@ fn rewrite_compound(
                 }
             }
             TokenKind::Pipe(_) => {
-                let seg = cmd[seg_start..tok.offset].trim();
-                let is_pipe_incompatible = seg.starts_with("find ")
-                    || seg == "find"
-                    || seg.starts_with("fd ")
-                    || seg == "fd";
-                let rewritten = if is_pipe_incompatible {
-                    seg.to_string()
-                } else {
-                    rewrite_segment(seg, excluded, transparent_prefixes)
-                        .unwrap_or_else(|| seg.to_string())
-                };
-                if rewritten != seg {
+                let analysis = analyze_pipeline(cmd, &tokens, seg_start, tok.offset);
+                let pipeline = cmd[seg_start..analysis.end_offset].trim();
+                let rewritten_pipeline = rewrite_pipeline_final_stage(
+                    cmd,
+                    seg_start,
+                    analysis,
+                    excluded,
+                    transparent_prefixes,
+                );
+
+                if let Some(rewritten) = rewritten_pipeline {
                     any_changed = true;
+                    result.push_str(&rewritten);
+                } else {
+                    result.push_str(pipeline);
                 }
-                result.push_str(&rewritten);
 
-                let pipe_group_end = tokens.iter().find(|t| {
-                    t.offset > tok.offset
-                        && (t.kind == TokenKind::Operator
-                            || (t.kind == TokenKind::Shellism && t.value == "&"))
-                });
-
-                match pipe_group_end {
-                    Some(next_op) => {
-                        result.push(' ');
-                        result.push_str(cmd[tok.offset..next_op.offset].trim());
-                        seg_start = next_op.offset;
+                match analysis.next_clause_offset {
+                    Some(next_clause_offset) => {
+                        seg_start = next_clause_offset;
+                        continue;
                     }
                     None => {
-                        result.push(' ');
-                        result.push_str(cmd[tok.offset..].trim_start());
                         return if any_changed { Some(result) } else { None };
                     }
                 }
@@ -737,6 +828,32 @@ const BUILTIN_TRANSPARENT_PREFIXES: &[&str] =
 
 const MAX_PREFIX_DEPTH: usize = 10;
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RewriteContext {
+    Normal,
+    PipelineFinal,
+}
+
+/// Checks whether grep or rg reads patterns from a file.
+fn search_uses_pattern_file(cmd: &str) -> bool {
+    shell_split(cmd)
+        .into_iter()
+        .skip(1)
+        .take_while(|arg| arg != "--")
+        .any(|arg| {
+            arg == "--file"
+                || arg.starts_with("--file=")
+                || arg
+                    .strip_prefix('-')
+                    .filter(|flags| !flags.starts_with('-'))
+                    .is_some_and(|flags| flags.contains('f'))
+        })
+}
+
+fn pipeline_final_command_is_safe(rtk_cmd: &str, cmd: &str) -> bool {
+    !matches!(rtk_cmd, "rtk grep" | "rtk rg") || !search_uses_pattern_file(cmd)
+}
+
 enum ExcludePattern {
     Regex(Regex),
     Prefix(String),
@@ -792,7 +909,13 @@ fn rewrite_segment(
     excluded: &[ExcludePattern],
     transparent_prefixes: &[String],
 ) -> Option<String> {
-    rewrite_segment_inner(seg, excluded, transparent_prefixes, 0)
+    rewrite_segment_inner(
+        seg,
+        excluded,
+        transparent_prefixes,
+        RewriteContext::Normal,
+        0,
+    )
 }
 
 fn is_excluded(cmd: &str, excluded: &[ExcludePattern]) -> bool {
@@ -806,6 +929,7 @@ fn rewrite_segment_inner(
     seg: &str,
     excluded: &[ExcludePattern],
     transparent_prefixes: &[String],
+    context: RewriteContext,
     depth: usize,
 ) -> Option<String> {
     let trimmed = seg.trim();
@@ -828,8 +952,13 @@ fn rewrite_segment_inner(
             );
             return None;
         }
-        let rewritten =
-            rewrite_segment_inner(rest_after_env, excluded, transparent_prefixes, depth + 1)?;
+        let rewritten = rewrite_segment_inner(
+            rest_after_env,
+            excluded,
+            transparent_prefixes,
+            context,
+            depth + 1,
+        )?;
         return Some(format!("{}{}", env_prefix, rewritten));
     }
 
@@ -838,7 +967,7 @@ fn rewrite_segment_inner(
             if rest.is_empty() {
                 return None;
             }
-            return rewrite_segment_inner(rest, excluded, transparent_prefixes, depth + 1)
+            return rewrite_segment_inner(rest, excluded, transparent_prefixes, context, depth + 1)
                 .map(|rewritten| format!("{} {}", prefix, rewritten));
         }
     }
@@ -850,7 +979,7 @@ fn rewrite_segment_inner(
             if rest.is_empty() {
                 return None;
             }
-            return rewrite_segment_inner(rest, excluded, transparent_prefixes, depth + 1)
+            return rewrite_segment_inner(rest, excluded, transparent_prefixes, context, depth + 1)
                 .map(|rewritten| format!("{} {}", prefix, rewritten));
         }
     }
@@ -864,7 +993,9 @@ fn rewrite_segment_inner(
         return Some(trimmed.to_string());
     }
 
-    if cmd_part.starts_with("head -") || cmd_part.starts_with("tail ") {
+    if context == RewriteContext::Normal
+        && (cmd_part.starts_with("head -") || cmd_part.starts_with("tail "))
+    {
         return rewrite_line_range(cmd_part).map(|r| format!("{}{}", r, redirect_suffix));
     }
 
@@ -890,6 +1021,9 @@ fn rewrite_segment_inner(
         }
         // TOML-only commands: consult the registry so the hook filters them too (#2179).
         Classification::Unsupported { .. } => {
+            if context == RewriteContext::PipelineFinal {
+                return None;
+            }
             if crate::core::toml_filter::toml_disabled() {
                 return None;
             }
@@ -911,6 +1045,11 @@ fn rewrite_segment_inner(
 
     // Find the matching rule (rtk_cmd values are unique across all rules)
     let rule = RULES.iter().find(|r| r.rtk_cmd == rtk_equivalent)?;
+    if context == RewriteContext::PipelineFinal
+        && (!rule.pipeline_final_safe || !pipeline_final_command_is_safe(rule.rtk_cmd, cmd_part))
+    {
+        return None;
+    }
 
     if let Some(parts) = parse_golangci_run_parts(cmd_part) {
         let rewritten = if parts.global_segment.is_empty() {
@@ -994,6 +1133,86 @@ mod tests {
 
     fn rewrite_command_no_prefixes(cmd: &str, excluded: &[String]) -> Option<String> {
         super::rewrite_command(cmd, excluded, &[])
+    }
+
+    fn analyze_test_pipeline(cmd: &str) -> PipelineAnalysis {
+        let tokens = tokenize(cmd);
+        let first_pipe_offset = tokens
+            .iter()
+            .find(|token| matches!(token.kind, TokenKind::Pipe(_)))
+            .expect("test command must contain a pipe")
+            .offset;
+
+        analyze_pipeline(cmd, &tokens, 0, first_pipe_offset)
+    }
+
+    #[test]
+    fn test_analyze_pipeline_finds_final_stage() {
+        let cmd = "git log | grep feat | wc -l";
+        let analysis = analyze_test_pipeline(cmd);
+
+        assert_eq!(analysis.end_offset, cmd.len());
+        assert_eq!(analysis.next_clause_offset, None);
+        assert_eq!(
+            cmd[analysis.final_stage_start.unwrap()..analysis.end_offset].trim(),
+            "wc -l"
+        );
+    }
+
+    #[test]
+    fn test_analyze_pipeline_rejects_stderr_pipe() {
+        let analysis = analyze_test_pipeline("cargo test |& grep FAILED");
+
+        assert_eq!(analysis.final_stage_start, None);
+    }
+
+    #[test]
+    fn test_analyze_pipeline_rejects_empty_stage() {
+        let analysis = analyze_test_pipeline("cargo test | | grep FAILED");
+
+        assert_eq!(analysis.final_stage_start, None);
+    }
+
+    #[test]
+    fn test_analyze_pipeline_stops_at_next_clause() {
+        let cmd = "cargo test | grep FAILED && git status";
+        let analysis = analyze_test_pipeline(cmd);
+        let next_clause_offset = cmd.find("&&").unwrap();
+
+        assert_eq!(analysis.end_offset, next_clause_offset);
+        assert_eq!(analysis.next_clause_offset, Some(next_clause_offset));
+        assert_eq!(
+            cmd[analysis.final_stage_start.unwrap()..analysis.end_offset].trim(),
+            "grep FAILED"
+        );
+    }
+
+    #[test]
+    fn test_pipeline_final_safe_rule_set() {
+        let safe_rules: Vec<_> = RULES
+            .iter()
+            .filter(|rule| rule.pipeline_final_safe)
+            .map(|rule| rule.rtk_cmd)
+            .collect();
+
+        assert_eq!(safe_rules, vec!["rtk grep", "rtk rg", "rtk wc"]);
+    }
+
+    #[test]
+    fn test_pipeline_final_search_pattern_file_is_unsafe() {
+        for command in [
+            "grep -f patterns.txt input.txt",
+            "grep -rfpatterns.txt input",
+            "grep --file patterns.txt input.txt",
+            "grep --file=patterns.txt input.txt",
+            "rg -f patterns.txt input.txt",
+            "rg --file=patterns.txt input.txt",
+        ] {
+            assert!(search_uses_pattern_file(command), "{command}");
+        }
+
+        assert!(!search_uses_pattern_file("grep -- -f"));
+        assert!(!search_uses_pattern_file("grep -F pattern"));
     }
 
     #[test]
@@ -1514,10 +1733,10 @@ mod tests {
     }
 
     #[test]
-    fn test_rewrite_toml_in_pipe_left_only() {
+    fn test_rewrite_toml_pipe_rewrites_only_safe_final() {
         assert_eq!(
-            rewrite_command_no_prefixes("jj log | head", &[]),
-            Some("rtk jj log | head".into())
+            rewrite_command_no_prefixes("jj log | grep change", &[]),
+            Some("jj log | rtk grep change".into())
         );
     }
 
@@ -1692,11 +1911,10 @@ mod tests {
     }
 
     #[test]
-    fn test_rewrite_pipe_first_only() {
-        // After a pipe, the filter command stays raw
+    fn test_rewrite_pipe_final_safe_stage_only() {
         assert_eq!(
             rewrite_command_no_prefixes("git log -10 | grep feat", &[]),
-            Some("rtk git log -10 | grep feat".into())
+            Some("git log -10 | rtk grep feat".into())
         );
     }
 
@@ -1711,9 +1929,53 @@ mod tests {
     }
 
     #[test]
-    fn test_rewrite_find_pipe_xargs_wc() {
+    fn test_rewrite_find_pipe_wc_rewrites_only_wc() {
         assert_eq!(
             rewrite_command_no_prefixes("find src -type f | wc -l", &[]),
+            Some("find src -type f | rtk wc -l".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_multi_pipe_final_safe_stage_only() {
+        assert_eq!(
+            rewrite_command_no_prefixes("git log | grep feat | wc -l", &[]),
+            Some("git log | grep feat | rtk wc -l".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_pipe_unsafe_final_stage_stays_raw() {
+        assert_eq!(
+            rewrite_command_no_prefixes("cargo test | tail -50", &[]),
+            None
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("find . | xargs grep TODO", &[]),
+            None
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes(
+                "printf 'src/main.rs\\n' | grep -f /dev/null src/main.rs",
+                &[]
+            ),
+            None
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes(
+                "printf 'src/main.rs\\n' | rg --file=/dev/null src/main.rs",
+                &[]
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn test_rewrite_malformed_pipeline_stays_raw() {
+        assert_eq!(rewrite_command_no_prefixes("| grep FAILED", &[]), None);
+        assert_eq!(rewrite_command_no_prefixes("cargo test |", &[]), None);
+        assert_eq!(
+            rewrite_command_no_prefixes("cargo test | | grep FAILED", &[]),
             None
         );
     }
@@ -1884,8 +2146,8 @@ mod tests {
     #[test]
     fn test_rewrite_redirect_2_gt_amp_1_with_pipe() {
         assert_eq!(
-            rewrite_command_no_prefixes("cargo test 2>&1 | head", &[]),
-            Some("rtk cargo test 2>&1 | head".into())
+            rewrite_command_no_prefixes("cargo test 2>&1 | grep FAILED", &[]),
+            Some("cargo test 2>&1 | rtk grep FAILED".into())
         );
     }
 
@@ -3549,10 +3811,10 @@ mod tests {
 
     #[test]
     fn test_rewrite_compound_pipe_raw_filter() {
-        // Pipe: rewrite first segment only, pass through rest unchanged
+        // Producers stay raw; only a pipeline-safe final stage is rewritten.
         assert_eq!(
             rewrite_command_no_prefixes("cargo test | grep FAILED", &[]),
-            Some("rtk cargo test | grep FAILED".into())
+            Some("cargo test | rtk grep FAILED".into())
         );
     }
 
@@ -3560,7 +3822,7 @@ mod tests {
     fn test_rewrite_compound_pipe_git_grep() {
         assert_eq!(
             rewrite_command_no_prefixes("git log -10 | grep feat", &[]),
-            Some("rtk git log -10 | grep feat".into())
+            Some("git log -10 | rtk grep feat".into())
         );
     }
 
@@ -4294,7 +4556,7 @@ mod tests {
     fn test_rewrite_pipe_then_and() {
         assert_eq!(
             rewrite_command_no_prefixes("git log | head -5 && git stash", &[]),
-            Some("rtk git log | head -5 && rtk git stash".into())
+            Some("git log | head -5 && rtk git stash".into())
         );
     }
 
@@ -4302,7 +4564,7 @@ mod tests {
     fn test_rewrite_pipe_then_semicolon() {
         assert_eq!(
             rewrite_command_no_prefixes("cargo test | head; git status", &[]),
-            Some("rtk cargo test | head; rtk git status".into())
+            Some("cargo test | head; rtk git status".into())
         );
     }
 
@@ -4310,7 +4572,7 @@ mod tests {
     fn test_rewrite_pipe_then_or() {
         assert_eq!(
             rewrite_command_no_prefixes("cargo test | grep FAIL || git stash", &[]),
-            Some("rtk cargo test | grep FAIL || rtk git stash".into())
+            Some("cargo test | rtk grep FAIL || rtk git stash".into())
         );
     }
 
@@ -4321,7 +4583,7 @@ mod tests {
                 "RUST_BACKTRACE=1 cargo test 2>&1 | grep FAILED && git stash",
                 &[]
             ),
-            Some("RUST_BACKTRACE=1 rtk cargo test 2>&1 | grep FAILED && rtk git stash".into())
+            Some("RUST_BACKTRACE=1 cargo test 2>&1 | rtk grep FAILED && rtk git stash".into())
         );
     }
 
@@ -4329,7 +4591,7 @@ mod tests {
     fn test_rewrite_and_then_pipe() {
         assert_eq!(
             rewrite_command_no_prefixes("git status && cargo test | grep FAIL", &[]),
-            Some("rtk git status && rtk cargo test | grep FAIL".into())
+            Some("rtk git status && cargo test | rtk grep FAIL".into())
         );
     }
 
@@ -4337,7 +4599,47 @@ mod tests {
     fn test_rewrite_multi_pipe_then_and() {
         assert_eq!(
             rewrite_command_no_prefixes("git log | head | tail && git status", &[]),
-            Some("rtk git log | head | tail && rtk git status".into())
+            Some("git log | head | tail && rtk git status".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_pipeline_final_normalizes_prefixes() {
+        assert_eq!(
+            rewrite_command_no_prefixes("cargo test | FOO=1 command grep FAILED", &[]),
+            Some("cargo test | FOO=1 command rtk grep FAILED".into())
+        );
+        assert_eq!(
+            super::rewrite_command(
+                "cargo test | docker exec tools grep FAILED",
+                &[],
+                &["docker exec tools".into()]
+            ),
+            Some("cargo test | docker exec tools rtk grep FAILED".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_opaque_grouped_pipeline_stays_raw() {
+        assert_eq!(
+            rewrite_command_no_prefixes("echo x | { cat; git log; } | grep feat", &[]),
+            None
+        );
+    }
+
+    #[test]
+    fn test_rewrite_stderr_pipe_stays_raw() {
+        assert_eq!(
+            rewrite_command_no_prefixes("cargo test |& grep FAILED", &[]),
+            None
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("cargo test | grep FAILED |& wc -l", &[]),
+            None
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("cargo test |& grep FAILED && git status", &[]),
+            Some("cargo test |& grep FAILED && rtk git status".into())
         );
     }
 

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -3,6 +3,9 @@ use super::report::RtkStatus;
 pub struct RtkRule {
     pub pattern: &'static str,
     pub rtk_cmd: &'static str,
+    /// The wrapper can preserve stdin and exit-code semantics as a final pipeline stage.
+    /// Command-specific argument checks may further restrict eligibility.
+    pub pipeline_final_safe: bool,
     pub rewrite_prefixes: &'static [&'static str],
     pub category: &'static str,
     pub savings_pct: f64,
@@ -14,6 +17,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|checkout|push|pull|branch|fetch|stash|worktree)",
         rtk_cmd: "rtk git",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["git", "yadm"],
         category: "Git",
         savings_pct: 70.0,
@@ -28,6 +32,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^gh\s+(pr|issue|run|repo|api|release)",
         rtk_cmd: "rtk gh",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["gh"],
         category: "GitHub",
         savings_pct: 82.0,
@@ -37,6 +42,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^glab\s+(mr|issue|ci|pipeline|api|release)",
         rtk_cmd: "rtk glab",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["glab"],
         category: "GitLab",
         savings_pct: 82.0,
@@ -46,6 +52,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^cargo\s+(build|test|clippy|check|fmt|install)",
         rtk_cmd: "rtk cargo",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["cargo"],
         category: "Cargo",
         savings_pct: 80.0,
@@ -55,6 +62,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^pnpm\s+(exec|i|install|list|ls|outdated|run|run-script)",
         rtk_cmd: "rtk pnpm",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["pnpm"],
         category: "PackageManager",
         savings_pct: 80.0,
@@ -64,6 +72,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^npm\s+(exec|run|run-script|rum|urn|x)(\s|$)",
         rtk_cmd: "rtk npm",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["npm"],
         category: "PackageManager",
         savings_pct: 70.0,
@@ -73,6 +82,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^npx\s+",
         rtk_cmd: "rtk npx",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["npx"],
         category: "PackageManager",
         savings_pct: 70.0,
@@ -82,6 +92,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^(cat|head|tail)\s+",
         rtk_cmd: "rtk read",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["cat", "head", "tail"],
         category: "Files",
         savings_pct: 60.0,
@@ -91,6 +102,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^grep\s+",
         rtk_cmd: "rtk grep",
+        pipeline_final_safe: true,
         rewrite_prefixes: &["grep"],
         category: "Files",
         savings_pct: 75.0,
@@ -100,6 +112,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^rg\s+",
         rtk_cmd: "rtk rg",
+        pipeline_final_safe: true,
         rewrite_prefixes: &["rg"],
         category: "Files",
         savings_pct: 75.0,
@@ -109,6 +122,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^ls(\s|$)",
         rtk_cmd: "rtk ls",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["ls"],
         category: "Files",
         savings_pct: 65.0,
@@ -118,6 +132,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^find\s+",
         rtk_cmd: "rtk find",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["find"],
         category: "Files",
         savings_pct: 70.0,
@@ -127,6 +142,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?tsc(\s|$)",
         rtk_cmd: "rtk tsc",
+        pipeline_final_safe: false,
         rewrite_prefixes: &[
             "npm exec tsc",
             "npm rum tsc",
@@ -152,6 +168,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?(biome|eslint|lint)(\s|$)",
         rtk_cmd: "rtk lint",
+        pipeline_final_safe: false,
         rewrite_prefixes: &[
             "biome",
             "eslint",
@@ -203,6 +220,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?prettier",
         rtk_cmd: "rtk prettier",
+        pipeline_final_safe: false,
         rewrite_prefixes: &[
             "npm exec prettier",
             "npm prettier",
@@ -228,6 +246,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?next\s+build",
         rtk_cmd: "rtk next",
+        pipeline_final_safe: false,
         rewrite_prefixes: &[
             "next build",
             "npm exec next build",
@@ -253,6 +272,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?jest(\s+run)?(\s|$)",
         rtk_cmd: "rtk jest",
+        pipeline_final_safe: false,
         rewrite_prefixes: &[
             "jest run",
             "jest",
@@ -293,6 +313,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?vitest(\s+run)?(\s|$)",
         rtk_cmd: "rtk vitest",
+        pipeline_final_safe: false,
         rewrite_prefixes: &[
             "npm exec vitest run",
             "npm exec vitest",
@@ -333,6 +354,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?playwright",
         rtk_cmd: "rtk playwright",
+        pipeline_final_safe: false,
         rewrite_prefixes: &[
             "npm exec playwright",
             "npm playwright",
@@ -358,6 +380,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?prisma",
         rtk_cmd: "rtk prisma",
+        pipeline_final_safe: false,
         rewrite_prefixes: &[
             "npm exec prisma",
             "npm prisma",
@@ -383,6 +406,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^docker\s+(ps|images|logs|run|exec|build|compose\s+(ps|logs|build))",
         rtk_cmd: "rtk docker",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["docker"],
         category: "Infra",
         savings_pct: 85.0,
@@ -392,6 +416,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^kubectl\s+(get|logs|describe|apply)",
         rtk_cmd: "rtk kubectl",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["kubectl"],
         category: "Infra",
         savings_pct: 85.0,
@@ -401,6 +426,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^oc\s+(get|logs|describe|apply|status|adm)",
         rtk_cmd: "rtk oc",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["oc"],
         category: "Infra",
         savings_pct: 85.0,
@@ -410,6 +436,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^tree(\s|$)",
         rtk_cmd: "rtk tree",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["tree"],
         category: "Files",
         savings_pct: 70.0,
@@ -419,6 +446,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^diff\s+",
         rtk_cmd: "rtk diff",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["diff"],
         category: "Files",
         savings_pct: 60.0,
@@ -428,6 +456,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^curl\s+",
         rtk_cmd: "rtk curl",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["curl"],
         category: "Network",
         savings_pct: 70.0,
@@ -437,6 +466,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^wget\s+",
         rtk_cmd: "rtk wget",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["wget"],
         category: "Network",
         savings_pct: 65.0,
@@ -446,6 +476,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^(python3?\s+-m\s+)?mypy(\s|$)",
         rtk_cmd: "rtk mypy",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["python3 -m mypy", "python -m mypy", "mypy"],
         category: "Build",
         savings_pct: 80.0,
@@ -455,6 +486,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^ruff\s+(check|format)",
         rtk_cmd: "rtk ruff",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["ruff"],
         category: "Python",
         savings_pct: 80.0,
@@ -464,6 +496,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^(python[0-9.]*\s+-m\s+)?pytest(\s|$)",
         rtk_cmd: "rtk pytest",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["python3 -m pytest", "python -m pytest", "pytest"],
         category: "Python",
         savings_pct: 90.0,
@@ -473,6 +506,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^(pip3?|uv\s+pip)\s+(list|outdated|install|show)",
         rtk_cmd: "rtk pip",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["pip3", "pip", "uv pip"],
         category: "Python",
         savings_pct: 75.0,
@@ -482,6 +516,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^uv\s+run(?:\s|$)",
         rtk_cmd: "rtk uv",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["uv"],
         category: "Python",
         savings_pct: 70.0,
@@ -491,6 +526,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^go\s+(test|build|vet)",
         rtk_cmd: "rtk go",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["go"],
         category: "Go",
         savings_pct: 85.0,
@@ -500,6 +536,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^(?:golangci-lint|golangci)\s+(run)(?:\s|$)",
         rtk_cmd: "rtk golangci-lint run",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["golangci-lint run", "golangci run"],
         category: "Go",
         savings_pct: 85.0,
@@ -509,6 +546,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^bundle\s+(install|update)\b",
         rtk_cmd: "rtk bundle",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["bundle"],
         category: "Ruby",
         savings_pct: 70.0,
@@ -518,6 +556,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^(?:bundle\s+exec\s+)?(?:bin/)?(?:rake|rails)\s+test",
         rtk_cmd: "rtk rake",
+        pipeline_final_safe: false,
         rewrite_prefixes: &[
             "bundle exec rails",
             "bundle exec rake",
@@ -533,6 +572,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^(?:bundle\s+exec\s+)?rspec(?:\s|$)",
         rtk_cmd: "rtk rspec",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["bundle exec rspec", "bin/rspec", "rspec"],
         category: "Tests",
         savings_pct: 65.0,
@@ -542,6 +582,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^(?:bundle\s+exec\s+)?rubocop(?:\s|$)",
         rtk_cmd: "rtk rubocop",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["bundle exec rubocop", "rubocop"],
         category: "Build",
         savings_pct: 65.0,
@@ -552,6 +593,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^php\s+artisan(?:\s|$)",
         rtk_cmd: "rtk php",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["php"],
         category: "Build",
         savings_pct: 70.0,
@@ -561,6 +603,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^php\s+-l(?:\s|$)",
         rtk_cmd: "rtk php",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["php"],
         category: "Build",
         savings_pct: 60.0,
@@ -570,6 +613,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^(?:php\s+)?(?:\./)?(?:(?:vendor/)?bin/)?phpunit(?:\s|$)",
         rtk_cmd: "rtk phpunit",
+        pipeline_final_safe: false,
         // rewrite_segment_inner normalizes the php wrapper, `./`, vendor/bin and
         // composer bin-dir before matching, so only the residual forms remain:
         // a plain `bin/` (not a Composer dir, so it survives normalization) and
@@ -583,6 +627,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^(?:php\s+)?(?:\./)?(?:(?:vendor/)?bin/)?phpstan\s+analy[sz]e\b",
         rtk_cmd: "rtk phpstan",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["bin/phpstan", "phpstan"],
         category: "Build",
         savings_pct: 65.0,
@@ -592,6 +637,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^(?:\./)?(?:vendor/bin/)?pest(?:\s|$)",
         rtk_cmd: "rtk pest",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["pest"],
         category: "Tests",
         savings_pct: 80.0,
@@ -601,6 +647,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^(?:\./)?(?:vendor/bin/)?paratest(?:\s|$)",
         rtk_cmd: "rtk paratest",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["paratest"],
         category: "Tests",
         savings_pct: 80.0,
@@ -610,6 +657,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^(?:\./)?(?:vendor/bin/)?ecs(?:\s|$)",
         rtk_cmd: "rtk ecs",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["ecs"],
         category: "Build",
         savings_pct: 70.0,
@@ -619,6 +667,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^(?:\./)?(?:vendor/bin/)?pint(?:\s|$)",
         rtk_cmd: "rtk pint",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["pint"],
         category: "Build",
         savings_pct: 70.0,
@@ -628,6 +677,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^aws\s+",
         rtk_cmd: "rtk aws",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["aws"],
         category: "Infra",
         savings_pct: 80.0,
@@ -652,6 +702,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^psql(\s|$)",
         rtk_cmd: "rtk psql",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["psql"],
         category: "Infra",
         savings_pct: 75.0,
@@ -661,6 +712,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^ansible-playbook\b",
         rtk_cmd: "rtk ansible-playbook",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["ansible-playbook"],
         category: "Infra",
         savings_pct: 70.0,
@@ -670,6 +722,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^brew\s+(install|upgrade)\b",
         rtk_cmd: "rtk brew",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["brew"],
         category: "PackageManager",
         savings_pct: 65.0,
@@ -679,6 +732,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^composer\s+(install|update|require)\b",
         rtk_cmd: "rtk composer",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["composer"],
         category: "PackageManager",
         savings_pct: 65.0,
@@ -688,6 +742,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^df(\s|$)",
         rtk_cmd: "rtk df",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["df"],
         category: "System",
         savings_pct: 60.0,
@@ -697,6 +752,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^dotnet\s+build\b",
         rtk_cmd: "rtk dotnet",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["dotnet"],
         category: "Build",
         savings_pct: 70.0,
@@ -706,6 +762,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^du\b",
         rtk_cmd: "rtk du",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["du"],
         category: "System",
         savings_pct: 60.0,
@@ -715,6 +772,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^fail2ban-client\b",
         rtk_cmd: "rtk fail2ban-client",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["fail2ban-client"],
         category: "Infra",
         savings_pct: 60.0,
@@ -724,6 +782,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^gcloud\b",
         rtk_cmd: "rtk gcloud",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["gcloud"],
         category: "Infra",
         savings_pct: 65.0,
@@ -733,6 +792,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^(?:\./gradlew|gradlew\.bat|gradlew|gradle)(?:\s+(test|build|clean|assemble\w*|install\w*|check|lint\w*|dependencies))?(\s|$)",
         rtk_cmd: "rtk gradlew",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["./gradlew", "gradlew.bat", "gradlew", "gradle"],
         category: "Build",
         savings_pct: 75.0,
@@ -742,6 +802,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^hadolint\b",
         rtk_cmd: "rtk hadolint",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["hadolint"],
         category: "Build",
         savings_pct: 65.0,
@@ -751,6 +812,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^helm\b",
         rtk_cmd: "rtk helm",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["helm"],
         category: "Infra",
         savings_pct: 65.0,
@@ -760,6 +822,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^iptables\b",
         rtk_cmd: "rtk iptables",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["iptables"],
         category: "Infra",
         savings_pct: 60.0,
@@ -769,6 +832,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^make\b",
         rtk_cmd: "rtk make",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["make"],
         category: "Build",
         savings_pct: 65.0,
@@ -778,6 +842,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^markdownlint\b",
         rtk_cmd: "rtk markdownlint",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["markdownlint"],
         category: "Build",
         savings_pct: 65.0,
@@ -787,6 +852,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^mix\s+(compile|format)(\s|$)",
         rtk_cmd: "rtk mix",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["mix"],
         category: "Build",
         savings_pct: 65.0,
@@ -796,6 +862,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^(?:\./mvnw|mvnw\.cmd|mvnw|mvn)\b(?:\s+\S+)*?\s+(compile|test|integration-test|package|install|verify|deploy)\b",
         rtk_cmd: "rtk mvn",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["./mvnw", "mvnw.cmd", "mvnw", "mvn"],
         category: "Build",
         savings_pct: 82.0,
@@ -805,6 +872,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^ping\b",
         rtk_cmd: "rtk ping",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["ping"],
         category: "Network",
         savings_pct: 60.0,
@@ -814,6 +882,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^pio\s+run",
         rtk_cmd: "rtk pio",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["pio"],
         category: "Build",
         savings_pct: 65.0,
@@ -823,6 +892,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^poetry\s+(install|lock|update)\b",
         rtk_cmd: "rtk poetry",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["poetry"],
         category: "Python",
         savings_pct: 65.0,
@@ -832,6 +902,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^pre-commit\b",
         rtk_cmd: "rtk pre-commit",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["pre-commit"],
         category: "Build",
         savings_pct: 65.0,
@@ -841,6 +912,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^ps(\s|$)",
         rtk_cmd: "rtk ps",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["ps"],
         category: "System",
         savings_pct: 60.0,
@@ -850,6 +922,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^pulumi\s+(preview|up|destroy|refresh|stack)(\s|$)",
         rtk_cmd: "rtk pulumi",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["pulumi"],
         category: "Infra",
         savings_pct: 45.0,
@@ -865,6 +938,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^quarto\s+render",
         rtk_cmd: "rtk quarto",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["quarto"],
         category: "Build",
         savings_pct: 65.0,
@@ -874,6 +948,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^rsync\b",
         rtk_cmd: "rtk rsync",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["rsync"],
         category: "Network",
         savings_pct: 65.0,
@@ -883,6 +958,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^shellcheck\b",
         rtk_cmd: "rtk shellcheck",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["shellcheck"],
         category: "Build",
         savings_pct: 65.0,
@@ -892,6 +968,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^shopify\s+theme\s+(push|pull)",
         rtk_cmd: "rtk shopify",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["shopify"],
         category: "Build",
         savings_pct: 65.0,
@@ -901,6 +978,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^sops\b",
         rtk_cmd: "rtk sops",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["sops"],
         category: "Infra",
         savings_pct: 60.0,
@@ -910,6 +988,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^swift\s+(build|test)\b",
         rtk_cmd: "rtk swift",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["swift"],
         category: "Build",
         savings_pct: 65.0,
@@ -919,6 +998,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^systemctl\s+status\b",
         rtk_cmd: "rtk systemctl",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["systemctl"],
         category: "System",
         savings_pct: 65.0,
@@ -928,6 +1008,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^terraform\s+plan",
         rtk_cmd: "rtk terraform",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["terraform"],
         category: "Infra",
         savings_pct: 70.0,
@@ -937,6 +1018,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^tofu\s+(fmt|init|plan|validate)(\s|$)",
         rtk_cmd: "rtk tofu",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["tofu"],
         category: "Infra",
         savings_pct: 70.0,
@@ -946,6 +1028,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^trunk\s+build",
         rtk_cmd: "rtk trunk",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["trunk"],
         category: "Build",
         savings_pct: 65.0,
@@ -955,6 +1038,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^uv\s+(sync|pip\s+install)\b",
         rtk_cmd: "rtk uv",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["uv"],
         category: "Python",
         savings_pct: 65.0,
@@ -964,6 +1048,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^yamllint\b",
         rtk_cmd: "rtk yamllint",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["yamllint"],
         category: "Build",
         savings_pct: 65.0,
@@ -973,6 +1058,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^wc(\s|$)",
         rtk_cmd: "rtk wc",
+        pipeline_final_safe: true,
         rewrite_prefixes: &["wc"],
         category: "Files",
         savings_pct: 60.0,
@@ -982,6 +1068,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^gt\s+",
         rtk_cmd: "rtk gt",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["gt"],
         category: "Git",
         savings_pct: 70.0,
@@ -991,6 +1078,7 @@ pub const RULES: &[RtkRule] = &[
     RtkRule {
         pattern: r"^liquibase(?:\s|$)",
         rtk_cmd: "rtk liquibase",
+        pipeline_final_safe: false,
         rewrite_prefixes: &["liquibase"],
         category: "Infra",
         savings_pct: 65.0,

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -1118,6 +1118,17 @@ mod tests {
     }
 
     #[test]
+    fn test_claude_pipeline_rewrites_only_safe_final_stage() {
+        let result = run_claude_inner(&claude_input("cargo test | grep FAILED")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let cmd = v
+            .pointer("/hookSpecificOutput/updatedInput/command")
+            .and_then(|c| c.as_str())
+            .unwrap();
+        assert_eq!(cmd, "cargo test | rtk grep FAILED");
+    }
+
+    #[test]
     fn test_claude_json_output_structure() {
         let result = run_claude_inner(&claude_input("git status")).unwrap();
         let v: Value = serde_json::from_str(&result).unwrap();

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -601,6 +601,15 @@ mod tests {
     }
 
     #[test]
+    fn test_stderr_pipe_segments_checked() {
+        let deny = vec!["rm -rf".to_string()];
+        assert_eq!(
+            check_command_with_rules("cat file |& rm -rf /", &deny, &[], &[]),
+            PermissionVerdict::Deny
+        );
+    }
+
+    #[test]
     fn test_ask_verdict() {
         let ask = vec!["git push".to_string()];
         assert_eq!(

--- a/tests/pipeline_stdin_test.rs
+++ b/tests/pipeline_stdin_test.rs
@@ -1,0 +1,44 @@
+#![cfg(unix)]
+
+use std::io::Write;
+use std::process::{Command, Output, Stdio};
+
+fn run_with_stdin(command: &mut Command, input: &[u8]) -> Output {
+    let mut child = command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn command");
+    child
+        .stdin
+        .take()
+        .expect("piped stdin")
+        .write_all(input)
+        .expect("write stdin");
+    child.wait_with_output().expect("wait for command")
+}
+
+#[test]
+fn wc_reads_piped_stdin() {
+    let output = run_with_stdin(
+        Command::new(env!("CARGO_BIN_EXE_rtk")).args(["wc", "-l"]),
+        b"alpha\nbeta\n",
+    );
+
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "2");
+}
+
+#[test]
+fn wc_preserves_native_failure_exit_code() {
+    let invalid_option = "--definitely-invalid-rtk-test-option";
+    let rtk = run_with_stdin(
+        Command::new(env!("CARGO_BIN_EXE_rtk")).args(["wc", invalid_option]),
+        b"input\n",
+    );
+    let native = run_with_stdin(Command::new("wc").arg(invalid_option), b"input\n");
+
+    assert!(!rtk.status.success());
+    assert_eq!(rtk.status.code(), native.status.code());
+}


### PR DESCRIPTION
## Summary

- Preserve pipeline producers and intermediate stages, rewriting only a verified-safe final `grep`, `rg`, or `wc` stage.
- Keep pattern-file searches, unsupported commands, malformed/grouped pipelines, and `|&` pipelines raw.
- Tokenize `|&` atomically while continuing to check both sides during permission analysis.

## Behavior

Automatic rewriting previously could rewrite a pipeline producer, changing the bytes consumed by downstream commands.

This PR changes pipeline rewriting so that:

- Producers and intermediate stages remain unchanged.
- Only a verified-safe final stage may be rewritten.
- `grep`, `rg`, and `wc` are initially eligible.
- `grep` and `rg` using `-f`/`--file` remain raw because those forms are not yet parsed safely.
- Unsupported, malformed, grouped, and `|&` pipelines remain raw.
- Commands after independent `&&`, `||`, and `;` operators can still be rewritten.
- `|&` is tokenized atomically while permission checks continue to inspect both sides.

For example:

```text
cargo test | grep FAILED
  -> cargo test | rtk grep FAILED

git log | grep feat | wc -l
  -> git log | grep feat | rtk wc -l

cargo test | tail -50
  -> unchanged

cargo test |& grep FAILED
  -> unchanged
```

## Follow-ups

To keep this PR focused and reviewable, I plan to address the following in separate PRs.

- Consider a consumable token iterator or cursor if pipeline analysis grows, so already-processed tokens do not need to be skipped repeatedly.
- Support additional final commands after verifying their stdin, exit-code, interactivity, streaming, and argument-specific behavior.
- Consider replacing `rtk_cmd` string comparisons and centralized command-specific checks with structured rule-level safety policies such as `Never`, `Always`, and `Conditional`.
- Handle redirects and explicit RTK pipeline producers separately.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all`
- [x] `cargo test --test pipeline_stdin_test`
- [ ] Manual testing: `rtk <command>` output inspected

> **Important:** This PR targets the `develop` branch.
