### PR TITLE
chore: gitignore .claude/settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ credentials.json
 secrets.json
 *.secret
 
+# Local Claude Code config (may contain machine-local settings/tokens)
+.claude/settings.local.json
+
 # IDE
 .idea/
 .vscode/


### PR DESCRIPTION
`.claude/settings.local.json` is machine-local Claude Code config that can contain local tokens/paths — same risk class as CVE-2025-59536/CVE-2026-21852 for committed local-settings files. Small, mechanical fix: add it to `.gitignore` so it can't be accidentally committed.