### PR TITLE
fix(hooks): honor CLAUDE_CONFIG_DIR when loading permission rules

### DIFF
--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -2,6 +2,7 @@ use super::constants::{
     CLAUDE_DIR, CURSOR_DIR, DROID_DIR, DROID_HOME_ENV, DROID_SETTINGS_FILE, GEMINI_DIR,
     SETTINGS_JSON, SETTINGS_LOCAL_JSON,
 };
+use super::init::resolve_claude_dir;
 use crate::core::stream::exec_capture;
 use crate::discover::lexer::split_for_permissions;
 use serde_json::Value;
@@ -174,15 +175,25 @@ fn append_bash_rules(rules_value: Option<&Value>, target: &mut Vec<String>) {
 
 /// Return the ordered list of Claude Code settings file paths to check.
 fn get_settings_paths() -> Vec<PathBuf> {
+    get_settings_paths_from(find_project_root(), resolve_claude_dir().ok())
+}
+
+/// Assemble the settings paths for a project root and a resolved Claude config dir.
+///
+/// `claude_dir` is already resolved, so it honors `CLAUDE_CONFIG_DIR` when set.
+fn get_settings_paths_from(
+    project_root: Option<PathBuf>,
+    claude_dir: Option<PathBuf>,
+) -> Vec<PathBuf> {
     let mut paths = Vec::new();
 
-    if let Some(root) = find_project_root() {
+    if let Some(root) = project_root {
         paths.push(root.join(CLAUDE_DIR).join(SETTINGS_JSON));
         paths.push(root.join(CLAUDE_DIR).join(SETTINGS_LOCAL_JSON));
     }
-    if let Some(home) = dirs::home_dir() {
-        paths.push(home.join(CLAUDE_DIR).join(SETTINGS_JSON));
-        paths.push(home.join(CLAUDE_DIR).join(SETTINGS_LOCAL_JSON));
+    if let Some(claude_dir) = claude_dir {
+        paths.push(claude_dir.join(SETTINGS_JSON));
+        paths.push(claude_dir.join(SETTINGS_LOCAL_JSON));
     }
 
     paths
@@ -470,6 +481,39 @@ fn split_compound_command(cmd: &str) -> Vec<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_get_settings_paths_uses_the_resolved_claude_dir() {
+        let project = PathBuf::from("/workspace/project");
+        let profile = PathBuf::from("/profiles/work/.claude");
+
+        let paths = get_settings_paths_from(Some(project.clone()), Some(profile.clone()));
+
+        assert_eq!(
+            paths,
+            vec![
+                project.join(CLAUDE_DIR).join(SETTINGS_JSON),
+                project.join(CLAUDE_DIR).join(SETTINGS_LOCAL_JSON),
+                profile.join(SETTINGS_JSON),
+                profile.join(SETTINGS_LOCAL_JSON),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_get_settings_paths_without_a_claude_dir() {
+        let project = PathBuf::from("/workspace/project");
+
+        let paths = get_settings_paths_from(Some(project.clone()), None);
+
+        assert_eq!(
+            paths,
+            vec![
+                project.join(CLAUDE_DIR).join(SETTINGS_JSON),
+                project.join(CLAUDE_DIR).join(SETTINGS_LOCAL_JSON),
+            ]
+        );
+    }
 
     #[test]
     fn test_parse_bash_pattern() {


### PR DESCRIPTION
## Summary

Fixes #3133.

`get_settings_paths()` in `src/hooks/permissions.rs` built the global
`settings.json`/`settings.local.json` paths directly from
`dirs::home_dir()`, bypassing `resolve_claude_dir()` (which already
checks `CLAUDE_CONFIG_DIR` before falling back to `$HOME/.claude`).
Every other Claude Code path resolution in the codebase goes through
`resolve_claude_dir()` — this was the one spot that didn't.

Practical effect: with multiple Claude profiles (e.g. via a tool like
`claude-profile` that switches accounts by setting
`CLAUDE_CONFIG_DIR`), RTK's auto-allow/deny/ask permission checks kept
reading the default `~/.claude/settings.json` instead of the active
profile's settings — so permission decisions didn't match whichever
profile Claude Code itself was actually using.

## Changes

- `get_settings_paths()` now resolves the global settings location via
  `resolve_claude_dir()` instead of hand-rolling `home_dir().join(".claude")`.
- Added `test_get_settings_paths_honors_claude_config_dir` verifying the
  override is picked up and the default `~/.claude` path is excluded
  when `CLAUDE_CONFIG_DIR` is set.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets` clean
- [x] `cargo test --all` — 2518 passed, 8 ignored
- [x] Manual check: pointed `CLAUDE_CONFIG_DIR` at a temp dir with its
      own `settings.json` and confirmed rtk's permission rules are now
      read from it