### PR TITLE
fix(sbt): filter selective test tasks (testOnly, testQuick)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ rtk ruff check                  # Python linting (JSON, -80%)
 rtk golangci-lint run           # Go linting (JSON, -85%)
 rtk rubocop                     # Ruby linting (JSON, -60%+)
 rtk sbt test                    # ScalaTest output (-90%)
+rtk sbt testOnly com.example.X  # Single/selective tests, same filter (-90%)
 rtk sbt compile                 # Compilation errors only (-75%)
 rtk sbt run                     # Strip SBT preamble noise
 ```

--- a/src/cmds/scala/sbt_cmd.rs
+++ b/src/cmds/scala/sbt_cmd.rs
@@ -60,6 +60,21 @@ fn is_integration_test_cmd(subcommand: &str) -> bool {
     ) || (subcommand.ends_with(":test") || subcommand.ends_with("/test"))
 }
 
+/// Selective/single-test task names that emit ScalaTest/munit output just like
+/// `sbt test` (e.g. `sbt testOnly com.example.MySpec`, `sbt testQuick`).
+const SELECTIVE_TEST_TASKS: &[&str] = &["testOnly", "testQuick"];
+
+/// Returns true if `subcommand` produces ScalaTest/munit test output and should be
+/// filtered like `sbt test`. Covers integration-test tasks (it:test,
+/// IntegrationTest/test) and selective test tasks (testOnly, testQuick), including
+/// scoped forms such as `Test/testOnly` or `it/testQuick`.
+fn is_test_cmd(subcommand: &str) -> bool {
+    // A scoped task carries the config as a prefix ("Test/testOnly", "it:testOnly");
+    // the task name is the final segment after any '/' or ':'.
+    let task = subcommand.rsplit(['/', ':']).next().unwrap_or(subcommand);
+    SELECTIVE_TEST_TASKS.contains(&task) || is_integration_test_cmd(subcommand)
+}
+
 /// Returns true if `s` is a scoped SBT task (e.g. `Test/test`, `it/Test/compile`).
 fn is_scoped_task(s: &str) -> bool {
     !s.starts_with('-') && (s.contains('/') || s.contains(':'))
@@ -126,11 +141,13 @@ pub fn run_other(args: &[OsString], verbose: u8) -> Result<i32> {
 
     let subcommand = args[0].to_string_lossy().into_owned();
 
-    // Integration test commands (it:test, IntegrationTest/test, etc.) produce standard
-    // ScalaTest output — filter them like `sbt test`, through the shared runner so the
-    // never_worse cap and tee hint apply (an unrecognized output would otherwise be
-    // reprinted verbatim plus the hint, i.e. more than the raw command produced).
-    if is_integration_test_cmd(&subcommand) {
+    // Test-producing tasks — integration tests (it:test, IntegrationTest/test) and
+    // selective tests (testOnly, testQuick, incl. scoped forms like Test/testOnly) —
+    // emit standard ScalaTest/munit output, so filter them like `sbt test`. Routing
+    // through the shared runner applies the never_worse cap and tee hint (an
+    // unrecognized output would otherwise be reprinted verbatim plus the hint, i.e.
+    // more than the raw command produced).
+    if is_test_cmd(&subcommand) {
         let mut cmd = resolved_command("sbt");
         cmd.arg(&subcommand);
         for arg in &args[1..] {
@@ -146,9 +163,17 @@ pub fn run_other(args: &[OsString], verbose: u8) -> Result<i32> {
             .map(|a| a.to_string_lossy().into_owned())
             .collect();
         let args_display = if rest.is_empty() {
-            subcommand
+            subcommand.clone()
         } else {
             format!("{} {}", subcommand, rest.join(" "))
+        };
+
+        // Integration tests keep their own tee label; selective tests share the
+        // `sbt test` log since they are the same task family.
+        let tee_label = if is_integration_test_cmd(&subcommand) {
+            "sbt_it_test"
+        } else {
+            "sbt_test"
         };
 
         return runner::run_filtered(
@@ -156,7 +181,7 @@ pub fn run_other(args: &[OsString], verbose: u8) -> Result<i32> {
             "sbt",
             &args_display,
             filter_sbt_test,
-            RunOptions::with_tee("sbt_it_test"),
+            RunOptions::with_tee(tee_label),
         );
     }
 
@@ -692,6 +717,25 @@ mod tests {
         assert!(!is_integration_test_cmd("test"));
         assert!(!is_integration_test_cmd("compile"));
         assert!(!is_integration_test_cmd("assembly"));
+    }
+
+    #[test]
+    fn test_is_test_cmd() {
+        // Selective/single-test tasks (bare and scoped) route to the test filter.
+        assert!(is_test_cmd("testOnly"));
+        assert!(is_test_cmd("testQuick"));
+        assert!(is_test_cmd("Test/testOnly"));
+        assert!(is_test_cmd("it/testQuick"));
+        assert!(is_test_cmd("it:testOnly"));
+        // Integration-test tasks still qualify (delegates to is_integration_test_cmd).
+        assert!(is_test_cmd("it:test"));
+        assert!(is_test_cmd("IntegrationTest/test"));
+        assert!(is_test_cmd("e2e/test"));
+        // Non-test tasks must not be filtered as tests.
+        assert!(!is_test_cmd("compile"));
+        assert!(!is_test_cmd("assembly"));
+        assert!(!is_test_cmd("update"));
+        assert!(!is_test_cmd("testable")); // must not substring-match "test"
     }
 
     // --- sbt test: munit format ---

--- a/src/cmds/scala/sbt_cmd.rs
+++ b/src/cmds/scala/sbt_cmd.rs
@@ -60,10 +60,6 @@ fn is_integration_test_cmd(subcommand: &str) -> bool {
     ) || (subcommand.ends_with(":test") || subcommand.ends_with("/test"))
 }
 
-/// Selective/single-test task names that emit ScalaTest/munit output just like
-/// `sbt test` (e.g. `sbt testOnly com.example.MySpec`, `sbt testQuick`).
-const SELECTIVE_TEST_TASKS: &[&str] = &["testOnly", "testQuick"];
-
 /// Returns true if `subcommand` produces ScalaTest/munit test output and should be
 /// filtered like `sbt test`. Covers integration-test tasks (it:test,
 /// IntegrationTest/test) and selective test tasks (testOnly, testQuick), including
@@ -72,7 +68,7 @@ fn is_test_cmd(subcommand: &str) -> bool {
     // A scoped task carries the config as a prefix ("Test/testOnly", "it:testOnly");
     // the task name is the final segment after any '/' or ':'.
     let task = subcommand.rsplit(['/', ':']).next().unwrap_or(subcommand);
-    SELECTIVE_TEST_TASKS.contains(&task) || is_integration_test_cmd(subcommand)
+    matches!(task, "testOnly" | "testQuick") || is_integration_test_cmd(subcommand)
 }
 
 /// Returns true if `s` is a scoped SBT task (e.g. `Test/test`, `it/Test/compile`).
@@ -158,22 +154,22 @@ pub fn run_other(args: &[OsString], verbose: u8) -> Result<i32> {
             eprintln!("Running: sbt {} ...", subcommand);
         }
 
-        let rest: Vec<String> = args[1..]
-            .iter()
-            .map(|a| a.to_string_lossy().into_owned())
-            .collect();
-        let args_display = if rest.is_empty() {
-            subcommand.clone()
-        } else {
-            format!("{} {}", subcommand, rest.join(" "))
-        };
-
         // Integration tests keep their own tee label; selective tests share the
         // `sbt test` log since they are the same task family.
         let tee_label = if is_integration_test_cmd(&subcommand) {
             "sbt_it_test"
         } else {
             "sbt_test"
+        };
+
+        let rest: Vec<String> = args[1..]
+            .iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        let args_display = if rest.is_empty() {
+            subcommand
+        } else {
+            format!("{} {}", subcommand, rest.join(" "))
         };
 
         return runner::run_filtered(

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1412,6 +1412,30 @@ mod tests {
     }
 
     #[test]
+    fn test_rewrite_sbt_test_only() {
+        // Single/selective test tasks must rewrite so they get ScalaTest filtering.
+        assert_eq!(
+            rewrite_command_no_prefixes("sbt testOnly com.example.MySpec", &[]),
+            Some("rtk sbt testOnly com.example.MySpec".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("sbt testQuick", &[]),
+            Some("rtk sbt testQuick".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("sbt test", &[]),
+            Some("rtk sbt test".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_sbt_does_not_match_unrelated_tasks() {
+        // The `(?:\s|$)` anchor must keep us from rewriting tasks that merely
+        // start with a recognized subcommand (e.g. a custom `testify` task).
+        assert_eq!(rewrite_command_no_prefixes("sbt testify", &[]), None);
+    }
+
+    #[test]
     fn test_rewrite_compound_and() {
         assert_eq!(
             rewrite_command_no_prefixes("git add . && cargo test", &[]),

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -508,12 +508,12 @@ pub const RULES: &[RtkRule] = &[
     },
     // Scala/SBT
     RtkRule {
-        pattern: r"^sbt\s+(test|compile|run|clean|assembly|package)(?:\s|$)",
+        pattern: r"^sbt\s+(testOnly|testQuick|test|compile|run|clean|assembly|package)(?:\s|$)",
         rtk_cmd: "rtk sbt",
         rewrite_prefixes: &["sbt"],
         category: "Build",
         savings_pct: 80.0,
-        subcmd_savings: &[("test", 90.0), ("compile", 75.0)],
+        subcmd_savings: &[("test", 90.0), ("testOnly", 90.0), ("compile", 75.0)],
         subcmd_status: &[],
     },
     RtkRule {


### PR DESCRIPTION
## What

Follow-up to #752. `sbt testOnly <spec>` and `sbt testQuick` — the commands you run to execute a single test or the just-changed tests, the tightest inner loop for a Scala dev — were passed through **unfiltered**, even though they emit the exact same ScalaTest/munit output that `filter_sbt_test` already handles.

Reported by @greenhost87 on #752:
> Minor problem - single test execution via `sbt testOnly` falls into `rtk sbt <other>`

## Why it slipped through

Two layers, both missing the task:

1. **Rewrite rule** (`src/discover/rules.rs`): the subcommand alternation listed `test` but not `testOnly`/`testQuick`. With the `(?:\s|$)` anchor, `test` cannot match `testOnly`, so `sbt testOnly …` was never rewritten to `rtk sbt …`.
2. **Routing** (`src/cmds/scala/sbt_cmd.rs`): even as `rtk sbt testOnly …`, `run_other` only recognized integration-test tasks (`:test` / `/test` suffixes) and fell through to `run_passthrough`.

## Change

- Add `testOnly`/`testQuick` to the rewrite alternation, **keeping the `(?:\s|$)` anchor** so custom tasks like `testify` are still not rewritten.
- New `is_test_cmd()` helper recognizes `testOnly`/`testQuick` and their scoped forms (`Test/testOnly`, `it:testQuick`, …) in addition to the existing integration-test tasks.
- `run_other` routes all test-producing tasks through `runner::run_filtered` with `filter_sbt_test`, so the `never_worse` cap and tee hint apply (Transparency) — same shared-runner shape as the rest of the module.

No new output format; the filter itself is unchanged and already covered by fixtures.

## Tests

- `test_is_test_cmd` — bare + scoped `testOnly`/`testQuick`, integration tasks, and negatives (`compile`, `assembly`, `update`, `testable`).
- `test_rewrite_sbt_test_only` / `test_rewrite_sbt_does_not_match_unrelated_tasks`.

`cargo fmt --all --check` ✅ · `cargo clippy --all-targets` (no warnings) ✅ · `cargo test --all` (2520 passed) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)