### PR TITLE
fix(sbt): filter testOnly/testQuick like sbt test

### DIFF
--- a/src/cmds/scala/sbt_cmd.rs
+++ b/src/cmds/scala/sbt_cmd.rs
@@ -63,7 +63,7 @@ fn is_integration_test_cmd(subcommand: &str) -> bool {
 fn is_test_task(subcommand: &str) -> bool {
     let task = subcommand.split_whitespace().next().unwrap_or(subcommand);
     let task = task.rsplit(['/', ':']).next().unwrap_or(task);
-    matches!(task, "testOnly" | "testQuick" | "test-only" | "test-quick")
+    matches!(task, "testOnly" | "testQuick")
 }
 
 /// Returns true if `s` is a scoped SBT task (e.g. `Test/test`, `it/Test/compile`).
@@ -704,7 +704,6 @@ mod tests {
     fn test_is_test_task() {
         assert!(is_test_task("testOnly"));
         assert!(is_test_task("testQuick"));
-        assert!(is_test_task("test-only"));
         assert!(is_test_task("Test/testOnly"));
         assert!(is_test_task("core/testOnly"));
         assert!(is_test_task("it:testOnly"));

--- a/src/cmds/scala/sbt_cmd.rs
+++ b/src/cmds/scala/sbt_cmd.rs
@@ -147,6 +147,12 @@ pub fn run_other(args: &[OsString], verbose: u8) -> Result<i32> {
             eprintln!("Running: sbt {} ...", subcommand);
         }
 
+        let tee_label = if is_integration_test_cmd(&subcommand) {
+            "sbt_it_test"
+        } else {
+            "sbt_test"
+        };
+
         let rest: Vec<String> = args[1..]
             .iter()
             .map(|a| a.to_string_lossy().into_owned())
@@ -155,12 +161,6 @@ pub fn run_other(args: &[OsString], verbose: u8) -> Result<i32> {
             subcommand
         } else {
             format!("{} {}", subcommand, rest.join(" "))
-        };
-
-        let tee_label = if is_integration_test_cmd(&subcommand) {
-            "sbt_it_test"
-        } else {
-            "sbt_test"
         };
 
         return runner::run_filtered(

--- a/src/cmds/scala/sbt_cmd.rs
+++ b/src/cmds/scala/sbt_cmd.rs
@@ -60,6 +60,12 @@ fn is_integration_test_cmd(subcommand: &str) -> bool {
     ) || (subcommand.ends_with(":test") || subcommand.ends_with("/test"))
 }
 
+fn is_test_task(subcommand: &str) -> bool {
+    let task = subcommand.split_whitespace().next().unwrap_or(subcommand);
+    let task = task.rsplit(['/', ':']).next().unwrap_or(task);
+    matches!(task, "testOnly" | "testQuick" | "test-only" | "test-quick")
+}
+
 /// Returns true if `s` is a scoped SBT task (e.g. `Test/test`, `it/Test/compile`).
 fn is_scoped_task(s: &str) -> bool {
     !s.starts_with('-') && (s.contains('/') || s.contains(':'))
@@ -130,7 +136,7 @@ pub fn run_other(args: &[OsString], verbose: u8) -> Result<i32> {
     // ScalaTest output — filter them like `sbt test`, through the shared runner so the
     // never_worse cap and tee hint apply (an unrecognized output would otherwise be
     // reprinted verbatim plus the hint, i.e. more than the raw command produced).
-    if is_integration_test_cmd(&subcommand) {
+    if is_integration_test_cmd(&subcommand) || is_test_task(&subcommand) {
         let mut cmd = resolved_command("sbt");
         cmd.arg(&subcommand);
         for arg in &args[1..] {
@@ -692,6 +698,24 @@ mod tests {
         assert!(!is_integration_test_cmd("test"));
         assert!(!is_integration_test_cmd("compile"));
         assert!(!is_integration_test_cmd("assembly"));
+    }
+
+    #[test]
+    fn test_is_test_task() {
+        assert!(is_test_task("testOnly"));
+        assert!(is_test_task("testQuick"));
+        assert!(is_test_task("test-only"));
+        assert!(is_test_task("Test/testOnly"));
+        assert!(is_test_task("core/testOnly"));
+        assert!(is_test_task("it:testOnly"));
+        assert!(is_test_task("testOnly com.example.MySpec"));
+        assert!(is_test_task("testOnly *CalcSpec"));
+        assert!(is_test_task("core/testOnly com.example.MySpec"));
+        assert!(!is_test_task("test"));
+        assert!(!is_test_task("Test/test"));
+        assert!(!is_test_task("testOnlyFoo"));
+        assert!(!is_test_task("compile"));
+        assert!(!is_test_task("clean; testOnly com.example.MySpec"));
     }
 
     // --- sbt test: munit format ---

--- a/src/cmds/scala/sbt_cmd.rs
+++ b/src/cmds/scala/sbt_cmd.rs
@@ -157,12 +157,18 @@ pub fn run_other(args: &[OsString], verbose: u8) -> Result<i32> {
             format!("{} {}", subcommand, rest.join(" "))
         };
 
+        let tee_label = if is_integration_test_cmd(&subcommand) {
+            "sbt_it_test"
+        } else {
+            "sbt_test"
+        };
+
         return runner::run_filtered(
             cmd,
             "sbt",
             &args_display,
             filter_sbt_test,
-            RunOptions::with_tee("sbt_it_test"),
+            RunOptions::with_tee(tee_label),
         );
     }
 

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -3399,6 +3399,35 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_rewrite_sbt_test_only() {
+        assert_eq!(
+            rewrite_command_no_prefixes("sbt testOnly com.example.MySpec", &[]),
+            Some("rtk sbt testOnly com.example.MySpec".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes(r#"sbt "testOnly com.example.MySpec""#, &[]),
+            Some(r#"rtk sbt "testOnly com.example.MySpec""#.into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes(r#"sbt "testOnly *MySpec -- -z foo""#, &[]),
+            Some(r#"rtk sbt "testOnly *MySpec -- -z foo""#.into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("sbt testQuick", &[]),
+            Some("rtk sbt testQuick".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_sbt_does_not_match_unrelated_tasks() {
+        assert_eq!(rewrite_command_no_prefixes("sbt testify", &[]), None);
+        assert_eq!(
+            rewrite_command_no_prefixes(r#"sbt "test:compile""#, &[]),
+            None
+        );
+    }
+
     // --- Maven ---
 
     #[test]

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -508,12 +508,12 @@ pub const RULES: &[RtkRule] = &[
     },
     // Scala/SBT
     RtkRule {
-        pattern: r"^sbt\s+(test|compile|run|clean|assembly|package)(?:\s|$)",
+        pattern: r#"^sbt\s+["']?(testOnly|testQuick|test|compile|run|clean|assembly|package)(?:[\s"']|$)"#,
         rtk_cmd: "rtk sbt",
         rewrite_prefixes: &["sbt"],
         category: "Build",
         savings_pct: 80.0,
-        subcmd_savings: &[("test", 90.0), ("compile", 75.0)],
+        subcmd_savings: &[("test", 90.0), ("testOnly", 90.0), ("compile", 75.0)],
         subcmd_status: &[],
     },
     RtkRule {


### PR DESCRIPTION
Follow-up to #752, reported by @greenhost87: `sbt testOnly` fell through to passthrough (0% savings) and the rewrite rule never matched it.

Routes `testOnly`/`testQuick` (bare, scoped, and quoted forms like `sbt "testOnly com.example.MySpec"`) through the existing test filter, and extends the rewrite rule to match them.