### PR TITLE
docs(readme): list sbt testOnly in supported-commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ rtk ruff check                  # Python linting (JSON, -80%)
 rtk golangci-lint run           # Go linting (JSON, -85%)
 rtk rubocop                     # Ruby linting (JSON, -60%+)
 rtk sbt test                    # ScalaTest output (-90%)
+rtk sbt testOnly com.example.X  # Single/selective tests, same filter (-90%)
 rtk sbt compile                 # Compilation errors only (-75%)
 rtk sbt run                     # Strip SBT preamble noise
 ```


### PR DESCRIPTION
Follow-up to #3140. Now that `testOnly`/`testQuick` route through the `sbt test` filter, this adds `testOnly` to the README command list so single/selective test runs show up next to `sbt test`.

```
rtk sbt test                    # ScalaTest output (-90%)
rtk sbt testOnly com.example.X  # Single/selective tests, same filter (-90%)
rtk sbt compile                 # Compilation errors only (-75%)
```

Docs only, no code change. Opening it as a separate PR as suggested — thanks @aeppling!
