### PR TITLE
feat(hooks): add Devin CLI integration

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -321,6 +321,23 @@ rtk gain --graph      # With ASCII graph
 rtk gain --history    # With command history
 ```
 
+## Devin CLI Setup
+
+```bash
+# User-scoped (all Devin projects)
+rtk init -g --agent devin
+
+# Project-scoped (commit .devin/ to share)
+rtk init --agent devin
+
+# Verify
+rtk init --agent devin --show
+```
+
+Installs a `PreToolUse` hook (matcher `^exec$`) into `~/.config/devin/config.json` (global) or `.devin/hooks.v1.json` (project). Respects `$DEVIN_CONFIG_DIR`.
+
+RTK syncs with Devin CLI's own permission settings. Allowed commands are auto-approved and rewritten; blocked commands are blocked; all others are rewritten so Devin CLI can prompt on the rewritten command.
+
 ## Validated Token Savings
 
 ### Production T3 Stack Project

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ rtk init --agent kimi           # Kimi AI
 rtk init -g --agent pi          # Pi
 rtk init --agent hermes         # Hermes
 rtk init -g --agent droid       # Factory Droid
+rtk init -g --agent devin       # Devin CLI
 
 # 2. Restart your AI tool, then test
 git status  # Automatically rewritten to rtk git status
@@ -370,7 +371,7 @@ rtk init -g
 
 ## Supported AI Tools
 
-RTK supports 15 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents for 60-90% token savings where the agent supports command interception.
+RTK integrates with the following AI coding tools. Each integration rewrites shell commands to `rtk` equivalents for 60-90% token savings where the agent supports command interception.
 
 | Tool | Install | Method |
 |------|---------|--------|
@@ -391,6 +392,7 @@ RTK supports 15 AI coding tools. Each integration rewrites shell commands to `rt
 | **Google Antigravity** | `rtk init --agent antigravity` | .agents/rules/antigravity-rtk-rules.md (project-scoped) |
 | **Kimi AI** | `rtk init --agent kimi` | AGENTS.md (project-scoped) |
 | **Factory Droid** | `rtk init -g --agent droid` (or per-project) | PreToolUse hook in `~/.factory/hooks.json` (matcher `Execute`) |
+|| **Devin CLI** | `rtk init -g --agent devin` (or per-project) | PreToolUse hook in `~/.config/devin/config.json`, `.devin/config.json`, `.devin/config.local.json` or `.devin/hooks.v1.json` (matcher `exec`) |
 
 For per-agent setup details, override controls, and graceful degradation, see the [Supported Agents guide](https://www.rtk-ai.app/guide/getting-started/supported-agents). The Hermes plugin source and tests live in `hooks/hermes/`; installed Hermes runtime files still live under `~/.hermes/plugins/rtk-rewrite/`.
 

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -38,6 +38,7 @@ Agent runs "cargo test"
 | Pi | TypeScript extension (`tool_call` event) | Yes |
 | Hermes | Python plugin (`terminal` command mutation) | Yes |
 | Factory Droid | Shell hook (`PreToolUse`, matcher `Execute`) | Yes |
+| Devin CLI | Shell hook (`PreToolUse`, matcher `exec`) | Yes |
 | Cline / Roo Code | Rules file (prompt-level) | N/A |
 | Windsurf | Rules file (prompt-level) | N/A |
 | Codex CLI | AGENTS.md instructions | N/A |
@@ -157,6 +158,26 @@ rtk init --uninstall --agent droid
 ```
 
 Removes only RTK's hook entry; other hooks and settings are untouched.
+
+### Devin CLI
+
+```bash
+rtk init -g --agent devin    # user-scoped (~/.config/devin/config.json)
+rtk init --agent devin       # project-scoped (.devin/hooks.v1.json, commit to share)
+```
+
+Installs a `PreToolUse` hook (matcher `^exec$`) into Devin CLI's hook config. RTK picks an existing Devin hook file when possible (`.devin/hooks.v1.json`, `.devin/config.json`, or `.devin/config.local.json` for project; `~/.config/devin/config.json` for global), and respects `$DEVIN_CONFIG_DIR`.
+
+RTK reads Devin CLI's own `permissions` settings (`allow`/`ask`/`deny`) from `~/.config/devin/config.json`, `.devin/config.json`, and `.devin/config.local.json`. Rules like `Exec(git)` or tool-level `"exec"` are mapped to RTK's permission check. Allowed commands emit `decision: approve` plus the rewritten `updatedInput`; denied commands emit `decision: block`; everything else is rewritten via `updatedInput` without a decision so Devin CLI prompts on the rewritten command. If an existing project `AGENTS.md` is present, RTK appends a short instructions block encouraging use of `rtk read`/`rtk grep`/`rtk find` for Devin CLI built-ins.
+
+Uninstall:
+
+```bash
+rtk init --uninstall -g --agent devin
+rtk init --uninstall --agent devin
+```
+
+Removes only RTK's hook entry and the AGENTS.md block; other hooks and settings are untouched.
 
 ### Cline / Roo Code
 

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -6,7 +6,7 @@
 
 The **lifecycle management** layer for LLM agent hooks: install, uninstall, verify integrity, audit usage, and manage trust. This component creates and maintains the hook artifacts that live in `hooks/` (root), but does **not** execute rewrite logic itself — that lives in `discover/registry`.
 
-Owns: `rtk init` installation flows (5 agents via `AgentTarget` enum + 3 special modes: Gemini, Codex, OpenCode), SHA-256 integrity verification, hook version checking, audit log analysis, `rtk rewrite` CLI entry point, and TOML filter trust management.
+Owns: `rtk init` installation flows (11 agents via `AgentTarget` enum + 3 special modes: Gemini, Codex, OpenCode), SHA-256 integrity verification, hook version checking, audit log analysis, `rtk rewrite` CLI entry point, and TOML filter trust management.
 
 Does **not** own: the deployed hook scripts themselves (that's `hooks/`), the rewrite pattern registry (that's `discover/`), or command filtering (that's `cmds/`).
 
@@ -32,6 +32,7 @@ LLM agent integration layer that installs, validates, and executes command-rewri
 | Cursor | `rtk init -g --agent cursor` | Cursor hook | hooks.json |
 | Pi | `rtk init --agent pi` | `.pi/extensions/rtk.ts` | -- |
 | Hermes | `rtk init --agent hermes` | Python plugin in `~/.hermes/plugins/rtk-rewrite/` | `config.yaml` `plugins.enabled` |
+| Devin CLI | `rtk init -g --agent devin` | Devin CLI hook in `~/.config/devin/config.json`, `.devin/config.json`, `.devin/config.local.json` or `.devin/hooks.v1.json` | `config.json` / `hooks.v1.json` |
 
 
 ## Integrity Verification
@@ -90,6 +91,7 @@ Rules are loaded from all Claude Code `settings.json` files (project + global, i
 | Gemini CLI (rtk hook gemini) | No (allow/deny only) | allow (limitation — no ask mode in Gemini) |
 | Copilot CLI (rtk hook copilot) | No updatedInput | deny-with-suggestion (unchanged) |
 | Codex | ask parsed but no-op | allow (limitation — fails open) |
+| Devin CLI (rtk hook devin) | Yes | `decision` omitted; Devin CLI prompts on `updatedInput` |
 
 ### Implementation
 

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -53,6 +53,21 @@ pub const DROID_EXECUTE_MATCHER: &str = "Execute";
 /// `.factory` segment is appended to it): `$FACTORY_HOME_OVERRIDE/.factory`.
 pub const DROID_HOME_ENV: &str = "FACTORY_HOME_OVERRIDE";
 
+/// Devin CLI config directory (project: `.devin/`, global: `~/.config/devin/`).
+pub const DEVIN_DIR: &str = ".devin";
+/// Standalone Devin hooks file (project-level, root is the event map).
+pub const DEVIN_HOOKS_FILE: &str = "hooks.v1.json";
+/// Devin settings file (global and project, hooks live under a top-level `hooks` key).
+pub const DEVIN_SETTINGS_FILE: &str = "config.json";
+/// Devin local override settings file (`gitignored` personal project overrides).
+pub const DEVIN_SETTINGS_LOCAL_JSON: &str = "config.local.json";
+/// Tool matcher used by Devin CLI for shell command execution.
+pub const DEVIN_EXECUTE_MATCHER: &str = "^exec$";
+/// Native Rust hook command for Devin CLI.
+pub const DEVIN_HOOK_COMMAND: &str = "rtk hook devin";
+/// Environment variable to override the Devin global config directory.
+pub const DEVIN_CONFIG_DIR_ENV: &str = "DEVIN_CONFIG_DIR";
+
 pub const HERMES_DIR: &str = ".hermes";
 pub const HERMES_PLUGINS_SUBDIR: &str = "plugins";
 pub const HERMES_PLUGIN_NAME: &str = "rtk-rewrite";

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -128,11 +128,18 @@ fn get_rewritten(cmd: &str) -> Option<String> {
 enum HookDecision {
     AllowRewrite(String),
     AskRewrite(String),
+    /// Approve the original command unchanged (used when the user explicitly
+    /// allowed it but RTK has no filter for it).
+    AllowOriginal(String),
     Defer,
     Deny,
 }
 
-fn decide_from_verdict(cmd: &str, verdict: PermissionVerdict) -> HookDecision {
+fn decide_from_verdict(
+    cmd: &str,
+    verdict: PermissionVerdict,
+    allow_original: bool,
+) -> HookDecision {
     if verdict == PermissionVerdict::Deny {
         return HookDecision::Deny;
     }
@@ -142,12 +149,20 @@ fn decide_from_verdict(cmd: &str, verdict: PermissionVerdict) -> HookDecision {
     match get_rewritten(cmd) {
         Some(r) if verdict == PermissionVerdict::Allow => HookDecision::AllowRewrite(r),
         Some(r) => HookDecision::AskRewrite(r),
+        None if allow_original && verdict == PermissionVerdict::Allow => {
+            HookDecision::AllowOriginal(cmd.to_string())
+        }
         None => HookDecision::Defer,
     }
 }
 
 fn decide_hook_action(cmd: &str, host: permissions::Host) -> HookDecision {
-    decide_from_verdict(cmd, permissions::check_command_for(cmd, host))
+    let allow_original = host == permissions::Host::Devin;
+    decide_from_verdict(
+        cmd,
+        permissions::check_command_for(cmd, host),
+        allow_original,
+    )
 }
 
 fn handle_vscode(cmd: &str) -> Result<()> {
@@ -157,7 +172,7 @@ fn handle_vscode(cmd: &str) -> Result<()> {
             return Ok(());
         }
         HookDecision::Defer => return Ok(()),
-        HookDecision::AllowRewrite(r) => ("allow", r),
+        HookDecision::AllowRewrite(r) | HookDecision::AllowOriginal(r) => ("allow", r),
         HookDecision::AskRewrite(r) => ("ask", r),
     };
 
@@ -201,7 +216,7 @@ fn copilot_cli_response_from_decision(
             return None;
         }
         HookDecision::Defer => return None,
-        HookDecision::AllowRewrite(r) => (r, true),
+        HookDecision::AllowRewrite(r) | HookDecision::AllowOriginal(r) => (r, true),
         HookDecision::AskRewrite(r) => (r, false),
     };
 
@@ -262,6 +277,7 @@ pub fn run_gemini() -> Result<()> {
             audit_log("ask", cmd, rewritten);
             print_gemini("ask_user", Some(rewritten));
         }
+        HookDecision::AllowOriginal(_) => print_gemini("allow", None),
         HookDecision::Defer => print_gemini("ask_user", None),
     }
 
@@ -362,7 +378,7 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
                 cmd: cmd.to_string(),
             }
         }
-        HookDecision::AllowRewrite(r) => (r, true),
+        HookDecision::AllowRewrite(r) | HookDecision::AllowOriginal(r) => (r, true),
         HookDecision::AskRewrite(r) => (r, false),
     };
 
@@ -548,7 +564,7 @@ fn run_cursor_inner_with_rules(
     };
 
     let verdict = permissions::check_command_with_rules(&cmd, deny_rules, ask_rules, allow_rules);
-    match decide_from_verdict(&cmd, verdict) {
+    match decide_from_verdict(&cmd, verdict, false) {
         HookDecision::AllowRewrite(rewritten) => cursor_allow(&rewritten),
         HookDecision::AskRewrite(rewritten) => cursor_ask(&rewritten),
         _ => "{}".to_string(),
@@ -595,7 +611,7 @@ fn droid_response_from_decision(v: &Value, cmd: &str, decision: HookDecision) ->
             audit_log("deny", cmd, "");
             return None;
         }
-        HookDecision::Defer => return None,
+        HookDecision::Defer | HookDecision::AllowOriginal(_) => return None,
         HookDecision::AllowRewrite(r) | HookDecision::AskRewrite(r) => r,
     };
 
@@ -640,6 +656,95 @@ pub fn run_droid() -> Result<()> {
     Ok(())
 }
 
+// ── Devin CLI PreToolUse hook ──────────────────────────────────
+
+fn process_devin_payload(v: &Value) -> Option<Value> {
+    let cmd = devin_execute_command(v)?;
+    devin_response_from_decision(v, cmd, decide_hook_action(cmd, permissions::Host::Devin))
+}
+
+/// Extract the shell command when the payload targets Devin CLI's `exec` tool.
+fn devin_execute_command(v: &Value) -> Option<&str> {
+    let tool_name = v.get("tool_name").and_then(|t| t.as_str()).unwrap_or("");
+    // The installed matcher is `^exec$`; tolerate a missing/ambiguous tool_name defensively.
+    if !matches!(tool_name, "exec" | "bash" | "") {
+        return None;
+    }
+
+    v.pointer("/tool_input/command")
+        .and_then(|c| c.as_str())
+        .filter(|c| !c.is_empty())
+}
+
+/// Build the Devin CLI hook response for a decision from the shared flow.
+///
+/// Devin CLI expects a top-level `decision` (`approve`/`block`) and a
+/// `hookSpecificOutput.updatedInput` for rewrites. On `Ask`/`Default` we omit
+/// `decision` so Devin runs its own permission prompt on the rewritten command.
+fn devin_response_from_decision(v: &Value, cmd: &str, decision: HookDecision) -> Option<Value> {
+    match decision {
+        HookDecision::Deny => {
+            audit_log("deny", cmd, "");
+            Some(json!({
+                "decision": "block",
+                "reason": "Blocked by RTK permission rule"
+            }))
+        }
+        HookDecision::AllowOriginal(_) => {
+            audit_log("allow", cmd, "");
+            Some(json!({"decision": "approve"}))
+        }
+        HookDecision::Defer => None,
+        HookDecision::AllowRewrite(rewritten) => {
+            audit_log("rewrite", cmd, &rewritten);
+            build_devin_rewrite_response(v, &rewritten, true)
+        }
+        HookDecision::AskRewrite(rewritten) => {
+            audit_log("ask", cmd, &rewritten);
+            build_devin_rewrite_response(v, &rewritten, false)
+        }
+    }
+}
+
+fn build_devin_rewrite_response(v: &Value, rewritten: &str, allow: bool) -> Option<Value> {
+    let mut ti = v.get("tool_input").cloned().unwrap_or_else(|| json!({}));
+    if let Some(obj) = ti.as_object_mut() {
+        obj.insert("command".into(), Value::String(rewritten.to_string()));
+    }
+    let mut output = json!({
+        "hookSpecificOutput": {
+            "hookEventName": PRE_TOOL_USE_KEY,
+            "updatedInput": ti
+        }
+    });
+    if allow {
+        output["decision"] = json!("approve");
+    }
+    Some(output)
+}
+
+/// Run the Devin CLI PreToolUse hook natively.
+pub fn run_devin() -> Result<()> {
+    let input = read_stdin_limited()?;
+    let input = strip_leading_bom(&input).trim();
+    if input.is_empty() {
+        return Ok(());
+    }
+
+    let v: Value = match serde_json::from_str(input) {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = writeln!(io::stderr(), "[rtk hook] Failed to parse JSON input: {e}");
+            return Ok(());
+        }
+    };
+
+    if let Some(output) = process_devin_payload(&v) {
+        let _ = writeln!(io::stdout(), "{output}");
+    }
+    Ok(())
+}
+
 /// Hermetic test path: no Droid settings (empty rules).
 #[cfg(test)]
 fn run_droid_inner(input: &str) -> Option<String> {
@@ -657,7 +762,28 @@ fn run_droid_inner_with_rules(
     let v: Value = serde_json::from_str(input).ok()?;
     let cmd = droid_execute_command(&v)?;
     let verdict = permissions::check_command_with_rules(cmd, deny_rules, ask_rules, allow_rules);
-    droid_response_from_decision(&v, cmd, decide_from_verdict(cmd, verdict)).map(|o| o.to_string())
+    droid_response_from_decision(&v, cmd, decide_from_verdict(cmd, verdict, false))
+        .map(|o| o.to_string())
+}
+
+#[cfg(test)]
+fn run_devin_inner(input: &str) -> Option<String> {
+    run_devin_inner_with_rules(input, &[], &[], &[])
+}
+
+#[cfg(test)]
+fn run_devin_inner_with_rules(
+    input: &str,
+    deny_rules: &[String],
+    ask_rules: &[String],
+    allow_rules: &[String],
+) -> Option<String> {
+    let input = strip_leading_bom(input).trim();
+    let v: Value = serde_json::from_str(input).ok()?;
+    let cmd = devin_execute_command(&v)?;
+    let verdict = permissions::check_command_with_rules(cmd, deny_rules, ask_rules, allow_rules);
+    devin_response_from_decision(&v, cmd, decide_from_verdict(cmd, verdict, true))
+        .map(|o| o.to_string())
 }
 
 #[cfg(test)]
@@ -868,7 +994,11 @@ mod tests {
             &[],
             &["Bash(git:*)".to_string()],
         );
-        copilot_cli_response_from_decision(&cli_args(cmd), decide_from_verdict(cmd, verdict), cmd)
+        copilot_cli_response_from_decision(
+            &cli_args(cmd),
+            decide_from_verdict(cmd, verdict, false),
+            cmd,
+        )
     }
 
     #[test]
@@ -1394,7 +1524,7 @@ mod tests {
         allow: &[String],
     ) -> HookDecision {
         let verdict = permissions::check_command_with_rules(cmd, deny, ask, allow);
-        decide_from_verdict(cmd, verdict)
+        decide_from_verdict(cmd, verdict, false)
     }
 
     fn all_allowed() -> Vec<String> {
@@ -1472,6 +1602,7 @@ mod tests {
             }
             HookDecision::AllowRewrite(r) => gemini_json("allow", Some(&r)),
             HookDecision::AskRewrite(r) => gemini_json("ask_user", Some(&r)),
+            HookDecision::AllowOriginal(_) => gemini_json("allow", None),
             HookDecision::Defer => gemini_json("ask_user", None),
         }
     }
@@ -1730,5 +1861,139 @@ mod tests {
         // so Droid runs them unchanged.
         let input = droid_input("Execute", "definitely-not-a-real-binary --foo");
         assert!(run_droid_inner(&input).is_none());
+    }
+
+    // --- Devin CLI hook ---
+
+    fn devin_input(tool: &str, cmd: &str) -> String {
+        json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": tool,
+            "tool_input": { "command": cmd, "shell_id": "main" }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn test_devin_allow_emits_approve_and_rewrite() {
+        let input = devin_input("exec", "git status");
+        let out = run_devin_inner_with_rules(&input, &[], &[], &["git".to_string()])
+            .expect("rewrite expected");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["decision"], "approve");
+        assert_eq!(
+            v.pointer("/hookSpecificOutput/updatedInput/command"),
+            Some(&json!("rtk git status"))
+        );
+        assert_eq!(
+            v.pointer("/hookSpecificOutput/hookEventName"),
+            Some(&json!("PreToolUse"))
+        );
+        // Extra tool_input fields must be preserved.
+        assert_eq!(
+            v.pointer("/hookSpecificOutput/updatedInput/shell_id"),
+            Some(&json!("main"))
+        );
+    }
+
+    #[test]
+    fn test_devin_exec_tool_rule_allows_all() {
+        let input = devin_input("exec", "cargo test");
+        let out = run_devin_inner_with_rules(&input, &[], &[], &["*".to_string()])
+            .expect("rewrite expected");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["decision"], "approve");
+        assert!(v
+            .pointer("/hookSpecificOutput/updatedInput/command")
+            .and_then(|c| c.as_str())
+            .is_some_and(|c| c.starts_with("rtk ")));
+    }
+
+    #[test]
+    fn test_devin_default_asks_without_decision() {
+        let input = devin_input("exec", "git status");
+        let out = run_devin_inner(&input).expect("rewrite expected");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert!(
+            v.get("decision").is_none(),
+            "Ask/Default must omit decision"
+        );
+        assert_eq!(
+            v.pointer("/hookSpecificOutput/updatedInput/command"),
+            Some(&json!("rtk git status"))
+        );
+    }
+
+    #[test]
+    fn test_devin_deny_emits_block() {
+        let input = devin_input("exec", "rm -rf /tmp/x");
+        let out = run_devin_inner_with_rules(&input, &["rm -rf".to_string()], &[], &[])
+            .expect("block expected");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["decision"], "block");
+        assert!(v.get("hookSpecificOutput").is_none());
+    }
+
+    #[test]
+    fn test_devin_passthrough_unsupported() {
+        let input = devin_input("exec", "htop");
+        assert!(run_devin_inner(&input).is_none());
+    }
+
+    #[test]
+    fn test_devin_allow_unsupported_approves_original() {
+        // If the user explicitly allowed a command RTK cannot rewrite,
+        // RTK should still emit approve so Devin CLI auto-runs the original.
+        let input = devin_input("exec", "htop");
+        let out = run_devin_inner_with_rules(&input, &[], &[], &["htop".to_string()])
+            .expect("approve expected");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["decision"], "approve");
+        assert!(v.get("hookSpecificOutput").is_none());
+    }
+
+    #[test]
+    fn test_devin_already_rtk_passthrough() {
+        let input = devin_input("exec", "rtk git status");
+        assert!(run_devin_inner(&input).is_none());
+    }
+
+    #[test]
+    fn test_devin_env_prefix_preserved() {
+        let input = devin_input("exec", "RUST_LOG=debug cargo test");
+        let out = run_devin_inner_with_rules(&input, &[], &[], &["*".to_string()])
+            .expect("rewrite expected");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(
+            v.pointer("/hookSpecificOutput/updatedInput/command"),
+            Some(&json!("RUST_LOG=debug rtk cargo test"))
+        );
+    }
+
+    #[test]
+    fn test_devin_ignores_non_exec_tool() {
+        let input = devin_input("read", "src/main.rs");
+        assert!(run_devin_inner(&input).is_none());
+    }
+
+    #[test]
+    fn test_devin_empty_command_passthrough() {
+        let input = devin_input("exec", "");
+        assert!(run_devin_inner(&input).is_none());
+    }
+
+    #[test]
+    fn test_devin_malformed_json_passthrough() {
+        assert!(run_devin_inner("not-json").is_none());
+    }
+
+    #[test]
+    fn test_devin_bom_stripped() {
+        let payload = devin_input("exec", "git status");
+        let with_bom = format!("\u{feff}{}", payload);
+        let out = run_devin_inner_with_rules(&with_bom, &[], &[], &["git".to_string()])
+            .expect("rewrite expected");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["decision"], "approve");
     }
 }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -13,15 +13,18 @@ use crate::hooks::constants::{
 };
 
 use super::constants::{
-    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND, DROID_DIR,
-    DROID_EXECUTE_MATCHER, DROID_HOME_ENV, DROID_HOOKS_FILE, DROID_HOOKS_SUBDIR,
-    DROID_HOOK_COMMAND, DROID_SETTINGS_FILE, GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR,
-    HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON,
-    HOOKS_SUBDIR, PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR,
-    PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
+    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND, DEVIN_DIR,
+    DEVIN_EXECUTE_MATCHER, DEVIN_HOOKS_FILE, DEVIN_HOOK_COMMAND, DEVIN_SETTINGS_FILE,
+    DEVIN_SETTINGS_LOCAL_JSON, DROID_DIR, DROID_EXECUTE_MATCHER, DROID_HOME_ENV, DROID_HOOKS_FILE,
+    DROID_HOOKS_SUBDIR, DROID_HOOK_COMMAND, DROID_SETTINGS_FILE, GEMINI_HOOK_FILE, HERMES_DIR,
+    HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE,
+    HERMES_PLUGIN_NAME, HOOKS_JSON, HOOKS_SUBDIR, PI_CODING_AGENT_DIR_ENV, PI_DIR,
+    PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR, PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE,
+    SETTINGS_JSON,
 };
 use super::integrity;
 use super::is_claude_hook_command;
+use super::permissions;
 
 // Embedded OpenCode plugin (auto-rewrite)
 const OPENCODE_PLUGIN: &str = include_str!("../../hooks/opencode/rtk.ts");
@@ -3356,6 +3359,549 @@ fn remove_droid_hook_from_json(root: &mut serde_json::Value, layout: DroidLayout
     modified
 }
 
+// ─── Devin CLI support ────────────────────────────────────────────────
+
+const RTK_DEVIN_AGENTS_BLOCK: &str = r##"<!-- rtk-instructions -->
+When running shell commands, prefer `rtk <command>` (e.g. `rtk git status`, `rtk cargo test`, `rtk grep`, `rtk find`, `rtk read`). RTK compacts supported command output and passes unsupported commands through unchanged.
+<!-- /rtk-instructions -->"##;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DevinLayout {
+    /// `hooks.v1.json`: the event map is the file's root object.
+    Root,
+    /// `config.json`: hook events live under a top-level `hooks` key.
+    Nested,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct DevinHookFile {
+    path: PathBuf,
+    layout: DevinLayout,
+}
+
+/// Install Devin CLI PreToolUse hook.
+pub fn run_devin_mode(global: bool, patch_mode: PatchMode, ctx: InitContext) -> Result<()> {
+    let target = resolve_devin_install_target(global)?;
+
+    if !ctx.dry_run {
+        if let Some(parent) = target.path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "Failed to create Devin config directory: {}",
+                    parent.display()
+                )
+            })?;
+        }
+    }
+
+    let patched = patch_devin_hook_file(&target, patch_mode, ctx)?;
+
+    if !global && patch_mode != PatchMode::Skip && patched {
+        maybe_patch_devin_agents_md(ctx)?;
+    }
+
+    if ctx.dry_run {
+        print_dry_run_footer();
+    } else {
+        let scope = if global { "global" } else { "project" };
+        println!("\nDevin CLI hook registered ({scope}).\n");
+        println!("  Command:    {}", DEVIN_HOOK_COMMAND);
+        println!("  Hooks file: {}", target.path.display());
+        if patched {
+            println!("  RTK PreToolUse entry added");
+        } else {
+            println!("  RTK PreToolUse entry already present or skipped");
+        }
+        println!("  Restart Devin CLI. Test with: git status\n");
+    }
+
+    Ok(())
+}
+
+fn resolve_devin_install_target(global: bool) -> Result<DevinHookFile> {
+    if global {
+        let dir = permissions::resolve_devin_config_dir()
+            .context("Cannot determine Devin config directory. Set $DEVIN_CONFIG_DIR or $HOME.")?;
+        return Ok(DevinHookFile {
+            path: dir.join(DEVIN_SETTINGS_FILE),
+            layout: DevinLayout::Nested,
+        });
+    }
+
+    let devin_dir = std::env::current_dir()
+        .context("Failed to read current directory")?
+        .join(DEVIN_DIR);
+
+    let candidates = devin_hook_file_candidates(&devin_dir);
+
+    for candidate in &candidates {
+        if let Some(json) = read_devin_json(&candidate.path)? {
+            if devin_hook_already_present(&json, candidate.layout) {
+                return Ok(candidate.clone());
+            }
+        }
+    }
+
+    for candidate in &candidates {
+        if candidate.path.exists() {
+            return Ok(candidate.clone());
+        }
+    }
+
+    Ok(DevinHookFile {
+        path: devin_dir.join(DEVIN_HOOKS_FILE),
+        layout: DevinLayout::Root,
+    })
+}
+
+fn devin_hook_file_candidates(devin_dir: &Path) -> [DevinHookFile; 3] {
+    [
+        DevinHookFile {
+            path: devin_dir.join(DEVIN_HOOKS_FILE),
+            layout: DevinLayout::Root,
+        },
+        DevinHookFile {
+            path: devin_dir.join(DEVIN_SETTINGS_FILE),
+            layout: DevinLayout::Nested,
+        },
+        DevinHookFile {
+            path: devin_dir.join(DEVIN_SETTINGS_LOCAL_JSON),
+            layout: DevinLayout::Nested,
+        },
+    ]
+}
+
+fn read_devin_json(path: &Path) -> Result<Option<serde_json::Value>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    if content.trim().is_empty() {
+        return Ok(Some(serde_json::json!({})));
+    }
+    serde_json::from_str(&content)
+        .map(Some)
+        .with_context(|| format!("Failed to parse {} as JSON", path.display()))
+}
+
+fn devin_events(root: &serde_json::Value, layout: DevinLayout) -> &serde_json::Value {
+    match layout {
+        DevinLayout::Root => root,
+        DevinLayout::Nested => root.get("hooks").unwrap_or(&serde_json::Value::Null),
+    }
+}
+
+fn devin_hook_already_present(root: &serde_json::Value, layout: DevinLayout) -> bool {
+    let pre = match devin_events(root, layout)
+        .get(PRE_TOOL_USE_KEY)
+        .and_then(|p| p.as_array())
+    {
+        Some(arr) => arr,
+        None => return false,
+    };
+
+    pre.iter().any(|matcher_entry| {
+        let matcher = matcher_entry
+            .get("matcher")
+            .and_then(|m| m.as_str())
+            .unwrap_or("");
+        if matcher != DEVIN_EXECUTE_MATCHER {
+            return false;
+        }
+        matcher_entry
+            .get("hooks")
+            .and_then(|h| h.as_array())
+            .map(|arr| arr.as_slice())
+            .unwrap_or(&[])
+            .iter()
+            .any(|hook| {
+                hook.get("command")
+                    .and_then(|c| c.as_str())
+                    .is_some_and(|cmd| cmd == DEVIN_HOOK_COMMAND)
+            })
+    })
+}
+
+fn insert_devin_hook_entry(root: &mut serde_json::Value, layout: DevinLayout) -> Result<()> {
+    let events = match layout {
+        DevinLayout::Root => root
+            .as_object_mut()
+            .context("Devin hook file root is not an object")?,
+        DevinLayout::Nested => root
+            .as_object_mut()
+            .context("Devin config root is not an object")?
+            .entry("hooks")
+            .or_insert_with(|| serde_json::json!({}))
+            .as_object_mut()
+            .context("Devin config `hooks` key is not an object")?,
+    };
+
+    let pre_tool_use = events
+        .entry(PRE_TOOL_USE_KEY)
+        .or_insert_with(|| serde_json::json!([]))
+        .as_array_mut()
+        .context("PreToolUse value is not an array")?;
+
+    for entry in pre_tool_use.iter_mut() {
+        let matcher = entry.get("matcher").and_then(|m| m.as_str()).unwrap_or("");
+        if matcher == DEVIN_EXECUTE_MATCHER {
+            if let Some(hook_array) = entry.get_mut("hooks").and_then(|h| h.as_array_mut()) {
+                hook_array.push(serde_json::json!({
+                    "type": "command",
+                    "command": DEVIN_HOOK_COMMAND
+                }));
+                return Ok(());
+            }
+        }
+    }
+
+    pre_tool_use.push(serde_json::json!({
+        "matcher": DEVIN_EXECUTE_MATCHER,
+        "hooks": [
+            { "type": "command", "command": DEVIN_HOOK_COMMAND }
+        ]
+    }));
+    Ok(())
+}
+
+fn patch_devin_hook_file(file: &DevinHookFile, mode: PatchMode, ctx: InitContext) -> Result<bool> {
+    let InitContext { verbose, dry_run } = ctx;
+    let path = &file.path;
+
+    let mut root = read_devin_json(path)?.unwrap_or_else(|| serde_json::json!({}));
+
+    if devin_hook_already_present(&root, file.layout) {
+        if verbose > 0 {
+            eprintln!("{}: RTK hook already present", path.display());
+        }
+        return Ok(false);
+    }
+
+    match mode {
+        PatchMode::Skip => {
+            print_devin_manual_instructions(path, file.layout);
+            return Ok(false);
+        }
+        PatchMode::Ask => {
+            if dry_run {
+                println!("[dry-run] would prompt before patching {}", path.display());
+            } else if !prompt_user_consent(path)? {
+                print_devin_manual_instructions(path, file.layout);
+                return Ok(false);
+            }
+        }
+        PatchMode::Auto => {}
+    }
+
+    insert_devin_hook_entry(&mut root, file.layout)?;
+
+    let serialized =
+        serde_json::to_string_pretty(&root).context("Failed to serialize Devin hook file")?;
+
+    if dry_run {
+        println!("[dry-run] would patch Devin hook file: {}", path.display());
+        if verbose > 0 {
+            println!("[dry-run] content:\n{}", serialized);
+        }
+        return Ok(true);
+    }
+
+    if path.exists() {
+        let backup_path = path.with_extension("json.bak");
+        fs::copy(path, &backup_path)
+            .with_context(|| format!("Failed to backup to {}", backup_path.display()))?;
+        if verbose > 0 {
+            eprintln!("Backup: {}", backup_path.display());
+        }
+    }
+
+    atomic_write(path, &serialized)?;
+    Ok(true)
+}
+
+fn print_devin_manual_instructions(path: &Path, layout: DevinLayout) {
+    println!(
+        "To install manually, add the following to {}:",
+        path.display()
+    );
+    let entry = serde_json::json!({
+        "matcher": DEVIN_EXECUTE_MATCHER,
+        "hooks": [
+            { "type": "command", "command": DEVIN_HOOK_COMMAND }
+        ]
+    });
+    match layout {
+        DevinLayout::Root => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    PRE_TOOL_USE_KEY: [entry]
+                }))
+                .unwrap()
+            );
+        }
+        DevinLayout::Nested => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "hooks": {
+                        PRE_TOOL_USE_KEY: [entry]
+                    }
+                }))
+                .unwrap()
+            );
+        }
+    }
+}
+
+fn maybe_patch_devin_agents_md(ctx: InitContext) -> Result<()> {
+    let path = PathBuf::from(AGENTS_MD);
+    if !path.exists() {
+        return Ok(());
+    }
+    write_rtk_block(
+        &path,
+        RTK_DEVIN_AGENTS_BLOCK,
+        "RTK instructions",
+        "rtk init --agent devin",
+        ctx,
+    )?;
+    Ok(())
+}
+
+pub fn uninstall_devin(global: bool, ctx: InitContext) -> Result<()> {
+    let removed = uninstall_devin_artifacts(global, ctx)?;
+
+    if removed.is_empty() {
+        println!("RTK Devin CLI support was not installed (nothing to remove)");
+    } else {
+        let header = if ctx.dry_run {
+            "[dry-run] would uninstall RTK for Devin CLI:"
+        } else {
+            "RTK uninstalled for Devin CLI:"
+        };
+        println!("{}", header);
+        for item in removed {
+            println!("  - {}", item);
+        }
+    }
+
+    if ctx.dry_run {
+        print_dry_run_footer();
+    }
+    Ok(())
+}
+
+fn uninstall_devin_artifacts(global: bool, ctx: InitContext) -> Result<Vec<String>> {
+    let mut removed = Vec::new();
+
+    let devin_dir = if global {
+        permissions::resolve_devin_config_dir()
+            .context("Cannot determine Devin config directory. Set $DEVIN_CONFIG_DIR or $HOME.")?
+    } else {
+        std::env::current_dir()
+            .context("Failed to read current directory")?
+            .join(DEVIN_DIR)
+    };
+
+    for candidate in devin_hook_file_candidates(&devin_dir) {
+        if remove_devin_hook_from_file(&candidate, ctx)? {
+            removed.push(format!("Devin hook file: {}", candidate.path.display()));
+        }
+    }
+
+    if !global {
+        let agents_md = PathBuf::from(AGENTS_MD);
+        if agents_md.exists() {
+            let content = fs::read_to_string(&agents_md)
+                .with_context(|| format!("Failed to read AGENTS.md: {}", agents_md.display()))?;
+            if content.contains(RTK_BLOCK_START) {
+                let (cleaned, did_remove) = remove_rtk_block(&content);
+                if did_remove {
+                    if !ctx.dry_run {
+                        atomic_write(&agents_md, &cleaned)?;
+                    }
+                    removed.push(format!("AGENTS.md: {}", agents_md.display()));
+                }
+            }
+        }
+    }
+
+    Ok(removed)
+}
+
+fn remove_devin_hook_from_file(file: &DevinHookFile, ctx: InitContext) -> Result<bool> {
+    let InitContext { verbose, dry_run } = ctx;
+    let path = &file.path;
+
+    let mut root = match read_devin_json(path)? {
+        Some(v) => v,
+        None => return Ok(false),
+    };
+
+    if !remove_devin_hook_from_json(&mut root, file.layout) {
+        return Ok(false);
+    }
+
+    if dry_run {
+        println!(
+            "[dry-run] would remove RTK entry from Devin hook file: {}",
+            path.display()
+        );
+    } else {
+        let backup_path = path.with_extension("json.bak");
+        fs::copy(path, &backup_path).ok();
+
+        let serialized =
+            serde_json::to_string_pretty(&root).context("Failed to serialize Devin hook file")?;
+        atomic_write(path, &serialized)?;
+
+        if verbose > 0 {
+            eprintln!("Removed RTK hook from {}", path.display());
+        }
+    }
+    Ok(true)
+}
+
+fn remove_devin_hook_from_json(root: &mut serde_json::Value, layout: DevinLayout) -> bool {
+    let events_obj = match layout {
+        DevinLayout::Root => root.as_object_mut(),
+        DevinLayout::Nested => root.get_mut("hooks").and_then(|h| h.as_object_mut()),
+    };
+    let events_obj = match events_obj {
+        Some(o) => o,
+        None => return false,
+    };
+
+    let pre_tool_use = match events_obj
+        .get_mut(PRE_TOOL_USE_KEY)
+        .and_then(|p| p.as_array_mut())
+    {
+        Some(arr) => arr,
+        None => return false,
+    };
+
+    let mut modified = false;
+    let mut empty_matchers = Vec::new();
+
+    for (idx, entry) in pre_tool_use.iter_mut().enumerate() {
+        let matcher = entry.get("matcher").and_then(|m| m.as_str()).unwrap_or("");
+        if matcher != DEVIN_EXECUTE_MATCHER {
+            continue;
+        }
+        if let Some(hook_arr) = entry.get_mut("hooks").and_then(|h| h.as_array_mut()) {
+            let original = hook_arr.len();
+            hook_arr.retain(|hook| {
+                hook.get("command").and_then(|c| c.as_str()) != Some(DEVIN_HOOK_COMMAND)
+            });
+            if hook_arr.len() < original {
+                modified = true;
+            }
+            if hook_arr.is_empty() {
+                empty_matchers.push(idx);
+            }
+        }
+    }
+
+    for idx in empty_matchers.into_iter().rev() {
+        pre_tool_use.remove(idx);
+        modified = true;
+    }
+
+    if pre_tool_use.is_empty() {
+        events_obj.remove(PRE_TOOL_USE_KEY);
+        modified = true;
+    }
+
+    if layout == DevinLayout::Nested
+        && root
+            .get("hooks")
+            .and_then(|h| h.as_object())
+            .is_some_and(|o| o.is_empty())
+    {
+        if let Some(obj) = root.as_object_mut() {
+            obj.remove("hooks");
+        }
+    }
+
+    modified
+}
+
+pub fn show_devin_config() -> Result<()> {
+    println!("rtk Configuration (Devin CLI):\n");
+
+    match permissions::resolve_devin_config_dir() {
+        Some(dir) => {
+            let global_config = dir.join(DEVIN_SETTINGS_FILE);
+            if let Some(v) = read_devin_json(&global_config)? {
+                if devin_hook_already_present(&v, DevinLayout::Nested) {
+                    println!(
+                        "[ok] Global hook: {} in {}",
+                        DEVIN_HOOK_COMMAND,
+                        global_config.display()
+                    );
+                } else {
+                    println!(
+                        "[--] Global hook: not present in {}",
+                        global_config.display()
+                    );
+                }
+            } else {
+                println!("[--] Global hook: {} not found", global_config.display());
+            }
+        }
+        None => println!("[--] Devin config directory not found"),
+    }
+
+    let local_devin_dir = std::env::current_dir()
+        .map(|d| d.join(DEVIN_DIR))
+        .unwrap_or_default();
+    for path in [
+        local_devin_dir.join(DEVIN_HOOKS_FILE),
+        local_devin_dir.join(DEVIN_SETTINGS_FILE),
+        local_devin_dir.join(DEVIN_SETTINGS_LOCAL_JSON),
+    ] {
+        let layout = if path.file_name().and_then(|n| n.to_str()) == Some(DEVIN_HOOKS_FILE) {
+            DevinLayout::Root
+        } else {
+            DevinLayout::Nested
+        };
+        if let Some(v) = read_devin_json(&path)? {
+            if devin_hook_already_present(&v, layout) {
+                println!(
+                    "[ok] Project hook: {} in {}",
+                    DEVIN_HOOK_COMMAND,
+                    path.display()
+                );
+            } else {
+                println!("[--] Project hook: not present in {}", path.display());
+            }
+        } else {
+            println!("[--] Project hook: {} not found", path.display());
+        }
+    }
+
+    let agents_md = PathBuf::from(AGENTS_MD);
+    if agents_md.exists()
+        && fs::read_to_string(&agents_md)
+            .unwrap_or_default()
+            .contains(RTK_BLOCK_START)
+    {
+        println!("[ok] AGENTS.md: RTK instructions present");
+    } else {
+        println!("[--] AGENTS.md: not found or no RTK instructions");
+    }
+
+    println!("\nUsage:");
+    println!("  rtk init -g --agent devin          # Global Devin CLI hook");
+    println!("  rtk init --agent devin             # Project Devin CLI hook");
+    println!("  rtk init --agent devin --uninstall # Remove Devin CLI hook");
+    println!("  rtk init --agent devin --dry-run   # Preview changes");
+
+    Ok(())
+}
+
 fn codex_rtk_md_ref(codex_dir: &Path) -> String {
     format!("@{}", codex_dir.join(RTK_MD).display())
 }
@@ -3868,12 +4414,12 @@ fn remove_cursor_hook_from_json(root: &mut serde_json::Value) -> bool {
 }
 
 /// Show current rtk configuration
-pub fn show_config(codex: bool) -> Result<()> {
-    if codex {
-        return show_codex_config();
+pub fn show_config(codex: bool, agent: Option<crate::AgentTarget>) -> Result<()> {
+    match agent {
+        Some(crate::AgentTarget::Devin) => show_devin_config(),
+        _ if codex => show_codex_config(),
+        _ => show_claude_config(),
     }
-
-    show_claude_config()
 }
 
 fn show_claude_config() -> Result<()> {
@@ -4103,6 +4649,7 @@ fn show_claude_config() -> Result<()> {
     println!("  rtk init -g --codex         # Configure $CODEX_HOME/AGENTS.md + $CODEX_HOME/RTK.md (or ~/.codex/)");
     println!("  rtk init -g --opencode      # OpenCode plugin only");
     println!("  rtk init -g --agent cursor  # Install Cursor Agent hooks");
+    println!("  rtk init -g --agent devin   # Install Devin CLI hook");
 
     Ok(())
 }

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -1,5 +1,6 @@
 use super::constants::{
-    CLAUDE_DIR, CURSOR_DIR, DROID_DIR, DROID_HOME_ENV, DROID_SETTINGS_FILE, GEMINI_DIR,
+    CLAUDE_DIR, CURSOR_DIR, DEVIN_CONFIG_DIR_ENV, DEVIN_DIR, DEVIN_SETTINGS_FILE,
+    DEVIN_SETTINGS_LOCAL_JSON, DROID_DIR, DROID_HOME_ENV, DROID_SETTINGS_FILE, GEMINI_DIR,
     SETTINGS_JSON, SETTINGS_LOCAL_JSON,
 };
 use crate::core::stream::exec_capture;
@@ -36,6 +37,7 @@ pub enum Host {
     Cursor,
     Gemini,
     Droid,
+    Devin,
 }
 
 pub fn check_command_for(cmd: &str, host: Host) -> PermissionVerdict {
@@ -44,6 +46,7 @@ pub fn check_command_for(cmd: &str, host: Host) -> PermissionVerdict {
         Host::Cursor => load_cursor_rules(),
         Host::Gemini => load_gemini_rules(),
         Host::Droid => load_droid_rules(),
+        Host::Devin => load_devin_rules(),
     };
     check_command_with_rules(cmd, &deny_rules, &ask_rules, &allow_rules)
 }
@@ -186,6 +189,82 @@ fn get_settings_paths() -> Vec<PathBuf> {
     }
 
     paths
+}
+
+// ── Devin CLI permission rules ───────────────────────────────────
+
+fn load_devin_rules() -> (Vec<String>, Vec<String>, Vec<String>) {
+    let mut deny_rules = Vec::new();
+    let mut ask_rules = Vec::new();
+    let mut allow_rules = Vec::new();
+
+    for path in get_devin_settings_paths() {
+        let Some(json) = read_json(&path) else {
+            continue;
+        };
+        let Some(permissions) = json.get("permissions") else {
+            continue;
+        };
+
+        append_devin_rules(permissions.get("deny"), &mut deny_rules);
+        append_devin_rules(permissions.get("ask"), &mut ask_rules);
+        append_devin_rules(permissions.get("allow"), &mut allow_rules);
+    }
+
+    (deny_rules, ask_rules, allow_rules)
+}
+
+fn get_devin_settings_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    if let Some(root) = find_project_root() {
+        paths.push(root.join(DEVIN_DIR).join(DEVIN_SETTINGS_FILE));
+        paths.push(root.join(DEVIN_DIR).join(DEVIN_SETTINGS_LOCAL_JSON));
+    }
+    if let Some(dir) = resolve_devin_config_dir() {
+        paths.push(dir.join(DEVIN_SETTINGS_FILE));
+    }
+
+    paths
+}
+
+pub(crate) fn resolve_devin_config_dir() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os(DEVIN_CONFIG_DIR_ENV).filter(|v| !v.is_empty()) {
+        return Some(PathBuf::from(path));
+    }
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME").filter(|v| !v.is_empty()) {
+        return Some(PathBuf::from(xdg).join("devin"));
+    }
+    default_devin_config_dir()
+}
+
+#[cfg(windows)]
+fn default_devin_config_dir() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("devin"))
+}
+
+#[cfg(not(windows))]
+fn default_devin_config_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|d| d.join(".config/devin"))
+}
+
+/// Extract `Exec(<pattern>)` and tool-based `exec` rules from Devin permissions.
+fn append_devin_rules(rules_value: Option<&Value>, target: &mut Vec<String>) {
+    let Some(arr) = rules_value.and_then(|v| v.as_array()) else {
+        return;
+    };
+    for rule in arr.iter().filter_map(|r| r.as_str()) {
+        if rule == "exec" {
+            target.push("*".to_string());
+            continue;
+        }
+        if let Some(inner) = rule.strip_prefix("Exec(").and_then(|s| s.strip_suffix(')')) {
+            let inner = inner.trim();
+            if !inner.is_empty() {
+                target.push(inner.to_string());
+            }
+        }
+    }
 }
 
 fn read_json(path: &std::path::Path) -> Option<Value> {
@@ -334,14 +413,14 @@ pub(crate) fn droid_rules_from_settings(
     (deny, Vec::new(), Vec::new())
 }
 
-/// Locate the project root by walking up from CWD looking for `.claude/`.
+/// Locate the project root by walking up from CWD looking for `.claude/` or `.devin/`.
 ///
 /// Falls back to `git rev-parse --show-toplevel` if not found via directory walk.
 fn find_project_root() -> Option<PathBuf> {
-    // Fast path: walk up CWD looking for .claude/ — no subprocess needed.
+    // Fast path: walk up CWD looking for .claude/ or .devin/ — no subprocess needed.
     let mut dir = std::env::current_dir().ok()?;
     loop {
-        if dir.join(CLAUDE_DIR).exists() {
+        if dir.join(CLAUDE_DIR).exists() || dir.join(DEVIN_DIR).exists() {
             return Some(dir);
         }
         if !dir.pop() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,8 @@ pub enum AgentTarget {
     Hermes,
     /// Factory Droid CLI
     Droid,
+    /// Devin CLI
+    Devin,
 }
 
 #[derive(Parser)]
@@ -866,6 +868,8 @@ enum HookCommands {
     Copilot,
     /// Process Factory Droid PreToolUse hook (reads JSON from stdin)
     Droid,
+    /// Process Devin CLI PreToolUse hook (reads JSON from stdin)
+    Devin,
     /// Check how a command would be rewritten by the hook engine (dry-run)
     Check {
         /// Target agent
@@ -2013,7 +2017,9 @@ fn run_cli() -> Result<i32> {
                 dry_run,
             };
             if show {
-                hooks::init::show_config(codex)?;
+                hooks::init::show_config(codex, agent)?;
+            } else if uninstall && agent == Some(AgentTarget::Devin) {
+                hooks::init::uninstall_devin(global, ctx)?;
             } else if uninstall && copilot {
                 if global {
                     hooks::init::uninstall_copilot_global(ctx)?;
@@ -2068,6 +2074,18 @@ fn run_cli() -> Result<i32> {
                 hooks::init::run_hermes_mode(ctx)?;
             } else if agent == Some(AgentTarget::Droid) {
                 hooks::init::run_droid_mode(global, ctx)?;
+            } else if agent == Some(AgentTarget::Devin) {
+                if codex || gemini || copilot || opencode || claude_md {
+                    anyhow::bail!("--agent devin cannot be combined with --codex, --gemini, --copilot, --opencode, or --claude-md");
+                }
+                let patch_mode = if auto_patch {
+                    hooks::init::PatchMode::Auto
+                } else if no_patch {
+                    hooks::init::PatchMode::Skip
+                } else {
+                    hooks::init::PatchMode::Ask
+                };
+                hooks::init::run_devin_mode(global, patch_mode, ctx)?;
             } else {
                 let install_opencode = opencode;
                 let install_claude = !opencode;
@@ -2436,6 +2454,10 @@ fn run_cli() -> Result<i32> {
             }
             HookCommands::Droid => {
                 hooks::hook_cmd::run_droid()?;
+                0
+            }
+            HookCommands::Devin => {
+                hooks::hook_cmd::run_devin()?;
                 0
             }
             HookCommands::Check { agent: _, command } => {
@@ -2921,6 +2943,17 @@ mod tests {
     }
 
     #[test]
+    fn test_try_parse_init_agent_devin() {
+        let cli = Cli::try_parse_from(["rtk", "init", "--agent", "devin"]).unwrap();
+        match cli.command {
+            Commands::Init { agent, .. } => {
+                assert_eq!(agent, Some(AgentTarget::Devin));
+            }
+            _ => panic!("Expected Init command"),
+        }
+    }
+
+    #[test]
     fn test_try_parse_kubectl_get_alias() {
         let cli = Cli::try_parse_from(["rtk", "kubectl", "get", "pods", "-n", "default"]).unwrap();
 
@@ -3203,6 +3236,17 @@ mod tests {
             cli.command,
             Commands::Hook {
                 command: HookCommands::Claude
+            }
+        ));
+    }
+
+    #[test]
+    fn test_hook_devin_parses() {
+        let cli = Cli::try_parse_from(["rtk", "hook", "devin"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Hook {
+                command: HookCommands::Devin
             }
         ));
     }


### PR DESCRIPTION
<!-- Thanks for contributing -->

## What changed

Adds first-class [Devin CLI](https://docs.devin.ai/cli) support to RTK, following the same hook/rewrite pattern already used for Claude Code, Cursor, Gemini CLI, and Factory Droid.

Files touched:
- `src/hooks/constants.rs` — Devin constants: `.devin`, `hooks.v1.json`, `config.json`, `config.local.json`, matcher `^exec$`, hook command `rtk hook devin`, and `$DEVIN_CONFIG_DIR` override.
- `src/hooks/permissions.rs` — `Host::Devin` and `load_devin_rules()` that read Devin CLI `permissions.allow/ask/deny` from `~/.config/devin/config.json`, `.devin/config.json`, and `.devin/config.local.json`. Supports both `Exec(<pattern>)` and tool-level `"exec"` rules.
- `src/hooks/hook_cmd.rs` — `run_devin()` / `process_devin_payload()` / `devin_response_from_decision()`. Emits the Devin PreToolUse JSON response (`decision` + `hookSpecificOutput.updatedInput.command`). If a command is allowed but RTK has no filter for it, the original command is approved unchanged.
- `src/hooks/init.rs` — `run_devin_mode()`, `uninstall_devin()`, `show_devin_config()`, plus nested/root config patching and `AGENTS.md` instruction injection.
- `src/main.rs` — `AgentTarget::Devin`, `HookCommands::Devin`, and dispatch in `init` and `hook` paths.
- Docs: `README.md`, `INSTALL.md`, `docs/guide/getting-started/supported-agents.md`, `src/hooks/README.md`.
- Tests: new unit and integration tests covering Devin hook responses, BOM handling, permission rules, and the init/uninstall flow.

Closes #3143

## Why

Devin CLI exposes a documented `PreToolUse` hook that fires before the `exec` tool runs:
- [Hooks overview](https://docs.devin.ai/cli/extensibility/hooks/overview)
- [Lifecycle hooks / PreToolUse](https://docs.devin.ai/cli/extensibility/hooks/lifecycle-hooks)
- [Permissions](https://docs.devin.ai/cli/reference/permissions)
- [Config file format](https://docs.devin.ai/cli/reference/configuration/config-file)
- [Global vs project config precedence](https://docs.devin.ai/cli/reference/configuration/global-vs-local)

The hook can return:
- `decision: approve/block` to control execution
- `hookSpecificOutput.updatedInput` to rewrite tool arguments before execution

This is the same shape RTK already uses for Claude Code and Cursor, so a Devin integration fits the existing architecture without adding new dependencies.

### Key design decisions

- Matcher `^exec$` because Devin routes shell commands through the `exec` tool.
- Read `permissions` from Devin's own config files so users do not maintain a second allowlist; `Exec(git status)` in Devin `allow` maps to RTK's `allow` rule for `git status`.
- Support `hooks.v1.json` (root event map) and `config.json`/`config.local.json` (nested under `hooks`) because Devin CLI reads hooks from all of these locations.
- Respect `$DEVIN_CONFIG_DIR`, `XDG_CONFIG_HOME`, and `%APPDATA%` for global config resolution.
- Approve the original command unchanged when RTK has no filter but the user explicitly allowed it, preserving Devin CLI Normal/Bypass/Autonomous mode semantics.

## Testing

### Automated tests

```bash
cargo fmt --all
cargo clippy --all-targets
cargo test --all
```

Result:

```
running 2481 tests
test result: ok. 2473 passed; 0 failed; 8 ignored; 0 measured; 0 filtered out
```

Devin-specific tests added:
- `test_devin_allow_emits_approve_and_rewrite`
- `test_devin_allow_unsupported_approves_original`
- `test_devin_exec_tool_rule_allows_all`
- `test_devin_default_asks_without_decision`
- `test_devin_deny_emits_block`
- `test_devin_passthrough_unsupported`
- `test_devin_already_rtk_passthrough`
- `test_devin_env_prefix_preserved`
- `test_devin_ignores_non_exec_tool`
- `test_devin_empty_command_passthrough`
- `test_devin_malformed_json_passthrough`
- `test_devin_bom_stripped`

### Manual verification

Global install:

```bash
rtk init -g --agent devin --auto-patch
rtk init --agent devin --show
```

Output:

```
rtk Configuration (Devin CLI):

[ok] Global hook: rtk hook devin in /Users/warelik/.config/devin/config.json
[--] Project hook: /Users/warelik/Developer/rtk/.devin/hooks.v1.json not found
[--] Project hook: /Users/warelik/Developer/rtk/.devin/config.json not found
[--] Project hook: /Users/warelik/Developer/rtk/.devin/config.local.json not found
[--] AGENTS.md: not found or no RTK instructions
```

Hook responses:

```bash
$ echo '{"tool_name":"exec","tool_input":{"command":"git status"}}' | rtk hook devin
{"hookSpecificOutput":{"hookEventName":"PreToolUse","updatedInput":{"command":"rtk git status"}},"decision":"approve"}

$ echo '{"tool_name":"exec","tool_input":{"command":"git branch -a"}}' | rtk hook devin
{"hookSpecificOutput":{"hookEventName":"PreToolUse","updatedInput":{"command":"rtk git branch -a"}}}

$ echo '{"tool_name":"exec","tool_input":{"command":"python3 -c \"print(1)\""}}' | rtk hook devin
{"decision":"approve"}

$ echo '{"tool_name":"exec","tool_input":{"command":"htop"}}' | rtk hook devin
# (empty output — Devin CLI applies its own permission mode)

$ echo '{"tool_name":"Read","tool_input":{"file":"foo.txt"}}' | rtk hook devin
# (empty output — non-exec tool passes through)
```

Project install/uninstall round-trip in a temporary directory:

```bash
rtk init --agent devin --auto-patch   # creates .devin/hooks.v1.json + patches AGENTS.md
rtk init --agent devin --uninstall    # removes both
```

## Checklist

- [x] Code style matches existing files (`cargo fmt --all`)
- [x] `cargo clippy --all-targets` passes with no warnings
- [x] `cargo test --all` passes
- [x] No new external dependencies
- [x] Documentation updated (README, INSTALL, supported-agents, hooks/README)
- [x] Backward compatible — does not change existing Claude/Cursor/Gemini/Droid behavior
