### PR TITLE
feat(hooks): Add first-class Devin CLI integration

### DIFF
--- a/.github/hooks/rtk-rewrite.json
+++ b/.github/hooks/rtk-rewrite.json
@@ -1,11 +1,21 @@
 {
+  "version": 1,
   "hooks": {
     "PreToolUse": [
       {
         "type": "command",
-        "command": "rtk hook",
+        "command": "rtk hook copilot",
         "cwd": ".",
         "timeout": 5
+      }
+    ],
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "rtk hook copilot",
+        "powershell": "rtk hook copilot",
+        "cwd": ".",
+        "timeoutSec": 5
       }
     ]
   }

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -323,6 +323,23 @@ rtk gain --graph      # With ASCII graph
 rtk gain --history    # With command history
 ```
 
+## Devin CLI Setup
+
+```bash
+# User-scoped (all Devin projects)
+rtk init -g --agent devin
+
+# Project-scoped (commit .devin/ to share)
+rtk init --agent devin
+
+# Verify
+rtk init --agent devin --show
+```
+
+Installs a `PreToolUse` hook (matcher `^exec$`) into `~/.config/devin/config.json` (global) or `.devin/hooks.v1.json` (project). Respects `$DEVIN_CONFIG_DIR`.
+
+RTK syncs with Devin CLI's own permission settings. Allowed commands are auto-approved and rewritten; blocked commands are blocked; all others are rewritten so Devin CLI can prompt on the rewritten command.
+
 ## What RTK Filters
 
 RTK compresses the output of a shell command before your agent reads it. What that looks like in practice:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -325,6 +325,18 @@ rtk gain --history    # With command history
 
 ## Devin CLI Setup
 
+### One-command install from a fork
+
+```bash
+git clone https://github.com/warelik/rtk.git
+cd rtk
+bash install-devin.sh
+```
+
+This builds `rtk` from source with `cargo install --path .`, then runs `rtk init -g --agent devin --auto-patch` to register the global hooks and lifecycle instructions.
+
+### Manual install (if you already have `rtk`)
+
 ```bash
 # User-scoped (all Devin projects)
 rtk init -g --agent devin

--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ Download from [releases](https://github.com/rtk-ai/rtk/releases):
 
 > **Windows users**: Extract the zip and place `rtk.exe` somewhere in your PATH (e.g. `C:\Users\<you>\.local\bin`). Run RTK from **Command Prompt**, **PowerShell**, or **Windows Terminal** — do not double-click the `.exe` (it will flash and close). The full hook system works natively on Windows (and in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)). See [Windows setup](#windows) below for details.
 
+### Devin CLI (this fork)
+
+One-command install from a cloned fork — builds `rtk` from source and registers the Devin CLI hooks globally.
+
+```bash
+git clone https://github.com/warelik/rtk.git
+cd rtk
+bash install-devin.sh
+```
+
+Then restart Devin CLI and test with `git status`.
+
 ### Verify Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ rtk init --agent kimi           # Kimi AI
 rtk init -g --agent pi          # Pi
 rtk init --agent hermes         # Hermes
 rtk init -g --agent droid       # Factory Droid
+rtk init -g --agent devin       # Devin CLI
 
 # 2. Restart your AI tool, then test
 git status  # Automatically rewritten to rtk git status
@@ -381,7 +382,7 @@ rtk init -g
 
 ## Supported AI Tools
 
-RTK supports 15 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents, reducing the bash output the agent reads where the agent supports command interception.
+RTK supports 15 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents for 60-90% token savings where the agent supports command interception.
 
 | Tool | Install | Method |
 |------|---------|--------|
@@ -402,6 +403,7 @@ RTK supports 15 AI coding tools. Each integration rewrites shell commands to `rt
 | **Google Antigravity** | `rtk init --agent antigravity` | .agents/rules/antigravity-rtk-rules.md (project-scoped) |
 | **Kimi AI** | `rtk init --agent kimi` | AGENTS.md (project-scoped) |
 | **Factory Droid** | `rtk init -g --agent droid` (or per-project) | PreToolUse hook in `~/.factory/hooks.json` (matcher `Execute`) |
+|| **Devin CLI** | `rtk init -g --agent devin` (or per-project) | PreToolUse hook in `~/.config/devin/config.json`, `.devin/config.json`, `.devin/config.local.json` or `.devin/hooks.v1.json` (matcher `exec`) |
 
 For per-agent setup details, override controls, and graceful degradation, see the [Supported Agents guide](https://www.rtk-ai.app/guide/getting-started/supported-agents). The Hermes plugin source and tests live in `hooks/hermes/`; installed Hermes runtime files still live under `~/.hermes/plugins/rtk-rewrite/`.
 

--- a/docs/guide/devin-cli.md
+++ b/docs/guide/devin-cli.md
@@ -1,0 +1,118 @@
+---
+title: Devin CLI
+description: One-command setup and reference for RTK + Devin CLI integration
+sidebar:
+  order: 5
+---
+
+# Devin CLI Integration
+
+RTK integrates with [Devin CLI](https://docs.devin.ai/get-started) through a `PreToolUse` hook and a small set of lifecycle context hooks. Any allowed `exec` tool call is rewritten to `rtk <command>` before it reaches the shell, giving you compact output without per-command prompting.
+
+## One-command install from a fork
+
+```bash
+git clone https://github.com/warelik/rtk.git
+cd rtk
+bash install-devin.sh
+```
+
+`install-devin.sh` does two things:
+
+1. Builds and installs the `rtk` binary with `cargo install --path .`.
+2. Registers the global Devin CLI hooks with `rtk init -g --agent devin --auto-patch`.
+
+After it finishes, restart Devin CLI and test with:
+
+```bash
+git status
+```
+
+## Manual setup
+
+If you already have `rtk` installed from another source:
+
+```bash
+# Global (all Devin projects)
+rtk init -g --agent devin
+
+# Per-project (commit .devin/ to share with teammates)
+rtk init --agent devin
+```
+
+## What gets installed
+
+| Scope | Files / entries |
+|-------|-----------------|
+| Global | `~/.config/devin/config.json` — `PreToolUse` hook + `SessionStart` / `UserPromptSubmit` / `PostCompaction` lifecycle hooks |
+| Global | `~/.config/devin/hooks/rtk/rtk-devin.js` — lifecycle hook runner |
+| Global | `~/.config/devin/hooks/rtk/rtk-instructions.md` — RTK context injected into Devin |
+| Global | `~/Library/Application Support/rtk/filters.toml` (macOS) or `~/.config/rtk/filters.toml` (Linux) — filter template |
+| Project | `.devin/hooks.v1.json` or `.devin/config.json` — same hooks, scoped to the project |
+| Project | `.devin/hooks/rtk/rtk-devin.js` + `rtk-instructions.md` |
+
+The project-level paths use `$DEVIN_PROJECT_DIR` so they remain portable when committed.
+
+## Verify
+
+```bash
+rtk init --agent devin --show   # show detected config state
+rtk verify                        # check hook file integrity + filter tests
+```
+
+`rtk verify` now checks both the Claude-style native hook and the Devin CLI lifecycle files against the source-of-truth content embedded in the `rtk` binary.
+
+## How the rewrite works
+
+Devin CLI sends a JSON payload to the hook:
+
+```json
+{
+  "tool_name": "exec",
+  "tool_input": { "command": "git status" }
+}
+```
+
+RTK rewrites it to:
+
+```json
+{
+  "tool_name": "exec",
+  "tool_input": { "command": "rtk git status" }
+}
+```
+
+For commands that Devin CLI already allows, RTK also emits `permissionDecision: "approve"` so the user is not prompted twice. Blocked commands are blocked; unknown commands are rewritten without auto-approval so Devin CLI can ask on the rewritten command.
+
+## Escape hatches
+
+- `RTK_DISABLED=1 <command>` — bypass RTK rewriting for a single command.
+- `rtk proxy <command>` — run the raw command without filtering (still subject to Devin CLI permission checks).
+- `rtk <meta>` (`rtk gain`, `rtk --version`, `rtk discover`) — automatically approved.
+
+## Uninstall
+
+```bash
+# Remove global Devin CLI hooks
+rtk init -g --agent devin --uninstall
+
+# Remove binary (if installed via cargo)
+cargo uninstall rtk
+```
+
+## Test suite
+
+The Devin CLI hook has a regression suite:
+
+```bash
+bash hooks/devin/test-rtk-devin.sh
+```
+
+It covers rewrite patterns, environment-prefix handling, meta commands, wrappers, `RTK_DISABLED`, and commands that should not be rewritten.
+
+## Troubleshooting
+
+- `rtk command not found` after `install-devin.sh` — make sure `$HOME/.cargo/bin` is on your PATH.
+- `permission denied` on `install-devin.sh` — it should be executable; otherwise run `bash install-devin.sh`.
+- Hook not firing — restart Devin CLI after `rtk init`.
+- Changed hook files — `rtk verify` will flag tampering or version skew; re-run `rtk init -g --agent devin --auto-patch` to restore.

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -38,7 +38,7 @@ Agent runs "cargo test"
 | Pi | TypeScript extension (`tool_call` event) | Yes |
 | Hermes | Python plugin (`terminal` command mutation) | Yes |
 | Factory Droid | Shell hook (`PreToolUse`, matcher `Execute`) | Yes |
-| Devin CLI | Shell hook (`PreToolUse`, matcher `exec`) | Yes |
+| Devin CLI | Shell hook (`PreToolUse` + lifecycle context hooks, matcher `exec`) | Yes |
 | Cline / Roo Code | Rules file (prompt-level) | N/A |
 | Windsurf | Rules file (prompt-level) | N/A |
 | Codex CLI | AGENTS.md instructions | N/A |
@@ -166,9 +166,11 @@ rtk init -g --agent devin    # user-scoped (~/.config/devin/config.json)
 rtk init --agent devin       # project-scoped (.devin/hooks.v1.json, commit to share)
 ```
 
-Installs a `PreToolUse` hook (matcher `^exec$`) into Devin CLI's hook config. RTK picks an existing Devin hook file when possible (`.devin/hooks.v1.json`, `.devin/config.json`, or `.devin/config.local.json` for project; `~/.config/devin/config.json` for global), and respects `$DEVIN_CONFIG_DIR`.
+Installs a `PreToolUse` hook (matcher `^exec$`) **and lifecycle context hooks** (`SessionStart`, `UserPromptSubmit`, `PostCompaction`) into Devin CLI's hook config. RTK picks an existing Devin hook file when possible (`.devin/hooks.v1.json`, `.devin/config.json`, or `.devin/config.local.json` for project; `~/.config/devin/config.json` for global), and respects `$DEVIN_CONFIG_DIR`.
 
-RTK reads Devin CLI's own `permissions` settings (`allow`/`ask`/`deny`) from `~/.config/devin/config.json`, `.devin/config.json`, and `.devin/config.local.json`. Rules like `Exec(git)` or tool-level `"exec"` are mapped to RTK's permission check. Allowed commands emit `decision: approve` plus the rewritten `updatedInput`; denied commands emit `decision: block`; everything else is rewritten via `updatedInput` without a decision so Devin CLI prompts on the rewritten command. If an existing project `AGENTS.md` is present, RTK appends a short instructions block encouraging use of `rtk read`/`rtk grep`/`rtk find` for Devin CLI built-ins.
+The lifecycle hooks run a small Node script (`rtk-devin.js`) that injects `rtk-instructions.md` into Devin CLI's context, so RTK usage guidance and escape hatches (e.g. `RTK_DISABLED=1`) survive compaction and are refreshed at the start of every session and user prompt. Devin CLI is intentionally **hook-first**; no `AGENTS.md`/`RTK.md` block is written.
+
+RTK reads Devin CLI's own `permissions` settings (`allow`/`ask`/`deny`) from `~/.config/devin/config.json`, `.devin/config.json`, and `.devin/config.local.json`. Rules like `Exec(git)` or tool-level `"exec"` are mapped to RTK's permission check. Allowed commands emit `decision: approve` plus the rewritten `updatedInput`; denied commands emit `decision: block`; everything else is rewritten via `updatedInput` without a decision so Devin CLI prompts on the rewritten command.
 
 Uninstall:
 
@@ -177,7 +179,7 @@ rtk init --uninstall -g --agent devin
 rtk init --uninstall --agent devin
 ```
 
-Removes only RTK's hook entry and the AGENTS.md block; other hooks and settings are untouched.
+Removes RTK's hook entries, lifecycle hook files (`rtk-devin.js`, `rtk-instructions.md`), and runtime state (`.rtk-active`); other hooks and settings are untouched.
 
 ### Cline / Roo Code
 

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -38,6 +38,7 @@ Agent runs "cargo test"
 | Pi | TypeScript extension (`tool_call` event) | Yes |
 | Hermes | Python plugin (`terminal` command mutation) | Yes |
 | Factory Droid | Shell hook (`PreToolUse`, matcher `Execute`) | Yes |
+| Devin CLI | Shell hook (`PreToolUse`, matcher `exec`) | Yes |
 | Cline / Roo Code | Rules file (prompt-level) | N/A |
 | Windsurf | Rules file (prompt-level) | N/A |
 | Codex CLI | AGENTS.md instructions | N/A |
@@ -157,6 +158,26 @@ rtk init --uninstall --agent droid
 ```
 
 Removes only RTK's hook entry; other hooks and settings are untouched.
+
+### Devin CLI
+
+```bash
+rtk init -g --agent devin    # user-scoped (~/.config/devin/config.json)
+rtk init --agent devin       # project-scoped (.devin/hooks.v1.json, commit to share)
+```
+
+Installs a `PreToolUse` hook (matcher `^exec$`) into Devin CLI's hook config. RTK picks an existing Devin hook file when possible (`.devin/hooks.v1.json`, `.devin/config.json`, or `.devin/config.local.json` for project; `~/.config/devin/config.json` for global), and respects `$DEVIN_CONFIG_DIR`.
+
+RTK reads Devin CLI's own `permissions` settings (`allow`/`ask`/`deny`) from `~/.config/devin/config.json`, `.devin/config.json`, and `.devin/config.local.json`. Rules like `Exec(git)` or tool-level `"exec"` are mapped to RTK's permission check. Allowed commands emit `decision: approve` plus the rewritten `updatedInput`; denied commands emit `decision: block`; everything else is rewritten via `updatedInput` without a decision so Devin CLI prompts on the rewritten command. If an existing project `AGENTS.md` is present, RTK appends a short instructions block encouraging use of `rtk read`/`rtk grep`/`rtk find` for Devin CLI built-ins.
+
+Uninstall:
+
+```bash
+rtk init --uninstall -g --agent devin
+rtk init --uninstall --agent devin
+```
+
+Removes only RTK's hook entry and the AGENTS.md block; other hooks and settings are untouched.
 
 ### Cline / Roo Code
 

--- a/docs/upstream/issue-devin-cli.md
+++ b/docs/upstream/issue-devin-cli.md
@@ -1,0 +1,50 @@
+# Upstream issue draft: Add Devin CLI support
+
+## Title
+feat(hooks): Add first-class Devin CLI integration
+
+## Description
+
+Devin CLI (https://docs.devin.ai/get-started) is a command-line interface for the Devin autonomous coding agent. It exposes a `PreToolUse` hook system and lifecycle hooks (`SessionStart`, `UserPromptSubmit`, `PostCompaction`) that are a natural fit for RTK's command interception model.
+
+### Goal
+
+Add native Devin CLI support to RTK so that shell commands invoked by Devin CLI are transparently rewritten to `rtk <command>`, producing compact output without per-command prompting.
+
+### Why this matters
+
+- Devin CLI users currently miss out on RTK's token savings because there is no hook integration.
+- Devin CLI already has its own `permissions` model (`allow`/`ask`/`deny`). RTK can respect it, so allowed commands stay auto-approved, denied commands stay blocked, and unknown commands are rewritten so Devin CLI prompts on the rewritten command.
+- Hook-based integration is the most effective RTK delivery mechanism (100% adoption across all conversations and subagents with zero per-command context overhead).
+
+### Proposed behavior
+
+```bash
+rtk init -g --agent devin   # global install
+rtk init --agent devin      # project install
+rtk init --agent devin --show
+rtk init --agent devin --uninstall
+```
+
+Installs:
+- A `PreToolUse` hook (matcher `^exec$`) into `~/.config/devin/config.json` (global) or `.devin/hooks.v1.json` / `.devin/config.json` (project).
+- Lifecycle context hooks that inject `rtk-instructions.md` into Devin CLI context on `SessionStart`, `UserPromptSubmit`, and `PostCompaction`.
+- A portable Node lifecycle script (`rtk-devin.js`) and instruction file (`rtk-instructions.md`).
+
+`rtk hook devin` reads the JSON payload from Devin CLI, rewrites supported commands, and emits `permissionDecision` when Devin CLI's own permission settings allow the command.
+
+### Acceptance criteria
+
+- [ ] `rtk init -g --agent devin` installs the global hook and lifecycle instructions.
+- [ ] `rtk init --agent devin` installs project-scoped hooks (portable paths using `$DEVIN_PROJECT_DIR`).
+- [ ] `rtk hook devin` correctly rewrites `git status`, `cargo test`, `docker ps`, etc. to `rtk <command>`.
+- [ ] Allowed commands emit `decision: approve`; denied commands emit `decision: block`.
+- [ ] `RTK_DISABLED=1 <cmd>` bypasses rewriting.
+- [ ] `rtk verify` checks the integrity of the installed Devin CLI hook files.
+- [ ] `rtk init --agent devin --uninstall` removes RTK entries and hook files without touching user hooks.
+- [ ] A regression test suite exists for the Devin CLI hook (`hooks/devin/test-rtk-devin.sh`).
+- [ ] Documentation is updated (`README.md`, `INSTALL.md`, `docs/guide/getting-started/supported-agents.md`, plus a dedicated `docs/guide/devin-cli.md`).
+
+### Related
+
+This would bring Devin CLI to parity with Claude Code, Cursor, Gemini CLI, Codex, GitHub Copilot, Factory Droid, and the other agents already supported by RTK.

--- a/docs/upstream/pr-copilot-hook-fix.md
+++ b/docs/upstream/pr-copilot-hook-fix.md
@@ -1,0 +1,20 @@
+# Upstream PR draft: Fix stale command in `.github/hooks/rtk-rewrite.json`
+
+## Title
+fix(github): update copilot hook json to use `rtk hook copilot`
+
+## Summary
+
+The repository's `.github/hooks/rtk-rewrite.json` still references the legacy `rtk hook` command. This PR updates it to `rtk hook copilot` and adds the `preToolUse` entry used by Copilot CLI, matching the format written by `rtk init -g --copilot`.
+
+## Changes
+
+- `.github/hooks/rtk-rewrite.json`
+  - `command` changed from `rtk hook` to `rtk hook copilot`.
+  - Added `version: 1`.
+  - Added `preToolUse` block with `bash` / `powershell` variants for Copilot CLI.
+
+## Test plan
+
+- [ ] `rtk init -g --copilot` produces the same JSON structure as `.github/hooks/rtk-rewrite.json`.
+- [ ] `rtk verify` (if checking copilot hooks) passes.

--- a/docs/upstream/pr-devin-cli.md
+++ b/docs/upstream/pr-devin-cli.md
@@ -7,6 +7,8 @@ feat(hooks): Add first-class Devin CLI integration
 
 Adds native support for [Devin CLI](https://docs.devin.ai/get-started) via a `PreToolUse` hook and lifecycle context hooks. Devin CLI shell commands are rewritten to `rtk <command>` whenever RTK has a filter, with decisions (`approve` / `block`) synced to Devin CLI's own permission settings.
 
+Closes #3205
+
 ## Changes
 
 - `src/hooks/hook_cmd.rs`
@@ -30,6 +32,8 @@ Adds native support for [Devin CLI](https://docs.devin.ai/get-started) via a `Pr
   - Update Devin CLI docs and supported-agents table.
 - `docs/guide/devin-cli.md`
   - New dedicated Devin CLI setup and troubleshooting guide.
+- `.github/hooks/rtk-rewrite.json`
+  - Fix stale `rtk hook` command to `rtk hook copilot` and add the `preToolUse` schema used by Copilot CLI.
 
 ## Test plan
 

--- a/docs/upstream/pr-devin-cli.md
+++ b/docs/upstream/pr-devin-cli.md
@@ -7,7 +7,12 @@ feat(hooks): Add first-class Devin CLI integration
 
 Adds native support for [Devin CLI](https://docs.devin.ai/get-started) via a `PreToolUse` hook and lifecycle context hooks. Devin CLI shell commands are rewritten to `rtk <command>` whenever RTK has a filter, with decisions (`approve` / `block`) synced to Devin CLI's own permission settings.
 
-Closes #3205
+Closes #3143
+
+## Related
+
+- #3143 — original feature request for Devin CLI support.
+- #2605, #1851 — earlier community attempts at Devin integration (kept open as related references).
 
 ## Changes
 

--- a/docs/upstream/pr-devin-cli.md
+++ b/docs/upstream/pr-devin-cli.md
@@ -1,0 +1,67 @@
+# Upstream PR draft: Add Devin CLI support
+
+## Title
+feat(hooks): Add first-class Devin CLI integration
+
+## Summary
+
+Adds native support for [Devin CLI](https://docs.devin.ai/get-started) via a `PreToolUse` hook and lifecycle context hooks. Devin CLI shell commands are rewritten to `rtk <command>` whenever RTK has a filter, with decisions (`approve` / `block`) synced to Devin CLI's own permission settings.
+
+## Changes
+
+- `src/hooks/hook_cmd.rs`
+  - New `process_devin_payload`, `devin_decide_for_command`, `devin_decide_explicit_rtk`, and helpers for explicit `rtk <meta>` / `rtk proxy <cmd>` / `rtk <allowed>` handling.
+- `src/hooks/init.rs`
+  - `run_devin_mode`, `uninstall_devin`, `show_devin_config`, `devin_rtk_hook_dir`, `write_devin_hook_files`, and helpers to patch/remove Devin CLI hook config.
+  - Writes `rtk-devin.js`, `rtk-instructions.md`, and `.gitignore` to the RTK hook directory.
+- `src/hooks/integrity.rs`
+  - `run_verify_devin` and `verify_devin_hook_dir` verify installed Devin lifecycle files against the source-of-truth content embedded in the binary.
+- `src/hooks/permissions.rs`
+  - `load_devin_rules` and `get_devin_settings_paths` read Devin CLI `permissions.allow/ask/deny` from `~/.config/devin/config.json` and `.devin/config.json*`.
+- `src/hooks/constants.rs`
+  - Adds `DEVIN_*` constants (matcher, hook command, config dir env).
+- `src/main.rs`
+  - Adds `AgentTarget::Devin` and `HookCommands::Devin`, wires `rtk verify` to run Devin integrity checks.
+- `hooks/devin/rtk-devin.js`, `hooks/devin/rtk-instructions.md`, `hooks/devin/rtk-awareness.md`
+  - New source-of-truth lifecycle hook files, included at build time via `include_str!`.
+- `hooks/devin/test-rtk-devin.sh`
+  - 34-test regression suite for the Devin CLI hook.
+- `docs/guide/getting-started/supported-agents.md`, `README.md`, `INSTALL.md`
+  - Update Devin CLI docs and supported-agents table.
+- `docs/guide/devin-cli.md`
+  - New dedicated Devin CLI setup and troubleshooting guide.
+
+## Test plan
+
+- [ ] `cargo test` passes (2505+ tests).
+- [ ] `cargo clippy --all-targets` passes with no warnings.
+- [ ] `bash hooks/devin/test-rtk-devin.sh` passes (34/34).
+- [ ] Clean install: clone fork, run `bash install-devin.sh`, restart Devin CLI, run `git status` → should execute `rtk git status`.
+- [ ] `rtk verify` reports `PASS` for Devin CLI global and project hook files.
+- [ ] `rtk init -g --agent devin --uninstall` removes RTK entries and hook files without touching other hooks.
+
+## Usage
+
+```bash
+# One-command install from the fork
+git clone https://github.com/warelik/rtk.git
+cd rtk
+bash install-devin.sh
+
+# Or, if rtk is already installed
+rtk init -g --agent devin
+```
+
+Then restart Devin CLI and test with `git status`.
+
+## Backwards compatibility
+
+- No existing integrations are changed.
+- Devin CLI is opt-in via `--agent devin`.
+- Lifecycle hooks are idempotent; re-running `rtk init -g --agent devin` is safe.
+
+## Notes for reviewers
+
+- This PR intentionally takes a hook-first approach: no `AGENTS.md`/`RTK.md` injection is written, matching Devin CLI's native hook architecture.
+- The lifecycle script uses a small state file (`.rtk-active`) to avoid re-injecting the full instruction block on every user prompt while still re-injecting after context compaction.
+- Devin CLI config can be overridden with `$DEVIN_CONFIG_DIR`, and project hook files use `$DEVIN_PROJECT_DIR` for portability.

--- a/hooks/devin/rtk-awareness.md
+++ b/hooks/devin/rtk-awareness.md
@@ -1,0 +1,61 @@
+<!-- rtk-instructions -->
+# RTK - Rust Token Killer
+
+**Usage**: Token-optimized CLI proxy (cuts up to 90% of bash output)
+
+## How Devin CLI uses RTK
+
+The Devin CLI `PreToolUse` hook automatically rewrites supported shell commands to `rtk <command>` before execution. Unsupported commands pass through unchanged, so prefixing with `rtk` is always safe.
+
+## Meta Commands (always use rtk directly)
+
+```bash
+rtk gain              # Show token savings analytics
+rtk gain --history    # Show command usage history with savings
+rtk discover          # Analyze Devin CLI history for missed opportunities
+rtk proxy <cmd>       # Execute raw command without filtering (for debugging)
+```
+
+## Installation Verification
+
+```bash
+rtk --version         # Should show: rtk X.Y.Z
+rtk gain              # Should work (not "command not found")
+which rtk             # Verify correct binary
+```
+
+⚠️ **Name collision**: If `rtk gain` fails, you may have reachingforthejack/rtk (Rust Type Kit) installed instead.
+
+## Common Commands to Run Through RTK
+
+```bash
+rtk git status
+rtk git log
+rtk git diff
+rtk git add
+rtk git commit
+rtk git push
+rtk cargo test
+rtk cargo build
+rtk cargo clippy
+rtk jest
+rtk vitest
+rtk pytest
+rtk ls
+rtk grep
+rtk find
+rtk read
+rtk docker ps
+rtk docker logs
+rtk kubectl get
+rtk kubectl logs
+rtk gh pr view
+rtk gh run list
+```
+
+Prefix any shell command with `rtk` to get compact output. If RTK has no filter for it, the command runs unchanged.
+
+## Permission Sync
+
+RTK reads `permissions.allow/ask/deny` from Devin CLI's own config files (`.devin/config.json`, `.devin/config.local.json`, `~/.config/devin/config.json`). Allowed commands are auto-approved and rewritten; denied commands are blocked; all others are rewritten so Devin CLI can prompt on the rewritten command.
+<!-- /rtk-instructions -->

--- a/hooks/devin/rtk-devin.js
+++ b/hooks/devin/rtk-devin.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// rtk — Devin CLI lifecycle hook adapter
+// Injects RTK instructions into context on SessionStart/UserPromptSubmit/PostCompaction.
+// The actual command rewriting is done by the PreToolUse hook "rtk hook devin".
+//
+// Uses a small state file to avoid re-injecting the full instruction block on
+// every user prompt, while still re-injecting after context compaction.
+
+const fs = require('fs');
+const path = require('path');
+
+const EVENT = process.argv[2] || 'SessionStart';
+const STATE_FILE = path.join(__dirname, '.rtk-active');
+const TTL_MS = 60 * 60 * 1000; // re-inject at least once per hour
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let input = '';
+    let done = false;
+    function finish() {
+      if (done) return;
+      done = true;
+      resolve(input);
+    }
+    process.stdin.on('data', (chunk) => { input += chunk; });
+    process.stdin.on('end', finish);
+    process.stdin.on('error', finish);
+    setTimeout(finish, 500).unref();
+  });
+}
+
+function shouldInject() {
+  if (EVENT === 'SessionStart' || EVENT === 'PostCompaction') {
+    return true;
+  }
+  try {
+    const stat = fs.statSync(STATE_FILE);
+    const age = Date.now() - stat.mtimeMs;
+    if (age < TTL_MS) {
+      return false;
+    }
+  } catch (e) {
+    // State missing or unreadable: inject.
+  }
+  return true;
+}
+
+function markActive() {
+  try {
+    fs.writeFileSync(STATE_FILE, EVENT);
+  } catch (e) {
+    // Best-effort: don't block the session.
+  }
+}
+
+function instructionsPath() {
+  return path.join(__dirname, 'rtk-instructions.md');
+}
+
+async function main() {
+  // Only inject instructions on context-carrying lifecycle events.
+  if (!['SessionStart', 'UserPromptSubmit', 'PostCompaction'].includes(EVENT)) {
+    return;
+  }
+
+  await readStdin(); // consume stdin (e.g. prompt or source), content not needed
+
+  if (!shouldInject()) {
+    return;
+  }
+
+  let context;
+  try {
+    context = fs.readFileSync(instructionsPath(), 'utf8');
+  } catch (e) {
+    // Fail silently so the session is not blocked if the instructions file is missing.
+    return;
+  }
+
+  markActive();
+
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: EVENT,
+      additionalContext: context,
+    },
+  };
+  process.stdout.write(JSON.stringify(output));
+}
+
+main().catch(() => { /* best-effort: never block the session */ });

--- a/hooks/devin/rtk-instructions.md
+++ b/hooks/devin/rtk-instructions.md
@@ -1,0 +1,57 @@
+# RTK - Rust Token Killer
+
+**Usage**: Token-optimized CLI proxy (cuts up to 90% of bash output).
+
+## How Devin CLI uses RTK
+
+A `PreToolUse` hook intercepts every `exec` (shell) command and rewrites it to `rtk <command>` whenever RTK has a filter. Use normal command names (`git status`, `cargo test`, `cat file.md`, `grep pattern .`, `find . -name '*.rs'`, `ls`, etc.) — the hook converts them automatically. Only call `rtk` directly for meta commands (`rtk gain`, `rtk proxy`, etc.) or when the hook has no matching rewrite.
+
+## Meta / always use RTK directly
+
+```bash
+rtk gain                 # Show token savings summary
+rtk gain --history       # Show savings + command history
+rtk discover             # Find missed RTK opportunities (Claude Code history)
+rtk proxy <cmd>          # Run raw command without filtering, still tracked
+rtk run <cmd>            # Run via sh -c (raw, no filtering or tracking)
+rtk pipe                 # Read stdin, apply RTK filter, print
+rtk trust                # Trust project-local .rtk/filters.toml
+rtk untrust              # Revoke trust for project filters
+rtk verify               # Verify hook integrity / TOML filter tests
+rtk config               # Show or create RTK config
+```
+
+## Common commands auto-rewritten by the hook
+
+```bash
+git status, git log, git diff, git add, git commit, git push
+cargo test, cargo build, cargo clippy, cargo install
+npm run, npx, pnpm, bun, yarn
+jest, vitest, pytest, playwright
+tsc, eslint, prettier, lint, format, ruff, mypy
+docker ps, docker logs, docker build, docker compose
+kubectl get, kubectl logs, kubectl describe
+gh pr view, gh run list, gh issue list
+glab ...
+aws ...
+psql ...
+curl ...
+find . -name '*.rs'
+grep pattern . -r
+cat file.md
+ls, tree, wc, wget
+```
+
+For the full command list run `rtk --help`.
+
+## Permission Sync
+
+RTK reads `permissions.allow/ask/deny` from Devin CLI's own config files (`.devin/config.json`, `.devin/config.local.json`, `~/.config/devin/config.json`). Allowed commands are auto-approved and rewritten; denied commands are blocked; everything else is rewritten so Devin CLI can prompt on the rewritten command.
+
+## Escape hatches
+
+- `RTK_DISABLED=1 <cmd>` — run raw command without RTK rewrite.
+- `rtk proxy <cmd>` — run raw but track usage in `rtk gain --history`.
+- `rtk run <cmd>` — fully raw, no tracking.
+
+When you call `rtk` directly, prefix a shell command with `rtk` to get compact output. If RTK has no filter for it, the command runs unchanged.

--- a/hooks/devin/test-rtk-devin.sh
+++ b/hooks/devin/test-rtk-devin.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# Test suite for the Devin CLI RTK PreToolUse hook.
+# Feeds mock JSON through `rtk hook devin` and verifies decisions/rewrites.
+#
+# Usage: bash hooks/devin/test-rtk-devin.sh
+# Or from an installed hook dir: bash ~/.config/devin/hooks/rtk/test-rtk-devin.sh
+
+HOOK="${HOOK:-rtk hook devin}"
+PASS=0
+FAIL=0
+TOTAL=0
+
+# Isolate from the user's global Devin permissions so tests are deterministic.
+# Devin still picks up project .devin/config.json* if present, but those should
+# be empty/nonexistent in the test context.
+TEST_CONFIG_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_CONFIG_DIR"' EXIT
+export DEVIN_CONFIG_DIR="$TEST_CONFIG_DIR"
+
+# Colors
+GREEN='\033[32m'
+RED='\033[31m'
+DIM='\033[2m'
+RESET='\033[0m'
+
+payload() {
+  local cmd="$1"
+  jq -n --arg cmd "$cmd" '{"tool_name":"exec","tool_input":{"command":$cmd}}'
+}
+
+test_rewrite() {
+  local description="$1"
+  local input_cmd="$2"
+  local expected_cmd="$3"  # empty string = expect no rewrite
+  TOTAL=$((TOTAL + 1))
+
+  local output
+  output=$(payload "$input_cmd" | $HOOK 2>/dev/null) || true
+
+  if [ -z "$expected_cmd" ]; then
+    if [ -z "$output" ]; then
+      printf "  ${GREEN}PASS${RESET} %s ${DIM}→ (no rewrite)${RESET}\n" "$description"
+      PASS=$((PASS + 1))
+    else
+      local actual
+      actual=$(echo "$output" | jq -r '.hookSpecificOutput.updatedInput.command // empty' 2>/dev/null)
+      printf "  ${RED}FAIL${RESET} %s\n" "$description"
+      printf "       expected: (no rewrite)\n"
+      printf "       actual:   %s\n" "$actual"
+      FAIL=$((FAIL + 1))
+    fi
+  else
+    local actual
+    actual=$(echo "$output" | jq -r '.hookSpecificOutput.updatedInput.command // empty' 2>/dev/null)
+    if [ "$actual" = "$expected_cmd" ]; then
+      printf "  ${GREEN}PASS${RESET} %s ${DIM}→ %s${RESET}\n" "$description" "$actual"
+      PASS=$((PASS + 1))
+    else
+      printf "  ${RED}FAIL${RESET} %s\n" "$description"
+      printf "       expected: %s\n" "$expected_cmd"
+      printf "       actual:   %s\n" "$actual"
+      FAIL=$((FAIL + 1))
+    fi
+  fi
+}
+
+test_decision() {
+  local description="$1"
+  local input_cmd="$2"
+  local expected_decision="$3"  # approve / block / none
+  TOTAL=$((TOTAL + 1))
+
+  local output
+  output=$(payload "$input_cmd" | $HOOK 2>/dev/null) || true
+
+  local actual
+  if [ -z "$output" ]; then
+    actual="none"
+  else
+    actual=$(echo "$output" | jq -r '.decision // "none"' 2>/dev/null || echo "none")
+  fi
+
+  if [ "$actual" = "$expected_decision" ]; then
+    printf "  ${GREEN}PASS${RESET} %s ${DIM}→ decision=%s${RESET}\n" "$description" "$actual"
+    PASS=$((PASS + 1))
+  else
+    printf "  ${RED}FAIL${RESET} %s\n" "$description"
+    printf "       expected decision: %s\n" "$expected_decision"
+    printf "       actual decision:   %s\n" "$actual"
+    printf "       output:            %s\n" "$output"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "============================================"
+echo "  Devin CLI RTK Hook Test Suite"
+echo "============================================"
+echo ""
+
+# ---- SECTION 1: Existing patterns (regression) ----
+echo "--- Existing patterns (regression) ---"
+test_rewrite "git status" \
+  "git status" \
+  "rtk git status"
+
+test_rewrite "git log --oneline -10" \
+  "git log --oneline -10" \
+  "rtk git log --oneline -10"
+
+test_rewrite "git diff HEAD" \
+  "git diff HEAD" \
+  "rtk git diff HEAD"
+
+test_rewrite "git show abc123" \
+  "git show abc123" \
+  "rtk git show abc123"
+
+test_rewrite "git add ." \
+  "git add ." \
+  "rtk git add ."
+
+test_rewrite "cargo test" \
+  "cargo test" \
+  "rtk cargo test"
+
+test_rewrite "cargo build" \
+  "cargo build" \
+  "rtk cargo build"
+
+test_rewrite "cargo clippy --all-targets" \
+  "cargo clippy --all-targets" \
+  "rtk cargo clippy --all-targets"
+
+test_rewrite "ls -la" \
+  "ls -la" \
+  "rtk ls -la"
+
+test_rewrite "find . -name '*.rs'" \
+  "find . -name '*.rs'" \
+  "rtk find . -name '*.rs'"
+
+test_rewrite "grep -rn pattern src/" \
+  "grep -rn pattern src/" \
+  "rtk grep -rn pattern src/"
+
+test_rewrite "rg pattern src/" \
+  "rg pattern src/" \
+  "rtk rg pattern src/"
+
+test_rewrite "docker ps" \
+  "docker ps" \
+  "rtk docker ps"
+
+test_rewrite "docker compose logs web" \
+  "docker compose logs web" \
+  "rtk docker compose logs web"
+
+test_rewrite "kubectl get pods" \
+  "kubectl get pods" \
+  "rtk kubectl get pods"
+
+test_rewrite "gh pr list" \
+  "gh pr list" \
+  "rtk gh pr list"
+
+test_rewrite "npx playwright test" \
+  "npx playwright test" \
+  "rtk playwright test"
+
+test_rewrite "npx vitest" \
+  "npx vitest" \
+  "rtk vitest"
+
+test_rewrite "npx jest" \
+  "npx jest" \
+  "rtk jest"
+
+test_rewrite "npm run test:e2e" \
+  "npm run test:e2e" \
+  "rtk npm run test:e2e"
+
+echo ""
+
+# ---- SECTION 2: Env var prefix handling ----
+echo "--- Env var prefix handling ---"
+test_rewrite "env + git status" \
+  "GIT_PAGER=cat git status" \
+  "GIT_PAGER=cat rtk git status"
+
+test_rewrite "multi env + vitest" \
+  "NODE_ENV=test CI=1 npx vitest" \
+  "NODE_ENV=test CI=1 rtk vitest"
+
+echo ""
+
+# ---- SECTION 3: RTK meta commands ----
+echo "--- RTK meta commands (should be auto-approved) ---"
+test_decision "rtk gain" \
+  "rtk gain" \
+  "approve"
+
+test_decision "rtk --version" \
+  "rtk --version" \
+  "approve"
+
+test_decision "rtk discover" \
+  "rtk discover" \
+  "approve"
+
+echo ""
+
+# ---- SECTION 4: Already RTK / wrappers ----
+echo "--- Already RTK and wrappers ---"
+test_rewrite "rtk git status" \
+  "rtk git status" \
+  "rtk git status"
+
+test_decision "rtk proxy git status (no allow, deferred)" \
+  "rtk proxy git status" \
+  "none"
+
+echo ""
+
+# ---- SECTION 5: RTK_DISABLED ----
+echo "--- RTK_DISABLED (#escape hatch) ---"
+test_rewrite "RTK_DISABLED=1 git status (no rewrite)" \
+  "RTK_DISABLED=1 git status" \
+  ""
+
+test_rewrite "FOO=1 RTK_DISABLED=1 cargo test (no rewrite)" \
+  "FOO=1 RTK_DISABLED=1 cargo test" \
+  ""
+
+echo ""
+
+# ---- SECTION 6: Should NOT rewrite ----
+echo "--- Should NOT rewrite ---"
+test_rewrite "heredoc" \
+  "cat <<'EOF'
+hello
+EOF" \
+  ""
+
+test_rewrite "echo (no pattern)" \
+  "echo hello world" \
+  ""
+
+test_rewrite "cd (no pattern)" \
+  "cd /tmp" \
+  ""
+
+test_rewrite "mkdir (no pattern)" \
+  "mkdir -p foo/bar" \
+  ""
+
+test_rewrite "python3 script.py (no pattern)" \
+  "python3 script.py" \
+  ""
+
+echo ""
+
+# ---- SUMMARY ----
+echo "============================================"
+if [ $FAIL -eq 0 ]; then
+  printf "  ${GREEN}ALL $TOTAL TESTS PASSED${RESET}\n"
+else
+  printf "  ${RED}$FAIL FAILED${RESET} / $TOTAL total ($PASS passed)\n"
+fi
+echo "============================================"
+
+exit $FAIL

--- a/install-devin.sh
+++ b/install-devin.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# One-command installer for RTK + Devin CLI integration.
+# Run from the repo root: bash install-devin.sh
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+RED='\033[31m'
+GREEN='\033[32m'
+RESET='\033[0m'
+
+err() {
+    echo -e "${RED}error:${RESET} $*" >&2
+    exit 1
+}
+
+ok() {
+    echo -e "${GREEN}ok:${RESET} $*"
+}
+
+# 1. Verify Rust toolchain
+if ! command -v cargo &>/dev/null; then
+    err "cargo not found. Install Rust first: https://rustup.rs"
+fi
+
+# 2. Build and install the rtk binary
+ok "building and installing rtk (this may take a minute)..."
+cargo install --path . --locked --force
+
+# 3. Make sure rtk is reachable in this script's PATH
+RTK_BIN="$(command -v rtk || true)"
+if [[ -z "$RTK_BIN" ]]; then
+    # cargo install defaults to ~/.cargo/bin; try adding it for this session
+    export PATH="${HOME}/.cargo/bin:${PATH}"
+    RTK_BIN="$(command -v rtk || true)"
+fi
+if [[ -z "$RTK_BIN" ]]; then
+    err "rtk was installed but is not on PATH. Add ${HOME}/.cargo/bin to your PATH and re-run."
+fi
+
+ok "rtk installed at ${RTK_BIN}"
+
+# 4. Install Devin CLI hooks globally
+ok "installing Devin CLI hooks..."
+rtk init -g --agent devin --auto-patch
+
+ok "Devin CLI integration is installed."
+echo "   Restart Devin CLI for the hooks to take effect."
+echo "   Test it by running: git status"

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -6,7 +6,7 @@
 
 The **lifecycle management** layer for LLM agent hooks: install, uninstall, verify integrity, audit usage, and manage trust. This component creates and maintains the hook artifacts that live in `hooks/` (root), but does **not** execute rewrite logic itself — that lives in `discover/registry`.
 
-Owns: `rtk init` installation flows (5 agents via `AgentTarget` enum + 3 special modes: Gemini, Codex, OpenCode), SHA-256 integrity verification, hook version checking, audit log analysis, `rtk rewrite` CLI entry point, and TOML filter trust management.
+Owns: `rtk init` installation flows (11 agents via `AgentTarget` enum + 3 special modes: Gemini, Codex, OpenCode), SHA-256 integrity verification, hook version checking, audit log analysis, `rtk rewrite` CLI entry point, and TOML filter trust management.
 
 Does **not** own: the deployed hook scripts themselves (that's `hooks/`), the rewrite pattern registry (that's `discover/`), or command filtering (that's `cmds/`).
 
@@ -32,6 +32,7 @@ LLM agent integration layer that installs, validates, and executes command-rewri
 | Cursor | `rtk init -g --agent cursor` | Cursor hook | hooks.json |
 | Pi | `rtk init --agent pi` | `.pi/extensions/rtk.ts` | -- |
 | Hermes | `rtk init --agent hermes` | Python plugin in `~/.hermes/plugins/rtk-rewrite/` | `config.yaml` `plugins.enabled` |
+| Devin CLI | `rtk init -g --agent devin` | Devin CLI hook in `~/.config/devin/config.json`, `.devin/config.json`, `.devin/config.local.json` or `.devin/hooks.v1.json` | `config.json` / `hooks.v1.json` |
 
 
 ## Integrity Verification
@@ -90,6 +91,7 @@ Rules are loaded from all Claude Code `settings.json` files (project + global, i
 | Gemini CLI (rtk hook gemini) | No (allow/deny only) | allow (limitation — no ask mode in Gemini) |
 | Copilot CLI (rtk hook copilot) | No updatedInput | deny-with-suggestion (unchanged) |
 | Codex | ask parsed but no-op | allow (limitation — fails open) |
+| Devin CLI (rtk hook devin) | Yes | `decision` omitted; Devin CLI prompts on `updatedInput` |
 
 ### Implementation
 

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -53,6 +53,21 @@ pub const DROID_EXECUTE_MATCHER: &str = "Execute";
 /// `.factory` segment is appended to it): `$FACTORY_HOME_OVERRIDE/.factory`.
 pub const DROID_HOME_ENV: &str = "FACTORY_HOME_OVERRIDE";
 
+/// Devin CLI config directory (project: `.devin/`, global: `~/.config/devin/`).
+pub const DEVIN_DIR: &str = ".devin";
+/// Standalone Devin hooks file (project-level, root is the event map).
+pub const DEVIN_HOOKS_FILE: &str = "hooks.v1.json";
+/// Devin settings file (global and project, hooks live under a top-level `hooks` key).
+pub const DEVIN_SETTINGS_FILE: &str = "config.json";
+/// Devin local override settings file (`gitignored` personal project overrides).
+pub const DEVIN_SETTINGS_LOCAL_JSON: &str = "config.local.json";
+/// Tool matcher used by Devin CLI for shell command execution.
+pub const DEVIN_EXECUTE_MATCHER: &str = "^exec$";
+/// Native Rust hook command for Devin CLI.
+pub const DEVIN_HOOK_COMMAND: &str = "rtk hook devin";
+/// Environment variable to override the Devin global config directory.
+pub const DEVIN_CONFIG_DIR_ENV: &str = "DEVIN_CONFIG_DIR";
+
 pub const HERMES_DIR: &str = ".hermes";
 pub const HERMES_PLUGINS_SUBDIR: &str = "plugins";
 pub const HERMES_PLUGIN_NAME: &str = "rtk-rewrite";

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -660,7 +660,100 @@ pub fn run_droid() -> Result<()> {
 
 fn process_devin_payload(v: &Value) -> Option<Value> {
     let cmd = devin_execute_command(v)?;
-    devin_response_from_decision(v, cmd, decide_hook_action(cmd, permissions::Host::Devin))
+    let (original, decision) = devin_decide_for_command(cmd);
+    devin_response_from_decision(v, original, decision)
+}
+
+/// Decide the hook action for a Devin CLI `exec` command.
+/// If the command is already prefixed with `rtk`, evaluate the inner command
+/// so that `rtk rm -rf /` is still blocked while `rtk gain` is allowed.
+fn devin_decide_for_command(cmd: &str) -> (&str, HookDecision) {
+    if let Some(inner) = cmd.strip_prefix("rtk ") {
+        (cmd, devin_decide_explicit_rtk(cmd, inner.trim_start()))
+    } else {
+        (cmd, decide_hook_action(cmd, permissions::Host::Devin))
+    }
+}
+
+fn devin_decide_explicit_rtk(original: &str, inner: &str) -> HookDecision {
+    // Escape hatches / wrappers that execute an arbitrary command.
+    // Approve only if the wrapped command itself is allowed.
+    for wrapper in ["proxy ", "run ", "err ", "test ", "summary "] {
+        if let Some(rest) = inner.strip_prefix(wrapper) {
+            return devin_decide_wrapper(original, rest);
+        }
+    }
+
+    // Safe RTK meta subcommands that do not spawn arbitrary user-controlled shell commands.
+    if is_rtk_meta_subcommand(inner) {
+        return HookDecision::AllowOriginal(original.to_string());
+    }
+
+    // Otherwise evaluate the inner command like a normal shell command:
+    // e.g. "git status" -> "rtk git status", "cat file" -> "rtk read file".
+    devin_decide_inner_command(original, inner)
+}
+
+/// Approve an explicit `rtk <wrapper> <cmd>` only when <cmd> is allowed.
+fn devin_decide_wrapper(original: &str, inner_cmd: &str) -> HookDecision {
+    match permissions::check_command_for(inner_cmd, permissions::Host::Devin) {
+        PermissionVerdict::Deny => HookDecision::Deny,
+        PermissionVerdict::Allow => HookDecision::AllowOriginal(original.to_string()),
+        _ => HookDecision::Defer,
+    }
+}
+
+/// Evaluate `inner` as a normal shell command and, if allowed, rewrite it to `rtk <inner>`.
+fn devin_decide_inner_command(original: &str, inner: &str) -> HookDecision {
+    let verdict = permissions::check_command_for(inner, permissions::Host::Devin);
+    if verdict == PermissionVerdict::Deny {
+        return HookDecision::Deny;
+    }
+    if crate::discover::lexer::contains_unattestable_construct(inner) {
+        return HookDecision::Defer;
+    }
+    match get_rewritten(inner) {
+        Some(r) if verdict == PermissionVerdict::Allow => HookDecision::AllowRewrite(r),
+        Some(r) => HookDecision::AskRewrite(r),
+        None if verdict == PermissionVerdict::Allow => {
+            HookDecision::AllowOriginal(original.to_string())
+        }
+        None => HookDecision::Defer,
+    }
+}
+
+/// RTK subcommands that are pure RTK operations and do not spawn arbitrary shell commands.
+fn is_rtk_meta_subcommand(inner: &str) -> bool {
+    if inner.is_empty() {
+        return true; // bare `rtk` -> help
+    }
+    let first = inner.split_whitespace().next().unwrap_or("");
+    matches!(
+        first,
+        "gain"
+            | "discover"
+            | "session"
+            | "telemetry"
+            | "learn"
+            | "cc-economics"
+            | "config"
+            | "trust"
+            | "untrust"
+            | "verify"
+            | "read"
+            | "smart"
+            | "json"
+            | "deps"
+            | "env"
+            | "log"
+            | "pipe"
+            | "--version"
+            | "--help"
+            | "-V"
+            | "-h"
+            | "version"
+            | "help"
+    )
 }
 
 /// Extract the shell command when the payload targets Devin CLI's `exec` tool.

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -128,11 +128,18 @@ fn get_rewritten(cmd: &str) -> Option<String> {
 enum HookDecision {
     AllowRewrite(String),
     AskRewrite(String),
+    /// Approve the original command unchanged (used when the user explicitly
+    /// allowed it but RTK has no filter for it).
+    AllowOriginal(String),
     Defer,
     Deny,
 }
 
-fn decide_from_verdict(cmd: &str, verdict: PermissionVerdict) -> HookDecision {
+fn decide_from_verdict(
+    cmd: &str,
+    verdict: PermissionVerdict,
+    allow_original: bool,
+) -> HookDecision {
     if verdict == PermissionVerdict::Deny {
         return HookDecision::Deny;
     }
@@ -142,12 +149,20 @@ fn decide_from_verdict(cmd: &str, verdict: PermissionVerdict) -> HookDecision {
     match get_rewritten(cmd) {
         Some(r) if verdict == PermissionVerdict::Allow => HookDecision::AllowRewrite(r),
         Some(r) => HookDecision::AskRewrite(r),
+        None if allow_original && verdict == PermissionVerdict::Allow => {
+            HookDecision::AllowOriginal(cmd.to_string())
+        }
         None => HookDecision::Defer,
     }
 }
 
 fn decide_hook_action(cmd: &str, host: permissions::Host) -> HookDecision {
-    decide_from_verdict(cmd, permissions::check_command_for(cmd, host))
+    let allow_original = host == permissions::Host::Devin;
+    decide_from_verdict(
+        cmd,
+        permissions::check_command_for(cmd, host),
+        allow_original,
+    )
 }
 
 fn handle_vscode(cmd: &str) -> Result<()> {
@@ -157,7 +172,7 @@ fn handle_vscode(cmd: &str) -> Result<()> {
             return Ok(());
         }
         HookDecision::Defer => return Ok(()),
-        HookDecision::AllowRewrite(r) => ("allow", r),
+        HookDecision::AllowRewrite(r) | HookDecision::AllowOriginal(r) => ("allow", r),
         HookDecision::AskRewrite(r) => ("ask", r),
     };
 
@@ -201,7 +216,7 @@ fn copilot_cli_response_from_decision(
             return None;
         }
         HookDecision::Defer => return None,
-        HookDecision::AllowRewrite(r) => (r, true),
+        HookDecision::AllowRewrite(r) | HookDecision::AllowOriginal(r) => (r, true),
         HookDecision::AskRewrite(r) => (r, false),
     };
 
@@ -262,6 +277,7 @@ pub fn run_gemini() -> Result<()> {
             audit_log("ask", cmd, rewritten);
             print_gemini("ask_user", Some(rewritten));
         }
+        HookDecision::AllowOriginal(_) => print_gemini("allow", None),
         HookDecision::Defer => print_gemini("ask_user", None),
     }
 
@@ -362,7 +378,7 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
                 cmd: cmd.to_string(),
             }
         }
-        HookDecision::AllowRewrite(r) => (r, true),
+        HookDecision::AllowRewrite(r) | HookDecision::AllowOriginal(r) => (r, true),
         HookDecision::AskRewrite(r) => (r, false),
     };
 
@@ -548,7 +564,7 @@ fn run_cursor_inner_with_rules(
     };
 
     let verdict = permissions::check_command_with_rules(&cmd, deny_rules, ask_rules, allow_rules);
-    match decide_from_verdict(&cmd, verdict) {
+    match decide_from_verdict(&cmd, verdict, false) {
         HookDecision::AllowRewrite(rewritten) => cursor_allow(&rewritten),
         HookDecision::AskRewrite(rewritten) => cursor_ask(&rewritten),
         _ => "{}".to_string(),
@@ -595,7 +611,7 @@ fn droid_response_from_decision(v: &Value, cmd: &str, decision: HookDecision) ->
             audit_log("deny", cmd, "");
             return None;
         }
-        HookDecision::Defer => return None,
+        HookDecision::Defer | HookDecision::AllowOriginal(_) => return None,
         HookDecision::AllowRewrite(r) | HookDecision::AskRewrite(r) => r,
     };
 
@@ -640,6 +656,95 @@ pub fn run_droid() -> Result<()> {
     Ok(())
 }
 
+// ── Devin CLI PreToolUse hook ──────────────────────────────────
+
+fn process_devin_payload(v: &Value) -> Option<Value> {
+    let cmd = devin_execute_command(v)?;
+    devin_response_from_decision(v, cmd, decide_hook_action(cmd, permissions::Host::Devin))
+}
+
+/// Extract the shell command when the payload targets Devin CLI's `exec` tool.
+fn devin_execute_command(v: &Value) -> Option<&str> {
+    let tool_name = v.get("tool_name").and_then(|t| t.as_str()).unwrap_or("");
+    // The installed matcher is `^exec$`; tolerate a missing/ambiguous tool_name defensively.
+    if !matches!(tool_name, "exec" | "bash" | "") {
+        return None;
+    }
+
+    v.pointer("/tool_input/command")
+        .and_then(|c| c.as_str())
+        .filter(|c| !c.is_empty())
+}
+
+/// Build the Devin CLI hook response for a decision from the shared flow.
+///
+/// Devin CLI expects a top-level `decision` (`approve`/`block`) and a
+/// `hookSpecificOutput.updatedInput` for rewrites. On `Ask`/`Default` we omit
+/// `decision` so Devin runs its own permission prompt on the rewritten command.
+fn devin_response_from_decision(v: &Value, cmd: &str, decision: HookDecision) -> Option<Value> {
+    match decision {
+        HookDecision::Deny => {
+            audit_log("deny", cmd, "");
+            Some(json!({
+                "decision": "block",
+                "reason": "Blocked by RTK permission rule"
+            }))
+        }
+        HookDecision::AllowOriginal(_) => {
+            audit_log("allow", cmd, "");
+            Some(json!({"decision": "approve"}))
+        }
+        HookDecision::Defer => None,
+        HookDecision::AllowRewrite(rewritten) => {
+            audit_log("rewrite", cmd, &rewritten);
+            build_devin_rewrite_response(v, &rewritten, true)
+        }
+        HookDecision::AskRewrite(rewritten) => {
+            audit_log("ask", cmd, &rewritten);
+            build_devin_rewrite_response(v, &rewritten, false)
+        }
+    }
+}
+
+fn build_devin_rewrite_response(v: &Value, rewritten: &str, allow: bool) -> Option<Value> {
+    let mut ti = v.get("tool_input").cloned().unwrap_or_else(|| json!({}));
+    if let Some(obj) = ti.as_object_mut() {
+        obj.insert("command".into(), Value::String(rewritten.to_string()));
+    }
+    let mut output = json!({
+        "hookSpecificOutput": {
+            "hookEventName": PRE_TOOL_USE_KEY,
+            "updatedInput": ti
+        }
+    });
+    if allow {
+        output["decision"] = json!("approve");
+    }
+    Some(output)
+}
+
+/// Run the Devin CLI PreToolUse hook natively.
+pub fn run_devin() -> Result<()> {
+    let input = read_stdin_limited()?;
+    let input = strip_leading_bom(&input).trim();
+    if input.is_empty() {
+        return Ok(());
+    }
+
+    let v: Value = match serde_json::from_str(input) {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = writeln!(io::stderr(), "[rtk hook] Failed to parse JSON input: {e}");
+            return Ok(());
+        }
+    };
+
+    if let Some(output) = process_devin_payload(&v) {
+        let _ = writeln!(io::stdout(), "{output}");
+    }
+    Ok(())
+}
+
 /// Hermetic test path: no Droid settings (empty rules).
 #[cfg(test)]
 fn run_droid_inner(input: &str) -> Option<String> {
@@ -657,7 +762,28 @@ fn run_droid_inner_with_rules(
     let v: Value = serde_json::from_str(input).ok()?;
     let cmd = droid_execute_command(&v)?;
     let verdict = permissions::check_command_with_rules(cmd, deny_rules, ask_rules, allow_rules);
-    droid_response_from_decision(&v, cmd, decide_from_verdict(cmd, verdict)).map(|o| o.to_string())
+    droid_response_from_decision(&v, cmd, decide_from_verdict(cmd, verdict, false))
+        .map(|o| o.to_string())
+}
+
+#[cfg(test)]
+fn run_devin_inner(input: &str) -> Option<String> {
+    run_devin_inner_with_rules(input, &[], &[], &[])
+}
+
+#[cfg(test)]
+fn run_devin_inner_with_rules(
+    input: &str,
+    deny_rules: &[String],
+    ask_rules: &[String],
+    allow_rules: &[String],
+) -> Option<String> {
+    let input = strip_leading_bom(input).trim();
+    let v: Value = serde_json::from_str(input).ok()?;
+    let cmd = devin_execute_command(&v)?;
+    let verdict = permissions::check_command_with_rules(cmd, deny_rules, ask_rules, allow_rules);
+    devin_response_from_decision(&v, cmd, decide_from_verdict(cmd, verdict, true))
+        .map(|o| o.to_string())
 }
 
 #[cfg(test)]
@@ -868,7 +994,11 @@ mod tests {
             &[],
             &["Bash(git:*)".to_string()],
         );
-        copilot_cli_response_from_decision(&cli_args(cmd), decide_from_verdict(cmd, verdict), cmd)
+        copilot_cli_response_from_decision(
+            &cli_args(cmd),
+            decide_from_verdict(cmd, verdict, false),
+            cmd,
+        )
     }
 
     #[test]
@@ -1405,7 +1535,7 @@ mod tests {
         allow: &[String],
     ) -> HookDecision {
         let verdict = permissions::check_command_with_rules(cmd, deny, ask, allow);
-        decide_from_verdict(cmd, verdict)
+        decide_from_verdict(cmd, verdict, false)
     }
 
     fn all_allowed() -> Vec<String> {
@@ -1483,6 +1613,7 @@ mod tests {
             }
             HookDecision::AllowRewrite(r) => gemini_json("allow", Some(&r)),
             HookDecision::AskRewrite(r) => gemini_json("ask_user", Some(&r)),
+            HookDecision::AllowOriginal(_) => gemini_json("allow", None),
             HookDecision::Defer => gemini_json("ask_user", None),
         }
     }
@@ -1741,5 +1872,139 @@ mod tests {
         // so Droid runs them unchanged.
         let input = droid_input("Execute", "definitely-not-a-real-binary --foo");
         assert!(run_droid_inner(&input).is_none());
+    }
+
+    // --- Devin CLI hook ---
+
+    fn devin_input(tool: &str, cmd: &str) -> String {
+        json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": tool,
+            "tool_input": { "command": cmd, "shell_id": "main" }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn test_devin_allow_emits_approve_and_rewrite() {
+        let input = devin_input("exec", "git status");
+        let out = run_devin_inner_with_rules(&input, &[], &[], &["git".to_string()])
+            .expect("rewrite expected");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["decision"], "approve");
+        assert_eq!(
+            v.pointer("/hookSpecificOutput/updatedInput/command"),
+            Some(&json!("rtk git status"))
+        );
+        assert_eq!(
+            v.pointer("/hookSpecificOutput/hookEventName"),
+            Some(&json!("PreToolUse"))
+        );
+        // Extra tool_input fields must be preserved.
+        assert_eq!(
+            v.pointer("/hookSpecificOutput/updatedInput/shell_id"),
+            Some(&json!("main"))
+        );
+    }
+
+    #[test]
+    fn test_devin_exec_tool_rule_allows_all() {
+        let input = devin_input("exec", "cargo test");
+        let out = run_devin_inner_with_rules(&input, &[], &[], &["*".to_string()])
+            .expect("rewrite expected");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["decision"], "approve");
+        assert!(v
+            .pointer("/hookSpecificOutput/updatedInput/command")
+            .and_then(|c| c.as_str())
+            .is_some_and(|c| c.starts_with("rtk ")));
+    }
+
+    #[test]
+    fn test_devin_default_asks_without_decision() {
+        let input = devin_input("exec", "git status");
+        let out = run_devin_inner(&input).expect("rewrite expected");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert!(
+            v.get("decision").is_none(),
+            "Ask/Default must omit decision"
+        );
+        assert_eq!(
+            v.pointer("/hookSpecificOutput/updatedInput/command"),
+            Some(&json!("rtk git status"))
+        );
+    }
+
+    #[test]
+    fn test_devin_deny_emits_block() {
+        let input = devin_input("exec", "rm -rf /tmp/x");
+        let out = run_devin_inner_with_rules(&input, &["rm -rf".to_string()], &[], &[])
+            .expect("block expected");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["decision"], "block");
+        assert!(v.get("hookSpecificOutput").is_none());
+    }
+
+    #[test]
+    fn test_devin_passthrough_unsupported() {
+        let input = devin_input("exec", "htop");
+        assert!(run_devin_inner(&input).is_none());
+    }
+
+    #[test]
+    fn test_devin_allow_unsupported_approves_original() {
+        // If the user explicitly allowed a command RTK cannot rewrite,
+        // RTK should still emit approve so Devin CLI auto-runs the original.
+        let input = devin_input("exec", "htop");
+        let out = run_devin_inner_with_rules(&input, &[], &[], &["htop".to_string()])
+            .expect("approve expected");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["decision"], "approve");
+        assert!(v.get("hookSpecificOutput").is_none());
+    }
+
+    #[test]
+    fn test_devin_already_rtk_passthrough() {
+        let input = devin_input("exec", "rtk git status");
+        assert!(run_devin_inner(&input).is_none());
+    }
+
+    #[test]
+    fn test_devin_env_prefix_preserved() {
+        let input = devin_input("exec", "RUST_LOG=debug cargo test");
+        let out = run_devin_inner_with_rules(&input, &[], &[], &["*".to_string()])
+            .expect("rewrite expected");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(
+            v.pointer("/hookSpecificOutput/updatedInput/command"),
+            Some(&json!("RUST_LOG=debug rtk cargo test"))
+        );
+    }
+
+    #[test]
+    fn test_devin_ignores_non_exec_tool() {
+        let input = devin_input("read", "src/main.rs");
+        assert!(run_devin_inner(&input).is_none());
+    }
+
+    #[test]
+    fn test_devin_empty_command_passthrough() {
+        let input = devin_input("exec", "");
+        assert!(run_devin_inner(&input).is_none());
+    }
+
+    #[test]
+    fn test_devin_malformed_json_passthrough() {
+        assert!(run_devin_inner("not-json").is_none());
+    }
+
+    #[test]
+    fn test_devin_bom_stripped() {
+        let payload = devin_input("exec", "git status");
+        let with_bom = format!("\u{feff}{}", payload);
+        let out = run_devin_inner_with_rules(&with_bom, &[], &[], &["git".to_string()])
+            .expect("rewrite expected");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["decision"], "approve");
     }
 }

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -665,9 +665,8 @@ fn process_devin_payload(v: &Value) -> Option<Value> {
 
 /// Extract the shell command when the payload targets Devin CLI's `exec` tool.
 fn devin_execute_command(v: &Value) -> Option<&str> {
-    let tool_name = v.get("tool_name").and_then(|t| t.as_str()).unwrap_or("");
-    // The installed matcher is `^exec$`; tolerate a missing/ambiguous tool_name defensively.
-    if !matches!(tool_name, "exec" | "bash" | "") {
+    let tool_name = v.get("tool_name").and_then(|t| t.as_str())?;
+    if tool_name != "exec" {
         return None;
     }
 
@@ -682,31 +681,27 @@ fn devin_execute_command(v: &Value) -> Option<&str> {
 /// `hookSpecificOutput.updatedInput` for rewrites. On `Ask`/`Default` we omit
 /// `decision` so Devin runs its own permission prompt on the rewritten command.
 fn devin_response_from_decision(v: &Value, cmd: &str, decision: HookDecision) -> Option<Value> {
-    match decision {
+    let allow = matches!(
+        decision,
+        HookDecision::AllowRewrite(_) | HookDecision::AllowOriginal(_)
+    );
+    let rewritten = match decision {
         HookDecision::Deny => {
             audit_log("deny", cmd, "");
-            Some(json!({
+            return Some(json!({
                 "decision": "block",
                 "reason": "Blocked by RTK permission rule"
-            }))
+            }));
         }
         HookDecision::AllowOriginal(_) => {
             audit_log("allow", cmd, "");
-            Some(json!({"decision": "approve"}))
+            return Some(json!({"decision": "approve"}));
         }
-        HookDecision::Defer => None,
-        HookDecision::AllowRewrite(rewritten) => {
-            audit_log("rewrite", cmd, &rewritten);
-            build_devin_rewrite_response(v, &rewritten, true)
-        }
-        HookDecision::AskRewrite(rewritten) => {
-            audit_log("ask", cmd, &rewritten);
-            build_devin_rewrite_response(v, &rewritten, false)
-        }
-    }
-}
+        HookDecision::Defer => return None,
+        HookDecision::AllowRewrite(r) | HookDecision::AskRewrite(r) => r,
+    };
 
-fn build_devin_rewrite_response(v: &Value, rewritten: &str, allow: bool) -> Option<Value> {
+    audit_log(if allow { "rewrite" } else { "ask" }, cmd, &rewritten);
     let mut ti = v.get("tool_input").cloned().unwrap_or_else(|| json!({}));
     if let Some(obj) = ti.as_object_mut() {
         obj.insert("command".into(), Value::String(rewritten.to_string()));

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -2952,9 +2952,9 @@ fn droid_hook_file_candidates(droid_dir: &Path) -> [DroidHookFile; 3] {
     ]
 }
 
-/// Read a Droid config file as JSON. `Ok(None)` when the file doesn't exist;
+/// Read a JSON config file. `Ok(None)` when the file doesn't exist;
 /// an empty file parses as `{}`.
-fn read_droid_json(path: &Path) -> Result<Option<serde_json::Value>> {
+fn read_optional_json(path: &Path) -> Result<Option<serde_json::Value>> {
     if !path.exists() {
         return Ok(None);
     }
@@ -3010,7 +3010,7 @@ fn resolve_droid_install_target(droid_dir: &Path) -> Result<DroidHookFile> {
     };
 
     if let Some(path) = &live_hooks_json {
-        if let Some(json) = read_droid_json(path)? {
+        if let Some(json) = read_optional_json(path)? {
             if droid_has_pre_tool_use(&json, DroidLayout::Root) {
                 return Ok(DroidHookFile {
                     path: path.clone(),
@@ -3020,7 +3020,7 @@ fn resolve_droid_install_target(droid_dir: &Path) -> Result<DroidHookFile> {
         }
     }
 
-    if let Some(json) = read_droid_json(&settings)? {
+    if let Some(json) = read_optional_json(&settings)? {
         if droid_has_pre_tool_use(&json, DroidLayout::Nested) {
             return Ok(DroidHookFile {
                 path: settings,
@@ -3104,7 +3104,7 @@ fn run_droid_mode_at(droid_dir: &Path, global: bool, ctx: InitContext) -> Result
 fn patch_droid_hook_file(file: &DroidHookFile, ctx: InitContext) -> Result<bool> {
     let InitContext { verbose, dry_run } = ctx;
     let path = &file.path;
-    let mut root = read_droid_json(path)?.unwrap_or_else(|| serde_json::json!({}));
+    let mut root = read_optional_json(path)?.unwrap_or_else(|| serde_json::json!({}));
 
     if droid_hook_already_present(&root, file.layout) {
         if verbose > 0 {
@@ -3263,7 +3263,7 @@ fn remove_droid_hook_from_file(file: &DroidHookFile, ctx: InitContext) -> Result
     let InitContext { verbose, dry_run } = ctx;
     let path = &file.path;
 
-    let mut root = match read_droid_json(path)? {
+    let mut root = match read_optional_json(path)? {
         Some(v) => v,
         None => return Ok(false),
     };
@@ -3435,7 +3435,7 @@ fn resolve_devin_install_target(global: bool) -> Result<DevinHookFile> {
     let candidates = devin_hook_file_candidates(&devin_dir);
 
     for candidate in &candidates {
-        if let Some(json) = read_devin_json(&candidate.path)? {
+        if let Some(json) = read_optional_json(&candidate.path)? {
             if devin_hook_already_present(&json, candidate.layout) {
                 return Ok(candidate.clone());
             }
@@ -3469,20 +3469,6 @@ fn devin_hook_file_candidates(devin_dir: &Path) -> [DevinHookFile; 3] {
             layout: DevinLayout::Nested,
         },
     ]
-}
-
-fn read_devin_json(path: &Path) -> Result<Option<serde_json::Value>> {
-    if !path.exists() {
-        return Ok(None);
-    }
-    let content =
-        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
-    if content.trim().is_empty() {
-        return Ok(Some(serde_json::json!({})));
-    }
-    serde_json::from_str(&content)
-        .map(Some)
-        .with_context(|| format!("Failed to parse {} as JSON", path.display()))
 }
 
 fn devin_events(root: &serde_json::Value, layout: DevinLayout) -> &serde_json::Value {
@@ -3569,7 +3555,7 @@ fn patch_devin_hook_file(file: &DevinHookFile, mode: PatchMode, ctx: InitContext
     let InitContext { verbose, dry_run } = ctx;
     let path = &file.path;
 
-    let mut root = read_devin_json(path)?.unwrap_or_else(|| serde_json::json!({}));
+    let mut root = read_optional_json(path)?.unwrap_or_else(|| serde_json::json!({}));
 
     if devin_hook_already_present(&root, file.layout) {
         if verbose > 0 {
@@ -3735,7 +3721,7 @@ fn remove_devin_hook_from_file(file: &DevinHookFile, ctx: InitContext) -> Result
     let InitContext { verbose, dry_run } = ctx;
     let path = &file.path;
 
-    let mut root = match read_devin_json(path)? {
+    let mut root = match read_optional_json(path)? {
         Some(v) => v,
         None => return Ok(false),
     };
@@ -3834,7 +3820,7 @@ pub fn show_devin_config() -> Result<()> {
     match permissions::resolve_devin_config_dir() {
         Some(dir) => {
             let global_config = dir.join(DEVIN_SETTINGS_FILE);
-            if let Some(v) = read_devin_json(&global_config)? {
+            if let Some(v) = read_optional_json(&global_config)? {
                 if devin_hook_already_present(&v, DevinLayout::Nested) {
                     println!(
                         "[ok] Global hook: {} in {}",
@@ -3867,7 +3853,7 @@ pub fn show_devin_config() -> Result<()> {
         } else {
             DevinLayout::Nested
         };
-        if let Some(v) = read_devin_json(&path)? {
+        if let Some(v) = read_optional_json(&path)? {
             if devin_hook_already_present(&v, layout) {
                 println!(
                     "[ok] Project hook: {} in {}",

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -3361,7 +3361,11 @@ fn remove_droid_hook_from_json(root: &mut serde_json::Value, layout: DroidLayout
 
 // ─── Devin CLI support ────────────────────────────────────────────────
 
-const RTK_DEVIN_AGENTS_BLOCK: &str = include_str!("../../hooks/devin/rtk-awareness.md");
+pub(crate) const RTK_DEVIN_JS: &str = include_str!("../../hooks/devin/rtk-devin.js");
+pub(crate) const RTK_DEVIN_INSTRUCTIONS: &str =
+    include_str!("../../hooks/devin/rtk-instructions.md");
+const RTK_DEVIN_GITIGNORE: &str =
+    "# Runtime state created by the RTK Devin CLI lifecycle hook\n.rtk-active\n";
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum DevinLayout {
@@ -3377,9 +3381,10 @@ struct DevinHookFile {
     layout: DevinLayout,
 }
 
-/// Install Devin CLI PreToolUse hook.
+/// Install Devin CLI hooks (PreToolUse rewrite + lifecycle context hooks).
 pub fn run_devin_mode(global: bool, patch_mode: PatchMode, ctx: InitContext) -> Result<()> {
     let target = resolve_devin_install_target(global)?;
+    let hook_dir = devin_rtk_hook_dir(&target, global)?;
 
     if !ctx.dry_run {
         if let Some(parent) = target.path.parent() {
@@ -3390,31 +3395,29 @@ pub fn run_devin_mode(global: bool, patch_mode: PatchMode, ctx: InitContext) -> 
                 )
             })?;
         }
+        fs::create_dir_all(&hook_dir).with_context(|| {
+            format!(
+                "Failed to create RTK hook directory: {}",
+                hook_dir.display()
+            )
+        })?;
+        write_devin_hook_files(&hook_dir, ctx)?;
     }
 
-    let patched = patch_devin_hook_file(&target, patch_mode, ctx)?;
+    let patched = patch_devin_hook_file(&target, global, patch_mode, ctx)?;
 
-    // Project instructions and filters (local projects)
-    let agents_md_path: PathBuf;
-    let filters_path: PathBuf;
-    if !global {
-        agents_md_path = PathBuf::from(AGENTS_MD);
-        filters_path = PathBuf::from(".rtk").join("filters.toml");
-        generate_project_filters_template(ctx)?;
-        maybe_patch_devin_agents_md(ctx, &agents_md_path)?;
-    } else {
-        // Global instructions and filters
-        agents_md_path = permissions::resolve_devin_config_dir()
-            .map(|d| d.join(AGENTS_MD))
-            .unwrap_or_else(|| PathBuf::from(AGENTS_MD));
-        filters_path = dirs::config_dir()
+    let filters_path: PathBuf = if global {
+        dirs::config_dir()
             .unwrap_or_else(|| PathBuf::from(".config"))
             .join(crate::core::constants::RTK_DATA_DIR)
-            .join("filters.toml");
+            .join("filters.toml")
+    } else {
+        PathBuf::from(".rtk").join("filters.toml")
+    };
+    if global {
         generate_global_filters_template(ctx)?;
-        if let Some(dir) = permissions::resolve_devin_config_dir() {
-            maybe_patch_devin_agents_md(ctx, &dir.join(AGENTS_MD))?;
-        }
+    } else {
+        generate_project_filters_template(ctx)?;
     }
 
     if ctx.dry_run {
@@ -3424,17 +3427,67 @@ pub fn run_devin_mode(global: bool, patch_mode: PatchMode, ctx: InitContext) -> 
         println!("\nDevin CLI hook registered ({scope}).\n");
         println!("  Command:    {}", DEVIN_HOOK_COMMAND);
         println!("  Hooks file: {}", target.path.display());
-        println!("  AGENTS.md:  {}", agents_md_path.display());
+        println!("  Hook dir:   {}", hook_dir.display());
         println!("  Filters:    {} (template)", filters_path.display());
         if patched {
-            println!("  RTK PreToolUse entry added");
+            println!("  RTK entries added (PreToolUse + lifecycle hooks)");
         } else {
-            println!("  RTK PreToolUse entry already present or skipped");
+            println!("  RTK entries already present or skipped");
         }
         println!("  Restart Devin CLI. Test with: git status\n");
     }
 
     Ok(())
+}
+
+fn devin_rtk_hook_dir(target: &DevinHookFile, global: bool) -> Result<PathBuf> {
+    let base = target
+        .path
+        .parent()
+        .context("Devin hook file has no parent directory")?;
+    if global {
+        Ok(base.join("hooks").join("rtk"))
+    } else {
+        // Project-level hooks live in .devin/hooks/rtk so the path is portable.
+        Ok(PathBuf::from(DEVIN_DIR).join("hooks").join("rtk"))
+    }
+}
+
+fn write_devin_hook_files(hook_dir: &Path, ctx: InitContext) -> Result<()> {
+    let js_path = hook_dir.join("rtk-devin.js");
+    let md_path = hook_dir.join("rtk-instructions.md");
+    let gitignore_path = hook_dir.join(".gitignore");
+
+    if !ctx.dry_run {
+        atomic_write(&js_path, RTK_DEVIN_JS)?;
+        atomic_write(&md_path, RTK_DEVIN_INSTRUCTIONS)?;
+        atomic_write(&gitignore_path, RTK_DEVIN_GITIGNORE)?;
+    } else {
+        println!(
+            "[dry-run] would create {}, {} and {}",
+            js_path.display(),
+            md_path.display(),
+            gitignore_path.display()
+        );
+    }
+    Ok(())
+}
+
+/// Shell command to invoke the Node lifecycle hook for a given event.
+fn devin_node_hook_command(hook_dir: &Path, event: &str, global: bool) -> String {
+    if global {
+        format!(
+            r#"node "{}" {}"#,
+            hook_dir.join("rtk-devin.js").display(),
+            event
+        )
+    } else {
+        format!(
+            r#"node "$DEVIN_PROJECT_DIR/{}/rtk-devin.js" {}"#,
+            hook_dir.display(),
+            event
+        )
+    }
 }
 
 fn resolve_devin_install_target(global: bool) -> Result<DevinHookFile> {
@@ -3498,15 +3551,14 @@ fn devin_events(root: &serde_json::Value, layout: DevinLayout) -> &serde_json::V
 }
 
 fn devin_hook_already_present(root: &serde_json::Value, layout: DevinLayout) -> bool {
-    let pre = match devin_events(root, layout)
-        .get(PRE_TOOL_USE_KEY)
-        .and_then(|p| p.as_array())
-    {
+    let events = devin_events(root, layout);
+
+    // PreToolUse hook must be present.
+    let pre_tool_use = match events.get(PRE_TOOL_USE_KEY).and_then(|p| p.as_array()) {
         Some(arr) => arr,
         None => return false,
     };
-
-    pre.iter().any(|matcher_entry| {
+    let has_pre_tool_use = pre_tool_use.iter().any(|matcher_entry| {
         let matcher = matcher_entry
             .get("matcher")
             .and_then(|m| m.as_str())
@@ -3525,10 +3577,46 @@ fn devin_hook_already_present(root: &serde_json::Value, layout: DevinLayout) -> 
                     .and_then(|c| c.as_str())
                     .is_some_and(|cmd| cmd == DEVIN_HOOK_COMMAND)
             })
-    })
+    });
+    if !has_pre_tool_use {
+        return false;
+    }
+
+    // Lifecycle context hooks (SessionStart, UserPromptSubmit, PostCompaction) must be present.
+    for event in ["SessionStart", "UserPromptSubmit", "PostCompaction"] {
+        let has_event = events
+            .get(event)
+            .and_then(|a| a.as_array())
+            .map(|arr| {
+                arr.iter().any(|entry| {
+                    entry
+                        .get("hooks")
+                        .and_then(|h| h.as_array())
+                        .map(|hooks| {
+                            hooks.iter().any(|hook| {
+                                hook.get("command")
+                                    .and_then(|c| c.as_str())
+                                    .is_some_and(|cmd| cmd.contains("rtk-devin.js"))
+                            })
+                        })
+                        .unwrap_or(false)
+                })
+            })
+            .unwrap_or(false);
+        if !has_event {
+            return false;
+        }
+    }
+
+    true
 }
 
-fn insert_devin_hook_entry(root: &mut serde_json::Value, layout: DevinLayout) -> Result<()> {
+fn insert_devin_hook_entry(
+    root: &mut serde_json::Value,
+    layout: DevinLayout,
+    hook_dir: &Path,
+    global: bool,
+) -> Result<()> {
     let events = match layout {
         DevinLayout::Root => root
             .as_object_mut()
@@ -3542,64 +3630,107 @@ fn insert_devin_hook_entry(root: &mut serde_json::Value, layout: DevinLayout) ->
             .context("Devin config `hooks` key is not an object")?,
     };
 
+    // PreToolUse: rewrite exec commands via `rtk hook devin`.
     let pre_tool_use = events
         .entry(PRE_TOOL_USE_KEY)
         .or_insert_with(|| serde_json::json!([]))
         .as_array_mut()
         .context("PreToolUse value is not an array")?;
 
+    let mut rtk_pre_added = false;
     for entry in pre_tool_use.iter_mut() {
         let matcher = entry.get("matcher").and_then(|m| m.as_str()).unwrap_or("");
         if matcher == DEVIN_EXECUTE_MATCHER {
             if let Some(hook_array) = entry.get_mut("hooks").and_then(|h| h.as_array_mut()) {
                 hook_array.push(serde_json::json!({
                     "type": "command",
-                    "command": DEVIN_HOOK_COMMAND
+                    "command": DEVIN_HOOK_COMMAND,
+                    "timeout": 2
                 }));
-                return Ok(());
+                rtk_pre_added = true;
+                break;
             }
         }
     }
+    if !rtk_pre_added {
+        pre_tool_use.push(serde_json::json!({
+            "matcher": DEVIN_EXECUTE_MATCHER,
+            "hooks": [
+                { "type": "command", "command": DEVIN_HOOK_COMMAND, "timeout": 2 }
+            ]
+        }));
+    }
 
-    pre_tool_use.push(serde_json::json!({
-        "matcher": DEVIN_EXECUTE_MATCHER,
-        "hooks": [
-            { "type": "command", "command": DEVIN_HOOK_COMMAND }
-        ]
-    }));
+    // Lifecycle hooks: inject RTK instructions into context.
+    for event in ["SessionStart", "UserPromptSubmit", "PostCompaction"] {
+        let arr = events
+            .entry(event)
+            .or_insert_with(|| serde_json::json!([]))
+            .as_array_mut()
+            .context(format!("{} value is not an array", event))?;
+
+        let command = devin_node_hook_command(hook_dir, event, global);
+        let already_present = arr.iter().any(|entry| {
+            entry
+                .get("hooks")
+                .and_then(|h| h.as_array())
+                .map(|hooks| {
+                    hooks.iter().any(|hook| {
+                        hook.get("command")
+                            .and_then(|c| c.as_str())
+                            .is_some_and(|cmd| cmd == command)
+                    })
+                })
+                .unwrap_or(false)
+        });
+        if !already_present {
+            arr.push(serde_json::json!({
+                "hooks": [
+                    { "type": "command", "command": command }
+                ]
+            }));
+        }
+    }
+
     Ok(())
 }
 
-fn patch_devin_hook_file(file: &DevinHookFile, mode: PatchMode, ctx: InitContext) -> Result<bool> {
+fn patch_devin_hook_file(
+    file: &DevinHookFile,
+    global: bool,
+    mode: PatchMode,
+    ctx: InitContext,
+) -> Result<bool> {
     let InitContext { verbose, dry_run } = ctx;
     let path = &file.path;
 
+    let hook_dir = devin_rtk_hook_dir(file, global)?;
     let mut root = read_optional_json(path)?.unwrap_or_else(|| serde_json::json!({}));
 
     if devin_hook_already_present(&root, file.layout) {
         if verbose > 0 {
-            eprintln!("{}: RTK hook already present", path.display());
+            eprintln!("{}: RTK hooks already present", path.display());
         }
         return Ok(false);
     }
 
     match mode {
         PatchMode::Skip => {
-            print_devin_manual_instructions(path, file.layout);
+            print_devin_manual_instructions(path, &hook_dir, global, file.layout);
             return Ok(false);
         }
         PatchMode::Ask => {
             if dry_run {
                 println!("[dry-run] would prompt before patching {}", path.display());
             } else if !prompt_user_consent(path)? {
-                print_devin_manual_instructions(path, file.layout);
+                print_devin_manual_instructions(path, &hook_dir, global, file.layout);
                 return Ok(false);
             }
         }
         PatchMode::Auto => {}
     }
 
-    insert_devin_hook_entry(&mut root, file.layout)?;
+    insert_devin_hook_entry(&mut root, file.layout, &hook_dir, global)?;
 
     let serialized =
         serde_json::to_string_pretty(&root).context("Failed to serialize Devin hook file")?;
@@ -3625,50 +3756,61 @@ fn patch_devin_hook_file(file: &DevinHookFile, mode: PatchMode, ctx: InitContext
     Ok(true)
 }
 
-fn print_devin_manual_instructions(path: &Path, layout: DevinLayout) {
+fn print_devin_manual_instructions(
+    path: &Path,
+    hook_dir: &Path,
+    global: bool,
+    layout: DevinLayout,
+) {
     println!(
-        "To install manually, add the following to {}:",
-        path.display()
+        "To install manually, add the following to {} (and copy hooks/devin/rtk-devin.js + rtk-instructions.md to {}):",
+        path.display(),
+        hook_dir.display()
     );
-    let entry = serde_json::json!({
+
+    let pre_tool_entry = serde_json::json!({
         "matcher": DEVIN_EXECUTE_MATCHER,
         "hooks": [
-            { "type": "command", "command": DEVIN_HOOK_COMMAND }
+            { "type": "command", "command": DEVIN_HOOK_COMMAND, "timeout": 2 }
         ]
     });
-    match layout {
+
+    let mut lifecycle = serde_json::Map::new();
+    for event in ["SessionStart", "UserPromptSubmit", "PostCompaction"] {
+        let command = devin_node_hook_command(hook_dir, event, global);
+        lifecycle.insert(
+            event.to_string(),
+            serde_json::json!([
+                { "hooks": [{ "type": "command", "command": command }] }
+            ]),
+        );
+    }
+
+    let sample = match layout {
         DevinLayout::Root => {
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&serde_json::json!({
-                    PRE_TOOL_USE_KEY: [entry]
-                }))
-                .unwrap()
+            let mut root = serde_json::Map::new();
+            root.insert(
+                PRE_TOOL_USE_KEY.to_string(),
+                serde_json::json!([pre_tool_entry]),
             );
+            for (k, v) in lifecycle {
+                root.insert(k, v);
+            }
+            serde_json::Value::Object(root)
         }
         DevinLayout::Nested => {
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&serde_json::json!({
-                    "hooks": {
-                        PRE_TOOL_USE_KEY: [entry]
-                    }
-                }))
-                .unwrap()
+            let mut hooks = serde_json::Map::new();
+            hooks.insert(
+                PRE_TOOL_USE_KEY.to_string(),
+                serde_json::json!([pre_tool_entry]),
             );
+            for (k, v) in lifecycle {
+                hooks.insert(k, v);
+            }
+            serde_json::json!({ "hooks": hooks })
         }
-    }
-}
-
-fn maybe_patch_devin_agents_md(ctx: InitContext, path: &Path) -> Result<()> {
-    write_rtk_block(
-        path,
-        RTK_DEVIN_AGENTS_BLOCK,
-        "RTK instructions",
-        "rtk init --agent devin",
-        ctx,
-    )?;
-    Ok(())
+    };
+    println!("{}", serde_json::to_string_pretty(&sample).unwrap());
 }
 
 pub fn uninstall_devin(global: bool, ctx: InitContext) -> Result<()> {
@@ -3712,7 +3854,22 @@ fn uninstall_devin_artifacts(global: bool, ctx: InitContext) -> Result<Vec<Strin
         }
     }
 
-    // Remove RTK instructions from AGENTS.md
+    // Remove RTK hook directory (rtk-devin.js + rtk-instructions.md).
+    let hook_dir = if global {
+        permissions::resolve_devin_config_dir()
+            .map(|d| d.join("hooks").join("rtk"))
+            .unwrap_or_else(|| PathBuf::from(".config/devin/hooks/rtk"))
+    } else {
+        PathBuf::from(DEVIN_DIR).join("hooks").join("rtk")
+    };
+    if hook_dir.exists() {
+        if !ctx.dry_run {
+            let _ = fs::remove_dir_all(&hook_dir);
+        }
+        removed.push(format!("RTK hook directory: {}", hook_dir.display()));
+    }
+
+    // Legacy: remove RTK instructions from AGENTS.md (old install method).
     let agents_md = if global {
         permissions::resolve_devin_config_dir()
             .map(|d| d.join(AGENTS_MD))
@@ -3786,44 +3943,66 @@ fn remove_devin_hook_from_json(root: &mut serde_json::Value, layout: DevinLayout
         None => return false,
     };
 
-    let pre_tool_use = match events_obj
+    let mut modified = false;
+
+    // Remove PreToolUse rtk hook entry.
+    if let Some(pre_tool_use) = events_obj
         .get_mut(PRE_TOOL_USE_KEY)
         .and_then(|p| p.as_array_mut())
     {
-        Some(arr) => arr,
-        None => return false,
-    };
-
-    let mut modified = false;
-    let mut empty_matchers = Vec::new();
-
-    for (idx, entry) in pre_tool_use.iter_mut().enumerate() {
-        let matcher = entry.get("matcher").and_then(|m| m.as_str()).unwrap_or("");
-        if matcher != DEVIN_EXECUTE_MATCHER {
-            continue;
+        let mut empty_matchers = Vec::new();
+        for (idx, entry) in pre_tool_use.iter_mut().enumerate() {
+            let matcher = entry.get("matcher").and_then(|m| m.as_str()).unwrap_or("");
+            if matcher != DEVIN_EXECUTE_MATCHER {
+                continue;
+            }
+            if let Some(hook_arr) = entry.get_mut("hooks").and_then(|h| h.as_array_mut()) {
+                let original = hook_arr.len();
+                hook_arr.retain(|hook| {
+                    hook.get("command").and_then(|c| c.as_str()) != Some(DEVIN_HOOK_COMMAND)
+                });
+                if hook_arr.len() < original {
+                    modified = true;
+                }
+                if hook_arr.is_empty() {
+                    empty_matchers.push(idx);
+                }
+            }
         }
-        if let Some(hook_arr) = entry.get_mut("hooks").and_then(|h| h.as_array_mut()) {
-            let original = hook_arr.len();
-            hook_arr.retain(|hook| {
-                hook.get("command").and_then(|c| c.as_str()) != Some(DEVIN_HOOK_COMMAND)
+        for idx in empty_matchers.into_iter().rev() {
+            pre_tool_use.remove(idx);
+            modified = true;
+        }
+        if pre_tool_use.is_empty() {
+            events_obj.remove(PRE_TOOL_USE_KEY);
+            modified = true;
+        }
+    }
+
+    // Remove lifecycle context hook entries.
+    for event in ["SessionStart", "UserPromptSubmit", "PostCompaction"] {
+        if let Some(arr) = events_obj.get_mut(event).and_then(|a| a.as_array_mut()) {
+            let original_len = arr.len();
+            arr.retain(|entry| {
+                !entry
+                    .get("hooks")
+                    .and_then(|h| h.as_array())
+                    .map(|hooks| {
+                        hooks.iter().any(|hook| {
+                            hook.get("command")
+                                .and_then(|c| c.as_str())
+                                .is_some_and(|cmd| cmd.contains("rtk-devin.js"))
+                        })
+                    })
+                    .unwrap_or(false)
             });
-            if hook_arr.len() < original {
+            if arr.len() < original_len {
                 modified = true;
             }
-            if hook_arr.is_empty() {
-                empty_matchers.push(idx);
+            if arr.is_empty() {
+                events_obj.remove(event);
             }
         }
-    }
-
-    for idx in empty_matchers.into_iter().rev() {
-        pre_tool_use.remove(idx);
-        modified = true;
-    }
-
-    if pre_tool_use.is_empty() {
-        events_obj.remove(PRE_TOOL_USE_KEY);
-        modified = true;
     }
 
     if layout == DevinLayout::Nested
@@ -3850,35 +4029,33 @@ pub fn show_devin_config() -> Result<()> {
                 Ok(Some(v)) => {
                     if devin_hook_already_present(&v, DevinLayout::Nested) {
                         println!(
-                            "[ok] Global hook: {} in {}",
-                            DEVIN_HOOK_COMMAND,
+                            "[ok] Global hooks: PreToolUse + lifecycle in {}",
                             global_config.display()
                         );
                     } else {
                         println!(
-                            "[--] Global hook: not present in {}",
+                            "[--] Global hooks: not fully configured in {}",
                             global_config.display()
                         );
                     }
                 }
-                Ok(None) => println!("[--] Global hook: {} not found", global_config.display()),
+                Ok(None) => println!("[--] Global config: {} not found", global_config.display()),
                 Err(_) => println!(
-                    "[warn] Global hook: {} invalid JSON",
+                    "[warn] Global config: {} invalid JSON",
                     global_config.display()
                 ),
             }
 
-            // Global AGENTS.md
-            let global_agents = dir.join(AGENTS_MD);
-            if global_agents.exists() {
-                let content = fs::read_to_string(&global_agents).unwrap_or_default();
-                if content.contains(RTK_BLOCK_START) {
-                    println!("[ok] Global AGENTS.md: {}", global_agents.display());
-                } else {
-                    println!("[--] Global AGENTS.md: exists but rtk not configured");
-                }
+            let global_hook_dir = dir.join("hooks").join("rtk");
+            if global_hook_dir.join("rtk-devin.js").exists()
+                && global_hook_dir.join("rtk-instructions.md").exists()
+            {
+                println!("[ok] Global hook files: {}", global_hook_dir.display());
             } else {
-                println!("[--] Global AGENTS.md: not found");
+                println!(
+                    "[--] Global hook files: not found in {}",
+                    global_hook_dir.display()
+                );
             }
         }
         None => println!("[--] Devin config directory not found"),
@@ -3901,30 +4078,31 @@ pub fn show_devin_config() -> Result<()> {
             Ok(Some(v)) => {
                 if devin_hook_already_present(&v, layout) {
                     println!(
-                        "[ok] Project hook: {} in {}",
-                        DEVIN_HOOK_COMMAND,
+                        "[ok] Project hooks: PreToolUse + lifecycle in {}",
                         path.display()
                     );
                 } else {
-                    println!("[--] Project hook: not present in {}", path.display());
+                    println!(
+                        "[--] Project hooks: not fully configured in {}",
+                        path.display()
+                    );
                 }
             }
-            Ok(None) => println!("[--] Project hook: {} not found", path.display()),
-            Err(_) => println!("[warn] Project hook: {} invalid JSON", path.display()),
+            Ok(None) => println!("[--] Project config: {} not found", path.display()),
+            Err(_) => println!("[warn] Project config: {} invalid JSON", path.display()),
         }
     }
 
-    // Local AGENTS.md
-    let local_agents_md = PathBuf::from(AGENTS_MD);
-    if local_agents_md.exists() {
-        let content = fs::read_to_string(&local_agents_md).unwrap_or_default();
-        if content.contains(RTK_BLOCK_START) {
-            println!("[ok] Local AGENTS.md: rtk instructions present");
-        } else {
-            println!("[--] Local AGENTS.md: exists but rtk not configured");
-        }
+    let local_hook_dir = PathBuf::from(DEVIN_DIR).join("hooks").join("rtk");
+    if local_hook_dir.join("rtk-devin.js").exists()
+        && local_hook_dir.join("rtk-instructions.md").exists()
+    {
+        println!("[ok] Project hook files: {}", local_hook_dir.display());
     } else {
-        println!("[--] Local AGENTS.md: not found");
+        println!(
+            "[--] Project hook files: not found in {}",
+            local_hook_dir.display()
+        );
     }
 
     println!("\nUsage:");

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -3396,8 +3396,16 @@ pub fn run_devin_mode(global: bool, patch_mode: PatchMode, ctx: InitContext) -> 
 
     let patched = patch_devin_hook_file(&target, patch_mode, ctx)?;
 
-    if !global && patch_mode != PatchMode::Skip && patched {
-        maybe_patch_devin_agents_md(ctx)?;
+    // Project instructions and filters (local projects)
+    if !global {
+        generate_project_filters_template(ctx)?;
+        maybe_patch_devin_agents_md(ctx, &PathBuf::from(AGENTS_MD))?;
+    } else {
+        // Global instructions and filters
+        generate_global_filters_template(ctx)?;
+        if let Some(dir) = permissions::resolve_devin_config_dir() {
+            maybe_patch_devin_agents_md(ctx, &dir.join(AGENTS_MD))?;
+        }
     }
 
     if ctx.dry_run {
@@ -3641,13 +3649,9 @@ fn print_devin_manual_instructions(path: &Path, layout: DevinLayout) {
     }
 }
 
-fn maybe_patch_devin_agents_md(ctx: InitContext) -> Result<()> {
-    let path = PathBuf::from(AGENTS_MD);
-    if !path.exists() {
-        return Ok(());
-    }
+fn maybe_patch_devin_agents_md(ctx: InitContext, path: &Path) -> Result<()> {
     write_rtk_block(
-        &path,
+        path,
         RTK_DEVIN_AGENTS_BLOCK,
         "RTK instructions",
         "rtk init --agent devin",
@@ -3697,19 +3701,24 @@ fn uninstall_devin_artifacts(global: bool, ctx: InitContext) -> Result<Vec<Strin
         }
     }
 
-    if !global {
-        let agents_md = PathBuf::from(AGENTS_MD);
-        if agents_md.exists() {
-            let content = fs::read_to_string(&agents_md)
-                .with_context(|| format!("Failed to read AGENTS.md: {}", agents_md.display()))?;
-            if content.contains(RTK_BLOCK_START) {
-                let (cleaned, did_remove) = remove_rtk_block(&content);
-                if did_remove {
-                    if !ctx.dry_run {
-                        atomic_write(&agents_md, &cleaned)?;
-                    }
-                    removed.push(format!("AGENTS.md: {}", agents_md.display()));
+    // Remove RTK instructions from AGENTS.md
+    let agents_md = if global {
+        permissions::resolve_devin_config_dir()
+            .map(|d| d.join(AGENTS_MD))
+            .unwrap_or_else(|| PathBuf::from(AGENTS_MD))
+    } else {
+        PathBuf::from(AGENTS_MD)
+    };
+    if agents_md.exists() {
+        let content = fs::read_to_string(&agents_md)
+            .with_context(|| format!("Failed to read AGENTS.md: {}", agents_md.display()))?;
+        if content.contains(RTK_BLOCK_START) {
+            let (cleaned, did_remove) = remove_rtk_block(&content);
+            if did_remove {
+                if !ctx.dry_run {
+                    atomic_write(&agents_md, &cleaned)?;
                 }
+                removed.push(format!("AGENTS.md: {}", agents_md.display()));
             }
         }
     }
@@ -3836,6 +3845,19 @@ pub fn show_devin_config() -> Result<()> {
             } else {
                 println!("[--] Global hook: {} not found", global_config.display());
             }
+
+            // Global AGENTS.md
+            let global_agents = dir.join(AGENTS_MD);
+            if global_agents.exists() {
+                let content = fs::read_to_string(&global_agents).unwrap_or_default();
+                if content.contains(RTK_BLOCK_START) {
+                    println!("[ok] Global AGENTS.md: {}", global_agents.display());
+                } else {
+                    println!("[--] Global AGENTS.md: exists but rtk not configured");
+                }
+            } else {
+                println!("[--] Global AGENTS.md: not found");
+            }
         }
         None => println!("[--] Devin config directory not found"),
     }
@@ -3868,15 +3890,17 @@ pub fn show_devin_config() -> Result<()> {
         }
     }
 
-    let agents_md = PathBuf::from(AGENTS_MD);
-    if agents_md.exists()
-        && fs::read_to_string(&agents_md)
-            .unwrap_or_default()
-            .contains(RTK_BLOCK_START)
-    {
-        println!("[ok] AGENTS.md: RTK instructions present");
+    // Local AGENTS.md
+    let local_agents_md = PathBuf::from(AGENTS_MD);
+    if local_agents_md.exists() {
+        let content = fs::read_to_string(&local_agents_md).unwrap_or_default();
+        if content.contains(RTK_BLOCK_START) {
+            println!("[ok] Local AGENTS.md: rtk instructions present");
+        } else {
+            println!("[--] Local AGENTS.md: exists but rtk not configured");
+        }
     } else {
-        println!("[--] AGENTS.md: not found or no RTK instructions");
+        println!("[--] Local AGENTS.md: not found");
     }
 
     println!("\nUsage:");

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -13,15 +13,18 @@ use crate::hooks::constants::{
 };
 
 use super::constants::{
-    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND, DROID_DIR,
-    DROID_EXECUTE_MATCHER, DROID_HOME_ENV, DROID_HOOKS_FILE, DROID_HOOKS_SUBDIR,
-    DROID_HOOK_COMMAND, DROID_SETTINGS_FILE, GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR,
-    HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON,
-    HOOKS_SUBDIR, PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR,
-    PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
+    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND, DEVIN_DIR,
+    DEVIN_EXECUTE_MATCHER, DEVIN_HOOKS_FILE, DEVIN_HOOK_COMMAND, DEVIN_SETTINGS_FILE,
+    DEVIN_SETTINGS_LOCAL_JSON, DROID_DIR, DROID_EXECUTE_MATCHER, DROID_HOME_ENV, DROID_HOOKS_FILE,
+    DROID_HOOKS_SUBDIR, DROID_HOOK_COMMAND, DROID_SETTINGS_FILE, GEMINI_HOOK_FILE, HERMES_DIR,
+    HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE,
+    HERMES_PLUGIN_NAME, HOOKS_JSON, HOOKS_SUBDIR, PI_CODING_AGENT_DIR_ENV, PI_DIR,
+    PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR, PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE,
+    SETTINGS_JSON,
 };
 use super::integrity;
 use super::is_claude_hook_command;
+use super::permissions;
 
 // Embedded OpenCode plugin (auto-rewrite)
 const OPENCODE_PLUGIN: &str = include_str!("../../hooks/opencode/rtk.ts");
@@ -3356,6 +3359,549 @@ fn remove_droid_hook_from_json(root: &mut serde_json::Value, layout: DroidLayout
     modified
 }
 
+// ─── Devin CLI support ────────────────────────────────────────────────
+
+const RTK_DEVIN_AGENTS_BLOCK: &str = r##"<!-- rtk-instructions -->
+When running shell commands, prefer `rtk <command>` (e.g. `rtk git status`, `rtk cargo test`, `rtk grep`, `rtk find`, `rtk read`). RTK compacts supported command output and passes unsupported commands through unchanged.
+<!-- /rtk-instructions -->"##;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DevinLayout {
+    /// `hooks.v1.json`: the event map is the file's root object.
+    Root,
+    /// `config.json`: hook events live under a top-level `hooks` key.
+    Nested,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct DevinHookFile {
+    path: PathBuf,
+    layout: DevinLayout,
+}
+
+/// Install Devin CLI PreToolUse hook.
+pub fn run_devin_mode(global: bool, patch_mode: PatchMode, ctx: InitContext) -> Result<()> {
+    let target = resolve_devin_install_target(global)?;
+
+    if !ctx.dry_run {
+        if let Some(parent) = target.path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "Failed to create Devin config directory: {}",
+                    parent.display()
+                )
+            })?;
+        }
+    }
+
+    let patched = patch_devin_hook_file(&target, patch_mode, ctx)?;
+
+    if !global && patch_mode != PatchMode::Skip && patched {
+        maybe_patch_devin_agents_md(ctx)?;
+    }
+
+    if ctx.dry_run {
+        print_dry_run_footer();
+    } else {
+        let scope = if global { "global" } else { "project" };
+        println!("\nDevin CLI hook registered ({scope}).\n");
+        println!("  Command:    {}", DEVIN_HOOK_COMMAND);
+        println!("  Hooks file: {}", target.path.display());
+        if patched {
+            println!("  RTK PreToolUse entry added");
+        } else {
+            println!("  RTK PreToolUse entry already present or skipped");
+        }
+        println!("  Restart Devin CLI. Test with: git status\n");
+    }
+
+    Ok(())
+}
+
+fn resolve_devin_install_target(global: bool) -> Result<DevinHookFile> {
+    if global {
+        let dir = permissions::resolve_devin_config_dir()
+            .context("Cannot determine Devin config directory. Set $DEVIN_CONFIG_DIR or $HOME.")?;
+        return Ok(DevinHookFile {
+            path: dir.join(DEVIN_SETTINGS_FILE),
+            layout: DevinLayout::Nested,
+        });
+    }
+
+    let devin_dir = std::env::current_dir()
+        .context("Failed to read current directory")?
+        .join(DEVIN_DIR);
+
+    let candidates = devin_hook_file_candidates(&devin_dir);
+
+    for candidate in &candidates {
+        if let Some(json) = read_devin_json(&candidate.path)? {
+            if devin_hook_already_present(&json, candidate.layout) {
+                return Ok(candidate.clone());
+            }
+        }
+    }
+
+    for candidate in &candidates {
+        if candidate.path.exists() {
+            return Ok(candidate.clone());
+        }
+    }
+
+    Ok(DevinHookFile {
+        path: devin_dir.join(DEVIN_HOOKS_FILE),
+        layout: DevinLayout::Root,
+    })
+}
+
+fn devin_hook_file_candidates(devin_dir: &Path) -> [DevinHookFile; 3] {
+    [
+        DevinHookFile {
+            path: devin_dir.join(DEVIN_HOOKS_FILE),
+            layout: DevinLayout::Root,
+        },
+        DevinHookFile {
+            path: devin_dir.join(DEVIN_SETTINGS_FILE),
+            layout: DevinLayout::Nested,
+        },
+        DevinHookFile {
+            path: devin_dir.join(DEVIN_SETTINGS_LOCAL_JSON),
+            layout: DevinLayout::Nested,
+        },
+    ]
+}
+
+fn read_devin_json(path: &Path) -> Result<Option<serde_json::Value>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    if content.trim().is_empty() {
+        return Ok(Some(serde_json::json!({})));
+    }
+    serde_json::from_str(&content)
+        .map(Some)
+        .with_context(|| format!("Failed to parse {} as JSON", path.display()))
+}
+
+fn devin_events(root: &serde_json::Value, layout: DevinLayout) -> &serde_json::Value {
+    match layout {
+        DevinLayout::Root => root,
+        DevinLayout::Nested => root.get("hooks").unwrap_or(&serde_json::Value::Null),
+    }
+}
+
+fn devin_hook_already_present(root: &serde_json::Value, layout: DevinLayout) -> bool {
+    let pre = match devin_events(root, layout)
+        .get(PRE_TOOL_USE_KEY)
+        .and_then(|p| p.as_array())
+    {
+        Some(arr) => arr,
+        None => return false,
+    };
+
+    pre.iter().any(|matcher_entry| {
+        let matcher = matcher_entry
+            .get("matcher")
+            .and_then(|m| m.as_str())
+            .unwrap_or("");
+        if matcher != DEVIN_EXECUTE_MATCHER {
+            return false;
+        }
+        matcher_entry
+            .get("hooks")
+            .and_then(|h| h.as_array())
+            .map(|arr| arr.as_slice())
+            .unwrap_or(&[])
+            .iter()
+            .any(|hook| {
+                hook.get("command")
+                    .and_then(|c| c.as_str())
+                    .is_some_and(|cmd| cmd == DEVIN_HOOK_COMMAND)
+            })
+    })
+}
+
+fn insert_devin_hook_entry(root: &mut serde_json::Value, layout: DevinLayout) -> Result<()> {
+    let events = match layout {
+        DevinLayout::Root => root
+            .as_object_mut()
+            .context("Devin hook file root is not an object")?,
+        DevinLayout::Nested => root
+            .as_object_mut()
+            .context("Devin config root is not an object")?
+            .entry("hooks")
+            .or_insert_with(|| serde_json::json!({}))
+            .as_object_mut()
+            .context("Devin config `hooks` key is not an object")?,
+    };
+
+    let pre_tool_use = events
+        .entry(PRE_TOOL_USE_KEY)
+        .or_insert_with(|| serde_json::json!([]))
+        .as_array_mut()
+        .context("PreToolUse value is not an array")?;
+
+    for entry in pre_tool_use.iter_mut() {
+        let matcher = entry.get("matcher").and_then(|m| m.as_str()).unwrap_or("");
+        if matcher == DEVIN_EXECUTE_MATCHER {
+            if let Some(hook_array) = entry.get_mut("hooks").and_then(|h| h.as_array_mut()) {
+                hook_array.push(serde_json::json!({
+                    "type": "command",
+                    "command": DEVIN_HOOK_COMMAND
+                }));
+                return Ok(());
+            }
+        }
+    }
+
+    pre_tool_use.push(serde_json::json!({
+        "matcher": DEVIN_EXECUTE_MATCHER,
+        "hooks": [
+            { "type": "command", "command": DEVIN_HOOK_COMMAND }
+        ]
+    }));
+    Ok(())
+}
+
+fn patch_devin_hook_file(file: &DevinHookFile, mode: PatchMode, ctx: InitContext) -> Result<bool> {
+    let InitContext { verbose, dry_run } = ctx;
+    let path = &file.path;
+
+    let mut root = read_devin_json(path)?.unwrap_or_else(|| serde_json::json!({}));
+
+    if devin_hook_already_present(&root, file.layout) {
+        if verbose > 0 {
+            eprintln!("{}: RTK hook already present", path.display());
+        }
+        return Ok(false);
+    }
+
+    match mode {
+        PatchMode::Skip => {
+            print_devin_manual_instructions(path, file.layout);
+            return Ok(false);
+        }
+        PatchMode::Ask => {
+            if dry_run {
+                println!("[dry-run] would prompt before patching {}", path.display());
+            } else if !prompt_user_consent(path)? {
+                print_devin_manual_instructions(path, file.layout);
+                return Ok(false);
+            }
+        }
+        PatchMode::Auto => {}
+    }
+
+    insert_devin_hook_entry(&mut root, file.layout)?;
+
+    let serialized =
+        serde_json::to_string_pretty(&root).context("Failed to serialize Devin hook file")?;
+
+    if dry_run {
+        println!("[dry-run] would patch Devin hook file: {}", path.display());
+        if verbose > 0 {
+            println!("[dry-run] content:\n{}", serialized);
+        }
+        return Ok(true);
+    }
+
+    if path.exists() {
+        let backup_path = path.with_extension("json.bak");
+        fs::copy(path, &backup_path)
+            .with_context(|| format!("Failed to backup to {}", backup_path.display()))?;
+        if verbose > 0 {
+            eprintln!("Backup: {}", backup_path.display());
+        }
+    }
+
+    atomic_write(path, &serialized)?;
+    Ok(true)
+}
+
+fn print_devin_manual_instructions(path: &Path, layout: DevinLayout) {
+    println!(
+        "To install manually, add the following to {}:",
+        path.display()
+    );
+    let entry = serde_json::json!({
+        "matcher": DEVIN_EXECUTE_MATCHER,
+        "hooks": [
+            { "type": "command", "command": DEVIN_HOOK_COMMAND }
+        ]
+    });
+    match layout {
+        DevinLayout::Root => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    PRE_TOOL_USE_KEY: [entry]
+                }))
+                .unwrap()
+            );
+        }
+        DevinLayout::Nested => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "hooks": {
+                        PRE_TOOL_USE_KEY: [entry]
+                    }
+                }))
+                .unwrap()
+            );
+        }
+    }
+}
+
+fn maybe_patch_devin_agents_md(ctx: InitContext) -> Result<()> {
+    let path = PathBuf::from(AGENTS_MD);
+    if !path.exists() {
+        return Ok(());
+    }
+    write_rtk_block(
+        &path,
+        RTK_DEVIN_AGENTS_BLOCK,
+        "RTK instructions",
+        "rtk init --agent devin",
+        ctx,
+    )?;
+    Ok(())
+}
+
+pub fn uninstall_devin(global: bool, ctx: InitContext) -> Result<()> {
+    let removed = uninstall_devin_artifacts(global, ctx)?;
+
+    if removed.is_empty() {
+        println!("RTK Devin CLI support was not installed (nothing to remove)");
+    } else {
+        let header = if ctx.dry_run {
+            "[dry-run] would uninstall RTK for Devin CLI:"
+        } else {
+            "RTK uninstalled for Devin CLI:"
+        };
+        println!("{}", header);
+        for item in removed {
+            println!("  - {}", item);
+        }
+    }
+
+    if ctx.dry_run {
+        print_dry_run_footer();
+    }
+    Ok(())
+}
+
+fn uninstall_devin_artifacts(global: bool, ctx: InitContext) -> Result<Vec<String>> {
+    let mut removed = Vec::new();
+
+    let devin_dir = if global {
+        permissions::resolve_devin_config_dir()
+            .context("Cannot determine Devin config directory. Set $DEVIN_CONFIG_DIR or $HOME.")?
+    } else {
+        std::env::current_dir()
+            .context("Failed to read current directory")?
+            .join(DEVIN_DIR)
+    };
+
+    for candidate in devin_hook_file_candidates(&devin_dir) {
+        if remove_devin_hook_from_file(&candidate, ctx)? {
+            removed.push(format!("Devin hook file: {}", candidate.path.display()));
+        }
+    }
+
+    if !global {
+        let agents_md = PathBuf::from(AGENTS_MD);
+        if agents_md.exists() {
+            let content = fs::read_to_string(&agents_md)
+                .with_context(|| format!("Failed to read AGENTS.md: {}", agents_md.display()))?;
+            if content.contains(RTK_BLOCK_START) {
+                let (cleaned, did_remove) = remove_rtk_block(&content);
+                if did_remove {
+                    if !ctx.dry_run {
+                        atomic_write(&agents_md, &cleaned)?;
+                    }
+                    removed.push(format!("AGENTS.md: {}", agents_md.display()));
+                }
+            }
+        }
+    }
+
+    Ok(removed)
+}
+
+fn remove_devin_hook_from_file(file: &DevinHookFile, ctx: InitContext) -> Result<bool> {
+    let InitContext { verbose, dry_run } = ctx;
+    let path = &file.path;
+
+    let mut root = match read_devin_json(path)? {
+        Some(v) => v,
+        None => return Ok(false),
+    };
+
+    if !remove_devin_hook_from_json(&mut root, file.layout) {
+        return Ok(false);
+    }
+
+    if dry_run {
+        println!(
+            "[dry-run] would remove RTK entry from Devin hook file: {}",
+            path.display()
+        );
+    } else {
+        let backup_path = path.with_extension("json.bak");
+        fs::copy(path, &backup_path).ok();
+
+        let serialized =
+            serde_json::to_string_pretty(&root).context("Failed to serialize Devin hook file")?;
+        atomic_write(path, &serialized)?;
+
+        if verbose > 0 {
+            eprintln!("Removed RTK hook from {}", path.display());
+        }
+    }
+    Ok(true)
+}
+
+fn remove_devin_hook_from_json(root: &mut serde_json::Value, layout: DevinLayout) -> bool {
+    let events_obj = match layout {
+        DevinLayout::Root => root.as_object_mut(),
+        DevinLayout::Nested => root.get_mut("hooks").and_then(|h| h.as_object_mut()),
+    };
+    let events_obj = match events_obj {
+        Some(o) => o,
+        None => return false,
+    };
+
+    let pre_tool_use = match events_obj
+        .get_mut(PRE_TOOL_USE_KEY)
+        .and_then(|p| p.as_array_mut())
+    {
+        Some(arr) => arr,
+        None => return false,
+    };
+
+    let mut modified = false;
+    let mut empty_matchers = Vec::new();
+
+    for (idx, entry) in pre_tool_use.iter_mut().enumerate() {
+        let matcher = entry.get("matcher").and_then(|m| m.as_str()).unwrap_or("");
+        if matcher != DEVIN_EXECUTE_MATCHER {
+            continue;
+        }
+        if let Some(hook_arr) = entry.get_mut("hooks").and_then(|h| h.as_array_mut()) {
+            let original = hook_arr.len();
+            hook_arr.retain(|hook| {
+                hook.get("command").and_then(|c| c.as_str()) != Some(DEVIN_HOOK_COMMAND)
+            });
+            if hook_arr.len() < original {
+                modified = true;
+            }
+            if hook_arr.is_empty() {
+                empty_matchers.push(idx);
+            }
+        }
+    }
+
+    for idx in empty_matchers.into_iter().rev() {
+        pre_tool_use.remove(idx);
+        modified = true;
+    }
+
+    if pre_tool_use.is_empty() {
+        events_obj.remove(PRE_TOOL_USE_KEY);
+        modified = true;
+    }
+
+    if layout == DevinLayout::Nested
+        && root
+            .get("hooks")
+            .and_then(|h| h.as_object())
+            .is_some_and(|o| o.is_empty())
+    {
+        if let Some(obj) = root.as_object_mut() {
+            obj.remove("hooks");
+        }
+    }
+
+    modified
+}
+
+pub fn show_devin_config() -> Result<()> {
+    println!("rtk Configuration (Devin CLI):\n");
+
+    match permissions::resolve_devin_config_dir() {
+        Some(dir) => {
+            let global_config = dir.join(DEVIN_SETTINGS_FILE);
+            if let Some(v) = read_devin_json(&global_config)? {
+                if devin_hook_already_present(&v, DevinLayout::Nested) {
+                    println!(
+                        "[ok] Global hook: {} in {}",
+                        DEVIN_HOOK_COMMAND,
+                        global_config.display()
+                    );
+                } else {
+                    println!(
+                        "[--] Global hook: not present in {}",
+                        global_config.display()
+                    );
+                }
+            } else {
+                println!("[--] Global hook: {} not found", global_config.display());
+            }
+        }
+        None => println!("[--] Devin config directory not found"),
+    }
+
+    let local_devin_dir = std::env::current_dir()
+        .map(|d| d.join(DEVIN_DIR))
+        .unwrap_or_default();
+    for path in [
+        local_devin_dir.join(DEVIN_HOOKS_FILE),
+        local_devin_dir.join(DEVIN_SETTINGS_FILE),
+        local_devin_dir.join(DEVIN_SETTINGS_LOCAL_JSON),
+    ] {
+        let layout = if path.file_name().and_then(|n| n.to_str()) == Some(DEVIN_HOOKS_FILE) {
+            DevinLayout::Root
+        } else {
+            DevinLayout::Nested
+        };
+        if let Some(v) = read_devin_json(&path)? {
+            if devin_hook_already_present(&v, layout) {
+                println!(
+                    "[ok] Project hook: {} in {}",
+                    DEVIN_HOOK_COMMAND,
+                    path.display()
+                );
+            } else {
+                println!("[--] Project hook: not present in {}", path.display());
+            }
+        } else {
+            println!("[--] Project hook: {} not found", path.display());
+        }
+    }
+
+    let agents_md = PathBuf::from(AGENTS_MD);
+    if agents_md.exists()
+        && fs::read_to_string(&agents_md)
+            .unwrap_or_default()
+            .contains(RTK_BLOCK_START)
+    {
+        println!("[ok] AGENTS.md: RTK instructions present");
+    } else {
+        println!("[--] AGENTS.md: not found or no RTK instructions");
+    }
+
+    println!("\nUsage:");
+    println!("  rtk init -g --agent devin          # Global Devin CLI hook");
+    println!("  rtk init --agent devin             # Project Devin CLI hook");
+    println!("  rtk init --agent devin --uninstall # Remove Devin CLI hook");
+    println!("  rtk init --agent devin --dry-run   # Preview changes");
+
+    Ok(())
+}
+
 fn codex_rtk_md_ref(codex_dir: &Path) -> String {
     format!("@{}", codex_dir.join(RTK_MD).display())
 }
@@ -3868,12 +4414,12 @@ fn remove_cursor_hook_from_json(root: &mut serde_json::Value) -> bool {
 }
 
 /// Show current rtk configuration
-pub fn show_config(codex: bool) -> Result<()> {
-    if codex {
-        return show_codex_config();
+pub fn show_config(codex: bool, agent: Option<crate::AgentTarget>) -> Result<()> {
+    match agent {
+        Some(crate::AgentTarget::Devin) => show_devin_config(),
+        _ if codex => show_codex_config(),
+        _ => show_claude_config(),
     }
-
-    show_claude_config()
 }
 
 fn show_claude_config() -> Result<()> {
@@ -4103,6 +4649,7 @@ fn show_claude_config() -> Result<()> {
     println!("  rtk init -g --codex         # Configure $CODEX_HOME/AGENTS.md + $CODEX_HOME/RTK.md (or ~/.codex/)");
     println!("  rtk init -g --opencode      # OpenCode plugin only");
     println!("  rtk init -g --agent cursor  # Install Cursor Agent hooks");
+    println!("  rtk init -g --agent devin   # Install Devin CLI hook");
 
     Ok(())
 }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -3361,9 +3361,7 @@ fn remove_droid_hook_from_json(root: &mut serde_json::Value, layout: DroidLayout
 
 // ─── Devin CLI support ────────────────────────────────────────────────
 
-const RTK_DEVIN_AGENTS_BLOCK: &str = r##"<!-- rtk-instructions -->
-When running shell commands, prefer `rtk <command>` (e.g. `rtk git status`, `rtk cargo test`, `rtk grep`, `rtk find`, `rtk read`). RTK compacts supported command output and passes unsupported commands through unchanged.
-<!-- /rtk-instructions -->"##;
+const RTK_DEVIN_AGENTS_BLOCK: &str = include_str!("../../hooks/devin/rtk-awareness.md");
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum DevinLayout {
@@ -3397,11 +3395,22 @@ pub fn run_devin_mode(global: bool, patch_mode: PatchMode, ctx: InitContext) -> 
     let patched = patch_devin_hook_file(&target, patch_mode, ctx)?;
 
     // Project instructions and filters (local projects)
+    let agents_md_path: PathBuf;
+    let filters_path: PathBuf;
     if !global {
+        agents_md_path = PathBuf::from(AGENTS_MD);
+        filters_path = PathBuf::from(".rtk").join("filters.toml");
         generate_project_filters_template(ctx)?;
-        maybe_patch_devin_agents_md(ctx, &PathBuf::from(AGENTS_MD))?;
+        maybe_patch_devin_agents_md(ctx, &agents_md_path)?;
     } else {
         // Global instructions and filters
+        agents_md_path = permissions::resolve_devin_config_dir()
+            .map(|d| d.join(AGENTS_MD))
+            .unwrap_or_else(|| PathBuf::from(AGENTS_MD));
+        filters_path = dirs::config_dir()
+            .unwrap_or_else(|| PathBuf::from(".config"))
+            .join(crate::core::constants::RTK_DATA_DIR)
+            .join("filters.toml");
         generate_global_filters_template(ctx)?;
         if let Some(dir) = permissions::resolve_devin_config_dir() {
             maybe_patch_devin_agents_md(ctx, &dir.join(AGENTS_MD))?;
@@ -3415,6 +3424,8 @@ pub fn run_devin_mode(global: bool, patch_mode: PatchMode, ctx: InitContext) -> 
         println!("\nDevin CLI hook registered ({scope}).\n");
         println!("  Command:    {}", DEVIN_HOOK_COMMAND);
         println!("  Hooks file: {}", target.path.display());
+        println!("  AGENTS.md:  {}", agents_md_path.display());
+        println!("  Filters:    {} (template)", filters_path.display());
         if patched {
             println!("  RTK PreToolUse entry added");
         } else {

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -3727,7 +3727,13 @@ fn uninstall_devin_artifacts(global: bool, ctx: InitContext) -> Result<Vec<Strin
             let (cleaned, did_remove) = remove_rtk_block(&content);
             if did_remove {
                 if !ctx.dry_run {
-                    atomic_write(&agents_md, &cleaned)?;
+                    if cleaned.trim().is_empty() {
+                        fs::remove_file(&agents_md).with_context(|| {
+                            format!("Failed to remove AGENTS.md: {}", agents_md.display())
+                        })?;
+                    } else {
+                        atomic_write(&agents_md, &cleaned)?;
+                    }
                 }
                 removed.push(format!("AGENTS.md: {}", agents_md.display()));
             }
@@ -3840,21 +3846,26 @@ pub fn show_devin_config() -> Result<()> {
     match permissions::resolve_devin_config_dir() {
         Some(dir) => {
             let global_config = dir.join(DEVIN_SETTINGS_FILE);
-            if let Some(v) = read_optional_json(&global_config)? {
-                if devin_hook_already_present(&v, DevinLayout::Nested) {
-                    println!(
-                        "[ok] Global hook: {} in {}",
-                        DEVIN_HOOK_COMMAND,
-                        global_config.display()
-                    );
-                } else {
-                    println!(
-                        "[--] Global hook: not present in {}",
-                        global_config.display()
-                    );
+            match read_optional_json(&global_config) {
+                Ok(Some(v)) => {
+                    if devin_hook_already_present(&v, DevinLayout::Nested) {
+                        println!(
+                            "[ok] Global hook: {} in {}",
+                            DEVIN_HOOK_COMMAND,
+                            global_config.display()
+                        );
+                    } else {
+                        println!(
+                            "[--] Global hook: not present in {}",
+                            global_config.display()
+                        );
+                    }
                 }
-            } else {
-                println!("[--] Global hook: {} not found", global_config.display());
+                Ok(None) => println!("[--] Global hook: {} not found", global_config.display()),
+                Err(_) => println!(
+                    "[warn] Global hook: {} invalid JSON",
+                    global_config.display()
+                ),
             }
 
             // Global AGENTS.md
@@ -3886,18 +3897,20 @@ pub fn show_devin_config() -> Result<()> {
         } else {
             DevinLayout::Nested
         };
-        if let Some(v) = read_optional_json(&path)? {
-            if devin_hook_already_present(&v, layout) {
-                println!(
-                    "[ok] Project hook: {} in {}",
-                    DEVIN_HOOK_COMMAND,
-                    path.display()
-                );
-            } else {
-                println!("[--] Project hook: not present in {}", path.display());
+        match read_optional_json(&path) {
+            Ok(Some(v)) => {
+                if devin_hook_already_present(&v, layout) {
+                    println!(
+                        "[ok] Project hook: {} in {}",
+                        DEVIN_HOOK_COMMAND,
+                        path.display()
+                    );
+                } else {
+                    println!("[--] Project hook: not present in {}", path.display());
+                }
             }
-        } else {
-            println!("[--] Project hook: {} not found", path.display());
+            Ok(None) => println!("[--] Project hook: {} not found", path.display()),
+            Err(_) => println!("[warn] Project hook: {} invalid JSON", path.display()),
         }
     }
 

--- a/src/hooks/integrity.rs
+++ b/src/hooks/integrity.rs
@@ -265,6 +265,80 @@ pub fn run_verify(verbose: u8) -> Result<()> {
     Ok(())
 }
 
+/// Run Devin CLI hook integrity check and print results (for `rtk verify`).
+///
+/// Compares the installed lifecycle hook files (`rtk-devin.js` and
+/// `rtk-instructions.md`) against the source-of-truth content embedded in the
+/// RTK binary at build time. This catches tampering and version skew.
+pub fn run_verify_devin(_verbose: u8) -> Result<()> {
+    let mut any_scope = false;
+
+    // Global Devin hook directory
+    if let Some(config_dir) = super::permissions::resolve_devin_config_dir() {
+        let global_dir = config_dir.join("hooks").join("rtk");
+        if global_dir.exists() {
+            any_scope = true;
+            verify_devin_hook_dir(&global_dir, "global")?;
+        }
+    }
+
+    // Project-local Devin hook directory
+    let project_dir = PathBuf::from(".devin").join("hooks").join("rtk");
+    if project_dir.exists() {
+        any_scope = true;
+        verify_devin_hook_dir(&project_dir, "project")?;
+    }
+
+    if !any_scope {
+        println!("SKIP  Devin CLI hooks not installed");
+        println!("      Run `rtk init --agent devin` or `rtk init -g --agent devin` to install.");
+    }
+
+    Ok(())
+}
+
+fn verify_devin_hook_dir(dir: &Path, scope: &str) -> Result<()> {
+    let js_path = dir.join("rtk-devin.js");
+    let md_path = dir.join("rtk-instructions.md");
+
+    if !js_path.exists() || !md_path.exists() {
+        println!(
+            "WARN  Devin CLI {scope} hook files incomplete in {}",
+            dir.display()
+        );
+        return Ok(());
+    }
+
+    let js_actual = fs::read_to_string(&js_path)
+        .with_context(|| format!("Failed to read {}", js_path.display()))?;
+    let md_actual = fs::read_to_string(&md_path)
+        .with_context(|| format!("Failed to read {}", md_path.display()))?;
+
+    let js_expected = super::init::RTK_DEVIN_JS;
+    let md_expected = super::init::RTK_DEVIN_INSTRUCTIONS;
+
+    if js_actual != js_expected || md_actual != md_expected {
+        eprintln!("FAIL  Devin CLI {scope} hook files do not match the installed RTK binary");
+        if js_actual != js_expected {
+            eprintln!("  tampered: {}", js_path.display());
+        }
+        if md_actual != md_expected {
+            eprintln!("  tampered: {}", md_path.display());
+        }
+        eprintln!("  Run `rtk init --agent devin` or `rtk init -g --agent devin` to restore.");
+        std::process::exit(1);
+    }
+
+    let js_hash = compute_hash(&js_path)?;
+    let md_hash = compute_hash(&md_path)?;
+    println!("PASS  Devin CLI {scope} hook files verified");
+    println!("      sha256:{}  rtk-devin.js", js_hash);
+    println!("      sha256:{}  rtk-instructions.md", md_hash);
+    println!("      {}", dir.display());
+
+    Ok(())
+}
+
 /// Runtime integrity gate. Called at startup for operational commands.
 ///
 /// Behavior:

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -238,14 +238,12 @@ pub(crate) fn resolve_devin_config_dir() -> Option<PathBuf> {
     default_devin_config_dir()
 }
 
-#[cfg(windows)]
 fn default_devin_config_dir() -> Option<PathBuf> {
-    dirs::config_dir().map(|d| d.join("devin"))
-}
-
-#[cfg(not(windows))]
-fn default_devin_config_dir() -> Option<PathBuf> {
-    dirs::home_dir().map(|d| d.join(".config/devin"))
+    if cfg!(windows) {
+        dirs::config_dir().map(|d| d.join("devin"))
+    } else {
+        dirs::home_dir().map(|d| d.join(".config/devin"))
+    }
 }
 
 /// Extract `Exec(<pattern>)` and tool-based `exec` rules from Devin permissions.

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -1,5 +1,6 @@
 use super::constants::{
-    CLAUDE_DIR, CURSOR_DIR, DROID_DIR, DROID_HOME_ENV, DROID_SETTINGS_FILE, GEMINI_DIR,
+    CLAUDE_DIR, CURSOR_DIR, DEVIN_CONFIG_DIR_ENV, DEVIN_DIR, DEVIN_SETTINGS_FILE,
+    DEVIN_SETTINGS_LOCAL_JSON, DROID_DIR, DROID_HOME_ENV, DROID_SETTINGS_FILE, GEMINI_DIR,
     SETTINGS_JSON, SETTINGS_LOCAL_JSON,
 };
 use crate::core::stream::exec_capture;
@@ -36,6 +37,7 @@ pub enum Host {
     Cursor,
     Gemini,
     Droid,
+    Devin,
 }
 
 pub fn check_command_for(cmd: &str, host: Host) -> PermissionVerdict {
@@ -44,6 +46,7 @@ pub fn check_command_for(cmd: &str, host: Host) -> PermissionVerdict {
         Host::Cursor => load_cursor_rules(),
         Host::Gemini => load_gemini_rules(),
         Host::Droid => load_droid_rules(),
+        Host::Devin => load_devin_rules(),
     };
     check_command_with_rules(cmd, &deny_rules, &ask_rules, &allow_rules)
 }
@@ -186,6 +189,82 @@ fn get_settings_paths() -> Vec<PathBuf> {
     }
 
     paths
+}
+
+// ── Devin CLI permission rules ───────────────────────────────────
+
+fn load_devin_rules() -> (Vec<String>, Vec<String>, Vec<String>) {
+    let mut deny_rules = Vec::new();
+    let mut ask_rules = Vec::new();
+    let mut allow_rules = Vec::new();
+
+    for path in get_devin_settings_paths() {
+        let Some(json) = read_json(&path) else {
+            continue;
+        };
+        let Some(permissions) = json.get("permissions") else {
+            continue;
+        };
+
+        append_devin_rules(permissions.get("deny"), &mut deny_rules);
+        append_devin_rules(permissions.get("ask"), &mut ask_rules);
+        append_devin_rules(permissions.get("allow"), &mut allow_rules);
+    }
+
+    (deny_rules, ask_rules, allow_rules)
+}
+
+fn get_devin_settings_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    if let Some(root) = find_project_root() {
+        paths.push(root.join(DEVIN_DIR).join(DEVIN_SETTINGS_FILE));
+        paths.push(root.join(DEVIN_DIR).join(DEVIN_SETTINGS_LOCAL_JSON));
+    }
+    if let Some(dir) = resolve_devin_config_dir() {
+        paths.push(dir.join(DEVIN_SETTINGS_FILE));
+    }
+
+    paths
+}
+
+pub(crate) fn resolve_devin_config_dir() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os(DEVIN_CONFIG_DIR_ENV).filter(|v| !v.is_empty()) {
+        return Some(PathBuf::from(path));
+    }
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME").filter(|v| !v.is_empty()) {
+        return Some(PathBuf::from(xdg).join("devin"));
+    }
+    default_devin_config_dir()
+}
+
+#[cfg(windows)]
+fn default_devin_config_dir() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("devin"))
+}
+
+#[cfg(not(windows))]
+fn default_devin_config_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|d| d.join(".config/devin"))
+}
+
+/// Extract `Exec(<pattern>)` and tool-based `exec` rules from Devin permissions.
+fn append_devin_rules(rules_value: Option<&Value>, target: &mut Vec<String>) {
+    let Some(arr) = rules_value.and_then(|v| v.as_array()) else {
+        return;
+    };
+    for rule in arr.iter().filter_map(|r| r.as_str()) {
+        if rule == "exec" {
+            target.push("*".to_string());
+            continue;
+        }
+        if let Some(inner) = rule.strip_prefix("Exec(").and_then(|s| s.strip_suffix(')')) {
+            let inner = inner.trim();
+            if !inner.is_empty() {
+                target.push(inner.to_string());
+            }
+        }
+    }
 }
 
 fn read_json(path: &std::path::Path) -> Option<Value> {
@@ -334,14 +413,14 @@ pub(crate) fn droid_rules_from_settings(
     (deny, Vec::new(), Vec::new())
 }
 
-/// Locate the project root by walking up from CWD looking for `.claude/`.
+/// Locate the project root by walking up from CWD looking for `.claude/` or `.devin/`.
 ///
 /// Falls back to `git rev-parse --show-toplevel` if not found via directory walk.
 fn find_project_root() -> Option<PathBuf> {
-    // Fast path: walk up CWD looking for .claude/ — no subprocess needed.
+    // Fast path: walk up CWD looking for .claude/ or .devin/ — no subprocess needed.
     let mut dir = std::env::current_dir().ok()?;
     loop {
-        if dir.join(CLAUDE_DIR).exists() {
+        if dir.join(CLAUDE_DIR).exists() || dir.join(DEVIN_DIR).exists() {
             return Some(dir);
         }
         if !dir.pop() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1570,6 +1570,8 @@ where
         uninstall_hermes(ctx)
     } else if agent == Some(AgentTarget::Droid) {
         hooks::init::uninstall_droid(global, ctx)
+    } else if agent == Some(AgentTarget::Devin) {
+        hooks::init::uninstall_devin(global, ctx)
     } else {
         let cursor = agent == Some(AgentTarget::Cursor);
         let pi = agent == Some(AgentTarget::Pi);
@@ -2016,10 +2018,15 @@ fn run_cli() -> Result<i32> {
                 verbose: cli.verbose,
                 dry_run,
             };
+            let patch_mode = if auto_patch {
+                hooks::init::PatchMode::Auto
+            } else if no_patch {
+                hooks::init::PatchMode::Skip
+            } else {
+                hooks::init::PatchMode::Ask
+            };
             if show {
                 hooks::init::show_config(codex, agent)?;
-            } else if uninstall && agent == Some(AgentTarget::Devin) {
-                hooks::init::uninstall_devin(global, ctx)?;
             } else if uninstall && copilot {
                 if global {
                     hooks::init::uninstall_copilot_global(ctx)?;
@@ -2037,13 +2044,6 @@ fn run_cli() -> Result<i32> {
                     hooks::init::uninstall,
                 )?;
             } else if gemini {
-                let patch_mode = if auto_patch {
-                    hooks::init::PatchMode::Auto
-                } else if no_patch {
-                    hooks::init::PatchMode::Skip
-                } else {
-                    hooks::init::PatchMode::Ask
-                };
                 hooks::init::run_gemini(global, hook_only, patch_mode, ctx)?;
             } else if copilot {
                 if global {
@@ -2078,13 +2078,6 @@ fn run_cli() -> Result<i32> {
                 if codex || gemini || copilot || opencode || claude_md {
                     anyhow::bail!("--agent devin cannot be combined with --codex, --gemini, --copilot, --opencode, or --claude-md");
                 }
-                let patch_mode = if auto_patch {
-                    hooks::init::PatchMode::Auto
-                } else if no_patch {
-                    hooks::init::PatchMode::Skip
-                } else {
-                    hooks::init::PatchMode::Ask
-                };
                 hooks::init::run_devin_mode(global, patch_mode, ctx)?;
             } else {
                 let install_opencode = opencode;
@@ -2093,13 +2086,6 @@ fn run_cli() -> Result<i32> {
                 let install_windsurf = agent == Some(AgentTarget::Windsurf);
                 let install_cline = agent == Some(AgentTarget::Cline);
 
-                let patch_mode = if auto_patch {
-                    hooks::init::PatchMode::Auto
-                } else if no_patch {
-                    hooks::init::PatchMode::Skip
-                } else {
-                    hooks::init::PatchMode::Ask
-                };
                 hooks::init::run(
                     global,
                     install_claude,

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,8 @@ pub enum AgentTarget {
     Hermes,
     /// Factory Droid CLI
     Droid,
+    /// Devin CLI
+    Devin,
 }
 
 #[derive(Parser)]
@@ -866,6 +868,8 @@ enum HookCommands {
     Copilot,
     /// Process Factory Droid PreToolUse hook (reads JSON from stdin)
     Droid,
+    /// Process Devin CLI PreToolUse hook (reads JSON from stdin)
+    Devin,
     /// Check how a command would be rewritten by the hook engine (dry-run)
     Check {
         /// Target agent
@@ -2013,7 +2017,9 @@ fn run_cli() -> Result<i32> {
                 dry_run,
             };
             if show {
-                hooks::init::show_config(codex)?;
+                hooks::init::show_config(codex, agent)?;
+            } else if uninstall && agent == Some(AgentTarget::Devin) {
+                hooks::init::uninstall_devin(global, ctx)?;
             } else if uninstall && copilot {
                 if global {
                     hooks::init::uninstall_copilot_global(ctx)?;
@@ -2068,6 +2074,18 @@ fn run_cli() -> Result<i32> {
                 hooks::init::run_hermes_mode(ctx)?;
             } else if agent == Some(AgentTarget::Droid) {
                 hooks::init::run_droid_mode(global, ctx)?;
+            } else if agent == Some(AgentTarget::Devin) {
+                if codex || gemini || copilot || opencode || claude_md {
+                    anyhow::bail!("--agent devin cannot be combined with --codex, --gemini, --copilot, --opencode, or --claude-md");
+                }
+                let patch_mode = if auto_patch {
+                    hooks::init::PatchMode::Auto
+                } else if no_patch {
+                    hooks::init::PatchMode::Skip
+                } else {
+                    hooks::init::PatchMode::Ask
+                };
+                hooks::init::run_devin_mode(global, patch_mode, ctx)?;
             } else {
                 let install_opencode = opencode;
                 let install_claude = !opencode;
@@ -2436,6 +2454,10 @@ fn run_cli() -> Result<i32> {
             }
             HookCommands::Droid => {
                 hooks::hook_cmd::run_droid()?;
+                0
+            }
+            HookCommands::Devin => {
+                hooks::hook_cmd::run_devin()?;
                 0
             }
             HookCommands::Check { agent: _, command } => {
@@ -2921,6 +2943,17 @@ mod tests {
     }
 
     #[test]
+    fn test_try_parse_init_agent_devin() {
+        let cli = Cli::try_parse_from(["rtk", "init", "--agent", "devin"]).unwrap();
+        match cli.command {
+            Commands::Init { agent, .. } => {
+                assert_eq!(agent, Some(AgentTarget::Devin));
+            }
+            _ => panic!("Expected Init command"),
+        }
+    }
+
+    #[test]
     fn test_try_parse_kubectl_get_alias() {
         let cli = Cli::try_parse_from(["rtk", "kubectl", "get", "pods", "-n", "default"]).unwrap();
 
@@ -3203,6 +3236,17 @@ mod tests {
             cli.command,
             Commands::Hook {
                 command: HookCommands::Claude
+            }
+        ));
+    }
+
+    #[test]
+    fn test_hook_devin_parses() {
+        let cli = Cli::try_parse_from(["rtk", "hook", "devin"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Hook {
+                command: HookCommands::Devin
             }
         ));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2698,8 +2698,9 @@ fn run_cli() -> Result<i32> {
                 // Filter-specific mode: run only that filter's tests
                 hooks::verify_cmd::run(filter, require_all)?;
             } else {
-                // Default or --require-all: always run integrity check first
+                // Default or --require-all: always run integrity checks first
                 hooks::integrity::run_verify(cli.verbose)?;
+                hooks::integrity::run_verify_devin(cli.verbose)?;
                 hooks::verify_cmd::run(None, require_all)?;
             }
             0


### PR DESCRIPTION
# Upstream PR draft: Add Devin CLI support

## Title
feat(hooks): Add first-class Devin CLI integration

## Summary

Adds native support for [Devin CLI](https://docs.devin.ai/get-started) via a `PreToolUse` hook and lifecycle context hooks. Devin CLI shell commands are rewritten to `rtk <command>` whenever RTK has a filter, with decisions (`approve` / `block`) synced to Devin CLI's own permission settings.

Closes #3143

## Related

- #3143 — original feature request for Devin CLI support.
- #2605, #1851 — earlier community attempts at Devin integration (kept open as related references).

## Changes

- `src/hooks/hook_cmd.rs`
  - New `process_devin_payload`, `devin_decide_for_command`, `devin_decide_explicit_rtk`, and helpers for explicit `rtk <meta>` / `rtk proxy <cmd>` / `rtk <allowed>` handling.
- `src/hooks/init.rs`
  - `run_devin_mode`, `uninstall_devin`, `show_devin_config`, `devin_rtk_hook_dir`, `write_devin_hook_files`, and helpers to patch/remove Devin CLI hook config.
  - Writes `rtk-devin.js`, `rtk-instructions.md`, and `.gitignore` to the RTK hook directory.
- `src/hooks/integrity.rs`
  - `run_verify_devin` and `verify_devin_hook_dir` verify installed Devin lifecycle files against the source-of-truth content embedded in the binary.
- `src/hooks/permissions.rs`
  - `load_devin_rules` and `get_devin_settings_paths` read Devin CLI `permissions.allow/ask/deny` from `~/.config/devin/config.json` and `.devin/config.json*`.
- `src/hooks/constants.rs`
  - Adds `DEVIN_*` constants (matcher, hook command, config dir env).
- `src/main.rs`
  - Adds `AgentTarget::Devin` and `HookCommands::Devin`, wires `rtk verify` to run Devin integrity checks.
- `hooks/devin/rtk-devin.js`, `hooks/devin/rtk-instructions.md`, `hooks/devin/rtk-awareness.md`
  - New source-of-truth lifecycle hook files, included at build time via `include_str!`.
- `hooks/devin/test-rtk-devin.sh`
  - 34-test regression suite for the Devin CLI hook.
- `docs/guide/getting-started/supported-agents.md`, `README.md`, `INSTALL.md`
  - Update Devin CLI docs and supported-agents table.
- `docs/guide/devin-cli.md`
  - New dedicated Devin CLI setup and troubleshooting guide.
- `.github/hooks/rtk-rewrite.json`
  - Fix stale `rtk hook` command to `rtk hook copilot` and add the `preToolUse` schema used by Copilot CLI.

## Test plan

- [ ] `cargo test` passes (2505+ tests).
- [ ] `cargo clippy --all-targets` passes with no warnings.
- [ ] `bash hooks/devin/test-rtk-devin.sh` passes (34/34).
- [ ] Clean install: clone fork, run `bash install-devin.sh`, restart Devin CLI, run `git status` → should execute `rtk git status`.
- [ ] `rtk verify` reports `PASS` for Devin CLI global and project hook files.
- [ ] `rtk init -g --agent devin --uninstall` removes RTK entries and hook files without touching other hooks.

## Usage

```bash
# One-command install from the fork
git clone https://github.com/warelik/rtk.git
cd rtk
bash install-devin.sh

# Or, if rtk is already installed
rtk init -g --agent devin
```

Then restart Devin CLI and test with `git status`.

## Backwards compatibility

- No existing integrations are changed.
- Devin CLI is opt-in via `--agent devin`.
- Lifecycle hooks are idempotent; re-running `rtk init -g --agent devin` is safe.

## Notes for reviewers

- This PR intentionally takes a hook-first approach: no `AGENTS.md`/`RTK.md` injection is written, matching Devin CLI's native hook architecture.
- The lifecycle script uses a small state file (`.rtk-active`) to avoid re-injecting the full instruction block on every user prompt while still re-injecting after context compaction.
- Devin CLI config can be overridden with `$DEVIN_CONFIG_DIR`, and project hook files use `$DEVIN_PROJECT_DIR` for portability.
