### PR TITLE
fix(git): filter git show <rev>:<path> blob reads past a size threshold

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -1,6 +1,7 @@
 //! Filters git output — log, status, diff, and more — keeping just the essential info.
 
 use crate::core::args_utils;
+use crate::core::filter::{self, FilterLevel, Language};
 use crate::core::guard::never_worse;
 use crate::core::runner::{self, RunOptions};
 use crate::core::stream::{
@@ -13,6 +14,7 @@ use crate::core::utils::{
 };
 use anyhow::{Context, Result};
 use std::ffi::OsString;
+use std::path::Path;
 use std::process::Command;
 use std::process::Stdio;
 
@@ -247,17 +249,30 @@ fn run_show(
             eprintln!("{}", result.stderr);
             return Ok(result.exit_code);
         }
-        if wants_blob_show {
-            print!("{}", result.stdout);
+
+        let shown = if wants_blob_show {
+            filter_blob_show(&result.stdout, args)
         } else {
-            println!("{}", result.stdout.trim());
+            result.stdout.clone()
+        };
+
+        if wants_blob_show {
+            print!("{}", shown);
+        } else {
+            println!("{}", shown.trim());
         }
+
+        let label = if wants_blob_show && shown.len() < result.stdout.len() {
+            format!("rtk git show {} (blob-filtered)", args.join(" "))
+        } else {
+            format!("rtk git show {} (passthrough)", args.join(" "))
+        };
 
         timer.track(
             &format!("git show {}", args.join(" ")),
-            &format!("rtk git show {} (passthrough)", args.join(" ")),
+            &label,
             &result.stdout,
-            &result.stdout,
+            &shown,
         );
 
         return Ok(0);
@@ -333,6 +348,33 @@ fn run_show(
 fn is_blob_show_arg(arg: &str) -> bool {
     // Detect `rev:path` style arguments while ignoring flags like `--pretty=format:...`.
     !arg.starts_with('-') && arg.contains(':')
+}
+
+/// Blobs at or under this many lines stay raw passthrough — not worth the filter pass.
+const BLOB_FILTER_LINE_THRESHOLD: usize = 200;
+
+/// `git show <rev>:<path>` prints a file at a revision, not a diff — unlike the diff
+/// form (auto-compacted below), it was falling straight through with zero token
+/// savings even on huge files. For blobs past the threshold, run the same
+/// comment-stripping filter `rtk read -l minimal` uses, keyed off the path's
+/// extension, and let `never_worse` fall back to raw if filtering doesn't help.
+fn filter_blob_show(raw: &str, args: &[String]) -> String {
+    if raw.lines().count() <= BLOB_FILTER_LINE_THRESHOLD {
+        return raw.to_string();
+    }
+
+    let lang = args
+        .iter()
+        .find(|arg| is_blob_show_arg(arg))
+        .and_then(|arg| arg.rsplit_once(':'))
+        .map(|(_, path)| path)
+        .and_then(|path| Path::new(path).extension())
+        .and_then(|ext| ext.to_str())
+        .map(Language::from_extension)
+        .unwrap_or(Language::Unknown);
+
+    let filtered = filter::get_filter(FilterLevel::Minimal).filter(raw, &lang);
+    never_worse(raw, &filtered).to_string()
 }
 
 pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
@@ -2284,6 +2326,40 @@ mod tests {
         assert!(!is_blob_show_arg("--pretty=format:%h"));
         assert!(!is_blob_show_arg("--format=short"));
         assert!(!is_blob_show_arg("HEAD"));
+    }
+
+    #[test]
+    fn test_filter_blob_show_passthrough_under_threshold() {
+        let raw = "fn main() {\n    // a comment\n    println!(\"hi\");\n}\n";
+        let args = vec!["HEAD:src/main.rs".to_string()];
+        // Well under BLOB_FILTER_LINE_THRESHOLD, must stay byte-identical.
+        assert_eq!(filter_blob_show(raw, &args), raw);
+    }
+
+    #[test]
+    fn test_filter_blob_show_strips_comments_over_threshold() {
+        let mut raw = String::new();
+        for i in 0..250 {
+            raw.push_str(&format!("// comment {}\nlet x{} = {};\n", i, i, i));
+        }
+        let args = vec!["HEAD:src/main.rs".to_string()];
+        let filtered = filter_blob_show(&raw, &args);
+        assert!(filtered.len() < raw.len(), "filtered output should be smaller");
+        assert!(!filtered.contains("// comment"));
+        assert!(filtered.contains("let x0 = 0;"));
+        assert!(filtered.contains("let x249 = 249;"));
+    }
+
+    #[test]
+    fn test_filter_blob_show_unknown_extension_still_bounded_by_never_worse() {
+        // No recognized extension (Language::Unknown) — filter must never grow the output.
+        let mut raw = String::new();
+        for i in 0..250 {
+            raw.push_str(&format!("line {}\n", i));
+        }
+        let args = vec!["HEAD:README".to_string()];
+        let filtered = filter_blob_show(&raw, &args);
+        assert!(filtered.len() <= raw.len());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #3116

## Root cause

`git show <rev>:<path>` (blob read form) was routed to raw passthrough unconditionally in `run_show`, same as `--stat`/`--pretty` output. Unlike the diff form of `git show`, which auto-compacts below in the same function, the blob form never went through any filtering — confirmed against a real 5-week command-history DB: 436 calls, 3.82M input tokens, 0.6% aggregate savings vs. 50%+ for the `<rev> -- <path>` diff form.

## Fix

- Blobs at or under 200 lines (`BLOB_FILTER_LINE_THRESHOLD`) stay byte-identical passthrough — not worth a filter pass, per the issue's own suggested conservative threshold.
- Past that, the blob is run through the existing `MinimalFilter` (the same comment/blank-line-stripping filter `rtk read -l minimal` uses), with the language detected from the path segment of the `rev:path` arg.
- `never_worse` (already used everywhere else in this file) guards the result — if filtering doesn't actually shrink the output, raw is shown instead.
- Tracking label switches to `(blob-filtered)` vs `(passthrough)` depending on whether filtering actually reduced size, so telemetry can distinguish the two going forward.

## Verification

- `cargo test` — 2474 passed, 0 failed (3 new tests added: under-threshold passthrough stays byte-identical, over-threshold strips comments while preserving code, unknown-extension blobs are still bounded by `never_worse`).
- `cargo fmt --check` / `cargo clippy -- -D warnings` — clean.
- Live repro against this repo's own `git.rs` (3367 lines): raw `git show HEAD:src/cmds/git/git.rs` is 113,289 bytes; `rtk git show` of the same blob is 105,016 bytes (comments/blank-lines stripped, code untouched — diffed to confirm no code lines were removed, only `//` comment lines).
- Small file (`Cargo.toml`, well under the threshold) is confirmed byte-identical between `git show` and `rtk git show`.

The 200-line threshold is a first cut per the issue's own suggestion ("so tiny files stay passthrough") — happy to tune it if you'd rather key off byte size or make it configurable.