### PR TITLE
fix(read): head -N truncation must be a literal contiguous prefix

### DIFF
--- a/src/core/filter.rs
+++ b/src/core/filter.rs
@@ -326,33 +326,15 @@ pub fn smart_truncate(content: &str, max_lines: usize, _lang: &Language) -> Stri
         return content.to_string();
     }
 
-    let mut result = Vec::with_capacity(max_lines + 1);
-    let mut kept_lines = 0;
-
-    for line in &lines {
-        let trimmed = line.trim();
-
-        // Prioritize structurally important lines so the visible window stays useful.
-        // The old approach interleaved "// ... N lines omitted" markers which AI agents
-        // treated as code, causing parsing confusion and extra retry loops.
-        let is_important = FUNC_SIGNATURE.is_match(trimmed)
-            || IMPORT_PATTERN.is_match(trimmed)
-            || trimmed.starts_with("pub ")
-            || trimmed.starts_with("export ")
-            || trimmed == "}"
-            || trimmed == "{";
-
-        if is_important || kept_lines < max_lines / 2 {
-            result.push((*line).to_string());
-            kept_lines += 1;
-        }
-        // Non-important lines beyond max_lines/2 are silently skipped —
-        // no inline markers that could be mistaken for file content.
-
-        if kept_lines >= max_lines - 1 {
-            break;
-        }
-    }
+    // Bounded reads (head -N, rtk read --max-lines) promise the literal first N
+    // lines, unchanged — the same contract `head` itself has. Pulling in
+    // "important-looking" lines from later in the file (rtk-ai/rtk#3046) breaks
+    // that contract silently: a closing `}` from far past the window can land
+    // right after an early line with no marker, reading as an adjacent syntax
+    // error that isn't real. Keep it a plain contiguous slice, like the
+    // tail-lines path already does.
+    let kept_lines = max_lines.saturating_sub(1);
+    let mut result: Vec<String> = lines[..kept_lines].iter().map(|l| l.to_string()).collect();
 
     // Single end-of-output marker: not code syntax, unambiguous to AI agents.
     // Invariant: kept_lines + N == lines.len() (N = lines not shown)
@@ -518,8 +500,7 @@ fn main() {
 
     #[test]
     fn test_smart_truncate_no_annotations() {
-        // 10 plain-text lines, max_lines=3: smart logic keeps first max_lines/2=1 line.
-        // (None of the lines match FUNC_SIGNATURE or IMPORT_PATTERN patterns.)
+        // 10 plain-text lines, max_lines=3: keeps a contiguous first max_lines-1=2 lines.
         let input = "line1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9\nline10\n";
         let output = smart_truncate(input, 3, &Language::Unknown);
         // Must NOT contain old-style "// ... N lines omitted" annotations
@@ -527,10 +508,34 @@ fn main() {
             !output.contains("// ..."),
             "smart_truncate must not insert synthetic comment annotations"
         );
-        // Must contain clean end-of-output marker (1 kept + 9 omitted = 10 total)
-        assert!(output.contains("[9 more lines]"));
-        // Only the first line is kept (plain-text, no important signatures)
-        assert!(output.starts_with("line1\n"));
+        // Must contain clean end-of-output marker (2 kept + 8 omitted = 10 total)
+        assert!(output.contains("[8 more lines]"));
+        // The first two lines are kept, contiguously
+        assert!(output.starts_with("line1\nline2\n["));
+    }
+
+    #[test]
+    fn test_smart_truncate_does_not_pull_in_later_important_lines() {
+        // rtk-ai/rtk#3046: a `head -N` view must be a literal contiguous prefix.
+        // The old "importance" heuristic pulled a bare `}` in from line 63 of a
+        // 154-line file into a 30-line window, producing a false "orphaned }"
+        // that wasn't actually adjacent to anything shown above it.
+        let mut lines: Vec<String> = (0..60).map(|i| format!("export FOO_{}=1", i)).collect();
+        lines.push("}".to_string()); // line 61: a closing brace far past the window
+        lines.push("more content".to_string());
+        let content = lines.join("\n");
+
+        let output = smart_truncate(&content, 30, &Language::Unknown);
+
+        // The bare `}` must NOT appear pulled into the truncated window —
+        // only the first 29 lines (all "export FOO_*") plus the marker.
+        assert!(
+            !output.lines().any(|l| l.trim() == "}"),
+            "closing brace from beyond the window must not be pulled in:\n{}",
+            output
+        );
+        assert!(output.starts_with("export FOO_0=1\n"));
+        assert!(output.ends_with("[33 more lines]"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #3046.

`rtk read --max-lines N` — what `head -N` (and `cat`/`tail` via the same rule) rewrites to — is supposed to carry the exact same contract as `head` itself: the literal first N lines, unchanged. Instead, `smart_truncate` scanned the **entire** file and pulled in any line matching an "important" pattern (function signatures, imports, `pub`/`export` prefixes, or a bare `}`/`{`) regardless of how far past the requested window it actually was, capping total shown lines at N with no marker indicating where lines were skipped from the middle.

Concretely, for a 154-line file with `head -30`: a closing `}` from line 63 got pulled in (it matched the bare-brace "important" rule) while its own function header on line 61 — which didn't match any of the importance patterns — got silently dropped. The output showed that stray `}` sitting directly after an early, unrelated line with nothing indicating a gap existed. The agent reading it concluded the file had a genuine orphaned brace and nearly edited the user's real shell config to "fix" a defect that was actually just missing context from `head`'s own output.

This is the same category of bug the project's own design principle calls out directly (`CONTRIBUTING.md` § Transparency): RTK's output must be "a valid, useful subset of the original tool's output, not a different format the LLM wouldn't expect." A `head`-shaped request answered with a non-contiguous "greatest hits" sample is exactly that kind of invented format.

**Fix:** replace the importance-based scan with a plain contiguous slice of the first `max_lines - 1` lines plus the existing single trailing marker — matching the `tail-lines` path in the same function, which was already implemented correctly as a genuine contiguous slice.

## Test plan

- [x] Updated `test_smart_truncate_no_annotations` for the corrected line count (was asserting the buggy `max_lines/2` behavior)
- [x] Added `test_smart_truncate_does_not_pull_in_later_important_lines` — directly reproduces the #3046 shape (a bare `}` past the window) and asserts it's no longer pulled in
- [x] `test_smart_truncate_overflow_count_exact` (kept-count + reported-more == total invariant) needed no changes — still holds under the new contiguous logic
- [x] `cargo test` — 2472 passed, 0 failed
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets` — no issues