### PR TITLE
build(windows): embed VERSIONINFO into the compiled .exe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "embed-resource"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbfdaacccebec3b28e4866b8973543c7647797db5ada1bdab552e48fe665fbbd"
+dependencies = [
+ "cc",
+ "memchr",
+ "rustc_version",
+ "toml 1.1.3+spec-1.1.0",
+ "vswhom",
+ "winreg",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,6 +953,7 @@ dependencies = [
  "codepage",
  "colored",
  "dirs",
+ "embed-resource",
  "encoding_rs",
  "flate2",
  "getrandom 0.4.2",
@@ -952,7 +967,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "toml",
+ "toml 0.8.23",
  "ureq",
  "walkdir",
  "which",
@@ -971,6 +986,15 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -1093,6 +1117,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -1220,9 +1253,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -1235,6 +1283,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,10 +1299,19 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -1253,6 +1319,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "typenum"
@@ -1329,6 +1401,26 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vswhom"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b"
+dependencies = [
+ "libc",
+ "vswhom-sys",
+]
+
+[[package]]
+name = "vswhom-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -1704,6 +1796,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
+name = "winreg"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,9 @@ windows-sys = { version = "0.59", features = [
 [build-dependencies]
 toml = "0.8"
 
+[target.'cfg(windows)'.build-dependencies]
+embed-resource = "3.0"
+
 [dev-dependencies]
 
 [profile.release]

--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,16 @@ fn main() {
         // the CLI binary so `rtk.exe --version`, `--help`, and hook entry
         // points start reliably without requiring ad-hoc RUSTFLAGS.
         println!("cargo:rustc-link-arg=/STACK:8388608");
+
+        // Embed publisher/product VERSIONINFO into the compiled .exe. An
+        // unsigned binary with no version metadata is a documented contributing
+        // factor to AV heuristic false positives (#3124) — this doesn't replace
+        // code signing (tracked separately in #2989), but it's a real, cheap
+        // improvement over shipping a "faceless" binary.
+        println!("cargo:rerun-if-changed=rtk.rc");
+        embed_resource::compile("rtk.rc", embed_resource::NONE)
+            .manifest_optional()
+            .unwrap();
     }
 
     let filters_dir = Path::new("src/filters");

--- a/rtk.rc
+++ b/rtk.rc
@@ -1,0 +1,32 @@
+// Windows VERSIONINFO resource — https://learn.microsoft.com/en-us/windows/win32/menurc/versioninfo-resource
+//
+// Unsigned CLI binaries with no embedded version metadata are a well-documented
+// contributing factor to AV heuristic false positives (rtk-ai/rtk#3124). This
+// doesn't replace code signing (tracked separately in #2989) but gives the
+// compiled .exe real publisher/product identity instead of looking "faceless."
+1 VERSIONINFO
+FILEVERSION     0,42,4,0
+PRODUCTVERSION  0,42,4,0
+FILEFLAGSMASK   0x3fL
+FILEFLAGS       0x0L
+FILEOS          0x40004L
+FILETYPE        0x1L
+FILESUBTYPE     0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName", "rtk-ai\0"
+            VALUE "FileDescription", "rtk - Rust Token Killer, CLI proxy for LLM token savings\0"
+            VALUE "OriginalFilename", "rtk.exe\0"
+            VALUE "ProductName", "rtk\0"
+            VALUE "LegalCopyright", "Apache-2.0. See https://github.com/rtk-ai/rtk\0"
+        END
+    END
+
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0409, 1200
+    END
+END


### PR DESCRIPTION
## Summary

Relates to #3124 (v0.43.0 flagged as a virus by Microsoft Defender).

An unsigned binary shipping with zero embedded version metadata — no CompanyName, ProductName, FileVersion, publisher identity of any kind — is a documented contributing factor to AV heuristic false positives for Rust/Go CLI tools generally. This adds a Windows-only build.rs step that compiles `rtk.rc` via `embed-resource` and links the result into the binary, giving the compiled `.exe` real version/publisher metadata instead of shipping "faceless."

**I want to be upfront about what this does and doesn't accomplish**, rather than overclaim a fix for something I can't fully verify:

- **Verified working:** `FileVersion`/`ProductVersion` (`0.42.4.0`) and `Language` (English - United States) are correctly embedded and readable — checked directly against the built binary via .NET's `FileVersionInfo` API.
- **Not working, and I don't know why:** the `StringFileInfo` string values (`CompanyName`, `ProductName`, `FileDescription`, `LegalCopyright`, `OriginalFilename`) still come back empty on inspection, even after getting the `FIXEDFILEINFO` block (`FILEVERSION`/`PRODUCTVERSION`/etc.) correct and confirming the langID/codepage block matches the `VarFileInfo` `Translation` value. I suspect an RC codepage/encoding mismatch, but I didn't pin it down, and at that point I was guessing at `rc.exe` syntax variations without a cheap way to verify each guess — didn't want to keep committing time to that without a clearer lead. Left the `StringFileInfo` block in place since it's harmless even non-functional, and someone with more Windows resource-compiler experience may spot the issue at a glance.
- **This is not a replacement for code signing** (tracked separately in #2989) — that remains the real fix for enterprise allowlisting, and it's a cost/infrastructure decision for the maintainers, not something a contributor PR can resolve.
- **Whether this measurably affects the actual Defender false-positive rate is not something I can verify** without a real signed release build and live detection telemetry over time. AV heuristics are opaque; I'm not claiming this closes #3124, just that it's a real, low-risk improvement over the current state.

Happy to have someone else pick up the StringFileInfo gap, or to keep digging myself if there's a specific lead worth chasing.

## Test plan

- [x] `cargo build` — compiles clean on Windows, `rc.exe` runs without error, resulting `.lib` links into the binary
- [x] Verified via `[System.Diagnostics.FileVersionInfo]::GetVersionInfo()` against the built `target\debug\rtk.exe`: `FileVersionRaw`/`ProductVersionRaw` = `0.42.4.0`, `Language` = `English (United States)` — both correct
- [x] `cargo fmt --all`, `cargo clippy --all-targets`, `cargo test` — all clean, 2472 passed, 0 failed
- [ ] StringFileInfo values (CompanyName/ProductName/etc.) — not resolved, documented above