### PR TITLE
feat: add --secure, --no-telemetry, --no-tracking flags + config for corporate compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,9 +463,17 @@ rtk telemetry disable    # Withdraw consent — stops all collection immediately
 rtk telemetry forget     # Withdraw consent + delete all local data + request server-side erasure
 ```
 
+**Override via CLI flag (per-invocation):**
+```bash
+rtk --no-telemetry git log -5       # Skip telemetry for this command
+rtk --no-tracking cargo build       # Skip local history.db for this command
+rtk --secure git log -5             # Disable both (overrides config.toml)
+```
+
 **Override via environment:**
 ```bash
-export RTK_TELEMETRY_DISABLED=1   # Blocks telemetry regardless of consent
+export RTK_TELEMETRY_DISABLED=1    # Blocks telemetry regardless of consent
+export RTK_DISABLE_TRACKING=1      # Blocks local tracking regardless of consent
 ```
 
 ## Star History

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -127,6 +127,12 @@ rtk telemetry disable    # Withdraw consent
 rtk telemetry forget     # Withdraw consent + delete local data + request server erasure
 ```
 
+CLI flag override (blocks telemetry regardless of consent, per invocation):
+```bash
+rtk --no-telemetry git log -5
+rtk --secure git log -5          # also disables local tracking
+```
+
 Environment variable override (blocks telemetry regardless of consent):
 ```bash
 export RTK_TELEMETRY_DISABLED=1

--- a/docs/guide/getting-started/configuration.md
+++ b/docs/guide/getting-started/configuration.md
@@ -22,6 +22,9 @@ rtk config --create   # create config file with defaults
 ## Full config structure
 
 ```toml
+secure = false              # master switch: disables BOTH telemetry AND tracking
+                            # overrides [tracking] and [telemetry] below
+
 [tracking]
 enabled = true              # enable/disable token tracking
 history_days = 90           # retention in days (auto-cleanup)
@@ -59,7 +62,8 @@ For full details on what is collected, opt-out options, and GDPR rights, see [Te
 |----------|-------------|
 | `RTK_DISABLED=1` | Disable RTK for a single command (`RTK_DISABLED=1 git status`) |
 | `RTK_TEE_DIR` | Override the tee directory |
-| `RTK_TELEMETRY_DISABLED=1` | Disable telemetry |
+| `RTK_TELEMETRY_DISABLED=1` | Disable telemetry (overrides config) |
+| `RTK_DISABLE_TRACKING=1` | Disable local tracking database (overrides config) |
 | `RTK_HOOK_AUDIT=1` | Enable hook audit logging |
 | `SKIP_ENV_VALIDATION=1` | Skip env validation (useful with Next.js) |
 
@@ -119,10 +123,13 @@ Data sent: device hash, version, OS, architecture, command count/24h, top comman
 To opt out:
 
 ```bash
-# Via environment variable
+# Via CLI flag (per-invocation)
+rtk --no-telemetry git log -5
+
+# Via environment variable (session or CI)
 export RTK_TELEMETRY_DISABLED=1
 
-# Via config.toml
+# Via config.toml (MDM-deployable)
 [telemetry]
 enabled = false
 ```

--- a/docs/guide/resources/telemetry.md
+++ b/docs/guide/resources/telemetry.md
@@ -132,6 +132,12 @@ rtk telemetry disable    # Withdraw consent
 rtk telemetry forget     # Withdraw consent + delete local data + request server erasure
 ```
 
+CLI flag override (blocks telemetry regardless of consent, per invocation):
+```bash
+rtk --no-telemetry git log -5
+rtk --secure git log -5          # also disables local tracking
+```
+
 Environment variable override (blocks telemetry regardless of consent):
 ```bash
 export RTK_TELEMETRY_DISABLED=1

--- a/docs/usage/TRACKING.md
+++ b/docs/usage/TRACKING.md
@@ -539,7 +539,8 @@ let _ = conn.execute(
 ## Security & Privacy
 
 - **Local storage only**: Tracking database never leaves the machine
-- **Telemetry requires consent**: RTK can send a daily anonymous usage ping (version, OS, command counts, token savings). Disabled by default, requires explicit consent via `rtk init` or `rtk telemetry enable`. Manage with `rtk telemetry status/disable/forget`. Override: `RTK_TELEMETRY_DISABLED=1`
+- **Telemetry requires consent**: RTK can send a daily anonymous usage ping (version, OS, command counts, token savings). Disabled by default, requires explicit consent via `rtk init` or `rtk telemetry enable`. Manage with `rtk telemetry status/disable/forget`. Override: `RTK_TELEMETRY_DISABLED=1` or `rtk --no-telemetry`
+- **Tracking can be disabled**: Disable the local tracking database via `RTK_DISABLE_TRACKING=1`, `rtk --no-tracking`, or `[tracking] enabled = false` in `config.toml`. Use `rtk --secure` to disable both tracking and telemetry at once.
 - **User control**: Users can delete `~/.local/share/rtk/tracking.db` anytime
 - **90-day retention**: Old data automatically purged
 

--- a/src/analytics/cc_economics.rs
+++ b/src/analytics/cc_economics.rs
@@ -187,7 +187,31 @@ pub fn run(
     format: &str,
     verbose: u8,
 ) -> Result<()> {
-    let tracker = Tracker::new().context("Failed to initialize tracking database")?;
+    if crate::core::secure::is_tracking_forced_off()
+        || std::env::var("RTK_DISABLE_TRACKING").as_deref() == Ok("1")
+    {
+        match format {
+            "json" => println!("{}", serde_json::json!({"tracking": "disabled"})),
+            _ => println!(
+                "Tracking is disabled by --secure, --no-tracking, or config.toml. No data to show."
+            ),
+        }
+        return Ok(());
+    }
+    let tracker = match Tracker::new() {
+        Ok(t) => t,
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("tracking disabled") {
+                match format {
+                    "json" => println!("{}", serde_json::json!({"tracking": "disabled"})),
+                    _ => println!("{}", msg),
+                }
+                return Ok(());
+            }
+            anyhow::bail!("Failed to initialize tracking database: {}", msg);
+        }
+    };
 
     match format {
         "json" => export_json(&tracker, daily, weekly, monthly, all),

--- a/src/analytics/gain.rs
+++ b/src/analytics/gain.rs
@@ -782,3 +782,18 @@ fn confirm_reset() -> Result<bool> {
 
     Ok(matches!(line.trim().to_lowercase().as_str(), "y" | "yes"))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_disabled_message_printed_when_tracking_forced_off() {
+        crate::core::secure::set_no_tracking();
+        let result = run(
+            false, false, false, false, "", false, false, false, false, "", false, false, false, 0,
+        );
+        crate::core::secure::reset_for_tests();
+        assert!(result.is_ok());
+    }
+}

--- a/src/analytics/gain.rs
+++ b/src/analytics/gain.rs
@@ -28,7 +28,29 @@ pub fn run(
     yes: bool,
     _verbose: u8,
 ) -> Result<()> {
-    let tracker = Tracker::new().context("Failed to initialize tracking database")?;
+    if crate::core::secure::is_tracking_forced_off()
+        || std::env::var("RTK_DISABLE_TRACKING").as_deref() == Ok("1")
+    {
+        println!(
+            "{}",
+            styled(
+                "Tracking is disabled by --secure, --no-tracking, or config.toml. No data to show.",
+                true
+            )
+        );
+        return Ok(());
+    }
+    let tracker = match Tracker::new() {
+        Ok(t) => t,
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("tracking disabled") {
+                println!("{}", styled(&msg, false));
+                return Ok(());
+            }
+            anyhow::bail!("Failed to initialize tracking database: {}", msg);
+        }
+    };
     let project_scope = resolve_project_scope(project)?; // added: resolve project path
 
     if reset {

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -7,6 +7,11 @@ use std::path::PathBuf;
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct Config {
+    /// Secure mode: disables both telemetry and tracking.
+    /// Overrides [tracking] and [telemetry] individual settings.
+    /// CLI --secure and env vars take precedence over this.
+    #[serde(default)]
+    pub secure: bool,
     #[serde(default)]
     pub tracking: TrackingConfig,
     #[serde(default)]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -7,6 +7,7 @@ pub mod display_helpers;
 pub mod filter;
 pub mod guard;
 pub mod runner;
+pub mod secure;
 pub mod stream;
 pub mod tee;
 pub mod telemetry;

--- a/src/core/secure.rs
+++ b/src/core/secure.rs
@@ -1,0 +1,49 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
+
+static INITIALIZED: OnceLock<()> = OnceLock::new();
+static TELEMETRY_FORCE_DISABLED: AtomicBool = AtomicBool::new(false);
+static TRACKING_FORCE_DISABLED: AtomicBool = AtomicBool::new(false);
+
+fn init() {
+    INITIALIZED.get_or_init(|| {
+        let args: Vec<String> = std::env::args().collect();
+        if args.iter().any(|a| a == "--secure") {
+            TELEMETRY_FORCE_DISABLED.store(true, Ordering::Relaxed);
+            TRACKING_FORCE_DISABLED.store(true, Ordering::Relaxed);
+        } else {
+            if args.iter().any(|a| a == "--no-telemetry") {
+                TELEMETRY_FORCE_DISABLED.store(true, Ordering::Relaxed);
+            }
+            if args.iter().any(|a| a == "--no-tracking") {
+                TRACKING_FORCE_DISABLED.store(true, Ordering::Relaxed);
+            }
+        }
+    });
+}
+
+pub fn set_secure() {
+    init();
+    TELEMETRY_FORCE_DISABLED.store(true, Ordering::Relaxed);
+    TRACKING_FORCE_DISABLED.store(true, Ordering::Relaxed);
+}
+
+pub fn set_no_telemetry() {
+    init();
+    TELEMETRY_FORCE_DISABLED.store(true, Ordering::Relaxed);
+}
+
+pub fn set_no_tracking() {
+    init();
+    TRACKING_FORCE_DISABLED.store(true, Ordering::Relaxed);
+}
+
+pub fn is_telemetry_forced_off() -> bool {
+    init();
+    TELEMETRY_FORCE_DISABLED.load(Ordering::Relaxed)
+}
+
+pub fn is_tracking_forced_off() -> bool {
+    init();
+    TRACKING_FORCE_DISABLED.load(Ordering::Relaxed)
+}

--- a/src/core/secure.rs
+++ b/src/core/secure.rs
@@ -47,3 +47,69 @@ pub fn is_tracking_forced_off() -> bool {
     init();
     TRACKING_FORCE_DISABLED.load(Ordering::Relaxed)
 }
+
+/// Reset all secure state — only available in tests.
+#[cfg(test)]
+pub fn reset_for_tests() {
+    TELEMETRY_FORCE_DISABLED.store(false, Ordering::Relaxed);
+    TRACKING_FORCE_DISABLED.store(false, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reset() {
+        TELEMETRY_FORCE_DISABLED.store(false, Ordering::Relaxed);
+        TRACKING_FORCE_DISABLED.store(false, Ordering::Relaxed);
+    }
+
+    #[test]
+    fn test_initial_state_is_false() {
+        reset();
+        assert!(!is_telemetry_forced_off());
+        assert!(!is_tracking_forced_off());
+    }
+
+    #[test]
+    fn test_secure_disables_both() {
+        reset();
+        set_secure();
+        assert!(is_telemetry_forced_off());
+        assert!(is_tracking_forced_off());
+    }
+
+    #[test]
+    fn test_no_telemetry_disables_telemetry_only() {
+        reset();
+        set_no_telemetry();
+        assert!(is_telemetry_forced_off());
+        assert!(!is_tracking_forced_off());
+    }
+
+    #[test]
+    fn test_no_tracking_disables_tracking_only() {
+        reset();
+        set_no_tracking();
+        assert!(!is_telemetry_forced_off());
+        assert!(is_tracking_forced_off());
+    }
+
+    #[test]
+    fn test_secure_overrides_individual_flags() {
+        reset();
+        set_no_telemetry();
+        set_secure();
+        assert!(is_telemetry_forced_off());
+        assert!(is_tracking_forced_off());
+    }
+
+    #[test]
+    fn test_setters_are_idempotent() {
+        reset();
+        set_secure();
+        set_secure();
+        assert!(is_telemetry_forced_off());
+        assert!(is_tracking_forced_off());
+    }
+}

--- a/src/core/telemetry.rs
+++ b/src/core/telemetry.rs
@@ -25,6 +25,11 @@ pub fn maybe_ping() {
         return;
     }
 
+    // --secure or --no-telemetry → highest priority override
+    if super::secure::is_telemetry_forced_off() {
+        return;
+    }
+
     // Check opt-out: env var (single source of truth in telemetry_cmd)
     if super::telemetry_cmd::telemetry_disabled_by_env() {
         return;
@@ -35,6 +40,11 @@ pub fn maybe_ping() {
         Ok(c) => c,
         Err(_) => return,
     };
+
+    // secure=true in config.toml disables telemetry
+    if cfg.secure {
+        return;
+    }
 
     // RGPD: require explicit consent before any telemetry
     match cfg.telemetry.consent_given {

--- a/src/core/telemetry_cmd.rs
+++ b/src/core/telemetry_cmd.rs
@@ -48,6 +48,7 @@ fn run_status() -> Result<()> {
     };
 
     let env_override = telemetry_disabled_by_env();
+    let secure_override = super::secure::is_telemetry_forced_off();
 
     println!("Telemetry status:");
     println!("  consent:       {}", consent_str);
@@ -55,6 +56,9 @@ fn run_status() -> Result<()> {
         println!("  consent date:  {}", date);
     }
     println!("  enabled:       {}", enabled_str);
+    if secure_override {
+        println!("  secure flag:   --secure or --no-telemetry (blocked)");
+    }
     if env_override {
         println!("  env override:  RTK_TELEMETRY_DISABLED=1 (blocked)");
     }

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -247,6 +247,22 @@ impl Tracker {
     /// # Ok::<(), anyhow::Error>(())
     /// ```
     pub fn new() -> Result<Self> {
+        // Priority: --secure / --no-tracking > RTK_DISABLE_TRACKING=1 > config.toml
+        crate::core::secure::is_tracking_forced_off();
+        if crate::core::secure::is_tracking_forced_off() {
+            anyhow::bail!("tracking disabled by --secure or --no-tracking");
+        }
+        if std::env::var("RTK_DISABLE_TRACKING").as_deref() == Ok("1") {
+            anyhow::bail!("tracking disabled by RTK_DISABLE_TRACKING=1");
+        }
+        if let Ok(cfg) = crate::core::config::Config::load() {
+            if cfg.secure {
+                anyhow::bail!("tracking disabled by secure=true in config.toml");
+            }
+            if !cfg.tracking.enabled {
+                anyhow::bail!("tracking disabled in config.toml");
+            }
+        }
         let db_path = get_db_path()?;
         if let Some(parent) = db_path.parent() {
             std::fs::create_dir_all(parent)?;

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -470,6 +470,11 @@ pub fn save_telemetry_consent(accepted: bool) -> Result<()> {
 fn prompt_telemetry_consent() -> Result<()> {
     use std::io::{self, BufRead, IsTerminal};
 
+    // --secure or --no-telemetry → skip prompt entirely
+    if crate::core::secure::is_telemetry_forced_off() {
+        return Ok(());
+    }
+
     let config = crate::core::config::Config::load().unwrap_or_default();
     match config.telemetry.consent_given {
         Some(true) => return Ok(()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,18 @@ struct Cli {
     /// Set SKIP_ENV_VALIDATION=1 for child processes (Next.js, tsc, lint, prisma)
     #[arg(long = "skip-env", global = true)]
     skip_env: bool,
+
+    /// Disable telemetry AND tracking, overriding config.toml and env vars
+    #[arg(long = "secure", global = true)]
+    secure: bool,
+
+    /// Disable telemetry pings, overriding config.toml (alias: env RTK_TELEMETRY_DISABLED=1)
+    #[arg(long = "no-telemetry", global = true)]
+    no_telemetry: bool,
+
+    /// Disable local tracking database, overriding config.toml (alias: env RTK_DISABLE_TRACKING=1)
+    #[arg(long = "no-tracking", global = true)]
+    no_tracking: bool,
 }
 
 #[derive(Debug, Subcommand)]
@@ -1574,9 +1586,6 @@ where
 }
 
 fn run_cli() -> Result<i32> {
-    // Fire-and-forget telemetry ping (1/day, non-blocking)
-    core::telemetry::maybe_ping();
-
     let cli = match Cli::try_parse_from(std::env::args_os()) {
         Ok(cli) => cli,
         Err(e) => {
@@ -1586,6 +1595,23 @@ fn run_cli() -> Result<i32> {
             return run_fallback(e);
         }
     };
+
+    // Set secure state from parsed CLI (raw-arg init() already caught fallback path)
+    if cli.secure {
+        core::secure::set_secure();
+    } else {
+        if cli.no_telemetry {
+            core::secure::set_no_telemetry();
+        }
+        if cli.no_tracking {
+            core::secure::set_no_tracking();
+        }
+    }
+
+    // Fire-and-forget telemetry ping (1/day, non-blocking), gated by secure
+    if !core::secure::is_telemetry_forced_off() {
+        core::telemetry::maybe_ping();
+    }
 
     // Warn if installed hook is outdated/missing (1/day, non-blocking).
     // Skip for Gain — it shows its own inline hook warning.


### PR DESCRIPTION
## Summary

- Add `--secure`, `--no-telemetry`, `--no-tracking` CLI flags for corporate compliance
- Add `secure = true` config.toml field (MDM-deployable)
- Respect existing `[tracking] enabled = false` config (was previously ignored)
- All flags/config/env follow priority: CLI > env > config > defaults

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test` — 2470 pass
- [x] Manual: `rtk --no-telemetry telemetry status` shows "secure flag: blocked"
- [x] Manual: `rtk --no-tracking gain` shows "Tracking is disabled"
- [x] Manual: `rtk --secure git log -1` runs without creating history.db
- [x] Manual: `RTK_DISABLE_TRACKING=1 rtk gain` shows disabled message
- [x] Unit tests for secure.rs init/setters (5 tests)
- [x] Unit test for gain run disabled message