### PR TITLE
fix(benchmark): use deterministic curl and wget responses

### DIFF
--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -346,8 +346,7 @@ bench "wc" "wc Cargo.toml src/main.rs" "$RTK wc Cargo.toml src/main.rs"
 # ===================
 section "curl"
 if command -v curl &> /dev/null; then
-  # The base64 value decodes to: {"status":"ok","items":[1,2,3]}
-  bench "curl json" "curl -s https://mockhttp.org/base64/eyJzdGF0dXMiOiJvayIsIml0ZW1zIjpbMSwyLDNdfQ==" "$RTK curl https://mockhttp.org/base64/eyJzdGF0dXMiOiJvayIsIml0ZW1zIjpbMSwyLDNdfQ=="
+  bench "curl json" "curl -s https://mockhttp.org/json/1" "$RTK curl https://mockhttp.org/json/1"
   bench "curl text" "curl -s https://mockhttp.org/robots.txt" "$RTK curl https://mockhttp.org/robots.txt"
 fi
 
@@ -356,8 +355,8 @@ fi
 # ===================
 if command -v wget &> /dev/null; then
   section "wget"
-  bench "wget" "wget -qO- https://mockhttp.org/range/1000" "$RTK wget https://mockhttp.org/range/1000"
-  rm -f 1000 2>/dev/null
+  bench "wget" "wget -qO- https://mockhttp.org/json/1" "$RTK wget https://mockhttp.org/json/1"
+  rm -f 1 2>/dev/null
 fi
 
 # ===================

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -346,7 +346,8 @@ bench "wc" "wc Cargo.toml src/main.rs" "$RTK wc Cargo.toml src/main.rs"
 # ===================
 section "curl"
 if command -v curl &> /dev/null; then
-  bench "curl json" "curl -s https://mockhttp.org/json" "$RTK curl https://mockhttp.org/json"
+  # The base64 value decodes to: {"status":"ok","items":[1,2,3]}
+  bench "curl json" "curl -s https://mockhttp.org/base64/eyJzdGF0dXMiOiJvayIsIml0ZW1zIjpbMSwyLDNdfQ==" "$RTK curl https://mockhttp.org/base64/eyJzdGF0dXMiOiJvayIsIml0ZW1zIjpbMSwyLDNdfQ=="
   bench "curl text" "curl -s https://mockhttp.org/robots.txt" "$RTK curl https://mockhttp.org/robots.txt"
 fi
 
@@ -355,8 +356,8 @@ fi
 # ===================
 if command -v wget &> /dev/null; then
   section "wget"
-  bench "wget" "wget -qO- https://mockhttp.org/json" "$RTK wget https://mockhttp.org/json"
-  rm -f json 2>/dev/null
+  bench "wget" "wget -qO- https://mockhttp.org/range/1000" "$RTK wget https://mockhttp.org/range/1000"
+  rm -f 1000 2>/dev/null
 fi
 
 # ===================


### PR DESCRIPTION
## Summary

- Use MockHTTP’s indexed `/json/1` endpoint for the curl and wget benchmarks.
- Prevent false regressions caused by comparing different randomly selected JSON responses.

The previous `/json` endpoint selects a random response for each request. This meant the raw command and RTK could receive responses with different sizes.

The indexed endpoint returns the same response for every request. This PR should be merged after `/json/1` is deployed to MockHTTP.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] `bash -n scripts/benchmark.sh`
- [ ] Manual testing after `/json/1` is deployed

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.