### PR TITLE
Fix flaky curl/wget benchmark tests with local fixtures

### DIFF
--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -346,8 +346,25 @@ bench "wc" "wc Cargo.toml src/main.rs" "$RTK wc Cargo.toml src/main.rs"
 # ===================
 section "curl"
 if command -v curl &> /dev/null; then
-  bench "curl json" "curl -s https://mockhttp.org/json/1" "$RTK curl https://mockhttp.org/json/1"
-  bench "curl text" "curl -s https://mockhttp.org/robots.txt" "$RTK curl https://mockhttp.org/robots.txt"
+  cat > /tmp/rtk_bench_curl.json << 'CURLJSONEOF'
+{
+  "slideshow": {
+    "title": "Sample Slide Show",
+    "author": "rtk bench fixture",
+    "slides": [
+      {"title": "Wake up to WonderWidgets!", "type": "all"},
+      {"title": "Overview", "type": "all"}
+    ]
+  }
+}
+CURLJSONEOF
+  cat > /tmp/rtk_bench_curl.txt << 'CURLTXTEOF'
+User-agent: *
+Disallow: /deny
+CURLTXTEOF
+  bench "curl json" "cat /tmp/rtk_bench_curl.json" "$RTK curl file:///tmp/rtk_bench_curl.json"
+  bench "curl text" "cat /tmp/rtk_bench_curl.txt" "$RTK curl file:///tmp/rtk_bench_curl.txt"
+  rm -f /tmp/rtk_bench_curl.json /tmp/rtk_bench_curl.txt
 fi
 
 # ===================
@@ -355,8 +372,20 @@ fi
 # ===================
 if command -v wget &> /dev/null; then
   section "wget"
-  bench "wget" "wget -qO- https://mockhttp.org/json/1" "$RTK wget https://mockhttp.org/json/1"
-  rm -f 1 2>/dev/null
+  cat > /tmp/rtk_bench_wget.json << 'WGETJSONEOF'
+{
+  "slideshow": {
+    "title": "Sample Slide Show",
+    "author": "rtk bench fixture",
+    "slides": [
+      {"title": "Wake up to WonderWidgets!", "type": "all"},
+      {"title": "Overview", "type": "all"}
+    ]
+  }
+}
+WGETJSONEOF
+  bench "wget" "cat /tmp/rtk_bench_wget.json" "$RTK wget file:///tmp/rtk_bench_wget.json"
+  rm -f /tmp/rtk_bench_wget.json rtk_bench_wget.json json 2>/dev/null
 fi
 
 # ===================


### PR DESCRIPTION
Fixes #2844

Replaces the two live requests to mockhttp.org in the curl/wget benchmark sections with local `file://` fixtures, matching the existing heredoc-fixture pattern already used by the json/log sections. This removes the nondeterminism caused by depending on an external service being reachable and consistent across two separate live requests.

Supersedes #3169, rebuilt directly on current `develop` to avoid the merge conflict that PR hit (develop had independently changed the same curl/wget lines to use `/json/1`, moot now that the section no longer hits mockhttp.org at all).