### PR TITLE
fix(hook): detect Copilot CLI shell tool on Windows

### DIFF
--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -87,9 +87,10 @@ fn detect_format(v: &Value) -> HookFormat {
         return HookFormat::PassThrough;
     }
 
-    // Copilot CLI: camelCase keys, toolArgs is a JSON-encoded string
+    // Copilot CLI: camelCase keys, toolArgs is a JSON-encoded string.
+    // The shell tool is "bash" on Unix and "powershell" on Windows.
     if let Some(tool_name) = v.get("toolName").and_then(|t| t.as_str()) {
-        if matches!(tool_name, "bash" | "run_in_terminal") {
+        if matches!(tool_name, "bash" | "powershell" | "run_in_terminal") {
             if let Some(tool_args_str) = v.get("toolArgs").and_then(|t| t.as_str()) {
                 if let Ok(tool_args) = serde_json::from_str::<Value>(tool_args_str) {
                     if let Some(cmd) = tool_args
@@ -724,9 +725,9 @@ mod tests {
         })
     }
 
-    fn copilot_cli_input(cmd: &str) -> Value {
+    fn copilot_cli_input(tool: &str, cmd: &str) -> Value {
         let args = serde_json::to_string(&json!({ "command": cmd })).unwrap();
-        json!({ "toolName": "bash", "toolArgs": args })
+        json!({ "toolName": tool, "toolArgs": args })
     }
 
     fn copilot_ide_input(cmd: &str) -> Value {
@@ -758,7 +759,7 @@ mod tests {
     #[test]
     fn test_detect_copilot_cli_bash() {
         assert!(matches!(
-            detect_format(&copilot_cli_input("git status")),
+            detect_format(&copilot_cli_input("bash", "git status")),
             HookFormat::CopilotCli { .. }
         ));
     }
@@ -768,6 +769,15 @@ mod tests {
         assert!(matches!(
             detect_format(&copilot_ide_input("git status")),
             HookFormat::CopilotIde { .. }
+        ));
+    }
+
+    #[test]
+    fn test_detect_copilot_cli_powershell() {
+        // Copilot CLI names its shell tool "powershell" on Windows, not "bash".
+        assert!(matches!(
+            detect_format(&copilot_cli_input("powershell", "git status")),
+            HookFormat::CopilotCli { .. }
         ));
     }
 
@@ -783,8 +793,11 @@ mod tests {
         // (confirmed for Cursor). run_copilot strips them before parsing;
         // verify both Copilot formats still parse after the same handling.
         for raw in [
-            format!("\u{feff}{}", copilot_cli_input("git status")),
-            format!("\u{feff}\u{feff}{}", copilot_cli_input("git status")),
+            format!("\u{feff}{}", copilot_cli_input("bash", "git status")),
+            format!(
+                "\u{feff}\u{feff}{}",
+                copilot_cli_input("bash", "git status")
+            ),
         ] {
             let cleaned = strip_leading_bom(&raw).trim();
             let v: Value = serde_json::from_str(cleaned).expect("BOM-stripped JSON must parse");


### PR DESCRIPTION
## Summary

- `detect_format` matched the native Copilot CLI payload only on `toolName == "bash"`. Copilot CLI names its shell tool **`powershell`** on Windows, so the payload fell through to `PassThrough` and the `HookFormat::CopilotCli` branch was unreachable there.
- Consequence: on Windows only the Claude-compat `PreToolUse` entry answers, via `HookFormat::VsCode`, which emits `permissionDecision: "ask"` — a permission prompt on **every** rewritten command (see #3037), and one the allowlist cannot suppress since only `allow`/`deny` short-circuit Copilot's permission flow.
- This also matches the Windows limitation documented in the README (*"On native Windows (cmd.exe / PowerShell), RTK filters work but the hook does not auto-rewrite commands"*) and reported in #2424.

Fixes #3178.

## Test plan

- [x] `cargo fmt --all -- --check` ✅ · `cargo clippy --all-targets` ✅ (no warnings) · `cargo test --all` — `hooks::` subset 396/396 green, new `test_detect_copilot_cli_powershell` passes

  Run locally on rustc 1.97.1 / stable-x86_64-pc-windows-msvc. `fmt` caught a width overflow in my own patch, fixed in `10ca886`. `cargo test --all` reports 16 failures, all in `core::stream::tests` (`program not found` — they spawn Unix binaries); verified identical on unmodified `origin/develop`, so pre-existing on Windows and unrelated. Details in the comments below.

- [x] Manual verification against a live Copilot CLI session

  Captured with a logging hook wired to the camelCase `preToolUse` entry, Copilot CLI 1.0.73 / Windows 11, RTK 0.43.0 (official release asset):

  ```json
  {"sessionId":"c1b3f427-...","timestamp":1784807355614,"cwd":"C:\\Windows\\System32",
   "toolName":"powershell","toolArgs":"{\"command\":\"rtk gain\",\"description\":\"...\"}"}
  ```

  `toolArgs` is already the JSON-encoded string RTK expects — only `toolName` differed. And with the shipped binary:

  ```console
  $ echo '{"toolName":"powershell","toolArgs":"{\"command\":\"git status\"}"}' | rtk hook copilot
                                       # empty: PassThrough, native path skipped

  $ echo '{"tool_name":"Bash","tool_input":{"command":"git status"}}' | rtk hook copilot
  {"hookSpecificOutput":{...,"permissionDecision":"ask",...,"updatedInput":{"command":"rtk git status"}}}
  ```

## Note

This is complementary to #3037, not a replacement. With this fix the native path is reached on Windows and returns `modifiedArgs` without a `permissionDecision`, but the `PreToolUse` entry that `rtk init` also writes still answers `ask` for the same tool call. Unless #3037 lands as well (or the generated hook file stops declaring both entries), Windows users keep getting a prompt on every command.

