### PR TITLE
fix(search): display nb line only if requested

### DIFF
--- a/src/cmds/system/search.rs
+++ b/src/cmds/system/search.rs
@@ -397,7 +397,13 @@ fn show_file(paths: &[String], extra_args: &[String]) -> bool {
 }
 
 fn show_line(extra_args: &[String]) -> bool {
-    !has_short_flag(extra_args, 'N')
+    // Faithful to grep: line numbers appear only when the agent asks for them
+    // (`-n`/`--line-number`). Adding them by default corrupts downstream parses
+    // (e.g. `grep X | awk -F: '{print $1}'`) and breaks RTK's transparency.
+    // `-N`/`--no-line-number` still force them off when combined with `-n`.
+    (has_short_flag(extra_args, 'n')
+        || extra_args.iter().any(|f| f == "--line-number"))
+        && !has_short_flag(extra_args, 'N')
         && !extra_args.iter().any(|f| f == "--no-line-number")
 }
 
@@ -612,8 +618,8 @@ pub fn run(
     // -n. We force -nH--null for robust parsing, then drop what the engine itself
     // would not have shown.
     let show_file = by_file.len() > 1 || show_file(&paths, &extra_args);
-    // Always surface the line number (the openable position) unless the agent
-    // explicitly turned it off; the filename is the only conditional part.
+    // Surface the line number only when the agent requested it (-n), matching
+    // real grep; the filename is the other conditional part.
     let show_line = show_line(&extra_args);
 
     // Faithful baseline: exactly what the real command prints, full content.

--- a/src/cmds/system/search.rs
+++ b/src/cmds/system/search.rs
@@ -120,13 +120,27 @@ fn grep_slug(idx: usize, path: &str) -> String {
     format!("grep_{}_{}", idx, tail)
 }
 
-/// Format a file's matches as `path<sep>line<sep>content`. Tee blocks use the
-/// real (un-compacted) `path` so recovered lines stay openable.
-fn match_block(path: &str, entries: &[(usize, bool, String)]) -> String {
+/// Tee recovery block, mirroring the primary output's `show_file`/`show_line`
+/// so recovered overflow is a faithful continuation. Uses the real `path`.
+fn match_block(
+    path: &str,
+    entries: &[(usize, bool, String)],
+    show_file: bool,
+    show_line: bool,
+) -> String {
     let mut s = String::new();
     for (line_num, is_match, content) in entries {
         let sep = if *is_match { ':' } else { '-' };
-        s.push_str(&format!("{}{}{}{}{}\n", path, sep, line_num, sep, content));
+        if show_file {
+            s.push_str(path);
+            s.push(sep);
+        }
+        if show_line {
+            s.push_str(&line_num.to_string());
+            s.push(sep);
+        }
+        s.push_str(content);
+        s.push('\n');
     }
     s
 }
@@ -397,10 +411,7 @@ fn show_file(paths: &[String], extra_args: &[String]) -> bool {
 }
 
 fn show_line(extra_args: &[String]) -> bool {
-    // Faithful to grep: line numbers appear only when the agent asks for them
-    // (`-n`/`--line-number`). Adding them by default corrupts downstream parses
-    // (e.g. `grep X | awk -F: '{print $1}'`) and breaks RTK's transparency.
-    // `-N`/`--no-line-number` still force them off when combined with `-n`.
+    // Faithful to grep: line numbers only when asked (-n), off by default.
     (has_short_flag(extra_args, 'n')
         || extra_args.iter().any(|f| f == "--line-number"))
         && !has_short_flag(extra_args, 'N')
@@ -647,7 +658,7 @@ pub fn run(
     for (idx, (file, entries)) in files.into_iter().enumerate() {
         if shown >= max_results {
             skipped_files += 1;
-            skipped_block.push_str(&match_block(file, entries));
+            skipped_block.push_str(&match_block(file, entries, show_file, show_line));
             continue;
         }
 
@@ -681,9 +692,9 @@ pub fn run(
         if remaining == 0 {
             continue;
         }
-        // Tee the file's full matches (real path) so the tail hint recovers them
-        // openably, skipping the lines already shown.
-        let full_block = match_block(file, entries);
+        // Tee the file's full matches so the tail hint recovers them, skipping
+        // the lines already shown.
+        let full_block = match_block(file, entries, show_file, show_line);
         match crate::core::tee::force_tee_tail_hint(&full_block, &grep_slug(idx, file), file_shown + 1)
         {
             Some(hint) => {

--- a/src/cmds/system/search.rs
+++ b/src/cmds/system/search.rs
@@ -120,14 +120,8 @@ fn grep_slug(idx: usize, path: &str) -> String {
     format!("grep_{}_{}", idx, tail)
 }
 
-/// Format a file's matches as `path<sep>line<sep>content`, always fully
-/// qualified with the real (un-compacted) `path` and the line number.
-///
-/// Deliberately does NOT mirror the display's `show_file`/`show_line`: this is
-/// the tee recovery block, internal state rather than command output, and its
-/// job is to make every dropped match openable. A plain `rtk grep pat file`
-/// prints bare content (faithful to grep), but the matches RTK truncated are
-/// only recoverable if the tee still says where they are.
+/// Format a file's matches as `path<sep>line<sep>content`. Tee blocks use the
+/// real (un-compacted) `path` so recovered lines stay openable.
 fn match_block(path: &str, entries: &[(usize, bool, String)]) -> String {
     let mut s = String::new();
     for (line_num, is_match, content) in entries {
@@ -403,10 +397,6 @@ fn show_file(paths: &[String], extra_args: &[String]) -> bool {
 }
 
 fn show_line(extra_args: &[String]) -> bool {
-    // Faithful to grep: line numbers appear only when the agent asks for them
-    // (`-n`/`--line-number`). Adding them by default corrupts downstream parses
-    // (e.g. `grep X | awk -F: '{print $1}'`) and breaks RTK's transparency.
-    // `-N`/`--no-line-number` still force them off when combined with `-n`.
     (has_short_flag(extra_args, 'n')
         || extra_args.iter().any(|f| f == "--line-number"))
         && !has_short_flag(extra_args, 'N')
@@ -1431,9 +1421,8 @@ mod tests {
         args.iter().map(|s| s.to_string()).collect()
     }
 
-    /// The display is opt-in, exactly like real grep: no `-n`, no line numbers.
     #[test]
-    fn show_line_requires_an_explicit_request() {
+    fn show_line_is_off_without_an_explicit_request() {
         assert!(!show_line(&flags(&[])));
         assert!(!show_line(&flags(&["-i"])));
         assert!(!show_line(&flags(&["-r"])));
@@ -1444,20 +1433,16 @@ mod tests {
     fn show_line_honours_n_in_every_spelling() {
         assert!(show_line(&flags(&["-n"])));
         assert!(show_line(&flags(&["--line-number"])));
-        assert!(show_line(&flags(&["-rn"]))); // inside a short cluster
+        assert!(show_line(&flags(&["-rn"])));
         assert!(show_line(&flags(&["-in"])));
     }
 
-    /// `-N`/`--no-line-number` are rg spellings; grep rejects them upstream.
     #[test]
-    fn show_line_respects_explicit_negation() {
+    fn show_line_is_off_when_explicitly_negated() {
         assert!(!show_line(&flags(&["-N"])));
         assert!(!show_line(&flags(&["--no-line-number"])));
     }
 
-    /// The tee block is recovery state, not command output: it stays fully
-    /// qualified even when the display drops the path and the line number,
-    /// otherwise the matches RTK truncated become unlocatable.
     #[test]
     fn match_block_stays_fully_qualified() {
         let entries = vec![
@@ -1471,8 +1456,6 @@ mod tests {
         );
     }
 
-    /// A plain single-file grep displays bare content, but its overflow must
-    /// still be recoverable to a `file:line` the agent can open.
     #[test]
     fn match_block_keeps_position_when_display_drops_it() {
         assert!(!show_line(&flags(&[])));

--- a/src/cmds/system/search.rs
+++ b/src/cmds/system/search.rs
@@ -120,27 +120,19 @@ fn grep_slug(idx: usize, path: &str) -> String {
     format!("grep_{}_{}", idx, tail)
 }
 
-/// Tee recovery block, mirroring the primary output's `show_file`/`show_line`
-/// so recovered overflow is a faithful continuation. Uses the real `path`.
-fn match_block(
-    path: &str,
-    entries: &[(usize, bool, String)],
-    show_file: bool,
-    show_line: bool,
-) -> String {
+/// Format a file's matches as `path<sep>line<sep>content`, always fully
+/// qualified with the real (un-compacted) `path` and the line number.
+///
+/// Deliberately does NOT mirror the display's `show_file`/`show_line`: this is
+/// the tee recovery block, internal state rather than command output, and its
+/// job is to make every dropped match openable. A plain `rtk grep pat file`
+/// prints bare content (faithful to grep), but the matches RTK truncated are
+/// only recoverable if the tee still says where they are.
+fn match_block(path: &str, entries: &[(usize, bool, String)]) -> String {
     let mut s = String::new();
     for (line_num, is_match, content) in entries {
         let sep = if *is_match { ':' } else { '-' };
-        if show_file {
-            s.push_str(path);
-            s.push(sep);
-        }
-        if show_line {
-            s.push_str(&line_num.to_string());
-            s.push(sep);
-        }
-        s.push_str(content);
-        s.push('\n');
+        s.push_str(&format!("{}{}{}{}{}\n", path, sep, line_num, sep, content));
     }
     s
 }
@@ -411,7 +403,10 @@ fn show_file(paths: &[String], extra_args: &[String]) -> bool {
 }
 
 fn show_line(extra_args: &[String]) -> bool {
-    // Faithful to grep: line numbers only when asked (-n), off by default.
+    // Faithful to grep: line numbers appear only when the agent asks for them
+    // (`-n`/`--line-number`). Adding them by default corrupts downstream parses
+    // (e.g. `grep X | awk -F: '{print $1}'`) and breaks RTK's transparency.
+    // `-N`/`--no-line-number` still force them off when combined with `-n`.
     (has_short_flag(extra_args, 'n')
         || extra_args.iter().any(|f| f == "--line-number"))
         && !has_short_flag(extra_args, 'N')
@@ -629,8 +624,6 @@ pub fn run(
     // -n. We force -nH--null for robust parsing, then drop what the engine itself
     // would not have shown.
     let show_file = by_file.len() > 1 || show_file(&paths, &extra_args);
-    // Surface the line number only when the agent requested it (-n), matching
-    // real grep; the filename is the other conditional part.
     let show_line = show_line(&extra_args);
 
     // Faithful baseline: exactly what the real command prints, full content.
@@ -658,7 +651,7 @@ pub fn run(
     for (idx, (file, entries)) in files.into_iter().enumerate() {
         if shown >= max_results {
             skipped_files += 1;
-            skipped_block.push_str(&match_block(file, entries, show_file, show_line));
+            skipped_block.push_str(&match_block(file, entries));
             continue;
         }
 
@@ -692,9 +685,9 @@ pub fn run(
         if remaining == 0 {
             continue;
         }
-        // Tee the file's full matches so the tail hint recovers them, skipping
-        // the lines already shown.
-        let full_block = match_block(file, entries, show_file, show_line);
+        // Tee the file's full matches (real path) so the tail hint recovers them
+        // openably, skipping the lines already shown.
+        let full_block = match_block(file, entries);
         match crate::core::tee::force_tee_tail_hint(&full_block, &grep_slug(idx, file), file_shown + 1)
         {
             Some(hint) => {
@@ -1432,6 +1425,59 @@ mod tests {
         assert!(!has_format_flag(&["-A", "3"]));
         assert!(!has_format_flag(&["-v"]));
         assert!(!has_format_flag(&["-rin"]));
+    }
+
+    fn flags(args: &[&str]) -> Vec<String> {
+        args.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// The display is opt-in, exactly like real grep: no `-n`, no line numbers.
+    #[test]
+    fn show_line_requires_an_explicit_request() {
+        assert!(!show_line(&flags(&[])));
+        assert!(!show_line(&flags(&["-i"])));
+        assert!(!show_line(&flags(&["-r"])));
+        assert!(!show_line(&flags(&["-A", "3"])));
+    }
+
+    #[test]
+    fn show_line_honours_n_in_every_spelling() {
+        assert!(show_line(&flags(&["-n"])));
+        assert!(show_line(&flags(&["--line-number"])));
+        assert!(show_line(&flags(&["-rn"]))); // inside a short cluster
+        assert!(show_line(&flags(&["-in"])));
+    }
+
+    /// `-N`/`--no-line-number` are rg spellings; grep rejects them upstream.
+    #[test]
+    fn show_line_respects_explicit_negation() {
+        assert!(!show_line(&flags(&["-N"])));
+        assert!(!show_line(&flags(&["--no-line-number"])));
+    }
+
+    /// The tee block is recovery state, not command output: it stays fully
+    /// qualified even when the display drops the path and the line number,
+    /// otherwise the matches RTK truncated become unlocatable.
+    #[test]
+    fn match_block_stays_fully_qualified() {
+        let entries = vec![
+            (3usize, true, "line 3 needle".to_string()),
+            (4usize, false, "line 4 context".to_string()),
+        ];
+        let block = match_block("src/deep/file.rs", &entries);
+        assert_eq!(
+            block,
+            "src/deep/file.rs:3:line 3 needle\nsrc/deep/file.rs-4-line 4 context\n"
+        );
+    }
+
+    /// A plain single-file grep displays bare content, but its overflow must
+    /// still be recoverable to a `file:line` the agent can open.
+    #[test]
+    fn match_block_keeps_position_when_display_drops_it() {
+        assert!(!show_line(&flags(&[])));
+        let entries = vec![(42usize, true, "hit".to_string())];
+        assert_eq!(match_block("f.txt", &entries), "f.txt:42:hit\n");
     }
 
     // Verify line numbers are always enabled in the engine invocation (parse_flags).

--- a/tests/grep_faithful_format_test.rs
+++ b/tests/grep_faithful_format_test.rs
@@ -49,7 +49,7 @@ fn single_multi_recursive_and_h_match_grep() {
     assert_eq_grep(&["apple", &f1]); // single: content only, no position
     assert_eq_grep(&["a", &f1, &f2]); // multi: filename only, no position
     assert_eq_grep(&["-H", "apple", &f1]); // -H forces filename on a single file
-    assert_eq_grep(&["-n", "apple", &f1]); // -n adds the line number
+    assert_eq_grep(&["-n", "apple", &f1]);
     assert_eq_grep(&["-r", "a", d.path().to_str().unwrap()]); // recursive
 }
 

--- a/tests/grep_faithful_format_test.rs
+++ b/tests/grep_faithful_format_test.rs
@@ -1,8 +1,10 @@
 #![cfg(unix)]
-//! For un-capped searches `rtk grep X` must be byte-identical to `grep X`:
-//! the line number only when `-n` asks for it, the filename only when grep
-//! itself prints one. Covers content and regex edge cases (colons, digits,
-//! shell metachars, unicode, colon-in-path) that must never be misparsed.
+//! For un-capped searches `rtk grep X` must be byte-identical to `grep X`.
+//! Every scenario runs twice, with and without `-n`, so both the presence and
+//! the absence of the line number are pinned: grep prints one only when asked,
+//! and the filename only when it would itself. Covers content and regex edge
+//! cases (colons, digits, shell metachars, unicode, colon-in-path) that must
+//! never be misparsed.
 
 use std::io::Write;
 use std::process::{Command, Stdio};
@@ -35,6 +37,13 @@ fn assert_eq_grep(args: &[&str]) {
     assert_eq!(rc, gc, "exit code mismatch for {args:?}");
 }
 
+fn assert_eq_grep_with_and_without_n(args: &[&str]) {
+    assert_eq_grep(args);
+    let mut with_n = vec!["-n"];
+    with_n.extend_from_slice(args);
+    assert_eq_grep(&with_n);
+}
+
 fn write(dir: &std::path::Path, name: &str, body: &str) -> String {
     let p = dir.join(name);
     std::fs::write(&p, body).expect("write");
@@ -46,18 +55,17 @@ fn single_multi_recursive_and_h_match_grep() {
     let d = tempfile::tempdir().unwrap();
     let f1 = write(d.path(), "f1.txt", "apple\nzebra apple\nbanana\n");
     let f2 = write(d.path(), "f2.txt", "apricot\n");
-    assert_eq_grep(&["apple", &f1]); // single: content only, no position
-    assert_eq_grep(&["a", &f1, &f2]); // multi: filename only, no position
-    assert_eq_grep(&["-H", "apple", &f1]); // -H forces filename on a single file
-    assert_eq_grep(&["-n", "apple", &f1]);
-    assert_eq_grep(&["-r", "a", d.path().to_str().unwrap()]); // recursive
+    assert_eq_grep_with_and_without_n(&["apple", &f1]); // single: no filename
+    assert_eq_grep_with_and_without_n(&["a", &f1, &f2]); // multi: filename
+    assert_eq_grep_with_and_without_n(&["-H", "apple", &f1]); // -H forces filename
+    assert_eq_grep_with_and_without_n(&["-r", "a", d.path().to_str().unwrap()]);
 }
 
 #[test]
 fn no_match_matches_grep() {
     let d = tempfile::tempdir().unwrap();
     let f = write(d.path(), "f.txt", "hello\n");
-    assert_eq_grep(&["zzz_no_match_xyz", &f]); // empty stdout, exit 1
+    assert_eq_grep_with_and_without_n(&["zzz_no_match_xyz", &f]); // empty stdout, exit 1
 }
 
 #[test]
@@ -68,29 +76,29 @@ fn nasty_content_is_not_misparsed() {
         "n.txt",
         "12:34 looks like a line number\na::b::c ClassRegistry::init('x')\nport :8080: here\n$(rm -rf /) `whoami` && echo\n中文 テスト مرحبا\n",
     );
-    assert_eq_grep(&[":", &f]);
-    assert_eq_grep(&["ClassRegistry", &f]);
-    assert_eq_grep(&["中文", &f]);
-    assert_eq_grep(&["whoami", &f]);
+    assert_eq_grep_with_and_without_n(&[":", &f]);
+    assert_eq_grep_with_and_without_n(&["ClassRegistry", &f]);
+    assert_eq_grep_with_and_without_n(&["中文", &f]);
+    assert_eq_grep_with_and_without_n(&["whoami", &f]);
 }
 
 #[test]
 fn regex_metacharacters_match_grep() {
     let d = tempfile::tempdir().unwrap();
     let f = write(d.path(), "r.txt", "a.b\naxb\nfoo.bar\n[x]\n");
-    assert_eq_grep(&["a.b", &f]); // . is any-char
-    assert_eq_grep(&["-F", "a.b", &f]); // fixed-string
-    assert_eq_grep(&["^foo", &f]); // anchor
-    assert_eq_grep(&["-E", "ax?b", &f]); // ERE
+    assert_eq_grep_with_and_without_n(&["a.b", &f]); // . is any-char
+    assert_eq_grep_with_and_without_n(&["-F", "a.b", &f]); // fixed-string
+    assert_eq_grep_with_and_without_n(&["^foo", &f]); // anchor
+    assert_eq_grep_with_and_without_n(&["-E", "ax?b", &f]); // ERE
 }
 
 #[test]
 fn context_flags_match_grep() {
     let d = tempfile::tempdir().unwrap();
     let f = write(d.path(), "c.txt", "x\nMATCH\ny\nz\n");
-    assert_eq_grep(&["-A1", "MATCH", &f]);
-    assert_eq_grep(&["-B1", "MATCH", &f]);
-    assert_eq_grep(&["-C1", "MATCH", &f]);
+    assert_eq_grep_with_and_without_n(&["-A1", "MATCH", &f]);
+    assert_eq_grep_with_and_without_n(&["-B1", "MATCH", &f]);
+    assert_eq_grep_with_and_without_n(&["-C1", "MATCH", &f]);
 }
 
 #[test]
@@ -101,7 +109,7 @@ fn context_group_separator_matches_grep() {
         "sep.txt",
         "match A\nfill1\nfill2\nfill3\nmatch B\n",
     );
-    assert_eq_grep(&["-A1", "match", &f]);
+    assert_eq_grep_with_and_without_n(&["-A1", "match", &f]);
 }
 
 // #1436: a single-file `-n` search with `::` content and a BRE pattern with
@@ -115,11 +123,11 @@ fn issue_1436_colons_and_literal_parens() {
         "shell.php",
         "use Util\\ClassRegistry;\nclass Foo {\n    public function run() {\n        $this->m = ClassRegistry::init('Collections.QueueProcess');\n        try {\n            deleteRow($id);\n            $this->delete();\n        } catch (\\Exception $e) {\n        } finally {}\n    }\n    private function delete() {}\n}\n",
     );
-    assert_eq_grep(&[
+    assert_eq_grep_with_and_without_n(&[
         "private function delete\\|try\\|catch\\|finally\\|delete()",
         &f,
     ]);
-    assert_eq_grep(&["init", &f]); // ClassRegistry::init must stay one intact line
+    assert_eq_grep_with_and_without_n(&["init", &f]); // ClassRegistry::init must stay one intact line
 }
 
 // #1436 (comments): a leading `^` anchor must stay scoped to the given file
@@ -134,9 +142,9 @@ fn issue_1436_anchor_scope_and_trailing_colon() {
         "t.py",
         "x = 1\nif crypto >= MAX_CRYPTO:\nclass Foo:\n",
     );
-    assert_eq_grep(&["^pub", &f]); // anchored pattern must not escape the path
-    assert_eq_grep(&["MAX_CRYPTO", &py]); // trailing-colon line kept intact
-    assert_eq_grep(&["class", &py]);
+    assert_eq_grep_with_and_without_n(&["^pub", &f]); // anchored pattern must not escape the path
+    assert_eq_grep_with_and_without_n(&["MAX_CRYPTO", &py]); // trailing-colon line kept intact
+    assert_eq_grep_with_and_without_n(&["class", &py]);
 }
 
 #[test]
@@ -144,15 +152,15 @@ fn colon_in_filename_matches_grep() {
     let d = tempfile::tempdir().unwrap();
     let f1 = write(d.path(), "weird:name.txt", "hit\n");
     let f2 = write(d.path(), "other.txt", "hit\n");
-    assert_eq_grep(&["hit", &f1, &f2]); // colon in a path must not fool the parser
+    assert_eq_grep_with_and_without_n(&["hit", &f1, &f2]); // colon in a path must not fool the parser
 }
 
 #[test]
 fn case_insensitive_and_invert_match_grep() {
     let d = tempfile::tempdir().unwrap();
     let f = write(d.path(), "i.txt", "Apple\nbanana\nAPPLE\n");
-    assert_eq_grep(&["-i", "apple", &f]);
-    assert_eq_grep(&["-v", "apple", &f]);
+    assert_eq_grep_with_and_without_n(&["-i", "apple", &f]);
+    assert_eq_grep_with_and_without_n(&["-v", "apple", &f]);
 }
 
 #[test]
@@ -168,7 +176,11 @@ fn piped_stdin_matches_grep() {
         c.stdin.take().unwrap().write_all(input.as_bytes()).unwrap();
         String::from_utf8_lossy(&c.wait_with_output().unwrap().stdout).into_owned()
     };
-    let rtk = feed(Command::new(env!("CARGO_BIN_EXE_rtk")).args(["grep", "apple"]));
-    let grep = feed(Command::new("grep").args(["apple"]));
-    assert_eq!(rtk, grep, "piped stdin must equal plain grep");
+    for args in [vec!["apple"], vec!["-n", "apple"]] {
+        let mut rtk_args = vec!["grep"];
+        rtk_args.extend_from_slice(&args);
+        let rtk = feed(Command::new(env!("CARGO_BIN_EXE_rtk")).args(&rtk_args));
+        let grep = feed(Command::new("grep").args(&args));
+        assert_eq!(rtk, grep, "piped stdin mismatch for {args:?}");
+    }
 }

--- a/tests/grep_faithful_format_test.rs
+++ b/tests/grep_faithful_format_test.rs
@@ -20,19 +20,17 @@ fn rtk_grep(args: &[&str]) -> (String, Option<i32>) {
     )
 }
 
-fn grep_n(args: &[&str]) -> (String, Option<i32>) {
-    let mut a = vec!["-n"];
-    a.extend_from_slice(args);
-    let out = Command::new("grep").args(&a).output().expect("grep");
+fn grep_plain(args: &[&str]) -> (String, Option<i32>) {
+    let out = Command::new("grep").args(args).output().expect("grep");
     (
         String::from_utf8_lossy(&out.stdout).into_owned(),
         out.status.code(),
     )
 }
 
-fn assert_eq_grep_n(args: &[&str]) {
+fn assert_eq_grep(args: &[&str]) {
     let (rtk, rc) = rtk_grep(args);
-    let (grep, gc) = grep_n(args);
+    let (grep, gc) = grep_plain(args);
     assert_eq!(rtk, grep, "stdout mismatch for {args:?}");
     assert_eq!(rc, gc, "exit code mismatch for {args:?}");
 }
@@ -48,17 +46,18 @@ fn single_multi_recursive_and_h_match_grep_n() {
     let d = tempfile::tempdir().unwrap();
     let f1 = write(d.path(), "f1.txt", "apple\nzebra apple\nbanana\n");
     let f2 = write(d.path(), "f2.txt", "apricot\n");
-    assert_eq_grep_n(&["apple", &f1]); // single: position only
-    assert_eq_grep_n(&["a", &f1, &f2]); // multi: file + position
-    assert_eq_grep_n(&["-H", "apple", &f1]); // -H forces filename on a single file
-    assert_eq_grep_n(&["-r", "a", d.path().to_str().unwrap()]); // recursive
+    assert_eq_grep(&["apple", &f1]); // single: content only, no position
+    assert_eq_grep(&["a", &f1, &f2]); // multi: filename only, no position
+    assert_eq_grep(&["-H", "apple", &f1]); // -H forces filename on a single file
+    assert_eq_grep(&["-n", "apple", &f1]); // -n adds the line number
+    assert_eq_grep(&["-r", "a", d.path().to_str().unwrap()]); // recursive
 }
 
 #[test]
 fn no_match_matches_grep_n() {
     let d = tempfile::tempdir().unwrap();
     let f = write(d.path(), "f.txt", "hello\n");
-    assert_eq_grep_n(&["zzz_no_match_xyz", &f]); // empty stdout, exit 1
+    assert_eq_grep(&["zzz_no_match_xyz", &f]); // empty stdout, exit 1
 }
 
 #[test]
@@ -69,29 +68,29 @@ fn nasty_content_is_not_misparsed() {
         "n.txt",
         "12:34 looks like a line number\na::b::c ClassRegistry::init('x')\nport :8080: here\n$(rm -rf /) `whoami` && echo\n中文 テスト مرحبا\n",
     );
-    assert_eq_grep_n(&[":", &f]);
-    assert_eq_grep_n(&["ClassRegistry", &f]);
-    assert_eq_grep_n(&["中文", &f]);
-    assert_eq_grep_n(&["whoami", &f]);
+    assert_eq_grep(&[":", &f]);
+    assert_eq_grep(&["ClassRegistry", &f]);
+    assert_eq_grep(&["中文", &f]);
+    assert_eq_grep(&["whoami", &f]);
 }
 
 #[test]
 fn regex_metacharacters_match_grep_n() {
     let d = tempfile::tempdir().unwrap();
     let f = write(d.path(), "r.txt", "a.b\naxb\nfoo.bar\n[x]\n");
-    assert_eq_grep_n(&["a.b", &f]); // . is any-char
-    assert_eq_grep_n(&["-F", "a.b", &f]); // fixed-string
-    assert_eq_grep_n(&["^foo", &f]); // anchor
-    assert_eq_grep_n(&["-E", "ax?b", &f]); // ERE
+    assert_eq_grep(&["a.b", &f]); // . is any-char
+    assert_eq_grep(&["-F", "a.b", &f]); // fixed-string
+    assert_eq_grep(&["^foo", &f]); // anchor
+    assert_eq_grep(&["-E", "ax?b", &f]); // ERE
 }
 
 #[test]
 fn context_flags_match_grep_n() {
     let d = tempfile::tempdir().unwrap();
     let f = write(d.path(), "c.txt", "x\nMATCH\ny\nz\n");
-    assert_eq_grep_n(&["-A1", "MATCH", &f]);
-    assert_eq_grep_n(&["-B1", "MATCH", &f]);
-    assert_eq_grep_n(&["-C1", "MATCH", &f]);
+    assert_eq_grep(&["-A1", "MATCH", &f]);
+    assert_eq_grep(&["-B1", "MATCH", &f]);
+    assert_eq_grep(&["-C1", "MATCH", &f]);
 }
 
 #[test]
@@ -102,7 +101,7 @@ fn context_group_separator_matches_grep_n() {
         "sep.txt",
         "match A\nfill1\nfill2\nfill3\nmatch B\n",
     );
-    assert_eq_grep_n(&["-A1", "match", &f]);
+    assert_eq_grep(&["-A1", "match", &f]);
 }
 
 // #1436: a single-file `-n` search with `::` content and a BRE pattern with
@@ -116,11 +115,11 @@ fn issue_1436_colons_and_literal_parens() {
         "shell.php",
         "use Util\\ClassRegistry;\nclass Foo {\n    public function run() {\n        $this->m = ClassRegistry::init('Collections.QueueProcess');\n        try {\n            deleteRow($id);\n            $this->delete();\n        } catch (\\Exception $e) {\n        } finally {}\n    }\n    private function delete() {}\n}\n",
     );
-    assert_eq_grep_n(&[
+    assert_eq_grep(&[
         "private function delete\\|try\\|catch\\|finally\\|delete()",
         &f,
     ]);
-    assert_eq_grep_n(&["init", &f]); // ClassRegistry::init must stay one intact line
+    assert_eq_grep(&["init", &f]); // ClassRegistry::init must stay one intact line
 }
 
 // #1436 (comments): a leading `^` anchor must stay scoped to the given file
@@ -135,9 +134,9 @@ fn issue_1436_anchor_scope_and_trailing_colon() {
         "t.py",
         "x = 1\nif crypto >= MAX_CRYPTO:\nclass Foo:\n",
     );
-    assert_eq_grep_n(&["^pub", &f]); // anchored pattern must not escape the path
-    assert_eq_grep_n(&["MAX_CRYPTO", &py]); // trailing-colon line kept intact
-    assert_eq_grep_n(&["class", &py]);
+    assert_eq_grep(&["^pub", &f]); // anchored pattern must not escape the path
+    assert_eq_grep(&["MAX_CRYPTO", &py]); // trailing-colon line kept intact
+    assert_eq_grep(&["class", &py]);
 }
 
 #[test]
@@ -145,15 +144,15 @@ fn colon_in_filename_matches_grep_n() {
     let d = tempfile::tempdir().unwrap();
     let f1 = write(d.path(), "weird:name.txt", "hit\n");
     let f2 = write(d.path(), "other.txt", "hit\n");
-    assert_eq_grep_n(&["hit", &f1, &f2]); // colon in a path must not fool the parser
+    assert_eq_grep(&["hit", &f1, &f2]); // colon in a path must not fool the parser
 }
 
 #[test]
 fn case_insensitive_and_invert_match_grep_n() {
     let d = tempfile::tempdir().unwrap();
     let f = write(d.path(), "i.txt", "Apple\nbanana\nAPPLE\n");
-    assert_eq_grep_n(&["-i", "apple", &f]);
-    assert_eq_grep_n(&["-v", "apple", &f]);
+    assert_eq_grep(&["-i", "apple", &f]);
+    assert_eq_grep(&["-v", "apple", &f]);
 }
 
 #[test]
@@ -170,6 +169,6 @@ fn piped_stdin_matches_grep_n() {
         String::from_utf8_lossy(&c.wait_with_output().unwrap().stdout).into_owned()
     };
     let rtk = feed(Command::new(env!("CARGO_BIN_EXE_rtk")).args(["grep", "apple"]));
-    let grep = feed(Command::new("grep").args(["-n", "apple"]));
-    assert_eq!(rtk, grep, "piped stdin must equal grep -n");
+    let grep = feed(Command::new("grep").args(["apple"]));
+    assert_eq!(rtk, grep, "piped stdin must equal plain grep");
 }

--- a/tests/grep_faithful_format_test.rs
+++ b/tests/grep_faithful_format_test.rs
@@ -1,8 +1,8 @@
 #![cfg(unix)]
-//! For un-capped searches `rtk grep X` must be byte-identical to `grep -n X`:
-//! line number always, filename only when grep itself prints one. Covers content
-//! and regex edge cases (colons, digits, shell metachars, unicode, colon-in-path)
-//! that must never be misparsed.
+//! For un-capped searches `rtk grep X` must be byte-identical to `grep X`:
+//! the line number only when `-n` asks for it, the filename only when grep
+//! itself prints one. Covers content and regex edge cases (colons, digits,
+//! shell metachars, unicode, colon-in-path) that must never be misparsed.
 
 use std::io::Write;
 use std::process::{Command, Stdio};
@@ -42,7 +42,7 @@ fn write(dir: &std::path::Path, name: &str, body: &str) -> String {
 }
 
 #[test]
-fn single_multi_recursive_and_h_match_grep_n() {
+fn single_multi_recursive_and_h_match_grep() {
     let d = tempfile::tempdir().unwrap();
     let f1 = write(d.path(), "f1.txt", "apple\nzebra apple\nbanana\n");
     let f2 = write(d.path(), "f2.txt", "apricot\n");
@@ -54,7 +54,7 @@ fn single_multi_recursive_and_h_match_grep_n() {
 }
 
 #[test]
-fn no_match_matches_grep_n() {
+fn no_match_matches_grep() {
     let d = tempfile::tempdir().unwrap();
     let f = write(d.path(), "f.txt", "hello\n");
     assert_eq_grep(&["zzz_no_match_xyz", &f]); // empty stdout, exit 1
@@ -75,7 +75,7 @@ fn nasty_content_is_not_misparsed() {
 }
 
 #[test]
-fn regex_metacharacters_match_grep_n() {
+fn regex_metacharacters_match_grep() {
     let d = tempfile::tempdir().unwrap();
     let f = write(d.path(), "r.txt", "a.b\naxb\nfoo.bar\n[x]\n");
     assert_eq_grep(&["a.b", &f]); // . is any-char
@@ -85,7 +85,7 @@ fn regex_metacharacters_match_grep_n() {
 }
 
 #[test]
-fn context_flags_match_grep_n() {
+fn context_flags_match_grep() {
     let d = tempfile::tempdir().unwrap();
     let f = write(d.path(), "c.txt", "x\nMATCH\ny\nz\n");
     assert_eq_grep(&["-A1", "MATCH", &f]);
@@ -94,7 +94,7 @@ fn context_flags_match_grep_n() {
 }
 
 #[test]
-fn context_group_separator_matches_grep_n() {
+fn context_group_separator_matches_grep() {
     let d = tempfile::tempdir().unwrap();
     let f = write(
         d.path(),
@@ -140,7 +140,7 @@ fn issue_1436_anchor_scope_and_trailing_colon() {
 }
 
 #[test]
-fn colon_in_filename_matches_grep_n() {
+fn colon_in_filename_matches_grep() {
     let d = tempfile::tempdir().unwrap();
     let f1 = write(d.path(), "weird:name.txt", "hit\n");
     let f2 = write(d.path(), "other.txt", "hit\n");
@@ -148,7 +148,7 @@ fn colon_in_filename_matches_grep_n() {
 }
 
 #[test]
-fn case_insensitive_and_invert_match_grep_n() {
+fn case_insensitive_and_invert_match_grep() {
     let d = tempfile::tempdir().unwrap();
     let f = write(d.path(), "i.txt", "Apple\nbanana\nAPPLE\n");
     assert_eq_grep(&["-i", "apple", &f]);
@@ -156,7 +156,7 @@ fn case_insensitive_and_invert_match_grep_n() {
 }
 
 #[test]
-fn piped_stdin_matches_grep_n() {
+fn piped_stdin_matches_grep() {
     let input = "apple\nzebra\napple pie\n";
     let feed = |cmd: &mut Command| {
         let mut c = cmd

--- a/tests/search_compress_test.rs
+++ b/tests/search_compress_test.rs
@@ -307,8 +307,8 @@ fn small_grep_not_worse_than_plain() {
     let stdout = String::from_utf8_lossy(&out.stdout);
 
     assert!(
-        stdout.trim() == "1:foo",
-        "single-file grep must equal `grep -n` (position, no filename):\n{stdout}"
+        stdout.trim() == "foo",
+        "single-file grep must equal plain `grep` (content only, no position/filename):\n{stdout}"
     );
     assert!(
         !stdout.contains("matches in"),


### PR DESCRIPTION
Line numbers now appear only when the agent requests them (-n / --line-number); -N / --no-line-number still force them off. 