### PR TITLE
feat(graphify): graphify compatibility command

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,9 @@ rtk env -f AWS                  # Filtered env vars
 rtk log app.log                 # Deduplicated logs
 rtk curl <url>                  # Truncate + save full output
 rtk wget <url>                  # Download, strip progress bars
+rtk graphify query <keyword>    # Preserve nodes and high-signal relationships
+rtk graphify explain <keyword>  # Keep Graphify's native connection summary
+rtk graphify update .           # Strip progress; retain warning order
 rtk summary <long command>      # Heuristic summary
 rtk proxy <command>             # Raw passthrough + tracking
 ```

--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -101,6 +101,14 @@ struct TomlFilterDef {
     head_lines: Option<usize>,
     tail_lines: Option<usize>,
     max_lines: Option<usize>,
+    /// Ordered line-priority groups used before max_lines trimming. Matching
+    /// groups are retained first, while output order itself stays unchanged.
+    #[serde(default)]
+    priority_lines_matching: Vec<String>,
+    /// Skip priority trimming when the tool has already emitted its own bounded
+    /// response marker (for example, graphify's native token-budget warning).
+    #[serde(default)]
+    priority_skip_if_output_matches: Vec<String>,
     on_empty: Option<String>,
     /// When true, stderr is captured and merged with stdout before filtering.
     /// Use for tools like liquibase that emit banners/logs to stderr.
@@ -148,6 +156,8 @@ pub struct CompiledFilter {
     head_lines: Option<usize>,
     tail_lines: Option<usize>,
     pub max_lines: Option<usize>,
+    priority_lines_matching: Vec<Regex>,
+    priority_skip_if_output_matches: Vec<Regex>,
     on_empty: Option<String>,
     /// When true, the runner should capture stderr and merge it with stdout.
     pub filter_stderr: bool,
@@ -374,6 +384,28 @@ fn compile_filter(name: String, def: TomlFilterDef) -> Result<CompiledFilter, St
         LineFilter::None
     };
 
+    let priority_lines_matching = def
+        .priority_lines_matching
+        .into_iter()
+        .map(|pattern| {
+            Regex::new(&pattern)
+                .map_err(|e| format!("invalid priority_lines_matching regex '{}': {}", pattern, e))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let priority_skip_if_output_matches = def
+        .priority_skip_if_output_matches
+        .into_iter()
+        .map(|pattern| {
+            Regex::new(&pattern).map_err(|e| {
+                format!(
+                    "invalid priority_skip_if_output_matches regex '{}': {}",
+                    pattern, e
+                )
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
     Ok(CompiledFilter {
         name,
         description: def.description,
@@ -386,6 +418,8 @@ fn compile_filter(name: String, def: TomlFilterDef) -> Result<CompiledFilter, St
         head_lines: def.head_lines,
         tail_lines: def.tail_lines,
         max_lines: def.max_lines,
+        priority_lines_matching,
+        priority_skip_if_output_matches,
         on_empty: def.on_empty,
         filter_stderr: def.filter_stderr,
     })
@@ -500,6 +534,46 @@ pub fn apply_filter(filter: &CompiledFilter, stdout: &str) -> String {
     apply_filter_with_info(filter, stdout).0
 }
 
+fn prioritize_lines(lines: &[String], groups: &[Regex], max: usize) -> Vec<String> {
+    let mut selected = vec![false; lines.len()];
+    let mut kept = 0;
+
+    for group in groups {
+        for (index, line) in lines.iter().enumerate() {
+            if kept == max {
+                break;
+            }
+            if !selected[index] && group.is_match(line) {
+                selected[index] = true;
+                kept += 1;
+            }
+        }
+        if kept == max {
+            break;
+        }
+    }
+
+    for (index, _) in lines.iter().enumerate() {
+        if kept == max {
+            break;
+        }
+        if !selected[index] {
+            selected[index] = true;
+            kept += 1;
+        }
+    }
+
+    let omitted = lines.len() - kept;
+    let mut result = lines
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| selected[*index])
+        .map(|(_, line)| line.clone())
+        .collect::<Vec<_>>();
+    result.push(format!("... ({} lines omitted)", omitted));
+    result
+}
+
 #[derive(Debug, PartialEq)]
 pub enum Lossiness {
     None,
@@ -611,7 +685,19 @@ pub fn apply_filter_with_info(filter: &CompiledFilter, stdout: &str) -> (String,
 
     // 7. max_lines — absolute cap applied after head/tail (includes omit messages)
     let mut max_cut: Option<usize> = None;
-    if let Some(max) = filter.max_lines {
+    let priority_configured =
+        filter.max_lines.is_some() && !filter.priority_lines_matching.is_empty();
+    let priority_skip = filter
+        .priority_skip_if_output_matches
+        .iter()
+        .any(|pattern| lines.iter().any(|line| pattern.is_match(line)));
+    if priority_configured {
+        let max = filter.max_lines.unwrap_or_default();
+        if !priority_skip && lines.len() > max {
+            lines = prioritize_lines(&lines, &filter.priority_lines_matching, max);
+            noncontiguous_drop = true;
+        }
+    } else if let Some(max) = filter.max_lines {
         if lines.len() > max {
             let dropped = lines.len() - max;
             lines.truncate(max);
@@ -1845,6 +1931,9 @@ match_command = "^make\\b"
             "du",
             "fail2ban-client",
             "gcloud",
+            "graphify-explain",
+            "graphify-query",
+            "graphify-update",
             "hadolint",
             "helm",
             "iptables",
@@ -1896,11 +1985,100 @@ match_command = "^make\\b"
         let filters = make_filters(BUILTIN_TOML);
         assert_eq!(
             filters.len(),
-            63,
-            "Expected exactly 63 built-in filters, got {}. \
+            66,
+            "Expected exactly 66 built-in filters, got {}. \
              Update this count when adding/removing filters in src/filters/.",
             filters.len()
         );
+    }
+
+    #[test]
+    fn test_graphify_filters_match_only_supported_subcommands() {
+        let filters = make_filters(BUILTIN_TOML);
+
+        for (command, name) in [
+            ("graphify query Business --budget 5000", "graphify-query"),
+            ("graphify explain Business", "graphify-explain"),
+            ("graphify update .", "graphify-update"),
+        ] {
+            assert_eq!(find_filter_in(command, &filters).unwrap().name, name);
+        }
+
+        assert!(find_filter_in("graphify path Business Service", &filters).is_none());
+    }
+
+    #[test]
+    fn test_graphify_filters_preserve_native_output_contracts() {
+        let filters = make_filters(BUILTIN_TOML);
+        let find = |name: &str| filters.iter().find(|filter| filter.name == name).unwrap();
+
+        let update = find("graphify-update");
+        assert!(
+            !update.filter_stderr,
+            "graphify warnings are emitted on stderr and must not be reordered after stdout"
+        );
+
+        let explain = find("graphify-explain");
+        assert_eq!(explain.head_lines, None);
+        assert_eq!(explain.tail_lines, None);
+
+        let query = find("graphify-query");
+        assert_eq!(
+            apply_filter(
+                query,
+                "Traversal: BFS depth=2 | Start: ['BusinessController'] | 1 nodes found\n\nNODE BusinessController [src=app/Http/Controllers/BusinessController.php loc=L30 community=56]\nEDGE BusinessController --calls [INFERRED]--> ayoencrypt()"
+            ),
+            "Traversal: BFS depth=2 | Start: ['BusinessController'] | 1 nodes found\n\nNODE BusinessController [src=app/Http/Controllers/BusinessController.php loc=L30]\nEDGE BusinessController --calls [INFERRED]--> ayoencrypt()"
+        );
+    }
+
+    #[test]
+    fn test_priority_line_selection_keeps_high_signal_edges_before_low_signal_edges() {
+        let filters = make_filters(
+            r#"
+schema_version = 1
+
+[filters.graphify-query]
+match_command = "^graphify\\s+query(?:\\s|$)"
+priority_lines_matching = [
+  "^Traversal:",
+  "^NODE ",
+  "^EDGE .*--(?:calls|references)\\b",
+  "^EDGE .*\\[INFERRED(?:\\s|\\])",
+  "^EDGE .*--(?:contains|method|inherits)\\b",
+  "^EDGE ",
+]
+max_lines = 4
+"#,
+        );
+        let query = find_filter_in("graphify query BusinessController", &filters).unwrap();
+
+        assert_eq!(
+            apply_filter(
+                query,
+                "Traversal: BFS depth=2\nNODE BusinessController\nEDGE BusinessController --imports [EXTRACTED]--> Exception\nEDGE BusinessController --mixes_in [EXTRACTED]--> BusinessTrait\nEDGE .getNearby() --calls [INFERRED]--> ayoencrypt()"
+            ),
+            "Traversal: BFS depth=2\nNODE BusinessController\nEDGE BusinessController --imports [EXTRACTED]--> Exception\nEDGE .getNearby() --calls [INFERRED]--> ayoencrypt()\n... (1 lines omitted)"
+        );
+    }
+
+    #[test]
+    fn test_priority_line_selection_does_not_recrop_graphify_native_truncation() {
+        let filters = make_filters(
+            r#"
+schema_version = 1
+
+[filters.graphify-query]
+match_command = "^graphify\\s+query(?:\\s|$)"
+priority_lines_matching = ["^NODE ", "^EDGE "]
+priority_skip_if_output_matches = ["^\\[!\\] TRUNCATED:"]
+max_lines = 2
+"#,
+        );
+        let query = find_filter_in("graphify query Business", &filters).unwrap();
+        let native_truncated = "[!] TRUNCATED: showing 30 of 73 nodes\n\nNODE BusinessController\nEDGE .getNearby() --calls [INFERRED]--> ayoencrypt()";
+
+        assert_eq!(apply_filter(query, native_truncated), native_truncated);
     }
 
     /// Verify that every built-in filter has at least one inline test.
@@ -1954,11 +2132,11 @@ expected = "output line 1\noutput line 2"
         let combined = format!("{}\n\n{}", BUILTIN_TOML, new_filter);
         let filters = make_filters(&combined);
 
-        // All 63 existing filters still present + 1 new = 64
+        // All 66 existing filters still present + 1 new = 67
         assert_eq!(
             filters.len(),
-            64,
-            "Expected 64 filters after concat (63 built-in + 1 new)"
+            67,
+            "Expected 67 filters after concat (66 built-in + 1 new)"
         );
 
         // New filter is discoverable

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1737,6 +1737,40 @@ mod tests {
     }
 
     #[test]
+    fn test_classify_graphify_subcommands_as_supported() {
+        for command in [
+            "graphify query Business",
+            "graphify query Business --budget 5000",
+            "graphify explain Business",
+            "graphify update .",
+        ] {
+            assert_eq!(
+                classify_command(command),
+                Classification::Supported {
+                    rtk_equivalent: "rtk graphify",
+                    category: "Files",
+                    estimated_savings_pct: 60.0,
+                    status: RtkStatus::Existing,
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn test_rewrite_graphify_subcommands() {
+        for command in [
+            "graphify query Business",
+            "graphify explain Business",
+            "graphify update .",
+        ] {
+            assert_eq!(
+                rewrite_command_no_prefixes(command, &[]),
+                Some(format!("rtk {command}"))
+            );
+        }
+    }
+
+    #[test]
     fn test_rewrite_toml_absolute_path() {
         assert_eq!(
             rewrite_command_no_prefixes("/usr/bin/jj log", &[]),

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -717,6 +717,13 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
+        pattern: r"^graphify\s+(query|update|explain)(?:\s|$)",
+        rtk_cmd: "rtk graphify",
+        rewrite_prefixes: &["graphify"],
+        category: "Files",
+        ..RtkRule::DEFAULT
+    },
+    RtkRule {
         pattern: r"^(?:\./gradlew|gradlew\.bat|gradlew|gradle)(?:\s+(test|build|clean|assemble\w*|install\w*|check|lint\w*|dependencies))?(\s|$)",
         rtk_cmd: "rtk gradlew",
         rewrite_prefixes: &["./gradlew", "gradlew.bat", "gradlew", "gradle"],

--- a/src/filters/README.md
+++ b/src/filters/README.md
@@ -58,6 +58,8 @@ expected = "expected filtered output"
 | `match_output` | array | Short-circuit rules (`{ pattern, message }`) |
 | `truncate_lines_at` | int | Truncate lines longer than N characters |
 | `max_lines` | int | Keep only the first N lines |
+| `priority_lines_matching` | regex[] | With `max_lines`, retain matching groups in priority order while preserving source order |
+| `priority_skip_if_output_matches` | regex[] | With priority selection, skip RTK's cap when the output already has a native truncation marker |
 | `tail_lines` | int | Keep only the last N lines (applied after other filters) |
 | `on_empty` | string | Fallback message when filtered output is empty |
 
@@ -92,7 +94,7 @@ flowchart TD
         R["TomlFilterRegistry::load()\n1. .rtk/filters.toml\n2. ~/.config/rtk/filters.toml\n3. BUILTIN_TOML\n4. passthrough"] --> S
         S{"match_command\nmatches?"} -->|"no match"| T[["exec raw (passthrough)"]]
         S -->|"match"| U["exec command\ncapture stdout"]
-        U --> V["8-stage pipeline\nstrip_ansi → replace → match_output\n→ strip/keep_lines → truncate\n→ tail_lines → max_lines → on_empty"]
+        U --> V["8-stage pipeline\nstrip_ansi → replace → match_output\n→ strip/keep_lines → truncate\n→ head/tail → priority/max_lines → on_empty"]
         V --> W[["print filtered output + exit code"]]
     end
 

--- a/src/filters/graphify-explain.toml
+++ b/src/filters/graphify-explain.toml
@@ -1,0 +1,81 @@
+[filters.graphify-explain]
+description = "Preserve graphify's native connection and grouped-file summary"
+match_command = "^graphify\\s+explain(?:\\s|$)"
+
+[[tests.graphify-explain]]
+name = "preserves a small explanation"
+input = """
+Node: .previewRetailer()
+  ID:        app_http_controllers_api_v1_principal_retailercontroller_retailercontroller_previewretailer
+  Source:    app/Http/Controllers/Api/V1/Principal/RetailerController.php L2419
+  Type:      code
+  Community: 87
+  Degree:    2
+
+Connections (2):
+  --> Illuminate\\Http\\Request [references] [EXTRACTED] app/Http/Controllers/Api/V1/Principal/RetailerController.php:L2419
+  <-- RetailerController [method] [EXTRACTED] app/Http/Controllers/Api/V1/Principal/RetailerController.php:L2419
+"""
+expected = """
+Node: .previewRetailer()
+  ID:        app_http_controllers_api_v1_principal_retailercontroller_retailercontroller_previewretailer
+  Source:    app/Http/Controllers/Api/V1/Principal/RetailerController.php L2419
+  Type:      code
+  Community: 87
+  Degree:    2
+
+Connections (2):
+  --> Illuminate\\Http\\Request [references] [EXTRACTED] app/Http/Controllers/Api/V1/Principal/RetailerController.php:L2419
+  <-- RetailerController [method] [EXTRACTED] app/Http/Controllers/Api/V1/Principal/RetailerController.php:L2419
+"""
+
+[[tests.graphify-explain]]
+name = "keeps identity and grouped tail for a high-degree node"
+input = """
+Node: Illuminate\\Database\\Eloquent\\Model
+  ID:        illuminate_database_eloquent_model
+  Source:
+  Type:      code
+  Community: 1
+  Degree:    524
+
+Connections (524):
+  <-- Voucher [inherits] [EXTRACTED] app/Models/B2c/Voucher.php:L26
+  <-- Business [inherits] [EXTRACTED] app/Models/Business.php:L33
+  <-- Member [inherits] [EXTRACTED] app/Models/Member.php:L16
+  <-- PaylaterContract [inherits] [EXTRACTED] app/Models/PaylaterContract.php:L8
+  ... and 504 more
+  Grouped by file:
+    <-- app/Models/AnalyticsFactsSla.php: 2 connections
+    <-- app/Models/AnalyticsFactsTips.php: 2 connections
+    <-- app/Models/Area.php: 2 connections
+    <-- app/Models/Areas.php: 2 connections
+    <-- app/Models/B2c/BusinessAreas.php: 2 connections
+    <-- app/Models/B2c/BusinessWarehouse.php: 2 connections
+    <-- app/Models/B2c/VoucherLimit.php: 2 connections
+    ... and 240 more files
+"""
+expected = """
+Node: Illuminate\\Database\\Eloquent\\Model
+  ID:        illuminate_database_eloquent_model
+  Source:
+  Type:      code
+  Community: 1
+  Degree:    524
+
+Connections (524):
+  <-- Voucher [inherits] [EXTRACTED] app/Models/B2c/Voucher.php:L26
+  <-- Business [inherits] [EXTRACTED] app/Models/Business.php:L33
+  <-- Member [inherits] [EXTRACTED] app/Models/Member.php:L16
+  <-- PaylaterContract [inherits] [EXTRACTED] app/Models/PaylaterContract.php:L8
+  ... and 504 more
+  Grouped by file:
+    <-- app/Models/AnalyticsFactsSla.php: 2 connections
+    <-- app/Models/AnalyticsFactsTips.php: 2 connections
+    <-- app/Models/Area.php: 2 connections
+    <-- app/Models/Areas.php: 2 connections
+    <-- app/Models/B2c/BusinessAreas.php: 2 connections
+    <-- app/Models/B2c/BusinessWarehouse.php: 2 connections
+    <-- app/Models/B2c/VoucherLimit.php: 2 connections
+    ... and 240 more files
+"""

--- a/src/filters/graphify-query.toml
+++ b/src/filters/graphify-query.toml
@@ -1,0 +1,110 @@
+[filters.graphify-query]
+description = "Keep graphify query nodes and high-signal relationships"
+match_command = "^graphify\\s+query(?:\\s|$)"
+replace = [
+  { pattern = " community=\\d+", replacement = "" },
+]
+priority_lines_matching = [
+  "^Traversal:",
+  "^\\[!\\] TRUNCATED:",
+  "^NODE ",
+  "^EDGE .*--(?:calls|references)\\b",
+  "^EDGE .*\\[INFERRED(?:\\s|\\])",
+  "^EDGE .*--(?:contains|method|inherits)\\b",
+  "^EDGE ",
+]
+priority_skip_if_output_matches = ["^\\[!\\] TRUNCATED:"]
+max_lines = 60
+
+[[tests.graphify-query]]
+name = "preserves a small query"
+input = """
+Traversal: BFS depth=2 | Start: ['.retailer()'] | 2 nodes found
+
+NODE .retailer() [src=app/Models/Member.php loc=L102 community=29]
+NODE Member [src=app/Models/Member.php loc=L16 community=29]
+EDGE Member --method [EXTRACTED]--> .retailer() at=app/Models/Member.php:L102
+"""
+expected = """
+Traversal: BFS depth=2 | Start: ['.retailer()'] | 2 nodes found
+
+NODE .retailer() [src=app/Models/Member.php loc=L102]
+NODE Member [src=app/Models/Member.php loc=L16]
+EDGE Member --method [EXTRACTED]--> .retailer() at=app/Models/Member.php:L102
+"""
+
+[[tests.graphify-query]]
+name = "keeps leading nodes and trailing edges"
+input = """
+Traversal: BFS depth=2 | Start: ['RetailerController'] | 14 nodes found
+
+NODE RetailerController [src=app/Http/Controllers/Api/V1/Integration/RetailerController.php loc=L17 community=235]
+NODE Controller [src=app/Http/Controllers/Controller.php loc=L17 community=2]
+NODE LogIntegration.php [src=app/Traits/Integration/LogIntegration.php loc=L1 community=235]
+NODE V1/Integration/RetailerController.php [src=app/Http/Controllers/Api/V1/Integration/RetailerController.php loc=L1 community=235]
+NODE .integration() [src=app/Http/Controllers/Api/V1/Integration/RetailerController.php loc=L27 community=0]
+NODE Illuminate\\Http\\Request [src= loc= community=0]
+NODE Exception [src= loc= community=8]
+NODE V1/Integration/WholesalerController.php [src=app/Http/Controllers/Api/V1/Integration/WholesalerController.php loc=L1 community=235]
+NODE V2/Integration/RetailerController.php [src=app/Http/Controllers/Api/V2/Integration/RetailerController.php loc=L1 community=235]
+NODE V2/Integration/WholesalerController.php [src=app/Http/Controllers/Api/V2/Integration/WholesalerController.php loc=L1 community=235]
+EDGE RetailerController --method [EXTRACTED]--> .integration() at=app/Http/Controllers/Api/V1/Integration/RetailerController.php:L27
+EDGE RetailerController --inherits [EXTRACTED]--> Controller at=app/Http/Controllers/Api/V1/Integration/RetailerController.php:L17
+EDGE RetailerController --mixes_in [EXTRACTED]--> LogIntegration.php at=app/Http/Controllers/Api/V1/Integration/RetailerController.php:L19
+EDGE .integration() --references [EXTRACTED context=parameter_type]--> Illuminate\\Http\\Request at=app/Http/Controllers/Api/V1/Integration/RetailerController.php:L27
+EDGE V1/Integration/WholesalerController.php --imports [EXTRACTED context=import]--> LogIntegration.php at=app/Http/Controllers/Api/V1/Integration/WholesalerController.php:L10
+EDGE WholesalerController --mixes_in [EXTRACTED]--> LogIntegration.php at=app/Http/Controllers/Api/V1/Integration/WholesalerController.php:L18
+EDGE V2/Integration/RetailerController.php --imports [EXTRACTED context=import]--> LogIntegration.php at=app/Http/Controllers/Api/V2/Integration/RetailerController.php:L10
+EDGE RetailerController --mixes_in [EXTRACTED]--> LogIntegration.php at=app/Http/Controllers/Api/V2/Integration/RetailerController.php:L19
+EDGE V2/Integration/WholesalerController.php --imports [EXTRACTED context=import]--> LogIntegration.php at=app/Http/Controllers/Api/V2/Integration/WholesalerController.php:L10
+EDGE WholesalerController --mixes_in [EXTRACTED]--> LogIntegration.php at=app/Http/Controllers/Api/V2/Integration/WholesalerController.php:L18
+"""
+expected = """
+Traversal: BFS depth=2 | Start: ['RetailerController'] | 14 nodes found
+
+NODE RetailerController [src=app/Http/Controllers/Api/V1/Integration/RetailerController.php loc=L17]
+NODE Controller [src=app/Http/Controllers/Controller.php loc=L17]
+NODE LogIntegration.php [src=app/Traits/Integration/LogIntegration.php loc=L1]
+NODE V1/Integration/RetailerController.php [src=app/Http/Controllers/Api/V1/Integration/RetailerController.php loc=L1]
+NODE .integration() [src=app/Http/Controllers/Api/V1/Integration/RetailerController.php loc=L27]
+NODE Illuminate\\Http\\Request [src= loc=]
+NODE Exception [src= loc=]
+NODE V1/Integration/WholesalerController.php [src=app/Http/Controllers/Api/V1/Integration/WholesalerController.php loc=L1]
+NODE V2/Integration/RetailerController.php [src=app/Http/Controllers/Api/V2/Integration/RetailerController.php loc=L1]
+NODE V2/Integration/WholesalerController.php [src=app/Http/Controllers/Api/V2/Integration/WholesalerController.php loc=L1]
+EDGE RetailerController --method [EXTRACTED]--> .integration() at=app/Http/Controllers/Api/V1/Integration/RetailerController.php:L27
+EDGE RetailerController --inherits [EXTRACTED]--> Controller at=app/Http/Controllers/Api/V1/Integration/RetailerController.php:L17
+EDGE RetailerController --mixes_in [EXTRACTED]--> LogIntegration.php at=app/Http/Controllers/Api/V1/Integration/RetailerController.php:L19
+EDGE .integration() --references [EXTRACTED context=parameter_type]--> Illuminate\\Http\\Request at=app/Http/Controllers/Api/V1/Integration/RetailerController.php:L27
+EDGE V1/Integration/WholesalerController.php --imports [EXTRACTED context=import]--> LogIntegration.php at=app/Http/Controllers/Api/V1/Integration/WholesalerController.php:L10
+EDGE WholesalerController --mixes_in [EXTRACTED]--> LogIntegration.php at=app/Http/Controllers/Api/V1/Integration/WholesalerController.php:L18
+EDGE V2/Integration/RetailerController.php --imports [EXTRACTED context=import]--> LogIntegration.php at=app/Http/Controllers/Api/V2/Integration/RetailerController.php:L10
+EDGE RetailerController --mixes_in [EXTRACTED]--> LogIntegration.php at=app/Http/Controllers/Api/V2/Integration/RetailerController.php:L19
+EDGE V2/Integration/WholesalerController.php --imports [EXTRACTED context=import]--> LogIntegration.php at=app/Http/Controllers/Api/V2/Integration/WholesalerController.php:L10
+EDGE WholesalerController --mixes_in [EXTRACTED]--> LogIntegration.php at=app/Http/Controllers/Api/V2/Integration/WholesalerController.php:L18
+"""
+
+[[tests.graphify-query]]
+name = "keeps BusinessController calls and references before imports"
+input = """
+Traversal: BFS depth=2 | Start: ['BusinessController'] | 3 nodes found
+
+NODE BusinessController [src=app/Http/Controllers/Api/V1/Customer/BusinessController.php loc=L30 community=56]
+NODE .getNearby() [src=app/Http/Controllers/Api/V1/Customer/BusinessController.php loc=L48 community=56]
+NODE ayoencrypt() [src=app/Helpers/SecurityHelpers.php loc=L4 community=16]
+EDGE BusinessController --mixes_in [EXTRACTED]--> BusinessTrait.php at=app/Http/Controllers/Api/V1/Customer/BusinessController.php:L32
+EDGE V1/Customer/BusinessController.php --imports [EXTRACTED context=import]--> Exception at=app/Http/Controllers/Api/V1/Customer/BusinessController.php:L22
+EDGE .getNearby() --calls [INFERRED context=call]--> ayoencrypt() at=app/Http/Controllers/Api/V1/Customer/BusinessController.php:L58
+EDGE .getNearby() --references [EXTRACTED context=parameter_type]--> Illuminate\\Http\\Request at=app/Http/Controllers/Api/V1/Customer/BusinessController.php:L48
+"""
+expected = """
+Traversal: BFS depth=2 | Start: ['BusinessController'] | 3 nodes found
+
+NODE BusinessController [src=app/Http/Controllers/Api/V1/Customer/BusinessController.php loc=L30]
+NODE .getNearby() [src=app/Http/Controllers/Api/V1/Customer/BusinessController.php loc=L48]
+NODE ayoencrypt() [src=app/Helpers/SecurityHelpers.php loc=L4]
+EDGE BusinessController --mixes_in [EXTRACTED]--> BusinessTrait.php at=app/Http/Controllers/Api/V1/Customer/BusinessController.php:L32
+EDGE V1/Customer/BusinessController.php --imports [EXTRACTED context=import]--> Exception at=app/Http/Controllers/Api/V1/Customer/BusinessController.php:L22
+EDGE .getNearby() --calls [INFERRED context=call]--> ayoencrypt() at=app/Http/Controllers/Api/V1/Customer/BusinessController.php:L58
+EDGE .getNearby() --references [EXTRACTED context=parameter_type]--> Illuminate\\Http\\Request at=app/Http/Controllers/Api/V1/Customer/BusinessController.php:L48
+"""

--- a/src/filters/graphify-update.toml
+++ b/src/filters/graphify-update.toml
@@ -1,0 +1,39 @@
+[filters.graphify-update]
+description = "Strip graphify update progress while preserving warnings and outcomes"
+match_command = "^graphify\\s+update(?:\\s|$)"
+strip_lines_matching = [
+  "^\\s*$",
+  "^Re-extracting code files in .+ \\(no LLM needed\\)\\.\\.\\.$",
+  "^  AST extraction: \\d+/\\d+ uncached files \\(\\d+%\\)$",
+  "^Code graph updated\\. For doc/paper/image changes run /graphify --update in your AI assistant\\.$",
+  "^Tip: set GEMINI_API_KEY or GOOGLE_API_KEY to use Gemini for semantic extraction\\.$",
+]
+
+[[tests.graphify-update]]
+name = "preserves warnings and the final update outcome"
+input = """
+Re-extracting code files in /workspace/app (no LLM needed)...
+  AST extraction: 14/14 uncached files (100%)
+  warning: 1 source file(s) produced zero nodes and are absent from the graph: .githooks-config.json.
+  warning: 9 .sql file(s) contributed nothing to the graph because tree_sitter_sql is not installed.
+[graphify watch] No code-graph topology changes detected; outputs left untouched.
+Code graph updated. For doc/paper/image changes run /graphify --update in your AI assistant.
+Tip: set GEMINI_API_KEY or GOOGLE_API_KEY to use Gemini for semantic extraction.
+"""
+expected = """
+  warning: 1 source file(s) produced zero nodes and are absent from the graph: .githooks-config.json.
+  warning: 9 .sql file(s) contributed nothing to the graph because tree_sitter_sql is not installed.
+[graphify watch] No code-graph topology changes detected; outputs left untouched.
+"""
+
+[[tests.graphify-update]]
+name = "preserves failed rebuild output"
+input = """
+Re-extracting code files in /workspace/app (no LLM needed)...
+[graphify watch] Rebuild failed: graph is empty
+Nothing to update or rebuild failed — check output above.
+"""
+expected = """
+[graphify watch] Rebuild failed: graph is empty
+Nothing to update or rebuild failed — check output above.
+"""


### PR DESCRIPTION
Fixes #3159

## Summary
Add first-class RTK compatibility for Graphify `query`, `explain`, and `update`.

- `rtk discover` now recognizes Graphify’s supported subcommands and the hook rewrite path produces `rtk graphify …`.
- Query output removes numeric `community=N` metadata and uses priority-aware trimming: nodes, `calls`, `references`, and `[INFERRED]` relationships survive before lower-signal `imports` / `mixes_in` edges.
- RTK does not re-crop Graphify output that already contains Graphify’s native `[!] TRUNCATED` budget marker.
- Explain output now preserves Graphify’s own connection list and grouped-by-file summary without a second head/tail truncation.
- Update output no longer merges stderr into stdout, preventing Graphify warning lines from being reordered around `[graphify watch]` results.

## Related issue

#3159 

## Implementation details

### Part 1: Discover and rewrite support

Added a static Graphify rule for:

- `graphify query`
- `graphify explain`
- `graphify update`

This makes these commands visible to `rtk discover` and rewritable by the hook. The rewrite regression test includes `graphify query Business --budget 5000`, proving RTK preserves the requested Graphify budget verbatim.

### Part 2: Query signal preservation

Added two generic TOML pipeline controls:

- `priority_lines_matching`
- `priority_skip_if_output_matches`

The Graphify query profile uses them to retain high-value call-graph information before low-signal import/mixin boilerplate, while preserving the source order of retained lines. When Graphify has already applied its own token budget, RTK leaves the native result intact rather than truncating it again.

The BusinessController fixture covers mixed `imports`, `mixes_in`, `calls`, and `references` output.

### Part 3: Native Graphify summaries and update ordering

`graphify explain` already emits a bounded summary: up to 20 connections plus a grouped-by-file section. RTK now preserves that native structure, including `ID:` because Graphify accepts node IDs as `graphify explain` input.

`graphify update` warnings are emitted on stderr while `[graphify watch]` output is emitted on stdout. Capturing and concatenating the streams reordered those messages, so the update profile now filters stdout only and leaves warning ordering intact.

### Filter rules

| Command | Rule | Result |
|---|---|---|
| `graphify query` | Remove numeric `community=N`; keep nodes, then `calls` / `references` / `[INFERRED]` edges before structural and import/mixin edges; cap at 60 lines | Keeps call-graph signal when output must be reduced |
| `graphify query` with `[!] TRUNCATED` | Skip RTK priority trimming | Graphify’s native token-budget summary remains intact |
| `graphify explain` | No RTK line cap | Keeps Graphify’s native 20-connection and grouped-by-file summary verbatim |
| `graphify update` | Strip re-extraction banner, completed AST progress, generic success line, and Gemini tip; do not capture/merge stderr | Keeps warnings in their original order relative to `[graphify watch]` output |

```toml
# graphify query
replace = [
  { pattern = " community=\\d+", replacement = "" },
]
priority_lines_matching = [
  "^Traversal:",
  "^\\[!\\] TRUNCATED:",
  "^NODE ",
  "^EDGE .*--(?:calls|references)\\b",
  "^EDGE .*\\[INFERRED(?:\\s|\\])",
  "^EDGE .*--(?:contains|method|inherits)\\b",
  "^EDGE ",
]
priority_skip_if_output_matches = ["^\\[!\\] TRUNCATED:"]
max_lines = 60
```

## Test plan
- [x] `cargo test graphify -- --nocapture` — 5 Graphify-focused tests pass
- [x] `cargo test priority_line_selection -- --nocapture` — priority retention and native-truncation bypass pass
- [x] `cargo run -- verify --filter graphify-query` — 3/3 inline tests pass
- [x] `cargo run -- verify --filter graphify-explain` — 2/2 inline tests pass
- [x] `cargo run -- verify --filter graphify-update` — 2/2 inline tests pass
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets`
- [x] `git diff --check`
- [ ] `cargo test --all` — 2,483 tests pass, but 14 unrelated failures remain in curl, tracking DB, and global-hook tests due existing expectations and sandbox write restrictions; none touch the Graphify files changed here.

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
