### PR TITLE
docs(readme): clarify Copilot quick start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ rtk gain        # Should show the savings dashboard
 
 ```bash
 # 1. Install for your AI tool
-rtk init -g                     # Claude Code / Copilot (default)
+rtk init -g                     # Claude Code (default)
+rtk init -g --copilot           # GitHub Copilot
 rtk init -g --gemini            # Gemini CLI
 rtk init -g --codex             # Codex (OpenAI)
 rtk init -g --agent cursor      # Cursor


### PR DESCRIPTION
## What changed
- Split the README quick-start install command for Claude Code and GitHub Copilot into separate lines.
- Clarified that `rtk init -g` is the Claude Code default and `rtk init -g --copilot` is the GitHub Copilot setup command.

## Why
The quick-start section currently describes `rtk init -g` as `Claude Code / Copilot (default)`, but Copilot setup uses the explicit `--copilot` flag.

Fixes #2244.

## How I tested
- `git diff --check`
