### PR TITLE
feat: add resume context command

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ rtk discover                    # Find missed savings opportunities
 rtk discover --all --since 7    # All projects, last 7 days
 
 rtk session                     # Show RTK adoption across recent sessions
+rtk resume                      # Compact Git + saved execution context for a new agent session
+rtk resume --save --plan docs/plans/issue-42.md --completed "tests pass" --next "request review"
 ```
 
 ## Global Flags

--- a/docs/guide/analytics/resume.md
+++ b/docs/guide/analytics/resume.md
@@ -1,0 +1,22 @@
+---
+title: Resume
+description: Persist and retrieve compact repository execution context for a new agent session
+---
+
+# Resume
+
+`rtk resume` replaces repeated repository-orientation commands with one compact record. It reports the current worktree, branch, merge-base, cleanliness, and HEAD, alongside optional execution fields: active plan, completed steps, blockers, last reviewed commit, and next action.
+
+It is read-only by default. RTK stores saved fields outside the repository in its normal local data directory, keyed by the canonical repository path, so it never creates or changes project files.
+
+```bash
+rtk resume
+rtk resume --format json
+rtk resume --save --plan docs/plans/issue-42.md \
+  --completed "unit tests pass" \
+  --blocker "awaiting security review" \
+  --last-reviewed abc1234 \
+  --next "open a draft PR"
+```
+
+Repeat `--completed` or `--blocker` to replace the corresponding list. Supplying context fields without `--save` fails rather than silently changing state.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -60,9 +60,10 @@ See [Token Savings Analytics](./analytics/gain.md) for export formats and analys
 ```bash
 rtk discover       # find commands that ran without RTK (missed savings)
 rtk session        # RTK adoption rate per Claude Code session
+rtk resume         # compact Git and persisted execution context
 ```
 
-See [Discover and Session](./analytics/discover.md) for details.
+See [Discover and Session](./analytics/discover.md) and [Resume](./analytics/resume.md) for details.
 
 ## Further reading
 

--- a/src/cmds/system/resume.rs
+++ b/src/cmds/system/resume.rs
@@ -1,0 +1,201 @@
+//! Compact, per-repository execution context for resuming agent work.
+//!
+//! Context is stored outside the repository in RTK's normal local data directory.
+//! Reading is side-effect free; callers must opt in to writes with `--save`.
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::core::constants::RTK_DATA_DIR;
+
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
+struct SavedContext {
+    active_plan: Option<String>,
+    completed_steps: Vec<String>,
+    blockers: Vec<String>,
+    last_reviewed_commit: Option<String>,
+    next_action: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ResumeContext {
+    worktree: String,
+    branch: String,
+    base: Option<String>,
+    clean: bool,
+    head: String,
+    #[serde(flatten)]
+    saved: SavedContext,
+}
+
+pub fn run(
+    save: bool,
+    plan: Option<String>,
+    completed_steps: Vec<String>,
+    blockers: Vec<String>,
+    last_reviewed: Option<String>,
+    next: Option<String>,
+    format: &str,
+) -> Result<()> {
+    if format != "text" && format != "json" {
+        bail!("Unsupported format '{format}'. Use text or json.");
+    }
+    if (!completed_steps.is_empty()
+        || !blockers.is_empty()
+        || plan.is_some()
+        || last_reviewed.is_some()
+        || next.is_some())
+        && !save
+    {
+        bail!("Context fields require --save; read-only resume never changes state.");
+    }
+
+    let repo = git(&["rev-parse", "--show-toplevel"])?;
+    let path = context_path(Path::new(&repo))?;
+    let mut saved = load_context(&path)?;
+    if save {
+        if let Some(value) = plan {
+            saved.active_plan = Some(value);
+        }
+        if !completed_steps.is_empty() {
+            saved.completed_steps = completed_steps;
+        }
+        if !blockers.is_empty() {
+            saved.blockers = blockers;
+        }
+        if let Some(value) = last_reviewed {
+            saved.last_reviewed_commit = Some(value);
+        }
+        if let Some(value) = next {
+            saved.next_action = Some(value);
+        }
+        save_context(&path, &saved)?;
+    }
+
+    let state = ResumeContext {
+        worktree: repo,
+        branch: git(&["branch", "--show-current"])? ,
+        base: merge_base().ok(),
+        clean: git(&["status", "--porcelain"])?.is_empty(),
+        head: git(&["rev-parse", "HEAD"])? ,
+        saved,
+    };
+    print_context(&state, format)
+}
+
+fn git(args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .output()
+        .context("Failed to run git")?;
+    if !output.status.success() {
+        bail!(
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn merge_base() -> Result<String> {
+    for candidate in ["@{upstream}", "origin/HEAD", "main", "master"] {
+        if let Ok(base) = git(&["merge-base", "HEAD", candidate]) {
+            return Ok(base);
+        }
+    }
+    bail!("No upstream or conventional base branch found")
+}
+
+fn context_path(repo: &Path) -> Result<PathBuf> {
+    let canonical = repo.canonicalize().context("Cannot canonicalize repository path")?;
+    let hash = format!("{:x}", Sha256::digest(canonical.to_string_lossy().as_bytes()));
+    let data = dirs::data_local_dir().context("Cannot determine local data directory")?;
+    Ok(data.join(RTK_DATA_DIR).join("resume").join(format!("{hash}.json")))
+}
+
+fn load_context(path: &Path) -> Result<SavedContext> {
+    if !path.exists() {
+        return Ok(SavedContext::default());
+    }
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    serde_json::from_str(&content).with_context(|| format!("Failed to parse {}", path.display()))
+}
+
+fn save_context(path: &Path, context: &SavedContext) -> Result<()> {
+    let parent = path.parent().context("Resume context path has no parent")?;
+    fs::create_dir_all(parent).with_context(|| format!("Failed to create {}", parent.display()))?;
+    let content = serde_json::to_string_pretty(context).context("Failed to serialize resume context")?;
+    fs::write(path, content + "\n")
+        .with_context(|| format!("Failed to write {}", path.display()))
+}
+
+fn print_context(context: &ResumeContext, format: &str) -> Result<()> {
+    if format == "json" {
+        println!("{}", serde_json::to_string(context)?);
+        return Ok(());
+    }
+    println!(
+        "repo={} branch={} base={} clean={} head={}",
+        context.worktree,
+        context.branch,
+        context.base.as_deref().unwrap_or("unknown"),
+        context.clean,
+        context.head
+    );
+    println!("plan={}", context.saved.active_plan.as_deref().unwrap_or("unset"));
+    println!("completed={}", context.saved.completed_steps.join(" | "));
+    println!("blockers={}", context.saved.blockers.join(" | "));
+    println!("last_reviewed={}", context.saved.last_reviewed_commit.as_deref().unwrap_or("unset"));
+    println!("next={}", context.saved.next_action.as_deref().unwrap_or("unset"));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn context_path_is_stable_and_does_not_live_in_the_repository() {
+        let repo = std::env::current_dir().unwrap();
+        let first = context_path(&repo).unwrap();
+        let second = context_path(&repo).unwrap();
+        assert_eq!(first, second);
+        assert!(!first.starts_with(repo));
+    }
+
+    #[test]
+    fn saved_context_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("context.json");
+        let expected = SavedContext {
+            active_plan: Some("docs/plans/a.md".into()),
+            completed_steps: vec!["tests".into()],
+            blockers: vec!["review".into()],
+            last_reviewed_commit: Some("abc123".into()),
+            next_action: Some("open PR".into()),
+        };
+        save_context(&path, &expected).unwrap();
+        assert_eq!(load_context(&path).unwrap(), expected);
+    }
+
+    #[test]
+    fn context_fields_require_explicit_save() {
+        let error = run(
+            false,
+            Some("docs/plans/a.md".into()),
+            Vec::new(),
+            Vec::new(),
+            None,
+            None,
+            "text",
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("require --save"));
+    }
+}

--- a/src/core/constants.rs
+++ b/src/core/constants.rs
@@ -23,6 +23,7 @@ pub const RTK_META_COMMANDS: &[&str] = &[
     "trust",
     "untrust",
     "session",
+    "resume",
     "rewrite",
     "telemetry",
     "smart",

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -577,15 +577,53 @@ pub(crate) mod tests {
         }
     }
 
+    #[cfg(unix)]
+    fn script_command(script: &str) -> Command {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", script]);
+        cmd
+    }
+
+    #[cfg(windows)]
+    fn script_command(script: &str) -> Command {
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/C", script]);
+        cmd
+    }
+
+    #[cfg(unix)]
+    fn large_output_command(stderr: bool) -> Command {
+        let redirect = if stderr { " 1>&2" } else { "" };
+        script_command(&format!(
+            "dd if=/dev/zero bs=1024 count=11264 2>/dev/null | tr '\\0' 'a' | fold -w 80{redirect}"
+        ))
+    }
+
+    #[cfg(windows)]
+    fn large_output_command(stderr: bool) -> Command {
+        let write = if stderr {
+            "[Console]::Error.WriteLine($chunk)"
+        } else {
+            "Write-Output $chunk"
+        };
+        let mut cmd = Command::new("powershell.exe");
+        cmd.args([
+            "-NoProfile",
+            "-Command",
+            &format!("$chunk = 'a' * 1024; 1..11264 | ForEach-Object {{ {write} }}"),
+        ]);
+        cmd
+    }
+
     #[test]
     fn test_exit_code_zero() {
-        let status = Command::new("true").status().unwrap();
+        let status = script_command("exit 0").status().unwrap();
         assert_eq!(status_to_exit_code(status), 0);
     }
 
     #[test]
     fn test_exit_code_nonzero() {
-        let status = Command::new("false").status().unwrap();
+        let status = script_command("exit 1").status().unwrap();
         assert_eq!(status_to_exit_code(status), 1);
     }
 
@@ -661,8 +699,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_run_streaming_passthrough_echo() {
-        let mut cmd = Command::new("echo");
-        cmd.arg("hello");
+        let mut cmd = script_command("echo hello");
         let result = run_streaming(&mut cmd, StdinMode::Null, FilterMode::Passthrough).unwrap();
         assert_eq!(result.exit_code, 0);
         // Passthrough inherits TTY — raw/filtered are empty
@@ -672,15 +709,14 @@ pub(crate) mod tests {
     #[test]
     fn test_run_streaming_exit_code_preserved() {
         // nosemgrep: interpreter-execution
-        let mut cmd = Command::new("sh");
-        cmd.args(["-c", "exit 42"]);
+        let mut cmd = script_command("exit 42");
         let result = run_streaming(&mut cmd, StdinMode::Null, FilterMode::Passthrough).unwrap();
         assert_eq!(result.exit_code, 42);
     }
 
     #[test]
     fn test_run_streaming_exit_code_zero() {
-        let mut cmd = Command::new("true");
+        let mut cmd = script_command("exit 0");
         let result = run_streaming(&mut cmd, StdinMode::Null, FilterMode::Passthrough).unwrap();
         assert_eq!(result.exit_code, 0);
         assert!(result.success());
@@ -688,7 +724,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_run_streaming_exit_code_one() {
-        let mut cmd = Command::new("false");
+        let mut cmd = script_command("exit 1");
         let result = run_streaming(&mut cmd, StdinMode::Null, FilterMode::Passthrough).unwrap();
         assert_eq!(result.exit_code, 1);
         assert!(!result.success());
@@ -736,13 +772,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_run_streaming_raw_cap_at_10mb() {
-        // nosemgrep: interpreter-execution
-        let mut cmd = Command::new("sh");
-        // ~11 MiB of 80-char lines (fast: fewer lines than `yes | head -6M`)
-        cmd.args([
-            "-c",
-            "dd if=/dev/zero bs=1024 count=11264 2>/dev/null | tr '\\0' 'a' | fold -w 80",
-        ]);
+        let mut cmd = large_output_command(false);
         let result = run_streaming(&mut cmd, StdinMode::Null, FilterMode::CaptureOnly).unwrap();
         assert!(
             result.raw.len() <= 10_485_760 + 100,
@@ -757,13 +787,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_run_streaming_stderr_cap_at_10mb() {
-        // nosemgrep: interpreter-execution
-        let mut cmd = Command::new("sh");
-        // ~11 MiB on stderr, nothing on stdout
-        cmd.args([
-            "-c",
-            "dd if=/dev/zero bs=1024 count=11264 2>/dev/null | tr '\\0' 'a' | fold -w 80 1>&2",
-        ]);
+        let mut cmd = large_output_command(true);
         let result = run_streaming(&mut cmd, StdinMode::Null, FilterMode::CaptureOnly).unwrap();
         // raw = raw_stdout + raw_stderr; stdout is empty so raw ≈ stderr size
         assert!(
@@ -775,7 +799,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_child_guard_prevents_zombie() {
-        let mut cmd = Command::new("true");
+        let mut cmd = script_command("exit 0");
         let result = run_streaming(&mut cmd, StdinMode::Null, FilterMode::CaptureOnly);
         assert!(result.is_ok());
         assert_eq!(result.unwrap().exit_code, 0);
@@ -783,31 +807,31 @@ pub(crate) mod tests {
 
     #[test]
     fn test_run_streaming_null_stdin_cat() {
+        #[cfg(unix)]
         let mut cmd = Command::new("cat");
+        #[cfg(windows)]
+        let mut cmd = script_command("type nul");
         let result = run_streaming(&mut cmd, StdinMode::Null, FilterMode::Passthrough).unwrap();
         assert_eq!(result.exit_code, 0);
     }
 
     #[test]
     fn test_run_streaming_raw_contains_stdout() {
-        let mut cmd = Command::new("echo");
-        cmd.arg("test_output_xyz");
+        let mut cmd = script_command("echo test_output_xyz");
         let result = run_streaming(&mut cmd, StdinMode::Null, FilterMode::CaptureOnly).unwrap();
         assert!(result.raw.contains("test_output_xyz"));
     }
 
     #[test]
     fn test_run_streaming_capture_only_filtered_equals_raw() {
-        let mut cmd = Command::new("echo");
-        cmd.arg("check_equality");
+        let mut cmd = script_command("echo check_equality");
         let result = run_streaming(&mut cmd, StdinMode::Null, FilterMode::CaptureOnly).unwrap();
         assert_eq!(result.filtered.trim(), result.raw_stdout.trim());
     }
 
     #[test]
     fn test_exec_capture_success() {
-        let mut cmd = Command::new("echo");
-        cmd.arg("hello_capture");
+        let mut cmd = script_command("echo hello_capture");
         let result = exec_capture(&mut cmd).unwrap();
         assert!(result.success());
         assert_eq!(result.exit_code, 0);
@@ -816,7 +840,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_exec_capture_failure() {
-        let mut cmd = Command::new("false");
+        let mut cmd = script_command("exit 1");
         let result = exec_capture(&mut cmd).unwrap();
         assert!(!result.success());
         assert_eq!(result.exit_code, 1);
@@ -825,8 +849,7 @@ pub(crate) mod tests {
     #[test]
     fn test_exec_capture_stderr() {
         // nosemgrep: interpreter-execution
-        let mut cmd = Command::new("sh");
-        cmd.args(["-c", "echo err_msg >&2"]);
+        let mut cmd = script_command("echo err_msg >&2");
         let result = exec_capture(&mut cmd).unwrap();
         assert!(result.stderr.contains("err_msg"));
     }
@@ -834,8 +857,7 @@ pub(crate) mod tests {
     #[test]
     fn test_exec_capture_combined() {
         // nosemgrep: interpreter-execution
-        let mut cmd = Command::new("sh");
-        cmd.args(["-c", "echo out_msg; echo err_msg >&2"]);
+        let mut cmd = script_command("echo out_msg & echo err_msg >&2");
         let result = exec_capture(&mut cmd).unwrap();
         let combined = result.combined();
         assert!(combined.contains("out_msg"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,8 @@ use cmds::ruby::{rake_cmd, rspec_cmd, rubocop_cmd};
 use cmds::rust::{cargo_cmd, runner};
 use cmds::scala::sbt_cmd;
 use cmds::system::{
-    deps, env_cmd, find_cmd, format_cmd, json_cmd, local_llm, log_cmd, ls, pipe_cmd, read, search,
-    summary, tree, wc_cmd,
+    deps, env_cmd, find_cmd, format_cmd, json_cmd, local_llm, log_cmd, ls, pipe_cmd, read, resume,
+    search, summary, tree, wc_cmd,
 };
 
 use anyhow::{Context, Result};
@@ -595,6 +595,31 @@ enum Commands {
 
     /// Show RTK adoption across Claude Code sessions
     Session {},
+
+    /// Save or show compact repository execution context for the next agent session
+    Resume {
+        /// Persist supplied context fields for this repository
+        #[arg(long)]
+        save: bool,
+        /// Active plan path or identifier
+        #[arg(long)]
+        plan: Option<String>,
+        /// Completed step (repeat for multiple steps)
+        #[arg(long = "completed")]
+        completed_steps: Vec<String>,
+        /// Current blocker (repeat for multiple blockers)
+        #[arg(long = "blocker")]
+        blockers: Vec<String>,
+        /// Commit last reviewed by a human or reviewer
+        #[arg(long)]
+        last_reviewed: Option<String>,
+        /// Next action for the following session
+        #[arg(long)]
+        next: Option<String>,
+        /// Output format: text or json
+        #[arg(short, long, default_value = "text")]
+        format: String,
+    },
 
     /// Manage telemetry consent and data (RGPD/GDPR)
     Telemetry {
@@ -2269,6 +2294,27 @@ fn run_cli() -> Result<i32> {
             0
         }
 
+        Commands::Resume {
+            save,
+            plan,
+            completed_steps,
+            blockers,
+            last_reviewed,
+            next,
+            format,
+        } => {
+            resume::run(
+                save,
+                plan,
+                completed_steps,
+                blockers,
+                last_reviewed,
+                next,
+                &format,
+            )?;
+            0
+        }
+
         Commands::Telemetry { command } => {
             core::telemetry_cmd::run(&command)?;
             0
@@ -3066,6 +3112,50 @@ mod tests {
             match cli.command {
                 Commands::Gain { failures, .. } => assert!(failures),
                 _ => panic!("Expected Gain command"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_resume_save_flags_parse() {
+        let result = Cli::try_parse_from([
+            "rtk",
+            "resume",
+            "--save",
+            "--plan",
+            "docs/plans/42.md",
+            "--completed",
+            "tests pass",
+            "--blocker",
+            "review",
+            "--last-reviewed",
+            "abc123",
+            "--next",
+            "open PR",
+            "--format",
+            "json",
+        ]);
+        assert!(result.is_ok());
+        if let Ok(cli) = result {
+            match cli.command {
+                Commands::Resume {
+                    save,
+                    plan,
+                    completed_steps,
+                    blockers,
+                    last_reviewed,
+                    next,
+                    format,
+                } => {
+                    assert!(save);
+                    assert_eq!(plan.as_deref(), Some("docs/plans/42.md"));
+                    assert_eq!(completed_steps, vec!["tests pass"]);
+                    assert_eq!(blockers, vec!["review"]);
+                    assert_eq!(last_reviewed.as_deref(), Some("abc123"));
+                    assert_eq!(next.as_deref(), Some("open PR"));
+                    assert_eq!(format, "json");
+                }
+                _ => panic!("Expected Resume command"),
             }
         }
     }


### PR DESCRIPTION
## Summary
- add `rtk resume` for compact per-worktree execution context
- require `--save` for persistent context updates
- make stream test fixtures portable across Windows and Unix

## Validation
- `cargo fmt --check`
- `cargo check --all-targets`
- `cargo test --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`

Local validation passed: 2,493 tests passed; 8 ignored.