### PR TITLE
fix(discover): preserve case terminators (;; ;& ;;&) in hook rewrite

### DIFF
--- a/src/discover/lexer.rs
+++ b/src/discover/lexer.rs
@@ -1004,6 +1004,85 @@ mod tests {
     }
 
     #[test]
+    fn test_case_terminators_atomic() {
+        // `;;`, `;&`, `;;&` are single Operator tokens, never split (#3197)
+        let tokens = tokenize("a;; b;& c;;& d");
+        let ops: Vec<&str> = tokens
+            .iter()
+            .filter(|t| t.kind == TokenKind::Operator)
+            .map(|t| t.value.as_str())
+            .collect();
+        assert_eq!(ops, vec![";;", ";&", ";;&"]);
+    }
+
+    #[test]
+    fn test_quoted_case_terminator_not_operator() {
+        for cmd in ["grep ';;' file", "echo \";;\"", "echo 'a;&b'"] {
+            let tokens = tokenize(cmd);
+            assert!(
+                !tokens.iter().any(|t| t.kind == TokenKind::Operator),
+                "{} must not produce an Operator token",
+                cmd
+            );
+        }
+    }
+
+    #[test]
+    fn test_spaced_semicolons_stay_separate() {
+        // `; ;` is two real separators, not a case terminator
+        let tokens = tokenize("a ; ; b");
+        let ops: Vec<&str> = tokens
+            .iter()
+            .filter(|t| t.kind == TokenKind::Operator)
+            .map(|t| t.value.as_str())
+            .collect();
+        assert_eq!(ops, vec![";", ";"]);
+    }
+
+    #[test]
+    fn test_escaped_semicolon_is_arg() {
+        // find -exec's `\;` is an escaped word, not a separator
+        let tokens = tokenize(r"find . -exec rm {} \;");
+        assert!(!tokens.iter().any(|t| t.kind == TokenKind::Operator));
+        assert!(tokens
+            .iter()
+            .any(|t| t.kind == TokenKind::Arg && t.value == r"\;"));
+    }
+
+    #[test]
+    fn test_triple_semicolon_greedy_left() {
+        let tokens = tokenize("a;;; b");
+        let ops: Vec<&str> = tokens
+            .iter()
+            .filter(|t| t.kind == TokenKind::Operator)
+            .map(|t| t.value.as_str())
+            .collect();
+        assert_eq!(ops, vec![";;", ";"]);
+    }
+
+    #[test]
+    fn test_case_terminator_offset_after_utf8() {
+        // multibyte chars before `;;` must not skew offset/segment math
+        let cmd = "echo café;; ls";
+        let tokens = tokenize(cmd);
+        let op = tokens
+            .iter()
+            .find(|t| t.kind == TokenKind::Operator)
+            .expect("operator token");
+        assert_eq!(op.value, ";;");
+        assert_eq!(&cmd[op.offset..op.offset + op.value.len()], ";;");
+        assert_eq!(split_on_operators(cmd, false), vec!["echo café", "ls"]);
+    }
+
+    #[test]
+    fn test_split_perms_checks_case_arm_bodies() {
+        // Atomic `;;` must not hide a case-arm command from permission checks
+        let segments = split_for_permissions("case x in a) rm -rf /tmp/x;; b) git push;& esac");
+        assert!(segments.contains(&"rm -rf /tmp/x"));
+        assert!(segments.contains(&"git push"));
+    }
+
+    #[test]
     fn test_offset_tracking() {
         let tokens = tokenize("a && b");
         assert_eq!(tokens[0].offset, 0);

--- a/src/discover/lexer.rs
+++ b/src/discover/lexer.rs
@@ -145,12 +145,26 @@ fn tokenize_inner(input: &str, emit_newline: bool) -> Vec<ParsedToken> {
             }
             ';' => {
                 flush_arg(&mut tokens, &mut current, current_start);
+                let start = byte_pos;
+                byte_pos += char_len;
+                // `;;`, `;;&` and `;&` are case-statement terminators: atomic
+                // tokens, not two `;` separators (splitting them breaks bash).
+                let mut val = String::from(";");
+                if chars.peek() == Some(&';') {
+                    chars.next();
+                    byte_pos += 1;
+                    val.push(';');
+                }
+                if chars.peek() == Some(&'&') {
+                    chars.next();
+                    byte_pos += 1;
+                    val.push('&');
+                }
                 tokens.push(ParsedToken {
                     kind: TokenKind::Operator,
-                    value: ";".into(),
-                    offset: byte_pos,
+                    value: val,
+                    offset: start,
                 });
-                byte_pos += char_len;
                 current_start = byte_pos;
             }
             '&' => {

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -3880,6 +3880,24 @@ mod tests {
     }
 
     #[test]
+    fn test_rewrite_preserves_quoted_case_terminator() {
+        // `;;` inside quotes is data, not an operator
+        assert_eq!(
+            rewrite_command_no_prefixes("grep ';;' file.txt; ls /tmp", &[]),
+            Some("rtk grep ';;' file.txt; rtk ls /tmp".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_preserves_find_exec_escaped_semicolon() {
+        // `\;` is find's terminator word; `;` right after it is a real separator
+        assert_eq!(
+            rewrite_command_no_prefixes(r"find /tmp -type f -exec echo {} \;; git status", &[]),
+            Some(r"rtk find /tmp -type f -exec echo {} \;; rtk git status".into())
+        );
+    }
+
+    #[test]
     fn test_rewrite_compound_or() {
         // `||` fallback: left rewritten, right rewritten
         assert_eq!(

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -717,8 +717,8 @@ fn rewrite_compound(
                     any_changed = true;
                 }
                 result.push_str(&rewritten);
-                if tok.value == ";" {
-                    result.push(';');
+                if tok.value.starts_with(';') {
+                    result.push_str(&tok.value);
                     let after = tok.offset + tok.value.len();
                     if after < cmd.len() {
                         result.push(' ');
@@ -3863,6 +3863,21 @@ mod tests {
     }
 
     // --- Compound operator edge cases ---
+
+    #[test]
+    fn test_rewrite_preserves_case_terminators() {
+        // `;;` must stay atomic — `; ;` is a bash syntax error (#3197)
+        assert_eq!(
+            rewrite_command_no_prefixes(
+                "ls /tmp; case x in a) echo 1;; b) echo 2;& c) echo 3;;& *) echo 4;; esac",
+                &[]
+            ),
+            Some(
+                "rtk ls /tmp; case x in a) echo 1;; b) echo 2;& c) echo 3;;& *) echo 4;; esac"
+                    .into()
+            )
+        );
+    }
 
     #[test]
     fn test_rewrite_compound_or() {


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

- The lexer tokenized `;;` as two separate `;` operators, and the rejoin step printed each one back as `"; "`, so any command that mixed a rewritable command with a case statement got corrupted into a bash syntax error.
- `;;`, `;&`, and `;;&` are now lexed as single operator tokens, using the same lookahead pattern already used for `&&`/`||`, and the rejoin step writes back the token's original value instead of reconstructing it character by character.
- Fixes #3197.

## Test plan
<!-- How did you verify this works? -->

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

Ran the pre-commit gate locally. I also added a regression test, `test_rewrite_preserves_case_terminators`. It covers the three terminators (`;;`, `;&`, `;;&`) in a case statement. I checked this test fails against the old lexer (reproduces the `; ;` corruption). It passes with the fix.

- Reverted lexer change locally reproduces the ; ; corruption caught by `test_rewrite_preserves_case_terminators`; fix turns it green.
quoted/escaped ;; (never operators), ; ; with space (stays two separators), `;;;` (greedy-left `;; + ;`), UTF-8 adjacent to ;; (offset), ;& at start/end of string.Invalid-bash inputs remain invalid, but don't become worse.
- Atomic `;;` yields byte matching segment boundaries to the old two-`;` tokens in `split_for_permissions`/`split_on_operators`, and case-arm bodies (e.g. a) `rm -rf x;;)` are still surfaced for permission checking.
- End-to-end: issue repro an 18-snippet matrix (case/select/until, nested case, quoted ;;, find -exec ;, heredocs, pipes-in-arms, unicode) through rtk hook claude; rewrites pass bash -n (or the original was already invalid, e.g. ;;& on bash v3.2) and case bodies are preserved byte-verbatim. Pipes-inside-case and heredocs correctly fall back to passthrough.

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.


## Possible follow-up

Not needed for this fix, but worth noting: the lexer handles multi-char operators with per-branch lookahead (`|` peeks for `||`/`|&`, `&` for `&&`/`&>`, and now `;` for `;;`/`;&`/`;;&`). A table-driven longest-match over a single operator list might make future operators a one-line addition and keep the rejoin spacing rules in one place. The issue also suggested splicing rewritten segments back by byte offset, leaving untouched bytes verbatim — that would get rid of this whole class of rejoin bugs. 
