### PR TITLE
fix(init): strip UTF-8 BOM when parsing hand-edited JSON config files

### DIFF
--- a/src/cmds/dotnet/dotnet_cmd.rs
+++ b/src/cmds/dotnet/dotnet_cmd.rs
@@ -639,9 +639,7 @@ fn parse_global_json_mtp_mode(path: &Path) -> bool {
     let Ok(content) = std::fs::read_to_string(path) else {
         return false;
     };
-    let Ok(json) =
-        serde_json::from_str::<Value>(crate::core::utils::strip_leading_bom(&content))
-    else {
+    let Ok(json) = crate::core::utils::from_json_str::<Value>(&content) else {
         return false;
     };
     json.get("test")

--- a/src/cmds/dotnet/dotnet_cmd.rs
+++ b/src/cmds/dotnet/dotnet_cmd.rs
@@ -639,7 +639,9 @@ fn parse_global_json_mtp_mode(path: &Path) -> bool {
     let Ok(content) = std::fs::read_to_string(path) else {
         return false;
     };
-    let Ok(json) = serde_json::from_str::<Value>(&content) else {
+    let Ok(json) =
+        serde_json::from_str::<Value>(crate::core::utils::strip_leading_bom(&content))
+    else {
         return false;
     };
     json.get("test")

--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -864,8 +864,10 @@ mod tests {
 
     #[test]
     fn test_toml_parse_tolerates_utf8_bom() {
-        // Hand-edited filter files on Windows often carry a BOM, which the
-        // toml crate rejects.
+        // Hand-edited filter files on Windows often carry a BOM. The toml
+        // crate tolerates it natively — this pin is why the TOML file-read
+        // sites (config.rs, toml_filter.rs) deliberately skip
+        // strip_leading_bom; if a crate upgrade regresses this, add it there.
         let bom = "\u{feff}schema_version = 1\n[filters.a]\nmatch_command = \"^a\"\n";
         assert!(filter_parse_error(bom).is_none());
         assert_eq!(match_patterns_in(bom), vec!["^a".to_string()]);

--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -863,6 +863,15 @@ mod tests {
     }
 
     #[test]
+    fn test_toml_parse_tolerates_utf8_bom() {
+        // Hand-edited filter files on Windows often carry a BOM, which the
+        // toml crate rejects.
+        let bom = "\u{feff}schema_version = 1\n[filters.a]\nmatch_command = \"^a\"\n";
+        assert!(filter_parse_error(bom).is_none());
+        assert_eq!(match_patterns_in(bom), vec!["^a".to_string()]);
+    }
+
+    #[test]
     fn test_is_rtk_reserved_command() {
         assert!(is_rtk_reserved_command("git"));
         assert!(is_rtk_reserved_command("cargo"));

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -418,7 +418,7 @@ fn composer_bin_dirs_from(env_bin_dir: Option<&str>, composer_json: Option<&str>
 }
 
 fn read_composer_bin_dir(composer_json: &str) -> Option<PathBuf> {
-    let parsed: Value = serde_json::from_str(composer_json).ok()?;
+    let parsed: Value = serde_json::from_str(strip_leading_bom(composer_json)).ok()?;
     let bin_dir = parsed.get("config")?.get("bin-dir")?.as_str()?.trim();
     if bin_dir.is_empty() {
         None

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -68,6 +68,12 @@ pub fn strip_leading_bom(input: &str) -> &str {
     s
 }
 
+/// BOM-tolerant `serde_json::from_str`. Prefer this over `serde_json::from_str`
+/// anywhere the JSON may have been written by a human, an editor, or another tool.
+pub fn from_json_str<'a, T: serde::Deserialize<'a>>(s: &'a str) -> serde_json::Result<T> {
+    serde_json::from_str(strip_leading_bom(s))
+}
+
 /// Executes a command and returns cleaned stdout/stderr.
 ///
 /// # Arguments
@@ -418,7 +424,7 @@ fn composer_bin_dirs_from(env_bin_dir: Option<&str>, composer_json: Option<&str>
 }
 
 fn read_composer_bin_dir(composer_json: &str) -> Option<PathBuf> {
-    let parsed: Value = serde_json::from_str(strip_leading_bom(composer_json)).ok()?;
+    let parsed: Value = from_json_str(composer_json).ok()?;
     let bin_dir = parsed.get("config")?.get("bin-dir")?.as_str()?.trim();
     if bin_dir.is_empty() {
         None
@@ -485,6 +491,30 @@ mod tests {
         assert_eq!(strip_leading_bom("\u{feff}\u{feff}\u{feff}hello"), "hello");
         // BOM in the middle is preserved (not "leading").
         assert_eq!(strip_leading_bom("a\u{feff}b"), "a\u{feff}b");
+    }
+
+    #[test]
+    fn test_from_json_str_strips_bom() {
+        let v: Value = from_json_str("\u{feff}{\"foo\": 1}").unwrap();
+        assert_eq!(v["foo"], 1);
+    }
+
+    #[test]
+    fn test_from_json_str_no_bom() {
+        let v: Value = from_json_str("{\"foo\": 1}").unwrap();
+        assert_eq!(v["foo"], 1);
+    }
+
+    #[test]
+    fn test_from_json_str_borrowed_type() {
+        // Deserialize<'a> (not DeserializeOwned) must keep zero-copy
+        // borrowing working through the wrapper.
+        #[derive(serde::Deserialize)]
+        struct Borrowed<'a> {
+            name: &'a str,
+        }
+        let b: Borrowed = from_json_str("\u{feff}{\"name\": \"rtk\"}").unwrap();
+        assert_eq!(b.name, "rtk");
     }
 
     #[test]

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -55,6 +55,19 @@ pub fn strip_ansi(text: &str) -> String {
     ANSI_RE.replace_all(text, "").to_string()
 }
 
+/// Strip one or more leading UTF-8 BOMs (`EF BB BF`, sometimes doubled),
+/// which serde_json refuses to parse. Windows editors (Notepad, PowerShell
+/// 5.1 `Out-File -Encoding utf8`) prepend one to hand-edited config files,
+/// and Cursor on Windows ships hook payloads with them. Strip defensively
+/// wherever RTK parses JSON a human or another tool may have written.
+pub fn strip_leading_bom(input: &str) -> &str {
+    let mut s = input;
+    while let Some(rest) = s.strip_prefix('\u{feff}') {
+        s = rest;
+    }
+    s
+}
+
 /// Executes a command and returns cleaned stdout/stderr.
 ///
 /// # Arguments
@@ -460,6 +473,19 @@ pub fn human_bytes(bytes: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_strip_leading_bom_helper() {
+        // Direct unit test on the helper so future refactors can't
+        // regress the loop semantics without a clear failure signal.
+        assert_eq!(strip_leading_bom(""), "");
+        assert_eq!(strip_leading_bom("hello"), "hello");
+        assert_eq!(strip_leading_bom("\u{feff}hello"), "hello");
+        assert_eq!(strip_leading_bom("\u{feff}\u{feff}hello"), "hello");
+        assert_eq!(strip_leading_bom("\u{feff}\u{feff}\u{feff}hello"), "hello");
+        // BOM in the middle is preserved (not "leading").
+        assert_eq!(strip_leading_bom("a\u{feff}b"), "a\u{feff}b");
+    }
 
     #[test]
     fn test_truncate_short_string() {

--- a/src/hooks/hook_check.rs
+++ b/src/hooks/hook_check.rs
@@ -4,7 +4,7 @@ use super::constants::{HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTIN
 use super::init::resolve_claude_dir;
 use super::is_claude_hook_command;
 use crate::core::constants::RTK_DATA_DIR;
-use crate::core::utils::strip_leading_bom;
+use crate::core::utils::from_json_str;
 use std::path::PathBuf;
 
 const CURRENT_HOOK_VERSION: u8 = 3;
@@ -65,7 +65,7 @@ fn binary_hook_registered(claude_dir: &std::path::Path) -> bool {
         Ok(c) if !c.trim().is_empty() => c,
         _ => return false,
     };
-    let root: serde_json::Value = match serde_json::from_str(strip_leading_bom(&content)) {
+    let root: serde_json::Value = match from_json_str(&content) {
         Ok(v) => v,
         Err(_) => return false,
     };

--- a/src/hooks/hook_check.rs
+++ b/src/hooks/hook_check.rs
@@ -4,6 +4,7 @@ use super::constants::{HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTIN
 use super::init::resolve_claude_dir;
 use super::is_claude_hook_command;
 use crate::core::constants::RTK_DATA_DIR;
+use crate::core::utils::strip_leading_bom;
 use std::path::PathBuf;
 
 const CURRENT_HOOK_VERSION: u8 = 3;
@@ -64,7 +65,7 @@ fn binary_hook_registered(claude_dir: &std::path::Path) -> bool {
         Ok(c) if !c.trim().is_empty() => c,
         _ => return false,
     };
-    let root: serde_json::Value = match serde_json::from_str(&content) {
+    let root: serde_json::Value = match serde_json::from_str(strip_leading_bom(&content)) {
         Ok(v) => v,
         Err(_) => return false,
     };

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -9,6 +9,7 @@ use anyhow::{Context, Result};
 use serde_json::{json, Value};
 use std::io::{self, Read, Write};
 
+use crate::core::utils::strip_leading_bom;
 use crate::discover::registry::{has_heredoc, rewrite_command};
 
 const STDIN_CAP: usize = 1_048_576; // 1 MiB
@@ -439,18 +440,6 @@ fn run_claude_inner(input: &str) -> Option<String> {
 }
 
 // ── Cursor native hook ─────────────────────────────────────────
-
-/// Cursor on Windows ships hook payloads with one or more leading
-/// UTF-8 BOMs (`EF BB BF`, sometimes doubled), which serde_json
-/// refuses to parse. Strip them defensively so the rewrite path keeps
-/// working instead of silently returning `{}`.
-fn strip_leading_bom(input: &str) -> &str {
-    let mut s = input;
-    while let Some(rest) = s.strip_prefix('\u{feff}') {
-        s = rest;
-    }
-    s
-}
 
 /// Run the Cursor Agent hook natively.
 pub fn run_cursor() -> Result<()> {
@@ -1283,19 +1272,6 @@ mod tests {
         assert_eq!(v["continue"], true);
         assert_eq!(v["permission"], "allow");
         assert_eq!(v["updated_input"]["command"], "rtk git status");
-    }
-
-    #[test]
-    fn test_strip_leading_bom_helper() {
-        // Direct unit test on the helper so future refactors can't
-        // regress the loop semantics without a clear failure signal.
-        assert_eq!(strip_leading_bom(""), "");
-        assert_eq!(strip_leading_bom("hello"), "hello");
-        assert_eq!(strip_leading_bom("\u{feff}hello"), "hello");
-        assert_eq!(strip_leading_bom("\u{feff}\u{feff}hello"), "hello");
-        assert_eq!(strip_leading_bom("\u{feff}\u{feff}\u{feff}hello"), "hello");
-        // BOM in the middle is preserved (not "leading").
-        assert_eq!(strip_leading_bom("a\u{feff}b"), "a\u{feff}b");
     }
 
     // --- Audit logging ---

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -7,6 +7,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 
+use crate::core::utils::strip_leading_bom;
 use crate::hooks::constants::{
     CONFIG_DIR, COPILOT_HOME_ENV, COPILOT_HOOK_FILE, COPILOT_INSTRUCTIONS_FILE, COPILOT_USER_DIR,
     CURSOR_DIR, GEMINI_DIR, GITHUB_DIR, OPENCODE_PLUGIN_FILE, OPENCODE_SUBDIR, PLUGIN_SUBDIR,
@@ -595,12 +596,13 @@ fn remove_hook_from_settings(ctx: InitContext) -> Result<bool> {
 
     let content = fs::read_to_string(&settings_path)
         .with_context(|| format!("Failed to read {}", settings_path.display()))?;
+    let content = strip_leading_bom(&content);
 
     if content.trim().is_empty() {
         return Ok(false);
     }
 
-    let mut root: serde_json::Value = serde_json::from_str(&content)
+    let mut root: serde_json::Value = serde_json::from_str(content)
         .with_context(|| format!("Failed to parse {} as JSON", settings_path.display()))?;
 
     let removed = remove_hook_from_json(&mut root);
@@ -965,11 +967,12 @@ fn patch_settings_json_command(
     let mut root = if settings_path.exists() {
         let content = fs::read_to_string(&settings_path)
             .with_context(|| format!("Failed to read {}", settings_path.display()))?;
+        let content = strip_leading_bom(&content);
 
         if content.trim().is_empty() {
             serde_json::json!({})
         } else {
-            serde_json::from_str(&content)
+            serde_json::from_str(content)
                 .with_context(|| format!("Failed to parse {} as JSON", settings_path.display()))?
         }
     } else {
@@ -1303,11 +1306,12 @@ fn remove_legacy_settings_entries(ctx: InitContext) -> Result<()> {
 
     let content = fs::read_to_string(&settings_path)
         .with_context(|| format!("Failed to read {}", settings_path.display()))?;
+    let content = strip_leading_bom(&content);
     if content.trim().is_empty() {
         return Ok(());
     }
 
-    let mut root: serde_json::Value = serde_json::from_str(&content)
+    let mut root: serde_json::Value = serde_json::from_str(content)
         .with_context(|| format!("Failed to parse {}", settings_path.display()))?;
 
     if !remove_legacy_hook_entries_from_json(&mut root) {
@@ -2957,10 +2961,11 @@ fn read_droid_json(path: &Path) -> Result<Option<serde_json::Value>> {
     }
     let content =
         fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    let content = strip_leading_bom(&content);
     if content.trim().is_empty() {
         return Ok(Some(serde_json::json!({})));
     }
-    serde_json::from_str(&content)
+    serde_json::from_str(content)
         .map(Some)
         .with_context(|| format!("Failed to parse {} as JSON", path.display()))
 }
@@ -3621,10 +3626,11 @@ fn patch_cursor_hooks_json(path: &Path, ctx: InitContext) -> Result<bool> {
     let mut root = if path.exists() {
         let content = fs::read_to_string(path)
             .with_context(|| format!("Failed to read {}", path.display()))?;
+        let content = strip_leading_bom(&content);
         if content.trim().is_empty() {
             serde_json::json!({ "version": 1 })
         } else {
-            serde_json::from_str(&content)
+            serde_json::from_str(content)
                 .with_context(|| format!("Failed to parse {} as JSON", path.display()))?
         }
     } else {
@@ -3732,11 +3738,12 @@ fn remove_legacy_cursor_hooks_json_entries(path: &Path, ctx: InitContext) -> Res
 
     let content =
         fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    let content = strip_leading_bom(&content);
     if content.trim().is_empty() {
         return Ok(());
     }
 
-    let mut root: serde_json::Value = serde_json::from_str(&content)
+    let mut root: serde_json::Value = serde_json::from_str(content)
         .with_context(|| format!("Failed to parse {}", path.display()))?;
 
     if !remove_legacy_cursor_hook_entries_from_json(&mut root) {
@@ -3813,9 +3820,10 @@ fn remove_cursor_hooks(ctx: InitContext) -> Result<Vec<String>> {
     if hooks_json_path.exists() {
         let content = fs::read_to_string(&hooks_json_path)
             .with_context(|| format!("Failed to read {}", hooks_json_path.display()))?;
+        let content = strip_leading_bom(&content);
 
         if !content.trim().is_empty() {
-            if let Ok(mut root) = serde_json::from_str::<serde_json::Value>(&content) {
+            if let Ok(mut root) = serde_json::from_str::<serde_json::Value>(content) {
                 if remove_cursor_hook_from_json(&mut root) {
                     if dry_run {
                         println!(
@@ -3889,7 +3897,7 @@ fn show_claude_config() -> Result<()> {
     let settings_path = claude_dir.join(SETTINGS_JSON);
     let binary_hook_registered = if settings_path.exists() {
         let content = fs::read_to_string(&settings_path).unwrap_or_default();
-        if let Ok(root) = serde_json::from_str::<serde_json::Value>(&content) {
+        if let Ok(root) = serde_json::from_str::<serde_json::Value>(strip_leading_bom(&content)) {
             hook_already_present(&root, CLAUDE_HOOK_COMMAND)
         } else {
             false
@@ -4009,8 +4017,9 @@ fn show_claude_config() -> Result<()> {
     // Check settings.json (detailed status)
     if settings_path.exists() {
         let content = fs::read_to_string(&settings_path)?;
+        let content = strip_leading_bom(&content);
         if !content.trim().is_empty() {
-            if let Ok(root) = serde_json::from_str::<serde_json::Value>(&content) {
+            if let Ok(root) = serde_json::from_str::<serde_json::Value>(content) {
                 if hook_already_present(&root, CLAUDE_HOOK_COMMAND) {
                     println!("[ok] settings.json: RTK hook configured");
                 } else {
@@ -4047,7 +4056,8 @@ fn show_claude_config() -> Result<()> {
         // Check for binary command in hooks.json first
         let cursor_binary_registered = if cursor_hooks_json.exists() {
             let content = fs::read_to_string(&cursor_hooks_json).unwrap_or_default();
-            if let Ok(root) = serde_json::from_str::<serde_json::Value>(&content) {
+            if let Ok(root) = serde_json::from_str::<serde_json::Value>(strip_leading_bom(&content))
+            {
                 cursor_hook_already_present(&root)
             } else {
                 false
@@ -4269,7 +4279,7 @@ fn patch_gemini_settings(
     let mut settings: serde_json::Value = if settings_path.exists() {
         let content = fs::read_to_string(&settings_path)
             .with_context(|| format!("Failed to read {}", settings_path.display()))?;
-        serde_json::from_str(&content).unwrap_or(serde_json::json!({}))
+        serde_json::from_str(strip_leading_bom(&content)).unwrap_or(serde_json::json!({}))
     } else {
         serde_json::json!({})
     };
@@ -4411,7 +4421,9 @@ fn uninstall_gemini(ctx: InitContext) -> Result<Vec<String>> {
     let settings_path = gemini_dir.join(SETTINGS_JSON);
     if settings_path.exists() {
         let content = fs::read_to_string(&settings_path)?;
-        if let Ok(mut settings) = serde_json::from_str::<serde_json::Value>(&content) {
+        if let Ok(mut settings) =
+            serde_json::from_str::<serde_json::Value>(strip_leading_bom(&content))
+        {
             let bt_pointer = format!("/hooks/{}", BEFORE_TOOL_KEY);
             if let Some(arr) = settings
                 .pointer_mut(&bt_pointer)
@@ -6873,6 +6885,59 @@ mod tests {
             assert!(
                 content.contains(CLAUDE_HOOK_COMMAND),
                 "settings.json must contain hook command"
+            );
+        });
+    }
+
+    #[test]
+    fn test_patch_settings_json_tolerates_utf8_bom() {
+        let tmp = TempDir::new().unwrap();
+        with_claude_dir_override(&tmp, |claude_dir| {
+            // Notepad and PowerShell 5.1 `Out-File -Encoding utf8` prepend a BOM.
+            let settings = claude_dir.join(SETTINGS_JSON);
+            fs::write(&settings, "\u{feff}{\"foo\": 1}").unwrap();
+
+            let result = patch_settings_json_command(
+                CLAUDE_HOOK_COMMAND,
+                PatchMode::Auto,
+                false,
+                InitContext::default(),
+            );
+            assert!(
+                result.is_ok(),
+                "BOM-prefixed settings.json must not abort init: {:?}",
+                result.err()
+            );
+
+            let content = fs::read_to_string(&settings).unwrap();
+            let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+            assert_eq!(v["foo"], 1, "existing keys must survive the patch");
+            assert!(
+                content.contains(CLAUDE_HOOK_COMMAND),
+                "hook must be installed"
+            );
+        });
+    }
+
+    #[test]
+    fn test_patch_settings_json_bom_only_file() {
+        // U+FEFF is not whitespace, so the `content.trim().is_empty()`
+        // empty-file guard does not catch a BOM-only file.
+        let tmp = TempDir::new().unwrap();
+        with_claude_dir_override(&tmp, |claude_dir| {
+            let settings = claude_dir.join(SETTINGS_JSON);
+            fs::write(&settings, "\u{feff}").unwrap();
+
+            let result = patch_settings_json_command(
+                CLAUDE_HOOK_COMMAND,
+                PatchMode::Auto,
+                false,
+                InitContext::default(),
+            );
+            assert!(
+                result.is_ok(),
+                "BOM-only settings.json must be treated as empty: {:?}",
+                result.err()
             );
         });
     }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -6920,6 +6920,30 @@ mod tests {
     }
 
     #[test]
+    fn test_patch_settings_json_bom_plus_invalid_json_still_errors() {
+        // Stripping the BOM must not mask genuinely broken JSON: the
+        // parse-error context has to survive so the user gets blamed for
+        // the right thing.
+        let tmp = TempDir::new().unwrap();
+        with_claude_dir_override(&tmp, |claude_dir| {
+            let settings = claude_dir.join(SETTINGS_JSON);
+            fs::write(&settings, "\u{feff}{not valid json").unwrap();
+
+            let result = patch_settings_json_command(
+                CLAUDE_HOOK_COMMAND,
+                PatchMode::Auto,
+                false,
+                InitContext::default(),
+            );
+            let err = result.expect_err("invalid JSON must still fail");
+            assert!(
+                err.to_string().contains("Failed to parse"),
+                "error must carry the parse context, got: {err:#}"
+            );
+        });
+    }
+
+    #[test]
     fn test_patch_settings_json_bom_only_file() {
         // U+FEFF is not whitespace, so the `content.trim().is_empty()`
         // empty-file guard does not catch a BOM-only file.

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -7,7 +7,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 
-use crate::core::utils::strip_leading_bom;
+use crate::core::utils::{from_json_str, strip_leading_bom};
 use crate::hooks::constants::{
     CONFIG_DIR, COPILOT_HOME_ENV, COPILOT_HOOK_FILE, COPILOT_INSTRUCTIONS_FILE, COPILOT_USER_DIR,
     CURSOR_DIR, GEMINI_DIR, GITHUB_DIR, OPENCODE_PLUGIN_FILE, OPENCODE_SUBDIR, PLUGIN_SUBDIR,
@@ -602,7 +602,7 @@ fn remove_hook_from_settings(ctx: InitContext) -> Result<bool> {
         return Ok(false);
     }
 
-    let mut root: serde_json::Value = serde_json::from_str(content)
+    let mut root: serde_json::Value = from_json_str(content)
         .with_context(|| format!("Failed to parse {} as JSON", settings_path.display()))?;
 
     let removed = remove_hook_from_json(&mut root);
@@ -972,7 +972,7 @@ fn patch_settings_json_command(
         if content.trim().is_empty() {
             serde_json::json!({})
         } else {
-            serde_json::from_str(content)
+            from_json_str(content)
                 .with_context(|| format!("Failed to parse {} as JSON", settings_path.display()))?
         }
     } else {
@@ -1311,7 +1311,7 @@ fn remove_legacy_settings_entries(ctx: InitContext) -> Result<()> {
         return Ok(());
     }
 
-    let mut root: serde_json::Value = serde_json::from_str(content)
+    let mut root: serde_json::Value = from_json_str(content)
         .with_context(|| format!("Failed to parse {}", settings_path.display()))?;
 
     if !remove_legacy_hook_entries_from_json(&mut root) {
@@ -2965,7 +2965,7 @@ fn read_droid_json(path: &Path) -> Result<Option<serde_json::Value>> {
     if content.trim().is_empty() {
         return Ok(Some(serde_json::json!({})));
     }
-    serde_json::from_str(content)
+    from_json_str(content)
         .map(Some)
         .with_context(|| format!("Failed to parse {} as JSON", path.display()))
 }
@@ -3630,7 +3630,7 @@ fn patch_cursor_hooks_json(path: &Path, ctx: InitContext) -> Result<bool> {
         if content.trim().is_empty() {
             serde_json::json!({ "version": 1 })
         } else {
-            serde_json::from_str(content)
+            from_json_str(content)
                 .with_context(|| format!("Failed to parse {} as JSON", path.display()))?
         }
     } else {
@@ -3743,8 +3743,8 @@ fn remove_legacy_cursor_hooks_json_entries(path: &Path, ctx: InitContext) -> Res
         return Ok(());
     }
 
-    let mut root: serde_json::Value = serde_json::from_str(content)
-        .with_context(|| format!("Failed to parse {}", path.display()))?;
+    let mut root: serde_json::Value =
+        from_json_str(content).with_context(|| format!("Failed to parse {}", path.display()))?;
 
     if !remove_legacy_cursor_hook_entries_from_json(&mut root) {
         return Ok(());
@@ -3823,7 +3823,7 @@ fn remove_cursor_hooks(ctx: InitContext) -> Result<Vec<String>> {
         let content = strip_leading_bom(&content);
 
         if !content.trim().is_empty() {
-            if let Ok(mut root) = serde_json::from_str::<serde_json::Value>(content) {
+            if let Ok(mut root) = from_json_str::<serde_json::Value>(content) {
                 if remove_cursor_hook_from_json(&mut root) {
                     if dry_run {
                         println!(
@@ -3897,7 +3897,7 @@ fn show_claude_config() -> Result<()> {
     let settings_path = claude_dir.join(SETTINGS_JSON);
     let binary_hook_registered = if settings_path.exists() {
         let content = fs::read_to_string(&settings_path).unwrap_or_default();
-        if let Ok(root) = serde_json::from_str::<serde_json::Value>(strip_leading_bom(&content)) {
+        if let Ok(root) = from_json_str::<serde_json::Value>(&content) {
             hook_already_present(&root, CLAUDE_HOOK_COMMAND)
         } else {
             false
@@ -4019,7 +4019,7 @@ fn show_claude_config() -> Result<()> {
         let content = fs::read_to_string(&settings_path)?;
         let content = strip_leading_bom(&content);
         if !content.trim().is_empty() {
-            if let Ok(root) = serde_json::from_str::<serde_json::Value>(content) {
+            if let Ok(root) = from_json_str::<serde_json::Value>(content) {
                 if hook_already_present(&root, CLAUDE_HOOK_COMMAND) {
                     println!("[ok] settings.json: RTK hook configured");
                 } else {
@@ -4056,8 +4056,7 @@ fn show_claude_config() -> Result<()> {
         // Check for binary command in hooks.json first
         let cursor_binary_registered = if cursor_hooks_json.exists() {
             let content = fs::read_to_string(&cursor_hooks_json).unwrap_or_default();
-            if let Ok(root) = serde_json::from_str::<serde_json::Value>(strip_leading_bom(&content))
-            {
+            if let Ok(root) = from_json_str::<serde_json::Value>(&content) {
                 cursor_hook_already_present(&root)
             } else {
                 false
@@ -4279,7 +4278,14 @@ fn patch_gemini_settings(
     let mut settings: serde_json::Value = if settings_path.exists() {
         let content = fs::read_to_string(&settings_path)
             .with_context(|| format!("Failed to read {}", settings_path.display()))?;
-        serde_json::from_str(strip_leading_bom(&content)).unwrap_or(serde_json::json!({}))
+        let content = strip_leading_bom(&content);
+
+        if content.trim().is_empty() {
+            serde_json::json!({})
+        } else {
+            from_json_str(content)
+                .with_context(|| format!("Failed to parse {} as JSON", settings_path.display()))?
+        }
     } else {
         serde_json::json!({})
     };
@@ -4421,9 +4427,7 @@ fn uninstall_gemini(ctx: InitContext) -> Result<Vec<String>> {
     let settings_path = gemini_dir.join(SETTINGS_JSON);
     if settings_path.exists() {
         let content = fs::read_to_string(&settings_path)?;
-        if let Ok(mut settings) =
-            serde_json::from_str::<serde_json::Value>(strip_leading_bom(&content))
-        {
+        if let Ok(mut settings) = from_json_str::<serde_json::Value>(&content) {
             let bt_pointer = format!("/hooks/{}", BEFORE_TOOL_KEY);
             if let Some(arr) = settings
                 .pointer_mut(&bt_pointer)
@@ -6964,6 +6968,38 @@ mod tests {
                 result.err()
             );
         });
+    }
+
+    #[test]
+    fn test_patch_gemini_settings_malformed_json_errors_without_overwriting() {
+        // A parse failure (not a BOM) must propagate as an error, not get
+        // swallowed into an empty object that then overwrites the user's
+        // existing settings on write-back.
+        let tmp = TempDir::new().unwrap();
+        let gemini_dir = tmp.path().join(".gemini");
+        fs::create_dir_all(&gemini_dir).unwrap();
+        let settings_path = gemini_dir.join(SETTINGS_JSON);
+        let original = "{\"model\": \"foo\", \"mcpServers\": {},"; // trailing comma
+        fs::write(&settings_path, original).unwrap();
+
+        let result = patch_gemini_settings(
+            &gemini_dir,
+            Path::new("/fake/hook/path"),
+            PatchMode::Auto,
+            InitContext::default(),
+        );
+
+        let err = result.expect_err("malformed JSON must fail, not silently reset");
+        assert!(
+            err.to_string().contains("Failed to parse"),
+            "error must carry the parse context, got: {err:#}"
+        );
+
+        let content = fs::read_to_string(&settings_path).unwrap();
+        assert_eq!(
+            content, original,
+            "settings.json must not be overwritten when parsing fails"
+        );
     }
 
     #[test]

--- a/src/hooks/integrity.rs
+++ b/src/hooks/integrity.rs
@@ -323,6 +323,7 @@ pub fn runtime_check() -> Result<()> {
 }
 
 fn settings_has_claude_hook(content: &str) -> bool {
+    let content = crate::core::utils::strip_leading_bom(content);
     let Ok(root) = serde_json::from_str::<serde_json::Value>(content) else {
         return false;
     };

--- a/src/hooks/integrity.rs
+++ b/src/hooks/integrity.rs
@@ -323,8 +323,7 @@ pub fn runtime_check() -> Result<()> {
 }
 
 fn settings_has_claude_hook(content: &str) -> bool {
-    let content = crate::core::utils::strip_leading_bom(content);
-    let Ok(root) = serde_json::from_str::<serde_json::Value>(content) else {
+    let Ok(root) = crate::core::utils::from_json_str::<serde_json::Value>(content) else {
         return false;
     };
 

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -137,7 +137,9 @@ fn load_permission_rules() -> (Vec<String>, Vec<String>, Vec<String>) {
         let Ok(content) = std::fs::read_to_string(&path) else {
             continue;
         };
-        let Ok(json) = serde_json::from_str::<Value>(&content) else {
+        let Ok(json) =
+            serde_json::from_str::<Value>(crate::core::utils::strip_leading_bom(&content))
+        else {
             eprintln!(
                 "[rtk] warning: failed to parse permissions from {}",
                 path.display()
@@ -190,7 +192,7 @@ fn get_settings_paths() -> Vec<PathBuf> {
 
 fn read_json(path: &std::path::Path) -> Option<Value> {
     let content = std::fs::read_to_string(path).ok()?;
-    match serde_json::from_str::<Value>(&content) {
+    match serde_json::from_str::<Value>(crate::core::utils::strip_leading_bom(&content)) {
         Ok(v) => Some(v),
         Err(_) => {
             eprintln!(

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -137,9 +137,7 @@ fn load_permission_rules() -> (Vec<String>, Vec<String>, Vec<String>) {
         let Ok(content) = std::fs::read_to_string(&path) else {
             continue;
         };
-        let Ok(json) =
-            serde_json::from_str::<Value>(crate::core::utils::strip_leading_bom(&content))
-        else {
+        let Ok(json) = crate::core::utils::from_json_str::<Value>(&content) else {
             eprintln!(
                 "[rtk] warning: failed to parse permissions from {}",
                 path.display()
@@ -192,7 +190,7 @@ fn get_settings_paths() -> Vec<PathBuf> {
 
 fn read_json(path: &std::path::Path) -> Option<Value> {
     let content = std::fs::read_to_string(path).ok()?;
-    match serde_json::from_str::<Value>(crate::core::utils::strip_leading_bom(&content)) {
+    match crate::core::utils::from_json_str::<Value>(&content) {
         Ok(v) => Some(v),
         Err(_) => {
             eprintln!(


### PR DESCRIPTION
## Bug

`rtk init -g --auto-patch` aborts with exit 1 on a `settings.json` that begins with a UTF-8 BOM:

```
rtk: Failed to parse C:\...\settings.json as JSON: expected value at line 1 column 1
```

Notepad and PowerShell 5.1's `Out-File -Encoding utf8` / `>` both write a BOM by default, so any Windows user who hand-edits `~/.claude/settings.json` loses RTK hook installation — with an error that blames their (valid) JSON. Two aggravating details:

- init prints "RTK hook registered (global)" *before* failing, so the output claims success while the hook is absent.
- The statusline patch path (`serde_json::from_str(&content).unwrap_or(json!({}))` in `init.rs`) swallows the parse failure and silently **wipes existing settings** on write-back.
- `permissions.rs` silently drops the user's deny/ask/allow rules, and `hook_check.rs` misreports the hook as not installed.

## Repro

```powershell
$sandbox = Join-Path $env:TEMP "rtk-bom"; New-Item -ItemType Directory -Force $sandbox | Out-Null
$env:CLAUDE_CONFIG_DIR = $sandbox
$json = '{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"echo hi"}]}]}}'
[System.IO.File]::WriteAllText((Join-Path $sandbox "settings.json"), $json, (New-Object System.Text.UTF8Encoding($true)))
rtk init -g --auto-patch   # before: EXIT=1, hook not installed; after: EXIT=0, hook added, echo-hi entry preserved
```

Verified before/after with real binaries on Windows 11.

## Fix

Reuse, not new code: `strip_leading_bom` already exists in `hook_cmd.rs`, guarding the hook **stdin** entry points (Cursor on Windows ships BOM-prefixed payloads). The file-read paths never got the same treatment. This PR:

- Promotes the helper to `src/core/utils.rs` (`pub`), moves its unit test along; stdin behavior unchanged (existing BOM stdin tests still pass).
- Applies it at every site that parses JSON a human may have hand-edited: 12 `settings.json`/`hooks.json` sites in `init.rs`, `hook_check.rs`, `integrity.rs`, `permissions.rs` (×2), plus `composer.json` (`core/utils.rs`) and `global.json` (`dotnet_cmd.rs`).

Deliberately untouched:
- **TOML sites** (`config.rs`, filter DSL): the `toml` crate tolerates a leading BOM natively — pinned by a new regression test so a crate upgrade can't silently regress it.
- **BOM on write-back is dropped**: RFC 8259 §8.1 forbids adding a BOM to JSON.

## Tests

- `test_patch_settings_json_tolerates_utf8_bom` — BOM + valid JSON: init succeeds, existing keys survive (written red-first; failed with the exact repro error)
- `test_patch_settings_json_bom_only_file` — U+FEFF is not whitespace, so the `trim().is_empty()` guard alone misses a BOM-only file
- `test_patch_settings_json_bom_plus_invalid_json_still_errors` — stripping must not mask genuinely broken JSON
- `test_toml_parse_tolerates_utf8_bom` — pins the toml crate behavior
- `test_strip_leading_bom_helper` — moved with the helper (empty, single/double/triple BOM, mid-string BOM preserved)

## Quality gate

On this branch (off `develop`), Windows x86_64-pc-windows-msvc:

```
cargo fmt --all            → clean
cargo clippy --all-targets → zero warnings
cargo test --all           → 2493 passed, 0 failed (8 ignored)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
