### PR TITLE
fix(discover): log real hook decisions instead of guessing coverage retroactively

### DIFF
--- a/src/analytics/session_cmd.rs
+++ b/src/analytics/session_cmd.rs
@@ -1,6 +1,7 @@
 //! Compares RTK-routed vs raw commands in a coding session.
 
 use crate::core::utils::format_tokens;
+use crate::discover::is_already_rtk;
 use crate::discover::provider::{ClaudeProvider, ExtractedCommand, SessionProvider};
 use crate::discover::registry::{classify_command, split_command_chain, Classification};
 use anyhow::{Context, Result};
@@ -27,7 +28,9 @@ impl SessionSummary {
 
 /// Count RTK-covered commands from extracted commands.
 /// A command is "covered" if it either:
-/// - starts with "rtk " (explicit rtk invocation), or
+/// - is an explicit rtk invocation, excluding `rtk proxy` (see `is_already_rtk` —
+///   proxy deliberately runs the raw command unfiltered, so it must not count as
+///   adopted usage), or
 /// - would be rewritten by the hook (classify_command returns Supported)
 ///
 /// Chained commands (e.g. "cd ./path && rtk ls") are split so each part
@@ -39,7 +42,7 @@ fn count_rtk_commands(cmds: &[ExtractedCommand]) -> (usize, usize, usize) {
         let parts = split_command_chain(&c.command);
         for part in &parts {
             total += 1;
-            if part.starts_with("rtk ")
+            if is_already_rtk(part)
                 || matches!(classify_command(part), Classification::Supported { .. })
             {
                 rtk += 1;
@@ -271,6 +274,20 @@ mod tests {
         let (total, rtk, _) = count_rtk_commands(&cmds);
         assert_eq!(total, 3);
         assert_eq!(rtk, 0);
+    }
+
+    #[test]
+    fn test_count_rtk_proxy_not_counted_as_adopted() {
+        // `rtk proxy <cmd>` deliberately runs the raw command unfiltered — it must
+        // not count as adopted rtk usage, or the session report would flatter
+        // itself via its own escape hatch (mirrors discover::is_already_rtk).
+        let cmds = vec![
+            make_cmd("rtk proxy git log -20", Some(2000)),
+            make_cmd("rtk git status", Some(200)),
+        ];
+        let (total, rtk, _) = count_rtk_commands(&cmds);
+        assert_eq!(total, 2);
+        assert_eq!(rtk, 1, "only the explicit non-proxy rtk invocation counts");
     }
 
     #[test]

--- a/src/analytics/session_cmd.rs
+++ b/src/analytics/session_cmd.rs
@@ -200,6 +200,7 @@ mod tests {
             command: command.to_string(),
             output_len,
             session_id: "test".to_string(),
+            tool_use_id: "toolu_test".to_string(),
             output_content: None,
             is_error: false,
             sequence_index: 0,

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -150,6 +150,17 @@ pub fn limits() -> LimitsConfig {
     Config::load().map(|c| c.limits).unwrap_or_default()
 }
 
+/// Get `(exclude_commands, transparent_prefixes)` for hook-rewrite decisions.
+/// Falls back to empty (no exclusions/prefixes) if config can't be loaded.
+/// Shared by every place that decides whether/how to rewrite a command
+/// (`hooks::hook_cmd`, `hooks::rewrite_cmd`, `discover`, `rtk rewrite`'s CLI
+/// entry point in `main.rs`) so they can't drift from each other.
+pub fn hook_rewrite_params() -> (Vec<String>, Vec<String>) {
+    Config::load()
+        .map(|c| (c.hooks.exclude_commands, c.hooks.transparent_prefixes))
+        .unwrap_or_default()
+}
+
 impl Config {
     pub fn load() -> Result<Self> {
         let path = get_config_path()?;

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -155,10 +155,33 @@ pub fn limits() -> LimitsConfig {
 /// Shared by every place that decides whether/how to rewrite a command
 /// (`hooks::hook_cmd`, `hooks::rewrite_cmd`, `discover`, `rtk rewrite`'s CLI
 /// entry point in `main.rs`) so they can't drift from each other.
+///
+/// Reads the process-wide cached config (see `cached_config`), not a fresh
+/// `Config::load()`: this is on the PreToolUse hook's hot path, and
+/// `tracking::get_db_path` (called via `Tracker::new()` for `hook_decisions`
+/// logging, right after this in the same hook invocation) also reads config —
+/// without caching, that's two full disk-read-plus-TOML-parse round trips per
+/// single Bash tool call instead of one.
 pub fn hook_rewrite_params() -> (Vec<String>, Vec<String>) {
-    Config::load()
-        .map(|c| (c.hooks.exclude_commands, c.hooks.transparent_prefixes))
-        .unwrap_or_default()
+    let c = cached_config();
+    (
+        c.hooks.exclude_commands.clone(),
+        c.hooks.transparent_prefixes.clone(),
+    )
+}
+
+/// Process-wide cached `Config::load()` result, populated on first use.
+///
+/// Safe for read-only callers on hot paths that may load config multiple times
+/// within a single `rtk` invocation (a `rtk` process is short-lived and exits
+/// after one subcommand, so there's no cross-invocation staleness to worry
+/// about) — but NOT used by any path that mutates and saves config within the
+/// same process run (e.g. `hooks::init::save_telemetry_consent`'s load-mutate-save),
+/// since those must always observe a fresh read. Only reach for this from a
+/// caller that never itself writes config.toml.
+pub(crate) fn cached_config() -> &'static Config {
+    static CACHE: std::sync::OnceLock<Config> = std::sync::OnceLock::new();
+    CACHE.get_or_init(|| Config::load().unwrap_or_default())
 }
 
 impl Config {

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -33,6 +33,7 @@ use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection};
 use serde::Serialize;
+use std::collections::HashMap;
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::time::Instant;
@@ -105,6 +106,72 @@ pub struct CommandRecord {
     pub saved_tokens: usize,
     /// Savings percentage ((saved / input) * 100)
     pub savings_pct: f64,
+}
+
+/// The real outcome a PreToolUse hook reached for one Bash call.
+///
+/// Shared by both ends of the `hook_decisions` log: `hooks::hook_cmd` writes it at
+/// the moment the hook actually runs, and `discover` reads it back to know whether
+/// a historical command was truly covered. `Display`/`FromStr` are the only
+/// string boundary — everywhere else this stays a typed enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookOutcome {
+    /// Rewritten and auto-allowed.
+    Allow,
+    /// Rewritten, but Claude Code still prompts the user.
+    Ask,
+    /// A deny rule matched — the hook never rewrites, defers to native deny handling.
+    Deny,
+    /// An unattestable construct (substitution, etc.) — the hook defers, no rewrite.
+    Defer,
+}
+
+impl HookOutcome {
+    /// Whether this outcome means the command was actually routed through RTK.
+    pub fn is_covered(self) -> bool {
+        matches!(self, HookOutcome::Allow | HookOutcome::Ask)
+    }
+}
+
+impl std::fmt::Display for HookOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            HookOutcome::Allow => "allow",
+            HookOutcome::Ask => "ask",
+            HookOutcome::Deny => "deny",
+            HookOutcome::Defer => "defer",
+        })
+    }
+}
+
+impl std::str::FromStr for HookOutcome {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "allow" => Ok(HookOutcome::Allow),
+            "ask" => Ok(HookOutcome::Ask),
+            "deny" => Ok(HookOutcome::Deny),
+            "defer" => Ok(HookOutcome::Defer),
+            _ => Err(()),
+        }
+    }
+}
+
+/// A single PreToolUse hook decision, logged at the moment the hook actually ran.
+///
+/// Keyed by `tool_use_id` so it can be joined 1:1 against the same id Claude Code
+/// stores on the transcript's `tool_use`/`tool_result` blocks — giving `rtk discover`
+/// ground truth about historical hook coverage instead of re-deriving a guess from
+/// today's hook-install state and registry.
+///
+/// Only carries what `discover` actually consumes (the decision). The
+/// `hook_decisions` table itself also stores `timestamp`/`raw_cmd`/`rewritten_cmd`/
+/// `rtk_version` for direct inspection (`sqlite3 tracking.db`), but nothing in Rust
+/// reads those back today — add fields here if/when something does.
+#[derive(Debug, Clone, Copy)]
+pub struct HookDecisionRecord {
+    pub decision: HookOutcome,
 }
 
 /// Aggregated statistics across all recorded commands.
@@ -336,6 +403,29 @@ impl Tracker {
             [],
         )?;
 
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS hook_decisions (
+                id INTEGER PRIMARY KEY,
+                timestamp TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                tool_use_id TEXT NOT NULL,
+                project_path TEXT DEFAULT '',
+                raw_cmd TEXT NOT NULL,
+                decision TEXT NOT NULL,
+                rewritten_cmd TEXT,
+                rtk_version TEXT NOT NULL
+            )",
+            [],
+        )?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_hook_decisions_tool_use_id ON hook_decisions(tool_use_id)",
+            [],
+        )?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_hook_decisions_timestamp ON hook_decisions(timestamp)",
+            [],
+        )?;
+
         restrict_db_files(&db_path);
 
         Ok(Self { conn })
@@ -387,6 +477,28 @@ impl Tracker {
         )?;
         self.conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_pf_timestamp ON parse_failures(timestamp)",
+            [],
+        )?;
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS hook_decisions (
+                id INTEGER PRIMARY KEY,
+                timestamp TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                tool_use_id TEXT NOT NULL,
+                project_path TEXT DEFAULT '',
+                raw_cmd TEXT NOT NULL,
+                decision TEXT NOT NULL,
+                rewritten_cmd TEXT,
+                rtk_version TEXT NOT NULL
+            )",
+            [],
+        )?;
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_hook_decisions_tool_use_id ON hook_decisions(tool_use_id)",
+            [],
+        )?;
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_hook_decisions_timestamp ON hook_decisions(timestamp)",
             [],
         )?;
         Ok(())
@@ -461,16 +573,21 @@ impl Tracker {
             "DELETE FROM parse_failures WHERE timestamp < ?1",
             params![cutoff.to_rfc3339()],
         )?;
+        self.conn.execute(
+            "DELETE FROM hook_decisions WHERE timestamp < ?1",
+            params![cutoff.to_rfc3339()],
+        )?;
         Ok(())
     }
 
-    /// Delete all tracked data (commands + parse_failures), resetting all stats to zero.
+    /// Delete all tracked data (commands + parse_failures + hook_decisions), resetting all stats to zero.
     pub fn reset_all(&self) -> Result<()> {
         self.conn
             .execute_batch(
                 "BEGIN;
                  DELETE FROM commands;
                  DELETE FROM parse_failures;
+                 DELETE FROM hook_decisions;
                  COMMIT;",
             )
             .context("Failed to reset tracking database")?;
@@ -496,6 +613,88 @@ impl Tracker {
         )?;
         self.cleanup_old()?;
         Ok(())
+    }
+
+    /// Record a PreToolUse hook decision at the moment the hook actually ran.
+    ///
+    /// `decision` must be one of `"allow"`, `"ask"`, `"deny"`, `"defer"`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_hook_decision(
+        &self,
+        session_id: &str,
+        tool_use_id: &str,
+        project_path: &str,
+        raw_cmd: &str,
+        decision: HookOutcome,
+        rewritten_cmd: Option<&str>,
+        rtk_version: &str,
+    ) -> Result<()> {
+        self.conn.execute(
+            "INSERT INTO hook_decisions (timestamp, session_id, tool_use_id, project_path, raw_cmd, decision, rewritten_cmd, rtk_version)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                Utc::now().to_rfc3339(),
+                session_id,
+                tool_use_id,
+                project_path,
+                raw_cmd,
+                decision.to_string(),
+                rewritten_cmd,
+                rtk_version,
+            ],
+        )?;
+        self.cleanup_old()?;
+        Ok(())
+    }
+
+    /// Bulk-fetch every hook decision at or after `cutoff`, keyed by `tool_use_id`.
+    ///
+    /// Meant to be called once per `rtk discover` run (mirroring the existing
+    /// single `Config::load()`/`hook_status()` snapshot pattern), so per-command
+    /// lookups during the scan loop are in-memory instead of one query each.
+    pub fn hook_decisions_since(
+        &self,
+        cutoff: DateTime<Utc>,
+    ) -> Result<HashMap<String, HookDecisionRecord>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT tool_use_id, decision
+             FROM hook_decisions
+             WHERE timestamp >= ?1",
+        )?;
+        let rows = stmt
+            .query_map(params![cutoff.to_rfc3339()], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let mut out = HashMap::with_capacity(rows.len());
+        for (tool_use_id, decision) in rows {
+            // Skip rows with an unrecognized decision string (e.g. written by a
+            // future rtk version with a decision this build doesn't know) rather
+            // than failing the whole query — `discover` just falls back to its
+            // estimate heuristic for that command.
+            if let Ok(decision) = decision.parse::<HookOutcome>() {
+                out.insert(tool_use_id, HookDecisionRecord { decision });
+            }
+        }
+        Ok(out)
+    }
+
+    /// Earliest timestamp any hook decision was logged, if any exist.
+    ///
+    /// Used to tell `rtk discover` where the "measured" window starts — any scan
+    /// range before this point falls back to the estimate-based heuristic.
+    pub fn earliest_hook_decision_timestamp(&self) -> Result<Option<DateTime<Utc>>> {
+        let ts: Option<String> =
+            self.conn
+                .query_row("SELECT MIN(timestamp) FROM hook_decisions", [], |row| {
+                    row.get(0)
+                })?;
+        Ok(ts.and_then(|t| {
+            DateTime::parse_from_rfc3339(&t)
+                .ok()
+                .map(|dt| dt.with_timezone(&Utc))
+        }))
     }
 
     /// Get parse failure summary for `rtk gain --failures`.
@@ -1756,5 +1955,126 @@ mod tests {
             let mode = std::fs::metadata(p).expect("metadata").permissions().mode() & 0o777;
             assert_eq!(mode, 0o600, "expected 0600 on {}", p.display());
         }
+    }
+
+    // rtk-ai/rtk#3148: ground-truth hook-decision logging, so `discover` can join
+    // real hook outcomes back to transcript entries by `tool_use_id` instead of
+    // re-deriving a guess from today's hook/config state.
+    #[test]
+    fn test_record_and_lookup_hook_decision_by_tool_use_id() {
+        let tracker = Tracker::new_in_memory().expect("Failed to create in-memory tracker");
+
+        tracker
+            .record_hook_decision(
+                "session-1",
+                "toolu_abc123",
+                "/home/user/project",
+                "git status",
+                HookOutcome::Allow,
+                Some("rtk git status"),
+                "0.42.4",
+            )
+            .expect("Failed to record hook decision");
+
+        let cutoff = Utc::now() - chrono::Duration::days(1);
+        let log = tracker
+            .hook_decisions_since(cutoff)
+            .expect("Failed to query hook decisions");
+
+        let record = log
+            .get("toolu_abc123")
+            .expect("record not found by tool_use_id");
+        assert_eq!(record.decision, HookOutcome::Allow);
+
+        // The other columns aren't exposed on HookDecisionRecord (nothing in Rust
+        // reads them back yet), but they must still be persisted correctly for
+        // direct DB inspection.
+        let (raw_cmd, rewritten_cmd, rtk_version): (String, Option<String>, String) = tracker
+            .conn
+            .query_row(
+                "SELECT raw_cmd, rewritten_cmd, rtk_version FROM hook_decisions WHERE tool_use_id = ?1",
+                params!["toolu_abc123"],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("row not found");
+        assert_eq!(raw_cmd, "git status");
+        assert_eq!(rewritten_cmd.as_deref(), Some("rtk git status"));
+        assert_eq!(rtk_version, "0.42.4");
+    }
+
+    #[test]
+    fn test_hook_decisions_since_excludes_older_rows() {
+        let tracker = Tracker::new_in_memory().expect("Failed to create in-memory tracker");
+
+        tracker
+            .record_hook_decision(
+                "session-1",
+                "toolu_old",
+                "",
+                "git status",
+                HookOutcome::Deny,
+                None,
+                "0.42.4",
+            )
+            .expect("Failed to record hook decision");
+
+        // Cutoff in the future — the row above should not appear.
+        let cutoff = Utc::now() + chrono::Duration::days(1);
+        let log = tracker
+            .hook_decisions_since(cutoff)
+            .expect("Failed to query hook decisions");
+
+        assert!(!log.contains_key("toolu_old"));
+    }
+
+    #[test]
+    fn test_earliest_hook_decision_timestamp() {
+        let tracker = Tracker::new_in_memory().expect("Failed to create in-memory tracker");
+
+        assert!(tracker
+            .earliest_hook_decision_timestamp()
+            .expect("query failed")
+            .is_none());
+
+        tracker
+            .record_hook_decision(
+                "s",
+                "toolu_1",
+                "",
+                "ls",
+                HookOutcome::Allow,
+                Some("rtk ls"),
+                "0.42.4",
+            )
+            .expect("Failed to record hook decision");
+
+        assert!(tracker
+            .earliest_hook_decision_timestamp()
+            .expect("query failed")
+            .is_some());
+    }
+
+    #[test]
+    fn test_reset_all_clears_hook_decisions() {
+        let tracker = Tracker::new_in_memory().expect("Failed to create in-memory tracker");
+
+        tracker
+            .record_hook_decision(
+                "s",
+                "toolu_1",
+                "",
+                "ls",
+                HookOutcome::Allow,
+                Some("rtk ls"),
+                "0.42.4",
+            )
+            .expect("Failed to record hook decision");
+
+        tracker.reset_all().expect("Failed to reset");
+
+        assert!(tracker
+            .earliest_hook_decision_timestamp()
+            .expect("query failed")
+            .is_none());
     }
 }

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -290,6 +290,114 @@ pub struct MonthStats {
 /// Type alias for command statistics tuple: (command, count, saved_tokens, avg_savings_pct, avg_time_ms)
 type CommandStats = (String, usize, usize, f64, u64);
 
+/// Current tracking-DB schema version, stored in the SQLite `user_version` pragma.
+///
+/// `Tracker::new()` is on the hot path (every `rtk <cmd>` invocation and every
+/// PreToolUse hook call), so schema creation/migration must not re-run on every
+/// call. Bump this whenever `run_schema_migrations` gains a new statement; a stale
+/// `user_version` triggers exactly one re-run of the full migration sequence, then
+/// the pragma is updated so subsequent opens skip straight past it.
+const SCHEMA_VERSION: i64 = 1;
+
+/// Create all tables/indexes, run column migrations, and stamp `user_version` to
+/// `SCHEMA_VERSION` for the on-disk tracker DB.
+///
+/// Runs once per database, gated by `SCHEMA_VERSION` in `Tracker::new()` — not on
+/// every call, since this is otherwise on the hot path (every `rtk <cmd>` and every
+/// PreToolUse hook invocation).
+fn run_schema_migrations(conn: &Connection) -> Result<()> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS commands (
+            id INTEGER PRIMARY KEY,
+            timestamp TEXT NOT NULL,
+            original_cmd TEXT NOT NULL,
+            rtk_cmd TEXT NOT NULL,
+            input_tokens INTEGER NOT NULL,
+            output_tokens INTEGER NOT NULL,
+            saved_tokens INTEGER NOT NULL,
+            savings_pct REAL NOT NULL
+        )",
+        [],
+    )?;
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_timestamp ON commands(timestamp)",
+        [],
+    )?;
+
+    // Migration: add exec_time_ms column if it doesn't exist
+    let _ = conn.execute(
+        "ALTER TABLE commands ADD COLUMN exec_time_ms INTEGER DEFAULT 0",
+        [],
+    );
+    // Migration: add project_path column with DEFAULT '' for new rows // changed: added DEFAULT
+    let _ = conn.execute(
+        "ALTER TABLE commands ADD COLUMN project_path TEXT DEFAULT ''",
+        [],
+    );
+    // One-time migration: normalize NULLs from pre-default schema // changed: guarded with EXISTS
+    let has_nulls: bool = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM commands WHERE project_path IS NULL)",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap_or(false);
+    if has_nulls {
+        let _ = conn.execute(
+            "UPDATE commands SET project_path = '' WHERE project_path IS NULL",
+            [],
+        );
+    }
+    // Index for fast project-scoped gain queries // added
+    let _ = conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_project_path_timestamp ON commands(project_path, timestamp)",
+        [],
+    );
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS parse_failures (
+            id INTEGER PRIMARY KEY,
+            timestamp TEXT NOT NULL,
+            raw_command TEXT NOT NULL,
+            error_message TEXT NOT NULL,
+            fallback_succeeded INTEGER NOT NULL DEFAULT 0
+        )",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_pf_timestamp ON parse_failures(timestamp)",
+        [],
+    )?;
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS hook_decisions (
+            id INTEGER PRIMARY KEY,
+            timestamp TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            tool_use_id TEXT NOT NULL,
+            project_path TEXT DEFAULT '',
+            raw_cmd TEXT NOT NULL,
+            decision TEXT NOT NULL,
+            rewritten_cmd TEXT,
+            rtk_version TEXT NOT NULL
+        )",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_hook_decisions_tool_use_id ON hook_decisions(tool_use_id)",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_hook_decisions_timestamp ON hook_decisions(timestamp)",
+        [],
+    )?;
+
+    conn.pragma_update(None, "user_version", SCHEMA_VERSION)?;
+
+    Ok(())
+}
+
 impl Tracker {
     /// Create a new tracker instance.
     ///
@@ -334,97 +442,23 @@ impl Tracker {
 
         let conn = Connection::open(&db_path)?;
         // WAL mode + busy_timeout for concurrent access (multiple Claude Code instances).
-        // Non-fatal: NFS/read-only filesystems may not support WAL.
+        // Non-fatal: NFS/read-only filesystems may not support WAL. Cheap on every
+        // open (WAL mode persists in the DB file; busy_timeout is a per-connection
+        // in-memory setting), so these stay unconditional.
         let _ = conn.execute_batch(
             "PRAGMA journal_mode=WAL;
              PRAGMA busy_timeout=5000;",
         );
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS commands (
-                id INTEGER PRIMARY KEY,
-                timestamp TEXT NOT NULL,
-                original_cmd TEXT NOT NULL,
-                rtk_cmd TEXT NOT NULL,
-                input_tokens INTEGER NOT NULL,
-                output_tokens INTEGER NOT NULL,
-                saved_tokens INTEGER NOT NULL,
-                savings_pct REAL NOT NULL
-            )",
-            [],
-        )?;
 
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_timestamp ON commands(timestamp)",
-            [],
-        )?;
-
-        // Migration: add exec_time_ms column if it doesn't exist
-        let _ = conn.execute(
-            "ALTER TABLE commands ADD COLUMN exec_time_ms INTEGER DEFAULT 0",
-            [],
-        );
-        // Migration: add project_path column with DEFAULT '' for new rows // changed: added DEFAULT
-        let _ = conn.execute(
-            "ALTER TABLE commands ADD COLUMN project_path TEXT DEFAULT ''",
-            [],
-        );
-        // One-time migration: normalize NULLs from pre-default schema // changed: guarded with EXISTS
-        let has_nulls: bool = conn
-            .query_row(
-                "SELECT EXISTS(SELECT 1 FROM commands WHERE project_path IS NULL)",
-                [],
-                |row| row.get(0),
-            )
-            .unwrap_or(false);
-        if has_nulls {
-            let _ = conn.execute(
-                "UPDATE commands SET project_path = '' WHERE project_path IS NULL",
-                [],
-            );
+        // Schema creation/migration is comparatively expensive (several CREATE
+        // TABLE/INDEX/ALTER statements plus a table scan) and `Tracker::new()` is
+        // called on every `rtk <cmd>` invocation and every PreToolUse hook call, so
+        // gate it behind a single cheap `user_version` read instead of re-running it
+        // every time.
+        let current_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+        if current_version < SCHEMA_VERSION {
+            run_schema_migrations(&conn)?;
         }
-        // Index for fast project-scoped gain queries // added
-        let _ = conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_project_path_timestamp ON commands(project_path, timestamp)",
-            [],
-        );
-
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS parse_failures (
-                id INTEGER PRIMARY KEY,
-                timestamp TEXT NOT NULL,
-                raw_command TEXT NOT NULL,
-                error_message TEXT NOT NULL,
-                fallback_succeeded INTEGER NOT NULL DEFAULT 0
-            )",
-            [],
-        )?;
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_pf_timestamp ON parse_failures(timestamp)",
-            [],
-        )?;
-
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS hook_decisions (
-                id INTEGER PRIMARY KEY,
-                timestamp TEXT NOT NULL,
-                session_id TEXT NOT NULL,
-                tool_use_id TEXT NOT NULL,
-                project_path TEXT DEFAULT '',
-                raw_cmd TEXT NOT NULL,
-                decision TEXT NOT NULL,
-                rewritten_cmd TEXT,
-                rtk_version TEXT NOT NULL
-            )",
-            [],
-        )?;
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_hook_decisions_tool_use_id ON hook_decisions(tool_use_id)",
-            [],
-        )?;
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_hook_decisions_timestamp ON hook_decisions(timestamp)",
-            [],
-        )?;
 
         restrict_db_files(&db_path);
 
@@ -617,15 +651,12 @@ impl Tracker {
 
     /// Record a PreToolUse hook decision at the moment the hook actually ran.
     ///
-    /// `decision` must be one of `"allow"`, `"ask"`, `"deny"`, `"defer"`.
-    #[allow(clippy::too_many_arguments)]
-    /// Record a PreToolUse hook decision at the moment the hook actually ran.
-    ///
     /// Deliberately does *not* run `cleanup_old()` — this fires on every single
     /// Bash tool call (the hook's hot path, under the project's <10ms latency
     /// budget), so a 3-table DELETE sweep here would tax every command, not just
     /// RTK-covered ones. Retention for `hook_decisions` piggybacks on whatever
     /// cadence `record()`/`record_parse_failure()` already run cleanup at.
+    #[allow(clippy::too_many_arguments)]
     pub fn record_hook_decision(
         &self,
         session_id: &str,
@@ -1807,6 +1838,40 @@ mod tests {
             "expected default path ending with rtk/history.db, got: {}",
             db_path.display()
         );
+    }
+
+    // 8b. Tracker::new() gates schema migration behind PRAGMA user_version, so a
+    // fresh DB gets stamped to SCHEMA_VERSION and a second open on the same file
+    // still works (and doesn't re-run/fail the migration).
+    #[test]
+    fn test_schema_migration_gated_by_user_version() {
+        use std::env;
+        use std::sync::Mutex;
+        static ENV_LOCK: Mutex<()> = Mutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap();
+
+        let db_path =
+            env::temp_dir().join(format!("rtk_test_schema_version_{}.db", std::process::id()));
+        let _ = std::fs::remove_file(&db_path);
+        env::set_var("RTK_DB_PATH", &db_path);
+
+        let tracker = Tracker::new().expect("first open should run migrations");
+        let version: i64 = tracker
+            .conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .expect("user_version should be readable");
+        assert_eq!(version, SCHEMA_VERSION);
+        drop(tracker);
+
+        // Second open on the same file must skip migrations without erroring, and
+        // the DB must still be fully usable (tables from the first open persist).
+        let tracker2 = Tracker::new().expect("second open should skip migrations cleanly");
+        tracker2
+            .record("git status", "rtk git status", 100, 20, 50)
+            .expect("commands table should already exist and accept writes");
+
+        env::remove_var("RTK_DB_PATH");
+        let _ = std::fs::remove_file(&db_path);
     }
 
     // 9. project_filter_params uses GLOB pattern with * wildcard // added

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -398,6 +398,23 @@ fn run_schema_migrations(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+/// Warn the user when a tracking-DB write fails because a table is missing.
+///
+/// Migrations only run once per database (gated by `SCHEMA_VERSION`/
+/// `user_version` in `Tracker::new()`), so if a table is dropped or corrupted
+/// out-of-band (manual `sqlite3` surgery, disk issue, partial restore) after
+/// `user_version` is already current, it silently stays missing forever —
+/// there's no automatic re-migration to fall back on the way there used to be
+/// when every open re-ran the full schema unconditionally. Point the user at
+/// the fix instead of failing silently.
+fn warn_if_missing_table(context: &str, err: &rusqlite::Error) {
+    if err.to_string().contains("no such table") {
+        eprintln!(
+            "rtk: tracking database looks corrupted ({context}: {err}). Run `rtk init` to recreate it."
+        );
+    }
+}
+
 impl Tracker {
     /// Create a new tracker instance.
     ///
@@ -422,47 +439,9 @@ impl Tracker {
     /// # Ok::<(), anyhow::Error>(())
     /// ```
     pub fn new() -> Result<Self> {
-        let db_path = get_db_path()?;
-        if let Some(parent) = db_path.parent() {
-            crate::core::utils::create_private_dir(parent)?;
-        }
-
-        // Create the file ourselves so SQLite derives the -wal/-shm modes from
-        // an already-private DB instead of the umask.
-        crate::core::utils::open_private(
-            std::fs::OpenOptions::new().write(true).create(true),
-            &db_path,
-        )
-        .with_context(|| {
-            format!(
-                "Failed to pre-create private DB file: {}",
-                db_path.display()
-            )
-        })?;
-
-        let conn = Connection::open(&db_path)?;
-        // WAL mode + busy_timeout for concurrent access (multiple Claude Code instances).
-        // Non-fatal: NFS/read-only filesystems may not support WAL. Cheap on every
-        // open (WAL mode persists in the DB file; busy_timeout is a per-connection
-        // in-memory setting), so these stay unconditional.
-        let _ = conn.execute_batch(
-            "PRAGMA journal_mode=WAL;
-             PRAGMA busy_timeout=5000;",
-        );
-
-        // Schema creation/migration is comparatively expensive (several CREATE
-        // TABLE/INDEX/ALTER statements plus a table scan) and `Tracker::new()` is
-        // called on every `rtk <cmd>` invocation and every PreToolUse hook call, so
-        // gate it behind a single cheap `user_version` read instead of re-running it
-        // every time.
-        let current_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-        if current_version < SCHEMA_VERSION {
-            run_schema_migrations(&conn)?;
-        }
-
-        restrict_db_files(&db_path);
-
-        Ok(Self { conn })
+        Ok(Self {
+            conn: open_and_prepare(MigrationMode::GatedByVersion)?,
+        })
     }
 
     /// Create an isolated in-memory tracker for tests.
@@ -591,7 +570,8 @@ impl Tracker {
                 pct,
                 exec_time_ms as i64
             ],
-        )?;
+        )
+        .inspect_err(|e| warn_if_missing_table("record", e))?;
 
         self.cleanup_old()?;
         Ok(())
@@ -644,7 +624,8 @@ impl Tracker {
                 error_message,
                 fallback_succeeded as i32,
             ],
-        )?;
+        )
+        .inspect_err(|e| warn_if_missing_table("record_parse_failure", e))?;
         self.cleanup_old()?;
         Ok(())
     }
@@ -680,7 +661,8 @@ impl Tracker {
                 rewritten_cmd,
                 rtk_version,
             ],
-        )?;
+        )
+        .inspect_err(|e| warn_if_missing_table("record_hook_decision", e))?;
         Ok(())
     }
 
@@ -1507,6 +1489,77 @@ pub(crate) fn get_db_path() -> Result<PathBuf> {
     Ok(data_dir.join(RTK_DATA_DIR).join(HISTORY_DB))
 }
 
+/// Whether to gate schema migrations behind `user_version` (the hot-path
+/// default) or always re-run them (used by `rtk init`, which isn't a hot path
+/// and wants to self-heal a dropped/corrupted table — see `ensure_schema_fresh`).
+enum MigrationMode {
+    GatedByVersion,
+    Always,
+}
+
+/// Open (creating if needed) the tracking DB, apply pragmas, and run schema
+/// migrations per `mode`. Shared by `Tracker::new()` (hot path, gated) and
+/// `ensure_schema_fresh` (`rtk init`, unconditional).
+fn open_and_prepare(mode: MigrationMode) -> Result<Connection> {
+    let db_path = get_db_path()?;
+    if let Some(parent) = db_path.parent() {
+        crate::core::utils::create_private_dir(parent)?;
+    }
+
+    // Create the file ourselves so SQLite derives the -wal/-shm modes from
+    // an already-private DB instead of the umask.
+    crate::core::utils::open_private(
+        std::fs::OpenOptions::new().write(true).create(true),
+        &db_path,
+    )
+    .with_context(|| {
+        format!(
+            "Failed to pre-create private DB file: {}",
+            db_path.display()
+        )
+    })?;
+
+    let conn = Connection::open(&db_path)?;
+    // WAL mode + busy_timeout for concurrent access (multiple Claude Code instances).
+    // Non-fatal: NFS/read-only filesystems may not support WAL. Cheap on every
+    // open (WAL mode persists in the DB file; busy_timeout is a per-connection
+    // in-memory setting), so these stay unconditional.
+    let _ = conn.execute_batch(
+        "PRAGMA journal_mode=WAL;
+         PRAGMA busy_timeout=5000;",
+    );
+
+    match mode {
+        MigrationMode::Always => run_schema_migrations(&conn)?,
+        MigrationMode::GatedByVersion => {
+            // Schema creation/migration is comparatively expensive (several CREATE
+            // TABLE/INDEX/ALTER statements plus a table scan) and `Tracker::new()` is
+            // called on every `rtk <cmd>` invocation and every PreToolUse hook call, so
+            // gate it behind a single cheap `user_version` read instead of re-running it
+            // every time.
+            let current_version: i64 =
+                conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+            if current_version < SCHEMA_VERSION {
+                run_schema_migrations(&conn)?;
+            }
+        }
+    }
+
+    restrict_db_files(&db_path);
+
+    Ok(conn)
+}
+
+/// Unconditionally re-run schema migrations, bypassing the `user_version` gate
+/// `Tracker::new()` uses on its hot path. Meant to be called from `rtk init`
+/// (not a hot path): this both pre-warms the schema during install/upgrade and
+/// self-heals a table dropped/corrupted out-of-band after `user_version` was
+/// already stamped current (see `warn_if_missing_table`) — `CREATE TABLE IF NOT
+/// EXISTS`/`ALTER TABLE` are additive, so existing history is left untouched.
+pub fn ensure_schema_fresh() -> Result<()> {
+    open_and_prepare(MigrationMode::Always).map(|_| ())
+}
+
 /// Individual parse failure record.
 #[derive(Debug)]
 pub struct ParseFailureRecord {
@@ -1694,6 +1747,14 @@ pub fn args_display(args: &[OsString]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// Serializes tests that mutate the process-global `RTK_DB_PATH` env var.
+    /// Must be a single shared static: a `static` declared inside each test
+    /// function body is a distinct static per function, not a shared lock, so
+    /// tests using separate locals don't actually serialize against each other
+    /// and can race on the same global env var under parallel `cargo test`.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     // 1. estimate_tokens — verify ~4 chars/token ratio
     #[test]
@@ -1822,8 +1883,6 @@ mod tests {
     #[test]
     fn test_db_path_env_and_default() {
         use std::env;
-        use std::sync::Mutex;
-        static ENV_LOCK: Mutex<()> = Mutex::new(());
         let _guard = ENV_LOCK.lock().unwrap();
 
         let custom_path = env::temp_dir().join("rtk_test_custom.db");
@@ -1846,8 +1905,6 @@ mod tests {
     #[test]
     fn test_schema_migration_gated_by_user_version() {
         use std::env;
-        use std::sync::Mutex;
-        static ENV_LOCK: Mutex<()> = Mutex::new(());
         let _guard = ENV_LOCK.lock().unwrap();
 
         let db_path =
@@ -1871,6 +1928,53 @@ mod tests {
             .expect("commands table should already exist and accept writes");
 
         env::remove_var("RTK_DB_PATH");
+        let _ = std::fs::remove_file(&db_path);
+    }
+
+    // 8c. Re-running run_schema_migrations() unconditionally (what
+    // ensure_schema_fresh()/MigrationMode::Always does, vs. Tracker::new()'s
+    // gated hot path) recreates a table dropped out-of-band, even though
+    // user_version is already at SCHEMA_VERSION. This is the self-heal `rtk
+    // init` relies on instead of a dedicated repair flag.
+    //
+    // Exercises the migration function directly on its own throwaway on-disk
+    // connection rather than going through ensure_schema_fresh()/Tracker::new()
+    // (which read the process-global RTK_DB_PATH env var): this test doesn't
+    // need the ENV_LOCK serialization those need, and — critically — never
+    // leaves the *shared default* tracking DB in a dropped-table state where
+    // an unrelated, concurrently-running test that opens Tracker::new()
+    // without its own RTK_DB_PATH override could observe it.
+    #[test]
+    fn test_run_schema_migrations_heals_dropped_table_when_forced() {
+        let db_path = std::env::temp_dir().join(format!(
+            "rtk_test_heal_migrations_{}.db",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&db_path);
+        let conn = Connection::open(&db_path).expect("open should succeed");
+
+        run_schema_migrations(&conn).expect("first migration run should succeed");
+        conn.execute("DROP TABLE hook_decisions", [])
+            .expect("drop should succeed");
+        assert!(
+            conn.execute(
+                "INSERT INTO hook_decisions (timestamp, session_id, tool_use_id, raw_cmd, decision, rtk_version) VALUES ('t','s','u','c','allow','0')",
+                [],
+            )
+            .is_err(),
+            "table should genuinely be gone after DROP"
+        );
+
+        // Forced re-run (what ensure_schema_fresh does) recreates it, even
+        // though user_version is already stamped to SCHEMA_VERSION.
+        run_schema_migrations(&conn).expect("forced re-run should recreate the dropped table");
+        conn.execute(
+            "INSERT INTO hook_decisions (timestamp, session_id, tool_use_id, raw_cmd, decision, rtk_version) VALUES ('t','s','u','c','allow','0')",
+            [],
+        )
+        .expect("hook_decisions table should exist and accept writes again");
+
+        drop(conn);
         let _ = std::fs::remove_file(&db_path);
     }
 

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -619,6 +619,13 @@ impl Tracker {
     ///
     /// `decision` must be one of `"allow"`, `"ask"`, `"deny"`, `"defer"`.
     #[allow(clippy::too_many_arguments)]
+    /// Record a PreToolUse hook decision at the moment the hook actually ran.
+    ///
+    /// Deliberately does *not* run `cleanup_old()` — this fires on every single
+    /// Bash tool call (the hook's hot path, under the project's <10ms latency
+    /// budget), so a 3-table DELETE sweep here would tax every command, not just
+    /// RTK-covered ones. Retention for `hook_decisions` piggybacks on whatever
+    /// cadence `record()`/`record_parse_failure()` already run cleanup at.
     pub fn record_hook_decision(
         &self,
         session_id: &str,
@@ -643,7 +650,6 @@ impl Tracker {
                 rtk_version,
             ],
         )?;
-        self.cleanup_old()?;
         Ok(())
     }
 

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -1801,6 +1801,7 @@ mod tests {
             "rtk_test_timed_exec_records_{}.db",
             std::process::id()
         ));
+        // nosemgrep: filesystem-deletion -- test-only cleanup of this test's own throwaway temp DB file, not production/user data.
         let _ = std::fs::remove_file(&db_path);
         env::set_var("RTK_DB_PATH", &db_path);
 
@@ -1815,6 +1816,7 @@ mod tests {
 
         drop(tracker);
         env::remove_var("RTK_DB_PATH");
+        // nosemgrep: filesystem-deletion -- test-only cleanup of this test's own throwaway temp DB file, not production/user data.
         let _ = std::fs::remove_file(&db_path);
     }
 
@@ -1828,6 +1830,7 @@ mod tests {
             "rtk_test_timed_exec_passthrough_{}.db",
             std::process::id()
         ));
+        // nosemgrep: filesystem-deletion -- test-only cleanup of this test's own throwaway temp DB file, not production/user data.
         let _ = std::fs::remove_file(&db_path);
         env::set_var("RTK_DB_PATH", &db_path);
 
@@ -1848,6 +1851,7 @@ mod tests {
 
         drop(tracker);
         env::remove_var("RTK_DB_PATH");
+        // nosemgrep: filesystem-deletion -- test-only cleanup of this test's own throwaway temp DB file, not production/user data.
         let _ = std::fs::remove_file(&db_path);
     }
 
@@ -1883,6 +1887,7 @@ mod tests {
 
         let db_path =
             env::temp_dir().join(format!("rtk_test_schema_version_{}.db", std::process::id()));
+        // nosemgrep: filesystem-deletion -- test-only cleanup of this test's own throwaway temp DB file, not production/user data.
         let _ = std::fs::remove_file(&db_path);
         env::set_var("RTK_DB_PATH", &db_path);
 
@@ -1902,6 +1907,7 @@ mod tests {
             .expect("commands table should already exist and accept writes");
 
         env::remove_var("RTK_DB_PATH");
+        // nosemgrep: filesystem-deletion -- test-only cleanup of this test's own throwaway temp DB file, not production/user data.
         let _ = std::fs::remove_file(&db_path);
     }
 
@@ -1924,6 +1930,7 @@ mod tests {
             "rtk_test_heal_migrations_{}.db",
             std::process::id()
         ));
+        // nosemgrep: filesystem-deletion -- test-only cleanup of this test's own throwaway temp DB file, not production/user data.
         let _ = std::fs::remove_file(&db_path);
         let conn = Connection::open(&db_path).expect("open should succeed");
 
@@ -1949,6 +1956,7 @@ mod tests {
         .expect("hook_decisions table should exist and accept writes again");
 
         drop(conn);
+        // nosemgrep: filesystem-deletion -- test-only cleanup of this test's own throwaway temp DB file, not production/user data.
         let _ = std::fs::remove_file(&db_path);
     }
 

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -1719,13 +1719,15 @@ mod tests {
     // 3. Tracker::record + get_recent — round-trip DB
     #[test]
     fn test_tracker_record_and_recent() {
-        let tracker = Tracker::new().expect("Failed to create tracker");
+        // In-memory: isolated per-test DB, immune to the shared on-disk DB's
+        // cross-test races under parallel `cargo test` (see get_recent(N) racing
+        // against concurrent inserts from other tests hitting the same file).
+        let tracker = Tracker::new_in_memory().expect("Failed to create tracker");
 
-        // Use unique test identifier to avoid conflicts with other tests
-        let test_cmd = format!("rtk git status test_{}", std::process::id());
+        let test_cmd = "rtk git status test";
 
         tracker
-            .record("git status", &test_cmd, 100, 20, 50)
+            .record("git status", test_cmd, 100, 20, 50)
             .expect("Failed to record");
 
         let recent = tracker.get_recent(10).expect("Failed to get recent");
@@ -1743,21 +1745,20 @@ mod tests {
     // 4. track_passthrough doesn't dilute stats (input=0, output=0)
     #[test]
     fn test_track_passthrough_no_dilution() {
-        let tracker = Tracker::new().expect("Failed to create tracker");
+        // In-memory: isolated per-test DB, see test_tracker_record_and_recent.
+        let tracker = Tracker::new_in_memory().expect("Failed to create tracker");
 
-        // Use unique test identifiers
-        let pid = std::process::id();
-        let cmd1 = format!("rtk cmd1_test_{}", pid);
-        let cmd2 = format!("rtk cmd2_passthrough_test_{}", pid);
+        let cmd1 = "rtk cmd1_test";
+        let cmd2 = "rtk cmd2_passthrough_test";
 
         // Record one real command with 80% savings
         tracker
-            .record("cmd1", &cmd1, 1000, 200, 10)
+            .record("cmd1", cmd1, 1000, 200, 10)
             .expect("Failed to record cmd1");
 
         // Record passthrough (0, 0)
         tracker
-            .record("cmd2", &cmd2, 0, 0, 5)
+            .record("cmd2", cmd2, 0, 0, 5)
             .expect("Failed to record passthrough");
 
         // Verify both records exist in recent history
@@ -1785,8 +1786,24 @@ mod tests {
     }
 
     // 5. TimedExecution::track records with exec_time > 0
+    //
+    // TimedExecution::track() hardcodes Tracker::new() internally (real
+    // on-disk DB via get_db_path()), so it can't take an in-memory tracker
+    // like the tests above. Point RTK_DB_PATH at a private temp file instead —
+    // otherwise get_recent(5) races against every other test concurrently
+    // inserting into the same shared default DB and can miss this test's own
+    // record once 5+ other rows land first.
     #[test]
     fn test_timed_execution_records_time() {
+        use std::env;
+        let _guard = ENV_LOCK.lock().unwrap();
+        let db_path = env::temp_dir().join(format!(
+            "rtk_test_timed_exec_records_{}.db",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&db_path);
+        env::set_var("RTK_DB_PATH", &db_path);
+
         let timer = TimedExecution::start();
         std::thread::sleep(std::time::Duration::from_millis(10));
         timer.track("test cmd", "rtk test", "raw input data", "filtered");
@@ -1795,11 +1812,25 @@ mod tests {
         let tracker = Tracker::new().expect("Failed to create tracker");
         let recent = tracker.get_recent(5).expect("Failed to get recent");
         assert!(recent.iter().any(|r| r.rtk_cmd == "rtk test"));
+
+        drop(tracker);
+        env::remove_var("RTK_DB_PATH");
+        let _ = std::fs::remove_file(&db_path);
     }
 
     // 6. TimedExecution::track_passthrough records with 0 tokens
+    // Same isolation rationale as test_timed_execution_records_time above.
     #[test]
     fn test_timed_execution_passthrough() {
+        use std::env;
+        let _guard = ENV_LOCK.lock().unwrap();
+        let db_path = env::temp_dir().join(format!(
+            "rtk_test_timed_exec_passthrough_{}.db",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&db_path);
+        env::set_var("RTK_DB_PATH", &db_path);
+
         let timer = TimedExecution::start();
         timer.track_passthrough("git tag", "rtk git tag (passthrough)");
 
@@ -1814,6 +1845,10 @@ mod tests {
         // savings_pct should be 0 for passthrough
         assert_eq!(pt.savings_pct, 0.0);
         assert_eq!(pt.saved_tokens, 0);
+
+        drop(tracker);
+        env::remove_var("RTK_DB_PATH");
+        let _ = std::fs::remove_file(&db_path);
     }
 
     // 7. get_db_path respects environment variable RTK_DB_PATH
@@ -1958,11 +1993,12 @@ mod tests {
     // 12. record_parse_failure + get_parse_failure_summary roundtrip
     #[test]
     fn test_parse_failure_roundtrip() {
-        let tracker = Tracker::new().expect("Failed to create tracker");
-        let test_cmd = format!("git -C /path status test_{}", std::process::id());
+        // In-memory: isolated per-test DB, see test_tracker_record_and_recent.
+        let tracker = Tracker::new_in_memory().expect("Failed to create tracker");
+        let test_cmd = "git -C /path status test";
 
         tracker
-            .record_parse_failure(&test_cmd, "unrecognized subcommand", true)
+            .record_parse_failure(test_cmd, "unrecognized subcommand", true)
             .expect("Failed to record parse failure");
 
         let summary = tracker
@@ -1976,24 +2012,23 @@ mod tests {
     // 13. recovery_rate calculation
     #[test]
     fn test_parse_failure_recovery_rate() {
-        let tracker = Tracker::new().expect("Failed to create tracker");
-        let pid = std::process::id();
+        // In-memory: isolated per-test DB, see test_tracker_record_and_recent.
+        let tracker = Tracker::new_in_memory().expect("Failed to create tracker");
 
         // 2 successes, 1 failure
         tracker
-            .record_parse_failure(&format!("cmd_ok1_{}", pid), "err", true)
+            .record_parse_failure("cmd_ok1", "err", true)
             .unwrap();
         tracker
-            .record_parse_failure(&format!("cmd_ok2_{}", pid), "err", true)
+            .record_parse_failure("cmd_ok2", "err", true)
             .unwrap();
         tracker
-            .record_parse_failure(&format!("cmd_fail_{}", pid), "err", false)
+            .record_parse_failure("cmd_fail", "err", false)
             .unwrap();
 
         let summary = tracker.get_parse_failure_summary().unwrap();
-        // We can't assert exact rate because other tests may have added records,
-        // but we can verify recovery_rate is between 0 and 100
-        assert!(summary.recovery_rate >= 0.0 && summary.recovery_rate <= 100.0);
+        // Isolated DB, so the rate is now exact: 2/3 successes ≈ 66.7%.
+        assert!((summary.recovery_rate - 66.7).abs() < 0.1);
     }
 
     #[test]

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -445,76 +445,15 @@ impl Tracker {
     }
 
     /// Create an isolated in-memory tracker for tests.
+    ///
+    /// Runs the same `run_schema_migrations` the real on-disk `Tracker::new()`
+    /// path uses, rather than hand-duplicating the DDL — a second copy would
+    /// silently drift from the real schema the next time `SCHEMA_VERSION` bumps.
     #[cfg(test)]
     pub fn new_in_memory() -> Result<Self> {
         let conn = Connection::open_in_memory().context("Failed to open in-memory DB")?;
-        let tracker = Self { conn };
-        tracker.init_schema()?;
-        Ok(tracker)
-    }
-
-    #[cfg(test)]
-    fn init_schema(&self) -> Result<()> {
-        self.conn.execute(
-            "CREATE TABLE IF NOT EXISTS commands (
-                id INTEGER PRIMARY KEY,
-                timestamp TEXT NOT NULL,
-                original_cmd TEXT NOT NULL,
-                rtk_cmd TEXT NOT NULL,
-                input_tokens INTEGER NOT NULL,
-                output_tokens INTEGER NOT NULL,
-                saved_tokens INTEGER NOT NULL,
-                savings_pct REAL NOT NULL,
-                exec_time_ms INTEGER DEFAULT 0,
-                project_path TEXT DEFAULT ''
-            )",
-            [],
-        )?;
-        self.conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_timestamp ON commands(timestamp)",
-            [],
-        )?;
-        self.conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_project_path_timestamp ON commands(project_path, timestamp)",
-            [],
-        )?;
-        self.conn.execute(
-            "CREATE TABLE IF NOT EXISTS parse_failures (
-                id INTEGER PRIMARY KEY,
-                timestamp TEXT NOT NULL,
-                raw_command TEXT NOT NULL,
-                error_message TEXT NOT NULL,
-                fallback_succeeded INTEGER NOT NULL DEFAULT 0
-            )",
-            [],
-        )?;
-        self.conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_pf_timestamp ON parse_failures(timestamp)",
-            [],
-        )?;
-        self.conn.execute(
-            "CREATE TABLE IF NOT EXISTS hook_decisions (
-                id INTEGER PRIMARY KEY,
-                timestamp TEXT NOT NULL,
-                session_id TEXT NOT NULL,
-                tool_use_id TEXT NOT NULL,
-                project_path TEXT DEFAULT '',
-                raw_cmd TEXT NOT NULL,
-                decision TEXT NOT NULL,
-                rewritten_cmd TEXT,
-                rtk_version TEXT NOT NULL
-            )",
-            [],
-        )?;
-        self.conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_hook_decisions_tool_use_id ON hook_decisions(tool_use_id)",
-            [],
-        )?;
-        self.conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_hook_decisions_timestamp ON hook_decisions(timestamp)",
-            [],
-        )?;
-        Ok(())
+        run_schema_migrations(&conn)?;
+        Ok(Self { conn })
     }
 
     /// Record a command execution with token counts and timing.

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -415,14 +415,25 @@ fn warn_if_missing_table(context: &str, err: &rusqlite::Error) {
     }
 }
 
-/// Pure core of `Tracker::maybe_cleanup_hook_decisions`'s sampling decision, taking
-/// the nanosecond reading directly so it's deterministically testable without
-/// waiting on a real 1-in-`rate` chance. Doesn't need to be cryptographically
-/// random, just cheap and not obviously correlated with call timing — reusing the
-/// wall-clock read the caller already pays for avoids pulling in a `rand`
-/// dependency just for a sampling backstop.
-fn should_sample_cleanup(nanos: u32, rate: u32) -> bool {
-    nanos.is_multiple_of(rate)
+/// Pure core of `Tracker::maybe_cleanup_hook_decisions`'s sampling decision.
+///
+/// Hashes `key` (the call's `tool_use_id`, always distinct per hook invocation)
+/// rather than reading the wall clock: a nanosecond-based sample (an earlier
+/// version of this used `Utc::now().timestamp_subsec_nanos() % rate`) silently
+/// breaks on any clock source whose resolution isn't fine enough to hit every
+/// residue mod `rate` — e.g. a coarse virtualized/Windows timer ticking in
+/// large, evenly-divisible steps could make the check fire on nearly 100% of
+/// calls (defeating the sampling entirely) or effectively 0% (undoing the
+/// backstop against unbounded growth), depending on the tick size, with no
+/// visible symptom short of profiling. Doesn't need to be cryptographically
+/// random, just cheap and evenly distributed across calls — `DefaultHasher`
+/// over an already-unique string avoids pulling in a `rand` dependency just for
+/// a sampling backstop.
+fn should_sample_cleanup(key: &str, rate: u32) -> bool {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    key.hash(&mut hasher);
+    hasher.finish().is_multiple_of(rate as u64)
 }
 
 impl Tracker {
@@ -616,7 +627,7 @@ impl Tracker {
             ],
         )
         .inspect_err(|e| warn_if_missing_table("record_hook_decision", e))?;
-        self.maybe_cleanup_hook_decisions()?;
+        self.maybe_cleanup_hook_decisions(tool_use_id)?;
         Ok(())
     }
 
@@ -626,12 +637,9 @@ impl Tracker {
     /// commands are mostly `Deny`/`Defer`'d — and so rarely trigger `record()`'s or
     /// `record_parse_failure()`'s own cleanup — without paying a DELETE on every
     /// single hook invocation.
-    fn maybe_cleanup_hook_decisions(&self) -> Result<()> {
+    fn maybe_cleanup_hook_decisions(&self, tool_use_id: &str) -> Result<()> {
         const HOOK_DECISIONS_CLEANUP_SAMPLE_RATE: u32 = 500;
-        if !should_sample_cleanup(
-            Utc::now().timestamp_subsec_nanos(),
-            HOOK_DECISIONS_CLEANUP_SAMPLE_RATE,
-        ) {
+        if !should_sample_cleanup(tool_use_id, HOOK_DECISIONS_CLEANUP_SAMPLE_RATE) {
             return Ok(());
         }
         self.cleanup_hook_decisions()
@@ -1488,21 +1496,30 @@ fn open_and_prepare(mode: MigrationMode) -> Result<Connection> {
 
     // `create_private_dir` is cheap even when the directory already exists (its own
     // chmod is a no-op past the first call — see `utils::set_owner_only`), so it
-    // stays unconditional. The pre-create-and-chmod-the-file dance below is a
-    // genuinely separate open()/close() pair from the `Connection::open` right
-    // after it, so it's skipped once the file already exists — it only matters the
-    // *first* time the DB is ever created (so SQLite derives the -wal/-shm modes
-    // from an already-private DB instead of the umask). `Tracker::new()` is on the
+    // stays unconditional.
+    //
+    // For a brand-new DB, pre-create the file ourselves via `open_private` so
+    // SQLite derives the -wal/-shm modes from an already-private DB instead of the
+    // umask. For an already-existing DB, skip that pre-create's own redundant
+    // open()/close() pair (a second file open on top of the `Connection::open`
+    // right after it) — but still re-chmod the file *before* `Connection::open`
+    // via the now-cheap `restrict_file` (a no-op stat once permissions already
+    // match), rather than only healing it via `restrict_db_files` at the very
+    // end. Skipping the pre-open heal entirely would let `Connection::open` and
+    // any migration writes touch a file whose permissions had drifted (external
+    // tampering, restored backup) before anything corrected them — the same
+    // "chmod before SQLite ever opens it" invariant the original pre-create dance
+    // provided, just without paying its extra open. `Tracker::new()` is on the
     // hot path for every `rtk <cmd>` and, since rtk-ai/rtk#3206's hook_decisions
     // ground-truth logging, every single PreToolUse hook call (not just
-    // RTK-covered ones), so this redundant open on the already-set-up common case
-    // matters for the <10ms budget. `restrict_db_files` below still runs every
-    // time to self-heal a file whose permissions somehow drifted, but is itself
-    // now a cheap no-op stat once permissions are already correct.
+    // RTK-covered ones), so avoiding that redundant open on the already-set-up
+    // common case matters for the <10ms budget.
     if let Some(parent) = db_path.parent() {
         crate::core::utils::create_private_dir(parent)?;
     }
-    if !db_path.exists() {
+    if db_path.exists() {
+        crate::core::utils::restrict_file(&db_path);
+    } else {
         crate::core::utils::open_private(
             std::fs::OpenOptions::new().write(true).create(true),
             &db_path,
@@ -2300,11 +2317,20 @@ mod tests {
 
     #[test]
     fn test_should_sample_cleanup_pure() {
-        assert!(should_sample_cleanup(0, 500));
-        assert!(should_sample_cleanup(500, 500));
-        assert!(should_sample_cleanup(1000, 500));
-        assert!(!should_sample_cleanup(1, 500));
-        assert!(!should_sample_cleanup(499, 500));
+        // Deterministic for a given key (same tool_use_id always samples the same
+        // way), and observably not "always true"/"always false" across a spread of
+        // distinct keys — the actual hit rate isn't asserted (that would pin the
+        // hash implementation), just that it's a real subset.
+        let sampled: Vec<bool> = (0..2000)
+            .map(|i| should_sample_cleanup(&format!("toolu_{i}"), 500))
+            .collect();
+        assert!(sampled.iter().any(|&s| s), "some keys should sample");
+        assert!(sampled.iter().any(|&s| !s), "most keys should not sample");
+
+        // Same key, same rate → same decision every time.
+        let a = should_sample_cleanup("toolu_stable", 500);
+        let b = should_sample_cleanup("toolu_stable", 500);
+        assert_eq!(a, b);
     }
 
     #[test]

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -415,6 +415,16 @@ fn warn_if_missing_table(context: &str, err: &rusqlite::Error) {
     }
 }
 
+/// Pure core of `Tracker::maybe_cleanup_hook_decisions`'s sampling decision, taking
+/// the nanosecond reading directly so it's deterministically testable without
+/// waiting on a real 1-in-`rate` chance. Doesn't need to be cryptographically
+/// random, just cheap and not obviously correlated with call timing — reusing the
+/// wall-clock read the caller already pays for avoids pulling in a `rand`
+/// dependency just for a sampling backstop.
+fn should_sample_cleanup(nanos: u32, rate: u32) -> bool {
+    nanos.is_multiple_of(rate)
+}
+
 impl Tracker {
     /// Create a new tracker instance.
     ///
@@ -571,11 +581,15 @@ impl Tracker {
 
     /// Record a PreToolUse hook decision at the moment the hook actually ran.
     ///
-    /// Deliberately does *not* run `cleanup_old()` — this fires on every single
-    /// Bash tool call (the hook's hot path, under the project's <10ms latency
-    /// budget), so a 3-table DELETE sweep here would tax every command, not just
-    /// RTK-covered ones. Retention for `hook_decisions` piggybacks on whatever
-    /// cadence `record()`/`record_parse_failure()` already run cleanup at.
+    /// Deliberately does *not* run the full `cleanup_old()` (which sweeps
+    /// `commands`/`parse_failures` too) unconditionally — this fires on every
+    /// single Bash tool call (the hook's hot path, under the project's <10ms
+    /// latency budget), so a 3-table DELETE sweep here would tax every command,
+    /// not just RTK-covered ones. Retention mostly piggybacks on whatever cadence
+    /// `record()`/`record_parse_failure()` already run cleanup at, but a user whose
+    /// commands are almost entirely `Deny`/`Defer`'d may rarely trigger either of
+    /// those, so `hook_decisions` alone still gets a `maybe_cleanup_hook_decisions`
+    /// sweep — sampled, not every call — as a backstop against unbounded growth.
     #[allow(clippy::too_many_arguments)]
     pub fn record_hook_decision(
         &self,
@@ -602,6 +616,36 @@ impl Tracker {
             ],
         )
         .inspect_err(|e| warn_if_missing_table("record_hook_decision", e))?;
+        self.maybe_cleanup_hook_decisions()?;
+        Ok(())
+    }
+
+    /// Sampled retention sweep for `hook_decisions` alone (not the full 3-table
+    /// `cleanup_old()`), run on roughly 1-in-`HOOK_DECISIONS_CLEANUP_SAMPLE_RATE`
+    /// calls to `record_hook_decision`. Bounds the table's growth for a user whose
+    /// commands are mostly `Deny`/`Defer`'d — and so rarely trigger `record()`'s or
+    /// `record_parse_failure()`'s own cleanup — without paying a DELETE on every
+    /// single hook invocation.
+    fn maybe_cleanup_hook_decisions(&self) -> Result<()> {
+        const HOOK_DECISIONS_CLEANUP_SAMPLE_RATE: u32 = 500;
+        if !should_sample_cleanup(
+            Utc::now().timestamp_subsec_nanos(),
+            HOOK_DECISIONS_CLEANUP_SAMPLE_RATE,
+        ) {
+            return Ok(());
+        }
+        self.cleanup_hook_decisions()
+    }
+
+    /// The actual `hook_decisions` DELETE sweep, split out from
+    /// `maybe_cleanup_hook_decisions` so it's directly callable (bypassing the
+    /// sampling gate) from tests without needing to hit the 1-in-N chance for real.
+    fn cleanup_hook_decisions(&self) -> Result<()> {
+        let cutoff = Utc::now() - chrono::Duration::days(DEFAULT_HISTORY_DAYS);
+        self.conn.execute(
+            "DELETE FROM hook_decisions WHERE timestamp < ?1",
+            params![cutoff.to_rfc3339()],
+        )?;
         Ok(())
     }
 
@@ -1441,22 +1485,35 @@ enum MigrationMode {
 /// `ensure_schema_fresh` (`rtk init`, unconditional).
 fn open_and_prepare(mode: MigrationMode) -> Result<Connection> {
     let db_path = get_db_path()?;
+
+    // `create_private_dir` is cheap even when the directory already exists (its own
+    // chmod is a no-op past the first call — see `utils::set_owner_only`), so it
+    // stays unconditional. The pre-create-and-chmod-the-file dance below is a
+    // genuinely separate open()/close() pair from the `Connection::open` right
+    // after it, so it's skipped once the file already exists — it only matters the
+    // *first* time the DB is ever created (so SQLite derives the -wal/-shm modes
+    // from an already-private DB instead of the umask). `Tracker::new()` is on the
+    // hot path for every `rtk <cmd>` and, since rtk-ai/rtk#3206's hook_decisions
+    // ground-truth logging, every single PreToolUse hook call (not just
+    // RTK-covered ones), so this redundant open on the already-set-up common case
+    // matters for the <10ms budget. `restrict_db_files` below still runs every
+    // time to self-heal a file whose permissions somehow drifted, but is itself
+    // now a cheap no-op stat once permissions are already correct.
     if let Some(parent) = db_path.parent() {
         crate::core::utils::create_private_dir(parent)?;
     }
-
-    // Create the file ourselves so SQLite derives the -wal/-shm modes from
-    // an already-private DB instead of the umask.
-    crate::core::utils::open_private(
-        std::fs::OpenOptions::new().write(true).create(true),
-        &db_path,
-    )
-    .with_context(|| {
-        format!(
-            "Failed to pre-create private DB file: {}",
-            db_path.display()
+    if !db_path.exists() {
+        crate::core::utils::open_private(
+            std::fs::OpenOptions::new().write(true).create(true),
+            &db_path,
         )
-    })?;
+        .with_context(|| {
+            format!(
+                "Failed to pre-create private DB file: {}",
+                db_path.display()
+            )
+        })?;
+    }
 
     let conn = Connection::open(&db_path)?;
     // WAL mode + busy_timeout for concurrent access (multiple Claude Code instances).
@@ -2233,5 +2290,69 @@ mod tests {
             .earliest_hook_decision_timestamp()
             .expect("query failed")
             .is_none());
+    }
+
+    // rtk-ai/rtk#3206 review: hook_decisions grows unbounded for a user whose
+    // commands are mostly Deny/Defer'd, since record_hook_decision deliberately
+    // skips the full cleanup_old() sweep and those decisions rarely trigger
+    // record()/record_parse_failure()'s own cleanup. maybe_cleanup_hook_decisions
+    // is a sampled backstop against that.
+
+    #[test]
+    fn test_should_sample_cleanup_pure() {
+        assert!(should_sample_cleanup(0, 500));
+        assert!(should_sample_cleanup(500, 500));
+        assert!(should_sample_cleanup(1000, 500));
+        assert!(!should_sample_cleanup(1, 500));
+        assert!(!should_sample_cleanup(499, 500));
+    }
+
+    #[test]
+    fn test_cleanup_hook_decisions_deletes_only_stale_rows() {
+        let tracker = Tracker::new_in_memory().expect("Failed to create in-memory tracker");
+
+        // Recent row, via the real API.
+        tracker
+            .record_hook_decision(
+                "s",
+                "toolu_recent",
+                "",
+                "ls",
+                HookOutcome::Allow,
+                Some("rtk ls"),
+                "0.42.4",
+            )
+            .expect("Failed to record hook decision");
+
+        // Stale row, inserted directly: record_hook_decision always stamps
+        // Utc::now(), so there's no other way to get an old row into the table.
+        let stale_ts = (Utc::now() - chrono::Duration::days(DEFAULT_HISTORY_DAYS + 1)).to_rfc3339();
+        tracker
+            .conn
+            .execute(
+                "INSERT INTO hook_decisions (timestamp, session_id, tool_use_id, project_path, raw_cmd, decision, rewritten_cmd, rtk_version)
+                 VALUES (?1, 's', 'toolu_stale', '', 'ls', 'allow', 'rtk ls', '0.42.4')",
+                params![stale_ts],
+            )
+            .expect("Failed to insert stale row");
+
+        // Call the sweep directly, bypassing maybe_cleanup_hook_decisions' sampling
+        // gate — this test isn't exercising the sampling decision, just the DELETE.
+        tracker
+            .cleanup_hook_decisions()
+            .expect("cleanup should succeed");
+
+        let far_past = DateTime::<Utc>::MIN_UTC;
+        let all = tracker
+            .hook_decisions_since(far_past)
+            .expect("query failed");
+        assert!(
+            all.contains_key("toolu_recent"),
+            "recent row should survive cleanup"
+        );
+        assert!(
+            !all.contains_key("toolu_stale"),
+            "stale row should be deleted by cleanup"
+        );
     }
 }

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -131,16 +131,24 @@ impl HookOutcome {
     pub fn is_covered(self) -> bool {
         matches!(self, HookOutcome::Allow | HookOutcome::Ask)
     }
-}
 
-impl std::fmt::Display for HookOutcome {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(match self {
+    /// The `'static` string this variant serializes to in the `hook_decisions`
+    /// table. Exists so `record_hook_decision` can bind it directly as a param
+    /// (rusqlite accepts `&str`) instead of heap-allocating via `.to_string()` on
+    /// every single hook invocation for what's always one of four literals.
+    fn as_str(self) -> &'static str {
+        match self {
             HookOutcome::Allow => "allow",
             HookOutcome::Ask => "ask",
             HookOutcome::Deny => "deny",
             HookOutcome::Defer => "defer",
-        })
+        }
+    }
+}
+
+impl std::fmt::Display for HookOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 
@@ -621,13 +629,22 @@ impl Tracker {
                 tool_use_id,
                 project_path,
                 raw_cmd,
-                decision.to_string(),
+                decision.as_str(),
                 rewritten_cmd,
                 rtk_version,
             ],
         )
         .inspect_err(|e| warn_if_missing_table("record_hook_decision", e))?;
-        self.maybe_cleanup_hook_decisions(tool_use_id)?;
+
+        // The INSERT above already committed as its own autocommit statement —
+        // whatever happens to the retention sweep must not be reported as if it
+        // were *this* write failing (a caller like `log_hook_decision` prints
+        // "hook_decisions logging failed" on `Err`, which would be a lie here:
+        // the decision genuinely was recorded and is readable by `rtk discover`).
+        // Best-effort only, same as the rest of this best-effort side channel.
+        if let Err(e) = self.maybe_cleanup_hook_decisions(tool_use_id) {
+            eprintln!("rtk: warning: hook_decisions retention sweep failed: {e}");
+        }
         Ok(())
     }
 
@@ -671,14 +688,16 @@ impl Tracker {
              FROM hook_decisions
              WHERE timestamp >= ?1",
         )?;
-        let rows = stmt
-            .query_map(params![cutoff.to_rfc3339()], |row| {
-                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-            })?
-            .collect::<Result<Vec<_>, _>>()?;
+        let rows = stmt.query_map(params![cutoff.to_rfc3339()], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
 
-        let mut out = HashMap::with_capacity(rows.len());
-        for (tool_use_id, decision) in rows {
+        // Single pass: insert directly instead of collecting into an intermediate
+        // Vec first and looping over that separately — this scales with
+        // hook_decisions table size and runs once per `rtk discover` invocation.
+        let mut out = HashMap::new();
+        for row in rows {
+            let (tool_use_id, decision) = row?;
             // Skip rows with an unrecognized decision string (e.g. written by a
             // future rtk version with a decision this build doesn't know) rather
             // than failing the whole query — `discover` just falls back to its
@@ -690,10 +709,17 @@ impl Tracker {
         Ok(out)
     }
 
-    /// Earliest timestamp any hook decision was logged, if any exist.
+    /// Earliest timestamp among *currently-retained* hook decision rows, if any
+    /// exist. NOT the date logging first began: `hook_decisions` is pruned by the
+    /// same `DEFAULT_HISTORY_DAYS` window as the rest of the tracking DB (see
+    /// `cleanup_hook_decisions`), so this rolls forward over time — on a
+    /// long-running install it settles at roughly "now minus `DEFAULT_HISTORY_DAYS`",
+    /// not the true install date.
     ///
-    /// Used to tell `rtk discover` where the "measured" window starts — any scan
-    /// range before this point falls back to the estimate-based heuristic.
+    /// Used to tell `rtk discover` where the "measured" window currently starts —
+    /// any scan range before this point falls back to the estimate-based heuristic,
+    /// permanently (not just transitionally), since retention keeps pruning the
+    /// tail as new rows come in.
     pub fn earliest_hook_decision_timestamp(&self) -> Result<Option<DateTime<Utc>>> {
         let ts: Option<String> =
             self.conn
@@ -1468,11 +1494,19 @@ pub(crate) fn get_db_path() -> Result<PathBuf> {
         return Ok(PathBuf::from(custom_path));
     }
 
-    // Priority 2: Configuration file
-    if let Ok(config) = crate::core::config::Config::load() {
-        if let Some(db_path) = config.tracking.database_path {
-            return Ok(db_path);
-        }
+    // Priority 2: Configuration file. Reads the process-wide cached config (see
+    // `config::cached_config`), not a fresh `Config::load()`: this runs inside
+    // `Tracker::new()`, which `log_hook_decision` now calls on every single
+    // PreToolUse hook invocation — `hook_rewrite_params()` (called earlier in the
+    // same hook invocation, via `get_rewritten`) already reads config too, so
+    // without caching that's two full disk-read-plus-TOML-parse round trips per
+    // Bash tool call instead of one.
+    if let Some(db_path) = crate::core::config::cached_config()
+        .tracking
+        .database_path
+        .clone()
+    {
+        return Ok(db_path);
     }
 
     // Priority 3: Default platform-specific location

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -131,16 +131,24 @@ impl HookOutcome {
     pub fn is_covered(self) -> bool {
         matches!(self, HookOutcome::Allow | HookOutcome::Ask)
     }
-}
 
-impl std::fmt::Display for HookOutcome {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(match self {
+    /// The `'static` string this variant serializes to in the `hook_decisions`
+    /// table. Exists so `record_hook_decision` can bind it directly as a param
+    /// (rusqlite accepts `&str`) instead of heap-allocating via `.to_string()` on
+    /// every single hook invocation for what's always one of four literals.
+    fn as_str(self) -> &'static str {
+        match self {
             HookOutcome::Allow => "allow",
             HookOutcome::Ask => "ask",
             HookOutcome::Deny => "deny",
             HookOutcome::Defer => "defer",
-        })
+        }
+    }
+}
+
+impl std::fmt::Display for HookOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 
@@ -621,13 +629,22 @@ impl Tracker {
                 tool_use_id,
                 project_path,
                 raw_cmd,
-                decision.to_string(),
+                decision.as_str(),
                 rewritten_cmd,
                 rtk_version,
             ],
         )
         .inspect_err(|e| warn_if_missing_table("record_hook_decision", e))?;
-        self.maybe_cleanup_hook_decisions(tool_use_id)?;
+
+        // The INSERT above already committed as its own autocommit statement —
+        // whatever happens to the retention sweep must not be reported as if it
+        // were *this* write failing (a caller like `log_hook_decision` prints
+        // "hook_decisions logging failed" on `Err`, which would be a lie here:
+        // the decision genuinely was recorded and is readable by `rtk discover`).
+        // Best-effort only, same as the rest of this best-effort side channel.
+        if let Err(e) = self.maybe_cleanup_hook_decisions(tool_use_id) {
+            eprintln!("rtk: warning: hook_decisions retention sweep failed: {e}");
+        }
         Ok(())
     }
 
@@ -671,14 +688,16 @@ impl Tracker {
              FROM hook_decisions
              WHERE timestamp >= ?1",
         )?;
-        let rows = stmt
-            .query_map(params![cutoff.to_rfc3339()], |row| {
-                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-            })?
-            .collect::<Result<Vec<_>, _>>()?;
+        let rows = stmt.query_map(params![cutoff.to_rfc3339()], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?;
 
-        let mut out = HashMap::with_capacity(rows.len());
-        for (tool_use_id, decision) in rows {
+        // Single pass: insert directly instead of collecting into an intermediate
+        // Vec first and looping over that separately — this scales with
+        // hook_decisions table size and runs once per `rtk discover` invocation.
+        let mut out = HashMap::new();
+        for row in rows {
+            let (tool_use_id, decision) = row?;
             // Skip rows with an unrecognized decision string (e.g. written by a
             // future rtk version with a decision this build doesn't know) rather
             // than failing the whole query — `discover` just falls back to its
@@ -690,10 +709,17 @@ impl Tracker {
         Ok(out)
     }
 
-    /// Earliest timestamp any hook decision was logged, if any exist.
+    /// Earliest timestamp among *currently-retained* hook decision rows, if any
+    /// exist. NOT the date logging first began: `hook_decisions` is pruned by the
+    /// same `DEFAULT_HISTORY_DAYS` window as the rest of the tracking DB (see
+    /// `cleanup_hook_decisions`), so this rolls forward over time — on a
+    /// long-running install it settles at roughly "now minus `DEFAULT_HISTORY_DAYS`",
+    /// not the true install date.
     ///
-    /// Used to tell `rtk discover` where the "measured" window starts — any scan
-    /// range before this point falls back to the estimate-based heuristic.
+    /// Used to tell `rtk discover` where the "measured" window currently starts —
+    /// any scan range before this point falls back to the estimate-based heuristic,
+    /// permanently (not just transitionally), since retention keeps pruning the
+    /// tail as new rows come in.
     pub fn earliest_hook_decision_timestamp(&self) -> Result<Option<DateTime<Utc>>> {
         let ts: Option<String> =
             self.conn
@@ -1469,11 +1495,19 @@ pub(crate) fn get_db_path() -> Result<PathBuf> {
         return Ok(PathBuf::from(custom_path));
     }
 
-    // Priority 2: Configuration file
-    if let Ok(config) = crate::core::config::Config::load() {
-        if let Some(db_path) = config.tracking.database_path {
-            return Ok(db_path);
-        }
+    // Priority 2: Configuration file. Reads the process-wide cached config (see
+    // `config::cached_config`), not a fresh `Config::load()`: this runs inside
+    // `Tracker::new()`, which `log_hook_decision` now calls on every single
+    // PreToolUse hook invocation — `hook_rewrite_params()` (called earlier in the
+    // same hook invocation, via `get_rewritten`) already reads config too, so
+    // without caching that's two full disk-read-plus-TOML-parse round trips per
+    // Bash tool call instead of one.
+    if let Some(db_path) = crate::core::config::cached_config()
+        .tracking
+        .database_path
+        .clone()
+    {
+        return Ok(db_path);
     }
 
     // Priority 3: Default platform-specific location

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -398,6 +398,23 @@ fn run_schema_migrations(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+/// Warn the user when a tracking-DB write fails because a table is missing.
+///
+/// Migrations only run once per database (gated by `SCHEMA_VERSION`/
+/// `user_version` in `Tracker::new()`), so if a table is dropped or corrupted
+/// out-of-band (manual `sqlite3` surgery, disk issue, partial restore) after
+/// `user_version` is already current, it silently stays missing forever —
+/// there's no automatic re-migration to fall back on the way there used to be
+/// when every open re-ran the full schema unconditionally. Point the user at
+/// the fix instead of failing silently.
+fn warn_if_missing_table(context: &str, err: &rusqlite::Error) {
+    if err.to_string().contains("no such table") {
+        eprintln!(
+            "rtk: tracking database looks corrupted ({context}: {err}). Run `rtk init` to recreate it."
+        );
+    }
+}
+
 impl Tracker {
     /// Create a new tracker instance.
     ///
@@ -422,47 +439,9 @@ impl Tracker {
     /// # Ok::<(), anyhow::Error>(())
     /// ```
     pub fn new() -> Result<Self> {
-        let db_path = get_db_path()?;
-        if let Some(parent) = db_path.parent() {
-            crate::core::utils::create_private_dir(parent)?;
-        }
-
-        // Create the file ourselves so SQLite derives the -wal/-shm modes from
-        // an already-private DB instead of the umask.
-        crate::core::utils::open_private(
-            std::fs::OpenOptions::new().write(true).create(true),
-            &db_path,
-        )
-        .with_context(|| {
-            format!(
-                "Failed to pre-create private DB file: {}",
-                db_path.display()
-            )
-        })?;
-
-        let conn = Connection::open(&db_path)?;
-        // WAL mode + busy_timeout for concurrent access (multiple Claude Code instances).
-        // Non-fatal: NFS/read-only filesystems may not support WAL. Cheap on every
-        // open (WAL mode persists in the DB file; busy_timeout is a per-connection
-        // in-memory setting), so these stay unconditional.
-        let _ = conn.execute_batch(
-            "PRAGMA journal_mode=WAL;
-             PRAGMA busy_timeout=5000;",
-        );
-
-        // Schema creation/migration is comparatively expensive (several CREATE
-        // TABLE/INDEX/ALTER statements plus a table scan) and `Tracker::new()` is
-        // called on every `rtk <cmd>` invocation and every PreToolUse hook call, so
-        // gate it behind a single cheap `user_version` read instead of re-running it
-        // every time.
-        let current_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-        if current_version < SCHEMA_VERSION {
-            run_schema_migrations(&conn)?;
-        }
-
-        restrict_db_files(&db_path);
-
-        Ok(Self { conn })
+        Ok(Self {
+            conn: open_and_prepare(MigrationMode::GatedByVersion)?,
+        })
     }
 
     /// Create an isolated in-memory tracker for tests.
@@ -591,7 +570,8 @@ impl Tracker {
                 pct,
                 exec_time_ms as i64
             ],
-        )?;
+        )
+        .inspect_err(|e| warn_if_missing_table("record", e))?;
 
         self.cleanup_old()?;
         Ok(())
@@ -644,7 +624,8 @@ impl Tracker {
                 error_message,
                 fallback_succeeded as i32,
             ],
-        )?;
+        )
+        .inspect_err(|e| warn_if_missing_table("record_parse_failure", e))?;
         self.cleanup_old()?;
         Ok(())
     }
@@ -680,7 +661,8 @@ impl Tracker {
                 rewritten_cmd,
                 rtk_version,
             ],
-        )?;
+        )
+        .inspect_err(|e| warn_if_missing_table("record_hook_decision", e))?;
         Ok(())
     }
 
@@ -1508,6 +1490,77 @@ pub(crate) fn get_db_path() -> Result<PathBuf> {
     Ok(data_dir.join(RTK_DATA_DIR).join(HISTORY_DB))
 }
 
+/// Whether to gate schema migrations behind `user_version` (the hot-path
+/// default) or always re-run them (used by `rtk init`, which isn't a hot path
+/// and wants to self-heal a dropped/corrupted table — see `ensure_schema_fresh`).
+enum MigrationMode {
+    GatedByVersion,
+    Always,
+}
+
+/// Open (creating if needed) the tracking DB, apply pragmas, and run schema
+/// migrations per `mode`. Shared by `Tracker::new()` (hot path, gated) and
+/// `ensure_schema_fresh` (`rtk init`, unconditional).
+fn open_and_prepare(mode: MigrationMode) -> Result<Connection> {
+    let db_path = get_db_path()?;
+    if let Some(parent) = db_path.parent() {
+        crate::core::utils::create_private_dir(parent)?;
+    }
+
+    // Create the file ourselves so SQLite derives the -wal/-shm modes from
+    // an already-private DB instead of the umask.
+    crate::core::utils::open_private(
+        std::fs::OpenOptions::new().write(true).create(true),
+        &db_path,
+    )
+    .with_context(|| {
+        format!(
+            "Failed to pre-create private DB file: {}",
+            db_path.display()
+        )
+    })?;
+
+    let conn = Connection::open(&db_path)?;
+    // WAL mode + busy_timeout for concurrent access (multiple Claude Code instances).
+    // Non-fatal: NFS/read-only filesystems may not support WAL. Cheap on every
+    // open (WAL mode persists in the DB file; busy_timeout is a per-connection
+    // in-memory setting), so these stay unconditional.
+    let _ = conn.execute_batch(
+        "PRAGMA journal_mode=WAL;
+         PRAGMA busy_timeout=5000;",
+    );
+
+    match mode {
+        MigrationMode::Always => run_schema_migrations(&conn)?,
+        MigrationMode::GatedByVersion => {
+            // Schema creation/migration is comparatively expensive (several CREATE
+            // TABLE/INDEX/ALTER statements plus a table scan) and `Tracker::new()` is
+            // called on every `rtk <cmd>` invocation and every PreToolUse hook call, so
+            // gate it behind a single cheap `user_version` read instead of re-running it
+            // every time.
+            let current_version: i64 =
+                conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+            if current_version < SCHEMA_VERSION {
+                run_schema_migrations(&conn)?;
+            }
+        }
+    }
+
+    restrict_db_files(&db_path);
+
+    Ok(conn)
+}
+
+/// Unconditionally re-run schema migrations, bypassing the `user_version` gate
+/// `Tracker::new()` uses on its hot path. Meant to be called from `rtk init`
+/// (not a hot path): this both pre-warms the schema during install/upgrade and
+/// self-heals a table dropped/corrupted out-of-band after `user_version` was
+/// already stamped current (see `warn_if_missing_table`) — `CREATE TABLE IF NOT
+/// EXISTS`/`ALTER TABLE` are additive, so existing history is left untouched.
+pub fn ensure_schema_fresh() -> Result<()> {
+    open_and_prepare(MigrationMode::Always).map(|_| ())
+}
+
 /// Individual parse failure record.
 #[derive(Debug)]
 pub struct ParseFailureRecord {
@@ -1695,6 +1748,14 @@ pub fn args_display(args: &[OsString]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// Serializes tests that mutate the process-global `RTK_DB_PATH` env var.
+    /// Must be a single shared static: a `static` declared inside each test
+    /// function body is a distinct static per function, not a shared lock, so
+    /// tests using separate locals don't actually serialize against each other
+    /// and can race on the same global env var under parallel `cargo test`.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     // 1. estimate_tokens — verify ~4 chars/token ratio
     #[test]
@@ -1823,8 +1884,6 @@ mod tests {
     #[test]
     fn test_db_path_env_and_default() {
         use std::env;
-        use std::sync::Mutex;
-        static ENV_LOCK: Mutex<()> = Mutex::new(());
         let _guard = ENV_LOCK.lock().unwrap();
 
         let custom_path = env::temp_dir().join("rtk_test_custom.db");
@@ -1847,8 +1906,6 @@ mod tests {
     #[test]
     fn test_schema_migration_gated_by_user_version() {
         use std::env;
-        use std::sync::Mutex;
-        static ENV_LOCK: Mutex<()> = Mutex::new(());
         let _guard = ENV_LOCK.lock().unwrap();
 
         let db_path =
@@ -1872,6 +1929,53 @@ mod tests {
             .expect("commands table should already exist and accept writes");
 
         env::remove_var("RTK_DB_PATH");
+        let _ = std::fs::remove_file(&db_path);
+    }
+
+    // 8c. Re-running run_schema_migrations() unconditionally (what
+    // ensure_schema_fresh()/MigrationMode::Always does, vs. Tracker::new()'s
+    // gated hot path) recreates a table dropped out-of-band, even though
+    // user_version is already at SCHEMA_VERSION. This is the self-heal `rtk
+    // init` relies on instead of a dedicated repair flag.
+    //
+    // Exercises the migration function directly on its own throwaway on-disk
+    // connection rather than going through ensure_schema_fresh()/Tracker::new()
+    // (which read the process-global RTK_DB_PATH env var): this test doesn't
+    // need the ENV_LOCK serialization those need, and — critically — never
+    // leaves the *shared default* tracking DB in a dropped-table state where
+    // an unrelated, concurrently-running test that opens Tracker::new()
+    // without its own RTK_DB_PATH override could observe it.
+    #[test]
+    fn test_run_schema_migrations_heals_dropped_table_when_forced() {
+        let db_path = std::env::temp_dir().join(format!(
+            "rtk_test_heal_migrations_{}.db",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&db_path);
+        let conn = Connection::open(&db_path).expect("open should succeed");
+
+        run_schema_migrations(&conn).expect("first migration run should succeed");
+        conn.execute("DROP TABLE hook_decisions", [])
+            .expect("drop should succeed");
+        assert!(
+            conn.execute(
+                "INSERT INTO hook_decisions (timestamp, session_id, tool_use_id, raw_cmd, decision, rtk_version) VALUES ('t','s','u','c','allow','0')",
+                [],
+            )
+            .is_err(),
+            "table should genuinely be gone after DROP"
+        );
+
+        // Forced re-run (what ensure_schema_fresh does) recreates it, even
+        // though user_version is already stamped to SCHEMA_VERSION.
+        run_schema_migrations(&conn).expect("forced re-run should recreate the dropped table");
+        conn.execute(
+            "INSERT INTO hook_decisions (timestamp, session_id, tool_use_id, raw_cmd, decision, rtk_version) VALUES ('t','s','u','c','allow','0')",
+            [],
+        )
+        .expect("hook_decisions table should exist and accept writes again");
+
+        drop(conn);
         let _ = std::fs::remove_file(&db_path);
     }
 

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -33,6 +33,7 @@ use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection};
 use serde::Serialize;
+use std::collections::HashMap;
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::time::Instant;
@@ -105,6 +106,72 @@ pub struct CommandRecord {
     pub saved_tokens: usize,
     /// Savings percentage ((saved / input) * 100)
     pub savings_pct: f64,
+}
+
+/// The real outcome a PreToolUse hook reached for one Bash call.
+///
+/// Shared by both ends of the `hook_decisions` log: `hooks::hook_cmd` writes it at
+/// the moment the hook actually runs, and `discover` reads it back to know whether
+/// a historical command was truly covered. `Display`/`FromStr` are the only
+/// string boundary — everywhere else this stays a typed enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookOutcome {
+    /// Rewritten and auto-allowed.
+    Allow,
+    /// Rewritten, but Claude Code still prompts the user.
+    Ask,
+    /// A deny rule matched — the hook never rewrites, defers to native deny handling.
+    Deny,
+    /// An unattestable construct (substitution, etc.) — the hook defers, no rewrite.
+    Defer,
+}
+
+impl HookOutcome {
+    /// Whether this outcome means the command was actually routed through RTK.
+    pub fn is_covered(self) -> bool {
+        matches!(self, HookOutcome::Allow | HookOutcome::Ask)
+    }
+}
+
+impl std::fmt::Display for HookOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            HookOutcome::Allow => "allow",
+            HookOutcome::Ask => "ask",
+            HookOutcome::Deny => "deny",
+            HookOutcome::Defer => "defer",
+        })
+    }
+}
+
+impl std::str::FromStr for HookOutcome {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "allow" => Ok(HookOutcome::Allow),
+            "ask" => Ok(HookOutcome::Ask),
+            "deny" => Ok(HookOutcome::Deny),
+            "defer" => Ok(HookOutcome::Defer),
+            _ => Err(()),
+        }
+    }
+}
+
+/// A single PreToolUse hook decision, logged at the moment the hook actually ran.
+///
+/// Keyed by `tool_use_id` so it can be joined 1:1 against the same id Claude Code
+/// stores on the transcript's `tool_use`/`tool_result` blocks — giving `rtk discover`
+/// ground truth about historical hook coverage instead of re-deriving a guess from
+/// today's hook-install state and registry.
+///
+/// Only carries what `discover` actually consumes (the decision). The
+/// `hook_decisions` table itself also stores `timestamp`/`raw_cmd`/`rewritten_cmd`/
+/// `rtk_version` for direct inspection (`sqlite3 tracking.db`), but nothing in Rust
+/// reads those back today — add fields here if/when something does.
+#[derive(Debug, Clone, Copy)]
+pub struct HookDecisionRecord {
+    pub decision: HookOutcome,
 }
 
 /// Aggregated statistics across all recorded commands.
@@ -336,6 +403,29 @@ impl Tracker {
             [],
         )?;
 
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS hook_decisions (
+                id INTEGER PRIMARY KEY,
+                timestamp TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                tool_use_id TEXT NOT NULL,
+                project_path TEXT DEFAULT '',
+                raw_cmd TEXT NOT NULL,
+                decision TEXT NOT NULL,
+                rewritten_cmd TEXT,
+                rtk_version TEXT NOT NULL
+            )",
+            [],
+        )?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_hook_decisions_tool_use_id ON hook_decisions(tool_use_id)",
+            [],
+        )?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_hook_decisions_timestamp ON hook_decisions(timestamp)",
+            [],
+        )?;
+
         restrict_db_files(&db_path);
 
         Ok(Self { conn })
@@ -387,6 +477,28 @@ impl Tracker {
         )?;
         self.conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_pf_timestamp ON parse_failures(timestamp)",
+            [],
+        )?;
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS hook_decisions (
+                id INTEGER PRIMARY KEY,
+                timestamp TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                tool_use_id TEXT NOT NULL,
+                project_path TEXT DEFAULT '',
+                raw_cmd TEXT NOT NULL,
+                decision TEXT NOT NULL,
+                rewritten_cmd TEXT,
+                rtk_version TEXT NOT NULL
+            )",
+            [],
+        )?;
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_hook_decisions_tool_use_id ON hook_decisions(tool_use_id)",
+            [],
+        )?;
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_hook_decisions_timestamp ON hook_decisions(timestamp)",
             [],
         )?;
         Ok(())
@@ -461,16 +573,21 @@ impl Tracker {
             "DELETE FROM parse_failures WHERE timestamp < ?1",
             params![cutoff.to_rfc3339()],
         )?;
+        self.conn.execute(
+            "DELETE FROM hook_decisions WHERE timestamp < ?1",
+            params![cutoff.to_rfc3339()],
+        )?;
         Ok(())
     }
 
-    /// Delete all tracked data (commands + parse_failures), resetting all stats to zero.
+    /// Delete all tracked data (commands + parse_failures + hook_decisions), resetting all stats to zero.
     pub fn reset_all(&self) -> Result<()> {
         self.conn
             .execute_batch(
                 "BEGIN;
                  DELETE FROM commands;
                  DELETE FROM parse_failures;
+                 DELETE FROM hook_decisions;
                  COMMIT;",
             )
             .context("Failed to reset tracking database")?;
@@ -496,6 +613,88 @@ impl Tracker {
         )?;
         self.cleanup_old()?;
         Ok(())
+    }
+
+    /// Record a PreToolUse hook decision at the moment the hook actually ran.
+    ///
+    /// `decision` must be one of `"allow"`, `"ask"`, `"deny"`, `"defer"`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_hook_decision(
+        &self,
+        session_id: &str,
+        tool_use_id: &str,
+        project_path: &str,
+        raw_cmd: &str,
+        decision: HookOutcome,
+        rewritten_cmd: Option<&str>,
+        rtk_version: &str,
+    ) -> Result<()> {
+        self.conn.execute(
+            "INSERT INTO hook_decisions (timestamp, session_id, tool_use_id, project_path, raw_cmd, decision, rewritten_cmd, rtk_version)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                Utc::now().to_rfc3339(),
+                session_id,
+                tool_use_id,
+                project_path,
+                raw_cmd,
+                decision.to_string(),
+                rewritten_cmd,
+                rtk_version,
+            ],
+        )?;
+        self.cleanup_old()?;
+        Ok(())
+    }
+
+    /// Bulk-fetch every hook decision at or after `cutoff`, keyed by `tool_use_id`.
+    ///
+    /// Meant to be called once per `rtk discover` run (mirroring the existing
+    /// single `Config::load()`/`hook_status()` snapshot pattern), so per-command
+    /// lookups during the scan loop are in-memory instead of one query each.
+    pub fn hook_decisions_since(
+        &self,
+        cutoff: DateTime<Utc>,
+    ) -> Result<HashMap<String, HookDecisionRecord>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT tool_use_id, decision
+             FROM hook_decisions
+             WHERE timestamp >= ?1",
+        )?;
+        let rows = stmt
+            .query_map(params![cutoff.to_rfc3339()], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let mut out = HashMap::with_capacity(rows.len());
+        for (tool_use_id, decision) in rows {
+            // Skip rows with an unrecognized decision string (e.g. written by a
+            // future rtk version with a decision this build doesn't know) rather
+            // than failing the whole query — `discover` just falls back to its
+            // estimate heuristic for that command.
+            if let Ok(decision) = decision.parse::<HookOutcome>() {
+                out.insert(tool_use_id, HookDecisionRecord { decision });
+            }
+        }
+        Ok(out)
+    }
+
+    /// Earliest timestamp any hook decision was logged, if any exist.
+    ///
+    /// Used to tell `rtk discover` where the "measured" window starts — any scan
+    /// range before this point falls back to the estimate-based heuristic.
+    pub fn earliest_hook_decision_timestamp(&self) -> Result<Option<DateTime<Utc>>> {
+        let ts: Option<String> =
+            self.conn
+                .query_row("SELECT MIN(timestamp) FROM hook_decisions", [], |row| {
+                    row.get(0)
+                })?;
+        Ok(ts.and_then(|t| {
+            DateTime::parse_from_rfc3339(&t)
+                .ok()
+                .map(|dt| dt.with_timezone(&Utc))
+        }))
     }
 
     /// Get parse failure summary for `rtk gain --failures`.
@@ -1757,5 +1956,126 @@ mod tests {
             let mode = std::fs::metadata(p).expect("metadata").permissions().mode() & 0o777;
             assert_eq!(mode, 0o600, "expected 0600 on {}", p.display());
         }
+    }
+
+    // rtk-ai/rtk#3148: ground-truth hook-decision logging, so `discover` can join
+    // real hook outcomes back to transcript entries by `tool_use_id` instead of
+    // re-deriving a guess from today's hook/config state.
+    #[test]
+    fn test_record_and_lookup_hook_decision_by_tool_use_id() {
+        let tracker = Tracker::new_in_memory().expect("Failed to create in-memory tracker");
+
+        tracker
+            .record_hook_decision(
+                "session-1",
+                "toolu_abc123",
+                "/home/user/project",
+                "git status",
+                HookOutcome::Allow,
+                Some("rtk git status"),
+                "0.42.4",
+            )
+            .expect("Failed to record hook decision");
+
+        let cutoff = Utc::now() - chrono::Duration::days(1);
+        let log = tracker
+            .hook_decisions_since(cutoff)
+            .expect("Failed to query hook decisions");
+
+        let record = log
+            .get("toolu_abc123")
+            .expect("record not found by tool_use_id");
+        assert_eq!(record.decision, HookOutcome::Allow);
+
+        // The other columns aren't exposed on HookDecisionRecord (nothing in Rust
+        // reads them back yet), but they must still be persisted correctly for
+        // direct DB inspection.
+        let (raw_cmd, rewritten_cmd, rtk_version): (String, Option<String>, String) = tracker
+            .conn
+            .query_row(
+                "SELECT raw_cmd, rewritten_cmd, rtk_version FROM hook_decisions WHERE tool_use_id = ?1",
+                params!["toolu_abc123"],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("row not found");
+        assert_eq!(raw_cmd, "git status");
+        assert_eq!(rewritten_cmd.as_deref(), Some("rtk git status"));
+        assert_eq!(rtk_version, "0.42.4");
+    }
+
+    #[test]
+    fn test_hook_decisions_since_excludes_older_rows() {
+        let tracker = Tracker::new_in_memory().expect("Failed to create in-memory tracker");
+
+        tracker
+            .record_hook_decision(
+                "session-1",
+                "toolu_old",
+                "",
+                "git status",
+                HookOutcome::Deny,
+                None,
+                "0.42.4",
+            )
+            .expect("Failed to record hook decision");
+
+        // Cutoff in the future — the row above should not appear.
+        let cutoff = Utc::now() + chrono::Duration::days(1);
+        let log = tracker
+            .hook_decisions_since(cutoff)
+            .expect("Failed to query hook decisions");
+
+        assert!(!log.contains_key("toolu_old"));
+    }
+
+    #[test]
+    fn test_earliest_hook_decision_timestamp() {
+        let tracker = Tracker::new_in_memory().expect("Failed to create in-memory tracker");
+
+        assert!(tracker
+            .earliest_hook_decision_timestamp()
+            .expect("query failed")
+            .is_none());
+
+        tracker
+            .record_hook_decision(
+                "s",
+                "toolu_1",
+                "",
+                "ls",
+                HookOutcome::Allow,
+                Some("rtk ls"),
+                "0.42.4",
+            )
+            .expect("Failed to record hook decision");
+
+        assert!(tracker
+            .earliest_hook_decision_timestamp()
+            .expect("query failed")
+            .is_some());
+    }
+
+    #[test]
+    fn test_reset_all_clears_hook_decisions() {
+        let tracker = Tracker::new_in_memory().expect("Failed to create in-memory tracker");
+
+        tracker
+            .record_hook_decision(
+                "s",
+                "toolu_1",
+                "",
+                "ls",
+                HookOutcome::Allow,
+                Some("rtk ls"),
+                "0.42.4",
+            )
+            .expect("Failed to record hook decision");
+
+        tracker.reset_all().expect("Failed to reset");
+
+        assert!(tracker
+            .earliest_hook_decision_timestamp()
+            .expect("query failed")
+            .is_none());
     }
 }

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -1720,13 +1720,15 @@ mod tests {
     // 3. Tracker::record + get_recent — round-trip DB
     #[test]
     fn test_tracker_record_and_recent() {
-        let tracker = Tracker::new().expect("Failed to create tracker");
+        // In-memory: isolated per-test DB, immune to the shared on-disk DB's
+        // cross-test races under parallel `cargo test` (see get_recent(N) racing
+        // against concurrent inserts from other tests hitting the same file).
+        let tracker = Tracker::new_in_memory().expect("Failed to create tracker");
 
-        // Use unique test identifier to avoid conflicts with other tests
-        let test_cmd = format!("rtk git status test_{}", std::process::id());
+        let test_cmd = "rtk git status test";
 
         tracker
-            .record("git status", &test_cmd, 100, 20, 50)
+            .record("git status", test_cmd, 100, 20, 50)
             .expect("Failed to record");
 
         let recent = tracker.get_recent(10).expect("Failed to get recent");
@@ -1744,21 +1746,20 @@ mod tests {
     // 4. track_passthrough doesn't dilute stats (input=0, output=0)
     #[test]
     fn test_track_passthrough_no_dilution() {
-        let tracker = Tracker::new().expect("Failed to create tracker");
+        // In-memory: isolated per-test DB, see test_tracker_record_and_recent.
+        let tracker = Tracker::new_in_memory().expect("Failed to create tracker");
 
-        // Use unique test identifiers
-        let pid = std::process::id();
-        let cmd1 = format!("rtk cmd1_test_{}", pid);
-        let cmd2 = format!("rtk cmd2_passthrough_test_{}", pid);
+        let cmd1 = "rtk cmd1_test";
+        let cmd2 = "rtk cmd2_passthrough_test";
 
         // Record one real command with 80% savings
         tracker
-            .record("cmd1", &cmd1, 1000, 200, 10)
+            .record("cmd1", cmd1, 1000, 200, 10)
             .expect("Failed to record cmd1");
 
         // Record passthrough (0, 0)
         tracker
-            .record("cmd2", &cmd2, 0, 0, 5)
+            .record("cmd2", cmd2, 0, 0, 5)
             .expect("Failed to record passthrough");
 
         // Verify both records exist in recent history
@@ -1786,8 +1787,24 @@ mod tests {
     }
 
     // 5. TimedExecution::track records with exec_time > 0
+    //
+    // TimedExecution::track() hardcodes Tracker::new() internally (real
+    // on-disk DB via get_db_path()), so it can't take an in-memory tracker
+    // like the tests above. Point RTK_DB_PATH at a private temp file instead —
+    // otherwise get_recent(5) races against every other test concurrently
+    // inserting into the same shared default DB and can miss this test's own
+    // record once 5+ other rows land first.
     #[test]
     fn test_timed_execution_records_time() {
+        use std::env;
+        let _guard = ENV_LOCK.lock().unwrap();
+        let db_path = env::temp_dir().join(format!(
+            "rtk_test_timed_exec_records_{}.db",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&db_path);
+        env::set_var("RTK_DB_PATH", &db_path);
+
         let timer = TimedExecution::start();
         std::thread::sleep(std::time::Duration::from_millis(10));
         timer.track("test cmd", "rtk test", "raw input data", "filtered");
@@ -1796,11 +1813,25 @@ mod tests {
         let tracker = Tracker::new().expect("Failed to create tracker");
         let recent = tracker.get_recent(5).expect("Failed to get recent");
         assert!(recent.iter().any(|r| r.rtk_cmd == "rtk test"));
+
+        drop(tracker);
+        env::remove_var("RTK_DB_PATH");
+        let _ = std::fs::remove_file(&db_path);
     }
 
     // 6. TimedExecution::track_passthrough records with 0 tokens
+    // Same isolation rationale as test_timed_execution_records_time above.
     #[test]
     fn test_timed_execution_passthrough() {
+        use std::env;
+        let _guard = ENV_LOCK.lock().unwrap();
+        let db_path = env::temp_dir().join(format!(
+            "rtk_test_timed_exec_passthrough_{}.db",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&db_path);
+        env::set_var("RTK_DB_PATH", &db_path);
+
         let timer = TimedExecution::start();
         timer.track_passthrough("git tag", "rtk git tag (passthrough)");
 
@@ -1815,6 +1846,10 @@ mod tests {
         // savings_pct should be 0 for passthrough
         assert_eq!(pt.savings_pct, 0.0);
         assert_eq!(pt.saved_tokens, 0);
+
+        drop(tracker);
+        env::remove_var("RTK_DB_PATH");
+        let _ = std::fs::remove_file(&db_path);
     }
 
     // 7. get_db_path respects environment variable RTK_DB_PATH
@@ -1959,11 +1994,12 @@ mod tests {
     // 12. record_parse_failure + get_parse_failure_summary roundtrip
     #[test]
     fn test_parse_failure_roundtrip() {
-        let tracker = Tracker::new().expect("Failed to create tracker");
-        let test_cmd = format!("git -C /path status test_{}", std::process::id());
+        // In-memory: isolated per-test DB, see test_tracker_record_and_recent.
+        let tracker = Tracker::new_in_memory().expect("Failed to create tracker");
+        let test_cmd = "git -C /path status test";
 
         tracker
-            .record_parse_failure(&test_cmd, "unrecognized subcommand", true)
+            .record_parse_failure(test_cmd, "unrecognized subcommand", true)
             .expect("Failed to record parse failure");
 
         let summary = tracker
@@ -1977,24 +2013,23 @@ mod tests {
     // 13. recovery_rate calculation
     #[test]
     fn test_parse_failure_recovery_rate() {
-        let tracker = Tracker::new().expect("Failed to create tracker");
-        let pid = std::process::id();
+        // In-memory: isolated per-test DB, see test_tracker_record_and_recent.
+        let tracker = Tracker::new_in_memory().expect("Failed to create tracker");
 
         // 2 successes, 1 failure
         tracker
-            .record_parse_failure(&format!("cmd_ok1_{}", pid), "err", true)
+            .record_parse_failure("cmd_ok1", "err", true)
             .unwrap();
         tracker
-            .record_parse_failure(&format!("cmd_ok2_{}", pid), "err", true)
+            .record_parse_failure("cmd_ok2", "err", true)
             .unwrap();
         tracker
-            .record_parse_failure(&format!("cmd_fail_{}", pid), "err", false)
+            .record_parse_failure("cmd_fail", "err", false)
             .unwrap();
 
         let summary = tracker.get_parse_failure_summary().unwrap();
-        // We can't assert exact rate because other tests may have added records,
-        // but we can verify recovery_rate is between 0 and 100
-        assert!(summary.recovery_rate >= 0.0 && summary.recovery_rate <= 100.0);
+        // Isolated DB, so the rate is now exact: 2/3 successes ≈ 66.7%.
+        assert!((summary.recovery_rate - 66.7).abs() < 0.1);
     }
 
     #[test]

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -415,14 +415,25 @@ fn warn_if_missing_table(context: &str, err: &rusqlite::Error) {
     }
 }
 
-/// Pure core of `Tracker::maybe_cleanup_hook_decisions`'s sampling decision, taking
-/// the nanosecond reading directly so it's deterministically testable without
-/// waiting on a real 1-in-`rate` chance. Doesn't need to be cryptographically
-/// random, just cheap and not obviously correlated with call timing — reusing the
-/// wall-clock read the caller already pays for avoids pulling in a `rand`
-/// dependency just for a sampling backstop.
-fn should_sample_cleanup(nanos: u32, rate: u32) -> bool {
-    nanos.is_multiple_of(rate)
+/// Pure core of `Tracker::maybe_cleanup_hook_decisions`'s sampling decision.
+///
+/// Hashes `key` (the call's `tool_use_id`, always distinct per hook invocation)
+/// rather than reading the wall clock: a nanosecond-based sample (an earlier
+/// version of this used `Utc::now().timestamp_subsec_nanos() % rate`) silently
+/// breaks on any clock source whose resolution isn't fine enough to hit every
+/// residue mod `rate` — e.g. a coarse virtualized/Windows timer ticking in
+/// large, evenly-divisible steps could make the check fire on nearly 100% of
+/// calls (defeating the sampling entirely) or effectively 0% (undoing the
+/// backstop against unbounded growth), depending on the tick size, with no
+/// visible symptom short of profiling. Doesn't need to be cryptographically
+/// random, just cheap and evenly distributed across calls — `DefaultHasher`
+/// over an already-unique string avoids pulling in a `rand` dependency just for
+/// a sampling backstop.
+fn should_sample_cleanup(key: &str, rate: u32) -> bool {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    key.hash(&mut hasher);
+    hasher.finish().is_multiple_of(rate as u64)
 }
 
 impl Tracker {
@@ -616,7 +627,7 @@ impl Tracker {
             ],
         )
         .inspect_err(|e| warn_if_missing_table("record_hook_decision", e))?;
-        self.maybe_cleanup_hook_decisions()?;
+        self.maybe_cleanup_hook_decisions(tool_use_id)?;
         Ok(())
     }
 
@@ -626,12 +637,9 @@ impl Tracker {
     /// commands are mostly `Deny`/`Defer`'d — and so rarely trigger `record()`'s or
     /// `record_parse_failure()`'s own cleanup — without paying a DELETE on every
     /// single hook invocation.
-    fn maybe_cleanup_hook_decisions(&self) -> Result<()> {
+    fn maybe_cleanup_hook_decisions(&self, tool_use_id: &str) -> Result<()> {
         const HOOK_DECISIONS_CLEANUP_SAMPLE_RATE: u32 = 500;
-        if !should_sample_cleanup(
-            Utc::now().timestamp_subsec_nanos(),
-            HOOK_DECISIONS_CLEANUP_SAMPLE_RATE,
-        ) {
+        if !should_sample_cleanup(tool_use_id, HOOK_DECISIONS_CLEANUP_SAMPLE_RATE) {
             return Ok(());
         }
         self.cleanup_hook_decisions()
@@ -1489,21 +1497,30 @@ fn open_and_prepare(mode: MigrationMode) -> Result<Connection> {
 
     // `create_private_dir` is cheap even when the directory already exists (its own
     // chmod is a no-op past the first call — see `utils::set_owner_only`), so it
-    // stays unconditional. The pre-create-and-chmod-the-file dance below is a
-    // genuinely separate open()/close() pair from the `Connection::open` right
-    // after it, so it's skipped once the file already exists — it only matters the
-    // *first* time the DB is ever created (so SQLite derives the -wal/-shm modes
-    // from an already-private DB instead of the umask). `Tracker::new()` is on the
+    // stays unconditional.
+    //
+    // For a brand-new DB, pre-create the file ourselves via `open_private` so
+    // SQLite derives the -wal/-shm modes from an already-private DB instead of the
+    // umask. For an already-existing DB, skip that pre-create's own redundant
+    // open()/close() pair (a second file open on top of the `Connection::open`
+    // right after it) — but still re-chmod the file *before* `Connection::open`
+    // via the now-cheap `restrict_file` (a no-op stat once permissions already
+    // match), rather than only healing it via `restrict_db_files` at the very
+    // end. Skipping the pre-open heal entirely would let `Connection::open` and
+    // any migration writes touch a file whose permissions had drifted (external
+    // tampering, restored backup) before anything corrected them — the same
+    // "chmod before SQLite ever opens it" invariant the original pre-create dance
+    // provided, just without paying its extra open. `Tracker::new()` is on the
     // hot path for every `rtk <cmd>` and, since rtk-ai/rtk#3206's hook_decisions
     // ground-truth logging, every single PreToolUse hook call (not just
-    // RTK-covered ones), so this redundant open on the already-set-up common case
-    // matters for the <10ms budget. `restrict_db_files` below still runs every
-    // time to self-heal a file whose permissions somehow drifted, but is itself
-    // now a cheap no-op stat once permissions are already correct.
+    // RTK-covered ones), so avoiding that redundant open on the already-set-up
+    // common case matters for the <10ms budget.
     if let Some(parent) = db_path.parent() {
         crate::core::utils::create_private_dir(parent)?;
     }
-    if !db_path.exists() {
+    if db_path.exists() {
+        crate::core::utils::restrict_file(&db_path);
+    } else {
         crate::core::utils::open_private(
             std::fs::OpenOptions::new().write(true).create(true),
             &db_path,
@@ -2301,11 +2318,20 @@ mod tests {
 
     #[test]
     fn test_should_sample_cleanup_pure() {
-        assert!(should_sample_cleanup(0, 500));
-        assert!(should_sample_cleanup(500, 500));
-        assert!(should_sample_cleanup(1000, 500));
-        assert!(!should_sample_cleanup(1, 500));
-        assert!(!should_sample_cleanup(499, 500));
+        // Deterministic for a given key (same tool_use_id always samples the same
+        // way), and observably not "always true"/"always false" across a spread of
+        // distinct keys — the actual hit rate isn't asserted (that would pin the
+        // hash implementation), just that it's a real subset.
+        let sampled: Vec<bool> = (0..2000)
+            .map(|i| should_sample_cleanup(&format!("toolu_{i}"), 500))
+            .collect();
+        assert!(sampled.iter().any(|&s| s), "some keys should sample");
+        assert!(sampled.iter().any(|&s| !s), "most keys should not sample");
+
+        // Same key, same rate → same decision every time.
+        let a = should_sample_cleanup("toolu_stable", 500);
+        let b = should_sample_cleanup("toolu_stable", 500);
+        assert_eq!(a, b);
     }
 
     #[test]

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -415,6 +415,16 @@ fn warn_if_missing_table(context: &str, err: &rusqlite::Error) {
     }
 }
 
+/// Pure core of `Tracker::maybe_cleanup_hook_decisions`'s sampling decision, taking
+/// the nanosecond reading directly so it's deterministically testable without
+/// waiting on a real 1-in-`rate` chance. Doesn't need to be cryptographically
+/// random, just cheap and not obviously correlated with call timing — reusing the
+/// wall-clock read the caller already pays for avoids pulling in a `rand`
+/// dependency just for a sampling backstop.
+fn should_sample_cleanup(nanos: u32, rate: u32) -> bool {
+    nanos.is_multiple_of(rate)
+}
+
 impl Tracker {
     /// Create a new tracker instance.
     ///
@@ -571,11 +581,15 @@ impl Tracker {
 
     /// Record a PreToolUse hook decision at the moment the hook actually ran.
     ///
-    /// Deliberately does *not* run `cleanup_old()` — this fires on every single
-    /// Bash tool call (the hook's hot path, under the project's <10ms latency
-    /// budget), so a 3-table DELETE sweep here would tax every command, not just
-    /// RTK-covered ones. Retention for `hook_decisions` piggybacks on whatever
-    /// cadence `record()`/`record_parse_failure()` already run cleanup at.
+    /// Deliberately does *not* run the full `cleanup_old()` (which sweeps
+    /// `commands`/`parse_failures` too) unconditionally — this fires on every
+    /// single Bash tool call (the hook's hot path, under the project's <10ms
+    /// latency budget), so a 3-table DELETE sweep here would tax every command,
+    /// not just RTK-covered ones. Retention mostly piggybacks on whatever cadence
+    /// `record()`/`record_parse_failure()` already run cleanup at, but a user whose
+    /// commands are almost entirely `Deny`/`Defer`'d may rarely trigger either of
+    /// those, so `hook_decisions` alone still gets a `maybe_cleanup_hook_decisions`
+    /// sweep — sampled, not every call — as a backstop against unbounded growth.
     #[allow(clippy::too_many_arguments)]
     pub fn record_hook_decision(
         &self,
@@ -602,6 +616,36 @@ impl Tracker {
             ],
         )
         .inspect_err(|e| warn_if_missing_table("record_hook_decision", e))?;
+        self.maybe_cleanup_hook_decisions()?;
+        Ok(())
+    }
+
+    /// Sampled retention sweep for `hook_decisions` alone (not the full 3-table
+    /// `cleanup_old()`), run on roughly 1-in-`HOOK_DECISIONS_CLEANUP_SAMPLE_RATE`
+    /// calls to `record_hook_decision`. Bounds the table's growth for a user whose
+    /// commands are mostly `Deny`/`Defer`'d — and so rarely trigger `record()`'s or
+    /// `record_parse_failure()`'s own cleanup — without paying a DELETE on every
+    /// single hook invocation.
+    fn maybe_cleanup_hook_decisions(&self) -> Result<()> {
+        const HOOK_DECISIONS_CLEANUP_SAMPLE_RATE: u32 = 500;
+        if !should_sample_cleanup(
+            Utc::now().timestamp_subsec_nanos(),
+            HOOK_DECISIONS_CLEANUP_SAMPLE_RATE,
+        ) {
+            return Ok(());
+        }
+        self.cleanup_hook_decisions()
+    }
+
+    /// The actual `hook_decisions` DELETE sweep, split out from
+    /// `maybe_cleanup_hook_decisions` so it's directly callable (bypassing the
+    /// sampling gate) from tests without needing to hit the 1-in-N chance for real.
+    fn cleanup_hook_decisions(&self) -> Result<()> {
+        let cutoff = Utc::now() - chrono::Duration::days(DEFAULT_HISTORY_DAYS);
+        self.conn.execute(
+            "DELETE FROM hook_decisions WHERE timestamp < ?1",
+            params![cutoff.to_rfc3339()],
+        )?;
         Ok(())
     }
 
@@ -1442,22 +1486,35 @@ enum MigrationMode {
 /// `ensure_schema_fresh` (`rtk init`, unconditional).
 fn open_and_prepare(mode: MigrationMode) -> Result<Connection> {
     let db_path = get_db_path()?;
+
+    // `create_private_dir` is cheap even when the directory already exists (its own
+    // chmod is a no-op past the first call — see `utils::set_owner_only`), so it
+    // stays unconditional. The pre-create-and-chmod-the-file dance below is a
+    // genuinely separate open()/close() pair from the `Connection::open` right
+    // after it, so it's skipped once the file already exists — it only matters the
+    // *first* time the DB is ever created (so SQLite derives the -wal/-shm modes
+    // from an already-private DB instead of the umask). `Tracker::new()` is on the
+    // hot path for every `rtk <cmd>` and, since rtk-ai/rtk#3206's hook_decisions
+    // ground-truth logging, every single PreToolUse hook call (not just
+    // RTK-covered ones), so this redundant open on the already-set-up common case
+    // matters for the <10ms budget. `restrict_db_files` below still runs every
+    // time to self-heal a file whose permissions somehow drifted, but is itself
+    // now a cheap no-op stat once permissions are already correct.
     if let Some(parent) = db_path.parent() {
         crate::core::utils::create_private_dir(parent)?;
     }
-
-    // Create the file ourselves so SQLite derives the -wal/-shm modes from
-    // an already-private DB instead of the umask.
-    crate::core::utils::open_private(
-        std::fs::OpenOptions::new().write(true).create(true),
-        &db_path,
-    )
-    .with_context(|| {
-        format!(
-            "Failed to pre-create private DB file: {}",
-            db_path.display()
+    if !db_path.exists() {
+        crate::core::utils::open_private(
+            std::fs::OpenOptions::new().write(true).create(true),
+            &db_path,
         )
-    })?;
+        .with_context(|| {
+            format!(
+                "Failed to pre-create private DB file: {}",
+                db_path.display()
+            )
+        })?;
+    }
 
     let conn = Connection::open(&db_path)?;
     // WAL mode + busy_timeout for concurrent access (multiple Claude Code instances).
@@ -2234,5 +2291,69 @@ mod tests {
             .earliest_hook_decision_timestamp()
             .expect("query failed")
             .is_none());
+    }
+
+    // rtk-ai/rtk#3206 review: hook_decisions grows unbounded for a user whose
+    // commands are mostly Deny/Defer'd, since record_hook_decision deliberately
+    // skips the full cleanup_old() sweep and those decisions rarely trigger
+    // record()/record_parse_failure()'s own cleanup. maybe_cleanup_hook_decisions
+    // is a sampled backstop against that.
+
+    #[test]
+    fn test_should_sample_cleanup_pure() {
+        assert!(should_sample_cleanup(0, 500));
+        assert!(should_sample_cleanup(500, 500));
+        assert!(should_sample_cleanup(1000, 500));
+        assert!(!should_sample_cleanup(1, 500));
+        assert!(!should_sample_cleanup(499, 500));
+    }
+
+    #[test]
+    fn test_cleanup_hook_decisions_deletes_only_stale_rows() {
+        let tracker = Tracker::new_in_memory().expect("Failed to create in-memory tracker");
+
+        // Recent row, via the real API.
+        tracker
+            .record_hook_decision(
+                "s",
+                "toolu_recent",
+                "",
+                "ls",
+                HookOutcome::Allow,
+                Some("rtk ls"),
+                "0.42.4",
+            )
+            .expect("Failed to record hook decision");
+
+        // Stale row, inserted directly: record_hook_decision always stamps
+        // Utc::now(), so there's no other way to get an old row into the table.
+        let stale_ts = (Utc::now() - chrono::Duration::days(DEFAULT_HISTORY_DAYS + 1)).to_rfc3339();
+        tracker
+            .conn
+            .execute(
+                "INSERT INTO hook_decisions (timestamp, session_id, tool_use_id, project_path, raw_cmd, decision, rewritten_cmd, rtk_version)
+                 VALUES (?1, 's', 'toolu_stale', '', 'ls', 'allow', 'rtk ls', '0.42.4')",
+                params![stale_ts],
+            )
+            .expect("Failed to insert stale row");
+
+        // Call the sweep directly, bypassing maybe_cleanup_hook_decisions' sampling
+        // gate — this test isn't exercising the sampling decision, just the DELETE.
+        tracker
+            .cleanup_hook_decisions()
+            .expect("cleanup should succeed");
+
+        let far_past = DateTime::<Utc>::MIN_UTC;
+        let all = tracker
+            .hook_decisions_since(far_past)
+            .expect("query failed");
+        assert!(
+            all.contains_key("toolu_recent"),
+            "recent row should survive cleanup"
+        );
+        assert!(
+            !all.contains_key("toolu_stale"),
+            "stale row should be deleted by cleanup"
+        );
     }
 }

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -290,6 +290,114 @@ pub struct MonthStats {
 /// Type alias for command statistics tuple: (command, count, saved_tokens, avg_savings_pct, avg_time_ms)
 type CommandStats = (String, usize, usize, f64, u64);
 
+/// Current tracking-DB schema version, stored in the SQLite `user_version` pragma.
+///
+/// `Tracker::new()` is on the hot path (every `rtk <cmd>` invocation and every
+/// PreToolUse hook call), so schema creation/migration must not re-run on every
+/// call. Bump this whenever `run_schema_migrations` gains a new statement; a stale
+/// `user_version` triggers exactly one re-run of the full migration sequence, then
+/// the pragma is updated so subsequent opens skip straight past it.
+const SCHEMA_VERSION: i64 = 1;
+
+/// Create all tables/indexes, run column migrations, and stamp `user_version` to
+/// `SCHEMA_VERSION` for the on-disk tracker DB.
+///
+/// Runs once per database, gated by `SCHEMA_VERSION` in `Tracker::new()` — not on
+/// every call, since this is otherwise on the hot path (every `rtk <cmd>` and every
+/// PreToolUse hook invocation).
+fn run_schema_migrations(conn: &Connection) -> Result<()> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS commands (
+            id INTEGER PRIMARY KEY,
+            timestamp TEXT NOT NULL,
+            original_cmd TEXT NOT NULL,
+            rtk_cmd TEXT NOT NULL,
+            input_tokens INTEGER NOT NULL,
+            output_tokens INTEGER NOT NULL,
+            saved_tokens INTEGER NOT NULL,
+            savings_pct REAL NOT NULL
+        )",
+        [],
+    )?;
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_timestamp ON commands(timestamp)",
+        [],
+    )?;
+
+    // Migration: add exec_time_ms column if it doesn't exist
+    let _ = conn.execute(
+        "ALTER TABLE commands ADD COLUMN exec_time_ms INTEGER DEFAULT 0",
+        [],
+    );
+    // Migration: add project_path column with DEFAULT '' for new rows // changed: added DEFAULT
+    let _ = conn.execute(
+        "ALTER TABLE commands ADD COLUMN project_path TEXT DEFAULT ''",
+        [],
+    );
+    // One-time migration: normalize NULLs from pre-default schema // changed: guarded with EXISTS
+    let has_nulls: bool = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM commands WHERE project_path IS NULL)",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap_or(false);
+    if has_nulls {
+        let _ = conn.execute(
+            "UPDATE commands SET project_path = '' WHERE project_path IS NULL",
+            [],
+        );
+    }
+    // Index for fast project-scoped gain queries // added
+    let _ = conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_project_path_timestamp ON commands(project_path, timestamp)",
+        [],
+    );
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS parse_failures (
+            id INTEGER PRIMARY KEY,
+            timestamp TEXT NOT NULL,
+            raw_command TEXT NOT NULL,
+            error_message TEXT NOT NULL,
+            fallback_succeeded INTEGER NOT NULL DEFAULT 0
+        )",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_pf_timestamp ON parse_failures(timestamp)",
+        [],
+    )?;
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS hook_decisions (
+            id INTEGER PRIMARY KEY,
+            timestamp TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            tool_use_id TEXT NOT NULL,
+            project_path TEXT DEFAULT '',
+            raw_cmd TEXT NOT NULL,
+            decision TEXT NOT NULL,
+            rewritten_cmd TEXT,
+            rtk_version TEXT NOT NULL
+        )",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_hook_decisions_tool_use_id ON hook_decisions(tool_use_id)",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_hook_decisions_timestamp ON hook_decisions(timestamp)",
+        [],
+    )?;
+
+    conn.pragma_update(None, "user_version", SCHEMA_VERSION)?;
+
+    Ok(())
+}
+
 impl Tracker {
     /// Create a new tracker instance.
     ///
@@ -334,97 +442,23 @@ impl Tracker {
 
         let conn = Connection::open(&db_path)?;
         // WAL mode + busy_timeout for concurrent access (multiple Claude Code instances).
-        // Non-fatal: NFS/read-only filesystems may not support WAL.
+        // Non-fatal: NFS/read-only filesystems may not support WAL. Cheap on every
+        // open (WAL mode persists in the DB file; busy_timeout is a per-connection
+        // in-memory setting), so these stay unconditional.
         let _ = conn.execute_batch(
             "PRAGMA journal_mode=WAL;
              PRAGMA busy_timeout=5000;",
         );
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS commands (
-                id INTEGER PRIMARY KEY,
-                timestamp TEXT NOT NULL,
-                original_cmd TEXT NOT NULL,
-                rtk_cmd TEXT NOT NULL,
-                input_tokens INTEGER NOT NULL,
-                output_tokens INTEGER NOT NULL,
-                saved_tokens INTEGER NOT NULL,
-                savings_pct REAL NOT NULL
-            )",
-            [],
-        )?;
 
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_timestamp ON commands(timestamp)",
-            [],
-        )?;
-
-        // Migration: add exec_time_ms column if it doesn't exist
-        let _ = conn.execute(
-            "ALTER TABLE commands ADD COLUMN exec_time_ms INTEGER DEFAULT 0",
-            [],
-        );
-        // Migration: add project_path column with DEFAULT '' for new rows // changed: added DEFAULT
-        let _ = conn.execute(
-            "ALTER TABLE commands ADD COLUMN project_path TEXT DEFAULT ''",
-            [],
-        );
-        // One-time migration: normalize NULLs from pre-default schema // changed: guarded with EXISTS
-        let has_nulls: bool = conn
-            .query_row(
-                "SELECT EXISTS(SELECT 1 FROM commands WHERE project_path IS NULL)",
-                [],
-                |row| row.get(0),
-            )
-            .unwrap_or(false);
-        if has_nulls {
-            let _ = conn.execute(
-                "UPDATE commands SET project_path = '' WHERE project_path IS NULL",
-                [],
-            );
+        // Schema creation/migration is comparatively expensive (several CREATE
+        // TABLE/INDEX/ALTER statements plus a table scan) and `Tracker::new()` is
+        // called on every `rtk <cmd>` invocation and every PreToolUse hook call, so
+        // gate it behind a single cheap `user_version` read instead of re-running it
+        // every time.
+        let current_version: i64 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+        if current_version < SCHEMA_VERSION {
+            run_schema_migrations(&conn)?;
         }
-        // Index for fast project-scoped gain queries // added
-        let _ = conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_project_path_timestamp ON commands(project_path, timestamp)",
-            [],
-        );
-
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS parse_failures (
-                id INTEGER PRIMARY KEY,
-                timestamp TEXT NOT NULL,
-                raw_command TEXT NOT NULL,
-                error_message TEXT NOT NULL,
-                fallback_succeeded INTEGER NOT NULL DEFAULT 0
-            )",
-            [],
-        )?;
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_pf_timestamp ON parse_failures(timestamp)",
-            [],
-        )?;
-
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS hook_decisions (
-                id INTEGER PRIMARY KEY,
-                timestamp TEXT NOT NULL,
-                session_id TEXT NOT NULL,
-                tool_use_id TEXT NOT NULL,
-                project_path TEXT DEFAULT '',
-                raw_cmd TEXT NOT NULL,
-                decision TEXT NOT NULL,
-                rewritten_cmd TEXT,
-                rtk_version TEXT NOT NULL
-            )",
-            [],
-        )?;
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_hook_decisions_tool_use_id ON hook_decisions(tool_use_id)",
-            [],
-        )?;
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_hook_decisions_timestamp ON hook_decisions(timestamp)",
-            [],
-        )?;
 
         restrict_db_files(&db_path);
 
@@ -617,15 +651,12 @@ impl Tracker {
 
     /// Record a PreToolUse hook decision at the moment the hook actually ran.
     ///
-    /// `decision` must be one of `"allow"`, `"ask"`, `"deny"`, `"defer"`.
-    #[allow(clippy::too_many_arguments)]
-    /// Record a PreToolUse hook decision at the moment the hook actually ran.
-    ///
     /// Deliberately does *not* run `cleanup_old()` — this fires on every single
     /// Bash tool call (the hook's hot path, under the project's <10ms latency
     /// budget), so a 3-table DELETE sweep here would tax every command, not just
     /// RTK-covered ones. Retention for `hook_decisions` piggybacks on whatever
     /// cadence `record()`/`record_parse_failure()` already run cleanup at.
+    #[allow(clippy::too_many_arguments)]
     pub fn record_hook_decision(
         &self,
         session_id: &str,
@@ -1808,6 +1839,40 @@ mod tests {
             "expected default path ending with rtk/history.db, got: {}",
             db_path.display()
         );
+    }
+
+    // 8b. Tracker::new() gates schema migration behind PRAGMA user_version, so a
+    // fresh DB gets stamped to SCHEMA_VERSION and a second open on the same file
+    // still works (and doesn't re-run/fail the migration).
+    #[test]
+    fn test_schema_migration_gated_by_user_version() {
+        use std::env;
+        use std::sync::Mutex;
+        static ENV_LOCK: Mutex<()> = Mutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap();
+
+        let db_path =
+            env::temp_dir().join(format!("rtk_test_schema_version_{}.db", std::process::id()));
+        let _ = std::fs::remove_file(&db_path);
+        env::set_var("RTK_DB_PATH", &db_path);
+
+        let tracker = Tracker::new().expect("first open should run migrations");
+        let version: i64 = tracker
+            .conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .expect("user_version should be readable");
+        assert_eq!(version, SCHEMA_VERSION);
+        drop(tracker);
+
+        // Second open on the same file must skip migrations without erroring, and
+        // the DB must still be fully usable (tables from the first open persist).
+        let tracker2 = Tracker::new().expect("second open should skip migrations cleanly");
+        tracker2
+            .record("git status", "rtk git status", 100, 20, 50)
+            .expect("commands table should already exist and accept writes");
+
+        env::remove_var("RTK_DB_PATH");
+        let _ = std::fs::remove_file(&db_path);
     }
 
     // 9. project_filter_params uses GLOB pattern with * wildcard // added

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -1802,6 +1802,7 @@ mod tests {
             "rtk_test_timed_exec_records_{}.db",
             std::process::id()
         ));
+        // nosemgrep: filesystem-deletion -- test-only cleanup of this test's own throwaway temp DB file, not production/user data.
         let _ = std::fs::remove_file(&db_path);
         env::set_var("RTK_DB_PATH", &db_path);
 
@@ -1816,6 +1817,7 @@ mod tests {
 
         drop(tracker);
         env::remove_var("RTK_DB_PATH");
+        // nosemgrep: filesystem-deletion -- test-only cleanup of this test's own throwaway temp DB file, not production/user data.
         let _ = std::fs::remove_file(&db_path);
     }
 
@@ -1829,6 +1831,7 @@ mod tests {
             "rtk_test_timed_exec_passthrough_{}.db",
             std::process::id()
         ));
+        // nosemgrep: filesystem-deletion -- test-only cleanup of this test's own throwaway temp DB file, not production/user data.
         let _ = std::fs::remove_file(&db_path);
         env::set_var("RTK_DB_PATH", &db_path);
 
@@ -1849,6 +1852,7 @@ mod tests {
 
         drop(tracker);
         env::remove_var("RTK_DB_PATH");
+        // nosemgrep: filesystem-deletion -- test-only cleanup of this test's own throwaway temp DB file, not production/user data.
         let _ = std::fs::remove_file(&db_path);
     }
 
@@ -1884,6 +1888,7 @@ mod tests {
 
         let db_path =
             env::temp_dir().join(format!("rtk_test_schema_version_{}.db", std::process::id()));
+        // nosemgrep: filesystem-deletion -- test-only cleanup of this test's own throwaway temp DB file, not production/user data.
         let _ = std::fs::remove_file(&db_path);
         env::set_var("RTK_DB_PATH", &db_path);
 
@@ -1903,6 +1908,7 @@ mod tests {
             .expect("commands table should already exist and accept writes");
 
         env::remove_var("RTK_DB_PATH");
+        // nosemgrep: filesystem-deletion -- test-only cleanup of this test's own throwaway temp DB file, not production/user data.
         let _ = std::fs::remove_file(&db_path);
     }
 
@@ -1925,6 +1931,7 @@ mod tests {
             "rtk_test_heal_migrations_{}.db",
             std::process::id()
         ));
+        // nosemgrep: filesystem-deletion -- test-only cleanup of this test's own throwaway temp DB file, not production/user data.
         let _ = std::fs::remove_file(&db_path);
         let conn = Connection::open(&db_path).expect("open should succeed");
 
@@ -1950,6 +1957,7 @@ mod tests {
         .expect("hook_decisions table should exist and accept writes again");
 
         drop(conn);
+        // nosemgrep: filesystem-deletion -- test-only cleanup of this test's own throwaway temp DB file, not production/user data.
         let _ = std::fs::remove_file(&db_path);
     }
 

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -293,6 +293,25 @@ pub fn open_private(
     Ok(file)
 }
 
+/// Pure core of `set_owner_only`'s "is a chmod even needed" check, taking the raw
+/// `st_mode` reading directly so it's deterministically testable without touching
+/// the filesystem (an unprivileged `chmod` setting setuid/setgid isn't reliably
+/// honored across every environment — e.g. some sandboxed/containerized
+/// filesystems silently drop it — so a test that round-trips through a real file
+/// would be flaky rather than actually exercising this logic).
+///
+/// Masks with `0o7777`, NOT `0o777`: setuid/setgid/sticky live in the `0o7000`
+/// range, above the rwx bits but below the file-type bits `st_mode` also carries.
+/// A `0o777` mask would strip those dangerous bits out of the comparison too, so
+/// a file with e.g. setuid set (`0o4600`) would read as "already correct" against
+/// a `target` of `0o600` and permanently skip the chmod that would clear it —
+/// defeating the self-heal `set_owner_only` exists to provide, for exactly the
+/// files (external tampering, restored backups) it's meant to catch.
+#[cfg(unix)]
+fn mode_already_correct(actual: u32, target: u32) -> bool {
+    actual & 0o7777 == target
+}
+
 #[cfg(unix)]
 fn set_owner_only(path: &std::path::Path, mode: u32) {
     use std::os::unix::fs::PermissionsExt;
@@ -303,8 +322,9 @@ fn set_owner_only(path: &std::path::Path, mode: u32) {
     // budget, so a redundant chmod on the already-correct common case adds up.
     // Falls through to chmod on any metadata-read failure, erring toward
     // enforcing the permission rather than silently skipping it.
+    //
     if let Ok(meta) = fs::metadata(path) {
-        if meta.permissions().mode() & 0o777 == mode {
+        if mode_already_correct(meta.permissions().mode(), mode) {
             return;
         }
     }
@@ -1129,5 +1149,47 @@ mod tests {
         // Second call hits the already-correct fast path — must stay 0o600.
         restrict_file(&file);
         assert_eq!(mode_of(&file), 0o600);
+    }
+
+    // Regression: the fast-path comparison must mask with 0o7777 (including
+    // setuid/setgid/sticky), not 0o777 — a 0o777 mask would make a file with e.g.
+    // setuid set (0o4600) read as "already 0o600" and permanently skip the chmod
+    // that clears the dangerous bit. Tested against the pure mask logic directly
+    // (not round-tripped through a real chmod) since an unprivileged chmod setting
+    // setuid isn't reliably honored across every environment — some sandboxed/
+    // containerized filesystems silently drop it, which would make a
+    // filesystem-based version of this test flaky rather than exercise the logic.
+    #[test]
+    #[cfg(unix)]
+    fn test_mode_already_correct_rejects_setuid_bit() {
+        assert!(
+            !mode_already_correct(0o4600, 0o600),
+            "setuid set (0o4600) must not read as already-correct against target 0o600"
+        );
+        assert!(
+            !mode_already_correct(0o2600, 0o600),
+            "setgid set (0o2600) must not read as already-correct against target 0o600"
+        );
+        assert!(
+            !mode_already_correct(0o1600, 0o600),
+            "sticky bit set (0o1600) must not read as already-correct against target 0o600"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_mode_already_correct_accepts_exact_match() {
+        assert!(mode_already_correct(0o600, 0o600));
+        assert!(mode_already_correct(0o700, 0o700));
+        assert!(!mode_already_correct(0o644, 0o600));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_mode_already_correct_ignores_file_type_bits() {
+        // `st_mode` carries file-type bits (e.g. S_IFREG = 0o100000) above the
+        // 0o7777 permission range this function masks to — those must not affect
+        // the comparison either way.
+        assert!(mode_already_correct(0o100600, 0o600));
     }
 }

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -296,6 +296,18 @@ pub fn open_private(
 #[cfg(unix)]
 fn set_owner_only(path: &std::path::Path, mode: u32) {
     use std::os::unix::fs::PermissionsExt;
+    // Skip the chmod syscall once permissions already match. This runs on every
+    // `Tracker::new()` call, which is now on the PreToolUse hook's hot path for
+    // *every* Bash tool call (not just RTK-covered ones — see rtk-ai/rtk#3206's
+    // hook_decisions ground-truth logging), under the project's <10ms latency
+    // budget, so a redundant chmod on the already-correct common case adds up.
+    // Falls through to chmod on any metadata-read failure, erring toward
+    // enforcing the permission rather than silently skipping it.
+    if let Ok(meta) = fs::metadata(path) {
+        if meta.permissions().mode() & 0o777 == mode {
+            return;
+        }
+    }
     let _ = fs::set_permissions(path, fs::Permissions::from_mode(mode));
 }
 
@@ -1083,5 +1095,39 @@ mod tests {
     fn test_restrict_file_ignores_missing_path() {
         let tmp = tempfile::tempdir().unwrap();
         restrict_file(&tmp.path().join("absent.db-wal"));
+    }
+
+    // rtk-ai/rtk#3206 review: set_owner_only now skips the chmod syscall once
+    // permissions already match, since Tracker::new() (which calls this via
+    // create_private_dir/open_private/restrict_db_files) is on the PreToolUse
+    // hook's hot path for every Bash tool call. These don't observe the skipped
+    // syscall directly, but confirm the already-correct case stays correct
+    // (idempotent) across repeated calls, on both a directory and a file.
+
+    #[test]
+    #[cfg(unix)]
+    fn test_set_owner_only_idempotent_when_already_correct_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("already-private");
+        create_private_dir(&dir).unwrap();
+        assert_eq!(mode_of(&dir), 0o700);
+
+        // Second call hits the already-correct fast path — must stay 0o700.
+        create_private_dir(&dir).unwrap();
+        assert_eq!(mode_of(&dir), 0o700);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_restrict_file_idempotent_when_already_correct() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("history.db");
+        fs::write(&file, b"x").unwrap();
+        restrict_file(&file);
+        assert_eq!(mode_of(&file), 0o600);
+
+        // Second call hits the already-correct fast path — must stay 0o600.
+        restrict_file(&file);
+        assert_eq!(mode_of(&file), 0o600);
     }
 }

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -6,6 +6,7 @@
 //! - Command execution with error context
 
 use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
 use regex::Regex;
 use serde_json::Value;
 use std::fs;
@@ -13,6 +14,25 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::sync::LazyLock;
 use std::sync::OnceLock;
+
+/// Compute `days` ago from now, clamped instead of panicking on overflow.
+///
+/// `days` is typically user-supplied (`--since <days>`) and unbounded. Naively
+/// building `chrono::Duration::days(days as i64)` and subtracting it from
+/// `Utc::now()` panics for a large enough value ("DateTime - TimeDelta
+/// overflowed") — this happened identically in `rtk discover --since` and `rtk
+/// hook audit --since` before both were routed through this helper. `days` is
+/// capped to `i64::MAX` before the `as i64` cast (a `u64` past `i64::MAX` would
+/// otherwise reinterpret as negative, turning "look back" into "look forward"),
+/// and any remaining overflow building or applying the `Duration` falls back to
+/// `DateTime::<Utc>::MIN_UTC` — an arbitrarily distant cutoff means "no lower
+/// bound", which is exactly what an absurdly large `--since` should behave like.
+pub fn days_ago_cutoff(days: u64) -> DateTime<Utc> {
+    let days = days.min(i64::MAX as u64) as i64;
+    chrono::Duration::try_days(days)
+        .and_then(|d| Utc::now().checked_sub_signed(d))
+        .unwrap_or(DateTime::<Utc>::MIN_UTC)
+}
 
 /// Truncates a string to `max_len` characters, appending `...` if needed.
 ///
@@ -503,6 +523,25 @@ mod tests {
     #[test]
     fn test_truncate_short_string() {
         assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn test_days_ago_cutoff_normal_value_is_in_the_past() {
+        let cutoff = days_ago_cutoff(30);
+        assert!(cutoff < Utc::now());
+    }
+
+    #[test]
+    fn test_days_ago_cutoff_does_not_panic_on_huge_since_days() {
+        // rtk-ai/rtk#3206 review: `rtk discover --since 100000000` and `rtk hook
+        // audit --since 100000000` both panicked with "DateTime - TimeDelta
+        // overflowed". Must clamp instead of crashing.
+        assert_eq!(days_ago_cutoff(100_000_000), DateTime::<Utc>::MIN_UTC);
+    }
+
+    #[test]
+    fn test_days_ago_cutoff_does_not_panic_on_u64_max() {
+        assert_eq!(days_ago_cutoff(u64::MAX), DateTime::<Utc>::MIN_UTC);
     }
 
     #[test]

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -312,6 +312,25 @@ pub fn open_private(
     Ok(file)
 }
 
+/// Pure core of `set_owner_only`'s "is a chmod even needed" check, taking the raw
+/// `st_mode` reading directly so it's deterministically testable without touching
+/// the filesystem (an unprivileged `chmod` setting setuid/setgid isn't reliably
+/// honored across every environment — e.g. some sandboxed/containerized
+/// filesystems silently drop it — so a test that round-trips through a real file
+/// would be flaky rather than actually exercising this logic).
+///
+/// Masks with `0o7777`, NOT `0o777`: setuid/setgid/sticky live in the `0o7000`
+/// range, above the rwx bits but below the file-type bits `st_mode` also carries.
+/// A `0o777` mask would strip those dangerous bits out of the comparison too, so
+/// a file with e.g. setuid set (`0o4600`) would read as "already correct" against
+/// a `target` of `0o600` and permanently skip the chmod that would clear it —
+/// defeating the self-heal `set_owner_only` exists to provide, for exactly the
+/// files (external tampering, restored backups) it's meant to catch.
+#[cfg(unix)]
+fn mode_already_correct(actual: u32, target: u32) -> bool {
+    actual & 0o7777 == target
+}
+
 #[cfg(unix)]
 fn set_owner_only(path: &std::path::Path, mode: u32) {
     use std::os::unix::fs::PermissionsExt;
@@ -322,8 +341,9 @@ fn set_owner_only(path: &std::path::Path, mode: u32) {
     // budget, so a redundant chmod on the already-correct common case adds up.
     // Falls through to chmod on any metadata-read failure, erring toward
     // enforcing the permission rather than silently skipping it.
+    //
     if let Ok(meta) = fs::metadata(path) {
-        if meta.permissions().mode() & 0o777 == mode {
+        if mode_already_correct(meta.permissions().mode(), mode) {
             return;
         }
     }
@@ -1471,5 +1491,47 @@ mod tests {
         // Second call hits the already-correct fast path — must stay 0o600.
         restrict_file(&file);
         assert_eq!(mode_of(&file), 0o600);
+    }
+
+    // Regression: the fast-path comparison must mask with 0o7777 (including
+    // setuid/setgid/sticky), not 0o777 — a 0o777 mask would make a file with e.g.
+    // setuid set (0o4600) read as "already 0o600" and permanently skip the chmod
+    // that clears the dangerous bit. Tested against the pure mask logic directly
+    // (not round-tripped through a real chmod) since an unprivileged chmod setting
+    // setuid isn't reliably honored across every environment — some sandboxed/
+    // containerized filesystems silently drop it, which would make a
+    // filesystem-based version of this test flaky rather than exercise the logic.
+    #[test]
+    #[cfg(unix)]
+    fn test_mode_already_correct_rejects_setuid_bit() {
+        assert!(
+            !mode_already_correct(0o4600, 0o600),
+            "setuid set (0o4600) must not read as already-correct against target 0o600"
+        );
+        assert!(
+            !mode_already_correct(0o2600, 0o600),
+            "setgid set (0o2600) must not read as already-correct against target 0o600"
+        );
+        assert!(
+            !mode_already_correct(0o1600, 0o600),
+            "sticky bit set (0o1600) must not read as already-correct against target 0o600"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_mode_already_correct_accepts_exact_match() {
+        assert!(mode_already_correct(0o600, 0o600));
+        assert!(mode_already_correct(0o700, 0o700));
+        assert!(!mode_already_correct(0o644, 0o600));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_mode_already_correct_ignores_file_type_bits() {
+        // `st_mode` carries file-type bits (e.g. S_IFREG = 0o100000) above the
+        // 0o7777 permission range this function masks to — those must not affect
+        // the comparison either way.
+        assert!(mode_already_correct(0o100600, 0o600));
     }
 }

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -6,6 +6,7 @@
 //! - Command execution with error context
 
 use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
 use regex::Regex;
 use serde_json::Value;
 use std::fs;
@@ -13,6 +14,25 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::sync::LazyLock;
 use std::sync::OnceLock;
+
+/// Compute `days` ago from now, clamped instead of panicking on overflow.
+///
+/// `days` is typically user-supplied (`--since <days>`) and unbounded. Naively
+/// building `chrono::Duration::days(days as i64)` and subtracting it from
+/// `Utc::now()` panics for a large enough value ("DateTime - TimeDelta
+/// overflowed") — this happened identically in `rtk discover --since` and `rtk
+/// hook audit --since` before both were routed through this helper. `days` is
+/// capped to `i64::MAX` before the `as i64` cast (a `u64` past `i64::MAX` would
+/// otherwise reinterpret as negative, turning "look back" into "look forward"),
+/// and any remaining overflow building or applying the `Duration` falls back to
+/// `DateTime::<Utc>::MIN_UTC` — an arbitrarily distant cutoff means "no lower
+/// bound", which is exactly what an absurdly large `--since` should behave like.
+pub fn days_ago_cutoff(days: u64) -> DateTime<Utc> {
+    let days = days.min(i64::MAX as u64) as i64;
+    chrono::Duration::try_days(days)
+        .and_then(|d| Utc::now().checked_sub_signed(d))
+        .unwrap_or(DateTime::<Utc>::MIN_UTC)
+}
 
 /// Truncates a string to `max_len` characters, appending `...` if needed.
 ///
@@ -684,6 +704,25 @@ mod tests {
     #[test]
     fn test_truncate_short_string() {
         assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn test_days_ago_cutoff_normal_value_is_in_the_past() {
+        let cutoff = days_ago_cutoff(30);
+        assert!(cutoff < Utc::now());
+    }
+
+    #[test]
+    fn test_days_ago_cutoff_does_not_panic_on_huge_since_days() {
+        // rtk-ai/rtk#3206 review: `rtk discover --since 100000000` and `rtk hook
+        // audit --since 100000000` both panicked with "DateTime - TimeDelta
+        // overflowed". Must clamp instead of crashing.
+        assert_eq!(days_ago_cutoff(100_000_000), DateTime::<Utc>::MIN_UTC);
+    }
+
+    #[test]
+    fn test_days_ago_cutoff_does_not_panic_on_u64_max() {
+        assert_eq!(days_ago_cutoff(u64::MAX), DateTime::<Utc>::MIN_UTC);
     }
 
     #[test]

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -315,6 +315,18 @@ pub fn open_private(
 #[cfg(unix)]
 fn set_owner_only(path: &std::path::Path, mode: u32) {
     use std::os::unix::fs::PermissionsExt;
+    // Skip the chmod syscall once permissions already match. This runs on every
+    // `Tracker::new()` call, which is now on the PreToolUse hook's hot path for
+    // *every* Bash tool call (not just RTK-covered ones — see rtk-ai/rtk#3206's
+    // hook_decisions ground-truth logging), under the project's <10ms latency
+    // budget, so a redundant chmod on the already-correct common case adds up.
+    // Falls through to chmod on any metadata-read failure, erring toward
+    // enforcing the permission rather than silently skipping it.
+    if let Ok(meta) = fs::metadata(path) {
+        if meta.permissions().mode() & 0o777 == mode {
+            return;
+        }
+    }
     let _ = fs::set_permissions(path, fs::Permissions::from_mode(mode));
 }
 
@@ -1425,5 +1437,39 @@ mod tests {
                 bytes
             );
         }
+    }
+
+    // rtk-ai/rtk#3206 review: set_owner_only now skips the chmod syscall once
+    // permissions already match, since Tracker::new() (which calls this via
+    // create_private_dir/open_private/restrict_db_files) is on the PreToolUse
+    // hook's hot path for every Bash tool call. These don't observe the skipped
+    // syscall directly, but confirm the already-correct case stays correct
+    // (idempotent) across repeated calls, on both a directory and a file.
+
+    #[test]
+    #[cfg(unix)]
+    fn test_set_owner_only_idempotent_when_already_correct_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("already-private");
+        create_private_dir(&dir).unwrap();
+        assert_eq!(mode_of(&dir), 0o700);
+
+        // Second call hits the already-correct fast path — must stay 0o700.
+        create_private_dir(&dir).unwrap();
+        assert_eq!(mode_of(&dir), 0o700);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_restrict_file_idempotent_when_already_correct() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("history.db");
+        fs::write(&file, b"x").unwrap();
+        restrict_file(&file);
+        assert_eq!(mode_of(&file), 0o600);
+
+        // Second call hits the already-correct fast path — must stay 0o600.
+        restrict_file(&file);
+        assert_eq!(mode_of(&file), 0o600);
     }
 }

--- a/src/discover/mod.rs
+++ b/src/discover/mod.rs
@@ -190,9 +190,7 @@ pub fn run(
     // today's hook-install state; fall back to a heuristic only for history that
     // predates logging (or isn't Claude Code).
     let hook_installed = hook_status() != HookStatus::Missing;
-    let (excluded, transparent_prefixes) = crate::core::config::Config::load()
-        .map(|c| (c.hooks.exclude_commands, c.hooks.transparent_prefixes))
-        .unwrap_or_default();
+    let (excluded, transparent_prefixes) = crate::core::config::hook_rewrite_params();
 
     let cutoff = Utc::now() - chrono::Duration::days(since_days as i64);
     let (hook_log, measured_since): (HashMap<String, HookDecisionRecord>, Option<DateTime<Utc>>) =

--- a/src/discover/mod.rs
+++ b/src/discover/mod.rs
@@ -195,6 +195,7 @@ pub fn run(
     let mut already_rtk_estimated: usize = 0;
     let mut parse_errors: usize = 0;
     let mut rtk_disabled_count: usize = 0;
+    let mut rtk_disabled_estimated: usize = 0;
     let mut rtk_disabled_cmds: HashMap<String, usize> = HashMap::new();
     let mut supported_map: HashMap<&'static str, SupportedBucket> = HashMap::new();
     let mut unsupported_map: HashMap<String, UnsupportedBucket> = HashMap::new();
@@ -234,6 +235,9 @@ pub fn run(
                         );
                         if coverage.is_covered() {
                             rtk_disabled_count += 1;
+                            if coverage.is_estimated() {
+                                rtk_disabled_estimated += 1;
+                            }
                             let display = truncate_command(actual_cmd);
                             *rtk_disabled_cmds.entry(display).or_insert(0) += 1;
                         }
@@ -412,6 +416,7 @@ pub fn run(
         unsupported,
         parse_errors,
         rtk_disabled_count,
+        rtk_disabled_estimated,
         rtk_disabled_examples,
         agent_status: report::AgentIntegrationStatus::detect(),
     };

--- a/src/discover/mod.rs
+++ b/src/discover/mod.rs
@@ -50,6 +50,20 @@ impl Coverage {
 
 /// Determine whether `cmd` was (or, absent a log entry, likely would have been)
 /// routed through RTK by the installed PreToolUse hook.
+///
+/// Known imprecision: the caller splits a chained command (`a && b`) into parts
+/// and calls this once per part with the *same* `tool_use_id`, since Claude Code's
+/// PreToolUse hook fires once per tool call for the whole raw command. A `Deny`/
+/// `Ask` verdict genuinely is chain-wide (`permissions::check_command_with_rules`
+/// denies/asks the entire chain if any segment matches), but the real rewrite
+/// (`registry::rewrite_command`) is best-effort *per segment* — it can rewrite
+/// just `a` and leave an unsupported `b` untouched. Neither `Measured` (one
+/// `hook_decisions` row per `tool_use_id`, no per-segment detail) nor `Estimated`
+/// re-derives that per-segment split, so a segment can be reported covered/missed
+/// based on a sibling segment's fate. Not worth chasing further: `Estimated` is a
+/// transitional fallback for history that predates `hook_decisions` logging and
+/// naturally fades out as that log backfills — after ~90 days only `Measured`
+/// should remain in practice.
 fn hook_coverage(
     cmd: &str,
     tool_use_id: &str,

--- a/src/discover/mod.rs
+++ b/src/discover/mod.rs
@@ -7,6 +7,7 @@ mod report;
 pub mod rules;
 
 use anyhow::Result;
+use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 
 use provider::{ClaudeProvider, SessionProvider};
@@ -16,7 +17,104 @@ use registry::{
 };
 use report::{DiscoverReport, SupportedEntry, UnsupportedEntry};
 
+use crate::core::tracking::{HookDecisionRecord, Tracker};
 use crate::discover::registry::prefix_contains_rtk_disabled;
+use crate::hooks::hook_check::{status as hook_status, HookStatus};
+use crate::hooks::permissions::{self, PermissionVerdict};
+
+/// Whether a `Supported` command was actually routed through RTK, and how
+/// confident we are in that answer.
+///
+/// `Measured` comes from a real `hook_decisions` log row, keyed by the
+/// transcript's `tool_use_id` — ground truth about what the hook actually did
+/// at the time. `Estimated` is the fallback for history that predates hook-decision
+/// logging (or isn't Claude Code): a best-effort guess using *today's*
+/// hook-install state, config, and registry, which may not reflect reality at
+/// the time the command actually ran.
+enum Coverage {
+    Measured(bool),
+    Estimated(bool),
+}
+
+impl Coverage {
+    fn is_covered(&self) -> bool {
+        match self {
+            Coverage::Measured(covered) | Coverage::Estimated(covered) => *covered,
+        }
+    }
+
+    fn is_estimated(&self) -> bool {
+        matches!(self, Coverage::Estimated(_))
+    }
+}
+
+/// Determine whether `cmd` was (or, absent a log entry, likely would have been)
+/// routed through RTK by the installed PreToolUse hook.
+fn hook_coverage(
+    cmd: &str,
+    tool_use_id: &str,
+    hook_log: &HashMap<String, HookDecisionRecord>,
+    hook_installed: bool,
+    excluded: &[String],
+    transparent_prefixes: &[String],
+) -> Coverage {
+    if let Some(record) = hook_log.get(tool_use_id) {
+        return Coverage::Measured(record.decision.is_covered());
+    }
+    Coverage::Estimated(estimate_hook_coverage(
+        cmd,
+        hook_installed,
+        excluded,
+        transparent_prefixes,
+    ))
+}
+
+/// Best-effort guess at whether the *currently* installed hook would rewrite `cmd`,
+/// used only when no `hook_decisions` log row exists for this exact invocation.
+/// Reads real permission config — see `estimate_hook_coverage_with_verdict` for the
+/// pure decision core.
+fn estimate_hook_coverage(
+    cmd: &str,
+    hook_installed: bool,
+    excluded: &[String],
+    transparent_prefixes: &[String],
+) -> bool {
+    let verdict = permissions::check_command_for(cmd, permissions::Host::Claude);
+    estimate_hook_coverage_with_verdict(
+        cmd,
+        verdict,
+        hook_installed,
+        excluded,
+        transparent_prefixes,
+    )
+}
+
+/// Pure core of `estimate_hook_coverage`, taking the permission verdict directly so
+/// it's testable without depending on real config files. Mirrors the real hook's own
+/// decision order (`hooks::hook_cmd::decide_from_verdict`): a `Deny`-rule match or an
+/// unattestable construct means the hook would never have rewritten this, regardless
+/// of registry support.
+fn estimate_hook_coverage_with_verdict(
+    cmd: &str,
+    verdict: PermissionVerdict,
+    hook_installed: bool,
+    excluded: &[String],
+    transparent_prefixes: &[String],
+) -> bool {
+    hook_installed
+        && verdict != PermissionVerdict::Deny
+        && !lexer::contains_unattestable_construct(cmd)
+        && registry::rewrite_command(cmd, excluded, transparent_prefixes).is_some()
+}
+
+/// Whether an already-`rtk`-prefixed command counts as coverage. `rtk proxy <cmd>`
+/// deliberately runs the raw command unfiltered, so it must not count — that would
+/// let the audit flatter itself via its own escape hatch. This is ground truth read
+/// directly from the transcript (the model really did invoke `rtk`), not a guess.
+fn is_already_rtk(cmd: &str) -> bool {
+    let trimmed = cmd.trim();
+    trimmed.starts_with("rtk ") && !trimmed.starts_with("rtk proxy")
+}
 
 /// Aggregation bucket for supported commands.
 struct SupportedBucket {
@@ -72,8 +170,29 @@ pub fn run(
         }
     }
 
+    // Transcripts record commands as the model emitted them, before the PreToolUse
+    // hook rewrites them. Prefer ground truth from the `hook_decisions` log (keyed by
+    // `tool_use_id`, populated at the moment the hook actually ran) over guessing from
+    // today's hook-install state; fall back to a heuristic only for history that
+    // predates logging (or isn't Claude Code).
+    let hook_installed = hook_status() != HookStatus::Missing;
+    let (excluded, transparent_prefixes) = crate::core::config::Config::load()
+        .map(|c| (c.hooks.exclude_commands, c.hooks.transparent_prefixes))
+        .unwrap_or_default();
+
+    let cutoff = Utc::now() - chrono::Duration::days(since_days as i64);
+    let (hook_log, measured_since): (HashMap<String, HookDecisionRecord>, Option<DateTime<Utc>>) =
+        Tracker::new()
+            .map(|t| {
+                let log = t.hook_decisions_since(cutoff).unwrap_or_default();
+                let measured_since = t.earliest_hook_decision_timestamp().ok().flatten();
+                (log, measured_since)
+            })
+            .unwrap_or_default();
+
     let mut total_commands: usize = 0;
     let mut already_rtk: usize = 0;
+    let mut already_rtk_estimated: usize = 0;
     let mut parse_errors: usize = 0;
     let mut rtk_disabled_count: usize = 0;
     let mut rtk_disabled_cmds: HashMap<String, usize> = HashMap::new();
@@ -100,15 +219,23 @@ pub fn run(
                 // Detect RTK_DISABLED= bypass before classification
                 let (env_prefix, actual_cmd) = strip_disabled_prefix(part);
                 if prefix_contains_rtk_disabled(env_prefix) {
-                    // Only count if the underlying command is one RTK supports
-                    match classify_command(actual_cmd) {
-                        Classification::Supported { .. } => {
+                    // Only count if the underlying command is one RTK supports, AND the
+                    // hook would actually have covered it — otherwise RTK_DISABLED=
+                    // bypassed nothing (hook wasn't installed / excluded / would defer
+                    // / would deny), and flagging it as a "bypass" would be false advice.
+                    if let Classification::Supported { .. } = classify_command(actual_cmd) {
+                        let coverage = hook_coverage(
+                            actual_cmd,
+                            &ext_cmd.tool_use_id,
+                            &hook_log,
+                            hook_installed,
+                            &excluded,
+                            &transparent_prefixes,
+                        );
+                        if coverage.is_covered() {
                             rtk_disabled_count += 1;
                             let display = truncate_command(actual_cmd);
                             *rtk_disabled_cmds.entry(display).or_insert(0) += 1;
-                        }
-                        _ => {
-                            // RTK_DISABLED on unsupported/ignored command — not interesting
                         }
                     }
                     continue;
@@ -121,6 +248,25 @@ pub fn run(
                         estimated_savings_pct,
                         status,
                     } => {
+                        let coverage = hook_coverage(
+                            part,
+                            &ext_cmd.tool_use_id,
+                            &hook_log,
+                            hook_installed,
+                            &excluded,
+                            &transparent_prefixes,
+                        );
+
+                        if coverage.is_covered() {
+                            // Hook already routed this through RTK at runtime — it's
+                            // coverage, not a missed opportunity.
+                            already_rtk += 1;
+                            if coverage.is_estimated() {
+                                already_rtk_estimated += 1;
+                            }
+                            continue;
+                        }
+
                         let bucket = supported_map.entry(rtk_equivalent).or_insert_with(|| {
                             SupportedBucket {
                                 rtk_equivalent,
@@ -169,8 +315,10 @@ pub fn run(
                         bucket.count += 1;
                     }
                     Classification::Ignored => {
-                        // Check if it starts with "rtk "
-                        if part.trim().starts_with("rtk ") {
+                        // Ground truth from the transcript itself — the model really
+                        // did invoke `rtk` directly (excluding the deliberate
+                        // unfiltered `rtk proxy` escape hatch).
+                        if is_already_rtk(part) {
                             already_rtk += 1;
                         }
                         // Otherwise just skip
@@ -257,6 +405,8 @@ pub fn run(
         sessions_scanned: sessions.len(),
         total_commands,
         already_rtk,
+        already_rtk_estimated,
+        measured_since: measured_since.map(|ts| ts.format("%Y-%m-%d").to_string()),
         since_days,
         supported,
         unsupported,
@@ -293,5 +443,144 @@ fn truncate_command(cmd: &str) -> String {
         0 => String::new(),
         1 => parts[0].to_string(),
         _ => format!("{} {}", parts[0], parts[1]),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::tracking::HookOutcome;
+
+    // rtk-ai/rtk#3148: hook-rewritten commands were counted as missed savings
+    // because transcripts record the pre-rewrite (raw) form of the command.
+    // Real hook decisions are logged (`hook_decisions`, keyed by `tool_use_id`)
+    // now so coverage is measured, not guessed; `estimate_hook_coverage`/
+    // `Coverage::Estimated` — partially modeled on #3164's heuristic, with its
+    // permission-deny gap fixed — remain only as the fallback for history that
+    // predates that log.
+
+    fn record(decision: HookOutcome) -> HookDecisionRecord {
+        HookDecisionRecord { decision }
+    }
+
+    #[test]
+    fn test_estimate_hook_coverage_false_when_hook_not_installed() {
+        // No hook installed → the raw command genuinely ran unfiltered; still a miss.
+        assert!(!estimate_hook_coverage_with_verdict(
+            "grep -n foo bar.py",
+            PermissionVerdict::Default,
+            false,
+            &[],
+            &[]
+        ));
+    }
+
+    #[test]
+    fn test_estimate_hook_coverage_true_for_rewritable_command() {
+        assert!(estimate_hook_coverage_with_verdict(
+            "grep -n foo bar.py",
+            PermissionVerdict::Default,
+            true,
+            &[],
+            &[]
+        ));
+        assert!(estimate_hook_coverage_with_verdict(
+            "ls -la",
+            PermissionVerdict::Allow,
+            true,
+            &[],
+            &[]
+        ));
+    }
+
+    #[test]
+    fn test_estimate_hook_coverage_false_for_unattestable_construct() {
+        // The hook itself defers on unattestable constructs (substitutions, etc.),
+        // so a command containing one was never actually rewritten — genuine miss.
+        assert!(!estimate_hook_coverage_with_verdict(
+            "git status $(rm -rf /tmp/x)",
+            PermissionVerdict::Default,
+            true,
+            &[],
+            &[]
+        ));
+    }
+
+    #[test]
+    fn test_estimate_hook_coverage_false_when_excluded_by_config() {
+        // Even with the hook installed, a command the user excluded via config
+        // was never rewritten — the hook stepped aside, so it's a genuine miss.
+        let excluded = vec!["grep".to_string()];
+        assert!(!estimate_hook_coverage_with_verdict(
+            "grep -n foo bar.py",
+            PermissionVerdict::Default,
+            true,
+            &excluded,
+            &[]
+        ));
+    }
+
+    #[test]
+    fn test_estimate_hook_coverage_false_when_denied() {
+        // A command matching a permissions.deny rule is never auto-rewritten by the
+        // real hook (it defers to Claude Code's native deny handling) — counting it
+        // as covered would over-count savings for commands the hook actually denied.
+        assert!(!estimate_hook_coverage_with_verdict(
+            "rm -rf /",
+            PermissionVerdict::Deny,
+            true,
+            &[],
+            &[]
+        ));
+    }
+
+    #[test]
+    fn test_is_already_rtk_plain_rewrite() {
+        assert!(is_already_rtk("rtk grep -n foo bar.py"));
+    }
+
+    #[test]
+    fn test_is_already_rtk_excludes_proxy_escape_hatch() {
+        // rtk#3148 secondary finding: `rtk proxy` deliberately bypasses filtering,
+        // so it must not count as coverage.
+        assert!(!is_already_rtk("rtk proxy grep -n foo bar.py"));
+    }
+
+    #[test]
+    fn test_is_already_rtk_false_for_unrelated_command() {
+        assert!(!is_already_rtk("grep -n foo bar.py"));
+    }
+
+    #[test]
+    fn test_hook_coverage_prefers_measured_log_over_estimate() {
+        // Even if the current hook state would estimate "not covered" (hook
+        // uninstalled today), a real log row is ground truth and wins.
+        let mut log = HashMap::new();
+        log.insert("toolu_1".to_string(), record(HookOutcome::Allow));
+
+        let coverage = hook_coverage("git status", "toolu_1", &log, false, &[], &[]);
+        assert!(matches!(coverage, Coverage::Measured(true)));
+        assert!(coverage.is_covered());
+        assert!(!coverage.is_estimated());
+    }
+
+    #[test]
+    fn test_hook_coverage_measured_deny_is_a_genuine_miss() {
+        let mut log = HashMap::new();
+        log.insert("toolu_1".to_string(), record(HookOutcome::Deny));
+
+        let coverage = hook_coverage("rm -rf /", "toolu_1", &log, true, &[], &[]);
+        assert!(matches!(coverage, Coverage::Measured(false)));
+        assert!(!coverage.is_covered());
+    }
+
+    #[test]
+    fn test_hook_coverage_falls_back_to_estimate_when_no_log_row() {
+        // No log entry for this tool_use_id — predates logging (or non-Claude) —
+        // falls back to the current-state heuristic, flagged as estimated.
+        let log = HashMap::new();
+
+        let coverage = hook_coverage("ls -la", "toolu_missing", &log, true, &[], &[]);
+        assert!(coverage.is_estimated());
     }
 }

--- a/src/discover/mod.rs
+++ b/src/discover/mod.rs
@@ -125,7 +125,7 @@ fn estimate_hook_coverage_with_verdict(
 /// deliberately runs the raw command unfiltered, so it must not count — that would
 /// let the audit flatter itself via its own escape hatch. This is ground truth read
 /// directly from the transcript (the model really did invoke `rtk`), not a guess.
-fn is_already_rtk(cmd: &str) -> bool {
+pub(crate) fn is_already_rtk(cmd: &str) -> bool {
     let trimmed = cmd.trim();
     trimmed.starts_with("rtk ") && !trimmed.starts_with("rtk proxy")
 }

--- a/src/discover/mod.rs
+++ b/src/discover/mod.rs
@@ -48,6 +48,18 @@ impl Coverage {
     }
 }
 
+/// Preloaded permission rules, read from disk once per `discover` run instead of
+/// once per command. `check_command_for` re-reads every settings file on disk on
+/// every call; over a large history (tens of thousands of commands) that dominated
+/// runtime (see rtk-ai/rtk#3206 review: 80s vs 2.5s on the measured path). Threaded
+/// through `hook_coverage`/`estimate_hook_coverage` so the estimate path reuses one
+/// in-memory snapshot instead of hitting the filesystem per command.
+struct PermissionRules {
+    deny: Vec<String>,
+    ask: Vec<String>,
+    allow: Vec<String>,
+}
+
 /// Determine whether `cmd` was (or, absent a log entry, likely would have been)
 /// routed through RTK by the installed PreToolUse hook.
 ///
@@ -69,6 +81,7 @@ fn hook_coverage(
     tool_use_id: &str,
     hook_log: &HashMap<String, HookDecisionRecord>,
     hook_installed: bool,
+    rules: &PermissionRules,
     excluded: &[String],
     transparent_prefixes: &[String],
 ) -> Coverage {
@@ -78,6 +91,7 @@ fn hook_coverage(
     Coverage::Estimated(estimate_hook_coverage(
         cmd,
         hook_installed,
+        rules,
         excluded,
         transparent_prefixes,
     ))
@@ -85,15 +99,24 @@ fn hook_coverage(
 
 /// Best-effort guess at whether the *currently* installed hook would rewrite `cmd`,
 /// used only when no `hook_decisions` log row exists for this exact invocation.
-/// Reads real permission config — see `estimate_hook_coverage_with_verdict` for the
-/// pure decision core.
+///
+/// Checks `hook_installed` before touching `rules`/the lexer/the registry: with no
+/// hook installed the answer is always "not covered", so there's no reason to pay
+/// for the permission-verdict lookup, the unattestable-construct scan, or the
+/// registry rewrite check on every single command in the scan (see
+/// rtk-ai/rtk#3206 review: 100s of wasted work on histories with no hook ever
+/// installed, since that case never had a chance to short-circuit before).
 fn estimate_hook_coverage(
     cmd: &str,
     hook_installed: bool,
+    rules: &PermissionRules,
     excluded: &[String],
     transparent_prefixes: &[String],
 ) -> bool {
-    let verdict = permissions::check_command_for(cmd, permissions::Host::Claude);
+    if !hook_installed {
+        return false;
+    }
+    let verdict = permissions::check_command_with_rules(cmd, &rules.deny, &rules.ask, &rules.allow);
     estimate_hook_coverage_with_verdict(
         cmd,
         verdict,
@@ -128,6 +151,24 @@ fn estimate_hook_coverage_with_verdict(
 pub(crate) fn is_already_rtk(cmd: &str) -> bool {
     let trimmed = cmd.trim();
     trimmed.starts_with("rtk ") && !trimmed.starts_with("rtk proxy")
+}
+
+/// Earliest timestamp to query `hook_decisions` for, given `--since <days>`.
+///
+/// `since_days` is user-supplied and unbounded; a huge value (e.g. `--since
+/// 100000000`) previously made `chrono::Duration::days` + subtraction from
+/// `Utc::now()` overflow and panic (rtk-ai/rtk#3206 review). Clamped in two
+/// places: `since_days` is capped to `i64::MAX` before the `as i64` cast (a
+/// `u64` past `i64::MAX` would otherwise reinterpret as negative, turning
+/// "look back" into "look forward"), and any remaining overflow building or
+/// applying the `Duration` falls back to `DateTime::<Utc>::MIN_UTC` — an
+/// arbitrarily distant cutoff means "no lower bound", which is exactly what
+/// an absurdly large `--since` should behave like instead of crashing.
+fn hook_decisions_cutoff(since_days: u64) -> DateTime<Utc> {
+    let days = since_days.min(i64::MAX as u64) as i64;
+    chrono::Duration::try_days(days)
+        .and_then(|d| Utc::now().checked_sub_signed(d))
+        .unwrap_or(DateTime::<Utc>::MIN_UTC)
 }
 
 /// Aggregation bucket for supported commands.
@@ -192,7 +233,11 @@ pub fn run(
     let hook_installed = hook_status() != HookStatus::Missing;
     let (excluded, transparent_prefixes) = crate::core::config::hook_rewrite_params();
 
-    let cutoff = Utc::now() - chrono::Duration::days(since_days as i64);
+    // Loaded once up front (see `PermissionRules`), not once per command.
+    let (deny, ask, allow) = permissions::load_rules_for(permissions::Host::Claude);
+    let rules = PermissionRules { deny, ask, allow };
+
+    let cutoff = hook_decisions_cutoff(since_days);
     let (hook_log, measured_since): (HashMap<String, HookDecisionRecord>, Option<DateTime<Utc>>) =
         Tracker::new()
             .map(|t| {
@@ -236,20 +281,25 @@ pub fn run(
                     // hook would actually have covered it — otherwise RTK_DISABLED=
                     // bypassed nothing (hook wasn't installed / excluded / would defer
                     // / would deny), and flagging it as a "bypass" would be false advice.
+                    //
+                    // Deliberately always the *estimate*, never `hook_coverage`'s measured
+                    // log: `RTK_DISABLED=` makes `get_rewritten` return `None` unconditionally
+                    // (registry.rs #345), so the real logged decision for a bypassed command
+                    // is always `Defer` (never `Allow`/`Ask`) — that's the hook correctly
+                    // recording that it stepped aside, not evidence about whether the command
+                    // would have been covered absent the bypass. Consulting the measured log
+                    // here would make this section report zero bypassed commands as soon as
+                    // real hook-decision rows exist (rtk-ai/rtk#3206 review).
                     if let Classification::Supported { .. } = classify_command(actual_cmd) {
-                        let coverage = hook_coverage(
+                        if estimate_hook_coverage(
                             actual_cmd,
-                            &ext_cmd.tool_use_id,
-                            &hook_log,
                             hook_installed,
+                            &rules,
                             &excluded,
                             &transparent_prefixes,
-                        );
-                        if coverage.is_covered() {
+                        ) {
                             rtk_disabled_count += 1;
-                            if coverage.is_estimated() {
-                                rtk_disabled_estimated += 1;
-                            }
+                            rtk_disabled_estimated += 1;
                             let display = truncate_command(actual_cmd);
                             *rtk_disabled_cmds.entry(display).or_insert(0) += 1;
                         }
@@ -269,6 +319,7 @@ pub fn run(
                             &ext_cmd.tool_use_id,
                             &hook_log,
                             hook_installed,
+                            &rules,
                             &excluded,
                             &transparent_prefixes,
                         );
@@ -480,6 +531,14 @@ mod tests {
         HookDecisionRecord { decision }
     }
 
+    fn empty_rules() -> PermissionRules {
+        PermissionRules {
+            deny: vec![],
+            ask: vec![],
+            allow: vec![],
+        }
+    }
+
     #[test]
     fn test_estimate_hook_coverage_false_when_hook_not_installed() {
         // No hook installed → the raw command genuinely ran unfiltered; still a miss.
@@ -552,6 +611,26 @@ mod tests {
     }
 
     #[test]
+    fn test_hook_decisions_cutoff_normal_value_is_in_the_past() {
+        let cutoff = hook_decisions_cutoff(30);
+        assert!(cutoff < Utc::now());
+    }
+
+    #[test]
+    fn test_hook_decisions_cutoff_does_not_panic_on_huge_since_days() {
+        // rtk-ai/rtk#3206 review: `rtk discover --since 100000000` panicked with
+        // "DateTime - TimeDelta overflowed". Must clamp instead of crashing.
+        let cutoff = hook_decisions_cutoff(100_000_000);
+        assert_eq!(cutoff, DateTime::<Utc>::MIN_UTC);
+    }
+
+    #[test]
+    fn test_hook_decisions_cutoff_does_not_panic_on_u64_max() {
+        let cutoff = hook_decisions_cutoff(u64::MAX);
+        assert_eq!(cutoff, DateTime::<Utc>::MIN_UTC);
+    }
+
+    #[test]
     fn test_is_already_rtk_plain_rewrite() {
         assert!(is_already_rtk("rtk grep -n foo bar.py"));
     }
@@ -575,7 +654,15 @@ mod tests {
         let mut log = HashMap::new();
         log.insert("toolu_1".to_string(), record(HookOutcome::Allow));
 
-        let coverage = hook_coverage("git status", "toolu_1", &log, false, &[], &[]);
+        let coverage = hook_coverage(
+            "git status",
+            "toolu_1",
+            &log,
+            false,
+            &empty_rules(),
+            &[],
+            &[],
+        );
         assert!(matches!(coverage, Coverage::Measured(true)));
         assert!(coverage.is_covered());
         assert!(!coverage.is_estimated());
@@ -586,7 +673,7 @@ mod tests {
         let mut log = HashMap::new();
         log.insert("toolu_1".to_string(), record(HookOutcome::Deny));
 
-        let coverage = hook_coverage("rm -rf /", "toolu_1", &log, true, &[], &[]);
+        let coverage = hook_coverage("rm -rf /", "toolu_1", &log, true, &empty_rules(), &[], &[]);
         assert!(matches!(coverage, Coverage::Measured(false)));
         assert!(!coverage.is_covered());
     }
@@ -597,7 +684,15 @@ mod tests {
         // falls back to the current-state heuristic, flagged as estimated.
         let log = HashMap::new();
 
-        let coverage = hook_coverage("ls -la", "toolu_missing", &log, true, &[], &[]);
+        let coverage = hook_coverage(
+            "ls -la",
+            "toolu_missing",
+            &log,
+            true,
+            &empty_rules(),
+            &[],
+            &[],
+        );
         assert!(coverage.is_estimated());
     }
 }

--- a/src/discover/mod.rs
+++ b/src/discover/mod.rs
@@ -63,6 +63,17 @@ struct PermissionRules {
 /// Determine whether `cmd` was (or, absent a log entry, likely would have been)
 /// routed through RTK by the installed PreToolUse hook.
 ///
+/// Do NOT call this for an `RTK_DISABLED=`-bypassed command — call
+/// `estimate_hook_coverage` directly instead. `hook_coverage` trusts a measured
+/// `hook_decisions` row as ground truth, but for a bypassed command the real logged
+/// decision is always `Defer` (see `registry.rs` #345 / `get_rewritten`), which only
+/// confirms the hook stepped aside — it says nothing about whether the command would
+/// have been covered absent the bypass, which is the actual question the
+/// RTK_DISABLED= bucket is answering. Consulting the measured log there made that
+/// bucket silently collapse to (near) zero once real `hook_decisions` rows
+/// accumulated (rtk-ai/rtk#3206 review) — the counterfactual can only ever be
+/// answered by the estimate.
+///
 /// Known imprecision: the caller splits a chained command (`a && b`) into parts
 /// and calls this once per part with the *same* `tool_use_id`, since Claude Code's
 /// PreToolUse hook fires once per tool call for the whole raw command. A `Deny`/
@@ -153,24 +164,6 @@ pub(crate) fn is_already_rtk(cmd: &str) -> bool {
     trimmed.starts_with("rtk ") && !trimmed.starts_with("rtk proxy")
 }
 
-/// Earliest timestamp to query `hook_decisions` for, given `--since <days>`.
-///
-/// `since_days` is user-supplied and unbounded; a huge value (e.g. `--since
-/// 100000000`) previously made `chrono::Duration::days` + subtraction from
-/// `Utc::now()` overflow and panic (rtk-ai/rtk#3206 review). Clamped in two
-/// places: `since_days` is capped to `i64::MAX` before the `as i64` cast (a
-/// `u64` past `i64::MAX` would otherwise reinterpret as negative, turning
-/// "look back" into "look forward"), and any remaining overflow building or
-/// applying the `Duration` falls back to `DateTime::<Utc>::MIN_UTC` — an
-/// arbitrarily distant cutoff means "no lower bound", which is exactly what
-/// an absurdly large `--since` should behave like instead of crashing.
-fn hook_decisions_cutoff(since_days: u64) -> DateTime<Utc> {
-    let days = since_days.min(i64::MAX as u64) as i64;
-    chrono::Duration::try_days(days)
-        .and_then(|d| Utc::now().checked_sub_signed(d))
-        .unwrap_or(DateTime::<Utc>::MIN_UTC)
-}
-
 /// Aggregation bucket for supported commands.
 struct SupportedBucket {
     rtk_equivalent: &'static str,
@@ -237,7 +230,7 @@ pub fn run(
     let (deny, ask, allow) = permissions::load_rules_for(permissions::Host::Claude);
     let rules = PermissionRules { deny, ask, allow };
 
-    let cutoff = hook_decisions_cutoff(since_days);
+    let cutoff = crate::core::utils::days_ago_cutoff(since_days);
     let (hook_log, measured_since): (HashMap<String, HookDecisionRecord>, Option<DateTime<Utc>>) =
         Tracker::new()
             .map(|t| {
@@ -608,26 +601,6 @@ mod tests {
             &[],
             &[]
         ));
-    }
-
-    #[test]
-    fn test_hook_decisions_cutoff_normal_value_is_in_the_past() {
-        let cutoff = hook_decisions_cutoff(30);
-        assert!(cutoff < Utc::now());
-    }
-
-    #[test]
-    fn test_hook_decisions_cutoff_does_not_panic_on_huge_since_days() {
-        // rtk-ai/rtk#3206 review: `rtk discover --since 100000000` panicked with
-        // "DateTime - TimeDelta overflowed". Must clamp instead of crashing.
-        let cutoff = hook_decisions_cutoff(100_000_000);
-        assert_eq!(cutoff, DateTime::<Utc>::MIN_UTC);
-    }
-
-    #[test]
-    fn test_hook_decisions_cutoff_does_not_panic_on_u64_max() {
-        let cutoff = hook_decisions_cutoff(u64::MAX);
-        assert_eq!(cutoff, DateTime::<Utc>::MIN_UTC);
     }
 
     #[test]

--- a/src/discover/mod.rs
+++ b/src/discover/mod.rs
@@ -51,13 +51,27 @@ impl Coverage {
 /// Preloaded permission rules, read from disk once per `discover` run instead of
 /// once per command. `check_command_for` re-reads every settings file on disk on
 /// every call; over a large history (tens of thousands of commands) that dominated
-/// runtime (see rtk-ai/rtk#3206 review: 80s vs 2.5s on the measured path). Threaded
-/// through `hook_coverage`/`estimate_hook_coverage` so the estimate path reuses one
-/// in-memory snapshot instead of hitting the filesystem per command.
+/// runtime (see rtk-ai/rtk#3206 review: 80s vs 2.5s on the measured path).
 struct PermissionRules {
     deny: Vec<String>,
     ask: Vec<String>,
     allow: Vec<String>,
+}
+
+/// Everything `hook_coverage`/`estimate_hook_coverage` need to judge a command,
+/// besides the command (and `tool_use_id`) itself — built once per `discover` run
+/// and passed by reference to every per-command call.
+///
+/// Grouped into one struct rather than five individual positional params: with
+/// `excluded`/`transparent_prefixes` both `Vec<String>`, a swapped argument order
+/// at a call site would compile silently and misclassify RTK_DISABLED bypass
+/// coverage (code-review finding on rtk-ai/rtk#3206's fixup round).
+struct CoverageContext {
+    hook_log: HashMap<String, HookDecisionRecord>,
+    hook_installed: bool,
+    rules: PermissionRules,
+    excluded: Vec<String>,
+    transparent_prefixes: Vec<String>,
 }
 
 /// Determine whether `cmd` was (or, absent a log entry, likely would have been)
@@ -87,25 +101,11 @@ struct PermissionRules {
 /// transitional fallback for history that predates `hook_decisions` logging and
 /// naturally fades out as that log backfills — after ~90 days only `Measured`
 /// should remain in practice.
-fn hook_coverage(
-    cmd: &str,
-    tool_use_id: &str,
-    hook_log: &HashMap<String, HookDecisionRecord>,
-    hook_installed: bool,
-    rules: &PermissionRules,
-    excluded: &[String],
-    transparent_prefixes: &[String],
-) -> Coverage {
-    if let Some(record) = hook_log.get(tool_use_id) {
+fn hook_coverage(cmd: &str, tool_use_id: &str, ctx: &CoverageContext) -> Coverage {
+    if let Some(record) = ctx.hook_log.get(tool_use_id) {
         return Coverage::Measured(record.decision.is_covered());
     }
-    Coverage::Estimated(estimate_hook_coverage(
-        cmd,
-        hook_installed,
-        rules,
-        excluded,
-        transparent_prefixes,
-    ))
+    Coverage::Estimated(estimate_hook_coverage(cmd, ctx))
 }
 
 /// Best-effort guess at whether the *currently* installed hook would rewrite `cmd`,
@@ -117,24 +117,17 @@ fn hook_coverage(
 /// registry rewrite check on every single command in the scan (see
 /// rtk-ai/rtk#3206 review: 100s of wasted work on histories with no hook ever
 /// installed, since that case never had a chance to short-circuit before).
-fn estimate_hook_coverage(
-    cmd: &str,
-    hook_installed: bool,
-    rules: &PermissionRules,
-    excluded: &[String],
-    transparent_prefixes: &[String],
-) -> bool {
-    if !hook_installed {
+fn estimate_hook_coverage(cmd: &str, ctx: &CoverageContext) -> bool {
+    if !ctx.hook_installed {
         return false;
     }
-    let verdict = permissions::check_command_with_rules(cmd, &rules.deny, &rules.ask, &rules.allow);
-    estimate_hook_coverage_with_verdict(
+    let verdict = permissions::check_command_with_rules(
         cmd,
-        verdict,
-        hook_installed,
-        excluded,
-        transparent_prefixes,
-    )
+        &ctx.rules.deny,
+        &ctx.rules.ask,
+        &ctx.rules.allow,
+    );
+    estimate_hook_coverage_with_verdict(cmd, verdict, ctx)
 }
 
 /// Pure core of `estimate_hook_coverage`, taking the permission verdict directly so
@@ -145,14 +138,12 @@ fn estimate_hook_coverage(
 fn estimate_hook_coverage_with_verdict(
     cmd: &str,
     verdict: PermissionVerdict,
-    hook_installed: bool,
-    excluded: &[String],
-    transparent_prefixes: &[String],
+    ctx: &CoverageContext,
 ) -> bool {
-    hook_installed
+    ctx.hook_installed
         && verdict != PermissionVerdict::Deny
         && !lexer::contains_unattestable_construct(cmd)
-        && registry::rewrite_command(cmd, excluded, transparent_prefixes).is_some()
+        && registry::rewrite_command(cmd, &ctx.excluded, &ctx.transparent_prefixes).is_some()
 }
 
 /// Whether an already-`rtk`-prefixed command counts as coverage. `rtk proxy <cmd>`
@@ -240,6 +231,14 @@ pub fn run(
             })
             .unwrap_or_default();
 
+    let coverage_ctx = CoverageContext {
+        hook_log,
+        hook_installed,
+        rules,
+        excluded,
+        transparent_prefixes,
+    };
+
     let mut total_commands: usize = 0;
     let mut already_rtk: usize = 0;
     let mut already_rtk_estimated: usize = 0;
@@ -284,13 +283,7 @@ pub fn run(
                     // here would make this section report zero bypassed commands as soon as
                     // real hook-decision rows exist (rtk-ai/rtk#3206 review).
                     if let Classification::Supported { .. } = classify_command(actual_cmd) {
-                        if estimate_hook_coverage(
-                            actual_cmd,
-                            hook_installed,
-                            &rules,
-                            &excluded,
-                            &transparent_prefixes,
-                        ) {
+                        if estimate_hook_coverage(actual_cmd, &coverage_ctx) {
                             rtk_disabled_count += 1;
                             rtk_disabled_estimated += 1;
                             let display = truncate_command(actual_cmd);
@@ -307,15 +300,7 @@ pub fn run(
                         estimated_savings_pct,
                         status,
                     } => {
-                        let coverage = hook_coverage(
-                            part,
-                            &ext_cmd.tool_use_id,
-                            &hook_log,
-                            hook_installed,
-                            &rules,
-                            &excluded,
-                            &transparent_prefixes,
-                        );
+                        let coverage = hook_coverage(part, &ext_cmd.tool_use_id, &coverage_ctx);
 
                         if coverage.is_covered() {
                             // Hook already routed this through RTK at runtime — it's
@@ -532,33 +517,41 @@ mod tests {
         }
     }
 
+    /// Build a `CoverageContext` for tests, with an empty `hook_log` (so every
+    /// call falls through to the estimate) and no permission/exclusion rules
+    /// unless overridden by the caller after construction.
+    fn test_ctx(hook_installed: bool) -> CoverageContext {
+        CoverageContext {
+            hook_log: HashMap::new(),
+            hook_installed,
+            rules: empty_rules(),
+            excluded: vec![],
+            transparent_prefixes: vec![],
+        }
+    }
+
     #[test]
     fn test_estimate_hook_coverage_false_when_hook_not_installed() {
         // No hook installed → the raw command genuinely ran unfiltered; still a miss.
         assert!(!estimate_hook_coverage_with_verdict(
             "grep -n foo bar.py",
             PermissionVerdict::Default,
-            false,
-            &[],
-            &[]
+            &test_ctx(false),
         ));
     }
 
     #[test]
     fn test_estimate_hook_coverage_true_for_rewritable_command() {
+        let ctx = test_ctx(true);
         assert!(estimate_hook_coverage_with_verdict(
             "grep -n foo bar.py",
             PermissionVerdict::Default,
-            true,
-            &[],
-            &[]
+            &ctx,
         ));
         assert!(estimate_hook_coverage_with_verdict(
             "ls -la",
             PermissionVerdict::Allow,
-            true,
-            &[],
-            &[]
+            &ctx,
         ));
     }
 
@@ -569,9 +562,7 @@ mod tests {
         assert!(!estimate_hook_coverage_with_verdict(
             "git status $(rm -rf /tmp/x)",
             PermissionVerdict::Default,
-            true,
-            &[],
-            &[]
+            &test_ctx(true),
         ));
     }
 
@@ -579,13 +570,12 @@ mod tests {
     fn test_estimate_hook_coverage_false_when_excluded_by_config() {
         // Even with the hook installed, a command the user excluded via config
         // was never rewritten — the hook stepped aside, so it's a genuine miss.
-        let excluded = vec!["grep".to_string()];
+        let mut ctx = test_ctx(true);
+        ctx.excluded = vec!["grep".to_string()];
         assert!(!estimate_hook_coverage_with_verdict(
             "grep -n foo bar.py",
             PermissionVerdict::Default,
-            true,
-            &excluded,
-            &[]
+            &ctx,
         ));
     }
 
@@ -597,9 +587,7 @@ mod tests {
         assert!(!estimate_hook_coverage_with_verdict(
             "rm -rf /",
             PermissionVerdict::Deny,
-            true,
-            &[],
-            &[]
+            &test_ctx(true),
         ));
     }
 
@@ -624,18 +612,11 @@ mod tests {
     fn test_hook_coverage_prefers_measured_log_over_estimate() {
         // Even if the current hook state would estimate "not covered" (hook
         // uninstalled today), a real log row is ground truth and wins.
-        let mut log = HashMap::new();
-        log.insert("toolu_1".to_string(), record(HookOutcome::Allow));
+        let mut ctx = test_ctx(false);
+        ctx.hook_log
+            .insert("toolu_1".to_string(), record(HookOutcome::Allow));
 
-        let coverage = hook_coverage(
-            "git status",
-            "toolu_1",
-            &log,
-            false,
-            &empty_rules(),
-            &[],
-            &[],
-        );
+        let coverage = hook_coverage("git status", "toolu_1", &ctx);
         assert!(matches!(coverage, Coverage::Measured(true)));
         assert!(coverage.is_covered());
         assert!(!coverage.is_estimated());
@@ -643,10 +624,11 @@ mod tests {
 
     #[test]
     fn test_hook_coverage_measured_deny_is_a_genuine_miss() {
-        let mut log = HashMap::new();
-        log.insert("toolu_1".to_string(), record(HookOutcome::Deny));
+        let mut ctx = test_ctx(true);
+        ctx.hook_log
+            .insert("toolu_1".to_string(), record(HookOutcome::Deny));
 
-        let coverage = hook_coverage("rm -rf /", "toolu_1", &log, true, &empty_rules(), &[], &[]);
+        let coverage = hook_coverage("rm -rf /", "toolu_1", &ctx);
         assert!(matches!(coverage, Coverage::Measured(false)));
         assert!(!coverage.is_covered());
     }
@@ -655,17 +637,7 @@ mod tests {
     fn test_hook_coverage_falls_back_to_estimate_when_no_log_row() {
         // No log entry for this tool_use_id — predates logging (or non-Claude) —
         // falls back to the current-state heuristic, flagged as estimated.
-        let log = HashMap::new();
-
-        let coverage = hook_coverage(
-            "ls -la",
-            "toolu_missing",
-            &log,
-            true,
-            &empty_rules(),
-            &[],
-            &[],
-        );
+        let coverage = hook_coverage("ls -la", "toolu_missing", &test_ctx(true));
         assert!(coverage.is_estimated());
     }
 }

--- a/src/discover/mod.rs
+++ b/src/discover/mod.rs
@@ -97,42 +97,59 @@ struct CoverageContext {
 /// accumulated (rtk-ai/rtk#3206 review) — the counterfactual can only ever be
 /// answered by the estimate.
 ///
-/// Known imprecision: the caller splits a chained command (`a && b`) into parts
-/// and calls this once per part with the *same* `tool_use_id`, since Claude Code's
-/// PreToolUse hook fires once per tool call for the whole raw command. A `Deny`/
-/// `Ask` verdict genuinely is chain-wide (`permissions::check_command_with_rules`
-/// denies/asks the entire chain if any segment matches), but the real rewrite
-/// (`registry::rewrite_command`) is best-effort *per segment* — it can rewrite
-/// just `a` and leave an unsupported `b` untouched. Neither `Measured` (one
+/// The caller splits a chained command (`a && b`) into parts and calls this once
+/// per part with the *same* `tool_use_id`, since Claude Code's PreToolUse hook
+/// fires once per tool call for the whole raw command. `raw_cmd` MUST be the full,
+/// unsplit original command line (`ExtractedCommand::command`) even though this is
+/// being asked about one `part` of it — passing an isolated segment here would
+/// silently blind the `Deny`/`Ask` permission check to sibling segments (a
+/// chain-wide deny rule matching only `a` would go undetected when checking `b` in
+/// isolation, since `permissions::check_command_with_rules` only re-derives the
+/// chain from whatever string it's given). The real rewrite (`registry::
+/// rewrite_command`) genuinely is best-effort *per segment* though — it can
+/// rewrite just `a` and leave an unsupported `b` untouched — so `rewrite_cmd` is
+/// deliberately the isolated `part`, not `raw_cmd`. Neither `Measured` (one
 /// `hook_decisions` row per `tool_use_id`, no per-segment detail) nor `Estimated`
-/// re-derives that per-segment split, so a segment can be reported covered/missed
-/// based on a sibling segment's fate. Not worth chasing further: `Estimated` is a
-/// transitional fallback for history that predates `hook_decisions` logging and
-/// naturally fades out as that log backfills — after ~90 days only `Measured`
-/// should remain in practice.
-fn hook_coverage(cmd: &str, tool_use_id: &str, ctx: &CoverageContext) -> Coverage {
+/// re-derives the rewrite's per-segment split, so a segment can still be reported
+/// covered/missed based on a sibling segment's rewrite fate — that residual
+/// imprecision is unavoidable without per-segment hook logging and isn't worth
+/// chasing further. `Estimated` is the fallback for history that predates
+/// `hook_decisions` logging — but note it does NOT simply fade out over time:
+/// `hook_decisions` rows are pruned by the same `DEFAULT_HISTORY_DAYS` retention
+/// window as the rest of the tracking DB (see `Tracker::cleanup_hook_decisions`),
+/// so any `--since` reaching further back than that window permanently needs
+/// `Estimated`, indefinitely, not just during an initial backfill period.
+fn hook_coverage(
+    raw_cmd: &str,
+    rewrite_cmd: &str,
+    tool_use_id: &str,
+    ctx: &CoverageContext,
+) -> Coverage {
     if let Some(record) = ctx.hook_log.get(tool_use_id) {
         return Coverage::Measured(record.decision.is_covered());
     }
-    Coverage::Estimated(estimate_hook_coverage(cmd, cmd, ctx))
+    Coverage::Estimated(estimate_hook_coverage(raw_cmd, rewrite_cmd, ctx))
 }
 
 /// Best-effort guess at whether the *currently* installed hook would rewrite this
 /// command, used only when no `hook_decisions` log row exists for this exact
 /// invocation.
 ///
-/// Takes two forms of the command because the RTK_DISABLED= bypass call site
-/// (`run`) needs them to differ: `permission_cmd` is checked against permission
-/// rules and scanned for unattestable constructs, and MUST be the exact string
-/// the real hook would have seen — including any `RTK_DISABLED=` prefix — since
-/// that's what Claude Code's permission engine actually evaluates against
-/// (`hooks::hook_cmd::decide_hook_action` never strips it). `rewrite_cmd` is
-/// passed to `registry::rewrite_command`, which itself detects and refuses an
-/// `RTK_DISABLED=` prefix (registry.rs #345) — so for the bypass call site this
-/// must be the already-*stripped* command, or every bypassed command would
-/// register as never-covered regardless of whether it's otherwise supported,
-/// defeating the point of the RTK_DISABLED bucket entirely. For the ordinary
-/// (non-bypass) call site both are simply the same string.
+/// Takes two forms of the command because callers generally need them to differ:
+/// `permission_cmd` is checked against permission rules and scanned for
+/// unattestable constructs, and MUST be the exact full string the real hook would
+/// have seen — the whole raw command line, chain operators and any
+/// `RTK_DISABLED=` prefix intact — since that's what Claude Code's permission
+/// engine actually evaluates (`hooks::hook_cmd::decide_hook_action` never splits
+/// or strips it; see `hook_coverage`'s doc comment for why an isolated chain
+/// segment would blind the deny/ask check to sibling segments). `rewrite_cmd` is
+/// passed to `registry::rewrite_command`, which is genuinely best-effort
+/// *per segment* — pass the isolated segment being evaluated. For the RTK_DISABLED=
+/// bypass call site specifically, `rewrite_cmd` must also have the prefix already
+/// *stripped*, since `rewrite_command` itself detects and refuses a raw
+/// `RTK_DISABLED=` prefix (registry.rs #345) — passing it unstripped there would
+/// make every bypassed command register as never-covered regardless of whether
+/// it's otherwise supported, defeating the point of the RTK_DISABLED bucket.
 ///
 /// Checks `hook_installed` before touching `rules`/the lexer/the registry: with no
 /// hook installed the answer is always "not covered", so there's no reason to pay
@@ -191,10 +208,14 @@ fn estimate_hook_coverage_with_verdict(
 /// silently collapse to (near) zero once real `hook_decisions` rows accumulated
 /// (rtk-ai/rtk#3206 review) — only the estimate can ever answer this.
 ///
-/// `raw_cmd` (with the prefix intact) is what the real hook's permission check
-/// would have seen; `stripped_cmd` (prefix removed) is what `registry::
-/// rewrite_command` needs, since it refuses a raw `RTK_DISABLED=`-prefixed string
-/// on its own — see `estimate_hook_coverage`'s doc comment for the full reasoning.
+/// `raw_cmd` must be the *full, unsplit* original command line
+/// (`ExtractedCommand::command`), prefix and any sibling chain segments intact —
+/// what the real hook's permission check would have seen (see `hook_coverage`'s
+/// doc comment for why an isolated segment would blind the deny/ask check to
+/// siblings). `stripped_cmd` is the isolated, prefix-*removed* segment being
+/// evaluated, which is what `registry::rewrite_command` needs since it refuses a
+/// raw `RTK_DISABLED=`-prefixed string on its own — see `estimate_hook_coverage`'s
+/// doc comment for the full reasoning.
 fn would_be_covered_without_bypass(
     raw_cmd: &str,
     stripped_cmd: &str,
@@ -358,24 +379,45 @@ pub fn run(
 
                 // Detect RTK_DISABLED= bypass before classification
                 let (env_prefix, actual_cmd) = strip_disabled_prefix(part);
-                if prefix_contains_rtk_disabled(env_prefix) {
-                    // Only count if the underlying command is one RTK supports, AND the
-                    // hook would actually have covered it — otherwise RTK_DISABLED=
-                    // bypassed nothing (hook wasn't installed / excluded / would defer
-                    // / would deny), and flagging it as a "bypass" would be false advice.
-                    //
-                    // See `would_be_covered_without_bypass`'s doc comment for why this must
-                    // never go through `hook_coverage`'s measured-log path.
-                    if let Classification::Supported { .. } = classify_command(actual_cmd) {
-                        if would_be_covered_without_bypass(part, actual_cmd, &coverage_ctx) {
-                            rtk_disabled_count += 1;
-                            rtk_disabled_estimated += 1;
-                            let display = truncate_command(actual_cmd);
-                            *rtk_disabled_cmds.entry(display).or_insert(0) += 1;
+                let part = if prefix_contains_rtk_disabled(env_prefix) {
+                    match classify_command(actual_cmd) {
+                        Classification::Supported { .. } => {
+                            // Only count as a "bypass" if the hook would actually have
+                            // covered it absent the bypass — otherwise RTK_DISABLED=
+                            // bypassed nothing (hook wasn't installed / excluded / would
+                            // defer / would deny), and flagging it as a "bypass" would be
+                            // false advice. See `would_be_covered_without_bypass`'s doc
+                            // comment for why this must never go through `hook_coverage`'s
+                            // measured-log path.
+                            if would_be_covered_without_bypass(
+                                &ext_cmd.command,
+                                actual_cmd,
+                                &coverage_ctx,
+                            ) {
+                                rtk_disabled_count += 1;
+                                rtk_disabled_estimated += 1;
+                                let display = truncate_command(actual_cmd);
+                                *rtk_disabled_cmds.entry(display).or_insert(0) += 1;
+                                continue;
+                            }
+                            // Genuinely never had a chance regardless of the bypass (no
+                            // hook installed / excluded by config / etc.) — a real
+                            // missed-savings opportunity like any other command, not a
+                            // "bypass" of anything. Fall through to the normal
+                            // classification below (using the env-stripped command)
+                            // instead of vanishing from the whole report — previously
+                            // this case was counted only in `total_commands` and nowhere
+                            // else (rtk-ai/rtk#3206 review).
+                            actual_cmd
                         }
+                        // Unsupported/Ignored under RTK_DISABLED= isn't interesting
+                        // either way — rtk was never going to touch it regardless of
+                        // the bypass.
+                        _ => continue,
                     }
-                    continue;
-                }
+                } else {
+                    part
+                };
 
                 match classify_command(part) {
                     Classification::Supported {
@@ -384,7 +426,12 @@ pub fn run(
                         estimated_savings_pct,
                         status,
                     } => {
-                        let coverage = hook_coverage(part, &ext_cmd.tool_use_id, &coverage_ctx);
+                        let coverage = hook_coverage(
+                            &ext_cmd.command,
+                            part,
+                            &ext_cmd.tool_use_id,
+                            &coverage_ctx,
+                        );
 
                         if coverage.is_covered() {
                             // Hook already routed this through RTK at runtime — it's
@@ -704,6 +751,35 @@ mod tests {
     }
 
     #[test]
+    fn test_estimate_hook_coverage_sees_chain_wide_deny_from_full_raw_command() {
+        // Regression: check_command_with_rules re-derives the chain from whatever
+        // string it's handed, so a deny rule matching only a *sibling* segment
+        // (e.g. "cd /sensitive" in "cd /sensitive && grep -rn foo .") is invisible
+        // if the isolated segment being evaluated ("grep -rn foo .") is what gets
+        // passed as the permission-check command — exactly what the real hook
+        // would NOT do (it always evaluates the whole raw line). Must pass the
+        // full, unsplit command as `raw_cmd`, not the isolated `rewrite_cmd`.
+        let mut ctx = test_ctx(true);
+        ctx.rules.deny = vec!["cd /sensitive".to_string()];
+        let full_chain = "cd /sensitive && grep -rn foo .";
+        let isolated_segment = "grep -rn foo .";
+
+        assert!(
+            !estimate_hook_coverage(full_chain, isolated_segment, &ctx),
+            "a deny rule matching a sibling chain segment must still deny the whole chain"
+        );
+
+        // Sanity check demonstrating the bug this guards against: checking
+        // permissions against the isolated segment alone (instead of the full
+        // chain) misses the sibling's deny match entirely.
+        assert!(
+            estimate_hook_coverage(isolated_segment, isolated_segment, &ctx),
+            "checking the isolated segment alone should miss the sibling's deny rule \
+             (demonstrates why raw_cmd must be the full chain, not a segment)"
+        );
+    }
+
+    #[test]
     fn test_is_already_rtk_plain_rewrite() {
         assert!(is_already_rtk("rtk grep -n foo bar.py"));
     }
@@ -728,7 +804,7 @@ mod tests {
         ctx.hook_log
             .insert("toolu_1".to_string(), record(HookOutcome::Allow));
 
-        let coverage = hook_coverage("git status", "toolu_1", &ctx);
+        let coverage = hook_coverage("git status", "git status", "toolu_1", &ctx);
         assert!(matches!(coverage, Coverage::Measured(true)));
         assert!(coverage.is_covered());
         assert!(!coverage.is_estimated());
@@ -740,7 +816,7 @@ mod tests {
         ctx.hook_log
             .insert("toolu_1".to_string(), record(HookOutcome::Deny));
 
-        let coverage = hook_coverage("rm -rf /", "toolu_1", &ctx);
+        let coverage = hook_coverage("rm -rf /", "rm -rf /", "toolu_1", &ctx);
         assert!(matches!(coverage, Coverage::Measured(false)));
         assert!(!coverage.is_covered());
     }
@@ -749,7 +825,7 @@ mod tests {
     fn test_hook_coverage_falls_back_to_estimate_when_no_log_row() {
         // No log entry for this tool_use_id — predates logging (or non-Claude) —
         // falls back to the current-state heuristic, flagged as estimated.
-        let coverage = hook_coverage("ls -la", "toolu_missing", &test_ctx(true));
+        let coverage = hook_coverage("ls -la", "ls -la", "toolu_missing", &test_ctx(true));
         assert!(coverage.is_estimated());
     }
 }

--- a/src/discover/mod.rs
+++ b/src/discover/mod.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use provider::{ClaudeProvider, SessionProvider};
 use registry::{
     category_avg_tokens, classify_command, split_command_chain, strip_disabled_prefix,
-    Classification,
+    Classification, ExcludePattern,
 };
 use report::{DiscoverReport, SupportedEntry, UnsupportedEntry};
 
@@ -62,23 +62,32 @@ struct PermissionRules {
 /// besides the command (and `tool_use_id`) itself — built once per `discover` run
 /// and passed by reference to every per-command call.
 ///
-/// Grouped into one struct rather than five individual positional params: with
+/// Grouped into one struct rather than several individual positional params: with
 /// `excluded`/`transparent_prefixes` both `Vec<String>`, a swapped argument order
 /// at a call site would compile silently and misclassify RTK_DISABLED bypass
 /// coverage (code-review finding on rtk-ai/rtk#3206's fixup round).
+///
+/// `exclude_patterns`/`normalized_transparent_prefixes` are `registry::
+/// rewrite_command`'s exclude-pattern regexes and normalized prefixes,
+/// precompiled once here instead of inside `rewrite_command` on every call — that
+/// recompilation is exactly the "recompute per command instead of once per run"
+/// class of cost this PR's `PermissionRules`/`hook_status` caching already fixed
+/// elsewhere, left as a hot-loop cost in `estimate_hook_coverage_with_verdict`'s
+/// `registry::rewrite_command` call until now (code-review finding on rtk-ai/rtk#3206's
+/// second fixup round).
 struct CoverageContext {
     hook_log: HashMap<String, HookDecisionRecord>,
     hook_installed: bool,
     rules: PermissionRules,
-    excluded: Vec<String>,
-    transparent_prefixes: Vec<String>,
+    exclude_patterns: Vec<ExcludePattern>,
+    normalized_transparent_prefixes: Vec<String>,
 }
 
 /// Determine whether `cmd` was (or, absent a log entry, likely would have been)
 /// routed through RTK by the installed PreToolUse hook.
 ///
 /// Do NOT call this for an `RTK_DISABLED=`-bypassed command — call
-/// `estimate_hook_coverage` directly instead. `hook_coverage` trusts a measured
+/// `would_be_covered_without_bypass` instead. `hook_coverage` trusts a measured
 /// `hook_decisions` row as ground truth, but for a bypassed command the real logged
 /// decision is always `Defer` (see `registry.rs` #345 / `get_rewritten`), which only
 /// confirms the hook stepped aside — it says nothing about whether the command would
@@ -105,11 +114,25 @@ fn hook_coverage(cmd: &str, tool_use_id: &str, ctx: &CoverageContext) -> Coverag
     if let Some(record) = ctx.hook_log.get(tool_use_id) {
         return Coverage::Measured(record.decision.is_covered());
     }
-    Coverage::Estimated(estimate_hook_coverage(cmd, ctx))
+    Coverage::Estimated(estimate_hook_coverage(cmd, cmd, ctx))
 }
 
-/// Best-effort guess at whether the *currently* installed hook would rewrite `cmd`,
-/// used only when no `hook_decisions` log row exists for this exact invocation.
+/// Best-effort guess at whether the *currently* installed hook would rewrite this
+/// command, used only when no `hook_decisions` log row exists for this exact
+/// invocation.
+///
+/// Takes two forms of the command because the RTK_DISABLED= bypass call site
+/// (`run`) needs them to differ: `permission_cmd` is checked against permission
+/// rules and scanned for unattestable constructs, and MUST be the exact string
+/// the real hook would have seen — including any `RTK_DISABLED=` prefix — since
+/// that's what Claude Code's permission engine actually evaluates against
+/// (`hooks::hook_cmd::decide_hook_action` never strips it). `rewrite_cmd` is
+/// passed to `registry::rewrite_command`, which itself detects and refuses an
+/// `RTK_DISABLED=` prefix (registry.rs #345) — so for the bypass call site this
+/// must be the already-*stripped* command, or every bypassed command would
+/// register as never-covered regardless of whether it's otherwise supported,
+/// defeating the point of the RTK_DISABLED bucket entirely. For the ordinary
+/// (non-bypass) call site both are simply the same string.
 ///
 /// Checks `hook_installed` before touching `rules`/the lexer/the registry: with no
 /// hook installed the answer is always "not covered", so there's no reason to pay
@@ -117,33 +140,67 @@ fn hook_coverage(cmd: &str, tool_use_id: &str, ctx: &CoverageContext) -> Coverag
 /// registry rewrite check on every single command in the scan (see
 /// rtk-ai/rtk#3206 review: 100s of wasted work on histories with no hook ever
 /// installed, since that case never had a chance to short-circuit before).
-fn estimate_hook_coverage(cmd: &str, ctx: &CoverageContext) -> bool {
+fn estimate_hook_coverage(permission_cmd: &str, rewrite_cmd: &str, ctx: &CoverageContext) -> bool {
     if !ctx.hook_installed {
         return false;
     }
     let verdict = permissions::check_command_with_rules(
-        cmd,
+        permission_cmd,
         &ctx.rules.deny,
         &ctx.rules.ask,
         &ctx.rules.allow,
     );
-    estimate_hook_coverage_with_verdict(cmd, verdict, ctx)
+    estimate_hook_coverage_with_verdict(permission_cmd, rewrite_cmd, verdict, ctx)
 }
 
 /// Pure core of `estimate_hook_coverage`, taking the permission verdict directly so
 /// it's testable without depending on real config files. Mirrors the real hook's own
 /// decision order (`hooks::hook_cmd::decide_from_verdict`): a `Deny`-rule match or an
 /// unattestable construct means the hook would never have rewritten this, regardless
-/// of registry support.
+/// of registry support. See `estimate_hook_coverage` for why `permission_cmd` and
+/// `rewrite_cmd` can differ.
 fn estimate_hook_coverage_with_verdict(
-    cmd: &str,
+    permission_cmd: &str,
+    rewrite_cmd: &str,
     verdict: PermissionVerdict,
     ctx: &CoverageContext,
 ) -> bool {
     ctx.hook_installed
         && verdict != PermissionVerdict::Deny
-        && !lexer::contains_unattestable_construct(cmd)
-        && registry::rewrite_command(cmd, &ctx.excluded, &ctx.transparent_prefixes).is_some()
+        && !lexer::contains_unattestable_construct(permission_cmd)
+        && registry::rewrite_command_precompiled(
+            rewrite_cmd,
+            &ctx.exclude_patterns,
+            &ctx.normalized_transparent_prefixes,
+        )
+        .is_some()
+}
+
+/// Would `raw_cmd` (still carrying its `RTK_DISABLED=` prefix) have been covered
+/// by the hook if the bypass weren't there?
+///
+/// The *only* correct way to answer this question — deliberately named and kept
+/// separate from `hook_coverage` so an RTK_DISABLED= call site reaches for this
+/// instead of `hook_coverage` by construction, not just by doc comment. A prior
+/// review round had to catch exactly this mixup once already: `hook_coverage`
+/// trusts a measured `hook_decisions` row as ground truth, but a bypassed
+/// command's real logged decision is always `Defer` (`get_rewritten` refuses an
+/// `RTK_DISABLED=` prefix unconditionally — registry.rs #345), which only confirms
+/// the hook stepped aside and says nothing about the counterfactual this function
+/// answers. Consulting the measured log there made the RTK_DISABLED bucket
+/// silently collapse to (near) zero once real `hook_decisions` rows accumulated
+/// (rtk-ai/rtk#3206 review) — only the estimate can ever answer this.
+///
+/// `raw_cmd` (with the prefix intact) is what the real hook's permission check
+/// would have seen; `stripped_cmd` (prefix removed) is what `registry::
+/// rewrite_command` needs, since it refuses a raw `RTK_DISABLED=`-prefixed string
+/// on its own — see `estimate_hook_coverage`'s doc comment for the full reasoning.
+fn would_be_covered_without_bypass(
+    raw_cmd: &str,
+    stripped_cmd: &str,
+    ctx: &CoverageContext,
+) -> bool {
+    estimate_hook_coverage(raw_cmd, stripped_cmd, ctx)
 }
 
 /// Whether an already-`rtk`-prefixed command counts as coverage. `rtk proxy <cmd>`
@@ -216,27 +273,60 @@ pub fn run(
     // predates logging (or isn't Claude Code).
     let hook_installed = hook_status() != HookStatus::Missing;
     let (excluded, transparent_prefixes) = crate::core::config::hook_rewrite_params();
+    // Compiled once here (see `CoverageContext`'s doc comment), not once per
+    // command inside `registry::rewrite_command`.
+    let exclude_patterns = registry::compile_exclude_patterns(&excluded);
+    let normalized_transparent_prefixes =
+        registry::normalize_transparent_prefixes(&transparent_prefixes);
 
     // Loaded once up front (see `PermissionRules`), not once per command.
     let (deny, ask, allow) = permissions::load_rules_for(permissions::Host::Claude);
     let rules = PermissionRules { deny, ask, allow };
 
     let cutoff = crate::core::utils::days_ago_cutoff(since_days);
+    // Every other hook_decisions-touching path (record()/record_parse_failure()/
+    // record_hook_decision() in tracking.rs) warns the user when a write fails
+    // because a table is missing, pointing them at `rtk init` to self-heal. This
+    // read path used to swallow the same class of error via unwrap_or_default()/
+    // ok().flatten(), silently reporting "no hook-decision log yet" for what could
+    // actually be a corrupted database — warn here too instead of going quiet.
     let (hook_log, measured_since): (HashMap<String, HookDecisionRecord>, Option<DateTime<Utc>>) =
-        Tracker::new()
-            .map(|t| {
-                let log = t.hook_decisions_since(cutoff).unwrap_or_default();
-                let measured_since = t.earliest_hook_decision_timestamp().ok().flatten();
+        match Tracker::new() {
+            Ok(t) => {
+                let log = t.hook_decisions_since(cutoff).unwrap_or_else(|e| {
+                    eprintln!(
+                        "rtk: warning: failed to read hook_decisions log ({e}). \
+                         Coverage will fall back to the current-state estimate. \
+                         Run `rtk init` if the tracking database looks corrupted."
+                    );
+                    HashMap::new()
+                });
+                let measured_since = t.earliest_hook_decision_timestamp().unwrap_or_else(|e| {
+                    eprintln!("rtk: warning: failed to read hook_decisions log timestamp ({e}).");
+                    None
+                });
                 (log, measured_since)
-            })
-            .unwrap_or_default();
+            }
+            Err(e) => {
+                // A brand-new install with no tracking DB yet is the common,
+                // benign case here — only surface this under --verbose so a fresh
+                // `rtk discover` run doesn't alarm a first-time user.
+                if verbose > 0 {
+                    eprintln!(
+                        "rtk: warning: failed to open tracking database ({e}). \
+                         Coverage will fall back to the current-state estimate."
+                    );
+                }
+                (HashMap::new(), None)
+            }
+        };
 
     let coverage_ctx = CoverageContext {
         hook_log,
         hook_installed,
         rules,
-        excluded,
-        transparent_prefixes,
+        exclude_patterns,
+        normalized_transparent_prefixes,
     };
 
     let mut total_commands: usize = 0;
@@ -274,16 +364,10 @@ pub fn run(
                     // bypassed nothing (hook wasn't installed / excluded / would defer
                     // / would deny), and flagging it as a "bypass" would be false advice.
                     //
-                    // Deliberately always the *estimate*, never `hook_coverage`'s measured
-                    // log: `RTK_DISABLED=` makes `get_rewritten` return `None` unconditionally
-                    // (registry.rs #345), so the real logged decision for a bypassed command
-                    // is always `Defer` (never `Allow`/`Ask`) — that's the hook correctly
-                    // recording that it stepped aside, not evidence about whether the command
-                    // would have been covered absent the bypass. Consulting the measured log
-                    // here would make this section report zero bypassed commands as soon as
-                    // real hook-decision rows exist (rtk-ai/rtk#3206 review).
+                    // See `would_be_covered_without_bypass`'s doc comment for why this must
+                    // never go through `hook_coverage`'s measured-log path.
                     if let Classification::Supported { .. } = classify_command(actual_cmd) {
-                        if estimate_hook_coverage(actual_cmd, &coverage_ctx) {
+                        if would_be_covered_without_bypass(part, actual_cmd, &coverage_ctx) {
                             rtk_disabled_count += 1;
                             rtk_disabled_estimated += 1;
                             let display = truncate_command(actual_cmd);
@@ -525,8 +609,8 @@ mod tests {
             hook_log: HashMap::new(),
             hook_installed,
             rules: empty_rules(),
-            excluded: vec![],
-            transparent_prefixes: vec![],
+            exclude_patterns: vec![],
+            normalized_transparent_prefixes: vec![],
         }
     }
 
@@ -534,6 +618,7 @@ mod tests {
     fn test_estimate_hook_coverage_false_when_hook_not_installed() {
         // No hook installed → the raw command genuinely ran unfiltered; still a miss.
         assert!(!estimate_hook_coverage_with_verdict(
+            "grep -n foo bar.py",
             "grep -n foo bar.py",
             PermissionVerdict::Default,
             &test_ctx(false),
@@ -545,10 +630,12 @@ mod tests {
         let ctx = test_ctx(true);
         assert!(estimate_hook_coverage_with_verdict(
             "grep -n foo bar.py",
+            "grep -n foo bar.py",
             PermissionVerdict::Default,
             &ctx,
         ));
         assert!(estimate_hook_coverage_with_verdict(
+            "ls -la",
             "ls -la",
             PermissionVerdict::Allow,
             &ctx,
@@ -561,6 +648,7 @@ mod tests {
         // so a command containing one was never actually rewritten — genuine miss.
         assert!(!estimate_hook_coverage_with_verdict(
             "git status $(rm -rf /tmp/x)",
+            "git status $(rm -rf /tmp/x)",
             PermissionVerdict::Default,
             &test_ctx(true),
         ));
@@ -571,8 +659,9 @@ mod tests {
         // Even with the hook installed, a command the user excluded via config
         // was never rewritten — the hook stepped aside, so it's a genuine miss.
         let mut ctx = test_ctx(true);
-        ctx.excluded = vec!["grep".to_string()];
+        ctx.exclude_patterns = registry::compile_exclude_patterns(&["grep".to_string()]);
         assert!(!estimate_hook_coverage_with_verdict(
+            "grep -n foo bar.py",
             "grep -n foo bar.py",
             PermissionVerdict::Default,
             &ctx,
@@ -586,9 +675,32 @@ mod tests {
         // as covered would over-count savings for commands the hook actually denied.
         assert!(!estimate_hook_coverage_with_verdict(
             "rm -rf /",
+            "rm -rf /",
             PermissionVerdict::Deny,
             &test_ctx(true),
         ));
+    }
+
+    #[test]
+    fn test_estimate_hook_coverage_uses_full_raw_command_for_permission_check() {
+        // Regression: the RTK_DISABLED= bypass path must check permission rules
+        // against the *full* raw command (prefix intact) — matching what the real
+        // hook's permission engine actually evaluates — even though the rewrite
+        // check needs the stripped form. An exact-match deny rule on the literal
+        // prefixed command only matches the raw form, not the stripped one.
+        let mut ctx = test_ctx(true);
+        ctx.rules.deny = vec!["RTK_DISABLED=1 git status".to_string()];
+
+        assert!(
+            !would_be_covered_without_bypass("RTK_DISABLED=1 git status", "git status", &ctx),
+            "a deny rule matching the raw (prefixed) command must still apply"
+        );
+
+        // Sanity check: the same deny rule does NOT match the stripped form alone —
+        // if `estimate_hook_coverage` regressed to checking permissions against
+        // `stripped_cmd` instead of `raw_cmd`, this assertion would start failing
+        // (the bug would make it come back true instead of false above).
+        assert!(estimate_hook_coverage("git status", "git status", &ctx));
     }
 
     #[test]

--- a/src/discover/provider.rs
+++ b/src/discover/provider.rs
@@ -16,6 +16,10 @@ pub struct ExtractedCommand {
     pub output_len: Option<usize>,
     #[allow(dead_code)]
     pub session_id: String,
+    /// The Claude Code `tool_use_id` for this Bash call — the same id the
+    /// PreToolUse hook receives, letting hook-decision logs join back to this
+    /// exact transcript entry.
+    pub tool_use_id: String,
     /// Actual output content (first ~1000 chars for error detection)
     pub output_content: Option<String>,
     /// Whether the tool_result indicated an error
@@ -257,6 +261,7 @@ impl SessionProvider for ClaudeProvider {
                 command,
                 output_len,
                 session_id: session_id.clone(),
+                tool_use_id: tool_id,
                 output_content,
                 is_error,
                 sequence_index,

--- a/src/discover/provider.rs
+++ b/src/discover/provider.rs
@@ -65,9 +65,14 @@ impl ClaudeProvider {
         }
 
         // `days * 86400` can overflow u64 for a large user-supplied `--since` (same
-        // overflow class as `discover::hook_decisions_cutoff` fixes for the
-        // hook_decisions query) — use checked_mul and fall back to the epoch, which
-        // for "days ago" naturally means "no lower bound", instead of panicking.
+        // overflow class `core::utils::days_ago_cutoff` fixes for the hook_decisions
+        // query) — use checked_mul and fall back to the epoch, which for "days ago"
+        // naturally means "no lower bound", instead of panicking. Kept as its own
+        // SystemTime-based implementation rather than reusing days_ago_cutoff
+        // directly: this filters on file mtimes (SystemTime), not chrono
+        // DateTime<Utc>, and days_ago_cutoff's MIN_UTC fallback wouldn't convert to
+        // a valid SystemTime anyway. If this overflow-clamping logic needs a fix,
+        // check whether the same fix applies to days_ago_cutoff too.
         let cutoff = since_days.map(|days| {
             days.checked_mul(86400)
                 .and_then(|secs| SystemTime::now().checked_sub(Duration::from_secs(secs)))

--- a/src/discover/provider.rs
+++ b/src/discover/provider.rs
@@ -64,9 +64,13 @@ impl ClaudeProvider {
             return Ok(Vec::new());
         }
 
+        // `days * 86400` can overflow u64 for a large user-supplied `--since` (same
+        // overflow class as `discover::hook_decisions_cutoff` fixes for the
+        // hook_decisions query) — use checked_mul and fall back to the epoch, which
+        // for "days ago" naturally means "no lower bound", instead of panicking.
         let cutoff = since_days.map(|days| {
-            SystemTime::now()
-                .checked_sub(Duration::from_secs(days * 86400))
+            days.checked_mul(86400)
+                .and_then(|secs| SystemTime::now().checked_sub(Duration::from_secs(secs)))
                 .unwrap_or(SystemTime::UNIX_EPOCH)
         });
 

--- a/src/discover/provider.rs
+++ b/src/discover/provider.rs
@@ -16,6 +16,10 @@ pub struct ExtractedCommand {
     pub output_len: Option<usize>,
     #[allow(dead_code)]
     pub session_id: String,
+    /// The Claude Code `tool_use_id` for this Bash call — the same id the
+    /// PreToolUse hook receives, letting hook-decision logs join back to this
+    /// exact transcript entry.
+    pub tool_use_id: String,
     /// Actual output content (first ~1000 chars for error detection)
     pub output_content: Option<String>,
     /// Whether the tool_result indicated an error
@@ -261,6 +265,7 @@ impl SessionProvider for ClaudeProvider {
                 command,
                 output_len,
                 session_id: session_id.clone(),
+                tool_use_id: tool_id,
                 output_content,
                 is_error,
                 sequence_index,

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -571,6 +571,25 @@ pub fn rewrite_command(
     excluded: &[String],
     transparent_prefixes: &[String],
 ) -> Option<String> {
+    let compiled = compile_exclude_patterns(excluded);
+    let normalized_prefixes = normalize_transparent_prefixes(transparent_prefixes);
+    rewrite_command_precompiled(cmd, &compiled, &normalized_prefixes)
+}
+
+/// Core of `rewrite_command`, taking already-compiled exclude patterns and
+/// already-normalized transparent prefixes so a caller checking many commands
+/// against the same config in a loop can compile once and reuse — instead of
+/// recompiling `exclude_commands` regexes on every single call. `rewrite_command`
+/// itself is the right entry point for a one-off check (real hook invocations,
+/// `rtk rewrite`, tests); this exists for `rtk discover`'s estimate-coverage
+/// fallback, which calls this once per historical command scanned (the same
+/// compile-once-per-run pattern this PR already applies to permission rules —
+/// see `discover::PermissionRules` — and hook-install status).
+pub(crate) fn rewrite_command_precompiled(
+    cmd: &str,
+    compiled: &[ExcludePattern],
+    normalized_prefixes: &[String],
+) -> Option<String> {
     // Bash joins `\<NL>` with nothing, so `<<` or `$((` can arrive split across
     // a continuation; the space-join below would erase them (#3188 review).
     if cmd.contains('\\') {
@@ -594,14 +613,11 @@ pub fn rewrite_command(
         return None;
     }
 
-    let compiled = compile_exclude_patterns(excluded);
-    let normalized_prefixes = normalize_transparent_prefixes(transparent_prefixes);
-
     if trimmed.contains('\n') {
-        return rewrite_multiline_block(trimmed, &compiled, &normalized_prefixes);
+        return rewrite_multiline_block(trimmed, compiled, normalized_prefixes);
     }
 
-    rewrite_single(trimmed, &compiled, &normalized_prefixes)
+    rewrite_single(trimmed, compiled, normalized_prefixes)
 }
 
 /// Rewrite one logical command line (no unquoted newlines).
@@ -1213,12 +1229,12 @@ fn pipeline_final_command_is_safe(rtk_cmd: &str, cmd: &str) -> bool {
     !matches!(rtk_cmd, "rtk grep" | "rtk rg") || !search_uses_pattern_file(cmd)
 }
 
-enum ExcludePattern {
+pub(crate) enum ExcludePattern {
     Regex(Regex),
     Prefix(String),
 }
 
-fn compile_exclude_patterns(patterns: &[String]) -> Vec<ExcludePattern> {
+pub(crate) fn compile_exclude_patterns(patterns: &[String]) -> Vec<ExcludePattern> {
     patterns
         .iter()
         .filter_map(|pattern| {
@@ -1249,7 +1265,7 @@ fn compile_exclude_patterns(patterns: &[String]) -> Vec<ExcludePattern> {
         .collect()
 }
 
-fn normalize_transparent_prefixes(prefixes: &[String]) -> Vec<String> {
+pub(crate) fn normalize_transparent_prefixes(prefixes: &[String]) -> Vec<String> {
     let mut normalized: Vec<String> = prefixes
         .iter()
         .map(|prefix| prefix.trim())

--- a/src/discover/report.rs
+++ b/src/discover/report.rs
@@ -98,6 +98,14 @@ pub struct DiscoverReport {
     pub sessions_scanned: usize,
     pub total_commands: usize,
     pub already_rtk: usize,
+    /// Subset of `already_rtk` that came from the current-state heuristic fallback
+    /// rather than a measured `hook_decisions` log entry — i.e. history that
+    /// predates hook-decision logging (or isn't Claude Code).
+    pub already_rtk_estimated: usize,
+    /// Date (`YYYY-MM-DD`) the earliest `hook_decisions` log entry was recorded, if
+    /// any exist. `None` means no measured data at all — every coverage number in
+    /// this report is an estimate.
+    pub measured_since: Option<String>,
     pub since_days: u64,
     pub supported: Vec<SupportedEntry>,
     pub unsupported: Vec<UnsupportedEntry>,
@@ -140,6 +148,18 @@ pub fn format_text(report: &DiscoverReport, limit: usize, verbose: bool) -> Stri
             0.0
         }
     ));
+    if report.already_rtk_estimated > 0 {
+        match &report.measured_since {
+            Some(date) => out.push_str(&format!(
+                "  includes ~{} estimated from current hook/config state (measured hook-decision logging began {date}; older history is estimated and may not reflect what was actually installed at the time)\n",
+                report.already_rtk_estimated
+            )),
+            None => out.push_str(&format!(
+                "  all {} estimated from current hook/config state -- no hook-decision log yet, coverage may not reflect historical reality\n",
+                report.already_rtk_estimated
+            )),
+        }
+    }
 
     if report.supported.is_empty() && report.unsupported.is_empty() {
         out.push_str("\nNo missed savings found. RTK usage looks good!\n");
@@ -279,6 +299,8 @@ mod tests {
             sessions_scanned: 1,
             total_commands,
             already_rtk,
+            already_rtk_estimated: 0,
+            measured_since: None,
             since_days: 30,
             supported: vec![],
             unsupported: vec![],
@@ -287,6 +309,35 @@ mod tests {
             rtk_disabled_examples: vec![],
             agent_status: AgentIntegrationStatus::default(),
         }
+    }
+
+    #[test]
+    fn test_format_text_omits_estimate_caveat_when_fully_measured() {
+        let report = make_report(100, 10);
+        let output = format_text(&report, 10, false);
+        assert!(!output.contains("estimated from current hook/config state"));
+    }
+
+    #[test]
+    fn test_format_text_shows_estimate_caveat_with_measured_boundary() {
+        let mut report = make_report(100, 10);
+        report.already_rtk_estimated = 4;
+        report.measured_since = Some("2026-07-20".to_string());
+
+        let output = format_text(&report, 10, false);
+        assert!(output.contains("includes ~4 estimated from current hook/config state"));
+        assert!(output.contains("measured hook-decision logging began 2026-07-20"));
+    }
+
+    #[test]
+    fn test_format_text_shows_fully_estimated_caveat_when_no_log_yet() {
+        let mut report = make_report(100, 10);
+        report.already_rtk_estimated = 10;
+        report.measured_since = None;
+
+        let output = format_text(&report, 10, false);
+        assert!(output.contains("all 10 estimated from current hook/config state"));
+        assert!(output.contains("no hook-decision log yet"));
     }
 
     // B6 regression: integer division truncated small percentages to 0%.

--- a/src/discover/report.rs
+++ b/src/discover/report.rs
@@ -111,6 +111,9 @@ pub struct DiscoverReport {
     pub unsupported: Vec<UnsupportedEntry>,
     pub parse_errors: usize,
     pub rtk_disabled_count: usize,
+    /// Subset of `rtk_disabled_count` from the estimate fallback rather than a
+    /// measured `hook_decisions` log entry — same caveat as `already_rtk_estimated`.
+    pub rtk_disabled_estimated: usize,
     pub rtk_disabled_examples: Vec<String>,
     pub agent_status: AgentIntegrationStatus,
 }
@@ -233,6 +236,12 @@ pub fn format_text(report: &DiscoverReport, limit: usize, verbose: bool) -> Stri
         if !report.rtk_disabled_examples.is_empty() {
             out.push_str(&format!("  {}\n", report.rtk_disabled_examples.join(", ")));
         }
+        if report.rtk_disabled_estimated > 0 {
+            out.push_str(&format!(
+                "  includes ~{} estimated from current hook/config state\n",
+                report.rtk_disabled_estimated
+            ));
+        }
         out.push_str("-> Remove RTK_DISABLED=1 to recover token savings\n");
     }
 
@@ -306,6 +315,7 @@ mod tests {
             unsupported: vec![],
             parse_errors: 0,
             rtk_disabled_count: 0,
+            rtk_disabled_estimated: 0,
             rtk_disabled_examples: vec![],
             agent_status: AgentIntegrationStatus::default(),
         }
@@ -338,6 +348,44 @@ mod tests {
         let output = format_text(&report, 10, false);
         assert!(output.contains("all 10 estimated from current hook/config state"));
         assert!(output.contains("no hook-decision log yet"));
+    }
+
+    fn dummy_supported_entry() -> SupportedEntry {
+        SupportedEntry {
+            command: "git status".to_string(),
+            count: 1,
+            rtk_equivalent: "rtk git",
+            category: "Git",
+            estimated_savings_tokens: 10,
+            estimated_savings_pct: 50.0,
+            rtk_status: RtkStatus::Existing,
+        }
+    }
+
+    #[test]
+    fn test_format_text_shows_rtk_disabled_estimate_caveat() {
+        // The RTK_DISABLED block only renders past the "no missed savings" early
+        // return, so this needs at least one supported entry to reach it.
+        let mut report = make_report(100, 10);
+        report.supported = vec![dummy_supported_entry()];
+        report.rtk_disabled_count = 3;
+        report.rtk_disabled_estimated = 2;
+
+        let output = format_text(&report, 10, false);
+        assert!(output.contains("RTK_DISABLED BYPASS -- 3 commands"));
+        assert!(output.contains("includes ~2 estimated from current hook/config state"));
+    }
+
+    #[test]
+    fn test_format_text_omits_rtk_disabled_estimate_caveat_when_fully_measured() {
+        let mut report = make_report(100, 10);
+        report.supported = vec![dummy_supported_entry()];
+        report.rtk_disabled_count = 3;
+        report.rtk_disabled_estimated = 0;
+
+        let output = format_text(&report, 10, false);
+        assert!(output.contains("RTK_DISABLED BYPASS -- 3 commands"));
+        assert!(!output.contains("includes ~0 estimated"));
     }
 
     // B6 regression: integer division truncated small percentages to 0%.

--- a/src/discover/report.rs
+++ b/src/discover/report.rs
@@ -102,9 +102,15 @@ pub struct DiscoverReport {
     /// rather than a measured `hook_decisions` log entry — i.e. history that
     /// predates hook-decision logging (or isn't Claude Code).
     pub already_rtk_estimated: usize,
-    /// Date (`YYYY-MM-DD`) the earliest `hook_decisions` log entry was recorded, if
-    /// any exist. `None` means no measured data at all — every coverage number in
-    /// this report is an estimate.
+    /// Date (`YYYY-MM-DD`) of the *oldest currently-retained* `hook_decisions` log
+    /// entry, if any exist. `None` means no measured data at all — every coverage
+    /// number in this report is an estimate.
+    ///
+    /// NOT an install date: `hook_decisions` rows are pruned by the same
+    /// `DEFAULT_HISTORY_DAYS` retention window as the rest of the tracking DB
+    /// (`Tracker::cleanup_hook_decisions`), so this date is a rolling boundary —
+    /// on a machine with months of real usage it still reads as "~90 days ago",
+    /// not the date logging actually began.
     pub measured_since: Option<String>,
     pub since_days: u64,
     pub supported: Vec<SupportedEntry>,
@@ -162,7 +168,7 @@ pub fn format_text(report: &DiscoverReport, limit: usize, verbose: bool) -> Stri
     if report.already_rtk_estimated > 0 {
         match &report.measured_since {
             Some(date) => out.push_str(&format!(
-                "  includes ~{} estimated from current hook/config state (measured hook-decision logging began {date}; older history is estimated and may not reflect what was actually installed at the time)\n",
+                "  includes ~{} estimated from current hook/config state (measured data covers {date} onward; older history is estimated and may not reflect what was actually installed at the time)\n",
                 report.already_rtk_estimated
             )),
             None => out.push_str(&format!(
@@ -172,7 +178,16 @@ pub fn format_text(report: &DiscoverReport, limit: usize, verbose: bool) -> Stri
         }
     }
 
-    if report.supported.is_empty() && report.unsupported.is_empty() {
+    // The RTK_DISABLED bypass section below is unconditional on `rtk_disabled_count`
+    // alone (it doesn't touch `supported`/`unsupported`), so this early return must
+    // also check it — otherwise a user whose *every* RTK-supported command ran as
+    // `RTK_DISABLED=1 <cmd>` never populates `supported`/`unsupported` at all, and
+    // this would print "RTK usage looks good!" while hiding that 100% of their
+    // commands ran unfiltered.
+    if report.supported.is_empty()
+        && report.unsupported.is_empty()
+        && report.rtk_disabled_count == 0
+    {
         out.push_str("\nNo missed savings found. RTK usage looks good!\n");
         append_agent_notes(&mut out, report.agent_status);
         return out;
@@ -344,7 +359,7 @@ mod tests {
 
         let output = format_text(&report, 10, false);
         assert!(output.contains("includes ~4 estimated from current hook/config state"));
-        assert!(output.contains("measured hook-decision logging began 2026-07-20"));
+        assert!(output.contains("measured data covers 2026-07-20 onward"));
     }
 
     #[test]
@@ -372,8 +387,6 @@ mod tests {
 
     #[test]
     fn test_format_text_shows_rtk_disabled_estimate_caveat() {
-        // The RTK_DISABLED block only renders past the "no missed savings" early
-        // return, so this needs at least one supported entry to reach it.
         let mut report = make_report(100, 10);
         report.supported = vec![dummy_supported_entry()];
         report.rtk_disabled_count = 3;
@@ -382,6 +395,26 @@ mod tests {
         let output = format_text(&report, 10, false);
         assert!(output.contains("RTK_DISABLED BYPASS -- 3 commands"));
         assert!(output.contains("includes ~2 estimated from current hook/config state"));
+    }
+
+    #[test]
+    fn test_format_text_rtk_disabled_section_survives_empty_supported_and_unsupported() {
+        // Regression: a user whose *every* RTK-supported command ran as
+        // `RTK_DISABLED=1 <cmd>` never populates supported/unsupported at all — the
+        // early "no missed savings" return must not fire just because those two are
+        // empty when rtk_disabled_count says otherwise, or the report would falsely
+        // claim "RTK usage looks good!" while hiding that every command ran
+        // unfiltered.
+        let mut report = make_report(100, 10);
+        report.rtk_disabled_count = 5;
+        report.rtk_disabled_estimated = 5;
+
+        let output = format_text(&report, 10, false);
+        assert!(
+            !output.contains("No missed savings found"),
+            "must not claim things look good when rtk_disabled_count > 0: {output}"
+        );
+        assert!(output.contains("RTK_DISABLED BYPASS -- 5 commands"));
     }
 
     #[test]

--- a/src/discover/report.rs
+++ b/src/discover/report.rs
@@ -111,8 +111,16 @@ pub struct DiscoverReport {
     pub unsupported: Vec<UnsupportedEntry>,
     pub parse_errors: usize,
     pub rtk_disabled_count: usize,
-    /// Subset of `rtk_disabled_count` from the estimate fallback rather than a
-    /// measured `hook_decisions` log entry — same caveat as `already_rtk_estimated`.
+    /// Always equal to `rtk_disabled_count`: unlike `already_rtk_estimated`, this can
+    /// never be a *strict* subset. An `RTK_DISABLED=` bypass makes the hook's own
+    /// logged decision `Defer` unconditionally (see `registry.rs` #345 / `get_rewritten`),
+    /// so a real `hook_decisions` row for a bypassed command never says "this would
+    /// have been covered" — it only ever confirms the hook stepped aside, which is
+    /// already known from the bypass itself. So `rtk_disabled_count` is always computed
+    /// from the current-state estimate, never the measured log, and this field mirrors
+    /// it 1:1. Kept as its own field (rather than folded away) so the report's JSON/text
+    /// output keeps disclosing "this bucket is an estimate" the same way
+    /// `already_rtk_estimated` does, instead of silently going quiet about it.
     pub rtk_disabled_estimated: usize,
     pub rtk_disabled_examples: Vec<String>,
     pub agent_status: AgentIntegrationStatus,
@@ -377,14 +385,21 @@ mod tests {
     }
 
     #[test]
-    fn test_format_text_omits_rtk_disabled_estimate_caveat_when_fully_measured() {
+    fn test_format_text_omits_rtk_disabled_estimate_caveat_when_zero() {
+        // `format_text` renders whatever it's given and doesn't enforce the
+        // rtk_disabled_estimated == rtk_disabled_count invariant `discover::run`
+        // now always produces (see the field doc on `DiscoverReport::
+        // rtk_disabled_estimated`: a bypassed command's hook decision is always
+        // `Defer`, so this bucket is never measured — `run` sets both counters
+        // together, never a count > 0 / estimated == 0 combination). This test is
+        // just exercising the renderer's zero-suppression on its own terms.
         let mut report = make_report(100, 10);
         report.supported = vec![dummy_supported_entry()];
-        report.rtk_disabled_count = 3;
+        report.rtk_disabled_count = 0;
         report.rtk_disabled_estimated = 0;
 
         let output = format_text(&report, 10, false);
-        assert!(output.contains("RTK_DISABLED BYPASS -- 3 commands"));
+        assert!(!output.contains("RTK_DISABLED BYPASS"));
         assert!(!output.contains("includes ~0 estimated"));
     }
 

--- a/src/hooks/hook_audit_cmd.rs
+++ b/src/hooks/hook_audit_cmd.rs
@@ -59,7 +59,11 @@ fn filter_since_days(entries: &[AuditEntry], days: u64) -> Vec<&AuditEntry> {
         return entries.iter().collect();
     }
 
-    let cutoff = chrono::Utc::now() - chrono::Duration::days(days as i64);
+    // `crate::core::utils::days_ago_cutoff` clamps instead of panicking on a huge
+    // `days` (see its doc comment) — `rtk hook audit --since <huge>` used to crash
+    // with the same "DateTime - TimeDelta overflowed" panic `rtk discover --since`
+    // did (rtk-ai/rtk#3206 review).
+    let cutoff = crate::core::utils::days_ago_cutoff(days);
     let cutoff_str = cutoff.format("%Y-%m-%dT%H:%M:%SZ").to_string();
 
     entries
@@ -236,6 +240,20 @@ mod tests {
         ];
         let result = filter_since_days(&entries, 0);
         assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_filter_since_days_does_not_panic_on_huge_value() {
+        // rtk-ai/rtk#3206 review: `rtk hook audit --since 100000000` panicked with
+        // "DateTime - TimeDelta overflowed" — same overflow class fixed for `rtk
+        // discover --since` via the shared `core::utils::days_ago_cutoff`.
+        let entries = vec![make_entry("rewrite", "git status")];
+        let result = filter_since_days(&entries, 100_000_000);
+        assert_eq!(
+            result.len(),
+            1,
+            "an absurdly large --since should mean 'no lower bound', not exclude everything"
+        );
     }
 
     #[test]

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -9,6 +9,7 @@ use anyhow::{Context, Result};
 use serde_json::{json, Value};
 use std::io::{self, Read, Write};
 
+use crate::core::tracking::HookOutcome;
 use crate::discover::registry::{has_heredoc, rewrite_command};
 
 const STDIN_CAP: usize = 1_048_576; // 1 MiB
@@ -562,10 +563,11 @@ enum PayloadAction {
     Rewrite {
         cmd: String,
         rewritten: String,
+        decision: HookOutcome,
         output: Value,
     },
     Skip {
-        reason: &'static str,
+        decision: HookOutcome,
         cmd: String,
     },
     Ignore,
@@ -584,13 +586,13 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
     let (rewritten, allow) = match decide_hook_action(cmd, permissions::Host::Claude) {
         HookDecision::Deny => {
             return PayloadAction::Skip {
-                reason: "skip:deny_rule",
+                decision: HookOutcome::Deny,
                 cmd: cmd.to_string(),
             }
         }
         HookDecision::Defer => {
             return PayloadAction::Skip {
-                reason: "skip:defer",
+                decision: HookOutcome::Defer,
                 cmd: cmd.to_string(),
             }
         }
@@ -622,7 +624,55 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
     PayloadAction::Rewrite {
         cmd: cmd.to_string(),
         rewritten,
+        decision: if allow {
+            HookOutcome::Allow
+        } else {
+            HookOutcome::Ask
+        },
         output: json!({ "hookSpecificOutput": hook_output }),
+    }
+}
+
+/// Pull the fields `log_hook_decision` needs out of the raw PreToolUse payload.
+/// `None` when `session_id`/`tool_use_id` are absent — both are required to join
+/// back to the transcript later, so there's nothing useful to log without them.
+/// Split out from `log_hook_decision` so this extraction is unit-testable without
+/// touching the tracking DB.
+fn hook_log_fields(v: &Value) -> Option<(&str, &str, &str)> {
+    let session_id = v.get("session_id").and_then(|s| s.as_str())?;
+    let tool_use_id = v.get("tool_use_id").and_then(|s| s.as_str())?;
+    let project_path = v.get("cwd").and_then(|c| c.as_str()).unwrap_or("");
+    Some((session_id, tool_use_id, project_path))
+}
+
+/// Log the real hook decision to the tracking DB, keyed by the transcript's
+/// `tool_use_id`, so `rtk discover` can later read ground truth about historical
+/// hook coverage instead of re-deriving a guess from today's hook-install state.
+///
+/// Best-effort only — a tracking failure must never affect the hook's real output
+/// (fallback pattern from `rust-patterns.md`): this is a side channel, not the
+/// hook's actual job.
+fn log_hook_decision(v: &Value, cmd: &str, decision: HookOutcome, rewritten: Option<&str>) {
+    let Some((session_id, tool_use_id, project_path)) = hook_log_fields(v) else {
+        return;
+    };
+
+    let Ok(tracker) = crate::core::tracking::Tracker::new() else {
+        return;
+    };
+    if let Err(e) = tracker.record_hook_decision(
+        session_id,
+        tool_use_id,
+        project_path,
+        cmd,
+        decision,
+        rewritten,
+        env!("CARGO_PKG_VERSION"),
+    ) {
+        let _ = writeln!(
+            io::stderr(),
+            "[rtk hook] hook_decisions logging failed: {e}"
+        );
     }
 }
 
@@ -647,13 +697,16 @@ pub fn run_claude() -> Result<()> {
         PayloadAction::Rewrite {
             cmd,
             rewritten,
+            decision,
             output,
         } => {
             audit_log("rewrite", &cmd, &rewritten);
+            log_hook_decision(&v, &cmd, decision, Some(&rewritten));
             let _ = writeln!(io::stdout(), "{output}");
         }
-        PayloadAction::Skip { reason, cmd } => {
-            audit_log(reason, &cmd, "");
+        PayloadAction::Skip { decision, cmd } => {
+            audit_log(&decision.to_string(), &cmd, "");
+            log_hook_decision(&v, &cmd, decision, None);
         }
         PayloadAction::Ignore => {}
     }
@@ -1400,6 +1453,50 @@ mod tests {
             }
         })
         .to_string()
+    }
+
+    /// Matches the real PreToolUse payload shape captured from a live Claude Code
+    /// session (verified fields: session_id, transcript_path, cwd, tool_use_id).
+    fn claude_payload_with_ids(cmd: &str, session_id: &str, tool_use_id: &str, cwd: &str) -> Value {
+        json!({
+            "session_id": session_id,
+            "transcript_path": "/home/user/.claude/projects/-home-user-project/session.jsonl",
+            "cwd": cwd,
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": { "command": cmd },
+            "tool_use_id": tool_use_id
+        })
+    }
+
+    #[test]
+    fn test_hook_log_fields_extracts_real_payload_shape() {
+        let v =
+            claude_payload_with_ids("git status", "sess-1", "toolu_01ABC", "/home/user/project");
+        let (session_id, tool_use_id, project_path) = hook_log_fields(&v).unwrap();
+        assert_eq!(session_id, "sess-1");
+        assert_eq!(tool_use_id, "toolu_01ABC");
+        assert_eq!(project_path, "/home/user/project");
+    }
+
+    #[test]
+    fn test_hook_log_fields_none_without_tool_use_id() {
+        // Older/foreign payload shapes without a tool_use_id must not be logged —
+        // there's no join key to match it back to a transcript entry.
+        let v: Value = serde_json::from_str(&claude_input("git status")).unwrap();
+        assert!(hook_log_fields(&v).is_none());
+    }
+
+    #[test]
+    fn test_hook_log_fields_defaults_missing_cwd_to_empty() {
+        let v = json!({
+            "session_id": "sess-1",
+            "tool_use_id": "toolu_01ABC",
+            "tool_name": "Bash",
+            "tool_input": { "command": "git status" }
+        });
+        let (_, _, project_path) = hook_log_fields(&v).unwrap();
+        assert_eq!(project_path, "");
     }
 
     #[test]

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -1551,10 +1551,7 @@ mod tests {
         match process_claude_payload_from_decision(
             &v,
             "git status",
-            HookDecision::AskRewrite {
-                rewritten: "rtk git status".to_string(),
-                explicit: true,
-            },
+            HookDecision::AskRewrite("rtk git status".to_string()),
         ) {
             PayloadAction::Rewrite { decision, .. } => assert_eq!(decision, HookOutcome::Ask),
             other => {

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -711,15 +711,29 @@ pub fn run_claude() -> Result<()> {
             decision,
             output,
         } => {
+            // Write the response Claude Code is synchronously blocked on FIRST.
+            // `log_hook_decision` is a best-effort side channel (see its own doc
+            // comment: "a tracking failure must never affect the hook's real
+            // output") that opens a SQLite connection with a 5s busy_timeout — on
+            // lock contention (concurrent hook invocations sharing the default
+            // history.db) that write can block for real seconds. Since this fires
+            // on every single Bash tool call now (not just RTK-covered ones), that
+            // latency must never sit in front of the response, or it directly
+            // stalls the tool call it's supposedly just logging.
+            let _ = writeln!(io::stdout(), "{output}");
             audit_log("rewrite", &cmd, &rewritten);
             log_hook_decision(&v, &cmd, decision, Some(&rewritten));
-            let _ = writeln!(io::stdout(), "{output}");
         }
         PayloadAction::Skip { decision, cmd } => {
             // `rtk hook audit`'s skip-breakdown groups by a "skip:<reason>" prefix
             // (see hook_audit_cmd.rs) — Skip is only ever reached via Deny/Defer,
             // so map those to the reasons it expects rather than the bare
             // HookOutcome::Display used for the Rewrite/tracking-DB paths.
+            //
+            // Skip has no stdout response to write (Claude Code falls through to
+            // its own native handling), but log_hook_decision is still deferred to
+            // last for the same reason as the Rewrite arm above: it must never be
+            // what a Bash tool call is waiting on.
             let audit_action = match decision {
                 HookOutcome::Deny => "skip:deny_rule",
                 HookOutcome::Defer => "skip:defer",
@@ -1502,8 +1516,26 @@ mod tests {
     #[test]
     fn test_hook_log_fields_none_without_tool_use_id() {
         // Older/foreign payload shapes without a tool_use_id must not be logged —
-        // there's no join key to match it back to a transcript entry.
+        // there's no join key to match it back to a transcript entry. Uses the
+        // real claude_input() fixture, which also lacks session_id — see the
+        // isolated variant below for a payload that has session_id present but
+        // tool_use_id specifically absent.
         let v: Value = serde_json::from_str(&claude_input("git status")).unwrap();
+        assert!(hook_log_fields(&v).is_none());
+    }
+
+    #[test]
+    fn test_hook_log_fields_none_with_session_id_but_no_tool_use_id() {
+        // hook_log_fields checks session_id first and short-circuits via `?`, so
+        // the fixture above (missing both fields) can't tell us whether
+        // tool_use_id extraction specifically works — it passes even if that
+        // check were completely broken. This isolates tool_use_id: session_id
+        // present, tool_use_id absent.
+        let v = json!({
+            "session_id": "sess-1",
+            "tool_name": "Bash",
+            "tool_input": { "command": "git status" }
+        });
         assert!(hook_log_fields(&v).is_none());
     }
 

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -559,6 +559,7 @@ fn audit_log_inner(action: &str, original: &str, rewritten: &str) -> Option<()> 
 
 // ── Claude Code native hook ────────────────────────────────────
 
+#[derive(Debug)]
 enum PayloadAction {
     Rewrite {
         cmd: String,
@@ -583,7 +584,19 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
         None => return PayloadAction::Ignore,
     };
 
-    let (rewritten, allow) = match decide_hook_action(cmd, permissions::Host::Claude) {
+    process_claude_payload_from_decision(v, cmd, decide_hook_action(cmd, permissions::Host::Claude))
+}
+
+/// Pure core of `process_claude_payload`, taking the hook decision directly so the
+/// full Allow/Ask/Deny/Defer matrix is unit-testable without depending on real
+/// permission config files — mirrors the `copilot_cli_response_from_decision`/
+/// `droid_response_from_decision` split already used elsewhere in this file.
+fn process_claude_payload_from_decision(
+    v: &Value,
+    cmd: &str,
+    decision: HookDecision,
+) -> PayloadAction {
+    let (rewritten, allow) = match decision {
         HookDecision::Deny => {
             return PayloadAction::Skip {
                 decision: HookOutcome::Deny,
@@ -1497,6 +1510,80 @@ mod tests {
         });
         let (_, _, project_path) = hook_log_fields(&v).unwrap();
         assert_eq!(project_path, "");
+    }
+
+    // The decision field on PayloadAction feeds directly into hook_decisions —
+    // exercise the full Allow/Ask/Deny/Defer matrix against the pure
+    // process_claude_payload_from_decision (no real permission config needed).
+
+    #[test]
+    fn test_process_claude_payload_decision_allow() {
+        let v = claude_input_value("git status");
+        match process_claude_payload_from_decision(
+            &v,
+            "git status",
+            HookDecision::AllowRewrite("rtk git status".to_string()),
+        ) {
+            PayloadAction::Rewrite {
+                decision,
+                rewritten,
+                ..
+            } => {
+                assert_eq!(decision, HookOutcome::Allow);
+                assert_eq!(rewritten, "rtk git status");
+            }
+            other => {
+                panic!("expected Rewrite, got a different PayloadAction variant instead: {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn test_process_claude_payload_decision_ask() {
+        let v = claude_input_value("git status");
+        match process_claude_payload_from_decision(
+            &v,
+            "git status",
+            HookDecision::AskRewrite {
+                rewritten: "rtk git status".to_string(),
+                explicit: true,
+            },
+        ) {
+            PayloadAction::Rewrite { decision, .. } => assert_eq!(decision, HookOutcome::Ask),
+            other => {
+                panic!("expected Rewrite, got a different PayloadAction variant instead: {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn test_process_claude_payload_decision_deny() {
+        let v = claude_input_value("rm -rf /");
+        match process_claude_payload_from_decision(&v, "rm -rf /", HookDecision::Deny) {
+            PayloadAction::Skip { decision, .. } => assert_eq!(decision, HookOutcome::Deny),
+            other => {
+                panic!("expected Skip, got a different PayloadAction variant instead: {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn test_process_claude_payload_decision_defer() {
+        let v = claude_input_value("git status $(rm -rf /tmp/x)");
+        match process_claude_payload_from_decision(
+            &v,
+            "git status $(rm -rf /tmp/x)",
+            HookDecision::Defer,
+        ) {
+            PayloadAction::Skip { decision, .. } => assert_eq!(decision, HookOutcome::Defer),
+            other => {
+                panic!("expected Skip, got a different PayloadAction variant instead: {other:?}")
+            }
+        }
+    }
+
+    fn claude_input_value(cmd: &str) -> Value {
+        serde_json::from_str(&claude_input(cmd)).unwrap()
     }
 
     #[test]

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -718,7 +718,16 @@ pub fn run_claude() -> Result<()> {
             let _ = writeln!(io::stdout(), "{output}");
         }
         PayloadAction::Skip { decision, cmd } => {
-            audit_log(&decision.to_string(), &cmd, "");
+            // `rtk hook audit`'s skip-breakdown groups by a "skip:<reason>" prefix
+            // (see hook_audit_cmd.rs) — Skip is only ever reached via Deny/Defer,
+            // so map those to the reasons it expects rather than the bare
+            // HookOutcome::Display used for the Rewrite/tracking-DB paths.
+            let audit_action = match decision {
+                HookOutcome::Deny => "skip:deny_rule",
+                HookOutcome::Defer => "skip:defer",
+                HookOutcome::Allow | HookOutcome::Ask => "skip",
+            };
+            audit_log(audit_action, &cmd, "");
             log_hook_decision(&v, &cmd, decision, None);
         }
         PayloadAction::Ignore => {}

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -237,9 +237,7 @@ fn get_rewritten(cmd: &str) -> Option<String> {
         return None;
     }
 
-    let (excluded, transparent_prefixes) = crate::core::config::Config::load()
-        .map(|c| (c.hooks.exclude_commands, c.hooks.transparent_prefixes))
-        .unwrap_or_default();
+    let (excluded, transparent_prefixes) = crate::core::config::hook_rewrite_params();
 
     let rewritten = rewrite_command(cmd, &excluded, &transparent_prefixes)?;
 

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -9,6 +9,7 @@ use anyhow::{Context, Result};
 use serde_json::{json, Value};
 use std::io::{self, Read, Write};
 
+use crate::core::tracking::HookOutcome;
 use crate::core::utils::strip_leading_bom;
 use crate::discover::registry::{has_heredoc, rewrite_command};
 
@@ -586,10 +587,11 @@ enum PayloadAction {
     Rewrite {
         cmd: String,
         rewritten: String,
+        decision: HookOutcome,
         output: Value,
     },
     Skip {
-        reason: &'static str,
+        decision: HookOutcome,
         cmd: String,
     },
     Ignore,
@@ -608,13 +610,13 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
     let (rewritten, allow) = match decide_hook_action(cmd, permissions::Host::Claude) {
         HookDecision::Deny => {
             return PayloadAction::Skip {
-                reason: "skip:deny_rule",
+                decision: HookOutcome::Deny,
                 cmd: cmd.to_string(),
             }
         }
         HookDecision::Defer => {
             return PayloadAction::Skip {
-                reason: "skip:defer",
+                decision: HookOutcome::Defer,
                 cmd: cmd.to_string(),
             }
         }
@@ -646,7 +648,55 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
     PayloadAction::Rewrite {
         cmd: cmd.to_string(),
         rewritten,
+        decision: if allow {
+            HookOutcome::Allow
+        } else {
+            HookOutcome::Ask
+        },
         output: json!({ "hookSpecificOutput": hook_output }),
+    }
+}
+
+/// Pull the fields `log_hook_decision` needs out of the raw PreToolUse payload.
+/// `None` when `session_id`/`tool_use_id` are absent — both are required to join
+/// back to the transcript later, so there's nothing useful to log without them.
+/// Split out from `log_hook_decision` so this extraction is unit-testable without
+/// touching the tracking DB.
+fn hook_log_fields(v: &Value) -> Option<(&str, &str, &str)> {
+    let session_id = v.get("session_id").and_then(|s| s.as_str())?;
+    let tool_use_id = v.get("tool_use_id").and_then(|s| s.as_str())?;
+    let project_path = v.get("cwd").and_then(|c| c.as_str()).unwrap_or("");
+    Some((session_id, tool_use_id, project_path))
+}
+
+/// Log the real hook decision to the tracking DB, keyed by the transcript's
+/// `tool_use_id`, so `rtk discover` can later read ground truth about historical
+/// hook coverage instead of re-deriving a guess from today's hook-install state.
+///
+/// Best-effort only — a tracking failure must never affect the hook's real output
+/// (fallback pattern from `rust-patterns.md`): this is a side channel, not the
+/// hook's actual job.
+fn log_hook_decision(v: &Value, cmd: &str, decision: HookOutcome, rewritten: Option<&str>) {
+    let Some((session_id, tool_use_id, project_path)) = hook_log_fields(v) else {
+        return;
+    };
+
+    let Ok(tracker) = crate::core::tracking::Tracker::new() else {
+        return;
+    };
+    if let Err(e) = tracker.record_hook_decision(
+        session_id,
+        tool_use_id,
+        project_path,
+        cmd,
+        decision,
+        rewritten,
+        env!("CARGO_PKG_VERSION"),
+    ) {
+        let _ = writeln!(
+            io::stderr(),
+            "[rtk hook] hook_decisions logging failed: {e}"
+        );
     }
 }
 
@@ -671,13 +721,16 @@ pub fn run_claude() -> Result<()> {
         PayloadAction::Rewrite {
             cmd,
             rewritten,
+            decision,
             output,
         } => {
             audit_log("rewrite", &cmd, &rewritten);
+            log_hook_decision(&v, &cmd, decision, Some(&rewritten));
             let _ = writeln!(io::stdout(), "{output}");
         }
-        PayloadAction::Skip { reason, cmd } => {
-            audit_log(reason, &cmd, "");
+        PayloadAction::Skip { decision, cmd } => {
+            audit_log(&decision.to_string(), &cmd, "");
+            log_hook_decision(&v, &cmd, decision, None);
         }
         PayloadAction::Ignore => {}
     }
@@ -1423,6 +1476,50 @@ mod tests {
             }
         })
         .to_string()
+    }
+
+    /// Matches the real PreToolUse payload shape captured from a live Claude Code
+    /// session (verified fields: session_id, transcript_path, cwd, tool_use_id).
+    fn claude_payload_with_ids(cmd: &str, session_id: &str, tool_use_id: &str, cwd: &str) -> Value {
+        json!({
+            "session_id": session_id,
+            "transcript_path": "/home/user/.claude/projects/-home-user-project/session.jsonl",
+            "cwd": cwd,
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": { "command": cmd },
+            "tool_use_id": tool_use_id
+        })
+    }
+
+    #[test]
+    fn test_hook_log_fields_extracts_real_payload_shape() {
+        let v =
+            claude_payload_with_ids("git status", "sess-1", "toolu_01ABC", "/home/user/project");
+        let (session_id, tool_use_id, project_path) = hook_log_fields(&v).unwrap();
+        assert_eq!(session_id, "sess-1");
+        assert_eq!(tool_use_id, "toolu_01ABC");
+        assert_eq!(project_path, "/home/user/project");
+    }
+
+    #[test]
+    fn test_hook_log_fields_none_without_tool_use_id() {
+        // Older/foreign payload shapes without a tool_use_id must not be logged —
+        // there's no join key to match it back to a transcript entry.
+        let v: Value = serde_json::from_str(&claude_input("git status")).unwrap();
+        assert!(hook_log_fields(&v).is_none());
+    }
+
+    #[test]
+    fn test_hook_log_fields_defaults_missing_cwd_to_empty() {
+        let v = json!({
+            "session_id": "sess-1",
+            "tool_use_id": "toolu_01ABC",
+            "tool_name": "Bash",
+            "tool_input": { "command": "git status" }
+        });
+        let (_, _, project_path) = hook_log_fields(&v).unwrap();
+        assert_eq!(project_path, "");
     }
 
     #[test]

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -1574,10 +1574,7 @@ mod tests {
         match process_claude_payload_from_decision(
             &v,
             "git status",
-            HookDecision::AskRewrite {
-                rewritten: "rtk git status".to_string(),
-                explicit: true,
-            },
+            HookDecision::AskRewrite("rtk git status".to_string()),
         ) {
             PayloadAction::Rewrite { decision, .. } => assert_eq!(decision, HookOutcome::Ask),
             other => {

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -742,7 +742,16 @@ pub fn run_claude() -> Result<()> {
             let _ = writeln!(io::stdout(), "{output}");
         }
         PayloadAction::Skip { decision, cmd } => {
-            audit_log(&decision.to_string(), &cmd, "");
+            // `rtk hook audit`'s skip-breakdown groups by a "skip:<reason>" prefix
+            // (see hook_audit_cmd.rs) — Skip is only ever reached via Deny/Defer,
+            // so map those to the reasons it expects rather than the bare
+            // HookOutcome::Display used for the Rewrite/tracking-DB paths.
+            let audit_action = match decision {
+                HookOutcome::Deny => "skip:deny_rule",
+                HookOutcome::Defer => "skip:defer",
+                HookOutcome::Allow | HookOutcome::Ask => "skip",
+            };
+            audit_log(audit_action, &cmd, "");
             log_hook_decision(&v, &cmd, decision, None);
         }
         PayloadAction::Ignore => {}

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -735,15 +735,29 @@ pub fn run_claude() -> Result<()> {
             decision,
             output,
         } => {
+            // Write the response Claude Code is synchronously blocked on FIRST.
+            // `log_hook_decision` is a best-effort side channel (see its own doc
+            // comment: "a tracking failure must never affect the hook's real
+            // output") that opens a SQLite connection with a 5s busy_timeout — on
+            // lock contention (concurrent hook invocations sharing the default
+            // history.db) that write can block for real seconds. Since this fires
+            // on every single Bash tool call now (not just RTK-covered ones), that
+            // latency must never sit in front of the response, or it directly
+            // stalls the tool call it's supposedly just logging.
+            let _ = writeln!(io::stdout(), "{output}");
             audit_log("rewrite", &cmd, &rewritten);
             log_hook_decision(&v, &cmd, decision, Some(&rewritten));
-            let _ = writeln!(io::stdout(), "{output}");
         }
         PayloadAction::Skip { decision, cmd } => {
             // `rtk hook audit`'s skip-breakdown groups by a "skip:<reason>" prefix
             // (see hook_audit_cmd.rs) — Skip is only ever reached via Deny/Defer,
             // so map those to the reasons it expects rather than the bare
             // HookOutcome::Display used for the Rewrite/tracking-DB paths.
+            //
+            // Skip has no stdout response to write (Claude Code falls through to
+            // its own native handling), but log_hook_decision is still deferred to
+            // last for the same reason as the Rewrite arm above: it must never be
+            // what a Bash tool call is waiting on.
             let audit_action = match decision {
                 HookOutcome::Deny => "skip:deny_rule",
                 HookOutcome::Defer => "skip:defer",
@@ -1525,8 +1539,26 @@ mod tests {
     #[test]
     fn test_hook_log_fields_none_without_tool_use_id() {
         // Older/foreign payload shapes without a tool_use_id must not be logged —
-        // there's no join key to match it back to a transcript entry.
+        // there's no join key to match it back to a transcript entry. Uses the
+        // real claude_input() fixture, which also lacks session_id — see the
+        // isolated variant below for a payload that has session_id present but
+        // tool_use_id specifically absent.
         let v: Value = serde_json::from_str(&claude_input("git status")).unwrap();
+        assert!(hook_log_fields(&v).is_none());
+    }
+
+    #[test]
+    fn test_hook_log_fields_none_with_session_id_but_no_tool_use_id() {
+        // hook_log_fields checks session_id first and short-circuits via `?`, so
+        // the fixture above (missing both fields) can't tell us whether
+        // tool_use_id extraction specifically works — it passes even if that
+        // check were completely broken. This isolates tool_use_id: session_id
+        // present, tool_use_id absent.
+        let v = json!({
+            "session_id": "sess-1",
+            "tool_name": "Bash",
+            "tool_input": { "command": "git status" }
+        });
         assert!(hook_log_fields(&v).is_none());
     }
 

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -238,9 +238,7 @@ fn get_rewritten(cmd: &str) -> Option<String> {
         return None;
     }
 
-    let (excluded, transparent_prefixes) = crate::core::config::Config::load()
-        .map(|c| (c.hooks.exclude_commands, c.hooks.transparent_prefixes))
-        .unwrap_or_default();
+    let (excluded, transparent_prefixes) = crate::core::config::hook_rewrite_params();
 
     let rewritten = rewrite_command(cmd, &excluded, &transparent_prefixes)?;
 

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -583,6 +583,7 @@ fn audit_log_inner(action: &str, original: &str, rewritten: &str) -> Option<()> 
 
 // ── Claude Code native hook ────────────────────────────────────
 
+#[derive(Debug)]
 enum PayloadAction {
     Rewrite {
         cmd: String,
@@ -607,7 +608,19 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
         None => return PayloadAction::Ignore,
     };
 
-    let (rewritten, allow) = match decide_hook_action(cmd, permissions::Host::Claude) {
+    process_claude_payload_from_decision(v, cmd, decide_hook_action(cmd, permissions::Host::Claude))
+}
+
+/// Pure core of `process_claude_payload`, taking the hook decision directly so the
+/// full Allow/Ask/Deny/Defer matrix is unit-testable without depending on real
+/// permission config files — mirrors the `copilot_cli_response_from_decision`/
+/// `droid_response_from_decision` split already used elsewhere in this file.
+fn process_claude_payload_from_decision(
+    v: &Value,
+    cmd: &str,
+    decision: HookDecision,
+) -> PayloadAction {
+    let (rewritten, allow) = match decision {
         HookDecision::Deny => {
             return PayloadAction::Skip {
                 decision: HookOutcome::Deny,
@@ -1520,6 +1533,80 @@ mod tests {
         });
         let (_, _, project_path) = hook_log_fields(&v).unwrap();
         assert_eq!(project_path, "");
+    }
+
+    // The decision field on PayloadAction feeds directly into hook_decisions —
+    // exercise the full Allow/Ask/Deny/Defer matrix against the pure
+    // process_claude_payload_from_decision (no real permission config needed).
+
+    #[test]
+    fn test_process_claude_payload_decision_allow() {
+        let v = claude_input_value("git status");
+        match process_claude_payload_from_decision(
+            &v,
+            "git status",
+            HookDecision::AllowRewrite("rtk git status".to_string()),
+        ) {
+            PayloadAction::Rewrite {
+                decision,
+                rewritten,
+                ..
+            } => {
+                assert_eq!(decision, HookOutcome::Allow);
+                assert_eq!(rewritten, "rtk git status");
+            }
+            other => {
+                panic!("expected Rewrite, got a different PayloadAction variant instead: {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn test_process_claude_payload_decision_ask() {
+        let v = claude_input_value("git status");
+        match process_claude_payload_from_decision(
+            &v,
+            "git status",
+            HookDecision::AskRewrite {
+                rewritten: "rtk git status".to_string(),
+                explicit: true,
+            },
+        ) {
+            PayloadAction::Rewrite { decision, .. } => assert_eq!(decision, HookOutcome::Ask),
+            other => {
+                panic!("expected Rewrite, got a different PayloadAction variant instead: {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn test_process_claude_payload_decision_deny() {
+        let v = claude_input_value("rm -rf /");
+        match process_claude_payload_from_decision(&v, "rm -rf /", HookDecision::Deny) {
+            PayloadAction::Skip { decision, .. } => assert_eq!(decision, HookOutcome::Deny),
+            other => {
+                panic!("expected Skip, got a different PayloadAction variant instead: {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn test_process_claude_payload_decision_defer() {
+        let v = claude_input_value("git status $(rm -rf /tmp/x)");
+        match process_claude_payload_from_decision(
+            &v,
+            "git status $(rm -rf /tmp/x)",
+            HookDecision::Defer,
+        ) {
+            PayloadAction::Skip { decision, .. } => assert_eq!(decision, HookOutcome::Defer),
+            other => {
+                panic!("expected Skip, got a different PayloadAction variant instead: {other:?}")
+            }
+        }
+    }
+
+    fn claude_input_value(cmd: &str) -> Value {
+        serde_json::from_str(&claude_input(cmd)).unwrap()
     }
 
     #[test]

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -348,8 +348,13 @@ pub fn run(
         // already the natural "something's wrong, reinstall" move, so no separate
         // repair flag is needed. `CREATE TABLE IF NOT EXISTS`/`ALTER TABLE` are
         // additive, so existing history is left untouched. Never fail `rtk init`
-        // over a tracking-DB hiccup.
-        let _ = crate::core::tracking::ensure_schema_fresh();
+        // over a tracking-DB hiccup — but still tell the user something's wrong,
+        // consistent with every other best-effort warning in this function
+        // (rust-patterns.md's anti-pattern rule: a silent `Err(_) => {}` leaves
+        // the user with zero indication anything went wrong).
+        if let Err(e) = crate::core::tracking::ensure_schema_fresh() {
+            eprintln!("  [warn] Failed to prepare tracking database: {e}");
+        }
     }
 
     if dry_run {

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -339,11 +339,17 @@ pub fn run(
 
     if !dry_run {
         prompt_telemetry_consent()?;
-        // Best-effort: pre-warm the tracking DB's schema during install/upgrade so
-        // the first PreToolUse hook invocation (or `rtk <cmd>`) after this doesn't
-        // have to pay the one-time migration cost itself. Never fail `rtk init`
+        // Best-effort: unconditionally re-run tracking-DB schema migrations during
+        // install/upgrade (bypassing the `user_version` gate `Tracker::new()` uses
+        // on its hot path). This both pre-warms the schema so the first PreToolUse
+        // hook invocation (or `rtk <cmd>`) after this doesn't pay the one-time
+        // migration cost itself, and self-heals a table dropped/corrupted
+        // out-of-band (see `tracking::warn_if_missing_table`) — `rtk init` is
+        // already the natural "something's wrong, reinstall" move, so no separate
+        // repair flag is needed. `CREATE TABLE IF NOT EXISTS`/`ALTER TABLE` are
+        // additive, so existing history is left untouched. Never fail `rtk init`
         // over a tracking-DB hiccup.
-        let _ = crate::core::tracking::Tracker::new();
+        let _ = crate::core::tracking::ensure_schema_fresh();
     }
 
     if dry_run {

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -339,6 +339,11 @@ pub fn run(
 
     if !dry_run {
         prompt_telemetry_consent()?;
+        // Best-effort: pre-warm the tracking DB's schema during install/upgrade so
+        // the first PreToolUse hook invocation (or `rtk <cmd>`) after this doesn't
+        // have to pay the one-time migration cost itself. Never fail `rtk init`
+        // over a tracking-DB hiccup.
+        let _ = crate::core::tracking::Tracker::new();
     }
 
     if dry_run {

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -340,6 +340,11 @@ pub fn run(
 
     if !dry_run {
         prompt_telemetry_consent()?;
+        // Best-effort: pre-warm the tracking DB's schema during install/upgrade so
+        // the first PreToolUse hook invocation (or `rtk <cmd>`) after this doesn't
+        // have to pay the one-time migration cost itself. Never fail `rtk init`
+        // over a tracking-DB hiccup.
+        let _ = crate::core::tracking::Tracker::new();
     }
 
     if dry_run {

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -340,11 +340,17 @@ pub fn run(
 
     if !dry_run {
         prompt_telemetry_consent()?;
-        // Best-effort: pre-warm the tracking DB's schema during install/upgrade so
-        // the first PreToolUse hook invocation (or `rtk <cmd>`) after this doesn't
-        // have to pay the one-time migration cost itself. Never fail `rtk init`
+        // Best-effort: unconditionally re-run tracking-DB schema migrations during
+        // install/upgrade (bypassing the `user_version` gate `Tracker::new()` uses
+        // on its hot path). This both pre-warms the schema so the first PreToolUse
+        // hook invocation (or `rtk <cmd>`) after this doesn't pay the one-time
+        // migration cost itself, and self-heals a table dropped/corrupted
+        // out-of-band (see `tracking::warn_if_missing_table`) — `rtk init` is
+        // already the natural "something's wrong, reinstall" move, so no separate
+        // repair flag is needed. `CREATE TABLE IF NOT EXISTS`/`ALTER TABLE` are
+        // additive, so existing history is left untouched. Never fail `rtk init`
         // over a tracking-DB hiccup.
-        let _ = crate::core::tracking::Tracker::new();
+        let _ = crate::core::tracking::ensure_schema_fresh();
     }
 
     if dry_run {

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -349,8 +349,13 @@ pub fn run(
         // already the natural "something's wrong, reinstall" move, so no separate
         // repair flag is needed. `CREATE TABLE IF NOT EXISTS`/`ALTER TABLE` are
         // additive, so existing history is left untouched. Never fail `rtk init`
-        // over a tracking-DB hiccup.
-        let _ = crate::core::tracking::ensure_schema_fresh();
+        // over a tracking-DB hiccup — but still tell the user something's wrong,
+        // consistent with every other best-effort warning in this function
+        // (rust-patterns.md's anti-pattern rule: a silent `Err(_) => {}` leaves
+        // the user with zero indication anything went wrong).
+        if let Err(e) = crate::core::tracking::ensure_schema_fresh() {
+            eprintln!("  [warn] Failed to prepare tracking database: {e}");
+        }
     }
 
     if dry_run {

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -41,14 +41,24 @@ pub enum Host {
 }
 
 pub fn check_command_for(cmd: &str, host: Host) -> PermissionVerdict {
-    let (deny_rules, ask_rules, allow_rules) = match host {
+    let (deny_rules, ask_rules, allow_rules) = load_rules_for(host);
+    check_command_with_rules(cmd, &deny_rules, &ask_rules, &allow_rules)
+}
+
+/// Load `host`'s deny/ask/allow Bash rules from disk, doing the settings-file I/O
+/// exactly once. Exposed so a caller that checks many commands against the same
+/// host in a loop (e.g. `rtk discover` scanning thousands of transcript commands)
+/// can load once up front and reuse `check_command_with_rules` per command instead
+/// of going through `check_command_for` and re-reading every settings file from
+/// disk on every single call.
+pub(crate) fn load_rules_for(host: Host) -> (Vec<String>, Vec<String>, Vec<String>) {
+    match host {
         Host::Claude => load_permission_rules(),
         Host::Cursor => load_cursor_rules(),
         Host::Gemini => load_gemini_rules(),
         Host::Droid => load_droid_rules(),
         Host::Vibe => (Vec::new(), Vec::new(), Vec::new()),
-    };
-    check_command_with_rules(cmd, &deny_rules, &ask_rules, &allow_rules)
+    }
 }
 
 /// Internal implementation allowing tests to inject rules without file I/O.

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -40,14 +40,24 @@ pub enum Host {
 }
 
 pub fn check_command_for(cmd: &str, host: Host) -> PermissionVerdict {
-    let (deny_rules, ask_rules, allow_rules) = match host {
+    let (deny_rules, ask_rules, allow_rules) = load_rules_for(host);
+    check_command_with_rules(cmd, &deny_rules, &ask_rules, &allow_rules)
+}
+
+/// Load `host`'s deny/ask/allow Bash rules from disk, doing the settings-file I/O
+/// exactly once. Exposed so a caller that checks many commands against the same
+/// host in a loop (e.g. `rtk discover` scanning thousands of transcript commands)
+/// can load once up front and reuse `check_command_with_rules` per command instead
+/// of going through `check_command_for` and re-reading every settings file from
+/// disk on every single call.
+pub(crate) fn load_rules_for(host: Host) -> (Vec<String>, Vec<String>, Vec<String>) {
+    match host {
         Host::Claude => load_permission_rules(),
         Host::Cursor => load_cursor_rules(),
         Host::Gemini => load_gemini_rules(),
         Host::Droid => load_droid_rules(),
         Host::Vibe => (Vec::new(), Vec::new(), Vec::new()),
-    };
-    check_command_with_rules(cmd, &deny_rules, &ask_rules, &allow_rules)
+    }
 }
 
 /// Internal implementation allowing tests to inject rules without file I/O.

--- a/src/hooks/rewrite_cmd.rs
+++ b/src/hooks/rewrite_cmd.rs
@@ -16,9 +16,7 @@ use std::io::Write;
 /// | 2    | (none)   | Deny rule matched — hook defers to Claude Code native deny.  |
 /// | 3    | rewritten| Ask rule matched — hook rewrites but lets Claude Code prompt.|
 pub fn run(cmd: &str) -> anyhow::Result<()> {
-    let (excluded, transparent_prefixes) = crate::core::config::Config::load()
-        .map(|c| (c.hooks.exclude_commands, c.hooks.transparent_prefixes))
-        .unwrap_or_default();
+    let (excluded, transparent_prefixes) = crate::core::config::hook_rewrite_params();
 
     match evaluate(cmd, &excluded, &transparent_prefixes) {
         RewriteOutcome::Allow(rewritten) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2460,9 +2460,7 @@ fn run_cli() -> Result<i32> {
             HookCommands::Check { agent: _, command } => {
                 use crate::discover::registry::rewrite_command;
                 let raw = command.join(" ");
-                let (excluded, transparent_prefixes) = crate::core::config::Config::load()
-                    .map(|c| (c.hooks.exclude_commands, c.hooks.transparent_prefixes))
-                    .unwrap_or_default();
+                let (excluded, transparent_prefixes) = crate::core::config::hook_rewrite_params();
                 match rewrite_command(&raw, &excluded, &transparent_prefixes) {
                     Some(rewritten) => {
                         println!("{}", rewritten);

--- a/src/main.rs
+++ b/src/main.rs
@@ -2504,9 +2504,7 @@ fn run_cli() -> Result<i32> {
             HookCommands::Check { agent: _, command } => {
                 use crate::discover::registry::rewrite_command;
                 let raw = command.join(" ");
-                let (excluded, transparent_prefixes) = crate::core::config::Config::load()
-                    .map(|c| (c.hooks.exclude_commands, c.hooks.transparent_prefixes))
-                    .unwrap_or_default();
+                let (excluded, transparent_prefixes) = crate::core::config::hook_rewrite_params();
                 match rewrite_command(&raw, &excluded, &transparent_prefixes) {
                     Some(rewritten) => {
                         println!("{}", rewritten);


### PR DESCRIPTION
## Summary

`rtk discover` re-derives whether a historical transcript command would have been covered by the PreToolUse hook using *today's* hook-install state and registry, applied uniformly across the whole scan window (default 30 days). PR #3164 attempted a fix along these lines but has the same gap: history that predates the hook being installed, or a registry/permission change, gets mis-classified — plus it misses `permissions.deny` and doesn't gate the `RTK_DISABLED=` bypass bucket the same way.

This PR logs the *real* PreToolUse decision (allow/ask/deny/defer) at the moment the Claude Code hook actually runs, keyed by `tool_use_id` — the same id Claude Code stores on the transcript's `tool_use`/`tool_result` blocks (verified empirically, not assumed) — so `discover` can join real hook outcomes back to transcript entries instead of guessing. Falls back to a heuristic estimate only for history that predates logging (or exceeds the tracking DB's retention window — see below), and labels that portion of the report as an estimate rather than blending it in silently.

- New `hook_decisions` SQLite table + `HookOutcome` enum (`Display`/`FromStr`), shared between the writer (`hooks::hook_cmd`) and reader (`discover`). Logging happens after the hook's real stdout response is written, never in front of it — it's a best-effort side channel and must never add latency to the tool call it's recording.
- `ExtractedCommand` now carries `tool_use_id` so transcript entries can join against the log.
- `Coverage::Measured`/`Coverage::Estimated`: prefers the real log; the estimate fallback checks `PermissionVerdict::Deny` against the *full* raw command (not an isolated chain segment — a deny rule matching a sibling segment must still deny the whole chain), and stops crediting `RTK_DISABLED=` as a "bypass" when the hook wouldn't actually have covered the command anyway (that case now shows as a genuine missed-savings opportunity instead of disappearing from the report).
- Report gains `already_rtk_estimated`/`rtk_disabled_estimated` + `measured_since`, with a text-mode caveat explaining when/why part of a coverage number is an estimate. `measured_since` reflects the oldest currently-retained log entry, not an install date — `hook_decisions` is pruned by the same retention window as the rest of the tracking DB, so the estimate fallback is a permanent fact of scanning far enough back, not a transitional one.
- `record_hook_decision()` skips the full 3-table `cleanup_old()` sweep on its hot path (every Bash tool call, not just RTK-covered ones), but still gets a lightweight sampled retention sweep of its own so a user whose commands are mostly denied/deferred doesn't grow the table unbounded.
- Permission rules, exclude-pattern regexes, and hook-install status are loaded/compiled once per `discover` run instead of once per scanned command, and config is cached per-process for the hook's hot path — a large history (tens of thousands of commands) was previously dominated by this redundant I/O.
- `rtk discover --since <very large>` no longer crashes; the cutoff computation is clamped instead of overflowing.

Fixes #3148

## End-to-end validation

Beyond `cargo test --all` (2749 passed) and `cargo clippy --all-targets` (clean), ran the built release binary against a synthetic Claude Code transcript to validate the fix's actual runtime behavior, isolating state via `CLAUDE_CONFIG_DIR` (Claude config dir) and `RTK_DB_PATH` (tracking DB) so nothing touched real user data.

**Setup**: one synthetic session transcript with four Bash tool calls, each with its own `tool_use_id`:
- `grep foo bar.py` — Supported, cleanly rewritable
- `git status` — Supported, cleanly rewritable
- `git status $(whoami)` — Supported but contains an unattestable construct (command substitution), which the hook always defers on
- `rtk proxy grep foo bar.py` — already `rtk`-prefixed, but via the escape hatch that must not count as coverage

**Scenario 1 — hook never installed** (no `settings.json` in the synthetic `CLAUDE_CONFIG_DIR`, empty `hook_decisions` table):
```
Already using RTK: 0 commands (0.0%)
MISSED SAVINGS -- Commands RTK already handles
Command                  Count    RTK Equivalent     Status        Est. Savings
git status                   2    rtk git            existing      ~4 tokens
grep foo                     1    rtk grep           existing      ~2 tokens
```
`git status` (both instances, including the unattestable one) and `grep` correctly show as missed; `rtk proxy` doesn't appear in either bucket.

**Scenario 2 — hook installed, with real decisions logged**: wrote a `settings.json` registering `rtk hook claude` as the PreToolUse hook, then piped the matching real PreToolUse JSON payload for each of the four commands (same `tool_use_id`s as the transcript) through the actual built `rtk hook claude` binary, populating `hook_decisions` for real. Verified via direct sqlite read that all four rows landed with the expected decisions (`grep`→ask, `git status`→ask, the `$(whoami)` variant→defer, `rtk proxy`→defer). Then ran `rtk discover` against the same DB/transcript:
```
Already using RTK: 2 commands (50.0%)
MISSED SAVINGS -- Commands RTK already handles
Command                  Count    RTK Equivalent     Status        Est. Savings
git status                   1    rtk git            existing      ~2 tokens
```
- Coverage jumped to 2/4 (50%), matching the two commands that were actually rewritable.
- `git status $(whoami)` still correctly shows as a genuine MISS (the hook really did defer on it — this isn't just "it was estimated as uncovered", it's a *measured* defer).
- `rtk proxy` still doesn't inflate either bucket.
- JSON output (`--format json`) confirmed `already_rtk_estimated: 0` and `measured_since` set to the log's timestamp — proving the *measured* path drove the result end-to-end, not the heuristic fallback.

**Additional scenarios verified since**: an RTK_DISABLED= bypass on a command the hook wouldn't have covered anyway now shows as missed savings rather than vanishing from the report; a chain-wide deny rule (`cd /sensitive && grep -rn foo .`) matching only one segment correctly denies the whole chain in the estimate; `rtk discover --since 100000000` no longer panics; a real PreToolUse payload piped through the built binary still writes a correct `hook_decisions` row with the response written before the log entry.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test --all` (2749 passed, 0 failed)
- [x] Manual e2e run against a synthetic transcript, hook-absent vs hook-installed-with-real-decisions (see above)
- [x] Verified `hook_decisions` rows persist correctly via direct sqlite inspection
- [x] Merged and resolved conflicts against `upstream/develop`
