### PR TITLE
fix(grep): keep line truncation when no match was capped

### DIFF
--- a/src/cmds/system/search.rs
+++ b/src/cmds/system/search.rs
@@ -694,8 +694,8 @@ pub fn run(
         body.push_str(&format!("+{} more files{}\n", skipped_files, hint));
     }
 
-    // Switch to the grouped form only when capping actually shrank the output;
-    // otherwise emit the faithful baseline, so RTK never exceeds the real command.
+    // The grouped form carries a header, so it only pays for itself when matches
+    // were actually dropped and the header explains where they went.
     let capped = shown < total_matches || skipped_files > 0;
     let rtk_output = if capped {
         format!(
@@ -708,7 +708,14 @@ pub fn run(
         body
     };
 
-    let output = if capped && rtk_output.len() < plain.len() {
+    // `capped` only knows about matches that were DROPPED. It says nothing about
+    // matches that were SHORTENED, and by this point `clean_line` has already
+    // trimmed every one of them to `--max-len`. Requiring `capped` here threw
+    // that work away whenever the match count happened to fit under the caps -
+    // which is exactly the shape of a grep over a file with very long lines: few
+    // matches, enormous content. The length comparison alone already keeps the
+    // promise that RTK never emits more than the real command.
+    let output = if rtk_output.len() < plain.len() {
         rtk_output
     } else {
         plain

--- a/tests/search_compress_test.rs
+++ b/tests/search_compress_test.rs
@@ -376,3 +376,56 @@ fn binary_match_is_skipped_unless_text_requested() {
         "-a must show the binary content"
     );
 }
+
+// --- line truncation must survive when nothing was capped by count ---
+
+#[test]
+fn long_line_is_truncated_even_when_no_match_is_capped() {
+    let long = "x".repeat(50_000);
+    let content = format!("MATCH {long}\nMATCH short\n");
+    let (_dir, path) = write_temp(&content);
+
+    let out = rtk()
+        .args(["grep", "-n", "MATCH", path.to_str().unwrap()])
+        .output()
+        .expect("rtk grep");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        stdout.contains("MATCH short"),
+        "both matches must still be reported:\n{stdout}"
+    );
+    // Two matches fit well under --max 200, so nothing is dropped; the win here
+    // is the per-line cap, and it must not be discarded for that reason.
+    assert!(
+        stdout.len() < 5_000,
+        "a 50 000-char line must be cut to --max-len, got {} bytes",
+        stdout.len()
+    );
+}
+
+#[test]
+fn many_short_matches_keep_the_faithful_baseline() {
+    let content = (0..20)
+        .map(|i| format!("MATCH line {i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let (_dir, path) = write_temp(&format!("{content}\n"));
+
+    let out = rtk()
+        .args(["grep", "-n", "MATCH", path.to_str().unwrap()])
+        .output()
+        .expect("rtk grep");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        !stdout.contains("matches in"),
+        "nothing was capped, so no grouped header belongs here:\n{stdout}"
+    );
+    for i in 0..20 {
+        assert!(
+            stdout.contains(&format!("MATCH line {i}")),
+            "short matches must survive untouched:\n{stdout}"
+        );
+    }
+}


### PR DESCRIPTION
## What

`rtk grep` returns its output unfiltered — byte for byte identical to raw `grep` — whenever the matching lines are very long but few enough to fit under `--max`. `--max-len` appears to do nothing in that case.

## Why

In `src/cmds/system/search.rs`:

```rust
let capped = shown < total_matches || skipped_files > 0;
let output = if capped && rtk_output.len() < plain.len() { rtk_output } else { plain };
```

`capped` only tracks matches that were **dropped** by `--max` / `grep_max_per_file`. It says nothing about matches that were **shortened**, and by the time it is read, `clean_line` has already trimmed every line to `--max-len`. Gating on `capped` throws that work away and prints `plain`, which is built from the raw output with full content.

## Reproduce

```bash
printf 'MARKER %s\nMARKER short line\n' "$(head -c 200000 /dev/zero | tr '\0' 'x')" > long.txt

rtk grep -n MARKER long.txt        | wc -c   # 200030
rtk grep -l 80 -n MARKER long.txt  | wc -c   # 200030  <- -l 80 ignored
rtk proxy grep -n MARKER long.txt  | wc -c   # 200030
```

Real-world case that led to this: a 15.8 MB rust-analyzer stats log of 29 lines, the longest 7 842 749 characters. `rtk grep` over it returned 7 842 933 bytes, identical to raw grep. That single command was 37% of a whole day's measured input tokens in our usage.

## Fix

Drop `capped` from the output condition. The length comparison alone already keeps the documented guarantee that RTK never emits more than the real command, and it is the correct rule for both kinds of shrinking — dropped matches and shortened lines. `capped` stays where it belongs: deciding whether the grouped header is worth its cost.

## Results

| case | before | after |
|---|---:|---:|
| 15.8 MB log, 29 lines | 7 842 933 B | **265 B** |
| single 200 000-char line | 200 030 B | **106 B** |
| 5 000 ordinary lines | 2 341 B | 2 341 B (unchanged) |

## Tests

Two tests added to `tests/search_compress_test.rs`:

- `long_line_is_truncated_even_when_no_match_is_capped` — red before this change, green after.
- `many_short_matches_keep_the_faithful_baseline` — guards the other direction: with nothing capped, the faithful baseline is still used and no grouped header appears.

Full suite green. Note that the file is `#![cfg(unix)]`, as it already was; I additionally ran both tests on Windows by temporarily relaxing that gate, and verified the numbers above against the built binary.
