### PR TITLE
fix(hooks): stop Copilot from silently deciding permission on unconfigured commands

### DIFF
--- a/docs/contributing/TECHNICAL.md
+++ b/docs/contributing/TECHNICAL.md
@@ -314,7 +314,7 @@ Start here, then drill down into each README for file-level details.
 |-----------|-------|-------------------------------|
 | [`hooks/`](../hooks/README.md) | _(parent)_ | **All JSON formats**, rewrite registry overview, exit code contract, override controls |
 | [`claude/`](../hooks/claude/README.md) | Claude Code | Shell hook mechanism, `PreToolUse` JSON, test script |
-| [`copilot/`](../hooks/copilot/README.md) | GitHub Copilot | Rust binary hook, VS Code Chat vs Copilot CLI dual format |
+| [`copilot/`](../hooks/copilot/README.md) | GitHub Copilot | Rust binary hook, single `PreToolUse` schema shared by VS Code Chat and Copilot CLI |
 | [`cursor/`](../hooks/cursor/README.md) | Cursor IDE | Shell hook, empty JSON response requirement |
 | [`cline/`](../hooks/cline/README.md) | Cline / Roo Code | Rules file (prompt-level, no programmatic hook) |
 | [`windsurf/`](../hooks/windsurf/README.md) | Windsurf / Cascade | Rules file (workspace-scoped) |
@@ -331,7 +331,7 @@ RTK supports the following LLM agents through hook integrations:
 |-------|-----------|-----------|---------------------|
 | Claude Code | Shell hook | `PreToolUse` in `settings.json` | Yes (`updatedInput`) |
 | GitHub Copilot (VS Code) | Rust binary | `rtk hook copilot` reads JSON | Yes (`updatedInput`) |
-| GitHub Copilot CLI | Rust binary | `rtk hook copilot` reads JSON | No (deny + suggestion) |
+| GitHub Copilot CLI | Rust binary | `rtk hook copilot` reads JSON | Yes (`updatedInput`) |
 | Cursor | Rust binary | `rtk hook cursor` reads JSON | Yes (`updated_input`) |
 | Gemini CLI | Rust binary | `rtk hook gemini` reads JSON | Yes (`hookSpecificOutput`) |
 | Cline/Roo Code | Rules file | Prompt-level guidance | N/A (prompt) |

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -30,7 +30,7 @@ Agent runs "cargo test"
 |-------|-----------------|---------------------------|
 | Claude Code | Shell hook (`PreToolUse`) | Yes |
 | VS Code Copilot Chat | Shell hook (`PreToolUse`) | Yes |
-| GitHub Copilot CLI | Shell hook (`preToolUse` `modifiedArgs`) | Yes |
+| GitHub Copilot CLI | Shell hook (`PreToolUse`) | Yes |
 | Cursor | Shell hook (`preToolUse`) | Yes |
 | Gemini CLI | Rust binary (`BeforeTool`) | Yes |
 | OpenCode | TypeScript plugin (`tool.execute.before`) | Yes |
@@ -74,7 +74,9 @@ rtk init --copilot            # project-scoped (.github/hooks/)
 rtk init --global --copilot   # user-scoped (~/.copilot/hooks/, respects $COPILOT_HOME)
 ```
 
-Project-scoped writes `.github/hooks/rtk-rewrite.json` (both hosts get transparent rewrite — VS Code Chat via `updatedInput`, Copilot CLI via `modifiedArgs`) plus the RTK block in `.github/copilot-instructions.md`. User-scoped writes the same hook config to `~/.copilot/hooks/rtk-rewrite.json` and the RTK block to `~/.copilot/copilot-instructions.md` (both respect `$COPILOT_HOME` if set).
+Project-scoped writes `.github/hooks/rtk-rewrite.json` — a single `PreToolUse` entry shared by both hosts, each getting transparent rewrite via `updatedInput` — plus the RTK block in `.github/copilot-instructions.md`. User-scoped writes the same hook config to `~/.copilot/hooks/rtk-rewrite.json` and the RTK block to `~/.copilot/copilot-instructions.md` (both respect `$COPILOT_HOME` if set).
+
+Earlier `rtk` versions also registered a second, camelCase `preToolUse` entry for Copilot CLI's native schema. Copilot CLI treats `PreToolUse`/`preToolUse` as independent hooks and runs both sequentially for the same tool call — a redundant process spawn with no behavioral benefit, since Copilot CLI honors the single `PreToolUse` schema on its own. Re-run `rtk init --copilot` (or `--global --copilot`) to upgrade an existing install to the single-hook config.
 
 Uninstall:
 

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -30,6 +30,10 @@ fn read_stdin_limited() -> Result<String> {
 /// Format detected from the preToolUse JSON input.
 enum HookFormat {
     /// VS Code Copilot Chat / Claude Code: `tool_name` + `tool_input.command`, supports `updatedInput`.
+    /// If using the PreToolUse pascal case form, Copilot CLI also remaps its native `bash`/`powershell`
+    /// runtime tool to `tool_name: "Bash"` for this schema and honors its `updatedInput`, live-verified
+    /// on Linux+Windows 11 with Copilot CLI 1.0.73+ by rewriting a marker command end-to-end
+    /// see <https://github.com/rtk-ai/rtk/pull/3179#issuecomment-5088268495>.
     VsCode { command: String },
     /// GitHub Copilot CLI's native schema: camelCase `toolName` + `toolArgs` (JSON string),
     /// supports `modifiedArgs` for transparent rewrite. `rtk init --copilot` no longer
@@ -38,6 +42,10 @@ enum HookFormat {
     /// see git history). Kept for installs that haven't re-run `rtk init --copilot` since
     /// upgrading, and as the schema JetBrains/IntelliJ's Copilot plugin uses under a
     /// different `toolName` value (`run_in_terminal`, not `bash` — see #2443/#3093).
+    /// On Windows, Copilot CLI reports this schema's `toolName` as the unmapped runtime
+    /// name `"powershell"` (#3178/#3179) — but since the `VsCode` schema above already
+    /// works standalone there, that arm is legacy-only: relevant for un-upgraded installs,
+    /// not exercised by a fresh `rtk init --copilot` on any platform.
     /// Carries the full parsed `toolArgs` object so we can rewrite `command` while preserving
     /// host-supplied metadata (description, initial_wait, mode, …) the tool requires.
     CopilotCli { command: String, args: Value },
@@ -81,6 +89,9 @@ fn detect_format(v: &Value) -> HookFormat {
     // "run_in_terminal" is VS Code Copilot Chat's actual terminal tool name
     // (confirmed via live payload capture) — without it, detect_format falls
     // through to PassThrough and the hook never fires for VS Code Copilot Chat.
+    // No separate Windows/"powershell" case is needed: Copilot CLI remaps both
+    // `bash` and `powershell` to `tool_name: "Bash"` for this schema — already
+    // handled below, live-confirmed (see the VsCode variant doc).
     if let Some(tool_name) = v.get("tool_name").and_then(|t| t.as_str()) {
         if matches!(
             tool_name,
@@ -99,12 +110,12 @@ fn detect_format(v: &Value) -> HookFormat {
         return HookFormat::PassThrough;
     }
 
-    // Copilot's native camelCase schema: toolName + toolArgs (JSON-encoded string).
+    // Copilot CLI's native camelCase schema: toolName + toolArgs (JSON-encoded string).
     // The shell tool is "bash" on Unix and "powershell" on Windows.
     // Only reachable today via a not-yet-upgraded install's leftover camelCase
     // preToolUse registration (see the CopilotCli variant doc) or a host that
     // registers this schema itself, like JetBrains/IntelliJ's Copilot plugin
-    // (toolName "run_in_terminal", tracked separately in #2443/#3093).
+    // (toolName "run_in_terminal").
     if let Some(tool_name) = v.get("toolName").and_then(|t| t.as_str()) {
         if matches!(tool_name, "bash" | "powershell" | "run_in_terminal") {
             if let Some(tool_args_str) = v.get("toolArgs").and_then(|t| t.as_str()) {
@@ -243,7 +254,7 @@ fn copilot_ide_response_from_decision(decision: HookDecision, cmd: &str) -> Opti
             audit_log("deny", cmd, "");
             "Blocked by RTK permission rule".to_string()
         }
-        HookDecision::AllowRewrite(rewritten) | HookDecision::AskRewrite { rewritten, .. } => {
+        HookDecision::AllowRewrite(rewritten) | HookDecision::AskRewrite(rewritten) => {
             audit_log("rewrite", cmd, &rewritten);
             format!("RTK token optimization: re-run this command as `{rewritten}` instead.")
         }
@@ -986,10 +997,7 @@ mod tests {
     #[test]
     fn test_copilot_ide_rewrite_returns_deny_with_suggestion() {
         let response = copilot_ide_response_from_decision(
-            HookDecision::AskRewrite {
-                rewritten: "rtk git status".into(),
-                explicit: false,
-            },
+            HookDecision::AskRewrite("rtk git status".into()),
             "git status",
         )
         .unwrap();

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -31,7 +31,13 @@ fn read_stdin_limited() -> Result<String> {
 enum HookFormat {
     /// VS Code Copilot Chat / Claude Code: `tool_name` + `tool_input.command`, supports `updatedInput`.
     VsCode { command: String },
-    /// GitHub Copilot CLI: camelCase `toolName` + `toolArgs` (JSON string), supports `modifiedArgs` for transparent rewrite.
+    /// GitHub Copilot CLI's native schema: camelCase `toolName` + `toolArgs` (JSON string),
+    /// supports `modifiedArgs` for transparent rewrite. `rtk init --copilot` no longer
+    /// registers this schema (Copilot CLI honors the PascalCase `VsCode` schema on its
+    /// own — registering both caused a redundant second hook invocation per tool call,
+    /// see git history). Kept for installs that haven't re-run `rtk init --copilot` since
+    /// upgrading, and as the schema JetBrains/IntelliJ's Copilot plugin uses under a
+    /// different `toolName` value (`run_in_terminal`, not `bash` — see #2443/#3093).
     /// Carries the full parsed `toolArgs` object so we can rewrite `command` while preserving
     /// host-supplied metadata (description, initial_wait, mode, …) the tool requires.
     CopilotCli { command: String, args: Value },
@@ -93,8 +99,12 @@ fn detect_format(v: &Value) -> HookFormat {
         return HookFormat::PassThrough;
     }
 
-    // Copilot CLI: camelCase keys, toolArgs is a JSON-encoded string.
+    // Copilot's native camelCase schema: toolName + toolArgs (JSON-encoded string).
     // The shell tool is "bash" on Unix and "powershell" on Windows.
+    // Only reachable today via a not-yet-upgraded install's leftover camelCase
+    // preToolUse registration (see the CopilotCli variant doc) or a host that
+    // registers this schema itself, like JetBrains/IntelliJ's Copilot plugin
+    // (toolName "run_in_terminal", tracked separately in #2443/#3093).
     if let Some(tool_name) = v.get("toolName").and_then(|t| t.as_str()) {
         if matches!(tool_name, "bash" | "powershell" | "run_in_terminal") {
             if let Some(tool_args_str) = v.get("toolArgs").and_then(|t| t.as_str()) {

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -71,9 +71,15 @@ pub fn run_copilot() -> Result<()> {
 }
 
 fn detect_format(v: &Value) -> HookFormat {
-    // VS Code Copilot Chat / Claude Code: snake_case keys
+    // VS Code Copilot Chat / Claude Code: snake_case keys.
+    // "run_in_terminal" is VS Code Copilot Chat's actual terminal tool name
+    // (confirmed via live payload capture) — without it, detect_format falls
+    // through to PassThrough and the hook never fires for VS Code Copilot Chat.
     if let Some(tool_name) = v.get("tool_name").and_then(|t| t.as_str()) {
-        if matches!(tool_name, "runTerminalCommand" | "Bash" | "bash") {
+        if matches!(
+            tool_name,
+            "runTerminalCommand" | "run_in_terminal" | "Bash" | "bash"
+        ) {
             if let Some(cmd) = v
                 .pointer("/tool_input/command")
                 .and_then(|c| c.as_str())
@@ -761,6 +767,16 @@ mod tests {
     fn test_detect_vscode_run_terminal_command() {
         assert!(matches!(
             detect_format(&vscode_input("runTerminalCommand", "cargo test")),
+            HookFormat::VsCode { .. }
+        ));
+    }
+
+    #[test]
+    fn test_detect_vscode_run_in_terminal() {
+        // VS Code Copilot Chat's actual terminal tool name, confirmed via
+        // live payload capture — distinct from "runTerminalCommand".
+        assert!(matches!(
+            detect_format(&vscode_input("run_in_terminal", "cargo test")),
             HookFormat::VsCode { .. }
         ));
     }

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -138,7 +138,7 @@ fn get_rewritten(cmd: &str) -> Option<String> {
 
 enum HookDecision {
     AllowRewrite(String),
-    AskRewrite { rewritten: String, explicit: bool },
+    AskRewrite(String),
     Defer,
     Deny,
 }
@@ -152,10 +152,7 @@ fn decide_from_verdict(cmd: &str, verdict: PermissionVerdict) -> HookDecision {
     }
     match get_rewritten(cmd) {
         Some(r) if verdict == PermissionVerdict::Allow => HookDecision::AllowRewrite(r),
-        Some(r) => HookDecision::AskRewrite {
-            rewritten: r,
-            explicit: verdict == PermissionVerdict::Ask,
-        },
+        Some(r) => HookDecision::AskRewrite(r),
         None => HookDecision::Defer,
     }
 }
@@ -165,28 +162,46 @@ fn decide_hook_action(cmd: &str, host: permissions::Host) -> HookDecision {
 }
 
 fn handle_vscode(cmd: &str) -> Result<()> {
-    let (decision, rewritten) = match decide_hook_action(cmd, permissions::Host::Claude) {
+    if let Some(output) = vscode_response(cmd) {
+        let _ = writeln!(io::stdout(), "{output}");
+    }
+    Ok(())
+}
+
+fn vscode_response(cmd: &str) -> Option<Value> {
+    vscode_response_from_decision(decide_hook_action(cmd, permissions::Host::Claude), cmd)
+}
+
+/// Build the VS Code Copilot Chat / Copilot CLI (PascalCase compat) hook response.
+///
+/// Mirrors `process_claude_payload`: `permissionDecision: "allow"` is only ever
+/// asserted for an explicit, user-configured Allow rule. Every other rewrite
+/// (Default verdict or an explicit Ask rule) omits the field entirely, leaving
+/// the host's own native prompt/allowlist flow in control — see #3037, where
+/// asserting `"ask"` here made Copilot CLI 1.0.66+ force a blocking dialog with
+/// no "remember" option on every rewritten command.
+fn vscode_response_from_decision(decision: HookDecision, cmd: &str) -> Option<Value> {
+    let (rewritten, allow) = match decision {
         HookDecision::Deny => {
             audit_log("deny", cmd, "");
-            return Ok(());
+            return None;
         }
-        HookDecision::Defer => return Ok(()),
-        HookDecision::AllowRewrite(r) => ("allow", r),
-        HookDecision::AskRewrite { rewritten: r, .. } => ("ask", r),
+        HookDecision::Defer => return None,
+        HookDecision::AllowRewrite(r) => (r, true),
+        HookDecision::AskRewrite(r) => (r, false),
     };
 
     audit_log("rewrite", cmd, &rewritten);
 
-    let output = json!({
-        "hookSpecificOutput": {
-            "hookEventName": PRE_TOOL_USE_KEY,
-            "permissionDecision": decision,
-            "permissionDecisionReason": "RTK auto-rewrite",
-            "updatedInput": { "command": rewritten }
-        }
+    let mut hook_output = json!({
+        "hookEventName": PRE_TOOL_USE_KEY,
+        "permissionDecisionReason": "RTK auto-rewrite",
+        "updatedInput": { "command": rewritten }
     });
-    let _ = writeln!(io::stdout(), "{output}");
-    Ok(())
+    if allow {
+        hook_output["permissionDecision"] = json!("allow");
+    }
+    Some(json!({ "hookSpecificOutput": hook_output }))
 }
 
 fn handle_copilot_cli(cmd: &str, args: &Value) -> Result<()> {
@@ -244,13 +259,7 @@ fn copilot_cli_response_from_decision(
         }
         HookDecision::Defer => return None,
         HookDecision::AllowRewrite(r) => (r, true),
-        HookDecision::AskRewrite {
-            rewritten: r,
-            explicit,
-        } => {
-            let is_simple = crate::discover::lexer::split_for_permissions(cmd).len() <= 1;
-            (r, !explicit && is_simple)
-        }
+        HookDecision::AskRewrite(r) => (r, false),
     };
 
     audit_log("rewrite", cmd, &rewritten);
@@ -306,7 +315,7 @@ pub fn run_gemini() -> Result<()> {
             audit_log("rewrite", cmd, rewritten);
             print_gemini("allow", Some(rewritten));
         }
-        HookDecision::AskRewrite { ref rewritten, .. } => {
+        HookDecision::AskRewrite(ref rewritten) => {
             audit_log("ask", cmd, rewritten);
             print_gemini("ask_user", Some(rewritten));
         }
@@ -411,7 +420,7 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
             }
         }
         HookDecision::AllowRewrite(r) => (r, true),
-        HookDecision::AskRewrite { rewritten: r, .. } => (r, false),
+        HookDecision::AskRewrite(r) => (r, false),
     };
 
     let updated_input = {
@@ -535,7 +544,7 @@ pub fn run_cursor() -> Result<()> {
             audit_log("rewrite", &cmd, &rewritten);
             cursor_allow(&rewritten)
         }
-        HookDecision::AskRewrite { rewritten, .. } => {
+        HookDecision::AskRewrite(rewritten) => {
             audit_log("ask", &cmd, &rewritten);
             cursor_ask(&rewritten)
         }
@@ -598,7 +607,7 @@ fn run_cursor_inner_with_rules(
     let verdict = permissions::check_command_with_rules(&cmd, deny_rules, ask_rules, allow_rules);
     match decide_from_verdict(&cmd, verdict) {
         HookDecision::AllowRewrite(rewritten) => cursor_allow(&rewritten),
-        HookDecision::AskRewrite { rewritten, .. } => cursor_ask(&rewritten),
+        HookDecision::AskRewrite(rewritten) => cursor_ask(&rewritten),
         _ => "{}".to_string(),
     }
 }
@@ -644,7 +653,7 @@ fn droid_response_from_decision(v: &Value, cmd: &str, decision: HookDecision) ->
             return None;
         }
         HookDecision::Defer => return None,
-        HookDecision::AllowRewrite(r) | HookDecision::AskRewrite { rewritten: r, .. } => r,
+        HookDecision::AllowRewrite(r) | HookDecision::AskRewrite(r) => r,
     };
 
     audit_log("rewrite", cmd, &rewritten);
@@ -834,6 +843,61 @@ mod tests {
         assert!(get_rewritten("cat <<'EOF'\nhello\nEOF").is_none());
     }
 
+    // --- VS Code Copilot Chat / Copilot CLI (PascalCase) handler ---
+    // Serves both VS Code Copilot Chat's PreToolUse hook and Copilot CLI's
+    // PascalCase-compat entry (#3037): the same `rtk hook copilot` call
+    // answers both from one JSON schema.
+
+    #[test]
+    fn test_vscode_allow_rewrite_sets_permission_allow() {
+        let r = vscode_response_from_decision(
+            HookDecision::AllowRewrite("rtk git status".into()),
+            "git status",
+        )
+        .unwrap();
+        assert_eq!(r["hookSpecificOutput"]["permissionDecision"], "allow");
+        assert_eq!(
+            r["hookSpecificOutput"]["updatedInput"]["command"],
+            "rtk git status"
+        );
+    }
+
+    #[test]
+    fn test_vscode_ask_rewrite_omits_permission_decision() {
+        // Default (unconfigured) and explicit-Ask verdicts both land here as
+        // AskRewrite — neither must assert a decision, matching Claude's own
+        // hook (process_claude_payload). Asserting "ask" is what caused #3037:
+        // Copilot CLI 1.0.66+ treats it as authoritative and forces a blocking
+        // dialog with no "remember" option on every rewritten command.
+        let r = vscode_response_from_decision(
+            HookDecision::AskRewrite("rtk cargo test".into()),
+            "cargo test",
+        )
+        .unwrap();
+        assert!(
+            r["hookSpecificOutput"]
+                .as_object()
+                .unwrap()
+                .get("permissionDecision")
+                .is_none(),
+            "AskRewrite must NOT set permissionDecision"
+        );
+        assert_eq!(
+            r["hookSpecificOutput"]["updatedInput"]["command"],
+            "rtk cargo test"
+        );
+    }
+
+    #[test]
+    fn test_vscode_deny_returns_none() {
+        assert!(vscode_response_from_decision(HookDecision::Deny, "cargo test").is_none());
+    }
+
+    #[test]
+    fn test_vscode_defer_returns_none() {
+        assert!(vscode_response_from_decision(HookDecision::Defer, "cargo test").is_none());
+    }
+
     // --- Copilot CLI handler: transparent rewrite via modifiedArgs ---
 
     fn cli_args(cmd: &str) -> Value {
@@ -841,37 +905,20 @@ mod tests {
     }
 
     #[test]
-    fn test_copilot_cli_default_ask_rewrite_sets_permission_allow() {
+    fn test_copilot_cli_ask_rewrite_omits_permission_decision() {
+        // Whether the Ask verdict came from an explicit rule or the Default
+        // (unconfigured) fallback, RTK must never assert a decision here —
+        // matches Claude's own hook (process_claude_payload) and avoids the
+        // Copilot CLI 1.0.66+ forced-prompt bug from #3037.
         let r = copilot_cli_response_from_decision(
             &cli_args("cargo test"),
-            HookDecision::AskRewrite {
-                rewritten: "rtk cargo test".into(),
-                explicit: false,
-            },
-            "cargo test",
-        )
-        .unwrap();
-        assert_eq!(
-            r["permissionDecision"], "allow",
-            "Default AskRewrite must set permissionDecision to allow — Copilot CLI 1.0.66+ prompts on every command without it"
-        );
-        assert_eq!(r["modifiedArgs"]["command"], "rtk cargo test");
-    }
-
-    #[test]
-    fn test_copilot_cli_explicit_ask_rewrite_omits_permission_decision() {
-        let r = copilot_cli_response_from_decision(
-            &cli_args("cargo test"),
-            HookDecision::AskRewrite {
-                rewritten: "rtk cargo test".into(),
-                explicit: true,
-            },
+            HookDecision::AskRewrite("rtk cargo test".into()),
             "cargo test",
         )
         .unwrap();
         assert!(
             r.get("permissionDecision").is_none(),
-            "Explicit AskRewrite must NOT auto-allow — user deliberately configured ask for this command"
+            "AskRewrite must NOT set permissionDecision — the host's native prompt/allowlist stays in control"
         );
         assert_eq!(r["modifiedArgs"]["command"], "rtk cargo test");
     }
@@ -1000,10 +1047,7 @@ mod tests {
         });
         let r = copilot_cli_response_from_decision(
             &args,
-            HookDecision::AskRewrite {
-                rewritten: "rtk cargo install ripgrep".into(),
-                explicit: false,
-            },
+            HookDecision::AskRewrite("rtk cargo install ripgrep".into()),
             "cargo install ripgrep",
         )
         .unwrap();
@@ -1577,7 +1621,7 @@ mod tests {
     fn test_decide_ask_for_default_verdict() {
         assert!(matches!(
             decide_with_rules("git status", &[], &[], &[]),
-            HookDecision::AskRewrite { .. }
+            HookDecision::AskRewrite(_)
         ));
     }
 
@@ -1635,7 +1679,7 @@ mod tests {
                 r#"{"decision":"deny","reason":"Blocked by RTK permission rule"}"#.to_string()
             }
             HookDecision::AllowRewrite(r) => gemini_json("allow", Some(&r)),
-            HookDecision::AskRewrite { rewritten: r, .. } => gemini_json("ask_user", Some(&r)),
+            HookDecision::AskRewrite(r) => gemini_json("ask_user", Some(&r)),
             HookDecision::Defer => gemini_json("ask_user", None),
         }
     }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -4448,7 +4448,14 @@ fn uninstall_gemini(ctx: InitContext) -> Result<Vec<String>> {
 
 // ── Copilot integration ─────────────────────────────────────
 
-// PreToolUse = VS Code schema, preToolUse = Copilot CLI schema (same file, both hosts).
+// Single PascalCase `PreToolUse` entry, shared by VS Code Copilot Chat and
+// Copilot CLI. Previously this file also declared a camelCase `preToolUse`
+// entry for Copilot CLI's native schema, but Copilot CLI registers BOTH keys
+// as independent hooks and runs them sequentially, chaining the camelCase
+// hook's rewrite into the PascalCase hook's input — a redundant second
+// process spawn per tool call for no behavioral benefit (confirmed live:
+// Copilot CLI honors the PascalCase-only schema on its own, receiving the
+// same `tool_name`/`tool_input.command` shape either way).
 const COPILOT_HOOK_JSON: &str = r#"{
   "version": 1,
   "hooks": {
@@ -4458,15 +4465,6 @@ const COPILOT_HOOK_JSON: &str = r#"{
         "command": "rtk hook copilot",
         "cwd": ".",
         "timeout": 5
-      }
-    ],
-    "preToolUse": [
-      {
-        "type": "command",
-        "bash": "rtk hook copilot",
-        "powershell": "rtk hook copilot",
-        "cwd": ".",
-        "timeoutSec": 5
       }
     ]
   }
@@ -7534,25 +7532,23 @@ mod tests {
     }
 
     #[test]
-    fn test_copilot_hook_json_serves_both_vscode_and_cli_schemas() {
+    fn test_copilot_hook_json_serves_single_pascalcase_schema() {
         let v: serde_json::Value = serde_json::from_str(COPILOT_HOOK_JSON).unwrap();
 
         let vscode = &v["hooks"]["PreToolUse"][0];
         assert_eq!(vscode["command"], "rtk hook copilot");
         assert!(vscode["timeout"].is_number(), "VS Code uses `timeout`");
+        assert_eq!(v["version"], 1);
 
-        assert_eq!(v["version"], 1, "Copilot CLI requires top-level version");
-        let cli = &v["hooks"]["preToolUse"][0];
-        assert_eq!(cli["bash"], "rtk hook copilot");
-        assert_eq!(cli["powershell"], "rtk hook copilot");
         assert!(
-            cli["timeoutSec"].is_number(),
-            "Copilot CLI uses `timeoutSec`"
+            v["hooks"].get("preToolUse").is_none(),
+            "must not register a second, redundant camelCase hook — Copilot CLI treats \
+             PreToolUse and preToolUse as independent hooks and runs both sequentially"
         );
     }
 
     #[test]
-    fn test_copilot_init_writes_dual_schema_to_disk() {
+    fn test_copilot_init_writes_single_schema_to_disk() {
         let temp = TempDir::new().unwrap();
         run_copilot_at(temp.path(), InitContext::default()).unwrap();
 
@@ -7566,7 +7562,44 @@ mod tests {
 
         assert_eq!(v["hooks"]["PreToolUse"][0]["command"], "rtk hook copilot");
         assert_eq!(v["version"], 1);
-        assert_eq!(v["hooks"]["preToolUse"][0]["bash"], "rtk hook copilot");
+        assert!(v["hooks"].get("preToolUse").is_none());
+    }
+
+    #[test]
+    fn test_copilot_init_upgrades_old_dual_schema_install() {
+        // Simulates a pre-existing install from before this fix, which wrote
+        // both a PascalCase PreToolUse and a camelCase preToolUse entry.
+        // Re-running `rtk init --copilot` must overwrite it with the current
+        // single-schema config, not leave the stale camelCase entry in place.
+        let old_dual_schema_json = r#"{
+  "version": 1,
+  "hooks": {
+    "PreToolUse": [
+      { "type": "command", "command": "rtk hook copilot", "cwd": ".", "timeout": 5 }
+    ],
+    "preToolUse": [
+      { "type": "command", "bash": "rtk hook copilot", "powershell": "rtk hook copilot", "cwd": ".", "timeoutSec": 5 }
+    ]
+  }
+}
+"#;
+
+        let temp = TempDir::new().unwrap();
+        let hooks_dir = temp.path().join(".github").join("hooks");
+        fs::create_dir_all(&hooks_dir).unwrap();
+        let hook_path = hooks_dir.join("rtk-rewrite.json");
+        fs::write(&hook_path, old_dual_schema_json).unwrap();
+
+        run_copilot_at(temp.path(), InitContext::default()).unwrap();
+
+        let v: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&hook_path).unwrap()).unwrap();
+        assert_eq!(v["hooks"]["PreToolUse"][0]["command"], "rtk hook copilot");
+        assert!(
+            v["hooks"].get("preToolUse").is_none(),
+            "re-running init must upgrade an old dual-schema install, dropping the \
+             redundant camelCase preToolUse entry"
+        );
     }
 
     #[test]
@@ -7694,7 +7727,39 @@ mod tests {
             serde_json::from_str(&fs::read_to_string(&hook_path).unwrap()).unwrap();
         assert_eq!(v["version"], 1);
         assert_eq!(v["hooks"]["PreToolUse"][0]["command"], "rtk hook copilot");
-        assert_eq!(v["hooks"]["preToolUse"][0]["bash"], "rtk hook copilot");
+        assert!(v["hooks"].get("preToolUse").is_none());
+    }
+
+    #[test]
+    fn test_copilot_global_install_upgrades_old_dual_schema_install() {
+        let old_dual_schema_json = r#"{
+  "version": 1,
+  "hooks": {
+    "PreToolUse": [
+      { "type": "command", "command": "rtk hook copilot", "cwd": ".", "timeout": 5 }
+    ],
+    "preToolUse": [
+      { "type": "command", "bash": "rtk hook copilot", "powershell": "rtk hook copilot", "cwd": ".", "timeoutSec": 5 }
+    ]
+  }
+}
+"#;
+
+        let temp = TempDir::new().unwrap();
+        let hooks_dir = temp.path().join("hooks");
+        fs::create_dir_all(&hooks_dir).unwrap();
+        let hook_path = hooks_dir.join("rtk-rewrite.json");
+        fs::write(&hook_path, old_dual_schema_json).unwrap();
+
+        run_copilot_global_at(temp.path(), InitContext::default()).unwrap();
+
+        let v: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&hook_path).unwrap()).unwrap();
+        assert_eq!(v["hooks"]["PreToolUse"][0]["command"], "rtk hook copilot");
+        assert!(
+            v["hooks"].get("preToolUse").is_none(),
+            "re-running global init must upgrade an old dual-schema install"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the root cause of #3037 properly, instead of the workaround `84aa4d6`/`0df6929` shipped, and closes two related gaps found while validating it live against real Copilot CLI (1.0.75) and VS Code Copilot Chat.

- **`permissionDecision` parity** — `handle_vscode` (`rtk hook copilot`'s PascalCase path, shared by VS Code Copilot Chat and Copilot CLI's Claude-compat entry) always asserted `permissionDecision: "allow"` or `"ask"`. Asserting `"ask"` is exactly what `#3037` reported: Copilot CLI 1.0.66+ treats it as authoritative and forces a distinct, memory-less "Hook permission request" dialog on *every* call. `84aa4d6`/`0df6929` patched the camelCase native path instead (which never had this problem) with an auto-allow heuristic — the actual bug in `handle_vscode` was never touched. Now `rtk hook copilot` only ever asserts `permissionDecision: allow` for an explicit, user-configured Allow rule — exactly the same rule Claude Code's own hook (`process_claude_payload`) and Factory Droid's hook already use. Everything else omits the field, per GitHub's own docs ("empty output uses default behavior" — hook silence is a supported, intentional no-op, not a workaround), letting Copilot's native trust-on-first-use dialog (which *does* have a working "don't ask again" option) take over.
- **Dual hook registration removed** — `rtk init --copilot` registered both a PascalCase `PreToolUse` and a camelCase `preToolUse` entry in the same file. Live testing (raw stdin capture, both hook-order and key-order reversed) showed Copilot CLI treats them as two independent, sequentially-run hooks regardless of declaration order — camelCase always runs first and does the real rewrite, PascalCase always runs second on the already-rewritten command and just defers. A redundant process spawn with no behavioral benefit, since Copilot CLI honors the PascalCase-only schema perfectly well on its own. Dropped the camelCase entry; existing installs upgrade on the next `rtk init --copilot` / `rtk init --global --copilot` re-run (`write_if_changed` overwrites unconditionally on content diff — verified with dedicated upgrade tests, not just fresh-install tests).
- **VS Code Copilot Chat tool-name gap** — found while testing the above live in actual VS Code: `detect_format` only recognized `tool_name` values `"runTerminalCommand"`/`"Bash"`/`"bash"`. A real captured payload from VS Code Copilot Chat showed it actually sends `"run_in_terminal"` — unrecognized, so the hook fell through to `PassThrough` and never fired at all for VS Code Copilot Chat (no rewrite, no decision, nothing). Added `"run_in_terminal"` to the recognized set. Fixes #1425

## Live validation

All three changes were validated against the real, currently-released binaries and both real hosts (not just unit tests):

- Built the actual `develop` HEAD (`23d1e89`) fresh as the true "before" baseline (an initially-used stale local install turned out to predate both `84aa4d6` and `0df6929` entirely).
- Confirmed via raw stdin capture that Copilot CLI 1.0.75 genuinely sends the PascalCase (`tool_name`/`tool_input.command`) payload shape when only that key is registered — not just a VS-Code-relayed artifact.
- Reproduced the exact `#3037` bug live: `develop` HEAD's literal `permissionDecision: "ask"` produces a distinct "Hook permission request" / "RTK auto-rewrite" dialog with **no** remember option, repeating on every call.
- Confirmed the fix produces Copilot's normal generic trust dialog instead, with a working "don't ask again" option — one prompt per repo, then silent, matching Claude Code's own UX.
- Confirmed real VS Code Copilot Chat (freshly installed) now correctly rewrites a compound `cd <dir> && git status --short --branch` command to `cd <dir> && rtk git status --short --branch`, with no forced `permissionDecision`.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test --all` (2498 tests, all green)
- [x] New unit tests: `vscode_response_from_decision` decision matrix (allow/ask/deny/defer), dual-schema-upgrade tests (project + global scoped), `run_in_terminal` format detection
- [x] Live end-to-end validation against real `copilot` CLI 1.0.75 and VS Code Copilot Chat, described above

🤖 Generated with [Claude Code](https://claude.com/claude-code)