### PR TITLE
fix(build): use GNU-correct stack linker flag on windows-gnu target

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,7 +9,12 @@ fn main() {
         // main-thread stack during process startup. Reserve a larger stack for
         // the CLI binary so `rtk.exe --version`, `--help`, and hook entry
         // points start reliably without requiring ad-hoc RUSTFLAGS.
-        println!("cargo:rustc-link-arg=/STACK:8388608");
+        // MSVC's link.exe and GNU/mingw's ld use different flag syntax for this.
+        if std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc") {
+            println!("cargo:rustc-link-arg=/STACK:8388608");
+        } else {
+            println!("cargo:rustc-link-arg=-Wl,--stack,8388608");
+        }
     }
 
     let filters_dir = Path::new("src/filters");


### PR DESCRIPTION
## Summary

Fixes #3215.

`build.rs` unconditionally emitted the MSVC-only `/STACK:8388608` linker flag on any Windows build. On the `x86_64-pc-windows-gnu` target the linker is GNU `ld`, which doesn't understand `/STACK:` syntax — it treats it as a missing file operand and the link step fails. This breaks `cargo install --git ...` (and any local build) for anyone whose active Rust toolchain targets `*-pc-windows-gnu`.

## Change

Branch on `CARGO_CFG_TARGET_ENV` (set by Cargo for build scripts) so:
- MSVC (`link.exe`) keeps `/STACK:8388608`
- GNU (`ld`, via mingw) gets the equivalent `-Wl,--stack,8388608`

## Testing

Built and ran successfully on `x86_64-pc-windows-gnu`:

```
cargo +stable-x86_64-pc-windows-gnu install --path .
rtk --version
rtk hook claude   # confirmed via simulated PreToolUse payload
rtk gain
```

All worked as expected; no change in behavior on MSVC (flag/logic unchanged for that branch).