### PR TITLE
fix(tsc): respect failed compiler exit status

### DIFF
--- a/src/cmds/js/tsc_cmd.rs
+++ b/src/cmds/js/tsc_cmd.rs
@@ -78,8 +78,14 @@ impl BlockHandler for TscHandler {
         line.starts_with("  ") || line.starts_with('\t')
     }
 
-    fn format_summary(&self, _exit_code: i32, _raw: &str) -> Option<String> {
+    fn format_summary(&self, exit_code: i32, _raw: &str) -> Option<String> {
         if self.error_count == 0 {
+            if exit_code != 0 {
+                return Some(format!(
+                    "TypeScript: compilation failed (exit {})\n",
+                    exit_code
+                ));
+            }
             return Some("TypeScript: No errors found\n".to_string());
         }
 
@@ -320,6 +326,19 @@ Found 3 errors in 2 files.
         let mut f = BlockStreamFilter::new(TscHandler::new());
         let result = run_block_filter(&mut f, input, 0);
         assert!(result.contains("No errors found"), "got: {}", result);
+    }
+
+    #[test]
+    fn test_tsc_stream_nonzero_exit_without_diagnostics() {
+        let input = "This is not the tsc command you are looking for\n";
+        let mut f = BlockStreamFilter::new(TscHandler::new());
+        let result = run_block_filter(&mut f, input, 1);
+        assert!(
+            result.contains("TypeScript: compilation failed (exit 1)"),
+            "got: {}",
+            result
+        );
+        assert!(!result.contains("No errors found"), "got: {}", result);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

- Prevent the `tsc` streaming filter from reporting "No errors found" when the compiler exits non-zero without parseable diagnostics.
- Add regression coverage for an unparsed TypeScript compiler failure.
- Fixes #3220

## Test plan
<!-- How did you verify this works? -->

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `target/debug/rtk tsc --definitely-invalid-option` reports `TypeScript: compilation failed (exit 1)` and preserves exit code 1.

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
