### PR TITLE
docs(hook): distinguish typed and rewritten commands

### DIFF
--- a/hooks/claude/rtk-awareness.md
+++ b/hooks/claude/rtk-awareness.md
@@ -2,7 +2,7 @@
 
 **Usage**: Token-optimized CLI proxy (cuts up to 90% of bash output)
 
-## Meta Commands (always use rtk directly)
+## Meta Commands (type these with `rtk` directly)
 
 ```bash
 rtk gain              # Show token savings analytics
@@ -21,9 +21,10 @@ which rtk             # Verify correct binary
 
 ⚠️ **Name collision**: If `rtk gain` fails, you may have reachingforthejack/rtk (Rust Type Kit) installed instead.
 
-## Hook-Based Usage
+## Hook-Rewritten Commands
 
-All other commands are automatically rewritten by the Claude Code hook.
-Example: `git status` → `rtk git status` (transparent, 0 tokens overhead)
+For git, gh, cargo, and other hook-covered tools, type the plain command without an `rtk` prefix. The Claude Code hook rewrites it after permission checks.
+
+Example: type `git status`. The hook transparently runs `rtk git status`; do not type the rewritten form yourself.
 
 Refer to CLAUDE.md for full command reference.

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -4872,6 +4872,13 @@ mod tests {
     }
 
     #[test]
+    fn test_claude_rtk_md_distinguishes_meta_and_rewritten_commands() {
+        assert!(RTK_SLIM.contains("Meta Commands (type these with `rtk` directly)"));
+        assert!(RTK_SLIM.contains("type the plain command without an `rtk` prefix"));
+        assert!(RTK_SLIM.contains("do not type the rewritten form yourself"));
+    }
+
+    #[test]
     fn test_claude_md_mode_creates_full_injection() {
         // Just verify RTK_INSTRUCTIONS constant has the right content
         assert!(RTK_INSTRUCTIONS.contains(RTK_BLOCK_START));


### PR DESCRIPTION
## Summary

- Clarify that only RTK meta commands should be typed with the `rtk` prefix.
- Tell Claude to type hook-covered commands in their plain form, and test the generated `RTK.md` contract.

Fixes #3186

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: generated `RTK.md` with `rtk init -g` in a temporary Claude config directory and inspected the command guidance

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
