### PR TITLE
fix(gh): preserve stdin for filtered PR actions

### DIFF
--- a/src/cmds/git/gh_cmd.rs
+++ b/src/cmds/git/gh_cmd.rs
@@ -901,7 +901,9 @@ fn pr_create(args: &[String], _verbose: u8) -> Result<i32> {
             };
             ok_confirmation("created", &detail)
         },
-        RunOptions::stdout_only().early_exit_on_failure(),
+        RunOptions::stdout_only()
+            .early_exit_on_failure()
+            .inherit_stdin(),
     )
 }
 
@@ -975,7 +977,9 @@ fn pr_action(action: &str, args: &[String], _verbose: u8) -> Result<i32> {
         "gh",
         &format!("pr {}", subcmd),
         move |_stdout| ok_confirmation(&action, &pr_num),
-        RunOptions::stdout_only().early_exit_on_failure(),
+        RunOptions::stdout_only()
+            .early_exit_on_failure()
+            .inherit_stdin(),
     )
 }
 

--- a/tests/pipeline_stdin_test.rs
+++ b/tests/pipeline_stdin_test.rs
@@ -1,6 +1,7 @@
 #![cfg(unix)]
 
 use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
 use std::process::{Command, Output, Stdio};
 
 fn run_with_stdin(command: &mut Command, input: &[u8]) -> Output {
@@ -41,4 +42,62 @@ fn wc_preserves_native_failure_exit_code() {
 
     assert!(!rtk.status.success());
     assert_eq!(rtk.status.code(), native.status.code());
+}
+
+#[test]
+fn filtered_gh_pr_actions_preserve_piped_stdin() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let gh = temp.path().join("gh");
+    let capture = temp.path().join("stdin.txt");
+    std::fs::write(
+        &gh,
+        "#!/bin/sh\ncat > \"$RTK_STDIN_CAPTURE\"\nprintf 'https://github.com/example/repo/pull/42\\n'\n",
+    )
+    .expect("write fake gh");
+    let mut permissions = std::fs::metadata(&gh)
+        .expect("fake gh metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&gh, permissions).expect("make fake gh executable");
+    let path = format!(
+        "{}:{}",
+        temp.path().display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    let create = run_with_stdin(
+        Command::new(env!("CARGO_BIN_EXE_rtk"))
+            .env("PATH", &path)
+            .env("RTK_STDIN_CAPTURE", &capture)
+            .args(["gh", "pr", "create", "--body-file", "-"]),
+        b"body from stdin\n",
+    );
+
+    assert!(
+        create.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&create.stderr)
+    );
+    assert_eq!(
+        std::fs::read(&capture).expect("read captured create stdin"),
+        b"body from stdin\n"
+    );
+
+    let comment = run_with_stdin(
+        Command::new(env!("CARGO_BIN_EXE_rtk"))
+            .env("PATH", path)
+            .env("RTK_STDIN_CAPTURE", &capture)
+            .args(["gh", "pr", "comment", "42", "--body-file", "-"]),
+        b"comment from stdin\n",
+    );
+
+    assert!(
+        comment.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&comment.stderr)
+    );
+    assert_eq!(
+        std::fs::read(capture).expect("read captured comment stdin"),
+        b"comment from stdin\n"
+    );
 }


### PR DESCRIPTION
## Summary

- preserve piped stdin for filtered `gh pr create`, `comment`, and `edit` actions
- cover `--body-file -` with fake-`gh` integration tests for create and comment

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: the regression test failed before `.inherit_stdin()` and captures the exact input afterward

The generic passthrough and parse-fallback paths already inherit stdin. This only changes the filtered GitHub PR actions whose `RunOptions::stdout_only()` previously selected `StdinMode::Null`.
