### PR TITLE
fix(tracking): stop tests writing into the real history.db

### DIFF
--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -247,7 +247,7 @@ impl Tracker {
     /// # Ok::<(), anyhow::Error>(())
     /// ```
     pub fn new() -> Result<Self> {
-        let db_path = get_db_path()?;
+        let db_path = tracker_db_path()?;
         if let Some(parent) = db_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
@@ -1233,6 +1233,39 @@ fn get_db_path() -> Result<PathBuf> {
     // Priority 3: Default platform-specific location
     let data_dir = dirs::data_local_dir().unwrap_or_else(|| PathBuf::from("."));
     Ok(data_dir.join(RTK_DATA_DIR).join(HISTORY_DB))
+}
+
+/// Resolve the path the tracker actually opens.
+///
+/// Identical to [`get_db_path`] in a release build. Under `cfg(test)` it diverts
+/// to a per-process temp file unless `RTK_DB_PATH` is set explicitly.
+///
+/// This exists because `cargo test` — which CONTRIBUTING tells contributors to
+/// run — used to insert rows straight into the developer's real
+/// `<data-dir>/rtk/history.db`. Every write path funnels through
+/// `Tracker::new()`, so it is not only the handful of tests in this module that
+/// leak: any command test exercising the real code path via [`TimedExecution`]
+/// leaks too (`find`/`git`/`read` tests accounted for the majority of the rows
+/// observed in the wild). Fixing it here rather than per-test makes the whole
+/// class impossible instead of patching the instances.
+///
+/// Guarding at the *open* site keeps `get_db_path` a pure configuration
+/// resolver, so `test_db_path_env_and_default` still asserts real precedence
+/// rules rather than the test shim.
+fn tracker_db_path() -> Result<PathBuf> {
+    #[cfg(test)]
+    {
+        // An explicit RTK_DB_PATH still wins, so a test can point at a fixture
+        // on purpose (test_db_path_env_and_default relies on that precedence).
+        if std::env::var_os("RTK_DB_PATH").is_none() {
+            // Stable within the process: Tracker::new() is called many times per
+            // test binary and every call must land on the same database.
+            return Ok(
+                std::env::temp_dir().join(format!("rtk-test-history-{}.db", std::process::id()))
+            );
+        }
+    }
+    get_db_path()
 }
 
 /// Individual parse failure record.


### PR DESCRIPTION
## Problem

`cargo test` — which CONTRIBUTING instructs contributors to run — inserted rows into the developer's live `<data-dir>/rtk/history.db`. On one machine a single full run wrote **25 `commands` rows and 8 `parse_failures` rows**, which then show up in `rtk gain` output and in anything downstream that treats that database as real telemetry.

## Why the fix is at `tracker_db_path()` and not per-test

Every write path funnels through `Tracker::new()`, so the leak is not limited to the few tests in this module that construct a `Tracker` directly: command tests that exercise the real code path via `TimedExecution` leak too, and in practice those (`find`, `git`, `read`) accounted for the **majority** of the observed rows. Converting individual tests to `new_in_memory()` would have missed them — I counted 10 rows attributable to the direct-`Tracker` tests out of 25 total.

`tracker_db_path()` diverts to a per-process temp file under `cfg(test)`, so no present or future test can reach the real database regardless of which code path it exercises.

## Preserved behaviour

- An explicit `RTK_DB_PATH` still takes precedence.
- `get_db_path()` stays a pure configuration resolver, so `test_db_path_env_and_default` continues to assert the real precedence rules instead of the test shim.

## Verification

Full suite on `x86_64-pc-windows-msvc` leaves **zero** test rows in the real database and writes to `rtk-test-history-<pid>.db` in the temp dir instead. `cargo fmt --check` and `cargo clippy --all-targets` clean.
