### PR TITLE
fix(prisma): only match supported commands

### DIFF
--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -368,7 +368,7 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
-        pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?prisma",
+        pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?prisma\s+(generate|migrate|db push)",
         rtk_cmd: "rtk prisma",
         rewrite_prefixes: &[
             "npm exec prisma",


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

- To prevent rewrite of `npx prisma validate` (unsupported subcommand) to `rtk prisma validate` (which leads to `[rtk: No such file or directory (os error 2)]`)

## Test plan
<!-- How did you verify this works? -->

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
