### PR TITLE
ci: guard release/CD jobs to only run on the upstream repo, not forks

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,8 +20,9 @@ jobs:
 
   pre-release:
     if: >-
-      github.ref == 'refs/heads/develop'
-      || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/master')
+      github.repository_owner == 'rtk-ai'
+      && (github.ref == 'refs/heads/develop'
+      || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/master'))
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
@@ -98,7 +99,10 @@ jobs:
   # ═══════════════════════════════════════════════
 
   release-please:
-    if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    if: >-
+      github.repository_owner == 'rtk-ai'
+      && github.ref == 'refs/heads/master'
+      && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## What

Adds a `github.repository_owner == 'rtk-ai'` guard to the two root jobs in `cd.yml` (`pre-release` and `release-please`), so the release/CD pipeline only ever runs on this repo, not on forks.

## Why

Any push to `develop`/`master` on a fork currently triggers `cd.yml`, and the `pre-release` job fails immediately:

```
LATEST_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | grep -v '-' | head -1)
::error::No stable release tag found
```

Forking a repo doesn't copy tags, and a plain `git fetch`/`gh repo sync` on a fork doesn't pull them either — so any fork with commits of its own (even something as simple as adding an unrelated workflow file, which is how I hit this) permanently has zero `v*.*.*` tags and this job can never succeed there. The rest of the pipeline (`build-prerelease`, `release-please`, `build-release`, `update-latest-tag`) already cascades to `skipped` correctly once its `needs.*.outputs` are empty, so no other jobs needed a guard — just the two entry points.

This is a real annoyance for anyone forking rtk to contribute (red X / failure email on the very first push), not just a cosmetic issue.

## Testing

Verified directly on `mrnickson-hue/rtk`: before the guard, pushing to `develop` produced the failure above; after adding it, the same push resulted in `pre-release` reporting `skipped` instead of `failure`, with no change in behavior on pushes to the real `rtk-ai/rtk` (the guard only *adds* a condition that is already true there).