### PR TITLE
fix(search): stop MSYS children from eating backslashes in argv

### DIFF
--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -340,6 +340,54 @@ pub fn resolve_binary(name: &str) -> Result<PathBuf> {
 /// # Returns
 /// A `Command` configured with the resolved binary path.
 pub fn resolved_command(name: &str) -> Command {
+    let mut cmd = resolved_command_inner(name);
+    disable_msys_argv_globbing(&mut cmd);
+    cmd
+}
+
+/// Stop MSYS/Cygwin children from re-expanding argv (Windows only).
+///
+/// Git for Windows ships MSYS builds of `grep`, `find`, `wc`, … Those binaries
+/// re-parse the Windows command line at startup and run glob expansion over
+/// argv, which consumes the backslashes of anything that merely looks like a
+/// glob. A POSIX basic-regex pattern is the common casualty:
+///
+/// ```text
+///   rtk passes  \[energia\]           MSYS grep receives  [energia]
+///   rtk passes  in_waiting\|\.read(   MSYS grep receives  in_waiting|.read(
+/// ```
+///
+/// The first turns a literal-bracket search into a character class (matches
+/// nearly every line); the second turns a valid alternation into a literal that
+/// matches nothing — reported as a plain "no match" with exit 1, indistinguishable
+/// from a legitimate empty result. An agent that greps to decide whether a symbol
+/// exists reads that as proof of absence.
+///
+/// This never showed up in CI: the search/error faithfulness suites are gated
+/// `#![cfg(unix)]`, so the Windows job compiles them away and reports green.
+///
+/// rtk receives arguments already expanded by the caller's shell, so a second
+/// expansion inside the child is never wanted. `MSYS=noglob` disables exactly
+/// that step and leaves argv verbatim. Existing options in the variable are
+/// preserved — it is a space-separated list.
+fn disable_msys_argv_globbing(cmd: &mut Command) {
+    #[cfg(windows)]
+    {
+        const OPT: &str = "noglob";
+        let value = match std::env::var("MSYS") {
+            Ok(current) if current.split_whitespace().any(|o| o == OPT) => current,
+            Ok(current) if !current.trim().is_empty() => format!("{current} {OPT}"),
+            _ => OPT.to_string(),
+        };
+        cmd.env("MSYS", value);
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = cmd;
+    }
+}
+
+fn resolved_command_inner(name: &str) -> Command {
     match resolve_binary(name) {
         Ok(path) => Command::new(path),
         Err(e) => {

--- a/tests/search_argv_fidelity_test.rs
+++ b/tests/search_argv_fidelity_test.rs
@@ -1,0 +1,122 @@
+//! Argv fidelity: a pattern must reach the engine exactly as the agent typed it.
+//!
+//! Deliberately NOT `#![cfg(unix)]`. The failure this guards against is
+//! Windows-only: Git for Windows ships MSYS builds of `grep`, and an MSYS child
+//! re-parses the Windows command line and glob-expands argv, eating the
+//! backslashes of a POSIX basic-regex pattern. `\[x\]` arrives as `[x]` (a
+//! character class — matches almost every line) and `a\|\.b(` arrives as
+//! `a|.b(` (a literal — matches nothing, reported as exit 1 "no match").
+//!
+//! The silent direction is the dangerous one: an agent greps to decide whether
+//! a symbol exists, reads "no match", and concludes absence.
+//!
+//! Expectations are hardcoded from POSIX BRE semantics rather than taken from a
+//! live `grep` run. A spawned baseline is not usable here: the test harness is
+//! itself a native Windows process, so its own `grep` call is mangled the same
+//! way and would "confirm" whatever rtk did.
+
+use std::process::Command;
+
+const LINES: [&str; 6] = [
+    "alpha [energia] um",
+    "beta energia dois",
+    "gamma outro",
+    "delta in_waiting",
+    "call .read(x)",
+    "sem parenteses",
+];
+
+/// `(pattern, line numbers a POSIX BRE engine must report)`.
+const CASES: &[(&str, &[usize])] = &[
+    // No backslash: matches even when argv is mangled — the control.
+    ("energia", &[1, 2]),
+    // Bare character class: every line has one of e/n/r/g/i/a.
+    ("[energia]", &[1, 2, 3, 4, 5, 6]),
+    // Literal brackets. Mangled argv degrades this into the class above.
+    (r"\[energia\]", &[1]),
+    // BRE alternation.
+    (r"alpha\|gamma", &[1, 3]),
+    // In BRE a bare `|` is literal, so this must NOT match.
+    ("alpha|gamma", &[]),
+    // The silent false negative: `(` is literal in BRE, the alternation is real.
+    (r"in_waiting\|\.read(", &[4, 5]),
+    (r"\.read(", &[5]),
+    // A genuine no-match, so the shape of "found nothing" is covered too.
+    ("nao_existe_mesmo", &[]),
+];
+
+fn rtk(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .env("LC_ALL", "C")
+        .args(args)
+        .output()
+        .expect("rtk")
+}
+
+fn grep_available() -> bool {
+    Command::new("grep")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn fixture() -> (tempfile::TempDir, String) {
+    let d = tempfile::tempdir().expect("tempdir");
+    let p = d.path().join("t.txt");
+    std::fs::write(&p, format!("{}\n", LINES.join("\n"))).expect("write");
+    let s = p.to_str().unwrap().to_string();
+    (d, s)
+}
+
+fn expected_stdout(nums: &[usize]) -> String {
+    nums.iter()
+        .map(|n| format!("{n}:{}\n", LINES[n - 1]))
+        .collect()
+}
+
+#[test]
+fn escaped_bre_patterns_reach_the_engine_verbatim() {
+    if !grep_available() {
+        eprintln!("skipping: no `grep` on PATH");
+        return;
+    }
+    let (_d, file) = fixture();
+
+    for (pattern, nums) in CASES {
+        let out = rtk(&["grep", "-n", pattern, &file]);
+        assert_eq!(
+            String::from_utf8_lossy(&out.stdout),
+            expected_stdout(nums),
+            "wrong lines for pattern {pattern:?}"
+        );
+        assert_eq!(
+            out.status.code(),
+            Some(if nums.is_empty() { 1 } else { 0 }),
+            "exit code must follow grep's convention for pattern {pattern:?}"
+        );
+    }
+}
+
+/// The headline failure, asserted alone so a break names itself: the pattern
+/// matches two lines, and rtk must never produce the empty/exit-1 shape that an
+/// agent reads as "searched, found nothing".
+#[test]
+fn alternation_with_literal_paren_is_not_reported_as_no_match() {
+    if !grep_available() {
+        eprintln!("skipping: no `grep` on PATH");
+        return;
+    }
+    let (_d, file) = fixture();
+
+    let out = rtk(&["grep", "-n", r"in_waiting\|\.read(", &file]);
+    assert_ne!(
+        out.status.code(),
+        Some(1),
+        "exit 1 here reads as 'no match' for a pattern that matches two lines"
+    );
+    assert!(
+        !String::from_utf8_lossy(&out.stdout).trim().is_empty(),
+        "empty output for a matching pattern is a silent false negative"
+    );
+}


### PR DESCRIPTION
## Summary

- On Windows, a BRE pattern never reaches `grep` as typed: `rtk grep '\[x\]' f` returns the whole file, and `rtk grep 'in_waiting\|\.read(' f` reports **no match with exit 1** for a file that matches two lines.
- The cause is not in rtk's parsing. Git for Windows ships **MSYS** builds of `grep`/`find`/`wc`; an MSYS child re-parses the Windows command line at startup and **glob-expands argv**, and backslashes are the escape character in that pass, so they are consumed. Measured at the boundary (native process → MSYS `echo`):

  | passed | MSYS received |
  |---|---|
  | `\[energia\]` | `[energia]` |
  | `in_waiting\|\.read(` | `in_waiting\|.read(` |
  | `\.read(` | `.read(` |

  The first turns a literal-bracket search into a character class (matches nearly every line). The second turns a valid alternation into a literal that matches nothing — surfaced as exit 1 with empty output, **indistinguishable from a legitimate empty result**.
- Running the engine the user typed (#2641) does not help: the mangling happens **inside the child's own startup**, after a faithful spawn. Verified with an argv-dumping stub — the pattern leaves rtk intact (`argv[7] = <\[energia\]>`), the engine is invoked exactly once, and rtk renders faithfully what it gets back.
- Fix: `MSYS=noglob` on the single choke point where rtk resolves an external binary. rtk receives arguments already expanded by the caller's shell, so a second expansion inside the child is never wanted. Existing options in the variable are preserved (it is a space-separated list). `CYGWIN=noglob` was measured and does **not** work; `MSYS=noglob` does.

This is the silent direction of #1436, which is still open. An agent greps to decide whether a symbol exists, reads "no match", and concludes absence. It cost me a full misdiagnosis of an embedded firmware that was correct the whole time.

### Why CI never caught it

`cargo test --all` does run on `windows-latest`, but **6 of the 7 integration test files are gated `#![cfg(unix)]`** — including every search and error/exit faithfulness suite. On Windows they compile to nothing and the job reports green.

The new test is therefore deliberately **not** `cfg(unix)`. Its expectations are hardcoded from POSIX BRE semantics rather than taken from a live `grep` run: the test harness is itself a native Windows process, so its own baseline call would be mangled the same way and would confirm whatever rtk did. (I hit exactly that while writing it — the first version failed *with* the fix applied, because the baseline was the broken one.)

Un-gating the remaining `cfg(unix)` suites looks worthwhile but is a larger change; happy to open a follow-up if you want it.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo test --all` — **2511 passed, 0 failed** (Windows, `x86_64-pc-windows-gnu`)
- [x] New regression test proven in **both** directions: fails without the fix, passes with it
- [x] Manual: 9 patterns compared against real `grep` line-by-line **and** on exit code — 9/9 identical, including the two no-match cases

```
  ok  grep=2(e0) rtk=2(e0)  [energia]
  ok  grep=1(e0) rtk=1(e0)  [\[energia\]]
  ok  grep=6(e0) rtk=6(e0)  [[energia]]
  ok  grep=2(e0) rtk=2(e0)  [alpha\|gamma]
  ok  grep=0(e1) rtk=0(e1)  [alpha|gamma]
  ok  grep=2(e0) rtk=2(e0)  [in_waiting\|\.read(]
  ok  grep=2(e0) rtk=2(e0)  [in_waiting\|read(]
  ok  grep=1(e0) rtk=1(e0)  [\.read(]
  ok  grep=0(e1) rtk=0(e1)  [nao_existe_mesmo]
```

Note: building on `x86_64-pc-windows-gnu` currently requires the one-line `build.rs` fix I sent separately — that target does not link at all on `develop`.
