### PR TITLE
fix(build): use the GNU linker's stack flag on *-pc-windows-gnu

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,13 +3,28 @@ use std::fs;
 use std::path::Path;
 
 fn main() {
-    #[cfg(windows)]
-    {
-        // Clap + the full command graph can exceed the default 1 MiB Windows
-        // main-thread stack during process startup. Reserve a larger stack for
-        // the CLI binary so `rtk.exe --version`, `--help`, and hook entry
-        // points start reliably without requiring ad-hoc RUSTFLAGS.
-        println!("cargo:rustc-link-arg=/STACK:8388608");
+    // Clap + the full command graph can exceed the default 1 MiB Windows
+    // main-thread stack during process startup. Reserve a larger stack for
+    // the CLI binary so `rtk.exe --version`, `--help`, and hook entry
+    // points start reliably without requiring ad-hoc RUSTFLAGS.
+    //
+    // The spelling is linker-specific: MSVC's link.exe takes `/STACK:<bytes>`,
+    // while `*-pc-windows-gnu` links with GNU ld, which reads `/STACK:...` as a
+    // FILE PATH and aborts with `cannot find /STACK:8388608` — the crate does not
+    // link at all on that target.
+    //
+    // Gate on the TARGET, not the host: inside a build script `#[cfg(windows)]`
+    // describes the machine compiling build.rs, so it also fires when
+    // cross-compiling away from Windows and misses cross-compiling toward it.
+    // `CARGO_CFG_*` is the target-accurate source.
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    if target_os == "windows" {
+        if target_env == "msvc" {
+            println!("cargo:rustc-link-arg=/STACK:8388608");
+        } else {
+            println!("cargo:rustc-link-arg=-Wl,--stack,8388608");
+        }
     }
 
     let filters_dir = Path::new("src/filters");


### PR DESCRIPTION
## Summary

- `rtk` does not build at all on `x86_64-pc-windows-gnu`:

  ```
  error: linking with `x86_64-w64-mingw32-gcc` failed: exit code: 1
    = note: ld.exe: cannot find /STACK:8388608: No such file or directory
  ```

- `build.rs` emits `cargo:rustc-link-arg=/STACK:8388608`, which is **MSVC `link.exe` syntax**. GNU ld reads `/STACK:8388608` as a **file path** and aborts. CI only covers `windows-latest` (msvc), so the gnu target has been silently unbuildable.
- Emit `-Wl,--stack,8388608` there instead, keeping `/STACK:` for msvc so the original intent (a larger main-thread stack for clap's command graph) is preserved on both.
- Also switches the gate from `#[cfg(windows)]` to `CARGO_CFG_TARGET_OS`/`CARGO_CFG_TARGET_ENV`. Inside a build script `#[cfg(windows)]` describes the **host** compiling `build.rs`, not the target, so today it fires when cross-compiling *away* from Windows and misses cross-compiling *toward* it.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo test --all` on `x86_64-pc-windows-gnu` — **2511 passed, 0 failed** (this target could not produce a binary before this change)
- [x] Manual: `rtk --version`, `rtk grep`, `rtk find`, `rtk git status` all start and run — the larger stack is still applied, just spelled for the right linker
