### PR TITLE
fix(hook): enable copilot file access by completing hook command with agent name

### DIFF
--- a/.github/hooks/rtk-rewrite.json
+++ b/.github/hooks/rtk-rewrite.json
@@ -3,7 +3,7 @@
     "PreToolUse": [
       {
         "type": "command",
-        "command": "rtk hook",
+        "command": "rtk hook copilot",
         "cwd": ".",
         "timeout": 5
       }


### PR DESCRIPTION
## Summary
- GitHub Copilot was unable to access files in the repo due to incomplete hook command
- Fix: Extend `.github/hooks/rtk-rewrite.json` command from `"rtk hook"` to `"rtk hook copilot"`

## Test plan
- [x] `cargo fmt --all --check && cargo clippy --all-targets && cargo test` — all passed (2565 tests)
- [x] Verified hook integration with Copilot (see screenshot below)
- [x] File validated as valid JSON: `jq empty .github/hooks/rtk-rewrite.json` passed

## Evidence
Before the fix:
<img width="1100" height="243" alt="Screenshot 2026-07-27 at 15 47 05" src="https://github.com/user-attachments/assets/026892fb-62a9-4ce8-ada8-198b562ba007" />

After the fix:
<img width="1100" height="657" alt="Screenshot 2026-07-27 at 15 48 43" src="https://github.com/user-attachments/assets/d7835a9d-a5cb-4b98-ac9a-698028a96d6e" />