### PR TITLE
fix(hook): preserve command bypass prefix

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -826,7 +826,7 @@ const ROUTABLE_WRAPPER_PREFIXES: &[&str] = &["uv run"];
 
 /// Shell keywords that wrap a command without changing which one runs. They are
 /// not spawnable, so they must never fall through: `rtk exec foo` cannot run.
-const SHELL_KEYWORD_PREFIXES: &[&str] = &["noglob", "command", "builtin", "exec", "nocorrect"];
+const SHELL_KEYWORD_PREFIXES: &[&str] = &["noglob", "builtin", "exec", "nocorrect"];
 
 /// Every built-in transparent wrapper, paired with whether it may fall through.
 /// Derived from the two lists above so they cannot drift apart.
@@ -4391,11 +4391,14 @@ mod tests {
     }
 
     #[test]
-    fn test_shell_prefix_command() {
-        assert_eq!(
-            rewrite_command_no_prefixes("command git status", &[]),
-            Some("command rtk git status".into())
-        );
+    fn test_shell_prefix_command_bypasses_rewrite() {
+        for command in [
+            "command git status",
+            "command grep -rn X a",
+            "command find . -print0 | xargs -0 tool",
+        ] {
+            assert_eq!(rewrite_command_no_prefixes(command, &[]), None);
+        }
     }
 
     #[test]
@@ -4679,7 +4682,7 @@ mod tests {
     fn test_rewrite_pipeline_final_normalizes_prefixes() {
         assert_eq!(
             rewrite_command_no_prefixes("cargo test | FOO=1 command grep FAILED", &[]),
-            Some("cargo test | FOO=1 command rtk grep FAILED".into())
+            None
         );
         assert_eq!(
             super::rewrite_command(


### PR DESCRIPTION
Fixes #3230

## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

- Leaves commands prefixed with the POSIX `command` bypass untouched by hook rewriting.
- Adds regression coverage for direct commands, pipelines, and environment-prefixed pipeline stages.

## Test plan
<!-- How did you verify this works? -->

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `target/debug/rtk rewrite 'command git status'` produced no rewrite, while the `git status` control rewrote to `rtk git status`.

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
