### PR TITLE
fix(windows): preserve exact hook command behavior

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -125,10 +125,15 @@ fn run_diff(
         .iter()
         .any(|arg| arg == "--stat" || arg == "--numstat" || arg == "--shortstat");
 
+    // These flags use exit code 1 to report a non-empty diff. Running RTK's
+    // preliminary --stat command and treating that code as an error used to
+    // discard the diff output entirely.
+    let wants_exit_semantics = diff_requires_exact_exit(args);
+
     // Check if user wants compact diff (default RTK behavior)
     let wants_compact = !args.iter().any(|arg| arg == "--no-compact");
 
-    if wants_stat || !wants_compact {
+    if wants_stat || wants_exit_semantics || !wants_compact {
         // User wants stat or explicitly no compacting - pass through directly
         let mut cmd = git_cmd(global_args);
         cmd.arg("diff");
@@ -141,12 +146,12 @@ fn run_diff(
 
         let result = exec_capture(&mut cmd).context("Failed to run git diff")?;
 
-        if !result.success() {
-            eprintln!("{}", result.stderr);
-            return Ok(result.exit_code);
+        if !result.stdout.is_empty() {
+            print!("{}", result.stdout);
         }
-
-        println!("{}", result.stdout.trim());
+        if !result.stderr.is_empty() {
+            eprint!("{}", result.stderr);
+        }
 
         timer.track(
             &format!("git diff {}", args.join(" ")),
@@ -155,7 +160,7 @@ fn run_diff(
             &result.stdout,
         );
 
-        return Ok(0);
+        return Ok(result.exit_code);
     }
 
     // Default RTK behavior: stat first, then compacted diff
@@ -213,6 +218,11 @@ fn run_diff(
     );
 
     Ok(0)
+}
+
+fn diff_requires_exact_exit(args: &[String]) -> bool {
+    args.iter()
+        .any(|arg| arg == "--exit-code" || arg == "--quiet" || arg == "-q")
 }
 
 fn run_show(
@@ -448,6 +458,28 @@ fn run_log(
             || arg.starts_with("--max-count")
     });
 
+    // An explicit format or an unbounded history selector expresses exact
+    // caller intent. Preserve both the full history and the exact formatting.
+    if log_requires_passthrough(args, has_format_flag, has_limit_flag) {
+        for arg in args {
+            cmd.arg(arg);
+        }
+        let result = exec_capture(&mut cmd).context("Failed to run git log")?;
+        if !result.stdout.is_empty() {
+            print!("{}", result.stdout);
+        }
+        if !result.stderr.is_empty() {
+            eprint!("{}", result.stderr);
+        }
+        timer.track(
+            &format!("git log {}", args.join(" ")),
+            &format!("rtk git log {} (passthrough)", args.join(" ")),
+            &result.stdout,
+            &result.stdout,
+        );
+        return Ok(result.exit_code);
+    }
+
     // Apply RTK defaults only if user didn't specify them
     // Use %b (body) to preserve first line of commit body for agent context
     // (BREAKING CHANGE, Closes #xxx, design notes)
@@ -460,10 +492,6 @@ fn run_log(
         // User explicitly passed -N / -n N / --max-count=N → respect their choice
         let n = parse_user_limit(args).unwrap_or(10);
         (n, true)
-    } else if has_format_flag {
-        // --oneline / --pretty without -N: user wants compact output, allow more
-        cmd.arg("-50");
-        (50, false)
     } else {
         // No flags at all: default to 10
         cmd.arg("-10");
@@ -508,6 +536,14 @@ fn run_log(
     );
 
     Ok(0)
+}
+
+fn log_requires_passthrough(
+    args: &[String],
+    has_format_flag: bool,
+    has_limit_flag: bool,
+) -> bool {
+    has_format_flag || (!args.is_empty() && !has_limit_flag)
 }
 
 /// Filter git log output: truncate long messages, cap lines
@@ -2940,6 +2976,32 @@ no changes added to commit (use "git add" and/or "git commit -a")
         // user_set_limit=false means cap at limit
         let result = filter_log_output(oneline_output, 3, false, true);
         assert_eq!(result.lines().count(), 3);
+    }
+
+    #[test]
+    fn test_diff_exit_semantics_force_passthrough() {
+        assert!(diff_requires_exact_exit(&["--exit-code".to_string()]));
+        assert!(diff_requires_exact_exit(&["--quiet".to_string()]));
+        assert!(diff_requires_exact_exit(&["-q".to_string()]));
+        assert!(!diff_requires_exact_exit(&["--stat".to_string()]));
+    }
+
+    #[test]
+    fn test_log_explicit_format_forces_passthrough() {
+        let args = vec!["--format=%H".to_string()];
+        assert!(log_requires_passthrough(&args, true, false));
+    }
+
+    #[test]
+    fn test_log_unbounded_query_forces_passthrough() {
+        let args = vec!["--all".to_string()];
+        assert!(log_requires_passthrough(&args, false, false));
+    }
+
+    #[test]
+    fn test_log_explicit_limit_keeps_compact_path() {
+        let args = vec!["-20".to_string()];
+        assert!(!log_requires_passthrough(&args, false, true));
     }
 
     /// Regression test: `git branch <name>` must create, not list.

--- a/src/cmds/system/search.rs
+++ b/src/cmds/system/search.rs
@@ -283,11 +283,12 @@ impl Engine {
         self.bin()
     }
 
-    /// `-n -H --null` are parse aids (NUL keeps the regroup unambiguous, #1436);
-    /// `-I` skips binary noise (-a overrides).
+    /// `-n -H -Z` are broadly supported parse aids. NUL keeps regrouping
+    /// unambiguous (#1436); do not inject GNU-only `-I`/`--null` because Windows
+    /// grep replacements may reject them.
     fn parse_flags(self) -> &'static [&'static str] {
         match self {
-            Engine::Grep => &["-n", "-H", "-I", "--null"],
+            Engine::Grep => &["-n", "-H", "-Z"],
             Engine::Rg => &["-n", "--with-filename", "--null"],
         }
     }
@@ -317,12 +318,16 @@ fn engine_command<T: AsRef<str>>(
     for a in extra_args {
         cmd.arg(a.as_ref());
     }
-    if line_buffered {
+    if line_buffered && matches!(engine, Engine::Rg) {
         // The engine writes through a pipe, so flush each match immediately.
         cmd.arg("--line-buffered");
     }
-    for p in patterns {
-        cmd.args(["-e", p]);
+    if patterns.len() == 1 {
+        cmd.arg(&patterns[0]);
+    } else {
+        for p in patterns {
+            cmd.args(["-e", p]);
+        }
     }
     cmd.arg("--");
     cmd.args(paths);
@@ -444,7 +449,7 @@ fn passthrough<T: AsRef<str>>(
     stream_stdin: bool,
 ) -> Result<i32> {
     let mut cmd = resolved_command(engine.bin());
-    if stream_stdin && !std::io::stdout().is_terminal() {
+    if stream_stdin && !std::io::stdout().is_terminal() && matches!(engine, Engine::Rg) {
         // Keep passthrough output live when stdout is piped.
         cmd.arg("--line-buffered");
     }
@@ -544,6 +549,12 @@ pub fn run(
 
     // format/shape flags (-c/-l/-o/...): already-minimal native output, passthrough.
     if has_format_flag(&extra_args) {
+        return passthrough(&timer, engine, &args, &real_cmd, reads_piped_stdin);
+    }
+
+    // Multiple grep patterns require `-e`, which is not implemented by every
+    // Windows grep replacement. Preserve the user's exact engine invocation.
+    if matches!(engine, Engine::Grep) && patterns.len() > 1 {
         return passthrough(&timer, engine, &args, &real_cmd, reads_piped_stdin);
     }
 

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -183,6 +183,10 @@ impl Config {
 }
 
 fn get_config_path() -> Result<PathBuf> {
+    if let Some(config_dir) = std::env::var_os("RTK_CONFIG_DIR") {
+        return Ok(PathBuf::from(config_dir).join(CONFIG_TOML));
+    }
+
     let config_dir = dirs::config_dir().unwrap_or_else(|| PathBuf::from("."));
     Ok(config_dir.join(RTK_DATA_DIR).join(CONFIG_TOML))
 }

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -557,6 +557,18 @@ pub(crate) mod tests {
     use super::*;
     use std::process::Command;
 
+    fn shell_command(posix_script: &str, windows_script: &str) -> Command {
+        if cfg!(windows) {
+            let mut command = Command::new("cmd.exe");
+            command.args(["/d", "/c", windows_script]);
+            command
+        } else {
+            let mut command = Command::new("sh");
+            command.args(["-c", posix_script]);
+            command
+        }
+    }
+
     struct LineFilter<F: FnMut(&str) -> Option<String>> {
         f: F,
     }
@@ -671,9 +683,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_run_streaming_exit_code_preserved() {
-        // nosemgrep: interpreter-execution
-        let mut cmd = Command::new("sh");
-        cmd.args(["-c", "exit 42"]);
+        let mut cmd = shell_command("exit 42", "exit 42");
         let result = run_streaming(&mut cmd, StdinMode::Null, FilterMode::Passthrough).unwrap();
         assert_eq!(result.exit_code, 42);
     }
@@ -734,6 +744,7 @@ pub(crate) mod tests {
         assert_eq!(result.exit_code, 0);
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn test_run_streaming_raw_cap_at_10mb() {
         // nosemgrep: interpreter-execution
@@ -755,6 +766,7 @@ pub(crate) mod tests {
         );
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn test_run_streaming_stderr_cap_at_10mb() {
         // nosemgrep: interpreter-execution
@@ -824,18 +836,17 @@ pub(crate) mod tests {
 
     #[test]
     fn test_exec_capture_stderr() {
-        // nosemgrep: interpreter-execution
-        let mut cmd = Command::new("sh");
-        cmd.args(["-c", "echo err_msg >&2"]);
+        let mut cmd = shell_command("echo err_msg >&2", "echo err_msg 1>&2");
         let result = exec_capture(&mut cmd).unwrap();
         assert!(result.stderr.contains("err_msg"));
     }
 
     #[test]
     fn test_exec_capture_combined() {
-        // nosemgrep: interpreter-execution
-        let mut cmd = Command::new("sh");
-        cmd.args(["-c", "echo out_msg; echo err_msg >&2"]);
+        let mut cmd = shell_command(
+            "echo out_msg; echo err_msg >&2",
+            "echo out_msg & echo err_msg 1>&2",
+        );
         let result = exec_capture(&mut cmd).unwrap();
         let combined = result.combined();
         assert!(combined.contains("out_msg"));

--- a/src/hooks/audit_log.rs
+++ b/src/hooks/audit_log.rs
@@ -1,0 +1,79 @@
+//! Resolves the hook audit log consistently across platforms.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+const AUDIT_DIR_ENV: &str = "RTK_AUDIT_DIR";
+const AUDIT_LOG_FILE: &str = "hook-audit.log";
+
+fn audit_dir_from(
+    override_dir: Option<OsString>,
+    home_dir: Option<PathBuf>,
+    temp_dir: PathBuf,
+) -> PathBuf {
+    if let Some(dir) = override_dir.filter(|value| !value.is_empty()) {
+        return PathBuf::from(dir);
+    }
+
+    home_dir
+        .unwrap_or(temp_dir)
+        .join(".local")
+        .join("share")
+        .join("rtk")
+}
+
+/// Returns the configured hook audit log path.
+pub(crate) fn path() -> PathBuf {
+    audit_dir_from(
+        std::env::var_os(AUDIT_DIR_ENV),
+        dirs::home_dir(),
+        std::env::temp_dir(),
+    )
+    .join(AUDIT_LOG_FILE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn override_directory_wins() {
+        let dir = audit_dir_from(
+            Some(OsString::from("C:\\rtk-audit")),
+            Some(PathBuf::from("C:\\Users\\tester")),
+            PathBuf::from("C:\\Temp"),
+        );
+
+        assert_eq!(dir, PathBuf::from("C:\\rtk-audit"));
+    }
+
+    #[test]
+    fn home_directory_is_cross_platform_default() {
+        let dir = audit_dir_from(
+            None,
+            Some(PathBuf::from("C:\\Users\\tester")),
+            PathBuf::from("C:\\Temp"),
+        );
+
+        assert_eq!(
+            dir,
+            PathBuf::from("C:\\Users\\tester")
+                .join(".local")
+                .join("share")
+                .join("rtk")
+        );
+    }
+
+    #[test]
+    fn temp_directory_is_last_resort() {
+        let dir = audit_dir_from(None, None, PathBuf::from("C:\\Temp"));
+
+        assert_eq!(
+            dir,
+            PathBuf::from("C:\\Temp")
+                .join(".local")
+                .join("share")
+                .join("rtk")
+        );
+    }
+}

--- a/src/hooks/hook_audit_cmd.rs
+++ b/src/hooks/hook_audit_cmd.rs
@@ -2,19 +2,6 @@
 
 use anyhow::{Context, Result};
 use std::collections::HashMap;
-use std::path::PathBuf;
-
-/// Default log file location (aligned with hook's $HOME/.local/share/rtk/).
-fn default_log_path() -> PathBuf {
-    if let Ok(dir) = std::env::var("RTK_AUDIT_DIR") {
-        PathBuf::from(dir).join("hook-audit.log")
-    } else {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-        PathBuf::from(home)
-            .join(".local/share/rtk")
-            .join("hook-audit.log")
-    }
-}
 
 /// A single parsed audit log entry.
 struct AuditEntry {
@@ -69,7 +56,7 @@ fn filter_since_days(entries: &[AuditEntry], days: u64) -> Vec<&AuditEntry> {
 }
 
 pub fn run(since_days: u64, verbose: u8) -> Result<()> {
-    let log_path = default_log_path();
+    let log_path = super::audit_log::path();
 
     if !log_path.exists() {
         println!("No audit log found at {}", log_path.display());

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -351,10 +351,9 @@ fn sanitize_log_field(s: &str) -> String {
 }
 
 fn audit_log_inner(action: &str, original: &str, rewritten: &str) -> Option<()> {
-    let home = dirs::home_dir()?;
-    let dir = home.join(".local").join("share").join("rtk");
-    std::fs::create_dir_all(&dir).ok()?;
-    let path = dir.join("hook-audit.log");
+    let path = super::audit_log::path();
+    let dir = path.parent()?;
+    std::fs::create_dir_all(dir).ok()?;
     let mut file = std::fs::OpenOptions::new()
         .create(true)
         .append(true)

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1,5 +1,6 @@
 //! Hook installation and lifecycle management for AI coding agents.
 
+mod audit_log;
 pub mod constants;
 pub mod hook_audit_cmd;
 pub mod hook_check;

--- a/src/hooks/rewrite_cmd.rs
+++ b/src/hooks/rewrite_cmd.rs
@@ -45,8 +45,15 @@ enum RewriteOutcome {
 }
 
 fn evaluate(cmd: &str, excluded: &[String], transparent_prefixes: &[String]) -> RewriteOutcome {
-    let verdict = check_command(cmd);
+    evaluate_with_verdict(cmd, excluded, transparent_prefixes, check_command(cmd))
+}
 
+fn evaluate_with_verdict(
+    cmd: &str,
+    excluded: &[String],
+    transparent_prefixes: &[String],
+    verdict: PermissionVerdict,
+) -> RewriteOutcome {
     if verdict == PermissionVerdict::Deny {
         return RewriteOutcome::Deny;
     }
@@ -91,12 +98,16 @@ mod tests {
     }
 
     mod unattestable_passthrough {
-        use super::super::{evaluate, RewriteOutcome};
+        use super::super::{evaluate_with_verdict, PermissionVerdict, RewriteOutcome};
+
+        fn evaluate(cmd: &str) -> RewriteOutcome {
+            evaluate_with_verdict(cmd, &[], &[], PermissionVerdict::Default)
+        }
 
         #[test]
         fn test_backtick_substitution_passthrough() {
             assert_eq!(
-                evaluate("git status `rm -rf /tmp/x`", &[], &[]),
+                evaluate("git status `rm -rf /tmp/x`"),
                 RewriteOutcome::Passthrough
             );
         }
@@ -104,7 +115,7 @@ mod tests {
         #[test]
         fn test_dollar_substitution_passthrough() {
             assert_eq!(
-                evaluate("git status $(rm -rf /tmp/x)", &[], &[]),
+                evaluate("git status $(rm -rf /tmp/x)"),
                 RewriteOutcome::Passthrough
             );
         }
@@ -112,7 +123,7 @@ mod tests {
         #[test]
         fn test_double_quoted_substitution_passthrough() {
             assert_eq!(
-                evaluate("git log --pretty=\"$(rm -rf /tmp/x)\"", &[], &[]),
+                evaluate("git log --pretty=\"$(rm -rf /tmp/x)\""),
                 RewriteOutcome::Passthrough
             );
         }
@@ -120,7 +131,7 @@ mod tests {
         #[test]
         fn test_file_redirect_passthrough() {
             assert_eq!(
-                evaluate("git log > /tmp/out.txt", &[], &[]),
+                evaluate("git log > /tmp/out.txt"),
                 RewriteOutcome::Passthrough
             );
         }
@@ -128,17 +139,14 @@ mod tests {
         #[test]
         fn test_fd_dup_redirect_still_rewrites() {
             assert!(matches!(
-                evaluate("git status 2>&1", &[], &[]),
+                evaluate("git status 2>&1"),
                 RewriteOutcome::Ask(_)
             ));
         }
 
         #[test]
         fn test_plain_command_still_rewrites() {
-            assert!(matches!(
-                evaluate("git status", &[], &[]),
-                RewriteOutcome::Ask(_)
-            ));
+            assert!(matches!(evaluate("git status"), RewriteOutcome::Ask(_)));
         }
     }
 

--- a/tests/guard_integration_test.rs
+++ b/tests/guard_integration_test.rs
@@ -130,12 +130,17 @@ fn grep_no_match_emits_empty_not_a_message() {
     std::fs::write(dir.path().join("a.txt"), "hello world\n").expect("write");
     // Faithful grep needs -r to descend a directory; we no longer force recursion
     // by routing through rg (the engine-faithful contract).
-    let (out, code) = rtk_in_dir(dir.path(), &["grep", "-r", "zzz_no_match_xyz", "."]);
+    let (out, stderr, code) =
+        rtk_output_in_dir(dir.path(), &["grep", "-r", "zzz_no_match_xyz", "."]);
     assert!(
         out.trim().is_empty(),
         "no-match grep must emit empty, not a '0 matches' line: {out:?}"
     );
-    assert_eq!(code, Some(1), "grep no-match must preserve exit 1");
+    assert_eq!(
+        code,
+        Some(1),
+        "grep no-match must preserve exit 1; stderr: {stderr}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Prevents silent output and argument mangling for exact git diff/log queries, makes hook audit paths configurable on Windows, isolates config-sensitive tests, and improves grep compatibility. Validated with cargo fmt, cargo clippy -D warnings, 2,504 unit tests, and 11 integration tests.