### PR TITLE
fix(cicd): git app token for next release

### DIFF
--- a/.github/workflows/next-release.yml
+++ b/.github/workflows/next-release.yml
@@ -5,18 +5,24 @@ on:
     types: [closed]
     branches: [develop]
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 jobs:
   update-next-release:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        id: app-token
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: read
+          permission-pull-requests: write
+
       - name: Update Next Release PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary

cicd was crashing because token not valid anymore since git enterprise
use github app token like others ci