### PR TITLE
fix(ci): skip CD pipeline entry jobs on forks

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,9 +19,11 @@ jobs:
   # ═══════════════════════════════════════════════
 
   pre-release:
+    # Forks don't inherit tags; skip CD on non-canonical repos (see #3237)
     if: >-
-      github.ref == 'refs/heads/develop'
-      || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/master')
+      github.repository_owner == 'rtk-ai'
+      && (github.ref == 'refs/heads/develop'
+      || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/master'))
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
@@ -98,7 +100,11 @@ jobs:
   # ═══════════════════════════════════════════════
 
   release-please:
-    if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    # Forks don't inherit tags/secrets; skip CD on non-canonical repos (see #3237)
+    if: >-
+      github.repository_owner == 'rtk-ai'
+      && github.ref == 'refs/heads/master'
+      && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## Summary

- Guard `pre-release` and `release-please` in `cd.yml` with `github.repository_owner == ''rtk-ai''` so the CD/release pipeline only runs on the canonical repo.
- Forks do not inherit release tags, so the pre-release version step always fails with `No stable release tag found` on any develop/master push. Downstream jobs already skip when entry outputs are empty; only these two entry points were failing.

Fixes #3237

## Test plan

- [x] Verify YAML conditions: both entry jobs require `github.repository_owner == ''rtk-ai''` in addition to existing branch/event gates
- [ ] On a fork push to `develop`: CD workflow runs but `pre-release` is **skipped** (no red X)
- [ ] On `rtk-ai/rtk` push to `develop`: `pre-release` still runs as before
- [ ] On `rtk-ai/rtk` push to `master`: `release-please` still runs as before