### PR TITLE
refactor: simplify regex initialization

### DIFF
--- a/src/cmds/rust/cargo_cmd.rs
+++ b/src/cmds/rust/cargo_cmd.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::ffi::OsString;
-use std::sync::OnceLock;
+use std::sync::LazyLock;
 
 #[derive(Debug, Clone)]
 pub enum CargoCommand {
@@ -620,18 +620,12 @@ fn flush_failure_block(header: &mut String, body: &mut Vec<String>, failures: &m
 
 /// Filter cargo nextest output - show failures + compact summary
 fn filter_cargo_nextest(output: &str) -> String {
-    static SUMMARY_RE: OnceLock<regex::Regex> = OnceLock::new();
-    let summary_re = SUMMARY_RE.get_or_init(|| {
-        regex::Regex::new(
-            r"Summary \[\s*([\d.]+)s\]\s+(\d+) tests? run:\s+(\d+) passed(?:,\s+(\d+) failed)?(?:,\s+(\d+) skipped)?"
-        ).expect("invalid nextest summary regex")
-    });
+    let summary_re = regex::Regex::new(
+        r"Summary \[\s*([\d.]+)s\]\s+(\d+) tests? run:\s+(\d+) passed(?:,\s+(\d+) failed)?(?:,\s+(\d+) skipped)?"
+    ).expect("invalid nextest summary regex");
 
-    static STARTING_RE: OnceLock<regex::Regex> = OnceLock::new();
-    let starting_re = STARTING_RE.get_or_init(|| {
-        regex::Regex::new(r"Starting \d+ tests? across (\d+) binar(?:y|ies)")
-            .expect("invalid nextest starting regex")
-    });
+    let starting_re = regex::Regex::new(r"Starting \d+ tests? across (\d+) binar(?:y|ies)")
+        .expect("invalid nextest starting regex");
 
     let mut failures: Vec<String> = Vec::new();
     let mut in_failure_block = false;
@@ -1041,14 +1035,13 @@ impl AggregatedTestResult {
     /// Parse a test result summary line
     /// Format: "test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s"
     fn parse_line(line: &str) -> Option<Self> {
-        static RE: OnceLock<regex::Regex> = OnceLock::new();
-        let re = RE.get_or_init(|| {
+        static RE: LazyLock<regex::Regex> = LazyLock::new(|| {
             regex::Regex::new(
                 r"test result: (\w+)\.\s+(\d+) passed;\s+(\d+) failed;\s+(\d+) ignored;\s+(\d+) measured;\s+(\d+) filtered out(?:;\s+finished in ([\d.]+)s)?"
             ).unwrap()
         });
 
-        let caps = re.captures(line)?;
+        let caps = RE.captures(line)?;
         let status = caps.get(1)?.as_str();
 
         // Only aggregate if status is "ok" (all tests passed)


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

This is a follow-up to #3244.

- Replace the fixed `OnceLock<Regex>` in `AggregatedTestResult::parse_line()` with `LazyLock<Regex>`, allowing repeated calls to reuse one compiled regex.
- Replace the two function-local static regex caches in `filter_cargo_nextest()` with ordinary local regexes.

## Test plan
<!-- How did you verify this works? -->

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
