### PR TITLE
fix(grep): free -m for GNU --max-count instead of rtk --max

### DIFF
--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -216,7 +216,7 @@ rtk grep <pattern> [chemin] [options]
 | Option | Court | Defaut | Description |
 |--------|-------|--------|-------------|
 | `--max-len` | `-l` | 80 | Longueur maximale de ligne |
-| `--max` | `-m` | 50 | Nombre maximum de resultats |
+| `--max` |  | 200 | Nombre maximum de resultats (pas de raccourci, `-m` est reserve a `grep --max-count`) |
 | `--context-only` |  | non | Afficher uniquement le contexte du match (pas de raccourci, `-c` est reserve a `grep --count`) |
 | `--file-type` | `-t` | tous | Filtrer par type (ts, py, rust, etc.) |
 | `--line-numbers` | `-n` | oui | Numeros de ligne (toujours actif) |

--- a/src/main.rs
+++ b/src/main.rs
@@ -315,7 +315,13 @@ enum Commands {
         #[arg(short = 'l', long, default_value = "80")]
         max_len: usize,
         /// Max results to show
-        #[arg(short, long, default_value = "200")]
+        // No short: `-m` is GNU grep's --max-count (stop after N matches per
+        // file). Deriving it to RTK's --max (a display cap) silently swallowed
+        // `-m N` so grep never saw the real --max-count. Without the short, `-m`
+        // flows to extra_args and is forwarded verbatim to grep/rg, which applies
+        // genuine --max-count while RTK still compacts (matches how `rtk rg -m`
+        // already behaves). --max keeps its long form.
+        #[arg(long, default_value = "200")]
         max: usize,
         /// Show only match context (not full line)
         #[arg(long)]
@@ -2953,6 +2959,24 @@ mod tests {
                 command: OcCommands::Other(_),
             } => {}
             _ => panic!("Expected Oc Other command"),
+        }
+    }
+
+    #[test]
+    fn test_try_parse_grep_dash_m_is_max_count() {
+        // Regression: `-m` is GNU grep's --max-count, not RTK's --max. It must
+        // parse (not consume the pattern), keep `max` at its default, and reach
+        // extra_args so it is forwarded to grep as a real --max-count.
+        let cli = Cli::try_parse_from(["rtk", "grep", "-m", "5", "pattern", "file"]).unwrap();
+
+        match cli.command {
+            Commands::Grep {
+                max, extra_args, ..
+            } => {
+                assert_eq!(max, 200, "max must stay at its default, not consume `-m`");
+                assert_eq!(extra_args, vec!["-m", "5", "pattern", "file"]);
+            }
+            _ => panic!("Expected Grep command"),
         }
     }
 

--- a/tests/grep_faithful_format_test.rs
+++ b/tests/grep_faithful_format_test.rs
@@ -184,3 +184,28 @@ fn piped_stdin_matches_grep() {
         assert_eq!(rtk, grep, "piped stdin mismatch for {args:?}");
     }
 }
+
+// Regression: `-m` is GNU grep's --max-count (stop after N matches), not RTK's
+// --max display cap. RTK must forward `-m N` to grep so the scan actually stops
+// at N — i.e. `rtk grep -m N` equals `grep -m N` (checked with and without -n).
+// Covers `-m` leading and trailing. With the short bound to --max, `-m` was
+// swallowed and never reached grep, so the output diverged.
+#[test]
+fn dash_m_max_count_matches_grep_n() {
+    let d = tempfile::tempdir().unwrap();
+    let f = write(d.path(), "m.txt", "hit1\nhit2\nhit3\nhit4\nhit5\n");
+    assert_eq_grep_with_and_without_n(&["-m", "2", "hit", &f]); // -m leading
+    assert_eq_grep_with_and_without_n(&["hit", &f, "-m", "3"]); // -m trailing
+    assert_eq_grep_with_and_without_n(&["-m", "9", "hit", &f]); // N >= total: no truncation, all 5
+}
+
+// `--max-count` is per file, so the multi-file case is the one that motivates the
+// fix: each file must be independently capped and the grouped output must still
+// equal `grep -m N` (with and without -n).
+#[test]
+fn dash_m_max_count_is_per_file_like_grep_n() {
+    let d = tempfile::tempdir().unwrap();
+    let f1 = write(d.path(), "a.txt", "hit\nhit\nhit\n");
+    let f2 = write(d.path(), "b.txt", "hit\nhit\nhit\n");
+    assert_eq_grep_with_and_without_n(&["-m", "2", "hit", &f1, &f2]); // 2 per file, both files
+}


### PR DESCRIPTION
## Summary

- `rtk grep`'s `-m` short (derived from `--max`, a display cap) collided with GNU grep where **`-m N` = `--max-count`** (stop after N matches per file). `rtk grep -m N <pat>` set RTK's display cap instead of forwarding `--max-count`, so grep never actually stopped early — a silent semantic mismatch (no parse error).
- Fix: drop the short. `-m` now flows to `extra_args` and is forwarded verbatim to the real `grep`/`rg` (it's not in `has_format_flag`, so it takes the normal engine path, not passthrough), which applies genuine `--max-count` while RTK still compacts. This makes `Grep` consistent with `Rg`, which never had the short and already forwarded `-m` correctly. `--max` keeps its long form and `default_value = "200"`.
- Docs: drop the `-m` short from the grep options table and correct its stale default (`50` → `200`, matching the code).

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test` — fmt clean, clippy 0 warnings, **2502 passed / 0 failed**.
- [x] New tests:
  - `test_try_parse_grep_dash_m_is_max_count` — clap parses `grep -m 5 <pat> <file>`, keeps `max` at 200, puts `-m 5` in `extra_args`.
  - `dash_m_max_count_matches_grep_n` — end-to-end: `rtk grep -m N` is byte-identical to `grep -n -m N` (`-m` leading, trailing, and N ≥ total).
  - `dash_m_max_count_is_per_file_like_grep_n` — multi-file, since `--max-count` is per file.
- [x] Manual: before the fix `rtk grep -m 2 . <file>` showed every line (`-m` swallowed); after, it stops at 2 like `grep -m 2`.

> Same class of GNU short-flag collision as the `-l` fix in #3258 (submitted separately per the single-focus PR rule). A related `-t` short (`--file-type`) also shadows ripgrep's `-t`/`--type`; left out of scope here and worth a follow-up.
