### PR TITLE
fix(git-diff): emit hunk lines at column 0 so `^-` anchors again

### DIFF
--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -332,17 +332,72 @@ rtk git diff [args...]    # Supporte --stat, --cached, --staged, etc.
 ```
 
 **Avant / Apres :**
+
+`git diff` brut, 21 lignes :
 ```
-# git diff (~100 lignes)                    # rtk git diff (~25 lignes)
-diff --git a/src/main.rs b/src/main.rs      src/main.rs (+5/-2)
-index abc123..def456 100644                    +  let config = Config::load()?;
---- a/src/main.rs                              +  config.validate()?;
-+++ b/src/main.rs                              -  // old code
-@@ -10,6 +10,8 @@                              -  let x = 42;
-   fn main() {                               src/git.rs (+1/-1)
-+    let config = Config::load()?;              ~  format!("ok {}", branch)
-...30 lignes de headers et contexte...
+diff --git a/git.rs b/git.rs
+index 50f7a19..225f918 100644
+--- a/git.rs
++++ b/git.rs
+@@ -1,3 +1,3 @@
+ fn helper(branch: &str) -> String {
+-    format!("ko {}", branch)
++    format!("ok {}", branch)
+ }
+diff --git a/main.rs b/main.rs
+index 765936a..7abfb4f 100644
+--- a/main.rs
++++ b/main.rs
+@@ -1,5 +1,5 @@
+ fn main() {
+-    let x = 42;
+-    // old code
++    let config = Config::load()?;
++    config.validate()?;
+     println!("start");
+ }
 ```
+
+`rtk git diff`, 15 lignes :
+```
+ git.rs  | 2 +-
+ main.rs | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+Changes:
+
+git.rs
+@@ -1,3 +1,3 @@
+ fn helper(branch: &str) -> String {
+-    format!("ko {}", branch)
++    format!("ok {}", branch)
+ }
+  +1 -1
+
+main.rs
+@@ -1,5 +1,5 @@
+ fn main() {
+-    let x = 42;
+-    // old code
++    let config = Config::load()?;
++    config.validate()?;
+     println!("start");
+ }
+  +2 -2
+```
+
+Les lignes de hunk et les en-tetes `@@` sortent en colonne 0, dans la forme
+unifiee de git, donc `rtk git diff | grep "^-"` fonctionne. Les annotations
+propres a rtk restent indentees de deux espaces pour que ces memes greps ne
+les comptent pas : le total par fichier (`  +2 -2`) et la note de troncature
+(`  ... (30 deletions, 20 additions truncated)`).
+
+Deux limites de l'audit ancre. Au-dela de 100 lignes de changement par hunk,
+`grep -c "^-"` plafonne a ce qui est affiche ; la note de troncature indique
+le reste, par signe, mais elle est indentee et donc invisible au meme grep.
+Et la sortie n'est pas un patch applicable : rtk supprime les en-tetes
+`diff --git` / `---` / `+++`. Utilisez `rtk proxy git diff` pour un patch
+fidele.
 
 ---
 

--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -358,9 +358,9 @@ index 765936a..7abfb4f 100644
  }
 ```
 
-`rtk git diff`, 15 lignes :
+`rtk git diff`, 24 lignes :
 ```
- git.rs  | 2 +-
+git.rs  | 2 +-
  main.rs | 4 ++--
  2 files changed, 3 insertions(+), 3 deletions(-)
 
@@ -386,18 +386,29 @@ main.rs
   +2 -2
 ```
 
+Sur un diff aussi petit, rtk economise peu : 440 octets bruts contre 392
+filtres, soit 11 %. La compression vient des diffs ou les en-tetes par fichier
+et les plafonds par hunk pesent. Sur un diff de 4 fichiers dont un hunk de 300
+lignes changees, la sortie passe de 335 a 140 lignes et de 13 262 a 4 880
+octets, soit 63 % de reduction, avec la note de troncature et le rappel
+`[full diff: rtk git diff --no-compact]`.
+
 Les lignes de hunk et les en-tetes `@@` sortent en colonne 0, dans la forme
 unifiee de git, donc `rtk git diff | grep "^-"` fonctionne. Les annotations
 propres a rtk restent indentees de deux espaces pour que ces memes greps ne
 les comptent pas : le total par fichier (`  +2 -2`) et la note de troncature
 (`  ... (30 deletions, 20 additions truncated)`).
 
-Deux limites de l'audit ancre. Au-dela de 100 lignes de changement par hunk,
+Trois limites de l'audit ancre. Au-dela de 100 lignes de changement par hunk,
 `grep -c "^-"` plafonne a ce qui est affiche ; la note de troncature indique
 le reste, par signe, mais elle est indentee et donc invisible au meme grep.
-Et la sortie n'est pas un patch applicable : rtk supprime les en-tetes
-`diff --git` / `---` / `+++`. Utilisez `rtk proxy git diff` pour un patch
-fidele.
+Sur un diff combine (`diff --cc`, ce que git produit pour chaque chemin en
+conflit pendant un merge, rebase, cherry-pick ou stash pop), le marqueur peut
+occuper la deuxieme colonne : ` +ours` est compte dans le total `+N -M` mais
+reste invisible a `grep "^+"`. Et la sortie n'est pas un patch applicable :
+rtk supprime les en-tetes `diff --git` / `---` / `+++`. Utilisez
+`rtk proxy git diff` pour un patch fidele, ou `rtk gh pr diff --patch`, qui
+passe sans filtrage.
 
 ---
 

--- a/src/cmds/git/gh_cmd.rs
+++ b/src/cmds/git/gh_cmd.rs
@@ -916,6 +916,11 @@ fn pr_merge(args: &[String], _verbose: u8) -> Result<i32> {
 
 /// Flags that change `gh pr diff` output from unified diff to a different format.
 /// When present, compact_diff would produce empty output since it expects diff headers.
+///
+/// `--patch` is here because GitHub's `.patch` is an mbox of `format-patch`
+/// output, not a unified diff: each patch carries a commit message, a bare
+/// `---` before the diffstat, and a `-- ` signature. Someone asking for a patch
+/// wants one that applies, so it passes through whole.
 fn has_non_diff_format_flag(args: &[String]) -> bool {
     args.iter().any(|a| {
         a == "--name-only"
@@ -923,6 +928,7 @@ fn has_non_diff_format_flag(args: &[String]) -> bool {
             || a == "--stat"
             || a == "--numstat"
             || a == "--shortstat"
+            || a == "--patch"
     })
 }
 
@@ -1385,6 +1391,12 @@ mod tests {
     #[test]
     fn test_non_diff_format_flag_shortstat() {
         assert!(has_non_diff_format_flag(&["--shortstat".into()]));
+    }
+
+    #[test]
+    fn test_has_non_diff_format_flag_patch() {
+        // `--patch` yields an mbox, which compact_diff has no business parsing.
+        assert!(has_non_diff_format_flag(&["--patch".into()]));
     }
 
     #[test]

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -126,7 +126,7 @@ fn run_diff(
         .any(|arg| arg == "--stat" || arg == "--numstat" || arg == "--shortstat");
 
     // Check if user wants compact diff (default RTK behavior)
-    let wants_compact = !args.iter().any(|arg| arg == "--no-compact");
+    let wants_compact = !args.iter().any(|arg| arg == "--no-compact") && !emits_word_diff(args);
 
     if wants_stat || !wants_compact {
         // User wants stat or explicitly no compacting - pass through directly
@@ -236,7 +236,7 @@ fn run_show(
     // pass through directly to avoid duplicated output from compact-show steps.
     let wants_blob_show = args.iter().any(|arg| is_blob_show_arg(arg));
 
-    if wants_stat_only || wants_format || wants_blob_show {
+    if wants_stat_only || wants_format || wants_blob_show || emits_word_diff(args) {
         let mut cmd = git_cmd(global_args);
         cmd.arg("show");
         for arg in args {
@@ -330,6 +330,26 @@ fn run_show(
     Ok(0)
 }
 
+/// Whether these args make git emit a word diff rather than a line diff.
+///
+/// `compact_diff` reads a unified or combined diff: a body line's first column
+/// (or columns) is a marker and the rest is content. A word diff drops the
+/// marker entirely and puts `[-removed-]` / `{+added+}` inline, so its body
+/// lines are arbitrary content in the marker position. A line starting with `+`
+/// then counts as an addition, one starting with `\` is dropped as a
+/// no-newline annotation, and one whose content happens to start `diff --`
+/// opens a new file section. There is nothing to compact faithfully, so these
+/// modes pass through.
+fn emits_word_diff(args: &[String]) -> bool {
+    args.iter().any(|arg| {
+        arg == "--word-diff"
+            || arg.starts_with("--word-diff=")
+            || arg.starts_with("--word-diff-regex")
+            || arg == "--color-words"
+            || arg.starts_with("--color-words=")
+    })
+}
+
 fn is_blob_show_arg(arg: &str) -> bool {
     // Detect `rev:path` style arguments while ignoring flags like `--pretty=format:...`.
     !arg.starts_with('-') && arg.contains(':')
@@ -353,16 +373,50 @@ fn diff_header_path(line: &str) -> String {
     {
         return path.to_string();
     }
-    match line.split(" b/").nth(1) {
+    let rest = match line.splitn(3, ' ').nth(2) {
+        Some(rest) => rest,
+        None => return "unknown".to_string(),
+    };
+    if let Some(path) = same_path_twice(rest) {
+        return path.to_string();
+    }
+    match rest.split(" b/").nth(1) {
         Some(path) => path.to_string(),
-        None => {
-            let rest = line.splitn(3, ' ').nth(2).unwrap_or("unknown");
-            // A single-path header (`diff --cc`) carries the quoting too.
-            rest.strip_prefix('"')
-                .and_then(|r| r.strip_suffix('"'))
-                .unwrap_or(rest)
-                .to_string()
-        }
+        // A single-path header (`diff --cc`) carries the quoting too.
+        None => rest
+            .strip_prefix('"')
+            .and_then(|r| r.strip_suffix('"'))
+            .unwrap_or(rest)
+            .to_string(),
+    }
+}
+
+/// The path a `diff --git` header names twice, split at the midpoint.
+///
+/// Anything but a rename names the same path on both sides, so the two halves
+/// are the same length and the separating space sits dead centre. Splitting
+/// there instead of on the first ` b/` keeps a path that contains that
+/// substring — a file under a directory named `x b` — and it does not care what
+/// the prefixes are, so `--no-prefix` and a custom `--src-prefix` work too.
+///
+/// `None` for a rename, whose halves differ in length, and for a single-path
+/// header; both fall through to the ` b/` split.
+fn same_path_twice(rest: &str) -> Option<&str> {
+    if rest.len().is_multiple_of(2) {
+        return None;
+    }
+    let mid = rest.len() / 2;
+    // A space at the midpoint is a char boundary, so both halves are valid.
+    if rest.as_bytes().get(mid) != Some(&b' ') {
+        return None;
+    }
+    let (left, right) = (&rest[..mid], &rest[mid + 1..]);
+    if left == right {
+        return Some(left);
+    }
+    match (left.strip_prefix("a/"), right.strip_prefix("b/")) {
+        (Some(p1), Some(p2)) if p1 == p2 => Some(p1),
+        _ => None,
     }
 }
 
@@ -434,7 +488,7 @@ fn parse_hunk_header(line: &str) -> Option<HunkHeader> {
     }
     let body = line[at_run..].split('@').next()?;
 
-    let mut parents = Vec::new();
+    let mut parents: Vec<usize> = Vec::new();
     let mut new = None;
     for group in body.split_whitespace() {
         let Some(rest) = group.strip_prefix(['-', '+']) else {
@@ -453,11 +507,22 @@ fn parse_hunk_header(line: &str) -> Option<HunkHeader> {
         }
     }
 
+    // `@@` has one marker column, `@@@` two, and so on for more parents.
+    let prefix_width = at_run - 1;
+    // A well-formed header lists exactly one range per marker column. When it
+    // does not, only the columns can be charged, so trust them: an untracked
+    // parent would otherwise sit at its declared count forever and the hunk
+    // would never close, while a parent with no column of its own would be
+    // charged against nothing. A missing range gets `usize::MAX`, which keeps
+    // the hunk open to the next header rather than dropping its body.
+    if parents.len() != prefix_width {
+        parents.resize(prefix_width, usize::MAX);
+    }
+
     Some(HunkHeader {
         parents,
         new: new.unwrap_or(0),
-        // `@@` has one marker column, `@@@` two, and so on for more parents.
-        prefix_width: at_run - 1,
+        prefix_width,
     })
 }
 
@@ -2190,8 +2255,10 @@ fn run_stash(
                 return Ok(result.exit_code);
             }
 
-            let filtered = if patch_mode {
+            let filtered = if patch_mode && !emits_word_diff(args) {
                 compact_diff(&result.stdout, 100)
+            } else if patch_mode {
+                result.stdout.clone()
             } else {
                 compact_stash_stat(&result.stdout)
             };
@@ -2898,6 +2965,81 @@ mod tests {
             diff_header_path(r#"diff --git "a/Ã©t.txt" b/plain.txt"#),
             "plain.txt"
         );
+    }
+
+    #[test]
+    fn test_emits_word_diff_detects_every_form() {
+        for flag in [
+            "--word-diff",
+            "--word-diff=plain",
+            "--word-diff=porcelain",
+            "--word-diff-regex=.",
+            "--color-words",
+            "--color-words=.",
+        ] {
+            assert!(
+                emits_word_diff(&[flag.to_string()]),
+                "{} must pass through",
+                flag
+            );
+        }
+        assert!(!emits_word_diff(&["--stat".to_string()]));
+        assert!(!emits_word_diff(&["-U10".to_string()]));
+        assert!(!emits_word_diff(&[]));
+    }
+
+    #[test]
+    fn test_parse_hunk_header_reconciles_ranges_with_marker_columns() {
+        // A well-formed header lists one range per marker column. When it does
+        // not, only the columns can be charged. A missing range must not leave
+        // an untracked parent holding the hunk open forever, and an extra one
+        // must not sit at its declared count with no column to spend it.
+        let h = parse_hunk_header("@@@ -1 +1 @@@").expect("two columns, one range");
+        assert_eq!(h.prefix_width, 2);
+        assert_eq!(h.parents, vec![1, usize::MAX]);
+
+        let h = parse_hunk_header("@@@ -1 -1 -1 +0,0 @@@").expect("two columns, three ranges");
+        assert_eq!(h.prefix_width, 2);
+        assert_eq!(h.parents, vec![1, 1]);
+    }
+
+    #[test]
+    fn test_compact_diff_extra_range_does_not_strand_a_hunk() {
+        // With the third range untracked, `--x` left it at 1 forever, so the
+        // hunk never closed and the mbox signature became its content.
+        let out = compact_diff("diff --cc f\n@@@ -1 -1 -1 +0,0 @@@\n--x\n-- \n2.40.0\n", 100);
+        assert!(out.contains("--x"), "got:\n{}", out);
+        assert!(!out.contains("2.40.0"), "got:\n{}", out);
+        assert!(!out.contains("-- "), "got:\n{}", out);
+        // One line, removed from both parents, is one deletion.
+        assert!(out.contains("+0 -1"), "got:\n{}", out);
+    }
+
+    #[test]
+    fn test_compact_diff_missing_range_keeps_the_body() {
+        // One range for two columns: the untracked parent gets `usize::MAX`, so
+        // the hunk stays open to the next header rather than closing early and
+        // dropping ` -lost`.
+        let out = compact_diff("diff --cc f\n@@@ -1 +1 @@@\n +kept\n -lost\n", 100);
+        assert!(out.contains(" +kept"), "got:\n{}", out);
+        assert!(out.contains(" -lost"), "got:\n{}", out);
+        assert!(out.contains("+1 -1"), "got:\n{}", out);
+    }
+
+    #[test]
+    fn test_diff_header_path_splits_the_pair_at_its_midpoint() {
+        // A file under a directory named `x b` puts the ` b/` separator inside
+        // the path, so the first match is the wrong one.
+        assert_eq!(diff_header_path("diff --git a/x b/y b/x b/y"), "x b/y");
+        // `--no-prefix` and custom prefixes leave no ` b/` at all.
+        assert_eq!(diff_header_path("diff --git x x"), "x");
+        assert_eq!(
+            diff_header_path("diff --git src/main.rs src/main.rs"),
+            "src/main.rs"
+        );
+        // A rename's halves differ in length, so the ` b/` split still names
+        // the destination.
+        assert_eq!(diff_header_path("diff --git a/old.txt b/new.txt"), "new.txt");
     }
 
     #[test]

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -374,12 +374,21 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
             hunk_shown = 0;
             // Preserve the full unified diff hunk header, including trailing
             // function / symbol context after the second @@ marker.
-            result.push(format!("  {}", line));
+            //
+            // Hunk-body lines below are emitted at column 0, in git's own
+            // unified shape. An earlier revision indented them two spaces to
+            // nest them under the filename, which silently broke every
+            // `git diff | grep '^-'` audit: the content was all there, but the
+            // `^` anchor no longer matched, so "was anything removed?" answered
+            // a confident, wrong "no". rtk's own annotations (the `+N -M` tally
+            // and `... (N lines truncated)`) keep the indent precisely so they
+            // are not mistaken for diff lines by the same greps.
+            result.push(line.to_string());
         } else if in_hunk {
             if line.starts_with('+') && !line.starts_with("+++") {
                 added += 1;
                 if hunk_shown < max_hunk_lines {
-                    result.push(format!("  {}", line));
+                    result.push(line.to_string());
                     hunk_shown += 1;
                 } else {
                     hunk_skipped += 1;
@@ -387,15 +396,15 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
             } else if line.starts_with('-') && !line.starts_with("---") {
                 removed += 1;
                 if hunk_shown < max_hunk_lines {
-                    result.push(format!("  {}", line));
+                    result.push(line.to_string());
                     hunk_shown += 1;
                 } else {
                     hunk_skipped += 1;
                 }
             } else if hunk_shown < max_hunk_lines && !line.starts_with("\\") {
-                // Context line
+                // Context line (git already prefixes it with a space).
                 if hunk_shown > 0 {
-                    result.push(format!("  {}", line));
+                    result.push(line.to_string());
                     hunk_shown += 1;
                 }
             }
@@ -2410,6 +2419,38 @@ mod tests {
         let result = compact_diff(diff, 100);
         assert!(result.contains("foo.rs"));
         assert!(result.contains("+"));
+    }
+
+    #[test]
+    fn test_compact_diff_hunk_lines_are_grep_anchorable() {
+        // Regression: hunk-body lines were indented two spaces, so
+        // `git diff | grep '^-'` matched nothing and an audit of "was anything
+        // removed?" got a confident, wrong "no". The content was never missing;
+        // the `^` anchor was what broke. Added lines were equally affected, so
+        // this is not a deletions-only defect.
+        let diff = "diff --git a/f.txt b/f.txt\n\
+                    --- a/f.txt\n\
+                    +++ b/f.txt\n\
+                    @@ -1,5 +1,4 @@\n\
+                    \x20keep1\n\
+                    -DELETED_A\n\
+                    \x20keep2\n\
+                    -DELETED_B\n\
+                    +ADDED\n";
+        let result = compact_diff(diff, 100);
+
+        let removed: Vec<&str> = result.lines().filter(|l| l.starts_with('-')).collect();
+        let added: Vec<&str> = result.lines().filter(|l| l.starts_with('+')).collect();
+
+        assert_eq!(removed, vec!["-DELETED_A", "-DELETED_B"], "`^-` must anchor");
+        assert_eq!(added, vec!["+ADDED"], "`^+` must anchor");
+
+        // rtk's own tally stays indented so these same greps never count it as
+        // a diff line. Without this, `^+` would pick up the "+1 -2" summary.
+        assert!(result.contains("  +1 -2"), "tally must stay indented");
+
+        // Context lines keep git's leading space, so they are not `^-`/`^+`.
+        assert!(result.lines().any(|l| l == " keep2"));
     }
 
     #[test]

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -338,12 +338,64 @@ fn is_blob_show_arg(arg: &str) -> bool {
 /// Path named by a diff section header.
 ///
 /// `diff --git a/p b/p` carries the path twice; `diff --cc p` and
-/// `diff --combined p` carry it once, at the end.
+/// `diff --combined p` carry it once, as the whole remainder of the line. git
+/// does not quote spaces in these headers, so the remainder is taken as-is.
 fn diff_header_path(line: &str) -> String {
     match line.split(" b/").nth(1) {
         Some(path) => path.to_string(),
-        None => line.rsplit(' ').next().unwrap_or("unknown").to_string(),
+        None => line.splitn(3, ' ').nth(2).unwrap_or("unknown").to_string(),
     }
+}
+
+/// Line budget a hunk header declares, and how wide its body prefix is.
+struct HunkHeader {
+    /// Lines the hunk spans in the first parent.
+    old: usize,
+    /// Lines the hunk spans in the result file.
+    new: usize,
+    /// Marker columns: 1 for `@@`, and one per parent for a combined `@@@`.
+    prefix_width: usize,
+}
+
+/// Parse `@@ -a,b +c,d @@` and the combined `@@@ -a,b -c,d +e,f @@@`.
+///
+/// The counts bound the hunk body, which is what lets the body end where the
+/// hunk ends rather than running on until the next header. Anything after it —
+/// an mbox envelope, a `--` signature, trailing prose — is then outside every
+/// hunk and cannot be read as diff content. A count is 1 when the header omits
+/// it (`@@ -1 +1 @@`).
+fn parse_hunk_header(line: &str) -> Option<HunkHeader> {
+    let at_run = line.len() - line.trim_start_matches('@').len();
+    if at_run < 2 {
+        return None;
+    }
+    let body = line[at_run..].split('@').next()?;
+
+    let mut old = None;
+    let mut new = None;
+    for group in body.split_whitespace() {
+        let Some(rest) = group.strip_prefix(['-', '+']) else {
+            continue;
+        };
+        let count = match rest.split_once(',') {
+            Some((_, c)) => c.parse::<usize>().ok()?,
+            None => 1,
+        };
+        if group.starts_with('-') {
+            // A combined header lists one range per parent; the first is the
+            // one whose line numbers the `-` column tracks.
+            old.get_or_insert(count);
+        } else {
+            new = Some(count);
+        }
+    }
+
+    Some(HunkHeader {
+        old: old.unwrap_or(0),
+        new: new.unwrap_or(0),
+        // `@@` has one marker column, `@@@` two, and so on for more parents.
+        prefix_width: at_run - 1,
+    })
 }
 
 /// Render the note for change lines dropped past `max_hunk_lines`, split by
@@ -365,11 +417,11 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
     let mut current_file = String::new();
     let mut added = 0;
     let mut removed = 0;
-    let mut in_hunk = false;
+    let mut hunk: Option<HunkHeader> = None;
     let mut hunk_shown = 0;
     let mut skipped_add = 0usize;
     let mut skipped_del = 0usize;
-    let mut leading_context = 0usize;
+    let mut leading_context: Vec<String> = Vec::new();
     let mut leading_context_total = 0usize;
     let max_hunk_lines = 100;
     // Context before a hunk's first change, up to three lines per hunk and
@@ -382,12 +434,10 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
     let mut was_truncated = false;
 
     for line in diff.lines() {
-        // `diff --cc` / `diff --combined` head the sections git emits for
-        // unmerged paths. Matching only `diff --git` left `in_hunk` set from
-        // the previous section, so the `---` / `+++` headers of every combined
-        // section after the first were counted and printed as hunk content.
+        // Every diff section header (`--git`, `--cc`, `--combined`) opens a new
+        // file and closes any open hunk, so the `---` / `+++` headers that
+        // follow it are never read as hunk content.
         if line.starts_with("diff --") {
-            // Flush hunk truncation before starting a new file
             if let Some(note) = hunk_truncation_note(skipped_del, skipped_add) {
                 result.push(note);
                 was_truncated = true;
@@ -401,63 +451,98 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
             result.push(format!("\n{}", current_file));
             added = 0;
             removed = 0;
-            in_hunk = false;
+            hunk = None;
             hunk_shown = 0;
-            leading_context = 0;
-        } else if line.starts_with("@@") {
-            // Flush hunk truncation before starting a new hunk
+            leading_context.clear();
+        } else if let Some(header) = parse_hunk_header(line) {
             if let Some(note) = hunk_truncation_note(skipped_del, skipped_add) {
                 result.push(note);
                 was_truncated = true;
                 skipped_del = 0;
                 skipped_add = 0;
             }
-            in_hunk = true;
+            hunk = Some(header);
             hunk_shown = 0;
-            leading_context = 0;
+            leading_context.clear();
             // Preserve the full unified diff hunk header, including trailing
             // function / symbol context after the second @@ marker.
             result.push(line.to_string());
-        } else if in_hunk {
+        } else if let Some(header) = hunk.as_mut() {
+            if header.old == 0 && header.new == 0 {
+                hunk = None;
+                continue;
+            }
+            if line.starts_with('\\') {
+                // "\ No newline at end of file" annotates the line above and
+                // occupies no line in either file.
+                continue;
+            }
+
+            let width = header.prefix_width.min(line.len());
+            let markers = &line[..width];
+            // A combined diff carries one marker column per parent, so a line
+            // changed against only one of them has its marker in column 2.
+            let is_add = markers.contains('+');
+            let is_del = markers.contains('-');
+            // Present in the result file unless it is a pure deletion, and in
+            // the first parent unless it is a pure addition.
+            header.new = header.new.saturating_sub(if is_del && !is_add { 0 } else { 1 });
+            header.old = header.old.saturating_sub(if is_add && !is_del { 0 } else { 1 });
+
             // Hunk bodies emit at column 0 in git's own unified shape, so
             // `^+` / `^-` anchor. rtk's own annotations stay indented so those
             // same anchors never match them. Inside a hunk every `+`/`-` line
             // is content: the `---` / `+++` file headers only ever appear
-            // before the first `@@`, where `in_hunk` is still false.
-            if line.starts_with('+') {
-                added += 1;
+            // before the first hunk header.
+            if is_add || is_del {
+                if is_add {
+                    added += 1;
+                }
+                if is_del {
+                    removed += 1;
+                }
                 if hunk_shown < max_hunk_lines {
+                    // The context immediately preceding the change, so the body
+                    // reads as contiguous with it. The diff-wide budget is
+                    // charged here rather than on buffering, so a line the ring
+                    // evicted never costs anything.
+                    let room = leading_context_cap.saturating_sub(leading_context_total);
+                    let keep = leading_context.len().min(room);
+                    let skip = leading_context.len() - keep;
+                    for ctx in leading_context.drain(..).skip(skip) {
+                        result.push(ctx);
+                    }
+                    leading_context_total += keep;
                     result.push(line.to_string());
                     hunk_shown += 1;
+                } else if is_del {
+                    skipped_del += 1;
                 } else {
                     skipped_add += 1;
                 }
-            } else if line.starts_with('-') {
-                removed += 1;
+                leading_context.clear();
+            } else if hunk_shown > 0 {
                 if hunk_shown < max_hunk_lines {
                     result.push(line.to_string());
                     hunk_shown += 1;
-                } else {
-                    skipped_del += 1;
                 }
-            } else if !line.starts_with('\\') {
-                // Context line (git already prefixes it with a space).
-                if hunk_shown > 0 {
-                    if hunk_shown < max_hunk_lines {
-                        result.push(line.to_string());
-                        hunk_shown += 1;
-                    }
-                } else if leading_context < max_leading_context
-                    && leading_context_total < leading_context_cap
-                {
-                    result.push(line.to_string());
-                    leading_context += 1;
-                    leading_context_total += 1;
+            } else if leading_context_total < leading_context_cap {
+                // Keep the last `max_leading_context` lines rather than the
+                // first: with `-U10` or `--function-context` the first ones sit
+                // ten lines above the change and would imply an adjacency the
+                // file does not have.
+                if leading_context.len() == max_leading_context {
+                    leading_context.remove(0);
                 }
+                leading_context.push(line.to_string());
+            }
+
+            if header.old == 0 && header.new == 0 {
+                hunk = None;
             }
         }
 
-        if result.len() - leading_context_total >= max_lines {
+        if result.len().saturating_sub(leading_context_total) >= max_lines {
             result.push("\n... (more changes truncated)".to_string());
             was_truncated = true;
             break;
@@ -2554,10 +2639,9 @@ mod tests {
 
     #[test]
     fn test_compact_diff_combined_diff_headers_are_not_hunk_content() {
-        // `diff --cc` sections (unmerged paths during a merge / rebase /
-        // cherry-pick / stash pop) do not match `diff --git`, so `in_hunk`
-        // stayed true from the previous section and the `---` / `+++` headers
-        // of every later file were printed at column 0 and counted.
+        // `diff --cc` sections do not match `diff --git`, so the reset fires on
+        // the `diff --` prefix and the `---` / `+++` headers of every section
+        // stay outside the hunk body.
         let diff = "diff --cc a.txt\n\
                     index ba2906d,e45c9c2..0000000\n\
                     --- a/a.txt\n\
@@ -2565,28 +2649,143 @@ mod tests {
                     @@@ -1,1 -1,1 +1,5 @@@\n\
                     ++<<<<<<< HEAD\n\
                     \x20+main\n\
+                    ++=======\n\
+                    + side\n\
+                    ++>>>>>>> side\n\
                     diff --cc z.txt\n\
                     index ba2906d,e45c9c2..0000000\n\
                     --- a/z.txt\n\
                     +++ b/z.txt\n\
                     @@@ -1,1 -1,1 +1,5 @@@\n\
                     ++<<<<<<< HEAD\n\
-                    \x20+main\n";
+                    \x20+main\n\
+                    ++=======\n\
+                    + side\n\
+                    ++>>>>>>> side\n";
         let result = compact_diff(diff, 500);
 
-        let removed: Vec<&str> = result.lines().filter(|l| l.starts_with('-')).collect();
-        assert!(
-            removed.is_empty(),
-            "no deletions in this diff, got {:?} in:\n{}",
-            removed,
-            result
-        );
         assert!(
             !result.lines().any(|l| l.starts_with("+++ b/")),
             "file headers must not reach the hunk body, got:\n{}",
             result
         );
         assert!(result.contains("z.txt"), "got:\n{}", result);
+        // A combined diff carries one marker column per parent, so ` +main` is
+        // an addition against the second parent. The tally counts all five
+        // added lines per file; an anchored `^+` sees only the four whose
+        // marker sits in column 1. That gap is documented in FEATURES.md.
+        assert_eq!(
+            result.matches("  +5 -0").count(),
+            2,
+            "column-2 markers must be counted, got:\n{}",
+            result
+        );
+        let anchored = result.lines().filter(|l| l.starts_with('+')).count();
+        assert_eq!(anchored, 8, "four per file anchor, got:\n{}", result);
+    }
+
+    #[test]
+    fn test_compact_diff_mbox_signature_is_not_a_deletion() {
+        // `gh pr diff --patch` yields an mbox: a bare `---` before the diffstat
+        // and a `-- ` signature after each patch, both at column 0. The hunk
+        // ends where its declared line counts run out, so neither is read as
+        // hunk content.
+        let diff = "From abc Mon Sep 17 00:00:00 2001\n\
+                    Subject: [PATCH 1/2] one\n\
+                    \n\
+                    ---\n\
+                    \x20f.txt | 2 +-\n\
+                    \n\
+                    diff --git a/f.txt b/f.txt\n\
+                    --- a/f.txt\n\
+                    +++ b/f.txt\n\
+                    @@ -1,2 +1,2 @@\n\
+                    -old1\n\
+                    +new1\n\
+                    \x20tail1\n\
+                    -- \n\
+                    2.40.0\n\
+                    \n\
+                    From def Mon Sep 17 00:00:00 2001\n\
+                    Subject: [PATCH 2/2] two\n\
+                    \n\
+                    ---\n\
+                    diff --git a/g.txt b/g.txt\n\
+                    --- a/g.txt\n\
+                    +++ b/g.txt\n\
+                    @@ -1,2 +1,2 @@\n\
+                    -old2\n\
+                    +new2\n\
+                    \x20tail2\n\
+                    -- \n\
+                    2.40.0\n";
+        let result = compact_diff(diff, 500);
+
+        let removed: Vec<&str> = result.lines().filter(|l| l.starts_with('-')).collect();
+        assert_eq!(
+            removed,
+            vec!["-old1", "-old2"],
+            "only real deletions anchor, got:\n{}",
+            result
+        );
+        assert!(
+            !result.contains("Subject:"),
+            "mbox envelope must stay out of the body, got:\n{}",
+            result
+        );
+        assert!(result.contains("  +1 -1"), "tally counts real changes only, got:\n{}", result);
+    }
+
+    #[test]
+    fn test_compact_diff_leading_context_is_adjacent_to_the_change() {
+        // With `-U10` the first context lines sit ten lines above the change.
+        // Emitting those would tell the reader that ctx3 precedes the deletion
+        // when ctx10 does.
+        let mut diff = String::from("diff --git a/f.rs b/f.rs\n@@ -1,11 +1,11 @@\n");
+        for i in 1..=10 {
+            diff.push_str(&format!(" ctx{}\n", i));
+        }
+        diff.push_str("-old\n+new\n");
+        let result = compact_diff(&diff, 500);
+
+        let ctx: Vec<&str> = result.lines().filter(|l| l.starts_with(" ctx")).collect();
+        assert_eq!(
+            ctx,
+            vec![" ctx8", " ctx9", " ctx10"],
+            "the last context lines, not the first, got:\n{}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_diff_header_path_keeps_spaces() {
+        assert_eq!(
+            diff_header_path("diff --git a/my file.txt b/my file.txt"),
+            "my file.txt"
+        );
+        assert_eq!(diff_header_path("diff --cc my file.txt"), "my file.txt");
+        assert_eq!(
+            diff_header_path("diff --combined my file.txt"),
+            "my file.txt"
+        );
+    }
+
+    #[test]
+    fn test_parse_hunk_header_counts() {
+        let h = parse_hunk_header("@@ -10,3 +10,4 @@ fn ctx() {").expect("unified header");
+        assert_eq!((h.old, h.new, h.prefix_width), (3, 4, 1));
+
+        // Omitted counts mean one line.
+        let h = parse_hunk_header("@@ -1 +1 @@").expect("single-line header");
+        assert_eq!((h.old, h.new), (1, 1));
+
+        // A combined header lists one range per parent; `old` tracks the first.
+        let h = parse_hunk_header("@@@ -1,1 -1,1 +1,5 @@@").expect("combined header");
+        assert_eq!((h.old, h.new, h.prefix_width), (1, 5, 2));
+
+        assert!(parse_hunk_header("@ -1,1 +1,1 @").is_none());
+        assert!(parse_hunk_header("-- ").is_none());
+        assert!(parse_hunk_header("---").is_none());
     }
 
     #[test]

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -340,14 +340,26 @@ fn run_show(
 /// no-newline annotation, and one whose content happens to start `diff --`
 /// opens a new file section. There is nothing to compact faithfully, so these
 /// modes pass through.
+///
+/// `--word-diff=none` is the mode that turns a word diff back off, leaving an
+/// ordinary unified diff to compact. Modes are last-one-wins, which is what
+/// that mode is for: overriding an alias or an earlier flag on the same line.
 fn emits_word_diff(args: &[String]) -> bool {
-    args.iter().any(|arg| {
-        arg == "--word-diff"
-            || arg.starts_with("--word-diff=")
+    let mut word_diff = false;
+    for arg in args {
+        if let Some(mode) = arg.strip_prefix("--word-diff=") {
+            word_diff = mode != "none";
+        } else if arg == "--word-diff"
             || arg.starts_with("--word-diff-regex")
             || arg == "--color-words"
             || arg.starts_with("--color-words=")
-    })
+        {
+            // `--color-words[=<regex>]` takes a regex rather than a mode, so
+            // there is no `none` to honour on that spelling.
+            word_diff = true;
+        }
+    }
+    word_diff
 }
 
 fn is_blob_show_arg(arg: &str) -> bool {
@@ -358,36 +370,36 @@ fn is_blob_show_arg(arg: &str) -> bool {
 /// Path named by a diff section header.
 ///
 /// `diff --git a/p b/p` carries the path twice; `diff --cc p` and
-/// `diff --combined p` carry it once, as the whole remainder of the line.
+/// `diff --combined p` carry it once, as the whole remainder of the line. Only
+/// the two-path form can be split at its midpoint, so the header kind decides
+/// which shape to read: `diff --cc dup dup` names one file called `dup dup`,
+/// not the file `dup` twice.
 ///
-/// Under the default `core.quotepath`, git wraps a path in `"` and escapes it
-/// when it holds a non-ASCII byte, a control character or a quote — but not
-/// when it merely holds a space. So the separator is ` b/` for a plain path and
-/// ` "b/` for a quoted one, and a path with a space in it needs neither form
-/// handled specially.
+/// Under the default `core.quotepath`, git wraps a path in `"` and escapes any
+/// non-ASCII byte, control character, quote or backslash inside it — but not a
+/// space. The quoting is undone here, so the header carries the path as it is
+/// on disk and a `grep` over the output finds it by name.
 fn diff_header_path(line: &str) -> String {
-    if let Some(path) = line
+    let Some(rest) = line.splitn(3, ' ').nth(2) else {
+        return "unknown".to_string();
+    };
+    if !line.starts_with("diff --git ") {
+        return unquote_path(rest);
+    }
+    if let Some(path) = same_path_twice(rest) {
+        return path;
+    }
+    // A rename names two different paths, and the destination is the second.
+    if let Some(quoted) = rest
         .split(" \"b/")
         .nth(1)
-        .and_then(|rest| rest.strip_suffix('"'))
+        .and_then(|dst| dst.strip_suffix('"'))
     {
-        return path.to_string();
-    }
-    let rest = match line.splitn(3, ' ').nth(2) {
-        Some(rest) => rest,
-        None => return "unknown".to_string(),
-    };
-    if let Some(path) = same_path_twice(rest) {
-        return path.to_string();
+        return unescape_path(quoted);
     }
     match rest.split(" b/").nth(1) {
         Some(path) => path.to_string(),
-        // A single-path header (`diff --cc`) carries the quoting too.
-        None => rest
-            .strip_prefix('"')
-            .and_then(|r| r.strip_suffix('"'))
-            .unwrap_or(rest)
-            .to_string(),
+        None => unquote_path(rest),
     }
 }
 
@@ -396,12 +408,16 @@ fn diff_header_path(line: &str) -> String {
 /// Anything but a rename names the same path on both sides, so the two halves
 /// are the same length and the separating space sits dead centre. Splitting
 /// there instead of on the first ` b/` keeps a path that contains that
-/// substring — a file under a directory named `x b` — and it does not care what
-/// the prefixes are, so `--no-prefix` and a custom `--src-prefix` work too.
+/// substring — a file under a directory named `x b`. Prefixes are then dropped
+/// by matching the halves against each other rather than by name, so
+/// `--no-prefix` and any custom `--src-prefix` / `--dst-prefix` read alike.
 ///
-/// `None` for a rename, whose halves differ in length, and for a single-path
-/// header; both fall through to the ` b/` split.
-fn same_path_twice(rest: &str) -> Option<&str> {
+/// `None` for a rename, whose halves differ past their first component, and for
+/// anything else the two halves disagree on; both fall through to the ` b/`
+/// split. A `--no-prefix` rename between two directories is the one shape this
+/// cannot tell from a prefix pair — space-separated paths with no prefix are
+/// ambiguous by construction — and it reads as the shared trailing path.
+fn same_path_twice(rest: &str) -> Option<String> {
     if rest.len().is_multiple_of(2) {
         return None;
     }
@@ -410,14 +426,74 @@ fn same_path_twice(rest: &str) -> Option<&str> {
     if rest.as_bytes().get(mid) != Some(&b' ') {
         return None;
     }
-    let (left, right) = (&rest[..mid], &rest[mid + 1..]);
+    let (left, right) = (unquote_path(&rest[..mid]), unquote_path(&rest[mid + 1..]));
     if left == right {
         return Some(left);
     }
-    match (left.strip_prefix("a/"), right.strip_prefix("b/")) {
-        (Some(p1), Some(p2)) if p1 == p2 => Some(p1),
-        _ => None,
+    let (_, left_path) = left.split_once('/')?;
+    let (_, right_path) = right.split_once('/')?;
+    (left_path == right_path).then(|| right_path.to_string())
+}
+
+/// Undo git's `core.quotepath` quoting: `"a/\303\251.txt"` becomes `a/é.txt`.
+///
+/// A path git did not quote is returned as-is, so either form can be passed.
+fn unquote_path(raw: &str) -> String {
+    match raw.strip_prefix('"').and_then(|r| r.strip_suffix('"')) {
+        Some(quoted) => unescape_path(quoted),
+        None => raw.to_string(),
     }
+}
+
+/// Decode the C escapes inside a quoted path.
+///
+/// The octal escapes spell out the path's bytes one at a time, so a multi-byte
+/// character arrives as several of them; they are collected as bytes and
+/// decoded once at the end rather than per escape. A path whose bytes are not
+/// UTF-8 keeps replacement characters, which is as close as a `String` gets.
+fn unescape_path(quoted: &str) -> String {
+    let bytes = quoted.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != b'\\' || i + 1 == bytes.len() {
+            out.push(bytes[i]);
+            i += 1;
+            continue;
+        }
+        let escape = bytes[i + 1];
+        if escape.is_ascii_digit() {
+            let end = (i + 4).min(bytes.len());
+            let octal = std::str::from_utf8(&bytes[i + 1..end])
+                .ok()
+                .and_then(|digits| u8::from_str_radix(digits, 8).ok());
+            match octal {
+                Some(byte) => {
+                    out.push(byte);
+                    i = end;
+                }
+                // Not an octal escape after all: keep the backslash verbatim.
+                None => {
+                    out.push(bytes[i]);
+                    i += 1;
+                }
+            }
+            continue;
+        }
+        out.push(match escape {
+            b'a' => 0x07,
+            b'b' => 0x08,
+            b't' => b'\t',
+            b'n' => b'\n',
+            b'v' => 0x0b,
+            b'f' => 0x0c,
+            b'r' => b'\r',
+            // `\"` and `\\` stand for themselves.
+            other => other,
+        });
+        i += 2;
+    }
+    String::from_utf8_lossy(&out).into_owned()
 }
 
 /// Line budget a hunk header declares, and how wide its body prefix is.
@@ -2968,6 +3044,38 @@ mod tests {
     }
 
     #[test]
+    fn test_diff_header_path_unescapes_gits_default_quoting() {
+        // What git actually emits under the default `core.quotepath`: one octal
+        // escape per byte, so the header has to be decoded rather than merely
+        // unwrapped, or `rtk git diff | grep été` finds nothing.
+        assert_eq!(
+            diff_header_path(r#"diff --git "a/\303\251t\303\251.txt" "b/\303\251t\303\251.txt""#),
+            "été.txt"
+        );
+        assert_eq!(
+            diff_header_path(r#"diff --cc "\303\251t\303\251.txt""#),
+            "été.txt"
+        );
+        assert_eq!(
+            diff_header_path(r#"diff --git a/plain.txt "b/\303\251t.txt""#),
+            "ét.txt"
+        );
+        // The single-character escapes, and a backslash standing for itself.
+        assert_eq!(
+            diff_header_path(r#"diff --cc "tab\there.txt""#),
+            "tab\there.txt"
+        );
+        assert_eq!(
+            diff_header_path(r#"diff --cc "quote\"here.txt""#),
+            "quote\"here.txt"
+        );
+        assert_eq!(
+            diff_header_path(r#"diff --cc "back\\slash.txt""#),
+            r"back\slash.txt"
+        );
+    }
+
+    #[test]
     fn test_emits_word_diff_detects_every_form() {
         for flag in [
             "--word-diff",
@@ -2986,6 +3094,25 @@ mod tests {
         assert!(!emits_word_diff(&["--stat".to_string()]));
         assert!(!emits_word_diff(&["-U10".to_string()]));
         assert!(!emits_word_diff(&[]));
+    }
+
+    #[test]
+    fn test_emits_word_diff_honours_the_none_mode() {
+        // `--word-diff=none` leaves an ordinary unified diff, which compacts
+        // like any other. Treating it as a word diff passed the whole raw diff
+        // through, so a defensive `--word-diff=none` lost every saving.
+        assert!(!emits_word_diff(&["--word-diff=none".to_string()]));
+        // Modes are last-one-wins, which is what `none` exists to do.
+        assert!(!emits_word_diff(&[
+            "--word-diff".to_string(),
+            "--word-diff=none".to_string()
+        ]));
+        assert!(emits_word_diff(&[
+            "--word-diff=none".to_string(),
+            "--word-diff".to_string()
+        ]));
+        // `--color-words` takes a regex, so `none` there is a pattern.
+        assert!(emits_word_diff(&["--color-words=none".to_string()]));
     }
 
     #[test]
@@ -3037,9 +3164,22 @@ mod tests {
             diff_header_path("diff --git src/main.rs src/main.rs"),
             "src/main.rs"
         );
-        // A rename's halves differ in length, so the ` b/` split still names
-        // the destination.
+        // Prefixes are matched against each other, not by name, so a custom
+        // `--dst-prefix` reads like any other pair.
+        assert_eq!(diff_header_path("diff --git a/f.txt w/f.txt"), "f.txt");
+        assert_eq!(diff_header_path("diff --git i/f.txt w/f.txt"), "f.txt");
+        // A rename's halves disagree past their first component, so the ` b/`
+        // split still names the destination.
         assert_eq!(diff_header_path("diff --git a/old.txt b/new.txt"), "new.txt");
+    }
+
+    #[test]
+    fn test_diff_header_path_does_not_split_single_path_headers() {
+        // `diff --cc` names one path. Splitting its remainder at the midpoint
+        // would read a file called `dup dup` as the file `dup` named twice.
+        assert_eq!(diff_header_path("diff --cc dup dup"), "dup dup");
+        assert_eq!(diff_header_path("diff --combined dup dup"), "dup dup");
+        assert_eq!(diff_header_path("diff --cc a/x b/x"), "a/x b/x");
     }
 
     #[test]

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -335,6 +335,20 @@ fn is_blob_show_arg(arg: &str) -> bool {
     !arg.starts_with('-') && arg.contains(':')
 }
 
+/// Render the note for change lines dropped past `max_hunk_lines`, split by
+/// sign so an anchored `^-` / `^+` audit can tell what it did not see.
+fn hunk_truncation_note(deletions: usize, additions: usize) -> Option<String> {
+    match (deletions, additions) {
+        (0, 0) => None,
+        (0, a) => Some(format!("  ... ({} additions truncated)", a)),
+        (d, 0) => Some(format!("  ... ({} deletions truncated)", d)),
+        (d, a) => Some(format!(
+            "  ... ({} deletions, {} additions truncated)",
+            d, a
+        )),
+    }
+}
+
 pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
     let mut result = Vec::new();
     let mut current_file = String::new();
@@ -342,17 +356,23 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
     let mut removed = 0;
     let mut in_hunk = false;
     let mut hunk_shown = 0;
-    let mut hunk_skipped = 0usize;
+    let mut skipped_add = 0usize;
+    let mut skipped_del = 0usize;
+    let mut leading_context = 0usize;
     let max_hunk_lines = 100;
+    // Context before a hunk's first change gets its own budget so it cannot
+    // crowd the change itself out of `max_hunk_lines`.
+    let max_leading_context = 3;
     let mut was_truncated = false;
 
     for line in diff.lines() {
         if line.starts_with("diff --git") {
             // Flush hunk truncation before starting a new file
-            if hunk_skipped > 0 {
-                result.push(format!("  ... ({} lines truncated)", hunk_skipped));
+            if let Some(note) = hunk_truncation_note(skipped_del, skipped_add) {
+                result.push(note);
                 was_truncated = true;
-                hunk_skipped = 0;
+                skipped_del = 0;
+                skipped_add = 0;
             }
             if !current_file.is_empty() && (added > 0 || removed > 0) {
                 result.push(format!("  +{} -{}", added, removed));
@@ -363,49 +383,53 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
             removed = 0;
             in_hunk = false;
             hunk_shown = 0;
+            leading_context = 0;
         } else if line.starts_with("@@") {
             // Flush hunk truncation before starting a new hunk
-            if hunk_skipped > 0 {
-                result.push(format!("  ... ({} lines truncated)", hunk_skipped));
+            if let Some(note) = hunk_truncation_note(skipped_del, skipped_add) {
+                result.push(note);
                 was_truncated = true;
-                hunk_skipped = 0;
+                skipped_del = 0;
+                skipped_add = 0;
             }
             in_hunk = true;
             hunk_shown = 0;
+            leading_context = 0;
             // Preserve the full unified diff hunk header, including trailing
             // function / symbol context after the second @@ marker.
-            //
-            // Hunk-body lines below are emitted at column 0, in git's own
-            // unified shape. An earlier revision indented them two spaces to
-            // nest them under the filename, which silently broke every
-            // `git diff | grep '^-'` audit: the content was all there, but the
-            // `^` anchor no longer matched, so "was anything removed?" answered
-            // a confident, wrong "no". rtk's own annotations (the `+N -M` tally
-            // and `... (N lines truncated)`) keep the indent precisely so they
-            // are not mistaken for diff lines by the same greps.
             result.push(line.to_string());
         } else if in_hunk {
-            if line.starts_with('+') && !line.starts_with("+++") {
+            // Hunk bodies emit at column 0 in git's own unified shape, so
+            // `^+` / `^-` anchor. rtk's own annotations stay indented so those
+            // same anchors never match them. Inside a hunk every `+`/`-` line
+            // is content: the `---` / `+++` file headers only ever appear
+            // before the first `@@`, where `in_hunk` is still false.
+            if line.starts_with('+') {
                 added += 1;
                 if hunk_shown < max_hunk_lines {
                     result.push(line.to_string());
                     hunk_shown += 1;
                 } else {
-                    hunk_skipped += 1;
+                    skipped_add += 1;
                 }
-            } else if line.starts_with('-') && !line.starts_with("---") {
+            } else if line.starts_with('-') {
                 removed += 1;
                 if hunk_shown < max_hunk_lines {
                     result.push(line.to_string());
                     hunk_shown += 1;
                 } else {
-                    hunk_skipped += 1;
+                    skipped_del += 1;
                 }
-            } else if hunk_shown < max_hunk_lines && !line.starts_with("\\") {
+            } else if !line.starts_with('\\') {
                 // Context line (git already prefixes it with a space).
                 if hunk_shown > 0 {
+                    if hunk_shown < max_hunk_lines {
+                        result.push(line.to_string());
+                        hunk_shown += 1;
+                    }
+                } else if leading_context < max_leading_context {
                     result.push(line.to_string());
-                    hunk_shown += 1;
+                    leading_context += 1;
                 }
             }
         }
@@ -418,8 +442,8 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
     }
 
     // Flush last hunk
-    if hunk_skipped > 0 {
-        result.push(format!("  ... ({} lines truncated)", hunk_skipped));
+    if let Some(note) = hunk_truncation_note(skipped_del, skipped_add) {
+        result.push(note);
         was_truncated = true;
     }
 
@@ -2423,11 +2447,6 @@ mod tests {
 
     #[test]
     fn test_compact_diff_hunk_lines_are_grep_anchorable() {
-        // Regression: hunk-body lines were indented two spaces, so
-        // `git diff | grep '^-'` matched nothing and an audit of "was anything
-        // removed?" got a confident, wrong "no". The content was never missing;
-        // the `^` anchor was what broke. Added lines were equally affected, so
-        // this is not a deletions-only defect.
         let diff = "diff --git a/f.txt b/f.txt\n\
                     --- a/f.txt\n\
                     +++ b/f.txt\n\
@@ -2450,7 +2469,82 @@ mod tests {
         assert!(result.contains("  +1 -2"), "tally must stay indented");
 
         // Context lines keep git's leading space, so they are not `^-`/`^+`.
+        // Both are emitted: the one before the first change as well as the one
+        // between changes.
+        assert!(
+            result.lines().any(|l| l == " keep1"),
+            "leading context must survive, got:\n{}",
+            result
+        );
         assert!(result.lines().any(|l| l == " keep2"));
+    }
+
+    #[test]
+    fn test_compact_diff_keeps_content_starting_with_plus_or_minus() {
+        // `---` / `+++` are file headers only before the first `@@`. Inside a
+        // hunk, `++i;` and `-- sql comment` are content and must be neither
+        // dropped from the body nor missing from the tally.
+        let diff = "diff --git a/f.sql b/f.sql\n\
+                    --- a/f.sql\n\
+                    +++ b/f.sql\n\
+                    @@ -1,2 +1,2 @@\n\
+                    --- sql comment\n\
+                    +++i;\n";
+        let result = compact_diff(diff, 100);
+
+        assert!(
+            result.lines().any(|l| l == "--- sql comment"),
+            "deleted SQL comment must survive, got:\n{}",
+            result
+        );
+        assert!(
+            result.lines().any(|l| l == "+++i;"),
+            "added `++i;` must survive, got:\n{}",
+            result
+        );
+        assert!(result.contains("  +1 -1"), "tally must count both, got:\n{}", result);
+    }
+
+    #[test]
+    fn test_compact_diff_leading_context_has_its_own_budget() {
+        // Leading context must not consume the 100-line change budget: a hunk
+        // opening with more context than the budget still shows every change.
+        let mut diff = String::from("diff --git a/f.rs b/f.rs\n@@ -1,120 +1,120 @@\n");
+        for i in 0..20 {
+            diff.push_str(&format!(" ctx{}\n", i));
+        }
+        for i in 0..100 {
+            diff.push_str(&format!("-del{}\n", i));
+        }
+        let result = compact_diff(&diff, 1000);
+
+        let ctx = result.lines().filter(|l| l.starts_with(" ctx")).count();
+        let dels = result.lines().filter(|l| l.starts_with("-del")).count();
+        assert_eq!(ctx, 3, "leading context is capped, got:\n{}", result);
+        assert_eq!(dels, 100, "every change must still be shown, got:\n{}", result);
+        assert!(
+            !result.contains("truncated"),
+            "no change was dropped, got:\n{}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_compact_diff_truncation_note_splits_by_sign() {
+        // An anchored `^-` audit needs to know how many deletions it did not
+        // see, which a merged "N lines truncated" cannot tell it.
+        let mut diff = String::from("diff --git a/f.rs b/f.rs\n@@ -1,160 +1,160 @@\n");
+        for i in 0..80 {
+            diff.push_str(&format!("-del{}\n", i));
+            diff.push_str(&format!("+add{}\n", i));
+        }
+        let result = compact_diff(&diff, 1000);
+
+        assert!(
+            result.contains("  ... (30 deletions, 30 additions truncated)"),
+            "expected per-sign truncation note, got:\n{}",
+            result
+        );
     }
 
     #[test]
@@ -3641,8 +3735,8 @@ no changes added to commit (use "git add" and/or "git commit -a")
         }
         let result = compact_diff(&diff, 500);
         assert!(
-            result.contains("50 lines truncated"),
-            "Expected '50 lines truncated' (150 - 100 = 50), got:\n{}",
+            result.contains("50 additions truncated"),
+            "Expected '50 additions truncated' (150 - 100 = 50), got:\n{}",
             result
         );
     }

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -335,6 +335,17 @@ fn is_blob_show_arg(arg: &str) -> bool {
     !arg.starts_with('-') && arg.contains(':')
 }
 
+/// Path named by a diff section header.
+///
+/// `diff --git a/p b/p` carries the path twice; `diff --cc p` and
+/// `diff --combined p` carry it once, at the end.
+fn diff_header_path(line: &str) -> String {
+    match line.split(" b/").nth(1) {
+        Some(path) => path.to_string(),
+        None => line.rsplit(' ').next().unwrap_or("unknown").to_string(),
+    }
+}
+
 /// Render the note for change lines dropped past `max_hunk_lines`, split by
 /// sign so an anchored `^-` / `^+` audit can tell what it did not see.
 fn hunk_truncation_note(deletions: usize, additions: usize) -> Option<String> {
@@ -359,14 +370,23 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
     let mut skipped_add = 0usize;
     let mut skipped_del = 0usize;
     let mut leading_context = 0usize;
+    let mut leading_context_total = 0usize;
     let max_hunk_lines = 100;
-    // Context before a hunk's first change gets its own budget so it cannot
-    // crowd the change itself out of `max_hunk_lines`.
+    // Context before a hunk's first change, up to three lines per hunk and
+    // `max_lines / 10` across the diff. It does not count against `max_lines`,
+    // so it cannot displace change lines, and the diff-wide cap is what bounds
+    // the overrun that exemption would otherwise allow: a diff of many small
+    // hunks would otherwise spend three exempt lines on every one of them.
     let max_leading_context = 3;
+    let leading_context_cap = max_lines / 10;
     let mut was_truncated = false;
 
     for line in diff.lines() {
-        if line.starts_with("diff --git") {
+        // `diff --cc` / `diff --combined` head the sections git emits for
+        // unmerged paths. Matching only `diff --git` left `in_hunk` set from
+        // the previous section, so the `---` / `+++` headers of every combined
+        // section after the first were counted and printed as hunk content.
+        if line.starts_with("diff --") {
             // Flush hunk truncation before starting a new file
             if let Some(note) = hunk_truncation_note(skipped_del, skipped_add) {
                 result.push(note);
@@ -377,7 +397,7 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
             if !current_file.is_empty() && (added > 0 || removed > 0) {
                 result.push(format!("  +{} -{}", added, removed));
             }
-            current_file = line.split(" b/").nth(1).unwrap_or("unknown").to_string();
+            current_file = diff_header_path(line);
             result.push(format!("\n{}", current_file));
             added = 0;
             removed = 0;
@@ -427,14 +447,17 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
                         result.push(line.to_string());
                         hunk_shown += 1;
                     }
-                } else if leading_context < max_leading_context {
+                } else if leading_context < max_leading_context
+                    && leading_context_total < leading_context_cap
+                {
                     result.push(line.to_string());
                     leading_context += 1;
+                    leading_context_total += 1;
                 }
             }
         }
 
-        if result.len() >= max_lines {
+        if result.len() - leading_context_total >= max_lines {
             result.push("\n... (more changes truncated)".to_string());
             was_truncated = true;
             break;
@@ -2525,6 +2548,100 @@ mod tests {
         assert!(
             !result.contains("truncated"),
             "no change was dropped, got:\n{}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_compact_diff_combined_diff_headers_are_not_hunk_content() {
+        // `diff --cc` sections (unmerged paths during a merge / rebase /
+        // cherry-pick / stash pop) do not match `diff --git`, so `in_hunk`
+        // stayed true from the previous section and the `---` / `+++` headers
+        // of every later file were printed at column 0 and counted.
+        let diff = "diff --cc a.txt\n\
+                    index ba2906d,e45c9c2..0000000\n\
+                    --- a/a.txt\n\
+                    +++ b/a.txt\n\
+                    @@@ -1,1 -1,1 +1,5 @@@\n\
+                    ++<<<<<<< HEAD\n\
+                    \x20+main\n\
+                    diff --cc z.txt\n\
+                    index ba2906d,e45c9c2..0000000\n\
+                    --- a/z.txt\n\
+                    +++ b/z.txt\n\
+                    @@@ -1,1 -1,1 +1,5 @@@\n\
+                    ++<<<<<<< HEAD\n\
+                    \x20+main\n";
+        let result = compact_diff(diff, 500);
+
+        let removed: Vec<&str> = result.lines().filter(|l| l.starts_with('-')).collect();
+        assert!(
+            removed.is_empty(),
+            "no deletions in this diff, got {:?} in:\n{}",
+            removed,
+            result
+        );
+        assert!(
+            !result.lines().any(|l| l.starts_with("+++ b/")),
+            "file headers must not reach the hunk body, got:\n{}",
+            result
+        );
+        assert!(result.contains("z.txt"), "got:\n{}", result);
+    }
+
+    #[test]
+    fn test_compact_diff_leading_context_does_not_displace_change_lines() {
+        // Leading context is exempt from `max_lines`, so the same number of
+        // change lines survives whether or not the hunks open with context.
+        let build = |with_context: bool| {
+            let mut diff = String::new();
+            for f in 0..30 {
+                diff.push_str(&format!("diff --git a/f{}.rs b/f{}.rs\n", f, f));
+                diff.push_str("@@ -1,20 +1,20 @@\n");
+                if with_context {
+                    for c in 0..3 {
+                        diff.push_str(&format!(" ctx{}_{}\n", f, c));
+                    }
+                }
+                for i in 0..12 {
+                    diff.push_str(&format!("-del{}_{}\n", f, i));
+                }
+            }
+            diff
+        };
+        let count_changes =
+            |out: &str| out.lines().filter(|l| l.starts_with("-del")).count();
+
+        let without = compact_diff(&build(false), 500);
+        let with = compact_diff(&build(true), 500);
+        assert_eq!(
+            count_changes(&with),
+            count_changes(&without),
+            "leading context displaced change lines:\n{}",
+            with
+        );
+    }
+
+    #[test]
+    fn test_compact_diff_leading_context_is_capped_across_the_diff() {
+        // The diff-wide cap is what bounds the exemption: without it, a diff of
+        // many small hunks would spend three exempt lines on each one.
+        let mut diff = String::new();
+        for f in 0..200 {
+            diff.push_str(&format!("diff --git a/f{}.rs b/f{}.rs\n", f, f));
+            diff.push_str("@@ -1,4 +1,4 @@\n");
+            for c in 0..3 {
+                diff.push_str(&format!(" ctx{}_{}\n", f, c));
+            }
+            diff.push_str(&format!("-del{}\n", f));
+        }
+        let result = compact_diff(&diff, 500);
+
+        let ctx = result.lines().filter(|l| l.starts_with(" ctx")).count();
+        assert!(
+            ctx <= 50,
+            "leading context must stay within max_lines / 10, got {} in:\n{}",
+            ctx,
             result
         );
     }

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -338,23 +338,86 @@ fn is_blob_show_arg(arg: &str) -> bool {
 /// Path named by a diff section header.
 ///
 /// `diff --git a/p b/p` carries the path twice; `diff --cc p` and
-/// `diff --combined p` carry it once, as the whole remainder of the line. git
-/// does not quote spaces in these headers, so the remainder is taken as-is.
+/// `diff --combined p` carry it once, as the whole remainder of the line.
+///
+/// Under the default `core.quotepath`, git wraps a path in `"` and escapes it
+/// when it holds a non-ASCII byte, a control character or a quote — but not
+/// when it merely holds a space. So the separator is ` b/` for a plain path and
+/// ` "b/` for a quoted one, and a path with a space in it needs neither form
+/// handled specially.
 fn diff_header_path(line: &str) -> String {
+    if let Some(path) = line
+        .split(" \"b/")
+        .nth(1)
+        .and_then(|rest| rest.strip_suffix('"'))
+    {
+        return path.to_string();
+    }
     match line.split(" b/").nth(1) {
         Some(path) => path.to_string(),
-        None => line.splitn(3, ' ').nth(2).unwrap_or("unknown").to_string(),
+        None => {
+            let rest = line.splitn(3, ' ').nth(2).unwrap_or("unknown");
+            // A single-path header (`diff --cc`) carries the quoting too.
+            rest.strip_prefix('"')
+                .and_then(|r| r.strip_suffix('"'))
+                .unwrap_or(rest)
+                .to_string()
+        }
     }
 }
 
 /// Line budget a hunk header declares, and how wide its body prefix is.
 struct HunkHeader {
-    /// Lines the hunk spans in the first parent.
-    old: usize,
+    /// Lines the hunk spans in each parent, in marker-column order. One entry
+    /// for a unified `@@`, one per parent for a combined `@@@`.
+    parents: Vec<usize>,
     /// Lines the hunk spans in the result file.
     new: usize,
     /// Marker columns: 1 for `@@`, and one per parent for a combined `@@@`.
     prefix_width: usize,
+}
+
+impl HunkHeader {
+    /// Whether every declared line has been accounted for, which is where the
+    /// hunk body ends. A combined hunk is not done until *every* parent's
+    /// budget is spent: a line removed from only the second parent spends that
+    /// parent's budget and neither the first's nor the result's.
+    fn exhausted(&self) -> bool {
+        self.new == 0 && self.parents.iter().all(|&remaining| remaining == 0)
+    }
+
+    /// Charge a body line against the budgets it occupies.
+    ///
+    /// Column `i` is the line's marker against parent `i + 1`. `-` there means
+    /// the line is in that parent and is being removed; a space on a line that
+    /// is not a removal means the line is in that parent unchanged. Both spend
+    /// one of that parent's lines. `+` there, or a space on a removal line,
+    /// means the line is not in that parent at all.
+    ///
+    /// Collapsing the columns into one add/delete pair, as an aggregate over
+    /// the whole prefix does, loses that distinction and leaves a combined
+    /// hunk's budget unable to converge.
+    fn consume(&mut self, markers: &[u8]) {
+        let is_add = markers.contains(&b'+');
+        let is_del = markers.contains(&b'-');
+        for (i, remaining) in self.parents.iter_mut().enumerate() {
+            let column = markers.get(i).copied();
+            let present = if is_del {
+                column == Some(b'-')
+            } else {
+                // A line shorter than the prefix reads as context, which is
+                // what a bare blank line in a unified diff body is.
+                column != Some(b'+')
+            };
+            if present {
+                *remaining = remaining.saturating_sub(1);
+            }
+        }
+        // In the result file unless the line is a pure deletion.
+        if is_add || !is_del {
+            self.new = self.new.saturating_sub(1);
+        }
+    }
 }
 
 /// Parse `@@ -a,b +c,d @@` and the combined `@@@ -a,b -c,d +e,f @@@`.
@@ -371,7 +434,7 @@ fn parse_hunk_header(line: &str) -> Option<HunkHeader> {
     }
     let body = line[at_run..].split('@').next()?;
 
-    let mut old = None;
+    let mut parents = Vec::new();
     let mut new = None;
     for group in body.split_whitespace() {
         let Some(rest) = group.strip_prefix(['-', '+']) else {
@@ -382,16 +445,16 @@ fn parse_hunk_header(line: &str) -> Option<HunkHeader> {
             None => 1,
         };
         if group.starts_with('-') {
-            // A combined header lists one range per parent; the first is the
-            // one whose line numbers the `-` column tracks.
-            old.get_or_insert(count);
+            // A combined header lists one range per parent, in the same order
+            // as the marker columns.
+            parents.push(count);
         } else {
             new = Some(count);
         }
     }
 
     Some(HunkHeader {
-        old: old.unwrap_or(0),
+        parents,
         new: new.unwrap_or(0),
         // `@@` has one marker column, `@@@` two, and so on for more parents.
         prefix_width: at_run - 1,
@@ -410,6 +473,27 @@ fn hunk_truncation_note(deletions: usize, additions: usize) -> Option<String> {
             d, a
         )),
     }
+}
+
+/// Emit the buffered leading context, charged against the diff-wide budget.
+///
+/// Keeps the lines closest to the change when the budget cannot take all of
+/// them. Called wherever a hunk closes as well as at its first change line:
+/// context buffered by a hunk that ends without one would otherwise be dropped,
+/// leaving a bare hunk header with nothing under it.
+fn flush_leading_context(
+    buffer: &mut Vec<String>,
+    result: &mut Vec<String>,
+    total: &mut usize,
+    cap: usize,
+) {
+    let room = cap.saturating_sub(*total);
+    let keep = buffer.len().min(room);
+    let skip = buffer.len() - keep;
+    for ctx in buffer.drain(..).skip(skip) {
+        result.push(ctx);
+    }
+    *total += keep;
 }
 
 pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
@@ -438,6 +522,12 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
         // file and closes any open hunk, so the `---` / `+++` headers that
         // follow it are never read as hunk content.
         if line.starts_with("diff --") {
+            flush_leading_context(
+                &mut leading_context,
+                &mut result,
+                &mut leading_context_total,
+                leading_context_cap,
+            );
             if let Some(note) = hunk_truncation_note(skipped_del, skipped_add) {
                 result.push(note);
                 was_truncated = true;
@@ -453,8 +543,13 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
             removed = 0;
             hunk = None;
             hunk_shown = 0;
-            leading_context.clear();
         } else if let Some(header) = parse_hunk_header(line) {
+            flush_leading_context(
+                &mut leading_context,
+                &mut result,
+                &mut leading_context_total,
+                leading_context_cap,
+            );
             if let Some(note) = hunk_truncation_note(skipped_del, skipped_add) {
                 result.push(note);
                 was_truncated = true;
@@ -463,12 +558,11 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
             }
             hunk = Some(header);
             hunk_shown = 0;
-            leading_context.clear();
             // Preserve the full unified diff hunk header, including trailing
             // function / symbol context after the second @@ marker.
             result.push(line.to_string());
         } else if let Some(header) = hunk.as_mut() {
-            if header.old == 0 && header.new == 0 {
+            if header.exhausted() {
                 hunk = None;
                 continue;
             }
@@ -478,16 +572,16 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
                 continue;
             }
 
+            // Slice the marker columns as bytes. `prefix_width` counts columns,
+            // and the markers are ASCII by construction, but the body content
+            // right after them is not: `--word-diff` emits body lines with no
+            // marker column at all, so a `char`-unaware `&line[..width]` splits
+            // a leading multi-byte character and panics.
             let width = header.prefix_width.min(line.len());
-            let markers = &line[..width];
-            // A combined diff carries one marker column per parent, so a line
-            // changed against only one of them has its marker in column 2.
-            let is_add = markers.contains('+');
-            let is_del = markers.contains('-');
-            // Present in the result file unless it is a pure deletion, and in
-            // the first parent unless it is a pure addition.
-            header.new = header.new.saturating_sub(if is_del && !is_add { 0 } else { 1 });
-            header.old = header.old.saturating_sub(if is_add && !is_del { 0 } else { 1 });
+            let markers = &line.as_bytes()[..width];
+            let is_add = markers.contains(&b'+');
+            let is_del = markers.contains(&b'-');
+            header.consume(markers);
 
             // Hunk bodies emit at column 0 in git's own unified shape, so
             // `^+` / `^-` anchor. rtk's own annotations stay indented so those
@@ -504,15 +598,14 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
                 if hunk_shown < max_hunk_lines {
                     // The context immediately preceding the change, so the body
                     // reads as contiguous with it. The diff-wide budget is
-                    // charged here rather than on buffering, so a line the ring
-                    // evicted never costs anything.
-                    let room = leading_context_cap.saturating_sub(leading_context_total);
-                    let keep = leading_context.len().min(room);
-                    let skip = leading_context.len() - keep;
-                    for ctx in leading_context.drain(..).skip(skip) {
-                        result.push(ctx);
-                    }
-                    leading_context_total += keep;
+                    // charged on emit rather than on buffering, so a line the
+                    // ring evicted never costs anything.
+                    flush_leading_context(
+                        &mut leading_context,
+                        &mut result,
+                        &mut leading_context_total,
+                        leading_context_cap,
+                    );
                     result.push(line.to_string());
                     hunk_shown += 1;
                 } else if is_del {
@@ -537,8 +630,14 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
                 leading_context.push(line.to_string());
             }
 
-            if header.old == 0 && header.new == 0 {
+            if header.exhausted() {
                 hunk = None;
+                flush_leading_context(
+                    &mut leading_context,
+                    &mut result,
+                    &mut leading_context_total,
+                    leading_context_cap,
+                );
             }
         }
 
@@ -550,6 +649,12 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
     }
 
     // Flush last hunk
+    flush_leading_context(
+        &mut leading_context,
+        &mut result,
+        &mut leading_context_total,
+        leading_context_cap,
+    );
     if let Some(note) = hunk_truncation_note(skipped_del, skipped_add) {
         result.push(note);
         was_truncated = true;
@@ -2771,21 +2876,103 @@ mod tests {
     }
 
     #[test]
+    fn test_diff_header_path_handles_gits_quoted_paths() {
+        // Under the default `core.quotepath`, git escapes a non-ASCII path and
+        // wraps it in quotes, which removes the ` b/` separator the plain form
+        // is split on. Without the quoted form handled, the fallback returned
+        // the whole remainder — both paths — as the section header.
+        assert_eq!(
+            diff_header_path(r#"diff --git "a/Ã©tÃ©.txt" "b/Ã©tÃ©.txt""#),
+            r"Ã©tÃ©.txt"
+        );
+        assert_eq!(
+            diff_header_path(r#"diff --cc "Ã©tÃ©.txt""#),
+            r"Ã©tÃ©.txt"
+        );
+        // A rename quotes each side on its own.
+        assert_eq!(
+            diff_header_path(r#"diff --git a/plain.txt "b/Ã©t.txt""#),
+            r"Ã©t.txt"
+        );
+        assert_eq!(
+            diff_header_path(r#"diff --git "a/Ã©t.txt" b/plain.txt"#),
+            "plain.txt"
+        );
+    }
+
+    #[test]
     fn test_parse_hunk_header_counts() {
         let h = parse_hunk_header("@@ -10,3 +10,4 @@ fn ctx() {").expect("unified header");
-        assert_eq!((h.old, h.new, h.prefix_width), (3, 4, 1));
+        assert_eq!((h.parents.as_slice(), h.new, h.prefix_width), (&[3][..], 4, 1));
 
         // Omitted counts mean one line.
         let h = parse_hunk_header("@@ -1 +1 @@").expect("single-line header");
-        assert_eq!((h.old, h.new), (1, 1));
+        assert_eq!((h.parents.as_slice(), h.new), (&[1][..], 1));
 
-        // A combined header lists one range per parent; `old` tracks the first.
-        let h = parse_hunk_header("@@@ -1,1 -1,1 +1,5 @@@").expect("combined header");
-        assert_eq!((h.old, h.new, h.prefix_width), (1, 5, 2));
+        // A combined header lists one range per parent, in marker-column order.
+        // Every one of them bounds the hunk body.
+        let h = parse_hunk_header("@@@ -1,1 -1,4 +1,5 @@@").expect("combined header");
+        assert_eq!(
+            (h.parents.as_slice(), h.new, h.prefix_width),
+            (&[1, 4][..], 5, 2)
+        );
 
         assert!(parse_hunk_header("@ -1,1 +1,1 @").is_none());
         assert!(parse_hunk_header("-- ").is_none());
         assert!(parse_hunk_header("---").is_none());
+    }
+
+    #[test]
+    fn test_compact_diff_non_ascii_body_line_without_a_marker_does_not_panic() {
+        // `--word-diff` / `--color-words` emit body lines with no marker column,
+        // so content lands where the markers are sliced. Slicing by byte index
+        // split a leading multi-byte character and aborted the process.
+        let out = compact_diff(
+            "diff --git a/f.txt b/f.txt\n@@ -1,3 +1,3 @@\n-old\n+new\nécole ancienne ligne\n",
+            100,
+        );
+        assert!(out.contains("-old"), "got:\n{}", out);
+        assert!(out.contains("+new"), "got:\n{}", out);
+        assert!(out.contains("école ancienne ligne"), "got:\n{}", out);
+    }
+
+    #[test]
+    fn test_compact_diff_combined_hunk_ends_at_its_declared_length() {
+        // Every parent's declared range bounds the body. Charging only the
+        // first parent left `old` unable to converge on real conflict output,
+        // so the hunk never closed by count and the mbox / signature / prose
+        // guard did not apply to combined sections at all.
+        let conflict = "diff --cc f.txt\n@@@ -1,1 -1,1 +1,5 @@@\n++<<<<<<<\n +main\n++=======\n+ side\n++>>>>>>>\n-- \ntrailing signature\n";
+        let out = compact_diff(conflict, 100);
+        assert!(!out.contains("trailing signature"), "got:\n{}", out);
+        assert!(!out.contains("-- "), "got:\n{}", out);
+        assert!(out.contains("+5 -0"), "got:\n{}", out);
+    }
+
+    #[test]
+    fn test_compact_diff_combined_hunk_keeps_second_parent_removals() {
+        // `-1,2 -1,4 +1,2`: two removals spend only the second parent's budget.
+        // Closing on the first parent and the result alone dropped them with no
+        // tally and no truncation note — a silent loss.
+        let out = compact_diff(
+            "diff --cc f.txt\n@@@ -1,2 -1,4 +1,2 @@@\n  a\n  b\n -x\n -y\n",
+            100,
+        );
+        assert!(out.contains(" -x"), "got:\n{}", out);
+        assert!(out.contains(" -y"), "got:\n{}", out);
+        assert!(out.contains("+0 -2"), "got:\n{}", out);
+    }
+
+    #[test]
+    fn test_compact_diff_flushes_context_from_a_hunk_with_no_change_line() {
+        // The buffer drained only on the first change line, so a hunk that ends
+        // without one rendered as a bare header with nothing under it.
+        let out = compact_diff(
+            "diff --git a/g.txt b/g.txt\n@@ -1,3 +1,3 @@\n ctx1\n ctx2\n ctx3\n",
+            100,
+        );
+        assert!(out.contains(" ctx1"), "got:\n{}", out);
+        assert!(out.contains(" ctx3"), "got:\n{}", out);
     }
 
     #[test]

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -605,13 +605,21 @@ fn parse_hunk_header(line: &str) -> Option<HunkHeader> {
 /// Render the note for change lines dropped past `max_hunk_lines`, split by
 /// sign so an anchored `^-` / `^+` audit can tell what it did not see.
 fn hunk_truncation_note(deletions: usize, additions: usize) -> Option<String> {
+    fn count(n: usize, noun: &str) -> String {
+        if n == 1 {
+            format!("{} {}", n, noun)
+        } else {
+            format!("{} {}s", n, noun)
+        }
+    }
     match (deletions, additions) {
         (0, 0) => None,
-        (0, a) => Some(format!("  ... ({} additions truncated)", a)),
-        (d, 0) => Some(format!("  ... ({} deletions truncated)", d)),
+        (0, a) => Some(format!("  ... ({} truncated)", count(a, "addition"))),
+        (d, 0) => Some(format!("  ... ({} truncated)", count(d, "deletion"))),
         (d, a) => Some(format!(
-            "  ... ({} deletions, {} additions truncated)",
-            d, a
+            "  ... ({}, {} truncated)",
+            count(d, "deletion"),
+            count(a, "addition")
         )),
     }
 }
@@ -3312,6 +3320,23 @@ mod tests {
             ctx,
             result
         );
+    }
+
+    #[test]
+    fn test_hunk_truncation_note_counts_one_as_singular() {
+        assert_eq!(
+            hunk_truncation_note(1, 0).as_deref(),
+            Some("  ... (1 deletion truncated)")
+        );
+        assert_eq!(
+            hunk_truncation_note(0, 1).as_deref(),
+            Some("  ... (1 addition truncated)")
+        );
+        assert_eq!(
+            hunk_truncation_note(1, 2).as_deref(),
+            Some("  ... (1 deletion, 2 additions truncated)")
+        );
+        assert_eq!(hunk_truncation_note(0, 0), None);
     }
 
     #[test]


### PR DESCRIPTION
A grep anchored to the start of a line finds nothing in `rtk git diff` output:

```
raw:  git diff | grep -c "^-"   -> 3
rtk:  git diff | grep -c "^-"   -> 0
```

`compact_diff` indents every hunk-body line two spaces to nest it under the filename (`format!("  {}", line)`), which moves the content off column 0 and breaks the `^` anchor.

Two things worth stating precisely, because both were initially diagnosed wrong on our side:

- **Nothing is dropped.** The content is on screen the whole time, and `--stat` plus the per-file `+N -M` tally report accurately. `grep -c DELETED_LINE_A` (unanchored) returns 1 both raw and filtered. It is a rendering issue, not data loss.
- **It is not deletion-specific.** `^+` breaks identically — measured raw `^-`=3 / `^+`=2 versus rtk `^-`=0 / `^+`=0. There is no `+`/`-` asymmetry.

The cost is a silent false negative for any anchored grep over a diff: auditing "was a test expectation weakened" with `git diff tests/ | grep "^-"` returns empty while `--stat` reports deletions in the same range, and empty is exactly the answer that ends the investigation.

**Fix:** hunk bodies emit at column 0 in git's own unified shape. rtk's own annotations keep the indent, so the same greps never count them as diff lines.

After:

```
rtk:  git diff | grep -c "^-"   -> 2
```

2 is the exact deletion count; raw's 3 includes the `--- a/f.txt` header, so the piped grep was never a correct count even unfiltered.

## What the anchored audit does and does not promise

Review surfaced three holes in the original "`grep -c '^-'` gives you the exact deletion count" claim. All three are closed, two by fixing the code and one by stating the limit here.

**Content that looks like a file header.** The `+++` / `---` guards ran inside the hunk-body branch, where they can only match content: git emits the file headers before the first `@@`. So an added `++i;` or a removed `-- sql comment` was dropped from the body *and* left out of the tally, and a diff doing both rendered as a bare hunk header with nothing under it. The guards are gone.

**Combined diffs.** `diff --cc` sections, which git emits for unmerged paths during a merge, rebase, cherry-pick, or stash pop, never matched the `diff --git` reset, so `in_hunk` stayed set across sections and the `---` / `+++` headers of every file after the first reached the body. Once hunk bodies emit at column 0, those headers anchor too: a two-file conflict with zero deletions returned `^-` = 1. The reset fires on any `diff --` prefix now, so the headers land before the first `@@` again and the same repo returns 0.

**Combined diffs put the marker in column 2.** `diff --cc` carries one marker column per parent, so a line changed against only one of them (` +ours`, ` -theirs`) does not anchor. It is counted in the `+N -M` tally now, but `grep "^+"` cannot see it without rewriting the line, so `docs/usage/FEATURES.md` states the limit next to the others. Against `git diff --numstat` on three complete commit ranges the tally is exact.

**Past 100 change lines in a hunk, the count plateaus.** A 300-deletion hunk yields `grep -c "^-"` = 100 while the tally correctly says `+300 -300`. The truncation note carries the remainder and is split by sign — `... (200 deletions truncated)` — but it is indented by design, so the anchored grep cannot see it. If you gate CI on `grep -c "^-"`, gate on the `+N -M` tally instead, or pass `--no-compact`.

Two notes on the budgets. Exempting leading context from `max_lines` makes it a soft cap: output can exceed it by up to 10%, so the `git stash show -p` call site that passes 100 can see 110. Separately, and pre-existing on `develop`, the previous file's tally and the next file's header are pushed before the budget is checked, so a many-file diff can carry two entries past `max_lines`. And a hunk now ends when the line counts in its `@@` header are consumed, so trailing text after a diff — an mbox envelope, a `-- ` signature, prose — is outside every hunk rather than read as its body. `gh pr diff --patch` additionally passes through unfiltered: GitHub's `.patch` is an mbox, not a unified diff.

**A hunk's declared length is per parent, and a combined hunk spends one budget per marker column.** In a combined diff a space means opposite things depending on the line: on a change line the line is in that parent unchanged, on a removal line it is absent from it. Collapsing the columns into one add/delete pair lost that, so the first parent's budget never converged on real conflict output and the hunk never closed by count — everything above about keeping envelopes and signatures out of the body silently did not apply to `diff --cc`, which is what git emits for every unmerged path. The reverse case closed early and dropped the body: `@@@ -1,2 -1,4 +1,2 @@@` over two removals from the second parent alone rendered as a bare hunk header, with no tally and no truncation note. A header whose range count disagrees with its column count is reconciled against the columns, since only a column can be charged.

**Word diffs pass through unfiltered.** `--word-diff`, `--word-diff-regex` and `--color-words` drop the marker column and put `[-removed-]` / `{+added+}` inline, so a body line is arbitrary content in the position the compactor reads as a marker. Slicing those bytes as bytes rather than as a `str` fixes the crash on a leading multi-byte character — `rtk git diff --word-diff` exited 101 with empty stdout — but not the misparse: a row starting `+` counts as an addition and spends the wrong budget, one starting `\` is dropped as a no-newline annotation, and a real `git show --word-diff=plain` row reading `diff --git [-a/src/main.rs...` opens a new file section. There is no faithful compaction of a word diff, so `run_diff`, `run_show` and `git stash show -p` hand these modes straight through. `rtk pipe --filter git-diff` has no flags to read and still misparses word-diff text piped into it; `compact_diff` reads a unified or combined diff, and that is now what its callers give it.

**Section paths are read without guessing at the separator.** Under the default `core.quotepath` git escapes a non-ASCII path and wraps it in `"`, which removes the ` b/` the plain form splits on, so the fallback returned both paths as the section header. And ` b/` is not a reliable separator anyway: it appears inside the path for a file under a directory named `x b`, and `--no-prefix` or a custom `--src-prefix` leaves none at all. Anything but a rename names the same path twice, so the halves are the same length and the separating space sits dead centre; splitting there covers all of those and does not care what the prefixes are. A rename's halves differ in length and fall through to the ` b/` split, which names the destination.

Leading context is also emitted now. It was silently dropped before the first `+` or `-` of each hunk, which contradicted the "nothing is dropped" claim above. It keeps the last three lines before the change rather than the first, so the body is contiguous with it under `-U10` or `--function-context`, and is capped at `max_lines / 10` across the diff and exempt from `max_lines` so it cannot displace change lines. On a five-commit diff of this repo it costs 0.1 points of byte reduction against master (71.7% versus 71.8%) while taking anchorable change lines from 0 to 201.

This does not make the output an applyable patch — rtk still drops the `diff --git` / `---` / `+++` headers, so a patch parser rejects it regardless. Use `rtk proxy git diff` when you need a faithful patch. The indent was never what made that case fail.

`docs/usage/FEATURES.md` is updated to real captured output; its illustration showed change lines indented under a `src/main.rs (+5/-2)` header that no version of rtk emits.

## Testing

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all` are clean on this branch, apart from two `hooks::rewrite_cmd::tests::unattestable_passthrough` failures that reproduce with this branch's changes stashed and that it does not touch. `cmds::git::git` is 119 tests.

Ordinary unified diffs come out byte-identical to the previous head: checked on a 26,561-line real diff of this repo, on a 390-line one, and on a 300-case generated corpus covering additions, deletions, replacements, empty rows, Unicode content, leading `+` / `-` / `\`, multiple hunks and multiple files. The one intentional divergence is a hunk that ends without a change line, which now emits its buffered context instead of a bare header.


