### PR TITLE
fix(exec): report a missing binary as command-not-found, exit 127

### DIFF
--- a/src/analytics/ccusage.rs
+++ b/src/analytics/ccusage.rs
@@ -98,12 +98,13 @@ fn binary_exists() -> bool {
 /// Build the ccusage command, falling back to npx if binary not in PATH
 fn build_command() -> Option<Command> {
     if binary_exists() {
-        return Some(resolved_command("ccusage"));
+        return resolved_command("ccusage").ok();
     }
 
     // Fallback: try npx
     eprintln!("[info] ccusage not installed globally, fetching via npx...");
     let npx_check = resolved_command("npx")
+        .ok()?
         .arg("--yes")
         .arg("ccusage")
         .arg("--help")
@@ -112,7 +113,7 @@ fn build_command() -> Option<Command> {
         .status();
 
     if npx_check.map(|s| s.success()).unwrap_or(false) {
-        let mut cmd = resolved_command("npx");
+        let mut cmd = resolved_command("npx").ok()?;
         cmd.arg("--yes");
         cmd.arg("ccusage");
         return Some(cmd);

--- a/src/cmds/cloud/aws_cmd.rs
+++ b/src/cmds/cloud/aws_cmd.rs
@@ -220,7 +220,7 @@ fn is_structured_operation(args: &[String]) -> bool {
 fn run_generic(subcommand: &str, args: &[String], verbose: u8, full_sub: &str) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
-    let mut cmd = resolved_command("aws");
+    let mut cmd = resolved_command("aws")?;
     cmd.arg(subcommand);
 
     let mut has_output_flag = false;
@@ -285,7 +285,7 @@ fn run_aws_json(
     extra_args: &[String],
     verbose: u8,
 ) -> Result<(String, String, std::process::ExitStatus)> {
-    let mut cmd = resolved_command("aws");
+    let mut cmd = resolved_command("aws")?;
     for arg in sub_args {
         cmd.arg(arg);
     }
@@ -377,7 +377,7 @@ fn run_aws_filtered(
 fn run_s3_ls(extra_args: &[String], verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
-    let mut cmd = resolved_command("aws");
+    let mut cmd = resolved_command("aws")?;
     cmd.args(["s3", "ls"]);
     for arg in extra_args {
         cmd.arg(arg);
@@ -425,7 +425,7 @@ fn run_s3_transfer(operation: &str, extra_args: &[String], verbose: u8) -> Resul
     let rtk_label = format!("rtk aws s3 {}", operation);
     let slug = format!("aws_s3_{}", operation);
 
-    let mut cmd = resolved_command("aws");
+    let mut cmd = resolved_command("aws")?;
     cmd.args(["s3", operation]);
     for arg in extra_args {
         cmd.arg(arg);

--- a/src/cmds/cloud/container.rs
+++ b/src/cmds/cloud/container.rs
@@ -58,7 +58,7 @@ where
 fn docker_ps(_verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
-    let base = exec_capture(resolved_command("docker").args(["ps"]))
+    let base = exec_capture(resolved_command("docker")?.args(["ps"]))
         .context("Failed to run docker ps")?;
     if !base.success() {
         eprint!("{}", base.stderr);
@@ -68,7 +68,7 @@ fn docker_ps(_verbose: u8) -> Result<i32> {
     }
     let raw = base.stdout;
 
-    let stdout = match exec_capture(resolved_command("docker").args([
+    let stdout = match exec_capture(resolved_command("docker")?.args([
         "ps",
         "--format",
         "{{.ID}}\t{{.Names}}\t{{.Status}}\t{{.Image}}\t{{.Ports}}",
@@ -114,7 +114,7 @@ fn docker_ps(_verbose: u8) -> Result<i32> {
 fn docker_ps_all(_verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
-    let base = exec_capture(resolved_command("docker").args(["ps", "-a"]))
+    let base = exec_capture(resolved_command("docker")?.args(["ps", "-a"]))
         .context("Failed to run docker ps -a")?;
     if !base.success() {
         eprint!("{}", base.stderr);
@@ -124,7 +124,7 @@ fn docker_ps_all(_verbose: u8) -> Result<i32> {
     }
     let raw = base.stdout;
 
-    let stdout = match exec_capture(resolved_command("docker").args([
+    let stdout = match exec_capture(resolved_command("docker")?.args([
         "ps",
         "-a",
         "--format",
@@ -230,7 +230,7 @@ fn format_container_line_from_parts(parts: &[&str], with_ports: bool) -> Option<
 fn docker_images(_verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
-    let base = exec_capture(resolved_command("docker").args(["images"]))
+    let base = exec_capture(resolved_command("docker")?.args(["images"]))
         .context("Failed to run docker images")?;
     if !base.success() {
         eprint!("{}", base.stderr);
@@ -240,7 +240,7 @@ fn docker_images(_verbose: u8) -> Result<i32> {
     }
     let raw = base.stdout;
 
-    let stdout = match exec_capture(resolved_command("docker").args([
+    let stdout = match exec_capture(resolved_command("docker")?.args([
         "images",
         "--format",
         "{{.Repository}}:{{.Tag}}\t{{.Size}}",
@@ -326,7 +326,7 @@ fn docker_logs(args: &[String], _verbose: u8) -> Result<i32> {
         return Ok(0);
     }
 
-    let mut cmd = resolved_command("docker");
+    let mut cmd = resolved_command("docker")?;
     cmd.args(["logs", "--tail", "100", container]);
 
     let label = format!("logs {}", container);
@@ -346,7 +346,7 @@ fn docker_logs(args: &[String], _verbose: u8) -> Result<i32> {
 }
 
 pub fn k8s_pods(tool: &str, args: &[String], _verbose: u8) -> Result<i32> {
-    let mut cmd = resolved_command(tool);
+    let mut cmd = resolved_command(tool)?;
     cmd.args(["get", "pods", "-o", "json"]);
     for arg in args {
         cmd.arg(arg);
@@ -432,7 +432,7 @@ fn format_kubectl_pods(json: &Value) -> String {
 }
 
 pub fn k8s_services(tool: &str, args: &[String], _verbose: u8) -> Result<i32> {
-    let mut cmd = resolved_command(tool);
+    let mut cmd = resolved_command(tool)?;
     cmd.args(["get", "services", "-o", "json"]);
     for arg in args {
         cmd.arg(arg);
@@ -499,7 +499,7 @@ pub fn k8s_logs(tool: &str, args: &[String], _verbose: u8) -> Result<i32> {
         return Ok(0);
     }
 
-    let mut cmd = resolved_command(tool);
+    let mut cmd = resolved_command(tool)?;
     cmd.args(["logs", "--tail", "100", pod]);
     for arg in args.iter().skip(1) {
         cmd.arg(arg);
@@ -679,7 +679,7 @@ pub fn run_compose_ps(all: bool, verbose: u8) -> Result<i32> {
     if all {
         raw_args.push("-a");
     }
-    let raw_result = exec_capture(resolved_command("docker").args(&raw_args))
+    let raw_result = exec_capture(resolved_command("docker")?.args(&raw_args))
         .context("Failed to run docker compose ps")?;
 
     if !raw_result.success() {
@@ -693,7 +693,7 @@ pub fn run_compose_ps(all: bool, verbose: u8) -> Result<i32> {
         format_args.push("-a");
     }
     format_args.extend(["--format", "{{.Name}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}"]);
-    let result = exec_capture(resolved_command("docker").args(&format_args))
+    let result = exec_capture(resolved_command("docker")?.args(&format_args))
         .context("Failed to run docker compose ps --format")?;
 
     if !result.success() {
@@ -716,7 +716,7 @@ pub fn run_compose_ps(all: bool, verbose: u8) -> Result<i32> {
 }
 
 pub fn run_compose_logs(service: Option<&str>, tail: u32, verbose: u8) -> Result<i32> {
-    let mut cmd = resolved_command("docker");
+    let mut cmd = resolved_command("docker")?;
     let tail_str = tail.to_string();
     cmd.args(["compose", "logs", "--tail", &tail_str]);
     if let Some(svc) = service {
@@ -739,7 +739,7 @@ pub fn run_compose_logs(service: Option<&str>, tail: u32, verbose: u8) -> Result
 }
 
 pub fn run_compose_build(service: Option<&str>, verbose: u8) -> Result<i32> {
-    let mut cmd = resolved_command("docker");
+    let mut cmd = resolved_command("docker")?;
     cmd.args(["compose", "build"]);
     if let Some(svc) = service {
         cmd.arg(svc);

--- a/src/cmds/cloud/curl_cmd.rs
+++ b/src/cmds/cloud/curl_cmd.rs
@@ -22,7 +22,7 @@ const MAX_RESPONSE_SIZE: usize = 500;
 
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
-    let mut cmd = resolved_command("curl");
+    let mut cmd = resolved_command("curl")?;
     cmd.arg("-s"); // Silent mode (no progress bar)
 
     for arg in args {

--- a/src/cmds/cloud/psql_cmd.rs
+++ b/src/cmds/cloud/psql_cmd.rs
@@ -25,7 +25,7 @@ static RECORD_HEADER: LazyLock<Regex> =
 // - On success: tracking raw includes stderr (previously stdout-only, but stderr is empty on success)
 // - Tee hint uses merged stdout+stderr as raw (was stdout-only)
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
-    let mut cmd = resolved_command("psql");
+    let mut cmd = resolved_command("psql")?;
     for arg in args {
         cmd.arg(arg);
     }

--- a/src/cmds/cloud/wget_cmd.rs
+++ b/src/cmds/cloud/wget_cmd.rs
@@ -21,7 +21,7 @@ pub fn run(url: &str, args: &[String], verbose: u8) -> Result<i32> {
     }
     cmd_args.push(url);
 
-    let mut cmd = resolved_command("wget");
+    let mut cmd = resolved_command("wget")?;
     cmd.args(&cmd_args);
     let result = exec_capture(&mut cmd).context("Failed to run wget")?;
 
@@ -65,7 +65,7 @@ pub fn run_stdout(url: &str, args: &[String], verbose: u8) -> Result<i32> {
     }
     cmd_args.push(url);
 
-    let mut cmd = resolved_command("wget");
+    let mut cmd = resolved_command("wget")?;
     cmd.args(&cmd_args);
     let result = exec_capture(&mut cmd).context("Failed to run wget")?;
 

--- a/src/cmds/dotnet/dotnet_cmd.rs
+++ b/src/cmds/dotnet/dotnet_cmd.rs
@@ -36,7 +36,7 @@ pub fn run_restore(args: &[String], verbose: u8) -> Result<i32> {
 pub fn run_format(args: &[String], verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
     let (report_path, cleanup_report_path) = resolve_format_report_path(args);
-    let mut cmd = resolved_command("dotnet");
+    let mut cmd = resolved_command("dotnet")?;
     cmd.env(DOTNET_CLI_UI_LANGUAGE, DOTNET_CLI_UI_LANGUAGE_VALUE);
     cmd.arg("format");
 
@@ -82,7 +82,7 @@ pub fn run_passthrough(args: &[OsString], verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
     let subcommand = args[0].to_string_lossy().to_string();
 
-    let mut cmd = resolved_command("dotnet");
+    let mut cmd = resolved_command("dotnet")?;
     cmd.env(DOTNET_CLI_UI_LANGUAGE, DOTNET_CLI_UI_LANGUAGE_VALUE);
     cmd.arg(&subcommand);
     for arg in &args[1..] {
@@ -119,7 +119,7 @@ fn run_dotnet_with_binlog(subcommand: &str, args: &[String], verbose: u8) -> Res
     // For test commands, prefer user-provided results directory; otherwise create isolated one.
     let (trx_results_dir, cleanup_trx_results_dir) = resolve_trx_results_dir(subcommand, args);
 
-    let mut cmd = resolved_command("dotnet");
+    let mut cmd = resolved_command("dotnet")?;
     cmd.env(DOTNET_CLI_UI_LANGUAGE, DOTNET_CLI_UI_LANGUAGE_VALUE);
     cmd.arg(subcommand);
 

--- a/src/cmds/git/gh_cmd.rs
+++ b/src/cmds/git/gh_cmd.rs
@@ -228,7 +228,7 @@ fn run_pr(args: &[String], verbose: u8, ultra_compact: bool) -> Result<i32> {
 }
 
 fn list_prs(args: &[String], _verbose: u8, ultra_compact: bool) -> Result<i32> {
-    let mut cmd = resolved_command("gh");
+    let mut cmd = resolved_command("gh")?;
     cmd.args([
         "pr",
         "list",
@@ -337,7 +337,7 @@ fn view_pr(args: &[String], _verbose: u8, ultra_compact: bool) -> Result<i32> {
         }
         return run_passthrough_with_extra("gh", &base, &extra_args);
     }
-    let mut cmd = resolved_command("gh");
+    let mut cmd = resolved_command("gh")?;
     cmd.args(["pr", "view"]);
     if let Some(id) = pr_number_opt.as_deref() {
         cmd.arg(id);
@@ -445,7 +445,7 @@ fn format_pr_view(json: &Value, ultra_compact: bool) -> String {
 fn pr_checks(args: &[String], _verbose: u8, _ultra_compact: bool) -> Result<i32> {
     // `gh pr checks` without an identifier defaults to the PR for the current branch.
     let (pr_number_opt, extra_args) = parse_optional_identifier(args);
-    let mut cmd = resolved_command("gh");
+    let mut cmd = resolved_command("gh")?;
     cmd.args(["pr", "checks"]);
     if let Some(id) = pr_number_opt.as_deref() {
         cmd.arg(id);
@@ -509,7 +509,7 @@ fn pr_status(args: &[String], _verbose: u8, _ultra_compact: bool) -> Result<i32>
         return run_passthrough("gh", "pr", &passthrough_args);
     }
 
-    let mut cmd = resolved_command("gh");
+    let mut cmd = resolved_command("gh")?;
     cmd.args(["pr", "status", "--json", pr_status_json_fields()]);
     for arg in args {
         cmd.arg(arg);
@@ -593,7 +593,7 @@ fn run_issue(args: &[String], verbose: u8, ultra_compact: bool) -> Result<i32> {
 }
 
 fn list_issues(args: &[String], _verbose: u8, ultra_compact: bool) -> Result<i32> {
-    let mut cmd = resolved_command("gh");
+    let mut cmd = resolved_command("gh")?;
     cmd.args(["issue", "list", "--json", "number,title,state,author"]);
     for arg in args {
         cmd.arg(arg);
@@ -653,7 +653,7 @@ fn view_issue(args: &[String], _verbose: u8) -> Result<i32> {
         }
         return run_passthrough_with_extra("gh", &base, &extra_args);
     }
-    let mut cmd = resolved_command("gh");
+    let mut cmd = resolved_command("gh")?;
     cmd.args(["issue", "view"]);
     if let Some(id) = issue_number_opt.as_deref() {
         cmd.arg(id);
@@ -716,7 +716,7 @@ fn run_workflow(args: &[String], verbose: u8, ultra_compact: bool) -> Result<i32
 }
 
 fn list_runs(args: &[String], _verbose: u8, ultra_compact: bool) -> Result<i32> {
-    let mut cmd = resolved_command("gh");
+    let mut cmd = resolved_command("gh")?;
     cmd.args([
         "run",
         "list",
@@ -787,7 +787,7 @@ fn view_run(args: &[String], _verbose: u8) -> Result<i32> {
         }
         return run_passthrough_with_extra("gh", &base, &extra_args);
     }
-    let mut cmd = resolved_command("gh");
+    let mut cmd = resolved_command("gh")?;
     cmd.args(["run", "view"]);
     if let Some(id) = run_id_opt.as_deref() {
         cmd.arg(id);
@@ -847,7 +847,7 @@ fn run_repo(args: &[String], _verbose: u8, _ultra_compact: bool) -> Result<i32> 
     if subcommand != "view" {
         return run_passthrough("gh", "repo", args);
     }
-    let mut cmd = resolved_command("gh");
+    let mut cmd = resolved_command("gh")?;
     cmd.arg("repo").arg("view");
     for arg in rest_args {
         cmd.arg(arg);
@@ -881,7 +881,7 @@ fn format_repo_view(json: &Value) -> String {
 }
 
 fn pr_create(args: &[String], _verbose: u8) -> Result<i32> {
-    let mut cmd = resolved_command("gh");
+    let mut cmd = resolved_command("gh")?;
     cmd.args(["pr", "create"]);
     for arg in args {
         cmd.arg(arg);
@@ -936,7 +936,7 @@ fn pr_diff(args: &[String], _verbose: u8) -> Result<i32> {
     if no_compact || has_non_diff_format_flag(&gh_args) {
         return run_passthrough_with_extra("gh", &["pr", "diff"], &gh_args);
     }
-    let mut cmd = resolved_command("gh");
+    let mut cmd = resolved_command("gh")?;
     cmd.args(["pr", "diff"]);
     for arg in gh_args.iter() {
         cmd.arg(arg);
@@ -963,7 +963,7 @@ fn pr_action(action: &str, args: &[String], _verbose: u8) -> Result<i32> {
         .find(|a| !a.starts_with('-'))
         .map(|s| format!("#{}", s))
         .unwrap_or_default();
-    let mut cmd = resolved_command("gh");
+    let mut cmd = resolved_command("gh")?;
     cmd.arg("pr");
     for arg in args {
         cmd.arg(arg);

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -35,12 +35,12 @@ pub enum GitCommand {
 
 /// Create a git Command with global options (e.g. -C, -c, --git-dir, --work-tree)
 /// prepended before any subcommand arguments.
-fn git_cmd(global_args: &[String]) -> Command {
-    let mut cmd = resolved_command("git");
+fn git_cmd(global_args: &[String]) -> Result<Command> {
+    let mut cmd = resolved_command("git")?;
     for arg in global_args {
         cmd.arg(arg);
     }
-    cmd
+    Ok(cmd)
 }
 
 /// Create a git Command for internal parsing that must be locale-stable.
@@ -48,10 +48,11 @@ fn git_cmd(global_args: &[String]) -> Command {
 /// We only use this for non-user-facing parses where RTK depends on git's
 /// English status phrases. User-visible passthrough output keeps the user's
 /// locale.
-fn git_cmd_c_locale(global_args: &[String]) -> Command {
-    let mut cmd = git_cmd(global_args);
+fn git_cmd_c_locale(global_args: &[String]) -> Result<Command> {
+    let mut cmd = git_cmd(global_args)?;
     cmd.env("LC_ALL", "C");
-    cmd
+    Ok(cmd)
+
 }
 
 fn uses_compact_status_path(args: &[String]) -> bool {
@@ -72,15 +73,16 @@ fn uses_compact_status_path(args: &[String]) -> bool {
     saw_branch
 }
 
-fn build_status_command(args: &[String], global_args: &[String]) -> Command {
-    let mut cmd = git_cmd(global_args);
+fn build_status_command(args: &[String], global_args: &[String]) -> Result<Command> {
+    let mut cmd = git_cmd(global_args)?;
     cmd.arg("status");
     if uses_compact_status_path(args) {
         cmd.args(["--porcelain", "-b"]);
     } else {
         cmd.args(args);
     }
-    cmd
+    Ok(cmd)
+
 }
 
 pub fn run(
@@ -130,7 +132,7 @@ fn run_diff(
 
     if wants_stat || !wants_compact {
         // User wants stat or explicitly no compacting - pass through directly
-        let mut cmd = git_cmd(global_args);
+        let mut cmd = git_cmd(global_args)?;
         cmd.arg("diff");
         for arg in args {
             if arg == "--no-compact" {
@@ -159,7 +161,7 @@ fn run_diff(
     }
 
     // Default RTK behavior: stat first, then compacted diff
-    let mut cmd = git_cmd(global_args);
+    let mut cmd = git_cmd(global_args)?;
     cmd.arg("diff").arg("--stat");
 
     for arg in args {
@@ -186,7 +188,7 @@ fn run_diff(
     }
 
     // Now get actual diff but compact it
-    let mut diff_cmd = git_cmd(global_args);
+    let mut diff_cmd = git_cmd(global_args)?;
     diff_cmd.arg("diff");
     for arg in args {
         diff_cmd.arg(arg);
@@ -237,7 +239,7 @@ fn run_show(
     let wants_blob_show = args.iter().any(|arg| is_blob_show_arg(arg));
 
     if wants_stat_only || wants_format || wants_blob_show {
-        let mut cmd = git_cmd(global_args);
+        let mut cmd = git_cmd(global_args)?;
         cmd.arg("show");
         for arg in args {
             cmd.arg(arg);
@@ -264,7 +266,7 @@ fn run_show(
     }
 
     // Get raw output for tracking
-    let mut raw_cmd = git_cmd(global_args);
+    let mut raw_cmd = git_cmd(global_args)?;
     raw_cmd.arg("show");
     for arg in args {
         raw_cmd.arg(arg);
@@ -274,7 +276,7 @@ fn run_show(
         .unwrap_or_default();
 
     // Step 1: one-line commit summary
-    let mut summary_cmd = git_cmd(global_args);
+    let mut summary_cmd = git_cmd(global_args)?;
     summary_cmd.args(["show", "--no-patch", "--pretty=format:%h %s (%ar) <%an>"]);
     for arg in args {
         summary_cmd.arg(arg);
@@ -287,7 +289,7 @@ fn run_show(
     let mut printed = summary_result.stdout.trim().to_string();
 
     // Step 2: --stat summary
-    let mut stat_cmd = git_cmd(global_args);
+    let mut stat_cmd = git_cmd(global_args)?;
     stat_cmd.args(["show", "--stat", "--pretty=format:"]);
     for arg in args {
         stat_cmd.arg(arg);
@@ -300,7 +302,7 @@ fn run_show(
     }
 
     // Step 3: compacted diff
-    let mut diff_cmd = git_cmd(global_args);
+    let mut diff_cmd = git_cmd(global_args)?;
     diff_cmd.args(["show", "--pretty=format:"]);
     for arg in args {
         diff_cmd.arg(arg);
@@ -433,7 +435,7 @@ fn run_log(
 ) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
-    let mut cmd = git_cmd(global_args);
+    let mut cmd = git_cmd(global_args)?;
     cmd.arg("log");
 
     // Check if user provided format flags
@@ -827,7 +829,7 @@ fn run_status(args: &[String], verbose: u8, global_args: &[String]) -> Result<i3
     // Keep a narrow compact path for no-arg status and branch/short-only flags.
     // More complex explicit args still use the existing minimal-filter path.
     if !uses_compact_status_path(args) {
-        let mut cmd = build_status_command(args, global_args);
+        let mut cmd = build_status_command(args, global_args)?;
         let result = exec_capture(&mut cmd).context("Failed to run git status")?;
 
         if !result.success() {
@@ -862,14 +864,14 @@ fn run_status(args: &[String], verbose: u8, global_args: &[String]) -> Result<i3
         return Ok(0);
     }
 
-    let mut raw_cmd = git_cmd_c_locale(global_args);
+    let mut raw_cmd = git_cmd_c_locale(global_args)?;
     raw_cmd.arg("status");
     raw_cmd.args(args);
     let raw_output = exec_capture(&mut raw_cmd)
         .map(|r| r.stdout)
         .unwrap_or_default();
 
-    let mut cmd = build_status_command(args, global_args);
+    let mut cmd = build_status_command(args, global_args)?;
     let result = exec_capture(&mut cmd).context("Failed to run git status")?;
 
     if !result.success() {
@@ -931,7 +933,7 @@ fn run_status(args: &[String], verbose: u8, global_args: &[String]) -> Result<i3
 fn run_add(args: &[String], verbose: u8, global_args: &[String]) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
-    let mut cmd = git_cmd(global_args);
+    let mut cmd = git_cmd(global_args)?;
     cmd.arg("add");
 
     // Pass all arguments directly to git (flags like -A, -p, --all, etc.)
@@ -953,7 +955,7 @@ fn run_add(args: &[String], verbose: u8, global_args: &[String]) -> Result<i32> 
 
     if result.success() {
         // Count what was added
-        let mut stat_cmd = git_cmd(global_args);
+        let mut stat_cmd = git_cmd(global_args)?;
         stat_cmd.args(["diff", "--cached", "--stat", "--shortstat"]);
         let stat_result = exec_capture(&mut stat_cmd).context("Failed to check staged files")?;
 
@@ -996,13 +998,14 @@ fn run_add(args: &[String], verbose: u8, global_args: &[String]) -> Result<i32> 
     Ok(0)
 }
 
-fn build_commit_command(args: &[String], global_args: &[String]) -> Command {
-    let mut cmd = git_cmd(global_args);
+fn build_commit_command(args: &[String], global_args: &[String]) -> Result<Command> {
+    let mut cmd = git_cmd(global_args)?;
     cmd.arg("commit");
     for arg in args {
         cmd.arg(arg);
     }
-    cmd
+    Ok(cmd)
+
 }
 
 /// Parse the first line of `git commit` success output and return a compact token.
@@ -1032,7 +1035,7 @@ fn run_commit(args: &[String], verbose: u8, global_args: &[String]) -> Result<i3
         eprintln!("{}", original_cmd);
     }
 
-    let output = build_commit_command(args, global_args)
+    let output = build_commit_command(args, global_args)?
         .stdin(Stdio::inherit())
         .output()
         .context("Failed to run git commit")?;
@@ -1090,7 +1093,7 @@ fn run_checkout(args: &[String], verbose: u8, global_args: &[String]) -> Result<
         eprintln!("git checkout");
     }
 
-    let mut cmd = git_cmd(global_args);
+    let mut cmd = git_cmd(global_args)?;
     cmd.arg("checkout");
     for arg in &args {
         cmd.arg(arg);
@@ -1323,7 +1326,7 @@ fn run_push(args: &[String], verbose: u8, global_args: &[String]) -> Result<i32>
         eprintln!("git push");
     }
 
-    let mut cmd = git_cmd(global_args);
+    let mut cmd = git_cmd(global_args)?;
     cmd.arg("push");
     for arg in args {
         cmd.arg(arg);
@@ -1355,7 +1358,7 @@ fn run_pull(args: &[String], verbose: u8, global_args: &[String]) -> Result<i32>
         eprintln!("git pull");
     }
 
-    let mut cmd = git_cmd(global_args);
+    let mut cmd = git_cmd(global_args)?;
     cmd.arg("pull");
     for arg in args {
         cmd.arg(arg);
@@ -1482,7 +1485,7 @@ fn run_branch(args: &[String], verbose: u8, global_args: &[String]) -> Result<i3
 
     // --show-current: passthrough with raw stdout (not "ok")
     if has_show_flag {
-        let mut cmd = git_cmd(global_args);
+        let mut cmd = git_cmd(global_args)?;
         cmd.arg("branch");
         for arg in args {
             cmd.arg(arg);
@@ -1512,7 +1515,7 @@ fn run_branch(args: &[String], verbose: u8, global_args: &[String]) -> Result<i3
 
     // Write operation: action flags, or positional args without list flags (= branch creation)
     if has_action_flag || (has_positional_arg && !has_list_flag) {
-        let mut cmd = git_cmd(global_args);
+        let mut cmd = git_cmd(global_args)?;
         cmd.arg("branch");
         for arg in args {
             cmd.arg(arg);
@@ -1545,7 +1548,7 @@ fn run_branch(args: &[String], verbose: u8, global_args: &[String]) -> Result<i3
     }
 
     // List mode: show compact branch list
-    let mut cmd = git_cmd(global_args);
+    let mut cmd = git_cmd(global_args)?;
     cmd.arg("branch");
     if !has_list_flag {
         cmd.arg("-a");
@@ -1652,7 +1655,7 @@ fn run_fetch(args: &[String], verbose: u8, global_args: &[String]) -> Result<i32
         eprintln!("git fetch");
     }
 
-    let mut cmd = git_cmd(global_args);
+    let mut cmd = git_cmd(global_args)?;
     cmd.arg("fetch");
     for arg in args {
         cmd.arg(arg);
@@ -1722,7 +1725,7 @@ fn run_stash(
 
     match subcommand {
         Some("list") => {
-            let mut cmd = git_cmd(global_args);
+            let mut cmd = git_cmd(global_args)?;
             cmd.args(["stash", "list"]);
             let result = exec_capture(&mut cmd).context("Failed to run git stash list")?;
 
@@ -1747,7 +1750,7 @@ fn run_stash(
         Some("show") => {
             let patch_mode = args.iter().any(|a| a == "-p" || a == "--patch");
 
-            let mut cmd = git_cmd(global_args);
+            let mut cmd = git_cmd(global_args)?;
             cmd.args(["stash", "show"]);
             for arg in args {
                 cmd.arg(arg);
@@ -1773,7 +1776,7 @@ fn run_stash(
         Some("apply") | Some("branch") | Some("clear") | Some("create") | Some("drop")
         | Some("export") | Some("import") | Some("pop") | Some("store") => {
             let sub = subcommand.unwrap();
-            let mut cmd = git_cmd(global_args);
+            let mut cmd = git_cmd(global_args)?;
             cmd.args(["stash", sub]);
             for arg in args {
                 cmd.arg(arg);
@@ -1812,7 +1815,7 @@ fn run_stash(
                 Some(s) => ("push", Some(s)),
                 None => ("push", None),
             };
-            let mut cmd = git_cmd(global_args);
+            let mut cmd = git_cmd(global_args)?;
             cmd.args(["stash", sub]);
             if let Some(arg) = arg {
                 cmd.arg(arg);
@@ -1958,7 +1961,7 @@ fn run_worktree(args: &[String], verbose: u8, global_args: &[String]) -> Result<
     });
 
     if has_action {
-        let mut cmd = git_cmd(global_args);
+        let mut cmd = git_cmd(global_args)?;
         cmd.arg("worktree");
         for arg in args {
             cmd.arg(arg);
@@ -1988,7 +1991,7 @@ fn run_worktree(args: &[String], verbose: u8, global_args: &[String]) -> Result<
     }
 
     // Default: list mode
-    let mut cmd = git_cmd(global_args);
+    let mut cmd = git_cmd(global_args)?;
     cmd.args(["worktree", "list"]);
     let result = exec_capture(&mut cmd).context("Failed to run git worktree list")?;
 
@@ -2052,7 +2055,7 @@ pub fn run_passthrough(args: &[OsString], global_args: &[String], verbose: u8) -
     if verbose > 0 {
         eprintln!("git passthrough: {:?}", args);
     }
-    let status = git_cmd(global_args)
+    let status = git_cmd(global_args)?
         .args(args)
         .status()
         .context("Failed to run git")?;
@@ -2075,7 +2078,7 @@ mod tests {
 
     #[test]
     fn test_git_cmd_no_global_args() {
-        let cmd = git_cmd(&[]);
+        let cmd = git_cmd(&[]).expect("git_cmd: git must resolve in tests");
         let program = cmd.get_program().to_string_lossy().to_string();
         // On Windows, resolved_command returns full path (e.g. "C:\Program Files\Git\bin\git.exe")
         let basename = std::path::Path::new(&program)
@@ -2091,7 +2094,7 @@ mod tests {
     #[test]
     fn test_git_cmd_with_directory() {
         let global_args = vec!["-C".to_string(), "/tmp".to_string()];
-        let cmd = git_cmd(&global_args);
+        let cmd = git_cmd(&global_args).expect("git_cmd: git must resolve in tests");
         let args: Vec<_> = cmd.get_args().collect();
         assert_eq!(args, vec!["-C", "/tmp"]);
     }
@@ -2106,7 +2109,7 @@ mod tests {
             "--git-dir".to_string(),
             "/foo/.git".to_string(),
         ];
-        let cmd = git_cmd(&global_args);
+        let cmd = git_cmd(&global_args).expect("git_cmd: git must resolve in tests");
         let args: Vec<_> = cmd.get_args().collect();
         assert_eq!(
             args,
@@ -2124,14 +2127,14 @@ mod tests {
     #[test]
     fn test_git_cmd_with_boolean_flags() {
         let global_args = vec!["--no-pager".to_string(), "--bare".to_string()];
-        let cmd = git_cmd(&global_args);
+        let cmd = git_cmd(&global_args).expect("git_cmd: git must resolve in tests");
         let args: Vec<_> = cmd.get_args().collect();
         assert_eq!(args, vec!["--no-pager", "--bare"]);
     }
 
     #[test]
     fn test_git_cmd_c_locale_sets_stable_env() {
-        let cmd = git_cmd_c_locale(&[]);
+        let cmd = git_cmd_c_locale(&[]).expect("git_cmd_c_locale: binary must resolve in tests");
         let envs: Vec<_> = cmd
             .get_envs()
             .map(|(key, value)| {
@@ -2146,7 +2149,7 @@ mod tests {
 
     #[test]
     fn test_build_status_command_default_compact() {
-        let cmd = build_status_command(&[], &[]);
+        let cmd = build_status_command(&[], &[]).expect("build_status_command: binary must resolve in tests");
         let args: Vec<_> = cmd.get_args().collect();
         assert_eq!(args, vec!["status", "--porcelain", "-b"]);
     }
@@ -2173,7 +2176,7 @@ mod tests {
     #[test]
     fn test_build_status_command_with_user_args_passthrough() {
         let args = vec!["--short".to_string(), "--branch".to_string()];
-        let cmd = build_status_command(&args, &[]);
+        let cmd = build_status_command(&args, &[]).expect("build_status_command: binary must resolve in tests");
         let cmd_args: Vec<_> = cmd.get_args().collect();
         assert_eq!(cmd_args, vec!["status", "--porcelain", "-b"]);
     }
@@ -2181,7 +2184,7 @@ mod tests {
     #[test]
     fn test_build_status_command_with_incompatible_user_args_passthrough() {
         let args = vec!["--porcelain".to_string(), "-uno".to_string()];
-        let cmd = build_status_command(&args, &[]);
+        let cmd = build_status_command(&args, &[]).expect("build_status_command: binary must resolve in tests");
         let cmd_args: Vec<_> = cmd.get_args().collect();
         assert_eq!(cmd_args, vec!["status", "--porcelain", "-uno"]);
     }
@@ -2989,7 +2992,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
     #[test]
     fn test_commit_single_message() {
         let args = vec!["-m".to_string(), "fix: typo".to_string()];
-        let cmd = build_commit_command(&args, &[]);
+        let cmd = build_commit_command(&args, &[]).expect("build_commit_command: binary must resolve in tests");
         let cmd_args: Vec<_> = cmd
             .get_args()
             .map(|a| a.to_string_lossy().to_string())
@@ -3005,7 +3008,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
             "-m".to_string(),
             "This allows git commit -m \"title\" -m \"body\".".to_string(),
         ];
-        let cmd = build_commit_command(&args, &[]);
+        let cmd = build_commit_command(&args, &[]).expect("build_commit_command: binary must resolve in tests");
         let cmd_args: Vec<_> = cmd
             .get_args()
             .map(|a| a.to_string_lossy().to_string())
@@ -3026,7 +3029,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
     #[test]
     fn test_commit_am_flag() {
         let args = vec!["-am".to_string(), "quick fix".to_string()];
-        let cmd = build_commit_command(&args, &[]);
+        let cmd = build_commit_command(&args, &[]).expect("build_commit_command: binary must resolve in tests");
         let cmd_args: Vec<_> = cmd
             .get_args()
             .map(|a| a.to_string_lossy().to_string())
@@ -3041,7 +3044,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
             "-m".to_string(),
             "new msg".to_string(),
         ];
-        let cmd = build_commit_command(&args, &[]);
+        let cmd = build_commit_command(&args, &[]).expect("build_commit_command: binary must resolve in tests");
         let cmd_args: Vec<_> = cmd
             .get_args()
             .map(|a| a.to_string_lossy().to_string())

--- a/src/cmds/git/glab_cmd.rs
+++ b/src/cmds/git/glab_cmd.rs
@@ -343,7 +343,7 @@ fn format_mr_list(json: &Value, ultra_compact: bool) -> String {
 }
 
 fn mr_list(args: &[String], _verbose: u8, ultra_compact: bool) -> Result<i32> {
-    let mut cmd = resolved_command("glab");
+    let mut cmd = resolved_command("glab")?;
     cmd.args(["mr", "list", "-F", "json"]);
     for arg in args {
         cmd.arg(arg);
@@ -432,7 +432,7 @@ fn mr_view(args: &[String], _verbose: u8, ultra_compact: bool) -> Result<i32> {
         return run_passthrough_with_extra("glab", &base, &extra_args);
     }
 
-    let mut cmd = resolved_command("glab");
+    let mut cmd = resolved_command("glab")?;
     cmd.args(["mr", "view"]);
     if let Some(id) = mr_number_opt.as_deref() {
         cmd.arg(id);
@@ -449,7 +449,7 @@ fn mr_view(args: &[String], _verbose: u8, ultra_compact: bool) -> Result<i32> {
 }
 
 fn mr_create(args: &[String], _verbose: u8) -> Result<i32> {
-    let mut cmd = resolved_command("glab");
+    let mut cmd = resolved_command("glab")?;
     cmd.args(["mr", "create"]);
     for arg in args {
         cmd.arg(arg);
@@ -474,7 +474,7 @@ fn mr_create(args: &[String], _verbose: u8) -> Result<i32> {
 }
 
 fn mr_diff(args: &[String], _verbose: u8) -> Result<i32> {
-    let mut cmd = resolved_command("glab");
+    let mut cmd = resolved_command("glab")?;
     cmd.args(["mr", "diff"]);
     for arg in args {
         cmd.arg(arg);
@@ -498,7 +498,7 @@ fn mr_diff(args: &[String], _verbose: u8) -> Result<i32> {
 /// Uses extract_identifier_and_extra_args to correctly find the MR number
 /// even when it appears after flags (e.g. `glab mr note -m "msg" 42`).
 fn mr_action(subcmd: &str, label: &str, args: &[String], _verbose: u8) -> Result<i32> {
-    let mut cmd = resolved_command("glab");
+    let mut cmd = resolved_command("glab")?;
     cmd.args(["mr", subcmd]);
     for arg in args {
         cmd.arg(arg);
@@ -576,7 +576,7 @@ fn format_issue_list(json: &Value, ultra_compact: bool) -> String {
 }
 
 fn issue_list(args: &[String], _verbose: u8, ultra_compact: bool) -> Result<i32> {
-    let mut cmd = resolved_command("glab");
+    let mut cmd = resolved_command("glab")?;
     cmd.args(["issue", "list", "-F", "json"]);
     for arg in args {
         cmd.arg(arg);
@@ -633,7 +633,7 @@ fn issue_view(args: &[String], _verbose: u8) -> Result<i32> {
         return run_passthrough_with_extra("glab", &base, &extra_args);
     }
 
-    let mut cmd = resolved_command("glab");
+    let mut cmd = resolved_command("glab")?;
     cmd.args(["issue", "view"]);
     if let Some(id) = issue_number_opt.as_deref() {
         cmd.arg(id);
@@ -704,7 +704,7 @@ fn format_ci_list(json: &Value, ultra_compact: bool) -> String {
 }
 
 fn ci_list(args: &[String], _verbose: u8, ultra_compact: bool) -> Result<i32> {
-    let mut cmd = resolved_command("glab");
+    let mut cmd = resolved_command("glab")?;
     cmd.args(["ci", "list", "-F", "json"]);
     for arg in args {
         cmd.arg(arg);
@@ -755,7 +755,7 @@ fn format_ci_status(raw: &str, ultra_compact: bool) -> String {
 
 fn ci_status(args: &[String], _verbose: u8, ultra_compact: bool) -> Result<i32> {
     // glab ci status does not support -F json — text parsing with raw fallback
-    let mut cmd = resolved_command("glab");
+    let mut cmd = resolved_command("glab")?;
     cmd.args(["ci", "status"]);
     for arg in args {
         cmd.arg(arg);
@@ -770,7 +770,7 @@ fn ci_status(args: &[String], _verbose: u8, ultra_compact: bool) -> Result<i32> 
 }
 
 fn ci_trace(args: &[String]) -> Result<i32> {
-    let mut cmd = resolved_command("glab");
+    let mut cmd = resolved_command("glab")?;
     cmd.args(["ci", "trace"]);
     for arg in args {
         cmd.arg(arg);
@@ -904,7 +904,7 @@ fn format_release_list(raw: &str) -> Option<String> {
 }
 
 fn release_list(args: &[String]) -> Result<i32> {
-    let mut cmd = resolved_command("glab");
+    let mut cmd = resolved_command("glab")?;
     cmd.args(["release", "list"]);
     for arg in args {
         cmd.arg(arg);
@@ -919,7 +919,7 @@ fn release_list(args: &[String]) -> Result<i32> {
 }
 
 fn release_view(args: &[String]) -> Result<i32> {
-    let mut cmd = resolved_command("glab");
+    let mut cmd = resolved_command("glab")?;
     cmd.args(["release", "view"]);
     for arg in args {
         cmd.arg(arg);

--- a/src/cmds/git/gt_cmd.rs
+++ b/src/cmds/git/gt_cmd.rs
@@ -31,7 +31,7 @@ fn run_gt_filtered(
 ) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
-    let mut cmd = resolved_command("gt");
+    let mut cmd = resolved_command("gt")?;
     for part in subcmd {
         cmd.arg(part);
     }

--- a/src/cmds/go/go_cmd.rs
+++ b/src/cmds/go/go_cmd.rs
@@ -45,7 +45,7 @@ struct PackageResult {
 }
 
 pub fn run_test(args: &[String], verbose: u8) -> Result<i32> {
-    let mut cmd = resolved_command("go");
+    let mut cmd = resolved_command("go")?;
     cmd.arg("test");
 
     let skip_json = args.iter().any(|a| a == "-json" || a.starts_with("-bench"));
@@ -82,7 +82,7 @@ pub fn run_test(args: &[String], verbose: u8) -> Result<i32> {
 }
 
 pub fn run_build(args: &[String], verbose: u8) -> Result<i32> {
-    let mut cmd = resolved_command("go");
+    let mut cmd = resolved_command("go")?;
     cmd.arg("build");
 
     for arg in args {
@@ -103,7 +103,7 @@ pub fn run_build(args: &[String], verbose: u8) -> Result<i32> {
 }
 
 pub fn run_vet(args: &[String], verbose: u8) -> Result<i32> {
-    let mut cmd = resolved_command("go");
+    let mut cmd = resolved_command("go")?;
     cmd.arg("vet");
 
     for arg in args {
@@ -138,7 +138,7 @@ pub fn run_other(args: &[OsString], verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
     let subcommand = args[0].to_string_lossy();
-    let mut cmd = resolved_command("go");
+    let mut cmd = resolved_command("go")?;
     cmd.arg(&*subcommand);
 
     for arg in &args[1..] {
@@ -173,7 +173,12 @@ pub fn run_other(args: &[OsString], verbose: u8) -> Result<i32> {
 /// Detect golangci-lint major version when invoked via `go tool`.
 /// Returns 1 on any failure (safe fallback — v1 behaviour).
 fn detect_go_tool_golangci_version() -> u32 {
-    let output = resolved_command("go")
+    // A missing `go` is "any failure" per the contract above, not a hard error:
+    // this only picks a formatting branch.
+    let Ok(mut cmd) = resolved_command("go") else {
+        return 1;
+    };
+    let output = cmd
         .arg("tool")
         .arg("golangci-lint")
         .arg("--version")
@@ -238,7 +243,7 @@ fn run_go_tool_golangci_lint(args: &[OsString], verbose: u8) -> Result<i32> {
 
     let version = detect_go_tool_golangci_version();
 
-    let mut cmd = resolved_command("go");
+    let mut cmd = resolved_command("go")?;
     cmd.arg("tool").arg("golangci-lint");
 
     let has_format = has_golangci_format_flag(args);

--- a/src/cmds/go/golangci_cmd.rs
+++ b/src/cmds/go/golangci_cmd.rs
@@ -101,7 +101,11 @@ pub(crate) fn parse_major_version(version_output: &str) -> u32 {
 /// Run `golangci-lint --version` and return the major version number.
 /// Returns 1 on any failure.
 pub(crate) fn detect_major_version() -> u32 {
-    let mut cmd = resolved_command("golangci-lint");
+    // A missing binary is "any failure" per the contract above; the real run
+    // will report it properly.
+    let Ok(mut cmd) = resolved_command("golangci-lint") else {
+        return 1;
+    };
     cmd.arg("--version");
 
     match exec_capture(&mut cmd) {
@@ -127,7 +131,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
 fn run_filtered(original_args: &[String], invocation: &RunInvocation, verbose: u8) -> Result<i32> {
     let version = detect_major_version();
 
-    let mut cmd = resolved_command("golangci-lint");
+    let mut cmd = resolved_command("golangci-lint")?;
     for arg in build_filtered_args(invocation, version) {
         cmd.arg(arg);
     }

--- a/src/cmds/js/lint_cmd.rs
+++ b/src/cmds/js/lint_cmd.rs
@@ -98,9 +98,9 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     // Python linters use resolved_command() directly (they're on PATH via pip/pipx)
     // JS linters use package_manager_exec (npx/pnpm exec)
     let mut cmd = if is_python_linter(linter) {
-        resolved_command(linter)
+        resolved_command(linter)?
     } else {
-        package_manager_exec(linter)
+        package_manager_exec(linter)?
     };
 
     // Add format flags based on linter

--- a/src/cmds/js/next_cmd.rs
+++ b/src/cmds/js/next_cmd.rs
@@ -12,9 +12,9 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     let next_exists = tool_exists("next");
 
     let mut cmd = if next_exists {
-        resolved_command("next")
+        resolved_command("next")?
     } else {
-        let mut c = resolved_command("npx");
+        let mut c = resolved_command("npx")?;
         c.arg("next");
         c
     };

--- a/src/cmds/js/npm_cmd.rs
+++ b/src/cmds/js/npm_cmd.rs
@@ -109,7 +109,7 @@ pub fn exec(args: &[String], verbose: u8, skip_env: bool) -> Result<i32> {
 /// emits the verbose log line, and routes through `runner::run_filtered` with
 /// the npm output filter.
 fn run_filtered(name: &str, args: &[String], verbose: u8, skip_env: bool) -> Result<i32> {
-    let mut cmd = resolved_command(name);
+    let mut cmd = resolved_command(name)?;
     for arg in args {
         cmd.arg(arg);
     }

--- a/src/cmds/js/playwright_cmd.rs
+++ b/src/cmds/js/playwright_cmd.rs
@@ -243,17 +243,17 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     let pm = detect_package_manager();
     let mut cmd = match pm {
         "pnpm" => {
-            let mut c = resolved_command("pnpm");
+            let mut c = resolved_command("pnpm")?;
             c.arg("exec").arg("--").arg("playwright");
             c
         }
         "yarn" => {
-            let mut c = resolved_command("yarn");
+            let mut c = resolved_command("yarn")?;
             c.arg("exec").arg("--").arg("playwright");
             c
         }
         _ => {
-            let mut c = resolved_command("npx");
+            let mut c = resolved_command("npx")?;
             c.arg("--no-install").arg("--").arg("playwright");
             c
         }

--- a/src/cmds/js/pnpm_cmd.rs
+++ b/src/cmds/js/pnpm_cmd.rs
@@ -365,7 +365,7 @@ pub fn run(cmd: PnpmCommand, args: &[String], verbose: u8) -> Result<i32> {
 fn run_list(depth: usize, args: &[String], verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
-    let mut cmd = resolved_command("pnpm");
+    let mut cmd = resolved_command("pnpm")?;
     cmd.arg("list");
     cmd.arg(format!("--depth={}", depth));
     cmd.arg("--json");
@@ -422,7 +422,7 @@ fn run_list(depth: usize, args: &[String], verbose: u8) -> Result<i32> {
 fn run_outdated(args: &[String], verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
-    let mut cmd = resolved_command("pnpm");
+    let mut cmd = resolved_command("pnpm")?;
     cmd.arg("outdated");
     cmd.arg("--format");
     cmd.arg("json");
@@ -473,7 +473,7 @@ fn run_outdated(args: &[String], verbose: u8) -> Result<i32> {
 fn run_install(args: &[String], verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
-    let mut cmd = resolved_command("pnpm");
+    let mut cmd = resolved_command("pnpm")?;
     cmd.arg("install");
 
     for arg in args {

--- a/src/cmds/js/prettier_cmd.rs
+++ b/src/cmds/js/prettier_cmd.rs
@@ -6,7 +6,7 @@ use crate::core::utils::package_manager_exec;
 use anyhow::Result;
 
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
-    let mut cmd = package_manager_exec("prettier");
+    let mut cmd = package_manager_exec("prettier")?;
 
     for arg in args {
         cmd.arg(arg);

--- a/src/cmds/js/prisma_cmd.rs
+++ b/src/cmds/js/prisma_cmd.rs
@@ -30,20 +30,20 @@ pub fn run(cmd: PrismaCommand, args: &[String], verbose: u8) -> Result<i32> {
 }
 
 /// Create a Command that will run prisma (tries global first, then npx)
-fn create_prisma_command() -> Command {
+fn create_prisma_command() -> Result<Command> {
     if tool_exists("prisma") {
         resolved_command("prisma")
     } else {
-        let mut c = resolved_command("npx");
+        let mut c = resolved_command("npx")?;
         c.arg("prisma");
-        c
+        Ok(c)
     }
 }
 
 fn run_generate(args: &[String], verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
-    let mut cmd = create_prisma_command();
+    let mut cmd = create_prisma_command()?;
     cmd.arg("generate");
 
     for arg in args {
@@ -81,7 +81,7 @@ fn run_generate(args: &[String], verbose: u8) -> Result<i32> {
 fn run_migrate(subcommand: MigrateSubcommand, args: &[String], verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
-    let mut cmd = create_prisma_command();
+    let mut cmd = create_prisma_command()?;
     cmd.arg("migrate");
 
     let cmd_name = match &subcommand {
@@ -141,7 +141,7 @@ fn run_migrate(subcommand: MigrateSubcommand, args: &[String], verbose: u8) -> R
 fn run_db_push(args: &[String], verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
-    let mut cmd = create_prisma_command();
+    let mut cmd = create_prisma_command()?;
     cmd.arg("db").arg("push");
 
     for arg in args {

--- a/src/cmds/js/tsc_cmd.rs
+++ b/src/cmds/js/tsc_cmd.rs
@@ -16,9 +16,9 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     let tsc_exists = tool_exists("tsc");
 
     let mut cmd = if tsc_exists {
-        resolved_command("tsc")
+        resolved_command("tsc")?
     } else {
-        let mut c = resolved_command("npx");
+        let mut c = resolved_command("npx")?;
         c.arg("tsc");
         c
     };

--- a/src/cmds/js/vitest_cmd.rs
+++ b/src/cmds/js/vitest_cmd.rs
@@ -206,7 +206,7 @@ pub fn run_test(command: &Commands, args: &[String], verbose: u8) -> Result<i32>
     let (framework, mut cmd) = match command {
         Commands::Vitest { .. } => {
             let framework = "vitest";
-            let mut cmd = package_manager_exec(framework);
+            let mut cmd = package_manager_exec(framework)?;
             let effective_args = build_vitest_effective_args(args);
             passthrough_requested = effective_args.passthrough;
             cmd.args(effective_args.args);
@@ -214,7 +214,7 @@ pub fn run_test(command: &Commands, args: &[String], verbose: u8) -> Result<i32>
         }
         Commands::Jest { .. } => {
             let framework = "jest";
-            let mut cmd = package_manager_exec(framework);
+            let mut cmd = package_manager_exec(framework)?;
             cmd
                 // Force non-watch mode
                 .arg("--no-watch")

--- a/src/cmds/jvm/gradlew_cmd.rs
+++ b/src/cmds/jvm/gradlew_cmd.rs
@@ -84,20 +84,21 @@ fn gradlew_binary() -> &'static str {
 /// semgrep's `dynamic-command-execution` rule stays happy. The `gradle` system
 /// binary is resolved via `resolved_command("gradle")` for PATHEXT support on
 /// Windows (`.CMD`/`.BAT` shims) — matches how cargo, golangci-lint, etc. do it.
-fn new_gradle_command(args: &[String]) -> Command {
+fn new_gradle_command(args: &[String]) -> Result<Command> {
     let mut cmd = if cfg!(windows) {
         if std::path::Path::new(".\\gradlew.bat").exists() {
             Command::new(".\\gradlew.bat")
         } else {
-            resolved_command("gradle")
+            resolved_command("gradle")?
         }
     } else if std::path::Path::new("./gradlew").exists() {
         Command::new("./gradlew")
     } else {
-        resolved_command("gradle")
+        resolved_command("gradle")?
     };
     cmd.args(args);
-    cmd
+    Ok(cmd)
+
 }
 
 /// `StreamFilter` for build mode: keeps lines for which `filter_build_line` returns true.
@@ -127,7 +128,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         return runner::run_passthrough(gradlew_binary(), &osargs, verbose);
     }
 
-    let cmd = new_gradle_command(args);
+    let cmd = new_gradle_command(args)?;
     let args_display = args.join(" ");
     let tool = gradlew_binary();
 

--- a/src/cmds/jvm/mvn_cmd.rs
+++ b/src/cmds/jvm/mvn_cmd.rs
@@ -891,20 +891,21 @@ fn mvn_binary() -> &'static str {
     }
 }
 
-fn new_mvn_command(args: &[String]) -> Command {
+fn new_mvn_command(args: &[String]) -> Result<Command> {
     let mut cmd = if cfg!(windows) {
         if Path::new(".\\mvnw.cmd").exists() {
             Command::new(".\\mvnw.cmd")
         } else {
-            resolved_command("mvn")
+            resolved_command("mvn")?
         }
     } else if Path::new("./mvnw").exists() {
         Command::new("./mvnw")
     } else {
-        resolved_command("mvn")
+        resolved_command("mvn")?
     };
     cmd.args(args);
-    cmd
+    Ok(cmd)
+
 }
 
 // ── Entry point ─────────────────────────────────────────────────────────────
@@ -932,7 +933,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
             return runner::run_passthrough(tool, &osargs, verbose);
         }
         return runner::run_filtered(
-            new_mvn_command(args),
+            new_mvn_command(args)?,
             tool,
             &args_display,
             filter_quiet,
@@ -944,21 +945,21 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
 
     match phase {
         MvnPhase::Test => runner::run_filtered(
-            new_mvn_command(args),
+            new_mvn_command(args)?,
             tool,
             &args_display,
             filter_surefire,
             RunOptions::with_tee("mvn_test"),
         ),
         MvnPhase::Compile => runner::run_filtered(
-            new_mvn_command(args),
+            new_mvn_command(args)?,
             tool,
             &args_display,
             filter_compile,
             RunOptions::with_tee("mvn_compile"),
         ),
         MvnPhase::Package => runner::run_filtered(
-            new_mvn_command(args),
+            new_mvn_command(args)?,
             tool,
             &args_display,
             filter_package,

--- a/src/cmds/php/ecs_cmd.rs
+++ b/src/cmds/php/ecs_cmd.rs
@@ -5,7 +5,7 @@ use crate::core::runner;
 use anyhow::Result;
 
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
-    let mut cmd = php_tool_command("ecs");
+    let mut cmd = php_tool_command("ecs")?;
     for arg in args {
         cmd.arg(arg);
     }

--- a/src/cmds/php/paratest_cmd.rs
+++ b/src/cmds/php/paratest_cmd.rs
@@ -6,7 +6,7 @@ use crate::core::runner;
 use anyhow::Result;
 
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
-    let mut cmd = php_tool_command("paratest");
+    let mut cmd = php_tool_command("paratest")?;
 
     let has_no_progress = args.iter().any(|a| a == "--no-progress");
     if !has_no_progress {

--- a/src/cmds/php/pest_cmd.rs
+++ b/src/cmds/php/pest_cmd.rs
@@ -6,7 +6,7 @@ use crate::core::runner;
 use anyhow::Result;
 
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
-    let mut cmd = php_tool_command("pest");
+    let mut cmd = php_tool_command("pest")?;
 
     let has_no_progress = args.iter().any(|a| a == "--no-progress");
     if !has_no_progress {

--- a/src/cmds/php/php_cmd.rs
+++ b/src/cmds/php/php_cmd.rs
@@ -7,7 +7,7 @@ use crate::core::utils::resolved_command;
 use anyhow::Result;
 
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
-    let mut cmd = resolved_command("php");
+    let mut cmd = resolved_command("php")?;
     for arg in args {
         cmd.arg(arg);
     }

--- a/src/cmds/php/phpstan_cmd.rs
+++ b/src/cmds/php/phpstan_cmd.rs
@@ -50,7 +50,7 @@ struct PhpstanMessage {
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     // Composer-aware resolution (COMPOSER_BIN_DIR / config.bin-dir), matching
     // the other php tools, with PATH fallback for a global install.
-    let mut cmd = php_tool_command("phpstan");
+    let mut cmd = php_tool_command("phpstan")?;
 
     // Utility commands (--version, list, clear-result-cache, worker, …): real passthrough.
     // Only analyse/analyze subcommands get filtered and token-tracked.

--- a/src/cmds/php/phpunit_cmd.rs
+++ b/src/cmds/php/phpunit_cmd.rs
@@ -20,7 +20,7 @@ const MAX_DETAIL_LINES_PER_FAILURE: usize = 2;
 static FAILURE_HEADING_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^\d+\) \S").unwrap());
 
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
-    let mut cmd = php_tool_command("phpunit");
+    let mut cmd = php_tool_command("phpunit")?;
     for arg in args {
         cmd.arg(arg);
     }

--- a/src/cmds/php/pint_cmd.rs
+++ b/src/cmds/php/pint_cmd.rs
@@ -34,7 +34,7 @@ struct PintFile {
 }
 
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
-    let mut cmd = php_tool_command("pint");
+    let mut cmd = php_tool_command("pint")?;
 
     let has_format = args
         .iter()

--- a/src/cmds/php/utils.rs
+++ b/src/cmds/php/utils.rs
@@ -1,4 +1,5 @@
 use crate::core::utils::{composer_tool_paths, resolve_binary, resolved_command};
+use anyhow::Result;
 use regex::Regex;
 use std::path::Path;
 use std::process::Command;
@@ -8,7 +9,7 @@ static ANSI_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\x1b\[[0-9;]*[A-
 static CONTROL_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]").unwrap());
 
-pub fn php_tool_command(tool: &str) -> Command {
+pub fn php_tool_command(tool: &str) -> Result<Command> {
     for local_tool in composer_tool_paths(tool) {
         let local_tool_name = local_tool.to_string_lossy().into_owned();
         // Route through resolved_command (the sanctioned constructor) rather than

--- a/src/cmds/python/mypy_cmd.rs
+++ b/src/cmds/python/mypy_cmd.rs
@@ -9,9 +9,9 @@ use std::sync::LazyLock;
 
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     let mut cmd = if tool_exists("mypy") {
-        resolved_command("mypy")
+        resolved_command("mypy")?
     } else {
-        let mut c = resolved_command("python3");
+        let mut c = resolved_command("python3")?;
         c.arg("-m").arg("mypy");
         c
     };

--- a/src/cmds/python/pip_cmd.rs
+++ b/src/cmds/python/pip_cmd.rs
@@ -58,7 +58,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
 }
 
 fn run_list(base_cmd: &str, args: &[String], verbose: u8) -> Result<(String, String, i32)> {
-    let mut cmd = resolved_command(base_cmd);
+    let mut cmd = resolved_command(base_cmd)?;
 
     if base_cmd == "uv" {
         cmd.arg("pip");
@@ -86,7 +86,7 @@ fn run_list(base_cmd: &str, args: &[String], verbose: u8) -> Result<(String, Str
 }
 
 fn run_outdated(base_cmd: &str, args: &[String], verbose: u8) -> Result<(String, String, i32)> {
-    let mut cmd = resolved_command(base_cmd);
+    let mut cmd = resolved_command(base_cmd)?;
 
     if base_cmd == "uv" {
         cmd.arg("pip");
@@ -114,7 +114,7 @@ fn run_outdated(base_cmd: &str, args: &[String], verbose: u8) -> Result<(String,
 }
 
 fn run_passthrough(base_cmd: &str, args: &[String], verbose: u8) -> Result<(String, String, i32)> {
-    let mut cmd = resolved_command(base_cmd);
+    let mut cmd = resolved_command(base_cmd)?;
 
     if base_cmd == "uv" {
         cmd.arg("pip");

--- a/src/cmds/python/pytest_cmd.rs
+++ b/src/cmds/python/pytest_cmd.rs
@@ -19,9 +19,9 @@ enum ParseState {
 
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     let mut cmd = if tool_exists("pytest") {
-        resolved_command("pytest")
+        resolved_command("pytest")?
     } else {
-        let mut c = resolved_command("python");
+        let mut c = resolved_command("python")?;
         c.arg("-m").arg("pytest");
         c
     };

--- a/src/cmds/python/ruff_cmd.rs
+++ b/src/cmds/python/ruff_cmd.rs
@@ -38,7 +38,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
 
     let is_format = args.iter().any(|a| a == "format");
 
-    let mut cmd = resolved_command("ruff");
+    let mut cmd = resolved_command("ruff")?;
 
     // Both spellings: injecting a second --output-format makes ruff reject the call.
     let user_set_output_format = args

--- a/src/cmds/python/uv_cmd.rs
+++ b/src/cmds/python/uv_cmd.rs
@@ -53,7 +53,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     let original_cmd = display_command("uv", &args_display);
     let rtk_cmd = display_command("rtk uv", &args_display);
 
-    let mut cmd = resolved_command("uv");
+    let mut cmd = resolved_command("uv")?;
     cmd.args(args);
 
     if verbose > 0 {

--- a/src/cmds/rust/cargo_cmd.rs
+++ b/src/cmds/rust/cargo_cmd.rs
@@ -264,7 +264,7 @@ fn run_cargo_filtered<F>(
 where
     F: Fn(&str) -> String,
 {
-    let mut cmd = resolved_command("cargo");
+    let mut cmd = resolved_command("cargo")?;
     cmd.arg(subcommand);
 
     let restored_args = args_utils::restore_double_dash(args);
@@ -296,7 +296,7 @@ fn run_cargo_filtered_with_exit<F>(
 where
     F: Fn(&str, i32) -> String,
 {
-    let mut cmd = resolved_command("cargo");
+    let mut cmd = resolved_command("cargo")?;
     cmd.arg(subcommand);
 
     let restored_args = args_utils::restore_double_dash(args);
@@ -323,7 +323,7 @@ fn run_cargo_streamed(
     verbose: u8,
     filter: Box<dyn StreamFilter>,
 ) -> Result<i32> {
-    let mut cmd = resolved_command("cargo");
+    let mut cmd = resolved_command("cargo")?;
     cmd.arg(subcommand);
 
     let restored_args = args_utils::restore_double_dash(args);

--- a/src/cmds/scala/sbt_cmd.rs
+++ b/src/cmds/scala/sbt_cmd.rs
@@ -81,7 +81,7 @@ fn run_task(
     tee_label: &str,
     verbose: u8,
 ) -> Result<i32> {
-    let mut cmd = resolved_command("sbt");
+    let mut cmd = resolved_command("sbt")?;
 
     let (sbt_task, rest) = match args.first() {
         Some(a) if is_scoped_task(a) => (a.as_str(), &args[1..]),
@@ -135,7 +135,7 @@ pub fn run_other(args: &[OsString], verbose: u8) -> Result<i32> {
     // never_worse cap and tee hint apply (an unrecognized output would otherwise be
     // reprinted verbatim plus the hint, i.e. more than the raw command produced).
     if is_integration_test_cmd(&subcommand) || is_test_task(&subcommand) {
-        let mut cmd = resolved_command("sbt");
+        let mut cmd = resolved_command("sbt")?;
         cmd.arg(&subcommand);
         for arg in &args[1..] {
             cmd.arg(arg);

--- a/src/cmds/system/format_cmd.rs
+++ b/src/cmds/system/format_cmd.rs
@@ -75,10 +75,10 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
 
     // Build command based on formatter
     let mut cmd = match formatter.as_str() {
-        "prettier" => package_manager_exec("prettier"),
-        "black" | "ruff" => resolved_command(formatter.as_str()),
-        "biome" => package_manager_exec("biome"),
-        _ => resolved_command(formatter.as_str()),
+        "prettier" => package_manager_exec("prettier")?,
+        "black" | "ruff" => resolved_command(formatter.as_str())?,
+        "biome" => package_manager_exec("biome")?,
+        _ => resolved_command(formatter.as_str())?,
     };
 
     // Add formatter-specific flags

--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -48,7 +48,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         .map(|s| s.as_str())
         .collect();
 
-    let mut cmd = resolved_command("ls");
+    let mut cmd = resolved_command("ls")?;
     cmd.env("LC_ALL", "C");
     cmd.arg("-la");
     for flag in &flags {

--- a/src/cmds/system/search.rs
+++ b/src/cmds/system/search.rs
@@ -302,7 +302,7 @@ fn engine_capture<T: AsRef<str>>(
     patterns: &[String],
     paths: &[String],
 ) -> Result<CaptureResult> {
-    let mut cmd = engine_command(engine, extra_args, patterns, paths, false);
+    let mut cmd = engine_command(engine, extra_args, patterns, paths, false)?;
     exec_capture_stdin(&mut cmd).context("search failed")
 }
 
@@ -312,8 +312,8 @@ fn engine_command<T: AsRef<str>>(
     patterns: &[String],
     paths: &[String],
     line_buffered: bool,
-) -> Command {
-    let mut cmd = resolved_command(engine.bin());
+) -> Result<Command> {
+    let mut cmd = resolved_command(engine.bin())?;
     cmd.args(engine.parse_flags());
     for a in extra_args {
         cmd.arg(a.as_ref());
@@ -327,7 +327,7 @@ fn engine_command<T: AsRef<str>>(
     }
     cmd.arg("--");
     cmd.args(paths);
-    cmd
+    Ok(cmd)
 }
 
 fn format_match_line(line: &str, show_file: bool, show_line: bool) -> Option<String> {
@@ -418,7 +418,7 @@ fn run_streaming_search(
         shown: 0,
         cap_reported: false,
     };
-    let mut cmd = engine_command(engine, extra_args, patterns, paths, true);
+    let mut cmd = engine_command(engine, extra_args, patterns, paths, true)?;
     let result = stream::run_streaming(
         &mut cmd,
         StdinMode::Inherit,
@@ -444,7 +444,7 @@ fn passthrough<T: AsRef<str>>(
     real_cmd: &str,
     stream_stdin: bool,
 ) -> Result<i32> {
-    let mut cmd = resolved_command(engine.bin());
+    let mut cmd = resolved_command(engine.bin())?;
     if stream_stdin && !std::io::stdout().is_terminal() {
         // Keep passthrough output live when stdout is piped.
         cmd.arg("--line-buffered");
@@ -507,7 +507,7 @@ pub fn run(
         .iter()
         .any(|a| a == "--version" || a == "--help" || a == "-h")
     {
-        let mut cmd = resolved_command(engine.bin());
+        let mut cmd = resolved_command(engine.bin())?;
         cmd.args(args);
         let result = exec_capture(&mut cmd).context("search failed")?;
         print!("{}", result.stdout);
@@ -1424,7 +1424,11 @@ mod tests {
     fn test_rg_always_has_line_numbers() {
         // engine_capture always passes "-n" to the engine via parse_flags().
         // This test documents that -n is built-in, so the clap flag is safe to ignore.
-        let mut cmd = resolved_command("rg");
+        // Runners without ripgrep installed can't exercise this; the flag
+        // contract under test is unchanged either way.
+        let Ok(mut cmd) = resolved_command("rg") else {
+            return;
+        };
         cmd.args(["-n", "--no-heading", "NONEXISTENT_PATTERN_12345", "."]);
         // If rg is available, it should accept -n without error (exit 1 = no match, not error)
         if let Ok(output) = cmd.output() {

--- a/src/cmds/system/tree.rs
+++ b/src/cmds/system/tree.rs
@@ -22,7 +22,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         );
     }
 
-    let mut cmd = resolved_command("tree");
+    let mut cmd = resolved_command("tree")?;
 
     let show_all = args.iter().any(|a| a == "-a" || a == "--all");
     let has_ignore = args.iter().any(|a| a == "-I" || a.starts_with("--ignore="));

--- a/src/cmds/system/wc_cmd.rs
+++ b/src/cmds/system/wc_cmd.rs
@@ -11,7 +11,7 @@ use crate::core::utils::resolved_command;
 use anyhow::Result;
 
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
-    let mut cmd = resolved_command("wc");
+    let mut cmd = resolved_command("wc")?;
     for arg in args {
         cmd.arg(arg);
     }

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -257,7 +257,7 @@ pub fn run_passthrough(tool: &str, args: &[std::ffi::OsString], verbose: u8) -> 
     if verbose > 0 {
         eprintln!("{} passthrough: {:?}", tool, args);
     }
-    let mut cmd = crate::core::utils::resolved_command(tool);
+    let mut cmd = crate::core::utils::resolved_command(tool)?;
     cmd.args(args);
     let args_str = tracking::args_display(args);
     run(

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -1,3 +1,4 @@
+use crate::core::utils::CommandNotFound;
 use anyhow::{Context, Result};
 use std::io::{self, BufRead, BufReader, BufWriter, Write};
 use std::process::{Command, Stdio};
@@ -532,22 +533,6 @@ impl CaptureResult {
         format!("{}{}", self.stdout, self.stderr)
     }
 }
-
-/// A wrapped binary that isn't on PATH. Typed so `main` can exit 127 (the POSIX
-/// command-not-found status) instead of a generic 1, which any `cmd || fallback`
-/// or CI gate testing for 127 would otherwise misread as an ordinary failure.
-#[derive(Debug)]
-pub struct CommandNotFound {
-    pub program: String,
-}
-
-impl std::fmt::Display for CommandNotFound {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}: command not found", self.program)
-    }
-}
-
-impl std::error::Error for CommandNotFound {}
 
 /// Turn a spawn failure into an accurate diagnostic.
 ///

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -260,7 +260,8 @@ pub fn run_streaming(
         };
         cmd.stdout(Stdio::inherit());
         cmd.stderr(Stdio::inherit());
-        let status = cmd.status().context("Failed to spawn process")?;
+        let program = program_of(cmd);
+        let status = cmd.status().map_err(|e| exec_error(&program, e))?;
         return Ok(StreamResult {
             exit_code: status_to_exit_code(status),
             raw: String::new(),
@@ -290,7 +291,8 @@ pub fn run_streaming(
 
     let is_streaming = matches!(stdout_mode, FilterMode::Streaming(_));
 
-    let mut child = ChildGuard(cmd.spawn().context("Failed to spawn process")?);
+    let program = program_of(cmd);
+    let mut child = ChildGuard(cmd.spawn().map_err(|e| exec_error(&program, e))?);
 
     let stdin_thread: Option<std::thread::JoinHandle<()>> = match stdin_mode {
         StdinMode::Filter(mut filter) => {
@@ -531,9 +533,49 @@ impl CaptureResult {
     }
 }
 
+/// A wrapped binary that isn't on PATH. Typed so `main` can exit 127 (the POSIX
+/// command-not-found status) instead of a generic 1, which any `cmd || fallback`
+/// or CI gate testing for 127 would otherwise misread as an ordinary failure.
+#[derive(Debug)]
+pub struct CommandNotFound {
+    pub program: String,
+}
+
+impl std::fmt::Display for CommandNotFound {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: command not found", self.program)
+    }
+}
+
+impl std::error::Error for CommandNotFound {}
+
+/// Turn a spawn failure into an accurate diagnostic.
+///
+/// The raw errno cannot answer "is this binary missing?". POSIX `execvp` walks
+/// PATH, and if any candidate directory is unreadable it reports **EACCES over
+/// ENOENT** even when nothing matched. On WSL the Windows interop entries (e.g.
+/// `/mnt/c/.../WindowsApps`) are routinely unreadable, so a plainly missing
+/// binary surfaces as `Permission denied (os error 13)` and reads like a
+/// sandbox or permissions problem, inviting a bypass that then fails
+/// differently. `which` walks the same PATH but skips unreadable directories,
+/// so it answers the question the errno can't. Ask it rather than the errno.
+fn exec_error(program: &str, err: std::io::Error) -> anyhow::Error {
+    if which::which(program).is_err() {
+        return anyhow::Error::new(CommandNotFound {
+            program: program.to_string(),
+        });
+    }
+    anyhow::Error::new(err).context(format!("Failed to execute {}", program))
+}
+
+fn program_of(cmd: &Command) -> String {
+    cmd.get_program().to_string_lossy().into_owned()
+}
+
 pub fn exec_capture(cmd: &mut Command) -> Result<CaptureResult> {
     cmd.stdin(Stdio::null());
-    let output = cmd.output().context("Failed to execute command")?;
+    let program = program_of(cmd);
+    let output = cmd.output().map_err(|e| exec_error(&program, e))?;
     Ok(CaptureResult {
         stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
         stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
@@ -544,7 +586,8 @@ pub fn exec_capture(cmd: &mut Command) -> Result<CaptureResult> {
 /// Like [`exec_capture`] but inherits stdin so a wrapped engine can read a piped stdin.
 pub fn exec_capture_stdin(cmd: &mut Command) -> Result<CaptureResult> {
     cmd.stdin(Stdio::inherit());
-    let output = cmd.output().context("Failed to execute command")?;
+    let program = program_of(cmd);
+    let output = cmd.output().map_err(|e| exec_error(&program, e))?;
     Ok(CaptureResult {
         stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
         stderr: String::from_utf8_lossy(&output.stderr).into_owned(),

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -285,26 +285,26 @@ pub fn detect_package_manager() -> &'static str {
 
 /// Build a Command using the detected package manager's exec mechanism.
 /// Returns a Command ready to have tool-specific args appended.
-pub fn package_manager_exec(tool: &str) -> Command {
+pub fn package_manager_exec(tool: &str) -> Result<Command> {
     if tool_exists(tool) {
         resolved_command(tool)
     } else {
         let pm = detect_package_manager();
         match pm {
             "pnpm" => {
-                let mut c = resolved_command("pnpm");
+                let mut c = resolved_command("pnpm")?;
                 c.arg("exec").arg("--").arg(tool);
-                c
+                Ok(c)
             }
             "yarn" => {
-                let mut c = resolved_command("yarn");
+                let mut c = resolved_command("yarn")?;
                 c.arg("exec").arg("--").arg(tool);
-                c
+                Ok(c)
             }
             _ => {
-                let mut c = resolved_command("npx");
+                let mut c = resolved_command("npx")?;
                 c.arg("--no-install").arg("--").arg(tool);
-                c
+                Ok(c)
             }
         }
     }
@@ -327,34 +327,57 @@ pub fn resolve_binary(name: &str) -> Result<PathBuf> {
     which::which(name).context(format!("Binary '{}' not found on PATH", name))
 }
 
+/// A wrapped binary that isn't on PATH.
+///
+/// Typed so `main` can exit 127 (the POSIX command-not-found status) instead of
+/// a generic 1, which any `cmd || fallback` or CI gate testing for 127 would
+/// otherwise misread as an ordinary failure.
+#[derive(Debug)]
+pub struct CommandNotFound {
+    pub program: String,
+}
+
+impl std::fmt::Display for CommandNotFound {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: command not found", self.program)
+    }
+}
+
+impl std::error::Error for CommandNotFound {}
+
 /// Create a `Command` with PATHEXT-aware binary resolution.
 ///
-/// Drop-in replacement for `Command::new(name)` that works on Windows
-/// with `.CMD`/`.BAT`/`.PS1` wrappers.
+/// Drop-in replacement for `Command::new(name)` that works on Windows with
+/// `.CMD`/`.BAT`/`.PS1` wrappers.
 ///
-/// Falls back to `Command::new(name)` if resolution fails, so native
-/// commands (git, cargo) still work even if `which` can't find them.
+/// Returns `CommandNotFound` on Unix when `which` can't resolve the binary,
+/// rather than falling back to a bare-name spawn. The fallback used to hide the
+/// one fact rtk already knew: the errno from a bare-name exec cannot answer "is
+/// this binary missing?", because POSIX `execvp` reports **EACCES over ENOENT**
+/// if any PATH directory was unreadable. On WSL the Windows interop entries
+/// (`/mnt/c/.../WindowsApps`) are routinely unreadable, so a plainly missing
+/// binary surfaced as `Permission denied (os error 13)` and read like a sandbox
+/// fault. `which` walks the same PATH but skips unreadable directories, so its
+/// verdict is the trustworthy one — propagate it instead of discarding it.
 ///
-/// # Arguments
-/// * `name` - Binary name (e.g., "vitest", "eslint")
-///
-/// # Returns
-/// A `Command` configured with the resolved binary path.
-pub fn resolved_command(name: &str) -> Command {
+/// Windows keeps the fallback: a `.CMD`/`.BAT` wrapper can evade `which` while
+/// still being executable, so there the exec attempt is still worth making.
+pub fn resolved_command(name: &str) -> Result<Command> {
     match resolve_binary(name) {
-        Ok(path) => Command::new(path),
+        // nosemgrep: dynamic-command-execution -- `path` is which's resolution of a caller-supplied tool name; this is the sanctioned constructor the rule exists to funnel callers into
+        Ok(path) => Ok(Command::new(path)),
         Err(e) => {
-            // On Windows, resolution failure likely means a .CMD/.BAT wrapper
-            // wasn't found — always warn so users have a signal.
-            // On Unix, this is less common; only log in debug builds.
-            if cfg!(any(target_os = "windows", debug_assertions)) {
+            if cfg!(target_os = "windows") {
                 eprintln!(
                     "rtk: Failed to resolve '{}' via PATH, falling back to direct exec: {}",
                     name, e
                 );
+                // nosemgrep: dynamic-command-execution -- Windows-only fallback for .CMD/.BAT wrappers that evade which
+                return Ok(Command::new(name));
             }
-
-            Command::new(name)
+            Err(anyhow::Error::new(CommandNotFound {
+                program: name.to_string(),
+            }))
         }
     }
 }
@@ -460,6 +483,40 @@ pub fn human_bytes(bytes: u64) -> String {
 
 #[cfg(test)]
 mod tests {
+
+    // --- resolved_command: which's verdict must not be discarded ---
+
+    #[test]
+    fn test_resolved_command_resolves_a_real_binary() {
+        // sh is on PATH on every unix box CI runs on.
+        assert!(resolved_command("sh").is_ok());
+    }
+
+    #[test]
+    #[cfg(not(target_os = "windows"))]
+    fn test_resolved_command_reports_missing_binary_as_not_found() {
+        // The bug this guards: falling back to a bare-name spawn let the errno
+        // decide, and POSIX execvp reports EACCES over ENOENT when any PATH dir
+        // is unreadable (WSL's WindowsApps), so a missing binary surfaced as
+        // "Permission denied (os error 13)". which skips unreadable dirs, so its
+        // verdict is the trustworthy one.
+        let err = resolved_command("rtk_definitely_no_such_binary_zzz")
+            .expect_err("missing binary must not resolve");
+        let not_found = err
+            .downcast_ref::<CommandNotFound>()
+            .expect("must be typed CommandNotFound so main can exit 127");
+        assert_eq!(not_found.program, "rtk_definitely_no_such_binary_zzz");
+        assert!(
+            err.to_string().contains("command not found"),
+            "got: {}",
+            err
+        );
+        assert!(
+            !err.to_string().contains("os error 13"),
+            "must not leak the misleading errno: {}",
+            err
+        );
+    }
     use super::*;
 
     #[test]
@@ -703,9 +760,10 @@ mod tests {
     #[test]
     fn test_resolved_command_executes_known_command() {
         let output = resolved_command("cargo")
+            .expect("cargo must resolve on PATH in tests")
             .arg("--version")
             .output()
-            .expect("resolved_command('cargo') should execute");
+            .expect("cargo --version should execute");
         assert!(
             output.status.success(),
             "cargo --version should succeed via resolved_command"
@@ -846,7 +904,8 @@ mod tests {
             // When resolve_binary fails, resolved_command should fall back to
             // Command::new(name) instead of panicking.  On Windows this also
             // prints a warning to stderr.
-            let mut cmd = resolved_command("nonexistent_binary_xyz_99999");
+            let mut cmd = resolved_command("nonexistent_binary_xyz_99999")
+                .expect("resolved_command: binary must resolve in tests");
             // The Command should be created (not panic).  Attempting to run it
             // will fail, but that's expected — we just verify the fallback path
             // produces a usable Command.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1322,14 +1322,14 @@ fn run_fallback(parse_error: clap::Error) -> Result<i32> {
         // TOML match: capture stdout for filtering
         let result = if filter.filter_stderr {
             // Merge stderr into stdout so the filter can strip banners emitted by tools like liquibase
-            core::utils::resolved_command(&args[0])
+            core::utils::resolved_command(&args[0])?
                 .args(&args[1..])
                 .stdin(std::process::Stdio::inherit())
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped()) // captured for merging
                 .output()
         } else {
-            core::utils::resolved_command(&args[0])
+            core::utils::resolved_command(&args[0])?
                 .args(&args[1..])
                 .stdin(std::process::Stdio::inherit())
                 .stdout(std::process::Stdio::piped()) // capture
@@ -1398,7 +1398,7 @@ fn run_fallback(parse_error: clap::Error) -> Result<i32> {
         }
     } else {
         // No TOML match: original passthrough behaviour (Stdio::inherit, streaming)
-        let status = core::utils::resolved_command(&args[0])
+        let status = core::utils::resolved_command(&args[0])?
             .args(&args[1..])
             .stdin(std::process::Stdio::inherit())
             .stdout(std::process::Stdio::inherit())
@@ -1543,7 +1543,14 @@ fn main() {
         Ok(code) => code,
         Err(e) => {
             eprintln!("rtk: {:#}", e);
-            1
+            // POSIX reserves 127 for command-not-found. Collapsing it into a
+            // generic 1 makes `cmd || fallback` and CI gates that test for 127
+            // read a missing binary as an ordinary failure.
+            if e.downcast_ref::<core::utils::CommandNotFound>().is_some() {
+                127
+            } else {
+                1
+            }
         }
     };
     std::process::exit(code);
@@ -2322,7 +2329,7 @@ fn run_cli() -> Result<i32> {
                             _ => {
                                 // Passthrough other prisma subcommands
                                 let timer = core::tracking::TimedExecution::start();
-                                let mut cmd = core::utils::resolved_command("npx");
+                                let mut cmd = core::utils::resolved_command("npx")?;
                                 for arg in &args {
                                     cmd.arg(arg);
                                 }
@@ -2337,7 +2344,7 @@ fn run_cli() -> Result<i32> {
                         }
                     } else {
                         let timer = core::tracking::TimedExecution::start();
-                        let status = core::utils::resolved_command("npx")
+                        let status = core::utils::resolved_command("npx")?
                             .arg("prisma")
                             .status()
                             .context("Failed to run npx prisma")?;
@@ -2574,7 +2581,7 @@ fn run_cli() -> Result<i32> {
             }
 
             let mut child = ChildGuard(Some(
-                core::utils::resolved_command(cmd_name.as_ref())
+                core::utils::resolved_command(cmd_name.as_ref())?
                     .args(&cmd_args)
                     .stdout(Stdio::piped())
                     .stderr(Stdio::piped())


### PR DESCRIPTION
## Symptom

```
$ rtk phpstan --version
rtk: Failed to run phpstan: Failed to execute command: Permission denied (os error 13)
$ echo $?
1
```

phpstan is simply not installed. Plain bash says `command not found`. The misleading errno suggests a sandbox or permission problem and invites a bypass that then fails differently.

## Why the obvious fix does not work

Mapping `io::ErrorKind::NotFound` to "command not found" would **not** fix this, because the error kind genuinely *is* `PermissionDenied`. rtk is not mislabelling ENOENT.

The cause is PATH pollution interacting with POSIX `execvp` semantics. `execvp` walks PATH, collects ENOENT for each miss, and if it hits an unreadable directory it reports **EACCES, not ENOENT**, even though nothing was found. On WSL, `/mnt/c/Windows/system32/config/systemprofile/AppData/Local/Microsoft/WindowsApps` is on PATH and unreadable, which is enough to trigger it. Isolated by PATH control:

```
env PATH=/usr/bin:/bin:$HOME/.cargo/bin rtk phpstan   # No such file or directory (os error 2)  <- ENOENT
rtk phpstan                                           # Permission denied (os error 13)         <- EACCES
```

So the errno is environment-dependent noise, and any fix that reasons *from* it is unreliable.

## The fix: stop inferring from errno — rtk already knows

`core/utils.rs::resolve_binary()` calls `which::which(name)` (dependency already present) and returns a clean not-found verdict. `which` is reliable exactly where errno is not: under the poisoned PATH it correctly skips the unreadable directory rather than being poisoned by it. `resolved_command()` was then *swallowing* that verdict and falling back to a bare-name spawn.

`resolved_command` now returns `Result<Command>` and raises a typed `CommandNotFound` instead of falling back, so `which`s answer can no longer be discarded.

## Also: exit 127

rtk exited **1** on command-not-found where POSIX and bash exit **127**, so `cmd || fallback` and CI gates testing for 127 read a missing binary as an ordinary failure. `main` now maps `CommandNotFound` to 127. Fixing the message without the exit code would leave that trap standing.

```
$ rtk phpstan --version
rtk: phpstan: command not found     # exit 127
$ rtk mvn -v
rtk: mvn: command not found         # exit 127
```

## Why the diff is wide, and why it is the right layer

A first attempt patched the four `core/stream.rs` exec sites. That covered the shared runner path and **nothing else**, because 39 sites across 12 files call `.status()` / `.output()` / `.spawn()` directly. Patching exec sites was chasing symptoms: `resolved_command` is the single constructor every path already routes through (even `php_tool_command` delegates to it), so one signature change reaches all of them.

Hence the file count — it is mechanical `?` propagation through the Command-building helpers (`php_tool_command`, `git_cmd` and its git siblings, `package_manager_exec`, `create_prisma_command`, `new_gradle_command`, `new_mvn_command`) and their call sites, not 48 independent changes.

**Deliberate exceptions:**

- **Windows keeps the fallback.** A `.CMD`/`.BAT` wrapper can evade `which` while still being executable.
- **Two version probes do not propagate** (`detect_major_version`, `detect_go_tool_golangci_version`). Both are documented "returns 1 on any failure", they only select a formatting branch, and the real run reports the missing binary properly.

## Testing

`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all` are clean on this branch. Verified end-to-end: `rtk <missing>` prints `rtk: <name>: command not found` and exits 127; a resolvable binary is unaffected.