### PR TITLE
fix(hook): split compound commands on newlines for rewriting

### DIFF
--- a/src/discover/lexer.rs
+++ b/src/discover/lexer.rs
@@ -26,6 +26,15 @@ pub fn tokenize(input: &str) -> Vec<ParsedToken> {
     tokenize_inner(input, false)
 }
 
+/// Like [`tokenize`], but emits a `\n` (and `\r`) as an `Operator` token instead of
+/// treating it as plain whitespace. Multi-line command strings (e.g. `cd /x\ngrep foo`,
+/// common in worktree/`cd`-prefixed workflows) are equivalent to `;`-separated clauses,
+/// so the rewriter must break on them to reach each clause. See [`split_for_permissions`],
+/// which already tokenizes with newlines enabled.
+pub fn tokenize_with_newlines(input: &str) -> Vec<ParsedToken> {
+    tokenize_inner(input, true)
+}
+
 fn tokenize_inner(input: &str, emit_newline: bool) -> Vec<ParsedToken> {
     let mut tokens = Vec::new();
     let mut current = String::new();

--- a/src/discover/lexer.rs
+++ b/src/discover/lexer.rs
@@ -263,6 +263,14 @@ fn tokenize_inner(input: &str, emit_newline: bool) -> Vec<ParsedToken> {
                     offset: byte_pos,
                 });
                 byte_pos += char_len;
+                // Treat CRLF as a single logical newline so it yields exactly one
+                // separator token (no spurious blank clause). A raw CR/LF *inside*
+                // quotes never reaches here — it's consumed by the quote branch
+                // above — so this only collapses the real newline tokens.
+                if c == '\r' && chars.peek() == Some(&'\n') {
+                    chars.next();
+                    byte_pos += 1;
+                }
                 current_start = byte_pos;
             }
             c if c.is_whitespace() => {
@@ -1275,6 +1283,9 @@ mod tests {
         assert!(!contains_unattestable_construct("git log | head"));
         assert!(!contains_unattestable_construct("sleep 1 &"));
         assert!(!contains_unattestable_construct("git status\ncargo build"));
+        assert!(!contains_unattestable_construct(
+            "git status\r\ncargo build"
+        ));
     }
 
     #[test]
@@ -1342,6 +1353,30 @@ mod tests {
     #[test]
     fn test_split_perms_newline_inside_quotes_not_split() {
         let segments = split_for_permissions("echo 'line1\nline2'");
+        assert_eq!(segments.len(), 1);
+        assert!(segments[0].starts_with("echo"));
+    }
+
+    #[test]
+    fn test_split_perms_crlf() {
+        // CRLF between clauses is one separator (parity with LF): the permission
+        // layer must still see each clause as its own segment so a command hidden
+        // after a CRLF is scrutinized, not folded into its predecessor.
+        assert_eq!(
+            split_for_permissions("git status\r\nrm -rf ~"),
+            vec!["git status", "rm -rf ~"]
+        );
+    }
+
+    #[test]
+    fn test_split_perms_cr_inside_quotes_not_split() {
+        // A raw CR (or CRLF) *inside* quotes is not a separator, so it can't be
+        // used to smuggle a second command past per-segment permission checks: the
+        // quoted content stays part of a single segment.
+        let segments = split_for_permissions("echo 'a\rrm -rf ~'");
+        assert_eq!(segments.len(), 1);
+        assert!(segments[0].starts_with("echo"));
+        let segments = split_for_permissions("echo \"a\r\nrm -rf ~\"");
         assert_eq!(segments.len(), 1);
         assert!(segments[0].starts_with("echo"));
     }

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -2,7 +2,6 @@
 
 use crate::core::utils::composer_bin_dirs;
 use regex::{Regex, RegexSet};
-use std::borrow::Cow;
 use std::path::Path;
 use std::sync::LazyLock;
 
@@ -702,15 +701,6 @@ fn rewrite_compound(
     excluded: &[ExcludePattern],
     transparent_prefixes: &[String],
 ) -> Option<String> {
-    // Normalize CRLF/lone-CR to LF so one logical newline yields exactly one
-    // separator (avoids emitting a blank line for `\r\n`). Both the tokens and the
-    // slices below are taken from `cmd`, so they stay consistent.
-    let normalized: Cow<str> = if cmd.contains('\r') {
-        Cow::Owned(cmd.replace("\r\n", "\n").replace('\r', "\n"))
-    } else {
-        Cow::Borrowed(cmd)
-    };
-    let cmd = normalized.as_ref();
     // Newline-aware: a bare `\n` separates clauses just like `;`, so multi-line
     // commands (e.g. `cd /x\ngrep foo`) get each clause rewritten instead of being
     // swallowed as a single unrewritable segment.
@@ -3964,6 +3954,23 @@ mod tests {
         assert_eq!(
             rewrite_command_no_prefixes("cd /x\r\ngrep foo", &[]),
             Some("cd /x\nrtk grep foo".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_compound_cr_inside_quotes_not_a_separator() {
+        // A raw CR *inside* a quoted argument must not be treated as a clause
+        // separator: it stays part of the (single) segment and is preserved
+        // verbatim. Regression guard for over-broad CRLF normalization that used
+        // to `replace('\r', "\n")` across the whole command, splitting quoted CRs.
+        assert_eq!(
+            rewrite_command_no_prefixes("grep 'a\rb' file.txt", &[]),
+            Some("rtk grep 'a\rb' file.txt".into())
+        );
+        // Same for a CRLF sequence embedded in a quoted argument.
+        assert_eq!(
+            rewrite_command_no_prefixes("grep \"a\r\nb\" file.txt", &[]),
+            Some("rtk grep \"a\r\nb\" file.txt".into())
         );
     }
 

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -2,10 +2,14 @@
 
 use crate::core::utils::composer_bin_dirs;
 use regex::{Regex, RegexSet};
+use std::borrow::Cow;
 use std::path::Path;
 use std::sync::LazyLock;
 
-use super::lexer::{shell_split, split_on_operators, tokenize, ParsedToken, PipeKind, TokenKind};
+use super::lexer::{
+    shell_split, split_on_operators, tokenize, tokenize_with_newlines, ParsedToken, PipeKind,
+    TokenKind,
+};
 use super::rules::{IGNORED_EXACT, IGNORED_PREFIXES, RULES};
 
 const PHP_TOOL_NAMES: [&str; 6] = ["phpunit", "phpstan", "ecs", "pest", "paratest", "pint"];
@@ -590,7 +594,12 @@ pub fn rewrite_command(
         || trimmed.contains("||")
         || trimmed.contains(';')
         || trimmed.contains('|')
-        || trimmed.contains(" & ");
+        || trimmed.contains(" & ")
+        // A newline separates clauses too, so a command that starts with `rtk`
+        // but has more lines (`rtk gain\nls -la`) must still fall through so the
+        // later lines get rewritten instead of being returned verbatim.
+        || trimmed.contains('\n')
+        || trimmed.contains('\r');
     if !has_compound && (trimmed.starts_with("rtk ") || trimmed == "rtk") {
         return Some(trimmed.to_string());
     }
@@ -693,7 +702,19 @@ fn rewrite_compound(
     excluded: &[ExcludePattern],
     transparent_prefixes: &[String],
 ) -> Option<String> {
-    let tokens = tokenize(cmd);
+    // Normalize CRLF/lone-CR to LF so one logical newline yields exactly one
+    // separator (avoids emitting a blank line for `\r\n`). Both the tokens and the
+    // slices below are taken from `cmd`, so they stay consistent.
+    let normalized: Cow<str> = if cmd.contains('\r') {
+        Cow::Owned(cmd.replace("\r\n", "\n").replace('\r', "\n"))
+    } else {
+        Cow::Borrowed(cmd)
+    };
+    let cmd = normalized.as_ref();
+    // Newline-aware: a bare `\n` separates clauses just like `;`, so multi-line
+    // commands (e.g. `cd /x\ngrep foo`) get each clause rewritten instead of being
+    // swallowed as a single unrewritable segment.
+    let tokens = tokenize_with_newlines(cmd);
     let has_pipe = tokens
         .iter()
         .any(|token| matches!(token.kind, TokenKind::Pipe(_)));
@@ -727,6 +748,9 @@ fn rewrite_compound(
                     if after < cmd.len() {
                         result.push(' ');
                     }
+                } else if tok.value == "\n" {
+                    // Preserve the newline verbatim (no surrounding spaces), like `;`.
+                    result.push('\n');
                 } else {
                     result.push(' ');
                     result.push_str(&tok.value);
@@ -3884,6 +3908,71 @@ mod tests {
             Some("rtk git status; rtk cargo test".into())
         );
     }
+
+    #[test]
+    fn test_rewrite_compound_newline_cd_prefix() {
+        // A bare `\n` separates clauses like `;`: the `cd` clause is left untouched
+        // and the following clause is rewritten. This is the common worktree pattern
+        // (`cd <worktree>\n<cmd>`) that previously escaped rewriting entirely.
+        assert_eq!(
+            rewrite_command_no_prefixes("cd /x\ngrep foo bar", &[]),
+            Some("cd /x\nrtk grep foo bar".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_compound_newline_both_sides() {
+        assert_eq!(
+            rewrite_command_no_prefixes("git status\ngrep foo bar", &[]),
+            Some("rtk git status\nrtk grep foo bar".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_compound_newline_with_pipe() {
+        // Newline splits into clauses; the pipeline final stage inside the second
+        // clause still gets its producer left raw and `grep` rewritten.
+        assert_eq!(
+            rewrite_command_no_prefixes("cd /x\ngit log -10 | grep feat", &[]),
+            Some("cd /x\ngit log -10 | rtk grep feat".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_compound_newline_final() {
+        // A trailing newline is stripped by the outer `.trim()` before rewriting
+        // (harmless: a trailing blank line is a no-op), so no spurious segment.
+        assert_eq!(
+            rewrite_command_no_prefixes("grep foo bar\n", &[]),
+            Some("rtk grep foo bar".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_compound_newline_after_rtk_prefix() {
+        // Regression for the `has_compound` fast-path: a command that starts with
+        // `rtk` but has more lines must still rewrite the later lines.
+        assert_eq!(
+            rewrite_command_no_prefixes("rtk gain\nls -la", &[]),
+            Some("rtk gain\nrtk ls -la".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_compound_crlf_single_separator() {
+        // CRLF collapses to a single LF separator (no spurious blank line).
+        assert_eq!(
+            rewrite_command_no_prefixes("cd /x\r\ngrep foo", &[]),
+            Some("cd /x\nrtk grep foo".into())
+        );
+    }
+
+    // NOTE: safety of `\n` inside `$(...)`/backticks is enforced one layer up, at
+    // the hook/permission boundary (command substitution defers, never rewrites) —
+    // see `test_hook_newline_inside_command_substitution_defers` in hooks::hook_cmd.
+    // `rewrite_command` deliberately still rewrites the leading command of a segment
+    // even when a substitution is present (cf. `test_rewrite_command_substitution_passthrough`),
+    // so there is nothing to assert about substitution at this layer.
 
     #[test]
     fn test_rewrite_compound_pipe_raw_filter() {

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -1075,6 +1075,23 @@ mod tests {
     }
 
     #[test]
+    fn test_hook_newline_inside_command_substitution_defers() {
+        // Newline-aware rewriting must not corrupt a value captured in a multi-line
+        // `$(...)` / backtick substitution: the hook boundary defers on any command
+        // substitution, so no rewrite is emitted. Guards the newline-split change.
+        for cmd in [
+            "files=$(\n  grep foo bar\n)",
+            "echo $(grep a\ngrep b)",
+            "echo `grep foo\nbar`",
+        ] {
+            assert!(
+                end_to_end(cmd).is_none(),
+                "multi-line substitution must defer (no rewrite) for {cmd:?}"
+            );
+        }
+    }
+
+    #[test]
     fn test_copilot_cli_cve_file_redirect_amp_returns_none() {
         assert!(
             end_to_end("git status >& /tmp/evil").is_none(),


### PR DESCRIPTION
### Problem

The hook rewriter splits a command line on `&&`, `||`, `;` and `|` before rewriting each clause, but **not on a bare newline**. So a multi-line command such as

```
cd /some/worktree
grep foo bar.txt
```

is treated as a single unrewritable segment and escapes rewriting entirely — `grep`/`git`/`find`/… on the following lines never become `rtk grep`/… This is common in `cd <dir>`-prefixed and worktree-oriented workflows, where it drops rtk coverage on those commands to ~0%.

### Fix

- Add `tokenize_with_newlines` (thin wrapper over the existing `tokenize_inner(_, true)`) and use it in `rewrite_compound`, so a bare `\n` is treated as a clause separator like `;`. The `\n` is re-emitted verbatim in the rejoin (no surrounding spaces), preserving the original layout.
- Include `\n`/`\r` in the `has_compound` fast-path so a command that *starts* with `rtk` but has more lines (`rtk gain\nls -la`) still falls through and rewrites the later lines.
- Collapse `\r\n`/lone `\r` to a single `\n` separator so CRLF input doesn't emit a spurious blank line.

### Safety

Command-substitution safety is unaffected: the permission/hook layer already defers on `$(...)`/backticks (and other unattestable constructs) *before* rewriting, and the allow-per-segment permission verdict already splits on newlines (the existing newline-bypass CVE guards). This change only touches the rewriter, which runs after and independently of the permission verdict — it can't elevate a decision or change how a dangerous command is treated. Verified end-to-end that `git status\nrm -rf …` is byte-identical to before (no auto-allow) and that multi-line `$(...)` defers with no rewrite.

### Tests

New unit tests for: `cd`-prefixed newline, both-sides rewrite, newline+pipe, trailing newline, `rtk`-prefixed multi-line, CRLF collapse; plus a hook-level regression test that multi-line command substitution defers. `cargo fmt --check` and `cargo clippy --all-targets` clean; full suite green.
