### PR TITLE
fix(dotnet): ignore diagnostics in XML comments

### DIFF
--- a/src/cmds/dotnet/binlog.rs
+++ b/src/cmds/dotnet/binlog.rs
@@ -99,6 +99,8 @@ static RESTORE_DIAGNOSTIC_RE: LazyLock<Regex> = LazyLock::new(|| {
     )
     .expect("valid regex")
 });
+static XML_COMMENT_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?s)<!--.*?-->").expect("valid regex"));
 static PROJECT_PATH_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?m)^\s*([A-Za-z]:)?[^\r\n]*\.csproj(?:\s|$)").expect("valid regex")
 });
@@ -988,6 +990,8 @@ pub fn parse_restore_from_text(text: &str) -> RestoreSummary {
 
 pub fn parse_restore_issues_from_text(text: &str) -> (Vec<BinlogIssue>, Vec<BinlogIssue>) {
     let text = text.replace("\r\n", "\n");
+    // Binlogs embed imported project files, so exclude their comments from text fallbacks.
+    let text = XML_COMMENT_RE.replace_all(&text, "");
     let clean = strip_ansi(&text);
     let scrubbed = scrub_sensitive_env_vars(&clean);
     let mut errors = Vec::new();
@@ -1266,6 +1270,25 @@ Switch: /tmp/nonexistent.csproj
         assert!(summary.errors[0]
             .message
             .contains("Project file does not exist"));
+    }
+
+    #[test]
+    fn test_parse_build_from_text_ignores_diagnostics_in_xml_comments() {
+        let input = r#"
+<!--
+  If the resulting string is not a valid conditional compilation symbol,
+  the compiler will generate the following warning:
+    warning MSB3052: The parameter to the compiler is invalid, '/define:0BAD_DEFINE' will be ignored.
+-->
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+"#;
+
+        let summary = parse_build_from_text(input);
+        assert!(summary.succeeded);
+        assert!(summary.warnings.is_empty());
+        assert!(summary.errors.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- exclude XML comments before the fallback diagnostic regex scans binlog text
- prevent example diagnostics embedded in imported `.targets` files from becoming build warnings
- add a regression test for the .NET SDK `MSB3052` / `0BAD_DEFINE` comment

## Root cause

MSBuild binlogs include the full text of imported project and targets files. On otherwise clean builds, `parse_build_from_text` falls back to `parse_restore_issues_from_text`, whose diagnostic regex also matched warning-shaped lines inside XML comments. The .NET 10.0.302 SDK contains such an example for `MSB3052`, so RTK reported a warning that the compiler never emitted.

The fallback now strips XML comments before scanning for diagnostics. This is deliberately general rather than special-casing `0BAD_DEFINE`, so other example diagnostics in imported XML cannot surface the same way.

## Validation

- regression test demonstrated failing before the fix and passing afterward
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets`
- `cargo test --all` — 2566 passed, 8 ignored
- exact manual reproduction with official .NET SDK 10.0.302 on macOS arm64:
  - clean build: `1 warnings` before, `0 warnings` after
  - build with real `CS0219`: still reports the real warning and `1 warnings`

Fixes #3277
