### PR TITLE
fix(hook): delegate lint scripts to package managers

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -3837,16 +3837,12 @@ mod tests {
             "npm exec eslint",
             "npm rum biome",
             "npm rum eslint",
-            "npm rum lint",
             "npm run biome",
             "npm run eslint",
-            "npm run lint",
             "npm run-script biome",
             "npm run-script eslint",
-            "npm run-script lint",
             "npm urn biome",
             "npm urn eslint",
-            "npm urn lint",
             "npm x biome",
             "npm x eslint",
             "pnpm dlx biome",
@@ -3855,10 +3851,8 @@ mod tests {
             "pnpm exec eslint",
             "pnpm run biome",
             "pnpm run eslint",
-            "pnpm run lint",
             "pnpm run-script biome",
             "pnpm run-script eslint",
-            "pnpm run-script lint",
             "npm biome",
             "npm eslint",
             "npm lint",
@@ -3867,7 +3861,6 @@ mod tests {
             "npx lint",
             "pnpm biome",
             "pnpm eslint",
-            "pnpm lint",
             "pnpx biome",
             "pnpx eslint",
             "pnpx lint",
@@ -3897,16 +3890,12 @@ mod tests {
             "npm exec eslint",
             "npm rum biome",
             "npm rum eslint",
-            "npm rum lint",
             "npm run biome",
             "npm run eslint",
-            "npm run lint",
             "npm run-script biome",
             "npm run-script eslint",
-            "npm run-script lint",
             "npm urn biome",
             "npm urn eslint",
-            "npm urn lint",
             "npm x biome",
             "npm x eslint",
             "pnpm dlx biome",
@@ -3915,10 +3904,8 @@ mod tests {
             "pnpm exec eslint",
             "pnpm run biome",
             "pnpm run eslint",
-            "pnpm run lint",
             "pnpm run-script biome",
             "pnpm run-script eslint",
-            "pnpm run-script lint",
             "npm biome",
             "npm eslint",
             "npm lint",
@@ -3927,7 +3914,6 @@ mod tests {
             "npx lint",
             "pnpm biome",
             "pnpm eslint",
-            "pnpm lint",
             "pnpx biome",
             "pnpx eslint",
             "pnpx lint",
@@ -3939,6 +3925,26 @@ mod tests {
             assert_eq!(
                 rewrite_command_no_prefixes(command, &[]),
                 Some("rtk lint".into()),
+                "Failed for command: {}",
+                command
+            );
+        }
+    }
+
+    #[test]
+    fn test_rewrite_lint_scripts_delegate_to_package_manager() {
+        let commands = vec![
+            ("npm run lint", "rtk npm run lint"),
+            ("npm run-script lint", "rtk npm run-script lint"),
+            ("pnpm run lint", "rtk pnpm run lint"),
+            ("pnpm run-script lint", "rtk pnpm run-script lint"),
+            ("pnpm lint", "rtk pnpm lint"),
+        ];
+
+        for (command, expected) in commands {
+            assert_eq!(
+                rewrite_command_no_prefixes(command, &[]),
+                Some(expected.into()),
                 "Failed for command: {}",
                 command
             );

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -79,7 +79,7 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
-        pattern: r"^pnpm\s+(exec|i|install|list|ls|outdated|run|run-script)",
+        pattern: r"^pnpm\s+(exec|i|install|list|ls|outdated|run|run-script|lint)(\s|$)",
         rtk_cmd: "rtk pnpm",
         rewrite_prefixes: &["pnpm"],
         category: "PackageManager",
@@ -168,7 +168,7 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
-        pattern: r"^((p?np(m|x)|p?npm\s+(exec|run|run-script)|npm\s+(rum|urn|x)|pnpm\s+dlx)\s+)?(biome|eslint|lint)(\s|$)",
+        pattern: r"^((npx|pnpx|p?npm\s+exec|npm\s+x|pnpm\s+dlx)\s+)?(biome|eslint|lint)(\s|$)|^(?:npm|pnpm)\s+(?:biome|eslint)(\s|$)|^npm\s+lint(\s|$)|^p?npm\s+(?:run|run-script|rum|urn)\s+(?:biome|eslint)(\s|$)",
         rtk_cmd: "rtk lint",
         rewrite_prefixes: &[
             "biome",
@@ -181,16 +181,12 @@ pub const RULES: &[RtkRule] = &[
             "npm lint",
             "npm rum biome",
             "npm rum eslint",
-            "npm rum lint",
             "npm run biome",
             "npm run eslint",
-            "npm run lint",
             "npm run-script biome",
             "npm run-script eslint",
-            "npm run-script lint",
             "npm urn biome",
             "npm urn eslint",
-            "npm urn lint",
             "npm x biome",
             "npm x eslint",
             "npx biome",
@@ -202,13 +198,10 @@ pub const RULES: &[RtkRule] = &[
             "pnpm eslint",
             "pnpm exec biome",
             "pnpm exec eslint",
-            "pnpm lint",
             "pnpm run biome",
             "pnpm run eslint",
-            "pnpm run lint",
             "pnpm run-script biome",
             "pnpm run-script eslint",
-            "pnpm run-script lint",
             "pnpx biome",
             "pnpx eslint",
             "pnpx lint",


### PR DESCRIPTION
## Summary
- Keep `npm/pnpm run lint` and `pnpm lint` rewrites on the package-manager route so project scripts are preserved.
- Keep explicit ESLint/Biome invocations routed through `rtk lint`.

## Test verification (RED -> GREEN)
RED on upstream-base behavior with the new regression test:
```text
thread 'discover::registry::tests::test_rewrite_lint_scripts_delegate_to_package_manager' panicked at src/discover/registry.rs:3945:13:
assertion `left == right` failed: Failed for command: npm run lint
  left: Some("rtk lint")
 right: Some("rtk npm run lint")
test discover::registry::tests::test_rewrite_lint_scripts_delegate_to_package_manager ... FAILED
```

GREEN after the fix:
```text
test discover::registry::tests::test_rewrite_lint_scripts_delegate_to_package_manager ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2633 filtered out
```

Full local CI replay:
```text
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test --all
test result: ok. 2626 passed; 0 failed; 8 ignored; 0 measured; 0 filtered out
```

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all`
- [x] Manual testing: `rtk rewrite "npm run lint"` behavior covered by regression test

Fixes #3286

> **Important:** All PRs must target the `develop` branch (not `master`).