### PR TITLE
feat(hook): add Kiro CLI preToolUse hook support

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -42,6 +42,7 @@ Each agent subdirectory has its own README with hook-specific details:
 - **[`opencode/`](opencode/README.md)** — TypeScript plugin, `zx` library, `tool.execute.before` event, in-place mutation
 - **[`pi/`](pi/README.md)** — TypeScript extension, `tool_call` event, `isToolCallEventType` guard, in-place mutation, `~/.pi/agent/extensions/`
 - **[`hermes/`](hermes/README.md)** — Python plugin, `pre_tool_call` hook, in-place terminal command mutation
+- **[`kiro/`](kiro/README.md)** — Rust binary hook, `preToolUse` deny-with-suggestion (no transparent rewrite exists in Kiro's hook contract), manual `.kiro/agents/*.json` wiring
 
 ## Supported Agents
 
@@ -58,6 +59,7 @@ Each agent subdirectory has its own README with hook-specific details:
 | OpenCode | TypeScript plugin (`tool.execute.before`) | In-place mutation | Yes |
 | Pi | TypeScript extension (`tool_call` event) | In-place mutation | Yes |
 | Hermes | Python plugin (`pre_tool_call`) | In-place mutation | Yes |
+| Kiro CLI | Rust binary (`rtk hook kiro`) | Deny-with-suggestion | No (agent retries) |
 
 ## JSON Formats by Agent
 

--- a/hooks/kiro/README.md
+++ b/hooks/kiro/README.md
@@ -1,0 +1,41 @@
+# Kiro CLI Hooks
+
+> Part of [`hooks/`](../README.md) — see also [`src/hooks/`](../../src/hooks/README.md) for installation code
+
+## Specifics
+
+- Uses the `rtk hook kiro` Rust binary (not a shell script) — no `jq` dependency, matches the Copilot/Gemini/Droid binary-hook pattern rather than the Claude Code shell-script pattern.
+- Kiro's documented `preToolUse` hook contract ([kiro.dev CLI docs, "Hooks System"](https://kiro.dev/docs/cli/experimental/hooks/)) supports only two outcomes: **exit 0** (allow, unmodified) or **exit 2** (block, STDERR text is returned to the LLM). There is no `updatedInput`-equivalent transparent-rewrite mechanism — unlike Claude Code, Cursor, and VS Code Copilot Chat, a Kiro hook cannot silently substitute a different command for the agent to run.
+- This makes the integration **deny-with-suggestion**, structurally identical to the JetBrains Copilot IDE integration: on a real rewrite match, exit 2 with `[rtk] Use \`<rewritten>\` instead for reduced token usage.` on stderr. Kiro surfaces that stderr text back to the LLM, which can retry with the suggested command on its next turn.
+- Input JSON shape (per Kiro's docs): `{"hook_event_name":"preToolUse","cwd":"...","tool_name":"shell","tool_input":{"command":"..."}}`. The `shell` tool's documented legacy aliases (`execute_bash`, `execute_cmd`) are also matched, since older `tool_input` payloads may still use them.
+- Matches Copilot CLI's pattern for the exit-code contract specifically (§ "Exit Code Contract" in `../README.md`): all infrastructure failures (missing binary, bad JSON, non-shell tool, empty command) exit 0 — never block a command over a bug in this hook itself. Exit 2 is reserved exclusively for genuine, confirmed rewrite suggestions.
+
+## Kiro agent configuration wiring
+
+Kiro has no dedicated hook-installer directory convention like `~/.claude/settings.json` — hooks are declared per-agent inside `.kiro/agents/<name>.json` (or `~/.kiro/agents/<name>.json` for global agents). Add:
+
+```json
+{
+  "hooks": {
+    "preToolUse": [
+      {
+        "matcher": "shell",
+        "command": "rtk hook kiro",
+        "timeout_ms": 5000
+      }
+    ]
+  }
+}
+```
+
+`rtk init` does not yet automate this file edit for Kiro (unlike its `~/.claude/settings.json` JSON-patching for Claude Code) — this is a manual, one-line addition to whichever agent config(s) you want token-optimized. See `../../src/hooks/README.md` for the installer architecture if automating this is added later.
+
+## Testing
+
+```bash
+echo '{"hook_event_name":"preToolUse","cwd":"/tmp","tool_name":"shell","tool_input":{"command":"git status"}}' | rtk hook kiro
+echo "exit: $?"   # expect 2, stderr suggests `rtk git status`
+
+echo '{"hook_event_name":"preToolUse","cwd":"/tmp","tool_name":"shell","tool_input":{"command":"rtk git status"}}' | rtk hook kiro
+echo "exit: $?"   # expect 0, silent — already using rtk
+```

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -224,6 +224,80 @@ fn copilot_ide_response_from_decision(decision: HookDecision, cmd: &str) -> Opti
     }))
 }
 
+// ── Kiro CLI hook ──────────────────────────────────────────────
+//
+// Kiro's documented `preToolUse` hook contract (kiro-cli docs, "Hooks
+// System" + "Agent Configuration"):
+//   Input (stdin):  {"hook_event_name":"preToolUse","cwd":"...",
+//                    "tool_name":"shell","tool_input":{"command":"..."}}
+//   Exit 0:  allow tool execution, unchanged
+//   Exit 2:  block tool execution, STDERR returned to the LLM
+//   other:   warn to user, allow tool execution (command runs unmodified)
+//
+// Critically, there is NO documented `updatedInput`/transparent-rewrite
+// mechanism for Kiro (unlike Claude Code/Cursor/VS Code Copilot Chat) —
+// a preToolUse hook can only allow or block, never silently substitute a
+// different command. This makes Kiro structurally identical to the
+// JetBrains Copilot IDE integration above: the only honest option is
+// deny-with-suggestion (exit 2, put the `rtk`-prefixed command in
+// stderr so the calling LLM sees it and can retry with the rewritten
+// form itself). "Tool name" for the shell tool is `shell` per Kiro's
+// tool-naming docs, with `execute_bash`/`execute_cmd` as legacy aliases
+// that also appear in older tool_input payloads — all three are matched.
+//
+// Per the hooks README's Exit Code Contract, a hook must never exit
+// nonzero on infrastructure failure (missing binary, bad JSON, etc.) —
+// only exit 2 for an ACTUAL rewrite suggestion, since that's the one
+// case Kiro's contract defines as "block and surface stderr to the LLM"
+// rather than "warn the human and proceed anyway."
+pub fn run_kiro() -> i32 {
+    let input = match read_stdin_limited() {
+        Ok(s) => s,
+        Err(_) => return 0,
+    };
+    let input = strip_leading_bom(&input).trim();
+    if input.is_empty() {
+        return 0;
+    }
+
+    let v: Value = match serde_json::from_str(input) {
+        Ok(v) => v,
+        Err(_) => return 0,
+    };
+
+    let is_shell_tool = v
+        .get("tool_name")
+        .and_then(|t| t.as_str())
+        .map(|name| matches!(name, "shell" | "execute_bash" | "execute_cmd"))
+        .unwrap_or(false);
+    if !is_shell_tool {
+        return 0;
+    }
+
+    let Some(cmd) = v
+        .pointer("/tool_input/command")
+        .and_then(|c| c.as_str())
+        .filter(|c| !c.is_empty())
+    else {
+        return 0;
+    };
+
+    match decide_hook_action(cmd, permissions::Host::Kiro) {
+        HookDecision::Defer | HookDecision::Deny => 0,
+        HookDecision::AllowRewrite(rewritten) | HookDecision::AskRewrite { rewritten, .. } => {
+            audit_log("rewrite", cmd, &rewritten);
+            // Exit 2: Kiro blocks execution and returns this stderr text to
+            // the LLM (me), which sees the suggestion and can retry with
+            // `rtk <original command>` itself on the next turn.
+            let _ = writeln!(
+                io::stderr(),
+                "[rtk] Use `{rewritten}` instead for reduced token usage."
+            );
+            2
+        }
+    }
+}
+
 fn copilot_cli_response(cmd: &str, args: &Value) -> Option<Value> {
     copilot_cli_response_from_decision(
         args,

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -36,6 +36,13 @@ pub enum Host {
     Cursor,
     Gemini,
     Droid,
+    /// Kiro CLI. Reuses Claude's permission rule files — Kiro has no
+    /// separate rule-file convention of its own (no `.kiro/settings/rtk*`
+    /// equivalent exists yet), and its shell-command permission model
+    /// (`toolsSettings.shell.allowedCommands`/`deniedCommands` in
+    /// `.kiro/agents/*.json`) is enforced by Kiro itself independently of
+    /// this hook, so there's nothing Kiro-specific to load here.
+    Kiro,
 }
 
 pub fn check_command_for(cmd: &str, host: Host) -> PermissionVerdict {
@@ -44,6 +51,7 @@ pub fn check_command_for(cmd: &str, host: Host) -> PermissionVerdict {
         Host::Cursor => load_cursor_rules(),
         Host::Gemini => load_gemini_rules(),
         Host::Droid => load_droid_rules(),
+        Host::Kiro => load_permission_rules(),
     };
     check_command_with_rules(cmd, &deny_rules, &ask_rules, &allow_rules)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -866,6 +866,12 @@ enum HookCommands {
     Copilot,
     /// Process Factory Droid PreToolUse hook (reads JSON from stdin)
     Droid,
+    /// Process Kiro CLI preToolUse hook (reads JSON from stdin). Kiro's
+    /// hook contract only supports allow (exit 0) or block-with-stderr
+    /// (exit 2) — there is no `updatedInput`-style transparent rewrite —
+    /// so this always emits a deny-with-suggestion response, structurally
+    /// identical to the JetBrains Copilot IDE integration.
+    Kiro,
     /// Check how a command would be rewritten by the hook engine (dry-run)
     Check {
         /// Target agent
@@ -2438,6 +2444,7 @@ fn run_cli() -> Result<i32> {
                 hooks::hook_cmd::run_droid()?;
                 0
             }
+            HookCommands::Kiro => hooks::hook_cmd::run_kiro(),
             HookCommands::Check { agent: _, command } => {
                 use crate::discover::registry::rewrite_command;
                 let raw = command.join(" ");


### PR DESCRIPTION
## What

Adds `rtk hook kiro` — a `preToolUse` hook integration for [Kiro CLI](https://kiro.dev/docs/cli/), following the same deny-with-suggestion pattern already used for the JetBrains Copilot IDE integration.

## Why this approach

Kiro's documented `preToolUse` hook contract only supports two outcomes:
- **exit 0**: allow, unmodified
- **exit 2**: block, STDERR text is returned to the LLM

There is no `updatedInput`-equivalent transparent-rewrite mechanism like Claude Code, Cursor, or VS Code Copilot Chat have — a Kiro hook cannot silently substitute a different command. This makes Kiro structurally identical to the existing JetBrains Copilot IDE integration, not the Claude Code shell-hook pattern, so I followed that precedent rather than inventing something new.

On a real rewrite match, the hook exits 2 with `[rtk] Use `<rewritten>` instead for reduced token usage.` on stderr — Kiro surfaces that text back to the calling LLM, which can retry with the suggested command on its next turn.

## Changes

- `src/hooks/permissions.rs`: added `Host::Kiro` (reuses Claude's permission rule files — Kiro has no separate rule-file convention of its own yet)
- `src/hooks/hook_cmd.rs`: added `run_kiro()`, matching Kiro's documented JSON shape (`hook_event_name`/`tool_name`/`tool_input.command`), matching the `shell` tool name plus its documented legacy aliases (`execute_bash`, `execute_cmd`)
- `src/main.rs`: added `HookCommands::Kiro` subcommand + dispatch
- `hooks/kiro/README.md`: new, documents the integration and the manual `.kiro/agents/*.json` wiring (no automated `rtk init` installer for this yet — flagged as a follow-up, not attempted here to keep this PR scoped)
- `hooks/README.md`: added Kiro row to the agent table + directory listing

## Testing

Verified end-to-end with real stdin against all 4 cases:
```bash
echo '{"hook_event_name":"preToolUse","cwd":"/tmp","tool_name":"shell","tool_input":{"command":"git status"}}' | rtk hook kiro
# exit 2, stderr: [rtk] Use `rtk git status` instead for reduced token usage.

echo '{"hook_event_name":"preToolUse","cwd":"/tmp","tool_name":"shell","tool_input":{"command":"rtk git status"}}' | rtk hook kiro
# exit 0, silent — already using rtk

echo '{"hook_event_name":"preToolUse","cwd":"/tmp","tool_name":"fs_read","tool_input":{"operations":[]}}' | rtk hook kiro
# exit 0, silent — non-shell tool

echo '{"hook_event_name":"preToolUse","cwd":"/tmp","tool_name":"execute_bash","tool_input":{"command":"cargo test"}}' | rtk hook kiro
# exit 2, stderr: [rtk] Use `rtk cargo test` instead for reduced token usage. (legacy alias also matched)
```

`cargo fmt --all && cargo clippy --all-targets && cargo test --all` — all pass clean (2511 tests, 0 failures, 0 clippy warnings).

## Not included (flagged as follow-up, kept out of scope for this PR)

- No automated `rtk init` installer support for patching `.kiro/agents/*.json` (unlike the Claude Code `~/.claude/settings.json` JSON-patching path) — wiring is currently manual, documented in `hooks/kiro/README.md`.
- No `rtk hook check --agent kiro` / telemetry-string entries — happy to add in a follow-up if maintainers want parity there.