### PR TITLE
V3/codex hook

### DIFF
--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -12,6 +12,17 @@ pub const BEFORE_TOOL_KEY: &str = "BeforeTool";
 pub const CLAUDE_HOOK_COMMAND: &str = "rtk hook claude";
 /// Native Rust hook command for Cursor (replaces rtk-rewrite.sh).
 pub const CURSOR_HOOK_COMMAND: &str = "rtk hook cursor";
+/// Native Rust hook command for Codex CLI PreToolUse.
+pub const CODEX_HOOK_COMMAND: &str = "rtk hook codex";
+/// Codex hook config file ($CODEX_HOME/hooks.json). Codex also accepts
+/// inline `[[hooks]]` tables in config.toml; RTK writes the dedicated
+/// JSON file to avoid clobbering user-managed config.toml content.
+pub const CODEX_HOOKS_JSON: &str = "hooks.json";
+/// Marker field RTK writes inside each hook entry it owns. Lets uninstall
+/// identify RTK-managed entries even if the user has edited the command
+/// path (e.g. moved the rtk binary). Underscore-prefix prevents clash
+/// with reserved Codex schema field names.
+pub const CODEX_HOOK_RTK_MARKER: &str = "_rtk_managed";
 
 pub const CONFIG_DIR: &str = ".config";
 pub const OPENCODE_SUBDIR: &str = "opencode";

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -438,6 +438,83 @@ fn run_claude_inner(input: &str) -> Option<String> {
     }
 }
 
+// ── Codex CLI native hook ──────────────────────────────────────
+//
+// Codex's PreToolUse protocol (per developers.openai.com/codex/hooks):
+//   stdin  : {"hook_event_name":"PreToolUse","tool_name":"Bash",
+//             "tool_input":{"command":"..."}, session_id, turn_id, cwd, ...}
+//   stdout : {"hookSpecificOutput":{"hookEventName":"PreToolUse",
+//             "permissionDecision":"allow|deny", "updatedInput":{"command":"..."}}}
+//
+// The response schema is byte-identical to Claude's, so we reuse
+// `process_claude_payload`. Codex-specific differences live entirely in
+// `run_codex`: it emits `{}` (Codex's neutral no-opinion) on every
+// non-rewrite path (empty stdin, malformed JSON, non-Bash tool, skip,
+// ignore) rather than going silent. Codex semantics permit multiple
+// matching hooks to run concurrently — unlike Claude #1515, there is
+// no manifest fallthrough to engineer here.
+
+/// Run the Codex CLI PreToolUse hook natively.
+pub fn run_codex() -> Result<()> {
+    let input = read_stdin_limited()?;
+    let input = input.trim();
+    if input.is_empty() {
+        let _ = writeln!(io::stdout(), "{{}}");
+        return Ok(());
+    }
+
+    let v: Value = match serde_json::from_str(input) {
+        Ok(v) => v,
+        Err(_) => {
+            // Fail-open: emit neutral no-opinion, no stderr noise.
+            let _ = writeln!(io::stdout(), "{{}}");
+            return Ok(());
+        }
+    };
+
+    // Codex currently fires PreToolUse only for the Bash tool; defend
+    // against future event/tool expansion by emitting `{}` for anything
+    // else rather than misinterpreting the payload.
+    let tool_name = v.get("tool_name").and_then(|t| t.as_str()).unwrap_or("");
+    if tool_name != "Bash" {
+        let _ = writeln!(io::stdout(), "{{}}");
+        return Ok(());
+    }
+
+    match process_claude_payload(&v) {
+        PayloadAction::Rewrite {
+            cmd,
+            rewritten,
+            output,
+        } => {
+            audit_log("rewrite", &cmd, &rewritten);
+            let _ = writeln!(io::stdout(), "{output}");
+        }
+        PayloadAction::Skip { reason, cmd } => {
+            audit_log(reason, &cmd, "");
+            let _ = writeln!(io::stdout(), "{{}}");
+        }
+        PayloadAction::Ignore => {
+            let _ = writeln!(io::stdout(), "{{}}");
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+fn run_codex_inner(input: &str) -> Option<String> {
+    let v: Value = serde_json::from_str(input).ok()?;
+    let tool_name = v.get("tool_name").and_then(|t| t.as_str()).unwrap_or("");
+    if tool_name != "Bash" {
+        return None;
+    }
+    match process_claude_payload(&v) {
+        PayloadAction::Rewrite { output, .. } => Some(output.to_string()),
+        _ => None,
+    }
+}
+
 // ── Cursor native hook ─────────────────────────────────────────
 
 /// Cursor on Windows ships hook payloads with one or more leading
@@ -1016,6 +1093,160 @@ mod tests {
     fn test_claude_no_tool_input_passthrough() {
         let input = json!({ "tool_name": "Bash" }).to_string();
         assert!(run_claude_inner(&input).is_none());
+    }
+
+    // --- Codex handler ---
+
+    fn codex_input(cmd: &str) -> String {
+        // Codex PreToolUse stdin includes session/turn metadata that RTK
+        // ignores, plus the canonical Bash payload. Tests use the full
+        // shape to catch regressions where extra fields confuse parsing.
+        json!({
+            "session_id": "s-1234",
+            "tool_use_id": "tu-5678",
+            "turn_id": "t-9012",
+            "cwd": "/repo",
+            "permission_mode": "default",
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": { "command": cmd }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn test_codex_rewrite_git_status() {
+        let result = run_codex_inner(&codex_input("git status")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let cmd = v
+            .pointer("/hookSpecificOutput/updatedInput/command")
+            .and_then(|c| c.as_str())
+            .unwrap();
+        assert_eq!(cmd, "rtk git status");
+    }
+
+    #[test]
+    fn test_codex_output_matches_claude_schema_byte_for_byte() {
+        // RTK reuses process_claude_payload because the OpenAI Codex
+        // PreToolUse response schema is identical to Claude's. This test
+        // pins that invariant so a future Claude-only tweak that drifts
+        // the schema gets caught.
+        let codex = run_codex_inner(&codex_input("git status")).unwrap();
+        let claude = run_claude_inner(&claude_input("git status")).unwrap();
+        assert_eq!(codex, claude);
+    }
+
+    #[test]
+    fn test_codex_hookspecificoutput_structure() {
+        let result = run_codex_inner(&codex_input("git status")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let hook = &v["hookSpecificOutput"];
+        assert_eq!(hook["hookEventName"], PRE_TOOL_USE_KEY);
+        assert_eq!(hook["permissionDecisionReason"], "RTK auto-rewrite");
+        assert!(hook["updatedInput"].is_object());
+        assert!(hook["updatedInput"]["command"].is_string());
+    }
+
+    #[test]
+    fn test_codex_non_bash_tool_returns_none() {
+        // Codex PreToolUse currently only fires for Bash, but defensive:
+        // if a future Codex sends shell_view or fs_read here, RTK must
+        // refuse rather than misinterpret.
+        let input = json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "shell_view",
+            "tool_input": { "command": "git status" }
+        })
+        .to_string();
+        assert!(run_codex_inner(&input).is_none());
+    }
+
+    #[test]
+    fn test_codex_passthrough_no_output() {
+        // htop has no RTK rewrite — payload returns None (-> "{}" in I/O wrapper).
+        assert!(run_codex_inner(&codex_input("htop")).is_none());
+    }
+
+    #[test]
+    fn test_codex_already_rtk_passthrough() {
+        assert!(run_codex_inner(&codex_input("rtk git status")).is_none());
+    }
+
+    #[test]
+    fn test_codex_compound_command_rewrites_both_segments() {
+        let result = run_codex_inner(&codex_input("git add . && cargo test")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let cmd = v
+            .pointer("/hookSpecificOutput/updatedInput/command")
+            .and_then(|c| c.as_str())
+            .unwrap();
+        assert_eq!(cmd, "rtk git add . && rtk cargo test");
+    }
+
+    #[test]
+    fn test_codex_env_prefix_preserved() {
+        let result = run_codex_inner(&codex_input("GIT_PAGER=cat git status")).unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let cmd = v
+            .pointer("/hookSpecificOutput/updatedInput/command")
+            .and_then(|c| c.as_str())
+            .unwrap();
+        assert_eq!(cmd, "GIT_PAGER=cat rtk git status");
+    }
+
+    #[test]
+    fn test_codex_substitution_not_rewritten() {
+        // CVE-class: command substitution payloads must skip so Codex
+        // applies its own permission policy instead of auto-allowing.
+        assert!(run_codex_inner(&codex_input("git status `rm -rf /tmp/x`")).is_none());
+        assert!(run_codex_inner(&codex_input("git status $(rm -rf /tmp/x)")).is_none());
+    }
+
+    #[test]
+    fn test_codex_file_redirect_not_rewritten() {
+        assert!(run_codex_inner(&codex_input("git log > /tmp/out.txt")).is_none());
+    }
+
+    #[test]
+    fn test_codex_empty_command_returns_none() {
+        let input = json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": { "command": "" }
+        })
+        .to_string();
+        assert!(run_codex_inner(&input).is_none());
+    }
+
+    #[test]
+    fn test_codex_malformed_json_returns_none() {
+        assert!(run_codex_inner("not valid json {{{").is_none());
+    }
+
+    #[test]
+    fn test_codex_no_tool_input_returns_none() {
+        let input = json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash"
+        })
+        .to_string();
+        assert!(run_codex_inner(&input).is_none());
+    }
+
+    #[test]
+    fn test_codex_extra_session_fields_ignored() {
+        // session_id / turn_id / cwd / permission_mode must not affect
+        // the rewrite. codex_input() already adds them — this verifies
+        // a smaller payload with NONE of them rewrites identically.
+        let minimal = json!({
+            "tool_name": "Bash",
+            "tool_input": { "command": "git status" }
+        })
+        .to_string();
+        let full = codex_input("git status");
+        let minimal_out = run_codex_inner(&minimal).unwrap();
+        let full_out = run_codex_inner(&full).unwrap();
+        assert_eq!(minimal_out, full_out);
     }
 
     // --- Cursor handler ---

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -339,6 +339,12 @@ enum PayloadAction {
     Ignore,
 }
 
+#[derive(Clone, Copy)]
+enum AskRewriteHandling {
+    EmitWithoutAllow,
+    Skip(&'static str),
+}
+
 fn process_claude_payload(v: &Value) -> PayloadAction {
     let cmd = match v
         .pointer("/tool_input/command")
@@ -349,7 +355,22 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
         None => return PayloadAction::Ignore,
     };
 
-    let (rewritten, allow) = match decide_hook_action(cmd, permissions::Host::Claude) {
+    let decision = decide_hook_action(cmd, permissions::Host::Claude);
+    process_pre_tool_use_payload_with_decision(
+        v,
+        cmd,
+        decision,
+        AskRewriteHandling::EmitWithoutAllow,
+    )
+}
+
+fn process_pre_tool_use_payload_with_decision(
+    v: &Value,
+    cmd: &str,
+    decision: HookDecision,
+    ask_rewrite_handling: AskRewriteHandling,
+) -> PayloadAction {
+    let (rewritten, allow) = match decision {
         HookDecision::Deny => {
             return PayloadAction::Skip {
                 reason: "skip:deny_rule",
@@ -363,7 +384,15 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
             }
         }
         HookDecision::AllowRewrite(r) => (r, true),
-        HookDecision::AskRewrite(r) => (r, false),
+        HookDecision::AskRewrite(r) => match ask_rewrite_handling {
+            AskRewriteHandling::EmitWithoutAllow => (r, false),
+            AskRewriteHandling::Skip(reason) => {
+                return PayloadAction::Skip {
+                    reason,
+                    cmd: cmd.to_string(),
+                }
+            }
+        },
     };
 
     let updated_input = {
@@ -392,6 +421,33 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
         rewritten,
         output: json!({ "hookSpecificOutput": hook_output }),
     }
+}
+
+fn process_codex_payload(v: &Value) -> PayloadAction {
+    let cmd = match v
+        .pointer("/tool_input/command")
+        .and_then(|c| c.as_str())
+        .filter(|c| !c.is_empty())
+    {
+        Some(c) => c,
+        None => return PayloadAction::Ignore,
+    };
+
+    let decision = decide_hook_action(cmd, permissions::Host::Claude);
+    process_codex_payload_with_decision(v, cmd, decision)
+}
+
+fn process_codex_payload_with_decision(
+    v: &Value,
+    cmd: &str,
+    decision: HookDecision,
+) -> PayloadAction {
+    process_pre_tool_use_payload_with_decision(
+        v,
+        cmd,
+        decision,
+        AskRewriteHandling::Skip("skip:codex_requires_allow_for_updated_input"),
+    )
 }
 
 /// Run the Claude Code PreToolUse hook natively.
@@ -446,13 +502,13 @@ fn run_claude_inner(input: &str) -> Option<String> {
 //   stdout : {"hookSpecificOutput":{"hookEventName":"PreToolUse",
 //             "permissionDecision":"allow|deny", "updatedInput":{"command":"..."}}}
 //
-// The response schema is byte-identical to Claude's, so we reuse
-// `process_claude_payload`. Codex-specific differences live entirely in
-// `run_codex`: it emits `{}` (Codex's neutral no-opinion) on every
-// non-rewrite path (empty stdin, malformed JSON, non-Bash tool, skip,
-// ignore) rather than going silent. Codex semantics permit multiple
-// matching hooks to run concurrently — unlike Claude #1515, there is
-// no manifest fallthrough to engineer here.
+// Codex rejects `updatedInput` unless the same hook output also carries
+// `permissionDecision: "allow"`. Claude can rewrite and still let its
+// native prompt run by omitting `permissionDecision`; Codex cannot, so
+// `run_codex` only emits rewrites that RTK can explicitly allow and
+// emits `{}` (Codex's neutral no-opinion) for default/ask decisions.
+// Codex semantics permit multiple matching hooks to run concurrently —
+// unlike Claude #1515, there is no manifest fallthrough to engineer here.
 
 /// Run the Codex CLI PreToolUse hook natively.
 pub fn run_codex() -> Result<()> {
@@ -481,7 +537,7 @@ pub fn run_codex() -> Result<()> {
         return Ok(());
     }
 
-    match process_claude_payload(&v) {
+    match process_codex_payload(&v) {
         PayloadAction::Rewrite {
             cmd,
             rewritten,
@@ -509,7 +565,31 @@ fn run_codex_inner(input: &str) -> Option<String> {
     if tool_name != "Bash" {
         return None;
     }
-    match process_claude_payload(&v) {
+    match process_codex_payload(&v) {
+        PayloadAction::Rewrite { output, .. } => Some(output.to_string()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+fn run_codex_inner_with_rules(
+    input: &str,
+    deny: &[String],
+    ask: &[String],
+    allow: &[String],
+) -> Option<String> {
+    let v: Value = serde_json::from_str(input).ok()?;
+    let tool_name = v.get("tool_name").and_then(|t| t.as_str()).unwrap_or("");
+    if tool_name != "Bash" {
+        return None;
+    }
+    let cmd = v
+        .pointer("/tool_input/command")
+        .and_then(|c| c.as_str())
+        .filter(|c| !c.is_empty())?;
+    let verdict = permissions::check_command_with_rules(cmd, deny, ask, allow);
+    let decision = decide_from_verdict(cmd, verdict);
+    match process_codex_payload_with_decision(&v, cmd, decision) {
         PayloadAction::Rewrite { output, .. } => Some(output.to_string()),
         _ => None,
     }
@@ -1114,9 +1194,13 @@ mod tests {
         .to_string()
     }
 
+    fn run_codex_allowed(input: &str) -> Option<String> {
+        run_codex_inner_with_rules(input, &[], &[], &["*".to_string()])
+    }
+
     #[test]
     fn test_codex_rewrite_git_status() {
-        let result = run_codex_inner(&codex_input("git status")).unwrap();
+        let result = run_codex_allowed(&codex_input("git status")).unwrap();
         let v: Value = serde_json::from_str(&result).unwrap();
         let cmd = v
             .pointer("/hookSpecificOutput/updatedInput/command")
@@ -1126,22 +1210,28 @@ mod tests {
     }
 
     #[test]
-    fn test_codex_output_matches_claude_schema_byte_for_byte() {
-        // RTK reuses process_claude_payload because the OpenAI Codex
-        // PreToolUse response schema is identical to Claude's. This test
-        // pins that invariant so a future Claude-only tweak that drifts
-        // the schema gets caught.
-        let codex = run_codex_inner(&codex_input("git status")).unwrap();
-        let claude = run_claude_inner(&claude_input("git status")).unwrap();
-        assert_eq!(codex, claude);
+    fn test_codex_default_rewrite_returns_none_to_avoid_invalid_schema() {
+        assert!(run_codex_inner_with_rules(&codex_input("git status"), &[], &[], &[]).is_none());
+    }
+
+    #[test]
+    fn test_codex_ask_rewrite_returns_none_to_avoid_invalid_schema() {
+        assert!(run_codex_inner_with_rules(
+            &codex_input("git status"),
+            &[],
+            &["git *".to_string()],
+            &["git *".to_string()],
+        )
+        .is_none());
     }
 
     #[test]
     fn test_codex_hookspecificoutput_structure() {
-        let result = run_codex_inner(&codex_input("git status")).unwrap();
+        let result = run_codex_allowed(&codex_input("git status")).unwrap();
         let v: Value = serde_json::from_str(&result).unwrap();
         let hook = &v["hookSpecificOutput"];
         assert_eq!(hook["hookEventName"], PRE_TOOL_USE_KEY);
+        assert_eq!(hook["permissionDecision"], "allow");
         assert_eq!(hook["permissionDecisionReason"], "RTK auto-rewrite");
         assert!(hook["updatedInput"].is_object());
         assert!(hook["updatedInput"]["command"].is_string());
@@ -1158,23 +1248,23 @@ mod tests {
             "tool_input": { "command": "git status" }
         })
         .to_string();
-        assert!(run_codex_inner(&input).is_none());
+        assert!(run_codex_allowed(&input).is_none());
     }
 
     #[test]
     fn test_codex_passthrough_no_output() {
         // htop has no RTK rewrite — payload returns None (-> "{}" in I/O wrapper).
-        assert!(run_codex_inner(&codex_input("htop")).is_none());
+        assert!(run_codex_allowed(&codex_input("htop")).is_none());
     }
 
     #[test]
     fn test_codex_already_rtk_passthrough() {
-        assert!(run_codex_inner(&codex_input("rtk git status")).is_none());
+        assert!(run_codex_allowed(&codex_input("rtk git status")).is_none());
     }
 
     #[test]
     fn test_codex_compound_command_rewrites_both_segments() {
-        let result = run_codex_inner(&codex_input("git add . && cargo test")).unwrap();
+        let result = run_codex_allowed(&codex_input("git add . && cargo test")).unwrap();
         let v: Value = serde_json::from_str(&result).unwrap();
         let cmd = v
             .pointer("/hookSpecificOutput/updatedInput/command")
@@ -1185,7 +1275,7 @@ mod tests {
 
     #[test]
     fn test_codex_env_prefix_preserved() {
-        let result = run_codex_inner(&codex_input("GIT_PAGER=cat git status")).unwrap();
+        let result = run_codex_allowed(&codex_input("GIT_PAGER=cat git status")).unwrap();
         let v: Value = serde_json::from_str(&result).unwrap();
         let cmd = v
             .pointer("/hookSpecificOutput/updatedInput/command")
@@ -1198,13 +1288,13 @@ mod tests {
     fn test_codex_substitution_not_rewritten() {
         // CVE-class: command substitution payloads must skip so Codex
         // applies its own permission policy instead of auto-allowing.
-        assert!(run_codex_inner(&codex_input("git status `rm -rf /tmp/x`")).is_none());
-        assert!(run_codex_inner(&codex_input("git status $(rm -rf /tmp/x)")).is_none());
+        assert!(run_codex_allowed(&codex_input("git status `rm -rf /tmp/x`")).is_none());
+        assert!(run_codex_allowed(&codex_input("git status $(rm -rf /tmp/x)")).is_none());
     }
 
     #[test]
     fn test_codex_file_redirect_not_rewritten() {
-        assert!(run_codex_inner(&codex_input("git log > /tmp/out.txt")).is_none());
+        assert!(run_codex_allowed(&codex_input("git log > /tmp/out.txt")).is_none());
     }
 
     #[test]
@@ -1215,7 +1305,7 @@ mod tests {
             "tool_input": { "command": "" }
         })
         .to_string();
-        assert!(run_codex_inner(&input).is_none());
+        assert!(run_codex_allowed(&input).is_none());
     }
 
     #[test]
@@ -1244,8 +1334,8 @@ mod tests {
         })
         .to_string();
         let full = codex_input("git status");
-        let minimal_out = run_codex_inner(&minimal).unwrap();
-        let full_out = run_codex_inner(&full).unwrap();
+        let minimal_out = run_codex_allowed(&minimal).unwrap();
+        let full_out = run_codex_allowed(&full).unwrap();
         assert_eq!(minimal_out, full_out);
     }
 

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -1241,31 +1241,61 @@ mod tests {
         run_codex_inner_with_rules(input, &[], &[], &["*".to_string()])
     }
 
-    #[test]
-    fn test_codex_rewrite_git_status() {
-        let result = run_codex_allowed(&codex_input("git status")).unwrap();
-        let v: Value = serde_json::from_str(&result).unwrap();
-        let cmd = v
-            .pointer("/hookSpecificOutput/updatedInput/command")
-            .and_then(|c| c.as_str())
-            .unwrap();
-        assert_eq!(cmd, "rtk git status");
+    fn run_codex_allowed_json(input: &str) -> Option<Value> {
+        run_codex_allowed(input).map(|result| serde_json::from_str(&result).unwrap())
     }
 
     #[test]
-    fn test_codex_default_rewrite_returns_none_to_avoid_invalid_schema() {
-        assert!(run_codex_inner_with_rules(&codex_input("git status"), &[], &[], &[]).is_none());
+    fn test_codex_allowed_rewrites_emit_allow_with_updated_input() {
+        let cases = [
+            ("simple command", "git status", "rtk git status"),
+            (
+                "compound command",
+                "git add . && cargo test",
+                "rtk git add . && rtk cargo test",
+            ),
+            (
+                "environment prefix",
+                "GIT_PAGER=cat git status",
+                "GIT_PAGER=cat rtk git status",
+            ),
+        ];
+
+        for (name, input_command, expected_command) in cases {
+            let v = run_codex_allowed_json(&codex_input(input_command)).unwrap();
+            let hook = &v["hookSpecificOutput"];
+            assert_eq!(hook["hookEventName"], PRE_TOOL_USE_KEY, "{name}");
+            assert_eq!(hook["permissionDecision"], "allow", "{name}");
+            assert_eq!(
+                hook["permissionDecisionReason"], "RTK auto-rewrite",
+                "{name}"
+            );
+            assert_eq!(hook["updatedInput"]["command"], expected_command, "{name}");
+        }
     }
 
     #[test]
-    fn test_codex_ask_rewrite_returns_none_to_avoid_invalid_schema() {
-        assert!(run_codex_inner_with_rules(
-            &codex_input("git status"),
-            &[],
-            &["git *".to_string()],
-            &["git *".to_string()],
-        )
-        .is_none());
+    fn test_codex_non_allow_rewrites_return_none_to_avoid_invalid_schema() {
+        // Codex rejects `updatedInput` unless permissionDecision is `allow`;
+        // default/ask rewrites therefore emit no output and let Codex handle
+        // the original command through its native permission flow.
+        let cases = [
+            ("default", vec![], vec![], vec![]),
+            (
+                "ask",
+                vec![],
+                vec!["git *".to_string()],
+                vec!["git *".to_string()],
+            ),
+        ];
+
+        for (name, deny, ask, allow) in cases {
+            assert!(
+                run_codex_inner_with_rules(&codex_input("git status"), &deny, &ask, &allow)
+                    .is_none(),
+                "{name}"
+            );
+        }
     }
 
     #[test]
@@ -1289,18 +1319,6 @@ mod tests {
     }
 
     #[test]
-    fn test_codex_hookspecificoutput_structure() {
-        let result = run_codex_allowed(&codex_input("git status")).unwrap();
-        let v: Value = serde_json::from_str(&result).unwrap();
-        let hook = &v["hookSpecificOutput"];
-        assert_eq!(hook["hookEventName"], PRE_TOOL_USE_KEY);
-        assert_eq!(hook["permissionDecision"], "allow");
-        assert_eq!(hook["permissionDecisionReason"], "RTK auto-rewrite");
-        assert!(hook["updatedInput"].is_object());
-        assert!(hook["updatedInput"]["command"].is_string());
-    }
-
-    #[test]
     fn test_codex_non_bash_tool_returns_none() {
         // Codex PreToolUse currently only fires for Bash, but defensive:
         // if a future Codex sends shell_view or fs_read here, RTK must
@@ -1315,36 +1333,15 @@ mod tests {
     }
 
     #[test]
-    fn test_codex_passthrough_no_output() {
-        // htop has no RTK rewrite — payload returns None (-> "{}" in I/O wrapper).
-        assert!(run_codex_allowed(&codex_input("htop")).is_none());
-    }
-
-    #[test]
-    fn test_codex_already_rtk_passthrough() {
-        assert!(run_codex_allowed(&codex_input("rtk git status")).is_none());
-    }
-
-    #[test]
-    fn test_codex_compound_command_rewrites_both_segments() {
-        let result = run_codex_allowed(&codex_input("git add . && cargo test")).unwrap();
-        let v: Value = serde_json::from_str(&result).unwrap();
-        let cmd = v
-            .pointer("/hookSpecificOutput/updatedInput/command")
-            .and_then(|c| c.as_str())
-            .unwrap();
-        assert_eq!(cmd, "rtk git add . && rtk cargo test");
-    }
-
-    #[test]
-    fn test_codex_env_prefix_preserved() {
-        let result = run_codex_allowed(&codex_input("GIT_PAGER=cat git status")).unwrap();
-        let v: Value = serde_json::from_str(&result).unwrap();
-        let cmd = v
-            .pointer("/hookSpecificOutput/updatedInput/command")
-            .and_then(|c| c.as_str())
-            .unwrap();
-        assert_eq!(cmd, "GIT_PAGER=cat rtk git status");
+    fn test_codex_skip_cases_return_none() {
+        // htop has no RTK rewrite; already-prefixed and redirected commands
+        // must also skip so Codex sees no hook output (-> "{}" in I/O wrapper).
+        for command in ["htop", "rtk git status", "git log > /tmp/out.txt"] {
+            assert!(
+                run_codex_allowed(&codex_input(command)).is_none(),
+                "{command}"
+            );
+        }
     }
 
     #[test]
@@ -1356,34 +1353,31 @@ mod tests {
     }
 
     #[test]
-    fn test_codex_file_redirect_not_rewritten() {
-        assert!(run_codex_allowed(&codex_input("git log > /tmp/out.txt")).is_none());
-    }
+    fn test_codex_invalid_payloads_return_none() {
+        let cases = [
+            ("malformed json", "not valid json {{{".to_string()),
+            (
+                "empty command",
+                json!({
+                    "hook_event_name": "PreToolUse",
+                    "tool_name": "Bash",
+                    "tool_input": { "command": "" }
+                })
+                .to_string(),
+            ),
+            (
+                "missing tool_input",
+                json!({
+                    "hook_event_name": "PreToolUse",
+                    "tool_name": "Bash"
+                })
+                .to_string(),
+            ),
+        ];
 
-    #[test]
-    fn test_codex_empty_command_returns_none() {
-        let input = json!({
-            "hook_event_name": "PreToolUse",
-            "tool_name": "Bash",
-            "tool_input": { "command": "" }
-        })
-        .to_string();
-        assert!(run_codex_allowed(&input).is_none());
-    }
-
-    #[test]
-    fn test_codex_malformed_json_returns_none() {
-        assert!(run_codex_inner("not valid json {{{").is_none());
-    }
-
-    #[test]
-    fn test_codex_no_tool_input_returns_none() {
-        let input = json!({
-            "hook_event_name": "PreToolUse",
-            "tool_name": "Bash"
-        })
-        .to_string();
-        assert!(run_codex_inner(&input).is_none());
+        for (name, input) in cases {
+            assert!(run_codex_inner(&input).is_none(), "{name}");
+        }
     }
 
     #[test]

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -332,6 +332,10 @@ enum PayloadAction {
         rewritten: String,
         output: Value,
     },
+    Deny {
+        cmd: String,
+        reason: String,
+    },
     Skip {
         reason: &'static str,
         cmd: String,
@@ -344,6 +348,14 @@ enum AskRewriteHandling {
     EmitWithoutAllow,
     Skip(&'static str),
 }
+
+#[derive(Clone, Copy)]
+enum DenyHandling {
+    Skip(&'static str),
+    Emit(&'static str),
+}
+
+const RTK_PERMISSION_DENY_REASON: &str = "Blocked by RTK permission rule";
 
 fn process_claude_payload(v: &Value) -> PayloadAction {
     let cmd = match v
@@ -360,6 +372,7 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
         v,
         cmd,
         decision,
+        DenyHandling::Skip("skip:deny_rule"),
         AskRewriteHandling::EmitWithoutAllow,
     )
 }
@@ -368,15 +381,24 @@ fn process_pre_tool_use_payload_with_decision(
     v: &Value,
     cmd: &str,
     decision: HookDecision,
+    deny_handling: DenyHandling,
     ask_rewrite_handling: AskRewriteHandling,
 ) -> PayloadAction {
     let (rewritten, allow) = match decision {
-        HookDecision::Deny => {
-            return PayloadAction::Skip {
-                reason: "skip:deny_rule",
-                cmd: cmd.to_string(),
+        HookDecision::Deny => match deny_handling {
+            DenyHandling::Skip(reason) => {
+                return PayloadAction::Skip {
+                    reason,
+                    cmd: cmd.to_string(),
+                }
             }
-        }
+            DenyHandling::Emit(reason) => {
+                return PayloadAction::Deny {
+                    cmd: cmd.to_string(),
+                    reason: reason.to_string(),
+                }
+            }
+        },
         HookDecision::Defer => {
             return PayloadAction::Skip {
                 reason: "skip:defer",
@@ -446,8 +468,19 @@ fn process_codex_payload_with_decision(
         v,
         cmd,
         decision,
+        DenyHandling::Emit(RTK_PERMISSION_DENY_REASON),
         AskRewriteHandling::Skip("skip:codex_requires_allow_for_updated_input"),
     )
+}
+
+fn pre_tool_use_deny_output(reason: &str) -> Value {
+    json!({
+        "hookSpecificOutput": {
+            "hookEventName": PRE_TOOL_USE_KEY,
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason
+        }
+    })
 }
 
 /// Run the Claude Code PreToolUse hook natively.
@@ -478,6 +511,9 @@ pub fn run_claude() -> Result<()> {
         }
         PayloadAction::Skip { reason, cmd } => {
             audit_log(reason, &cmd, "");
+        }
+        PayloadAction::Deny { reason, cmd, .. } => {
+            audit_log("deny", &cmd, &reason);
         }
         PayloadAction::Ignore => {}
     }
@@ -550,6 +586,11 @@ pub fn run_codex() -> Result<()> {
             audit_log(reason, &cmd, "");
             let _ = writeln!(io::stdout(), "{{}}");
         }
+        PayloadAction::Deny { cmd, reason } => {
+            audit_log("deny", &cmd, &reason);
+            let output = pre_tool_use_deny_output(&reason);
+            let _ = writeln!(io::stdout(), "{output}");
+        }
         PayloadAction::Ignore => {
             let _ = writeln!(io::stdout(), "{{}}");
         }
@@ -567,6 +608,7 @@ fn run_codex_inner(input: &str) -> Option<String> {
     }
     match process_codex_payload(&v) {
         PayloadAction::Rewrite { output, .. } => Some(output.to_string()),
+        PayloadAction::Deny { reason, .. } => Some(pre_tool_use_deny_output(&reason).to_string()),
         _ => None,
     }
 }
@@ -591,6 +633,7 @@ fn run_codex_inner_with_rules(
     let decision = decide_from_verdict(cmd, verdict);
     match process_codex_payload_with_decision(&v, cmd, decision) {
         PayloadAction::Rewrite { output, .. } => Some(output.to_string()),
+        PayloadAction::Deny { reason, .. } => Some(pre_tool_use_deny_output(&reason).to_string()),
         _ => None,
     }
 }
@@ -1223,6 +1266,26 @@ mod tests {
             &["git *".to_string()],
         )
         .is_none());
+    }
+
+    #[test]
+    fn test_codex_deny_emits_block_without_updated_input() {
+        let result = run_codex_inner_with_rules(
+            &codex_input("git status"),
+            &["git status".to_string()],
+            &[],
+            &["*".to_string()],
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let hook = &v["hookSpecificOutput"];
+        assert_eq!(hook["hookEventName"], PRE_TOOL_USE_KEY);
+        assert_eq!(hook["permissionDecision"], "deny");
+        assert_eq!(
+            hook["permissionDecisionReason"],
+            "Blocked by RTK permission rule"
+        );
+        assert!(hook.get("updatedInput").is_none());
     }
 
     #[test]

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -934,20 +934,21 @@ fn uninstall_codex_at(codex_dir: &Path, ctx: InitContext) -> Result<Vec<String>>
             .with_context(|| format!("Failed to read hooks.json: {}", hooks_json_path.display()))?;
         match remove_codex_hook_from_json(&content, CODEX_HOOK_COMMAND)? {
             Some(new_content) if new_content.is_empty() => {
+                let empty_hooks_json = "{}\n";
                 if dry_run {
                     println!(
-                        "[dry-run] would remove empty hooks.json: {}",
+                        "[dry-run] would clear empty hooks.json: {}",
                         hooks_json_path.display()
                     );
                 } else {
-                    fs::remove_file(&hooks_json_path).with_context(|| {
-                        format!("Failed to remove hooks.json: {}", hooks_json_path.display())
+                    atomic_write(&hooks_json_path, empty_hooks_json).with_context(|| {
+                        format!("Failed to clear hooks.json: {}", hooks_json_path.display())
                     })?;
                     if verbose > 0 {
-                        eprintln!("Removed empty hooks.json: {}", hooks_json_path.display());
+                        eprintln!("Cleared empty hooks.json: {}", hooks_json_path.display());
                     }
                 }
-                removed.push(format!("hooks.json: {}", hooks_json_path.display()));
+                removed.push("hooks.json: cleared RTK-only content".to_string());
             }
             Some(new_content) => {
                 if dry_run {
@@ -5882,7 +5883,7 @@ mod tests {
     }
 
     #[test]
-    fn test_uninstall_codex_at_deletes_hooks_json_when_only_rtk_entry_present() {
+    fn test_uninstall_codex_at_clears_hooks_json_when_only_rtk_entry_present() {
         let temp = TempDir::new().unwrap();
         let codex_dir = temp.path();
         let hooks_json = codex_dir.join("hooks.json");
@@ -5906,10 +5907,8 @@ mod tests {
         .unwrap();
 
         uninstall_codex_at(codex_dir, InitContext::default()).unwrap();
-        assert!(
-            !hooks_json.exists(),
-            "hooks.json with only rtk entry must be deleted"
-        );
+        let cleared = fs::read_to_string(&hooks_json).unwrap();
+        assert_eq!(cleared, "{}\n", "RTK-only hooks.json must be cleared");
     }
 
     #[test]

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -4754,8 +4754,7 @@ mod tests {
 
     #[test]
     fn test_codex_mode_accepts_auto_patch() {
-        // v3 change (was: --codex --auto-patch rejected, before Codex shipped
-        // PreToolUse Bash interception). Now: --auto-patch ALSO writes
+        // Native Codex hook mode allows --auto-patch so install can write
         // ~/.codex/hooks.json. Use dry_run to avoid touching the real $HOME.
         let r = run(
             false,
@@ -4773,14 +4772,13 @@ mod tests {
                 ..Default::default()
             },
         );
-        assert!(r.is_ok(), "--codex --auto-patch must succeed (v3): {r:?}");
+        assert!(r.is_ok(), "--codex --auto-patch must succeed: {r:?}");
     }
 
     #[test]
     fn test_codex_mode_accepts_no_patch() {
-        // v3 change: --codex --no-patch now means file-only mode
-        // (RTK.md + AGENTS.md, no hooks.json) — same as bare --codex.
-        // Use dry_run to avoid touching the real $HOME.
+        // --codex --no-patch is file-only mode: RTK.md + AGENTS.md,
+        // no hooks.json. Use dry_run to avoid touching the real $HOME.
         let r = run(
             false,
             false,
@@ -4797,7 +4795,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        assert!(r.is_ok(), "--codex --no-patch must succeed (v3): {r:?}");
+        assert!(r.is_ok(), "--codex --no-patch must succeed: {r:?}");
     }
 
     #[test]
@@ -5609,18 +5607,29 @@ mod tests {
 
     // --- Codex hooks.json install / upsert / uninstall ---
 
+    fn parse_codex_hooks_json(output: &str) -> serde_json::Value {
+        serde_json::from_str(output).unwrap()
+    }
+
+    fn codex_pre_tool_use_entries(root: &serde_json::Value) -> &[serde_json::Value] {
+        root.pointer("/hooks/PreToolUse")
+            .and_then(|a| a.as_array())
+            .unwrap()
+    }
+
+    fn codex_hook_command(entries: &[serde_json::Value], index: usize) -> &str {
+        entries[index]["hooks"][0]["command"].as_str().unwrap()
+    }
+
     #[test]
     fn test_codex_upsert_adds_to_empty_file() {
         let (out, action) = upsert_codex_hook_json(None, CODEX_HOOK_COMMAND).unwrap();
         assert_eq!(action, CodexHookUpsert::Added);
-        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let entries = v
-            .pointer("/hooks/PreToolUse")
-            .and_then(|a| a.as_array())
-            .unwrap();
+        let v = parse_codex_hooks_json(&out);
+        let entries = codex_pre_tool_use_entries(&v);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0]["matcher"], "^Bash$");
-        assert_eq!(entries[0]["hooks"][0]["command"], CODEX_HOOK_COMMAND);
+        assert_eq!(codex_hook_command(entries, 0), CODEX_HOOK_COMMAND);
         assert_eq!(entries[0]["hooks"][0][CODEX_HOOK_RTK_MARKER], true);
         assert_eq!(entries[0]["hooks"][0]["timeout"], 30);
     }
@@ -5654,11 +5663,8 @@ mod tests {
         .to_string();
         let (out, action) = upsert_codex_hook_json(Some(&existing), CODEX_HOOK_COMMAND).unwrap();
         assert_eq!(action, CodexHookUpsert::Added);
-        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let entries = v
-            .pointer("/hooks/PreToolUse")
-            .and_then(|a| a.as_array())
-            .unwrap();
+        let v = parse_codex_hooks_json(&out);
+        let entries = codex_pre_tool_use_entries(&v);
         assert_eq!(
             entries.len(),
             2,
@@ -5666,10 +5672,10 @@ mod tests {
         );
         // Foreign first, rtk appended.
         assert_eq!(
-            entries[0]["hooks"][0]["command"],
+            codex_hook_command(entries, 0),
             "/usr/local/bin/my-audit-logger"
         );
-        assert_eq!(entries[1]["hooks"][0]["command"], CODEX_HOOK_COMMAND);
+        assert_eq!(codex_hook_command(entries, 1), CODEX_HOOK_COMMAND);
     }
 
     #[test]
@@ -5692,13 +5698,10 @@ mod tests {
         .to_string();
         let (out, action) = upsert_codex_hook_json(Some(&existing), CODEX_HOOK_COMMAND).unwrap();
         assert_eq!(action, CodexHookUpsert::Updated);
-        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let entries = v
-            .pointer("/hooks/PreToolUse")
-            .and_then(|a| a.as_array())
-            .unwrap();
+        let v = parse_codex_hooks_json(&out);
+        let entries = codex_pre_tool_use_entries(&v);
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0]["hooks"][0]["command"], CODEX_HOOK_COMMAND);
+        assert_eq!(codex_hook_command(entries, 0), CODEX_HOOK_COMMAND);
     }
 
     #[test]
@@ -5721,13 +5724,10 @@ mod tests {
         .to_string();
         let (out, action) = upsert_codex_hook_json(Some(&existing), CODEX_HOOK_COMMAND).unwrap();
         assert_eq!(action, CodexHookUpsert::Updated);
-        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
-        let entries = v
-            .pointer("/hooks/PreToolUse")
-            .and_then(|a| a.as_array())
-            .unwrap();
+        let v = parse_codex_hooks_json(&out);
+        let entries = codex_pre_tool_use_entries(&v);
         assert_eq!(entries.len(), 1, "must not duplicate the rtk entry");
-        assert_eq!(entries[0]["hooks"][0]["command"], CODEX_HOOK_COMMAND);
+        assert_eq!(codex_hook_command(entries, 0), CODEX_HOOK_COMMAND);
         assert_eq!(entries[0]["hooks"][0][CODEX_HOOK_RTK_MARKER], true);
     }
 
@@ -5788,14 +5788,11 @@ mod tests {
         let result = remove_codex_hook_from_json(&mixed, CODEX_HOOK_COMMAND)
             .unwrap()
             .expect("rtk entry should have been removed");
-        let v: serde_json::Value = serde_json::from_str(&result).unwrap();
-        let entries = v
-            .pointer("/hooks/PreToolUse")
-            .and_then(|a| a.as_array())
-            .unwrap();
+        let v = parse_codex_hooks_json(&result);
+        let entries = codex_pre_tool_use_entries(&v);
         assert_eq!(entries.len(), 1);
         assert_eq!(
-            entries[0]["hooks"][0]["command"],
+            codex_hook_command(entries, 0),
             "/usr/local/bin/my-audit-logger"
         );
     }
@@ -5875,15 +5872,11 @@ mod tests {
             "uninstall report must mention hooks.json, got: {removed:?}"
         );
 
-        let after: serde_json::Value =
-            serde_json::from_str(&fs::read_to_string(&hooks_json).unwrap()).unwrap();
-        let entries = after
-            .pointer("/hooks/PreToolUse")
-            .and_then(|a| a.as_array())
-            .unwrap();
+        let after = parse_codex_hooks_json(&fs::read_to_string(&hooks_json).unwrap());
+        let entries = codex_pre_tool_use_entries(&after);
         assert_eq!(entries.len(), 1);
         assert_eq!(
-            entries[0]["hooks"][0]["command"],
+            codex_hook_command(entries, 0),
             "/usr/local/bin/my-audit-logger"
         );
     }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -13,11 +13,12 @@ use crate::hooks::constants::{
 };
 
 use super::constants::{
-    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CURSOR_HOOK_COMMAND,
-    GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_INIT_FILE,
-    HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON, HOOKS_SUBDIR,
-    PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR, PI_PLUGIN_FILE,
-    PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
+    BEFORE_TOOL_KEY, CLAUDE_DIR, CLAUDE_HOOK_COMMAND, CODEX_DIR, CODEX_HOOKS_JSON,
+    CODEX_HOOK_COMMAND, CODEX_HOOK_RTK_MARKER, CURSOR_HOOK_COMMAND, GEMINI_HOOK_FILE, HERMES_DIR,
+    HERMES_PLUGINS_SUBDIR, HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE,
+    HERMES_PLUGIN_NAME, HOOKS_JSON, HOOKS_SUBDIR, PI_CODING_AGENT_DIR_ENV, PI_DIR,
+    PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR, PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE,
+    SETTINGS_JSON,
 };
 use super::integrity;
 
@@ -273,13 +274,12 @@ pub fn run(
         if hook_only {
             anyhow::bail!("--codex cannot be combined with --hook-only");
         }
-        if matches!(patch_mode, PatchMode::Auto) {
-            anyhow::bail!("--codex cannot be combined with --auto-patch");
-        }
-        if matches!(patch_mode, PatchMode::Skip) {
-            anyhow::bail!("--codex cannot be combined with --no-patch");
-        }
-        run_codex_mode(global, ctx)?;
+        // `--codex --auto-patch` now ALSO writes ~/.codex/hooks.json
+        // (Codex CLI added PreToolUse Bash interception in v0.117.0).
+        // `--codex --no-patch` keeps the file-only behavior — same as bare
+        // `--codex`. Both are valid; we forward patch_mode into the codex
+        // installer which decides whether to write the hook config.
+        run_codex_mode(global, patch_mode, ctx)?;
     } else {
         // Validation: Global-only features
         if install_opencode && !global {
@@ -923,6 +923,53 @@ fn uninstall_codex_at(codex_dir: &Path, ctx: InitContext) -> Result<Vec<String>>
         ctx,
     )? {
         removed.push("AGENTS.md: removed @RTK.md reference".to_string());
+    }
+
+    // Remove RTK's PreToolUse entry from hooks.json (if present).
+    // Foreign entries stay; we only ever delete what we own (matched by
+    // the `_rtk_managed` marker or a `rtk hook codex` command prefix).
+    let hooks_json_path = codex_dir.join(CODEX_HOOKS_JSON);
+    if hooks_json_path.exists() {
+        let content = fs::read_to_string(&hooks_json_path)
+            .with_context(|| format!("Failed to read hooks.json: {}", hooks_json_path.display()))?;
+        match remove_codex_hook_from_json(&content, CODEX_HOOK_COMMAND)? {
+            Some(new_content) if new_content.is_empty() => {
+                if dry_run {
+                    println!(
+                        "[dry-run] would remove empty hooks.json: {}",
+                        hooks_json_path.display()
+                    );
+                } else {
+                    fs::remove_file(&hooks_json_path).with_context(|| {
+                        format!("Failed to remove hooks.json: {}", hooks_json_path.display())
+                    })?;
+                    if verbose > 0 {
+                        eprintln!("Removed empty hooks.json: {}", hooks_json_path.display());
+                    }
+                }
+                removed.push(format!("hooks.json: {}", hooks_json_path.display()));
+            }
+            Some(new_content) => {
+                if dry_run {
+                    println!(
+                        "[dry-run] would update hooks.json: remove RTK PreToolUse entry from {}",
+                        hooks_json_path.display()
+                    );
+                } else {
+                    atomic_write(&hooks_json_path, &new_content).with_context(|| {
+                        format!("Failed to write hooks.json: {}", hooks_json_path.display())
+                    })?;
+                    if verbose > 0 {
+                        eprintln!(
+                            "Removed RTK PreToolUse entry from hooks.json: {}",
+                            hooks_json_path.display()
+                        );
+                    }
+                }
+                removed.push("hooks.json: removed RTK PreToolUse entry".to_string());
+            }
+            None => {}
+        }
     }
 
     Ok(removed)
@@ -2256,21 +2303,38 @@ fn normalized_yaml_scalar(value: &str) -> Option<String> {
     (!trimmed.is_empty()).then(|| trimmed.to_string())
 }
 
-fn run_codex_mode(global: bool, ctx: InitContext) -> Result<()> {
-    let (agents_md_path, rtk_md_path) = if global {
+fn run_codex_mode(global: bool, patch_mode: PatchMode, ctx: InitContext) -> Result<()> {
+    let (agents_md_path, rtk_md_path, hooks_json_path) = if global {
         let codex_dir = resolve_codex_dir()?;
-        (codex_dir.join(AGENTS_MD), codex_dir.join(RTK_MD))
+        (
+            codex_dir.join(AGENTS_MD),
+            codex_dir.join(RTK_MD),
+            codex_dir.join(CODEX_HOOKS_JSON),
+        )
     } else {
-        (PathBuf::from(AGENTS_MD), PathBuf::from(RTK_MD))
+        (
+            PathBuf::from(AGENTS_MD),
+            PathBuf::from(RTK_MD),
+            PathBuf::from(".codex").join(CODEX_HOOKS_JSON),
+        )
     };
 
-    run_codex_mode_with_paths(agents_md_path, rtk_md_path, global, ctx)
+    run_codex_mode_with_paths(
+        agents_md_path,
+        rtk_md_path,
+        hooks_json_path,
+        global,
+        patch_mode,
+        ctx,
+    )
 }
 
 fn run_codex_mode_with_paths(
     agents_md_path: PathBuf,
     rtk_md_path: PathBuf,
+    hooks_json_path: PathBuf,
     global: bool,
+    patch_mode: PatchMode,
     ctx: InitContext,
 ) -> Result<()> {
     let InitContext { dry_run, .. } = ctx;
@@ -2301,6 +2365,17 @@ fn run_codex_mode_with_paths(
     write_if_changed(&rtk_md_path, RTK_SLIM_CODEX, RTK_MD, ctx)?;
     let added_ref = patch_agents_md(&agents_md_path, &rtk_md_ref, ctx)?;
 
+    // PreToolUse hook installation (opt-in via --auto-patch).
+    // Codex semantics permit multiple matching hooks to run concurrently
+    // (developers.openai.com/codex/hooks), so we APPEND to any existing
+    // hooks.json rather than displacing foreign entries. Idempotent: a
+    // second run with the same rtk binary path is a no-op.
+    let hook_action = if matches!(patch_mode, PatchMode::Auto) {
+        Some(install_codex_hook(&hooks_json_path, ctx)?)
+    } else {
+        None
+    };
+
     if !dry_run {
         println!("\nRTK configured for Codex CLI.\n");
         println!("  RTK.md:    {}", rtk_md_path.display());
@@ -2308,6 +2383,37 @@ fn run_codex_mode_with_paths(
             println!("  AGENTS.md: {} reference added", rtk_md_ref);
         } else {
             println!("  AGENTS.md: {} reference already present", rtk_md_ref);
+        }
+        match hook_action {
+            Some(CodexHookUpsert::Added) => {
+                println!(
+                    "  hooks.json: PreToolUse hook installed at {}",
+                    hooks_json_path.display()
+                );
+                println!(
+                    "\n  Next: run `codex` and open `/hooks` to review & trust the new RTK hook."
+                );
+            }
+            Some(CodexHookUpsert::Updated) => {
+                println!(
+                    "  hooks.json: existing RTK hook entry updated at {}",
+                    hooks_json_path.display()
+                );
+                println!(
+                    "\n  Note: if you previously trusted this hook, the SHA changed —\n        re-trust via `codex` -> `/hooks` if Codex flags it."
+                );
+            }
+            Some(CodexHookUpsert::Unchanged) => {
+                println!(
+                    "  hooks.json: RTK PreToolUse hook already present (unchanged) at {}",
+                    hooks_json_path.display()
+                );
+            }
+            None => {
+                println!(
+                    "  hooks.json: skipped (file-only mode). Re-run with --auto-patch to install."
+                );
+            }
         }
         if global {
             println!(
@@ -2323,6 +2429,279 @@ fn run_codex_mode_with_paths(
     }
 
     Ok(())
+}
+
+// --- Codex CLI PreToolUse hook installer ---
+//
+// Writes a JSON config to `$CODEX_HOME/hooks.json` that registers
+// `rtk hook codex` as a Bash-matcher PreToolUse hook. The file is the
+// dedicated discovery location Codex uses (alongside inline `[hooks]`
+// tables in `config.toml`); RTK chooses hooks.json to avoid mutating
+// the user's config.toml at all.
+//
+// Codex semantics (developers.openai.com/codex/hooks): "Multiple
+// matching command hooks for the same event are launched concurrently,
+// so one hook cannot prevent another matching hook from starting." So
+// unlike Claude #1515, there is NO collision to engineer around — we
+// append our hook alongside any existing entries and Codex runs them
+// all. Foreign entries (user-managed or other tools) are preserved
+// verbatim.
+//
+// Each entry RTK owns carries a `_rtk_managed: true` marker that lets
+// uninstall find them even if the user later edits the command path
+// (e.g. moves the rtk binary). Re-installing is fully idempotent: a
+// matching entry with the same command + same marker leaves the file
+// untouched.
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum CodexHookUpsert {
+    /// File didn't exist or had no RTK entry — appended a new one.
+    Added,
+    /// RTK entry existed but command changed — updated in place.
+    Updated,
+    /// RTK entry already present with identical content — no-op.
+    Unchanged,
+}
+
+fn install_codex_hook(hooks_json_path: &Path, ctx: InitContext) -> Result<CodexHookUpsert> {
+    let InitContext { dry_run, .. } = ctx;
+
+    let existing = if hooks_json_path.exists() {
+        Some(
+            fs::read_to_string(hooks_json_path)
+                .with_context(|| format!("Failed to read {}", hooks_json_path.display()))?,
+        )
+    } else {
+        None
+    };
+
+    let (new_json, action) = upsert_codex_hook_json(existing.as_deref(), CODEX_HOOK_COMMAND)?;
+
+    if matches!(action, CodexHookUpsert::Unchanged) {
+        return Ok(action);
+    }
+
+    if dry_run {
+        match action {
+            CodexHookUpsert::Added => println!(
+                "[dry-run] would add Codex PreToolUse hook entry to {}",
+                hooks_json_path.display()
+            ),
+            CodexHookUpsert::Updated => println!(
+                "[dry-run] would update Codex PreToolUse hook entry in {}",
+                hooks_json_path.display()
+            ),
+            CodexHookUpsert::Unchanged => {} // already returned above
+        }
+        return Ok(action);
+    }
+
+    if let Some(parent) = hooks_json_path.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "Failed to create Codex config directory: {}",
+                parent.display()
+            )
+        })?;
+    }
+
+    atomic_write(hooks_json_path, &new_json)
+        .with_context(|| format!("Failed to write {}", hooks_json_path.display()))?;
+
+    Ok(action)
+}
+
+/// Pure JSON transform: load hooks.json contents (or None), produce the new
+/// contents and the action taken. Foreign hook entries are preserved byte-
+/// for-byte (apart from re-serialization). Tests target this function
+/// directly without touching the filesystem.
+fn upsert_codex_hook_json(
+    existing: Option<&str>,
+    rtk_command: &str,
+) -> Result<(String, CodexHookUpsert)> {
+    use serde_json::{json, Map, Value};
+
+    let mut root: Value = match existing {
+        None => json!({}),
+        Some(s) if s.trim().is_empty() => json!({}),
+        Some(s) => serde_json::from_str(s).with_context(|| {
+            "Refusing to clobber existing Codex hooks.json: file is not valid JSON. \
+             Move or repair it manually and re-run."
+        })?,
+    };
+
+    if !root.is_object() {
+        anyhow::bail!(
+            "Codex hooks.json root must be a JSON object, found {}",
+            value_kind(&root)
+        );
+    }
+
+    // Ensure root.hooks.PreToolUse is an array.
+    let hooks_obj = root
+        .as_object_mut()
+        .expect("checked above")
+        .entry("hooks")
+        .or_insert_with(|| Value::Object(Map::new()));
+    if !hooks_obj.is_object() {
+        anyhow::bail!(
+            "Codex hooks.json `hooks` field must be a JSON object, found {}",
+            value_kind(hooks_obj)
+        );
+    }
+    let pre_arr = hooks_obj
+        .as_object_mut()
+        .expect("checked above")
+        .entry(PRE_TOOL_USE_KEY)
+        .or_insert_with(|| Value::Array(Vec::new()));
+    if !pre_arr.is_array() {
+        anyhow::bail!(
+            "Codex hooks.json `hooks.{}` must be an array, found {}",
+            PRE_TOOL_USE_KEY,
+            value_kind(pre_arr)
+        );
+    }
+    let pre_arr = pre_arr.as_array_mut().expect("checked above");
+
+    // The canonical RTK entry we want present. matcher="^Bash$" is the
+    // Codex PreToolUse matcher syntax (anchored regex). statusMessage is
+    // a tiny user-facing breadcrumb Codex surfaces while the hook runs.
+    let rtk_entry = json!({
+        "matcher": "^Bash$",
+        "hooks": [{
+            "type": "command",
+            "command": rtk_command,
+            "timeout": 30,
+            "statusMessage": "RTK rewriting Bash command",
+            CODEX_HOOK_RTK_MARKER: true
+        }]
+    });
+
+    // Look for an existing RTK-managed entry, identified by either:
+    //   (a) any sub-hook carrying the `_rtk_managed: true` marker, or
+    //   (b) any sub-hook whose `command` starts with `rtk hook codex`.
+    // (a) is the durable marker; (b) catches pre-marker installs and
+    // hand-written entries. Either way we keep at most ONE RTK entry.
+    let mut rtk_index: Option<usize> = None;
+    for (i, entry) in pre_arr.iter().enumerate() {
+        let sub = entry.pointer("/hooks").and_then(|v| v.as_array());
+        if let Some(hooks) = sub {
+            let owned = hooks.iter().any(|h| {
+                h.get(CODEX_HOOK_RTK_MARKER) == Some(&Value::Bool(true))
+                    || h.get("command")
+                        .and_then(|c| c.as_str())
+                        .is_some_and(|c| c.starts_with(rtk_command))
+            });
+            if owned {
+                rtk_index = Some(i);
+                break;
+            }
+        }
+    }
+
+    let action = match rtk_index {
+        Some(i) => {
+            if pre_arr[i] == rtk_entry {
+                CodexHookUpsert::Unchanged
+            } else {
+                pre_arr[i] = rtk_entry;
+                CodexHookUpsert::Updated
+            }
+        }
+        None => {
+            pre_arr.push(rtk_entry);
+            CodexHookUpsert::Added
+        }
+    };
+
+    let rendered = if matches!(action, CodexHookUpsert::Unchanged) {
+        existing.unwrap_or("").to_string()
+    } else {
+        let mut s =
+            serde_json::to_string_pretty(&root).context("Failed to serialize Codex hooks.json")?;
+        s.push('\n');
+        s
+    };
+
+    Ok((rendered, action))
+}
+
+fn value_kind(v: &serde_json::Value) -> &'static str {
+    match v {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "boolean",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
+/// Remove RTK-managed entries from a Codex hooks.json. Returns the new
+/// JSON content (Some) if anything changed, or None if nothing to remove.
+/// Foreign entries are preserved verbatim.
+fn remove_codex_hook_from_json(existing: &str, rtk_command: &str) -> Result<Option<String>> {
+    use serde_json::{Map, Value};
+
+    if existing.trim().is_empty() {
+        return Ok(None);
+    }
+    let mut root: Value = serde_json::from_str(existing)
+        .context("Refusing to clobber Codex hooks.json: file is not valid JSON")?;
+    let Some(hooks) = root.get_mut("hooks").and_then(|v| v.as_object_mut()) else {
+        return Ok(None);
+    };
+    let Some(pre_arr) = hooks
+        .get_mut(PRE_TOOL_USE_KEY)
+        .and_then(|v| v.as_array_mut())
+    else {
+        return Ok(None);
+    };
+
+    let mut changed = false;
+    let before_len = pre_arr.len();
+    pre_arr.retain(|entry| {
+        let owned = entry
+            .pointer("/hooks")
+            .and_then(|v| v.as_array())
+            .is_some_and(|hs| {
+                hs.iter().any(|h| {
+                    h.get(CODEX_HOOK_RTK_MARKER) == Some(&Value::Bool(true))
+                        || h.get("command")
+                            .and_then(|c| c.as_str())
+                            .is_some_and(|c| c.starts_with(rtk_command))
+                })
+            });
+        if owned {
+            changed = true;
+        }
+        !owned
+    });
+    if !changed && pre_arr.len() == before_len {
+        return Ok(None);
+    }
+
+    // Collapse empty containers so we never leave behind {"hooks":{"PreToolUse":[]}}.
+    if pre_arr.is_empty() {
+        hooks.remove(PRE_TOOL_USE_KEY);
+    }
+    let hooks_empty = hooks.is_empty();
+    if hooks_empty {
+        if let Some(obj) = root.as_object_mut() {
+            obj.remove("hooks");
+        }
+    }
+
+    let is_root_object_empty = root.as_object().map(Map::is_empty).unwrap_or(false);
+    if is_root_object_empty {
+        // Caller treats Some("") as "delete the file".
+        return Ok(Some(String::new()));
+    }
+
+    let mut s =
+        serde_json::to_string_pretty(&root).context("Failed to serialize Codex hooks.json")?;
+    s.push('\n');
+    Ok(Some(s))
 }
 
 // --- upsert_rtk_block: idempotent RTK block management ---
@@ -4374,8 +4753,11 @@ mod tests {
     }
 
     #[test]
-    fn test_codex_mode_rejects_auto_patch() {
-        let err = run(
+    fn test_codex_mode_accepts_auto_patch() {
+        // v3 change (was: --codex --auto-patch rejected, before Codex shipped
+        // PreToolUse Bash interception). Now: --auto-patch ALSO writes
+        // ~/.codex/hooks.json. Use dry_run to avoid touching the real $HOME.
+        let r = run(
             false,
             false,
             false,
@@ -4386,18 +4768,20 @@ mod tests {
             false,
             true,
             PatchMode::Auto,
-            InitContext::default(),
-        )
-        .unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "--codex cannot be combined with --auto-patch"
+            InitContext {
+                dry_run: true,
+                ..Default::default()
+            },
         );
+        assert!(r.is_ok(), "--codex --auto-patch must succeed (v3): {r:?}");
     }
 
     #[test]
-    fn test_codex_mode_rejects_no_patch() {
-        let err = run(
+    fn test_codex_mode_accepts_no_patch() {
+        // v3 change: --codex --no-patch now means file-only mode
+        // (RTK.md + AGENTS.md, no hooks.json) — same as bare --codex.
+        // Use dry_run to avoid touching the real $HOME.
+        let r = run(
             false,
             false,
             false,
@@ -4408,13 +4792,12 @@ mod tests {
             false,
             true,
             PatchMode::Skip,
-            InitContext::default(),
-        )
-        .unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "--codex cannot be combined with --no-patch"
+            InitContext {
+                dry_run: true,
+                ..Default::default()
+            },
         );
+        assert!(r.is_ok(), "--codex --no-patch must succeed (v3): {r:?}");
     }
 
     #[test]
@@ -4989,14 +5372,22 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let agents_md = temp.path().join("AGENTS.md");
         let rtk_md = temp.path().join("RTK.md");
+        let hooks_json = temp.path().join("hooks.json");
 
         run_codex_mode_with_paths(
             agents_md.clone(),
             rtk_md.clone(),
+            hooks_json.clone(),
             true,
+            PatchMode::Skip,
             InitContext::default(),
         )
         .unwrap();
+        // File-only mode (PatchMode::Skip): hooks.json must NOT be created.
+        assert!(
+            !hooks_json.exists(),
+            "PatchMode::Skip must not write hooks.json"
+        );
 
         assert!(rtk_md.exists());
         assert_eq!(fs::read_to_string(&rtk_md).unwrap(), RTK_SLIM_CODEX);
@@ -5184,17 +5575,25 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let agents_md = temp.path().join("AGENTS.md");
         let rtk_md = temp.path().join("RTK.md");
+        let hooks_json = temp.path().join("hooks.json");
 
         run_codex_mode_with_paths(
             agents_md.clone(),
             rtk_md.clone(),
+            hooks_json.clone(),
             true,
+            PatchMode::Auto,
             InitContext {
                 dry_run: true,
                 ..Default::default()
             },
         )
         .unwrap();
+        assert!(
+            !hooks_json.exists(),
+            "dry-run must not create hooks.json: {}",
+            hooks_json.display()
+        );
 
         assert!(
             !rtk_md.exists(),
@@ -5205,6 +5604,363 @@ mod tests {
             !agents_md.exists(),
             "dry-run must not create AGENTS.md: {}",
             agents_md.display()
+        );
+    }
+
+    // --- Codex hooks.json install / upsert / uninstall ---
+
+    #[test]
+    fn test_codex_upsert_adds_to_empty_file() {
+        let (out, action) = upsert_codex_hook_json(None, CODEX_HOOK_COMMAND).unwrap();
+        assert_eq!(action, CodexHookUpsert::Added);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let entries = v
+            .pointer("/hooks/PreToolUse")
+            .and_then(|a| a.as_array())
+            .unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["matcher"], "^Bash$");
+        assert_eq!(entries[0]["hooks"][0]["command"], CODEX_HOOK_COMMAND);
+        assert_eq!(entries[0]["hooks"][0][CODEX_HOOK_RTK_MARKER], true);
+        assert_eq!(entries[0]["hooks"][0]["timeout"], 30);
+    }
+
+    #[test]
+    fn test_codex_upsert_is_idempotent() {
+        let (first, action1) = upsert_codex_hook_json(None, CODEX_HOOK_COMMAND).unwrap();
+        assert_eq!(action1, CodexHookUpsert::Added);
+        // Second pass with identical existing JSON: must be Unchanged.
+        let (second, action2) = upsert_codex_hook_json(Some(&first), CODEX_HOOK_COMMAND).unwrap();
+        assert_eq!(action2, CodexHookUpsert::Unchanged);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn test_codex_upsert_preserves_foreign_entries() {
+        // User's pre-existing hooks.json with an unrelated PreToolUse entry
+        // (e.g. an audit logger) must survive the install untouched.
+        let existing = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "^Bash$",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "/usr/local/bin/my-audit-logger",
+                        "timeout": 5
+                    }]
+                }]
+            }
+        })
+        .to_string();
+        let (out, action) = upsert_codex_hook_json(Some(&existing), CODEX_HOOK_COMMAND).unwrap();
+        assert_eq!(action, CodexHookUpsert::Added);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let entries = v
+            .pointer("/hooks/PreToolUse")
+            .and_then(|a| a.as_array())
+            .unwrap();
+        assert_eq!(
+            entries.len(),
+            2,
+            "foreign entry must remain alongside rtk entry"
+        );
+        // Foreign first, rtk appended.
+        assert_eq!(
+            entries[0]["hooks"][0]["command"],
+            "/usr/local/bin/my-audit-logger"
+        );
+        assert_eq!(entries[1]["hooks"][0]["command"], CODEX_HOOK_COMMAND);
+    }
+
+    #[test]
+    fn test_codex_upsert_updates_when_command_changed() {
+        // User moved the rtk binary. Old entry has the marker, new install
+        // should rewrite the command without creating a duplicate.
+        let existing = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "^Bash$",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "/old/path/rtk hook codex",
+                        "timeout": 30,
+                        CODEX_HOOK_RTK_MARKER: true
+                    }]
+                }]
+            }
+        })
+        .to_string();
+        let (out, action) = upsert_codex_hook_json(Some(&existing), CODEX_HOOK_COMMAND).unwrap();
+        assert_eq!(action, CodexHookUpsert::Updated);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let entries = v
+            .pointer("/hooks/PreToolUse")
+            .and_then(|a| a.as_array())
+            .unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["hooks"][0]["command"], CODEX_HOOK_COMMAND);
+    }
+
+    #[test]
+    fn test_codex_upsert_handles_unmarked_pre_existing_rtk_entry() {
+        // Older RTK installs (pre-marker) wrote entries without the
+        // `_rtk_managed` field. Detect them via command-prefix match
+        // and upgrade in place rather than duplicating.
+        let existing = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "^Bash$",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "rtk hook codex --legacy-flag",
+                        "timeout": 10
+                    }]
+                }]
+            }
+        })
+        .to_string();
+        let (out, action) = upsert_codex_hook_json(Some(&existing), CODEX_HOOK_COMMAND).unwrap();
+        assert_eq!(action, CodexHookUpsert::Updated);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let entries = v
+            .pointer("/hooks/PreToolUse")
+            .and_then(|a| a.as_array())
+            .unwrap();
+        assert_eq!(entries.len(), 1, "must not duplicate the rtk entry");
+        assert_eq!(entries[0]["hooks"][0]["command"], CODEX_HOOK_COMMAND);
+        assert_eq!(entries[0]["hooks"][0][CODEX_HOOK_RTK_MARKER], true);
+    }
+
+    #[test]
+    fn test_codex_upsert_refuses_malformed_json() {
+        let err = upsert_codex_hook_json(Some("{ not valid json"), CODEX_HOOK_COMMAND)
+            .expect_err("must refuse to overwrite malformed JSON");
+        let msg = format!("{:#}", err);
+        assert!(
+            msg.contains("not valid JSON"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_codex_remove_returns_none_when_no_rtk_entry() {
+        // Foreign-only hooks.json: removal must report no-op, not None-data-loss.
+        let foreign = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "^Bash$",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "/usr/local/bin/my-audit-logger"
+                    }]
+                }]
+            }
+        })
+        .to_string();
+        let result = remove_codex_hook_from_json(&foreign, CODEX_HOOK_COMMAND).unwrap();
+        assert!(result.is_none(), "no rtk entry -> no rewrite");
+    }
+
+    #[test]
+    fn test_codex_remove_strips_only_rtk_entry() {
+        let mixed = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "^Bash$",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "/usr/local/bin/my-audit-logger"
+                        }]
+                    },
+                    {
+                        "matcher": "^Bash$",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "rtk hook codex",
+                            CODEX_HOOK_RTK_MARKER: true
+                        }]
+                    }
+                ]
+            }
+        })
+        .to_string();
+        let result = remove_codex_hook_from_json(&mixed, CODEX_HOOK_COMMAND)
+            .unwrap()
+            .expect("rtk entry should have been removed");
+        let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let entries = v
+            .pointer("/hooks/PreToolUse")
+            .and_then(|a| a.as_array())
+            .unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0]["hooks"][0]["command"],
+            "/usr/local/bin/my-audit-logger"
+        );
+    }
+
+    #[test]
+    fn test_codex_remove_returns_empty_string_when_file_becomes_empty() {
+        // Only-rtk file -> caller signal "delete the file" via empty string.
+        let rtk_only = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "^Bash$",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "rtk hook codex",
+                        CODEX_HOOK_RTK_MARKER: true
+                    }]
+                }]
+            }
+        })
+        .to_string();
+        let result = remove_codex_hook_from_json(&rtk_only, CODEX_HOOK_COMMAND)
+            .unwrap()
+            .expect("rtk entry should have been removed");
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_install_codex_hook_creates_file_and_is_idempotent_on_disk() {
+        let temp = TempDir::new().unwrap();
+        let hooks_json = temp.path().join("hooks.json");
+
+        let action1 = install_codex_hook(&hooks_json, InitContext::default()).unwrap();
+        assert_eq!(action1, CodexHookUpsert::Added);
+        assert!(hooks_json.exists());
+
+        // Second call must be a no-op (file content stable).
+        let before = fs::read_to_string(&hooks_json).unwrap();
+        let action2 = install_codex_hook(&hooks_json, InitContext::default()).unwrap();
+        assert_eq!(action2, CodexHookUpsert::Unchanged);
+        let after = fs::read_to_string(&hooks_json).unwrap();
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn test_uninstall_codex_at_removes_hooks_json_rtk_entry() {
+        let temp = TempDir::new().unwrap();
+        let codex_dir = temp.path();
+        let hooks_json = codex_dir.join("hooks.json");
+
+        // Plant a hooks.json containing both an rtk entry and a foreign entry.
+        let mixed = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "^Bash$",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "/usr/local/bin/my-audit-logger"
+                        }]
+                    },
+                    {
+                        "matcher": "^Bash$",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "rtk hook codex",
+                            CODEX_HOOK_RTK_MARKER: true
+                        }]
+                    }
+                ]
+            }
+        });
+        fs::write(&hooks_json, serde_json::to_string_pretty(&mixed).unwrap()).unwrap();
+
+        let removed = uninstall_codex_at(codex_dir, InitContext::default()).unwrap();
+        assert!(
+            removed.iter().any(|r| r.contains("hooks.json")),
+            "uninstall report must mention hooks.json, got: {removed:?}"
+        );
+
+        let after: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&hooks_json).unwrap()).unwrap();
+        let entries = after
+            .pointer("/hooks/PreToolUse")
+            .and_then(|a| a.as_array())
+            .unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0]["hooks"][0]["command"],
+            "/usr/local/bin/my-audit-logger"
+        );
+    }
+
+    #[test]
+    fn test_uninstall_codex_at_deletes_hooks_json_when_only_rtk_entry_present() {
+        let temp = TempDir::new().unwrap();
+        let codex_dir = temp.path();
+        let hooks_json = codex_dir.join("hooks.json");
+
+        let rtk_only = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "^Bash$",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "rtk hook codex",
+                        CODEX_HOOK_RTK_MARKER: true
+                    }]
+                }]
+            }
+        });
+        fs::write(
+            &hooks_json,
+            serde_json::to_string_pretty(&rtk_only).unwrap(),
+        )
+        .unwrap();
+
+        uninstall_codex_at(codex_dir, InitContext::default()).unwrap();
+        assert!(
+            !hooks_json.exists(),
+            "hooks.json with only rtk entry must be deleted"
+        );
+    }
+
+    #[test]
+    fn test_uninstall_codex_at_leaves_foreign_only_hooks_json_intact() {
+        let temp = TempDir::new().unwrap();
+        let codex_dir = temp.path();
+        let hooks_json = codex_dir.join("hooks.json");
+
+        let foreign = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "^Bash$",
+                    "hooks": [{
+                        "type": "command",
+                        "command": "/usr/local/bin/my-audit-logger"
+                    }]
+                }]
+            }
+        });
+        let original = serde_json::to_string_pretty(&foreign).unwrap();
+        fs::write(&hooks_json, &original).unwrap();
+
+        uninstall_codex_at(codex_dir, InitContext::default()).unwrap();
+        assert!(hooks_json.exists(), "foreign-only file must not be removed");
+        let after = fs::read_to_string(&hooks_json).unwrap();
+        assert_eq!(after, original, "foreign content must be byte-identical");
+    }
+
+    #[test]
+    fn test_uninstall_codex_at_is_idempotent_with_hooks_json() {
+        let temp = TempDir::new().unwrap();
+        let codex_dir = temp.path();
+
+        install_codex_hook(&codex_dir.join("hooks.json"), InitContext::default()).unwrap();
+
+        let first = uninstall_codex_at(codex_dir, InitContext::default()).unwrap();
+        let second = uninstall_codex_at(codex_dir, InitContext::default()).unwrap();
+        assert!(
+            first.iter().any(|r| r.contains("hooks.json")),
+            "first uninstall must report hooks.json"
+        );
+        assert!(
+            !second.iter().any(|r| r.contains("hooks.json")),
+            "second uninstall must report nothing (already gone)"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -781,6 +781,8 @@ enum HookCommands {
     Gemini,
     /// Process Copilot preToolUse hook (VS Code + Copilot CLI, reads JSON from stdin)
     Copilot,
+    /// Process Codex CLI PreToolUse hook (reads JSON from stdin)
+    Codex,
     /// Check how a command would be rewritten by the hook engine (dry-run)
     Check {
         /// Target agent
@@ -2274,6 +2276,10 @@ fn run_cli() -> Result<i32> {
             }
             HookCommands::Copilot => {
                 hooks::hook_cmd::run_copilot()?;
+                0
+            }
+            HookCommands::Codex => {
+                hooks::hook_cmd::run_codex()?;
                 0
             }
             HookCommands::Check { agent: _, command } => {


### PR DESCRIPTION
## Summary

- Adds native Codex `PreToolUse` hook handling for Bash commands.
- Adds `rtk init --codex --auto-patch` install/uninstall support for
  `$CODEX_HOME/hooks.json`.
- Emits Codex-compatible allow, deny, and no-decision responses.

Extends #377 (`feat(init): add Codex CLI support via AGENTS.md + RTK.md
workflow`) from advisory setup files to Codex's native hook protocol.

## Problem

Codex hook output has stricter schema requirements than Claude-style rewrite
responses. In particular, Codex rejects `updatedInput` unless the same response
also has `permissionDecision: "allow"`. A deny response must include a reason
and must not include `updatedInput`.

Without native support, Codex Bash commands either stay raw or risk invalid hook
JSON when RTK attempts to rewrite them.

## Behavior Changes

| Codex `PreToolUse` case | Before | After |
|---|---|---|
| Default/ask rule, command `git status` | A rewrite response can be invalid for Codex. | stdout `{}`; Codex runs raw `git status`. |
| Explicit allow `Bash(git *)`, command `git status` | Command stays raw. | Emits `permissionDecision: "allow"` and `updatedInput.command = "rtk git status"`. |
| Explicit deny `Bash(git status)` | Deny cannot be represented safely by the old path. | Emits `permissionDecision: "deny"` with a reason and no `updatedInput`. |
| `rtk init --codex --auto-patch` with existing hooks | No native RTK Codex hook upsert. | Adds/removes only the RTK-managed entry; foreign entries remain. |

## Implementation

- Adds `rtk hook codex`.
- Adds Codex-specific hook response construction in `src/hooks/hook_cmd.rs`.
- Adds Codex hook constants and an `_rtk_managed` marker for install hygiene.
- Adds Codex install, upsert, and uninstall helpers in `src/hooks/init.rs`.
- Preserves non-Bash and malformed payloads as no-decision responses.

## Compatibility Notes

- No `updatedInput` is emitted unless Codex receives
  `permissionDecision: "allow"`.
- Deny responses include `permissionDecisionReason` and omit `updatedInput`.
- Existing non-RTK `hooks.json` entries are preserved.
- Protocol stderr cleanliness is handled by the separate hook-warning cleanup
  PR; the Codex schema behavior here is independent.

## Test Plan

- [x] `cargo test -q codex`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test`
- [x] `git diff --check`

Expected installed behavior:

```text
default/no explicit allow
=> {}

allow rule Bash(git *)
=> permissionDecision=allow with updatedInput.command="rtk git status"

deny rule Bash(git status)
=> permissionDecision=deny with no updatedInput
```
