### PR TITLE
fix(ci)/cicd add aarch64 musl release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,10 @@ jobs:
             os: ubuntu-latest
             archive: tar.gz
             musl: true
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            archive: tar.gz
+            musl: true
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             archive: tar.gz
@@ -290,7 +294,7 @@ jobs:
         run: |
           echo "mac_arm=$(grep aarch64-apple-darwin.tar.gz checksums.txt | head -1 | awk '{print $1}')" >> $GITHUB_OUTPUT
           echo "mac_intel=$(grep x86_64-apple-darwin.tar.gz checksums.txt | head -1 | awk '{print $1}')" >> $GITHUB_OUTPUT
-          echo "linux_arm=$(grep aarch64-unknown-linux-gnu.tar.gz checksums.txt | head -1 | awk '{print $1}')" >> $GITHUB_OUTPUT
+          echo "linux_arm_musl=$(grep aarch64-unknown-linux-musl.tar.gz checksums.txt | head -1 | awk '{print $1}')" >> $GITHUB_OUTPUT
           echo "linux_intel=$(grep x86_64-unknown-linux-musl.tar.gz checksums.txt | head -1 | awk '{print $1}')" >> $GITHUB_OUTPUT
 
       - name: Generate formula
@@ -309,8 +313,8 @@ jobs:
               url "https://github.com/rtk-ai/rtk/releases/download/TAG_PLACEHOLDER/rtk-x86_64-apple-darwin.tar.gz"
               sha256 "SHA_MAC_INTEL_PLACEHOLDER"
             elsif OS.linux? && Hardware::CPU.arm?
-              url "https://github.com/rtk-ai/rtk/releases/download/TAG_PLACEHOLDER/rtk-aarch64-unknown-linux-gnu.tar.gz"
-              sha256 "SHA_LINUX_ARM_PLACEHOLDER"
+              url "https://github.com/rtk-ai/rtk/releases/download/TAG_PLACEHOLDER/rtk-aarch64-unknown-linux-musl.tar.gz"
+              sha256 "SHA_LINUX_ARM_MUSL_PLACEHOLDER"
             elsif OS.linux? && Hardware::CPU.intel?
               url "https://github.com/rtk-ai/rtk/releases/download/TAG_PLACEHOLDER/rtk-x86_64-unknown-linux-musl.tar.gz"
               sha256 "SHA_LINUX_INTEL_PLACEHOLDER"
@@ -347,7 +351,7 @@ jobs:
           sed -i "s/TAG_PLACEHOLDER/${{ steps.version.outputs.tag }}/g" rtk.rb
           sed -i "s/SHA_MAC_ARM_PLACEHOLDER/${{ steps.sha.outputs.mac_arm }}/g" rtk.rb
           sed -i "s/SHA_MAC_INTEL_PLACEHOLDER/${{ steps.sha.outputs.mac_intel }}/g" rtk.rb
-          sed -i "s/SHA_LINUX_ARM_PLACEHOLDER/${{ steps.sha.outputs.linux_arm }}/g" rtk.rb
+          sed -i "s/SHA_LINUX_ARM_MUSL_PLACEHOLDER/${{ steps.sha.outputs.linux_arm_musl }}/g" rtk.rb
           sed -i "s/SHA_LINUX_INTEL_PLACEHOLDER/${{ steps.sha.outputs.linux_intel }}/g" rtk.rb
           # Remove leading spaces from heredoc
           sed -i 's/^          //' rtk.rb

--- a/Formula/rtk.rb
+++ b/Formula/rtk.rb
@@ -23,13 +23,13 @@ class Rtk < Formula
 
   on_linux do
     on_intel do
-      url "https://github.com/rtk-ai/rtk/releases/download/v#{version}/rtk-x86_64-unknown-linux-gnu.tar.gz"
+      url "https://github.com/rtk-ai/rtk/releases/download/v#{version}/rtk-x86_64-unknown-linux-musl.tar.gz"
       sha256 "PLACEHOLDER_SHA256_LINUX_INTEL"
     end
 
     on_arm do
-      url "https://github.com/rtk-ai/rtk/releases/download/v#{version}/rtk-aarch64-unknown-linux-gnu.tar.gz"
-      sha256 "PLACEHOLDER_SHA256_LINUX_ARM"
+      url "https://github.com/rtk-ai/rtk/releases/download/v#{version}/rtk-aarch64-unknown-linux-musl.tar.gz"
+      sha256 "PLACEHOLDER_SHA256_LINUX_ARM_MUSL"
     end
   end
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ cargo install --git https://github.com/rtk-ai/rtk
 
 Download from [releases](https://github.com/rtk-ai/rtk/releases):
 - macOS: `rtk-x86_64-apple-darwin.tar.gz` / `rtk-aarch64-apple-darwin.tar.gz`
-- Linux: `rtk-x86_64-unknown-linux-musl.tar.gz` / `rtk-aarch64-unknown-linux-gnu.tar.gz`
+- Linux: `rtk-x86_64-unknown-linux-musl.tar.gz` / `rtk-aarch64-unknown-linux-musl.tar.gz`
 - Windows: `rtk-x86_64-pc-windows-msvc.zip`
 
 > **Windows users**: Extract the zip and place `rtk.exe` somewhere in your PATH (e.g. `C:\Users\<you>\.local\bin`). Run RTK from **Command Prompt**, **PowerShell**, or **Windows Terminal** — do not double-click the `.exe` (it will flash and close). The full hook system works natively on Windows (and in [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)). See [Windows setup](#windows) below for details.


### PR DESCRIPTION
## Summary
- Adds `aarch64-unknown-linux-musl` to the release build matrix, enabling ARM64 users on glibc-constrained systems (Ubuntu 22.04 LTS, Graviton EC2) to use prebuilt binaries
- Updates Homebrew formula to prefer musl (static linking) for Linux ARM64, matching the existing x86_64-musl approach for cross-platform compatibility
- Updates checksum parsing and documentation to include the new aarch64-musl binary in releases

Addresses: https://github.com/rtk-ai/rtk/issues/3241

## Test plan
- [x] Tested locally: `docker run ubuntu:latest` with full `cargo build --release --target aarch64-unknown-linux-musl` ✓ Binary created successfully (~5.2MB)
- [x] Verified YAML syntax: `yamllint .github/workflows/release.yml` ✓
- [x] Pre-commit gate passed: `cargo fmt --all --check && cargo clippy --all-targets && cargo test --all` ✓ (2565 tests pass)
- [ ] CI validation: Release workflow will build all 5 targets (macOS x86/ARM, Linux x86/ARM-musl/ARM-gnu, Windows)
- [ ] Homebrew integration: Verify formula generates correctly with aarch64-musl checksums