### PR TITLE
fix(discover): rewrite supported dotnet commands

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1877,6 +1877,17 @@ mod tests {
     }
 
     #[test]
+    fn test_rewrite_dotnet_supported_subcommands() {
+        for subcommand in ["build", "test", "restore", "format"] {
+            assert_eq!(
+                rewrite_command_no_prefixes(&format!("dotnet {subcommand}"), &[]),
+                Some(format!("rtk dotnet {subcommand}")),
+                "dotnet {subcommand} should use the dotnet filter"
+            );
+        }
+    }
+
+    #[test]
     fn test_rewrite_playwright() {
         let commands = vec![
             "npm exec playwright",

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -687,11 +687,12 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
-        pattern: r"^dotnet\s+build\b",
+        pattern: r"^dotnet\s+(build|test|restore|format)\b",
         rtk_cmd: "rtk dotnet",
         rewrite_prefixes: &["dotnet"],
         category: "Build",
         savings_pct: 70.0,
+        subcmd_savings: &[("test", 90.0)],
         ..RtkRule::DEFAULT
     },
     RtkRule {


### PR DESCRIPTION
## Summary

- expand the dotnet discovery rule to build, test, restore, and format
- report the higher expected savings for test invocations
- add regression coverage for every supported dotnet subcommand

Closes #3300

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets`
- `cargo test`