### PR TITLE
docs(init): trim always-loaded awareness templates

### DIFF
--- a/hooks/claude/rtk-awareness.md
+++ b/hooks/claude/rtk-awareness.md
@@ -11,19 +11,7 @@ rtk discover          # Analyze Claude Code history for missed opportunities
 rtk proxy <cmd>       # Execute raw command without filtering (for debugging)
 ```
 
-## Installation Verification
-
-```bash
-rtk --version         # Should show: rtk X.Y.Z
-rtk gain              # Should work (not "command not found")
-which rtk             # Verify correct binary
-```
-
-⚠️ **Name collision**: If `rtk gain` fails, you may have reachingforthejack/rtk (Rust Type Kit) installed instead.
-
 ## Hook-Based Usage
 
 All other commands are automatically rewritten by the Claude Code hook.
 Example: `git status` → `rtk git status` (transparent, 0 tokens overhead)
-
-Refer to CLAUDE.md for full command reference.

--- a/hooks/codex/rtk-awareness.md
+++ b/hooks/codex/rtk-awareness.md
@@ -22,11 +22,3 @@ rtk gain            # Token savings analytics
 rtk gain --history  # Recent command savings history
 rtk proxy <cmd>     # Run raw command without filtering
 ```
-
-## Verification
-
-```bash
-rtk --version
-rtk gain
-which rtk
-```

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -4872,6 +4872,15 @@ mod tests {
     }
 
     #[test]
+    fn test_awareness_templates_omit_one_time_setup() {
+        assert!(!RTK_SLIM.contains("Installation Verification"));
+        assert!(!RTK_SLIM.contains("which rtk"));
+        assert!(!RTK_SLIM.contains("Refer to CLAUDE.md for full command reference."));
+        assert!(!RTK_SLIM_CODEX.contains("## Verification"));
+        assert!(!RTK_SLIM_CODEX.contains("which rtk"));
+    }
+
+    #[test]
     fn test_claude_md_mode_creates_full_injection() {
         // Just verify RTK_INSTRUCTIONS constant has the right content
         assert!(RTK_INSTRUCTIONS.contains(RTK_BLOCK_START));


### PR DESCRIPTION
Fixes #3306

Remove one-time installation checks from the Claude and Codex awareness templates, and drop the dangling Claude command-reference pointer. The generated files now contain only guidance that remains useful in every session.

Validation:
- Added a regression test for both embedded templates
- `cargo fmt --all --check`
- `cargo clippy --all-targets`
- `cargo test` (2512 passed, 8 ignored)
- `git diff --check`