### PR TITLE
fix(hooks): honour exclude_commands for head and tail

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -992,6 +992,12 @@ fn rewrite_segment_inner(
             if !routable {
                 return None;
             }
+            // The inner command may have been dropped because it is excluded.
+            // Re-testing the wrapped form would route it through the wrapper's
+            // own filter, defeating the exclusion.
+            if is_excluded(ENV_PREFIX.replace(rest, "").trim(), excluded) {
+                return None;
+            }
             break;
         }
     }
@@ -2280,6 +2286,27 @@ mod tests {
         assert_eq!(
             rewrite_command_no_prefixes("git status", &excluded),
             Some("rtk git status".into())
+        );
+    }
+
+    #[test]
+    fn test_routable_wrapper_honours_exclude_commands() {
+        // `uv run` is a routable wrapper: when the inner rewrite is dropped it
+        // falls through and re-tests `uv run <cmd>` as a `uv` invocation. That
+        // fall-through must not resurrect a command the user excluded.
+        let excluded = vec!["head".to_string(), "tail".to_string()];
+        assert_eq!(
+            rewrite_command_no_prefixes("uv run head -20 src/main.rs", &excluded),
+            None
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("uv run cat src/main.rs", &["cat".to_string()]),
+            None
+        );
+        // A non-excluded inner command still rewrites through the wrapper.
+        assert_eq!(
+            rewrite_command_no_prefixes("uv run head -20 src/main.rs", &["cat".to_string()]),
+            Some("uv run rtk read src/main.rs --max-lines 20".into())
         );
     }
 

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1020,6 +1020,12 @@ fn rewrite_segment_inner(
     if context == RewriteContext::Normal
         && (cmd_part.starts_with("head -") || cmd_part.starts_with("tail "))
     {
+        // head/tail rewrite to `rtk read`, so honour exclude_commands here too —
+        // this branch returns before the checks below and used to ignore the list.
+        let stripped = ENV_PREFIX.replace(cmd_part, "");
+        if is_excluded(stripped.trim(), excluded) {
+            return None;
+        }
         return rewrite_line_range(cmd_part).map(|r| format!("{}{}", r, redirect_suffix));
     }
 
@@ -2247,6 +2253,33 @@ mod tests {
     }
 
     // --- P0.2: head -N rewrite ---
+
+    #[test]
+    fn test_head_tail_honour_exclude_commands() {
+        // head/tail rewrite to `rtk read`; excluding them must suppress that.
+        let excluded = vec!["head".to_string(), "tail".to_string()];
+        assert_eq!(
+            rewrite_command_no_prefixes("head -20 src/main.rs", &excluded),
+            None
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("tail -20 src/main.rs", &excluded),
+            None
+        );
+        // ...and must not affect unrelated commands.
+        assert_eq!(
+            rewrite_command_no_prefixes("git status", &excluded),
+            Some("rtk git status".into())
+        );
+    }
+
+    #[test]
+    fn test_head_tail_rewrite_when_not_excluded() {
+        assert_eq!(
+            rewrite_command_no_prefixes("head -20 src/main.rs", &["cat".to_string()]),
+            Some("rtk read src/main.rs --max-lines 20".into())
+        );
+    }
 
     #[test]
     fn test_rewrite_head_numeric_flag() {

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1022,8 +1022,8 @@ fn rewrite_segment_inner(
     {
         // head/tail rewrite to `rtk read`, so honour exclude_commands here too —
         // this branch returns before the checks below and used to ignore the list.
-        let stripped = ENV_PREFIX.replace(cmd_part, "");
-        if is_excluded(stripped.trim(), excluded) {
+        // Any sudo/env prefix has already been peeled by strip_disabled_prefix above.
+        if is_excluded(cmd_part, excluded) {
             return None;
         }
         return rewrite_line_range(cmd_part).map(|r| format!("{}{}", r, redirect_suffix));
@@ -2264,6 +2264,16 @@ mod tests {
         );
         assert_eq!(
             rewrite_command_no_prefixes("tail -20 src/main.rs", &excluded),
+            None
+        );
+        // A sudo/env prefix is peeled by strip_disabled_prefix before this branch,
+        // so the exclusion still applies to the wrapped head/tail.
+        assert_eq!(
+            rewrite_command_no_prefixes("sudo head -20 src/main.rs", &excluded),
+            None
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("RUST_LOG=debug tail -20 src/main.rs", &excluded),
             None
         );
         // ...and must not affect unrelated commands.


### PR DESCRIPTION
Fixes #2823. Fixes #3371. Fixes #2363.

Partially addresses #3107 — this closes the `exclude_commands` half only. The memory half
(`rtk read` buffering the whole file) is unaffected and tracked separately.

## Problem

`head -N <file>` and `tail -N <file>` are rewritten to `rtk read`, but listing `head` or `tail` in `[hooks] exclude_commands` has no effect — they are still rewritten.

Root cause is ordering in `rewrite_segment_inner` (`src/discover/registry.rs`): the `head -` / `tail ` branch returns early, before the `is_excluded()` check in the `Classification::Supported` arm below it.

Reproduce with `exclude_commands = ["head", "tail"]`:

```
$ rtk hook check "head -20 src/main.rs"
rtk read src/main.rs --max-lines 20     # expected: no rewrite
```

This leaves no way to opt out of routing file contents through `rtk read` — relevant when you want a file read verbatim and not filtered.

## Fix

Applies the exclusion check inside that branch, mirroring how the `Supported` arm strips an env prefix before matching, so behaviour is consistent between the two paths.

## Tests

Two regression tests in `src/discover/registry.rs`:

- `test_head_tail_honour_exclude_commands` — `head`/`tail` suppressed when excluded, `git status` unaffected
- `test_head_tail_rewrite_when_not_excluded` — normal rewrite still happens when they are not in the list

## Pre-commit gate

`cargo fmt --all --check` and `cargo clippy --all-targets` are clean.

`cargo test` passes except 3 pre-existing failures in `hooks::rewrite_cmd::tests::unattestable_passthrough` (`test_plain_command_still_rewrites`, `test_fd_dup_redirect_still_rewrites`, `test_dollar_substitution_passthrough`). These fail identically on a clean checkout of `develop` with this branch stashed — they assert `evaluate("git status", &[], &[])` is `Ask`, but `check_command` consults the developer's real agent permission settings, so the outcome is `Allow` on a machine where `git status` is pre-allowed. Happy to file that separately.
