### PR TITLE
fix(opencode): use cross-platform process API

### DIFF
--- a/docs/contributing/TECHNICAL.md
+++ b/docs/contributing/TECHNICAL.md
@@ -319,7 +319,7 @@ Start here, then drill down into each README for file-level details.
 | [`cline/`](../hooks/cline/README.md) | Cline / Roo Code | Rules file (prompt-level, no programmatic hook) |
 | [`windsurf/`](../hooks/windsurf/README.md) | Windsurf / Cascade | Rules file (workspace-scoped) |
 | [`codex/`](../hooks/codex/README.md) | OpenAI Codex CLI | Awareness document, AGENTS.md integration |
-| [`opencode/`](../hooks/opencode/README.md) | OpenCode | TypeScript plugin, zx library, in-place mutation |
+| [`opencode/`](../hooks/opencode/README.md) | OpenCode | TypeScript plugin, Node `execFile`, in-place mutation |
 
 ---
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -39,7 +39,7 @@ Each agent subdirectory has its own README with hook-specific details:
 - **[`cline/`](cline/README.md)** — Rules file (prompt-level), `.clinerules` project-local installation
 - **[`windsurf/`](windsurf/README.md)** — Rules file (prompt-level), `.windsurfrules` workspace-scoped
 - **[`codex/`](codex/README.md)** — Awareness document, `AGENTS.md` integration, `$CODEX_HOME` or `~/.codex/` location
-- **[`opencode/`](opencode/README.md)** — TypeScript plugin, `zx` library, `tool.execute.before` event, in-place mutation
+- **[`opencode/`](opencode/README.md)** — TypeScript plugin, Node `execFile`, `tool.execute.before` event, in-place mutation
 - **[`pi/`](pi/README.md)** — TypeScript extension, `tool_call` event, `isToolCallEventType` guard, in-place mutation, `~/.pi/agent/extensions/`
 - **[`hermes/`](hermes/README.md)** — Python plugin, `pre_tool_call` hook, in-place terminal command mutation
 
@@ -159,11 +159,18 @@ Returns `{}` when no rewrite (Cursor requires JSON for all paths).
 
 ### OpenCode (TypeScript Plugin)
 
-Mutates `args.command` in-place via the zx library:
+Mutates `args.command` in-place via Node's cross-platform `execFile` API:
 
 ```typescript
-const result = await $`rtk rewrite ${command}`.quiet().nothrow()
-const rewritten = String(result.stdout).trim()
+function runRtk(args: string[]): Promise<string> {
+  return new Promise((resolve) => {
+    execFile("rtk", args, { windowsHide: true }, (_error, stdout) => {
+      resolve(String(stdout ?? "").trim())
+    })
+  })
+}
+
+const rewritten = await runRtk(["rewrite", command])
 if (rewritten && rewritten !== command) {
   (args as Record<string, unknown>).command = rewritten
 }

--- a/hooks/opencode/README.md
+++ b/hooks/opencode/README.md
@@ -4,8 +4,8 @@
 
 ## Specifics
 
-- TypeScript plugin using the zx library (not a shell hook)
+- TypeScript plugin using Node's cross-platform `child_process.execFile` API (not a shell hook)
 - Intercepts `tool.execute.before` events, calls `rtk rewrite` as a subprocess
-- Uses `.quiet().nothrow()` to silently ignore failures
+- Passes subprocess arguments without a shell and treats empty stdout as no rewrite
 - Mutates `args.command` in-place if rewrite differs from original
 - Installed to `~/.config/opencode/plugins/rtk.ts` by `rtk init -g --opencode`

--- a/hooks/opencode/rtk.ts
+++ b/hooks/opencode/rtk.ts
@@ -1,4 +1,5 @@
 import type { Plugin } from "@opencode-ai/plugin"
+import { execFile } from "node:child_process"
 
 // RTK OpenCode plugin — rewrites commands to use rtk for token savings.
 // Requires: rtk >= 0.23.0 in PATH.
@@ -7,10 +8,18 @@ import type { Plugin } from "@opencode-ai/plugin"
 // which is the single source of truth (src/discover/registry.rs).
 // To add or change rewrite rules, edit the Rust registry — not this file.
 
-export const RtkOpenCodePlugin: Plugin = async ({ $ }) => {
-  try {
-    await $`which rtk`.quiet()
-  } catch {
+function runRtk(args: string[]): Promise<string> {
+  return new Promise((resolve) => {
+    execFile("rtk", args, { windowsHide: true }, (_error, stdout) => {
+      // `rtk rewrite` may return a non-zero status while still emitting a rewrite.
+      resolve(String(stdout ?? "").trim())
+    })
+  })
+}
+
+export const RtkOpenCodePlugin: Plugin = async () => {
+  const version = await runRtk(["--version"])
+  if (!version) {
     console.warn("[rtk] rtk binary not found in PATH — plugin disabled")
     return {}
   }
@@ -25,14 +34,9 @@ export const RtkOpenCodePlugin: Plugin = async ({ $ }) => {
       const command = (args as Record<string, unknown>).command
       if (typeof command !== "string" || !command) return
 
-      try {
-        const result = await $`rtk rewrite ${command}`.quiet().nothrow()
-        const rewritten = String(result.stdout).trim()
-        if (rewritten && rewritten !== command) {
-          ;(args as Record<string, unknown>).command = rewritten
-        }
-      } catch {
-        // rtk rewrite failed — pass through unchanged
+      const rewritten = await runRtk(["rewrite", command])
+      if (rewritten && rewritten !== command) {
+        ;(args as Record<string, unknown>).command = rewritten
       }
     },
   }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -4839,6 +4839,20 @@ mod tests {
     }
 
     #[test]
+    fn test_opencode_plugin_uses_cross_platform_process_api() {
+        assert!(
+            OPENCODE_PLUGIN.contains(r#"import { execFile } from "node:child_process""#),
+            "OpenCode plugin must use Node's cross-platform child process API"
+        );
+        assert!(OPENCODE_PLUGIN.contains("function runRtk(args: string[]): Promise<string>"));
+        assert!(OPENCODE_PLUGIN.contains(r#"execFile("rtk", args, { windowsHide: true }"#));
+        assert!(OPENCODE_PLUGIN.contains(r#"await runRtk(["--version"])"#));
+        assert!(OPENCODE_PLUGIN.contains(r#"await runRtk(["rewrite", command])"#));
+        assert!(!OPENCODE_PLUGIN.contains("({ $ })"));
+        assert!(!OPENCODE_PLUGIN.contains("which rtk"));
+    }
+
+    #[test]
     fn test_opencode_plugin_remove() {
         let temp = TempDir::new().unwrap();
         let opencode_dir = temp.path().join("opencode");


### PR DESCRIPTION
## Summary

- replace the Bun-only `$` helper and Unix-only `which` probe with Node `execFile`
- pass rewrite commands as literal subprocess arguments without invoking a shell
- keep successful rewrite stdout even when the rewrite protocol exits nonzero
- update OpenCode integration docs and add embedded-plugin regression coverage

Closes #3326

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test`
- [x] Bundle the TypeScript plugin with Bun and invoke it against a fake `rtk` binary, verifying literal command arguments and nonzero-exit stdout handling