### PR TITLE
docs: install Cargo builds from release branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,11 @@ curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/instal
 ### Cargo
 
 ```bash
-cargo install --git https://github.com/rtk-ai/rtk
+cargo install --git https://github.com/rtk-ai/rtk --branch master rtk
 ```
+
+The `master` branch tracks released versions. Omit `--branch master` only when
+you intentionally want the latest development build.
 
 ### Pre-built Binaries
 
@@ -102,8 +105,8 @@ Download from [releases](https://github.com/rtk-ai/rtk/releases):
 ### Verify Installation
 
 ```bash
-rtk --version   # Should show "rtk 0.28.2"
-rtk gain        # Should show the savings dashboard
+rtk --version
+rtk gain        # Rust Token Killer savings dashboard
 ```
 
 > **Name collision warning**: Another project named "rtk" (Rust Type Kit) exists on crates.io. If `rtk gain` fails, you have the wrong package. Use `cargo install --git` above instead.


### PR DESCRIPTION
## What changed

- target the stable `master` branch in the README Cargo install command
- explain how to opt into the development build
- remove the stale hard-coded version from installation verification

## Why

`cargo install --git` uses the repository default branch when no source selector
is supplied. RTK defaults to `develop`, whose package version is `0.42.4`, while
the current released `master` branch is `0.44.1`. This caused the behavior
reported in discussion #3062: a Cargo install did not match the GitHub release.

## Impact

Cargo users now install the stable released build by following the README.
Contributors can still omit `--branch master` when they intentionally need the
development branch.

## Validation

- `bash scripts/validate-docs.sh`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all`
- `git diff --check`

Related: https://github.com/rtk-ai/rtk/discussions/3062
