### PR TITLE
fix(read): track Python triple-quoted strings in minimal filter

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -31,6 +31,28 @@ Three-tier filter lookup (first match wins):
 2. `~/.config/rtk/filters.toml` (user-global)
 3. Built-in filters concatenated by `build.rs` at compile time
 
+## Source File Comment Stripping
+
+`src/core/filter.rs` is a separate engine from the TOML DSL: it filters *source
+files* (used by `rtk read`) rather than command output. At `-l minimal` it
+strips comments using the per-language delimiters in
+`Language::comment_patterns()`.
+
+Python does not use that walk. It has no block comments — `"""` opens a
+*string*, which may be a docstring or an ordinary value — so it gets a
+string-aware path that removes `#` comments and leaves string contents alone.
+Matching `"""` as a block delimiter misread both of these:
+
+```python
+QUERY = """          # contains """ without starting with it
+SELECT 1
+"""
+
+"""Module doc."""    # opens and closes on one line
+```
+
+Docstrings are kept at `minimal`; `aggressive` is what drops them.
+
 ## Tracking Database Schema
 
 ```sql

--- a/src/core/filter.rs
+++ b/src/core/filter.rs
@@ -157,8 +157,85 @@ pub struct MinimalFilter;
 
 static MULTIPLE_BLANK_LINES: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\n{3,}").unwrap());
 
+/// Advances triple-quoted string state across one line, returning the delimiter
+/// still open at end of line. The two quote kinds are tracked separately so a
+/// `'''` inside a `"""` string is text rather than a close.
+fn advance_triple_quote(line: &str, open: Option<&'static str>) -> Option<&'static str> {
+    let bytes = line.as_bytes();
+    let mut state = open;
+    let mut i = 0;
+
+    while i + 3 <= bytes.len() {
+        let delim = match &bytes[i..i + 3] {
+            b"\"\"\"" => Some("\"\"\""),
+            b"'''" => Some("'''"),
+            _ => None,
+        };
+
+        match (state, delim) {
+            (Some(current), Some(found)) if current == found => {
+                state = None;
+                i += 3;
+            }
+            (None, Some(found)) => {
+                state = Some(found);
+                i += 3;
+            }
+            _ => i += 1,
+        }
+    }
+    state
+}
+
+/// Python has no block comments. `"""` opens a *string*, which may be a
+/// docstring or an ordinary value, so it cannot be matched with the
+/// line-oriented block-comment rules the other languages use: a line such as
+/// `QUERY = """` both contains and "closes" the delimiter, and a single-line
+/// docstring toggles the state once and never back.
+///
+/// Minimal keeps docstrings, so the only thing to remove here is `#` comments,
+/// and the only state needed is whether we are inside a triple-quoted string.
+fn filter_python_minimal(content: &str) -> String {
+    let mut result = String::with_capacity(content.len());
+    let mut open_string: Option<&'static str> = None;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        // Inside a string every line is literal text, including one that starts
+        // with `#`.
+        if open_string.is_some() {
+            result.push_str(line);
+            result.push('\n');
+            open_string = advance_triple_quote(line, open_string);
+            continue;
+        }
+
+        // A comment's contents are not code, so any delimiter in it is not real.
+        if trimmed.starts_with('#') {
+            continue;
+        }
+
+        if trimmed.is_empty() {
+            result.push('\n');
+            continue;
+        }
+
+        result.push_str(line);
+        result.push('\n');
+        open_string = advance_triple_quote(line, None);
+    }
+
+    let result = MULTIPLE_BLANK_LINES.replace_all(&result, "\n\n");
+    result.trim().to_string()
+}
+
 impl FilterStrategy for MinimalFilter {
     fn filter(&self, content: &str, lang: &Language) -> String {
+        if *lang == Language::Python {
+            return filter_python_minimal(content);
+        }
+
         let patterns = lang.comment_patterns();
         let mut result = String::with_capacity(content.len());
         let mut in_block_comment = false;
@@ -451,6 +528,100 @@ mod tests {
             result.contains("/* not a comment */"),
             "Aggressive filter must not strip comment-like patterns in JSON"
         );
+    }
+
+    // --- Python triple-quoted strings in minimal mode ---
+
+    #[test]
+    fn test_minimal_python_keeps_multiline_string_assignment() {
+        let code = r#"QUERY = """
+SELECT id
+FROM users
+"""
+import os
+"#;
+        let result = MinimalFilter.filter(code, &Language::Python);
+        assert!(
+            result.contains(r#"QUERY = """#),
+            "the line opening the string was dropped, leaving its body as loose text:\n{}",
+            result
+        );
+        assert!(
+            result.contains("SELECT id"),
+            "string body lost:\n{}",
+            result
+        );
+        assert!(
+            result.contains("import os"),
+            "code after string lost:\n{}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_minimal_python_strips_comments_after_oneline_docstring() {
+        let code = r#""""Module doc."""
+import os
+# strip me
+def go():
+    return 1
+"#;
+        let result = MinimalFilter.filter(code, &Language::Python);
+        assert!(
+            !result.contains("# strip me"),
+            "a one-line docstring left the filter stuck in docstring mode, so no \
+             later comment was stripped:\n{}",
+            result
+        );
+        assert!(
+            result.contains(r#""""Module doc.""""#),
+            "docstring lost:\n{}",
+            result
+        );
+        assert!(result.contains("def go():"), "code lost:\n{}", result);
+    }
+
+    #[test]
+    fn test_minimal_python_keeps_hash_inside_docstring() {
+        let code = r#""""
+# not a comment, it is prose
+"""
+x = 1
+"#;
+        let result = MinimalFilter.filter(code, &Language::Python);
+        assert!(
+            result.contains("# not a comment, it is prose"),
+            "text inside a docstring was stripped as a comment:\n{}",
+            result
+        );
+        assert!(result.contains("x = 1"));
+    }
+
+    #[test]
+    fn test_minimal_python_single_quoted_docstring_does_not_close_double() {
+        let code = r#""""Doc mentioning ''' inline."""
+# strip me
+x = 1
+"#;
+        let result = MinimalFilter.filter(code, &Language::Python);
+        assert!(
+            !result.contains("# strip me"),
+            "a ''' inside a \"\"\" string confused the tracker:\n{}",
+            result
+        );
+        assert!(result.contains("x = 1"));
+    }
+
+    #[test]
+    fn test_minimal_python_still_strips_plain_comments() {
+        let code = r#"# leading comment
+import os
+x = 1  # trailing comment kept, matching prior behavior
+"#;
+        let result = MinimalFilter.filter(code, &Language::Python);
+        assert!(!result.contains("# leading comment"));
+        assert!(result.contains("import os"));
+        assert!(result.contains("x = 1"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The minimal filter treats `"""` as a block-comment delimiter for Python. Python has no block comments. `"""` opens a string, which may be a docstring or an ordinary value. Matching it with the line-oriented block-comment rules goes wrong in two ways.

First, a line like `QUERY = """` contains the delimiter without starting with it, so it is taken for a block-comment opener. The same `"""` then satisfies the closing test on that one line. The line is dropped and its string body is left behind as loose text.

```
$ rtk read -l minimal example.py
SELECT id            # the `QUERY = """` line is gone
FROM users
"""
import os
# this comment should be stripped
```

Second, a one-line docstring such as `"""Module doc."""` toggles the docstring flag once and never back. The filter stays in docstring mode for the rest of the file and stops stripping comments at all. Most Python modules open with a docstring, so this is the common case rather than the corner case.

The fix gives Python a string-aware path. Minimal keeps docstrings, so the only thing to remove is `#` comments, and the only state needed is whether we are inside a triple-quoted string. Delimiter kinds are tracked separately so a `'''` inside a `"""` string does not close it. Comment lines are skipped before the scan, so a delimiter mentioned inside a comment does not open a string.

Every other language keeps the existing block-comment walk. The change is an early return guarded on `Language::Python`, so no other language can reach different code.

## Blast radius

`-l minimal` affects all Python, so I checked the surrounding behavior rather than assuming.

Measured reduction at `-l minimal` on Python 3.14 stdlib files, before and after:

| File | Raw bytes | Before | After |
|------|-----------|--------|-------|
| `json/decoder.py` | 12873 | 0.5% | 6.7% |
| `argparse.py` | 106655 | 3.4% | 16.7% |
| `typing.py` | 135870 | 7.1% | 10.1% |
| `dataclasses.py` | 71536 | 43.3% | 43.3% |

`dataclasses.py` is unchanged because its module docstring spans several lines, which the old toggle happened to handle.

Correctness over 60 stdlib files, comparing filtered output against the set of real code lines in each source, where a real code line means non-blank, not a whole-line `#` comment, and not inside a string according to `tokenize`:

- before: 16 of 60 files lost at least one line of real code
- after: 0 of 60

Non-Python output is unchanged. I diffed both binaries over 294 comparisons and found no differences:

- 270 over repo files at `minimal` and `aggressive`, covering Rust, Shell, TOML and Markdown
- 24 over one file per comment-pattern group at `none`, `minimal` and `aggressive`, covering JavaScript, TypeScript, Go, Ruby, Java, C, C++ and an unknown extension

One thing I did not change, so it is not covered by the above. The same `contains()` matching misfires for the brace languages when a string literal holds comment-like text. That is #2384, which is closed as completed, but `trimmed.contains(start)` is still on `develop` at `src/core/filter.rs:173`, and the same-line open and close case at 178-183 still runs `continue` unconditionally. Both behaviours reproduce today:

```
$ cat u.rs
fn main() {
    let pattern = "/* comment marker */";
    let keep_me = 42;
    println!("{} {}", pattern, keep_me);
}

$ rtk read -l minimal u.rs
fn main() {
    let keep_me = 42;
    println!("{} {}", pattern, keep_me);
}
```

The declaration is gone while the use of `pattern` remains, which is the "field names that do not exist" symptom from that issue. An unterminated marker is worse, because it swallows the rest of the file:

```
$ cat v.rs
fn main() {
    let a = "/* only start";
    let b = 1;
    let c = 2;
}

$ rtk read -l minimal v.rs
fn main() {
```

I have left this out of this PR because it is a wider change with its own risk profile, and this one is scoped to Python. Flagging it here because #2384 reads as resolved and is not. Happy to take it as a separate PR if you want it.

## Test plan

`cargo fmt --all -- --check` clean. `cargo clippy --all-targets` reports 0 warnings and 0 errors. `cargo test --all` passes 2580 tests across 8 test binaries, 8 ignored, 0 failed. `bash scripts/check-test-presence.sh origin/develop` passes.

Five tests added in `src/core/filter.rs`, taking the main binary from 2511 to 2516. Three of them fail on unmodified `develop`:

- a multi-line string assignment keeps its opening line and its body (fails before)
- comments are still stripped after a one-line docstring (fails before)
- a `'''` written inside a `"""` docstring does not end it (fails before)
- a `#` line inside a docstring is kept as prose (passes before, guards the fix)
- ordinary `#` comments are still stripped (passes before, guards the fix)

## Relationship to #3335

This is a follow-up to #3335 and does not depend on it. I found this bug while testing that one. The two are independent and can merge in either order. This branch is cut from `develop` and shares no code with #3335.

They both touch `src/core/filter.rs`, which auto-merges cleanly. They both add a section to `src/core/README.md`, which conflicts. I will rebase whichever one lands second.

This does not fix #3260. That issue is about `-l aggressive` and XML.

---
🤖 Opened with [Superhuman](https://github.com/gaurav0107/superhuman), an open-source contribution agent.

