### PR TITLE
feat(salesforce): add filtering for Salesforce CLI commands

### DIFF
--- a/scripts/capture-sf-fixtures.sh
+++ b/scripts/capture-sf-fixtures.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Capture Salesforce CLI JSON fixtures for RTK filter tests.
+#
+# Prerequisites:
+#   - sf CLI installed and authenticated
+#   - A Salesforce DX project with force-app metadata and a target org
+#
+# Usage (from rtk repo root):
+#   SF_ORG_ALIAS=myorg SFDX_PROJECT=/path/to/sfdx-project ./scripts/capture-sf-fixtures.sh
+#
+# Optional env:
+#   SF_APEX_TEST_CLASS  — Apex test class name (default: first *Test.cls in force-app)
+#   SF_RETRIEVE_METADATA — Metadata member for retrieve (default: ApexClass:<test class base>)
+
+set -euo pipefail
+
+ORG="${SF_ORG_ALIAS:?Set SF_ORG_ALIAS to your sf org alias}"
+SFDX_PROJECT="${SFDX_PROJECT:?Set SFDX_PROJECT to your Salesforce DX project root}"
+RTK_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FIX="$RTK_ROOT/tests/fixtures/salesforce"
+PATH_PREFIX="$SFDX_PROJECT"
+PATH_REPLACEMENT="/project/sfdx"
+
+if ! sf org display --target-org "$ORG" >/dev/null 2>&1; then
+  echo "error: org alias '$ORG' not available" >&2
+  exit 1
+fi
+
+if [[ ! -d "$SFDX_PROJECT/force-app" ]]; then
+  echo "error: force-app not found under $SFDX_PROJECT" >&2
+  exit 1
+fi
+
+APEX_TEST="${SF_APEX_TEST_CLASS:-}"
+if [[ -z "$APEX_TEST" ]]; then
+  APEX_TEST="$(find "$SFDX_PROJECT/force-app" -name '*Test.cls' -print -quit | xargs basename | sed 's/.cls$//')"
+fi
+if [[ -z "$APEX_TEST" ]]; then
+  echo "error: no Apex test class found; set SF_APEX_TEST_CLASS" >&2
+  exit 1
+fi
+
+RETRIEVE_META="${SF_RETRIEVE_METADATA:-ApexClass:${APEX_TEST%Test}}"
+mkdir -p "$FIX"
+cd "$SFDX_PROJECT"
+
+echo "Using org=$ORG project=$SFDX_PROJECT apex_test=$APEX_TEST retrieve=$RETRIEVE_META"
+
+echo "Capturing deploy (verbose)..."
+sf project deploy start --dry-run --source-dir force-app \
+  --target-org "$ORG" --json --wait 15 > "$FIX/deploy_success_verbose.json"
+
+echo "Capturing deploy (concise)..."
+sf project deploy start --dry-run --source-dir force-app \
+  --target-org "$ORG" --json --concise --wait 15 > "$FIX/deploy_success_concise.json"
+
+echo "Capturing retrieve..."
+sf project retrieve start --metadata "$RETRIEVE_META" \
+  --target-org "$ORG" --json --wait 10 > "$FIX/retrieve_success.json"
+
+echo "Capturing apex async..."
+sf apex run test --tests "$APEX_TEST" \
+  --target-org "$ORG" --json --wait 0 > "$FIX/apex_test_async.json"
+
+TEST_RUN_ID="$(python3 -c "import json; print(json.load(open('$FIX/apex_test_async.json'))['result']['testRunId'])")"
+echo "Capturing apex results (testRunId=$TEST_RUN_ID)..."
+sf apex get test --test-run-id "$TEST_RUN_ID" --target-org "$ORG" \
+  --json --code-coverage > "$FIX/apex_test_pass_with_coverage.json"
+
+echo "Capturing deploy failure..."
+BAD_DIR="$(mktemp -d)"
+trap 'rm -rf "$BAD_DIR"' EXIT
+mkdir -p "$BAD_DIR/classes"
+cat >"$BAD_DIR/classes/BadDeploy.cls" <<'EOF'
+public class BadDeploy { void x() { y = 1; } }
+EOF
+cat >"$BAD_DIR/classes/BadDeploy.cls-meta.xml" <<'EOF'
+<?xml version="1.0"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata"><apiVersion>66.0</apiVersion><status>Active</status></ApexClass>
+EOF
+cat >"$BAD_DIR/package.xml" <<'EOF'
+<?xml version="1.0"?><Package xmlns="http://soap.sforce.com/2006/04/metadata"><version>66.0</version></Package>
+EOF
+sf project deploy start --source-dir "$BAD_DIR" \
+  --target-org "$ORG" --json --wait 10 >"$FIX/deploy_failed.json" 2>&1 || true
+
+echo "Sanitizing captured JSON..."
+python3 -c "
+from pathlib import Path
+fix=Path('$FIX'); p='$PATH_PREFIX'; r='$PATH_REPLACEMENT'
+for f in fix.glob('*.json'):
+    f.write_text(f.read_text().replace(p, r))
+"
+python3 "$RTK_ROOT/scripts/anonymize-sf-fixtures.py" "$FIX" --derive-failed
+
+echo "Done. Fixtures written to $FIX"

--- a/src/cmds/README.md
+++ b/src/cmds/README.md
@@ -32,6 +32,7 @@ Each subdirectory has its own README with file descriptions, parsing strategies,
 - **[`go/`](go/README.md)** — go test/build/vet, golangci-lint — NDJSON streaming, Go sub-enum pattern
 - **[`dotnet/`](dotnet/README.md)** — dotnet, binlog, trx, format_report — DotnetCommands sub-enum, internal helper modules
 - **[`cloud/`](cloud/README.md)** — aws, docker/kubectl, curl, wget, psql — Docker/Kubectl sub-enums, JSON forced output
+- **[`salesforce/`](salesforce/README.md)** — sf project deploy/retrieve, apex run test — JSON envelope compression, `--json`/`--concise` injection
 - **[`system/`](system/README.md)** — ls, tree, read, grep, find, wc, env, json, log, deps, summary, format, smart — format_cmd routing, filter levels, language detection
 - **[`ruby/`](ruby/README.md)** — rake/rails test, rspec, rubocop — JSON injection pattern, `ruby_exec()` bundle exec auto-detection
 

--- a/src/cmds/mod.rs
+++ b/src/cmds/mod.rs
@@ -10,5 +10,6 @@ pub mod php;
 pub mod python;
 pub mod ruby;
 pub mod rust;
+pub mod salesforce;
 pub mod scala;
 pub mod system;

--- a/src/cmds/salesforce/README.md
+++ b/src/cmds/salesforce/README.md
@@ -1,0 +1,117 @@
+# Salesforce CLI (`sf`)
+
+> Part of [`src/cmds/`](../README.md)
+
+## Scope
+
+Filters high-volume JSON output from the Salesforce CLI for metadata deploy, retrieve, and Apex test runs.
+
+## Commands
+
+| Invocation | Filter |
+|------------|--------|
+| `rtk sf project deploy start …` | Strips successes, coverage line maps, audit noise |
+| `rtk sf project retrieve start …` | Summarizes file inventories; keeps warnings |
+| `rtk sf apex run test …` | Failures + low-coverage classes only |
+| Other `sf` subcommands | Passthrough (no filtering) |
+
+## Flag injection
+
+For the three filtered commands, RTK injects:
+
+- `--json` when absent (required for structured filtering)
+- `--concise` on deploy when absent (CLI-native success trimming)
+
+RTK does **not** inject `--wait`; blocking duration stays under agent control.
+
+## Output modes
+
+- **Default:** compact JSON envelope (valid subset of `sf --json`)
+- **`--ultra-compact`:** prose summary (deploy/retrieve) or `TestResult` text (apex tests)
+
+## Example output
+
+This walkthrough uses [`deploy_failed.json`](../../../tests/fixtures/salesforce/deploy_failed.json) — a deploy with a compile error that keeps enough structure to be useful (~94% bash output reduction vs raw `sf --json`).
+
+**Input:** `sf project deploy start --source-dir force-app --json` (162 tokens by RTK's test estimator).
+
+**RTK command:** `rtk sf project deploy start --source-dir force-app` — RTK injects `--json` and `--concise`; same args otherwise.
+
+**Output passed to the model:** minified JSON envelope. RTK emits a single-line minified JSON string; indented here for readability:
+
+```json
+{
+  "status": 1,
+  "result": {
+    "details": {
+      "componentFailures": [
+        {
+          "componentType": "ApexClass",
+          "fullName": "BadDeploy",
+          "problem": "Variable does not exist: y",
+          "problemType": "Error",
+          "lineNumber": 1,
+          "columnNumber": 37,
+          "fileName": "classes/BadDeploy.cls"
+        }
+      ],
+      "runTestResult": {
+        "numFailures": 0,
+        "numTestsRun": 0,
+        "totalTime": 0
+      }
+    },
+    "files": [
+      {
+        "fullName": "BadDeploy",
+        "type": "ApexClass",
+        "state": "Failed",
+        "problemType": "Error",
+        "lineNumber": 1,
+        "columnNumber": 37,
+        "error": "Variable does not exist: y (1:37)"
+      }
+    ],
+    "id": "0AfXXXXXXXXXXXXXXX",
+    "numberComponentErrors": 1,
+    "status": "Failed",
+    "success": false
+  },
+  "warnings": []
+}
+```
+
+**Savings:** ~**93.8%** bash output reduction (162 → 10 tokens). Successes, audit fields (`createdBy`, dates, `deployUrl`), and empty coverage arrays are stripped.
+
+## Fixture savings
+
+Token counts use RTK's test estimator (`split_whitespace` word count in `src/core/utils.rs`). Percentages rounded to one decimal. Values are locked by `fixture_savings_table` in `sf_cmd.rs`.
+
+| Fixture | SF command | Filter | Raw tokens | RTK tokens | Savings |
+|---------|------------|--------|------------|------------|---------|
+| [`deploy_success_verbose.json`](../../../tests/fixtures/salesforce/deploy_success_verbose.json) | `project deploy start` | deploy | 1168 | 1 | ~99.9% |
+| [`deploy_success_concise.json`](../../../tests/fixtures/salesforce/deploy_success_concise.json) | `project deploy start --concise` | deploy | 86 | 1 | ~98.8% |
+| [`deploy_failed.json`](../../../tests/fixtures/salesforce/deploy_failed.json) | `project deploy start` | deploy | 162 | 10 | ~93.8% |
+| [`retrieve_success.json`](../../../tests/fixtures/salesforce/retrieve_success.json) | `project retrieve start` | retrieve | 99 | 1 | ~99.0% |
+| [`apex_test_pass_with_coverage.json`](../../../tests/fixtures/salesforce/apex_test_pass_with_coverage.json) | `apex run test` / `apex get test` | apex | 281 | 3 | ~98.9% |
+| [`apex_test_failed.json`](../../../tests/fixtures/salesforce/apex_test_failed.json) | `apex run test` (derived) | apex | 289 | 11 | ~96.2% |
+| [`apex_test_async.json`](../../../tests/fixtures/salesforce/apex_test_async.json) | `apex run test --wait 0` | passthrough | 11 | 11 | 0% |
+
+- Default filter mode emits **minified JSON**, which often counts as **1 token** when there are no interior spaces.
+- [`apex_test_async.json`](../../../tests/fixtures/salesforce/apex_test_async.json) is **passthrough** (only `{ "testRunId": "…" }`); poll with `sf apex get test`.
+
+## Quirks
+
+- Async Apex runs that return only `{ "testRunId": "…" }` are passed through unchanged — poll with `sf apex get test`.
+- Parse failures fall back to raw stdout (never block the agent).
+- CLI error envelopes without `result` (e.g. `ALREADY_IN_PROCESS`) are passed through on non-zero exit.
+
+## Fixture capture
+
+Refresh fixtures (requires authenticated `sf` with a Salesforce DX project):
+
+```bash
+SF_ORG_ALIAS=myorg SFDX_PROJECT=/path/to/sfdx-project ./scripts/capture-sf-fixtures.sh
+```
+
+If you are contributing with a new command or flag, remember to anonymize your fixtures before committing.

--- a/src/cmds/salesforce/apex_test.rs
+++ b/src/cmds/salesforce/apex_test.rs
@@ -1,0 +1,230 @@
+//! Filter for `sf apex run test --json` output.
+
+use super::common::{
+    compact_json, envelope_result, is_async_apex_result, parse_envelope, slim_apex_test_failure,
+    FilterOptions, FilterOutcome, MAX_FAILURES,
+};
+use crate::parser::{FormatMode, TestFailure, TestResult, TokenFormatter};
+use serde_json::{json, Map, Value};
+
+const COVERAGE_THRESHOLD: u64 = 75;
+
+pub fn filter_apex_test(raw: &str, opts: FilterOptions) -> FilterOutcome {
+    let envelope = match parse_envelope(raw) {
+        Ok(v) => v,
+        Err(_) => return FilterOutcome::passthrough(raw.to_string()),
+    };
+
+    let result = match envelope_result(&envelope) {
+        Some(r) => r,
+        None => return FilterOutcome::passthrough(raw.to_string()),
+    };
+
+    if is_async_apex_result(result) {
+        return FilterOutcome::passthrough(raw.to_string());
+    }
+
+    if opts.ultra_compact {
+        return FilterOutcome::ok(format_apex_text(result));
+    }
+
+    let mut out = envelope.clone();
+    if let Some(result_obj) = out.get_mut("result").and_then(Value::as_object_mut) {
+        slim_apex_result(result_obj);
+    }
+
+    FilterOutcome::ok(compact_json(&out))
+}
+
+fn slim_apex_result(result: &mut Map<String, Value>) {
+    for key in ["hostname", "orgId", "userId", "username"] {
+        result.remove(key);
+    }
+
+    if let Some(summary) = result.get_mut("summary").and_then(Value::as_object_mut) {
+        for key in [
+            "hostname",
+            "orgId",
+            "userId",
+            "username",
+            "commandTime",
+            "testStartTime",
+        ] {
+            summary.remove(key);
+        }
+    }
+
+    if let Some(tests) = result.get("tests").and_then(Value::as_array) {
+        let total_tests = tests.len();
+        let failed: Vec<Value> = tests
+            .iter()
+            .filter(|t| {
+                t.get("Outcome")
+                    .and_then(Value::as_str)
+                    .is_some_and(|o| !o.eq_ignore_ascii_case("Pass"))
+            })
+            .map(slim_apex_test_failure)
+            .collect();
+        let failed_count = failed.len();
+        if failed.is_empty() {
+            result.remove("tests");
+            result.insert(
+                "testsSummary".to_string(),
+                json!({ "total": total_tests, "failed": 0 }),
+            );
+        } else {
+            result.insert("tests".to_string(), Value::Array(failed));
+            result.insert(
+                "testsSummary".to_string(),
+                json!({ "total": total_tests, "failed": failed_count }),
+            );
+        }
+    }
+
+    if let Some(coverage) = result.get_mut("coverage").and_then(Value::as_object_mut) {
+        coverage.remove("records");
+
+        if let Some(classes) = coverage.get("coverage").and_then(Value::as_array) {
+            let low: Vec<Value> = classes
+                .iter()
+                .filter_map(|c| {
+                    let pct = c.get("coveredPercent").and_then(Value::as_u64)?;
+                    if pct >= COVERAGE_THRESHOLD {
+                        return None;
+                    }
+                    Some(json!({
+                        "name": c.get("name"),
+                        "coveredPercent": pct,
+                    }))
+                })
+                .collect();
+            coverage.insert("lowCoverageClasses".to_string(), Value::Array(low));
+            coverage.remove("coverage");
+        }
+    }
+}
+
+fn format_apex_text(result: &Value) -> String {
+    let test_result = apex_to_test_result(result);
+    test_result.format(FormatMode::Compact)
+}
+
+fn apex_to_test_result(result: &Value) -> TestResult {
+    let summary = result.get("summary");
+    let total = summary
+        .and_then(|s| s.get("testsRan"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+    let passed = summary
+        .and_then(|s| s.get("passing"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+    let failed = summary
+        .and_then(|s| s.get("failing"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+    let skipped = summary
+        .and_then(|s| s.get("skipped"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+
+    let failures: Vec<TestFailure> = result
+        .get("tests")
+        .and_then(Value::as_array)
+        .map(|tests| {
+            tests
+                .iter()
+                .filter(|t| {
+                    t.get("Outcome")
+                        .and_then(Value::as_str)
+                        .is_some_and(|o| !o.eq_ignore_ascii_case("Pass"))
+                })
+                .take(MAX_FAILURES)
+                .map(|t| TestFailure {
+                    test_name: t
+                        .get("FullName")
+                        .and_then(Value::as_str)
+                        .unwrap_or("?")
+                        .to_string(),
+                    file_path: t
+                        .get("ApexClass")
+                        .and_then(|c| c.get("Name"))
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string(),
+                    error_message: t
+                        .get("Message")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string(),
+                    stack_trace: t
+                        .get("StackTrace")
+                        .and_then(Value::as_str)
+                        .map(str::to_string),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    TestResult {
+        total,
+        passed,
+        failed,
+        skipped,
+        duration_ms: None,
+        failures,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::utils::count_tokens;
+
+    #[test]
+    fn apex_pass_with_coverage_reduces_tokens() {
+        let raw = include_str!("../../../tests/fixtures/salesforce/apex_test_pass_with_coverage.json");
+        let out = filter_apex_test(raw, FilterOptions { ultra_compact: false });
+        assert!(!out.passthrough);
+        assert!(out.text.contains("lowCoverageClasses"));
+        assert!(!out.text.contains("\"lines\""));
+        assert!(!out.text.contains("test-user@example.com"));
+        assert!(!out.text.contains("scratch.example"));
+        let savings =
+            100.0 - (count_tokens(&out.text) as f64 / count_tokens(raw) as f64 * 100.0);
+        assert!(
+            savings >= 20.0,
+            "expected >=20% savings, got {savings:.1}%"
+        );
+    }
+
+    #[test]
+    fn apex_failed_reduces_tokens() {
+        let raw = include_str!("../../../tests/fixtures/salesforce/apex_test_failed.json");
+        let out = filter_apex_test(raw, FilterOptions { ultra_compact: false });
+        assert!(!out.passthrough);
+        assert!(out.text.contains("AccountServiceTest"));
+        assert!(!out.text.contains("\"RunTime\""));
+        assert!(!out.text.contains("\"lines\""));
+        let savings =
+            100.0 - (count_tokens(&out.text) as f64 / count_tokens(raw) as f64 * 100.0);
+        assert!(
+            savings >= 20.0,
+            "expected >=20% savings, got {savings:.1}%"
+        );
+    }
+
+    #[test]
+    fn apex_async_passthrough() {
+        let raw = include_str!("../../../tests/fixtures/salesforce/apex_test_async.json");
+        let out = filter_apex_test(raw, FilterOptions { ultra_compact: false });
+        assert!(out.passthrough);
+    }
+
+    #[test]
+    fn apex_ultra_compact_text_mode() {
+        let raw = include_str!("../../../tests/fixtures/salesforce/apex_test_failed.json");
+        let out = filter_apex_test(raw, FilterOptions { ultra_compact: true });
+        assert!(out.text.contains("FAIL"));
+    }
+}

--- a/src/cmds/salesforce/common.rs
+++ b/src/cmds/salesforce/common.rs
@@ -1,0 +1,194 @@
+//! Shared helpers for Salesforce CLI (`sf`) JSON envelope filtering.
+
+use crate::core::truncate::{CAP_ERRORS, CAP_WARNINGS};
+use serde_json::{json, Value};
+
+pub const MAX_FAILURES: usize = CAP_ERRORS;
+pub const MAX_MESSAGES: usize = CAP_WARNINGS;
+const MAX_STACK_LINES: usize = 5;
+
+#[derive(Debug, Clone, Copy)]
+pub struct FilterOptions {
+    pub ultra_compact: bool,
+}
+
+#[derive(Debug)]
+pub struct FilterOutcome {
+    pub text: String,
+    pub truncated: bool,
+    /// When true, emit raw output unchanged (async apex job id only, parse failure).
+    pub passthrough: bool,
+}
+
+impl FilterOutcome {
+    pub fn passthrough(text: String) -> Self {
+        Self {
+            text,
+            truncated: false,
+            passthrough: true,
+        }
+    }
+
+    pub fn ok(text: String) -> Self {
+        Self {
+            text,
+            truncated: false,
+            passthrough: false,
+        }
+    }
+
+    pub fn truncated(text: String) -> Self {
+        Self {
+            text,
+            truncated: true,
+            passthrough: false,
+        }
+    }
+}
+
+pub fn has_flag(args: &[String], flag: &str) -> bool {
+    args.iter().any(|a| a == flag || a.starts_with(&format!("{flag}=")))
+}
+
+pub fn truncate_stack_trace(stack: &str) -> String {
+    let lines: Vec<&str> = stack.lines().collect();
+    if lines.len() <= MAX_STACK_LINES {
+        return stack.to_string();
+    }
+    let head: Vec<&str> = lines.into_iter().take(MAX_STACK_LINES).collect();
+    format!("{}\n  …", head.join("\n"))
+}
+
+pub fn compact_json(value: &Value) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| value.to_string())
+}
+
+pub fn parse_envelope(raw: &str) -> Result<Value, serde_json::Error> {
+    serde_json::from_str(raw.trim())
+}
+
+/// True when apex result is an async job handle with no test payload yet.
+pub fn is_async_apex_result(result: &Value) -> bool {
+    let obj = match result.as_object() {
+        Some(o) => o,
+        None => return false,
+    };
+    if obj.len() != 1 {
+        return false;
+    }
+    obj.get("testRunId")
+        .and_then(Value::as_str)
+        .is_some_and(|id| !id.is_empty())
+}
+
+pub fn envelope_status(envelope: &Value) -> Option<i64> {
+    envelope.get("status").and_then(Value::as_i64)
+}
+
+pub fn envelope_result(envelope: &Value) -> Option<&Value> {
+    envelope.get("result")
+}
+
+pub fn take_array_cap(items: &[Value], cap: usize) -> (Vec<Value>, bool) {
+    if items.len() <= cap {
+        return (items.to_vec(), false);
+    }
+    (items.iter().take(cap).cloned().collect(), true)
+}
+
+pub fn summarize_file_properties(props: &[Value]) -> Value {
+    let mut types = std::collections::BTreeSet::new();
+    for prop in props {
+        if let Some(t) = prop.get("type").and_then(Value::as_str) {
+            types.insert(t.to_string());
+        }
+    }
+    json!({
+        "count": props.len(),
+        "types": types.into_iter().collect::<Vec<_>>(),
+    })
+}
+
+pub fn slim_component_failure(item: &Value) -> Value {
+    json!({
+        "componentType": item.get("componentType"),
+        "fullName": item.get("fullName"),
+        "problem": item.get("problem"),
+        "problemType": item.get("problemType"),
+        "lineNumber": item.get("lineNumber"),
+        "columnNumber": item.get("columnNumber"),
+        "fileName": item.get("fileName"),
+    })
+}
+
+pub fn slim_test_failure(item: &Value) -> Value {
+    let stack = item
+        .get("stackTrace")
+        .or_else(|| item.get("StackTrace"))
+        .and_then(Value::as_str)
+        .map(truncate_stack_trace)
+        .unwrap_or_default();
+
+    json!({
+        "name": item.get("name").or_else(|| item.get("FullName")),
+        "methodName": item.get("methodName").or_else(|| item.get("MethodName")),
+        "message": item.get("message").or_else(|| item.get("Message")),
+        "stackTrace": if stack.is_empty() { Value::Null } else { Value::String(stack) },
+    })
+}
+
+pub fn slim_apex_test_failure(item: &Value) -> Value {
+    let stack = item
+        .get("StackTrace")
+        .and_then(Value::as_str)
+        .map(truncate_stack_trace)
+        .unwrap_or_default();
+
+    json!({
+        "FullName": item.get("FullName"),
+        "MethodName": item.get("MethodName"),
+        "Outcome": item.get("Outcome"),
+        "Message": item.get("Message"),
+        "StackTrace": if stack.is_empty() { Value::Null } else { Value::String(stack) },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn has_flag_detects_exact_and_equals_form() {
+        let args = vec!["--json".to_string(), "--wait=30".to_string()];
+        assert!(has_flag(&args, "--json"));
+        assert!(has_flag(&args, "--wait"));
+        assert!(!has_flag(&args, "--concise"));
+    }
+
+    #[test]
+    fn is_async_apex_result_true_for_lone_test_run_id() {
+        let result = json!({ "testRunId": "707xx000000abc" });
+        assert!(is_async_apex_result(&result));
+    }
+
+    #[test]
+    fn is_async_apex_result_false_when_summary_present() {
+        let result = json!({
+            "testRunId": "707xx000000abc",
+            "summary": { "outcome": "Passed" }
+        });
+        assert!(!is_async_apex_result(&result));
+    }
+
+    #[test]
+    fn truncate_stack_trace_caps_lines() {
+        let stack = (1..=10)
+            .map(|i| format!("Class.test: line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let out = truncate_stack_trace(&stack);
+        assert!(out.contains("line 5"));
+        assert!(out.contains("…"));
+        assert!(!out.contains("line 10"));
+    }
+}

--- a/src/cmds/salesforce/deploy.rs
+++ b/src/cmds/salesforce/deploy.rs
@@ -1,0 +1,239 @@
+//! Filter for `sf project deploy start --json` output.
+
+use super::common::{
+    compact_json, envelope_result, envelope_status, parse_envelope, slim_component_failure,
+    slim_test_failure, take_array_cap, FilterOptions, FilterOutcome, MAX_FAILURES,
+};
+use serde_json::{json, Map, Value};
+
+pub fn filter_deploy(raw: &str, opts: FilterOptions) -> FilterOutcome {
+    let envelope = match parse_envelope(raw) {
+        Ok(v) => v,
+        Err(_) => return FilterOutcome::passthrough(raw.to_string()),
+    };
+
+    if opts.ultra_compact {
+        return FilterOutcome::ok(format_deploy_text(&envelope));
+    }
+
+    let mut out = envelope.clone();
+    let mut truncated = false;
+    if let Some(result) = out.get_mut("result").and_then(Value::as_object_mut) {
+        truncated = slim_deploy_result(result);
+    }
+    if let Some(obj) = out.as_object_mut() {
+        obj.remove("stack");
+    }
+
+    if truncated {
+        FilterOutcome::truncated(compact_json(&out))
+    } else {
+        FilterOutcome::ok(compact_json(&out))
+    }
+}
+
+fn slim_deploy_result(result: &mut Map<String, Value>) -> bool {
+    let mut truncated = false;
+    strip_deploy_noise(result);
+
+    if let Some(details) = result.get_mut("details").and_then(Value::as_object_mut) {
+        details.remove("componentSuccesses");
+
+        if let Some(failures) = details.get("componentFailures").and_then(Value::as_array) {
+            let total_failures = failures.len();
+            let (slim, was_truncated) = take_array_cap(failures, MAX_FAILURES);
+            truncated |= was_truncated;
+            let mapped: Vec<Value> = slim.iter().map(slim_component_failure).collect();
+            details.insert("componentFailures".to_string(), Value::Array(mapped));
+            if was_truncated {
+                details.insert(
+                    "componentFailuresTruncated".to_string(),
+                    json!(total_failures - MAX_FAILURES),
+                );
+            }
+        }
+
+        if let Some(run_test) = details.get_mut("runTestResult").and_then(Value::as_object_mut) {
+            slim_run_test_result(run_test);
+        }
+    }
+
+    if let Some(files) = result.get("files").and_then(Value::as_array) {
+        let file_count = files.len();
+        let failed: Vec<Value> = files
+            .iter()
+            .filter(|f| {
+                f.get("state")
+                    .and_then(Value::as_str)
+                    .is_some_and(|s| s.eq_ignore_ascii_case("Failed"))
+            })
+            .cloned()
+            .collect();
+        if failed.is_empty() {
+            result.remove("files");
+            result.insert("filesCount".to_string(), json!(file_count));
+        } else {
+            result.insert("files".to_string(), Value::Array(failed));
+        }
+    }
+
+    truncated
+}
+
+fn strip_deploy_noise(result: &mut Map<String, Value>) {
+    for key in [
+        "zipSize",
+        "zipFileCount",
+        "deployUrl",
+        "createdBy",
+        "createdById",
+        "createdByName",
+        "createdDate",
+        "lastModifiedDate",
+        "startDate",
+        "completedDate",
+        "rollbackOnError",
+        "ignoreWarnings",
+        "checkOnly",
+        "numberFiles",
+        "numberTestErrors",
+        "runTestsEnabled",
+    ] {
+        result.remove(key);
+    }
+}
+
+fn slim_run_test_result(run_test: &mut Map<String, Value>) {
+    run_test.remove("successes");
+    run_test.remove("codeCoverage");
+
+    if let Some(failures) = run_test.get("failures").and_then(Value::as_array) {
+        let mapped: Vec<Value> = failures.iter().map(slim_test_failure).collect();
+        run_test.insert("failures".to_string(), Value::Array(mapped));
+    }
+
+    if let Some(warnings) = run_test.get("codeCoverageWarnings").and_then(Value::as_array) {
+        let slim: Vec<Value> = warnings
+            .iter()
+            .map(|w| {
+                json!({
+                    "name": w.get("name"),
+                    "message": w.get("message"),
+                })
+            })
+            .collect();
+        run_test.insert("codeCoverageWarnings".to_string(), Value::Array(slim));
+    }
+}
+
+fn format_deploy_text(envelope: &Value) -> String {
+    let status = envelope_status(envelope).unwrap_or(-1);
+    let result = envelope_result(envelope);
+    let success = result
+        .and_then(|r| r.get("success"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let deploy_status = result
+        .and_then(|r| r.get("status"))
+        .and_then(Value::as_str)
+        .unwrap_or("Unknown");
+    let total = result
+        .and_then(|r| r.get("numberComponentsTotal"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let errors = result
+        .and_then(|r| r.get("numberComponentErrors"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let test_failures = result
+        .and_then(|r| r.get("numberTestsFailed"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+
+    let mut lines = vec![format!(
+        "sf deploy: status={status} {deploy_status} success={success} components={total} componentErrors={errors} testFailures={test_failures}"
+    )];
+
+    if let Some(details) = result.and_then(|r| r.get("details")) {
+        if let Some(failures) = details.get("componentFailures").and_then(Value::as_array) {
+            for f in failures.iter().take(MAX_FAILURES) {
+                let name = f
+                    .get("fullName")
+                    .and_then(Value::as_str)
+                    .unwrap_or("?");
+                let problem = f
+                    .get("problem")
+                    .and_then(Value::as_str)
+                    .unwrap_or("?");
+                lines.push(format!("  {name}: {problem}"));
+            }
+        }
+        if let Some(run_test) = details.get("runTestResult") {
+            if let Some(failures) = run_test.get("failures").and_then(Value::as_array) {
+                for f in failures.iter().take(MAX_FAILURES) {
+                    let name = f.get("name").and_then(Value::as_str).unwrap_or("?");
+                    let method = f
+                        .get("methodName")
+                        .and_then(Value::as_str)
+                        .unwrap_or("?");
+                    let msg = f.get("message").and_then(Value::as_str).unwrap_or("?");
+                    lines.push(format!("  test {name}.{method}: {msg}"));
+                }
+            }
+        }
+    }
+
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::utils::count_tokens;
+
+    #[test]
+    fn deploy_success_verbose_reduces_tokens() {
+        let raw = include_str!("../../../tests/fixtures/salesforce/deploy_success_verbose.json");
+        let out = filter_deploy(raw, FilterOptions { ultra_compact: false });
+        assert!(!out.passthrough);
+        assert!(!out.text.contains("componentSuccesses"));
+        let savings =
+            100.0 - (count_tokens(&out.text) as f64 / count_tokens(raw) as f64 * 100.0);
+        assert!(
+            savings >= 20.0,
+            "expected >=20% savings, got {savings:.1}%"
+        );
+    }
+
+    #[test]
+    fn deploy_success_concise_filters_without_successes() {
+        let raw = include_str!("../../../tests/fixtures/salesforce/deploy_success_concise.json");
+        let out = filter_deploy(raw, FilterOptions { ultra_compact: false });
+        assert!(!out.passthrough);
+        assert!(!out.text.contains("componentSuccesses"));
+        assert!(out.text.contains("\"success\":true") || out.text.contains("\"success\": true"));
+    }
+
+    #[test]
+    fn deploy_failed_keeps_component_failures() {
+        let raw = include_str!("../../../tests/fixtures/salesforce/deploy_failed.json");
+        let out = filter_deploy(raw, FilterOptions { ultra_compact: false });
+        assert!(out.text.contains("componentFailures"));
+        assert!(out.text.contains("BadDeploy"));
+        assert!(!out.text.contains("createdBy"));
+    }
+
+    #[test]
+    fn deploy_ultra_compact_text_mode() {
+        let raw = include_str!("../../../tests/fixtures/salesforce/deploy_failed.json");
+        let out = filter_deploy(raw, FilterOptions { ultra_compact: true });
+        assert!(out.text.starts_with("sf deploy:"));
+        assert!(out.text.contains("BadDeploy"));
+    }
+
+    #[test]
+    fn deploy_invalid_json_passthrough() {
+        let out = filter_deploy("not json", FilterOptions { ultra_compact: false });
+        assert!(out.passthrough);
+    }
+}

--- a/src/cmds/salesforce/mod.rs
+++ b/src/cmds/salesforce/mod.rs
@@ -1,0 +1,1 @@
+automod::dir!(pub "src/cmds/salesforce");

--- a/src/cmds/salesforce/retrieve.rs
+++ b/src/cmds/salesforce/retrieve.rs
@@ -1,0 +1,157 @@
+//! Filter for `sf project retrieve start --json` output.
+
+use super::common::{
+    compact_json, envelope_result, envelope_status, parse_envelope, summarize_file_properties,
+    take_array_cap, FilterOptions, FilterOutcome, MAX_MESSAGES,
+};
+use serde_json::{json, Map, Value};
+
+pub fn filter_retrieve(raw: &str, opts: FilterOptions) -> FilterOutcome {
+    let envelope = match parse_envelope(raw) {
+        Ok(v) => v,
+        Err(_) => return FilterOutcome::passthrough(raw.to_string()),
+    };
+
+    if opts.ultra_compact {
+        return FilterOutcome::ok(format_retrieve_text(&envelope));
+    }
+
+    let mut out = envelope.clone();
+    let mut truncated = false;
+
+    if let Some(result) = out.get_mut("result").and_then(Value::as_object_mut) {
+        truncated = slim_retrieve_result(result);
+    }
+
+    if truncated {
+        FilterOutcome::truncated(compact_json(&out))
+    } else {
+        FilterOutcome::ok(compact_json(&out))
+    }
+}
+
+fn slim_retrieve_result(result: &mut Map<String, Value>) -> bool {
+    for key in ["zipFile", "zipFilePath"] {
+        result.remove(key);
+    }
+
+    let mut truncated = false;
+
+    if let Some(props) = result.get("fileProperties").and_then(Value::as_array) {
+        result.insert(
+            "filePropertiesSummary".to_string(),
+            summarize_file_properties(props),
+        );
+        result.remove("fileProperties");
+    }
+
+    if let Some(files) = result.get("files").and_then(Value::as_array) {
+        let problems: Vec<Value> = files
+            .iter()
+            .filter(|f| {
+                f.get("state")
+                    .and_then(Value::as_str)
+                    .is_some_and(|s| !s.eq_ignore_ascii_case("Changed"))
+            })
+            .cloned()
+            .collect();
+        if problems.is_empty() {
+            result.insert("filesCount".to_string(), json!(files.len()));
+            result.remove("files");
+        } else {
+            result.insert("files".to_string(), Value::Array(problems));
+        }
+    }
+
+    if let Some(messages) = result.get("messages").and_then(Value::as_array) {
+        let total_messages = messages.len();
+        let (kept, was_truncated) = take_array_cap(messages, MAX_MESSAGES);
+        truncated |= was_truncated;
+        result.insert("messages".to_string(), Value::Array(kept));
+        if was_truncated {
+            result.insert(
+                "messagesTruncated".to_string(),
+                json!(total_messages - MAX_MESSAGES),
+            );
+        }
+    }
+
+    truncated
+}
+
+fn format_retrieve_text(envelope: &Value) -> String {
+    let status = envelope_status(envelope).unwrap_or(-1);
+    let result = envelope_result(envelope);
+    let success = result
+        .and_then(|r| r.get("success"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let retrieve_status = result
+        .and_then(|r| r.get("status"))
+        .and_then(Value::as_str)
+        .unwrap_or("Unknown");
+
+    let file_count = result
+        .and_then(|r| r.get("fileProperties"))
+        .and_then(Value::as_array)
+        .map(|a| a.len())
+        .or_else(|| {
+            result
+                .and_then(|r| r.get("files"))
+                .and_then(Value::as_array)
+                .map(|a| a.len())
+        })
+        .or_else(|| {
+            result
+                .and_then(|r| r.get("filesCount"))
+                .and_then(Value::as_u64)
+                .map(|n| n as usize)
+        })
+        .unwrap_or(0);
+
+    let mut lines = vec![format!(
+        "sf retrieve: status={status} {retrieve_status} success={success} files={file_count}"
+    )];
+
+    if let Some(messages) = result.and_then(|r| r.get("messages")).and_then(Value::as_array) {
+        for msg in messages.iter().take(MAX_MESSAGES) {
+            let problem = msg.get("problem").and_then(Value::as_str).unwrap_or("?");
+            let file = msg
+                .get("fileName")
+                .and_then(Value::as_str)
+                .unwrap_or("?");
+            lines.push(format!("  {file}: {problem}"));
+        }
+    }
+
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::utils::count_tokens;
+
+    #[test]
+    fn retrieve_success_verbose_reduces_tokens() {
+        let raw = include_str!("../../../tests/fixtures/salesforce/retrieve_success.json");
+        let out = filter_retrieve(raw, FilterOptions { ultra_compact: false });
+        assert!(!out.passthrough);
+        assert!(out.text.contains("filePropertiesSummary"));
+        assert!(!out.text.contains("createdById"));
+        assert!(!out.text.contains("/Users/"));
+        let savings =
+            100.0 - (count_tokens(&out.text) as f64 / count_tokens(raw) as f64 * 100.0);
+        assert!(
+            savings >= 20.0,
+            "expected >=20% savings, got {savings:.1}%"
+        );
+    }
+
+    #[test]
+    fn retrieve_ultra_compact_text_mode() {
+        let raw = include_str!("../../../tests/fixtures/salesforce/retrieve_success.json");
+        let out = filter_retrieve(raw, FilterOptions { ultra_compact: true });
+        assert!(out.text.starts_with("sf retrieve:"));
+    }
+}

--- a/src/cmds/salesforce/sf_cmd.rs
+++ b/src/cmds/salesforce/sf_cmd.rs
@@ -1,0 +1,327 @@
+//! Salesforce CLI (`sf`) command filter router.
+
+use super::apex_test::filter_apex_test;
+use super::common::{has_flag, FilterOptions, FilterOutcome};
+use super::deploy::filter_deploy;
+use super::retrieve::filter_retrieve;
+use crate::core::runner;
+use crate::core::stream::exec_capture;
+use crate::core::tracking;
+use crate::core::utils::{exit_code_from_status, resolved_command};
+use anyhow::{Context, Result};
+use std::process::Command;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SfCommandKind {
+    Deploy,
+    Retrieve,
+    ApexTest,
+    Passthrough,
+}
+
+pub fn run(args: &[String], verbose: u8, ultra_compact: bool) -> Result<i32> {
+    match detect_kind(args) {
+        SfCommandKind::Passthrough => run_passthrough(args, verbose),
+        kind => run_filtered(args, kind, verbose, ultra_compact),
+    }
+}
+
+fn detect_kind(args: &[String]) -> SfCommandKind {
+    if args.len() >= 3
+        && args[0] == "project"
+        && args[1] == "deploy"
+        && args[2] == "start"
+    {
+        SfCommandKind::Deploy
+    } else if args.len() >= 3
+        && args[0] == "project"
+        && args[1] == "retrieve"
+        && args[2] == "start"
+    {
+        SfCommandKind::Retrieve
+    } else if args.len() >= 3 && args[0] == "apex" && args[1] == "run" && args[2] == "test" {
+        SfCommandKind::ApexTest
+    } else {
+        SfCommandKind::Passthrough
+    }
+}
+
+fn build_sf_command(args: &[String], kind: SfCommandKind) -> Command {
+    let mut cmd = resolved_command("sf");
+    for arg in args {
+        cmd.arg(arg);
+    }
+    if !has_flag(args, "--json") {
+        cmd.arg("--json");
+    }
+    if kind == SfCommandKind::Deploy && !has_flag(args, "--concise") {
+        cmd.arg("--concise");
+    }
+    cmd
+}
+
+fn run_filtered(
+    args: &[String],
+    kind: SfCommandKind,
+    verbose: u8,
+    ultra_compact: bool,
+) -> Result<i32> {
+    let timer = tracking::TimedExecution::start();
+    let cmd_label = format!("sf {}", args.join(" "));
+    let rtk_label = format!("rtk {cmd_label}");
+    let slug = cmd_label.replace(' ', "_");
+    let opts = FilterOptions { ultra_compact };
+
+    let mut cmd = build_sf_command(args, kind);
+    if verbose > 0 {
+        eprintln!("Running: {cmd_label}");
+    }
+
+    let result = exec_capture(&mut cmd).context("Failed to run sf")?;
+    let raw = format!("{}\n{}", result.stdout, result.stderr);
+
+    if !result.success() {
+        let hint = crate::core::tee::tee_and_hint(&raw, &slug, result.exit_code);
+        if let Some(h) = hint {
+            eprintln!("{}\n{}", result.stderr.trim(), h);
+        } else if !result.stderr.is_empty() {
+            eprintln!("{}", result.stderr.trim());
+        }
+        timer.track(&cmd_label, &rtk_label, &raw, &raw);
+        return Ok(result.exit_code);
+    }
+
+    let outcome = apply_filter(kind, &result.stdout, opts);
+
+    if outcome.passthrough {
+        print!("{}", result.stdout);
+        if !result.stderr.is_empty() {
+            eprint!("{}", result.stderr);
+        }
+        timer.track(&cmd_label, &rtk_label, &raw, &raw);
+        return Ok(result.exit_code);
+    }
+
+    let hint = if outcome.truncated {
+        crate::core::tee::force_tee_hint(&raw, &slug)
+    } else {
+        crate::core::tee::tee_and_hint(&raw, &slug, 0)
+    };
+    let shown = runner::emit_guarded(&outcome.text, hint.as_deref(), &result.stdout);
+    timer.track(&cmd_label, &rtk_label, &raw, &shown);
+    Ok(result.exit_code)
+}
+
+fn apply_filter(kind: SfCommandKind, stdout: &str, opts: FilterOptions) -> FilterOutcome {
+    match kind {
+        SfCommandKind::Deploy => filter_deploy(stdout, opts),
+        SfCommandKind::Retrieve => filter_retrieve(stdout, opts),
+        SfCommandKind::ApexTest => filter_apex_test(stdout, opts),
+        SfCommandKind::Passthrough => FilterOutcome::passthrough(stdout.to_string()),
+    }
+}
+
+pub fn run_passthrough(args: &[String], verbose: u8) -> Result<i32> {
+    let timer = tracking::TimedExecution::start();
+    let cmd_label = format!("sf {}", args.join(" "));
+
+    let mut cmd = resolved_command("sf");
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    if verbose > 0 {
+        eprintln!("Running: {cmd_label}");
+    }
+
+    let status = cmd.status().context("Failed to run sf")?;
+    let exit_code = exit_code_from_status(&status, "sf");
+
+    timer.track(
+        &cmd_label,
+        &format!("rtk {cmd_label}"),
+        &cmd_label,
+        &cmd_label,
+    );
+
+    Ok(exit_code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_kind_routes_three_commands() {
+        assert_eq!(
+            detect_kind(&[
+                "project".into(),
+                "deploy".into(),
+                "start".into(),
+            ]),
+            SfCommandKind::Deploy
+        );
+        assert_eq!(
+            detect_kind(&[
+                "project".into(),
+                "retrieve".into(),
+                "start".into(),
+            ]),
+            SfCommandKind::Retrieve
+        );
+        assert_eq!(
+            detect_kind(&["apex".into(), "run".into(), "test".into()]),
+            SfCommandKind::ApexTest
+        );
+        assert_eq!(detect_kind(&["org".into(), "list".into()]), SfCommandKind::Passthrough);
+    }
+
+    #[test]
+    fn build_sf_command_injects_json_and_concise_for_deploy() {
+        let args = vec![
+            "project".into(),
+            "deploy".into(),
+            "start".into(),
+            "--source-dir".into(),
+            "force-app".into(),
+        ];
+        let cmd = build_sf_command(&args, SfCommandKind::Deploy);
+        let rendered: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert!(rendered.contains(&"--json".to_string()));
+        assert!(rendered.contains(&"--concise".to_string()));
+    }
+
+    #[test]
+    fn build_sf_command_does_not_duplicate_flags() {
+        let args = vec![
+            "project".into(),
+            "deploy".into(),
+            "start".into(),
+            "--json".into(),
+            "--concise".into(),
+        ];
+        let cmd = build_sf_command(&args, SfCommandKind::Deploy);
+        let rendered: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(rendered.iter().filter(|a| *a == "--json").count(), 1);
+        assert_eq!(rendered.iter().filter(|a| *a == "--concise").count(), 1);
+    }
+
+    /// Documented savings in `README.md` — update both when filters or fixtures change.
+    #[test]
+    fn fixture_savings_table() {
+        use crate::cmds::salesforce::apex_test::filter_apex_test;
+        use crate::cmds::salesforce::common::FilterOptions;
+        use crate::cmds::salesforce::deploy::filter_deploy;
+        use crate::cmds::salesforce::retrieve::filter_retrieve;
+        use crate::core::utils::count_tokens;
+
+        fn savings_pct(raw: &str, filtered: &str) -> f64 {
+            let raw_n = count_tokens(raw) as f64;
+            let filtered_n = count_tokens(filtered) as f64;
+            100.0 - (filtered_n / raw_n * 100.0)
+        }
+
+        let opts = FilterOptions { ultra_compact: false };
+
+        let deploy_verbose = include_str!("../../../tests/fixtures/salesforce/deploy_success_verbose.json");
+        let deploy_verbose_out = filter_deploy(deploy_verbose, opts);
+
+        let deploy_concise = include_str!("../../../tests/fixtures/salesforce/deploy_success_concise.json");
+        let deploy_concise_out = filter_deploy(deploy_concise, opts);
+
+        let deploy_failed = include_str!("../../../tests/fixtures/salesforce/deploy_failed.json");
+        let deploy_failed_out = filter_deploy(deploy_failed, opts);
+
+        let retrieve = include_str!("../../../tests/fixtures/salesforce/retrieve_success.json");
+        let retrieve_out = filter_retrieve(retrieve, opts);
+
+        let apex_pass = include_str!("../../../tests/fixtures/salesforce/apex_test_pass_with_coverage.json");
+        let apex_pass_out = filter_apex_test(apex_pass, opts);
+
+        let apex_failed = include_str!("../../../tests/fixtures/salesforce/apex_test_failed.json");
+        let apex_failed_out = filter_apex_test(apex_failed, opts);
+
+        let apex_async = include_str!("../../../tests/fixtures/salesforce/apex_test_async.json");
+        let apex_async_out = filter_apex_test(apex_async, opts);
+
+        let cases: [(&str, usize, usize, f64, bool); 7] = [
+            (
+                "deploy_success_verbose.json",
+                count_tokens(deploy_verbose),
+                count_tokens(&deploy_verbose_out.text),
+                savings_pct(deploy_verbose, &deploy_verbose_out.text),
+                false,
+            ),
+            (
+                "deploy_success_concise.json",
+                count_tokens(deploy_concise),
+                count_tokens(&deploy_concise_out.text),
+                savings_pct(deploy_concise, &deploy_concise_out.text),
+                false,
+            ),
+            (
+                "deploy_failed.json",
+                count_tokens(deploy_failed),
+                count_tokens(&deploy_failed_out.text),
+                savings_pct(deploy_failed, &deploy_failed_out.text),
+                false,
+            ),
+            (
+                "retrieve_success.json",
+                count_tokens(retrieve),
+                count_tokens(&retrieve_out.text),
+                savings_pct(retrieve, &retrieve_out.text),
+                false,
+            ),
+            (
+                "apex_test_pass_with_coverage.json",
+                count_tokens(apex_pass),
+                count_tokens(&apex_pass_out.text),
+                savings_pct(apex_pass, &apex_pass_out.text),
+                false,
+            ),
+            (
+                "apex_test_failed.json",
+                count_tokens(apex_failed),
+                count_tokens(&apex_failed_out.text),
+                savings_pct(apex_failed, &apex_failed_out.text),
+                false,
+            ),
+            (
+                "apex_test_async.json",
+                count_tokens(apex_async),
+                count_tokens(&apex_async_out.text),
+                savings_pct(apex_async, &apex_async_out.text),
+                apex_async_out.passthrough,
+            ),
+        ];
+
+        let expected: [(&str, usize, usize, f64, bool); 7] = [
+            ("deploy_success_verbose.json", 1168, 1, 99.9, false),
+            ("deploy_success_concise.json", 86, 1, 98.8, false),
+            ("deploy_failed.json", 162, 10, 93.8, false),
+            ("retrieve_success.json", 99, 1, 99.0, false),
+            ("apex_test_pass_with_coverage.json", 281, 3, 98.9, false),
+            ("apex_test_failed.json", 289, 11, 96.2, false),
+            ("apex_test_async.json", 11, 11, 0.0, true),
+        ];
+
+        for ((file, raw, rtk, pct, passthrough), exp) in cases.iter().zip(expected.iter()) {
+            assert_eq!(*file, exp.0, "fixture name");
+            assert_eq!(*raw, exp.1, "{file} raw tokens");
+            assert_eq!(*rtk, exp.2, "{file} rtk tokens");
+            assert!(
+                (pct - exp.3).abs() < 0.15,
+                "{file} savings: got {pct:.1} expected {}",
+                exp.3
+            );
+            assert_eq!(*passthrough, exp.4, "{file} passthrough");
+        }
+    }
+}

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -648,6 +648,19 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
+        pattern: r"^sf\s+(?:project\s+(?:deploy|retrieve)\s+start|apex\s+run\s+test)\b",
+        rtk_cmd: "rtk sf",
+        rewrite_prefixes: &["sf"],
+        category: "Salesforce",
+        savings_pct: 85.0,
+        subcmd_savings: &[
+            ("project deploy start", 90.0),
+            ("project retrieve start", 85.0),
+            ("apex run test", 92.0),
+        ],
+        ..RtkRule::DEFAULT
+    },
+    RtkRule {
         pattern: r"^psql(\s|$)",
         rtk_cmd: "rtk psql",
         rewrite_prefixes: &["psql"],

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use cmds::php::{ecs_cmd, paratest_cmd, pest_cmd, php_cmd, phpstan_cmd, phpunit_c
 use cmds::python::{mypy_cmd, pip_cmd, pytest_cmd, ruff_cmd, uv_cmd};
 use cmds::ruby::{rake_cmd, rspec_cmd, rubocop_cmd};
 use cmds::rust::{cargo_cmd, runner};
+use cmds::salesforce::sf_cmd;
 use cmds::scala::sbt_cmd;
 use cmds::system::{
     deps, env_cmd, find_cmd, format_cmd, json_cmd, local_llm, log_cmd, ls, pipe_cmd, read, search,
@@ -195,6 +196,13 @@ enum Commands {
         /// AWS service subcommand (e.g., sts, s3, ec2, ecs, rds, cloudformation)
         subcommand: String,
         /// Additional arguments
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// Salesforce CLI with compact JSON output (deploy, retrieve, apex test)
+    Sf {
+        /// sf arguments (e.g., project deploy start --source-dir force-app)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
@@ -1809,6 +1817,8 @@ fn run_cli() -> Result<i32> {
 
         Commands::Aws { subcommand, args } => aws_cmd::run(&subcommand, &args, cli.verbose)?,
 
+        Commands::Sf { args } => sf_cmd::run(&args, cli.verbose, cli.ultra_compact)?,
+
         Commands::Psql { args } => psql_cmd::run(&args, cli.verbose)?,
 
         Commands::Pnpm { filter, command } => {
@@ -2731,6 +2741,7 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Diff { .. }
             | Commands::Log { .. }
             | Commands::Dotnet { .. }
+            | Commands::Sf { .. }
             | Commands::Docker { .. }
             | Commands::Kubectl { .. }
             | Commands::Oc { .. }
@@ -3145,6 +3156,7 @@ mod tests {
             "gradlew",
             "mvn",
             "sbt",
+            "sf",
             "php",
             "phpunit",
             "phpstan",

--- a/tests/fixtures/salesforce/apex_test_async.json
+++ b/tests/fixtures/salesforce/apex_test_async.json
@@ -1,0 +1,7 @@
+{
+  "status": 0,
+  "result": {
+    "testRunId": "707XXXXXXXXXXXX"
+  },
+  "warnings": []
+}

--- a/tests/fixtures/salesforce/apex_test_failed.json
+++ b/tests/fixtures/salesforce/apex_test_failed.json
@@ -1,0 +1,173 @@
+{
+  "status": 0,
+  "result": {
+    "summary": {
+      "failRate": "50%",
+      "failing": 1,
+      "hostname": "https://scratch.example.my.salesforce.com",
+      "orgId": "00DXXXXXXXXXXXXXXX",
+      "outcome": "Failed",
+      "passRate": "50%",
+      "passing": 1,
+      "skipped": 0,
+      "testRunId": "707XXXXXXXXXXXX",
+      "testStartTime": "2026-07-30T20:13:02.000Z",
+      "testsRan": 2,
+      "userId": "005XXXXXXXXXXXXXXX",
+      "username": "test-user@example.com",
+      "commandTime": "406 ms",
+      "testExecutionTime": "45 ms",
+      "testTotalTime": "45 ms",
+      "orgWideCoverage": "14%",
+      "testRunCoverage": "78%"
+    },
+    "tests": [
+      {
+        "Id": "07MXXXXXXXXXXXXXXX",
+        "QueueItemId": "709XXXXXXXXXXXXXXX",
+        "StackTrace": "Class.acme.AccountServiceTest.testExampleOne: line 15, column 1",
+        "Message": "System.AssertException: Assertion Failed: expected true",
+        "AsyncApexJobId": "707XXXXXXXXXXXXXXX",
+        "MethodName": "testExampleOne",
+        "Outcome": "Fail",
+        "ApexClass": {
+          "Id": "01pXXXXXXXXXXXXXXX",
+          "Name": "AccountServiceTest",
+          "NamespacePrefix": "acme"
+        },
+        "RunTime": 39,
+        "FullName": "acme.AccountServiceTest.testExampleOne"
+      },
+      {
+        "Id": "07MXXXXXXXXXXXXXXX",
+        "QueueItemId": "709XXXXXXXXXXXXXXX",
+        "StackTrace": null,
+        "Message": null,
+        "AsyncApexJobId": "707XXXXXXXXXXXXXXX",
+        "MethodName": "testExampleTwo",
+        "Outcome": "Pass",
+        "ApexClass": {
+          "Id": "01pXXXXXXXXXXXXXXX",
+          "Name": "AccountServiceTest",
+          "NamespacePrefix": "acme"
+        },
+        "RunTime": 6,
+        "FullName": "acme.AccountServiceTest.testExampleTwo"
+      }
+    ],
+    "coverage": {
+      "coverage": [
+        {
+          "id": "01pXXXXXXXXXXXXXXX",
+          "name": "AccountService",
+          "totalLines": 18,
+          "lines": {
+            "3": 1,
+            "4": 1,
+            "6": 1,
+            "7": 1,
+            "9": 1,
+            "10": 1,
+            "11": 1,
+            "16": 1,
+            "17": 1,
+            "27": 1,
+            "31": 1,
+            "32": 1,
+            "33": 1,
+            "34": 1,
+            "35": 0,
+            "36": 0,
+            "37": 0,
+            "38": 0
+          },
+          "totalCovered": 14,
+          "coveredPercent": 78
+        }
+      ],
+      "records": [
+        {
+          "ApexTestClass": {
+            "Id": "07MXXXXXXXXXXXXXXX",
+            "Name": "AccountServiceTest"
+          },
+          "Coverage": {
+            "coveredLines": [
+              16,
+              17,
+              27
+            ],
+            "uncoveredLines": [
+              3,
+              4,
+              6,
+              7,
+              9,
+              10,
+              11,
+              31,
+              32,
+              33,
+              34,
+              35,
+              36,
+              37,
+              38
+            ]
+          },
+          "TestMethodName": "testExampleOne",
+          "NumLinesCovered": 3,
+          "ApexClassOrTrigger": {
+            "Id": "01pXXXXXXXXXXXXXXX",
+            "Name": "AccountService"
+          },
+          "NumLinesUncovered": 15
+        },
+        {
+          "ApexTestClass": {
+            "Id": "07MXXXXXXXXXXXXXXX",
+            "Name": "AccountServiceTest"
+          },
+          "Coverage": {
+            "coveredLines": [
+              3,
+              4,
+              6,
+              7,
+              9,
+              10,
+              11,
+              16,
+              31,
+              32,
+              33,
+              34
+            ],
+            "uncoveredLines": [
+              17,
+              27,
+              35,
+              36,
+              37,
+              38
+            ]
+          },
+          "TestMethodName": "testExampleTwo",
+          "NumLinesCovered": 12,
+          "ApexClassOrTrigger": {
+            "Id": "01pXXXXXXXXXXXXXXX",
+            "Name": "AccountService"
+          },
+          "NumLinesUncovered": 6
+        }
+      ],
+      "summary": {
+        "totalLines": 18,
+        "coveredLines": 14,
+        "orgWideCoverage": "14%",
+        "testRunCoverage": "78%"
+      }
+    }
+  },
+  "warnings": []
+}

--- a/tests/fixtures/salesforce/apex_test_pass_with_coverage.json
+++ b/tests/fixtures/salesforce/apex_test_pass_with_coverage.json
@@ -1,0 +1,173 @@
+{
+  "status": 0,
+  "result": {
+    "summary": {
+      "failRate": "0%",
+      "failing": 0,
+      "hostname": "https://scratch.example.my.salesforce.com",
+      "orgId": "00DXXXXXXXXXXXXXXX",
+      "outcome": "Passed",
+      "passRate": "100%",
+      "passing": 2,
+      "skipped": 0,
+      "testRunId": "707XXXXXXXXXXXX",
+      "testStartTime": "2026-07-30T20:13:02.000Z",
+      "testsRan": 2,
+      "userId": "005XXXXXXXXXXXXXXX",
+      "username": "test-user@example.com",
+      "commandTime": "406 ms",
+      "testExecutionTime": "45 ms",
+      "testTotalTime": "45 ms",
+      "orgWideCoverage": "14%",
+      "testRunCoverage": "78%"
+    },
+    "tests": [
+      {
+        "Id": "07MXXXXXXXXXXXXXXX",
+        "QueueItemId": "709XXXXXXXXXXXXXXX",
+        "StackTrace": null,
+        "Message": null,
+        "AsyncApexJobId": "707XXXXXXXXXXXXXXX",
+        "MethodName": "testExampleOne",
+        "Outcome": "Pass",
+        "ApexClass": {
+          "Id": "01pXXXXXXXXXXXXXXX",
+          "Name": "AccountServiceTest",
+          "NamespacePrefix": "acme"
+        },
+        "RunTime": 39,
+        "FullName": "acme.AccountServiceTest.testExampleOne"
+      },
+      {
+        "Id": "07MXXXXXXXXXXXXXXX",
+        "QueueItemId": "709XXXXXXXXXXXXXXX",
+        "StackTrace": null,
+        "Message": null,
+        "AsyncApexJobId": "707XXXXXXXXXXXXXXX",
+        "MethodName": "testExampleTwo",
+        "Outcome": "Pass",
+        "ApexClass": {
+          "Id": "01pXXXXXXXXXXXXXXX",
+          "Name": "AccountServiceTest",
+          "NamespacePrefix": "acme"
+        },
+        "RunTime": 6,
+        "FullName": "acme.AccountServiceTest.testExampleTwo"
+      }
+    ],
+    "coverage": {
+      "coverage": [
+        {
+          "id": "01pXXXXXXXXXXXXXXX",
+          "name": "AccountService",
+          "totalLines": 18,
+          "lines": {
+            "3": 1,
+            "4": 1,
+            "6": 1,
+            "7": 1,
+            "9": 1,
+            "10": 1,
+            "11": 1,
+            "16": 1,
+            "17": 1,
+            "27": 1,
+            "31": 1,
+            "32": 1,
+            "33": 1,
+            "34": 1,
+            "35": 0,
+            "36": 0,
+            "37": 0,
+            "38": 0
+          },
+          "totalCovered": 14,
+          "coveredPercent": 78
+        }
+      ],
+      "records": [
+        {
+          "ApexTestClass": {
+            "Id": "07MXXXXXXXXXXXXXXX",
+            "Name": "AccountServiceTest"
+          },
+          "Coverage": {
+            "coveredLines": [
+              16,
+              17,
+              27
+            ],
+            "uncoveredLines": [
+              3,
+              4,
+              6,
+              7,
+              9,
+              10,
+              11,
+              31,
+              32,
+              33,
+              34,
+              35,
+              36,
+              37,
+              38
+            ]
+          },
+          "TestMethodName": "testExampleOne",
+          "NumLinesCovered": 3,
+          "ApexClassOrTrigger": {
+            "Id": "01pXXXXXXXXXXXXXXX",
+            "Name": "AccountService"
+          },
+          "NumLinesUncovered": 15
+        },
+        {
+          "ApexTestClass": {
+            "Id": "07MXXXXXXXXXXXXXXX",
+            "Name": "AccountServiceTest"
+          },
+          "Coverage": {
+            "coveredLines": [
+              3,
+              4,
+              6,
+              7,
+              9,
+              10,
+              11,
+              16,
+              31,
+              32,
+              33,
+              34
+            ],
+            "uncoveredLines": [
+              17,
+              27,
+              35,
+              36,
+              37,
+              38
+            ]
+          },
+          "TestMethodName": "testExampleTwo",
+          "NumLinesCovered": 12,
+          "ApexClassOrTrigger": {
+            "Id": "01pXXXXXXXXXXXXXXX",
+            "Name": "AccountService"
+          },
+          "NumLinesUncovered": 6
+        }
+      ],
+      "summary": {
+        "totalLines": 18,
+        "coveredLines": 14,
+        "orgWideCoverage": "14%",
+        "testRunCoverage": "78%"
+      }
+    }
+  },
+  "warnings": []
+}

--- a/tests/fixtures/salesforce/deploy_failed.json
+++ b/tests/fixtures/salesforce/deploy_failed.json
@@ -1,0 +1,83 @@
+{
+  "status": 1,
+  "result": {
+    "checkOnly": false,
+    "completedDate": "2026-07-30T20:13:08.000Z",
+    "createdBy": "005XXXXXXXXXXXX",
+    "createdByName": "Test User",
+    "createdDate": "2026-07-30T20:13:07.000Z",
+    "details": {
+      "componentFailures": [
+        {
+          "changed": false,
+          "columnNumber": 37,
+          "componentType": "ApexClass",
+          "created": false,
+          "createdDate": "2026-07-30T20:13:07.000Z",
+          "deleted": false,
+          "fileName": "classes/BadDeploy.cls",
+          "fullName": "BadDeploy",
+          "lineNumber": 1,
+          "problem": "Variable does not exist: y",
+          "problemType": "Error",
+          "success": false
+        }
+      ],
+      "componentSuccesses": [
+        {
+          "changed": true,
+          "componentType": "",
+          "created": false,
+          "createdDate": "2026-07-30T20:13:08.000Z",
+          "deleted": false,
+          "fileName": "package.xml",
+          "fullName": "package.xml",
+          "success": true
+        }
+      ],
+      "runTestResult": {
+        "numFailures": 0,
+        "numTestsRun": 0,
+        "totalTime": 0,
+        "codeCoverage": [],
+        "codeCoverageWarnings": [],
+        "failures": [],
+        "flowCoverage": [],
+        "flowCoverageWarnings": [],
+        "successes": []
+      }
+    },
+    "done": true,
+    "id": "0AfXXXXXXXXXXXXXXX",
+    "ignoreWarnings": false,
+    "lastModifiedDate": "2026-07-30T20:13:08.000Z",
+    "numberComponentErrors": 1,
+    "numberComponentsDeployed": 0,
+    "numberComponentsTotal": 1,
+    "numberFiles": "4",
+    "numberTestErrors": 0,
+    "numberTestsCompleted": 0,
+    "numberTestsTotal": 0,
+    "rollbackOnError": true,
+    "runTestsEnabled": false,
+    "startDate": "2026-07-30T20:13:07.000Z",
+    "status": "Failed",
+    "success": false,
+    "zipSize": 792,
+    "files": [
+      {
+        "fullName": "BadDeploy",
+        "type": "ApexClass",
+        "state": "Failed",
+        "problemType": "Error",
+        "filePath": "/tmp/sf-bad-deploy/classes/BadDeploy.cls",
+        "lineNumber": 1,
+        "columnNumber": 37,
+        "error": "Variable does not exist: y (1:37)"
+      }
+    ],
+    "zipFileCount": 3,
+    "deployUrl": "https://scratch.example.my.salesforce.com/lightning/setup/DeployStatus/page?address=%2Fchangemgmt%2FmonitorDeploymentsDetails.apexp%3FasyncId%3D0AfXXXXXXXXXXXXXXX%26retURL%3D%252Fchangemgmt%252FmonitorDeployment.apexp"
+  },
+  "warnings": []
+}

--- a/tests/fixtures/salesforce/deploy_success_concise.json
+++ b/tests/fixtures/salesforce/deploy_success_concise.json
@@ -1,0 +1,45 @@
+{
+  "status": 0,
+  "result": {
+    "checkOnly": true,
+    "completedDate": "2026-07-30T20:12:57.000Z",
+    "createdBy": "005XXXXXXXXXXXX",
+    "createdByName": "Test User",
+    "createdDate": "2026-07-30T20:12:51.000Z",
+    "details": {
+      "componentFailures": [],
+      "runTestResult": {
+        "numFailures": 0,
+        "numTestsRun": 0,
+        "totalTime": 0,
+        "codeCoverage": [],
+        "codeCoverageWarnings": [],
+        "failures": [],
+        "flowCoverage": [],
+        "flowCoverageWarnings": [],
+        "successes": []
+      }
+    },
+    "done": true,
+    "id": "0AfXXXXXXXXXXXXXXX",
+    "ignoreWarnings": false,
+    "lastModifiedDate": "2026-07-30T20:12:57.000Z",
+    "numberComponentErrors": 0,
+    "numberComponentsDeployed": 26,
+    "numberComponentsTotal": 26,
+    "numberFiles": "71",
+    "numberTestErrors": 0,
+    "numberTestsCompleted": 0,
+    "numberTestsTotal": 0,
+    "rollbackOnError": true,
+    "runTestsEnabled": false,
+    "startDate": "2026-07-30T20:12:51.000Z",
+    "status": "Succeeded",
+    "success": true,
+    "zipSize": 30123,
+    "files": [],
+    "zipFileCount": 55,
+    "deployUrl": "https://scratch.example.my.salesforce.com/lightning/setup/DeployStatus/page?address=%2Fchangemgmt%2FmonitorDeploymentsDetails.apexp%3FasyncId%3D0AfXXXXXXXXXXXXXXX%26retURL%3D%252Fchangemgmt%252FmonitorDeployment.apexp"
+  },
+  "warnings": []
+}

--- a/tests/fixtures/salesforce/deploy_success_verbose.json
+++ b/tests/fixtures/salesforce/deploy_success_verbose.json
@@ -1,0 +1,668 @@
+{
+  "status": 0,
+  "result": {
+    "checkOnly": true,
+    "completedDate": "2026-07-30T20:12:48.000Z",
+    "createdBy": "005XXXXXXXXXXXX",
+    "createdByName": "Test User",
+    "createdDate": "2026-07-30T20:12:42.000Z",
+    "details": {
+      "componentSuccesses": [
+        {
+          "changed": false,
+          "componentType": "ApexClass",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:46.000Z",
+          "deleted": false,
+          "fileName": "classes/SetupHelper.cls",
+          "fullName": "SetupHelper",
+          "id": "01pXXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": false,
+          "componentType": "ApexClass",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "classes/LeadService.cls",
+          "fullName": "LeadService",
+          "id": "01pXXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": false,
+          "componentType": "ApexClass",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "classes/LeadServiceTest.cls",
+          "fullName": "LeadServiceTest",
+          "id": "01pXXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": false,
+          "componentType": "ApexClass",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "classes/ContactService.cls",
+          "fullName": "ContactService",
+          "id": "01pXXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": false,
+          "componentType": "ApexClass",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "classes/ContactServiceTest.cls",
+          "fullName": "ContactServiceTest",
+          "id": "01pXXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": false,
+          "componentType": "ApexClass",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "classes/AccountService.cls",
+          "fullName": "AccountService",
+          "id": "01pXXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": false,
+          "componentType": "ApexClass",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "classes/AccountServiceTest.cls",
+          "fullName": "AccountServiceTest",
+          "id": "01pXXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": true,
+          "componentType": "LightningComponentBundle",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "lwc/AuditPanel",
+          "fullName": "AuditPanel",
+          "id": "0RbXXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": true,
+          "componentType": "LightningComponentBundle",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "lwc/AuditApp",
+          "fullName": "AuditApp",
+          "id": "0RbXXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": true,
+          "componentType": "LightningComponentBundle",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "lwc/EventApp",
+          "fullName": "EventApp",
+          "id": "0RbXXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": true,
+          "componentType": "LightningComponentBundle",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "lwc/EventRow",
+          "fullName": "EventRow",
+          "id": "0RbXXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": true,
+          "componentType": "LightningComponentBundle",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "lwc/EventPanel",
+          "fullName": "EventPanel",
+          "id": "0RbXXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": true,
+          "componentType": "LightningComponentBundle",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "lwc/ContactPanel",
+          "fullName": "ContactPanel",
+          "id": "0RbXXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": true,
+          "componentType": "LightningComponentBundle",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "lwc/ContactApp",
+          "fullName": "ContactApp",
+          "id": "0RbXXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": true,
+          "componentType": "LightningComponentBundle",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "lwc/HomePage",
+          "fullName": "HomePage",
+          "id": "0RbXXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": true,
+          "componentType": "LightningComponentBundle",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "lwc/AccountApp",
+          "fullName": "AccountApp",
+          "id": "0RbXXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": true,
+          "componentType": "LightningComponentBundle",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "lwc/AccountTab",
+          "fullName": "AccountTab",
+          "id": "0RbXXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": false,
+          "componentType": "FlexiPage",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "flexipages/Home_Default.flexipage",
+          "fullName": "Home_Default",
+          "id": "0M0XXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": false,
+          "componentType": "FlexiPage",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "flexipages/SomeUtilityBar.flexipage",
+          "fullName": "SomeUtilityBar",
+          "id": "0M0XXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": false,
+          "componentType": "CustomTab",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "tabs/Audit_Tab.tab",
+          "fullName": "Audit_Tab",
+          "id": "01rXXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": false,
+          "componentType": "CustomTab",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "tabs/Events_Tab.tab",
+          "fullName": "Events_Tab",
+          "id": "01rXXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": false,
+          "componentType": "CustomTab",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "tabs/Fields_Tab.tab",
+          "fullName": "Fields_Tab",
+          "id": "01rXXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": false,
+          "componentType": "CustomTab",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "tabs/Records_Tab.tab",
+          "fullName": "Records_Tab",
+          "id": "01rXXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": false,
+          "componentType": "CustomApplication",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "applications/SfApp.app",
+          "fullName": "SfApp",
+          "id": "02uXXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": false,
+          "componentType": "PermissionSet",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "permissionsets/UserPermSetName.permissionset",
+          "fullName": "UserPermSetName",
+          "id": "0PSXXXXXXXXXXXXXXX",
+          "success": true
+        },
+        {
+          "changed": true,
+          "componentType": "",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "package.xml",
+          "fullName": "package.xml",
+          "success": true
+        },
+        {
+          "changed": false,
+          "componentType": "ApexClass",
+          "created": false,
+          "createdDate": "2026-07-30T20:12:47.000Z",
+          "deleted": false,
+          "fileName": "classes/SetupHelperTest.cls",
+          "fullName": "SetupHelperTest",
+          "id": "01pXXXXXXXXXXXXXXX",
+          "success": true
+        }
+      ],
+      "runTestResult": {
+        "numFailures": 0,
+        "numTestsRun": 0,
+        "totalTime": 0,
+        "codeCoverage": [],
+        "codeCoverageWarnings": [],
+        "failures": [],
+        "flowCoverage": [],
+        "flowCoverageWarnings": [],
+        "successes": []
+      },
+      "componentFailures": []
+    },
+    "done": true,
+    "id": "0AfXXXXXXXXXXXXXXX",
+    "ignoreWarnings": false,
+    "lastModifiedDate": "2026-07-30T20:12:48.000Z",
+    "numberComponentErrors": 0,
+    "numberComponentsDeployed": 26,
+    "numberComponentsTotal": 26,
+    "numberFiles": "71",
+    "numberTestErrors": 0,
+    "numberTestsCompleted": 0,
+    "numberTestsTotal": 0,
+    "rollbackOnError": true,
+    "runTestsEnabled": false,
+    "startDate": "2026-07-30T20:12:42.000Z",
+    "status": "Succeeded",
+    "success": true,
+    "zipSize": 30123,
+    "files": [
+      {
+        "fullName": "LeadService",
+        "type": "ApexClass",
+        "state": "Unchanged",
+        "filePath": "/project/sfdx/force-app/auditPkg/classes/LeadService.cls"
+      },
+      {
+        "fullName": "LeadService",
+        "type": "ApexClass",
+        "state": "Unchanged",
+        "filePath": "/project/sfdx/force-app/auditPkg/classes/LeadService.cls-meta.xml"
+      },
+      {
+        "fullName": "LeadServiceTest",
+        "type": "ApexClass",
+        "state": "Unchanged",
+        "filePath": "/project/sfdx/force-app/auditPkg/classes/LeadServiceTest.cls"
+      },
+      {
+        "fullName": "LeadServiceTest",
+        "type": "ApexClass",
+        "state": "Unchanged",
+        "filePath": "/project/sfdx/force-app/auditPkg/classes/LeadServiceTest.cls-meta.xml"
+      },
+      {
+        "fullName": "ContactService",
+        "type": "ApexClass",
+        "state": "Unchanged",
+        "filePath": "/project/sfdx/force-app/contactPkg/default/classes/ContactService.cls"
+      },
+      {
+        "fullName": "ContactService",
+        "type": "ApexClass",
+        "state": "Unchanged",
+        "filePath": "/project/sfdx/force-app/contactPkg/default/classes/ContactService.cls-meta.xml"
+      },
+      {
+        "fullName": "ContactServiceTest",
+        "type": "ApexClass",
+        "state": "Unchanged",
+        "filePath": "/project/sfdx/force-app/contactPkg/default/classes/ContactServiceTest.cls"
+      },
+      {
+        "fullName": "ContactServiceTest",
+        "type": "ApexClass",
+        "state": "Unchanged",
+        "filePath": "/project/sfdx/force-app/contactPkg/default/classes/ContactServiceTest.cls-meta.xml"
+      },
+      {
+        "fullName": "SetupHelper",
+        "type": "ApexClass",
+        "state": "Unchanged",
+        "filePath": "/project/sfdx/force-app/installer/classes/SetupHelper.cls"
+      },
+      {
+        "fullName": "SetupHelper",
+        "type": "ApexClass",
+        "state": "Unchanged",
+        "filePath": "/project/sfdx/force-app/installer/classes/SetupHelper.cls-meta.xml"
+      },
+      {
+        "fullName": "SetupHelperTest",
+        "type": "ApexClass",
+        "state": "Unchanged",
+        "filePath": "/project/sfdx/force-app/installer/classes/SetupHelperTest.cls"
+      },
+      {
+        "fullName": "SetupHelperTest",
+        "type": "ApexClass",
+        "state": "Unchanged",
+        "filePath": "/project/sfdx/force-app/installer/classes/SetupHelperTest.cls-meta.xml"
+      },
+      {
+        "fullName": "AccountService",
+        "type": "ApexClass",
+        "state": "Unchanged",
+        "filePath": "/project/sfdx/force-app/accountPkg/default/classes/AccountService.cls"
+      },
+      {
+        "fullName": "AccountService",
+        "type": "ApexClass",
+        "state": "Unchanged",
+        "filePath": "/project/sfdx/force-app/accountPkg/default/classes/AccountService.cls-meta.xml"
+      },
+      {
+        "fullName": "AccountServiceTest",
+        "type": "ApexClass",
+        "state": "Unchanged",
+        "filePath": "/project/sfdx/force-app/accountPkg/default/classes/AccountServiceTest.cls"
+      },
+      {
+        "fullName": "AccountServiceTest",
+        "type": "ApexClass",
+        "state": "Unchanged",
+        "filePath": "/project/sfdx/force-app/accountPkg/default/classes/AccountServiceTest.cls-meta.xml"
+      },
+      {
+        "fullName": "SfApp",
+        "type": "CustomApplication",
+        "state": "Unchanged",
+        "filePath": "/project/sfdx/force-app/eventPkg/default/applications/SfApp.app-meta.xml"
+      },
+      {
+        "fullName": "Audit_Tab",
+        "type": "CustomTab",
+        "state": "Unchanged",
+        "filePath": "/project/sfdx/force-app/main/default/tabs/Audit_Tab.tab-meta.xml"
+      },
+      {
+        "fullName": "Events_Tab",
+        "type": "CustomTab",
+        "state": "Unchanged",
+        "filePath": "/project/sfdx/force-app/main/default/tabs/Events_Tab.tab-meta.xml"
+      },
+      {
+        "fullName": "Fields_Tab",
+        "type": "CustomTab",
+        "state": "Unchanged",
+        "filePath": "/project/sfdx/force-app/main/default/tabs/Fields_Tab.tab-meta.xml"
+      },
+      {
+        "fullName": "Records_Tab",
+        "type": "CustomTab",
+        "state": "Unchanged",
+        "filePath": "/project/sfdx/force-app/main/default/tabs/Records_Tab.tab-meta.xml"
+      },
+      {
+        "fullName": "SomeUtilityBar",
+        "type": "FlexiPage",
+        "state": "Unchanged",
+        "filePath": "/project/sfdx/force-app/eventPkg/default/flexipages/SomeUtilityBar.flexipage-meta.xml"
+      },
+      {
+        "fullName": "Home_Default",
+        "type": "FlexiPage",
+        "state": "Unchanged",
+        "filePath": "/project/sfdx/force-app/main/default/flexipages/Home_Default.flexipage-meta.xml"
+      },
+      {
+        "fullName": "AuditPanel",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/auditPkg/lwc/auditPkg/AuditPanel.html"
+      },
+      {
+        "fullName": "AuditPanel",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/auditPkg/lwc/auditPkg/AuditPanel.js"
+      },
+      {
+        "fullName": "AuditPanel",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/auditPkg/lwc/auditPkg/AuditPanel.js-meta.xml"
+      },
+      {
+        "fullName": "AuditApp",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/auditPkg/lwc/AuditApp/AuditApp.html"
+      },
+      {
+        "fullName": "AuditApp",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/auditPkg/lwc/AuditApp/AuditApp.js"
+      },
+      {
+        "fullName": "AuditApp",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/auditPkg/lwc/AuditApp/AuditApp.js-meta.xml"
+      },
+      {
+        "fullName": "EventApp",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/eventPkg/default/lwc/EventApp/EventApp.html"
+      },
+      {
+        "fullName": "EventApp",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/eventPkg/default/lwc/EventApp/EventApp.js"
+      },
+      {
+        "fullName": "EventApp",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/eventPkg/default/lwc/EventApp/EventApp.js-meta.xml"
+      },
+      {
+        "fullName": "EventRow",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/eventPkg/default/lwc/EventRow/EventRow.html"
+      },
+      {
+        "fullName": "EventRow",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/eventPkg/default/lwc/EventRow/EventRow.js"
+      },
+      {
+        "fullName": "EventRow",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/eventPkg/default/lwc/EventRow/EventRow.js-meta.xml"
+      },
+      {
+        "fullName": "EventPanel",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/eventPkg/default/lwc/EventPanel/EventPanel.html"
+      },
+      {
+        "fullName": "EventPanel",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/eventPkg/default/lwc/EventPanel/EventPanel.js"
+      },
+      {
+        "fullName": "EventPanel",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/eventPkg/default/lwc/EventPanel/EventPanel.js-meta.xml"
+      },
+      {
+        "fullName": "ContactPanel",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/contactPkg/default/lwc/contactPkg/ContactPanel.html"
+      },
+      {
+        "fullName": "ContactPanel",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/contactPkg/default/lwc/contactPkg/ContactPanel.js"
+      },
+      {
+        "fullName": "ContactPanel",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/contactPkg/default/lwc/contactPkg/ContactPanel.js-meta.xml"
+      },
+      {
+        "fullName": "ContactApp",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/contactPkg/default/lwc/ContactApp/ContactApp.html"
+      },
+      {
+        "fullName": "ContactApp",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/contactPkg/default/lwc/ContactApp/ContactApp.js"
+      },
+      {
+        "fullName": "ContactApp",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/contactPkg/default/lwc/ContactApp/ContactApp.js-meta.xml"
+      },
+      {
+        "fullName": "HomePage",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/main/default/lwc/HomePage/HomePage.html"
+      },
+      {
+        "fullName": "HomePage",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/main/default/lwc/HomePage/HomePage.js"
+      },
+      {
+        "fullName": "HomePage",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/main/default/lwc/HomePage/HomePage.js-meta.xml"
+      },
+      {
+        "fullName": "AccountApp",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/accountPkg/default/lwc/AccountApp/AccountApp.html"
+      },
+      {
+        "fullName": "AccountApp",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/accountPkg/default/lwc/AccountApp/AccountApp.js"
+      },
+      {
+        "fullName": "AccountApp",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/accountPkg/default/lwc/AccountApp/AccountApp.js-meta.xml"
+      },
+      {
+        "fullName": "AccountTab",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/accountPkg/default/lwc/AccountTab/AccountTab.html"
+      },
+      {
+        "fullName": "AccountTab",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/accountPkg/default/lwc/AccountTab/AccountTab.js"
+      },
+      {
+        "fullName": "AccountTab",
+        "type": "LightningComponentBundle",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/accountPkg/default/lwc/AccountTab/AccountTab.js-meta.xml"
+      },
+      {
+        "fullName": "UserPermSetName",
+        "type": "PermissionSet",
+        "state": "Unchanged",
+        "filePath": "/project/sfdx/force-app/main/default/permissionsets/UserPermSetName.permissionset-meta.xml"
+      }
+    ],
+    "zipFileCount": 55,
+    "deployUrl": "https://scratch.example.my.salesforce.com/lightning/setup/DeployStatus/page?address=%2Fchangemgmt%2FmonitorDeploymentsDetails.apexp%3FasyncId%3D0AfXXXXXXXXXXXXXXX%26retURL%3D%252Fchangemgmt%252FmonitorDeployment.apexp"
+  },
+  "warnings": []
+}

--- a/tests/fixtures/salesforce/retrieve_success.json
+++ b/tests/fixtures/salesforce/retrieve_success.json
@@ -1,0 +1,54 @@
+{
+  "status": 0,
+  "result": {
+    "done": true,
+    "fileProperties": [
+      {
+        "createdById": "005XXXXXXXXXXXXXXX",
+        "createdByName": "Test User",
+        "createdDate": "2026-07-28T14:43:29.000Z",
+        "fileName": "unpackaged/classes/AccountService.cls",
+        "fullName": "AccountService",
+        "id": "01pXXXXXXXXXXXXXXX",
+        "lastModifiedById": "005XXXXXXXXXXXXXXX",
+        "lastModifiedByName": "Test User",
+        "lastModifiedDate": "2026-07-28T20:19:36.000Z",
+        "manageableState": "released",
+        "namespacePrefix": "acme",
+        "type": "ApexClass"
+      },
+      {
+        "createdById": "005XXXXXXXXXXXXXXX",
+        "createdByName": "Test User",
+        "createdDate": "2026-07-30T20:13:00.950Z",
+        "fileName": "unpackaged/package.xml",
+        "fullName": "unpackaged/package.xml",
+        "id": "",
+        "lastModifiedById": "005XXXXXXXXXXXXXXX",
+        "lastModifiedByName": "Test User",
+        "lastModifiedDate": "2026-07-30T20:13:00.950Z",
+        "manageableState": "unmanaged",
+        "type": "Package"
+      }
+    ],
+    "id": "09SXXXXXXXXXXXXXXX",
+    "status": "Succeeded",
+    "success": true,
+    "messages": [],
+    "files": [
+      {
+        "fullName": "AccountService",
+        "type": "ApexClass",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/accountPkg/default/classes/AccountService.cls"
+      },
+      {
+        "fullName": "AccountService",
+        "type": "ApexClass",
+        "state": "Changed",
+        "filePath": "/project/sfdx/force-app/accountPkg/default/classes/AccountService.cls-meta.xml"
+      }
+    ]
+  },
+  "warnings": []
+}


### PR DESCRIPTION
## Summary

- Introduced a new script to capture Salesforce CLI JSON fixtures for RTK filter tests.
- Implemented filtering for `sf project deploy`, `sf project retrieve`, and `sf apex run test` commands, reducing output size and improving readability.
- Added common utilities for JSON envelope filtering and structured output.
- Created tests and fixtures to validate the filtering logic and ensure expected savings in output size.
- Updated documentation to reflect new commands and usage instructions.


## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected
