### PR TITLE
test(benchmark): use stable curl JSON fixture

### DIFF
--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -12,6 +12,7 @@ else
 fi
 BENCH_DIR="$(pwd)/scripts/benchmark"
 RTK_ROOT="$(pwd)"
+CURL_JSON_FIXTURE="file://$RTK_ROOT/tests/fixtures/oc_pods.json"
 
 if [ -z "$CI" ]; then
   rm -rf "$BENCH_DIR"
@@ -346,7 +347,7 @@ bench "wc" "wc Cargo.toml src/main.rs" "$RTK wc Cargo.toml src/main.rs"
 # ===================
 section "curl"
 if command -v curl &> /dev/null; then
-  bench "curl json" "curl -s https://mockhttp.org/json/1" "$RTK curl https://mockhttp.org/json/1"
+  bench "curl json" "curl -s '$CURL_JSON_FIXTURE'" "$RTK curl '$CURL_JSON_FIXTURE'"
   bench "curl text" "curl -s https://mockhttp.org/robots.txt" "$RTK curl https://mockhttp.org/robots.txt"
 fi
 


### PR DESCRIPTION
## Summary

- replace the rotating `https://mockhttp.org/json/1` benchmark input with the repository `oc_pods.json` fixture
- keep raw and RTK curl commands pointed at the same deterministic payload
- avoid false token-growth failures caused by two requests receiving unrelated JSON documents

## Why

`mockhttp.org/json/1` rotates among different response bodies. The benchmark performs separate raw and RTK requests, so it can compare different documents and report apparent token growth even when RTK behavior is unchanged. This is reproducible on `develop`.

Using a local file URL makes the comparison deterministic and requires no runtime code changes.

## Validation

- `bash -n scripts/benchmark.sh`
- `git diff --check`
- release build
- curl benchmark row: `2523 -> 2523 (+0%)`