### PR TITLE
fix: parse-failure tracking, Windows tee path, passthrough output loss (#3339)

### DIFF
--- a/src/cmds/js/playwright_cmd.rs
+++ b/src/cmds/js/playwright_cmd.rs
@@ -288,6 +288,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     // Parse output using PlaywrightParser
     let parse_result = PlaywrightParser::parse(&result.stdout);
     let mode = FormatMode::from_verbosity(verbose);
+    let tier = parse_result.tier();
 
     let filtered = match parse_result {
         ParseResult::Full(data) => {
@@ -302,21 +303,37 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
             }
             data.format(mode)
         }
-        ParseResult::Passthrough(raw) => {
+        ParseResult::Passthrough(_) => {
             emit_passthrough_warning("playwright", "All parsing tiers failed");
-            raw
+            // Truncate the combined stdout+stderr (`raw`), not the parser's
+            // stdout-only truncated output — otherwise a stderr-only failure
+            // (empty stdout) shows nothing, and the guard has no way to
+            // recover content that was never in `filtered` to begin with.
+            truncate_passthrough(&raw)
         }
     };
 
     let hint = crate::core::tee::tee_and_hint(&raw, "playwright", result.exit_code);
     let shown = crate::core::runner::emit_guarded(&filtered, hint.as_deref(), &raw);
 
-    timer.track(
-        &format!("playwright {}", args.join(" ")),
-        &format!("rtk playwright {}", args.join(" ")),
-        &raw,
-        &shown,
-    );
+    let cmd_label = format!("playwright {}", args.join(" "));
+    if tier == 3 {
+        // Tier 3 is a genuine parse failure, not token savings — record it
+        // as such instead of feeding it into the savings timer.
+        tracking::record_parse_failure_silent(
+            &cmd_label,
+            "All parsing tiers failed",
+            !shown.trim().is_empty(),
+        );
+        timer.track_passthrough(&cmd_label, &format!("rtk {} (passthrough)", cmd_label));
+    } else {
+        timer.track(
+            &cmd_label,
+            &format!("rtk playwright {}", args.join(" ")),
+            &raw,
+            &shown,
+        );
+    }
 
     // Preserve exit code for CI/CD
     if !result.success() {
@@ -470,5 +487,76 @@ mod tests {
         let result = PlaywrightParser::parse(invalid);
         assert_eq!(result.tier(), 3); // Passthrough
         assert!(!result.is_ok());
+    }
+
+    // --- Tier 3 (Passthrough) content-loss regression tests ---
+    //
+    // `run()` shells out to a real `playwright` binary and writes to a real
+    // SQLite tracking DB, so it isn't practically unit-testable here. Instead
+    // these tests exercise `truncate_passthrough` directly against the
+    // function that mirrors exactly what the `ParseResult::Passthrough` arm
+    // in `run()` does — plus the (already-pure) `emit_guarded` call that
+    // follows it, so the content-loss fix is verified end-to-end without
+    // needing a process or a database.
+
+    #[test]
+    fn test_passthrough_shown_includes_stdout_when_stderr_empty() {
+        let stdout = "some captured stdout output that failed all parse tiers";
+        let stderr = "";
+        let raw = format!("{}\n{}", stdout, stderr);
+
+        let filtered = truncate_passthrough(&raw);
+        let shown = crate::core::runner::emit_guarded(&filtered, None, &raw);
+
+        assert!(shown.contains(stdout));
+    }
+
+    #[test]
+    fn test_passthrough_shown_includes_stderr_when_stdout_empty() {
+        // Regression: the old code truncated `result.stdout` alone inside
+        // PlaywrightParser::parse, so an empty stdout with a real failure
+        // reported only on stderr produced NO visible output at all.
+        let stdout = "";
+        let stderr = "Error: browser launch failed with exit code 1";
+        let raw = format!("{}\n{}", stdout, stderr);
+
+        let filtered = truncate_passthrough(&raw);
+        let shown = crate::core::runner::emit_guarded(&filtered, None, &raw);
+
+        assert!(shown.contains(stderr));
+    }
+
+    #[test]
+    fn test_passthrough_shown_empty_when_both_streams_empty() {
+        let stdout = "";
+        let stderr = "";
+        let raw = format!("{}\n{}", stdout, stderr);
+
+        let filtered = truncate_passthrough(&raw);
+        let shown = crate::core::runner::emit_guarded(&filtered, None, &raw);
+
+        // Nothing to show — don't force fake non-empty content.
+        assert!(shown.trim().is_empty());
+    }
+
+    #[test]
+    fn test_passthrough_shown_truncated_but_keeps_tee_hint() {
+        let max_chars = crate::core::config::limits().passthrough_max_chars;
+        let stdout = "x".repeat(max_chars + 500);
+        let stderr = String::new();
+        let raw = format!("{}\n{}", stdout, stderr);
+
+        let filtered = truncate_passthrough(&raw);
+        let hint = Some("[RTK:TEE] full output saved to /tmp/playwright-abc.log");
+        let shown = crate::core::runner::emit_guarded(&filtered, hint, &raw);
+
+        assert!(
+            shown.len() < raw.len(),
+            "expected truncation to shrink output"
+        );
+        assert!(
+            shown.contains("[RTK:TEE]"),
+            "tee hint must survive the guard"
+        );
     }
 }

--- a/src/cmds/js/pnpm_cmd.rs
+++ b/src/cmds/js/pnpm_cmd.rs
@@ -381,11 +381,14 @@ fn run_list(depth: usize, args: &[String], verbose: u8) -> Result<i32> {
         return Ok(result.exit_code);
     }
 
+    let combined = result.combined();
+
     let is_filtered = args
         .iter()
         .any(|a| matches!(a.as_str(), "--prod" | "-P" | "--dev" | "-D"));
 
     let parse_result = PnpmListParser::parse(&result.stdout);
+    let tier = parse_result.tier();
 
     let filtered = match parse_result {
         ParseResult::Full(data) => {
@@ -400,21 +403,44 @@ fn run_list(depth: usize, args: &[String], verbose: u8) -> Result<i32> {
             }
             format_dependency_listing(&data, !is_filtered)
         }
-        ParseResult::Passthrough(raw) => {
+        ParseResult::Passthrough(_) => {
             emit_passthrough_warning("pnpm list", "All parsing tiers failed");
-            raw
+            // Build from the combined stdout+stderr, not the parser's
+            // stdout-only truncated output — otherwise a stderr-only warning
+            // (e.g. a registry notice) on an otherwise-empty stdout produces
+            // no visible output at all.
+            truncate_passthrough(&combined)
         }
     };
 
-    let shown = never_worse(&result.stdout, &filtered);
-    println!("{}", shown);
-
-    timer.track(
-        &format!("pnpm list --depth={}", depth),
-        &format!("rtk pnpm list --depth={}", depth),
-        &result.stdout,
-        shown,
-    );
+    let cmd_label = format!("pnpm list --depth={}", depth);
+    if tier == 3 {
+        // Tier 3 is a genuine parse failure: guard/display against the
+        // combined stdout+stderr this arm recovered from, and record it as
+        // a failure — not token savings — instead of feeding it into the
+        // savings timer.
+        let shown = never_worse(&combined, &filtered);
+        println!("{}", shown);
+        tracking::record_parse_failure_silent(
+            &cmd_label,
+            "All parsing tiers failed",
+            !shown.trim().is_empty(),
+        );
+        timer.track_passthrough(&cmd_label, &format!("rtk {} (passthrough)", cmd_label));
+    } else {
+        // Tiers 1/2 are unaffected by the passthrough fix: keep guarding
+        // and tracking against stdout alone, as before, so a stderr-only
+        // warning alongside a successful parse doesn't inflate the
+        // reported savings ratio.
+        let shown = never_worse(&result.stdout, &filtered);
+        println!("{}", shown);
+        timer.track(
+            &cmd_label,
+            &format!("rtk pnpm list --depth={}", depth),
+            &result.stdout,
+            shown,
+        );
+    }
 
     Ok(0)
 }
@@ -436,6 +462,7 @@ fn run_outdated(args: &[String], verbose: u8) -> Result<i32> {
 
     // Parse output using PnpmOutdatedParser
     let parse_result = PnpmOutdatedParser::parse(&result.stdout);
+    let tier = parse_result.tier();
     let mode = FormatMode::from_verbosity(verbose);
 
     let filtered = match parse_result {
@@ -451,9 +478,12 @@ fn run_outdated(args: &[String], verbose: u8) -> Result<i32> {
             }
             data.format(mode)
         }
-        ParseResult::Passthrough(raw) => {
+        ParseResult::Passthrough(_) => {
             emit_passthrough_warning("pnpm outdated", "All parsing tiers failed");
-            raw
+            // Build from the combined stdout+stderr, not the parser's
+            // stdout-only truncated output — otherwise a real error reported
+            // only on stderr (with malformed/empty JSON on stdout) is lost.
+            truncate_passthrough(&combined)
         }
     };
 
@@ -465,7 +495,18 @@ fn run_outdated(args: &[String], verbose: u8) -> Result<i32> {
     let shown = never_worse(&combined, &display);
     println!("{}", shown);
 
-    timer.track("pnpm outdated", "rtk pnpm outdated", &combined, shown);
+    if tier == 3 {
+        // Tier 3 is a genuine parse failure, not token savings — record it
+        // as such instead of feeding it into the savings timer.
+        tracking::record_parse_failure_silent(
+            "pnpm outdated",
+            "All parsing tiers failed",
+            !shown.trim().is_empty(),
+        );
+        timer.track_passthrough("pnpm outdated", "rtk pnpm outdated (passthrough)");
+    } else {
+        timer.track("pnpm outdated", "rtk pnpm outdated", &combined, shown);
+    }
 
     Ok(0)
 }
@@ -673,5 +714,90 @@ mod tests {
         let eslint = state.dependencies.iter().find(|d| d.name == "eslint").unwrap();
         assert!(!react.dev_dependency, "react should be prod");
         assert!(eslint.dev_dependency, "eslint should be dev");
+    }
+
+    // --- Tier 3 (Passthrough) content-loss regression tests ---
+    //
+    // `run_list`/`run_outdated` shell out to a real `pnpm` binary and write
+    // to a real SQLite tracking DB, so they aren't practically unit-testable
+    // here. Instead these tests exercise `truncate_passthrough` directly
+    // against the combined stdout+stderr, mirroring exactly what each
+    // `run_*`'s `ParseResult::Passthrough` arm does — so the content-loss
+    // fix is verified without needing a process or a database.
+
+    #[test]
+    fn test_pnpm_list_passthrough_includes_stderr_when_stdout_empty() {
+        // Regression: the old code passed the parser's stdout-only
+        // truncated output straight through, so a registry warning reported
+        // only on stderr (with empty/near-empty stdout) produced no visible
+        // output at all.
+        let stdout = "";
+        let stderr = "WARN  registry lookup failed, using cached metadata";
+        let combined = format!("{}{}", stdout, stderr);
+
+        assert_eq!(PnpmListParser::parse(stdout).tier(), 3);
+
+        let filtered = truncate_passthrough(&combined);
+        let shown = never_worse(&combined, &filtered);
+        assert!(
+            shown.contains("registry lookup failed"),
+            "stderr content must survive passthrough: got {shown}"
+        );
+    }
+
+    #[test]
+    fn test_pnpm_outdated_passthrough_includes_both_streams() {
+        // Malformed JSON on stdout plus a real error on stderr: the shown
+        // output must include both, not just stdout.
+        let stdout = "{not valid json";
+        let stderr = "Error: ENOENT: no such file or directory, open 'package.json'";
+        let combined = format!("{}{}", stdout, stderr);
+
+        assert_eq!(PnpmOutdatedParser::parse(stdout).tier(), 3);
+
+        let filtered = truncate_passthrough(&combined);
+        let display = if filtered.trim().is_empty() {
+            "All packages up-to-date".to_string()
+        } else {
+            filtered.clone()
+        };
+        let shown = never_worse(&combined, &display);
+
+        assert!(shown.contains("not valid json"), "stdout content lost: got {shown}");
+        assert!(
+            shown.contains("ENOENT: no such file or directory"),
+            "stderr content lost: got {shown}"
+        );
+    }
+
+    #[test]
+    fn test_pnpm_outdated_empty_both_streams_shows_up_to_date() {
+        // Regression: genuinely empty output on both streams (no outdated
+        // packages, e.g. real `pnpm outdated --format json` prints "{}")
+        // must still fall back to "All packages up-to-date" via the
+        // `filtered.trim().is_empty()` check — this fix must not touch
+        // that empty-display fallback. (The final `never_worse` guard
+        // clamp against the raw combined output is exercised separately by
+        // `guard.rs`'s own tests and is out of scope here.)
+        let stdout = "{}";
+        let stderr = "";
+        let combined = format!("{}{}", stdout, stderr);
+
+        let parse_result = PnpmOutdatedParser::parse(stdout);
+        assert_eq!(parse_result.tier(), 1, "\"{{}}\" is valid empty JSON, not Passthrough");
+
+        let filtered = match parse_result {
+            ParseResult::Full(data) => data.format(FormatMode::from_verbosity(0)),
+            ParseResult::Degraded(data, _) => data.format(FormatMode::from_verbosity(0)),
+            ParseResult::Passthrough(_) => truncate_passthrough(&combined),
+        };
+
+        let display = if filtered.trim().is_empty() {
+            "All packages up-to-date".to_string()
+        } else {
+            filtered.clone()
+        };
+
+        assert_eq!(display, "All packages up-to-date");
     }
 }

--- a/src/cmds/js/vitest_cmd.rs
+++ b/src/cmds/js/vitest_cmd.rs
@@ -253,12 +253,24 @@ pub fn run_test(command: &Commands, args: &[String], verbose: u8) -> Result<i32>
     let rendered = render_test_output(&filtered, &combined, &tee_label, result.exit_code);
     let shown = crate::core::runner::emit_guarded(&rendered, None, &combined);
 
-    timer.track(
-        format!("{} run", framework).as_str(),
-        format!("rtk {} run", framework).as_str(),
-        &combined,
-        &shown,
-    );
+    let cmd_label = format!("{} run", framework);
+    if filtered.is_parse_failure {
+        // Genuine Tier-3 parse failure — not token savings — record it as
+        // such instead of feeding it into the savings timer.
+        tracking::record_parse_failure_silent(
+            &cmd_label,
+            "All parsing tiers failed",
+            !shown.trim().is_empty(),
+        );
+        timer.track_passthrough(&cmd_label, &format!("rtk {} (passthrough)", cmd_label));
+    } else {
+        timer.track(
+            cmd_label.as_str(),
+            format!("rtk {} run", framework).as_str(),
+            &combined,
+            &shown,
+        );
+    }
 
     if !result.success() {
         return Ok(result.exit_code);
@@ -274,6 +286,7 @@ struct EffectiveVitestArgs {
 struct FormattedTestOutput {
     text: String,
     truncated: bool,
+    is_parse_failure: bool,
 }
 
 impl FormattedTestOutput {
@@ -281,6 +294,7 @@ impl FormattedTestOutput {
         Self {
             text,
             truncated: false,
+            is_parse_failure: false,
         }
     }
 
@@ -288,7 +302,16 @@ impl FormattedTestOutput {
         Self {
             text,
             truncated: true,
+            is_parse_failure: false,
         }
+    }
+
+    /// Marks this output as originating from a genuine Tier-3 parse failure
+    /// (all parsing tiers failed), as opposed to an explicit user-requested
+    /// passthrough (e.g. `--reporter=verbose`) which is not a failure.
+    fn parse_failure(mut self) -> Self {
+        self.is_parse_failure = true;
+        self
     }
 }
 
@@ -350,7 +373,10 @@ fn format_test_output(
         }
         ParseResult::Passthrough(_) => {
             emit_passthrough_warning(framework, "All parsing tiers failed");
-            format_passthrough_output(stdout)
+            // Build from the combined stdout+stderr, not stdout alone —
+            // otherwise a stderr-only failure (empty/near-empty stdout)
+            // produces no visible output at all.
+            format_passthrough_output(combined).parse_failure()
         }
     }
 }
@@ -602,5 +628,73 @@ Scope: all 6 workspace projects
         assert!(rendered.contains("[RTK:PASSTHROUGH] Output truncated"));
         assert!(rendered.contains("[full output: /tmp/vitest_run.log]"));
         assert!(!rendered.contains("wrong-path.log"));
+    }
+
+    // --- Tier 3 (Passthrough) content-loss + tracking regression tests ---
+
+    #[test]
+    fn test_genuine_parse_failure_with_stdout_marks_parse_failure_and_keeps_content() {
+        let stdout = "random output with no structure that fails all parse tiers";
+        let combined = stdout.to_string();
+
+        let filtered = format_test_output("vitest", stdout, &combined, false, 0);
+
+        assert!(filtered.is_parse_failure);
+        assert!(filtered.text.contains("random output with no structure"));
+    }
+
+    #[test]
+    fn test_genuine_parse_failure_empty_stdout_uses_combined_stderr() {
+        // Regression: previously format_passthrough_output(stdout) was called
+        // with an empty stdout, producing empty/near-empty output even though
+        // stderr (part of `combined`) had real failure content.
+        let stdout = "";
+        let combined = "Error: could not resolve entry module 'src/index.ts'".to_string();
+
+        let filtered = format_test_output("vitest", stdout, &combined, false, 0);
+
+        assert!(filtered.is_parse_failure);
+        assert!(filtered
+            .text
+            .contains("Error: could not resolve entry module"));
+    }
+
+    #[test]
+    fn test_explicit_passthrough_requested_is_not_a_parse_failure() {
+        let output = " ✓ some.test.ts > case\n Tests  1 passed (1)\n";
+
+        let filtered = format_test_output("vitest", output, output, true, 0);
+
+        assert!(!filtered.is_parse_failure);
+        assert!(filtered.text.contains("Tests  1 passed"));
+    }
+
+    #[test]
+    fn test_full_json_parse_is_not_a_parse_failure() {
+        let json = r#"{
+            "numTotalTests": 1,
+            "numPassedTests": 1,
+            "numFailedTests": 0,
+            "numPendingTests": 0,
+            "testResults": [],
+            "startTime": 1000
+        }"#;
+
+        let filtered = format_test_output("vitest", json, json, false, 0);
+
+        assert!(!filtered.is_parse_failure);
+    }
+
+    #[test]
+    fn test_degraded_regex_fallback_is_not_a_parse_failure() {
+        let text = r#"
+ Test Files  1 passed (1)
+      Tests  5 passed (5)
+   Duration  10ms
+        "#;
+
+        let filtered = format_test_output("vitest", text, text, false, 0);
+
+        assert!(!filtered.is_parse_failure);
     }
 }

--- a/src/core/tee.rs
+++ b/src/core/tee.rs
@@ -168,10 +168,67 @@ pub fn tee_raw(raw: &str, command_slug: &str, exit_code: i32) -> Option<PathBuf>
     )
 }
 
+/// Convert an MSYS/Git-Bash-style home path (e.g. `/c/Users/name`) to a
+/// native Windows path (`C:\Users\name`) so it can be compared against
+/// native paths via `strip_prefix`. Git Bash sets `HOME` in this POSIX-like
+/// form by default; passed through unconverted, it would never match a
+/// native path and would silently defeat the `~/` shorthand entirely.
+/// Returns `None` for anything that isn't in this exact shape (already-native
+/// paths, e.g. a corporate `HOME` override, are left to the caller as-is).
+#[cfg(windows)]
+fn msys_home_to_native(raw: &str) -> Option<PathBuf> {
+    let rest = raw.strip_prefix('/')?;
+    let mut chars = rest.chars();
+    let drive = chars.next()?;
+    if !drive.is_ascii_alphabetic() {
+        return None;
+    }
+    match chars.next() {
+        None => Some(PathBuf::from(format!("{}:\\", drive.to_ascii_uppercase()))),
+        Some('/') => {
+            let tail: String = chars.collect();
+            Some(PathBuf::from(format!(
+                "{}:\\{}",
+                drive.to_ascii_uppercase(),
+                tail.replace('/', "\\")
+            )))
+        }
+        _ => None,
+    }
+}
+
+fn home_from_env() -> Option<PathBuf> {
+    // An empty (but set) HOME would otherwise become an empty PathBuf, and
+    // `Path::strip_prefix("")` trivially succeeds for any path — every teed
+    // file would then read as "home-relative" and get a bogus `~/` prefix.
+    let raw = std::env::var("HOME").ok().filter(|s| !s.is_empty())?;
+    #[cfg(windows)]
+    {
+        msys_home_to_native(&raw).or(Some(PathBuf::from(raw)))
+    }
+    #[cfg(not(windows))]
+    {
+        Some(PathBuf::from(raw))
+    }
+}
+
 fn display_path(path: &std::path::Path) -> String {
-    if let Some(home) = dirs::home_dir() {
+    // Prefer $HOME over the OS home-directory API: Git Bash/MSYS and other
+    // POSIX-like shells set HOME themselves, and that is the root their own
+    // `~` expansion resolves against -- which can differ from the OS API on
+    // redirected/roaming Windows profiles. $HOME may be MSYS-style
+    // (`/c/Users/name`) and needs converting before it's usable as a native
+    // path prefix -- see `msys_home_to_native`.
+    let home = home_from_env().or_else(dirs::home_dir);
+    if let Some(home) = home {
         if let Ok(relative) = path.strip_prefix(&home) {
-            return format!("~/{}", relative.display());
+            // Normalize to forward slashes unconditionally so the hint never
+            // mixes `~/` with native (backslash) separators on Windows.
+            let relative = relative
+                .display()
+                .to_string()
+                .replace(std::path::MAIN_SEPARATOR, "/");
+            return format!("~/{}", relative);
         }
     }
     path.display().to_string()
@@ -562,6 +619,59 @@ mod tests {
         assert!(
             !hint.contains("\\ "),
             "hint should not encourage backslash-escaped whitespace"
+        );
+    }
+
+    #[test]
+    fn test_msys_home_to_native_converts_drive_letter_path() {
+        assert_eq!(
+            msys_home_to_native("/c/Users/name"),
+            Some(PathBuf::from(r"C:\Users\name"))
+        );
+    }
+
+    #[test]
+    fn test_msys_home_to_native_converts_bare_drive_root() {
+        assert_eq!(msys_home_to_native("/c"), Some(PathBuf::from(r"C:\")));
+    }
+
+    #[test]
+    fn test_msys_home_to_native_rejects_non_msys_paths() {
+        // A corporate/explicit HOME override already in native-ish form
+        // (drive letter, not MSYS's bare "/c/..." shape) isn't MSYS-style;
+        // the caller falls back to using it as-is rather than mangling it.
+        assert_eq!(msys_home_to_native("C:/SPB_Data/Users/name"), None);
+        // Not Windows-shaped at all (e.g. a plain Linux/macOS HOME).
+        assert_eq!(msys_home_to_native("/home/name"), None);
+    }
+
+    #[test]
+    fn test_display_path_never_mixes_separators_for_home_relative_paths() {
+        // Platform-neutral regression test for the Windows separator-mixing
+        // bug: whatever "home" this process resolves to (via $HOME or the
+        // OS API), a home-relative hint must render with forward slashes
+        // only, never a mix of "/" and native backslashes. Reads whatever
+        // home is actually available rather than mutating $HOME, so this
+        // test is safe to run concurrently with the rest of the suite.
+        let Some(home) = home_from_env().or_else(dirs::home_dir) else {
+            return;
+        };
+        let path = home
+            .join("AppData")
+            .join("Local")
+            .join("rtk")
+            .join("tee")
+            .join("123_test.log");
+
+        let displayed = display_path(&path);
+
+        assert!(
+            displayed.starts_with("~/"),
+            "expected a home-relative hint, got {displayed}"
+        );
+        assert!(
+            !displayed.contains('\\'),
+            "display_path must not mix separators: {displayed}"
         );
     }
 


### PR DESCRIPTION
Fixes the three related bugs reported in #3339, all rooted in how rtk's Tier-3 "parsing failed" fallback (`ParseResult::Passthrough`) is tracked and displayed.

## 1. `rtk gain` counted parse failures as savings

`timer.track(...)` was called unconditionally, even for Passthrough-tier runs. Since the passthrough content is a truncated view of the raw output, the size difference between "raw" and "shown" was counted as savings — even though nothing was parsed or summarized, and truncation only happened because parsing failed.

Fix: route genuine Tier-3 failures through the existing `record_parse_failure_silent` + `TimedExecution::track_passthrough` plumbing (already used by `rtk gain --failures`) instead of the generic savings timer. Applied to `playwright test`, `pnpm list`, `pnpm outdated`, and `vitest`/`jest run` — the four call sites sharing this pattern. Explicit user-requested passthrough (e.g. vitest's `--reporter` override) is untouched — it isn't a failure.

## 2. Tee hint path broken on Windows

`[full output: ~/path/to/log]` mixed a forward-slash `~` with native backslash separators, and could resolve `~` against a different home directory than the invoking Git Bash/MSYS shell's own `~` expansion uses.

Fix, in `display_path`:
- Normalize the home-relative portion to forward slashes unconditionally (previously only the whitespace-quoting branch did this).
- Prefer `$HOME` over the OS home-directory API when stripping the home prefix, converting Git Bash/MSYS's POSIX-style `HOME` (`/c/Users/name`) to a native path first — otherwise it would never match via `strip_prefix` and would silently defeat the `~` shorthand.
- Reject an empty `HOME` value (an empty `PathBuf`'s `strip_prefix` trivially matches everything).

This keeps the existing `~/` shorthand (per #2325's direction) rather than reverting to always-absolute paths, an approach previously tried in #2187/#2701.

## 3. Passthrough could silently emit nothing

When parsing failed and a command's real output was empty on stdout (diagnostic on stderr instead), the passthrough fallback was itself empty. `never_worse` then preferred that empty result over the real combined output, discarding it.

Fix: build the passthrough fallback content from the combined stdout+stderr instead of stdout alone, for all four call sites above.

## Notes

- No local rtk checkout existed when this was written — verified against a fresh `develop` clone before implementing.
- `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --all` all pass (2523 tests; the only 2 failures in this environment — `hooks::rewrite_cmd::tests::unattestable_passthrough::*` — are pre-existing and unrelated, reproduced identically on unmodified `develop`).
- `pnpm list`'s Tier-1/Degraded guard and tracking stay anchored to stdout alone (unchanged) — only the Tier-3 arm uses the combined stream, so a stderr notice alongside a successful parse doesn't inflate the reported savings ratio.
