### PR TITLE
fix(init): install Pi extension under .omp so OMP discovers it

### DIFF
--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -109,7 +109,7 @@ rtk init --agent pi
 rtk init --agent pi --global
 ```
 
-Creates `.pi/extensions/rtk.ts` (local) or `~/.pi/agent/extensions/rtk.ts` (global). Pi auto-discovers extensions from both paths on startup.
+Creates `.omp/extensions/rtk.ts` (local) or `~/.omp/agent/extensions/rtk.ts` (global). OMP auto-discovers extensions from both paths on startup.
 
 Uninstall:
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -40,7 +40,7 @@ Each agent subdirectory has its own README with hook-specific details:
 - **[`windsurf/`](windsurf/README.md)** — Rules file (prompt-level), `.windsurfrules` workspace-scoped
 - **[`codex/`](codex/README.md)** — Awareness document, `AGENTS.md` integration, `$CODEX_HOME` or `~/.codex/` location
 - **[`opencode/`](opencode/README.md)** — TypeScript plugin, `zx` library, `tool.execute.before` event, in-place mutation
-- **[`pi/`](pi/README.md)** — TypeScript extension, `tool_call` event, `isToolCallEventType` guard, in-place mutation, `~/.pi/agent/extensions/`
+- **[`pi/`](pi/README.md)** — TypeScript extension, `tool_call` event, `isToolCallEventType` guard, in-place mutation, `~/.omp/agent/extensions/`
 - **[`hermes/`](hermes/README.md)** — Python plugin, `pre_tool_call` hook, in-place terminal command mutation
 
 ## Supported Agents

--- a/hooks/pi/README.md
+++ b/hooks/pi/README.md
@@ -19,18 +19,18 @@ with other Pi extensions.
 - Calls `rtk rewrite` via `pi.exec`; mutates `event.input.command` in-place if rewrite differs
 - All error paths return `undefined` (pass through); RTK never blocks execution
 - Version guard at load time: checks `rtk >= 0.23.0`; warns and registers no-op if too old or missing
-- Installed to `.pi/extensions/rtk.ts` by `rtk init --agent pi` (project-local) or `~/.pi/agent/extensions/rtk.ts` by `rtk init --agent pi --global`
+- Installed to `.omp/extensions/rtk.ts` by `rtk init --agent pi` (project-local) or `~/.omp/agent/extensions/rtk.ts` by `rtk init --agent pi --global`
 
 ## Uninstall
 
 ```bash
 # Remove project-local install (run from the project root)
 rtk init --uninstall --agent pi
-# → removes .pi/extensions/rtk.ts
+# → removes .omp/extensions/rtk.ts
 
 # Remove global install
 rtk init --uninstall --agent pi --global
-# → removes ~/.pi/agent/extensions/rtk.ts
+# → removes ~/.omp/agent/extensions/rtk.ts
 ```
 
 Uninstall is idempotent — re-running when nothing is installed is a no-op.

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -30,7 +30,7 @@ LLM agent integration layer that installs, validates, and executes command-rewri
 | Cline | `rtk init --agent cline` | `.clinerules` | -- |
 | Codex | `rtk init --codex` | RTK.md in `$CODEX_HOME` or `~/.codex` | AGENTS.md |
 | Cursor | `rtk init -g --agent cursor` | Cursor hook | hooks.json |
-| Pi | `rtk init --agent pi` | `.pi/extensions/rtk.ts` | -- |
+| Pi | `rtk init --agent pi` | `.omp/extensions/rtk.ts` | -- |
 | Hermes | `rtk init --agent hermes` | Python plugin in `~/.hermes/plugins/rtk-rewrite/` | `config.yaml` `plugins.enabled` |
 
 

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -30,8 +30,8 @@ pub const COPILOT_INSTRUCTIONS_FILE: &str = "copilot-instructions.md";
 pub const COPILOT_USER_DIR: &str = ".copilot";
 pub const COPILOT_HOME_ENV: &str = "COPILOT_HOME";
 
-pub const PI_DIR: &str = ".pi/agent";
-pub const PI_LOCAL_DIR: &str = ".pi";
+pub const PI_DIR: &str = ".omp/agent";
+pub const PI_LOCAL_DIR: &str = ".omp";
 pub const PI_EXTENSIONS_SUBDIR: &str = "extensions";
 pub const PI_PLUGIN_FILE: &str = "rtk.ts";
 pub const PI_CODING_AGENT_DIR_ENV: &str = "PI_CODING_AGENT_DIR";

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -3383,7 +3383,7 @@ fn pi_plugin_path(pi_dir: &Path) -> PathBuf {
 
 /// Return the Pi extension install path for the given scope.
 /// global=true  → `$PI_CODING_AGENT_DIR/extensions/rtk.ts`
-/// global=false → `./.pi/extensions/rtk.ts`
+/// global=false → `./.omp/extensions/rtk.ts`
 fn pi_plugin_path_for_scope(global: bool) -> Result<PathBuf> {
     if global {
         Ok(pi_plugin_path(&resolve_pi_dir()?))
@@ -3457,7 +3457,7 @@ fn uninstall_pi(global: bool, ctx: InitContext) -> Result<()> {
 /// Install the Pi extension (hook-only; no AGENTS.md injection).
 ///
 /// global=true  → `$PI_CODING_AGENT_DIR/extensions/rtk.ts`
-/// global=false → `.pi/extensions/rtk.ts`
+/// global=false → `.omp/extensions/rtk.ts`
 pub fn run_pi_mode(global: bool, ctx: InitContext) -> Result<()> {
     let InitContext {
         verbose: _,
@@ -7183,7 +7183,7 @@ mod tests {
 
         let plugin = tmp
             .path()
-            .join(".pi")
+            .join(".omp")
             .join(PI_EXTENSIONS_SUBDIR)
             .join(PI_PLUGIN_FILE);
         assert!(plugin.exists(), "local Pi extension must be created");
@@ -7256,7 +7256,7 @@ mod tests {
 
         let plugin = tmp
             .path()
-            .join(".pi")
+            .join(".omp")
             .join(PI_EXTENSIONS_SUBDIR)
             .join(PI_PLUGIN_FILE);
         assert!(!plugin.exists(), "local plugin must be removed");
@@ -7327,8 +7327,8 @@ mod tests {
         result.unwrap();
 
         assert!(
-            !tmp.path().join(".pi").join(PI_EXTENSIONS_SUBDIR).exists(),
-            "dry-run must not create .pi/extensions/"
+            !tmp.path().join(".omp").join(PI_EXTENSIONS_SUBDIR).exists(),
+            "dry-run must not create .omp/extensions/"
         );
     }
 
@@ -7373,7 +7373,7 @@ mod tests {
         run_pi_mode(false, InitContext::default()).unwrap();
         let plugin = tmp
             .path()
-            .join(".pi")
+            .join(".omp")
             .join(PI_EXTENSIONS_SUBDIR)
             .join(PI_PLUGIN_FILE);
         assert!(


### PR DESCRIPTION
## Problem

`rtk init --agent pi` installs the TypeScript extension to `.pi/extensions/rtk.ts` (project) / `~/.pi/agent/extensions/rtk.ts` (global). The current Oh My Pi (OMP) runtime auto-discovers extensions **only** from `<cwd>/.omp/extensions` and `~/.omp/agent/extensions`; `.pi/extensions` is not a discovery root. The extension is therefore written but never loaded, so no commands are rewritten and `rtk gain` shows no OMP activity.

## Root cause

The install directory literals — not the extension code. OMP still honors the `PI_CODING_AGENT_DIR` env var, and its default agent dir is `~/.omp/agent`, so pointing the paths at `.omp` aligns install, uninstall, and OMP's discovery.

## Fix

- `src/hooks/constants.rs`: `PI_DIR` `.pi/agent` → `.omp/agent`, `PI_LOCAL_DIR` `.pi` → `.omp`
- `src/hooks/init.rs`: matching doc comments + test assertions
- docs: `hooks/README.md`, `hooks/pi/README.md`, `src/hooks/README.md`, `docs/guide/getting-started/supported-agents.md`

The extension file (`hooks/pi/rtk.ts`), the `--agent pi` flag, the `PI_*` constant names, and `PI_CODING_AGENT_DIR` are unchanged. Paths-only, minimal.

## Verification

Verified end-to-end against a live `omp v17.0.6`:

- With the extension at `~/.omp/agent/extensions/rtk.ts`, OMP loads it on startup via native discovery and its `tool_call` handler rewrites bash commands through `rtk rewrite`.
- Example: `ls -la /tmp/…` was rewritten to `rtk ls -la /tmp/…`, executed, and logged in rtk's history at 94.4% savings — `rtk gain` now reflects OMP usage.

Gate: `cargo fmt --all --check`, `cargo clippy --all-targets`, and full `cargo test` all pass (the `test_run_pi_mode_*` / `test_pi_*` tests now assert `.omp`).
