### PR TITLE
docs(codex): avoid prefixing shell builtins

### DIFF
--- a/hooks/codex/rtk-awareness.md
+++ b/hooks/codex/rtk-awareness.md
@@ -4,7 +4,8 @@
 
 ## Rule
 
-Always prefix shell commands with `rtk`.
+Prefix supported executable commands with `rtk`. Do not prefix shell builtins such as `cd`
+or `export`; in a compound command, prefix only the executable command:
 
 Examples:
 
@@ -13,7 +14,12 @@ rtk git status
 rtk cargo test
 rtk npm run build
 rtk pytest -q
+cd backend && rtk cargo test
 ```
+
+Use `rtk rewrite` when the correct placement is unclear. For example,
+`rtk rewrite 'cd backend && uv run pytest tests/'` prints
+`cd backend && uv run rtk pytest tests/`.
 
 ## Meta Commands
 
@@ -30,3 +36,6 @@ rtk --version
 rtk gain
 which rtk
 ```
+
+An error prefixed with `[rtk:` came from RTK and does not mean the binary is unavailable.
+Run the checks above before falling back to raw commands.

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -2833,6 +2833,14 @@ mod tests {
     }
 
     #[test]
+    fn test_rewrite_cd_then_uv_run_pytest() {
+        assert_eq!(
+            rewrite_command_no_prefixes("cd backend && uv run pytest tests/", &[]),
+            Some("cd backend && uv run rtk pytest tests/".into())
+        );
+    }
+
+    #[test]
     fn test_rewrite_env_uv_run_pytest() {
         assert_eq!(
             rewrite_command_no_prefixes("PYTHONPATH=. uv run pytest tests/", &[]),


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

- Clarify that Codex should prefix executable commands, not shell builtins such as `cd`.
- Document how `rtk rewrite` places RTK within a compound `cd && uv run pytest` command.
- Add a regression test for that exact rewrite path and explain how to verify RTK availability.

Fixes #3331.

## Test plan
<!-- How did you verify this works? -->

- [x] `cargo fmt --all -- --check && cargo clippy --all-targets -- -D warnings && cargo test`
  (2,512 unit tests and 64 integration tests passed; 8 unit tests ignored)
- [x] Manual testing: `./target/debug/rtk rewrite 'cd backend && uv run pytest tests/'`
  printed `cd backend && uv run rtk pytest tests/`

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
