### PR TITLE
fix(test): preserve diagnostics from generic runner failures

### DIFF
--- a/src/cmds/rust/runner.rs
+++ b/src/cmds/rust/runner.rs
@@ -34,6 +34,15 @@ static ERROR_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(|| {
     ]
 });
 
+static TEST_FAIL_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^.*\bfail\b.*$").unwrap());
+static ZERO_OUTCOME_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?i)\b(?:0\s+(?:test\s+)?(?:failed|failures?|errors?|warnings?)|(?:failures?|errors?|warnings?)\s*:\s*0)\b",
+    )
+    .unwrap()
+});
+
 struct ErrorStreamFilter {
     in_error_block: bool,
     blank_count: usize,
@@ -136,23 +145,29 @@ pub fn run_test(command: &str, verbose: u8) -> Result<i32> {
     }
     let cmd = build_shell_command(command);
     let command_owned = command.to_string();
-    crate::core::runner::run_filtered(
+    crate::core::runner::run_filtered_with_exit(
         cmd,
         "test",
         command,
-        move |raw| extract_test_summary(raw, &command_owned),
-        crate::core::runner::RunOptions::with_tee("test"),
+        move |raw, exit_code| extract_test_summary(raw, &command_owned, exit_code),
+        crate::core::runner::RunOptions::with_tee("test").authoritative_failure_output(),
     )
 }
 
-#[cfg(test)]
 fn filter_errors(output: &str) -> String {
     let mut result = Vec::new();
     let mut in_error_block = false;
     let mut blank_count = 0;
 
     for line in output.lines() {
-        let is_error_line = ERROR_PATTERNS.iter().any(|p| p.is_match(line));
+        // Ignore zero-valued outcome counters such as "12 passed, 0 failed";
+        // otherwise they can hide the actual unclassified diagnostic by
+        // suppressing the safer first/last excerpt fallback.
+        let without_zero_outcomes = ZERO_OUTCOME_PATTERN.replace_all(line, "");
+        let is_error_line = TEST_FAIL_PATTERN.is_match(&without_zero_outcomes)
+            || ERROR_PATTERNS
+                .iter()
+                .any(|pattern| pattern.is_match(&without_zero_outcomes));
 
         if is_error_line {
             in_error_block = true;
@@ -178,9 +193,60 @@ fn filter_errors(output: &str) -> String {
     result.join("\n")
 }
 
-fn extract_test_summary(output: &str, command: &str) -> String {
+fn append_failure_excerpt(output: &mut String, lines: &[&str], anchors: &[&str]) {
+    let nonempty_indices: Vec<_> = lines
+        .iter()
+        .enumerate()
+        .filter_map(|(index, line)| (!line.trim().is_empty()).then_some(index))
+        .collect();
+    let mut selected = std::collections::BTreeSet::new();
+
+    for index in nonempty_indices.iter().take(5) {
+        selected.insert(*index);
+    }
+    for index in nonempty_indices.iter().rev().take(5) {
+        selected.insert(*index);
+    }
+
+    let mut anchor_search_start = 0;
+    for anchor in anchors.iter().take(MAX_RUNNER_LINES) {
+        let Some(offset) = lines[anchor_search_start..]
+            .iter()
+            .position(|line| line == anchor)
+        else {
+            continue;
+        };
+        let index = anchor_search_start + offset;
+        anchor_search_start = index + 1;
+
+        let Ok(nonempty_position) = nonempty_indices.binary_search(&index) else {
+            continue;
+        };
+        let start = nonempty_position.saturating_sub(2);
+        let end = (nonempty_position + 2).min(nonempty_indices.len().saturating_sub(1));
+        for context_index in nonempty_indices.iter().take(end + 1).skip(start) {
+            selected.insert(*context_index);
+        }
+    }
+
+    let mut previous = None;
+    for index in selected {
+        if let Some(previous_index) = previous {
+            if index > previous_index + 1 {
+                output.push_str(&format!(
+                    "  ... {} lines omitted ...\n",
+                    index - previous_index - 1
+                ));
+            }
+        }
+        output.push_str(&format!("  {}\n", lines[index]));
+        previous = Some(index);
+    }
+}
+
+fn extract_test_summary(raw_output: &str, command: &str, exit_code: i32) -> String {
     let mut result = Vec::new();
-    let lines: Vec<&str> = output.lines().collect();
+    let lines: Vec<&str> = raw_output.lines().collect();
 
     let is_cargo = command.contains("cargo test");
     let is_pytest = command.contains("pytest");
@@ -238,10 +304,25 @@ fn extract_test_summary(output: &str, command: &str) -> String {
 
     let mut output = String::new();
 
+    // The child status is authoritative. A successful runner may legitimately
+    // mention recovered or expected failures, while a failing runner must never
+    // be reduced to a success-looking summary.
+    if exit_code == 0 {
+        if !result.is_empty() {
+            output.push_str("SUMMARY:\n");
+            for line in &result {
+                output.push_str(&format!("  {}\n", line));
+            }
+        } else {
+            output.push_str("[ok] All tests passed (unrecognized test runner)\n");
+        }
+        return output;
+    }
+
     if !failures.is_empty() {
         output.push_str("[FAIL] FAILURES:\n");
-        for f in failures.iter().take(MAX_RUNNER_FAILURES) {
-            output.push_str(&format!("  {}\n", f));
+        for failure in failures.iter().take(MAX_RUNNER_FAILURES) {
+            output.push_str(&format!("  {}\n", failure));
         }
         if failures.len() > MAX_RUNNER_FAILURES {
             output.push_str(&format!(
@@ -249,8 +330,8 @@ fn extract_test_summary(output: &str, command: &str) -> String {
                 failures.len() - MAX_RUNNER_FAILURES
             ));
         }
-        for f in failure_lines.iter().take(MAX_RUNNER_LINES) {
-            output.push_str(&format!("  {}\n", f.trim()));
+        for line in failure_lines.iter().take(MAX_RUNNER_LINES) {
+            output.push_str(&format!("  {}\n", line.trim()));
         }
         if failure_lines.len() > MAX_RUNNER_LINES {
             output.push_str(&format!(
@@ -259,20 +340,44 @@ fn extract_test_summary(output: &str, command: &str) -> String {
             ));
         }
         output.push('\n');
+        output.push_str("CONTEXT:\n");
+        let failure_anchors: Vec<_> = failures
+            .iter()
+            .take(MAX_RUNNER_FAILURES)
+            .map(String::as_str)
+            .collect();
+        append_failure_excerpt(&mut output, &lines, &failure_anchors);
+    } else {
+        let detected_errors = filter_errors(raw_output);
+        if !detected_errors.is_empty() {
+            output.push_str("[FAIL] DETECTED FAILURES:\n");
+            let error_lines: Vec<_> = detected_errors.lines().collect();
+            for line in error_lines.iter().take(MAX_RUNNER_LINES) {
+                output.push_str(&format!("  {}\n", line));
+            }
+            if error_lines.len() > MAX_RUNNER_LINES {
+                output.push_str(&format!(
+                    "  ... +{} more\n",
+                    error_lines.len() - MAX_RUNNER_LINES
+                ));
+            }
+            output.push('\n');
+            output.push_str("CONTEXT:\n");
+            append_failure_excerpt(&mut output, &lines, &error_lines);
+        } else {
+            output.push_str(&format!(
+                "[FAIL] Command failed (exit code: {})\n",
+                exit_code
+            ));
+
+            append_failure_excerpt(&mut output, &lines, &[]);
+        }
     }
 
     if !result.is_empty() {
         output.push_str("SUMMARY:\n");
-        for r in &result {
-            output.push_str(&format!("  {}\n", r));
-        }
-    } else {
-        output.push_str("OUTPUT (last 5 lines):\n");
-        let start = lines.len().saturating_sub(5);
-        for line in &lines[start..] {
-            if !line.trim().is_empty() {
-                output.push_str(&format!("  {}\n", line));
-            }
+        for line in &result {
+            output.push_str(&format!("  {}\n", line));
         }
     }
 
@@ -289,5 +394,62 @@ mod tests {
         let filtered = filter_errors(output);
         assert!(filtered.contains("error"));
         assert!(!filtered.contains("info"));
+    }
+
+    #[test]
+    fn test_filter_errors_ignores_zero_failure_counters() {
+        assert!(filter_errors("12 passed, 0 failed").is_empty());
+        assert!(filter_errors("12 passed, 0 test failures").is_empty());
+        assert!(filter_errors("Failures: 0").is_empty());
+        assert!(filter_errors("12 passed, 1 failed").contains("1 failed"));
+        assert!(filter_errors("Failures: 1").contains("Failures: 1"));
+    }
+
+    #[test]
+    fn test_standalone_fail_is_scoped_to_test_filter() {
+        let mut stream = ErrorStreamFilter::new();
+        assert_eq!(stream.feed_line("FAIL: expected assertion"), None);
+        assert!(filter_errors("FAIL: expected assertion").contains("FAIL:"));
+    }
+
+    #[test]
+    fn test_nonzero_classified_runner_keeps_unrecognized_diagnostic() {
+        let mut raw = String::from("12 passed, 0 failed\nprocess terminated by sentinel 417\n");
+        for index in 1..=20 {
+            raw.push_str(&format!("cleanup step {index}\n"));
+        }
+        let filtered = extract_test_summary(&raw, "pytest-wrapper", 9);
+        assert!(filtered.contains("process terminated by sentinel 417"));
+        assert!(filtered.contains("cleanup step 20"));
+        assert!(filtered.contains("SUMMARY:"));
+    }
+
+    #[test]
+    fn test_anchor_context_keeps_middle_adjacent_diagnostic() {
+        let lines = [
+            "setup 1",
+            "setup 2",
+            "setup 3",
+            "setup 4",
+            "setup 5",
+            "setup 6",
+            "FAILED test_middle",
+            "diagnostic sentinel MIDDLE-417",
+            "cleanup 1",
+            "cleanup 2",
+            "cleanup 3",
+            "cleanup 4",
+            "cleanup 5",
+            "cleanup 6",
+        ];
+        let mut output = String::new();
+        append_failure_excerpt(&mut output, &lines, &["FAILED test_middle"]);
+        assert!(output.contains("diagnostic sentinel MIDDLE-417"));
+    }
+
+    #[test]
+    fn test_zero_exit_never_emits_failure_banner() {
+        let filtered = extract_test_summary("FAILED but recovered\n", "pytest-wrapper", 0);
+        assert!(!filtered.contains("[FAIL]"));
     }
 }

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -35,6 +35,10 @@ pub struct RunOptions<'a> {
     pub tee_label: Option<&'a str>,
     pub filter_stdout_only: bool,
     pub skip_filter_on_failure: bool,
+    /// On nonzero exit, emit the exit-aware filter result even when it is
+    /// longer than the raw output. Use only when the filter adds essential
+    /// failure state that the raw output may contradict or omit.
+    pub authoritative_failure_output: bool,
     pub no_trailing_newline: bool,
     /// Forward rtk's own stdin to the child process. Needed for commands that
     /// can read from a pipe (e.g. `cat file | rtk wc`); without it the child
@@ -64,6 +68,11 @@ impl<'a> RunOptions<'a> {
 
     pub fn early_exit_on_failure(mut self) -> Self {
         self.skip_filter_on_failure = true;
+        self
+    }
+
+    pub fn authoritative_failure_output(mut self) -> Self {
+        self.authoritative_failure_output = true;
         self
     }
 
@@ -135,7 +144,21 @@ where
         raw
     };
 
-    let shown = if let Some(label) = opts.tee_label {
+    let shown = if opts.authoritative_failure_output && exit_code != 0 {
+        let hint = opts
+            .tee_label
+            .and_then(|label| crate::core::tee::tee_and_hint(raw, label, exit_code));
+        let body = match hint {
+            Some(hint) => format!("{}\n{}", filtered, hint),
+            None => filtered,
+        };
+        if opts.no_trailing_newline {
+            print!("{}", body);
+        } else {
+            println!("{}", body);
+        }
+        body
+    } else if let Some(label) = opts.tee_label {
         print_with_hint(&filtered, raw, raw_for_tracking, label, exit_code)
     } else {
         let guarded = crate::core::guard::never_worse(raw_for_tracking, &filtered).to_string();

--- a/tests/generic_test_runner_test.rs
+++ b/tests/generic_test_runner_test.rs
@@ -1,0 +1,256 @@
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::process::Command;
+
+fn run_script(body: &str) -> std::process::Output {
+    run_named_script("custom-test-runner.sh", body)
+}
+
+fn run_named_script(name: &str, body: &str) -> std::process::Output {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let script = dir.path().join(name);
+    std::fs::write(&script, format!("#!/bin/sh\n{body}\n")).expect("write script");
+    let mut permissions = std::fs::metadata(&script)
+        .expect("script metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&script, permissions).expect("make script executable");
+
+    Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args(["test", script.to_str().expect("utf-8 script path")])
+        .output()
+        .expect("run rtk test")
+}
+
+#[test]
+fn generic_runner_surfaces_failure_before_passing_tail() {
+    let output = run_script(
+        r#"
+printf '%s\n' 'FAIL: test_login broke'
+i=1
+while [ "$i" -le 20 ]; do
+  printf 'PASS: case_%s\n' "$i"
+  i=$((i + 1))
+done
+exit 1
+"#,
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(
+        stdout.contains("FAIL: test_login broke"),
+        "failure line must remain visible: {stdout:?}"
+    );
+    assert!(
+        !stdout.contains("OUTPUT (last 5 lines):"),
+        "a passing tail must not replace the failure: {stdout:?}"
+    );
+}
+
+#[test]
+fn generic_runner_with_zero_exit_does_not_report_failure_words() {
+    let output = run_script(
+        r#"
+printf '%s\n' '12 passed, 0 failed'
+exit 0
+"#,
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(
+        !stdout.contains("[FAIL]"),
+        "zero exit must take precedence over scary words: {stdout:?}"
+    );
+    assert!(
+        !stdout.contains("SUMMARY:\n  12 passed, 0 failed"),
+        "a passing summary must not be promoted as a failure: {stdout:?}"
+    );
+}
+
+#[test]
+fn generic_runner_nonzero_exit_overrides_success_looking_summary() {
+    let output = run_named_script(
+        "pytest-wrapper.sh",
+        r#"
+printf '%s\n' '12 passed, 0 failed'
+printf '%s\n' 'process terminated by sentinel 417'
+i=1
+while [ "$i" -le 20 ]; do
+  printf 'cleanup step %s\n' "$i"
+  i=$((i + 1))
+done
+exit 9
+"#,
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert_eq!(output.status.code(), Some(9));
+    assert!(
+        stdout.starts_with("[FAIL]"),
+        "nonzero exit must be presented as a failure: {stdout:?}"
+    );
+    assert!(
+        stdout.contains("process terminated by sentinel 417"),
+        "nonzero exit must preserve diagnostics even after a success-looking line: {stdout:?}"
+    );
+    assert!(
+        stdout.contains("cleanup step 20") && stdout.contains("lines omitted"),
+        "failure excerpt must retain both the head and tail: {stdout:?}"
+    );
+}
+
+#[test]
+fn generic_runner_short_nonzero_success_summary_keeps_failure_banner() {
+    let output = run_named_script(
+        "pytest-wrapper.sh",
+        r#"
+printf '%s\n' '12 passed, 0 failed'
+exit 9
+"#,
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert_eq!(output.status.code(), Some(9));
+    assert!(
+        stdout.starts_with("[FAIL]"),
+        "never-worse must not replace authoritative failure output: {stdout:?}"
+    );
+}
+
+#[test]
+fn generic_runner_empty_nonzero_output_is_not_silent() {
+    let output = run_named_script("pytest-wrapper.sh", "exit 9");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert_eq!(output.status.code(), Some(9));
+    assert!(
+        stdout.contains("[FAIL] Command failed (exit code: 9)"),
+        "empty nonzero output must produce an actionable failure: {stdout:?}"
+    );
+}
+
+#[test]
+fn generic_runner_detected_error_keeps_adjacent_causal_context() {
+    let output = run_script(
+        r#"
+for i in 1 2 3 4 5 6 7 8 9 10; do printf 'setup step %s\n' "$i"; done
+printf '%s\n' 'error: wrapper failed'
+printf '\n\n'
+printf '%s\n' 'process terminated by sentinel MIDDLE-417'
+i=1
+while [ "$i" -le 20 ]; do
+  printf 'cleanup step %s\n' "$i"
+  i=$((i + 1))
+done
+exit 9
+"#,
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert_eq!(output.status.code(), Some(9));
+    assert!(stdout.starts_with("[FAIL]"));
+    assert!(
+        stdout.contains("process terminated by sentinel MIDDLE-417"),
+        "detected error must retain adjacent causal context: {stdout:?}"
+    );
+}
+
+#[test]
+fn generic_runner_recognized_failure_keeps_nearby_diagnostic_context() {
+    let output = run_named_script(
+        "pytest-wrapper.sh",
+        r#"
+for i in 1 2 3 4 5 6 7 8 9 10; do printf 'setup step %s\n' "$i"; done
+printf '%s\n' 'FAILED test_middle - assertion mismatch'
+printf '\n\n'
+printf '%s\n' 'diagnostic sentinel MIDDLE-417'
+i=1
+while [ "$i" -le 20 ]; do
+  printf 'cleanup step %s\n' "$i"
+  i=$((i + 1))
+done
+printf '%s\n' '================ 1 failed in 0.1s ================'
+exit 9
+"#,
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert_eq!(output.status.code(), Some(9));
+    assert!(
+        stdout.contains("FAILED test_middle"),
+        "nonzero recognized failure must remain visible: {stdout:?}"
+    );
+    assert!(
+        stdout.contains("diagnostic sentinel MIDDLE-417"),
+        "recognized failure must retain nearby diagnostic context: {stdout:?}"
+    );
+}
+
+#[test]
+fn generic_runner_duplicate_failure_anchors_remain_bounded() {
+    let output = run_named_script(
+        "pytest-wrapper.sh",
+        r#"
+i=1
+while [ "$i" -le 200 ]; do
+  printf '%s\n' 'FAILED duplicate_test - assertion mismatch'
+  printf 'diagnostic %s\n' "$i"
+  i=$((i + 1))
+done
+exit 9
+"#,
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert_eq!(output.status.code(), Some(9));
+    assert!(stdout.contains("FAILED duplicate_test"));
+    assert!(
+        stdout.lines().count() < 100,
+        "duplicate anchors must not force raw-output fallback: {} lines",
+        stdout.lines().count()
+    );
+}
+
+#[test]
+fn generic_runner_with_zero_exit_never_emits_failure_banner() {
+    let output = run_named_script(
+        "not-pytest-check.sh",
+        r#"
+printf '%s\n' 'FAILED but recovered'
+i=1
+while [ "$i" -le 20 ]; do
+  printf 'recovery step %s\n' "$i"
+  i=$((i + 1))
+done
+exit 0
+"#,
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(
+        !stdout.contains("[FAIL]"),
+        "zero-exit output must never receive a failure banner: {stdout:?}"
+    );
+}
+
+#[test]
+fn generic_runner_without_error_keywords_keeps_diagnostics_and_status() {
+    let output = run_script(
+        r#"
+printf '%s\n' 'setup aborted by sentinel 417'
+printf '%s\n' 'diagnostic payload'
+exit 7
+"#,
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert_eq!(output.status.code(), Some(7));
+    assert!(
+        stdout.contains("setup aborted by sentinel 417") && stdout.contains("diagnostic payload"),
+        "unclassified failure diagnostics must remain visible: {stdout:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Pass the child process exit code into generic test summarization and treat it as authoritative.
- Bypass the shared never-worse raw fallback on nonzero generic-test exits so short success-looking or empty raw output cannot erase the failure banner.
- Recover failure diagnostics from the complete raw output rather than the displayed tail.
- Keep bounded head/tail context plus anchor-centered context around detected errors and recognized specialized failures, including diagnostics displaced by cleanup tails.
- Ignore zero-valued counters such as `0 failed` when locating real diagnostics.
- Keep standalone `FAIL:` recognition scoped to `rtk test` so `rtk err` behavior is unchanged.
- Add subprocess and unit regressions for early failures, heuristic runner-name collisions, contradictory zero-exit text, success-looking nonzero summaries, zero-failure counters, recognized failures with nearby causal diagnostics, and unknown failure formats.

## Safety contract

- Exit code `0` never receives a failure banner solely because output contains words such as `FAILED`.
- A nonzero exit always receives a failure presentation and retains bounded actionable context.
- Full raw output remains available to RTK tee handling.
- Never-worse output capping remains active.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked`
- `cargo test --locked --test generic_test_runner_test`

The complete locked suite passed locally: 2,515 unit tests passed, 8 ignored, plus all integration targets.

Fixes #2420

This overlaps earlier work in #2427, #2683, and #2996, but adds full-output diagnostic recovery, authoritative exit-status handling, and regression coverage for success-looking nonzero output and zero-exit scary words.