### PR TITLE
fix(security): address followup review comments on private-file hardening

### DIFF
--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -254,10 +254,16 @@ impl Tracker {
 
         // Create the file ourselves so SQLite derives the -wal/-shm modes from
         // an already-private DB instead of the umask.
-        let _ = crate::core::utils::open_private(
+        crate::core::utils::open_private(
             std::fs::OpenOptions::new().write(true).create(true),
             &db_path,
-        );
+        )
+        .with_context(|| {
+            format!(
+                "Failed to pre-create private DB file: {}",
+                db_path.display()
+            )
+        })?;
 
         let conn = Connection::open(&db_path)?;
         // WAL mode + busy_timeout for concurrent access (multiple Claude Code instances).
@@ -1247,7 +1253,7 @@ fn db_sidecars(db_path: &std::path::Path) -> Vec<PathBuf> {
         .collect()
 }
 
-fn get_db_path() -> Result<PathBuf> {
+pub(crate) fn get_db_path() -> Result<PathBuf> {
     // Priority 1: Environment variable RTK_DB_PATH
     if let Ok(custom_path) = std::env::var("RTK_DB_PATH") {
         return Ok(PathBuf::from(custom_path));

--- a/src/hooks/integrity.rs
+++ b/src/hooks/integrity.rs
@@ -274,15 +274,20 @@ fn report_hook_status(verbose: u8) -> Result<()> {
 /// Report a data directory other local users can reach. RTK tightens it to 0700
 /// on every run, but that chmod fails silently when the directory belongs to
 /// another user — `rtk verify` is where that surfaces, never the command path.
+///
+/// Checks the parent of the actual resolved DB path (honoring `RTK_DB_PATH` and
+/// `config.tracking.database_path` overrides), not just the default location.
 #[cfg(unix)]
 fn report_data_dir_privacy() {
-    use super::super::core::constants::RTK_DATA_DIR;
     use std::os::unix::fs::PermissionsExt;
 
-    let Some(dir) = dirs::data_local_dir().map(|d| d.join(RTK_DATA_DIR)) else {
+    let Ok(db_path) = crate::core::tracking::get_db_path() else {
         return;
     };
-    let Ok(meta) = std::fs::metadata(&dir) else {
+    let Some(dir) = db_path.parent() else {
+        return;
+    };
+    let Ok(meta) = std::fs::metadata(dir) else {
         return;
     };
 


### PR DESCRIPTION
## Summary
Followup to the private-file hardening PR (store history db, tee logs and audit log owner-only). Three review comments weren't addressed before merge:

- `report_data_dir_privacy()` in `src/hooks/integrity.rs` hardcoded the default `dirs::data_local_dir()/rtk` path, so `rtk verify` would report on the wrong directory (or silently skip the real one) when `RTK_DB_PATH` or `config.tracking.database_path` is set. It now resolves the actual DB path via `tracking::get_db_path()` and checks that path's parent directory.
- Non-conventional import `use super::super::core::constants::RTK_DATA_DIR;` in `integrity.rs` — removed now that the constant lookup lives inside `tracking::get_db_path()`.
- `Tracker::new()` discarded the `Result` from the pre-create `open_private()` call with `let _ =`. It now propagates the error with `.with_context(...)?`, consistent with this repo's "always context, always anyhow" rule.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets` (no warnings)
- [x] `cargo test --all` (2584 passed)