### PR TITLE
fix(tracking): count Unicode characters when estimating tokens

### DIFF
--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -1319,7 +1319,7 @@ pub fn record_parse_failure_silent(raw_command: &str, error_message: &str, succe
 /// ```
 pub fn estimate_tokens(text: &str) -> usize {
     // ~4 chars per token on average
-    (text.len() as f64 / 4.0).ceil() as usize
+    text.chars().count().div_ceil(4)
 }
 
 /// Helper struct for timing command execution
@@ -1467,6 +1467,7 @@ mod tests {
         assert_eq!(estimate_tokens("abcde"), 2); // 5 chars = ceil(1.25) = 2
         assert_eq!(estimate_tokens("a"), 1); // 1 char = ceil(0.25) = 1
         assert_eq!(estimate_tokens("12345678"), 2); // 8 chars = 2 tokens
+        assert_eq!(estimate_tokens("你好"), 1); // 2 chars (6 bytes) = ceil(0.5) = 1
     }
 
     // 2. args_display — format OsString vec

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -1468,6 +1468,8 @@ mod tests {
         assert_eq!(estimate_tokens("a"), 1); // 1 char = ceil(0.25) = 1
         assert_eq!(estimate_tokens("12345678"), 2); // 8 chars = 2 tokens
         assert_eq!(estimate_tokens("你好"), 1); // 2 chars (6 bytes) = ceil(0.5) = 1
+        assert_eq!(estimate_tokens("😀😃😄😁😆"), 2); // 5 chars (20 bytes) = ceil(1.25) = 2
+        assert_eq!(estimate_tokens("hello你好🌍"), 2); // 8 chars (15 bytes) = 2 tokens
     }
 
     // 2. args_display — format OsString vec


### PR DESCRIPTION
 ## Summary

  - Update `estimate_tokens` to count Unicode characters instead of UTF-8 bytes, matching the
  documented `ceil(chars / 4)` heuristic.
  - Add regression coverage for non-ASCII input. Fixes #3359.

  ## Test plan

  - [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
  - [x] Manual testing: `rtk proxy printf '你好\n'` output inspected with an isolated tracking
  database; input and output were each estimated as one token.


> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
