### PR TITLE
fix(docker): forward value-taking flags for compose ps/logs/build

### DIFF
--- a/src/cmds/cloud/container.rs
+++ b/src/cmds/cloud/container.rs
@@ -671,14 +671,29 @@ pub fn run_docker_passthrough(args: &[OsString], verbose: u8) -> Result<i32> {
     crate::core::runner::run_passthrough("docker", args, verbose)
 }
 
-/// Run `docker compose ps` (or `docker compose ps -a`) with compact output
-pub fn run_compose_ps(all: bool, verbose: u8) -> Result<i32> {
+/// Run `docker compose ps` (or `docker compose ps -a`) with compact output.
+/// `extra_args` carries any additional flags/positionals the user passed
+/// (service name filters, `--format`, etc.) so they're never silently dropped.
+pub fn run_compose_ps(all: bool, extra_args: &[String], verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
+
+    let has_user_format = extra_args
+        .iter()
+        .any(|a| a == "--format" || a.starts_with("--format="));
 
     let mut raw_args: Vec<&str> = vec!["compose", "ps"];
     if all {
         raw_args.push("-a");
     }
+    raw_args.extend(extra_args.iter().map(String::as_str));
+
+    if has_user_format {
+        // The user asked for a specific docker format — that's exact output they
+        // likely parse downstream, so forward it verbatim instead of compacting.
+        let os_args: Vec<OsString> = raw_args.iter().map(OsString::from).collect();
+        return crate::core::runner::run_passthrough("docker", &os_args, verbose);
+    }
+
     let raw_result = exec_capture(resolved_command("docker").args(&raw_args))
         .context("Failed to run docker compose ps")?;
 
@@ -692,6 +707,7 @@ pub fn run_compose_ps(all: bool, verbose: u8) -> Result<i32> {
     if all {
         format_args.push("-a");
     }
+    format_args.extend(extra_args.iter().map(String::as_str));
     format_args.extend(["--format", "{{.Name}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}"]);
     let result = exec_capture(resolved_command("docker").args(&format_args))
         .context("Failed to run docker compose ps --format")?;
@@ -715,13 +731,20 @@ pub fn run_compose_ps(all: bool, verbose: u8) -> Result<i32> {
     Ok(0)
 }
 
-pub fn run_compose_logs(service: Option<&str>, tail: u32, verbose: u8) -> Result<i32> {
+pub fn run_compose_logs(service: Option<&str>, extra_args: &[String], verbose: u8) -> Result<i32> {
+    let has_user_tail = extra_args
+        .iter()
+        .any(|a| a == "--tail" || a.starts_with("--tail="));
+
     let mut cmd = resolved_command("docker");
-    let tail_str = tail.to_string();
-    cmd.args(["compose", "logs", "--tail", &tail_str]);
+    cmd.args(["compose", "logs"]);
+    if !has_user_tail {
+        cmd.args(["--tail", "100"]);
+    }
     if let Some(svc) = service {
         cmd.arg(svc);
     }
+    cmd.args(extra_args);
 
     let svc_label = service.unwrap_or("all");
     runner::run_filtered(
@@ -738,18 +761,20 @@ pub fn run_compose_logs(service: Option<&str>, tail: u32, verbose: u8) -> Result
     )
 }
 
-pub fn run_compose_build(service: Option<&str>, verbose: u8) -> Result<i32> {
+pub fn run_compose_build(extra_args: &[String], verbose: u8) -> Result<i32> {
     let mut cmd = resolved_command("docker");
     cmd.args(["compose", "build"]);
-    if let Some(svc) = service {
-        cmd.arg(svc);
-    }
+    cmd.args(extra_args);
 
-    let svc_label = service.unwrap_or("all");
+    let label = if extra_args.is_empty() {
+        "all".to_string()
+    } else {
+        extra_args.join(" ")
+    };
     runner::run_filtered(
         cmd,
         "docker",
-        &format!("compose build {}", svc_label),
+        &format!("compose build {}", label),
         |raw| {
             if verbose > 0 {
                 eprintln!("raw docker compose build:\n{}", raw);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1025,19 +1025,23 @@ enum ComposeCommands {
     Ps {
         #[arg(short = 'a', long)]
         all: bool,
+        /// Extra docker compose ps flags/args (e.g. --format, service names)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
     },
     /// Show compose logs (deduplicated)
     Logs {
         /// Optional service name
         service: Option<String>,
-        /// Number of log lines to fetch
-        #[arg(long, default_value_t = 100)]
-        tail: u32,
+        /// Extra docker compose logs flags (e.g. --tail, --no-log-prefix)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
     },
     /// Build compose services (summary)
     Build {
-        /// Optional service name
-        service: Option<String>,
+        /// Extra docker compose build flags/args (e.g. --progress, service names)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
     },
     /// Passthrough: runs any unsupported compose subcommand directly
     #[command(external_subcommand)]
@@ -1920,12 +1924,14 @@ fn run_cli() -> Result<i32> {
                 container::run(container::ContainerCmd::DockerLogs, &[c], cli.verbose)?
             }
             DockerCommands::Compose { command: compose } => match compose {
-                ComposeCommands::Ps { all } => container::run_compose_ps(all, cli.verbose)?,
-                ComposeCommands::Logs { service, tail } => {
-                    container::run_compose_logs(service.as_deref(), tail, cli.verbose)?
+                ComposeCommands::Ps { all, args } => {
+                    container::run_compose_ps(all, &args, cli.verbose)?
                 }
-                ComposeCommands::Build { service } => {
-                    container::run_compose_build(service.as_deref(), cli.verbose)?
+                ComposeCommands::Logs { service, args } => {
+                    container::run_compose_logs(service.as_deref(), &args, cli.verbose)?
+                }
+                ComposeCommands::Build { args } => {
+                    container::run_compose_build(&args, cli.verbose)?
                 }
                 ComposeCommands::Other(args) => {
                     container::run_compose_passthrough(&args, cli.verbose)?
@@ -3616,6 +3622,91 @@ mod tests {
                 assert!(global);
             }
             _ => panic!("Expected Init command"),
+        }
+    }
+
+    #[test]
+    fn test_compose_ps_accepts_format_flag() {
+        // rtk-ai/rtk#2945 (compose subtree): `docker compose ps --format ...`
+        // was rejected as an unrecognized argument and fell back to raw output.
+        let cli = Cli::try_parse_from(["rtk", "docker", "compose", "ps", "--format", "{{.Name}}"])
+            .expect("compose ps --format should parse");
+        match cli.command {
+            Commands::Docker {
+                command:
+                    DockerCommands::Compose {
+                        command: ComposeCommands::Ps { all, args },
+                    },
+            } => {
+                assert!(!all);
+                assert_eq!(args, ["--format", "{{.Name}}"]);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_compose_ps_accepts_service_filter() {
+        let cli = Cli::try_parse_from(["rtk", "docker", "compose", "ps", "web", "api"])
+            .expect("compose ps with service names should parse");
+        match cli.command {
+            Commands::Docker {
+                command:
+                    DockerCommands::Compose {
+                        command: ComposeCommands::Ps { args, .. },
+                    },
+            } => assert_eq!(args, ["web", "api"]),
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_compose_logs_accepts_no_log_prefix_flag() {
+        let cli = Cli::try_parse_from([
+            "rtk",
+            "docker",
+            "compose",
+            "logs",
+            "cms",
+            "--no-log-prefix",
+            "--tail",
+            "200",
+        ])
+        .expect("compose logs --no-log-prefix should parse");
+        match cli.command {
+            Commands::Docker {
+                command:
+                    DockerCommands::Compose {
+                        command: ComposeCommands::Logs { service, args },
+                    },
+            } => {
+                assert_eq!(service.as_deref(), Some("cms"));
+                assert_eq!(args, ["--no-log-prefix", "--tail", "200"]);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_compose_build_accepts_progress_flag_and_multiple_services() {
+        let cli = Cli::try_parse_from([
+            "rtk",
+            "docker",
+            "compose",
+            "build",
+            "--progress=plain",
+            "control-plane",
+            "cms",
+        ])
+        .expect("compose build --progress and multiple services should parse");
+        match cli.command {
+            Commands::Docker {
+                command:
+                    DockerCommands::Compose {
+                        command: ComposeCommands::Build { args },
+                    },
+            } => assert_eq!(args, ["--progress=plain", "control-plane", "cms"]),
+            other => panic!("unexpected command: {other:?}"),
         }
     }
 }


### PR DESCRIPTION
## Summary

- `rtk docker compose ps` now accepts arbitrary trailing flags/positionals (e.g. `--format`, service-name filters) instead of erroring on anything beyond `-a`
- `rtk docker compose logs` now accepts `--no-log-prefix` and any other docker flags (previously only `[SERVICE]` and `--tail` were recognized)
- `rtk docker compose build` now accepts `--progress=plain` and multiple service names (previously only a single optional `service`)
- When the caller supplies their own `--format` to `ps`, RTK forwards the call verbatim instead of compacting, since it needs its own template for the compact view and shouldn't silently discard output the caller is likely parsing downstream

Same root cause as #2945, but scoped to the `docker compose` subcommand tree, which #2945's own fix (#2971) does not touch — that PR only covers top-level `docker ps/images/logs`.

## Reproduction (before this fix)

```
$ rtk docker compose ps --format json
error: unexpected argument '--format' found
$ rtk docker compose logs cms --no-log-prefix --tail 200
error: unexpected argument '--no-log-prefix' found
$ rtk docker compose build --progress=plain cms
error: unexpected argument '--progress' found
```

All three fell back to raw output before erroring out entirely on some call shapes (measured via `parse_failures` on a real machine — 21 occurrences across these three subcommands, `fallback_succeeded=1` throughout, so no breakage, just 0% savings on these calls).

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets` (clean)
- [x] `cargo test --all` — 2,524 passed, 0 failed, 8 ignored (pre-existing environment-dependent ignores, same as on `develop`)
- [x] Added 4 new clap-parsing tests covering `--format`, positional service filters, `--no-log-prefix`, and `--progress=plain` + multiple services
- [x] Manual: `docker compose ps --format json`, `ps <service>`, `logs <svc> --no-log-prefix --tail 200`, and `build --progress=plain <svc> <svc>` all now reach the real `docker` binary (verified they fail only on "no configuration file provided", not on rtk's arg parser)