### PR TITLE
fix: discover supported dotnet subcommands

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -3098,6 +3098,45 @@ mod tests {
         );
     }
 
+    // --- .NET tooling ---
+
+    #[test]
+    fn test_classify_dotnet_supported_subcommands() {
+        for command in [
+            "dotnet build App.sln",
+            "dotnet test --no-build",
+            "dotnet restore App.sln",
+            "dotnet format --verify-no-changes",
+        ] {
+            assert!(matches!(
+                classify_command(command),
+                Classification::Supported {
+                    rtk_equivalent: "rtk dotnet",
+                    ..
+                }
+            ));
+        }
+    }
+
+    #[test]
+    fn test_rewrite_dotnet_supported_subcommands() {
+        for (command, expected) in [
+            ("dotnet build App.sln", "rtk dotnet build App.sln"),
+            ("dotnet test --no-build", "rtk dotnet test --no-build"),
+            ("dotnet restore App.sln", "rtk dotnet restore App.sln"),
+            (
+                "dotnet format --verify-no-changes",
+                "rtk dotnet format --verify-no-changes",
+            ),
+        ] {
+            assert_eq!(
+                rewrite_command_no_prefixes(command, &[]),
+                Some(expected.into()),
+                "Failed for command: {command}"
+            );
+        }
+    }
+
     #[test]
     fn test_rewrite_golangci_lint() {
         assert_eq!(

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -687,7 +687,7 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
-        pattern: r"^dotnet\s+build\b",
+        pattern: r"^dotnet\s+(build|test|restore|format)\b",
         rtk_cmd: "rtk dotnet",
         rewrite_prefixes: &["dotnet"],
         category: "Build",


### PR DESCRIPTION
## Summary

- recognize `dotnet test`, `dotnet restore`, and `dotnet format` alongside `dotnet build`
- add classification and rewrite coverage for all four supported subcommands

Fixes #3300

## Validation

- `cargo test dotnet_supported` (2 passed)
- `cargo fmt --all --check && cargo clippy --all-targets && cargo test` (2,522 unit tests and 47 integration tests passed)
- `cargo run --quiet -- rewrite "dotnet test --no-build"` → `rtk dotnet test --no-build`
- `git diff --check`

## AI assistance

Prepared with Codex assistance; the patch and validation results were reviewed before submission.