### PR TITLE
docs: init command for copilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ rtk gain        # Should show the savings dashboard
 
 ```bash
 # 1. Install for your AI tool
-rtk init -g                     # Claude Code / Copilot (default)
+rtk init -g                     # Claude Code (default)
+rtk init -g --copilot           # Copilot
 rtk init -g --gemini            # Gemini CLI
 rtk init -g --codex             # Codex (OpenAI)
 rtk init -g --agent cursor      # Cursor


### PR DESCRIPTION
The global init needs the --copilot flag to work with Copilot CLI.

## Summary
- Clarifying how to init RTK on a machine only using Copilot CLI.
- The previous default without the `--copilot` flag is not working.