### PR TITLE
fix(config): [limits] section is ignored, and a partial section silently resets the whole config

### DIFF
--- a/docs/contributing/TECHNICAL.md
+++ b/docs/contributing/TECHNICAL.md
@@ -314,7 +314,7 @@ Start here, then drill down into each README for file-level details.
 |-----------|-------|-------------------------------|
 | [`hooks/`](../hooks/README.md) | _(parent)_ | **All JSON formats**, rewrite registry overview, exit code contract, override controls |
 | [`claude/`](../hooks/claude/README.md) | Claude Code | Shell hook mechanism, `PreToolUse` JSON, test script |
-| [`copilot/`](../hooks/copilot/README.md) | GitHub Copilot | Rust binary hook, VS Code Chat vs Copilot CLI dual format |
+| [`copilot/`](../hooks/copilot/README.md) | GitHub Copilot | Rust binary hook, single `PreToolUse` schema shared by VS Code Chat and Copilot CLI |
 | [`cursor/`](../hooks/cursor/README.md) | Cursor IDE | Shell hook, empty JSON response requirement |
 | [`cline/`](../hooks/cline/README.md) | Cline / Roo Code | Rules file (prompt-level, no programmatic hook) |
 | [`windsurf/`](../hooks/windsurf/README.md) | Windsurf / Cascade | Rules file (workspace-scoped) |
@@ -331,7 +331,7 @@ RTK supports the following LLM agents through hook integrations:
 |-------|-----------|-----------|---------------------|
 | Claude Code | Shell hook | `PreToolUse` in `settings.json` | Yes (`updatedInput`) |
 | GitHub Copilot (VS Code) | Rust binary | `rtk hook copilot` reads JSON | Yes (`updatedInput`) |
-| GitHub Copilot CLI | Rust binary | `rtk hook copilot` reads JSON | No (deny + suggestion) |
+| GitHub Copilot CLI | Rust binary | `rtk hook copilot` reads JSON | Yes (`updatedInput`) |
 | Cursor | Rust binary | `rtk hook cursor` reads JSON | Yes (`updated_input`) |
 | Gemini CLI | Rust binary | `rtk hook gemini` reads JSON | Yes (`hookSpecificOutput`) |
 | Cline/Roo Code | Rules file | Prompt-level guidance | N/A (prompt) |

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -30,7 +30,7 @@ Agent runs "cargo test"
 |-------|-----------------|---------------------------|
 | Claude Code | Shell hook (`PreToolUse`) | Yes |
 | VS Code Copilot Chat | Shell hook (`PreToolUse`) | Yes |
-| GitHub Copilot CLI | Shell hook (`preToolUse` `modifiedArgs`) | Yes |
+| GitHub Copilot CLI | Shell hook (`PreToolUse`) | Yes |
 | Cursor | Shell hook (`preToolUse`) | Yes |
 | Gemini CLI | Rust binary (`BeforeTool`) | Yes |
 | OpenCode | TypeScript plugin (`tool.execute.before`) | Yes |
@@ -74,7 +74,9 @@ rtk init --copilot            # project-scoped (.github/hooks/)
 rtk init --global --copilot   # user-scoped (~/.copilot/hooks/, respects $COPILOT_HOME)
 ```
 
-Project-scoped writes `.github/hooks/rtk-rewrite.json` (both hosts get transparent rewrite — VS Code Chat via `updatedInput`, Copilot CLI via `modifiedArgs`) plus the RTK block in `.github/copilot-instructions.md`. User-scoped writes the same hook config to `~/.copilot/hooks/rtk-rewrite.json` and the RTK block to `~/.copilot/copilot-instructions.md` (both respect `$COPILOT_HOME` if set).
+Project-scoped writes `.github/hooks/rtk-rewrite.json` — a single `PreToolUse` entry shared by both hosts, each getting transparent rewrite via `updatedInput` — plus the RTK block in `.github/copilot-instructions.md`. User-scoped writes the same hook config to `~/.copilot/hooks/rtk-rewrite.json` and the RTK block to `~/.copilot/copilot-instructions.md` (both respect `$COPILOT_HOME` if set).
+
+Earlier `rtk` versions also registered a second, camelCase `preToolUse` entry for Copilot CLI's native schema. Copilot CLI treats `PreToolUse`/`preToolUse` as independent hooks and runs both sequentially for the same tool call — a redundant process spawn with no behavioral benefit, since Copilot CLI honors the single `PreToolUse` schema on its own. Re-run `rtk init --copilot` (or `--global --copilot`) to upgrade an existing install to the single-hook config.
 
 Uninstall:
 

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -312,7 +312,10 @@ grep_max_results = 5000
 "#;
         let config: Config = toml::from_str(toml).expect("partial [limits] must parse");
         assert_eq!(config.limits.grep_max_results, 5000);
-        assert_eq!(config.limits.grep_max_per_file, 25, "unset field keeps default");
+        assert_eq!(
+            config.limits.grep_max_per_file, 25,
+            "unset field keeps default"
+        );
         assert_eq!(config.limits.status_max_files, 15);
     }
 

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -120,6 +120,10 @@ pub struct TelemetryConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+// Without this, every field is mandatory: a config that sets only one limit
+// fails to deserialize, which fails the WHOLE Config::load() and silently
+// reverts every other section (hooks, filters, ...) to its default.
+#[serde(default)]
 pub struct LimitsConfig {
     /// Max total grep results to show (default: 200)
     pub grep_max_results: usize,
@@ -295,5 +299,34 @@ consent_date = "2026-04-10T12:00:00Z"
             config.telemetry.consent_date.as_deref(),
             Some("2026-04-10T12:00:00Z")
         );
+    }
+
+    #[test]
+    fn test_partial_limits_section_keeps_other_defaults() {
+        // A [limits] section that sets only one field must deserialize. Before
+        // #[serde(default)] this failed, which failed the WHOLE Config::load()
+        // and silently reverted every other section to its default.
+        let toml = r#"
+[limits]
+grep_max_results = 5000
+"#;
+        let config: Config = toml::from_str(toml).expect("partial [limits] must parse");
+        assert_eq!(config.limits.grep_max_results, 5000);
+        assert_eq!(config.limits.grep_max_per_file, 25, "unset field keeps default");
+        assert_eq!(config.limits.status_max_files, 15);
+    }
+
+    #[test]
+    fn test_partial_limits_does_not_clobber_other_sections() {
+        let toml = r#"
+[hooks]
+transparent_prefixes = ["rg"]
+
+[limits]
+grep_max_results = 5000
+"#;
+        let config: Config = toml::from_str(toml).expect("must parse");
+        assert_eq!(config.hooks.transparent_prefixes, vec!["rg".to_string()]);
+        assert_eq!(config.limits.grep_max_results, 5000);
     }
 }

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -30,6 +30,10 @@ fn read_stdin_limited() -> Result<String> {
 /// Format detected from the preToolUse JSON input.
 enum HookFormat {
     /// VS Code Copilot Chat / Claude Code: `tool_name` + `tool_input.command`, supports `updatedInput`.
+    /// If using the PreToolUse pascal case form, Copilot CLI also remaps its native `bash`/`powershell`
+    /// runtime tool to `tool_name: "Bash"` for this schema and honors its `updatedInput`, live-verified
+    /// on Linux+Windows 11 with Copilot CLI 1.0.73+ by rewriting a marker command end-to-end
+    /// see <https://github.com/rtk-ai/rtk/pull/3179#issuecomment-5088268495>.
     VsCode { command: String },
     /// GitHub Copilot CLI's native schema: camelCase `toolName` + `toolArgs` (JSON string),
     /// supports `modifiedArgs` for transparent rewrite. `rtk init --copilot` no longer
@@ -38,6 +42,10 @@ enum HookFormat {
     /// see git history). Kept for installs that haven't re-run `rtk init --copilot` since
     /// upgrading, and as the schema JetBrains/IntelliJ's Copilot plugin uses under a
     /// different `toolName` value (`run_in_terminal`, not `bash` — see #2443/#3093).
+    /// On Windows, Copilot CLI reports this schema's `toolName` as the unmapped runtime
+    /// name `"powershell"` (#3178/#3179) — but since the `VsCode` schema above already
+    /// works standalone there, that arm is legacy-only: relevant for un-upgraded installs,
+    /// not exercised by a fresh `rtk init --copilot` on any platform.
     /// Carries the full parsed `toolArgs` object so we can rewrite `command` while preserving
     /// host-supplied metadata (description, initial_wait, mode, …) the tool requires.
     CopilotCli { command: String, args: Value },
@@ -81,6 +89,9 @@ fn detect_format(v: &Value) -> HookFormat {
     // "run_in_terminal" is VS Code Copilot Chat's actual terminal tool name
     // (confirmed via live payload capture) — without it, detect_format falls
     // through to PassThrough and the hook never fires for VS Code Copilot Chat.
+    // No separate Windows/"powershell" case is needed: Copilot CLI remaps both
+    // `bash` and `powershell` to `tool_name: "Bash"` for this schema — already
+    // handled below, live-confirmed (see the VsCode variant doc).
     if let Some(tool_name) = v.get("tool_name").and_then(|t| t.as_str()) {
         if matches!(
             tool_name,
@@ -99,12 +110,12 @@ fn detect_format(v: &Value) -> HookFormat {
         return HookFormat::PassThrough;
     }
 
-    // Copilot's native camelCase schema: toolName + toolArgs (JSON-encoded string).
+    // Copilot CLI's native camelCase schema: toolName + toolArgs (JSON-encoded string).
     // The shell tool is "bash" on Unix and "powershell" on Windows.
     // Only reachable today via a not-yet-upgraded install's leftover camelCase
     // preToolUse registration (see the CopilotCli variant doc) or a host that
     // registers this schema itself, like JetBrains/IntelliJ's Copilot plugin
-    // (toolName "run_in_terminal", tracked separately in #2443/#3093).
+    // (toolName "run_in_terminal").
     if let Some(tool_name) = v.get("toolName").and_then(|t| t.as_str()) {
         if matches!(tool_name, "bash" | "powershell" | "run_in_terminal") {
             if let Some(tool_args_str) = v.get("toolArgs").and_then(|t| t.as_str()) {
@@ -243,7 +254,7 @@ fn copilot_ide_response_from_decision(decision: HookDecision, cmd: &str) -> Opti
             audit_log("deny", cmd, "");
             "Blocked by RTK permission rule".to_string()
         }
-        HookDecision::AllowRewrite(rewritten) | HookDecision::AskRewrite { rewritten, .. } => {
+        HookDecision::AllowRewrite(rewritten) | HookDecision::AskRewrite(rewritten) => {
             audit_log("rewrite", cmd, &rewritten);
             format!("RTK token optimization: re-run this command as `{rewritten}` instead.")
         }
@@ -986,10 +997,7 @@ mod tests {
     #[test]
     fn test_copilot_ide_rewrite_returns_deny_with_suggestion() {
         let response = copilot_ide_response_from_decision(
-            HookDecision::AskRewrite {
-                rewritten: "rtk git status".into(),
-                explicit: false,
-            },
+            HookDecision::AskRewrite("rtk git status".into()),
             "git status",
         )
         .unwrap();

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -31,7 +31,13 @@ fn read_stdin_limited() -> Result<String> {
 enum HookFormat {
     /// VS Code Copilot Chat / Claude Code: `tool_name` + `tool_input.command`, supports `updatedInput`.
     VsCode { command: String },
-    /// GitHub Copilot CLI: camelCase `toolName` + `toolArgs` (JSON string), supports `modifiedArgs` for transparent rewrite.
+    /// GitHub Copilot CLI's native schema: camelCase `toolName` + `toolArgs` (JSON string),
+    /// supports `modifiedArgs` for transparent rewrite. `rtk init --copilot` no longer
+    /// registers this schema (Copilot CLI honors the PascalCase `VsCode` schema on its
+    /// own — registering both caused a redundant second hook invocation per tool call,
+    /// see git history). Kept for installs that haven't re-run `rtk init --copilot` since
+    /// upgrading, and as the schema JetBrains/IntelliJ's Copilot plugin uses under a
+    /// different `toolName` value (`run_in_terminal`, not `bash` — see #2443/#3093).
     /// Carries the full parsed `toolArgs` object so we can rewrite `command` while preserving
     /// host-supplied metadata (description, initial_wait, mode, …) the tool requires.
     CopilotCli { command: String, args: Value },
@@ -93,8 +99,12 @@ fn detect_format(v: &Value) -> HookFormat {
         return HookFormat::PassThrough;
     }
 
-    // Copilot CLI: camelCase keys, toolArgs is a JSON-encoded string.
+    // Copilot's native camelCase schema: toolName + toolArgs (JSON-encoded string).
     // The shell tool is "bash" on Unix and "powershell" on Windows.
+    // Only reachable today via a not-yet-upgraded install's leftover camelCase
+    // preToolUse registration (see the CopilotCli variant doc) or a host that
+    // registers this schema itself, like JetBrains/IntelliJ's Copilot plugin
+    // (toolName "run_in_terminal", tracked separately in #2443/#3093).
     if let Some(tool_name) = v.get("toolName").and_then(|t| t.as_str()) {
         if matches!(tool_name, "bash" | "powershell" | "run_in_terminal") {
             if let Some(tool_args_str) = v.get("toolArgs").and_then(|t| t.as_str()) {

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -71,9 +71,15 @@ pub fn run_copilot() -> Result<()> {
 }
 
 fn detect_format(v: &Value) -> HookFormat {
-    // VS Code Copilot Chat / Claude Code: snake_case keys
+    // VS Code Copilot Chat / Claude Code: snake_case keys.
+    // "run_in_terminal" is VS Code Copilot Chat's actual terminal tool name
+    // (confirmed via live payload capture) — without it, detect_format falls
+    // through to PassThrough and the hook never fires for VS Code Copilot Chat.
     if let Some(tool_name) = v.get("tool_name").and_then(|t| t.as_str()) {
-        if matches!(tool_name, "runTerminalCommand" | "Bash" | "bash") {
+        if matches!(
+            tool_name,
+            "runTerminalCommand" | "run_in_terminal" | "Bash" | "bash"
+        ) {
             if let Some(cmd) = v
                 .pointer("/tool_input/command")
                 .and_then(|c| c.as_str())
@@ -761,6 +767,16 @@ mod tests {
     fn test_detect_vscode_run_terminal_command() {
         assert!(matches!(
             detect_format(&vscode_input("runTerminalCommand", "cargo test")),
+            HookFormat::VsCode { .. }
+        ));
+    }
+
+    #[test]
+    fn test_detect_vscode_run_in_terminal() {
+        // VS Code Copilot Chat's actual terminal tool name, confirmed via
+        // live payload capture — distinct from "runTerminalCommand".
+        assert!(matches!(
+            detect_format(&vscode_input("run_in_terminal", "cargo test")),
             HookFormat::VsCode { .. }
         ));
     }

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -138,7 +138,7 @@ fn get_rewritten(cmd: &str) -> Option<String> {
 
 enum HookDecision {
     AllowRewrite(String),
-    AskRewrite { rewritten: String, explicit: bool },
+    AskRewrite(String),
     Defer,
     Deny,
 }
@@ -152,10 +152,7 @@ fn decide_from_verdict(cmd: &str, verdict: PermissionVerdict) -> HookDecision {
     }
     match get_rewritten(cmd) {
         Some(r) if verdict == PermissionVerdict::Allow => HookDecision::AllowRewrite(r),
-        Some(r) => HookDecision::AskRewrite {
-            rewritten: r,
-            explicit: verdict == PermissionVerdict::Ask,
-        },
+        Some(r) => HookDecision::AskRewrite(r),
         None => HookDecision::Defer,
     }
 }
@@ -165,28 +162,46 @@ fn decide_hook_action(cmd: &str, host: permissions::Host) -> HookDecision {
 }
 
 fn handle_vscode(cmd: &str) -> Result<()> {
-    let (decision, rewritten) = match decide_hook_action(cmd, permissions::Host::Claude) {
+    if let Some(output) = vscode_response(cmd) {
+        let _ = writeln!(io::stdout(), "{output}");
+    }
+    Ok(())
+}
+
+fn vscode_response(cmd: &str) -> Option<Value> {
+    vscode_response_from_decision(decide_hook_action(cmd, permissions::Host::Claude), cmd)
+}
+
+/// Build the VS Code Copilot Chat / Copilot CLI (PascalCase compat) hook response.
+///
+/// Mirrors `process_claude_payload`: `permissionDecision: "allow"` is only ever
+/// asserted for an explicit, user-configured Allow rule. Every other rewrite
+/// (Default verdict or an explicit Ask rule) omits the field entirely, leaving
+/// the host's own native prompt/allowlist flow in control — see #3037, where
+/// asserting `"ask"` here made Copilot CLI 1.0.66+ force a blocking dialog with
+/// no "remember" option on every rewritten command.
+fn vscode_response_from_decision(decision: HookDecision, cmd: &str) -> Option<Value> {
+    let (rewritten, allow) = match decision {
         HookDecision::Deny => {
             audit_log("deny", cmd, "");
-            return Ok(());
+            return None;
         }
-        HookDecision::Defer => return Ok(()),
-        HookDecision::AllowRewrite(r) => ("allow", r),
-        HookDecision::AskRewrite { rewritten: r, .. } => ("ask", r),
+        HookDecision::Defer => return None,
+        HookDecision::AllowRewrite(r) => (r, true),
+        HookDecision::AskRewrite(r) => (r, false),
     };
 
     audit_log("rewrite", cmd, &rewritten);
 
-    let output = json!({
-        "hookSpecificOutput": {
-            "hookEventName": PRE_TOOL_USE_KEY,
-            "permissionDecision": decision,
-            "permissionDecisionReason": "RTK auto-rewrite",
-            "updatedInput": { "command": rewritten }
-        }
+    let mut hook_output = json!({
+        "hookEventName": PRE_TOOL_USE_KEY,
+        "permissionDecisionReason": "RTK auto-rewrite",
+        "updatedInput": { "command": rewritten }
     });
-    let _ = writeln!(io::stdout(), "{output}");
-    Ok(())
+    if allow {
+        hook_output["permissionDecision"] = json!("allow");
+    }
+    Some(json!({ "hookSpecificOutput": hook_output }))
 }
 
 fn handle_copilot_cli(cmd: &str, args: &Value) -> Result<()> {
@@ -244,13 +259,7 @@ fn copilot_cli_response_from_decision(
         }
         HookDecision::Defer => return None,
         HookDecision::AllowRewrite(r) => (r, true),
-        HookDecision::AskRewrite {
-            rewritten: r,
-            explicit,
-        } => {
-            let is_simple = crate::discover::lexer::split_for_permissions(cmd).len() <= 1;
-            (r, !explicit && is_simple)
-        }
+        HookDecision::AskRewrite(r) => (r, false),
     };
 
     audit_log("rewrite", cmd, &rewritten);
@@ -306,7 +315,7 @@ pub fn run_gemini() -> Result<()> {
             audit_log("rewrite", cmd, rewritten);
             print_gemini("allow", Some(rewritten));
         }
-        HookDecision::AskRewrite { ref rewritten, .. } => {
+        HookDecision::AskRewrite(ref rewritten) => {
             audit_log("ask", cmd, rewritten);
             print_gemini("ask_user", Some(rewritten));
         }
@@ -411,7 +420,7 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
             }
         }
         HookDecision::AllowRewrite(r) => (r, true),
-        HookDecision::AskRewrite { rewritten: r, .. } => (r, false),
+        HookDecision::AskRewrite(r) => (r, false),
     };
 
     let updated_input = {
@@ -535,7 +544,7 @@ pub fn run_cursor() -> Result<()> {
             audit_log("rewrite", &cmd, &rewritten);
             cursor_allow(&rewritten)
         }
-        HookDecision::AskRewrite { rewritten, .. } => {
+        HookDecision::AskRewrite(rewritten) => {
             audit_log("ask", &cmd, &rewritten);
             cursor_ask(&rewritten)
         }
@@ -598,7 +607,7 @@ fn run_cursor_inner_with_rules(
     let verdict = permissions::check_command_with_rules(&cmd, deny_rules, ask_rules, allow_rules);
     match decide_from_verdict(&cmd, verdict) {
         HookDecision::AllowRewrite(rewritten) => cursor_allow(&rewritten),
-        HookDecision::AskRewrite { rewritten, .. } => cursor_ask(&rewritten),
+        HookDecision::AskRewrite(rewritten) => cursor_ask(&rewritten),
         _ => "{}".to_string(),
     }
 }
@@ -644,7 +653,7 @@ fn droid_response_from_decision(v: &Value, cmd: &str, decision: HookDecision) ->
             return None;
         }
         HookDecision::Defer => return None,
-        HookDecision::AllowRewrite(r) | HookDecision::AskRewrite { rewritten: r, .. } => r,
+        HookDecision::AllowRewrite(r) | HookDecision::AskRewrite(r) => r,
     };
 
     audit_log("rewrite", cmd, &rewritten);
@@ -834,6 +843,61 @@ mod tests {
         assert!(get_rewritten("cat <<'EOF'\nhello\nEOF").is_none());
     }
 
+    // --- VS Code Copilot Chat / Copilot CLI (PascalCase) handler ---
+    // Serves both VS Code Copilot Chat's PreToolUse hook and Copilot CLI's
+    // PascalCase-compat entry (#3037): the same `rtk hook copilot` call
+    // answers both from one JSON schema.
+
+    #[test]
+    fn test_vscode_allow_rewrite_sets_permission_allow() {
+        let r = vscode_response_from_decision(
+            HookDecision::AllowRewrite("rtk git status".into()),
+            "git status",
+        )
+        .unwrap();
+        assert_eq!(r["hookSpecificOutput"]["permissionDecision"], "allow");
+        assert_eq!(
+            r["hookSpecificOutput"]["updatedInput"]["command"],
+            "rtk git status"
+        );
+    }
+
+    #[test]
+    fn test_vscode_ask_rewrite_omits_permission_decision() {
+        // Default (unconfigured) and explicit-Ask verdicts both land here as
+        // AskRewrite — neither must assert a decision, matching Claude's own
+        // hook (process_claude_payload). Asserting "ask" is what caused #3037:
+        // Copilot CLI 1.0.66+ treats it as authoritative and forces a blocking
+        // dialog with no "remember" option on every rewritten command.
+        let r = vscode_response_from_decision(
+            HookDecision::AskRewrite("rtk cargo test".into()),
+            "cargo test",
+        )
+        .unwrap();
+        assert!(
+            r["hookSpecificOutput"]
+                .as_object()
+                .unwrap()
+                .get("permissionDecision")
+                .is_none(),
+            "AskRewrite must NOT set permissionDecision"
+        );
+        assert_eq!(
+            r["hookSpecificOutput"]["updatedInput"]["command"],
+            "rtk cargo test"
+        );
+    }
+
+    #[test]
+    fn test_vscode_deny_returns_none() {
+        assert!(vscode_response_from_decision(HookDecision::Deny, "cargo test").is_none());
+    }
+
+    #[test]
+    fn test_vscode_defer_returns_none() {
+        assert!(vscode_response_from_decision(HookDecision::Defer, "cargo test").is_none());
+    }
+
     // --- Copilot CLI handler: transparent rewrite via modifiedArgs ---
 
     fn cli_args(cmd: &str) -> Value {
@@ -841,37 +905,20 @@ mod tests {
     }
 
     #[test]
-    fn test_copilot_cli_default_ask_rewrite_sets_permission_allow() {
+    fn test_copilot_cli_ask_rewrite_omits_permission_decision() {
+        // Whether the Ask verdict came from an explicit rule or the Default
+        // (unconfigured) fallback, RTK must never assert a decision here —
+        // matches Claude's own hook (process_claude_payload) and avoids the
+        // Copilot CLI 1.0.66+ forced-prompt bug from #3037.
         let r = copilot_cli_response_from_decision(
             &cli_args("cargo test"),
-            HookDecision::AskRewrite {
-                rewritten: "rtk cargo test".into(),
-                explicit: false,
-            },
-            "cargo test",
-        )
-        .unwrap();
-        assert_eq!(
-            r["permissionDecision"], "allow",
-            "Default AskRewrite must set permissionDecision to allow — Copilot CLI 1.0.66+ prompts on every command without it"
-        );
-        assert_eq!(r["modifiedArgs"]["command"], "rtk cargo test");
-    }
-
-    #[test]
-    fn test_copilot_cli_explicit_ask_rewrite_omits_permission_decision() {
-        let r = copilot_cli_response_from_decision(
-            &cli_args("cargo test"),
-            HookDecision::AskRewrite {
-                rewritten: "rtk cargo test".into(),
-                explicit: true,
-            },
+            HookDecision::AskRewrite("rtk cargo test".into()),
             "cargo test",
         )
         .unwrap();
         assert!(
             r.get("permissionDecision").is_none(),
-            "Explicit AskRewrite must NOT auto-allow — user deliberately configured ask for this command"
+            "AskRewrite must NOT set permissionDecision — the host's native prompt/allowlist stays in control"
         );
         assert_eq!(r["modifiedArgs"]["command"], "rtk cargo test");
     }
@@ -1000,10 +1047,7 @@ mod tests {
         });
         let r = copilot_cli_response_from_decision(
             &args,
-            HookDecision::AskRewrite {
-                rewritten: "rtk cargo install ripgrep".into(),
-                explicit: false,
-            },
+            HookDecision::AskRewrite("rtk cargo install ripgrep".into()),
             "cargo install ripgrep",
         )
         .unwrap();
@@ -1577,7 +1621,7 @@ mod tests {
     fn test_decide_ask_for_default_verdict() {
         assert!(matches!(
             decide_with_rules("git status", &[], &[], &[]),
-            HookDecision::AskRewrite { .. }
+            HookDecision::AskRewrite(_)
         ));
     }
 
@@ -1635,7 +1679,7 @@ mod tests {
                 r#"{"decision":"deny","reason":"Blocked by RTK permission rule"}"#.to_string()
             }
             HookDecision::AllowRewrite(r) => gemini_json("allow", Some(&r)),
-            HookDecision::AskRewrite { rewritten: r, .. } => gemini_json("ask_user", Some(&r)),
+            HookDecision::AskRewrite(r) => gemini_json("ask_user", Some(&r)),
             HookDecision::Defer => gemini_json("ask_user", None),
         }
     }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -4448,7 +4448,14 @@ fn uninstall_gemini(ctx: InitContext) -> Result<Vec<String>> {
 
 // ── Copilot integration ─────────────────────────────────────
 
-// PreToolUse = VS Code schema, preToolUse = Copilot CLI schema (same file, both hosts).
+// Single PascalCase `PreToolUse` entry, shared by VS Code Copilot Chat and
+// Copilot CLI. Previously this file also declared a camelCase `preToolUse`
+// entry for Copilot CLI's native schema, but Copilot CLI registers BOTH keys
+// as independent hooks and runs them sequentially, chaining the camelCase
+// hook's rewrite into the PascalCase hook's input — a redundant second
+// process spawn per tool call for no behavioral benefit (confirmed live:
+// Copilot CLI honors the PascalCase-only schema on its own, receiving the
+// same `tool_name`/`tool_input.command` shape either way).
 const COPILOT_HOOK_JSON: &str = r#"{
   "version": 1,
   "hooks": {
@@ -4458,15 +4465,6 @@ const COPILOT_HOOK_JSON: &str = r#"{
         "command": "rtk hook copilot",
         "cwd": ".",
         "timeout": 5
-      }
-    ],
-    "preToolUse": [
-      {
-        "type": "command",
-        "bash": "rtk hook copilot",
-        "powershell": "rtk hook copilot",
-        "cwd": ".",
-        "timeoutSec": 5
       }
     ]
   }
@@ -7534,25 +7532,23 @@ mod tests {
     }
 
     #[test]
-    fn test_copilot_hook_json_serves_both_vscode_and_cli_schemas() {
+    fn test_copilot_hook_json_serves_single_pascalcase_schema() {
         let v: serde_json::Value = serde_json::from_str(COPILOT_HOOK_JSON).unwrap();
 
         let vscode = &v["hooks"]["PreToolUse"][0];
         assert_eq!(vscode["command"], "rtk hook copilot");
         assert!(vscode["timeout"].is_number(), "VS Code uses `timeout`");
+        assert_eq!(v["version"], 1);
 
-        assert_eq!(v["version"], 1, "Copilot CLI requires top-level version");
-        let cli = &v["hooks"]["preToolUse"][0];
-        assert_eq!(cli["bash"], "rtk hook copilot");
-        assert_eq!(cli["powershell"], "rtk hook copilot");
         assert!(
-            cli["timeoutSec"].is_number(),
-            "Copilot CLI uses `timeoutSec`"
+            v["hooks"].get("preToolUse").is_none(),
+            "must not register a second, redundant camelCase hook — Copilot CLI treats \
+             PreToolUse and preToolUse as independent hooks and runs both sequentially"
         );
     }
 
     #[test]
-    fn test_copilot_init_writes_dual_schema_to_disk() {
+    fn test_copilot_init_writes_single_schema_to_disk() {
         let temp = TempDir::new().unwrap();
         run_copilot_at(temp.path(), InitContext::default()).unwrap();
 
@@ -7566,7 +7562,44 @@ mod tests {
 
         assert_eq!(v["hooks"]["PreToolUse"][0]["command"], "rtk hook copilot");
         assert_eq!(v["version"], 1);
-        assert_eq!(v["hooks"]["preToolUse"][0]["bash"], "rtk hook copilot");
+        assert!(v["hooks"].get("preToolUse").is_none());
+    }
+
+    #[test]
+    fn test_copilot_init_upgrades_old_dual_schema_install() {
+        // Simulates a pre-existing install from before this fix, which wrote
+        // both a PascalCase PreToolUse and a camelCase preToolUse entry.
+        // Re-running `rtk init --copilot` must overwrite it with the current
+        // single-schema config, not leave the stale camelCase entry in place.
+        let old_dual_schema_json = r#"{
+  "version": 1,
+  "hooks": {
+    "PreToolUse": [
+      { "type": "command", "command": "rtk hook copilot", "cwd": ".", "timeout": 5 }
+    ],
+    "preToolUse": [
+      { "type": "command", "bash": "rtk hook copilot", "powershell": "rtk hook copilot", "cwd": ".", "timeoutSec": 5 }
+    ]
+  }
+}
+"#;
+
+        let temp = TempDir::new().unwrap();
+        let hooks_dir = temp.path().join(".github").join("hooks");
+        fs::create_dir_all(&hooks_dir).unwrap();
+        let hook_path = hooks_dir.join("rtk-rewrite.json");
+        fs::write(&hook_path, old_dual_schema_json).unwrap();
+
+        run_copilot_at(temp.path(), InitContext::default()).unwrap();
+
+        let v: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&hook_path).unwrap()).unwrap();
+        assert_eq!(v["hooks"]["PreToolUse"][0]["command"], "rtk hook copilot");
+        assert!(
+            v["hooks"].get("preToolUse").is_none(),
+            "re-running init must upgrade an old dual-schema install, dropping the \
+             redundant camelCase preToolUse entry"
+        );
     }
 
     #[test]
@@ -7694,7 +7727,39 @@ mod tests {
             serde_json::from_str(&fs::read_to_string(&hook_path).unwrap()).unwrap();
         assert_eq!(v["version"], 1);
         assert_eq!(v["hooks"]["PreToolUse"][0]["command"], "rtk hook copilot");
-        assert_eq!(v["hooks"]["preToolUse"][0]["bash"], "rtk hook copilot");
+        assert!(v["hooks"].get("preToolUse").is_none());
+    }
+
+    #[test]
+    fn test_copilot_global_install_upgrades_old_dual_schema_install() {
+        let old_dual_schema_json = r#"{
+  "version": 1,
+  "hooks": {
+    "PreToolUse": [
+      { "type": "command", "command": "rtk hook copilot", "cwd": ".", "timeout": 5 }
+    ],
+    "preToolUse": [
+      { "type": "command", "bash": "rtk hook copilot", "powershell": "rtk hook copilot", "cwd": ".", "timeoutSec": 5 }
+    ]
+  }
+}
+"#;
+
+        let temp = TempDir::new().unwrap();
+        let hooks_dir = temp.path().join("hooks");
+        fs::create_dir_all(&hooks_dir).unwrap();
+        let hook_path = hooks_dir.join("rtk-rewrite.json");
+        fs::write(&hook_path, old_dual_schema_json).unwrap();
+
+        run_copilot_global_at(temp.path(), InitContext::default()).unwrap();
+
+        let v: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&hook_path).unwrap()).unwrap();
+        assert_eq!(v["hooks"]["PreToolUse"][0]["command"], "rtk hook copilot");
+        assert!(
+            v["hooks"].get("preToolUse").is_none(),
+            "re-running global init must upgrade an old dual-schema install"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1987,16 +1987,14 @@ fn run_cli() -> Result<i32> {
             &extra_args,
             cli.verbose,
         )?,
-        Commands::Rg { extra_args } => {
-            search::run(
-                search::Engine::Rg,
-                80,
-                core::config::limits().grep_max_results,
-                false,
-                &extra_args,
-                cli.verbose,
-            )?
-        }
+        Commands::Rg { extra_args } => search::run(
+            search::Engine::Rg,
+            80,
+            core::config::limits().grep_max_results,
+            false,
+            &extra_args,
+            cli.verbose,
+        )?,
 
         Commands::Init {
             global,

--- a/src/main.rs
+++ b/src/main.rs
@@ -314,9 +314,9 @@ enum Commands {
         /// Max line length
         #[arg(short = 'l', long, default_value = "80")]
         max_len: usize,
-        /// Max results to show
-        #[arg(short, long, default_value = "200")]
-        max: usize,
+        /// Max results to show [default: limits.grep_max_results, or 200]
+        #[arg(short, long)]
+        max: Option<usize>,
         /// Show only match context (not full line)
         #[arg(long)]
         context_only: bool,
@@ -1982,13 +1982,20 @@ fn run_cli() -> Result<i32> {
         } => search::run(
             search::Engine::Grep,
             max_len,
-            max,
+            max.unwrap_or_else(|| core::config::limits().grep_max_results),
             context_only,
             &extra_args,
             cli.verbose,
         )?,
         Commands::Rg { extra_args } => {
-            search::run(search::Engine::Rg, 80, 200, false, &extra_args, cli.verbose)?
+            search::run(
+                search::Engine::Rg,
+                80,
+                core::config::limits().grep_max_results,
+                false,
+                &extra_args,
+                cli.verbose,
+            )?
         }
 
         Commands::Init {


### PR DESCRIPTION
## Summary

Two related defects mean the `[limits]` config section does not work, and setting it partially breaks *the rest of your config too*.

### 1. `grep_max_results` is dead config

It is declared, defaulted, and printed by `rtk config` — but never read anywhere in the codebase:

```
$ rg 'grep_max_results' src/
src/core/config.rs:125:    pub grep_max_results: usize,
src/core/config.rs:139:            grep_max_results: 200,
```

(`grep_max_per_file` *is* read, in `search.rs`, so the section looks like it works.)

The cap actually applied comes from clap's hardcoded default on `rtk grep`:

```rust
#[arg(short, long, default_value = "200")]
max: usize,
```

So setting the documented key has no effect. `Commands::Rg` hardcoded `200` the same way.

**Before:**
```console
$ printf '[limits]\ngrep_max_results = 5000\ngrep_max_per_file = 500\n' > ~/.config/rtk/config.toml
$ rtk grep -n 'the' ./skills | wc -l
202                      # still capped at 200
$ rtk grep -n 'the' ./skills -m 5000 | wc -l
4869                     # only the CLI flag works
```

**After** — `max` becomes `Option<usize>` and falls back to the config value, so precedence is CLI > config > default:

```console
$ # grep_max_results = 3   -> 3 results
$ # grep_max_results = 400 -> all 182 results
$ # grep_max_results = 3, with --max 50 -> 50 results   (CLI still wins)
```

### 2. A partial `[limits]` section breaks the whole config

`LimitsConfig` has no serde defaults, so every one of its five fields is mandatory. A config that sets only one limit fails to deserialize — and because that fails the entire `Config::load()`, **every other section silently reverts to defaults**, including `[hooks] transparent_prefixes` and `exclude_commands`.

```console
$ printf '[limits]\ngrep_max_results = 5000\n' > ~/.config/rtk/config.toml
$ rtk config
rtk: TOML parse error at line 1, column 1
     missing field `status_max_files`
```

That is a confusing failure on its own, but the dangerous part is the silent blast radius onto unrelated sections.

`#[serde(default)]` on the struct fixes it, and matches what `TelemetryConfig`, `HooksConfig`, and every field of `Config` already do.

## Changes

- `src/core/config.rs` — `#[serde(default)]` on `LimitsConfig`
- `src/main.rs` — `rtk grep --max` is now `Option<usize>`, falling back to `limits.grep_max_results`; `Commands::Rg` uses the config value instead of a hardcoded `200`
- two regression tests: a partial `[limits]` parses and keeps other fields' defaults, and it no longer clobbers `[hooks]`

## Verification

`cargo fmt --all -- --check` clean, `cargo clippy --all-targets` no warnings.

`cargo test --bin rtk` → **2526 passed**.

Two pre-existing failures in `hooks::rewrite_cmd::tests::unattestable_passthrough` (`test_plain_command_still_rewrites`, `test_fd_dup_redirect_still_rewrites`) reproduce identically on pristine `master` with my changes stashed. They read the real user config, so they pass or fail depending on whether `~/.config/rtk/config.toml` exists on the machine running them — worth isolating separately, but out of scope here.

## Why this mattered

Found while debugging what looked like `rtk grep` silently dropping matches. It does not drop them — but with `grep_max_per_file = 25` unfixable via config, a file with 30 matches shows 25, and the total in the header stays honest, so nothing looks wrong. For an LLM agent consuming the output, a truncated search reads as "no more matches" and becomes a wrong conclusion rather than a smaller one.
