### PR TITLE
fix(git log): make the injected -50/-10 cap and --no-merges visible in output

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -497,7 +497,28 @@ fn run_log(
 
     // Post-process: truncate long messages, cap lines only if RTK set the default
     let filtered = filter_log_output(&result.stdout, limit, user_set_limit, has_format_flag);
-    let filtered = never_worse(&result.stdout, &filtered).to_string();
+    let mut filtered = never_worse(&result.stdout, &filtered).to_string();
+    // RTK injected its own -N cap above. When it plausibly bit, say so —
+    // otherwise a truncated history reads as the full one and misleads the
+    // caller about repo state. Appended after never_worse on purpose: the
+    // few extra tokens are the cost of not lying. Entry counting is exact
+    // for the RTK default format (---END--- terminator) and a line-count
+    // heuristic for user formats (multi-line formats may fire it early; the
+    // notice is then merely a hint, never wrong about content).
+    if !user_set_limit {
+        let entries = if has_format_flag {
+            result.stdout.lines().filter(|l| !l.trim().is_empty()).count()
+        } else {
+            result.stdout.matches("---END---").count()
+        };
+        if entries >= limit {
+            let merges_note = if !wants_merges { ", merges hidden" } else { "" };
+            filtered.push_str(&format!(
+                "\n... (capped at {} commits by rtk{}; pass -n <N> for full history)",
+                limit, merges_note
+            ));
+        }
+    }
     println!("{}", filtered);
 
     timer.track(


### PR DESCRIPTION
### Problem

`rtk git log` silently rewrites the underlying git invocation:

- `--pretty` / `--oneline` / `--format` without a count → injects `-50`
- no flags at all → injects `-10`
- plus `--no-merges` whenever no explicit count or merge flag is given

The cap happens at the git level, so nothing downstream can tell the output was truncated — not the user, not an agent, and not even rtk's own ledger (input tokens == output tokens, "0% saved"). In a 401-commit repo, `git log --pretty=format:'%ad'` through rtk returns 50 dates with no indication that 351 commits (and all merge commits) are missing. An agent reading that output concluded the repo was two days old and charted history accordingly. (Real incident, 2026-08-03.)

### Fix

In `run_log`, when rtk injected the cap and the returned entry count reached it, append one line:

```
... (capped at 50 commits by rtk, merges hidden; pass -n <N> for full history)
```

- Exact detection for rtk's default format (counts `---END---` terminators); conservative line-count heuristic for user formats (multi-line formats may fire the hint a commit early — the notice is then merely a hint, never wrong about content).
- Explicit `-n` / `--max-count` paths are untouched: no injection, no notice.
- Appended after the `never_worse` guard deliberately: the notice costs ~15 tokens, which the guard would otherwise strip. A silent 8× history truncation misleads callers in a way 15 tokens can't. Happy to gate it behind a config flag if you'd prefer.

### Tests

- `cargo test` on this branch (master base): 2,584 passed, 0 failed — no existing behavior changed. Also verified against v0.43.0: 2,276 passed, 0 failed.
- Fixture repo (62 commits incl. 1 merge):
  - formatted log → 50 lines + notice (current master: 50 lines, silent)
  - `-n 62` → 62 lines, no notice
  - bare `git log` → 10 entries + notice
  - 5-commit repo → full output, no notice
