### PR TITLE
fix(git): suppress blank line on empty git log range

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -498,7 +498,11 @@ fn run_log(
     // Post-process: truncate long messages, cap lines only if RTK set the default
     let filtered = filter_log_output(&result.stdout, limit, user_set_limit, has_format_flag);
     let filtered = never_worse(&result.stdout, &filtered).to_string();
-    println!("{}", filtered);
+    // Empty range (e.g. HEAD..HEAD) must produce empty output, not a bare
+    // newline — `println!` on an empty string still breaks `| wc -l` (#3365).
+    if !filtered.is_empty() {
+        println!("{}", filtered);
+    }
 
     timer.track(
         &format!("git log {}", args.join(" ")),
@@ -3087,6 +3091,55 @@ no changes added to commit (use "git add" and/or "git commit -a")
             "Expected 'not a git repository' on stderr, got stderr={:?}, stdout={:?}",
             stderr,
             stdout
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    // Regression test for #3365: an empty commit range (e.g. HEAD..HEAD) must
+    // produce empty stdout, not a bare newline, or `| wc -l` reports 1 instead of 0.
+    #[test]
+    #[ignore] // Requires `cargo build` first — run with `cargo test --ignored`
+    fn test_git_log_empty_range_produces_no_output() {
+        let bin_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("debug")
+            .join("rtk");
+        assert!(
+            bin_path.exists(),
+            "Debug binary not found at {:?} — run `cargo build` first",
+            bin_path
+        );
+
+        let tmp = std::env::temp_dir().join("rtk_test_empty_log_range");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+
+        let git = |args: &[&str]| {
+            std::process::Command::new("git")
+                .args(args)
+                .current_dir(&tmp)
+                .output()
+                .expect("git command should run")
+        };
+        git(&["init", "-q"]);
+        git(&["config", "user.email", "test@example.com"]);
+        git(&["config", "user.name", "Test"]);
+        std::fs::write(tmp.join("file.txt"), "content").expect("write file");
+        git(&["add", "."]);
+        git(&["commit", "-q", "-m", "initial commit"]);
+
+        let output = std::process::Command::new(&bin_path)
+            .args(["git", "log", "--oneline", "HEAD..HEAD"])
+            .current_dir(&tmp)
+            .output()
+            .expect("Failed to run rtk");
+
+        assert!(output.status.success());
+        assert!(
+            output.stdout.is_empty(),
+            "Expected empty stdout for an empty commit range, got {:?}",
+            String::from_utf8_lossy(&output.stdout)
         );
 
         let _ = std::fs::remove_dir_all(&tmp);

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -3096,55 +3096,6 @@ no changes added to commit (use "git add" and/or "git commit -a")
         let _ = std::fs::remove_dir_all(&tmp);
     }
 
-    // Regression test for #3365: an empty commit range (e.g. HEAD..HEAD) must
-    // produce empty stdout, not a bare newline, or `| wc -l` reports 1 instead of 0.
-    #[test]
-    #[ignore] // Requires `cargo build` first — run with `cargo test --ignored`
-    fn test_git_log_empty_range_produces_no_output() {
-        let bin_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("target")
-            .join("debug")
-            .join("rtk");
-        assert!(
-            bin_path.exists(),
-            "Debug binary not found at {:?} — run `cargo build` first",
-            bin_path
-        );
-
-        let tmp = std::env::temp_dir().join("rtk_test_empty_log_range");
-        let _ = std::fs::remove_dir_all(&tmp);
-        std::fs::create_dir_all(&tmp).expect("create temp dir");
-
-        let git = |args: &[&str]| {
-            std::process::Command::new("git")
-                .args(args)
-                .current_dir(&tmp)
-                .output()
-                .expect("git command should run")
-        };
-        git(&["init", "-q"]);
-        git(&["config", "user.email", "test@example.com"]);
-        git(&["config", "user.name", "Test"]);
-        std::fs::write(tmp.join("file.txt"), "content").expect("write file");
-        git(&["add", "."]);
-        git(&["commit", "-q", "-m", "initial commit"]);
-
-        let output = std::process::Command::new(&bin_path)
-            .args(["git", "log", "--oneline", "HEAD..HEAD"])
-            .current_dir(&tmp)
-            .output()
-            .expect("Failed to run rtk");
-
-        assert!(output.status.success());
-        assert!(
-            output.stdout.is_empty(),
-            "Expected empty stdout for an empty commit range, got {:?}",
-            String::from_utf8_lossy(&output.stdout)
-        );
-
-        let _ = std::fs::remove_dir_all(&tmp);
-    }
-
     // --- truncation accuracy ---
 
     #[test]

--- a/tests/git_log_empty_range_test.rs
+++ b/tests/git_log_empty_range_test.rs
@@ -1,0 +1,39 @@
+use std::process::Command;
+
+fn init_git_repo() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    for args in [
+        &["init", "-q", "-b", "main"][..],
+        &["config", "user.email", "t@t.t"][..],
+        &["config", "user.name", "t"][..],
+        &["commit", "-q", "--allow-empty", "-m", "init"][..],
+    ] {
+        let ok = Command::new("git")
+            .args(args)
+            .current_dir(dir.path())
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        assert!(ok, "git setup failed: {args:?}");
+    }
+    dir
+}
+
+// #3365: an empty range must print nothing, or `| wc -l` counts 1 instead of 0.
+#[test]
+fn git_log_empty_range_produces_no_output() {
+    let dir = init_git_repo();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args(["git", "log", "--oneline", "HEAD..HEAD"])
+        .current_dir(dir.path())
+        .output()
+        .expect("spawn rtk");
+
+    assert!(output.status.success());
+    assert!(
+        output.stdout.is_empty(),
+        "expected empty stdout for an empty commit range, got {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}


### PR DESCRIPTION
## Summary

- `rtk git log` on an empty commit range (e.g. `HEAD..HEAD`) printed a single blank line instead of producing no output at all, because `println!("{}", filtered)` always emits a trailing newline even when `filtered` is empty.
- This breaks the common `git log <upstream>..HEAD | wc -l` idiom used by coding agents to count unpushed commits: they see "1" instead of "0" and can waste turns re-investigating or re-pushing already-pushed branches.
- Fix: only call `println!` when the filtered output is non-empty, matching the pattern already used elsewhere in this file (e.g. `run_add`) for optional/empty output.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets` (no warnings)
- [x] `cargo test --all --no-fail-fast` — 3781 passed, 1 failed: `copilot_selfheal_test::unwritable_hooks_dir_never_breaks_the_hook`, which relies on a read-only directory and cannot fail as root in a container; it does not go through `git log`. The two timestamp-based `dotnet_trx` tests are flaky under the container's mtime resolution and fail on `develop` as well.
- [x] Regression test in `tests/git_log_empty_range_test.rs`: builds a real temp repo, runs the `rtk` binary cargo builds for the suite (`CARGO_BIN_EXE_rtk`) against `HEAD..HEAD`, and asserts stdout is empty. Runs under a plain `cargo test`. Verified on current `develop`: fails without the fix (`"\n"`), passes with it.

Fixes #3365
