### PR TITLE
fix(rewrite): register xcodebuild commands

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -3265,6 +3265,53 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_classify_xcodebuild() {
+        assert_eq!(
+            classify_command("xcodebuild build -project Foo.xcodeproj"),
+            Classification::Supported {
+                rtk_equivalent: "rtk xcodebuild",
+                category: "Build",
+                estimated_savings_pct: 85.0,
+                status: RtkStatus::Existing,
+            }
+        );
+    }
+
+    #[test]
+    fn test_rewrite_xcodebuild_actions() {
+        for (command, expected) in [
+            (
+                "xcodebuild build -project Foo.xcodeproj",
+                "rtk xcodebuild build -project Foo.xcodeproj",
+            ),
+            (
+                "xcodebuild test -scheme MyApp -destination 'platform=iOS Simulator,name=iPhone 15'",
+                "rtk xcodebuild test -scheme MyApp -destination 'platform=iOS Simulator,name=iPhone 15'",
+            ),
+            (
+                "xcodebuild archive -workspace MyApp.xcworkspace",
+                "rtk xcodebuild archive -workspace MyApp.xcworkspace",
+            ),
+            ("xcodebuild clean", "rtk xcodebuild clean"),
+        ] {
+            assert_eq!(
+                rewrite_command_no_prefixes(command, &[]),
+                Some(expected.into()),
+                "unexpected rewrite for {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_xcodebuild_rule_requires_word_boundary() {
+        assert!(matches!(
+            classify_command("xcodebuilder build"),
+            Classification::Unsupported { .. }
+        ));
+        assert_eq!(rewrite_command_no_prefixes("xcodebuilder build", &[]), None);
+    }
+
     // --- #336: docker compose supported subcommands rewritten, unsupported skipped ---
 
     #[test]

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -882,6 +882,14 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
+        pattern: r"^xcodebuild\b",
+        rtk_cmd: "rtk xcodebuild",
+        rewrite_prefixes: &["xcodebuild"],
+        category: "Build",
+        savings_pct: 85.0,
+        ..RtkRule::DEFAULT
+    },
+    RtkRule {
         pattern: r"^systemctl\s+status\b",
         rtk_cmd: "rtk systemctl",
         rewrite_prefixes: &["systemctl"],


### PR DESCRIPTION
Ensure direct xcodebuild invocations are classified for discovery and consistently routed through the existing TOML filter.

## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

- Fixes https://github.com/rtk-ai/rtk/issues/1551
- Adds `xcodebuild` to the discover registry

## Test plan
<!-- How did you verify this works? -->

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
