### PR TITLE
fix(cargo): don't inject a redundant summary line when 0 crates compiled

### DIFF
--- a/src/cmds/rust/cargo_cmd.rs
+++ b/src/cmds/rust/cargo_cmd.rs
@@ -900,7 +900,11 @@ fn merge_diag_counts(error_count: usize, warnings: usize, json: &JsonDiagnostics
 
 fn cargo_build_success_line(compiled: usize, finished: Option<&str>, label: &str) -> String {
     match finished {
+        // Nothing was recompiled and cargo's own "Finished" line already says so —
+        // adding a "(0 crates compiled)" summary on top is pure noise, not a summary.
+        Some(f) if compiled == 0 => format!("{}\n", f),
         Some(f) => format!("cargo {} ({} crates compiled)\n{}\n", label, compiled, f),
+        None if compiled == 0 => format!("cargo {}: ok (up to date, nothing recompiled)\n", label),
         None => format!("cargo {} ({} crates compiled)\n", label, compiled),
     }
 }
@@ -1562,6 +1566,30 @@ mod tests {
         let result = filter_cargo_build(output);
         assert!(result.contains("cargo build"));
         assert!(result.contains("3 crates compiled"));
+    }
+
+    #[test]
+    fn test_filter_cargo_build_up_to_date_with_finished_line() {
+        // Nothing to recompile: cargo emits only its own "Finished" line. Adding a
+        // "(0 crates compiled)" summary on top would grow the output past the raw
+        // input for zero informational gain (see #759, #1140).
+        let output = "    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.31s\n";
+        let result = filter_cargo_build(output);
+        // The existing capture normalizes cargo's leading indentation; only the
+        // "(0 crates compiled)" summary line is what this fix removes.
+        assert_eq!(
+            result,
+            "Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.31s\n"
+        );
+        assert!(!result.contains("crates compiled"));
+    }
+
+    #[test]
+    fn test_filter_cargo_build_up_to_date_no_finished_line() {
+        // Some cargo invocations succeed with 0 crates compiled and no captured
+        // "Finished" line at all — distinguish this from a silent failure.
+        let result = filter_cargo_build("");
+        assert_eq!(result, "cargo build: ok (up to date, nothing recompiled)\n");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`cargo_build_success_line()` always prepended a `"cargo build (N crates compiled)"` line — even when `N == 0` and cargo's own `Finished` line already said so. On a no-op build (nothing to recompile), this turns a single-line raw output into two lines: a net **token increase**, not a reduction.

Caught live via `scripts/benchmark.sh`:
```
🔴 cargo build   │ cargo build 2>&1 || true │ rtk cargo build 2>&1 │  18 →  25 (-38%)
```

Also covers the sibling case where no `Finished` line is captured at all (still 0 crates compiled) — distinguishing a genuine success from a silent failure.

## Fix

```rust
fn cargo_build_success_line(compiled: usize, finished: Option<&str>, label: &str) -> String {
    match finished {
        Some(f) if compiled == 0 => format!("{}\n", f),
        Some(f) => format!("cargo {} ({} crates compiled)\n{}\n", label, compiled, f),
        None if compiled == 0 => format!("cargo {}: ok (up to date, nothing recompiled)\n", label),
        None => format!("cargo {} ({} crates compiled)\n", label, compiled),
    }
}
```

## Context

- Fixes #759 (cargo output on success is too terse / ambiguous)
- Supersedes #1140, which targeted the same root cause but was closed for mechanical reasons (auto-generated PR branched off `master` instead of `develop`, producing a diverging/conflicting diff) — not rejected on merit. This PR covers both the case #1140 addressed (`finished_line == None`) and the case it left unchanged (`finished_line == Some(..)`, which is the one actually caught by the benchmark).

## Test plan

- [x] 2 new unit tests: `test_filter_cargo_build_up_to_date_with_finished_line`, `test_filter_cargo_build_up_to_date_no_finished_line`
- [x] Existing `test_filter_cargo_build_success` (compiled > 0 path) unaffected
- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test --all` — 2494 passed, 0 failed
- [x] Verified against the real release binary:
  ```
  raw: "    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.06s"
  rtk: "Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.07s"
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>