### PR TITLE
fix(cargo): rewrite toolchain selectors

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -2316,6 +2316,22 @@ mod tests {
     }
 
     #[test]
+    fn test_rewrite_cargo_toolchain_selector() {
+        for (input, expected) in [
+            ("cargo +stable check", "rtk cargo +stable check"),
+            ("cargo +nightly test", "rtk cargo +nightly test"),
+            ("cargo +1.75.0 clippy", "rtk cargo +1.75.0 clippy"),
+            ("cargo +beta build", "rtk cargo +beta build"),
+        ] {
+            assert_eq!(
+                rewrite_command_no_prefixes(input, &[]),
+                Some(expected.into()),
+                "toolchain selector should be preserved for {input}"
+            );
+        }
+    }
+
+    #[test]
     fn test_rewrite_compound_and() {
         assert_eq!(
             rewrite_command_no_prefixes("git add . && cargo test", &[]),

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -69,7 +69,7 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
-        pattern: r"^cargo\s+(build|test|clippy|check|fmt|install)",
+        pattern: r"^cargo\s+(?:\+\S+\s+)?(build|test|clippy|check|fmt|install)",
         rtk_cmd: "rtk cargo",
         rewrite_prefixes: &["cargo"],
         category: "Cargo",


### PR DESCRIPTION
## Summary

- recognize Cargo rustup `+toolchain` selectors before supported subcommands
- preserve selectors while routing through the existing `rtk cargo` filter
- cover stable, nightly, version-pinned, and beta selectors

Closes #3387.

## Validation

- `cargo +1.91.0 fmt --all --check`
- `cargo +1.91.0 clippy --all-targets`
- `cargo +1.91.0 test`
- `cargo +1.91.0 test -- --ignored`
- manual: `target/debug/rtk hook check 'cargo +stable check'`

## AI assistance

Developed with OpenAI Codex assistance; I reviewed and validated the final diff.
