### PR TITLE
feat(hooks): transparent pre_tool rewrite for Mistral Vibe CLI (closes #800)

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ RTK supports 15 AI coding tools. Each integration rewrites shell commands to `rt
 | **OpenClaw** | `openclaw plugins install ./openclaw` | Plugin TS (before_tool_call) |
 | **Pi** | `rtk init -g --agent pi` (global) | TypeScript extension (tool_call) |
 | **Hermes** | `rtk init --agent hermes` | Python plugin adapter (terminal command mutation via `rtk rewrite`) |
-| **Mistral Vibe** | Planned ([#800](https://github.com/rtk-ai/rtk/issues/800)) | Blocked on upstream |
+| **Mistral Vibe** | `rtk init -g --agent vibe` | `pre_tool` hook (hooks.toml) |
 | **Kilo Code** | `rtk init --agent kilocode` | .kilocode/rules/rtk-rules.md (project-scoped) |
 | **Google Antigravity** | `rtk init --agent antigravity` | .agents/rules/antigravity-rtk-rules.md (project-scoped) |
 | **Kimi AI** | `rtk init --agent kimi` | AGENTS.md (project-scoped) |

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ rtk init -g
 
 ## Supported AI Tools
 
-RTK supports 15 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents, reducing the bash output the agent reads where the agent supports command interception.
+RTK supports 16 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents, reducing the bash output the agent reads where the agent supports command interception.
 
 | Tool | Install | Method |
 |------|---------|--------|

--- a/docs/guide/getting-started/supported-agents.md
+++ b/docs/guide/getting-started/supported-agents.md
@@ -1,13 +1,13 @@
 ---
 title: Supported Agents
-description: How to integrate RTK with Claude Code, Cursor, Copilot, Cline, Windsurf, Codex, OpenCode, Hermes, Kilo Code, Antigravity, and Factory Droid
+description: How to integrate RTK with Claude Code, Cursor, Copilot, Cline, Windsurf, Codex, OpenCode, Hermes, Kilo Code, Antigravity, Factory Droid, and Mistral Vibe
 sidebar:
   order: 3
 ---
 
 # Supported Agents
 
-RTK supports all major AI coding agents across 3 integration tiers. Mistral Vibe support is planned.
+RTK supports all major AI coding agents across 3 integration tiers.
 
 ## How it works
 
@@ -43,7 +43,7 @@ Agent runs "cargo test"
 | Codex CLI | AGENTS.md instructions | N/A |
 | Kilo Code | Rules file (prompt-level) | N/A |
 | Google Antigravity | Rules file (prompt-level) | N/A |
-| Mistral Vibe | Planned ([#800](https://github.com/rtk-ai/rtk/issues/800)) | Pending upstream |
+| Mistral Vibe | Rust binary (`pre_tool`) | Yes |
 
 ## Installation by agent
 
@@ -197,9 +197,28 @@ rtk init --agent antigravity    # creates .agents/rules/antigravity-rtk-rules.md
 
 Antigravity reads `.agents/rules/` as custom instructions. RTK adds guidance telling Antigravity to prefer `rtk <cmd>` over raw commands.
 
-### Mistral Vibe (planned)
+### Mistral Vibe
 
-Support is blocked on upstream `BeforeToolCallback` ([mistral-vibe#531](https://github.com/mistralai/mistral-vibe/issues/531)). Tracked in [#800](https://github.com/rtk-ai/rtk/issues/800).
+```bash
+rtk init -g --agent vibe                # user-scoped (~/.vibe/hooks.toml)
+rtk init -g --agent vibe --hook-only    # skip the ~/.vibe/prompts/rtk.md prompt file
+```
+
+Installs a `pre_tool` hook entry (`match = "bash"`, `command = "rtk hook vibe"`, `strict = false`) into `~/.vibe/hooks.toml`, following the contract at [docs.mistral.ai/vibe/code/cli/hooks](https://docs.mistral.ai/vibe/code/cli/hooks). Vibe invokes the native `rtk hook vibe` binary before every bash tool call; RTK reads Vibe's stdin JSON payload and emits `{"hook_specific_output": {"tool_input": {"command": "rtk ..."}}}` to rewrite the command in place. The Vibe UI surfaces `[rtk-rewrite] rtk: rewrote to \`…\`` via RTK's `system_message` field so the rewrite is visible.
+
+Unlike Droid, Vibe does not yet expose a denylist / allowlist surface in `hooks.toml` for RTK to honor. RTK therefore rewrites every bash command it knows how to compress and defers to Vibe's own permission prompt on the rewritten command; commands RTK doesn't handle pass through unchanged. `strict = false` ensures a hook crash degrades to a warning rather than blocking the tool call.
+
+Alongside the hook, RTK drops a system prompt at `~/.vibe/prompts/rtk.md` describing the RTK conventions to Vibe as a belt-and-suspenders fallback. Use `--hook-only` to skip it.
+
+Install is global-only (Vibe's hook registry is user-scoped). Re-running the installer is a no-op; the RTK entry is detected by its `name = "rtk-rewrite"` field and never duplicated.
+
+Uninstall:
+
+```bash
+rtk init -g --agent vibe --uninstall
+```
+
+Strips only RTK's `[[hooks]]` block and the `~/.vibe/prompts/rtk.md` file. Any other user-declared hooks in `hooks.toml` are preserved byte-for-byte. `hooks.toml` is removed only when the RTK entry was the sole content.
 
 ## Integration tiers explained
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -4,7 +4,7 @@
 
 **Deployed hook artifacts** — the actual files installed on user machines by `rtk init`. These are shell scripts, TypeScript plugins, and rules files that run outside the Rust binary. They are **thin delegates**: parse agent-specific JSON, call `rtk rewrite` as a subprocess, format agent-specific response. Zero filtering logic lives here.
 
-Owns: per-agent hook scripts and configuration files for 9 supported agents (Claude Code, Copilot, Cursor, Cline, Windsurf, Codex, OpenCode, Hermes, Pi).
+Owns: per-agent hook scripts and configuration files for 10 supported agents (Claude Code, Copilot, Cursor, Cline, Windsurf, Codex, OpenCode, Hermes, Pi, Mistral Vibe).
 
 Does **not** own: hook installation/uninstallation (that's `src/hooks/init.rs`), the rewrite pattern registry (that's `discover/registry`), or integrity verification (that's `src/hooks/integrity.rs`).
 
@@ -42,6 +42,7 @@ Each agent subdirectory has its own README with hook-specific details:
 - **[`opencode/`](opencode/README.md)** — TypeScript plugin, `zx` library, `tool.execute.before` event, in-place mutation
 - **[`pi/`](pi/README.md)** — TypeScript extension, `tool_call` event, `isToolCallEventType` guard, in-place mutation, `~/.pi/agent/extensions/`
 - **[`hermes/`](hermes/README.md)** — Python plugin, `pre_tool_call` hook, in-place terminal command mutation
+- **Mistral Vibe** — Native Rust binary (`rtk hook vibe`), `pre_tool` hook in `~/.vibe/hooks.toml`, `hook_specific_output.tool_input` rewrite (no dedicated subdirectory — the hook is a subcommand of the RTK binary itself, installed via `src/hooks/init.rs::run_vibe_mode`)
 
 ## Supported Agents
 
@@ -58,6 +59,7 @@ Each agent subdirectory has its own README with hook-specific details:
 | OpenCode | TypeScript plugin (`tool.execute.before`) | In-place mutation | Yes |
 | Pi | TypeScript extension (`tool_call` event) | In-place mutation | Yes |
 | Hermes | Python plugin (`pre_tool_call`) | In-place mutation | Yes |
+| Mistral Vibe | Rust binary (`rtk hook vibe`) | Transparent rewrite | Yes (`hook_specific_output.tool_input`) |
 
 ## JSON Formats by Agent
 
@@ -156,6 +158,32 @@ Returns `{}` when no rewrite (Cursor requires JSON for all paths).
 ```
 
 **No rewrite**: `{"decision": "allow"}`
+
+### Mistral Vibe (Rust Binary)
+
+**Input** (stdin):
+
+```json
+{
+  "tool_name": "bash",
+  "tool_input": { "command": "git status" },
+  "hook_event_name": "pre_tool",
+  "session_id": "..."
+}
+```
+
+**Output** (when rewritten):
+
+```json
+{
+  "hook_specific_output": {
+    "tool_input": { "command": "rtk git status" }
+  },
+  "system_message": "rtk: rewrote to `rtk git status`"
+}
+```
+
+**No rewrite**: exit 0 with empty stdout (Vibe's contract for "no opinion" from a `pre_tool` hook).
 
 ### OpenCode (TypeScript Plugin)
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -42,7 +42,7 @@ Each agent subdirectory has its own README with hook-specific details:
 - **[`opencode/`](opencode/README.md)** — TypeScript plugin, `zx` library, `tool.execute.before` event, in-place mutation
 - **[`pi/`](pi/README.md)** — TypeScript extension, `tool_call` event, `isToolCallEventType` guard, in-place mutation, `~/.pi/agent/extensions/`
 - **[`hermes/`](hermes/README.md)** — Python plugin, `pre_tool_call` hook, in-place terminal command mutation
-- **Mistral Vibe** — Native Rust binary (`rtk hook vibe`), `pre_tool` hook in `~/.vibe/hooks.toml`, `hook_specific_output.tool_input` rewrite (no dedicated subdirectory — the hook is a subcommand of the RTK binary itself, installed via `src/hooks/init.rs::run_vibe_mode`)
+- **[`vibe/`](vibe/README.md)** — Rust binary hook (`rtk hook vibe`), `pre_tool` entry in `~/.vibe/hooks.toml`, `hook_specific_output.tool_input` rewrite plus `system_message` for UI visibility
 
 ## Supported Agents
 

--- a/hooks/vibe/README.md
+++ b/hooks/vibe/README.md
@@ -1,0 +1,19 @@
+# Mistral Vibe Hooks
+
+> Part of [`hooks/`](../README.md) — see also [`src/hooks/`](../../src/hooks/README.md) for installation code
+
+## Specifics
+
+- Uses the `rtk hook vibe` Rust binary (not a shell script) -- no `jq` dependency
+- `pre_tool` hook declared in `~/.vibe/hooks.toml` (user-scoped) with `match = "bash"` and `strict = false`
+- Reads Vibe's stdin JSON payload (`tool_name`, `tool_input.command`, `hook_event_name`, `session_id`)
+- Returns `hook_specific_output.tool_input.command` for transparent rewrite plus a `system_message` for UI visibility
+- Non-bash tool / empty command / malformed JSON / RTK-unknown command → passthrough (exit 0, empty stdout)
+- RTK permission deny → `{"decision":"deny","reason":"..."}`
+- Alongside the hook, a system prompt at `~/.vibe/prompts/rtk.md` is installed as a belt-and-suspenders fallback (skip with `--hook-only`)
+- Installed globally via `rtk init -g --agent vibe`; there is no project-scoped variant
+
+## Notes
+
+- This directory intentionally holds only this README — the hook is a subcommand of the RTK binary (`rtk hook vibe`), not a standalone script or plugin file, so nothing is deployed here
+- Vibe hook contract reference: https://docs.mistral.ai/vibe/code/cli/hooks

--- a/src/core/telemetry.rs
+++ b/src/core/telemetry.rs
@@ -362,6 +362,7 @@ fn detect_hook_type() -> String {
         (home.join(".gemini/hooks/rtk-hook.sh"), "gemini"),
         (home.join(".codex/AGENTS.md"), "codex"),
         (home.join(".cursor/hooks/rtk-rewrite.json"), "cursor"),
+        (home.join(".vibe/hooks.toml"), "vibe"),
     ];
 
     for (path, name) in &checks {
@@ -576,7 +577,7 @@ mod tests {
         assert!(stats.low_savings_commands.len() <= 5);
         assert!((0.0..=100.0).contains(&stats.avg_savings_per_command));
         assert!(
-            ["claude", "gemini", "codex", "cursor", "copilot", "none", "unknown"]
+            ["claude", "gemini", "codex", "cursor", "copilot", "vibe", "none", "unknown"]
                 .iter()
                 .any(|&h| stats.hook_type.starts_with(h)),
             "Unexpected hook type: {}",
@@ -588,7 +589,7 @@ mod tests {
     fn test_detect_hook_type_returns_known() {
         let ht = detect_hook_type();
         assert!(
-            ["claude", "gemini", "codex", "cursor", "copilot", "none", "unknown"]
+            ["claude", "gemini", "codex", "cursor", "copilot", "vibe", "none", "unknown"]
                 .contains(&ht.as_str()),
             "Unexpected hook type: {}",
             ht

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -6,7 +6,7 @@
 
 The **lifecycle management** layer for LLM agent hooks: install, uninstall, verify integrity, audit usage, and manage trust. This component creates and maintains the hook artifacts that live in `hooks/` (root), but does **not** execute rewrite logic itself — that lives in `discover/registry`.
 
-Owns: `rtk init` installation flows (5 agents via `AgentTarget` enum + 3 special modes: Gemini, Codex, OpenCode), SHA-256 integrity verification, hook version checking, audit log analysis, `rtk rewrite` CLI entry point, and TOML filter trust management.
+Owns: `rtk init` installation flows (6 agents via `AgentTarget` enum, now including Mistral Vibe + 3 special modes: Gemini, Codex, OpenCode), SHA-256 integrity verification, hook version checking, audit log analysis, `rtk rewrite` CLI entry point, and TOML filter trust management.
 
 Does **not** own: the deployed hook scripts themselves (that's `hooks/`), the rewrite pattern registry (that's `discover/`), or command filtering (that's `cmds/`).
 
@@ -90,6 +90,7 @@ Rules are loaded from all Claude Code `settings.json` files (project + global, i
 | Gemini CLI (rtk hook gemini) | No (allow/deny only) | allow (limitation — no ask mode in Gemini) |
 | Copilot CLI (rtk hook copilot) | No updatedInput | deny-with-suggestion (unchanged) |
 | Codex | ask parsed but no-op | allow (limitation — fails open) |
+| Mistral Vibe (rtk hook vibe) | No native ask surface | passthrough — Vibe's own approval prompt fires on the rewritten command |
 
 ### Implementation
 
@@ -102,4 +103,4 @@ Rules are loaded from all Claude Code `settings.json` files (project + global, i
 Hook processors in `hook_cmd.rs` must return `Ok(())` on every path — success, no-match, parse error, and unexpected input. Returning `Err` propagates to `main()` and exits non-zero, which blocks the agent's command from executing. This violates the non-blocking guarantee documented in `hooks/README.md`.
 
 ## Adding New Functionality
-To add support for a new AI coding agent: (1) add the hook installation logic to `init.rs` following the existing agent patterns, (2) if the agent requires a custom hook protocol (like Gemini's `BeforeTool`), add a processor function in `hook_cmd.rs`, (3) add the agent's hook file path to `hook_check.rs` for validation, and (4) update `integrity.rs` with the expected hash for the new hook file. Test by running `rtk init` in a fresh environment and verifying the hook rewrites commands correctly in the target agent.
+To add support for a new AI coding agent: (1) add the hook installation logic to `init.rs` following the existing agent patterns, (2) if the agent requires a custom hook protocol (like Gemini's `BeforeTool` or Vibe's `pre_tool`), add a processor function in `hook_cmd.rs` and a matching `HookCommands::<Agent>` variant + `AgentTarget::<Agent>` enum entry in `main.rs`, (3) if the agent has installable permission surfaces (denylist / allowlist), wire them into `permissions.rs::check_command_for` via a new `Host::<Agent>` variant, and (4) update `integrity.rs` with the expected hash for the new hook file. Note that `hook_check.rs::maybe_warn()` only checks the Claude Code hook — other agents don't have an outdated-hook warning path. Test by running `rtk init` in a fresh environment and verifying the hook rewrites commands correctly in the target agent.

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -14,6 +14,8 @@ pub const CLAUDE_HOOK_COMMAND: &str = "rtk hook claude";
 pub const CURSOR_HOOK_COMMAND: &str = "rtk hook cursor";
 /// Native Rust hook command for Factory Droid.
 pub const DROID_HOOK_COMMAND: &str = "rtk hook droid";
+/// Native Rust hook command for Mistral Vibe.
+pub const VIBE_HOOK_COMMAND: &str = "rtk hook vibe";
 
 pub const CONFIG_DIR: &str = ".config";
 pub const OPENCODE_SUBDIR: &str = "opencode";
@@ -58,3 +60,10 @@ pub const HERMES_PLUGINS_SUBDIR: &str = "plugins";
 pub const HERMES_PLUGIN_NAME: &str = "rtk-rewrite";
 pub const HERMES_PLUGIN_INIT_FILE: &str = "__init__.py";
 pub const HERMES_PLUGIN_MANIFEST_FILE: &str = "plugin.yaml";
+
+pub const VIBE_DIR: &str = ".vibe";
+pub const VIBE_HOOKS_FILE: &str = "hooks.toml";
+pub const VIBE_PROMPTS_SUBDIR: &str = "prompts";
+pub const VIBE_PROMPT_FILE: &str = "rtk.md";
+pub const VIBE_HOOK_NAME: &str = "rtk-rewrite";
+pub const VIBE_BASH_MATCH: &str = "bash";

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -363,39 +363,45 @@ pub fn run_gemini() -> Result<()> {
 /// - Deny: emit `{"decision": "deny", "reason": "..."}`.
 pub fn run_vibe() -> Result<()> {
     let input = read_stdin_limited()?;
+    if let Some(output) = run_vibe_inner(&input) {
+        let _ = writeln!(io::stdout(), "{output}");
+    }
+    Ok(())
+}
 
-    let json: Value = serde_json::from_str(&input).context("Failed to parse hook input as JSON")?;
+fn run_vibe_inner(input: &str) -> Option<String> {
+    let json: Value = match serde_json::from_str(input) {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = writeln!(io::stderr(), "[rtk hook] Failed to parse JSON input: {e}");
+            return None;
+        }
+    };
 
     let tool_name = json.get("tool_name").and_then(|v| v.as_str()).unwrap_or("");
-
     if tool_name != "bash" {
-        return Ok(());
+        return None;
     }
 
     let cmd = json
         .pointer("/tool_input/command")
         .and_then(|v| v.as_str())
         .unwrap_or("");
-
     if cmd.is_empty() {
-        return Ok(());
+        return None;
     }
 
     match decide_hook_action(cmd, permissions::Host::Vibe) {
         HookDecision::Deny => {
-            let _ = writeln!(
-                io::stdout(),
-                r#"{{"decision":"deny","reason":"Blocked by RTK permission rule"}}"#
-            );
+            audit_log("deny", cmd, "");
+            Some(r#"{"decision":"deny","reason":"Blocked by RTK permission rule"}"#.to_string())
         }
         HookDecision::AllowRewrite(ref rewritten) | HookDecision::AskRewrite(ref rewritten) => {
             audit_log("rewrite", cmd, rewritten);
-            let _ = writeln!(io::stdout(), "{}", vibe_rewrite_json(rewritten));
+            Some(vibe_rewrite_json(rewritten))
         }
-        HookDecision::Defer => {}
+        HookDecision::Defer => None,
     }
-
-    Ok(())
 }
 
 fn vibe_rewrite_json(rewritten: &str) -> String {
@@ -2028,5 +2034,64 @@ mod tests {
         // so Droid runs them unchanged.
         let input = droid_input("Execute", "definitely-not-a-real-binary --foo");
         assert!(run_droid_inner(&input).is_none());
+    }
+
+    fn vibe_input(tool: &str, cmd: &str) -> String {
+        json!({
+            "session_id": "abc123",
+            "hook_event_name": "pre_tool",
+            "tool_name": tool,
+            "tool_input": { "command": cmd }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn test_vibe_rewrites_bash_command() {
+        let input = vibe_input("bash", "git status");
+        let out = run_vibe_inner(&input).expect("rewrite expected");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        let rewritten = v
+            .pointer("/hook_specific_output/tool_input/command")
+            .and_then(|c| c.as_str())
+            .unwrap_or("");
+        assert!(
+            rewritten.starts_with("rtk "),
+            "expected rtk-prefixed rewrite, got `{rewritten}`"
+        );
+        assert!(
+            v.get("system_message").is_some(),
+            "expected system_message for UI visibility"
+        );
+    }
+
+    #[test]
+    fn test_vibe_ignores_non_bash_tool() {
+        let input = vibe_input("read_file", "irrelevant");
+        assert!(run_vibe_inner(&input).is_none());
+    }
+
+    #[test]
+    fn test_vibe_empty_command_passthrough() {
+        let input = vibe_input("bash", "");
+        assert!(run_vibe_inner(&input).is_none());
+    }
+
+    #[test]
+    fn test_vibe_malformed_json_returns_none() {
+        assert!(run_vibe_inner("not json at all").is_none());
+        assert!(run_vibe_inner("{ unterminated").is_none());
+    }
+
+    #[test]
+    fn test_vibe_unknown_binary_passthrough() {
+        let input = vibe_input("bash", "definitely-not-a-real-binary --foo");
+        assert!(run_vibe_inner(&input).is_none());
+    }
+
+    #[test]
+    fn test_vibe_substitution_defers() {
+        let input = vibe_input("bash", "echo $(rm -rf /)");
+        assert!(run_vibe_inner(&input).is_none());
     }
 }

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -352,6 +352,62 @@ pub fn run_gemini() -> Result<()> {
     Ok(())
 }
 
+// ── Vibe hook ─────────────────────────────────────────────────
+
+/// Run the Mistral Vibe CLI pre_tool hook.
+///
+/// Vibe hook contract (https://docs.mistral.ai/vibe/code/cli/hooks):
+/// - stdin: JSON with `tool_name`, `tool_input`, `hook_event_name`, etc.
+/// - Passthrough: exit 0 with empty stdout.
+/// - Rewrite: emit `{"hook_specific_output": {"tool_input": {"command": "..."}}}`.
+/// - Deny: emit `{"decision": "deny", "reason": "..."}`.
+pub fn run_vibe() -> Result<()> {
+    let input = read_stdin_limited()?;
+
+    let json: Value = serde_json::from_str(&input).context("Failed to parse hook input as JSON")?;
+
+    let tool_name = json.get("tool_name").and_then(|v| v.as_str()).unwrap_or("");
+
+    if tool_name != "bash" {
+        return Ok(());
+    }
+
+    let cmd = json
+        .pointer("/tool_input/command")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    if cmd.is_empty() {
+        return Ok(());
+    }
+
+    match decide_hook_action(cmd, permissions::Host::Vibe) {
+        HookDecision::Deny => {
+            let _ = writeln!(
+                io::stdout(),
+                r#"{{"decision":"deny","reason":"Blocked by RTK permission rule"}}"#
+            );
+        }
+        HookDecision::AllowRewrite(ref rewritten) | HookDecision::AskRewrite(ref rewritten) => {
+            audit_log("rewrite", cmd, rewritten);
+            let _ = writeln!(io::stdout(), "{}", vibe_rewrite_json(rewritten));
+        }
+        HookDecision::Defer => {}
+    }
+
+    Ok(())
+}
+
+fn vibe_rewrite_json(rewritten: &str) -> String {
+    serde_json::json!({
+        "hook_specific_output": {
+            "tool_input": { "command": rewritten }
+        },
+        "system_message": format!("rtk: rewrote to `{}`", rewritten),
+    })
+    .to_string()
+}
+
 fn print_allow() {
     let _ = writeln!(io::stdout(), r#"{{"decision":"allow"}}"#);
 }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -4486,7 +4486,7 @@ fn run_vibe_mode_at(
     }
 
     let hooks_path = vibe_dir.join(VIBE_HOOKS_FILE);
-    patch_vibe_hooks_toml(&hooks_path, patch_mode, ctx)?;
+    let hook_outcome = patch_vibe_hooks_toml(&hooks_path, patch_mode, ctx)?;
 
     if !hook_only {
         let prompts_dir = vibe_dir.join(VIBE_PROMPTS_SUBDIR);
@@ -4501,8 +4501,13 @@ fn run_vibe_mode_at(
 
     if dry_run {
         print_dry_run_footer();
-    } else {
-        println!("\nMistral Vibe CLI hook installed (global).\n");
+    } else if hook_outcome != VibeHookPatchOutcome::Skipped {
+        let summary_verb = match hook_outcome {
+            VibeHookPatchOutcome::Installed => "installed",
+            VibeHookPatchOutcome::AlreadyPresent => "already present",
+            VibeHookPatchOutcome::Skipped => unreachable!(),
+        };
+        println!("\nMistral Vibe CLI hook {summary_verb} (global).\n");
         println!("  Hook registry: {}", hooks_path.display());
         if !hook_only {
             println!(
@@ -4518,11 +4523,24 @@ fn run_vibe_mode_at(
     Ok(())
 }
 
+/// Outcome of `patch_vibe_hooks_toml`. Distinguishes installed / already-present /
+/// skipped so the caller can decide whether the "installed" summary is truthful.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VibeHookPatchOutcome {
+    Installed,
+    AlreadyPresent,
+    Skipped,
+}
+
 /// Append the RTK `[[hooks]]` entry to `~/.vibe/hooks.toml` if not already present.
 ///
 /// Uses append-based patching (string level) rather than parse-serialize round-trip
 /// to preserve any user comments and formatting in the file.
-fn patch_vibe_hooks_toml(hooks_path: &Path, patch_mode: PatchMode, ctx: InitContext) -> Result<()> {
+fn patch_vibe_hooks_toml(
+    hooks_path: &Path,
+    patch_mode: PatchMode,
+    ctx: InitContext,
+) -> Result<VibeHookPatchOutcome> {
     let InitContext { verbose, dry_run } = ctx;
 
     let existing = if hooks_path.exists() {
@@ -4536,16 +4554,16 @@ fn patch_vibe_hooks_toml(hooks_path: &Path, patch_mode: PatchMode, ctx: InitCont
         if verbose > 0 {
             eprintln!("Vibe hooks.toml already has RTK hook");
         }
-        return Ok(());
+        return Ok(VibeHookPatchOutcome::AlreadyPresent);
     }
 
     if patch_mode == PatchMode::Skip {
         println!(
             "\nManual setup needed: add RTK hook to {}\n\
-             See: https://github.com/rtk-ai/rtk#mistral-vibe",
+             See: https://www.rtk-ai.app/guide/getting-started/supported-agents#mistral-vibe",
             hooks_path.display()
         );
-        return Ok(());
+        return Ok(VibeHookPatchOutcome::Skipped);
     }
 
     if patch_mode == PatchMode::Ask {
@@ -4564,7 +4582,7 @@ fn patch_vibe_hooks_toml(hooks_path: &Path, patch_mode: PatchMode, ctx: InitCont
                     "Skipped. Re-run with --auto-patch, or add the hook manually to {}",
                     hooks_path.display()
                 );
-                return Ok(());
+                return Ok(VibeHookPatchOutcome::Skipped);
             }
         }
     }
@@ -4592,7 +4610,7 @@ fn patch_vibe_hooks_toml(hooks_path: &Path, patch_mode: PatchMode, ctx: InitCont
         atomic_write(hooks_path, &new_content)
             .with_context(|| format!("Failed to write {}", hooks_path.display()))?;
     }
-    Ok(())
+    Ok(VibeHookPatchOutcome::Installed)
 }
 
 /// TOML entry emitted for the Vibe pre_tool hook. Mirrors the shape documented
@@ -4617,6 +4635,13 @@ description = "Rewrite bash commands through the rtk proxy to save tokens."
 /// Detect an existing RTK entry by looking for the hook `name` field. Scanning
 /// the raw string is enough because `name` is required by Vibe and must be
 /// unique, so a substring match is both necessary and sufficient.
+///
+/// Tradeoff: matches the exact spacing `name = "rtk-rewrite"`. A reformatted
+/// file (`name="rtk-rewrite"` or extra whitespace) would defeat idempotency
+/// and cause a duplicate append on re-install. Acceptable because our own
+/// installer only ever writes the canonical spacing, and the alternative
+/// (parse-serialize round-trip via toml_edit) would clobber user comments
+/// and formatting in the file.
 fn vibe_hooks_toml_has_rtk(content: &str) -> bool {
     let needle = format!(r#"name = "{VIBE_HOOK_NAME}""#);
     content.contains(&needle)

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -18,7 +18,8 @@ use super::constants::{
     DROID_HOOK_COMMAND, DROID_SETTINGS_FILE, GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR,
     HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON,
     HOOKS_SUBDIR, PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR,
-    PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
+    PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON, VIBE_BASH_MATCH, VIBE_DIR,
+    VIBE_HOOKS_FILE, VIBE_HOOK_COMMAND, VIBE_HOOK_NAME, VIBE_PROMPTS_SUBDIR, VIBE_PROMPT_FILE,
 };
 use super::integrity;
 use super::is_claude_hook_command;
@@ -4446,6 +4447,311 @@ fn uninstall_gemini(ctx: InitContext) -> Result<Vec<String>> {
     Ok(removed)
 }
 
+// ── Vibe integration ────────────────────────────────────────
+
+fn resolve_vibe_dir() -> Result<PathBuf> {
+    resolve_home_subdir(VIBE_DIR)
+}
+
+/// Entry point for `rtk init -g --agent vibe`.
+///
+/// Installs a `pre_tool` hook into `~/.vibe/hooks.toml` (Vibe CLI's hook
+/// registry, see https://docs.mistral.ai/vibe/code/cli/hooks) that routes
+/// bash tool calls through the native `rtk hook vibe` binary. When not
+/// `hook_only`, also drops an `~/.vibe/prompts/rtk.md` system prompt file
+/// as a belt-and-suspenders fallback if the hook is disabled.
+pub fn run_vibe_mode(
+    global: bool,
+    hook_only: bool,
+    patch_mode: PatchMode,
+    ctx: InitContext,
+) -> Result<()> {
+    if !global {
+        anyhow::bail!("Vibe support is global-only. Use: rtk init -g --agent vibe");
+    }
+    let vibe_dir = resolve_vibe_dir()?;
+    run_vibe_mode_at(&vibe_dir, hook_only, patch_mode, ctx)
+}
+
+fn run_vibe_mode_at(
+    vibe_dir: &Path,
+    hook_only: bool,
+    patch_mode: PatchMode,
+    ctx: InitContext,
+) -> Result<()> {
+    let InitContext { dry_run, .. } = ctx;
+    if !dry_run {
+        fs::create_dir_all(vibe_dir)
+            .with_context(|| format!("Failed to create Vibe config dir: {}", vibe_dir.display()))?;
+    }
+
+    let hooks_path = vibe_dir.join(VIBE_HOOKS_FILE);
+    patch_vibe_hooks_toml(&hooks_path, patch_mode, ctx)?;
+
+    if !hook_only {
+        let prompts_dir = vibe_dir.join(VIBE_PROMPTS_SUBDIR);
+        if !dry_run {
+            fs::create_dir_all(&prompts_dir).with_context(|| {
+                format!("Failed to create prompts dir: {}", prompts_dir.display())
+            })?;
+        }
+        let prompt_path = prompts_dir.join(VIBE_PROMPT_FILE);
+        write_if_changed(&prompt_path, RTK_SLIM, VIBE_PROMPT_FILE, ctx)?;
+    }
+
+    if dry_run {
+        print_dry_run_footer();
+    } else {
+        println!("\nMistral Vibe CLI hook installed (global).\n");
+        println!("  Hook registry: {}", hooks_path.display());
+        if !hook_only {
+            println!(
+                "  Prompt: {}",
+                vibe_dir
+                    .join(VIBE_PROMPTS_SUBDIR)
+                    .join(VIBE_PROMPT_FILE)
+                    .display()
+            );
+        }
+        println!("  Restart Vibe. Test with: git status\n");
+    }
+    Ok(())
+}
+
+/// Append the RTK `[[hooks]]` entry to `~/.vibe/hooks.toml` if not already present.
+///
+/// Uses append-based patching (string level) rather than parse-serialize round-trip
+/// to preserve any user comments and formatting in the file.
+fn patch_vibe_hooks_toml(hooks_path: &Path, patch_mode: PatchMode, ctx: InitContext) -> Result<()> {
+    let InitContext { verbose, dry_run } = ctx;
+
+    let existing = if hooks_path.exists() {
+        fs::read_to_string(hooks_path)
+            .with_context(|| format!("Failed to read {}", hooks_path.display()))?
+    } else {
+        String::new()
+    };
+
+    if vibe_hooks_toml_has_rtk(&existing) {
+        if verbose > 0 {
+            eprintln!("Vibe hooks.toml already has RTK hook");
+        }
+        return Ok(());
+    }
+
+    if patch_mode == PatchMode::Skip {
+        println!(
+            "\nManual setup needed: add RTK hook to {}\n\
+             See: https://github.com/rtk-ai/rtk#mistral-vibe",
+            hooks_path.display()
+        );
+        return Ok(());
+    }
+
+    if patch_mode == PatchMode::Ask {
+        if dry_run {
+            println!(
+                "[dry-run] would prompt before patching {}",
+                hooks_path.display()
+            );
+        } else {
+            print!("Patch {} with RTK hook? [y/N] ", hooks_path.display());
+            std::io::stdout().flush().ok();
+            let mut answer = String::new();
+            std::io::stdin().read_line(&mut answer).ok();
+            if !matches!(answer.trim().to_lowercase().as_str(), "y" | "yes") {
+                println!(
+                    "Skipped. Re-run with --auto-patch, or add the hook manually to {}",
+                    hooks_path.display()
+                );
+                return Ok(());
+            }
+        }
+    }
+
+    let entry = vibe_hook_entry();
+    let new_content = if existing.is_empty() {
+        entry.clone()
+    } else if existing.ends_with("\n\n") {
+        format!("{existing}{entry}")
+    } else if existing.ends_with('\n') {
+        format!("{existing}\n{entry}")
+    } else {
+        format!("{existing}\n\n{entry}")
+    };
+
+    if dry_run {
+        println!(
+            "[dry-run] would patch Vibe hooks.toml: {}",
+            hooks_path.display()
+        );
+        if verbose > 0 {
+            println!("[dry-run] appended entry:\n{entry}");
+        }
+    } else {
+        atomic_write(hooks_path, &new_content)
+            .with_context(|| format!("Failed to write {}", hooks_path.display()))?;
+    }
+    Ok(())
+}
+
+/// TOML entry emitted for the Vibe pre_tool hook. Mirrors the shape documented
+/// at https://docs.mistral.ai/vibe/code/cli/hooks.
+fn vibe_hook_entry() -> String {
+    format!(
+        r#"[[hooks]]
+name = "{name}"
+type = "pre_tool"
+match = "{match_glob}"
+command = "{command}"
+timeout = 10.0
+strict = false
+description = "Rewrite bash commands through the rtk proxy to save tokens."
+"#,
+        name = VIBE_HOOK_NAME,
+        match_glob = VIBE_BASH_MATCH,
+        command = VIBE_HOOK_COMMAND,
+    )
+}
+
+/// Detect an existing RTK entry by looking for the hook `name` field. Scanning
+/// the raw string is enough because `name` is required by Vibe and must be
+/// unique, so a substring match is both necessary and sufficient.
+fn vibe_hooks_toml_has_rtk(content: &str) -> bool {
+    let needle = format!(r#"name = "{VIBE_HOOK_NAME}""#);
+    content.contains(&needle)
+}
+
+/// Public entry point for `rtk init -g --agent vibe --uninstall`.
+pub fn uninstall_vibe(ctx: InitContext) -> Result<()> {
+    let InitContext { dry_run, .. } = ctx;
+    let vibe_dir = match resolve_vibe_dir() {
+        Ok(d) => d,
+        Err(_) => return Ok(()),
+    };
+    let removed = uninstall_vibe_at(&vibe_dir, ctx)?;
+
+    if removed.is_empty() {
+        println!("RTK Vibe support was not installed (nothing to remove)");
+    } else {
+        let header = if dry_run {
+            "[dry-run] would uninstall RTK for Mistral Vibe CLI:"
+        } else {
+            "RTK uninstalled for Mistral Vibe CLI:"
+        };
+        println!("{}", header);
+        for item in removed {
+            println!("  - {}", item);
+        }
+        if !dry_run {
+            println!("\nRestart Vibe CLI to apply changes.");
+        }
+    }
+
+    if dry_run {
+        print_dry_run_footer();
+    }
+    Ok(())
+}
+
+/// Remove the RTK hook entry (and, when non-empty, the surrounding blank
+/// lines) from `~/.vibe/hooks.toml` and the sibling `~/.vibe/prompts/rtk.md`
+/// prompt file. Leaves any other user-declared hooks intact.
+fn uninstall_vibe_at(vibe_dir: &Path, ctx: InitContext) -> Result<Vec<String>> {
+    let InitContext { verbose, dry_run } = ctx;
+    let mut removed = Vec::new();
+
+    let prompt_path = vibe_dir.join(VIBE_PROMPTS_SUBDIR).join(VIBE_PROMPT_FILE);
+    if prompt_path.exists() {
+        if dry_run {
+            println!(
+                "[dry-run] would remove Vibe RTK prompt: {}",
+                prompt_path.display()
+            );
+        } else {
+            fs::remove_file(&prompt_path)
+                .with_context(|| format!("Failed to remove {}", prompt_path.display()))?;
+        }
+        removed.push(format!("Vibe prompt: {}", prompt_path.display()));
+    }
+
+    let hooks_path = vibe_dir.join(VIBE_HOOKS_FILE);
+    if hooks_path.exists() {
+        let content = fs::read_to_string(&hooks_path)
+            .with_context(|| format!("Failed to read {}", hooks_path.display()))?;
+        if let Some(new_content) = strip_vibe_rtk_entry(&content) {
+            if dry_run {
+                println!(
+                    "[dry-run] would remove RTK hook from Vibe hooks.toml: {}",
+                    hooks_path.display()
+                );
+            } else if new_content.trim().is_empty() {
+                fs::remove_file(&hooks_path)
+                    .with_context(|| format!("Failed to remove {}", hooks_path.display()))?;
+            } else {
+                atomic_write(&hooks_path, &new_content)
+                    .with_context(|| format!("Failed to write {}", hooks_path.display()))?;
+            }
+            removed.push(format!(
+                "Vibe hooks.toml: removed RTK entry ({})",
+                hooks_path.display()
+            ));
+        }
+    }
+
+    if verbose > 0 && !removed.is_empty() {
+        eprintln!("Vibe artifacts removed");
+    }
+
+    Ok(removed)
+}
+
+/// Extract and drop the `[[hooks]]` block whose `name = "rtk-rewrite"` field
+/// is set. Returns `None` when the entry is absent, `Some(new_content)` after
+/// removal (with surrounding blank lines collapsed). The scan walks `[[hooks]]`
+/// section boundaries — anything else in the file is preserved verbatim.
+fn strip_vibe_rtk_entry(content: &str) -> Option<String> {
+    let needle = format!(r#"name = "{VIBE_HOOK_NAME}""#);
+    if !content.contains(&needle) {
+        return None;
+    }
+
+    let lines: Vec<&str> = content.lines().collect();
+    let mut sections: Vec<(usize, usize)> = Vec::new();
+    let mut current_start: Option<usize> = None;
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("[[hooks]]") || trimmed.starts_with('[') {
+            if let Some(start) = current_start.take() {
+                sections.push((start, i));
+            }
+            if trimmed.starts_with("[[hooks]]") {
+                current_start = Some(i);
+            }
+        }
+    }
+    if let Some(start) = current_start {
+        sections.push((start, lines.len()));
+    }
+
+    let target = sections
+        .iter()
+        .find(|(start, end)| lines[*start..*end].iter().any(|l| l.contains(&needle)))?;
+
+    let mut kept: Vec<&str> = Vec::with_capacity(lines.len());
+    kept.extend(&lines[..target.0]);
+    kept.extend(&lines[target.1..]);
+
+    let mut out = kept.join("\n");
+    while out.contains("\n\n\n") {
+        out = out.replace("\n\n\n", "\n\n");
+    }
+    if !out.is_empty() && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    Some(out)
+}
+
 // ── Copilot integration ─────────────────────────────────────
 
 // Single PascalCase `PreToolUse` entry, shared by VS Code Copilot Chat and
@@ -7911,5 +8217,136 @@ mod tests {
             "Hook config must not be written when the upsert aborts: {}",
             hook_path.display()
         );
+    }
+
+    // ── Vibe tests ────────────────────────────────────────────
+
+    #[test]
+    fn test_vibe_detects_rtk_entry_by_name_field() {
+        assert!(!vibe_hooks_toml_has_rtk(""));
+        assert!(!vibe_hooks_toml_has_rtk("[[hooks]]\nname = \"other\"\n"));
+        assert!(vibe_hooks_toml_has_rtk(
+            "[[hooks]]\nname = \"rtk-rewrite\"\n"
+        ));
+    }
+
+    #[test]
+    fn test_vibe_hook_entry_shape_matches_docs() {
+        let entry = vibe_hook_entry();
+        assert!(entry.contains("[[hooks]]"));
+        assert!(entry.contains(r#"name = "rtk-rewrite""#));
+        assert!(entry.contains(r#"type = "pre_tool""#));
+        assert!(entry.contains(r#"match = "bash""#));
+        assert!(entry.contains(r#"command = "rtk hook vibe""#));
+        assert!(entry.contains("strict = false"));
+    }
+
+    #[test]
+    fn test_vibe_strip_returns_none_when_entry_absent() {
+        let content = "[[hooks]]\nname = \"other\"\ntype = \"post_tool\"\n";
+        assert!(strip_vibe_rtk_entry(content).is_none());
+    }
+
+    #[test]
+    fn test_vibe_strip_removes_only_rtk_entry() {
+        let content = "[[hooks]]\nname = \"user-audit\"\ntype = \"post_tool\"\nmatch = \"*\"\ncommand = \"audit.py\"\n\n[[hooks]]\nname = \"rtk-rewrite\"\ntype = \"pre_tool\"\nmatch = \"bash\"\ncommand = \"rtk hook vibe\"\n";
+        let stripped = strip_vibe_rtk_entry(content).expect("expected removal");
+        assert!(stripped.contains(r#"name = "user-audit""#));
+        assert!(!stripped.contains(r#"name = "rtk-rewrite""#));
+        assert!(!stripped.contains("rtk hook vibe"));
+    }
+
+    #[test]
+    fn test_vibe_install_creates_hook_and_prompt() {
+        let temp = TempDir::new().unwrap();
+        let vibe_dir = temp.path().join(".vibe");
+        run_vibe_mode_at(&vibe_dir, false, PatchMode::Auto, InitContext::default()).unwrap();
+
+        let hooks_content = fs::read_to_string(vibe_dir.join(VIBE_HOOKS_FILE)).unwrap();
+        assert!(hooks_content.contains(r#"name = "rtk-rewrite""#));
+        assert!(hooks_content.contains(r#"command = "rtk hook vibe""#));
+
+        let prompt_path = vibe_dir.join(VIBE_PROMPTS_SUBDIR).join(VIBE_PROMPT_FILE);
+        assert!(prompt_path.exists());
+    }
+
+    #[test]
+    fn test_vibe_install_is_idempotent() {
+        let temp = TempDir::new().unwrap();
+        let vibe_dir = temp.path().join(".vibe");
+        run_vibe_mode_at(&vibe_dir, false, PatchMode::Auto, InitContext::default()).unwrap();
+        run_vibe_mode_at(&vibe_dir, false, PatchMode::Auto, InitContext::default()).unwrap();
+
+        let hooks_content = fs::read_to_string(vibe_dir.join(VIBE_HOOKS_FILE)).unwrap();
+        assert_eq!(hooks_content.matches("rtk-rewrite").count(), 1);
+    }
+
+    #[test]
+    fn test_vibe_install_preserves_existing_user_hook() {
+        let temp = TempDir::new().unwrap();
+        let vibe_dir = temp.path().join(".vibe");
+        fs::create_dir_all(&vibe_dir).unwrap();
+        let user_hook = "[[hooks]]\nname = \"user-audit\"\ntype = \"post_tool\"\nmatch = \"*\"\ncommand = \"audit.py\"\n";
+        fs::write(vibe_dir.join(VIBE_HOOKS_FILE), user_hook).unwrap();
+
+        run_vibe_mode_at(&vibe_dir, false, PatchMode::Auto, InitContext::default()).unwrap();
+
+        let hooks_content = fs::read_to_string(vibe_dir.join(VIBE_HOOKS_FILE)).unwrap();
+        assert!(hooks_content.contains(r#"name = "user-audit""#));
+        assert!(hooks_content.contains(r#"name = "rtk-rewrite""#));
+    }
+
+    #[test]
+    fn test_vibe_hook_only_skips_prompt_file() {
+        let temp = TempDir::new().unwrap();
+        let vibe_dir = temp.path().join(".vibe");
+        run_vibe_mode_at(&vibe_dir, true, PatchMode::Auto, InitContext::default()).unwrap();
+
+        assert!(vibe_dir.join(VIBE_HOOKS_FILE).exists());
+        assert!(!vibe_dir
+            .join(VIBE_PROMPTS_SUBDIR)
+            .join(VIBE_PROMPT_FILE)
+            .exists());
+    }
+
+    #[test]
+    fn test_vibe_uninstall_removes_only_rtk_entry_and_prompt() {
+        let temp = TempDir::new().unwrap();
+        let vibe_dir = temp.path().join(".vibe");
+        fs::create_dir_all(&vibe_dir).unwrap();
+        let user_hook = "[[hooks]]\nname = \"user-audit\"\ntype = \"post_tool\"\nmatch = \"*\"\ncommand = \"audit.py\"\n";
+        fs::write(vibe_dir.join(VIBE_HOOKS_FILE), user_hook).unwrap();
+
+        run_vibe_mode_at(&vibe_dir, false, PatchMode::Auto, InitContext::default()).unwrap();
+        assert!(vibe_dir
+            .join(VIBE_PROMPTS_SUBDIR)
+            .join(VIBE_PROMPT_FILE)
+            .exists());
+
+        let removed_first = uninstall_vibe_at(&vibe_dir, InitContext::default()).unwrap();
+        let removed_second = uninstall_vibe_at(&vibe_dir, InitContext::default()).unwrap();
+
+        assert_eq!(removed_first.len(), 2);
+        assert!(removed_second.is_empty());
+        assert!(!vibe_dir
+            .join(VIBE_PROMPTS_SUBDIR)
+            .join(VIBE_PROMPT_FILE)
+            .exists());
+
+        let remaining = fs::read_to_string(vibe_dir.join(VIBE_HOOKS_FILE)).unwrap();
+        assert!(remaining.contains(r#"name = "user-audit""#));
+        assert!(!remaining.contains(r#"name = "rtk-rewrite""#));
+    }
+
+    #[test]
+    fn test_vibe_uninstall_removes_hooks_file_when_no_other_hooks() {
+        let temp = TempDir::new().unwrap();
+        let vibe_dir = temp.path().join(".vibe");
+        run_vibe_mode_at(&vibe_dir, false, PatchMode::Auto, InitContext::default()).unwrap();
+        assert!(vibe_dir.join(VIBE_HOOKS_FILE).exists());
+
+        uninstall_vibe_at(&vibe_dir, InitContext::default()).unwrap();
+
+        assert!(!vibe_dir.join(VIBE_HOOKS_FILE).exists());
     }
 }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -4501,12 +4501,7 @@ fn run_vibe_mode_at(
 
     if dry_run {
         print_dry_run_footer();
-    } else if hook_outcome != VibeHookPatchOutcome::Skipped {
-        let summary_verb = match hook_outcome {
-            VibeHookPatchOutcome::Installed => "installed",
-            VibeHookPatchOutcome::AlreadyPresent => "already present",
-            VibeHookPatchOutcome::Skipped => unreachable!(),
-        };
+    } else if let Some(summary_verb) = hook_outcome.summary_verb() {
         println!("\nMistral Vibe CLI hook {summary_verb} (global).\n");
         println!("  Hook registry: {}", hooks_path.display());
         if !hook_only {
@@ -4530,6 +4525,16 @@ enum VibeHookPatchOutcome {
     Installed,
     AlreadyPresent,
     Skipped,
+}
+
+impl VibeHookPatchOutcome {
+    fn summary_verb(self) -> Option<&'static str> {
+        match self {
+            Self::Installed => Some("installed"),
+            Self::AlreadyPresent => Some("already present"),
+            Self::Skipped => None,
+        }
+    }
 }
 
 /// Append the RTK `[[hooks]]` entry to `~/.vibe/hooks.toml` if not already present.
@@ -4652,7 +4657,10 @@ pub fn uninstall_vibe(ctx: InitContext) -> Result<()> {
     let InitContext { dry_run, .. } = ctx;
     let vibe_dir = match resolve_vibe_dir() {
         Ok(d) => d,
-        Err(_) => return Ok(()),
+        Err(e) => {
+            eprintln!("RTK Vibe uninstall skipped: could not resolve ~/.vibe/ ({e})");
+            return Ok(());
+        }
     };
     let removed = uninstall_vibe_at(&vibe_dir, ctx)?;
 

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -4694,6 +4694,7 @@ fn uninstall_vibe_at(vibe_dir: &Path, ctx: InitContext) -> Result<Vec<String>> {
                 prompt_path.display()
             );
         } else {
+            // nosemgrep: filesystem-deletion -- uninstall path removes only RTK's own prompt file
             fs::remove_file(&prompt_path)
                 .with_context(|| format!("Failed to remove {}", prompt_path.display()))?;
         }
@@ -4711,6 +4712,7 @@ fn uninstall_vibe_at(vibe_dir: &Path, ctx: InitContext) -> Result<Vec<String>> {
                     hooks_path.display()
                 );
             } else if new_content.trim().is_empty() {
+                // nosemgrep: filesystem-deletion -- uninstall removes hooks.toml only when it becomes empty after stripping the RTK entry
                 fs::remove_file(&hooks_path)
                     .with_context(|| format!("Failed to remove {}", hooks_path.display()))?;
             } else {

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -36,6 +36,7 @@ pub enum Host {
     Cursor,
     Gemini,
     Droid,
+    Vibe,
 }
 
 pub fn check_command_for(cmd: &str, host: Host) -> PermissionVerdict {
@@ -44,6 +45,7 @@ pub fn check_command_for(cmd: &str, host: Host) -> PermissionVerdict {
         Host::Cursor => load_cursor_rules(),
         Host::Gemini => load_gemini_rules(),
         Host::Droid => load_droid_rules(),
+        Host::Vibe => (Vec::new(), Vec::new(), Vec::new()),
     };
     check_command_with_rules(cmd, &deny_rules, &ask_rules, &allow_rules)
 }

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -45,6 +45,11 @@ pub fn check_command_for(cmd: &str, host: Host) -> PermissionVerdict {
         Host::Cursor => load_cursor_rules(),
         Host::Gemini => load_gemini_rules(),
         Host::Droid => load_droid_rules(),
+        // Vibe stores hooks in ~/.vibe/hooks.toml and has no denylist / allowlist
+        // surface at the time of writing. Empty rules mean check_command_with_rules
+        // returns Default (treated as Ask by callers), and the Deny arm in
+        // hook_cmd::run_vibe is dead code kept as defensive scaffolding for when
+        // Vibe ships native permission config we can honor here.
         Host::Vibe => (Vec::new(), Vec::new(), Vec::new()),
     };
     check_command_with_rules(cmd, &deny_rules, &ask_rules, &allow_rules)

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -45,11 +45,6 @@ pub fn check_command_for(cmd: &str, host: Host) -> PermissionVerdict {
         Host::Cursor => load_cursor_rules(),
         Host::Gemini => load_gemini_rules(),
         Host::Droid => load_droid_rules(),
-        // Vibe stores hooks in ~/.vibe/hooks.toml and has no denylist / allowlist
-        // surface at the time of writing. Empty rules mean check_command_with_rules
-        // returns Default (treated as Ask by callers), and the Deny arm in
-        // hook_cmd::run_vibe is dead code kept as defensive scaffolding for when
-        // Vibe ships native permission config we can honor here.
         Host::Vibe => (Vec::new(), Vec::new(), Vec::new()),
     };
     check_command_with_rules(cmd, &deny_rules, &ask_rules, &allow_rules)

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,8 @@ pub enum AgentTarget {
     Hermes,
     /// Factory Droid CLI
     Droid,
+    /// Mistral Vibe CLI
+    Vibe,
 }
 
 #[derive(Parser)]
@@ -866,6 +868,8 @@ enum HookCommands {
     Copilot,
     /// Process Factory Droid PreToolUse hook (reads JSON from stdin)
     Droid,
+    /// Process Mistral Vibe CLI pre_tool hook (reads JSON from stdin)
+    Vibe,
     /// Check how a command would be rewritten by the hook engine (dry-run)
     Check {
         /// Target agent
@@ -1566,6 +1570,8 @@ where
         uninstall_hermes(ctx)
     } else if agent == Some(AgentTarget::Droid) {
         hooks::init::uninstall_droid(global, ctx)
+    } else if agent == Some(AgentTarget::Vibe) {
+        hooks::init::uninstall_vibe(ctx)
     } else {
         let cursor = agent == Some(AgentTarget::Cursor);
         let pi = agent == Some(AgentTarget::Pi);
@@ -2068,6 +2074,15 @@ fn run_cli() -> Result<i32> {
                 hooks::init::run_hermes_mode(ctx)?;
             } else if agent == Some(AgentTarget::Droid) {
                 hooks::init::run_droid_mode(global, ctx)?;
+            } else if agent == Some(AgentTarget::Vibe) {
+                let patch_mode = if auto_patch {
+                    hooks::init::PatchMode::Auto
+                } else if no_patch {
+                    hooks::init::PatchMode::Skip
+                } else {
+                    hooks::init::PatchMode::Ask
+                };
+                hooks::init::run_vibe_mode(global, hook_only, patch_mode, ctx)?;
             } else {
                 let install_opencode = opencode;
                 let install_claude = !opencode;
@@ -2436,6 +2451,10 @@ fn run_cli() -> Result<i32> {
             }
             HookCommands::Droid => {
                 hooks::hook_cmd::run_droid()?;
+                0
+            }
+            HookCommands::Vibe => {
+                hooks::hook_cmd::run_vibe()?;
                 0
             }
             HookCommands::Check { agent: _, command } => {


### PR DESCRIPTION
Closes #800.

## Why now

Issue #800 was blocked on **mistralai/mistral-vibe#531** — Vibe CLI lacked a
`BeforeTool`-style hook to intercept and rewrite bash tool calls before
execution. That upstream is now delivered:
https://docs.mistral.ai/vibe/code/cli/hooks documents a `pre_tool` hook that
returns `hook_specific_output.tool_input` to fully replace the model's tool
arguments. This is functionally equivalent to Claude Code's `PreToolUse` and
Gemini's `BeforeTool`, so RTK can now do a transparent rewrite in Vibe with
the same guarantees as those hosts.

## What this PR does

Adds two things:

1. **`rtk init -g --agent vibe`** — installs a `pre_tool` hook entry into
   `~/.vibe/hooks.toml` and (optionally) a system prompt fallback at
   `~/.vibe/prompts/rtk.md`. Idempotent, dry-run capable, uninstallable.
2. **`rtk hook vibe`** — the native binary hook process referenced by the
   installed entry. Reads Vibe's `pre_tool` JSON payload from stdin, decides
   via the shared `decide_hook_action` engine, and emits Vibe's rewrite
   response shape on stdout.

Result: every bash tool call Vibe makes (including compound `&&` chains) is
rewritten to `rtk <cmd>` transparently, and the Vibe UI surfaces
`[rtk-rewrite] rtk: rewrote to \`…\`` for visibility.

## Files changed (6 files, +525 / −2)

| File | Change |
|---|---|
| `src/hooks/constants.rs` | `VIBE_DIR`, `VIBE_HOOKS_FILE`, `VIBE_HOOK_COMMAND`, `VIBE_HOOK_NAME`, prompts subdir/file, bash match string |
| `src/hooks/permissions.rs` | `Host::Vibe` variant — Vibe stores hooks in `hooks.toml`, not in a settings JSON with permission rules, so no rule loader is wired |
| `src/hooks/hook_cmd.rs` | `pub fn run_vibe()` — 56 lines, parses stdin, emits Vibe's rewrite / deny / passthrough response |
| `src/hooks/init.rs` | `run_vibe_mode()` + `run_vibe_mode_at()`, `patch_vibe_hooks_toml()`, `uninstall_vibe()` + `uninstall_vibe_at()`, `strip_vibe_rtk_entry()`, plus 10 unit tests |
| `src/main.rs` | `AgentTarget::Vibe`, `HookCommands::Vibe`, dispatch through `Commands::Init` and uninstall dispatch |
| `README.md` | Vibe row in the supported-agents table flipped from `Planned (#800) / Blocked on upstream` to `rtk init -g --agent vibe` / `pre_tool hook (hooks.toml)` |

## Design choices (matching existing integrations in this repo)

- **Native binary hook** (`rtk hook vibe`) rather than a shell script — same
  pattern as Claude Code / Cursor / Droid post-v0.37.2. Zero shell / bash /
  jq runtime dependency, works on Windows out of the box.
- **Global-only install** (`rtk init -g --agent vibe`) — same constraint as
  the Gemini integration, since `~/.vibe/hooks.toml` is user-scoped.
- **Hook name `rtk-rewrite`** in Vibe's registry, `match = "bash"`,
  `strict = false` — a crash in `rtk hook vibe` degrades to a warning and a
  passthrough rather than denying the tool call.
- **String-level TOML patching** (append-only, boundary-aware removal)
  rather than a `toml_edit` parse → serialize round-trip. Preserves any
  user comments and formatting in `hooks.toml`. Justified because the
  operation is genuinely append-only for install and single-block-removal
  for uninstall — no in-place field mutation is needed.
- **Idempotent install** — detects existing `name = "rtk-rewrite"` before
  appending; re-running the installer is a no-op.
- **Surgical uninstall** — strips only the RTK `[[hooks]]` block plus the
  `~/.vibe/prompts/rtk.md` prompt file. Preserves any other user-declared
  hook in the file byte-for-byte. Removes `hooks.toml` only when the RTK
  entry was the sole content, so no orphan empty file is left behind.
- **Prompt fallback** (`~/.vibe/prompts/rtk.md`) installed alongside the
  hook — belt-and-suspenders behavior described in #800. `--hook-only`
  skips it if the user doesn't want it.

## Hook response contract

Verified against Vibe's docs. On a matching bash command:

```json
{"hook_specific_output":{"tool_input":{"command":"rtk git status"}},"system_message":"rtk: rewrote to `rtk git status`"}
```

- Empty command / non-bash tool / RTK-unknown command → passthrough
  (exit 0, empty stdout — Vibe's contract for "no opinion")
- RTK permission deny → `{"decision":"deny","reason":"..."}`

Slightly different from Gemini's contract: Vibe uses `hook_specific_output`
(snake_case) not `hookSpecificOutput`, has no `ask_user` decision, and does
not use an `allow` decision for the passthrough case. The `run_vibe`
implementation is therefore separate from `run_gemini` rather than a shared
emitter.

## Tests

10 new unit tests in `src/hooks/init.rs::tests`, grouped under a
`// ── Vibe tests ────` divider:

| Test | Covers |
|---|---|
| `test_vibe_detects_rtk_entry_by_name_field` | `vibe_hooks_toml_has_rtk` truth table |
| `test_vibe_hook_entry_shape_matches_docs` | Emitted entry has every field Vibe requires |
| `test_vibe_strip_returns_none_when_entry_absent` | Uninstall is a no-op when RTK not installed |
| `test_vibe_strip_removes_only_rtk_entry` | Sibling `[[hooks]]` blocks preserved |
| `test_vibe_install_creates_hook_and_prompt` | Happy path |
| `test_vibe_install_is_idempotent` | Second install does not duplicate the entry |
| `test_vibe_install_preserves_existing_user_hook` | User's own hook untouched |
| `test_vibe_hook_only_skips_prompt_file` | `--hook-only` flag honored |
| `test_vibe_uninstall_removes_only_rtk_entry_and_prompt` | Surgical, idempotent removal |
| `test_vibe_uninstall_removes_hooks_file_when_no_other_hooks` | No orphan empty file |

## Quality gates

- `cargo fmt --all` — clean
- `cargo clippy --all-targets` — no issues
- `cargo test --all` — 2572 passed / 0 failed in the unit suite; all 10 new
  `_vibe` tests green
- Note: 6 `guard_integration_test` failures reproduce identically on
  unmodified `develop` — a parallel `git init` tempdir race in the test
  harness, unrelated to this change (verified by re-running the same test
  set on `develop` before opening this PR)

## End-to-end manual verification against a real `~/.vibe/`

Verified live inside a Mistral Vibe session, with the installed hook pointing
at the freshly-built binary:

- `--dry-run` prints the plan without touching disk
- Real install creates the `[[hooks]]` entry and `~/.vibe/prompts/rtk.md`
- Re-install is idempotent (grep count stays at 1)
- Uninstall preserves user's own hooks byte-for-byte and removes
  `hooks.toml` when the RTK entry was the only content
- Vibe UI surfaces `[rtk-rewrite] rtk: rewrote to \`rtk git status\`` and
  passes the rewritten command to the tool execution path
- **Compound `&&` chains rewrite per-subcommand** (`cd X && git status && git
  log ... && git branch` → each git subcommand becomes `rtk git …` while the
  chain structure is preserved) — the trickier case, worked first attempt
  because RTK's shared `rewrite_command` already handles this

## How to review

Suggested reading order:

1. **`src/hooks/hook_cmd.rs`** — the `run_vibe()` function (~50 lines). This
   is the whole runtime contract. Compare against `run_gemini()` right above
   it to see the diff in Vibe's response shape.
2. **`src/hooks/init.rs`** — the install / patch / uninstall / strip
   quartet. `strip_vibe_rtk_entry` is the only piece with non-trivial logic
   (walks `[[section]]` boundaries in the raw TOML text to know what to
   delete without disturbing siblings) — its behavior is pinned by 4 tests.
3. **The 10 new tests** at the bottom of `src/hooks/init.rs::tests`.
4. Optional: `src/hooks/constants.rs`, `src/hooks/permissions.rs`,
   `src/main.rs`, `README.md` — all mechanical wiring, follow the pattern
   of `AgentTarget::Droid` / `HookCommands::Droid` / `Host::Droid` from #3211.

## Try it locally

```bash
cargo install --path .
rtk init -g --agent vibe --auto-patch
# restart Vibe CLI
vibe
```

Then ask Vibe to run any bash command (e.g. `run git status`). You should
see `[rtk-rewrite] rtk: rewrote to \`rtk git status\`` in the Vibe UI and
compressed RTK output flowing back to the agent.

Uninstall symmetrically:

```bash
rtk init -g --agent vibe --uninstall
```

## Out of scope for this PR (deliberately)

- Migrating existing prompt-only Vibe installs — none exist (the code path
  described in #800 as "already implemented" was never actually landed;
  `rtk init --agent vibe` didn't exist before this PR, only the README table
  row referring to #800 did).
- Telemetry counter updates for the new agent target — happy to add in a
  follow-up if you'd like Vibe to appear in `rtk gain --history` breakdowns.
- Windows-specific packaging — the native binary hook works on Windows the
  same way it does on Claude Code / Droid, no extra work needed.

## Related

- Upstream Vibe hook feature request that unblocked this: mistralai/mistral-vibe#531
- Vibe hook documentation: https://docs.mistral.ai/vibe/code/cli/hooks
