### PR TITLE
fix(rewrite): never rewrite yadm to rtk git; keep bare git add a no-op

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -43,6 +43,18 @@ fn git_cmd(global_args: &[String]) -> Command {
     cmd
 }
 
+/// Append pathspecs to a `git add` invocation.
+///
+/// A bare `git add` gets no pathspec at all: real git treats it as a
+/// deliberate no-op ("Nothing specified, nothing added."). Adding `.`
+/// implicitly would stage the whole working tree from a command the user
+/// aimed at nothing in particular. Regression test for rtk issue #3408.
+fn append_add_pathspecs(cmd: &mut Command, args: &[String]) {
+    for arg in args {
+        cmd.arg(arg);
+    }
+}
+
 /// Create a git Command for internal parsing that must be locale-stable.
 ///
 /// We only use this for non-user-facing parses where RTK depends on git's
@@ -934,14 +946,11 @@ fn run_add(args: &[String], verbose: u8, global_args: &[String]) -> Result<i32> 
     let mut cmd = git_cmd(global_args);
     cmd.arg("add");
 
-    // Pass all arguments directly to git (flags like -A, -p, --all, etc.)
-    if args.is_empty() {
-        cmd.arg(".");
-    } else {
-        for arg in args {
-            cmd.arg(arg);
-        }
-    }
+    // Pass all arguments directly to git (flags like -A, -p, --all, etc.).
+    // A bare `git add` receives no pathspec: real git treats it as a
+    // deliberate no-op ("Nothing specified, nothing added."), and staging '.'
+    // implicitly would stage the whole worktree. See rtk issue #3408.
+    append_add_pathspecs(&mut cmd, args);
 
     let result = exec_capture(&mut cmd).context("Failed to run git add")?;
 
@@ -2084,8 +2093,30 @@ mod tests {
             .to_string_lossy()
             .to_string();
         assert_eq!(basename, "git");
+        assert_eq!(basename, "git");
         let args: Vec<_> = cmd.get_args().collect();
         assert!(args.is_empty());
+    }
+
+    #[test]
+    fn test_add_with_no_args_gets_no_pathspec() {
+        // Regression for #3408: a bare `git add` must stay a no-op and must
+        // never implicitly stage '.'.
+        let mut cmd = git_cmd(&[]);
+        cmd.arg("add");
+        append_add_pathspecs(&mut cmd, &[]);
+        let args: Vec<_> = cmd.get_args().collect();
+        assert_eq!(args, vec!["add"]);
+    }
+
+    #[test]
+    fn test_add_with_args_passes_them_through() {
+        let mut cmd = git_cmd(&[]);
+        cmd.arg("add");
+        let args = vec!["-A".to_string(), "src/main.rs".to_string()];
+        append_add_pathspecs(&mut cmd, &args);
+        let collected: Vec<_> = cmd.get_args().collect();
+        assert_eq!(collected, vec!["add", "-A", "src/main.rs"]);
     }
 
     #[test]

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -2093,7 +2093,6 @@ mod tests {
             .to_string_lossy()
             .to_string();
         assert_eq!(basename, "git");
-        assert_eq!(basename, "git");
         let args: Vec<_> = cmd.get_args().collect();
         assert!(args.is_empty());
     }

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1915,13 +1915,12 @@ mod tests {
 
     #[test]
     fn test_classify_yadm_status() {
+        // yadm manages a separate dotfiles repository; it must never be
+        // rewritten to `rtk git`, which would act on the current project.
         assert_eq!(
             classify_command("yadm status"),
-            Classification::Supported {
-                rtk_equivalent: "rtk git",
-                category: "Git",
-                estimated_savings_pct: 70.0,
-                status: RtkStatus::Existing,
+            Classification::Unsupported {
+                base_command: "yadm status".to_string(),
             }
         );
     }
@@ -1930,20 +1929,35 @@ mod tests {
     fn test_classify_yadm_diff() {
         assert_eq!(
             classify_command("yadm diff"),
-            Classification::Supported {
-                rtk_equivalent: "rtk git",
-                category: "Git",
-                estimated_savings_pct: 80.0,
-                status: RtkStatus::Existing,
+            Classification::Unsupported {
+                base_command: "yadm diff".to_string(),
             }
         );
     }
 
     #[test]
     fn test_rewrite_yadm_status() {
+        // Regression for #3408: yadm subcommands must route through the yadm
+        // filter to the yadm binary, never to git in the current directory.
         assert_eq!(
             rewrite_command_no_prefixes("yadm status", &[]),
-            Some("rtk git status".to_string())
+            Some("rtk yadm status".to_string())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_yadm_commit() {
+        assert_eq!(
+            rewrite_command_no_prefixes("yadm commit -m x", &[]),
+            Some("rtk yadm commit -m x".to_string())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_yadm_add() {
+        assert_eq!(
+            rewrite_command_no_prefixes("yadm add .", &[]),
+            Some("rtk yadm add .".to_string())
         );
     }
 

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -37,9 +37,9 @@ impl Default for RtkRule {
 
 pub const RULES: &[RtkRule] = &[
     RtkRule {
-        pattern: r"^(?:git|yadm)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|checkout|push|pull|branch|fetch|stash|worktree)",
+        pattern: r"^(?:git)\s+(?:-[Cc]\s+\S+\s+)*(status|log|diff|show|add|commit|checkout|push|pull|branch|fetch|stash|worktree)",
         rtk_cmd: "rtk git",
-        rewrite_prefixes: &["git", "yadm"],
+        rewrite_prefixes: &["git"],
         category: "Git",
         savings_pct: 70.0,
         subcmd_savings: &[


### PR DESCRIPTION
Fixes #3408

Two rewrite-layer defects that combine into a data-integrity problem.

## 1. `yadm` is rewritten to `git`

The git rule in `src/discover/rules.rs` enumerated `yadm` in its pattern and `rewrite_prefixes`, so `rtk rewrite yadm status` produced `rtk git status`. `rtk git` executes the literal `git` binary in the current working directory. Since yadm manages a separate dotfiles repository whose work-tree is `$HOME`, `yadm commit`, `yadm push`, `yadm checkout`, and `yadm add` silently redirected to the project repo the shell was standing in.

`yadm list` already routed correctly to `rtk yadm list` because the yadm filter (`src/filters/yadm.toml`) handled it; the git rule shadowed that filter for exactly the subcommands it enumerated.

Fix: remove `yadm` from the rule's pattern and `rewrite_prefixes`. All yadm subcommands now route through the yadm filter to `rtk yadm <subcommand>`, which executes the yadm binary against the dotfiles repo.

```
$ rtk rewrite yadm status   →  rtk yadm status
$ rtk rewrite yadm commit -m x → rtk yadm commit -m x
$ rtk rewrite yadm add .    →  rtk yadm add .
```

## 2. Bare `git add` gained a `.`

`src/cmds/git/git.rs` injected `"."` when `git add` had no pathspec. Real `git add` with no pathspec is a deliberate no-op ("Nothing specified, nothing added."). Through rtk it staged the entire working tree, including files the user had not tracked.

Reproduced at v0.44.2 (`700bdde`):

```
$ git add                      # real git
Nothing specified, nothing added.
$ git diff --cached --name-only
                               # (nothing staged)

$ rtk git add
$ git diff --cached --name-only
.env
tracked.txt
```

Fix: a bare `rtk git add` passes no pathspec, so nothing gets staged implicitly. Verified after the fix: `rtk git add` stages nothing.

## Tests

- `discover::registry::tests::test_classify_yadm_status`, `test_classify_yadm_diff` — yadm is no longer classified as `rtk git`.
- `test_rewrite_yadm_status`, `test_rewrite_yadm_commit`, `test_rewrite_yadm_add` — regression tests for the rewrite path.
- `cmds::git::git::tests::test_add_with_no_args_gets_no_pathspec`, `test_add_with_args_passes_them_through` — regression tests for the add pathspec behavior.

`cargo test` (2566 + integration suites) passes; `cargo clippy --all-targets` is clean.