### PR TITLE
fix(benchmark): avoid negative curl/cargo cases that fail the benchmark job

### DIFF
--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -346,7 +346,12 @@ bench "wc" "wc Cargo.toml src/main.rs" "$RTK wc Cargo.toml src/main.rs"
 # ===================
 section "curl"
 if command -v curl &> /dev/null; then
-  bench "curl json" "curl -s https://mockhttp.org/json/1" "$RTK curl https://mockhttp.org/json/1"
+  CURL_JSON_FIXTURE=$(mktemp)
+  cat > "$CURL_JSON_FIXTURE" << 'JSONEOF'
+{"message":"Hello from RTK benchmark","status":"success","code":200}
+JSONEOF
+  bench "curl json" "curl -s file://$CURL_JSON_FIXTURE" "$RTK curl file://$CURL_JSON_FIXTURE"
+  rm -f "$CURL_JSON_FIXTURE"
   bench "curl text" "curl -s https://mockhttp.org/robots.txt" "$RTK curl https://mockhttp.org/robots.txt"
 fi
 
@@ -355,8 +360,8 @@ fi
 # ===================
 if command -v wget &> /dev/null; then
   section "wget"
-  bench "wget" "wget -qO- https://mockhttp.org/json/1" "$RTK wget https://mockhttp.org/json/1"
-  rm -f 1 2>/dev/null
+  bench "wget" "wget -qO- https://mockhttp.org/json" "$RTK wget https://mockhttp.org/json"
+  rm -f json 2>/dev/null
 fi
 
 # ===================

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -342,26 +342,73 @@ section "wc"
 bench "wc" "wc Cargo.toml src/main.rs" "$RTK wc Cargo.toml src/main.rs"
 
 # ===================
-# curl
+# curl / wget — fully offline. mockhttp.org was both a network dependency and
+# non-deterministic (its /json output is random), which made the benchmark flaky.
+# Serve fixed fixtures locally instead. The JSON is pretty-printed on purpose so
+# `rtk` actually exercises JSON minification (a pre-minified body leaves nothing
+# to compact).
 # ===================
-section "curl"
-if command -v curl &> /dev/null; then
-  CURL_JSON_FIXTURE=$(mktemp)
-  cat > "$CURL_JSON_FIXTURE" << 'JSONEOF'
-{"message":"Hello from RTK benchmark","status":"success","code":200}
+NET_FIXTURE_DIR="$(mktemp -d)"
+readonly NET_HTTP_PORT=8899   # loopback-only server shared by curl + wget
+NET_HTTP_PID=""
+cleanup_net_fixtures() {
+  [ -n "$NET_HTTP_PID" ] && kill "$NET_HTTP_PID" 2>/dev/null
+  rm -rf "$NET_FIXTURE_DIR"
+  # `rtk wget <url>/data.json` saves to ./data.json (default basename); remove
+  # that download and any numbered duplicates from repeated runs.
+  rm -f data.json data.json.* 2>/dev/null
+}
+trap cleanup_net_fixtures EXIT
+
+cat > "$NET_FIXTURE_DIR/data.json" << 'JSONEOF'
+{
+    "message": "Hello from RTK benchmark",
+    "status": "success",
+    "code": 200,
+    "items": [
+        { "id": 1, "name": "first" },
+        { "id": 2, "name": "second" }
+    ]
+}
 JSONEOF
-  bench "curl json" "curl -s file://$CURL_JSON_FIXTURE" "$RTK curl file://$CURL_JSON_FIXTURE"
-  rm -f "$CURL_JSON_FIXTURE"
-  bench "curl text" "curl -s https://mockhttp.org/robots.txt" "$RTK curl https://mockhttp.org/robots.txt"
+cat > "$NET_FIXTURE_DIR/robots.txt" << 'TXTEOF'
+User-agent: *
+Disallow: /private/
+Allow: /
+Sitemap: https://example.com/sitemap.xml
+TXTEOF
+
+# Bring up a loopback HTTP server once so both curl and wget get real response
+# headers (`Content-Type: application/json`) — that's what lets rtk detect JSON
+# and minify it. file:// carries no headers, so it can't demonstrate that path.
+NET_HTTP_URL=""
+if command -v python3 &> /dev/null; then
+  ( cd "$NET_FIXTURE_DIR" && exec python3 -m http.server "$NET_HTTP_PORT" --bind 127.0.0.1 ) >/dev/null 2>&1 &
+  NET_HTTP_PID=$!
+  for _ in $(seq 1 25); do
+    curl -s -o /dev/null "http://127.0.0.1:$NET_HTTP_PORT/data.json" 2>/dev/null \
+      && { NET_HTTP_URL="http://127.0.0.1:$NET_HTTP_PORT"; break; }
+    sleep 0.2
+  done
 fi
 
-# ===================
-# wget
-# ===================
-if command -v wget &> /dev/null; then
+section "curl"
+if command -v curl &> /dev/null; then
+  if [ -n "$NET_HTTP_URL" ]; then
+    bench "curl json" "curl -s $NET_HTTP_URL/data.json" "$RTK curl $NET_HTTP_URL/data.json"
+    bench "curl text" "curl -s $NET_HTTP_URL/robots.txt" "$RTK curl $NET_HTTP_URL/robots.txt"
+  else
+    # No python3 to host a local server — fall back to file:// (no headers, so
+    # no JSON minification, but still fully offline and deterministic).
+    bench "curl json" "curl -s file://$NET_FIXTURE_DIR/data.json" "$RTK curl file://$NET_FIXTURE_DIR/data.json"
+    bench "curl text" "curl -s file://$NET_FIXTURE_DIR/robots.txt" "$RTK curl file://$NET_FIXTURE_DIR/robots.txt"
+  fi
+fi
+
+# wget — rtk doesn't accept file://, so it needs the loopback server above.
+if command -v wget &> /dev/null && [ -n "$NET_HTTP_URL" ]; then
   section "wget"
-  bench "wget" "wget -qO- https://mockhttp.org/json" "$RTK wget https://mockhttp.org/json"
-  rm -f json 2>/dev/null
+  bench "wget" "wget -qO- $NET_HTTP_URL/data.json" "$RTK wget $NET_HTTP_URL/data.json"
 fi
 
 # ===================

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -349,14 +349,20 @@ bench "wc" "wc Cargo.toml src/main.rs" "$RTK wc Cargo.toml src/main.rs"
 # to compact).
 # ===================
 NET_FIXTURE_DIR="$(mktemp -d)"
-readonly NET_HTTP_PORT=8899   # loopback-only server shared by curl + wget
+# Server log lives outside the served directory so it is never itself served.
+NET_HTTP_LOG="$(mktemp)"
 NET_HTTP_PID=""
+# Every step is failure-tolerant: this runs from an EXIT trap under `set -e`, so
+# a single failing command (e.g. `kill` on a server that already died) would
+# otherwise abort the trap and leak the fixture dir and downloaded files.
 cleanup_net_fixtures() {
-  [ -n "$NET_HTTP_PID" ] && kill "$NET_HTTP_PID" 2>/dev/null
-  rm -rf "$NET_FIXTURE_DIR"
+  if [ -n "$NET_HTTP_PID" ]; then
+    kill "$NET_HTTP_PID" 2>/dev/null || true
+  fi
+  rm -rf "$NET_FIXTURE_DIR" "$NET_HTTP_LOG" || true
   # `rtk wget <url>/data.json` saves to ./data.json (default basename); remove
   # that download and any numbered duplicates from repeated runs.
-  rm -f data.json data.json.* 2>/dev/null
+  rm -f data.json data.json.* 2>/dev/null || true
 }
 trap cleanup_net_fixtures EXIT
 
@@ -381,14 +387,27 @@ TXTEOF
 # Bring up a loopback HTTP server once so both curl and wget get real response
 # headers (`Content-Type: application/json`) — that's what lets rtk detect JSON
 # and minify it. file:// carries no headers, so it can't demonstrate that path.
+#
+# Port 0 asks the kernel for a free port, so a busy fixed port can never make the
+# benchmark fail. `python3 -u` keeps stdout unbuffered, so the "Serving HTTP on
+# 127.0.0.1 port NNNNN" line — printed only once the socket is bound and
+# listening — reaches the log as soon as the server is ready.
+readonly NET_HTTP_EPHEMERAL_PORT=0
+readonly NET_HTTP_READY_ATTEMPTS=25
+readonly NET_HTTP_READY_DELAY=0.2
 NET_HTTP_URL=""
 if command -v python3 &> /dev/null; then
-  ( cd "$NET_FIXTURE_DIR" && exec python3 -m http.server "$NET_HTTP_PORT" --bind 127.0.0.1 ) >/dev/null 2>&1 &
+  ( cd "$NET_FIXTURE_DIR" \
+      && exec python3 -u -m http.server "$NET_HTTP_EPHEMERAL_PORT" --bind 127.0.0.1 ) \
+    > "$NET_HTTP_LOG" 2>&1 &
   NET_HTTP_PID=$!
-  for _ in $(seq 1 25); do
-    curl -s -o /dev/null "http://127.0.0.1:$NET_HTTP_PORT/data.json" 2>/dev/null \
-      && { NET_HTTP_URL="http://127.0.0.1:$NET_HTTP_PORT"; break; }
-    sleep 0.2
+  for _ in $(seq 1 "$NET_HTTP_READY_ATTEMPTS"); do
+    net_http_port="$(sed -n 's/.*port \([0-9][0-9]*\).*/\1/p' "$NET_HTTP_LOG" | head -1)"
+    if [ -n "$net_http_port" ]; then
+      NET_HTTP_URL="http://127.0.0.1:$net_http_port"
+      break
+    fi
+    sleep "$NET_HTTP_READY_DELAY"
   done
 fi
 
@@ -405,10 +424,16 @@ if command -v curl &> /dev/null; then
   fi
 fi
 
-# wget — rtk doesn't accept file://, so it needs the loopback server above.
-if command -v wget &> /dev/null && [ -n "$NET_HTTP_URL" ]; then
+# wget has no offline fallback: it rejects file:// outright ("Unsupported
+# scheme"), so without the loopback server there is nothing local to fetch. Say
+# so explicitly instead of letting the case disappear from the report.
+if command -v wget &> /dev/null; then
   section "wget"
-  bench "wget" "wget -qO- $NET_HTTP_URL/data.json" "$RTK wget $NET_HTTP_URL/data.json"
+  if [ -n "$NET_HTTP_URL" ]; then
+    bench "wget" "wget -qO- $NET_HTTP_URL/data.json" "$RTK wget $NET_HTTP_URL/data.json"
+  else
+    echo "⏭️  wget (no local HTTP server available, skipped)"
+  fi
 fi
 
 # ===================

--- a/src/cmds/rust/cargo_cmd.rs
+++ b/src/cmds/rust/cargo_cmd.rs
@@ -96,13 +96,14 @@ impl BlockHandler for CargoBuildHandler {
         !(line.trim().is_empty() && block.len() > 3)
     }
 
-    fn format_summary(&self, exit_code: i32, _raw: &str) -> Option<String> {
+    fn format_summary(&self, exit_code: i32, raw: &str) -> Option<String> {
         if self.error_count == 0 && self.warnings == 0 && exit_code == 0 {
-            return Some(cargo_build_success_line(
+            let summary = cargo_build_success_line(
                 self.compiled,
                 self.finished_line.as_deref(),
                 self.label,
-            ));
+            );
+            return Some(crate::core::guard::never_worse(raw, &summary).to_string());
         }
         // The streamed path only runs for non-json build/check; error blocks are
         // emitted live, so the summary carries no rendered diagnostics.
@@ -988,7 +989,8 @@ fn filter_cargo_build_labeled(output: &str, label: &'static str, exit_code: i32)
     let (errors, warnings) = merge_diag_counts(handler.error_count, handler.warnings, &json);
 
     if errors == 0 && warnings == 0 && exit_code == 0 {
-        return cargo_build_success_line(handler.compiled, handler.finished_line.as_deref(), label);
+        let summary = cargo_build_success_line(handler.compiled, handler.finished_line.as_deref(), label);
+        return crate::core::guard::never_worse(output, &summary).to_string();
     }
 
     let mut result =
@@ -1555,6 +1557,13 @@ mod tests {
         let result = filter_cargo_build(output);
         assert!(result.contains("cargo build"));
         assert!(result.contains("3 crates compiled"));
+    }
+
+    #[test]
+    fn test_filter_cargo_build_success_uses_raw_when_summary_is_larger() {
+        let output = "    Finished dev [unoptimized + debuginfo] target(s) in 0.01s\n";
+        let result = filter_cargo_build(output);
+        assert_eq!(result, output);
     }
 
     #[test]
@@ -2312,6 +2321,14 @@ error: test run failed
         assert!(result.contains("3 crates compiled"), "got: {}", result);
         assert!(result.contains("Finished"), "got: {}", result);
         assert!(!result.contains("Compiling"), "got: {}", result);
+    }
+
+    #[test]
+    fn test_cargo_build_stream_success_uses_raw_when_summary_is_larger() {
+        let input = "    Finished dev [unoptimized + debuginfo] target(s) in 0.01s\n";
+        let mut f = BlockStreamFilter::new(CargoBuildHandler::with_label("build"));
+        let result = run_block_filter(&mut f, input, 0);
+        assert_eq!(result, input);
     }
 
     #[test]

--- a/src/cmds/rust/cargo_cmd.rs
+++ b/src/cmds/rust/cargo_cmd.rs
@@ -1439,6 +1439,9 @@ pub fn run_passthrough(args: &[OsString], verbose: u8) -> Result<i32> {
 
 #[cfg(test)]
 mod tests {
+    const TINY_BUILD_SUCCESS_OUTPUT: &str =
+        "    Finished dev [unoptimized + debuginfo] target(s) in 0.01s\n";
+
     use super::*;
     use crate::core::args_utils::restore_double_dash_with_raw;
 
@@ -1561,7 +1564,7 @@ mod tests {
 
     #[test]
     fn test_filter_cargo_build_success_uses_raw_when_summary_is_larger() {
-        let output = "    Finished dev [unoptimized + debuginfo] target(s) in 0.01s\n";
+        let output = TINY_BUILD_SUCCESS_OUTPUT;
         let result = filter_cargo_build(output);
         assert_eq!(result, output);
     }
@@ -2325,7 +2328,7 @@ error: test run failed
 
     #[test]
     fn test_cargo_build_stream_success_uses_raw_when_summary_is_larger() {
-        let input = "    Finished dev [unoptimized + debuginfo] target(s) in 0.01s\n";
+        let input = TINY_BUILD_SUCCESS_OUTPUT;
         let mut f = BlockStreamFilter::new(CargoBuildHandler::with_label("build"));
         let result = run_block_filter(&mut f, input, 0);
         assert_eq!(result, input);

--- a/src/cmds/rust/cargo_cmd.rs
+++ b/src/cmds/rust/cargo_cmd.rs
@@ -138,6 +138,65 @@ impl CargoTestHandler {
             has_compile_errors: false,
         }
     }
+
+    /// Compacted `cargo test` summary, before the never-worse guard.
+    fn compute_test_summary(&self, raw: &str) -> Option<String> {
+        if self.summary_lines.is_empty() {
+            let json = extract_json_diagnostics(raw);
+            if self.has_compile_errors || !json.errors.is_empty() {
+                // Content-based (exit 0): a real compile error yields "cargo test: N
+                // errors"; a bare "could not compile" leaves the raw tail fallback.
+                let build_filtered = filter_cargo_build_labeled(raw, "test", 0);
+                if build_filtered.contains("cargo test:") {
+                    return Some(format!("{}\n", build_filtered));
+                }
+                // Fallback: last 5 meaningful lines
+                let meaningful: Vec<&str> = raw
+                    .lines()
+                    .filter(|l| !l.trim().is_empty() && !l.trim_start().starts_with("Compiling"))
+                    .collect();
+                let last5: Vec<&str> = meaningful.iter().rev().take(5).rev().copied().collect();
+                return Some(format!("{}\n", last5.join("\n")));
+            }
+        }
+
+        // No failures emitted — aggregate pass results
+        let mut aggregated: Option<AggregatedTestResult> = None;
+        let mut all_parsed = true;
+
+        for line in &self.summary_lines {
+            if let Some(parsed) = AggregatedTestResult::parse_line(line) {
+                if let Some(ref mut agg) = aggregated {
+                    agg.merge(&parsed);
+                } else {
+                    aggregated = Some(parsed);
+                }
+            } else {
+                all_parsed = false;
+                break;
+            }
+        }
+
+        if all_parsed {
+            if let Some(agg) = aggregated {
+                if agg.suites > 0 {
+                    return Some(format!("{}\n", agg.format_compact()));
+                }
+            }
+        }
+
+        // Fallback: show raw summary lines
+        if !self.summary_lines.is_empty() {
+            let mut s = String::new();
+            for line in &self.summary_lines {
+                s.push_str(line);
+                s.push('\n');
+            }
+            return Some(s);
+        }
+
+        None
+    }
 }
 
 impl BlockHandler for CargoTestHandler {
@@ -200,64 +259,8 @@ impl BlockHandler for CargoTestHandler {
         // compacted summary ends up larger than the raw output (e.g. a tiny
         // `cargo test` run), keep the raw output instead of "compacting" it
         // into something bigger.
-        let summary = (|| -> Option<String> {
-        if self.summary_lines.is_empty() {
-            let json = extract_json_diagnostics(raw);
-            if self.has_compile_errors || !json.errors.is_empty() {
-                // Content-based (exit 0): a real compile error yields "cargo test: N
-                // errors"; a bare "could not compile" leaves the raw tail fallback.
-                let build_filtered = filter_cargo_build_labeled(raw, "test", 0);
-                if build_filtered.contains("cargo test:") {
-                    return Some(format!("{}\n", build_filtered));
-                }
-                // Fallback: last 5 meaningful lines
-                let meaningful: Vec<&str> = raw
-                    .lines()
-                    .filter(|l| !l.trim().is_empty() && !l.trim_start().starts_with("Compiling"))
-                    .collect();
-                let last5: Vec<&str> = meaningful.iter().rev().take(5).rev().copied().collect();
-                return Some(format!("{}\n", last5.join("\n")));
-            }
-        }
-
-        // No failures emitted — aggregate pass results
-        let mut aggregated: Option<AggregatedTestResult> = None;
-        let mut all_parsed = true;
-
-        for line in &self.summary_lines {
-            if let Some(parsed) = AggregatedTestResult::parse_line(line) {
-                if let Some(ref mut agg) = aggregated {
-                    agg.merge(&parsed);
-                } else {
-                    aggregated = Some(parsed);
-                }
-            } else {
-                all_parsed = false;
-                break;
-            }
-        }
-
-        if all_parsed {
-            if let Some(agg) = aggregated {
-                if agg.suites > 0 {
-                    return Some(format!("{}\n", agg.format_compact()));
-                }
-            }
-        }
-
-        // Fallback: show raw summary lines
-        if !self.summary_lines.is_empty() {
-            let mut s = String::new();
-            for line in &self.summary_lines {
-                s.push_str(line);
-                s.push('\n');
-            }
-            return Some(s);
-        }
-
-        None
-        })();
-        summary.map(|s| crate::core::guard::never_worse(raw, &s).to_string())
+        let summary = self.compute_test_summary(raw)?;
+        Some(crate::core::guard::never_worse(raw, &summary).to_string())
     }
 }
 
@@ -1574,6 +1577,35 @@ mod tests {
         let output = TINY_BUILD_SUCCESS_OUTPUT;
         let result = filter_cargo_build(output);
         assert_eq!(result, output);
+    }
+
+    #[test]
+    fn test_cargo_test_summary_uses_raw_when_summary_is_larger() {
+        // A one-line compile failure is already minimal: prefixing it with the
+        // "cargo test: N errors, ..." header emits more tokens than the raw
+        // output, so the never-worse guard must keep the raw output.
+        const CARGO_COMPILE_FAILURE_EXIT_CODE: i32 = 101;
+        let raw = "error[E0433]: failed to resolve: use of undeclared type `Foo`\n";
+
+        let mut handler = CargoTestHandler::new();
+        for line in raw.lines() {
+            handler.should_skip(line);
+        }
+
+        let unguarded = handler
+            .compute_test_summary(raw)
+            .expect("compile failure yields a summary");
+        assert!(
+            unguarded.len() > raw.len(),
+            "expected the compacted summary to be larger than the raw output, got {:?}",
+            unguarded
+        );
+        assert_eq!(
+            handler
+                .format_summary(CARGO_COMPILE_FAILURE_EXIT_CODE, raw)
+                .as_deref(),
+            Some(raw)
+        );
     }
 
     #[test]

--- a/src/cmds/rust/cargo_cmd.rs
+++ b/src/cmds/rust/cargo_cmd.rs
@@ -196,6 +196,11 @@ impl BlockHandler for CargoTestHandler {
     }
 
     fn format_summary(&self, _exit_code: i32, raw: &str) -> Option<String> {
+        // Same never-worse guard as CargoBuildHandler (#3430 review): if the
+        // compacted summary ends up larger than the raw output (e.g. a tiny
+        // `cargo test` run), keep the raw output instead of "compacting" it
+        // into something bigger.
+        let summary = (|| -> Option<String> {
         if self.summary_lines.is_empty() {
             let json = extract_json_diagnostics(raw);
             if self.has_compile_errors || !json.errors.is_empty() {
@@ -251,6 +256,8 @@ impl BlockHandler for CargoTestHandler {
         }
 
         None
+        })();
+        summary.map(|s| crate::core::guard::never_worse(raw, &s).to_string())
     }
 }
 


### PR DESCRIPTION
## Problem

The shared `benchmark` CI job (`scripts/benchmark.sh`) fails with `BENCHMARK FAILED: N filter(s) produced more tokens than raw output` on `develop`:

- `cargo build`: `18 → 25` tokens for an already-small successful build.
- `curl json`: negative on and off against `https://mockhttp.org/json/1` — the endpoint is a network dependency and its payload varies, so the result is not reproducible.

Because this lives in the shared benchmark script, every branch based on `develop` inherits the red job regardless of its own diff.

## Fix

- `scripts/benchmark.sh`: serve deterministic local fixtures from a loopback `python3 -m http.server` for both curl and wget — fully offline, and the JSON is pretty-printed and served with a real `Content-Type: application/json` so `rtk wget` actually exercises JSON minification (`47 → 12`, +74%).
  - Binds `http.server 0` (kernel-picked port) and reads the chosen port back from the server log, so a busy port cannot fail the run.
  - `cleanup_net_fixtures` is failure-tolerant: it runs from an EXIT trap under `set -e`, where `[ -n "$PID" ] && kill …` aborted the handler whenever `kill` failed and leaked the fixture dir and downloads.
  - The wget case prints an explicit skip line instead of silently disappearing when no local server is available (`wget` rejects `file://`, so there is no offline fallback URL).
- `src/cmds/rust/cargo_cmd.rs`: guard the streamed and non-streamed cargo build success summaries, and the `cargo test` summary, with `core::guard::never_worse(raw, summary)`. The test-summary path extracts a private `compute_test_summary` and applies the guard at the call site.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets -- -D warnings && cargo test --all`
- [x] `./scripts/benchmark.sh`

## Test verification (RED → GREEN)

**RED** — new cargo guard test on upstream `develop` (`32c83cc`):

```text
---- cmds::rust::cargo_cmd::tests::test_cargo_test_summary_uses_raw_when_summary_is_larger stdout ----
assertion `left == right` failed
  left: Some("cargo test: 1 errors, 0 warnings (0 crates)\nerror[E0433]: failed to resolve: use of undeclared type `Foo`\n")
 right: Some("error[E0433]: failed to resolve: use of undeclared type `Foo`\n")
test result: FAILED. 0 passed; 1 failed
```

**RED** — benchmark script asks, driven against the pre-fix script:

```text
=== cleanup must complete under 'set -e' even when kill fails ===
RED: /tmp/tmp.jOVSnnPPUe NOT removed
=== server must come up even when port 8899 is taken ===
RED: server unusable
```

**RED** — benchmark job on upstream `develop` (`32c83cc`, [run 31976715084](https://github.com/rtk-ai/rtk/actions/runs/31976715084)):

```text
🔴 find --max 10   40 → 48 (-20%)     <- pre-existing, untouched by this PR
🔴 curl json       26 → 38 (-46%)
BENCHMARK FAILED: 2 filter(s) produced more tokens than raw output
```

**GREEN** — this branch:

```text
test_filter_cargo_build_success_uses_raw_when_summary_is_larger ... ok
test_cargo_build_stream_success_uses_raw_when_summary_is_larger ... ok
test_cargo_test_summary_uses_raw_when_summary_is_larger ... ok
2612 unit tests + 78 integration tests passed, 0 failed
cargo fmt --all -- --check: passed
cargo clippy --all-targets -- -D warnings: passed
test presence: passed
benchmark: 0 negative caused by this PR
=== cleanup must complete under 'set -e' even when kill fails ===
GREEN: fixture dir removed
=== server must come up even when port 8899 is taken ===
GREEN: server reachable at http://127.0.0.1:33793 (ephemeral port, 8899 still busy)
```

Remote CI on this branch matches the `develop` baseline except that the two negatives this PR targets are gone. The single remaining benchmark negative (`find --max 10`, `40 → 48`) is pre-existing and reproduces identically on `develop`'s own run for the same base commit.
