### PR TITLE
fix(find/git): avoid UTF-8 mid-char byte-slice panics

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -1009,15 +1009,20 @@ fn build_commit_command(args: &[String], global_args: &[String]) -> Command {
 /// Handles: `[main abc1234def] message`, `[main (root-commit) abc1234def] msg`,
 /// localized variants, and multibyte branch names.
 fn parse_commit_output(line: &str) -> String {
-    if let Some(bracket_end) = line.find(']') {
-        let bracket_content = &line[1..bracket_end];
-        let hash = bracket_content.split_whitespace().next_back().unwrap_or("");
-        if !hash.is_empty() && hash.len() >= 7 {
-            let short_hash: String = hash.chars().take(7).collect();
-            format!("ok {}", short_hash)
-        } else {
-            "ok".to_string()
-        }
+    // Require a leading `[` via strip_prefix so we never byte-slice at index 1
+    // when the first character is multibyte, or when `]` appears before any `[`
+    // (e.g. hook noise). See #3415.
+    let Some(after_open) = line.strip_prefix('[') else {
+        return "ok".to_string();
+    };
+    let Some(bracket_end) = after_open.find(']') else {
+        return "ok".to_string();
+    };
+    let bracket_content = &after_open[..bracket_end];
+    let hash = bracket_content.split_whitespace().next_back().unwrap_or("");
+    if !hash.is_empty() && hash.len() >= 7 {
+        let short_hash: String = hash.chars().take(7).collect();
+        format!("ok {}", short_hash)
     } else {
         "ok".to_string()
     }
@@ -2867,6 +2872,18 @@ no changes added to commit (use "git add" and/or "git commit -a")
     #[test]
     fn test_parse_commit_output_empty() {
         assert_eq!(parse_commit_output(""), "ok");
+    }
+
+    /// Regression #3415: `]` with no leading `[` used to slice `1..0` and panic.
+    #[test]
+    fn test_parse_commit_output_leading_close_bracket() {
+        assert_eq!(parse_commit_output("] done"), "ok");
+    }
+
+    /// Regression #3415: multibyte text before `]` must not byte-slice at index 1.
+    #[test]
+    fn test_parse_commit_output_multibyte_without_open_bracket() {
+        assert_eq!(parse_commit_output("日本] x"), "ok");
     }
 
     // --- commit outcome classification (issue #2494) ---

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -7,6 +7,19 @@ use ignore::WalkBuilder;
 use std::collections::HashMap;
 use std::path::Path;
 
+/// Truncate a directory path for display, keeping the trailing portion.
+///
+/// Uses char boundaries so non-ASCII paths (CJK, Thai, …) never panic on a
+/// mid-character byte index. See #3415.
+fn truncate_path_display(dir: &str, max_bytes: usize) -> String {
+    if dir.len() <= max_bytes {
+        return dir.to_string();
+    }
+    let keep = max_bytes.saturating_sub(3); // room for "..."
+    let start = dir.floor_char_boundary(dir.len().saturating_sub(keep));
+    format!("...{}", &dir[start..])
+}
+
 /// Match a filename against a glob pattern (supports `*` and `?`).
 fn glob_match(pattern: &str, name: &str) -> bool {
     glob_match_inner(pattern.as_bytes(), name.as_bytes())
@@ -322,11 +335,7 @@ pub fn run(
         }
 
         let files_in_dir = &by_dir[dir];
-        let dir_display = if dir.len() > 50 {
-            format!("...{}", &dir[dir.len() - 47..])
-        } else {
-            dir.clone()
-        };
+        let dir_display = truncate_path_display(dir, 50);
 
         let remaining_budget = max_results - displayed;
         if files_in_dir.len() <= remaining_budget {
@@ -391,6 +400,41 @@ mod tests {
     /// Convert string slices to Vec<String> for test convenience.
     fn args(values: &[&str]) -> Vec<String> {
         values.iter().map(|s| s.to_string()).collect()
+    }
+
+    // --- truncate_path_display (#3415) ---
+
+    #[test]
+    fn truncate_path_display_ascii_short_unchanged() {
+        assert_eq!(truncate_path_display("src/cmds", 50), "src/cmds");
+    }
+
+    #[test]
+    fn truncate_path_display_ascii_long_keeps_tail() {
+        let dir = "a".repeat(60);
+        let shown = truncate_path_display(&dir, 50);
+        assert!(shown.starts_with("..."));
+        assert_eq!(shown.len(), 50); // "..." + 47 ascii bytes
+        assert!(shown.ends_with(&"a".repeat(47)));
+    }
+
+    /// Regression #3415: Thai chars are 3 bytes each; mid-char byte slice used to panic.
+    #[test]
+    fn truncate_path_display_thai_long_no_panic() {
+        let dir = "ก".repeat(20); // 60 bytes
+        let shown = truncate_path_display(&dir, 50);
+        assert!(shown.starts_with("..."));
+        assert!(shown.is_char_boundary(shown.len()));
+        assert!(shown.chars().skip(3).all(|c| c == 'ก'));
+    }
+
+    /// Regression #3415: CJK chars are 3 bytes each.
+    #[test]
+    fn truncate_path_display_cjk_long_no_panic() {
+        let dir = "日".repeat(20); // 60 bytes
+        let shown = truncate_path_display(&dir, 50);
+        assert!(shown.starts_with("..."));
+        assert!(shown.chars().skip(3).all(|c| c == '日'));
     }
 
     // --- glob_match unit tests ---


### PR DESCRIPTION
## Summary
- Fix `rtk find` display truncation so paths longer than 50 bytes truncate on char boundaries (Thai/CJK paths no longer panic).
- Fix `parse_commit_output` to require a leading `[` via `strip_prefix` instead of `&line[1..]`, so hook noise / multibyte first lines cannot panic.
- Add regression tests for ASCII truncation parity and the two panic shapes from #3415.

Fixes #3415

## Test plan
- [x] `cargo test --bin rtk truncate_path_display`
- [x] `cargo test --bin rtk test_parse_commit_output`
- [x] `cargo fmt --all`
- [x] `cargo clippy --bin rtk --all-targets -- -D warnings`