### PR TITLE
docs: remove outdated references to -u flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,8 +290,8 @@ rtk session                     # Show RTK adoption across recent sessions
 ## Global Flags
 
 ```bash
--u, --ultra-compact    # ASCII icons, inline format (further output reduction)
--v, --verbose          # Increase verbosity (-v, -vv, -vvv)
+--ultra-compact    # ASCII icons, inline format (further output reduction)
+--verbose          # Increase verbosity (-v, -vv, -vvv)
 ```
 
 ## Examples

--- a/docs/contributing/ARCHITECTURE.md
+++ b/docs/contributing/ARCHITECTURE.md
@@ -769,7 +769,7 @@ if verbose > 0 {
 
 ```
 ┌────────────────────────────────────────────────────────────────────────┐
-│                       Ultra-Compact Mode (-u)                          │
+│                       Ultra-Compact Mode                               │
 └────────────────────────────────────────────────────────────────────────┘
 
 main.rs:51-53
@@ -1028,7 +1028,7 @@ Overhead Sources:
 - **Derive Macros**: Less boilerplate (declarative CLI definition)
 - **Auto-Generated Help**: `--help` generated automatically
 - **Type Safety**: Parse arguments directly into typed structs
-- **Global Flags**: `-v` and `-u` work across all commands
+- **Global Flags**: `-v` works across all commands
 
 ---
 
@@ -1052,7 +1052,7 @@ Overhead Sources:
 | **Exit Code Preservation** | Passing through tool's exit code for CI/CD reliability |
 | **Package Manager Detection** | Identifying pnpm/yarn/npm to execute JS/TS tools correctly |
 | **Verbosity Levels** | `-v/-vv/-vvv` for progressively more debug output |
-| **Ultra-Compact** | `-u` flag for maximum compression (ASCII icons, inline format) |
+| **Ultra-Compact** | `--ultra-compact` flag for maximum compression (ASCII icons, inline format) |
 
 ---
 


### PR DESCRIPTION
Closes #3426. Removed all obsolete mentions of the deleted -u flag in README.md and ARCHITECTURE.md.