### PR TITLE
fix(tracking): honor tracking.history_days instead of the hardcoded default

### DIFF
--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -462,15 +462,48 @@ impl Tracker {
 
     fn cleanup_old(&self) -> Result<()> {
         let cutoff = Utc::now() - chrono::Duration::days(self.history_days);
-        self.conn.execute(
-            "DELETE FROM commands WHERE timestamp < ?1",
-            params![cutoff.to_rfc3339()],
-        )?;
-        self.conn.execute(
+        let cutoff = cutoff.to_rfc3339();
+        let mut deleted = self
+            .conn
+            .execute("DELETE FROM commands WHERE timestamp < ?1", params![cutoff])?;
+        deleted += self.conn.execute(
             "DELETE FROM parse_failures WHERE timestamp < ?1",
-            params![cutoff.to_rfc3339()],
+            params![cutoff],
         )?;
+        if deleted > 0 {
+            self.reclaim_if_fragmented();
+        }
         Ok(())
+    }
+
+    /// Return freed pages to the filesystem when enough of the file is empty.
+    ///
+    /// These databases have no `auto_vacuum`, so a delete only marks pages reusable:
+    /// the file never shrinks on its own. Shortening `history_days` therefore prunes
+    /// millions of rows and leaves the file at its old size until something vacuums.
+    ///
+    /// `VACUUM` rewrites the whole database and takes an exclusive lock, so it must not
+    /// run on every `cleanup_old` (that is once per tracked command). Gating on the free
+    /// ratio keeps it near-free in steady state, where inserts reuse freed pages and the
+    /// freelist stays flat, and lets it fire on the bulk deletes that actually strand
+    /// space. Failure is ignored: reclaiming disk must never fail a user's command.
+    fn reclaim_if_fragmented(&self) {
+        let free: i64 = match self
+            .conn
+            .query_row("PRAGMA freelist_count", [], |r| r.get(0))
+        {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        let total: i64 = match self.conn.query_row("PRAGMA page_count", [], |r| r.get(0)) {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        if should_reclaim(free, total) {
+            // Cannot run inside a transaction, and needs scratch space roughly the size
+            // of the live data. Both are why this stays best-effort.
+            let _ = self.conn.execute_batch("VACUUM;");
+        }
     }
 
     /// Delete all tracked data (commands + parse_failures), resetting all stats to zero.
@@ -1276,6 +1309,21 @@ fn configured_history_days() -> i64 {
     )
 }
 
+/// Free pages below this never justify a rewrite, whatever the ratio. At SQLite's 4 KiB
+/// default this is ~16 MB, so small databases are left alone.
+const VACUUM_MIN_FREE_PAGES: i64 = 4096;
+/// Percentage of the file that must be free pages before a rewrite pays for itself.
+const VACUUM_MIN_FREE_PCT: i64 = 25;
+
+/// Decision half of [`Tracker::reclaim_if_fragmented`], split out so the thresholds are
+/// testable without building a database large enough to cross them.
+fn should_reclaim(free_pages: i64, total_pages: i64) -> bool {
+    if total_pages <= 0 || free_pages < VACUUM_MIN_FREE_PAGES {
+        return false;
+    }
+    free_pages.saturating_mul(100) / total_pages >= VACUUM_MIN_FREE_PCT
+}
+
 /// Clamping half of [`configured_history_days`], split out so it is testable without
 /// touching the real config file.
 fn resolve_history_days(configured: Option<u32>) -> i64 {
@@ -1800,6 +1848,83 @@ mod tests {
             stale, 1,
             "10-day-old command should survive 30-day retention"
         );
+    }
+
+    #[test]
+    fn test_should_reclaim_thresholds() {
+        // Steady state: inserts reuse freed pages, so the freelist stays flat and a
+        // per-command VACUUM would be pure waste.
+        assert!(!should_reclaim(0, 100_000), "no free pages");
+        assert!(
+            !should_reclaim(VACUUM_MIN_FREE_PAGES - 1, VACUUM_MIN_FREE_PAGES),
+            "tiny database, high ratio: not worth a rewrite"
+        );
+        assert!(
+            !should_reclaim(VACUUM_MIN_FREE_PAGES * 2, 1_000_000),
+            "plenty of free pages but a small share of the file"
+        );
+        // The bulk-delete case this exists for: shortening history_days strands most
+        // of the file.
+        assert!(
+            should_reclaim(450_000, 500_000),
+            "90% free after a retention drop should reclaim"
+        );
+        assert!(should_reclaim(
+            VACUUM_MIN_FREE_PAGES,
+            VACUUM_MIN_FREE_PAGES * 4
+        ));
+        // Guards against a divide-by-zero on an empty or unreadable database.
+        assert!(!should_reclaim(10, 0), "zero pages must not divide");
+    }
+
+    #[test]
+    fn test_vacuum_returns_space_after_bulk_delete() {
+        let t = Tracker::new_in_memory().expect("in-memory tracker");
+        let old = (Utc::now() - chrono::Duration::days(400)).to_rfc3339();
+        for i in 0..4000 {
+            t.conn
+                .execute(
+                    "INSERT INTO commands
+                     (timestamp, original_cmd, rtk_cmd, input_tokens, output_tokens,
+                      saved_tokens, savings_pct, exec_time_ms, project_path)
+                     VALUES (?1, ?2, ?2, 100, 20, 80, 80.0, 0, '')",
+                    params![old, format!("padding row {} {}", i, "x".repeat(400))],
+                )
+                .expect("insert bulk row");
+        }
+        let before: i64 = t
+            .conn
+            .query_row("PRAGMA page_count", [], |r| r.get(0))
+            .expect("page_count");
+
+        t.conn
+            .execute("DELETE FROM commands", [])
+            .expect("bulk delete");
+        let freed: i64 = t
+            .conn
+            .query_row("PRAGMA freelist_count", [], |r| r.get(0))
+            .expect("freelist_count");
+        assert!(
+            freed > 0,
+            "delete alone should strand pages, not return them"
+        );
+
+        t.conn.execute_batch("VACUUM;").expect("vacuum");
+        let after: i64 = t
+            .conn
+            .query_row("PRAGMA page_count", [], |r| r.get(0))
+            .expect("page_count");
+        assert!(
+            after < before,
+            "VACUUM should shrink the database ({} -> {} pages)",
+            before,
+            after
+        );
+        let leftover: i64 = t
+            .conn
+            .query_row("PRAGMA freelist_count", [], |r| r.get(0))
+            .expect("freelist_count");
+        assert_eq!(leftover, 0, "VACUUM should leave no free pages");
     }
 
     #[test]

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -90,6 +90,9 @@ use super::constants::{DEFAULT_HISTORY_DAYS, HISTORY_DB, RTK_DATA_DIR};
 /// ```
 pub struct Tracker {
     conn: Connection,
+    /// Retention window in days, resolved once at construction. `cleanup_old` runs on
+    /// every record, so this must not re-read the config file per call.
+    history_days: i64,
 }
 
 /// Individual command record from tracking history.
@@ -338,14 +341,20 @@ impl Tracker {
 
         restrict_db_files(&db_path);
 
-        Ok(Self { conn })
+        Ok(Self {
+            conn,
+            history_days: configured_history_days(),
+        })
     }
 
     /// Create an isolated in-memory tracker for tests.
     #[cfg(test)]
     pub fn new_in_memory() -> Result<Self> {
         let conn = Connection::open_in_memory().context("Failed to open in-memory DB")?;
-        let tracker = Self { conn };
+        let tracker = Self {
+            conn,
+            history_days: configured_history_days(),
+        };
         tracker.init_schema()?;
         Ok(tracker)
     }
@@ -452,7 +461,7 @@ impl Tracker {
     }
 
     fn cleanup_old(&self) -> Result<()> {
-        let cutoff = Utc::now() - chrono::Duration::days(DEFAULT_HISTORY_DAYS);
+        let cutoff = Utc::now() - chrono::Duration::days(self.history_days);
         self.conn.execute(
             "DELETE FROM commands WHERE timestamp < ?1",
             params![cutoff.to_rfc3339()],
@@ -1253,6 +1262,29 @@ fn db_sidecars(db_path: &std::path::Path) -> Vec<PathBuf> {
         .collect()
 }
 
+/// Retention window for `cleanup_old`, from `tracking.history_days`.
+///
+/// Falls back to the default on any config problem, including a `[tracking]` section
+/// that omits `history_days` (the field has no serde default, so a partial section
+/// fails the whole parse). A non-positive value also falls back rather than being
+/// honored: a typo'd `0` would otherwise delete the entire history on the next write.
+fn configured_history_days() -> i64 {
+    resolve_history_days(
+        crate::core::config::Config::load()
+            .ok()
+            .map(|c| c.tracking.history_days),
+    )
+}
+
+/// Clamping half of [`configured_history_days`], split out so it is testable without
+/// touching the real config file.
+fn resolve_history_days(configured: Option<u32>) -> i64 {
+    configured
+        .map(i64::from)
+        .filter(|d| *d > 0)
+        .unwrap_or(DEFAULT_HISTORY_DAYS)
+}
+
 pub(crate) fn get_db_path() -> Result<PathBuf> {
     // Priority 1: Environment variable RTK_DB_PATH
     if let Ok(custom_path) = std::env::var("RTK_DB_PATH") {
@@ -1681,6 +1713,115 @@ mod tests {
         // We can't assert exact rate because other tests may have added records,
         // but we can verify recovery_rate is between 0 and 100
         assert!(summary.recovery_rate >= 0.0 && summary.recovery_rate <= 100.0);
+    }
+
+    /// Backdated tracker: one `commands` and one `parse_failures` row 10 days old,
+    /// with an explicit retention window.
+    #[cfg(test)]
+    fn tracker_with_10_day_old_rows(history_days: i64) -> Tracker {
+        let mut t = Tracker::new_in_memory().expect("in-memory tracker");
+        t.history_days = history_days;
+        let old = (Utc::now() - chrono::Duration::days(10)).to_rfc3339();
+        t.conn
+            .execute(
+                "INSERT INTO commands
+                 (timestamp, original_cmd, rtk_cmd, input_tokens, output_tokens,
+                  saved_tokens, savings_pct, exec_time_ms, project_path)
+                 VALUES (?1, 'old cmd', 'rtk old cmd', 100, 20, 80, 80.0, 0, '')",
+                params![old],
+            )
+            .expect("insert backdated command");
+        t.conn
+            .execute(
+                "INSERT INTO parse_failures
+                 (timestamp, raw_command, error_message, fallback_succeeded)
+                 VALUES (?1, 'old raw', 'old err', 1)",
+                params![old],
+            )
+            .expect("insert backdated parse failure");
+        t
+    }
+
+    // Regression: cleanup_old hardcoded DEFAULT_HISTORY_DAYS, so tracking.history_days
+    // was declared, defaulted, written into config.toml, documented — and never read.
+    // Both directions are asserted deliberately: a hardcoded 90 still passes the
+    // "retained" half, so only the "pruned" half catches the regression, and only the
+    // pair proves the field is what drives the cutoff.
+    #[test]
+    fn test_cleanup_old_prunes_beyond_configured_history_days() {
+        let t = tracker_with_10_day_old_rows(3);
+
+        t.record("git status", "rtk git status fresh", 100, 20, 5)
+            .expect("record triggers cleanup_old");
+
+        let stale: i64 = t
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM commands WHERE rtk_cmd = 'rtk old cmd'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("count commands");
+        assert_eq!(
+            stale, 0,
+            "10-day-old command should be pruned at 3-day retention"
+        );
+
+        let stale_pf: i64 = t
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM parse_failures WHERE raw_command = 'old raw'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("count parse_failures");
+        assert_eq!(
+            stale_pf, 0,
+            "10-day-old parse failure should be pruned at 3-day retention"
+        );
+    }
+
+    #[test]
+    fn test_cleanup_old_retains_within_configured_history_days() {
+        let t = tracker_with_10_day_old_rows(30);
+
+        t.record("git status", "rtk git status fresh", 100, 20, 5)
+            .expect("record triggers cleanup_old");
+
+        let stale: i64 = t
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM commands WHERE rtk_cmd = 'rtk old cmd'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("count commands");
+        assert_eq!(
+            stale, 1,
+            "10-day-old command should survive 30-day retention"
+        );
+    }
+
+    #[test]
+    fn test_resolve_history_days() {
+        assert_eq!(
+            resolve_history_days(Some(30)),
+            30,
+            "honors a configured value"
+        );
+        // A missing/unparseable config (including a [tracking] section that omits
+        // history_days, which fails the whole parse) must not change retention.
+        assert_eq!(
+            resolve_history_days(None),
+            DEFAULT_HISTORY_DAYS,
+            "absent config falls back to the default"
+        );
+        // A typo'd 0 would otherwise delete the entire history on the next write.
+        assert_eq!(
+            resolve_history_days(Some(0)),
+            DEFAULT_HISTORY_DAYS,
+            "zero falls back rather than wiping history"
+        );
     }
 
     #[test]


### PR DESCRIPTION
`tracking.history_days` has no effect. `Tracker::cleanup_old` computes its cutoff from the `DEFAULT_HISTORY_DAYS` constant, so the retention window stays at 90 days no matter what the config says.

The setting looks live from every other angle. It's a field on `TrackingConfig`, it gets a default, `Config::save` writes it into the generated `config.toml`, and `src/core/README.md` documents it. Nothing reads it.

I found this with a 1.9 GB `history.db` (3.4M `commands` rows, 3.2M `parse_failures`) and no way to shrink the window.

## Fix

`Tracker` resolves the window once at construction and stores it on the struct. `cleanup_old` reads that field.

`Config::load()` stays out of `cleanup_old` deliberately: it runs on every `record()` and `record_parse_failure()`, so loading the config there would put a file read in the per-command path.

A non-positive value falls back to the default rather than being honored. A typo'd `history_days = 0` would otherwise delete the whole history on the next write. That fallback also covers an unparseable config, including a `[tracking]` section that omits `history_days`, since the field has no serde default and a partial section fails the whole parse.

## Tests

`test_resolve_history_days` covers the clamping. Two `cleanup_old` tests assert both directions against a backdated row: pruned at a 3 day window, retained at 30.

Both directions are needed. A hardcoded 90 still passes "retained within window", so only "pruned beyond window" catches the regression. I checked by reverting the cutoff line on its own, and that test fails (`left: 1, right: 0`) while its sibling stays green.

That asymmetry is probably why the bug lasted. Every existing config test uses the default value, and a dead knob is invisible to any test that never sets it to something else.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, and `cargo test --bin rtk core::tracking` are clean on this branch.

`cargo test --all` fails two tests, `unattestable_passthrough::test_plain_command_still_rewrites` and `test_fd_dup_redirect_still_rewrites`. They fail the same way on unmodified `develop` (checked in a detached worktree at `3044911`), so they're unrelated to this change. They read the host's real `settings.json`, which is why the result depends on the machine.

End to end on a copy of the real database, with `history_days = 30`: 3,087,798 rows older than the window pruned on the next write, 3,369,148 `commands` down to 280,984.

## Second commit: return the pruned space

Fixing the setting on its own doesn't shrink anything. There's no `auto_vacuum` on these databases, so a delete only marks pages reusable. Dropping 90 to 30 pruned 3.09M rows and left the file at 1.9 GB with 445,466 free pages, which makes the setting look broken even once it works.

So `cleanup_old` now counts what it deleted and, when anything went, vacuums if enough of the file is free pages.

`VACUUM` can't run unconditionally here. `cleanup_old` fires once per tracked command, and `VACUUM` rewrites the whole database under an exclusive lock, which would blow the startup budget and stall concurrent rtk processes sharing the DB. The free-page ratio gate keeps it dormant in steady state, where inserts reuse freed pages, and lets it fire on the bulk deletes that strand space. Thresholds are 4096 free pages (~16 MB at the default page size) and 25% of the file, both named constants.

Measured on a 196 MB database:

| | pages | freelist | size |
|---|---|---|---|
| 20 consecutive tracked commands | 50,067 unchanged | 1 to 4 | 196 MB |
| after injecting 300k out-of-window rows | 81,797 | 0 | 320 MB |
| next tracked command | 50,053 | 0 | 196 MB |

The gate stays shut across normal use and opens on the bulk prune. `quick_check` ok afterward.

`VACUUM` failure is ignored, same as the existing WAL pragma. It needs scratch space near the size of the live data and can't run inside a transaction, and neither is a reason to fail someone's command.

If you'd rather keep this PR to the config fix alone, say so and I'll split the second commit out.
