### PR TITLE
Make the bundled SQLite an opt-out default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 colored = "3"
 dirs = "5"
-rusqlite = { version = "0.31", features = ["bundled"] }
+rusqlite = { version = "0.31" }
 toml = "0.8"
 chrono = "0.4"
 tempfile = "3"
@@ -33,6 +33,14 @@ flate2 = "1.0"
 quick-xml = "0.37"
 which = "8"
 automod = "1"
+
+[features]
+default = ["bundled-sqlite"]
+# Compile and statically link SQLite from the copy vendored in
+# libsqlite3-sys. Distribution packages build with
+# --no-default-features so the binary links the system SQLite and is
+# covered by the distribution's SQLite security updates.
+bundled-sqlite = ["rusqlite/bundled"]
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"


### PR DESCRIPTION
Packaging rtk for openSUSE, and this is the one change I cannot make cleanly downstream.

`rusqlite = { version = "0.31", features = ["bundled"] }` statically links a private copy of SQLite into the binary. For the prebuilt binaries the installer ships that is exactly right — zero dependencies is a feature. For a distribution package it is a blocker: a bundled SQLite has to be tracked and rebuilt separately for every SQLite CVE, and most distribution policies (openSUSE, Fedora, Debian) forbid shipping bundled libraries at all.

This PR moves it behind a feature that is **on by default**:

```toml
[features]
default = ["bundled-sqlite"]
bundled-sqlite = ["rusqlite/bundled"]
```

Nothing changes for `cargo build`, `cargo install`, `cargo generate-rpm` or `.github/workflows/release.yml` — the default feature set still bundles. A packager builds with `--no-default-features` and gets a binary that links the system `libsqlite3` and inherits the distribution SQLite updates.

Verified on openSUSE Tumbleweed (aarch64): built against the system SQLite, full test suite green (2584 passed / 0 failed), and the resulting binary resolves `libsqlite3.so.0` from `/lib64`.

Without this I have to carry a downstream patch that deletes the `bundled` feature outright, which has to be rebased on every release. Happy to rename the feature or adjust the wording if you prefer something else.