### PR TITLE
Enforce -Dwarnings in CI instead of in the manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
     name: clippy
     needs: fmt
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -Dwarnings
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -58,6 +60,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+    env:
+      RUSTFLAGS: -Dwarnings
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,4 +68,3 @@ assets = [
 
 [lints.rust]
 unsafe_code = "deny"
-warnings = "deny"


### PR DESCRIPTION
Second of two packaging papercuts found while packaging rtk for openSUSE (the other is #3446).

`[lints.rust] warnings = "deny"` applies to *every* build of rtk, not just the ones CI runs. CI pins its toolchain with `dtolnay/rust-toolchain@stable`; distributions do not — openSUSE Tumbleweed is on rustc 1.97 against a `rust-version = "1.91"` floor. Every rustc release adds or widens lints, so the first one that touches rtk turns a warning nobody has seen yet into a hard build failure for every downstream consumer simultaneously, and the only escape is patching Cargo.toml.

This moves the enforcement to where it belongs:

- drop `warnings = "deny"` from `[lints.rust]`
- set `RUSTFLAGS: -Dwarnings` on the `clippy` and `test` jobs in `ci.yml`

CI fails on warnings exactly as it does today — and now covers dependency builds too, which the manifest lint did not. A newer toolchain outside CI degrades to a warning that can be fixed on your normal schedule rather than breaking the build.

`unsafe_code = "deny"` stays in the manifest: that is a deliberate design constraint of the crate, not lint drift.

Happy to put the env at workflow level instead if you would rather have it apply to every job — I kept it to the two that compile so the "Clippy security lints" step, which greps its own output for `warning:`, keeps behaving as written.