### PR TITLE
fix(hook): return revised input from Pi tool_call handler

### DIFF
--- a/hooks/pi/README.md
+++ b/hooks/pi/README.md
@@ -16,7 +16,7 @@ with other Pi extensions.
 
 - TypeScript extension using Pi's `ExtensionAPI` (not a shell hook, no `zx` dependency)
 - Subscribes to `tool_call` event, narrows to `bash` tool via `isToolCallEventType`
-- Calls `rtk rewrite` via `pi.exec`; mutates `event.input.command` in-place if rewrite differs
+- Calls `rtk rewrite` via `pi.exec`; returns a revised `{ input }` (not an in-place mutation of `event.input`) when the rewrite differs, per `ToolCallEventResult`
 - All error paths return `undefined` (pass through); RTK never blocks execution
 - Version guard at load time: checks `rtk >= 0.23.0`; warns and registers no-op if too old or missing
 - Installed to `.pi/extensions/rtk.ts` by `rtk init --agent pi` (project-local) or `~/.pi/agent/extensions/rtk.ts` by `rtk init --agent pi --global`

--- a/hooks/pi/rtk.ts
+++ b/hooks/pi/rtk.ts
@@ -6,9 +6,9 @@
 // To add or change rewrite rules, edit the Rust registry — not this file.
 //
 // Exit code contract for `rtk rewrite`:
-//   0 + stdout  Rewrite found → mutate command
+//   0 + stdout  Rewrite found → revised command returned to the caller
 //   1           No RTK equivalent → pass through unchanged
-//   3 + stdout  Rewrite (advisory) → mutate command
+//   3 + stdout  Rewrite (advisory) → revised command returned to the caller
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 import { isToolCallEventType } from "@earendil-works/pi-coding-agent"
@@ -68,9 +68,14 @@ export default async function (pi: ExtensionAPI) {
 
       // Delegate to RTK.
       const rewritten = await rewriteCommand(pi, cmd, ctx.signal)
-      if (rewritten && rewritten !== cmd) {
-        event.input.command = rewritten
-      }
+      if (!rewritten || rewritten === cmd) return
+
+      // The Pi/OMP dispatcher builds the args a tool actually executes with
+      // from a separate copy of `event.input`; it only substitutes a handler's
+      // RETURNED `{ input }` (see ToolCallEventResult), so mutating
+      // `event.input.command` here has no effect on execution — it silently
+      // rewrites a value nothing reads.
+      return { input: { ...event.input, command: rewritten } }
     } catch (err) {
       // Fail open: never block execution on an unexpected error.
       console.warn("[rtk] unexpected error in tool_call handler; passing through command", err)

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -7169,6 +7169,25 @@ mod tests {
     }
 
     #[test]
+    fn test_pi_plugin_returns_revised_input_instead_of_mutating_in_place() {
+        // Regression test: the Pi/OMP `tool_call` dispatcher builds the args a
+        // tool actually executes with from a separate copy of `event.input`;
+        // it only substitutes a handler's RETURNED `{ input }`. A handler that
+        // mutates `event.input.command` and returns nothing silently rewrites
+        // a value nothing reads, so the bash command never actually changes.
+        assert!(
+            PI_PLUGIN.contains("return { input:"),
+            "tool_call handler must return the revised input (ToolCallEventResult), \
+             not just mutate event.input in place"
+        );
+        assert!(
+            !PI_PLUGIN.contains("event.input.command = rewritten"),
+            "tool_call handler must not rely on mutating event.input in place; \
+             the dispatcher never observes it"
+        );
+    }
+
+    #[test]
     fn test_run_pi_mode_local_installs_plugin() {
         let tmp = TempDir::new().unwrap();
         let _cwd_guard = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());


### PR DESCRIPTION
## Summary

- Fixes the merged Pi extension (`hooks/pi/rtk.ts`, #1741, released in rtk 0.42) so `rtk rewrite` results actually take effect — today the extension never rewrites a single command.
- Root cause: the Pi/OMP `tool_call` dispatcher builds the args a tool actually executes with from a separate copy of `event.input`; it only substitutes a handler's **returned** `{ input }` (`ToolCallEventResult`). The handler mutated `event.input.command` in place and returned nothing, so the rewrite was silently discarded on every call.
- Fix: `return { input: { ...event.input, command: rewritten } }` instead of mutating, preserving the other `BashToolInput` fields via spread.
- Updates `hooks/pi/README.md`'s "Specifics" section, which documented the broken mutate-in-place mechanism as the intended design.
- Adds a regression test (`test_pi_plugin_returns_revised_input_instead_of_mutating_in_place`) asserting the shipped plugin source returns the revision and does not rely on mutating `event.input` in place.

## Why this matters

This is the same file discussed in the [Oh My Pi integration](https://github.com/can1357/oh-my-pi) and [rtk#591](https://github.com/rtk-ai/rtk/issues/591). That integration's review discussion assumed "mutate `event.input.command`" was a working mechanism. It isn't in the affected OMP runtime, per its `ExtensionAPI` behavior and confirmed empirically: after applying this exact fix locally and running a real `omp -p --auto-approve "git status"` session, `rtk`'s own `history.db` recorded `git status → rtk git status`; before the fix, nothing was ever rewritten despite the extension loading and probing successfully.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test` (2563 passed, 0 failed, incl. new regression test)
- [x] `bun --eval 'await import("./hooks/pi/rtk.ts")'`
- [x] Manual end-to-end: built a fresh `omp` session (Oh My Pi, the extension consumer for #591), installed this exact fixed source as its `tool_call` handler, ran `git status` through the agent's bash tool. `rtk`'s local history.db recorded the command as `original_cmd: git status`, `rtk_cmd: rtk git status` — confirming the **executed** shell command was rewritten, not just displayed.

Related: #401, #591, #1741