### PR TITLE
fix(hooks): stop unit tests reading the developer's config.toml

### DIFF
--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -231,22 +231,46 @@ fn heal_legacy_hook_file(path: &std::path::Path) -> bool {
         .is_ok()
 }
 
-fn get_rewritten(cmd: &str) -> Option<String> {
+/// Rewrite `cmd` using caller-supplied hook exclusions.
+///
+/// Kept free of file I/O so unit tests can exercise the decision path without
+/// reading the developer's `config.toml` — mirrors `check_command_with_rules`.
+fn get_rewritten_with(
+    cmd: &str,
+    excluded: &[String],
+    transparent_prefixes: &[String],
+) -> Option<String> {
     if has_heredoc(cmd) {
         return None;
     }
 
-    let (excluded, transparent_prefixes) = crate::core::config::Config::load()
-        .map(|c| (c.hooks.exclude_commands, c.hooks.transparent_prefixes))
-        .unwrap_or_default();
-
-    let rewritten = rewrite_command(cmd, &excluded, &transparent_prefixes)?;
+    let rewritten = rewrite_command(cmd, excluded, transparent_prefixes)?;
 
     if rewritten == cmd {
         return None;
     }
 
     Some(rewritten)
+}
+
+/// The user's `[hooks]` exclusions and transparent prefixes.
+#[cfg(not(test))]
+fn hook_exclusions() -> (Vec<String>, Vec<String>) {
+    crate::core::config::Config::load()
+        .map(|c| (c.hooks.exclude_commands, c.hooks.transparent_prefixes))
+        .unwrap_or_default()
+}
+
+/// Unit tests never read the developer's `config.toml`.
+///
+/// Reading it made `cargo test` environment-dependent: on a machine with
+/// `[hooks] exclude_commands = ["git", ...]`, 23 of the 108 tests in this module
+/// failed, because commands the tests expect to be rewritten were excluded. CI
+/// stayed green only because CI has no user config. Tests that need exclusions
+/// pass them explicitly via the `*_with` entry points.
+#[cfg(test)]
+fn hook_exclusions() -> (Vec<String>, Vec<String>) {
+    (Vec::new(), Vec::new())
 }
 
 enum HookDecision {
@@ -256,18 +280,30 @@ enum HookDecision {
     Deny,
 }
 
-fn decide_from_verdict(cmd: &str, verdict: PermissionVerdict) -> HookDecision {
+/// Decide using caller-supplied hook exclusions. File-I/O-free; see
+/// `get_rewritten_with`.
+fn decide_from_verdict_with(
+    cmd: &str,
+    verdict: PermissionVerdict,
+    excluded: &[String],
+    transparent_prefixes: &[String],
+) -> HookDecision {
     if verdict == PermissionVerdict::Deny {
         return HookDecision::Deny;
     }
     if crate::discover::lexer::contains_unattestable_construct(cmd) {
         return HookDecision::Defer;
     }
-    match get_rewritten(cmd) {
+    match get_rewritten_with(cmd, excluded, transparent_prefixes) {
         Some(r) if verdict == PermissionVerdict::Allow => HookDecision::AllowRewrite(r),
         Some(r) => HookDecision::AskRewrite(r),
         None => HookDecision::Defer,
     }
+}
+
+fn decide_from_verdict(cmd: &str, verdict: PermissionVerdict) -> HookDecision {
+    let (excluded, transparent_prefixes) = hook_exclusions();
+    decide_from_verdict_with(cmd, verdict, &excluded, &transparent_prefixes)
 }
 
 fn decide_hook_action(cmd: &str, host: permissions::Host) -> HookDecision {
@@ -896,6 +932,13 @@ fn run_droid_inner_with_rules(
 mod tests {
     use super::*;
 
+    /// Rewrite with no exclusions. Tests must not inherit the developer's
+    /// `config.toml`; exclusion behavior is covered explicitly by the
+    /// `rewrite_command_no_prefixes` tests below.
+    fn get_rewritten(cmd: &str) -> Option<String> {
+        get_rewritten_with(cmd, &[], &[])
+    }
+
     fn rewrite_command_no_prefixes(cmd: &str, excluded: &[String]) -> Option<String> {
         crate::discover::registry::rewrite_command(cmd, excluded, &[])
     }
@@ -1011,6 +1054,15 @@ mod tests {
     #[test]
     fn test_get_rewritten_supported() {
         assert!(get_rewritten("git status").is_some());
+    }
+
+    /// The rest of this module deliberately runs with no exclusions, so pin the
+    /// production behavior here: a configured `[hooks] exclude_commands` entry
+    /// must still suppress the rewrite.
+    #[test]
+    fn test_get_rewritten_with_honors_exclusions() {
+        assert!(get_rewritten_with("git status", &[], &[]).is_some());
+        assert!(get_rewritten_with("git status", &["git".to_string()], &[]).is_none());
     }
 
     #[test]
@@ -1784,7 +1836,8 @@ mod tests {
         allow: &[String],
     ) -> HookDecision {
         let verdict = permissions::check_command_with_rules(cmd, deny, ask, allow);
-        decide_from_verdict(cmd, verdict)
+        // No exclusions: tests must not inherit the developer's config.toml.
+        decide_from_verdict_with(cmd, verdict, &[], &[])
     }
 
     fn all_allowed() -> Vec<String> {

--- a/src/hooks/rewrite_cmd.rs
+++ b/src/hooks/rewrite_cmd.rs
@@ -44,9 +44,16 @@ enum RewriteOutcome {
     Ask(String),
 }
 
-fn evaluate(cmd: &str, excluded: &[String], transparent_prefixes: &[String]) -> RewriteOutcome {
-    let verdict = check_command(cmd);
-
+/// Evaluate with a caller-supplied verdict.
+///
+/// Kept free of file I/O so unit tests can exercise the rewrite path without
+/// reading the host's permission settings — mirrors `check_command_with_rules`.
+fn evaluate_with_verdict(
+    cmd: &str,
+    verdict: PermissionVerdict,
+    excluded: &[String],
+    transparent_prefixes: &[String],
+) -> RewriteOutcome {
     if verdict == PermissionVerdict::Deny {
         return RewriteOutcome::Deny;
     }
@@ -62,6 +69,11 @@ fn evaluate(cmd: &str, excluded: &[String], transparent_prefixes: &[String]) -> 
         },
         None => RewriteOutcome::Passthrough,
     }
+}
+
+/// Load the host's permission verdict for `cmd`, then evaluate.
+fn evaluate(cmd: &str, excluded: &[String], transparent_prefixes: &[String]) -> RewriteOutcome {
+    evaluate_with_verdict(cmd, check_command(cmd), excluded, transparent_prefixes)
 }
 
 #[cfg(test)]
@@ -91,7 +103,25 @@ mod tests {
     }
 
     mod unattestable_passthrough {
-        use super::super::{evaluate, RewriteOutcome};
+        use super::super::{evaluate_with_verdict, PermissionVerdict, RewriteOutcome};
+
+        /// Evaluate with the default verdict and no exclusions.
+        ///
+        /// The real `evaluate` reads the host's permission settings
+        /// (`~/.claude/settings.json`), so these tests failed on any machine with
+        /// a matching deny rule while passing in CI, which has none.
+        fn evaluate(
+            cmd: &str,
+            excluded: &[String],
+            transparent_prefixes: &[String],
+        ) -> RewriteOutcome {
+            evaluate_with_verdict(
+                cmd,
+                PermissionVerdict::Default,
+                excluded,
+                transparent_prefixes,
+            )
+        }
 
         #[test]
         fn test_backtick_substitution_passthrough() {


### PR DESCRIPTION
## Problem

`cargo test` is **red for contributors who use rtk and green in CI**, which is why this hasn't
surfaced upstream. Two places in the hook decision path do file I/O, so unit tests inherit the
contributor's machine configuration.

**1. `get_rewritten` calls `Config::load()`** — reads `$CONFIG_DIR/rtk/config.toml`. With a
configured

```toml
[hooks]
exclude_commands = ["git", "ls", "grep", ...]
```

commands the tests expect to be rewritten are excluded, `get_rewritten` returns `None`, and the
decision comes back `Defer`. `test_claude_rewrite_git_status` — which asserts `git status` →
`rtk git status` — fails, along with 22 others spanning every host handler (claude, cursor,
gemini, droid, vibe, copilot), since they all funnel through `decide_from_verdict`.

**2. `evaluate` calls `check_command`** — reads `~/.claude/settings.json` and
`$PROJECT_ROOT/.claude/settings.json`. The `unattestable_passthrough` tests pass explicit empty
exclusions but still inherit that ambient verdict, so with a matching deny rule the outcome is
`Deny` instead of `Ask` and 2 more tests fail.

Excluding `git` is a reasonable real-world config — it's what you'd set to keep exact `git`
output for a coding agent — so this is not an exotic setup.

### Measured

Pristine checkout of `develop`, no source changes, only the config file moved aside:

| condition | `hooks::hook_cmd` |
|---|---|
| `config.toml` present with `[hooks] exclude_commands` | **23 of 108 fail** |
| same file moved aside | **108 pass, 0 fail** |

## Fix

Split file I/O out of the decision path, mirroring the convention `permissions` already
established with `check_command_with_rules` — whose doc comment reads *"Internal implementation
allowing tests to inject rules without file I/O."* The seam existed; these paths just didn't
use it.

| commit | change |
|---|---|
| `stop unit tests reading the developer's config.toml` | `get_rewritten_with` / `decide_from_verdict_with` take exclusions as parameters; `hook_exclusions()` becomes the single loader and is `#[cfg(test)]`-stubbed to empty so no test path reaches the filesystem. |
| `stop rewrite tests reading the host's permission settings` | `evaluate_with_verdict` takes the verdict as a parameter; `evaluate` loads it and delegates; the test module supplies `PermissionVerdict::Default`. |

**Production behavior is unchanged** in both cases — the loading wrappers still load. The only
behavioral difference is inside `#[cfg(test)]`.

Added `test_get_rewritten_with_honors_exclusions` so the exclusion behavior the other tests now
bypass stays pinned rather than silently untested.

## Verification

Run **with a populated `config.toml` and `settings.json` in place** — the condition that used to
fail:

- unit test binary: **25 failures → 0** (2571 passed, 8 ignored)
- `cargo clippy --release --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

## Note for maintainers

Two related issues found while investigating, **not** addressed here:

1. `tests/copilot_selfheal_test.rs` (added in #3449) fails **10 of 12 on a pristine `develop`
   checkout** on a machine with existing Copilot hook config — same class of ambient-state
   dependency, in brand-new code. Happy to extend this PR to cover it if you'd like.
2. `core::tracking` tests are flaky under full-suite parallelism — they share one real SQLite
   tracking DB. They pass 14/14 in isolation, both parallel and single-threaded.
