### PR TITLE
fix(rewrite): preserve quoted assignment data

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -5684,6 +5684,45 @@ mod tests {
     }
 
     #[test]
+    fn test_rewrite_compound_preserves_double_quoted_prose_assignment() {
+        let command =
+            r#"T="chore(skills): make every Pocock skill model-invocable"; echo "len=${#T}""#;
+
+        assert_eq!(rewrite_command_no_prefixes(command, &[]), None);
+    }
+
+    #[test]
+    fn test_rewrite_compound_preserves_single_quoted_prose_assignment() {
+        let command = r#"T='please make a cake'; printf '%s' "$T""#;
+
+        assert_eq!(rewrite_command_no_prefixes(command, &[]), None);
+    }
+
+    #[test]
+    fn test_rewrite_single_preserves_inline_title_prose() {
+        let command =
+            r#"gh pr edit 1476 --title "chore(skills): make every Pocock skill model-invocable""#;
+
+        assert_eq!(
+            rewrite_command_no_prefixes(command, &[]),
+            Some(
+                r#"rtk gh pr edit 1476 --title "chore(skills): make every Pocock skill model-invocable""#
+                    .into()
+            )
+        );
+    }
+
+    #[test]
+    fn test_rewrite_compound_preserves_title_before_gh_edit() {
+        let command = r#"T="chore(skills): make every Pocock skill model-invocable"; echo "len=${#T}"; [ ${#T} -le 100 ] && gh pr edit 1476 --title "$T""#;
+
+        assert_eq!(
+            rewrite_command_no_prefixes(command, &[]),
+            Some(r#"T="chore(skills): make every Pocock skill model-invocable"; echo "len=${#T}"; [ ${#T} -le 100 ] && rtk gh pr edit 1476 --title "$T""#.into())
+        );
+    }
+
+    #[test]
     fn test_rewrite_compound_pipe_raw_filter() {
         // Producers stay raw; only a pipeline-safe final stage is rewritten.
         assert_eq!(

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -63,8 +63,11 @@ static COMPILED: LazyLock<Vec<Regex>> = LazyLock::new(|| {
 static ENV_PREFIX: LazyLock<Regex> = LazyLock::new(|| {
     let double_quoted = r#""(?:[^"\\]|\\.)*""#;
     let single_quoted = r#"'(?:[^'\\]|\\.)*'"#;
-    let unquoted = r#"[^\s]*"#;
-    let env_value = format!("(?:{}|{}|{})", double_quoted, single_quoted, unquoted);
+    // Quotes must be handled by the complete quoted alternatives above.
+    // Otherwise regex backtracking can reinterpret a quoted assignment as a
+    // partial unquoted value and expose literal data as a command (#3262).
+    let unquoted = r#"[^\s'"]+"#;
+    let env_value = format!("(?:{}|{}|{})*", double_quoted, single_quoted, unquoted);
     let env_assign = format!(r#"[A-Z_][A-Z0-9_]*={}"#, env_value);
     // NOTE: `sudo` is intentionally NOT stripped here. Rewriting `sudo docker ps`
     // to `sudo rtk docker ps` breaks at runtime because `rtk` is not on root's
@@ -3694,6 +3697,14 @@ mod tests {
     }
 
     #[test]
+    fn test_rewrite_env_concatenated_quoted_and_unquoted_value() {
+        assert_eq!(
+            rewrite_command_no_prefixes("FOO='bar baz'qux git status", &[]),
+            Some("FOO='bar baz'qux rtk git status".into())
+        );
+    }
+
+    #[test]
     fn test_classify_env_quoted_value_stripped() {
         assert_eq!(
             classify_command(r#"GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no" git push"#),
@@ -5642,6 +5653,33 @@ mod tests {
         assert_eq!(
             rewrite_command_no_prefixes("git status; cargo test", &[]),
             Some("rtk git status; rtk cargo test".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_compound_preserves_quoted_assignment_data() {
+        let command = r#"D='# shellcheck disable=SC2034  # comment'; for f in hooks/*.sh; do sed -i '' -e "s|^TS_BACKUP=|${D}\nTS_BACKUP=|" "$f"; done"#;
+
+        assert_eq!(rewrite_command_no_prefixes(command, &[]), None);
+    }
+
+    #[test]
+    fn test_rewrite_compound_only_rewrites_commands_outside_assignment_quotes() {
+        let command = "D='# shellcheck | git status; $(whoami)' ; cargo test";
+
+        assert_eq!(
+            rewrite_command_no_prefixes(command, &[]),
+            Some("D='# shellcheck | git status; $(whoami)'; rtk cargo test".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_compound_preserves_double_quoted_assignment_data() {
+        let command = r#"D="run shellcheck later"; git status"#;
+
+        assert_eq!(
+            rewrite_command_no_prefixes(command, &[]),
+            Some(r#"D="run shellcheck later"; rtk git status"#.into())
         );
     }
 

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -5699,6 +5699,30 @@ mod tests {
     }
 
     #[test]
+    fn test_rewrite_compound_preserves_quoted_git_diff_with_argument() {
+        let command = "X='git diff --stat'; cargo test";
+
+        assert_eq!(
+            rewrite_command_no_prefixes(command, &[]),
+            Some("X='git diff --stat'; rtk cargo test".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_compound_preserves_embedded_quoted_git_diff() {
+        let command = "X='a git diff --stat b'; echo hi";
+
+        assert_eq!(rewrite_command_no_prefixes(command, &[]), None);
+    }
+
+    #[test]
+    fn test_rewrite_compound_preserves_bare_quoted_git_diff() {
+        let command = "X='git diff'; echo hi";
+
+        assert_eq!(rewrite_command_no_prefixes(command, &[]), None);
+    }
+
+    #[test]
     fn test_rewrite_single_preserves_inline_title_prose() {
         let command =
             r#"gh pr edit 1476 --title "chore(skills): make every Pocock skill model-invocable""#;


### PR DESCRIPTION
## Summary

- prevent the environment-prefix regex from backtracking into quoted assignment values and exposing literal data as a command
- preserve valid shell values composed from quoted and unquoted fragments
- add regressions for the original `shellcheck` corruption and the latest reported single-/double-quoted PR-title and prose cases
- rebase the branch onto current `develop`

## Root cause

The lexer kept quote boundaries and byte offsets correctly. The corruption happened later in `ENV_PREFIX`: when a complete quoted assignment did not satisfy the trailing-whitespace requirement at a compound-command boundary, the regex could fall back to the broad unquoted alternative and match only the start of the assignment. The remaining literal text then looked like a command and was rewritten.

The unquoted fragment now excludes quote characters, while the environment value accepts a sequence of complete quoted or unquoted fragments. This prevents partial reinterpretation without regressing valid forms such as `FOO='bar baz'qux git status`.

This is independent of #3202's case-terminator lexer fix.

## Security behavior

The original #3262 payload now passes through unchanged. A supported command outside the quoted assignment is still rewritten:

```text
D='# shellcheck | git status; $(whoami)' ; cargo test
  -> D='# shellcheck | git status; $(whoami)'; rtk cargo test
```

The latest reported shapes are covered too:

- `T="... make ..."; echo "len=${#T}"` preserves the double-quoted value
- `T='please make a cake'; printf '%s' "$T"` preserves the single-quoted value
- the longer `T=...; echo ...; [ ... ] && gh pr edit ... --title "$T"` form preserves `T` while rewriting only the external `gh` command
- a simple `gh pr edit --title "... make ..."` still takes the normal rewrite path and preserves its title bytes

## Test plan

- `cargo fmt --all`
- `cargo clippy --all-targets`
- `cargo test --all`: 2583 passed, 0 failed, 8 ignored; all integration suites passed
- targeted regressions for the four latest reported command shapes

Closes #3262