### PR TITLE
docs: fix Cursor init flag and document Windows paths

### DIFF
--- a/docs/guide/analytics/gain.md
+++ b/docs/guide/analytics/gain.md
@@ -122,7 +122,10 @@ Savings %     = (Saved / Input) × 100
 
 Savings data is stored locally in SQLite:
 
-- **Location**: `~/.local/share/rtk/history.db` (Linux / macOS)
+- **Location**:
+  - Linux: `~/.local/share/rtk/history.db`
+  - macOS: `~/Library/Application Support/rtk/history.db`
+  - Windows: `%LOCALAPPDATA%\rtk\history.db` (e.g. `C:\Users\<you>\AppData\Local\rtk\history.db`)
 - **Retention**: 90 days (automatic cleanup)
 - **Scope**: Global across all projects and Claude sessions
 

--- a/docs/guide/getting-started/configuration.md
+++ b/docs/guide/getting-started/configuration.md
@@ -13,6 +13,7 @@ sidebar:
 |----------|------|
 | Linux | `~/.config/rtk/config.toml` |
 | macOS | `~/Library/Application Support/rtk/config.toml` |
+| Windows | `%APPDATA%\rtk\config.toml` (e.g. `C:\Users\<you>\AppData\Roaming\rtk\config.toml`) |
 
 ```bash
 rtk config            # show current configuration

--- a/docs/guide/resources/troubleshooting.md
+++ b/docs/guide/resources/troubleshooting.md
@@ -45,9 +45,9 @@ rtk gain    # should now show token savings stats
 
 2. Initialize the hook:
    ```bash
-   rtk init --global    # Claude Code
-   rtk init --global --cursor    # Cursor
-   rtk init --global --opencode  # OpenCode
+   rtk init --global              # Claude Code
+   rtk init --global --agent cursor  # Cursor (no bare --cursor flag)
+   rtk init --global --opencode   # OpenCode
    ```
 
 3. Restart your AI assistant.


### PR DESCRIPTION
## Summary
Fixes documentation gaps from #3429 (docs items only):

1. 	roubleshooting.md: 
tk init --global --cursor does not exist — use --agent cursor (consistent with supported-agents docs).
2. configuration.md: add Windows config path %APPDATA%\rtk\config.toml.
3. gain.md: document Windows/macOS/Linux history.db locations.

## Notes
- RuboCop autocorrect alias / struct field fix from #3429 left for a separate code PR.
- Docs-only.

Fixes #3429
