### PR TITLE
feat(cli): add sort passthrough wrapper

### DIFF
--- a/src/cmds/system/README.md
+++ b/src/cmds/system/README.md
@@ -8,6 +8,7 @@
 - `search.rs` backs both `rtk grep` and `rtk rg`: it runs the invoked engine (never substituting one for the other) and groups its output, reading `core/config` for `limits.grep_max_results` and `limits.grep_max_per_file`. Format-altering flags (`-c`, `-l`, `-L`, `-o`, `-Z`) bypass RTK filtering and run raw.
 - `local_llm.rs` (`rtk smart`) uses `core/filter` for heuristic file summarization
 - `format_cmd.rs` is a cross-ecosystem dispatcher: auto-detects and routes to `prettier_cmd` or `ruff_cmd` (black is handled inline, not as a separate module)
+- `rtk sort` passes arguments, stdin, stdout, and stderr directly to the native `sort` command
 
 ## Cross-command
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -418,6 +418,13 @@ enum Commands {
         args: Vec<String>,
     },
 
+    /// Sort lines using the native sort command
+    Sort {
+        /// Arguments passed to sort
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<OsString>,
+    },
+
     /// Show token savings summary and history
     Gain {
         /// Filter statistics to current project (current working directory) // added
@@ -2139,6 +2146,8 @@ fn run_cli() -> Result<i32> {
 
         Commands::Wc { args } => wc_cmd::run(&args, cli.verbose)?,
 
+        Commands::Sort { args } => core::runner::run_passthrough("sort", &args, cli.verbose)?,
+
         Commands::Gain {
             project, // added
             graph,
@@ -2757,6 +2766,7 @@ fn is_operational_command(cmd: &Commands) -> bool {
             | Commands::Grep { .. }
             | Commands::Rg { .. }
             | Commands::Wget { .. }
+            | Commands::Sort { .. }
             | Commands::Vitest { .. }
             | Commands::Prisma { .. }
             | Commands::Tsc { .. }
@@ -3049,6 +3059,15 @@ mod tests {
     }
 
     #[test]
+    fn test_try_parse_sort_args() {
+        let cli = Cli::try_parse_from(["rtk", "sort", "-u", "names.txt"]).unwrap();
+        match cli.command {
+            Commands::Sort { args } => assert_eq!(args, ["-u", "names.txt"]),
+            _ => panic!("Expected Commands::Sort"),
+        }
+    }
+
+    #[test]
     fn test_try_parse_git_with_dash_c_succeeds() {
         let result = Cli::try_parse_from(["rtk", "git", "-C", "/path", "status"]);
         assert!(
@@ -3138,6 +3157,7 @@ mod tests {
             "grep",
             "wget",
             "wc",
+            "sort",
             "jest",
             "vitest",
             "prisma",


### PR DESCRIPTION
## Summary

- Add a recognized `rtk sort` subcommand that delegates arguments and standard streams to native `sort`.
- Avoid the Clap parse failure and generic fallback round trip for `rtk sort` invocations.
- Fixes #3491.

## Test plan

- [x] `cargo fmt --all --check && cargo clippy --all-targets && cargo test`
- [x] Manual testing: piped duplicate lines through `target/debug/rtk sort -u` and verified sorted, unique output; verified native invalid-option exit code propagation.

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
