### PR TITLE
fix(aws): accept bare version flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -195,6 +195,7 @@ enum Commands {
     /// AWS CLI with compact output (force JSON, compress)
     Aws {
         /// AWS service subcommand (e.g., sts, s3, ec2, ecs, rds, cloudformation)
+        #[arg(allow_hyphen_values = true)]
         subcommand: String,
         /// Additional arguments
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
@@ -3062,6 +3063,20 @@ mod tests {
                 }
                 _ => panic!("Expected Git command"),
             }
+        }
+    }
+
+    #[test]
+    fn test_try_parse_aws_version_as_subcommand() {
+        let cli = Cli::try_parse_from(["rtk", "aws", "--version"])
+            .expect("aws --version should be forwarded to the AWS CLI");
+
+        match cli.command {
+            Commands::Aws { subcommand, args } => {
+                assert_eq!(subcommand, "--version");
+                assert!(args.is_empty());
+            }
+            _ => panic!("Expected Aws command"),
         }
     }
 


### PR DESCRIPTION
## Summary

- Accept a hyphen-prefixed first argument for `rtk aws`, so bare AWS global flags such as `--version` reach the native AWS CLI instead of failing in RTK's Clap parser.
- Add a parser regression that verifies `--version` is preserved as the AWS subcommand with no extra arguments.
- OpenAI Codex (GPT-5) assisted with reproducing the parse failure, implementing the focused change/test, and running and reviewing the validation below. I reviewed the final one-file diff and test results.

Fixes #3493.

## Root cause and scope

The trailing AWS arguments already allowed hyphen-prefixed values, but the required first `subcommand: String` did not. Clap therefore interpreted `--version` as an unknown RTK option and stopped before `aws_cmd::run()` could forward it.

This change applies the existing `allow_hyphen_values` behavior to that first positional value. The existing generic AWS path then executes `aws --version` without injecting an output format. No AWS output filter, service-specific route, other RTK command, or documented behavior is changed.

## Test plan

- [x] Regression proven red on unmodified `develop`: `cargo test test_try_parse_aws_version_as_subcommand` failed with `UnknownArgument("--version")`.
- [x] Focused green: the same command passes after the change.
- [x] `cargo fmt --all -- --check`.
- [x] `cargo clippy --all-targets -- -D warnings`.
- [x] `cargo test --all -- --skip unwritable_hooks_dir_never_breaks_the_hook`: 2,579 unit tests and all remaining integration tests passed. The excluded permissions test is invalid under a root container because root can write through an unwritable directory.
- [x] Re-ran the complete `copilot_selfheal_test` binary as unprivileged UID 65534: 13 passed, including `unwritable_hooks_dir_never_breaks_the_hook`.
- [x] Manual end-to-end check: put a controlled `aws` executable on `PATH` that accepts only `--version`; `target/debug/rtk aws --version` printed `aws-cli/2.31.0 test` and exited 0.
- [x] `git diff --check`.

> **Important:** This PR targets `develop`.
