### PR TITLE
fix: use line.len() - pos fallback in prisma migration slice

### DIFF
--- a/src/cmds/js/prisma_cmd.rs
+++ b/src/cmds/js/prisma_cmd.rs
@@ -316,7 +316,7 @@ fn filter_migrate_status(output: &str) -> String {
             applied_count += 1;
             if latest_migration.is_empty() && line.contains("202") {
                 if let Some(pos) = line.find("202") {
-                    let end = line[pos..].find(|c: char| c.is_whitespace()).unwrap_or(20);
+                    let end = line[pos..].find(|c: char| c.is_whitespace()).unwrap_or(line.len() - pos);
                     latest_migration = line[pos..pos + end].to_string();
                 }
             }


### PR DESCRIPTION
Fixes #3445

Line 319 uses `.unwrap_or(20)` as the fallback when no whitespace is found after the migration token. If the token is shorter than 20 bytes and at end-of-line, this causes an out-of-bounds slice panic.

Line 252 in the same file already has the correct fallback: `.unwrap_or(line.len() - pos)`. This PR applies the same fix to line 319.
