### PR TITLE
fix: propagate JSON parse error instead of silently overwriting Gemini settings

### DIFF
--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -4270,7 +4270,8 @@ fn patch_gemini_settings(
     let mut settings: serde_json::Value = if settings_path.exists() {
         let content = fs::read_to_string(&settings_path)
             .with_context(|| format!("Failed to read {}", settings_path.display()))?;
-        serde_json::from_str(&content).unwrap_or(serde_json::json!({}))
+        serde_json::from_str(&content)
+            .with_context(|| format!("Failed to parse {} as JSON", settings_path.display()))?
     } else {
         serde_json::json!({})
     };


### PR DESCRIPTION
Fixes #3400

The Gemini installer used `.unwrap_or(serde_json::json!({}))` which swallows JSON parse errors (BOM, trailing commas, half-written files) and silently overwrites the user's entire `~/.gemini/settings.json` with an empty object.

The Claude, Cursor, and Droid installers all use `.with_context()?` to propagate the error. This applies the same pattern to the Gemini path so the install fails loudly with the path and the parse error instead of overwriting.
