### PR TITLE
fix: check for RTK heading instead of bare substring in rules files

### DIFF
--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -1638,7 +1638,7 @@ fn run_cline_mode(ctx: InitContext) -> Result<()> {
     let rules_path = PathBuf::from(".clinerules");
 
     let existing = fs::read_to_string(&rules_path).unwrap_or_default();
-    if existing.contains("RTK") || existing.contains("rtk") {
+    if existing.contains("# RTK - Rust Token Killer") {
         if !dry_run {
             println!("\nRTK already configured for Cline in this project.\n");
             println!("  Rules: .clinerules (already present)");
@@ -1683,7 +1683,7 @@ fn run_windsurf_mode(ctx: InitContext) -> Result<()> {
     let rules_path = PathBuf::from(".windsurfrules");
 
     let existing = fs::read_to_string(&rules_path).unwrap_or_default();
-    if existing.contains("RTK") || existing.contains("rtk") {
+    if existing.contains("# RTK - Rust Token Killer") {
         if !dry_run {
             println!("\nRTK already configured for Windsurf in this project.\n");
             println!("  Rules: .windsurfrules (already present)");
@@ -1736,7 +1736,7 @@ fn run_kilocode_mode_at(base_dir: &Path, ctx: InitContext) -> Result<()> {
     let rules_path = target_dir.join("rtk-rules.md");
 
     let existing = fs::read_to_string(&rules_path).unwrap_or_default();
-    if existing.contains("RTK") || existing.contains("rtk") {
+    if existing.contains("# RTK - Rust Token Killer") {
         if !dry_run {
             println!("\nRTK already configured for Kilo Code in this project.\n");
             println!("  Rules: .kilocode/rules/rtk-rules.md (already present)");
@@ -1794,7 +1794,7 @@ fn run_antigravity_mode_at(base_dir: &Path, ctx: InitContext) -> Result<()> {
     let rules_path = target_dir.join("antigravity-rtk-rules.md");
 
     let existing = fs::read_to_string(&rules_path).unwrap_or_default();
-    if existing.contains("RTK") || existing.contains("rtk") {
+    if existing.contains("# RTK - Rust Token Killer") {
         if !dry_run {
             println!("\nRTK already configured for Antigravity in this project.\n");
             println!("  Rules: .agents/rules/antigravity-rtk-rules.md (already present)");


### PR DESCRIPTION
Fixes #3406

The Cline/Windsurf/Kilo/Antigravity installers checked if the rules file contained `"RTK"` or `"rtk"` to detect existing configuration. This falsely matched unrelated content — e.g. a Redux project's `.clinerules` mentioning "RTK Query" would cause the installer to skip silently and report success.

Changed all four checks to look for the actual heading the installer writes: `"# RTK - Rust Token Killer"`. This is specific enough to avoid false positives while still correctly detecting existing RTK installations.
