### PR TITLE
fix: preserve pytest result truth in compressed output

### DIFF
--- a/docs/merge-process/rtk-pytest-result-truth-preservation-20260809.md
+++ b/docs/merge-process/rtk-pytest-result-truth-preservation-20260809.md
@@ -1,0 +1,152 @@
+---
+title: RTK pytest 结果真实性修复合并过程
+status: source_ready
+owner: Camus
+template_id: report.merge_process.v1
+template_source: team-ai-pack/templates/merge-process-template.md
+related_prd: not_applicable
+related_technical_plan: not_applicable
+related_test_plan: not_applicable
+related_test_set: not_applicable
+last_updated: 2026-08-10
+---
+
+# 合并过程：RTK pytest 结果真实性修复
+
+> 本改动只修复 pytest 压缩输出的结果判定，并复用捕获层的截断事实；不增加通用超时、不恢复 Safe Runner child deadline、不触碰业务 runtime。
+
+## 产品汇报（与 Multica 正文对齐）
+
+### 需求对象与用户价值
+
+- 问题：pytest 已经收集或执行测试，但摘要未被识别时，RTK 会把“无法判断”误报成“没有测试”，让用户误以为测试没有运行。
+- 用户价值：用户继续得到真实退出码、可识别的通过/失败/跳过/收集数量、子测试数量和失败位置；摘要不完整时会明确看到“无法解析”，不会得到编造结论。
+- 如果不改：长时间运行、静默输出、摘要格式变化或捕获截断都会继续制造错误 no-tests 结论，掩盖真实失败。
+
+### 目标边界
+
+- In scope：pytest 单一解析主路、直接 pytest 执行的退出码与 stdout 截断事实传入、摘要识别、计数、失败位置和原始日志路径 fixtures。
+- Out of scope：Safe Runner、通用超时、10 MiB 捕获上限数值、其他 test/lint wrapper 的行为、业务 runtime、生产发布。
+- 历史相关卡 / 依赖：PR #1877 的本地异常证据；当前代码基于 `origin/develop` 的 RTK pytest wrapper。
+
+### 当前进度判断
+
+- 已完成：红灯复现、根因确认、最小解析修复、24 条 pytest 夹具、捕获截断观测 fixture、直接二进制退出码/失败位置/无法解析日志验证、两轮独立复核问题修正。
+- 进行中：本地提交、远程 PR、PR CI 和主线读回。
+- 未完成 / 缺口 / 阻塞：本地全量测试仍有 9 个未触达的 curl/SQLite 基线环境失败；远程 CI 尚未消费本提交。
+
+### RCA / 解决判断
+
+- 现象：原解析器五类计数全为零时直接输出 `No tests collected`；摘要缺失、格式未识别和捕获截断都会进入这条分支。
+- 根因或判断：摘要缺失不等于无测试；原逻辑没有保留“是否见到摘要”、`collected` 数量或真实退出码的判定上下文。
+- 处理或方案：直接 pytest 改走带真实退出码的既有 runner 入口；解析器单一路径记录 collected、摘要和显式 no-tests 信号，只有显式 no-tests 或 `collected 0 + pytest exit 5` 才输出 no-tests，其余降级为无法解析并保留退出码与失败位置。
+- 验证或待决策点：24 条解析夹具、捕获层 10 MiB 边界 fixture、49 条 Python 命令测试、Clippy 和真实二进制 pass/fail/no-tests/exit 4 已通过；最终独立复核、PR exact-head CI 和目标分支读回仍待完成。
+
+### 完整改动逻辑
+
+- 改动前：`pytest` 进入捕获 runner，过滤器只从摘要计数推断结果；所有零计数都被压成 no-tests。
+- 触发条件：直接执行 `rtk pytest ...` 时，既有 runner 把真实子进程退出码传给 pytest 解析器；管道输入继续复用兼容入口。
+- 唯一主路径：捕获层提供 stdout 与“是否截断”事实 → 清理 ANSI → 读取 collected → 识别唯一终态摘要 → 校验摘要与退出码 → 解析 passed/failed/skipped/xfail/xpass/error/subtests → 输出压缩结果。
+- 阻塞 / 失败路径：pytest exit 5 且 collected 不为正才输出 no-tests；无摘要、多摘要、截断、exit 0/1 与摘要冲突、或 exit 2/3/4 异常退出时统一输出“无法解析”、真实退出码、已知 collected、失败位置和原始日志路径。
+- 生产者与消费者：pytest 子进程产生 stdout/stderr 与退出码；既有 stream 捕获层额外暴露 stdout 是否超过既有 10 MiB 上限；runner 仅为 pytest 传入该事实并用 stdout+stderr 计算输出预算；`main` 继续消费真实返回码，`pipe_cmd` 继续消费无退出码兼容入口。没有新增旁路 writer 或业务状态文件。
+- 兼容与迁移：保留原有 xfail/xpass、失败摘要和管道入口；ANSI、quiet-mode、单等号和子测试摘要进入同一解析主路。
+- 回滚：回退本 PR 的 squash commit，恢复原 pytest 过滤器；不需要迁移数据或切换运行时配置。
+
+### 交付物、现阶段结论与下一步
+
+- 交付物 / 证据索引：`src/cmds/python/pytest_cmd.rs`；`outputs/rtk-pytest-truth/pytest-regression-final3.log`；`python-consumers-final2.log`；`clippy-final3.log`；`all-tests-final.log`。
+- 现阶段结论：source 层和本地直接消费者层证明 pytest 不再把摘要缺失误报为 no-tests；尚未证明 PR CI、main 或线上消费。
+- 下一步：提交并推送分支，创建 PR，等待 required CI，按 exact-head 合并并回读 main；runtime/online regression 不适用。
+
+## Discovery Gate
+
+- task classification: C - 已有 wrapper 的局部 bug 修复
+- research_status: not_required
+- research_depth: baseline
+- formal_research_reason: not_applicable
+- internal_sources: `src/cmds/python/pytest_cmd.rs`; `src/core/runner.rs`; `src/core/stream.rs`; `src/cmds/system/pipe_cmd.rs`; `CLAUDE.md`
+- external_sources: not_applicable
+- source_intake_artifact: not_applicable
+- research_conclusion: 复用现有 pytest runner 和 tee 路径，只收紧解析判定
+- research_gap: none
+- 调研结论: 复用现有主路；不新增通用 timeout、旁路或状态文件
+- authority_plan: not_applicable
+- test_plan: not_applicable
+- test_set: not_applicable
+- acceptance_registry: not_applicable
+- mechanism_key: not_applicable
+- metadata_note: 运行时退出码由既有 runner 产生；本 PR 只改变 pytest 输出层的可信判定和摘要保留。
+- related surfaces: source / pytest direct caller / pipe caller / unit fixtures / local binary smoke / PR CI / main
+- contracts / fixtures / smoke evidence: pytest parser fixtures and direct binary smoke recorded under `outputs/rtk-pytest-truth/`
+- surface-freeze-exempt: not_applicable；只修改一个已有解析器文件和一个合并过程记录
+- uncertainty / decision boundary: 10 MiB 捕获上限仍是既有合同；本 PR 只把捕获层已有的 stdout 截断事实暴露给 pytest 单一消费者，不改变上限、截断策略或其他 wrapper 行为。
+- 预估命中率依据: not_applicable
+- 误报代价: not_applicable
+- 退出条件: not_applicable
+
+## Change Summary
+
+- User / project value: 让 RTK pytest 输出只报告已被底层摘要或退出码证明的结论。
+- Actual changed behavior: 摘要缺失或不可识别时不再输出 `No tests collected`；直接 pytest 解析获得真实退出码，并保留 collected、子测试和失败位置。
+- In scope: `src/cmds/python/pytest_cmd.rs`、`src/core/stream.rs` 的 stdout 截断观测字段、`src/core/runner.rs` 的 pytest 专用 capture-aware 入口与本合并过程记录。
+- Out of scope: Safe Runner、超时、捕获上限数值、其他 wrapper 行为、hooks、业务 runtime、生产部署。
+- Touched source / callers / tests / config / docs: pytest source and fixtures；stream 只暴露已有截断事实，runner 新入口仅由 pytest 消费，既有调用方默认行为不变。
+- Runtime or external impact: none
+- external_write: not_applicable
+- external_endstate: pending_post_merge
+
+## Validation Evidence
+
+- targeted local / unit: pytest parser 24 passed; stream 10 MiB 截断边界 fixture passed; Python command consumer suite 49 passed; `cargo fmt --all -- --check`; `cargo clippy --all-targets` passed。
+- selected stable test cases: normal pass, failure, explicit no-tests, collected-but-summary-missing, quiet/ANSI/non-standard summary, silent interval then pass, 10 MiB 真实捕获截断、伪终态摘要、exit 2/3/4、stderr-only 参数错误、xfail/xpass 和 mixed subtest counts。
+- change-specific tests: `outputs/rtk-pytest-truth/pytest-regression-final3.log`
+- smoke / E2E when required: real binary pass exit 0; real failure exit 1 with `/private/tmp/...py:2`; empty directory real pytest exit 5。
+- PR / CI: pending push and exact-head CI
+- skipped checks and reason: full local suite is not clean because 9 unrelated curl tee and tracking SQLite tests fail in this environment; see `all-tests-serial-isolated.log`。
+- 旧调用方/旧数据兼容：pipe caller retains the one-argument compatibility function; no data migration。
+- legacy fixture 或真实 oracle: parser fixture and real pytest subprocess smoke
+- 行为是否变化: describe changed behavior
+- online regression: not applicable before merge; no runtime or external consumption surface
+- external owner write regression: not_applicable; no external owner write target
+
+## Review Evidence
+
+- required by current risk: yes
+- fresh-context review（仅新高风险或当前合同要求，否则 not_applicable）: read-only explorer and code-reviewer review requested; no write access
+- Codex review artifact / decision: pending final readback
+- Fable review artifact / decision: not_applicable
+- accepted findings and applied changes: 首轮发现精确伪摘要、伪 no-tests 横幅和 mixed subtests；第二轮发现 exit 2/3/4、真实捕获截断、stderr-only 空输出和冲突分支丢失败位置。全部收口到单一可信度判断和单一无法解析输出，均有 fixture 或真实二进制 smoke。
+- rejected / deferred findings and reason: none；stdout truncation provenance 已按复核意见以只读字段实施，runner 保持唯一日志 writer
+- reviewer boundary: review evidence is not CI, runtime, online acceptance, or external readback proof
+
+## Merge Readiness
+
+- source revision: local HEAD (PR head/CI/main pending; read back with `git rev-parse HEAD`)
+- target branch: `develop`
+- PR URL: pending
+- review decision: pending
+- required CI: pending
+- mergeability: pending
+- merge strategy: exact-head squash
+- merge owner: repository maintainer
+- rollback / revert path: revert the exact squash commit
+- ready to merge: no
+
+## Merge Result And Handoff
+
+- merge commit: pending
+- post-merge main readback: pending
+- promoted runtime required: no
+- next required document: not_applicable; no runtime/external acceptance surface
+- Promote / runtime owner: not_applicable
+- Online acceptance owner: not_applicable
+- Final closeout remains blocked until: PR exact-head CI and main readback complete
+
+## RCA 与风险
+
+- 现象：已收集或已执行的 pytest 被压缩器误报为 no-tests。
+- 根因或判断：缺少摘要存在性、collected 计数和退出码参与的可信判定；这是展示层误判，不是 pytest 子进程没有执行。
+- 处理或方案：单一 exit-aware parser；未知结果保守降级，真实退出码由既有 runner 返回。
+- 验证：红灯夹具先证明旧行为；24 条 pytest fixtures、捕获边界 fixture、49 条 Python consumer、真实二进制 smoke 和 Clippy 通过；全量测试的 9 个非相关失败已单独记录。
+- 剩余风险：远程 PR CI/目标分支尚未验证；完整 suite 的 9 项环境基线失败仍由各自 owner 处理。
+- 待决策点：无新增产品决策；只待外发授权、CI 与合并读回。

--- a/src/cmds/python/pytest_cmd.rs
+++ b/src/cmds/python/pytest_cmd.rs
@@ -51,31 +51,81 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         eprintln!("Running: pytest --tb=short -q {}", args.join(" "));
     }
 
-    runner::run_filtered(
+    runner::run_filtered_with_capture(
         cmd,
         "pytest",
         &args.join(" "),
-        filter_pytest_output,
-        runner::RunOptions::stdout_only().tee("pytest"),
+        filter_pytest_output_with_capture,
+        runner::RunOptions::stdout_only()
+            .guard_combined_output()
+            .force_tee_when_output_contains("result could not be parsed")
+            .tee("pytest"),
     )
 }
 
+/// Compatibility entry point for `rtk <input> | rtk pytest`.
+///
+/// The direct command uses the exit-aware variant below. Piped input has no
+/// child exit status, so it can only claim an explicit summary, never infer
+/// "no tests" from a missing summary.
 pub(crate) fn filter_pytest_output(output: &str) -> String {
+    filter_pytest_output_inner(output, None, false)
+}
+
+#[cfg(test)]
+fn filter_pytest_output_with_exit(output: &str, exit_code: i32) -> String {
+    filter_pytest_output_inner(output, Some(exit_code), false)
+}
+
+fn filter_pytest_output_with_capture(output: &str, exit_code: i32, stdout_truncated: bool) -> String {
+    filter_pytest_output_inner(output, Some(exit_code), stdout_truncated)
+}
+
+fn filter_pytest_output_inner(output: &str, exit_code: Option<i32>, stdout_truncated: bool) -> String {
     let mut state = ParseState::Header;
-    let mut test_files: Vec<String> = Vec::new();
     let mut failures: Vec<String> = Vec::new();
     let mut current_failure: Vec<String> = Vec::new();
     let mut xfail_lines: Vec<String> = Vec::new();
-    let mut summary_line = String::new();
+    let mut summary_line: Option<String> = None;
+    let mut collected: Option<usize> = None;
+    let mut explicit_no_tests = false;
+    let mut summary_signal_count = 0usize;
+    let lines: Vec<String> = output.lines().map(strip_ansi).collect();
+    let last_nonempty = lines.iter().rposition(|line| !line.trim().is_empty());
 
-    for line in output.lines() {
+    for (line_index, line) in lines.iter().enumerate() {
         let trimmed = line.trim();
 
         // State transitions
         if trimmed.starts_with("===") && trimmed.contains("test session starts") {
             state = ParseState::Header;
             continue;
-        } else if trimmed.starts_with("===") && trimmed.contains("FAILURES") {
+        } else if state == ParseState::Header {
+            // Only accept pytest's collection line while still in the session
+            // header. A test's own output can contain "collected N", but it
+            // cannot rewrite the collection count once progress has begun.
+            if let Some(count) = parse_collected_count(trimmed) {
+                collected = Some(count);
+                state = ParseState::TestProgress;
+                continue;
+            }
+        }
+
+        if is_explicit_no_tests_line(trimmed) {
+            summary_signal_count += 1;
+            // Pytest's terminal summary is the final non-empty output line.
+            // Earlier lookalikes may be arbitrary test output and are ignored.
+            if Some(line_index) == last_nonempty && collected.is_none_or(|count| count == 0) {
+                explicit_no_tests = true;
+            }
+            // Do not let a no-tests phrase from test output become a normal
+            // zero-count result candidate.
+            continue;
+        }
+
+        if trimmed.starts_with("===")
+            && (trimmed.contains("FAILURES") || trimmed.contains("ERRORS"))
+        {
             state = ParseState::Failures;
             continue;
         } else if trimmed.starts_with("===") && trimmed.contains("short test summary") {
@@ -86,24 +136,13 @@ pub(crate) fn filter_pytest_output(output: &str) -> String {
                 current_failure.clear();
             }
             continue;
-        } else if trimmed.starts_with("===")
-            && (trimmed.contains("passed")
-                || trimmed.contains("failed")
-                || trimmed.contains("skipped"))
-        {
-            summary_line = trimmed.to_string();
-            continue;
-        // quiet mode (-q): bare summary without === wrapper, e.g. "5 failed, 1698 passed, 2 skipped in 108.89s"
-        } else if summary_line.is_empty()
-            && !trimmed.starts_with("===")
-            && !trimmed.starts_with("FAILED")
-            && !trimmed.starts_with("ERROR")
-            && (trimmed.contains(" passed")
-                || trimmed.contains(" failed")
-                || trimmed.contains(" skipped"))
-            && trimmed.contains(" in ")
-        {
-            summary_line = trimmed.to_string();
+        } else if is_summary_candidate(trimmed) {
+            summary_signal_count += 1;
+            // Only pytest's terminal line can be its final result summary.
+            // A test may print an identical-looking line while it is running.
+            if Some(line_index) == last_nonempty {
+                summary_line = Some(trimmed.to_string());
+            }
             continue;
         }
 
@@ -114,15 +153,7 @@ pub(crate) fn filter_pytest_output(output: &str) -> String {
                     state = ParseState::TestProgress;
                 }
             }
-            ParseState::TestProgress => {
-                // Lines like "tests/test_foo.py ....  [ 40%]"
-                if !trimmed.is_empty()
-                    && !trimmed.starts_with("===")
-                    && (trimmed.contains(".py") || trimmed.contains("%]"))
-                {
-                    test_files.push(trimmed.to_string());
-                }
-            }
+            ParseState::TestProgress => {}
             ParseState::Failures => {
                 // Collect failure details
                 if trimmed.starts_with("___") {
@@ -152,8 +183,124 @@ pub(crate) fn filter_pytest_output(output: &str) -> String {
         failures.push(current_failure.join("\n"));
     }
 
-    // Build compact output
-    build_pytest_summary(&summary_line, &test_files, &failures, &xfail_lines)
+    if summary_signal_count != 1 {
+        summary_line = None;
+        explicit_no_tests = false;
+    }
+
+    let report = PytestReport {
+        collected,
+        summary_line,
+        explicit_no_tests,
+    };
+
+    build_pytest_summary(
+        &report,
+        &failures,
+        &xfail_lines,
+        exit_code,
+        stdout_truncated,
+    )
+}
+
+fn strip_ansi(line: &str) -> String {
+    let mut clean = String::with_capacity(line.len());
+    let mut chars = line.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '\x1b' {
+            // Skip CSI escape sequences such as "\x1b[32m" and
+            // "\x1b[0m" before applying textual matching.
+            for sequence_char in chars.by_ref() {
+                if sequence_char.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        } else {
+            clean.push(ch);
+        }
+    }
+    clean
+}
+
+fn normalized_tokens(line: &str) -> Vec<&str> {
+    line.split_whitespace()
+        .map(|token| token.trim_matches(|ch: char| "=,;()".contains(ch)))
+        .filter(|token| !token.is_empty())
+        .collect()
+}
+
+fn parse_collected_count(line: &str) -> Option<usize> {
+    let tokens = normalized_tokens(line);
+    tokens.windows(2).find_map(|window| {
+        if window[0].eq_ignore_ascii_case("collected") {
+            window[1].parse::<usize>().ok()
+        } else {
+            None
+        }
+    })
+}
+
+fn is_explicit_no_tests_line(line: &str) -> bool {
+    if !line.starts_with('=') || !line.ends_with('=') {
+        return false;
+    }
+    let content = line.trim_matches('=').trim().to_ascii_lowercase();
+    let tokens: Vec<&str> = content.split_whitespace().collect();
+    let phrase_len = if tokens.starts_with(&["no", "tests", "ran"])
+        || tokens.starts_with(&["no", "tests", "collected"])
+    {
+        3
+    } else {
+        return false;
+    };
+    tokens.len() == phrase_len
+        || (tokens.len() == phrase_len + 2
+            && tokens[phrase_len] == "in"
+            && tokens[phrase_len + 1]
+                .trim_end_matches('s')
+                .parse::<f64>()
+                .is_ok())
+}
+
+fn is_result_label(token: &str) -> bool {
+    matches!(
+        token.to_ascii_lowercase().as_str(),
+        "passed" | "failed" | "skipped" | "xfailed" | "xpassed" | "subtests"
+            | "error" | "errors"
+    )
+}
+
+fn is_summary_candidate(line: &str) -> bool {
+    if is_explicit_no_tests_line(line) {
+        return true;
+    }
+
+    let tokens = normalized_tokens(line);
+    if tokens
+        .first()
+        .is_none_or(|token| token.parse::<usize>().is_err())
+    {
+        return false;
+    }
+    let has_result_count = tokens
+        .windows(2)
+        .any(|window| window[0].parse::<usize>().is_ok() && is_result_label(window[1]));
+    if !has_result_count || line.starts_with("FAILED") || line.starts_with("ERROR") {
+        return false;
+    }
+
+    // Pytest result summaries carry a duration. Requiring it makes a test's
+    // ordinary "N passed" log line insufficient evidence, while still
+    // accepting canonical, quiet-mode, ANSI-cleaned, and non-standard
+    // summaries.
+    let tokens = normalized_tokens(line);
+    tokens.windows(2).any(|window| {
+        window[0].eq_ignore_ascii_case("in")
+            && window[1]
+                .trim_end_matches('s')
+                .parse::<f64>()
+                .is_ok()
+    })
 }
 
 #[derive(Default)]
@@ -163,14 +310,59 @@ struct PytestCounts {
     skipped: usize,
     xfailed: usize,
     xpassed: usize,
+    errors: usize,
+    subtests: usize,
+    subtest_passed: usize,
+    subtest_failed: usize,
+}
+
+struct PytestReport {
+    collected: Option<usize>,
+    summary_line: Option<String>,
+    explicit_no_tests: bool,
 }
 
 fn build_pytest_summary(
-    summary: &str,
-    _test_files: &[String],
+    report: &PytestReport,
     failures: &[String],
     xfail_lines: &[String],
+    exit_code: Option<i32>,
+    stdout_truncated: bool,
 ) -> String {
+    // Direct pytest reports no collection with exit 5. Piped compatibility
+    // input has no child status, so only an exact terminal summary can support
+    // the claim there.
+    if (exit_code == Some(5) || (exit_code.is_none() && report.explicit_no_tests))
+        && report.collected.is_none_or(|count| count == 0)
+    {
+        return if exit_code.is_none() {
+            "Pytest: No tests collected".to_string()
+        } else {
+            format!(
+                "Pytest: No tests collected (exit code {})",
+                exit_code.unwrap_or_default()
+            )
+        };
+    }
+
+    if stdout_truncated {
+        return build_unparsed_result(
+            report,
+            failures,
+            exit_code,
+            true,
+        );
+    }
+
+    let Some(summary) = report.summary_line.as_deref() else {
+        return build_unparsed_result(
+            report,
+            failures,
+            exit_code,
+            false,
+        );
+    };
+
     let counts = parse_summary_line(summary);
     let PytestCounts {
         passed,
@@ -178,16 +370,41 @@ fn build_pytest_summary(
         skipped,
         xfailed,
         xpassed,
+        errors,
+        subtests,
+        subtest_passed,
+        subtest_failed,
     } = counts;
 
-    if passed == 0 && failed == 0 && skipped == 0 && xfailed == 0 && xpassed == 0 {
-        return "Pytest: No tests collected".to_string();
+    let exit_conflicts_with_summary = match exit_code {
+        Some(0) => failed > 0 || errors > 0 || subtest_failed > 0,
+        Some(1) => failed == 0 && errors == 0 && subtest_failed == 0,
+        Some(_) => true,
+        None => false,
+    };
+    if exit_conflicts_with_summary {
+        return build_unparsed_result(
+            report,
+            failures,
+            exit_code,
+            false,
+        );
     }
 
-    let extras_present = skipped > 0 || xfailed > 0 || xpassed > 0 || !xfail_lines.is_empty();
+    let extras_present = skipped > 0
+        || xfailed > 0
+        || xpassed > 0
+        || errors > 0
+        || subtests > 0
+        || !xfail_lines.is_empty();
+
+    let collection_suffix = report
+        .collected
+        .map(|count| format!(" (collected {})", count))
+        .unwrap_or_default();
 
     if failed == 0 && passed > 0 && !extras_present {
-        return format!("Pytest: {} passed", passed);
+        return format!("Pytest: {} passed{}", passed, collection_suffix);
     }
 
     let mut result = String::new();
@@ -201,6 +418,21 @@ fn build_pytest_summary(
     if xpassed > 0 {
         result.push_str(&format!(", {} xpassed", xpassed));
     }
+    if errors > 0 {
+        result.push_str(&format!(", {} errors", errors));
+    }
+    if subtests > 0 {
+        if subtest_passed > 0 {
+            result.push_str(&format!(", {} subtests passed", subtest_passed));
+        }
+        if subtest_failed > 0 {
+            result.push_str(&format!(", {} subtests failed", subtest_failed));
+        }
+        if subtest_passed == 0 && subtest_failed == 0 {
+            result.push_str(&format!(", {} subtests", subtests));
+        }
+    }
+    result.push_str(&collection_suffix);
     result.push('\n');
 
     // Surface xfail/xpass entries (with their reasons) — XPASS in particular
@@ -285,31 +517,75 @@ fn build_pytest_summary(
     result.trim().to_string()
 }
 
+fn build_unparsed_result(
+    report: &PytestReport,
+    failures: &[String],
+    exit_code: Option<i32>,
+    stdout_truncated: bool,
+) -> String {
+    let exit = exit_code
+        .map(|code| code.to_string())
+        .unwrap_or_else(|| "unavailable".to_string());
+    let mut result = format!("Pytest: result could not be parsed (exit code {})", exit);
+    if stdout_truncated {
+        result.push_str(", stdout capture truncated");
+    }
+    if let Some(collected) = report.collected {
+        result.push_str(&format!(", collected {}", collected));
+    }
+    if !failures.is_empty() {
+        result.push_str("\nFailure positions:\n");
+        for failure in failures.iter().take(MAX_PYTEST_FAILURES) {
+            if let Some(position) = failure.lines().find(|line| {
+                line.starts_with("FAILED")
+                    || line.starts_with("ERROR")
+                    || line.contains(".py:")
+            }) {
+                result.push_str(&format!("  {}\n", truncate(position, 160)));
+            }
+        }
+    }
+    result.trim().to_string()
+}
+
 fn parse_summary_line(summary: &str) -> PytestCounts {
     let mut counts = PytestCounts::default();
 
-    // Parse lines like "=== 4 passed, 1 failed, 2 xfailed, 1 xpassed in 0.50s ==="
-    for part in summary.split(',') {
-        let words: Vec<&str> = part.split_whitespace().collect();
-        for (i, word) in words.iter().enumerate() {
-            if i == 0 {
-                continue;
+    // Parse canonical, quiet-mode, ANSI-decorated, and subtest summaries such
+    // as "=== 4 passed, 3 subtests passed in 0.50s ===".
+    let normalized = strip_ansi(summary);
+    let tokens = normalized_tokens(&normalized);
+    for (index, token) in tokens.iter().enumerate() {
+        let Ok(count) = token.parse::<usize>() else {
+            continue;
+        };
+        let Some(label) = tokens.get(index + 1) else {
+            continue;
+        };
+        match label.to_ascii_lowercase().as_str() {
+            "xpassed" => counts.xpassed = count,
+            "xfailed" => counts.xfailed = count,
+            "passed" => {
+                if index == 0 || tokens[index - 1] != "subtests" {
+                    counts.passed = count;
+                }
             }
-            let Ok(n) = words[i - 1].parse::<usize>() else {
-                continue;
-            };
-            // Order matters: "xpassed"/"xfailed" contain "passed"/"failed".
-            if word.contains("xpassed") {
-                counts.xpassed = n;
-            } else if word.contains("xfailed") {
-                counts.xfailed = n;
-            } else if word.contains("passed") {
-                counts.passed = n;
-            } else if word.contains("failed") {
-                counts.failed = n;
-            } else if word.contains("skipped") {
-                counts.skipped = n;
+            "failed" => {
+                if index == 0 || tokens[index - 1] != "subtests" {
+                    counts.failed = count;
+                }
             }
+            "skipped" => counts.skipped = count,
+            "error" | "errors" => counts.errors = count,
+            "subtests" => {
+                counts.subtests += count;
+                match tokens.get(index + 2).map(|outcome| outcome.to_ascii_lowercase()) {
+                    Some(outcome) if outcome == "passed" => counts.subtest_passed += count,
+                    Some(outcome) if outcome == "failed" => counts.subtest_failed += count,
+                    _ => {}
+                }
+            }
+            _ => {}
         }
     }
 
@@ -333,6 +609,7 @@ tests/test_foo.py .....                                            [100%]
         let result = filter_pytest_output(output);
         assert!(result.contains("Pytest"));
         assert!(result.contains("5 passed"));
+        assert!(result.contains("collected 5"));
     }
 
     #[test]
@@ -400,6 +677,102 @@ collected 0 items
     }
 
     #[test]
+    fn test_filter_pytest_log_text_cannot_override_real_result() {
+        let output = r#"=== test session starts ===
+collected 2 items
+
+tests/test_output.py ..                                             [100%]
+test output: === no tests ran in 0.00s ===
+test output: 1 passed in 0.01s
+collected 99 items
+
+=== short test summary info ===
+=== 2 passed in 0.10s ==="#;
+
+        let result = filter_pytest_output_with_exit(output, 0);
+        assert!(result.contains("2 passed"), "unexpected result: {result}");
+        assert!(result.contains("collected 2"), "unexpected result: {result}");
+        assert!(!result.contains("No tests collected"));
+        assert!(!result.contains("collected 99"));
+    }
+
+    #[test]
+    fn test_filter_pytest_exact_fake_summary_degrades_instead_of_lying() {
+        let output = r#"=== test session starts ===
+collected 1 item
+
+=== 1 failed in 0.01s ===
+tests/test_output.py .                                             [100%]
+=== 1 passed in 0.10s ==="#;
+
+        let result = filter_pytest_output_with_exit(output, 0);
+        assert!(result.contains("could not be parsed"), "unexpected result: {result}");
+        assert!(result.contains("exit code 0"));
+        assert!(!result.contains("No tests collected"));
+    }
+
+    #[test]
+    fn test_filter_pytest_fake_no_tests_banner_degrades() {
+        let output = r#"=== test session starts ===
+=== no tests ran in 0.01s ===
+tests/test_output.py .                                             [100%]
+=== 1 passed in 0.10s ==="#;
+
+        let result = filter_pytest_output_with_exit(output, 0);
+        assert!(result.contains("could not be parsed"), "unexpected result: {result}");
+        assert!(!result.contains("No tests collected"));
+    }
+
+    #[test]
+    fn test_filter_pytest_no_tests_banner_conflicting_with_exit_degrades() {
+        let output = "=== test session starts ===\ncollected 0 items\n=== no tests ran in 0.01s ===";
+        let result = filter_pytest_output_with_exit(output, 0);
+        assert!(result.contains("could not be parsed"), "unexpected result: {result}");
+        assert!(result.contains("exit code 0"));
+        assert!(!result.contains("No tests collected"));
+    }
+
+    #[test]
+    fn test_filter_pytest_non_result_exit_codes_always_degrade() {
+        let output = "=== test session starts ===\ncollected 1 item\n=== 1 passed in 0.01s ===";
+        for exit_code in [2, 3, 4] {
+            let result = filter_pytest_output_with_exit(output, exit_code);
+            assert!(result.contains("could not be parsed"), "unexpected result: {result}");
+            assert!(
+                result.contains(&format!("exit code {exit_code}")),
+                "unexpected result: {result}"
+            );
+            assert!(!result.contains("Pytest: 1 passed"));
+        }
+    }
+
+    #[test]
+    fn test_filter_pytest_capture_truncation_rejects_fake_terminal_summary() {
+        let output = "=== test session starts ===\ncollected 1 item\n=== 1 passed in 0.01s ===";
+        let result = filter_pytest_output_inner(output, Some(0), true);
+        assert!(result.contains("could not be parsed"), "unexpected result: {result}");
+        assert!(result.contains("stdout capture truncated"));
+        assert!(!result.contains("Pytest: 1 passed"));
+    }
+
+    #[test]
+    fn test_filter_pytest_summary_conflict_keeps_failure_position() {
+        let output = r#"=== test session starts ===
+collected 1 item
+
+=== FAILURES ===
+___ test_truth ___
+tests/test_truth.py:7: AssertionError
+
+=== short test summary info ===
+FAILED tests/test_truth.py::test_truth - AssertionError
+=== 1 passed in 0.01s ==="#;
+        let result = filter_pytest_output_with_exit(output, 1);
+        assert!(result.contains("could not be parsed"), "unexpected result: {result}");
+        assert!(result.contains("tests/test_truth.py:7"), "unexpected result: {result}");
+    }
+
+    #[test]
     fn test_parse_summary_line() {
         let c = parse_summary_line("=== 5 passed in 0.50s ===");
         assert_eq!((c.passed, c.failed, c.skipped), (5, 0, 0));
@@ -415,6 +788,18 @@ collected 0 items
             (c.passed, c.failed, c.xfailed, c.xpassed),
             (2, 1, 2, 1)
         );
+        assert_eq!((c.subtests, c.subtest_passed, c.subtest_failed), (0, 0, 0));
+
+        let c = parse_summary_line("=== 4 passed, 3 subtests passed in 0.5s ===");
+        assert_eq!((c.passed, c.subtests, c.subtest_passed), (4, 3, 3));
+
+        let c = parse_summary_line(
+            "=== 4 passed, 3 subtests passed, 1 subtests failed in 0.5s ===",
+        );
+        assert_eq!((c.subtests, c.subtest_passed, c.subtest_failed), (4, 3, 1));
+
+        let c = parse_summary_line("=== 1 error in 0.2s ===");
+        assert_eq!(c.errors, 1);
     }
 
     #[test]
@@ -515,5 +900,122 @@ collected 3 items
             "Should not say 'No tests collected' when tests were skipped. Got: {}",
             result
         );
+    }
+
+    #[test]
+    fn test_filter_pytest_truncated_before_summary_is_not_no_tests() {
+        // A long-running pytest process can have collected tests and emitted
+        // progress before its final summary is unavailable to the parser.
+        let output = r#"=== test session starts ===
+platform darwin -- Python 3.12.0
+collected 4 items
+
+tests/test_slow.py ....                                            [100%]
+"#;
+
+        let result = filter_pytest_output_with_exit(output, 1);
+        assert!(
+            !result.contains("No tests collected"),
+            "Missing summary must not be rewritten as no tests: {result}"
+        );
+        assert!(result.contains("could not be parsed"));
+        assert!(result.contains("exit code 1"));
+        assert!(result.contains("collected 4"));
+    }
+
+    #[test]
+    fn test_filter_pytest_subtest_summary_preserves_subtest_count() {
+        let output = r#"=== test session starts ===
+collected 4 items
+
+tests/test_subtests.py ....                                         [100%]
+
+=== 4 passed, 3 subtests passed in 0.50s ==="#;
+
+        let result = filter_pytest_output(output);
+        assert!(result.contains("4 passed"), "missing ordinary count: {result}");
+        assert!(
+            result.contains("3 subtests"),
+            "missing subtest count: {result}"
+        );
+        assert!(result.contains("collected 4"));
+    }
+
+    #[test]
+    fn test_filter_pytest_mixed_subtest_outcomes_preserve_both_counts() {
+        let output = r#"=== test session starts ===
+collected 4 items
+
+tests/test_subtests.py ....                                         [100%]
+
+=== 4 passed, 3 subtests passed, 1 subtests failed in 0.50s ==="#;
+
+        let result = filter_pytest_output_with_exit(output, 1);
+        assert!(result.contains("3 subtests passed"), "unexpected result: {result}");
+        assert!(result.contains("1 subtests failed"), "unexpected result: {result}");
+        assert!(!result.contains("exit code 1"), "unexpected result: {result}");
+    }
+
+    #[test]
+    fn test_filter_pytest_real_no_tests_requires_explicit_signal_or_exit_code() {
+        let explicit = filter_pytest_output_with_exit(
+            "=== test session starts ===\ncollected 0 items\n=== no tests ran in 0.00s ===",
+            5,
+        );
+        assert!(explicit.contains("No tests collected"));
+        assert!(explicit.contains("exit code 5"));
+
+        let missing_summary = filter_pytest_output_with_exit("collected 0 items\n", 1);
+        assert!(!missing_summary.contains("No tests collected"));
+        assert!(missing_summary.contains("could not be parsed"));
+    }
+
+    #[test]
+    fn test_filter_pytest_long_silence_then_pass_keeps_final_summary() {
+        // The absence of progress output is not evidence that collection
+        // failed. A final summary after a silent interval remains authoritative.
+        let output = r#"=== test session starts ===
+collected 4 items
+
+=== 4 passed in 420.00s ==="#;
+
+        let result = filter_pytest_output_with_exit(output, 0);
+        assert!(result.contains("4 passed"));
+        assert!(result.contains("collected 4"));
+        assert!(!result.contains("No tests collected"));
+    }
+
+    #[test]
+    fn test_filter_pytest_ansi_and_nonstandard_summary_is_parseable() {
+        let output = "=== test session starts ===\ncollected 2 items\n\n\x1b[32m= 2 passed in 0.10s =\x1b[0m\n";
+        let result = filter_pytest_output_with_exit(output, 0);
+        assert!(result.contains("2 passed"), "unexpected result: {result}");
+        assert!(result.contains("collected 2"));
+    }
+
+    #[test]
+    fn test_filter_pytest_ambiguous_bare_summaries_degrade() {
+        let output = r#"=== test session starts ===
+collected 2 items
+
+2 passed in 0.10s
+test output: 1 passed in 0.01s
+"#;
+
+        let result = filter_pytest_output_with_exit(output, 0);
+        assert!(result.contains("could not be parsed"), "unexpected result: {result}");
+        assert!(result.contains("exit code 0"));
+        assert!(!result.contains("No tests collected"));
+    }
+
+    #[test]
+    fn test_filter_pytest_capture_truncated_before_summary_is_unparseable() {
+        let mut output = String::from("=== test session starts ===\ncollected 1 items\n");
+        output.push_str(&"x".repeat(crate::core::stream::RAW_CAP));
+
+        let result = filter_pytest_output_with_exit(&output, 0);
+        assert!(result.contains("could not be parsed"));
+        assert!(result.contains("collected 1"));
+        assert!(!result.contains("No tests collected"));
     }
 }

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -34,6 +34,8 @@ pub fn print_with_hint(
 pub struct RunOptions<'a> {
     pub tee_label: Option<&'a str>,
     pub filter_stdout_only: bool,
+    pub guard_combined_output: bool,
+    pub force_tee_marker: Option<&'a str>,
     pub skip_filter_on_failure: bool,
     pub no_trailing_newline: bool,
     /// Forward rtk's own stdin to the child process. Needed for commands that
@@ -55,6 +57,21 @@ impl<'a> RunOptions<'a> {
             filter_stdout_only: true,
             ..Default::default()
         }
+    }
+
+    /// Parse stdout only while budgeting the rendered result against combined
+    /// stdout/stderr. This keeps an explicit fallback visible for stderr-only
+    /// command failures without feeding diagnostics into the parser.
+    pub fn guard_combined_output(mut self) -> Self {
+        self.guard_combined_output = true;
+        self
+    }
+
+    /// Force one raw-output artifact when the filtered result contains a
+    /// caller-owned fallback marker. The runner remains the sole tee writer.
+    pub fn force_tee_when_output_contains(mut self, marker: &'a str) -> Self {
+        self.force_tee_marker = Some(marker);
+        self
     }
 
     pub fn tee(mut self, label: &'a str) -> Self {
@@ -80,10 +97,12 @@ impl<'a> RunOptions<'a> {
 
 pub type CaptureFilter<'a> = Box<dyn Fn(&str) -> String + 'a>;
 pub type ExitAwareCaptureFilter<'a> = Box<dyn Fn(&str, i32) -> String + 'a>;
+pub type CaptureAwareFilter<'a> = Box<dyn Fn(&str, i32, bool) -> String + 'a>;
 
 pub enum RunMode<'a> {
     Filtered(CaptureFilter<'a>),
     FilteredWithExit(ExitAwareCaptureFilter<'a>),
+    FilteredWithCapture(CaptureAwareFilter<'a>),
     Streamed(Box<dyn StreamFilter + 'a>),
     Passthrough,
 }
@@ -97,7 +116,7 @@ fn run_captured_filter<F>(
     timer: tracking::TimedExecution,
 ) -> Result<i32>
 where
-    F: Fn(&str, i32) -> String,
+    F: Fn(&str, i32, bool) -> String,
 {
     let stdin_mode = if opts.inherit_stdin {
         StdinMode::Inherit
@@ -127,18 +146,31 @@ where
     } else {
         raw
     };
-    let filtered = filter_fn(text_to_filter, exit_code);
+    let filtered = filter_fn(text_to_filter, exit_code, result.stdout_truncated);
 
     let raw_for_tracking = if opts.filter_stdout_only {
         raw_stdout
     } else {
         raw
     };
+    let raw_for_guard = if opts.guard_combined_output {
+        raw
+    } else {
+        raw_for_tracking
+    };
 
     let shown = if let Some(label) = opts.tee_label {
-        print_with_hint(&filtered, raw, raw_for_tracking, label, exit_code)
+        if opts
+            .force_tee_marker
+            .is_some_and(|marker| filtered.contains(marker))
+        {
+            let hint = crate::core::tee::force_tee_hint(raw, label);
+            emit_guarded(&filtered, hint.as_deref(), raw_for_guard)
+        } else {
+            print_with_hint(&filtered, raw, raw_for_guard, label, exit_code)
+        }
     } else {
-        let guarded = crate::core::guard::never_worse(raw_for_tracking, &filtered).to_string();
+        let guarded = crate::core::guard::never_worse(raw_for_guard, &filtered).to_string();
         if opts.no_trailing_newline {
             print!("{}", guarded);
         } else {
@@ -171,7 +203,7 @@ pub fn run(
             cmd,
             tool_name,
             &cmd_label,
-            move |text, _| filter_fn(text),
+            move |text, _, _| filter_fn(text),
             opts,
             timer,
         ),
@@ -179,7 +211,15 @@ pub fn run(
             cmd,
             tool_name,
             &cmd_label,
-            move |text, exit_code| filter_fn(text, exit_code),
+            move |text, exit_code, _| filter_fn(text, exit_code),
+            opts,
+            timer,
+        ),
+        RunMode::FilteredWithCapture(filter_fn) => run_captured_filter(
+            cmd,
+            tool_name,
+            &cmd_label,
+            move |text, exit_code, stdout_truncated| filter_fn(text, exit_code, stdout_truncated),
             opts,
             timer,
         ),
@@ -249,6 +289,25 @@ where
         tool_name,
         args_display,
         RunMode::FilteredWithExit(Box::new(filter_fn)),
+        opts,
+    )
+}
+
+pub fn run_filtered_with_capture<F>(
+    cmd: Command,
+    tool_name: &str,
+    args_display: &str,
+    filter_fn: F,
+    opts: RunOptions<'_>,
+) -> Result<i32>
+where
+    F: Fn(&str, i32, bool) -> String,
+{
+    run(
+        cmd,
+        tool_name,
+        args_display,
+        RunMode::FilteredWithCapture(Box::new(filter_fn)),
         opts,
     )
 }

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -217,6 +217,7 @@ pub struct StreamResult {
     pub raw: String,
     pub raw_stdout: String,
     pub raw_stderr: String,
+    pub stdout_truncated: bool,
     pub filtered: String,
 }
 
@@ -266,6 +267,7 @@ pub fn run_streaming(
             raw: String::new(),
             raw_stdout: String::new(),
             raw_stderr: String::new(),
+            stdout_truncated: false,
             filtered: String::new(),
         });
     }
@@ -511,6 +513,7 @@ pub fn run_streaming(
         raw,
         raw_stdout,
         raw_stderr,
+        stdout_truncated: capped_out,
         filtered,
     })
 }
@@ -630,6 +633,7 @@ pub(crate) mod tests {
             raw: String::new(),
             raw_stdout: String::new(),
             raw_stderr: String::new(),
+            stdout_truncated: false,
             filtered: String::new(),
         };
         assert!(r.success());
@@ -642,6 +646,7 @@ pub(crate) mod tests {
             raw: String::new(),
             raw_stdout: String::new(),
             raw_stderr: String::new(),
+            stdout_truncated: false,
             filtered: String::new(),
         };
         assert!(!r.success());
@@ -654,6 +659,7 @@ pub(crate) mod tests {
             raw: String::new(),
             raw_stdout: String::new(),
             raw_stderr: String::new(),
+            stdout_truncated: false,
             filtered: String::new(),
         };
         assert!(!r.success());
@@ -753,6 +759,7 @@ pub(crate) mod tests {
             result.raw.len() > 1_000_000,
             "Should have captured significant data"
         );
+        assert!(result.stdout_truncated);
     }
 
     #[test]
@@ -771,6 +778,7 @@ pub(crate) mod tests {
             "stderr in raw should be capped at ~10 MiB, got {} bytes",
             result.raw.len()
         );
+        assert!(!result.stdout_truncated);
     }
 
     #[test]


### PR DESCRIPTION
---
title: RTK pytest 结果真实性修复合并过程
status: source_ready
owner: Camus
template_id: report.merge_process.v1
template_source: team-ai-pack/templates/merge-process-template.md
related_prd: not_applicable
related_technical_plan: not_applicable
related_test_plan: not_applicable
related_test_set: not_applicable
last_updated: 2026-08-10
---

# 合并过程：RTK pytest 结果真实性修复

> 本改动只修复 pytest 压缩输出的结果判定，并复用捕获层的截断事实；不增加通用超时、不恢复 Safe Runner child deadline、不触碰业务 runtime。

## 产品汇报（与 Multica 正文对齐）

### 需求对象与用户价值

- 问题：pytest 已经收集或执行测试，但摘要未被识别时，RTK 会把“无法判断”误报成“没有测试”，让用户误以为测试没有运行。
- 用户价值：用户继续得到真实退出码、可识别的通过/失败/跳过/收集数量、子测试数量和失败位置；摘要不完整时会明确看到“无法解析”，不会得到编造结论。
- 如果不改：长时间运行、静默输出、摘要格式变化或捕获截断都会继续制造错误 no-tests 结论，掩盖真实失败。

### 目标边界

- In scope：pytest 单一解析主路、直接 pytest 执行的退出码与 stdout 截断事实传入、摘要识别、计数、失败位置和原始日志路径 fixtures。
- Out of scope：Safe Runner、通用超时、10 MiB 捕获上限数值、其他 test/lint wrapper 的行为、业务 runtime、生产发布。
- 历史相关卡 / 依赖：PR #1877 的本地异常证据；当前代码基于 `origin/develop` 的 RTK pytest wrapper。

### 当前进度判断

- 已完成：红灯复现、根因确认、最小解析修复、24 条 pytest 夹具、捕获截断观测 fixture、直接二进制退出码/失败位置/无法解析日志验证、两轮独立复核问题修正。
- 进行中：本地提交、远程 PR、PR CI 和主线读回。
- 未完成 / 缺口 / 阻塞：本地全量测试仍有 9 个未触达的 curl/SQLite 基线环境失败；远程 CI 尚未消费本提交。

### RCA / 解决判断

- 现象：原解析器五类计数全为零时直接输出 `No tests collected`；摘要缺失、格式未识别和捕获截断都会进入这条分支。
- 根因或判断：摘要缺失不等于无测试；原逻辑没有保留“是否见到摘要”、`collected` 数量或真实退出码的判定上下文。
- 处理或方案：直接 pytest 改走带真实退出码的既有 runner 入口；解析器单一路径记录 collected、摘要和显式 no-tests 信号，只有显式 no-tests 或 `collected 0 + pytest exit 5` 才输出 no-tests，其余降级为无法解析并保留退出码与失败位置。
- 验证或待决策点：24 条解析夹具、捕获层 10 MiB 边界 fixture、49 条 Python 命令测试、Clippy 和真实二进制 pass/fail/no-tests/exit 4 已通过；最终独立复核、PR exact-head CI 和目标分支读回仍待完成。

### 完整改动逻辑

- 改动前：`pytest` 进入捕获 runner，过滤器只从摘要计数推断结果；所有零计数都被压成 no-tests。
- 触发条件：直接执行 `rtk pytest ...` 时，既有 runner 把真实子进程退出码传给 pytest 解析器；管道输入继续复用兼容入口。
- 唯一主路径：捕获层提供 stdout 与“是否截断”事实 → 清理 ANSI → 读取 collected → 识别唯一终态摘要 → 校验摘要与退出码 → 解析 passed/failed/skipped/xfail/xpass/error/subtests → 输出压缩结果。
- 阻塞 / 失败路径：pytest exit 5 且 collected 不为正才输出 no-tests；无摘要、多摘要、截断、exit 0/1 与摘要冲突、或 exit 2/3/4 异常退出时统一输出“无法解析”、真实退出码、已知 collected、失败位置和原始日志路径。
- 生产者与消费者：pytest 子进程产生 stdout/stderr 与退出码；既有 stream 捕获层额外暴露 stdout 是否超过既有 10 MiB 上限；runner 仅为 pytest 传入该事实并用 stdout+stderr 计算输出预算；`main` 继续消费真实返回码，`pipe_cmd` 继续消费无退出码兼容入口。没有新增旁路 writer 或业务状态文件。
- 兼容与迁移：保留原有 xfail/xpass、失败摘要和管道入口；ANSI、quiet-mode、单等号和子测试摘要进入同一解析主路。
- 回滚：回退本 PR 的 squash commit，恢复原 pytest 过滤器；不需要迁移数据或切换运行时配置。

### 交付物、现阶段结论与下一步

- 交付物 / 证据索引：`src/cmds/python/pytest_cmd.rs`；`outputs/rtk-pytest-truth/pytest-regression-final3.log`；`python-consumers-final2.log`；`clippy-final3.log`；`all-tests-final.log`。
- 现阶段结论：source 层和本地直接消费者层证明 pytest 不再把摘要缺失误报为 no-tests；尚未证明 PR CI、main 或线上消费。
- 下一步：提交并推送分支，创建 PR，等待 required CI，按 exact-head 合并并回读 main；runtime/online regression 不适用。

## Discovery Gate

- task classification: C - 已有 wrapper 的局部 bug 修复
- research_status: not_required
- research_depth: baseline
- formal_research_reason: not_applicable
- internal_sources: `src/cmds/python/pytest_cmd.rs`; `src/core/runner.rs`; `src/core/stream.rs`; `src/cmds/system/pipe_cmd.rs`; `CLAUDE.md`
- external_sources: not_applicable
- source_intake_artifact: not_applicable
- research_conclusion: 复用现有 pytest runner 和 tee 路径，只收紧解析判定
- research_gap: none
- 调研结论: 复用现有主路；不新增通用 timeout、旁路或状态文件
- authority_plan: not_applicable
- test_plan: not_applicable
- test_set: not_applicable
- acceptance_registry: not_applicable
- mechanism_key: not_applicable
- metadata_note: 运行时退出码由既有 runner 产生；本 PR 只改变 pytest 输出层的可信判定和摘要保留。
- related surfaces: source / pytest direct caller / pipe caller / unit fixtures / local binary smoke / PR CI / main
- contracts / fixtures / smoke evidence: pytest parser fixtures and direct binary smoke recorded under `outputs/rtk-pytest-truth/`
- surface-freeze-exempt: not_applicable；只修改一个已有解析器文件和一个合并过程记录
- uncertainty / decision boundary: 10 MiB 捕获上限仍是既有合同；本 PR 只把捕获层已有的 stdout 截断事实暴露给 pytest 单一消费者，不改变上限、截断策略或其他 wrapper 行为。
- 预估命中率依据: not_applicable
- 误报代价: not_applicable
- 退出条件: not_applicable

## Change Summary

- User / project value: 让 RTK pytest 输出只报告已被底层摘要或退出码证明的结论。
- Actual changed behavior: 摘要缺失或不可识别时不再输出 `No tests collected`；直接 pytest 解析获得真实退出码，并保留 collected、子测试和失败位置。
- In scope: `src/cmds/python/pytest_cmd.rs`、`src/core/stream.rs` 的 stdout 截断观测字段、`src/core/runner.rs` 的 pytest 专用 capture-aware 入口与本合并过程记录。
- Out of scope: Safe Runner、超时、捕获上限数值、其他 wrapper 行为、hooks、业务 runtime、生产部署。
- Touched source / callers / tests / config / docs: pytest source and fixtures；stream 只暴露已有截断事实，runner 新入口仅由 pytest 消费，既有调用方默认行为不变。
- Runtime or external impact: none
- external_write: not_applicable
- external_endstate: pending_post_merge

## Validation Evidence

- targeted local / unit: pytest parser 24 passed; stream 10 MiB 截断边界 fixture passed; Python command consumer suite 49 passed; `cargo fmt --all -- --check`; `cargo clippy --all-targets` passed。
- selected stable test cases: normal pass, failure, explicit no-tests, collected-but-summary-missing, quiet/ANSI/non-standard summary, silent interval then pass, 10 MiB 真实捕获截断、伪终态摘要、exit 2/3/4、stderr-only 参数错误、xfail/xpass 和 mixed subtest counts。
- change-specific tests: `outputs/rtk-pytest-truth/pytest-regression-final3.log`
- smoke / E2E when required: real binary pass exit 0; real failure exit 1 with `/private/tmp/...py:2`; empty directory real pytest exit 5。
- PR / CI: pending push and exact-head CI
- skipped checks and reason: full local suite is not clean because 9 unrelated curl tee and tracking SQLite tests fail in this environment; see `all-tests-serial-isolated.log`。
- 旧调用方/旧数据兼容：pipe caller retains the one-argument compatibility function; no data migration。
- legacy fixture 或真实 oracle: parser fixture and real pytest subprocess smoke
- 行为是否变化: describe changed behavior
- online regression: not applicable before merge; no runtime or external consumption surface
- external owner write regression: not_applicable; no external owner write target

## Review Evidence

- required by current risk: yes
- fresh-context review（仅新高风险或当前合同要求，否则 not_applicable）: read-only explorer and code-reviewer review requested; no write access
- Codex review artifact / decision: pending final readback
- Fable review artifact / decision: not_applicable
- accepted findings and applied changes: 首轮发现精确伪摘要、伪 no-tests 横幅和 mixed subtests；第二轮发现 exit 2/3/4、真实捕获截断、stderr-only 空输出和冲突分支丢失败位置。全部收口到单一可信度判断和单一无法解析输出，均有 fixture 或真实二进制 smoke。
- rejected / deferred findings and reason: none；stdout truncation provenance 已按复核意见以只读字段实施，runner 保持唯一日志 writer
- reviewer boundary: review evidence is not CI, runtime, online acceptance, or external readback proof

## Merge Readiness

- source revision: local HEAD (PR head/CI/main pending; read back with `git rev-parse HEAD`)
- target branch: `develop`
- PR URL: pending
- review decision: pending
- required CI: pending
- mergeability: pending
- merge strategy: exact-head squash
- merge owner: repository maintainer
- rollback / revert path: revert the exact squash commit
- ready to merge: no

## Merge Result And Handoff

- merge commit: pending
- post-merge main readback: pending
- promoted runtime required: no
- next required document: not_applicable; no runtime/external acceptance surface
- Promote / runtime owner: not_applicable
- Online acceptance owner: not_applicable
- Final closeout remains blocked until: PR exact-head CI and main readback complete

## RCA 与风险

- 现象：已收集或已执行的 pytest 被压缩器误报为 no-tests。
- 根因或判断：缺少摘要存在性、collected 计数和退出码参与的可信判定；这是展示层误判，不是 pytest 子进程没有执行。
- 处理或方案：单一 exit-aware parser；未知结果保守降级，真实退出码由既有 runner 返回。
- 验证：红灯夹具先证明旧行为；24 条 pytest fixtures、捕获边界 fixture、49 条 Python consumer、真实二进制 smoke 和 Clippy 通过；全量测试的 9 个非相关失败已单独记录。
- 剩余风险：远程 PR CI/目标分支尚未验证；完整 suite 的 9 项环境基线失败仍由各自 owner 处理。
- 待决策点：无新增产品决策；只待外发授权、CI 与合并读回。
