### PR TITLE
feat(gain): add median ratio, concentration and above-ceiling to summary

### DIFF
--- a/src/analytics/gain.rs
+++ b/src/analytics/gain.rs
@@ -118,6 +118,33 @@ pub fn run(
                 format_duration(summary.avg_time_ms)
             ),
         );
+        print_kpi(
+            "Median ratio",
+            format!(
+                "{:.2}x ({:.0}% unchanged)",
+                summary.median_ratio, summary.pct_unchanged
+            ),
+        );
+        print_kpi(
+            "Concentration",
+            format!(
+                "top {} {} = {:.1}% of total savings",
+                summary.concentration_top_n,
+                if summary.concentration_top_n == 1 {
+                    "command"
+                } else {
+                    "commands"
+                },
+                summary.concentration_pct
+            ),
+        );
+        print_kpi(
+            "Above ceiling",
+            format!(
+                "{} / {} commands",
+                summary.above_ceiling, summary.total_commands
+            ),
+        );
         print_efficiency_meter(summary.avg_savings_pct);
         println!();
 

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -182,6 +182,38 @@ pub struct HookDecisionRecord {
     pub decision: HookOutcome,
 }
 
+/// Above this, raw output is unlikely to have reached the model at all: agent CLIs
+/// truncate tool output first (~30k chars at roughly 4 chars per token).
+pub const CONTEXT_CEILING_TOKENS: usize = 7500;
+
+const CONCENTRATION_TOP_N: usize = 8;
+
+/// Median of a set of ratios. Empty input means nothing was measurable, which is
+/// reported as 1.0 (unchanged) rather than 0.0 (perfect compression).
+fn median(values: &mut [f64]) -> f64 {
+    if values.is_empty() {
+        return 1.0;
+    }
+    values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mid = values.len() / 2;
+    if values.len().is_multiple_of(2) {
+        (values[mid - 1] + values[mid]) / 2.0
+    } else {
+        values[mid]
+    }
+}
+
+/// Share of total savings held by the largest few commands, with the count actually used.
+fn concentration(saved: &mut [usize], total_saved: usize) -> (f64, usize) {
+    if saved.is_empty() || total_saved == 0 {
+        return (0.0, 0);
+    }
+    saved.sort_unstable_by(|a, b| b.cmp(a));
+    let n = saved.len().min(CONCENTRATION_TOP_N);
+    let top: usize = saved[..n].iter().sum();
+    ((top as f64 / total_saved as f64) * 100.0, n)
+}
+
 /// Aggregated statistics across all recorded commands.
 ///
 /// Provides overall metrics and breakdowns by command and by day.
@@ -206,6 +238,16 @@ pub struct GainSummary {
     pub by_command: Vec<(String, usize, usize, f64, u64)>,
     /// Last 30 days of activity: (date, saved_tokens)
     pub by_day: Vec<(String, usize)>,
+    /// Median of output/input across commands; 1.0 means the typical command is unchanged
+    pub median_ratio: f64,
+    /// Percentage of commands whose output was returned byte-for-byte
+    pub pct_unchanged: f64,
+    /// Share of total savings held by the largest `concentration_top_n` commands
+    pub concentration_pct: f64,
+    /// How many commands that share covers (at most 8, fewer if less data exists)
+    pub concentration_top_n: usize,
+    /// Commands whose raw output exceeded CONTEXT_CEILING_TOKENS
+    pub above_ceiling: usize,
 }
 
 /// Daily statistics for token savings and execution metrics.
@@ -826,6 +868,10 @@ impl Tracker {
         let mut total_output = 0usize;
         let mut total_saved = 0usize;
         let mut total_time_ms = 0u64;
+        let mut ratios: Vec<f64> = Vec::new();
+        let mut saved_each: Vec<usize> = Vec::new();
+        let mut unchanged = 0usize;
+        let mut above_ceiling = 0usize;
 
         let mut stmt = self.conn.prepare(
             "SELECT input_tokens, output_tokens, saved_tokens, exec_time_ms
@@ -850,7 +896,25 @@ impl Tracker {
             total_output += output;
             total_saved += saved;
             total_time_ms += time_ms;
+            saved_each.push(saved);
+            if input > 0 {
+                ratios.push(output as f64 / input as f64);
+            }
+            if input == output {
+                unchanged += 1;
+            }
+            if input > CONTEXT_CEILING_TOKENS {
+                above_ceiling += 1;
+            }
         }
+
+        let median_ratio = median(&mut ratios);
+        let pct_unchanged = if total_commands > 0 {
+            (unchanged as f64 / total_commands as f64) * 100.0
+        } else {
+            0.0
+        };
+        let (concentration_pct, concentration_top_n) = concentration(&mut saved_each, total_saved);
 
         let avg_savings_pct = if total_input > 0 {
             (total_saved as f64 / total_input as f64) * 100.0
@@ -877,6 +941,11 @@ impl Tracker {
             avg_time_ms,
             by_command,
             by_day,
+            median_ratio,
+            pct_unchanged,
+            concentration_pct,
+            concentration_top_n,
+            above_ceiling,
         })
     }
 
@@ -1794,6 +1863,59 @@ pub fn args_display(args: &[OsString]) -> String {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn median_empty_reports_unchanged() {
+        assert_eq!(median(&mut []), 1.0);
+    }
+
+    #[test]
+    fn median_single_value() {
+        assert_eq!(median(&mut [0.25]), 0.25);
+    }
+
+    #[test]
+    fn median_even_count_averages_middle_pair() {
+        assert_eq!(median(&mut [0.2, 0.4, 0.6, 0.8]), 0.5);
+    }
+
+    #[test]
+    fn median_odd_count_takes_centre() {
+        assert_eq!(median(&mut [0.9, 0.1, 0.5]), 0.5);
+    }
+
+    #[test]
+    fn concentration_empty_is_zero() {
+        assert_eq!(concentration(&mut [], 0), (0.0, 0));
+    }
+
+    #[test]
+    fn concentration_with_no_savings_is_zero() {
+        assert_eq!(concentration(&mut [0, 0, 0], 0), (0.0, 0));
+    }
+
+    #[test]
+    fn concentration_fewer_than_top_n_uses_what_exists() {
+        let (pct, n) = concentration(&mut [30, 70], 100);
+        assert_eq!(n, 2);
+        assert!((pct - 100.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn concentration_caps_at_top_n_and_takes_largest() {
+        // ten commands, 100 saved each; the top 8 hold 80% of the 1000 total
+        let (pct, n) = concentration(&mut [100; 10], 1000);
+        assert_eq!(n, 8);
+        assert!((pct - 80.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn concentration_is_dominated_by_one_outlier() {
+        // the shape this metric exists to expose
+        let (pct, n) = concentration(&mut [900, 10, 10, 10, 10, 10, 10, 10, 10, 10], 990);
+        assert_eq!(n, 8);
+        assert!(pct > 97.0, "one command should dominate, got {pct}");
+    }
     use super::*;
     use std::sync::Mutex;
 


### PR DESCRIPTION
Closes #3507.

`rtk gain` reports totals and averages only. Command output sizes are long-tailed, so a mean describes almost none of the population.

On my install — 10,376 commands, 90-day window — the headline reads **96.5% saved**, while the **median** command is **0.97x** and **53%** come back byte-for-byte unchanged. Both are true; only the first was visible.

## What it adds

Three lines in the summary block, using the existing `print_kpi` helper:

```
Median ratio:      0.97x (53% unchanged)
Concentration:     top 8 commands = 92.1% of total savings
Above ceiling:     396 / 10376 commands
```

- **Median ratio** — median of `output_tokens / input_tokens`, skipping rows with zero input. Empty input reports `1.0` (unchanged) rather than `0.0`, so "no data" never reads as "perfect compression".
- **Concentration** — share of total savings held by the largest 8 commands, with the count actually used so it stays honest on small datasets. This exists because a single recursive grep can dominate the total: on my data one command is 69% of it.
- **Above ceiling** — commands whose raw output exceeded `CONTEXT_CEILING_TOKENS` (7500, ~30k chars at ~4 chars/token), roughly where agent CLIs truncate. Makes the tail visible **without changing anything that is stored or how savings are computed**.

## Scope

Additive only — **149 insertions, 0 deletions.** No existing output line changes, no stored value changes, no new config key or CLI flag. `GainSummary` gains five fields, appended; nothing reordered.

## Verification

- `cargo fmt --check` clean
- `cargo clippy` clean
- `cargo test` — 2585 passed, 9 of them new

The new tests cover the empty set, a single value, even and odd counts for the median, zero savings, fewer commands than the top-N window, and the single-outlier shape the concentration metric exists to expose.

Numbers were cross-checked against an independent implementation reading the same database; median, unchanged percentage, concentration and above-ceiling count all agree.

## One thing worth flagging

Two tests fail on `develop` before this branch — `hooks::rewrite_cmd::tests::unattestable_passthrough::{test_plain_command_still_rewrites, test_fd_dup_redirect_still_rewrites}`. I confirmed they fail identically with this change stashed, so they are pre-existing and unrelated, but CI will be red until they are addressed. Happy to open a separate issue if that is useful.

## Note on process

The display code was drafted with an AI assistant and the statistics implementation, tests, and verification are mine; every line was reviewed and built locally before pushing. Flagging it since the project seems to work with agents openly.
