### PR TITLE
fix: preserve pytest and truncated output truth

### DIFF
--- a/src/cmds/python/pytest_cmd.rs
+++ b/src/cmds/python/pytest_cmd.rs
@@ -1,6 +1,5 @@
 //! Filters pytest output to show only failures and the summary line.
 
-use crate::core::config;
 use crate::core::runner;
 use crate::core::truncate::CAP_WARNINGS;
 use crate::core::utils::{resolved_command, strip_ansi, tool_exists, truncate};
@@ -52,20 +51,15 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         eprintln!("Running: pytest --tb=short -q {}", args.join(" "));
     }
 
-    runner::run_filtered_with_exit(
+    runner::run_filtered_with_facts(
         cmd,
         "pytest",
         &args.join(" "),
-        |raw, exit_code| {
+        |raw, exit_code, capture| {
             let clean = strip_ansi(raw);
-            let filtered = filter_pytest_output(&clean);
-            // Any other failure parsed as empty means the run broke before reporting.
-            if exit_code != 0 && exit_code != PYTEST_EXIT_NO_TESTS && filtered == PYTEST_NO_TESTS {
-                return truncate(clean.trim(), config::limits().passthrough_max_chars);
-            }
-            filtered
+            filter_pytest_output_with_exit(&clean, exit_code, !capture.complete())
         },
-        runner::RunOptions::stdout_only().tee("pytest"),
+        runner::RunOptions::with_tee("pytest").force_tee_on_unparseable(),
     )
 }
 
@@ -73,6 +67,175 @@ const PYTEST_NO_TESTS: &str = "Pytest: No tests collected";
 const PYTEST_EXIT_NO_TESTS: i32 = 5;
 
 pub(crate) fn filter_pytest_output(output: &str) -> String {
+    validate_and_render_pytest_output(output, None, false)
+}
+
+fn filter_pytest_output_with_exit(
+    output: &str,
+    exit_code: i32,
+    capture_truncated: bool,
+) -> String {
+    validate_and_render_pytest_output(output, Some(exit_code), capture_truncated)
+}
+
+fn validate_and_render_pytest_output(
+    output: &str,
+    exit_code: Option<i32>,
+    capture_truncated: bool,
+) -> String {
+    let summaries = terminal_summary_lines(output);
+    let (collected, collected_conflict) = parse_collected(output);
+    let exit_display = exit_code
+        .map(|code| code.to_string())
+        .unwrap_or_else(|| "unavailable".to_string());
+
+    let explicit_no_tests = summaries.len() == 1
+        && summaries[0].to_ascii_lowercase().contains("no tests ran")
+        && collected.unwrap_or(0) == 0
+        && !collected_conflict;
+    if explicit_no_tests && exit_code.is_none_or(|code| code == PYTEST_EXIT_NO_TESTS) {
+        return PYTEST_NO_TESTS.to_string();
+    }
+
+    let mut reason = None;
+    if capture_truncated {
+        reason = Some("stdout/stderr capture truncated");
+    } else if collected_conflict {
+        reason = Some("conflicting collected counts");
+    } else if summaries.len() != 1 {
+        reason = Some(if summaries.is_empty() {
+            "terminal summary missing"
+        } else {
+            "multiple terminal summaries"
+        });
+    } else if matches!(exit_code, Some(2 | 3 | 4)) {
+        reason = Some("pytest interrupted or usage/internal error");
+    } else if exit_code == Some(PYTEST_EXIT_NO_TESTS) {
+        reason = Some("exit code 5 without explicit zero collection");
+    }
+
+    let counts = summaries
+        .first()
+        .map(|line| parse_summary_line(line))
+        .unwrap_or_default();
+    let failure_outcomes = counts.failed + counts.errors + counts.subtests_failed;
+    let success_outcomes = counts.passed
+        + counts.skipped
+        + counts.xfailed
+        + counts.xpassed
+        + counts.subtests_passed;
+
+    if reason.is_none() {
+        match exit_code {
+            Some(0) if failure_outcomes > 0 || success_outcomes == 0 => {
+                reason = Some("exit code conflicts with terminal summary")
+            }
+            Some(1) if failure_outcomes == 0 => {
+                reason = Some("exit code conflicts with terminal summary")
+            }
+            Some(code) if code != 0 && code != 1 => {
+                reason = Some("unsupported pytest exit code for parsed summary")
+            }
+            None if failure_outcomes + success_outcomes == 0 => {
+                reason = Some("terminal summary has no recognized outcomes")
+            }
+            _ => {}
+        }
+    }
+
+    if let Some(reason) = reason {
+        return unparseable_pytest_result(output, &exit_display, collected, reason);
+    }
+
+    let rendered = render_pytest_output(output);
+    match collected {
+        Some(value) => format!("{rendered}\ncollected: {value}"),
+        None => rendered,
+    }
+}
+
+fn terminal_summary_lines(output: &str) -> Vec<&str> {
+    output
+        .lines()
+        .map(str::trim)
+        .filter(|line| {
+            let lower = line.to_ascii_lowercase();
+            let outcome = lower.contains(" passed")
+                || lower.contains(" failed")
+                || lower.contains(" skipped")
+                || lower.contains(" error")
+                || lower.contains(" xfailed")
+                || lower.contains(" xpassed")
+                || lower.contains(" subtest")
+                || lower.contains("no tests ran");
+            let terminal_shape = lower.contains(" in ")
+                && (!line.starts_with("===") || line.ends_with("==="));
+            outcome && terminal_shape && !line.starts_with("FAILED") && !line.starts_with("ERROR")
+        })
+        .collect()
+}
+
+fn parse_collected(output: &str) -> (Option<usize>, bool) {
+    let mut values = Vec::new();
+    for line in output.lines().map(str::trim) {
+        let Some(rest) = line.strip_prefix("collected ") else {
+            continue;
+        };
+        let Some(word) = rest.split_whitespace().next() else {
+            continue;
+        };
+        if let Ok(value) = word.parse::<usize>() {
+            values.push(value);
+        }
+    }
+    let first = values.first().copied();
+    let conflict = first.is_some_and(|value| values.iter().any(|other| *other != value));
+    (first, conflict)
+}
+
+fn unparseable_pytest_result(
+    output: &str,
+    exit_display: &str,
+    collected: Option<usize>,
+    reason: &str,
+) -> String {
+    let mut result = format!(
+        "Pytest: result could not be parsed (exit code {exit_display})\nreason: {reason}"
+    );
+    if let Some(value) = collected {
+        result.push_str(&format!("\ncollected: {value}"));
+    }
+    let locations = failure_locations(output);
+    if !locations.is_empty() {
+        result.push_str("\nFailure positions:\n");
+        for location in locations.iter().take(MAX_PYTEST_FAILURES) {
+            result.push_str("  ");
+            result.push_str(location);
+            result.push('\n');
+        }
+    }
+    result.trim_end().to_string()
+}
+
+fn failure_locations(output: &str) -> Vec<String> {
+    let mut locations = Vec::new();
+    for line in output.lines().map(str::trim) {
+        let looks_like_location = line.starts_with("FAILED ")
+            || line.starts_with("ERROR ")
+            || line.split_whitespace().any(|word| {
+                let Some((path, number)) = word.rsplit_once(':') else {
+                    return false;
+                };
+                path.ends_with(".py") && number.trim_end_matches(':').parse::<usize>().is_ok()
+            });
+        if looks_like_location && !locations.iter().any(|item| item == line) {
+            locations.push(truncate(line, 160));
+        }
+    }
+    locations
+}
+
+fn render_pytest_output(output: &str) -> String {
     let mut state = ParseState::Header;
     let mut test_files: Vec<String> = Vec::new();
     let mut failures: Vec<String> = Vec::new();
@@ -101,7 +264,9 @@ pub(crate) fn filter_pytest_output(output: &str) -> String {
         } else if trimmed.starts_with("===")
             && (trimmed.contains("passed")
                 || trimmed.contains("failed")
-                || trimmed.contains("skipped"))
+                || trimmed.contains("skipped")
+                || trimmed.contains("error")
+                || trimmed.contains("subtest"))
         {
             summary_line = trimmed.to_string();
             continue;
@@ -112,7 +277,9 @@ pub(crate) fn filter_pytest_output(output: &str) -> String {
             && !trimmed.starts_with("ERROR")
             && (trimmed.contains(" passed")
                 || trimmed.contains(" failed")
-                || trimmed.contains(" skipped"))
+                || trimmed.contains(" skipped")
+                || trimmed.contains(" error")
+                || trimmed.contains(" subtest"))
             && trimmed.contains(" in ")
         {
             summary_line = trimmed.to_string();
@@ -175,6 +342,9 @@ struct PytestCounts {
     skipped: usize,
     xfailed: usize,
     xpassed: usize,
+    errors: usize,
+    subtests_passed: usize,
+    subtests_failed: usize,
 }
 
 fn build_pytest_summary(
@@ -190,13 +360,30 @@ fn build_pytest_summary(
         skipped,
         xfailed,
         xpassed,
+        errors,
+        subtests_passed,
+        subtests_failed,
     } = counts;
 
-    if passed == 0 && failed == 0 && skipped == 0 && xfailed == 0 && xpassed == 0 {
+    if passed == 0
+        && failed == 0
+        && skipped == 0
+        && xfailed == 0
+        && xpassed == 0
+        && errors == 0
+        && subtests_passed == 0
+        && subtests_failed == 0
+    {
         return PYTEST_NO_TESTS.to_string();
     }
 
-    let extras_present = skipped > 0 || xfailed > 0 || xpassed > 0 || !xfail_lines.is_empty();
+    let extras_present = skipped > 0
+        || xfailed > 0
+        || xpassed > 0
+        || errors > 0
+        || subtests_passed > 0
+        || subtests_failed > 0
+        || !xfail_lines.is_empty();
 
     if failed == 0 && passed > 0 && !extras_present {
         return format!("Pytest: {} passed", passed);
@@ -212,6 +399,15 @@ fn build_pytest_summary(
     }
     if xpassed > 0 {
         result.push_str(&format!(", {} xpassed", xpassed));
+    }
+    if errors > 0 {
+        result.push_str(&format!(", {} error{}", errors, if errors == 1 { "" } else { "s" }));
+    }
+    if subtests_passed > 0 {
+        result.push_str(&format!(", {} subtests passed", subtests_passed));
+    }
+    if subtests_failed > 0 {
+        result.push_str(&format!(", {} subtest{} failed", subtests_failed, if subtests_failed == 1 { "" } else { "s" }));
     }
     result.push('\n');
 
@@ -302,26 +498,32 @@ fn parse_summary_line(summary: &str) -> PytestCounts {
 
     // Parse lines like "=== 4 passed, 1 failed, 2 xfailed, 1 xpassed in 0.50s ==="
     for part in summary.split(',') {
-        let words: Vec<&str> = part.split_whitespace().collect();
-        for (i, word) in words.iter().enumerate() {
-            if i == 0 {
-                continue;
-            }
-            let Ok(n) = words[i - 1].parse::<usize>() else {
-                continue;
-            };
-            // Order matters: "xpassed"/"xfailed" contain "passed"/"failed".
-            if word.contains("xpassed") {
-                counts.xpassed = n;
-            } else if word.contains("xfailed") {
-                counts.xfailed = n;
-            } else if word.contains("passed") {
-                counts.passed = n;
-            } else if word.contains("failed") {
-                counts.failed = n;
-            } else if word.contains("skipped") {
-                counts.skipped = n;
-            }
+        let normalized = part
+            .trim_matches('=')
+            .trim()
+            .to_ascii_lowercase();
+        let Some(n) = normalized
+            .split_whitespace()
+            .find_map(|word| word.parse::<usize>().ok())
+        else {
+            continue;
+        };
+        if normalized.contains("subtest") && normalized.contains("failed") {
+            counts.subtests_failed = n;
+        } else if normalized.contains("subtest") && normalized.contains("passed") {
+            counts.subtests_passed = n;
+        } else if normalized.contains("xpassed") {
+            counts.xpassed = n;
+        } else if normalized.contains("xfailed") {
+            counts.xfailed = n;
+        } else if normalized.contains("passed") {
+            counts.passed = n;
+        } else if normalized.contains("failed") {
+            counts.failed = n;
+        } else if normalized.contains("skipped") {
+            counts.skipped = n;
+        } else if normalized.contains("error") {
+            counts.errors = n;
         }
     }
 
@@ -527,5 +729,93 @@ collected 3 items
             "Should not say 'No tests collected' when tests were skipped. Got: {}",
             result
         );
+    }
+
+    #[test]
+    fn test_truth_matrix_only_exit_five_with_explicit_zero_collection_is_no_tests() {
+        let no_tests = "=== test session starts ===\ncollected 0 items\n\n=== no tests ran in 0.00s ===\n";
+        assert_eq!(
+            filter_pytest_output_with_exit(no_tests, PYTEST_EXIT_NO_TESTS, false),
+            PYTEST_NO_TESTS
+        );
+        assert_eq!(
+            filter_pytest_output_with_exit(
+                "no tests ran in 0.00s\n",
+                PYTEST_EXIT_NO_TESTS,
+                false,
+            ),
+            PYTEST_NO_TESTS
+        );
+
+        let positive_collection =
+            "=== test session starts ===\ncollected 3 items\n\n=== no tests ran in 0.00s ===\n";
+        let result = filter_pytest_output_with_exit(
+            positive_collection,
+            PYTEST_EXIT_NO_TESTS,
+            false,
+        );
+        assert!(result.contains("result could not be parsed (exit code 5)"));
+        assert!(result.contains("collected: 3"));
+    }
+
+    #[test]
+    fn test_truth_matrix_rejects_exit_and_summary_conflicts() {
+        let success = "collected 3 items\n=== 3 passed in 0.10s ===\n";
+        let result = filter_pytest_output_with_exit(success, 1, false);
+        assert!(result.contains("result could not be parsed (exit code 1)"));
+        assert!(!result.contains("Pytest: 3 passed"));
+
+        let failure = "collected 1 item\nFAILED tests/test_x.py::test_x - AssertionError\n=== 1 failed in 0.10s ===\n";
+        let result = filter_pytest_output_with_exit(failure, 0, false);
+        assert!(result.contains("result could not be parsed (exit code 0)"));
+        assert!(result.contains("tests/test_x.py::test_x"));
+    }
+
+    #[test]
+    fn test_truth_matrix_rejects_missing_multiple_and_truncated_summaries() {
+        let missing = "=== test session starts ===\ncollected 2 items\ntests/test_x.py ..\n";
+        assert!(filter_pytest_output_with_exit(missing, 0, false)
+            .contains("result could not be parsed (exit code 0)"));
+
+        let multiple = "collected 2 items\n=== 1 passed in 0.01s ===\n=== 2 passed in 0.02s ===\n";
+        assert!(filter_pytest_output_with_exit(multiple, 0, false)
+            .contains("result could not be parsed (exit code 0)"));
+
+        let truncated = "collected 2 items\n=== 2 passed in 0.02s ===\n";
+        let result = filter_pytest_output_with_exit(truncated, 0, true);
+        assert!(result.contains("result could not be parsed (exit code 0)"));
+        assert!(result.contains("capture truncated"));
+    }
+
+    #[test]
+    fn test_truth_matrix_preserves_collected_errors_subtests_and_failure_locations() {
+        let output = r#"=== test session starts ===
+collected 7 items
+
+=== FAILURES ===
+___ test_parent ___
+tests/test_parent.py:42: AssertionError
+
+=== short test summary info ===
+FAILED tests/test_parent.py::test_parent - AssertionError
+=== 4 passed, 1 failed, 1 error, 3 subtests passed, 1 subtest failed in 0.20s ==="#;
+        let result = filter_pytest_output_with_exit(output, 1, false);
+        assert!(result.contains("collected: 7"));
+        assert!(result.contains("4 passed, 1 failed"));
+        assert!(result.contains("1 error"));
+        assert!(result.contains("3 subtests passed"));
+        assert!(result.contains("1 subtest failed"));
+        assert!(result.contains("tests/test_parent.py:42"));
+    }
+
+    #[test]
+    fn test_truth_matrix_exit_two_three_four_are_always_unparseable() {
+        let looks_successful = "collected 1 item\n=== 1 passed in 0.01s ===\n";
+        for exit_code in [2, 3, 4] {
+            let result = filter_pytest_output_with_exit(looks_successful, exit_code, false);
+            assert!(result.contains(&format!(
+                "result could not be parsed (exit code {exit_code})"
+            )));
+        }
     }
 }

--- a/src/cmds/python/uv_cmd.rs
+++ b/src/cmds/python/uv_cmd.rs
@@ -75,7 +75,14 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         result.exit_code,
     );
 
-    runner::print_with_hint(&filtered, &result.raw, &result.raw, "uv", result.exit_code);
+    runner::print_with_hint(
+        &filtered,
+        &result.raw,
+        &result.raw,
+        "uv",
+        result.exit_code,
+        !result.stdout_truncated && !result.stderr_truncated,
+    );
     timer.track(&original_cmd, &rtk_cmd, &result.raw, &filtered);
 
     Ok(result.exit_code)

--- a/src/cmds/system/search.rs
+++ b/src/cmds/system/search.rs
@@ -110,19 +110,9 @@ fn parse_cluster(rest: &str) -> ClusterResult {
     ClusterResult::Boolean((!raw_prefix.is_empty()).then_some(raw_prefix))
 }
 
-/// Unique, descriptive tee slug for a file's overflow matches. `idx` disambiguates
-/// files within one grep; the tee filename's epoch handles separate runs.
-fn grep_slug(idx: usize, path: &str) -> String {
-    let cleaned: String = path
-        .chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
-        .collect();
-    let tail = &cleaned[cleaned.len().saturating_sub(32)..];
-    format!("grep_{}_{}", idx, tail)
-}
-
 /// Format a file's matches as `path<sep>line<sep>content`. Tee blocks use the
 /// real (un-compacted) `path` so recovered lines stay openable.
+#[cfg(test)]
 fn match_block(path: &str, entries: &[(usize, bool, String)]) -> String {
     let mut s = String::new();
     for (line_num, is_match, content) in entries {
@@ -372,8 +362,12 @@ impl StreamFilter for SearchStreamFilter {
             }
             self.cap_reported = true;
             return Some(format!(
-                "[rtk] output capped at {} results\n",
-                self.max_results
+                "[rtk] output capped at {} results\n{}\n",
+                self.max_results,
+                crate::core::tee::incomplete_output_meta_marker(
+                    "grep_stream_result_limit",
+                    Some(self.shown),
+                )
             ));
         }
 
@@ -617,7 +611,9 @@ pub fn run(
     let show_file = by_file.len() > 1 || show_file(&paths, &extra_args);
     let show_line = show_line(&extra_args);
 
-    // Faithful baseline: exactly what the real command prints, full content.
+    // Faithful user-visible baseline: the same text shape as the real command.
+    // Recovery stores this canonical display output, not the engine's internal
+    // NUL-delimited parse stream.
     let mut plain = String::new();
     for line in raw_output.lines() {
         let Some(output) = format_match_line(line, show_file, show_line) else {
@@ -638,11 +634,9 @@ pub fn run(
     let mut body = String::new();
     let mut shown = 0;
     let mut skipped_files = 0;
-    let mut skipped_block = String::new();
-    for (idx, (file, entries)) in files.into_iter().enumerate() {
+    for (file, entries) in files {
         if shown >= max_results {
             skipped_files += 1;
-            skipped_block.push_str(&match_block(file, entries));
             continue;
         }
 
@@ -676,23 +670,11 @@ pub fn run(
         if remaining == 0 {
             continue;
         }
-        // Tee the file's full matches (real path) so the tail hint recovers them
-        // openably, skipping the lines already shown.
-        let full_block = match_block(file, entries);
-        match crate::core::tee::force_tee_tail_hint(&full_block, &grep_slug(idx, file), file_shown + 1)
-        {
-            Some(hint) => {
-                body.push_str(&format!("  +{} more in {} {}\n", remaining, file_display, hint))
-            }
-            None => body.push_str(&format!("  +{} more in {}\n", remaining, file_display)),
-        }
+        body.push_str(&format!("  +{} more in {}\n", remaining, file_display));
     }
 
     if skipped_files > 0 {
-        let hint = crate::core::tee::force_tee_tail_hint(&skipped_block, "grep_skipped", 1)
-            .map(|h| format!(" {}", h))
-            .unwrap_or_default();
-        body.push_str(&format!("+{} more files{}\n", skipped_files, hint));
+        body.push_str(&format!("+{} more files\n", skipped_files));
     }
 
     // Switch to the grouped form only when capping actually shrank the output;
@@ -709,8 +691,27 @@ pub fn run(
         body
     };
 
+    let total_records: usize = by_file.values().map(Vec::len).sum();
+    let omitted_records = total_records.saturating_sub(shown);
     let output = if capped && rtk_output.len() < plain.len() {
-        rtk_output
+        match crate::core::tee::force_tee_artifact(&plain, "grep") {
+            Some(artifact) if artifact.complete => {
+                let recovery = crate::core::tee::full_output_recovery(
+                    &artifact,
+                    "grep_result_limit",
+                    Some(exit_code),
+                    Some(shown),
+                    Some(omitted_records),
+                );
+                let candidate = format!("{rtk_output}{recovery}\n");
+                if candidate.len() < plain.len() {
+                    candidate
+                } else {
+                    plain
+                }
+            }
+            _ => plain,
+        }
     } else {
         plain
     };
@@ -900,10 +901,24 @@ mod tests {
             filter.feed_line(concat!("(standard input)\0", "1:first")),
             Some("1:first\n".to_string())
         );
-        assert_eq!(
-            filter.feed_line(concat!("(standard input)\0", "2:second")),
-            Some("[rtk] output capped at 1 results\n".to_string())
-        );
+        let capped = filter
+            .feed_line(concat!("(standard input)\0", "2:second"))
+            .expect("cap notice");
+        assert!(capped.starts_with("[rtk] output capped at 1 results\n"));
+        let marker = capped
+            .lines()
+            .find(|line| line.starts_with(crate::core::tee::OUTPUT_META_PREFIX))
+            .expect("machine-readable cap metadata");
+        let parsed: serde_json::Value = serde_json::from_str(
+            marker
+                .strip_prefix(crate::core::tee::OUTPUT_META_PREFIX)
+                .expect("metadata prefix"),
+        )
+        .expect("valid cap metadata");
+        assert_eq!(parsed["truncated"], true);
+        assert_eq!(parsed["reason"], "grep_stream_result_limit");
+        assert_eq!(parsed["shown_records"], 1);
+        assert!(parsed["artifact"].is_null());
         assert_eq!(
             filter.feed_line(concat!("(standard input)\0", "3:third")),
             None

--- a/src/core/runner.rs
+++ b/src/core/runner.rs
@@ -25,8 +25,14 @@ pub fn print_with_hint(
     guard_raw: &str,
     tee_label: &str,
     exit_code: i32,
+    source_complete: bool,
 ) -> String {
-    let hint = crate::core::tee::tee_and_hint(tee_raw, tee_label, exit_code);
+    let hint = crate::core::tee::tee_and_hint_with_source_completeness(
+        tee_raw,
+        tee_label,
+        exit_code,
+        source_complete,
+    );
     emit_guarded(filtered, hint.as_deref(), guard_raw)
 }
 
@@ -40,6 +46,7 @@ pub struct RunOptions<'a> {
     /// can read from a pipe (e.g. `cat file | rtk wc`); without it the child
     /// gets an empty stdin and reports zero.
     pub inherit_stdin: bool,
+    pub force_tee_on_unparseable: bool,
 }
 
 impl<'a> RunOptions<'a> {
@@ -76,14 +83,33 @@ impl<'a> RunOptions<'a> {
         self.inherit_stdin = true;
         self
     }
+
+    pub fn force_tee_on_unparseable(mut self) -> Self {
+        self.force_tee_on_unparseable = true;
+        self
+    }
 }
 
 pub type CaptureFilter<'a> = Box<dyn Fn(&str) -> String + 'a>;
 pub type ExitAwareCaptureFilter<'a> = Box<dyn Fn(&str, i32) -> String + 'a>;
+pub type FactAwareCaptureFilter<'a> = Box<dyn Fn(&str, i32, CaptureFacts) -> String + 'a>;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CaptureFacts {
+    pub stdout_truncated: bool,
+    pub stderr_truncated: bool,
+}
+
+impl CaptureFacts {
+    pub fn complete(self) -> bool {
+        !self.stdout_truncated && !self.stderr_truncated
+    }
+}
 
 pub enum RunMode<'a> {
     Filtered(CaptureFilter<'a>),
     FilteredWithExit(ExitAwareCaptureFilter<'a>),
+    FilteredWithFacts(FactAwareCaptureFilter<'a>),
     Streamed(Box<dyn StreamFilter + 'a>),
     Passthrough,
 }
@@ -97,7 +123,7 @@ fn run_captured_filter<F>(
     timer: tracking::TimedExecution,
 ) -> Result<i32>
 where
-    F: Fn(&str, i32) -> String,
+    F: Fn(&str, i32, CaptureFacts) -> String,
 {
     let stdin_mode = if opts.inherit_stdin {
         StdinMode::Inherit
@@ -108,6 +134,10 @@ where
         .with_context(|| format!("Failed to run {}", tool_name))?;
 
     let exit_code = result.exit_code;
+    let capture_facts = CaptureFacts {
+        stdout_truncated: result.stdout_truncated,
+        stderr_truncated: result.stderr_truncated,
+    };
     let raw = &result.raw;
     let raw_stdout = &result.raw_stdout;
 
@@ -127,7 +157,7 @@ where
     } else {
         raw
     };
-    let filtered = filter_fn(text_to_filter, exit_code);
+    let filtered = filter_fn(text_to_filter, exit_code, capture_facts);
 
     let raw_for_tracking = if opts.filter_stdout_only {
         raw_stdout
@@ -136,7 +166,29 @@ where
     };
 
     let shown = if let Some(label) = opts.tee_label {
-        print_with_hint(&filtered, raw, raw_for_tracking, label, exit_code)
+        if opts.force_tee_on_unparseable && filtered.contains("result could not be parsed") {
+            let hint = crate::core::tee::force_tee_hint_with_source_completeness(
+                raw,
+                label,
+                exit_code,
+                capture_facts.complete(),
+            );
+            let truthful = match hint {
+                Some(hint) => format!("{filtered}\n{hint}"),
+                None => filtered.clone(),
+            };
+            println!("{truthful}");
+            truthful
+        } else {
+            print_with_hint(
+                &filtered,
+                raw,
+                raw_for_tracking,
+                label,
+                exit_code,
+                capture_facts.complete(),
+            )
+        }
     } else {
         let guarded = crate::core::guard::never_worse(raw_for_tracking, &filtered).to_string();
         if opts.no_trailing_newline {
@@ -171,7 +223,7 @@ pub fn run(
             cmd,
             tool_name,
             &cmd_label,
-            move |text, _| filter_fn(text),
+            move |text, _, _| filter_fn(text),
             opts,
             timer,
         ),
@@ -179,7 +231,15 @@ pub fn run(
             cmd,
             tool_name,
             &cmd_label,
-            move |text, exit_code| filter_fn(text, exit_code),
+            move |text, exit_code, _| filter_fn(text, exit_code),
+            opts,
+            timer,
+        ),
+        RunMode::FilteredWithFacts(filter_fn) => run_captured_filter(
+            cmd,
+            tool_name,
+            &cmd_label,
+            move |text, exit_code, facts| filter_fn(text, exit_code, facts),
             opts,
             timer,
         ),
@@ -249,6 +309,25 @@ where
         tool_name,
         args_display,
         RunMode::FilteredWithExit(Box::new(filter_fn)),
+        opts,
+    )
+}
+
+pub fn run_filtered_with_facts<F>(
+    cmd: Command,
+    tool_name: &str,
+    args_display: &str,
+    filter_fn: F,
+    opts: RunOptions<'_>,
+) -> Result<i32>
+where
+    F: Fn(&str, i32, CaptureFacts) -> String,
+{
+    run(
+        cmd,
+        tool_name,
+        args_display,
+        RunMode::FilteredWithFacts(Box::new(filter_fn)),
         opts,
     )
 }

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -217,6 +217,8 @@ pub struct StreamResult {
     pub raw: String,
     pub raw_stdout: String,
     pub raw_stderr: String,
+    pub stdout_truncated: bool,
+    pub stderr_truncated: bool,
     pub filtered: String,
 }
 
@@ -266,6 +268,8 @@ pub fn run_streaming(
             raw: String::new(),
             raw_stdout: String::new(),
             raw_stderr: String::new(),
+            stdout_truncated: false,
+            stderr_truncated: false,
             filtered: String::new(),
         });
     }
@@ -414,7 +418,7 @@ pub fn run_streaming(
         stdout_thread.join().ok();
         stderr_thread.join().ok();
     } else {
-        let stderr_thread = std::thread::spawn(move || -> String {
+        let stderr_thread = std::thread::spawn(move || -> (String, bool) {
             let mut raw_err = String::new();
             let mut capped = false;
             for line in BufReader::new(stderr).lines().map_while(Result::ok) {
@@ -425,7 +429,7 @@ pub fn run_streaming(
                     capped = true;
                 }
             }
-            raw_err
+            (raw_err, capped)
         });
 
         {
@@ -477,10 +481,12 @@ pub fn run_streaming(
             }
         }
 
-        raw_stderr = stderr_thread.join().unwrap_or_else(|e| {
+        let stderr_result = stderr_thread.join().unwrap_or_else(|e| {
             eprintln!("[rtk] warning: stderr reader thread panicked: {:?}", e);
-            String::new()
+            (String::new(), true)
         });
+        raw_stderr = stderr_result.0;
+        capped_err = stderr_result.1;
     }
     if let Some(t) = stdin_thread {
         t.join().ok();
@@ -511,6 +517,8 @@ pub fn run_streaming(
         raw,
         raw_stdout,
         raw_stderr,
+        stdout_truncated: capped_out,
+        stderr_truncated: capped_err,
         filtered,
     })
 }
@@ -630,6 +638,8 @@ pub(crate) mod tests {
             raw: String::new(),
             raw_stdout: String::new(),
             raw_stderr: String::new(),
+            stdout_truncated: false,
+            stderr_truncated: false,
             filtered: String::new(),
         };
         assert!(r.success());
@@ -642,6 +652,8 @@ pub(crate) mod tests {
             raw: String::new(),
             raw_stdout: String::new(),
             raw_stderr: String::new(),
+            stdout_truncated: false,
+            stderr_truncated: false,
             filtered: String::new(),
         };
         assert!(!r.success());
@@ -654,6 +666,8 @@ pub(crate) mod tests {
             raw: String::new(),
             raw_stdout: String::new(),
             raw_stderr: String::new(),
+            stdout_truncated: false,
+            stderr_truncated: false,
             filtered: String::new(),
         };
         assert!(!r.success());

--- a/src/core/tee.rs
+++ b/src/core/tee.rs
@@ -3,6 +3,38 @@
 use super::constants::RTK_DATA_DIR;
 use crate::core::config::Config;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+pub const OUTPUT_META_PREFIX: &str = "RTK_OUTPUT_META_V1 ";
+
+#[derive(Debug, Clone)]
+pub struct TeeArtifact {
+    pub path: PathBuf,
+    pub complete: bool,
+    pub source_bytes: usize,
+    pub stored_bytes: usize,
+}
+
+#[derive(serde::Serialize)]
+struct OutputArtifactMeta {
+    content: &'static str,
+    path: String,
+    complete: bool,
+    source_bytes: usize,
+    stored_bytes: usize,
+}
+
+#[derive(serde::Serialize)]
+struct OutputMeta<'a> {
+    schema: &'static str,
+    truncated: bool,
+    reason: &'a str,
+    raw_exit_code: Option<i32>,
+    recovery_start_line: Option<usize>,
+    shown_records: Option<usize>,
+    omitted_records: Option<usize>,
+    artifact: Option<OutputArtifactMeta>,
+}
 
 /// Minimum output size to tee (smaller outputs don't need recovery)
 const MIN_TEE_SIZE: usize = 500;
@@ -12,6 +44,8 @@ const DEFAULT_MAX_FILES: usize = 20;
 
 /// Default max file size (1MB)
 const DEFAULT_MAX_FILE_SIZE: usize = 1_048_576;
+
+static TEE_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// Sanitize a command slug for use in filenames.
 /// Replaces non-alphanumeric chars (except underscore/hyphen) with underscore,
@@ -113,25 +147,27 @@ fn create_tee_dir(tee_dir: &std::path::Path) -> Option<()> {
 
 /// Write raw output to a tee file in the given directory.
 /// Returns file path on success.
-fn write_tee_file(
+fn write_tee_artifact(
     raw: &str,
     command_slug: &str,
     tee_dir: &std::path::Path,
     max_file_size: usize,
     max_files: usize,
-) -> Option<PathBuf> {
+) -> Option<TeeArtifact> {
     create_tee_dir(tee_dir)?;
 
     let slug = sanitize_slug(command_slug);
     let epoch = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .ok()?
-        .as_secs();
-    let filename = format!("{}_{}.log", epoch, slug);
+        .as_nanos();
+    let nonce = TEE_FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let filename = format!("{}_{}_{}_{}.log", epoch, std::process::id(), nonce, slug);
     let filepath = tee_dir.join(filename);
 
     // Truncate at max_file_size (find a safe UTF-8 char boundary)
-    let content = if raw.len() > max_file_size {
+    let complete = raw.len() <= max_file_size;
+    let content = if !complete {
         let boundary = raw
             .char_indices()
             .take_while(|(i, _)| *i < max_file_size)
@@ -160,13 +196,31 @@ fn write_tee_file(
 
     // Rotate old files
     cleanup_old_files(tee_dir, max_files);
+    if !filepath.exists() {
+        return None;
+    }
 
-    Some(filepath)
+    Some(TeeArtifact {
+        path: filepath,
+        complete,
+        source_bytes: raw.len(),
+        stored_bytes: content.len(),
+    })
 }
 
-/// Write raw output to tee file if conditions are met.
-/// Returns file path on success, None if skipped/failed.
-pub fn tee_raw(raw: &str, command_slug: &str, exit_code: i32) -> Option<PathBuf> {
+#[cfg(test)]
+fn write_tee_file(
+    raw: &str,
+    command_slug: &str,
+    tee_dir: &std::path::Path,
+    max_file_size: usize,
+    max_files: usize,
+) -> Option<PathBuf> {
+    write_tee_artifact(raw, command_slug, tee_dir, max_file_size, max_files)
+        .map(|artifact| artifact.path)
+}
+
+fn tee_raw_artifact(raw: &str, command_slug: &str, exit_code: i32) -> Option<TeeArtifact> {
     // Check RTK_TEE=0 env override (disable)
     if std::env::var("RTK_TEE").ok().as_deref() == Some("0") {
         return None;
@@ -177,7 +231,7 @@ pub fn tee_raw(raw: &str, command_slug: &str, exit_code: i32) -> Option<PathBuf>
 
     let tee_dir = should_tee(&config.tee, raw.len(), exit_code, Some(tee_dir))?;
 
-    write_tee_file(
+    write_tee_artifact(
         raw,
         command_slug,
         &tee_dir,
@@ -252,14 +306,130 @@ fn format_hint(path: &std::path::Path) -> String {
     format!("[full output: {}]", display_shell_path(path))
 }
 
-/// Convenience: tee + format hint in one call.
-/// Returns hint string if file was written, None if skipped.
-pub fn tee_and_hint(raw: &str, command_slug: &str, exit_code: i32) -> Option<String> {
-    let path = tee_raw(raw, command_slug, exit_code)?;
-    Some(format_hint(&path))
+fn format_partial_hint(path: &std::path::Path) -> String {
+    format!("[partial recovery: {}]", display_shell_path(path))
 }
 
-fn force_tee_path(content: &str, command_slug: &str) -> Option<PathBuf> {
+pub fn output_meta_marker(
+    artifact: &TeeArtifact,
+    reason: &str,
+    raw_exit_code: Option<i32>,
+    recovery_start_line: Option<usize>,
+    shown_records: Option<usize>,
+    omitted_records: Option<usize>,
+) -> String {
+    let machine_path = if artifact.path.is_absolute() {
+        artifact.path.clone()
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(&artifact.path))
+            .unwrap_or_else(|_| artifact.path.clone())
+    };
+    let meta = OutputMeta {
+        schema: "rtk.output.v1",
+        truncated: true,
+        reason,
+        raw_exit_code,
+        recovery_start_line,
+        shown_records,
+        omitted_records,
+        artifact: Some(OutputArtifactMeta {
+            content: "complete_user_visible_output",
+            path: machine_path.display().to_string(),
+            complete: artifact.complete,
+            source_bytes: artifact.source_bytes,
+            stored_bytes: artifact.stored_bytes,
+        }),
+    };
+    let json = serde_json::to_string(&meta).expect("RTK output metadata must serialize");
+    format!("{OUTPUT_META_PREFIX}{json}")
+}
+
+pub fn incomplete_output_meta_marker(reason: &str, shown_records: Option<usize>) -> String {
+    let meta = OutputMeta {
+        schema: "rtk.output.v1",
+        truncated: true,
+        reason,
+        raw_exit_code: None,
+        recovery_start_line: None,
+        shown_records,
+        omitted_records: None,
+        artifact: None,
+    };
+    let json = serde_json::to_string(&meta).expect("RTK output metadata must serialize");
+    format!("{OUTPUT_META_PREFIX}{json}")
+}
+
+fn format_recovery(
+    human_hint: String,
+    artifact: &TeeArtifact,
+    reason: &str,
+    raw_exit_code: Option<i32>,
+    recovery_start_line: Option<usize>,
+    shown_records: Option<usize>,
+    omitted_records: Option<usize>,
+) -> String {
+    format!(
+        "{}\n{}",
+        human_hint,
+        output_meta_marker(
+            artifact,
+            reason,
+            raw_exit_code,
+            recovery_start_line,
+            shown_records,
+            omitted_records,
+        )
+    )
+}
+
+pub fn full_output_recovery(
+    artifact: &TeeArtifact,
+    reason: &str,
+    raw_exit_code: Option<i32>,
+    shown_records: Option<usize>,
+    omitted_records: Option<usize>,
+) -> String {
+    format_recovery(
+        format_hint(&artifact.path),
+        artifact,
+        reason,
+        raw_exit_code,
+        None,
+        shown_records,
+        omitted_records,
+    )
+}
+
+/// Convenience: tee + recovery metadata in one call.
+/// Non-empty lossy output always returns a machine marker, even when recovery
+/// is disabled, fails, or is only partial.
+pub fn tee_and_hint(raw: &str, command_slug: &str, exit_code: i32) -> Option<String> {
+    if raw.is_empty() {
+        return None;
+    }
+    Some(match tee_raw_artifact(raw, command_slug, exit_code) {
+        Some(artifact) => {
+            let hint = if artifact.complete {
+                format_hint(&artifact.path)
+            } else {
+                format_partial_hint(&artifact.path)
+            };
+            format_recovery(
+                hint,
+                &artifact,
+                "filtered_failure_output",
+                Some(exit_code),
+                None,
+                None,
+                None,
+            )
+        }
+        None => incomplete_output_meta_marker("filtered_failure_output", None),
+    })
+}
+
+pub fn force_tee_artifact(content: &str, command_slug: &str) -> Option<TeeArtifact> {
     if std::env::var("RTK_TEE").ok().as_deref() == Some("0") {
         return None;
     }
@@ -277,7 +447,7 @@ fn force_tee_path(content: &str, command_slug: &str) -> Option<PathBuf> {
     let tee_dir = get_tee_dir(&config)?;
     let tee_dir = create_tee_dir(&tee_dir).and(Some(tee_dir))?;
 
-    write_tee_file(
+    write_tee_artifact(
         content,
         command_slug,
         &tee_dir,
@@ -286,24 +456,58 @@ fn force_tee_path(content: &str, command_slug: &str) -> Option<PathBuf> {
     )
 }
 
-/// Returns `[full output: ~/path]`, or None if tee is disabled/skipped.
+/// Returns human recovery text plus machine metadata. Non-empty lossy output
+/// still gets an incomplete marker when tee is disabled or unavailable.
 pub fn force_tee_hint(raw: &str, command_slug: &str) -> Option<String> {
-    let path = force_tee_path(raw, command_slug)?;
-    Some(format_hint(&path))
+    if raw.is_empty() {
+        return None;
+    }
+    Some(match force_tee_artifact(raw, command_slug) {
+        Some(artifact) => {
+            let hint = if artifact.complete {
+                format_hint(&artifact.path)
+            } else {
+                format_partial_hint(&artifact.path)
+            };
+            format_recovery(hint, &artifact, "filtered_output", None, None, None, None)
+        }
+        None => incomplete_output_meta_marker("filtered_output", None),
+    })
 }
 
-/// Returns `[see remaining: tail -n +{line_offset} ~/path]`, or None if tee is disabled/skipped.
+/// Returns a tail recovery hint plus machine metadata when complete. Partial or
+/// unavailable recovery is labelled explicitly and never called full output.
 pub fn force_tee_tail_hint(
     content: &str,
     command_slug: &str,
     line_offset: usize,
 ) -> Option<String> {
-    let path = force_tee_path(content, command_slug)?;
-    Some(format!(
-        "[see remaining: tail -n +{} {}]",
-        line_offset,
-        display_shell_path(&path)
-    ))
+    if content.is_empty() {
+        return None;
+    }
+    Some(match force_tee_artifact(content, command_slug) {
+        Some(artifact) => {
+            let hint = if artifact.complete {
+                format!(
+                    "[see remaining: tail -n +{} {}]",
+                    line_offset,
+                    display_shell_path(&artifact.path)
+                )
+            } else {
+                format_partial_hint(&artifact.path)
+            };
+            format_recovery(
+                hint,
+                &artifact,
+                "filtered_output_tail",
+                None,
+                Some(line_offset),
+                None,
+                None,
+            )
+        }
+        None => incomplete_output_meta_marker("filtered_output_tail", None),
+    })
 }
 
 /// TeeMode controls when tee writes files.
@@ -424,6 +628,27 @@ mod tests {
         assert!(path.exists());
         let written = fs::read_to_string(&path).unwrap();
         assert!(written.contains("error: test failed"));
+    }
+
+    #[test]
+    fn test_write_tee_artifact_uses_unique_paths_for_same_slug() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let first =
+            write_tee_artifact("first", "grep", tmpdir.path(), 1000, 20).expect("first artifact");
+        let second =
+            write_tee_artifact("second", "grep", tmpdir.path(), 1000, 20).expect("second artifact");
+
+        assert_ne!(first.path, second.path);
+        assert_eq!(fs::read_to_string(first.path).unwrap(), "first");
+        assert_eq!(fs::read_to_string(second.path).unwrap(), "second");
+    }
+
+    #[test]
+    fn test_write_tee_artifact_returns_none_when_rotation_removes_it() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let artifact = write_tee_artifact("content", "grep", tmpdir.path(), 1000, 0);
+
+        assert!(artifact.is_none());
     }
 
     #[test]
@@ -561,6 +786,83 @@ mod tests {
     }
 
     #[test]
+    fn test_output_meta_marker_is_machine_parseable() {
+        let artifact = TeeArtifact {
+            path: PathBuf::from("/tmp/rtk/tee/full grep.log"),
+            complete: true,
+            source_bytes: 4096,
+            stored_bytes: 4096,
+        };
+        let marker = output_meta_marker(
+            &artifact,
+            "grep_result_limit",
+            Some(0),
+            None,
+            Some(25),
+            Some(7),
+        );
+        let payload = marker
+            .strip_prefix(OUTPUT_META_PREFIX)
+            .expect("stable RTK metadata prefix");
+        let parsed: serde_json::Value = serde_json::from_str(payload).expect("valid JSON metadata");
+
+        assert_eq!(parsed["schema"], "rtk.output.v1");
+        assert_eq!(parsed["truncated"], true);
+        assert_eq!(parsed["reason"], "grep_result_limit");
+        assert_eq!(parsed["raw_exit_code"], 0);
+        assert_eq!(parsed["shown_records"], 25);
+        assert_eq!(parsed["omitted_records"], 7);
+        assert_eq!(
+            parsed["artifact"]["content"],
+            "complete_user_visible_output"
+        );
+        assert_eq!(parsed["artifact"]["path"], "/tmp/rtk/tee/full grep.log");
+        assert_eq!(parsed["artifact"]["complete"], true);
+    }
+
+    #[test]
+    fn test_write_tee_artifact_reports_incomplete_storage() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let source = "x".repeat(2000);
+        let artifact = write_tee_artifact(&source, "grep", tmpdir.path(), 1000, 20)
+            .expect("tee artifact written");
+
+        assert!(!artifact.complete);
+        assert_eq!(artifact.source_bytes, 2000);
+        assert!(artifact.stored_bytes < artifact.source_bytes);
+    }
+
+    #[test]
+    fn test_incomplete_artifact_never_claims_full_output() {
+        let artifact = TeeArtifact {
+            path: PathBuf::from("/tmp/rtk/tee/partial.log"),
+            complete: false,
+            source_bytes: 2_000_000,
+            stored_bytes: 1_048_610,
+        };
+        let recovery = format_recovery(
+            format_partial_hint(&artifact.path),
+            &artifact,
+            "filtered_output",
+            None,
+            None,
+            None,
+            None,
+        );
+
+        assert!(recovery.starts_with("[partial recovery: "));
+        assert!(!recovery.contains("[full output:"));
+        let marker = recovery.lines().nth(1).expect("metadata marker");
+        let parsed: serde_json::Value = serde_json::from_str(
+            marker
+                .strip_prefix(OUTPUT_META_PREFIX)
+                .expect("metadata prefix"),
+        )
+        .expect("valid metadata");
+        assert_eq!(parsed["artifact"]["complete"], false);
+    }
+
+    #[test]
     fn test_display_shell_path_preserves_simple_paths() {
         let path = PathBuf::from("/tmp/rtk/tee/123_cargo_test.log");
         assert_eq!(display_shell_path(&path), "/tmp/rtk/tee/123_cargo_test.log");
@@ -678,13 +980,20 @@ directory = "/tmp/rtk-tee"
     }
 
     #[test]
-    fn test_force_tee_hint_respects_env_disable() {
-        // When RTK_TEE=0, force_tee_hint should return None
+    fn test_force_tee_hint_marks_unrecoverable_loss_when_env_disables_tee() {
         std::env::set_var("RTK_TEE", "0");
         let large_output = "x".repeat(1000);
         let hint = force_tee_hint(&large_output, "test_cmd");
         std::env::remove_var("RTK_TEE");
-        assert!(hint.is_none(), "Should respect RTK_TEE=0");
+        let hint = hint.expect("loss must remain machine-visible when tee is disabled");
+        assert!(hint.starts_with(OUTPUT_META_PREFIX));
+        let parsed: serde_json::Value = serde_json::from_str(
+            hint.strip_prefix(OUTPUT_META_PREFIX)
+                .expect("metadata prefix"),
+        )
+        .expect("valid metadata");
+        assert_eq!(parsed["truncated"], true);
+        assert!(parsed["artifact"].is_null());
     }
 
     #[test]

--- a/src/core/tee.rs
+++ b/src/core/tee.rs
@@ -360,6 +360,13 @@ pub fn incomplete_output_meta_marker(reason: &str, shown_records: Option<usize>)
     format!("{OUTPUT_META_PREFIX}{json}")
 }
 
+fn unavailable_recovery(reason: &str) -> String {
+    format!(
+        "[recovery unavailable]\n{}",
+        incomplete_output_meta_marker(reason, None)
+    )
+}
+
 fn format_recovery(
     human_hint: String,
     artifact: &TeeArtifact,
@@ -425,7 +432,7 @@ pub fn tee_and_hint(raw: &str, command_slug: &str, exit_code: i32) -> Option<Str
                 None,
             )
         }
-        None => incomplete_output_meta_marker("filtered_failure_output", None),
+        None => unavailable_recovery("filtered_failure_output"),
     })
 }
 
@@ -471,7 +478,7 @@ pub fn force_tee_hint(raw: &str, command_slug: &str) -> Option<String> {
             };
             format_recovery(hint, &artifact, "filtered_output", None, None, None, None)
         }
-        None => incomplete_output_meta_marker("filtered_output", None),
+        None => unavailable_recovery("filtered_output"),
     })
 }
 
@@ -506,7 +513,7 @@ pub fn force_tee_tail_hint(
                 None,
             )
         }
-        None => incomplete_output_meta_marker("filtered_output_tail", None),
+        None => unavailable_recovery("filtered_output_tail"),
     })
 }
 
@@ -986,14 +993,24 @@ directory = "/tmp/rtk-tee"
         let hint = force_tee_hint(&large_output, "test_cmd");
         std::env::remove_var("RTK_TEE");
         let hint = hint.expect("loss must remain machine-visible when tee is disabled");
-        assert!(hint.starts_with(OUTPUT_META_PREFIX));
+        assert!(hint.starts_with("[recovery unavailable]\n"));
+        let marker = hint.lines().nth(1).expect("standalone metadata line");
         let parsed: serde_json::Value = serde_json::from_str(
-            hint.strip_prefix(OUTPUT_META_PREFIX)
+            marker
+                .strip_prefix(OUTPUT_META_PREFIX)
                 .expect("metadata prefix"),
         )
         .expect("valid metadata");
         assert_eq!(parsed["truncated"], true);
         assert!(parsed["artifact"].is_null());
+    }
+
+    #[test]
+    fn test_unavailable_marker_stays_at_line_start_when_caller_prefixes_hint() {
+        let wrapped = format!("issues found: {}", unavailable_recovery("filtered_output"));
+        let marker = wrapped.lines().nth(1).expect("standalone metadata line");
+
+        assert!(marker.starts_with(OUTPUT_META_PREFIX));
     }
 
     #[test]

--- a/src/core/tee.rs
+++ b/src/core/tee.rs
@@ -30,6 +30,12 @@ struct OutputArtifactMeta {
 }
 
 #[derive(serde::Serialize)]
+struct RecoveryErrorMeta {
+    code: &'static str,
+    repair: &'static str,
+}
+
+#[derive(serde::Serialize)]
 struct OutputMeta<'a> {
     schema: &'static str,
     truncated: bool,
@@ -39,7 +45,11 @@ struct OutputMeta<'a> {
     shown_records: Option<usize>,
     omitted_records: Option<usize>,
     artifact: Option<OutputArtifactMeta>,
+    recovery_error: Option<RecoveryErrorMeta>,
 }
+
+const ARTIFACT_UNAVAILABLE_REPAIR: &str =
+    "unset RTK_TEE=0, enable tee, and set RTK_TEE_DIR to a writable owner-only directory; then rerun the command";
 
 /// Minimum output size to tee (smaller outputs don't need recovery)
 const MIN_TEE_SIZE: usize = 500;
@@ -406,6 +416,7 @@ pub fn output_meta_marker(
             incomplete_reason: artifact.incomplete_reason,
             sha256: artifact.sha256.clone(),
         }),
+        recovery_error: None,
     };
     let json = serde_json::to_string(&meta).expect("RTK output metadata must serialize");
     format!("{OUTPUT_META_PREFIX}{json}")
@@ -429,22 +440,35 @@ fn incomplete_output_meta_marker_with_exit(
         shown_records,
         omitted_records: None,
         artifact: None,
+        recovery_error: None,
     };
     let json = serde_json::to_string(&meta).expect("RTK output metadata must serialize");
     format!("{OUTPUT_META_PREFIX}{json}")
 }
 
 fn unavailable_recovery(reason: &str) -> String {
-    format!(
-        "[recovery unavailable]\n{}",
-        incomplete_output_meta_marker(reason, None)
-    )
+    unavailable_recovery_with_exit(reason, None)
 }
 
 fn unavailable_recovery_with_exit(reason: &str, raw_exit_code: Option<i32>) -> String {
+    let meta = OutputMeta {
+        schema: "rtk.output.v1",
+        truncated: true,
+        reason,
+        raw_exit_code,
+        recovery_start_line: None,
+        shown_records: None,
+        omitted_records: None,
+        artifact: None,
+        recovery_error: Some(RecoveryErrorMeta {
+            code: "artifact_unavailable",
+            repair: ARTIFACT_UNAVAILABLE_REPAIR,
+        }),
+    };
+    let json = serde_json::to_string(&meta).expect("RTK output metadata must serialize");
     format!(
-        "[recovery unavailable]\n{}",
-        incomplete_output_meta_marker_with_exit(reason, None, raw_exit_code)
+        "[recovery unavailable: artifact could not be persisted; {}]\n{}{}",
+        ARTIFACT_UNAVAILABLE_REPAIR, OUTPUT_META_PREFIX, json
     )
 }
 
@@ -1159,7 +1183,7 @@ directory = "/tmp/rtk-tee"
         let hint = force_tee_hint(&large_output, "test_cmd");
         std::env::remove_var("RTK_TEE");
         let hint = hint.expect("loss must remain machine-visible when tee is disabled");
-        assert!(hint.starts_with("[recovery unavailable]\n"));
+        assert!(hint.starts_with("[recovery unavailable:"));
         let marker = hint.lines().nth(1).expect("standalone metadata line");
         let parsed: serde_json::Value = serde_json::from_str(
             marker
@@ -1169,6 +1193,11 @@ directory = "/tmp/rtk-tee"
         .expect("valid metadata");
         assert_eq!(parsed["truncated"], true);
         assert!(parsed["artifact"].is_null());
+        assert_eq!(parsed["recovery_error"]["code"], "artifact_unavailable");
+        assert!(parsed["recovery_error"]["repair"]
+            .as_str()
+            .expect("repair text")
+            .contains("RTK_TEE_DIR"));
     }
 
     #[test]

--- a/src/core/tee.rs
+++ b/src/core/tee.rs
@@ -2,6 +2,7 @@
 
 use super::constants::RTK_DATA_DIR;
 use crate::core::config::Config;
+use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -13,6 +14,8 @@ pub struct TeeArtifact {
     pub complete: bool,
     pub source_bytes: usize,
     pub stored_bytes: usize,
+    pub incomplete_reason: Option<&'static str>,
+    pub sha256: String,
 }
 
 #[derive(serde::Serialize)]
@@ -22,6 +25,8 @@ struct OutputArtifactMeta {
     complete: bool,
     source_bytes: usize,
     stored_bytes: usize,
+    incomplete_reason: Option<&'static str>,
+    sha256: String,
 }
 
 #[derive(serde::Serialize)]
@@ -91,7 +96,27 @@ fn cleanup_old_files(dir: &std::path::Path, max_files: usize) {
         .into_iter()
         .flatten()
         .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().is_some_and(|ext| ext == "log"))
+        .filter(|entry| {
+            let Ok(file_type) = entry.file_type() else {
+                return false;
+            };
+            if !file_type.is_file() {
+                return false;
+            }
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else {
+                return false;
+            };
+            let Some(stem) = name.strip_suffix(".log") else {
+                return false;
+            };
+            let mut parts = stem.splitn(4, '_');
+            parts
+                .by_ref()
+                .take(3)
+                .all(|part| !part.is_empty() && part.chars().all(|ch| ch.is_ascii_digit()))
+                && parts.next().is_some_and(|slug| !slug.is_empty())
+        })
         .collect();
 
     if entries.len() <= max_files {
@@ -147,12 +172,31 @@ fn create_tee_dir(tee_dir: &std::path::Path) -> Option<()> {
 
 /// Write raw output to a tee file in the given directory.
 /// Returns file path on success.
+#[cfg(test)]
 fn write_tee_artifact(
     raw: &str,
     command_slug: &str,
     tee_dir: &std::path::Path,
     max_file_size: usize,
     max_files: usize,
+) -> Option<TeeArtifact> {
+    write_tee_artifact_with_source_completeness(
+        raw,
+        command_slug,
+        tee_dir,
+        max_file_size,
+        max_files,
+        true,
+    )
+}
+
+fn write_tee_artifact_with_source_completeness(
+    raw: &str,
+    command_slug: &str,
+    tee_dir: &std::path::Path,
+    max_file_size: usize,
+    max_files: usize,
+    source_complete: bool,
 ) -> Option<TeeArtifact> {
     create_tee_dir(tee_dir)?;
 
@@ -166,8 +210,9 @@ fn write_tee_artifact(
     let filepath = tee_dir.join(filename);
 
     // Truncate at max_file_size (find a safe UTF-8 char boundary)
-    let complete = raw.len() <= max_file_size;
-    let content = if !complete {
+    let storage_complete = raw.len() <= max_file_size;
+    let complete = source_complete && storage_complete;
+    let content = if !storage_complete {
         let boundary = raw
             .char_indices()
             .take_while(|(i, _)| *i < max_file_size)
@@ -193,6 +238,7 @@ fn write_tee_artifact(
     .ok()?;
     use std::io::Write;
     file.write_all(content.as_bytes()).ok()?;
+    let sha256 = format!("{:x}", Sha256::digest(content.as_bytes()));
 
     // Rotate old files
     cleanup_old_files(tee_dir, max_files);
@@ -205,6 +251,14 @@ fn write_tee_artifact(
         complete,
         source_bytes: raw.len(),
         stored_bytes: content.len(),
+        incomplete_reason: if !source_complete {
+            Some("capture_limit")
+        } else if !storage_complete {
+            Some("storage_limit")
+        } else {
+            None
+        },
+        sha256,
     })
 }
 
@@ -220,7 +274,12 @@ fn write_tee_file(
         .map(|artifact| artifact.path)
 }
 
-fn tee_raw_artifact(raw: &str, command_slug: &str, exit_code: i32) -> Option<TeeArtifact> {
+fn tee_raw_artifact_with_source_completeness(
+    raw: &str,
+    command_slug: &str,
+    exit_code: i32,
+    source_complete: bool,
+) -> Option<TeeArtifact> {
     // Check RTK_TEE=0 env override (disable)
     if std::env::var("RTK_TEE").ok().as_deref() == Some("0") {
         return None;
@@ -231,12 +290,13 @@ fn tee_raw_artifact(raw: &str, command_slug: &str, exit_code: i32) -> Option<Tee
 
     let tee_dir = should_tee(&config.tee, raw.len(), exit_code, Some(tee_dir))?;
 
-    write_tee_artifact(
+    write_tee_artifact_with_source_completeness(
         raw,
         command_slug,
         &tee_dir,
         config.tee.max_file_size,
         config.tee.max_files,
+        source_complete,
     )
 }
 
@@ -334,11 +394,17 @@ pub fn output_meta_marker(
         shown_records,
         omitted_records,
         artifact: Some(OutputArtifactMeta {
-            content: "complete_user_visible_output",
+            content: if artifact.complete {
+                "complete_user_visible_output"
+            } else {
+                "partial_user_visible_output"
+            },
             path: machine_path.display().to_string(),
             complete: artifact.complete,
             source_bytes: artifact.source_bytes,
             stored_bytes: artifact.stored_bytes,
+            incomplete_reason: artifact.incomplete_reason,
+            sha256: artifact.sha256.clone(),
         }),
     };
     let json = serde_json::to_string(&meta).expect("RTK output metadata must serialize");
@@ -346,11 +412,19 @@ pub fn output_meta_marker(
 }
 
 pub fn incomplete_output_meta_marker(reason: &str, shown_records: Option<usize>) -> String {
+    incomplete_output_meta_marker_with_exit(reason, shown_records, None)
+}
+
+fn incomplete_output_meta_marker_with_exit(
+    reason: &str,
+    shown_records: Option<usize>,
+    raw_exit_code: Option<i32>,
+) -> String {
     let meta = OutputMeta {
         schema: "rtk.output.v1",
         truncated: true,
         reason,
-        raw_exit_code: None,
+        raw_exit_code,
         recovery_start_line: None,
         shown_records,
         omitted_records: None,
@@ -364,6 +438,13 @@ fn unavailable_recovery(reason: &str) -> String {
     format!(
         "[recovery unavailable]\n{}",
         incomplete_output_meta_marker(reason, None)
+    )
+}
+
+fn unavailable_recovery_with_exit(reason: &str, raw_exit_code: Option<i32>) -> String {
+    format!(
+        "[recovery unavailable]\n{}",
+        incomplete_output_meta_marker_with_exit(reason, None, raw_exit_code)
     )
 }
 
@@ -412,31 +493,55 @@ pub fn full_output_recovery(
 /// Non-empty lossy output always returns a machine marker, even when recovery
 /// is disabled, fails, or is only partial.
 pub fn tee_and_hint(raw: &str, command_slug: &str, exit_code: i32) -> Option<String> {
+    tee_and_hint_with_source_completeness(raw, command_slug, exit_code, true)
+}
+
+pub fn tee_and_hint_with_source_completeness(
+    raw: &str,
+    command_slug: &str,
+    exit_code: i32,
+    source_complete: bool,
+) -> Option<String> {
     if raw.is_empty() {
         return None;
     }
-    Some(match tee_raw_artifact(raw, command_slug, exit_code) {
-        Some(artifact) => {
-            let hint = if artifact.complete {
-                format_hint(&artifact.path)
-            } else {
-                format_partial_hint(&artifact.path)
-            };
-            format_recovery(
-                hint,
-                &artifact,
-                "filtered_failure_output",
-                Some(exit_code),
-                None,
-                None,
-                None,
-            )
-        }
-        None => unavailable_recovery("filtered_failure_output"),
-    })
+    Some(
+        match tee_raw_artifact_with_source_completeness(
+            raw,
+            command_slug,
+            exit_code,
+            source_complete,
+        ) {
+            Some(artifact) => {
+                let hint = if artifact.complete {
+                    format_hint(&artifact.path)
+                } else {
+                    format_partial_hint(&artifact.path)
+                };
+                format_recovery(
+                    hint,
+                    &artifact,
+                    "filtered_failure_output",
+                    Some(exit_code),
+                    None,
+                    None,
+                    None,
+                )
+            }
+            None => unavailable_recovery("filtered_failure_output"),
+        },
+    )
 }
 
 pub fn force_tee_artifact(content: &str, command_slug: &str) -> Option<TeeArtifact> {
+    force_tee_artifact_with_source_completeness(content, command_slug, true)
+}
+
+fn force_tee_artifact_with_source_completeness(
+    content: &str,
+    command_slug: &str,
+    source_complete: bool,
+) -> Option<TeeArtifact> {
     if std::env::var("RTK_TEE").ok().as_deref() == Some("0") {
         return None;
     }
@@ -454,32 +559,61 @@ pub fn force_tee_artifact(content: &str, command_slug: &str) -> Option<TeeArtifa
     let tee_dir = get_tee_dir(&config)?;
     let tee_dir = create_tee_dir(&tee_dir).and(Some(tee_dir))?;
 
-    write_tee_artifact(
+    write_tee_artifact_with_source_completeness(
         content,
         command_slug,
         &tee_dir,
         config.tee.max_file_size,
         config.tee.max_files,
+        source_complete,
     )
 }
 
 /// Returns human recovery text plus machine metadata. Non-empty lossy output
 /// still gets an incomplete marker when tee is disabled or unavailable.
 pub fn force_tee_hint(raw: &str, command_slug: &str) -> Option<String> {
+    force_tee_hint_internal(raw, command_slug, None, true)
+}
+
+pub fn force_tee_hint_with_source_completeness(
+    raw: &str,
+    command_slug: &str,
+    exit_code: i32,
+    source_complete: bool,
+) -> Option<String> {
+    force_tee_hint_internal(raw, command_slug, Some(exit_code), source_complete)
+}
+
+fn force_tee_hint_internal(
+    raw: &str,
+    command_slug: &str,
+    raw_exit_code: Option<i32>,
+    source_complete: bool,
+) -> Option<String> {
     if raw.is_empty() {
         return None;
     }
-    Some(match force_tee_artifact(raw, command_slug) {
-        Some(artifact) => {
-            let hint = if artifact.complete {
-                format_hint(&artifact.path)
-            } else {
-                format_partial_hint(&artifact.path)
-            };
-            format_recovery(hint, &artifact, "filtered_output", None, None, None, None)
-        }
-        None => unavailable_recovery("filtered_output"),
-    })
+    Some(
+        match force_tee_artifact_with_source_completeness(raw, command_slug, source_complete) {
+            Some(artifact) => {
+                let hint = if artifact.complete {
+                    format_hint(&artifact.path)
+                } else {
+                    format_partial_hint(&artifact.path)
+                };
+                format_recovery(
+                    hint,
+                    &artifact,
+                    "filtered_output",
+                    raw_exit_code,
+                    None,
+                    None,
+                    None,
+                )
+            }
+            None => unavailable_recovery_with_exit("filtered_output", raw_exit_code),
+        },
+    )
 }
 
 /// Returns a tail recovery hint plus machine metadata when complete. Partial or
@@ -760,25 +894,27 @@ mod tests {
         let tmpdir = tempfile::tempdir().unwrap();
         let dir = tmpdir.path();
 
-        // Create 25 .log files
+        // Create 25 RTK-owned .log files plus one unrelated log.
         for i in 0..25 {
-            let filename = format!("{:010}_{}.log", 1000000 + i, "test");
+            let filename = format!("{:010}_1_{}_test.log", 1000000 + i, i);
             fs::write(dir.join(&filename), "content").unwrap();
         }
+        fs::write(dir.join("application.log"), "must remain").unwrap();
 
         cleanup_old_files(dir, 20);
 
         let remaining: Vec<_> = fs::read_dir(dir).unwrap().filter_map(|e| e.ok()).collect();
-        assert_eq!(remaining.len(), 20);
+        assert_eq!(remaining.len(), 21);
+        assert!(dir.join("application.log").exists());
 
         // Oldest 5 should be removed
         for i in 0..5 {
-            let filename = format!("{:010}_{}.log", 1000000 + i, "test");
+            let filename = format!("{:010}_1_{}_test.log", 1000000 + i, i);
             assert!(!dir.join(&filename).exists());
         }
         // Newest 20 should remain
         for i in 5..25 {
-            let filename = format!("{:010}_{}.log", 1000000 + i, "test");
+            let filename = format!("{:010}_1_{}_test.log", 1000000 + i, i);
             assert!(dir.join(&filename).exists());
         }
     }
@@ -799,6 +935,8 @@ mod tests {
             complete: true,
             source_bytes: 4096,
             stored_bytes: 4096,
+            incomplete_reason: None,
+            sha256: format!("{:x}", Sha256::digest(b"test")),
         };
         let marker = output_meta_marker(
             &artifact,
@@ -837,6 +975,32 @@ mod tests {
         assert!(!artifact.complete);
         assert_eq!(artifact.source_bytes, 2000);
         assert!(artifact.stored_bytes < artifact.source_bytes);
+        assert_eq!(artifact.incomplete_reason, Some("storage_limit"));
+    }
+
+    #[test]
+    fn test_capture_truncation_can_never_be_reported_as_complete_storage() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let source = "captured prefix only";
+        let artifact = write_tee_artifact_with_source_completeness(
+            source,
+            "pytest",
+            tmpdir.path(),
+            1000,
+            20,
+            false,
+        )
+        .expect("tee artifact written");
+
+        assert!(!artifact.complete);
+        assert_eq!(artifact.source_bytes, artifact.stored_bytes);
+        assert_eq!(artifact.incomplete_reason, Some("capture_limit"));
+        let marker = output_meta_marker(&artifact, "filtered_output", Some(0), None, None, None);
+        let payload = marker.strip_prefix(OUTPUT_META_PREFIX).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(payload).unwrap();
+        assert_eq!(parsed["artifact"]["content"], "partial_user_visible_output");
+        assert_eq!(parsed["artifact"]["complete"], false);
+        assert_eq!(parsed["artifact"]["incomplete_reason"], "capture_limit");
     }
 
     #[test]
@@ -846,6 +1010,8 @@ mod tests {
             complete: false,
             source_bytes: 2_000_000,
             stored_bytes: 1_048_610,
+            incomplete_reason: Some("storage_limit"),
+            sha256: format!("{:x}", Sha256::digest(b"partial")),
         };
         let recovery = format_recovery(
             format_partial_hint(&artifact.path),

--- a/tests/search_compress_test.rs
+++ b/tests/search_compress_test.rs
@@ -77,8 +77,9 @@ fn capped_single_file_shows_header() {
     }
     let filler: String = (0..40).map(|i| format!("w{i} ")).collect();
     let content: String = (0..60).map(|i| format!("foo {i} {filler}\n")).collect();
-    let (_dir, path) = write_temp(&content);
+    let (dir, path) = write_temp(&content);
     let out = rtk()
+        .env("RTK_TEE_DIR", dir.path().join("tee"))
         .args(["grep", "foo", path.to_str().unwrap()])
         .output()
         .expect("rtk grep");
@@ -239,7 +240,7 @@ fn bulky_grep_yields_token_savings() {
     for i in 0..60 {
         content.push_str(&format!("MATCH line {i} {filler}\n"));
     }
-    let (_dir, path) = write_temp(&content);
+    let (dir, path) = write_temp(&content);
 
     let raw = Command::new("rg")
         .args(["-nH", "MATCH", path.to_str().unwrap()])
@@ -248,6 +249,7 @@ fn bulky_grep_yields_token_savings() {
     let raw_tokens = count_tokens(&String::from_utf8_lossy(&raw.stdout));
 
     let out = rtk()
+        .env("RTK_TEE_DIR", dir.path().join("tee"))
         .args(["grep", "MATCH", path.to_str().unwrap()])
         .output()
         .expect("rtk grep");
@@ -258,6 +260,112 @@ fn bulky_grep_yields_token_savings() {
         savings >= 50.0,
         "expected >=50% token savings, got {savings:.1}% (raw={raw_tokens}, rtk={rtk_tokens})"
     );
+}
+
+#[test]
+fn capped_grep_emits_metadata_and_preserves_complete_visible_output() {
+    if !rg_available() {
+        return;
+    }
+    let filler = "long-result-content-".repeat(12);
+    let content: String = (0..32)
+        .map(|i| format!("needle-{i:02} {filler}\n"))
+        .collect();
+    let (dir, path) = write_temp(&content);
+    let tee_dir = dir.path().join("tee");
+    let out = rtk()
+        .env("RTK_TEE_DIR", &tee_dir)
+        .args(["grep", "needle", path.to_str().unwrap()])
+        .output()
+        .expect("rtk grep");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let marker = stdout
+        .lines()
+        .find(|line| line.starts_with("RTK_OUTPUT_META_V1 "))
+        .expect("capped grep must emit machine-readable truncation metadata");
+    let meta: serde_json::Value = serde_json::from_str(
+        marker
+            .strip_prefix("RTK_OUTPUT_META_V1 ")
+            .expect("metadata prefix"),
+    )
+    .expect("valid truncation metadata");
+
+    assert_eq!(meta["truncated"], true);
+    assert_eq!(meta["raw_exit_code"], 0);
+    assert_eq!(meta["shown_records"], 25);
+    assert_eq!(meta["omitted_records"], 7);
+    assert_eq!(meta["artifact"]["complete"], true);
+    assert_eq!(meta["artifact"]["content"], "complete_user_visible_output");
+
+    let artifact = meta["artifact"]["path"].as_str().expect("artifact path");
+    let recovered = std::fs::read_to_string(artifact).expect("read full grep artifact");
+    assert_eq!(
+        recovered, content,
+        "artifact must preserve the complete user-visible grep output"
+    );
+}
+
+#[test]
+fn grep_count_is_exact_and_never_marked_truncated() {
+    if !rg_available() {
+        return;
+    }
+    let content: String = (0..32).map(|i| format!("needle-{i:02}\n")).collect();
+    let (_dir, path) = write_temp(&content);
+    let out = rtk()
+        .args(["grep", "-c", "needle", path.to_str().unwrap()])
+        .output()
+        .expect("rtk grep -c");
+
+    assert!(out.status.success());
+    assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "32");
+    assert!(!String::from_utf8_lossy(&out.stdout).contains("RTK_OUTPUT_META_V1"));
+    assert!(!String::from_utf8_lossy(&out.stderr).contains("RTK_OUTPUT_META_V1"));
+}
+
+#[test]
+fn capped_grep_falls_back_to_full_output_when_tee_is_disabled() {
+    if !rg_available() {
+        return;
+    }
+    let filler = "long-result-content-".repeat(12);
+    let content: String = (0..32)
+        .map(|i| format!("needle-{i:02} {filler}\n"))
+        .collect();
+    let (_dir, path) = write_temp(&content);
+    let out = rtk()
+        .env("RTK_TEE", "0")
+        .args(["grep", "needle", path.to_str().unwrap()])
+        .output()
+        .expect("rtk grep");
+
+    assert!(out.status.success());
+    assert_eq!(String::from_utf8_lossy(&out.stdout), content);
+    assert!(!String::from_utf8_lossy(&out.stdout).contains("RTK_OUTPUT_META_V1"));
+}
+
+#[test]
+fn capped_grep_falls_back_to_full_output_when_tee_directory_is_unwritable() {
+    if !rg_available() {
+        return;
+    }
+    let filler = "long-result-content-".repeat(12);
+    let content: String = (0..32)
+        .map(|i| format!("needle-{i:02} {filler}\n"))
+        .collect();
+    let (dir, path) = write_temp(&content);
+    let blocked_tee_dir = dir.path().join("not-a-directory");
+    std::fs::write(&blocked_tee_dir, "blocked").expect("create blocked tee path");
+    let out = rtk()
+        .env("RTK_TEE_DIR", &blocked_tee_dir)
+        .args(["grep", "needle", path.to_str().unwrap()])
+        .output()
+        .expect("rtk grep");
+
+    assert!(out.status.success());
+    assert_eq!(String::from_utf8_lossy(&out.stdout), content);
+    assert!(!String::from_utf8_lossy(&out.stdout).contains("RTK_OUTPUT_META_V1"));
 }
 
 // --- grep-only syntax falls back to system grep (#2543) ---


### PR DESCRIPTION
## Why

RTK could expose two different kinds of false conclusions:

- capped grep output looked like complete output unless an agent noticed a natural-language tail hint;
- pytest output that could not be parsed could be rewritten as `No tests collected`, even when the real pytest process had collected or executed tests.

Compression may reduce displayed text, but it must not change the child exit code, test counts, failure locations, or whether the captured output is complete.

## What changed

- Add one machine-readable `RTK_OUTPUT_META_V1` line for lossy output.
- Preserve raw child exit code plus source/storage completeness through stream -> runner -> tee.
- Store tee artifacts as owner-only files and include content kind, byte counts, incomplete reason, and SHA-256.
- If an artifact cannot be persisted, emit `recovery_error.code=artifact_unavailable` plus a deterministic repair action instead of a vague missing-log hint.
- Keep grep count modes exact and preserve a complete recovery artifact for capped grep output.
- Parse pytest through one exit-aware truth matrix:
  - `No tests collected` is accepted only for pytest exit code 5 plus an explicit no-tests terminal summary.
  - pass/fail/skipped/error/subtest counts, collected count, and failure locations are preserved.
  - missing, multiple, conflicting, non-standard, or capture-truncated summaries return `result could not be parsed` with the real exit code and recovery artifact.
- Long periods without stdout do not synthesize a result; RTK waits for the child process and uses its final facts.

## Safety / non-goals

- No generic timeout.
- No Safe Runner or child-deadline changes.
- No command replay or arbitrary artifact reads.
- Other test/lint wrappers keep their existing parser behavior; only shared stream/runner/tee fact transport changed.

## Validation

- pytest truth matrix: 14 passed.
- tee integrity/rotation/metadata: 34 passed.
- stream capture and raw exit propagation: 38 passed.
- grep compression/integration: 18 passed.
- Real pytest usage error smoke: raw exit 4 preserved; output is `result could not be parsed`, not no-tests; complete 0600 artifact size and SHA-256 match the marker.
- Real pass, fail, and no-tests smokes preserve their native exit codes and final summaries.
- Real capped grep smoke: 220 matches, 25 shown, 195 omitted; the marker points to a complete 5,500-byte artifact whose SHA-256 matches, and the safe reader recovers all 220 records.
- Unwritable tee smoke: the marker keeps raw exit 4 and exposes a machine-readable recovery error with the exact `RTK_TEE_DIR` repair.
- `cargo fmt --check` and `git diff --check` pass.

Independent reviewer status: not claimed. Codex subagents could not start because of the current account usage limit, and the Workspace external Claude reviewer was blocked by data-egress policy. Upstream review remains required.

## Files

- `src/cmds/python/pytest_cmd.rs`
- `src/core/stream.rs`
- `src/core/runner.rs`
- `src/core/tee.rs`
- `src/cmds/system/search.rs`
- compatibility callers/tests

Current source head: `448ba8f2003303ff927b6a7df2c500a56e4d978e`.
