### PR TITLE
docs: remove stale support counters

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -4,7 +4,7 @@
 
 **Deployed hook artifacts** — the actual files installed on user machines by `rtk init`. These are shell scripts, TypeScript plugins, and rules files that run outside the Rust binary. They are **thin delegates**: parse agent-specific JSON, call `rtk rewrite` as a subprocess, format agent-specific response. Zero filtering logic lives here.
 
-Owns: per-agent hook scripts and configuration files for 10 supported agents (Claude Code, Copilot, Cursor, Cline, Windsurf, Codex, OpenCode, Hermes, Pi, Mistral Vibe).
+Owns: per-agent hook scripts and configuration files for supported agents (Claude Code, Copilot, Cursor, Cline, Windsurf, Codex, OpenCode, Hermes, Pi, Mistral Vibe).
 
 Does **not** own: hook installation/uninstallation (that's `src/hooks/init.rs`), the rewrite pattern registry (that's `discover/registry`), or integrity verification (that's `src/hooks/integrity.rs`).
 
@@ -27,7 +27,7 @@ Agent runs command (e.g., "cargo test --nocapture")
   -> Filtered output reaches LLM (up to 90% fewer bash output bytes)
 ```
 
-All rewrite logic lives in the Rust binary (`src/discover/registry.rs`). Hook scripts are **thin delegates** that handle agent-specific JSON formats and call `rtk rewrite` for the actual decision. This ensures a single source of truth for all 70+ rewrite patterns.
+All rewrite logic lives in the Rust binary (`src/discover/registry.rs`). Hook scripts are **thin delegates** that handle agent-specific JSON formats and call `rtk rewrite` for the actual decision. This ensures a single source of truth for command rewrite patterns.
 
 ## Directory Structure
 

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -61,7 +61,7 @@ In `openclaw.json`:
 
 ## What gets rewritten
 
-Everything that `rtk rewrite` supports (30+ commands). See the [full command list](https://github.com/rtk-ai/rtk#commands).
+Everything that `rtk rewrite` supports. See the [full command list](https://github.com/rtk-ai/rtk#commands).
 
 ## What's NOT rewritten
 

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -6,7 +6,7 @@
 
 The **lifecycle management** layer for LLM agent hooks: install, uninstall, verify integrity, audit usage, and manage trust. This component creates and maintains the hook artifacts that live in `hooks/` (root), but does **not** execute rewrite logic itself — that lives in `discover/registry`.
 
-Owns: `rtk init` installation flows (6 agents via `AgentTarget` enum, now including Mistral Vibe + 3 special modes: Gemini, Codex, OpenCode), SHA-256 integrity verification, hook version checking, audit log analysis, `rtk rewrite` CLI entry point, and TOML filter trust management.
+Owns: `rtk init` installation flows via the `AgentTarget` enum (including Mistral Vibe), special modes for Gemini, Codex, and OpenCode, SHA-256 integrity verification, hook version checking, audit log analysis, the `rtk rewrite` CLI entry point, and TOML filter trust management.
 
 Does **not** own: the deployed hook scripts themselves (that's `hooks/`), the rewrite pattern registry (that's `discover/`), or command filtering (that's `cmds/`).
 


### PR DESCRIPTION
## Summary

- remove hard-coded agent and rewrite-pattern totals from hook documentation
- remove the hard-coded command total from the OpenClaw integration README
- keep the root README as the single place that tracks support totals

Closes #3457

## Test plan

- [x] `cargo fmt --all --check`
- [x] `git diff --check`
- [x] targeted scan finds no agent, command, or rewrite-pattern totals in non-root README files
- [ ] `cargo clippy --all-targets && cargo test` (dependency fetch timed out on `index.crates.io` from the remote environment; GitHub CI is the full gate)
- [ ] Manual testing: not applicable for this documentation-only change
