### PR TITLE
fix(docs): make RTK version checks release agnostic

### DIFF
--- a/.claude/skills/security-guardian/SKILL.md
+++ b/.claude/skills/security-guardian/SKILL.md
@@ -286,9 +286,9 @@ fi
 # 3. Use absolute path (prevent PATH hijacking)
 RTK_BIN=$(which rtk)
 
-# 4. Validate RTK version (prevent downgrade attacks)
-if ! "$RTK_BIN" --version | grep -q "rtk 0.16"; then
-    echo "Warning: RTK version mismatch"
+# 4. Validate RTK binary identity and version format
+if ! "$RTK_BIN" --version 2>/dev/null | grep -Eq '^rtk [0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'; then
+    echo "Warning: RTK binary identity/version check failed"
 fi
 
 # 5. Execute with explicit path

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Download from [releases](https://github.com/rtk-ai/rtk/releases):
 ### Verify Installation
 
 ```bash
-rtk --version   # Should show "rtk 0.28.2"
+rtk --version   # Should print: rtk X.Y.Z
 rtk gain        # Should show the savings dashboard
 ```
 


### PR DESCRIPTION
## Summary

- Replace the README's release-specific version example with a release-agnostic format.
- Make the security skill validate the RTK binary name and semantic version shape instead of one obsolete version.

Closes #3396

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test`
- [x] Manual testing: verified `rtk 0.42.4` matches the new check and incomplete `rtk 0.16` does not.

I used an AI coding assistant to help inspect the issue and draft the patch. I reviewed the final diff and ran the checks above.
