### PR TITLE
fix(du): keep summary and depth-limited output raw

### DIFF
--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -167,11 +167,30 @@ pub struct CompiledFilter {
 impl CompiledFilter {
     /// True when any invoked arg matches (exact or prefix) an entry in
     /// `pass_through_if_args`. Prefix matching covers combined short flags
-    /// (`-sk`) and value-bearing long flags (`--max-depth=1`).
+    /// (`-sk`) and value-bearing long flags (`--max-depth=1`). Short-option
+    /// clusters where the target flag is not first (`-hs`, `-hd1`) are matched
+    /// by scanning the cluster for the single-char needle.
     pub fn should_pass_through(&self, args: &[String]) -> bool {
         self.pass_through_if_args.iter().any(|needle| {
-            args.iter()
-                .any(|arg| arg == needle || arg.starts_with(needle))
+            args.iter().any(|arg| {
+                if arg == needle || arg.starts_with(needle) {
+                    return true;
+                }
+                // Short-option cluster: a single-dash token carrying the
+                // needle's char somewhere (du -hs, -hd1). Long flags (--) are
+                // handled by the exact/prefix branch above.
+                let single = needle
+                    .strip_prefix('-')
+                    .filter(|c| !needle.starts_with("--") && c.chars().count() == 1);
+                match single {
+                    Some(c) => {
+                        arg.starts_with('-')
+                            && !arg.starts_with("--")
+                            && arg[1..].contains(c)
+                    }
+                    None => false,
+                }
+            })
         })
     }
 }
@@ -873,10 +892,16 @@ pass_through_if_args = ["-s", "--summarize", "-d", "--max-depth"]
         assert!(filter.should_pass_through(&["--max-depth".into(), "1".into()]));
         // Depth flag among other args.
         assert!(filter.should_pass_through(&["-h".into(), "-d1".into(), "/tmp".into()]));
+        // Short-option clusters where the target flag is not first.
+        assert!(filter.should_pass_through(&["-hs".into(), "/tmp".into()]));
+        assert!(filter.should_pass_through(&["-hd1".into(), "/tmp".into()]));
+        assert!(filter.should_pass_through(&["-ahd1".into()]));
         // Flags that must NOT opt out.
         assert!(!filter.should_pass_through(&["-h".into(), "/tmp".into()]));
         assert!(!filter.should_pass_through(&["/tmp".into()]));
         assert!(!filter.should_pass_through(&["-a".into(), "-c".into()]));
+        // Capitalized short flags are distinct flags, not the needle.
+        assert!(!filter.should_pass_through(&["-S".into()]));
     }
 
     #[test]

--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -184,9 +184,7 @@ impl CompiledFilter {
                     .filter(|c| !needle.starts_with("--") && c.chars().count() == 1);
                 match single {
                     Some(c) => {
-                        arg.starts_with('-')
-                            && !arg.starts_with("--")
-                            && arg[1..].contains(c)
+                        arg.starts_with('-') && !arg.starts_with("--") && arg[1..].contains(c)
                     }
                     None => false,
                 }

--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -14,6 +14,7 @@
 ///   - `RTK_TOML_DEBUG=1`  — print which filter matched and line counts to stderr
 ///
 /// Pipeline stages (applied in order):
+///   0. pass_through_if_args  - if any invoked arg matches (exact or prefix), skip filtering entirely
 ///   1. strip_ansi           — remove ANSI escape codes
 ///   2. replace              — regex substitutions, line-by-line, chainable
 ///   3. match_output         — short-circuit: if blob matches a pattern, return message immediately
@@ -106,6 +107,13 @@ struct TomlFilterDef {
     /// Use for tools like liquibase that emit banners/logs to stderr.
     #[serde(default)]
     filter_stderr: bool,
+    /// Skip filtering entirely when the invoked command carries any of these
+    /// argument prefixes (exact match or prefix). Lets declarative filters stay
+    /// flag-aware where truncation would drop the answer itself: e.g. `du -s`
+    /// emits one independent total per root, so a line cap would hide the
+    /// largest consumers. Matching args fall through to raw passthrough.
+    #[serde(default)]
+    pass_through_if_args: Vec<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -151,6 +159,21 @@ pub struct CompiledFilter {
     on_empty: Option<String>,
     /// When true, the runner should capture stderr and merge it with stdout.
     pub filter_stderr: bool,
+    /// If any invoked arg matches (exact or prefix), the filter is skipped and
+    /// the command runs as raw passthrough.
+    pass_through_if_args: Vec<String>,
+}
+
+impl CompiledFilter {
+    /// True when any invoked arg matches (exact or prefix) an entry in
+    /// `pass_through_if_args`. Prefix matching covers combined short flags
+    /// (`-sk`) and value-bearing long flags (`--max-depth=1`).
+    pub fn should_pass_through(&self, args: &[String]) -> bool {
+        self.pass_through_if_args.iter().any(|needle| {
+            args.iter()
+                .any(|arg| arg == needle || arg.starts_with(needle))
+        })
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -388,6 +411,7 @@ fn compile_filter(name: String, def: TomlFilterDef) -> Result<CompiledFilter, St
         max_lines: def.max_lines,
         on_empty: def.on_empty,
         filter_stderr: def.filter_stderr,
+        pass_through_if_args: def.pass_through_if_args,
     })
 }
 
@@ -827,6 +851,44 @@ mod tests {
                 "match-set disagreed with registry for {cmd:?}"
             );
         }
+    }
+
+    #[test]
+    fn test_pass_through_if_args_exact_and_prefix() {
+        let filter = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+pass_through_if_args = ["-s", "--summarize", "-d", "--max-depth"]
+"#,
+        );
+        // Exact match.
+        assert!(filter.should_pass_through(&["-s".into()]));
+        // Combined short flag: `-sk` starts with `-s`.
+        assert!(filter.should_pass_through(&["-sk".into(), "/tmp".into()]));
+        // Value-bearing long flag.
+        assert!(filter.should_pass_through(&["--max-depth=1".into()]));
+        // Space-separated long flag value.
+        assert!(filter.should_pass_through(&["--max-depth".into(), "1".into()]));
+        // Depth flag among other args.
+        assert!(filter.should_pass_through(&["-h".into(), "-d1".into(), "/tmp".into()]));
+        // Flags that must NOT opt out.
+        assert!(!filter.should_pass_through(&["-h".into(), "/tmp".into()]));
+        assert!(!filter.should_pass_through(&["/tmp".into()]));
+        assert!(!filter.should_pass_through(&["-a".into(), "-c".into()]));
+    }
+
+    #[test]
+    fn test_pass_through_if_args_empty_never_opts_out() {
+        let filter = first_filter(
+            r#"
+schema_version = 1
+[filters.f]
+match_command = "^cmd"
+"#,
+        );
+        assert!(!filter.should_pass_through(&["-s".into(), "--anything".into()]));
     }
 
     #[test]

--- a/src/filters/README.md
+++ b/src/filters/README.md
@@ -60,6 +60,7 @@ expected = "expected filtered output"
 | `max_lines` | int | Keep only the first N lines |
 | `tail_lines` | int | Keep only the last N lines (applied after other filters) |
 | `on_empty` | string | Fallback message when filtered output is empty |
+| `pass_through_if_args` | string[] | Skip filtering entirely when any invoked arg matches an entry exactly or by prefix. Short-option clusters are scanned for single-char entries (`-hs` matches `-s`). Use when a line cap would drop the answer itself, e.g. `du -s` rows are independent per-root totals: `pass_through_if_args = ["-s", "--summarize", "-d", "--max-depth"]` |
 
 ## Naming convention
 

--- a/src/filters/du.toml
+++ b/src/filters/du.toml
@@ -4,6 +4,10 @@ match_command = "^du\\b"
 strip_lines_matching = ["^\\s*$"]
 truncate_lines_at = 120
 max_lines = 40
+# Every row of `du -s` (and depth-limited output) is an independent answer for
+# its own root; a line cap would hide the largest consumers while reporting a
+# confident total. Run those shapes raw instead of truncating the answer.
+pass_through_if_args = ["-s", "--summarize", "-d", "--max-depth"]
 
 [[tests.du]]
 name = "preserves sizes, strips blank lines"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1323,106 +1323,117 @@ fn run_fallback(parse_error: clap::Error) -> Result<i32> {
     };
 
     if let Some(filter) = toml_match {
-        // TOML match: capture stdout for filtering
-        let result = if filter.filter_stderr {
-            // Merge stderr into stdout so the filter can strip banners emitted by tools like liquibase
-            core::utils::resolved_command(&args[0])
-                .args(&args[1..])
-                .stdin(std::process::Stdio::inherit())
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::piped()) // captured for merging
-                .output()
-        } else {
-            core::utils::resolved_command(&args[0])
-                .args(&args[1..])
-                .stdin(std::process::Stdio::inherit())
-                .stdout(std::process::Stdio::piped()) // capture
-                .stderr(std::process::Stdio::inherit()) // stderr always direct
-                .output()
-        };
+        // TOML match: capture stdout for filtering.
+        // Filters declaring pass_through_if_args (e.g. `du -s`, whose rows are
+        // independent per-root answers) skip filtering and run raw below.
+        if !filter.should_pass_through(&args[1..]) {
+            let result = if filter.filter_stderr {
+                // Merge stderr into stdout so the filter can strip banners emitted by tools like liquibase
+                core::utils::resolved_command(&args[0])
+                    .args(&args[1..])
+                    .stdin(std::process::Stdio::inherit())
+                    .stdout(std::process::Stdio::piped())
+                    .stderr(std::process::Stdio::piped()) // captured for merging
+                    .output()
+            } else {
+                core::utils::resolved_command(&args[0])
+                    .args(&args[1..])
+                    .stdin(std::process::Stdio::inherit())
+                    .stdout(std::process::Stdio::piped()) // capture
+                    .stderr(std::process::Stdio::inherit()) // stderr always direct
+                    .output()
+            };
 
-        match result {
-            Ok(output) => {
-                let exit_code = core::utils::exit_code_from_output(&output, &raw_command);
-                let stdout_raw = String::from_utf8_lossy(&output.stdout);
-                let stderr_raw = String::from_utf8_lossy(&output.stderr);
+            match result {
+                Ok(output) => {
+                    let exit_code = core::utils::exit_code_from_output(&output, &raw_command);
+                    let stdout_raw = String::from_utf8_lossy(&output.stdout);
+                    let stderr_raw = String::from_utf8_lossy(&output.stderr);
 
-                // Merge stderr into the text to filter when filter_stderr is enabled;
-                // otherwise emit stderr directly so it is always visible.
-                let combined_raw = if filter.filter_stderr {
-                    format!("{}{}", stdout_raw, stderr_raw)
-                } else {
-                    stdout_raw.to_string()
-                };
-                let success = output.status.success();
-                let (filtered, loss) =
-                    core::toml_filter::apply_filter_with_info(filter, &combined_raw);
-                let lossy = !matches!(loss, core::toml_filter::Lossiness::None);
+                    // Merge stderr into the text to filter when filter_stderr is enabled;
+                    // otherwise emit stderr directly so it is always visible.
+                    let combined_raw = if filter.filter_stderr {
+                        format!("{}{}", stdout_raw, stderr_raw)
+                    } else {
+                        stdout_raw.to_string()
+                    };
+                    let success = output.status.success();
+                    let (filtered, loss) =
+                        core::toml_filter::apply_filter_with_info(filter, &combined_raw);
+                    let lossy = !matches!(loss, core::toml_filter::Lossiness::None);
 
-                let hint = if !success {
-                    core::tee::tee_and_hint(&combined_raw, &raw_command, exit_code)
-                } else {
-                    match &loss {
-                        core::toml_filter::Lossiness::None => None,
-                        core::toml_filter::Lossiness::Tail {
-                            tee_payload,
-                            tail_offset,
-                        } => {
-                            core::tee::force_tee_tail_hint(tee_payload, &raw_command, *tail_offset)
+                    let hint = if !success {
+                        core::tee::tee_and_hint(&combined_raw, &raw_command, exit_code)
+                    } else {
+                        match &loss {
+                            core::toml_filter::Lossiness::None => None,
+                            core::toml_filter::Lossiness::Tail {
+                                tee_payload,
+                                tail_offset,
+                            } => core::tee::force_tee_tail_hint(
+                                tee_payload,
+                                &raw_command,
+                                *tail_offset,
+                            ),
+                            core::toml_filter::Lossiness::Whole => {
+                                core::tee::force_tee_hint(&combined_raw, &raw_command)
+                            }
                         }
-                        core::toml_filter::Lossiness::Whole => {
-                            core::tee::force_tee_hint(&combined_raw, &raw_command)
-                        }
-                    }
-                };
+                    };
 
-                // Never emit an unrecoverable truncation marker: fall back to full raw.
-                let shown = if lossy && hint.is_none() {
-                    core::runner::emit_guarded(&combined_raw, None, &combined_raw)
-                } else {
-                    core::runner::emit_guarded(&filtered, hint.as_deref(), &combined_raw)
-                };
+                    // Never emit an unrecoverable truncation marker: fall back to full raw.
+                    let shown = if lossy && hint.is_none() {
+                        core::runner::emit_guarded(&combined_raw, None, &combined_raw)
+                    } else {
+                        core::runner::emit_guarded(&filtered, hint.as_deref(), &combined_raw)
+                    };
 
-                timer.track(
-                    &raw_command,
-                    &format!("rtk:toml {}", raw_command),
-                    &combined_raw,
-                    &shown,
-                );
-                core::tracking::record_parse_failure_silent(&raw_command, &error_message, true);
+                    timer.track(
+                        &raw_command,
+                        &format!("rtk:toml {}", raw_command),
+                        &combined_raw,
+                        &shown,
+                    );
+                    core::tracking::record_parse_failure_silent(&raw_command, &error_message, true);
 
-                Ok(exit_code)
-            }
-            Err(e) => {
-                // Command not found — same behaviour as no-TOML path
-                core::tracking::record_parse_failure_silent(&raw_command, &error_message, false);
-                eprintln!("[rtk: {}]", e);
-                Ok(127)
+                    return Ok(exit_code);
+                }
+                Err(e) => {
+                    // Command not found — same behaviour as no-TOML path
+                    core::tracking::record_parse_failure_silent(
+                        &raw_command,
+                        &error_message,
+                        false,
+                    );
+                    eprintln!("[rtk: {}]", e);
+                    return Ok(127);
+                }
             }
         }
-    } else {
-        // No TOML match: original passthrough behaviour (Stdio::inherit, streaming)
-        let status = core::utils::resolved_command(&args[0])
-            .args(&args[1..])
-            .stdin(std::process::Stdio::inherit())
-            .stdout(std::process::Stdio::inherit())
-            .stderr(std::process::Stdio::inherit())
-            .status();
+    }
 
-        match status {
-            Ok(s) => {
-                timer.track_passthrough(&raw_command, &format!("rtk fallback: {}", raw_command));
+    // No TOML match, or the matched filter opted out via pass_through_if_args:
+    // raw streaming passthrough (Stdio::inherit, no capture, no filtering).
+    let status = core::utils::resolved_command(&args[0])
+        .args(&args[1..])
+        .stdin(std::process::Stdio::inherit())
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
+        .status();
 
-                core::tracking::record_parse_failure_silent(&raw_command, &error_message, true);
+    match status {
+        Ok(s) => {
+            timer.track_passthrough(&raw_command, &format!("rtk fallback: {}", raw_command));
 
-                Ok(core::utils::exit_code_from_status(&s, &raw_command))
-            }
-            Err(e) => {
-                core::tracking::record_parse_failure_silent(&raw_command, &error_message, false);
-                // Command not found or other OS error — single message, no duplicate Clap error
-                eprintln!("[rtk: {}]", e);
-                Ok(127)
-            }
+            core::tracking::record_parse_failure_silent(&raw_command, &error_message, true);
+
+            Ok(core::utils::exit_code_from_status(&s, &raw_command))
+        }
+        Err(e) => {
+            core::tracking::record_parse_failure_silent(&raw_command, &error_message, false);
+            // Command not found or other OS error — single message, no duplicate Clap error
+            eprintln!("[rtk: {}]", e);
+            Ok(127)
         }
     }
 }


### PR DESCRIPTION
## Summary

- `du` summary and depth-limited output now runs raw instead of being cut to 40 lines. Every row of `du -s` (or `-d N`) is an independent total for its own root, so the cap silently dropped the largest consumers while reporting a confident answer. A 312-row cache survey came back 42 rows with the 4.4 GB entry missing; exit code stayed 0.
- Added a small option to the TOML filter engine, `pass_through_if_args`, so any declarative filter can opt out of filtering for specific invocation shapes. `du.toml` uses it for `-s`, `--summarize`, `-d`, `--max-depth`. Plain tree output (`du -h .`) keeps the existing aggressive compression.
- Also checked the #3486 report that `du` disappeared from the rewrite path: on `develop` (and in the v0.45.0 tag) the rewrite rule, `rtk du` subcommand, and `du.toml` are all present. The reachable defect was the shape-blind line cap, fixed here.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test --all`
- [x] Manual verification (60 roots, sizes 5 KB to 200 KB):

| Invocation | Before | After |
|---|---|---|
| `rtk du -sk <60 roots>` | 40 rows + `... (20 lines truncated)` + tee hint | 60 rows, identical to raw `du` |
| `rtk du -h -d1 <tree>` | capped at 40 | raw |
| `rtk du -s <tree>` | capped at 40 | raw |
| `rtk du -h <tree>` | compressed | still compressed (savings kept) |
| `rtk rewrite "du -sh ."` | `rtk du -sh .` | unchanged |

- Unit tests: 2572 passed, 0 failed (2 new for the arg gate). The `copilot_selfheal_test` suite fails 10 tests, confirmed identical on clean `develop` before this change (Windows environment), unrelated.

## Details

Reproduction and mechanism. `du.toml` caps output at 40 lines. For a single-root tree (`du -h .`) interior rows are redundant with their parent totals, so the cap reads correctly. For `du -sk <glob>` every line is an independent answer and the drop is arbitrary (listing order, not size order), so a survey can understate the largest consumer by 17x while exiting 0.

Why this shape. Options considered: dropping the cap entirely would kill the 96.8% savings on `du -h .` that #284 shipped; special-casing `du` in the runner would be a per-path hack. The TOML engine had no flag awareness at all, so the option lives in the filter definition, default empty, backwards compatible with the existing `deny_unknown_fields` schema.

Edge cases covered by prefix matching: combined short flags (`-sk`, `-sh`), value-bearing long flags (`--max-depth=1`), space-separated forms (`-d 1`, `--max-depth 1`). Flags that stay filtered: `-h`, `-a`, `-c`, no-flag invocations.

Scope note. #3484 (helm) and #3485 (gcloud) report the same "filter missing" pattern. Their rewrite rules and `.toml` files are also present on `develop`, so like the `du` rewrite half they do not reproduce from source. They are `needs-reproduction`; left untouched.

Refs #3486
