### PR TITLE
fix(cicd): propagate security command failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Test logged command status propagation
+        run: bash scripts/run-with-log.sh --self-test
+
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
@@ -85,16 +88,21 @@ jobs:
           echo "## Security Scan Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Dependency Vulnerabilities" >> $GITHUB_STEP_SUMMARY
-          if cargo audit 2>&1 | tee audit.log; then
+          set +e
+          bash scripts/run-with-log.sh audit.log cargo audit
+          audit_status=$?
+          set -e
+          if [ "$audit_status" -eq 0 ]; then
             echo "No known vulnerabilities detected" >> $GITHUB_STEP_SUMMARY
           else
             echo "Vulnerabilities found:" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             cat audit.log >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "::warning::Dependency vulnerabilities detected - review required"
+            echo "::error::Dependency vulnerabilities detected - review required"
           fi
           echo "" >> $GITHUB_STEP_SUMMARY
+          exit "$audit_status"
 
       - name: Critical files check
         run: |
@@ -160,15 +168,22 @@ jobs:
       - name: Clippy security lints
         run: |
           echo "### Clippy Security Lints" >> $GITHUB_STEP_SUMMARY
-          if cargo clippy --all-targets -- -W clippy::unwrap_used -W clippy::panic -W clippy::expect_used 2>&1 | tee clippy.log | grep -E "warning:|error:"; then
+          set +e
+          bash scripts/run-with-log.sh clippy.log cargo clippy --all-targets -- -D clippy::unwrap_used -D clippy::panic -D clippy::expect_used
+          clippy_status=$?
+          set -e
+          if grep -Eq "warning:|error:" clippy.log; then
             echo "Security-related lints triggered:" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
             grep -E "warning:|error:" clippy.log | head -20 >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "::warning::Clippy security lints failed"
           else
             echo "All security lints passed" >> $GITHUB_STEP_SUMMARY
           fi
+          if [ "$clippy_status" -ne 0 ]; then
+            echo "::error::Clippy security lints failed"
+          fi
+          exit "$clippy_status"
 
       - name: Summary verdict
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -807,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -1499,15 +1499,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ sha2 = "0.10"
 ureq = "2"
 getrandom = "0.4"
 flate2 = "1.0"
-quick-xml = "0.37"
+quick-xml = "0.41"
 which = "8"
 automod = "1"
 

--- a/scripts/run-with-log.sh
+++ b/scripts/run-with-log.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+run_self_test() {
+    set -e
+
+    local script_path
+    local temp_dir
+    local status
+    script_path="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+    temp_dir=$(mktemp -d)
+    trap 'rm -f "$temp_dir/success.log" "$temp_dir/failure.log"; rmdir "$temp_dir"' RETURN
+
+    "$script_path" "$temp_dir/success.log" bash -c 'echo stdout; echo stderr >&2'
+    grep -qx 'stdout' "$temp_dir/success.log"
+    grep -qx 'stderr' "$temp_dir/success.log"
+
+    set +e
+    "$script_path" "$temp_dir/failure.log" bash -c 'echo failed; exit 23'
+    status=$?
+    set -e
+
+    if [ "$status" -ne 23 ]; then
+        echo "FAIL: expected command exit code 23, got $status"
+        return 1
+    fi
+    grep -qx 'failed' "$temp_dir/failure.log"
+
+    echo "PASS: command output is logged and its exit code is preserved"
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+    run_self_test
+    exit $?
+fi
+
+if [ "$#" -lt 2 ]; then
+    echo "Usage: $0 <log-file> <command> [args...]" >&2
+    exit 2
+fi
+
+log_file=$1
+shift
+
+"$@" 2>&1 | tee "$log_file"

--- a/src/cmds/dotnet/dotnet_cmd.rs
+++ b/src/cmds/dotnet/dotnet_cmd.rs
@@ -9,6 +9,7 @@ use crate::core::utils::{resolved_command, truncate};
 use crate::dotnet_format_report;
 use crate::dotnet_trx;
 use anyhow::{Context, Result};
+use quick_xml::escape::unescape;
 use quick_xml::events::Event;
 use quick_xml::Reader;
 use serde_json::Value;
@@ -618,8 +619,10 @@ fn scan_mtp_kind_in_file(path: &Path) -> MtpProjectKind {
                 );
             }
             Ok(Event::Text(e)) if inside_mtp_element => {
-                if let Ok(text) = e.unescape() {
-                    if text.trim().eq_ignore_ascii_case("true") {
+                if let Ok(decoded) = e.xml10_content() {
+                    if unescape(&decoded)
+                        .is_ok_and(|text| text.trim().eq_ignore_ascii_case("true"))
+                    {
                         return MtpProjectKind::VsTestBridge;
                     }
                 }
@@ -2118,6 +2121,23 @@ mod tests {
             r#"<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+  </PropertyGroup>
+</Project>"#,
+        )
+        .expect("write csproj");
+
+        assert_eq!(scan_mtp_kind_in_file(&csproj), MtpProjectKind::VsTestBridge);
+    }
+
+    #[test]
+    fn test_scan_mtp_kind_decodes_xml_entities() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let csproj = temp_dir.path().join("MyProject.csproj");
+        fs::write(
+            &csproj,
+            r#"<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <UseMicrosoftTestingPlatformRunner>tr&#x75;e</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 </Project>"#,
         )


### PR DESCRIPTION
## Summary

- preserve the wrapped command's exit status while still teeing Cargo Audit and Clippy output into job logs
- make dependency advisories and the targeted panic/unwrap/expect Clippy lints fail their steps instead of producing green false summaries
- update `crossbeam-epoch` and `quick-xml` to patched releases so the audit gate starts green; adapt the quick-xml text API and cover entity decoding

This addresses items 1 and 2 from #3394. The issue's separate lint-policy, Semgrep, release-trigger, and benchmark questions are intentionally left out of this focused PR.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/run-with-log.sh --self-test`
- [x] `cargo metadata --no-deps --format-version 1`
- [x] `cargo audit` 0.22.2 (no vulnerabilities; one allowed informational warning)
- [x] `actionlint .github/workflows/ci.yml`
- [ ] `cargo clippy --all-targets && cargo test` — delegated to the PR matrix because this Windows host does not have the MSVC linker/Build Tools installed

## AI assistance disclosure

AI assistance was used for issue triage, implementation, and test drafting. I reviewed the final diff, verified the dependency advisories against RustSec, and ran the checks listed above.