### PR TITLE
fix(build): use correct linker stack-size flag for GNU target

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,13 +3,20 @@ use std::fs;
 use std::path::Path;
 
 fn main() {
-    #[cfg(windows)]
-    {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
         // Clap + the full command graph can exceed the default 1 MiB Windows
         // main-thread stack during process startup. Reserve a larger stack for
         // the CLI binary so `rtk.exe --version`, `--help`, and hook entry
         // points start reliably without requiring ad-hoc RUSTFLAGS.
-        println!("cargo:rustc-link-arg=/STACK:8388608");
+        //
+        // MSVC's linker and the GNU (MinGW) linker take this flag in
+        // different syntaxes; `/STACK:` alone breaks the build on the
+        // x86_64-pc-windows-gnu target (`ld.exe: cannot find /STACK:8388608`).
+        if std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc") {
+            println!("cargo:rustc-link-arg=/STACK:8388608");
+        } else {
+            println!("cargo:rustc-link-arg=-Wl,--stack,8388608");
+        }
     }
 
     let filters_dir = Path::new("src/filters");


### PR DESCRIPTION
## Problem

`build.rs` unconditionally emits `/STACK:8388608` on any Windows build:

```rust
#[cfg(windows)]
{
    println!("cargo:rustc-link-arg=/STACK:8388608");
}
```

`/STACK:` is MSVC linker syntax. On `x86_64-pc-windows-gnu` (MinGW), the GNU
linker doesn't understand it and the build fails:

```
x86_64-w64-mingw32-gcc ... -o rtk.exe ...
ld.exe: cannot find /STACK:8388608: No such file or directory
collect2.exe: error: ld returned 1 exit status
```

This breaks `cargo build`/`cargo test`/`cargo install --path .` for anyone
whose default Rust toolchain is `stable-x86_64-pc-windows-gnu` instead of
`stable-x86_64-pc-windows-msvc` (a common setup for contributors who don't
have Visual Studio Build Tools installed).

## Fix

Select the flag syntax based on `CARGO_CFG_TARGET_ENV` (set by Cargo for
build scripts): keep `/STACK:8388608` for `msvc`, use the GNU-ld equivalent
`-Wl,--stack,8388608` otherwise. Also switched the outer guard from
`#[cfg(windows)]` (host-compile-time) to checking `CARGO_CFG_TARGET_OS`
(the actual build *target*), which is the more correct signal for a build
script and matches how `CARGO_CFG_TARGET_ENV` is already being read.

## Testing

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets` (no new warnings)
- [x] `cargo test` — 2575 passed, 8 ignored, 0 failed (previously: build didn't
      complete at all on this target)
- [x] `cargo install --path .` succeeds and produces a working `rtk.exe` on
      `stable-x86_64-pc-windows-gnu`

No behavior change on `x86_64-pc-windows-msvc` (still emits `/STACK:`) or
non-Windows targets (flag is skipped entirely, same as before).

Build-script-only change; not user-facing, so no docs update needed per
CONTRIBUTING.md.