### PR TITLE
fix(discover): sanitize colon when encoding Windows project paths

### DIFF
--- a/src/discover/provider.rs
+++ b/src/discover/provider.rs
@@ -117,15 +117,15 @@ impl ClaudeProvider {
 
     /// Encode a filesystem path to Claude Code's directory name format.
     ///
-    /// Claude Code replaces `/`, `.`, `_`, `\`, and any non-ASCII character
+    /// Claude Code replaces `/`, `.`, `_`, `\`, `:`, and any non-ASCII character
     /// with `-` when computing the project directory slug under `~/.claude/projects/`.
     ///
     /// `/Users/foo/bar`          → `-Users-foo-bar`
     /// `/Users/first.last/bar`   → `-Users-first-last-bar`
     /// `/home/chris/2_project`   → `-home-chris-2-project`
-    /// `C:\Users\foo\bar`        → `C:-Users-foo-bar`
+    /// `C:\Users\foo\bar`        → `C--Users-foo-bar`
     pub fn encode_project_path(path: &str) -> String {
-        const SANITIZED_CHARS: &[char] = &['/', '.', '_', '\\', ' ', '[', ']'];
+        const SANITIZED_CHARS: &[char] = &['/', '.', '_', '\\', ':', ' ', '[', ']'];
 
         path.chars()
             .map(|c| {
@@ -403,10 +403,14 @@ mod tests {
 
     #[test]
     fn test_encode_project_path_windows() {
-        // Windows backslashes are also replaced with '-'
+        // Windows backslashes AND the drive-letter colon are replaced with '-'.
+        // Verified against a real ~/.claude/projects/ folder name on Windows:
+        // cwd `C:\Projeto` produces the slug `C--Projeto`, not `C:-Projeto` —
+        // the colon must be sanitized too, or `rtk discover` (default mode,
+        // no --project) never matches any session and silently reports zero.
         assert_eq!(
             ClaudeProvider::encode_project_path(r"C:\Users\foo\bar"),
-            "C:-Users-foo-bar"
+            "C--Users-foo-bar"
         );
     }
 


### PR DESCRIPTION
## Problem

`rtk discover` (default mode, no `--project` flag) auto-detects the current
project by encoding `cwd` with `ClaudeProvider::encode_project_path()` and
substring-matching the result against directory names under
`~/.claude/projects/`.

That function's sanitized-character set is `['/', '.', '_', '\', ' ', '[', ']']`
— it does not include `:`. On Windows, a cwd like `C:\Users\foo\bar` is
encoded as `"C:-Users-foo-bar"` (colon kept literal). But Claude Code's real
directory name for that cwd is `"C--Users-foo-bar"` — Claude Code replaces
the drive-letter colon too, not just the backslashes.

Since the encoded filter is used as a substring match against real folder
names, the literal `:` never matches anything, so **default-mode `rtk
discover` on Windows always reports "0 sessions scanned"**, even with dozens
of real, recent sessions on disk for that exact project. I confirmed this
against an actual `~/.claude/projects/` folder name on a live Windows Claude
Code install (cwd `C:\<project>` → real folder `C--<project>`).

The existing test `test_encode_project_path_windows` actually asserted the
buggy behavior (`"C:-Users-foo-bar"`), so it didn't catch this.

Passing an explicit filter (`rtk discover -p <substring>`) already worked
correctly, since that path skips `encode_project_path` entirely and matches
the raw string directly — only the zero-flag auto-detect path was affected.
This likely explains why it went unnoticed: `--all` and `-p` are common
workarounds that mask the default-mode bug.

## Fix

Add `:` to `SANITIZED_CHARS` in `encode_project_path()`, update the doc
comment example, and correct `test_encode_project_path_windows` to assert
the real Claude Code output (`"C--Users-foo-bar"`).

## Testing

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets` (no new warnings)
- [x] `cargo test` — 2575 passed, 8 ignored, 0 failed
- [x] Manual: rebuilt and reinstalled locally, confirmed `rtk discover`
      (no flags) now finds the same session count as `rtk discover -p
      <project>` did before, on a real Windows Claude Code project

Note: on this machine, `cargo test`/`cargo install` only succeed after also
applying the GNU-linker build-script fix from #3547 (unrelated pre-existing
issue — this machine's default toolchain is `x86_64-pc-windows-gnu`). Not
included in this PR to keep the diff focused per the single-fix-per-PR rule
in CONTRIBUTING.md; verified in isolation by temporarily overlaying that fix
locally (uncommitted) before running the test suite, then reverting it so
this branch's diff is only `src/discover/provider.rs`.