### PR TITLE
fix(config): consume ignore dirs and files in system commands

### DIFF
--- a/docs/guide/getting-started/configuration.md
+++ b/docs/guide/getting-started/configuration.md
@@ -33,8 +33,8 @@ emoji = true                # use emojis in output
 max_width = 120             # maximum output width
 
 [filters]
-# These apply to file-reading commands (ls, find, grep, cat/rtk read).
-# Paths matching these patterns are excluded from output, keeping noise low.
+# These apply to directory-walking commands (rtk ls, rtk tree, rtk find,
+# and rtk grep/rtk rg pattern searches). Matching names are excluded from output.
 ignore_dirs = [".git", "node_modules", "target", "__pycache__", ".venv", "vendor"]
 ignore_files = ["*.lock", "*.min.js", "*.min.css"]
 

--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -1258,6 +1258,8 @@ emoji = true                # Utiliser les emojis
 max_width = 120             # Largeur maximale de sortie
 
 [filters]
+# Ces regles s'appliquent aux commandes qui parcourent les repertoires
+# (rtk ls, rtk tree, rtk find et les recherches rtk grep/rg).
 ignore_dirs = [".git", "node_modules", "target", "__pycache__", ".venv", "vendor"]
 ignore_files = ["*.lock", "*.min.js", "*.min.css"]
 

--- a/src/cmds/system/constants.rs
+++ b/src/cmds/system/constants.rs
@@ -1,3 +1,5 @@
+use crate::core::config::{self, FilterConfig};
+
 pub const NOISE_DIRS: &[&str] = &[
     "node_modules",
     ".git",
@@ -25,3 +27,95 @@ pub const NOISE_DIRS: &[&str] = &[
     "*.egg-info",
     ".eggs",
 ];
+
+#[derive(Debug, Clone)]
+pub(crate) struct IgnorePatterns {
+    pub(crate) noise: Vec<String>,
+    pub(crate) dirs: Vec<String>,
+    pub(crate) files: Vec<String>,
+}
+
+impl IgnorePatterns {
+    pub(crate) fn from_config(filters: &FilterConfig) -> Self {
+        Self {
+            noise: NOISE_DIRS.iter().map(|s| s.to_string()).collect(),
+            dirs: filters.ignore_dirs.clone(),
+            files: filters.ignore_files.clone(),
+        }
+    }
+
+    pub(crate) fn is_ignored_name(&self, name: &str, is_dir: bool) -> bool {
+        self.noise.iter().any(|pattern| glob_match(pattern, name))
+            || if is_dir {
+                self.dirs.iter().any(|pattern| glob_match(pattern, name))
+            } else {
+                self.files.iter().any(|pattern| glob_match(pattern, name))
+            }
+    }
+}
+
+/// Load configured ignore entries and merge them with the built-in list.
+pub(crate) fn configured_ignore_patterns() -> IgnorePatterns {
+    IgnorePatterns::from_config(&config::filters())
+}
+
+/// Match a filename against a glob pattern (supports `*` and `?`).
+pub(crate) fn glob_match(pattern: &str, name: &str) -> bool {
+    glob_match_inner(pattern.as_bytes(), name.as_bytes())
+}
+
+fn glob_match_inner(pat: &[u8], name: &[u8]) -> bool {
+    match (pat.first(), name.first()) {
+        (None, None) => true,
+        (Some(b'*'), _) => {
+            // '*' matches zero or more characters
+            glob_match_inner(&pat[1..], name)
+                || (!name.is_empty() && glob_match_inner(pat, &name[1..]))
+        }
+        (Some(b'?'), Some(_)) => glob_match_inner(&pat[1..], &name[1..]),
+        (Some(&p), Some(&n)) if p == n => glob_match_inner(&pat[1..], &name[1..]),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ignore_patterns_apply_builtin_noise_and_type_specific_config() {
+        let filters = FilterConfig {
+            ignore_dirs: vec!["canary".to_string()],
+            ignore_files: vec!["*.lock".to_string()],
+        };
+
+        let patterns = IgnorePatterns::from_config(&filters);
+
+        assert!(patterns.is_ignored_name("canary", true));
+        assert!(!patterns.is_ignored_name("canary", false));
+        assert!(patterns.is_ignored_name("package.lock", false));
+        assert!(!patterns.is_ignored_name("package.lock", true));
+        assert!(patterns.is_ignored_name("node_modules", true));
+        assert!(patterns.is_ignored_name(".DS_Store", false));
+    }
+
+    #[test]
+    fn ignore_patterns_load_real_config_toml() {
+        use std::io::Write;
+
+        let mut file = tempfile::NamedTempFile::new().expect("temp config");
+        writeln!(
+            file,
+            "[filters]\nignore_dirs = [\"canary\"]\nignore_files = [\"*.lock\"]"
+        )
+        .expect("write temp config");
+
+        let filters = config::filters_at(file.path());
+        let patterns = IgnorePatterns::from_config(&filters);
+
+        assert!(patterns.is_ignored_name("canary", true));
+        assert!(!patterns.is_ignored_name("canary", false));
+        assert!(patterns.is_ignored_name("package.lock", false));
+        assert!(!patterns.is_ignored_name("package.lock", true));
+    }
+}

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -4,27 +4,9 @@ use crate::core::guard::never_worse;
 use crate::core::tracking;
 use anyhow::{Context, Result};
 use ignore::WalkBuilder;
+use super::constants::{configured_ignore_patterns, glob_match};
 use std::collections::HashMap;
 use std::path::Path;
-
-/// Match a filename against a glob pattern (supports `*` and `?`).
-fn glob_match(pattern: &str, name: &str) -> bool {
-    glob_match_inner(pattern.as_bytes(), name.as_bytes())
-}
-
-fn glob_match_inner(pat: &[u8], name: &[u8]) -> bool {
-    match (pat.first(), name.first()) {
-        (None, None) => true,
-        (Some(b'*'), _) => {
-            // '*' matches zero or more characters
-            glob_match_inner(&pat[1..], name)
-                || (!name.is_empty() && glob_match_inner(pat, &name[1..]))
-        }
-        (Some(b'?'), Some(_)) => glob_match_inner(&pat[1..], &name[1..]),
-        (Some(&p), Some(&n)) if p == n => glob_match_inner(&pat[1..], &name[1..]),
-        _ => false,
-    }
-}
 
 /// Parsed arguments from either native find or RTK find syntax.
 #[derive(Debug)]
@@ -221,6 +203,19 @@ pub fn run(
         .git_ignore(true) // respect .gitignore
         .git_global(true)
         .git_exclude(true);
+    let ignore_patterns = configured_ignore_patterns();
+    builder.filter_entry(move |entry| {
+        if entry.depth() == 0 {
+            return true;
+        }
+        match entry.file_name().to_str() {
+            Some(name) => {
+                let is_dir = entry.file_type().is_some_and(|ft| ft.is_dir());
+                !ignore_patterns.is_ignored_name(name, is_dir)
+            }
+            None => true,
+        }
+    });
     if let Some(depth) = max_depth {
         builder.max_depth(Some(depth));
     }
@@ -387,6 +382,7 @@ pub fn run(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cmds::system::constants::IgnorePatterns;
 
     /// Convert string slices to Vec<String> for test convenience.
     fn args(values: &[&str]) -> Vec<String> {
@@ -616,5 +612,19 @@ mod tests {
         assert!(result.is_ok());
         // We can't easily capture stdout in unit tests, but at least
         // verify it runs without error. The smoke tests verify content.
+    }
+
+    #[test]
+    fn configured_ignore_patterns_skip_matching_names() {
+        let patterns = IgnorePatterns {
+            noise: vec![],
+            dirs: vec!["canary".to_string()],
+            files: vec!["*.lock".to_string()],
+        };
+
+        assert!(patterns.is_ignored_name("canary", true));
+        assert!(patterns.is_ignored_name("package.lock", false));
+        assert!(!patterns.is_ignored_name("src", false));
+        assert!(!patterns.is_ignored_name("canary", false));
     }
 }

--- a/src/cmds/system/ls.rs
+++ b/src/cmds/system/ls.rs
@@ -1,5 +1,7 @@
 //! Filters directory listings into a compact tree format.
 
+use super::constants::{configured_ignore_patterns, IgnorePatterns};
+#[cfg(test)]
 use super::constants::NOISE_DIRS;
 use crate::core::runner::{self, RunOptions};
 use crate::core::truncate::{reduced, CAP_WARNINGS};
@@ -82,12 +84,14 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         paths.join(" ")
     };
 
+    let ignore_patterns = configured_ignore_patterns();
     runner::run_filtered(
         cmd,
         "ls",
         &format!("-la {}", target_display),
         |raw| {
-            let (entries, summary, parsed_count) = compact_ls(raw, show_all, show_long);
+            let (entries, summary, parsed_count) =
+                compact_ls_with_ignores(raw, show_all, show_long, &ignore_patterns);
 
             // If no lines were parsed (e.g., unrecognized locale), fall back to raw output.
             // This is safer than returning "(empty)" for a non-empty directory.
@@ -238,7 +242,22 @@ fn perms_to_octal(perms: &str) -> Option<String> {
 /// Returns (entries, summary, parsed_count) so caller can suppress summary when piped.
 /// parsed_count tracks how many non-header lines were successfully parsed.
 /// If parsed_count == 0 but raw had content, caller should fall back to raw output.
+#[cfg(test)]
 fn compact_ls(raw: &str, show_all: bool, show_long: bool) -> (String, String, usize) {
+    let ignore_patterns = IgnorePatterns {
+        noise: NOISE_DIRS.iter().map(|s| s.to_string()).collect(),
+        dirs: vec![],
+        files: vec![],
+    };
+    compact_ls_with_ignores(raw, show_all, show_long, &ignore_patterns)
+}
+
+fn compact_ls_with_ignores(
+    raw: &str,
+    show_all: bool,
+    show_long: bool,
+    ignore_patterns: &IgnorePatterns,
+) -> (String, String, usize) {
     use std::collections::HashMap;
 
     let mut dirs: Vec<(String, Option<String>)> = Vec::new(); // (name, octal_perms)
@@ -262,8 +281,8 @@ fn compact_ls(raw: &str, show_all: bool, show_long: bool) -> (String, String, us
         };
         parsed_count += 1;
 
-        // Filter noise dirs unless -a
-        if !show_all && NOISE_DIRS.iter().any(|noise| name == *noise) {
+        // Filter ignored dirs/files unless -a
+        if !show_all && ignore_patterns.is_ignored_name(&name, file_type == 'd') {
             continue;
         }
 
@@ -711,5 +730,29 @@ mod tests {
         assert_eq!(parsed_count, 0);
         assert!(entries.is_empty());
         assert!(summary.is_empty());
+    }
+
+    #[test]
+    fn test_compact_ls_with_configured_ignores() {
+        let input = "total 12\n\
+                     drwxr-xr-x  2 user staff 64 Jan  1 12:00 canary\n\
+                     drwxr-xr-x  2 user staff 64 Jan  1 12:00 src\n\
+                     -rw-r--r--  1 user staff  0 Jan  1 12:00 package.lock\n";
+        let ignore_patterns = IgnorePatterns {
+            noise: vec![],
+            dirs: vec!["canary".to_string()],
+            files: vec!["*.lock".to_string()],
+        };
+
+        let (entries, _summary, _parsed) = compact_ls_with_ignores(
+            input,
+            false,
+            false,
+            &ignore_patterns,
+        );
+
+        assert!(entries.contains("src/"));
+        assert!(!entries.contains("canary"));
+        assert!(!entries.contains("package.lock"));
     }
 }

--- a/src/cmds/system/search.rs
+++ b/src/cmds/system/search.rs
@@ -19,6 +19,8 @@ use std::io::IsTerminal;
 use std::process::Command;
 use std::sync::LazyLock;
 
+use super::constants::{configured_ignore_patterns, IgnorePatterns};
+
 /// Short single-char flags that consume one following token (or inline remainder)
 /// as their value. `-e` is handled separately — its value goes to `patterns`.
 /// Includes all rg short flags that take a value argument except `-e` and `-r`
@@ -294,6 +296,41 @@ impl Engine {
     }
 }
 
+fn engine_ignore_args(engine: Engine, ignore_patterns: &IgnorePatterns) -> Vec<String> {
+    match engine {
+        Engine::Grep => ignore_patterns
+            .noise
+            .iter()
+            .chain(ignore_patterns.dirs.iter())
+            .map(|pattern| format!("--exclude-dir={pattern}"))
+            .chain(
+                ignore_patterns
+                    .noise
+                    .iter()
+                    .chain(ignore_patterns.files.iter())
+                    .map(|pattern| format!("--exclude={pattern}")),
+            )
+            .collect(),
+        Engine::Rg => ignore_patterns
+            .noise
+            .iter()
+            .map(|pattern| format!("--glob=!{pattern}"))
+            .chain(
+                ignore_patterns
+                    .dirs
+                    .iter()
+                    .map(|pattern| format!("--glob=!{pattern}/")),
+            )
+            .chain(
+                ignore_patterns
+                    .files
+                    .iter()
+                    .map(|pattern| format!("--glob=!{pattern}")),
+            )
+            .collect(),
+    }
+}
+
 /// Runs the agent's exact engine + flags for the grouping path, appending only the
 /// parse aids (see `Engine::parse_flags`).
 fn engine_capture<T: AsRef<str>>(
@@ -315,6 +352,7 @@ fn engine_command<T: AsRef<str>>(
 ) -> Command {
     let mut cmd = resolved_command(engine.bin());
     cmd.args(engine.parse_flags());
+    cmd.args(engine_ignore_args(engine, &configured_ignore_patterns()));
     for a in extra_args {
         cmd.arg(a.as_ref());
     }
@@ -850,6 +888,59 @@ fn compact_path(path: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn sample_ignore_patterns() -> IgnorePatterns {
+        IgnorePatterns {
+            noise: vec!["node_modules".to_string()],
+            dirs: vec!["canary".to_string()],
+            files: vec!["*.lock".to_string()],
+        }
+    }
+
+    #[test]
+    fn rg_engine_ignore_args_are_explicit_globs() {
+        let args = engine_ignore_args(Engine::Rg, &sample_ignore_patterns());
+
+        assert!(args.contains(&"--glob=!node_modules".to_string()));
+        assert!(args.contains(&"--glob=!canary/".to_string()));
+        assert!(args.contains(&"--glob=!*.lock".to_string()));
+        assert!(!args.iter().any(|arg| arg.starts_with("--exclude")));
+    }
+
+    #[test]
+    fn grep_engine_ignore_args_use_engine_exclude_flags() {
+        let args = engine_ignore_args(Engine::Grep, &sample_ignore_patterns());
+
+        assert!(args.contains(&"--exclude-dir=node_modules".to_string()));
+        assert!(args.contains(&"--exclude-dir=canary".to_string()));
+        assert!(args.contains(&"--exclude=node_modules".to_string()));
+        assert!(args.contains(&"--exclude=*.lock".to_string()));
+        assert!(!args.iter().any(|arg| arg.starts_with("--glob")));
+    }
+
+    #[test]
+    fn rg_engine_ignore_args_skip_matching_entries_when_available() {
+        let dir = tempfile::tempdir().expect("temp search fixture");
+        std::fs::create_dir_all(dir.path().join("canary")).expect("canary dir");
+        std::fs::create_dir_all(dir.path().join("node_modules")).expect("node_modules dir");
+        std::fs::create_dir_all(dir.path().join("src")).expect("src dir");
+        std::fs::write(dir.path().join("canary/canary.txt"), "needle\n").expect("canary file");
+        std::fs::write(dir.path().join("node_modules/dep.txt"), "needle\n").expect("noise file");
+        std::fs::write(dir.path().join("src/Cargo.lock"), "needle\n").expect("lock file");
+        std::fs::write(dir.path().join("src/main.rs"), "needle\n").expect("src file");
+
+        let mut cmd = resolved_command("rg");
+        cmd.args(engine_ignore_args(Engine::Rg, &sample_ignore_patterns()));
+        cmd.args(["-n", "needle", dir.path().to_str().unwrap()]);
+
+        if let Ok(output) = cmd.output() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            assert!(!stdout.contains("canary.txt"), "canary dir must be skipped");
+            assert!(!stdout.contains("dep.txt"), "noise dir must be skipped");
+            assert!(!stdout.contains("Cargo.lock"), "ignored file must be skipped");
+            assert!(stdout.contains("main.rs"), "non-ignored file must be searched");
+        }
+    }
 
     #[test]
     fn test_clean_line() {

--- a/src/cmds/system/tree.rs
+++ b/src/cmds/system/tree.rs
@@ -6,7 +6,7 @@
 //! Token optimization: automatically excludes noise directories via -I pattern
 //! unless -a flag is present (respecting user intent).
 
-use super::constants::NOISE_DIRS;
+use super::constants::{configured_ignore_patterns, IgnorePatterns};
 use crate::core::runner::{self, RunOptions};
 use crate::core::utils::{resolved_command, tool_exists};
 use anyhow::Result;
@@ -28,7 +28,8 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     let has_ignore = args.iter().any(|a| a == "-I" || a.starts_with("--ignore="));
 
     if !show_all && !has_ignore {
-        let ignore_pattern = NOISE_DIRS.join("|");
+        let ignore_patterns = configured_ignore_patterns();
+        let ignore_pattern = tree_ignore_pattern(&ignore_patterns);
         cmd.arg("-I").arg(&ignore_pattern);
     }
 
@@ -60,6 +61,17 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
             .early_exit_on_failure()
             .no_trailing_newline(),
     )
+}
+
+fn tree_ignore_pattern(ignore_patterns: &IgnorePatterns) -> String {
+    ignore_patterns
+        .noise
+        .iter()
+        .chain(ignore_patterns.dirs.iter())
+        .chain(ignore_patterns.files.iter())
+        .map(|s| s.as_str())
+        .collect::<Vec<_>>()
+        .join("|")
 }
 
 fn filter_tree_output(raw: &str) -> String {
@@ -96,6 +108,7 @@ fn filter_tree_output(raw: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cmds::system::constants::NOISE_DIRS;
 
     #[test]
     fn test_filter_removes_summary() {
@@ -165,5 +178,20 @@ mod tests {
         assert!(NOISE_DIRS.contains(&".next"));
         assert!(NOISE_DIRS.contains(&"dist"));
         assert!(NOISE_DIRS.contains(&"build"));
+    }
+
+    #[test]
+    fn test_tree_ignore_pattern_includes_configured_entries() {
+        let ignore_patterns = IgnorePatterns {
+            noise: vec!["node_modules".to_string()],
+            dirs: vec!["canary".to_string()],
+            files: vec!["*.lock".to_string()],
+        };
+
+        let pattern = tree_ignore_pattern(&ignore_patterns);
+
+        assert!(pattern.contains("node_modules"));
+        assert!(pattern.contains("canary"));
+        assert!(pattern.contains("*.lock"));
     }
 }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -3,7 +3,7 @@
 use super::constants::{CONFIG_TOML, DEFAULT_HISTORY_DAYS, RTK_DATA_DIR};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct Config {
@@ -150,12 +150,29 @@ pub fn limits() -> LimitsConfig {
     Config::load().map(|c| c.limits).unwrap_or_default()
 }
 
+/// Get filters config. Falls back to defaults if config can't be loaded.
+pub fn filters() -> FilterConfig {
+    match get_config_path() {
+        Ok(path) => filters_at(&path),
+        Err(_) => FilterConfig::default(),
+    }
+}
+
+/// Load filter config from an explicit config.toml path.
+pub(crate) fn filters_at(path: &Path) -> FilterConfig {
+    Config::load_from(path)
+        .map(|c| c.filters)
+        .unwrap_or_default()
+}
+
 impl Config {
     pub fn load() -> Result<Self> {
-        let path = get_config_path()?;
+        Self::load_from(&get_config_path()?)
+    }
 
+    fn load_from(path: &Path) -> Result<Self> {
         if path.exists() {
-            let content = std::fs::read_to_string(&path)?;
+            let content = std::fs::read_to_string(path)?;
             let config: Config = toml::from_str(&content)?;
             Ok(config)
         } else {


### PR DESCRIPTION
Fixes #3386

Wires `[filters].ignore_dirs` and `[filters].ignore_files` from `config.toml` into the system commands so user-configured filters are actually applied instead of silently ignored. The hardcoded noise defaults remain as the base set, with config values merged on top.

Validation run locally:
- `cargo fmt -- --check`
- `cargo test --bin rtk cmds::system`
- `cargo test --bin rtk core::config::tests`
- `cargo build --bin rtk`

This is a local commit prepared for human review; no PR was opened by the agent.