### PR TITLE
fix(discover): don't drop commands chained after a pipeline

### DIFF
--- a/src/discover/lexer.rs
+++ b/src/discover/lexer.rs
@@ -398,8 +398,10 @@ pub fn split_for_permissions(cmd: &str) -> Vec<&str> {
 /// Split a shell command on operators (`&&`, `||`, `;`) and optionally pipes (`|`),
 /// respecting quoted strings via the lexer.
 ///
-/// When `stop_at_pipe` is true, returns only segments before the first `|`
-/// (used by command rewriting — only the left side of a pipe gets rewritten).
+/// When `stop_at_pipe` is true, only the first segment of each pipeline is
+/// returned: the rest of the pipeline is skipped and splitting resumes after
+/// the next `&&`/`||`/`;` (used by discovery — the left side of a pipe is the
+/// rewrite candidate, and segments chained after the pipeline still count).
 /// When false, splits through pipes too (used by permission checking —
 /// every segment must be validated).
 pub fn split_on_operators(cmd: &str, stop_at_pipe: bool) -> Vec<&str> {
@@ -411,33 +413,45 @@ pub fn split_on_operators(cmd: &str, stop_at_pipe: bool) -> Vec<&str> {
     let tokens = tokenize(trimmed);
     let mut results = Vec::new();
     let mut seg_start: usize = 0;
+    // True while inside the tail of a pipeline whose head was already pushed;
+    // segments are skipped until the next chain operator.
+    let mut in_pipeline_tail = false;
 
     for tok in &tokens {
         match tok.kind {
             TokenKind::Operator => {
-                let segment = trimmed[seg_start..tok.offset].trim();
-                if !segment.is_empty() {
-                    results.push(segment);
+                if !in_pipeline_tail {
+                    let segment = trimmed[seg_start..tok.offset].trim();
+                    if !segment.is_empty() {
+                        results.push(segment);
+                    }
                 }
+                in_pipeline_tail = false;
                 seg_start = tok.offset + tok.value.len();
             }
             TokenKind::Pipe(_) => {
+                if in_pipeline_tail {
+                    continue;
+                }
                 let segment = trimmed[seg_start..tok.offset].trim();
                 if !segment.is_empty() {
                     results.push(segment);
                 }
                 if stop_at_pipe {
-                    return results;
+                    in_pipeline_tail = true;
+                } else {
+                    seg_start = tok.offset + tok.value.len();
                 }
-                seg_start = tok.offset + tok.value.len();
             }
             _ => {}
         }
     }
 
-    let tail = trimmed[seg_start..].trim();
-    if !tail.is_empty() {
-        results.push(tail);
+    if !in_pipeline_tail {
+        let tail = trimmed[seg_start..].trim();
+        if !tail.is_empty() {
+            results.push(tail);
+        }
     }
 
     results
@@ -1165,6 +1179,18 @@ mod tests {
     fn test_split_on_operators_stop_at_pipe() {
         assert_eq!(split_on_operators("a | b | c", true), vec!["a"]);
         assert_eq!(split_on_operators("a && b | c", true), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn test_split_on_operators_stop_at_pipe_resumes_after_chain_operator() {
+        assert_eq!(split_on_operators("a | b; c", true), vec!["a", "c"]);
+        assert_eq!(split_on_operators("a | b && c", true), vec!["a", "c"]);
+        assert_eq!(
+            split_on_operators("a | b || c | d; e", true),
+            vec!["a", "c", "e"]
+        );
+        // Pipeline tail at end of input stays dropped.
+        assert_eq!(split_on_operators("a; b | c", true), vec!["a", "b"]);
     }
 
     #[test]

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -2195,6 +2195,18 @@ mod tests {
     }
 
     #[test]
+    fn test_split_chain_continues_after_pipeline() {
+        // Commands chained after a pipeline must not be lost (#discover
+        // undercount): only the pipeline tail is skipped, the chain goes on.
+        assert_eq!(
+            split_command_chain(
+                "RTK_DISABLED=1 grep -n a f | head -10; RTK_DISABLED=1 grep -n b f"
+            ),
+            vec!["RTK_DISABLED=1 grep -n a f", "RTK_DISABLED=1 grep -n b f"]
+        );
+    }
+
+    #[test]
     fn test_split_single() {
         assert_eq!(split_command_chain("git status"), vec!["git status"]);
     }


### PR DESCRIPTION
## Problem

`split_on_operators(cmd, stop_at_pipe = true)` returns early at the first pipe token. That discards not just the pipeline tail (intended) but **every command chained after it** with `;`, `&&` or `||` (not intended). `rtk discover` therefore never sees those commands — they are missing from the supported/unsupported tables, from `total_commands`, and from the `RTK_DISABLED` bypass count.

Agents chain commands like this constantly:

```bash
RTK_DISABLED=1 grep -n a f | head -10; RTK_DISABLED=1 grep -n b f
```

`split_command_chain` before this fix: `["RTK_DISABLED=1 grep -n a f"]` — the second grep vanishes.

## Reproduction

Synthetic session with the command above, `rtk discover --all --format json` (v0.45.0): `rtk_disabled_count = 1`, expected 2.

## Fix

At a pipe with `stop_at_pipe = true`, skip segments only until the next chain operator (`;`/`&&`/`||`), then resume splitting — instead of returning. The pipeline tail is still dropped (`"a | b | c"` → `["a"]`, `"a && b | c"` → `["a", "b"]` unchanged), and `stop_at_pipe = false` behaviour is untouched. Only caller of the `true` mode is discover's `split_command_chain`.

## Impact measured on real data

On a real 30-day Claude Code history (~2000 session files), the `RTK_DISABLED` bypass section went from **21 to 30** detected commands — matching an independent Python scan of the same transcripts exactly (same per-command breakdown). The supported/unsupported tables gain the same previously-invisible commands.

## Tests

- `test_split_on_operators_stop_at_pipe_resumes_after_chain_operator` (lexer): `"a | b; c"` → `["a", "c"]`, `"a | b && c"` → `["a", "c"]`, `"a | b || c | d; e"` → `["a", "c", "e"]`, trailing tail still dropped.
- `test_split_chain_continues_after_pipeline` (registry): the RTK_DISABLED reproduction case.
- `cargo fmt --all` clean, `cargo clippy --all-targets` clean, `cargo test --all`: 2579 passed, 1 failed — `hooks::rewrite_cmd::tests::unattestable_passthrough::test_dollar_substitution_passthrough`, which also fails on pristine `master` in my environment (pre-existing, unrelated).