### PR TITLE
fix(aws): preserve query-shaped EKS responses

### DIFF
--- a/src/cmds/cloud/aws_cmd.rs
+++ b/src/cmds/cloud/aws_cmd.rs
@@ -1313,12 +1313,12 @@ fn filter_s3_objects(json_str: &str) -> Option<FilterResult> {
 
 fn filter_eks_cluster(json_str: &str) -> Option<FilterResult> {
     let v: Value = serde_json::from_str(json_str).ok()?;
-    let cluster = &v["cluster"];
+    let cluster = v.get("cluster")?.as_object()?;
 
-    let name = cluster["name"].as_str().unwrap_or("?");
-    let status = cluster["status"].as_str().unwrap_or("?");
-    let version = cluster["version"].as_str().unwrap_or("?");
-    let endpoint = cluster["endpoint"].as_str().unwrap_or("?");
+    let name = cluster.get("name")?.as_str()?;
+    let status = cluster.get("status")?.as_str()?;
+    let version = cluster.get("version")?.as_str()?;
+    let endpoint = cluster.get("endpoint")?.as_str()?;
     // certificateAuthority intentionally NOT read (base64 cert, 1000+ chars)
 
     let text = format!("{} {} k8s/{} {}", name, status, version, endpoint);
@@ -2340,6 +2340,16 @@ mod tests {
         // certificateAuthority should NOT appear
         assert!(!result.text.contains("LS0tLS1CRUdJTi"));
         assert!(!result.text.contains("VERY_LONG"));
+    }
+
+    #[test]
+    fn test_filter_eks_cluster_rejects_query_shaped_responses() {
+        for json in [r#""ACTIVE""#, r#"["ACTIVE"]"#, "null"] {
+            assert!(
+                filter_eks_cluster(json).is_none(),
+                "query-shaped response must pass through unchanged: {json}"
+            );
+        }
     }
 
     #[test]

--- a/src/cmds/cloud/aws_cmd.rs
+++ b/src/cmds/cloud/aws_cmd.rs
@@ -1311,12 +1311,12 @@ fn filter_s3_objects(json_str: &str) -> Option<FilterResult> {
 
 fn filter_eks_cluster(json_str: &str) -> Option<FilterResult> {
     let v: Value = serde_json::from_str(json_str).ok()?;
-    let cluster = &v["cluster"];
+    let cluster = v.get("cluster")?.as_object()?;
 
-    let name = cluster["name"].as_str().unwrap_or("?");
-    let status = cluster["status"].as_str().unwrap_or("?");
-    let version = cluster["version"].as_str().unwrap_or("?");
-    let endpoint = cluster["endpoint"].as_str().unwrap_or("?");
+    let name = cluster.get("name")?.as_str()?;
+    let status = cluster.get("status")?.as_str()?;
+    let version = cluster.get("version")?.as_str()?;
+    let endpoint = cluster.get("endpoint")?.as_str()?;
     // certificateAuthority intentionally NOT read (base64 cert, 1000+ chars)
 
     let text = format!("{} {} k8s/{} {}", name, status, version, endpoint);
@@ -2338,6 +2338,16 @@ mod tests {
         // certificateAuthority should NOT appear
         assert!(!result.text.contains("LS0tLS1CRUdJTi"));
         assert!(!result.text.contains("VERY_LONG"));
+    }
+
+    #[test]
+    fn test_filter_eks_cluster_rejects_query_shaped_responses() {
+        for json in [r#""ACTIVE""#, r#"["ACTIVE"]"#, "null"] {
+            assert!(
+                filter_eks_cluster(json).is_none(),
+                "query-shaped response must pass through unchanged: {json}"
+            );
+        }
     }
 
     #[test]

--- a/tests/proxy_faithful_test.rs
+++ b/tests/proxy_faithful_test.rs
@@ -1,0 +1,73 @@
+//! Proxy mode must preserve the child command's arguments, output streams,
+//! and exit status. This protects the documented raw escape hatch (#3549).
+
+use std::process::Command;
+
+#[cfg(unix)]
+#[test]
+fn proxy_preserves_args_streams_and_exit_code() {
+    let output = Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args([
+            "proxy",
+            "sh",
+            "-c",
+            "printf 'out:%s' \"$1\"; printf 'err:%s' \"$2\" >&2; exit 23",
+            "proxy-fixture",
+            "value with spaces",
+            "--query=cluster.status",
+        ])
+        .output()
+        .expect("run rtk proxy fixture");
+
+    assert_eq!(
+        output.status.code(),
+        Some(23),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "out:value with spaces"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "err:--query=cluster.status"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn proxy_preserves_args_streams_and_exit_code() {
+    let fixture_dir = tempfile::tempdir().expect("create proxy fixture directory");
+    let script = fixture_dir.path().join("proxy-fixture.ps1");
+    std::fs::write(
+        &script,
+        "[Console]::Out.Write('out:' + $args[0]); [Console]::Error.Write('err:' + $args[1]); exit 23",
+    )
+    .expect("write proxy fixture");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .arg("proxy")
+        .arg("powershell.exe")
+        .args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-File"])
+        .arg(&script)
+        .args(["value with spaces", "--query=cluster.status"])
+        .env("CLAUDE_CONFIG_DIR", fixture_dir.path().join("no-claude"))
+        .output()
+        .expect("run rtk proxy fixture");
+
+    assert_eq!(
+        output.status.code(),
+        Some(23),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "out:value with spaces"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "err:--query=cluster.status"
+    );
+}


### PR DESCRIPTION
## Summary

- make the EKS `describe-cluster` formatter reject scalar, array, null, and incomplete response shapes instead of fabricating `? ? k8s/? ?`
- preserve query-shaped AWS responses through the existing raw-output fallback
- add a cross-platform integration test proving `rtk proxy` preserves arguments, stdout, stderr, and non-zero exit codes

Fixes #3549.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test --all`
- [x] `cargo build --release`
- [x] Proxy integration fixture verifies spaced args, `--query=cluster.status`, stdout, stderr, and exit code 23

## Notes

The proxy test confirms that RTK's proxy layer forwards the child process result unchanged. The reproducible RTK-side corruption was in the filtered EKS path: AWS query output is a JSON scalar, while the formatter previously assumed a full `cluster` object and filled every missing field with `?`.
