### PR TITLE
fix(filters): correct turbo/quarto-render/bundle-install/gcc TOML filters

### DIFF
--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -1421,6 +1421,21 @@ make[1]: Leaving directory '/home/user/project/docs'
 
         let gpp_bare = find_filter_in("g++", &filters).expect("bare g++ must match gcc filter");
         assert_eq!(gpp_bare.name, "gcc");
+
+        // Versioned compiler invocations (e.g. Debian/Ubuntu's gcc-9, g++-11,
+        // Homebrew's gcc-13) must still match -- the fixed regex must not be
+        // narrower than the original `\b`-based one for this common case.
+        let gcc_versioned =
+            find_filter_in("gcc-9 -c foo.c", &filters).expect("gcc-9 must match gcc filter");
+        assert_eq!(gcc_versioned.name, "gcc");
+
+        let gpp_versioned =
+            find_filter_in("g++-11 foo.cpp", &filters).expect("g++-11 must match gcc filter");
+        assert_eq!(gpp_versioned.name, "gcc");
+
+        let gcc_versioned_minor = find_filter_in("gcc-4.9 -c foo.c", &filters)
+            .expect("gcc-4.9 (minor version) must match gcc filter");
+        assert_eq!(gcc_versioned_minor.name, "gcc");
     }
 
     // --- Edge cases ---

--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -1405,6 +1405,24 @@ make[1]: Leaving directory '/home/user/project/docs'
         );
     }
 
+    #[test]
+    fn test_gcc_match_command_matches_gpp() {
+        let filters = make_filters(BUILTIN_TOML);
+
+        let gcc_filter = find_filter_in("gcc -c foo.c", &filters).expect("gcc built-in");
+        assert_eq!(gcc_filter.name, "gcc");
+
+        let gpp_filter =
+            find_filter_in("g++ -c foo.cpp -o foo.o", &filters).expect("g++ must match gcc filter");
+        assert_eq!(
+            gpp_filter.name, "gcc",
+            "g++ invocations must be routed to the same 'gcc' filter as gcc invocations"
+        );
+
+        let gpp_bare = find_filter_in("g++", &filters).expect("bare g++ must match gcc filter");
+        assert_eq!(gpp_bare.name, "gcc");
+    }
+
     // --- Edge cases ---
 
     #[test]

--- a/src/filters/bundle-install.toml
+++ b/src/filters/bundle-install.toml
@@ -9,7 +9,7 @@ strip_lines_matching = [
   "^Resolving dependencies",
 ]
 match_output = [
-  { pattern = "Bundle complete!", message = "ok bundle: complete" },
+  { pattern = "Bundle complete!", message = "ok bundle: complete", unless = "Installing " },
   { pattern = "Bundle updated!", message = "ok bundle: updated" },
 ]
 max_lines = 30
@@ -41,7 +41,7 @@ Fetching simplecov 0.22.0
 Installing simplecov 0.22.0
 Bundle complete! 85 Gemfile dependencies, 202 gems now installed.
 """
-expected = "ok bundle: complete"
+expected = "Fetching rspec 3.13.0\nInstalling rspec 3.13.0\nFetching simplecov 0.22.0\nInstalling simplecov 0.22.0\nBundle complete! 85 Gemfile dependencies, 202 gems now installed."
 
 [[tests.bundle-install]]
 name = "update output"

--- a/src/filters/gcc.toml
+++ b/src/filters/gcc.toml
@@ -1,6 +1,6 @@
 [filters.gcc]
 description = "Compact gcc/g++ compiler output — strip notes, keep errors and warnings"
-match_command = "^g(cc|\\+\\+)(\\s|$)"
+match_command = "^g(cc|\\+\\+)(-[0-9.]+)?(\\s|$)"
 strip_ansi = true
 strip_lines_matching = [
   "^\\s*$",

--- a/src/filters/gcc.toml
+++ b/src/filters/gcc.toml
@@ -1,6 +1,6 @@
 [filters.gcc]
 description = "Compact gcc/g++ compiler output — strip notes, keep errors and warnings"
-match_command = "^g(cc|\\+\\+)\\b"
+match_command = "^g(cc|\\+\\+)(\\s|$)"
 strip_ansi = true
 strip_lines_matching = [
   "^\\s*$",

--- a/src/filters/quarto-render.toml
+++ b/src/filters/quarto-render.toml
@@ -13,7 +13,7 @@ strip_lines_matching = [
   "^  Resolving",
 ]
 match_output = [
-  { pattern = "Output created:", message = "ok (output created)" },
+  { pattern = "Output created:", message = "ok (output created)", unless = "ERROR|error:" },
 ]
 max_lines = 20
 
@@ -39,3 +39,16 @@ caused by:
   syntax error at line 10
 """
 expected = "ERROR: Render failed\ncaused by:\n  syntax error at line 10"
+
+[[tests.quarto-render]]
+name = "errors not swallowed when output created is also present"
+input = """
+processing file: retry.qmd
+  Validating schema
+ERROR: Render failed on first attempt
+
+caused by:
+  syntax error at line 10
+Output created: _site/retry.html
+"""
+expected = "ERROR: Render failed on first attempt\ncaused by:\n  syntax error at line 10\nOutput created: _site/retry.html"

--- a/src/filters/turbo.toml
+++ b/src/filters/turbo.toml
@@ -6,8 +6,6 @@ strip_lines_matching = [
   "^\\s*$",
   "^\\s*cache (hit|miss|bypass)",
   "^\\s*\\d+ packages in scope",
-  "^\\s*Tasks:\\s+\\d+",
-  "^\\s*Duration:\\s+",
   "^\\s*Remote caching (enabled|disabled)",
 ]
 truncate_lines_at = 150
@@ -17,12 +15,12 @@ on_empty = "turbo: ok"
 [[tests.turbo]]
 name = "strips cache noise, keeps task output"
 input = " cache hit, replaying logs abc123\n cache miss, executing abc456\n\n3 packages in scope\n\n> myapp:build\n\nCompiled successfully.\n\nTasks:    2 successful, 2 total (1 cached)\nDuration: 3.2s"
-expected = "> myapp:build\nCompiled successfully."
+expected = "> myapp:build\nCompiled successfully.\nTasks:    2 successful, 2 total (1 cached)\nDuration: 3.2s"
 
 [[tests.turbo]]
 name = "preserves error output"
 input = "> myapp:lint\n\nError: src/index.ts(5,1): error TS2304\n\nTasks:    0 successful, 1 total\nDuration: 1.1s"
-expected = "> myapp:lint\nError: src/index.ts(5,1): error TS2304"
+expected = "> myapp:lint\nError: src/index.ts(5,1): error TS2304\nTasks:    0 successful, 1 total\nDuration: 1.1s"
 
 [[tests.turbo]]
 name = "empty after stripping"


### PR DESCRIPTION
## Summary

Four independent bugs bundled in #3407, each isolated to its own `src/filters/*.toml` filter, all verified reproducing against current `develop` before the fix and against sibling filter patterns already in the codebase.

- **`turbo`** — a failed `turbo run` used to lose its own pass/fail tally. `Tasks:`/`Duration:` lines were unconditionally stripped, so a failing build showed only the error text with no indication of how many tasks failed. Those lines are no longer stripped.
- **`quarto-render`** — a render that errored on a first attempt but eventually produced output (e.g. after a retry) was reported as a clean `ok (output created)`, hiding the earlier error. Added an `unless = "ERROR|error:"` guard on the success shortcut, matching the pattern already used by `rsync.toml`/`swift-build.toml`.
- **`bundle-install`** — a mixed install (some gems cached, some freshly fetched) collapsed to a bare `ok bundle: complete`, discarding exactly the `Fetching`/`Installing` detail a user would want to see. Guarded the shortcut so that detail now survives.
- **`gcc`** — `g++` invocations never activated this filter at all (`\b` can't match between `+` and a following space), so C++ builds got zero compression. Fixed the `match_command` regex; also preserves versioned invocations (`gcc-9`, `g++-11`) that a stricter first-pass version of the fix would have silently dropped — caught in review and corrected.

## Validation

Each fix was written test-first: the relevant test fixture was updated to the correct expected value first, confirmed to fail against the unfixed filter, then the filter was corrected and confirmed to pass. Full gate: `cargo fmt --all -- --check` (clean), `cargo clippy --all-targets` (zero warnings), `rtk verify --require-all` (155/155 filter tests pass), `cargo test --all` (2574 passed; 2 pre-existing failures in `hooks::rewrite_cmd::tests::unattestable_passthrough` confirmed present on a clean `develop` checkout too, unrelated to this change — they depend on local Claude Code permission settings, a known environment-dependent issue in this test suite).

Session-settled decisions carried from planning: stop stripping the turbo tally rather than conditionally stripping it (user-directed, over conditional-stripping — the TOML filter DSL has no per-line success/failure awareness); guard `quarto-render`'s shortcut with `unless=` (user-directed, over leaving unguarded — matches the established sibling-filter pattern); fix the `bundle-install` test's assertion to match its own name rather than renaming the test (user-directed, over renaming — the current behavior throws away real information a mixed install should show); widen `gcc`'s `match_command` to cover `g++` (user-directed, over leaving as-is — C++ builds via `g++` are extremely common).

Related: Fixes #3407

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
