### PR TITLE
feat(config): quiet_hook_warnings to suppress hook warnings

### DIFF
--- a/src/analytics/gain.rs
+++ b/src/analytics/gain.rs
@@ -121,24 +121,31 @@ pub fn run(
         print_efficiency_meter(summary.avg_savings_pct);
         println!();
 
-        // Warn about hook issues that silently kill savings (stderr, not stdout)
-        match hook_check::status() {
-            hook_check::HookStatus::Missing => {
-                eprintln!(
-                    "{}",
-                    "[warn] No hook installed — run `rtk init -g` for automatic token savings"
-                        .yellow()
-                );
-                eprintln!();
+        // Warn about hook issues that silently kill savings (stderr, not stdout).
+        // Skip when user has opted in to hook-free usage via config.
+        if !crate::core::config::Config::load()
+            .ok()
+            .map(|c| c.hooks.quiet_hook_warnings)
+            .unwrap_or(false)
+        {
+            match hook_check::status() {
+                hook_check::HookStatus::Missing => {
+                    eprintln!(
+                        "{}",
+                        "[warn] No hook installed — run `rtk init -g` for automatic token savings"
+                            .yellow()
+                    );
+                    eprintln!();
+                }
+                hook_check::HookStatus::Outdated => {
+                    eprintln!(
+                        "{}",
+                        "[warn] Hook outdated — run `rtk init -g` to update".yellow()
+                    );
+                    eprintln!();
+                }
+                hook_check::HookStatus::Ok => {}
             }
-            hook_check::HookStatus::Outdated => {
-                eprintln!(
-                    "{}",
-                    "[warn] Hook outdated — run `rtk init -g` to update".yellow()
-                );
-                eprintln!();
-            }
-            hook_check::HookStatus::Ok => {}
         }
 
         // Lightweight RTK_DISABLED bypass check (best-effort, silent on failure)

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -51,6 +51,13 @@ pub struct HooksConfig {
     /// not anything else.
     #[serde(default)]
     pub transparent_prefixes: Vec<String>,
+
+    /// Suppress the "No hook installed / Hook outdated" warnings emitted by
+    /// `rtk gain`. Useful when the user intentionally opts out of hook-based
+    /// interception (e.g. via an AI agent's `CLAUDE.md` or `settings.json`)
+    /// and relies on explicit `rtk <cmd>` invocations instead.
+    #[serde(default)]
+    pub quiet_hook_warnings: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -224,6 +231,17 @@ exclude_commands = ["curl", "gh"]
         let config = Config::default();
         assert!(config.hooks.exclude_commands.is_empty());
         assert!(config.hooks.transparent_prefixes.is_empty());
+        assert!(!config.hooks.quiet_hook_warnings);
+    }
+
+    #[test]
+    fn test_hooks_config_quiet_hook_warnings_deserialize() {
+        let toml = r#"
+[hooks]
+quiet_hook_warnings = true
+"#;
+        let config: Config = toml::from_str(toml).expect("valid toml");
+        assert!(config.hooks.quiet_hook_warnings);
     }
 
     #[test]

--- a/src/hooks/hook_check.rs
+++ b/src/hooks/hook_check.rs
@@ -86,7 +86,14 @@ fn binary_hook_registered(claude_dir: &std::path::Path) -> bool {
 
 /// Check if the installed hook is missing or outdated, warn once per day.
 pub fn maybe_warn() {
-    // Don't block startup — fail silently on any error
+    // Respect user opt-out: if config says quiet_hook_warnings, skip entirely.
+    if crate::core::config::Config::load()
+        .ok()
+        .map(|c| c.hooks.quiet_hook_warnings)
+        .unwrap_or(false)
+    {
+        return;
+    }
     let _ = check_and_warn();
 }
 


### PR DESCRIPTION
## Summary

Fixes #682 — recurring "No hook installed / Hook outdated" warnings for
users who intentionally opt out of hook-based interception.

## Problem

When the user configures their AI agent via `CLAUDE.md` / `settings.json`
and relies on explicit `rtk <cmd>` invocations instead of the shell
rewrite hook, they still get the warning banner on every command:

```
[rtk] /!\ No hook installed — run `rtk init -g` for automatic token savings
```

This is noise, not a real issue, for users who have made an
intentional choice to skip the hook.

## Solution

Add `[hooks].quiet_hook_warnings = true` to `config.toml`. When set,
both warning paths are suppressed:

- `src/hooks/hook_check.rs` `maybe_warn()` — called from `main.rs` on
  every command invocation (this is the warning the issue screenshot
  shows)
- `src/analytics/gain.rs` `run()` — the `rtk gain` display warning

Default is `false`, so existing behaviour is unchanged.

## Usage

```toml
[hooks]
quiet_hook_warnings = true
```

## Changes

- `src/core/config.rs` — new `bool` field on `HooksConfig` with
  doc comment + two unit tests (default + deserialization)
- `src/analytics/gain.rs` — gate the gain display warning block
- `src/hooks/hook_check.rs` — gate the startup warning

All changes are additive, no API changes, no behaviour change when
unset.