### PR TITLE
fix(prisma): report real migration counts instead of 0 applied, 0 pending

### DIFF
--- a/src/cmds/js/prisma_cmd.rs
+++ b/src/cmds/js/prisma_cmd.rs
@@ -305,66 +305,133 @@ fn filter_migrate_dev(output: &str) -> String {
     result.trim().to_string()
 }
 
-/// Filter migrate status output
-fn filter_migrate_status(output: &str) -> String {
-    let mut applied_count = 0;
-    let mut pending_count = 0;
-    let mut latest_migration = String::new();
-
+/// Parses the `N migrations found in <path>` header that Prisma prints for
+/// both `migrate status` and `migrate deploy`. Returns `None` when the header
+/// is absent, which means the output is not a shape we know how to summarize.
+fn parse_migrations_found(output: &str) -> Option<usize> {
     for line in output.lines() {
-        if line.contains("applied") {
-            applied_count += 1;
-            if latest_migration.is_empty() && line.contains("202") {
-                if let Some(pos) = line.find("202") {
-                    let end = line[pos..].find(|c: char| c.is_whitespace()).unwrap_or(20);
-                    latest_migration = line[pos..pos + end].to_string();
-                }
+        let line = line.trim();
+        if !line.contains("found in") {
+            continue;
+        }
+        if line.starts_with("No migration found") {
+            return Some(0);
+        }
+        let mut words = line.split_whitespace();
+        let count = words.next().and_then(|word| word.parse::<usize>().ok());
+        let noun = words.next().unwrap_or("");
+        if let Some(count) = count {
+            if noun.starts_with("migration") {
+                return Some(count);
             }
         }
-        if line.contains("pending") || line.contains("unapplied") {
-            pending_count += 1;
-        }
     }
-
-    let mut result = String::new();
-    result.push_str(&format!(
-        "Migrations: {} applied, {} pending\n",
-        applied_count, pending_count
-    ));
-
-    if !latest_migration.is_empty() {
-        result.push_str(&format!("Latest: {}\n", latest_migration));
-    }
-
-    result.trim().to_string()
+    None
 }
 
-/// Filter migrate deploy output
-fn filter_migrate_deploy(output: &str) -> String {
-    let mut deployed = 0;
-    let mut errors = Vec::new();
+/// Collects the migration names Prisma lists under its
+/// `Following migration(s) have not yet been applied:` header.
+fn parse_pending_migrations(output: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut in_block = false;
 
     for line in output.lines() {
-        if line.contains("applied") || line.contains("✓") {
-            deployed += 1;
+        let line = line.trim();
+
+        if line.contains("have not yet been applied") {
+            in_block = true;
+            continue;
         }
-        if line.contains("error") || line.contains("ERROR") {
-            errors.push(line.trim().to_string());
+        if !in_block {
+            continue;
         }
+
+        // Blank lines before the first name are padding; after it, the list is over.
+        if line.is_empty() {
+            if names.is_empty() {
+                continue;
+            }
+            break;
+        }
+        // Migration directory names never contain spaces, so anything that does
+        // is the prose that follows the list.
+        if line.contains(' ') {
+            break;
+        }
+        names.push(line.to_string());
     }
 
-    let mut result = String::new();
+    names
+}
 
-    if errors.is_empty() {
-        result.push_str(&format!("{} migration(s) deployed\n", deployed));
-    } else {
-        result.push_str("[FAIL] Deployment failed:\n");
-        for err in errors.iter().take(5) {
-            result.push_str(&format!("  {}\n", err));
+/// Collects the migration names from Prisma's ``Applying migration `name` `` lines.
+fn parse_applied_migrations(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let rest = line.trim().strip_prefix("Applying migration ")?;
+            Some(rest.trim_matches('`').to_string())
+        })
+        .collect()
+}
+
+/// Filter migrate status output.
+///
+/// Prisma never prints an "N applied" line, so counting lines that merely
+/// contain the word `applied` reported `0 applied, 0 pending` against a
+/// healthy database, and counted the "have not yet been applied" header as an
+/// applied migration. Parse the documented shapes instead and fall back to the
+/// raw output on anything else (drift, failed migrations, shadow-database
+/// errors): a status summary that cannot be trusted is worse than no summary.
+fn filter_migrate_status(output: &str) -> String {
+    let total = parse_migrations_found(output);
+    let pending = parse_pending_migrations(output);
+    let up_to_date = output.contains("Database schema is up to date!");
+
+    match (total, up_to_date, pending.is_empty()) {
+        (Some(total), true, true) => format!("{} migration(s) found, schema up to date", total),
+        (Some(total), false, false) => {
+            let mut result = format!(
+                "{} migration(s) found, {} not yet applied:",
+                total,
+                pending.len()
+            );
+            for name in pending.iter().take(5) {
+                result.push_str(&format!("\n  - {}", name));
+            }
+            if pending.len() > 5 {
+                result.push_str(&format!("\n  ... and {} more", pending.len() - 5));
+            }
+            result
         }
+        _ => output.trim().to_string(),
+    }
+}
+
+/// Filter migrate deploy output.
+///
+/// Counts the ``Applying migration `name` `` lines Prisma emits per migration,
+/// not lines containing the word `applied` — the previous heuristic scored the
+/// two summary sentences and reported "2 migration(s) deployed" for a run that
+/// applied three. Unrecognized output is returned verbatim.
+fn filter_migrate_deploy(output: &str) -> String {
+    if output.contains("No pending migrations to apply") {
+        return "No pending migrations to apply".to_string();
     }
 
-    result.trim().to_string()
+    let applied = parse_applied_migrations(output);
+    if !applied.is_empty() && output.contains("successfully applied") {
+        let mut result = format!("{} migration(s) applied:", applied.len());
+        for name in applied.iter().take(5) {
+            result.push_str(&format!("\n  - {}", name));
+        }
+        if applied.len() > 5 {
+            result.push_str(&format!("\n  ... and {} more", applied.len() - 5));
+        }
+        return result;
+    }
+
+    output.trim().to_string()
 }
 
 /// Filter db push output
@@ -487,5 +554,166 @@ CREATE INDEX "session_status_idx" ON "Session"("status");
     fn test_extract_number() {
         assert_eq!(extract_number("42 models generated"), Some(42));
         assert_eq!(extract_number("no numbers here"), None);
+    }
+
+    // Fixtures below are verbatim captures from Prisma 7.8.0 against a
+    // PostgreSQL 16 database, not hand-written approximations.
+
+    const STATUS_UP_TO_DATE: &str = r#"Loaded Prisma config from prisma.config.ts.
+
+Prisma schema loaded from prisma\schema.prisma.
+Datasource "db": PostgreSQL database "rtk_probe", schema "public" at "localhost:5432"
+
+3 migrations found in prisma/migrations
+
+Database schema is up to date!
+"#;
+
+    const STATUS_PENDING: &str = r#"Loaded Prisma config from prisma.config.ts.
+
+Prisma schema loaded from prisma\schema.prisma.
+Datasource "db": PostgreSQL database "rtk_probe", schema "public" at "localhost:5432"
+
+4 migrations found in prisma/migrations
+Following migration have not yet been applied:
+20260401000000_add_flange
+
+To apply migrations in development run prisma migrate dev.
+To apply migrations in production run prisma migrate deploy.
+"#;
+
+    const DEPLOY_APPLYING: &str = r#"Loaded Prisma config from prisma.config.ts.
+
+Prisma schema loaded from prisma\schema.prisma.
+Datasource "db": PostgreSQL database "rtk_probe", schema "public" at "localhost:5432"
+
+3 migrations found in prisma/migrations
+
+Applying migration `20260101000000_init`
+Applying migration `20260201000000_add_gadget`
+Applying migration `20260301000000_add_sprocket`
+
+The following migration(s) have been applied:
+
+migrations/
+  └─ 20260101000000_init/
+    └─ migration.sql
+  └─ 20260201000000_add_gadget/
+    └─ migration.sql
+  └─ 20260301000000_add_sprocket/
+    └─ migration.sql
+
+All migrations have been successfully applied.
+"#;
+
+    const DEPLOY_NOOP: &str = r#"Loaded Prisma config from prisma.config.ts.
+
+Prisma schema loaded from prisma\schema.prisma.
+Datasource "db": PostgreSQL database "rtk_probe", schema "public" at "localhost:5432"
+
+3 migrations found in prisma/migrations
+
+
+No pending migrations to apply.
+"#;
+
+    #[test]
+    fn status_reports_the_real_total_when_up_to_date() {
+        let result = filter_migrate_status(STATUS_UP_TO_DATE);
+        assert_eq!(result, "3 migration(s) found, schema up to date");
+    }
+
+    /// Regression: the previous heuristic counted lines containing the word
+    /// "applied", which Prisma never prints on a healthy database, so a
+    /// six-migration project was summarized as "0 applied, 0 pending".
+    #[test]
+    fn status_never_claims_zero_when_migrations_exist() {
+        let result = filter_migrate_status(STATUS_UP_TO_DATE);
+        assert!(
+            !result.contains('0'),
+            "summary must not report a zero count for 3 migrations: {result}"
+        );
+        assert!(result.contains('3'), "summary must carry the real total: {result}");
+    }
+
+    #[test]
+    fn status_names_the_pending_migrations() {
+        let result = filter_migrate_status(STATUS_PENDING);
+        assert!(result.contains("4 migration(s) found"), "{result}");
+        assert!(result.contains("1 not yet applied"), "{result}");
+        assert!(result.contains("20260401000000_add_flange"), "{result}");
+    }
+
+    /// Regression: "Following migration have not yet been applied:" contains
+    /// the substring "applied", so the old counter scored a pending migration
+    /// as an applied one.
+    #[test]
+    fn status_does_not_count_the_pending_header_as_applied() {
+        let result = filter_migrate_status(STATUS_PENDING);
+        assert!(
+            !result.contains("1 applied"),
+            "pending header must not be read as an applied migration: {result}"
+        );
+    }
+
+    #[test]
+    fn status_falls_back_to_raw_on_unknown_shape() {
+        let drift = "Drift detected: your database schema is not in sync with your migration history.";
+        assert_eq!(filter_migrate_status(drift), drift);
+    }
+
+    #[test]
+    fn status_falls_back_when_totals_and_state_disagree() {
+        // "up to date" alongside a pending list is contradictory: refuse to summarize.
+        let contradictory = "2 migrations found in prisma/migrations\n\
+             Following migration have not yet been applied:\n\
+             20260401000000_add_flange\n\
+             Database schema is up to date!";
+        assert_eq!(filter_migrate_status(contradictory), contradictory);
+    }
+
+    #[test]
+    fn deploy_counts_every_applied_migration() {
+        let result = filter_migrate_deploy(DEPLOY_APPLYING);
+        assert!(
+            result.starts_with("3 migration(s) applied"),
+            "three migrations were applied, got: {result}"
+        );
+        assert!(result.contains("20260301000000_add_sprocket"), "{result}");
+    }
+
+    #[test]
+    fn deploy_reports_a_noop_run() {
+        assert_eq!(
+            filter_migrate_deploy(DEPLOY_NOOP),
+            "No pending migrations to apply"
+        );
+    }
+
+    #[test]
+    fn deploy_falls_back_to_raw_on_unknown_shape() {
+        let partial = "Applying migration `20260101000000_init`";
+        assert_eq!(filter_migrate_deploy(partial), partial);
+    }
+
+    #[test]
+    fn parses_the_migrations_found_header() {
+        assert_eq!(parse_migrations_found(STATUS_UP_TO_DATE), Some(3));
+        assert_eq!(parse_migrations_found(STATUS_PENDING), Some(4));
+        assert_eq!(
+            parse_migrations_found("1 migration found in prisma/migrations"),
+            Some(1)
+        );
+        assert_eq!(
+            parse_migrations_found("No migration found in prisma/migrations"),
+            Some(0)
+        );
+        assert_eq!(parse_migrations_found("nothing to see here"), None);
+    }
+
+    #[test]
+    fn pending_list_stops_before_the_trailing_prose() {
+        let names = parse_pending_migrations(STATUS_PENDING);
+        assert_eq!(names, vec!["20260401000000_add_flange".to_string()]);
     }
 }


### PR DESCRIPTION
## Problem

`rtk prisma migrate status` reports `Migrations: 0 applied, 0 pending` against a database that has migrations applied.

Reproduced on Prisma 7.8.0 + PostgreSQL 16, in a real project (6 migrations) and in an isolated throwaway project (2 migrations):

```
$ npx prisma migrate status
6 migrations found in prisma/migrations
Database schema is up to date!

$ rtk prisma migrate status
Migrations: 0 applied, 0 pending
```

`filter_migrate_status` counts lines containing the substring `applied`:

```rust
if line.contains("applied") { applied_count += 1; ... }
if line.contains("pending") || line.contains("unapplied") { pending_count += 1; }
```

Prisma does not print either word on a successful run — it prints `N migrations found in <path>` and `Database schema is up to date!`. This is not a Prisma 7 regression: no Prisma version emits the shape this counter expects, so the summary has always been `0 applied, 0 pending` on a healthy database.

Two related consequences of the same heuristic:

- `Following migration have not yet been applied:` contains `applied`, so a **pending** migration is scored as an **applied** one.
- `filter_migrate_deploy` reported `2 migration(s) deployed` for a run that applied three, having counted the two summary sentences instead of the per-migration `Applying migration \`name\`` lines.

Scope, measured rather than assumed: the filter only runs on success, and Prisma exits 1 when migrations are pending, so rtk falls through to raw passthrough in that case and the pending migration stays visible. Exit codes are propagated correctly. The damage is a confidently wrong count, not a hidden pending migration — but a count of `0` on a healthy project is the kind of output an agent will quote as fact.

`never_worse` cannot help here: it compares token counts, never correctness.

## Fix

Parse the documented output shapes, and **fall back to the raw output whenever the text does not match one of them** — drift, failed migrations, shadow-database errors. A summary that cannot be trusted is worse than no summary.

```
$ rtk prisma migrate status
3 migration(s) found, schema up to date

# with a migration that has not been applied yet
4 migration(s) found, 1 not yet applied:
  - 20260401000000_add_flange

# deploy
3 migration(s) applied:
  - 20260101000000_init
  - 20260201000000_add_gadget
  - 20260301000000_add_sprocket
```

## Tests

10 new tests. Fixtures are verbatim captures from Prisma 7.8.0 against PostgreSQL 16, not hand-written approximations. Two of them are explicit regression guards:

- `status_never_claims_zero_when_migrations_exist`
- `status_does_not_count_the_pending_header_as_applied`

Both were confirmed non-vacuous by mutation: forcing the count back to `0` makes them fail, and reverting makes them pass.

```
cargo test prisma   ->  16 passed; 0 failed
cargo fmt -- --check ->  clean
cargo clippy --all-targets -> no warnings
```

`cargo test` on the full crate is `2583 passed; 3 failed`. The three failures are in `hooks::rewrite_cmd::tests::unattestable_passthrough` and are **pre-existing on `develop`** (6f0b0ca) — verified by stashing this patch and re-running, and by moving `%APPDATA%\rtk\config.toml` aside to rule out local config. They are unrelated to this change; happy to open a separate issue if they are not already known.

Environment: Windows 11, `stable-x86_64-pc-windows-msvc`.
