### PR TITLE
fix(lint): a bare path is read as a linter name, turning the failure into a lint verdict

### DIFF
--- a/src/cmds/js/lint_cmd.rs
+++ b/src/cmds/js/lint_cmd.rs
@@ -74,13 +74,21 @@ fn strip_pm_prefix(args: &[String]) -> usize {
 
 /// Detect the linter name from args (after stripping PM prefixes).
 /// Returns the linter name and whether it was explicitly specified.
+///
+/// The rewrite rule maps `npx eslint src` to `rtk lint src`, dropping the
+/// linter name, so the first argument here is just as likely to be a path as
+/// a linter. A bare directory name (`src`, `app`, `lib`) carries no `.`, `/`
+/// or leading `-`, and used to be taken for a linter: rtk then ran
+/// `npx -- src`, which cannot exist, and the resulting package-manager error
+/// was summarized as a lint verdict. Checking the filesystem resolves the
+/// ambiguity in the only direction that cannot invent a linter run.
 fn detect_linter(args: &[String]) -> (&str, bool) {
     let is_path_or_flag = args.is_empty()
         || args[0].starts_with('-')
         || args[0].contains('/')
         || args[0].contains('.');
 
-    if is_path_or_flag {
+    if is_path_or_flag || std::path::Path::new(&args[0]).exists() {
         ("eslint", false)
     } else {
         (&args[0], true)
@@ -196,7 +204,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         }
         "pylint" => filter_pylint_json(&result.stdout),
         "mypy" => mypy_cmd::filter_mypy_output(&raw),
-        _ => filter_generic_lint(&raw),
+        _ => filter_generic_lint(&raw, result.success()),
     };
 
     let hint = crate::core::tee::tee_and_hint(&raw, "lint", result.exit_code);
@@ -442,8 +450,15 @@ fn filter_pylint_json(output: &str) -> String {
     result.trim().to_string()
 }
 
-/// Filter generic linter output (fallback for non-ESLint linters)
-fn filter_generic_lint(output: &str) -> String {
+/// Filter generic linter output (fallback for non-ESLint linters).
+///
+/// `succeeded` guards the clean verdict: this filter recognizes an issue by
+/// the words "error" and "warning", so a linter that never ran — missing
+/// binary, bad arguments, or a failure reported in the user's own language —
+/// yields zero of both and used to be summarized as "Lint: No issues found".
+/// A clean bill of health for a command that failed is the one output this
+/// filter must never produce, so a non-zero exit hands back the raw text.
+fn filter_generic_lint(output: &str, succeeded: bool) -> String {
     let mut warnings = 0;
     let mut errors = 0;
     let mut issues: Vec<String> = Vec::new();
@@ -461,6 +476,9 @@ fn filter_generic_lint(output: &str) -> String {
     }
 
     if errors == 0 && warnings == 0 {
+        if !succeeded {
+            return output.trim().to_string();
+        }
         return "Lint: No issues found".to_string();
     }
 
@@ -693,6 +711,68 @@ mod tests {
         let effective = &full_args[skip..];
         let (linter, _) = detect_linter(effective);
         assert_eq!(linter, "biome");
+    }
+
+    /// Regression: `npx eslint src` is rewritten to `rtk lint src`, so the
+    /// first argument is a path. Taking it for a linter ran `npx -- src`.
+    #[test]
+    fn detect_linter_treats_an_existing_directory_as_a_path() {
+        // Cargo runs unit tests from the crate root, where `src` exists.
+        // Reading the real cwd keeps this test free of any global mutation,
+        // which set_current_dir would impose on every test running alongside.
+        assert!(std::path::Path::new("src").is_dir(), "test precondition");
+
+        let args: Vec<String> = vec!["src".into()];
+        let (linter, explicit) = detect_linter(&args);
+
+        assert_eq!(linter, "eslint", "a directory that exists is a path");
+        assert!(!explicit);
+    }
+
+    #[test]
+    fn detect_linter_still_accepts_a_linter_name() {
+        // "biome" is not a directory here, so it keeps its linter meaning.
+        let args: Vec<String> = vec!["biome".into(), "check".into()];
+        let (linter, explicit) = detect_linter(&args);
+        assert_eq!(linter, "biome");
+        assert!(explicit);
+    }
+
+    /// Regression: pnpm reports a missing command without the word "error",
+    /// and in the user's locale. Both counters stayed at zero and the run was
+    /// summarized as clean although the linter never started.
+    #[test]
+    fn generic_lint_never_reports_clean_on_a_failed_run() {
+        let pnpm_failure = "'src' n'est pas reconnu en tant que commande interne\n\
+             ou externe, un programme executable ou un fichier de commandes.\n\
+             undefined\n\
+             ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command \"src\" not found";
+
+        let result = filter_generic_lint(pnpm_failure, false);
+        assert!(
+            !result.contains("No issues found"),
+            "a failed run must never read as clean: {result}"
+        );
+        assert!(
+            result.contains("ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL"),
+            "the raw failure must survive: {result}"
+        );
+    }
+
+    #[test]
+    fn generic_lint_reports_clean_on_a_successful_run() {
+        assert_eq!(
+            filter_generic_lint("Checked 12 files\n", true),
+            "Lint: No issues found"
+        );
+    }
+
+    #[test]
+    fn generic_lint_still_summarizes_real_findings() {
+        let output = "src/a.js:1:1 warning Unexpected console statement\n\
+             src/b.js:4:2 error Missing semicolon";
+        let result = filter_generic_lint(output, false);
+        assert!(result.starts_with("Lint: 1 errors, 1 warnings"), "{result}");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`rtk lint src` reports lint results for a run that never happened. Two shapes, depending on the package manager:

```
# npm — clean project, ESLint exits 0 with no findings
$ npx eslint src
$ echo $?
0

$ rtk lint src
Lint: 2 errors, 0 warnings
npm error could not determine executable to run
```

```
# pnpm — same command, opposite lie
$ rtk lint src
Lint: No issues found
```

That second one is the dangerous one: the only line printed says the project is clean, while ESLint never started.

## Cause

Three steps line up:

1. The rewrite rule maps `npx eslint src` to `rtk lint src`, dropping the linter name.
2. `detect_linter` treats the first argument as a linter name unless it starts with `-` or contains `.` or `/`. A bare directory — `src`, `app`, `lib`, `tests` — matches none of those, so `src` becomes the linter and rtk runs `npx -- src`.
3. That command fails, and `filter_generic_lint` scores the failure as lint output. It counts lines containing `error` or `warning`:
   - npm prints two `npm error …` lines → `Lint: 2 errors`.
   - pnpm prints `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "src" not found`, which contains neither word → both counters stay at 0 → `Lint: No issues found`.

On a non-English system the shell's own message is localized as well (`'src' n'est pas reconnu en tant que commande interne`), so a wording-based heuristic has nothing to latch onto there either.

The exit code is propagated correctly in both cases — but it is invisible to whoever reads the summary, and the summary is what an agent quotes.

## Fix

**`detect_linter`: an argument that exists on disk is a path.** `rtk lint src` then lints `src` with ESLint rather than inventing a linter named after the directory. A name that is not a path keeps its linter meaning, so `rtk lint biome check` and `rtk lint ruff` are unaffected. The ambiguity is real — the rewrite discards the information — so it is resolved in the only direction that cannot fabricate a linter run.

**`filter_generic_lint`: never certify a failed run as clean.** It now takes the exit status and returns the raw output instead of `Lint: No issues found` when the command failed. The filter recognizes issues by the words `error` and `warning`, which means it cannot distinguish a clean run from one that never started; the exit status can. Real findings are still summarized as before.

Verified with a build of this branch:

| Case | Before | After |
|---|---|---|
| `rtk lint src`, clean project, npm | `Lint: 2 errors, 0 warnings` | `ESLint: No issues found` |
| `rtk lint src`, ESLint absent, pnpm | `Lint: No issues found` | `ESLint output (JSON parse failed…)` + the pnpm error |
| `rtk lint <unknown-linter>` | `Lint: No issues found` | raw failure output |

## Tests

5 new tests, 20 passing in the module. Three are regression guards, all confirmed non-vacuous by mutation (inverting each guard makes them fail, restoring makes them pass):

- `detect_linter_treats_an_existing_directory_as_a_path`
- `generic_lint_never_reports_clean_on_a_failed_run` — fixture is the verbatim pnpm failure, localized line included
- `generic_lint_reports_clean_on_a_successful_run`

`cargo fmt -- --check` clean, `cargo clippy --all-targets` no warnings.

`cargo test` on the full crate: `2577 passed; 3 failed`. The three failures are in `hooks::rewrite_cmd::tests::unattestable_passthrough` and are pre-existing on `develop` (6f0b0ca), unrelated to this change — same ones noted in #3566.

Environment: Windows 11, `stable-x86_64-pc-windows-msvc`, npm and pnpm 10.34.4.
