### PR TITLE
fix(rewrite): never rewrite sudo-prefixed commands

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1311,6 +1311,13 @@ fn rewrite_segment_inner(
             );
             return None;
         }
+        // #3412: never insert rtk inside an elevated invocation. `sudo <tool>`
+        // elevates exactly one binary; rewriting to `sudo rtk <tool>` would run
+        // rtk's SQLite/tee/config/telemetry side effects as root and resolve
+        // the target binary outside sudo's secure_path. Pass through untouched.
+        if env_prefix.split_whitespace().any(|t| t == "sudo") {
+            return None;
+        }
         let rewritten = rewrite_segment_inner(
             rest_after_env,
             excluded,
@@ -4594,11 +4601,18 @@ mod tests {
 
     // --- sudo / env prefix + rewrite ---
 
+    // #3412: sudo-prefixed commands are never rewritten — inserting rtk into
+    // the elevation would run its database/tee/telemetry side effects as root.
     #[test]
-    fn test_rewrite_sudo_docker() {
+    fn test_rewrite_sudo_docker_skipped() {
+        assert_eq!(rewrite_command_no_prefixes("sudo docker ps", &[]), None);
+    }
+
+    #[test]
+    fn test_rewrite_sudo_with_env_assign_skipped() {
         assert_eq!(
-            rewrite_command_no_prefixes("sudo docker ps", &[]),
-            Some("sudo rtk docker ps".into())
+            rewrite_command_no_prefixes("env FOO=1 sudo iptables -L", &[]),
+            None
         );
     }
 
@@ -5147,9 +5161,16 @@ mod tests {
 
     #[test]
     fn test_env_prefix_composed_with_builtin() {
+        // #3412: the sudo prefix suppresses the rewrite even through a
+        // builtin transparent prefix like noglob.
         assert_eq!(
             rewrite_command_no_prefixes("sudo noglob git status", &[]),
-            Some("sudo noglob rtk git status".into())
+            None
+        );
+        // A plain env-assignment prefix still composes with builtins.
+        assert_eq!(
+            rewrite_command_no_prefixes("FOO=1 noglob git status", &[]),
+            Some("FOO=1 noglob rtk git status".into())
         );
     }
 


### PR DESCRIPTION
## Summary

- The rewrite re-attached a leading `sudo` in front of the rewritten command (`sudo iptables -L` → `sudo rtk iptables -L`), inserting rtk into the elevation the user granted to exactly one binary. An elevated rtk then writes the SQLite history db and tee files, parses config and fires the telemetry ping as root (leaving root-owned files in user-owned data directories), and resolves the target binary itself instead of letting `sudo`'s `secure_path` do it.
- `rewrite_segment_inner` now returns `None` when the stripped env prefix contains a `sudo` token, so sudo-prefixed commands pass through unrewritten — the same mechanism already used for `RTK_DISABLED=`. Plain `env` / `VAR=val` prefixes still rewrite as before, and the suppression also covers compositions like `sudo noglob git status` and `env FOO=1 sudo …`.
- Chose the pass-through option over rewriting to `rtk sudo <tool>` (no such passthrough exists today) — sudo-prefixed commands are rare and typically short-output, so the token cost of not filtering them is negligible next to running rtk's side effects as root.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets` (no warnings)
- [x] `cargo test` — 2661 passed, 8 ignored
- [x] Updated/added unit tests: `sudo docker ps` → no rewrite, `env FOO=1 sudo iptables -L` → no rewrite, `sudo noglob git status` → no rewrite, `FOO=1 noglob git status` still rewrites.
- [x] Verified with the built binary: `rtk rewrite "sudo docker ps"` exits 1 (no rewrite); `rtk rewrite "docker ps"` and `rtk rewrite "FOO=1 git status"` still rewrite (exit 3).

Fixes #3412

🤖 Generated with [Claude Code](https://claude.com/claude-code)