### PR TITLE
fix(init): migrate Cursor hooks.json before deleting the legacy hook script

### DIFF
--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -3567,6 +3567,14 @@ fn install_cursor_hooks(ctx: InitContext) -> Result<()> {
     let InitContext { verbose, dry_run } = ctx;
     let cursor_dir = resolve_cursor_dir()?;
 
+    // Register the binary command in hooks.json FIRST (this also drops any
+    // legacy rtk-rewrite.sh entries in the same write). Only once that has
+    // succeeded is it safe to delete the legacy script: deleting the script
+    // while hooks.json still references it leaves Cursor with a registered
+    // hook whose command does not exist (#3465).
+    let hooks_json_path = cursor_dir.join(HOOKS_JSON);
+    let patched = patch_cursor_hooks_json(&hooks_json_path, ctx)?;
+
     // Migrate old hook script if present
     let old_hook = cursor_dir.join("hooks").join(REWRITE_HOOK_FILE);
     if old_hook.exists() {
@@ -3584,18 +3592,7 @@ fn install_cursor_hooks(ctx: InitContext) -> Result<()> {
                 );
             }
         }
-        // Clean stale hooks.json entry pointing to the deleted script
-        let hooks_json_path = cursor_dir.join(HOOKS_JSON);
-        if let Err(e) = remove_legacy_cursor_hooks_json_entries(&hooks_json_path, ctx) {
-            if verbose > 0 {
-                eprintln!("  [warn] Failed to clean legacy Cursor hooks.json entry: {e}");
-            }
-        }
     }
-
-    // Create or patch hooks.json with binary command
-    let hooks_json_path = cursor_dir.join(HOOKS_JSON);
-    let patched = patch_cursor_hooks_json(&hooks_json_path, ctx)?;
 
     // Report (skip in dry-run)
     if !dry_run {
@@ -3632,15 +3629,23 @@ fn patch_cursor_hooks_json(path: &Path, ctx: InitContext) -> Result<bool> {
         serde_json::json!({ "version": 1 })
     };
 
-    // Check idempotency
-    if cursor_hook_already_present(&root) {
+    // Drop legacy rtk-rewrite.sh entries in the same write that registers the
+    // binary command, so the migration is atomic from Cursor's point of view
+    // (#3465). A legacy entry must never count as "already present": its
+    // script is about to be (or already was) deleted.
+    let legacy_removed = remove_legacy_cursor_hook_entries_from_json(&mut root);
+
+    // Check idempotency (a removed legacy entry still needs persisting)
+    let already_present = cursor_hook_already_present(&root);
+    if already_present && !legacy_removed {
         if verbose > 0 {
             eprintln!("Cursor hooks.json: RTK hook already present");
         }
         return Ok(false);
     }
-
-    insert_cursor_hook_entry(&mut root)?;
+    if !already_present {
+        insert_cursor_hook_entry(&mut root)?;
+    }
 
     let serialized =
         serde_json::to_string_pretty(&root).context("Failed to serialize hooks.json")?;
@@ -3672,8 +3677,10 @@ fn patch_cursor_hooks_json(path: &Path, ctx: InitContext) -> Result<bool> {
     Ok(true)
 }
 
-/// Check if RTK preToolUse hook is already present in Cursor hooks.json
-/// Matches on legacy rtk-rewrite.sh path OR new `rtk hook cursor` command
+/// Check if the RTK preToolUse hook is already present in Cursor hooks.json.
+/// Only the new `rtk hook cursor` command counts: a legacy rtk-rewrite.sh
+/// entry points at a script the installer deletes, so treating it as
+/// "present" would leave a registered hook with no script behind it (#3465).
 fn cursor_hook_already_present(root: &serde_json::Value) -> bool {
     let hooks = match root
         .get("hooks")
@@ -3688,7 +3695,7 @@ fn cursor_hook_already_present(root: &serde_json::Value) -> bool {
         entry
             .get("command")
             .and_then(|c| c.as_str())
-            .is_some_and(|cmd| cmd.contains(REWRITE_HOOK_FILE) || cmd == CURSOR_HOOK_COMMAND)
+            .is_some_and(|cmd| cmd == CURSOR_HOOK_COMMAND)
     })
 }
 
@@ -3720,45 +3727,6 @@ fn insert_cursor_hook_entry(root: &mut serde_json::Value) -> Result<()> {
         "command": CURSOR_HOOK_COMMAND,
         "matcher": "Shell"
     }));
-    Ok(())
-}
-
-/// Remove only legacy `rtk-rewrite.sh` entries from Cursor hooks.json.
-/// Preserves any existing `rtk hook cursor` entries (new format).
-fn remove_legacy_cursor_hooks_json_entries(path: &Path, ctx: InitContext) -> Result<()> {
-    let InitContext { verbose, dry_run } = ctx;
-    if !path.exists() {
-        return Ok(());
-    }
-
-    let content =
-        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
-    if content.trim().is_empty() {
-        return Ok(());
-    }
-
-    let mut root: serde_json::Value = serde_json::from_str(&content)
-        .with_context(|| format!("Failed to parse {}", path.display()))?;
-
-    if !remove_legacy_cursor_hook_entries_from_json(&mut root) {
-        return Ok(());
-    }
-
-    if dry_run {
-        println!(
-            "[dry-run] would remove legacy rtk-rewrite.sh entry from Cursor hooks.json: {}",
-            path.display()
-        );
-        return Ok(());
-    }
-
-    let serialized =
-        serde_json::to_string_pretty(&root).context("Failed to serialize hooks.json")?;
-    atomic_write(path, &serialized)?;
-
-    if verbose > 0 {
-        eprintln!("  [ok] Removed legacy rtk-rewrite.sh entry from Cursor hooks.json");
-    }
     Ok(())
 }
 
@@ -6879,7 +6847,9 @@ mod tests {
     // ─── Cursor hooks.json tests ───
 
     #[test]
-    fn test_cursor_hook_already_present_legacy_script() {
+    fn test_cursor_hook_already_present_legacy_script_does_not_count() {
+        // #3465: a legacy entry references a script the installer deletes, so
+        // it must not satisfy the presence check.
         let json_content = serde_json::json!({
             "version": 1,
             "hooks": {
@@ -6889,7 +6859,38 @@ mod tests {
                 }]
             }
         });
-        assert!(cursor_hook_already_present(&json_content));
+        assert!(!cursor_hook_already_present(&json_content));
+    }
+
+    #[test]
+    fn test_patch_cursor_hooks_json_migrates_legacy_entry() {
+        // #3465: a hooks.json that still references the legacy script must be
+        // rewritten to the binary command in one operation, never left with a
+        // dangling reference to a deleted script.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("hooks.json");
+        let legacy = serde_json::json!({
+            "version": 1,
+            "hooks": {
+                "preToolUse": [{
+                    "command": "./hooks/rtk-rewrite.sh",
+                    "matcher": "Shell"
+                }]
+            }
+        });
+        fs::write(&path, serde_json::to_string_pretty(&legacy).unwrap()).unwrap();
+
+        let ctx = InitContext {
+            verbose: 0,
+            dry_run: false,
+        };
+        assert!(patch_cursor_hooks_json(&path, ctx).unwrap());
+
+        let root: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let arr = root["hooks"]["preToolUse"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["command"].as_str().unwrap(), CURSOR_HOOK_COMMAND);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `rtk init -g --agent cursor` deleted `~/.cursor/hooks/rtk-rewrite.sh` first and updated `hooks.json` in a separate, error-swallowed pass; `cursor_hook_already_present` then accepted the stale legacy entry as "RTK hook already present". Net result on any failure of the cleanup pass: a registered Cursor preToolUse hook whose script no longer exists, reported as success (#3465).
- `patch_cursor_hooks_json` now strips legacy `rtk-rewrite.sh` entries and registers `rtk hook cursor` in the same atomic write, and the presence check only accepts the new binary command — a legacy entry can never satisfy it, since its script is about to be deleted.
- The legacy script is deleted only after `hooks.json` was successfully patched, so a parse failure propagates and leaves the still-working script hook in place. The now-redundant `remove_legacy_cursor_hooks_json_entries` pass is removed.
- The third problem in the issue (`--agent cursor` also running the Claude installer and touching `~/.claude/`) is the scope of #3290 / #3282 and is not changed here.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets` (no warnings)
- [x] `cargo test` — 2661 passed, 8 ignored
- [x] New regression test `test_patch_cursor_hooks_json_migrates_legacy_entry`: a hooks.json referencing the legacy script is rewritten to a single `rtk hook cursor` entry in one operation. Updated `test_cursor_hook_already_present_legacy_script*` to assert a legacy entry does not count as present.

Fixes #3465

🤖 Generated with [Claude Code](https://claude.com/claude-code)