### PR TITLE
fix(curl): use -sS so failures keep curl's error message

### DIFF
--- a/src/cmds/cloud/curl_cmd.rs
+++ b/src/cmds/cloud/curl_cmd.rs
@@ -23,14 +23,16 @@ const MAX_RESPONSE_SIZE: usize = 500;
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
     let mut cmd = resolved_command("curl");
-    cmd.arg("-s"); // Silent mode (no progress bar)
+    // -s silences the progress bar but ALSO suppresses error messages; -S
+    // re-enables them so a failure still says why (DNS, refused, TLS, ...).
+    cmd.arg("-sS");
 
     for arg in args {
         cmd.arg(arg);
     }
 
     if verbose > 0 {
-        eprintln!("Running: curl -s {}", args.join(" "));
+        eprintln!("Running: curl -sS {}", args.join(" "));
     }
 
     // Capture stdout as raw bytes (not UTF-8 String) so binary downloads

--- a/tests/curl_error_message_test.rs
+++ b/tests/curl_error_message_test.rs
@@ -1,0 +1,51 @@
+#![cfg(unix)]
+//! `rtk curl` must surface curl's own error message on failure: a bare `-s`
+//! suppresses error output, so a DNS failure / connection refused printed only
+//! "FAILED: curl " with no reason. `-sS` keeps the progress bar off while
+//! re-enabling error messages.
+
+use std::process::Command;
+
+fn curl_available() -> bool {
+    Command::new("curl")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn curl_failure_surfaces_reason() {
+    if !curl_available() {
+        eprintln!("curl not installed; skipping");
+        return;
+    }
+
+    // Port 1 on localhost: refused immediately, no network needed.
+    let out = Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args(["curl", "http://127.0.0.1:1/"])
+        .output()
+        .expect("run rtk curl");
+
+    assert!(
+        !out.status.success(),
+        "connection to port 1 should fail, got exit {:?}",
+        out.status.code()
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let failed_line = stderr
+        .lines()
+        .find(|l| l.contains("FAILED: curl"))
+        .unwrap_or_else(|| panic!("no FAILED line in stderr: {stderr}"));
+
+    // With plain -s the line was exactly "FAILED: curl " — no reason at all.
+    assert!(
+        failed_line.trim_end() != "FAILED: curl",
+        "curl error message swallowed, got only: {failed_line:?}"
+    );
+    assert!(
+        failed_line.contains("curl:") || failed_line.to_lowercase().contains("connect"),
+        "expected curl's own error text on the FAILED line, got: {failed_line:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- `rtk curl` injects a bare `-s`, which silences the progress bar but **also suppresses curl's error messages**
- Any failure — DNS, connection refused, TLS — printed only `FAILED: curl ` with no reason, forcing the agent to rerun the command outside rtk to learn what went wrong
- Fix: inject `-sS` — `-S` re-enables error messages while `-s` keeps progress output off

## Reproduction
```
$ rtk curl http://nonexistent.invalid/
FAILED: curl                                          # before: no reason, exit 6
FAILED: curl curl: (6) Could not resolve host: …      # after
```

## Test plan
- [x] Added regression test (`curl_failure_surfaces_reason`, offline-safe: connects to 127.0.0.1:1)
- [x] Verified the test fails on the previous `-s`-only behavior and passes with `-sS`
- [x] `cargo fmt && cargo clippy --all-targets && cargo test` passes (2661 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)