### PR TITLE
fix(git): don't misdetect a value-taking option's argument as a patch  flag

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -534,6 +534,8 @@ fn consumes_next_token_as_value(arg: &str) -> bool {
             | "--date"
             | "--decorate-refs"
             | "--decorate-refs-exclude"
+            | "--diff-algorithm"
+            | "--diff-filter"
             | "--diff-merges"
             | "--dst-prefix"
             | "--encoding"
@@ -2875,7 +2877,15 @@ A  added.rs
     fn test_patch_flag_as_value_of_grep_is_not_misdetected() {
         // `git log --grep -p` searches commit messages for the literal
         // string "-p"; git does not treat it as the patch flag.
-        for opt in ["--grep", "--author", "--committer", "-S", "-G"] {
+        for opt in [
+            "--author",
+            "--committer",
+            "--diff-algorithm",
+            "--diff-filter",
+            "--grep",
+            "-G",
+            "-S",
+        ] {
             let args = vec![opt.to_string(), "-p".to_string()];
             assert!(
                 !requests_raw_log_output(&args),

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -431,6 +431,12 @@ fn run_log(
     verbose: u8,
     global_args: &[String],
 ) -> Result<i32> {
+    // Re-insert `--` when clap's trailing_var_arg consumed it (issue #1215):
+    // without this, `rtk git log -- -p` loses its literal "--" and
+    // `requests_raw_log_output`/`log_arg_tokens` can no longer tell that
+    // `-p` is a pathspec, not the real patch flag.
+    let args = &args_utils::restore_double_dash(args);
+
     if requests_raw_log_output(args) {
         let passthrough_args: Vec<OsString> = std::iter::once(OsString::from("log"))
             .chain(args.iter().map(OsString::from))

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -443,15 +443,20 @@ fn run_log(
     let mut cmd = git_cmd(global_args);
     cmd.arg("log");
 
+    // Only inspect tokens that are actually flags — a value belonging to
+    // --grep/--author/etc. (e.g. `--grep --pretty`) must not be misread as
+    // one of the flags below.
+    let flag_args = real_flag_args(args);
+
     // Check if user provided format flags
-    let has_format_flag = args.iter().any(|arg| {
+    let has_format_flag = flag_args.iter().any(|arg| {
         arg.starts_with("--oneline") || arg.starts_with("--pretty") || arg.starts_with("--format")
     });
 
     // Check if user provided limit flag (-N, -n N, --max-count=N, --max-count N)
-    let has_limit_flag = args.iter().any(|arg| {
+    let has_limit_flag = flag_args.iter().any(|arg| {
         (arg.starts_with('-') && arg.chars().nth(1).is_some_and(|c| c.is_ascii_digit()))
-            || arg == "-n"
+            || *arg == "-n"
             || arg.starts_with("--max-count")
     });
 
@@ -478,9 +483,9 @@ fn run_log(
     };
 
     // Only add --no-merges if user didn't explicitly request merge commits
-    let wants_merges = args
+    let wants_merges = flag_args
         .iter()
-        .any(|arg| arg == "--merges" || arg == "--min-parents=2" || arg == "--no-merges");
+        .any(|arg| *arg == "--merges" || *arg == "--min-parents=2" || *arg == "--no-merges");
     // Don't add --no-merges if user explicitly requested merges or an exact count (-n N / --max-count)
     if !wants_merges && !has_limit_flag {
         cmd.arg("--no-merges");
@@ -573,59 +578,94 @@ fn consumes_next_token_as_value(arg: &str) -> bool {
     )
 }
 
-fn requests_raw_log_output(args: &[String]) -> bool {
+/// A git log argument, classified as either a flag or the value consumed
+/// by the preceding flag.
+enum LogArg<'a> {
+    Flag(&'a str),
+    Value { flag: &'a str, value: &'a str },
+}
+
+/// Tokenizes git log `args` into [`LogArg`]s, stopping at the `--` pathspec
+/// separator (tokens after it are paths, never flags or their values —
+/// e.g. `git log -- -5` means "history for the path literally named -5").
+/// `-n`/`--max-count`'s own count and every option in
+/// [`consumes_next_token_as_value`] are paired with the flag that consumes
+/// them. Shared by every git-log flag/value/limit check in [`run_log`] so
+/// `--`-handling and option-value handling live in one place instead of
+/// being reimplemented per check.
+fn log_arg_tokens(args: &[String]) -> Vec<LogArg<'_>> {
+    let mut tokens = Vec::with_capacity(args.len());
     let mut iter = args.iter().take_while(|arg| *arg != "--");
     while let Some(arg) = iter.next() {
-        if consumes_next_token_as_value(arg.as_str()) {
-            iter.next(); // skip the value token, whatever it looks like
-            continue;
+        let arg_str = arg.as_str();
+        if arg_str == "-n" || arg_str == "--max-count" || consumes_next_token_as_value(arg_str) {
+            if let Some(value) = iter.next() {
+                tokens.push(LogArg::Value {
+                    flag: arg_str,
+                    value: value.as_str(),
+                });
+                continue;
+            }
         }
-        if matches!(
-            arg.as_str(),
-            "-p" | "-u" | "--patch" | "--patch-with-raw" | "--patch-with-stat"
-        ) {
-            return true;
-        }
+        tokens.push(LogArg::Flag(arg_str));
     }
-    false
+    tokens
+}
+
+/// Filters `args` down to the tokens that are actual flags, dropping every
+/// token consumed as a value by the preceding option.
+fn real_flag_args(args: &[String]) -> Vec<&str> {
+    log_arg_tokens(args)
+        .into_iter()
+        .map(|token| match token {
+            LogArg::Flag(flag) | LogArg::Value { flag, .. } => flag,
+        })
+        .collect()
+}
+
+fn requests_raw_log_output(args: &[String]) -> bool {
+    log_arg_tokens(args).iter().any(|token| {
+        matches!(
+            token,
+            LogArg::Flag("-p" | "-u" | "--patch" | "--patch-with-raw" | "--patch-with-stat")
+        )
+    })
 }
 
 /// Filter git log output: truncate long messages, cap lines
 /// Parse the user-specified limit from git log args.
 /// Handles: -20, -n 20, --max-count=20, --max-count 20
 fn parse_user_limit(args: &[String]) -> Option<usize> {
-    let mut iter = args.iter();
-    while let Some(arg) = iter.next() {
-        // -20 (combined digit form)
-        if arg.starts_with('-')
-            && arg.len() > 1
-            && arg.chars().nth(1).is_some_and(|c| c.is_ascii_digit())
-        {
-            if let Ok(n) = arg[1..].parse::<usize>() {
-                return Some(n);
-            }
-        }
-        // -n 20 (two-token form)
-        if arg == "-n" {
-            if let Some(next) = iter.next() {
-                if let Ok(n) = next.parse::<usize>() {
+    for token in log_arg_tokens(args) {
+        match token {
+            // -20 (combined digit form)
+            LogArg::Flag(flag)
+                if flag.starts_with('-')
+                    && flag.len() > 1
+                    && flag.chars().nth(1).is_some_and(|c| c.is_ascii_digit()) =>
+            {
+                if let Ok(n) = flag[1..].parse::<usize>() {
                     return Some(n);
                 }
             }
-        }
-        // --max-count=20
-        if let Some(rest) = arg.strip_prefix("--max-count=") {
-            if let Ok(n) = rest.parse::<usize>() {
-                return Some(n);
-            }
-        }
-        // --max-count 20 (two-token form)
-        if arg == "--max-count" {
-            if let Some(next) = iter.next() {
-                if let Ok(n) = next.parse::<usize>() {
+            // -n 20 / --max-count 20 (two-token form)
+            LogArg::Value {
+                flag: "-n" | "--max-count",
+                value,
+            } => {
+                if let Ok(n) = value.parse::<usize>() {
                     return Some(n);
                 }
             }
+            // --max-count=20
+            LogArg::Flag(flag) => {
+                if let Some(rest) = flag.strip_prefix("--max-count=") {
+                    if let Ok(n) = rest.parse::<usize>() {
+                        return Some(n);
+                    }
+                }
+            }
+            LogArg::Value { .. } => {}
         }
     }
     None
@@ -2926,6 +2966,99 @@ A  added.rs
                 "a real -p after {opt} should still request raw output"
             );
         }
+    }
+
+    #[test]
+    fn test_real_flag_args_drops_value_taking_option_values() {
+        // `--grep`'s value is not itself a flag and must not appear in the
+        // filtered set, even when it looks like -N, --pretty, or --merges.
+        let args = vec!["--grep".to_string(), "-5".to_string()];
+        assert_eq!(real_flag_args(&args), vec!["--grep"]);
+    }
+
+    #[test]
+    fn test_real_flag_args_keeps_limit_flag_drops_its_value() {
+        let args = vec!["-n".to_string(), "15".to_string()];
+        assert_eq!(real_flag_args(&args), vec!["-n"]);
+
+        let args = vec!["--max-count".to_string(), "25".to_string()];
+        assert_eq!(real_flag_args(&args), vec!["--max-count"]);
+    }
+
+    #[test]
+    fn test_real_flag_args_keeps_genuine_flags() {
+        let args = vec!["--grep".to_string(), "fix".to_string(), "--oneline".to_string()];
+        assert_eq!(real_flag_args(&args), vec!["--grep", "--oneline"]);
+    }
+
+    #[test]
+    fn test_grep_value_looking_like_limit_flag_is_not_misdetected() {
+        // `git log --grep -5` searches commit messages for the literal
+        // string "-5"; it is not a request to limit output to 5 commits.
+        let args = vec!["--grep".to_string(), "-5".to_string()];
+        assert!(
+            !real_flag_args(&args)
+                .iter()
+                .any(|arg| arg.starts_with('-') && arg.chars().nth(1).is_some_and(|c| c.is_ascii_digit())),
+            "-5 as the value of --grep should not be seen as a limit flag"
+        );
+        assert_eq!(
+            parse_user_limit(&args),
+            None,
+            "-5 as the value of --grep should not be parsed as a limit"
+        );
+    }
+
+    #[test]
+    fn test_grep_value_looking_like_format_flag_is_not_misdetected() {
+        // `git log --grep --pretty` searches for the literal string
+        // "--pretty"; git consumes it as --grep's value, not a format flag.
+        let args = vec!["--grep".to_string(), "--pretty".to_string()];
+        assert!(
+            !real_flag_args(&args)
+                .iter()
+                .any(|arg| arg.starts_with("--pretty")),
+            "--pretty as the value of --grep should not be seen as a format flag"
+        );
+    }
+
+    #[test]
+    fn test_grep_value_looking_like_merges_flag_is_not_misdetected() {
+        // `git log --grep --merges` searches for the literal string
+        // "--merges"; git consumes it as --grep's value, not --merges.
+        let args = vec!["--grep".to_string(), "--merges".to_string()];
+        assert!(
+            !real_flag_args(&args).contains(&"--merges"),
+            "--merges as the value of --grep should not be seen as the --merges flag"
+        );
+    }
+
+    #[test]
+    fn test_parse_user_limit_skips_foreign_option_values() {
+        // A real limit later in the args is still found after a
+        // value-taking option's value is skipped.
+        let args = vec![
+            "--grep".to_string(),
+            "-5".to_string(),
+            "-20".to_string(),
+        ];
+        assert_eq!(parse_user_limit(&args), Some(20));
+    }
+
+    #[test]
+    fn test_log_arg_tokens_stop_at_pathspec_separator() {
+        // `git log -- -5` means "history for the path literally named -5",
+        // not a limit flag — tokens after `--` must be ignored entirely.
+        let args = vec!["--".to_string(), "-5".to_string()];
+        assert!(
+            real_flag_args(&args).is_empty(),
+            "-5 after -- is a pathspec, not a flag"
+        );
+        assert_eq!(
+            parse_user_limit(&args),
+            None,
+            "-5 after -- should not be parsed as a limit"
+        );
     }
 
     #[test]

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -545,8 +545,6 @@ fn consumes_next_token_as_value(arg: &str) -> bool {
             | "--inter-hunk-context"
             | "--line-prefix"
             | "--max-depth"
-            | "--max-parents"
-            | "--min-parents"
             | "--output"
             | "--output-indicator-context"
             | "--output-indicator-new"
@@ -2899,13 +2897,19 @@ A  added.rs
 
     #[test]
     fn test_optional_value_options_do_not_consume_next_token() {
-        // -U, --unified and --expand-tabs only take an attached value
-        // (-U3, --unified=3, --expand-tabs=4); a bare separate token after
+        // These options only take an attached value (-U3, --unified=3,
+        // --expand-tabs=4, --max-parents=2); a bare separate token after
         // them is not their value, so it must not be swallowed. Confirmed
-        // against git 2.53.0: `git log --expand-tabs 4` fails with
+        // against git 2.53.0: e.g. `git log --expand-tabs 4` fails with
         // "fatal: ambiguous argument '4'" rather than treating 4 as the
         // option's value.
-        for opt in ["-U", "--unified", "--expand-tabs"] {
+        for opt in [
+            "-U",
+            "--unified",
+            "--expand-tabs",
+            "--max-parents",
+            "--min-parents",
+        ] {
             let args = vec![opt.to_string(), "-p".to_string()];
             assert!(
                 requests_raw_log_output(&args),

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -517,15 +517,80 @@ fn run_log(
     Ok(0)
 }
 
+/// True for git log/diff options that take their value as a separate,
+/// space-delimited token (e.g. `--grep -p` searches messages for the
+/// literal string "-p"; it does not request patch output). Consuming
+/// that value token keeps flag-lookalike values from being misread as
+/// the corresponding boolean flag.
+fn consumes_next_token_as_value(arg: &str) -> bool {
+    matches!(
+        arg,
+        "--after"
+            | "--anchored"
+            | "--author"
+            | "--before"
+            | "--color-moved-ws"
+            | "--committer"
+            | "--date"
+            | "--decorate-refs"
+            | "--decorate-refs-exclude"
+            | "--diff-merges"
+            | "--dst-prefix"
+            | "--encoding"
+            | "--exclude"
+            | "--expand-tabs"
+            | "--find-object"
+            | "--glob"
+            | "--grep"
+            | "--grep-reflog"
+            | "--inter-hunk-context"
+            | "--line-prefix"
+            | "--max-depth"
+            | "--max-parents"
+            | "--min-parents"
+            | "--output"
+            | "--output-indicator-context"
+            | "--output-indicator-new"
+            | "--output-indicator-old"
+            | "--rotate-to"
+            | "--since"
+            | "--since-as-filter"
+            | "--skip"
+            | "--skip-to"
+            | "--src-prefix"
+            | "--stat-count"
+            | "--stat-name-width"
+            | "--stat-width"
+            | "--unified"
+            | "--until"
+            | "--word-diff-regex"
+            | "--ws-error-highlight"
+            | "-G"
+            | "-I"
+            | "-L"
+            | "-O"
+            | "-S"
+            | "-U"
+            | "-l"
+            | "-n"
+    )
+}
+
 fn requests_raw_log_output(args: &[String]) -> bool {
-    args.iter()
-        .take_while(|arg| *arg != "--")
-        .any(|arg| {
-            matches!(
-                arg.as_str(),
-                "-p" | "-u" | "--patch" | "--patch-with-raw" | "--patch-with-stat"
-            )
-        })
+    let mut iter = args.iter().take_while(|arg| *arg != "--");
+    while let Some(arg) = iter.next() {
+        if consumes_next_token_as_value(arg.as_str()) {
+            iter.next(); // skip the value token, whatever it looks like
+            continue;
+        }
+        if matches!(
+            arg.as_str(),
+            "-p" | "-u" | "--patch" | "--patch-with-raw" | "--patch-with-stat"
+        ) {
+            return true;
+        }
+    }
+    false
 }
 
 /// Filter git log output: truncate long messages, cap lines
@@ -1135,7 +1200,11 @@ fn format_checkout_output(args: &[String], raw: &str, exit_code: i32) -> String 
 
 fn format_checkout_success(args: &[String], raw: &str) -> String {
     if let Some(restored) = checkout_restored_count(args) {
-        return format!("ok {} {}", restored, pluralize(restored, "file restored", "files restored"));
+        return format!(
+            "ok {} {}",
+            restored,
+            pluralize(restored, "file restored", "files restored")
+        );
     }
     if let Some(branch) = checkout_reset_branch_arg(args) {
         return format!("ok {}", branch);
@@ -1233,7 +1302,11 @@ fn quoted_suffix<'a>(line: &'a str, prefix: &str) -> Option<&'a str> {
 }
 
 fn pluralize<'a>(count: usize, singular: &'a str, plural: &'a str) -> &'a str {
-    if count == 1 { singular } else { plural }
+    if count == 1 {
+        singular
+    } else {
+        plural
+    }
 }
 
 fn filter_checkout_failure(raw: &str) -> String {
@@ -1251,8 +1324,9 @@ fn filter_checkout_failure(raw: &str) -> String {
             || trimmed.starts_with("CONFLICT");
 
         if is_header {
-            in_file_list =
-                trimmed.contains("following") && trimmed.contains("files") && trimmed.ends_with(':');
+            in_file_list = trimmed.contains("following")
+                && trimmed.contains("files")
+                && trimmed.ends_with(':');
             important.push(trimmed.to_string());
             continue;
         }
@@ -1786,7 +1860,12 @@ fn run_stash(
                 compact_stash_stat(&result.stdout)
             };
             let shown = crate::core::runner::emit_guarded(&filtered, None, &result.stdout);
-            timer.track("git stash show", "rtk git stash show", &result.stdout, &shown);
+            timer.track(
+                "git stash show",
+                "rtk git stash show",
+                &result.stdout,
+                &shown,
+            );
         }
         Some("apply") | Some("branch") | Some("clear") | Some("create") | Some("drop")
         | Some("export") | Some("import") | Some("pop") | Some("store") => {
@@ -1920,7 +1999,7 @@ fn compress_stat_summary(summary: &str) -> String {
         .replace("deletion(-)", "-")
         .replace("files changed", "changed")
         .replace("file changed", "changed")
-		.replace(",", "")
+        .replace(",", "")
 }
 
 fn parse_stash_stat(stat: &str) -> (Vec<String>, String) {
@@ -2376,7 +2455,12 @@ mod tests {
         let (files, summary) = parse_stash_stat(raw);
         assert_eq!(
             files,
-            vec!["del.md 2 -", "keep.md 5 +-", "logo.bin (binary)", "new.rs 40 +"]
+            vec![
+                "del.md 2 -",
+                "keep.md 5 +-",
+                "logo.bin (binary)",
+                "new.rs 40 +"
+            ]
         );
         assert_eq!(summary, "4 files changed, 44 insertions(+), 3 deletions(-)");
     }
@@ -2390,7 +2474,10 @@ mod tests {
     #[test]
     fn test_compact_stash_stat_passthrough_numstat() {
         let raw = "0\t1\tdel.md\n3\t2\tkeep.md\n1\t0\tn1.rs\n";
-        assert_eq!(compact_stash_stat(raw), "0\t1\tdel.md\n3\t2\tkeep.md\n1\t0\tn1.rs");
+        assert_eq!(
+            compact_stash_stat(raw),
+            "0\t1\tdel.md\n3\t2\tkeep.md\n1\t0\tn1.rs"
+        );
     }
 
     #[test]
@@ -2464,7 +2551,11 @@ mod tests {
         let compact = format!("{}\n{}", files.join("\n"), summary);
         let savings =
             100.0 - (estimate_tokens(&compact) as f64 / estimate_tokens(raw) as f64 * 100.0);
-        assert!(savings >= 40.0, "expected >=40% savings, got {:.1}%", savings);
+        assert!(
+            savings >= 40.0,
+            "expected >=40% savings, got {:.1}%",
+            savings
+        );
     }
 
     #[test]
@@ -2751,7 +2842,13 @@ A  added.rs
 
     #[test]
     fn test_patch_log_flags_request_raw_output() {
-        for flag in ["-p", "-u", "--patch", "--patch-with-raw", "--patch-with-stat"] {
+        for flag in [
+            "-p",
+            "-u",
+            "--patch",
+            "--patch-with-raw",
+            "--patch-with-stat",
+        ] {
             let args = vec![flag.to_string()];
             assert!(requests_raw_log_output(&args), "{flag} should pass through");
         }
@@ -2777,6 +2874,30 @@ A  added.rs
                 "{flag} should remain on the filtered log path"
             );
         }
+    }
+
+    #[test]
+    fn test_patch_flag_as_value_of_grep_is_not_misdetected() {
+        // `git log --grep -p` searches commit messages for the literal
+        // string "-p"; git does not treat it as the patch flag.
+        for opt in ["--grep", "--author", "--committer", "-S", "-G"] {
+            let args = vec![opt.to_string(), "-p".to_string()];
+            assert!(
+                !requests_raw_log_output(&args),
+                "-p as the value of {opt} should stay on the filtered path"
+            );
+        }
+    }
+
+    #[test]
+    fn test_patch_flag_still_detected_after_value_taking_option() {
+        // The value-taking option consumes only its own value token;
+        // a genuine -p later in the args still triggers the raw path.
+        let args = vec!["--grep".to_string(), "fix".to_string(), "-p".to_string()];
+        assert!(
+            requests_raw_log_output(&args),
+            "a real -p after --grep's value should still request raw output"
+        );
     }
 
     #[test]

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -443,10 +443,12 @@ fn run_log(
     let mut cmd = git_cmd(global_args);
     cmd.arg("log");
 
-    // Only inspect tokens that are actually flags — a value belonging to
-    // --grep/--author/etc. (e.g. `--grep --pretty`) must not be misread as
-    // one of the flags below.
-    let flag_args = real_flag_args(args);
+    // Tokenize once and share it: flag-vs-value classification is reused
+    // below by both the flag-presence checks and the limit parsing, and a
+    // value belonging to --grep/--author/etc. (e.g. `--grep --pretty`) must
+    // not be misread as one of the flags below.
+    let tokens = log_arg_tokens(args);
+    let flag_args = flag_args_from_tokens(&tokens);
 
     // Check if user provided format flags
     let has_format_flag = flag_args.iter().any(|arg| {
@@ -470,7 +472,7 @@ fn run_log(
     // Determine limit: respect user's explicit -N flag, use sensible defaults otherwise
     let (limit, user_set_limit) = if has_limit_flag {
         // User explicitly passed -N / -n N / --max-count=N → respect their choice
-        let n = parse_user_limit(args).unwrap_or(10);
+        let n = parse_limit_from_tokens(&tokens).unwrap_or(10);
         (n, true)
     } else if has_format_flag {
         // --oneline / --pretty without -N: user wants compact output, allow more
@@ -598,7 +600,7 @@ fn log_arg_tokens(args: &[String]) -> Vec<LogArg<'_>> {
     let mut iter = args.iter().take_while(|arg| *arg != "--");
     while let Some(arg) = iter.next() {
         let arg_str = arg.as_str();
-        if arg_str == "-n" || arg_str == "--max-count" || consumes_next_token_as_value(arg_str) {
+        if arg_str == "--max-count" || consumes_next_token_as_value(arg_str) {
             if let Some(value) = iter.next() {
                 tokens.push(LogArg::Value {
                     flag: arg_str,
@@ -612,31 +614,67 @@ fn log_arg_tokens(args: &[String]) -> Vec<LogArg<'_>> {
     tokens
 }
 
-/// Filters `args` down to the tokens that are actual flags, dropping every
-/// token consumed as a value by the preceding option.
-fn real_flag_args(args: &[String]) -> Vec<&str> {
-    log_arg_tokens(args)
-        .into_iter()
+/// Filters `tokens` down to the flags themselves, dropping every value
+/// consumed by the preceding option.
+fn flag_args_from_tokens<'a>(tokens: &[LogArg<'a>]) -> Vec<&'a str> {
+    tokens
+        .iter()
         .map(|token| match token {
-            LogArg::Flag(flag) | LogArg::Value { flag, .. } => flag,
+            LogArg::Flag(flag) | LogArg::Value { flag, .. } => *flag,
         })
         .collect()
 }
 
-fn requests_raw_log_output(args: &[String]) -> bool {
-    log_arg_tokens(args).iter().any(|token| {
-        matches!(
-            token,
-            LogArg::Flag("-p" | "-u" | "--patch" | "--patch-with-raw" | "--patch-with-stat")
-        )
-    })
+/// Filters `args` down to the tokens that are actual flags, dropping every
+/// token consumed as a value by the preceding option. `run_log` shares a
+/// single tokenization via [`flag_args_from_tokens`] instead; this
+/// convenience wrapper exists for tests that only care about the flags.
+#[cfg(test)]
+fn real_flag_args(args: &[String]) -> Vec<&str> {
+    flag_args_from_tokens(&log_arg_tokens(args))
 }
 
-/// Filter git log output: truncate long messages, cap lines
+/// True for git log/diff flags that change the *shape* of git's raw output
+/// (patch text, diffstat, name lists) in a way RTK's injected
+/// `--pretty=format` + `---END---` markers can't coexist with — matching
+/// this must request the untouched passthrough path instead of RTK's
+/// filtered one (see [`requests_raw_log_output`]).
+fn requests_raw_diff_shape(flag: &str) -> bool {
+    matches!(
+        flag,
+        "-p" | "-u"
+            | "--dirstat"
+            | "--name-only"
+            | "--name-status"
+            | "--numstat"
+            | "--patch"
+            | "--patch-with-raw"
+            | "--patch-with-stat"
+            | "--raw"
+            | "--shortstat"
+            | "--stat"
+            | "--summary"
+    ) || flag.starts_with("--stat=")
+        || flag.starts_with("--dirstat=")
+}
+
+fn requests_raw_log_output(args: &[String]) -> bool {
+    log_arg_tokens(args)
+        .iter()
+        .any(|token| matches!(token, LogArg::Flag(flag) if requests_raw_diff_shape(flag)))
+}
+
 /// Parse the user-specified limit from git log args.
 /// Handles: -20, -n 20, --max-count=20, --max-count 20
+/// `run_log` shares a single tokenization via [`parse_limit_from_tokens`]
+/// instead; this convenience wrapper exists for tests.
+#[cfg(test)]
 fn parse_user_limit(args: &[String]) -> Option<usize> {
-    for token in log_arg_tokens(args) {
+    parse_limit_from_tokens(&log_arg_tokens(args))
+}
+
+fn parse_limit_from_tokens(tokens: &[LogArg<'_>]) -> Option<usize> {
+    for token in tokens {
         match token {
             // -20 (combined digit form)
             LogArg::Flag(flag)
@@ -2904,13 +2942,49 @@ A  added.rs
 
     #[test]
     fn test_non_patch_log_flags_remain_filtered() {
-        for flag in ["--no-patch", "--stat", "--oneline", "--format=%H"] {
+        for flag in ["--no-patch", "--oneline", "--format=%H"] {
             let args = vec![flag.to_string()];
             assert!(
                 !requests_raw_log_output(&args),
                 "{flag} should remain on the filtered log path"
             );
         }
+    }
+
+    #[test]
+    fn test_diff_shape_flags_request_raw_output() {
+        // These change the shape of git's raw output (diffstat, name lists)
+        // the same way -p does — RTK's injected --pretty=format markers
+        // can't coexist with them, so they must stay on the raw path too.
+        for flag in [
+            "--dirstat",
+            "--dirstat=files",
+            "--name-only",
+            "--name-status",
+            "--numstat",
+            "--raw",
+            "--shortstat",
+            "--stat",
+            "--stat=80",
+            "--summary",
+        ] {
+            let args = vec![flag.to_string()];
+            assert!(
+                requests_raw_log_output(&args),
+                "{flag} changes output shape and should request raw output"
+            );
+        }
+    }
+
+    #[test]
+    fn test_diff_shape_flag_as_value_of_grep_is_not_misdetected() {
+        // `git log --grep --stat` searches for the literal string
+        // "--stat"; git consumes it as --grep's value, not the --stat flag.
+        let args = vec!["--grep".to_string(), "--stat".to_string()];
+        assert!(
+            !requests_raw_log_output(&args),
+            "--stat as the value of --grep should stay on the filtered path"
+        );
     }
 
     #[test]

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -538,7 +538,6 @@ fn consumes_next_token_as_value(arg: &str) -> bool {
             | "--dst-prefix"
             | "--encoding"
             | "--exclude"
-            | "--expand-tabs"
             | "--find-object"
             | "--glob"
             | "--grep"
@@ -561,7 +560,6 @@ fn consumes_next_token_as_value(arg: &str) -> bool {
             | "--stat-count"
             | "--stat-name-width"
             | "--stat-width"
-            | "--unified"
             | "--until"
             | "--word-diff-regex"
             | "--ws-error-highlight"
@@ -570,7 +568,6 @@ fn consumes_next_token_as_value(arg: &str) -> bool {
             | "-L"
             | "-O"
             | "-S"
-            | "-U"
             | "-l"
             | "-n"
     )
@@ -2898,6 +2895,23 @@ A  added.rs
             requests_raw_log_output(&args),
             "a real -p after --grep's value should still request raw output"
         );
+    }
+
+    #[test]
+    fn test_optional_value_options_do_not_consume_next_token() {
+        // -U, --unified and --expand-tabs only take an attached value
+        // (-U3, --unified=3, --expand-tabs=4); a bare separate token after
+        // them is not their value, so it must not be swallowed. Confirmed
+        // against git 2.53.0: `git log --expand-tabs 4` fails with
+        // "fatal: ambiguous argument '4'" rather than treating 4 as the
+        // option's value.
+        for opt in ["-U", "--unified", "--expand-tabs"] {
+            let args = vec![opt.to_string(), "-p".to_string()];
+            assert!(
+                requests_raw_log_output(&args),
+                "a real -p after {opt} should still request raw output"
+            );
+        }
     }
 
     #[test]

--- a/tests/guard_integration_test.rs
+++ b/tests/guard_integration_test.rs
@@ -187,6 +187,32 @@ fn git_log_patch_output_matches_raw_git() {
 }
 
 #[test]
+fn git_log_dash_p_pathspec_after_double_dash_is_not_patch_flag() {
+    // Regression: `rtk git log -- -p` must not be misread as the real `-p`
+    // patch flag. Clap's `trailing_var_arg` strips the literal "--" before
+    // `run_log` sees `args`, so the pathspec-separator check must restore it
+    // (via restore_double_dash) before deciding whether to pass through raw
+    // patch output; otherwise a file literally named "-p" after "--" is
+    // wrongly treated as a request for `git log -p`.
+    let dir = init_git_repo();
+    std::fs::write(dir.path().join("-p"), "not a diff flag\n").expect("write -p file");
+    git_in_dir(dir.path(), &["add", "--", "-p"]);
+    git_in_dir(dir.path(), &["commit", "-q", "-m", "add dash-p file"]);
+
+    let (stdout, stderr, code) = rtk_output_in_dir(dir.path(), &["git", "log", "--", "-p"]);
+
+    assert_eq!(code, Some(0), "rtk stderr: {stderr}");
+    assert!(
+        !stdout.contains("diff --git") && !stdout.contains("@@"),
+        "-- -p should stay on RTK's filtered path, not raw patch output: {stdout:?}"
+    );
+    assert!(
+        stdout.contains("add dash-p file"),
+        "expected the commit touching the -p pathspec: {stdout:?}"
+    );
+}
+
+#[test]
 fn git_stash_show_no_stash_emits_empty_and_propagates_failure() {
     // Regression: previously printed "Empty stash" and returned Ok(0), masking
     // the underlying `git stash show` failure.


### PR DESCRIPTION
## Summary

Follow-up on #2951.

`requests_raw_log_output()` matched bare `-p`/`-u`/`--patch` tokens anywhere in the args, without checking whether the previous token was an option like `--grep` or `-S` that consumes the next token as its value. `git log --grep -p` searches commit messages for the literal string `-p` (verified against git 2.53.0: no diff output, same as `--grep=-p`), but RTK treated it as a patch request and skipped its own filtering/limit, dumping raw uncapped `git log` output for what is actually a plain grep search.

Skip the value token after any known value-taking `git log`/`git diff` option before checking for the patch flags.

## Test plan
- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk git log --grep -p` output inspected
