### PR TITLE
docs: fix dead guide and ARCHITECTURE links

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ RTK supports 16 AI coding tools. Each integration rewrites shell commands to `rt
 | **Kimi AI** | `rtk init --agent kimi` | AGENTS.md (project-scoped) |
 | **Factory Droid** | `rtk init -g --agent droid` (or per-project) | PreToolUse hook in `~/.factory/hooks.json` (matcher `Execute`) |
 
-For per-agent setup details, override controls, and graceful degradation, see the [Supported Agents guide](https://www.rtk-ai.app/guide/getting-started/supported-agents). The Hermes plugin source and tests live in `hooks/hermes/`; installed Hermes runtime files still live under `~/.hermes/plugins/rtk-rewrite/`.
+For per-agent setup details, override controls, and graceful degradation, see the [Supported Agents guide](https://github.com/rtk-ai/rtk/blob/develop/docs/guide/getting-started/supported-agents.md). The Hermes plugin source and tests live in `hooks/hermes/`; installed Hermes runtime files still live under `~/.hermes/plugins/rtk-rewrite/`.
 
 ## Configuration
 
@@ -425,7 +425,7 @@ FAILED: 2/15 tests
 [full output: ~/.local/share/rtk/tee/1707753600_cargo_test.log]
 ```
 
-For the full config reference (all sections, env vars, per-project filters), see the [Configuration guide](https://www.rtk-ai.app/guide/getting-started/configuration).
+For the full config reference (all sections, env vars, per-project filters), see the [Configuration guide](https://github.com/rtk-ai/rtk/blob/develop/docs/guide/getting-started/configuration.md).
 
 ### Uninstall
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -69,4 +69,4 @@ See [Discover and Session](./analytics/discover.md) for details.
 - [Configuration](./getting-started/configuration.md) — config.toml, global flags, env vars, tee recovery
 - [Troubleshooting](./resources/troubleshooting.md) — common issues and fixes
 - [Telemetry & Privacy](./resources/telemetry.md) — what RTK collects and how to opt out
-- [ARCHITECTURE.md](https://github.com/rtk-ai/rtk/blob/master/ARCHITECTURE.md) — system design for contributors
+- [ARCHITECTURE.md](https://github.com/rtk-ai/rtk/blob/develop/docs/contributing/ARCHITECTURE.md) — system design for contributors


### PR DESCRIPTION
Three dead links found by a docs audit:

1. **README.md** - links to `rtk-ai.app/guide/getting-started/supported-agents` and `.../configuration` return 404 (sibling pages like `/guide/getting-started/installation` and `/guide/getting-started/quick-start` do work, so these two pages are currently missing from the site). Pointed both at the corresponding pages in this repository, which are verified live. If the site pages come back, feel free to keep the site URLs instead.
2. **docs/guide/index.md** - links to `blob/master/ARCHITECTURE.md`, but the file lives at `docs/contributing/ARCHITECTURE.md` (and the default branch is `develop`). Updated to the verified path.