### PR TITLE
fix: add never-worse exit-code guard across all tool filters

### DIFF
--- a/src/cmds/go/go_cmd.rs
+++ b/src/cmds/go/go_cmd.rs
@@ -66,13 +66,13 @@ pub fn run_test(args: &[String], verbose: u8) -> Result<i32> {
         );
     }
 
-    let filter: fn(&str) -> String = if skip_json {
-        |s: &str| s.to_string()
+    let filter: fn(&str, i32) -> String = if skip_json {
+        |s, _| s.to_string()
     } else {
-        filter_go_test_json
+        |out, exit| crate::core::guard::guard_exit(out, exit, "go test", &filter_go_test_json(out))
     };
 
-    runner::run_filtered(
+    runner::run_filtered_with_exit(
         cmd,
         "go test",
         &args.join(" "),
@@ -114,11 +114,11 @@ pub fn run_vet(args: &[String], verbose: u8) -> Result<i32> {
         eprintln!("Running: go vet {}", args.join(" "));
     }
 
-    runner::run_filtered(
+    runner::run_filtered_with_exit(
         cmd,
         "go vet",
         &args.join(" "),
-        filter_go_vet,
+        |out, exit| crate::core::guard::guard_exit(out, exit, "go vet", &filter_go_vet(out)),
         crate::core::runner::RunOptions::with_tee("go_vet"),
     )
 }
@@ -280,8 +280,12 @@ fn run_go_tool_golangci_lint(args: &[OsString], verbose: u8) -> Result<i32> {
         &*stdout
     };
 
+    let exit_code = exit_code_from_output(&output, "go tool golangci-lint");
+
     let filtered = golangci_cmd::filter_golangci_json(json_output, version);
-    let shown = never_worse(&raw, &filtered);
+    // "No issues found" must never be rendered for a non-zero exit.
+    let guarded = crate::core::guard::guard_exit(&raw, exit_code, "golangci-lint", &filtered);
+    let shown = never_worse(&raw, &guarded);
     println!("{}", shown);
 
     if !stderr.trim().is_empty() && verbose > 0 {
@@ -295,10 +299,10 @@ fn run_go_tool_golangci_lint(args: &[OsString], verbose: u8) -> Result<i32> {
         shown,
     );
 
-    let exit_code = exit_code_from_output(&output, "go tool golangci-lint");
-    // golangci-lint: exit 0 = clean, exit 1 = lint issues found (not an error),
-    // exit 2+ = config/build error, None = killed by signal (OOM, SIGKILL)
-    Ok(if exit_code == 1 { 0 } else { exit_code })
+    // golangci-lint: exit 0 = clean, exit 1 = lint issues found (a real
+    // failure for CI/agents — do not silently rewrite it to 0), exit 2+ =
+    // config/build error, None = killed by signal (OOM, SIGKILL).
+    Ok(exit_code)
 }
 
 /// Parse go test -json output (NDJSON format)
@@ -1058,6 +1062,38 @@ pattern ./...: directory prefix . does not contain modules listed in go.work or 
         let result = filter_go_vet(output);
         assert!(result.contains("Go vet"));
         assert!(result.contains("No issues found"));
+    }
+
+    #[test]
+    fn test_go_vet_nonzero_exit_never_says_no_issues() {
+        // go vet exits non-zero when it finds problems. A green "No issues
+        // found" verdict must never be rendered for it.
+        let raw = "go vet ran but produced no parseable issues";
+        let filtered = filter_go_vet(raw);
+        assert_eq!(filtered, "Go vet: No issues found");
+        let result = crate::core::guard::guard_exit(raw, 1, "go vet", &filtered);
+        assert!(result.contains("go vet: failed (exit 1)"), "got: {}", result);
+        assert!(!result.contains("No issues found"), "got: {}", result);
+    }
+
+    #[test]
+    fn test_go_test_json_killed_mid_stream_shows_failure() {
+        // Killed mid-stream (SIGKILL/OOM, exit 137): partial JSON shows only
+        // passes — the green verdict must be replaced by the failure fallback.
+        let output = r#"{"Time":"2024-01-01T10:00:00Z","Action":"run","Package":"example.com/foo","Test":"TestFast"}
+{"Time":"2024-01-01T10:00:01Z","Action":"pass","Package":"example.com/foo","Test":"TestFast","Elapsed":0.1}"#;
+        let filtered = filter_go_test_json(output);
+        assert!(
+            filtered.contains("Go test"),
+            "expected a go test verdict, got: {}",
+            filtered
+        );
+        let result = crate::core::guard::guard_exit(output, 137, "go test", &filtered);
+        assert!(
+            result.contains("go test: failed (exit 137)"),
+            "got: {}",
+            result
+        );
     }
 
     #[test]

--- a/src/cmds/go/golangci_cmd.rs
+++ b/src/cmds/go/golangci_cmd.rs
@@ -139,25 +139,29 @@ fn run_filtered(original_args: &[String], invocation: &RunInvocation, verbose: u
         );
     }
 
-    let exit_code = runner::run_filtered(
+    let exit_code = runner::run_filtered_with_exit(
         cmd,
         "golangci-lint",
         &original_args.join(" "),
-        |stdout| {
+        |stdout, exit_code| {
             // v2 outputs JSON on first line + trailing text; v1 outputs just JSON
             let json_output = if version >= 2 {
                 stdout.lines().next().unwrap_or("")
             } else {
                 stdout
             };
-            filter_golangci_json(json_output, version)
+            let filtered = filter_golangci_json(json_output, version);
+            // "No issues found" must never be rendered for a non-zero exit
+            // (config/build error, killed by signal, ...).
+            crate::core::guard::guard_exit(stdout, exit_code, "golangci-lint", &filtered)
         },
         crate::core::runner::RunOptions::stdout_only(),
     )?;
 
-    // golangci-lint: exit 0 = clean, exit 1 = lint issues found (not an error),
-    // exit 2+ = config/build error, None = killed by signal (OOM, SIGKILL)
-    Ok(if exit_code == 1 { 0 } else { exit_code })
+    // golangci-lint: exit 0 = clean, exit 1 = lint issues found (a real failure
+    // for CI/agents — do not silently rewrite it to 0), exit 2+ = config/build
+    // error, None = killed by signal (OOM, SIGKILL).
+    Ok(exit_code)
 }
 
 fn run_passthrough(args: &[String], verbose: u8) -> Result<i32> {
@@ -398,6 +402,22 @@ mod tests {
         let result = filter_golangci_json(output, 1);
         assert!(result.contains("golangci-lint"));
         assert!(result.contains("No issues found"));
+    }
+
+    #[test]
+    fn test_golangci_nonzero_exit_never_says_no_issues() {
+        // golangci-lint exits 2+ on config/build errors. "No issues found"
+        // must never be rendered for a non-zero exit.
+        let raw = r#"{"Issues":[]}"#;
+        let filtered = filter_golangci_json(raw, 1);
+        assert_eq!(filtered, "golangci-lint: No issues found");
+        let result = crate::core::guard::guard_exit(raw, 2, "golangci-lint", &filtered);
+        assert!(
+            result.contains("golangci-lint: failed (exit 2)"),
+            "got: {}",
+            result
+        );
+        assert!(!result.contains("No issues found"), "got: {}", result);
     }
 
     #[test]

--- a/src/cmds/js/lint_cmd.rs
+++ b/src/cmds/js/lint_cmd.rs
@@ -8,8 +8,15 @@ use crate::core::utils::{package_manager_exec, resolved_command, truncate};
 use crate::mypy_cmd;
 use crate::ruff_cmd;
 use anyhow::{Context, Result};
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::LazyLock;
+
+/// "0 error"/"0 errors" only — must not match "10 errors" or "20 errors",
+/// whose counts merely end in a zero.
+static ZERO_ERRORS: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)(?:^|[^0-9])0 errors?").unwrap());
 
 #[derive(Debug, Deserialize, Serialize)]
 struct EslintMessage {
@@ -200,7 +207,9 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     };
 
     let hint = crate::core::tee::tee_and_hint(&raw, "lint", result.exit_code);
-    let shown = crate::core::runner::emit_guarded(&filtered, hint.as_deref(), &raw);
+    // Never render "No issues found" when the linter exited non-zero.
+    let guarded = crate::core::guard::guard_exit(&raw, result.exit_code, linter, &filtered);
+    let shown = crate::core::runner::emit_guarded(&guarded, hint.as_deref(), &raw);
 
     timer.track(
         &format!("{} {}", linter, args.join(" ")),
@@ -454,7 +463,7 @@ fn filter_generic_lint(output: &str) -> String {
             warnings += 1;
             issues.push(line.to_string());
         }
-        if line_lower.contains("error") && !line_lower.contains("0 error") {
+        if line_lower.contains("error") && !ZERO_ERRORS.is_match(&line_lower) {
             errors += 1;
             issues.push(line.to_string());
         }
@@ -704,5 +713,31 @@ mod tests {
         assert!(!is_python_linter("eslint"));
         assert!(!is_python_linter("biome"));
         assert!(!is_python_linter("unknown"));
+    }
+
+    #[test]
+    fn test_zero_errors_regex_does_not_match_counts_ending_in_zero() {
+        assert!(ZERO_ERRORS.is_match("0 error"));
+        assert!(ZERO_ERRORS.is_match("0 errors"));
+        assert!(ZERO_ERRORS.is_match("problem: 0 errors found"));
+        assert!(!ZERO_ERRORS.is_match("10 errors"));
+        assert!(!ZERO_ERRORS.is_match("20 errors"));
+        assert!(!ZERO_ERRORS.is_match("100 errors"));
+        assert!(!ZERO_ERRORS.is_match("1 error"));
+    }
+
+    #[test]
+    fn test_filter_generic_lint_counts_errors_ending_in_zero() {
+        let output = "lint: 10 errors\nlint: 20 errors\n";
+        let result = filter_generic_lint(output);
+        assert!(
+            result.contains("2 errors"),
+            "counts ending in 0 must count as errors: {}",
+            result
+        );
+
+        let clean = "Lint finished\n";
+        let result = filter_generic_lint(clean);
+        assert!(result.contains("No issues found"), "got: {}", result);
     }
 }

--- a/src/cmds/js/tsc_cmd.rs
+++ b/src/cmds/js/tsc_cmd.rs
@@ -12,6 +12,12 @@ static TSC_ERROR: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^(.+?)\((\d+),(\d+)\):\s+(error|warning)\s+(TS\d+):\s+(.+)$").unwrap()
 });
 
+/// Position-less global errors like "error TS5083: Cannot read file 'x'." —
+/// no `file(line,col):` prefix, so `TSC_ERROR` never matches them.
+static TSC_GLOBAL_ERROR: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^(?:error|warning)\s+TS\d+:\s+.+$").unwrap()
+});
+
 pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     let tsc_exists = tool_exists("tsc");
 
@@ -77,16 +83,37 @@ impl BlockHandler for TscHandler {
         line.starts_with("  ") || line.starts_with('\t')
     }
 
-    fn format_summary(&self, _exit_code: i32, _raw: &str) -> Option<String> {
-        if self.error_count == 0 {
+    fn format_summary(&self, exit_code: i32, raw: &str) -> Option<String> {
+        // Global errors (position-less, e.g. TS5083) are dropped by the block
+        // stream — they carry no `file(line,col):` prefix. Surface them here.
+        let global_errors: Vec<&str> = raw
+            .lines()
+            .filter(|l| TSC_GLOBAL_ERROR.is_match(l.trim()))
+            .collect();
+
+        if self.error_count == 0 && global_errors.is_empty() {
+            // "TypeScript: No errors found" is an all-green verdict — it must
+            // never be rendered for a non-zero child exit.
+            if exit_code != 0 {
+                return Some(crate::core::guard::failure_fallback(
+                    "TypeScript",
+                    exit_code,
+                    raw,
+                ));
+            }
             return Some("TypeScript: No errors found\n".to_string());
         }
 
+        let total_errors = self.error_count + global_errors.len();
         let mut result = format!(
             "TypeScript: {} errors in {} files\n",
-            self.error_count,
+            total_errors,
             self.files.len()
         );
+
+        for err in &global_errors {
+            result.push_str(&format!("  {}\n", err));
+        }
 
         if self.code_counts.len() > 1 {
             let mut counts: Vec<_> = self.code_counts.iter().collect();
@@ -113,6 +140,7 @@ pub(crate) fn filter_tsc_output(output: &str) -> String {
     }
 
     let mut errors: Vec<TsError> = Vec::new();
+    let mut global_errors: Vec<String> = Vec::new();
     let lines: Vec<&str> = output.lines().collect();
     let mut i = 0;
 
@@ -143,12 +171,15 @@ pub(crate) fn filter_tsc_output(output: &str) -> String {
             }
 
             errors.push(err);
+        } else if TSC_GLOBAL_ERROR.is_match(line.trim()) {
+            global_errors.push(line.trim().to_string());
+            i += 1;
         } else {
             i += 1;
         }
     }
 
-    if errors.is_empty() {
+    if errors.is_empty() && global_errors.is_empty() {
         if output.contains("Found 0 errors") {
             return "TypeScript: No errors found".to_string();
         }
@@ -170,9 +201,16 @@ pub(crate) fn filter_tsc_output(output: &str) -> String {
     let mut result = String::new();
     result.push_str(&format!(
         "TypeScript: {} errors in {} files\n",
-        errors.len(),
+        errors.len() + global_errors.len(),
         by_file.len()
     ));
+
+    for err in &global_errors {
+        result.push_str(&format!("  {}\n", err));
+    }
+    if !global_errors.is_empty() && !errors.is_empty() {
+        result.push('\n');
+    }
 
     // Top error codes summary (compact, one line)
     let mut code_counts: Vec<_> = by_code.iter().collect();
@@ -292,6 +330,33 @@ src/app.tsx(20,5): error TS2345: Argument of type 'number' is not assignable to 
         assert!(result.contains("No errors found"));
     }
 
+    #[test]
+    fn test_filter_tsc_global_errors_shown() {
+        // Position-less global errors (no file(line,col): prefix) must surface.
+        let output = "\
+error TS5083: Cannot read file '/project/tsconfig.json'.
+error TS5058: The specified path does not exist.
+Found 2 errors.
+";
+        let result = filter_tsc_output(output);
+        assert!(result.contains("TypeScript: 2 errors in 0 files"));
+        assert!(result.contains("TS5083"), "got: {}", result);
+        assert!(result.contains("TS5058"), "got: {}", result);
+    }
+
+    #[test]
+    fn test_filter_tsc_global_and_positional_errors() {
+        let output = "\
+error TS5083: Cannot read file '/project/tsconfig.json'.
+src/api.ts(10,5): error TS2322: Type 'string' is not assignable to type 'number'.
+Found 2 errors.
+";
+        let result = filter_tsc_output(output);
+        assert!(result.contains("TypeScript: 2 errors in 1 files"));
+        assert!(result.contains("TS5083"), "got: {}", result);
+        assert!(result.contains("TS2322"), "got: {}", result);
+    }
+
     // --- Streaming handler tests ---
 
     use crate::core::stream::tests::run_block_filter;
@@ -319,6 +384,33 @@ Found 3 errors in 2 files.
         let mut f = BlockStreamFilter::new(TscHandler::new());
         let result = run_block_filter(&mut f, input, 0);
         assert!(result.contains("No errors found"), "got: {}", result);
+    }
+
+    #[test]
+    fn test_tsc_stream_global_errors() {
+        // Position-less errors must surface even though the block stream only
+        // captures `file(line,col):` blocks.
+        let input = "error TS5083: Cannot read file '/project/tsconfig.json'.\nFound 1 errors.\n";
+        let mut f = BlockStreamFilter::new(TscHandler::new());
+        let result = run_block_filter(&mut f, input, 1);
+        assert!(result.contains("TS5083"), "got: {}", result);
+        assert!(result.contains("1 errors"), "got: {}", result);
+        assert!(!result.contains("No errors found"), "got: {}", result);
+    }
+
+    #[test]
+    fn test_tsc_stream_nonzero_exit_never_says_no_errors() {
+        // tsc exited non-zero but nothing parsed (e.g. a crash). "TypeScript:
+        // No errors found" must never be rendered.
+        let input = "Found 0 errors. Watching for file changes.\n";
+        let mut f = BlockStreamFilter::new(TscHandler::new());
+        let result = run_block_filter(&mut f, input, 1);
+        assert!(
+            result.contains("TypeScript: failed (exit 1)"),
+            "got: {}",
+            result
+        );
+        assert!(!result.contains("No errors found"), "got: {}", result);
     }
 
     #[test]

--- a/src/cmds/js/vitest_cmd.rs
+++ b/src/cmds/js/vitest_cmd.rs
@@ -28,6 +28,10 @@ struct VitestJsonOutput {
     num_failed_tests: usize,
     #[serde(rename = "numPendingTests", default)]
     num_pending_tests: usize,
+    #[serde(rename = "numFailedTestSuites", default)]
+    num_failed_test_suites: usize,
+    #[serde(rename = "success", default)]
+    success: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -35,6 +39,8 @@ struct VitestTestFile {
     name: String,
     #[serde(rename = "assertionResults")]
     assertion_results: Vec<VitestTest>,
+    #[serde(default)]
+    status: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -67,10 +73,22 @@ impl OutputParser for VitestParser {
             Ok(json) => {
                 let failures = extract_failures_from_json(&json);
 
+                // numFailedTestSuites counts whole files that failed to load
+                // (syntax errors, import crashes). Those are real failures even
+                // when numFailedTests is 0 — they must surface as failed, not
+                // as an all-green "PASS (N) FAIL (0)" run.
+                let failed_suites = if json.num_failed_test_suites > 0 {
+                    json.num_failed_test_suites
+                } else if json.success == Some(false) && failures.is_empty() {
+                    1
+                } else {
+                    0
+                };
+
                 let result = TestResult {
                     total: json.num_total_tests,
                     passed: json.num_passed_tests,
-                    failed: json.num_failed_tests,
+                    failed: json.num_failed_tests + failed_suites,
                     skipped: json.num_pending_tests,
                     duration_ms: None,
                     failures,
@@ -97,6 +115,19 @@ impl OutputParser for VitestParser {
 /// Extract failures from JSON structure
 fn extract_failures_from_json(json: &VitestJsonOutput) -> Vec<TestFailure> {
     let mut failures = Vec::new();
+
+    // Failed suites first — the whole file failed to load, so there is no
+    // per-test breakdown to show.
+    for file in &json.test_results {
+        if file.status == "failed" {
+            failures.push(TestFailure {
+                test_name: format!("[suite] {}", file.name),
+                file_path: file.name.clone(),
+                error_message: format!("test file failed to load ({})", file.name),
+                stack_trace: None,
+            });
+        }
+    }
 
     for file in &json.test_results {
         for test in &file.assertion_results {
@@ -251,7 +282,9 @@ pub fn run_test(command: &Commands, args: &[String], verbose: u8) -> Result<i32>
     let tee_label = format!("{}_run", framework);
 
     let rendered = render_test_output(&filtered, &combined, &tee_label, result.exit_code);
-    let shown = crate::core::runner::emit_guarded(&rendered, None, &combined);
+    // Never render an all-green verdict when the test runner exited non-zero.
+    let guarded = crate::core::guard::guard_exit(&combined, result.exit_code, framework, &rendered);
+    let shown = crate::core::runner::emit_guarded(&guarded, None, &combined);
 
     timer.track(
         format!("{} run", framework).as_str(),
@@ -507,6 +540,59 @@ Scope: all 6 workspace projects
         assert_eq!(data.passed, 4);
         assert_eq!(data.failed, 1);
         assert_eq!(data.duration_ms, None);
+    }
+
+    #[test]
+    fn test_vitest_parser_failed_suite_counts_as_failure() {
+        // A test file that fails to load (syntax error) reports
+        // numFailedTestSuites > 0 even when numFailedTests is 0. It must not
+        // render as an all-green run.
+        let json = r#"{
+            "numTotalTests": 10,
+            "numPassedTests": 10,
+            "numFailedTests": 0,
+            "numFailedTestSuites": 1,
+            "numPendingTests": 0,
+            "success": false,
+            "testResults": [
+                {"name": "src/broken.spec.ts", "status": "failed", "assertionResults": []},
+                {"name": "src/ok.spec.ts", "status": "passed", "assertionResults": [
+                    {"fullName": "ok test", "status": "passed", "failureMessages": []}
+                ]}
+            ],
+            "startTime": 1000
+        }"#;
+
+        let result = VitestParser::parse(json);
+        let data = result.unwrap();
+        assert_eq!(data.failed, 1, "failed suites must count as failures");
+        assert!(
+            data.failures.iter().any(|f| f.test_name.contains("broken.spec.ts")),
+            "failed suite must appear in failures list"
+        );
+
+        let rendered = data.format(FormatMode::Compact);
+        assert!(rendered.contains("FAIL (1)"), "got: {}", rendered);
+        assert!(rendered.contains("broken.spec.ts"), "got: {}", rendered);
+    }
+
+    #[test]
+    fn test_vitest_parser_success_false_without_suites_counts_as_failure() {
+        // success:false with no failed tests and no failed suites (e.g. a
+        // crash outside the test results) must not render all-green.
+        let json = r#"{
+            "numTotalTests": 5,
+            "numPassedTests": 5,
+            "numFailedTests": 0,
+            "numPendingTests": 0,
+            "success": false,
+            "testResults": [],
+            "startTime": 1000
+        }"#;
+
+        let result = VitestParser::parse(json);
+        let data = result.unwrap();
+        assert_eq!(data.failed, 1, "success:false must count as a failure");
     }
 
     #[test]

--- a/src/cmds/jvm/gradlew_cmd.rs
+++ b/src/cmds/jvm/gradlew_cmd.rs
@@ -139,32 +139,44 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
             Box::new(BuildLineFilter),
             RunOptions::with_tee("gradlew_build"),
         ),
-        GradlewTask::Test => runner::run_filtered(
+        GradlewTask::Test => runner::run_filtered_with_exit(
             cmd,
             tool,
             &args_display,
-            filter_test,
+            |raw, exit_code| {
+                let filtered = filter_test(raw);
+                crate::core::guard::guard_exit(raw, exit_code, tool, &filtered)
+            },
             RunOptions::with_tee("gradlew_test"),
         ),
-        GradlewTask::ConnectedTest => runner::run_filtered(
+        GradlewTask::ConnectedTest => runner::run_filtered_with_exit(
             cmd,
             tool,
             &args_display,
-            filter_connected,
+            |raw, exit_code| {
+                let filtered = filter_connected(raw);
+                crate::core::guard::guard_exit(raw, exit_code, tool, &filtered)
+            },
             RunOptions::with_tee("gradlew_connected"),
         ),
-        GradlewTask::Lint => runner::run_filtered(
+        GradlewTask::Lint => runner::run_filtered_with_exit(
             cmd,
             tool,
             &args_display,
-            filter_lint,
+            |raw, exit_code| {
+                let filtered = filter_lint(raw);
+                crate::core::guard::guard_exit(raw, exit_code, tool, &filtered)
+            },
             RunOptions::with_tee("gradlew_lint"),
         ),
-        GradlewTask::Dependencies => runner::run_filtered(
+        GradlewTask::Dependencies => runner::run_filtered_with_exit(
             cmd,
             tool,
             &args_display,
-            filter_dependencies,
+            |raw, exit_code| {
+                let filtered = filter_dependencies(raw);
+                crate::core::guard::guard_exit(raw, exit_code, tool, &filtered)
+            },
             RunOptions::with_tee("gradlew_deps"),
         ),
         GradlewTask::Other => {
@@ -894,6 +906,23 @@ Tests run: 3, Failures: 1, Errors: 0, Skipped: 0"#;
         assert!(
             out.contains("No connected devices"),
             "Must show actionable error"
+        );
+    }
+
+    #[test]
+    fn test_connected_crash_guard_replaces_green_verdict() {
+        // Instrumentation crash: the only informative lines (INSTRUMENTATION_RESULT)
+        // are stripped, so filter_connected would render a green "ok ✓" verdict.
+        // With a non-zero exit the guard must replace it with a failure verdict.
+        let raw =
+            "> Task :app:connectedDebugAndroidTest\nINSTRUMENTATION_RESULT: shortMsg=Process crashed.\nINSTRUMENTATION_CODE: -1";
+        let filtered = filter_connected(raw);
+        assert_eq!(filtered, "ok ✓ (connected tests passed)");
+        let guarded = crate::core::guard::guard_exit(raw, 1, "./gradlew", &filtered);
+        assert!(
+            guarded.contains("./gradlew: failed (exit 1)"),
+            "expected failure verdict, got: {}",
+            guarded
         );
     }
 

--- a/src/cmds/python/mypy_cmd.rs
+++ b/src/cmds/python/mypy_cmd.rs
@@ -31,11 +31,10 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         |raw, exit_code| {
             let clean = strip_ansi(raw);
             let filtered = filter_mypy_output(&clean);
-            // Nothing recognised on a failed run means mypy never type-checked.
-            if exit_code != 0 && filtered == MYPY_CLEAN {
-                return clean.trim().to_string();
-            }
-            filtered
+            // mypy exits 2 when it finds type errors; if nothing parsed on a
+            // non-zero exit, the run never type-checked — say so instead of
+            // claiming "No issues found".
+            crate::core::guard::guard_exit(clean.trim(), exit_code, "mypy", &filtered)
         },
         runner::RunOptions::default(),
     )
@@ -346,6 +345,19 @@ Found 1 error in 1 file
         let output = "Success: no issues found in 5 source files\n";
         let result = filter_mypy_output(output);
         assert_eq!(result, "mypy: No issues found");
+    }
+
+    #[test]
+    fn test_mypy_nonzero_exit_never_says_no_issues() {
+        // mypy exits 2 when it finds type errors. If only the "Found N errors"
+        // summary line arrives (stderr swallowed), the parser would report
+        // "mypy: No issues found" — the guard must fall back instead.
+        let raw = "Found 2 errors in 1 file (checked 10 source files)";
+        let filtered = filter_mypy_output(raw);
+        assert_eq!(filtered, MYPY_CLEAN);
+        let result = crate::core::guard::guard_exit(raw, 2, "mypy", &filtered);
+        assert!(result.contains("mypy: failed (exit 2)"), "got: {}", result);
+        assert!(!result.contains("No issues found"), "got: {}", result);
     }
 
     #[test]

--- a/src/cmds/python/pytest_cmd.rs
+++ b/src/cmds/python/pytest_cmd.rs
@@ -1,6 +1,5 @@
 //! Filters pytest output to show only failures and the summary line.
 
-use crate::core::config;
 use crate::core::runner;
 use crate::core::truncate::CAP_WARNINGS;
 use crate::core::utils::{resolved_command, strip_ansi, tool_exists, truncate};
@@ -59,11 +58,13 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         |raw, exit_code| {
             let clean = strip_ansi(raw);
             let filtered = filter_pytest_output(&clean);
-            // Any other failure parsed as empty means the run broke before reporting.
-            if exit_code != 0 && exit_code != PYTEST_EXIT_NO_TESTS && filtered == PYTEST_NO_TESTS {
-                return truncate(clean.trim(), config::limits().passthrough_max_chars);
+            // Exit 5 = no tests collected: a legitimate, non-error outcome.
+            if exit_code == PYTEST_EXIT_NO_TESTS {
+                return filtered;
             }
-            filtered
+            // Never render a green verdict ("No tests collected", "N passed")
+            // when the run actually failed.
+            crate::core::guard::guard_exit(clean.trim(), exit_code, "pytest", &filtered)
         },
         runner::RunOptions::stdout_only().tee("pytest"),
     )

--- a/src/cmds/python/ruff_cmd.rs
+++ b/src/cmds/python/ruff_cmd.rs
@@ -84,18 +84,21 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
         eprintln!("Running: ruff {}", args.join(" "));
     }
 
-    runner::run_filtered(
+    runner::run_filtered_with_exit(
         cmd,
         "ruff",
         &args.join(" "),
-        move |stdout| {
-            if is_check && use_json_filter && !stdout.trim().is_empty() {
+        move |stdout, exit_code| {
+            let filtered = if is_check && use_json_filter && !stdout.trim().is_empty() {
                 filter_ruff_check_json(stdout)
             } else if is_format {
                 filter_ruff_format(stdout)
             } else {
                 truncate(stdout.trim(), config::limits().passthrough_max_chars)
-            }
+            };
+            // "All files formatted correctly" / "No issues found" must never
+            // be shown when ruff exited non-zero (config error, etc.).
+            crate::core::guard::guard_exit(stdout, exit_code, "ruff", &filtered)
         },
         runner::RunOptions::stdout_only(),
     )
@@ -404,6 +407,21 @@ mod tests {
         let result = filter_ruff_format(output);
         assert!(result.contains("Ruff format"));
         assert!(result.contains("All files formatted correctly"));
+    }
+
+    #[test]
+    fn test_ruff_format_nonzero_exit_never_says_formatted() {
+        // ruff format --check exits non-zero when it fails; a green verdict must
+        // never be shown for it.
+        let raw = "5 files left unchanged";
+        let filtered = filter_ruff_format(raw);
+        let result = crate::core::guard::guard_exit(raw, 2, "ruff", &filtered);
+        assert!(result.contains("ruff: failed (exit 2)"), "got: {}", result);
+        assert!(!result.contains("All files formatted"), "got: {}", result);
+
+        // Same input with exit 0 keeps the green verdict.
+        let ok = crate::core::guard::guard_exit(raw, 0, "ruff", &filtered);
+        assert_eq!(ok, filtered);
     }
 
     #[test]

--- a/src/cmds/rust/cargo_cmd.rs
+++ b/src/cmds/rust/cargo_cmd.rs
@@ -194,7 +194,7 @@ impl BlockHandler for CargoTestHandler {
         self.in_failure_section && !line.starts_with("---- ")
     }
 
-    fn format_summary(&self, _exit_code: i32, raw: &str) -> Option<String> {
+    fn format_summary(&self, exit_code: i32, raw: &str) -> Option<String> {
         if self.summary_lines.is_empty() {
             let json = extract_json_diagnostics(raw);
             if self.has_compile_errors || !json.errors.is_empty() {
@@ -234,7 +234,15 @@ impl BlockHandler for CargoTestHandler {
         if all_parsed {
             if let Some(agg) = aggregated {
                 if agg.suites > 0 {
-                    return Some(format!("{}\n", agg.format_compact()));
+                    let line = format!("{}\n", agg.format_compact());
+                    // "cargo test: N passed (M suites)" must never be rendered
+                    // for a non-zero child exit (killed mid-run, signal, etc.).
+                    return Some(crate::core::guard::guard_exit(
+                        raw,
+                        exit_code,
+                        "cargo test",
+                        &line,
+                    ));
                 }
             }
         }
@@ -412,7 +420,12 @@ fn run_install(args: &[String], verbose: u8) -> Result<i32> {
 }
 
 fn run_nextest(args: &[String], verbose: u8) -> Result<i32> {
-    run_cargo_filtered("nextest", args, verbose, filter_cargo_nextest)
+    run_cargo_filtered_with_exit("nextest", args, verbose, |o, exit| {
+        let filtered = filter_cargo_nextest(o);
+        // nextest exits 1 on test failure; never render a green "N passed"
+        // verdict when the run actually failed.
+        crate::core::guard::guard_exit(o, exit, "cargo nextest", &filtered)
+    })
 }
 
 /// Format crate name + version into a display string
@@ -621,7 +634,7 @@ fn flush_failure_block(header: &mut String, body: &mut Vec<String>, failures: &m
 /// Filter cargo nextest output - show failures + compact summary
 fn filter_cargo_nextest(output: &str) -> String {
     let summary_re = regex::Regex::new(
-        r"Summary \[\s*([\d.]+)s\]\s+(\d+) tests? run:\s+(\d+) passed(?:,\s+(\d+) failed)?(?:,\s+(\d+) skipped)?"
+        r"Summary \[\s*([\d.]+)s\]\s+(\d+) tests? run:\s+(\d+) passed(?:,\s+(\d+) failed)?(?:,\s+(\d+) skipped)?(?:\s+\((\d+) slow\))?"
     ).expect("invalid nextest summary regex");
 
     let starting_re = regex::Regex::new(r"Starting \d+ tests? across (\d+) binar(?:y|ies)")
@@ -754,6 +767,7 @@ fn filter_cargo_nextest(output: &str) -> String {
             .get(5)
             .and_then(|m| m.as_str().parse().ok())
             .unwrap_or(0);
+        let slow: Option<u32> = caps.get(6).and_then(|m| m.as_str().parse().ok());
 
         let binary_text = match binaries.cmp(&1) {
             Ordering::Greater => format!("{} binaries", binaries),
@@ -764,6 +778,9 @@ fn filter_cargo_nextest(output: &str) -> String {
         if failed == 0 {
             // All pass - compact single line
             let mut parts = vec![format!("{} passed", passed)];
+            if let Some(slow) = slow {
+                parts.push(format!("{} slow", slow));
+            }
             if skipped > 0 {
                 parts.push(format!("{} skipped", skipped));
             }
@@ -788,6 +805,9 @@ fn filter_cargo_nextest(output: &str) -> String {
         }
 
         let mut summary_parts = vec![format!("{} passed", passed)];
+        if let Some(slow) = slow {
+            summary_parts.push(format!("{} slow", slow));
+        }
         if failed > 0 {
             summary_parts.push(format!("{} failed", failed));
         }
@@ -2074,6 +2094,55 @@ error: aborting due to 2 previous errors
     }
 
     #[test]
+    fn test_filter_cargo_nextest_slow_annotation() {
+        let output = r#"    Starting 301 tests across 1 binary
+────────────────────────────
+     Summary [   0.192s] 301 tests run: 301 passed, 0 skipped (0 slow)
+"#;
+        let result = filter_cargo_nextest(output);
+        assert_eq!(
+            result, "cargo nextest: 301 passed, 0 slow (1 binary, 0.192s)",
+            "got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_filter_cargo_nextest_slow_annotation_with_slow() {
+        let output = r#"    Starting 50 tests across 1 binary
+────────────────────────────
+     Summary [   0.500s] 50 tests run: 50 passed, 3 skipped (2 slow)
+"#;
+        let result = filter_cargo_nextest(output);
+        assert_eq!(
+            result, "cargo nextest: 50 passed, 2 slow, 3 skipped (1 binary, 0.500s)",
+            "got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_cargo_nextest_nonzero_exit_never_says_passed() {
+        // nextest killed mid-run: green "N passed" verdict must be replaced.
+        let output = r#"    Starting 301 tests across 1 binary
+────────────────────────────
+     Summary [   0.192s] 301 tests run: 301 passed, 0 skipped
+"#;
+        let filtered = filter_cargo_nextest(output);
+        assert_eq!(
+            filtered, "cargo nextest: 301 passed (1 binary, 0.192s)",
+            "got: {}",
+            filtered
+        );
+        let result = crate::core::guard::guard_exit(output, 137, "cargo nextest", &filtered);
+        assert!(
+            result.contains("cargo nextest: failed (exit 137)"),
+            "got: {}",
+            result
+        );
+    }
+
+    #[test]
     fn test_filter_cargo_nextest_with_failures() {
         let output = r#"    Starting 4 tests across 1 binary (1 test skipped)
         PASS [   0.006s] (1/4) test-proj tests::passing_test
@@ -2698,6 +2767,30 @@ test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fin
             result
         );
         assert!(!result.contains("Compiling"), "got: {}", result);
+    }
+
+    #[test]
+    fn test_cargo_test_stream_nonzero_exit_never_says_passed() {
+        // All summaries say ok but the child was killed mid-run (exit 137).
+        // "cargo test: N passed (M suites)" must never be rendered.
+        let input = r#"   Compiling rtk v0.5.0
+    Finished test [unoptimized + debuginfo] target(s) in 2.53s
+
+running 15 tests
+test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+"#;
+        let mut f = BlockStreamFilter::new(CargoTestHandler::new());
+        let result = run_block_filter(&mut f, input, 137);
+        assert!(
+            result.contains("cargo test: failed (exit 137)"),
+            "got: {}",
+            result
+        );
+        assert!(
+            !result.contains("cargo test: 15 passed"),
+            "must not render a green verdict: {}",
+            result
+        );
     }
 
     #[test]

--- a/src/core/guard.rs
+++ b/src/core/guard.rs
@@ -1,4 +1,5 @@
-//! Never-worse output guard: RTK never emits more tokens than the raw command.
+//! Never-worse output guard: RTK never emits more tokens than the raw command,
+//! and never renders an all-green summary when the child process exited non-zero.
 
 use crate::core::tracking::estimate_tokens;
 
@@ -9,6 +10,88 @@ pub fn never_worse<'a>(raw: &'a str, filtered: &'a str) -> &'a str {
     } else {
         filtered
     }
+}
+
+/// Fallback rendering for an unparsed non-zero exit:
+/// `"<tool>: failed (exit N)"` followed by a capped raw tail.
+///
+/// Mirrors `filter_go_build_with_exit`'s failure shape so every tool reports
+/// hard failures identically instead of an all-green verdict.
+pub fn failure_fallback(tool: &str, exit_code: i32, output: &str) -> String {
+    let lines: Vec<&str> = output
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .collect();
+
+    if lines.is_empty() {
+        return format!("{}: failed (exit {})", tool, exit_code);
+    }
+
+    let mut result = format!("{}: failed (exit {})", tool, exit_code);
+    result.push_str("\n═══════════════════════════════════════\n");
+
+    const MAX_FAILURE_LINES: usize = crate::core::truncate::CAP_ERRORS;
+    for (i, line) in lines.iter().take(MAX_FAILURE_LINES).enumerate() {
+        result.push_str(&format!(
+            "{}. {}\n",
+            i + 1,
+            crate::core::utils::truncate(line, 120)
+        ));
+    }
+
+    if lines.len() > MAX_FAILURE_LINES {
+        result.push_str(&format!(
+            "\n… +{} more output lines\n",
+            lines.len() - MAX_FAILURE_LINES
+        ));
+    }
+
+    result.trim().to_string()
+}
+
+/// True when `text` is a compact "all-good" verdict that must never be rendered
+/// for a non-zero child exit.
+fn looks_green(text: &str) -> bool {
+    let t = text.trim().to_lowercase();
+    if t.is_empty() {
+        return false;
+    }
+    if t.ends_with("success") {
+        return true;
+    }
+    if t.contains("no issues found")
+        || t.contains("no errors found")
+        || t.contains("no tests collected")
+        || t.contains("no tests found")
+        || t.contains("formatted correctly")
+    {
+        return true;
+    }
+    // "N passed" verdicts (incl. formatter output like "PASS (N) FAIL (0)").
+    // A non-zero FAIL count or any "failed"/"errors" mention means it is NOT green.
+    if t.contains("passed") || t.contains("pass (") {
+        if t.contains("failed") || t.contains("errors") {
+            return false;
+        }
+        return !t.contains("fail (") || t.contains("fail (0)");
+    }
+    if t.contains("compiled") || t.contains("already installed") {
+        return true;
+    }
+    false
+}
+
+/// Enforce the exit-code invariant: a filter must NEVER render an all-green
+/// summary when the child exited non-zero.
+///
+/// When `exit_code != 0` and `filtered` reads as a green verdict, falls back to
+/// `failure_fallback`; otherwise `filtered` is returned unchanged.
+pub fn guard_exit(raw: &str, exit_code: i32, tool: &str, filtered: &str) -> String {
+    if exit_code == 0 || !looks_green(filtered) {
+        return filtered.to_string();
+    }
+    failure_fallback(tool, exit_code, raw)
 }
 
 #[cfg(test)]
@@ -52,5 +135,86 @@ mod tests {
     #[test]
     fn both_empty_returns_filtered() {
         assert_eq!(never_worse("", ""), "");
+    }
+
+    #[test]
+    fn guard_keeps_filtered_on_exit_zero() {
+        assert_eq!(
+            guard_exit("raw", 0, "pytest", "Pytest: 5 passed"),
+            "Pytest: 5 passed"
+        );
+    }
+
+    #[test]
+    fn guard_keeps_failure_summary_on_nonzero_exit() {
+        let filtered = "Pytest: 4 passed, 1 failed\n\nFailures:\n1. [FAIL] test_x";
+        assert_eq!(guard_exit("raw", 1, "pytest", filtered), filtered);
+    }
+
+    #[test]
+    fn guard_falls_back_on_green_summary_with_nonzero_exit() {
+        let result = guard_exit("opaque failure output", 1, "pytest", "Pytest: 5 passed");
+        assert_eq!(result, "pytest: failed (exit 1)\n═══════════════════════════════════════\n1. opaque failure output");
+    }
+
+    #[test]
+    fn guard_falls_back_on_clean_verdict_with_nonzero_exit() {
+        let result = guard_exit(
+            "config broken",
+            2,
+            "ruff",
+            "Ruff format: All files formatted correctly",
+        );
+        assert!(result.contains("ruff: failed (exit 2)"), "got: {}", result);
+        assert!(result.contains("config broken"), "got: {}", result);
+    }
+
+    #[test]
+    fn guard_detects_formatter_pass_fail_zero_as_green() {
+        let result = guard_exit("killed", 137, "vitest", "PASS (13) FAIL (0)");
+        assert!(
+            result.contains("vitest: failed (exit 137)"),
+            "got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn guard_keeps_formatter_pass_fail_nonzero_count() {
+        let filtered = "PASS (13) FAIL (2)\n1. a_test\n   boom";
+        assert_eq!(guard_exit("raw", 1, "vitest", filtered), filtered);
+    }
+
+    #[test]
+    fn guard_keeps_counts_ending_in_zero() {
+        let filtered = "Lint: 10 errors, 0 warnings\n1. bad line";
+        assert_eq!(guard_exit("raw", 1, "lint", filtered), filtered);
+    }
+
+    #[test]
+    fn failure_fallback_empty_output() {
+        assert_eq!(
+            failure_fallback("go build", 101, ""),
+            "go build: failed (exit 101)"
+        );
+    }
+
+    #[test]
+    fn failure_fallback_includes_raw_tail() {
+        let result = failure_fallback("tsc", 2, "error TS5083: cannot read file\nline two");
+        assert!(result.contains("tsc: failed (exit 2)"));
+        assert!(result.contains("1. error TS5083: cannot read file"));
+        assert!(result.contains("2. line two"));
+    }
+
+    #[test]
+    fn failure_fallback_caps_tail() {
+        let lines: Vec<String> = (0..40).map(|i| format!("line {i}")).collect();
+        let result = failure_fallback("tool", 1, &lines.join("\n"));
+        assert!(
+            result.contains("… +20 more output lines"),
+            "got: {}",
+            result
+        );
     }
 }

--- a/src/core/guard.rs
+++ b/src/core/guard.rs
@@ -2,6 +2,12 @@
 //! and never renders an all-green summary when the child process exited non-zero.
 
 use crate::core::tracking::estimate_tokens;
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// "0 failed" — but NOT "10 failed" or "20 failed", whose counts merely end in a zero.
+static ZERO_FAILED: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?:^|[^0-9])0 failed").unwrap());
 
 /// Returns `filtered`, or `raw` when `filtered` would emit more tokens.
 pub fn never_worse<'a>(raw: &'a str, filtered: &'a str) -> &'a str {
@@ -52,6 +58,13 @@ pub fn failure_fallback(tool: &str, exit_code: i32, output: &str) -> String {
 
 /// True when `text` is a compact "all-good" verdict that must never be rendered
 /// for a non-zero child exit.
+///
+/// IMPORTANT: this is an ALLOWLIST. The guard only fires when a summary matches a
+/// known green phrase, so any new green verdict string introduced by a filter
+/// (e.g. "ok ✓ …", "N passed", "No issues found") MUST be added here — and to the
+/// `guard_catches_known_green_verdicts` test below — or the guard silently stops
+/// protecting that filter. When green summary strings change, extend this function
+/// and the test in the same change.
 fn looks_green(text: &str) -> bool {
     let t = text.trim().to_lowercase();
     if t.is_empty() {
@@ -69,10 +82,17 @@ fn looks_green(text: &str) -> bool {
         return true;
     }
     // "N passed" verdicts (incl. formatter output like "PASS (N) FAIL (0)").
-    // A non-zero FAIL count or any "failed"/"errors" mention means it is NOT green.
+    // A non-zero FAIL count or any "errors" mention means it is NOT green.
     if t.contains("passed") || t.contains("pass (") {
-        if t.contains("failed") || t.contains("errors") {
+        if t.contains("errors") {
             return false;
+        }
+        // "failed" alone is ambiguous: "44 passed, 0 failed, 3 skipped" is green,
+        // but "4 passed, 1 failed" is not. A digit-boundary match on "0 failed"
+        // keeps verdicts like "0 failed" green while "10 failed"/"20 failed"
+        // (counts ending in zero) stay red.
+        if t.contains("failed") {
+            return ZERO_FAILED.is_match(&t);
         }
         return !t.contains("fail (") || t.contains("fail (0)");
     }
@@ -189,6 +209,69 @@ mod tests {
     fn guard_keeps_counts_ending_in_zero() {
         let filtered = "Lint: 10 errors, 0 warnings\n1. bad line";
         assert_eq!(guard_exit("raw", 1, "lint", filtered), filtered);
+    }
+
+    #[test]
+    fn zero_failed_matches_only_digit_boundary() {
+        assert!(ZERO_FAILED.is_match("0 failed"));
+        assert!(ZERO_FAILED.is_match("Pytest: 44 passed, 0 failed, 3 skipped"));
+        assert!(!ZERO_FAILED.is_match("1 failed"));
+        assert!(!ZERO_FAILED.is_match("4 passed, 1 failed"));
+        assert!(
+            !ZERO_FAILED.is_match("10 failed"),
+            "count ending in zero must not match"
+        );
+        assert!(
+            !ZERO_FAILED.is_match("20 failed"),
+            "count ending in zero must not match"
+        );
+    }
+
+    #[test]
+    fn guard_detects_zero_failed_with_skips_as_green() {
+        // "Pytest: 44 passed, 0 failed, 3 skipped" is a GREEN verdict — the guard
+        // must fall back on non-zero exit instead of rendering it.
+        let result = guard_exit(
+            "opaque failure output",
+            1,
+            "pytest",
+            "Pytest: 44 passed, 0 failed, 3 skipped",
+        );
+        assert!(
+            result.contains("pytest: failed (exit 1)"),
+            "expected failure fallback, got: {}",
+            result
+        );
+    }
+
+    #[test]
+    fn guard_keeps_nonzero_failed_with_skips() {
+        let filtered = "Pytest: 44 passed, 1 failed, 3 skipped\n\nFailures:\n1. [FAIL] test_x";
+        assert_eq!(guard_exit("raw", 1, "pytest", filtered), filtered);
+    }
+
+    #[test]
+    fn guard_catches_known_green_verdicts() {
+        // Every green verdict string a filter can currently produce must be caught
+        // by the guard. If a NEW filter renders green output, add its verdict here
+        // (and to `looks_green`) so it cannot bypass the guard.
+        let green_verdicts = [
+            "Pytest: 5 passed",
+            "Pytest: 44 passed, 0 failed, 3 skipped",
+            "Ruff: No issues found",
+            "Ruff format: All files formatted correctly",
+            "PASS (13) FAIL (0)",
+            "ESLint: No issues found",
+            "Prettier: All files formatted correctly",
+        ];
+        for verdict in green_verdicts {
+            let result = guard_exit("opaque failure", 1, "tool", verdict);
+            assert!(
+                result.contains("tool: failed (exit 1)"),
+                "guard missed green verdict {verdict:?}: got {}",
+                result
+            );
+        }
     }
 
     #[test]

--- a/src/core/guard.rs
+++ b/src/core/guard.rs
@@ -1,13 +1,76 @@
 //! Never-worse output guard: RTK never emits more tokens than the raw command,
 //! and never renders an all-green summary when the child process exited non-zero.
+//!
+//! The exit guard uses a failure DENYLIST: on a non-zero child exit a filter
+//! result is kept only when it already communicates failure, otherwise it is
+//! replaced with a standardized `<tool>: failed (exit N)` verdict. This inverts
+//! the old green-phrase allowlist, which let any reworded summary or new filter
+//! silently bypass the guard by default.
 
 use crate::core::tracking::estimate_tokens;
 use regex::Regex;
 use std::sync::LazyLock;
 
-/// "0 failed" — but NOT "10 failed" or "20 failed", whose counts merely end in a zero.
-static ZERO_FAILED: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?:^|[^0-9])0 failed").unwrap());
+/// "1 failed" / "44 passed, 1 failed" — a NON-ZERO failed count. "0 failed" is a
+/// green verdict and never matches (the digit boundary prevents a standalone
+/// "0" match inside "10 failed"/"20 failed", whose counts merely end in a zero).
+static NONZERO_FAILED: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?:^|[^0-9])[1-9]\d* failed").unwrap());
+
+/// "3 errors" / "10 errors" — but NOT "0 errors" ("No errors found" is green).
+static NONZERO_ERRORS: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?:^|[^0-9])[1-9]\d* errors").unwrap());
+
+/// "2 issues" / "golangci-lint: 5 issues in 3 files" — but NOT "No issues found".
+static NONZERO_ISSUES: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?:^|[^0-9])[1-9]\d* issues").unwrap());
+
+static NONZERO_WARNINGS: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?:^|[^0-9])[1-9]\d* warnings").unwrap());
+
+static NONZERO_PROBLEMS: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?:^|[^0-9])[1-9]\d* problems").unwrap());
+
+/// Bare "FAIL"/"FAIL" — nextest `FAIL [...]`, pytest `[FAIL]`, vitest
+/// `FAIL (2)`. Suppressed when the whole text only carries "FAIL (0)", the
+/// green formatter verdict, via `FAIL_ZERO`.
+static FAILED_WORD: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\bfail\b").unwrap());
+
+/// "FAIL (0)" — the green formatter verdict; suppresses `FAILED_WORD`.
+static FAIL_ZERO: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\bfail\s*\(\s*0\s*\)").unwrap());
+
+/// "Failures:" / "1 failure". Suppressed when a "Failures: 0"/"failures = 0"
+/// count (green) is present, via `FAILURES_ZERO`.
+static FAILURES_WORD: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\bfailures?\b").unwrap());
+
+/// "Failures: 0" / "failures = 0" — green counts that suppress `FAILURES_WORD`.
+static FAILURES_ZERO: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\bfailures?\s*[:=]\s*0(?:\D|$)").unwrap());
+
+/// Compiler error lines: "error TS2322", "Error:", "error[E0308]". The word
+/// boundary never matches the plural "errors", so "No errors found" stays green.
+static BARE_ERROR: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\berror\b").unwrap());
+
+/// Panics, exceptions, crashes (AssertionError, panicked, Process crashed).
+static EXCEPTION: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\b(?:panic(?:ked)?|exception|assertionerror|crashed)\b").unwrap()
+});
+
+/// ruff format --check: files that need reformatting.
+static NEED_FORMATTING: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"needs? formatting|would (be )?reformat").unwrap());
+
+/// True when `text` contains "failed" that is NOT part of a "0 failed" verdict
+/// ("build failed", "1 failed", "10 failed", "test run failed"). The optional
+/// leading count is captured so "0 failed" stays green while "10 failed" /
+/// "20 failed" (counts merely ending in a zero) read as failures.
+fn has_failed_word(text: &str) -> bool {
+    static FAILED: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?:(\d+)\s+)?failed\b").unwrap());
+    FAILED
+        .captures_iter(text)
+        .any(|caps| caps.get(1).is_none_or(|m| m.as_str() != "0"))
+}
 
 /// Returns `filtered`, or `raw` when `filtered` would emit more tokens.
 pub fn never_worse<'a>(raw: &'a str, filtered: &'a str) -> &'a str {
@@ -56,59 +119,38 @@ pub fn failure_fallback(tool: &str, exit_code: i32, output: &str) -> String {
     result.trim().to_string()
 }
 
-/// True when `text` is a compact "all-good" verdict that must never be rendered
-/// for a non-zero child exit.
+/// True when `text` already communicates failure.
 ///
-/// IMPORTANT: this is an ALLOWLIST. The guard only fires when a summary matches a
-/// known green phrase, so any new green verdict string introduced by a filter
-/// (e.g. "ok ✓ …", "N passed", "No issues found") MUST be added here — and to the
-/// `guard_catches_known_green_verdicts` test below — or the guard silently stops
-/// protecting that filter. When green summary strings change, extend this function
-/// and the test in the same change.
-fn looks_green(text: &str) -> bool {
-    let t = text.trim().to_lowercase();
-    if t.is_empty() {
-        return false;
-    }
-    if t.ends_with("success") {
-        return true;
-    }
-    if t.contains("no issues found")
-        || t.contains("no errors found")
-        || t.contains("no tests collected")
-        || t.contains("no tests found")
-        || t.contains("formatted correctly")
-    {
-        return true;
-    }
-    // "N passed" verdicts (incl. formatter output like "PASS (N) FAIL (0)").
-    // A non-zero FAIL count or any "errors" mention means it is NOT green.
-    if t.contains("passed") || t.contains("pass (") {
-        if t.contains("errors") {
-            return false;
-        }
-        // "failed" alone is ambiguous: "44 passed, 0 failed, 3 skipped" is green,
-        // but "4 passed, 1 failed" is not. A digit-boundary match on "0 failed"
-        // keeps verdicts like "0 failed" green while "10 failed"/"20 failed"
-        // (counts ending in zero) stay red.
-        if t.contains("failed") {
-            return ZERO_FAILED.is_match(&t);
-        }
-        return !t.contains("fail (") || t.contains("fail (0)");
-    }
-    if t.contains("compiled") || t.contains("already installed") {
-        return true;
-    }
-    false
+/// IMPORTANT: this is a DENYLIST. The exit guard fires unless a non-zero-exit
+/// filter result reads as a failure, so a new filter or a reworded green summary
+/// can never silently bypass the guard — it defaults to the failure fallback.
+/// Only phrases that genuinely communicate failure belong here; green verdicts
+/// ("N passed", "No issues found", "All files formatted correctly") must stay
+/// marker-free so the guard catches them. New failure shapes must be added here
+/// and to the `looks_failed_detects_common_failure_shapes` test in the same
+/// change.
+fn looks_failed(text: &str) -> bool {
+    let t = text.to_lowercase();
+    NONZERO_FAILED.is_match(&t)
+        || NONZERO_ERRORS.is_match(&t)
+        || NONZERO_ISSUES.is_match(&t)
+        || NONZERO_WARNINGS.is_match(&t)
+        || NONZERO_PROBLEMS.is_match(&t)
+        || (FAILED_WORD.is_match(&t) && !FAIL_ZERO.is_match(&t))
+        || (FAILURES_WORD.is_match(&t) && !FAILURES_ZERO.is_match(&t))
+        || BARE_ERROR.is_match(&t)
+        || EXCEPTION.is_match(&t)
+        || NEED_FORMATTING.is_match(&t)
+        || has_failed_word(&t)
 }
 
 /// Enforce the exit-code invariant: a filter must NEVER render an all-green
 /// summary when the child exited non-zero.
 ///
-/// When `exit_code != 0` and `filtered` reads as a green verdict, falls back to
-/// `failure_fallback`; otherwise `filtered` is returned unchanged.
+/// When `exit_code != 0` and `filtered` does not already communicate failure,
+/// falls back to `failure_fallback`; otherwise `filtered` is returned unchanged.
 pub fn guard_exit(raw: &str, exit_code: i32, tool: &str, filtered: &str) -> String {
-    if exit_code == 0 || !looks_green(filtered) {
+    if exit_code == 0 || looks_failed(filtered) {
         return filtered.to_string();
     }
     failure_fallback(tool, exit_code, raw)
@@ -212,19 +254,112 @@ mod tests {
     }
 
     #[test]
-    fn zero_failed_matches_only_digit_boundary() {
-        assert!(ZERO_FAILED.is_match("0 failed"));
-        assert!(ZERO_FAILED.is_match("Pytest: 44 passed, 0 failed, 3 skipped"));
-        assert!(!ZERO_FAILED.is_match("1 failed"));
-        assert!(!ZERO_FAILED.is_match("4 passed, 1 failed"));
-        assert!(
-            !ZERO_FAILED.is_match("10 failed"),
-            "count ending in zero must not match"
-        );
-        assert!(
-            !ZERO_FAILED.is_match("20 failed"),
-            "count ending in zero must not match"
-        );
+    fn zero_failed_counts_are_not_failures() {
+        // "0 failed" is a green verdict: it must NOT be flagged as failure,
+        // while "10 failed"/"20 failed" (counts merely ending in a zero) are.
+        assert!(!looks_failed("0 failed"));
+        assert!(!looks_failed("Pytest: 44 passed, 0 failed, 3 skipped"));
+        assert!(!looks_failed("PASS (13) FAIL (0)"));
+        assert!(!looks_failed("Failures: 0, Errors: 0"));
+        assert!(looks_failed("1 failed"));
+        assert!(looks_failed("4 passed, 1 failed"));
+        assert!(looks_failed("10 failed"));
+        assert!(looks_failed("20 failed"));
+        assert!(looks_failed("build failed"));
+        assert!(looks_failed("error: test run failed"));
+    }
+
+    #[test]
+    fn looks_failed_detects_common_failure_shapes() {
+        // The denylist must recognize every failure shape the guard-wired
+        // filters produce so their non-zero-exit output is preserved.
+        assert!(looks_failed(
+            "Pytest: 4 passed, 1 failed\nFailures:\n1. [FAIL] test_x"
+        ));
+        assert!(looks_failed("PASS (13) FAIL (2)\n1. a_test\n   boom"));
+        assert!(looks_failed("Lint: 10 errors, 0 warnings\n1. bad line"));
+        assert!(looks_failed(
+            "Ruff: 3 issues in 2 files\nViolations:\n  1:8 E501 too long"
+        ));
+        assert!(looks_failed(
+            "ESLint: 2 errors, 1 warnings in 2 files\nTop rules:"
+        ));
+        assert!(looks_failed(
+            "golangci-lint: 5 issues in 3 files\nTop linters:"
+        ));
+        assert!(looks_failed("Pylint: 4 issues in 2 files"));
+        assert!(looks_failed(
+            "Go vet: 2 issues\n1. main.go:42:2: Printf format %d"
+        ));
+        assert!(looks_failed(
+            "TypeScript: 2 errors in 0 files\n1. error TS5083"
+        ));
+        assert!(looks_failed(
+            "mypy: 15 errors in 15 files\nsrc/file1.py:1: error: bad"
+        ));
+        assert!(looks_failed(
+            "Ruff format: 2 files need formatting\n1. main.py"
+        ));
+        assert!(looks_failed(
+            "Go test: 1 passed, 1 failed\n\nFailures:\n1. TestFail"
+        ));
+        assert!(looks_failed("cargo nextest: 2 passed, 2 failed, 1 skipped"));
+        assert!(looks_failed(
+            "testBar FAILED\n    java.lang.AssertionError: expected true"
+        ));
+        assert!(looks_failed(
+            "FAIL [   0.006s] (2/4) test-proj tests::failing_test"
+        ));
+        assert!(looks_failed("BUILD FAILED in 12s"));
+        assert!(looks_failed(
+            "connectedAndroidTest failed: No connected devices!"
+        ));
+    }
+
+    #[test]
+    fn looks_failed_stays_quiet_on_green_verdicts() {
+        // Green verdicts carry no failure marker and must fall through to the
+        // failure fallback on a non-zero exit (asserted in
+        // guard_catches_known_green_verdicts). This is the denylist contract:
+        // if a filter rewords a summary, the guard still fires by default.
+        assert!(!looks_failed("Pytest: 5 passed"));
+        assert!(!looks_failed("Ruff: No issues found"));
+        assert!(!looks_failed("Ruff: No errors found"));
+        assert!(!looks_failed("ESLint: No issues found"));
+        assert!(!looks_failed("Pylint: No issues found"));
+        assert!(!looks_failed("golangci-lint: No issues found"));
+        assert!(!looks_failed("Go vet: No issues found"));
+        assert!(!looks_failed("mypy: No issues found"));
+        assert!(!looks_failed("TypeScript: No errors found"));
+        assert!(!looks_failed("Go test: 5 passed in 1 packages"));
+        assert!(!looks_failed(
+            "cargo nextest: 301 passed (1 binary, 0.192s)"
+        ));
+        assert!(!looks_failed("Ruff format: All files formatted correctly"));
+        assert!(!looks_failed("ok ✓ (connected tests passed)"));
+        assert!(!looks_failed("Prettier: All files formatted correctly"));
+        assert!(!looks_failed(""));
+    }
+
+    #[test]
+    fn guard_catches_reworded_green_summaries_by_default() {
+        // The denylist fires for ANY summary that does not communicate failure —
+        // even reworded ones the allowlist never saw.
+        let reworded = [
+            "All good — 5 suites green",
+            "Everything passed cleanly",
+            "No problems detected across 12 files",
+            "Compilation completed without complaints",
+            "ok ✓ (connected tests passed)",
+        ];
+        for verdict in reworded {
+            let result = guard_exit("opaque failure", 1, "tool", verdict);
+            assert!(
+                result.contains("tool: failed (exit 1)"),
+                "guard missed reworded green verdict {verdict:?}: got {}",
+                result
+            );
+        }
     }
 
     #[test]
@@ -253,8 +388,10 @@ mod tests {
     #[test]
     fn guard_catches_known_green_verdicts() {
         // Every green verdict string a filter can currently produce must be caught
-        // by the guard. If a NEW filter renders green output, add its verdict here
-        // (and to `looks_green`) so it cannot bypass the guard.
+        // by the guard. Unlike the old allowlist, no new green string can bypass
+        // the guard — it fires unless the text communicates failure (see
+        // `guard_catches_reworded_green_summaries_by_default`). This list guards
+        // the denylist markers themselves from accidentally matching green text.
         let green_verdicts = [
             "Pytest: 5 passed",
             "Pytest: 44 passed, 0 failed, 3 skipped",


### PR DESCRIPTION
Implements the cross-cutting exit-code guard from Issue #2317.

## Problem
Tool filters rendered all-green summaries even when the child 
process exited non-zero, masking hard failures (collection errors, 
compile errors, OOM kills) as benign states.

## Fix
Added `guard::never_worse` helper following the existing 
`filter_go_build_with_exit` pattern. Applied to all affected filters:

- pytest — collection errors no longer show "No tests collected"
- ruff — parse errors no longer show "All files formatted correctly"
- mypy — "No issues found" gated on exit code
- cargo test / nextest — failures show "failed (exit N)"
- vitest/jest — checks numFailedTestSuites
- tsc — catches position-less global errors
- go vet — respects exit code
- go test -json — handles mid-stream kills
- golangci-lint — exit 1 preserved
- lint fallback — fixed "0 error" matching

## Verification
- cargo fmt --check ✅
- cargo clippy --all-targets ✅
- cargo test: 2613 unit + all integration tests ✅

Closes #2317