### PR TITLE
fix(search): cap raw retention so a large search cannot OOM the caller

### DIFF
--- a/src/cmds/system/search.rs
+++ b/src/cmds/system/search.rs
@@ -296,6 +296,13 @@ impl Engine {
 
 /// Runs the agent's exact engine + flags for the grouping path, appending only the
 /// parse aids (see `Engine::parse_flags`).
+///
+/// Retention is capped at `RAW_CAP` rather than `.output()`-buffered: a search
+/// over a large tree can emit gigabytes, and holding that twice (the byte buffer
+/// plus its lossy `String` copy) has OOM-killed the calling agent. The grouped
+/// form only ever renders `grep_max_results` matches, so the cap costs nothing
+/// but an under-count in the "N matches in M files" header, which is warned
+/// about on stderr by `run_streaming`.
 fn engine_capture<T: AsRef<str>>(
     engine: Engine,
     extra_args: &[T],
@@ -303,7 +310,13 @@ fn engine_capture<T: AsRef<str>>(
     paths: &[String],
 ) -> Result<CaptureResult> {
     let mut cmd = engine_command(engine, extra_args, patterns, paths, false);
-    exec_capture_stdin(&mut cmd).context("search failed")
+    let result = stream::run_streaming(&mut cmd, StdinMode::Inherit, FilterMode::CaptureOnly)
+        .context("search failed")?;
+    Ok(CaptureResult {
+        stdout: result.raw_stdout,
+        stderr: result.raw_stderr,
+        exit_code: result.exit_code,
+    })
 }
 
 fn engine_command<T: AsRef<str>>(

--- a/tests/search_memory_test.rs
+++ b/tests/search_memory_test.rs
@@ -1,0 +1,57 @@
+#![cfg(unix)]
+//! A path search must not buffer the engine's whole stdout.
+//!
+//! Regression: `rtk rg <pattern> logs/` over a 30 GB tree emitted 4.6 GB of
+//! matches, which rtk held twice (the `.output()` byte buffer plus its lossy
+//! `String` copy). The resulting ~9 GB got the calling agent OOM-killed. Raw
+//! retention is capped at `RAW_CAP`, so peak memory no longer scales with how
+//! much the engine emits.
+
+use std::io::Write;
+use std::process::Command;
+
+/// Enough match output that buffering it whole is unmistakable against the cap.
+const MATCH_BYTES: usize = 64 << 20;
+
+/// Address-space ceiling: comfortably above rtk's baseline plus a few copies of
+/// the 10 MiB cap, far below two copies of `MATCH_BYTES`.
+const VM_LIMIT_KB: usize = 400_000;
+
+#[test]
+fn path_search_does_not_buffer_whole_engine_output() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("big.log");
+    let line = format!("{}MATCHME{}\n", "x".repeat(40), "y".repeat(40));
+    {
+        let mut w = std::io::BufWriter::new(std::fs::File::create(&path).unwrap());
+        for _ in 0..(MATCH_BYTES / line.len()) {
+            w.write_all(line.as_bytes()).unwrap();
+        }
+        w.flush().unwrap();
+    }
+
+    let out = Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            "ulimit -v {}; exec {} grep MATCHME {}",
+            VM_LIMIT_KB,
+            env!("CARGO_BIN_EXE_rtk"),
+            path.display()
+        ))
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "rtk grep died under a {} KB address-space cap: {:?}\nstderr: {}",
+        VM_LIMIT_KB,
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        stdout.contains("matches in"),
+        "expected the capped grouped form, got: {}",
+        &stdout[..stdout.len().min(400)]
+    );
+}


### PR DESCRIPTION
## Summary

- `rtk grep`/`rtk rg` over a path buffers the engine's entire stdout via `.output()`, then copies it again with `from_utf8_lossy`. On a 30 GB log tree the search emitted 4.6 GB of matches, rtk peaked at ~9 GB, and the calling agent was OOM-killed (`Out of memory: Killed process (.rtk-wrapped) total-vm:8987044kB`).
- `| head -220` is no escape hatch on this path: nothing is written until the child exits, so the consumer never gets to close the pipe.
- Fix routes the capture through `run_streaming`'s `CaptureOnly`, which already caps retention at `RAW_CAP` (10 MiB) and warns when it truncates. One-line change plus a regression test — the streaming machinery was already there, the path-based branch just wasn't using it.

Output is unchanged for any search under the cap, so the byte-identity contract in `grep_faithful_format_test` still holds. Above the cap the grouped form only ever renders `grep_max_results` matches anyway; the `N matches in M files` header becomes a floor, and stderr says so.

Measured on a 64 MiB file of matches: peak allocation dropped from >90 MiB to the cap, and the search went from 2m25s to 25s (debug) / 10s (release), because the parse pass now runs over 10 MiB instead of everything.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
  - fmt clean, clippy clean, all integration suites green.
  - Note: `core::tracking::tests::*` flake on this machine (a different one each run, on `develop` unmodified too) — they share the real tracking DB.
- [x] New `tests/search_memory_test.rs`: 64 MiB of matches searched under `ulimit -v 400000`. Fails on `develop` with `memory allocation of 92274688 bytes failed`, passes here.
- [x] Manual: `rtk grep <pat> <64MiB file>` output byte-identical to the released binary on normal searches; the capped case prints the grouped form plus the truncation warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)