### PR TITLE
fix(hook): apply exclude_commands to path-prefixed invocations

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1382,7 +1382,13 @@ fn rewrite_segment_inner(
         Classification::Supported { rtk_equivalent, .. } => {
             let stripped = ENV_PREFIX.replace(cmd_part, "");
             let cmd_clean = stripped.trim();
-            if is_excluded(cmd_clean, excluded) {
+            // Match exclusions against the path-stripped form as well, the way
+            // the TOML branch below already does. A user who excludes "gradlew"
+            // means the tool, not one spelling of it, and `./gradlew` would
+            // otherwise rewrite straight through the exclusion.
+            if is_excluded(cmd_clean, excluded)
+                || is_excluded(&strip_absolute_path(cmd_clean), excluded)
+            {
                 return None;
             }
             rtk_equivalent
@@ -4684,6 +4690,29 @@ mod tests {
         assert_eq!(
             rewrite_command_no_prefixes("PGPASSWORD=postgres psql -h localhost", &excluded),
             None
+        );
+    }
+
+    #[test]
+    fn test_exclude_path_prefixed_command() {
+        // The tool is excluded however the caller spelled its path (#1053).
+        let excluded = vec!["gradlew".to_string()];
+        assert_eq!(
+            rewrite_command_no_prefixes("./gradlew assembleDebug", &excluded),
+            None
+        );
+
+        let excluded = vec!["phpunit".to_string()];
+        assert_eq!(
+            rewrite_command_no_prefixes("vendor/bin/phpunit tests/", &excluded),
+            None
+        );
+
+        // An unrelated exclusion still leaves the command alone.
+        let excluded = vec!["pytest".to_string()];
+        assert_eq!(
+            rewrite_command_no_prefixes("./gradlew assembleDebug", &excluded),
+            Some("rtk gradlew assembleDebug".into())
         );
     }
 


### PR DESCRIPTION
## Summary

- Match `exclude_commands` against the path-stripped command as well as the raw one, so an exclusion covers the tool rather than one spelling of it
- Excluding `gradlew` now stops `./gradlew`, and excluding `phpunit` now stops `vendor/bin/phpunit`; both currently rewrite straight through the exclusion
- Brings the supported-command branch in line with the TOML-only branch a few lines below, which already normalizes before matching

Part 3 of 3 for #1053, independent of the other two: it stands on its own and can merge in any order.

`exclude_commands` is compared against the raw command, so the setting only works for the spelling the user happened to type. Anyone who configures an exclusion for a tool reasonably expects it to hold however that tool is invoked, and today a `./`-prefixed or `vendor/bin`-prefixed invocation slips past it and gets rewritten anyway.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] `test_exclude_path_prefixed_command` covers `./gradlew` under an exclusion of `gradlew`, `vendor/bin/phpunit` under `phpunit`, and an unrelated exclusion still leaving the command rewritten
- [x] Full suite: 2600 passed on `develop`, 2601 with this branch, with the same 9 failures in both (`cmds::cloud::curl_cmd`, `core::tracking`), which fail on unmodified `develop` in my environment
