### PR TITLE
fix(rewrite): rewrite path-prefixed commands and keep the caller's binary

### DIFF
--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -365,6 +365,23 @@ pub fn resolve_binary(name: &str) -> Result<PathBuf> {
     which::which(name).context(format!("Binary '{}' not found on PATH", name))
 }
 
+/// Resolve the caller's own binary path from `RTK_BIN`, when it names `name`.
+///
+/// A user who runs `.venv/bin/pytest` means that pytest, not whichever one PATH
+/// happens to resolve first. The rewrite layer records the path it was given in
+/// `RTK_BIN`, and this is where handlers pick it back up (#1053).
+///
+/// The basename must match the requested tool, so a stale `RTK_BIN` left over
+/// from another command can never redirect an unrelated binary.
+fn rtk_bin_override(name: &str) -> Option<PathBuf> {
+    let path = PathBuf::from(std::env::var_os("RTK_BIN")?);
+    if path.file_name()? == std::ffi::OsStr::new(name) {
+        Some(path)
+    } else {
+        None
+    }
+}
+
 /// Create a `Command` with PATHEXT-aware binary resolution.
 ///
 /// Drop-in replacement for `Command::new(name)` that works on Windows
@@ -379,6 +396,10 @@ pub fn resolve_binary(name: &str) -> Result<PathBuf> {
 /// # Returns
 /// A `Command` configured with the resolved binary path.
 pub fn resolved_command(name: &str) -> Command {
+    if let Some(path) = rtk_bin_override(name) {
+        return Command::new(path); // nosemgrep: dynamic-command-execution
+    }
+
     match resolve_binary(name) {
         Ok(path) => Command::new(path),
         Err(e) => {
@@ -456,7 +477,16 @@ fn read_composer_bin_dir(composer_json: &str) -> Option<PathBuf> {
 /// Check if a tool exists on PATH (PATHEXT-aware on Windows).
 ///
 /// Replaces manual `Command::new("which").arg(tool)` checks that fail on Windows.
+///
+/// A tool reached through `RTK_BIN` counts as present even when it is absent
+/// from PATH, which is the normal case for a virtualenv or `node_modules/.bin`
+/// binary: handlers that branch on availability must see the same tool that
+/// `resolved_command` would run.
 pub fn tool_exists(name: &str) -> bool {
+    if rtk_bin_override(name).is_some_and(|path| path.exists()) {
+        return true;
+    }
+
     which::which(name).is_ok()
 }
 
@@ -624,6 +654,50 @@ fn output_codepage() -> Option<u16> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_rtk_bin_override_targets_only_the_named_tool() {
+        // The running test binary is a file that is certainly on disk, so the
+        // fixture needs no filesystem setup or cleanup of its own.
+        let real = std::env::current_exe().expect("current exe");
+        let name = real
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("exe file name")
+            .to_string();
+        let missing = std::env::temp_dir().join("rtk-fixture-absent-tool");
+
+        // Read every result before restoring the environment so a failed
+        // assertion can never leak RTK_BIN into the rest of the suite.
+        std::env::set_var("RTK_BIN", &real);
+        let program = resolved_command(&name).get_program().to_os_string();
+        let named_tool_exists = tool_exists(&name);
+        let other_tool = resolved_command("rtk-fixture-other")
+            .get_program()
+            .to_os_string();
+        std::env::set_var("RTK_BIN", &missing);
+        let missing_tool_exists = tool_exists("rtk-fixture-absent-tool");
+        std::env::remove_var("RTK_BIN");
+
+        assert_eq!(
+            program,
+            real.as_os_str(),
+            "resolved_command should run the RTK_BIN path when the basename matches"
+        );
+        assert!(
+            named_tool_exists,
+            "tool_exists should report a binary reachable only through RTK_BIN"
+        );
+        assert_ne!(
+            other_tool,
+            real.as_os_str(),
+            "a different tool must not inherit another command's RTK_BIN"
+        );
+        assert!(
+            !missing_tool_exists,
+            "tool_exists should not report a RTK_BIN path that is not on disk"
+        );
+    }
 
     #[test]
     fn test_truncate_short_string() {

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -9,7 +9,7 @@ use super::lexer::{
     shell_split, split_on_operators, tokenize, tokenize_with_newlines, ParsedToken, PipeKind,
     TokenKind,
 };
-use super::rules::{IGNORED_EXACT, IGNORED_PREFIXES, RULES};
+use super::rules::{RtkRule, IGNORED_EXACT, IGNORED_PREFIXES, RULES};
 
 const PHP_TOOL_NAMES: [&str; 6] = ["phpunit", "phpstan", "ecs", "pest", "paratest", "pint"];
 
@@ -1448,11 +1448,11 @@ fn rewrite_segment_inner(
     // classify_command does, so a small canonical prefix list matches every
     // invocation form instead of enumerating each literal spelling.
     let php_normalized;
-    let strip_target: &str = if rule
+    let php_tool = rule
         .rtk_cmd
         .strip_prefix("rtk ")
-        .is_some_and(|t| PHP_TOOL_NAMES.contains(&t))
-    {
+        .is_some_and(|t| PHP_TOOL_NAMES.contains(&t));
+    let strip_target: &str = if php_tool {
         // Peel `php ` then a leading `./` (normalize_php_tool_command only
         // strips `./` for paths that resolve to a Composer tool, so a plain
         // `./bin/<tool>` would otherwise survive and miss the prefix match).
@@ -1464,19 +1464,68 @@ fn rewrite_segment_inner(
         cmd_part
     };
 
+    let rewrite = |rest: &str| {
+        if rest.is_empty() {
+            format!("{}{}", rule.rtk_cmd, redirect_suffix)
+        } else {
+            format!("{} {}{}", rule.rtk_cmd, rest, redirect_suffix)
+        }
+    };
+
     // Try each rewrite prefix (longest first) with word-boundary check
     for &prefix in rule.rewrite_prefixes {
         if let Some(rest) = strip_word_prefix(strip_target, prefix) {
-            let rewritten = if rest.is_empty() {
-                format!("{}{}", rule.rtk_cmd, redirect_suffix)
-            } else {
-                format!("{} {}{}", rule.rtk_cmd, rest, redirect_suffix)
-            };
-            return Some(rewritten);
+            return Some(rewrite(rest));
         }
     }
 
-    None
+    // The Composer tools accept a deliberately narrow set of spellings above
+    // (`bin/pint` is rejected on purpose), so leave that ecosystem to its own
+    // normalization rather than widening it from here.
+    if php_tool {
+        return None;
+    }
+
+    rewrite_path_prefixed(strip_target, rule, &rewrite)
+}
+
+/// Match a command that names its binary by path (`.venv/bin/pytest`,
+/// `./node_modules/.bin/vitest`, `/usr/bin/grep`) and carry that path to the
+/// handler in `RTK_BIN`, so the rewrite runs the binary the caller chose
+/// instead of whatever PATH resolves (#1053).
+///
+/// Only reached once the literal prefixes have failed, so every command that
+/// rewrites today keeps its exact current output.
+///
+/// The path is preserved only when its basename is the tool rtk will re-invoke.
+/// `.venv/bin/python -m pytest` names python but routes to `rtk pytest`, and
+/// handing pytest a python path would resolve to the wrong binary, so those
+/// forms keep today's behavior of not rewriting at all.
+fn rewrite_path_prefixed(
+    cmd: &str,
+    rule: &RtkRule,
+    rewrite: &dyn Fn(&str) -> String,
+) -> Option<String> {
+    let normalized = strip_absolute_path(cmd);
+    if normalized == cmd {
+        return None;
+    }
+
+    let caller_bin = cmd.split_whitespace().next()?;
+    let tool = rule.rtk_cmd.strip_prefix("rtk ")?;
+    if caller_bin.rsplit('/').next() != Some(tool) {
+        return None;
+    }
+
+    let rest = rule
+        .rewrite_prefixes
+        .iter()
+        .find_map(|&prefix| strip_word_prefix(&normalized, prefix))?;
+
+    // Single-quote the path and escape embedded quotes the POSIX way, so an
+    // arbitrary directory name cannot break out of the assignment.
+    let quoted = caller_bin.replace('\'', "'\\''");
+    Some(format!("RTK_BIN='{}' {}", quoted, rewrite(rest)))
 }
 
 /// Strip a command prefix with word-boundary check.
@@ -5652,5 +5701,68 @@ mod tests {
             normalize_php_tool_command_with_dirs("./tools/bin/pest", &dirs),
             "pest"
         );
+    }
+
+    mod path_prefixed_invocations {
+        use super::rewrite_command_no_prefixes;
+
+        #[test]
+        fn test_rewrites_venv_binary_and_preserves_it() {
+            assert_eq!(
+                rewrite_command_no_prefixes(".venv/bin/pytest -v", &[]),
+                Some("RTK_BIN='.venv/bin/pytest' rtk pytest -v".into())
+            );
+            assert_eq!(
+                rewrite_command_no_prefixes(".venv/bin/ruff check .", &[]),
+                Some("RTK_BIN='.venv/bin/ruff' rtk ruff check .".into())
+            );
+        }
+
+        #[test]
+        fn test_rewrites_absolute_and_dot_slash_paths() {
+            assert_eq!(
+                rewrite_command_no_prefixes("/usr/bin/grep -rn foo", &[]),
+                Some("RTK_BIN='/usr/bin/grep' rtk grep -rn foo".into())
+            );
+            assert_eq!(
+                rewrite_command_no_prefixes("./node_modules/.bin/vitest run", &[]),
+                Some("RTK_BIN='./node_modules/.bin/vitest' rtk vitest".into())
+            );
+        }
+
+        #[test]
+        fn test_bare_command_carries_no_rtk_bin() {
+            assert_eq!(
+                rewrite_command_no_prefixes("pytest -v", &[]),
+                Some("rtk pytest -v".into())
+            );
+        }
+
+        #[test]
+        fn test_interpreter_form_is_left_alone() {
+            // The path names python but the rewrite routes to rtk pytest, so
+            // there is no binary to preserve and rewriting would run the wrong
+            // pytest. Leaving it unrewritten keeps the venv's interpreter.
+            assert_eq!(
+                rewrite_command_no_prefixes(".venv/bin/python -m pytest -v", &[]),
+                None
+            );
+        }
+
+        #[test]
+        fn test_quotes_are_escaped_in_the_preserved_path() {
+            assert_eq!(
+                rewrite_command_no_prefixes("./it's/bin/pytest -q", &[]),
+                Some(r"RTK_BIN='./it'\''s/bin/pytest' rtk pytest -q".into())
+            );
+        }
+
+        #[test]
+        fn test_unknown_tool_still_does_not_rewrite() {
+            assert_eq!(
+                rewrite_command_no_prefixes(".venv/bin/httpie GET /", &[]),
+                None
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Retry the rewrite match against the path-stripped command once the literal prefixes have failed, so `.venv/bin/pytest`, `./node_modules/.bin/vitest` and `/usr/bin/grep` stop falling out of the hook unfiltered
- Carry the caller's path in `RTK_BIN` so the handler runs the binary the user named instead of whatever PATH resolves
- Runs only as a fallback, so every command that rewrites today produces byte-identical output

Part 2 of 3 for #1053, and the part that fixes the reported bug. **Depends on #3590**, which must land first: without it the preserved path is emitted but ignored, which is the wrong-binary failure the issue warns about.

`rtk hook claude` rewrites `pytest -v`, but not `.venv/bin/pytest -v`. `classify_command` already normalizes the path when it decides the command is supported, and then the rewrite loop matches the literal prefixes against the raw token, which cannot start with `pytest`. Every path-prefixed invocation therefore falls out of the hook unfiltered: virtualenv binaries, `./node_modules/.bin`, and absolute `/usr/bin` paths alike.

This generalizes the normalization already merged for the Composer tools. `strip_target` handles the `php`/`vendor/bin` spellings today; `rewrite_path_prefixed()` does the same job for the other ecosystems. The Composer tools are explicitly left out of the new path, since they accept a deliberately narrow set of spellings (`bin/pint` is rejected on purpose) and widening that from here would break `test_rewrite_php_tool_invocation_forms`.

Two deliberate limits keep the blast radius at zero for commands that already work:

- The new matching runs **only after** the existing literal prefixes have failed, so any command that rewrites today is unchanged. `./gradlew` and `./vendor/bin/phpunit` are unaffected.
- The path is preserved **only when its basename is the tool rtk re-invokes**. `.venv/bin/python -m pytest` names python but routes to `rtk pytest`, so handing that path to pytest would resolve the wrong binary; those forms keep today's behavior of not rewriting. Covering them properly means teaching the python handlers about the interpreter, which belongs in its own PR.

The preserved path is single-quoted with POSIX `'\''` escaping, so a directory name containing a quote cannot break out of the assignment.

## Before / after

| command | before | after |
| --- | --- | --- |
| `pytest -v` | `rtk pytest -v` | unchanged |
| `.venv/bin/pytest -v` | no rewrite | `RTK_BIN='.venv/bin/pytest' rtk pytest -v` |
| `/usr/bin/grep -rn foo` | no rewrite | `RTK_BIN='/usr/bin/grep' rtk grep -rn foo` |
| `./node_modules/.bin/vitest run` | no rewrite | `RTK_BIN='./node_modules/.bin/vitest' rtk vitest` |
| `./gradlew assembleDebug` | `rtk gradlew assembleDebug` | unchanged |
| `.venv/bin/python -m pytest -v` | no rewrite | unchanged (see above) |

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] 6 new tests covering venv binaries, absolute and `./` paths, bare commands staying free of `RTK_BIN`, the interpreter form being left alone, quote escaping, and an unsupported tool still not rewriting
- [x] Full suite: 2600 passed on `develop`, 2607 with this branch (which includes #3590), with the same 9 failures in both (`cmds::cloud::curl_cmd`, `core::tracking`), which fail on unmodified `develop` in my environment. No existing expectation changed, which is the point of running the new matching only as a fallback.
- [x] Manual testing through the production hook: `echo '{"tool_name":"Bash","tool_input":{"command":".venv/bin/pytest -v"}}' | rtk hook claude` now returns `updatedInput.command` of `RTK_BIN='.venv/bin/pytest' rtk pytest -v`, where it previously returned nothing

Supersedes #1057 (same author, rebased onto current develop and split for review). Overlaps #1378, which takes the same `RTK_BIN` approach across more handlers; happy to fold this into that one if a maintainer prefers its scope.
