### PR TITLE
fix(cicd): stop benchmark.sh deleting the tracked scripts/benchmark harness

### DIFF
--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -13,9 +13,15 @@ fi
 BENCH_DIR="$(pwd)/scripts/benchmark"
 RTK_ROOT="$(pwd)"
 
+# Only the gitignored output subdirectories get wiped between local runs.
+# `$BENCH_DIR` itself is tracked — it also holds the TypeScript VM-benchmark
+# harness (run.ts, cleanup.ts, lib/) — so `rm -rf "$BENCH_DIR"` deleted that
+# harness from the working tree on every local run.
 if [ -z "$CI" ]; then
-  rm -rf "$BENCH_DIR"
-  mkdir -p "$BENCH_DIR/unix" "$BENCH_DIR/rtk" "$BENCH_DIR/diff"
+  for bench_output_dir in unix rtk diff; do
+    rm -rf "${BENCH_DIR:?}/$bench_output_dir"
+    mkdir -p "$BENCH_DIR/$bench_output_dir"
+  done
 fi
 
 safe_name() {


### PR DESCRIPTION
## Summary

- `scripts/benchmark.sh` deleted the **tracked** `scripts/benchmark/` TypeScript VM-benchmark harness from the working tree on every local run.
- Wipe only the three gitignored output subdirectories (`unix/`, `rtk/`, `diff/`) instead of the whole `$BENCH_DIR`.

Follow-up to #3430 — @KuSh asked for this in the merge comment.

## Problem

```sh
BENCH_DIR="$(pwd)/scripts/benchmark"

if [ -z "$CI" ]; then
  rm -rf "$BENCH_DIR"
  mkdir -p "$BENCH_DIR/unix" "$BENCH_DIR/rtk" "$BENCH_DIR/diff"
fi
```

`.gitignore` only ignores the three *output* subdirectories:

```
scripts/benchmark/diff/
scripts/benchmark/rtk/
scripts/benchmark/unix/
```

`$BENCH_DIR` itself is tracked and also holds the VM-benchmark harness — `run.ts`, `cleanup.ts`, `rebuild.ts`, `lib/report.ts`, `lib/test.ts`, `lib/vm.ts`, `cloud-init.yaml`. So `rm -rf "$BENCH_DIR"` removed all 7 of them.

The guard is `[ -z "$CI" ]`, so CI never hits it (fresh checkout anyway) — it only fires **locally**, i.e. exactly when a contributor runs the benchmark before pushing.

## Test verification (RED → GREEN)

There is no shell test harness in this repo, so this is a real observed run of the setup block against a clean checkout.

**RED** — on unmodified `develop` (`ba7a9ce`):

```text
tracked files before: 7 / present on disk: 7
tracked files after:  7 / present on disk: 0
git status:
   D scripts/benchmark/cleanup.ts
   D scripts/benchmark/cloud-init.yaml
   D scripts/benchmark/lib/report.ts
   D scripts/benchmark/lib/test.ts
   D scripts/benchmark/lib/vm.ts
   D scripts/benchmark/rebuild.ts
   D scripts/benchmark/run.ts
output dirs created: scripts/benchmark/diff scripts/benchmark/rtk scripts/benchmark/unix
```

**GREEN** — with this patch:

```text
tracked files before: 7 / present on disk: 7
tracked files after:  7 / present on disk: 7
git status:
output dirs created: scripts/benchmark/diff scripts/benchmark/rtk scripts/benchmark/unix
```

Stale output is still cleared — seeded a `STALE.md` in each of the three output dirs, ran the block again:

```text
stale files left: 0
tracked harness intact: 7/7
```

Full local CI replay, `CI` deliberately unset so the local path is the one exercised:

| job | `develop` (ba7a9ce) | this branch |
|---|---|---|
| test presence | PASS | PASS |
| fmt | PASS | PASS |
| clippy | PASS | PASS |
| test (`--all`) | PASS | PASS |
| build release | PASS | PASS |
| benchmark | `34 good / 27 warn / 0 negative / 1 fail` | `34 good / 27 warn / 0 negative / 1 fail` |
| **tracked harness surviving the run** | **0/7** | **7/7** |

The benchmark's single remaining `❌` (empty output) is pre-existing and identical on `develop`.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets -- -D warnings && cargo test --all`
- [x] `./scripts/benchmark.sh` with `CI` unset — harness intact afterwards
