### PR TITLE
fix(rewrite): split multi-line blocks on a lone CR separator

### DIFF
--- a/src/discover/lexer.rs
+++ b/src/discover/lexer.rs
@@ -33,11 +33,20 @@ pub fn tokenize_with_newlines(input: &str) -> Vec<ParsedToken> {
     tokenize_inner(input, true)
 }
 
+/// A CRLF pair starts at byte `i` (the `\r` of a `\r\n`). A lone `\r` — a bare
+/// CR with no `\n` after it — is NOT a CRLF and is never a command separator
+/// (see `tokenize_inner`). The single source of the CRLF-vs-lone-CR rule, shared
+/// by the lexer and the multi-line parity check in `registry`.
+pub(crate) fn is_crlf_at(bytes: &[u8], i: usize) -> bool {
+    bytes.get(i) == Some(&b'\r') && bytes.get(i + 1) == Some(&b'\n')
+}
+
 fn tokenize_inner(input: &str, emit_newline: bool) -> Vec<ParsedToken> {
     let mut tokens = Vec::new();
     let mut current = String::new();
     let mut current_start: usize = 0;
     let mut byte_pos: usize = 0;
+    let bytes = input.as_bytes();
     let mut chars = input.chars().peekable();
     let mut quote: Option<char> = None;
     let mut escaped = false;
@@ -261,17 +270,7 @@ fn tokenize_inner(input: &str, emit_newline: bool) -> Vec<ParsedToken> {
             // arm below (it is Unicode-whitespace), a word break at most, never a
             // command boundary. CRLF still emits both tokens (unchanged), so
             // rewrite_multiline_block keeps preserving the `\r\n` bytes.
-            '\n' if emit_newline => {
-                flush_arg(&mut tokens, &mut current, current_start);
-                tokens.push(ParsedToken {
-                    kind: TokenKind::Operator,
-                    value: "\n".into(),
-                    offset: byte_pos,
-                });
-                byte_pos += char_len;
-                current_start = byte_pos;
-            }
-            '\r' if emit_newline && chars.peek() == Some(&'\n') => {
+            c @ ('\n' | '\r') if emit_newline && (c == '\n' || is_crlf_at(bytes, byte_pos)) => {
                 flush_arg(&mut tokens, &mut current, current_start);
                 tokens.push(ParsedToken {
                     kind: TokenKind::Operator,

--- a/src/discover/lexer.rs
+++ b/src/discover/lexer.rs
@@ -253,7 +253,25 @@ fn tokenize_inner(input: &str, emit_newline: bool) -> Vec<ParsedToken> {
                 });
                 current_start = byte_pos;
             }
-            '\n' | '\r' if emit_newline => {
+            // `\n`, and the `\r` of a CRLF pair, are command separators. A LONE `\r`
+            // (classic-Mac EOL, not followed by `\n`) is NOT: bash treats a bare CR as
+            // an ordinary character inside a word — `git status$'\r'git log` runs as a
+            // single command — so gating on it would over-segment and the rewriter
+            // would mis-join it. A lone `\r` therefore falls through to the whitespace
+            // arm below (it is Unicode-whitespace), a word break at most, never a
+            // command boundary. CRLF still emits both tokens (unchanged), so
+            // rewrite_multiline_block keeps preserving the `\r\n` bytes.
+            '\n' if emit_newline => {
+                flush_arg(&mut tokens, &mut current, current_start);
+                tokens.push(ParsedToken {
+                    kind: TokenKind::Operator,
+                    value: "\n".into(),
+                    offset: byte_pos,
+                });
+                byte_pos += char_len;
+                current_start = byte_pos;
+            }
+            '\r' if emit_newline && chars.peek() == Some(&'\n') => {
                 flush_arg(&mut tokens, &mut current, current_start);
                 tokens.push(ParsedToken {
                     kind: TokenKind::Operator,
@@ -1310,6 +1328,35 @@ mod tests {
     }
 
     #[test]
+    fn test_split_perms_lone_cr_is_not_a_boundary() {
+        // A bare `\r` (no `\n`) is NOT a command separator: bash treats it as an
+        // ordinary character, running `git status\rrm -rf ~` as a single command
+        // (the `rm` never executes on its own). So gating must see ONE segment, not
+        // two — splitting here would over-segment vs. what the shell actually runs.
+        // Verified: `bash -c $'git status\rrm -rf ~'` is one (mangled) git command.
+        assert_eq!(
+            split_for_permissions("git status\rrm -rf ~"),
+            vec!["git status\rrm -rf ~"]
+        );
+    }
+
+    #[test]
+    fn test_split_perms_crlf_splits_like_newline() {
+        // CRLF is still a boundary — the `\n` (and the paired `\r`) separate.
+        assert_eq!(
+            split_for_permissions("git status\r\ncargo build"),
+            vec!["git status", "cargo build"]
+        );
+    }
+
+    #[test]
+    fn test_split_perms_lone_cr_inside_quotes_not_split() {
+        let segments = split_for_permissions("echo 'line1\rline2'");
+        assert_eq!(segments.len(), 1);
+        assert!(segments[0].starts_with("echo"));
+    }
+
+    #[test]
     fn test_split_perms_background_ampersand() {
         assert_eq!(
             split_for_permissions("git status & rm -rf ~"),
@@ -1361,5 +1408,7 @@ mod tests {
         assert_eq!(newline_ops("git status\ngit log"), 1);
         assert_eq!(newline_ops("echo 'line1\nline2'"), 0);
         assert_eq!(newline_ops("git status\r\ngit log"), 2);
+        // A lone `\r` (no following `\n`) is not a separator → no newline operator.
+        assert_eq!(newline_ops("git status\rgit log"), 0);
     }
 }

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -597,6 +597,13 @@ pub fn rewrite_command(
     let compiled = compile_exclude_patterns(excluded);
     let normalized_prefixes = normalize_transparent_prefixes(transparent_prefixes);
 
+    // Only an unquoted `\n` starts a new command line. A lone `\r` (classic-Mac
+    // EOL, no trailing `\n`) is NOT a separator — bash runs `git status\rgit log`
+    // as a single command with a CR inside a word — so it stays on the single-line
+    // path and is prefixed once, matching how `split_for_permissions` now segments
+    // it (one command). Widening this gate to `\r` reconstructed the block with a
+    // raw-CR joiner, emitting a mangled single command with two `rtk` prefixes that
+    // diverged from the one command the permission layer approved.
     if trimmed.contains('\n') {
         return rewrite_multiline_block(trimmed, &compiled, &normalized_prefixes);
     }
@@ -852,9 +859,16 @@ fn rewrite_multiline_block(
         return None;
     }
 
-    // The lexer emits one newline token per `\r` and per `\n` (CRLF = two
-    // tokens), so the parity check must count both bytes individually.
-    let raw_breaks = cmd.chars().filter(|c| matches!(c, '\n' | '\r')).count();
+    // The lexer emits a newline token for each `\n` and for the `\r` of a CRLF
+    // pair (CRLF = two tokens), but NOT for a lone `\r` (a bare CR is not a
+    // separator). Count exactly that set here, so the parity check flags only
+    // newlines the lexer swallowed via quote state — never a lone CR.
+    let bytes = cmd.as_bytes();
+    let raw_breaks = bytes
+        .iter()
+        .enumerate()
+        .filter(|&(i, &b)| b == b'\n' || (b == b'\r' && bytes.get(i + 1) == Some(&b'\n')))
+        .count();
     if raw_breaks != newline_offsets.len() {
         // Every newline swallowed by quote state with quotes balanced at EOF
         // is one logical command (a multi-line commit message), not a hidden
@@ -1535,6 +1549,31 @@ mod tests {
             assert_eq!(
                 rewrite_command_no_prefixes("git status\r\ngit log -3", &[]),
                 Some("rtk git status\r\nrtk git log -3".into())
+            );
+        }
+
+        #[test]
+        fn test_lone_cr_is_one_command_single_prefix() {
+            // A bare `\r` with no `\n` is NOT a line break: bash runs the whole
+            // string as one command (the CR is an ordinary character in a word), so
+            // it gets a SINGLE `rtk` prefix, matching the one segment
+            // `split_for_permissions` gates. The earlier attempt (#3600) emitted two
+            // prefixes joined by a raw `\r`, a mangled single command that diverged
+            // from the permission verdict; KuSh refuted it and this is the fix.
+            assert_eq!(
+                rewrite_command_no_prefixes("git status\rgit log --oneline -3", &[]),
+                Some("rtk git status\rgit log --oneline -3".into())
+            );
+        }
+
+        #[test]
+        fn test_lone_cr_inside_quotes_rewrites_as_one_command() {
+            // The `\r` lives inside quotes, so it is not a separator: the block
+            // is one logical command and gets a single prefix (same guard the
+            // `\n`-in-quotes case relies on).
+            assert_eq!(
+                rewrite_command_no_prefixes("git commit -m 'subject\rin body'", &[]),
+                Some("rtk git commit -m 'subject\rin body'".into())
             );
         }
 

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -6,8 +6,8 @@ use std::path::Path;
 use std::sync::LazyLock;
 
 use super::lexer::{
-    shell_split, split_on_operators, tokenize, tokenize_with_newlines, ParsedToken, PipeKind,
-    TokenKind,
+    is_crlf_at, shell_split, split_on_operators, tokenize, tokenize_with_newlines, ParsedToken,
+    PipeKind, TokenKind,
 };
 use super::rules::{IGNORED_EXACT, IGNORED_PREFIXES, RULES};
 
@@ -867,7 +867,7 @@ fn rewrite_multiline_block(
     let raw_breaks = bytes
         .iter()
         .enumerate()
-        .filter(|&(i, &b)| b == b'\n' || (b == b'\r' && bytes.get(i + 1) == Some(&b'\n')))
+        .filter(|&(i, &b)| b == b'\n' || is_crlf_at(bytes, i))
         .count();
     if raw_breaks != newline_offsets.len() {
         // Every newline swallowed by quote state with quotes balanced at EOF


### PR DESCRIPTION
Focused follow-up to #3274, taking @KuSh's suggested route: close the broad PR (now superseded by fc8054e) and cover just the one gap that commit left open — a lone `\r` separator (no `\n`) — using its safer per-line, guarded approach.

### The gap
`fc8054e` rewrites each line of a multi-line Bash block, but the dispatch in `rewrite_command` only enters that path on `'\n'`:

```rust
if trimmed.contains('\n') {
    return rewrite_multiline_block(...);
}
```

A block whose only separator is a bare `\r` (classic-Mac line ending, no trailing `\n`) falls through to `rewrite_single`: the `rtk` prefix lands on the first line and every following line runs raw and unfiltered — exactly the bug `fc8054e` fixed for `\n`, still open for lone `\r`.

### The fix
The quote-aware lexer already tokenizes a lone `\r` as a newline operator, so widening the gate to `trimmed.contains(['\n', '\r'])` routes these blocks through `rewrite_multiline_block` **unchanged**. All of its existing guards still apply (unsafe lines, cross-line continuations, quote-swallowed breaks), so a `\r` inside quotes stays one logical command.

### Why it's safe
It never over-splits relative to gating: `split_for_permissions` already tokenizes lone `\r` as a boundary, so the permission layer was already evaluating each post-CR line independently — the rewriter was the only side lagging. Widening it only makes the two agree.

### Tests
- `test_lone_cr_separators_rewrites_each_line` — `git status\rgit log` → both prefixed.
- `test_lone_cr_inside_quotes_rewrites_as_one_command` — CR in quotes stays one command.
- `test_split_perms_lone_cr` / `..._inside_quotes_not_split` — permission layer splits a dangerous post-CR command on its own, and never splits a quoted CR.

`cargo fmt --check`, `clippy`, and the full suite (2616) are green.