### PR TITLE
fix(find): never-worse guard, recovery hint, and dispatch on find's grammar

### DIFF
--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -188,7 +188,7 @@ fn passthrough_raw_find(args: &[String], verbose: u8) -> Result<()> {
     let mut cmd = crate::core::utils::resolved_command("find");
     cmd.args(args);
     let captured =
-        crate::core::stream::exec_capture(&mut cmd).context("Failed to execute find")?;
+        crate::core::stream::exec_capture_stdin(&mut cmd).context("Failed to execute find")?;
     print!("{}", captured.stdout);
     eprint!("{}", captured.stderr);
     timer.track_passthrough(&format!("find {}", args.join(" ")), "rtk find (passthrough)");

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -32,6 +32,7 @@ struct FindArgs {
     pattern: String,
     path: String,
     max_results: usize,
+    max_explicit: bool,
     max_depth: Option<usize>,
     file_type: String,
     case_insensitive: bool,
@@ -43,6 +44,7 @@ impl Default for FindArgs {
             pattern: "*".to_string(),
             path: ".".to_string(),
             max_results: 50,
+            max_explicit: false,
             max_depth: None,
             file_type: "f".to_string(),
             case_insensitive: false,
@@ -162,6 +164,7 @@ fn parse_rtk_find_args(args: &[String]) -> Result<FindArgs> {
             "-m" | "--max" => {
                 if let Some(val) = next_arg(args, &mut i) {
                     parsed.max_results = val.parse().context("invalid --max value")?;
+                    parsed.max_explicit = true;
                 }
             }
             "-t" | "--file-type" => {
@@ -184,6 +187,7 @@ pub fn run_from_args(args: &[String], verbose: u8) -> Result<()> {
         &parsed.pattern,
         &parsed.path,
         parsed.max_results,
+        parsed.max_explicit,
         parsed.max_depth,
         &parsed.file_type,
         parsed.case_insensitive,
@@ -205,10 +209,12 @@ fn build_capped_listing(files: &[String], max_results: usize) -> String {
     listing
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn run(
     pattern: &str,
     path: &str,
     max_results: usize,
+    max_explicit: bool,
     max_depth: Option<usize>,
     file_type: &str,
     case_insensitive: bool,
@@ -388,12 +394,20 @@ pub fn run(
 
     let capped_raw = build_capped_listing(&files, max_results);
     let shown = never_worse(&capped_raw, &body);
-    print!("{}", shown);
+    let mut output = shown.to_string();
+    if displayed < total_files && !max_explicit {
+        if let Some(hint) =
+            crate::core::tee::force_tee_tail_hint(&raw_output, "find", displayed + 1)
+        {
+            output.push_str(&format!("{}\n", hint));
+        }
+    }
+    print!("{}", output);
     timer.track(
         &format!("find {} -name '{}'", path, effective_pattern),
         "rtk find",
         &raw_output,
-        shown,
+        &output,
     );
 
     Ok(())
@@ -584,14 +598,14 @@ mod tests {
     #[test]
     fn find_dotfile_pattern_includes_hidden() {
         // .gitignore exists at the repo root — must be found when using a dotfile pattern
-        let result = run(".gitignore", ".", 50, Some(1), "f", false, 0);
+        let result = run(".gitignore", ".", 50, true, Some(1), "f", false, 0);
         assert!(result.is_ok(), "run with dotfile pattern should not error");
     }
 
     #[test]
     fn find_regular_pattern_skips_hidden() {
         // Non-dot pattern should not error (hidden dirs remain skipped)
-        let result = run("*.rs", "src", 5, None, "f", false, 0);
+        let result = run("*.rs", "src", 5, true, None, "f", false, 0);
         assert!(result.is_ok());
     }
 
@@ -600,28 +614,50 @@ mod tests {
     #[test]
     fn find_rs_files_in_src() {
         // Should find .rs files without error
-        let result = run("*.rs", "src", 100, None, "f", false, 0);
+        let result = run("*.rs", "src", 100, true, None, "f", false, 0);
         assert!(result.is_ok());
     }
 
     #[test]
     fn find_dot_pattern_works() {
         // "." pattern should not error (was broken before)
-        let result = run(".", "src", 10, None, "f", false, 0);
+        let result = run(".", "src", 10, true, None, "f", false, 0);
         assert!(result.is_ok());
     }
 
     #[test]
     fn find_no_matches() {
-        let result = run("*.xyz_nonexistent", "src", 50, None, "f", false, 0);
+        let result = run("*.xyz_nonexistent", "src", 50, true, None, "f", false, 0);
         assert!(result.is_ok());
     }
 
     #[test]
     fn find_respects_max() {
         // With max=2, should not error
-        let result = run("*.rs", "src", 2, None, "f", false, 0);
+        let result = run("*.rs", "src", 2, true, None, "f", false, 0);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn rtk_max_flag_marks_cap_explicit() {
+        let parsed = parse_find_args(&args(&["*.rs", "-m", "10"])).unwrap();
+        assert!(parsed.max_explicit);
+        let parsed = parse_find_args(&args(&["*.rs", "--max", "10"])).unwrap();
+        assert!(parsed.max_explicit);
+    }
+
+    #[test]
+    fn native_syntax_cap_stays_implicit() {
+        let parsed = parse_find_args(&args(&[".", "-name", "*.rs", "-type", "f"])).unwrap();
+        assert!(!parsed.max_explicit);
+    }
+
+    #[test]
+    fn default_cap_stays_implicit() {
+        let parsed = parse_find_args(&args(&[])).unwrap();
+        assert!(!parsed.max_explicit);
+        let parsed = parse_find_args(&args(&["*.rs", "src"])).unwrap();
+        assert!(!parsed.max_explicit);
     }
 
     #[test]
@@ -654,7 +690,7 @@ mod tests {
     #[test]
     fn find_gitignored_excluded() {
         // target/ is in .gitignore — files inside should not appear
-        let result = run("*", ".", 1000, None, "f", false, 0);
+        let result = run("*", ".", 1000, true, None, "f", false, 0);
         assert!(result.is_ok());
         // We can't easily capture stdout in unit tests, but at least
         // verify it runs without error. The smoke tests verify content.

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -5,6 +5,7 @@ use crate::core::tracking;
 use anyhow::{Context, Result};
 use ignore::WalkBuilder;
 use std::collections::HashMap;
+use std::io::Write;
 use std::path::Path;
 
 /// Match a filename against a glob pattern (supports `*` and `?`).
@@ -186,14 +187,18 @@ fn passthrough_raw_find(args: &[String], verbose: u8) -> Result<()> {
         eprintln!("find: passthrough (flags rtk cannot filter)");
     }
     let mut cmd = crate::core::utils::resolved_command("find");
-    cmd.args(args);
-    let captured =
-        crate::core::stream::exec_capture_stdin(&mut cmd).context("Failed to execute find")?;
-    print!("{}", captured.stdout);
-    eprint!("{}", captured.stderr);
+    cmd.args(args).stdin(std::process::Stdio::inherit());
+    let output = cmd.output().context("Failed to execute find")?;
+    let exit_code = crate::core::utils::exit_code_from_output(&output, "find");
+    let mut stdout = std::io::stdout().lock();
+    stdout.write_all(&output.stdout)?;
+    stdout.flush()?;
+    let mut stderr = std::io::stderr().lock();
+    stderr.write_all(&output.stderr)?;
+    stderr.flush()?;
     timer.track_passthrough(&format!("find {}", args.join(" ")), "rtk find (passthrough)");
-    if captured.exit_code != 0 {
-        std::process::exit(captured.exit_code);
+    if exit_code != 0 {
+        std::process::exit(exit_code);
     }
     Ok(())
 }

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -526,23 +526,9 @@ fn render(
         }
 
         let files_in_dir = &by_dir[dir];
-        let dir_display = if dir.chars().count() > 50 {
-            let tail: String = dir
-                .chars()
-                .rev()
-                .take(47)
-                .collect::<Vec<_>>()
-                .into_iter()
-                .rev()
-                .collect();
-            format!("...{}", tail)
-        } else {
-            dir.clone()
-        };
-
         let remaining_budget = max_results - displayed;
         if files_in_dir.len() <= remaining_budget {
-            body.push_str(&format!("{}/ {}\n", dir_display, files_in_dir.join(" ")));
+            body.push_str(&format!("{}/ {}\n", dir, files_in_dir.join(" ")));
             displayed += files_in_dir.len();
         } else {
             // Partial display: show only what fits in budget
@@ -551,7 +537,7 @@ fn render(
                 .take(remaining_budget)
                 .cloned()
                 .collect();
-            body.push_str(&format!("{}/ {}\n", dir_display, partial.join(" ")));
+            body.push_str(&format!("{}/ {}\n", dir, partial.join(" ")));
             displayed += partial.len();
             break;
         }

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -60,45 +60,129 @@ fn next_arg(args: &[String], i: &mut usize) -> Option<String> {
     args.get(*i).cloned()
 }
 
-/// Check if args contain native find flags (-name, -type, -maxdepth, etc.)
-fn has_native_find_flags(args: &[String]) -> bool {
-    args.iter()
-        .any(|a| a == "-name" || a == "-type" || a == "-maxdepth" || a == "-iname")
-}
+const RTK_FLAGS: &[&str] = &["-m", "--max", "-t", "--file-type"];
 
-/// Native find flags that RTK cannot handle correctly.
-/// These involve compound predicates, actions, or semantics we don't support.
-const UNSUPPORTED_FIND_FLAGS: &[&str] = &[
-    "-not", "!", "-or", "-o", "-and", "-a", "-exec", "-execdir", "-delete", "-print0", "-newer",
-    "-perm", "-size", "-mtime", "-mmin", "-atime", "-amin", "-ctime", "-cmin", "-empty", "-link",
-    "-regex", "-iregex",
+const VERBATIM_ACTIONS: &[&str] = &[
+    "-exec", "-execdir", "-ok", "-okdir", "-delete", "-print", "-print0", "-printf", "-fprint",
+    "-fprint0", "-fprintf", "-ls", "-fls",
 ];
 
-fn has_unsupported_find_flags(args: &[String]) -> bool {
-    args.iter()
-        .any(|a| UNSUPPORTED_FIND_FLAGS.contains(&a.as_str()))
+enum Dispatch {
+    Native(FindArgs),
+    Compress {
+        paths: Vec<String>,
+        expr: Vec<String>,
+        max_results: usize,
+        max_explicit: bool,
+    },
+    Verbatim,
 }
 
-/// Parse arguments from raw args vec, supporting both native find and RTK syntax.
-///
-/// Native find syntax: `find . -name "*.rs" -type f -maxdepth 3`
-/// RTK syntax: `find *.rs [path] [-m max] [-t type]`
-fn parse_find_args(args: &[String]) -> Result<FindArgs> {
+fn is_expression_token(token: &str) -> bool {
+    token.starts_with('-') || token == "!" || token == "(" || token == ")"
+}
+
+fn has_glob_meta(token: &str) -> bool {
+    token.contains('*') || token.contains('?')
+}
+
+fn subset_only(expr: &[String]) -> bool {
+    let mut i = 0;
+    while i < expr.len() {
+        match expr[i].as_str() {
+            "-name" | "-iname" => match expr.get(i + 1) {
+                Some(v) if !v.contains('[') => i += 2,
+                _ => return false,
+            },
+            "-type" => match expr.get(i + 1).map(String::as_str) {
+                Some("f") | Some("d") => i += 2,
+                _ => return false,
+            },
+            "-maxdepth" => match expr.get(i + 1) {
+                Some(v) if v.parse::<usize>().is_ok() => i += 2,
+                _ => return false,
+            },
+            _ => return false,
+        }
+    }
+    true
+}
+
+/// Native find syntax: `find [paths...] [expression]` (paths end at the first
+/// token starting with `-`, `!` or a parenthesis, exactly like find).
+/// RTK syntax (first token contains `*` or `?`): `find <pattern> [path] [-m max] [-t type]`
+fn dispatch(args: &[String]) -> Result<Dispatch> {
     if args.is_empty() {
-        return Ok(FindArgs::default());
+        return Ok(Dispatch::Native(FindArgs::default()));
+    }
+    if !is_expression_token(&args[0]) && has_glob_meta(&args[0]) {
+        return parse_rtk_find_args(args).map(Dispatch::Native);
     }
 
-    if has_unsupported_find_flags(args) {
-        anyhow::bail!(
-            "rtk find does not support compound predicates or actions (e.g. -not, -exec). Use `find` directly."
-        );
+    let split = args
+        .iter()
+        .position(|t| is_expression_token(t))
+        .unwrap_or(args.len());
+    let paths = args[..split].to_vec();
+    let expr = &args[split..];
+
+    if expr.iter().any(|t| VERBATIM_ACTIONS.contains(&t.as_str())) {
+        if expr.iter().any(|t| RTK_FLAGS.contains(&t.as_str())) {
+            anyhow::bail!(
+                "rtk find: -m/-t cannot be combined with find actions (-exec, -delete, -print0, ...)"
+            );
+        }
+        return Ok(Dispatch::Verbatim);
     }
 
-    if has_native_find_flags(args) {
-        parse_native_find_args(args)
-    } else {
-        parse_rtk_find_args(args)
+    let mut find_expr: Vec<String> = Vec::new();
+    let mut max_results = FindArgs::default().max_results;
+    let mut max_explicit = false;
+    let mut rtk_type: Option<String> = None;
+    let mut i = 0;
+    while i < expr.len() {
+        match expr[i].as_str() {
+            "-m" | "--max" => {
+                let v = expr.get(i + 1).context("missing value for --max")?;
+                max_results = v.parse().context("invalid --max value")?;
+                max_explicit = true;
+                i += 2;
+            }
+            "-t" | "--file-type" => {
+                let v = expr.get(i + 1).context("missing value for --file-type")?;
+                rtk_type = Some(v.clone());
+                i += 2;
+            }
+            _ => {
+                find_expr.push(expr[i].clone());
+                i += 1;
+            }
+        }
     }
+    if let Some(t) = rtk_type {
+        find_expr.push("-type".to_string());
+        find_expr.push(t);
+    }
+
+    if paths.len() <= 1 && subset_only(&find_expr) {
+        let mut native_args = paths.clone();
+        native_args.extend(find_expr.iter().cloned());
+        let mut parsed = if native_args.is_empty() {
+            FindArgs::default()
+        } else {
+            parse_native_find_args(&native_args)?
+        };
+        parsed.max_results = max_results;
+        parsed.max_explicit = max_explicit;
+        return Ok(Dispatch::Native(parsed));
+    }
+
+    Ok(Dispatch::Compress {
+        paths,
+        expr: find_expr,
+        max_results,
+        max_explicit,
+    })
 }
 
 /// Parse native find syntax: `find [path] -name "*.rs" -type f -maxdepth 3`
@@ -173,7 +257,12 @@ fn parse_rtk_find_args(args: &[String]) -> Result<FindArgs> {
                     parsed.file_type = val;
                 }
             }
-            _ => {}
+            other => anyhow::bail!(
+                "rtk find: '{}' is not supported after a pattern; use find syntax: find <path> -name '{}' {} ...",
+                other,
+                parsed.pattern,
+                other
+            ),
         }
         i += 1;
     }
@@ -181,10 +270,10 @@ fn parse_rtk_find_args(args: &[String]) -> Result<FindArgs> {
     Ok(parsed)
 }
 
-fn passthrough_raw_find(args: &[String], verbose: u8) -> Result<()> {
+fn run_verbatim(args: &[String], verbose: u8) -> Result<()> {
     let timer = tracking::TimedExecution::start();
     if verbose > 0 {
-        eprintln!("find: passthrough (flags rtk cannot filter)");
+        eprintln!("find: verbatim (find actions produce non-listing output)");
     }
     let mut cmd = crate::core::utils::resolved_command("find");
     cmd.args(args).stdin(std::process::Stdio::inherit());
@@ -203,22 +292,82 @@ fn passthrough_raw_find(args: &[String], verbose: u8) -> Result<()> {
     Ok(())
 }
 
-/// Entry point from main.rs — parses raw args then delegates to run().
-pub fn run_from_args(args: &[String], verbose: u8) -> Result<()> {
-    if has_unsupported_find_flags(args) {
-        return passthrough_raw_find(args, verbose);
+fn run_compress(
+    paths: &[String],
+    expr: &[String],
+    max_results: usize,
+    max_explicit: bool,
+    verbose: u8,
+) -> Result<()> {
+    let timer = tracking::TimedExecution::start();
+    if verbose > 0 {
+        eprintln!("find: results from find, compressed by rtk");
     }
-    let parsed = parse_find_args(args)?;
-    run(
-        &parsed.pattern,
-        &parsed.path,
-        parsed.max_results,
-        parsed.max_explicit,
-        parsed.max_depth,
-        &parsed.file_type,
-        parsed.case_insensitive,
-        verbose,
-    )
+    let mut cmd = crate::core::utils::resolved_command("find");
+    cmd.args(paths);
+    if !expr.is_empty() {
+        cmd.arg("(");
+        cmd.args(expr);
+        cmd.arg(")");
+    }
+    cmd.arg("-print0").stdin(std::process::Stdio::inherit());
+    let output = cmd.output().context("Failed to execute find")?;
+    let exit_code = crate::core::utils::exit_code_from_output(&output, "find");
+    {
+        let mut stderr = std::io::stderr().lock();
+        stderr.write_all(&output.stderr)?;
+        stderr.flush()?;
+    }
+    let entries: Vec<&[u8]> = output
+        .stdout
+        .split(|b| *b == 0)
+        .filter(|s| !s.is_empty())
+        .collect();
+    let track_cmd = format!("find {} {}", paths.join(" "), expr.join(" "));
+    if entries.iter().any(|e| std::str::from_utf8(e).is_err()) {
+        let raw: Vec<u8> = entries.iter().flat_map(|e| [*e, b"\n"].concat()).collect();
+        let mut stdout = std::io::stdout().lock();
+        stdout.write_all(&raw)?;
+        stdout.flush()?;
+        timer.track_passthrough(&track_cmd, "rtk find (passthrough)");
+    } else {
+        let files: Vec<String> = entries
+            .iter()
+            .map(|e| {
+                let s = String::from_utf8_lossy(e);
+                s.strip_prefix("./").unwrap_or(&s).to_string()
+            })
+            .collect();
+        let raw_output = files.join("\n");
+        render(files, max_results, max_explicit, &track_cmd, &raw_output, &timer);
+    }
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
+    Ok(())
+}
+
+/// Entry point from main.rs — dispatches on find's grammar then delegates.
+pub fn run_from_args(args: &[String], verbose: u8) -> Result<()> {
+    match dispatch(args)? {
+        Dispatch::Native(parsed) => run(
+            &parsed.pattern,
+            &parsed.path,
+            parsed.max_results,
+            parsed.max_explicit,
+            parsed.max_depth,
+            &parsed.file_type,
+            parsed.case_insensitive,
+            verbose,
+        ),
+        Dispatch::Compress {
+            paths,
+            expr,
+            max_results,
+            max_explicit,
+        } => run_compress(&paths, &expr, max_results, max_explicit, verbose),
+        Dispatch::Verbatim => run_verbatim(args, verbose),
+    }
 }
 
 fn group_by_dir(files: &[String]) -> HashMap<String, Vec<String>> {
@@ -292,6 +441,11 @@ pub fn run(
 
     let want_dirs = file_type == "d";
 
+    if !Path::new(path).exists() {
+        eprintln!("find: '{}': No such file or directory", path);
+        std::process::exit(1);
+    }
+
     // When the pattern targets dotfiles (e.g. -name ".claude.json"), we must walk hidden
     // entries; otherwise skip them to keep results tidy (#1101).
     let search_hidden = effective_pattern.starts_with('.');
@@ -352,21 +506,41 @@ pub fn run(
 
         if !display_path.is_empty() {
             files.push(display_path);
+        } else if !is_dir {
+            files.push(path.to_string());
         }
     }
 
+    let raw_output = {
+        let mut sorted = files.clone();
+        sorted.sort();
+        sorted.join("\n")
+    };
+    render(
+        files,
+        max_results,
+        max_explicit,
+        &format!("find {} -name '{}'", path, effective_pattern),
+        &raw_output,
+        &timer,
+    );
+
+    Ok(())
+}
+
+fn render(
+    mut files: Vec<String>,
+    max_results: usize,
+    max_explicit: bool,
+    track_cmd: &str,
+    raw_output: &str,
+    timer: &tracking::TimedExecution,
+) {
     files.sort();
 
-    let raw_output = files.join("\n");
-
     if files.is_empty() {
-        timer.track(
-            &format!("find {} -name '{}'", path, effective_pattern),
-            "rtk find",
-            &raw_output,
-            "",
-        );
-        return Ok(());
+        timer.track(track_cmd, "rtk find", raw_output, "");
+        return;
     }
 
     let ordered = display_ordered(&files);
@@ -389,8 +563,9 @@ pub fn run(
         }
 
         let files_in_dir = &by_dir[dir];
-        let dir_display = if dir.len() > 50 {
-            format!("...{}", &dir[dir.len() - 47..])
+        let dir_display = if dir.chars().count() > 50 {
+            let tail: String = dir.chars().rev().take(47).collect::<Vec<_>>().into_iter().rev().collect();
+            format!("...{}", tail)
         } else {
             dir.clone()
         };
@@ -450,14 +625,7 @@ pub fn run(
         }
     }
     print!("{}", output);
-    timer.track(
-        &format!("find {} -name '{}'", path, effective_pattern),
-        "rtk find",
-        &raw_output,
-        &output,
-    );
-
-    Ok(())
+    timer.track(track_cmd, "rtk find", raw_output, &output);
 }
 
 #[cfg(test)]
@@ -467,6 +635,119 @@ mod tests {
     /// Convert string slices to Vec<String> for test convenience.
     fn args(values: &[&str]) -> Vec<String> {
         values.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn parse_find_args(a: &[String]) -> Result<FindArgs> {
+        match dispatch(a)? {
+            Dispatch::Native(p) => Ok(p),
+            Dispatch::Compress { .. } => anyhow::bail!("dispatched to compress"),
+            Dispatch::Verbatim => anyhow::bail!("dispatched to verbatim"),
+        }
+    }
+
+    fn class(a: &[&str]) -> &'static str {
+        match dispatch(&args(a)) {
+            Ok(Dispatch::Native(_)) => "native",
+            Ok(Dispatch::Compress { .. }) => "compress",
+            Ok(Dispatch::Verbatim) => "verbatim",
+            Err(_) => "error",
+        }
+    }
+
+    #[test]
+    fn bare_directory_positional_is_a_path() {
+        for a in [&["src"][..], &["src/"], &["./src"], &["/tmp"], &["."]] {
+            let p = parse_find_args(&args(a)).unwrap();
+            assert_eq!(p.path, a[0], "{a:?}");
+            assert_eq!(p.pattern, "*", "{a:?}");
+        }
+    }
+
+    #[test]
+    fn leading_glob_token_is_rtk_pattern_syntax() {
+        let p = parse_find_args(&args(&["*.rs", "src", "-m", "5"])).unwrap();
+        assert_eq!(p.pattern, "*.rs");
+        assert_eq!(p.path, "src");
+        assert_eq!(p.max_results, 5);
+        assert!(p.max_explicit);
+    }
+
+    #[test]
+    fn rtk_pattern_syntax_rejects_find_predicates() {
+        assert_eq!(class(&["*.rs", "src", "-m", "5", "-mtime", "+7"]), "error");
+        assert_eq!(class(&["*.rs", "-exec", "rm", "{}", ";"]), "error");
+    }
+
+    #[test]
+    fn subset_expressions_stay_native() {
+        assert_eq!(class(&[".", "-name", "*.rs", "-type", "f", "-maxdepth", "2"]), "native");
+        assert_eq!(class(&["-name", "*.rs"]), "native");
+        assert_eq!(class(&["src", "-iname", "README*"]), "native");
+        assert_eq!(class(&[".", "-type", "d"]), "native");
+        assert_eq!(class(&[".", "-name", "*.rs", "-m", "10"]), "native");
+    }
+
+    #[test]
+    fn unmodeled_listing_predicates_compress_via_find() {
+        assert_eq!(class(&["-mindepth", "2"]), "compress");
+        assert_eq!(class(&[".", "-path", "*/target/*", "-name", "*.rs"]), "compress");
+        assert_eq!(class(&[".", "-type", "l"]), "compress");
+        assert_eq!(class(&[".", "-name", "[ab]*.txt"]), "compress");
+        assert_eq!(class(&[".", "-name", "a", "-o", "-name", "b"]), "compress");
+        assert_eq!(class(&[".", "-not", "-name", "*.rs"]), "compress");
+        assert_eq!(class(&[".", "-mtime", "-7"]), "compress");
+        assert_eq!(class(&[".", "src"]), "compress");
+        assert_eq!(class(&[".", "-name"]), "compress");
+        assert_eq!(class(&[".", "-maxdepth", "abc"]), "compress");
+        assert_eq!(class(&[".", "-prune"]), "compress");
+    }
+
+    #[test]
+    fn actions_and_output_formats_run_verbatim() {
+        for a in [
+            &[".", "-name", "*.rs", "-exec", "cat", "{}", ";"][..],
+            &[".", "-delete"],
+            &[".", "-print0"],
+            &[".", "-printf", "%p\n"],
+            &[".", "-ls"],
+            &[".", "-ok", "rm", "{}", ";"],
+        ] {
+            assert_eq!(class(a), "verbatim", "{a:?}");
+        }
+    }
+
+    #[test]
+    fn rtk_flags_with_actions_is_an_error() {
+        assert_eq!(class(&[".", "-name", "*.rs", "-m", "5", "-exec", "cat", "{}", ";"]), "error");
+    }
+
+    #[test]
+    fn rtk_flags_are_stripped_before_find_in_compress_mode() {
+        match dispatch(&args(&[".", "-mtime", "-7", "-m", "5", "-t", "d"])).unwrap() {
+            Dispatch::Compress {
+                paths,
+                expr,
+                max_results,
+                max_explicit,
+            } => {
+                assert_eq!(paths, args(&["."]));
+                assert_eq!(expr, args(&["-mtime", "-7", "-type", "d"]));
+                assert_eq!(max_results, 5);
+                assert!(max_explicit);
+            }
+            _ => panic!("expected compress"),
+        }
+    }
+
+    #[test]
+    fn long_unicode_dir_label_does_not_panic() {
+        let root = std::env::temp_dir().join(format!("rtk-find-unicode-{}", std::process::id()));
+        let dir = root.join("é".repeat(30));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("f.txt"), "").unwrap();
+        let result = run("*.txt", root.to_str().unwrap(), 50, true, None, "f", false, 0);
+        let _ = std::fs::remove_dir_all(&root);
+        assert!(result.is_ok());
     }
 
     // --- glob_match unit tests ---
@@ -572,17 +853,13 @@ mod tests {
     // --- parse_find_args: unsupported flags ---
 
     #[test]
-    fn parse_native_find_rejects_not() {
-        let result = parse_find_args(&args(&[".", "-name", "*.rs", "-not", "-name", "*_test.rs"]));
-        assert!(result.is_err());
-        let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("compound predicates"));
+    fn parse_native_find_not_is_not_native() {
+        assert_eq!(class(&[".", "-name", "*.rs", "-not", "-name", "*_test.rs"]), "compress");
     }
 
     #[test]
-    fn parse_native_find_rejects_exec() {
-        let result = parse_find_args(&args(&[".", "-name", "*.tmp", "-exec", "rm", "{}", ";"]));
-        assert!(result.is_err());
+    fn parse_native_find_exec_is_not_native() {
+        assert_eq!(class(&[".", "-name", "*.tmp", "-exec", "rm", "{}", ";"]), "verbatim");
     }
 
     // --- parse_find_args: RTK syntax ---
@@ -683,20 +960,6 @@ mod tests {
         // With max=2, should not error
         let result = run("*.rs", "src", 2, true, None, "f", false, 0);
         assert!(result.is_ok());
-    }
-
-    #[test]
-    fn unsupported_flags_route_to_passthrough() {
-        for flag in ["-not", "!", "-o", "-exec", "-delete", "-mtime", "-regex"] {
-            assert!(has_unsupported_find_flags(&args(&[".", flag])), "{flag}");
-        }
-        assert!(has_unsupported_find_flags(&args(&[
-            ".", "-name", "*.rs", "-not", "-name", "*_test.rs"
-        ])));
-        assert!(!has_unsupported_find_flags(&args(&[
-            ".", "-name", "*.rs", "-type", "f", "-maxdepth", "2"
-        ])));
-        assert!(!has_unsupported_find_flags(&args(&["*.rs", "src", "-m", "10"])));
     }
 
     #[test]

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -137,10 +137,13 @@ fn parse_subset(paths: &[String], expr: &[String]) -> Option<FindArgs> {
 
 /// find syntax: `find [options] [paths...] [expression]` — paths end at the first
 /// token starting with `-`, `!` or a parenthesis, exactly like find.
-/// RTK syntax (first token contains `*` or `?`): `find <pattern> [path] [-m max] [-t type]`
+/// RTK syntax: `find <pattern> [path] [-m max] [-t type]` — used when the first
+/// token contains `*` or `?`, or is not an existing directory.
 fn dispatch(original: &[String]) -> Result<Dispatch> {
     let (args, max, file_type) = peel_trailing_rtk_flags(original);
-    let legacy = !args.is_empty() && !is_expression_token(&args[0]) && has_glob_meta(&args[0]);
+    let legacy = !args.is_empty()
+        && !is_expression_token(&args[0])
+        && (has_glob_meta(&args[0]) || !Path::new(&args[0]).is_dir());
     let args = if legacy {
         legacy_to_find_syntax(&args)
     } else {
@@ -466,12 +469,17 @@ pub fn run(
             continue;
         }
 
-        if entry_path == Path::new(path) && is_dir {
-            continue;
+        let display_path = entry_path
+            .strip_prefix(path)
+            .unwrap_or(entry_path)
+            .to_string_lossy()
+            .to_string();
+
+        if !display_path.is_empty() {
+            files.push(display_path);
+        } else if !is_dir {
+            files.push(path.to_string());
         }
-        let display_path = entry_path.to_string_lossy();
-        let display_path = display_path.strip_prefix("./").unwrap_or(&display_path);
-        files.push(display_path.to_string());
     }
 
     let raw_output = {
@@ -526,9 +534,23 @@ fn render(
         }
 
         let files_in_dir = &by_dir[dir];
+        let dir_display = if dir.chars().count() > 50 {
+            let tail: String = dir
+                .chars()
+                .rev()
+                .take(47)
+                .collect::<Vec<_>>()
+                .into_iter()
+                .rev()
+                .collect();
+            format!("...{}", tail)
+        } else {
+            dir.clone()
+        };
+
         let remaining_budget = max_results - displayed;
         if files_in_dir.len() <= remaining_budget {
-            body.push_str(&format!("{}/ {}\n", dir, files_in_dir.join(" ")));
+            body.push_str(&format!("{}/ {}\n", dir_display, files_in_dir.join(" ")));
             displayed += files_in_dir.len();
         } else {
             // Partial display: show only what fits in budget
@@ -537,7 +559,7 @@ fn render(
                 .take(remaining_budget)
                 .cloned()
                 .collect();
-            body.push_str(&format!("{}/ {}\n", dir, partial.join(" ")));
+            body.push_str(&format!("{}/ {}\n", dir_display, partial.join(" ")));
             displayed += partial.len();
             break;
         }
@@ -637,6 +659,18 @@ mod tests {
             assert_eq!(p.path, a[0], "{a:?}");
             assert_eq!(p.pattern, "*", "{a:?}");
         }
+    }
+
+    #[test]
+    fn literal_name_that_is_not_a_directory_stays_a_pattern() {
+        let p = parse_find_args(&args(&["Cargo.toml"])).unwrap();
+        assert_eq!(p.pattern, "Cargo.toml");
+        assert_eq!(p.path, ".");
+        let p = parse_find_args(&args(&["no_such_dir_xyz"])).unwrap();
+        assert_eq!(p.pattern, "no_such_dir_xyz");
+        let p = parse_find_args(&args(&["README.md", "src"])).unwrap();
+        assert_eq!(p.pattern, "README.md");
+        assert_eq!(p.path, "src");
     }
 
     #[test]

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -216,6 +216,41 @@ pub fn run_from_args(args: &[String], verbose: u8) -> Result<()> {
     )
 }
 
+fn group_by_dir(files: &[String]) -> HashMap<String, Vec<String>> {
+    let mut by_dir: HashMap<String, Vec<String>> = HashMap::new();
+    for file in files {
+        let p = Path::new(file);
+        let dir = p
+            .parent()
+            .map(|d| d.to_string_lossy().to_string())
+            .unwrap_or_else(|| ".".to_string());
+        let dir = if dir.is_empty() { ".".to_string() } else { dir };
+        let filename = p
+            .file_name()
+            .map(|f| f.to_string_lossy().to_string())
+            .unwrap_or_default();
+        by_dir.entry(dir).or_default().push(filename);
+    }
+    by_dir
+}
+
+fn display_ordered(files: &[String]) -> Vec<String> {
+    let by_dir = group_by_dir(files);
+    let mut dirs: Vec<_> = by_dir.keys().cloned().collect();
+    dirs.sort();
+    let mut ordered = Vec::with_capacity(files.len());
+    for dir in &dirs {
+        for filename in &by_dir[dir] {
+            if dir == "." {
+                ordered.push(filename.clone());
+            } else {
+                ordered.push(format!("{}/{}", dir, filename));
+            }
+        }
+    }
+    ordered
+}
+
 fn build_capped_listing(files: &[String], max_results: usize) -> String {
     let mut listing = files
         .iter()
@@ -329,23 +364,9 @@ pub fn run(
         return Ok(());
     }
 
-    // Group by directory
-    let mut by_dir: HashMap<String, Vec<String>> = HashMap::new();
+    let ordered = display_ordered(&files);
 
-    for file in &files {
-        let p = Path::new(file);
-        let dir = p
-            .parent()
-            .map(|d| d.to_string_lossy().to_string())
-            .unwrap_or_else(|| ".".to_string());
-        let dir = if dir.is_empty() { ".".to_string() } else { dir };
-        let filename = p
-            .file_name()
-            .map(|f| f.to_string_lossy().to_string())
-            .unwrap_or_default();
-        by_dir.entry(dir).or_default().push(filename);
-    }
-
+    let by_dir = group_by_dir(&files);
     let mut dirs: Vec<_> = by_dir.keys().cloned().collect();
     dirs.sort();
     let dirs_count = dirs.len();
@@ -413,12 +434,12 @@ pub fn run(
         body.push_str(&format!("{}\n", ext_line));
     }
 
-    let capped_raw = build_capped_listing(&files, max_results);
+    let capped_raw = build_capped_listing(&ordered, max_results);
     let shown = never_worse(&capped_raw, &body);
     let mut output = shown.to_string();
     if displayed < total_files && !max_explicit {
         if let Some(hint) =
-            crate::core::tee::force_tee_tail_hint(&raw_output, "find", displayed + 1)
+            crate::core::tee::force_tee_tail_hint(&ordered.join("\n"), "find", displayed + 1)
         {
             output.push_str(&format!("{}\n", hint));
         }
@@ -693,6 +714,36 @@ mod tests {
         assert!(!parsed.max_explicit);
         let parsed = parse_find_args(&args(&["*.rs", "src"])).unwrap();
         assert!(!parsed.max_explicit);
+    }
+
+    #[test]
+    fn tee_remainder_matches_hidden_files_when_dir_sort_diverges() {
+        // "logs-old/f01" < "logs/f01" in flat path sort ('-' < '/'), but the
+        // display sorts by dir name where "logs" < "logs-old". The tee must
+        // follow display order or tail returns already-shown files.
+        let mut files: Vec<String> = Vec::new();
+        for i in 1..=30 {
+            files.push(format!("logs/f{:02}.txt", i));
+            files.push(format!("logs-old/f{:02}.txt", i));
+        }
+        files.sort();
+        assert!(files[0].starts_with("logs-old/"));
+
+        let ordered = display_ordered(&files);
+        assert!(ordered[0].starts_with("logs/"));
+        assert_eq!(ordered.len(), 60);
+
+        let hidden = &ordered[50..];
+        assert_eq!(hidden.first().unwrap(), "logs-old/f21.txt");
+        assert_eq!(hidden.last().unwrap(), "logs-old/f30.txt");
+        assert!(hidden.iter().all(|f| f.starts_with("logs-old/")));
+    }
+
+    #[test]
+    fn display_ordered_keeps_root_files_in_root_group() {
+        let files: Vec<String> = args(&["zebra.txt", "logs/a.txt", "alpha.txt"]);
+        let ordered = display_ordered(&files);
+        assert_eq!(ordered, args(&["zebra.txt", "alpha.txt", "logs/a.txt"]));
     }
 
     #[test]

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -726,12 +726,11 @@ mod tests {
 
     #[test]
     fn long_unicode_dir_label_does_not_panic() {
-        let root = std::env::temp_dir().join(format!("rtk-find-unicode-{}", std::process::id()));
-        let dir = root.join("é".repeat(30));
+        let root = tempfile::TempDir::new().unwrap();
+        let dir = root.path().join("é".repeat(30));
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("f.txt"), "").unwrap();
-        let result = run("*.txt", root.to_str().unwrap(), 50, true, None, "f", false, 0);
-        let _ = std::fs::remove_dir_all(&root);
+        let result = run("*.txt", root.path().to_str().unwrap(), 50, true, None, "f", false, 0);
         assert!(result.is_ok());
     }
 

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -180,8 +180,34 @@ fn parse_rtk_find_args(args: &[String]) -> Result<FindArgs> {
     Ok(parsed)
 }
 
+fn passthrough_raw_find(args: &[String], verbose: u8) -> Result<()> {
+    let timer = tracking::TimedExecution::start();
+    if verbose > 0 {
+        eprintln!("find: passthrough (flags rtk cannot filter)");
+    }
+    let mut cmd = crate::core::utils::resolved_command("find");
+    cmd.args(args);
+    let captured =
+        crate::core::stream::exec_capture(&mut cmd).context("Failed to execute find")?;
+    print!("{}", captured.stdout);
+    eprint!("{}", captured.stderr);
+    timer.track(
+        &format!("find {}", args.join(" ")),
+        "rtk find",
+        &captured.stdout,
+        &captured.stdout,
+    );
+    if captured.exit_code != 0 {
+        std::process::exit(captured.exit_code);
+    }
+    Ok(())
+}
+
 /// Entry point from main.rs — parses raw args then delegates to run().
 pub fn run_from_args(args: &[String], verbose: u8) -> Result<()> {
+    if has_unsupported_find_flags(args) {
+        return passthrough_raw_find(args, verbose);
+    }
     let parsed = parse_find_args(args)?;
     run(
         &parsed.pattern,
@@ -636,6 +662,20 @@ mod tests {
         // With max=2, should not error
         let result = run("*.rs", "src", 2, true, None, "f", false, 0);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn unsupported_flags_route_to_passthrough() {
+        for flag in ["-not", "!", "-o", "-exec", "-delete", "-mtime", "-regex"] {
+            assert!(has_unsupported_find_flags(&args(&[".", flag])), "{flag}");
+        }
+        assert!(has_unsupported_find_flags(&args(&[
+            ".", "-name", "*.rs", "-not", "-name", "*_test.rs"
+        ])));
+        assert!(!has_unsupported_find_flags(&args(&[
+            ".", "-name", "*.rs", "-type", "f", "-maxdepth", "2"
+        ])));
+        assert!(!has_unsupported_find_flags(&args(&["*.rs", "src", "-m", "10"])));
     }
 
     #[test]

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -191,6 +191,20 @@ pub fn run_from_args(args: &[String], verbose: u8) -> Result<()> {
     )
 }
 
+fn build_capped_listing(files: &[String], max_results: usize) -> String {
+    let mut listing = files
+        .iter()
+        .take(max_results)
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("\n");
+    if files.len() > max_results {
+        listing.push_str(&format!("\n+{} more", files.len() - max_results));
+    }
+    listing.push('\n');
+    listing
+}
+
 pub fn run(
     pattern: &str,
     path: &str,
@@ -372,7 +386,8 @@ pub fn run(
         body.push_str(&format!("{}\n", ext_line));
     }
 
-    let shown = never_worse(&raw_output, &body);
+    let capped_raw = build_capped_listing(&files, max_results);
+    let shown = never_worse(&capped_raw, &body);
     print!("{}", shown);
     timer.track(
         &format!("find {} -name '{}'", path, effective_pattern),
@@ -607,6 +622,33 @@ mod tests {
         // With max=2, should not error
         let result = run("*.rs", "src", 2, None, "f", false, 0);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn capped_listing_no_truncation() {
+        let files = args(&["a.rs", "b.rs"]);
+        assert_eq!(build_capped_listing(&files, 10), "a.rs\nb.rs\n");
+    }
+
+    #[test]
+    fn capped_listing_truncates_with_marker() {
+        let files = args(&["a.rs", "b.rs", "c.rs", "d.rs"]);
+        assert_eq!(build_capped_listing(&files, 2), "a.rs\nb.rs\n+2 more\n");
+    }
+
+    #[test]
+    fn capped_listing_at_exact_max_has_no_marker() {
+        let files = args(&["a.rs", "b.rs"]);
+        assert_eq!(build_capped_listing(&files, 2), "a.rs\nb.rs\n");
+    }
+
+    #[test]
+    fn capped_baseline_beats_grouped_summary_on_tiny_result_sets() {
+        use crate::core::guard::never_worse;
+        let files = args(&["a.rs"]);
+        let capped = build_capped_listing(&files, 10);
+        let grouped = "1F 1D:\n\n./ a.rs\n\next: .rs(1)\n";
+        assert_eq!(never_worse(&capped, grouped), capped);
     }
 
     #[test]

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -191,12 +191,7 @@ fn passthrough_raw_find(args: &[String], verbose: u8) -> Result<()> {
         crate::core::stream::exec_capture(&mut cmd).context("Failed to execute find")?;
     print!("{}", captured.stdout);
     eprint!("{}", captured.stderr);
-    timer.track(
-        &format!("find {}", args.join(" ")),
-        "rtk find",
-        &captured.stdout,
-        &captured.stdout,
-    );
+    timer.track_passthrough(&format!("find {}", args.join(" ")), "rtk find (passthrough)");
     if captured.exit_code != 0 {
         std::process::exit(captured.exit_code);
     }

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -1,7 +1,7 @@
 //! Filters find results by grouping files by directory.
 
-use crate::core::guard::never_worse;
 use crate::core::tracking;
+use crate::core::truncate::CAP_INVENTORY;
 use anyhow::{Context, Result};
 use ignore::WalkBuilder;
 use std::collections::HashMap;
@@ -44,20 +44,13 @@ impl Default for FindArgs {
         Self {
             pattern: "*".to_string(),
             path: ".".to_string(),
-            max_results: 50,
+            max_results: CAP_INVENTORY,
             max_explicit: false,
             max_depth: None,
             file_type: "f".to_string(),
             case_insensitive: false,
         }
     }
-}
-
-/// Consume the next argument from `args` at position `i`, advancing the index.
-/// Returns `None` if `i` is past the end of `args`.
-fn next_arg(args: &[String], i: &mut usize) -> Option<String> {
-    *i += 1;
-    args.get(*i).cloned()
 }
 
 const VERBATIM_ACTIONS: &[&str] = &[
@@ -71,8 +64,10 @@ enum Dispatch {
         options: Vec<String>,
         paths: Vec<String>,
         expr: Vec<String>,
+        max: Option<usize>,
+        file_type: Option<String>,
     },
-    Verbatim,
+    Verbatim(Vec<String>),
 }
 
 fn is_expression_token(token: &str) -> bool {
@@ -144,13 +139,16 @@ fn parse_subset(paths: &[String], expr: &[String]) -> Option<FindArgs> {
 /// token starting with `-`, `!` or a parenthesis, exactly like find.
 /// RTK syntax (first token contains `*` or `?`): `find <pattern> [path] [-m max] [-t type]`
 fn dispatch(args: &[String]) -> Result<Dispatch> {
-    let options = args[..leading_options_len(args)].to_vec();
+    let (args, max, file_type) = peel_trailing_rtk_flags(args);
+    let legacy = !args.is_empty() && !is_expression_token(&args[0]) && has_glob_meta(&args[0]);
+    let args = if legacy {
+        legacy_to_find_syntax(&args)
+    } else {
+        args
+    };
+
+    let options = args[..leading_options_len(&args)].to_vec();
     let rest = &args[options.len()..];
-
-    if options.is_empty() && !rest.is_empty() && !is_expression_token(&rest[0]) && has_glob_meta(&rest[0]) {
-        return parse_rtk_find_args(rest).map(Dispatch::Native);
-    }
-
     let split = rest
         .iter()
         .position(|t| is_expression_token(t))
@@ -159,95 +157,110 @@ fn dispatch(args: &[String]) -> Result<Dispatch> {
     let expr = rest[split..].to_vec();
 
     if expr.iter().any(|t| VERBATIM_ACTIONS.contains(&t.as_str())) {
-        return Ok(Dispatch::Verbatim);
+        if max.is_some() || file_type.is_some() {
+            anyhow::bail!(
+                "rtk find: -m/-t cannot limit find actions (-exec, -delete, -print0, ...); run find without them"
+            );
+        }
+        return Ok(Dispatch::Verbatim(args));
     }
     if options.is_empty() {
-        if let Some(parsed) = parse_subset(&paths, &expr) {
-            return Ok(Dispatch::Native(parsed));
+        if let Some(mut parsed) = parse_subset(&paths, &expr) {
+            let repeated_max = max.is_some() && parsed.max_explicit;
+            let repeated_type = file_type.is_some() && parsed.file_type != FindArgs::default().file_type;
+            if !repeated_max && !repeated_type {
+                if let Some(n) = max {
+                    parsed.max_results = n;
+                    parsed.max_explicit = true;
+                }
+                if let Some(t) = file_type {
+                    parsed.file_type = t;
+                }
+                return Ok(Dispatch::Native(parsed));
+            }
         }
     }
     Ok(Dispatch::Compress {
         options,
         paths,
         expr,
+        max,
+        file_type,
     })
 }
 
-/// Parse RTK syntax: `find <pattern> [path] [-m max] [-t type]`
-fn parse_rtk_find_args(args: &[String]) -> Result<FindArgs> {
-    let mut parsed = FindArgs {
-        pattern: args[0].clone(),
-        ..FindArgs::default()
-    };
-    let mut i = 1;
-
-    // Second positional arg (if not a flag) is the path
-    if i < args.len() && !args[i].starts_with('-') {
-        parsed.path = args[i].clone();
-        i += 1;
+/// RTK syntax `find <pattern> [path] ...` rewritten as find syntax
+/// `[path] -name <pattern> ...` so every token after the pattern is dispatched
+/// like any find expression.
+fn legacy_to_find_syntax(args: &[String]) -> Vec<String> {
+    let mut rebuilt = Vec::with_capacity(args.len() + 1);
+    let mut rest = &args[1..];
+    if let Some(path) = rest.first().filter(|p| !is_expression_token(p)) {
+        rebuilt.push(path.clone());
+        rest = &rest[1..];
     }
+    rebuilt.push("-name".to_string());
+    rebuilt.push(args[0].clone());
+    rebuilt.extend(rest.iter().cloned());
+    rebuilt
+}
 
-    while i < args.len() {
-        match args[i].as_str() {
-            "-m" | "--max" => {
-                if let Some(val) = next_arg(args, &mut i) {
-                    parsed.max_results = val.parse().context("invalid --max value")?;
-                    parsed.max_explicit = true;
-                }
+/// rtk's own flags are only recognized at the very end of the command line,
+/// where they cannot be an -exec argument or a predicate value.
+fn peel_trailing_rtk_flags(args: &[String]) -> (Vec<String>, Option<usize>, Option<String>) {
+    let mut end = args.len();
+    let mut max = None;
+    let mut file_type = None;
+    while end >= 2 {
+        let flag = args[end - 2].as_str();
+        let value = &args[end - 1];
+        match flag {
+            "-m" | "--max" if max.is_none() => match value.parse::<usize>() {
+                Ok(n) => max = Some(n),
+                Err(_) => break,
+            },
+            "-t" | "--file-type" if file_type.is_none() && (value == "f" || value == "d") => {
+                file_type = Some(value.clone())
             }
-            "-t" | "--file-type" => {
-                if let Some(val) = next_arg(args, &mut i) {
-                    parsed.file_type = val;
-                }
-            }
-            other => anyhow::bail!(
-                "rtk find: '{}' is not supported after a pattern; use find syntax: find <path> -name '{}' {} ...",
-                other,
-                parsed.pattern,
-                other
-            ),
+            _ => break,
         }
-        i += 1;
+        end -= 2;
     }
-
-    Ok(parsed)
+    (args[..end].to_vec(), max, file_type)
 }
 
 fn run_verbatim(args: &[String], verbose: u8) -> Result<()> {
-    let timer = tracking::TimedExecution::start();
-    if verbose > 0 {
-        eprintln!("find: verbatim (find actions produce non-listing output)");
-    }
-    let mut cmd = crate::core::utils::resolved_command("find");
-    cmd.args(args).stdin(std::process::Stdio::inherit());
-    let output = cmd.output().context("Failed to execute find")?;
-    let exit_code = crate::core::utils::exit_code_from_output(&output, "find");
-    let mut stdout = std::io::stdout().lock();
-    stdout.write_all(&output.stdout)?;
-    stdout.flush()?;
-    let mut stderr = std::io::stderr().lock();
-    stderr.write_all(&output.stderr)?;
-    stderr.flush()?;
-    timer.track_passthrough(&format!("find {}", args.join(" ")), "rtk find (passthrough)");
+    let os_args: Vec<std::ffi::OsString> = args.iter().map(std::ffi::OsString::from).collect();
+    let exit_code = crate::core::runner::run_passthrough("find", &os_args, verbose)?;
     if exit_code != 0 {
         std::process::exit(exit_code);
     }
     Ok(())
 }
 
-fn run_compress(options: &[String], paths: &[String], expr: &[String], verbose: u8) -> Result<()> {
+fn run_compress(
+    options: &[String],
+    paths: &[String],
+    expr: &[String],
+    max: Option<usize>,
+    file_type: Option<&str>,
+    verbose: u8,
+) -> Result<()> {
     let timer = tracking::TimedExecution::start();
     if verbose > 0 {
         eprintln!("find: results from find, compressed by rtk");
     }
-    let defaults = FindArgs::default();
-    let (max_results, max_explicit) = (defaults.max_results, defaults.max_explicit);
+    let max_results = max.unwrap_or(CAP_INVENTORY);
+    let max_explicit = max.is_some();
     let mut cmd = crate::core::utils::resolved_command("find");
     cmd.args(options).args(paths);
     if !expr.is_empty() {
         cmd.arg("(");
         cmd.args(expr);
         cmd.arg(")");
+    }
+    if let Some(t) = file_type {
+        cmd.arg("-type").arg(t);
     }
     cmd.arg("-print0").stdin(std::process::Stdio::inherit());
     let output = cmd.output().context("Failed to execute find")?;
@@ -311,8 +324,10 @@ pub fn run_from_args(args: &[String], verbose: u8) -> Result<()> {
             options,
             paths,
             expr,
-        } => run_compress(&options, &paths, &expr, verbose),
-        Dispatch::Verbatim => run_verbatim(args, verbose),
+            max,
+            file_type,
+        } => run_compress(&options, &paths, &expr, max, file_type.as_deref(), verbose),
+        Dispatch::Verbatim(args) => run_verbatim(&args, verbose),
     }
 }
 
@@ -561,17 +576,17 @@ fn render(
     }
 
     let capped_raw = build_capped_listing(&ordered, max_results);
-    let shown = never_worse(&capped_raw, &body);
-    let mut output = shown.to_string();
-    if displayed < total_files && !max_explicit {
-        if let Some(hint) =
-            crate::core::tee::force_tee_tail_hint(&ordered.join("\n"), "find", displayed + 1)
-        {
-            output.push_str(&format!("{}\n", hint));
-        }
-    }
-    print!("{}", output);
-    timer.track(track_cmd, "rtk find", raw_output, &output);
+    let hint = if displayed < total_files && !max_explicit {
+        crate::core::tee::force_tee_tail_hint(&ordered.join("\n"), "find", displayed + 1)
+    } else {
+        None
+    };
+    let shown = crate::core::runner::emit_guarded(
+        body.trim_end_matches('\n'),
+        hint.as_deref(),
+        capped_raw.trim_end_matches('\n'),
+    );
+    timer.track(track_cmd, "rtk find", raw_output, &shown);
 }
 
 #[cfg(test)]
@@ -587,7 +602,7 @@ mod tests {
         match dispatch(a)? {
             Dispatch::Native(p) => Ok(p),
             Dispatch::Compress { .. } => anyhow::bail!("dispatched to compress"),
-            Dispatch::Verbatim => anyhow::bail!("dispatched to verbatim"),
+            Dispatch::Verbatim(_) => anyhow::bail!("dispatched to verbatim"),
         }
     }
 
@@ -595,9 +610,16 @@ mod tests {
         match dispatch(&args(a)) {
             Ok(Dispatch::Native(_)) => "native",
             Ok(Dispatch::Compress { .. }) => "compress",
-            Ok(Dispatch::Verbatim) => "verbatim",
+            Ok(Dispatch::Verbatim(_)) => "verbatim",
             Err(_) => "error",
         }
+    }
+
+    #[test]
+    fn rtk_flags_never_silently_dropped_before_actions() {
+        assert_eq!(class(&["*.rs", "src", "-delete", "-m", "1"]), "error");
+        assert_eq!(class(&[".", "-name", "*.rs", "-exec", "echo", "{}", ";", "-t", "d"]), "error");
+        assert_eq!(class(&[".", "-name", "*.rs", "-exec", "echo", "{}", ";"]), "verbatim");
     }
 
     #[test]
@@ -619,9 +641,40 @@ mod tests {
     }
 
     #[test]
-    fn rtk_pattern_syntax_rejects_find_predicates() {
-        assert_eq!(class(&["*.rs", "src", "-m", "5", "-mtime", "+7"]), "error");
-        assert_eq!(class(&["*.rs", "-exec", "rm", "{}", ";"]), "error");
+    fn rtk_pattern_syntax_with_find_predicates_never_blocks() {
+        match dispatch(&args(&["*.rs", "src", "-mtime", "+7", "-m", "5"])).unwrap() {
+            Dispatch::Compress {
+                paths, expr, max, ..
+            } => {
+                assert_eq!(paths, args(&["src"]));
+                assert_eq!(expr, args(&["-name", "*.rs", "-mtime", "+7"]));
+                assert_eq!(max, Some(5));
+            }
+            _ => panic!("expected compress"),
+        }
+        match dispatch(&args(&["*.rs", "-exec", "rm", "{}", ";"])).unwrap() {
+            Dispatch::Verbatim(a) => assert_eq!(a, args(&["-name", "*.rs", "-exec", "rm", "{}", ";"])),
+            _ => panic!("expected verbatim"),
+        }
+    }
+
+    #[test]
+    fn trailing_rtk_flags_are_peeled_in_every_class() {
+        let (rest, max, ty) = peel_trailing_rtk_flags(&args(&[".", "-mtime", "-7", "-t", "d", "-m", "5"]));
+        assert_eq!(rest, args(&[".", "-mtime", "-7"]));
+        assert_eq!(max, Some(5));
+        assert_eq!(ty.as_deref(), Some("d"));
+        let (rest, max, _) = peel_trailing_rtk_flags(&args(&[".", "-name", "-m"]));
+        assert_eq!(rest, args(&[".", "-name", "-m"]));
+        assert_eq!(max, None);
+        let (rest, max, _) = peel_trailing_rtk_flags(&args(&[".", "-exec", "grep", "-m", "1", "x", "{}", ";"]));
+        assert_eq!(rest.len(), 8);
+        assert_eq!(max, None);
+        match dispatch(&args(&[".", "-mtime", "-7", "-m", "5"])).unwrap() {
+            Dispatch::Compress { max, .. } => assert_eq!(max, Some(5)),
+            _ => panic!("expected compress"),
+        }
+        assert_eq!(class(&[".", "-name", "*.rs", "-exec", "cat", "{}", ";", "-m", "5"]), "error");
     }
 
     #[test]
@@ -663,13 +716,12 @@ mod tests {
     }
 
     #[test]
-    fn rtk_flags_are_only_interpreted_in_the_native_subset() {
+    fn rtk_flags_mid_expression_reach_find_untouched() {
         assert_eq!(class(&[".", "-name", "*.rs", "-m", "5", "-exec", "grep", "-m", "1", "x", "{}", ";"]), "verbatim");
-        match dispatch(&args(&[".", "-mtime", "-7", "-m", "5"])).unwrap() {
-            Dispatch::Compress { options, paths, expr } => {
-                assert!(options.is_empty());
-                assert_eq!(paths, args(&["."]));
-                assert_eq!(expr, args(&["-mtime", "-7", "-m", "5"]));
+        match dispatch(&args(&[".", "-m", "5", "-mtime", "-7"])).unwrap() {
+            Dispatch::Compress { expr, max, .. } => {
+                assert_eq!(expr, args(&["-m", "5", "-mtime", "-7"]));
+                assert_eq!(max, None);
             }
             _ => panic!("expected compress"),
         }

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -138,8 +138,8 @@ fn parse_subset(paths: &[String], expr: &[String]) -> Option<FindArgs> {
 /// find syntax: `find [options] [paths...] [expression]` — paths end at the first
 /// token starting with `-`, `!` or a parenthesis, exactly like find.
 /// RTK syntax (first token contains `*` or `?`): `find <pattern> [path] [-m max] [-t type]`
-fn dispatch(args: &[String]) -> Result<Dispatch> {
-    let (args, max, file_type) = peel_trailing_rtk_flags(args);
+fn dispatch(original: &[String]) -> Result<Dispatch> {
+    let (args, max, file_type) = peel_trailing_rtk_flags(original);
     let legacy = !args.is_empty() && !is_expression_token(&args[0]) && has_glob_meta(&args[0]);
     let args = if legacy {
         legacy_to_find_syntax(&args)
@@ -157,17 +157,18 @@ fn dispatch(args: &[String]) -> Result<Dispatch> {
     let expr = rest[split..].to_vec();
 
     if expr.iter().any(|t| VERBATIM_ACTIONS.contains(&t.as_str())) {
-        if max.is_some() || file_type.is_some() {
-            anyhow::bail!(
-                "rtk find: -m/-t cannot limit find actions (-exec, -delete, -print0, ...); run find without them"
-            );
-        }
-        return Ok(Dispatch::Verbatim(args));
+        let verbatim = if legacy {
+            legacy_to_find_syntax(original)
+        } else {
+            original.to_vec()
+        };
+        return Ok(Dispatch::Verbatim(verbatim));
     }
     if options.is_empty() {
         if let Some(mut parsed) = parse_subset(&paths, &expr) {
             let repeated_max = max.is_some() && parsed.max_explicit;
-            let repeated_type = file_type.is_some() && parsed.file_type != FindArgs::default().file_type;
+            let repeated_type =
+                file_type.is_some() && parsed.file_type != FindArgs::default().file_type;
             if !repeated_max && !repeated_type {
                 if let Some(n) = max {
                     parsed.max_results = n;
@@ -299,7 +300,14 @@ fn run_compress(
             })
             .collect();
         let raw_output = files.join("\n");
-        render(files, max_results, max_explicit, &track_cmd, &raw_output, &timer);
+        render(
+            files,
+            max_results,
+            max_explicit,
+            &track_cmd,
+            &raw_output,
+            &timer,
+        );
     }
     if exit_code != 0 {
         std::process::exit(exit_code);
@@ -458,18 +466,12 @@ pub fn run(
             continue;
         }
 
-        // Store path relative to search root
-        let display_path = entry_path
-            .strip_prefix(path)
-            .unwrap_or(entry_path)
-            .to_string_lossy()
-            .to_string();
-
-        if !display_path.is_empty() {
-            files.push(display_path);
-        } else if !is_dir {
-            files.push(path.to_string());
+        if entry_path == Path::new(path) && is_dir {
+            continue;
         }
+        let display_path = entry_path.to_string_lossy();
+        let display_path = display_path.strip_prefix("./").unwrap_or(&display_path);
+        files.push(display_path.to_string());
     }
 
     let raw_output = {
@@ -525,7 +527,14 @@ fn render(
 
         let files_in_dir = &by_dir[dir];
         let dir_display = if dir.chars().count() > 50 {
-            let tail: String = dir.chars().rev().take(47).collect::<Vec<_>>().into_iter().rev().collect();
+            let tail: String = dir
+                .chars()
+                .rev()
+                .take(47)
+                .collect::<Vec<_>>()
+                .into_iter()
+                .rev()
+                .collect();
             format!("...{}", tail)
         } else {
             dir.clone()
@@ -581,11 +590,13 @@ fn render(
     } else {
         None
     };
-    let shown = crate::core::runner::emit_guarded(
-        body.trim_end_matches('\n'),
-        hint.as_deref(),
-        capped_raw.trim_end_matches('\n'),
-    );
+    let listing = capped_raw.trim_end_matches('\n');
+    let baseline = match &hint {
+        Some(h) => format!("{}\n{}", listing, h),
+        None => listing.to_string(),
+    };
+    let shown =
+        crate::core::runner::emit_guarded(body.trim_end_matches('\n'), hint.as_deref(), &baseline);
     timer.track(track_cmd, "rtk find", raw_output, &shown);
 }
 
@@ -616,10 +627,21 @@ mod tests {
     }
 
     #[test]
-    fn rtk_flags_never_silently_dropped_before_actions() {
-        assert_eq!(class(&["*.rs", "src", "-delete", "-m", "1"]), "error");
-        assert_eq!(class(&[".", "-name", "*.rs", "-exec", "echo", "{}", ";", "-t", "d"]), "error");
-        assert_eq!(class(&[".", "-name", "*.rs", "-exec", "echo", "{}", ";"]), "verbatim");
+    fn rtk_flags_before_actions_reach_find_so_it_refuses_them() {
+        match dispatch(&args(&["*.rs", "src", "-delete", "-m", "1"])).unwrap() {
+            Dispatch::Verbatim(a) => {
+                assert_eq!(a, args(&["src", "-name", "*.rs", "-delete", "-m", "1"]))
+            }
+            _ => panic!("expected verbatim"),
+        }
+        match dispatch(&args(&[
+            ".", "-name", "*.rs", "-exec", "echo", "{}", ";", "-t", "d",
+        ]))
+        .unwrap()
+        {
+            Dispatch::Verbatim(a) => assert!(a.ends_with(&args(&["-t", "d"]))),
+            _ => panic!("expected verbatim"),
+        }
     }
 
     #[test]
@@ -653,33 +675,43 @@ mod tests {
             _ => panic!("expected compress"),
         }
         match dispatch(&args(&["*.rs", "-exec", "rm", "{}", ";"])).unwrap() {
-            Dispatch::Verbatim(a) => assert_eq!(a, args(&["-name", "*.rs", "-exec", "rm", "{}", ";"])),
+            Dispatch::Verbatim(a) => {
+                assert_eq!(a, args(&["-name", "*.rs", "-exec", "rm", "{}", ";"]))
+            }
             _ => panic!("expected verbatim"),
         }
     }
 
     #[test]
     fn trailing_rtk_flags_are_peeled_in_every_class() {
-        let (rest, max, ty) = peel_trailing_rtk_flags(&args(&[".", "-mtime", "-7", "-t", "d", "-m", "5"]));
+        let (rest, max, ty) =
+            peel_trailing_rtk_flags(&args(&[".", "-mtime", "-7", "-t", "d", "-m", "5"]));
         assert_eq!(rest, args(&[".", "-mtime", "-7"]));
         assert_eq!(max, Some(5));
         assert_eq!(ty.as_deref(), Some("d"));
         let (rest, max, _) = peel_trailing_rtk_flags(&args(&[".", "-name", "-m"]));
         assert_eq!(rest, args(&[".", "-name", "-m"]));
         assert_eq!(max, None);
-        let (rest, max, _) = peel_trailing_rtk_flags(&args(&[".", "-exec", "grep", "-m", "1", "x", "{}", ";"]));
+        let (rest, max, _) =
+            peel_trailing_rtk_flags(&args(&[".", "-exec", "grep", "-m", "1", "x", "{}", ";"]));
         assert_eq!(rest.len(), 8);
         assert_eq!(max, None);
         match dispatch(&args(&[".", "-mtime", "-7", "-m", "5"])).unwrap() {
             Dispatch::Compress { max, .. } => assert_eq!(max, Some(5)),
             _ => panic!("expected compress"),
         }
-        assert_eq!(class(&[".", "-name", "*.rs", "-exec", "cat", "{}", ";", "-m", "5"]), "error");
+        assert_eq!(
+            class(&[".", "-name", "*.rs", "-exec", "cat", "{}", ";", "-m", "5"]),
+            "verbatim"
+        );
     }
 
     #[test]
     fn subset_expressions_stay_native() {
-        assert_eq!(class(&[".", "-name", "*.rs", "-type", "f", "-maxdepth", "2"]), "native");
+        assert_eq!(
+            class(&[".", "-name", "*.rs", "-type", "f", "-maxdepth", "2"]),
+            "native"
+        );
         assert_eq!(class(&["-name", "*.rs"]), "native");
         assert_eq!(class(&["src", "-iname", "README*"]), "native");
         assert_eq!(class(&[".", "-type", "d"]), "native");
@@ -689,7 +721,10 @@ mod tests {
     #[test]
     fn unmodeled_listing_predicates_compress_via_find() {
         assert_eq!(class(&["-mindepth", "2"]), "compress");
-        assert_eq!(class(&[".", "-path", "*/target/*", "-name", "*.rs"]), "compress");
+        assert_eq!(
+            class(&[".", "-path", "*/target/*", "-name", "*.rs"]),
+            "compress"
+        );
         assert_eq!(class(&[".", "-type", "l"]), "compress");
         assert_eq!(class(&[".", "-name", "[ab]*.txt"]), "compress");
         assert_eq!(class(&[".", "-name", "a", "-o", "-name", "b"]), "compress");
@@ -717,7 +752,10 @@ mod tests {
 
     #[test]
     fn rtk_flags_mid_expression_reach_find_untouched() {
-        assert_eq!(class(&[".", "-name", "*.rs", "-m", "5", "-exec", "grep", "-m", "1", "x", "{}", ";"]), "verbatim");
+        assert_eq!(
+            class(&[".", "-name", "*.rs", "-m", "5", "-exec", "grep", "-m", "1", "x", "{}", ";"]),
+            "verbatim"
+        );
         match dispatch(&args(&[".", "-m", "5", "-mtime", "-7"])).unwrap() {
             Dispatch::Compress { expr, max, .. } => {
                 assert_eq!(expr, args(&["-m", "5", "-mtime", "-7"]));
@@ -745,21 +783,36 @@ mod tests {
                 _ => panic!("expected compress for {a:?}"),
             }
         }
-        assert_eq!(class(&["-D", "tree", ".", "-exec", "true", ";"]), "verbatim");
+        assert_eq!(
+            class(&["-D", "tree", ".", "-exec", "true", ";"]),
+            "verbatim"
+        );
     }
 
     #[test]
     fn repeated_subset_predicates_go_to_find() {
         assert_eq!(class(&[".", "-name", "a", "-name", "b"]), "compress");
-        assert_eq!(class(&[".", "-iname", "*.txt", "-name", "*.TXT"]), "compress");
+        assert_eq!(
+            class(&[".", "-iname", "*.txt", "-name", "*.TXT"]),
+            "compress"
+        );
         assert_eq!(class(&[".", "-type", "f", "-type", "d"]), "compress");
-        assert_eq!(class(&[".", "-maxdepth", "1", "-maxdepth", "2"]), "compress");
-        assert_eq!(class(&[".", "-name", "*.rs", "-m", "5", "-m", "6"]), "compress");
+        assert_eq!(
+            class(&[".", "-maxdepth", "1", "-maxdepth", "2"]),
+            "compress"
+        );
+        assert_eq!(
+            class(&[".", "-name", "*.rs", "-m", "5", "-m", "6"]),
+            "compress"
+        );
     }
 
     #[test]
     fn subset_accepts_rtk_type_flag_and_iname() {
-        let p = parse_find_args(&args(&["src", "-iname", "README*", "-t", "d", "--max", "3"])).unwrap();
+        let p = parse_find_args(&args(&[
+            "src", "-iname", "README*", "-t", "d", "--max", "3",
+        ]))
+        .unwrap();
         assert_eq!(p.path, "src");
         assert!(p.case_insensitive);
         assert_eq!(p.file_type, "d");
@@ -782,7 +835,16 @@ mod tests {
         let dir = root.path().join("é".repeat(30));
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("f.txt"), "").unwrap();
-        let result = run("*.txt", root.path().to_str().unwrap(), 50, true, None, "f", false, 0);
+        let result = run(
+            "*.txt",
+            root.path().to_str().unwrap(),
+            50,
+            true,
+            None,
+            "f",
+            false,
+            0,
+        );
         assert!(result.is_ok());
     }
 
@@ -890,12 +952,18 @@ mod tests {
 
     #[test]
     fn parse_native_find_not_is_not_native() {
-        assert_eq!(class(&[".", "-name", "*.rs", "-not", "-name", "*_test.rs"]), "compress");
+        assert_eq!(
+            class(&[".", "-name", "*.rs", "-not", "-name", "*_test.rs"]),
+            "compress"
+        );
     }
 
     #[test]
     fn parse_native_find_exec_is_not_native() {
-        assert_eq!(class(&[".", "-name", "*.tmp", "-exec", "rm", "{}", ";"]), "verbatim");
+        assert_eq!(
+            class(&[".", "-name", "*.tmp", "-exec", "rm", "{}", ";"]),
+            "verbatim"
+        );
     }
 
     // --- parse_find_args: RTK syntax ---

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -60,8 +60,6 @@ fn next_arg(args: &[String], i: &mut usize) -> Option<String> {
     args.get(*i).cloned()
 }
 
-const RTK_FLAGS: &[&str] = &["-m", "--max", "-t", "--file-type"];
-
 const VERBATIM_ACTIONS: &[&str] = &[
     "-exec", "-execdir", "-ok", "-okdir", "-delete", "-print", "-print0", "-printf", "-fprint",
     "-fprint0", "-fprintf", "-ls", "-fls",
@@ -70,10 +68,9 @@ const VERBATIM_ACTIONS: &[&str] = &[
 enum Dispatch {
     Native(FindArgs),
     Compress {
+        options: Vec<String>,
         paths: Vec<String>,
         expr: Vec<String>,
-        max_results: usize,
-        max_explicit: bool,
     },
     Verbatim,
 }
@@ -86,148 +83,94 @@ fn has_glob_meta(token: &str) -> bool {
     token.contains('*') || token.contains('?')
 }
 
-fn subset_only(expr: &[String]) -> bool {
+/// Leading find options: `-H`, `-L`, `-P`, `-D debugopts`, `-Olevel`.
+fn leading_options_len(args: &[String]) -> usize {
     let mut i = 0;
-    while i < expr.len() {
-        match expr[i].as_str() {
-            "-name" | "-iname" => match expr.get(i + 1) {
-                Some(v) if !v.contains('[') => i += 2,
-                _ => return false,
-            },
-            "-type" => match expr.get(i + 1).map(String::as_str) {
-                Some("f") | Some("d") => i += 2,
-                _ => return false,
-            },
-            "-maxdepth" => match expr.get(i + 1) {
-                Some(v) if v.parse::<usize>().is_ok() => i += 2,
-                _ => return false,
-            },
-            _ => return false,
-        }
-    }
-    true
-}
-
-/// Native find syntax: `find [paths...] [expression]` (paths end at the first
-/// token starting with `-`, `!` or a parenthesis, exactly like find).
-/// RTK syntax (first token contains `*` or `?`): `find <pattern> [path] [-m max] [-t type]`
-fn dispatch(args: &[String]) -> Result<Dispatch> {
-    if args.is_empty() {
-        return Ok(Dispatch::Native(FindArgs::default()));
-    }
-    if !is_expression_token(&args[0]) && has_glob_meta(&args[0]) {
-        return parse_rtk_find_args(args).map(Dispatch::Native);
-    }
-
-    let split = args
-        .iter()
-        .position(|t| is_expression_token(t))
-        .unwrap_or(args.len());
-    let paths = args[..split].to_vec();
-    let expr = &args[split..];
-
-    if expr.iter().any(|t| VERBATIM_ACTIONS.contains(&t.as_str())) {
-        if expr.iter().any(|t| RTK_FLAGS.contains(&t.as_str())) {
-            anyhow::bail!(
-                "rtk find: -m/-t cannot be combined with find actions (-exec, -delete, -print0, ...)"
-            );
-        }
-        return Ok(Dispatch::Verbatim);
-    }
-
-    let mut find_expr: Vec<String> = Vec::new();
-    let mut max_results = FindArgs::default().max_results;
-    let mut max_explicit = false;
-    let mut rtk_type: Option<String> = None;
-    let mut i = 0;
-    while i < expr.len() {
-        match expr[i].as_str() {
-            "-m" | "--max" => {
-                let v = expr.get(i + 1).context("missing value for --max")?;
-                max_results = v.parse().context("invalid --max value")?;
-                max_explicit = true;
-                i += 2;
-            }
-            "-t" | "--file-type" => {
-                let v = expr.get(i + 1).context("missing value for --file-type")?;
-                rtk_type = Some(v.clone());
-                i += 2;
-            }
-            _ => {
-                find_expr.push(expr[i].clone());
-                i += 1;
-            }
-        }
-    }
-    if let Some(t) = rtk_type {
-        find_expr.push("-type".to_string());
-        find_expr.push(t);
-    }
-
-    if paths.len() <= 1 && subset_only(&find_expr) {
-        let mut native_args = paths.clone();
-        native_args.extend(find_expr.iter().cloned());
-        let mut parsed = if native_args.is_empty() {
-            FindArgs::default()
-        } else {
-            parse_native_find_args(&native_args)?
-        };
-        parsed.max_results = max_results;
-        parsed.max_explicit = max_explicit;
-        return Ok(Dispatch::Native(parsed));
-    }
-
-    Ok(Dispatch::Compress {
-        paths,
-        expr: find_expr,
-        max_results,
-        max_explicit,
-    })
-}
-
-/// Parse native find syntax: `find [path] -name "*.rs" -type f -maxdepth 3`
-fn parse_native_find_args(args: &[String]) -> Result<FindArgs> {
-    let mut parsed = FindArgs::default();
-    let mut i = 0;
-
-    // First non-flag argument is the path (standard find behavior)
-    if !args[0].starts_with('-') {
-        parsed.path = args[0].clone();
-        i = 1;
-    }
-
     while i < args.len() {
         match args[i].as_str() {
-            "-name" => {
-                if let Some(val) = next_arg(args, &mut i) {
-                    parsed.pattern = val;
-                }
-            }
-            "-iname" => {
-                if let Some(val) = next_arg(args, &mut i) {
-                    parsed.pattern = val;
-                    parsed.case_insensitive = true;
-                }
-            }
-            "-type" => {
-                if let Some(val) = next_arg(args, &mut i) {
-                    parsed.file_type = val;
-                }
-            }
-            "-maxdepth" => {
-                if let Some(val) = next_arg(args, &mut i) {
-                    parsed.max_depth = Some(val.parse().context("invalid -maxdepth value")?);
-                }
-            }
-            flag if flag.starts_with('-') => {
-                eprintln!("rtk find: unknown flag '{}', ignored", flag);
-            }
-            _ => {}
+            "-H" | "-L" | "-P" => i += 1,
+            "-D" if i + 1 < args.len() => i += 2,
+            t if t.len() > 2 && (t.starts_with("-D") || t.starts_with("-O")) => i += 1,
+            _ => break,
         }
-        i += 1;
+    }
+    i.min(args.len())
+}
+
+/// The subset rtk walks itself: one path, each of -name/-iname (globs with * and ?
+/// only), -type f|d, -maxdepth N, -m/--max N, -t/--file-type f|d at most once.
+fn parse_subset(paths: &[String], expr: &[String]) -> Option<FindArgs> {
+    if paths.len() > 1 {
+        return None;
+    }
+    let mut parsed = FindArgs::default();
+    if let Some(p) = paths.first() {
+        parsed.path = p.clone();
+    }
+    let mut seen_name = false;
+    let mut seen_type = false;
+    let mut seen_depth = false;
+    let mut seen_max = false;
+    let mut i = 0;
+    while i < expr.len() {
+        let value = expr.get(i + 1)?;
+        match expr[i].as_str() {
+            "-name" | "-iname" if !seen_name && !value.contains('[') => {
+                parsed.pattern = value.clone();
+                parsed.case_insensitive = expr[i] == "-iname";
+                seen_name = true;
+            }
+            "-type" | "-t" | "--file-type" if !seen_type && (value == "f" || value == "d") => {
+                parsed.file_type = value.clone();
+                seen_type = true;
+            }
+            "-maxdepth" if !seen_depth => {
+                parsed.max_depth = Some(value.parse().ok()?);
+                seen_depth = true;
+            }
+            "-m" | "--max" if !seen_max => {
+                parsed.max_results = value.parse().ok()?;
+                parsed.max_explicit = true;
+                seen_max = true;
+            }
+            _ => return None,
+        }
+        i += 2;
+    }
+    Some(parsed)
+}
+
+/// find syntax: `find [options] [paths...] [expression]` — paths end at the first
+/// token starting with `-`, `!` or a parenthesis, exactly like find.
+/// RTK syntax (first token contains `*` or `?`): `find <pattern> [path] [-m max] [-t type]`
+fn dispatch(args: &[String]) -> Result<Dispatch> {
+    let options = args[..leading_options_len(args)].to_vec();
+    let rest = &args[options.len()..];
+
+    if options.is_empty() && !rest.is_empty() && !is_expression_token(&rest[0]) && has_glob_meta(&rest[0]) {
+        return parse_rtk_find_args(rest).map(Dispatch::Native);
     }
 
-    Ok(parsed)
+    let split = rest
+        .iter()
+        .position(|t| is_expression_token(t))
+        .unwrap_or(rest.len());
+    let paths = rest[..split].to_vec();
+    let expr = rest[split..].to_vec();
+
+    if expr.iter().any(|t| VERBATIM_ACTIONS.contains(&t.as_str())) {
+        return Ok(Dispatch::Verbatim);
+    }
+    if options.is_empty() {
+        if let Some(parsed) = parse_subset(&paths, &expr) {
+            return Ok(Dispatch::Native(parsed));
+        }
+    }
+    Ok(Dispatch::Compress {
+        options,
+        paths,
+        expr,
+    })
 }
 
 /// Parse RTK syntax: `find <pattern> [path] [-m max] [-t type]`
@@ -292,19 +235,15 @@ fn run_verbatim(args: &[String], verbose: u8) -> Result<()> {
     Ok(())
 }
 
-fn run_compress(
-    paths: &[String],
-    expr: &[String],
-    max_results: usize,
-    max_explicit: bool,
-    verbose: u8,
-) -> Result<()> {
+fn run_compress(options: &[String], paths: &[String], expr: &[String], verbose: u8) -> Result<()> {
     let timer = tracking::TimedExecution::start();
     if verbose > 0 {
         eprintln!("find: results from find, compressed by rtk");
     }
+    let defaults = FindArgs::default();
+    let (max_results, max_explicit) = (defaults.max_results, defaults.max_explicit);
     let mut cmd = crate::core::utils::resolved_command("find");
-    cmd.args(paths);
+    cmd.args(options).args(paths);
     if !expr.is_empty() {
         cmd.arg("(");
         cmd.args(expr);
@@ -323,7 +262,12 @@ fn run_compress(
         .split(|b| *b == 0)
         .filter(|s| !s.is_empty())
         .collect();
-    let track_cmd = format!("find {} {}", paths.join(" "), expr.join(" "));
+    let track_cmd = format!(
+        "find {} {} {}",
+        options.join(" "),
+        paths.join(" "),
+        expr.join(" ")
+    );
     if entries.iter().any(|e| std::str::from_utf8(e).is_err()) {
         let raw: Vec<u8> = entries.iter().flat_map(|e| [*e, b"\n"].concat()).collect();
         let mut stdout = std::io::stdout().lock();
@@ -335,7 +279,10 @@ fn run_compress(
             .iter()
             .map(|e| {
                 let s = String::from_utf8_lossy(e);
-                s.strip_prefix("./").unwrap_or(&s).to_string()
+                match s.strip_prefix("./") {
+                    Some(rest) if !rest.is_empty() => rest.to_string(),
+                    _ => s.to_string(),
+                }
             })
             .collect();
         let raw_output = files.join("\n");
@@ -361,11 +308,10 @@ pub fn run_from_args(args: &[String], verbose: u8) -> Result<()> {
             verbose,
         ),
         Dispatch::Compress {
+            options,
             paths,
             expr,
-            max_results,
-            max_explicit,
-        } => run_compress(&paths, &expr, max_results, max_explicit, verbose),
+        } => run_compress(&options, &paths, &expr, verbose),
         Dispatch::Verbatim => run_verbatim(args, verbose),
     }
 }
@@ -382,7 +328,7 @@ fn group_by_dir(files: &[String]) -> HashMap<String, Vec<String>> {
         let filename = p
             .file_name()
             .map(|f| f.to_string_lossy().to_string())
-            .unwrap_or_default();
+            .unwrap_or_else(|| file.clone());
         by_dir.entry(dir).or_default().push(filename);
     }
     by_dir
@@ -717,26 +663,65 @@ mod tests {
     }
 
     #[test]
-    fn rtk_flags_with_actions_is_an_error() {
-        assert_eq!(class(&[".", "-name", "*.rs", "-m", "5", "-exec", "cat", "{}", ";"]), "error");
-    }
-
-    #[test]
-    fn rtk_flags_are_stripped_before_find_in_compress_mode() {
-        match dispatch(&args(&[".", "-mtime", "-7", "-m", "5", "-t", "d"])).unwrap() {
-            Dispatch::Compress {
-                paths,
-                expr,
-                max_results,
-                max_explicit,
-            } => {
+    fn rtk_flags_are_only_interpreted_in_the_native_subset() {
+        assert_eq!(class(&[".", "-name", "*.rs", "-m", "5", "-exec", "grep", "-m", "1", "x", "{}", ";"]), "verbatim");
+        match dispatch(&args(&[".", "-mtime", "-7", "-m", "5"])).unwrap() {
+            Dispatch::Compress { options, paths, expr } => {
+                assert!(options.is_empty());
                 assert_eq!(paths, args(&["."]));
-                assert_eq!(expr, args(&["-mtime", "-7", "-type", "d"]));
-                assert_eq!(max_results, 5);
-                assert!(max_explicit);
+                assert_eq!(expr, args(&["-mtime", "-7", "-m", "5"]));
             }
             _ => panic!("expected compress"),
         }
+    }
+
+    #[test]
+    fn leading_find_options_are_forwarded_ahead_of_paths() {
+        for a in [
+            &["-L", "src", "-name", "*.rs"][..],
+            &["-H", "src"],
+            &["-P", ".", "-type", "l"],
+            &["-D", "tree", ".", "-name", "x"],
+            &["-O2", ".", "-name", "x"],
+            &["-L"],
+        ] {
+            match dispatch(&args(a)).unwrap() {
+                Dispatch::Compress { options, paths, .. } => {
+                    assert!(!options.is_empty(), "{a:?}");
+                    assert!(paths.iter().all(|p| !p.starts_with('-')), "{a:?}");
+                }
+                _ => panic!("expected compress for {a:?}"),
+            }
+        }
+        assert_eq!(class(&["-D", "tree", ".", "-exec", "true", ";"]), "verbatim");
+    }
+
+    #[test]
+    fn repeated_subset_predicates_go_to_find() {
+        assert_eq!(class(&[".", "-name", "a", "-name", "b"]), "compress");
+        assert_eq!(class(&[".", "-iname", "*.txt", "-name", "*.TXT"]), "compress");
+        assert_eq!(class(&[".", "-type", "f", "-type", "d"]), "compress");
+        assert_eq!(class(&[".", "-maxdepth", "1", "-maxdepth", "2"]), "compress");
+        assert_eq!(class(&[".", "-name", "*.rs", "-m", "5", "-m", "6"]), "compress");
+    }
+
+    #[test]
+    fn subset_accepts_rtk_type_flag_and_iname() {
+        let p = parse_find_args(&args(&["src", "-iname", "README*", "-t", "d", "--max", "3"])).unwrap();
+        assert_eq!(p.path, "src");
+        assert!(p.case_insensitive);
+        assert_eq!(p.file_type, "d");
+        assert_eq!(p.max_results, 3);
+        assert!(p.max_explicit);
+        assert_eq!(class(&[".", "-type", "l"]), "compress");
+        assert_eq!(class(&[".", "-t", "x"]), "compress");
+    }
+
+    #[test]
+    fn root_entry_keeps_its_name() {
+        let ordered = display_ordered(&args(&[".", "a.rs"]));
+        assert_eq!(ordered, args(&[".", "a.rs"]));
+        assert_eq!(build_capped_listing(&ordered, 10), ".\na.rs\n");
     }
 
     #[test]


### PR DESCRIPTION
Started as the benchmark negative on find --max 10; grew into making rtk find correct on every input shape, per review.

rtk find now parses arguments like find: options, then paths, then the expression. So find src lists src instead of matching a file named src. rtk walks only the subset it models (-name/-iname globs, -type f|d, -maxdepth, each once). Any other listing predicate (-path, -mtime, -not, -o, -type l, brackets, -mindepth, -L ...) runs the real find and its results go through the same compressed renderer. Actions (-exec, -delete, -print0, -ok ...) run through runner::run_passthrough: live output, stdin inherited, exit code kept.

rtk's own -m/-t are read only as trailing tokens and apply to both native and compressed runs; combined with an action they are refused rather than dropped. Legacy 'find <pattern> ...' is rewritten to -name form and dispatched, never errors. The tee hint goes through runner::emit_guarded; default cap is CAP_INVENTORY; nonexistent path exits 1; no panic on long non-ASCII dir names.

Not changed, for the maintainer to decide: the native walker still skips hidden and gitignored entries and defaults to files (documented rtk behavior), and prints paths relative to the search root.

Verified: ~8k fuzzed invocations per iteration against GNU find and the pre-PR binary, 2713 tests, benchmark find cases all positive. The remaining CI red is the golangci-lint benchmark case, unrelated to this PR.