### PR TITLE
fix(npm): stream filtered output before exit

### DIFF
--- a/src/cmds/js/npm_cmd.rs
+++ b/src/cmds/js/npm_cmd.rs
@@ -1,6 +1,7 @@
 //! Filters npm output and auto-injects the "run" subcommand when appropriate.
 
 use crate::core::runner;
+use crate::core::stream::{LineHandler, LineStreamFilter};
 use crate::core::utils::resolved_command;
 use anyhow::Result;
 
@@ -106,8 +107,7 @@ pub fn exec(args: &[String], verbose: u8, skip_env: bool) -> Result<i32> {
 /// Shared command-execution path for `run` (npm) and `exec` (npx).
 ///
 /// Builds the resolved command, appends args, applies `SKIP_ENV_VALIDATION`,
-/// emits the verbose log line, and routes through `runner::run_filtered` with
-/// the npm output filter.
+/// emits the verbose log line, and streams through the npm output filter.
 fn run_filtered(name: &str, args: &[String], verbose: u8, skip_env: bool) -> Result<i32> {
     let mut cmd = resolved_command(name);
     for arg in args {
@@ -123,48 +123,71 @@ fn run_filtered(name: &str, args: &[String], verbose: u8, skip_env: bool) -> Res
         eprintln!("Running: {} {}", name, args_display);
     }
 
-    runner::run_filtered(
+    runner::run_streamed(
         cmd,
         name,
         &args_display,
-        filter_npm_output,
+        Box::new(LineStreamFilter::new(NpmLineHandler::default())),
         runner::RunOptions::default(),
     )
 }
 
-/// Filter npm run output - strip boilerplate, progress bars, npm WARN
-fn filter_npm_output(output: &str) -> String {
-    let mut result = Vec::new();
+#[derive(Default)]
+struct NpmLineHandler {
+    emitted_line: bool,
+}
 
-    for line in output.lines() {
+impl LineHandler for NpmLineHandler {
+    fn should_skip(&mut self, line: &str) -> bool {
         // Skip npm boilerplate
         if line.starts_with('>') && line.contains('@') {
-            continue;
+            return true;
         }
         // Skip npm lifecycle scripts
         if line.trim_start().starts_with("npm WARN") {
-            continue;
+            return true;
         }
         if line.trim_start().starts_with("npm notice") {
-            continue;
+            return true;
         }
         // Skip progress indicators
         if line.contains("⸩") || line.contains("⸨") || line.contains("...") && line.len() < 10 {
-            continue;
+            return true;
         }
         // Skip empty lines
         if line.trim().is_empty() {
-            continue;
+            return true;
         }
 
-        result.push(line.to_string());
+        false
     }
 
-    if result.is_empty() {
-        "ok".to_string()
-    } else {
-        result.join("\n")
+    fn observe_line(&mut self, _line: &str) {
+        self.emitted_line = true;
     }
+
+    fn format_summary(&self, _exit_code: i32, raw: &str) -> Option<String> {
+        if self.emitted_line || raw.is_empty() {
+            return None;
+        }
+
+        Some(crate::core::guard::never_worse(raw, "ok\n").to_string())
+    }
+}
+
+#[cfg(test)]
+fn filter_npm_output(output: &str) -> String {
+    use crate::core::stream::StreamFilter;
+
+    let mut filter = LineStreamFilter::new(NpmLineHandler::default());
+    let mut filtered = output
+        .lines()
+        .filter_map(|line| filter.feed_line(line))
+        .collect::<String>();
+    if let Some(summary) = filter.on_exit(0, output) {
+        filtered.push_str(&summary);
+    }
+    filtered.trim_end_matches('\n').to_string()
 }
 
 #[cfg(test)]
@@ -188,6 +211,31 @@ npm notice
         assert!(!result.contains("npm notice"));
         assert!(!result.contains("> project@"));
         assert!(result.contains("Build completed"));
+    }
+
+    #[test]
+    fn test_filter_npm_output_preserves_line_filtering_semantics() {
+        let output = "> project@1.0.0 build\n\
+> next build\n\
+  npm WARN deprecated package\n\
+npm notice update available\n\
+⸩\n\
+...\n\
+\n\
+meaningful output\n";
+
+        assert_eq!(filter_npm_output(output), "> next build\nmeaningful output");
+    }
+
+    #[test]
+    fn test_filter_npm_output_all_filtered() {
+        let output = "> project@1.0.0 build\nnpm WARN hidden\nnpm notice hidden\n\n";
+        assert_eq!(filter_npm_output(output), "ok");
+    }
+
+    #[test]
+    fn test_filter_npm_output_truly_silent() {
+        assert_eq!(filter_npm_output(""), "");
     }
 
     #[test]

--- a/tests/npm_streaming_test.rs
+++ b/tests/npm_streaming_test.rs
@@ -1,0 +1,142 @@
+#![cfg(unix)]
+
+use std::io::{BufRead, BufReader, Read};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
+
+fn npm_is_available() -> bool {
+    Command::new("npm")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+#[test]
+fn npm_silent_success_preserves_zero_byte_output() {
+    if !npm_is_available() {
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("create npm fixture directory");
+    std::fs::write(
+        dir.path().join("package.json"),
+        r#"{
+  "private": true,
+  "scripts": {
+    "silent": "node silent.mjs"
+  }
+}
+"#,
+    )
+    .expect("write package.json");
+    std::fs::write(dir.path().join("silent.mjs"), b"").expect("write silent script");
+
+    let raw = Command::new("npm")
+        .args(["run", "--silent", "silent"])
+        .current_dir(dir.path())
+        .output()
+        .expect("run silent npm script directly");
+    assert!(raw.status.success(), "raw npm script should succeed");
+    assert_eq!(
+        raw.stdout, b"",
+        "fixture must produce zero raw stdout bytes"
+    );
+    assert_eq!(
+        raw.stderr, b"",
+        "fixture must produce zero raw stderr bytes"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args(["npm", "run", "--silent", "silent"])
+        .current_dir(dir.path())
+        .env("RTK_DB_PATH", dir.path().join("tracking.db"))
+        .output()
+        .expect("run silent npm script through rtk");
+
+    assert!(output.status.success(), "rtk npm should preserve success");
+    assert_eq!(output.stdout, b"", "zero raw stdout must stay silent");
+    assert_eq!(output.stderr, b"", "zero raw stderr must stay silent");
+}
+
+#[test]
+fn npm_emits_meaningful_stdout_before_script_exits() {
+    if !npm_is_available() {
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("create npm fixture directory");
+    std::fs::write(
+        dir.path().join("package.json"),
+        r#"{
+  "private": true,
+  "scripts": {
+    "ready": "node ready.mjs"
+  }
+}
+"#,
+    )
+    .expect("write package.json");
+    std::fs::write(
+        dir.path().join("ready.mjs"),
+        r#"import { existsSync } from "node:fs";
+
+console.log("READY npm-streaming-regression");
+console.error("meaningful npm stderr");
+const deadline = Date.now() + 15_000;
+const timer = setInterval(() => {
+  if (existsSync(process.env.RTK_TEST_STOP_FILE) || Date.now() >= deadline) {
+    clearInterval(timer);
+  }
+}, 20);
+"#,
+    )
+    .expect("write readiness script");
+
+    let stop_file = dir.path().join("stop");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args(["npm", "run", "--silent", "ready"])
+        .current_dir(dir.path())
+        .env("RTK_TEST_STOP_FILE", &stop_file)
+        .env("RTK_DB_PATH", dir.path().join("tracking.db"))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn rtk npm");
+    let stdout = child.stdout.take().expect("capture rtk stdout");
+    let stderr = child.stderr.take().expect("capture rtk stderr");
+    let (tx, rx) = mpsc::channel();
+    let reader = std::thread::spawn(move || {
+        let mut line = String::new();
+        BufReader::new(stdout)
+            .read_line(&mut line)
+            .expect("read readiness line");
+        tx.send(line).ok();
+    });
+    let stderr_reader = std::thread::spawn(move || {
+        let mut output = String::new();
+        BufReader::new(stderr)
+            .read_to_string(&mut output)
+            .expect("read rtk stderr");
+        output
+    });
+
+    let streamed = rx.recv_timeout(Duration::from_secs(5));
+    let child_was_alive = child.try_wait().expect("poll rtk npm").is_none();
+
+    std::fs::write(&stop_file, b"stop").expect("signal readiness script to stop");
+    let output_status = child.wait().expect("wait for rtk npm");
+    reader.join().expect("join stdout reader");
+    let stderr = stderr_reader.join().expect("join stderr reader");
+
+    let line = streamed.expect("readiness should be emitted before the npm script exits");
+    assert_eq!(line, "READY npm-streaming-regression\n");
+    assert!(
+        child_was_alive,
+        "npm script exited before readiness was read"
+    );
+    assert!(output_status.success(), "rtk npm should preserve success");
+    assert_eq!(stderr, "meaningful npm stderr\n");
+}


### PR DESCRIPTION
## Summary

- stream npm/npx output through RTK's existing line-filter pipeline instead of retaining stdout until child exit
- preserve npm boilerplate/warning/progress filtering and the existing `ok` result when every line is filtered
- add an integration regression that proves readiness stdout and meaningful stderr are observable while the npm script is still alive

## Why

`rtk npm` used `FilterMode::CaptureOnly`, so a long-running npm script could emit a readiness receipt but its parent would not see that receipt until the child exited. This breaks dev servers, watchers, daemons, and agent orchestration that starts a background service before launching a dependent worker.

The npm filter is line-oriented, so it can use RTK's existing streaming abstraction without guessing which script names are long-running and without disabling filtering.

Fixes #3604.

## Validation

- `cargo test --test npm_streaming_test`
- `cargo test cmds::js::npm_cmd::tests`
- `cargo fmt --all --check`
- `cargo clippy --all-targets`
- `cargo test` — 2693 passed, 8 ignored
- manual built-binary smoke: readiness appeared in the parent process output while the npm child remained alive
- quiet-script parity: installed and patched binaries both returned `ok\n`, exit 0
