### PR TITLE
fix(hooks): keep the hook protocol channel free of the setup nag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1595,7 +1595,18 @@ fn run_cli() -> Result<i32> {
 
     // Warn if installed hook is outdated/missing (1/day, non-blocking).
     // Skip for Gain — it shows its own inline hook warning.
-    if !matches!(cli.command, Commands::Gain { .. }) {
+    //
+    // Also skip for Hook and Rewrite: those *are* the hook, and their stdout and
+    // stderr are a protocol channel the calling agent parses. A stray line there
+    // is exactly the stderr pollution the quiet-stderr guard is about — and on Windows the agent
+    // merges stderr into its context, so one nag costs more tokens than the
+    // command saved. This only ever fired for users who have Claude Code
+    // installed without the rtk hook, which is why CI (no `~/.claude` at all,
+    // so `status()` reports Ok) never caught it.
+    if !matches!(
+        cli.command,
+        Commands::Gain { .. } | Commands::Hook { .. } | Commands::Rewrite { .. }
+    ) {
         hooks::hook_check::maybe_warn();
     }
 


### PR DESCRIPTION
## Problem

`rtk hook` and `rtk rewrite` **are** the hook. The agent that invokes them parses their stdout and stderr as a protocol channel, so an extra line there is corruption, not a diagnostic.

`maybe_warn()` was allowed to fire for both. On a machine that has Claude Code installed but not the rtk hook, that puts

```
[rtk] /!\ No hook installed - run `rtk init -g` for automatic token savings
```

into the protocol stream once a day. `Gain` was already excluded for exactly this reason; `Hook` and `Rewrite` were missed.

## This is not theoretical

On such a machine, ten tests in `tests/copilot_selfheal_test.rs` fail today — every one on the same assertion:

```
stderr must stay silent (protocol safety) for payload {"tool_name":"Bash",...},
got: [rtk] /!\ No hook installed - run `rtk init -g` ...
```

CI never sees it because a fresh runner has no `~/.claude` at all, so `status()` returns Ok and the warning never fires. The tests are correct; the nag was leaking into a channel it must never touch.

## Fix

Add `Commands::Hook` and `Commands::Rewrite` to the same exclusion list `Commands::Gain` already sits in.

## Testing

No new test — `copilot_selfheal_test.rs` already pins this contract with 12 assertions on stderr silence; they were simply unreachable in CI. Before/after on an affected machine:

```
before: test result: FAILED. 2 passed; 10 failed
after:  test result: ok.    12 passed;  0 failed
```

Full suite, `cargo fmt --check`, and `cargo clippy --all-targets` clean on `x86_64-pc-windows-gnu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)