### PR TITLE
fix(test): make the invalid-UTF-8 assertion code-page independent

### DIFF
--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -608,7 +608,17 @@ pub(crate) mod tests {
         assert_eq!(lines.len(), 3, "got: {:?}", lines);
         assert_eq!(lines[0], "ERRO A: ascii");
         assert!(lines[1].starts_with("ERRO B: "), "got: {:?}", lines[1]);
-        assert!(lines[1].contains('\u{FFFD}'), "got: {:?}", lines[1]);
+        // The bad byte decodes to exactly one character, whatever that
+        // turns out to be: U+FFFD when there is no code page to consult,
+        // or the code page's own mapping (0xE3 is pi on cp437, a-tilde on
+        // cp1252). What must not happen is the byte taking the rest of
+        // the line with it.
+        assert_eq!(
+            lines[1].chars().count(),
+            "ERRO B: ".len() + 1,
+            "got: {:?}",
+            lines[1]
+        );
         assert_eq!(lines[2], "ERRO C: ascii again");
     }
 


### PR DESCRIPTION
## Problem

`test_read_lines_lossy_preserves_lines_after_invalid_utf8` asserts that the injected bad byte becomes `U+FFFD`. That is only true when there is no console code page to consult.

`read_lines_lossy` decodes through the console code page, so on a machine where one applies the byte legitimately decodes to a real character — `0xE3` is `π` on cp437, `ã` on cp1252 — and the test fails against a *correctly working* decoder:

```
panicked at src/core/stream.rs:611:9:
got: "ERRO B: π"
```

CI passes either way because a fresh runner's console has no code page to apply.

## Fix

The property this test exists to protect is not *which* character comes out — it is that one bad byte does not swallow the rest of the line. Assert that directly: the line is its prefix plus exactly one character, whatever that character decodes to. The surrounding assertions (line count, the lines before and after) are unchanged, so the regression it was written for is still pinned.

## Scope

Standalone on purpose. This is an existing test of yours, unrelated to any feature work, so it is not bundled with anything else.

## Testing

```
cargo test --bin rtk test_read_lines_lossy
test result: ok. 5 passed; 0 failed
```

`cargo clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)