### PR TITLE
fix(hooks): make the hook path work on Windows

### DIFF
--- a/src/hooks/hook_audit_cmd.rs
+++ b/src/hooks/hook_audit_cmd.rs
@@ -4,16 +4,12 @@ use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-/// Default log file location (aligned with hook's $HOME/.local/share/rtk/).
+/// Default log file location. Resolution lives in `hooks::audit_dir` so the
+/// reader here and the writer in `hook_cmd` can never disagree.
 fn default_log_path() -> PathBuf {
-    if let Ok(dir) = std::env::var("RTK_AUDIT_DIR") {
-        PathBuf::from(dir).join("hook-audit.log")
-    } else {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-        PathBuf::from(home)
-            .join(".local/share/rtk")
-            .join("hook-audit.log")
-    }
+    super::audit_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("hook-audit.log")
 }
 
 /// A single parsed audit log entry.

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -100,7 +100,13 @@ fn detect_format(v: &Value) -> HookFormat {
     if let Some(tool_name) = v.get("tool_name").and_then(|t| t.as_str()) {
         if matches!(
             tool_name,
-            "runTerminalCommand" | "run_in_terminal" | "Bash" | "bash"
+            "runTerminalCommand"
+                | "run_in_terminal"
+                | "Bash"
+                | "bash"
+                | "powershell"
+                | "pwsh"
+                | "cmd"
         ) {
             if let Some(cmd) = v
                 .pointer("/tool_input/command")
@@ -398,7 +404,11 @@ fn copilot_cli_response_from_decision(
 pub fn run_gemini() -> Result<()> {
     let input = read_stdin_limited()?;
 
-    let json: Value = serde_json::from_str(&input).context("Failed to parse hook input as JSON")?;
+    // Strip leading BOM(s) before parsing: some Windows hosts prepend UTF-8
+    // BOMs to hook stdin, which serde_json rejects.
+    let input = strip_leading_bom(&input);
+
+    let json: Value = serde_json::from_str(input).context("Failed to parse hook input as JSON")?;
 
     let tool_name = json.get("tool_name").and_then(|v| v.as_str()).unwrap_or("");
 
@@ -465,7 +475,8 @@ fn run_vibe_inner(input: &str) -> Option<String> {
     };
 
     let tool_name = json.get("tool_name").and_then(|v| v.as_str()).unwrap_or("");
-    if tool_name != "bash" {
+    // Support both bash and PowerShell on Windows
+    if !matches!(tool_name, "bash" | "powershell" | "pwsh" | "cmd") {
         return None;
     }
 
@@ -535,8 +546,7 @@ fn sanitize_log_field(s: &str) -> String {
 }
 
 fn audit_log_inner(action: &str, original: &str, rewritten: &str) -> Option<()> {
-    let home = dirs::home_dir()?;
-    let dir = home.join(".local").join("share").join("rtk");
+    let dir = super::audit_dir()?;
     crate::core::utils::create_private_dir(&dir).ok()?;
     let path = dir.join("hook-audit.log");
     let mut file = crate::core::utils::open_private(
@@ -630,7 +640,9 @@ fn process_claude_payload(v: &Value) -> PayloadAction {
 pub fn run_claude() -> Result<()> {
     let input = read_stdin_limited()?;
 
-    let input = input.trim();
+    // Strip leading BOM(s) before trimming: some Windows hosts prepend UTF-8
+    // BOMs to hook stdin (confirmed for Cursor/Copilot), which serde_json rejects.
+    let input = strip_leading_bom(&input).trim();
     if input.is_empty() {
         return Ok(());
     }

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -12,15 +12,66 @@ pub mod rewrite_cmd;
 pub mod trust;
 pub mod verify_cmd;
 
+/// Directory holding the hook audit log.
+///
+/// `RTK_AUDIT_DIR` overrides everything. Otherwise Windows uses
+/// `%LOCALAPPDATA%/rtk`, and Unix keeps the historic `$XDG_DATA_HOME/rtk`
+/// or `$HOME/.local/share/rtk` -- deliberately not `dirs::data_local_dir()`,
+/// which resolves to `~/Library/Application Support` on macOS and would
+/// silently move an existing user's log.
+pub fn audit_dir() -> Option<std::path::PathBuf> {
+    use std::path::PathBuf;
+
+    if let Ok(dir) = std::env::var("RTK_AUDIT_DIR") {
+        return Some(PathBuf::from(dir));
+    }
+
+    #[cfg(windows)]
+    {
+        std::env::var("LOCALAPPDATA")
+            .map(PathBuf::from)
+            .ok()
+            .or_else(dirs::data_local_dir)
+            .map(|d| d.join("rtk"))
+    }
+
+    #[cfg(not(windows))]
+    {
+        std::env::var("XDG_DATA_HOME")
+            .map(PathBuf::from)
+            .ok()
+            .or_else(|| dirs::home_dir().map(|h| h.join(".local").join("share")))
+            .map(|d| d.join("rtk"))
+    }
+}
+
 pub fn is_claude_hook_command(command: &str) -> bool {
     let parts = crate::discover::lexer::shell_split(command);
-    let [binary, hook, claude] = parts.as_slice() else {
+    let [_binary, hook, claude] = parts.as_slice() else {
         return false;
     };
 
-    let binary_name = binary.rsplit(['/', '\\']).next().unwrap_or(binary);
+    // Take the binary's name from the raw text, not from `binary`.
+    // `shell_split` applies POSIX unquoting, which consumes the separators in a
+    // Windows path -- `C:\...\rtk.exe` arrives here as `C:...rtk.exe`, with
+    // nothing left for `rsplit` to find.
+    let raw = leading_token(command);
+    let binary_name = raw.rsplit(['/', '\\']).next().unwrap_or(raw);
 
-    binary_name == "rtk" && hook == "hook" && claude == "claude"
+    // `rtk.exe` is what the command reads on Windows.
+    (binary_name == "rtk" || binary_name.eq_ignore_ascii_case("rtk.exe"))
+        && hook == "hook"
+        && claude == "claude"
+}
+
+/// The command's first token, with one layer of surrounding quotes removed.
+fn leading_token(command: &str) -> &str {
+    let command = command.trim_start();
+    if let Some(rest) = command.strip_prefix(['"', '\'']) {
+        let quote = command.as_bytes()[0] as char;
+        return rest.split(quote).next().unwrap_or(rest);
+    }
+    command.split_whitespace().next().unwrap_or(command)
 }
 
 #[cfg(test)]
@@ -33,6 +84,15 @@ mod tests {
         assert!(is_claude_hook_command("/opt/homebrew/bin/rtk hook claude"));
         assert!(is_claude_hook_command(
             "\"/opt/homebrew/bin/rtk\" hook claude"
+        ));
+    }
+
+    #[test]
+    fn claude_hook_command_matches_windows_exe_and_backslash_path() {
+        assert!(is_claude_hook_command("rtk.exe hook claude"));
+        assert!(is_claude_hook_command("RTK.EXE hook claude"));
+        assert!(is_claude_hook_command(
+            r"C:\Users\me\AppData\Local\rtk\bin\rtk.exe hook claude"
         ));
     }
 


### PR DESCRIPTION
## Problem

Three defects, all on the path a Windows agent actually takes.

### 1. Hook input rejected outright

Some Windows hosts prepend a UTF-8 BOM to the JSON they write to hook stdin. `serde_json` refuses it, so `run_claude` and `run_gemini` died on the first byte:

```
Failed to parse hook input as JSON: expected value at line 1 column 1
```

`strip_leading_bom` already exists in this file for exactly this reason (the Cursor hook), it just was not applied to the Claude and Gemini entry points. On input without a BOM it is a no-op.

### 2. The hook did not recognize itself

`is_claude_hook_command` compared the binary name against `"rtk"`. On Windows the command reads `rtk.exe hook claude`, so the check failed and the hook was treated as an ordinary command.

Fixing the `.exe` suffix alone was not enough. `shell_split` applies POSIX unquoting, which **consumes the separators in a Windows path** — `C:\Users\me\...\rtk.exe` arrives as `C:Usersme...rtk.exe`, leaving nothing for the existing `rsplit(['/', '\'])` to find. The binary's name is now taken from the raw command text instead, so absolute Windows paths (quoted or not) match.

### 3. Audit log written somewhere unwritable

Reader and writer both hardcoded `$HOME/.local/share/rtk`, falling back to `/tmp`. On Windows `HOME` is frequently unset and `/tmp` does not exist. The two also disagreed — only the reader honoured `RTK_AUDIT_DIR`.

Resolution now lives in one `hooks::audit_dir()` that both call, so they cannot drift again.

> **Deliberately not `dirs::data_local_dir()`.** That is `~/Library/Application Support` on macOS, so adopting it would silently relocate an existing macOS user's audit log. Unix keeps the historic `$XDG_DATA_HOME` / `$HOME/.local/share`; only Windows gets `%LOCALAPPDATA%\rtk`.

Also accepts `powershell`, `pwsh` and `cmd` as terminal tool names alongside `bash`, since that is what Windows hosts report.

## Testing

New test `claude_hook_command_matches_windows_exe_and_backslash_path` covers bare `rtk.exe`, uppercase `RTK.EXE`, and a full `C:\...\rtk.exe` path — the last of which failed until the raw-token fix above. Existing `strip_leading_bom` and `is_claude_hook_command` tests still pass unchanged.

Full suite on `x86_64-pc-windows-gnu`: **2616 passed**. `cargo fmt --check` and `cargo clippy --all-targets` clean. The single unrelated failure on this toolchain is fixed in #3615.

## Not included

The Gemini hook wrapper is still generated as `#!/bin/bash`. Making it a Windows batch file also requires renaming `rtk-hook-gemini.sh` and teaching `hook_check` the new name, and I could not verify how the Gemini CLI invokes that file. Left for a separate, properly-verified PR rather than guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)