### PR TITLE
feat(core): let agents silence non-error stderr diagnostics

### DIFF
--- a/docs/guide/getting-started/configuration.md
+++ b/docs/guide/getting-started/configuration.md
@@ -61,7 +61,30 @@ For full details on what is collected, opt-out options, and GDPR rights, see [Te
 | `RTK_TEE_DIR` | Override the tee directory |
 | `RTK_TELEMETRY_DISABLED=1` | Disable telemetry |
 | `RTK_HOOK_AUDIT=1` | Enable hook audit logging |
+| `RTK_QUIET=1` | Suppress non-error diagnostics on stderr (see below) |
 | `SKIP_ENV_VALIDATION=1` | Skip env validation (useful with Next.js) |
+
+### Quiet diagnostics (`RTK_QUIET` / `hooks.quiet`)
+
+When RTK cannot resolve a binary through `PATH` it falls back to a direct exec
+and prints a one-line note to stderr. That note is useful in a terminal and
+harmful inside an agent: on Windows the agent merges stderr into its context,
+so a diagnostic about a command that worked anyway costs more tokens than the
+command saved.
+
+Silence it per-invocation with an environment variable, or permanently in the
+config file:
+
+```powershell
+$env:RTK_QUIET = '1'
+```
+
+```toml
+[hooks]
+quiet = true
+```
+
+Real errors are still reported; only informational output is suppressed.
 
 ## Tee system
 

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -51,6 +51,13 @@ pub struct HooksConfig {
     /// not anything else.
     #[serde(default)]
     pub transparent_prefixes: Vec<String>,
+
+    /// Suppress non-error diagnostic output to stderr during hook execution.
+    /// When true, only actual errors are written to stderr; informational
+    /// messages (PATH resolution warnings, etc.) are silenced. This prevents
+    /// stderr pollution in AI agent contexts that merge stderr into the prompt.
+    #[serde(default)]
+    pub quiet: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -224,6 +231,19 @@ exclude_commands = ["curl", "gh"]
         let config = Config::default();
         assert!(config.hooks.exclude_commands.is_empty());
         assert!(config.hooks.transparent_prefixes.is_empty());
+    }
+
+    #[test]
+    fn test_hooks_quiet_defaults_off_and_deserializes() {
+        // Off unless asked for: existing users see no change.
+        assert!(!Config::default().hooks.quiet);
+
+        let config: Config = toml::from_str("[hooks]\nquiet = true\n").expect("valid toml");
+        assert!(config.hooks.quiet);
+
+        // A config predating the field must still parse.
+        let config: Config = toml::from_str("[hooks]\n").expect("valid toml");
+        assert!(!config.hooks.quiet);
     }
 
     #[test]

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -365,6 +365,20 @@ pub fn resolve_binary(name: &str) -> Result<PathBuf> {
     which::which(name).context(format!("Binary '{}' not found on PATH", name))
 }
 
+/// `hooks.quiet` from the config file, read once per process.
+///
+/// `Config::load` re-reads and re-parses the file on every call, and this sits
+/// on the command-resolution path, so the answer is cached rather than paid for
+/// each time a lookup falls back.
+fn hooks_quiet() -> bool {
+    static QUIET: OnceLock<bool> = OnceLock::new();
+    *QUIET.get_or_init(|| {
+        crate::core::config::Config::load()
+            .map(|c| c.hooks.quiet)
+            .unwrap_or(false)
+    })
+}
+
 /// Create a `Command` with PATHEXT-aware binary resolution.
 ///
 /// Drop-in replacement for `Command::new(name)` that works on Windows
@@ -385,7 +399,10 @@ pub fn resolved_command(name: &str) -> Command {
             // On Windows, resolution failure likely means a .CMD/.BAT wrapper
             // wasn't found — always warn so users have a signal.
             // On Unix, this is less common; only log in debug builds.
-            if cfg!(any(target_os = "windows", debug_assertions)) {
+            // Respect quiet mode: RTK_QUIET=1 or hooks.quiet in the config.
+            let quiet = std::env::var("RTK_QUIET").as_deref() == Ok("1") || hooks_quiet();
+
+            if !quiet && cfg!(any(target_os = "windows", debug_assertions)) {
                 eprintln!(
                     "rtk: Failed to resolve '{}' via PATH, falling back to direct exec: {}",
                     name, e


### PR DESCRIPTION
## Problem

When binary resolution through `PATH` fails, RTK falls back to a direct exec and prints a note to stderr:

```
rtk: Failed to resolve 'x' via PATH, falling back to direct exec: ...
```

In a terminal that is a useful signal. Inside an agent it is the opposite:

- The command **still ran**. Nothing failed.
- On Windows the agent merges stderr into its context, so the note lands in the prompt.
- A diagnostic about a command that worked costs more tokens than the filter saved.

Not spending those tokens is the entire point of the project.

## Fix

Two opt-ins, both default off:

```powershell
$env:RTK_QUIET = '1'
```

```toml
[hooks]
quiet = true
```

Informational stderr is suppressed; **real errors are untouched**. Existing users see no change.

## Performance note

The config lookup is cached in a `OnceLock`. `Config::load()` re-reads and re-parses the file on every call, and this sits on the command-resolution path — reading it uncached would put file I/O on the critical path the project explicitly keeps clear ("no config file I/O on the critical path"). With the cache, the cost is one read per process, only when a PATH lookup actually falls back.

## Testing

`test_hooks_quiet_defaults_off_and_deserializes` pins all three cases: default off, `quiet = true` parses, and a config predating the field still parses. The suppression itself is a single `!quiet &&` guard on an existing branch, gated on env/config that a unit test cannot mutate without racing other tests.

Docs added to `docs/guide/getting-started/configuration.md`.

Full suite on `x86_64-pc-windows-gnu`: **2615 passed**. `cargo fmt --check` and `cargo clippy --all-targets` clean. The single unrelated failure on this toolchain is fixed in #3615.

🤖 Generated with [Claude Code](https://claude.com/claude-code)