### PR TITLE
docs(gh): clarify api passthrough

### DIFF
--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -469,7 +469,11 @@ rtk gh <sous-commande> [args...]
 | `rtk gh pr checks` | Status des checks CI | ~79% |
 | `rtk gh issue list` | Liste des issues compacte | ~80% |
 | `rtk gh run list` | Status des workflow runs | ~82% |
-| `rtk gh api <endpoint>` | Reponse API compacte | ~26% |
+| `rtk gh api <endpoint>` | Reponse API complete (passthrough intentionnel) | 0% |
+
+`rtk gh api` preserve volontairement la reponse complete pour ne pas perdre
+de valeurs. Filtrez la reponse a la source avec `--jq` lorsque vous n'avez
+besoin que de champs specifiques.
 
 **Avant / Apres :**
 ```

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -177,13 +177,13 @@ rtk git worktree        # Compact worktree
 
 Note: Git passthrough works for ALL subcommands, even those not explicitly listed.
 
-### GitHub (26-87% savings)
+### GitHub (79-87% savings)
 ```bash
 rtk gh pr view <num>    # Compact PR view (87%)
 rtk gh pr checks        # Compact PR checks (79%)
 rtk gh run list         # Compact workflow runs (82%)
 rtk gh issue list       # Compact issue list (80%)
-rtk gh api              # Compact API responses (26%)
+rtk gh api              # Intentional passthrough (0%); filter at the source with --jq
 ```
 
 ### JavaScript/TypeScript Tooling (70-90% savings)


### PR DESCRIPTION
## Summary

- Correct the documented behavior of `rtk gh api` to its intentional 0% passthrough.
- Remove the incorrect 26% saving from the generated `rtk init` guidance.
- Recommend filtering API output at the source with `--jq`.

Closes #3448

## Validation

- `git diff --check`
- Rust toolchain is not installed in this environment, so `cargo fmt` and tests could not be run.