### PR TITLE
feat(filters): add sqlite3 TOML filter

### DIFF
--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -1864,6 +1864,7 @@ match_command = "^make\\b"
             "shellcheck",
             "shopify-theme",
             "sops",
+            "sqlite3",
             "swift-build",
             "systemctl-status",
             "terraform-plan",
@@ -1892,8 +1893,8 @@ match_command = "^make\\b"
         let filters = make_filters(BUILTIN_TOML);
         assert_eq!(
             filters.len(),
-            63,
-            "Expected exactly 63 built-in filters, got {}. \
+            64,
+            "Expected exactly 64 built-in filters, got {}. \
              Update this count when adding/removing filters in src/filters/.",
             filters.len()
         );
@@ -1950,11 +1951,11 @@ expected = "output line 1\noutput line 2"
         let combined = format!("{}\n\n{}", BUILTIN_TOML, new_filter);
         let filters = make_filters(&combined);
 
-        // All 63 existing filters still present + 1 new = 64
+        // All 64 existing filters still present + 1 new = 65
         assert_eq!(
             filters.len(),
-            64,
-            "Expected 64 filters after concat (63 built-in + 1 new)"
+            65,
+            "Expected 65 filters after concat (64 built-in + 1 new)"
         );
 
         // New filter is discoverable

--- a/src/filters/sqlite3.toml
+++ b/src/filters/sqlite3.toml
@@ -1,0 +1,30 @@
+[filters.sqlite3]
+description = "Compact sqlite3 CLI output — strip column-mode header underlines, empty lines, and the sqliterc loading banner"
+match_command = "^sqlite3\\b"
+strip_ansi = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^Loading resources from ",
+  "^-+(\\s+-+)+\\s*$",
+]
+on_empty = "sqlite3: no rows"
+
+[[tests.sqlite3]]
+name = "strips column-mode underline, keeps header and rows"
+input = "id  name\n--  -----\n1   alice\n2   bob\n"
+expected = "id  name\n1   alice\n2   bob\n"
+
+[[tests.sqlite3]]
+name = "strips empty lines, keeps list-mode rows"
+input = "1|alice\n\n2|bob\n"
+expected = "1|alice\n2|bob\n"
+
+[[tests.sqlite3]]
+name = "strips sqliterc loading banner"
+input = "Loading resources from /Users/me/.sqliterc\n1\n"
+expected = "1\n"
+
+[[tests.sqlite3]]
+name = "passthrough compact default list mode"
+input = "1|alice\n2|bob\n"
+expected = "1|alice\n2|bob\n"


### PR DESCRIPTION
## Summary

Adds a built-in TOML filter for the `sqlite3` CLI (`src/filters/sqlite3.toml`, `match_command = "^sqlite3\b"`), same shape as the existing `jq.toml` / `ssh.toml` filters.

Strips only always-uninteresting decoration:
- column-mode header underlines (`--  -----`)
- empty lines
- the sqliterc `Loading resources from` banner

Default list-mode query rows (`1|alice`) pass through untouched. No `max_lines` / `truncate_lines_at` (position-based cuts).

## Why TOML, not a Rust module

Open PR #1972 (`feat(sqlite): add sqlite3 filter with table output compression`) is a Rust `sqlite_cmd.rs` wrapper with a 50-row cap — currently `DIRTY` / `CONFLICTING`. This PR is the smaller TOML slice, matching how `jq` and `ssh` already ship, so it can land independently. Happy to close this if #1972 is the preferred path.

Related: #1253, #1605, #3196 (mentions sqlite3 as a secondary case).

## Proof against stock rtk 0.45.0

Project-local copy of this filter, trusted vs untrusted, on macOS, binary `/Users/Michael/.local/bin/rtk` = rtk 0.45.0:

**Representative command** (kit corpus uses `sqlite3 -header -column`, e.g. hum-rail):

```
sqlite3 -header -column :memory: "CREATE TABLE t(id INTEGER, name TEXT);" \
  "INSERT INTO t VALUES (1,'alice'),(2,'bob');" "SELECT * FROM t;"
```

| Arm | hook rewrite | bytes | output |
|---|---|---|---|
| untrusted | `No rewrite for: sqlite3 ...` | 40 | keeps `--  -----` underline |
| trusted | `rtk sqlite3 -header -column ...` (rewrite rc=0) | 30 | underline stripped; header + rows kept |

Default list-mode `SELECT` is identical on both arms (14 bytes, `1\|alice\n2\|bob\n`) — already compact; the filter is a no-op there by design.

`rtk verify --filter sqlite3` → `4/4 tests passed` once trusted.

## Test plan

- [ ] `cargo test --lib test_builtin_filter_count test_builtin_all_expected_filters_present test_new_filter_discoverable_after_concat test_builtin_all_filters_have_inline_tests`
- [ ] Manual: `rtk sqlite3 -header -column db.sqlite "SELECT * FROM t LIMIT 5"` drops the underline
- [ ] Manual: `rtk sqlite3 db.sqlite "SELECT 1"` passthrough