### PR TITLE
fix(copilot): make checked-in PreToolUse hook work with current Copilot CLI

### DIFF
--- a/.github/hooks/rtk-rewrite.json
+++ b/.github/hooks/rtk-rewrite.json
@@ -1,9 +1,9 @@
 {
   "hooks": {
-    "PreToolUse": [
+    "preToolUse": [
       {
         "type": "command",
-        "command": "rtk hook",
+        "command": "rtk hook copilot",
         "cwd": ".",
         "timeout": 5
       }


### PR DESCRIPTION
## Summary

The repo-scoped Copilot hook `.github/hooks/rtk-rewrite.json` (added in #605) has two defects that compound on current Copilot CLI:

1. **`"command": "rtk hook"` is missing the required subcommand.** Bare `rtk hook` prints usage and exits 2. Command `preToolUse` hooks are **fail-closed** in current Copilot CLI (any non-zero exit denies the tool call), so every shell call in this repository is denied and Copilot sessions here are completely blocked. On older CLI versions this only logged spurious `parse_failure` entries (#836).

2. **PascalCase `"PreToolUse"` selects the VS Code-compatible snake_case payload.** That routes through the VS Code response path (`hookSpecificOutput` + `permissionDecision: "ask"`), and Copilot CLI >= 1.0.66 honors `ask` — prompting on every single command interactively and hard-denying in `-p` mode (#3037). The native camelCase `"preToolUse"` event delivers the documented `toolName`/`toolArgs` payload, and the hook answers with `modifiedArgs`, which the CLI applies transparently.

## Fix

```diff
-    "PreToolUse": [
+    "preToolUse": [
       {
         "type": "command",
-        "command": "rtk hook",
+        "command": "rtk hook copilot",
```

This matches what `rtk init --copilot` already generates correctly today.

## Verification (Copilot CLI 1.0.80, macOS)

- `echo '<toolName/toolArgs payload>' | rtk hook copilot` exits 0 and emits `{"permissionDecision":"allow","modifiedArgs":{...}}` (with #3149 behavior).
- End-to-end: `copilot -p "run: git status"` in this repo executes the transparently rewritten `rtk git status` (rtk-compressed output observed in the tool result), no permission prompt, no denial.
- Before the event-name fix, the same setup denied every command with `Denied by preToolUse hook (unable to ask user for confirmation): RTK auto-rewrite`.

Refs #836 (same broken command; that issue's parse_failure symptom is the old-CLI manifestation of defect 1). Complements #3149 (which fixed the response decision; this fixes the payload routing that still forces the VS Code path).

## Notes

- Config-only change; no Rust code touched, so the `cargo fmt/clippy/test` gate is unaffected. Verified manually end-to-end as described above.
- #837 (init cleanup of orphaned broken files) is complementary and still useful; this PR fixes the checked-in file itself.
