### PR TITLE
fix(hooks): detect wrapper scripts and settings.local.json when checking hook installation

### DIFF
--- a/docs/guide/resources/troubleshooting.md
+++ b/docs/guide/resources/troubleshooting.md
@@ -61,6 +61,7 @@ rtk gain    # should now show token savings stats
    ```bash
    cat ~/.claude/settings.json | grep rtk
    ```
+   RTK also recognizes the hook in `settings.local.json`, or wrapped in a shell script or inline `sh -c "rtk hook claude"` command.
 
 ## RTK not found after `cargo install`
 

--- a/src/hooks/hook_check.rs
+++ b/src/hooks/hook_check.rs
@@ -1,9 +1,13 @@
 //! Detects whether RTK hooks are installed and warns if they are outdated.
 
-use super::constants::{HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON};
+use super::constants::{
+    CLAUDE_HOOK_COMMAND, HOOKS_SUBDIR, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON,
+    SETTINGS_LOCAL_JSON,
+};
 use super::init::resolve_claude_dir;
-use super::is_claude_hook_command;
+use super::is_claude_hook_invocation;
 use crate::core::constants::RTK_DATA_DIR;
+use crate::discover::lexer::shell_split;
 use std::path::PathBuf;
 
 const CURRENT_HOOK_VERSION: u8 = 3;
@@ -57,9 +61,20 @@ pub fn status() -> HookStatus {
     }
 }
 
-/// Check if the native binary command is registered in settings.json
+/// Wrapper scripts larger than this are not inspected (avoid reading arbitrary large files).
+const MAX_WRAPPER_SCRIPT_BYTES: u64 = 64 * 1024;
+
+/// Check if the native binary command is registered in settings.json or
+/// settings.local.json, directly or via a wrapper script (e.g.
+/// `bash ~/.claude/hooks/rtk-pipe-guard.sh`) that pipes into it.
 fn binary_hook_registered(claude_dir: &std::path::Path) -> bool {
-    let settings_path = claude_dir.join(SETTINGS_JSON);
+    [SETTINGS_JSON, SETTINGS_LOCAL_JSON]
+        .iter()
+        .any(|file_name| settings_file_registers_hook(claude_dir, file_name))
+}
+
+fn settings_file_registers_hook(claude_dir: &std::path::Path, file_name: &str) -> bool {
+    let settings_path = claude_dir.join(file_name);
     let content = match std::fs::read_to_string(&settings_path) {
         Ok(c) if !c.trim().is_empty() => c,
         _ => return false,
@@ -76,12 +91,63 @@ fn binary_hook_registered(claude_dir: &std::path::Path) -> bool {
         Some(arr) => arr,
         None => return false,
     };
-    pre_tool_use
+    let commands: Vec<&str> = pre_tool_use
         .iter()
         .filter_map(|entry| entry.get("hooks")?.as_array())
         .flatten()
         .filter_map(|hook| hook.get("command")?.as_str())
-        .any(is_claude_hook_command)
+        .collect();
+
+    commands.iter().any(|cmd| is_claude_hook_invocation(cmd))
+        || commands
+            .iter()
+            .any(|cmd| wrapper_script_references_hook(cmd, claude_dir))
+}
+
+/// True if `cmd` invokes a wrapper script (directly, or via an interpreter/
+/// `env` prefix — see [`super::skip_wrapper_prefix`]) whose contents
+/// reference the rtk hook command.
+fn wrapper_script_references_hook(cmd: &str, claude_dir: &std::path::Path) -> bool {
+    let tokens = shell_split(cmd);
+    let Some(token) = super::skip_wrapper_prefix(&tokens).first() else {
+        return false;
+    };
+    if token.starts_with('$') {
+        return false; // unresolvable env-var path — can't be probed on disk
+    }
+
+    let home = dirs::home_dir();
+    let script_path = if let Some(rest) = token.strip_prefix("~/") {
+        match home {
+            Some(h) => h.join(rest),
+            None => return false,
+        }
+    } else if token.as_str() == "~" {
+        match home {
+            Some(h) => h.to_path_buf(),
+            None => return false,
+        }
+    } else {
+        let candidate = PathBuf::from(token);
+        if candidate.is_absolute() {
+            candidate
+        } else {
+            claude_dir.join(candidate)
+        }
+    };
+
+    let Ok(meta) = std::fs::metadata(&script_path) else {
+        return false;
+    };
+    if !meta.is_file() || meta.len() > MAX_WRAPPER_SCRIPT_BYTES {
+        return false;
+    }
+    let Ok(content) = std::fs::read_to_string(&script_path) else {
+        return false;
+    };
+    content
+        .lines()
+        .any(|line| !line.trim_start().starts_with('#') && line.contains(CLAUDE_HOOK_COMMAND))
 }
 
 /// Check if the installed hook is missing or outdated, warn once per day.
@@ -231,6 +297,186 @@ mod tests {
         .expect("write settings");
 
         assert!(binary_hook_registered(tmp.path()));
+    }
+
+    fn write_settings(claude_dir: &std::path::Path, file_name: &str, command: &str) {
+        std::fs::create_dir_all(claude_dir).unwrap();
+        let json = format!(
+            r#"{{"hooks":{{"{}":[{{"hooks":[{{"command":"{}"}}]}}]}}}}"#,
+            PRE_TOOL_USE_KEY,
+            command.replace('\\', "\\\\").replace('"', "\\\"")
+        );
+        std::fs::write(claude_dir.join(file_name), json).unwrap();
+    }
+
+    #[test]
+    fn test_binary_hook_registered_missing_settings() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(tmp.path()).unwrap();
+        assert!(!binary_hook_registered(tmp.path()));
+    }
+
+    #[test]
+    fn test_binary_hook_registered_settings_local_only() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_settings(tmp.path(), SETTINGS_LOCAL_JSON, CLAUDE_HOOK_COMMAND);
+        assert!(binary_hook_registered(tmp.path()));
+    }
+
+    #[test]
+    fn test_binary_hook_registered_inline_wrapper_string() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_settings(tmp.path(), SETTINGS_JSON, r#"bash -c "rtk hook claude""#);
+        assert!(binary_hook_registered(tmp.path()));
+    }
+
+    #[test]
+    fn test_binary_hook_registered_wrapper_script_with_hook_string() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let claude_dir = tmp.path();
+        let script_path = claude_dir.join(HOOKS_SUBDIR).join("rtk-pipe-guard.sh");
+        std::fs::create_dir_all(script_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &script_path,
+            format!("#!/bin/bash\ncat | {}\n", CLAUDE_HOOK_COMMAND),
+        )
+        .unwrap();
+        let command = format!("bash {}", script_path.display());
+        write_settings(claude_dir, SETTINGS_JSON, &command);
+        assert!(binary_hook_registered(claude_dir));
+    }
+
+    #[test]
+    fn test_binary_hook_registered_wrapper_script_without_hook_string() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let claude_dir = tmp.path();
+        let script_path = claude_dir.join(HOOKS_SUBDIR).join("unrelated.sh");
+        std::fs::create_dir_all(script_path.parent().unwrap()).unwrap();
+        std::fs::write(&script_path, "#!/bin/bash\necho hi\n").unwrap();
+        let command = format!("bash {}", script_path.display());
+        write_settings(claude_dir, SETTINGS_JSON, &command);
+        assert!(!binary_hook_registered(claude_dir));
+    }
+
+    #[test]
+    fn test_binary_hook_registered_wrapper_script_hook_only_in_comment() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let claude_dir = tmp.path();
+        let script_path = claude_dir.join(HOOKS_SUBDIR).join("rtk-pipe-guard.sh");
+        std::fs::create_dir_all(script_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &script_path,
+            format!("#!/bin/bash\n# {}\necho hi\n", CLAUDE_HOOK_COMMAND),
+        )
+        .unwrap();
+        let command = format!("bash {}", script_path.display());
+        write_settings(claude_dir, SETTINGS_JSON, &command);
+        assert!(!binary_hook_registered(claude_dir));
+    }
+
+    #[test]
+    fn test_binary_hook_registered_wrapper_script_hook_on_piped_line() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let claude_dir = tmp.path();
+        let script_path = claude_dir.join(HOOKS_SUBDIR).join("rtk-pipe-guard.sh");
+        std::fs::create_dir_all(script_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &script_path,
+            format!(
+                "#!/bin/bash\nprintf '%s' \"$INPUT\" | {}\n",
+                CLAUDE_HOOK_COMMAND
+            ),
+        )
+        .unwrap();
+        let command = format!("bash {}", script_path.display());
+        write_settings(claude_dir, SETTINGS_JSON, &command);
+        assert!(binary_hook_registered(claude_dir));
+    }
+
+    #[test]
+    fn test_binary_hook_registered_wrapper_quoted_path_with_space() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let claude_dir = tmp.path();
+        let script_path = claude_dir.join(HOOKS_SUBDIR).join("rtk pipe guard.sh");
+        std::fs::create_dir_all(script_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &script_path,
+            format!("#!/bin/bash\n{}\n", CLAUDE_HOOK_COMMAND),
+        )
+        .unwrap();
+        let command = format!("bash \"{}\"", script_path.display());
+        write_settings(claude_dir, SETTINGS_JSON, &command);
+        assert!(binary_hook_registered(claude_dir));
+    }
+
+    #[test]
+    fn test_binary_hook_registered_wrapper_bin_bash_prefix() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let claude_dir = tmp.path();
+        let script_path = claude_dir.join(HOOKS_SUBDIR).join("rtk-pipe-guard.sh");
+        std::fs::create_dir_all(script_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &script_path,
+            format!("#!/bin/bash\n{}\n", CLAUDE_HOOK_COMMAND),
+        )
+        .unwrap();
+        let command = format!("/bin/bash {}", script_path.display());
+        write_settings(claude_dir, SETTINGS_JSON, &command);
+        assert!(binary_hook_registered(claude_dir));
+    }
+
+    #[test]
+    fn test_binary_hook_registered_wrapper_env_prefix() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let claude_dir = tmp.path();
+        let script_path = claude_dir.join(HOOKS_SUBDIR).join("rtk-pipe-guard.sh");
+        std::fs::create_dir_all(script_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &script_path,
+            format!("#!/bin/bash\n{}\n", CLAUDE_HOOK_COMMAND),
+        )
+        .unwrap();
+        let command = format!("env RTK_LOG=1 bash {}", script_path.display());
+        write_settings(claude_dir, SETTINGS_JSON, &command);
+        assert!(binary_hook_registered(claude_dir));
+    }
+
+    /// Serialises tests that mutate the process-wide `HOME` env var.
+    static HOME_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn test_wrapper_script_tilde_resolves_via_home_not_claude_dir_parent() {
+        let _guard = HOME_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let fake_home = tempfile::tempdir().expect("tempdir");
+        let script_path = fake_home
+            .path()
+            .join(HOOKS_SUBDIR)
+            .join("rtk-pipe-guard.sh");
+        std::fs::create_dir_all(script_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &script_path,
+            format!("#!/bin/bash\n{}\n", CLAUDE_HOOK_COMMAND),
+        )
+        .unwrap();
+
+        // claude_dir sits far away from fake_home, so claude_dir.parent()
+        // would resolve "~/..." to the wrong directory — only dirs::home_dir()
+        // (backed by $HOME) resolves it to fake_home.
+        let unrelated = tempfile::tempdir().expect("tempdir");
+        let claude_dir = unrelated.path().join("nested").join("claude_config");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+
+        let orig_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", fake_home.path());
+        let command = "bash ~/hooks/rtk-pipe-guard.sh".to_string();
+        write_settings(&claude_dir, SETTINGS_JSON, &command);
+        let result = binary_hook_registered(&claude_dir);
+        match orig_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+
+        assert!(result);
     }
 
     #[test]

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -6859,6 +6859,43 @@ mod tests {
     }
 
     #[test]
+    fn test_remove_hook_from_json_preserves_wrapper_form() {
+        let mut json_content = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "/Users/test/.claude/hooks/rtk-rewrite.sh"
+                        }]
+                    },
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{
+                            "type": "command",
+                            "command": "env RTK_LOG=1 rtk hook claude"
+                        }]
+                    }
+                ]
+            }
+        });
+
+        let removed = remove_hook_from_json(&mut json_content);
+        assert!(removed);
+
+        // Only the legacy script entry is removed — a wrapper-form command
+        // is not an exact `rtk hook claude` invocation, so uninstall must
+        // leave it in place.
+        let pre_tool_use = json_content["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(pre_tool_use.len(), 1);
+        assert_eq!(
+            pre_tool_use[0]["hooks"][0]["command"].as_str().unwrap(),
+            "env RTK_LOG=1 rtk hook claude"
+        );
+    }
+
+    #[test]
     fn test_remove_hook_when_not_present() {
         let mut json_content = serde_json::json!({
             "hooks": {

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -23,6 +23,62 @@ pub fn is_claude_hook_command(command: &str) -> bool {
     binary_name == "rtk" && hook == "hook" && claude == "claude"
 }
 
+/// Broader match used only by wrapper-script detection (`hook_check`).
+/// Matches `rtk hook claude` after skipping any wrapper prefix (interpreter,
+/// `env`, flags, `KEY=VALUE` assignments — see [`is_wrapper_prefix_token`]),
+/// or — for the inline `sh -c "rtk hook claude"` form — a single leftover
+/// token that itself splits into that invocation.
+fn is_claude_hook_invocation(command: &str) -> bool {
+    is_claude_hook_invocation_parts(&crate::discover::lexer::shell_split(command))
+}
+
+fn is_claude_hook_invocation_parts(parts: &[String]) -> bool {
+    match skip_wrapper_prefix(parts) {
+        [binary, hook, claude] => {
+            hook == "hook"
+                && claude == "claude"
+                && binary.rsplit(['/', '\\']).next().unwrap_or(binary) == "rtk"
+        }
+        [single] => {
+            let inner = crate::discover::lexer::shell_split(single);
+            inner.len() > 1 && is_claude_hook_invocation_parts(&inner)
+        }
+        _ => false,
+    }
+}
+
+/// Shell interpreters skipped when locating the real command/script inside a
+/// wrapper invocation (`bash script.sh`, `env KEY=val rtk hook claude`, ...).
+const WRAPPER_INTERPRETERS: &[&str] = &["bash", "sh", "zsh"];
+
+/// `KEY=VALUE` env-assignment shape (bare identifier on the left of `=`).
+static ENV_ASSIGNMENT_RE: std::sync::LazyLock<regex::Regex> =
+    std::sync::LazyLock::new(|| regex::Regex::new(r"^[A-Za-z_][A-Za-z0-9_]*=").unwrap());
+
+/// True for tokens that only route to the real command and are never
+/// themselves the thing being located: shell flags, `KEY=VALUE` env
+/// assignments, unresolvable `$VAR`-prefixed paths, and interpreter/`env`
+/// binaries (matched by file name so `/bin/bash` and `bash` both skip).
+fn is_wrapper_prefix_token(token: &str) -> bool {
+    if token.starts_with('-') || token.starts_with('$') || ENV_ASSIGNMENT_RE.is_match(token) {
+        return true;
+    }
+    let name = std::path::Path::new(token)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(token);
+    name == "env" || WRAPPER_INTERPRETERS.contains(&name)
+}
+
+/// Strip a leading run of wrapper-prefix tokens (see [`is_wrapper_prefix_token`]).
+fn skip_wrapper_prefix(parts: &[String]) -> &[String] {
+    let skip = parts
+        .iter()
+        .take_while(|t| is_wrapper_prefix_token(t))
+        .count();
+    &parts[skip..]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -41,5 +97,40 @@ mod tests {
         assert!(!is_claude_hook_command("not-rtk hook claude"));
         assert!(!is_claude_hook_command("/opt/homebrew/bin/rtk hook cursor"));
         assert!(!is_claude_hook_command("echo rtk hook claude"));
+    }
+
+    #[test]
+    fn claude_hook_command_rejects_wrapper_forms() {
+        // Wrapper forms are matched by `is_claude_hook_invocation` only —
+        // `is_claude_hook_command` stays exact-3-token so uninstall/detection
+        // callers (init.rs, integrity.rs) never treat a wrapper entry as the
+        // direct hook and delete or mis-detect it.
+        assert!(!is_claude_hook_command(r#"bash -c "rtk hook claude""#));
+        assert!(!is_claude_hook_command("bash rtk hook claude"));
+        assert!(!is_claude_hook_command("env RTK_LOG=1 rtk hook claude"));
+    }
+
+    #[test]
+    fn hook_invocation_matches_inline_wrapper_form() {
+        // `sh -c "rtk hook claude"` — the quoted command is a single token
+        // after shell_split; must be re-split and matched.
+        assert!(is_claude_hook_invocation(r#"bash -c "rtk hook claude""#));
+        assert!(is_claude_hook_invocation("sh -c 'rtk hook claude'"));
+    }
+
+    #[test]
+    fn hook_invocation_matches_env_and_interpreter_prefix() {
+        assert!(is_claude_hook_invocation("bash rtk hook claude"));
+        assert!(is_claude_hook_invocation("/bin/bash rtk hook claude"));
+        assert!(is_claude_hook_invocation("env RTK_LOG=1 rtk hook claude"));
+    }
+
+    #[test]
+    fn hook_invocation_rejects_malformed_env_assignment_prefix() {
+        // "9INVALID=1" isn't a valid `KEY=VALUE` shape (identifiers can't
+        // start with a digit) — must not be skipped as an env-assignment
+        // wrapper-prefix token.
+        assert!(!is_claude_hook_invocation("9INVALID=1 rtk hook claude"));
+        assert!(is_claude_hook_invocation("RTK_LOG=1 rtk hook claude"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1595,7 +1595,8 @@ fn run_cli() -> Result<i32> {
 
     // Warn if installed hook is outdated/missing (1/day, non-blocking).
     // Skip for Gain — it shows its own inline hook warning.
-    if !matches!(cli.command, Commands::Gain { .. }) {
+    // Skip for Hook — warning would pollute hook stderr during execution.
+    if !matches!(cli.command, Commands::Gain { .. } | Commands::Hook { .. }) {
         hooks::hook_check::maybe_warn();
     }
 


### PR DESCRIPTION
## Problem

`rtk gain` prints `[warn] No hook installed — run 'rtk init -g'` on installs where the hook demonstrably runs. Detection requires a hook command that shell-splits to exactly `[rtk, hook, claude]`, reads only settings.json, and the legacy fallback matches only a file literally named rtk-rewrite.sh — so any wrapper script (a common way to gate specific commands before handing off to `rtk hook claude`) is reported as Missing, every day.

## Fix

A new detection-only matcher recognizes the `rtk hook claude` invocation embedded in a longer command line, resolves wrapper scripts (interpreter/env/flag prefixes skipped, quotes stripped, `~` expanded, relative paths resolved against the settings dir, readable files up to 64KB scanned for a non-comment invocation line), and scans settings.local.json beside settings.json. `is_claude_hook_command` keeps its exact-match semantics, so `rtk init` uninstall and integrity checks behave exactly as before. `rtk hook ...` runs also no longer emit the warning mid-hook (previously only the Gain JSON path was quiet).

## Tests

New fixture tests across mod.rs and hook_check.rs: exact form, inline wrapper, script variants (quoted path with space, /bin/bash prefix, env prefix), settings.local.json-only, comment-only wrapper rejected, missing settings rejected. Full suite green in a clean environment.
