### PR TITLE
fix(git): keep +/-/@@ diff markers at column 0 in compact_diff

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -355,7 +355,7 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
                 hunk_skipped = 0;
             }
             if !current_file.is_empty() && (added > 0 || removed > 0) {
-                result.push(format!("  +{} -{}", added, removed));
+                result.push(format!("  (+{} -{})", added, removed));
             }
             current_file = line.split(" b/").nth(1).unwrap_or("unknown").to_string();
             result.push(format!("\n{}", current_file));
@@ -373,13 +373,18 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
             in_hunk = true;
             hunk_shown = 0;
             // Preserve the full unified diff hunk header, including trailing
-            // function / symbol context after the second @@ marker.
-            result.push(format!("  {}", line));
+            // function / symbol context after the second @@ marker. Hunk
+            // headers and hunk lines are emitted at column 0, exactly as git
+            // prints them: indenting them would move the `+`/`-`/`@@` marker
+            // off the line start and silently break every anchored consumer
+            // (`grep -E '^[+-]'`, `patch`, diff-aware tooling) that reads
+            // RTK's stdout through a pipe.
+            result.push(line.to_string());
         } else if in_hunk {
             if line.starts_with('+') && !line.starts_with("+++") {
                 added += 1;
                 if hunk_shown < max_hunk_lines {
-                    result.push(format!("  {}", line));
+                    result.push(line.to_string());
                     hunk_shown += 1;
                 } else {
                     hunk_skipped += 1;
@@ -387,7 +392,7 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
             } else if line.starts_with('-') && !line.starts_with("---") {
                 removed += 1;
                 if hunk_shown < max_hunk_lines {
-                    result.push(format!("  {}", line));
+                    result.push(line.to_string());
                     hunk_shown += 1;
                 } else {
                     hunk_skipped += 1;
@@ -395,7 +400,7 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
             } else if hunk_shown < max_hunk_lines && !line.starts_with("\\") {
                 // Context line
                 if hunk_shown > 0 {
-                    result.push(format!("  {}", line));
+                    result.push(line.to_string());
                     hunk_shown += 1;
                 }
             }
@@ -415,7 +420,7 @@ pub(crate) fn compact_diff(diff: &str, max_lines: usize) -> String {
     }
 
     if !current_file.is_empty() && (added > 0 || removed > 0) {
-        result.push(format!("  +{} -{}", added, removed));
+        result.push(format!("  (+{} -{})", added, removed));
     }
 
     if was_truncated {
@@ -2428,6 +2433,58 @@ mod tests {
             "Expected full hunk header with trailing context, got:\n{}",
             result
         );
+    }
+
+    #[test]
+    fn test_compact_diff_keeps_diff_markers_at_column_zero() {
+        // Regression: compact_diff used to indent hunk lines by two spaces,
+        // so `rtk git diff | grep -E '^[+-]'` matched nothing (exit 1) even
+        // when the diff had changes — a silent false negative for any
+        // pipeline that parses the output like a unified diff.
+        let diff = r#"diff --git a/foo.rs b/foo.rs
+--- a/foo.rs
++++ b/foo.rs
+@@ -1,4 +1,4 @@
+ fn main() {
+-    println!("old");
++    println!("new");
+ }
+"#;
+        let result = compact_diff(diff, 100);
+        let lines: Vec<&str> = result.lines().collect();
+        assert!(
+            lines.contains(&"@@ -1,4 +1,4 @@"),
+            "hunk header must start at column 0, got:\n{}",
+            result
+        );
+        assert!(
+            lines.contains(&"-    println!(\"old\");"),
+            "removed line must keep `-` at column 0, got:\n{}",
+            result
+        );
+        assert!(
+            lines.contains(&"+    println!(\"new\");"),
+            "added line must keep `+` at column 0, got:\n{}",
+            result
+        );
+        assert!(
+            lines.contains(&" }"),
+            "context line must keep its leading space, got:\n{}",
+            result
+        );
+        // The per-file summary must not be mistaken for an added line.
+        let anchored: Vec<&str> = lines
+            .iter()
+            .copied()
+            .filter(|l| l.starts_with('+') || l.starts_with('-'))
+            .collect();
+        assert_eq!(
+            anchored,
+            vec!["-    println!(\"old\");", "+    println!(\"new\");"],
+            "only real hunk lines may start with +/-, got:\n{}",
+            result
+        );
+        assert!(result.contains("  (+1 -1)"), "got:\n{}", result);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `compact_diff()` indents hunk lines by two spaces, moving `+`/`-`/`@@` off column 0 — so `rtk git diff | grep -E '^[+-]'` silently matches nothing (false negative for any diff-parsing pipeline). Reproduced on the latest release, 0.45.0.
- Emit hunk headers and hunk lines at column 0 exactly as git prints them; re-spell the per-file summary as `(+N -M)` so it can't read as an added line.
- Output shrinks by 2 bytes per hunk line; adds a regression test.

## Test plan

- [x] `cargo fmt --all --check && cargo clippy --all-targets && cargo test` (2,705 tests pass, clippy clean)
- [x] Manual testing: `rtk git diff` output inspected before/after on a real repo (transcripts below)
- [x] New unit test `test_compact_diff_keeps_diff_markers_at_column_zero` covers markers at column 0, context-line leading space, and the summary-line disguise

---

## Problem

`compact_diff()` indents every hunk header and hunk line by two spaces. That moves the `+` / `-` / `@@` markers off column 0, so any consumer that reads RTK's `git diff` / `git show` output like a unified diff silently gets nothing.

Because the Claude Code hook rewrites `git` → `rtk git` transparently, the agent does not know the output was reformatted. The failing pipeline exits `1` with empty stdout — which looks exactly like "no matching changes". It is a convincing false negative, not an error.

### Reproduction (rtk 0.45.0, macOS)

One file, one edit — replace a word and add two bullet lines:

```
$ git diff
diff --git a/lorem.md b/lorem.md
index 2ad72b9..18d813e 100644
--- a/lorem.md
+++ b/lorem.md
@@ -1,6 +1,8 @@
 # Lorem ipsum

 Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Sed do eiusmod tempor incididunt ut labore et dolore magna ALIQUA.
 Ut enim ad minim veniam, quis nostrud exercitation ullamco.
+- Excepteur sint occaecat cupidatat non proident.
+- Sunt in culpa qui officia deserunt mollit anim id est laborum.
 Duis aute irure dolor in reprehenderit in voluptate velit.
```

The same diff through `rtk git diff` (actual output):

```
$ rtk git diff
lorem.md | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)

Changes:

lorem.md
  @@ -1,6 +1,8 @@
  -Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
  +Sed do eiusmod tempor incididunt ut labore et dolore magna ALIQUA.
   Ut enim ad minim veniam, quis nostrud exercitation ullamco.
  +- Excepteur sint occaecat cupidatat non proident.
  +- Sunt in culpa qui officia deserunt mollit anim id est laborum.
   Duis aute irure dolor in reprehenderit in voluptate velit.
  +3 -1
```

Every marker now sits at column 2, so:

```
$ git diff     | grep -cE '^[+-]'        # raw
6
$ rtk git diff | grep -cE '^[+-]'        # rtk
0
$ rtk git diff | grep -E '^\+.*occaecat' >/dev/null; echo $?
1
```

`0` matches, exit `1` — indistinguishable from a genuinely clean result. Note also the bare `  +3 -1` per-file summary on the last line: once markers are back at column 0, a line shaped like that would itself read as an added line, so it needs re-spelling too.

We hit this twice in one day while measuring an Odoo 17→18 schema delta: two independent safety checks (`git diff A B | grep -E '^[+-].*fields\.'` for model renames and for `Selection` key changes) both reported "0 findings". Both had findings. A later session committed on the strength of an "edit verified, grep shows nothing unexpected" check that had matched nothing for the same reason.

This contradicts the project's own Transparency principle in `CONTRIBUTING.md`:

> If an LLM parses `git diff` output, RTK's filtered version must still look like `git diff` output.

## Fix

- Emit hunk headers (`@@`) and hunk lines (`+`, `-`, context ` `) at column 0, exactly as git prints them. File names and the truncation hints keep their current shape.
- Re-spell the per-file summary `  +N -M` as `  (+N -M)` so it can never be mistaken for an added line (same notation `diff_cmd.rs` already uses).
- Add `test_compact_diff_keeps_diff_markers_at_column_zero` as a regression test.

Side effect: two fewer bytes per hunk line, so the compacted output gets slightly *smaller*.

Same repo, this branch's build (actual output):

```
$ rtk git diff
lorem.md | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)

Changes:

lorem.md
@@ -1,6 +1,8 @@
-Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Sed do eiusmod tempor incididunt ut labore et dolore magna ALIQUA.
 Ut enim ad minim veniam, quis nostrud exercitation ullamco.
+- Excepteur sint occaecat cupidatat non proident.
+- Sunt in culpa qui officia deserunt mollit anim id est laborum.
 Duis aute irure dolor in reprehenderit in voluptate velit.
  (+3 -1)

$ rtk git diff | grep -cE '^[+-]'
4
```

(4, not 6: the raw count includes the `--- a/` / `+++ b/` file headers, which compact mode drops by design. All four real changed lines are found, and the `(+3 -1)` summary no longer masquerades as one.)

`cargo fmt --check`, `cargo clippy -D warnings` and the full `cargo test` (2,705 tests) pass.

## Affected callers

`compact_diff` is shared by `git diff`, `git show`, `git stash show`, `rtk pipe`, `gh`/`glab` diff views — all of them gain column-0 markers.
