### PR TITLE
Change the way how to check the installation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,7 +21,7 @@
 rtk --version
 
 # CRITICAL: Verify it's the Token Killer (not Type Kit)
-rtk gain    # Should show the savings dashboard, NOT "command not found"
+rtk help | head  # Should show the "high-performance CLI proxy", NOT "command not found"
 
 # Check installation path
 which rtk
@@ -49,7 +49,7 @@ curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/master/install.sh | sh
 
 After installation, **verify you have the correct rtk**:
 ```bash
-rtk gain  # Must show the savings dashboard (not "command not found")
+rtk help | head # Should show the "high-performance CLI proxy", NOT "command not found"
 ```
 
 ### Alternative: Manual Installation
@@ -62,7 +62,7 @@ cargo install --git https://github.com/rtk-ai/rtk
 cargo install rtk
 
 # ALWAYS VERIFY after installation
-rtk gain  # MUST show the savings dashboard, not "command not found"
+rtk help | head # Should show the "high-performance CLI proxy", NOT "command not found"
 ```
 
 ⚠️ **WARNING**: `cargo install rtk` from crates.io might install the wrong package. Always verify with `rtk gain`.


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

- `rtk gain` produces no output on a fresh installation. `rtk help` provides a clearer explanation

```shell
$ rtk gain
No tracking data yet.
Run some rtk commands to start tracking savings.
```

```shell
$ rtk help | head
A high-performance CLI proxy designed to filter and summarize system outputs before they reach your LLM context.

Usage: rtk [OPTIONS] <COMMAND>

Commands:
  ls             List directory contents with token-optimized output (proxy to native ls)
  tree           Directory tree with token-optimized output (proxy to native tree)
  read           Read file with intelligent filtering
  smart          Generate 2-line technical summary (heuristic-based)
  git            Git commands with compact output
```

## Test plan
<!-- How did you verify this works? -->

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
