### PR TITLE
feat(discover): route the standalone docker-compose binary

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1499,6 +1499,48 @@ mod tests {
     use super::super::report::RtkStatus;
     use super::*;
 
+    mod docker_compose_hyphenated {
+        use super::rewrite_command_no_prefixes;
+
+        /// `docker compose ps` was routed but the standalone `docker-compose`
+        /// binary -- still what most projects invoke -- was not.
+        #[test]
+        fn hyphenated_form_routes_to_the_same_filter() {
+            for (cmd, want) in [
+                ("docker-compose ps", "rtk docker compose ps"),
+                ("docker-compose logs", "rtk docker compose logs"),
+                ("docker-compose build", "rtk docker compose build"),
+                ("docker-compose ps -a", "rtk docker compose ps -a"),
+            ] {
+                assert_eq!(
+                    rewrite_command_no_prefixes(cmd, &[]).as_deref(),
+                    Some(want),
+                    "{cmd} should rewrite to {want}"
+                );
+            }
+        }
+
+        #[test]
+        fn subcommand_form_still_rewrites() {
+            assert_eq!(
+                rewrite_command_no_prefixes("docker compose ps", &[]).as_deref(),
+                Some("rtk docker compose ps")
+            );
+        }
+
+        /// Subcommands with no filter -- and the long-running ones -- stay native.
+        #[test]
+        fn unfiltered_compose_subcommands_are_left_alone() {
+            for cmd in [
+                "docker-compose up",
+                "docker-compose down",
+                "docker-compose exec web sh",
+            ] {
+                assert_eq!(rewrite_command_no_prefixes(cmd, &[]), None, "{cmd}");
+            }
+        }
+    }
+
     fn rewrite_command_no_prefixes(cmd: &str, excluded: &[String]) -> Option<String> {
         super::rewrite_command(cmd, excluded, &[])
     }

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -400,6 +400,17 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
+        // The standalone `docker-compose` binary is still what most projects
+        // invoke. Same filters as the `docker compose` subcommand form, which
+        // was already routed.
+        pattern: r"^docker-compose\s+(ps|logs|build)(\s|$)",
+        rtk_cmd: "rtk docker compose",
+        rewrite_prefixes: &["docker-compose"],
+        category: "Infra",
+        savings_pct: 85.0,
+        ..RtkRule::DEFAULT
+    },
+    RtkRule {
         pattern: r"^kubectl\s+(get|logs|describe|apply)",
         rtk_cmd: "rtk kubectl",
         rewrite_prefixes: &["kubectl"],


### PR DESCRIPTION
Closes #3652.

## Summary

- New rule routing `docker-compose (ps|logs|build)` to `rtk docker compose …`, the same filters
  the v2 subcommand spelling already reaches.
- Scoped to the three subcommands that have filters. `up`, `down` and `exec` stay native — `up`
  and `exec` are long-running or interactive, and rtk captures rather than streams.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

### Unit tests (added)

`src/discover/registry.rs`, module `docker_compose_hyphenated`:

- `hyphenated_form_routes_to_the_same_filter` — `ps`, `logs`, `build`, and `ps -a`, each landing
  on `rtk docker compose …`.
- `subcommand_form_still_rewrites` — the v2 spelling is untouched.
- `unfiltered_compose_subcommands_are_left_alone` — `up`, `down`, `exec web sh` return `None`.

### Behavioural check (fake `docker-compose` on PATH)

The fake honours the `--format "{{.Name}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}"` template rtk
passes, as the real binary does:

| Command | Preserved | Size | Exit |
|---|---|---|---|
| `docker-compose ps` | all three services `web`, `db`, `cache`, and `Exited` state | 205 B → 150 B (27% smaller) | 0 |
| `docker-compose logs` | `FATAL` line | unchanged | 0 |