### PR TITLE
feat(discover): route dotnet test, restore and format

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1499,6 +1499,49 @@ mod tests {
     use super::super::report::RtkStatus;
     use super::*;
 
+    mod dotnet_subcommands {
+        use super::rewrite_command_no_prefixes;
+
+        /// `dotnet test` is the noisiest of the four and has a dedicated trx
+        /// parser, but only `dotnet build` was routed.
+        #[test]
+        fn filtered_subcommands_are_rewritten() {
+            for cmd in [
+                "dotnet build",
+                "dotnet test",
+                "dotnet restore",
+                "dotnet format",
+            ] {
+                assert_eq!(
+                    rewrite_command_no_prefixes(cmd, &[]).as_deref(),
+                    Some(format!("rtk {cmd}").as_str()),
+                    "{cmd} should route to rtk dotnet"
+                );
+            }
+        }
+
+        #[test]
+        fn subcommands_with_arguments_are_rewritten() {
+            assert_eq!(
+                rewrite_command_no_prefixes("dotnet test MyProj.csproj -v n", &[]).as_deref(),
+                Some("rtk dotnet test MyProj.csproj -v n")
+            );
+        }
+
+        /// Subcommands with no rtk filter stay on the native binary.
+        #[test]
+        fn unfiltered_subcommands_are_left_alone() {
+            for cmd in [
+                "dotnet run",
+                "dotnet publish",
+                "dotnet new console",
+                "dotnet testhost",
+            ] {
+                assert_eq!(rewrite_command_no_prefixes(cmd, &[]), None, "{cmd}");
+            }
+        }
+    }
+
     fn rewrite_command_no_prefixes(cmd: &str, excluded: &[String]) -> Option<String> {
         super::rewrite_command(cmd, excluded, &[])
     }

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -687,7 +687,10 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
-        pattern: r"^dotnet\s+build\b",
+        // DotnetCommands already has Test, Restore and Format variants with
+        // their own filters (trx parsing, binlog, format report); only build was
+        // ever routed here.
+        pattern: r"^dotnet\s+(build|test|restore|format)\b",
         rtk_cmd: "rtk dotnet",
         rewrite_prefixes: &["dotnet"],
         category: "Build",


### PR DESCRIPTION
Closes #3654.

## Summary

- Widens the dotnet rule from `build` to `build|test|restore|format`, matching the four
  `DotnetCommands` variants that already have filters.
- No filter changes.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

### Unit tests (added)

`src/discover/registry.rs`, module `dotnet_subcommands`:

- `filtered_subcommands_are_rewritten` — all four route to `rtk dotnet`.
- `subcommands_with_arguments_are_rewritten` — `dotnet test MyProj.csproj -v n`.
- `unfiltered_subcommands_are_left_alone` — `dotnet run`, `dotnet publish`, `dotnet new console`
  and `dotnet testhost` must **not** match, so commands with no filter stay native and `\b` is
  doing its job.

### Behavioural check (fake `dotnet` on PATH)

| Command | Preserved | Size | Exit |
|---|---|---|---|
| `dotnet test` | failing test `RejectsBadPassword` + error message | 266 B → 204 B (24% smaller) | 1 |
| `dotnet restore` | `1 projects`, `0 errors` | 79 B → 61 B (23% smaller) | 0 |
| `dotnet format` | offending file `Program.cs` | unchanged | 2 |

Note: `rtk dotnet test` invokes `dotnet test -nologo --logger trx --results-directory <tmp>`. When
no trx file is produced (as with a stub binary) it falls back to printing the raw output, so the
failure is never swallowed.