### PR TITLE
fix(search): stop rtk grep from claiming the engine's short flags

### DIFF
--- a/src/cmds/system/search.rs
+++ b/src/cmds/system/search.rs
@@ -386,7 +386,17 @@ impl StreamFilter for SearchStreamFilter {
     }
 }
 
+/// True when the agent asked for grep's `-h` / `--no-filename`. RTK forces `-H`
+/// on the engine so its own parser can split the output, so it has to drop the
+/// prefix itself rather than relying on the engine to omit it.
+fn suppress_filename(extra_args: &[String]) -> bool {
+    has_short_flag(extra_args, 'h') || extra_args.iter().any(|f| f == "--no-filename")
+}
+
 fn show_file(paths: &[String], extra_args: &[String]) -> bool {
+    if suppress_filename(extra_args) {
+        return false;
+    }
     paths.len() > 1
         || paths.iter().any(|p| std::path::Path::new(p).is_dir())
         || has_short_flag(extra_args, 'H')
@@ -505,10 +515,11 @@ pub fn run(
     // --version / --help: pass through to the engine without filtering.
     // Note: Clap strips `--` before populating trailing_var_arg, so both
     // `rtk grep --version` and `rtk grep -- --version` land here identically.
-    if args
-        .iter()
-        .any(|a| a == "--version" || a == "--help" || a == "-h")
-    {
+    // `-h` is help for rg but --no-filename for grep, so it only counts as a
+    // help request for rg.
+    if args.iter().any(|a| {
+        a == "--version" || a == "--help" || (matches!(engine, Engine::Rg) && a == "-h")
+    }) {
         let mut cmd = resolved_command(engine.bin());
         cmd.args(args);
         let result = exec_capture(&mut cmd).context("search failed")?;
@@ -614,7 +625,8 @@ pub fn run(
     // show one (multiple files, a directory, -r or -H), the line number only with
     // -n. We force -nH--null for robust parsing, then drop what the engine itself
     // would not have shown.
-    let show_file = by_file.len() > 1 || show_file(&paths, &extra_args);
+    let show_file =
+        !suppress_filename(&extra_args) && (by_file.len() > 1 || show_file(&paths, &extra_args));
     let show_line = show_line(&extra_args);
 
     // Faithful baseline: exactly what the real command prints, full content.
@@ -850,6 +862,7 @@ fn compact_path(path: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
 
     #[test]
     fn test_clean_line() {
@@ -1652,4 +1665,33 @@ mod tests {
         assert!(f(&["--context=1"]));
         assert!(!f(&["--color", "auto"]));
     }
+
+    /// grep's -h / --no-filename suppresses the filename prefix. RTK forces
+    /// -H on the engine for parsing, so it must drop the prefix itself when the
+    /// agent asked for -h.
+    #[test]
+    fn no_filename_flag_suppresses_the_prefix() {
+        let two_paths = vec!["a.log".to_string(), "b.log".to_string()];
+        assert!(
+            show_file(&two_paths, &[]),
+            "two paths normally show filenames"
+        );
+        assert!(
+            !show_file(&two_paths, &["-h".to_string()]),
+            "-h must suppress the filename prefix"
+        );
+        assert!(
+            !show_file(&two_paths, &["--no-filename".to_string()]),
+            "--no-filename must suppress the filename prefix"
+        );
+        assert!(
+            !show_file(&two_paths, &["-rh".to_string()]),
+            "-h inside a cluster must suppress the filename prefix"
+        );
+        assert!(
+            show_file(&two_paths, &["-H".to_string()]),
+            "-H still forces filenames on"
+        );
+    }
+
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,8 @@ struct Cli {
 #[derive(Debug, Subcommand)]
 enum Commands {
     /// List directory contents with token-optimized output (proxy to native ls)
+    // ls -h is --human-readable, not a help request.
+    #[command(disable_help_flag = true)]
     Ls {
         /// Arguments passed to ls (supports all native ls flags like -l, -a, -h, -R)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
@@ -312,18 +314,22 @@ enum Commands {
     },
 
     /// Compact grep - strips whitespace, truncates, groups by file
+    // Every single letter belongs to the proxied engine, so rtk claims none of
+    // them: -l is grep's --files-with-matches, -m its --max-count, -t rg's
+    // --type, and -h grep's --no-filename. Long forms only, help flag off.
+    #[command(disable_help_flag = true)]
     Grep {
         /// Max line length
-        #[arg(short = 'l', long, default_value = "80")]
+        #[arg(long, default_value = "80")]
         max_len: usize,
         /// Max results to show
-        #[arg(short, long, default_value = "200")]
+        #[arg(long, default_value = "200")]
         max: usize,
         /// Show only match context (not full line)
         #[arg(long)]
         context_only: bool,
         /// Filter by file type (e.g., ts, py, rust)
-        #[arg(short = 't', long)]
+        #[arg(long)]
         file_type: Option<String>,
         /// Pattern, path, and any grep/rg flags (e.g. -v, -i, -A 3, --glob, --version)
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
@@ -2793,6 +2799,67 @@ fn is_operational_command(cmd: &Commands) -> bool {
 mod tests {
     use super::*;
     use clap::Parser;
+
+    /// A proxy subcommand must not own single letters that belong to the tool it
+    /// proxies. `rtk grep` claimed -l (--max-len), -m (--max), -t (--file-type)
+    /// and clap's automatic -h, so `grep -l 404 a.log b.log` searched b.log for
+    /// the literal "a.log", `grep -m 1` dropped --max-count, and `grep -h`
+    /// printed rtk's help instead of searching.
+    #[test]
+    fn grep_does_not_swallow_engine_short_flags() {
+        for flag in ["-l", "-m", "-t"] {
+            let cli = Cli::try_parse_from(["rtk", "grep", flag, "404", "a.log"])
+                .unwrap_or_else(|e| panic!("`rtk grep {flag} 404 a.log` must parse: {e}"));
+            match cli.command {
+                Commands::Grep { extra_args, .. } => assert!(
+                    extra_args.contains(&flag.to_string()),
+                    "{flag} was swallowed by rtk's own option; extra_args = {extra_args:?}"
+                ),
+                other => panic!("expected Grep, got {other:?}"),
+            }
+        }
+    }
+
+    /// grep's -h is --no-filename and ls's -h is --human-readable; neither is a
+    /// help request. clap claims -h unless the subcommand opts out.
+    #[test]
+    fn dash_h_reaches_the_proxied_tool() {
+        let cli = Cli::try_parse_from(["rtk", "grep", "-h", "ERROR", "a.log"])
+            .expect("`rtk grep -h` must parse, not trigger clap's help");
+        match cli.command {
+            Commands::Grep { extra_args, .. } => {
+                assert!(extra_args.contains(&"-h".to_string()), "got {extra_args:?}")
+            }
+            other => panic!("expected Grep, got {other:?}"),
+        }
+
+        let cli = Cli::try_parse_from(["rtk", "ls", "-h"])
+            .expect("`rtk ls -h` must parse, not trigger clap's help");
+        match cli.command {
+            Commands::Ls { args } => assert!(args.contains(&"-h".to_string()), "got {args:?}"),
+            other => panic!("expected Ls, got {other:?}"),
+        }
+    }
+
+    /// The long forms stay available so rtk's own knobs are still reachable.
+    #[test]
+    fn grep_long_options_still_parse() {
+        let cli = Cli::try_parse_from(["rtk", "grep", "--max-len", "40", "--max", "5", "needle"])
+            .expect("long forms must still work");
+        match cli.command {
+            Commands::Grep {
+                max_len,
+                max,
+                extra_args,
+                ..
+            } => {
+                assert_eq!(max_len, 40);
+                assert_eq!(max, 5);
+                assert_eq!(extra_args, vec!["needle".to_string()]);
+            }
+            other => panic!("expected Grep, got {other:?}"),
+        }
+    }
     use std::cell::Cell;
 
     #[test]


### PR DESCRIPTION
Closes #3663.

## Summary

- `rtk grep` no longer claims `-l`, `-m` or `-t` — those letters are grep's
  `--files-with-matches`, grep's `--max-count` and rg's `--type`. The knobs keep their long
  names (`--max-len`, `--max`, `--file-type`).
- `disable_help_flag` on `Grep` and `Ls`, so clap stops claiming `-h`: it is `--no-filename`
  for grep and `--human-readable` for ls, not a help request. Follows the existing
  `Commands::Psql` precedent.
- `-h` is still treated as help for **rg** (where it genuinely is), and for grep it now
  suppresses the filename prefix in the compressed output, since RTK forces `-H` on the engine
  for its own parsing.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

### Unit tests (added, TDD — red before green)

`src/main.rs`:

- `grep_does_not_swallow_engine_short_flags` — `-l`, `-m`, `-t` all reach `extra_args`.
  Fails on `develop`.
- `dash_h_reaches_the_proxied_tool` — `rtk grep -h …` and `rtk ls -h` parse instead of
  triggering clap's help. Fails on `develop`.
- `grep_long_options_still_parse` — control: `--max-len 40 --max 5` still bind rtk's own
  fields. Passes before and after.

`src/cmds/system/search.rs`:

- `no_filename_flag_suppresses_the_prefix` — `-h`, `--no-filename` and the `-rh` cluster
  suppress the filename prefix; `-H` still forces it on. Fails on `develop`.

### Behavioural check against real grep / ls

| Command | Before | After |
|---|---|---|
| `grep -l 404 a.log b.log` | no output, exit 1 | 2 filenames, identical |
| `grep -m 1 hit m.txt` | 4 lines | 1 line, identical |
| `grep -m 2 hit m.txt` | 4 lines | 2 lines, identical |
| `grep -h 404 a.log b.log` | rtk help page, exit 0 | 2 lines, no prefix, identical |
| `grep -hn 404 a.log b.log` | already correct | identical |
| `grep --no-filename 404 a.log b.log` | already correct | identical |
| `ls -h` | rtk help page | directory listing |

Controls confirming nothing else moved: `grep 404 a b` (prefix still shown), `grep -H 404 a`,
`grep -n 404 a`, `grep -c 404 a b`, `grep -l GET a b`, `grep -m1 hit m.txt` — all identical
before and after. `rtk grep --max-len 40 --max 5 404 a.log` still honours rtk's own options.

### Suite

`cargo test --all`: 2629 passed, 0 failed (2625 on `develop`, +4 from this PR).
`cargo clippy --all-targets`: clean. `cargo fmt --all`: clean.