### PR TITLE
fix(search): treat -f/--file as a pattern source, not a positional pa…

### DIFF
--- a/src/cmds/system/search.rs
+++ b/src/cmds/system/search.rs
@@ -146,6 +146,10 @@ fn extract_pattern_path<T: AsRef<str>>(args: &[T]) -> (Vec<String>, Vec<String>,
     let mut e_patterns: Vec<String> = Vec::new();
     let mut positionals: Vec<String> = Vec::new();
     let mut flags: Vec<String> = Vec::new();
+    // -f/--file read patterns from a file, so like -e they leave every
+    // positional as a path. Tracked during the scan rather than by inspecting
+    // `flags` afterwards, so another flag's *value* can't be mistaken for it.
+    let mut has_pattern_file = false;
     let mut past_dashdash = false;
     let mut i = 0;
 
@@ -177,6 +181,7 @@ fn extract_pattern_path<T: AsRef<str>>(args: &[T]) -> (Vec<String>, Vec<String>,
             }
             // Other long value-taking flags: consume next token as value.
             if VALUE_FLAGS_LONG.contains(&arg) {
+                has_pattern_file |= arg == "--file";
                 flags.push(arg.to_string());
                 if i + 1 < args.len() {
                     flags.push(args[i + 1].as_ref().to_string());
@@ -186,6 +191,7 @@ fn extract_pattern_path<T: AsRef<str>>(args: &[T]) -> (Vec<String>, Vec<String>,
                 }
                 continue;
             }
+            has_pattern_file |= arg.starts_with("--file=");
             flags.push(arg.to_string());
             i += 1;
             continue;
@@ -219,6 +225,7 @@ fn extract_pattern_path<T: AsRef<str>>(args: &[T]) -> (Vec<String>, Vec<String>,
                             i += 1;
                         }
                     } else {
+                        has_pattern_file |= flag == 'f';
                         flags.push(format!("-{}", flag));
                         if !inline.is_empty() {
                             flags.push(inline);
@@ -239,9 +246,10 @@ fn extract_pattern_path<T: AsRef<str>>(args: &[T]) -> (Vec<String>, Vec<String>,
         }
     }
 
-    // If -e/--regexp was used: all positionals are paths.
+    // If a pattern source was used (-e/--regexp, or -f/--file reading patterns
+    // from a file): all positionals are paths.
     // Otherwise: first positional is the pattern, rest are paths.
-    let (patterns, paths) = if !e_patterns.is_empty() {
+    let (patterns, paths) = if !e_patterns.is_empty() || has_pattern_file {
         (e_patterns, positionals)
     } else {
         let paths = positionals.iter().skip(1).cloned().collect();
@@ -850,6 +858,44 @@ fn compact_path(path: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `-f FILE` / `--file FILE` supply patterns *from a file* — the file-based
+    /// twin of `-e`, in grep and rg alike. Treating them as ordinary
+    /// value-taking flags consumed the search path as the pattern and left the
+    /// path list empty, so the engine silently read stdin instead.
+    #[test]
+    fn pattern_file_flag_leaves_positionals_as_paths() {
+        for form in [
+            vec!["-f", "pats.txt", "hay.txt"],
+            vec!["--file", "pats.txt", "hay.txt"],
+            vec!["--file=pats.txt", "hay.txt"],
+            vec!["-fpats.txt", "hay.txt"],
+        ] {
+            let (patterns, paths, _flags) = extract_pattern_path(&form);
+            assert!(
+                patterns.is_empty(),
+                "{form:?}: a pattern file must not turn a positional into the pattern, got {patterns:?}"
+            );
+            assert_eq!(paths, vec!["hay.txt"], "{form:?}: the search path must survive");
+        }
+    }
+
+    /// The pattern file must still reach the engine, otherwise the search runs
+    /// with no patterns at all.
+    #[test]
+    fn pattern_file_flag_is_forwarded_to_the_engine() {
+        let (_patterns, _paths, flags) = extract_pattern_path(&["-f", "pats.txt", "hay.txt"]);
+        assert_eq!(flags, vec!["-f", "pats.txt"]);
+    }
+
+    /// Guard the ordinary form: without a pattern source the first positional
+    /// is still the pattern.
+    #[test]
+    fn positional_pattern_still_wins_without_a_pattern_source() {
+        let (patterns, paths, _flags) = extract_pattern_path(&["needle", "hay.txt"]);
+        assert_eq!(patterns, vec!["needle"]);
+        assert_eq!(paths, vec!["hay.txt"]);
+    }
 
     #[test]
     fn test_clean_line() {


### PR DESCRIPTION
Closes #3665.

## Summary

- Treat `-f` / `--file` as a **pattern source** in `extract_pattern_path`, exactly like
  `-e` / `--regexp`: when one is present every positional is a path, not a pattern.
- Fixes `rtk grep -f patterns.txt app.log` silently returning no matches (exit 1) where real
  grep returns matches — and, with two files, returning matches from the wrong file.
- The flag is tracked during the arg scan rather than by inspecting `flags` afterwards, so
  another option's *value* that happens to read `-f` cannot be mistaken for it.

With no positional pattern left, `run()` takes its existing `patterns.is_empty()` passthrough
branch and executes the user's command verbatim — correct output, no compression on this form.
Grouping `-f` searches is a follow-up; correctness first.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

### Unit tests (added, TDD — red before green)

`src/cmds/system/search.rs`:

- `pattern_file_flag_leaves_positionals_as_paths` — all four spellings (`-f F`, `--file F`,
  `--file=F`, `-fF`) yield no positional pattern and keep the search path.
  Fails on `develop` with: `["-f", "pats.txt", "hay.txt"]: a pattern file must not turn a
  positional into the pattern, got ["hay.txt"]`.
- `pattern_file_flag_is_forwarded_to_the_engine` — `-f` and its value still reach the engine.
- `positional_pattern_still_wins_without_a_pattern_source` — guards the ordinary form.

### Behavioural check against real grep

Every case below now produces byte-identical output and exit code to GNU grep:

| Command | Before | After |
|---|---|---|
| `grep -f patterns.txt app.log` | no output, exit 1 | 3 lines, exit 0 — identical |
| `grep --file patterns.txt app.log` | no output, exit 1 | identical |
| `grep --file=patterns.txt app.log` | no output, exit 1 | identical |
| `grep -fpatterns.txt app.log` | no output, exit 1 | identical |
| `grep -f patterns.txt app.log second.log` | wrong file's match | 4 lines, identical |
| `grep -n -f patterns.txt app.log` | no output, exit 1 | identical |

Controls confirming ordinary grep is untouched: `grep -n ERROR`, `grep -c ERROR`,
`grep -e ERROR -e WARN`, `grep ERROR a b` — all identical before and after.