### PR TITLE
feat(discover): rewrite head -n N and head --lines N

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -80,6 +80,13 @@ static GIT_GLOBAL_OPT: LazyLock<Regex> = LazyLock::new(|| {
 static HEAD_N: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^head\s+-(\d+)\s+(\S+)$").unwrap());
 static HEAD_LINES: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^head\s+--lines=(\d+)\s+(\S+)$").unwrap());
+// `head -n N file` / `head --lines N file` mirror the tail arms below. Without
+// them the most common spelling of head fell through unrewritten while the
+// matching tail spelling was handled.
+static HEAD_N_SPACE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^head\s+-n\s+(\d+)\s+(\S+)$").unwrap());
+static HEAD_LINES_SPACE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^head\s+--lines\s+(\d+)\s+(\S+)$").unwrap());
 static TAIL_N: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^tail\s+-(\d+)\s+(\S+)$").unwrap());
 static TAIL_N_SPACE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^tail\s+-n\s+(\d+)\s+(\S+)$").unwrap());
@@ -1143,7 +1150,7 @@ fn rewrite_compound(
 }
 
 fn rewrite_line_range(cmd: &str) -> Option<String> {
-    for re in [&*HEAD_N, &*HEAD_LINES] {
+    for re in [&*HEAD_N, &*HEAD_N_SPACE, &*HEAD_LINES, &*HEAD_LINES_SPACE] {
         if let Some(caps) = re.captures(cmd) {
             let n = caps.get(1)?.as_str();
             let file = caps.get(2)?.as_str();
@@ -1498,6 +1505,39 @@ fn strip_word_prefix<'a>(cmd: &'a str, prefix: &str) -> Option<&'a str> {
 mod tests {
     use super::super::report::RtkStatus;
     use super::*;
+
+    /// head and tail must be rewritten through the same set of spellings.
+    /// `tail -n N file` was handled while `head -n N file` -- the more common
+    /// of the two -- fell through unrewritten.
+    #[test]
+    fn head_and_tail_rewrite_the_same_spellings() {
+        let cases = [
+            ("head -20 f.txt", "rtk read f.txt --max-lines 20"),
+            ("head -n 20 f.txt", "rtk read f.txt --max-lines 20"),
+            ("head --lines=20 f.txt", "rtk read f.txt --max-lines 20"),
+            ("head --lines 20 f.txt", "rtk read f.txt --max-lines 20"),
+            ("tail -20 f.txt", "rtk read f.txt --tail-lines 20"),
+            ("tail -n 20 f.txt", "rtk read f.txt --tail-lines 20"),
+            ("tail --lines=20 f.txt", "rtk read f.txt --tail-lines 20"),
+            ("tail --lines 20 f.txt", "rtk read f.txt --tail-lines 20"),
+        ];
+        for (cmd, want) in cases {
+            assert_eq!(
+                rewrite_line_range(cmd).as_deref(),
+                Some(want),
+                "{cmd} should rewrite to {want}"
+            );
+        }
+    }
+
+    /// Forms `rtk read` cannot express must stay unrewritten rather than being
+    /// silently turned into a line count.
+    #[test]
+    fn unsupported_head_forms_are_left_alone() {
+        for cmd in ["head -c 500 f.txt", "head -3 a b c", "head"] {
+            assert_eq!(rewrite_line_range(cmd), None, "{cmd} must not be rewritten");
+        }
+    }
 
     fn rewrite_command_no_prefixes(cmd: &str, excluded: &[String]) -> Option<String> {
         super::rewrite_command(cmd, excluded, &[])


### PR DESCRIPTION
Closes #3667.

## Summary

- Adds `HEAD_N_SPACE` (`head -n N file`) and `HEAD_LINES_SPACE` (`head --lines N file`), mirroring
  the `tail` arms that already exist, so head and tail are rewritten through the same four
  spellings.
- Forms `rtk read` cannot express — `head -c N` (bytes), multi-file, stdin — still fall through to
  the native binary.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

### Unit tests (added, TDD — red before green)

`src/discover/registry.rs`:

- `head_and_tail_rewrite_the_same_spellings` — a table of all eight forms. Red on `develop` with
  `head -n 20 f.txt should rewrite to rtk read f.txt --max-lines 20`.
- `unsupported_head_forms_are_left_alone` — `head -c 500 f.txt`, `head -3 a b c`, bare `head`
  stay unrewritten, so a byte count is never silently reinterpreted as a line count.

### Behavioural check through `rtk rewrite`

All four head spellings and all four tail spellings produce the expected rewrite; `head -c 500`
and `head -3 a b c` return exit 1 (passthrough).

### Suite

`cargo test --all`: 2627 passed, 0 failed (2625 on `develop`, +2 from this PR).
`cargo clippy --all-targets`: clean. `cargo fmt --all`: clean.