### PR TITLE
feat(discover): route npm's lifecycle subcommands

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1499,6 +1499,58 @@ mod tests {
     use super::super::report::RtkStatus;
     use super::*;
 
+    /// npm's lifecycle subcommands are the noisiest thing an agent runs, and
+    /// npm_cmd already knows them -- KNOWN_SUBCOMMANDS lists install, ci, test,
+    /// audit and outdated so it does not inject `run` for them. Only the
+    /// rewrite rule was too narrow to route them.
+    mod npm_lifecycle {
+        use super::rewrite_command_no_prefixes;
+
+        #[test]
+        fn lifecycle_subcommands_are_rewritten() {
+            for cmd in [
+                "npm test",
+                "npm install",
+                "npm install express",
+                "npm i",
+                "npm ci",
+                "npm audit",
+                "npm outdated",
+                "npm ls",
+                "npm list",
+            ] {
+                assert_eq!(
+                    rewrite_command_no_prefixes(cmd, &[]).as_deref(),
+                    Some(format!("rtk {cmd}").as_str()),
+                    "{cmd} should route to rtk npm"
+                );
+            }
+        }
+
+        #[test]
+        fn already_supported_forms_still_rewrite() {
+            for cmd in ["npm run build", "npm exec vitest", "npm run-script lint"] {
+                assert!(
+                    rewrite_command_no_prefixes(cmd, &[]).is_some(),
+                    "{cmd} must keep working"
+                );
+            }
+        }
+
+        /// Guard against the regex matching a longer word that merely starts
+        /// with a listed subcommand.
+        #[test]
+        fn similar_subcommands_are_not_captured() {
+            for cmd in ["npm install-test", "npm testify", "npm auditlog"] {
+                assert_eq!(
+                    rewrite_command_no_prefixes(cmd, &[]),
+                    None,
+                    "{cmd} must not be treated as a known subcommand"
+                );
+            }
+        }
+    }
+
     fn rewrite_command_no_prefixes(cmd: &str, excluded: &[String]) -> Option<String> {
         super::rewrite_command(cmd, excluded, &[])
     }

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -87,7 +87,10 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
-        pattern: r"^npm\s+(exec|run|run-script|rum|urn|x)(\s|$)",
+        // npm_cmd already treats install/ci/test/audit/outdated/ls as known
+        // subcommands (it only injects `run` for bare script names), so these
+        // are filtered correctly -- the rule just never routed them here.
+        pattern: r"^npm\s+(exec|run|run-script|rum|urn|x|test|install|i|ci|audit|outdated|ls|list)(\s|$)",
         rtk_cmd: "rtk npm",
         rewrite_prefixes: &["npm"],
         category: "PackageManager",


### PR DESCRIPTION
Closes #3671.

## Summary

- Widens the npm rewrite rule to cover the lifecycle subcommands `npm_cmd` already knows about:
  `test`, `install`, `i`, `ci`, `audit`, `outdated`, `ls`, `list`.
- No filter changes. `npm_cmd::KNOWN_SUBCOMMANDS` already excludes these from `run` injection, so
  they were always handled correctly — the rule simply never routed them.

## Measured savings (fake npm emitting realistic output)

| Command | Before | After | Notes |
|---|---|---|---|
| `npm install` | 2616 B | **226 B (92% smaller)** | keeps `added 1284 packages` and `found 3 vulnerabilities (1 moderate, 2 high)` |
| `npm test` | 1719 B | 1701 B (2% smaller) | modest — the noise is the test runner's, not npm's |

Being straight about `npm test`: the win is small, because `filter_npm_output` strips *npm*
boilerplate and a failing vitest run is mostly the runner's own output. It is included for
consistency (`npm run test` is already routed) and because it strips the `> app@1.0.0 test` header
and `npm ERR!` trailer. `install`/`ci` are where the value is.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

### Unit tests (added)

`src/discover/registry.rs`, module `npm_lifecycle`:

- `lifecycle_subcommands_are_rewritten` — all nine forms route to `rtk npm`. Red on `develop`
  (`rtk rewrite "npm test"` exits 1, no rewrite).
- `already_supported_forms_still_rewrite` — `npm run build`, `npm exec vitest`, `npm run-script lint`.
- `similar_subcommands_are_not_captured` — `npm install-test`, `npm testify`, `npm auditlog` must
  **not** match. The rule keeps its `(\s|$)` anchor precisely for this.

### Behavioural check (information preservation)

With a fake `npm` on `PATH` emitting realistic output, every load-bearing token survives and the
exit code is propagated:

| Command | Preserved | Exit |
|---|---|---|
| `npm test` | failing file `auth.test.ts`, `1 failed` | 1 |
| `npm audit` | `lodash`, `minimist`, `critical` | 1 |
| `npm outdated` | `express`, `lodash` | 1 |
| `npm install` / `npm ci` | package count | 0 |