### PR TITLE
feat(discover): route pnpm's bare script forms

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -1499,6 +1499,64 @@ mod tests {
     use super::super::report::RtkStatus;
     use super::*;
 
+    mod pnpm_bare_scripts {
+        use super::rewrite_command_no_prefixes;
+
+        /// pnpm runs a bare script name directly (`pnpm test` == `pnpm run test`).
+        #[test]
+        fn bare_script_names_are_rewritten() {
+            for cmd in ["pnpm test", "pnpm build", "pnpm typecheck", "pnpm format"] {
+                assert_eq!(
+                    rewrite_command_no_prefixes(cmd, &[]).as_deref(),
+                    Some(format!("rtk {cmd}").as_str()),
+                    "{cmd} should route to rtk pnpm"
+                );
+            }
+        }
+
+        /// Long-running scripts must NOT be routed: they never terminate, and rtk
+        /// captures output rather than streaming it, so the agent would hang with
+        /// nothing on screen.
+        #[test]
+        fn long_running_scripts_are_left_alone() {
+            for cmd in ["pnpm dev", "pnpm start", "pnpm serve", "pnpm watch"] {
+                assert_eq!(
+                    rewrite_command_no_prefixes(cmd, &[]),
+                    None,
+                    "{cmd} must not be captured by rtk"
+                );
+            }
+        }
+
+        /// `pnpm lint` is deliberately NOT in the pnpm rule: it already routes to
+        /// the dedicated eslint/biome filter, which understands the tool's output
+        /// format rather than just stripping package-manager boilerplate.
+        #[test]
+        fn lint_keeps_its_dedicated_filter() {
+            assert_eq!(
+                rewrite_command_no_prefixes("pnpm lint", &[]).as_deref(),
+                Some("rtk lint"),
+                "pnpm lint should reach the eslint/biome filter, not rtk pnpm"
+            );
+        }
+
+        #[test]
+        fn existing_subcommands_still_rewrite() {
+            for cmd in ["pnpm install", "pnpm run build", "pnpm outdated", "pnpm ls"] {
+                assert!(rewrite_command_no_prefixes(cmd, &[]).is_some(), "{cmd}");
+            }
+        }
+
+        /// The rule had no word boundary, so a longer word starting with a listed
+        /// subcommand matched.
+        #[test]
+        fn similar_names_are_not_captured() {
+            for cmd in ["pnpm installer", "pnpm testify", "pnpm buildkite"] {
+                assert_eq!(rewrite_command_no_prefixes(cmd, &[]), None, "{cmd}");
+            }
+        }
+    }
+
     fn rewrite_command_no_prefixes(cmd: &str, excluded: &[String]) -> Option<String> {
         super::rewrite_command(cmd, excluded, &[])
     }

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -79,7 +79,14 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
-        pattern: r"^pnpm\s+(exec|i|install|list|ls|outdated|run|run-script)",
+        // pnpm accepts a bare script name (`pnpm test` == `pnpm run test`), and
+        // rtk pnpm forwards args verbatim, so these route correctly.
+        // Deliberately NOT dev/start/serve/watch: those don't terminate, and rtk
+        // captures rather than streams, so the agent would see nothing and hang.
+        // `lint` is absent on purpose: `pnpm lint` already routes to the dedicated
+        // eslint/biome filter (`rtk lint`), which knows the tool's output format.
+        // The trailing (\s|$) is new -- without it `pnpm installer` matched.
+        pattern: r"^pnpm\s+(exec|i|install|list|ls|outdated|run|run-script|test|build|typecheck|format)(\s|$)",
         rtk_cmd: "rtk pnpm",
         rewrite_prefixes: &["pnpm"],
         category: "PackageManager",


### PR DESCRIPTION
Closes #3675.

## Summary

- Routes pnpm's bare script forms: `test`, `build`, `typecheck`, `format`.
- Adds the missing `(\s|$)` word boundary — `pnpm installer` used to match the `install`
  alternative and get rewritten.
- **`lint` is deliberately excluded**: `pnpm lint` already routes to the dedicated eslint/biome
  filter (`rtk lint`), which parses the tool's output rather than just stripping package-manager
  boilerplate. Sending it to `rtk pnpm` would have been a downgrade.
- **Deliberately excludes `dev`, `start`, `serve`, `watch.`** Those never terminate, and rtk
  captures rather than streams, so routing them would hang the agent with no output. This is the
  one case where *not* adding coverage is the correct call.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected

### Unit tests (added)

`src/discover/registry.rs`, module `pnpm_bare_scripts`:

- `bare_script_names_are_rewritten` — the five safe scripts.
- `long_running_scripts_are_left_alone` — `dev`, `start`, `serve`, `watch` must return `None`.
  This is the test that keeps the hazard closed.
- `lint_keeps_its_dedicated_filter` — asserts `pnpm lint` still resolves to `rtk lint`.
- `existing_subcommands_still_rewrite` — `install`, `run build`, `outdated`, `ls`.
- `similar_names_are_not_captured` — `pnpm installer`, `pnpm testify`, `pnpm buildkite`.

### Behavioural check

Fake `pnpm` on `PATH`; failing output preserved and exit codes propagated:
`pnpm test` keeps `a.test.ts` + `1 failed` (exit 1); `pnpm build` keeps `dist/index.js` (exit 0).

Savings on these samples are ~0%: pnpm's own output is already terse, and the filter strips
package-manager boilerplate that small fixtures don't have. The value here is coverage
consistency and tracking, not compression — flagging that honestly rather than claiming a win.

## What the tests caught

The first draft included `lint` in the rule. The unit test failed with
`left: Some("rtk lint")`, `right: Some("rtk pnpm lint")` — the dedicated linter filter was already
winning, and adding `lint` here would only have created ambiguity between two rules. The
expectation was wrong, not the code; `lint` was dropped and a test now pins the existing routing.