### PR TITLE
fix(git): keep the trailing newline on filtered 'git status' output

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -985,6 +985,25 @@ fn filter_status_with_args(output: &str) -> String {
     }
 }
 
+/// Ensure filtered output ends with exactly one trailing newline, matching git.
+///
+/// `filter_status_with_args` joins its kept lines with `\n` and therefore has no
+/// terminal newline, while `never_worse` may hand back git's raw stdout, which
+/// does. Printing either verbatim is wrong in one of the two cases: the joined
+/// form glues its last entry to whatever prints next, so
+/// `rtk git status --porcelain | wc -l` undercounts by one — reporting `0`, i.e.
+/// "clean", on a tree with a single change.
+///
+/// Empty output is left empty: `--porcelain` on a clean tree prints nothing at
+/// all, and a lone newline there would be a different fidelity bug.
+fn with_trailing_newline(output: &str) -> String {
+    if output.is_empty() || output.ends_with('\n') {
+        output.to_string()
+    } else {
+        format!("{}\n", output)
+    }
+}
+
 fn run_status(args: &[String], verbose: u8, global_args: &[String]) -> Result<i32> {
     let timer = tracking::TimedExecution::start();
 
@@ -1013,7 +1032,7 @@ fn run_status(args: &[String], verbose: u8, global_args: &[String]) -> Result<i3
 
         // Apply minimal filtering: strip ANSI, remove hints, empty lines
         let filtered = filter_status_with_args(&result.stdout);
-        let filtered = never_worse(&result.stdout, &filtered).to_string();
+        let filtered = with_trailing_newline(never_worse(&result.stdout, &filtered));
         print!("{}", filtered);
 
         timer.track(
@@ -2336,6 +2355,36 @@ mod tests {
         let cmd = build_status_command(&[], &[]);
         let args: Vec<_> = cmd.get_args().collect();
         assert_eq!(args, vec!["status", "--porcelain", "-b"]);
+    }
+
+    #[test]
+    fn with_trailing_newline_appends_when_missing() {
+        assert_eq!(
+            with_trailing_newline(" M tracked.txt\n?? zzz-last.txt"),
+            " M tracked.txt\n?? zzz-last.txt\n"
+        );
+    }
+
+    #[test]
+    fn with_trailing_newline_leaves_existing_newline_alone() {
+        assert_eq!(with_trailing_newline(" M tracked.txt\n"), " M tracked.txt\n");
+    }
+
+    #[test]
+    fn with_trailing_newline_keeps_empty_output_empty() {
+        // `--porcelain` on a clean tree prints nothing; a lone newline would be
+        // its own fidelity bug.
+        assert_eq!(with_trailing_newline(""), "");
+    }
+
+    #[test]
+    fn filtered_status_line_count_matches_git() {
+        // The regression this guards: `rtk git status --porcelain | wc -l`
+        // reported 0 on a one-file dirty tree, i.e. a false "clean".
+        let raw = "?? handoff/\n";
+        let filtered = with_trailing_newline(&filter_status_with_args(raw));
+        assert_eq!(filtered.lines().count(), raw.lines().count());
+        assert_eq!(filtered, raw);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `rtk git status` drops the trailing newline on the arg-carrying path (`--short` / `-s` / `--porcelain`), so the last entry glues to whatever prints next.
- Worse than cosmetic: any pipeline that counts lines undercounts by one, so **`rtk git status --porcelain | wc -l` reports `0` — a false "clean" — on a tree with exactly one change.** Anything gating a commit/no-commit decision on piped porcelain output takes the wrong branch.
- Fixed by normalizing to exactly one trailing newline in a pure, unit-tested helper. Empty output stays empty, so `--porcelain` on a clean tree still correctly prints nothing.

### Root cause

In `run_status`, the non-compact path ends with:

```rust
let filtered = filter_status_with_args(&result.stdout);
let filtered = never_worse(&result.stdout, &filtered).to_string();
print!("{}", filtered);
```

`filter_status_with_args` joins its kept lines with `\n` and so has **no** terminal newline, while `never_worse` may instead hand back git's raw stdout, which **does**. `print!` is therefore wrong in exactly one of the two cases. This is also why bare `status`, `diff --stat`, `log` and `branch` are unaffected — they end in `println!`.

`with_trailing_newline` handles both inputs, which is why the fix is a helper rather than swapping `print!` for `println!` (that would double the newline whenever `never_worse` falls back to raw).

### Reproduction

```console
$ /usr/bin/git status --porcelain | cat -A
?? handoff/$
$ rtk git status --porcelain | cat -A
?? handoff/
$ /usr/bin/git status --porcelain | wc -l
1
$ rtk git status --porcelain | wc -l
0          # <- reads as a clean tree
```

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo test` — 2708 passed, 8 ignored (9 suites)
- [x] 4 new unit tests: newline appended when missing, existing newline left alone, empty output stays empty, and a line-count-parity test pinning the false-clean regression directly.
- [x] Manual: built `--release` and compared against `/usr/bin/git` by md5 **and** line count for `--short` / `-s` / `--porcelain` / `--porcelain=v1` across clean, single-untracked, 10-modified, staged, deleted, untracked-directory and 252-entry trees, plus inside a linked worktree. Byte-identical in every case.
- [x] Confirmed `--long` and bare `status` still take the compact path and are unchanged — this PR does not touch rtk's intended compaction, only restores fidelity where rtk already passes git's own output through.

## Scope

One function plus its tests, in `src/cmds/git/git.rs`. No behavior change to any other command, and no change to how much rtk compacts.
