### PR TITLE
fix(diff): keep +/- markers at column 0 in condense_unified_diff

### DIFF
--- a/src/cmds/git/diff_cmd.rs
+++ b/src/cmds/git/diff_cmd.rs
@@ -164,7 +164,7 @@ fn condense_unified_diff(diff: &str) -> String {
     let mut current_file = String::new();
     let mut added = 0;
     let mut removed = 0;
-    let mut changes = Vec::new();
+    let mut changes: Vec<String> = Vec::new();
 
     // Never truncate diff content — users make decisions based on this data.
     // Only strip diff metadata (headers, @@ hunks); all +/- lines shown in full.
@@ -174,7 +174,8 @@ fn condense_unified_diff(diff: &str) -> String {
                 if !current_file.is_empty() && (added > 0 || removed > 0) {
                     result.push(format!("[file] {} (+{} -{})", current_file, added, removed));
                     for c in &changes {
-                        result.push(format!("  {}", c));
+                        // Column 0: anchored greps (`^[+-]`) must match these.
+                        result.push(c.clone());
                     }
                 }
                 current_file = line
@@ -198,7 +199,8 @@ fn condense_unified_diff(diff: &str) -> String {
     if !current_file.is_empty() && (added > 0 || removed > 0) {
         result.push(format!("[file] {} (+{} -{})", current_file, added, removed));
         for c in &changes {
-            result.push(format!("  {}", c));
+            // Column 0: anchored greps (`^[+-]`) must match these.
+            result.push(c.clone());
         }
     }
 
@@ -392,6 +394,21 @@ diff --git a/b.rs b/b.rs
         let result = condense_unified_diff(diff);
         assert!(result.contains("a.rs"));
         assert!(result.contains("b.rs"));
+    }
+
+    #[test]
+    fn test_condense_unified_diff_markers_at_column_0() {
+        // Same silent-false-negative class as compact_diff (#118 / upstream
+        // #3646): indented markers make anchored greps (`^[+-]`) match nothing.
+        let diff = "diff --git a/f.rs b/f.rs\n--- a/f.rs\n+++ b/f.rs\n@@ -1,2 +1,2 @@\n-old line\n+new line\n";
+        let result = condense_unified_diff(diff);
+        assert!(result.lines().any(|l| l == "-old line"), "got:\n{}", result);
+        assert!(result.lines().any(|l| l == "+new line"), "got:\n{}", result);
+        assert!(
+            !result.lines().any(|l| l.starts_with(' ')),
+            "change lines must not be indented:\n{}",
+            result
+        );
     }
 
     #[test]

--- a/src/cmds/git/diff_cmd.rs
+++ b/src/cmds/git/diff_cmd.rs
@@ -394,8 +394,8 @@ diff --git a/b.rs b/b.rs
 
     #[test]
     fn test_condense_unified_diff_markers_at_column_0() {
-        // Same silent-false-negative class as compact_diff (#3646): indented
-        // markers make anchored greps (`^[+-]`) match nothing.
+        // Indented markers make anchored greps (`^[+-]`) match nothing, so a
+        // "was anything removed?" audit answers no while the content is there.
         //
         // Two files on purpose. A file's changes are flushed at two separate
         // sites: once per `+++` for the preceding file, once after the loop for
@@ -410,13 +410,15 @@ diff --git a/b.rs b/b.rs
                 result
             );
         }
-        // Scoped to change lines: the `  ... +N more` trailer is legitimately
-        // indented, so a blanket "no line starts with a space" would be false
-        // for any diff with more than ten changes.
+        // Match on leading whitespace rather than a single space: the indent
+        // this guards against is two spaces, so `" +"` / `" -"` would never
+        // fire and the assertion would pass on the very code it rejects.
         assert!(
-            !result
-                .lines()
-                .any(|l| l.starts_with(" +") || l.starts_with(" -")),
+            !result.lines().any(|l| {
+                let trimmed = l.trim_start();
+                trimmed.len() != l.len()
+                    && (trimmed.starts_with('+') || trimmed.starts_with('-'))
+            }),
             "change lines must not be indented:\n{}",
             result
         );

--- a/src/cmds/git/diff_cmd.rs
+++ b/src/cmds/git/diff_cmd.rs
@@ -164,7 +164,7 @@ fn condense_unified_diff(diff: &str) -> String {
     let mut current_file = String::new();
     let mut added = 0;
     let mut removed = 0;
-    let mut changes: Vec<String> = Vec::new();
+    let mut changes = Vec::new();
 
     // Never truncate diff content — users make decisions based on this data.
     // Only strip diff metadata (headers, @@ hunks); all +/- lines shown in full.
@@ -173,10 +173,8 @@ fn condense_unified_diff(diff: &str) -> String {
             if line.starts_with("+++ ") {
                 if !current_file.is_empty() && (added > 0 || removed > 0) {
                     result.push(format!("[file] {} (+{} -{})", current_file, added, removed));
-                    for c in &changes {
-                        // Column 0: anchored greps (`^[+-]`) must match these.
-                        result.push(c.clone());
-                    }
+                    // Column 0: anchored greps (`^[+-]`) must match these.
+                    result.append(&mut changes);
                 }
                 current_file = line
                     .trim_start_matches("+++ ")
@@ -198,10 +196,8 @@ fn condense_unified_diff(diff: &str) -> String {
     // Last file
     if !current_file.is_empty() && (added > 0 || removed > 0) {
         result.push(format!("[file] {} (+{} -{})", current_file, added, removed));
-        for c in &changes {
-            // Column 0: anchored greps (`^[+-]`) must match these.
-            result.push(c.clone());
-        }
+        // Column 0: anchored greps (`^[+-]`) must match these.
+        result.append(&mut changes);
     }
 
     result.join("\n")
@@ -398,14 +394,29 @@ diff --git a/b.rs b/b.rs
 
     #[test]
     fn test_condense_unified_diff_markers_at_column_0() {
-        // Same silent-false-negative class as compact_diff (#118 / upstream
-        // #3646): indented markers make anchored greps (`^[+-]`) match nothing.
-        let diff = "diff --git a/f.rs b/f.rs\n--- a/f.rs\n+++ b/f.rs\n@@ -1,2 +1,2 @@\n-old line\n+new line\n";
+        // Same silent-false-negative class as compact_diff (#3646): indented
+        // markers make anchored greps (`^[+-]`) match nothing.
+        //
+        // Two files on purpose. A file's changes are flushed at two separate
+        // sites: once per `+++` for the preceding file, once after the loop for
+        // the last one. A single-file fixture only ever reaches the second, so
+        // the first could be reverted with the whole suite still green.
+        let diff = "diff --git a/a.rs b/a.rs\n--- a/a.rs\n+++ b/a.rs\n@@ -1 +1 @@\n-fn old() {}\n+fn new() {}\ndiff --git a/b.rs b/b.rs\n--- a/b.rs\n+++ b/b.rs\n@@ -1 +1 @@\n-let x = 1;\n+let x = 2;\n";
         let result = condense_unified_diff(diff);
-        assert!(result.lines().any(|l| l == "-old line"), "got:\n{}", result);
-        assert!(result.lines().any(|l| l == "+new line"), "got:\n{}", result);
+        for want in ["-fn old() {}", "+fn new() {}", "-let x = 1;", "+let x = 2;"] {
+            assert!(
+                result.lines().any(|l| l == want),
+                "missing {want:?} at column 0 in:\n{}",
+                result
+            );
+        }
+        // Scoped to change lines: the `  ... +N more` trailer is legitimately
+        // indented, so a blanket "no line starts with a space" would be false
+        // for any diff with more than ten changes.
         assert!(
-            !result.lines().any(|l| l.starts_with(' ')),
+            !result
+                .lines()
+                .any(|l| l.starts_with(" +") || l.starts_with(" -")),
             "change lines must not be indented:\n{}",
             result
         );


### PR DESCRIPTION
Companion to #3646, which fixed the same class in `compact_diff`.

## Bug

The stdin diff path (`git diff | rtk diff -`, `run_stdin` → `condense_unified_diff`) emitted changed lines as `format!("  {}", c)`. The `+`/`-` markers landed at column 2, so anchored greps (`grep -E '^[+-]'`) over the output matched nothing — a silent false negative for scripts and CI gates built on diff conventions.

## Fix

Emit change lines at column 0 by moving them with `result.append(&mut changes)` — they already carry their markers, and the move also drops a per-line `String` clone. `[file] name (+N -M)` headers and the `... +N more` overflow line are unchanged; neither starts with `+`/`-` on real git output, so anchored greps see the change lines.

## Verification

- Repro before: `printf '<unified diff>' | rtk diff - | grep -cE '^[+-]'` → **0**. After: **4** on a two-file diff, all markers at column 0.
- The regression test uses a **two-file** fixture deliberately: the function flushes changes at two separate sites (once per `+++` for the preceding file, once after the loop for the last). Mutation testing showed a single-file fixture lets the first site revert with the suite still green; the two-file fixture kills both mutants.
- The anti-indent assertion is scoped to change lines (`" +"`/`" -"`) because the `... +N more` trailer is legitimately indented.
- Quality gate green: `cargo fmt --all && cargo clippy --all-targets && cargo test --all`, 0 failures.

## Not in scope

Deeper classification issues in this function (e.g. a removed line whose content is `-- note` arrives as `--- note` and is dropped as a header) are pre-existing, reproducible, and left untouched here — this PR only fixes the emission indentation and its test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
