### PR TITLE
fix(read): preserve context across truncated source

### DIFF
--- a/src/cmds/system/read.rs
+++ b/src/cmds/system/read.rs
@@ -38,16 +38,16 @@ pub fn run(
 
     // Apply filter
     let filter = filter::get_filter(level);
-    let mut filtered = filter.filter(&content, &lang);
+    let filtered = filter.filter(&content, &lang);
 
     // Safety: if filter emptied a non-empty file, fall back to raw content
-    if filtered.trim().is_empty() && !content.trim().is_empty() {
+    let (filtered, fell_back) = preserve_nonempty_input(&content, filtered);
+    if fell_back {
         eprintln!(
             "rtk: warning: filter produced empty output for {} ({} bytes), showing raw content",
             file.display(),
             content.len()
         );
-        filtered = content.clone();
     }
 
     if verbose > 0 {
@@ -64,15 +64,16 @@ pub fn run(
         );
     }
 
-    filtered = apply_line_window(&filtered, max_lines, tail_lines, &lang);
-
     let (raw, rtk_output) = if line_numbers {
         (
             format_with_line_numbers(&content),
-            format_with_line_numbers(&filtered),
+            apply_numbered_line_window(&filtered, max_lines, tail_lines, &lang),
         )
     } else {
-        (content.clone(), filtered.clone())
+        (
+            content.clone(),
+            apply_line_window(&filtered, max_lines, tail_lines, &lang),
+        )
     };
     let shown = never_worse(&raw, &rtk_output);
     print!("{}", shown);
@@ -116,7 +117,14 @@ pub fn run_stdin(
 
     // Apply filter
     let filter = filter::get_filter(level);
-    let mut filtered = filter.filter(&content, &lang);
+    let filtered = filter.filter(&content, &lang);
+    let (filtered, fell_back) = preserve_nonempty_input(&content, filtered);
+    if fell_back {
+        eprintln!(
+            "rtk: warning: filter produced empty output for stdin ({} bytes), showing raw content",
+            content.len()
+        );
+    }
 
     if verbose > 0 {
         let original_lines = content.lines().count();
@@ -132,21 +140,30 @@ pub fn run_stdin(
         );
     }
 
-    filtered = apply_line_window(&filtered, max_lines, tail_lines, &lang);
-
     let (raw, rtk_output) = if line_numbers {
         (
             format_with_line_numbers(&content),
-            format_with_line_numbers(&filtered),
+            apply_numbered_line_window(&filtered, max_lines, tail_lines, &lang),
         )
     } else {
-        (content.clone(), filtered.clone())
+        (
+            content.clone(),
+            apply_line_window(&filtered, max_lines, tail_lines, &lang),
+        )
     };
     let shown = never_worse(&raw, &rtk_output);
     print!("{}", shown);
 
     timer.track("cat - (stdin)", "rtk read -", &raw, shown);
     Ok(())
+}
+
+fn preserve_nonempty_input(content: &str, filtered: String) -> (String, bool) {
+    if filtered.trim().is_empty() && !content.trim().is_empty() {
+        (content.to_string(), true)
+    } else {
+        (filtered, false)
+    }
 }
 
 fn format_with_line_numbers(content: &str) -> String {
@@ -183,6 +200,33 @@ fn apply_line_window(
     }
 
     content.to_string()
+}
+
+fn apply_numbered_line_window(
+    content: &str,
+    max_lines: Option<usize>,
+    tail_lines: Option<usize>,
+    lang: &Language,
+) -> String {
+    if let Some(tail) = tail_lines {
+        if tail == 0 {
+            return String::new();
+        }
+        let lines: Vec<&str> = content.lines().collect();
+        let start = lines.len().saturating_sub(tail);
+        let width = lines.len().to_string().len();
+        let mut output = String::new();
+        for (index, line) in lines.iter().enumerate().skip(start) {
+            output.push_str(&format!("{:>width$} │ {}\n", index + 1, line));
+        }
+        return output;
+    }
+
+    if let Some(max) = max_lines {
+        return filter::smart_truncate_numbered(content, max, lang);
+    }
+
+    format_with_line_numbers(content)
 }
 
 #[cfg(test)]
@@ -233,7 +277,54 @@ fn main() {{
         let input = "a\nb\nc\nd\n";
         let output = apply_line_window(input, Some(2), None, &Language::Unknown);
         assert!(output.starts_with("a\n"));
-        assert!(output.contains("more lines"));
+        assert!(output.contains("lines omitted"));
+    }
+
+    #[test]
+    fn test_numbered_truncation_preserves_source_line_numbers() {
+        let input = r#"fn can_admin(user: &User) -> bool {
+    if !user.is_admin {
+        return false;
+    }
+    if user.is_banned {
+        return false;
+    }
+    if user.mfa_ok {
+        return true;
+    }
+    false
+}
+fn wipe_database() {
+    drop_all();
+}"#;
+
+        let output = apply_numbered_line_window(input, Some(10), None, &Language::Rust);
+
+        assert!(output.contains(" 5 │     if user.is_banned {"));
+        assert!(output.contains("   │ [1 line omitted]"));
+        assert!(output.contains(" 7 │     }"));
+        assert!(!output.contains(" 6 │     }"));
+    }
+
+    #[test]
+    fn test_numbered_tail_uses_source_line_numbers() {
+        let output =
+            apply_numbered_line_window("a\nb\nc\nd\n", None, Some(2), &Language::Unknown);
+        assert_eq!(output, "3 │ c\n4 │ d\n");
+    }
+
+    #[test]
+    fn test_nonempty_input_falls_back_from_empty_filter_output() {
+        let (output, fell_back) = preserve_nonempty_input("// build failed\n", String::new());
+        assert!(fell_back);
+        assert_eq!(output, "// build failed\n");
+    }
+
+    #[test]
+    fn test_empty_input_does_not_invent_fallback_output() {
+        let (output, fell_back) = preserve_nonempty_input("", String::new());
+        assert!(!fell_back);
+        assert!(output.is_empty());
     }
 
     fn rtk_bin() -> std::path::PathBuf {

--- a/src/core/filter.rs
+++ b/src/core/filter.rs
@@ -317,45 +317,129 @@ pub fn get_filter(level: FilterLevel) -> Box<dyn FilterStrategy> {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum TruncatedLine<'a> {
+    Source { number: usize, text: &'a str },
+    Omitted { count: usize },
+}
+
+fn is_structurally_important(line: &str) -> bool {
+    let trimmed = line.trim();
+    FUNC_SIGNATURE.is_match(trimmed)
+        || IMPORT_PATTERN.is_match(trimmed)
+        || trimmed.starts_with("pub ")
+        || trimmed.starts_with("export ")
+        || trimmed == "}"
+        || trimmed == "{"
+}
+
+fn select_truncated_lines<'a>(lines: &'a [&'a str], max_lines: usize) -> Vec<TruncatedLine<'a>> {
+    if max_lines == 0 || lines.is_empty() {
+        return Vec::new();
+    }
+
+    let prefix_len = (max_lines / 2)
+        .min(max_lines.saturating_sub(1))
+        .min(lines.len());
+    let mut selected: Vec<usize> = (0..prefix_len).collect();
+    let mut gap_count = 0;
+
+    for (index, line) in lines.iter().enumerate().skip(prefix_len) {
+        if !is_structurally_important(line) {
+            continue;
+        }
+
+        let adds_gap = selected
+            .last()
+            .map_or(index > 0, |previous| index > previous + 1);
+        let needs_tail_marker = index + 1 < lines.len();
+        let rendered_len =
+            selected.len() + 1 + gap_count + usize::from(adds_gap) + usize::from(needs_tail_marker);
+
+        if rendered_len <= max_lines {
+            selected.push(index);
+            gap_count += usize::from(adds_gap);
+        }
+    }
+
+    if selected.is_empty() {
+        return vec![TruncatedLine::Omitted { count: lines.len() }];
+    }
+
+    let mut result = Vec::with_capacity(max_lines);
+    let mut next_source_index = 0;
+    for index in selected {
+        if index > next_source_index {
+            result.push(TruncatedLine::Omitted {
+                count: index - next_source_index,
+            });
+        }
+        result.push(TruncatedLine::Source {
+            number: index + 1,
+            text: lines[index],
+        });
+        next_source_index = index + 1;
+    }
+    if next_source_index < lines.len() {
+        result.push(TruncatedLine::Omitted {
+            count: lines.len() - next_source_index,
+        });
+    }
+    result
+}
+
+fn omission_marker(count: usize) -> String {
+    let noun = if count == 1 { "line" } else { "lines" };
+    format!("[{count} {noun} omitted]")
+}
+
+fn render_truncated(lines: &[TruncatedLine<'_>]) -> String {
+    lines
+        .iter()
+        .map(|line| match line {
+            TruncatedLine::Source { text, .. } => (*text).to_string(),
+            TruncatedLine::Omitted { count } => omission_marker(*count),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 pub fn smart_truncate(content: &str, max_lines: usize, _lang: &Language) -> String {
     let lines: Vec<&str> = content.lines().collect();
     if lines.len() <= max_lines {
         return content.to_string();
     }
+    render_truncated(&select_truncated_lines(&lines, max_lines))
+}
 
-    let mut result = Vec::with_capacity(max_lines + 1);
-    let mut kept_lines = 0;
+pub(crate) fn smart_truncate_numbered(content: &str, max_lines: usize, _lang: &Language) -> String {
+    let source_lines: Vec<&str> = content.lines().collect();
+    let width = source_lines.len().to_string().len();
+    let lines = if source_lines.len() <= max_lines {
+        source_lines
+            .iter()
+            .enumerate()
+            .map(|(index, text)| TruncatedLine::Source {
+                number: index + 1,
+                text,
+            })
+            .collect()
+    } else {
+        select_truncated_lines(&source_lines, max_lines)
+    };
 
-    for line in &lines {
-        let trimmed = line.trim();
-
-        // Prioritize structurally important lines so the visible window stays useful.
-        // The old approach interleaved "// ... N lines omitted" markers which AI agents
-        // treated as code, causing parsing confusion and extra retry loops.
-        let is_important = FUNC_SIGNATURE.is_match(trimmed)
-            || IMPORT_PATTERN.is_match(trimmed)
-            || trimmed.starts_with("pub ")
-            || trimmed.starts_with("export ")
-            || trimmed == "}"
-            || trimmed == "{";
-
-        if is_important || kept_lines < max_lines / 2 {
-            result.push((*line).to_string());
-            kept_lines += 1;
-        }
-        // Non-important lines beyond max_lines/2 are silently skipped —
-        // no inline markers that could be mistaken for file content.
-
-        if kept_lines >= max_lines - 1 {
-            break;
+    let mut output = String::new();
+    for line in lines {
+        match line {
+            TruncatedLine::Source { number, text } => {
+                output.push_str(&format!("{number:>width$} │ {text}\n"));
+            }
+            TruncatedLine::Omitted { count } => {
+                output.push_str(&format!("{:width$} │ {}\n", "", omission_marker(count)));
+            }
         }
     }
-
-    // Single end-of-output marker: not code syntax, unambiguous to AI agents.
-    // Invariant: kept_lines + N == lines.len() (N = lines not shown)
-    result.push(format!("[{} more lines]", lines.len() - kept_lines));
-
-    result.join("\n")
+    output
 }
 
 #[cfg(test)]
@@ -473,8 +557,7 @@ fn main() {
     fn test_smart_truncate_overflow_count_exact() {
         // 200 plain-text lines (no function signatures/imports) with max_lines=20.
         // Smart selection keeps up to max_lines/2=10 non-important lines then stops.
-        // The overflow message "[N more lines]" must satisfy:
-        //   kept_count + N == total_lines
+        // Omission markers must account for every source line not shown.
         let total_lines = 200usize;
         let max_lines = 20usize;
         let content: String = (0..total_lines)
@@ -484,31 +567,29 @@ fn main() {
 
         let output = smart_truncate(&content, max_lines, &Language::Rust);
 
-        // Extract the overflow message
-        let overflow_line = output
+        let reported_omitted: usize = output
             .lines()
-            .find(|l| l.contains("more lines"))
-            .unwrap_or_else(|| panic!("No overflow message found in:\n{}", output));
-
-        // Parse "[N more lines]"
-        let reported_more: usize = overflow_line
-            .trim()
-            .strip_prefix('[')
-            .and_then(|s| s.split_whitespace().next())
-            .and_then(|n| n.parse().ok())
-            .unwrap_or_else(|| panic!("Could not parse overflow count from: {}", overflow_line));
+            .filter(|line| line.contains("omitted"))
+            .map(|line| {
+                line.trim()
+                    .strip_prefix('[')
+                    .and_then(|value| value.split_whitespace().next())
+                    .and_then(|count| count.parse::<usize>().ok())
+                    .unwrap_or_else(|| panic!("Could not parse omission count from: {line}"))
+            })
+            .sum();
 
         let kept_count = output
             .lines()
-            .filter(|l| !l.contains("more lines") && !l.contains("omitted"))
+            .filter(|line| !line.contains("omitted"))
             .count();
 
         assert_eq!(
-            kept_count + reported_more,
+            kept_count + reported_omitted,
             total_lines,
-            "kept ({}) + reported_more ({}) must equal total ({})",
+            "kept ({}) + reported_omitted ({}) must equal total ({})",
             kept_count,
-            reported_more,
+            reported_omitted,
             total_lines
         );
     }
@@ -524,8 +605,8 @@ fn main() {
             !output.contains("// ..."),
             "smart_truncate must not insert synthetic comment annotations"
         );
-        // Must contain clean end-of-output marker (1 kept + 9 omitted = 10 total)
-        assert!(output.contains("[9 more lines]"));
+        // Must contain a non-code omission marker (1 kept + 9 omitted = 10 total)
+        assert!(output.contains("[9 lines omitted]"));
         // Only the first line is kept (plain-text, no important signatures)
         assert!(output.starts_with("line1\n"));
     }
@@ -543,5 +624,49 @@ fn main() {
         let input = "a\nb\nc";
         let output = smart_truncate(input, 3, &Language::Unknown);
         assert_eq!(output, input);
+    }
+
+    #[test]
+    fn test_smart_truncate_marks_each_discontinuity() {
+        let input = r#"fn can_admin(user: &User) -> bool {
+    if !user.is_admin {
+        return false;
+    }
+    if user.is_banned {
+        return false;
+    }
+    if user.mfa_ok {
+        return true;
+    }
+    false
+}
+fn wipe_database() {
+    drop_all();
+}"#;
+
+        let output = smart_truncate(input, 10, &Language::Rust);
+
+        assert!(output.contains("    if user.is_banned {\n[1 line omitted]\n    }"));
+        assert!(
+            !output.contains("    if user.is_banned {\n    }"),
+            "a removed guard body must never look like an empty source block"
+        );
+    }
+
+    #[test]
+    fn test_smart_truncate_zero_lines_is_empty() {
+        assert_eq!(smart_truncate("first\nsecond\n", 0, &Language::Unknown), "");
+    }
+
+    #[test]
+    fn test_smart_truncate_never_exceeds_line_budget() {
+        let input = "plain one\nplain two\nplain three\nfn final_item() {}";
+        for max_lines in 0..=3 {
+            let output = smart_truncate(input, max_lines, &Language::Rust);
+            assert!(
+                output.lines().count() <= max_lines,
+                "max_lines={max_lines} produced {output:?}"
+            );
+        }
     }
 }

--- a/tests/read_integrity_test.rs
+++ b/tests/read_integrity_test.rs
@@ -1,0 +1,79 @@
+use std::io::Write;
+use std::process::{Command, Output, Stdio};
+
+const GUARD_SOURCE: &str = r#"fn can_admin(user: &User) -> bool {
+    if !user.is_admin {
+        return false;
+    }
+    if user.is_banned {
+        return false;
+    }
+    if user.mfa_ok {
+        return true;
+    }
+    false
+}
+fn wipe_database() {
+    drop_all();
+}
+"#;
+
+fn read_stdin(args: &[&str], input: &str) -> Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .arg("read")
+        .arg("-")
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn rtk read");
+    child
+        .stdin
+        .take()
+        .expect("piped stdin")
+        .write_all(input.as_bytes())
+        .expect("write stdin");
+    child.wait_with_output().expect("wait for rtk read")
+}
+
+#[test]
+fn truncation_marks_removed_guard_body_at_the_gap() {
+    let output = read_stdin(&["--max-lines", "10"], GUARD_SOURCE);
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("    if user.is_banned {\n[1 line omitted]\n    }"));
+    assert!(!stdout.contains("    if user.is_banned {\n    }"));
+    assert!(stdout.lines().count() <= 10);
+}
+
+#[test]
+fn numbered_truncation_uses_source_line_numbers() {
+    let output = read_stdin(&["--max-lines", "10", "--line-numbers"], GUARD_SOURCE);
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(" 5 │     if user.is_banned {"));
+    assert!(stdout.contains("   │ [1 line omitted]"));
+    assert!(stdout.contains(" 7 │     }"));
+    assert!(!stdout.contains(" 6 │     }"));
+}
+
+#[test]
+fn stdin_falls_back_when_filter_removes_nonempty_input() {
+    let input = "// BUILD FAILED\n// error: cannot find symbol at Main.java:42\n// 3 errors\n";
+    let output = read_stdin(&["--level", "minimal"], input);
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), input);
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("filter produced empty output for stdin")
+    );
+}
+
+#[test]
+fn zero_line_window_is_empty_without_panicking() {
+    let output = read_stdin(&["--max-lines", "0"], "nonempty\n");
+    assert!(output.status.success());
+    assert!(output.stdout.is_empty());
+}


### PR DESCRIPTION
## Summary

- preserve smart-truncation omission markers and source line numbers
- merge current develop while retaining its byte-faithful head/tail windows and zero-budget behavior
- retain the stdin empty-filter fallback and the original four integration regressions
- add a focused regression for numbered head output

The head rewrite and zero-budget handling are now also present upstream; the remaining contribution is visible gaps, numbering, and stdin fallback. This does not replace native head/tail slicing with smart selection.

## Verification (current merge)

Passed:
- cargo fmt --all --check
- cargo clippy --all-targets --locked
- read unit tests: 28 passed, 3 ignored
- filter unit tests: 13 passed
- read_integrity_test: 4 passed

cargo test --locked was run but did not fully pass: guard_integration_test had two failures, both reproduced individually:
- git_diff_dash_dash_stat_pathspec_after_double_dash_is_not_stat_flag
- git_log_malformed_digit_run_propagates_real_git_error

The Git command sources and that test file are identical to upstream/develop. This machine uses Apple Git 2.39.5; the latter assertion expects "not an integer", while Git emits "not a non-negative integer". No unrelated Git code or assertions were changed. Suites after that failure were not reached.

## AI assistance

OpenAI Codex assisted with the implementation, conflict resolution, and local verification. The commands and results above were observed locally; they are not a claim of a fully green suite.

Closes #3421