### PR TITLE
fix: emit trailing newline from rtk find output

### DIFF
--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -373,7 +373,13 @@ pub fn run(
     }
 
     let shown = never_worse(&raw_output, &body);
-    print!("{}", shown);
+    if shown.is_empty() {
+        // no matches
+    } else if shown.ends_with('\n') {
+        print!("{}", shown);
+    } else {
+        println!("{}", shown);
+    }
     timer.track(
         &format!("find {} -name '{}'", path, effective_pattern),
         "rtk find",


### PR DESCRIPTION
## Summary

fix: emit trailing newline from rtk find output

## Changes

- print! left the last path without a terminating newline, so wc -l under-counted by one.
- Match find(1) by ensuring non-empty output ends with a newline.

Fixes #3659
