### PR TITLE
fix(docs): separate Claude Code and Copilot init commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ rtk gain        # Should show the savings dashboard
 
 ```bash
 # 1. Install for your AI tool
-rtk init -g                     # Claude Code / Copilot (default)
+rtk init -g                     # Claude Code (default)
+rtk init -g --copilot           # Copilot
 rtk init -g --gemini            # Gemini CLI
 rtk init -g --codex             # Codex (OpenAI)
 rtk init -g --agent cursor      # Cursor


### PR DESCRIPTION
## Summary
- Split the misleading  line into two separate commands
-  installs Claude Code (the actual default)
-  installs Copilot

## Why
The original line implied both tools are installed by , but only Claude Code is the default. Copilot requires the  flag (verified in  and ).

## Test plan
- [ ] Verify  still installs Claude Code
- [ ] Verify  installs Copilot
- [ ] Verify the README renders correctly on GitHub

Closes #2244