### PR TITLE
fix(install): fix install script crashing when run on Windows with Git Bash

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,7 +41,7 @@ If you accidentally installed Rust Type Kit:
 cargo uninstall rtk
 ```
 
-### Quick Install (Linux/macOS)
+### Quick Install (Linux/macOS/Git for Windows)
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/master/install.sh | sh

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The token counts RTK reports are estimated as `bytes / 4` — RTK ships no token
 brew install rtk
 ```
 
-### Quick Install (Linux/macOS)
+### Quick Install (Linux/macOS/Git for Windows)
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
@@ -361,6 +361,16 @@ rtk init -g
 **Prerequisites**: some filters shell out to [ripgrep](https://github.com/BurntSushi/ripgrep) (`rg`). Install it and keep it on your PATH (e.g. `winget install BurntSushi.ripgrep.MSVC`) to avoid `Binary 'rg' not found on PATH` warnings.
 
 **Important**: Do not double-click `rtk.exe` — it is a CLI tool that prints usage and exits immediately. Always run it from a terminal (Command Prompt, PowerShell, or Windows Terminal).
+
+#### Git for Windows
+
+If you use 'Git Bash' on Windows, you can follow the same install process as Linux/macOS by running the following command:
+
+```bash
+# Inside Git Bash
+curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
+rtk init -g
+```
 
 ### WSL
 

--- a/README_es.md
+++ b/README_es.md
@@ -72,7 +72,7 @@ Los recuentos de tokens que reporta RTK se estiman como `bytes / 4`: RTK no incl
 brew install rtk
 ```
 
-### Instalacion rapida (Linux/macOS)
+### Instalacion rapida (Linux/macOS/Git for Windows)
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh

--- a/README_fr.md
+++ b/README_fr.md
@@ -72,7 +72,7 @@ Les nombres de tokens rapportes par RTK sont estimes avec `octets / 4` : RTK n'e
 brew install rtk
 ```
 
-### Installation rapide (Linux/macOS)
+### Installation rapide (Linux/macOS/Git for Windows)
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh

--- a/README_ja.md
+++ b/README_ja.md
@@ -72,7 +72,7 @@ RTK が報告するトークン数は `バイト数 / 4` で見積もられて�
 brew install rtk
 ```
 
-### クイックインストール（Linux/macOS）
+### クイックインストール（Linux/macOS/Git for Windows）
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh

--- a/README_ko.md
+++ b/README_ko.md
@@ -72,7 +72,7 @@ RTK가 보고하는 토큰 수는 `바이트 / 4`로 추정됩니다. RTK에는 
 brew install rtk
 ```
 
-### 빠른 설치 (Linux/macOS)
+### 빠른 설치 (Linux/macOS/Git for Windows)
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh

--- a/README_pt.md
+++ b/README_pt.md
@@ -73,7 +73,7 @@ As contagens de tokens que o RTK reporta são estimadas como `bytes / 4`: o RTK 
 brew install rtk
 ```
 
-### Instalação rápida (Linux/macOS)
+### Instalação rápida (Linux/macOS/Git for Windows)
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh

--- a/README_zh.md
+++ b/README_zh.md
@@ -72,7 +72,7 @@ RTK 报告的 token 数量按 `字节数 / 4` 估算：RTK 不内置分词器，
 brew install rtk
 ```
 
-### 快速安装（Linux/macOS）
+### 快速安装（Linux/macOS/Git for Windows）
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh

--- a/install.sh
+++ b/install.sh
@@ -30,9 +30,10 @@ error() {
 # Detect OS
 detect_os() {
     case "$(uname -s)" in
-        Linux*)  OS="linux";;
-        Darwin*) OS="darwin";;
-        *)       error "Unsupported operating system: $(uname -s)";;
+        Linux*)               OS="linux";;
+        Darwin*)              OS="darwin";;
+        MINGW*|MSYS*|CYGWIN*) OS="windows";;
+        *)                    error "Unsupported operating system: $(uname -s)";;
     esac
 }
 
@@ -80,7 +81,22 @@ get_target() {
         darwin)
             TARGET="${ARCH}-apple-darwin"
             ;;
+        windows)
+            case "$ARCH" in
+                x86_64) TARGET="x86_64-pc-windows-msvc";;
+                *)      error "Unsupported architecture for Windows: $ARCH";;
+            esac
+            ;;
     esac
+
+    # Windows releases ship as .zip with an .exe binary
+    if [ "$OS" = "windows" ]; then
+        ARCHIVE_EXT="zip"
+        BINARY_FILE="${BINARY_NAME}.exe"
+    else
+        ARCHIVE_EXT="tar.gz"
+        BINARY_FILE="${BINARY_NAME}"
+    fi
 }
 
 # Download and install
@@ -89,12 +105,12 @@ install() {
     info "Target: $TARGET"
     info "Version: $VERSION"
 
-    DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${BINARY_NAME}-${TARGET}.tar.gz"
+    DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${BINARY_NAME}-${TARGET}.${ARCHIVE_EXT}"
     CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${VERSION}/checksums.txt"
     TEMP_DIR=$(mktemp -d)
-    ARCHIVE="${TEMP_DIR}/${BINARY_NAME}.tar.gz"
+    ARCHIVE="${TEMP_DIR}/${BINARY_NAME}.${ARCHIVE_EXT}"
     CHECKSUMS="${TEMP_DIR}/checksums.txt"
-    ASSET_NAME="${BINARY_NAME}-${TARGET}.tar.gz"
+    ASSET_NAME="${BINARY_NAME}-${TARGET}.${ARCHIVE_EXT}"
 
     info "Downloading from: $DOWNLOAD_URL"
     if ! curl -fsSL "$DOWNLOAD_URL" -o "$ARCHIVE"; then
@@ -128,30 +144,41 @@ install() {
         info "Checksum verified."
     fi
 
+    info "Verifying archive contents..."
+
+    LIST_CMD="tar -tzf"
+    if [ "$ARCHIVE_EXT" = "zip" ]; then
+        command -v unzip >/dev/null 2>&1 || error "unzip is required to install on Windows but was not found"
+        LIST_CMD="unzip -Z1"
+    fi
+
     # Verify archive contents before extraction (CWE-22 path traversal).
     # Reject any entry with an absolute path or a ".." component.
-    info "Verifying archive contents..."
-    if tar -tzf "$ARCHIVE" | grep -qE '^/|(^|/)\.\.(/|$)'; then
+    if $LIST_CMD "$ARCHIVE" | grep -qE '^/|(^|/)\.\.(/|$)'; then
         error "Archive contains unsafe paths (absolute or directory traversal) — refusing to extract"
     fi
 
     info "Extracting..."
-    tar -xzf "$ARCHIVE" -C "$TEMP_DIR"
+    if [ "$ARCHIVE_EXT" = "zip" ]; then
+        unzip -q "$ARCHIVE" -d "$TEMP_DIR"
+    else
+        tar -xzf "$ARCHIVE" -C "$TEMP_DIR"
+    fi
 
     mkdir -p "$INSTALL_DIR"
-    mv "${TEMP_DIR}/${BINARY_NAME}" "${INSTALL_DIR}/"
+    mv "${TEMP_DIR}/${BINARY_FILE}" "${INSTALL_DIR}/"
 
-    chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
+    chmod +x "${INSTALL_DIR}/${BINARY_FILE}"
 
     # Cleanup
     rm -rf "$TEMP_DIR"
 
-    info "Successfully installed ${BINARY_NAME} to ${INSTALL_DIR}/${BINARY_NAME}"
+    info "Successfully installed ${BINARY_NAME} to ${INSTALL_DIR}/${BINARY_FILE}"
 }
 
 # Verify installation
 verify() {
-    INSTALLED_BIN="${INSTALL_DIR}/${BINARY_NAME}"
+    INSTALLED_BIN="${INSTALL_DIR}/${BINARY_FILE}"
     if [ -x "$INSTALLED_BIN" ]; then
         info "Verification: $("$INSTALLED_BIN" --version)"
     else

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env sh
-# Tests for install.sh path traversal check (issue #1250, CWE-22).
+# Tests for install.sh.
 #
-# Verifies:
-#   1. Safe archives (single binary, "./prefix", subdirs) are accepted.
-#   2. Archives with absolute paths are rejected pre-extraction.
-#   3. Archives with ".." components are rejected pre-extraction.
-#   4. The check is still present in install.sh (regression guard).
+# Section 1 — General install-path checks:
+#   OS/arch/target resolution (detect_os, get_target) across linux/darwin/windows,
+#   and archive extraction mechanics for both tar.gz and zip (Windows uses zip/.exe).
+#
+# Section 2 — CWE-22 path traversal checks (issue #1250):
+#   Archive-content verification rejects absolute paths and ".." components,
+#   for both the tar.gz (default) and zip (Windows) archive-listing paths.
 
 set -eu
 
@@ -17,30 +19,204 @@ if [ ! -f "$INSTALL_SH" ]; then
     exit 1
 fi
 
-if ! command -v python3 >/dev/null 2>&1; then
-    echo "SKIP: python3 not available — crafted tarball tests require python3"
-    exit 0
-fi
+# Referenced by the error() function in the real `install.sh` script
+RED='' NC=''
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
-# The check replicated from install.sh (keep in sync with install.sh).
-# Returns 0 when archive is safe, 1 when unsafe.
-check_archive() {
-    if tar -tzf "$1" | grep -qE '^/|(^|/)\.\.(/|$)'; then
-        return 1
-    fi
-    return 0
+FAIL=0
+pass() { printf '  PASS: %s\n' "$1"; }
+fail() { printf '  FAIL: %s\n' "$1"; FAIL=1; }
+skip() { printf '  SKIP: %s\n' "$1"; }
+
+# Extract a function body verbatim from the real install.sh so tests exercise
+# the actual current source rather than a hand-copied replica that can drift.
+extract_fn() {
+    sed -n "/^$1() {/,/^}/p" "$INSTALL_SH"
 }
 
-# --- Build safe archive using standard tar ---
-mkdir -p "$TMPDIR/safe_src"
-printf '#!/bin/sh\necho rtk\n' > "$TMPDIR/safe_src/rtk"
-(cd "$TMPDIR/safe_src" && tar -czf "$TMPDIR/safe.tgz" rtk)
+ERROR_FN=$(extract_fn error)
+DETECT_OS_FN=$(extract_fn detect_os)
+GET_TARGET_FN=$(extract_fn get_target)
+UNZIP_GUARD_LINE=$(grep -F 'command -v unzip' "$INSTALL_SH")
 
-# --- Build crafted malicious archives with python ---
-python3 - "$TMPDIR" <<'PY'
+# Prefer python3, but some environments (e.g. python.org's Windows installer) only
+# expose "python", so fall back to it once python3 installation is confirmed.
+PY3=""
+for cand in python3 python; do
+    if command -v "$cand" >/dev/null 2>&1 && "$cand" -c 'import sys; sys.exit(0 if sys.version_info[0] >= 3 else 1)' >/dev/null 2>&1; then
+        PY3="$cand"
+        break
+    fi
+done
+
+echo "==> Section 1: General install-path checks"
+
+# --- detect_os() ---
+
+run_detect_os() {
+    (
+        eval "$ERROR_FN"
+        eval "$DETECT_OS_FN"
+        MOCK_S="$1"
+        uname() { case "$1" in -s) printf '%s' "$MOCK_S" ;; esac; }
+        detect_os
+        echo "OS=$OS"
+    ) 2>&1
+}
+
+assert_os() {
+    label="$1" mock="$2" expected="$3"
+    if out=$(run_detect_os "$mock"); then rc=0; else rc=$?; fi
+    if [ "$rc" -eq 0 ] && [ "$out" = "OS=$expected" ]; then
+        pass "$label"
+    else
+        fail "$label (rc=$rc out='$out')"
+    fi
+}
+
+assert_os_error() {
+    label="$1" mock="$2"
+    if out=$(run_detect_os "$mock"); then rc=0; else rc=$?; fi
+    if [ "$rc" -ne 0 ]; then
+        pass "$label"
+    else
+        fail "$label (expected error, got rc=0 out='$out')"
+    fi
+}
+
+assert_os "detect_os: MINGW64 (Git Bash) -> windows" "MINGW64_NT-10.0-22631" "windows"
+assert_os "detect_os: MSYS -> windows" "MSYS_NT-10.0" "windows"
+assert_os "detect_os: CYGWIN -> windows" "CYGWIN_NT-10.0" "windows"
+assert_os "detect_os: Linux -> linux (regression)" "Linux" "linux"
+assert_os "detect_os: Darwin -> darwin (regression)" "Darwin" "darwin"
+assert_os_error "detect_os: unrecognized uname -s still errors" "FreeBSD"
+
+# --- get_target() ---
+
+run_get_target() {
+    os="$1" arch="$2"
+    (
+        eval "$ERROR_FN"
+        eval "$GET_TARGET_FN"
+        OS="$os"
+        ARCH="$arch"
+        BINARY_NAME="rtk"
+        get_target
+        echo "TARGET=$TARGET ARCHIVE_EXT=$ARCHIVE_EXT BINARY_FILE=$BINARY_FILE"
+    ) 2>&1
+}
+
+assert_target() {
+    label="$1" os="$2" arch="$3" expected="$4"
+    if out=$(run_get_target "$os" "$arch"); then rc=0; else rc=$?; fi
+    if [ "$rc" -eq 0 ] && [ "$out" = "$expected" ]; then
+        pass "$label"
+    else
+        fail "$label (rc=$rc out='$out')"
+    fi
+}
+
+assert_target_error() {
+    label="$1" os="$2" arch="$3"
+    if out=$(run_get_target "$os" "$arch"); then rc=0; else rc=$?; fi
+    if [ "$rc" -ne 0 ]; then
+        pass "$label"
+    else
+        fail "$label (expected error, got rc=0 out='$out')"
+    fi
+}
+
+assert_target "get_target: windows/x86_64 -> msvc target + zip/.exe" \
+    "windows" "x86_64" "TARGET=x86_64-pc-windows-msvc ARCHIVE_EXT=zip BINARY_FILE=rtk.exe"
+assert_target_error "get_target: windows/aarch64 is unsupported" "windows" "aarch64"
+assert_target "get_target: linux/x86_64 -> tar.gz/no-ext (regression)" \
+    "linux" "x86_64" "TARGET=x86_64-unknown-linux-musl ARCHIVE_EXT=tar.gz BINARY_FILE=rtk"
+assert_target "get_target: darwin/x86_64 -> tar.gz/no-ext (regression)" \
+    "darwin" "x86_64" "TARGET=x86_64-apple-darwin ARCHIVE_EXT=tar.gz BINARY_FILE=rtk"
+
+# --- missing-unzip dependency guard ---
+
+mkdir -p "$TMPDIR/empty_bin"
+
+run_missing_unzip_guard() {
+    (
+        PATH="$TMPDIR/empty_bin"
+        eval "$ERROR_FN"
+        eval "$UNZIP_GUARD_LINE"
+        echo "GUARD_DID_NOT_FIRE"
+    ) 2>&1
+}
+
+if out=$(run_missing_unzip_guard); then rc=0; else rc=$?; fi
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -qF "unzip is required"; then
+    pass "missing-unzip guard fires when unzip absent from PATH"
+else
+    fail "missing-unzip guard did not fire as expected (rc=$rc out='$out')"
+fi
+
+# --- extraction mechanics (real tar/unzip, no network) ---
+
+extract_archive() {
+    case "$1" in
+        *.zip) unzip -q "$1" -d "$2" ;;
+        *) tar -xzf "$1" -C "$2" ;;
+    esac
+}
+
+if command -v unzip >/dev/null 2>&1 && [ -n "$PY3" ]; then
+    "$PY3" - "$TMPDIR" <<'PY'
+import sys, zipfile
+base = sys.argv[1]
+with zipfile.ZipFile(f"{base}/exe.zip", "w") as z:
+    z.writestr("rtk.exe", "dummy windows binary content")
+PY
+    EXTRACT_DIR="$TMPDIR/extracted"
+    DEST_DIR="$TMPDIR/dest"
+    mkdir -p "$EXTRACT_DIR" "$DEST_DIR"
+    extract_archive "$TMPDIR/exe.zip" "$EXTRACT_DIR"
+    if [ -f "$EXTRACT_DIR/rtk.exe" ]; then
+        mv "$EXTRACT_DIR/rtk.exe" "$DEST_DIR/rtk.exe"
+        chmod +x "$DEST_DIR/rtk.exe"
+        if [ -x "$DEST_DIR/rtk.exe" ]; then
+            pass "zip extraction places and chmods rtk.exe correctly"
+        else
+            fail "rtk.exe not executable after chmod"
+        fi
+    else
+        fail "rtk.exe missing after zip extraction"
+    fi
+else
+    skip "zip extraction mechanics test (requires unzip and a python3-compatible interpreter)"
+fi
+
+echo ""
+echo "==> Section 2: CWE-22 path traversal checks (issue #1250)"
+
+if [ -z "$PY3" ]; then
+    echo "SKIP: no python3-compatible interpreter found — crafted archive tests require one"
+else
+    # The check replicated from install.sh (keep in sync with install.sh).
+    # Returns 0 when archive is safe, 1 when unsafe.
+    check_archive() {
+        case "$1" in
+            *.zip) list_cmd="unzip -Z1" ;;
+            *)     list_cmd="tar -tzf" ;;
+        esac
+        if $list_cmd "$1" 2>/dev/null | grep -qE '^/|(^|/)\.\.(/|$)'; then
+            return 1
+        fi
+        return 0
+    }
+
+    # --- Build safe archive using standard tar ---
+    mkdir -p "$TMPDIR/safe_src"
+    printf '#!/bin/sh\necho rtk\n' > "$TMPDIR/safe_src/rtk"
+    (cd "$TMPDIR/safe_src" && tar -czf "$TMPDIR/safe.tgz" rtk)
+
+    # --- Build crafted malicious tar archives with python ---
+    "$PY3" - "$TMPDIR" <<'PY'
 import sys, tarfile, io
 
 base = sys.argv[1]
@@ -60,37 +236,94 @@ make("middle.tgz", "rtk/../../../etc/evil")
 make("end_dotdot.tgz", "rtk/..")
 PY
 
-FAIL=0
-pass() { printf '  PASS: %s\n' "$1"; }
-fail() { printf '  FAIL: %s\n' "$1"; FAIL=1; }
+    echo "==> Functional checks (tar.gz)"
 
-echo "==> Functional checks"
-
-if check_archive "$TMPDIR/safe.tgz"; then
-    pass "safe archive accepted"
-else
-    fail "safe archive rejected (false positive)"
-fi
-
-for bad in traversal absolute middle end_dotdot; do
-    if check_archive "$TMPDIR/$bad.tgz"; then
-        fail "$bad archive accepted (should be rejected)"
+    if check_archive "$TMPDIR/safe.tgz"; then
+        pass "safe tar archive accepted"
     else
-        pass "$bad archive rejected"
+        fail "safe tar archive rejected (false positive)"
     fi
-done
 
-echo "==> Regression guard"
+    for bad in traversal absolute middle end_dotdot; do
+        if check_archive "$TMPDIR/$bad.tgz"; then
+            fail "$bad tar archive accepted (should be rejected)"
+        else
+            pass "$bad tar archive rejected"
+        fi
+    done
 
-if grep -qF 'tar -tzf' "$INSTALL_SH" && grep -qF '\.\.' "$INSTALL_SH"; then
-    pass "install.sh still contains the path-traversal check"
-else
-    fail "install.sh is missing the path-traversal check — was it removed?"
+    if command -v unzip >/dev/null 2>&1; then
+        # --- Build safe + crafted malicious zip archives with python ---
+        "$PY3" - "$TMPDIR" <<'PY'
+import sys, zipfile
+
+base = sys.argv[1]
+
+
+def make(name, entry):
+    with zipfile.ZipFile(f"{base}/{name}", "w") as z:
+        z.writestr(entry, "pwned")
+
+
+make("safe.zip", "rtk.exe")
+make("traversal.zip", "../etc/evil")
+make("absolute.zip", "/tmp/evil_abs")
+make("middle.zip", "rtk/../../../etc/evil")
+make("end_dotdot.zip", "rtk/..")
+PY
+
+        echo "==> Functional checks (zip)"
+
+        if check_archive "$TMPDIR/safe.zip"; then
+            pass "safe zip archive accepted"
+        else
+            fail "safe zip archive rejected (false positive)"
+        fi
+
+        for bad in traversal absolute middle end_dotdot; do
+            if check_archive "$TMPDIR/$bad.zip"; then
+                fail "$bad zip archive accepted (should be rejected)"
+            else
+                pass "$bad zip archive rejected"
+            fi
+        done
+    else
+        skip "zip archive traversal checks (unzip not available)"
+    fi
+
+    echo "==> Regression guard"
+
+    if grep -qF 'tar -tzf' "$INSTALL_SH" && grep -qF '\.\.' "$INSTALL_SH"; then
+        pass "install.sh still contains the tar.gz path-traversal check"
+    else
+        fail "install.sh is missing the tar.gz path-traversal check — was it removed?"
+    fi
+
+    if grep -qF 'unzip -Z1' "$INSTALL_SH"; then
+        pass "install.sh still contains the zip path-traversal check"
+    else
+        fail "install.sh is missing the zip path-traversal check — was it removed?"
+    fi
 fi
 
 echo ""
+echo "==> Regression guard: Windows support markers"
+
+check_marker() {
+    if grep -qF "$1" "$INSTALL_SH"; then
+        pass "install.sh still contains: $1"
+    else
+        fail "install.sh is missing: $1 — was Windows support removed?"
+    fi
+}
+
+check_marker 'MINGW*|MSYS*|CYGWIN*'
+check_marker 'x86_64-pc-windows-msvc'
+check_marker 'command -v unzip'
+
+echo ""
 if [ "$FAIL" -eq 0 ]; then
-    echo "All install.sh path traversal tests passed"
+    echo "All install.sh tests passed"
     exit 0
 else
     echo "Some tests failed"


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

Closes #1736.

- Adds support for using the `install.sh` script when on Git Bash. 
- Scans for Windows as OS 
  - Adds `.exe` to the binary name
  - Uses `.zip` instead of `.tar.gz`
    - Uses `unzip` command instead of `tar` command
- Updates README.md (all languages) and INSTALL.md 
- Builds out tests for install script using existing `test-install.sh` file
  - Doesn't add to CI pipeline, wasn't there before

## Test plan
<!-- How did you verify this works? -->

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected
- [x] Updated `test-install.sh` and ran manually 

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
