### PR TITLE
fix(deps): bump quick-xml/anyhow/crossbeam-epoch for RustSec advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "autocfg"
@@ -277,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -852,9 +852,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ sha2 = "0.10"
 ureq = "2"
 getrandom = "0.4"
 flate2 = "1.0"
-quick-xml = "0.37"
+quick-xml = "0.41"
 which = "8"
 automod = "1"
 

--- a/src/cmds/dotnet/dotnet_cmd.rs
+++ b/src/cmds/dotnet/dotnet_cmd.rs
@@ -618,7 +618,7 @@ fn scan_mtp_kind_in_file(path: &Path) -> MtpProjectKind {
                 );
             }
             Ok(Event::Text(e)) if inside_mtp_element => {
-                if let Ok(text) = e.unescape() {
+                if let Ok(text) = e.decode() {
                     if text.trim().eq_ignore_ascii_case("true") {
                         return MtpProjectKind::VsTestBridge;
                     }

--- a/src/cmds/dotnet/dotnet_trx.rs
+++ b/src/cmds/dotnet/dotnet_trx.rs
@@ -3,6 +3,7 @@
 use crate::binlog::{FailedTest, TestSummary};
 use chrono::{DateTime, FixedOffset};
 use quick_xml::events::{BytesStart, Event};
+use quick_xml::XmlVersion;
 use quick_xml::Reader;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
@@ -21,7 +22,7 @@ fn extract_attr_value(
             continue;
         }
 
-        if let Ok(value) = attr.decode_and_unescape_value(reader.decoder()) {
+        if let Ok(value) = attr.decoded_and_normalized_value(XmlVersion::default(), reader.decoder()) {
             return Some(value.into_owned());
         }
     }


### PR DESCRIPTION
Automated dependency bumps to address disclosed RustSec advisories found by [osv-scanner](https://google.github.io/osv-scanner/).

### Advisories
| Package | From → To | Advisory | Severity |
|---------|-----------|----------|----------|
| `quick-xml` | 0.37.5 → 0.41.0 | [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194.html), [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195.html) | High (DoS / mem exhaustion via untrusted XML) |
| `anyhow` | 1.0.102 → 1.0.103 | [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190.html) | Unsoundness in `Error::downcast_mut()` |
| `crossbeam-epoch` | 0.9.18 → 0.9.20 | [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204.html) | Invalid pointer deref in `fmt::Pointer` (transitive via `crossbeam-deque`) |

### Code changes
`quick-xml` 0.41 reworked text/attribute decoding. Two mechanical call-site updates (same approach as closed #2866):

- `src/cmds/dotnet/dotnet_cmd.rs`: `BytesText::unescape()` → `decode()`
- `src/cmds/dotnet/dotnet_trx.rs`: `Attribute::decode_and_unescape_value` → `decoded_and_normalized_value(XmlVersion::default(), …)`

### Prior art
- #2866 bumped to 0.41 with the same API migration but was closed without merging (author redirected to a personal fork). Advisories remain present on `develop`.
- #1742 (open) bumps only to 0.40.1, which does **not** clear RUSTSEC-2026-0194/0195 (fixed in 0.41.0). This PR supersedes that for the security fix.

### Verification
- Reproduced locally: yes
- Command: `osv-scanner scan source --recursive --no-ignore .` before → 4 vulns; after → 0
- Before: `quick-xml@0.37.5`, `anyhow@1.0.102`, `crossbeam-epoch@0.9.18` flagged
- After: `cargo build` clean; `cargo test -- cmds::dotnet` → 116 passed; osv-scanner → 0 remaining
- Environment: rustc stable, osv-scanner 2.5.1

No other code changes. Happy to adjust if you prefer splitting the bumps.