### PR TITLE
fix(agent): preserve env prefix before rtk

### DIFF
--- a/hooks/antigravity/rules.md
+++ b/hooks/antigravity/rules.md
@@ -4,7 +4,7 @@
 
 ## Rule
 
-Always prefix shell commands with `rtk` to minimize token consumption.
+Always prefix shell commands with `rtk` to minimize token consumption, except when using `env`: use `env X=Y rtk <command>` instead of `rtk env X=Y <command>`.
 
 Examples:
 

--- a/hooks/cline/rules.md
+++ b/hooks/cline/rules.md
@@ -4,7 +4,7 @@
 
 ## Rule
 
-Always prefix shell commands with `rtk` to minimize token consumption.
+Always prefix shell commands with `rtk` to minimize token consumption, except when using `env`: use `env X=Y rtk <command>` instead of `rtk env X=Y <command>`.
 
 Examples:
 

--- a/hooks/codex/rtk-awareness.md
+++ b/hooks/codex/rtk-awareness.md
@@ -4,7 +4,7 @@
 
 ## Rule
 
-Always prefix shell commands with `rtk`.
+Always prefix shell commands with `rtk`, except when using `env`: use `env X=Y rtk <command>` instead of `rtk env X=Y <command>`.
 
 Examples:
 

--- a/hooks/kilocode/rules.md
+++ b/hooks/kilocode/rules.md
@@ -4,7 +4,7 @@
 
 ## Rule
 
-Always prefix shell commands with `rtk` to minimize token consumption.
+Always prefix shell commands with `rtk` to minimize token consumption, except when using `env`: use `env X=Y rtk <command>` instead of `rtk env X=Y <command>`.
 
 Examples:
 

--- a/hooks/windsurf/rules.md
+++ b/hooks/windsurf/rules.md
@@ -4,7 +4,7 @@
 
 ## Rule
 
-Always prefix shell commands with `rtk` to minimize token consumption.
+Always prefix shell commands with `rtk` to minimize token consumption, except when using `env`: use `env X=Y rtk <command>` instead of `rtk env X=Y <command>`.
 
 Examples:
 

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -122,7 +122,7 @@ const RTK_INSTRUCTIONS: &str = r##"<!-- rtk-instructions v2 -->
 
 ## Golden Rule
 
-**Always prefix commands with `rtk`**. If RTK has a dedicated filter, it uses it. If not, it passes through unchanged. This means RTK is always safe to use.
+**Always prefix commands with `rtk`**, except when using `env`: use `env X=Y rtk <command>` instead of `rtk env X=Y <command>`. If RTK has a dedicated filter, it uses it. If not, it passes through unchanged. This means RTK is always safe to use.
 
 **Important**: Even in command chains with `&&`, use `rtk`:
 ```bash
@@ -4819,7 +4819,7 @@ const COPILOT_INSTRUCTIONS: &str = r#"<!-- rtk-instructions v2 -->
 
 ## Rule
 
-Always prefix shell commands with `rtk`:
+Always prefix shell commands with `rtk`, except when using `env`: use `env X=Y rtk <command>` instead of `rtk env X=Y <command>`:
 
 ```bash
 # Instead of:              Use:


### PR DESCRIPTION
## Summary

The existing agent instructions say to always prefix commands with `rtk`, which leads agents to generate commands such as `rtk env X=Y cargo test`. In this order, RTK handles `env` as the command and the inner supported command does not go through its token-saving filter. RTK already passes its environment to the commands it dispatches, so the native form `env X=Y rtk cargo test` preserves the required environment while still allowing RTK to filter the inner command.

 - Clarify agent instructions for commands using environment prefixes: use `env X=Y rtk <command>` instead of `rtk env X=Y <command>`.
 - Preserve the native behavior of the system `env` command while ensuring the wrapped command still benefits from RTK output filtering and token savings.

Resolves: #1606

## Test plan

No new tests were added because this change only updates agent-facing wording, and the existing test suite does not assert the exact instructional copy.

 - [x] `cargo fmt --all --check && cargo clippy --all-targets && cargo test`
 - [x] Manually verified that `env X=Y rtk <command>` executes correctly.

