### PR TITLE
feat(zcode): add ZCode agent support with global agent instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ rtk init --agent kimi           # Kimi AI
 rtk init -g --agent pi          # Pi
 rtk init --agent hermes         # Hermes
 rtk init -g --agent droid       # Factory Droid
+rtk init -g --agent zcode       # ZCode Agent
 
 # 2. Restart your AI tool, then test
 git status  # Automatically rewritten to rtk git status
@@ -381,7 +382,7 @@ rtk init -g
 
 ## Supported AI Tools
 
-RTK supports 16 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents, reducing the bash output the agent reads where the agent supports command interception.
+RTK supports 17 AI coding tools. Each integration rewrites shell commands to `rtk` equivalents, reducing the bash output the agent reads where the agent supports command interception.
 
 | Tool | Install | Method |
 |------|---------|--------|
@@ -402,6 +403,7 @@ RTK supports 16 AI coding tools. Each integration rewrites shell commands to `rt
 | **Google Antigravity** | `rtk init --agent antigravity` | .agents/rules/antigravity-rtk-rules.md (project-scoped) |
 | **Kimi AI** | `rtk init --agent kimi` | AGENTS.md (project-scoped) |
 | **Factory Droid** | `rtk init -g --agent droid` (or per-project) | PreToolUse hook in `~/.factory/hooks.json` (matcher `Execute`) |
+| **ZCode Agent** | `rtk init -g --agent zcode` | User-level `~/.zcode/AGENTS.md` instructions |
 
 For per-agent setup details, override controls, and graceful degradation, see the [Supported Agents guide](https://www.rtk-ai.app/guide/getting-started/supported-agents). The Hermes plugin source and tests live in `hooks/hermes/`; installed Hermes runtime files still live under `~/.hermes/plugins/rtk-rewrite/`.
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -4,7 +4,7 @@
 
 **Deployed hook artifacts** — the actual files installed on user machines by `rtk init`. These are shell scripts, TypeScript plugins, and rules files that run outside the Rust binary. They are **thin delegates**: parse agent-specific JSON, call `rtk rewrite` as a subprocess, format agent-specific response. Zero filtering logic lives here.
 
-Owns: per-agent hook scripts and configuration files for 10 supported agents (Claude Code, Copilot, Cursor, Cline, Windsurf, Codex, OpenCode, Hermes, Pi, Mistral Vibe).
+Owns: per-agent hook scripts and configuration files for supported coding agents.
 
 Does **not** own: hook installation/uninstallation (that's `src/hooks/init.rs`), the rewrite pattern registry (that's `discover/registry`), or integrity verification (that's `src/hooks/integrity.rs`).
 
@@ -60,6 +60,7 @@ Each agent subdirectory has its own README with hook-specific details:
 | Pi | TypeScript extension (`tool_call` event) | In-place mutation | Yes |
 | Hermes | Python plugin (`pre_tool_call`) | In-place mutation | Yes |
 | Mistral Vibe | Rust binary (`rtk hook vibe`) | Transparent rewrite | Yes (`hook_specific_output.tool_input`) |
+| ZCode Agent | User-level `AGENTS.md` | Prompt-level guidance | N/A |
 
 ## JSON Formats by Agent
 

--- a/hooks/zcode/README.md
+++ b/hooks/zcode/README.md
@@ -1,0 +1,9 @@
+# ZCode Agent Integration
+
+> Part of [`hooks/`](../README.md) — see also [`src/hooks/`](../../src/hooks/README.md) for installation code.
+
+## Specifics
+
+- Prompt-level guidance only; ZCode reads user-level `AGENTS.md` at task start.
+- `rtk-awareness.md` tells ZCode Agent to prefix shell commands with `rtk`.
+- Installed to `~/.zcode/AGENTS.md` by `rtk init -g --agent zcode`.

--- a/hooks/zcode/rtk-awareness.md
+++ b/hooks/zcode/rtk-awareness.md
@@ -1,0 +1,30 @@
+<!-- rtk-instructions v1 -->
+# RTK - Rust Token Killer (ZCode Agent)
+
+Always prefix shell commands with `rtk` to minimize token consumption.
+
+Examples:
+
+```bash
+rtk git status
+rtk cargo test
+rtk ls src/
+rtk grep "pattern" src/
+rtk find "*.rs" .
+rtk docker ps
+rtk gh pr list
+```
+
+## Meta Commands
+
+```bash
+rtk gain              # Show token savings
+rtk gain --history    # Show command usage history
+rtk discover          # Find missed RTK opportunities
+rtk proxy <cmd>       # Run raw output for debugging
+```
+
+RTK filters and compresses command output before it reaches the agent context,
+saving 60-90% tokens on common development operations. Use `rtk <cmd>` instead
+of raw commands whenever possible.
+<!-- /rtk-instructions -->

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -32,6 +32,7 @@ LLM agent integration layer that installs, validates, and executes command-rewri
 | Cursor | `rtk init -g --agent cursor` | Cursor hook | hooks.json |
 | Pi | `rtk init --agent pi` | `.pi/extensions/rtk.ts` | -- |
 | Hermes | `rtk init --agent hermes` | Python plugin in `~/.hermes/plugins/rtk-rewrite/` | `config.yaml` `plugins.enabled` |
+| ZCode | `rtk init -g --agent zcode` | User-level RTK instructions | `~/.zcode/AGENTS.md` |
 
 
 ## Integrity Verification

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -25,6 +25,7 @@ pub const OPENCODE_PLUGIN_FILE: &str = "rtk.ts";
 pub const CURSOR_DIR: &str = ".cursor";
 pub const CODEX_DIR: &str = ".codex";
 pub const GEMINI_DIR: &str = ".gemini";
+pub const ZCODE_DIR: &str = ".zcode";
 
 pub const GITHUB_DIR: &str = ".github";
 pub const COPILOT_HOOK_FILE: &str = "rtk-rewrite.json";

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -20,6 +20,7 @@ use super::constants::{
     HOOKS_SUBDIR, PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR,
     PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON, VIBE_BASH_MATCH, VIBE_DIR,
     VIBE_HOOKS_FILE, VIBE_HOOK_COMMAND, VIBE_HOOK_NAME, VIBE_PROMPTS_SUBDIR, VIBE_PROMPT_FILE,
+    ZCODE_DIR,
 };
 use super::integrity;
 use super::is_claude_hook_command;
@@ -33,6 +34,7 @@ const PI_PLUGIN: &str = include_str!("../../hooks/pi/rtk.ts");
 // Embedded slim RTK awareness instructions
 const RTK_SLIM: &str = include_str!("../../hooks/claude/rtk-awareness.md");
 const RTK_SLIM_CODEX: &str = include_str!("../../hooks/codex/rtk-awareness.md");
+const ZCODE_INSTRUCTIONS: &str = include_str!("../../hooks/zcode/rtk-awareness.md");
 
 /// Template written by `rtk init` when no filters.toml exists yet.
 const FILTERS_TEMPLATE: &str = r#"# Project-local RTK filters — commit this file with your repo.
@@ -3365,6 +3367,102 @@ fn resolve_opencode_dir() -> Result<PathBuf> {
     resolve_home_subdir(CONFIG_DIR).map(|p| p.join(OPENCODE_SUBDIR))
 }
 
+// ─── ZCode Agent support ─────────────────────────────────────────────
+
+fn resolve_zcode_dir() -> Result<PathBuf> {
+    resolve_home_subdir(ZCODE_DIR)
+}
+
+/// Install RTK instructions into ZCode's user-level AGENTS.md.
+///
+/// ZCode loads this file for every task, whereas skills are selected explicitly.
+/// RTK therefore installs its always-on guidance at the user level.
+pub fn run_zcode_mode(ctx: InitContext) -> Result<()> {
+    let zcode_dir = resolve_zcode_dir()?;
+    run_zcode_mode_at(&zcode_dir, ctx)
+}
+
+fn run_zcode_mode_at(zcode_dir: &Path, ctx: InitContext) -> Result<()> {
+    let InitContext { dry_run, .. } = ctx;
+    let agents_path = zcode_dir.join(AGENTS_MD);
+    if !dry_run {
+        fs::create_dir_all(zcode_dir).with_context(|| {
+            format!(
+                "Failed to create ZCode config directory: {}",
+                zcode_dir.display()
+            )
+        })?;
+    }
+
+    write_rtk_block(
+        &agents_path,
+        ZCODE_INSTRUCTIONS,
+        "ZCode instructions",
+        "rtk init -g --agent zcode",
+        ctx,
+    )?;
+
+    if !dry_run {
+        println!("\nRTK configured for ZCode Agent.\n");
+        println!("  Instructions: {}", agents_path.display());
+        println!("  ZCode Agent will now use rtk commands for token savings.");
+        println!("  Restart ZCode. Test with: git status\n");
+    }
+
+    Ok(())
+}
+
+pub fn uninstall_zcode(ctx: InitContext) -> Result<()> {
+    let zcode_dir = resolve_zcode_dir()?;
+    uninstall_zcode_at(&zcode_dir, ctx)
+}
+
+fn uninstall_zcode_at(zcode_dir: &Path, ctx: InitContext) -> Result<()> {
+    let InitContext { verbose, dry_run } = ctx;
+    let agents_path = zcode_dir.join(AGENTS_MD);
+    if !agents_path.exists() {
+        if !dry_run {
+            println!("RTK ZCode instructions were not installed (nothing to remove)");
+        }
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(&agents_path).with_context(|| {
+        format!(
+            "Failed to read ZCode instructions: {}",
+            agents_path.display()
+        )
+    })?;
+    let (cleaned, removed) = remove_rtk_block(&content);
+    if !removed {
+        if !dry_run {
+            println!("RTK ZCode instructions were not installed (nothing to remove)");
+        }
+        return Ok(());
+    }
+
+    if dry_run {
+        println!(
+            "[dry-run] would remove RTK instructions from {}",
+            agents_path.display()
+        );
+        print_dry_run_footer();
+        return Ok(());
+    }
+
+    atomic_write(&agents_path, &cleaned).with_context(|| {
+        format!(
+            "Failed to write ZCode instructions: {}",
+            agents_path.display()
+        )
+    })?;
+    if verbose > 0 {
+        eprintln!("Removed RTK instructions from {}", agents_path.display());
+    }
+    println!("RTK uninstalled for ZCode Agent.");
+    Ok(())
+}
+
 // ─── Pi coding agent support ──────────────────────────────────────────
 
 /// Resolve Pi config directory, honouring `PI_CODING_AGENT_DIR` override.
@@ -5417,6 +5515,45 @@ mod tests {
         run_kimi_mode_at(temp.path(), InitContext::default()).unwrap();
         let second = fs::read_to_string(&path).unwrap();
         assert_eq!(first, second, "Idempotent: content should not change");
+    }
+
+    #[test]
+    fn test_zcode_mode_creates_global_instructions() {
+        let temp = TempDir::new().unwrap();
+        run_zcode_mode_at(temp.path(), InitContext::default()).unwrap();
+
+        let agents_path = temp.path().join(AGENTS_MD);
+        let content = fs::read_to_string(agents_path).unwrap();
+        assert!(content.contains(RTK_BLOCK_START));
+        assert!(content.contains("Always prefix shell commands with `rtk`"));
+    }
+
+    #[test]
+    fn test_zcode_mode_preserves_user_instructions_and_is_idempotent() {
+        let temp = TempDir::new().unwrap();
+        let agents_path = temp.path().join(AGENTS_MD);
+        fs::write(&agents_path, "# Team preferences\n\nPrefer cargo fmt.\n").unwrap();
+
+        run_zcode_mode_at(temp.path(), InitContext::default()).unwrap();
+        let first = fs::read_to_string(&agents_path).unwrap();
+        run_zcode_mode_at(temp.path(), InitContext::default()).unwrap();
+        let second = fs::read_to_string(&agents_path).unwrap();
+
+        assert!(first.contains("Prefer cargo fmt."));
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn test_zcode_uninstall_preserves_user_instructions() {
+        let temp = TempDir::new().unwrap();
+        let agents_path = temp.path().join(AGENTS_MD);
+        fs::write(&agents_path, "# Team preferences\n\nPrefer cargo fmt.\n").unwrap();
+        run_zcode_mode_at(temp.path(), InitContext::default()).unwrap();
+
+        uninstall_zcode_at(temp.path(), InitContext::default()).unwrap();
+        let content = fs::read_to_string(&agents_path).unwrap();
+        assert!(content.contains("Prefer cargo fmt."));
+        assert!(!content.contains(RTK_BLOCK_START));
     }
 
     #[test]

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -5557,6 +5557,94 @@ mod tests {
     }
 
     #[test]
+    fn test_zcode_mode_dry_run_does_not_write() {
+        let dry_run = InitContext {
+            dry_run: true,
+            ..InitContext::default()
+        };
+
+        let absent = TempDir::new().unwrap();
+        run_zcode_mode_at(absent.path(), dry_run).unwrap();
+        assert!(!absent.path().join(AGENTS_MD).exists());
+
+        let existing = TempDir::new().unwrap();
+        let agents_path = existing.path().join(AGENTS_MD);
+        fs::write(&agents_path, "# Team preferences\n\nPrefer cargo fmt.\n").unwrap();
+        run_zcode_mode_at(existing.path(), dry_run).unwrap();
+        let content = fs::read_to_string(&agents_path).unwrap();
+        assert_eq!(content, "# Team preferences\n\nPrefer cargo fmt.\n");
+    }
+
+    #[test]
+    fn test_zcode_uninstall_noop_when_file_missing() {
+        let temp = TempDir::new().unwrap();
+        uninstall_zcode_at(temp.path(), InitContext::default()).unwrap();
+        assert!(!temp.path().join(AGENTS_MD).exists());
+    }
+
+    #[test]
+    fn test_zcode_uninstall_noop_when_no_rtk_block() {
+        let temp = TempDir::new().unwrap();
+        let agents_path = temp.path().join(AGENTS_MD);
+        fs::write(&agents_path, "# Team preferences\n\nPrefer cargo fmt.\n").unwrap();
+
+        uninstall_zcode_at(temp.path(), InitContext::default()).unwrap();
+        let content = fs::read_to_string(&agents_path).unwrap();
+        assert_eq!(content, "# Team preferences\n\nPrefer cargo fmt.\n");
+    }
+
+    #[test]
+    fn test_zcode_uninstall_dry_run_keeps_block() {
+        let temp = TempDir::new().unwrap();
+        let agents_path = temp.path().join(AGENTS_MD);
+        run_zcode_mode_at(temp.path(), InitContext::default()).unwrap();
+        let before = fs::read_to_string(&agents_path).unwrap();
+
+        let dry_run = InitContext {
+            dry_run: true,
+            ..InitContext::default()
+        };
+        uninstall_zcode_at(temp.path(), dry_run).unwrap();
+
+        let after = fs::read_to_string(&agents_path).unwrap();
+        assert_eq!(before, after, "Dry-run uninstall must not modify the file");
+    }
+
+    #[test]
+    fn test_zcode_reinstall_after_uninstall_restores_block() {
+        let temp = TempDir::new().unwrap();
+        let agents_path = temp.path().join(AGENTS_MD);
+        fs::write(&agents_path, "# Team preferences\n\nPrefer cargo fmt.\n").unwrap();
+
+        run_zcode_mode_at(temp.path(), InitContext::default()).unwrap();
+        let first = fs::read_to_string(&agents_path).unwrap();
+
+        uninstall_zcode_at(temp.path(), InitContext::default()).unwrap();
+        run_zcode_mode_at(temp.path(), InitContext::default()).unwrap();
+        let second = fs::read_to_string(&agents_path).unwrap();
+
+        assert!(first.contains("Prefer cargo fmt."));
+        assert_eq!(
+            first, second,
+            "Reinstall should restore the identical block"
+        );
+    }
+
+    #[test]
+    fn test_zcode_instructions_match_embedded_payload() {
+        let temp = TempDir::new().unwrap();
+        run_zcode_mode_at(temp.path(), InitContext::default()).unwrap();
+        let content = fs::read_to_string(temp.path().join(AGENTS_MD)).unwrap();
+
+        assert!(content.contains(RTK_BLOCK_START));
+        assert!(content.contains(RTK_BLOCK_END));
+        assert!(content.contains(ZCODE_INSTRUCTIONS.trim()));
+        for meta in ["rtk gain", "rtk discover", "rtk proxy"] {
+            assert!(content.contains(meta), "instructions must mention `{meta}`");
+        }
+    }
+
+    #[test]
     fn test_patch_agents_md_creates_missing_file() {
         let temp = TempDir::new().unwrap();
         let agents_md = temp.path().join("AGENTS.md");

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,8 @@ pub enum AgentTarget {
     Antigravity,
     /// Kimi AI
     Kimi,
+    /// ZCode Agent
+    Zcode,
     /// Pi coding agent
     Pi,
     /// Hermes CLI
@@ -2026,6 +2028,13 @@ fn run_cli() -> Result<i32> {
                 } else {
                     hooks::init::uninstall_copilot(ctx)?;
                 }
+            } else if uninstall && agent == Some(AgentTarget::Zcode) {
+                if !global {
+                    anyhow::bail!(
+                        "ZCode instructions are user-scoped. Use: rtk init -g --agent zcode"
+                    );
+                }
+                hooks::init::uninstall_zcode(ctx)?;
             } else if uninstall {
                 uninstall_init_dispatch(
                     agent,
@@ -2053,6 +2062,13 @@ fn run_cli() -> Result<i32> {
                 }
             } else if agent == Some(AgentTarget::Pi) {
                 hooks::init::run_pi_mode(global, ctx)?
+            } else if agent == Some(AgentTarget::Zcode) {
+                if !global {
+                    anyhow::bail!(
+                        "ZCode instructions are user-scoped. Use: rtk init -g --agent zcode"
+                    );
+                }
+                hooks::init::run_zcode_mode(ctx)?;
             } else if agent == Some(AgentTarget::Kilocode) {
                 if global {
                     anyhow::bail!("Kilo Code is project-scoped. Use: rtk init --agent kilocode");
@@ -2934,6 +2950,18 @@ mod tests {
         match cli.command {
             Commands::Init { agent, .. } => {
                 assert_eq!(agent, Some(AgentTarget::Hermes));
+            }
+            _ => panic!("Expected Init command"),
+        }
+    }
+
+    #[test]
+    fn test_try_parse_init_agent_zcode() {
+        let cli = Cli::try_parse_from(["rtk", "init", "--agent", "zcode", "--global"]).unwrap();
+        match cli.command {
+            Commands::Init { agent, global, .. } => {
+                assert_eq!(agent, Some(AgentTarget::Zcode));
+                assert!(global);
             }
             _ => panic!("Expected Init command"),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2968,6 +2968,26 @@ mod tests {
     }
 
     #[test]
+    fn test_try_parse_init_agent_zcode_uninstall() {
+        let cli =
+            Cli::try_parse_from(["rtk", "init", "--uninstall", "--agent", "zcode", "--global"])
+                .unwrap();
+        match cli.command {
+            Commands::Init {
+                agent,
+                global,
+                uninstall,
+                ..
+            } => {
+                assert_eq!(agent, Some(AgentTarget::Zcode));
+                assert!(global);
+                assert!(uninstall);
+            }
+            _ => panic!("Expected Init command"),
+        }
+    }
+
+    #[test]
     fn test_try_parse_kubectl_get_alias() {
         let cli = Cli::try_parse_from(["rtk", "kubectl", "get", "pods", "-n", "default"]).unwrap();
 


### PR DESCRIPTION
## Summary

Closes #2898, #2946
- Adds rtk init -g --agent zcode: installs an always-on RTK instructions block into the user-level ~/.zcode/AGENTS.md (marker-delimited, preserves existing user/team content, idempotent)
- Adds uninstall (rtk init --uninstall -g --agent zcode) removing only the RTK block; ZCode is strictly user-scoped (non-global invocation bails with guidance)
- Documents the integration in the READMEs and agent hooks docs

## Test plan
Installed and used extensively for a week without encountering any issues. It worked better than Claude Code.

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [x] Manual testing: `rtk <command>` output inspected
