### PR TITLE
feat(filter): add scientific and system command filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,15 @@ rtk pulumi refresh              # Drift summary
 rtk pulumi stack                # Stack metadata (strips owner/timestamps)
 ```
 
+### System & Documents
+```bash
+rtk systemctl --user status app.service  # Compact service status
+rtk systemctl --user list-units --failed # Compact unit listings
+rtk journalctl -u app.service -n 200      # Bounded, deduplicated journal output
+rtk pandoc input.md -o output.pdf         # Warnings and errors without progress noise
+rtk pdfinfo document.pdf                  # Essential PDF metadata
+```
+
 ### Data & Analytics
 ```bash
 rtk json config.json            # Structure without values

--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -1405,6 +1405,45 @@ make[1]: Leaving directory '/home/user/project/docs'
         );
     }
 
+    #[test]
+    fn test_new_toml_filters_save_at_least_20pct() {
+        let filters = make_filters(BUILTIN_TOML);
+        let cases = [
+            (
+                "journalctl --user -u app.service",
+                "Hint: You are currently not seeing messages from other users and the system.\n      Users in groups 'adm', 'systemd-journal' can see all messages.\n      Pass -q to turn off this notice.\n\nAug 26 10:00:00 host app[123]: started\nAug 26 10:00:01 host app[123]: ready\n",
+            ),
+            (
+                "systemctl --user list-units --failed",
+                "  UNIT          LOAD   ACTIVE SUB    DESCRIPTION\n  app.service   loaded failed failed Application\n\nLOAD   = Reflects whether the unit definition was properly loaded.\nACTIVE = The high-level unit activation state.\nSUB    = The low-level unit activation state.\n1 loaded units listed.\n",
+            ),
+            (
+                "pandoc --verbose input.md -o output.pdf",
+                "[INFO] Loaded input.md\n[INFO] Running filter citeproc\n[WARNING] Could not fetch resource image.png\n[INFO] Writing output output.pdf\n[INFO] Completed successfully\n",
+            ),
+            (
+                "pdfinfo manuscript.pdf",
+                "Title: Thesis chapter\nAuthor: Miko\nCustom Metadata: no\nMetadata Stream: yes\nTagged: yes\nUserProperties: no\nSuspects: no\nForm: none\nJavaScript: no\nPages: 42\nEncrypted: no\nPage size: 595.28 x 841.89 pts (A4)\nPage rot: 0\nFile size: 123456 bytes\nOptimized: yes\nPDF version: 1.7\n",
+            ),
+        ];
+
+        for (command, input) in cases {
+            let filter = find_filter_in(command, &filters).expect("new built-in filter");
+            let output = apply_filter(filter, input);
+            let input_words = input.split_whitespace().count();
+            let output_words = output.split_whitespace().count();
+            let savings = 100.0 - (output_words as f64 / input_words as f64 * 100.0);
+            assert!(
+                savings >= 20.0,
+                "{} filter: expected >=20% savings, got {:.1}% (in={} out={})",
+                filter.name,
+                savings,
+                input_words,
+                output_words
+            );
+        }
+    }
+
     // --- Edge cases ---
 
     #[test]
@@ -1844,10 +1883,13 @@ match_command = "^make\\b"
             "hadolint",
             "helm",
             "iptables",
+            "journalctl",
             "liquibase",
             "make",
             "markdownlint",
             "mix-compile",
+            "pandoc",
+            "pdfinfo",
             "mix-format",
             "ping",
             "pio-run",
@@ -1860,6 +1902,7 @@ match_command = "^make\\b"
             "pulumi-stack",
             "pulumi-up",
             "quarto-render",
+            "systemctl-list",
             "rsync",
             "shellcheck",
             "shopify-theme",
@@ -1892,8 +1935,8 @@ match_command = "^make\\b"
         let filters = make_filters(BUILTIN_TOML);
         assert_eq!(
             filters.len(),
-            63,
-            "Expected exactly 63 built-in filters, got {}. \
+            67,
+            "Expected exactly 67 built-in filters, got {}. \
              Update this count when adding/removing filters in src/filters/.",
             filters.len()
         );
@@ -1950,11 +1993,11 @@ expected = "output line 1\noutput line 2"
         let combined = format!("{}\n\n{}", BUILTIN_TOML, new_filter);
         let filters = make_filters(&combined);
 
-        // All 63 existing filters still present + 1 new = 64
+        // All 67 existing filters still present + 1 new = 68
         assert_eq!(
             filters.len(),
-            64,
-            "Expected 64 filters after concat (63 built-in + 1 new)"
+            68,
+            "Expected 68 filters after concat (67 built-in + 1 new)"
         );
 
         // New filter is discoverable

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -2400,6 +2400,33 @@ mod tests {
             Some("rtk just build".into())
         );
     }
+    #[test]
+    fn test_rewrite_scientific_and_system_toml_filters() {
+        for (raw, rewritten) in [
+            (
+                "journalctl --user -u litellm-proxy.service -n 200",
+                "rtk journalctl --user -u litellm-proxy.service -n 200",
+            ),
+            (
+                "systemctl --user list-units --failed",
+                "rtk systemctl --user list-units --failed",
+            ),
+            (
+                "systemctl --user status litellm-proxy.service",
+                "rtk systemctl --user status litellm-proxy.service",
+            ),
+            (
+                "pandoc manuscript.md -o manuscript.pdf",
+                "rtk pandoc manuscript.md -o manuscript.pdf",
+            ),
+            ("pdfinfo manuscript.pdf", "rtk pdfinfo manuscript.pdf"),
+        ] {
+            assert_eq!(
+                rewrite_command_no_prefixes(raw, &[]),
+                Some(rewritten.into())
+            );
+        }
+    }
 
     #[test]
     fn test_rewrite_toml_absolute_path() {

--- a/src/filters/journalctl.toml
+++ b/src/filters/journalctl.toml
@@ -1,0 +1,32 @@
+[filters.journalctl]
+description = "Compact journalctl output — strip boilerplate and bound long log lines"
+match_command = "^journalctl\\b"
+strip_ansi = true
+filter_stderr = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^-- No entries --$",
+  "^Hint: You are currently not seeing messages from other users and the system\\.$",
+  "^\\s+Users in groups 'adm', 'systemd-journal' can see all messages\\.$",
+  "^\\s+Pass -q to turn off this notice\\.$",
+]
+truncate_lines_at = 500
+max_lines = 120
+on_empty = "-- No entries --"
+
+[[tests.journalctl]]
+name = "permission hint and blank lines are stripped"
+input = """
+Hint: You are currently not seeing messages from other users and the system.
+      Users in groups 'adm', 'systemd-journal' can see all messages.
+      Pass -q to turn off this notice.
+
+Aug 26 10:00:00 host service[123]: started
+Aug 26 10:00:01 host service[123]: ready
+"""
+expected = "Aug 26 10:00:00 host service[123]: started\nAug 26 10:00:01 host service[123]: ready"
+
+[[tests.journalctl]]
+name = "no entries remains explicit"
+input = "-- No entries --\n"
+expected = "-- No entries --"

--- a/src/filters/pandoc.toml
+++ b/src/filters/pandoc.toml
@@ -1,0 +1,35 @@
+[filters.pandoc]
+description = "Compact Pandoc diagnostics — strip progress noise while preserving warnings and errors"
+match_command = "^pandoc\\b"
+strip_ansi = true
+filter_stderr = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^\\[INFO\\] Loaded ",
+  "^\\[INFO\\] Running filter ",
+  "^\\[INFO\\] Writing output ",
+  "^\\[INFO\\] Completed successfully",
+]
+truncate_lines_at = 500
+max_lines = 80
+on_empty = "pandoc: ok"
+
+[[tests.pandoc]]
+name = "informational progress is stripped but warnings survive"
+input = """
+[INFO] Loaded input.md
+[INFO] Running filter citeproc
+[WARNING] Could not fetch resource image.png
+[INFO] Writing output output.pdf
+"""
+expected = "[WARNING] Could not fetch resource image.png"
+
+[[tests.pandoc]]
+name = "quiet success becomes concise confirmation"
+input = ""
+expected = "pandoc: ok"
+
+[[tests.pandoc]]
+name = "errors remain visible"
+input = "pandoc: input.md: openBinaryFile: does not exist\n"
+expected = "pandoc: input.md: openBinaryFile: does not exist"

--- a/src/filters/pdfinfo.toml
+++ b/src/filters/pdfinfo.toml
@@ -1,0 +1,39 @@
+[filters.pdfinfo]
+description = "Compact pdfinfo metadata — keep document identity and rendering-relevant fields"
+match_command = "^pdfinfo\\b"
+strip_ansi = true
+keep_lines_matching = [
+  "^(Title|Subject|Keywords|Author|Creator|Producer|CreationDate|ModDate|Tagged|Form|Pages|Encrypted|Page size|File size|PDF version):",
+  "^Syntax (Error|Warning):",
+  "^I/O Error:",
+]
+truncate_lines_at = 300
+max_lines = 40
+on_empty = "pdfinfo: no metadata"
+
+[[tests.pdfinfo]]
+name = "technical noise is dropped while useful metadata remains"
+input = """
+Title:           Thesis chapter
+Author:          Miko
+Custom Metadata: no
+Metadata Stream: yes
+Tagged:          yes
+UserProperties:  no
+Suspects:        no
+Form:            none
+JavaScript:      no
+Pages:           42
+Encrypted:       no
+Page size:       595.28 x 841.89 pts (A4)
+Page rot:        0
+File size:       123456 bytes
+Optimized:       yes
+PDF version:     1.7
+"""
+expected = "Title:           Thesis chapter\nAuthor:          Miko\nTagged:          yes\nForm:            none\nPages:           42\nEncrypted:       no\nPage size:       595.28 x 841.89 pts (A4)\nFile size:       123456 bytes\nPDF version:     1.7"
+
+[[tests.pdfinfo]]
+name = "errors remain visible"
+input = "I/O Error: Couldn't open file 'missing.pdf': No such file or directory.\n"
+expected = "I/O Error: Couldn't open file 'missing.pdf': No such file or directory."

--- a/src/filters/systemctl-list.toml
+++ b/src/filters/systemctl-list.toml
@@ -1,0 +1,32 @@
+[filters.systemctl-list]
+description = "Compact systemctl listings — strip legends and bound large unit tables"
+match_command = "^systemctl(?:\\s+--(?:user|system|global|no-pager|plain|full|all))*\\s+(?:list-units|list-unit-files|list-timers|list-sockets|list-jobs)\\b"
+strip_ansi = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^\\s*(?:LOAD|ACTIVE|SUB)\\s+(?:=|→)",
+  "^\\s*(?:LEGEND:|Legend:)",
+  "^\\s*To show all installed unit files use ",
+]
+truncate_lines_at = 240
+max_lines = 80
+on_empty = "0 units listed."
+
+[[tests.systemctl-list]]
+name = "unit rows remain while legend is stripped"
+input = """
+  UNIT                 LOAD   ACTIVE SUB     DESCRIPTION
+  dbus.service         loaded active running D-Bus System Message Bus
+  ssh.service          loaded failed failed  OpenBSD Secure Shell server
+
+LOAD   = Reflects whether the unit definition was properly loaded.
+ACTIVE = The high-level unit activation state.
+SUB    = The low-level unit activation state.
+2 loaded units listed.
+"""
+expected = "  UNIT                 LOAD   ACTIVE SUB     DESCRIPTION\n  dbus.service         loaded active running D-Bus System Message Bus\n  ssh.service          loaded failed failed  OpenBSD Secure Shell server\n2 loaded units listed."
+
+[[tests.systemctl-list]]
+name = "empty listing reports zero units"
+input = ""
+expected = "0 units listed."

--- a/src/filters/systemctl-status.toml
+++ b/src/filters/systemctl-status.toml
@@ -1,6 +1,6 @@
 [filters.systemctl-status]
 description = "Compact systemctl status output — strip blank lines, limit to 20 lines"
-match_command = "^systemctl\\s+status\\b"
+match_command = "^systemctl(?:\\s+--(?:user|system|global|no-pager|plain|full|all))*\\s+status\\b"
 strip_ansi = true
 strip_lines_matching = [
   "^\\s*$",


### PR DESCRIPTION
## Summary

- add built-in TOML filters for `journalctl`, `systemctl list-*`, `pandoc`, and `pdfinfo`
- support global `systemctl` flags before `status`, including `--user`
- add hook rewrite, inline filter, savings-threshold, and registry coverage plus README examples

## Test plan

- [x] `cargo fmt --all --check && cargo clippy --all-targets && cargo test`
- [x] Manual testing: inspected `rtk journalctl --user -u litellm-proxy.service -n 5 --no-pager`
- [x] Manual testing: inspected `rtk systemctl --user list-units --failed --no-pager`
- [x] Installed build passed `rtk verify --require-all` (163/163 inline filters)

## Output reduction

The added regression test requires at least 20% word-count reduction for every new filter, matching the repository contribution floor.