### PR TITLE
fix(gain): show why a command fell back, not just that it did

### DIFF
--- a/src/analytics/gain.rs
+++ b/src/analytics/gain.rs
@@ -1,7 +1,7 @@
 //! Shows users how many tokens RTK has saved them over time.
 
 use crate::core::display_helpers::{format_duration, print_period_table};
-use crate::core::tracking::{DayStats, MonthStats, Tracker, WeekStats};
+use crate::core::tracking::{parse_error_reason, DayStats, MonthStats, Tracker, WeekStats};
 use crate::core::utils::{format_tokens, truncate};
 use crate::hooks::hook_check;
 use anyhow::{Context, Result};
@@ -721,6 +721,19 @@ fn show_failures(tracker: &Tracker) -> Result<()> {
         println!();
     }
 
+    // ISSUE #3625: the command that fell back was already here; the reason it
+    // fell back was recorded and then dropped, so reading this screen you could
+    // only guess at the cause. Show the reason, and lead with the reasons, since
+    // a thousand fallbacks are usually a handful of causes.
+    if !summary.top_errors.is_empty() {
+        println!("{}", styled("Top Reasons (by frequency)", true));
+        println!("{}", "─".repeat(60));
+        for (reason, count) in &summary.top_errors {
+            println!("  {:>4}x  {}", count, truncate(reason, 50));
+        }
+        println!();
+    }
+
     if !summary.recent.is_empty() {
         println!("{}", styled("Recent Failures (last 10)", true));
         println!("{}", "─".repeat(60));
@@ -730,7 +743,9 @@ fn show_failures(tracker: &Tracker) -> Result<()> {
             let ts_short = &rec.timestamp[..rec.timestamp.floor_char_boundary(16)];
             let status = if rec.fallback_succeeded { "ok" } else { "FAIL" };
             let cmd_display = truncate(&rec.raw_command, 40);
+            let reason = truncate(&parse_error_reason(&rec.error_message), 40);
             println!("  {} [{}] {}", ts_short, status, cmd_display);
+            println!("  {:>18}└─ {}", "", reason);
         }
         println!();
     }

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -530,6 +530,26 @@ impl Tracker {
             })?
             .collect::<Result<Vec<_>, _>>()?;
 
+        // Reasons, folded to their first line. Grouping in SQL would keep the
+        // usage block, so the same cause would appear once per command shape.
+        let mut stmt = self.conn.prepare(
+            "SELECT error_message, COUNT(*) as cnt FROM parse_failures GROUP BY error_message",
+        )?;
+        let mut reason_counts: std::collections::HashMap<String, usize> =
+            std::collections::HashMap::new();
+        for row in stmt.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)? as usize))
+        })? {
+            let (message, count) = row?;
+            *reason_counts
+                .entry(parse_error_reason(&message))
+                .or_insert(0) += count;
+        }
+        let mut top_errors: Vec<(String, usize)> = reason_counts.into_iter().collect();
+        // Count first, then reason, so equal counts keep a stable order.
+        top_errors.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        top_errors.truncate(10);
+
         // Recent 10
         let mut stmt = self.conn.prepare(
             "SELECT timestamp, raw_command, error_message, fallback_succeeded
@@ -552,6 +572,7 @@ impl Tracker {
             total: total as usize,
             recovery_rate,
             top_commands,
+            top_errors,
             recent,
         })
     }
@@ -1276,7 +1297,6 @@ pub(crate) fn get_db_path() -> Result<PathBuf> {
 pub struct ParseFailureRecord {
     pub timestamp: String,
     pub raw_command: String,
-    #[allow(dead_code)]
     pub error_message: String,
     pub fallback_succeeded: bool,
 }
@@ -1287,7 +1307,24 @@ pub struct ParseFailureSummary {
     pub total: usize,
     pub recovery_rate: f64,
     pub top_commands: Vec<(String, usize)>,
+    /// Distinct fallback reasons, most frequent first. A thousand rows of
+    /// "it fell back" collapse into the handful of causes behind them.
+    pub top_errors: Vec<(String, usize)>,
     pub recent: Vec<ParseFailureRecord>,
+}
+
+/// One-line form of a recorded parse error.
+///
+/// Clap errors carry a usage block and a "try --help" footer under the first
+/// line, so grouping on the raw text would split one cause into as many rows as
+/// there are commands. The first non-empty line is the cause.
+pub fn parse_error_reason(error_message: &str) -> String {
+    error_message
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(|line| line.trim_start_matches("error: ").to_string())
+        .unwrap_or_else(|| "no reason recorded".to_string())
 }
 
 /// Record a parse failure without ever crashing.
@@ -1681,6 +1718,61 @@ mod tests {
         // We can't assert exact rate because other tests may have added records,
         // but we can verify recovery_rate is between 0 and 100
         assert!(summary.recovery_rate >= 0.0 && summary.recovery_rate <= 100.0);
+    }
+
+    // 14. the reason a command fell back survives to the summary
+    #[test]
+    fn test_parse_error_reason_is_the_first_line_without_the_error_prefix() {
+        let clap_error = "error: unexpected argument '-oE' found\n\nUsage: rtk grep [OPTIONS]\n\nFor more information, try '--help'.";
+        assert_eq!(
+            parse_error_reason(clap_error),
+            "unexpected argument '-oE' found"
+        );
+        assert_eq!(parse_error_reason("\n\n  boom  \n"), "boom");
+        assert_eq!(parse_error_reason(""), "no reason recorded");
+        assert_eq!(parse_error_reason("   \n \n"), "no reason recorded");
+    }
+
+    #[test]
+    fn test_top_errors_group_one_cause_across_different_commands() {
+        let tracker = Tracker::new_in_memory().expect("Failed to create in-memory tracker");
+
+        // Same cause, different usage blocks: clap prints the offending command
+        // under the first line, so the raw messages differ.
+        tracker
+            .record_parse_failure(
+                "grep -oE (a|b) one.txt",
+                "error: unexpected argument '-oE' found\n\nUsage: rtk grep one.txt",
+                true,
+            )
+            .unwrap();
+        tracker
+            .record_parse_failure(
+                "grep -oE [A-Z]+ two.txt",
+                "error: unexpected argument '-oE' found\n\nUsage: rtk grep two.txt",
+                true,
+            )
+            .unwrap();
+        tracker
+            .record_parse_failure(
+                "poetry install",
+                "error: unrecognized subcommand 'poetry'",
+                true,
+            )
+            .unwrap();
+
+        let summary = tracker.get_parse_failure_summary().unwrap();
+
+        assert_eq!(
+            summary.top_errors,
+            vec![
+                ("unexpected argument '-oE' found".to_string(), 2),
+                ("unrecognized subcommand 'poetry'".to_string(), 1),
+            ],
+            "two commands sharing one cause must collapse into one reason"
+        );
+        // Grouping by command alone cannot say this: three commands, two causes.
+        assert_eq!(summary.top_commands.len(), 3);
     }
 
     #[test]


### PR DESCRIPTION
Closes nothing on its own, but it is the thing that would have answered #3625 in one screen.

### What is missing today

`rtk gain -F` records the parse error and then drops it. `ParseFailureRecord.error_message` is read out of SQLite and carries `#[allow(dead_code)]` on it — the reason is collected, stored, and never shown. So the screen can say a command fell back, but never which cause did it, and on #3625 that left 1204 rows of "it fell back" with nothing to group them by. The reporter had to guess at the cause from the command text, and guessed at metacharacter escaping.

### What this adds

Two read-only views over data already in the table:

```
Top Reasons (by frequency)
────────────────────────────────────────────────────────────
     2x  unrecognized subcommand 'poetry'
     1x  invalid value 'notanumber' for '--max-len <MAX_...
     1x  unrecognized subcommand 'nosuchcmd'

Recent Failures (last 10)
────────────────────────────────────────────────────────────
  2026-08-26T10:21 [FAIL] poetry lock
                    └─ unrecognized subcommand 'poetry'
  2026-08-26T10:21 [ok] grep --max-len=notanumber x README.md
                    └─ invalid value 'notanumber' for '--max...
```

That output is real, from a scratch DB via `RTK_DB_PATH`, not a mock-up.

Reasons fold to their first line before grouping. Clap prints the offending command in the usage block underneath, so grouping the raw text would split a single cause into as many rows as there are command shapes — which is exactly the failure mode this screen is meant to cure. The `error: ` prefix is stripped so the column stays readable, and an empty message reads `no reason recorded` rather than a blank row.

### Verification

- `cargo test`: **2626 passed, 1 failed**. The one failure is `core::tracking::tests::test_timed_execution_records_time`, on `assertion failed: recent.iter().any(|r| r.rtk_cmd == "rtk test")`. It uses the shared on-disk tracker, so under a parallel run other tests push its row out of the last-N window. It passes in isolation both on this branch and with my changes stashed, so it is pre-existing flakiness rather than something this PR introduced. Happy to send a separate PR pinning that test to an in-memory tracker if you want it.
- `cargo fmt --all -- --check` and `cargo clippy --all-targets` are clean.
- Mutation-checked rather than trusted green: grouping on the raw message instead of the first line turns the grouping test red (`left: [("error: unexpected argument '-oE' found\n\nUsage: rtk grep one.txt", 1), ...]`), and dropping the empty-message branch turns the reason test red. A test that has never been seen red is not a test.

### Limitations I should state

- Linux, Rust stable. I did not run the macOS or Windows paths.
- `Top Reasons` groups all history, not a time window, matching how `Top Commands` above it already behaves.
- The reason column is truncated to 50/40 chars like its neighbours, so a very long clap message is cut. The full text is still in the DB for anyone querying it directly.