### PR TITLE
fix(hook): honor exclusions for tail line ranges

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -996,6 +996,10 @@ fn rewrite_segment_inner(
     if context == RewriteContext::Normal
         && (cmd_part.starts_with("head -") || cmd_part.starts_with("tail "))
     {
+        let normalized = strip_absolute_path(cmd_part.trim());
+        if is_excluded(&normalized, excluded) {
+            return None;
+        }
         return rewrite_line_range(cmd_part).map(|r| format!("{}{}", r, redirect_suffix));
     }
 
@@ -3951,6 +3955,24 @@ mod tests {
         assert_eq!(
             rewrite_command_no_prefixes("git status", &excluded),
             Some("rtk git status".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_excludes_tail_line_range_special_case() {
+        let excluded = vec!["tail".to_string()];
+        assert_eq!(
+            rewrite_command_no_prefixes("tail -n 400 /var/log/foo.log", &excluded),
+            None
+        );
+    }
+
+    #[test]
+    fn test_rewrite_excludes_tail_line_range_with_regex() {
+        let excluded = vec!["^tail -n".to_string()];
+        assert_eq!(
+            rewrite_command_no_prefixes("tail -n 400 /var/log/foo.log", &excluded),
+            None
         );
     }
 


### PR DESCRIPTION
## Summary

- honor `hooks.exclude_commands` before the special `head`/`tail` line-range rewrite
- add literal and regex regression coverage for the `tail -n` escape hatch
- address the configuration bypass reported in #3107 without expanding this PR into the separate streaming/memory work

## Test plan

- [x] `cargo fmt --all --check && cargo clippy --all-targets && cargo test`
- [x] Manual testing: an isolated config with `tail` or `^tail -n` leaves `tail -n 400 /var/log/foo.log` unchanged; without an exclusion it still rewrites to `rtk read /var/log/foo.log --tail-lines 400`

Security note: this changes Tier 1 rewrite logic in `src/discover/registry.rs`; the diff received isolated full-suite testing and an independent senior security/quality review before publication.

---
Restored after an accidental fork deletion. Same commits as #3109.