### PR TITLE
fix(discover): route npm lifecycle commands

### DIFF
--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -4621,6 +4621,23 @@ mod tests {
     }
 
     #[test]
+    fn test_rewrite_npm_lifecycle_commands() {
+        assert_eq!(
+            rewrite_command_no_prefixes("npm test", &[]),
+            Some("rtk npm test".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("npm install --ignore-scripts", &[]),
+            Some("rtk npm install --ignore-scripts".into())
+        );
+    }
+
+    #[test]
+    fn test_rewrite_npm_does_not_match_unknown_subcommands() {
+        assert_eq!(rewrite_command_no_prefixes("npm publish", &[]), None);
+    }
+
+    #[test]
     fn test_all_rules_are_complete() {
         for rule in RULES {
             assert!(

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -87,7 +87,7 @@ pub const RULES: &[RtkRule] = &[
         ..RtkRule::DEFAULT
     },
     RtkRule {
-        pattern: r"^npm\s+(exec|run|run-script|rum|urn|x)(\s|$)",
+        pattern: r"^npm\s+(exec|run|run-script|rum|urn|x|install|i|ci|test|audit|outdated|ls|list)(\s|$)",
         rtk_cmd: "rtk npm",
         rewrite_prefixes: &["npm"],
         category: "PackageManager",


### PR DESCRIPTION
## Summary / Problem

Closes #3671. The discover hook routed `npm run` and `npm exec`, but skipped npm lifecycle commands such as `npm test` and `npm install`, so those commands missed RTK's output filtering.

## Changes

- Route npm lifecycle subcommands supported by the existing npm filter, including `install`, `ci`, `test`, `audit`, `outdated`, `ls`, and `list`.
- Add regression coverage for lifecycle commands and for leaving unknown commands such as `npm publish` untouched.

## Tests

- `cargo test discover::registry::tests::test_rewrite_npm -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`

All checks passed. The full test suite was not run because this is a focused regex and routing change.

## Compatibility / Known limitations

The existing npm command filter and all previously supported npm aliases remain unchanged. This only expands discover-time routing to the lifecycle subcommands listed above.

Issue: #3671
