### PR TITLE
feat(hooks): add omp (Oh My Pi) agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ rtk init --agent kilocode       # Kilo Code
 rtk init --agent antigravity    # Google Antigravity
 rtk init --agent kimi           # Kimi AI
 rtk init -g --agent pi          # Pi
+rtk init -g --agent omp         # Oh My Pi (omp)
 rtk init --agent hermes         # Hermes
 rtk init -g --agent droid       # Factory Droid
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -4,7 +4,7 @@
 
 **Deployed hook artifacts** — the actual files installed on user machines by `rtk init`. These are shell scripts, TypeScript plugins, and rules files that run outside the Rust binary. They are **thin delegates**: parse agent-specific JSON, call `rtk rewrite` as a subprocess, format agent-specific response. Zero filtering logic lives here.
 
-Owns: per-agent hook scripts and configuration files for 10 supported agents (Claude Code, Copilot, Cursor, Cline, Windsurf, Codex, OpenCode, Hermes, Pi, Mistral Vibe).
+Owns: per-agent hook scripts and configuration files for 11 supported agents (Claude Code, Copilot, Cursor, Cline, Windsurf, Codex, OpenCode, Hermes, Pi, omp, Mistral Vibe).
 
 Does **not** own: hook installation/uninstallation (that's `src/hooks/init.rs`), the rewrite pattern registry (that's `discover/registry`), or integrity verification (that's `src/hooks/integrity.rs`).
 
@@ -58,6 +58,7 @@ Each agent subdirectory has its own README with hook-specific details:
 | Codex CLI | AGENTS.md / instructions | Prompt-level guidance | N/A |
 | OpenCode | TypeScript plugin (`tool.execute.before`) | In-place mutation | Yes |
 | Pi | TypeScript extension (`tool_call` event) | In-place mutation | Yes |
+| omp | TypeScript extension (`tool_call` event) | In-place mutation | Yes |
 | Hermes | Python plugin (`pre_tool_call`) | In-place mutation | Yes |
 | Mistral Vibe | Rust binary (`rtk hook vibe`) | Transparent rewrite | Yes (`hook_specific_output.tool_input`) |
 
@@ -270,7 +271,7 @@ New integrations must follow the [Exit Code Contract](#exit-code-contract) and [
 | Tier | Mechanism | Maintenance | Examples |
 |------|-----------|-------------|----------|
 | **Full hook** | Shell script or Rust binary, intercepts commands via agent's hook API | High — must track agent API changes | Claude Code, Cursor, Copilot, Gemini |
-| **Plugin** | TypeScript/JS/Python plugin in agent's plugin system | Medium — agent manages loading | OpenCode, Hermes, Pi |
+| **Plugin** | TypeScript/JS/Python plugin in agent's plugin system | Medium — agent manages loading | OpenCode, Hermes, Pi, omp |
 | **Rules file** | Prompt-level instructions the agent reads | Low — no code to break | Cline, Windsurf, Codex |
 
 ### Eligibility

--- a/hooks/omp/README.md
+++ b/hooks/omp/README.md
@@ -1,0 +1,62 @@
+# Oh My Pi (omp) Hooks
+
+> Part of [`hooks/`](../README.md) — see also [`src/hooks/`](../../src/hooks/README.md) for installation code
+
+## Design Intent
+
+RTK's omp extension is a **rewrite-only token optimizer** for Oh My Pi (omp), the
+successor to the Pi coding agent. It mutates bash commands to their `rtk`-prefixed
+equivalents, cutting up to 90% of the bash output that reaches the context.
+
+omp and Pi expose the **same extension API**, so the extension file is identical to
+[`hooks/pi/rtk.ts`](../pi/rtk.ts); only the install location differs (the omp agent
+directory instead of the Pi one).
+
+**Permission gating is intentionally out of scope** — RTK does not block, confirm,
+or audit commands. That concern belongs to a dedicated permission extension.
+
+## Specifics
+
+- TypeScript extension using the shared `ExtensionAPI` (not a shell hook, no `zx`
+  dependency)
+- Subscribes to `tool_call`, narrows to `bash` via the `isBashToolCallEvent` guard
+- Calls `rtk rewrite` via `pi.exec`; mutates `event.input.command` in-place when the
+  rewrite differs
+- All error paths return `undefined` (pass through); RTK never blocks execution
+- Version guard at load time: checks `rtk >= 0.23.0`; warns and registers no-op if
+  too old or missing
+- Installed to `.omp/agent/extensions/rtk.ts` (project-local) by
+  `rtk init --agent omp`, or `~/.omp/agent/extensions/rtk.ts` by
+  `rtk init --agent omp --global`
+
+## Install
+
+```bash
+# Global (all omp projects) — recommended
+rtk init --agent omp --global --auto-patch
+
+# Project-local
+rtk init --agent omp --auto-patch
+```
+
+The omp agent directory honors `PI_CODING_AGENT_DIR` when set; otherwise it defaults
+to `~/.omp/agent`.
+
+## Uninstall
+
+```bash
+rtk init --uninstall --agent omp --global   # remove global install
+rtk init --uninstall --agent omp           # remove project-local install
+```
+
+Uninstall is idempotent — re-running when nothing is installed is a no-op.
+
+## Testing
+
+```bash
+# Load the extension directly without installing
+omp -e ./hooks/pi/rtk.ts
+
+# Verify rewrites are active — run a command, then check history
+rtk gain --history   # should show rtk-prefixed commands with savings %
+```

--- a/hooks/pi/README.md
+++ b/hooks/pi/README.md
@@ -20,6 +20,7 @@ with other Pi extensions.
 - All error paths return `undefined` (pass through); RTK never blocks execution
 - Version guard at load time: checks `rtk >= 0.23.0`; warns and registers no-op if too old or missing
 - Installed to `.pi/extensions/rtk.ts` by `rtk init --agent pi` (project-local) or `~/.pi/agent/extensions/rtk.ts` by `rtk init --agent pi --global`
+- omp (Oh My Pi) shares this same extension API and file — install it there with `rtk init --agent omp [--global]` (see [`hooks/omp/README.md`](../omp/README.md))
 
 ## Uninstall
 

--- a/src/hooks/constants.rs
+++ b/src/hooks/constants.rs
@@ -38,6 +38,14 @@ pub const PI_EXTENSIONS_SUBDIR: &str = "extensions";
 pub const PI_PLUGIN_FILE: &str = "rtk.ts";
 pub const PI_CODING_AGENT_DIR_ENV: &str = "PI_CODING_AGENT_DIR";
 
+/// Oh My Pi (omp) agent directory. omp is the successor to Pi and shares the
+/// same extension API; it resolves its agent directory via `PI_CODING_AGENT_DIR`
+/// (falling back to the same `~/.pi/agent` default), but conventionally stores
+/// extensions under `~/.omp/agent/extensions`.
+pub const OMP_DIR: &str = ".omp/agent";
+pub const OMP_EXTENSIONS_SUBDIR: &str = "extensions";
+pub const OMP_PLUGIN_FILE: &str = "rtk.ts";
+
 /// Factory Droid config directory, joined onto the resolved home directory.
 pub const DROID_DIR: &str = ".factory";
 /// Canonical Droid hooks file (Droid's own /hooks UI reads and writes this).

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -17,9 +17,10 @@ use super::constants::{
     DROID_EXECUTE_MATCHER, DROID_HOME_ENV, DROID_HOOKS_FILE, DROID_HOOKS_SUBDIR,
     DROID_HOOK_COMMAND, DROID_SETTINGS_FILE, GEMINI_HOOK_FILE, HERMES_DIR, HERMES_PLUGINS_SUBDIR,
     HERMES_PLUGIN_INIT_FILE, HERMES_PLUGIN_MANIFEST_FILE, HERMES_PLUGIN_NAME, HOOKS_JSON,
-    HOOKS_SUBDIR, PI_CODING_AGENT_DIR_ENV, PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR,
-    PI_PLUGIN_FILE, PRE_TOOL_USE_KEY, REWRITE_HOOK_FILE, SETTINGS_JSON, VIBE_BASH_MATCH, VIBE_DIR,
-    VIBE_HOOKS_FILE, VIBE_HOOK_COMMAND, VIBE_HOOK_NAME, VIBE_PROMPTS_SUBDIR, VIBE_PROMPT_FILE,
+    HOOKS_SUBDIR, OMP_DIR, OMP_EXTENSIONS_SUBDIR, OMP_PLUGIN_FILE, PI_CODING_AGENT_DIR_ENV,
+    PI_DIR, PI_EXTENSIONS_SUBDIR, PI_LOCAL_DIR, PI_PLUGIN_FILE, PRE_TOOL_USE_KEY,
+    REWRITE_HOOK_FILE, SETTINGS_JSON, VIBE_BASH_MATCH, VIBE_DIR, VIBE_HOOKS_FILE,
+    VIBE_HOOK_COMMAND, VIBE_HOOK_NAME, VIBE_PROMPTS_SUBDIR, VIBE_PROMPT_FILE,
 };
 use super::integrity;
 use super::is_claude_hook_command;
@@ -645,6 +646,7 @@ pub fn uninstall(
     codex: bool,
     cursor: bool,
     pi: bool,
+    omp: bool,
     ctx: InitContext,
 ) -> Result<()> {
     let InitContext { verbose, dry_run } = ctx;
@@ -685,6 +687,11 @@ pub fn uninstall(
 
     if pi {
         uninstall_pi(global, ctx)?;
+        return Ok(());
+    }
+
+    if omp {
+        uninstall_omp(global, ctx)?;
         return Ok(());
     }
 
@@ -3488,6 +3495,115 @@ pub fn run_pi_mode(global: bool, ctx: InitContext) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Resolve the omp agent directory. omp shares Pi's extension API and honors
+/// `PI_CODING_AGENT_DIR` when set; otherwise it falls back to `~/.omp/agent`.
+fn resolve_omp_dir() -> Result<PathBuf> {
+    if let Ok(dir) = std::env::var(PI_CODING_AGENT_DIR_ENV) {
+        if !dir.is_empty() {
+            return Ok(PathBuf::from(dir));
+        }
+    }
+    resolve_home_subdir(OMP_DIR)
+}
+
+/// Return the path to the installed omp extension file.
+fn omp_plugin_path(omp_dir: &Path) -> PathBuf {
+    omp_dir.join(OMP_EXTENSIONS_SUBDIR).join(OMP_PLUGIN_FILE)
+}
+
+/// Uninstall the omp extension for the given scope.
+fn uninstall_omp(global: bool, ctx: InitContext) -> Result<()> {
+    let InitContext { verbose, dry_run } = ctx;
+    let plugin_path = if global {
+        omp_plugin_path(&resolve_omp_dir()?)
+    } else {
+        PathBuf::from(OMP_DIR)
+            .join(OMP_EXTENSIONS_SUBDIR)
+            .join(OMP_PLUGIN_FILE)
+    };
+    let mut removed: Vec<String> = Vec::new();
+
+    if plugin_path.exists() {
+        if dry_run {
+            println!(
+                "[dry-run] would remove omp extension: {}",
+                plugin_path.display()
+            );
+        } else {
+            // nosemgrep: filesystem-deletion -- omp uninstall removes only the RTK-managed extension file.
+            fs::remove_file(&plugin_path).with_context(|| {
+                format!("Failed to remove omp extension: {}", plugin_path.display())
+            })?;
+            if verbose > 0 {
+                eprintln!("Removed omp extension: {}", plugin_path.display());
+            }
+            removed.push(format!("omp extension: {}", plugin_path.display()));
+        }
+    }
+
+    if dry_run {
+        print_dry_run_footer();
+    } else if !removed.is_empty() {
+        println!("RTK uninstalled (omp):");
+        for item in &removed {
+            println!("  - {}", item);
+        }
+        println!("\nRestart omp to apply changes.");
+    } else {
+        println!("RTK omp extension was not installed (nothing to remove)");
+    }
+    Ok(())
+}
+
+/// Install the omp extension (hook-only; no AGENTS.md injection). The extension
+/// file is identical to Pi's — omp and Pi expose the same extension API — but
+/// it lands in the omp agent directory.
+///
+/// global=true  → `$PI_CODING_AGENT_DIR/extensions/rtk.ts` (or `~/.omp/agent/extensions/rtk.ts`)
+/// global=false → `.omp/agent/extensions/rtk.ts` (project-local)
+pub fn run_omp_mode(global: bool, ctx: InitContext) -> Result<()> {
+    let InitContext { dry_run, .. } = ctx;
+    let plugin_path = if global {
+        let omp_dir = resolve_omp_dir()?;
+        let path = omp_plugin_path(&omp_dir);
+        if let Some(parent) = path.parent() {
+            ensure_pi_extensions_dir(parent, "omp extensions directory", ctx)?;
+        }
+        path
+    } else {
+        let path = PathBuf::from(OMP_DIR)
+            .join(OMP_EXTENSIONS_SUBDIR)
+            .join(OMP_PLUGIN_FILE);
+        if let Some(parent) = path.parent() {
+            ensure_pi_extensions_dir(parent, "local omp extensions directory", ctx)?;
+        }
+        path
+    };
+
+    let installed = ensure_pi_plugin_installed(&plugin_path, ctx)?;
+
+    if dry_run {
+        print_dry_run_footer();
+    } else {
+        print_omp_result(&plugin_path, installed);
+    }
+
+    Ok(())
+}
+
+fn print_omp_result(plugin_path: &Path, installed: bool) {
+    let status = if installed {
+        "installed"
+    } else {
+        "already up to date"
+    };
+    println!("RTK omp extension {}:", status);
+    println!("  Extension: {}", plugin_path.display());
+    println!();
+    println!("omp will load the extension automatically on next start.");
+    println!("Verify: omp -e {} --no-session", plugin_path.display());
 }
 
 fn print_pi_result(plugin_path: &Path, installed: bool) {
@@ -7221,7 +7337,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         with_claude_dir_override(&tmp, |claude_dir| {
             run_default_mode(true, PatchMode::Auto, false, InitContext::default()).unwrap();
-            uninstall(true, false, false, false, false, InitContext::default()).unwrap();
+            uninstall(true, false, false, false, false, false, InitContext::default()).unwrap();
 
             assert!(!claude_dir.join(RTK_MD).exists(), "RTK.md must be removed");
             let settings_content =
@@ -7349,7 +7465,7 @@ mod tests {
                 dry_run: true,
                 ..Default::default()
             };
-            uninstall(true, false, false, false, false, dry).unwrap();
+            uninstall(true, false, false, false, false, false, dry).unwrap();
 
             // Files must still exist with identical content
             assert!(
@@ -7582,7 +7698,7 @@ mod tests {
             let plugin = pi_dir.join(PI_EXTENSIONS_SUBDIR).join(PI_PLUGIN_FILE);
             assert!(plugin.exists());
 
-            uninstall(true, false, false, false, true, InitContext::default()).unwrap();
+            uninstall(true, false, false, false, true, false, InitContext::default()).unwrap();
 
             assert!(!plugin.exists(), "plugin must be removed");
         });
@@ -7596,7 +7712,7 @@ mod tests {
         std::env::set_current_dir(tmp.path()).unwrap();
 
         run_pi_mode(false, InitContext::default()).unwrap();
-        let result = uninstall(false, false, false, false, true, InitContext::default());
+        let result = uninstall(false, false, false, false, true, false, InitContext::default());
         std::env::set_current_dir(&cwd).unwrap();
         result.unwrap();
 
@@ -7695,6 +7811,7 @@ mod tests {
                 false,
                 false,
                 true,
+                false,
                 InitContext {
                     verbose: 0,
                     dry_run: true,
@@ -7705,6 +7822,97 @@ mod tests {
             assert!(
                 plugin.exists(),
                 "dry-run uninstall must not remove the Pi extension"
+            );
+        });
+    }
+
+    #[test]
+    fn test_run_omp_mode_global_installs_plugin() {
+        let tmp = TempDir::new().unwrap();
+        with_pi_dir_override(&tmp, |omp_dir| {
+            run_omp_mode(true, InitContext::default()).unwrap();
+
+            let plugin = omp_dir.join(OMP_EXTENSIONS_SUBDIR).join(OMP_PLUGIN_FILE);
+            assert!(plugin.exists(), "global omp extension must be created");
+
+            let content = fs::read_to_string(&plugin).unwrap();
+            assert!(
+                content.contains("rtk rewrite"),
+                "extension must delegate to rtk rewrite"
+            );
+        });
+    }
+
+    #[test]
+    fn test_run_omp_mode_local_installs_plugin() {
+        let tmp = TempDir::new().unwrap();
+        let _cwd_guard = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        let result = run_omp_mode(false, InitContext::default());
+        std::env::set_current_dir(&cwd).unwrap();
+        result.unwrap();
+
+        let plugin = tmp
+            .path()
+            .join(OMP_DIR)
+            .join(OMP_EXTENSIONS_SUBDIR)
+            .join(OMP_PLUGIN_FILE);
+        assert!(plugin.exists(), "local omp extension must be created");
+    }
+
+    #[test]
+    fn test_run_omp_mode_global_does_not_create_agents_md() {
+        let tmp = TempDir::new().unwrap();
+        with_pi_dir_override(&tmp, |omp_dir| {
+            run_omp_mode(true, InitContext::default()).unwrap();
+
+            let agents_md = omp_dir.join(AGENTS_MD);
+            assert!(!agents_md.exists(), "AGENTS.md must not be created");
+        });
+    }
+
+    #[test]
+    fn test_omp_global_uninstall_removes_plugin() {
+        let tmp = TempDir::new().unwrap();
+        with_pi_dir_override(&tmp, |omp_dir| {
+            run_omp_mode(true, InitContext::default()).unwrap();
+
+            let plugin = omp_dir.join(OMP_EXTENSIONS_SUBDIR).join(OMP_PLUGIN_FILE);
+            assert!(plugin.exists());
+
+            uninstall(
+                true,
+                false,
+                false,
+                false,
+                false,
+                true,
+                InitContext::default(),
+            )
+            .unwrap();
+
+            assert!(!plugin.exists(), "omp plugin must be removed");
+        });
+    }
+
+    #[test]
+    fn test_run_omp_mode_global_dry_run_writes_nothing() {
+        let tmp = TempDir::new().unwrap();
+        with_pi_dir_override(&tmp, |omp_dir| {
+            run_omp_mode(
+                true,
+                InitContext {
+                    verbose: 0,
+                    dry_run: true,
+                },
+            )
+            .unwrap();
+
+            assert!(
+                !omp_dir.join(OMP_EXTENSIONS_SUBDIR).exists(),
+                "dry-run must not create the omp extensions directory"
             );
         });
     }
@@ -7733,6 +7941,7 @@ mod tests {
             false,
             false,
             true,
+            false,
             InitContext {
                 verbose: 0,
                 dry_run: true,

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,8 @@ pub enum AgentTarget {
     Kimi,
     /// Pi coding agent
     Pi,
+    /// Oh My Pi (omp) coding agent
+    Omp,
     /// Hermes CLI
     Hermes,
     /// Factory Droid CLI
@@ -1564,7 +1566,7 @@ fn uninstall_init_dispatch<UninstallHermes, UninstallStandard>(
 ) -> Result<()>
 where
     UninstallHermes: FnOnce(hooks::init::InitContext) -> Result<()>,
-    UninstallStandard: FnOnce(bool, bool, bool, bool, bool, hooks::init::InitContext) -> Result<()>,
+    UninstallStandard: FnOnce(bool, bool, bool, bool, bool, bool, hooks::init::InitContext) -> Result<()>,
 {
     if agent == Some(AgentTarget::Hermes) {
         uninstall_hermes(ctx)
@@ -1575,7 +1577,8 @@ where
     } else {
         let cursor = agent == Some(AgentTarget::Cursor);
         let pi = agent == Some(AgentTarget::Pi);
-        uninstall_standard(global, gemini, codex, cursor, pi, ctx)
+        let omp = agent == Some(AgentTarget::Omp);
+        uninstall_standard(global, gemini, codex, cursor, pi, omp, ctx)
     }
 }
 
@@ -2053,6 +2056,8 @@ fn run_cli() -> Result<i32> {
                 }
             } else if agent == Some(AgentTarget::Pi) {
                 hooks::init::run_pi_mode(global, ctx)?
+            } else if agent == Some(AgentTarget::Omp) {
+                hooks::init::run_omp_mode(global, ctx)?
             } else if agent == Some(AgentTarget::Kilocode) {
                 if global {
                     anyhow::bail!("Kilo Code is project-scoped. Use: rtk init --agent kilocode");
@@ -3010,7 +3015,7 @@ mod tests {
                 assert!(ctx.dry_run);
                 Ok(())
             },
-            |_, _, _, _, _, _| {
+            |_, _, _, _, _, _, _| {
                 standard_called.set(true);
                 Ok(())
             },


### PR DESCRIPTION
## Summary

Add support for **Oh My Pi (omp)** — the successor to the Pi coding agent — to the RTK hook installer. omp exposes the same extension API as Pi, so the existing `rtk.ts` extension works unchanged; this PR wires up `rtk init --agent omp` to install it into the omp agent directory.

## What changed

- **`AgentTarget::Omp`** + `--agent omp` CLI value
- **`run_omp_mode` / `uninstall_omp`** in `src/hooks/init.rs` — mirror Pi mode but target the omp agent directory:
  - global: `~/.omp/agent/extensions/rtk.ts` (honors `PI_CODING_AGENT_DIR`)
  - local: `.omp/agent/extensions/rtk.ts`
- **Constants**: `OMP_DIR` (`.omp/agent`), `OMP_EXTENSIONS_SUBDIR`, `OMP_PLUGIN_FILE`
- **Docs**: `hooks/omp/README.md`, cross-reference in `hooks/pi/README.md`, supported-agents table + install list in `hooks/README.md` and root `README.md`
- **Tests**: 5 unit tests covering global/local install, uninstall, and dry-run

## Notes

- The extension file itself is shared with Pi (`hooks/pi/rtk.ts`); omp only differs in install location.
- omp honors `PI_CODING_AGENT_DIR` (the same env var Pi uses), defaulting to `~/.omp/agent`.

## Verification

- `cargo clippy` clean
- Full test suite passes (2649 + 5 new omp tests)
- Manual: `rtk init --agent omp --global` installs to `~/.omp/agent/extensions/rtk.ts`; `rtk init --uninstall --agent omp --global` removes it