### PR TITLE
ci: add stale bot for issues and PRs (90d stale, +7d close)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,20 +8,27 @@
 name: Manage stale issues and PRs
 on:
   schedule:
-    # Run daily
-    - cron: '0 6 * * *'
+    # Run weekly
+    - cron: '0 6 * * 1'
   workflow_dispatch:
 
-permissions:
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-issues: write
+          permission-pull-requests: write
+
       - uses: actions/stale@v9
         with:
+          repo-token: ${{ steps.app-token.outputs.token }}
           # --- Issues & PRs ---
           days-before-stale: 90
           days-before-close: 7

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,55 @@
+# Configuration for stale action workflow - https://github.com/actions/stale
+#
+# Mirrors facebook/react's config (days-before-stale: 90, days-before-close: 7),
+# adapted with rtk's own label taxonomy for exemptions. See #348 for the wider
+# triage-automation context this is a piece of; #348 originally scoped a stale
+# bot out ("oldest item is 17 days, no staleness problem yet") — that was true
+# in March 2026 at 51 open PRs, no longer true at current volume.
+name: Manage stale issues and PRs
+on:
+  schedule:
+    # Run daily
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # --- Issues & PRs ---
+          days-before-stale: 90
+          days-before-close: 7
+          operations-per-run: 500
+
+          # --- Issues ---
+          stale-issue-label: "stale"
+          stale-issue-message: >
+            This issue has been automatically marked as stale due to 90 days
+            of inactivity. **If this issue is still affecting you, please
+            leave any comment** (for example, "bump"), and we'll keep it open.
+            We are sorry that we haven't been able to prioritize it yet.
+          close-issue-message: >
+            Closing this issue after a prolonged period of inactivity. If
+            this issue is still present in the latest release, please open a
+            new issue with up-to-date information. Thank you!
+          exempt-issue-labels: "bug,enhancement,area:security,P0-critical,P1-high,DONE_REVIEW,good first issue,help wanted"
+
+          # --- PRs ---
+          stale-pr-label: "stale"
+          stale-pr-message: >
+            This pull request has been automatically marked as stale due to
+            90 days of inactivity. **If this pull request is still relevant,
+            please leave any comment** (for example, "bump"), and we'll keep
+            it open. Your contribution is very much appreciated — we're sorry
+            we haven't been able to review it yet.
+          close-pr-message: >
+            Closing this pull request after a prolonged period of inactivity.
+            If this is still relevant, please ask for it to be reopened.
+            Thank you!
+          exempt-pr-labels: "bug,enhancement,area:security,P0-critical,P1-high,DONE_REVIEW,good first issue,help wanted"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/stale.yml` using `actions/stale@v9`, mirroring facebook/react's config: 90 days of inactivity → `stale` label + comment, +7 more days with no reaction → auto-close.
- Applies to both issues and PRs. Exempt labels: `bug`, `enhancement`, `area:security`, `P0-critical`, `P1-high`, `DONE_REVIEW`, `good first issue`, `help wanted` — mirrors React's approach of protecting anything that's already been triaged.

## Context
#348 originally scoped a stale bot **out** of its triage-automation plan: *"Oldest item is 17 days. No staleness problem yet"* — accurate in March 2026 at 51 open PRs / 88 open issues.

That's no longer the case. At current volume (1049 open PRs):
- **253 PRs** (24%) have had zero activity in 90+ days
- **182 of those** have no label at all — never triaged, not just idle

This doesn't replace the broader triage system #348 proposes (templates, auto-labeling by path, `needs-info` follow-up, etc.) — it's a narrow, independent piece that can land on its own while the rest of that plan is still pending.

## Notes
- Thresholds (90d/+7d) are React's numbers, used as a reasonable starting point — open to tuning for rtk's actual velocity (happy to go tighter, e.g. Bun's 30d/+14d for PRs specifically, if that fits better).
- `operations-per-run: 500` to actually make a dent in the current backlog size; default is 30.
- Daily cron (`0 6 * * *`) rather than hourly, since this isn't time-sensitive.

## Test plan
- [ ] `workflow_dispatch` dry run on a fork or via `actions/stale`'s `debug-only: true` before merge, to sanity-check the label/message output against a handful of real PRs
- [ ] Confirm `exempt-*-labels` list against the actual label taxonomy (`gh api repos/rtk-ai/rtk/labels`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)