### PR TITLE
fix(hooks): match exclude_commands against the peeled command form

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ For per-agent setup details, override controls, and graceful degradation, see th
 
 ```toml
 [hooks]
-exclude_commands = ["curl", "playwright"]  # skip rewrite for these
+exclude_commands = ["curl", "playwright"]  # skip rewrite for these (matches `npx playwright` too)
 
 [tee]
 enabled = true          # save raw output on failure (default: true)

--- a/docs/guide/getting-started/configuration.md
+++ b/docs/guide/getting-started/configuration.md
@@ -95,6 +95,22 @@ Patterns match against the full command after stripping env prefixes (`sudo`, `V
 
 Subcommand patterns work too: `"git push"` excludes `git push origin main` but not `git status`.
 
+An entry names a tool RTK has a filter for, and that tool is covered however it is invoked.
+Before matching, RTK peels the wrapper, interpreter or path off the command and matches what is
+left, so `"playwright"` excludes `playwright test`, `npx playwright test` and
+`pnpm exec playwright test` alike; `"pytest"` also covers `python3 -m pytest tests/`, and
+`"phpunit"` covers `vendor/bin/phpunit` and `php vendor/bin/phpunit`.
+
+A tool RTK has no filter of its own for is matched as typed, because RTK only sees the wrapper:
+with `["my-tool"]`, `npx my-tool` still rewrites to `rtk npx my-tool`. Exclude `"npx"` to stop
+that.
+
+The arguments are kept when peeling, so an anchored pattern still narrows the way you wrote it:
+`"^ls$"` excludes a bare `ls` without swallowing `ls -la`. Matching stays exact — `"go"` never
+excludes `golangci-lint`, subcommand patterns stay literal (`"git push"` does not widen to all of
+`git`), and an entry never leaks to a different tool that happens to share an RTK filter: `"read"`
+does not exclude `cat`, and `"eslint"` does not exclude `biome`.
+
 Patterns starting with `^` are treated as regex:
 
 ```toml

--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -1230,6 +1230,12 @@ Pour empecher certaines commandes d'etre reecrites, ajoutez-les dans `config.tom
 exclude_commands = ["curl", "playwright"]
 ```
 
+Le motif est ancre en debut de commande : `"curl"` exclut `curl https://...` mais pas `curl-config`.
+Avant la comparaison, RTK retire le wrapper, l'interpreteur ou le chemin, donc `"playwright"` couvre
+`playwright test` comme `npx playwright test` ou `pnpm exec playwright test`, et `"pytest"` couvre
+aussi `python3 -m pytest tests/`. Les arguments sont conserves : `"^ls$"` exclut `ls` seul sans
+englober `ls -la`.
+
 ---
 
 ## Configuration

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -9,7 +9,7 @@ use super::lexer::{
     shell_split, split_on_operators, tokenize, tokenize_with_newlines, ParsedToken, PipeKind,
     TokenKind,
 };
-use super::rules::{IGNORED_EXACT, IGNORED_PREFIXES, RULES};
+use super::rules::{RtkRule, IGNORED_EXACT, IGNORED_PREFIXES, RULES};
 
 const PHP_TOOL_NAMES: [&str; 6] = ["phpunit", "phpstan", "ecs", "pest", "paratest", "pint"];
 
@@ -1382,7 +1382,10 @@ fn rewrite_segment_inner(
         Classification::Supported { rtk_equivalent, .. } => {
             let stripped = ENV_PREFIX.replace(cmd_part, "");
             let cmd_clean = stripped.trim();
-            if is_excluded(cmd_clean, excluded) {
+            if !excluded.is_empty()
+                && (is_excluded(cmd_clean, excluded)
+                    || is_excluded(&tool_form(cmd_clean, rtk_equivalent), excluded))
+            {
                 return None;
             }
             rtk_equivalent
@@ -1448,20 +1451,12 @@ fn rewrite_segment_inner(
     // classify_command does, so a small canonical prefix list matches every
     // invocation form instead of enumerating each literal spelling.
     let php_normalized;
-    let strip_target: &str = if rule
-        .rtk_cmd
-        .strip_prefix("rtk ")
-        .is_some_and(|t| PHP_TOOL_NAMES.contains(&t))
-    {
-        // Peel `php ` then a leading `./` (normalize_php_tool_command only
-        // strips `./` for paths that resolve to a Composer tool, so a plain
-        // `./bin/<tool>` would otherwise survive and miss the prefix match).
-        let unwrapped = strip_php_wrapper(cmd_part);
-        let unwrapped = unwrapped.strip_prefix("./").unwrap_or(unwrapped);
-        php_normalized = normalize_php_tool_command(unwrapped);
-        &php_normalized
-    } else {
-        cmd_part
+    let strip_target: &str = match php_tool_form(cmd_part, rule.rtk_cmd) {
+        Some(normalized) => {
+            php_normalized = normalized;
+            &php_normalized
+        }
+        None => cmd_part,
     };
 
     // Try each rewrite prefix (longest first) with word-boundary check
@@ -1477,6 +1472,70 @@ fn rewrite_segment_inner(
     }
 
     None
+}
+
+/// The tool-name portion of a matched rewrite prefix: the shortest token-suffix of
+/// `prefix` that is itself a rewrite prefix of the same rule. That peels the wrapper
+/// (`npx`, `pnpm exec`, `python3 -m`, `bundle exec`) while keeping a subcommand the
+/// rule treats as part of the tool, so `golangci-lint run` and `next build` survive
+/// intact instead of collapsing to `run` and `build`.
+fn tool_portion(prefix: &'static str, rule: &RtkRule) -> &'static str {
+    let mut best = prefix;
+    let mut rest = prefix;
+    while let Some(pos) = rest.find(' ') {
+        rest = &rest[pos + 1..];
+        if rule.rewrite_prefixes.contains(&rest) {
+            best = rest;
+        }
+    }
+    best
+}
+
+/// Rewrite a command into the spelling `exclude_commands` is written against.
+///
+/// An entry names a tool, but the command may spell it with a wrapper
+/// (`npx playwright test`), an interpreter (`python3 -m pytest tests/`) or a path
+/// (`vendor/bin/phpunit tests/`). Peeling that spelling down to the tool lets one entry
+/// cover every form. The arguments are kept, so an anchored pattern still means what it
+/// says: `"^ls$"` excludes a bare `ls` without swallowing `ls -la`.
+/// Canonical `<tool> <args>` form of a Composer-resolved PHP tool invocation, peeling
+/// the `php` wrapper and its ini flags, a leading `./`, and a vendor/composer bin dir.
+/// `None` when `rtk_cmd` is not one of those tools.
+///
+/// `normalize_php_tool_command` only strips `./` for paths that resolve to a Composer
+/// tool, so a plain `./bin/<tool>` would otherwise survive and miss the prefix match.
+fn php_tool_form(cmd: &str, rtk_cmd: &str) -> Option<String> {
+    rtk_cmd
+        .strip_prefix("rtk ")
+        .filter(|t| PHP_TOOL_NAMES.contains(t))?;
+    let unwrapped = strip_php_wrapper(cmd);
+    let unwrapped = unwrapped.strip_prefix("./").unwrap_or(unwrapped);
+    Some(normalize_php_tool_command(unwrapped))
+}
+
+fn tool_form(cmd_clean: &str, rtk_equivalent: &str) -> String {
+    // Same normalization the rewrite path applies, so the exclusion sees the tool
+    // whichever way it was spelled — including `php vendor/bin/phpunit`.
+    let normalized = strip_absolute_path(
+        &php_tool_form(cmd_clean, rtk_equivalent).unwrap_or_else(|| cmd_clean.to_string()),
+    );
+    RULES
+        .iter()
+        .find(|r| r.rtk_cmd == rtk_equivalent)
+        .and_then(|rule| {
+            rule.rewrite_prefixes.iter().find_map(|&prefix| {
+                let rest = strip_word_prefix(&normalized, prefix)?;
+                // No rewrite prefix carries a path outside its first token, and that
+                // token is already a basename here, so `tool_portion` needs no strip.
+                let tool = tool_portion(prefix, rule);
+                Some(if rest.is_empty() {
+                    tool.to_string()
+                } else {
+                    format!("{} {}", tool, rest)
+                })
+            })
+        })
+        .unwrap_or(normalized)
 }
 
 /// Strip a command prefix with word-boundary check.
@@ -4709,6 +4768,147 @@ mod tests {
     fn test_exclude_invalid_regex_fallback() {
         let excluded = vec!["curl[".to_string()];
         assert!(rewrite_command_no_prefixes("curl http://example.com", &excluded).is_some());
+    }
+
+    #[test]
+    fn test_exclude_covers_php_wrapper_forms() {
+        // The rewrite path normalizes `php` + ini flags, `./`, and vendor/composer
+        // bin dirs; the exclusion must see the same canonical form.
+        for (pattern, cmd) in [
+            ("phpunit", "vendor/bin/phpunit tests/"),
+            ("phpunit", "php vendor/bin/phpunit tests/"),
+            ("phpunit", "php bin/phpunit"),
+            ("phpstan", "php vendor/bin/phpstan analyse src"),
+        ] {
+            assert_eq!(
+                rewrite_command_no_prefixes(cmd, &[pattern.to_string()]),
+                None,
+                "expected `{}` to be excluded by `{}`",
+                cmd,
+                pattern
+            );
+        }
+        // A different PHP tool is untouched.
+        assert!(rewrite_command_no_prefixes(
+            "php vendor/bin/phpstan analyse src",
+            &["phpunit".to_string()]
+        )
+        .is_some());
+    }
+
+    #[test]
+    fn test_exclude_matches_wrapper_invoked_form() {
+        // #243: the README example, across every form that reaches `rtk playwright`.
+        let excluded = vec!["playwright".to_string()];
+        for cmd in [
+            "playwright test",
+            "npx playwright test",
+            "pnpm exec playwright test",
+            "pnpm dlx playwright test",
+        ] {
+            assert_eq!(
+                rewrite_command_no_prefixes(cmd, &excluded),
+                None,
+                "expected `{}` to be excluded",
+                cmd
+            );
+        }
+    }
+
+    #[test]
+    fn test_exclude_covers_interpreter_and_path_forms() {
+        // #3035: the interpreter form, and the path forms noted in #1053.
+        for (pattern, cmd) in [
+            ("pytest", "python3 -m pytest tests/ -q"),
+            ("pytest", "python -m pytest tests/"),
+            ("mypy", "python -m mypy ."),
+            ("gradlew", "./gradlew assembleDebug"),
+            ("phpunit", "vendor/bin/phpunit tests/"),
+            ("rspec", "bundle exec rspec"),
+        ] {
+            assert_eq!(
+                rewrite_command_no_prefixes(cmd, &[pattern.to_string()]),
+                None,
+                "expected `{}` to be excluded by `{}`",
+                cmd,
+                pattern
+            );
+        }
+    }
+
+    #[test]
+    fn test_exclude_covers_wrapper_when_tool_name_differs_from_target() {
+        // `eslint` and `biome` both resolve to `rtk lint`, so matching the resolved
+        // target instead of the peeled command would miss the wrapper form entirely.
+        let excluded = vec!["eslint".to_string()];
+        assert_eq!(rewrite_command_no_prefixes("eslint .", &excluded), None);
+        assert_eq!(rewrite_command_no_prefixes("npx eslint .", &excluded), None);
+        // ...and does not reach the other tool sharing that target.
+        assert!(rewrite_command_no_prefixes("npx biome check .", &excluded).is_some());
+    }
+
+    #[test]
+    fn test_exclude_keeps_arguments_so_anchored_regex_still_narrows() {
+        // An end-anchored entry exists to exclude the bare invocation only. Peeling
+        // must not drop the arguments, or `^ls$` would swallow every `ls`.
+        let excluded = vec!["^ls$".to_string()];
+        assert_eq!(rewrite_command_no_prefixes("ls", &excluded), None);
+        assert!(rewrite_command_no_prefixes("ls -la", &excluded).is_some());
+
+        // The same anchoring works through a wrapper.
+        let excluded = vec!["^pytest ".to_string()];
+        assert_eq!(
+            rewrite_command_no_prefixes("python3 -m pytest tests/", &excluded),
+            None
+        );
+    }
+
+    #[test]
+    fn test_exclude_does_not_widen_across_tools_sharing_a_target() {
+        // Entries name the tool the user types, not rtk's internal command, so an
+        // entry must not leak to every tool routed to the same filter.
+        for (pattern, cmd) in [
+            ("read", "cat foo.txt"),
+            ("lint", "eslint ."),
+            ("lint", "biome check ."),
+            ("git", "yadm status"),
+        ] {
+            assert!(
+                rewrite_command_no_prefixes(cmd, &[pattern.to_string()]).is_some(),
+                "`{}` must not be excluded by `{}`",
+                cmd,
+                pattern
+            );
+        }
+    }
+
+    #[test]
+    fn test_exclude_peeled_form_is_exact_token() {
+        let excluded = vec!["go".to_string()];
+        assert!(rewrite_command_no_prefixes("golangci-lint run ./...", &excluded).is_some());
+        assert_eq!(
+            rewrite_command_no_prefixes("go build ./...", &excluded),
+            None
+        );
+        // A rule whose prefix carries a subcommand keeps it, so `golangci-lint run`
+        // does not collapse to `run`.
+        assert_eq!(
+            rewrite_command_no_prefixes("golangci-lint run ./...", &["golangci-lint".to_string()]),
+            None
+        );
+    }
+
+    #[test]
+    fn test_exclude_subcommand_pattern_stays_narrow() {
+        let excluded = vec!["git push".to_string()];
+        assert_eq!(
+            rewrite_command_no_prefixes("git push origin main", &excluded),
+            None
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("git status", &excluded),
+            Some("rtk git status".into())
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #243. Fixes #3035.

## The problem

`exclude_commands` entries name a tool, but a command can spell that tool with a wrapper (`npx`, `pnpm exec`, `pnpm dlx`), an interpreter (`python3 -m`), or a path (`vendor/bin/`, `./`). Those spellings are absorbed by each rule's own pattern rather than stripped beforehand, so by the time `is_excluded` runs the string is still `npx playwright test` — and the anchored `^playwright($|\s)` never matches.

That produced an invisible asymmetry:

```toml
[hooks]
exclude_commands = ["playwright"]
```

| Command | before | after |
|---|---|---|
| `playwright test` | excluded ✅ | excluded ✅ |
| `npx playwright test` | **rewritten** ❌ | excluded ✅ |
| `pnpm exec playwright test` | **rewritten** ❌ | excluded ✅ |

Same tool, opposite outcomes, no warning. `README.md` shipped `exclude_commands = ["curl", "playwright"]` as *the* example — and `playwright` is a tool almost nobody invokes bare, so the documented example silently failed for the standard invocation. That's what @nhumrich hit in #243.

The same gap covers `python3 -m pytest` with `["pytest"]` (#3035), where the consequence is sharper: `-m` runs the current interpreter with CWD on `sys.path`, while the bare shim may be a different Python entirely, so the rewrite silently swaps interpreters — exactly what the exclusion existed to prevent.

## The fix

Peel the wrapper off the command and match what remains, OR'd with the existing check on the typed command.

Peeling uses the rule's own `rewrite_prefixes`: take the longest prefix the command matches, then the shortest token-suffix of that prefix which is itself a prefix of the same rule. That drops `npx` and `python3 -m` while keeping a subcommand the rule treats as part of the tool, so `golangci-lint run` does not collapse to `run`.

**The arguments are kept.** This is what makes anchored entries keep meaning what they say — `"^ls$"` excludes a bare `ls` without swallowing `ls -la`.

### Why not match the resolved `rtk` target

Substituting the rule's `rtk_cmd` is a one-liner, and it's wrong in three ways. Recording them because it's the obvious shortcut:

1. **It breaks anchored regexes.** `compile_exclude_patterns` passes `^`-prefixed entries through verbatim, so handing `is_excluded` a bare token turns an anchor written to *narrow* a pattern into one that widens it: `["^ls$"]` starts excluding every `ls`, `["^cargo$"]` every `cargo`.
2. **It misses tools whose target differs from the binary.** `eslint` and `biome` both resolve to `rtk lint`, so `["eslint"]` would still rewrite `npx eslint .` — the exact class of bug this PR is meant to close.
3. **It leaks across tools sharing a target.** `["read"]` would exclude `cat`, `["git"]` would exclude `yadm`, `["rake"]` would exclude `rails`.

Peeling has none of these. All three are covered by tests.

## Verified

Built binary, isolated `XDG_CONFIG_HOME`. Covered forms:

```
["playwright"]     playwright test / npx / pnpm exec / pnpm dlx   -> all excluded
["pytest"]         python3 -m pytest tests/ -q                    -> excluded
["eslint"]         npx eslint .                                   -> excluded
["gradlew"]        ./gradlew assembleDebug                        -> excluded
["phpunit"]        vendor/bin/phpunit tests/                      -> excluded
["rspec"]          bundle exec rspec                              -> excluded
["phpunit"]        php vendor/bin/phpunit tests/                  -> excluded
```

Exactness preserved:

```
["^ls$"]           ls -la                -> rewritten   ("ls" alone -> excluded)
["go"]             golangci-lint run     -> rewritten
["py"]             python3 -m pytest     -> rewritten
["git push"]       git status            -> rewritten
["read"]           cat foo.txt           -> rewritten
["lint"]           eslint . / biome ...  -> rewritten
["git"]            yadm status           -> rewritten
```

## Tests

Seven in `src/discover/registry.rs`, each mapped to a claim above:

- `test_exclude_matches_wrapper_invoked_form` — the README example across all four forms
- `test_exclude_covers_interpreter_and_path_forms` — `python -m`, `./`, `vendor/bin/`, `bundle exec`
- `test_exclude_covers_wrapper_when_tool_name_differs_from_target` — the eslint/biome case
- `test_exclude_keeps_arguments_so_anchored_regex_still_narrows` — `^ls$` and `^pytest `
- `test_exclude_does_not_widen_across_tools_sharing_a_target` — read/cat, lint/eslint, git/yadm
- `test_exclude_peeled_form_is_exact_token` — `["go"]` vs `golangci-lint`, and `golangci-lint run` kept whole
- `test_exclude_subcommand_pattern_stays_narrow` — `["git push"]` vs `git status`
- `test_exclude_covers_php_wrapper_forms` — `php vendor/bin/phpunit`, `php bin/phpunit`, `php vendor/bin/phpstan`

`cargo fmt --all --check`, `cargo clippy --all-targets` and `cargo test --all` are clean (2657 passed).

## Limits

Peeling is driven by each rule's `rewrite_prefixes`, so it only reaches tools RTK has a filter
for. A tool RTK sees only through a generic wrapper rule is matched as typed: with
`["my-tool"]`, `npx my-tool` still rewrites to `rtk npx my-tool` — exclude `"npx"` for that.
The docs state this rather than promising blanket coverage.

## Scope

Two adjacent gaps are deliberately **not** addressed here:

- **#1053** — path-prefixed commands failing to *rewrite*. This PR makes the exclusion honour path forms, which is fail-safe (a missed rewrite is passthrough), but the issue's actual ask is to make them rewrite while preserving the caller's binary, which needs a `--rtk-bin` override and handler changes. Leaving it open.
- **#2823 / #3371 / #2363** — the `head`/`tail` line-range fast path returns before any exclusion check. Different code path; #3324 covers it.

## Docs

- `docs/guide/getting-started/configuration.md` — documents peeling, the argument-preserving guarantee, and the exactness limits.
- `docs/usage/FEATURES.md` — same, matching the section's existing French.
- `README.md` — annotates the example so the `npx` case is stated where people copy it from.

