### PR TITLE
fix(build): use GNU stack flag on windows-gnu

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,7 +9,12 @@ fn main() {
         // main-thread stack during process startup. Reserve a larger stack for
         // the CLI binary so `rtk.exe --version`, `--help`, and hook entry
         // points start reliably without requiring ad-hoc RUSTFLAGS.
-        println!("cargo:rustc-link-arg=/STACK:8388608");
+        // MSVC's link.exe and GNU/mingw's ld use different flag syntax for this.
+        if std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc") {
+            println!("cargo:rustc-link-arg=/STACK:8388608");
+        } else {
+            println!("cargo:rustc-link-arg=-Wl,--stack,8388608");
+        }
     }
 
     let filters_dir = Path::new("src/filters");


### PR DESCRIPTION
## Summary

- Fix the Windows GNU/mingw build by using the linker-specific stack flag.
- Keep the existing `/STACK:8388608` behavior for MSVC.
- Use `-Wl,--stack,8388608` for the GNU Windows target.

Fixes #3215.

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets`
- [ ] `cargo test`
- [ ] Verify `x86_64-pc-windows-gnu` links with the GNU stack flag

This is the same underlying fix previously proposed in #3216, which was closed because the contributor could not sign the CLA; the issue remains open.