### PR TITLE
fix(pnpm): typecheck runs the caller's command, not tsc in the cwd

### DIFF
--- a/src/cmds/js/tsc_cmd.rs
+++ b/src/cmds/js/tsc_cmd.rs
@@ -105,6 +105,34 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     )
 }
 
+/// `pnpm typecheck` is a SCRIPT, not a tsc invocation. In a workspace it usually runs one tsc per
+/// package (`pnpm -r typecheck`, or a chain of per-package runs), and it may run `vue-tsc`, `tsc -b`, or
+/// something else entirely. Substituting `tsc` in the current directory answers a different question —
+/// and where the root holds no tsconfig, `tsc` prints its HELP, which carries no diagnostics, so the
+/// filter concluded "No errors found" for a typecheck that had in fact failed. Only the propagated exit
+/// code disagreed, and a summary line is what a reader believes. Run the script the caller asked for and
+/// filter what IT prints.
+///
+/// `args` is the whole pnpm argument list, filters included, so `--filter` works here as anywhere else.
+pub fn run_pnpm_typecheck(args: &[String], verbose: u8) -> Result<i32> {
+    let mut cmd = resolved_command("pnpm");
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    if verbose > 0 {
+        eprintln!("Running: pnpm {}", args.join(" "));
+    }
+
+    runner::run_streamed(
+        cmd,
+        "tsc",
+        &args.join(" "),
+        Box::new(BlockStreamFilter::new(TscHandler::new())),
+        runner::RunOptions::with_tee("tsc"),
+    )
+}
+
 struct TscHandler {
     error_count: usize,
     files: HashSet<String>,

--- a/src/cmds/js/tsc_cmd.rs
+++ b/src/cmds/js/tsc_cmd.rs
@@ -5,6 +5,7 @@ use crate::core::stream::{BlockHandler, BlockStreamFilter};
 use crate::core::truncate::{reduced, CAP_WARNINGS};
 use crate::core::utils::{resolved_command, strip_ansi, tool_exists, truncate};
 use anyhow::Result;
+use std::process::Command;
 use regex::Regex;
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -115,10 +116,7 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
 ///
 /// `args` is the whole pnpm argument list, filters included, so `--filter` works here as anywhere else.
 pub fn run_pnpm_typecheck(args: &[String], verbose: u8) -> Result<i32> {
-    let mut cmd = resolved_command("pnpm");
-    for arg in args {
-        cmd.arg(arg);
-    }
+    let cmd = pnpm_typecheck_command(args);
 
     if verbose > 0 {
         eprintln!("Running: pnpm {}", args.join(" "));
@@ -131,6 +129,16 @@ pub fn run_pnpm_typecheck(args: &[String], verbose: u8) -> Result<i32> {
         Box::new(BlockStreamFilter::new(TscHandler::new())),
         runner::RunOptions::with_tee("tsc"),
     )
+}
+
+/// Split out so a test can assert WHICH program this path runs without spawning it — the defect was
+/// never in the filtering, it was in running the wrong command.
+fn pnpm_typecheck_command(args: &[String]) -> Command {
+    let mut cmd = resolved_command("pnpm");
+    for arg in args {
+        cmd.arg(arg);
+    }
+    cmd
 }
 
 struct TscHandler {
@@ -402,6 +410,30 @@ pub(crate) fn filter_tsc_output(output: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The regression: this path used to run `tsc` in the current directory instead of the caller's
+    /// `pnpm typecheck`. Where the directory holds no tsconfig, `tsc` prints its help, which parses to
+    /// zero diagnostics — so a failing typecheck was reported as "No errors found".
+    #[test]
+    fn pnpm_typecheck_runs_pnpm_with_the_callers_arguments() {
+        let args = vec![
+            "--filter=@app/web".to_string(),
+            "typecheck".to_string(),
+            "--noEmit".to_string(),
+        ];
+        let cmd = pnpm_typecheck_command(&args);
+
+        let program = cmd.get_program().to_string_lossy().into_owned();
+        assert!(
+            program == "pnpm" || program.ends_with("/pnpm"),
+            "expected pnpm, ran {program}"
+        );
+        let forwarded: Vec<String> = cmd
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(forwarded, args, "filters and arguments reach pnpm unchanged");
+    }
 
     #[test]
     fn test_filter_tsc_output() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3589,7 +3589,11 @@ mod tests {
         match cli.command {
             Commands::Pnpm { filter, command } => {
                 assert_eq!(filter, vec!["@app1", "@app2"]);
-                assert_eq!(validate_pnpm_filters(&filter, &command), None, "nothing is dropped now");
+                assert_eq!(
+                    validate_pnpm_filters(&filter, &command),
+                    None,
+                    "nothing is dropped now"
+                );
                 match command {
                     PnpmCommands::Typecheck { args } => assert_eq!(args, vec!["--noEmit"]),
                     _ => panic!("Expected Pnpm Typecheck command"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1538,27 +1538,11 @@ fn merge_pnpm_args_os(filters: &[String], args: &[OsString]) -> Vec<OsString> {
         .collect()
 }
 
-/// Validate that pnpm filters are only used in the global context, not before subcommands like tsc.
-fn validate_pnpm_filters(filters: &[String], command: &PnpmCommands) -> Option<String> {
-    // Check if this is a Build or Typecheck command with filters
-    match command {
-        PnpmCommands::Typecheck { .. } => {
-            // FIXME: if filters are present, we should find out which workspaces are selected before running rtk dedicated commands
-            if !filters.is_empty() {
-                let cmd_name = match command {
-                    PnpmCommands::Typecheck { .. } => "tsc",
-                    _ => unreachable!(),
-                };
-                let msg = format!(
-                    "[rtk] warning: --filter is not yet supported for pnpm {}, filters preceding the subcommand will be ignored",
-                    cmd_name
-                );
-                return Some(msg);
-            }
-            None
-        }
-        _ => None,
-    }
+/// Warn about pnpm filters a subcommand cannot honour. Empty now that `typecheck` runs the caller's own
+/// pnpm command with its filters attached; kept as the place any future dedicated subcommand that drops
+/// them says so.
+fn validate_pnpm_filters(_filters: &[String], _command: &PnpmCommands) -> Option<String> {
+    None
 }
 
 fn main() {
@@ -1869,7 +1853,17 @@ fn run_cli() -> Result<i32> {
                     &merge_pnpm_args(&filter, &args),
                     cli.verbose,
                 )?,
-                PnpmCommands::Typecheck { args } => tsc_cmd::run(&args, cli.verbose)?,
+                PnpmCommands::Typecheck { args } => {
+                    // The caller's own command, filters and all — see tsc_cmd::run_pnpm_typecheck for
+                    // what running `tsc` here instead used to report.
+                    let mut pnpm_args: Vec<String> = filter
+                        .iter()
+                        .map(|value| format!("--filter={}", value))
+                        .collect();
+                    pnpm_args.push("typecheck".to_string());
+                    pnpm_args.extend(args.iter().cloned());
+                    tsc_cmd::run_pnpm_typecheck(&pnpm_args, cli.verbose)?
+                }
                 PnpmCommands::Other(args) => {
                     pnpm_cmd::run_passthrough(&merge_pnpm_args_os(&filter, &args), cli.verbose)?
                 }
@@ -3578,7 +3572,9 @@ mod tests {
     }
 
     #[test]
-    fn test_pnpm_typecheck_with_filters() {
+    fn test_pnpm_typecheck_forwards_its_filters() {
+        // Filters used to be parsed, warned about and dropped, so `pnpm --filter X typecheck` quietly
+        // type-checked something else. They are the caller's scope: they have to reach pnpm.
         let cli = Cli::try_parse_from([
             "rtk",
             "pnpm",
@@ -3587,20 +3583,19 @@ mod tests {
             "--filter",
             "@app2",
             "typecheck",
-            "--filter",
-            "@app3",
-            "--filter",
-            "@app4",
+            "--noEmit",
         ])
         .unwrap();
         match cli.command {
             Commands::Pnpm { filter, command } => {
-                let warning = validate_pnpm_filters(&filter, &command).unwrap();
-
                 assert_eq!(filter, vec!["@app1", "@app2"]);
-                assert_eq!(warning, "[rtk] warning: --filter is not yet supported for pnpm tsc, filters preceding the subcommand will be ignored")
+                assert_eq!(validate_pnpm_filters(&filter, &command), None, "nothing is dropped now");
+                match command {
+                    PnpmCommands::Typecheck { args } => assert_eq!(args, vec!["--noEmit"]),
+                    _ => panic!("Expected Pnpm Typecheck command"),
+                }
             }
-            _ => panic!("Expected Pnpm Build command"),
+            _ => panic!("Expected Pnpm command"),
         }
     }
 


### PR DESCRIPTION
## Summary

- `rtk pnpm typecheck` did not run `pnpm typecheck`. It discarded the pnpm invocation and ran bare `tsc` in the current directory with whatever arguments followed, so in a workspace it answered a different question — and where the root has no `tsconfig.json`, `tsc` printed its **help**, which contains no diagnostics, so the filter reported `TypeScript: No errors found` for a typecheck that had failed.
- `--filter` was parsed, warned about, and dropped (the `FIXME` in `validate_pnpm_filters`). Filters are the caller's scope; dropping them silently type-checks something other than what was asked for.
- Both are fixed by running the caller's own command through the same `TscHandler` stream filter. `rtk tsc` is untouched — asking for tsc still runs tsc.

### Why this one is worth fixing

The exit code was always propagated correctly, so CI was safe. What broke was the summary line, and that is the line a human or an agent reads. A filter that prints the opposite of the truth is worse than no filter: I trusted it on a pnpm workspace that was carrying 43 real type errors across two packages, and it told me the tree was clean.

`pnpm typecheck` is a **script**, not a tsc invocation. In a workspace it is usually one tsc per package, and it may be `vue-tsc`, `tsc -b`, or a chain — none of which `tsc` in the repo root reproduces.

## Test plan

- [x] `cargo fmt --all && cargo clippy --all-targets && cargo test` — fmt clean, zero clippy warnings, 2937 tests pass (2854 unit + 83 integration), 0 failures.
- [x] New unit test `pnpm_typecheck_runs_pnpm_with_the_callers_arguments` asserts which program the path spawns, without spawning it. Against the previous behaviour it fails with `expected pnpm, ran /…/tsc`, which is the bug in one line. The command construction is split into `pnpm_typecheck_command` for exactly this reason: the filtering was never the defect, running the wrong command was.
- [x] The existing filter test that asserted the dropped-`--filter` warning is replaced by one asserting the filters survive to pnpm.
- [x] Manual, on a real pnpm workspace (4 packages, TypeScript 5.9):

| | before | after |
|---|---|---|
| tree with 2 real errors | `TypeScript: No errors found`, exit 1 | both errors with file/line/code, exit 2 |
| `--filter @scope/web typecheck` | warning, filter ignored, whole repo | scopes to that package |
| clean tree | `No errors found`, exit 0 | unchanged — 28 bytes against tsc's 1304 |

## One question for a reviewer

`validate_pnpm_filters` now has no case left and always returns `None`. I kept it as the place a future dedicated subcommand that cannot honour filters would say so, rather than removing the call site from the dispatch path — happy to delete it outright if you would prefer that.
