### PR TITLE
feat(release): sign Windows binaries via SignPath

### DIFF
--- a/.github/workflows/CICD.md
+++ b/.github/workflows/CICD.md
@@ -114,6 +114,32 @@ Trigger: push to master (only) | Concurrency: never cancelled
                     notify    tap update  tag
 ```
 
+## Windows code signing (release.yml → sign-windows)
+
+The Windows `rtk.exe` is signed via [SignPath](https://signpath.io) between build
+and release (fixes Smart App Control blocking and Defender false positives —
+#3226, #2989):
+
+- `build` (windows leg) uploads the bare `rtk.exe` as artifact `rtk-windows-exe-unsigned`
+- `sign-windows` submits it to SignPath, waits for completion, re-zips the signed
+  exe and overwrites the `rtk-x86_64-pc-windows-msvc` artifact
+- `release` publishes the (now signed) zip; checksums are computed after signing
+
+Configuration (repo Settings → Secrets and variables → Actions):
+
+| Name | Kind | Value |
+|------|------|-------|
+| `SIGNPATH_API_TOKEN` | secret | SignPath API token (CI user) |
+| `SIGNPATH_ORGANIZATION_ID` | variable | SignPath organization UUID |
+
+SignPath-side setup: project slug `rtk`, signing policy slug `release-signing`,
+artifact configuration = single `pe-file` named `rtk.exe`, and the GitHub Actions
+trusted build system connected to the project.
+
+If `SIGNPATH_ORGANIZATION_ID` is unset, `sign-windows` is skipped and the release
+ships unsigned (previous behaviour). If signing is attempted and fails, the
+release job does not run.
+
 ## Manual release (release.yml)
 
 Trigger: workflow_dispatch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,6 @@ jobs:
   build:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
-    outputs:
-      # Set only by the windows-msvc leg (see "Expose Windows exe artifact id").
-      windows-exe-artifact-id: ${{ steps.win-artifact.outputs.id }}
     strategy:
       fail-fast: false
       matrix:
@@ -113,17 +110,10 @@ jobs:
       # by the sign-windows job below.
       - name: Upload unsigned Windows exe (for signing)
         if: matrix.os == 'windows-latest'
-        id: upload-exe
         uses: actions/upload-artifact@v4
         with:
           name: rtk-windows-exe-unsigned
           path: target/${{ matrix.target }}/release/rtk.exe
-
-      - name: Expose Windows exe artifact id
-        if: matrix.os == 'windows-latest'
-        id: win-artifact
-        shell: bash
-        run: echo "id=${{ steps.upload-exe.outputs.artifact-id }}" >> "$GITHUB_OUTPUT"
 
   # Signs rtk.exe via SignPath, then replaces the unsigned windows zip with a
   # signed one under the same artifact name so the release job needs no change.
@@ -134,16 +124,44 @@ jobs:
     needs: build
     if: vars.SIGNPATH_ORGANIZATION_ID != ''
     runs-on: ubuntu-latest
+    # Least-privilege: this job only reads the artifact list and talks to the
+    # SignPath API — it never checks out or writes repo contents.
+    permissions:
+      actions: read
     steps:
+      # Looked up by name via the REST API instead of threading a job-level
+      # output through the build matrix: GitHub does not guarantee matrix job
+      # ordering, and a job-level output set by only one leg ("last matrix job
+      # that runs wins") can arrive empty if a non-Windows leg happens to
+      # finish last (rare but real — Windows is usually, not always, slowest).
+      - name: Look up unsigned Windows exe artifact
+        id: find-artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          artifact_id=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+            --jq '.artifacts[] | select(.name == "rtk-windows-exe-unsigned") | .id')
+          if [ -z "$artifact_id" ]; then
+            echo "::error::rtk-windows-exe-unsigned artifact not found for run ${{ github.run_id }}"
+            exit 1
+          fi
+          echo "id=$artifact_id" >> "$GITHUB_OUTPUT"
+
       - name: Submit signing request
-        uses: signpath/github-action-submit-signing-request@v1.2
+        # Pinned by commit SHA (not the mutable v1.2 tag) per SignPath repo tag
+        # refs/tags/v1.2 = 4f13d373e8f0cd8d3c0465ff4877feff27aed2ae.
+        uses: signpath/github-action-submit-signing-request@4f13d373e8f0cd8d3c0465ff4877feff27aed2ae # v1.2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
           organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
           project-slug: rtk
           signing-policy-slug: release-signing
-          github-artifact-id: ${{ needs.build.outputs.windows-exe-artifact-id }}
+          github-artifact-id: ${{ steps.find-artifact.outputs.id }}
           wait-for-completion: true
+          # Default is 600s: too short if the signing policy requires a human
+          # approver. Signing itself is fast; waiting on an approval is the
+          # realistic bottleneck.
+          wait-for-completion-timeout-in-seconds: "3600"
           output-artifact-directory: signed
 
       - name: Repackage signed exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
   build:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    outputs:
+      # Set only by the windows-msvc leg (see "Expose Windows exe artifact id").
+      windows-exe-artifact-id: ${{ steps.win-artifact.outputs.id }}
     strategy:
       fail-fast: false
       matrix:
@@ -105,6 +108,56 @@ jobs:
           name: rtk-${{ matrix.target }}
           path: rtk-${{ matrix.target }}.${{ matrix.archive }}
 
+      # The bare exe is uploaded separately for SignPath: its artifact
+      # configuration signs a single pe-file, and the signed exe is re-zipped
+      # by the sign-windows job below.
+      - name: Upload unsigned Windows exe (for signing)
+        if: matrix.os == 'windows-latest'
+        id: upload-exe
+        uses: actions/upload-artifact@v4
+        with:
+          name: rtk-windows-exe-unsigned
+          path: target/${{ matrix.target }}/release/rtk.exe
+
+      - name: Expose Windows exe artifact id
+        if: matrix.os == 'windows-latest'
+        id: win-artifact
+        shell: bash
+        run: echo "id=${{ steps.upload-exe.outputs.artifact-id }}" >> "$GITHUB_OUTPUT"
+
+  # Signs rtk.exe via SignPath, then replaces the unsigned windows zip with a
+  # signed one under the same artifact name so the release job needs no change.
+  # Skipped entirely (unsigned release, previous behaviour) when the
+  # SIGNPATH_ORGANIZATION_ID repository variable is not configured.
+  sign-windows:
+    name: Sign Windows binary (SignPath)
+    needs: build
+    if: vars.SIGNPATH_ORGANIZATION_ID != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Submit signing request
+        uses: signpath/github-action-submit-signing-request@v1.2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: rtk
+          signing-policy-slug: release-signing
+          github-artifact-id: ${{ needs.build.outputs.windows-exe-artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: signed
+
+      - name: Repackage signed exe
+        run: |
+          cd signed
+          7z a ../rtk-x86_64-pc-windows-msvc.zip rtk.exe
+
+      - name: Replace Windows artifact with signed zip
+        uses: actions/upload-artifact@v4
+        with:
+          name: rtk-x86_64-pc-windows-msvc
+          path: rtk-x86_64-pc-windows-msvc.zip
+          overwrite: true
+
   build-deb:
     name: Build DEB package
     runs-on: ubuntu-latest
@@ -162,7 +215,15 @@ jobs:
 
   release:
     name: Create Release
-    needs: [build, build-deb, build-rpm]
+    needs: [build, sign-windows, build-deb, build-rpm]
+    # sign-windows may be skipped (no SignPath config) — release anyway with
+    # the unsigned zip, but never release if signing was attempted and failed.
+    if: >-
+      !cancelled() &&
+      needs.build.result == 'success' &&
+      needs.build-deb.result == 'success' &&
+      needs.build-rpm.result == 'success' &&
+      (needs.sign-windows.result == 'success' || needs.sign-windows.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v3

--- a/README.md
+++ b/README.md
@@ -500,6 +500,12 @@ Contributions welcome! Please open an issue or PR on [GitHub](https://github.com
 
 Join the community on [Discord](https://discord.gg/RySmvNF5kF).
 
+## Code Signing
+
+Free code signing on Windows provided by [SignPath.io](https://about.signpath.io/), certificate by [SignPath Foundation](https://signpath.org/).
+
+Windows release binaries (`rtk.exe`) are signed in CI via SignPath's GitHub Actions integration — builds are submitted from this repository's release workflow only, and signed with the SignPath Foundation certificate.
+
 ## License
 
 Apache License 2.0 - see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Problem

Windows release binaries are unsigned:

- **#3226** — Smart App Control blocks every new release for ~a week (reputation-based, each release is a fresh hash)
- **#2989** — enterprise allowlisting can't use publisher-based rules
- Recurring Defender false positives: #3124, #3214, #2694, #2070, #1749, #1782

## Change

New `sign-windows` job in `release.yml`, between `build` and `release`:

1. The windows build leg uploads the bare `rtk.exe` as artifact `rtk-windows-exe-unsigned`
2. `sign-windows` submits it to SignPath (`signpath/github-action-submit-signing-request@v1.2`, `wait-for-completion: true`)
3. The signed exe is re-zipped and **overwrites** the `rtk-x86_64-pc-windows-msvc` artifact — the release job and `checksums.txt` pick up the signed binary with zero changes downstream

Failure semantics:
- `SIGNPATH_ORGANIZATION_ID` repo variable absent → job **skipped**, release ships unsigned (previous behaviour; forks unaffected)
- Signing attempted and failed → release job does **not** run (never silently ship unsigned when signing is expected)

Docs added to `.github/workflows/CICD.md`.

## Required setup (not in this PR)

| Where | Name | Kind |
|-------|------|------|
| GitHub repo | `SIGNPATH_API_TOKEN` | Actions secret |
| GitHub repo | `SIGNPATH_ORGANIZATION_ID` | Actions variable |
| SignPath | project `rtk`, signing policy `release-signing` | |
| SignPath | artifact configuration: single `pe-file` `rtk.exe` | |
| SignPath | GitHub Actions trusted build system linked to the project | |

For SAC immediate trust an EV-grade cert is ideal; SignPath's OSS program certificate still gives a stable publisher identity for allowlisting and greatly reduces Defender FPs.

Refs #3226, #2989

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyGoVR59QcBsJ8WfnYwCe7