### PR TITLE
fix(phpt): unbreak develop after the .phpt filter merge

### DIFF
--- a/src/cmds/php/phpt_cmd.rs
+++ b/src/cmds/php/phpt_cmd.rs
@@ -12,9 +12,29 @@ use crate::core::runner;
 use crate::core::utils::{resolved_command, strip_ansi};
 use anyhow::Result;
 use regex::Regex;
+use std::sync::LazyLock;
 
 const MAX_FAILURES_SHOWN: usize = 20;
 const MAX_DIFF_LINES_PER_FAILURE: usize = 6;
+
+// Matches a status line. Anchor: either start-of-line ("FAIL desc [x.phpt]")
+// or immediately after the test bracket ("TEST N/M [x.phpt]PASS desc [x.phpt]").
+// We only accept the token after `]` or at line start so that prose like
+// "FAILED TEST SUMMARY" does not match.
+static STATUS_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?:^|\])(PASS|FAIL|SKIP|BORK|WARN|XLEAK|LEAK|XFAIL)\s+(.*?)\s*\[([^\[\]]+\.phpt)\]")
+        .unwrap()
+});
+static STAT_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"^\s*(Tests passed|Tests failed|Tests skipped|Tests warned|Expected fail|Expected leak|Tests leaked|Tests borked)\s*:\s*(\d+)",
+    )
+    .unwrap()
+});
+static NUMBER_OF_TESTS_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\s*Number of tests\s*:\s*(\d+)").unwrap());
+static TIME_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\s*Time taken\s*:\s*([0-9.]+)").unwrap());
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Status {
@@ -159,25 +179,6 @@ impl Parsed {
 }
 
 fn parse(stripped: &str) -> Parsed {
-    lazy_static::lazy_static! {
-        // Matches a status line. Anchor: either start-of-line ("FAIL desc [x.phpt]")
-        // or immediately after the test bracket ("TEST N/M [x.phpt]PASS desc [x.phpt]").
-        // We only accept the token after `]` or at line start so that prose like
-        // "FAILED TEST SUMMARY" does not match.
-        static ref STATUS_RE: Regex = Regex::new(
-            r"(?:^|\])(PASS|FAIL|SKIP|BORK|WARN|XLEAK|LEAK|XFAIL)\s+(.*?)\s*\[([^\[\]]+\.phpt)\]"
-        ).unwrap();
-        static ref STAT_RE: Regex = Regex::new(
-            r"^\s*(Tests passed|Tests failed|Tests skipped|Tests warned|Expected fail|Expected leak|Tests leaked|Tests borked)\s*:\s*(\d+)"
-        ).unwrap();
-        static ref NUMBER_OF_TESTS_RE: Regex = Regex::new(
-            r"^\s*Number of tests\s*:\s*(\d+)"
-        ).unwrap();
-        static ref TIME_RE: Regex = Regex::new(
-            r"^\s*Time taken\s*:\s*([0-9.]+)"
-        ).unwrap();
-    }
-
     let mut p = Parsed::default();
     let mut diff_buf: Vec<String> = Vec::new();
     let mut diff_total: usize = 0;

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -584,8 +584,7 @@ pub const RULES: &[RtkRule] = &[
         rewrite_prefixes: &["php run-tests.php"],
         category: "Tests",
         savings_pct: 99.0,
-        subcmd_savings: &[],
-        subcmd_status: &[],
+        ..RtkRule::DEFAULT
     },
     RtkRule {
         pattern: r"^(?:php\s+)?(?:\./)?(?:(?:vendor/)?bin/)?phpunit(?:\s|$)",


### PR DESCRIPTION
`develop` does not build since 2201905 (`feat(phpt): add PHP .phpt filter for php-src run-tests.php`, #1503). `cargo clippy --all-targets` fails with 7 errors.

## What broke

**1. `lazy_static` is not a dependency.**

`parse()` in `src/cmds/php/phpt_cmd.rs` declared its four regexes inside a `lazy_static::lazy_static!` block. The branch carried a matching `Cargo.toml`/`Cargo.lock` entry, but the manifest side did not survive the merge, so the crate is unresolved:

```
error[E0433]: cannot find module or crate `lazy_static` in this scope
   --> src/cmds/php/phpt_cmd.rs:162:5
```

…plus four `E0425 cannot find value STATUS_RE / NUMBER_OF_TESTS_RE / TIME_RE / STAT_RE` and one `unused import: regex::Regex` falling out of it.

Rather than re-add the crate, the regexes are hoisted to module-level `LazyLock<Regex>` statics — that's the mandated pattern in `.claude/rules/rust-patterns.md` and what every other filter in `src/cmds/php/` already does. The patterns and the comment explaining the `STATUS_RE` anchoring are unchanged.

**2. A `RtkRule` initializer that doesn't defer to `DEFAULT`.**

The `rtk phpt` rule listed `subcmd_savings` and `subcmd_status` explicitly instead of closing with `..RtkRule::DEFAULT`, so it missed `pipeline_final_safe` — a field develop added to `RtkRule` while the phpt branch was open:

```
error[E0063]: missing field `pipeline_final_safe` in initializer of `discover::rules::RtkRule`
   --> src/discover/rules.rs:581:5
```

Now spelled `..RtkRule::DEFAULT` like its neighbours. `phpt` is not pipeline-final safe (only `grep` and `rg` are), and `DEFAULT` already carries `false`, so behaviour is identical to what the phpt branch intended.

## Verification

```
cargo fmt --all && cargo clippy --all-targets && cargo test --all
```

Clean: zero clippy warnings, 2882 unit tests + all integration tests passing, including the phpt filter's own units, its insta snapshot, and its token-savings assertion.

No filter behaviour changes — this is a build fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)