### PR TITLE
fix(build): unbreak develop — undeclared lazy_static and a stale rule literal

### DIFF
--- a/src/cmds/php/phpt_cmd.rs
+++ b/src/cmds/php/phpt_cmd.rs
@@ -12,6 +12,7 @@ use crate::core::runner;
 use crate::core::utils::{resolved_command, strip_ansi};
 use anyhow::Result;
 use regex::Regex;
+use std::sync::LazyLock;
 
 const MAX_FAILURES_SHOWN: usize = 20;
 const MAX_DIFF_LINES_PER_FAILURE: usize = 6;
@@ -159,24 +160,26 @@ impl Parsed {
 }
 
 fn parse(stripped: &str) -> Parsed {
-    lazy_static::lazy_static! {
-        // Matches a status line. Anchor: either start-of-line ("FAIL desc [x.phpt]")
-        // or immediately after the test bracket ("TEST N/M [x.phpt]PASS desc [x.phpt]").
-        // We only accept the token after `]` or at line start so that prose like
-        // "FAILED TEST SUMMARY" does not match.
-        static ref STATUS_RE: Regex = Regex::new(
-            r"(?:^|\])(PASS|FAIL|SKIP|BORK|WARN|XLEAK|LEAK|XFAIL)\s+(.*?)\s*\[([^\[\]]+\.phpt)\]"
-        ).unwrap();
-        static ref STAT_RE: Regex = Regex::new(
-            r"^\s*(Tests passed|Tests failed|Tests skipped|Tests warned|Expected fail|Expected leak|Tests leaked|Tests borked)\s*:\s*(\d+)"
-        ).unwrap();
-        static ref NUMBER_OF_TESTS_RE: Regex = Regex::new(
-            r"^\s*Number of tests\s*:\s*(\d+)"
-        ).unwrap();
-        static ref TIME_RE: Regex = Regex::new(
-            r"^\s*Time taken\s*:\s*([0-9.]+)"
-        ).unwrap();
-    }
+    // Matches a status line. Anchor: either start-of-line ("FAIL desc [x.phpt]")
+    // or immediately after the test bracket ("TEST N/M [x.phpt]PASS desc [x.phpt]").
+    // We only accept the token after `]` or at line start so that prose like
+    // "FAILED TEST SUMMARY" does not match.
+    static STATUS_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?:^|\])(PASS|FAIL|SKIP|BORK|WARN|XLEAK|LEAK|XFAIL)\s+(.*?)\s*\[([^\[\]]+\.phpt)\]",
+        )
+        .unwrap()
+    });
+    static STAT_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"^\s*(Tests passed|Tests failed|Tests skipped|Tests warned|Expected fail|Expected leak|Tests leaked|Tests borked)\s*:\s*(\d+)",
+        )
+        .unwrap()
+    });
+    static NUMBER_OF_TESTS_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^\s*Number of tests\s*:\s*(\d+)").unwrap());
+    static TIME_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^\s*Time taken\s*:\s*([0-9.]+)").unwrap());
 
     let mut p = Parsed::default();
     let mut diff_buf: Vec<String> = Vec::new();

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -584,8 +584,7 @@ pub const RULES: &[RtkRule] = &[
         rewrite_prefixes: &["php run-tests.php"],
         category: "Tests",
         savings_pct: 99.0,
-        subcmd_savings: &[],
-        subcmd_status: &[],
+        ..RtkRule::DEFAULT
     },
     RtkRule {
         pattern: r"^(?:php\s+)?(?:\./)?(?:(?:vendor/)?bin/)?phpunit(?:\s|$)",


### PR DESCRIPTION
**`develop` does not compile at `e8541d1`.** Every open PR's CI is red until this lands, and every rebase targets a broken base.

```
error[E0433]: cannot find module or crate `lazy_static`
   --> src/cmds/php/phpt_cmd.rs:162:5
error[E0063]: missing field `pipeline_final_safe` in initializer of `RtkRule`
   --> src/discover/rules.rs:581:5
```

Two independent causes, both surfacing from #1503 meeting changes that were green on their own branches.

## 1. `lazy_static` is not a dependency

`phpt_cmd::parse` calls `lazy_static::lazy_static!`, but `lazy_static` appears nowhere in `Cargo.toml`.

Converted to `LazyLock<Regex>` rather than adding the crate, because that is what `.claude/rules/rust-patterns.md` already mandates:

> **Lazy regex** — Put fixed patterns reused across calls in `LazyLock<Regex>`

It was the only `lazy_static` reference in the tree, so nothing else needed touching and no dependency is added.

## 2. A rule literal that could not survive a new field

The phpt `RtkRule` spelled out all seven fields instead of ending with `..RtkRule::DEFAULT` like every neighbouring rule. When `pipeline_final_safe` was added to the struct, that literal stopped compiling.

Neither side could have caught this alone — the branch adding the field was green, and the branch adding the rule was green; only the merge breaks. Using the spread fixes it now *and* stops the next added field from doing the same thing again.

`savings_pct: 99.0` is kept explicit since it differs from `DEFAULT`'s 60.0.

## Verification

`cargo fmt --all --check`, `cargo clippy --all-targets` (zero warnings) and `cargo test --all` all clean on this branch. On `e8541d1` itself, `cargo build` fails outright.

No behaviour change: the four regexes are byte-identical, and `..RtkRule::DEFAULT` supplies exactly the values the literal had been writing by hand.
