### PR TITLE
fix(phpt): use LazyLock and RtkRule::DEFAULT so develop builds

### DIFF
--- a/src/cmds/php/phpt_cmd.rs
+++ b/src/cmds/php/phpt_cmd.rs
@@ -12,6 +12,7 @@ use crate::core::runner;
 use crate::core::utils::{resolved_command, strip_ansi};
 use anyhow::Result;
 use regex::Regex;
+use std::sync::LazyLock;
 
 const MAX_FAILURES_SHOWN: usize = 20;
 const MAX_DIFF_LINES_PER_FAILURE: usize = 6;
@@ -159,24 +160,26 @@ impl Parsed {
 }
 
 fn parse(stripped: &str) -> Parsed {
-    lazy_static::lazy_static! {
+    static STATUS_RE: LazyLock<Regex> = LazyLock::new(|| {
         // Matches a status line. Anchor: either start-of-line ("FAIL desc [x.phpt]")
         // or immediately after the test bracket ("TEST N/M [x.phpt]PASS desc [x.phpt]").
         // We only accept the token after `]` or at line start so that prose like
         // "FAILED TEST SUMMARY" does not match.
-        static ref STATUS_RE: Regex = Regex::new(
-            r"(?:^|\])(PASS|FAIL|SKIP|BORK|WARN|XLEAK|LEAK|XFAIL)\s+(.*?)\s*\[([^\[\]]+\.phpt)\]"
-        ).unwrap();
-        static ref STAT_RE: Regex = Regex::new(
-            r"^\s*(Tests passed|Tests failed|Tests skipped|Tests warned|Expected fail|Expected leak|Tests leaked|Tests borked)\s*:\s*(\d+)"
-        ).unwrap();
-        static ref NUMBER_OF_TESTS_RE: Regex = Regex::new(
-            r"^\s*Number of tests\s*:\s*(\d+)"
-        ).unwrap();
-        static ref TIME_RE: Regex = Regex::new(
-            r"^\s*Time taken\s*:\s*([0-9.]+)"
-        ).unwrap();
-    }
+        Regex::new(
+            r"(?:^|\])(PASS|FAIL|SKIP|BORK|WARN|XLEAK|LEAK|XFAIL)\s+(.*?)\s*\[([^\[\]]+\.phpt)\]",
+        )
+        .unwrap()
+    });
+    static STAT_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"^\s*(Tests passed|Tests failed|Tests skipped|Tests warned|Expected fail|Expected leak|Tests leaked|Tests borked)\s*:\s*(\d+)",
+        )
+        .unwrap()
+    });
+    static NUMBER_OF_TESTS_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^\s*Number of tests\s*:\s*(\d+)").unwrap());
+    static TIME_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^\s*Time taken\s*:\s*([0-9.]+)").unwrap());
 
     let mut p = Parsed::default();
     let mut diff_buf: Vec<String> = Vec::new();

--- a/src/discover/rules.rs
+++ b/src/discover/rules.rs
@@ -584,8 +584,7 @@ pub const RULES: &[RtkRule] = &[
         rewrite_prefixes: &["php run-tests.php"],
         category: "Tests",
         savings_pct: 99.0,
-        subcmd_savings: &[],
-        subcmd_status: &[],
+        ..RtkRule::DEFAULT
     },
     RtkRule {
         pattern: r"^(?:php\s+)?(?:\./)?(?:(?:vendor/)?bin/)?phpunit(?:\s|$)",


### PR DESCRIPTION
`develop` does not compile since #1503 merged (`e8541d1`). Release PR #3721 and every build job fail on it.

PR #1503 was authored 2026-04-24 and merged 2026-08-31 without a rebase. Two things changed underneath it in that window:

- `5269df7` removed `lazy_static` from `Cargo.toml` in favour of `LazyLock`. `phpt_cmd.rs` still calls `lazy_static::lazy_static!`, so the macro fails to expand and `STATUS_RE`, `STAT_RE`, `NUMBER_OF_TESTS_RE` and `TIME_RE` are never defined.
- `RtkRule` gained `pipeline_final_safe`. The new rule in `rules.rs` spells its fields out rather than using `..RtkRule::DEFAULT`, so it misses the new field.

This repairs @iliaal's feature rather than reverting it — the phpt filter itself is fine, only these two touchpoints went stale.

## Changes

- `phpt_cmd.rs`: the four statics become `LazyLock`, matching the other 25 files and the `LazyLock` rule in CLAUDE.md.
- `rules.rs`: use `..RtkRule::DEFAULT` like every neighbouring entry, so future fields do not break it again.

## Verification

```
before: e4b9705 (pre-merge develop)  0 errors
        e8541d1 (merge, = develop)   7 errors
after:  this branch                  0 errors
```

`cargo fmt --all --check` clean, `cargo clippy --all-targets` 0 warnings, `cargo test --all` **2965 passed, 0 failed** — the phpt tests run for the first time, since compilation previously stopped before them.

## Process note

Checks on #1503 passed against April's `develop`, not the current one. Requiring branches to be up to date before merge would prevent this class.