### PR TITLE
docs(config): scope the exclude_commands coverage claim to what is peeled

### DIFF
--- a/docs/guide/getting-started/configuration.md
+++ b/docs/guide/getting-started/configuration.md
@@ -96,11 +96,19 @@ Patterns match against the full command after stripping env prefixes (`sudo`, `V
 
 Subcommand patterns work too: `"git push"` excludes `git push origin main` but not `git status`.
 
-An entry names a tool RTK has a filter for, and that tool is covered however it is invoked.
-Before matching, RTK peels the wrapper, interpreter or path off the command and matches what is
-left, so `"playwright"` excludes `playwright test`, `npx playwright test` and
-`pnpm exec playwright test` alike; `"pytest"` also covers `python3 -m pytest tests/`, and
-`"phpunit"` covers `vendor/bin/phpunit` and `php vendor/bin/phpunit`.
+An entry names a tool RTK has a filter for, and covers the wrapper, interpreter and path spellings
+of it. Before matching, RTK peels those off the command and matches what is left, so
+`"playwright"` excludes `playwright test`, `npx playwright test` and `pnpm exec playwright test`
+alike; `"pytest"` also covers `python3 -m pytest tests/`, and `"phpunit"` covers
+`vendor/bin/phpunit` and `php vendor/bin/phpunit`.
+
+Three spellings are not peeled yet, and still rewrite despite a matching entry:
+
+| Entry | Command | Why |
+|---|---|---|
+| `"head"`, `"tail"` | `head -20 f`, `tail -n 5 f` | The line-range form takes a fast path that returns before the exclusion is consulted ([#2823](https://github.com/rtk-ai/rtk/issues/2823)). Without a line range, `head f` is excluded normally. |
+| `"gradlew"`, `"mvn"` | `gradlew.bat build`, `mvnw.cmd test` | Path stripping splits on `/`, so a `.bat`/`.cmd` spelling never reduces to the tool name. `./gradlew` and `gradlew` are both excluded ([#3617](https://github.com/rtk-ai/rtk/pull/3617)). |
+| `"golangci-lint"` | `golangci run ./...` | `golangci run` is one of the rule's own aliases and is kept whole, so it does not match the `golangci-lint` entry. Exclude `"golangci"` as well to cover it. |
 
 A tool RTK has no filter of its own for is matched as typed, because RTK only sees the wrapper:
 with `["my-tool"]`, `npx my-tool` still rewrites to `rtk npx my-tool`. Exclude `"npx"` to stop


### PR DESCRIPTION
Follow-up to #3749, addressing @aeppling's review nitpick. Docs only, no behaviour change.

## The problem

`configuration.md` claimed an excluded tool "is covered however it is invoked". The limits stated below it covered only tools without their own filter, plus the exactness guarantees — so three invocation forms of *filtered* tools were promised and not delivered.

## The fix

Scope the sentence to what is actually peeled, using @aeppling's suggested wording:

> An entry names a tool RTK has a filter for, and covers the wrapper, interpreter and path spellings of it.

Then table the three gaps rather than leaving them implied, each with its cause and tracking item.

## Verified

Every row checked against a build on `develop` at `e533c40` (the #3749 merge), by probing `rewrite_command` with the entry in place:

```
["head"]           head -20 f.txt          -> rtk read f.txt --max-lines 20   GAP
["head"]           head f.txt              -> excluded                        (no line range)
["tail"]           tail -n 5 f.txt         -> rtk read f.txt --tail-lines 5   GAP
["gradlew"]        gradlew.bat build       -> rtk gradlew build               GAP
["gradlew"]        ./gradlew build         -> excluded
["gradlew"]        gradlew build           -> excluded
["mvn"]            mvnw.cmd test           -> rtk mvn test                    GAP
["golangci-lint"]  golangci run ./...      -> rtk golangci-lint run ./...     GAP
["golangci-lint"]  golangci-lint run ./... -> excluded
```

`mvnw.cmd` is a fourth instance of the same `.bat`/`.cmd` cause as `gradlew.bat`, found while confirming row 2, so the table names both tools.

The documented workaround was verified too, since it is not symmetric:

```
["golangci"]                   golangci run ./...      -> excluded
["golangci"]                   golangci-lint run ./... -> rewritten   <- both entries needed
["golangci-lint", "golangci"]  both forms              -> excluded
```

## Causes

- **Rows 1** — the line-range form takes a fast path that returns before the exclusion check. Issue #2823; #3324 is the fix in flight.
- **Row 2** — `strip_absolute_path` splits on `/`, so a `.bat`/`.cmd` spelling is never reduced to the tool name. PR #3617 closes it.
- **Row 3** — `golangci run` is one of the rule's own `rewrite_prefixes` aliases, and `tool_portion` deliberately keeps a rule-owned subcommand whole so `golangci-lint run` does not collapse to `run`. Mapping aliases onto a canonical name would reintroduce the resolved-target matching #3749 rejected, so this is documented rather than fixed.

`docs/usage/FEATURES.md` needed no change — its French text was already scoped to "le wrapper, l'interpreteur ou le chemin".
