### PR TITLE
feat(tracking): add RTK_TIMINGS=1 per-stage timing breakdown on stderr

### DIFF
--- a/docs/guide/getting-started/configuration.md
+++ b/docs/guide/getting-started/configuration.md
@@ -62,7 +62,40 @@ For full details on what is collected, opt-out options, and GDPR rights, see [Te
 | `RTK_TEE_DIR` | Override the tee directory |
 | `RTK_TELEMETRY_DISABLED=1` | Disable telemetry |
 | `RTK_HOOK_AUDIT=1` | Enable hook audit logging |
+| `RTK_TIMINGS=1` | Print a per-stage timing breakdown to stderr after each command |
 | `SKIP_ENV_VALIDATION=1` | Skip env validation (useful with Next.js) |
+
+## Timing breakdown
+
+`rtk gain` records one duration per command, but it cannot say how much of a
+run was the wrapped command versus RTK itself. `RTK_TIMINGS=1` prints that
+split to stderr after each tracked command:
+
+```
+$ RTK_TIMINGS=1 rtk git status
+...
+rtk timings: total=41.2ms startup=2.9ms handler=37.8ms child=30.1ms spawns=2 filter=7.7ms track=0.5ms
+```
+
+- `total` — the whole process, start to this line
+- `startup` — CLI parsing, config, hook checks, before the command handler runs
+- `handler` — the span recorded in `rtk gain` analytics
+- `child` — wall time spent on spawned processes (`spawns` counts them). For
+  streaming commands this runs from spawn until output is drained, so it
+  includes RTK's concurrent reading and printing.
+- `filter` — derived as `handler - child`: RTK's own parsing, filtering, and
+  printing. Treat it as a floor — on streaming commands the overlapped work
+  sits in `child`.
+- `track` — the history-DB write, which runs after `handler` is measured
+
+The line goes to stderr only, so filtered stdout is unchanged. Commands that
+don't record analytics (`rtk gain`, `rtk --version`, `rtk run`, hook mode)
+print nothing.
+
+Note: coding agents capture stderr. With the RTK hook active, prefer setting
+`RTK_TIMINGS=1` per command in your own terminal over exporting it in your
+shell profile — otherwise the timing line lands in the agent's context on
+every rewritten command.
 
 ## Tee system
 

--- a/docs/usage/FEATURES.md
+++ b/docs/usage/FEATURES.md
@@ -1357,6 +1357,7 @@ exclude_commands = []       # Commandes a exclure de la recriture automatique
 | `RTK_TEE_DIR` | Surcharge le repertoire tee |
 | `RTK_TELEMETRY_DISABLED=1` | Desactiver la telemetrie |
 | `RTK_HOOK_AUDIT=1` | Activer l'audit du hook |
+| `RTK_TIMINGS=1` | Afficher sur stderr la repartition du temps par etape apres chaque commande |
 | `SKIP_ENV_VALIDATION=1` | Desactiver la validation d'env (Next.js, etc.) |
 
 ---

--- a/src/cmds/cloud/curl_cmd.rs
+++ b/src/cmds/cloud/curl_cmd.rs
@@ -37,7 +37,8 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     // survive intact. `String::from_utf8_lossy` would otherwise replace
     // every non-UTF-8 byte with U+FFFD (3 bytes), corrupting e.g. gzip
     // magic `1f 8b 08 00` into `1f ef bf bd 08 00` (#1087).
-    let output = cmd.output().context("Failed to run curl")?;
+    let output =
+        crate::core::timings::time_child(|| cmd.output()).context("Failed to run curl")?;
     let exit_code = output.status.code().unwrap_or(1);
 
     // Skip filtering on failure: curl can return HTML error bodies that would

--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -2636,10 +2636,9 @@ pub fn run_passthrough(args: &[OsString], global_args: &[String], verbose: u8) -
     if verbose > 0 {
         eprintln!("git passthrough: {:?}", args);
     }
-    let status = git_cmd(global_args)
-        .args(args)
-        .status()
-        .context("Failed to run git")?;
+    let status =
+        crate::core::timings::time_child(|| git_cmd(global_args).args(args).status())
+            .context("Failed to run git")?;
 
     let args_str = tracking::args_display(args);
     timer.track_passthrough(

--- a/src/cmds/python/uv_cmd.rs
+++ b/src/cmds/python/uv_cmd.rs
@@ -61,7 +61,8 @@ pub fn run(args: &[String], verbose: u8) -> Result<i32> {
     }
 
     if args.first().map(String::as_str) != Some("run") {
-        let status = cmd.status().context("Failed to run uv")?;
+        let status =
+            crate::core::timings::time_child(|| cmd.status()).context("Failed to run uv")?;
         timer.track_passthrough(&original_cmd, &format!("{rtk_cmd} (passthrough)"));
         return Ok(exit_code_from_status(&status, "uv"));
     }

--- a/src/cmds/system/find_cmd.rs
+++ b/src/cmds/system/find_cmd.rs
@@ -267,7 +267,8 @@ fn run_compress(
         cmd.arg("-type").arg(t);
     }
     cmd.arg("-print0").stdin(std::process::Stdio::inherit());
-    let output = cmd.output().context("Failed to execute find")?;
+    let output = crate::core::timings::time_child(|| cmd.output())
+        .context("Failed to execute find")?;
     let exit_code = crate::core::utils::exit_code_from_output(&output, "find");
     {
         let mut stderr = std::io::stderr().lock();

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -6,7 +6,7 @@
 
 Domain-agnostic building blocks with **no knowledge of any specific command, hook, or agent**. If a module references "git", "cargo", "claude", or any external tool by name, it does not belong here. Core is a leaf in the dependency graph — it is consumed by all other components but imports from none of them.
 
-Owns: configuration loading, token tracking persistence, TOML filter engine, tee output recovery, display formatting, telemetry, and shared utilities.
+Owns: configuration loading, token tracking persistence, TOML filter engine, tee output recovery, display formatting, telemetry, wall-clock stage timings (`RTK_TIMINGS`), and shared utilities.
 
 Does **not** own: command-specific filtering logic (that's `cmds/`), hook lifecycle management (that's `src/hooks/`), or analytics dashboards (that's `analytics/`).
 
@@ -114,6 +114,8 @@ Core provides infrastructure that `cmds/` and other components consume. These co
 ### Tracking (`TimedExecution`)
 
 Consumers must call `timer.track()` on **all** code paths — success, failure, and fallback. Calling `std::process::exit()` before `track()` loses metrics. The raw string passed to `track()` should include both stdout and stderr to produce accurate savings percentages.
+
+`track()`/`track_passthrough()` also emit the opt-in `RTK_TIMINGS=1` stderr breakdown (`timings::report`). Child time is attributed via the spawn helpers in `stream.rs`; a handler that spawns a process without going through them must wrap the spawn in `timings::time_child()` (or a `child_start`/`child_end` pair), or that child's runtime is misreported as `filter`.
 
 ### Tee (`tee_and_hint`)
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -11,6 +11,7 @@ pub mod stream;
 pub mod tee;
 pub mod telemetry;
 pub mod telemetry_cmd;
+pub mod timings;
 pub mod toml_filter;
 pub mod tracking;
 pub mod truncate;

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -301,7 +301,9 @@ pub fn run_streaming(
         };
         cmd.stdout(Stdio::inherit());
         cmd.stderr(Stdio::inherit());
+        let child_timer = super::timings::child_start();
         let status = cmd.status().context("Failed to spawn process")?;
+        super::timings::child_end(child_timer);
         return Ok(StreamResult {
             exit_code: status_to_exit_code(status),
             raw: String::new(),
@@ -331,6 +333,7 @@ pub fn run_streaming(
 
     let is_streaming = matches!(stdout_mode, FilterMode::Streaming(_));
 
+    let child_timer = super::timings::child_start();
     let mut child = ChildGuard(cmd.spawn().context("Failed to spawn process")?);
 
     let stdin_thread: Option<std::thread::JoinHandle<()>> = match stdin_mode {
@@ -525,6 +528,7 @@ pub fn run_streaming(
     }
 
     let status = child.0.wait().context("Failed to wait for child")?;
+    super::timings::child_end(child_timer);
     let exit_code = status_to_exit_code(status);
     let raw = format!("{}{}", raw_stdout, raw_stderr);
 
@@ -589,7 +593,9 @@ pub fn exec_capture_stdin(cmd: &mut Command) -> Result<CaptureResult> {
 /// used as the label so no call site has to pass one.
 fn capture(cmd: &mut Command) -> Result<CaptureResult> {
     let program = cmd.get_program().to_string_lossy().into_owned();
+    let child_timer = super::timings::child_start();
     let output = cmd.output().context("Failed to execute command")?;
+    super::timings::child_end(child_timer);
     let exit_code = super::utils::exit_code_from_output(&output, &program);
     Ok(CaptureResult {
         stdout: super::utils::decode_process_output(&output.stdout),

--- a/src/core/timings.rs
+++ b/src/core/timings.rs
@@ -1,0 +1,165 @@
+//! Opt-in wall-clock stage breakdown (`RTK_TIMINGS=1`), printed to stderr.
+//!
+//! The recorded `exec_time_ms` starts inside each command handler, so it can
+//! never say how much of a run was the wrapped command versus rtk itself.
+//! With `RTK_TIMINGS=1`, every tracked command prints one stderr line after
+//! it finishes:
+//!
+//! ```text
+//! rtk timings: total=41.2ms startup=2.9ms handler=37.8ms child=30.1ms spawns=2 filter=7.7ms track=0.5ms
+//! ```
+//!
+//! - `total`   — process start to this line
+//! - `startup` — process start to the handler's timer: CLI parse, config, hook checks
+//! - `handler` — the span recorded as `exec_time_ms`
+//! - `child`   — wall time spent on spawned processes (`spawns` counts them).
+//!   For streaming commands this runs from spawn until output is drained, so
+//!   it includes rtk's concurrent reading and printing.
+//! - `filter`  — derived as `handler - child`: rtk's own parsing, filtering,
+//!   and printing. A floor, not a measurement — on streaming commands the
+//!   overlapped work sits in `child`.
+//! - `track`   — the history-DB write, which runs after `exec_time_ms` is read
+//!
+//! Stderr-only, so filtered stdout stays a valid subset of the wrapped tool's
+//! output (Transparency). Disabled, every hook is a single boolean check
+//! (Zero Overhead). Commands that never call [`super::tracking::TimedExecution`]
+//! (`--version`, `gain`, `run`, hook mode) print nothing.
+//!
+//! Handlers that spawn a child without going through `stream.rs` must wrap
+//! the spawn in [`time_child`] (or a [`child_start`]/[`child_end`] pair), or
+//! that child's runtime is misreported as `filter`.
+
+use std::io::Write;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::LazyLock;
+use std::time::{Duration, Instant};
+
+static ENABLED: LazyLock<bool> =
+    LazyLock::new(|| std::env::var("RTK_TIMINGS").as_deref() == Ok("1"));
+
+static PROCESS_START: LazyLock<Instant> = LazyLock::new(Instant::now);
+
+static CHILD_MICROS: AtomicU64 = AtomicU64::new(0);
+static CHILD_SPAWNS: AtomicU64 = AtomicU64::new(0);
+
+pub fn enabled() -> bool {
+    *ENABLED
+}
+
+/// Pin the process-start instant. Call first thing in `main()`; without it,
+/// `total` and `startup` in [`report`] are meaningless (near-zero).
+pub fn mark_process_start() {
+    LazyLock::force(&PROCESS_START);
+}
+
+/// Start timing a child process. `None` when timings are disabled.
+pub fn child_start() -> Option<Instant> {
+    enabled().then(Instant::now)
+}
+
+/// Accumulate the wall time since [`child_start`]. No-op on `None`.
+pub fn child_end(started: Option<Instant>) {
+    if let Some(t) = started {
+        CHILD_MICROS.fetch_add(t.elapsed().as_micros() as u64, Ordering::Relaxed);
+        CHILD_SPAWNS.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Run `f` (a child spawn-and-wait) with its wall time attributed to `child`.
+pub fn time_child<T>(f: impl FnOnce() -> T) -> T {
+    let started = child_start();
+    let result = f();
+    child_end(started);
+    result
+}
+
+/// Print the breakdown line. Called by `TimedExecution` after the history-DB
+/// write; `handler_started` is its start instant, `handler` the span recorded
+/// as `exec_time_ms`, `track` the DB-write duration. Drains the child
+/// accumulators so each report covers one command.
+pub fn report(handler_started: Instant, handler: Duration, track: Duration) {
+    if !enabled() {
+        return;
+    }
+    let child = Duration::from_micros(CHILD_MICROS.swap(0, Ordering::Relaxed));
+    let spawns = CHILD_SPAWNS.swap(0, Ordering::Relaxed);
+    // Not eprintln!: a write failure (e.g. ENOSPC on stderr) must not turn
+    // into a panic that replaces the wrapped command's exit code.
+    let _ = writeln!(
+        std::io::stderr().lock(),
+        "{}",
+        format_report(
+            PROCESS_START.elapsed(),
+            handler_started.duration_since(*PROCESS_START),
+            handler,
+            child,
+            spawns,
+            track,
+        )
+    );
+}
+
+fn format_report(
+    total: Duration,
+    startup: Duration,
+    handler: Duration,
+    child: Duration,
+    spawns: u64,
+    track: Duration,
+) -> String {
+    let ms = |d: Duration| d.as_secs_f64() * 1000.0;
+    format!(
+        "rtk timings: total={:.1}ms startup={:.1}ms handler={:.1}ms child={:.1}ms spawns={} filter={:.1}ms track={:.1}ms",
+        ms(total),
+        ms(startup),
+        ms(handler),
+        ms(child),
+        spawns,
+        ms(handler.saturating_sub(child)),
+        ms(track),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_report_breakdown_line() {
+        let line = format_report(
+            Duration::from_micros(41_200),
+            Duration::from_micros(2_900),
+            Duration::from_micros(37_800),
+            Duration::from_micros(30_100),
+            2,
+            Duration::from_micros(500),
+        );
+        assert_eq!(
+            line,
+            "rtk timings: total=41.2ms startup=2.9ms handler=37.8ms child=30.1ms spawns=2 filter=7.7ms track=0.5ms"
+        );
+    }
+
+    #[test]
+    fn test_format_report_filter_saturates_when_child_exceeds_handler() {
+        // Streaming passthrough can wait on a child slightly past the handler
+        // span boundary; filter must clamp to 0, never underflow.
+        let line = format_report(
+            Duration::from_millis(10),
+            Duration::from_millis(1),
+            Duration::from_millis(5),
+            Duration::from_millis(6),
+            1,
+            Duration::ZERO,
+        );
+        assert!(line.contains("filter=0.0ms"), "got: {line}");
+    }
+
+    #[test]
+    fn test_time_child_returns_closure_result() {
+        // Assumes RTK_TIMINGS is unset in the test environment (like
+        // hook_cmd's env-var tests); with it set, parallel stream.rs tests
+        // share the global accumulators, so only the return value is checked.
+        assert_eq!(time_child(|| 7), 7);
+    }
+}

--- a/src/core/tracking.rs
+++ b/src/core/tracking.rs
@@ -1391,10 +1391,12 @@ impl TimedExecution {
     /// timer.track("ls -la", "rtk ls", input, output);
     /// ```
     pub fn track(&self, original_cmd: &str, rtk_cmd: &str, input: &str, output: &str) {
-        let elapsed_ms = self.start.elapsed().as_millis() as u64;
+        let handler = self.start.elapsed();
+        let elapsed_ms = handler.as_millis() as u64;
         let input_tokens = estimate_tokens(input);
         let output_tokens = estimate_tokens(output);
 
+        let track_timer = super::timings::enabled().then(Instant::now);
         if let Ok(tracker) = Tracker::new() {
             let _ = tracker.record(
                 original_cmd,
@@ -1404,6 +1406,11 @@ impl TimedExecution {
                 elapsed_ms,
             );
         }
+        super::timings::report(
+            self.start,
+            handler,
+            track_timer.map(|t| t.elapsed()).unwrap_or_default(),
+        );
     }
 
     /// Track passthrough commands (timing-only, no token counting).
@@ -1427,11 +1434,18 @@ impl TimedExecution {
     /// timer.track_passthrough("git tag", "rtk git tag");
     /// ```
     pub fn track_passthrough(&self, original_cmd: &str, rtk_cmd: &str) {
-        let elapsed_ms = self.start.elapsed().as_millis() as u64;
+        let handler = self.start.elapsed();
+        let elapsed_ms = handler.as_millis() as u64;
         // input_tokens=0, output_tokens=0 won't dilute savings statistics
+        let track_timer = super::timings::enabled().then(Instant::now);
         if let Ok(tracker) = Tracker::new() {
             let _ = tracker.record(original_cmd, rtk_cmd, 0, 0, elapsed_ms);
         }
+        super::timings::report(
+            self.start,
+            handler,
+            track_timer.map(|t| t.elapsed()).unwrap_or_default(),
+        );
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1363,22 +1363,24 @@ fn run_fallback(parse_error: clap::Error) -> Result<i32> {
 
     if let Some(filter) = toml_match {
         // TOML match: capture stdout for filtering
-        let result = if filter.filter_stderr {
-            // Merge stderr into stdout so the filter can strip banners emitted by tools like liquibase
-            core::utils::resolved_command(&args[0])
-                .args(&args[1..])
-                .stdin(std::process::Stdio::inherit())
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::piped()) // captured for merging
-                .output()
-        } else {
-            core::utils::resolved_command(&args[0])
-                .args(&args[1..])
-                .stdin(std::process::Stdio::inherit())
-                .stdout(std::process::Stdio::piped()) // capture
-                .stderr(std::process::Stdio::inherit()) // stderr always direct
-                .output()
-        };
+        let result = core::timings::time_child(|| {
+            if filter.filter_stderr {
+                // Merge stderr into stdout so the filter can strip banners emitted by tools like liquibase
+                core::utils::resolved_command(&args[0])
+                    .args(&args[1..])
+                    .stdin(std::process::Stdio::inherit())
+                    .stdout(std::process::Stdio::piped())
+                    .stderr(std::process::Stdio::piped()) // captured for merging
+                    .output()
+            } else {
+                core::utils::resolved_command(&args[0])
+                    .args(&args[1..])
+                    .stdin(std::process::Stdio::inherit())
+                    .stdout(std::process::Stdio::piped()) // capture
+                    .stderr(std::process::Stdio::inherit()) // stderr always direct
+                    .output()
+            }
+        });
 
         match result {
             Ok(output) => {
@@ -1441,12 +1443,14 @@ fn run_fallback(parse_error: clap::Error) -> Result<i32> {
         }
     } else {
         // No TOML match: original passthrough behaviour (Stdio::inherit, streaming)
-        let status = core::utils::resolved_command(&args[0])
-            .args(&args[1..])
-            .stdin(std::process::Stdio::inherit())
-            .stdout(std::process::Stdio::inherit())
-            .stderr(std::process::Stdio::inherit())
-            .status();
+        let status = core::timings::time_child(|| {
+            core::utils::resolved_command(&args[0])
+                .args(&args[1..])
+                .stdin(std::process::Stdio::inherit())
+                .stdout(std::process::Stdio::inherit())
+                .stderr(std::process::Stdio::inherit())
+                .status()
+        });
 
         match status {
             Ok(s) => {
@@ -1571,6 +1575,8 @@ fn validate_pnpm_filters(filters: &[String], command: &PnpmCommands) -> Option<S
 }
 
 fn main() {
+    core::timings::mark_process_start();
+
     // Reset SIGPIPE to default handler so writing to a closed pipe
     // e.g `rtk git log | head` exits silently instead of panicking.
     // Rust ignores SIGPIPE by default and with panic="abort" in the
@@ -2381,7 +2387,8 @@ fn run_cli() -> Result<i32> {
                                 for arg in &args {
                                     cmd.arg(arg);
                                 }
-                                let status = cmd.status().context("Failed to run npx prisma")?;
+                                let status = core::timings::time_child(|| cmd.status())
+                                    .context("Failed to run npx prisma")?;
                                 let args_str = args.join(" ");
                                 timer.track_passthrough(
                                     &format!("npx {}", args_str),
@@ -2392,10 +2399,10 @@ fn run_cli() -> Result<i32> {
                         }
                     } else {
                         let timer = core::tracking::TimedExecution::start();
-                        let status = core::utils::resolved_command("npx")
-                            .arg("prisma")
-                            .status()
-                            .context("Failed to run npx prisma")?;
+                        let status = core::timings::time_child(|| {
+                            core::utils::resolved_command("npx").arg("prisma").status()
+                        })
+                        .context("Failed to run npx prisma")?;
                         timer.track_passthrough("npx prisma", "rtk npx prisma (passthrough)");
                         core::utils::exit_code_from_status(&status, "npx prisma")
                     }
@@ -2636,6 +2643,7 @@ fn run_cli() -> Result<i32> {
                 }
             }
 
+            let child_timer = core::timings::child_start();
             let mut child = ChildGuard(Some(
                 core::utils::resolved_command(cmd_name.as_ref())
                     .args(&cmd_args)
@@ -2712,6 +2720,7 @@ fn run_cli() -> Result<i32> {
                 .context("Child process missing")?
                 .wait()
                 .context(format!("Failed waiting for command: {}", cmd_name))?;
+            core::timings::child_end(child_timer);
 
             let stdout_bytes = stdout_handle
                 .join()

--- a/tests/timings_integration_test.rs
+++ b/tests/timings_integration_test.rs
@@ -1,0 +1,90 @@
+//! End-to-end contract for the `RTK_TIMINGS=1` stderr breakdown:
+//! exactly one line, on stderr only, absent when the variable is unset,
+//! with child time attributed on both the central and the passthrough
+//! spawn paths.
+
+use std::process::Command;
+
+fn rtk(dir: &std::path::Path, timings: bool, args: &[&str]) -> std::process::Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_rtk"));
+    cmd.args(args)
+        .current_dir(dir)
+        // Keep analytics writes out of the developer's real history DB.
+        .env("RTK_DB_PATH", dir.join("history.db"))
+        .env_remove("RTK_TIMINGS");
+    if timings {
+        cmd.env("RTK_TIMINGS", "1");
+    }
+    cmd.output().expect("failed to run rtk binary")
+}
+
+fn timings_lines(output: &std::process::Output) -> Vec<String> {
+    String::from_utf8_lossy(&output.stderr)
+        .lines()
+        .filter(|l| l.starts_with("rtk timings: "))
+        .map(str::to_string)
+        .collect()
+}
+
+fn temp_dir(name: &str) -> std::path::PathBuf {
+    let dir =
+        std::env::temp_dir().join(format!("rtk_timings_test_{}_{}", name, std::process::id()));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+#[test]
+fn timings_line_present_once_on_stderr_and_absent_when_unset() {
+    let dir = temp_dir("wc");
+    std::fs::write(dir.join("f.txt"), "one\ntwo\n").unwrap();
+
+    let on = rtk(&dir, true, &["wc", "-l", "f.txt"]);
+    let lines = timings_lines(&on);
+    assert_eq!(
+        lines.len(),
+        1,
+        "stderr: {}",
+        String::from_utf8_lossy(&on.stderr)
+    );
+    let line = &lines[0];
+    for key in [
+        "total=", "startup=", "handler=", "child=", "spawns=", "filter=", "track=",
+    ] {
+        assert!(line.contains(key), "missing {key} in: {line}");
+    }
+    assert!(
+        !String::from_utf8_lossy(&on.stdout).contains("rtk timings:"),
+        "timings line leaked to stdout"
+    );
+
+    let off = rtk(&dir, false, &["wc", "-l", "f.txt"]);
+    assert!(timings_lines(&off).is_empty());
+    assert_eq!(
+        on.stdout, off.stdout,
+        "stdout must be identical with timings on"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn timings_attributes_child_time_on_passthrough_paths() {
+    // `git version` is an unsupported subcommand, so it takes the
+    // run_passthrough spawn that bypasses stream.rs.
+    let dir = temp_dir("passthrough");
+    let out = rtk(&dir, true, &["git", "version"]);
+    let lines = timings_lines(&out);
+    assert_eq!(
+        lines.len(),
+        1,
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !lines[0].contains("spawns=0"),
+        "passthrough child not attributed: {}",
+        lines[0]
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
rtk gain records one duration per command, so it cannot say how much of a run was the wrapped command versus rtk itself. With RTK_TIMINGS=1, every tracked command now prints one stderr line after it finishes:

  rtk timings: total=41.2ms startup=2.9ms handler=37.8ms child=30.1ms spawns=2 filter=7.7ms track=0.5ms

startup covers everything before the handler's timer, handler is the span recorded as exec_time_ms, child accumulates wall time across child spawns (spawns exposes double-spawn paths such as compact git status), filter is derived as handler minus child, and track is the history-DB write that runs after exec_time_ms is read.

Child time is attributed in the central stream.rs exec paths and at the direct-spawn sites inside tracked handlers (proxy, the parse-failure fallback, git/uv/npx-prisma passthrough, curl, delegated find) via a timings::time_child helper, so a slow wrapped command is never misreported as rtk filter cost. The report writes with an error-swallowing writeln, not eprintln, so a failing stderr cannot replace the wrapped command's exit code with an abort.

Stderr-only so filtered stdout stays a valid subset of the wrapped tool's output; disabled (the default), every hook is a single boolean check and hyperfine shows no measurable difference against the unpatched binary. Docs cover the streaming-mode child/filter semantics and warn against exporting the variable globally under an active hook. An integration test locks the stderr contract: exactly one line when enabled, none when unset, stdout byte-identical either way.

## Summary
<!-- What does this PR do? Keep it short (1-3 bullet points). -->

-

## Test plan
<!-- How did you verify this works? -->

- [ ] `cargo fmt --all && cargo clippy --all-targets && cargo test`
- [ ] Manual testing: `rtk <command>` output inspected

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
