### PR TITLE
test(filters): assert all builtin toml match_command patterns are anchored

### DIFF
--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -2032,19 +2032,64 @@ match_command = "^make\\b"
         );
     }
 
-    /// Verify that every built-in filter's match_command starts with `^`.
-    /// Prevents substring misfires where an unanchored match matches a subcommand or path in the middle of a command line.
+    /// Verify that every built-in filter is anchored across every top-level branch.
     #[test]
     fn test_builtin_all_filters_match_command_anchored() {
+        fn has_top_level_alternation(pattern: &str) -> bool {
+            let mut depth = 0;
+            let mut escaped = false;
+            let mut in_class = false;
+
+            for character in pattern.chars() {
+                if escaped {
+                    escaped = false;
+                    continue;
+                }
+                match character {
+                    '\\' => escaped = true,
+                    '[' if !in_class => in_class = true,
+                    ']' if in_class => in_class = false,
+                    '(' if !in_class => depth += 1,
+                    ')' if !in_class => depth -= 1,
+                    '|' if !in_class && depth == 0 => return true,
+                    _ => {}
+                }
+            }
+
+            false
+        }
+
         let filters = make_filters(BUILTIN_TOML);
         for filter in &filters {
+            let pattern = filter.match_regex.as_str();
             assert!(
-                filter.match_regex.as_str().starts_with('^'),
-                "Filter '{}' has match_command '{}' which does not start with '^'",
+                pattern.starts_with('^') && !has_top_level_alternation(pattern),
+                "Filter '{}' has match_command '{}' with an unanchored top-level branch",
                 filter.name,
-                filter.match_regex.as_str()
+                pattern
             );
         }
+
+        assert!(has_top_level_alternation(r"^liquibase\b|/liquibase\b"));
+        assert!(!has_top_level_alternation(r"^(liquibase\b|/liquibase\b)"));
+    }
+
+    #[test]
+    fn test_builtin_liquibase_filter_does_not_match_wrapped_or_path_commands() {
+        let filters = make_filters(BUILTIN_TOML);
+        let liquibase = filters
+            .iter()
+            .find(|filter| filter.name == "liquibase")
+            .expect("built-in liquibase filter should exist");
+
+        assert!(liquibase.match_regex.is_match("liquibase update"));
+        assert!(!liquibase
+            .match_regex
+            .is_match("timeout 5 /usr/bin/liquibase update"));
+        assert!(!liquibase
+            .match_regex
+            .is_match("nohup /opt/tools/liquibase update"));
+        assert!(!liquibase.match_regex.is_match("/usr/bin/liquibase update"));
     }
 
     /// Verify that every built-in filter has at least one inline test.

--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -2032,6 +2032,21 @@ match_command = "^make\\b"
         );
     }
 
+    /// Verify that every built-in filter's match_command starts with `^`.
+    /// Prevents substring misfires where an unanchored match matches a subcommand or path in the middle of a command line.
+    #[test]
+    fn test_builtin_all_filters_match_command_anchored() {
+        let filters = make_filters(BUILTIN_TOML);
+        for filter in &filters {
+            assert!(
+                filter.match_regex.as_str().starts_with('^'),
+                "Filter '{}' has match_command '{}' which does not start with '^'",
+                filter.name,
+                filter.match_regex.as_str()
+            );
+        }
+    }
+
     /// Verify that every built-in filter has at least one inline test.
     /// Prevents shipping filters with zero test coverage.
     #[test]

--- a/src/core/toml_filter.rs
+++ b/src/core/toml_filter.rs
@@ -235,6 +235,15 @@ impl TomlFilterRegistry {
 
         let mut compiled = Vec::new();
         for (name, def) in file.filters {
+            if !is_fully_anchored(&def.match_command) {
+                eprintln!(
+                    "[rtk] warning: filter '{}' in {}: match_command '{}' has a top-level branch \
+                     that does not start with '^'; it would match a path component mid-command. \
+                     Filter ignored.",
+                    name, source, def.match_command
+                );
+                continue;
+            }
             match compile_filter(name.clone(), def) {
                 Ok(f) => compiled.push(f),
                 Err(e) => eprintln!("[rtk] warning: filter '{}' in {}: {}", name, source, e),
@@ -458,12 +467,70 @@ fn collect_match_patterns() -> Vec<String> {
     patterns
 }
 
+/// Strip a leading inline-flag group such as `(?i)` so the anchor check sees the
+/// pattern body. `(?:` opens a non-capturing group and is left alone.
+fn strip_inline_flags(branch: &str) -> &str {
+    let Some(rest) = branch.strip_prefix("(?") else {
+        return branch;
+    };
+    let Some(end) = rest.find(')') else {
+        return branch;
+    };
+    if rest[..end].chars().all(|c| "imsuxU-".contains(c)) {
+        &rest[end + 1..]
+    } else {
+        branch
+    }
+}
+
+/// Split `pattern` on top-level `|`, ignoring alternations nested inside groups
+/// or character classes.
+fn top_level_branches(pattern: &str) -> Vec<&str> {
+    let mut branches = Vec::new();
+    let mut depth = 0usize;
+    let mut escaped = false;
+    let mut in_class = false;
+    let mut start = 0usize;
+
+    for (idx, character) in pattern.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match character {
+            '\\' => escaped = true,
+            '[' if !in_class => in_class = true,
+            ']' if in_class => in_class = false,
+            '(' if !in_class => depth += 1,
+            ')' if !in_class => depth = depth.saturating_sub(1),
+            '|' if !in_class && depth == 0 => {
+                branches.push(&pattern[start..idx]);
+                start = idx + 1;
+            }
+            _ => {}
+        }
+    }
+    branches.push(&pattern[start..]);
+    branches
+}
+
+/// A filter selects on argv[0], but its regex runs against the whole command
+/// line. A top-level branch that does not start with `^` therefore matches a
+/// path component or wrapper argument mid-line, so `timeout 5 /usr/bin/liquibase
+/// update` activates the liquibase filter and rewrites the wrapper instead.
+fn is_fully_anchored(pattern: &str) -> bool {
+    top_level_branches(pattern)
+        .iter()
+        .all(|branch| strip_inline_flags(branch).starts_with('^'))
+}
+
 fn match_patterns_in(content: &str) -> Vec<String> {
     match toml::from_str::<TomlFilterFile>(content) {
         Ok(file) if file.schema_version == 1 => file
             .filters
             .into_values()
             .map(|def| def.match_command)
+            .filter(|pattern| is_fully_anchored(pattern))
             .collect(),
         _ => Vec::new(),
     }
@@ -1511,6 +1578,16 @@ make[1]: Leaving directory '/home/user/project/docs'
                 .is_match("/usr/local/bin/liquibase update"),
             "a raw path-qualified invocation must not match — callers basename argv[0] before matching"
         );
+
+        for wrapped in [
+            "timeout 5 /usr/bin/liquibase update",
+            "nohup /opt/tools/liquibase update",
+        ] {
+            assert!(
+                !liquibase.match_regex.is_match(wrapped),
+                "a wrapper command must not activate the liquibase filter: {wrapped}"
+            );
+        }
     }
 
     #[test]
@@ -2032,64 +2109,53 @@ match_command = "^make\\b"
         );
     }
 
-    /// Verify that every built-in filter is anchored across every top-level branch.
+    /// Every built-in filter must be anchored on every top-level branch: the
+    /// match runs against the whole command line, so an unanchored branch
+    /// activates the filter on a path component or wrapper argument.
     #[test]
     fn test_builtin_all_filters_match_command_anchored() {
-        fn has_top_level_alternation(pattern: &str) -> bool {
-            let mut depth = 0;
-            let mut escaped = false;
-            let mut in_class = false;
-
-            for character in pattern.chars() {
-                if escaped {
-                    escaped = false;
-                    continue;
-                }
-                match character {
-                    '\\' => escaped = true,
-                    '[' if !in_class => in_class = true,
-                    ']' if in_class => in_class = false,
-                    '(' if !in_class => depth += 1,
-                    ')' if !in_class => depth -= 1,
-                    '|' if !in_class && depth == 0 => return true,
-                    _ => {}
-                }
-            }
-
-            false
-        }
-
-        let filters = make_filters(BUILTIN_TOML);
-        for filter in &filters {
-            let pattern = filter.match_regex.as_str();
+        // Read the raw patterns rather than the compiled registry: both loaders
+        // drop unanchored filters, so a compiled view cannot observe one.
+        let file: TomlFilterFile =
+            toml::from_str(BUILTIN_TOML).expect("built-in filters should parse");
+        assert!(!file.filters.is_empty());
+        for (name, def) in &file.filters {
             assert!(
-                pattern.starts_with('^') && !has_top_level_alternation(pattern),
-                "Filter '{}' has match_command '{}' with an unanchored top-level branch",
-                filter.name,
-                pattern
+                is_fully_anchored(&def.match_command),
+                "Filter '{}' has match_command '{}' with a top-level branch that does not start with '^'",
+                name,
+                def.match_command
             );
         }
 
-        assert!(has_top_level_alternation(r"^liquibase\b|/liquibase\b"));
-        assert!(!has_top_level_alternation(r"^(liquibase\b|/liquibase\b)"));
+        assert!(is_fully_anchored(r"^liquibase(?:\s|$)"));
+        assert!(is_fully_anchored(r"^(liquibase\b|/liquibase\b)"));
+        assert!(is_fully_anchored(r"^pnpm\b|^npm\b"));
+        assert!(is_fully_anchored(r"(?i)^liquibase\b"));
+        assert!(!is_fully_anchored(r"^liquibase\b|/liquibase\b"));
+        assert!(!is_fully_anchored(r"(?:^|/)liquibase(?:\s|$)"));
     }
 
+    /// The invariant above covers `BUILTIN_TOML`; project-local and global
+    /// filters are user-authored, so both loaders drop unanchored patterns
+    /// rather than letting them match mid-command.
     #[test]
-    fn test_builtin_liquibase_filter_does_not_match_wrapped_or_path_commands() {
-        let filters = make_filters(BUILTIN_TOML);
-        let liquibase = filters
-            .iter()
-            .find(|filter| filter.name == "liquibase")
-            .expect("built-in liquibase filter should exist");
+    fn test_unanchored_user_filter_is_rejected_by_both_loaders() {
+        let unanchored =
+            "schema_version = 1\n[filters.mytool]\nmatch_command = \"(?:^|/)mytool\\\\b\"\n";
+        assert!(match_patterns_in(unanchored).is_empty());
+        assert!(TomlFilterRegistry::parse_and_compile(unanchored, "test")
+            .expect("schema is valid")
+            .is_empty());
 
-        assert!(liquibase.match_regex.is_match("liquibase update"));
-        assert!(!liquibase
-            .match_regex
-            .is_match("timeout 5 /usr/bin/liquibase update"));
-        assert!(!liquibase
-            .match_regex
-            .is_match("nohup /opt/tools/liquibase update"));
-        assert!(!liquibase.match_regex.is_match("/usr/bin/liquibase update"));
+        let anchored = "schema_version = 1\n[filters.mytool]\nmatch_command = \"^mytool\\\\b\"\n";
+        assert_eq!(match_patterns_in(anchored), vec!["^mytool\\b".to_string()]);
+        assert_eq!(
+            TomlFilterRegistry::parse_and_compile(anchored, "test")
+                .expect("schema is valid")
+                .len(),
+            1
+        );
     }
 
     /// Verify that every built-in filter has at least one inline test.

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -6014,18 +6014,13 @@ mod tests {
     }
 
     #[test]
-    fn test_rewrite_liquibase_wrapper_and_paths() {
+    fn test_path_qualified_liquibase_is_not_rewritten() {
+        // #3757 originally requested path-qualified rewriting, but registry
+        // normalization currently classifies the basename without rewriting
+        // the original argv[0]. Pin that existing behavior explicitly.
         assert_eq!(
-            rewrite_command_no_prefixes("timeout 5 /usr/bin/liquibase update", &[]),
-            None
-        );
-        assert_eq!(
-            rewrite_command_no_prefixes("nohup /opt/tools/liquibase update", &[]),
-            None
-        );
-        assert_eq!(
-            rewrite_command_no_prefixes("liquibase update", &[]),
-            Some("rtk liquibase update".into())
+            rewrite_command_no_prefixes("/usr/bin/liquibase update", &[]),
+            None,
         );
     }
 }

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -6013,6 +6013,25 @@ mod tests {
         );
     }
 
+    /// `jj` is covered only by a TOML filter, never by the native RULES table,
+    /// so the bare case pins the TOML branch of the rewrite path and keeps the
+    /// wrapper assertions below from passing vacuously when TOML is disabled.
+    #[test]
+    fn test_toml_filter_rewrites_bare_command_but_not_wrapped_invocations() {
+        assert_eq!(
+            rewrite_command_no_prefixes("jj log", &[]),
+            Some("rtk jj log".into()),
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("timeout 5 /usr/bin/jj log", &[]),
+            None,
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("nohup /opt/tools/jj log", &[]),
+            None,
+        );
+    }
+
     #[test]
     fn test_path_qualified_liquibase_is_not_rewritten() {
         // #3757 originally requested path-qualified rewriting, but registry

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -6012,4 +6012,20 @@ mod tests {
             "pest"
         );
     }
+
+    #[test]
+    fn test_rewrite_liquibase_wrapper_and_paths() {
+        assert_eq!(
+            rewrite_command_no_prefixes("timeout 5 /usr/bin/liquibase update", &[]),
+            None
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("nohup /opt/tools/liquibase update", &[]),
+            None
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("liquibase update", &[]),
+            Some("rtk liquibase update".into())
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Pins that every built-in TOML filter `match_command` is anchored on **every top-level branch**, so a pattern cannot match a path component or subcommand mid-line. A filter selects on argv[0], but its regex runs against the whole command line, so an unanchored branch makes `timeout 5 /usr/bin/liquibase update` activate the liquibase filter and rewrite the wrapper.

The anchoring rule is now enforced at load time by a shared `is_fully_anchored` predicate applied to **both** loaders (`match_patterns_in` and `TomlFilterRegistry::parse_and_compile`), so it also covers project-local and global filters. Those are user-authored and were previously unguarded — which is where #3757 said the durable fix belonged. Unanchored filters are skipped with a warning rather than silently misfiring.

Refs #3757

## Validation

- `test_builtin_all_filters_match_command_anchored` — checks every built-in filter, reading **raw** patterns from `BUILTIN_TOML` so the load-time gate cannot hide an unanchored built-in from the assertion. Accepts per-branch anchoring (`^pnpm\b|^npm\b`) and inline flags (`(?i)^tool\b`); rejects `^liquibase\b|/liquibase\b` and `(?:^|/)liquibase(?:\s|$)`.
- `test_unanchored_user_filter_is_rejected_by_both_loaders` — pins that a user-authored unanchored filter is dropped by both load paths, keeping `MATCH_SET` and the compiled registry in agreement.
- `test_liquibase_match_command_ignores_path_substring` — extended with the wrapper cases (`timeout`, `nohup`) alongside the existing path-substring assertions and their rationale comment.
- `test_toml_filter_rewrites_bare_command_but_not_wrapped_invocations` — exercises the rewrite path end to end via `jj`, which is covered only by a TOML filter and never by the native `RULES` table. The bare case acts as a positive control so the wrapper assertions cannot pass vacuously.
- `test_path_qualified_liquibase_is_not_rewritten` — pins the current `None` for `/usr/bin/liquibase update`, with a comment recording that this diverges from #3757's requested behavior.

`cargo fmt --all`, `cargo clippy --all-targets` (clean), `cargo test --all` (all passing), verified both on this branch and merged onto the latest `develop`.

## Note on #3757

Changed `Closes` to `Refs`. That issue's third required-coverage bullet asks for `/usr/bin/liquibase update` to still be rewritten; this branch pins the current `None` as a characterization test instead.

That `None` is itself a bug, tracked in #3757 rather than fixed here. `classify_command` correctly reports the command as `Supported` — it is a liquibase invocation and RTK can filter it — but the rewrite path matches `RULES.rewrite_prefixes` against the un-normalized `cmd_part`, finds no prefix, and drops it. So every path-qualified invocation of every supported command silently skips filtering (`/usr/bin/grep`, `/usr/bin/make` behave the same), and `rtk discover` advertises an optimization the hook then declines.

The fix is to normalize `cmd_part` before that match, which is a behavior change beyond this PR's test-and-guard scope. When it lands, `test_path_qualified_liquibase_is_not_rewritten` should be updated to assert the rewrite rather than deleted, so the path-qualified case stays covered. #3757 stays open until then.
