### PR TITLE
fix(discover): count sudo RTK_DISABLED=1 commands as bypass in analytics

### DIFF
--- a/src/discover/mod.rs
+++ b/src/discover/mod.rs
@@ -11,8 +11,8 @@ use std::collections::HashMap;
 
 use provider::{ClaudeProvider, SessionProvider};
 use registry::{
-    category_avg_tokens, classify_command, split_command_chain, strip_disabled_prefix,
-    Classification,
+    category_avg_tokens, classify_command, split_command_chain,
+    strip_disabled_prefix_for_analytics, Classification,
 };
 use report::{DiscoverReport, SupportedEntry, UnsupportedEntry};
 
@@ -98,7 +98,7 @@ pub fn run(
                 total_commands += 1;
 
                 // Detect RTK_DISABLED= bypass before classification
-                let (env_prefix, actual_cmd) = strip_disabled_prefix(part);
+                let (env_prefix, actual_cmd) = strip_disabled_prefix_for_analytics(part);
                 if prefix_contains_rtk_disabled(env_prefix) {
                     // Only count if the underlying command is one RTK supports
                     match classify_command(actual_cmd) {

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -470,13 +470,27 @@ fn strip_absolute_path(cmd: &str) -> String {
     }
 }
 
+static SUDO_PREFIX_ANALYTICS: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^(?:sudo(?:\s+-[A-Za-z0-9_-]+(?:\s+\S+)?)*\s+)").unwrap()
+});
+
 pub fn prefix_contains_rtk_disabled(prefix_part: &str) -> bool {
     prefix_part.contains("RTK_DISABLED=")
 }
 
+/// Strip RTK_DISABLED=X and other env prefixes for analytics, skipping leading `sudo` and flags if present.
+pub fn strip_disabled_prefix_for_analytics(cmd: &str) -> (&str, &str) {
+    let trimmed = cmd.trim();
+    let after_sudo = SUDO_PREFIX_ANALYTICS.replace(trimmed, "");
+    let sudo_len = trimmed.len() - after_sudo.len();
+    let (_env_part, rest) = strip_disabled_prefix(&trimmed[sudo_len..]);
+    let full_prefix_len = trimmed.len() - rest.len();
+    (&trimmed[..full_prefix_len], rest)
+}
+
 /// Check if a command has RTK_DISABLED= prefix in its env prefix portion.
 pub fn cmd_has_rtk_disabled_prefix(cmd: &str) -> bool {
-    let (prefix_part, _) = strip_disabled_prefix(cmd);
+    let (prefix_part, _) = strip_disabled_prefix_for_analytics(cmd);
     prefix_contains_rtk_disabled(prefix_part)
 }
 
@@ -5137,9 +5151,19 @@ mod tests {
         assert!(cmd_has_rtk_disabled_prefix(
             "RTK_DISABLED=true git log --oneline"
         ));
+        assert!(cmd_has_rtk_disabled_prefix(
+            "sudo RTK_DISABLED=1 docker ps"
+        ));
+        assert!(cmd_has_rtk_disabled_prefix(
+            "sudo -E RTK_DISABLED=1 docker ps"
+        ));
+        assert!(cmd_has_rtk_disabled_prefix(
+            "RTK_DISABLED=1 sudo docker ps"
+        ));
         assert!(!cmd_has_rtk_disabled_prefix("git status"));
         assert!(!cmd_has_rtk_disabled_prefix("rtk git status"));
         assert!(!cmd_has_rtk_disabled_prefix("SOME_VAR=1 git status"));
+        assert!(!cmd_has_rtk_disabled_prefix("sudo docker ps"));
     }
 
     #[test]
@@ -5153,6 +5177,22 @@ mod tests {
             ("FOO=1 RTK_DISABLED=1 ", "cargo test")
         );
         assert_eq!(strip_disabled_prefix("git status"), ("", "git status"));
+    }
+
+    #[test]
+    fn test_strip_disabled_prefix_for_analytics() {
+        assert_eq!(
+            strip_disabled_prefix_for_analytics("sudo RTK_DISABLED=1 docker ps"),
+            ("sudo RTK_DISABLED=1 ", "docker ps")
+        );
+        assert_eq!(
+            strip_disabled_prefix_for_analytics("sudo -E RTK_DISABLED=1 docker ps"),
+            ("sudo -E RTK_DISABLED=1 ", "docker ps")
+        );
+        assert_eq!(
+            strip_disabled_prefix_for_analytics("RTK_DISABLED=1 sudo docker ps"),
+            ("RTK_DISABLED=1 sudo ", "docker ps")
+        );
     }
 
     // --- #485: absolute path normalization ---

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -470,22 +470,60 @@ fn strip_absolute_path(cmd: &str) -> String {
     }
 }
 
-static SUDO_PREFIX_ANALYTICS: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^(?:sudo(?:\s+-[A-Za-z0-9_-]+(?:\s+\S+)?)*\s+)").unwrap()
-});
-
 pub fn prefix_contains_rtk_disabled(prefix_part: &str) -> bool {
     prefix_part.contains("RTK_DISABLED=")
 }
 
-/// Strip RTK_DISABLED=X and other env prefixes for analytics, skipping leading `sudo` and flags if present.
+/// Strip an RTK_DISABLED prefix for analytics, including sudo options around it.
 pub fn strip_disabled_prefix_for_analytics(cmd: &str) -> (&str, &str) {
     let trimmed = cmd.trim();
-    let after_sudo = SUDO_PREFIX_ANALYTICS.replace(trimmed, "");
-    let sudo_len = trimmed.len() - after_sudo.len();
-    let (_env_part, rest) = strip_disabled_prefix(&trimmed[sudo_len..]);
-    let full_prefix_len = trimmed.len() - rest.len();
-    (&trimmed[..full_prefix_len], rest)
+    let tokens = tokenize(trimmed);
+
+    if let Some(disabled_index) = tokens
+        .iter()
+        .position(|token| token.value.starts_with("RTK_DISABLED="))
+    {
+        let mut saw_sudo = false;
+        let mut saw_sudo_flag = false;
+        let prefix_is_valid = tokens[..disabled_index].iter().all(|token| {
+            let value = token.value.as_str();
+            if value == "env" || value.contains('=') {
+                true
+            } else if value == "sudo" {
+                saw_sudo = true;
+                true
+            } else if saw_sudo && value.starts_with('-') {
+                saw_sudo_flag = true;
+                true
+            } else {
+                saw_sudo && saw_sudo_flag
+            }
+        });
+
+        if prefix_is_valid {
+            for token in &tokens[disabled_index + 1..] {
+                if token.kind != TokenKind::Arg {
+                    break;
+                }
+                if token.value == "sudo"
+                    || token.value == "env"
+                    || token.value.starts_with('-')
+                    || token.value.contains('=')
+                {
+                    continue;
+                }
+                let candidate = trimmed[token.offset..].trim();
+                if matches!(
+                    classify_command(candidate),
+                    Classification::Supported { .. }
+                ) {
+                    return (&trimmed[..token.offset], candidate);
+                }
+            }
+        }
+    }
+
+    strip_disabled_prefix(trimmed)
 }
 
 /// Check if a command has RTK_DISABLED= prefix in its env prefix portion.
@@ -5151,14 +5189,16 @@ mod tests {
         assert!(cmd_has_rtk_disabled_prefix(
             "RTK_DISABLED=true git log --oneline"
         ));
-        assert!(cmd_has_rtk_disabled_prefix(
-            "sudo RTK_DISABLED=1 docker ps"
-        ));
+        assert!(cmd_has_rtk_disabled_prefix("sudo RTK_DISABLED=1 docker ps"));
         assert!(cmd_has_rtk_disabled_prefix(
             "sudo -E RTK_DISABLED=1 docker ps"
         ));
         assert!(cmd_has_rtk_disabled_prefix(
-            "RTK_DISABLED=1 sudo docker ps"
+            "sudo -E -u root RTK_DISABLED=1 docker ps"
+        ));
+        assert!(cmd_has_rtk_disabled_prefix("RTK_DISABLED=1 sudo docker ps"));
+        assert!(cmd_has_rtk_disabled_prefix(
+            "RTK_DISABLED=1 sudo -E docker ps"
         ));
         assert!(!cmd_has_rtk_disabled_prefix("git status"));
         assert!(!cmd_has_rtk_disabled_prefix("rtk git status"));
@@ -5190,8 +5230,16 @@ mod tests {
             ("sudo -E RTK_DISABLED=1 ", "docker ps")
         );
         assert_eq!(
+            strip_disabled_prefix_for_analytics("sudo -E -u root RTK_DISABLED=1 docker ps"),
+            ("sudo -E -u root RTK_DISABLED=1 ", "docker ps")
+        );
+        assert_eq!(
             strip_disabled_prefix_for_analytics("RTK_DISABLED=1 sudo docker ps"),
             ("RTK_DISABLED=1 sudo ", "docker ps")
+        );
+        assert_eq!(
+            strip_disabled_prefix_for_analytics("RTK_DISABLED=1 sudo -E docker ps"),
+            ("RTK_DISABLED=1 sudo -E ", "docker ps")
         );
     }
 


### PR DESCRIPTION
## Summary

Adds an analytics-only prefix stripper (\strip_disabled_prefix_for_analytics\) that skips a leading \sudo\ (and optional sudo flags like \-E\) before delegating to the shared \strip_disabled_prefix\. This ensures that commands such as \sudo RTK_DISABLED=1 docker ps\ are counted as RTK bypasses in \tk discover\ and \tk gain\ without modifying the shared \strip_disabled_prefix\ used by rewrite routines.

Closes #3756

## Validation

- Added unit tests in \	est_cmd_has_rtk_disabled_prefix\ covering:
  - \sudo RTK_DISABLED=1 docker ps\ -> detected as bypass
  - \sudo -E RTK_DISABLED=1 docker ps\ -> detected as bypass
  - \RTK_DISABLED=1 sudo docker ps\ -> detected as bypass
  - \sudo docker ps\ -> not a bypass
- Added \	est_strip_disabled_prefix_for_analytics\ verifying prefix extraction
- Pinned \	est_strip_disabled_prefix\ to ensure the shared helper behavior remains unchanged
- Ran test suite with \cargo test --bin rtk\ (all tests passing)