### PR TITLE
fix(rewrite): rewrite inner commands of quoted sh/bash/zsh -c wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,19 @@ The most effective way to use rtk. The hook transparently intercepts Bash comman
 
 **Scope note:** this only applies to Bash tool calls. Claude Code built-in tools such as `Read`, `Grep`, and `Glob` bypass the hook, so use shell commands or explicit `rtk` commands when you want RTK filtering there.
 
+Simple quoted shell wrappers are also rewritten without changing the selected
+shell:
+
+```bash
+bash -c "head foo && grep -R bar ."
+# → bash -c "rtk read foo && rtk grep -R bar ."
+```
+
+This support is intentionally conservative: it covers exact `sh -c`,
+`bash -c`, and `zsh -c` wrappers with a quoted portable script. Shell expansion
+in an outer double quote, additional shell options, redirects to files, `fish`
+scripts, and nested wrappers pass through unchanged.
+
 ### Setup
 
 ```bash

--- a/docs/contributing/TECHNICAL.md
+++ b/docs/contributing/TECHNICAL.md
@@ -208,6 +208,7 @@ LLM Agent executes rewritten command
 Key design decisions:
 - **Lexer-based tokenization**: A single-pass state machine (`lexer.rs`) handles all shell constructs (quotes, escapes, redirects, operators). Used for both compound splitting and redirect stripping.
 - **Segment-level rewriting**: Compound commands are split by operators, each segment rewritten independently. Bash recombines them at execution time.
+- **Conservative shell-wrapper recursion**: Only exact quoted `sh|bash|zsh -c` wrappers enter one level of inner rewriting. The parser hands back byte ranges instead of a decoded script, so the wrapper's own bytes are never re-quoted.
 - **Pipe semantics**: Producers and intermediate stages of `|` remain raw. Only an argument-safe final stage whose rule has `pipeline_final_safe` may be rewritten; initially this is limited to ordinary `grep` and `rg` invocations. Search pattern-file forms (`-f`/`--file`) defer because they can consume pipeline stdin as configuration. `|&` is recognized separately and its complete pipeline stays raw.
 - **Double env prefix handling**: `classify_command()` strips env prefixes to match the underlying command against rules. `rewrite_segment()` extracts the same prefix separately to re-prepend it to the rewritten command.
 - **Fallback contract**: If any segment fails to match, it stays raw. `rewrite_command()` returns `None` only when zero segments were rewritten.

--- a/src/discover/README.md
+++ b/src/discover/README.md
@@ -23,6 +23,8 @@ When a hook sends `cargo fmt --all && cargo test 2>&1 | tail -20`:
 
 **Compound splitting** — The rewrite engine walks the tokens, splitting on `Operator` (`&&`, `||`, `;`) and typed `Pipe` tokens (`|`, `|&`). For normal pipelines, producers and intermediate stages stay raw, and only an argument-safe final stage marked `pipeline_final_safe` is rewritten. The initial safe set is ordinary `grep` and `rg` invocations; search pattern-file forms (`-f`/`--file`) defer because they can consume pipeline stdin as configuration. Stderr pipelines (`|&`) and pipelines containing opaque shell groups remain raw.
 
+**Quoted shell wrappers** — An exact `sh -c`, `bash -c`, or `zsh -c` segment whose script is one balanced quoted argument has that script rewritten in place, leaving the shell path, quote delimiters, spacing, suffix arguments and redirects byte-identical (`shell_wrapper.rs`). Recursion is capped at one level, so a wrapper inside a wrapper stays raw. A script carrying a newline, heredoc, `$((`, or any construct the lexer cannot attest defers unchanged, as does a `fish` script — fish control keywords (`and`, `or`, `if`) at a command boundary need a fish-aware lexer the shared one does not model.
+
 **Per-segment rewriting** — Each segment goes through:
 
 1. Strip trailing redirects (`2>&1`, `>/dev/null`) — matched via lexer tokens, set aside, re-appended after rewriting

--- a/src/discover/mod.rs
+++ b/src/discover/mod.rs
@@ -5,6 +5,7 @@ pub mod provider;
 pub mod registry;
 mod report;
 pub mod rules;
+pub(crate) mod shell_wrapper;
 
 use anyhow::Result;
 use chrono::{DateTime, Utc};

--- a/src/discover/registry.rs
+++ b/src/discover/registry.rs
@@ -6,10 +6,11 @@ use std::path::Path;
 use std::sync::LazyLock;
 
 use super::lexer::{
-    advance_quote_state, coalesce_words, is_crlf_at, shell_split, split_on_operators, tokenize,
-    tokenize_with_newlines, ParsedToken, PipeKind, TokenKind,
+    advance_quote_state, coalesce_words, contains_unattestable_construct, is_crlf_at, shell_split,
+    split_on_operators, tokenize, tokenize_with_newlines, ParsedToken, PipeKind, TokenKind,
 };
 use super::rules::{RtkRule, IGNORED_EXACT, IGNORED_PREFIXES, RULES};
+use super::shell_wrapper::parse_shell_wrapper;
 
 const PHP_TOOL_NAMES: [&str; 6] = ["phpunit", "phpstan", "ecs", "pest", "paratest", "pint"];
 
@@ -642,7 +643,7 @@ fn rewrite_single(
         return Some(trimmed.to_string());
     }
 
-    rewrite_compound(trimmed, excluded, transparent_prefixes)
+    rewrite_compound(trimmed, excluded, transparent_prefixes, 0)
 }
 
 /// Shell keywords that open or close a multi-line construct. A line inside a
@@ -1036,6 +1037,7 @@ fn rewrite_pipeline_final_stage(
     analysis: PipelineAnalysis,
     excluded: &[ExcludePattern],
     transparent_prefixes: &[String],
+    shell_wrapper_depth: usize,
 ) -> Option<String> {
     let final_stage_start = analysis.final_stage_start?;
     let final_stage = cmd[final_stage_start..analysis.end_offset].trim();
@@ -1046,6 +1048,7 @@ fn rewrite_pipeline_final_stage(
         transparent_prefixes,
         RewriteContext::PipelineFinal,
         0,
+        shell_wrapper_depth,
     )
     .filter(|rewritten| rewritten != final_stage)
     .map(|rewritten| {
@@ -1066,6 +1069,7 @@ fn rewrite_compound(
     cmd: &str,
     excluded: &[ExcludePattern],
     transparent_prefixes: &[String],
+    shell_wrapper_depth: usize,
 ) -> Option<String> {
     let tokens = tokenize(cmd);
     let has_pipe = tokens
@@ -1089,8 +1093,9 @@ fn rewrite_compound(
         match tok.kind {
             TokenKind::Operator => {
                 let seg = cmd[seg_start..tok.offset].trim();
-                let rewritten = rewrite_segment(seg, excluded, transparent_prefixes)
-                    .unwrap_or_else(|| seg.to_string());
+                let rewritten =
+                    rewrite_segment(seg, excluded, transparent_prefixes, shell_wrapper_depth)
+                        .unwrap_or_else(|| seg.to_string());
                 if rewritten != seg {
                     any_changed = true;
                 }
@@ -1120,6 +1125,7 @@ fn rewrite_compound(
                     analysis,
                     excluded,
                     transparent_prefixes,
+                    shell_wrapper_depth,
                 );
 
                 if let Some(rewritten) = rewritten_pipeline {
@@ -1141,8 +1147,9 @@ fn rewrite_compound(
             }
             TokenKind::Shellism if tok.value == "&" => {
                 let seg = cmd[seg_start..tok.offset].trim();
-                let rewritten = rewrite_segment(seg, excluded, transparent_prefixes)
-                    .unwrap_or_else(|| seg.to_string());
+                let rewritten =
+                    rewrite_segment(seg, excluded, transparent_prefixes, shell_wrapper_depth)
+                        .unwrap_or_else(|| seg.to_string());
                 if rewritten != seg {
                     any_changed = true;
                 }
@@ -1158,8 +1165,8 @@ fn rewrite_compound(
     }
 
     let seg = cmd[seg_start..].trim();
-    let rewritten =
-        rewrite_segment(seg, excluded, transparent_prefixes).unwrap_or_else(|| seg.to_string());
+    let rewritten = rewrite_segment(seg, excluded, transparent_prefixes, shell_wrapper_depth)
+        .unwrap_or_else(|| seg.to_string());
     if rewritten != seg {
         any_changed = true;
     }
@@ -1216,6 +1223,9 @@ fn builtin_transparent_prefixes() -> impl Iterator<Item = (&'static str, bool)> 
 }
 
 const MAX_PREFIX_DEPTH: usize = 10;
+
+/// A wrapper's script may be rewritten, but a script inside that script may not.
+const MAX_SHELL_WRAPPER_DEPTH: usize = 1;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum RewriteContext {
@@ -1297,6 +1307,7 @@ fn rewrite_segment(
     seg: &str,
     excluded: &[ExcludePattern],
     transparent_prefixes: &[String],
+    shell_wrapper_depth: usize,
 ) -> Option<String> {
     rewrite_segment_inner(
         seg,
@@ -1304,7 +1315,36 @@ fn rewrite_segment(
         transparent_prefixes,
         RewriteContext::Normal,
         0,
+        shell_wrapper_depth,
     )
+}
+
+/// Rewrite the portable commands inside an exact quoted `sh|bash|zsh|fish -c`
+/// script, leaving the wrapper's own bytes — shell path, quote delimiters,
+/// spacing, suffix arguments, redirects — untouched. Refs: #2767.
+fn rewrite_shell_wrapper(
+    command: &str,
+    excluded: &[ExcludePattern],
+    transparent_prefixes: &[String],
+    shell_wrapper_depth: usize,
+) -> Option<String> {
+    let wrapper = parse_shell_wrapper(command)?;
+    let script = wrapper.script(command)?;
+    if script.contains(['\n', '\r'])
+        || has_heredoc(script)
+        || script.contains("$((")
+        || contains_unattestable_construct(script)
+    {
+        return None;
+    }
+
+    let rewritten = rewrite_compound(
+        script,
+        excluded,
+        transparent_prefixes,
+        shell_wrapper_depth + 1,
+    )?;
+    wrapper.replace_script(command, &rewritten)
 }
 
 fn is_excluded(cmd: &str, excluded: &[ExcludePattern]) -> bool {
@@ -1320,10 +1360,22 @@ fn rewrite_segment_inner(
     transparent_prefixes: &[String],
     context: RewriteContext,
     depth: usize,
+    shell_wrapper_depth: usize,
 ) -> Option<String> {
     let trimmed = seg.trim();
     if trimmed.is_empty() {
         return None;
+    }
+
+    // Reached at any prefix depth, so a wrapper behind a transparent prefix
+    // (`direnv exec . bash -c '…'`) is still seen. `shell_wrapper_depth` is the
+    // only recursion bound that matters here.
+    if shell_wrapper_depth < MAX_SHELL_WRAPPER_DEPTH {
+        if let Some(rewritten) =
+            rewrite_shell_wrapper(trimmed, excluded, transparent_prefixes, shell_wrapper_depth)
+        {
+            return Some(rewritten);
+        }
     }
 
     if depth >= MAX_PREFIX_DEPTH {
@@ -1347,6 +1399,7 @@ fn rewrite_segment_inner(
             transparent_prefixes,
             context,
             depth + 1,
+            shell_wrapper_depth,
         )?;
         return Some(format!("{}{}", env_prefix, rewritten));
     }
@@ -1356,9 +1409,14 @@ fn rewrite_segment_inner(
             if rest.is_empty() {
                 return None;
             }
-            if let Some(rewritten) =
-                rewrite_segment_inner(rest, excluded, transparent_prefixes, context, depth + 1)
-            {
+            if let Some(rewritten) = rewrite_segment_inner(
+                rest,
+                excluded,
+                transparent_prefixes,
+                context,
+                depth + 1,
+                shell_wrapper_depth,
+            ) {
                 return Some(format!("{} {}", prefix, rewritten));
             }
             // #2768: falling through re-tests the full prefixed string, which is
@@ -1383,8 +1441,15 @@ fn rewrite_segment_inner(
             if rest.is_empty() {
                 return None;
             }
-            return rewrite_segment_inner(rest, excluded, transparent_prefixes, context, depth + 1)
-                .map(|rewritten| format!("{} {}", prefix, rewritten));
+            return rewrite_segment_inner(
+                rest,
+                excluded,
+                transparent_prefixes,
+                context,
+                depth + 1,
+                shell_wrapper_depth,
+            )
+            .map(|rewritten| format!("{} {}", prefix, rewritten));
         }
     }
 
@@ -6300,7 +6365,6 @@ mod tests {
             "pest"
         );
     }
-
     /// `jj` is covered only by a TOML filter, never by the native RULES table,
     /// so the bare case pins the TOML branch of the rewrite path and keeps the
     /// wrapper assertions below from passing vacuously when TOML is disabled.
@@ -6328,6 +6392,134 @@ mod tests {
         assert_eq!(
             rewrite_command_no_prefixes("/usr/bin/liquibase update", &[]),
             None,
+        );
+    }
+
+    // --- quoted shell wrapper tests ---
+
+    #[test]
+    fn test_shell_wrapper_rewrites_bash_command_string() {
+        assert_eq!(
+            rewrite_command_no_prefixes(r#"bash -c "head foo && grep -R bar .""#, &[]),
+            Some(r#"bash -c "rtk read foo && rtk grep -R bar .""#.into())
+        );
+    }
+
+    #[test]
+    fn test_shell_wrapper_leaves_fish_command_string_alone() {
+        assert_eq!(
+            rewrite_command_no_prefixes("fish -c 'git status; cargo test'", &[]),
+            None
+        );
+    }
+
+    #[test]
+    fn test_shell_wrapper_preserves_path_quotes_and_suffix_arguments() {
+        assert_eq!(
+            rewrite_command_no_prefixes("/bin/bash -c 'git status' command-name 'a b'", &[]),
+            Some("/bin/bash -c 'rtk git status' command-name 'a b'".into())
+        );
+    }
+
+    #[test]
+    fn test_shell_wrapper_supports_sh_zsh_and_horizontal_spacing() {
+        assert_eq!(
+            rewrite_command_no_prefixes("sh\t-c\t'git status'\tname", &[]),
+            Some("sh\t-c\t'rtk git status'\tname".into())
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("zsh -c 'cargo test'", &[]),
+            Some("zsh -c 'rtk cargo test'".into())
+        );
+    }
+
+    #[test]
+    fn test_shell_wrapper_rewrites_inside_outer_compound_command() {
+        assert_eq!(
+            rewrite_command_no_prefixes(r#"bash -c "git status && cargo test" || git status"#, &[]),
+            Some(r#"bash -c "rtk git status && rtk cargo test" || rtk git status"#.into())
+        );
+    }
+
+    #[test]
+    fn test_shell_wrapper_applies_inner_exclusions() {
+        let excluded = vec!["git".to_string()];
+        assert_eq!(
+            rewrite_command_no_prefixes("bash -c 'git status; cargo test'", &excluded),
+            Some("bash -c 'git status; rtk cargo test'".into())
+        );
+    }
+
+    #[test]
+    fn test_shell_wrapper_preserves_fd_redirect() {
+        assert_eq!(
+            rewrite_command_no_prefixes("bash -c 'git status' 2>&1", &[]),
+            Some("bash -c 'rtk git status' 2>&1".into())
+        );
+    }
+
+    #[test]
+    fn test_shell_wrapper_rejects_unsafe_or_unsupported_scripts() {
+        for command in [
+            "bash -c 'git status $(whoami)'",
+            "bash -c 'git status > /tmp/out'",
+            "bash -c 'git status\ncargo test'",
+            "fish -c 'git status; and cargo test'",
+            "bash -lc 'git status'",
+            r#"bash -c "git status $HOME""#,
+        ] {
+            assert_eq!(
+                rewrite_command_no_prefixes(command, &[]),
+                None,
+                "unsafe or unsupported wrapper must pass through: {command:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_shell_wrapper_rewrites_behind_a_strippable_prefix() {
+        assert_eq!(
+            rewrite_command_no_prefixes("command bash -c 'git status'", &[]),
+            Some("command bash -c 'rtk git status'".into())
+        );
+    }
+
+    #[test]
+    fn test_shell_wrapper_behind_sudo_is_not_rewritten() {
+        // The inner `rtk` would run as root, where it is off secure_path — the
+        // same reason a bare `sudo docker ps` is left alone. See #146.
+        assert_eq!(
+            rewrite_command_no_prefixes("sudo bash -c 'git status'", &[]),
+            None
+        );
+    }
+
+    #[test]
+    fn test_shell_wrapper_rewrites_behind_a_transparent_prefix() {
+        let prefixes = vec!["direnv exec .".to_string(), "devenv shell --".to_string()];
+        assert_eq!(
+            super::rewrite_command("direnv exec . bash -c 'git status'", &[], &prefixes),
+            Some("direnv exec . bash -c 'rtk git status'".into())
+        );
+        assert_eq!(
+            super::rewrite_command(
+                "devenv shell -- bash -c 'cargo test; git status'",
+                &[],
+                &prefixes
+            ),
+            Some("devenv shell -- bash -c 'rtk cargo test; rtk git status'".into())
+        );
+    }
+
+    #[test]
+    fn test_shell_wrapper_does_not_rewrite_nested_wrapper() {
+        assert_eq!(
+            rewrite_command_no_prefixes("bash -c 'bash -c \"git status\"'", &[]),
+            None
+        );
+        assert_eq!(
+            rewrite_command_no_prefixes("bash -c 'git status && bash -c \"cargo test\"'", &[]),
+            Some("bash -c 'rtk git status && bash -c \"cargo test\"'".into())
         );
     }
 }

--- a/src/discover/shell_wrapper.rs
+++ b/src/discover/shell_wrapper.rs
@@ -1,0 +1,291 @@
+//! Parses the conservative subset of quoted shell -c wrappers that RTK can rewrite.
+
+/// POSIX-family shells only. `fish` needs a fish-aware lexer to attest its
+/// control keywords (`and`, `or`, `if`) at a command boundary, which the shared
+/// lexer does not model, so a fish script is never treated as rewritable.
+const SUPPORTED_SHELLS: &[&str] = &["sh", "bash", "zsh"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ShellWrapper {
+    script_start: usize,
+    script_end: usize,
+}
+
+impl ShellWrapper {
+    pub(crate) fn script<'a>(&self, command: &'a str) -> Option<&'a str> {
+        command.get(self.script_start..self.script_end)
+    }
+
+    pub(crate) fn replace_script(&self, command: &str, rewritten: &str) -> Option<String> {
+        let prefix = command.get(..self.script_start)?;
+        let suffix = command.get(self.script_end..)?;
+        let mut result = String::with_capacity(prefix.len() + rewritten.len() + suffix.len());
+        result.push_str(prefix);
+        result.push_str(rewritten);
+        result.push_str(suffix);
+        Some(result)
+    }
+}
+
+/// Recognize a quoted shell -c script without decoding or re-quoting it.
+///
+/// Double-quoted scripts are accepted only when the outer shell has no active
+/// expansion or escape to evaluate. Unsupported forms return None, leaving the
+/// original command untouched.
+pub(crate) fn parse_shell_wrapper(command: &str) -> Option<ShellWrapper> {
+    let bytes = command.as_bytes();
+    if bytes.contains(&b'\0') {
+        return None;
+    }
+    let shell_end = supported_shell_end(command)?;
+
+    let mut position = skip_horizontal_space(bytes, shell_end);
+    if bytes.get(position..position + 2)? != b"-c" {
+        return None;
+    }
+    position += 2;
+    if !bytes
+        .get(position)
+        .is_some_and(|byte| is_horizontal_space(*byte))
+    {
+        return None;
+    }
+
+    position = skip_horizontal_space(bytes, position);
+    let quote = *bytes.get(position)?;
+    if !matches!(quote, b'\'' | b'"') {
+        return None;
+    }
+
+    let script_start = position + 1;
+    let script_end = find_script_end(bytes, script_start, quote)?;
+    if script_start == script_end {
+        return None;
+    }
+
+    let after_quote = script_end + 1;
+    if bytes
+        .get(after_quote)
+        .is_some_and(|byte| !is_horizontal_space(*byte))
+    {
+        return None;
+    }
+
+    Some(ShellWrapper {
+        script_start,
+        script_end,
+    })
+}
+
+/// Detect a supported shell whose option list requests command-string mode,
+/// including forms that the strict rewrite parser intentionally rejects.
+pub(crate) fn is_shell_wrapper_candidate(command: &str) -> bool {
+    let Some(shell_end) = supported_shell_end(command) else {
+        return false;
+    };
+    let rest_start = skip_horizontal_space(command.as_bytes(), shell_end);
+    let Some(rest) = command.get(rest_start..) else {
+        return false;
+    };
+
+    for option in rest.split_ascii_whitespace() {
+        if option == "--" || !option.starts_with('-') {
+            return false;
+        }
+        if option == "--command"
+            || option
+                .strip_prefix('-')
+                .is_some_and(|flags| !flags.starts_with('-') && flags.contains('c'))
+        {
+            return true;
+        }
+    }
+    false
+}
+
+fn supported_shell_end(command: &str) -> Option<usize> {
+    let shell_end = command
+        .as_bytes()
+        .iter()
+        .position(|byte| is_horizontal_space(*byte))?;
+    let shell = command.get(..shell_end)?;
+    let basename = shell.rsplit(['/', '\\']).next()?;
+    SUPPORTED_SHELLS.contains(&basename).then_some(shell_end)
+}
+
+fn is_horizontal_space(byte: u8) -> bool {
+    matches!(byte, b' ' | b'\t')
+}
+
+fn skip_horizontal_space(bytes: &[u8], mut position: usize) -> usize {
+    while bytes
+        .get(position)
+        .is_some_and(|byte| is_horizontal_space(*byte))
+    {
+        position += 1;
+    }
+    position
+}
+
+fn find_script_end(bytes: &[u8], start: usize, quote: u8) -> Option<usize> {
+    for (offset, byte) in bytes.get(start..)?.iter().copied().enumerate() {
+        if byte == quote {
+            return Some(start + offset);
+        }
+        if matches!(byte, b'\0' | b'\n' | b'\r') {
+            return None;
+        }
+        if quote == b'"' && matches!(byte, b'$' | b'\x60' | b'\\') {
+            return None;
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parsed_script(command: &str) -> Option<&str> {
+        parse_shell_wrapper(command)?.script(command)
+    }
+
+    #[test]
+    fn test_parse_shell_wrapper_double_quoted_bash() {
+        assert_eq!(
+            parsed_script(r#"bash -c "head foo && grep -R bar .""#),
+            Some("head foo && grep -R bar .")
+        );
+    }
+
+    #[test]
+    fn test_parse_shell_wrapper_rejects_fish() {
+        assert_eq!(parsed_script("fish -c 'git status; cargo test'"), None);
+    }
+
+    #[test]
+    fn test_parse_shell_wrapper_preserves_unicode_and_suffix() {
+        let command = "/bin/bash -c 'printf 日本語' command-name 'a b'";
+        let wrapper = parse_shell_wrapper(command).expect("wrapper should parse");
+        assert_eq!(wrapper.script(command), Some("printf 日本語"));
+        assert_eq!(
+            wrapper.replace_script(command, "rtk printf 日本語"),
+            Some("/bin/bash -c 'rtk printf 日本語' command-name 'a b'".into())
+        );
+    }
+
+    #[test]
+    fn test_parse_shell_wrapper_accepts_inner_expansion_in_single_quotes() {
+        assert_eq!(
+            parsed_script("bash -c 'printf \"%s\\n\" \"$HOME\"'"),
+            Some("printf \"%s\\n\" \"$HOME\"")
+        );
+    }
+
+    #[test]
+    fn test_parse_shell_wrapper_rejects_unsupported_shapes() {
+        for command in [
+            "bash -c git status",
+            "bash -c ''",
+            "bash -c 'git status",
+            "bash -c 'git'\" status\"",
+            "bash -lc 'git status'",
+            "bash -e -c 'git status'",
+            "python -c 'git status'",
+            "command bash -c 'git status'",
+            "bash\n-c 'git status'",
+            "bash -c 'git\0status'",
+        ] {
+            assert!(
+                parse_shell_wrapper(command).is_none(),
+                "unsupported wrapper must be rejected: {command:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_shell_wrapper_spans_are_valid_for_malformed_corpus() {
+        let corpus = [
+            "",
+            "日",
+            "bash",
+            "bash ",
+            "bash -",
+            "bash -c",
+            "bash -c ",
+            "bash -c '",
+            "bash -c '日",
+            "bash -c '日本語'",
+            "bash -c \"日本語\"",
+        ];
+
+        for input in corpus {
+            for end in input
+                .char_indices()
+                .map(|(index, _)| index)
+                .chain(std::iter::once(input.len()))
+            {
+                let candidate = &input[..end];
+                if let Some(wrapper) = parse_shell_wrapper(candidate) {
+                    assert!(wrapper.script(candidate).is_some());
+                    assert!(wrapper
+                        .replace_script(candidate, "rtk git status")
+                        .is_some());
+                }
+            }
+        }
+
+        let long_script = format!("bash -c '{}'", "日".repeat(32_768));
+        let wrapper = parse_shell_wrapper(&long_script).expect("long script should parse");
+        assert_eq!(
+            wrapper
+                .script(&long_script)
+                .map(|script| script.chars().count()),
+            Some(32_768)
+        );
+        assert!(wrapper
+            .replace_script(&long_script, "rtk git status")
+            .is_some());
+    }
+
+    #[test]
+    fn test_parse_shell_wrapper_rejects_active_double_quote_expansion() {
+        for command in [
+            r#"bash -c "git status $HOME""#,
+            r#"bash -c "git status $(whoami)""#,
+            "bash -c \"git status \x60whoami\x60\"",
+            r#"bash -c "printf \"escaped\"""#,
+        ] {
+            assert!(
+                parse_shell_wrapper(command).is_none(),
+                "active outer expansion must be rejected: {command:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_shell_wrapper_candidate_includes_unsupported_command_options() {
+        for command in [
+            "bash -c 'git status'",
+            "bash -lc 'git status'",
+            "bash -e -c 'git status'",
+            "/bin/zsh -fc 'git status'",
+        ] {
+            assert!(
+                is_shell_wrapper_candidate(command),
+                "command-string wrapper must be recognized: {command:?}"
+            );
+        }
+        for command in [
+            "bash script.sh",
+            "python -c 'git status'",
+            "bash -- script.sh",
+            "fish --command 'git status'",
+        ] {
+            assert!(
+                !is_shell_wrapper_candidate(command),
+                "non-wrapper must not be recognized: {command:?}"
+            );
+        }
+    }
+}

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -74,6 +74,13 @@ Deny > Ask > Allow (explicit) > Default (ask)
 
 Rules are loaded from all Claude Code `settings.json` files (project + global, including `.local` variants). Only `Bash(...)` rules are extracted; other scopes (Read, Write) are ignored.
 
+Quoted `sh -c`, `bash -c`, and `zsh -c` scripts add a
+second command-parsing boundary. RTK checks deny rules against both the outer
+wrapper and the parsed inner segments. A wrapper rewrite is never auto-allowed:
+its strongest RTK verdict is `Ask`. Ask-capable hosts prompt, while other
+hosts retain their existing native permission flow. Unsupported or ambiguous
+wrapper syntax is left unchanged for the host to evaluate.
+
 | Verdict | Trigger | rewrite_cmd exit | Hook behavior |
 |---------|---------|-----------------|---------------|
 | Deny | `permissions.deny` rule matched | 2 | Passthrough — host tool handles denial |
@@ -98,6 +105,7 @@ Rules are loaded from all Claude Code `settings.json` files (project + global, i
 - `permissions.rs` — loads deny/ask/allow rules, evaluates precedence, returns `PermissionVerdict`
 - `rewrite_cmd.rs` — maps verdict to exit code (consumed by shell hook)
 - `hook_cmd.rs` — maps verdict to JSON `permissionDecision` field (Copilot/Gemini)
+- `discover/shell_wrapper.rs` — shares conservative script-span parsing between rewrite and permission checks
 
 ## Exit Code Contract
 

--- a/src/hooks/hook_cmd.rs
+++ b/src/hooks/hook_cmd.rs
@@ -2503,4 +2503,90 @@ mod tests {
         let input = vibe_input("bash", "echo $(rm -rf /)");
         assert!(run_vibe_inner(&input).is_none());
     }
+    #[test]
+    fn test_copilot_cli_shell_wrapper_rewrites_without_auto_allow() {
+        let command = "bash -c 'git status; cargo test'";
+        let verdict = permissions::check_command_with_rules(command, &[], &[], &["*".to_string()]);
+        let response = copilot_cli_response_from_decision(
+            &cli_args(command),
+            decide_from_verdict(command, verdict),
+            command,
+        )
+        .expect("wrapper rewrite expected");
+        assert_eq!(
+            response["modifiedArgs"]["command"],
+            "bash -c 'rtk git status; rtk cargo test'"
+        );
+        assert!(response.get("permissionDecision").is_none());
+    }
+
+    #[test]
+    fn test_claude_shell_wrapper_rewrites_without_auto_allow() {
+        let result = run_claude_inner(&claude_input(r#"bash -c "head foo && grep -R bar .""#))
+            .expect("wrapper rewrite expected");
+        let v: Value = serde_json::from_str(&result).unwrap();
+        let output = &v["hookSpecificOutput"];
+        assert_eq!(
+            output["updatedInput"]["command"],
+            r#"bash -c "rtk read foo && rtk grep -R bar .""#
+        );
+        assert!(output.get("permissionDecision").is_none());
+    }
+
+    #[test]
+    fn test_cursor_shell_wrapper_rewrites_without_auto_allow() {
+        let result = run_cursor_allowed(&cursor_input(r#"bash -c "git status && cargo test""#));
+        let v: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(v["permission"], "ask");
+        assert_eq!(
+            v["updated_input"]["command"],
+            r#"bash -c "rtk git status && rtk cargo test""#
+        );
+    }
+
+    #[test]
+    fn test_decide_asks_for_allowed_shell_wrapper_rewrite() {
+        match decide_with_rules(
+            r#"bash -c "head foo && grep -R bar .""#,
+            &[],
+            &[],
+            &all_allowed(),
+        ) {
+            HookDecision::AskRewrite(rewritten) => {
+                assert_eq!(rewritten, r#"bash -c "rtk read foo && rtk grep -R bar .""#)
+            }
+            _ => panic!("supported shell wrapper must rewrite with confirmation"),
+        }
+    }
+
+    #[test]
+    fn test_gemini_shell_wrapper_asks_user_with_rewrite() {
+        let v: Value = serde_json::from_str(&gemini_render(
+            r#"zsh -c "git status && cargo test""#,
+            &[],
+            &[],
+            &all_allowed(),
+        ))
+        .unwrap();
+        assert_eq!(v["decision"], "ask_user");
+        assert_eq!(
+            v["hookSpecificOutput"]["tool_input"]["command"],
+            r#"zsh -c "rtk git status && rtk cargo test""#
+        );
+    }
+
+    #[test]
+    fn test_droid_shell_wrapper_rewrites_without_permission_decision() {
+        let input = droid_input("Execute", "bash -c 'git status; cargo test'");
+        let out = run_droid_inner(&input).expect("rewrite expected");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(
+            v.pointer("/hookSpecificOutput/updatedInput/command")
+                .and_then(Value::as_str),
+            Some("bash -c 'rtk git status; rtk cargo test'")
+        );
+        assert!(v
+            .pointer("/hookSpecificOutput/permissionDecision")
+            .is_none());
+    }
 }

--- a/src/hooks/permissions.rs
+++ b/src/hooks/permissions.rs
@@ -5,6 +5,7 @@ use super::constants::{
 use super::init::resolve_claude_dir;
 use crate::core::stream::exec_capture;
 use crate::discover::lexer::{is_word_boundary_whitespace, split_for_permissions};
+use crate::discover::shell_wrapper::{is_shell_wrapper_candidate, parse_shell_wrapper};
 use serde_json::Value;
 use std::path::PathBuf;
 
@@ -80,6 +81,10 @@ pub(crate) fn check_command_with_rules(
         }
     }
 
+    if let Some(verdict) = check_shell_wrapper_permissions(&segments, deny_rules) {
+        return verdict;
+    }
+
     // Can't decompose substitution / file-target redirects — never auto-allow.
     if crate::discover::lexer::contains_unattestable_construct(cmd) {
         return PermissionVerdict::Ask;
@@ -130,6 +135,36 @@ pub(crate) fn check_command_with_rules(
     } else {
         PermissionVerdict::Default
     }
+}
+
+fn check_shell_wrapper_permissions(
+    segments: &[&str],
+    deny_rules: &[String],
+) -> Option<PermissionVerdict> {
+    let mut contains_shell_wrapper = false;
+    for segment in segments {
+        let segment = segment.trim();
+        let Some(wrapper) = parse_shell_wrapper(segment) else {
+            contains_shell_wrapper |= is_shell_wrapper_candidate(segment);
+            continue;
+        };
+        let Some(script) = wrapper.script(segment) else {
+            return Some(PermissionVerdict::Ask);
+        };
+        contains_shell_wrapper = true;
+        let inner_denied = split_for_permissions(script).iter().any(|inner_segment| {
+            deny_rules
+                .iter()
+                .any(|pattern| command_matches_pattern(inner_segment.trim(), pattern))
+        });
+        if inner_denied {
+            return Some(PermissionVerdict::Deny);
+        }
+    }
+
+    // A quoted shell script hides a second parsing boundary from the host rule.
+    // Rewriting it is useful, but RTK must never turn that into auto-approval.
+    contains_shell_wrapper.then_some(PermissionVerdict::Ask)
 }
 
 /// Load deny, ask, and allow Bash rules from all Claude Code settings files.
@@ -1269,6 +1304,56 @@ mod tests {
         assert_eq!(
             check_command_with_rules("rm -rf /", &[], &[], &allow),
             PermissionVerdict::Default
+        );
+    }
+    #[test]
+    fn test_shell_wrapper_never_auto_allowed() {
+        let allow = vec!["*".to_string()];
+        assert_eq!(
+            check_command_with_rules(r#"bash -c "head foo && grep -R bar .""#, &[], &[], &allow),
+            PermissionVerdict::Ask
+        );
+    }
+
+    #[test]
+    fn test_shell_wrapper_inner_deny_wins() {
+        let deny = vec!["rm:*".to_string()];
+        let allow = vec!["*".to_string()];
+        assert_eq!(
+            check_command_with_rules(
+                "bash -c 'git status; rm -rf /tmp/example'",
+                &deny,
+                &[],
+                &allow
+            ),
+            PermissionVerdict::Deny
+        );
+    }
+
+    #[test]
+    fn test_unsupported_shell_wrapper_candidate_never_auto_allowed() {
+        let allow = vec!["*".to_string()];
+        for command in ["bash -lc 'git status'", "bash -e -c 'git status'"] {
+            assert_eq!(
+                check_command_with_rules(command, &[], &[], &allow),
+                PermissionVerdict::Ask,
+                "unsupported command-string wrapper must ask: {command:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_shell_wrapper_inner_deny_wins_inside_outer_compound() {
+        let deny = vec!["rm:*".to_string()];
+        let allow = vec!["*".to_string()];
+        assert_eq!(
+            check_command_with_rules(
+                "bash -c 'git status; rm -rf /tmp/example' && cargo test",
+                &deny,
+                &[],
+                &allow
+            ),
+            PermissionVerdict::Deny
         );
     }
 }

--- a/tests/rewrite_shell_wrapper_test.rs
+++ b/tests/rewrite_shell_wrapper_test.rs
@@ -1,0 +1,55 @@
+use std::process::{Command, Output};
+
+fn rewrite(command: &str) -> Output {
+    let home = tempfile::tempdir().expect("create isolated home");
+    Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .args(["rewrite", command])
+        .current_dir(home.path())
+        .env("HOME", home.path())
+        .env("XDG_CONFIG_HOME", home.path())
+        .env("RTK_TELEMETRY_DISABLED", "1")
+        .output()
+        .expect("run rtk rewrite")
+}
+
+#[test]
+fn bash_command_string_rewrites_inner_commands() {
+    let output = rewrite(r#"bash -c "head foo && grep -R bar .""#);
+
+    assert_eq!(output.status.code(), Some(3));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        r#"bash -c "rtk read foo && rtk grep -R bar .""#
+    );
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn zsh_command_string_rewrites_inner_commands() {
+    let output = rewrite("zsh -c 'git status; cargo test'");
+
+    assert_eq!(output.status.code(), Some(3));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "zsh -c 'rtk git status; rtk cargo test'"
+    );
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn fish_command_string_passes_through() {
+    let output = rewrite("fish -c 'git status; cargo test'");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn unsafe_inner_script_passes_through_without_output() {
+    let output = rewrite("bash -c 'git status $(whoami)'");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+    assert!(output.stderr.is_empty());
+}


### PR DESCRIPTION
## Summary

Rewrites the portable commands inside an exact quoted `sh -c`, `bash -c`, or `zsh -c` wrapper, leaving the wrapper's own bytes untouched.

```
bash -c "head foo && grep -R bar ."
  → bash -c "rtk read foo && rtk grep -R bar ."
```

Agents that reach a project toolchain through a wrapper (`direnv exec . bash -c '…'`, `devenv shell -- bash -c '…'`, container and CI runners) send every command as a quoted script, so the whole invocation was opaque and no inner command was rewritten.

`shell_wrapper.rs` and most tests are @pashifika's, from #3057, rebuilt against current `develop` — the rewrite engine has since gained `RewriteContext`, `PipeKind`, `analyze_pipeline`, `pipeline_final_safe` and multi-line block handling. Credited via `Co-authored-by`.

Refs #2767. That issue also asks for `fish -c`, which this deliberately leaves out (see Passthrough cases), so it does not close it.

**Overlaps #3057**, which is still open. Landing this one should close that one; I have no write access there.

## Eligibility

Deliberately narrow. The shell must be exactly `sh`, `bash`, or `zsh` (any path, e.g. `/bin/bash`), the option exactly `-c`, and the script one balanced single- or double-quoted argument.

Only the script's byte span is replaced, so shell path, quote delimiters, horizontal spacing, suffix arguments and fd redirects come back byte-identical:

```
/bin/bash -c 'git status' command-name 'a b'
  → /bin/bash -c 'rtk git status' command-name 'a b'

bash -c 'git status' 2>&1
  → bash -c 'rtk git status' 2>&1
```

A wrapper is found at any prefix depth, so one behind a transparent prefix or a strippable `command` is reached too:

```
direnv exec . bash -c 'git status'
  → direnv exec . bash -c 'rtk git status'
```

## Passthrough cases

These return to the host unchanged:

- a leading `sudo` — the inner `rtk` would run as root, where it is off `secure_path`, the same reason a bare `sudo docker ps` is left alone (#146). Pinned by `test_shell_wrapper_behind_sudo_is_not_rewritten`.
- a script containing a newline, heredoc, or `$((`
- active outer `$` expansion, backticks, or backslash escapes in a double-quoted script
- anything `contains_unattestable_construct` rejects — command/process substitution, file-target redirects
- extra shell options: `bash -lc`, `bash -e -c`, `fish --command`
- an unquoted or unbalanced script
- a wrapper nested inside a wrapper — recursion is capped at one level
- `fish`, whose control keywords (`and`, `or`, `if`) at a command boundary need a fish-aware lexer the shared one does not model

## Permission handling

A host's allow rule matched the outer command — it never parsed the quoted script. Rewriting inside that script therefore must not widen what the rule approved, so:

- deny rules are also evaluated against the inner commands, and an inner deny outranks an outer allow
- a wrapper rewrite is never auto-allowed; its strongest verdict is `Ask`, so a `*` allow rule cannot approve a script the host never saw
- `Ask`-capable hosts prompt, others keep their native permission flow

One parser backs both rewriting and permission evaluation, so the two paths agree on the boundary. Agent protocol coverage: Claude, Cursor, Gemini, Copilot CLI, Droid.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all` — 3,137 passed, 0 failed, 8 ignored, all 12 suites green
- [x] 30 new unit tests (parser, registry, permissions, agent protocols) + 4 CLI integration tests in `tests/rewrite_shell_wrapper_test.rs`
- [x] `rtk rewrite` verified end-to-end on wrapped and prefixed forms
- [ ] CI to validate Linux and Windows

Tested on Linux x86_64 (NixOS).
