### PR TITLE
fix(npx): preserve eslint in lint routing arguments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2358,7 +2358,7 @@ fn run_cli() -> Result<i32> {
             // Intelligent routing: delegate to specialized filters
             match args[0].as_str() {
                 "tsc" | "typescript" => tsc_cmd::run(&args[1..], cli.verbose)?,
-                "eslint" => lint_cmd::run(&args[1..], cli.verbose)?,
+                "eslint" => lint_cmd::run(&args, cli.verbose)?,
                 "prisma" => {
                     // Route to prisma_cmd based on subcommand
                     if args.len() > 1 {

--- a/tests/npx_eslint_test.rs
+++ b/tests/npx_eslint_test.rs
@@ -1,0 +1,46 @@
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::process::Command;
+
+#[test]
+fn npx_eslint_preserves_linter_and_bare_path_arguments() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    #[cfg(unix)]
+    let (filename, script) = (
+        "eslint",
+        "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$ARGS_FILE\"\nprintf '[]\\n'\nexit 1\n",
+    );
+    #[cfg(windows)]
+    let (filename, script) = (
+        "eslint.cmd",
+        "@echo off\r\n(for %%a in (%*) do @echo %%~a) > \"%ARGS_FILE%\"\r\necho []\r\nexit /b 1\r\n",
+    );
+    let eslint = dir.path().join(filename);
+    fs::write(&eslint, script).expect("write eslint fixture");
+    #[cfg(unix)]
+    fs::set_permissions(&eslint, fs::Permissions::from_mode(0o755)).expect("chmod eslint");
+
+    for path in ["src", "lib", "src/", "."] {
+        let args_file = dir.path().join("args");
+        let output = Command::new(env!("CARGO_BIN_EXE_rtk"))
+            .current_dir(dir.path())
+            .env("PATH", dir.path())
+            .env("ARGS_FILE", &args_file)
+            .env("RTK_DB_PATH", dir.path().join("tracking.db"))
+            .args(["npx", "eslint", path])
+            .output()
+            .expect("run rtk");
+
+        assert_eq!(
+            fs::read_to_string(&args_file)
+                .expect("eslint should execute")
+                .lines()
+                .collect::<Vec<_>>(),
+            vec!["-f", "json", path],
+            "eslint should receive the user path unchanged"
+        );
+        assert_eq!(output.status.code(), Some(1), "preserve linter exit code");
+        fs::remove_file(args_file).expect("remove captured args");
+    }
+}


### PR DESCRIPTION
## Summary

`rtk npx eslint src` drops the `eslint` token before calling `lint_cmd::run`, which then treats `src` as the linter name. Pass the full argument slice so the callee can consume the tool name once.

Adds a cross-platform CLI regression using a local ESLint stub. It checks bare and slash/dot paths, exact forwarded arguments, and the linter's nonzero exit status. This fixes the explicit `npx` dispatch independently of the implicit-path detection in #3567.

Fixes #3812.

## Test plan

- [x] Regression fails before the routing fix and passes after it.
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test --all`
- [x] `cargo test --test npx_eslint_test`

Validated on Windows with Rust 1.98.0 (MSVC). Unix-only targets are skipped on this platform; Linux/macOS remain for CI.
