### PR TITLE
fix(git): preserve explicit branch format output

### DIFF
--- a/src/cmds/git/git.rs
+++ b/src/cmds/git/git.rs
@@ -2010,7 +2010,24 @@ fn run_pull(args: &[String], verbose: u8, global_args: &[String]) -> Result<i32>
     Ok(0)
 }
 
+fn requests_raw_branch_output(args: &[String]) -> bool {
+    args.iter()
+        .take_while(|arg| arg.as_str() != "--")
+        .any(|arg| arg == "--format" || arg.starts_with("--format="))
+}
+
 fn run_branch(args: &[String], verbose: u8, global_args: &[String]) -> Result<i32> {
+    let args = &args_utils::restore_double_dash(args);
+
+    // Custom formats can contain whitespace, colors, and NULs that the branch
+    // list filter cannot interpret. Keep Git's output and exit status intact.
+    if requests_raw_branch_output(args) {
+        let passthrough_args: Vec<OsString> = std::iter::once(OsString::from("branch"))
+            .chain(args.iter().map(OsString::from))
+            .collect();
+        return run_passthrough(&passthrough_args, global_args, verbose);
+    }
+
     let timer = tracking::TimedExecution::start();
 
     if verbose > 0 {
@@ -3416,6 +3433,28 @@ mod tests {
         assert!(!is_blob_show_arg("--pretty=format:%h"));
         assert!(!is_blob_show_arg("--format=short"));
         assert!(!is_blob_show_arg("HEAD"));
+    }
+
+    #[test]
+    fn test_branch_format_passthrough_respects_option_boundary() {
+        for args in [
+            vec!["--format=%(refname:short)"],
+            vec!["--format", "%(refname:short)"],
+            vec!["--list", "--format="],
+        ] {
+            let args: Vec<String> = args.into_iter().map(String::from).collect();
+            assert!(requests_raw_branch_output(&args));
+        }
+        for args in [
+            vec![],
+            vec!["--list"],
+            vec!["--formatting"],
+            vec!["--", "--format=%(refname:short)"],
+            vec!["--list", "--", "--format"],
+        ] {
+            let args: Vec<String> = args.into_iter().map(String::from).collect();
+            assert!(!requests_raw_branch_output(&args));
+        }
     }
 
     #[test]

--- a/tests/git_branch_format_test.rs
+++ b/tests/git_branch_format_test.rs
@@ -1,0 +1,117 @@
+//! Explicit branch formats are user-owned output, including whitespace and NULs.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn git_command(repo: &Path) -> Command {
+    let mut command = Command::new("git");
+    command
+        .current_dir(repo)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", repo.join("no-global-config"))
+        .env("LC_ALL", "C");
+    command
+}
+
+fn git(repo: &Path, args: &[&str]) -> Output {
+    git_command(repo).args(args).output().expect("run git")
+}
+
+fn repository() -> tempfile::TempDir {
+    let repo = tempfile::tempdir().expect("temporary repository");
+    for args in [
+        vec!["init", "-q", "-b", "main"],
+        vec![
+            "-c",
+            "user.name=RTK Test",
+            "-c",
+            "user.email=rtk@example.invalid",
+            "commit",
+            "-q",
+            "--allow-empty",
+            "-m",
+            "initial",
+        ],
+        vec!["branch", "feature"],
+        vec!["update-ref", "refs/remotes/origin/main", "HEAD"],
+        vec!["update-ref", "refs/remotes/origin/remote-only", "HEAD"],
+    ] {
+        let output = git(repo.path(), &args);
+        assert!(
+            output.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    repo
+}
+
+fn assert_matches_git(repo: &Path, args: &[&str]) -> Output {
+    let native = git(repo, args);
+    let rtk = Command::new(env!("CARGO_BIN_EXE_rtk"))
+        .arg("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", repo.join("no-global-config"))
+        .env("LC_ALL", "C")
+        .env("RTK_DB_PATH", repo.join("rtk.db"))
+        .output()
+        .expect("run rtk git");
+
+    assert_eq!(rtk.status.code(), native.status.code(), "args: {args:?}");
+    assert_eq!(rtk.stdout, native.stdout, "stdout for {args:?}");
+    assert_eq!(rtk.stderr, native.stderr, "stderr for {args:?}");
+    native
+}
+
+#[test]
+fn branch_format_matches_git_for_both_option_spellings() {
+    let repo = repository();
+    for args in [
+        vec!["branch", "--format=%(refname:short)"],
+        vec!["branch", "--format", "%(refname:short)"],
+        vec![
+            "branch",
+            "--all",
+            "--sort=-refname",
+            "--format=%09  %(refname:short) %00%0a",
+        ],
+        vec![
+            "branch",
+            "--color=always",
+            "--format=%(color:red)%(refname:short)%(color:reset)",
+        ],
+    ] {
+        assert!(assert_matches_git(repo.path(), &args).status.success());
+    }
+}
+
+#[test]
+fn branch_format_preserves_empty_output_and_operand_boundary() {
+    let repo = repository();
+    let output = assert_matches_git(
+        repo.path(),
+        &[
+            "branch",
+            "--format=%(refname:short)",
+            "--list",
+            "--",
+            "--format=does-not-match",
+        ],
+    );
+    assert!(output.status.success());
+    assert!(output.stdout.is_empty());
+}
+
+#[test]
+fn branch_format_preserves_git_errors() {
+    let repo = repository();
+    for args in [
+        vec!["branch", "--format=%(not-a-valid-field)"],
+        vec!["branch", "--format"],
+    ] {
+        assert!(!assert_matches_git(repo.path(), &args).status.success());
+    }
+}


### PR DESCRIPTION
## Summary

`git branch --format=...` defines its own output layout. Passing it through the default branch-list filter can invent a nameless current-branch marker and alter user-selected content.

Route explicit `--format` / `--format=...` through the existing inherited-stdio Git passthrough, preserving stdout bytes, stderr, and exit status. Restore the Clap-consumed `--` boundary before detecting options. Default compact branch output stays unchanged.

Fixes #3809.

## Test plan

- [x] Real temporary Git repositories compare native Git and RTK stdout/stderr bytes and exit codes for both option spellings, sorting/remotes, whitespace/NUL, color, empty matches, operand boundaries, and invalid/missing formats.
- [x] Unit test checks format detection before/after `--`.
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test --all`: 2,921 unit tests and 28 integration tests passed, 8 ignored.

Validated after a clean package rebuild on Windows with Rust 1.98.0 (MSVC). Unix-only targets are skipped on this platform; Linux/macOS remain for CI.
