### PR TITLE
test(utils): avoid executing rustup in command resolution test

### DIFF
--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -920,15 +920,10 @@ mod tests {
     // ===== resolved_command tests (issue #212) =====
 
     #[test]
-    fn test_resolved_command_executes_known_command() {
-        let output = resolved_command("cargo")
-            .arg("--version")
-            .output()
-            .expect("resolved_command('cargo') should execute");
-        assert!(
-            output.status.success(),
-            "cargo --version should succeed via resolved_command"
-        );
+    fn test_resolved_command_uses_resolved_program() {
+        let command = resolved_command("cargo");
+        let resolved = resolve_binary("cargo").expect("cargo must be resolvable via PATH");
+        assert_eq!(command.get_program(), resolved.as_os_str());
     }
 
     // ===== tool_exists tests (issue #212) =====


### PR DESCRIPTION
## Summary

The command-resolution test currently runs `cargo --version`, so its outcome depends on rustup's per-user toolchain configuration after PATH resolution already succeeded. Assert that `resolved_command("cargo")` selects the program returned by `resolve_binary("cargo")`, and rename the test to match this contract.

This removes the runtime dependency on rustup's home directory without changing production behavior.

Fixes #3768.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test --all`

Validated on Windows with Rust 1.98.0 (MSVC). Unix-only targets are skipped on this platform; Linux/macOS remain for CI.
