### PR TITLE
test(pipeline): tolerate broken pipes from early child exits

### DIFF
--- a/tests/pipeline_stdin_test.rs
+++ b/tests/pipeline_stdin_test.rs
@@ -1,6 +1,6 @@
 #![cfg(unix)]
 
-use std::io::Write;
+use std::io::{ErrorKind, Write};
 use std::process::{Command, Output, Stdio};
 
 fn run_with_stdin(command: &mut Command, input: &[u8]) -> Output {
@@ -10,13 +10,24 @@ fn run_with_stdin(command: &mut Command, input: &[u8]) -> Output {
         .stderr(Stdio::piped())
         .spawn()
         .expect("spawn command");
-    child
-        .stdin
-        .take()
-        .expect("piped stdin")
-        .write_all(input)
-        .expect("write stdin");
+    if let Err(error) = child.stdin.take().expect("piped stdin").write_all(input) {
+        assert_eq!(error.kind(), ErrorKind::BrokenPipe, "write stdin: {error}");
+    }
     child.wait_with_output().expect("wait for command")
+}
+
+#[test]
+fn early_exit_preserves_output_and_status_when_stdin_is_closed() {
+    // More than a pipe buffer ensures the writer observes the closed reader,
+    // regardless of whether the child exits before or during write_all.
+    let input = vec![b'x'; 8 * 1024 * 1024];
+    let output = run_with_stdin(
+        Command::new("sh").args(["-c", "exec 0<&-; printf 'early exit\\n'; exit 7"]),
+        &input,
+    );
+
+    assert_eq!(output.status.code(), Some(7));
+    assert_eq!(output.stdout, b"early exit\n");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

The stdin test helper can race with a child that rejects its arguments and exits before reading stdin. Allow only `BrokenPipe` from `write_all`, then collect the child's output and exit status. Other write errors still fail the test.

Add a deterministic regression: a child closes stdin and exits with status 7, while the parent writes more than a pipe buffer. The test checks that the helper returns the child's stdout and status rather than panicking.

Fixes #3739.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test --all` on Windows, Rust 1.98.0 (MSVC).
- [x] All three stdin tests executed in a standalone harness on Windows with Git for Windows `sh`/`wc`; the early-exit regression fails with the original helper (`BrokenPipe`) and passes with the fix.

The integration file is `cfg(unix)`, so ordinary Windows Cargo tests skip it. The standalone check removed that gate only in a temporary copy; the committed file keeps its platform boundary. Native Linux/macOS execution remains for CI.
