### PR TITLE
fix(hermes): return modify directives for terminal rewrites

### DIFF
--- a/hooks/hermes/README.md
+++ b/hooks/hermes/README.md
@@ -20,7 +20,7 @@ python3 -m unittest discover -s hooks/hermes
 
 ## How it works
 
-Hermes loads plugins from Python, so the plugin entrypoint is Python. The Python code is only a thin Hermes adapter. It reads the Hermes terminal tool payload, calls `rtk rewrite` for the actual command decision, then mutates the terminal tool `command` before Hermes executes it.
+Hermes loads plugins from Python, so the plugin entrypoint is Python. The Python code is only a thin Hermes adapter. It reads the Hermes terminal tool payload, calls `rtk rewrite` for the actual command decision, then returns a `modify` directive with the rewritten `command` and all other terminal arguments preserved. The original payload stays unchanged; Hermes applies the returned directive before execution.
 
 All rewrite rules stay in Rust inside `rtk rewrite`. When RTK adds or changes command rewrite behavior, the Hermes plugin picks up that behavior by delegating to the RTK binary.
 
@@ -40,4 +40,4 @@ If rtk is not available in PATH when Hermes loads the plugin, the plugin prints 
 
 - Only Hermes `terminal` tool calls are rewritten.
 - Commands skipped by `rtk rewrite` stay unchanged, including commands already prefixed with `rtk`, compound shell commands, heredocs, and commands without an RTK filter.
-- Shell hooks are not used for Hermes command rewriting. The integration depends on Hermes loading Python plugins and passing a mutable terminal tool payload.
+- Shell hooks are not used for Hermes command rewriting. The integration depends on Hermes loading Python plugins and applying `pre_tool_call` modify directives.

--- a/hooks/hermes/rtk-rewrite/__init__.py
+++ b/hooks/hermes/rtk-rewrite/__init__.py
@@ -38,7 +38,7 @@ def _check_rtk():
 
 
 def _pre_tool_call(tool_name=None, args=None, **_kwargs):
-    """Rewrite mutable Hermes terminal command args when RTK provides a change."""
+    """Return a Hermes modify directive when RTK rewrites a terminal command."""
     try:
         if tool_name != "terminal" or not isinstance(args, dict):
             return
@@ -70,7 +70,7 @@ def _pre_tool_call(tool_name=None, args=None, **_kwargs):
 
         rewritten = result.stdout.strip()
         if rewritten and rewritten != command:
-            args["command"] = rewritten
+            return {"action": "modify", "args": {**args, "command": rewritten}}
     except Exception as e:
         _warn(str(e))
         return

--- a/hooks/hermes/tests/test_rtk_rewrite_plugin.py
+++ b/hooks/hermes/tests/test_rtk_rewrite_plugin.py
@@ -124,44 +124,32 @@ class RtkRewritePluginTest(unittest.TestCase):
 
         which.assert_called_once_with("rtk")
 
-    def test_rewrite_success_mutates_same_terminal_args_dict(self):
-        module, callback = self.load_callback()
-        args = {"command": "git status"}
+    def test_rewrite_returns_modify_directive_without_mutating_terminal_args(self):
+        for returncode in (0, 3):
+            with self.subTest(returncode=returncode):
+                module, callback = self.load_callback()
+                args = {"command": "git status", "workdir": "/repo", "timeout": 30}
 
-        with mock.patch.object(
-            module.subprocess,
-            "run",
-            return_value=FakeCompletedProcess(stdout="rtk git status\n"),
-        ):
-            callback(tool_name="terminal", args=args)
+                with mock.patch.object(
+                    module.subprocess,
+                    "run",
+                    return_value=FakeCompletedProcess(
+                        returncode=returncode, stdout="rtk git status\n"
+                    ),
+                ):
+                    directive = callback(tool_name="terminal", args=args)
 
-        self.assertEqual({"command": "rtk git status"}, args)
-
-    def test_rewrite_returncode_three_mutates_same_terminal_args_dict(self):
-        module, callback = self.load_callback()
-        args = {"command": "git status"}
-
-        with mock.patch.object(
-            module.subprocess,
-            "run",
-            return_value=FakeCompletedProcess(returncode=3, stdout="rtk git status\n"),
-        ):
-            callback(tool_name="terminal", args=args)
-
-        self.assertEqual({"command": "rtk git status"}, args)
-
-    def test_rewrite_returncode_zero_mutates_when_rewrite_changes_command(self):
-        module, callback = self.load_callback()
-        args = {"command": "git status"}
-
-        with mock.patch.object(
-            module.subprocess,
-            "run",
-            return_value=FakeCompletedProcess(stdout="rtk git status\n"),
-        ):
-            callback(tool_name="terminal", args=args)
-
-        self.assertEqual({"command": "rtk git status"}, args)
+                self.assertEqual(
+                    {
+                        "action": "modify",
+                        "args": {"command": "rtk git status", "workdir": "/repo", "timeout": 30},
+                    },
+                    directive,
+                )
+                self.assertIsNot(args, directive["args"])
+                self.assertEqual(
+                    {"command": "git status", "workdir": "/repo", "timeout": 30}, args
+                )
 
     def test_expected_passthrough_returncodes_do_not_warn_or_mutate(self):
         for returncode in (1, 2):
@@ -179,7 +167,7 @@ class RtkRewritePluginTest(unittest.TestCase):
                     ),
                 ):
                     with mock.patch.object(module.sys, "stderr", new_callable=io.StringIO) as stderr:
-                        callback(tool_name="terminal", args=args)
+                        self.assertIsNone(callback(tool_name="terminal", args=args))
 
                 self.assertEqual({"command": "git status"}, args)
                 self.assertEqual("", stderr.getvalue())
@@ -194,7 +182,7 @@ class RtkRewritePluginTest(unittest.TestCase):
             return_value=FakeCompletedProcess(returncode=4, stdout="rtk git status\n", stderr="bad news"),
         ):
             with mock.patch.object(module.sys, "stderr", new_callable=io.StringIO) as stderr:
-                callback(tool_name="terminal", args=args)
+                self.assertIsNone(callback(tool_name="terminal", args=args))
 
         self.assertEqual({"command": "git status"}, args)
         self.assertEqual("rtk: hermes plugin warning: rtk rewrite failed with exit 4: bad news\n", stderr.getvalue())
@@ -206,7 +194,7 @@ class RtkRewritePluginTest(unittest.TestCase):
         timeout = subprocess.TimeoutExpired(cmd=["rtk", "rewrite", "git status"], timeout=2)
         with mock.patch.object(module.subprocess, "run", side_effect=timeout):
             with mock.patch.object(module.sys, "stderr", new_callable=io.StringIO) as stderr:
-                callback(tool_name="terminal", args=args)
+                self.assertIsNone(callback(tool_name="terminal", args=args))
 
         self.assertEqual({"command": "git status"}, args)
         self.assertEqual("rtk: hermes plugin warning: rtk rewrite timed out\n", stderr.getvalue())
@@ -217,7 +205,7 @@ class RtkRewritePluginTest(unittest.TestCase):
 
         with mock.patch.object(module.subprocess, "run", side_effect=FileNotFoundError):
             with mock.patch.object(module.sys, "stderr", new_callable=io.StringIO) as stderr:
-                callback(tool_name="terminal", args=args)
+                self.assertIsNone(callback(tool_name="terminal", args=args))
 
         self.assertEqual({"command": "git status"}, args)
         self.assertIn("rtk: hermes plugin warning:", stderr.getvalue())
@@ -228,7 +216,7 @@ class RtkRewritePluginTest(unittest.TestCase):
 
         with mock.patch.object(module.subprocess, "run", side_effect=RuntimeError("boom")):
             with mock.patch.object(module.sys, "stderr", new_callable=io.StringIO) as stderr:
-                callback(tool_name="terminal", args=args)
+                self.assertIsNone(callback(tool_name="terminal", args=args))
 
         self.assertEqual({"command": "git status"}, args)
         self.assertEqual("rtk: hermes plugin warning: boom\n", stderr.getvalue())
@@ -238,7 +226,7 @@ class RtkRewritePluginTest(unittest.TestCase):
         args = {"command": "git status"}
 
         with mock.patch.object(module.subprocess, "run") as run:
-            callback(tool_name="read_file", args=args)
+            self.assertIsNone(callback(tool_name="read_file", args=args))
 
         run.assert_not_called()
         self.assertEqual({"command": "git status"}, args)
@@ -248,7 +236,7 @@ class RtkRewritePluginTest(unittest.TestCase):
         args = {}
 
         with mock.patch.object(module.subprocess, "run") as run:
-            callback(tool_name="terminal", args=args)
+            self.assertIsNone(callback(tool_name="terminal", args=args))
 
         run.assert_not_called()
         self.assertEqual({}, args)
@@ -258,7 +246,7 @@ class RtkRewritePluginTest(unittest.TestCase):
         args = {"command": ["git", "status"]}
 
         with mock.patch.object(module.subprocess, "run") as run:
-            callback(tool_name="terminal", args=args)
+            self.assertIsNone(callback(tool_name="terminal", args=args))
 
         run.assert_not_called()
         self.assertEqual({"command": ["git", "status"]}, args)
@@ -270,7 +258,7 @@ class RtkRewritePluginTest(unittest.TestCase):
                 args = {"command": command}
 
                 with mock.patch.object(module.subprocess, "run") as run:
-                    callback(tool_name="terminal", args=args)
+                    self.assertIsNone(callback(tool_name="terminal", args=args))
 
                 run.assert_not_called()
                 self.assertEqual({"command": command}, args)
@@ -286,7 +274,7 @@ class RtkRewritePluginTest(unittest.TestCase):
                     "run",
                     return_value=FakeCompletedProcess(stdout=stdout),
                 ):
-                    callback(tool_name="terminal", args=args)
+                    self.assertIsNone(callback(tool_name="terminal", args=args))
 
                 self.assertEqual({"command": "git status"}, args)
 
@@ -343,9 +331,12 @@ class InstalledRtkRewritePluginTest(unittest.TestCase):
                 callback = ctx.hooks["pre_tool_call"]
 
                 args = {"command": "git status"}
-                callback(tool_name="terminal", args=args)
+                directive = callback(tool_name="terminal", args=args)
 
-            self.assertEqual({"command": "rtk git status"}, args)
+            self.assertEqual(
+                {"action": "modify", "args": {"command": "rtk git status"}}, directive
+            )
+            self.assertEqual({"command": "git status"}, args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Hermes consumes `pre_tool_call` return directives, so mutating the supplied argument dictionary and returning `None` leaves terminal commands unchanged. Return an `action: modify` directive containing the rewritten command and a copy of every other argument.

The hook leaves its input untouched and still returns `None` on passthrough/error paths. Update the existing tests and plugin documentation to reflect this contract.

Fixes #3797.

## Test plan

- [x] New success regression fails before the fix for rewrite exit codes 0 and 3, then passes.
- [x] `uv run python -m unittest discover -s hooks/hermes -v`: 15 passed, 1 skipped (installed-flow test requires the Cargo/POSIX setup; Cargo was not on PATH for this Python run).
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test --all`

Rust checks ran on Windows with Rust 1.98.0 (MSVC). No live Hermes agent session was run; callback behavior and the upstream directive contract were verified.
