### PR TITLE
fix(prisma): stop migrate status panicking on a trailing migration id

### DIFF
--- a/src/cmds/js/prisma_cmd.rs
+++ b/src/cmds/js/prisma_cmd.rs
@@ -316,7 +316,9 @@ fn filter_migrate_status(output: &str) -> String {
             applied_count += 1;
             if latest_migration.is_empty() && line.contains("202") {
                 if let Some(pos) = line.find("202") {
-                    let end = line[pos..].find(|c: char| c.is_whitespace()).unwrap_or(20);
+                    let end = line[pos..]
+                        .find(|c: char| c.is_whitespace())
+                        .unwrap_or(line.len() - pos);
                     latest_migration = line[pos..pos + end].to_string();
                 }
             }
@@ -460,6 +462,21 @@ import { PrismaClient } from '@prisma/client'
         // Parser may not extract exact counts from this format, just check it doesn't crash
         assert!(!result.contains("Prisma schema loaded"));
         assert!(!result.contains("Start by importing"));
+    }
+
+    #[test]
+    fn test_filter_migrate_status_reads_a_timestamp_at_end_of_line() {
+        // The migration id ran to the end of the line, so there was no whitespace to find and
+        // the hardcoded fallback of 20 sliced past it -- a panic, which aborts in release and
+        // takes the user's whole command output with it.
+        let output = "Migration could not be applied at 2024-01-01T12:00:00";
+        let result = filter_migrate_status(output);
+        assert!(result.contains("2024-01-01T12:00:00"), "{result}");
+
+        // A multibyte character after the id must not split mid-char either.
+        let output = "1 migration applied 20240101_café";
+        let result = filter_migrate_status(output);
+        assert!(result.contains("20240101_café"), "{result}");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`filter_migrate_status` (`src/cmds/js/prisma_cmd.rs`) finds the `202…` migration id, looks for the whitespace that ends it, and falls back to a hardcoded 20 bytes when there is none:

```rust
let end = line[pos..].find(|c: char| c.is_whitespace()).unwrap_or(20);
latest_migration = line[pos..pos + end].to_string();
```

When the id runs to the end of the line there is no whitespace, so the slice runs past it:

```
Migration could not be applied at 2024-01-01T12:00:00
len 53, pos 34, end 20  ->  line[34..54]
thread panicked: end byte index 54 is out of bounds
```

Release builds set `panic = "abort"` (`Cargo.toml`), so `rtk prisma migrate status` dies outright and the user loses the command's output — the failure mode `.claude/rules/rust-patterns.md` singles out ("If filter fails, execute raw command unchanged. Never block the user").

A multibyte character straddling `pos + 20` panics the same way, as a char-boundary error instead.

## Fix

Fall back to the rest of the line, which is what the sibling `filter_migrate_dev` has always done 70 lines above:

```rust
let end = line[pos..]
    .find(|c: char| c.is_whitespace())
    .unwrap_or(line.len() - pos);
```

That bound is char-safe by construction: `line.len() - pos` is exactly the length of the `line[pos..]` slice.

## Test plan

`filter_migrate_status` had no test at all (only `test_filter_migrate_dev` existed). Added one covering both shapes — an id at end of line, and a multibyte character right after it — and verified it panics at `prisma_cmd.rs:320` with the old fallback restored, then passes with the fix.

`cargo fmt --all && cargo clippy --all-targets && cargo test --all` clean.

Found by a review round while working on another PR; unrelated to that work, so it is on its own branch off `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
