### PR TITLE
fix(hooks): replace zx shell with Node child_process in OpenCode plugin

### DIFF
--- a/docs/contributing/TECHNICAL.md
+++ b/docs/contributing/TECHNICAL.md
@@ -319,7 +319,7 @@ Start here, then drill down into each README for file-level details.
 | [`cline/`](../hooks/cline/README.md) | Cline / Roo Code | Rules file (prompt-level, no programmatic hook) |
 | [`windsurf/`](../hooks/windsurf/README.md) | Windsurf / Cascade | Rules file (workspace-scoped) |
 | [`codex/`](../hooks/codex/README.md) | OpenAI Codex CLI | Awareness document, AGENTS.md integration |
-| [`opencode/`](../hooks/opencode/README.md) | OpenCode | TypeScript plugin, zx library, in-place mutation |
+| [`opencode/`](../hooks/opencode/README.md) | OpenCode | TypeScript plugin, Node `execFile`, in-place mutation |
 
 ---
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -187,11 +187,18 @@ Returns `{}` when no rewrite (Cursor requires JSON for all paths).
 
 ### OpenCode (TypeScript Plugin)
 
-Mutates `args.command` in-place via the zx library:
+Mutates `args.command` in-place via Node's cross-platform `execFile` API:
 
 ```typescript
-const result = await $`rtk rewrite ${command}`.quiet().nothrow()
-const rewritten = String(result.stdout).trim()
+function runRtk(args: string[]): Promise<string> {
+  return new Promise((resolve) => {
+    execFile("rtk", args, { windowsHide: true }, (_error, stdout) => {
+      resolve(String(stdout ?? "").trim())
+    })
+  })
+}
+
+const rewritten = await runRtk(["rewrite", command])
 if (rewritten && rewritten !== command) {
   (args as Record<string, unknown>).command = rewritten
 }

--- a/hooks/opencode/README.md
+++ b/hooks/opencode/README.md
@@ -4,8 +4,8 @@
 
 ## Specifics
 
-- TypeScript plugin using the zx library (not a shell hook)
+- TypeScript plugin using Node's cross-platform `child_process.execFile` API (not a shell hook)
 - Intercepts `tool.execute.before` events, calls `rtk rewrite` as a subprocess
-- Uses `.quiet().nothrow()` to silently ignore failures
+- Passes subprocess arguments without a shell and treats empty stdout as no rewrite
 - Mutates `args.command` in-place if rewrite differs from original
 - Installed to `~/.config/opencode/plugins/rtk.ts` by `rtk init -g --opencode`

--- a/hooks/opencode/rtk.ts
+++ b/hooks/opencode/rtk.ts
@@ -1,4 +1,5 @@
 import type { Plugin } from "@opencode-ai/plugin"
+import { execFile } from "node:child_process"
 
 // RTK OpenCode plugin — rewrites commands to use rtk for token savings.
 // Requires: rtk >= 0.23.0 in PATH.
@@ -6,11 +7,24 @@ import type { Plugin } from "@opencode-ai/plugin"
 // This is a thin delegating plugin: all rewrite logic lives in `rtk rewrite`,
 // which is the single source of truth (src/discover/registry.rs).
 // To add or change rewrite rules, edit the Rust registry — not this file.
+//
+// Node's child_process is used instead of the Bun `$` shell because the
+// plugin context does not provide `$` under the Node runtime (e.g. Desktop)
+// and `which` does not exist on Windows.
 
-export const RtkOpenCodePlugin: Plugin = async ({ $ }) => {
-  try {
-    await $`which rtk`.quiet()
-  } catch {
+function runRtk(args: string[]): Promise<string> {
+  return new Promise((resolve) => {
+    execFile("rtk", args, { windowsHide: true }, (_error, stdout) => {
+      // `rtk rewrite` may return a non-zero status while still emitting a
+      // rewrite, so stdout is resolved regardless of the exit code.
+      resolve(String(stdout ?? "").trim())
+    })
+  })
+}
+
+export const RtkOpenCodePlugin: Plugin = async () => {
+  const version = await runRtk(["--version"])
+  if (!version) {
     console.warn("[rtk] rtk binary not found in PATH — plugin disabled")
     return {}
   }
@@ -25,14 +39,9 @@ export const RtkOpenCodePlugin: Plugin = async ({ $ }) => {
       const command = (args as Record<string, unknown>).command
       if (typeof command !== "string" || !command) return
 
-      try {
-        const result = await $`rtk rewrite ${command}`.quiet().nothrow()
-        const rewritten = String(result.stdout).trim()
-        if (rewritten && rewritten !== command) {
-          ;(args as Record<string, unknown>).command = rewritten
-        }
-      } catch {
-        // rtk rewrite failed — pass through unchanged
+      const rewritten = await runRtk(["rewrite", command])
+      if (rewritten && rewritten !== command) {
+        ;(args as Record<string, unknown>).command = rewritten
       }
     },
   }

--- a/src/hooks/init.rs
+++ b/src/hooks/init.rs
@@ -5240,6 +5240,20 @@ mod tests {
     }
 
     #[test]
+    fn test_opencode_plugin_uses_cross_platform_process_api() {
+        assert!(
+            OPENCODE_PLUGIN.contains(r#"import { execFile } from "node:child_process""#),
+            "OpenCode plugin must use Node's cross-platform child process API"
+        );
+        assert!(OPENCODE_PLUGIN.contains("function runRtk(args: string[]): Promise<string>"));
+        assert!(OPENCODE_PLUGIN.contains(r#"execFile("rtk", args, { windowsHide: true }"#));
+        assert!(OPENCODE_PLUGIN.contains(r#"await runRtk(["--version"])"#));
+        assert!(OPENCODE_PLUGIN.contains(r#"await runRtk(["rewrite", command])"#));
+        assert!(!OPENCODE_PLUGIN.contains("({ $ })"));
+        assert!(!OPENCODE_PLUGIN.contains("which rtk"));
+    }
+
+    #[test]
     fn test_opencode_plugin_remove() {
         let temp = TempDir::new().unwrap();
         let opencode_dir = temp.path().join("opencode");


### PR DESCRIPTION
## Summary

- replace the Bun-only `$` shell helper and Unix-only `which` probe with Node `execFile` in the OpenCode plugin
- pass rewrite commands as literal subprocess arguments, no shell involved
- keep successful rewrite stdout even when `rtk rewrite` exits non-zero (exit 3 = permission-gated rewrite)
- update the three doc references to the zx library
- add a regression test for the embedded plugin template

## Why

The current plugin fails silently in two environments:

1. **OpenCode Desktop / Node runtime:** `$` is `undefined` in the plugin context, so `` $`which rtk` `` throws `TypeError: $ is not a function`, the plugin factory crashes, and no hooks are registered — nothing is surfaced to the user.
2. **Windows CLI:** `which` does not exist.

A third subtlety: `rtk rewrite` uses non-zero exit codes as status signals (exit 3 with valid stdout such as `rtk git status`), so stdout must be resolved regardless of the exit code.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test` — `test_opencode_plugin*` pass (3/3). Note: 18 pre-existing failures in `core::stream::tests` on Windows ("program not found" — tests spawn Unix utils like `cat`/`echo`), present on a clean `develop` tree as well, unrelated to this change.
- [x] Functional test of the plugin under Bun (`@opencode-ai/plugin` contract): `"git status"` → `"rtk git status"`, PowerShell commands pass through unchanged, already-prefixed `rtk ...` commands are not double-prefixed
- [x] Live verification on Windows 11 + OpenCode CLI: hook fires, `rtk gain` tracks savings

Closes #3326
Related: #1993, #3330 (independent fix, same root causes; this PR targets current `develop`)

> **Important:** All PRs must target the `develop` branch (not `master`).
> See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for details.
